### PR TITLE
Fix crash during GET of manager network protocol

### DIFF
--- a/include/persistent_data_middleware.hpp
+++ b/include/persistent_data_middleware.hpp
@@ -8,6 +8,7 @@
 #include <boost/uuid/uuid.hpp>
 #include <boost/uuid/uuid_generators.hpp>
 #include <boost/uuid/uuid_io.hpp>
+#include <filesystem>
 #include <nlohmann/json.hpp>
 #include <pam_authenticate.hpp>
 #include <random>
@@ -20,13 +21,16 @@ namespace crow
 namespace persistent_data
 {
 
+namespace fs = std::filesystem;
+
 class Middleware
 {
-    // todo(ed) should read this from a fixed location somewhere, not CWD
-    static constexpr const char* filename = "bmcweb_persistent_data.json";
     int jsonRevision = 1;
 
   public:
+    // todo(ed) should read this from a fixed location somewhere, not CWD
+    static constexpr const char* filename = "bmcweb_persistent_data.json";
+
     struct Context
     {
     };
@@ -151,6 +155,12 @@ class Middleware
     void writeData()
     {
         std::ofstream persistentFile(filename);
+
+        // set the permission of the file to 640
+        fs::perms permission = fs::perms::owner_read | fs::perms::owner_write |
+                               fs::perms::group_read;
+        fs::permissions(filename, permission);
+
         nlohmann::json data{
             {"sessions", SessionStore::getInstance().authTokens},
             {"system_uuid", systemUuid},

--- a/redfish-core/lib/network_protocol.hpp
+++ b/redfish-core/lib/network_protocol.hpp
@@ -243,11 +243,12 @@ class NetworkProtocol : public Node
             asyncResp->res.jsonValue["NTP"]["NTPServers"] = ntpServers;
             if (hostName.empty() == false)
             {
-                asyncResp->res.jsonValue["FQDN"] = hostName;
+                std::string FQDN = std::move(hostName);
                 if (domainNames.empty() == false)
                 {
-                    asyncResp->res.jsonValue["FQDN"] += "." + domainNames[0];
+                    FQDN += "." + domainNames[0];
                 }
+                asyncResp->res.jsonValue["FQDN"] = std::move(FQDN);
             }
         });
 


### PR DESCRIPTION
If the ethernet interface is having the domain
name entry then Redfish GET request on network
manager protocol was crashing the bmcweb.

This commit fixes this behaviour.

Tested By:
Configure the Domain Name and run the GET request
on the network protocol: PASS

GET request on the network protocol even the
domain name was not configured : PASS

Redfish Validator: PASS

Signed-off-by: Ratan Gupta <ratagupt@linux.vnet.ibm.com>
Change-Id: I1e6cd6e3fe507ff375463ece1f6f10bae4d4fb6a