### PR TITLE
In the previous pull request, the password was being displayed in the logs. This has the changes to fix it.

### DIFF
--- a/include/logging_middleware.hpp
+++ b/include/logging_middleware.hpp
@@ -124,6 +124,8 @@ class Middleware
             // requests that contain passwords.
             if ((req.url ==
                  "/xyz/openbmc_project/user/ldap/action/CreateConfig") ||
+                (req.url ==
+                 "/xyz/openbmc_project/user/root/action/SetPassword") ||
                 (boost::algorithm::starts_with(
                     req.url, "/redfish/v1/AccountService/")) ||
                 (req.method() == "POST"_method &&

--- a/include/openbmc_dbus_rest.hpp
+++ b/include/openbmc_dbus_rest.hpp
@@ -1478,6 +1478,31 @@ void findActionOnInterface(std::shared_ptr<InProgressActionData> transaction,
         "org.freedesktop.DBus.Introspectable", "Introspect");
 }
 
+void handleActionSetPassword(std::shared_ptr<InProgressActionData> transaction)
+{
+    nlohmann::json::const_iterator setPasswdIt = transaction->arguments.begin();
+    std::string pwd = std::move(*setPasswdIt);
+
+    if (pwd.empty())
+    {
+        BMCWEB_LOG_ERROR << "Password Empty";
+        transaction->setErrorStatus("Password Empty");
+        transaction->outputFailed = true;
+        return;
+    }
+
+    if (!pamUpdatePassword("root", pwd))
+    {
+        BMCWEB_LOG_ERROR << "pamUpdatePassword Failed";
+        transaction->setErrorStatus("Password Not Modified");
+        transaction->outputFailed = true;
+        return;
+    }
+
+    BMCWEB_LOG_DEBUG << "pamUpdatePassword Successful";
+    return;
+}
+
 void handleAction(const crow::Request &req, crow::Response &res,
                   const std::string &objectPath, const std::string &methodName)
 {
@@ -1514,6 +1539,17 @@ void handleAction(const crow::Request &req, crow::Response &res,
     transaction->path = objectPath;
     transaction->methodName = methodName;
     transaction->arguments = std::move(*data);
+
+    // Special handling of Set Password as the password
+    // interface is not availble now.
+    if (methodName == "SetPassword")
+    {
+        transaction->methodPassed = true; // we know that password interface is
+                                          // not there so making it true
+        handleActionSetPassword(std::move(transaction));
+        return;
+    }
+
     crow::connections::systemBus->async_method_call(
         [transaction](
             const boost::system::error_code ec,


### PR DESCRIPTION
(DO NOT MERGE)
Change to reset the password

The REST call in this commit is needed for backward compatibility.
In earlier webserver(phosphor-rest-server), this API was available,
but not implemented in bmcweb.

So, this commit implements this API in bmcweb that enables resetting
the root user password.

Tested By:

curl -k -H "X-Auth-Token: $bmc_token" -d '{"data":["0penBmc123"]}'
-X POST https://${bmc}/xyz/openbmc_project/user/root/action/SetPassword

Signed-off-by: asmithakarun <asmitk01@in.ibm.com>
Change-Id: I149d2dd9446ade976e57d447060150b24fb09228