### PR TITLE
Fix KVM page to display the KVM session

### DIFF
--- a/include/kvm_websocket.hpp
+++ b/include/kvm_websocket.hpp
@@ -11,7 +11,7 @@ namespace crow
 namespace obmc_kvm
 {
 
-static constexpr const uint maxSessions = 4;
+static constexpr const uint maxSessions = 1;
 
 class KvmSession
 {
@@ -20,7 +20,7 @@ class KvmSession
         conn(conn), doingWrite(false), hostSocket(conn.get_io_context())
     {
         boost::asio::ip::tcp::endpoint endpoint(
-            boost::asio::ip::make_address("::1"), 5900);
+            boost::asio::ip::make_address("127.0.0.1"), 5900);
         hostSocket.async_connect(
             endpoint, [this, &conn](const boost::system::error_code& ec) {
                 if (ec)


### PR DESCRIPTION
Change the maxSession of Mowgli's KVM back to 1.

Launching a KVM session on the KVM page stopped working. The websocket
connection request began returning connection failure error
codes. This change fixes the asynchronous connection request to allow
it to succeed, and in turn display the KVM session.
(From master rev:  b8c7eb23f9b598274792fe3b8d178d1f2e4cc6b0 )

Signed-off-by: LuluTHSu <Lulu_Su@wistron.com>