### PR TITLE
SW472505: Improve the security headers

### DIFF
--- a/include/security_headers_middleware.hpp
+++ b/include/security_headers_middleware.hpp
@@ -37,19 +37,23 @@ struct SecurityHeadersMiddleware
         res.addHeader(bf::pragma, "no-cache");
         res.addHeader(bf::cache_control, "no-Store,no-Cache");
 
-        // The KVM currently needs to load images from base64 encoded strings.
-        // img-src 'self' data: is used to allow that.
+        res.addHeader("Content-Security-Policy", "default-src 'none'; "
+                                                 "img-src 'self' data:; "
+                                                 "font-src 'self'; "
+                                                 "style-src 'self'; "
+                                                 "script-src 'self'; "
+                                                 "connect-src 'self' wss:");
+        // The KVM currently needs to load images from base64 encoded
+        // strings. img-src 'self' data: is used to allow that.
         // https://stackoverflow.com/questions/18447970/content-security-policy-data-not-working-for-base64-images-in-chrome-28
-        res.addHeader("Content-Security-Policy",
-                      "default-src 'self'; img-src 'self' data:");
+
         res.addHeader("X-XSS-Protection", "1; "
                                           "mode=block");
         res.addHeader("X-Content-Type-Options", "nosniff");
-        res.addHeader("X-UA-Compatible", "IE=11");
 
 #ifdef BMCWEB_INSECURE_DISABLE_XSS_PREVENTION
-
-        res.addHeader(bf::access_control_allow_origin, "http://localhost:8080");
+        res.addHeader(bf::access_control_allow_origin,
+                      req.getHeaderValue("Origin"));
         res.addHeader(bf::access_control_allow_methods, "GET, "
                                                         "POST, "
                                                         "PUT, "


### PR DESCRIPTION
This is needed for websockets to work in Safari. (SW472505)
How Safari does Content-Security-Policy is different from other browsers,
This commit was merged here:
https://gerrit.openbmc-project.xyz/c/openbmc/bmcweb/+/24610

This patchset consists of two primary changes.

1. Content-Security-Policy is adjusted such that the "default" allowed
source is none, then we explicitly enable the few features we actually
use by setting them to self
2. Updates the XSS variables to simply forward back the hostname given
in the AccessControlAllowOrigin flag, which means that webpack dev
server could be running on any port.

Tested:
Tested IE11, Edge, Firefox, and Chrome for CSP errors.  Firefox flags
one error that doesn't seem to effect the webui.  All other browsers
load without issue.

Tested launching webpack-dev-server with XSS settings enabled.
Launches without warning on any port

Signed-off-by: Ed Tanous <ed.tanous@intel.com>
Change-Id: Id38f607917d19b0106c4c7708c764c45b646891e