### PR TITLE
Op940.01 expired password

### DIFF
--- a/crow/include/crow/routing.h
+++ b/crow/include/crow/routing.h
@@ -1,5 +1,6 @@
 #pragma once
 
+#include "json_msg_utility.hpp"
 #include "privileges.hpp"
 #include "sessions.hpp"
 
@@ -9,6 +10,7 @@
 #include <cerrno>
 #include <cstdint>
 #include <cstdlib>
+#include <error_messages.hpp>
 #include <limits>
 #include <memory>
 #include <tuple>
@@ -1233,42 +1235,107 @@ class Router
         redfish::Privileges userPrivileges;
         if (req.session != nullptr)
         {
-            // Get the user role from the session.
-            const std::string& userRole = req.session->userRole;
+            if (!req.session->isConfigureSelfOnly)
+            {
+                // Get the user role from the session.
+                const std::string& userRole = req.session->userRole;
 
-            BMCWEB_LOG_DEBUG << "USER ROLE=" << userRole;
+                BMCWEB_LOG_DEBUG << "USER ROLE=" << userRole;
 
-            // Get the user privileges from the role
-            userPrivileges = redfish::getUserPrivileges(userRole);
+                // Get the user's Redfish Privileges from the role.
+                userPrivileges = redfish::getUserPrivileges(userRole);
+            }
+            else
+            {
+                BMCWEB_LOG_DEBUG << "Session limited to ConfigureSelf";
+                userPrivileges = {"ConfigureSelf"};
+            }
         }
 
         if (!rules[ruleIndex]->checkPrivileges(userPrivileges))
         {
-            res.result(boost::beast::http::status::forbidden);
+            if (boost::starts_with(req.url, "/redfish/"))
+            {
+                if (req.session == nullptr)
+                {
+                    redfish::messages::noValidSession(res);
+                }
+                else
+                {
+                    redfish::messages::insufficientPrivilege(res);
+                    if (req.session->isConfigureSelfOnly)
+                    {
+                        redfish::messages::passwordChangeRequired(
+                            res, "/redfish/v1/AccountService/Accounts/" +
+                                     req.session->username);
+                    }
+                }
+            }
+#ifdef BMCWEB_ENABLE_DBUS_REST
+            else if (boost::starts_with(req.url, "/xyz/") ||
+                     boost::starts_with(req.url, "/bus/") ||
+                     boost::starts_with(req.url, "/list/") ||
+                     boost::starts_with(req.url, "/org/") ||
+                     boost::starts_with(req.url, "/action/") ||
+                     boost::starts_with(req.url, "/enumerate/") ||
+                     boost::starts_with(req.url, "/download/"))
+            {
+                if (req.session != nullptr)
+                {
+                    crow::setErrorResponse(
+                        res, boost::beast::http::status::forbidden,
+                        "The session is not authorized to access URI: " +
+                            std::string(req.url),
+                        crow::msg::forbiddenMsg);
+                    if (req.session->isConfigureSelfOnly)
+                    {
+                        crow::setPasswordChangeRequired(res,
+                                                        req.session->username);
+                    }
+                }
+                else
+                {
+                    // How can we get here?
+                    crow::setErrorResponse(
+                        res, boost::beast::http::status::unauthorized,
+                        crow::msg::unAuthMsg,
+                        "The request is not authenticated");
+                    if (req.getHeaderValue("User-Agent").empty())
+                    {
+                        res.addHeader("WWW-Authenticate", "Basic");
+                    }
+                }
+            }
+            else
+            {
+                res.result(boost::beast::http::status::forbidden);
+            }
             res.end();
-            return;
         }
-
-        // any uncaught exceptions become 500s
-        try
+#endif
+        else
         {
-            rules[ruleIndex]->handle(req, res, found.second);
-        }
-        catch (std::exception& e)
-        {
-            BMCWEB_LOG_ERROR << "An uncaught exception occurred: " << e.what();
-            res.result(boost::beast::http::status::internal_server_error);
-            res.end();
-            return;
-        }
-        catch (...)
-        {
-            BMCWEB_LOG_ERROR
-                << "An uncaught exception occurred. The type was unknown "
-                   "so no information was available.";
-            res.result(boost::beast::http::status::internal_server_error);
-            res.end();
-            return;
+            try
+            {
+                rules[ruleIndex]->handle(req, res, found.second);
+            }
+            catch (std::exception& e)
+            {
+                BMCWEB_LOG_ERROR << "An uncaught exception occurred: "
+                                 << e.what();
+                res.result(boost::beast::http::status::internal_server_error);
+                res.end();
+                return;
+            }
+            catch (...)
+            {
+                BMCWEB_LOG_ERROR
+                    << "An uncaught exception occurred. The type was unknown "
+                       "so no information was available.";
+                res.result(boost::beast::http::status::internal_server_error);
+                res.end();
+                return;
+            }
         }
     }
 

--- a/include/json_msg_utility.hpp
+++ b/include/json_msg_utility.hpp
@@ -1,0 +1,51 @@
+#pragma once
+
+#include "crow/http_response.h"
+
+namespace crow
+{
+namespace msg
+{
+const std::string notFoundMsg = "404 Not Found";
+const std::string badReqMsg = "400 Bad Request";
+const std::string methodNotAllowedMsg = "405 Method Not Allowed";
+const std::string forbiddenMsg = "403 Forbidden";
+const std::string methodFailedMsg = "500 Method Call Failed";
+const std::string methodOutputFailedMsg = "500 Method Output Error";
+const std::string unAuthMsg = "401 Unauthorized"; // Unauthenticated
+
+const std::string notFoundDesc =
+    "org.freedesktop.DBus.Error.FileNotFound: path or object not found";
+const std::string propNotFoundDesc = "The specified property cannot be found";
+const std::string noJsonDesc = "No JSON object could be decoded";
+const std::string methodNotFoundDesc = "The specified method cannot be found";
+const std::string methodNotAllowedDesc = "Method not allowed";
+const std::string forbiddenPropDesc =
+    "The specified property cannot be created";
+const std::string forbiddenResDesc = "The specified resource cannot be created";
+const std::string unAuthDesc = "The authentication could not be applied";
+const std::string forbiddenURIDesc = "The session is not authorized to access URI: ";
+
+} // namespace msg
+
+inline void setErrorResponse(crow::Response &res,
+                             boost::beast::http::status result,
+                             const std::string &desc, const std::string &msg)
+{
+    res.result(result);
+    res.jsonValue = {{"data", {{"description", desc}}},
+                     {"message", msg},
+                     {"status", "error"}};
+}
+
+inline void setPasswordChangeRequired(crow::Response &res,
+                                      const std::string &username)
+{
+    res.jsonValue["extendedMessage"] =
+        "The password for this account must be changed.  PATCH the 'Password' "
+        "property for the account under URI: "
+        "/redfish/v1/AccountService/Accounts/" +
+        username;
+}
+
+} // namespace crow

