### PR TITLE
openbmc_dbus_rest: Add numeric_limits range check

### DIFF
--- a/include/openbmc_dbus_rest.hpp
+++ b/include/openbmc_dbus_rest.hpp
@@ -576,6 +576,11 @@ int convertJsonToDbus(sd_bus_message *m, const std::string &arg_type,
             {
                 return -1;
             }
+            if ((*intValue < std::numeric_limits<int32_t>::lowest()) ||
+                (*intValue > std::numeric_limits<int32_t>::max()))
+            {
+                return -ERANGE;
+            }
             int32_t i = static_cast<int32_t>(*intValue);
             r = sd_bus_message_append_basic(m, argCode[0], &i);
             if (r < 0)
@@ -589,7 +594,18 @@ int convertJsonToDbus(sd_bus_message *m, const std::string &arg_type,
             int boolInt = false;
             if (intValue != nullptr)
             {
-                boolInt = *intValue > 0 ? 1 : 0;
+                if (*intValue == 1)
+                {
+                    boolInt = true;
+                }
+                else if (*intValue == 0)
+                {
+                    boolInt = false;
+                }
+                else
+                {
+                    return -ERANGE;
+                }
             }
             else if (b != nullptr)
             {
@@ -615,6 +631,11 @@ int convertJsonToDbus(sd_bus_message *m, const std::string &arg_type,
             {
                 return -1;
             }
+            if ((*intValue < std::numeric_limits<int16_t>::lowest()) ||
+                (*intValue > std::numeric_limits<int16_t>::max()))
+            {
+                return -ERANGE;
+            }
             int16_t n = static_cast<int16_t>(*intValue);
             r = sd_bus_message_append_basic(m, argCode[0], &n);
             if (r < 0)
@@ -628,6 +649,11 @@ int convertJsonToDbus(sd_bus_message *m, const std::string &arg_type,
             {
                 return -1;
             }
+            if ((*intValue < std::numeric_limits<int64_t>::lowest()) ||
+                (*intValue > std::numeric_limits<int64_t>::max()))
+            {
+                return -ERANGE;
+            }
             r = sd_bus_message_append_basic(m, argCode[0], intValue);
             if (r < 0)
             {
@@ -640,6 +666,11 @@ int convertJsonToDbus(sd_bus_message *m, const std::string &arg_type,
             {
                 return -1;
             }
+            if ((*uintValue < std::numeric_limits<uint8_t>::lowest()) ||
+                (*uintValue > std::numeric_limits<uint8_t>::max()))
+            {
+                return -ERANGE;
+            }
             uint8_t y = static_cast<uint8_t>(*uintValue);
             r = sd_bus_message_append_basic(m, argCode[0], &y);
         }
@@ -648,6 +679,11 @@ int convertJsonToDbus(sd_bus_message *m, const std::string &arg_type,
             if (uintValue == nullptr)
             {
                 return -1;
+            }
+            if ((*uintValue < std::numeric_limits<uint16_t>::lowest()) ||
+                (*uintValue > std::numeric_limits<uint16_t>::max()))
+            {
+                return -ERANGE;
             }
             uint16_t q = static_cast<uint16_t>(*uintValue);
             r = sd_bus_message_append_basic(m, argCode[0], &q);
@@ -658,6 +694,11 @@ int convertJsonToDbus(sd_bus_message *m, const std::string &arg_type,
             {
                 return -1;
             }
+            if ((*uintValue < std::numeric_limits<uint32_t>::lowest()) ||
+                (*uintValue > std::numeric_limits<uint32_t>::max()))
+            {
+                return -ERANGE;
+            }
             uint32_t u = static_cast<uint32_t>(*uintValue);
             r = sd_bus_message_append_basic(m, argCode[0], &u);
         }
@@ -667,10 +708,24 @@ int convertJsonToDbus(sd_bus_message *m, const std::string &arg_type,
             {
                 return -1;
             }
+            if ((*uintValue < std::numeric_limits<uint64_t>::lowest()) ||
+                (*uintValue > std::numeric_limits<uint64_t>::max()))
+            {
+                return -ERANGE;
+            }
             r = sd_bus_message_append_basic(m, argCode[0], uintValue);
         }
         else if (argCode == "d")
         {
+            if (doubleValue == nullptr)
+            {
+                return -1;
+            }
+            if ((*doubleValue < std::numeric_limits<double>::lowest()) ||
+                (*doubleValue > std::numeric_limits<double>::max()))
+            {
+                return -ERANGE;
+            }
             sd_bus_message_append_basic(m, argCode[0], doubleValue);
         }
         else if (boost::starts_with(argCode, "a"))
@@ -1856,8 +1911,18 @@ void handlePut(const crow::Request &req, crow::Response &res,
                                             transaction->propertyValue);
                                         if (r < 0)
                                         {
-                                            transaction->setErrorStatus(
-                                                "Invalid arg type");
+                                            if (r == -ERANGE)
+                                            {
+                                                transaction->setErrorStatus(
+                                                    "Provided property value "
+                                                    "is out of range for the "
+                                                    "property type");
+                                            }
+                                            else
+                                            {
+                                                transaction->setErrorStatus(
+                                                    "Invalid arg type");
+                                            }
                                             return;
                                         }
                                         r = sd_bus_message_close_container(


### PR DESCRIPTION
Add a range check for numerical values so that they are not truncated.

Tested:
   <type>:<interface>:<property>

 - bool: RebootPolicy: AutoReboot
   Valid: 0, 1
   Invalid: null, -1, 2

 - int64_t: Ambient Temp Sensor: WarningHigh
   Valid: -9223372036854775808, -1, 2500, 9223372036854775807
   Invalid: null, -9223372036854775809

 - uint8_t: Software: Priority
   Valid: 0, 1, 255
   Invalid: null, -1, 256

 - uint16_t: LED Physical: Period
   Valid: 0, 1000, 65535
   Invalid: null, -1, 65536

 - uint32_t: State PowerOnHours: POHCounter
   Valid: 0, 20, 4294967295
   Invalid: -1, 4294967296

 - uint64_t: State BMC: LastRebootTime
   Valid: 0, 1566402464000, 18446744073709551615
   Invalid: -1, 18446744073709551616

Closes: openbmc/bmcweb#101

Change-Id: I652333b0042b28ffb0a47b478d1a0a6e7ec994a7
Signed-off-by: Adriana Kobylak <anoo@us.ibm.com>