### PR TITLE
remove Item.Board from Power Redfish_util sensors

### DIFF
--- a/redfish-core/lib/power.hpp
+++ b/redfish-core/lib/power.hpp
@@ -314,8 +314,7 @@ inline void requestRoutesPower(App& app)
                     "/xyz/openbmc_project/object_mapper",
                     "xyz.openbmc_project.ObjectMapper", "GetSubTreePaths",
                     "/xyz/openbmc_project/inventory", 0,
-                    std::array<const char*, 2>{
-                        "xyz.openbmc_project.Inventory.Item.Board",
+                    std::array<const char*, 1>{
                         "xyz.openbmc_project.Inventory.Item.Chassis"});
             });
 

--- a/redfish-core/lib/redfish_util.hpp
+++ b/redfish-core/lib/redfish_util.hpp
@@ -55,8 +55,7 @@ void getMainChassisId(std::shared_ptr<bmcweb::AsyncResp> asyncResp,
         "/xyz/openbmc_project/object_mapper",
         "xyz.openbmc_project.ObjectMapper", "GetSubTree",
         "/xyz/openbmc_project/inventory", 0,
-        std::array<const char*, 2>{
-            "xyz.openbmc_project.Inventory.Item.Board",
+        std::array<const char*, 1>{
             "xyz.openbmc_project.Inventory.Item.Chassis"});
 }
 } // namespace redfish

--- a/redfish-core/lib/sensors.hpp
+++ b/redfish-core/lib/sensors.hpp
@@ -458,8 +458,7 @@ void getValidChassisPath(const std::shared_ptr<SensorsAsyncResp>& asyncResp,
                          Callback&& callback)
 {
     BMCWEB_LOG_DEBUG << "checkChassisId enter";
-    const std::array<const char*, 2> interfaces = {
-        "xyz.openbmc_project.Inventory.Item.Board",
+    const std::array<const char*, 1> interfaces = {
         "xyz.openbmc_project.Inventory.Item.Chassis"};
 
     auto respHandler =
@@ -514,8 +513,7 @@ void getChassis(const std::shared_ptr<SensorsAsyncResp>& sensorsAsyncResp,
                 Callback&& callback)
 {
     BMCWEB_LOG_DEBUG << "getChassis enter";
-    const std::array<const char*, 2> interfaces = {
-        "xyz.openbmc_project.Inventory.Item.Board",
+    const std::array<const char*, 1> interfaces = {
         "xyz.openbmc_project.Inventory.Item.Chassis"};
     auto respHandler = [callback{std::move(callback)}, sensorsAsyncResp](
                            const boost::system::error_code ec,
@@ -3105,8 +3103,7 @@ void getThermalMetrics(
     const std::shared_ptr<SensorsAsyncResp>& sensorsAsyncResp,
     Callback&& callback)
 {
-    const std::array<const char*, 2> interfaces = {
-        "xyz.openbmc_project.Inventory.Item.Board",
+    const std::array<const char*, 1> interfaces = {
         "xyz.openbmc_project.Inventory.Item.Chassis"};
     auto respHandler = [callback{std::move(callback)}, sensorsAsyncResp](
                            const boost::system::error_code ec,


### PR DESCRIPTION
When we tried to Move Inventory.Item.Board from Chassis to Assembly

as you see in this commit:- https://github.com/ibm-openbmc/bmcweb/pull/75

this commit brack Redfish validator and we below error
- 1 failProp errors in /redfish/v1/Systems/system
- 2 failProp errors in /redfish/v1/Managers/bmc
- 1 problemResource errors in /redfish/v1/Chassis/Blyth_Panel

This error message we get.
ERROR - Links.Chassis[0]: GET of resource at URI /redfish/v1/Chassis/Blyth_Panel returned HTTP 404. Check URI.

This error we get because we tried to move Item.Board from chassis to assembly that might be affected other place.
https://github.ibm.com/Abhishek-Patel/openbmc/commit/761a771cd99bc428bce6bcd526adad3f7c8b3b3a

To fix that, we remove Item.Board from all below files, So they unable to retrieve association path

- redfish-core/lib/power.hpp
- redfish-core/lib/redfish_util.hpp
- redfish-core/lib/sensors.hpp

Tested: Manually tested on the system and Run Redfish validator. Found no errors.