### PR TITLE
Move Inventory.Item.Board from Chassis to Assembly

### DIFF
--- a/redfish-core/lib/assembly.hpp
+++ b/redfish-core/lib/assembly.hpp
@@ -200,12 +200,13 @@ inline void
             "xyz.openbmc_project.ObjectMapper",
             "/xyz/openbmc_project/object_mapper",
             "xyz.openbmc_project.ObjectMapper", "GetObject", assembly,
-            std::array<const char*, 5>{
+            std::array<const char*, 6>{
                 "xyz.openbmc_project.Inventory.Item.Vrm",
                 "xyz.openbmc_project.Inventory.Item.Tpm",
                 "xyz.openbmc_project.Inventory.Item.Panel",
                 "xyz.openbmc_project.Inventory.Item.Battery",
-                "xyz.openbmc_project.Inventory.Item.DiskBackplane"});
+                "xyz.openbmc_project.Inventory.Item.DiskBackplane",
+                "xyz.openbmc_project.Inventory.Item.Board"});
 
         assemblyIndex++;
     }
@@ -348,12 +349,13 @@ inline void checkAssemblyInterface(
         "/xyz/openbmc_project/object_mapper",
         "xyz.openbmc_project.ObjectMapper", "GetSubTree",
         "/xyz/openbmc_project/inventory", int32_t(0),
-        std::array<const char*, 5>{
+        std::array<const char*, 6>{
             "xyz.openbmc_project.Inventory.Item.Vrm",
             "xyz.openbmc_project.Inventory.Item.Tpm",
             "xyz.openbmc_project.Inventory.Item.Panel",
             "xyz.openbmc_project.Inventory.Item.Battery",
-            "xyz.openbmc_project.Inventory.Item.DiskBackplane"});
+            "xyz.openbmc_project.Inventory.Item.DiskBackplane",
+            "xyz.openbmc_project.Inventory.Item.Board"});
 }
 
 /**
@@ -599,8 +601,8 @@ inline void getChassis(const std::shared_ptr<bmcweb::AsyncResp>& aResp,
         "/xyz/openbmc_project/object_mapper",
         "xyz.openbmc_project.ObjectMapper", "GetSubTreePaths",
         "/xyz/openbmc_project/inventory", 0,
-        std::array<const char*, 2>{"xyz.openbmc_project.Inventory.Item.Chassis",
-                                   "xyz.openbmc_project.Inventory.Item.Board"});
+        std::array<const char*, 1>{
+            "xyz.openbmc_project.Inventory.Item.Chassis"});
 }
 } // namespace assembly
 

--- a/redfish-core/lib/chassis.hpp
+++ b/redfish-core/lib/chassis.hpp
@@ -274,8 +274,10 @@ inline void requestRoutesChassis(App& app)
 
                         const std::vector<std::string>& interfaces2 =
                             connectionNames[0].second;
-                        const std::array<const char*, 1> hasIndicatorLed = {
-                            "xyz.openbmc_project.Inventory.Item.Panel"};
+                        const std::array<const char*, 2> hasIndicatorLed = {
+                            "xyz.openbmc_project.Inventory.Item.Panel",
+                            "xyz.openbmc_project.Inventory.Item.Board."
+                            "Motherboard"};
 
                         for (const char* interface : hasIndicatorLed)
                         {
@@ -534,8 +536,10 @@ inline void requestRoutesChassis(App& app)
                         const std::vector<std::string>& interfaces3 =
                             connectionNames[0].second;
 
-                        const std::array<const char*, 1> hasIndicatorLed = {
-                            "xyz.openbmc_project.Inventory.Item.Panel"};
+                        const std::array<const char*, 2> hasIndicatorLed = {
+                            "xyz.openbmc_project.Inventory.Item.Panel",
+                            "xyz.openbmc_project.Inventory.Item.Board."
+                            "Motherboard"};
                         bool indicatorChassis = false;
                         for (const char* interface : hasIndicatorLed)
                         {

--- a/redfish-core/lib/chassis.hpp
+++ b/redfish-core/lib/chassis.hpp
@@ -174,8 +174,7 @@ inline void requestRoutesChassisCollection(App& app)
 
                 collection_util::getCollectionMembers(
                     asyncResp, "/redfish/v1/Chassis",
-                    {"xyz.openbmc_project.Inventory.Item.Board",
-                     "xyz.openbmc_project.Inventory.Item.Chassis"});
+                    {"xyz.openbmc_project.Inventory.Item.Chassis"});
             });
 }
 
@@ -192,8 +191,7 @@ inline void requestRoutesChassis(App& app)
                                               const std::shared_ptr<
                                                   bmcweb::AsyncResp>& asyncResp,
                                               const std::string& chassisId) {
-            const std::array<const char*, 2> interfaces = {
-                "xyz.openbmc_project.Inventory.Item.Board",
+            const std::array<const char*, 1> interfaces = {
                 "xyz.openbmc_project.Inventory.Item.Chassis"};
 
             crow::connections::systemBus->async_method_call(
@@ -276,10 +274,8 @@ inline void requestRoutesChassis(App& app)
 
                         const std::vector<std::string>& interfaces2 =
                             connectionNames[0].second;
-                        const std::array<const char*, 2> hasIndicatorLed = {
-                            "xyz.openbmc_project.Inventory.Item.Panel",
-                            "xyz.openbmc_project.Inventory.Item.Board."
-                            "Motherboard"};
+                        const std::array<const char*, 1> hasIndicatorLed = {
+                            "xyz.openbmc_project.Inventory.Item.Panel"};
 
                         for (const char* interface : hasIndicatorLed)
                         {
@@ -497,8 +493,7 @@ inline void requestRoutesChassis(App& app)
                     "LocationIndicatorActive instead.\"");
             }
 
-            const std::array<const char*, 2> interfaces = {
-                "xyz.openbmc_project.Inventory.Item.Board",
+            const std::array<const char*, 1> interfaces = {
                 "xyz.openbmc_project.Inventory.Item.Chassis"};
 
             const std::string& chassisId = param;
@@ -539,10 +534,8 @@ inline void requestRoutesChassis(App& app)
                         const std::vector<std::string>& interfaces3 =
                             connectionNames[0].second;
 
-                        const std::array<const char*, 2> hasIndicatorLed = {
-                            "xyz.openbmc_project.Inventory.Item.Panel",
-                            "xyz.openbmc_project.Inventory.Item.Board."
-                            "Motherboard"};
+                        const std::array<const char*, 1> hasIndicatorLed = {
+                            "xyz.openbmc_project.Inventory.Item.Panel"};
                         bool indicatorChassis = false;
                         for (const char* interface : hasIndicatorLed)
                         {


### PR DESCRIPTION
A newer way of thinking in Redfish is for a simple rack server to have
one Redfish Chassis and things like boards modeled as Redfish
Assemblies under the Chassis.

This commit move Board under assembly. Moreover, if the association path
has "chassis/motherboard" or "/board/<Panel info>" this commit is able
to retrieve both information under assembly

busctl call xyz.openbmc_project.ObjectMapper \
  /xyz/openbmc_project/object_mapper xyz.openbmc_project.ObjectMapper \
  GetSubTreePaths sias /xyz/openbmc_project/ 0 1 \
  xyz.openbmc_project.Inventory.Item.Board

 as 2 "/xyz/openbmc_project/inventory/system/board/Blyth_Panel"
      "/xyz/openbmc_project/inventory/system/board/Nisqually_Backplane"

Tested: manually tested on system
  curl -k -H "X-Auth-Token: $token" -X GET
  https://${bmc}/redfish/v1/Chassis/chassis/Assembly

{
  "@odata.id": "/redfish/v1/Chassis/chassis/Assembly",
  "@odata.type": "#Assembly.v1_3_0.Assembly",
  "Assemblies": [
  {
    "@odata.id": "/redfish/v1/Chassis/chassis/Assembly#/Assemblies/0",
    "@odata.type": "#Assembly.v1_3_0.AssemblyData",
    "LocationIndicatorActive": null,
    "MemberId": "0",
    "Name": "Blyth_Panel"
  },
  {
    "@odata.id": "/redfish/v1/Chassis/chassis/Assembly#/Assemblies/1",
    "@odata.type": "#Assembly.v1_3_0.AssemblyData",
    "LocationIndicatorActive": null,
    "MemberId": "1",
    "Name": "Nisqually_Backplane"
  },
  {
    "@odata.id": "/redfish/v1/Chassis/chassis/Assembly#/Assemblies/2",
    "@odata.type": "#Assembly.v1_3_0.AssemblyData",
    "Location": {
      "PartLocation": {
        "ServiceLabel": "U78DA.ND0.WZS004K-D0"
       }
    },
    "LocationIndicatorActive": false,

    ...

  },

  ...
  ...
  ...

  ],
  "Assemblies@odata.count": 11,
  "Id": "Assembly",
  "Name": "Assembly Collection"
}

Email sent to openbmc list:
https://lists.ozlabs.org/pipermail/openbmc/2021-April/026059.html

Signed-off-by: Abhishek Patel <Abhishek.Patel@ibm.com>
Change-Id: Id76ff65125e6e86defbd2690bcc1dc274b5e6322