### PR TITLE
Redfish:Add GET and PATCH support for DHCP FallbackAddress

### DIFF
--- a/redfish-core/lib/ethernet.hpp
+++ b/redfish-core/lib/ethernet.hpp
@@ -94,6 +94,7 @@ struct EthernetInterfaceData
     uint32_t speed;
     bool auto_neg;
     bool DHCPEnabled;
+    std::string linkLocal;
     std::string hostname;
     std::string default_gateway;
     std::string ipv6_default_gateway;
@@ -149,6 +150,54 @@ inline std::string
     {
         return "SLAAC";
     }
+    return "";
+}
+
+inline std::string
+    translateLinkLocalDbusToRedfish(const std::string &inputLinkLocal)
+{
+    if (inputLinkLocal ==
+        "xyz.openbmc_project.Network.EthernetInterface.LinkLocalConf.fallback")
+    {
+        return "AutoConfig";
+    }
+
+    if (inputLinkLocal ==
+        "xyz.openbmc_project.Network.EthernetInterface.LinkLocalConf.none")
+    {
+        return "None";
+    }
+
+    if (inputLinkLocal ==
+        "xyz.openbmc_project.Network.EthernetInterface.LinkLocalConf.both")
+    {
+        return "Static";
+    }
+
+    return "None";
+}
+
+inline std::string
+    translateLinkLocalRedfishToDbus(const std::string &inputLinkLocal)
+{
+    if (inputLinkLocal == "AutoConfig")
+    {
+        return "xyz.openbmc_project.Network.EthernetInterface.LinkLocalConf."
+               "fallback";
+    }
+
+    if (inputLinkLocal == "None")
+    {
+        return "xyz.openbmc_project.Network.EthernetInterface.LinkLocalConf."
+               "none";
+    }
+
+    if (inputLinkLocal == "Static")
+    {
+        return "xyz.openbmc_project.Network.EthernetInterface.LinkLocalConf."
+               "both";
+    }
+
     return "";
 }
 
@@ -246,6 +295,17 @@ inline bool extractEthernetInterfaceData(const std::string &ethiface_id,
                             if (domainNames != nullptr)
                             {
                                 ethData.domainnames = std::move(*domainNames);
+                            }
+                        }
+                        else if (propertyPair.first == "LinkLocalAutoConf")
+                        {
+                            const std::string *linkLocalConf =
+                                std::get_if<std::string>(&propertyPair.second);
+                            if (linkLocalConf != nullptr)
+                            {
+                                ethData.linkLocal =
+                                    translateLinkLocalDbusToRedfish(
+                                        *linkLocalConf);
                             }
                         }
                     }
@@ -1077,6 +1137,27 @@ class EthernetInterface : public Node
             "xyz.openbmc_project.Network.EthernetInterface", propertyName,
             std::variant<bool>{value});
     }
+
+    void setDHCPFallback(const std::string &ifaceId, const std::string &value,
+                         const std::shared_ptr<AsyncResp> asyncResp)
+    {
+        std::string linkLocalConf = translateLinkLocalRedfishToDbus(value);
+        crow::connections::systemBus->async_method_call(
+            [asyncResp](const boost::system::error_code ec) {
+                if (ec)
+                {
+                    BMCWEB_LOG_ERROR << "D-Bus responses error: " << ec;
+                    messages::internalError(asyncResp->res);
+                    return;
+                }
+            },
+            "xyz.openbmc_project.Network",
+            "/xyz/openbmc_project/network/" + ifaceId,
+            "org.freedesktop.DBus.Properties", "Set",
+            "xyz.openbmc_project.Network.EthernetInterface",
+            "LinkLocalAutoConf", std::variant<std::string>(linkLocalConf));
+    }
+
     void setDHCPv4Config(const std::string &propertyName, const bool &value,
                          const std::shared_ptr<AsyncResp> asyncResp)
     {
@@ -1104,11 +1185,13 @@ class EthernetInterface : public Node
         std::optional<bool> useDNSServers;
         std::optional<bool> useDomainName;
         std::optional<bool> useNTPServers;
+        std::optional<std::string> fallbackAddress;
 
         if (!json_util::readJson(input, asyncResp->res, "DHCPEnabled",
                                  dhcpEnabled, "UseDNSServers", useDNSServers,
                                  "UseDomainName", useDomainName,
-                                 "UseNTPServers", useNTPServers))
+                                 "UseNTPServers", useNTPServers,
+                                 "FallbackAddress", fallbackAddress))
         {
             return;
         }
@@ -1135,6 +1218,12 @@ class EthernetInterface : public Node
         {
             BMCWEB_LOG_DEBUG << "set NTPEnabled...";
             setDHCPv4Config("NTPEnabled", *useNTPServers, asyncResp);
+        }
+
+        if (fallbackAddress)
+        {
+            BMCWEB_LOG_DEBUG << "set FallbackAddress...";
+            setDHCPFallback(ifaceId, *fallbackAddress, asyncResp);
         }
     }
     void handleIPv4StaticPatch(
@@ -1522,6 +1611,7 @@ class EthernetInterface : public Node
         json_response["SpeedMbps"] = ethData.speed;
         json_response["MACAddress"] = ethData.mac_address;
         json_response["DHCPv4"]["DHCPEnabled"] = ethData.DHCPEnabled;
+        json_response["DHCPv4"]["FallbackAddress"] = ethData.linkLocal;
 
         if (!ethData.hostname.empty())
         {


### PR DESCRIPTION
Tested by:
this commit has dependency on backend changes,phosphor-networkd commit
https://gerrit.openbmc-project.xyz/c/openbmc/phosphor-networkd/+/21088.

GET
PATCH -d '{"DHCPv4":{"FallbackAddress":"AutoConfig"}}'
PATCH -d '{"DHCPv4":{"FallbackAddress":"None"}}'
PATCH -d '{"DHCPv4":{"FallbackAddress":"Static"}}'

FallbackAddress is introduced in schema EthernetInterface.v1_5_0

Signed-off-by: Ravi Teja <raviteja28031990@gmail.com>
Change-Id: Id7ef44a17d318d2bae1616f6d7a0614f7d4f25ee