### PR TITLE
Fix "MemorySummary" status: Disabled on IBM systems

### DIFF
--- a/redfish-core/lib/systems.hpp
+++ b/redfish-core/lib/systems.hpp
@@ -27,40 +27,6 @@
 namespace redfish
 {
 
-/**
- * @brief Updates the Functional State of DIMMs
- *
- * @param[in] aResp Shared pointer for completing asynchronous calls
- * @param[in] dimmState Dimm's Functional state, true/false
- *
- * @return None.
- */
-void updateDimmProperties(std::shared_ptr<AsyncResp> aResp,
-                          const std::variant<bool> &dimmState)
-{
-    const bool *isDimmFunctional = std::get_if<bool>(&dimmState);
-    if (isDimmFunctional == nullptr)
-    {
-        messages::internalError(aResp->res);
-        return;
-    }
-    BMCWEB_LOG_DEBUG << "Dimm Functional:" << *isDimmFunctional;
-
-    // Set it as Enabled if atleast one DIMM is functional
-    // Update STATE only if previous State was DISABLED and current Dimm is
-    // ENABLED.
-    nlohmann::json &prevMemSummary =
-        aResp->res.jsonValue["MemorySummary"]["Status"]["State"];
-    if (prevMemSummary == "Disabled")
-    {
-        if (*isDimmFunctional == true)
-        {
-            aResp->res.jsonValue["MemorySummary"]["Status"]["State"] =
-                "Enabled";
-        }
-    }
-}
-
 /*
  * @brief Update "ProcessorSummary" "Count" based on Cpu PresenceState
  *
@@ -197,64 +163,29 @@ void getComputerSystem(std::shared_ptr<AsyncResp> aResp)
                                     BMCWEB_LOG_DEBUG << "Got "
                                                      << properties.size()
                                                      << "Dimm properties.";
-
-                                    if (properties.size() > 0)
+                                    for (const std::pair<std::string,
+                                                         VariantType>
+                                             &property : properties)
                                     {
-                                        for (const std::pair<std::string,
-                                                             VariantType>
-                                                 &property : properties)
+                                        if (property.first == "MemorySizeInKb")
                                         {
-                                            if (property.first ==
-                                                "MemorySizeInKb")
+                                            const uint64_t *value =
+                                                sdbusplus::message::variant_ns::
+                                                    get_if<uint64_t>(
+                                                        &property.second);
+                                            if (value != nullptr)
                                             {
-                                                const uint64_t *value =
-                                                    sdbusplus::message::
-                                                        variant_ns::get_if<
-                                                            uint64_t>(
-                                                            &property.second);
-                                                if (value != nullptr)
-                                                {
-                                                    aResp->res.jsonValue
-                                                        ["TotalSystemMemoryGi"
-                                                         "B"] +=
-                                                        *value / (1024 * 1024);
-                                                    aResp->res.jsonValue
-                                                        ["MemorySummary"]
-                                                        ["Status"]["State"] =
-                                                        "Enabled";
-                                                }
+                                                aResp->res.jsonValue
+                                                    ["TotalSystemMemoryGi"
+                                                     "B"] +=
+                                                    *value / (1024 * 1024);
+                                                aResp->res
+                                                    .jsonValue["MemorySummary"]
+                                                              ["Status"]
+                                                              ["State"] =
+                                                    "Enabled";
                                             }
                                         }
-                                    }
-                                    else
-                                    {
-                                        auto getDimmProperties =
-                                            [aResp](
-                                                const boost::system::error_code
-                                                    ec,
-                                                const std::variant<bool>
-                                                    &dimmState) {
-                                                if (ec)
-                                                {
-                                                    BMCWEB_LOG_ERROR
-                                                        << "DBUS response "
-                                                           "error "
-                                                        << ec;
-                                                    return;
-                                                }
-                                                updateDimmProperties(aResp,
-                                                                     dimmState);
-                                            };
-                                        crow::connections::systemBus
-                                            ->async_method_call(
-                                                std::move(getDimmProperties),
-                                                service, path,
-                                                "org.freedesktop.DBus."
-                                                "Properties",
-                                                "Get",
-                                                "xyz.openbmc_project.State."
-                                                "Decorator.OperationalStatus",
-                                                "Functional");
                                     }
                                 },
                                 connection.first, path,
@@ -266,11 +197,14 @@ void getComputerSystem(std::shared_ptr<AsyncResp> aResp)
                         {
                             BMCWEB_LOG_DEBUG
                                 << "Found Cpu, now get its properties.";
+
                             crow::connections::systemBus->async_method_call(
-                                [aResp](const boost::system::error_code ec,
-                                        const std::vector<
-                                            std::pair<std::string, VariantType>>
-                                            &properties) {
+                                [aResp, service{connection.first},
+                                 path(std::move(path))](
+                                    const boost::system::error_code ec,
+                                    const std::vector<
+                                        std::pair<std::string, VariantType>>
+                                        &properties) {
                                     if (ec)
                                     {
                                         BMCWEB_LOG_ERROR
@@ -281,30 +215,107 @@ void getComputerSystem(std::shared_ptr<AsyncResp> aResp)
                                     BMCWEB_LOG_DEBUG << "Got "
                                                      << properties.size()
                                                      << "Cpu properties.";
-                                    for (const auto &property : properties)
-                                    {
-                                        if (property.first == "ProcessorFamily")
-                                        {
-                                            const std::string *value =
-                                                sdbusplus::message::variant_ns::
-                                                    get_if<std::string>(
-                                                        &property.second);
-                                            if (value != nullptr)
-                                            {
-                                                nlohmann::json &procSummary =
-                                                    aResp->res.jsonValue
-                                                        ["ProcessorSumm"
-                                                         "ary"];
-                                                nlohmann::json &procCount =
-                                                    procSummary["Count"];
 
-                                                procCount =
-                                                    procCount.get<int>() + 1;
-                                                procSummary["Status"]["State"] =
-                                                    "Enabled";
-                                                procSummary["Model"] = *value;
+                                    if (properties.size() > 0)
+                                    {
+                                        for (const auto &property : properties)
+                                        {
+                                            if (property.first ==
+                                                "ProcessorFamily")
+                                            {
+                                                const std::string *value =
+                                                    sdbusplus::message::
+                                                        variant_ns::get_if<
+                                                            std::string>(
+                                                            &property.second);
+                                                if (value != nullptr)
+                                                {
+                                                    nlohmann::json
+                                                        &procSummary =
+                                                            aResp->res.jsonValue
+                                                                ["ProcessorSumm"
+                                                                 "ary"];
+                                                    nlohmann::json &procCount =
+                                                        procSummary["Count"];
+                                                    procCount =
+                                                        procCount.get<int>() +
+                                                        1;
+                                                    procSummary["Status"]
+                                                               ["State"] =
+                                                                   "Enabled";
+                                                    procSummary["Model"] =
+                                                        *value;
+                                                }
                                             }
                                         }
+                                    }
+                                    else
+                                    {
+                                        auto getCpuPresenceState =
+                                            [aResp](
+                                                const boost::system::error_code
+                                                    ec,
+                                                const std::variant<bool>
+                                                    &cpuPresenceCheck) {
+                                                if (ec)
+                                                {
+                                                    BMCWEB_LOG_ERROR
+                                                        << "DBUS response "
+                                                           "error "
+                                                        << ec;
+                                                    return;
+                                                }
+                                                modifyCpuPresenceState(
+                                                    aResp, cpuPresenceCheck);
+                                            };
+
+                                        auto getCpuFunctionalState =
+                                            [aResp](
+                                                const boost::system::error_code
+                                                    ec,
+                                                const std::variant<bool>
+                                                    &cpuFunctionalCheck) {
+                                                if (ec)
+                                                {
+                                                    BMCWEB_LOG_ERROR
+                                                        << "DBUS response "
+                                                           "error "
+                                                        << ec;
+                                                    return;
+                                                }
+                                                modifyCpuFunctionalState(
+                                                    aResp, cpuFunctionalCheck);
+                                            };
+                                        // Get the Presence of CPU
+                                        crow::connections::systemBus
+                                            ->async_method_call(
+                                                std::move(getCpuPresenceState),
+                                                service, path,
+                                                "org.freedesktop.DBus."
+                                                "Properties",
+                                                "Get",
+                                                "xyz.openbmc_project.Inventory."
+                                                "Item",
+                                                "Present");
+
+                                        // Get the Functional State
+                                        crow::connections::systemBus
+                                            ->async_method_call(
+                                                std::move(
+                                                    getCpuFunctionalState),
+                                                service, path,
+                                                "org.freedesktop.DBus."
+                                                "Properties",
+                                                "Get",
+                                                "xyz.openbmc_project.State."
+                                                "Decorator."
+                                                "OperationalStatus",
+                                                "Functional");
+
+                                        // Get the MODEL from
+                                        // xyz.openbmc_project.Inventory.Decorator.Asset
+                                        // support it later as Model  is Empty
+                                        // currently.
                                     }
                                 },
                                 connection.first, path,


### PR DESCRIPTION
"MemorySummary" Status is always Disabled.Fixed it.

Doing GET on Interface xyz.openbmc_project.State.Decorator.OperationalStatus
instead of xyz.openbmc_project.Inventory.Item.Dimm to get the State of Dimm

Tested:
-- Ran GET request on the ComputerSystem node when Host is Up
 curl -k -H "X-Auth-Token: $bmc_token" -X GET https://${bmc}/redfish/v1/Systems/system
 "MemorySummary": {
    "Status": {
      "State": "Enabled"
    },
    "TotalSystemMemoryGiB": 0
  },

Redfish schema validator.
ComputerSystem.v1_0_0.MemorySummary:Status
    value: OrderedDict([('State', 'Enabled')]) <class 'collections.OrderedDict'>
    has Type: Resource.Status complex
    is Optional
    ***going into Complex
Resource.Status:State
    value: Enabled <class 'str'>
    has Type: Resource.State enum
    is Optional
    permission OData.Permission/Read
    Success

MemorySummary.TotalSystemMemoryGiB                          PASS
MemorySummary.Status                                 complex
MemorySummary.Status.State                              PASS

Change-Id: I272a2c6c53f39be3dafd62759be4cc65aa0dd74f
Signed-off-by: Alpana Kumari <alpankum@in.ibm.com>

Conflicts:
	redfish-core/lib/systems.hpp