### PR TITLE
Remove req changes

### DIFF
--- a/http/http_connection.hpp
+++ b/http/http_connection.hpp
@@ -262,7 +262,6 @@ class Connection :
             }
             sslUser.resize(lastChar);
             std::string unsupportedClientId = "";
-            sessionIsFromTransport = true;
             userSession = persistent_data::SessionStore::getInstance()
                               .generateUserSession(
                                   sslUser, req->ipAddress.to_string(),
@@ -576,7 +575,6 @@ class Connection :
                 {
                     BMCWEB_LOG_DEBUG << "Unable to get client IP";
                 }
-                sessionIsFromTransport = false;
                 userSession = crow::authorization::authenticate(
                     req->url, ip, res, method, parser->get().base(),
                     userSession);
@@ -710,13 +708,6 @@ class Connection :
                                                       // newly created parser
                 buffer.consume(buffer.size());
 
-                // If the session was built from the transport, we don't need to
-                // clear it.  All other sessions are generated per request.
-                if (!sessionIsFromTransport)
-                {
-                    userSession = nullptr;
-                }
-
                 req.emplace(parser->release());
                 doReadHeaders();
             });
@@ -802,7 +793,6 @@ class Connection :
     std::optional<crow::Request> req;
     crow::Response res;
 
-    bool sessionIsFromTransport = false;
     std::shared_ptr<persistent_data::UserSession> userSession;
 
     std::optional<size_t> timerCancelKey;

--- a/http/http_connection.hpp
+++ b/http/http_connection.hpp
@@ -316,14 +316,15 @@ class Connection :
         // Fetch the client IP address
         readClientIp();
 
+        bool isInvalidRequest = false;
+
         // Check for HTTP version 1.1.
         if (parser->get().version() == 11)
         {
             if (parser->get()[boost::beast::http::field::host].empty())
             {
+                isInvalidRequest = true;
                 res.result(boost::beast::http::status::bad_request);
-                completeRequest();
-                return;
             }
         }
 
@@ -346,32 +347,42 @@ class Connection :
             BMCWEB_LOG_ERROR << p.what();
         }
 
-        res.setCompleteRequestHandler(nullptr);
-        res.isAliveHelper = [this]() -> bool { return isAlive(); };
+        if (!isInvalidRequest)
+        {
+            res.setCompleteRequestHandler(nullptr);
+            res.isAliveHelper = [this]() -> bool { return isAlive(); };
 
-        req->ioService = static_cast<decltype(req->ioService)>(
-            &adaptor.get_executor().context());
+            req->ioService = static_cast<decltype(req->ioService)>(
+                &adaptor.get_executor().context());
 
-        if (res.completed)
+            if (!res.completed)
+            {
+                res.setCompleteRequestHandler([self(shared_from_this())] {
+                    boost::asio::post(self->adaptor.get_executor(),
+                                      [self] { self->completeRequest(); });
+                });
+                if (req->isUpgrade() &&
+                    boost::iequals(
+                        req->getHeaderValue(boost::beast::http::field::upgrade),
+                        "websocket"))
+                {
+                    handler->handleUpgrade(*req, res, std::move(adaptor));
+                    // delete lambda with self shared_ptr
+                    // to enable connection destruction
+                    res.setCompleteRequestHandler(nullptr);
+                    return;
+                }
+                auto asyncResp = std::make_shared<bmcweb::AsyncResp>(res);
+                handler->handle(*req, asyncResp);
+            }
+            else
+            {
+                completeRequest();
+            }
+        }
+        else
         {
             completeRequest();
-            return;
-        }
-        res.setCompleteRequestHandler([self(shared_from_this())] {
-            boost::asio::post(self->adaptor.get_executor(),
-                              [self] { self->completeRequest(); });
-        });
-
-        if (req->isUpgrade() &&
-            boost::iequals(
-                req->getHeaderValue(boost::beast::http::field::upgrade),
-                "websocket"))
-        {
-            handler->handleUpgrade(*req, res, std::move(adaptor));
-            // delete lambda with self shared_ptr
-            // to enable connection destruction
-            res.setCompleteRequestHandler(nullptr);
-            return;
         }
 
         std::string url(req->target());
