### PR TITLE
SW474799: Fix remove callback user privilege access to login

### DIFF
--- a/redfish-core/include/privileges.hpp
+++ b/redfish-core/include/privileges.hpp
@@ -192,11 +192,17 @@ inline const Privileges& getUserPrivileges(const std::string& userRole)
         static Privileges op{"Login", "ConfigureSelf", "ConfigureComponents"};
         return op;
     }
-    else
+    else if (userRole == "priv-user")
     {
         // Redfish privilege : Readonly
         static Privileges readOnly{"Login", "ConfigureSelf"};
         return readOnly;
+    }
+    else
+    {
+        // Redfish Privilege : No privileges for callback users
+        static Privileges noPriv{};
+        return noPriv;
     }
 }
 

--- a/redfish-core/lib/roles.hpp
+++ b/redfish-core/lib/roles.hpp
@@ -61,7 +61,7 @@ inline bool getAssignedPrivFromRole(std::string_view role,
     }
     else if (role == "Callback")
     {
-        privArray = {"Login"};
+        privArray = {};
     }
     else
     {


### PR DESCRIPTION
The callback is an IPMI only role which should not be able to login
to Redfish/GUI. This follows the new GUI user management page
role table.

Fixes defect: 
SW474799, GUI Callback user has all user privileges but should
have only IPMI access as per GUI.

Upstream was merged here:
https://gerrit.openbmc-project.xyz/c/openbmc/bmcweb/+/24712/4

Callback privilege user must not be allowed to login,similar to IPMI.
This user is used for callback purpose from IPMI point of it, and
must be maintained in bmcweb to be consistent with IPMI, Hence
removing the access to login for callback user

Tested:
1.Create a user with username 'test1' and privilege -
  "Callback" via Redfish.
2.Using that Callback level credentials, try to do
  "Get" at this URI https://<ip-addr>/redfish/v1/Systems/system
3.output: Forbidden
4.use same URL to login from webUI with callback privilege
  https://<ip-addr>/redfish/v1/Systems/system
5.output: Forbidden
Signed-off-by: anil kumar appana <anil.kumarx.appana@intel.com>
Change-Id: I86dac565fc874e5d0fe033640ffc3de576a1f693