### PR TITLE
processorSummary edits

### DIFF
--- a/redfish-core/lib/systems.hpp
+++ b/redfish-core/lib/systems.hpp
@@ -314,8 +314,10 @@ inline void
                             crow::connections::systemBus->async_method_call(
                                 [aResp, service{connection.first},
                                  path](const boost::system::error_code ec2,
-                                       const std::vector<
-                                           std::pair<std::string, VariantType>>&
+                                       const std::vector<std::pair<
+                                           std::string,
+                                           std::variant<std::string, uint64_t,
+                                                        uint32_t, uint16_t>>>&
                                            properties) {
                                     if (ec2)
                                     {
@@ -385,10 +387,84 @@ inline void
                                             "OperationalStatus",
                                             "Functional");
 
-                                    // Get the MODEL from
-                                    // xyz.openbmc_project.Inventory.Decorator.Asset
-                                    // support it later as Model  is Empty
-                                    // currently.
+                                    for (const auto& property : properties)
+                                    {
+
+                                        if (property.first == "Family")
+                                        {
+                                            // Get the CPU Model
+                                            const std::string* modelStr =
+                                                std::get_if<std::string>(
+                                                    &property.second);
+                                            if (!modelStr)
+                                            {
+                                                messages::internalError(
+                                                    aResp->res);
+                                                return;
+                                            }
+                                            nlohmann::json& prevModel =
+                                                aResp->res.jsonValue
+                                                    ["ProcessorSummary"]
+                                                    ["Model"];
+                                            std::string* prevModelPtr =
+                                                prevModel
+                                                    .get_ptr<std::string*>();
+
+                                            // If CPU Models are different, use
+                                            // the first entry in alphabetical
+                                            // order
+
+                                            // If Model has never been set
+                                            // before, set it to *modelStr
+                                            if (prevModelPtr == nullptr)
+                                            {
+                                                prevModel = *modelStr;
+                                            }
+                                            // If Model has been set before,
+                                            // only change if new Model is
+                                            // higher in alphabetical order
+                                            else
+                                            {
+                                                if (*modelStr < *prevModelPtr)
+                                                {
+                                                    prevModel = *modelStr;
+                                                }
+                                            }
+                                        }
+
+                                        if (property.first == "CoreCount")
+                                        {
+
+                                            // Get CPU CoreCount and add it
+                                            // total
+                                            const uint16_t* coreCountVal =
+                                                std::get_if<uint16_t>(
+                                                    &property.second);
+
+                                            if (!coreCountVal)
+                                            {
+                                                messages::internalError(
+                                                    aResp->res);
+                                                return;
+                                            }
+
+                                            nlohmann::json& coreCount =
+                                                aResp->res.jsonValue
+                                                    ["ProcessorSummary"]
+                                                    ["CoreCount"];
+                                            uint64_t* coreCountPtr =
+                                                coreCount.get_ptr<uint64_t*>();
+
+                                            if (coreCountPtr == nullptr)
+                                            {
+                                                coreCount = *coreCountVal;
+                                            }
+                                            else
+                                            {
+                                                *coreCountPtr += *coreCountVal;
+                                            }
+                                        }
+                                    }
                                 },
                                 connection.first, path,
                                 "org.freedesktop.DBus.Properties", "GetAll",

--- a/redfish-core/lib/systems.hpp
+++ b/redfish-core/lib/systems.hpp
@@ -311,6 +311,57 @@ inline void
                             BMCWEB_LOG_DEBUG
                                 << "Found Cpu, now get its properties.";
 
+                            auto getCpuPresenceState =
+                                [aResp](const boost::system::error_code ec2,
+                                        const std::variant<bool>&
+                                            cpuPresenceCheck) {
+                                    if (ec2)
+                                    {
+                                        BMCWEB_LOG_ERROR
+                                            << "DBUS response error " << ec2;
+                                        return;
+                                    }
+                                    modifyCpuPresenceState(aResp,
+                                                           cpuPresenceCheck);
+                                };
+
+                            auto getCpuFunctionalState =
+                                [aResp](const boost::system::error_code ec2,
+                                        const std::variant<bool>&
+                                            cpuFunctionalCheck) {
+                                    if (ec2)
+                                    {
+                                        BMCWEB_LOG_ERROR
+                                            << "DBUS response error " << ec2;
+                                        return;
+                                    }
+                                    modifyCpuFunctionalState(
+                                        aResp, cpuFunctionalCheck);
+                                };
+
+                            // Get the Presence of CPU
+                            crow::connections::systemBus->async_method_call(
+                                std::move(getCpuPresenceState),
+                                connection.first, path,
+                                "org.freedesktop.DBus."
+                                "Properties",
+                                "Get",
+                                "xyz.openbmc_project.Inventory."
+                                "Item",
+                                "Present");
+
+                            // Get the Functional State
+                            crow::connections::systemBus->async_method_call(
+                                std::move(getCpuFunctionalState),
+                                connection.first, path,
+                                "org.freedesktop.DBus."
+                                "Properties",
+                                "Get",
+                                "xyz.openbmc_project.State."
+                                "Decorator."
+                                "OperationalStatus",
+                                "Functional");
+
                             crow::connections::systemBus->async_method_call(
                                 [aResp, service{connection.first},
                                  path](const boost::system::error_code ec2,
@@ -329,63 +380,6 @@ inline void
                                     BMCWEB_LOG_DEBUG << "Got "
                                                      << properties.size()
                                                      << " Cpu properties.";
-
-                                    auto getCpuPresenceState =
-                                        [aResp](
-                                            const boost::system::error_code ec3,
-                                            const std::variant<bool>&
-                                                cpuPresenceCheck) {
-                                            if (ec3)
-                                            {
-                                                BMCWEB_LOG_ERROR
-                                                    << "DBUS response error "
-                                                    << ec3;
-                                                return;
-                                            }
-                                            modifyCpuPresenceState(
-                                                aResp, cpuPresenceCheck);
-                                        };
-
-                                    auto getCpuFunctionalState =
-                                        [aResp](
-                                            const boost::system::error_code ec3,
-                                            const std::variant<bool>&
-                                                cpuFunctionalCheck) {
-                                            if (ec3)
-                                            {
-                                                BMCWEB_LOG_ERROR
-                                                    << "DBUS response error "
-                                                    << ec3;
-                                                return;
-                                            }
-                                            modifyCpuFunctionalState(
-                                                aResp, cpuFunctionalCheck);
-                                        };
-
-                                    // Get the Presence of CPU
-                                    crow::connections::systemBus
-                                        ->async_method_call(
-                                            std::move(getCpuPresenceState),
-                                            service, path,
-                                            "org.freedesktop.DBus."
-                                            "Properties",
-                                            "Get",
-                                            "xyz.openbmc_project.Inventory."
-                                            "Item",
-                                            "Present");
-
-                                    // Get the Functional State
-                                    crow::connections::systemBus
-                                        ->async_method_call(
-                                            std::move(getCpuFunctionalState),
-                                            service, path,
-                                            "org.freedesktop.DBus."
-                                            "Properties",
-                                            "Get",
-                                            "xyz.openbmc_project.State."
-                                            "Decorator."
-                                            "OperationalStatus",
-                                            "Functional");
 
                                     for (const auto& property : properties)
                                     {


### PR DESCRIPTION
Add Model & CoreCount to ProcessorSummary

In Redfish ComputerSystem schema, the ProcessorSummary parameter
lists summary information of the Processors on the system. This commit
adds the 'Model' and 'CoreCount' properties to ProcessorSummary.

If the CPU Models are different, then the 'Model' field takes the first
entry in alphabetical order.

Testing:

1. Redfish Validator Testing successfully passed.
2. Curl testing:

curl -k -H "X-Auth-Token: $tok" https://$bmc/redfish/v1/Systems/system

...
  "ProcessorSummary": {
    "CoreCount": 24,
    "Count": 2,
    "Model": "test_name",
    "Status": {
      "Health": "OK",
      "HealthRollup": "OK",
      "State": "Disabled"
    }
  },
...

Signed-off-by: Ali Ahmed <ama213000@gmail.com>
Change-Id: Idda4f20bd1bb3f5002791ad20787979c632ed5f0

------------------------------------------------------------------------------------------

Move nested dbus call in getComputerSystem

Dbus calls 'CpuPresenceState' and 'getCpuFunctionalState' do NOT call
out to xyz.openbmc_project.Inventory.Item.Cpu interface. Move their
calls to outside of the xyz.openbmc_project.Inventory.Item.Cpu loop.

Testing:

1. Redfish Validator Testing passed
2. Curl testing:

curl -k -H "X-Auth-Token: $tok" https://$bmc/redfish/v1/Systems/system
...
  "ProcessorSummary": {
    "CoreCount": 0,
    "Count": 2,
    "Model": "",
    "Status": {
      "Health": "OK",
      "HealthRollup": "OK",
      "State": "Enabled"
    }
  },
...

Signed-off-by: Ali Ahmed <ama213000@gmail.com>
Change-Id: Id4657836607a2261a188db8d565aaa2b1a414c5a