### PR TITLE
VMI Cert: Increase wait timeout for client certificate

### DIFF
--- a/include/ibm/management_console_rest.hpp
+++ b/include/ibm/management_console_rest.hpp
@@ -833,7 +833,7 @@ void handleCsrRequest(const std::shared_ptr<bmcweb::AsyncResp>& asyncResp,
         std::make_shared<boost::asio::steady_timer>(
             crow::connections::systemBus->get_io_context());
 
-    timeout->expires_after(std::chrono::seconds(5));
+    timeout->expires_after(std::chrono::seconds(60));
     crow::connections::systemBus->async_method_call(
         [asyncResp, timeout](const boost::system::error_code ec,
                              sdbusplus::message::message& m) {
@@ -879,10 +879,10 @@ void handleCsrRequest(const std::shared_ptr<bmcweb::AsyncResp>& asyncResp,
                 }
 
                 timeout->cancel();
-                asyncResp->res.result(
-                    boost::beast::http::status::internal_server_error);
-                asyncResp->res.jsonValue["Description"] =
-                    "Timed out waiting for HostInterface to serve request";
+                redfish::messages::serviceTemporarilyUnavailable(
+                    asyncResp->res, std::to_string(60));
+                BMCWEB_LOG_INFO
+                    << "Timed out waiting for HostInterface to serve request";
             };
 
             timeout->async_wait(timeoutHandler);


### PR DESCRIPTION
This commit is a workaround to fix HMC connection incomplete issue due to VMI delays
in signing client certificate.

we are yet to finalise handling this case. this is a workaround to unblock HMC