### PR TITLE
Clear UserSession in between requests

### DIFF
--- a/http/http_connection.hpp
+++ b/http/http_connection.hpp
@@ -262,6 +262,7 @@ class Connection :
             }
             sslUser.resize(lastChar);
             std::string unsupportedClientId = "";
+            sessionIsFromTransport = true;
             userSession = persistent_data::SessionStore::getInstance()
                               .generateUserSession(
                                   sslUser, req->ipAddress.to_string(),
@@ -575,6 +576,7 @@ class Connection :
                 {
                     BMCWEB_LOG_DEBUG << "Unable to get client IP";
                 }
+                sessionIsFromTransport = false;
                 userSession = crow::authorization::authenticate(
                     req->url, ip, res, method, parser->get().base(),
                     userSession);
@@ -708,6 +710,13 @@ class Connection :
                                                       // newly created parser
                 buffer.consume(buffer.size());
 
+                // If the session was built from the transport, we don't need to
+                // clear it.  All other sessions are generated per request.
+                if (!sessionIsFromTransport)
+                {
+                    userSession = nullptr;
+                }
+
                 req.emplace(parser->release());
                 doReadHeaders();
             });
@@ -793,6 +802,7 @@ class Connection :
     std::optional<crow::Request> req;
     crow::Response res;
 
+    bool sessionIsFromTransport = false;
     std::shared_ptr<persistent_data::UserSession> userSession;
 
     std::optional<size_t> timerCancelKey;


### PR DESCRIPTION
This upstream commit https://gerrit.openbmc-project.xyz/c/openbmc/bmcweb/+/46831 merged today. 

This is a straight cherry-pick. 
This should fix the CI fail we are seeing in our -30 PR’s.

Commit msg:
The previous commit moved userSession to possibly be a per-request
structure.  Previously, it was only a per-connection structure, so there
wasn't explicit clearing of it in between requests.  This can lead to
problems where a user remains authorized despite explicitly logging
themselves out.

Tested:
redfishtool -S Always -A Session -u root -p 0penBmc -vvvvvvvvv -r 192.168.7.2 raw GET /redfish/v1/Managers/bmc
Succeeded

Then a subsequent:
curl -vvvv --insecure  "https://192.168.7.2/redfish/v1/Managers/bmc"

Failed with 401

Signed-off-by: Ed Tanous <edtanous@google.com>
Change-Id: I5844406bd6bed628e5851d8c2f29af875adbaaff