### PR TITLE
Redfish: Raise resource not found (404) if path does not exist

### DIFF
--- a/redfish-core/lib/certificate_service.hpp
+++ b/redfish-core/lib/certificate_service.hpp
@@ -257,7 +257,8 @@ static void getCertificateProperties(
             if (ec)
             {
                 BMCWEB_LOG_ERROR << "DBUS response error: " << ec;
-                messages::internalError(asyncResp->res);
+                messages::resourceNotFound(asyncResp->res, name,
+                                           std::to_string(certId));
                 return;
             }
             asyncResp->res.jsonValue = {
@@ -448,7 +449,8 @@ class CertificateActionsReplaceCertificate : public Node
                 if (ec)
                 {
                     BMCWEB_LOG_ERROR << "DBUS response error: " << ec;
-                    messages::internalError(asyncResp->res);
+                    messages::resourceNotFound(asyncResp->res, name,
+                                               std::to_string(id));
                     return;
                 }
                 getCertificateProperties(asyncResp, objectPath, service, id,


### PR DESCRIPTION
During replace/querying for certificates, if the path specified
does not exist InternalError is thrown, the same is modified
to throw ResourceNotFound error.

Fixes: https://github.com/openbmc/bmcweb/issues/88
Tested:
1) Resource not found error is thrown during replace certificate
2) Resource not found error is thrown during querying for
   certificate.
bash-4.2$ curl -k -H "X-Auth-Token: $bmc_token" -X GET
https://${bmc}/redfish/v1/AccountService/LDAP/Certificates/1
{
  "error": {
    "@Message.ExtendedInfo": [
      {
        "@odata.type": "/redfish/v1/$metadata#Message.v1_0_0.Message",
        "Message": "The requested resource of type LDAP Certificate named 1 was
not found.",
        "MessageArgs": [
          "LDAP Certificate",
          "1"
        ],
        "MessageId": "Base.1.4.0.ResourceNotFound",
        "Resolution": "Provide a valid resource identifier and resubmit the
request.",
        "Severity": "Critical"
      }
    ],
    "code": "Base.1.4.0.ResourceNotFound",
    "message": "The requested resource of type LDAP Certificate named 1 was not
found."
  }
}

bash-4.2$ curl -c cjar -b cjar -k -H "X-Auth-Token: $bmc_token" -X POST
https://${bmc}/redfish/v1/CertificateService/Actions/CertificateService.ReplaceCertificate/
-d @data_https.json
{
  "error": {
    "@Message.ExtendedInfo": [
      {
        "@odata.type": "/redfish/v1/$metadata#Message.v1_0_0.Message",
        "Message": "The requested resource of type HTTPS certificate named 2 was
not found.",
        "MessageArgs": [
          "HTTPS certificate",
          "2"
        ],
        "MessageId": "Base.1.4.0.ResourceNotFound",
        "Resolution": "Provide a valid resource identifier and resubmit the
request.",
        "Severity": "Critical"
      }
    ],
    "code": "Base.1.4.0.ResourceNotFound",
    "message": "The requested resource of type HTTPS certificate named 2 was not
found."
  }
}

Signed-off-by: Marri Devender Rao <devenrao@in.ibm.com>
Change-Id: I88b90cbca88fd5a23929f7e7e0d4e32948d9713b