### PR TITLE
Fix "MemorySummary" status: Disabled on IBM systems

### DIFF
--- a/redfish-core/lib/systems.hpp
+++ b/redfish-core/lib/systems.hpp
@@ -28,6 +28,40 @@ namespace redfish
 {
 
 /**
+ * @brief Updates the Functional State of DIMMs
+ *
+ * @param[in] aResp Shared pointer for completing asynchronous calls
+ * @param[in] dimmState Dimm's Functional state, true/false
+ *
+ * @return None.
+ */
+void updateDimmProperties(std::shared_ptr<AsyncResp> aResp,
+                          const std::variant<bool> &dimmState)
+{
+    const bool *isDimmFunctional = std::get_if<bool>(&dimmState);
+    if (isDimmFunctional == nullptr)
+    {
+        messages::internalError(aResp->res);
+        return;
+    }
+    BMCWEB_LOG_DEBUG << "Dimm Functional:" << *isDimmFunctional;
+
+    // Set it as Enabled if atleast one DIMM is functional
+    // Update STATE only if previous State was DISABLED and current Dimm is
+    // ENABLED.
+    nlohmann::json &prevMemSummary =
+        aResp->res.jsonValue["MemorySummary"]["Status"]["State"];
+    if (prevMemSummary == "Disabled")
+    {
+        if (*isDimmFunctional == true)
+        {
+            aResp->res.jsonValue["MemorySummary"]["Status"]["State"] =
+                "Enabled";
+        }
+    }
+}
+
+/*
  * @brief Retrieves computer system properties over dbus
  *
  * @param[in] aResp Shared pointer for completing asynchronous calls
@@ -38,6 +72,7 @@ namespace redfish
 void getComputerSystem(std::shared_ptr<AsyncResp> aResp)
 {
     BMCWEB_LOG_DEBUG << "Get available system components.";
+
     crow::connections::systemBus->async_method_call(
         [aResp](
             const boost::system::error_code ec,
@@ -78,11 +113,14 @@ void getComputerSystem(std::shared_ptr<AsyncResp> aResp)
                         {
                             BMCWEB_LOG_DEBUG
                                 << "Found Dimm, now get its properties.";
+
                             crow::connections::systemBus->async_method_call(
-                                [aResp](const boost::system::error_code ec,
-                                        const std::vector<
-                                            std::pair<std::string, VariantType>>
-                                            &properties) {
+                                [aResp, service{connection.first},
+                                 path(std::move(path))](
+                                    const boost::system::error_code ec,
+                                    const std::vector<
+                                        std::pair<std::string, VariantType>>
+                                        &properties) {
                                     if (ec)
                                     {
                                         BMCWEB_LOG_ERROR
@@ -93,29 +131,64 @@ void getComputerSystem(std::shared_ptr<AsyncResp> aResp)
                                     BMCWEB_LOG_DEBUG << "Got "
                                                      << properties.size()
                                                      << "Dimm properties.";
-                                    for (const std::pair<std::string,
-                                                         VariantType>
-                                             &property : properties)
+
+                                    if (properties.size() > 0)
                                     {
-                                        if (property.first == "MemorySizeInKb")
+                                        for (const std::pair<std::string,
+                                                             VariantType>
+                                                 &property : properties)
                                         {
-                                            const uint64_t *value =
-                                                sdbusplus::message::variant_ns::
-                                                    get_if<uint64_t>(
-                                                        &property.second);
-                                            if (value != nullptr)
+                                            if (property.first ==
+                                                "MemorySizeInKb")
                                             {
-                                                aResp->res.jsonValue
-                                                    ["TotalSystemMemoryGi"
-                                                     "B"] +=
-                                                    *value / (1024 * 1024);
-                                                aResp->res
-                                                    .jsonValue["MemorySummary"]
-                                                              ["Status"]
-                                                              ["State"] =
-                                                    "Enabled";
+                                                const uint64_t *value =
+                                                    sdbusplus::message::
+                                                        variant_ns::get_if<
+                                                            uint64_t>(
+                                                            &property.second);
+                                                if (value != nullptr)
+                                                {
+                                                    aResp->res.jsonValue
+                                                        ["TotalSystemMemoryGi"
+                                                         "B"] +=
+                                                        *value / (1024 * 1024);
+                                                    aResp->res.jsonValue
+                                                        ["MemorySummary"]
+                                                        ["Status"]["State"] =
+                                                        "Enabled";
+                                                }
                                             }
                                         }
+                                    }
+                                    else
+                                    {
+                                        auto getDimmProperties =
+                                            [aResp](
+                                                const boost::system::error_code
+                                                    ec,
+                                                const std::variant<bool>
+                                                    &dimmState) {
+                                                if (ec)
+                                                {
+                                                    BMCWEB_LOG_ERROR
+                                                        << "DBUS response "
+                                                           "error "
+                                                        << ec;
+                                                    return;
+                                                }
+                                                updateDimmProperties(aResp,
+                                                                     dimmState);
+                                            };
+                                        crow::connections::systemBus
+                                            ->async_method_call(
+                                                std::move(getDimmProperties),
+                                                service, path,
+                                                "org.freedesktop.DBus."
+                                                "Properties",
+                                                "Get",
+                                                "xyz.openbmc_project.State."
+                                                "Decorator.OperationalStatus",
+                                                "Functional");
                                     }
                                 },
                                 connection.first, path,


### PR DESCRIPTION
"MemorySummary" Status is always Disabled.Fixed it.

Doing GET on Interface xyz.openbmc_project.State.Decorator.OperationalStatus
instead of xyz.openbmc_project.Inventory.Item.Dimm to get the State of Dimm

Tested:
-- Ran GET request on the ComputerSystem node when Host is Up
 curl -k -H "X-Auth-Token: $bmc_token" -X GET https://${bmc}/redfish/v1/Systems/system
 "MemorySummary": {
    "Status": {
      "State": "Enabled"
    },
    "TotalSystemMemoryGiB": 0
  },

Redfish schema validator.
ComputerSystem.v1_0_0.MemorySummary:Status
    value: OrderedDict([('State', 'Enabled')]) <class 'collections.OrderedDict'>
    has Type: Resource.Status complex
    is Optional
    ***going into Complex
Resource.Status:State
    value: Enabled <class 'str'>
    has Type: Resource.State enum
    is Optional
    permission OData.Permission/Read
    Success

MemorySummary.TotalSystemMemoryGiB                          PASS
MemorySummary.Status                                 complex
MemorySummary.Status.State                              PASS

Change-Id: I272a2c6c53f39be3dafd62759be4cc65aa0dd74f
Signed-off-by: Alpana Kumari <alpankum@in.ibm.com>