### PR TITLE
Change to reset the password

### DIFF
--- a/include/openbmc_dbus_rest.hpp
+++ b/include/openbmc_dbus_rest.hpp
@@ -2125,6 +2125,48 @@ template <typename... Middlewares> void requestRoutes(Crow<Middlewares...> &app)
                 handleDBusUrl(req, res, objectPath);
             });
 
+    BMCWEB_ROUTE(app, "/xyz/openbmc_project/user/root/action/SetPassword")
+        .requires({"ConfigureComponents", "ConfigureManager"})
+        .methods(
+            "PATCH"_method)([](const crow::Request &req, crow::Response &res) {
+            nlohmann::json data = nlohmann::json::parse(std::move(req.body));
+            const std::string *pwd;
+            for (const auto &item : data.items())
+            {
+                if (item.key() == "Password")
+                {
+                    pwd = item.value().get_ptr<const std::string *>();
+                }
+            }
+
+            if (!pwd || pwd->empty())
+            {
+                BMCWEB_LOG_ERROR << "Password Empty!";
+                res.jsonValue = {{"message", "400 Bad Request"},
+                                 {"status", "Error"},
+                                 {"data", "Password Not Updated"}};
+                res.end();
+                return;
+            }
+
+            if (!pamUpdatePassword("root", *pwd))
+            {
+                BMCWEB_LOG_ERROR << "pamUpdatePassword Failed";
+                res.jsonValue = {{"message", "500 Internal Server Error"},
+                                 {"status", "Error"},
+                                 {"data", "Password Not Updated"}};
+                res.end();
+                return;
+            }
+
+            BMCWEB_LOG_DEBUG << "pamUpdatePassword Successful";
+            res.jsonValue = {{"message", "204 Resource Updated Successfully"},
+                             {"status", "ok"},
+                             {"data", "Password Updated"}};
+            res.end();
+            return;
+        });
+
     BMCWEB_ROUTE(app, "/org/<path>")
         .requires({"Login"})
         .methods("GET"_method)([](const crow::Request &req, crow::Response &res,


### PR DESCRIPTION
The REST call in this commit is needed for backward compatibility.
In earlier webserver(phosphor-rest-server), this API was available,
but not implemented in bmcweb.

So, this commit implements this API in bmcweb that enables resetting
the root user password.

Tested By:

curl -k -H "X-Auth-Token: $bmc_token" -d '{"Password":"0penBmc123"}' -X PATCH https://${bmc}/xyz/openbmc_project/user/root/action/SetPassword

Signed-off-by: asmithakarun <asmitk01@in.ibm.com>
Change-Id: I149d2dd9446ade976e57d447060150b24fb09228