--- a/include/json_msg_utility.hpp
+++ b/include/json_msg_utility.hpp
@@ -42,10 +42,9 @@ inline void setPasswordChangeRequired(crow::Response &res,
                                       const std::string &username)
 {
     res.jsonValue["extendedMessage"] =
-        "The password for this account must be changed.  PATCH the 'Password' "
-        "property for the account under URI: "
-        "/redfish/v1/AccountService/Accounts/" +
-        username;
+        "The password for this account must be changed.  POST the new password "
+        "as JSON data {\"data\":[\"NEWPASSWORD\"]} to URI "
+        "/xyz/openbmc_project/user/root/action/SetPassword.";
 }
 
 } // namespace crow

--- a/include/openbmc_dbus_rest.hpp
+++ b/include/openbmc_dbus_rest.hpp
@@ -1480,7 +1480,8 @@ void handleActionSetPassword(std::shared_ptr<InProgressActionData> transaction)
         return;
     }
 
-    if (!pamUpdatePassword("root", pwd))
+    bool gotPamAuthtokError = false;
+    if (!pamUpdatePassword("root", pwd, gotPamAuthtokError))
     {
         BMCWEB_LOG_ERROR << "pamUpdatePassword Failed";
         transaction->setErrorStatus("Password Not Modified");
@@ -2214,48 +2215,6 @@ template <typename... Middlewares> void requestRoutes(Crow<Middlewares...> &app)
                 }
                 handleDBusUrl(req, res, objectPath);
             });
-
-    BMCWEB_ROUTE(app, "/xyz/openbmc_project/user/root/action/SetPassword")
-        .requires({"ConfigureComponents", "ConfigureManager"})
-        .methods(
-            "PATCH"_method)([](const crow::Request &req, crow::Response &res) {
-            nlohmann::json data = nlohmann::json::parse(std::move(req.body));
-            const std::string *pwd;
-            for (const auto &item : data.items())
-            {
-                if (item.key() == "Password")
-                {
-                    pwd = item.value().get_ptr<const std::string *>();
-                }
-            }
-
-            if (!pwd || pwd->empty())
-            {
-                BMCWEB_LOG_ERROR << "Password Empty!";
-                res.jsonValue = {{"message", "400 Bad Request"},
-                                 {"status", "Error"},
-                                 {"data", "Password Not Updated"}};
-                res.end();
-                return;
-            }
-
-            if (!pamUpdatePassword("root", *pwd))
-            {
-                BMCWEB_LOG_ERROR << "pamUpdatePassword Failed";
-                res.jsonValue = {{"message", "500 Internal Server Error"},
-                                 {"status", "Error"},
-                                 {"data", "Password Not Updated"}};
-                res.end();
-                return;
-            }
-
-            BMCWEB_LOG_DEBUG << "pamUpdatePassword Successful";
-            res.jsonValue = {{"message", "204 Resource Updated Successfully"},
-                             {"status", "ok"},
-                             {"data", "Password Updated"}};
-            res.end();
-            return;
-        });
 
     BMCWEB_ROUTE(app, "/org/<path>")
         .requires({"Login"})

--- a/include/openbmc_dbus_rest.hpp
+++ b/include/openbmc_dbus_rest.hpp
@@ -23,42 +23,17 @@
 #include <dbus_utility.hpp>
 #include <filesystem>
 #include <fstream>
