### PR TITLE
Fix Redfish Validator caused by Chassis.v1_9_1

### DIFF
--- a/redfish-core/lib/chassis.hpp
+++ b/redfish-core/lib/chassis.hpp
@@ -325,7 +325,7 @@ class Chassis : public Node
                     }
 
                     asyncResp->res.jsonValue["@odata.type"] =
-                        "#Chassis.v1_9_1.Chassis";
+                        "#Chassis.v1_9_0.Chassis";
                     asyncResp->res.jsonValue["@odata.id"] =
                         "/redfish/v1/Chassis/" + chassisId;
                     asyncResp->res.jsonValue["@odata.context"] =
@@ -394,7 +394,7 @@ class Chassis : public Node
 
                 // Couldn't find an object with that name.  return an error
                 messages::resourceNotFound(
-                    asyncResp->res, "#Chassis.v1_9_1.Chassis", chassisId);
+                    asyncResp->res, "#Chassis.v1_9_0.Chassis", chassisId);
             },
             "xyz.openbmc_project.ObjectMapper",
             "/xyz/openbmc_project/object_mapper",


### PR DESCRIPTION
Chassis.v1_9_1 is only part of the 2019.1 schema, we are using 2018.3
schema.

This fixes 6 Validator errors:
ERROR - 1 failProp errors in /redfish/v1/Systems/system
ERROR - 4 failMandatoryProp errors in /redfish/v1/Chassis
ERROR - Error message present in /redfish/v1/Chassis/chassis
ERROR - Error message present in /redfish/v1/Chassis/powersupply0
ERROR - Error message present in /redfish/v1/Chassis/powersupply1
ERROR - 1 failProp errors in /redfish/v1/Managers/bmc

2 errors still exist:
ERROR - 1 failProp errors in /redfish/v1/Chassis/motherboard
ERROR - 1 problemResource errors in /redfish/v1/Chassis/motherboard/Sensors

caused by
curl -k https://${bmc}/redfish/v1/Chassis/motherboard/Sensors
Internal Server Error

Signed-off-by: Gunnar Mills <gmills@us.ibm.com>