### PR TITLE
Add ServiceProviderNotify

### DIFF
--- a/redfish-core/lib/log_services.hpp
+++ b/redfish-core/lib/log_services.hpp
@@ -1553,6 +1553,7 @@ inline void requestRoutesDBusEventLogEntryCollection(App& app)
                         std::string* message = nullptr;
                         std::string* filePath = nullptr;
                         bool resolved = false;
+                        bool serviceProviderNotified = false;
                         for (auto& interfaceMap : objectPath.second)
                         {
                             if (interfaceMap.first ==
@@ -1612,6 +1613,22 @@ inline void requestRoutesDBusEventLogEntryCollection(App& app)
                                         }
                                         resolved = *resolveptr;
                                     }
+                                    else if (propertyMap.first ==
+                                             "ServiceProviderNotify")
+                                    {
+                                        bool* serviceProviderNotifiedptr =
+                                            std::get_if<bool>(
+                                                &propertyMap.second);
+                                        if (serviceProviderNotifiedptr ==
+                                            nullptr)
+                                        {
+                                            messages::internalError(
+                                                asyncResp->res);
+                                            return;
+                                        }
+                                        serviceProviderNotified =
+                                            *serviceProviderNotifiedptr;
+                                    }
                                 }
                                 if (id == nullptr || message == nullptr ||
                                     severity == nullptr)
@@ -1643,7 +1660,7 @@ inline void requestRoutesDBusEventLogEntryCollection(App& app)
                         }
                         entriesArray.push_back({});
                         nlohmann::json& thisEntry = entriesArray.back();
-                        thisEntry["@odata.type"] = "#LogEntry.v1_8_0.LogEntry";
+                        thisEntry["@odata.type"] = "#LogEntry.v1_9_0.LogEntry";
                         thisEntry["@odata.id"] =
                             "/redfish/v1/Systems/system/"
                             "LogServices/EventLog/Entries/" +
@@ -1652,6 +1669,8 @@ inline void requestRoutesDBusEventLogEntryCollection(App& app)
                         thisEntry["Id"] = std::to_string(*id);
                         thisEntry["Message"] = *message;
                         thisEntry["Resolved"] = resolved;
+                        thisEntry["ServiceProviderNotified"] =
+                            serviceProviderNotified;
                         thisEntry["EntryType"] = "Event";
                         thisEntry["Severity"] =
                             translateSeverityDbusToRedfish(*severity);
@@ -1720,6 +1739,7 @@ inline void requestRoutesDBusEventLogEntry(App& app)
                         std::string* severity = nullptr;
                         std::string* message = nullptr;
                         std::string* filePath = nullptr;
+                        bool serviceProviderNotified = false;
                         bool resolved = false;
 
                         for (auto& propertyMap : resp)
@@ -1775,6 +1795,19 @@ inline void requestRoutesDBusEventLogEntry(App& app)
                                 filePath = std::get_if<std::string>(
                                     &propertyMap.second);
                             }
+                            else if (propertyMap.first ==
+                                     "ServiceProviderNotify")
+                            {
+                                bool* serviceProviderNotifiedptr =
+                                    std::get_if<bool>(&propertyMap.second);
+                                if (serviceProviderNotifiedptr == nullptr)
+                                {
+                                    messages::internalError(asyncResp->res);
+                                    return;
+                                }
+                                serviceProviderNotified =
+                                    *serviceProviderNotifiedptr;
+                            }
                         }
                         if (id == nullptr || message == nullptr ||
                             severity == nullptr)
@@ -1783,7 +1816,7 @@ inline void requestRoutesDBusEventLogEntry(App& app)
                             return;
                         }
                         asyncResp->res.jsonValue["@odata.type"] =
-                            "#LogEntry.v1_8_0.LogEntry";
+                            "#LogEntry.v1_9_0.LogEntry";
                         asyncResp->res.jsonValue["@odata.id"] =
                             "/redfish/v1/Systems/system/LogServices/EventLog/"
                             "Entries/" +
@@ -1793,6 +1826,8 @@ inline void requestRoutesDBusEventLogEntry(App& app)
                         asyncResp->res.jsonValue["Id"] = std::to_string(*id);
                         asyncResp->res.jsonValue["Message"] = *message;
                         asyncResp->res.jsonValue["Resolved"] = resolved;
+                        asyncResp->res.jsonValue["ServiceProviderNotified"] =
+                            serviceProviderNotified;
                         asyncResp->res.jsonValue["EntryType"] = "Event";
                         asyncResp->res.jsonValue["Severity"] =
                             translateSeverityDbusToRedfish(*severity);


### PR DESCRIPTION
This upstream  commit: https://gerrit.openbmc-project.xyz/c/openbmc/bmcweb/+/46886
Add a ServiceProviderNotify property that can be used to indicate that
this event log should be notified to the service provider, if that is
implemented on the system.

ServiceProviderNotified is boolean true if notified, false otherwise.

@odata.type updated to  "#LogEntry.v1_9_0.LogEntry" to support
ServiceProviderNotified.

Tested:
 Manually tested on the system, Run Redfish validator. Found no error.

  curl -k -H "X-Auth-Token: $token" -X GET
  https://${bmc}/redfish/v1/Systems/system/LogServices/EventLog/Entries
  /{id}

  {
    "@odata.id": "/redfish/v1/Systems/system/LogServices/EventLog/
Entries/1",
    "@odata.type": "#LogEntry.v1_9_0.LogEntry",
    "AdditionalDataURI": "/redfish/v1/Systems/system/LogServices/
EventLog/attachment/1",
    "ServiceProviderNotified": true,
    "Severity": "OK"

    ...

  }

  curl -k -H "X-Auth-Token: $token" -X GET
  https://${bmc}/redfish/v1/Systems/system/LogServices/EventLog/Entries
  {
    "@odata.id": "/redfish/v1/Systems/system/LogServices/EventLog/
Entries",
    "@odata.type": "#LogEntryCollection.LogEntryCollection",
    "Description": "Collection of System Event Log Entries",
    "Members": [
      {
        "@odata.id": "/redfish/v1/Systems/system/LogServices/EventLog/
Entries/1",
        "@odata.type": "#LogEntry.v1_9_0.LogEntry",
        "AdditionalDataURI": "/redfish/v1/Systems/system/LogServices/
EventLog/attachment/1",
        "ServiceProviderNotified": true,
        "Severity": "OK"

        ...

      }

      ...
      ...

    ],
    "Members@odata.count": 82,
    "Name": "System Event Log Entries"
  }

Signed-off-by: Abhishek Patel <Abhishek.Patel@ibm.com>
Change-Id: I774bfec157481ccc9b4966bf5e8cc8f7d9a06fd0