### PR TITLE
Trigger panel lamp test

### DIFF
--- a/redfish-core/lib/oem/ibm/lamp_test.hpp
+++ b/redfish-core/lib/oem/ibm/lamp_test.hpp
@@ -131,7 +131,7 @@ inline void setLampTestState(const std::shared_ptr<bmcweb::AsyncResp>& aResp,
             BMCWEB_LOG_DEBUG << "GetObjectType: " << service;
 
             crow::connections::systemBus->async_method_call(
-                [aResp](const boost::system::error_code ec) {
+                [aResp, state](const boost::system::error_code ec) {
                     if (ec)
                     {
                         BMCWEB_LOG_DEBUG
@@ -139,6 +139,18 @@ inline void setLampTestState(const std::shared_ptr<bmcweb::AsyncResp>& aResp,
                         messages::internalError(aResp->res);
                         return;
                     }
+                    crow::connections::systemBus->async_method_call(
+                        [aResp](const boost::system::error_code ec) {
+                            if (ec)
+                            {
+                                BMCWEB_LOG_DEBUG << "Panel Lamp test failed."
+                                                 << ec;
+                                messages::internalError(aResp->res);
+                                return;
+                            }
+                        },
+                        "com.ibm.PanelApp", "/com/ibm/panel_app",
+                        "com.ibm.panel", "TriggerPanelLampTest", bool(state));
                 },
                 service, "/xyz/openbmc_project/led/groups/lamp_test",
                 "org.freedesktop.DBus.Properties", "Set",


### PR DESCRIPTION
Whenever the lamp test request is sent to
the LedManager, panel lamp test needs to be handled.

Panel lamp test is nothing but validating the
back leds present in the lcd panel.

This can be done by calling the "TriggerPanelLampTest"
dbus api which is hosted by the panel service.

When the LampTest request is set to true in bmcweb,
along with other led tests(initiated by led manager),
"TriggerPanelLampTest" dbus method is called with input
set to true, which in turn sends the panel lamp test command
to the panel micro code which takes care of validating the
panel leds.

When the LampTest request is set to false in bmcweb,
led manager stops the lamp test abruptly. Similarly
the lamp test is made to stop in panel by calling
"TriggerPanelLampTest" dbus method with input set to
false, which in turn executes panel function 01 which
is the default display in panel.

Link to "TriggerPanelLampTest" dbus api : https://rchgit01.rchland.ibm.com/gerrit1/c/122940/1

Test:
Tested on rainier.

1.
curl -k -H "X-Auth-Token: $bmc_token" -X PATCH https://${bmc}/redfish/v1/Systems/system -d '{"Oem":{"IBM":{"LampTest": true}}}’

Journal Log:
Sep 15 17:30:35 rain71bmc bmcweb[1499]: (2021-09-15 17:30:35) [DEBUG "lamp_test.hpp":101] Set lamp test status.
Sep 15 17:30:35 rain71bmc bmcweb[1499]: (2021-09-15 17:30:35) [DEBUG "lamp_test.hpp":131] GetObjectType: xyz.openbmc_project.LED.GroupManager
Sep 15 17:30:35 rain71bmc phosphor-ledmanager[421]: Failed to set Asserted property
Sep 15 17:30:35 rain71bmc ibm-panel[1720]: Panel lamp test initiated.

2.
curl -k -H "X-Auth-Token: $bmc_token" -X PATCH https://${bmc}/redfish/v1/Systems/system -d '{"Oem":{"IBM":{"LampTest": false}}}’

Journal Log:
Sep 15 17:31:01 rain71bmc bmcweb[1499]: (2021-09-15 17:31:01) [DEBUG "lamp_test.hpp":101] Set lamp test status.
Sep 15 17:31:01 rain71bmc bmcweb[1499]: (2021-09-15 17:31:01) [DEBUG "lamp_test.hpp":131] GetObjectType: xyz.openbmc_project.LED.GroupManager
Sep 15 17:31:01 rain71bmc phosphor-ledmanager[421]: Failed to set Asserted property
Sep 15 17:31:01 rain71bmc ibm-panel[1720]: [1B blob data]
Sep 15 17:31:01 rain71bmc ibm-panel[1720]: L1 : 01     N    PVM
Sep 15 17:31:01 rain71bmc ibm-panel[1720]: L2 :             T

Signed-off-by: Priyanga Ramasamy <priyanga24@in.ibm.com>