### PR TITLE
openbmc_dbus_rest: Support boolean value to set property of type byte

### DIFF
--- a/include/openbmc_dbus_rest.hpp
+++ b/include/openbmc_dbus_rest.hpp
@@ -662,16 +662,28 @@ int convertJsonToDbus(sd_bus_message *m, const std::string &arg_type,
         }
         else if (argCode == "y")
         {
+            uint8_t y = 0;
             if (uintValue == nullptr)
             {
-                return -1;
+                // Check if a boolean value was passed
+                if (b != nullptr)
+                {
+                    y = *b ? 1 : 0;
+                }
+                else
+                {
+                    return -1;
+                }
             }
-            if ((*uintValue < std::numeric_limits<uint8_t>::lowest()) ||
-                (*uintValue > std::numeric_limits<uint8_t>::max()))
+            else
             {
-                return -ERANGE;
+                if ((*uintValue < std::numeric_limits<uint8_t>::lowest()) ||
+                    (*uintValue > std::numeric_limits<uint8_t>::max()))
+                {
+                    return -ERANGE;
+                }
+                y = static_cast<uint8_t>(*uintValue);
             }
-            uint8_t y = static_cast<uint8_t>(*uintValue);
             r = sd_bus_message_append_basic(m, argCode[0], &y);
         }
         else if (argCode == "q")


### PR DESCRIPTION
Allow a value of true/false to be used to set a property value of type
byte. The boolean value will be translated to 1/0.

Tested:
$ curl -k -H "X-Auth-Token: $bmc_token" -X PUT -d '{"data":false}' https://$bmc/xyz/openbmc_project/software/8d622e87/attr/Priority
{
  "data": null,
  "message": "200 OK",
  "status": "ok"
}

Signed-off-by: Adriana Kobylak <anoo@us.ibm.com>
Change-Id: I82f2acfe63c6fb6cc6130fb4c63552d0a45945f4