### PR TITLE
Redfish: ApplyTime property GET and PATCH support (SW471786)

### DIFF
--- a/redfish-core/lib/update_service.hpp
+++ b/redfish-core/lib/update_service.hpp
@@ -339,7 +339,8 @@ class UpdateService : public Node
     void doGet(crow::Response &res, const crow::Request &req,
                const std::vector<std::string> &params) override
     {
-        res.jsonValue["@odata.type"] = "#UpdateService.v1_2_0.UpdateService";
+        std::shared_ptr<AsyncResp> aResp = std::make_shared<AsyncResp>(res);
+        res.jsonValue["@odata.type"] = "#UpdateService.v1_4_0.UpdateService";
         res.jsonValue["@odata.id"] = "/redfish/v1/UpdateService";
         res.jsonValue["@odata.context"] =
             "/redfish/v1/$metadata#UpdateService.UpdateService";
@@ -360,7 +361,42 @@ class UpdateService : public Node
         updateSvcSimpleUpdate["TransferProtocol@Redfish.AllowableValues"] = {
             "TFTP"};
 #endif
-        res.end();
+        // Get the current ApplyTime value
+        crow::connections::systemBus->async_method_call(
+            [aResp](const boost::system::error_code ec,
+                    const std::variant<std::string> &applyTime) {
+                if (ec)
+                {
+                    BMCWEB_LOG_DEBUG << "DBUS response error " << ec;
+                    messages::internalError(aResp->res);
+                    return;
+                }
+
+                const std::string *s = std::get_if<std::string>(&applyTime);
+                if (s == nullptr)
+                {
+                    return;
+                }
+                // Store the ApplyTime Value
+                if (*s == "xyz.openbmc_project.Software.ApplyTime."
+                          "RequestedApplyTimes.Immediate")
+                {
+                    aResp->res.jsonValue["HttpPushUriOptions"]
+                                        ["HttpPushUriApplyTime"]["ApplyTime"] =
+                        "Immediate";
+                }
+                else if (*s == "xyz.openbmc_project.Software.ApplyTime."
+                               "RequestedApplyTimes.OnReset")
+                {
+                    aResp->res.jsonValue["HttpPushUriOptions"]
+                                        ["HttpPushUriApplyTime"]["ApplyTime"] =
+                        "OnReset";
+                }
+            },
+            "xyz.openbmc_project.Settings",
+            "/xyz/openbmc_project/software/apply_time",
+            "org.freedesktop.DBus.Properties", "Get",
+            "xyz.openbmc_project.Software.ApplyTime", "RequestedApplyTime");
     }
 
     void doPatch(crow::Response &res, const crow::Request &req,
@@ -369,43 +405,44 @@ class UpdateService : public Node
         BMCWEB_LOG_DEBUG << "doPatch...";
 
         std::shared_ptr<AsyncResp> asyncResp = std::make_shared<AsyncResp>(res);
-        std::string applyTime;
 
-        if (!json_util::readJson(req, res, "ApplyTime", applyTime))
+        std::optional<nlohmann::json> pushUriOptions;
+        if (!json_util::readJson(req, res, "HttpPushUriOptions",
+                                 pushUriOptions))
         {
             return;
         }
 
-        if ((applyTime == "Immediate") || (applyTime == "OnReset"))
+        std::optional<nlohmann::json> pushUriApplyTime;
+        if (pushUriOptions)
         {
-            std::string applyTimeNewVal;
-            if (applyTime == "Immediate")
+            if (!json_util::readJson(*pushUriOptions, res,
+                                     "HttpPushUriApplyTime", pushUriApplyTime))
             {
-                applyTimeNewVal = "xyz.openbmc_project.Software.ApplyTime."
-                                  "RequestedApplyTimes.Immediate";
+                return;
             }
-            else
-            {
-                applyTimeNewVal = "xyz.openbmc_project.Software.ApplyTime."
-                                  "RequestedApplyTimes.OnReset";
-            }
+        }
 
-            // Set the requested image apply time value
-            crow::connections::systemBus->async_method_call(
-                [asyncResp](const boost::system::error_code ec) {
-                    if (ec)
-                    {
-                        BMCWEB_LOG_ERROR << "D-Bus responses error: " << ec;
-                        messages::internalError(asyncResp->res);
-                        return;
-                    }
-                    messages::success(asyncResp->res);
-                },
-                "xyz.openbmc_project.Settings",
-                "/xyz/openbmc_project/software/apply_time",
-                "org.freedesktop.DBus.Properties", "Set",
-                "xyz.openbmc_project.Software.ApplyTime", "RequestedApplyTime",
-                std::variant<std::string>{applyTimeNewVal});
+        std::string applyTime;
+        if (pushUriApplyTime)
+        {
+            if (!json_util::readJson(*pushUriApplyTime, res, "ApplyTime",
+                                     applyTime))
+            {
+                return;
+            }
+        }
+
+        std::string applyTimeNewVal;
+        if (applyTime == "Immediate")
+        {
+            applyTimeNewVal = "xyz.openbmc_project.Software.ApplyTime."
+                              "RequestedApplyTimes.Immediate";
+        }
+        else if (applyTime == "OnReset")
+        {
+            applyTimeNewVal = "xyz.openbmc_project.Software.ApplyTime."
+                              "RequestedApplyTimes.OnReset";
         }
         else
         {
@@ -413,7 +450,25 @@ class UpdateService : public Node
                                "acceptable values";
             messages::propertyValueNotInList(asyncResp->res, applyTime,
                                              "ApplyTime");
+            return;
         }
+
+        // Set the requested image apply time value
+        crow::connections::systemBus->async_method_call(
+            [asyncResp](const boost::system::error_code ec) {
+                if (ec)
+                {
+                    BMCWEB_LOG_ERROR << "D-Bus responses error: " << ec;
+                    messages::internalError(asyncResp->res);
+                    return;
+                }
+                messages::success(asyncResp->res);
+            },
+            "xyz.openbmc_project.Settings",
+            "/xyz/openbmc_project/software/apply_time",
+            "org.freedesktop.DBus.Properties", "Set",
+            "xyz.openbmc_project.Software.ApplyTime", "RequestedApplyTime",
+            std::variant<std::string>{applyTimeNewVal});
     }
 
     void doPost(crow::Response &res, const crow::Request &req,


### PR DESCRIPTION
This change is to GET and PATCH the ApplyTime property using the
UpdateServce redfish schema. GET request can be used to check the value
before initiating the BMC image upload and activation. PATCH request
can be used to update the ApplyTime value.

If the ApplyTime value is Immediate, force-reboot.service gets called
which reboots the BMC. If the ApplyTime value is OnReset, no force reboot
will be triggered and the new BMC image will be functional till the user
decideds to reboot the BMC manually.

Tested:
Changes passed the Redfish-Service-Validator test.

Success Scenarios:
1. If the value of ApplyTime is Immediate (GET request)
GET https://$bmc/redfish/v1/UpdateService
{
  "@odata.context": "/redfish/v1/$metadata#UpdateService.UpdateService",
  "@odata.id": "/redfish/v1/UpdateService",
  "@odata.type": "#UpdateService.v1_2_0.UpdateService",
  "ApplyTime": "Immediate",
  "Description": "Service for Software Update",
  "FirmwareInventory": {
    "@odata.id": "/redfish/v1/UpdateService/FirmwareInventory"
  },
  "HttpPushUri": "/redfish/v1/UpdateService",
  "Id": "UpdateService",
  "Name": "Update Service",
  "ServiceEnabled": true
}

2. PATCH request to change value to OnReset:

PATCH -d '{ "HttpPushUriOptions": { "HttpPushUriApplyTime":
{ "ApplyTime""OnReset"}}}' https://${bmc}/redfish/v1/UpdateService
{
  "@Message.ExtendedInfo": [
    {
      "@odata.type": "/redfish/v1/$metadata#Message.v1_0_0.Message",
      "Message": "Successfully Completed Request",
      "MessageArgs": [],
      "MessageId": "Base.1.4.0.Success",
      "Resolution": "None",
      "Severity": "OK"
    }
  ]
}

