### PR TITLE
Redfish(Network): IPV4 DHCP ipaddreses dont show gateway when in DHCP…

### DIFF
--- a/redfish-core/lib/ethernet.hpp
+++ b/redfish-core/lib/ethernet.hpp
@@ -855,8 +855,9 @@ void getEthernetIfaceData(const std::string &ethiface_id,
             // Fix global GW
             for (IPv4AddressData &ipv4 : ipv4Data)
             {
-                if ((ipv4.linktype == LinkType::Global) &&
-                    (ipv4.gateway == "0.0.0.0"))
+                if (((ipv4.linktype == LinkType::Global) &&
+                     (ipv4.gateway == "0.0.0.0")) ||
+                    (ipv4.origin == "DHCP"))
                 {
                     ipv4.gateway = ethData.default_gateway;
                 }


### PR DESCRIPTION
… mode

Tested by:
configuring DHCP,
GET https://${BMC_IP}/redfish/v1/Managers/bmc/EthernetInterfaces/eth0

Signed-off-by: Ravi Teja <raviteja28031990@gmail.com>
Change-Id: Ic7067db41fbb8327ef55cc7552f9153d1ecfb63a