### PR TITLE
Fixed Accelerator State

### DIFF
--- a/redfish-core/lib/cpudimm.hpp
+++ b/redfish-core/lib/cpudimm.hpp
@@ -259,8 +259,8 @@ void getAcceleratorDataByService(std::shared_ptr<AsyncResp> aResp,
         [acclrtrId, aResp{std::move(aResp)}](
             const boost::system::error_code ec,
             const boost::container::flat_map<
-                std::string, std::variant<std::string, uint32_t, uint16_t>>
-                &properties) {
+                std::string, std::variant<std::string, uint32_t, uint16_t,
+                                          bool>> &properties) {
             if (ec)
             {
                 BMCWEB_LOG_DEBUG << "DBUS response error";
@@ -269,19 +269,19 @@ void getAcceleratorDataByService(std::shared_ptr<AsyncResp> aResp,
             }
             aResp->res.jsonValue["Id"] = acclrtrId;
             aResp->res.jsonValue["Name"] = "Processor";
-            const std::string *accPresent = nullptr;
-            const std::string *accFunctional = nullptr;
+            const bool *accPresent = nullptr;
+            const bool *accFunctional = nullptr;
             std::string state = "";
 
             for (const auto &property : properties)
             {
                 if (property.first == "Functional")
                 {
-                    accFunctional = std::get_if<std::string>(&property.second);
+                    accFunctional = std::get_if<bool>(&property.second);
                 }
                 else if (property.first == "Present")
                 {
-                    accPresent = std::get_if<std::string>(&property.second);
+                    accPresent = std::get_if<bool>(&property.second);
                 }
             }
 
@@ -293,11 +293,11 @@ void getAcceleratorDataByService(std::shared_ptr<AsyncResp> aResp,
                 return;
             }
 
-            if ((*accPresent == "Present") && (*accFunctional == "Functional"))
+            if (*accPresent && *accFunctional)
             {
                 state = "Enabled";
             }
-            else if (*accPresent == "Present")
+            else if (*accPresent)
             {
                 state = "UnavailableOffline";
             }


### PR DESCRIPTION
This commit fixes a bug in getAcceleratorDataByService
when looking up the Present and Functional properties
on D-Bus.

The properties are booleans, but the code was trying
to read them as strings.

Tested:
-- Redfish validator comes out clean
-- Tested various combinations of present and functional
   properties on the GPU inventory objects:

xyz.openbmc_project.Inventory.Manager
/xyz/openbmc_project/inventory/system/chassis/motherboard/gv100card0
xyz.openbmc_project.State.Decorator.OperationalStatus Functional b "false"

/xyz/openbmc_project/inventory/system/chassis/motherboard/gv100card0
xyz.openbmc_project.Inventory.Item Present b "true"

$ curl -k -H "X-Auth-Token: $bmc_token" -X GET
https://${bmc}/redfish/v1/Systems/system/Processors/gv100card0
{
  "@odata.context": "/redfish/v1/$metadata#Processor.Processor",
  "@odata.id": "/redfish/v1/Systems/system/Processors/gv100card0",
  "@odata.type": "#Processor.v1_3_1.Processor",
  "Id": "gv100card0",
  "Name": "Processor",
  "ProcessorType": "Accelerator",
  "Status": {
    "Health": "OK",
    "State": "UnavailableOffline"
}

Set functional but not present:

$ curl -k -H "X-Auth-Token: $bmc_token" -X GET
https://${bmc}/redfish/v1/Systems/system/Processors/gv100card0
{
  "@odata.context": "/redfish/v1/$metadata#Processor.Processor",
  "@odata.id": "/redfish/v1/Systems/system/Processors/gv100card0",
  "@odata.type": "#Processor.v1_3_1.Processor",
  "Id": "gv100card0",
  "Name": "Processor",
  "ProcessorType": "Accelerator",
  "Status": {
    "Health": "OK",
    "State": "Absent"
}

Set functional and present:

$ curl -k -H "X-Auth-Token: $bmc_token" -X GET
https://${bmc}/redfish/v1/Systems/system/Processors/gv100card0
{
  "@odata.context": "/redfish/v1/$metadata#Processor.Processor",
  "@odata.id": "/redfish/v1/Systems/system/Processors/gv100card0",
  "@odata.type": "#Processor.v1_3_1.Processor",
  "Id": "gv100card0",
  "Name": "Processor",
  "ProcessorType": "Accelerator",
  "Status": {
    "Health": "OK",
    "State": "Enabled"
}

Set not functional and not present:

$ curl -k -H "X-Auth-Token: $bmc_token" -X GET
https://${bmc}/redfish/v1/Systems/system/Processors/gv100card0
{
  "@odata.context": "/redfish/v1/$metadata#Processor.Processor",
  "@odata.id": "/redfish/v1/Systems/system/Processors/gv100card0",
  "@odata.type": "#Processor.v1_3_1.Processor",
  "Id": "gv100card0",
  "Name": "Processor",
  "ProcessorType": "Accelerator",
  "Status": {
    "Health": "OK",
    "State": "Absent"
}

Signed-off-by: Santosh Puranik <santosh.puranik@in.ibm.com>
Change-Id: Ic5ccc9bcd3b2b245ffdd714105d5b4fed3ca4ea4