### PR TITLE
Move TPMRequiredToBoot under Boot for PATCH call

### DIFF
--- a/redfish-core/lib/systems.hpp
+++ b/redfish-core/lib/systems.hpp
@@ -2856,7 +2856,6 @@ inline void requestRoutesSystems(App& app)
                 std::optional<std::string> assetTag;
                 std::optional<std::string> powerRestorePolicy;
                 std::optional<std::string> powerMode;
-                std::optional<bool> trustedModuleRequiredToBoot;
                 std::optional<nlohmann::json> oem;
 
                 if (!json_util::readJson(
@@ -2864,9 +2863,7 @@ inline void requestRoutesSystems(App& app)
                         "LocationIndicatorActive", locationIndicatorActive,
                         "Boot", bootProps, "WatchdogTimer", wdtTimerProps,
                         "PowerRestorePolicy", powerRestorePolicy, "AssetTag",
-                        assetTag, "PowerMode", powerMode,
-                        "TrustedModuleRequiredToBoot",
-                        trustedModuleRequiredToBoot, "Oem", oem))
+                        assetTag, "PowerMode", powerMode, "Oem", oem))
                 {
                     return;
                 }
@@ -2898,13 +2895,16 @@ inline void requestRoutesSystems(App& app)
                     std::optional<std::string> bootType;
                     std::optional<std::string> bootEnable;
                     std::optional<std::string> automaticRetryConfig;
+                    std::optional<bool> trustedModuleRequiredToBoot;
 
                     if (!json_util::readJson(
                             *bootProps, asyncResp->res,
                             "BootSourceOverrideTarget", bootSource,
                             "BootSourceOverrideMode", bootType,
                             "BootSourceOverrideEnabled", bootEnable,
-                            "AutomaticRetryConfig", automaticRetryConfig))
+                            "AutomaticRetryConfig", automaticRetryConfig,
+                            "TrustedModuleRequiredToBoot",
+                            trustedModuleRequiredToBoot))
                     {
                         return;
                     }
@@ -2917,6 +2917,12 @@ inline void requestRoutesSystems(App& app)
                     if (automaticRetryConfig)
                     {
                         setAutomaticRetry(asyncResp, *automaticRetryConfig);
+                    }
+
+                    if (trustedModuleRequiredToBoot)
+                    {
+                        setTrustedModuleRequiredToBoot(
+                            asyncResp, *trustedModuleRequiredToBoot);
                     }
                 }
 
@@ -2945,12 +2951,6 @@ inline void requestRoutesSystems(App& app)
                 if (powerMode)
                 {
                     setPowerMode(asyncResp, *powerMode);
-                }
-
-                if (trustedModuleRequiredToBoot)
-                {
-                    setTrustedModuleRequiredToBoot(
-                        asyncResp, *trustedModuleRequiredToBoot);
                 }
 
                 if (oem)


### PR DESCRIPTION
TrustedModuleRequiredToBoot is a sub-parameter of the 'Boot' parameter.
Edits the patch code to make sure the patch happens under
'{"Boot":{"TrustedModuleRequiredToBoot": false}}', instead of current:
'{"TrustedModuleRequiredToBoot":false}'.

Testing:

1) Curl testing:

curl -k -H "X-Auth-Token: $token" -X PATCH \
-d '{"Boot":{"TrustedModuleRequiredToBoot": true}}' \
https://${bmc}/redfish/v1/Systems/system

curl -k -H "X-Auth-Token: $token" \
https://${bmc}/redfish/v1/Systems/system

{
...
  "Boot": {
    "AutomaticRetryAttempts": 3,
    "AutomaticRetryConfig": "Disabled",
    "AutomaticRetryConfig@Redfish.AllowableValues": [
      "Disabled",
      "RetryAttempts"
    ],
    "BootSourceOverrideEnabled": "Disabled",
    "BootSourceOverrideTarget": "BiosSetup",
    "BootSourceOverrideTarget@Redfish.AllowableValues": [
      "None",
      "Pxe",
      "Hdd",
      "Cd",
      "Diags",
      "BiosSetup",
      "Usb"
    ],
    "TrustedModuleRequiredToBoot": "Required"
  },
...
}

Signed-off-by: Ali Ahmed <ama213000@gmail.com>
Change-Id: I70b26a8e3c7282fa628dcc149d1328a8dc9f0b8b