### PR TITLE
Include user role in the persistent session data

### DIFF
--- a/include/sessions.hpp
+++ b/include/sessions.hpp
@@ -320,6 +320,10 @@ struct UserSession
             {
                 userSession->username = *thisValue;
             }
+            else if (element.key() == "user_role")
+            {
+                userSession->userRole = *thisValue;
+            }
             else
             {
                 BMCWEB_LOG_ERROR
@@ -530,7 +534,8 @@ struct adl_serializer<std::shared_ptr<crow::persistent_data::UserSession>>
             j = nlohmann::json{{"unique_id", p->uniqueId},
                                {"session_token", p->sessionToken},
                                {"username", p->username},
-                               {"csrf_token", p->csrfToken}};
+                               {"csrf_token", p->csrfToken},
+                               {"user_role", p->userRole}};
         }
     }
 };


### PR DESCRIPTION
The access to Redfish resources are based on the user role. When a
session is created, the role of the user at that time is stored in
the session details. The role changes, if any, will not be applicable
to the alreay created sessions.

Consider a scenario when bmcweb is restarted. If user role is not included
in the persistent session data, then at the time of starting bmcweb, the
current role of the user has to be considered as the role at the time of
creating the session is not known. The current role may be different from
the role when the session was created. That means, after creating a
session, role changes,if any, will be applied if bmcweb is restarted. If
bmcweb is not restarted during the life of a session, then role changes
are not applied. To avoid this difference in behaviour, store the user
role in the persistent session data.

Tested:
- Create a user with admin privilege
- Create a session for the above user
- Perform event log deletion; It is allowed since the user has admin privilege
- Modify the user privilege to operator
- Perform event log deletion; It is allowed since the modified privilege will
  not be considered for the existing session
- reboot
- With the same session token, you will be able to perform event log deletion
  as the modified privilege is not considered for the persistent session as
  well.

Signed-off-by: RAJESWARAN THILLAIGOVINDAN <rajeswgo@in.ibm.com>
Change-Id: I67557686b6d2d04f0f4454cb34670e3535c927e9