@@ -391,6 +402,7 @@ class Connection :
 
     bool isAlive()
     {
+
         if constexpr (std::is_same_v<Adaptor,
                                      boost::beast::ssl_stream<
                                          boost::asio::ip::tcp::socket>>)

--- a/http/http_request.hpp
+++ b/http/http_request.hpp
@@ -18,7 +18,7 @@ namespace crow
 
 struct Request
 {
-    boost::beast::http::request<boost::beast::http::string_body> req;
+    boost::beast::http::request<boost::beast::http::string_body>& req;
     boost::beast::http::fields& fields;
     std::string_view url{};
     boost::urls::url_view urlView{};
@@ -34,9 +34,9 @@ struct Request
 
     std::string userRole{};
     Request(
-        boost::beast::http::request<boost::beast::http::string_body> reqIn) :
-        req(std::move(reqIn)),
-        fields(req.base()), body(req.body())
+        boost::beast::http::request<boost::beast::http::string_body>& reqIn) :
+        req(reqIn),
+        fields(reqIn.base()), body(reqIn.body())
     {}
 
     boost::beast::http::verb method() const

--- a/include/forward_unauthorized.hpp
+++ b/include/forward_unauthorized.hpp
@@ -8,19 +8,18 @@ namespace forward_unauthorized
 
 static bool hasWebuiRoute = false;
 
-inline void sendUnauthorized(std::string_view url, std::string_view userAgent,
-                             std::string_view accept, crow::Response& res)
+inline void sendUnauthorized(const crow::Request& req, crow::Response& res)
 {
     // If it's a browser connecting, don't send the HTTP authenticate
     // header, to avoid possible CSRF attacks with basic auth
-    if (http_helpers::requestPrefersHtml(accept))
+    if (http_helpers::requestPrefersHtml(req))
     {
         // If we have a webui installed, redirect to that login page
         if (hasWebuiRoute)
         {
             res.result(boost::beast::http::status::temporary_redirect);
             res.addHeader("Location",
-                          "/#/login?next=" + http_helpers::urlEncode(url));
+                          "/#/login?next=" + http_helpers::urlEncode(req.url));
         }
         else
         {
@@ -36,7 +35,7 @@ inline void sendUnauthorized(std::string_view url, std::string_view userAgent,
         // only send the WWW-authenticate header if this isn't a xhr
         // from the browser.  Most scripts, tend to not set a user-agent header.
         // So key off that to know whether or not we need to suggest basic auth
-        if (userAgent.empty())
+        if (req.getHeaderValue("User-Agent").empty())
         {
             res.addHeader("WWW-Authenticate", "Basic");
         }

--- a/include/http_utility.hpp
+++ b/include/http_utility.hpp
@@ -5,8 +5,9 @@
 
 namespace http_helpers
 {
-inline bool requestPrefersHtml(std::string_view header)
+inline bool requestPrefersHtml(const crow::Request& req)
 {
+    std::string_view header = req.getHeaderValue("accept");
     std::vector<std::string> encodings;
     // chrome currently sends 6 accepts headers, firefox sends 4.
     encodings.reserve(6);

--- a/include/json_html_serializer.hpp
+++ b/include/json_html_serializer.hpp
@@ -397,9 +397,8 @@ inline void dumpfloat(std::string& out, double number,
     static constexpr auto d = std::numeric_limits<double>::max_digits10;
 
     // the actual conversion
-    std::ptrdiff_t len =
-        (std::snprintf)(numberbuffer.data(), numberbuffer.size(), "%.*g", d,
-                        number);
+    std::ptrdiff_t len = (std::snprintf)(
+        numberbuffer.data(), numberbuffer.size(), "%.*g", d, number);
 
     // negative value indicates an error
     if (len <= 0)


### PR DESCRIPTION
This commit reverts 6 changes. 
The most major change this commit is reverting is `Change ownership of boost::req to crow::req`
We don't need these commits yet since we don't have things like query parameters. 

The problem we are seeing is bmcweb running out of memory on code update. 
The hope is reverting these 6 will fix the problem. 

The reverts are:
    Remove unused variables in connection class
    Rearrange/clean code in connection
    fix clang formatting
    Rearrange/clean code in connection
    Remove unused variables in connection class
    Change ownership of boost::req to crow::req

Signed-off-by: Gunnar Mills <gmills@us.ibm.com>
Tested: Pending 