### PR TITLE
Fix SW527938: Fix dump file system path

### DIFF
--- a/include/dump_offload.hpp
+++ b/include/dump_offload.hpp
@@ -15,7 +15,7 @@ namespace crow
 namespace obmc_dump
 {
 
-std::string unixSocketPathDir = "/var/lib/bmcweb/";
+std::string unixSocketPathDir = "/var/lib/phosphor-debug-collector/";
 
 inline void handleDumpOffloadUrl(const crow::Request& req, crow::Response& res,
                                  const std::string& entryId,


### PR DESCRIPTION
When redfish client offloads the dump, bmcweb was looking for
the dump at "/var/lib/bmcweb/" path. But the dumps are stored at path
"/var/lib/phosphor-debug-collector/". This resulted in offload of
zero bytes of data.

This commit fixes the dump base path at bmcweb

Tested by:
  1. Create dump
  2. Offload dump using redfish command:
     GET /redfish/v1/Systems/system/LogServices/Dump/Entries/<dump_type>_<id>/attachment > <local_filename>
  3. Check the offloaded dump size/content
  4. No errors reported at BMC during offload

Signed-off-by: Sunitha Harish <sunharis@in.ibm.com>
Change-Id: I97dde10a950d333bade145f24c244c5bc761ccd3