Error Scenarios:
1. Test by giving wrong HttpPushUriOptions name
[Given as "HttpPushUriOptions1"]

PATCH -d '{ "HttpPushUriOptions1": { "HttpPushUriApplyTime":
{ "ApplyTime":"Immediate"}}}' https://${bmc}/redfish/v1/UpdateService
{
  "HttpPushUriOptions1@Message.ExtendedInfo": [
    {
      "@odata.type": "/redfish/v1/$metadata#Message.v1_0_0.Message",
      "Message": "The property HttpPushUriOptions1 is not in the list of valid properties for the resource.",
      "MessageArgs": [
        "HttpPushUriOptions1"
      ],
      "MessageId": "Base.1.4.0.PropertyUnknown",
      "Resolution": "Remove the unknown property from the request body and resubmit the request if the operation failed.",
      "Severity": "Warning"
    }
  ]
}

2. Test by giving wrong HttpPushUriApplyTime name
[Given as "HttpPushUriApplyTime1"]

PATCH -d '{ "HttpPushUriOptions": { "HttpPushUriApplyTime1":
{ "ApplyTime:"Immediate"}}}' https://${bmc}/redfish/v1/UpdateService
{
  "HttpPushUriApplyTime1@Message.ExtendedInfo": [
    {
      "@odata.type": "/redfish/v1/$metadata#Message.v1_0_0.Message",
      "Message": "The property HttpPushUriApplyTime1 is not in the list of valid properties for the resource.",
      "MessageArgs": [
        "HttpPushUriApplyTime1"
      ],
      "MessageId": "Base.1.4.0.PropertyUnknown",
      "Resolution": "Remove the unknown property from the request body and resubmit the request if the operation failed.",
      "Severity": "Warning"
    }
  ]
}

3. Test by giving wrong ApplyTime name [Given as "ApplyTime1"]
PATCH -d '{ "HttpPushUriOptions": { "HttpPushUriApplyTime":
{ "ApplyTime1":"Immediate"}}}' https://${bmc}/redfish/v1/UpdateService
{
  "ApplyTime1@Message.ExtendedInfo": [
    {
      "@odata.type": "/redfish/v1/$metadata#Message.v1_0_0.Message",
      "Message": "The property ApplyTime1 is not in the list of valid properties for the resource.",
      "MessageArgs": [
        "ApplyTime1"
      ],
      "MessageId": "Base.1.4.0.PropertyUnknown",
      "Resolution": "Remove the unknown property from the request body and resubmit the request if the operation failed.",
      "Severity": "Warning"
    }
  ],
  "ApplyTime@Message.ExtendedInfo": [
    {
      "@odata.type": "/redfish/v1/$metadata#Message.v1_0_0.Message",
      "Message": "The property ApplyTime is a required property and must be included in the request.",
      "MessageArgs": [
        "ApplyTime"
      ],
      "MessageId": "Base.1.4.0.PropertyMissing",
      "Resolution": "Ensure that the property is in the request body and has a valid value and resubmit the request if the operation failed.",
      "Severity": "Warning"
    }
  ]
}

