### PR TITLE
Allow deleteAll to delete all logs

### DIFF
--- a/include/openbmc_dbus_rest.hpp
+++ b/include/openbmc_dbus_rest.hpp
@@ -2024,6 +2024,18 @@ inline void handleDBusUrl(const crow::Request &req, crow::Response &res,
                 objectPath.substr((actionPosition + strlen(actionSeperator)),
                                   objectPath.length());
             objectPath = objectPath.substr(0, actionPosition);
+
+            // This is a hack to support backwards compatibility in XCAT for
+            // OP940. XCAT makes a call to delete all error logs as
+            // /xyz/openbmc_project/logging/action/deleteAll
+            // This worked before OP940 because the phosphor-rest-server was
+            // case insensitive for method names. bmcweb is case sensitive so
+            // requires DeleteAll.
+            if (postProperty.compare("deleteAll") == 0)
+            {
+                postProperty = "DeleteAll";
+            }
+
             handleAction(req, res, objectPath, postProperty);
             return;
         }


### PR DESCRIPTION
XCAT makes a call to delete all event logs as
/xyz/openbmc_project/logging/action/deleteAll
This worked before OP940 because the phosphor-rest-server was
case insensitive for method names. bmcweb is case sensitive so
requires "DeleteAll".

This is the least invasive and simplest way to make
this work I could think of.
Considered creating a new phosphor-dbus-interface and
implementing it in phosphor-logging but this gets complicated fast.
Also considered making all of these case insensitive.

Tested:
Other methods appeared to work, as did deleteAll.
Before:
curl -b cjar -k -H 'Content-Type: application/json' -X POST \
-d '{"data":[]}' https://$bm/xyz/openbmc_project/logging/action/deleteAll
{
  "data": {
    "description": "The specified method cannot be found"
  },
  "message": "404 Not Found",
  "status": "error"

With Fix:

curl -b cjar -k -H 'Content-Type: application/json' -X POST \
-d '{"data":[]}' https://$bmc/xyz/openbmc_project/logging/action/deleteAll
{
  "data": null,
  "message": "200 OK",
  "status": "ok"
}

And in the journal:
(2019-09-27 21:04:55) [INFO    ] Request:  0x18bb268 HTTP/1.1 POST /xyz/openbmc_project/logging/action/deleteAll
...
(2019-09-27 21:04:55) [DEBUG   ] handleAction on path: /xyz/openbmc_project/logging and method DeleteAll
...
(2019-09-27 21:04:55) [DEBUG   ] Found method named DeleteAll on interface xyz.openbmc_project.Collection.DeleteAll

Signed-off-by: Gunnar Mills <gmills@us.ibm.com>