### PR TITLE
Redfish: Add power metrics for openpower

### DIFF
--- a/redfish-core/lib/power.hpp
+++ b/redfish-core/lib/power.hpp
@@ -19,8 +19,199 @@
 #include "node.hpp"
 #include "sensors.hpp"
 
+#include <regex>
+
 namespace redfish
 {
+
+struct PowerMetrics : std::enable_shared_from_this<PowerMetrics>
+{
+    PowerMetrics(const std::shared_ptr<SensorsAsyncResp>& asyncResp) :
+        asyncResp(asyncResp)
+    {
+    }
+
+    ~PowerMetrics()
+    {
+        nlohmann::json& pc = asyncResp->res.jsonValue["PowerControl"];
+        if (pc.empty())
+        {
+            // Add mandatory properties for PowerControl
+            pc.push_back(
+                {{"@odata.type", "#Power.v1_0_0.PowerControl"},
+                 {"@odata.id", "/redfish/v1/Chassis/" + asyncResp->chassisId +
+                                   "/Power#/PowerControl/0"},
+                 {"Name", "Chassis Power Control"},
+                 {"MemberId", "0"}});
+        }
+
+        // Add PowerMetrics entries
+        nlohmann::json& pcJson = pc.back();
+
+        // Set metric values after all have been read
+        if (avgMetric != nullptr)
+        {
+            pcJson["PowerMetrics"]["AverageConsumedWatts"] = *avgMetric;
+        }
+
+        if (maxMetric != nullptr)
+        {
+            pcJson["PowerMetrics"]["MaxConsumedWatts"] =
+                *std::max_element(maxMetric->begin(), maxMetric->end());
+        }
+
+        if (avgMetric != nullptr || maxMetric != nullptr)
+        {
+            // Set interval based on number of history entries divided by 2
+            // Collection is done every 30s, Redfish interval is in minutes
+            pcJson["PowerMetrics"]["IntervalInMin"] = int30s / 2;
+        }
+    }
+
+    void getAverage(const std::string service, const std::string path)
+    {
+        std::shared_ptr<PowerMetrics> self = shared_from_this();
+        // Get aggregation history
+        crow::connections::systemBus->async_method_call(
+            [self](const boost::system::error_code ec,
+                   std::variant<std::vector<std::tuple<uint64_t, int64_t>>>&
+                       history) {
+                if (ec)
+                {
+                    // No average power aggregation history
+                    return;
+                }
+
+                auto* avgHistory =
+                    std::get_if<std::vector<std::tuple<uint64_t, int64_t>>>(
+                        &history);
+                if (avgHistory == nullptr || avgHistory->size() == 0)
+                {
+                    // Do not set/return average metric value
+                    return;
+                }
+
+                // Reduce down to a max of 10 minutes of aggregation history
+                if (avgHistory->size() > self->maxAggHistory)
+                {
+                    avgHistory->resize(self->maxAggHistory);
+                }
+
+                // Set the interval for this aggregation history
+                self->setInterval(avgHistory->size());
+
+                // Accumulate average power consumed per power supply
+                // as the total average power consumed
+                auto sum = std::accumulate(
+                    avgHistory->begin(), avgHistory->end(), 0,
+                    [](int64_t sum,
+                       const std::tuple<uint64_t, int64_t>& entry) {
+                        return sum + std::get<int64_t>(entry);
+                    });
+                if (self->avgMetric == nullptr)
+                {
+                    self->avgTotal = sum / avgHistory->size();
+                    self->avgMetric = &self->avgTotal;
+                }
+                else
+                {
+                    self->avgTotal = self->avgTotal + sum / avgHistory->size();
+                }
+            },
+            service, path, "org.freedesktop.DBus.Properties", "Get",
+            "org.open_power.Sensor.Aggregation.History.Average", "Values");
+    }
+
+    void getMaximum(const std::string service, const std::string path)
+    {
+        std::shared_ptr<PowerMetrics> self = shared_from_this();
+        // Get aggregation history
+        crow::connections::systemBus->async_method_call(
+            [self](const boost::system::error_code ec,
+                   std::variant<std::vector<std::tuple<uint64_t, int64_t>>>&
+                       history) {
+                if (ec)
+                {
+                    // No maximum power aggregation history
+                    return;
+                }
+
+                auto* maxHistory =
+                    std::get_if<std::vector<std::tuple<uint64_t, int64_t>>>(
+                        &history);
+                if (maxHistory == nullptr || maxHistory->size() == 0)
+                {
+                    // Do not set/return maximum metric value
+                    return;
+                }
+
+                // Reduce down to a max of 10 minutes of aggregation history
+                if (maxHistory->size() > self->maxAggHistory)
+                {
+                    maxHistory->resize(self->maxAggHistory);
+                }
+
+                // Set the interval for this aggregation history
+                self->setInterval(maxHistory->size());
+
+                // Accumulate maximum power consumed per power supply
+                // as the total maximum power consumed
+                if (self->maxMetric == nullptr)
+                {
+                    for (auto& maxEntry : *maxHistory)
+                    {
+                        self->maxTotals.emplace_back(
+                            std::get<int64_t>(maxEntry));
+                    }
+                    self->maxMetric = &self->maxTotals;
+                }
+                else
+                {
+                    auto hisIt = maxHistory->begin();
+                    auto totIt = self->maxTotals.begin();
+                    while (totIt != self->maxTotals.end())
+                    {
+                        *totIt = *totIt + std::get<int64_t>(*hisIt++);
+                        ++totIt;
+                        if (hisIt == maxHistory->end())
+                        {
+                            break;
+                        }
+                    }
+                    if (hisIt != maxHistory->end() &&
+                        totIt == self->maxTotals.end())
+                    {
+                        while (hisIt != maxHistory->end())
+                        {
+                            self->maxTotals.emplace_back(
+                                std::get<int64_t>(*hisIt));
+                            ++hisIt;
+                        }
+                    }
+                }
+            },
+            service, path, "org.freedesktop.DBus.Properties", "Get",
+            "org.open_power.Sensor.Aggregation.History.Maximum", "Values");
+    }
+
+    void setInterval(uint64_t int30sCount)
+    {
+        // Redfish has a single interval for all power metrics
+        // Set the interval to the highest history interval count
+        if (int30sCount > this->int30s)
+        {
+            this->int30s = int30sCount;
+        }
+    }
+
+    std::shared_ptr<SensorsAsyncResp> asyncResp;
+    int64_t avgTotal = 0;
+    int64_t* avgMetric = nullptr;
+    std::vector<int64_t> maxTotals;
+    std::vector<int64_t>* maxMetric = nullptr;
+    uint64_t int30s = 0;
+    const uint64_t maxAggHistory = 20;
+};
 
 class Power : public Node
 {
@@ -223,6 +414,77 @@ class Power : public Node
             "/xyz/openbmc_project/inventory", int32_t(0),
             std::array<const char*, 1>{
                 "xyz.openbmc_project.Inventory.Item.Chassis"});
+
+        // Retrieve OpenPower power metrics
+        const char* avgIntf =
+            "org.open_power.Sensor.Aggregation.History.Average";
+        const char* maxIntf =
+            "org.open_power.Sensor.Aggregation.History.Maximum";
+        crow::connections::systemBus->async_method_call(
+            [sensorAsyncResp, avgIntf, maxIntf](
+                const boost::system::error_code ec,
+                const std::vector<std::pair<
+                    std::string, std::vector<std::pair<
+                                     std::string, std::vector<std::string>>>>>&
+                    subtree) {
+                if (ec)
+                {
+                    // No OpenPower aggregation history
+                    return;
+                }
+
+                auto powerMetrics =
+                    std::make_shared<PowerMetrics>(sensorAsyncResp);
+                const std::regex psInputRegex =
+                    std::regex("(ps)([0-9]+)(_input_power)");
+
+                for (const auto& object : subtree)
+                {
+                    const auto& path = object.first;
+                    size_t metricPos = path.rfind("/");
+                    if (metricPos == std::string::npos)
+                    {
+                        // Last object path '/' not found
+                        continue;
+                    }
+
+                    // Get object name providing metric
+                    size_t objectPos = path.rfind("/", metricPos - 1);
+                    if (objectPos == std::string::npos)
+                    {
+                        // Invalid object path providing metric
+                        continue;
+                    }
+                    auto objectName =
+                        path.substr(objectPos + 1, (metricPos - 1) - objectPos);
+
+                    // Only get power metrics from ps*_input_power objects
+                    if (std::regex_match(objectName, psInputRegex))
+                    {
+                        for (const auto& service : object.second)
+                        {
+                            // Get aggregation history from the proper interface
+                            if (std::find(service.second.begin(),
+                                          service.second.end(),
+                                          avgIntf) != service.second.end())
+                            {
+                                powerMetrics->getAverage(service.first, path);
+                            }
+                            if (std::find(service.second.begin(),
+                                          service.second.end(),
+                                          maxIntf) != service.second.end())
+                            {
+                                powerMetrics->getMaximum(service.first, path);
+                            }
+                        }
+                    }
+                }
+            },
+            "xyz.openbmc_project.ObjectMapper",
+            "/xyz/openbmc_project/object_mapper",
+            "xyz.openbmc_project.ObjectMapper", "GetSubTree",
+            "/org/open_power/sensors/aggregation/per_30s", int32_t(0),
+            std::array<const char*, 2>{avgIntf, maxIntf});
     }
     void doPatch(crow::Response& res, const crow::Request& req,
                  const std::vector<std::string>& params) override


