### PR TITLE
Redfish: Make PATCH NTP Servers operate correctly

### DIFF
--- a/redfish-core/lib/network_protocol.hpp
+++ b/redfish-core/lib/network_protocol.hpp
@@ -353,7 +353,6 @@ class NetworkProtocol : public Node
                     messages::internalError(asyncResp->res);
                     return;
                 }
-                messages::success(asyncResp->res);
             },
             "xyz.openbmc_project.Network",
             "/xyz/openbmc_project/network/config",
@@ -378,10 +377,7 @@ class NetworkProtocol : public Node
         }
 
         crow::connections::systemBus->async_method_call(
-            [asyncResp,
-             ntpEnabled](const boost::system::error_code error_code) {
-                asyncResp->res.jsonValue["NTP"]["ProtocolEnabled"] = ntpEnabled;
-            },
+            [asyncResp](const boost::system::error_code error_code) {},
             "xyz.openbmc_project.Settings",
             "/xyz/openbmc_project/time/sync_method",
             "org.freedesktop.DBus.Properties", "Set",
@@ -393,14 +389,12 @@ class NetworkProtocol : public Node
                                const std::shared_ptr<AsyncResp>& asyncResp)
     {
         crow::connections::systemBus->async_method_call(
-            [asyncResp, ntpServers](const boost::system::error_code ec) {
+            [asyncResp](const boost::system::error_code ec) {
                 if (ec)
                 {
                     messages::internalError(asyncResp->res);
                     return;
                 }
-                asyncResp->res.jsonValue["NTP"]["NTPServers"] =
-                    std::move(ntpServers);
             },
             "xyz.openbmc_project.Network", "/xyz/openbmc_project/network/eth0",
             "org.freedesktop.DBus.Properties", "Set",
@@ -413,27 +407,38 @@ class NetworkProtocol : public Node
     {
         std::shared_ptr<AsyncResp> asyncResp = std::make_shared<AsyncResp>(res);
         std::optional<std::string> newHostName;
-        std::optional<std::vector<std::string>> ntpServers;
-        std::optional<bool> ntpEnabled;
+        std::optional<nlohmann::json> ntp;
 
-        if (!json_util::readJson(req, res, "HostName", newHostName,
-                                 "NTPServers", ntpServers, "NTPEnabled",
-                                 ntpEnabled))
+        if (!json_util::readJson(req, res, "HostName", newHostName, "NTP", ntp))
         {
             return;
         }
+
+        res.result(boost::beast::http::status::no_content);
         if (newHostName)
         {
             handleHostnamePatch(*newHostName, asyncResp);
-            return;
         }
-        if (ntpEnabled)
+
+        if (ntp)
         {
-            handleNTPProtocolEnabled(*ntpEnabled, asyncResp);
-        }
-        if (ntpServers)
-        {
-            handleNTPServersPatch(*ntpServers, asyncResp);
+            std::optional<std::vector<std::string>> ntpServers;
+            std::optional<bool> ntpEnabled;
+            if (!json_util::readJson(*ntp, res, "NTPServers", ntpServers,
+                                     "ProtocolEnabled", ntpEnabled))
+            {
+                return;
+            }
+
+            if (ntpEnabled)
+            {
+                handleNTPProtocolEnabled(*ntpEnabled, asyncResp);
+            }
+
+            if (ntpServers)
+            {
+                handleNTPServersPatch(*ntpServers, asyncResp);
+            }
         }
     }
 };


### PR DESCRIPTION
The Managers NTP node did not get implemented correctly.  The first
level parsing did not search for "NTP" as the base entry, nor did it
correctly attempt to acquire the NTPServers, NTPEnabled sub-nodes.

Removed the data response as it was returning a string vector instead
of a json::array. The original code caused a seg fault. Instead of
returning a carbon copy of the values sent, the return is a 204 code,
indicating success and returning no data.

Change-Id: Ifb82855e1cd143e3cf2cb8979531b01b27d32234
Signed-off-by: Johnathan Mantey <johnathanx.mantey@intel.com>