### PR TITLE
Updated UserRoleMap::getUserRole() to call GetUserInfo()

### DIFF
--- a/include/sessions.hpp
+++ b/include/sessions.hpp
@@ -25,6 +25,289 @@ enum class PersistenceType
     SINGLE_REQUEST // User times out once this request is completed.
 };
 
+constexpr char const* userService = "xyz.openbmc_project.User.Manager";
+constexpr char const* userObjPath = "/xyz/openbmc_project/user";
+constexpr char const* userAttrIface = "xyz.openbmc_project.User.Attributes";
+constexpr char const* dbusPropertiesIface = "org.freedesktop.DBus.Properties";
+
+class SessionStore;
+
+struct UserRoleMap
+{
+    using GetManagedPropertyType =
+        boost::container::flat_map<std::string,
+                                   std::variant<std::string, bool>>;
+
+    using InterfacesPropertiesType =
+        boost::container::flat_map<std::string, GetManagedPropertyType>;
+
+    using GetManagedObjectsType = std::vector<
+        std::pair<sdbusplus::message::object_path, InterfacesPropertiesType>>;
+
+    static UserRoleMap& getInstance()
+    {
+        static UserRoleMap userRoleMap;
+        return userRoleMap;
+    }
+
+    UserRoleMap(const UserRoleMap&) = delete;
+    UserRoleMap& operator=(const UserRoleMap&) = delete;
+
+    std::string getUserRole(std::string_view name)
+    {
+        // check the in memory user-role map
+        auto it = roleMap.find(std::string(name));
+        if (it != roleMap.end())
+        {
+            return it->second;
+        }
+
+        BMCWEB_LOG_DEBUG << "User name " << name
+                         << " is not found in the local UserRoleMap.";
+
+        // Call GetUserInfo to get the role from the LDAP server
+        auto method = crow::connections::systemBus->new_method_call(
+            userService, userObjPath, userService, "GetUserInfo");
+
+        // string_view is not support by this dbus call. Hence, need to create a
+        // temporary string object.
+        method.append(std::string(name));
+
+        auto reply = crow::connections::systemBus->call(method);
+
+        std::map<std::string, sdbusplus::message::variant<
+                                  bool, std::string, std::vector<std::string>>>
+            userInfo;
+        reply.read(userInfo);
+
+        const std::string* userRole = nullptr;
+        auto userInfoIter = userInfo.find("UserPrivilege");
+        if (userInfoIter != userInfo.end())
+        {
+            userRole = std::get_if<std::string>(&userInfoIter->second);
+        }
+
+        if (userRole != nullptr)
+        {
+            BMCWEB_LOG_DEBUG << "user name " << name << " role is "
+                             << *userRole;
+            return *userRole;
+        }
+        else
+        {
+            BMCWEB_LOG_ERROR << "Unable to find the userRole for the user "
+                             << name;
+        }
+
+        return "";
+    }
+
+    std::string
+        extractUserRole(const InterfacesPropertiesType& interfacesProperties)
+    {
+        auto iface = interfacesProperties.find(userAttrIface);
+        if (iface == interfacesProperties.end())
+        {
+            return {};
+        }
+
+        auto& properties = iface->second;
+        auto property = properties.find("UserPrivilege");
+        if (property == properties.end())
+        {
+            return {};
+        }
+
+        const std::string* role = std::get_if<std::string>(&property->second);
+        if (role == nullptr)
+        {
+            BMCWEB_LOG_ERROR << "UserPrivilege property value is null";
+            return {};
+        }
+
+        return *role;
+    }
+
+  private:
+    void userAdded(sdbusplus::message::message& m)
+    {
+        sdbusplus::message::object_path objPath;
+        InterfacesPropertiesType interfacesProperties;
+
+        try
+        {
+            m.read(objPath, interfacesProperties);
+        }
+        catch (const sdbusplus::exception::SdBusError& e)
+        {
+            BMCWEB_LOG_ERROR << "Failed to parse user add signal."
+                             << "ERROR=" << e.what()
+                             << "REPLY_SIG=" << m.get_signature();
+            return;
+        }
+        BMCWEB_LOG_DEBUG << "obj path = " << objPath.str;
+
+        std::size_t lastPos = objPath.str.rfind("/");
+        if (lastPos == std::string::npos)
+        {
+            return;
+        };
+
+        std::string name = objPath.str.substr(lastPos + 1);
+        std::string role = this->extractUserRole(interfacesProperties);
+
+        // Insert the newly added user name and the role
+        auto res = roleMap.emplace(name, role);
+        if (res.second == false)
+        {
+            BMCWEB_LOG_ERROR << "Insertion of the user=\"" << name
+                             << "\" in the roleMap failed.";
+            return;
+        }
+    }
+
+    void userRemoved(sdbusplus::message::message& m)
+    {
+        sdbusplus::message::object_path objPath;
+
+        try
+        {
+            m.read(objPath);
+        }
+        catch (const sdbusplus::exception::SdBusError& e)
+        {
+            BMCWEB_LOG_ERROR << "Failed to parse user delete signal.";
+            BMCWEB_LOG_ERROR << "ERROR=" << e.what()
+                             << "REPLY_SIG=" << m.get_signature();
+            return;
+        }
+
+        BMCWEB_LOG_DEBUG << "obj path = " << objPath.str;
+
+        std::size_t lastPos = objPath.str.rfind("/");
+        if (lastPos == std::string::npos)
+        {
+            return;
+        };
+
+        // User name must be atleast 1 char in length.
+        if ((lastPos + 1) >= objPath.str.length())
+        {
+            return;
+        }
+
+        std::string name = objPath.str.substr(lastPos + 1);
+
+        roleMap.erase(name);
+    }
+
+    void userPropertiesChanged(sdbusplus::message::message& m)
+    {
+        std::string interface;
+        GetManagedPropertyType changedProperties;
+        m.read(interface, changedProperties);
+        const std::string path = m.get_path();
+
+        BMCWEB_LOG_DEBUG << "Object Path = \"" << path << "\"";
+
+        std::size_t lastPos = path.rfind("/");
+        if (lastPos == std::string::npos)
+        {
+            return;
+        };
+
+        // User name must be at least 1 char in length.
+        if ((lastPos + 1) == path.length())
+        {
+            return;
+        }
+
+        std::string user = path.substr(lastPos + 1);
+
+        BMCWEB_LOG_DEBUG << "User Name = \"" << user << "\"";
+
+        auto index = changedProperties.find("UserPrivilege");
+        if (index == changedProperties.end())
+        {
+            return;
+        }
+
+        const std::string* role = std::get_if<std::string>(&index->second);
+        if (role == nullptr)
+        {
+            return;
+        }
+        BMCWEB_LOG_DEBUG << "Role = \"" << *role << "\"";
+
+        auto it = roleMap.find(user);
+        if (it == roleMap.end())
+        {
+            BMCWEB_LOG_ERROR << "User Name = \"" << user
+                             << "\" is not found. But, received "
+                                "propertiesChanged signal";
+            return;
+        }
+        it->second = *role;
+    }
+
+    UserRoleMap() :
+        userAddedSignal(
+            *crow::connections::systemBus,
+            sdbusplus::bus::match::rules::interfacesAdded(userObjPath),
+            [this](sdbusplus::message::message& m) {
+                BMCWEB_LOG_DEBUG << "User Added";
+                this->userAdded(m);
+            }),
+        userRemovedSignal(
+            *crow::connections::systemBus,
+            sdbusplus::bus::match::rules::interfacesRemoved(userObjPath),
+            [this](sdbusplus::message::message& m) {
+                BMCWEB_LOG_DEBUG << "User Removed";
+                this->userRemoved(m);
+            }),
+        userPropertiesChangedSignal(
+            *crow::connections::systemBus,
+            sdbusplus::bus::match::rules::path_namespace(userObjPath) +
+                sdbusplus::bus::match::rules::type::signal() +
+                sdbusplus::bus::match::rules::member("PropertiesChanged") +
+                sdbusplus::bus::match::rules::interface(dbusPropertiesIface) +
+                sdbusplus::bus::match::rules::argN(0, userAttrIface),
+            [this](sdbusplus::message::message& m) {
+                BMCWEB_LOG_DEBUG << "Properties Changed";
+                this->userPropertiesChanged(m);
+            })
+    {
+        crow::connections::systemBus->async_method_call(
+            [this](boost::system::error_code ec,
+                   GetManagedObjectsType& managedObjects) {
+                if (ec)
+                {
+                    BMCWEB_LOG_DEBUG << "User manager call failed, ignoring";
+                    return;
+                }
+
+                for (auto& managedObj : managedObjects)
+                {
+                    std::size_t lastPos = managedObj.first.str.rfind("/");
+                    if (lastPos == std::string::npos)
+                    {
+                        continue;
+                    };
+                    std::string name = managedObj.first.str.substr(lastPos + 1);
+                    std::string role = extractUserRole(managedObj.second);
+                    roleMap.emplace(name, role);
+                }
+            },
+            userService, userObjPath, "org.freedesktop.DBus.ObjectManager",
+            "GetManagedObjects");
+    }
+
+    boost::container::flat_map<std::string, std::string> roleMap;
+    sdbusplus::bus::match_t userAddedSignal;
+    sdbusplus::bus::match_t userRemovedSignal;
+    sdbusplus::bus::match_t userPropertiesChangedSignal;
+};
+
 struct UserSession
 {
     std::string uniqueId;


### PR DESCRIPTION
if the role is not found in the in memory user role map.

For the local users, the user role map is kept hot in memory
and further changes are tracked using dbus match object.

For the remote users, get the role from the user manager module,
which abstracts how the remote user details are stored and retrieved.

Tested:
-   Created a local user having admin privilege and verified that he is
    able to restart the system
    /redfish/v1/Systems/system/Actions/ComputerSystem.Reset
        -d '{"ResetType": "GracefulRestart"}'
-   Created a local user having user privilege and verified that he is
    unauthorized to restart the system
    /redfish/v1/Systems/system/Actions/ComputerSystem.Reset
        -d '{"ResetType": "GracefulRestart"}'
-   Created a remote user having admin privilege and verified that he is
    able to restart the system
    /redfish/v1/Systems/system/Actions/ComputerSystem.Reset
        -d '{"ResetType": "GracefulRestart"}'
-   Created a remote user having user privilege and verified that he is
    unauthorized to restart the system
    /redfish/v1/Systems/system/Actions/ComputerSystem.Reset
        -d '{"ResetType": "GracefulRestart"}'

Signed-off-by: RAJESWARAN THILLAIGOVINDAN <rajeswgo@in.ibm.com>
Change-Id: Ifd813e1af4dfcb7aeaba18e04b6c9767d2a5e95a