4. Giving wrong ApplyTime value ["Immediat" instead of "Immediate"]
PATCH -d '{ "HttpPushUriOptions": { "HttpPushUriApplyTime":
{ "ApplyTime":"Immediat"}}}' https://${bmc}/redfish/v1/UpdateService
{
  "ApplyTime@Message.ExtendedInfo": [
    {
      "@odata.type": "/redfish/v1/$metadata#Message.v1_0_0.Message",
      "Message": "The value Immediat for the property ApplyTime is not in the list of acceptable values.",
      "MessageArgs": [
        "Immediat",
        "ApplyTime"
      ],
      "MessageId": "Base.1.4.0.PropertyValueNotInList",
      "Resolution": "Choose a value from the enumeration list that the implementation can support and resubmit the request if the operation failed.",
      "Severity": "Warning"
    }
  ]
}

5. NULL value given for "HttpPushUriOptions"
PATCH -d '{ "HttpPushUriOptions": ""}' https://${bmc}/redfish/v1/UpdateSrvice
{
  "HttpPushUriOptions@Message.ExtendedInfo": [
    {
      "@odata.type": "/redfish/v1/$metadata#Message.v1_0_0.Message",
      "Message": "The value \"\" for the property HttpPushUriOptions is of a different type than the property can accept.",
      "MessageArgs": [
        "\"\"",
        "HttpPushUriOptions"
      ],
      "MessageId": "Base.1.4.0.PropertyValueTypeError",
      "Resolution": "Correct the value for the property in the request body and resubmit the request if the operation failed.",
      "Severity": "Warning"
    }
  ]
}

6. NULL value given for "HttpPushUriApplyTime"
PATCH -d '{ "HttpPushUriOptions": { "HttpPushUriApplyTime":""}}' https:/${bmc}/redfish/v1/UpdateService
{
  "HttpPushUriApplyTime@Message.ExtendedInfo": [
    {
      "@odata.type": "/redfish/v1/$metadata#Message.v1_0_0.Message",
      "Message": "The value \"\" for the property HttpPushUriApplyTime is of a different type than the property can accept.",
      "MessageArgs": [
        "\"\"",
        "HttpPushUriApplyTime"
      ],
      "MessageId": "Base.1.4.0.PropertyValueTypeError",
      "Resolution": "Correct the value for the property in the request body and resubmit the request if the operation failed.",
      "Severity": "Warning"
    }
  ]
}

7. NULL value given for "HttpPushUriApplyTime"
PATCH -d '{ "HttpPushUriOptions": { "HttpPushUriApplyTime":{ "ApplyTime":""}}}' https://${bmc}/redfish/v1/UpdateService
{
  "ApplyTime@Message.ExtendedInfo": [
    {
      "@odata.type": "/redfish/v1/$metadata#Message.v1_0_0.Message",
      "Message": "The value  for the property ApplyTime is not in the list of acceptable values.",
      "MessageArgs": [
        "",
        "ApplyTime"
      ],
      "MessageId": "Base.1.4.0.PropertyValueNotInList",
      "Resolution": "Choose a value from the enumeration list that the implementation can support and resubmit the request if the operation failed.",
      "Severity": "Warning"
    }
  ]
}

Signed-off-by: Jayashankar Padath <jayashankar.padath@in.ibm.com>
Change-Id: I336cfd0eb5b80d40d9b88b3e4fc6e216a003c0c9