### PR DESCRIPTION
The average and maximum consumed power aggregation history is read and
stored every 30 seconds within an openpower interface per power supply.
This pulls the entire aggregation history for each metric, over all
power supplies, and calculates a total average and maximum.

The total average consumed power is the result from adding the average
of all aggregation history entries per power supply. This is presented
as the `AverageConsumedWatts` in Redfish.

The total maximum consumed power is the result from adding the maximum
value determined from the aggregation history per power supply over the
same aggregation period. This is presented as the `MaxConsumedWatts` in
Redfish.

The `IntervalInMin` Redfish attribute is a single interval(in minutes)
at which all the Redfish power metrics were collected. Therefore, this
interval is set to the highest number of 30 second entries found of
aggregation history up to a 10 minute interval. (The openpower
aggregation history is collected and stored at the same time every 30
seconds, so this interval calculation should not affect the values
presented in Redfish for average and maximum power consumed.)

Tested:
    Used BMCWEB_LOG_DEBUG to verify number of method calls
    Used BMCWEB_LOG_DEBUG to verify data returned

  "PowerControl": [
    {
      "@odata.id": "/redfish/v1/Chassis/chassis/Power#/PowerControl/0",
      "@odata.type": "#Power.v1_0_0.PowerControl",
      "MemberId": "0",
      "Name": "Chassis Power Control",
      "PowerConsumedWatts": 268.0,
      "PowerLimit": {
        "LimitInWatts": 600.0
      },
      "PowerMetrics": {
        "AverageConsumedWatts": 173,
        "IntervalInMin": 10,
        "MaxConsumedWatts": 179
      },
      "Status": {
        "Health": "OK",
        "State": "Enabled"
      }
    }
  ]

Signed-off-by: Matthew Barth <msbarth@us.ibm.com>
Change-Id: I23e88ef77999ff4da005e5430160f196a9574b46