### PR TITLE
bmcweb implementation of NMI (soft reset) control code

### DIFF
--- a/redfish-core/lib/systems.hpp
+++ b/redfish-core/lib/systems.hpp
@@ -1090,6 +1090,11 @@ class SystemActionsReset : public Node
             command = "xyz.openbmc_project.State.Chassis.Transition.PowerCycle";
             hostCommand = false;
         }
+        else if (resetType == "Nmi")
+        {
+            doNMI(asyncResp);
+            return;
+        }
         else
         {
             messages::actionParameterUnknown(res, "Reset", resetType);
@@ -1149,6 +1154,31 @@ class SystemActionsReset : public Node
                 std::variant<std::string>{command});
         }
     }
+    /**
+     * Function transceives data with dbus directly.
+     */
+    void doNMI(const std::shared_ptr<AsyncResp> &asyncResp)
+    {
+        constexpr char const *serviceName =
+            "xyz.openbmc_project.Control.Host.NMI";
+        constexpr char const *objectPath =
+            "/xyz/openbmc_project/control/host0/nmi";
+        constexpr char const *interfaceName =
+            "xyz.openbmc_project.Control.Host.NMI";
+        constexpr char const *method = "NMI";
+
+        crow::connections::systemBus->async_method_call(
+            [asyncResp](const boost::system::error_code ec) {
+                if (ec)
+                {
+                    BMCWEB_LOG_ERROR << " Bad D-Bus request error: " << ec;
+                    messages::internalError(asyncResp->res);
+                    return;
+                }
+                messages::success(asyncResp->res);
+            },
+            serviceName, objectPath, interfaceName, method);
+    }
 };
 
 /**
@@ -1202,7 +1232,7 @@ class Systems : public Node
              "/redfish/v1/Systems/system/Actions/ComputerSystem.Reset"},
             {"ResetType@Redfish.AllowableValues",
              {"On", "ForceOff", "ForceOn", "ForceRestart", "GracefulRestart",
-              "GracefulShutdown", "PowerCycle"}}};
+              "GracefulShutdown", "PowerCycle", "Nmi"}}};
 
         res.jsonValue["LogServices"] = {
             {"@odata.id", "/redfish/v1/Systems/system/LogServices"}};


### PR DESCRIPTION
https://gerrit.openbmc-project.xyz/#/c/openbmc/bmcweb/+/22661/
bmcweb implementation of NMI (soft reset) control code

Tested: Verified following

  1) Redfish validator result is Negative
  2) verified following command triggered NMI on host
     curl -k -H "X-Auth-Token: $bmc_token" -X POST
     https://9.5.180.47/redfish/v1/Systems/system/Actions/ComputerSystem.Reset
     -d '{"ResetType":"Nmi"}'
     Response : OK
  2) Host rebooted and crash dump is collected

Signed-off-by: Lakshminarayana R. Kammath <lkammath@in.ibm.com>
Change-Id: I09efa1e3d94437c89afbe1a1b9d148cc4f577ebe