### PR TITLE
Fix error code for SNMP subscription

### DIFF
--- a/redfish-core/lib/event_service.hpp
+++ b/redfish-core/lib/event_service.hpp
@@ -191,7 +191,8 @@ inline void
                     const std::string& dbusSNMPid) {
             if (ec)
             {
-                messages::internalError(asyncResp->res);
+                BMCWEB_LOG_ERROR << "Create SNMP subscriber failed. " << ec;
+                messages::invalidObject(asyncResp->res, "Destination");
                 return;
             }
 


### PR DESCRIPTION
This commit fixes defect SW531983

Tested by:
Create SNMP subscriber with invalid IP address
Client should receive 400 response code

Signed-off-by: Sunitha Harish <sunharis@in.ibm.com>
Change-Id: I373a467ddf8e9996204d707cdf1fdd752dfa7e8c