### PR TITLE
REST and Redfish Traffic Logging

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -58,6 +58,8 @@ option (BMCWEB_INSECURE_ENABLE_REDFISH_FW_TFTP_UPDATE "Enable TFTP based
        firmware update transactions through Redfish
        UpdateService.SimpleUpdate." OFF)
 
+option (BMCWEB_ENABLE_TRAFFIC_LOGGING  "Enable traffic logging" OFF)
+
 project (bmc-webserver CXX)
 
 include (CTest)
@@ -277,7 +279,7 @@ target_compile_definitions (
     $<$<BOOL:${BMCWEB_ENABLE_REDFISH_BMC_JOURNAL}>: -DBMCWEB_ENABLE_REDFISH_BMC_JOURNAL>
     $<$<BOOL:${BMCWEB_ENABLE_REDFISH_DBUS_LOG_ENTRIES}>: -DBMCWEB_ENABLE_REDFISH_DBUS_LOG_ENTRIES>
     $<$<BOOL:${BMCWEB_INSECURE_ENABLE_REDFISH_FW_TFTP_UPDATE}>: -DBMCWEB_INSECURE_ENABLE_REDFISH_FW_TFTP_UPDATE>
-
+    $<$<BOOL:${BMCWEB_ENABLE_TRAFFIC_LOGGING}>: -DBMCWEB_ENABLE_TRAFFIC_LOGGING>
 )
 
 # configure and install systemd unit files

--- a/crow/include/crow/http_connection.h
+++ b/crow/include/crow/http_connection.h
@@ -336,6 +336,20 @@ class Connection
 
         if (!isInvalidRequest)
         {
+            if constexpr (std::is_same_v<Adaptor,
+                                         boost::beast::ssl_stream<
+                                             boost::asio::ip::tcp::socket>>)
+            {
+                req->remoteIp = adaptor.next_layer()
+                                    .remote_endpoint()
+                                    .address()
+                                    .to_string();
+            }
+            else
+            {
+                req->remoteIp = adaptor.remote_endpoint().address().to_string();
+            }
+
             res.completeRequestHandler = [] {};
             res.isAliveHelper = [this]() -> bool { return isAlive(); };
 

--- a/crow/include/crow/http_request.h
+++ b/crow/include/crow/http_request.h
@@ -23,6 +23,7 @@ struct Request
 
     void* middlewareContext{};
     boost::asio::io_context* ioService{};
+    std::string remoteIp;
 
     std::shared_ptr<crow::persistent_data::UserSession> session;
 

--- a/include/logging_middleware.hpp
+++ b/include/logging_middleware.hpp
@@ -1,0 +1,140 @@
+#pragma once
+
+#include <crow/app.h>
+#include <crow/http_request.h>
+#include <crow/http_response.h>
+
+#include <boost/algorithm/string/predicate.hpp>
+
+namespace crow
+{
+
+namespace logging
+{
+
+namespace dbusRule = sdbusplus::bus::match::rules;
+
+class Middleware
+{
+  public:
+    struct Context
+    {
+    };
+
+    Middleware() : loggingEnabled(false)
+    {
+        BMCWEB_LOG_DEBUG << "Logging middleware c'tor";
+        auto method = crow::connections::systemBus->new_method_call(
+            "xyz.openbmc_project.Settings",
+            "/xyz/openbmc_project/logging/rest_api_logs",
+            "org.freedesktop.DBus.Properties", "Get");
+
+        method.append("xyz.openbmc_project.Object.Enable", "Enabled");
+
+        auto reply = crow::connections::systemBus->call(method);
+
+        std::variant<bool> enabled;
+        reply.read(enabled);
+
+        bool* enabledPtr = std::get_if<bool>(&enabled);
+
+        if (!enabledPtr)
+        {
+            BMCWEB_LOG_ERROR << "Failed to read logging enabled setting";
+        }
+        else
+        {
+            loggingEnabled = *enabledPtr;
+            BMCWEB_LOG_DEBUG << "REST/Redfish logging enabled status: "
+                             << loggingEnabled;
+        }
+
+        // Register for property changed event on logging enabled DBus object
+        busMatcher = std::make_unique<sdbusplus::bus::match_t>(
+            *crow::connections::systemBus,
+            dbusRule::propertiesChanged(
+                "/xyz/openbmc_project/logging/rest_api_logs",
+                "xyz.openbmc_project.Object.Enable"),
+            [this](sdbusplus::message::message& msg) {
+                std::string interface;
+                std::map<std::string, std::variant<bool>> props;
+
+                msg.read(interface, props);
+
+                for (auto& prop : props)
+                {
+                    if (prop.first == "Enabled")
+                    {
+                        bool* enabled = std::get_if<bool>(&prop.second);
+                        if (enabled)
+                        {
+                            BMCWEB_LOG_DEBUG << "Logging enabled changed to: "
+                                             << *enabled;
+                            this->loggingEnabled = *enabled;
+                        }
+                        break;
+                    }
+                }
+            });
+    }
+
+    ~Middleware() = default;
+
+    void log(const crow::Request& req, crow::Response& res,
+             const std::string_view username, bool skipBody)
+    {
+        if (!loggingEnabled)
+        {
+            return;
+        }
+        std::cout << req.remoteIp << " "
+                  << "user:" << username << " " << req.methodString() << " "
+                  << req.url << " json:" << (skipBody ? "None" : req.body)
+                  << " " << res.resultInt() << " "
+                  << boost::beast::http::obsolete_reason(res.result())
+                  << std::endl;
+    }
+
+    void beforeHandle(crow::Request& /*req*/, Response& /*res*/,
+                      Context& /*ctx*/)
+    {
+    }
+
+    void afterHandle(Request& req, Response& res, Context& /*ctx*/)
+    {
+        if (!loggingEnabled)
+        {
+            return;
+        }
+        // Log all traffic for methods other than GET on
+        // Redfish and REST routes
+        if (req.method() != "GET"_method &&
+            (boost::algorithm::starts_with(req.url, "/redfish/v1") ||
+             boost::algorithm::starts_with(req.url, "/xyz/") ||
+             boost::algorithm::starts_with(req.url, "/org/")))
+        {
+            bool skipBody = false;
+
+            // Determine whether the body should be logged. Do not log body for
+            // requests that contain passwords.
+            if ((req.url ==
+                 "/xyz/openbmc_project/user/ldap/action/CreateConfig") ||
+                (boost::algorithm::starts_with(req.url,
+                                               "/redfish/v1/AccountService/")))
+            {
+                skipBody = true;
+            }
+            if (req.session)
+            {
+                log(req, res, req.session->username, skipBody);
+            }
+        }
+    }
+
+  private:
+    bool loggingEnabled;
+    std::unique_ptr<sdbusplus::bus::match_t> busMatcher;
+};
+
+} // namespace logging
+} // namespace crow

--- a/include/token_authorization_middleware.hpp
+++ b/include/token_authorization_middleware.hpp
@@ -388,6 +388,11 @@ template <typename... Middlewares> void requestRoutes(Crow<Middlewares...>& app)
                     auto session = persistent_data::SessionStore::getInstance()
                                        .generateUserSession(username);
 
+#ifdef BMCWEB_ENABLE_TRAFFIC_LOGGING
+                    app.template getMiddleware<crow::logging::Middleware>().log(
+                        req, res, username, true);
+#endif
+
                     if (looksLikeIbm)
                     {
                         // IBM requires a very specific login structure, and

--- a/include/webserver_common.hpp
+++ b/include/webserver_common.hpp
@@ -15,10 +15,16 @@
 */
 #pragma once
 
+#include "logging_middleware.hpp"
 #include "security_headers_middleware.hpp"
 #include "token_authorization_middleware.hpp"
 #include "webserver_common.hpp"
 
 using CrowApp = crow::App<crow::SecurityHeadersMiddleware,
                           crow::persistent_data::Middleware,
-                          crow::token_authorization::Middleware>;
+                          crow::token_authorization::Middleware
+#ifdef BMCWEB_ENABLE_TRAFFIC_LOGGING
+                          ,
+                          crow::logging::Middleware
+#endif // BMCWEB_ENABLE_TRAFFIC_LOGGING
+                          >;

--- a/redfish-core/lib/redfish_sessions.hpp
+++ b/redfish-core/lib/redfish_sessions.hpp
@@ -113,7 +113,8 @@ class SessionCollection : public Node
 {
   public:
     SessionCollection(CrowApp& app) :
-        Node(app, "/redfish/v1/SessionService/Sessions/"), memberSession(app)
+        Node(app, "/redfish/v1/SessionService/Sessions/"), memberSession(app),
+        app(app)
     {
         entityPrivileges = {
             {boost::beast::http::verb::get, {{"Login"}}},
@@ -195,6 +196,10 @@ class SessionCollection : public Node
         res.addHeader("Location", "/redfish/v1/SessionService/Sessions/" +
                                       session->uniqueId);
         res.result(boost::beast::http::status::created);
+#ifdef BMCWEB_ENABLE_TRAFFIC_LOGGING
+        app.template getMiddleware<crow::logging::Middleware>().log(
+            req, res, username, true);
+#endif
         memberSession.doGet(res, req, {session->uniqueId});
     }
 
@@ -203,6 +208,7 @@ class SessionCollection : public Node
      * member's doGet, as they should return 100% matching data
      */
     Sessions memberSession;
+    CrowApp& app;
 };
 
 class SessionService : public Node

--- a/src/webserver_main.cpp
+++ b/src/webserver_main.cpp
@@ -59,6 +59,8 @@ int main(int argc, char** argv)
     crow::logger::setLogLevel(crow::LogLevel::DEBUG);
 
     auto io = std::make_shared<boost::asio::io_context>();
+    crow::connections::systemBus =
+        std::make_shared<sdbusplus::asio::connection>(*io);
     CrowApp app(io);
 
     // Static assets need to be initialized before Authorization, because auth
@@ -95,8 +97,6 @@ int main(int argc, char** argv)
     BMCWEB_LOG_INFO << "bmcweb (" << __DATE__ << ": " << __TIME__ << ')';
     setupSocket(app);
 
-    crow::connections::systemBus =
-        std::make_shared<sdbusplus::asio::connection>(*io);
     redfish::RedfishService redfish(app);
 
     // Keep the user role map hot in memory and


### PR DESCRIPTION
This commits adds support to log request and respose
for all REST and Redfish traffic flowing through BMCWEB.

It does this by defining a new crow middleware.
The middleware can be compiled out at build time if it is not
desired by using the BMCWEB_ENABLE_TRAFFIC_LOGGING compile
option.

The option is not enabled by default, recipes can add this
option as required.

This logging can also be turned ON or OFF at runtime by using
the Enabled property on the /xyz/openbmc_project/logging/rest_api_logs
DBUS object.

The middleware makes decisions on what data needs to be logged
by looking at the request URL. Per IBM's requirements, it does not
log data for REST and Redfish routes that contain passwords.

Tested:
1) Made sure that by default, the compile option disables any logging.
2) Compiled bmcweb with the logging option enabled and made sure that
when the logging is turned ON using:

busctl set-property xyz.openbmc_project.Settings
/xyz/openbmc_project/logging/rest_api_logs xyz.openbmc_project.Object.Enable
Enabled "true"

the system journal shows REST and redfish traffic.

3) Turning logging OFF using:

busctl set-property xyz.openbmc_project.Settings
/xyz/openbmc_project/logging/rest_api_logs xyz.openbmc_project.Object.Enable
Enabled "false"

the logs (for subsequent requests) no longer appear in the journal.

Change-Id: Id99709e45fe5e8d1ea8f19835a696de07ffa6645
Signed-off-by: Santosh Puranik <santosh.puranik@in.ibm.com>