### PR TITLE
Redfish-Validator Fix: Remove Bios/Settings url

### DIFF
--- a/redfish-core/lib/bios.hpp
+++ b/redfish-core/lib/bios.hpp
@@ -161,11 +161,6 @@ inline void requestRoutesBiosService(App& app)
                 // Get the ActiveSoftwareImage and SoftwareImages
                 fw_util::populateFirmwareInformation(
                     asyncResp, fw_util::biosPurpose, "", true);
-                asyncResp->res.jsonValue["@Redfish.Settings"] = {
-                    {"@odata.type", "#Settings.v1_3_0.Settings"},
-                    {"SettingsObject",
-                     {{"@odata.id",
-                       "/redfish/v1/Systems/system/Bios/Settings"}}}};
                 asyncResp->res.jsonValue["AttributeRegistry"] =
                     "BiosAttributeRegistry";
                 asyncResp->res.jsonValue["Attributes"] = {};


### PR DESCRIPTION
Redfish validator fails for /redfish/v1/Systems/system/Bios/Settings
This commit fixes this by removing the refernce to this url while
performing GET on redfish/v1//Systems/system/Bios

Tested by: Run validator - pass

Signed-off-by: Sunitha Harish <sunharis@in.ibm.com>
Change-Id: I0684cd069a07c9faeed48330a48c68f9052e9be8