### PR TITLE
Thermal: Fix bad merge conflict resolve

### DIFF
--- a/redfish-core/lib/chassis.hpp
+++ b/redfish-core/lib/chassis.hpp
@@ -410,15 +410,16 @@ inline void requestRoutesChassis(App& app)
                                     {"@odata.id", "/redfish/v1/Chassis/" +
                                                       chassisId + "/Thermal"}};
 
-                                asyncResp->res.jsonValue["ThermalSubsystem"] = {
-                                    {"@odata.id", "/redfish/v1/Chassis/" +
-                                                      chassisId +
-                                                      "/ThermalSubsystem"}};
                                 // Power object
                                 asyncResp->res.jsonValue["Power"] = {
                                     {"@odata.id", "/redfish/v1/Chassis/" +
                                                       chassisId + "/Power"}};
 #endif
+
+                                asyncResp->res.jsonValue["ThermalSubsystem"] = {
+                                    {"@odata.id", "/redfish/v1/Chassis/" +
+                                                      chassisId +
+                                                      "/ThermalSubsystem"}};
 
                                 asyncResp->res.jsonValue["PowerSubsystem"] = {
                                     {"@odata.id", "/redfish/v1/Chassis/" +


### PR DESCRIPTION
https://github.ibm.com/openbmc/openbmc/pull/1376 is turning off
the old Power/Thermal.

When testing I did not see the ThermalSubsystem, on investigation
noticed this bad merge conflict resolve.

ThermalSubsystem should not be part of the BMCWEB_ALLOW_DEPRECATED_POWER_THERMAL
since is new and not deprecated. 

Tested: NONE
Signed-off-by: Gunnar Mills <gmills@us.ibm.com>