### PR TITLE
SW476583: Revert "Fix remove callback user privilege access to login"

### DIFF
--- a/redfish-core/include/privileges.hpp
+++ b/redfish-core/include/privileges.hpp
@@ -192,17 +192,11 @@ inline const Privileges& getUserPrivileges(const std::string& userRole)
         static Privileges op{"Login", "ConfigureSelf", "ConfigureComponents"};
         return op;
     }
-    else if (userRole == "priv-user")
+    else
     {
         // Redfish privilege : Readonly
         static Privileges readOnly{"Login", "ConfigureSelf"};
         return readOnly;
-    }
-    else
-    {
-        // Redfish Privilege : No privileges for callback users
-        static Privileges noPriv{};
-        return noPriv;
     }
 }
 

--- a/redfish-core/lib/roles.hpp
+++ b/redfish-core/lib/roles.hpp
@@ -61,7 +61,7 @@ inline bool getAssignedPrivFromRole(std::string_view role,
     }
     else if (role == "Callback")
     {
-        privArray = {};
+        privArray = {"Login"};
     }
     else
     {


### PR DESCRIPTION
This commit, the revert, was merged into master here:
https://gerrit.openbmc-project.xyz/c/openbmc/bmcweb/+/25319

Even though this change did remove permissions for the callback user to "GET" Redfish and /xyz resources it failed to prevent the callback user from using SOL console, KVM and attach virtual media devices. This change also introduced a Redfish Validator error.

Instead of this change, the callback role will be shown as a Read-only role with ssh, IPMI, WebUI, and Redfish access in the GUI User Management table and in documentation for OP940. This is more consistent.

This will close SW476583. Have reopened SW474799.
SW474799 will be deffered until a later release.

Original commit:
This reverts commit 8e69d148249f6a45cea10e988ec03430a5932784.

Reason for revert: This causes service validator failures.

I missed the fact that despite being asked a couple times, the service validator wasn't run.  Please run it, resolve your bug, and resubmit as a new review.

Change-Id: I0bb61ab1a618a96b2ed2c600825ec72b8d020ec0