### PR TITLE
Change Default of REST D-Bus to OFF

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -77,6 +77,7 @@ feature_map = {
 'redfish-provisioning-feature'    : '-DBMCWEB_ENABLE_REDFISH_PROVISIONING_FEATURE',
 'redfish-dump-log'                : '-DBMCWEB_ENABLE_REDFISH_DUMP_LOG',
 'rest'                            : '-DBMCWEB_ENABLE_DBUS_REST',
+'event-subscription'              : '-DBMCWEB_ENABLE_EVENT_SUBSCRIPTION_WEBSOCKET',
 'static-hosting'                  : '-DBMCWEB_ENABLE_STATIC_HOSTING',
 'insecure-tftp-update'            : '-DBMCWEB_INSECURE_ENABLE_REDFISH_FW_TFTP_UPDATE',
 #'vm-nbdproxy'                     : '-DBMCWEB_ENABLE_VM_NBDPROXY',

--- a/meson_options.txt
+++ b/meson_options.txt
@@ -11,7 +11,7 @@ option('vm-websocket', type : 'feature', value : 'enabled', description : '''Ena
 # removing it, it has been disabled to try to give those that use it the
 # opportunity to upstream their backend implementation
 #option('vm-nbdproxy', type: 'feature', value : 'disabled', description : 'Enable the Virtual Media WebSocket.')
-option('rest', type : 'feature', value : 'enabled', description : '''Enable Phosphor REST (D-Bus) APIs. Paths directly map Phosphor D-Bus object paths, for example, \'/xyz/openbmc_project/logging/entry/enumerate\'. See https://github.com/openbmc/docs/blob/master/rest-api.md.''')
+option('rest', type : 'feature', value : 'disabled', description : '''Enable Phosphor REST (D-Bus) APIs. Paths directly map Phosphor D-Bus object paths, for example, \'/xyz/openbmc_project/logging/entry/enumerate\'. See https://github.com/openbmc/docs/blob/master/rest-api.md.''')
 option('redfish', type : 'feature',value : 'enabled', description: 'Enable Redfish APIs.  Paths are under \'/redfish/v1/\'. See https://github.com/openbmc/bmcweb/blob/master/DEVELOPING.md#redfish.')
 option('host-serial-socket', type : 'feature', value : 'enabled', description : 'Enable host serial console WebSocket. Path is \'/console0\'.  See https://github.com/openbmc/docs/blob/master/console.md.')
 option('static-hosting', type : 'feature', value : 'enabled', description : 'Enable serving files from the \'/usr/share/www\' directory as paths under \'/\'.')

--- a/meson_options.txt
+++ b/meson_options.txt
@@ -12,6 +12,7 @@ option('vm-websocket', type : 'feature', value : 'enabled', description : '''Ena
 # opportunity to upstream their backend implementation
 #option('vm-nbdproxy', type: 'feature', value : 'disabled', description : 'Enable the Virtual Media WebSocket.')
 option('rest', type : 'feature', value : 'disabled', description : '''Enable Phosphor REST (D-Bus) APIs. Paths directly map Phosphor D-Bus object paths, for example, \'/xyz/openbmc_project/logging/entry/enumerate\'. See https://github.com/openbmc/docs/blob/master/rest-api.md.''')
+option('event-subscription', type : 'feature', value : 'enabled', description: 'Enable Event Subscription through websocket')
 option('redfish', type : 'feature',value : 'enabled', description: 'Enable Redfish APIs.  Paths are under \'/redfish/v1/\'. See https://github.com/openbmc/bmcweb/blob/master/DEVELOPING.md#redfish.')
 option('host-serial-socket', type : 'feature', value : 'enabled', description : 'Enable host serial console WebSocket. Path is \'/console0\'.  See https://github.com/openbmc/docs/blob/master/console.md.')
 option('static-hosting', type : 'feature', value : 'enabled', description : 'Enable serving files from the \'/usr/share/www\' directory as paths under \'/\'.')

--- a/src/webserver_main.cpp
+++ b/src/webserver_main.cpp
@@ -94,9 +94,12 @@ int main(int /*argc*/, char** /*argv*/)
 #endif
 
 #ifdef BMCWEB_ENABLE_DBUS_REST
-    crow::dbus_monitor::requestRoutes(app);
     crow::image_upload::requestRoutes(app);
     crow::openbmc_mapper::requestRoutes(app);
+#endif
+
+#ifdef BMCWEB_ENABLE_EVENT_SUBSCRIPTION_WEBSOCKET
+    crow::dbus_monitor::requestRoutes(app);
 #endif
 
 #ifdef BMCWEB_ENABLE_HOST_SERIAL_WEBSOCKET


### PR DESCRIPTION
REST D-Bus, while providing useful functionality, also allows
authenticated users access to privileged information that may be above
their permission level. This change sets the default to disabled. Users
if they wish can turn it back on in their own layers.

A lot of functionality previously provided by REST D-Bus is now
available on Redfish with more coming all the time.

Note: phosphor-webui uses the REST D-Bus so a user of that will have to
enable this in their layer. webui-vue, the replacement for
phosphor-webui, uses Redfish. See here [1].

Resolves openbmc/bmcweb/issues/114

[1] https://github.com/openbmc/webui-vue

Tested: Rest D-Bus was disabled

Change-Id: I35682b113287b3be4e19b033d0296790b204d8e0
Signed-off-by: James Feist <james.feist@linux.intel.com>
Signed-off-by: Ali Ahmed <ama213000@gmail.com>