### PR TITLE
bmcweb: better message for SetPassword failure

### DIFF
--- a/include/openbmc_dbus_rest.hpp
+++ b/include/openbmc_dbus_rest.hpp
@@ -1506,7 +1506,9 @@ void handleActionSetPassword(std::shared_ptr<InProgressActionData> transaction)
     if (!pamUpdatePassword("root", pwd))
     {
         BMCWEB_LOG_ERROR << "pamUpdatePassword Failed";
-        transaction->setErrorStatus("Password Not Modified");
+        transaction->setErrorStatus(
+            "Password Not Modified.  The new password was not accepted.  A "
+            "possible cause is the password value failed validation checks.");
         transaction->outputFailed = true;
         return;
     }


### PR DESCRIPTION
Enhances API /xyz/openbmc_project/user/root/action/SetPassword to
give a better error message when the new password is not accepted.

Fixes SW482129

Signed-off-by: Joseph Reynolds <joseph-reynolds@charter.net>