### PR TITLE
Fix Redfish Validator Errors in EventLog

### DIFF
--- a/redfish-core/lib/log_services.hpp
+++ b/redfish-core/lib/log_services.hpp
@@ -496,10 +496,10 @@ class EventLogService : public Node
         asyncResp->res.jsonValue["Entries"] = {
             {"@odata.id",
              "/redfish/v1/Systems/system/LogServices/EventLog/Entries"}};
-        asyncResp->res.jsonValue["Actions"] = {
-            {{"#LogService.ClearLog",
-              {{"target", "/redfish/v1/Systems/system/LogServices/EventLog/"
-                          "Actions/LogService.ClearLog"}}}}};
+        asyncResp->res.jsonValue["Actions"]["#LogService.ClearLog"] = {
+
+            {"target", "/redfish/v1/Systems/system/LogServices/EventLog/"
+                       "Actions/LogService.ClearLog"}};
     }
 };
 


### PR DESCRIPTION
/redfish/v1/Systems/system/LogServices/EventLog
ERROR - LogService.v1_0_0.LogService:Actions : Could not get
details on this property (This item should not be a List)
ERROR - Actions: Item is present, but no schema found

Before:

curl -k https://${bmc}/redfish/v1/Systems/system/LogServices/EventLog/
{
  "@odata.context": "/redfish/v1/$metadata#LogService.LogService",
  "@odata.id": "/redfish/v1/Systems/system/LogServices/EventLog",
  "@odata.type": "#LogService.v1_1_0.LogService",
  "Actions": [
    {
      "#LogService.ClearLog": {
        "target": "/redfish/v1/Systems/system/LogServices/EventLog/Actions/LogService.ClearLog"
      }
    }
  ],

After:

curl -k https://${bmc}/redfish/v1/Systems/system/LogServices/EventLog/
{
  "@odata.context": "/redfish/v1/$metadata#LogService.LogService",
  "@odata.id": "/redfish/v1/Systems/system/LogServices/EventLog",
  "@odata.type": "#LogService.v1_1_0.LogService",
  "Actions": {
    "#LogService.ClearLog": {
      "target": "/redfish/v1/Systems/system/LogServices/EventLog/Actions/LogService.ClearLog"
    }
  },

LogService.ClearLog currently does not work on master on Witherspoon,
see https://github.com/openbmc/bmcweb/issues/97

This fix is merged into bmcweb master. 

Change-Id: Id2cea926b4f5248782c751f3da247c4dc5662cf3
Tested: No longer see the Errors.
Signed-off-by: Gunnar Mills <gmills@us.ibm.com>