### PR TITLE
Ignore charset for /login attempts

### DIFF
--- a/include/token_authorization_middleware.hpp
+++ b/include/token_authorization_middleware.hpp
@@ -283,12 +283,13 @@ template <typename... Middlewares> void requestRoutes(Crow<Middlewares...>& app)
             // within it are not destroyed before we can use them
             nlohmann::json loginCredentials;
             // Check if auth was provided by a payload
-            if (contentType == "application/json")
+            if (boost::starts_with(contentType, "application/json"))
             {
                 loginCredentials =
                     nlohmann::json::parse(req.body, nullptr, false);
                 if (loginCredentials.is_discarded())
                 {
+                    BMCWEB_LOG_DEBUG << "Bad json in request";
                     res.result(boost::beast::http::status::bad_request);
                     res.end();
                     return;
@@ -429,6 +430,7 @@ template <typename... Middlewares> void requestRoutes(Crow<Middlewares...>& app)
             }
             else
             {
+                BMCWEB_LOG_DEBUG << "Couldn't interpret password";
                 res.result(boost::beast::http::status::bad_request);
             }
             res.end();


### PR DESCRIPTION
Needed to support IE 11.
Coming soon, IE 11 support, via https://gerrit.openbmc-project.xyz/c/openbmc/phosphor-webui/+/24062

bmcweb fails when attempting to login with a Content header of
application/json; charset=utf8.  This is because of an exact string
compare.  This commit changes the check to only check the begining of
the string, and adds some logging to make it more clear when we hit this
in the future.

Signed-off-by: Ed Tanous <ed.tanous@intel.com>
Change-Id: I972a80c174a18295205340271b781c9d6693ee17