+#include <json_msg_utility.hpp>
+#include <regex>
 #include <sdbusplus/message/types.hpp>
 
 namespace crow
 {
 namespace openbmc_mapper
 {
-
 using GetSubTreeType = std::vector<
     std::pair<std::string,
               std::vector<std::pair<std::string, std::vector<std::string>>>>>;
-
-const std::string notFoundMsg = "404 Not Found";
-const std::string badReqMsg = "400 Bad Request";
-const std::string methodNotAllowedMsg = "405 Method Not Allowed";
-const std::string forbiddenMsg = "403 Forbidden";
-const std::string methodFailedMsg = "500 Method Call Failed";
-const std::string methodOutputFailedMsg = "500 Method Output Error";
-
-const std::string notFoundDesc =
-    "org.freedesktop.DBus.Error.FileNotFound: path or object not found";
-const std::string propNotFoundDesc = "The specified property cannot be found";
-const std::string noJsonDesc = "No JSON object could be decoded";
-const std::string methodNotFoundDesc = "The specified method cannot be found";
-const std::string methodNotAllowedDesc = "Method not allowed";
-const std::string forbiddenPropDesc =
-    "The specified property cannot be created";
-const std::string forbiddenResDesc = "The specified resource cannot be created";
-
-void setErrorResponse(crow::Response &res, boost::beast::http::status result,
-                      const std::string &desc, const std::string &msg)
-{
-    res.result(result);
-    res.jsonValue = {{"data", {{"description", desc}}},
-                     {"message", msg},
-                     {"status", "error"}};
-}
 
 void introspectObjects(const std::string &processName,
                        const std::string &objectPath,
@@ -417,17 +392,19 @@ struct InProgressActionData
             {
                 if (!methodFailed)
                 {
-                    setErrorResponse(res, boost::beast::http::status::not_found,
-                                     methodNotFoundDesc, notFoundMsg);
+                    crow::setErrorResponse(
+                        res, boost::beast::http::status::not_found,
+                        crow::msg::methodNotFoundDesc, crow::msg::notFoundMsg);
                 }
             }
             else
             {
                 if (outputFailed)
                 {
-                    setErrorResponse(
+                    crow::setErrorResponse(
                         res, boost::beast::http::status::internal_server_error,
-                        "Method output failure", methodOutputFailedMsg);
+                        "Method output failure",
+                        crow::msg::methodOutputFailedMsg);
                 }
                 else
                 {
@@ -443,8 +420,8 @@ struct InProgressActionData
 
     void setErrorStatus(const std::string &desc)
     {
-        setErrorResponse(res, boost::beast::http::status::bad_request, desc,
-                         badReqMsg);
+        crow::setErrorResponse(res, boost::beast::http::status::bad_request,
+                               desc, crow::msg::badReqMsg);
     }
     crow::Response &res;
     std::string path;
@@ -1453,7 +1430,7 @@ void findActionOnInterface(std::shared_ptr<InProgressActionData> transaction,
 
                                         if (e)
                                         {
-                                            setErrorResponse(
+                                            crow::setErrorResponse(
                                                 transaction->res,
                                                 boost::beast::http::status::
                                                     bad_request,
@@ -1461,12 +1438,12 @@ void findActionOnInterface(std::shared_ptr<InProgressActionData> transaction,
                                         }
                                         else
                                         {
-                                            setErrorResponse(
+                                            crow::setErrorResponse(
                                                 transaction->res,
                                                 boost::beast::http::status::
                                                     bad_request,
                                                 "Method call failed",
-                                                methodFailedMsg);
+                                                crow::msg::methodFailedMsg);
                                         }
                                         return;
                                     }
@@ -1525,24 +1502,24 @@ void handleAction(const crow::Request &req, crow::Response &res,
 
     if (requestDbusData.is_discarded())
     {
-        setErrorResponse(res, boost::beast::http::status::bad_request,
-                         noJsonDesc, badReqMsg);
+        crow::setErrorResponse(res, boost::beast::http::status::bad_request,
+                               crow::msg::noJsonDesc, crow::msg::badReqMsg);
         res.end();
         return;
     }
     nlohmann::json::iterator data = requestDbusData.find("data");
     if (data == requestDbusData.end())
     {
-        setErrorResponse(res, boost::beast::http::status::bad_request,
-                         noJsonDesc, badReqMsg);
+        crow::setErrorResponse(res, boost::beast::http::status::bad_request,
+                               crow::msg::noJsonDesc, crow::msg::badReqMsg);
         res.end();
         return;
     }
 
     if (!data->is_array())
     {
-        setErrorResponse(res, boost::beast::http::status::bad_request,
-                         noJsonDesc, badReqMsg);
+        crow::setErrorResponse(res, boost::beast::http::status::bad_request,
+                               crow::msg::noJsonDesc, crow::msg::badReqMsg);
         res.end();
         return;
     }
@@ -1570,9 +1547,10 @@ void handleAction(const crow::Request &req, crow::Response &res,
             if (ec || interfaceNames.size() <= 0)
             {
                 BMCWEB_LOG_ERROR << "Can't find object";
-                setErrorResponse(
+                crow::setErrorResponse(
                     transaction->res, boost::beast::http::status::not_found,
-                    notFoundDesc + ": " + transaction->path, notFoundMsg);
+                    crow::msg::notFoundDesc + ": " + transaction->path,
+                    crow::msg::notFoundMsg);
                 return;
             }
 
@@ -1604,9 +1582,10 @@ void handleDelete(const crow::Request &req, crow::Response &res,
             if (ec || interfaceNames.size() <= 0)
             {
                 BMCWEB_LOG_ERROR << "Can't find object";
-                setErrorResponse(res,
-                                 boost::beast::http::status::method_not_allowed,
-                                 methodNotAllowedDesc, methodNotAllowedMsg);
+                crow::setErrorResponse(
+                    res, boost::beast::http::status::method_not_allowed,
+                    crow::msg::methodNotAllowedDesc,
+                    crow::msg::methodNotAllowedMsg);
                 res.end();
                 return;
             }
@@ -1636,8 +1615,9 @@ void handleList(crow::Response &res, const std::string &objectPath,
                std::vector<std::string> &objectPaths) {
             if (ec)
             {
-                setErrorResponse(res, boost::beast::http::status::not_found,
-                                 notFoundDesc, notFoundMsg);
+                crow::setErrorResponse(
+                    res, boost::beast::http::status::not_found,
+                    crow::msg::notFoundDesc, crow::msg::notFoundMsg);
             }
             else
             {
@@ -1675,9 +1655,10 @@ void handleEnumerate(crow::Response &res, const std::string &objectPath)
             {
                 BMCWEB_LOG_ERROR << "GetSubTree failed on "
                                  << transaction->objectPath;
-                setErrorResponse(transaction->asyncResp->res,
-                                 boost::beast::http::status::not_found,
-                                 notFoundDesc, notFoundMsg);
+                crow::setErrorResponse(transaction->asyncResp->res,
+                                       boost::beast::http::status::not_found,
+                                       crow::msg::notFoundDesc,
+                                       crow::msg::notFoundMsg);
                 return;
             }
 
@@ -1708,8 +1689,9 @@ void handleGet(crow::Response &res, std::string &objectPath,
                                    const GetObjectType &object_names) {
             if (ec || object_names.size() <= 0)
             {
-                setErrorResponse(res, boost::beast::http::status::not_found,
-                                 notFoundDesc, notFoundMsg);
+                crow::setErrorResponse(
+                    res, boost::beast::http::status::not_found,
+                    crow::msg::notFoundDesc, crow::msg::notFoundMsg);
                 res.end();
                 return;
             }
@@ -1725,8 +1707,9 @@ void handleGet(crow::Response &res, std::string &objectPath,
 
                 if (interfaceNames.size() <= 0)
                 {
-                    setErrorResponse(res, boost::beast::http::status::not_found,
-                                     notFoundDesc, notFoundMsg);
+                    crow::setErrorResponse(
+                        res, boost::beast::http::status::not_found,
+                        crow::msg::notFoundDesc, crow::msg::notFoundMsg);
                     res.end();
                     return;
                 }
@@ -1781,10 +1764,11 @@ void handleGet(crow::Response &res, std::string &objectPath,
                             {
                                 if (!propertyName->empty() && response->empty())
                                 {
-                                    setErrorResponse(
+                                    crow::setErrorResponse(
                                         res,
                                         boost::beast::http::status::not_found,
-                                        propNotFoundDesc, notFoundMsg);
+                                        crow::msg::propNotFoundDesc,
+                                        crow::msg::notFoundMsg);
                                 }
                                 else
                                 {
@@ -1813,8 +1797,9 @@ struct AsyncPutRequest
     {
         if (res.jsonValue.empty())
         {
-            setErrorResponse(res, boost::beast::http::status::forbidden,
-                             forbiddenMsg, forbiddenPropDesc);
+            crow::setErrorResponse(res, boost::beast::http::status::forbidden,
+                                   crow::msg::forbiddenMsg,
+                                   crow::msg::forbiddenPropDesc);
         }
 
         res.end();
@@ -1822,8 +1807,9 @@ struct AsyncPutRequest
 
     void setErrorStatus(const std::string &desc)
     {
-        setErrorResponse(res, boost::beast::http::status::internal_server_error,
-                         desc, badReqMsg);
+        crow::setErrorResponse(
+            res, boost::beast::http::status::internal_server_error, desc,
+            crow::msg::badReqMsg);
     }
 
     crow::Response &res;
@@ -1837,8 +1823,9 @@ void handlePut(const crow::Request &req, crow::Response &res,
 {
     if (destProperty.empty())
     {
-        setErrorResponse(res, boost::beast::http::status::forbidden,
-                         forbiddenResDesc, forbiddenMsg);
+        crow::setErrorResponse(res, boost::beast::http::status::forbidden,
+                               crow::msg::forbiddenResDesc,
+                               crow::msg::forbiddenMsg);
         res.end();
         return;
     }
@@ -1848,8 +1835,8 @@ void handlePut(const crow::Request &req, crow::Response &res,
 
     if (requestDbusData.is_discarded())
     {
-        setErrorResponse(res, boost::beast::http::status::bad_request,
-                         noJsonDesc, badReqMsg);
+        crow::setErrorResponse(res, boost::beast::http::status::bad_request,
+                               crow::msg::noJsonDesc, crow::msg::badReqMsg);
         res.end();
         return;
     }
@@ -1857,8 +1844,8 @@ void handlePut(const crow::Request &req, crow::Response &res,
     nlohmann::json::const_iterator propertyIt = requestDbusData.find("data");
     if (propertyIt == requestDbusData.end())
     {
-        setErrorResponse(res, boost::beast::http::status::bad_request,
-                         noJsonDesc, badReqMsg);
+        crow::setErrorResponse(res, boost::beast::http::status::bad_request,
+                               crow::msg::noJsonDesc, crow::msg::badReqMsg);
         res.end();
         return;
     }
@@ -1876,9 +1863,9 @@ void handlePut(const crow::Request &req, crow::Response &res,
                       const GetObjectType &object_names) {
             if (!ec && object_names.size() <= 0)
             {
-                setErrorResponse(transaction->res,
-                                 boost::beast::http::status::not_found,
-                                 propNotFoundDesc, notFoundMsg);
+                crow::setErrorResponse(
+                    transaction->res, boost::beast::http::status::not_found,
+                    crow::msg::propNotFoundDesc, crow::msg::notFoundMsg);
                 return;
             }
 
@@ -1994,7 +1981,7 @@ void handlePut(const crow::Request &req, crow::Response &res,
                                                     {
                                                         const sd_bus_error *e =
                                                             m.get_error();
-                                                        setErrorResponse(
+                                                        crow::setErrorResponse(
                                                             transaction->res,
                                                             boost::beast::http::
                                                                 status::
@@ -2116,8 +2103,9 @@ inline void handleDBusUrl(const crow::Request &req, crow::Response &res,
         return;
     }
 
-    setErrorResponse(res, boost::beast::http::status::method_not_allowed,
-                     methodNotAllowedDesc, methodNotAllowedMsg);
+    crow::setErrorResponse(res, boost::beast::http::status::method_not_allowed,
+                           crow::msg::methodNotAllowedDesc,
+                           crow::msg::methodNotAllowedMsg);
     res.end();
 }
 

--- a/include/pam_authenticate.hpp
+++ b/include/pam_authenticate.hpp
@@ -94,9 +94,21 @@ inline bool pamAuthenticateUser(const std::string_view username,
     return true;
 }
 
+
+/**
+ * @brief Change the user's password
+ *
+ * @param[in] username Name of user account to change
+ * @param[in] password The new password
+ * @param[out] gotPamAuthtokError true, if pam_chauthtok returned PAM_AUTHTOK_ERR
+ *             which usually means the password was rejected
+ *
+ * @returns true, if the password updated successfully */
 inline bool pamUpdatePassword(const std::string& username,
-                              const std::string& password)
+                              const std::string& password,
+                              bool& gotPamAuthtokError)
 {
+    gotPamAuthtokError = false;
     const struct pam_conv localConversation = {
         pamFunctionConversation, const_cast<char*>(password.c_str())};
     pam_handle_t* localAuthHandle = NULL; // this gets set by pam_start
@@ -110,6 +122,7 @@ inline bool pamUpdatePassword(const std::string& username,
 
     if (retval != PAM_SUCCESS)
     {
+        gotPamAuthtokError = (retval == PAM_AUTHTOK_ERR);
         pam_end(localAuthHandle, PAM_SUCCESS);
         return false;
     }

--- a/include/persistent_data_middleware.hpp
+++ b/include/persistent_data_middleware.hpp
@@ -117,7 +117,8 @@ class Middleware
                             BMCWEB_LOG_DEBUG
                                 << "Restored session: " << newSession->csrfToken
                                 << " " << newSession->uniqueId << " "
-                                << newSession->sessionToken;
+                                << newSession->sessionToken << " "
+                                << newSession->isConfigureSelfOnly;
                             SessionStore::getInstance().authTokens.emplace(
                                 newSession->sessionToken, newSession);
                         }

--- a/include/sessions.hpp
+++ b/include/sessions.hpp
@@ -362,6 +362,10 @@ struct UserSession
             {
                 userSession->userRole = *thisValue;
             }
+            else if (element.key() == "is_configure_self_only")
+            {
+                userSession->isConfigureSelfOnly = (*thisValue == "true");
+            }
             else
             {
                 BMCWEB_LOG_ERROR
@@ -379,7 +383,6 @@ struct UserSession
         // this is done temporarily
         userSession->lastUpdated = std::chrono::steady_clock::now();
         userSession->persistence = PersistenceType::TIMEOUT;
-        userSession->isConfigureSelfOnly = false;
 
         return userSession;
     }
@@ -435,7 +438,7 @@ class SessionStore
         BMCWEB_LOG_DEBUG << "user name=\"" << username << "\" role = " << role;
         auto session = std::make_shared<UserSession>(UserSession{
             uniqueId, sessionToken, std::string(username), role, csrfToken,
-            std::chrono::steady_clock::now(), persistence});
+                std::chrono::steady_clock::now(), persistence, configureSelfOnly});
         session->isConfigureSelfOnly = configureSelfOnly;
         auto it = authTokens.emplace(std::make_pair(sessionToken, session));
         // Only need to write to disk if session isn't about to be destroyed.
@@ -575,7 +578,8 @@ struct adl_serializer<std::shared_ptr<crow::persistent_data::UserSession>>
                                {"session_token", p->sessionToken},
                                {"username", p->username},
                                {"csrf_token", p->csrfToken},
-                               {"user_role", p->userRole}};
+                               {"user_role", p->userRole},
+                               {"is_configure_self_only", (p->isConfigureSelfOnly ? "true" : "false")}};
         }
     }
 };

--- a/include/sessions.hpp
+++ b/include/sessions.hpp
@@ -332,6 +332,7 @@ struct UserSession
     {
         std::shared_ptr<UserSession> userSession =
             std::make_shared<UserSession>();
+        userSession->isConfigureSelfOnly = false;
         for (const auto& element : j.items())
         {
             const std::string* thisValue =

--- a/include/sessions.hpp
+++ b/include/sessions.hpp
@@ -316,6 +316,7 @@ struct UserSession
     std::string csrfToken;
     std::chrono::time_point<std::chrono::steady_clock> lastUpdated;
     PersistenceType persistence;
+    bool isConfigureSelfOnly;
 
     /**
      * @brief Fills object with data from UserSession's JSON representation
@@ -378,6 +379,7 @@ struct UserSession
         // this is done temporarily
         userSession->lastUpdated = std::chrono::steady_clock::now();
         userSession->persistence = PersistenceType::TIMEOUT;
+        userSession->isConfigureSelfOnly = false;
 
         return userSession;
     }
@@ -389,7 +391,7 @@ class SessionStore
 {
   public:
     std::shared_ptr<UserSession> generateUserSession(
-        const std::string_view username,
+        const std::string_view username, bool configureSelfOnly,
         PersistenceType persistence = PersistenceType::TIMEOUT)
     {
         // TODO(ed) find a secure way to not generate session identifiers if
@@ -434,6 +436,7 @@ class SessionStore
         auto session = std::make_shared<UserSession>(UserSession{
             uniqueId, sessionToken, std::string(username), role, csrfToken,
             std::chrono::steady_clock::now(), persistence});
+        session->isConfigureSelfOnly = configureSelfOnly;
         auto it = authTokens.emplace(std::make_pair(sessionToken, session));
         // Only need to write to disk if session isn't about to be destroyed.
         needWrite = persistence == PersistenceType::TIMEOUT;

--- a/include/token_authorization_middleware.hpp
+++ b/include/token_authorization_middleware.hpp
@@ -131,8 +131,7 @@ class Middleware
         BMCWEB_LOG_DEBUG << "[AuthMiddleware] Authenticating user: " << user;
 
         bool passwordChangeRequired = false;
-        if (!pamAuthenticateUser(user, pass, passwordChangeRequired) ||
-            passwordChangeRequired)
+        if (!pamAuthenticateUser(user, pass, passwordChangeRequired))
         {
             return nullptr;
         }
@@ -144,7 +143,7 @@ class Middleware
         // This whole flow needs to be revisited anyway, as we can't be
         // calling directly into pam for every request
         return persistent_data::SessionStore::getInstance().generateUserSession(
-            user, false,
+            user, passwordChangeRequired,
             crow::persistent_data::PersistenceType::SINGLE_REQUEST);
     }
 

--- a/include/token_authorization_middleware.hpp
+++ b/include/token_authorization_middleware.hpp
@@ -6,6 +6,7 @@
 #include <crow/http_response.h>
 
 #include <boost/container/flat_set.hpp>
+#include <error_messages.hpp>
 #include <pam_authenticate.hpp>
 #include <persistent_data_middleware.hpp>
 #include <random>
@@ -129,7 +130,9 @@ class Middleware
 
         BMCWEB_LOG_DEBUG << "[AuthMiddleware] Authenticating user: " << user;
 
-        if (!pamAuthenticateUser(user, pass))
+        bool passwordChangeRequired = false;
+        if (!pamAuthenticateUser(user, pass, passwordChangeRequired) ||
+            passwordChangeRequired)
         {
             return nullptr;
         }
@@ -141,7 +144,8 @@ class Middleware
         // This whole flow needs to be revisited anyway, as we can't be
         // calling directly into pam for every request
         return persistent_data::SessionStore::getInstance().generateUserSession(
-            user, crow::persistent_data::PersistenceType::SINGLE_REQUEST);
+            user, false,
+            crow::persistent_data::PersistenceType::SINGLE_REQUEST);
     }
 
     const std::shared_ptr<crow::persistent_data::UserSession>
@@ -380,14 +384,17 @@ template <typename... Middlewares> void requestRoutes(Crow<Middlewares...>& app)
 
             if (!username.empty() && !password.empty())
             {
-                if (!pamAuthenticateUser(username, password))
+                bool passwordChangeRequired = false;
+                if (!pamAuthenticateUser(username, password,
+                                         passwordChangeRequired))
                 {
                     res.result(boost::beast::http::status::unauthorized);
                 }
                 else
                 {
                     auto session = persistent_data::SessionStore::getInstance()
-                                       .generateUserSession(username);
+                                       .generateUserSession(
+                                           username, passwordChangeRequired);
 
 #ifdef BMCWEB_ENABLE_TRAFFIC_LOGGING
                     app.template getMiddleware<crow::logging::Middleware>().log(
@@ -425,6 +432,10 @@ template <typename... Middlewares> void requestRoutes(Crow<Middlewares...>& app)
                     {
                         // if content type is json, assume json token
                         res.jsonValue = {{"token", session->sessionToken}};
+                    }
+                    if (passwordChangeRequired)
+                    {
+                        crow::setPasswordChangeRequired(res, session->username);
                     }
                 }
             }

--- a/redfish-core/include/error_messages.hpp
+++ b/redfish-core/include/error_messages.hpp
@@ -32,7 +32,7 @@ namespace redfish
 namespace messages
 {
 
-constexpr const char* messageVersionPrefix = "Base.1.2.0.";
+constexpr const char* messageVersionPrefix = "Base.1.5.0.";
 constexpr const char* messageAnnotation = "@Message.ExtendedInfo";
 
 /**
@@ -624,6 +624,24 @@ void accountModified(crow::Response& res);
  * @returns Message QueryParameterOutOfRange formatted to JSON */
 void queryParameterOutOfRange(crow::Response& res, const std::string& arg1,
                               const std::string& arg2, const std::string& arg3);
+
+/**
+ * @brief Formats PasswordChangeRequired message into JSON
+ * Message body: The password provided for this account must be changed
+ * before access is granted.  PATCH the 'Password' property for this
+ * account located at the target URI '%1' to complete this process.
+ *
+ * @param[in] arg1 Parameter of message that will replace %1 in its body.
+ *
+ * @returns Message PasswordChangeRequired formatted to JSON */
+void passwordChangeRequired(crow::Response& res, const std::string& arg1);
+
+/**
+ * @brief Formats SubscriptionTerminated message into JSON
+ * Message body: The event subscription has been terminated.
+ *
+ * @returns Message SubscriptionTerminated formatted to JSON */
+void subscriptionTerminated(crow::Response& res);
 
 } // namespace messages
 

--- a/redfish-core/include/node.hpp
+++ b/redfish-core/include/node.hpp
@@ -20,6 +20,7 @@
 #include "webserver_common.hpp"
 
 #include <error_messages.hpp>
+#include <sessions.hpp>
 #include <vector>
 
 #include "crow/http_request.h"
@@ -172,6 +173,28 @@ class Node
     {
         res.result(boost::beast::http::status::method_not_allowed);
         res.end();
+    }
+
+    /* @brief Would the operation be allowed if the user did not have
+     * the ConfigureSelf Privilege?
+     *
+     * @param req      the request
+     * @param verb     the operation's verb
+     *
+     * @returns        True if allowed, false otherwise
+     */
+    inline bool isAllowedWithoutConfigureSelf(const crow::Request& req)
+    {
+        const std::string& userRole =
+            crow::persistent_data::UserRoleMap::getInstance().getUserRole(
+                req.session->username);
+        Privileges effectiveUserPrivileges =
+            redfish::getUserPrivileges(userRole);
+        effectiveUserPrivileges.resetSinglePrivilege("ConfigureSelf");
+        const auto& requiredPrivilegesIt = entityPrivileges.find(req.method());
+        return (requiredPrivilegesIt != entityPrivileges.end()) and
+               isOperationAllowedWithPrivileges(requiredPrivilegesIt->second,
+                                                effectiveUserPrivileges);
     }
 };
 

--- a/redfish-core/include/node.hpp
+++ b/redfish-core/include/node.hpp
@@ -185,11 +185,18 @@ class Node
      */
     inline bool isAllowedWithoutConfigureSelf(const crow::Request& req)
     {
-        const std::string& userRole =
-            crow::persistent_data::UserRoleMap::getInstance().getUserRole(
-                req.session->username);
-        Privileges effectiveUserPrivileges =
-            redfish::getUserPrivileges(userRole);
+        Privileges effectiveUserPrivileges;
+        if ((req.session != nullptr) && (!req.session->isConfigureSelfOnly))
+        {
+            const std::string& userRole =
+                crow::persistent_data::UserRoleMap::getInstance().getUserRole(
+                    req.session->username);
+            effectiveUserPrivileges = redfish::getUserPrivileges(userRole);
+        }
+        else
+        {
+            effectiveUserPrivileges = {"ConfigureSelf"};
+        }
         effectiveUserPrivileges.resetSinglePrivilege("ConfigureSelf");
         const auto& requiredPrivilegesIt = entityPrivileges.find(req.method());
         return (requiredPrivilegesIt != entityPrivileges.end()) and

--- a/redfish-core/include/privileges.hpp
+++ b/redfish-core/include/privileges.hpp
@@ -62,6 +62,11 @@ static const std::vector<std::string> privilegeNames{basePrivileges.begin(),
  *        A bit is set if the privilege is required (entity domain) or granted
  *        (user domain) and false otherwise.
  *
+ *        This does not implement any Redfish property overrides,
+ *        subordinate overrides, or resource URI overrides.  This does
+ *        not implement the limitation of the ConfigureSelf privilege
+ *        to operate only on your own account or session.
+ *
  */
 class Privileges
 {
@@ -88,6 +93,29 @@ class Privileges
                                     << "in constructor";
             }
         }
+    }
+
+    /**
+     * @brief Resets the given privilege in the bitset
+     *
+     * @param[in] privilege  Privilege to be reset
+     *
+     * @return               None
+     *
+     */
+    bool resetSinglePrivilege(const char* privilege)
+    {
+        for (int searchIndex = 0; searchIndex < privilegeNames.size();
+             searchIndex++)
+        {
+            if (privilege == privilegeNames[searchIndex])
+            {
+                privilegeBitset.reset(searchIndex);
+                return true;
+            }
+        }
+
+        return false;
     }
 
     /**
@@ -173,6 +201,11 @@ class Privileges
         return (privilegeBitset & p.privilegeBitset) == p.privilegeBitset;
     }
 
+    std::string to_string() const
+    {
+        return privilegeBitset.to_string();
+    }
+
   private:
     std::bitset<maxPrivilegeCount> privilegeBitset = 0;
 };
@@ -192,6 +225,12 @@ inline const Privileges& getUserPrivileges(const std::string& userRole)
         static Privileges op{"Login", "ConfigureSelf", "ConfigureComponents"};
         return op;
     }
+    else if (userRole == "special-priv-configure-self")
+    {
+        // Redfish privilege : N/A - internal within BMCWeb
+        static Privileges configSelf{"ConfigureSelf"};
+        return configSelf;
+    }
     else
     {
         // Redfish privilege : Readonly
@@ -202,6 +241,34 @@ inline const Privileges& getUserPrivileges(const std::string& userRole)
 
 using OperationMap = boost::container::flat_map<boost::beast::http::verb,
                                                 std::vector<Privileges>>;
+
+/* @brief Checks if user is allowed to call an operation
+ *
+ * @param[in] operationPrivilegesRequired   Privileges required
+ * @param[in] userPrivileges                Privileges the user has
+ *
+ * @return                 True if operation is allowed, false otherwise
+ */
+inline bool isOperationAllowedWithPrivileges(
+    const std::vector<Privileges>& operationPrivilegesRequired,
+    const Privileges& userPrivileges)
+{
+    // If there are no privileges assigned, there are no privileges required
+    if (operationPrivilegesRequired.empty())
+    {
+        return true;
+    }
+    for (auto& requiredPrivileges : operationPrivilegesRequired)
+    {
+        BMCWEB_LOG_ERROR << "Checking operation privileges...";
+        if (userPrivileges.isSupersetOf(requiredPrivileges))
+        {
+            BMCWEB_LOG_ERROR << "...success";
+            return true;
+        }
+    }
+    return false;
+}
 
 /**
  * @brief Checks if given privileges allow to call an HTTP method
@@ -222,20 +289,7 @@ inline bool isMethodAllowedWithPrivileges(const boost::beast::http::verb method,
         return false;
     }
 
-    // If there are no privileges assigned, assume no privileges required
-    if (it->second.empty())
-    {
-        return true;
-    }
-
-    for (auto& requiredPrivileges : it->second)
-    {
-        if (userPrivileges.isSupersetOf(requiredPrivileges))
-        {
-            return true;
-        }
-    }
-    return false;
+    return isOperationAllowedWithPrivileges(it->second, userPrivileges);
 }
 
 /**

--- a/redfish-core/include/privileges.hpp
+++ b/redfish-core/include/privileges.hpp
@@ -210,6 +210,7 @@ class Privileges
     std::bitset<maxPrivilegeCount> privilegeBitset = 0;
 };
 
+// The caller must handle the PasswordChangeRequired condition.
 inline const Privileges& getUserPrivileges(const std::string& userRole)
 {
     // Redfish privilege : Administrator
@@ -224,12 +225,6 @@ inline const Privileges& getUserPrivileges(const std::string& userRole)
         // Redfish privilege : Operator
         static Privileges op{"Login", "ConfigureSelf", "ConfigureComponents"};
         return op;
-    }
-    else if (userRole == "special-priv-configure-self")
-    {
-        // Redfish privilege : N/A - internal within BMCWeb
-        static Privileges configSelf{"ConfigureSelf"};
-        return configSelf;
     }
     else
     {

--- a/redfish-core/lib/account_service.hpp
+++ b/redfish-core/lib/account_service.hpp
@@ -1428,7 +1428,13 @@ class ManagerAccount : public Node
             if (!isAllowedWithoutConfigureSelf(req))
             {
                 BMCWEB_LOG_DEBUG << "GET Account denied access";
-                messages::accessDenied(asyncResp->res, std::string(req.url));
+                redfish::messages::insufficientPrivilege(asyncResp->res);
+                if (req.session->isConfigureSelfOnly)
+                {
+                    redfish::messages::passwordChangeRequired(
+                        asyncResp->res, "/redfish/v1/AccountService/Accounts/" +
+                        req.session->username);
+                }
                 return;
             }
         }
@@ -1579,7 +1585,13 @@ class ManagerAccount : public Node
             {
                 BMCWEB_LOG_WARNING << "PATCH Password denied access";
                 asyncResp->res.clear();
-                messages::accessDenied(asyncResp->res, std::string(req.url));
+                messages::insufficientPrivilege(asyncResp->res);
+                if (req.session->isConfigureSelfOnly)
+                {
+                    redfish::messages::passwordChangeRequired(
+                        asyncResp->res, "/redfish/v1/AccountService/Accounts/" +
+                        req.session->username);
+                }
                 return;
             }
         }

--- a/redfish-core/lib/redfish_sessions.hpp
+++ b/redfish-core/lib/redfish_sessions.hpp
@@ -35,7 +35,8 @@ class Sessions : public Node
             {boost::beast::http::verb::head, {{"Login"}}},
             {boost::beast::http::verb::patch, {{"ConfigureManager"}}},
             {boost::beast::http::verb::put, {{"ConfigureManager"}}},
-            {boost::beast::http::verb::delete_, {{"ConfigureManager"}}},
+            {boost::beast::http::verb::delete_,
+             {{"ConfigureManager"}, {"ConfigureSelf"}}},
             {boost::beast::http::verb::post, {{"ConfigureManager"}}}};
     }
 
@@ -43,6 +44,7 @@ class Sessions : public Node
     void doGet(crow::Response& res, const crow::Request& req,
                const std::vector<std::string>& params) override
     {
+        // Note that control also reaches here via doPost and doDelete.
         auto session =
             crow::persistent_data::SessionStore::getInstance().getSessionByUid(
                 params[0]);
@@ -63,6 +65,12 @@ class Sessions : public Node
             "/redfish/v1/$metadata#Session.Session";
         res.jsonValue["Name"] = "User Session";
         res.jsonValue["Description"] = "Manager User Session";
+        if (session->isConfigureSelfOnly)
+        {
+            messages::passwordChangeRequired(
+                res,
+                "/redfish/v1/AccountService/Accounts/" + session->username);
+        }
 
         res.end();
     }
@@ -91,6 +99,24 @@ class Sessions : public Node
             messages::resourceNotFound(res, "Session", params[0]);
             res.end();
             return;
+        }
+
+        // Perform a tighter authority check for how the ConfigureSelf
+        // privilege interacts with the Session resource URI override.
+        // (Meaning: the ConfigureSelf privilege only applies to that
+        // session's Session resource.)  If a session is DELETEing
+        // some other session, then the ConfigureSelf privilege does
+        // not apply, so remove the user's ConfigureSelf privilege and
+        // perform the authority check again.
+        if (session->uniqueId != req.session->uniqueId)
+        {
+            if (!isAllowedWithoutConfigureSelf(req))
+            {
+                BMCWEB_LOG_WARNING << "DELETE Session denied access";
+                messages::accessDenied(res, std::string(req.url));
+                res.end();
+                return;
+            }
         }
 
         // DELETE should return representation of object that will be removed
@@ -179,7 +205,8 @@ class SessionCollection : public Node
             return;
         }
 
-        if (!pamAuthenticateUser(username, password))
+        bool passwordChangeRequired = false;
+        if (!pamAuthenticateUser(username, password, passwordChangeRequired))
         {
             messages::resourceAtUriUnauthorized(res, std::string(req.url),
                                                 "Invalid username or password");
@@ -191,7 +218,7 @@ class SessionCollection : public Node
         // User is authenticated - create session
         std::shared_ptr<crow::persistent_data::UserSession> session =
             crow::persistent_data::SessionStore::getInstance()
-                .generateUserSession(username);
+                .generateUserSession(username, passwordChangeRequired);
         res.addHeader("X-Auth-Token", session->sessionToken);
         res.addHeader("Location", "/redfish/v1/SessionService/Sessions/" +
                                       session->uniqueId);

--- a/redfish-core/lib/redfish_sessions.hpp
+++ b/redfish-core/lib/redfish_sessions.hpp
@@ -113,7 +113,13 @@ class Sessions : public Node
             if (!isAllowedWithoutConfigureSelf(req))
             {
                 BMCWEB_LOG_WARNING << "DELETE Session denied access";
-                messages::accessDenied(res, std::string(req.url));
+                messages::insufficientPrivilege(res);
+                if (req.session->isConfigureSelfOnly)
+                {
+                    redfish::messages::passwordChangeRequired(
+                        res, "/redfish/v1/AccountService/Accounts/" +
+                        req.session->username);
+                }
                 res.end();
                 return;
             }

--- a/redfish-core/src/error_messages.cpp
+++ b/redfish-core/src/error_messages.cpp
@@ -1508,6 +1508,52 @@ void queryParameterOutOfRange(crow::Response& res, const std::string& arg1,
              "is within the range of valid pages."}});
 }
 
+/**
+ * @internal
+ * @brief Formats PasswordChangeRequired message into JSON
+ *
+ * See header file for more information
+ * @endinternal
+ */
+void passwordChangeRequired(crow::Response& res, const std::string& arg1)
+{
+    messages::addMessageToJsonRoot(
+        res.jsonValue,
+        nlohmann::json{
+            {"@odata.type", "/redfish/v1/$metadata#Message.v1_5_0.Message"},
+            {"MessageId", "Base.1.5.0.PasswordChangeRequired"},
+            {"Message", "The password provided for this account must be "
+                        "changed before access is granted.  PATCH the "
+                        "'Password' property for this account located at "
+                        "the target URI '" +
+                            arg1 + "' to complete this process."},
+            {"MessageArgs", {arg1}},
+            {"Severity", "Critical"},
+            {"Resolution", "Change the password for this account using "
+                           "a PATCH to the 'Password' property at the URI "
+                           "provided."}});
+}
+
+/**
+ * @internal
+ * @brief Formats SubscriptionTerminated message into JSON
+ *
+ * See header file for more information
+ * @endinternal
+ */
+void subscriptionTerminated(crow::Response& res)
+{
+    messages::addMessageToJsonRoot(
+        res.jsonValue,
+        nlohmann::json{
+            {"@odata.type", "/redfish/v1/$metadata#Message.v1_5_0.Message"},
+            {"MessageId", "Base.1.5.0.SubscriptionTerminated"},
+            {"Message", "The event subscription has been terminated."},
+            {"MessageArgs", nlohmann::json::array()},
+            {"Severity", "OK"},
+            {"Resolution", "No resolution is required."}});
+}
+
 } // namespace messages
 
 } // namespace redfish


### PR DESCRIPTION
The first commit (d9d7571) is in review here: https://gerrit.openbmc-project.xyz/c/openbmc/bmcweb/+/25146
This first set of changes was tested in an internal test driver.
Note that bmcweb master (file include/sessions.hpp) has diverged from the OP940 branch: In master, the userRole has been removed from the UserSession object and is looked up for every operation.  For OP940, the userRole is still present in the UserSession.

The second two commits are bug fixes for the SetPassword API and to allow basic auth (syntax like GET https://root:0penBMC@${BMC}/xyz/...) to proceed when the password is expired.  They have not been reviewed.