### PR TITLE
Add support for redfish StopBootOnFault

### DIFF
--- a/redfish-core/lib/systems.hpp
+++ b/redfish-core/lib/systems.hpp
@@ -1379,6 +1379,102 @@ inline void
 }
 
 /**
+ * @brief Stop Boot On Fault over DBUS.
+ *
+ * @param[in] aResp     Shared pointer for generating response message.
+ *
+ * @return None.
+ */
+inline void getStopBootOnFault(const std::shared_ptr<bmcweb::AsyncResp>& aResp)
+{
+    BMCWEB_LOG_DEBUG << "Get Stop Boot On Fault";
+
+    // Get Stop Boot On Fault object path:
+    crow::connections::systemBus->async_method_call(
+        [aResp](
+            const boost::system::error_code ec,
+            const std::vector<std::pair<
+                std::string,
+                std::vector<std::pair<std::string, std::vector<std::string>>>>>&
+                subtree) {
+            if (ec)
+            {
+                messages::internalError(aResp->res);
+                return;
+            }
+            if (subtree.size() == 0)
+            {
+                return;
+            }
+            if (subtree.size() > 1)
+            {
+                // More then one StopBootOnFault object is not supported and is
+                // an error
+                BMCWEB_LOG_DEBUG << "Found more than 1 system D-Bus "
+                                    "StopBootOnFault objects: "
+                                 << subtree.size();
+                messages::internalError(aResp->res);
+                return;
+            }
+            if (subtree[0].first.empty() || subtree[0].second.size() != 1)
+            {
+                BMCWEB_LOG_DEBUG << "StopBootOnFault mapper error!";
+                messages::internalError(aResp->res);
+                return;
+            }
+            const std::string& path = subtree[0].first;
+            const std::string& service = subtree[0].second.begin()->first;
+            if (service.empty())
+            {
+                BMCWEB_LOG_DEBUG << "StopBootOnFault service mapper error!";
+                messages::internalError(aResp->res);
+                return;
+            }
+            // Valid Stop Boot On Fault object found, now read the current value
+            crow::connections::systemBus->async_method_call(
+                [aResp](const boost::system::error_code ec,
+                        std::variant<bool>& quiesceOnHwError) {
+                    if (ec)
+                    {
+                        BMCWEB_LOG_DEBUG
+                            << "DBUS response error on StopBootOnFault Get : "
+                            << ec;
+                        messages::internalError(aResp->res);
+                        return;
+                    }
+
+                    const bool* quiesceOnHwErrorPtr =
+                        std::get_if<bool>(&quiesceOnHwError);
+
+                    if (!quiesceOnHwErrorPtr)
+                    {
+                        messages::internalError(aResp->res);
+                        return;
+                    }
+
+                    BMCWEB_LOG_DEBUG << "Stop Boot On Fault: "
+                                     << *quiesceOnHwErrorPtr;
+                    if (*quiesceOnHwErrorPtr == true)
+                    {
+                        aResp->res.jsonValue["Boot"]["StopBootOnFault"] =
+                            "AnyFault";
+                    }
+                    else
+                    {
+                        aResp->res.jsonValue["Boot"]["StopBootOnFault"] =
+                            "Never";
+                    }
+                },
+                service, path, "org.freedesktop.DBus.Properties", "Get",
+                "xyz.openbmc_project.Logging.Settings", "QuiesceOnHwError");
+        },
+        "xyz.openbmc_project.ObjectMapper",
+        "/xyz/openbmc_project/object_mapper",
+        "xyz.openbmc_project.ObjectMapper", "GetSubTree", "/", 0,
+        std::array<const char*, 1>{"xyz.openbmc_project.Logging.Settings"});
+}
+
+/**
  * @brief Get TrustedModuleRequiredToBoot property. Determines whether or not
  * TPM is required for booting the host.
  *
@@ -1887,6 +1983,116 @@ inline void setAssetTag(const std::shared_ptr<bmcweb::AsyncResp>& aResp,
         "/xyz/openbmc_project/inventory", int32_t(0),
         std::array<const char*, 1>{
             "xyz.openbmc_project.Inventory.Item.System"});
+}
+
+/**
+ * @brief Validate the specified stopBootOnFault is valid and return the
+ * stopBootOnFault name associated with that string
+ *
+ * @param[in] aResp   Shared pointer for generating response message.
+ * @param[in] stopBootOnFaultString  String representing the desired
+ * stopBootOnFault
+ *
+ * @return stopBootOnFault value or empty  if incoming value is not valid
+ */
+inline std::optional<bool>
+    validstopBootOnFault(const std::string& stopBootOnFaultString)
+{
+    std::optional<bool> validstopBootEnabled;
+    if (stopBootOnFaultString == "AnyFault")
+    {
+        return true;
+    }
+    if (stopBootOnFaultString == "Never")
+    {
+        return false;
+    }
+    return std::nullopt;
+}
+
+/**
+ * @brief Sets stopBootOnFault
+ *
+ * @param[in] aResp   Shared pointer for generating response message.
+ * @param[in] stopBootOnFault  "StopBootOnFault" from request.
+ *
+ * @return None.
+ */
+inline void setStopBootOnFault(const std::shared_ptr<bmcweb::AsyncResp>& aResp,
+                               const std::string& stopBootOnFault)
+{
+    BMCWEB_LOG_DEBUG << "Set Stop Boot On Fault.";
+
+    std::optional<bool> stopBootEnabled = validstopBootOnFault(stopBootOnFault);
+
+    if (!stopBootEnabled)
+    {
+        return;
+    }
+    bool autoStopBootEnabled = *stopBootEnabled;
+
+    crow::connections::systemBus->async_method_call(
+        [aResp, autoStopBootEnabled](
+            const boost::system::error_code ec,
+            const std::vector<std::pair<
+                std::string,
+                std::vector<std::pair<std::string, std::vector<std::string>>>>>&
+                subtree) {
+            if (ec)
+            {
+                BMCWEB_LOG_DEBUG
+                    << "DBUS response error on StopBootOnFault GetSubTree "
+                    << ec;
+                messages::internalError(aResp->res);
+                return;
+            }
+            if (subtree.size() == 0)
+            {
+                messages::propertyValueNotInList(aResp->res, "ComputerSystem",
+                                                 "StopBootOnFault");
+                return;
+            }
+            if (subtree.size() > 1)
+            {
+                // More then one StopBootOnFault object is not supported and is
+                // an error
+                BMCWEB_LOG_DEBUG << "Found more than 1 system D-Bus "
+                                    "StopBootOnFault objects: "
+                                 << subtree.size();
+                messages::internalError(aResp->res);
+                return;
+            }
+            if (subtree[0].first.empty() || subtree[0].second.size() != 1)
+            {
+                BMCWEB_LOG_DEBUG << "StopBootOnFault mapper error!";
+                messages::internalError(aResp->res);
+                return;
+            }
+            const std::string& path = subtree[0].first;
+            const std::string& service = subtree[0].second.begin()->first;
+            if (service.empty())
+            {
+                BMCWEB_LOG_DEBUG << "StopBootOnFault service mapper error!";
+                messages::internalError(aResp->res);
+                return;
+            }
+
+            crow::connections::systemBus->async_method_call(
+                [aResp](const boost::system::error_code ec) {
+                    if (ec)
+                    {
+                        messages::internalError(aResp->res);
+                        return;
+                    }
+                },
+                service, path, "org.freedesktop.DBus.Properties", "Set",
+                "xyz.openbmc_project.Logging.Settings", "QuiesceOnHwError",
+                std::variant<bool>(autoStopBootEnabled));
+        },
+        "xyz.openbmc_project.ObjectMapper",
+        "/xyz/openbmc_project/object_mapper",
+        "xyz.openbmc_project.ObjectMapper", "GetSubTree", "/", 0,
+        std::array<const char*, 1>{"xyz.openbmc_project.Logging.Settings"});
 }
 
 /**
@@ -2833,6 +3039,7 @@ inline void requestRoutesSystems(App& app)
             getPCIeDeviceList(asyncResp, "PCIeDevices");
             getHostWatchdogTimer(asyncResp);
             getPowerRestorePolicy(asyncResp);
+            getStopBootOnFault(asyncResp);
             getAutomaticRetry(asyncResp);
             getLastResetTime(asyncResp);
 #ifdef BMCWEB_ENABLE_IBM_LAMP_TEST
@@ -2896,6 +3103,7 @@ inline void requestRoutesSystems(App& app)
                     std::optional<std::string> bootEnable;
                     std::optional<std::string> automaticRetryConfig;
                     std::optional<bool> trustedModuleRequiredToBoot;
+                    std::optional<std::string> stopBootOnFault;
 
                     if (!json_util::readJson(
                             *bootProps, asyncResp->res,
@@ -2904,7 +3112,8 @@ inline void requestRoutesSystems(App& app)
                             "BootSourceOverrideEnabled", bootEnable,
                             "AutomaticRetryConfig", automaticRetryConfig,
                             "TrustedModuleRequiredToBoot",
-                            trustedModuleRequiredToBoot))
+                            trustedModuleRequiredToBoot, "StopBootOnFault",
+                            stopBootOnFault))
                     {
                         return;
                     }
@@ -2918,11 +3127,14 @@ inline void requestRoutesSystems(App& app)
                     {
                         setAutomaticRetry(asyncResp, *automaticRetryConfig);
                     }
-
                     if (trustedModuleRequiredToBoot)
                     {
                         setTrustedModuleRequiredToBoot(
                             asyncResp, *trustedModuleRequiredToBoot);
+                    }
+                    if (stopBootOnFault)
+                    {
+                        setStopBootOnFault(asyncResp, *stopBootOnFault);
                     }
                 }
 
@@ -2988,7 +3200,6 @@ inline void requestRoutesSystems(App& app)
  */
 inline void requestRoutesSystemResetActionInfo(App& app)
 {
-
     /**
      * Functions triggers appropriate requests on DBus
      */


### PR DESCRIPTION
This commit is added get and set for StopBootOnFault Policy.
The StopBootOnFault is defined in ComputerSystem(boot).
It contains two values "Never" and "AnyFault".

ref:https://redfish.dmtf.org/schemas/v1/ComputerSystem.v1_15_0.json

Tested:

1.Validator passes

2.doGet method to get StopBootOnFault.

curl -k -H "X-Auth-Token: $token" -X GET
https://${bmc}/redfish/v1/Systems/system
{
  "@odata.id": "/redfish/v1/Systems/system",
  "@odata.type": "#ComputerSystem.v1_13_0.ComputerSystem",
  ...
  "Boot": {
    "AutomaticRetryAttempts": 3,
    "AutomaticRetryConfig": "RetryAttempts",
    "AutomaticRetryConfig@Redfish.AllowableValues": [
      "Disabled",
      "RetryAttempts"
    ],
    "BootSourceOverrideEnabled": "Disabled",
    "BootSourceOverrideMode": "Legacy",
    "BootSourceOverrideTarget": "None",
    "BootSourceOverrideTarget@Redfish.AllowableValues": [
      "None",
      "Pxe",
      "Hdd",
      "Cd",
      "Diags",
      "BiosSetup",
      "Usb"
    ],
    "RemainingAutomaticRetryAttempts": 3,
    "StopBootOnFault": "Never"
  },
...
}

3.doPatch method set the "StopBootOnFault" property
to AnyFault or Never and report error when set to other values

curl -k -H "X-Auth-Token: $token" -X GET
https://${bmc}/redfish/v1/Systems/system
{
  "@odata.id": "/redfish/v1/Systems/system",
  "@odata.type": "#ComputerSystem.v1_15_0.ComputerSystem",
  ...
  "Boot": {
    "AutomaticRetryAttempts": 3,
    "AutomaticRetryConfig": "RetryAttempts",
    "AutomaticRetryConfig@Redfish.AllowableValues": [
      "Disabled",
      "RetryAttempts"
    ],
    "BootSourceOverrideEnabled": "Disabled",
    "BootSourceOverrideMode": "Legacy",
    "BootSourceOverrideTarget": "None",
    "BootSourceOverrideTarget@Redfish.AllowableValues": [
      "None",
      "Pxe",
      "Hdd",
      "Cd",
      "Diags",
      "BiosSetup",
      "Usb"
    ],
    "RemainingAutomaticRetryAttempts": 3,
    "StopBootOnFault": "Never"
  },
  ...
}

curl -k -H "X-Auth-Token: $token" -X PATCH -d
'{ "Boot" :{"StopBootOnFault":"AnyFault"}}'
https://${bmc}/redfish/v1/Systems/system

A few seconds later,
curl -k -H "X-Auth-Token: $token" -X GET
https://${bmc}/redfish/v1/Systems/system
{
  "@odata.id": "/redfish/v1/Systems/system",
  "@odata.type": "#ComputerSystem.v1_15_0.ComputerSystem",
  ...
  "Boot": {
    "AutomaticRetryAttempts": 3,
    "AutomaticRetryConfig": "RetryAttempts",
    "AutomaticRetryConfig@Redfish.AllowableValues": [
      "Disabled",
      "RetryAttempts"
    ],
    "BootSourceOverrideEnabled": "Disabled",
    "BootSourceOverrideMode": "Legacy",
    "BootSourceOverrideTarget": "None",
    "BootSourceOverrideTarget@Redfish.AllowableValues": [
      "None",
      "Pxe",
      "Hdd",
      "Cd",
      "Diags",
      "BiosSetup",
      "Usb"
    ],
    "RemainingAutomaticRetryAttempts": 3,
    "StopBootOnFault": "AnyFault"
  },
  ...
}
curl -k -H "X-Auth-Token: $token" -X PATCH -d
'{ "Boot" :{"StopBootOnFault":"Never"}}'
https://${bmc}/redfish/v1/Systems/system

A few seconds later,
curl -k -H "X-Auth-Token: $token" -X GET
https://${bmc}/redfish/v1/Systems/system
{
  "@odata.id": "/redfish/v1/Systems/system",
  "@odata.type": "#ComputerSystem.v1_15_0.ComputerSystem",
  ...
  "Boot": {
    "AutomaticRetryAttempts": 3,
    "AutomaticRetryConfig": "RetryAttempts",
    "AutomaticRetryConfig@Redfish.AllowableValues": [
      "Disabled",
      "RetryAttempts"
    ],
    "BootSourceOverrideEnabled": "Disabled",
    "BootSourceOverrideMode": "Legacy",
    "BootSourceOverrideTarget": "None",
    "BootSourceOverrideTarget@Redfish.AllowableValues": [
      "None",
      "Pxe",
      "Hdd",
      "Cd",
      "Diags",
      "BiosSetup",
      "Usb"
    ],
    "RemainingAutomaticRetryAttempts": 3,
    "StopBootOnFault": "Never"
  },
  ...
}
curl -k -H "X-Auth-Token: $token" -X PATCH -d
'{ "Boot" :{"StopBootOnFault":"ERROR"}}'
https://${bmc}/redfish/v1/Systems/system
{
  "StopBootOnFault@Message.ExtendedInfo": [
    {
      "@odata.type": "#Message.v1_1_1.Message",
      "Message": "The value ERROR for the property StopBootOnFault
                  is not in the list of acceptable values.",
      "MessageArgs": [
        "ERROR",
        "StopBootOnFault"
      ],
      "MessageId": "Base.1.8.1.PropertyValueNotInList",
      "MessageSeverity": "Warning",
      "Resolution": "Choose a value from the enumeration list that
      the implementation can support and resubmit the request
      if the operation failed."
    }
  ]
}

Signed-off-by: Albert Zhang <zhanghaodi@inspur.com>
Change-Id: Ib2307deb413081edcbdecba9f234fe18571821a7