### PR TITLE
Nullify HttpHeaders per the specification

### DIFF
--- a/redfish-core/lib/event_service.hpp
+++ b/redfish-core/lib/event_service.hpp
@@ -518,7 +518,8 @@ inline void requestRoutesEventDestination(App& app)
                 asyncResp->res.jsonValue["Context"] = subValue->customText;
                 asyncResp->res.jsonValue["SubscriptionType"] =
                     subValue->subscriptionType;
-                asyncResp->res.jsonValue["HttpHeaders"] = subValue->httpHeaders;
+                asyncResp->res.jsonValue["HttpHeaders"] =
+                    nlohmann::json::array();
                 asyncResp->res.jsonValue["EventFormatType"] =
                     subValue->eventFormatType;
                 asyncResp->res.jsonValue["RegistryPrefixes"] =


### PR DESCRIPTION
This commit: https://gerrit.openbmc-project.xyz/c/openbmc/bmcweb/+/46837 merged last week. 

This follows the spec. 
This should also fix 1 of the Validator errors George is seeing in -30.

![image](https://user-images.githubusercontent.com/5455127/134208468-ca1f8da4-83ef-4623-952c-412721ef0fa9.png)


Per the definition of HttpHeaders in the schema "This object shall be
null or an empty array in responses."  This commit does as the
specification commands.

In theory, this could break clients that were checking the HttpHeaders
after posting it, but it's not being put behind an option flag in this
patchset for a couple reasons:
1. This has the potential to leak security secrets, as the normal use
case for this is to put in Authorization headers.
2. Given that the most likely client that would "break" is the one doing
the POST to this API, and it already has the data, it seems unlikely
that there's any implementation that would explicitly check that the
returned object is identical to the sent one, especially if error codes
are handled properly.

Tested:
curl -vvvv --insecure -u root:0penBmc "https://192.168.7.2:443/redfish/v1/EventService/Subscriptions" -X POST -d "{\"Destination\":\"http://192.168.7.2/foo\",\"Context\":\"Public\",\"Protocol\":\"Redfish\",\"HttpHeaders\": [{\"Foo\": \"Bar\"}]}"
Succeeded with 200

curl -vvvv --insecure -u root:0penBmc "https://192.168.7.2/redfish/v1/EventService/Subscriptions/405645225"
Returned

"HttpHeaders": [],

As part of its object

Signed-off-by: Ed Tanous <edtanous@google.com>
Change-Id: I32181044d0af6b4395daea3f6ca4480022fc7553