### PR TITLE
Implement SubProcessors for processor core

### DIFF
--- a/redfish-core/include/redfish.hpp
+++ b/redfish-core/include/redfish.hpp
@@ -163,6 +163,8 @@ class RedfishService
         requestRoutesOperatingConfig(app);
         requestRoutesMemoryCollection(app);
         requestRoutesMemory(app);
+        requestRoutesSubProcessors(app);
+        requestRoutesSubProcessorsCore(app);
 
         requestRoutesSystemsCollection(app);
         requestRoutesSystems(app);

--- a/redfish-core/lib/processor.hpp
+++ b/redfish-core/lib/processor.hpp
@@ -774,6 +774,13 @@ inline void getProcessorData(const std::shared_ptr<bmcweb::AsyncResp>& aResp,
                              const std::string& objectPath,
                              const MapperServiceMap& serviceMap)
 {
+    aResp->res.jsonValue["@odata.type"] = "#Processor.v1_11_0.Processor";
+    aResp->res.jsonValue["@odata.id"] =
+        "/redfish/v1/Systems/system/Processors/" + processorId;
+    aResp->res.jsonValue["SubProcessors"] = {
+        {"@odata.id", "/redfish/v1/Systems/system/Processors/" + processorId +
+                          "/SubProcessors"}};
+
     for (const auto& [serviceName, interfaceList] : serviceMap)
     {
         bool assertInterface = false;
@@ -849,6 +856,281 @@ inline void getProcessorData(const std::shared_ptr<bmcweb::AsyncResp>& aResp,
             getLocationIndicatorActive(aResp, objectPath);
         }
     }
+}
+
+template <typename Handler>
+inline void getProcessorPaths(const std::shared_ptr<bmcweb::AsyncResp>& aResp,
+                              const std::string& processorId, Handler&& handler)
+{
+    crow::connections::systemBus->async_method_call(
+        [processorId, aResp, handler{std::move(handler)}](
+            const boost::system::error_code ec,
+            const std::vector<std::string>& subTreePaths) {
+            if (ec)
+            {
+                BMCWEB_LOG_ERROR << "DBUS response error";
+                // No processor objects found by mapper
+                if (ec.value() == boost::system::errc::io_error)
+                {
+                    messages::resourceNotFound(aResp->res,
+                                               "#Processor.v1_11_0.Processor",
+                                               processorId);
+                    return;
+                }
+
+                messages::internalError(aResp->res);
+                return;
+            }
+
+            for (const std::string& cpuPath : subTreePaths)
+            {
+                if (sdbusplus::message::object_path(cpuPath).filename() !=
+                    processorId)
+                {
+                    continue;
+                }
+
+                handler(cpuPath);
+                return;
+            }
+
+            // Object not found
+            messages::resourceNotFound(
+                aResp->res, "#Processor.v1_11_0.Processor", processorId);
+        },
+        "xyz.openbmc_project.ObjectMapper",
+        "/xyz/openbmc_project/object_mapper",
+        "xyz.openbmc_project.ObjectMapper", "GetSubTreePaths",
+        "/xyz/openbmc_project/inventory", 0,
+        std::array<const char*, 1>{"xyz.openbmc_project.Inventory.Item.Cpu"});
+}
+
+inline void
+    getCpuCoreDataByService(const std::shared_ptr<bmcweb::AsyncResp>& aResp,
+                            const std::string& service,
+                            const std::string& objPath)
+{
+    BMCWEB_LOG_DEBUG << "Get available system cpu core resources by service.";
+
+    aResp->res.jsonValue["Status"]["State"] = "Enabled";
+    aResp->res.jsonValue["Status"]["Health"] = "OK";
+
+    crow::connections::systemBus->async_method_call(
+        [objPath, aResp](const boost::system::error_code ec,
+                         const dbus::utility::ManagedObjectType& dbusData) {
+            if (ec)
+            {
+                BMCWEB_LOG_DEBUG << "DBUS response error, ec: " << ec.value();
+                messages::internalError(aResp->res);
+                return;
+            }
+
+            for (const auto& [path, interfaces] : dbusData)
+            {
+                if (path != objPath)
+                {
+                    continue;
+                }
+
+                bool present = true;
+                bool functional = true;
+
+                for (const auto& [interface, properties] : interfaces)
+                {
+                    if (interface == "xyz.openbmc_project.State."
+                                     "Decorator.OperationalStatus")
+                    {
+                        for (const auto& [proName, proValue] : properties)
+                        {
+                            if (proName == "Functional")
+                            {
+                                const bool* value =
+                                    std::get_if<bool>(&proValue);
+                                if (value == nullptr)
+                                {
+                                    messages::internalError(aResp->res);
+                                    return;
+                                }
+                                functional = *value;
+                            }
+                        }
+                    }
+                    else if (interface == "xyz.openbmc_project.Inventory.Item")
+                    {
+                        for (const auto& [proName, proValue] : properties)
+                        {
+                            if (proName == "Present")
+                            {
+                                const bool* value =
+                                    std::get_if<bool>(&proValue);
+                                if (value == nullptr)
+                                {
+                                    messages::internalError(aResp->res);
+                                    return;
+                                }
+                                present = *value;
+                            }
+                            else if (proName == "PrettyName")
+                            {
+                                const std::string* prettyName =
+                                    std::get_if<std::string>(&proValue);
+                                if (prettyName == nullptr)
+                                {
+                                    messages::internalError(aResp->res);
+                                    return;
+                                }
+                                aResp->res.jsonValue["Name"] = *prettyName;
+                            }
+                        }
+                    }
+                }
+
+                if (present == false)
+                {
+                    aResp->res.jsonValue["Status"]["State"] = "Absent";
+                }
+                else
+                {
+                    if (!functional)
+                    {
+                        aResp->res.jsonValue["Status"]["Health"] = "Critical";
+                    }
+                }
+            }
+        },
+        service, "/xyz/openbmc_project/inventory",
+        "org.freedesktop.DBus.ObjectManager", "GetManagedObjects");
+}
+
+inline void getSubProcessorData(const std::shared_ptr<bmcweb::AsyncResp>& aResp,
+                                const std::string& processorId,
+                                const std::string& coreId)
+{
+    BMCWEB_LOG_DEBUG << "Get available system sub processor resources.";
+
+    auto callback = [aResp, processorId, coreId](const std::string& cpuPath) {
+        crow::connections::systemBus->async_method_call(
+            [aResp, processorId, coreId](
+                const boost::system::error_code ec,
+                const boost::container::flat_map<
+                    std::string, boost::container::flat_map<
+                                     std::string, std::vector<std::string>>>&
+                    subtree) {
+                if (ec)
+                {
+                    BMCWEB_LOG_DEBUG << "DBUS response error, ec: "
+                                     << ec.value();
+                    // No processor objects found by mapper
+                    if (ec.value() == boost::system::errc::io_error)
+                    {
+                        messages::resourceNotFound(
+                            aResp->res, "#Processor.v1_11_0.Processor",
+                            processorId);
+                        return;
+                    }
+
+                    messages::internalError(aResp->res);
+                    return;
+                }
+
+                for (const auto& object : subtree)
+                {
+                    if (sdbusplus::message::object_path(object.first)
+                            .filename() != coreId)
+                    {
+                        continue;
+                    }
+
+                    aResp->res.jsonValue["@odata.type"] =
+                        "#Processor.v1_11_0.Processor";
+                    aResp->res.jsonValue["@odata.id"] =
+                        std::string("/redfish/v1/Systems/system/Processors/")
+                            .append(processorId)
+                            .append("/SubProcessors/")
+                            .append(coreId);
+                    aResp->res.jsonValue["Name"] = "SubProcessor";
+                    aResp->res.jsonValue["Id"] = coreId;
+
+                    for (const auto& service : object.second)
+                    {
+                        getCpuCoreDataByService(aResp, service.first,
+                                                object.first);
+                        break;
+                    }
+                    return;
+                }
+
+                if (subtree.size() != 0)
+                {
+                    // Object not found
+                    messages::resourceNotFound(
+                        aResp->res, "#Processor.v1_11_0.Processor", coreId);
+                    return;
+                }
+            },
+            "xyz.openbmc_project.ObjectMapper",
+            "/xyz/openbmc_project/object_mapper",
+            "xyz.openbmc_project.ObjectMapper", "GetSubTree", cpuPath, 0,
+            std::array<const char*, 1>{
+                "xyz.openbmc_project.Inventory.Item.CpuCore"});
+    };
+
+    getProcessorPaths(aResp, processorId, std::move(callback));
+}
+
+inline void
+    getSubProcessorMembers(const std::shared_ptr<bmcweb::AsyncResp>& aResp,
+                           const std::string& processorId)
+{
+    auto callback = [aResp, processorId](const std::string& cpuPath) {
+        crow::connections::systemBus->async_method_call(
+            [processorId, aResp](const boost::system::error_code ec,
+                                 const std::vector<std::string>& subTreePaths) {
+                if (ec)
+                {
+                    BMCWEB_LOG_ERROR << "DBUS response error";
+                    // No processor objects found by mapper
+                    if (ec.value() == boost::system::errc::io_error)
+                    {
+                        messages::resourceNotFound(
+                            aResp->res, "#Processor.v1_11_0.Processor",
+                            processorId);
+                        return;
+                    }
+
+                    messages::internalError(aResp->res);
+                    return;
+                }
+
+                aResp->res.jsonValue["@odata.type"] =
+                    "#ProcessorCollection.ProcessorCollection";
+                aResp->res.jsonValue["@odata.id"] =
+                    "/redfish/v1/Systems/system/Processors/" + processorId +
+                    "/SubProcessors";
+                aResp->res.jsonValue["Name"] = "SubProcessor Collection";
+                nlohmann::json& members = aResp->res.jsonValue["Members"];
+                members = nlohmann::json::array();
+                std::string subProcessorsPath =
+                    "/redfish/v1/Systems/system/Processors/" + processorId +
+                    "/SubProcessors/";
+                for (const std::string& corePath : subTreePaths)
+                {
+                    members.push_back(
+                        {{"@odata.id",
+                          subProcessorsPath +
+                              sdbusplus::message::object_path(corePath)
+                                  .filename()}});
+                }
+                aResp->res.jsonValue["Members@odata.count"] = members.size();
+            },
+            "xyz.openbmc_project.ObjectMapper",
+            "/xyz/openbmc_project/object_mapper",
+            "xyz.openbmc_project.ObjectMapper", "GetSubTreePaths", cpuPath, 0,
+            std::array<const char*, 1>{
+                "xyz.openbmc_project.Inventory.Item.CpuCore"});
+    };
+
+    getProcessorPaths(aResp, processorId, std::move(callback));
 }
 
 /**
@@ -1365,11 +1647,6 @@ inline void requestRoutesProcessor(App& app)
             [](const crow::Request&,
                const std::shared_ptr<bmcweb::AsyncResp>& asyncResp,
                const std::string& processorId) {
-                asyncResp->res.jsonValue["@odata.type"] =
-                    "#Processor.v1_11_0.Processor";
-                asyncResp->res.jsonValue["@odata.id"] =
-                    "/redfish/v1/Systems/system/Processors/" + processorId;
-
                 getProcessorObject(asyncResp, processorId, getProcessorData);
             });
 
@@ -1417,6 +1694,32 @@ inline void requestRoutesProcessor(App& app)
                     setProcessorObject(asyncResp, processorId,
                                        locationIndicatorActive);
                 }
+            });
+}
+
+inline void requestRoutesSubProcessors(App& app)
+{
+    BMCWEB_ROUTE(app,
+                 "/redfish/v1/Systems/system/Processors/<str>/SubProcessors")
+        .privileges(redfish::privileges::getProcessorCollection)
+        .methods(boost::beast::http::verb::get)(
+            [](const crow::Request&,
+               const std::shared_ptr<bmcweb::AsyncResp>& asyncResp,
+               const std::string& processorId) {
+                getSubProcessorMembers(asyncResp, processorId);
+            });
+}
+
+inline void requestRoutesSubProcessorsCore(App& app)
+{
+    BMCWEB_ROUTE(
+        app, "/redfish/v1/Systems/system/Processors/<str>/SubProcessors/<str>")
+        .privileges(redfish::privileges::getProcessor)
+        .methods(boost::beast::http::verb::get)(
+            [](const crow::Request&,
+               const std::shared_ptr<bmcweb::AsyncResp>& asyncResp,
+               const std::string& processorId, const std::string& coreId) {
+                getSubProcessorData(asyncResp, processorId, coreId);
             });
 }
 


### PR DESCRIPTION
Created this PR to pull the upstream patch (https://gerrit.openbmc-project.xyz/c/openbmc/bmcweb/+/38570/43) to address the below comment.

- Enabled the Hardware Isolation (aka Guard) feature for Core and Memory #77 (comment)

**Note:** This upstream patch is required to enable the manual guard feature. 