### PR TITLE
Redfish: Implement HealthRollup in chassis schema

### DIFF
--- a/redfish-core/lib/chassis.hpp
+++ b/redfish-core/lib/chassis.hpp
@@ -240,7 +240,7 @@ inline void requestRoutesChassis(App& app)
                                     return;
                                 }
                                 health->inventory = std::move(*data);
-                                constexpr const std::array<const char*, 4>
+                                constexpr const std::array<const char*, 13>
                                     inventoryForChassis = {
                                         "xyz.openbmc_project.Inventory.Item."
                                         "Dimm",
@@ -249,7 +249,25 @@ inline void requestRoutesChassis(App& app)
                                         "xyz.openbmc_project.Inventory.Item."
                                         "PowerSupply",
                                         "xyz.openbmc_project.Inventory.Item."
-                                        "PCIeSlot"};
+                                        "Fan",
+                                        "xyz.openbmc_project.Inventory.Item."
+                                        "PCIeSlot",
+                                        "xyz.openbmc_project.Inventory.Item."
+                                        "Vrm",
+                                        "xyz.openbmc_project.Inventory.Item."
+                                        "Tpm",
+                                        "xyz.openbmc_project.Inventory.Item."
+                                        "Panel",
+                                        "xyz.openbmc_project.Inventory.Item."
+                                        "Battery",
+                                        "xyz.openbmc_project.Inventory.Item."
+                                        "DiskBackplane",
+                                        "xyz.openbmc_project.Inventory.Item."
+                                        "Board",
+                                        "xyz.openbmc_project.Inventory.Item."
+                                        "Board.Motherboard",
+                                        "xyz.openbmc_project.Inventory.Item."
+                                        "Connector"};
 
                                 crow::connections::systemBus->async_method_call(
                                     [health](const boost::system::error_code ec,

--- a/redfish-core/lib/chassis.hpp
+++ b/redfish-core/lib/chassis.hpp
@@ -240,6 +240,35 @@ inline void requestRoutesChassis(App& app)
                                     return;
                                 }
                                 health->inventory = std::move(*data);
+                                constexpr const std::array<const char*, 4>
+                                    inventoryForChassis = {
+                                        "xyz.openbmc_project.Inventory.Item."
+                                        "Dimm",
+                                        "xyz.openbmc_project.Inventory.Item."
+                                        "Cpu",
+                                        "xyz.openbmc_project.Inventory.Item."
+                                        "PowerSupply",
+                                        "xyz.openbmc_project.Inventory.Item."
+                                        "PCIeSlot"};
+
+                                crow::connections::systemBus->async_method_call(
+                                    [health](const boost::system::error_code ec,
+                                             std::vector<std::string>& resp) {
+                                        if (ec)
+                                        {
+                                            // no inventory
+                                            return;
+                                        }
+
+                                        health->inventory.insert(
+                                            health->inventory.end(),
+                                            resp.begin(), resp.end());
+                                    },
+                                    "xyz.openbmc_project.ObjectMapper",
+                                    "/xyz/openbmc_project/object_mapper",
+                                    "xyz.openbmc_project.ObjectMapper",
+                                    "GetSubTreePaths", "/", int32_t(0),
+                                    inventoryForChassis);
                             },
                             "xyz.openbmc_project.ObjectMapper",
                             path + "/all_sensors",

--- a/redfish-core/lib/health.hpp
+++ b/redfish-core/lib/health.hpp
@@ -126,7 +126,6 @@ struct HealthPopulate : std::enable_shared_from_this<HealthPopulate>
             if (boost::starts_with(path.str, globalInventoryPath) &&
                 boost::ends_with(path.str, "critical"))
             {
-                health = "Critical";
                 rollup = "Critical";
                 return;
             }


### PR DESCRIPTION
The health status of the current CPUs and powersupplies will not rollup
to chassis. This submission implements rollup of the health status of
CPUs and powersupplies to chassis.

Tested:
We need add the xyz.openbmc_project.Inventory.Item.Global interface to the chassis.
I create a critical association of powersupply1 using the same method as phosphor-logging:
https://github.com/openbmc/phosphor-logging/blob/76198a2ea2e3deb14078e0d3dd3932b657ddd9b8/extensions/openpower-pels/service_indicators.cpp#L83

Then the chassis HealthRollup will become critical:
curl -k -H "X-Auth-Token: $token" -X GET   https://${bmc}/redfish/v1/Chassis/chassis
"Status": {
    "Health": "OK",
    "HealthRollup": "Critical",
    "State": "Enabled"
  },

Signed-off-by: Chicago Duan <duanzhijia01@inspur.com>