### PR TITLE
Update privileges for sw474797

### DIFF
--- a/redfish-core/lib/account_service.hpp
+++ b/redfish-core/lib/account_service.hpp
@@ -1250,8 +1250,7 @@ class AccountsCollection : public Node
         Node(app, "/redfish/v1/AccountService/Accounts/")
     {
         entityPrivileges = {
-            {boost::beast::http::verb::get,
-             {{"ConfigureUsers"}, {"ConfigureManager"}}},
+            {boost::beast::http::verb::get, {{"Login"}}},
             {boost::beast::http::verb::head, {{"Login"}}},
             {boost::beast::http::verb::patch, {{"ConfigureUsers"}}},
             {boost::beast::http::verb::put, {{"ConfigureUsers"}}},

--- a/redfish-core/lib/account_service.hpp
+++ b/redfish-core/lib/account_service.hpp
@@ -573,8 +573,7 @@ class AccountService : public Node
     AccountService(CrowApp& app) : Node(app, "/redfish/v1/AccountService/")
     {
         entityPrivileges = {
-            {boost::beast::http::verb::get,
-             {{"ConfigureUsers"}, {"ConfigureManager"}}},
+            {boost::beast::http::verb::get, {{"Login"}}},
             {boost::beast::http::verb::head, {{"Login"}}},
             {boost::beast::http::verb::patch, {{"ConfigureUsers"}}},
             {boost::beast::http::verb::put, {{"ConfigureUsers"}}},


### PR DESCRIPTION
SW474797: GUI User and Operator privileged users are unable to change their own account's password.

The Readonly and Operator roles need to access paths such as 
/redfish/v1/AccountService/ (AccountService schema) and
/redfish/v1/AccountService/Accounts (ManagerAccountCollection schema)
to change thier own password. 
They will need to get properties such as max and min password length which are at
/redfish/v1/AccountService/.

According to Redfish PrivilegeRegistry
https://redfish.dmtf.org/registries/Redfish_1.0.4_PrivilegeRegistry.json  
"GET" should be a "Login" Privilege for the ManagerAccountCollection
and AccountService resources.

This was changed in Redfish 2019.3, redfish issue 1914 explains
more but one of the reasons was this exact case. 

Upstream can be found at: 
https://gerrit.openbmc-project.xyz/c/openbmc/bmcweb/+/28878/
https://gerrit.openbmc-project.xyz/c/openbmc/bmcweb/+/28881/
