### PR TITLE
Return invalid path in REST error response

### DIFF
--- a/include/openbmc_dbus_rest.hpp
+++ b/include/openbmc_dbus_rest.hpp
@@ -1522,9 +1522,9 @@ void handleAction(const crow::Request &req, crow::Response &res,
             if (ec || interfaceNames.size() <= 0)
             {
                 BMCWEB_LOG_ERROR << "Can't find object";
-                setErrorResponse(transaction->res,
-                                 boost::beast::http::status::not_found,
-                                 notFoundDesc, notFoundMsg);
+                setErrorResponse(
+                    transaction->res, boost::beast::http::status::not_found,
+                    notFoundDesc + ": " + transaction->path, notFoundMsg);
                 return;
             }
 


### PR DESCRIPTION
To be backwards compatible with OP910-OP930, need to return the invalid
path in the error message on REST api's. The xcat team relies on this
path to do post processing work.

Verified with xcat team that it is only the "path or object not found:"
error that requires this.

Tested:

Previous Response:
{
  "data": {
    "description": "org.freedesktop.DBus.Error.FileNotFound: path or object not found"
  },
  "message": "404 Not Found",
  "status": "error"
}

New Response:
{
  "data": {
    "description": "org.freedesktop.DBus.Error.FileNotFound: path or object not found: /xyz/openbmc_project/sensors/chassis/PowerSupplyRedundancy"
  },
  "message": "404 Not Found",
  "status": "error"
}

Signed-off-by: Andrew Geissler <geissonator@yahoo.com>