### PR TITLE
Added all Redfish schemas

### DIFF
--- a/Redfish.md
+++ b/Redfish.md
@@ -16,9 +16,6 @@ living document, and these schemas are subject to change.
 
 The latest Redfish schemas can be found [here](https://redfish.dmtf.org/schemas/)
 
-If using a previously unused schema, you will need to add it to the included
-schema list in scripts/update_schemas.py and run update_schemas.py.
-
 Fields common to all schemas
 
 - @odata.id

--- a/scripts/update_schemas.py
+++ b/scripts/update_schemas.py
@@ -11,113 +11,6 @@ import xml.etree.ElementTree as ET
 
 VERSION = "DSP8010_2021.2"
 
-# To use a new schema, add to list and rerun tool
-include_list = [
-    'AccountService',
-    'ActionInfo',
-    'Assembly',
-    'AttributeRegistry',
-    'Bios',
-    'Certificate',
-    'CertificateCollection',
-    'CertificateLocations',
-    'CertificateService',
-    'Chassis',
-    'ChassisCollection',
-    'ComputerSystem',
-    'ComputerSystemCollection',
-    'Drive',
-    'DriveCollection',
-    'EthernetInterface',
-    'EthernetInterfaceCollection',
-    'Event',
-    'EventDestination',
-    'EventDestinationCollection',
-    'EventService',
-    'FabricAdapter',
-    'FabricAdapterCollection',
-    'FanCollection',
-    'Fan',
-    'IPAddresses',
-    'JsonSchemaFile',
-    'JsonSchemaFileCollection',  # redfish/v1/JsonSchemas
-    'LogEntry',
-    'LogEntryCollection',
-    'LogService',
-    'LogServiceCollection',
-    'Manager',
-    'ManagerAccount',
-    'ManagerAccountCollection',
-    'ManagerCollection',
-    'ManagerNetworkProtocol',
-    'Memory',
-    'MemoryCollection',
-    'Message',
-    'MessageRegistry',
-    'MessageRegistryCollection',
-    'MessageRegistryFile',
-    'MessageRegistryFileCollection',
-    'MetricDefinition',
-    'MetricDefinitionCollection',
-    'MetricReport',
-    'MetricReportCollection',
-    'MetricReportDefinition',
-    'MetricReportDefinitionCollection',
-    'OperatingConfig',
-    'OperatingConfigCollection',
-    'PCIeDevice',
-    'PCIeDeviceCollection',
-    'PCIeFunction',
-    'PCIeFunctionCollection',
-    'PCIeSlots',
-    'Power',
-    'Port',
-    'PortCollection',
-    'PowerSubsystem',
-    'PowerSupplyCollection',
-    'PowerSupply',
-    'Privileges',  # Used in Role
-    'Processor',
-    'ProcessorCollection',
-    'RedfishError',
-    'RedfishExtensions',
-    'Redundancy',
-    'Resource',
-    'Role',
-    'RoleCollection',
-    'Sensor',
-    'SensorCollection',
-    'ServiceRoot',
-    'Session',
-    'SessionCollection',
-    'SessionService',
-    'Settings',
-    'SoftwareInventory',
-    'SoftwareInventoryCollection',
-    'Storage',
-    'StorageCollection',
-    'StorageController',
-    'StorageControllerCollection',
-    'Task',
-    'TaskCollection',
-    'TaskService',
-    'TelemetryService',
-    'Thermal',
-    'ThermalSubsystem',
-    'ThermalMetrics',
-    'UpdateService',
-    'VLanNetworkInterfaceCollection',
-    'VLanNetworkInterface',
-    'VirtualMedia',
-    'VirtualMediaCollection',
-    'odata',
-    'odata-v4',
-    'redfish-error',
-    'redfish-payload-annotations',
-    'redfish-schema',
-    'redfish-schema-v1',
-]
-
 SCRIPT_DIR = os.path.dirname(os.path.realpath(__file__))
 
 proxies = {
@@ -177,12 +70,6 @@ with open(metadata_index_path, 'w') as metadata_index:
             (zip_filepath != VERSION + "/csdl/") and \
                 (zip_filepath != VERSION + '/' + VERSION + "/csdl/"):
             filename = os.path.basename(zip_filepath)
-
-            # filename looks like Zone_v1.xml
-            filenamesplit = filename.split("_")
-            if filenamesplit[0] not in include_list:
-                print("excluding schema: " + filename)
-                continue
 
             with open(os.path.join(schema_path, filename), 'wb') as schema_out:
 
@@ -275,10 +162,6 @@ for zip_filepath in zip_ref.namelist():
     if zip_filepath.startswith(os.path.join(VERSION, VERSION, 'json-schema/')):
         filename = os.path.basename(zip_filepath)
         filenamesplit = filename.split(".")
-
-        # exclude schemas again to save flash space
-        if filenamesplit[0] not in include_list:
-            continue
 
         if len(filenamesplit) == 3:
             thisSchemaVersion = schema_files.get(filenamesplit[0], None)

--- a/static/redfish/v1/$metadata/index.xml
+++ b/static/redfish/v1/$metadata/index.xml
@@ -1,5 +1,15 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <edmx:Edmx xmlns:edmx="http://docs.oasis-open.org/odata/ns/edmx" Version="4.0">
+    <edmx:Reference Uri="/redfish/v1/schema/AccelerationFunction_v1.xml">
+        <edmx:Include Namespace="AccelerationFunction"/>
+        <edmx:Include Namespace="AccelerationFunction.v1_0_0"/>
+        <edmx:Include Namespace="AccelerationFunction.v1_0_1"/>
+        <edmx:Include Namespace="AccelerationFunction.v1_0_2"/>
+        <edmx:Include Namespace="AccelerationFunction.v1_0_3"/>
+    </edmx:Reference>
+    <edmx:Reference Uri="/redfish/v1/schema/AccelerationFunctionCollection_v1.xml">
+        <edmx:Include Namespace="AccelerationFunctionCollection"/>
+    </edmx:Reference>
     <edmx:Reference Uri="/redfish/v1/schema/AccountService_v1.xml">
         <edmx:Include Namespace="AccountService"/>
         <edmx:Include Namespace="AccountService.v1_0_0"/>
@@ -97,6 +107,46 @@
         <edmx:Include Namespace="ActionInfo.v1_1_3"/>
         <edmx:Include Namespace="ActionInfo.v1_2_0"/>
     </edmx:Reference>
+    <edmx:Reference Uri="/redfish/v1/schema/AddressPool_v1.xml">
+        <edmx:Include Namespace="AddressPool"/>
+        <edmx:Include Namespace="AddressPool.v1_0_0"/>
+        <edmx:Include Namespace="AddressPool.v1_0_1"/>
+        <edmx:Include Namespace="AddressPool.v1_0_2"/>
+        <edmx:Include Namespace="AddressPool.v1_1_0"/>
+        <edmx:Include Namespace="AddressPool.v1_1_1"/>
+        <edmx:Include Namespace="AddressPool.v1_2_0"/>
+    </edmx:Reference>
+    <edmx:Reference Uri="/redfish/v1/schema/AddressPoolCollection_v1.xml">
+        <edmx:Include Namespace="AddressPoolCollection"/>
+    </edmx:Reference>
+    <edmx:Reference Uri="/redfish/v1/schema/Aggregate_v1.xml">
+        <edmx:Include Namespace="Aggregate"/>
+        <edmx:Include Namespace="Aggregate.v1_0_0"/>
+        <edmx:Include Namespace="Aggregate.v1_0_1"/>
+    </edmx:Reference>
+    <edmx:Reference Uri="/redfish/v1/schema/AggregateCollection_v1.xml">
+        <edmx:Include Namespace="AggregateCollection"/>
+    </edmx:Reference>
+    <edmx:Reference Uri="/redfish/v1/schema/AggregationService_v1.xml">
+        <edmx:Include Namespace="AggregationService"/>
+        <edmx:Include Namespace="AggregationService.v1_0_0"/>
+        <edmx:Include Namespace="AggregationService.v1_0_1"/>
+    </edmx:Reference>
+    <edmx:Reference Uri="/redfish/v1/schema/AggregationSource_v1.xml">
+        <edmx:Include Namespace="AggregationSource"/>
+        <edmx:Include Namespace="AggregationSource.v1_0_0"/>
+        <edmx:Include Namespace="AggregationSource.v1_1_0"/>
+    </edmx:Reference>
+    <edmx:Reference Uri="/redfish/v1/schema/AggregationSourceCollection_v1.xml">
+        <edmx:Include Namespace="AggregationSourceCollection"/>
+    </edmx:Reference>
+    <edmx:Reference Uri="/redfish/v1/schema/AllowDeny_v1.xml">
+        <edmx:Include Namespace="AllowDeny"/>
+        <edmx:Include Namespace="AllowDeny.v1_0_0"/>
+    </edmx:Reference>
+    <edmx:Reference Uri="/redfish/v1/schema/AllowDenyCollection_v1.xml">
+        <edmx:Include Namespace="AllowDenyCollection"/>
+    </edmx:Reference>
     <edmx:Reference Uri="/redfish/v1/schema/Assembly_v1.xml">
         <edmx:Include Namespace="Assembly"/>
         <edmx:Include Namespace="Assembly.v1_0_0"/>
@@ -157,6 +207,17 @@
         <edmx:Include Namespace="AttributeRegistry.v1_3_5"/>
         <edmx:Include Namespace="AttributeRegistry.v1_3_6"/>
     </edmx:Reference>
+    <edmx:Reference Uri="/redfish/v1/schema/Battery_v1.xml">
+        <edmx:Include Namespace="Battery"/>
+        <edmx:Include Namespace="Battery.v1_0_0"/>
+    </edmx:Reference>
+    <edmx:Reference Uri="/redfish/v1/schema/BatteryCollection_v1.xml">
+        <edmx:Include Namespace="BatteryCollection"/>
+    </edmx:Reference>
+    <edmx:Reference Uri="/redfish/v1/schema/BatteryMetrics_v1.xml">
+        <edmx:Include Namespace="BatteryMetrics"/>
+        <edmx:Include Namespace="BatteryMetrics.v1_0_0"/>
+    </edmx:Reference>
     <edmx:Reference Uri="/redfish/v1/schema/Bios_v1.xml">
         <edmx:Include Namespace="Bios"/>
         <edmx:Include Namespace="Bios.v1_0_0"/>
@@ -173,6 +234,24 @@
         <edmx:Include Namespace="Bios.v1_1_1"/>
         <edmx:Include Namespace="Bios.v1_1_2"/>
         <edmx:Include Namespace="Bios.v1_2_0"/>
+    </edmx:Reference>
+    <edmx:Reference Uri="/redfish/v1/schema/BootOption_v1.xml">
+        <edmx:Include Namespace="BootOption"/>
+        <edmx:Include Namespace="BootOption.v1_0_0"/>
+        <edmx:Include Namespace="BootOption.v1_0_1"/>
+        <edmx:Include Namespace="BootOption.v1_0_2"/>
+        <edmx:Include Namespace="BootOption.v1_0_3"/>
+        <edmx:Include Namespace="BootOption.v1_0_4"/>
+    </edmx:Reference>
+    <edmx:Reference Uri="/redfish/v1/schema/BootOptionCollection_v1.xml">
+        <edmx:Include Namespace="BootOptionCollection"/>
+    </edmx:Reference>
+    <edmx:Reference Uri="/redfish/v1/schema/Cable_v1.xml">
+        <edmx:Include Namespace="Cable"/>
+        <edmx:Include Namespace="Cable.v1_0_0"/>
+    </edmx:Reference>
+    <edmx:Reference Uri="/redfish/v1/schema/CableCollection_v1.xml">
+        <edmx:Include Namespace="CableCollection"/>
     </edmx:Reference>
     <edmx:Reference Uri="/redfish/v1/schema/Certificate_v1.xml">
         <edmx:Include Namespace="Certificate"/>
@@ -349,6 +428,56 @@
     <edmx:Reference Uri="/redfish/v1/schema/ChassisCollection_v1.xml">
         <edmx:Include Namespace="ChassisCollection"/>
     </edmx:Reference>
+    <edmx:Reference Uri="/redfish/v1/schema/Circuit_v1.xml">
+        <edmx:Include Namespace="Circuit"/>
+        <edmx:Include Namespace="Circuit.v1_0_0"/>
+        <edmx:Include Namespace="Circuit.v1_0_1"/>
+        <edmx:Include Namespace="Circuit.v1_0_2"/>
+        <edmx:Include Namespace="Circuit.v1_1_0"/>
+        <edmx:Include Namespace="Circuit.v1_1_1"/>
+        <edmx:Include Namespace="Circuit.v1_2_0"/>
+        <edmx:Include Namespace="Circuit.v1_3_0"/>
+    </edmx:Reference>
+    <edmx:Reference Uri="/redfish/v1/schema/CircuitCollection_v1.xml">
+        <edmx:Include Namespace="CircuitCollection"/>
+    </edmx:Reference>
+    <edmx:Reference Uri="/redfish/v1/schema/CollectionCapabilities_v1.xml">
+        <edmx:Include Namespace="CollectionCapabilities"/>
+        <edmx:Include Namespace="CollectionCapabilities.v1_0_0"/>
+        <edmx:Include Namespace="CollectionCapabilities.v1_0_1"/>
+        <edmx:Include Namespace="CollectionCapabilities.v1_0_2"/>
+        <edmx:Include Namespace="CollectionCapabilities.v1_0_3"/>
+        <edmx:Include Namespace="CollectionCapabilities.v1_0_4"/>
+        <edmx:Include Namespace="CollectionCapabilities.v1_1_0"/>
+        <edmx:Include Namespace="CollectionCapabilities.v1_1_1"/>
+        <edmx:Include Namespace="CollectionCapabilities.v1_1_2"/>
+        <edmx:Include Namespace="CollectionCapabilities.v1_1_3"/>
+        <edmx:Include Namespace="CollectionCapabilities.v1_2_0"/>
+        <edmx:Include Namespace="CollectionCapabilities.v1_2_1"/>
+        <edmx:Include Namespace="CollectionCapabilities.v1_2_2"/>
+        <edmx:Include Namespace="CollectionCapabilities.v1_3_0"/>
+    </edmx:Reference>
+    <edmx:Reference Uri="/redfish/v1/schema/CompositionReservation_v1.xml">
+        <edmx:Include Namespace="CompositionReservation"/>
+        <edmx:Include Namespace="CompositionReservation.v1_0_0"/>
+    </edmx:Reference>
+    <edmx:Reference Uri="/redfish/v1/schema/CompositionReservationCollection_v1.xml">
+        <edmx:Include Namespace="CompositionReservationCollection"/>
+    </edmx:Reference>
+    <edmx:Reference Uri="/redfish/v1/schema/CompositionService_v1.xml">
+        <edmx:Include Namespace="CompositionService"/>
+        <edmx:Include Namespace="CompositionService.v1_0_0"/>
+        <edmx:Include Namespace="CompositionService.v1_0_1"/>
+        <edmx:Include Namespace="CompositionService.v1_0_2"/>
+        <edmx:Include Namespace="CompositionService.v1_0_3"/>
+        <edmx:Include Namespace="CompositionService.v1_0_4"/>
+        <edmx:Include Namespace="CompositionService.v1_0_5"/>
+        <edmx:Include Namespace="CompositionService.v1_1_0"/>
+        <edmx:Include Namespace="CompositionService.v1_1_1"/>
+        <edmx:Include Namespace="CompositionService.v1_1_2"/>
+        <edmx:Include Namespace="CompositionService.v1_1_3"/>
+        <edmx:Include Namespace="CompositionService.v1_2_0"/>
+    </edmx:Reference>
     <edmx:Reference Uri="/redfish/v1/schema/ComputerSystem_v1.xml">
         <edmx:Include Namespace="ComputerSystem"/>
         <edmx:Include Namespace="ComputerSystem.v1_0_0"/>
@@ -495,6 +624,28 @@
     <edmx:Reference Uri="/redfish/v1/schema/ComputerSystemCollection_v1.xml">
         <edmx:Include Namespace="ComputerSystemCollection"/>
     </edmx:Reference>
+    <edmx:Reference Uri="/redfish/v1/schema/Connection_v1.xml">
+        <edmx:Include Namespace="Connection"/>
+        <edmx:Include Namespace="Connection.v1_0_0"/>
+        <edmx:Include Namespace="Connection.v1_1_0"/>
+    </edmx:Reference>
+    <edmx:Reference Uri="/redfish/v1/schema/ConnectionCollection_v1.xml">
+        <edmx:Include Namespace="ConnectionCollection"/>
+    </edmx:Reference>
+    <edmx:Reference Uri="/redfish/v1/schema/ConnectionMethod_v1.xml">
+        <edmx:Include Namespace="ConnectionMethod"/>
+        <edmx:Include Namespace="ConnectionMethod.v1_0_0"/>
+    </edmx:Reference>
+    <edmx:Reference Uri="/redfish/v1/schema/ConnectionMethodCollection_v1.xml">
+        <edmx:Include Namespace="ConnectionMethodCollection"/>
+    </edmx:Reference>
+    <edmx:Reference Uri="/redfish/v1/schema/Control_v1.xml">
+        <edmx:Include Namespace="Control"/>
+        <edmx:Include Namespace="Control.v1_0_0"/>
+    </edmx:Reference>
+    <edmx:Reference Uri="/redfish/v1/schema/ControlCollection_v1.xml">
+        <edmx:Include Namespace="ControlCollection"/>
+    </edmx:Reference>
     <edmx:Reference Uri="/redfish/v1/schema/Drive_v1.xml">
         <edmx:Include Namespace="Drive"/>
         <edmx:Include Namespace="Drive.v1_0_0"/>
@@ -604,6 +755,96 @@
     </edmx:Reference>
     <edmx:Reference Uri="/redfish/v1/schema/DriveCollection_v1.xml">
         <edmx:Include Namespace="DriveCollection"/>
+    </edmx:Reference>
+    <edmx:Reference Uri="/redfish/v1/schema/Endpoint_v1.xml">
+        <edmx:Include Namespace="Endpoint"/>
+        <edmx:Include Namespace="Endpoint.v1_0_0"/>
+        <edmx:Include Namespace="Endpoint.v1_0_1"/>
+        <edmx:Include Namespace="Endpoint.v1_0_2"/>
+        <edmx:Include Namespace="Endpoint.v1_0_3"/>
+        <edmx:Include Namespace="Endpoint.v1_0_4"/>
+        <edmx:Include Namespace="Endpoint.v1_0_5"/>
+        <edmx:Include Namespace="Endpoint.v1_0_6"/>
+        <edmx:Include Namespace="Endpoint.v1_0_7"/>
+        <edmx:Include Namespace="Endpoint.v1_0_8"/>
+        <edmx:Include Namespace="Endpoint.v1_0_9"/>
+        <edmx:Include Namespace="Endpoint.v1_0_10"/>
+        <edmx:Include Namespace="Endpoint.v1_0_11"/>
+        <edmx:Include Namespace="Endpoint.v1_0_12"/>
+        <edmx:Include Namespace="Endpoint.v1_1_0"/>
+        <edmx:Include Namespace="Endpoint.v1_1_1"/>
+        <edmx:Include Namespace="Endpoint.v1_1_2"/>
+        <edmx:Include Namespace="Endpoint.v1_1_3"/>
+        <edmx:Include Namespace="Endpoint.v1_1_4"/>
+        <edmx:Include Namespace="Endpoint.v1_1_5"/>
+        <edmx:Include Namespace="Endpoint.v1_1_6"/>
+        <edmx:Include Namespace="Endpoint.v1_1_7"/>
+        <edmx:Include Namespace="Endpoint.v1_1_8"/>
+        <edmx:Include Namespace="Endpoint.v1_1_9"/>
+        <edmx:Include Namespace="Endpoint.v1_2_0"/>
+        <edmx:Include Namespace="Endpoint.v1_2_1"/>
+        <edmx:Include Namespace="Endpoint.v1_2_2"/>
+        <edmx:Include Namespace="Endpoint.v1_2_3"/>
+        <edmx:Include Namespace="Endpoint.v1_2_4"/>
+        <edmx:Include Namespace="Endpoint.v1_2_5"/>
+        <edmx:Include Namespace="Endpoint.v1_2_6"/>
+        <edmx:Include Namespace="Endpoint.v1_2_7"/>
+        <edmx:Include Namespace="Endpoint.v1_2_8"/>
+        <edmx:Include Namespace="Endpoint.v1_3_0"/>
+        <edmx:Include Namespace="Endpoint.v1_3_1"/>
+        <edmx:Include Namespace="Endpoint.v1_3_2"/>
+        <edmx:Include Namespace="Endpoint.v1_3_3"/>
+        <edmx:Include Namespace="Endpoint.v1_3_4"/>
+        <edmx:Include Namespace="Endpoint.v1_3_5"/>
+        <edmx:Include Namespace="Endpoint.v1_3_6"/>
+        <edmx:Include Namespace="Endpoint.v1_3_7"/>
+        <edmx:Include Namespace="Endpoint.v1_4_0"/>
+        <edmx:Include Namespace="Endpoint.v1_4_1"/>
+        <edmx:Include Namespace="Endpoint.v1_4_2"/>
+        <edmx:Include Namespace="Endpoint.v1_4_3"/>
+        <edmx:Include Namespace="Endpoint.v1_4_4"/>
+        <edmx:Include Namespace="Endpoint.v1_4_5"/>
+        <edmx:Include Namespace="Endpoint.v1_5_0"/>
+        <edmx:Include Namespace="Endpoint.v1_5_1"/>
+        <edmx:Include Namespace="Endpoint.v1_5_2"/>
+        <edmx:Include Namespace="Endpoint.v1_5_3"/>
+        <edmx:Include Namespace="Endpoint.v1_6_0"/>
+        <edmx:Include Namespace="Endpoint.v1_6_1"/>
+    </edmx:Reference>
+    <edmx:Reference Uri="/redfish/v1/schema/EndpointCollection_v1.xml">
+        <edmx:Include Namespace="EndpointCollection"/>
+    </edmx:Reference>
+    <edmx:Reference Uri="/redfish/v1/schema/EndpointGroup_v1.xml">
+        <edmx:Include Namespace="EndpointGroup"/>
+        <edmx:Include Namespace="EndpointGroup.v1_0_0"/>
+        <edmx:Include Namespace="EndpointGroup.v1_0_1"/>
+        <edmx:Include Namespace="EndpointGroup.v1_0_2"/>
+        <edmx:Include Namespace="EndpointGroup.v1_0_3"/>
+        <edmx:Include Namespace="EndpointGroup.v1_0_4"/>
+        <edmx:Include Namespace="EndpointGroup.v1_0_5"/>
+        <edmx:Include Namespace="EndpointGroup.v1_1_0"/>
+        <edmx:Include Namespace="EndpointGroup.v1_1_1"/>
+        <edmx:Include Namespace="EndpointGroup.v1_1_2"/>
+        <edmx:Include Namespace="EndpointGroup.v1_1_3"/>
+        <edmx:Include Namespace="EndpointGroup.v1_1_4"/>
+        <edmx:Include Namespace="EndpointGroup.v1_1_5"/>
+        <edmx:Include Namespace="EndpointGroup.v1_1_6"/>
+        <edmx:Include Namespace="EndpointGroup.v1_2_0"/>
+        <edmx:Include Namespace="EndpointGroup.v1_2_1"/>
+        <edmx:Include Namespace="EndpointGroup.v1_2_2"/>
+        <edmx:Include Namespace="EndpointGroup.v1_2_3"/>
+        <edmx:Include Namespace="EndpointGroup.v1_2_4"/>
+        <edmx:Include Namespace="EndpointGroup.v1_3_0"/>
+        <edmx:Include Namespace="EndpointGroup.v1_3_1"/>
+        <edmx:Include Namespace="EndpointGroup.v1_3_2"/>
+    </edmx:Reference>
+    <edmx:Reference Uri="/redfish/v1/schema/EndpointGroupCollection_v1.xml">
+        <edmx:Include Namespace="EndpointGroupCollection"/>
+    </edmx:Reference>
+    <edmx:Reference Uri="/redfish/v1/schema/EnvironmentMetrics_v1.xml">
+        <edmx:Include Namespace="EnvironmentMetrics"/>
+        <edmx:Include Namespace="EnvironmentMetrics.v1_0_0"/>
+        <edmx:Include Namespace="EnvironmentMetrics.v1_1_0"/>
     </edmx:Reference>
     <edmx:Reference Uri="/redfish/v1/schema/EthernetInterface_v1.xml">
         <edmx:Include Namespace="EthernetInterface"/>
@@ -852,19 +1093,103 @@
         <edmx:Include Namespace="EventService.v1_7_1"/>
         <edmx:Include Namespace="EventService.v1_7_2"/>
     </edmx:Reference>
+    <edmx:Reference Uri="/redfish/v1/schema/ExternalAccountProvider_v1.xml">
+        <edmx:Include Namespace="ExternalAccountProvider"/>
+        <edmx:Include Namespace="ExternalAccountProvider.v1_0_0"/>
+        <edmx:Include Namespace="ExternalAccountProvider.v1_0_1"/>
+        <edmx:Include Namespace="ExternalAccountProvider.v1_0_2"/>
+        <edmx:Include Namespace="ExternalAccountProvider.v1_0_3"/>
+        <edmx:Include Namespace="ExternalAccountProvider.v1_0_4"/>
+        <edmx:Include Namespace="ExternalAccountProvider.v1_0_5"/>
+        <edmx:Include Namespace="ExternalAccountProvider.v1_1_0"/>
+        <edmx:Include Namespace="ExternalAccountProvider.v1_1_1"/>
+        <edmx:Include Namespace="ExternalAccountProvider.v1_1_2"/>
+        <edmx:Include Namespace="ExternalAccountProvider.v1_1_3"/>
+        <edmx:Include Namespace="ExternalAccountProvider.v1_1_4"/>
+        <edmx:Include Namespace="ExternalAccountProvider.v1_2_0"/>
+        <edmx:Include Namespace="ExternalAccountProvider.v1_3_0"/>
+    </edmx:Reference>
+    <edmx:Reference Uri="/redfish/v1/schema/ExternalAccountProviderCollection_v1.xml">
+        <edmx:Include Namespace="ExternalAccountProviderCollection"/>
+    </edmx:Reference>
+    <edmx:Reference Uri="/redfish/v1/schema/Fabric_v1.xml">
+        <edmx:Include Namespace="Fabric"/>
+        <edmx:Include Namespace="Fabric.v1_0_0"/>
+        <edmx:Include Namespace="Fabric.v1_0_1"/>
+        <edmx:Include Namespace="Fabric.v1_0_2"/>
+        <edmx:Include Namespace="Fabric.v1_0_3"/>
+        <edmx:Include Namespace="Fabric.v1_0_4"/>
+        <edmx:Include Namespace="Fabric.v1_0_5"/>
+        <edmx:Include Namespace="Fabric.v1_0_6"/>
+        <edmx:Include Namespace="Fabric.v1_0_7"/>
+        <edmx:Include Namespace="Fabric.v1_0_8"/>
+        <edmx:Include Namespace="Fabric.v1_0_9"/>
+        <edmx:Include Namespace="Fabric.v1_1_0"/>
+        <edmx:Include Namespace="Fabric.v1_1_1"/>
+        <edmx:Include Namespace="Fabric.v1_1_2"/>
+        <edmx:Include Namespace="Fabric.v1_1_3"/>
+        <edmx:Include Namespace="Fabric.v1_2_0"/>
+        <edmx:Include Namespace="Fabric.v1_2_1"/>
+        <edmx:Include Namespace="Fabric.v1_2_2"/>
+    </edmx:Reference>
     <edmx:Reference Uri="/redfish/v1/schema/FabricAdapter_v1.xml">
         <edmx:Include Namespace="FabricAdapter"/>
         <edmx:Include Namespace="FabricAdapter.v1_0_0"/>
+        <edmx:Include Namespace="FabricAdapter.v1_1_0"/>
     </edmx:Reference>
     <edmx:Reference Uri="/redfish/v1/schema/FabricAdapterCollection_v1.xml">
         <edmx:Include Namespace="FabricAdapterCollection"/>
     </edmx:Reference>
+    <edmx:Reference Uri="/redfish/v1/schema/FabricCollection_v1.xml">
+        <edmx:Include Namespace="FabricCollection"/>
+    </edmx:Reference>
+    <edmx:Reference Uri="/redfish/v1/schema/Facility_v1.xml">
+        <edmx:Include Namespace="Facility"/>
+        <edmx:Include Namespace="Facility.v1_0_0"/>
+        <edmx:Include Namespace="Facility.v1_0_1"/>
+        <edmx:Include Namespace="Facility.v1_1_0"/>
+        <edmx:Include Namespace="Facility.v1_2_0"/>
+    </edmx:Reference>
+    <edmx:Reference Uri="/redfish/v1/schema/FacilityCollection_v1.xml">
+        <edmx:Include Namespace="FacilityCollection"/>
+    </edmx:Reference>
     <edmx:Reference Uri="/redfish/v1/schema/Fan_v1.xml">
         <edmx:Include Namespace="Fan"/>
         <edmx:Include Namespace="Fan.v1_0_0"/>
+        <edmx:Include Namespace="Fan.v1_0_1"/>
+        <edmx:Include Namespace="Fan.v1_1_0"/>
     </edmx:Reference>
     <edmx:Reference Uri="/redfish/v1/schema/FanCollection_v1.xml">
         <edmx:Include Namespace="FanCollection"/>
+    </edmx:Reference>
+    <edmx:Reference Uri="/redfish/v1/schema/GraphicsController_v1.xml">
+        <edmx:Include Namespace="GraphicsController"/>
+        <edmx:Include Namespace="GraphicsController.v1_0_0"/>
+    </edmx:Reference>
+    <edmx:Reference Uri="/redfish/v1/schema/GraphicsControllerCollection_v1.xml">
+        <edmx:Include Namespace="GraphicsControllerCollection"/>
+    </edmx:Reference>
+    <edmx:Reference Uri="/redfish/v1/schema/HostInterface_v1.xml">
+        <edmx:Include Namespace="HostInterface"/>
+        <edmx:Include Namespace="HostInterface.v1_0_0"/>
+        <edmx:Include Namespace="HostInterface.v1_0_1"/>
+        <edmx:Include Namespace="HostInterface.v1_0_2"/>
+        <edmx:Include Namespace="HostInterface.v1_0_3"/>
+        <edmx:Include Namespace="HostInterface.v1_0_4"/>
+        <edmx:Include Namespace="HostInterface.v1_0_5"/>
+        <edmx:Include Namespace="HostInterface.v1_1_0"/>
+        <edmx:Include Namespace="HostInterface.v1_1_1"/>
+        <edmx:Include Namespace="HostInterface.v1_1_2"/>
+        <edmx:Include Namespace="HostInterface.v1_1_3"/>
+        <edmx:Include Namespace="HostInterface.v1_1_4"/>
+        <edmx:Include Namespace="HostInterface.v1_1_5"/>
+        <edmx:Include Namespace="HostInterface.v1_2_0"/>
+        <edmx:Include Namespace="HostInterface.v1_2_1"/>
+        <edmx:Include Namespace="HostInterface.v1_2_2"/>
+        <edmx:Include Namespace="HostInterface.v1_3_0"/>
+    </edmx:Reference>
+    <edmx:Reference Uri="/redfish/v1/schema/HostInterfaceCollection_v1.xml">
+        <edmx:Include Namespace="HostInterfaceCollection"/>
     </edmx:Reference>
     <edmx:Reference Uri="/redfish/v1/schema/IPAddresses_v1.xml">
         <edmx:Include Namespace="IPAddresses"/>
@@ -882,6 +1207,28 @@
         <edmx:Include Namespace="IPAddresses.v1_1_1"/>
         <edmx:Include Namespace="IPAddresses.v1_1_2"/>
         <edmx:Include Namespace="IPAddresses.v1_1_3"/>
+    </edmx:Reference>
+    <edmx:Reference Uri="/redfish/v1/schema/Job_v1.xml">
+        <edmx:Include Namespace="Job"/>
+        <edmx:Include Namespace="Job.v1_0_0"/>
+        <edmx:Include Namespace="Job.v1_0_1"/>
+        <edmx:Include Namespace="Job.v1_0_2"/>
+        <edmx:Include Namespace="Job.v1_0_3"/>
+        <edmx:Include Namespace="Job.v1_0_4"/>
+        <edmx:Include Namespace="Job.v1_0_5"/>
+        <edmx:Include Namespace="Job.v1_0_6"/>
+        <edmx:Include Namespace="Job.v1_0_7"/>
+    </edmx:Reference>
+    <edmx:Reference Uri="/redfish/v1/schema/JobCollection_v1.xml">
+        <edmx:Include Namespace="JobCollection"/>
+    </edmx:Reference>
+    <edmx:Reference Uri="/redfish/v1/schema/JobService_v1.xml">
+        <edmx:Include Namespace="JobService"/>
+        <edmx:Include Namespace="JobService.v1_0_0"/>
+        <edmx:Include Namespace="JobService.v1_0_1"/>
+        <edmx:Include Namespace="JobService.v1_0_2"/>
+        <edmx:Include Namespace="JobService.v1_0_3"/>
+        <edmx:Include Namespace="JobService.v1_0_4"/>
     </edmx:Reference>
     <edmx:Reference Uri="/redfish/v1/schema/JsonSchemaFile_v1.xml">
         <edmx:Include Namespace="JsonSchemaFile"/>
@@ -901,6 +1248,24 @@
     </edmx:Reference>
     <edmx:Reference Uri="/redfish/v1/schema/JsonSchemaFileCollection_v1.xml">
         <edmx:Include Namespace="JsonSchemaFileCollection"/>
+    </edmx:Reference>
+    <edmx:Reference Uri="/redfish/v1/schema/Key_v1.xml">
+        <edmx:Include Namespace="Key"/>
+        <edmx:Include Namespace="Key.v1_0_0"/>
+    </edmx:Reference>
+    <edmx:Reference Uri="/redfish/v1/schema/KeyCollection_v1.xml">
+        <edmx:Include Namespace="KeyCollection"/>
+    </edmx:Reference>
+    <edmx:Reference Uri="/redfish/v1/schema/KeyPolicy_v1.xml">
+        <edmx:Include Namespace="KeyPolicy"/>
+        <edmx:Include Namespace="KeyPolicy.v1_0_0"/>
+    </edmx:Reference>
+    <edmx:Reference Uri="/redfish/v1/schema/KeyPolicyCollection_v1.xml">
+        <edmx:Include Namespace="KeyPolicyCollection"/>
+    </edmx:Reference>
+    <edmx:Reference Uri="/redfish/v1/schema/KeyService_v1.xml">
+        <edmx:Include Namespace="KeyService"/>
+        <edmx:Include Namespace="KeyService.v1_0_0"/>
     </edmx:Reference>
     <edmx:Reference Uri="/redfish/v1/schema/LogEntry_v1.xml">
         <edmx:Include Namespace="LogEntry"/>
@@ -1224,6 +1589,20 @@
         <edmx:Include Namespace="ManagerNetworkProtocol.v1_7_0"/>
         <edmx:Include Namespace="ManagerNetworkProtocol.v1_8_0"/>
     </edmx:Reference>
+    <edmx:Reference Uri="/redfish/v1/schema/Manifest_v1.xml">
+        <edmx:Include Namespace="Manifest"/>
+        <edmx:Include Namespace="Manifest.v1_0_0"/>
+    </edmx:Reference>
+    <edmx:Reference Uri="/redfish/v1/schema/MediaController_v1.xml">
+        <edmx:Include Namespace="MediaController"/>
+        <edmx:Include Namespace="MediaController.v1_0_0"/>
+        <edmx:Include Namespace="MediaController.v1_0_1"/>
+        <edmx:Include Namespace="MediaController.v1_1_0"/>
+        <edmx:Include Namespace="MediaController.v1_2_0"/>
+    </edmx:Reference>
+    <edmx:Reference Uri="/redfish/v1/schema/MediaControllerCollection_v1.xml">
+        <edmx:Include Namespace="MediaControllerCollection"/>
+    </edmx:Reference>
     <edmx:Reference Uri="/redfish/v1/schema/Memory_v1.xml">
         <edmx:Include Namespace="Memory"/>
         <edmx:Include Namespace="Memory.v1_0_0"/>
@@ -1319,8 +1698,90 @@
         <edmx:Include Namespace="Memory.v1_12_0"/>
         <edmx:Include Namespace="Memory.v1_13_0"/>
     </edmx:Reference>
+    <edmx:Reference Uri="/redfish/v1/schema/MemoryChunks_v1.xml">
+        <edmx:Include Namespace="MemoryChunks"/>
+        <edmx:Include Namespace="MemoryChunks.v1_0_0"/>
+        <edmx:Include Namespace="MemoryChunks.v1_0_1"/>
+        <edmx:Include Namespace="MemoryChunks.v1_0_2"/>
+        <edmx:Include Namespace="MemoryChunks.v1_0_3"/>
+        <edmx:Include Namespace="MemoryChunks.v1_0_4"/>
+        <edmx:Include Namespace="MemoryChunks.v1_0_5"/>
+        <edmx:Include Namespace="MemoryChunks.v1_0_6"/>
+        <edmx:Include Namespace="MemoryChunks.v1_0_7"/>
+        <edmx:Include Namespace="MemoryChunks.v1_1_0"/>
+        <edmx:Include Namespace="MemoryChunks.v1_1_1"/>
+        <edmx:Include Namespace="MemoryChunks.v1_1_2"/>
+        <edmx:Include Namespace="MemoryChunks.v1_1_3"/>
+        <edmx:Include Namespace="MemoryChunks.v1_1_4"/>
+        <edmx:Include Namespace="MemoryChunks.v1_1_5"/>
+        <edmx:Include Namespace="MemoryChunks.v1_2_0"/>
+        <edmx:Include Namespace="MemoryChunks.v1_2_1"/>
+        <edmx:Include Namespace="MemoryChunks.v1_2_2"/>
+        <edmx:Include Namespace="MemoryChunks.v1_2_3"/>
+        <edmx:Include Namespace="MemoryChunks.v1_2_4"/>
+        <edmx:Include Namespace="MemoryChunks.v1_2_5"/>
+        <edmx:Include Namespace="MemoryChunks.v1_2_6"/>
+        <edmx:Include Namespace="MemoryChunks.v1_3_0"/>
+        <edmx:Include Namespace="MemoryChunks.v1_3_1"/>
+        <edmx:Include Namespace="MemoryChunks.v1_3_2"/>
+        <edmx:Include Namespace="MemoryChunks.v1_4_0"/>
+        <edmx:Include Namespace="MemoryChunks.v1_4_1"/>
+    </edmx:Reference>
+    <edmx:Reference Uri="/redfish/v1/schema/MemoryChunksCollection_v1.xml">
+        <edmx:Include Namespace="MemoryChunksCollection"/>
+    </edmx:Reference>
     <edmx:Reference Uri="/redfish/v1/schema/MemoryCollection_v1.xml">
         <edmx:Include Namespace="MemoryCollection"/>
+    </edmx:Reference>
+    <edmx:Reference Uri="/redfish/v1/schema/MemoryDomain_v1.xml">
+        <edmx:Include Namespace="MemoryDomain"/>
+        <edmx:Include Namespace="MemoryDomain.v1_0_0"/>
+        <edmx:Include Namespace="MemoryDomain.v1_0_1"/>
+        <edmx:Include Namespace="MemoryDomain.v1_0_2"/>
+        <edmx:Include Namespace="MemoryDomain.v1_0_3"/>
+        <edmx:Include Namespace="MemoryDomain.v1_0_4"/>
+        <edmx:Include Namespace="MemoryDomain.v1_0_5"/>
+        <edmx:Include Namespace="MemoryDomain.v1_1_0"/>
+        <edmx:Include Namespace="MemoryDomain.v1_1_1"/>
+        <edmx:Include Namespace="MemoryDomain.v1_1_2"/>
+        <edmx:Include Namespace="MemoryDomain.v1_1_3"/>
+        <edmx:Include Namespace="MemoryDomain.v1_1_4"/>
+        <edmx:Include Namespace="MemoryDomain.v1_2_0"/>
+        <edmx:Include Namespace="MemoryDomain.v1_2_1"/>
+        <edmx:Include Namespace="MemoryDomain.v1_2_2"/>
+        <edmx:Include Namespace="MemoryDomain.v1_2_3"/>
+        <edmx:Include Namespace="MemoryDomain.v1_3_0"/>
+    </edmx:Reference>
+    <edmx:Reference Uri="/redfish/v1/schema/MemoryDomainCollection_v1.xml">
+        <edmx:Include Namespace="MemoryDomainCollection"/>
+    </edmx:Reference>
+    <edmx:Reference Uri="/redfish/v1/schema/MemoryMetrics_v1.xml">
+        <edmx:Include Namespace="MemoryMetrics"/>
+        <edmx:Include Namespace="MemoryMetrics.v1_0_0"/>
+        <edmx:Include Namespace="MemoryMetrics.v1_0_1"/>
+        <edmx:Include Namespace="MemoryMetrics.v1_0_2"/>
+        <edmx:Include Namespace="MemoryMetrics.v1_0_3"/>
+        <edmx:Include Namespace="MemoryMetrics.v1_0_4"/>
+        <edmx:Include Namespace="MemoryMetrics.v1_0_5"/>
+        <edmx:Include Namespace="MemoryMetrics.v1_0_6"/>
+        <edmx:Include Namespace="MemoryMetrics.v1_0_7"/>
+        <edmx:Include Namespace="MemoryMetrics.v1_0_8"/>
+        <edmx:Include Namespace="MemoryMetrics.v1_1_0"/>
+        <edmx:Include Namespace="MemoryMetrics.v1_1_1"/>
+        <edmx:Include Namespace="MemoryMetrics.v1_1_2"/>
+        <edmx:Include Namespace="MemoryMetrics.v1_1_3"/>
+        <edmx:Include Namespace="MemoryMetrics.v1_1_4"/>
+        <edmx:Include Namespace="MemoryMetrics.v1_1_5"/>
+        <edmx:Include Namespace="MemoryMetrics.v1_1_6"/>
+        <edmx:Include Namespace="MemoryMetrics.v1_1_7"/>
+        <edmx:Include Namespace="MemoryMetrics.v1_1_8"/>
+        <edmx:Include Namespace="MemoryMetrics.v1_2_0"/>
+        <edmx:Include Namespace="MemoryMetrics.v1_2_1"/>
+        <edmx:Include Namespace="MemoryMetrics.v1_2_2"/>
+        <edmx:Include Namespace="MemoryMetrics.v1_3_0"/>
+        <edmx:Include Namespace="MemoryMetrics.v1_3_1"/>
+        <edmx:Include Namespace="MemoryMetrics.v1_4_0"/>
+        <edmx:Include Namespace="MemoryMetrics.v1_4_1"/>
     </edmx:Reference>
     <edmx:Reference Uri="/redfish/v1/schema/Message_v1.xml">
         <edmx:Include Namespace="Message"/>
@@ -1479,6 +1940,161 @@
     <edmx:Reference Uri="/redfish/v1/schema/MetricReportDefinitionCollection_v1.xml">
         <edmx:Include Namespace="MetricReportDefinitionCollection"/>
     </edmx:Reference>
+    <edmx:Reference Uri="/redfish/v1/schema/NetworkAdapter_v1.xml">
+        <edmx:Include Namespace="NetworkAdapter"/>
+        <edmx:Include Namespace="NetworkAdapter.v1_0_0"/>
+        <edmx:Include Namespace="NetworkAdapter.v1_0_1"/>
+        <edmx:Include Namespace="NetworkAdapter.v1_0_2"/>
+        <edmx:Include Namespace="NetworkAdapter.v1_0_3"/>
+        <edmx:Include Namespace="NetworkAdapter.v1_0_4"/>
+        <edmx:Include Namespace="NetworkAdapter.v1_0_5"/>
+        <edmx:Include Namespace="NetworkAdapter.v1_0_6"/>
+        <edmx:Include Namespace="NetworkAdapter.v1_0_7"/>
+        <edmx:Include Namespace="NetworkAdapter.v1_1_0"/>
+        <edmx:Include Namespace="NetworkAdapter.v1_1_1"/>
+        <edmx:Include Namespace="NetworkAdapter.v1_1_2"/>
+        <edmx:Include Namespace="NetworkAdapter.v1_1_3"/>
+        <edmx:Include Namespace="NetworkAdapter.v1_1_4"/>
+        <edmx:Include Namespace="NetworkAdapter.v1_1_5"/>
+        <edmx:Include Namespace="NetworkAdapter.v1_1_6"/>
+        <edmx:Include Namespace="NetworkAdapter.v1_2_0"/>
+        <edmx:Include Namespace="NetworkAdapter.v1_2_1"/>
+        <edmx:Include Namespace="NetworkAdapter.v1_2_2"/>
+        <edmx:Include Namespace="NetworkAdapter.v1_2_3"/>
+        <edmx:Include Namespace="NetworkAdapter.v1_2_4"/>
+        <edmx:Include Namespace="NetworkAdapter.v1_2_5"/>
+        <edmx:Include Namespace="NetworkAdapter.v1_3_0"/>
+        <edmx:Include Namespace="NetworkAdapter.v1_3_1"/>
+        <edmx:Include Namespace="NetworkAdapter.v1_3_2"/>
+        <edmx:Include Namespace="NetworkAdapter.v1_3_3"/>
+        <edmx:Include Namespace="NetworkAdapter.v1_3_4"/>
+        <edmx:Include Namespace="NetworkAdapter.v1_4_0"/>
+        <edmx:Include Namespace="NetworkAdapter.v1_4_1"/>
+        <edmx:Include Namespace="NetworkAdapter.v1_5_0"/>
+        <edmx:Include Namespace="NetworkAdapter.v1_5_1"/>
+        <edmx:Include Namespace="NetworkAdapter.v1_6_0"/>
+        <edmx:Include Namespace="NetworkAdapter.v1_7_0"/>
+        <edmx:Include Namespace="NetworkAdapter.v1_8_0"/>
+    </edmx:Reference>
+    <edmx:Reference Uri="/redfish/v1/schema/NetworkAdapterCollection_v1.xml">
+        <edmx:Include Namespace="NetworkAdapterCollection"/>
+    </edmx:Reference>
+    <edmx:Reference Uri="/redfish/v1/schema/NetworkAdapterMetrics_v1.xml">
+        <edmx:Include Namespace="NetworkAdapterMetrics"/>
+        <edmx:Include Namespace="NetworkAdapterMetrics.v1_0_0"/>
+    </edmx:Reference>
+    <edmx:Reference Uri="/redfish/v1/schema/NetworkDeviceFunction_v1.xml">
+        <edmx:Include Namespace="NetworkDeviceFunction"/>
+        <edmx:Include Namespace="NetworkDeviceFunction.v1_0_0"/>
+        <edmx:Include Namespace="NetworkDeviceFunction.v1_0_1"/>
+        <edmx:Include Namespace="NetworkDeviceFunction.v1_0_2"/>
+        <edmx:Include Namespace="NetworkDeviceFunction.v1_0_3"/>
+        <edmx:Include Namespace="NetworkDeviceFunction.v1_0_4"/>
+        <edmx:Include Namespace="NetworkDeviceFunction.v1_0_5"/>
+        <edmx:Include Namespace="NetworkDeviceFunction.v1_0_6"/>
+        <edmx:Include Namespace="NetworkDeviceFunction.v1_0_7"/>
+        <edmx:Include Namespace="NetworkDeviceFunction.v1_0_8"/>
+        <edmx:Include Namespace="NetworkDeviceFunction.v1_0_9"/>
+        <edmx:Include Namespace="NetworkDeviceFunction.v1_1_0"/>
+        <edmx:Include Namespace="NetworkDeviceFunction.v1_1_1"/>
+        <edmx:Include Namespace="NetworkDeviceFunction.v1_1_2"/>
+        <edmx:Include Namespace="NetworkDeviceFunction.v1_1_3"/>
+        <edmx:Include Namespace="NetworkDeviceFunction.v1_1_4"/>
+        <edmx:Include Namespace="NetworkDeviceFunction.v1_1_5"/>
+        <edmx:Include Namespace="NetworkDeviceFunction.v1_1_6"/>
+        <edmx:Include Namespace="NetworkDeviceFunction.v1_1_7"/>
+        <edmx:Include Namespace="NetworkDeviceFunction.v1_1_8"/>
+        <edmx:Include Namespace="NetworkDeviceFunction.v1_2_0"/>
+        <edmx:Include Namespace="NetworkDeviceFunction.v1_2_1"/>
+        <edmx:Include Namespace="NetworkDeviceFunction.v1_2_2"/>
+        <edmx:Include Namespace="NetworkDeviceFunction.v1_2_3"/>
+        <edmx:Include Namespace="NetworkDeviceFunction.v1_2_4"/>
+        <edmx:Include Namespace="NetworkDeviceFunction.v1_2_5"/>
+        <edmx:Include Namespace="NetworkDeviceFunction.v1_2_6"/>
+        <edmx:Include Namespace="NetworkDeviceFunction.v1_2_7"/>
+        <edmx:Include Namespace="NetworkDeviceFunction.v1_2_8"/>
+        <edmx:Include Namespace="NetworkDeviceFunction.v1_3_0"/>
+        <edmx:Include Namespace="NetworkDeviceFunction.v1_3_1"/>
+        <edmx:Include Namespace="NetworkDeviceFunction.v1_3_2"/>
+        <edmx:Include Namespace="NetworkDeviceFunction.v1_3_3"/>
+        <edmx:Include Namespace="NetworkDeviceFunction.v1_3_4"/>
+        <edmx:Include Namespace="NetworkDeviceFunction.v1_3_5"/>
+        <edmx:Include Namespace="NetworkDeviceFunction.v1_3_6"/>
+        <edmx:Include Namespace="NetworkDeviceFunction.v1_4_0"/>
+        <edmx:Include Namespace="NetworkDeviceFunction.v1_4_1"/>
+        <edmx:Include Namespace="NetworkDeviceFunction.v1_4_2"/>
+        <edmx:Include Namespace="NetworkDeviceFunction.v1_4_3"/>
+        <edmx:Include Namespace="NetworkDeviceFunction.v1_5_0"/>
+        <edmx:Include Namespace="NetworkDeviceFunction.v1_5_1"/>
+        <edmx:Include Namespace="NetworkDeviceFunction.v1_5_2"/>
+        <edmx:Include Namespace="NetworkDeviceFunction.v1_6_0"/>
+        <edmx:Include Namespace="NetworkDeviceFunction.v1_7_0"/>
+    </edmx:Reference>
+    <edmx:Reference Uri="/redfish/v1/schema/NetworkDeviceFunctionCollection_v1.xml">
+        <edmx:Include Namespace="NetworkDeviceFunctionCollection"/>
+    </edmx:Reference>
+    <edmx:Reference Uri="/redfish/v1/schema/NetworkDeviceFunctionMetrics_v1.xml">
+        <edmx:Include Namespace="NetworkDeviceFunctionMetrics"/>
+        <edmx:Include Namespace="NetworkDeviceFunctionMetrics.v1_0_0"/>
+        <edmx:Include Namespace="NetworkDeviceFunctionMetrics.v1_1_0"/>
+    </edmx:Reference>
+    <edmx:Reference Uri="/redfish/v1/schema/NetworkInterface_v1.xml">
+        <edmx:Include Namespace="NetworkInterface"/>
+        <edmx:Include Namespace="NetworkInterface.v1_0_0"/>
+        <edmx:Include Namespace="NetworkInterface.v1_0_1"/>
+        <edmx:Include Namespace="NetworkInterface.v1_0_2"/>
+        <edmx:Include Namespace="NetworkInterface.v1_0_3"/>
+        <edmx:Include Namespace="NetworkInterface.v1_0_4"/>
+        <edmx:Include Namespace="NetworkInterface.v1_0_5"/>
+        <edmx:Include Namespace="NetworkInterface.v1_0_6"/>
+        <edmx:Include Namespace="NetworkInterface.v1_1_0"/>
+        <edmx:Include Namespace="NetworkInterface.v1_1_1"/>
+        <edmx:Include Namespace="NetworkInterface.v1_1_2"/>
+        <edmx:Include Namespace="NetworkInterface.v1_1_3"/>
+        <edmx:Include Namespace="NetworkInterface.v1_1_4"/>
+        <edmx:Include Namespace="NetworkInterface.v1_1_5"/>
+        <edmx:Include Namespace="NetworkInterface.v1_2_0"/>
+        <edmx:Include Namespace="NetworkInterface.v1_2_1"/>
+    </edmx:Reference>
+    <edmx:Reference Uri="/redfish/v1/schema/NetworkInterfaceCollection_v1.xml">
+        <edmx:Include Namespace="NetworkInterfaceCollection"/>
+    </edmx:Reference>
+    <edmx:Reference Uri="/redfish/v1/schema/NetworkPort_v1.xml">
+        <edmx:Include Namespace="NetworkPort"/>
+        <edmx:Include Namespace="NetworkPort.v1_0_0"/>
+        <edmx:Include Namespace="NetworkPort.v1_0_1"/>
+        <edmx:Include Namespace="NetworkPort.v1_0_2"/>
+        <edmx:Include Namespace="NetworkPort.v1_0_3"/>
+        <edmx:Include Namespace="NetworkPort.v1_0_4"/>
+        <edmx:Include Namespace="NetworkPort.v1_0_5"/>
+        <edmx:Include Namespace="NetworkPort.v1_0_6"/>
+        <edmx:Include Namespace="NetworkPort.v1_0_7"/>
+        <edmx:Include Namespace="NetworkPort.v1_0_8"/>
+        <edmx:Include Namespace="NetworkPort.v1_1_0"/>
+        <edmx:Include Namespace="NetworkPort.v1_1_1"/>
+        <edmx:Include Namespace="NetworkPort.v1_1_2"/>
+        <edmx:Include Namespace="NetworkPort.v1_1_3"/>
+        <edmx:Include Namespace="NetworkPort.v1_1_4"/>
+        <edmx:Include Namespace="NetworkPort.v1_1_5"/>
+        <edmx:Include Namespace="NetworkPort.v1_1_6"/>
+        <edmx:Include Namespace="NetworkPort.v1_1_7"/>
+        <edmx:Include Namespace="NetworkPort.v1_2_0"/>
+        <edmx:Include Namespace="NetworkPort.v1_2_1"/>
+        <edmx:Include Namespace="NetworkPort.v1_2_2"/>
+        <edmx:Include Namespace="NetworkPort.v1_2_3"/>
+        <edmx:Include Namespace="NetworkPort.v1_2_4"/>
+        <edmx:Include Namespace="NetworkPort.v1_2_5"/>
+        <edmx:Include Namespace="NetworkPort.v1_2_6"/>
+        <edmx:Include Namespace="NetworkPort.v1_2_7"/>
+        <edmx:Include Namespace="NetworkPort.v1_3_0"/>
+        <edmx:Include Namespace="NetworkPort.v1_3_1"/>
+        <edmx:Include Namespace="NetworkPort.v1_3_2"/>
+        <edmx:Include Namespace="NetworkPort.v1_4_0"/>
+        <edmx:Include Namespace="NetworkPort.v1_4_1"/>
+    </edmx:Reference>
+    <edmx:Reference Uri="/redfish/v1/schema/NetworkPortCollection_v1.xml">
+        <edmx:Include Namespace="NetworkPortCollection"/>
+    </edmx:Reference>
     <edmx:Reference Uri="/redfish/v1/schema/OperatingConfig_v1.xml">
         <edmx:Include Namespace="OperatingConfig"/>
         <edmx:Include Namespace="OperatingConfig.v1_0_0"/>
@@ -1487,6 +2103,26 @@
     </edmx:Reference>
     <edmx:Reference Uri="/redfish/v1/schema/OperatingConfigCollection_v1.xml">
         <edmx:Include Namespace="OperatingConfigCollection"/>
+    </edmx:Reference>
+    <edmx:Reference Uri="/redfish/v1/schema/Outlet_v1.xml">
+        <edmx:Include Namespace="Outlet"/>
+        <edmx:Include Namespace="Outlet.v1_0_0"/>
+        <edmx:Include Namespace="Outlet.v1_0_1"/>
+        <edmx:Include Namespace="Outlet.v1_0_2"/>
+        <edmx:Include Namespace="Outlet.v1_1_0"/>
+        <edmx:Include Namespace="Outlet.v1_1_1"/>
+        <edmx:Include Namespace="Outlet.v1_2_0"/>
+    </edmx:Reference>
+    <edmx:Reference Uri="/redfish/v1/schema/OutletCollection_v1.xml">
+        <edmx:Include Namespace="OutletCollection"/>
+    </edmx:Reference>
+    <edmx:Reference Uri="/redfish/v1/schema/OutletGroup_v1.xml">
+        <edmx:Include Namespace="OutletGroup"/>
+        <edmx:Include Namespace="OutletGroup.v1_0_0"/>
+        <edmx:Include Namespace="OutletGroup.v1_0_1"/>
+    </edmx:Reference>
+    <edmx:Reference Uri="/redfish/v1/schema/OutletGroupCollection_v1.xml">
+        <edmx:Include Namespace="OutletGroupCollection"/>
     </edmx:Reference>
     <edmx:Reference Uri="/redfish/v1/schema/PCIeDevice_v1.xml">
         <edmx:Include Namespace="PCIeDevice"/>
@@ -1559,6 +2195,9 @@
         <edmx:Include Namespace="PCIeSlots.v1_4_0"/>
         <edmx:Include Namespace="PCIeSlots.v1_4_1"/>
     </edmx:Reference>
+    <edmx:Reference Uri="/redfish/v1/schema/PhysicalContext_v1.xml">
+        <edmx:Include Namespace="PhysicalContext"/>
+    </edmx:Reference>
     <edmx:Reference Uri="/redfish/v1/schema/Port_v1.xml">
         <edmx:Include Namespace="Port"/>
         <edmx:Include Namespace="Port.v1_0_0"/>
@@ -1583,13 +2222,26 @@
         <edmx:Include Namespace="Port.v1_2_2"/>
         <edmx:Include Namespace="Port.v1_2_3"/>
         <edmx:Include Namespace="Port.v1_2_4"/>
+        <edmx:Include Namespace="Port.v1_2_5"/>
         <edmx:Include Namespace="Port.v1_3_0"/>
         <edmx:Include Namespace="Port.v1_3_1"/>
         <edmx:Include Namespace="Port.v1_3_2"/>
+        <edmx:Include Namespace="Port.v1_3_3"/>
         <edmx:Include Namespace="Port.v1_4_0"/>
+        <edmx:Include Namespace="Port.v1_4_1"/>
+        <edmx:Include Namespace="Port.v1_5_0"/>
     </edmx:Reference>
     <edmx:Reference Uri="/redfish/v1/schema/PortCollection_v1.xml">
         <edmx:Include Namespace="PortCollection"/>
+    </edmx:Reference>
+    <edmx:Reference Uri="/redfish/v1/schema/PortMetrics_v1.xml">
+        <edmx:Include Namespace="PortMetrics"/>
+        <edmx:Include Namespace="PortMetrics.v1_0_0"/>
+        <edmx:Include Namespace="PortMetrics.v1_0_1"/>
+        <edmx:Include Namespace="PortMetrics.v1_0_2"/>
+        <edmx:Include Namespace="PortMetrics.v1_1_0"/>
+        <edmx:Include Namespace="PortMetrics.v1_1_1"/>
+        <edmx:Include Namespace="PortMetrics.v1_2_0"/>
     </edmx:Reference>
     <edmx:Reference Uri="/redfish/v1/schema/Power_v1.xml">
         <edmx:Include Namespace="Power"/>
@@ -1665,16 +2317,69 @@
         <edmx:Include Namespace="Power.v1_7_0"/>
         <edmx:Include Namespace="Power.v1_7_1"/>
     </edmx:Reference>
+    <edmx:Reference Uri="/redfish/v1/schema/PowerDistribution_v1.xml">
+        <edmx:Include Namespace="PowerDistribution"/>
+        <edmx:Include Namespace="PowerDistribution.v1_0_0"/>
+        <edmx:Include Namespace="PowerDistribution.v1_0_1"/>
+        <edmx:Include Namespace="PowerDistribution.v1_0_2"/>
+        <edmx:Include Namespace="PowerDistribution.v1_0_3"/>
+        <edmx:Include Namespace="PowerDistribution.v1_1_0"/>
+    </edmx:Reference>
+    <edmx:Reference Uri="/redfish/v1/schema/PowerDistributionCollection_v1.xml">
+        <edmx:Include Namespace="PowerDistributionCollection"/>
+    </edmx:Reference>
+    <edmx:Reference Uri="/redfish/v1/schema/PowerDistributionMetrics_v1.xml">
+        <edmx:Include Namespace="PowerDistributionMetrics"/>
+        <edmx:Include Namespace="PowerDistributionMetrics.v1_0_0"/>
+        <edmx:Include Namespace="PowerDistributionMetrics.v1_0_1"/>
+        <edmx:Include Namespace="PowerDistributionMetrics.v1_1_0"/>
+        <edmx:Include Namespace="PowerDistributionMetrics.v1_2_0"/>
+    </edmx:Reference>
+    <edmx:Reference Uri="/redfish/v1/schema/PowerDomain_v1.xml">
+        <edmx:Include Namespace="PowerDomain"/>
+        <edmx:Include Namespace="PowerDomain.v1_0_0"/>
+        <edmx:Include Namespace="PowerDomain.v1_0_1"/>
+        <edmx:Include Namespace="PowerDomain.v1_1_0"/>
+    </edmx:Reference>
+    <edmx:Reference Uri="/redfish/v1/schema/PowerDomainCollection_v1.xml">
+        <edmx:Include Namespace="PowerDomainCollection"/>
+    </edmx:Reference>
+    <edmx:Reference Uri="/redfish/v1/schema/PowerEquipment_v1.xml">
+        <edmx:Include Namespace="PowerEquipment"/>
+        <edmx:Include Namespace="PowerEquipment.v1_0_0"/>
+        <edmx:Include Namespace="PowerEquipment.v1_1_0"/>
+    </edmx:Reference>
     <edmx:Reference Uri="/redfish/v1/schema/PowerSubsystem_v1.xml">
         <edmx:Include Namespace="PowerSubsystem"/>
         <edmx:Include Namespace="PowerSubsystem.v1_0_0"/>
+        <edmx:Include Namespace="PowerSubsystem.v1_1_0"/>
     </edmx:Reference>
     <edmx:Reference Uri="/redfish/v1/schema/PowerSupply_v1.xml">
         <edmx:Include Namespace="PowerSupply"/>
         <edmx:Include Namespace="PowerSupply.v1_0_0"/>
+        <edmx:Include Namespace="PowerSupply.v1_0_1"/>
+        <edmx:Include Namespace="PowerSupply.v1_1_0"/>
     </edmx:Reference>
     <edmx:Reference Uri="/redfish/v1/schema/PowerSupplyCollection_v1.xml">
         <edmx:Include Namespace="PowerSupplyCollection"/>
+    </edmx:Reference>
+    <edmx:Reference Uri="/redfish/v1/schema/PowerSupplyMetrics_v1.xml">
+        <edmx:Include Namespace="PowerSupplyMetrics"/>
+        <edmx:Include Namespace="PowerSupplyMetrics.v1_0_0"/>
+    </edmx:Reference>
+    <edmx:Reference Uri="/redfish/v1/schema/PrivilegeRegistry_v1.xml">
+        <edmx:Include Namespace="PrivilegeRegistry"/>
+        <edmx:Include Namespace="PrivilegeRegistry.v1_0_0"/>
+        <edmx:Include Namespace="PrivilegeRegistry.v1_0_1"/>
+        <edmx:Include Namespace="PrivilegeRegistry.v1_0_2"/>
+        <edmx:Include Namespace="PrivilegeRegistry.v1_0_3"/>
+        <edmx:Include Namespace="PrivilegeRegistry.v1_0_4"/>
+        <edmx:Include Namespace="PrivilegeRegistry.v1_0_5"/>
+        <edmx:Include Namespace="PrivilegeRegistry.v1_1_0"/>
+        <edmx:Include Namespace="PrivilegeRegistry.v1_1_1"/>
+        <edmx:Include Namespace="PrivilegeRegistry.v1_1_2"/>
+        <edmx:Include Namespace="PrivilegeRegistry.v1_1_3"/>
+        <edmx:Include Namespace="PrivilegeRegistry.v1_1_4"/>
     </edmx:Reference>
     <edmx:Reference Uri="/redfish/v1/schema/Privileges_v1.xml">
         <edmx:Include Namespace="Privileges"/>
@@ -1772,6 +2477,27 @@
     </edmx:Reference>
     <edmx:Reference Uri="/redfish/v1/schema/ProcessorCollection_v1.xml">
         <edmx:Include Namespace="ProcessorCollection"/>
+    </edmx:Reference>
+    <edmx:Reference Uri="/redfish/v1/schema/ProcessorMetrics_v1.xml">
+        <edmx:Include Namespace="ProcessorMetrics"/>
+        <edmx:Include Namespace="ProcessorMetrics.v1_0_0"/>
+        <edmx:Include Namespace="ProcessorMetrics.v1_0_1"/>
+        <edmx:Include Namespace="ProcessorMetrics.v1_0_2"/>
+        <edmx:Include Namespace="ProcessorMetrics.v1_0_3"/>
+        <edmx:Include Namespace="ProcessorMetrics.v1_0_4"/>
+        <edmx:Include Namespace="ProcessorMetrics.v1_0_5"/>
+        <edmx:Include Namespace="ProcessorMetrics.v1_1_0"/>
+        <edmx:Include Namespace="ProcessorMetrics.v1_1_1"/>
+        <edmx:Include Namespace="ProcessorMetrics.v1_1_2"/>
+        <edmx:Include Namespace="ProcessorMetrics.v1_1_3"/>
+        <edmx:Include Namespace="ProcessorMetrics.v1_1_4"/>
+        <edmx:Include Namespace="ProcessorMetrics.v1_2_0"/>
+        <edmx:Include Namespace="ProcessorMetrics.v1_2_1"/>
+        <edmx:Include Namespace="ProcessorMetrics.v1_2_2"/>
+        <edmx:Include Namespace="ProcessorMetrics.v1_3_0"/>
+    </edmx:Reference>
+    <edmx:Reference Uri="/redfish/v1/schema/Protocol_v1.xml">
+        <edmx:Include Namespace="Protocol"/>
     </edmx:Reference>
     <edmx:Reference Uri="/redfish/v1/schema/RedfishError_v1.xml">
         <edmx:Include Namespace="RedfishError.v1_0_0"/>
@@ -1945,6 +2671,38 @@
         <edmx:Include Namespace="Resource.v1_12_1"/>
         <edmx:Include Namespace="Resource.v1_13_0"/>
     </edmx:Reference>
+    <edmx:Reference Uri="/redfish/v1/schema/ResourceBlock_v1.xml">
+        <edmx:Include Namespace="ResourceBlock"/>
+        <edmx:Include Namespace="ResourceBlock.v1_0_0"/>
+        <edmx:Include Namespace="ResourceBlock.v1_0_1"/>
+        <edmx:Include Namespace="ResourceBlock.v1_0_2"/>
+        <edmx:Include Namespace="ResourceBlock.v1_0_3"/>
+        <edmx:Include Namespace="ResourceBlock.v1_0_4"/>
+        <edmx:Include Namespace="ResourceBlock.v1_0_5"/>
+        <edmx:Include Namespace="ResourceBlock.v1_0_6"/>
+        <edmx:Include Namespace="ResourceBlock.v1_1_0"/>
+        <edmx:Include Namespace="ResourceBlock.v1_1_1"/>
+        <edmx:Include Namespace="ResourceBlock.v1_1_2"/>
+        <edmx:Include Namespace="ResourceBlock.v1_1_3"/>
+        <edmx:Include Namespace="ResourceBlock.v1_1_4"/>
+        <edmx:Include Namespace="ResourceBlock.v1_1_5"/>
+        <edmx:Include Namespace="ResourceBlock.v1_1_6"/>
+        <edmx:Include Namespace="ResourceBlock.v1_2_0"/>
+        <edmx:Include Namespace="ResourceBlock.v1_2_1"/>
+        <edmx:Include Namespace="ResourceBlock.v1_2_2"/>
+        <edmx:Include Namespace="ResourceBlock.v1_2_3"/>
+        <edmx:Include Namespace="ResourceBlock.v1_2_4"/>
+        <edmx:Include Namespace="ResourceBlock.v1_2_5"/>
+        <edmx:Include Namespace="ResourceBlock.v1_3_0"/>
+        <edmx:Include Namespace="ResourceBlock.v1_3_1"/>
+        <edmx:Include Namespace="ResourceBlock.v1_3_2"/>
+        <edmx:Include Namespace="ResourceBlock.v1_3_3"/>
+        <edmx:Include Namespace="ResourceBlock.v1_3_4"/>
+        <edmx:Include Namespace="ResourceBlock.v1_4_0"/>
+    </edmx:Reference>
+    <edmx:Reference Uri="/redfish/v1/schema/ResourceBlockCollection_v1.xml">
+        <edmx:Include Namespace="ResourceBlockCollection"/>
+    </edmx:Reference>
     <edmx:Reference Uri="/redfish/v1/schema/Role_v1.xml">
         <edmx:Include Namespace="Role"/>
         <edmx:Include Namespace="Role.v1_0_0"/>
@@ -1975,6 +2733,53 @@
     <edmx:Reference Uri="/redfish/v1/schema/RoleCollection_v1.xml">
         <edmx:Include Namespace="RoleCollection"/>
     </edmx:Reference>
+    <edmx:Reference Uri="/redfish/v1/schema/RouteEntry_v1.xml">
+        <edmx:Include Namespace="RouteEntry"/>
+        <edmx:Include Namespace="RouteEntry.v1_0_0"/>
+        <edmx:Include Namespace="RouteEntry.v1_0_1"/>
+    </edmx:Reference>
+    <edmx:Reference Uri="/redfish/v1/schema/RouteEntryCollection_v1.xml">
+        <edmx:Include Namespace="RouteEntryCollection"/>
+    </edmx:Reference>
+    <edmx:Reference Uri="/redfish/v1/schema/RouteSetEntry_v1.xml">
+        <edmx:Include Namespace="RouteSetEntry"/>
+        <edmx:Include Namespace="RouteSetEntry.v1_0_0"/>
+        <edmx:Include Namespace="RouteSetEntry.v1_0_1"/>
+    </edmx:Reference>
+    <edmx:Reference Uri="/redfish/v1/schema/RouteSetEntryCollection_v1.xml">
+        <edmx:Include Namespace="RouteSetEntryCollection"/>
+    </edmx:Reference>
+    <edmx:Reference Uri="/redfish/v1/schema/Schedule_v1.xml">
+        <edmx:Include Namespace="Schedule"/>
+        <edmx:Include Namespace="Schedule.v1_0_0"/>
+        <edmx:Include Namespace="Schedule.v1_0_1"/>
+        <edmx:Include Namespace="Schedule.v1_1_0"/>
+        <edmx:Include Namespace="Schedule.v1_1_1"/>
+        <edmx:Include Namespace="Schedule.v1_1_2"/>
+        <edmx:Include Namespace="Schedule.v1_2_0"/>
+        <edmx:Include Namespace="Schedule.v1_2_1"/>
+        <edmx:Include Namespace="Schedule.v1_2_2"/>
+    </edmx:Reference>
+    <edmx:Reference Uri="/redfish/v1/schema/SecureBoot_v1.xml">
+        <edmx:Include Namespace="SecureBoot"/>
+        <edmx:Include Namespace="SecureBoot.v1_0_0"/>
+        <edmx:Include Namespace="SecureBoot.v1_0_1"/>
+        <edmx:Include Namespace="SecureBoot.v1_0_2"/>
+        <edmx:Include Namespace="SecureBoot.v1_0_3"/>
+        <edmx:Include Namespace="SecureBoot.v1_0_4"/>
+        <edmx:Include Namespace="SecureBoot.v1_0_5"/>
+        <edmx:Include Namespace="SecureBoot.v1_0_6"/>
+        <edmx:Include Namespace="SecureBoot.v1_0_7"/>
+        <edmx:Include Namespace="SecureBoot.v1_1_0"/>
+    </edmx:Reference>
+    <edmx:Reference Uri="/redfish/v1/schema/SecureBootDatabase_v1.xml">
+        <edmx:Include Namespace="SecureBootDatabase"/>
+        <edmx:Include Namespace="SecureBootDatabase.v1_0_0"/>
+        <edmx:Include Namespace="SecureBootDatabase.v1_0_1"/>
+    </edmx:Reference>
+    <edmx:Reference Uri="/redfish/v1/schema/SecureBootDatabaseCollection_v1.xml">
+        <edmx:Include Namespace="SecureBootDatabaseCollection"/>
+    </edmx:Reference>
     <edmx:Reference Uri="/redfish/v1/schema/Sensor_v1.xml">
         <edmx:Include Namespace="Sensor"/>
         <edmx:Include Namespace="Sensor.v1_0_0"/>
@@ -1997,6 +2802,32 @@
     </edmx:Reference>
     <edmx:Reference Uri="/redfish/v1/schema/SensorCollection_v1.xml">
         <edmx:Include Namespace="SensorCollection"/>
+    </edmx:Reference>
+    <edmx:Reference Uri="/redfish/v1/schema/SerialInterface_v1.xml">
+        <edmx:Include Namespace="SerialInterface"/>
+        <edmx:Include Namespace="SerialInterface.v1_0_0"/>
+        <edmx:Include Namespace="SerialInterface.v1_0_2"/>
+        <edmx:Include Namespace="SerialInterface.v1_0_3"/>
+        <edmx:Include Namespace="SerialInterface.v1_0_4"/>
+        <edmx:Include Namespace="SerialInterface.v1_0_5"/>
+        <edmx:Include Namespace="SerialInterface.v1_0_6"/>
+        <edmx:Include Namespace="SerialInterface.v1_0_7"/>
+        <edmx:Include Namespace="SerialInterface.v1_0_8"/>
+        <edmx:Include Namespace="SerialInterface.v1_0_9"/>
+        <edmx:Include Namespace="SerialInterface.v1_0_10"/>
+        <edmx:Include Namespace="SerialInterface.v1_0_11"/>
+        <edmx:Include Namespace="SerialInterface.v1_1_0"/>
+        <edmx:Include Namespace="SerialInterface.v1_1_1"/>
+        <edmx:Include Namespace="SerialInterface.v1_1_2"/>
+        <edmx:Include Namespace="SerialInterface.v1_1_3"/>
+        <edmx:Include Namespace="SerialInterface.v1_1_4"/>
+        <edmx:Include Namespace="SerialInterface.v1_1_5"/>
+        <edmx:Include Namespace="SerialInterface.v1_1_6"/>
+        <edmx:Include Namespace="SerialInterface.v1_1_7"/>
+        <edmx:Include Namespace="SerialInterface.v1_1_8"/>
+    </edmx:Reference>
+    <edmx:Reference Uri="/redfish/v1/schema/SerialInterfaceCollection_v1.xml">
+        <edmx:Include Namespace="SerialInterfaceCollection"/>
     </edmx:Reference>
     <edmx:Reference Uri="/redfish/v1/schema/ServiceRoot_v1.xml">
         <edmx:Include Namespace="ServiceRoot"/>
@@ -2106,6 +2937,43 @@
         <edmx:Include Namespace="Settings.v1_3_1"/>
         <edmx:Include Namespace="Settings.v1_3_2"/>
         <edmx:Include Namespace="Settings.v1_3_3"/>
+    </edmx:Reference>
+    <edmx:Reference Uri="/redfish/v1/schema/Signature_v1.xml">
+        <edmx:Include Namespace="Signature"/>
+        <edmx:Include Namespace="Signature.v1_0_0"/>
+        <edmx:Include Namespace="Signature.v1_0_1"/>
+        <edmx:Include Namespace="Signature.v1_0_2"/>
+    </edmx:Reference>
+    <edmx:Reference Uri="/redfish/v1/schema/SignatureCollection_v1.xml">
+        <edmx:Include Namespace="SignatureCollection"/>
+    </edmx:Reference>
+    <edmx:Reference Uri="/redfish/v1/schema/SimpleStorage_v1.xml">
+        <edmx:Include Namespace="SimpleStorage"/>
+        <edmx:Include Namespace="SimpleStorage.v1_0_0"/>
+        <edmx:Include Namespace="SimpleStorage.v1_0_2"/>
+        <edmx:Include Namespace="SimpleStorage.v1_0_3"/>
+        <edmx:Include Namespace="SimpleStorage.v1_0_4"/>
+        <edmx:Include Namespace="SimpleStorage.v1_0_5"/>
+        <edmx:Include Namespace="SimpleStorage.v1_0_6"/>
+        <edmx:Include Namespace="SimpleStorage.v1_0_7"/>
+        <edmx:Include Namespace="SimpleStorage.v1_0_8"/>
+        <edmx:Include Namespace="SimpleStorage.v1_1_0"/>
+        <edmx:Include Namespace="SimpleStorage.v1_1_1"/>
+        <edmx:Include Namespace="SimpleStorage.v1_1_2"/>
+        <edmx:Include Namespace="SimpleStorage.v1_1_3"/>
+        <edmx:Include Namespace="SimpleStorage.v1_1_4"/>
+        <edmx:Include Namespace="SimpleStorage.v1_1_5"/>
+        <edmx:Include Namespace="SimpleStorage.v1_1_6"/>
+        <edmx:Include Namespace="SimpleStorage.v1_2_0"/>
+        <edmx:Include Namespace="SimpleStorage.v1_2_1"/>
+        <edmx:Include Namespace="SimpleStorage.v1_2_2"/>
+        <edmx:Include Namespace="SimpleStorage.v1_2_3"/>
+        <edmx:Include Namespace="SimpleStorage.v1_2_4"/>
+        <edmx:Include Namespace="SimpleStorage.v1_3_0"/>
+        <edmx:Include Namespace="SimpleStorage.v1_3_1"/>
+    </edmx:Reference>
+    <edmx:Reference Uri="/redfish/v1/schema/SimpleStorageCollection_v1.xml">
+        <edmx:Include Namespace="SimpleStorageCollection"/>
     </edmx:Reference>
     <edmx:Reference Uri="/redfish/v1/schema/SoftwareInventory_v1.xml">
         <edmx:Include Namespace="SoftwareInventory"/>
@@ -2226,6 +3094,43 @@
     </edmx:Reference>
     <edmx:Reference Uri="/redfish/v1/schema/StorageControllerCollection_v1.xml">
         <edmx:Include Namespace="StorageControllerCollection"/>
+    </edmx:Reference>
+    <edmx:Reference Uri="/redfish/v1/schema/Switch_v1.xml">
+        <edmx:Include Namespace="Switch"/>
+        <edmx:Include Namespace="Switch.v1_0_0"/>
+        <edmx:Include Namespace="Switch.v1_0_1"/>
+        <edmx:Include Namespace="Switch.v1_0_2"/>
+        <edmx:Include Namespace="Switch.v1_0_3"/>
+        <edmx:Include Namespace="Switch.v1_0_4"/>
+        <edmx:Include Namespace="Switch.v1_0_5"/>
+        <edmx:Include Namespace="Switch.v1_0_6"/>
+        <edmx:Include Namespace="Switch.v1_0_7"/>
+        <edmx:Include Namespace="Switch.v1_0_8"/>
+        <edmx:Include Namespace="Switch.v1_0_9"/>
+        <edmx:Include Namespace="Switch.v1_1_0"/>
+        <edmx:Include Namespace="Switch.v1_1_1"/>
+        <edmx:Include Namespace="Switch.v1_1_2"/>
+        <edmx:Include Namespace="Switch.v1_1_3"/>
+        <edmx:Include Namespace="Switch.v1_1_4"/>
+        <edmx:Include Namespace="Switch.v1_1_5"/>
+        <edmx:Include Namespace="Switch.v1_1_6"/>
+        <edmx:Include Namespace="Switch.v1_2_0"/>
+        <edmx:Include Namespace="Switch.v1_2_1"/>
+        <edmx:Include Namespace="Switch.v1_2_2"/>
+        <edmx:Include Namespace="Switch.v1_2_3"/>
+        <edmx:Include Namespace="Switch.v1_3_0"/>
+        <edmx:Include Namespace="Switch.v1_3_1"/>
+        <edmx:Include Namespace="Switch.v1_3_2"/>
+        <edmx:Include Namespace="Switch.v1_3_3"/>
+        <edmx:Include Namespace="Switch.v1_4_0"/>
+        <edmx:Include Namespace="Switch.v1_4_1"/>
+        <edmx:Include Namespace="Switch.v1_4_2"/>
+        <edmx:Include Namespace="Switch.v1_5_0"/>
+        <edmx:Include Namespace="Switch.v1_5_1"/>
+        <edmx:Include Namespace="Switch.v1_6_0"/>
+    </edmx:Reference>
+    <edmx:Reference Uri="/redfish/v1/schema/SwitchCollection_v1.xml">
+        <edmx:Include Namespace="SwitchCollection"/>
     </edmx:Reference>
     <edmx:Reference Uri="/redfish/v1/schema/Task_v1.xml">
         <edmx:Include Namespace="Task"/>
@@ -2384,6 +3289,25 @@
         <edmx:Include Namespace="ThermalSubsystem"/>
         <edmx:Include Namespace="ThermalSubsystem.v1_0_0"/>
     </edmx:Reference>
+    <edmx:Reference Uri="/redfish/v1/schema/Triggers_v1.xml">
+        <edmx:Include Namespace="Triggers"/>
+        <edmx:Include Namespace="Triggers.v1_0_0"/>
+        <edmx:Include Namespace="Triggers.v1_0_1"/>
+        <edmx:Include Namespace="Triggers.v1_0_2"/>
+        <edmx:Include Namespace="Triggers.v1_0_3"/>
+        <edmx:Include Namespace="Triggers.v1_0_4"/>
+        <edmx:Include Namespace="Triggers.v1_0_5"/>
+        <edmx:Include Namespace="Triggers.v1_0_6"/>
+        <edmx:Include Namespace="Triggers.v1_1_0"/>
+        <edmx:Include Namespace="Triggers.v1_1_1"/>
+        <edmx:Include Namespace="Triggers.v1_1_2"/>
+        <edmx:Include Namespace="Triggers.v1_1_3"/>
+        <edmx:Include Namespace="Triggers.v1_1_4"/>
+        <edmx:Include Namespace="Triggers.v1_2_0"/>
+    </edmx:Reference>
+    <edmx:Reference Uri="/redfish/v1/schema/TriggersCollection_v1.xml">
+        <edmx:Include Namespace="TriggersCollection"/>
+    </edmx:Reference>
     <edmx:Reference Uri="/redfish/v1/schema/UpdateService_v1.xml">
         <edmx:Include Namespace="UpdateService"/>
         <edmx:Include Namespace="UpdateService.v1_0_0"/>
@@ -2454,6 +3378,21 @@
         <edmx:Include Namespace="UpdateService.v1_9_0"/>
         <edmx:Include Namespace="UpdateService.v1_10_0"/>
     </edmx:Reference>
+    <edmx:Reference Uri="/redfish/v1/schema/USBController_v1.xml">
+        <edmx:Include Namespace="USBController"/>
+        <edmx:Include Namespace="USBController.v1_0_0"/>
+    </edmx:Reference>
+    <edmx:Reference Uri="/redfish/v1/schema/USBControllerCollection_v1.xml">
+        <edmx:Include Namespace="USBControllerCollection"/>
+    </edmx:Reference>
+    <edmx:Reference Uri="/redfish/v1/schema/VCATEntry_v1.xml">
+        <edmx:Include Namespace="VCATEntry"/>
+        <edmx:Include Namespace="VCATEntry.v1_0_0"/>
+        <edmx:Include Namespace="VCATEntry.v1_0_1"/>
+    </edmx:Reference>
+    <edmx:Reference Uri="/redfish/v1/schema/VCATEntryCollection_v1.xml">
+        <edmx:Include Namespace="VCATEntryCollection"/>
+    </edmx:Reference>
     <edmx:Reference Uri="/redfish/v1/schema/VirtualMedia_v1.xml">
         <edmx:Include Namespace="VirtualMedia"/>
         <edmx:Include Namespace="VirtualMedia.v1_0_0"/>
@@ -2511,6 +3450,80 @@
     </edmx:Reference>
     <edmx:Reference Uri="/redfish/v1/schema/VLanNetworkInterfaceCollection_v1.xml">
         <edmx:Include Namespace="VLanNetworkInterfaceCollection"/>
+    </edmx:Reference>
+    <edmx:Reference Uri="/redfish/v1/schema/Volume_v1.xml">
+        <edmx:Include Namespace="Volume"/>
+        <edmx:Include Namespace="Volume.v1_0_0"/>
+        <edmx:Include Namespace="Volume.v1_0_1"/>
+        <edmx:Include Namespace="Volume.v1_0_2"/>
+        <edmx:Include Namespace="Volume.v1_0_3"/>
+        <edmx:Include Namespace="Volume.v1_0_4"/>
+        <edmx:Include Namespace="Volume.v1_1_0"/>
+        <edmx:Include Namespace="Volume.v1_1_1"/>
+        <edmx:Include Namespace="Volume.v1_1_2"/>
+        <edmx:Include Namespace="Volume.v1_1_3"/>
+        <edmx:Include Namespace="Volume.v1_1_4"/>
+        <edmx:Include Namespace="Volume.v1_1_5"/>
+        <edmx:Include Namespace="Volume.v1_2_0"/>
+        <edmx:Include Namespace="Volume.v1_2_1"/>
+        <edmx:Include Namespace="Volume.v1_2_2"/>
+        <edmx:Include Namespace="Volume.v1_2_3"/>
+        <edmx:Include Namespace="Volume.v1_2_4"/>
+        <edmx:Include Namespace="Volume.v1_2_5"/>
+        <edmx:Include Namespace="Volume.v1_3_0"/>
+        <edmx:Include Namespace="Volume.v1_3_1"/>
+        <edmx:Include Namespace="Volume.v1_3_2"/>
+        <edmx:Include Namespace="Volume.v1_3_3"/>
+        <edmx:Include Namespace="Volume.v1_3_4"/>
+        <edmx:Include Namespace="Volume.v1_4_0"/>
+        <edmx:Include Namespace="Volume.v1_4_1"/>
+        <edmx:Include Namespace="Volume.v1_4_2"/>
+        <edmx:Include Namespace="Volume.v1_4_3"/>
+        <edmx:Include Namespace="Volume.v1_5_0"/>
+        <edmx:Include Namespace="Volume.v1_5_1"/>
+        <edmx:Include Namespace="Volume.v1_6_0"/>
+        <edmx:Include Namespace="Volume.v1_6_1"/>
+        <edmx:Include Namespace="Volume.v1_6_2"/>
+    </edmx:Reference>
+    <edmx:Reference Uri="/redfish/v1/schema/VolumeCollection_v1.xml">
+        <edmx:Include Namespace="VolumeCollection"/>
+    </edmx:Reference>
+    <edmx:Reference Uri="/redfish/v1/schema/Zone_v1.xml">
+        <edmx:Include Namespace="Zone"/>
+        <edmx:Include Namespace="Zone.v1_0_0"/>
+        <edmx:Include Namespace="Zone.v1_0_1"/>
+        <edmx:Include Namespace="Zone.v1_0_2"/>
+        <edmx:Include Namespace="Zone.v1_0_3"/>
+        <edmx:Include Namespace="Zone.v1_0_4"/>
+        <edmx:Include Namespace="Zone.v1_0_5"/>
+        <edmx:Include Namespace="Zone.v1_0_6"/>
+        <edmx:Include Namespace="Zone.v1_1_0"/>
+        <edmx:Include Namespace="Zone.v1_1_1"/>
+        <edmx:Include Namespace="Zone.v1_1_2"/>
+        <edmx:Include Namespace="Zone.v1_1_3"/>
+        <edmx:Include Namespace="Zone.v1_1_4"/>
+        <edmx:Include Namespace="Zone.v1_1_5"/>
+        <edmx:Include Namespace="Zone.v1_2_0"/>
+        <edmx:Include Namespace="Zone.v1_2_1"/>
+        <edmx:Include Namespace="Zone.v1_2_2"/>
+        <edmx:Include Namespace="Zone.v1_2_3"/>
+        <edmx:Include Namespace="Zone.v1_2_4"/>
+        <edmx:Include Namespace="Zone.v1_3_0"/>
+        <edmx:Include Namespace="Zone.v1_3_1"/>
+        <edmx:Include Namespace="Zone.v1_3_2"/>
+        <edmx:Include Namespace="Zone.v1_3_3"/>
+        <edmx:Include Namespace="Zone.v1_3_4"/>
+        <edmx:Include Namespace="Zone.v1_4_0"/>
+        <edmx:Include Namespace="Zone.v1_4_1"/>
+        <edmx:Include Namespace="Zone.v1_4_2"/>
+        <edmx:Include Namespace="Zone.v1_4_3"/>
+        <edmx:Include Namespace="Zone.v1_5_0"/>
+        <edmx:Include Namespace="Zone.v1_5_1"/>
+        <edmx:Include Namespace="Zone.v1_6_0"/>
+        <edmx:Include Namespace="Zone.v1_6_1"/>
+    </edmx:Reference>
+    <edmx:Reference Uri="/redfish/v1/schema/ZoneCollection_v1.xml">
+        <edmx:Include Namespace="ZoneCollection"/>
     </edmx:Reference>
     <edmx:DataServices>
         <Schema xmlns="http://docs.oasis-open.org/odata/ns/edm" Namespace="Service">

--- a/static/redfish/v1/JsonSchemas/AccelerationFunction/AccelerationFunction.json
+++ b/static/redfish/v1/JsonSchemas/AccelerationFunction/AccelerationFunction.json
@@ -1,0 +1,266 @@
+{
+    "$id": "http://redfish.dmtf.org/schemas/v1/AccelerationFunction.v1_0_3.json",
+    "$ref": "#/definitions/AccelerationFunction",
+    "$schema": "http://redfish.dmtf.org/schemas/v1/redfish-schema-v1.json",
+    "copyright": "Copyright 2014-2020 DMTF. For the full DMTF copyright policy, see http://www.dmtf.org/about/policies/copyright",
+    "definitions": {
+        "AccelerationFunction": {
+            "additionalProperties": false,
+            "description": "The AccelerationFunction schema describes an acceleration function that a processor implements.  This can include functions such as audio processing, compression, encryption, packet inspection, packet switching, scheduling, or video processing.",
+            "longDescription": "This Resource shall represent the acceleration function that a processor implements in a Redfish implementation.  This can include functions such as audio processing, compression, encryption, packet inspection, packet switching, scheduling, or video processing.",
+            "patternProperties": {
+                "^([a-zA-Z_][a-zA-Z0-9_]*)?@(odata|Redfish|Message)\\.[a-zA-Z_][a-zA-Z0-9_]*$": {
+                    "description": "This property shall specify a valid odata or Redfish property.",
+                    "type": [
+                        "array",
+                        "boolean",
+                        "integer",
+                        "number",
+                        "null",
+                        "object",
+                        "string"
+                    ]
+                }
+            },
+            "properties": {
+                "@odata.context": {
+                    "$ref": "http://redfish.dmtf.org/schemas/v1/odata-v4.json#/definitions/context"
+                },
+                "@odata.etag": {
+                    "$ref": "http://redfish.dmtf.org/schemas/v1/odata-v4.json#/definitions/etag"
+                },
+                "@odata.id": {
+                    "$ref": "http://redfish.dmtf.org/schemas/v1/odata-v4.json#/definitions/id"
+                },
+                "@odata.type": {
+                    "$ref": "http://redfish.dmtf.org/schemas/v1/odata-v4.json#/definitions/type"
+                },
+                "AccelerationFunctionType": {
+                    "anyOf": [
+                        {
+                            "$ref": "#/definitions/AccelerationFunctionType"
+                        },
+                        {
+                            "type": "null"
+                        }
+                    ],
+                    "description": "The acceleration function type.",
+                    "longDescription": "This property shall contain the string that identifies the acceleration function type.",
+                    "readonly": true
+                },
+                "Actions": {
+                    "$ref": "#/definitions/Actions",
+                    "description": "The available actions for this Resource.",
+                    "longDescription": "This property shall contain the available actions for this Resource."
+                },
+                "Description": {
+                    "anyOf": [
+                        {
+                            "$ref": "http://redfish.dmtf.org/schemas/v1/Resource.json#/definitions/Description"
+                        },
+                        {
+                            "type": "null"
+                        }
+                    ],
+                    "readonly": true
+                },
+                "FpgaReconfigurationSlots": {
+                    "description": "An array of the reconfiguration slot identifiers of the FPGA that this acceleration function occupies.",
+                    "items": {
+                        "type": "string"
+                    },
+                    "longDescription": "This property shall contain an array of the FPGA reconfiguration slot identifiers that this acceleration function occupies.",
+                    "readonly": true,
+                    "type": "array"
+                },
+                "Id": {
+                    "$ref": "http://redfish.dmtf.org/schemas/v1/Resource.json#/definitions/Id",
+                    "readonly": true
+                },
+                "Links": {
+                    "$ref": "#/definitions/Links",
+                    "description": "The links to other Resources that are related to this Resource.",
+                    "longDescription": "This property shall contain links to Resources that are related to but are not contained by, or subordinate to, this Resource."
+                },
+                "Manufacturer": {
+                    "description": "The acceleration function code manufacturer.",
+                    "longDescription": "This property shall contain a string that identifies the manufacturer of the acceleration function.",
+                    "readonly": true,
+                    "type": "string"
+                },
+                "Name": {
+                    "$ref": "http://redfish.dmtf.org/schemas/v1/Resource.json#/definitions/Name",
+                    "readonly": true
+                },
+                "Oem": {
+                    "$ref": "http://redfish.dmtf.org/schemas/v1/Resource.json#/definitions/Oem",
+                    "description": "The OEM extension property.",
+                    "longDescription": "This property shall contain the OEM extensions.  All values for properties that this object contains shall conform to the Redfish Specification-described requirements."
+                },
+                "PowerWatts": {
+                    "description": "The acceleration function power consumption, in watts.",
+                    "longDescription": "This property shall contain the total acceleration function power consumption, in watts.",
+                    "readonly": true,
+                    "type": "integer",
+                    "units": "W"
+                },
+                "Status": {
+                    "$ref": "http://redfish.dmtf.org/schemas/v1/Resource.json#/definitions/Status",
+                    "description": "The status and health of the Resource and its subordinate or dependent Resources.",
+                    "longDescription": "This property shall contain any status or health properties of the Resource."
+                },
+                "UUID": {
+                    "anyOf": [
+                        {
+                            "$ref": "http://redfish.dmtf.org/schemas/v1/Resource.json#/definitions/UUID"
+                        },
+                        {
+                            "type": "null"
+                        }
+                    ],
+                    "description": "The UUID for this acceleration function.",
+                    "longDescription": "This property shall contain a UUID for the acceleration function.  RFC4122 describes methods that can create the value.  The value should be considered to be opaque.  Client software should only treat the overall value as a UUID and should not interpret any sub-fields within the UUID.",
+                    "readonly": true
+                },
+                "Version": {
+                    "description": "The acceleration function version.",
+                    "longDescription": "This property shall describe the acceleration function version.",
+                    "readonly": true,
+                    "type": "string"
+                }
+            },
+            "required": [
+                "@odata.id",
+                "@odata.type",
+                "Id",
+                "Name"
+            ],
+            "type": "object"
+        },
+        "AccelerationFunctionType": {
+            "enum": [
+                "Encryption",
+                "Compression",
+                "PacketInspection",
+                "PacketSwitch",
+                "Scheduler",
+                "AudioProcessing",
+                "VideoProcessing",
+                "OEM"
+            ],
+            "enumDescriptions": {
+                "AudioProcessing": "An audio processing function.",
+                "Compression": "A compression function.",
+                "Encryption": "An encryption function.",
+                "OEM": "An OEM-defined acceleration function.",
+                "PacketInspection": "A packet inspection function.",
+                "PacketSwitch": "A packet switch function.",
+                "Scheduler": "A scheduler function.",
+                "VideoProcessing": "A video processing function."
+            },
+            "type": "string"
+        },
+        "Actions": {
+            "additionalProperties": false,
+            "description": "The available actions for this Resource.",
+            "longDescription": "This type shall contain the available actions for this Resource.",
+            "patternProperties": {
+                "^([a-zA-Z_][a-zA-Z0-9_]*)?@(odata|Redfish|Message)\\.[a-zA-Z_][a-zA-Z0-9_]*$": {
+                    "description": "This property shall specify a valid odata or Redfish property.",
+                    "type": [
+                        "array",
+                        "boolean",
+                        "integer",
+                        "number",
+                        "null",
+                        "object",
+                        "string"
+                    ]
+                }
+            },
+            "properties": {
+                "Oem": {
+                    "$ref": "#/definitions/OemActions",
+                    "description": "The available OEM-specific actions for this Resource.",
+                    "longDescription": "This property shall contain the available OEM-specific actions for this Resource."
+                }
+            },
+            "type": "object"
+        },
+        "Links": {
+            "additionalProperties": false,
+            "description": "The links to other Resources that are related to this Resource.",
+            "longDescription": "This Redfish Specification-described type shall contain links to Resources that are related to but are not contained by, or subordinate to, this Resource.",
+            "patternProperties": {
+                "^([a-zA-Z_][a-zA-Z0-9_]*)?@(odata|Redfish|Message)\\.[a-zA-Z_][a-zA-Z0-9_]*$": {
+                    "description": "This property shall specify a valid odata or Redfish property.",
+                    "type": [
+                        "array",
+                        "boolean",
+                        "integer",
+                        "number",
+                        "null",
+                        "object",
+                        "string"
+                    ]
+                }
+            },
+            "properties": {
+                "Endpoints": {
+                    "description": "An array of links to the endpoints that connect to this acceleration function.",
+                    "items": {
+                        "$ref": "http://redfish.dmtf.org/schemas/v1/Endpoint.json#/definitions/Endpoint"
+                    },
+                    "longDescription": "This property shall contain an array of links to Resources of the Endpoint type that are associated with this acceleration function.",
+                    "readonly": true,
+                    "type": "array"
+                },
+                "Endpoints@odata.count": {
+                    "$ref": "http://redfish.dmtf.org/schemas/v1/odata-v4.json#/definitions/count"
+                },
+                "Oem": {
+                    "$ref": "http://redfish.dmtf.org/schemas/v1/Resource.json#/definitions/Oem",
+                    "description": "The OEM extension property.",
+                    "longDescription": "This property shall contain the OEM extensions.  All values for properties contained in this object shall conform to the Redfish Specification-described requirements."
+                },
+                "PCIeFunctions": {
+                    "description": "An array of links to the PCIeFunctions associated with this acceleration function.",
+                    "items": {
+                        "$ref": "http://redfish.dmtf.org/schemas/v1/PCIeFunction.json#/definitions/PCIeFunction"
+                    },
+                    "longDescription": "This property shall contain an array of links of the PCIeFunction type that represent the PCIe functions associated with this acceleration function.",
+                    "readonly": true,
+                    "type": "array"
+                },
+                "PCIeFunctions@odata.count": {
+                    "$ref": "http://redfish.dmtf.org/schemas/v1/odata-v4.json#/definitions/count"
+                }
+            },
+            "type": "object"
+        },
+        "OemActions": {
+            "additionalProperties": true,
+            "description": "The available OEM-specific actions for this Resource.",
+            "longDescription": "This type shall contain the available OEM-specific actions for this Resource.",
+            "patternProperties": {
+                "^([a-zA-Z_][a-zA-Z0-9_]*)?@(odata|Redfish|Message)\\.[a-zA-Z_][a-zA-Z0-9_]*$": {
+                    "description": "This property shall specify a valid odata or Redfish property.",
+                    "type": [
+                        "array",
+                        "boolean",
+                        "integer",
+                        "number",
+                        "null",
+                        "object",
+                        "string"
+                    ]
+                }
+            },
+            "properties": {},
+            "type": "object"
+        }
+    },
+    "owningEntity": "DMTF",
+    "release": "2018.3",
+    "title": "#AccelerationFunction.v1_0_3.AccelerationFunction"
+}

--- a/static/redfish/v1/JsonSchemas/AccelerationFunction/index.json
+++ b/static/redfish/v1/JsonSchemas/AccelerationFunction/index.json
@@ -1,0 +1,21 @@
+{
+    "@odata.context": "/redfish/v1/$metadata#JsonSchemaFile.JsonSchemaFile",
+    "@odata.id": "/redfish/v1/JsonSchemas/AccelerationFunction",
+    "@odata.type": "#JsonSchemaFile.v1_0_2.JsonSchemaFile",
+    "Name": "AccelerationFunction Schema File",
+    "Schema": "#AccelerationFunction.AccelerationFunction",
+    "Description": "AccelerationFunction Schema File Location",
+    "Id": "AccelerationFunction",
+    "Languages": [
+        "en"
+    ],
+    "Languages@odata.count": 1,
+    "Location": [
+        {
+            "Language": "en",
+            "PublicationUri": "http://redfish.dmtf.org/schemas/v1/AccelerationFunction.json",
+            "Uri": "/redfish/v1/JsonSchemas/AccelerationFunction/AccelerationFunction.json"
+        }
+    ],
+    "Location@odata.count": 1
+}

--- a/static/redfish/v1/JsonSchemas/AddressPool/AddressPool.json
+++ b/static/redfish/v1/JsonSchemas/AddressPool/AddressPool.json
@@ -1,0 +1,2080 @@
+{
+    "$id": "http://redfish.dmtf.org/schemas/v1/AddressPool.v1_2_0.json",
+    "$ref": "#/definitions/AddressPool",
+    "$schema": "http://redfish.dmtf.org/schemas/v1/redfish-schema-v1.json",
+    "copyright": "Copyright 2014-2021 DMTF. For the full DMTF copyright policy, see http://www.dmtf.org/about/policies/copyright",
+    "definitions": {
+        "ASNumberRange": {
+            "additionalProperties": false,
+            "description": "Autonomous System (AS) number range.",
+            "longDescription": "This type shall contain the Autonomous System (AS) number range.",
+            "patternProperties": {
+                "^([a-zA-Z_][a-zA-Z0-9_]*)?@(odata|Redfish|Message)\\.[a-zA-Z_][a-zA-Z0-9_]*$": {
+                    "description": "This property shall specify a valid odata or Redfish property.",
+                    "type": [
+                        "array",
+                        "boolean",
+                        "integer",
+                        "number",
+                        "null",
+                        "object",
+                        "string"
+                    ]
+                }
+            },
+            "properties": {
+                "Lower": {
+                    "description": "Lower Autonomous System (AS) number.",
+                    "longDescription": "This property shall contain the lower Autonomous System (AS) number to be used as part of a range of ASN values.",
+                    "maximum": 65535,
+                    "minimum": 1,
+                    "readonly": false,
+                    "type": "integer",
+                    "versionAdded": "v1_1_0"
+                },
+                "Upper": {
+                    "description": "Upper Autonomous System (AS) number.",
+                    "longDescription": "This property shall contain the upper Autonomous System (AS) number to be used as part of a range of ASN values.",
+                    "maximum": 65535,
+                    "minimum": 1,
+                    "readonly": false,
+                    "type": "integer",
+                    "versionAdded": "v1_1_0"
+                }
+            },
+            "type": "object"
+        },
+        "Actions": {
+            "additionalProperties": false,
+            "description": "The available actions for this resource.",
+            "longDescription": "This type shall contain the available actions for this resource.",
+            "patternProperties": {
+                "^([a-zA-Z_][a-zA-Z0-9_]*)?@(odata|Redfish|Message)\\.[a-zA-Z_][a-zA-Z0-9_]*$": {
+                    "description": "This property shall specify a valid odata or Redfish property.",
+                    "type": [
+                        "array",
+                        "boolean",
+                        "integer",
+                        "number",
+                        "null",
+                        "object",
+                        "string"
+                    ]
+                }
+            },
+            "properties": {
+                "Oem": {
+                    "$ref": "#/definitions/OemActions",
+                    "description": "The available OEM-specific actions for this resource.",
+                    "longDescription": "This property shall contain the available OEM-specific actions for this resource."
+                }
+            },
+            "type": "object"
+        },
+        "AddressPool": {
+            "additionalProperties": false,
+            "description": "The schema definition of an address pool and its configuration.",
+            "longDescription": "This resource shall represent an address pool in a Redfish implementation.",
+            "patternProperties": {
+                "^([a-zA-Z_][a-zA-Z0-9_]*)?@(odata|Redfish|Message)\\.[a-zA-Z_][a-zA-Z0-9_]*$": {
+                    "description": "This property shall specify a valid odata or Redfish property.",
+                    "type": [
+                        "array",
+                        "boolean",
+                        "integer",
+                        "number",
+                        "null",
+                        "object",
+                        "string"
+                    ]
+                }
+            },
+            "properties": {
+                "@odata.context": {
+                    "$ref": "http://redfish.dmtf.org/schemas/v1/odata-v4.json#/definitions/context"
+                },
+                "@odata.etag": {
+                    "$ref": "http://redfish.dmtf.org/schemas/v1/odata-v4.json#/definitions/etag"
+                },
+                "@odata.id": {
+                    "$ref": "http://redfish.dmtf.org/schemas/v1/odata-v4.json#/definitions/id"
+                },
+                "@odata.type": {
+                    "$ref": "http://redfish.dmtf.org/schemas/v1/odata-v4.json#/definitions/type"
+                },
+                "Actions": {
+                    "$ref": "#/definitions/Actions",
+                    "description": "The available actions for this resource.",
+                    "longDescription": "This property shall contain the available actions for this resource."
+                },
+                "Description": {
+                    "anyOf": [
+                        {
+                            "$ref": "http://redfish.dmtf.org/schemas/v1/Resource.json#/definitions/Description"
+                        },
+                        {
+                            "type": "null"
+                        }
+                    ],
+                    "readonly": true
+                },
+                "Ethernet": {
+                    "$ref": "#/definitions/Ethernet",
+                    "description": "The Ethernet related properties for this address pool.",
+                    "longDescription": "This property shall contain the Ethernet related properties to this address pool.",
+                    "versionAdded": "v1_1_0"
+                },
+                "GenZ": {
+                    "$ref": "#/definitions/GenZ",
+                    "description": "The Gen-Z related properties for this address pool.",
+                    "longDescription": "This property shall contain the Gen-Z related properties to this address pool."
+                },
+                "Id": {
+                    "$ref": "http://redfish.dmtf.org/schemas/v1/Resource.json#/definitions/Id",
+                    "readonly": true
+                },
+                "Links": {
+                    "$ref": "#/definitions/Links",
+                    "description": "The links to other resources that are related to this resource.",
+                    "longDescription": "This property shall contain links to resources that are related to but are not contained by, or subordinate to, this resource."
+                },
+                "Name": {
+                    "$ref": "http://redfish.dmtf.org/schemas/v1/Resource.json#/definitions/Name",
+                    "readonly": true
+                },
+                "Oem": {
+                    "$ref": "http://redfish.dmtf.org/schemas/v1/Resource.json#/definitions/Oem",
+                    "description": "The OEM extension property.",
+                    "longDescription": "This property shall contain the OEM extensions.  All values for properties that this object contains shall conform to the Redfish Specification-described requirements."
+                },
+                "Status": {
+                    "$ref": "http://redfish.dmtf.org/schemas/v1/Resource.json#/definitions/Status",
+                    "description": "The status and health of the resource and its subordinate or dependent resources.",
+                    "longDescription": "This property shall contain any status or health properties of the resource."
+                }
+            },
+            "required": [
+                "@odata.id",
+                "@odata.type",
+                "Id",
+                "Name"
+            ],
+            "type": "object"
+        },
+        "BFDSingleHopOnly": {
+            "additionalProperties": false,
+            "description": "Bidirectional Forwarding Detection (BFD) related properties for an Ethernet fabric.",
+            "longDescription": "This type shall contain the BFD related properties for an Ethernet fabric that uses Bidirectional Forwarding Detection (BFD) for link fault detection.",
+            "patternProperties": {
+                "^([a-zA-Z_][a-zA-Z0-9_]*)?@(odata|Redfish|Message)\\.[a-zA-Z_][a-zA-Z0-9_]*$": {
+                    "description": "This property shall specify a valid odata or Redfish property.",
+                    "type": [
+                        "array",
+                        "boolean",
+                        "integer",
+                        "number",
+                        "null",
+                        "object",
+                        "string"
+                    ]
+                }
+            },
+            "properties": {
+                "DemandModeEnabled": {
+                    "description": "Bidirectional Forwarding Detection (BFD) Demand Mode status.",
+                    "longDescription": "This property shall indicate if Bidirectional Forwarding Detection (BFD) Demand Mode is enabled.  In Demand mode, no periodic BFD Control packets will flow in either direction.",
+                    "readonly": false,
+                    "type": [
+                        "boolean",
+                        "null"
+                    ],
+                    "versionAdded": "v1_1_0"
+                },
+                "DesiredMinTxIntervalMilliseconds": {
+                    "description": "Desired Bidirectional Forwarding Detection (BFD) minimal transmit interval.",
+                    "longDescription": "This property shall contain the minimum interval, in milliseconds, that the local system would like to use when transmitting Bidirectional Forwarding Detection (BFD) Control packets, less any jitter applied.",
+                    "readonly": false,
+                    "type": [
+                        "integer",
+                        "null"
+                    ],
+                    "versionAdded": "v1_1_0"
+                },
+                "KeyChain": {
+                    "description": "Bidirectional Forwarding Detection (BFD) Key Chain name.",
+                    "longDescription": "This property shall contain the name of the Bidirectional Forwarding Detection (BFD) Key Chain.",
+                    "readonly": false,
+                    "type": [
+                        "string",
+                        "null"
+                    ],
+                    "versionAdded": "v1_1_0"
+                },
+                "LocalMultiplier": {
+                    "description": "Bidirectional Forwarding Detection (BFD) multiplier value.",
+                    "longDescription": "This property shall contain the Bidirectional Forwarding Detection (BFD) multiplier value.  A BFD multiplier consists of the number of consecutive BFD packets that shall be missed from a BFD peer before declaring that peer unavailable, and informing the higher-layer protocols of the failure.",
+                    "readonly": false,
+                    "type": [
+                        "integer",
+                        "null"
+                    ],
+                    "versionAdded": "v1_1_0"
+                },
+                "MeticulousModeEnabled": {
+                    "description": "Meticulous MD5 authentication of the Bidirectional Forwarding Detection (BFD) session.",
+                    "longDescription": "This property shall indicate whether the keyed MD5 sequence number is updated with every packet.  If `true`, the keyed MD5 sequence number is updated with every packet, if `false` it is updated periodically.",
+                    "readonly": false,
+                    "type": [
+                        "boolean",
+                        "null"
+                    ],
+                    "versionAdded": "v1_1_0"
+                },
+                "RequiredMinRxIntervalMilliseconds": {
+                    "description": "Bidirectional Forwarding Detection (BFD) receive value.",
+                    "longDescription": "This property shall contain the Bidirectional Forwarding Detection (BFD) receive value.  The BFD receive value determines how frequently (in milliseconds) BFD packets will be expected to be received from BFD peers.",
+                    "readonly": false,
+                    "type": [
+                        "integer",
+                        "null"
+                    ],
+                    "versionAdded": "v1_1_0"
+                },
+                "SourcePort": {
+                    "description": "Bidirectional Forwarding Detection (BFD) source port.",
+                    "longDescription": "This property shall contain the Bidirectional Forwarding Detection (BFD) source port.",
+                    "maximum": 65535,
+                    "minimum": 49152,
+                    "readonly": false,
+                    "type": [
+                        "integer",
+                        "null"
+                    ],
+                    "versionAdded": "v1_1_0"
+                }
+            },
+            "type": "object"
+        },
+        "BGPEvpn": {
+            "additionalProperties": false,
+            "description": "BGP Ethernet Virtual Private Network (BGP EVPN) related properties for an Ethernet fabric.",
+            "longDescription": "This type shall contain the EVPN related properties for an Ethernet fabric that uses an IETF defined Ethernet Virtual Private Network (EVPN) based control plane specification based on RFC7432.",
+            "patternProperties": {
+                "^([a-zA-Z_][a-zA-Z0-9_]*)?@(odata|Redfish|Message)\\.[a-zA-Z_][a-zA-Z0-9_]*$": {
+                    "description": "This property shall specify a valid odata or Redfish property.",
+                    "type": [
+                        "array",
+                        "boolean",
+                        "integer",
+                        "number",
+                        "null",
+                        "object",
+                        "string"
+                    ]
+                }
+            },
+            "properties": {
+                "ARPProxyEnabled": {
+                    "description": "Address Resolution Protocol (ARP) proxy status.",
+                    "longDescription": "This property shall indicate whether proxy Address Resolution Protocol (ARP) is enabled.",
+                    "readonly": false,
+                    "type": [
+                        "boolean",
+                        "null"
+                    ],
+                    "versionAdded": "v1_1_0"
+                },
+                "ARPSupressionEnabled": {
+                    "description": "Address Resolution Protocol (ARP) suppression status.",
+                    "longDescription": "This property shall indicate whether Address Resolution Protocol (ARP) suppression is enabled.",
+                    "readonly": false,
+                    "type": [
+                        "boolean",
+                        "null"
+                    ],
+                    "versionAdded": "v1_1_0"
+                },
+                "AnycastGatewayIPAddress": {
+                    "description": "The anycast gateway IPv4 address.",
+                    "longDescription": "This property shall contain the anycast gateway IPv4 address for a host subnet.",
+                    "pattern": "^(?:[0-9]{1,3}\\.){3}[0-9]{1,3}$",
+                    "readonly": false,
+                    "type": [
+                        "string",
+                        "null"
+                    ],
+                    "versionAdded": "v1_1_0"
+                },
+                "AnycastGatewayMACAddress": {
+                    "description": "The anycast gateway MAC address.",
+                    "longDescription": "This property shall contain the anycast gateway MAC address for a host subnet.",
+                    "pattern": "^([0-9A-Fa-f]{2}[:-]){5}([0-9A-Fa-f]{2})$",
+                    "readonly": false,
+                    "type": [
+                        "string",
+                        "null"
+                    ],
+                    "versionAdded": "v1_1_0"
+                },
+                "ESINumberRange": {
+                    "anyOf": [
+                        {
+                            "$ref": "#/definitions/ESINumberRange"
+                        },
+                        {
+                            "type": "null"
+                        }
+                    ],
+                    "description": "The Ethernet Segment Identifier (ESI) number range for the fabric.",
+                    "longDescription": "This property shall contain Ethernet Segment Identifier (ESI) number ranges for allocation in supporting functions such as multihoming.",
+                    "versionAdded": "v1_1_0"
+                },
+                "EVINumberRange": {
+                    "anyOf": [
+                        {
+                            "$ref": "#/definitions/EVINumberRange"
+                        },
+                        {
+                            "type": "null"
+                        }
+                    ],
+                    "description": "The Ethernet Virtual Private Network (EVPN) Instance number (EVI) number range for the fabric.",
+                    "longDescription": "This property shall contain the Ethernet Virtual Private Network (EVPN) Instance number (EVI) range for EVPN based fabrics.",
+                    "versionAdded": "v1_1_0"
+                },
+                "GatewayIPAddress": {
+                    "description": "The gateway IPv4 address.",
+                    "longDescription": "This property shall contain the Gateway IPv4 address for a host subnet.",
+                    "pattern": "^(?:[0-9]{1,3}\\.){3}[0-9]{1,3}$",
+                    "readonly": false,
+                    "type": [
+                        "string",
+                        "null"
+                    ],
+                    "versionAdded": "v1_1_0"
+                },
+                "GatewayIPAddressRange": {
+                    "anyOf": [
+                        {
+                            "$ref": "#/definitions/GatewayIPAddressRange"
+                        },
+                        {
+                            "type": "null"
+                        }
+                    ],
+                    "description": "The IPv4 address range for gateways.",
+                    "longDescription": "This property shall contain the IPv4 address range for gateway nodes on this subnet.",
+                    "versionAdded": "v1_2_0"
+                },
+                "NDPProxyEnabled": {
+                    "description": "Network Discovery Protocol (NDP) proxy status.",
+                    "longDescription": "This property shall indicate whether Network Discovery Protocol (NDP) proxy is enabled.",
+                    "readonly": false,
+                    "type": [
+                        "boolean",
+                        "null"
+                    ],
+                    "versionAdded": "v1_1_0"
+                },
+                "NDPSupressionEnabled": {
+                    "description": "Network Discovery Protocol (NDP) suppression status.",
+                    "longDescription": "This property shall indicate whether Network Discovery Protocol (NDP) suppression is enabled.",
+                    "readonly": false,
+                    "type": [
+                        "boolean",
+                        "null"
+                    ],
+                    "versionAdded": "v1_1_0"
+                },
+                "RouteDistinguisherAdministratorSubfield": {
+                    "description": "The Route Distinguisher (RD) Administrator subfield.",
+                    "longDescription": "This property shall contain the RFC4364-defined Route Distinguisher (RD) Administrator subfield.",
+                    "readonly": false,
+                    "type": [
+                        "string",
+                        "null"
+                    ],
+                    "versionAdded": "v1_2_0"
+                },
+                "RouteDistinguisherRange": {
+                    "anyOf": [
+                        {
+                            "$ref": "#/definitions/RouteDistinguisherRange"
+                        },
+                        {
+                            "type": "null"
+                        }
+                    ],
+                    "description": "The Route Distinguisher (RD) number range for the fabric.",
+                    "longDescription": "This property shall contain the Route Distinguisher (RD) Instance number range for Ethernet Virtual Private Network (EVPN) based fabrics.",
+                    "versionAdded": "v1_1_0"
+                },
+                "RouteTargetAdministratorSubfield": {
+                    "description": "The Route Target (RT) Administrator Subfield.",
+                    "longDescription": "This property shall contain the RFC4364-defined Route Target (RT) Administrator subfield.",
+                    "readonly": false,
+                    "type": [
+                        "string",
+                        "null"
+                    ],
+                    "versionAdded": "v1_2_0"
+                },
+                "RouteTargetRange": {
+                    "anyOf": [
+                        {
+                            "$ref": "#/definitions/RouteTargetRange"
+                        },
+                        {
+                            "type": "null"
+                        }
+                    ],
+                    "description": "The Route Target (RT) number range for the fabric.",
+                    "longDescription": "This property shall contain the Route Target (RT) Instance number range for Ethernet Virtual Private Network (EVPN) based fabrics.",
+                    "versionAdded": "v1_1_0"
+                },
+                "UnderlayMulticastEnabled": {
+                    "description": "Underlay multicast status.",
+                    "longDescription": "This property shall indicate whether multicast is enabled on the Ethernet fabric underlay.",
+                    "readonly": false,
+                    "type": [
+                        "boolean",
+                        "null"
+                    ],
+                    "versionAdded": "v1_1_0"
+                },
+                "UnknownUnicastSuppressionEnabled": {
+                    "description": "Suppression of unknown unicast packets.",
+                    "longDescription": "This property shall indicate whether unknown unicast packets should be suppressed.",
+                    "readonly": false,
+                    "type": [
+                        "boolean",
+                        "null"
+                    ],
+                    "versionAdded": "v1_1_0"
+                },
+                "VLANIdentifierAddressRange": {
+                    "anyOf": [
+                        {
+                            "$ref": "#/definitions/VLANIdentifierAddressRange"
+                        },
+                        {
+                            "type": "null"
+                        }
+                    ],
+                    "description": "The VLAN tag range for the fabric.",
+                    "longDescription": "This property shall contain Virtual LAN (VLAN) tag range for host addresses.",
+                    "versionAdded": "v1_1_0"
+                }
+            },
+            "type": "object"
+        },
+        "BGPNeighbor": {
+            "additionalProperties": false,
+            "description": "Border Gateway Protocol (BGP) neighbor related properties.",
+            "longDescription": "This type shall contain all Border Gateway Protocol (BGP) neighbor related properties.",
+            "patternProperties": {
+                "^([a-zA-Z_][a-zA-Z0-9_]*)?@(odata|Redfish|Message)\\.[a-zA-Z_][a-zA-Z0-9_]*$": {
+                    "description": "This property shall specify a valid odata or Redfish property.",
+                    "type": [
+                        "array",
+                        "boolean",
+                        "integer",
+                        "number",
+                        "null",
+                        "object",
+                        "string"
+                    ]
+                }
+            },
+            "properties": {
+                "Address": {
+                    "description": "Border Gateway Protocol (BGP) neighbor address.",
+                    "longDescription": "This property shall contain the IPv4 address assigned to a Border Gateway Protocol (BGP) neighbor.",
+                    "pattern": "^(?:[0-9]{1,3}\\.){3}[0-9]{1,3}$",
+                    "readonly": false,
+                    "type": [
+                        "string",
+                        "null"
+                    ],
+                    "versionAdded": "v1_1_0"
+                },
+                "AllowOwnASEnabled": {
+                    "description": "Allow own Autonomous System (AS) status.",
+                    "longDescription": "This property shall indicate whether the Autonomous System (AS) of the receiving router is permitted in a Border Gateway Protocol (BGP) update.  If `true`, routes should be received and processed even if the router detects its own ASN in the AS-Path.  If `false`, they should be dropped.",
+                    "readonly": false,
+                    "type": [
+                        "boolean",
+                        "null"
+                    ],
+                    "versionAdded": "v1_1_0"
+                },
+                "CIDR": {
+                    "description": "The Classless Inter-Domain Routing (CIDR) value used for neighbor communication.  This is the number of ones before the first zero in the subnet mask.",
+                    "longDescription": "The value of this property shall contain the RFC4271-defined Classless Inter-Domain Routing (CIDR) value.",
+                    "readonly": false,
+                    "type": "integer",
+                    "versionAdded": "v1_2_0"
+                },
+                "ConnectRetrySeconds": {
+                    "description": "Border Gateway Protocol (BGP) retry timer in seconds.",
+                    "longDescription": "This property shall contain the Border Gateway Protocol (BGP) Retry Timer.  The BGP Retry Timer allows the administrator to set the amount of time in seconds between retries to establish a connection to configured peers which have gone down.",
+                    "readonly": false,
+                    "type": [
+                        "integer",
+                        "null"
+                    ],
+                    "versionAdded": "v1_1_0"
+                },
+                "Enabled": {
+                    "description": "An indication of whether BGP neighbor communication is enabled.",
+                    "longDescription": "The value of this property shall indicate whether BGP neighbor communication is enabled.",
+                    "readonly": false,
+                    "type": "boolean",
+                    "versionAdded": "v1_2_0"
+                },
+                "HoldTimeSeconds": {
+                    "description": "Border Gateway Protocol (BGP) hold timer in seconds.",
+                    "longDescription": "This property shall contain the Border Gateway Protocol (BGP) Hold Timer agreed upon between peers.",
+                    "readonly": false,
+                    "type": [
+                        "integer",
+                        "null"
+                    ],
+                    "versionAdded": "v1_1_0"
+                },
+                "KeepaliveIntervalSeconds": {
+                    "description": "Border Gateway Protocol (BGP) Keepalive timer in seconds.",
+                    "longDescription": "This property shall contain the Keepalive timer in seconds.  It is used in conjunction with the Border Gateway Protocol (BGP) hold timer.",
+                    "readonly": false,
+                    "type": [
+                        "integer",
+                        "null"
+                    ],
+                    "versionAdded": "v1_1_0"
+                },
+                "LocalAS": {
+                    "description": "Local Autonomous System (AS) number.",
+                    "longDescription": "This property shall contain the Autonomous System (AS) number of the local Border Gateway Protocol (BGP) peer.",
+                    "maximum": 65535,
+                    "minimum": 1,
+                    "readonly": false,
+                    "type": [
+                        "integer",
+                        "null"
+                    ],
+                    "versionAdded": "v1_1_0"
+                },
+                "LogStateChangesEnabled": {
+                    "description": "Border Gateway Protocol (BGP) neighbor log state change status.",
+                    "longDescription": "This property shall indicate whether Border Gateway Protocol (BGP) neighbor state changes are logged.",
+                    "readonly": false,
+                    "type": [
+                        "boolean",
+                        "null"
+                    ],
+                    "versionAdded": "v1_1_0"
+                },
+                "MaxPrefix": {
+                    "anyOf": [
+                        {
+                            "$ref": "#/definitions/MaxPrefix"
+                        },
+                        {
+                            "type": "null"
+                        }
+                    ],
+                    "description": "Border Gateway Protocol (BGP) max prefix properties.",
+                    "longDescription": "These properties are applicable to configuring Border Gateway Protocol (BGP) max prefix related properties.",
+                    "versionAdded": "v1_1_0"
+                },
+                "MinimumAdvertisementIntervalSeconds": {
+                    "description": "Minimum Border Gateway Protocol (BGP) advertisement interval in seconds.",
+                    "longDescription": "This property shall contain the minimum time between Border Gateway Protocol (BGP) route advertisements in seconds.",
+                    "readonly": false,
+                    "type": [
+                        "integer",
+                        "null"
+                    ],
+                    "versionAdded": "v1_1_0"
+                },
+                "PassiveModeEnabled": {
+                    "description": "Border Gateway Protocol (BGP) passive mode status.",
+                    "longDescription": "This property shall indicate whether Border Gateway Protocol (BGP) passive mode is enabled.",
+                    "readonly": false,
+                    "type": [
+                        "boolean",
+                        "null"
+                    ],
+                    "versionAdded": "v1_1_0"
+                },
+                "PathMTUDiscoveryEnabled": {
+                    "description": "Path MTU discovery status.",
+                    "longDescription": "This property shall indicate whether MTU discovery is permitted.",
+                    "readonly": false,
+                    "type": [
+                        "boolean",
+                        "null"
+                    ],
+                    "versionAdded": "v1_1_0"
+                },
+                "PeerAS": {
+                    "description": "Peer Autonomous System (AS) number.",
+                    "longDescription": "This property shall contain the Autonomous System (AS) number of the external Border Gateway Protocol (BGP) peer.",
+                    "maximum": 65535,
+                    "minimum": 1,
+                    "readonly": false,
+                    "type": [
+                        "integer",
+                        "null"
+                    ],
+                    "versionAdded": "v1_1_0"
+                },
+                "ReplacePeerASEnabled": {
+                    "description": "Replace Border Gateway Protocol (BGP) peer Autonomous System (AS) status.",
+                    "longDescription": "This property shall indicate whether peer Autonomous System (AS) numbers should be replaced.  If `true`, private ASNs are removed and replaced with the peer AS.  If `false`, they remain unchanged.",
+                    "readonly": false,
+                    "type": [
+                        "boolean",
+                        "null"
+                    ],
+                    "versionAdded": "v1_1_0"
+                },
+                "TCPMaxSegmentSizeBytes": {
+                    "description": "TCP max segment size in Bytes.",
+                    "longDescription": "This property shall contain the TCP max segment size in Bytes signifying the number of bytes that shall be transported in a single packet.",
+                    "readonly": false,
+                    "type": [
+                        "integer",
+                        "null"
+                    ],
+                    "versionAdded": "v1_1_0"
+                },
+                "TreatAsWithdrawEnabled": {
+                    "description": "Border Gateway Protocol (BGP) treat as withdraw status.",
+                    "longDescription": "This property shall indicate Border Gateway Protocol (BGP) withdraw status.  If `true`, the UPDATE message containing the path attribute shall be treated as though all contained routes had been withdrawn.  If `false`, they should remain.",
+                    "readonly": false,
+                    "type": [
+                        "boolean",
+                        "null"
+                    ],
+                    "versionAdded": "v1_1_0"
+                }
+            },
+            "type": "object"
+        },
+        "BGPRoute": {
+            "additionalProperties": false,
+            "description": "Border Gateway Protocol (BGP) route properties.",
+            "longDescription": "This type shall contain properties that are applicable to configuring Border Gateway Protocol (BGP) route related properties.",
+            "patternProperties": {
+                "^([a-zA-Z_][a-zA-Z0-9_]*)?@(odata|Redfish|Message)\\.[a-zA-Z_][a-zA-Z0-9_]*$": {
+                    "description": "This property shall specify a valid odata or Redfish property.",
+                    "type": [
+                        "array",
+                        "boolean",
+                        "integer",
+                        "number",
+                        "null",
+                        "object",
+                        "string"
+                    ]
+                }
+            },
+            "properties": {
+                "AdvertiseInactiveRoutesEnabled": {
+                    "description": "Advertise inactive route status.",
+                    "longDescription": "This property shall indicate whether inactive routes should be advertised.  If `true`, advertise the best Border Gateway Protocol (BGP) route that is inactive because of Interior Gateway Protocol (IGP) preference.  If `false`, do not use as part of BGP best path selection.",
+                    "readonly": false,
+                    "type": [
+                        "boolean",
+                        "null"
+                    ],
+                    "versionAdded": "v1_1_0"
+                },
+                "DistanceExternal": {
+                    "description": "Route distance for external routes.",
+                    "longDescription": "This property shall modify the administrative distance for routes learned via External BGP (eBGP).",
+                    "readonly": false,
+                    "type": [
+                        "integer",
+                        "null"
+                    ],
+                    "versionAdded": "v1_1_0"
+                },
+                "DistanceInternal": {
+                    "description": "Route distance for internal routes.",
+                    "longDescription": "This property shall modify the administrative distance for routes learned via Internal BGP (iBGP).",
+                    "readonly": false,
+                    "type": [
+                        "integer",
+                        "null"
+                    ],
+                    "versionAdded": "v1_1_0"
+                },
+                "DistanceLocal": {
+                    "description": "Route distance for local routes.",
+                    "longDescription": "This property shall modify the administrative distance for routes configured on a local router.",
+                    "readonly": false,
+                    "type": [
+                        "integer",
+                        "null"
+                    ],
+                    "versionAdded": "v1_1_0"
+                },
+                "ExternalCompareRouterIdEnabled": {
+                    "description": "Compare router id status.",
+                    "longDescription": "This property shall indicate whether external router ids should be compared.  If `true`, prefer the route that comes from the Border Gateway Protocol (BGP) router with the lowest router ID.  If `false`, do not use as part of BGP best path selection.",
+                    "readonly": false,
+                    "type": [
+                        "boolean",
+                        "null"
+                    ],
+                    "versionAdded": "v1_1_0"
+                },
+                "FlapDampingEnabled": {
+                    "description": "Route flap dampening status.",
+                    "longDescription": "This property shall indicate whether route flap dampening should be enabled.",
+                    "readonly": false,
+                    "type": [
+                        "boolean",
+                        "null"
+                    ],
+                    "versionAdded": "v1_1_0"
+                },
+                "SendDefaultRouteEnabled": {
+                    "description": "Send default route status.",
+                    "longDescription": "This property shall indicate whether the default route should be advertised.  If `true`, the default route is advertised to all Border Gateway Protocol (BGP) neighbors unless specifically denied.  If `false`, the default route is not advertised.",
+                    "readonly": false,
+                    "type": [
+                        "boolean",
+                        "null"
+                    ],
+                    "versionAdded": "v1_1_0"
+                }
+            },
+            "type": "object"
+        },
+        "CommonBGPProperties": {
+            "additionalProperties": false,
+            "description": "Common BGP properties.",
+            "longDescription": "This property shall contain properties shared across both External and Internal Border Gateway Protocol (BGP) related properties.",
+            "patternProperties": {
+                "^([a-zA-Z_][a-zA-Z0-9_]*)?@(odata|Redfish|Message)\\.[a-zA-Z_][a-zA-Z0-9_]*$": {
+                    "description": "This property shall specify a valid odata or Redfish property.",
+                    "type": [
+                        "array",
+                        "boolean",
+                        "integer",
+                        "number",
+                        "null",
+                        "object",
+                        "string"
+                    ]
+                }
+            },
+            "properties": {
+                "ASNumberRange": {
+                    "anyOf": [
+                        {
+                            "$ref": "#/definitions/ASNumberRange"
+                        },
+                        {
+                            "type": "null"
+                        }
+                    ],
+                    "description": "Autonomous System (AS) number range.",
+                    "longDescription": "This property shall contain the range of Autonomous System (AS) numbers assigned to each Border Gateway Protocol (BGP) peer within the fabric.",
+                    "versionAdded": "v1_1_0"
+                },
+                "BGPNeighbor": {
+                    "anyOf": [
+                        {
+                            "$ref": "#/definitions/BGPNeighbor"
+                        },
+                        {
+                            "type": "null"
+                        }
+                    ],
+                    "description": "Border Gateway Protocol (BGP) neighbor related properties.",
+                    "longDescription": "This property shall contain all Border Gateway Protocol (BGP) neighbor related properties.",
+                    "versionAdded": "v1_1_0"
+                },
+                "BGPRoute": {
+                    "anyOf": [
+                        {
+                            "$ref": "#/definitions/BGPRoute"
+                        },
+                        {
+                            "type": "null"
+                        }
+                    ],
+                    "description": "Border Gateway Protocol (BGP) route related properties.",
+                    "longDescription": "This property shall contain Border Gateway Protocol (BGP) route related properties.",
+                    "versionAdded": "v1_1_0"
+                },
+                "GracefulRestart": {
+                    "anyOf": [
+                        {
+                            "$ref": "#/definitions/GracefulRestart"
+                        },
+                        {
+                            "type": "null"
+                        }
+                    ],
+                    "description": "Graceful restart related properties.",
+                    "longDescription": "This property shall contain all graceful restart related properties.",
+                    "versionAdded": "v1_1_0"
+                },
+                "MultiplePaths": {
+                    "anyOf": [
+                        {
+                            "$ref": "#/definitions/MultiplePaths"
+                        },
+                        {
+                            "type": "null"
+                        }
+                    ],
+                    "description": "Multiple path related properties.",
+                    "longDescription": "This property shall contain all multiple path related properties.",
+                    "versionAdded": "v1_1_0"
+                },
+                "SendCommunityEnabled": {
+                    "description": "This property shall indicate whether community attributes are sent.",
+                    "longDescription": "This property shall indicate whether community attributes are sent to BGP neighbors.",
+                    "readonly": false,
+                    "type": [
+                        "boolean",
+                        "null"
+                    ],
+                    "versionAdded": "v1_1_0"
+                }
+            },
+            "type": "object"
+        },
+        "DHCP": {
+            "additionalProperties": false,
+            "description": "DHCP related properties for an Ethernet fabric.",
+            "longDescription": "This type shall contain for assigning DHCP related properties to the Ethernet fabric.",
+            "patternProperties": {
+                "^([a-zA-Z_][a-zA-Z0-9_]*)?@(odata|Redfish|Message)\\.[a-zA-Z_][a-zA-Z0-9_]*$": {
+                    "description": "This property shall specify a valid odata or Redfish property.",
+                    "type": [
+                        "array",
+                        "boolean",
+                        "integer",
+                        "number",
+                        "null",
+                        "object",
+                        "string"
+                    ]
+                }
+            },
+            "properties": {
+                "DHCPInterfaceMTUBytes": {
+                    "description": "Dynamic Host Configuration Protocol (DHCP) interface Maximum Transmission Unit (MTU).",
+                    "longDescription": "This property shall contain the Maximum Transmission Unit (MTU) to use on this interface in bytes.",
+                    "maximum": 9194,
+                    "minimum": 68,
+                    "readonly": false,
+                    "type": [
+                        "integer",
+                        "null"
+                    ],
+                    "versionAdded": "v1_1_0"
+                },
+                "DHCPRelayEnabled": {
+                    "description": "Dynamic Host Configuration Protocol (DHCP) relay status.",
+                    "longDescription": "This property shall indicate whether Dynamic Host Configuration Protocol (DHCP) Relay is enabled.",
+                    "readonly": false,
+                    "type": [
+                        "boolean",
+                        "null"
+                    ],
+                    "versionAdded": "v1_1_0"
+                },
+                "DHCPServer": {
+                    "description": "The Dynamic Host Configuration Protocol (DHCP) IPv4 addresses for this Ethernet fabric.",
+                    "items": {
+                        "type": [
+                            "string",
+                            "null"
+                        ]
+                    },
+                    "longDescription": "This property shall contain an array of addresses assigned to the Dynamic Host Configuration Protocol (DHCP) server for this Ethernet fabric.",
+                    "readonly": false,
+                    "type": "array",
+                    "versionAdded": "v1_1_0"
+                }
+            },
+            "type": "object"
+        },
+        "EBGP": {
+            "additionalProperties": false,
+            "description": "External BGP (eBGP) related properties for an Ethernet fabric.",
+            "longDescription": "This type shall contain the External BGP (eBGP) related properties for an Ethernet fabric.",
+            "patternProperties": {
+                "^([a-zA-Z_][a-zA-Z0-9_]*)?@(odata|Redfish|Message)\\.[a-zA-Z_][a-zA-Z0-9_]*$": {
+                    "description": "This property shall specify a valid odata or Redfish property.",
+                    "type": [
+                        "array",
+                        "boolean",
+                        "integer",
+                        "number",
+                        "null",
+                        "object",
+                        "string"
+                    ]
+                }
+            },
+            "properties": {
+                "ASNumberRange": {
+                    "anyOf": [
+                        {
+                            "$ref": "#/definitions/ASNumberRange"
+                        },
+                        {
+                            "type": "null"
+                        }
+                    ],
+                    "description": "Autonomous System (AS) number range.",
+                    "longDescription": "This property shall contain the range of Autonomous System (AS) numbers assigned to each Border Gateway Protocol (BGP) peer within the fabric.",
+                    "versionAdded": "v1_1_0"
+                },
+                "AllowDuplicateASEnabled": {
+                    "description": "Allow duplicate Autonomous System (AS) path.",
+                    "longDescription": "This property shall indicate whether duplicate Autonomous System (AS) numbers are allowed.  If `true`, routes with the same AS number as the receiving router should be allowed.  If `false`,routes should be dropped if the router receives its own AS number in a Border Gateway Protocol (BGP) update.",
+                    "readonly": false,
+                    "type": [
+                        "boolean",
+                        "null"
+                    ],
+                    "versionAdded": "v1_1_0"
+                },
+                "AllowOverrideASEnabled": {
+                    "description": "Option to override an Autonomous System (AS) number with the AS number of the sending peer .",
+                    "longDescription": "This property shall indicate whether Autonomous System (AS) numbers should be overridden.  If `true`, AS number should be overridden with the AS number of the sending peer.  If `false`, AS number override is disabled.",
+                    "readonly": false,
+                    "type": [
+                        "boolean",
+                        "null"
+                    ],
+                    "versionAdded": "v1_1_0"
+                },
+                "AlwaysCompareMEDEnabled": {
+                    "description": "Compare Multi Exit Discriminator (MED) status.",
+                    "longDescription": "This property shall indicate whether neighbor Multi Exit Discriminator (MED) attributes should be compared.",
+                    "readonly": false,
+                    "type": [
+                        "boolean",
+                        "null"
+                    ],
+                    "versionAdded": "v1_1_0"
+                },
+                "BGPLocalPreference": {
+                    "description": "Local preference value.",
+                    "longDescription": "This property shall contain the local preference value.  Highest local preference value is preferred for Border Gateway Protocol (BGP) best path selection.",
+                    "readonly": false,
+                    "type": [
+                        "integer",
+                        "null"
+                    ],
+                    "versionAdded": "v1_1_0"
+                },
+                "BGPNeighbor": {
+                    "anyOf": [
+                        {
+                            "$ref": "#/definitions/BGPNeighbor"
+                        },
+                        {
+                            "type": "null"
+                        }
+                    ],
+                    "description": "Border Gateway Protocol (BGP) neighbor related properties.",
+                    "longDescription": "This property shall contain all Border Gateway Protocol (BGP) neighbor related properties.",
+                    "versionAdded": "v1_1_0"
+                },
+                "BGPRoute": {
+                    "anyOf": [
+                        {
+                            "$ref": "#/definitions/BGPRoute"
+                        },
+                        {
+                            "type": "null"
+                        }
+                    ],
+                    "description": "Border Gateway Protocol (BGP) route related properties.",
+                    "longDescription": "This property shall contain Border Gateway Protocol (BGP) route related properties.",
+                    "versionAdded": "v1_1_0"
+                },
+                "BGPWeight": {
+                    "description": "BGP weight attribute.",
+                    "longDescription": "This property shall contain the Border Gateway Protocol (BGP) weight attribute value for external peers.  A higher BGP weight value is preferred for BGP best path selection.",
+                    "readonly": false,
+                    "type": [
+                        "integer",
+                        "null"
+                    ],
+                    "versionAdded": "v1_1_0"
+                },
+                "GracefulRestart": {
+                    "anyOf": [
+                        {
+                            "$ref": "#/definitions/GracefulRestart"
+                        },
+                        {
+                            "type": "null"
+                        }
+                    ],
+                    "description": "Graceful restart related properties.",
+                    "longDescription": "This property shall contain all graceful restart related properties.",
+                    "versionAdded": "v1_1_0"
+                },
+                "MED": {
+                    "description": "BGP Multi Exit Discriminator (MED) value.",
+                    "longDescription": "This property shall contain the Border Gateway Protocol (BGP) Multi Exit Discriminator (MED) value.  A lower MED value is preferred for BGP best path selection.",
+                    "readonly": false,
+                    "type": [
+                        "integer",
+                        "null"
+                    ],
+                    "versionAdded": "v1_1_0"
+                },
+                "MultihopEnabled": {
+                    "description": "External BGP (eBGP) multihop status.",
+                    "longDescription": "This property shall indicate whether External BGP (eBGP) multihop is enabled.",
+                    "readonly": false,
+                    "type": [
+                        "boolean",
+                        "null"
+                    ],
+                    "versionAdded": "v1_1_0"
+                },
+                "MultihopTTL": {
+                    "description": "External BGP (eBGP) multihop Time to Live (TTL) value.",
+                    "longDescription": "This property shall contain the External BGP (eBGP) multihop Time to Live (TTL) value.",
+                    "readonly": false,
+                    "type": [
+                        "integer",
+                        "null"
+                    ],
+                    "versionAdded": "v1_1_0"
+                },
+                "MultiplePaths": {
+                    "anyOf": [
+                        {
+                            "$ref": "#/definitions/MultiplePaths"
+                        },
+                        {
+                            "type": "null"
+                        }
+                    ],
+                    "description": "Multiple path related properties.",
+                    "longDescription": "This property shall contain all multiple path related properties.",
+                    "versionAdded": "v1_1_0"
+                },
+                "SendCommunityEnabled": {
+                    "description": "This property shall indicate whether community attributes are sent.",
+                    "longDescription": "This property shall indicate whether community attributes are sent to BGP neighbors.",
+                    "readonly": false,
+                    "type": [
+                        "boolean",
+                        "null"
+                    ],
+                    "versionAdded": "v1_1_0"
+                }
+            },
+            "type": "object"
+        },
+        "ESINumberRange": {
+            "additionalProperties": false,
+            "description": "The Ethernet Segment Identifier (ESI) number range for an Ethernet fabric.",
+            "longDescription": "This type shall contain Ethernet Segment Identifier (ESI) number ranges for allocation in supporting functions such as multihoming.",
+            "patternProperties": {
+                "^([a-zA-Z_][a-zA-Z0-9_]*)?@(odata|Redfish|Message)\\.[a-zA-Z_][a-zA-Z0-9_]*$": {
+                    "description": "This property shall specify a valid odata or Redfish property.",
+                    "type": [
+                        "array",
+                        "boolean",
+                        "integer",
+                        "number",
+                        "null",
+                        "object",
+                        "string"
+                    ]
+                }
+            },
+            "properties": {
+                "Lower": {
+                    "description": "Lower Ethernet Segment Identifier (ESI) number.",
+                    "longDescription": "This property shall contain the lower Ethernet Segment Identifier (ESI) number to be used as part of a range of ESI numbers.",
+                    "readonly": false,
+                    "type": "integer",
+                    "versionAdded": "v1_1_0"
+                },
+                "Upper": {
+                    "description": "Upper Ethernet Segment Identifier (ESI) number.",
+                    "longDescription": "This property shall contain the upper Ethernet Segment Identifier (ESI) number to be used as part of a range of ESI numbers.",
+                    "readonly": false,
+                    "type": "integer",
+                    "versionAdded": "v1_1_0"
+                }
+            },
+            "type": "object"
+        },
+        "EVINumberRange": {
+            "additionalProperties": false,
+            "description": "The Ethernet Virtual Private Network (EVPN) Instance (EVI) number range for an Ethernet fabric.",
+            "longDescription": "This type shall contain the Ethernet Virtual Private Network (EVPN) Instance (EVI) number range for EVPN based fabrics.",
+            "patternProperties": {
+                "^([a-zA-Z_][a-zA-Z0-9_]*)?@(odata|Redfish|Message)\\.[a-zA-Z_][a-zA-Z0-9_]*$": {
+                    "description": "This property shall specify a valid odata or Redfish property.",
+                    "type": [
+                        "array",
+                        "boolean",
+                        "integer",
+                        "number",
+                        "null",
+                        "object",
+                        "string"
+                    ]
+                }
+            },
+            "properties": {
+                "Lower": {
+                    "description": "Lower Ethernet Virtual Private Network (EVPN) Instance (EVI) number.",
+                    "longDescription": "This property shall contain the lower Ethernet Virtual Private Network (EVPN) Instance (EVI) number to be used as part of a range of EVI numbers.",
+                    "readonly": false,
+                    "type": "integer",
+                    "versionAdded": "v1_1_0"
+                },
+                "Upper": {
+                    "description": "Upper Ethernet Virtual Private Network (EVPN) Instance (EVI) number.",
+                    "longDescription": "This property shall contain the upper Ethernet Virtual Private Network (EVPN) Instance (EVI) number to be used as part of a range of EVI numbers.",
+                    "readonly": false,
+                    "type": "integer",
+                    "versionAdded": "v1_1_0"
+                }
+            },
+            "type": "object"
+        },
+        "Ethernet": {
+            "additionalProperties": false,
+            "description": "Ethernet related properties for an address pool.",
+            "longDescription": "This type shall contain the Ethernet related properties for an address pool.",
+            "patternProperties": {
+                "^([a-zA-Z_][a-zA-Z0-9_]*)?@(odata|Redfish|Message)\\.[a-zA-Z_][a-zA-Z0-9_]*$": {
+                    "description": "This property shall specify a valid odata or Redfish property.",
+                    "type": [
+                        "array",
+                        "boolean",
+                        "integer",
+                        "number",
+                        "null",
+                        "object",
+                        "string"
+                    ]
+                }
+            },
+            "properties": {
+                "BFDSingleHopOnly": {
+                    "anyOf": [
+                        {
+                            "$ref": "#/definitions/BFDSingleHopOnly"
+                        },
+                        {
+                            "type": "null"
+                        }
+                    ],
+                    "description": "Bidirectional Forwarding Detection (BFD) related properties for this Ethernet fabric.",
+                    "longDescription": "This property shall contain the Bidirectional Forwarding Detection (BFD) related properties for this Ethernet fabric.",
+                    "versionAdded": "v1_1_0"
+                },
+                "BGPEvpn": {
+                    "anyOf": [
+                        {
+                            "$ref": "#/definitions/BGPEvpn"
+                        },
+                        {
+                            "type": "null"
+                        }
+                    ],
+                    "description": "BGP Ethernet Virtual Private Network (EVPN) related properties for this Ethernet fabric.",
+                    "longDescription": "This property shall contain the BGP Ethernet Virtual Private Network (EVPN) related properties for this Ethernet fabric.",
+                    "versionAdded": "v1_1_0"
+                },
+                "EBGP": {
+                    "anyOf": [
+                        {
+                            "$ref": "#/definitions/EBGP"
+                        },
+                        {
+                            "type": "null"
+                        }
+                    ],
+                    "description": "External BGP (eBGP) related properties for this Ethernet fabric.",
+                    "longDescription": "This property shall contain the External BGP (eBGP) related properties for this Ethernet fabric.",
+                    "versionAdded": "v1_1_0"
+                },
+                "IPv4": {
+                    "anyOf": [
+                        {
+                            "$ref": "#/definitions/IPv4"
+                        },
+                        {
+                            "type": "null"
+                        }
+                    ],
+                    "description": "IPv4 and Virtual LAN (VLAN) related addressing for this Ethernet fabric.",
+                    "longDescription": "This property shall contain IPv4 and Virtual LAN (VLAN) addressing related properties for this Ethernet fabric.",
+                    "versionAdded": "v1_1_0"
+                },
+                "MultiProtocolEBGP": {
+                    "anyOf": [
+                        {
+                            "$ref": "#/definitions/EBGP"
+                        },
+                        {
+                            "type": "null"
+                        }
+                    ],
+                    "description": "Multi Protocol eBGP (MP eBGP) related properties for this Ethernet fabric.",
+                    "longDescription": "This property shall contain the Multi Protocol eBGP (MP eBGP) related properties for this Ethernet fabric.",
+                    "versionAdded": "v1_1_0"
+                },
+                "MultiProtocolIBGP": {
+                    "anyOf": [
+                        {
+                            "$ref": "#/definitions/CommonBGPProperties"
+                        },
+                        {
+                            "type": "null"
+                        }
+                    ],
+                    "description": "Multi Protocol iBGP (MP iBGP) related properties for this Ethernet fabric.",
+                    "longDescription": "This property shall contain the Multi Protocol iBGP (MP iBGP) related properties for this Ethernet fabric.",
+                    "versionAdded": "v1_1_0"
+                }
+            },
+            "type": "object"
+        },
+        "GatewayIPAddressRange": {
+            "additionalProperties": false,
+            "description": "The IPv4 address range for gateway nodes for Ethernet Virtual Private Network (EVPN) based fabrics.",
+            "longDescription": "This type shall contain the IPv4 address range for gateway nodes for Ethernet Virtual Private Network (EVPN) based fabrics.",
+            "patternProperties": {
+                "^([a-zA-Z_][a-zA-Z0-9_]*)?@(odata|Redfish|Message)\\.[a-zA-Z_][a-zA-Z0-9_]*$": {
+                    "description": "This property shall specify a valid odata or Redfish property.",
+                    "type": [
+                        "array",
+                        "boolean",
+                        "integer",
+                        "number",
+                        "null",
+                        "object",
+                        "string"
+                    ]
+                }
+            },
+            "properties": {
+                "Lower": {
+                    "description": "The lower IPv4 address.",
+                    "longDescription": "This property shall contain the lower IP address to be used as part of a range of addresses for gateway nodes in Ethernet Virtual Private Network (EVPN) based fabrics.",
+                    "pattern": "^(?:[0-9]{1,3}\\.){3}[0-9]{1,3}$",
+                    "readonly": false,
+                    "type": [
+                        "string",
+                        "null"
+                    ],
+                    "versionAdded": "v1_2_0"
+                },
+                "Upper": {
+                    "description": "The upper IPv4 address.",
+                    "longDescription": "This property shall contain the upper IP address to be used as part of a range of addresses for gateway nodes in Ethernet Virtual Private Network (EVPN) based fabrics.",
+                    "pattern": "^(?:[0-9]{1,3}\\.){3}[0-9]{1,3}$",
+                    "readonly": false,
+                    "type": [
+                        "string",
+                        "null"
+                    ],
+                    "versionAdded": "v1_2_0"
+                }
+            },
+            "type": "object"
+        },
+        "GenZ": {
+            "additionalProperties": false,
+            "description": "Gen-Z related properties for an address pool.",
+            "longDescription": "This type shall contain Gen-Z related properties for an address pool.",
+            "patternProperties": {
+                "^([a-zA-Z_][a-zA-Z0-9_]*)?@(odata|Redfish|Message)\\.[a-zA-Z_][a-zA-Z0-9_]*$": {
+                    "description": "This property shall specify a valid odata or Redfish property.",
+                    "type": [
+                        "array",
+                        "boolean",
+                        "integer",
+                        "number",
+                        "null",
+                        "object",
+                        "string"
+                    ]
+                }
+            },
+            "properties": {
+                "AccessKey": {
+                    "description": "The Access Key required for this address pool.",
+                    "longDescription": "This property shall contain the Gen-Z Core Specification-defined Access Key required for this address pool.",
+                    "pattern": "^0[xX]([a-fA-F]|[0-9]){2}$",
+                    "readonly": false,
+                    "type": [
+                        "string",
+                        "null"
+                    ]
+                },
+                "MaxCID": {
+                    "description": "The maximum value for the Component Identifier (CID).",
+                    "longDescription": "This property shall contain the maximum value for the Gen-Z Core Specification-defined Component Identifier (CID).",
+                    "readonly": false,
+                    "type": [
+                        "integer",
+                        "null"
+                    ]
+                },
+                "MaxSID": {
+                    "description": "The maximum value for the Subnet Identifier (SID).",
+                    "longDescription": "This property shall contain the maximum value for the Gen-Z Core Specification-defined Subnet Identifier (SID).",
+                    "readonly": false,
+                    "type": [
+                        "integer",
+                        "null"
+                    ]
+                },
+                "MinCID": {
+                    "description": "The minimum value for the Component Identifier (CID).",
+                    "longDescription": "This property shall contain the minimum value for the Gen-Z Core Specification-defined Component Identifier (CID).",
+                    "readonly": false,
+                    "type": [
+                        "integer",
+                        "null"
+                    ]
+                },
+                "MinSID": {
+                    "description": "The minimum value for the Subnet Identifier (SID).",
+                    "longDescription": "This property shall contain the minimum value for the Gen-Z Core Specification-defined Subnet Identifier (SID).",
+                    "readonly": false,
+                    "type": [
+                        "integer",
+                        "null"
+                    ]
+                }
+            },
+            "type": "object"
+        },
+        "GracefulRestart": {
+            "additionalProperties": false,
+            "description": "Border Gateway Protocol (BGP) graceful restart properties.",
+            "longDescription": "This type shall contain properties that are applicable to configuring Border Gateway Protocol (BGP) graceful restart related properties.",
+            "patternProperties": {
+                "^([a-zA-Z_][a-zA-Z0-9_]*)?@(odata|Redfish|Message)\\.[a-zA-Z_][a-zA-Z0-9_]*$": {
+                    "description": "This property shall specify a valid odata or Redfish property.",
+                    "type": [
+                        "array",
+                        "boolean",
+                        "integer",
+                        "number",
+                        "null",
+                        "object",
+                        "string"
+                    ]
+                }
+            },
+            "properties": {
+                "GracefulRestartEnabled": {
+                    "description": "Border Gateway Protocol (BGP) graceful restart status.",
+                    "longDescription": "This property shall indicate whether to enable Border Gateway Protocol (BGP) graceful restart features.",
+                    "readonly": false,
+                    "type": [
+                        "boolean",
+                        "null"
+                    ],
+                    "versionAdded": "v1_1_0"
+                },
+                "HelperModeEnabled": {
+                    "description": "Graceful restart helper mode status.",
+                    "longDescription": "This property shall indicate what to do with stale routes.  If `true`, the router continues to be forward packets to stale routes, if `false`, it does not forward packets to stale routes.",
+                    "readonly": false,
+                    "type": [
+                        "boolean",
+                        "null"
+                    ],
+                    "versionAdded": "v1_1_0"
+                },
+                "StaleRoutesTimeSeconds": {
+                    "description": "Stale route timer in seconds.",
+                    "longDescription": "This property shall contain the time in seconds to hold stale routes for a restarting peer.",
+                    "readonly": false,
+                    "type": [
+                        "integer",
+                        "null"
+                    ],
+                    "versionAdded": "v1_1_0"
+                },
+                "TimeSeconds": {
+                    "description": "Graceful restart timer in seconds.",
+                    "longDescription": "This property shall contain the time in seconds to wait for a graceful restart capable neighbor to re-establish Border Gateway Protocol (BGP) peering.",
+                    "readonly": false,
+                    "type": [
+                        "integer",
+                        "null"
+                    ],
+                    "versionAdded": "v1_1_0"
+                }
+            },
+            "type": "object"
+        },
+        "IPv4": {
+            "additionalProperties": false,
+            "description": "IPv4 and Virtual LAN (VLAN) related addressing for an Ethernet fabric.",
+            "longDescription": "This type shall contain IPv4 and Virtual LAN (VLAN) addressing related properties for an Ethernet fabric.",
+            "patternProperties": {
+                "^([a-zA-Z_][a-zA-Z0-9_]*)?@(odata|Redfish|Message)\\.[a-zA-Z_][a-zA-Z0-9_]*$": {
+                    "description": "This property shall specify a valid odata or Redfish property.",
+                    "type": [
+                        "array",
+                        "boolean",
+                        "integer",
+                        "number",
+                        "null",
+                        "object",
+                        "string"
+                    ]
+                }
+            },
+            "properties": {
+                "AnycastGatewayIPAddress": {
+                    "description": "The anycast gateway IPv4 address.",
+                    "longDescription": "This property shall contain the anycast gateway IPv4 address for a host subnet.",
+                    "pattern": "^(?:[0-9]{1,3}\\.){3}[0-9]{1,3}$",
+                    "readonly": false,
+                    "type": [
+                        "string",
+                        "null"
+                    ],
+                    "versionAdded": "v1_1_0"
+                },
+                "AnycastGatewayMACAddress": {
+                    "description": "The anycast gateway MAC address.",
+                    "longDescription": "This property shall contain the anycast gateway MAC address for a host subnet.",
+                    "pattern": "^([0-9A-Fa-f]{2}[:-]){5}([0-9A-Fa-f]{2})$",
+                    "readonly": false,
+                    "type": [
+                        "string",
+                        "null"
+                    ],
+                    "versionAdded": "v1_1_0"
+                },
+                "DHCP": {
+                    "anyOf": [
+                        {
+                            "$ref": "#/definitions/DHCP"
+                        },
+                        {
+                            "type": "null"
+                        }
+                    ],
+                    "description": "The Dynamic Host Configuration Protocol (DHCP) related addressing for this Ethernet fabric.",
+                    "longDescription": "This property shall contain the primary and secondary Dynamic Host Configuration Protocol (DHCP) server addressing for this Ethernet fabric.",
+                    "versionAdded": "v1_1_0"
+                },
+                "DNSDomainName": {
+                    "description": "The Domain Name Service (DNS) domain name for this Ethernet fabric.",
+                    "longDescription": "This property shall contain the Domain Name Service (DNS) domain name for this Ethernet fabric.",
+                    "readonly": false,
+                    "type": [
+                        "string",
+                        "null"
+                    ],
+                    "versionAdded": "v1_1_0"
+                },
+                "DNSServer": {
+                    "description": "The Domain Name Service (DNS) servers for this Ethernet fabric.",
+                    "items": {
+                        "type": [
+                            "string",
+                            "null"
+                        ]
+                    },
+                    "longDescription": "This property shall contain an array of the Domain Name Service (DNS) servers for this Ethernet fabric.",
+                    "pattern": "^(?:[0-9]{1,3}\\.){3}[0-9]{1,3}$",
+                    "readonly": false,
+                    "type": "array",
+                    "versionAdded": "v1_1_0"
+                },
+                "DistributeIntoUnderlayEnabled": {
+                    "description": "Indicates if host subnets should be distributed into the fabric underlay.",
+                    "longDescription": "This property shall indicate whether host subnets are distributed into the fabric underlay.",
+                    "readonly": false,
+                    "type": [
+                        "boolean",
+                        "null"
+                    ],
+                    "versionAdded": "v1_1_0"
+                },
+                "EBGPAddressRange": {
+                    "anyOf": [
+                        {
+                            "$ref": "#/definitions/IPv4AddressRange"
+                        },
+                        {
+                            "type": "null"
+                        }
+                    ],
+                    "description": "External BGP (eBGP) related addressing for this Ethernet fabric.",
+                    "longDescription": "This property shall contain the range of IPv4 addresses assigned to External BGP (eBGP).",
+                    "versionAdded": "v1_1_0"
+                },
+                "FabricLinkAddressRange": {
+                    "anyOf": [
+                        {
+                            "$ref": "#/definitions/IPv4AddressRange"
+                        },
+                        {
+                            "type": "null"
+                        }
+                    ],
+                    "description": "Link related addressing for this Ethernet fabric.",
+                    "longDescription": "This property shall contain the range of link IPv4 addressing between Ethernet switches.",
+                    "versionAdded": "v1_1_0"
+                },
+                "GatewayIPAddress": {
+                    "description": "The gateway IPv4 address.",
+                    "longDescription": "This property shall contain the gateway IPv4 address for a host subnet.",
+                    "pattern": "^(?:[0-9]{1,3}\\.){3}[0-9]{1,3}$",
+                    "readonly": false,
+                    "type": [
+                        "string",
+                        "null"
+                    ],
+                    "versionAdded": "v1_1_0"
+                },
+                "HostAddressRange": {
+                    "anyOf": [
+                        {
+                            "$ref": "#/definitions/IPv4AddressRange"
+                        },
+                        {
+                            "type": "null"
+                        }
+                    ],
+                    "description": "IPv4 related end host subnet addressing for this Ethernet fabric.",
+                    "longDescription": "This property shall contain the range of IP subnets used for host addressing.",
+                    "versionAdded": "v1_1_0"
+                },
+                "IBGPAddressRange": {
+                    "anyOf": [
+                        {
+                            "$ref": "#/definitions/IPv4AddressRange"
+                        },
+                        {
+                            "type": "null"
+                        }
+                    ],
+                    "description": "Internal BGP (iBGP) related addressing for this Ethernet fabric.",
+                    "longDescription": "This property shall contain the range of IPv4 addresses assigned to Internal BGP (iBGP).",
+                    "versionAdded": "v1_1_0"
+                },
+                "LoopbackAddressRange": {
+                    "anyOf": [
+                        {
+                            "$ref": "#/definitions/IPv4AddressRange"
+                        },
+                        {
+                            "type": "null"
+                        }
+                    ],
+                    "description": "Loopback related addressing for this Ethernet fabric.",
+                    "longDescription": "This property shall contain the range of loopback addresses assigned to Ethernet switches.",
+                    "versionAdded": "v1_1_0"
+                },
+                "ManagementAddressRange": {
+                    "anyOf": [
+                        {
+                            "$ref": "#/definitions/IPv4AddressRange"
+                        },
+                        {
+                            "type": "null"
+                        }
+                    ],
+                    "description": "Management related addressing for this Ethernet fabric.",
+                    "longDescription": "This property shall contain the range of management IPv4 addresses assigned to Ethernet switches.",
+                    "versionAdded": "v1_1_0"
+                },
+                "NTPOffsetHoursMinutes": {
+                    "description": "The Network Time Protocol (NTP) offset configuration.",
+                    "longDescription": "This property shall contain the Network Time Protocol (NTP) offset.  The NTP offset property is used to calculate the time from UTC (Universal Time Coordinated) time in hours and minutes.",
+                    "readonly": false,
+                    "type": [
+                        "integer",
+                        "null"
+                    ],
+                    "versionAdded": "v1_1_0"
+                },
+                "NTPServer": {
+                    "description": "The Network Time Protocol (NTP) servers for this Ethernet fabric.",
+                    "items": {
+                        "type": [
+                            "string",
+                            "null"
+                        ]
+                    },
+                    "longDescription": "This property shall contain an array of the Network Time Protocol (NTP) servers for this Ethernet fabric.",
+                    "readonly": false,
+                    "type": "array",
+                    "versionAdded": "v1_1_0"
+                },
+                "NTPTimezone": {
+                    "description": "The Network Time Protocol (NTP) timezone for this Ethernet fabric.",
+                    "longDescription": "This property shall contain the Network Time Protocol (NTP) timezone name assigned to this Ethernet fabric.",
+                    "readonly": false,
+                    "type": [
+                        "string",
+                        "null"
+                    ],
+                    "versionAdded": "v1_1_0"
+                },
+                "NativeVLAN": {
+                    "description": "The native Virtual LAN (VLAN) tag value.",
+                    "longDescription": "This property shall contain native Virtual LAN (VLAN) tag value for untagged traffic.",
+                    "maximum": 4094,
+                    "minimum": 1,
+                    "readonly": false,
+                    "type": [
+                        "integer",
+                        "null"
+                    ],
+                    "versionAdded": "v1_1_0"
+                },
+                "SystemMACRange": {
+                    "anyOf": [
+                        {
+                            "$ref": "#/definitions/SystemMACRange"
+                        },
+                        {
+                            "type": "null"
+                        }
+                    ],
+                    "description": "The MAC address range for systems in this subnet.",
+                    "longDescription": "This property shall contain the Media Access Control (MAC) address range for systems in Ethernet Virtual Private Network (EVPN) based fabrics.",
+                    "versionAdded": "v1_2_0"
+                },
+                "VLANIdentifierAddressRange": {
+                    "anyOf": [
+                        {
+                            "$ref": "#/definitions/VLANIdentifierAddressRange"
+                        },
+                        {
+                            "type": "null"
+                        }
+                    ],
+                    "description": "Virtual LAN (VLAN) tag related addressing for this Ethernet fabric or for end host networks.",
+                    "longDescription": "This property shall contain Virtual LAN (VLAN) tags for the entire fabric as well as to end hosts.",
+                    "versionAdded": "v1_1_0"
+                }
+            },
+            "type": "object"
+        },
+        "IPv4AddressRange": {
+            "additionalProperties": false,
+            "description": "IPv4 related address range for an Ethernet fabric.",
+            "longDescription": "This type shall contain an IPv4 related address range for an Ethernet fabric.",
+            "patternProperties": {
+                "^([a-zA-Z_][a-zA-Z0-9_]*)?@(odata|Redfish|Message)\\.[a-zA-Z_][a-zA-Z0-9_]*$": {
+                    "description": "This property shall specify a valid odata or Redfish property.",
+                    "type": [
+                        "array",
+                        "boolean",
+                        "integer",
+                        "number",
+                        "null",
+                        "object",
+                        "string"
+                    ]
+                }
+            },
+            "properties": {
+                "Lower": {
+                    "description": "Lower IPv4 network address.",
+                    "longDescription": "This property shall contain the lower IPv4 network address to be used as part of a subnet.",
+                    "pattern": "^(?:[0-9]{1,3}\\.){3}[0-9]{1,3}$",
+                    "readonly": false,
+                    "type": [
+                        "string",
+                        "null"
+                    ],
+                    "versionAdded": "v1_1_0"
+                },
+                "Upper": {
+                    "description": "Upper IPv4 network address.",
+                    "longDescription": "This property shall contain the upper IPv4 network address to be used as part of a host subnet.",
+                    "pattern": "^(?:[0-9]{1,3}\\.){3}[0-9]{1,3}$",
+                    "readonly": false,
+                    "type": [
+                        "string",
+                        "null"
+                    ],
+                    "versionAdded": "v1_1_0"
+                }
+            },
+            "type": "object"
+        },
+        "Links": {
+            "additionalProperties": false,
+            "description": "The links to other resources that are related to this resource.",
+            "longDescription": "This Redfish Specification-described type shall contain links to resources that are related to but are not contained by, or subordinate to, this resource.",
+            "patternProperties": {
+                "^([a-zA-Z_][a-zA-Z0-9_]*)?@(odata|Redfish|Message)\\.[a-zA-Z_][a-zA-Z0-9_]*$": {
+                    "description": "This property shall specify a valid odata or Redfish property.",
+                    "type": [
+                        "array",
+                        "boolean",
+                        "integer",
+                        "number",
+                        "null",
+                        "object",
+                        "string"
+                    ]
+                }
+            },
+            "properties": {
+                "Endpoints": {
+                    "description": "An array of links to the endpoints that this address pool contains.",
+                    "items": {
+                        "$ref": "http://redfish.dmtf.org/schemas/v1/Endpoint.json#/definitions/Endpoint"
+                    },
+                    "longDescription": "This property shall contain an array of links to resources of type Endpoint that this address pool contains.",
+                    "readonly": false,
+                    "type": "array"
+                },
+                "Endpoints@odata.count": {
+                    "$ref": "http://redfish.dmtf.org/schemas/v1/odata-v4.json#/definitions/count"
+                },
+                "Oem": {
+                    "$ref": "http://redfish.dmtf.org/schemas/v1/Resource.json#/definitions/Oem",
+                    "description": "The OEM extension property.",
+                    "longDescription": "This property shall contain the OEM extensions.  All values for properties contained in this object shall conform to the Redfish Specification-described requirements."
+                },
+                "Zones": {
+                    "description": "An array of links to the zones that this address pool contains.",
+                    "items": {
+                        "$ref": "http://redfish.dmtf.org/schemas/v1/Zone.json#/definitions/Zone"
+                    },
+                    "longDescription": "This property shall contain an array of links to resources of type Zone that this address pool contains.",
+                    "readonly": false,
+                    "type": "array"
+                },
+                "Zones@odata.count": {
+                    "$ref": "http://redfish.dmtf.org/schemas/v1/odata-v4.json#/definitions/count"
+                }
+            },
+            "type": "object"
+        },
+        "MaxPrefix": {
+            "additionalProperties": false,
+            "description": "Border Gateway Protocol (BGP) max prefix properties.",
+            "longDescription": "This type shall contain properties that are applicable to configuring Border Gateway Protocol (BGP) max prefix related properties.",
+            "patternProperties": {
+                "^([a-zA-Z_][a-zA-Z0-9_]*)?@(odata|Redfish|Message)\\.[a-zA-Z_][a-zA-Z0-9_]*$": {
+                    "description": "This property shall specify a valid odata or Redfish property.",
+                    "type": [
+                        "array",
+                        "boolean",
+                        "integer",
+                        "number",
+                        "null",
+                        "object",
+                        "string"
+                    ]
+                }
+            },
+            "properties": {
+                "MaxPrefixNumber": {
+                    "description": "Maximum prefix number.",
+                    "longDescription": "This property shall contain the maximum number of prefixes allowed from the neighbor.",
+                    "readonly": false,
+                    "type": [
+                        "integer",
+                        "null"
+                    ],
+                    "versionAdded": "v1_1_0"
+                },
+                "RestartTimerSeconds": {
+                    "description": "Border Gateway Protocol (BGP) restart timer in seconds.",
+                    "longDescription": "This property determines how long peer routers will wait to delete stale routes before a Border Gateway Protocol (BGP) open message is received.  This timer should be less than the BGP HoldTimeSeconds property.",
+                    "readonly": false,
+                    "type": [
+                        "integer",
+                        "null"
+                    ],
+                    "versionAdded": "v1_1_0"
+                },
+                "ShutdownThresholdPercentage": {
+                    "description": "Shutdown threshold status.",
+                    "longDescription": "This property shall contain the percentage of the maximum prefix received value at which the router starts to generate a warning message.",
+                    "maximum": 100,
+                    "minimum": 1,
+                    "readonly": false,
+                    "type": [
+                        "number",
+                        "null"
+                    ],
+                    "units": "%",
+                    "versionAdded": "v1_1_0"
+                },
+                "ThresholdWarningOnlyEnabled": {
+                    "description": "Threshold warning only status.",
+                    "longDescription": "This property shall indicate what action to take if the Border Gateway Protocol (BGP) route threshold is reached.  If `true`, when the Maximum-Prefix limit is exceeded, a log message is generated.  If `false`, when the Maximum-Prefix limit is exceeded, the peer session is terminated.",
+                    "readonly": false,
+                    "type": [
+                        "boolean",
+                        "null"
+                    ],
+                    "versionAdded": "v1_1_0"
+                }
+            },
+            "type": "object"
+        },
+        "MultiplePaths": {
+            "additionalProperties": false,
+            "description": "Border Gateway Protocol (BGP) multiple path properties.",
+            "longDescription": "This type shall contain properties that are applicable to configuring Border Gateway Protocol (BGP) multiple path related properties.",
+            "patternProperties": {
+                "^([a-zA-Z_][a-zA-Z0-9_]*)?@(odata|Redfish|Message)\\.[a-zA-Z_][a-zA-Z0-9_]*$": {
+                    "description": "This property shall specify a valid odata or Redfish property.",
+                    "type": [
+                        "array",
+                        "boolean",
+                        "integer",
+                        "number",
+                        "null",
+                        "object",
+                        "string"
+                    ]
+                }
+            },
+            "properties": {
+                "MaximumPaths": {
+                    "description": "Maximum paths number.",
+                    "longDescription": "This property shall contain the maximum number of paths for multi path operation.",
+                    "readonly": false,
+                    "type": [
+                        "integer",
+                        "null"
+                    ],
+                    "versionAdded": "v1_1_0"
+                },
+                "UseMultiplePathsEnabled": {
+                    "description": "Border Gateway Protocol (BGP) multiple paths status.",
+                    "longDescription": "This property shall indicate whether multiple paths should be advertised.  If `true`, Border Gateway Protocol (BGP) advertises multiple paths for the same prefix for path diversity.  If `false`, it advertises based on best path selection.",
+                    "readonly": false,
+                    "type": [
+                        "boolean",
+                        "null"
+                    ],
+                    "versionAdded": "v1_1_0"
+                }
+            },
+            "type": "object"
+        },
+        "OemActions": {
+            "additionalProperties": true,
+            "description": "The available OEM-specific actions for this resource.",
+            "longDescription": "This type shall contain the available OEM-specific actions for this resource.",
+            "patternProperties": {
+                "^([a-zA-Z_][a-zA-Z0-9_]*)?@(odata|Redfish|Message)\\.[a-zA-Z_][a-zA-Z0-9_]*$": {
+                    "description": "This property shall specify a valid odata or Redfish property.",
+                    "type": [
+                        "array",
+                        "boolean",
+                        "integer",
+                        "number",
+                        "null",
+                        "object",
+                        "string"
+                    ]
+                }
+            },
+            "properties": {},
+            "type": "object"
+        },
+        "RouteDistinguisherRange": {
+            "additionalProperties": false,
+            "description": "The Route Distinguisher (RD) number range for an Ethernet fabric.",
+            "longDescription": "This type shall contain the Route Distinguisher (RD) Instance number range for Ethernet Virtual Private Network (EVPN) based fabrics.",
+            "patternProperties": {
+                "^([a-zA-Z_][a-zA-Z0-9_]*)?@(odata|Redfish|Message)\\.[a-zA-Z_][a-zA-Z0-9_]*$": {
+                    "description": "This property shall specify a valid odata or Redfish property.",
+                    "type": [
+                        "array",
+                        "boolean",
+                        "integer",
+                        "number",
+                        "null",
+                        "object",
+                        "string"
+                    ]
+                }
+            },
+            "properties": {
+                "Lower": {
+                    "description": "Lower Route Distinguisher (RD) number.",
+                    "longDescription": "This property shall contain the lower Route Distinguisher (RD) number to be used as part of a range of Route Distinguisher values.",
+                    "readonly": false,
+                    "type": "integer",
+                    "versionAdded": "v1_1_0"
+                },
+                "Upper": {
+                    "description": "Upper Route Distinguisher (RD) number.",
+                    "longDescription": "This property shall contain the upper Route Distinguisher (RD) number to be used as part of a range of Route Distinguisher values.",
+                    "readonly": false,
+                    "type": "integer",
+                    "versionAdded": "v1_1_0"
+                }
+            },
+            "type": "object"
+        },
+        "RouteTargetRange": {
+            "additionalProperties": false,
+            "description": "The Route Target (RT) number range for the fabric.",
+            "longDescription": "This type shall contain the Route Target (RT) Instance number range for Ethernet Virtual Private Network (EVPN) based fabrics.",
+            "patternProperties": {
+                "^([a-zA-Z_][a-zA-Z0-9_]*)?@(odata|Redfish|Message)\\.[a-zA-Z_][a-zA-Z0-9_]*$": {
+                    "description": "This property shall specify a valid odata or Redfish property.",
+                    "type": [
+                        "array",
+                        "boolean",
+                        "integer",
+                        "number",
+                        "null",
+                        "object",
+                        "string"
+                    ]
+                }
+            },
+            "properties": {
+                "Lower": {
+                    "description": "Lower Route Target (RT) number.",
+                    "longDescription": "This property shall contain the lower Route Target (RT) number to be used as part of a range of Route Target values.",
+                    "readonly": false,
+                    "type": [
+                        "integer",
+                        "null"
+                    ],
+                    "versionAdded": "v1_1_0"
+                },
+                "Upper": {
+                    "description": "Upper Route Target (RT) number.",
+                    "longDescription": "This property shall contain the upper Route Target (RT) number to be used as part of a range of Route Target values.",
+                    "readonly": false,
+                    "type": [
+                        "integer",
+                        "null"
+                    ],
+                    "versionAdded": "v1_1_0"
+                }
+            },
+            "type": "object"
+        },
+        "SystemMACRange": {
+            "additionalProperties": false,
+            "description": "The Media Access Control (MAC) address range for the EVPN based fabrics.",
+            "longDescription": "This type shall contain the Media Access Control (MAC) address range for Ethernet Virtual Private Network (EVPN) based fabrics.",
+            "patternProperties": {
+                "^([a-zA-Z_][a-zA-Z0-9_]*)?@(odata|Redfish|Message)\\.[a-zA-Z_][a-zA-Z0-9_]*$": {
+                    "description": "This property shall specify a valid odata or Redfish property.",
+                    "type": [
+                        "array",
+                        "boolean",
+                        "integer",
+                        "number",
+                        "null",
+                        "object",
+                        "string"
+                    ]
+                }
+            },
+            "properties": {
+                "Lower": {
+                    "description": "The lower system MAC address.",
+                    "longDescription": "This property shall contain the lower system Media Access Control (MAC) address to be used as part of a range of system MAC addresses.",
+                    "pattern": "^([0-9A-Fa-f]{2}[:-]){5}([0-9A-Fa-f]{2})$",
+                    "readonly": false,
+                    "type": [
+                        "string",
+                        "null"
+                    ],
+                    "versionAdded": "v1_2_0"
+                },
+                "Upper": {
+                    "description": "The upper system MAC address.",
+                    "longDescription": "This property shall contain the upper system Media Access Control (MAC) address to be used as part of a range of system MAC addresses.",
+                    "pattern": "^([0-9A-Fa-f]{2}[:-]){5}([0-9A-Fa-f]{2})$",
+                    "readonly": false,
+                    "type": [
+                        "string",
+                        "null"
+                    ],
+                    "versionAdded": "v1_2_0"
+                }
+            },
+            "type": "object"
+        },
+        "VLANIdentifierAddressRange": {
+            "additionalProperties": false,
+            "description": "VLAN tag related addressing for an Ethernet fabric or for end host networks.",
+            "longDescription": "This type shall contain for assigning Virtual LAN (VLAN) tags for the entire fabric as well as for end hosts.",
+            "patternProperties": {
+                "^([a-zA-Z_][a-zA-Z0-9_]*)?@(odata|Redfish|Message)\\.[a-zA-Z_][a-zA-Z0-9_]*$": {
+                    "description": "This property shall specify a valid odata or Redfish property.",
+                    "type": [
+                        "array",
+                        "boolean",
+                        "integer",
+                        "number",
+                        "null",
+                        "object",
+                        "string"
+                    ]
+                }
+            },
+            "properties": {
+                "Lower": {
+                    "description": "Virtual LAN (VLAN) tag lower value.",
+                    "longDescription": "This property shall contain the Virtual LAN (VLAN) tag lower value.",
+                    "maximum": 4094,
+                    "minimum": 1,
+                    "readonly": false,
+                    "type": [
+                        "integer",
+                        "null"
+                    ],
+                    "versionAdded": "v1_1_0"
+                },
+                "Upper": {
+                    "description": "Virtual LAN (VLAN) tag upper value.",
+                    "longDescription": "This property shall contain the Virtual LAN (VLAN) tag upper value.",
+                    "maximum": 4094,
+                    "minimum": 1,
+                    "readonly": false,
+                    "type": [
+                        "integer",
+                        "null"
+                    ],
+                    "versionAdded": "v1_1_0"
+                }
+            },
+            "type": "object"
+        }
+    },
+    "owningEntity": "DMTF",
+    "release": "2021.2",
+    "title": "#AddressPool.v1_2_0.AddressPool"
+}

--- a/static/redfish/v1/JsonSchemas/AddressPool/index.json
+++ b/static/redfish/v1/JsonSchemas/AddressPool/index.json
@@ -1,0 +1,21 @@
+{
+    "@odata.context": "/redfish/v1/$metadata#JsonSchemaFile.JsonSchemaFile",
+    "@odata.id": "/redfish/v1/JsonSchemas/AddressPool",
+    "@odata.type": "#JsonSchemaFile.v1_0_2.JsonSchemaFile",
+    "Name": "AddressPool Schema File",
+    "Schema": "#AddressPool.AddressPool",
+    "Description": "AddressPool Schema File Location",
+    "Id": "AddressPool",
+    "Languages": [
+        "en"
+    ],
+    "Languages@odata.count": 1,
+    "Location": [
+        {
+            "Language": "en",
+            "PublicationUri": "http://redfish.dmtf.org/schemas/v1/AddressPool.json",
+            "Uri": "/redfish/v1/JsonSchemas/AddressPool/AddressPool.json"
+        }
+    ],
+    "Location@odata.count": 1
+}

--- a/static/redfish/v1/JsonSchemas/Aggregate/Aggregate.json
+++ b/static/redfish/v1/JsonSchemas/Aggregate/Aggregate.json
@@ -1,0 +1,333 @@
+{
+    "$id": "http://redfish.dmtf.org/schemas/v1/Aggregate.v1_0_1.json",
+    "$ref": "#/definitions/Aggregate",
+    "$schema": "http://redfish.dmtf.org/schemas/v1/redfish-schema-v1.json",
+    "copyright": "Copyright 2014-2020 DMTF. For the full DMTF copyright policy, see http://www.dmtf.org/about/policies/copyright",
+    "definitions": {
+        "Actions": {
+            "additionalProperties": false,
+            "description": "The available actions for this resource.",
+            "longDescription": "This type shall contain the available actions for this resource.",
+            "patternProperties": {
+                "^([a-zA-Z_][a-zA-Z0-9_]*)?@(odata|Redfish|Message)\\.[a-zA-Z_][a-zA-Z0-9_]*$": {
+                    "description": "This property shall specify a valid odata or Redfish property.",
+                    "type": [
+                        "array",
+                        "boolean",
+                        "integer",
+                        "number",
+                        "null",
+                        "object",
+                        "string"
+                    ]
+                }
+            },
+            "properties": {
+                "#Aggregate.AddElements": {
+                    "$ref": "#/definitions/AddElements"
+                },
+                "#Aggregate.RemoveElements": {
+                    "$ref": "#/definitions/RemoveElements"
+                },
+                "#Aggregate.Reset": {
+                    "$ref": "#/definitions/Reset"
+                },
+                "#Aggregate.SetDefaultBootOrder": {
+                    "$ref": "#/definitions/SetDefaultBootOrder"
+                },
+                "Oem": {
+                    "$ref": "#/definitions/OemActions",
+                    "description": "The available OEM-specific actions for this resource.",
+                    "longDescription": "This property shall contain the available OEM-specific actions for this resource."
+                }
+            },
+            "type": "object"
+        },
+        "AddElements": {
+            "additionalProperties": false,
+            "description": "This action is used to add one or more resources to the aggregate.",
+            "longDescription": "This action shall add one or more resources to the aggregate, resulting in that the resources are included in the Elements array of the aggregate.",
+            "parameters": {
+                "Elements": {
+                    "description": "An array of resource links to add to the Elements array.",
+                    "items": {
+                        "$ref": "http://redfish.dmtf.org/schemas/v1/Resource.json#/definitions/Resource"
+                    },
+                    "longDescription": "This parameter shall contain an array of links to the specified resources to add to the aggregate's Elements array.",
+                    "requiredParameter": true,
+                    "type": "array"
+                }
+            },
+            "patternProperties": {
+                "^([a-zA-Z_][a-zA-Z0-9_]*)?@(odata|Redfish|Message)\\.[a-zA-Z_][a-zA-Z0-9_]*$": {
+                    "description": "This property shall specify a valid odata or Redfish property.",
+                    "type": [
+                        "array",
+                        "boolean",
+                        "integer",
+                        "number",
+                        "null",
+                        "object",
+                        "string"
+                    ]
+                }
+            },
+            "properties": {
+                "target": {
+                    "description": "Link to invoke action",
+                    "format": "uri-reference",
+                    "type": "string"
+                },
+                "title": {
+                    "description": "Friendly action name",
+                    "type": "string"
+                }
+            },
+            "type": "object"
+        },
+        "Aggregate": {
+            "additionalProperties": false,
+            "description": "The Aggregate schema describes a grouping method for an aggregation service.  Aggregates are formal groups of resources that are more persistent than ad hoc groupings.",
+            "longDescription": "This resource shall represent an aggregation service grouping method for a Redfish implementation.",
+            "patternProperties": {
+                "^([a-zA-Z_][a-zA-Z0-9_]*)?@(odata|Redfish|Message)\\.[a-zA-Z_][a-zA-Z0-9_]*$": {
+                    "description": "This property shall specify a valid odata or Redfish property.",
+                    "type": [
+                        "array",
+                        "boolean",
+                        "integer",
+                        "number",
+                        "null",
+                        "object",
+                        "string"
+                    ]
+                }
+            },
+            "properties": {
+                "@odata.context": {
+                    "$ref": "http://redfish.dmtf.org/schemas/v1/odata-v4.json#/definitions/context"
+                },
+                "@odata.etag": {
+                    "$ref": "http://redfish.dmtf.org/schemas/v1/odata-v4.json#/definitions/etag"
+                },
+                "@odata.id": {
+                    "$ref": "http://redfish.dmtf.org/schemas/v1/odata-v4.json#/definitions/id"
+                },
+                "@odata.type": {
+                    "$ref": "http://redfish.dmtf.org/schemas/v1/odata-v4.json#/definitions/type"
+                },
+                "Actions": {
+                    "$ref": "#/definitions/Actions",
+                    "description": "The available actions for this resource.",
+                    "longDescription": "This property shall contain the available actions for this resource."
+                },
+                "Description": {
+                    "anyOf": [
+                        {
+                            "$ref": "http://redfish.dmtf.org/schemas/v1/Resource.json#/definitions/Description"
+                        },
+                        {
+                            "type": "null"
+                        }
+                    ],
+                    "readonly": true
+                },
+                "Elements": {
+                    "description": "The elements of this aggregate.",
+                    "items": {
+                        "$ref": "http://redfish.dmtf.org/schemas/v1/Resource.json#/definitions/Resource"
+                    },
+                    "longDescription": "This property shall contain an array of links to the elements of this aggregate.",
+                    "readonly": true,
+                    "type": "array"
+                },
+                "Elements@odata.count": {
+                    "$ref": "http://redfish.dmtf.org/schemas/v1/odata-v4.json#/definitions/count"
+                },
+                "ElementsCount": {
+                    "description": "The number of entries in the Elements array.",
+                    "longDescription": "This property shall contain the number of entries in the Elements array.",
+                    "minimum": 0,
+                    "readonly": true,
+                    "type": [
+                        "integer",
+                        "null"
+                    ]
+                },
+                "Id": {
+                    "$ref": "http://redfish.dmtf.org/schemas/v1/Resource.json#/definitions/Id",
+                    "readonly": true
+                },
+                "Name": {
+                    "$ref": "http://redfish.dmtf.org/schemas/v1/Resource.json#/definitions/Name",
+                    "readonly": true
+                },
+                "Oem": {
+                    "$ref": "http://redfish.dmtf.org/schemas/v1/Resource.json#/definitions/Oem",
+                    "description": "The OEM extension property.",
+                    "longDescription": "This property shall contain the OEM extensions.  All values for properties that this object contains shall conform to the Redfish Specification-described requirements."
+                }
+            },
+            "required": [
+                "Elements",
+                "@odata.id",
+                "@odata.type",
+                "Id",
+                "Name"
+            ],
+            "requiredOnCreate": [
+                "Elements"
+            ],
+            "type": "object"
+        },
+        "OemActions": {
+            "additionalProperties": true,
+            "description": "The available OEM-specific actions for this resource.",
+            "longDescription": "This type shall contain the available OEM-specific actions for this resource.",
+            "patternProperties": {
+                "^([a-zA-Z_][a-zA-Z0-9_]*)?@(odata|Redfish|Message)\\.[a-zA-Z_][a-zA-Z0-9_]*$": {
+                    "description": "This property shall specify a valid odata or Redfish property.",
+                    "type": [
+                        "array",
+                        "boolean",
+                        "integer",
+                        "number",
+                        "null",
+                        "object",
+                        "string"
+                    ]
+                }
+            },
+            "properties": {},
+            "type": "object"
+        },
+        "RemoveElements": {
+            "additionalProperties": false,
+            "description": "This action is used to remove one or more resources from the aggregate.",
+            "longDescription": "This action shall remove one or more resources from the aggregate, resulting in that the resources are removed from the Elements array of the aggregate.",
+            "parameters": {
+                "Elements": {
+                    "description": "An array of resource links to remove from the Elements array.",
+                    "items": {
+                        "$ref": "http://redfish.dmtf.org/schemas/v1/Resource.json#/definitions/Resource"
+                    },
+                    "longDescription": "This parameter shall contain an array of links to the specified resources to remove from the aggregate's Elements array.",
+                    "requiredParameter": true,
+                    "type": "array"
+                }
+            },
+            "patternProperties": {
+                "^([a-zA-Z_][a-zA-Z0-9_]*)?@(odata|Redfish|Message)\\.[a-zA-Z_][a-zA-Z0-9_]*$": {
+                    "description": "This property shall specify a valid odata or Redfish property.",
+                    "type": [
+                        "array",
+                        "boolean",
+                        "integer",
+                        "number",
+                        "null",
+                        "object",
+                        "string"
+                    ]
+                }
+            },
+            "properties": {
+                "target": {
+                    "description": "Link to invoke action",
+                    "format": "uri-reference",
+                    "type": "string"
+                },
+                "title": {
+                    "description": "Friendly action name",
+                    "type": "string"
+                }
+            },
+            "type": "object"
+        },
+        "Reset": {
+            "additionalProperties": false,
+            "description": "This action is used to reset a collection of resources.  For example, this could be an aggregate or a list of computer systems.",
+            "longDescription": "This action shall perform a reset of a collection of resources.",
+            "parameters": {
+                "BatchSize": {
+                    "description": "The number of elements in each batch being reset.",
+                    "longDescription": "This parameter shall contain the number of elements in each batch simultaneously being issued a reset.",
+                    "minimum": 0,
+                    "type": "integer"
+                },
+                "DelayBetweenBatchesInSeconds": {
+                    "description": "The delay of the batches of elements being reset in seconds.",
+                    "longDescription": "This parameter shall contain the delay of the batches of elements being reset in seconds.",
+                    "minimum": 0,
+                    "type": "integer",
+                    "units": "s"
+                },
+                "ResetType": {
+                    "$ref": "http://redfish.dmtf.org/schemas/v1/Resource.json#/definitions/ResetType",
+                    "description": "The type of reset.",
+                    "longDescription": "This parameter shall contain the type of reset.  The service can accept a request without the parameter and perform an implementation-specific default reset."
+                }
+            },
+            "patternProperties": {
+                "^([a-zA-Z_][a-zA-Z0-9_]*)?@(odata|Redfish|Message)\\.[a-zA-Z_][a-zA-Z0-9_]*$": {
+                    "description": "This property shall specify a valid odata or Redfish property.",
+                    "type": [
+                        "array",
+                        "boolean",
+                        "integer",
+                        "number",
+                        "null",
+                        "object",
+                        "string"
+                    ]
+                }
+            },
+            "properties": {
+                "target": {
+                    "description": "Link to invoke action",
+                    "format": "uri-reference",
+                    "type": "string"
+                },
+                "title": {
+                    "description": "Friendly action name",
+                    "type": "string"
+                }
+            },
+            "type": "object"
+        },
+        "SetDefaultBootOrder": {
+            "additionalProperties": false,
+            "description": "This action is used to restore the boot order to the default state for the computer systems that are members of this aggregate.",
+            "longDescription": "This action shall restore the boot order to the default state for the computer systems that are members of this aggregate.",
+            "parameters": {},
+            "patternProperties": {
+                "^([a-zA-Z_][a-zA-Z0-9_]*)?@(odata|Redfish|Message)\\.[a-zA-Z_][a-zA-Z0-9_]*$": {
+                    "description": "This property shall specify a valid odata or Redfish property.",
+                    "type": [
+                        "array",
+                        "boolean",
+                        "integer",
+                        "number",
+                        "null",
+                        "object",
+                        "string"
+                    ]
+                }
+            },
+            "properties": {
+                "target": {
+                    "description": "Link to invoke action",
+                    "format": "uri-reference",
+                    "type": "string"
+                },
+                "title": {
+                    "description": "Friendly action name",
+                    "type": "string"
+                }
+            },
+            "type": "object"
+        }
+    },
+    "owningEntity": "DMTF",
+    "release": "2020.2",
+    "title": "#Aggregate.v1_0_1.Aggregate"
+}

--- a/static/redfish/v1/JsonSchemas/Aggregate/index.json
+++ b/static/redfish/v1/JsonSchemas/Aggregate/index.json
@@ -1,0 +1,21 @@
+{
+    "@odata.context": "/redfish/v1/$metadata#JsonSchemaFile.JsonSchemaFile",
+    "@odata.id": "/redfish/v1/JsonSchemas/Aggregate",
+    "@odata.type": "#JsonSchemaFile.v1_0_2.JsonSchemaFile",
+    "Name": "Aggregate Schema File",
+    "Schema": "#Aggregate.Aggregate",
+    "Description": "Aggregate Schema File Location",
+    "Id": "Aggregate",
+    "Languages": [
+        "en"
+    ],
+    "Languages@odata.count": 1,
+    "Location": [
+        {
+            "Language": "en",
+            "PublicationUri": "http://redfish.dmtf.org/schemas/v1/Aggregate.json",
+            "Uri": "/redfish/v1/JsonSchemas/Aggregate/Aggregate.json"
+        }
+    ],
+    "Location@odata.count": 1
+}

--- a/static/redfish/v1/JsonSchemas/AggregationService/AggregationService.json
+++ b/static/redfish/v1/JsonSchemas/AggregationService/AggregationService.json
@@ -1,0 +1,268 @@
+{
+    "$id": "http://redfish.dmtf.org/schemas/v1/AggregationService.v1_0_1.json",
+    "$ref": "#/definitions/AggregationService",
+    "$schema": "http://redfish.dmtf.org/schemas/v1/redfish-schema-v1.json",
+    "copyright": "Copyright 2014-2020 DMTF. For the full DMTF copyright policy, see http://www.dmtf.org/about/policies/copyright",
+    "definitions": {
+        "Actions": {
+            "additionalProperties": false,
+            "description": "The available actions for this resource.",
+            "longDescription": "This type shall contain the available actions for this resource.",
+            "patternProperties": {
+                "^([a-zA-Z_][a-zA-Z0-9_]*)?@(odata|Redfish|Message)\\.[a-zA-Z_][a-zA-Z0-9_]*$": {
+                    "description": "This property shall specify a valid odata or Redfish property.",
+                    "type": [
+                        "array",
+                        "boolean",
+                        "integer",
+                        "number",
+                        "null",
+                        "object",
+                        "string"
+                    ]
+                }
+            },
+            "properties": {
+                "#AggregationService.Reset": {
+                    "$ref": "#/definitions/Reset"
+                },
+                "#AggregationService.SetDefaultBootOrder": {
+                    "$ref": "#/definitions/SetDefaultBootOrder"
+                },
+                "Oem": {
+                    "$ref": "#/definitions/OemActions",
+                    "description": "The available OEM-specific actions for this resource.",
+                    "longDescription": "This property shall contain the available OEM-specific actions for this resource."
+                }
+            },
+            "type": "object"
+        },
+        "AggregationService": {
+            "additionalProperties": true,
+            "description": "The AggregationService schema contains properties for managing aggregation operations, either on ad hoc combinations of resources or on defined sets of resources called aggregates.  Access points define the properties needed to access the entity being aggregated and connection methods describe the protocol or other semantics of the connection.",
+            "longDescription": "This resource shall represent an aggregation service for a Redfish implementation.",
+            "patternProperties": {
+                "^([a-zA-Z_][a-zA-Z0-9_]*)?@(odata|Redfish|Message)\\.[a-zA-Z_][a-zA-Z0-9_]*$": {
+                    "description": "This property shall specify a valid odata or Redfish property.",
+                    "type": [
+                        "array",
+                        "boolean",
+                        "integer",
+                        "number",
+                        "null",
+                        "object",
+                        "string"
+                    ]
+                }
+            },
+            "properties": {
+                "@odata.context": {
+                    "$ref": "http://redfish.dmtf.org/schemas/v1/odata-v4.json#/definitions/context"
+                },
+                "@odata.etag": {
+                    "$ref": "http://redfish.dmtf.org/schemas/v1/odata-v4.json#/definitions/etag"
+                },
+                "@odata.id": {
+                    "$ref": "http://redfish.dmtf.org/schemas/v1/odata-v4.json#/definitions/id"
+                },
+                "@odata.type": {
+                    "$ref": "http://redfish.dmtf.org/schemas/v1/odata-v4.json#/definitions/type"
+                },
+                "Actions": {
+                    "$ref": "#/definitions/Actions",
+                    "description": "The available actions for this resource.",
+                    "longDescription": "This property shall contain the available actions for this resource."
+                },
+                "Aggregates": {
+                    "$ref": "http://redfish.dmtf.org/schemas/v1/AggregateCollection.json#/definitions/AggregateCollection",
+                    "description": "The link to the collection of aggregates associated with this service.",
+                    "longDescription": "This property shall contain a link to a resource collection of type AggregateCollection.",
+                    "readonly": true
+                },
+                "AggregationSources": {
+                    "$ref": "http://redfish.dmtf.org/schemas/v1/AggregationSourceCollection.json#/definitions/AggregationSourceCollection",
+                    "description": "The link to the collection of aggregation sources associated with this service.",
+                    "longDescription": "This property shall contain a link to a resource collection of type AggregationSourceCollection.",
+                    "readonly": true
+                },
+                "ConnectionMethods": {
+                    "$ref": "http://redfish.dmtf.org/schemas/v1/ConnectionMethodCollection.json#/definitions/ConnectionMethodCollection",
+                    "description": "The link to the collection of connection methods associated with this service.",
+                    "longDescription": "This property shall contain a link to a resource collection of type ConnectionMethodCollection.",
+                    "readonly": true
+                },
+                "Description": {
+                    "anyOf": [
+                        {
+                            "$ref": "http://redfish.dmtf.org/schemas/v1/Resource.json#/definitions/Description"
+                        },
+                        {
+                            "type": "null"
+                        }
+                    ],
+                    "readonly": true
+                },
+                "Id": {
+                    "$ref": "http://redfish.dmtf.org/schemas/v1/Resource.json#/definitions/Id",
+                    "readonly": true
+                },
+                "Name": {
+                    "$ref": "http://redfish.dmtf.org/schemas/v1/Resource.json#/definitions/Name",
+                    "readonly": true
+                },
+                "Oem": {
+                    "$ref": "http://redfish.dmtf.org/schemas/v1/Resource.json#/definitions/Oem",
+                    "description": "The OEM extension property.",
+                    "longDescription": "This property shall contain the OEM extensions.  All values for properties that this object contains shall conform to the Redfish Specification-described requirements."
+                },
+                "ServiceEnabled": {
+                    "description": "An indication of whether the aggregation service is enabled.",
+                    "longDescription": "This property shall indicate whether the aggregation service is enabled.",
+                    "readonly": false,
+                    "type": [
+                        "boolean",
+                        "null"
+                    ]
+                },
+                "Status": {
+                    "$ref": "http://redfish.dmtf.org/schemas/v1/Resource.json#/definitions/Status",
+                    "description": "The status and health of the resource and its subordinate or dependent resources.",
+                    "longDescription": "This property shall contain any status or health properties of the resource."
+                }
+            },
+            "required": [
+                "@odata.id",
+                "@odata.type",
+                "Id",
+                "Name"
+            ],
+            "type": "object"
+        },
+        "OemActions": {
+            "additionalProperties": true,
+            "description": "The available OEM-specific actions for this resource.",
+            "longDescription": "This type shall contain the available OEM-specific actions for this resource.",
+            "patternProperties": {
+                "^([a-zA-Z_][a-zA-Z0-9_]*)?@(odata|Redfish|Message)\\.[a-zA-Z_][a-zA-Z0-9_]*$": {
+                    "description": "This property shall specify a valid odata or Redfish property.",
+                    "type": [
+                        "array",
+                        "boolean",
+                        "integer",
+                        "number",
+                        "null",
+                        "object",
+                        "string"
+                    ]
+                }
+            },
+            "properties": {},
+            "type": "object"
+        },
+        "Reset": {
+            "additionalProperties": false,
+            "description": "This action is used to reset a set of resources. For example this could be a list of computer systems.",
+            "longDescription": "This action shall perform a reset of a set of resources.",
+            "parameters": {
+                "BatchSize": {
+                    "description": "The number of elements in each batch being reset.",
+                    "longDescription": "This parameter shall contain the number of elements in each batch simultaneously being issued a reset.",
+                    "minimum": 0,
+                    "type": "integer"
+                },
+                "DelayBetweenBatchesInSeconds": {
+                    "description": "The delay of the batches of elements being reset in seconds.",
+                    "longDescription": "This parameter shall contain the delay of the batches of elements being reset in seconds.",
+                    "minimum": 0,
+                    "type": "integer",
+                    "units": "s"
+                },
+                "ResetType": {
+                    "$ref": "http://redfish.dmtf.org/schemas/v1/Resource.json#/definitions/ResetType",
+                    "description": "The type of reset.",
+                    "longDescription": "This parameter shall contain the type of reset.  The service can accept a request without the parameter and perform an implementation-specific default reset."
+                },
+                "TargetURIs": {
+                    "description": "An array of links to the resources being reset.",
+                    "items": {
+                        "$ref": "http://redfish.dmtf.org/schemas/v1/Resource.json#/definitions/Resource"
+                    },
+                    "longDescription": "This parameter shall contain an array of links to the resources being reset.",
+                    "requiredParameter": true,
+                    "type": "array"
+                }
+            },
+            "patternProperties": {
+                "^([a-zA-Z_][a-zA-Z0-9_]*)?@(odata|Redfish|Message)\\.[a-zA-Z_][a-zA-Z0-9_]*$": {
+                    "description": "This property shall specify a valid odata or Redfish property.",
+                    "type": [
+                        "array",
+                        "boolean",
+                        "integer",
+                        "number",
+                        "null",
+                        "object",
+                        "string"
+                    ]
+                }
+            },
+            "properties": {
+                "target": {
+                    "description": "Link to invoke action",
+                    "format": "uri-reference",
+                    "type": "string"
+                },
+                "title": {
+                    "description": "Friendly action name",
+                    "type": "string"
+                }
+            },
+            "type": "object"
+        },
+        "SetDefaultBootOrder": {
+            "additionalProperties": false,
+            "description": "This action is used to restore the boot order to the default state for the specified computer systems.",
+            "longDescription": "This action shall restore the boot order to the default state for the specified computer systems.",
+            "parameters": {
+                "Systems": {
+                    "description": "The computer systems to restore.",
+                    "items": {
+                        "$ref": "http://redfish.dmtf.org/schemas/v1/ComputerSystem.json#/definitions/ComputerSystem"
+                    },
+                    "longDescription": "This parameter shall contain an array of links to resources of type ComputerSystem.",
+                    "requiredParameter": true,
+                    "type": "array"
+                }
+            },
+            "patternProperties": {
+                "^([a-zA-Z_][a-zA-Z0-9_]*)?@(odata|Redfish|Message)\\.[a-zA-Z_][a-zA-Z0-9_]*$": {
+                    "description": "This property shall specify a valid odata or Redfish property.",
+                    "type": [
+                        "array",
+                        "boolean",
+                        "integer",
+                        "number",
+                        "null",
+                        "object",
+                        "string"
+                    ]
+                }
+            },
+            "properties": {
+                "target": {
+                    "description": "Link to invoke action",
+                    "format": "uri-reference",
+                    "type": "string"
+                },
+                "title": {
+                    "description": "Friendly action name",
+                    "type": "string"
+                }
+            },
+            "type": "object"
+        }
+    },
+    "owningEntity": "DMTF",
+    "release": "2020.2",
+    "title": "#AggregationService.v1_0_1.AggregationService"
+}

--- a/static/redfish/v1/JsonSchemas/AggregationService/index.json
+++ b/static/redfish/v1/JsonSchemas/AggregationService/index.json
@@ -1,0 +1,21 @@
+{
+    "@odata.context": "/redfish/v1/$metadata#JsonSchemaFile.JsonSchemaFile",
+    "@odata.id": "/redfish/v1/JsonSchemas/AggregationService",
+    "@odata.type": "#JsonSchemaFile.v1_0_2.JsonSchemaFile",
+    "Name": "AggregationService Schema File",
+    "Schema": "#AggregationService.AggregationService",
+    "Description": "AggregationService Schema File Location",
+    "Id": "AggregationService",
+    "Languages": [
+        "en"
+    ],
+    "Languages@odata.count": 1,
+    "Location": [
+        {
+            "Language": "en",
+            "PublicationUri": "http://redfish.dmtf.org/schemas/v1/AggregationService.json",
+            "Uri": "/redfish/v1/JsonSchemas/AggregationService/AggregationService.json"
+        }
+    ],
+    "Location@odata.count": 1
+}

--- a/static/redfish/v1/JsonSchemas/AggregationSource/AggregationSource.json
+++ b/static/redfish/v1/JsonSchemas/AggregationSource/AggregationSource.json
@@ -1,0 +1,367 @@
+{
+    "$id": "http://redfish.dmtf.org/schemas/v1/AggregationSource.v1_1_0.json",
+    "$ref": "#/definitions/AggregationSource",
+    "$schema": "http://redfish.dmtf.org/schemas/v1/redfish-schema-v1.json",
+    "copyright": "Copyright 2014-2020 DMTF. For the full DMTF copyright policy, see http://www.dmtf.org/about/policies/copyright",
+    "definitions": {
+        "Actions": {
+            "additionalProperties": false,
+            "description": "The available actions for this resource.",
+            "longDescription": "This type shall contain the available actions for this resource.",
+            "patternProperties": {
+                "^([a-zA-Z_][a-zA-Z0-9_]*)?@(odata|Redfish|Message)\\.[a-zA-Z_][a-zA-Z0-9_]*$": {
+                    "description": "This property shall specify a valid odata or Redfish property.",
+                    "type": [
+                        "array",
+                        "boolean",
+                        "integer",
+                        "number",
+                        "null",
+                        "object",
+                        "string"
+                    ]
+                }
+            },
+            "properties": {
+                "Oem": {
+                    "$ref": "#/definitions/OemActions",
+                    "description": "The available OEM-specific actions for this resource.",
+                    "longDescription": "This property shall contain the available OEM-specific actions for this resource."
+                }
+            },
+            "type": "object"
+        },
+        "AggregationSource": {
+            "additionalProperties": false,
+            "description": "The AggregationSource schema is used to represent the source of information for a subset of the resources provided by a Redfish service.  It can be thought of as a provider of information.  As such, most such interfaces have requirements to support the gathering of information like address and account used to access the information.",
+            "longDescription": "This resource shall represent an aggregation source for a Redfish implementation.",
+            "patternProperties": {
+                "^([a-zA-Z_][a-zA-Z0-9_]*)?@(odata|Redfish|Message)\\.[a-zA-Z_][a-zA-Z0-9_]*$": {
+                    "description": "This property shall specify a valid odata or Redfish property.",
+                    "type": [
+                        "array",
+                        "boolean",
+                        "integer",
+                        "number",
+                        "null",
+                        "object",
+                        "string"
+                    ]
+                }
+            },
+            "properties": {
+                "@odata.context": {
+                    "$ref": "http://redfish.dmtf.org/schemas/v1/odata-v4.json#/definitions/context"
+                },
+                "@odata.etag": {
+                    "$ref": "http://redfish.dmtf.org/schemas/v1/odata-v4.json#/definitions/etag"
+                },
+                "@odata.id": {
+                    "$ref": "http://redfish.dmtf.org/schemas/v1/odata-v4.json#/definitions/id"
+                },
+                "@odata.type": {
+                    "$ref": "http://redfish.dmtf.org/schemas/v1/odata-v4.json#/definitions/type"
+                },
+                "Actions": {
+                    "$ref": "#/definitions/Actions",
+                    "description": "The available actions for this resource.",
+                    "longDescription": "This property shall contain the available actions for this resource."
+                },
+                "Description": {
+                    "anyOf": [
+                        {
+                            "$ref": "http://redfish.dmtf.org/schemas/v1/Resource.json#/definitions/Description"
+                        },
+                        {
+                            "type": "null"
+                        }
+                    ],
+                    "readonly": true
+                },
+                "HostName": {
+                    "description": "The URI of the system to be accessed.",
+                    "format": "uri-reference",
+                    "longDescription": "This property shall contain the URI of the system to be accessed.",
+                    "readonly": false,
+                    "type": [
+                        "string",
+                        "null"
+                    ]
+                },
+                "Id": {
+                    "$ref": "http://redfish.dmtf.org/schemas/v1/Resource.json#/definitions/Id",
+                    "readonly": true
+                },
+                "Links": {
+                    "$ref": "#/definitions/Links",
+                    "description": "The links to other resources that are related to this resource.",
+                    "longDescription": "This property shall contain links to resources that are related to but are not contained by, or subordinate to, this resource."
+                },
+                "Name": {
+                    "$ref": "http://redfish.dmtf.org/schemas/v1/Resource.json#/definitions/Name",
+                    "readonly": true
+                },
+                "Oem": {
+                    "$ref": "http://redfish.dmtf.org/schemas/v1/Resource.json#/definitions/Oem",
+                    "description": "The OEM extension property.",
+                    "longDescription": "This property shall contain the OEM extensions.  All values for properties that this object contains shall conform to the Redfish Specification-described requirements."
+                },
+                "Password": {
+                    "description": "The password for accessing the aggregation source.  The value is `null` in responses.",
+                    "longDescription": "This property shall contain a password for accessing the aggregation source.  The value shall be `null` in responses.",
+                    "readonly": false,
+                    "type": [
+                        "string",
+                        "null"
+                    ]
+                },
+                "SNMP": {
+                    "anyOf": [
+                        {
+                            "$ref": "#/definitions/SNMPSettings"
+                        },
+                        {
+                            "type": "null"
+                        }
+                    ],
+                    "description": "SNMP settings of the aggregation source.",
+                    "longDescription": "This property shall contain the SNMP settings of the aggregation source.",
+                    "versionAdded": "v1_1_0"
+                },
+                "UserName": {
+                    "description": "The user name for accessing the aggregation source.",
+                    "longDescription": "This property shall contain the user name for accessing the aggregation source.",
+                    "readonly": false,
+                    "type": [
+                        "string",
+                        "null"
+                    ]
+                }
+            },
+            "required": [
+                "HostName",
+                "@odata.id",
+                "@odata.type",
+                "Id",
+                "Name"
+            ],
+            "requiredOnCreate": [
+                "HostName"
+            ],
+            "type": "object"
+        },
+        "Links": {
+            "additionalProperties": false,
+            "description": "The links to other resources that are related to this resource.",
+            "longDescription": "This Redfish Specification-described type shall contain links to resources that are related to but are not contained by, or subordinate to, this resource.",
+            "patternProperties": {
+                "^([a-zA-Z_][a-zA-Z0-9_]*)?@(odata|Redfish|Message)\\.[a-zA-Z_][a-zA-Z0-9_]*$": {
+                    "description": "This property shall specify a valid odata or Redfish property.",
+                    "type": [
+                        "array",
+                        "boolean",
+                        "integer",
+                        "number",
+                        "null",
+                        "object",
+                        "string"
+                    ]
+                }
+            },
+            "properties": {
+                "ConnectionMethod": {
+                    "anyOf": [
+                        {
+                            "$ref": "http://redfish.dmtf.org/schemas/v1/ConnectionMethod.json#/definitions/ConnectionMethod"
+                        },
+                        {
+                            "type": "null"
+                        }
+                    ],
+                    "description": "An array of links to the connection methods used to contact this aggregation source.",
+                    "longDescription": "This property shall contain an array of links to resources of type ConnectionMethod that are used to connect to the aggregation source.",
+                    "readonly": true
+                },
+                "Oem": {
+                    "$ref": "http://redfish.dmtf.org/schemas/v1/Resource.json#/definitions/Oem",
+                    "description": "The OEM extension property.",
+                    "longDescription": "This property shall contain the OEM extensions.  All values for properties contained in this object shall conform to the Redfish Specification-described requirements."
+                },
+                "ResourcesAccessed": {
+                    "description": "An array links to the resources added to the service through this aggregation source.  It is recommended that this be the minimal number of properties needed to find the resources that would be lost when the aggregation source is deleted.",
+                    "items": {
+                        "$ref": "http://redfish.dmtf.org/schemas/v1/Resource.json#/definitions/Resource"
+                    },
+                    "longDescription": "This property shall contain an array of links to the resources added to the service through the aggregation source.  It is recommended that this be the minimal number of properties needed to find the resources that would be lost when the aggregation source is deleted.  For example, this could be the pointers to the members of the root level collections or the manager of a BMC.",
+                    "readonly": true,
+                    "type": "array"
+                },
+                "ResourcesAccessed@odata.count": {
+                    "$ref": "http://redfish.dmtf.org/schemas/v1/odata-v4.json#/definitions/count"
+                }
+            },
+            "type": "object"
+        },
+        "OemActions": {
+            "additionalProperties": true,
+            "description": "The available OEM-specific actions for this resource.",
+            "longDescription": "This type shall contain the available OEM-specific actions for this resource.",
+            "patternProperties": {
+                "^([a-zA-Z_][a-zA-Z0-9_]*)?@(odata|Redfish|Message)\\.[a-zA-Z_][a-zA-Z0-9_]*$": {
+                    "description": "This property shall specify a valid odata or Redfish property.",
+                    "type": [
+                        "array",
+                        "boolean",
+                        "integer",
+                        "number",
+                        "null",
+                        "object",
+                        "string"
+                    ]
+                }
+            },
+            "properties": {},
+            "type": "object"
+        },
+        "SNMPAuthenticationProtocols": {
+            "enum": [
+                "None",
+                "CommunityString",
+                "HMAC_MD5",
+                "HMAC_SHA96",
+                "HMAC128_SHA224",
+                "HMAC192_SHA256",
+                "HMAC256_SHA384",
+                "HMAC384_SHA512"
+            ],
+            "enumDescriptions": {
+                "CommunityString": "Trap community string authentication.",
+                "HMAC128_SHA224": "HMAC-128-SHA-224 authentication.",
+                "HMAC192_SHA256": "HMAC-192-SHA-256 authentication.",
+                "HMAC256_SHA384": "HMAC-256-SHA-384 authentication.",
+                "HMAC384_SHA512": "HMAC-384-SHA-512 authentication.",
+                "HMAC_MD5": "HMAC-MD5-96 authentication.",
+                "HMAC_SHA96": "HMAC-SHA-96 authentication.",
+                "None": "No authentication."
+            },
+            "enumLongDescriptions": {
+                "CommunityString": "This value shall indicate authentication using SNMP community strings and the value of TrapCommunity.",
+                "HMAC128_SHA224": "This value shall indicate authentication for SNMPv3 access conforms to the RFC7860-defined usmHMAC128SHA224AuthProtocol.",
+                "HMAC192_SHA256": "This value shall indicate authentication for SNMPv3 access conforms to the RFC7860-defined usmHMAC192SHA256AuthProtocol.",
+                "HMAC256_SHA384": "This value shall indicate authentication for SNMPv3 access conforms to the RFC7860-defined usmHMAC256SHA384AuthProtocol.",
+                "HMAC384_SHA512": "This value shall indicate authentication for SNMPv3 access conforms to the RFC7860-defined usmHMAC384SHA512AuthProtocol.",
+                "HMAC_MD5": "This value shall indicate authentication conforms to the RFC3414-defined HMAC-MD5-96 authentication protocol.",
+                "HMAC_SHA96": "This value shall indicate authentication conforms to the RFC3414-defined HMAC-SHA-96 authentication protocol.",
+                "None": "This value shall indicate authentication is not required."
+            },
+            "type": "string"
+        },
+        "SNMPEncryptionProtocols": {
+            "enum": [
+                "None",
+                "CBC_DES",
+                "CFB128_AES128"
+            ],
+            "enumDescriptions": {
+                "CBC_DES": "CBC-DES encryption.",
+                "CFB128_AES128": "CFB128-AES-128 encryption.",
+                "None": "No encryption."
+            },
+            "enumLongDescriptions": {
+                "CBC_DES": "This value shall indicate encryption conforms to the RFC3414-defined CBC-DES encryption protocol.",
+                "CFB128_AES128": "This value shall indicate encryption conforms to the RFC3414-defined CFB128-AES-128 encryption protocol.",
+                "None": "This value shall indicate there is no encryption."
+            },
+            "type": "string"
+        },
+        "SNMPSettings": {
+            "additionalProperties": false,
+            "description": "Settings for an SNMP aggregation source.",
+            "longDescription": "This type shall contain the settings for an SNMP aggregation source.",
+            "patternProperties": {
+                "^([a-zA-Z_][a-zA-Z0-9_]*)?@(odata|Redfish|Message)\\.[a-zA-Z_][a-zA-Z0-9_]*$": {
+                    "description": "This property shall specify a valid odata or Redfish property.",
+                    "type": [
+                        "array",
+                        "boolean",
+                        "integer",
+                        "number",
+                        "null",
+                        "object",
+                        "string"
+                    ]
+                }
+            },
+            "properties": {
+                "AuthenticationKey": {
+                    "description": "The secret authentication key for SNMPv3.",
+                    "longDescription": "This property shall contain the key for SNMPv3 authentication.  The value shall be `null` in responses.  This property accepts a passphrase or a hex-encoded key.  If the string starts with `Passphrase:`, the remainder of the string shall be the passphrase and shall be converted to the key as described in the 'Password to Key Algorithm' section of RFC3414.  If the string starts with `Hex:`, then the remainder of the string shall be the key encoded in hexadecimal notation.  If the string starts with neither, the full string shall be a passphrase and shall be converted to the key as described in the 'Password to Key Algorithm' section of RFC3414.  The passphrase can contain any printable characters except for the double quotation mark.",
+                    "pattern": "(^[ !#-~]+$)|(^Passphrase:[ ^[ !#-~]+$)|(^Hex:[0-9A-Fa-f]{24,96})|(^\\*+$)",
+                    "readonly": false,
+                    "type": [
+                        "string",
+                        "null"
+                    ],
+                    "versionAdded": "v1_1_0"
+                },
+                "AuthenticationKeySet": {
+                    "description": "Indicates if the AuthenticationKey property is set.",
+                    "longDescription": "This property shall contain `true` if a valid value was provided for the AuthenticationKey property.  Otherwise, the property shall contain `false`.",
+                    "readonly": true,
+                    "type": "boolean",
+                    "versionAdded": "v1_1_0"
+                },
+                "AuthenticationProtocol": {
+                    "anyOf": [
+                        {
+                            "$ref": "#/definitions/SNMPAuthenticationProtocols"
+                        },
+                        {
+                            "type": "null"
+                        }
+                    ],
+                    "description": "The authentication protocol for SNMPv3.",
+                    "longDescription": "This property shall contain the SNMPv3 authentication protocol.",
+                    "readonly": false,
+                    "versionAdded": "v1_1_0"
+                },
+                "EncryptionKey": {
+                    "description": "The secret authentication key for SNMPv3.",
+                    "longDescription": "This property shall contain the key for SNMPv3 encryption.  The value shall be `null` in responses.  This property accepts a passphrase or a hex-encoded key.  If the string starts with `Passphrase:`, the remainder of the string shall be the passphrase and shall be converted to the key as described in the 'Password to Key Algorithm' section of RFC3414.  If the string starts with `Hex:`, then the remainder of the string shall be the key encoded in hexadecimal notation.  If the string starts with neither, the full string shall be a passphrase and shall be converted to the key as described in the 'Password to Key Algorithm' section of RFC3414.  The passphrase can contain any printable characters except for the double quotation mark.",
+                    "pattern": "(^[A-Za-z0-9]+$)|(^\\*+$)",
+                    "readonly": false,
+                    "type": [
+                        "string",
+                        "null"
+                    ],
+                    "versionAdded": "v1_1_0"
+                },
+                "EncryptionKeySet": {
+                    "description": "Indicates if the EncryptionKey property is set.",
+                    "longDescription": "This property shall contain `true` if a valid value was provided for the EncryptionKey property.  Otherwise, the property shall contain `false`.",
+                    "readonly": true,
+                    "type": "boolean",
+                    "versionAdded": "v1_1_0"
+                },
+                "EncryptionProtocol": {
+                    "anyOf": [
+                        {
+                            "$ref": "#/definitions/SNMPEncryptionProtocols"
+                        },
+                        {
+                            "type": "null"
+                        }
+                    ],
+                    "description": "The encryption protocol for SNMPv3.",
+                    "longDescription": "This property shall contain the SNMPv3 encryption protocol.",
+                    "readonly": false,
+                    "versionAdded": "v1_1_0"
+                }
+            },
+            "type": "object"
+        }
+    },
+    "owningEntity": "DMTF",
+    "release": "2020.4",
+    "title": "#AggregationSource.v1_1_0.AggregationSource"
+}

--- a/static/redfish/v1/JsonSchemas/AggregationSource/index.json
+++ b/static/redfish/v1/JsonSchemas/AggregationSource/index.json
@@ -1,0 +1,21 @@
+{
+    "@odata.context": "/redfish/v1/$metadata#JsonSchemaFile.JsonSchemaFile",
+    "@odata.id": "/redfish/v1/JsonSchemas/AggregationSource",
+    "@odata.type": "#JsonSchemaFile.v1_0_2.JsonSchemaFile",
+    "Name": "AggregationSource Schema File",
+    "Schema": "#AggregationSource.AggregationSource",
+    "Description": "AggregationSource Schema File Location",
+    "Id": "AggregationSource",
+    "Languages": [
+        "en"
+    ],
+    "Languages@odata.count": 1,
+    "Location": [
+        {
+            "Language": "en",
+            "PublicationUri": "http://redfish.dmtf.org/schemas/v1/AggregationSource.json",
+            "Uri": "/redfish/v1/JsonSchemas/AggregationSource/AggregationSource.json"
+        }
+    ],
+    "Location@odata.count": 1
+}

--- a/static/redfish/v1/JsonSchemas/AllowDeny/AllowDeny.json
+++ b/static/redfish/v1/JsonSchemas/AllowDeny/AllowDeny.json
@@ -1,0 +1,272 @@
+{
+    "$id": "http://redfish.dmtf.org/schemas/v1/AllowDeny.v1_0_0.json",
+    "$ref": "#/definitions/AllowDeny",
+    "$schema": "http://redfish.dmtf.org/schemas/v1/redfish-schema-v1.json",
+    "copyright": "Copyright 2014-2021 DMTF. For the full DMTF copyright policy, see http://www.dmtf.org/about/policies/copyright",
+    "definitions": {
+        "Actions": {
+            "additionalProperties": false,
+            "description": "The available actions for this resource.",
+            "longDescription": "This type shall contain the available actions for this resource.",
+            "patternProperties": {
+                "^([a-zA-Z_][a-zA-Z0-9_]*)?@(odata|Redfish|Message)\\.[a-zA-Z_][a-zA-Z0-9_]*$": {
+                    "description": "This property shall specify a valid odata or Redfish property.",
+                    "type": [
+                        "array",
+                        "boolean",
+                        "integer",
+                        "number",
+                        "null",
+                        "object",
+                        "string"
+                    ]
+                }
+            },
+            "properties": {
+                "Oem": {
+                    "$ref": "#/definitions/OemActions",
+                    "description": "The available OEM-specific actions for this resource.",
+                    "longDescription": "This property shall contain the available OEM-specific actions for this resource."
+                }
+            },
+            "type": "object"
+        },
+        "AllowDeny": {
+            "additionalProperties": false,
+            "description": "The AllowDeny schema represents a set of allow or deny configurations.",
+            "longDescription": "This resource shall represent an AllowDeny resource in a Redfish implementation.",
+            "patternProperties": {
+                "^([a-zA-Z_][a-zA-Z0-9_]*)?@(odata|Redfish|Message)\\.[a-zA-Z_][a-zA-Z0-9_]*$": {
+                    "description": "This property shall specify a valid odata or Redfish property.",
+                    "type": [
+                        "array",
+                        "boolean",
+                        "integer",
+                        "number",
+                        "null",
+                        "object",
+                        "string"
+                    ]
+                }
+            },
+            "properties": {
+                "@odata.context": {
+                    "$ref": "http://redfish.dmtf.org/schemas/v1/odata-v4.json#/definitions/context"
+                },
+                "@odata.etag": {
+                    "$ref": "http://redfish.dmtf.org/schemas/v1/odata-v4.json#/definitions/etag"
+                },
+                "@odata.id": {
+                    "$ref": "http://redfish.dmtf.org/schemas/v1/odata-v4.json#/definitions/id"
+                },
+                "@odata.type": {
+                    "$ref": "http://redfish.dmtf.org/schemas/v1/odata-v4.json#/definitions/type"
+                },
+                "Actions": {
+                    "$ref": "#/definitions/Actions",
+                    "description": "The available actions for this resource.",
+                    "longDescription": "This property shall contain the available actions for this resource."
+                },
+                "AllowType": {
+                    "anyOf": [
+                        {
+                            "$ref": "#/definitions/AllowType"
+                        },
+                        {
+                            "type": "null"
+                        }
+                    ],
+                    "description": "Indicates the type of permission.",
+                    "longDescription": "This property shall indicate the type of permission.",
+                    "readonly": false
+                },
+                "Description": {
+                    "anyOf": [
+                        {
+                            "$ref": "http://redfish.dmtf.org/schemas/v1/Resource.json#/definitions/Description"
+                        },
+                        {
+                            "type": "null"
+                        }
+                    ],
+                    "readonly": true
+                },
+                "DestinationPortLower": {
+                    "description": "The TCP, UDP, or other destination port to which this rule begins to application, inclusive.",
+                    "longDescription": "This property shall contain the TCP, UDP, or other destination port to which this rule begins application, inclusive.",
+                    "readonly": false,
+                    "type": [
+                        "integer",
+                        "null"
+                    ]
+                },
+                "DestinationPortUpper": {
+                    "description": "The TCP, UDP, or other destination port to which this rule ends application, inclusive.",
+                    "longDescription": "This property shall contain the TCP, UDP, or other destination port to which this rule ends application, inclusive.",
+                    "readonly": false,
+                    "type": [
+                        "integer",
+                        "null"
+                    ]
+                },
+                "Direction": {
+                    "anyOf": [
+                        {
+                            "$ref": "#/definitions/DataDirection"
+                        },
+                        {
+                            "type": "null"
+                        }
+                    ],
+                    "description": "Indicates the direction of the data to which this permission applies.",
+                    "longDescription": "This value shall indicate the direction of the data to which this permission applies for this network device function.",
+                    "readonly": false
+                },
+                "IANAProtocolNumber": {
+                    "description": "The IANA protocol number to which this permission applies.  For TCP, this is `6`.  For UDP, this is `17`.",
+                    "longDescription": "This property shall contain the IANA protocol number to which this permission applies.",
+                    "readonly": false,
+                    "type": [
+                        "integer",
+                        "null"
+                    ]
+                },
+                "IPAddressLower": {
+                    "description": "The lower IP address to which this permission applies.",
+                    "longDescription": "This property shall contain the lower IP address to which this permission applies.",
+                    "readonly": false,
+                    "type": [
+                        "string",
+                        "null"
+                    ]
+                },
+                "IPAddressType": {
+                    "anyOf": [
+                        {
+                            "$ref": "#/definitions/IPAddressType"
+                        },
+                        {
+                            "type": "null"
+                        }
+                    ],
+                    "description": "The type of IP address populated in the IPAddressLower and IPAddressUpper properties.",
+                    "longDescription": "This property shall contain the type of IP address populated in the IPAddressLower and IPAddressUpper properties.  Services shall not permit mixing IPv6 and IPv4 addresses on the same resource.",
+                    "readonly": false
+                },
+                "IPAddressUpper": {
+                    "description": "The upper IP address to which this permission applies.",
+                    "longDescription": "This property shall contain the upper IP address to which this permission applies.",
+                    "readonly": false,
+                    "type": [
+                        "string",
+                        "null"
+                    ]
+                },
+                "Id": {
+                    "$ref": "http://redfish.dmtf.org/schemas/v1/Resource.json#/definitions/Id",
+                    "readonly": true
+                },
+                "Name": {
+                    "$ref": "http://redfish.dmtf.org/schemas/v1/Resource.json#/definitions/Name",
+                    "readonly": true
+                },
+                "Oem": {
+                    "$ref": "http://redfish.dmtf.org/schemas/v1/Resource.json#/definitions/Oem",
+                    "description": "The OEM extension property.",
+                    "longDescription": "This property shall contain the OEM extensions.  All values for properties that this object contains shall conform to the Redfish Specification-described requirements."
+                },
+                "SourcePortLower": {
+                    "description": "The TCP, UDP, or other source port to which this rule begins application, inclusive.",
+                    "longDescription": "This property shall contain the TCP, UDP, or other source port to which this rule begins application, inclusive.",
+                    "readonly": false,
+                    "type": [
+                        "integer",
+                        "null"
+                    ]
+                },
+                "SourcePortUpper": {
+                    "description": "The TCP, UDP or other source port to which this rule ends application, inclusive.",
+                    "longDescription": "This property shall contain the TCP, UDP, or other source port to which this rule ends application, inclusive.",
+                    "readonly": false,
+                    "type": [
+                        "integer",
+                        "null"
+                    ]
+                },
+                "StatefulSession": {
+                    "description": "Indicates if this is a permission that only applies to stateful connection.",
+                    "longDescription": "This property shall indicate if this permission only applies to stateful connection, which are those using SYN, ACK, and FIN.",
+                    "readonly": false,
+                    "type": [
+                        "boolean",
+                        "null"
+                    ]
+                }
+            },
+            "required": [
+                "@odata.id",
+                "@odata.type",
+                "Id",
+                "Name"
+            ],
+            "type": "object"
+        },
+        "AllowType": {
+            "enum": [
+                "Allow",
+                "Deny"
+            ],
+            "enumDescriptions": {
+                "Allow": "Indicates that traffic that matches the criteria in this resource shall be permitted.",
+                "Deny": "Indicates that traffic that matches the criteria in this resource shall not be permitted."
+            },
+            "type": "string"
+        },
+        "DataDirection": {
+            "enum": [
+                "Ingress",
+                "Egress"
+            ],
+            "enumDescriptions": {
+                "Egress": "Indicates that this limit is enforced on packets and bytes transmitted by the network device function.",
+                "Ingress": "Indicates that this limit is enforced on packets and bytes received by the network device function."
+            },
+            "type": "string"
+        },
+        "IPAddressType": {
+            "enum": [
+                "IPv4",
+                "IPv6"
+            ],
+            "enumDescriptions": {
+                "IPv4": "IPv4 addressing is used for all IP-fields in this object.",
+                "IPv6": "IPv6 addressing is used for all IP-fields in this object."
+            },
+            "type": "string"
+        },
+        "OemActions": {
+            "additionalProperties": true,
+            "description": "The available OEM-specific actions for this resource.",
+            "longDescription": "This type shall contain the available OEM-specific actions for this resource.",
+            "patternProperties": {
+                "^([a-zA-Z_][a-zA-Z0-9_]*)?@(odata|Redfish|Message)\\.[a-zA-Z_][a-zA-Z0-9_]*$": {
+                    "description": "This property shall specify a valid odata or Redfish property.",
+                    "type": [
+                        "array",
+                        "boolean",
+                        "integer",
+                        "number",
+                        "null",
+                        "object",
+                        "string"
+                    ]
+                }
+            },
+            "properties": {},
+            "type": "object"
+        }
+    },
+    "owningEntity": "DMTF",
+    "release": "2021.2",
+    "title": "#AllowDeny.v1_0_0.AllowDeny"
+}

--- a/static/redfish/v1/JsonSchemas/AllowDeny/index.json
+++ b/static/redfish/v1/JsonSchemas/AllowDeny/index.json
@@ -1,0 +1,21 @@
+{
+    "@odata.context": "/redfish/v1/$metadata#JsonSchemaFile.JsonSchemaFile",
+    "@odata.id": "/redfish/v1/JsonSchemas/AllowDeny",
+    "@odata.type": "#JsonSchemaFile.v1_0_2.JsonSchemaFile",
+    "Name": "AllowDeny Schema File",
+    "Schema": "#AllowDeny.AllowDeny",
+    "Description": "AllowDeny Schema File Location",
+    "Id": "AllowDeny",
+    "Languages": [
+        "en"
+    ],
+    "Languages@odata.count": 1,
+    "Location": [
+        {
+            "Language": "en",
+            "PublicationUri": "http://redfish.dmtf.org/schemas/v1/AllowDeny.json",
+            "Uri": "/redfish/v1/JsonSchemas/AllowDeny/AllowDeny.json"
+        }
+    ],
+    "Location@odata.count": 1
+}

--- a/static/redfish/v1/JsonSchemas/Battery/Battery.json
+++ b/static/redfish/v1/JsonSchemas/Battery/Battery.json
@@ -1,0 +1,466 @@
+{
+    "$id": "http://redfish.dmtf.org/schemas/v1/Battery.v1_0_0.json",
+    "$ref": "#/definitions/Battery",
+    "$schema": "http://redfish.dmtf.org/schemas/v1/redfish-schema-v1.json",
+    "copyright": "Copyright 2014-2021 DMTF. For the full DMTF copyright policy, see http://www.dmtf.org/about/policies/copyright",
+    "definitions": {
+        "Actions": {
+            "additionalProperties": false,
+            "description": "The available actions for this resource.",
+            "longDescription": "This type shall contain the available actions for this resource.",
+            "patternProperties": {
+                "^([a-zA-Z_][a-zA-Z0-9_]*)?@(odata|Redfish|Message)\\.[a-zA-Z_][a-zA-Z0-9_]*$": {
+                    "description": "This property shall specify a valid odata or Redfish property.",
+                    "type": [
+                        "array",
+                        "boolean",
+                        "integer",
+                        "number",
+                        "null",
+                        "object",
+                        "string"
+                    ]
+                }
+            },
+            "properties": {
+                "#Battery.Calibrate": {
+                    "$ref": "#/definitions/Calibrate"
+                },
+                "#Battery.Reset": {
+                    "$ref": "#/definitions/Reset"
+                },
+                "#Battery.SelfTest": {
+                    "$ref": "#/definitions/SelfTest"
+                },
+                "Oem": {
+                    "$ref": "#/definitions/OemActions",
+                    "description": "The available OEM-specific actions for this resource.",
+                    "longDescription": "This property shall contain the available OEM-specific actions for this resource."
+                }
+            },
+            "type": "object"
+        },
+        "Battery": {
+            "additionalProperties": false,
+            "description": "The Battery schema describes a battery unit, such as those used to provide systems with power during a power loss event.",
+            "longDescription": "This resource shall represent a battery for a Redfish implementation.",
+            "patternProperties": {
+                "^([a-zA-Z_][a-zA-Z0-9_]*)?@(odata|Redfish|Message)\\.[a-zA-Z_][a-zA-Z0-9_]*$": {
+                    "description": "This property shall specify a valid odata or Redfish property.",
+                    "type": [
+                        "array",
+                        "boolean",
+                        "integer",
+                        "number",
+                        "null",
+                        "object",
+                        "string"
+                    ]
+                }
+            },
+            "properties": {
+                "@odata.context": {
+                    "$ref": "http://redfish.dmtf.org/schemas/v1/odata-v4.json#/definitions/context"
+                },
+                "@odata.etag": {
+                    "$ref": "http://redfish.dmtf.org/schemas/v1/odata-v4.json#/definitions/etag"
+                },
+                "@odata.id": {
+                    "$ref": "http://redfish.dmtf.org/schemas/v1/odata-v4.json#/definitions/id"
+                },
+                "@odata.type": {
+                    "$ref": "http://redfish.dmtf.org/schemas/v1/odata-v4.json#/definitions/type"
+                },
+                "Actions": {
+                    "$ref": "#/definitions/Actions",
+                    "description": "The available actions for this resource.",
+                    "longDescription": "This property shall contain the available actions for this resource."
+                },
+                "Assembly": {
+                    "$ref": "http://redfish.dmtf.org/schemas/v1/Assembly.json#/definitions/Assembly",
+                    "description": "The link to the assembly associated with this battery.",
+                    "longDescription": "This property shall contain a link to a resource of type Assembly.",
+                    "readonly": true
+                },
+                "CapacityActualAmpHours": {
+                    "description": "The actual maximum capacity of this battery in amp-hours.",
+                    "longDescription": "This property shall contain the actual maximum capacity of this battery in amp-hours.",
+                    "minimum": 0,
+                    "readonly": true,
+                    "type": [
+                        "number",
+                        "null"
+                    ],
+                    "units": "A.h"
+                },
+                "CapacityActualWattHours": {
+                    "description": "The actual maximum capacity of this battery in watt-hours.",
+                    "longDescription": "This property shall contain the actual maximum capacity of this battery in watt-hours.",
+                    "minimum": 0,
+                    "readonly": true,
+                    "type": [
+                        "number",
+                        "null"
+                    ],
+                    "units": "W.h"
+                },
+                "CapacityRatedAmpHours": {
+                    "description": "The rated maximum capacity of this battery in amp-hours.",
+                    "longDescription": "This property shall contain the rated maximum capacity of this battery in amp-hours.",
+                    "minimum": 0,
+                    "readonly": true,
+                    "type": [
+                        "number",
+                        "null"
+                    ],
+                    "units": "A.h"
+                },
+                "CapacityRatedWattHours": {
+                    "description": "The rated maximum capacity of this battery in watt-hours.",
+                    "longDescription": "This property shall contain the rated maximum capacity of this battery in watt-hours.",
+                    "minimum": 0,
+                    "readonly": true,
+                    "type": [
+                        "number",
+                        "null"
+                    ],
+                    "units": "W.h"
+                },
+                "ChargeState": {
+                    "anyOf": [
+                        {
+                            "$ref": "#/definitions/ChargeState"
+                        },
+                        {
+                            "type": "null"
+                        }
+                    ],
+                    "description": "The charge state of this battery.",
+                    "longDescription": "This property shall contain the charge state of this battery.",
+                    "readonly": true
+                },
+                "Description": {
+                    "anyOf": [
+                        {
+                            "$ref": "http://redfish.dmtf.org/schemas/v1/Resource.json#/definitions/Description"
+                        },
+                        {
+                            "type": "null"
+                        }
+                    ],
+                    "readonly": true
+                },
+                "FirmwareVersion": {
+                    "description": "The firmware version for this battery.",
+                    "longDescription": "This property shall contain the firmware version as defined by the manufacturer for this battery.",
+                    "readonly": true,
+                    "type": [
+                        "string",
+                        "null"
+                    ]
+                },
+                "HotPluggable": {
+                    "description": "An indication of whether this device can be inserted or removed while the equipment is in operation.",
+                    "longDescription": "This property shall indicate whether the device can be inserted or removed while the underlying equipment otherwise remains in its current operational state.  Devices indicated as hot-pluggable shall allow the device to become operable without altering the operational state of the underlying equipment.  Devices that cannot be inserted or removed from equipment in operation, or devices that cannot become operable without affecting the operational state of that equipment, shall be indicated as not hot-pluggable.",
+                    "readonly": true,
+                    "type": [
+                        "boolean",
+                        "null"
+                    ]
+                },
+                "Id": {
+                    "$ref": "http://redfish.dmtf.org/schemas/v1/Resource.json#/definitions/Id",
+                    "readonly": true
+                },
+                "Location": {
+                    "$ref": "http://redfish.dmtf.org/schemas/v1/Resource.json#/definitions/Location",
+                    "description": "The location of the battery.",
+                    "longDescription": "This property shall contain location information of this battery."
+                },
+                "LocationIndicatorActive": {
+                    "description": "An indicator allowing an operator to physically locate this resource.",
+                    "longDescription": "This property shall contain the state of the indicator used to physically identify or locate this resource.",
+                    "readonly": false,
+                    "type": [
+                        "boolean",
+                        "null"
+                    ]
+                },
+                "Manufacturer": {
+                    "description": "The manufacturer of this battery.",
+                    "longDescription": "This property shall contain the name of the organization responsible for producing the battery.  This organization may be the entity from whom the battery is purchased, but this is not necessarily true.",
+                    "readonly": true,
+                    "type": [
+                        "string",
+                        "null"
+                    ]
+                },
+                "MaxChargeRateAmps": {
+                    "description": "The maximum charge rate of this battery in amps.",
+                    "longDescription": "This property shall contain the maximum charge rate of this battery in amps.",
+                    "minimum": 0,
+                    "readonly": true,
+                    "type": [
+                        "number",
+                        "null"
+                    ],
+                    "units": "A"
+                },
+                "MaxChargeVoltage": {
+                    "description": "The maximum charge voltage of this battery.",
+                    "longDescription": "This property shall contain the maximum charge voltage of this battery.",
+                    "minimum": 0,
+                    "readonly": true,
+                    "type": [
+                        "number",
+                        "null"
+                    ],
+                    "units": "V"
+                },
+                "MaxDischargeRateAmps": {
+                    "description": "The maximum discharge rate of this battery in amps.",
+                    "longDescription": "This property shall contain the maximum discharge rate of this battery in amps.",
+                    "minimum": 0,
+                    "readonly": true,
+                    "type": [
+                        "number",
+                        "null"
+                    ],
+                    "units": "A"
+                },
+                "Metrics": {
+                    "$ref": "http://redfish.dmtf.org/schemas/v1/BatteryMetrics.json#/definitions/BatteryMetrics",
+                    "description": "The link to the battery metrics resource associated with this battery.",
+                    "longDescription": "This property shall contain a link to a resource of type BatteryMetrics.",
+                    "readonly": true
+                },
+                "Model": {
+                    "description": "The model number for this battery.",
+                    "longDescription": "This property shall contain the model information as defined by the manufacturer for this battery.",
+                    "readonly": true,
+                    "type": [
+                        "string",
+                        "null"
+                    ]
+                },
+                "Name": {
+                    "$ref": "http://redfish.dmtf.org/schemas/v1/Resource.json#/definitions/Name",
+                    "readonly": true
+                },
+                "Oem": {
+                    "$ref": "http://redfish.dmtf.org/schemas/v1/Resource.json#/definitions/Oem",
+                    "description": "The OEM extension property.",
+                    "longDescription": "This property shall contain the OEM extensions.  All values for properties that this object contains shall conform to the Redfish Specification-described requirements."
+                },
+                "PartNumber": {
+                    "description": "The part number for this battery.",
+                    "longDescription": "This property shall contain the part number as defined by the manufacturer for this battery.",
+                    "readonly": true,
+                    "type": [
+                        "string",
+                        "null"
+                    ]
+                },
+                "ProductionDate": {
+                    "description": "The production or manufacturing date of this battery.",
+                    "format": "date-time",
+                    "longDescription": "This property shall contain the date of production or manufacture for this battery.",
+                    "readonly": true,
+                    "type": [
+                        "string",
+                        "null"
+                    ]
+                },
+                "SerialNumber": {
+                    "description": "The serial number for this battery.",
+                    "longDescription": "This property shall contain the serial number as defined by the manufacturer for this battery.",
+                    "readonly": true,
+                    "type": [
+                        "string",
+                        "null"
+                    ]
+                },
+                "SparePartNumber": {
+                    "description": "The spare part number for this battery.",
+                    "longDescription": "This property shall contain the spare or replacement part number as defined by the manufacturer for this battery.",
+                    "readonly": true,
+                    "type": [
+                        "string",
+                        "null"
+                    ]
+                },
+                "StateOfHealthPercent": {
+                    "$ref": "http://redfish.dmtf.org/schemas/v1/Sensor.json#/definitions/SensorExcerpt",
+                    "description": "The state of health of this battery.",
+                    "excerptCopy": "SensorExcerpt",
+                    "longDescription": "This property shall contain the state of health of this battery as a percentage."
+                },
+                "Status": {
+                    "$ref": "http://redfish.dmtf.org/schemas/v1/Resource.json#/definitions/Status",
+                    "description": "The status and health of the resource and its subordinate or dependent resources.",
+                    "longDescription": "This property shall contain any status or health properties of the resource."
+                },
+                "Version": {
+                    "description": "The hardware version of this battery.",
+                    "longDescription": "This property shall contain the hardware version of this battery as determined by the vendor or supplier.",
+                    "readonly": true,
+                    "type": [
+                        "string",
+                        "null"
+                    ]
+                }
+            },
+            "required": [
+                "@odata.id",
+                "@odata.type",
+                "Id",
+                "Name"
+            ],
+            "type": "object"
+        },
+        "Calibrate": {
+            "additionalProperties": false,
+            "description": "This action performs a self-calibration, or learn cycle, of the battery.",
+            "longDescription": "This action shall perform a self-calibration, or learn cycle, of the battery.",
+            "parameters": {},
+            "patternProperties": {
+                "^([a-zA-Z_][a-zA-Z0-9_]*)?@(odata|Redfish|Message)\\.[a-zA-Z_][a-zA-Z0-9_]*$": {
+                    "description": "This property shall specify a valid odata or Redfish property.",
+                    "type": [
+                        "array",
+                        "boolean",
+                        "integer",
+                        "number",
+                        "null",
+                        "object",
+                        "string"
+                    ]
+                }
+            },
+            "properties": {
+                "target": {
+                    "description": "Link to invoke action",
+                    "format": "uri-reference",
+                    "type": "string"
+                },
+                "title": {
+                    "description": "Friendly action name",
+                    "type": "string"
+                }
+            },
+            "type": "object"
+        },
+        "ChargeState": {
+            "enum": [
+                "Idle",
+                "Charging",
+                "Discharging"
+            ],
+            "enumDescriptions": {
+                "Charging": "The battery is charging.",
+                "Discharging": "The battery is discharging.",
+                "Idle": "The battery is idle."
+            },
+            "enumLongDescriptions": {
+                "Charging": "This value shall indicate the battery is charging and energy is entering the battery.",
+                "Discharging": "This value shall indicate the battery is discharging and energy is leaving the battery.",
+                "Idle": "This value shall indicate the battery is idle and energy is not entering or leaving the battery.  Small amounts of energy may enter or leave the battery while in this state if the battery is regulating itself."
+            },
+            "type": "string"
+        },
+        "OemActions": {
+            "additionalProperties": true,
+            "description": "The available OEM-specific actions for this resource.",
+            "longDescription": "This type shall contain the available OEM-specific actions for this resource.",
+            "patternProperties": {
+                "^([a-zA-Z_][a-zA-Z0-9_]*)?@(odata|Redfish|Message)\\.[a-zA-Z_][a-zA-Z0-9_]*$": {
+                    "description": "This property shall specify a valid odata or Redfish property.",
+                    "type": [
+                        "array",
+                        "boolean",
+                        "integer",
+                        "number",
+                        "null",
+                        "object",
+                        "string"
+                    ]
+                }
+            },
+            "properties": {},
+            "type": "object"
+        },
+        "Reset": {
+            "additionalProperties": false,
+            "description": "This action resets the battery.",
+            "longDescription": "This action shall reset the battery.",
+            "parameters": {
+                "ResetType": {
+                    "$ref": "http://redfish.dmtf.org/schemas/v1/Resource.json#/definitions/ResetType",
+                    "description": "The type of reset.",
+                    "longDescription": "This parameter shall contain the type of reset.  The service can accept a request without the parameter and shall perform a `GracefulRestart`."
+                }
+            },
+            "patternProperties": {
+                "^([a-zA-Z_][a-zA-Z0-9_]*)?@(odata|Redfish|Message)\\.[a-zA-Z_][a-zA-Z0-9_]*$": {
+                    "description": "This property shall specify a valid odata or Redfish property.",
+                    "type": [
+                        "array",
+                        "boolean",
+                        "integer",
+                        "number",
+                        "null",
+                        "object",
+                        "string"
+                    ]
+                }
+            },
+            "properties": {
+                "target": {
+                    "description": "Link to invoke action",
+                    "format": "uri-reference",
+                    "type": "string"
+                },
+                "title": {
+                    "description": "Friendly action name",
+                    "type": "string"
+                }
+            },
+            "type": "object"
+        },
+        "SelfTest": {
+            "additionalProperties": false,
+            "description": "This action performs a self-test of the battery.",
+            "longDescription": "This action shall perform a self-test of the battery.",
+            "parameters": {},
+            "patternProperties": {
+                "^([a-zA-Z_][a-zA-Z0-9_]*)?@(odata|Redfish|Message)\\.[a-zA-Z_][a-zA-Z0-9_]*$": {
+                    "description": "This property shall specify a valid odata or Redfish property.",
+                    "type": [
+                        "array",
+                        "boolean",
+                        "integer",
+                        "number",
+                        "null",
+                        "object",
+                        "string"
+                    ]
+                }
+            },
+            "properties": {
+                "target": {
+                    "description": "Link to invoke action",
+                    "format": "uri-reference",
+                    "type": "string"
+                },
+                "title": {
+                    "description": "Friendly action name",
+                    "type": "string"
+                }
+            },
+            "type": "object"
+        }
+    },
+    "owningEntity": "DMTF",
+    "release": "2021.2",
+    "title": "#Battery.v1_0_0.Battery"
+}

--- a/static/redfish/v1/JsonSchemas/Battery/index.json
+++ b/static/redfish/v1/JsonSchemas/Battery/index.json
@@ -1,0 +1,21 @@
+{
+    "@odata.context": "/redfish/v1/$metadata#JsonSchemaFile.JsonSchemaFile",
+    "@odata.id": "/redfish/v1/JsonSchemas/Battery",
+    "@odata.type": "#JsonSchemaFile.v1_0_2.JsonSchemaFile",
+    "Name": "Battery Schema File",
+    "Schema": "#Battery.Battery",
+    "Description": "Battery Schema File Location",
+    "Id": "Battery",
+    "Languages": [
+        "en"
+    ],
+    "Languages@odata.count": 1,
+    "Location": [
+        {
+            "Language": "en",
+            "PublicationUri": "http://redfish.dmtf.org/schemas/v1/Battery.json",
+            "Uri": "/redfish/v1/JsonSchemas/Battery/Battery.json"
+        }
+    ],
+    "Location@odata.count": 1
+}

--- a/static/redfish/v1/JsonSchemas/BatteryMetrics/BatteryMetrics.json
+++ b/static/redfish/v1/JsonSchemas/BatteryMetrics/BatteryMetrics.json
@@ -1,0 +1,215 @@
+{
+    "$id": "http://redfish.dmtf.org/schemas/v1/BatteryMetrics.v1_0_0.json",
+    "$ref": "#/definitions/BatteryMetrics",
+    "$schema": "http://redfish.dmtf.org/schemas/v1/redfish-schema-v1.json",
+    "copyright": "Copyright 2014-2021 DMTF. For the full DMTF copyright policy, see http://www.dmtf.org/about/policies/copyright",
+    "definitions": {
+        "Actions": {
+            "additionalProperties": false,
+            "description": "The available actions for this resource.",
+            "longDescription": "This type shall contain the available actions for this resource.",
+            "patternProperties": {
+                "^([a-zA-Z_][a-zA-Z0-9_]*)?@(odata|Redfish|Message)\\.[a-zA-Z_][a-zA-Z0-9_]*$": {
+                    "description": "This property shall specify a valid odata or Redfish property.",
+                    "type": [
+                        "array",
+                        "boolean",
+                        "integer",
+                        "number",
+                        "null",
+                        "object",
+                        "string"
+                    ]
+                }
+            },
+            "properties": {
+                "Oem": {
+                    "$ref": "#/definitions/OemActions",
+                    "description": "The available OEM-specific actions for this resource.",
+                    "longDescription": "This property shall contain the available OEM-specific actions for this resource."
+                }
+            },
+            "type": "object"
+        },
+        "BatteryMetrics": {
+            "additionalProperties": false,
+            "description": "The BatteryMetrics schema contains definitions for the metrics of a battery unit.",
+            "longDescription": "This resource shall be used to represent the metrics of a battery unit for a Redfish implementation.",
+            "patternProperties": {
+                "^([a-zA-Z_][a-zA-Z0-9_]*)?@(odata|Redfish|Message)\\.[a-zA-Z_][a-zA-Z0-9_]*$": {
+                    "description": "This property shall specify a valid odata or Redfish property.",
+                    "type": [
+                        "array",
+                        "boolean",
+                        "integer",
+                        "number",
+                        "null",
+                        "object",
+                        "string"
+                    ]
+                }
+            },
+            "properties": {
+                "@odata.context": {
+                    "$ref": "http://redfish.dmtf.org/schemas/v1/odata-v4.json#/definitions/context"
+                },
+                "@odata.etag": {
+                    "$ref": "http://redfish.dmtf.org/schemas/v1/odata-v4.json#/definitions/etag"
+                },
+                "@odata.id": {
+                    "$ref": "http://redfish.dmtf.org/schemas/v1/odata-v4.json#/definitions/id"
+                },
+                "@odata.type": {
+                    "$ref": "http://redfish.dmtf.org/schemas/v1/odata-v4.json#/definitions/type"
+                },
+                "Actions": {
+                    "$ref": "#/definitions/Actions",
+                    "description": "The available actions for this resource.",
+                    "longDescription": "This property shall contain the available actions for this resource."
+                },
+                "CellVoltages": {
+                    "description": "The cell voltage readings for this battery.",
+                    "excerptCopy": "SensorVoltageExcerpt",
+                    "items": {
+                        "$ref": "http://redfish.dmtf.org/schemas/v1/Sensor.json#/definitions/SensorVoltageExcerpt"
+                    },
+                    "longDescription": "This property shall contain the cell voltage sensors for this battery.",
+                    "type": "array"
+                },
+                "CellVoltages@odata.count": {
+                    "$ref": "http://redfish.dmtf.org/schemas/v1/odata-v4.json#/definitions/count"
+                },
+                "ChargePercent": {
+                    "$ref": "http://redfish.dmtf.org/schemas/v1/Sensor.json#/definitions/SensorExcerpt",
+                    "description": "The amount of charge available in this battery as a percentage.",
+                    "excerptCopy": "SensorExcerpt",
+                    "longDescription": "This property shall contain the amount of charge available in this battery as a percentage."
+                },
+                "Description": {
+                    "anyOf": [
+                        {
+                            "$ref": "http://redfish.dmtf.org/schemas/v1/Resource.json#/definitions/Description"
+                        },
+                        {
+                            "type": "null"
+                        }
+                    ],
+                    "readonly": true
+                },
+                "DischargeCycles": {
+                    "description": "The number of discharges this battery sustained.",
+                    "longDescription": "This property shall contain the number of discharges this battery sustained.",
+                    "minimum": 0,
+                    "readonly": true,
+                    "type": [
+                        "number",
+                        "null"
+                    ]
+                },
+                "Id": {
+                    "$ref": "http://redfish.dmtf.org/schemas/v1/Resource.json#/definitions/Id",
+                    "readonly": true
+                },
+                "InputCurrentAmps": {
+                    "$ref": "http://redfish.dmtf.org/schemas/v1/Sensor.json#/definitions/SensorCurrentExcerpt",
+                    "description": "The input current reading for this battery.",
+                    "excerptCopy": "SensorCurrentExcerpt",
+                    "longDescription": "This property shall contain the input current sensor for this battery."
+                },
+                "InputVoltage": {
+                    "$ref": "http://redfish.dmtf.org/schemas/v1/Sensor.json#/definitions/SensorVoltageExcerpt",
+                    "description": "The input voltage reading for this battery.",
+                    "excerptCopy": "SensorVoltageExcerpt",
+                    "longDescription": "This property shall contain the input voltage sensor for this battery."
+                },
+                "Name": {
+                    "$ref": "http://redfish.dmtf.org/schemas/v1/Resource.json#/definitions/Name",
+                    "readonly": true
+                },
+                "Oem": {
+                    "$ref": "http://redfish.dmtf.org/schemas/v1/Resource.json#/definitions/Oem",
+                    "description": "The OEM extension property.",
+                    "longDescription": "This property shall contain the OEM extensions.  All values for properties that this object contains shall conform to the Redfish Specification-described requirements."
+                },
+                "OutputCurrentAmps": {
+                    "description": "The output current readings for this battery.",
+                    "excerptCopy": "SensorCurrentExcerpt",
+                    "items": {
+                        "$ref": "http://redfish.dmtf.org/schemas/v1/Sensor.json#/definitions/SensorCurrentExcerpt"
+                    },
+                    "longDescription": "This property shall contain the output current sensors for this battery.  The sensors shall appear in the same array order as the OutputVoltages property.",
+                    "type": "array"
+                },
+                "OutputCurrentAmps@odata.count": {
+                    "$ref": "http://redfish.dmtf.org/schemas/v1/odata-v4.json#/definitions/count"
+                },
+                "OutputVoltages": {
+                    "description": "The output voltage readings for this battery.",
+                    "excerptCopy": "SensorVoltageExcerpt",
+                    "items": {
+                        "$ref": "http://redfish.dmtf.org/schemas/v1/Sensor.json#/definitions/SensorVoltageExcerpt"
+                    },
+                    "longDescription": "This property shall contain the output voltage sensors for this battery.  The sensors shall appear in the same array order as the OutputCurrentAmps property.",
+                    "type": "array"
+                },
+                "OutputVoltages@odata.count": {
+                    "$ref": "http://redfish.dmtf.org/schemas/v1/odata-v4.json#/definitions/count"
+                },
+                "Status": {
+                    "$ref": "http://redfish.dmtf.org/schemas/v1/Resource.json#/definitions/Status",
+                    "description": "The status and health of the resource and its subordinate or dependent resources.",
+                    "longDescription": "This property shall contain any status or health properties of the resource."
+                },
+                "StoredChargeAmpHours": {
+                    "$ref": "http://redfish.dmtf.org/schemas/v1/Sensor.json#/definitions/SensorExcerpt",
+                    "description": "The charge stored in this battery in amp-hours.",
+                    "excerptCopy": "SensorExcerpt",
+                    "longDescription": "This property shall contain the charge sensor for this battery in amp-hours."
+                },
+                "StoredEnergyWattHours": {
+                    "$ref": "http://redfish.dmtf.org/schemas/v1/Sensor.json#/definitions/SensorExcerpt",
+                    "description": "The energy stored in this battery in watt-hours.",
+                    "excerptCopy": "SensorExcerpt",
+                    "longDescription": "This property shall contain the energy sensor for this battery in watt-hours."
+                },
+                "TemperatureCelsius": {
+                    "$ref": "http://redfish.dmtf.org/schemas/v1/Sensor.json#/definitions/SensorExcerpt",
+                    "description": "The temperature reading for this battery.",
+                    "excerptCopy": "SensorExcerpt",
+                    "longDescription": "This property shall contain the temperature sensor for this battery."
+                }
+            },
+            "required": [
+                "@odata.id",
+                "@odata.type",
+                "Id",
+                "Name"
+            ],
+            "type": "object"
+        },
+        "OemActions": {
+            "additionalProperties": true,
+            "description": "The available OEM-specific actions for this resource.",
+            "longDescription": "This type shall contain the available OEM-specific actions for this resource.",
+            "patternProperties": {
+                "^([a-zA-Z_][a-zA-Z0-9_]*)?@(odata|Redfish|Message)\\.[a-zA-Z_][a-zA-Z0-9_]*$": {
+                    "description": "This property shall specify a valid odata or Redfish property.",
+                    "type": [
+                        "array",
+                        "boolean",
+                        "integer",
+                        "number",
+                        "null",
+                        "object",
+                        "string"
+                    ]
+                }
+            },
+            "properties": {},
+            "type": "object"
+        }
+    },
+    "owningEntity": "DMTF",
+    "release": "2021.2",
+    "title": "#BatteryMetrics.v1_0_0.BatteryMetrics"
+}

--- a/static/redfish/v1/JsonSchemas/BatteryMetrics/index.json
+++ b/static/redfish/v1/JsonSchemas/BatteryMetrics/index.json
@@ -1,0 +1,21 @@
+{
+    "@odata.context": "/redfish/v1/$metadata#JsonSchemaFile.JsonSchemaFile",
+    "@odata.id": "/redfish/v1/JsonSchemas/BatteryMetrics",
+    "@odata.type": "#JsonSchemaFile.v1_0_2.JsonSchemaFile",
+    "Name": "BatteryMetrics Schema File",
+    "Schema": "#BatteryMetrics.BatteryMetrics",
+    "Description": "BatteryMetrics Schema File Location",
+    "Id": "BatteryMetrics",
+    "Languages": [
+        "en"
+    ],
+    "Languages@odata.count": 1,
+    "Location": [
+        {
+            "Language": "en",
+            "PublicationUri": "http://redfish.dmtf.org/schemas/v1/BatteryMetrics.json",
+            "Uri": "/redfish/v1/JsonSchemas/BatteryMetrics/BatteryMetrics.json"
+        }
+    ],
+    "Location@odata.count": 1
+}

--- a/static/redfish/v1/JsonSchemas/BootOption/BootOption.json
+++ b/static/redfish/v1/JsonSchemas/BootOption/BootOption.json
@@ -1,0 +1,190 @@
+{
+    "$id": "http://redfish.dmtf.org/schemas/v1/BootOption.v1_0_4.json",
+    "$ref": "#/definitions/BootOption",
+    "$schema": "http://redfish.dmtf.org/schemas/v1/redfish-schema-v1.json",
+    "copyright": "Copyright 2014-2020 DMTF. For the full DMTF copyright policy, see http://www.dmtf.org/about/policies/copyright",
+    "definitions": {
+        "Actions": {
+            "additionalProperties": false,
+            "description": "The available actions for this resource.",
+            "longDescription": "This type shall contain the available actions for this resource.",
+            "patternProperties": {
+                "^([a-zA-Z_][a-zA-Z0-9_]*)?@(odata|Redfish|Message)\\.[a-zA-Z_][a-zA-Z0-9_]*$": {
+                    "description": "This property shall specify a valid odata or Redfish property.",
+                    "type": [
+                        "array",
+                        "boolean",
+                        "integer",
+                        "number",
+                        "null",
+                        "object",
+                        "string"
+                    ]
+                }
+            },
+            "properties": {
+                "Oem": {
+                    "$ref": "#/definitions/OemActions",
+                    "description": "The available OEM-specific actions for this resource.",
+                    "longDescription": "This property shall contain the available OEM-specific actions for this resource."
+                }
+            },
+            "type": "object"
+        },
+        "BootOption": {
+            "additionalProperties": false,
+            "description": "The BootOption schema reports information about a single boot option in a system.  It represents the properties of a bootable device available in the system.",
+            "longDescription": "This resource shall represent a single boot option within a system.",
+            "patternProperties": {
+                "^([a-zA-Z_][a-zA-Z0-9_]*)?@(odata|Redfish|Message)\\.[a-zA-Z_][a-zA-Z0-9_]*$": {
+                    "description": "This property shall specify a valid odata or Redfish property.",
+                    "type": [
+                        "array",
+                        "boolean",
+                        "integer",
+                        "number",
+                        "null",
+                        "object",
+                        "string"
+                    ]
+                }
+            },
+            "properties": {
+                "@odata.context": {
+                    "$ref": "http://redfish.dmtf.org/schemas/v1/odata-v4.json#/definitions/context"
+                },
+                "@odata.etag": {
+                    "$ref": "http://redfish.dmtf.org/schemas/v1/odata-v4.json#/definitions/etag"
+                },
+                "@odata.id": {
+                    "$ref": "http://redfish.dmtf.org/schemas/v1/odata-v4.json#/definitions/id"
+                },
+                "@odata.type": {
+                    "$ref": "http://redfish.dmtf.org/schemas/v1/odata-v4.json#/definitions/type"
+                },
+                "Actions": {
+                    "$ref": "#/definitions/Actions",
+                    "description": "The available actions for this resource.",
+                    "longDescription": "This property shall contain the available actions for this resource."
+                },
+                "Alias": {
+                    "anyOf": [
+                        {
+                            "$ref": "http://redfish.dmtf.org/schemas/v1/ComputerSystem.json#/definitions/BootSource"
+                        },
+                        {
+                            "type": "null"
+                        }
+                    ],
+                    "description": "The alias of this boot source.",
+                    "longDescription": "This property shall contain the string alias of this boot source that describes the type of boot.",
+                    "readonly": true
+                },
+                "BootOptionEnabled": {
+                    "description": "An indication of whether the boot option is enabled.  If `true`, it is enabled.  If `false`, the boot option that the boot order array on the computer system contains is skipped.  In the UEFI context, this property shall influence the load option active flag for the boot option.",
+                    "longDescription": "This property shall indicate whether the boot option is enabled.  If `true`, it is enabled.  If `false`, the boot option that the boot order array on the computer system contains shall be skipped.  In the UEFI context, this property shall influence the load option active flag for the boot option.",
+                    "readonly": false,
+                    "type": [
+                        "boolean",
+                        "null"
+                    ]
+                },
+                "BootOptionReference": {
+                    "description": "The unique boot option.",
+                    "longDescription": "This property shall correspond to the boot option or device.  For UEFI systems, this string shall match the UEFI boot option variable name, such as `Boot####`.  The BootOrder array of a computer system resource contains this value.",
+                    "readonly": true,
+                    "type": [
+                        "string",
+                        "null"
+                    ]
+                },
+                "Description": {
+                    "anyOf": [
+                        {
+                            "$ref": "http://redfish.dmtf.org/schemas/v1/Resource.json#/definitions/Description"
+                        },
+                        {
+                            "type": "null"
+                        }
+                    ],
+                    "readonly": true
+                },
+                "DisplayName": {
+                    "description": "The user-readable display name of the boot option that appears in the boot order list in the user interface.",
+                    "longDescription": "This property shall contain a user-readable boot option name, as it should appear in the boot order list in the user interface.",
+                    "readonly": true,
+                    "type": [
+                        "string",
+                        "null"
+                    ]
+                },
+                "Id": {
+                    "$ref": "http://redfish.dmtf.org/schemas/v1/Resource.json#/definitions/Id",
+                    "readonly": true
+                },
+                "Name": {
+                    "$ref": "http://redfish.dmtf.org/schemas/v1/Resource.json#/definitions/Name",
+                    "readonly": true
+                },
+                "Oem": {
+                    "$ref": "http://redfish.dmtf.org/schemas/v1/Resource.json#/definitions/Oem",
+                    "description": "The OEM extension property.",
+                    "longDescription": "This property shall contain the OEM extensions.  All values for properties that this object contains shall conform to the Redfish Specification-described requirements."
+                },
+                "RelatedItem": {
+                    "description": "An array of links to resources or objects associated with this boot option.",
+                    "items": {
+                        "$ref": "http://redfish.dmtf.org/schemas/v1/odata-v4.json#/definitions/idRef"
+                    },
+                    "longDescription": "This property shall contain an array of links to resources or objects that are associated with this boot option.",
+                    "readonly": true,
+                    "type": "array"
+                },
+                "RelatedItem@odata.count": {
+                    "$ref": "http://redfish.dmtf.org/schemas/v1/odata-v4.json#/definitions/count"
+                },
+                "UefiDevicePath": {
+                    "description": "The UEFI device path to access this UEFI boot option.",
+                    "longDescription": "This property shall contain the UEFI Specification-defined UEFI device path that identifies and locates the device for this boot option.",
+                    "readonly": true,
+                    "type": [
+                        "string",
+                        "null"
+                    ]
+                }
+            },
+            "required": [
+                "BootOptionReference",
+                "@odata.id",
+                "@odata.type",
+                "Id",
+                "Name"
+            ],
+            "type": "object"
+        },
+        "OemActions": {
+            "additionalProperties": true,
+            "description": "The available OEM-specific actions for this resource.",
+            "longDescription": "This type shall contain the available OEM-specific actions for this resource.",
+            "patternProperties": {
+                "^([a-zA-Z_][a-zA-Z0-9_]*)?@(odata|Redfish|Message)\\.[a-zA-Z_][a-zA-Z0-9_]*$": {
+                    "description": "This property shall specify a valid odata or Redfish property.",
+                    "type": [
+                        "array",
+                        "boolean",
+                        "integer",
+                        "number",
+                        "null",
+                        "object",
+                        "string"
+                    ]
+                }
+            },
+            "properties": {},
+            "type": "object"
+        }
+    },
+    "owningEntity": "DMTF",
+    "release": "2017.3",
+    "title": "#BootOption.v1_0_4.BootOption"
+}

--- a/static/redfish/v1/JsonSchemas/BootOption/index.json
+++ b/static/redfish/v1/JsonSchemas/BootOption/index.json
@@ -1,0 +1,21 @@
+{
+    "@odata.context": "/redfish/v1/$metadata#JsonSchemaFile.JsonSchemaFile",
+    "@odata.id": "/redfish/v1/JsonSchemas/BootOption",
+    "@odata.type": "#JsonSchemaFile.v1_0_2.JsonSchemaFile",
+    "Name": "BootOption Schema File",
+    "Schema": "#BootOption.BootOption",
+    "Description": "BootOption Schema File Location",
+    "Id": "BootOption",
+    "Languages": [
+        "en"
+    ],
+    "Languages@odata.count": 1,
+    "Location": [
+        {
+            "Language": "en",
+            "PublicationUri": "http://redfish.dmtf.org/schemas/v1/BootOption.json",
+            "Uri": "/redfish/v1/JsonSchemas/BootOption/BootOption.json"
+        }
+    ],
+    "Location@odata.count": 1
+}

--- a/static/redfish/v1/JsonSchemas/Cable/Cable.json
+++ b/static/redfish/v1/JsonSchemas/Cable/Cable.json
@@ -1,0 +1,490 @@
+{
+    "$id": "http://redfish.dmtf.org/schemas/v1/Cable.v1_0_0.json",
+    "$ref": "#/definitions/Cable",
+    "$schema": "http://redfish.dmtf.org/schemas/v1/redfish-schema-v1.json",
+    "copyright": "Copyright 2014-2021 DMTF. For the full DMTF copyright policy, see http://www.dmtf.org/about/policies/copyright",
+    "definitions": {
+        "Actions": {
+            "additionalProperties": false,
+            "description": "The available actions for this resource.",
+            "longDescription": "This type shall contain the available actions for this resource.",
+            "patternProperties": {
+                "^([a-zA-Z_][a-zA-Z0-9_]*)?@(odata|Redfish|Message)\\.[a-zA-Z_][a-zA-Z0-9_]*$": {
+                    "description": "This property shall specify a valid odata or Redfish property.",
+                    "type": [
+                        "array",
+                        "boolean",
+                        "integer",
+                        "number",
+                        "null",
+                        "object",
+                        "string"
+                    ]
+                }
+            },
+            "properties": {
+                "Oem": {
+                    "$ref": "#/definitions/OemActions",
+                    "description": "The available OEM-specific actions for this resource.",
+                    "longDescription": "This property shall contain the available OEM-specific actions for this resource."
+                }
+            },
+            "type": "object"
+        },
+        "Cable": {
+            "additionalProperties": true,
+            "description": "The Cable schema contains properties that describe a cable connecting endpoints of a chassis, port, or any other cable-compatible endpoint.",
+            "longDescription": "This resource contains a simple cable for a Redfish implementation.",
+            "patternProperties": {
+                "^([a-zA-Z_][a-zA-Z0-9_]*)?@(odata|Redfish|Message)\\.[a-zA-Z_][a-zA-Z0-9_]*$": {
+                    "description": "This property shall specify a valid odata or Redfish property.",
+                    "type": [
+                        "array",
+                        "boolean",
+                        "integer",
+                        "number",
+                        "null",
+                        "object",
+                        "string"
+                    ]
+                }
+            },
+            "properties": {
+                "@odata.context": {
+                    "$ref": "http://redfish.dmtf.org/schemas/v1/odata-v4.json#/definitions/context"
+                },
+                "@odata.etag": {
+                    "$ref": "http://redfish.dmtf.org/schemas/v1/odata-v4.json#/definitions/etag"
+                },
+                "@odata.id": {
+                    "$ref": "http://redfish.dmtf.org/schemas/v1/odata-v4.json#/definitions/id"
+                },
+                "@odata.type": {
+                    "$ref": "http://redfish.dmtf.org/schemas/v1/odata-v4.json#/definitions/type"
+                },
+                "Actions": {
+                    "$ref": "#/definitions/Actions",
+                    "description": "The available actions for this resource.",
+                    "longDescription": "This property shall contain the available actions for this resource."
+                },
+                "Assembly": {
+                    "$ref": "http://redfish.dmtf.org/schemas/v1/Assembly.json#/definitions/Assembly",
+                    "description": "The link to the assembly associated with this cable.",
+                    "longDescription": "This property shall contain a link to a resource of type Assembly.",
+                    "readonly": true
+                },
+                "AssetTag": {
+                    "description": "The user-assigned asset tag for this cable.",
+                    "longDescription": "This property shall track the cable for inventory purposes.",
+                    "readonly": false,
+                    "type": [
+                        "string",
+                        "null"
+                    ]
+                },
+                "CableClass": {
+                    "anyOf": [
+                        {
+                            "$ref": "#/definitions/CableClass"
+                        },
+                        {
+                            "type": "null"
+                        }
+                    ],
+                    "description": "The identifier for the downstream resource.",
+                    "longDescription": "The property shall contain the cable class for this cable.",
+                    "readonly": false
+                },
+                "CableStatus": {
+                    "$ref": "#/definitions/CableStatus",
+                    "description": "The user-reported status of this resource.",
+                    "longDescription": "This property shall contain the user-reported status of this resource.",
+                    "readonly": false
+                },
+                "CableType": {
+                    "description": "The type of this cable.",
+                    "longDescription": "This property shall contain a user-defined type for this cable.",
+                    "readonly": false,
+                    "type": [
+                        "string",
+                        "null"
+                    ]
+                },
+                "Description": {
+                    "anyOf": [
+                        {
+                            "$ref": "http://redfish.dmtf.org/schemas/v1/Resource.json#/definitions/Description"
+                        },
+                        {
+                            "type": "null"
+                        }
+                    ],
+                    "readonly": true
+                },
+                "DownstreamConnectorTypes": {
+                    "description": "The connector types this cable supports.",
+                    "items": {
+                        "$ref": "#/definitions/ConnectorType"
+                    },
+                    "longDescription": "The property shall contain an array of connector types this cable supports.",
+                    "readonly": false,
+                    "type": "array"
+                },
+                "DownstreamName": {
+                    "description": "The identifier for the downstream resource.",
+                    "longDescription": "This property shall contain any identifier for a downstream resource.",
+                    "readonly": false,
+                    "type": [
+                        "string",
+                        "null"
+                    ]
+                },
+                "Id": {
+                    "$ref": "http://redfish.dmtf.org/schemas/v1/Resource.json#/definitions/Id",
+                    "readonly": true
+                },
+                "LengthMeters": {
+                    "description": "The length of the cable in meters.",
+                    "longDescription": "This property shall contain the length of the cable in meters.",
+                    "readonly": false,
+                    "type": [
+                        "number",
+                        "null"
+                    ]
+                },
+                "Links": {
+                    "$ref": "#/definitions/Links",
+                    "description": "The links to other resources that are related to this resource.",
+                    "longDescription": "This property shall contain links to resources that are related to but are not contained by, or subordinate to, this resource."
+                },
+                "Location": {
+                    "$ref": "http://redfish.dmtf.org/schemas/v1/Resource.json#/definitions/Location",
+                    "description": "The location of the assembly.",
+                    "longDescription": "This property shall contain location information of the associated assembly."
+                },
+                "Manufacturer": {
+                    "description": "The manufacturer of this cable.",
+                    "longDescription": "This property shall contain the name of the organization responsible for producing the cable.  This organization might be the entity from whom the cable is purchased, but this is not necessarily true.",
+                    "readonly": false,
+                    "type": [
+                        "string",
+                        "null"
+                    ]
+                },
+                "Model": {
+                    "description": "The model number of the cable.",
+                    "longDescription": "This property shall contain the name by which the manufacturer generally refers to the cable.",
+                    "readonly": false,
+                    "type": [
+                        "string",
+                        "null"
+                    ]
+                },
+                "Name": {
+                    "$ref": "http://redfish.dmtf.org/schemas/v1/Resource.json#/definitions/Name",
+                    "readonly": true
+                },
+                "Oem": {
+                    "$ref": "http://redfish.dmtf.org/schemas/v1/Resource.json#/definitions/Oem",
+                    "description": "The OEM extension property.",
+                    "longDescription": "This property shall contain the OEM extensions.  All values for properties that this object contains shall conform to the Redfish Specification-described requirements."
+                },
+                "PartNumber": {
+                    "description": "The part number for this cable.",
+                    "longDescription": "This property shall contain the part number assigned by the organization that is responsible for producing or manufacturing the cable.",
+                    "readonly": false,
+                    "type": [
+                        "string",
+                        "null"
+                    ]
+                },
+                "SKU": {
+                    "description": "The SKU for this cable.",
+                    "longDescription": "This property shall contain the stock-keeping unit (SKU) number for this cable.",
+                    "readonly": false,
+                    "type": [
+                        "string",
+                        "null"
+                    ]
+                },
+                "SerialNumber": {
+                    "description": "The serial number for this cable.",
+                    "longDescription": "This property shall contain the manufacturer-allocated number that identifies the cable.",
+                    "readonly": false,
+                    "type": [
+                        "string",
+                        "null"
+                    ]
+                },
+                "Status": {
+                    "$ref": "http://redfish.dmtf.org/schemas/v1/Resource.json#/definitions/Status",
+                    "description": "The status and health of the resource and its subordinate or dependent resources.",
+                    "longDescription": "This property shall contain any status or health properties of the resource."
+                },
+                "UpstreamConnectorTypes": {
+                    "description": "The connector types this cable supports.",
+                    "items": {
+                        "$ref": "#/definitions/ConnectorType"
+                    },
+                    "longDescription": "The property shall contain an array of connector types this cable supports.",
+                    "readonly": false,
+                    "type": "array"
+                },
+                "UpstreamName": {
+                    "description": "The identifier for the downstream resource.",
+                    "longDescription": "This property shall contain any identifier for an upstream resource.",
+                    "readonly": false,
+                    "type": [
+                        "string",
+                        "null"
+                    ]
+                },
+                "UserDescription": {
+                    "description": "The description of this cable.",
+                    "longDescription": "This property shall contain a user-defined description for this cable.",
+                    "readonly": false,
+                    "type": [
+                        "string",
+                        "null"
+                    ]
+                },
+                "Vendor": {
+                    "description": "The manufacturer of this cable.",
+                    "longDescription": "This property shall contain the name of the company that provides the final product that includes this cable.",
+                    "readonly": false,
+                    "type": [
+                        "string",
+                        "null"
+                    ]
+                }
+            },
+            "required": [
+                "@odata.id",
+                "@odata.type",
+                "Id",
+                "Name"
+            ],
+            "type": "object"
+        },
+        "CableClass": {
+            "enum": [
+                "Power",
+                "Network",
+                "Storage",
+                "Fan",
+                "PCIe",
+                "USB",
+                "Video",
+                "Fabric",
+                "Serial",
+                "General"
+            ],
+            "enumDescriptions": {
+                "Fabric": "This cable is used for connecting to a fabric.",
+                "Fan": "This cable is used for connecting to a fan system.",
+                "General": "This cable is used for providing general connectivity.",
+                "Network": "This cable is used for connecting to a networking system.",
+                "PCIe": "This cable is used for connecting to a PCIe endpoint.",
+                "Power": "This cable is used for connecting to a power system.",
+                "Serial": "This cable is used for connecting to a serial endpoint.",
+                "Storage": "This cable is used for connecting to a storage system.",
+                "USB": "This cable is used for connecting to a USB endpoint.",
+                "Video": "This cable is used for connecting to a video system."
+            },
+            "type": "string"
+        },
+        "CableStatus": {
+            "enum": [
+                "Normal",
+                "Degraded",
+                "Failed",
+                "Testing",
+                "Disabled",
+                "SetByService"
+            ],
+            "enumDescriptions": {
+                "Degraded": "The cable is degraded.",
+                "Disabled": "The cable is disabled.",
+                "Failed": "The cable has failed.",
+                "Normal": "The cable is operating normally.",
+                "SetByService": "The cable status is set by the service.",
+                "Testing": "The cable is under test."
+            },
+            "enumLongDescriptions": {
+                "Degraded": "This value shall indicate the cable is degraded.  The State property in Status shall contain the value `Enabled` and The Health property in Status shall contain the value `Warning`.",
+                "Disabled": "This value shall indicate the cable is disabled.  The State property in Status shall contain the value `Disabled`.",
+                "Failed": "This value shall indicate the cable has failed.  The State property in Status shall contain the value `Enabled` and The Health property in Status shall contain the value `Critical`.",
+                "Normal": "This value shall indicate the cable is operating normally.  The State property in Status shall contain the value `Enabled` and The Health property in Status shall contain the value `OK`.",
+                "SetByService": "This value shall indicate the status for the cable is not defined by the user.  If implemented, the service shall determine the value of the State and Health properties in Status.",
+                "Testing": "This value shall indicate the cable is under test.  The State property in Status shall contain the value `InTest`."
+            },
+            "type": "string"
+        },
+        "ConnectorType": {
+            "enum": [
+                "ACPower",
+                "DB9",
+                "DCPower",
+                "DisplayPort",
+                "HDMI",
+                "ICI",
+                "IPASS",
+                "PCIe",
+                "Proprietary",
+                "RJ45",
+                "SATA",
+                "SCSI",
+                "SlimSAS",
+                "SFP",
+                "SFPPlus",
+                "USBA",
+                "USBC",
+                "QSFP"
+            ],
+            "enumDescriptions": {
+                "ACPower": "This cable connects to a AC power connector.",
+                "DB9": "This cable connects to a DB9 connector.",
+                "DCPower": "This cable connects to a DC power connector.",
+                "DisplayPort": "This cable connects to a DisplayPort power connector.",
+                "HDMI": "This cable connects to an HDMI connector.",
+                "ICI": "This cable connects to an ICI connector.",
+                "IPASS": "This cable connects to an IPASS connector.",
+                "PCIe": "This cable connects to a PCIe connector.",
+                "Proprietary": "This cable connects to a proprietary connector.",
+                "QSFP": "This cable connects to a QSFP connector.",
+                "RJ45": "This cable connects to an RJ45 connector.",
+                "SATA": "This cable connects to a SATA connector.",
+                "SCSI": "This cable connects to a SCSI connector.",
+                "SFP": "This cable connects to a SFP connector.",
+                "SFPPlus": "This cable connects to a SFPPlus connector.",
+                "SlimSAS": "This cable connects to a SlimSAS connector.",
+                "USBA": "This cable connects to a USB-A connector.",
+                "USBC": "This cable connects to a USB-C connector."
+            },
+            "type": "string"
+        },
+        "Links": {
+            "additionalProperties": false,
+            "description": "The links to other resources that are related to this resource.",
+            "longDescription": "This Redfish Specification-described type shall contain links to resources that are related to but are not contained by, or subordinate to, this resource.",
+            "patternProperties": {
+                "^([a-zA-Z_][a-zA-Z0-9_]*)?@(odata|Redfish|Message)\\.[a-zA-Z_][a-zA-Z0-9_]*$": {
+                    "description": "This property shall specify a valid odata or Redfish property.",
+                    "type": [
+                        "array",
+                        "boolean",
+                        "integer",
+                        "number",
+                        "null",
+                        "object",
+                        "string"
+                    ]
+                }
+            },
+            "properties": {
+                "DownstreamChassis": {
+                    "description": "An array of links to the downstream chassis connected to this cable.",
+                    "items": {
+                        "$ref": "http://redfish.dmtf.org/schemas/v1/Chassis.json#/definitions/Chassis"
+                    },
+                    "longDescription": "This property shall contain an array of links to resources of type Chassis that represent the physical downstream containers connected to this cable.",
+                    "readonly": false,
+                    "type": "array"
+                },
+                "DownstreamChassis@odata.count": {
+                    "$ref": "http://redfish.dmtf.org/schemas/v1/odata-v4.json#/definitions/count"
+                },
+                "DownstreamPorts": {
+                    "description": "An array of links to the downstream ports connected to this cable.",
+                    "items": {
+                        "$ref": "http://redfish.dmtf.org/schemas/v1/Port.json#/definitions/Port"
+                    },
+                    "longDescription": "This property shall contain an array of links to resources of type Port that represent the physical downstream connections connected to this cable.",
+                    "readonly": false,
+                    "type": "array"
+                },
+                "DownstreamPorts@odata.count": {
+                    "$ref": "http://redfish.dmtf.org/schemas/v1/odata-v4.json#/definitions/count"
+                },
+                "DownstreamResources": {
+                    "description": "An array of links to the downstream resources connected to this cable.",
+                    "items": {
+                        "$ref": "http://redfish.dmtf.org/schemas/v1/Resource.json#/definitions/Resource"
+                    },
+                    "longDescription": "This property shall contain an array of links to resources that represent the physical downstream connections connected to this cable.  Even if the resource is already referenced in another property within Links, such as DownstreamPorts or DownstreamChassis, it shall also be referenced in this property.",
+                    "readonly": false,
+                    "type": "array"
+                },
+                "DownstreamResources@odata.count": {
+                    "$ref": "http://redfish.dmtf.org/schemas/v1/odata-v4.json#/definitions/count"
+                },
+                "Oem": {
+                    "$ref": "http://redfish.dmtf.org/schemas/v1/Resource.json#/definitions/Oem",
+                    "description": "The OEM extension property.",
+                    "longDescription": "This property shall contain the OEM extensions.  All values for properties contained in this object shall conform to the Redfish Specification-described requirements."
+                },
+                "UpstreamChassis": {
+                    "description": "An array of links to the upstream chassis connected to this cable.",
+                    "items": {
+                        "$ref": "http://redfish.dmtf.org/schemas/v1/Chassis.json#/definitions/Chassis"
+                    },
+                    "longDescription": "This property shall contain an array of links to resources of type Chassis that represent the physical upstream containers connected to this cable.",
+                    "readonly": false,
+                    "type": "array"
+                },
+                "UpstreamChassis@odata.count": {
+                    "$ref": "http://redfish.dmtf.org/schemas/v1/odata-v4.json#/definitions/count"
+                },
+                "UpstreamPorts": {
+                    "description": "An array of links to the upstream ports connected to this cable.",
+                    "items": {
+                        "$ref": "http://redfish.dmtf.org/schemas/v1/Port.json#/definitions/Port"
+                    },
+                    "longDescription": "This property shall contain an array of links to resources of type Port that represent the physical upstream connections connected to this cable.",
+                    "readonly": false,
+                    "type": "array"
+                },
+                "UpstreamPorts@odata.count": {
+                    "$ref": "http://redfish.dmtf.org/schemas/v1/odata-v4.json#/definitions/count"
+                },
+                "UpstreamResources": {
+                    "description": "An array of links to the upstream resources connected to this cable.",
+                    "items": {
+                        "$ref": "http://redfish.dmtf.org/schemas/v1/Resource.json#/definitions/Resource"
+                    },
+                    "longDescription": "This property shall contain an array of links to resources that represent the physical upstream connections connected to this cable.  Even if the resource is already referenced in another property within Links, such as UpstreamPorts or UpstreamChassis, it shall also be referenced in this property.",
+                    "readonly": false,
+                    "type": "array"
+                },
+                "UpstreamResources@odata.count": {
+                    "$ref": "http://redfish.dmtf.org/schemas/v1/odata-v4.json#/definitions/count"
+                }
+            },
+            "type": "object"
+        },
+        "OemActions": {
+            "additionalProperties": true,
+            "description": "The available OEM-specific actions for this resource.",
+            "longDescription": "This type shall contain the available OEM-specific actions for this resource.",
+            "patternProperties": {
+                "^([a-zA-Z_][a-zA-Z0-9_]*)?@(odata|Redfish|Message)\\.[a-zA-Z_][a-zA-Z0-9_]*$": {
+                    "description": "This property shall specify a valid odata or Redfish property.",
+                    "type": [
+                        "array",
+                        "boolean",
+                        "integer",
+                        "number",
+                        "null",
+                        "object",
+                        "string"
+                    ]
+                }
+            },
+            "properties": {},
+            "type": "object"
+        }
+    },
+    "owningEntity": "DMTF",
+    "release": "2021.2",
+    "title": "#Cable.v1_0_0.Cable"
+}

--- a/static/redfish/v1/JsonSchemas/Cable/index.json
+++ b/static/redfish/v1/JsonSchemas/Cable/index.json
@@ -1,0 +1,21 @@
+{
+    "@odata.context": "/redfish/v1/$metadata#JsonSchemaFile.JsonSchemaFile",
+    "@odata.id": "/redfish/v1/JsonSchemas/Cable",
+    "@odata.type": "#JsonSchemaFile.v1_0_2.JsonSchemaFile",
+    "Name": "Cable Schema File",
+    "Schema": "#Cable.Cable",
+    "Description": "Cable Schema File Location",
+    "Id": "Cable",
+    "Languages": [
+        "en"
+    ],
+    "Languages@odata.count": 1,
+    "Location": [
+        {
+            "Language": "en",
+            "PublicationUri": "http://redfish.dmtf.org/schemas/v1/Cable.json",
+            "Uri": "/redfish/v1/JsonSchemas/Cable/Cable.json"
+        }
+    ],
+    "Location@odata.count": 1
+}

--- a/static/redfish/v1/JsonSchemas/Circuit/Circuit.json
+++ b/static/redfish/v1/JsonSchemas/Circuit/Circuit.json
@@ -1,0 +1,1034 @@
+{
+    "$id": "http://redfish.dmtf.org/schemas/v1/Circuit.v1_3_0.json",
+    "$ref": "#/definitions/Circuit",
+    "$schema": "http://redfish.dmtf.org/schemas/v1/redfish-schema-v1.json",
+    "copyright": "Copyright 2014-2021 DMTF. For the full DMTF copyright policy, see http://www.dmtf.org/about/policies/copyright",
+    "definitions": {
+        "Actions": {
+            "additionalProperties": false,
+            "description": "The available actions for this resource.",
+            "longDescription": "This type shall contain the available actions for this resource.",
+            "patternProperties": {
+                "^([a-zA-Z_][a-zA-Z0-9_]*)?@(odata|Redfish|Message)\\.[a-zA-Z_][a-zA-Z0-9_]*$": {
+                    "description": "This property shall specify a valid odata or Redfish property.",
+                    "type": [
+                        "array",
+                        "boolean",
+                        "integer",
+                        "number",
+                        "null",
+                        "object",
+                        "string"
+                    ]
+                }
+            },
+            "properties": {
+                "#Circuit.BreakerControl": {
+                    "$ref": "#/definitions/BreakerControl"
+                },
+                "#Circuit.PowerControl": {
+                    "$ref": "#/definitions/PowerControl"
+                },
+                "#Circuit.ResetMetrics": {
+                    "$ref": "#/definitions/ResetMetrics"
+                },
+                "Oem": {
+                    "$ref": "#/definitions/OemActions",
+                    "description": "The available OEM-specific actions for this resource.",
+                    "longDescription": "This property shall contain the available OEM-specific actions for this resource."
+                }
+            },
+            "type": "object"
+        },
+        "BreakerControl": {
+            "additionalProperties": false,
+            "description": "This action attempts to reset the circuit breaker.",
+            "longDescription": "This action shall control the state of the circuit breaker or over-current protection device.",
+            "parameters": {
+                "PowerState": {
+                    "$ref": "http://redfish.dmtf.org/schemas/v1/Circuit.json#/definitions/PowerState",
+                    "description": "The desired power state of the circuit if the breaker is reset successfully.",
+                    "longDescription": "This parameter shall contain the desired power state of the circuit."
+                }
+            },
+            "patternProperties": {
+                "^([a-zA-Z_][a-zA-Z0-9_]*)?@(odata|Redfish|Message)\\.[a-zA-Z_][a-zA-Z0-9_]*$": {
+                    "description": "This property shall specify a valid odata or Redfish property.",
+                    "type": [
+                        "array",
+                        "boolean",
+                        "integer",
+                        "number",
+                        "null",
+                        "object",
+                        "string"
+                    ]
+                }
+            },
+            "properties": {
+                "target": {
+                    "description": "Link to invoke action",
+                    "format": "uri-reference",
+                    "type": "string"
+                },
+                "title": {
+                    "description": "Friendly action name",
+                    "type": "string"
+                }
+            },
+            "type": "object"
+        },
+        "Circuit": {
+            "additionalProperties": false,
+            "description": "This is the schema definition for an electrical circuit.",
+            "longDescription": "This resource shall be used to represent an electrical circuit for a Redfish implementation.",
+            "patternProperties": {
+                "^([a-zA-Z_][a-zA-Z0-9_]*)?@(odata|Redfish|Message)\\.[a-zA-Z_][a-zA-Z0-9_]*$": {
+                    "description": "This property shall specify a valid odata or Redfish property.",
+                    "type": [
+                        "array",
+                        "boolean",
+                        "integer",
+                        "number",
+                        "null",
+                        "object",
+                        "string"
+                    ]
+                }
+            },
+            "properties": {
+                "@odata.context": {
+                    "$ref": "http://redfish.dmtf.org/schemas/v1/odata-v4.json#/definitions/context"
+                },
+                "@odata.etag": {
+                    "$ref": "http://redfish.dmtf.org/schemas/v1/odata-v4.json#/definitions/etag"
+                },
+                "@odata.id": {
+                    "$ref": "http://redfish.dmtf.org/schemas/v1/odata-v4.json#/definitions/id"
+                },
+                "@odata.type": {
+                    "$ref": "http://redfish.dmtf.org/schemas/v1/odata-v4.json#/definitions/type"
+                },
+                "Actions": {
+                    "$ref": "#/definitions/Actions",
+                    "description": "The available actions for this resource.",
+                    "longDescription": "This property shall contain the available actions for this resource."
+                },
+                "BreakerState": {
+                    "anyOf": [
+                        {
+                            "$ref": "http://redfish.dmtf.org/schemas/v1/Circuit.json#/definitions/BreakerStates"
+                        },
+                        {
+                            "type": "null"
+                        }
+                    ],
+                    "description": "The state of the over current protection device.",
+                    "longDescription": "This property shall contain the state of the over current protection device.",
+                    "readonly": true
+                },
+                "CircuitType": {
+                    "anyOf": [
+                        {
+                            "$ref": "#/definitions/CircuitType"
+                        },
+                        {
+                            "type": "null"
+                        }
+                    ],
+                    "description": "The type of circuit.",
+                    "longDescription": "This property shall contain the type of circuit.",
+                    "readonly": true
+                },
+                "CriticalCircuit": {
+                    "description": "Designates if this is a critical circuit.",
+                    "longDescription": "This property shall indicate whether the circuit is designated as a critical circuit, and therefore is excluded from autonomous logic that could affect the state of the circuit.  The value shall be `true` if the circuit is deemed critical, and `false` if the circuit is not critical.",
+                    "readonly": false,
+                    "type": [
+                        "boolean",
+                        "null"
+                    ]
+                },
+                "CurrentAmps": {
+                    "anyOf": [
+                        {
+                            "$ref": "http://redfish.dmtf.org/schemas/v1/Sensor.json#/definitions/SensorCurrentExcerpt"
+                        },
+                        {
+                            "type": "null"
+                        }
+                    ],
+                    "description": "The current reading for this single phase circuit.",
+                    "excerptCopy": "SensorCurrentExcerpt",
+                    "longDescription": "This property shall contain the current, measured in Amperes, for this single phase circuit.  This property shall not appear in resource instances representing poly-phase circuits."
+                },
+                "Description": {
+                    "anyOf": [
+                        {
+                            "$ref": "http://redfish.dmtf.org/schemas/v1/Resource.json#/definitions/Description"
+                        },
+                        {
+                            "type": "null"
+                        }
+                    ],
+                    "readonly": true
+                },
+                "ElectricalContext": {
+                    "anyOf": [
+                        {
+                            "$ref": "http://redfish.dmtf.org/schemas/v1/Sensor.json#/definitions/ElectricalContext"
+                        },
+                        {
+                            "type": "null"
+                        }
+                    ],
+                    "description": "The combination of current-carrying conductors.",
+                    "longDescription": "This property shall contain the combination of current-carrying conductors that distribute power.",
+                    "readonly": true
+                },
+                "EnergykWh": {
+                    "anyOf": [
+                        {
+                            "$ref": "http://redfish.dmtf.org/schemas/v1/Sensor.json#/definitions/SensorEnergykWhExcerpt"
+                        },
+                        {
+                            "type": "null"
+                        }
+                    ],
+                    "description": "The energy reading for this circuit.",
+                    "excerptCopy": "SensorEnergykWhExcerpt",
+                    "longDescription": "This property shall contain the total energy, measured in kilowatt-hours (kW.h), for this circuit, that represents the `Total` ElectricalContext sensor when multiple energy sensors exist for this circuit."
+                },
+                "FrequencyHz": {
+                    "anyOf": [
+                        {
+                            "$ref": "http://redfish.dmtf.org/schemas/v1/Sensor.json#/definitions/SensorExcerpt"
+                        },
+                        {
+                            "type": "null"
+                        }
+                    ],
+                    "description": "The frequency reading for this circuit.",
+                    "excerptCopy": "SensorExcerpt",
+                    "longDescription": "This property shall contain the frequency sensor for this circuit."
+                },
+                "Id": {
+                    "$ref": "http://redfish.dmtf.org/schemas/v1/Resource.json#/definitions/Id",
+                    "readonly": true
+                },
+                "IndicatorLED": {
+                    "anyOf": [
+                        {
+                            "$ref": "http://redfish.dmtf.org/schemas/v1/Resource.json#/definitions/IndicatorLED"
+                        },
+                        {
+                            "type": "null"
+                        }
+                    ],
+                    "deprecated": "This property has been deprecated in favor of the LocationIndicatorActive property.",
+                    "description": "The state of the indicator LED, which identifies the circuit.",
+                    "longDescription": "This property shall contain the indicator light state for the indicator light associated with this circuit.",
+                    "readonly": false,
+                    "versionDeprecated": "v1_1_0"
+                },
+                "Links": {
+                    "$ref": "#/definitions/Links",
+                    "description": "The links to other resources that are related to this resource.",
+                    "longDescription": "This property shall contain links to resources that are related to but are not contained by, or subordinate to, this resource."
+                },
+                "LocationIndicatorActive": {
+                    "description": "An indicator allowing an operator to physically locate this resource.",
+                    "longDescription": "This property shall contain the state of the indicator used to physically identify or locate this resource.  A write to this property shall update the value of IndicatorLED in this resource, if supported, to reflect the implementation of the locating function.",
+                    "readonly": false,
+                    "type": [
+                        "boolean",
+                        "null"
+                    ],
+                    "versionAdded": "v1_1_0"
+                },
+                "Name": {
+                    "$ref": "http://redfish.dmtf.org/schemas/v1/Resource.json#/definitions/Name",
+                    "readonly": true
+                },
+                "NominalVoltage": {
+                    "anyOf": [
+                        {
+                            "$ref": "http://redfish.dmtf.org/schemas/v1/Circuit.json#/definitions/NominalVoltageType"
+                        },
+                        {
+                            "type": "null"
+                        }
+                    ],
+                    "description": "The nominal voltage for this circuit.",
+                    "longDescription": "This property shall contain the nominal voltage for this circuit, in Volts.",
+                    "readonly": true
+                },
+                "Oem": {
+                    "$ref": "http://redfish.dmtf.org/schemas/v1/Resource.json#/definitions/Oem",
+                    "description": "The OEM extension property.",
+                    "longDescription": "This property shall contain the OEM extensions.  All values for properties that this object contains shall conform to the Redfish Specification-described requirements."
+                },
+                "PhaseWiringType": {
+                    "anyOf": [
+                        {
+                            "$ref": "http://redfish.dmtf.org/schemas/v1/Circuit.json#/definitions/PhaseWiringType"
+                        },
+                        {
+                            "type": "null"
+                        }
+                    ],
+                    "description": "The number of ungrounded current-carrying conductors (phases) and the total number of conductors (wires).",
+                    "longDescription": "This property shall contain the number of ungrounded current-carrying conductors (phases) and the total number of conductors (wires).",
+                    "readonly": true
+                },
+                "PlugType": {
+                    "anyOf": [
+                        {
+                            "$ref": "http://redfish.dmtf.org/schemas/v1/Circuit.json#/definitions/PlugType"
+                        },
+                        {
+                            "type": "null"
+                        }
+                    ],
+                    "description": "The type of plug according to NEMA, IEC, or regional standards.",
+                    "longDescription": "This property shall contain the type of physical plug used for this circuit, as defined by IEC, NEMA, or regional standard.",
+                    "readonly": true
+                },
+                "PolyPhaseCurrentAmps": {
+                    "anyOf": [
+                        {
+                            "$ref": "#/definitions/CurrentSensors"
+                        },
+                        {
+                            "type": "null"
+                        }
+                    ],
+                    "description": "The current readings for this circuit.",
+                    "longDescription": "This property shall contain the current sensor(s) for this circuit.  For single phase circuits this property shall contain a duplicate copy of the current sensor referenced in the CurrentSensor property, if present.  For poly-phase circuits this property should contain multiple current sensor readings used to fully describe the circuit."
+                },
+                "PolyPhaseEnergykWh": {
+                    "anyOf": [
+                        {
+                            "$ref": "#/definitions/EnergySensors"
+                        },
+                        {
+                            "type": "null"
+                        }
+                    ],
+                    "description": "The energy readings for this circuit.",
+                    "longDescription": "This property shall contain the energy sensor(s) for this circuit.  For single phase circuits this property shall contain a duplicate copy of the energy sensor referenced in the EnergySensor property, if present.  For poly-phase circuits this property should contain multiple energy sensor readings used to fully describe the circuit."
+                },
+                "PolyPhasePowerWatts": {
+                    "anyOf": [
+                        {
+                            "$ref": "#/definitions/PowerSensors"
+                        },
+                        {
+                            "type": "null"
+                        }
+                    ],
+                    "description": "The power readings for this circuit.",
+                    "longDescription": "This property shall contain the power sensor(s) for this circuit.  For single phase circuits this property shall contain a duplicate copy of the power sensor referenced in the PowerSensor property, if present.  For poly-phase circuits this property should contain multiple power sensor readings used to fully describe the circuit."
+                },
+                "PolyPhaseVoltage": {
+                    "anyOf": [
+                        {
+                            "$ref": "#/definitions/VoltageSensors"
+                        },
+                        {
+                            "type": "null"
+                        }
+                    ],
+                    "description": "The voltage readings for this circuit.",
+                    "longDescription": "This property shall contain the voltage sensor(s) for this circuit.  For single phase circuits this property shall contain a duplicate copy of the voltage sensor referenced in the VoltageSensor property, if present.  For poly-phase circuits this property should contain multiple voltage sensor readings used to fully describe the circuit."
+                },
+                "PowerCycleDelaySeconds": {
+                    "description": "The number of seconds to delay power on after a PowerControl action to cycle power.  Zero seconds indicates no delay.",
+                    "longDescription": "This property shall contain the number of seconds to delay power on after a PowerControl action to cycle power.  The value `0` shall indicate no delay to power on.",
+                    "readonly": false,
+                    "type": [
+                        "number",
+                        "null"
+                    ]
+                },
+                "PowerEnabled": {
+                    "description": "Indicates if the circuit can be powered.",
+                    "longDescription": "This property shall indicate the power enable state of the circuit.  The value `true` shall indicate that the circuit can be powered on, and `false` shall indicate that the circuit cannot be powered.",
+                    "readonly": true,
+                    "type": [
+                        "boolean",
+                        "null"
+                    ]
+                },
+                "PowerLoadPercent": {
+                    "anyOf": [
+                        {
+                            "$ref": "http://redfish.dmtf.org/schemas/v1/Sensor.json#/definitions/SensorExcerpt"
+                        },
+                        {
+                            "type": "null"
+                        }
+                    ],
+                    "description": "The power load (%) for this circuit.",
+                    "excerptCopy": "SensorExcerpt",
+                    "longDescription": "This property shall contain the power load, measured in percent, for this circuit, that represents the `Total` ElectricalContext for this circuit.",
+                    "versionAdded": "v1_3_0"
+                },
+                "PowerOffDelaySeconds": {
+                    "description": "The number of seconds to delay power off after a PowerControl action.  Zero seconds indicates no delay to power off.",
+                    "longDescription": "This property shall contain the number of seconds to delay power off after a PowerControl action.  The value `0` shall indicate no delay to power off.",
+                    "readonly": false,
+                    "type": [
+                        "number",
+                        "null"
+                    ]
+                },
+                "PowerOnDelaySeconds": {
+                    "description": "The number of seconds to delay power up after a power cycle or a PowerControl action.  Zero seconds indicates no delay to power up.",
+                    "longDescription": "This property shall contain the number of seconds to delay power up after a power cycle or a PowerControl action.  The value `0` shall indicate no delay to power up.",
+                    "readonly": false,
+                    "type": [
+                        "number",
+                        "null"
+                    ]
+                },
+                "PowerRestoreDelaySeconds": {
+                    "description": "The number of seconds to delay power on after power has been restored.  Zero seconds indicates no delay.",
+                    "longDescription": "This property shall contain the number of seconds to delay power on after a power fault.  The value `0` shall indicate no delay to power on.",
+                    "readonly": false,
+                    "type": [
+                        "number",
+                        "null"
+                    ]
+                },
+                "PowerRestorePolicy": {
+                    "$ref": "http://redfish.dmtf.org/schemas/v1/Circuit.json#/definitions/PowerRestorePolicyTypes",
+                    "description": "The desired power state of the circuit when power is restored after a power loss.",
+                    "longDescription": "This property shall contain the desired PowerState of the circuit when power is applied.  The value `LastState` shall return the circuit to the PowerState it was in when power was lost.",
+                    "readonly": false
+                },
+                "PowerState": {
+                    "anyOf": [
+                        {
+                            "$ref": "http://redfish.dmtf.org/schemas/v1/Resource.json#/definitions/PowerState"
+                        },
+                        {
+                            "type": "null"
+                        }
+                    ],
+                    "description": "The power state of the circuit.",
+                    "longDescription": "This property shall contain the power state of the circuit.",
+                    "readonly": true
+                },
+                "PowerWatts": {
+                    "anyOf": [
+                        {
+                            "$ref": "http://redfish.dmtf.org/schemas/v1/Sensor.json#/definitions/SensorPowerExcerpt"
+                        },
+                        {
+                            "type": "null"
+                        }
+                    ],
+                    "description": "The power reading for this circuit.",
+                    "excerptCopy": "SensorPowerExcerpt",
+                    "longDescription": "This property shall contain the total power, measured in Watts, for this circuit, that represents the `Total` ElectricalContext sensor when multiple power sensors exist for this circuit."
+                },
+                "RatedCurrentAmps": {
+                    "description": "The rated maximum current allowed for this circuit.",
+                    "longDescription": "This property shall contain the rated maximum current for this circuit, in Amps, after any required de-rating, due to safety agency or other regulatory requirements, has been applied.",
+                    "minimum": 0,
+                    "readonly": true,
+                    "type": [
+                        "number",
+                        "null"
+                    ],
+                    "units": "A"
+                },
+                "Status": {
+                    "$ref": "http://redfish.dmtf.org/schemas/v1/Resource.json#/definitions/Status",
+                    "description": "The status and health of the resource and its subordinate or dependent resources.",
+                    "longDescription": "This property shall contain any status or health properties of the resource."
+                },
+                "Voltage": {
+                    "anyOf": [
+                        {
+                            "$ref": "http://redfish.dmtf.org/schemas/v1/Sensor.json#/definitions/SensorVoltageExcerpt"
+                        },
+                        {
+                            "type": "null"
+                        }
+                    ],
+                    "description": "The voltage reading for this single phase circuit.",
+                    "excerptCopy": "SensorVoltageExcerpt",
+                    "longDescription": "This property shall contain the voltage, measured in Volts, for this single phase circuit.  This property shall not appear in resource instances representing poly-phase circuits."
+                },
+                "VoltageType": {
+                    "anyOf": [
+                        {
+                            "$ref": "#/definitions/VoltageType"
+                        },
+                        {
+                            "type": "null"
+                        }
+                    ],
+                    "description": "The type of voltage applied to the circuit.",
+                    "longDescription": "This property shall contain the type of voltage applied to the circuit.",
+                    "readonly": true
+                }
+            },
+            "required": [
+                "@odata.id",
+                "@odata.type",
+                "Id",
+                "Name"
+            ],
+            "type": "object"
+        },
+        "CircuitType": {
+            "enum": [
+                "Mains",
+                "Branch",
+                "Subfeed",
+                "Feeder"
+            ],
+            "enumDescriptions": {
+                "Branch": "A branch (output) circuit.",
+                "Feeder": "A feeder (output) circuit.",
+                "Mains": "A mains input or utility circuit.",
+                "Subfeed": "A subfeed (output) circuit."
+            },
+            "type": "string"
+        },
+        "CurrentSensors": {
+            "additionalProperties": false,
+            "description": "The current sensors for this circuit.",
+            "longDescription": "This type shall contain properties that describe current sensor readings for a circuit.",
+            "patternProperties": {
+                "^([a-zA-Z_][a-zA-Z0-9_]*)?@(odata|Redfish|Message)\\.[a-zA-Z_][a-zA-Z0-9_]*$": {
+                    "description": "This property shall specify a valid odata or Redfish property.",
+                    "type": [
+                        "array",
+                        "boolean",
+                        "integer",
+                        "number",
+                        "null",
+                        "object",
+                        "string"
+                    ]
+                }
+            },
+            "properties": {
+                "Line1": {
+                    "anyOf": [
+                        {
+                            "$ref": "http://redfish.dmtf.org/schemas/v1/Sensor.json#/definitions/SensorCurrentExcerpt"
+                        },
+                        {
+                            "type": "null"
+                        }
+                    ],
+                    "description": "Line 1 current sensor.",
+                    "excerptCopy": "SensorCurrentExcerpt",
+                    "longDescription": "This property shall contain a Sensor excerpt of type Current that measures current for L1.  This property shall not be present if the circuit does not include an L1 measurement."
+                },
+                "Line2": {
+                    "anyOf": [
+                        {
+                            "$ref": "http://redfish.dmtf.org/schemas/v1/Sensor.json#/definitions/SensorCurrentExcerpt"
+                        },
+                        {
+                            "type": "null"
+                        }
+                    ],
+                    "description": "Line 2 current sensor.",
+                    "excerptCopy": "SensorCurrentExcerpt",
+                    "longDescription": "This property shall contain a Sensor excerpt of type Current that measures current for L2.  This property shall not be present if the circuit does not include an L2 measurement."
+                },
+                "Line3": {
+                    "anyOf": [
+                        {
+                            "$ref": "http://redfish.dmtf.org/schemas/v1/Sensor.json#/definitions/SensorCurrentExcerpt"
+                        },
+                        {
+                            "type": "null"
+                        }
+                    ],
+                    "description": "Line 3 current sensor.",
+                    "excerptCopy": "SensorCurrentExcerpt",
+                    "longDescription": "This property shall contain a Sensor excerpt of type Current that measures current for L3.  This property shall not be present if the circuit does not include an L3 measurement."
+                },
+                "Neutral": {
+                    "anyOf": [
+                        {
+                            "$ref": "http://redfish.dmtf.org/schemas/v1/Sensor.json#/definitions/SensorCurrentExcerpt"
+                        },
+                        {
+                            "type": "null"
+                        }
+                    ],
+                    "description": "Neutral line current sensor.",
+                    "excerptCopy": "SensorCurrentExcerpt",
+                    "longDescription": "This property shall contain a Sensor excerpt of type Current that measures current for the Neutral line.  This property shall not be present if the circuit does not include a Neutral measurement."
+                }
+            },
+            "type": "object"
+        },
+        "EnergySensors": {
+            "additionalProperties": false,
+            "description": "The energy readings for this circuit.",
+            "longDescription": "This type shall contain properties that describe energy sensor readings for a circuit.",
+            "patternProperties": {
+                "^([a-zA-Z_][a-zA-Z0-9_]*)?@(odata|Redfish|Message)\\.[a-zA-Z_][a-zA-Z0-9_]*$": {
+                    "description": "This property shall specify a valid odata or Redfish property.",
+                    "type": [
+                        "array",
+                        "boolean",
+                        "integer",
+                        "number",
+                        "null",
+                        "object",
+                        "string"
+                    ]
+                }
+            },
+            "properties": {
+                "Line1ToLine2": {
+                    "anyOf": [
+                        {
+                            "$ref": "http://redfish.dmtf.org/schemas/v1/Sensor.json#/definitions/SensorEnergykWhExcerpt"
+                        },
+                        {
+                            "type": "null"
+                        }
+                    ],
+                    "description": "The Line 1 to Line 2 energy reading for this circuit.",
+                    "excerptCopy": "SensorEnergykWhExcerpt",
+                    "longDescription": "This property shall contain a Sensor excerpt of type EnergykWh that measures energy between L1 and L2.  This property shall not be present if the circuit does not include an L1-L2 measurement."
+                },
+                "Line1ToNeutral": {
+                    "anyOf": [
+                        {
+                            "$ref": "http://redfish.dmtf.org/schemas/v1/Sensor.json#/definitions/SensorEnergykWhExcerpt"
+                        },
+                        {
+                            "type": "null"
+                        }
+                    ],
+                    "description": "The Line 1 to Neutral energy reading for this circuit.",
+                    "excerptCopy": "SensorEnergykWhExcerpt",
+                    "longDescription": "This property shall contain a Sensor excerpt of type EnergykWh that measures energy between L1 and Neutral.  This property shall not be present if the circuit does not include an L1-Neutral measurement."
+                },
+                "Line2ToLine3": {
+                    "anyOf": [
+                        {
+                            "$ref": "http://redfish.dmtf.org/schemas/v1/Sensor.json#/definitions/SensorEnergykWhExcerpt"
+                        },
+                        {
+                            "type": "null"
+                        }
+                    ],
+                    "description": "The Line 2 to Line 3 energy reading for this circuit.",
+                    "excerptCopy": "SensorEnergykWhExcerpt",
+                    "longDescription": "This property shall contain a Sensor excerpt of type EnergykWh that measures energy between L2 and L3.  This property shall not be present if the circuit does not include an L2-L3 measurement."
+                },
+                "Line2ToNeutral": {
+                    "anyOf": [
+                        {
+                            "$ref": "http://redfish.dmtf.org/schemas/v1/Sensor.json#/definitions/SensorEnergykWhExcerpt"
+                        },
+                        {
+                            "type": "null"
+                        }
+                    ],
+                    "description": "The Line 2 to Neutral energy reading for this circuit.",
+                    "excerptCopy": "SensorEnergykWhExcerpt",
+                    "longDescription": "This property shall contain a Sensor excerpt of type EnergykWh that measures energy between L2 and Neutral.  This property shall not be present if the circuit does not include an L2-Neutral measurement."
+                },
+                "Line3ToLine1": {
+                    "anyOf": [
+                        {
+                            "$ref": "http://redfish.dmtf.org/schemas/v1/Sensor.json#/definitions/SensorEnergykWhExcerpt"
+                        },
+                        {
+                            "type": "null"
+                        }
+                    ],
+                    "description": "The Line 3 to Line 1 energy reading for this circuit.",
+                    "excerptCopy": "SensorEnergykWhExcerpt",
+                    "longDescription": "This property shall contain a Sensor excerpt of type EnergykWh that measures energy between L3 and L1.  This property shall not be present if the circuit does not include an L3-L1 measurement."
+                },
+                "Line3ToNeutral": {
+                    "anyOf": [
+                        {
+                            "$ref": "http://redfish.dmtf.org/schemas/v1/Sensor.json#/definitions/SensorEnergykWhExcerpt"
+                        },
+                        {
+                            "type": "null"
+                        }
+                    ],
+                    "description": "The Line 3 to Neutral energy reading for this circuit.",
+                    "excerptCopy": "SensorEnergykWhExcerpt",
+                    "longDescription": "This property shall contain a Sensor excerpt of type EnergykWh that measures energy between L3 and Neutral.  This property shall not be present if the circuit does not include an L3-Neutral measurement."
+                }
+            },
+            "type": "object"
+        },
+        "Links": {
+            "additionalProperties": false,
+            "description": "The links to other resources that are related to this resource.",
+            "longDescription": "This Redfish Specification-described type shall contain links to resources that are related to but are not contained by, or subordinate to, this resource.",
+            "patternProperties": {
+                "^([a-zA-Z_][a-zA-Z0-9_]*)?@(odata|Redfish|Message)\\.[a-zA-Z_][a-zA-Z0-9_]*$": {
+                    "description": "This property shall specify a valid odata or Redfish property.",
+                    "type": [
+                        "array",
+                        "boolean",
+                        "integer",
+                        "number",
+                        "null",
+                        "object",
+                        "string"
+                    ]
+                }
+            },
+            "properties": {
+                "BranchCircuit": {
+                    "anyOf": [
+                        {
+                            "$ref": "http://redfish.dmtf.org/schemas/v1/Circuit.json#/definitions/Circuit"
+                        },
+                        {
+                            "type": "null"
+                        }
+                    ],
+                    "description": "A reference to the branch circuit related to this circuit.",
+                    "longDescription": "This property shall contain a link to a resource of type Circuit that represents the branch circuit associated with this circuit.",
+                    "readonly": true
+                },
+                "Oem": {
+                    "$ref": "http://redfish.dmtf.org/schemas/v1/Resource.json#/definitions/Oem",
+                    "description": "The OEM extension property.",
+                    "longDescription": "This property shall contain the OEM extensions.  All values for properties contained in this object shall conform to the Redfish Specification-described requirements."
+                },
+                "Outlets": {
+                    "description": "An array of references to the outlets contained by this circuit.",
+                    "items": {
+                        "$ref": "http://redfish.dmtf.org/schemas/v1/Outlet.json#/definitions/Outlet"
+                    },
+                    "longDescription": "This property shall contain an array of links to resources of type Outlet that represent the outlets associated with this circuit.",
+                    "readonly": true,
+                    "type": "array"
+                },
+                "Outlets@odata.count": {
+                    "$ref": "http://redfish.dmtf.org/schemas/v1/odata-v4.json#/definitions/count"
+                }
+            },
+            "type": "object"
+        },
+        "OemActions": {
+            "additionalProperties": true,
+            "description": "The available OEM-specific actions for this resource.",
+            "longDescription": "This type shall contain the available OEM-specific actions for this resource.",
+            "patternProperties": {
+                "^([a-zA-Z_][a-zA-Z0-9_]*)?@(odata|Redfish|Message)\\.[a-zA-Z_][a-zA-Z0-9_]*$": {
+                    "description": "This property shall specify a valid odata or Redfish property.",
+                    "type": [
+                        "array",
+                        "boolean",
+                        "integer",
+                        "number",
+                        "null",
+                        "object",
+                        "string"
+                    ]
+                }
+            },
+            "properties": {},
+            "type": "object"
+        },
+        "PowerControl": {
+            "additionalProperties": false,
+            "description": "This action turns the circuit on or off.",
+            "longDescription": "This action shall control the power state of the circuit.",
+            "parameters": {
+                "PowerState": {
+                    "$ref": "http://redfish.dmtf.org/schemas/v1/Resource.json#/definitions/PowerState",
+                    "description": "The desired power state of the circuit.",
+                    "longDescription": "This parameter shall contain the desired power state of the circuit."
+                }
+            },
+            "patternProperties": {
+                "^([a-zA-Z_][a-zA-Z0-9_]*)?@(odata|Redfish|Message)\\.[a-zA-Z_][a-zA-Z0-9_]*$": {
+                    "description": "This property shall specify a valid odata or Redfish property.",
+                    "type": [
+                        "array",
+                        "boolean",
+                        "integer",
+                        "number",
+                        "null",
+                        "object",
+                        "string"
+                    ]
+                }
+            },
+            "properties": {
+                "target": {
+                    "description": "Link to invoke action",
+                    "format": "uri-reference",
+                    "type": "string"
+                },
+                "title": {
+                    "description": "Friendly action name",
+                    "type": "string"
+                }
+            },
+            "type": "object"
+        },
+        "PowerSensors": {
+            "additionalProperties": false,
+            "description": "This property contains the power sensors.",
+            "longDescription": "This type shall contain properties that describe power sensor readings for a circuit.",
+            "patternProperties": {
+                "^([a-zA-Z_][a-zA-Z0-9_]*)?@(odata|Redfish|Message)\\.[a-zA-Z_][a-zA-Z0-9_]*$": {
+                    "description": "This property shall specify a valid odata or Redfish property.",
+                    "type": [
+                        "array",
+                        "boolean",
+                        "integer",
+                        "number",
+                        "null",
+                        "object",
+                        "string"
+                    ]
+                }
+            },
+            "properties": {
+                "Line1ToLine2": {
+                    "anyOf": [
+                        {
+                            "$ref": "http://redfish.dmtf.org/schemas/v1/Sensor.json#/definitions/SensorPowerExcerpt"
+                        },
+                        {
+                            "type": "null"
+                        }
+                    ],
+                    "description": "The Line 1 to Line 2 power reading for this circuit.",
+                    "excerptCopy": "SensorPowerExcerpt",
+                    "longDescription": "This property shall contain a Sensor excerpt of type Power that measures power between L1 and L2.  This property shall not be present if the circuit does not include an L1-L2 measurement."
+                },
+                "Line1ToNeutral": {
+                    "anyOf": [
+                        {
+                            "$ref": "http://redfish.dmtf.org/schemas/v1/Sensor.json#/definitions/SensorPowerExcerpt"
+                        },
+                        {
+                            "type": "null"
+                        }
+                    ],
+                    "description": "The Line 1 to Neutral power reading for this circuit.",
+                    "excerptCopy": "SensorPowerExcerpt",
+                    "longDescription": "This property shall contain a Sensor excerpt of type Power that measures power between L1 and Neutral.  This property shall not be present if the circuit does not include an L1-Neutral measurement."
+                },
+                "Line2ToLine3": {
+                    "anyOf": [
+                        {
+                            "$ref": "http://redfish.dmtf.org/schemas/v1/Sensor.json#/definitions/SensorPowerExcerpt"
+                        },
+                        {
+                            "type": "null"
+                        }
+                    ],
+                    "description": "The Line 2 to Line 3 power reading for this circuit.",
+                    "excerptCopy": "SensorPowerExcerpt",
+                    "longDescription": "This property shall contain a sensor excerpt of type Power that measures power between L2 and L3.  This property shall not be present if the circuit does not include an L2-L3 measurement."
+                },
+                "Line2ToNeutral": {
+                    "anyOf": [
+                        {
+                            "$ref": "http://redfish.dmtf.org/schemas/v1/Sensor.json#/definitions/SensorPowerExcerpt"
+                        },
+                        {
+                            "type": "null"
+                        }
+                    ],
+                    "description": "The Line 2 to Neutral power reading for this circuit.",
+                    "excerptCopy": "SensorPowerExcerpt",
+                    "longDescription": "This property shall contain a Sensor excerpt of type Power that measures power between L2 and Neutral.  This property shall not be present if the circuit does not include an L2-Neutral measurement."
+                },
+                "Line3ToLine1": {
+                    "anyOf": [
+                        {
+                            "$ref": "http://redfish.dmtf.org/schemas/v1/Sensor.json#/definitions/SensorPowerExcerpt"
+                        },
+                        {
+                            "type": "null"
+                        }
+                    ],
+                    "description": "The Line 3 to Line 1 power reading for this circuit.",
+                    "excerptCopy": "SensorPowerExcerpt",
+                    "longDescription": "This property shall contain a Sensor excerpt of type Power that measures power between L3 and L1.  This property shall not be present if the circuit does not include an L3-L1 measurement."
+                },
+                "Line3ToNeutral": {
+                    "anyOf": [
+                        {
+                            "$ref": "http://redfish.dmtf.org/schemas/v1/Sensor.json#/definitions/SensorPowerExcerpt"
+                        },
+                        {
+                            "type": "null"
+                        }
+                    ],
+                    "description": "The Line 3 to Neutral power reading for this circuit.",
+                    "excerptCopy": "SensorPowerExcerpt",
+                    "longDescription": "This property shall contain a Sensor excerpt of type Power that measures power between L3 and Neutral.  This property shall not be present if the circuit does not include an L3-Neutral measurement."
+                }
+            },
+            "type": "object"
+        },
+        "ResetMetrics": {
+            "additionalProperties": false,
+            "description": "This action resets metrics related to this circuit.",
+            "longDescription": "This action shall reset any time intervals or counted values for this circuit.",
+            "parameters": {},
+            "patternProperties": {
+                "^([a-zA-Z_][a-zA-Z0-9_]*)?@(odata|Redfish|Message)\\.[a-zA-Z_][a-zA-Z0-9_]*$": {
+                    "description": "This property shall specify a valid odata or Redfish property.",
+                    "type": [
+                        "array",
+                        "boolean",
+                        "integer",
+                        "number",
+                        "null",
+                        "object",
+                        "string"
+                    ]
+                }
+            },
+            "properties": {
+                "target": {
+                    "description": "Link to invoke action",
+                    "format": "uri-reference",
+                    "type": "string"
+                },
+                "title": {
+                    "description": "Friendly action name",
+                    "type": "string"
+                }
+            },
+            "type": "object"
+        },
+        "VoltageSensors": {
+            "additionalProperties": false,
+            "description": "The voltage readings for this circuit.",
+            "longDescription": "This type shall contain properties that describe voltage sensor readings for a circuit.",
+            "patternProperties": {
+                "^([a-zA-Z_][a-zA-Z0-9_]*)?@(odata|Redfish|Message)\\.[a-zA-Z_][a-zA-Z0-9_]*$": {
+                    "description": "This property shall specify a valid odata or Redfish property.",
+                    "type": [
+                        "array",
+                        "boolean",
+                        "integer",
+                        "number",
+                        "null",
+                        "object",
+                        "string"
+                    ]
+                }
+            },
+            "properties": {
+                "Line1ToLine2": {
+                    "anyOf": [
+                        {
+                            "$ref": "http://redfish.dmtf.org/schemas/v1/Sensor.json#/definitions/SensorVoltageExcerpt"
+                        },
+                        {
+                            "type": "null"
+                        }
+                    ],
+                    "description": "The Line 1 to Line 2 voltage reading for this circuit.",
+                    "excerptCopy": "SensorVoltageExcerpt",
+                    "longDescription": "This property shall contain a Sensor excerpt of type Voltage that measures voltage between L1 and L2.  This property shall not be present if the circuit does not include an L1-L2 measurement."
+                },
+                "Line1ToNeutral": {
+                    "anyOf": [
+                        {
+                            "$ref": "http://redfish.dmtf.org/schemas/v1/Sensor.json#/definitions/SensorVoltageExcerpt"
+                        },
+                        {
+                            "type": "null"
+                        }
+                    ],
+                    "description": "The Line 1 to Neutral voltage reading for this circuit.",
+                    "excerptCopy": "SensorVoltageExcerpt",
+                    "longDescription": "This property shall contain a Sensor excerpt of type Voltage that measures voltage between L1 and Neutral.  This property shall not be present if the circuit does not include an L1-Neutral measurement."
+                },
+                "Line2ToLine3": {
+                    "anyOf": [
+                        {
+                            "$ref": "http://redfish.dmtf.org/schemas/v1/Sensor.json#/definitions/SensorVoltageExcerpt"
+                        },
+                        {
+                            "type": "null"
+                        }
+                    ],
+                    "description": "The Line 2 to Line 3 voltage reading for this circuit.",
+                    "excerptCopy": "SensorVoltageExcerpt",
+                    "longDescription": "This property shall contain a Sensor excerpt of type Voltage that measures voltage between L2 and L3.  This property shall not be present if the circuit does not include an L2-L3 measurement."
+                },
+                "Line2ToNeutral": {
+                    "anyOf": [
+                        {
+                            "$ref": "http://redfish.dmtf.org/schemas/v1/Sensor.json#/definitions/SensorVoltageExcerpt"
+                        },
+                        {
+                            "type": "null"
+                        }
+                    ],
+                    "description": "The Line 2 to Neutral voltage reading for this circuit.",
+                    "excerptCopy": "SensorVoltageExcerpt",
+                    "longDescription": "This property shall contain a Sensor excerpt of type Voltage that measures voltage between L2 and Neutral.  This property shall not be present if the circuit does not include an L2-Neutral measurement."
+                },
+                "Line3ToLine1": {
+                    "anyOf": [
+                        {
+                            "$ref": "http://redfish.dmtf.org/schemas/v1/Sensor.json#/definitions/SensorVoltageExcerpt"
+                        },
+                        {
+                            "type": "null"
+                        }
+                    ],
+                    "description": "The Line 3 to Line 1 voltage reading for this circuit.",
+                    "excerptCopy": "SensorVoltageExcerpt",
+                    "longDescription": "This property shall contain a Sensor excerpt of type Voltage that measures voltage between L3 and L1.  This property shall not be present if the circuit does not include an L3-L1 measurement."
+                },
+                "Line3ToNeutral": {
+                    "anyOf": [
+                        {
+                            "$ref": "http://redfish.dmtf.org/schemas/v1/Sensor.json#/definitions/SensorVoltageExcerpt"
+                        },
+                        {
+                            "type": "null"
+                        }
+                    ],
+                    "description": "The Line 3 to Neutral voltage reading for this circuit.",
+                    "excerptCopy": "SensorVoltageExcerpt",
+                    "longDescription": "This property shall contain a Sensor excerpt of type Voltage that measures voltage between L3 and Neutral.  This property shall not be present if the circuit does not include an L3-Neutral measurement."
+                }
+            },
+            "type": "object"
+        },
+        "VoltageType": {
+            "enum": [
+                "AC",
+                "DC"
+            ],
+            "enumDescriptions": {
+                "AC": "Alternating Current (AC) circuit.",
+                "DC": "Direct Current (DC) circuit."
+            },
+            "type": "string"
+        }
+    },
+    "owningEntity": "DMTF",
+    "release": "2021.2",
+    "title": "#Circuit.v1_3_0.Circuit"
+}

--- a/static/redfish/v1/JsonSchemas/Circuit/index.json
+++ b/static/redfish/v1/JsonSchemas/Circuit/index.json
@@ -1,0 +1,21 @@
+{
+    "@odata.context": "/redfish/v1/$metadata#JsonSchemaFile.JsonSchemaFile",
+    "@odata.id": "/redfish/v1/JsonSchemas/Circuit",
+    "@odata.type": "#JsonSchemaFile.v1_0_2.JsonSchemaFile",
+    "Name": "Circuit Schema File",
+    "Schema": "#Circuit.Circuit",
+    "Description": "Circuit Schema File Location",
+    "Id": "Circuit",
+    "Languages": [
+        "en"
+    ],
+    "Languages@odata.count": 1,
+    "Location": [
+        {
+            "Language": "en",
+            "PublicationUri": "http://redfish.dmtf.org/schemas/v1/Circuit.json",
+            "Uri": "/redfish/v1/JsonSchemas/Circuit/Circuit.json"
+        }
+    ],
+    "Location@odata.count": 1
+}

--- a/static/redfish/v1/JsonSchemas/CollectionCapabilities/CollectionCapabilities.json
+++ b/static/redfish/v1/JsonSchemas/CollectionCapabilities/CollectionCapabilities.json
@@ -1,0 +1,162 @@
+{
+    "$id": "http://redfish.dmtf.org/schemas/v1/CollectionCapabilities.v1_3_0.json",
+    "$schema": "http://redfish.dmtf.org/schemas/v1/redfish-schema-v1.json",
+    "copyright": "Copyright 2014-2021 DMTF. For the full DMTF copyright policy, see http://www.dmtf.org/about/policies/copyright",
+    "definitions": {
+        "Capability": {
+            "additionalProperties": false,
+            "description": "This type describes a capability of a collection for a specific use case.",
+            "longDescription": "This type shall describe a capability of a resource collection in terms of how a client can create resources within the collection for the specified use case.",
+            "patternProperties": {
+                "^([a-zA-Z_][a-zA-Z0-9_]*)?@(odata|Redfish|Message)\\.[a-zA-Z_][a-zA-Z0-9_]*$": {
+                    "description": "This property shall specify a valid odata or Redfish property.",
+                    "type": [
+                        "array",
+                        "boolean",
+                        "integer",
+                        "number",
+                        "null",
+                        "object",
+                        "string"
+                    ]
+                }
+            },
+            "properties": {
+                "CapabilitiesObject": {
+                    "$ref": "http://redfish.dmtf.org/schemas/v1/odata-v4.json#/definitions/idRef",
+                    "description": "The link to the resource the client can issue a GET request against to understand how to form a POST request for a collection.",
+                    "longDescription": "This property shall contain a link to a resource that matches the type for a resource collection and shall contain annotations that describe the properties allowed in the POST request.",
+                    "readonly": true
+                },
+                "Links": {
+                    "$ref": "#/definitions/Links",
+                    "description": "The links to other resources that are related to this resource.",
+                    "longDescription": "This property shall contain links to resources that are related to but are not contained by, or subordinate to, this resource."
+                },
+                "UseCase": {
+                    "$ref": "#/definitions/UseCase",
+                    "description": "The use case in which a client can issue a POST request to the collection.",
+                    "longDescription": "This property shall contain an enumerated value that describes the use case for this capability instance.",
+                    "readonly": true
+                }
+            },
+            "required": [
+                "CapabilitiesObject",
+                "UseCase",
+                "Links"
+            ],
+            "type": "object"
+        },
+        "CollectionCapabilities": {
+            "additionalProperties": false,
+            "description": "This type describes the capabilities of a collection.",
+            "longDescription": "This type shall describe any capabilities of a resource collection in terms of how a client can create resources within the resource collection.",
+            "patternProperties": {
+                "^([a-zA-Z_][a-zA-Z0-9_]*)?@(odata|Redfish|Message)\\.[a-zA-Z_][a-zA-Z0-9_]*$": {
+                    "description": "This property shall specify a valid odata or Redfish property.",
+                    "type": [
+                        "array",
+                        "boolean",
+                        "integer",
+                        "number",
+                        "null",
+                        "object",
+                        "string"
+                    ]
+                }
+            },
+            "properties": {
+                "Capabilities": {
+                    "description": "The list of capabilities supported by this resource.",
+                    "items": {
+                        "$ref": "#/definitions/Capability"
+                    },
+                    "longDescription": "This property shall contain an array of objects that describe the capabilities of this resource collection.",
+                    "type": "array"
+                },
+                "MaxMembers": {
+                    "description": "The maximum number of members allowed in this collection.",
+                    "longDescription": "This property shall contain the maximum number of members allowed in this resource collection.",
+                    "minimum": 1,
+                    "readonly": true,
+                    "type": "integer",
+                    "versionAdded": "v1_2_0"
+                }
+            },
+            "type": "object"
+        },
+        "Links": {
+            "additionalProperties": false,
+            "description": "The links to other resources that are related to this resource.",
+            "longDescription": "This Redfish Specification-described type shall contain links to resources that are related to but are not contained by, or subordinate to, this resource.",
+            "patternProperties": {
+                "^([a-zA-Z_][a-zA-Z0-9_]*)?@(odata|Redfish|Message)\\.[a-zA-Z_][a-zA-Z0-9_]*$": {
+                    "description": "This property shall specify a valid odata or Redfish property.",
+                    "type": [
+                        "array",
+                        "boolean",
+                        "integer",
+                        "number",
+                        "null",
+                        "object",
+                        "string"
+                    ]
+                }
+            },
+            "properties": {
+                "Oem": {
+                    "$ref": "http://redfish.dmtf.org/schemas/v1/Resource.json#/definitions/Oem",
+                    "description": "The OEM extension property.",
+                    "longDescription": "This property shall contain the OEM extensions.  All values for properties contained in this object shall conform to the Redfish Specification-described requirements."
+                },
+                "RelatedItem": {
+                    "description": "An array of links to resources associated with this capability.",
+                    "items": {
+                        "$ref": "http://redfish.dmtf.org/schemas/v1/odata-v4.json#/definitions/idRef"
+                    },
+                    "longDescription": "This property shall contain an array of links to resources that are related to this capability.",
+                    "readonly": true,
+                    "type": "array"
+                },
+                "RelatedItem@odata.count": {
+                    "$ref": "http://redfish.dmtf.org/schemas/v1/odata-v4.json#/definitions/count"
+                },
+                "TargetCollection": {
+                    "$ref": "http://redfish.dmtf.org/schemas/v1/Resource.json#/definitions/ResourceCollection",
+                    "description": "The link to the collection that this capabilities structure is describing.",
+                    "longDescription": "This property shall contain a link to a resource collection that this structure describes.  A client can use this structure to understand how to form the POST request for the collection.",
+                    "readonly": true
+                }
+            },
+            "required": [
+                "TargetCollection"
+            ],
+            "type": "object"
+        },
+        "UseCase": {
+            "enum": [
+                "ComputerSystemComposition",
+                "ComputerSystemConstrainedComposition",
+                "VolumeCreation",
+                "ResourceBlockComposition",
+                "ResourceBlockConstrainedComposition"
+            ],
+            "enumDescriptions": {
+                "ComputerSystemComposition": "This capability describes a client creating a new computer system resource from a set of disaggregated hardware.",
+                "ComputerSystemConstrainedComposition": "This capability describes a client creating a new computer system resource from a set of constraints.",
+                "ResourceBlockComposition": "This capability describes a client creating a new resource block from a set of other resource blocks.",
+                "ResourceBlockConstrainedComposition": "This capability describes a client creating a new resource block from a set of constraints.",
+                "VolumeCreation": "This capability describes a client creating a new volume resource as part of an existing storage subsystem."
+            },
+            "enumVersionAdded": {
+                "ComputerSystemConstrainedComposition": "v1_1_0",
+                "ResourceBlockComposition": "v1_3_0",
+                "ResourceBlockConstrainedComposition": "v1_3_0"
+            },
+            "type": "string"
+        }
+    },
+    "owningEntity": "DMTF",
+    "release": "2020.4",
+    "title": "#CollectionCapabilities.v1_3_0"
+}

--- a/static/redfish/v1/JsonSchemas/CollectionCapabilities/index.json
+++ b/static/redfish/v1/JsonSchemas/CollectionCapabilities/index.json
@@ -1,0 +1,21 @@
+{
+    "@odata.context": "/redfish/v1/$metadata#JsonSchemaFile.JsonSchemaFile",
+    "@odata.id": "/redfish/v1/JsonSchemas/CollectionCapabilities",
+    "@odata.type": "#JsonSchemaFile.v1_0_2.JsonSchemaFile",
+    "Name": "CollectionCapabilities Schema File",
+    "Schema": "#CollectionCapabilities.CollectionCapabilities",
+    "Description": "CollectionCapabilities Schema File Location",
+    "Id": "CollectionCapabilities",
+    "Languages": [
+        "en"
+    ],
+    "Languages@odata.count": 1,
+    "Location": [
+        {
+            "Language": "en",
+            "PublicationUri": "http://redfish.dmtf.org/schemas/v1/CollectionCapabilities.json",
+            "Uri": "/redfish/v1/JsonSchemas/CollectionCapabilities/CollectionCapabilities.json"
+        }
+    ],
+    "Location@odata.count": 1
+}

--- a/static/redfish/v1/JsonSchemas/CompositionReservation/CompositionReservation.json
+++ b/static/redfish/v1/JsonSchemas/CompositionReservation/CompositionReservation.json
@@ -1,0 +1,158 @@
+{
+    "$id": "http://redfish.dmtf.org/schemas/v1/CompositionReservation.v1_0_0.json",
+    "$ref": "#/definitions/CompositionReservation",
+    "$schema": "http://redfish.dmtf.org/schemas/v1/redfish-schema-v1.json",
+    "copyright": "Copyright 2014-2021 DMTF. For the full DMTF copyright policy, see http://www.dmtf.org/about/policies/copyright",
+    "definitions": {
+        "Actions": {
+            "additionalProperties": false,
+            "description": "The available actions for this resource.",
+            "longDescription": "This type shall contain the available actions for this resource.",
+            "patternProperties": {
+                "^([a-zA-Z_][a-zA-Z0-9_]*)?@(odata|Redfish|Message)\\.[a-zA-Z_][a-zA-Z0-9_]*$": {
+                    "description": "This property shall specify a valid odata or Redfish property.",
+                    "type": [
+                        "array",
+                        "boolean",
+                        "integer",
+                        "number",
+                        "null",
+                        "object",
+                        "string"
+                    ]
+                }
+            },
+            "properties": {
+                "Oem": {
+                    "$ref": "#/definitions/OemActions",
+                    "description": "The available OEM-specific actions for this resource.",
+                    "longDescription": "This property shall contain the available OEM-specific actions for this resource."
+                }
+            },
+            "type": "object"
+        },
+        "CompositionReservation": {
+            "additionalProperties": false,
+            "description": "The CompositionReservation schema contains reservation information related to the Compose action defined in the CompositionService resource when the of RequestType parameter contains the value `PreviewReserve`.",
+            "longDescription": "This resource represents the composition reservation of the composition service for a Redfish implementation.",
+            "patternProperties": {
+                "^([a-zA-Z_][a-zA-Z0-9_]*)?@(odata|Redfish|Message)\\.[a-zA-Z_][a-zA-Z0-9_]*$": {
+                    "description": "This property shall specify a valid odata or Redfish property.",
+                    "type": [
+                        "array",
+                        "boolean",
+                        "integer",
+                        "number",
+                        "null",
+                        "object",
+                        "string"
+                    ]
+                }
+            },
+            "properties": {
+                "@odata.context": {
+                    "$ref": "http://redfish.dmtf.org/schemas/v1/odata-v4.json#/definitions/context"
+                },
+                "@odata.etag": {
+                    "$ref": "http://redfish.dmtf.org/schemas/v1/odata-v4.json#/definitions/etag"
+                },
+                "@odata.id": {
+                    "$ref": "http://redfish.dmtf.org/schemas/v1/odata-v4.json#/definitions/id"
+                },
+                "@odata.type": {
+                    "$ref": "http://redfish.dmtf.org/schemas/v1/odata-v4.json#/definitions/type"
+                },
+                "Actions": {
+                    "$ref": "#/definitions/Actions",
+                    "description": "The available actions for this resource.",
+                    "longDescription": "This property shall contain the available actions for this resource."
+                },
+                "Client": {
+                    "description": "The client that owns the reservation.",
+                    "longDescription": "This property shall contain the client that owns the reservation.  The service shall determine this value based on the client that invoked the Compose action that resulted in the creation of this reservation.",
+                    "readonly": true,
+                    "type": "string"
+                },
+                "Description": {
+                    "anyOf": [
+                        {
+                            "$ref": "http://redfish.dmtf.org/schemas/v1/Resource.json#/definitions/Description"
+                        },
+                        {
+                            "type": "null"
+                        }
+                    ],
+                    "readonly": true
+                },
+                "Id": {
+                    "$ref": "http://redfish.dmtf.org/schemas/v1/Resource.json#/definitions/Id",
+                    "readonly": true
+                },
+                "Manifest": {
+                    "$ref": "http://redfish.dmtf.org/schemas/v1/Manifest.json#/definitions/Manifest",
+                    "description": "The manifest document processed by the service that resulted in this reservation.",
+                    "longDescription": "This property shall contain the manifest document processed by the service that resulted in this reservation.  This property shall be required if the RequestFormat parameter in the Compose action request contained the value `Manifest`."
+                },
+                "Name": {
+                    "$ref": "http://redfish.dmtf.org/schemas/v1/Resource.json#/definitions/Name",
+                    "readonly": true
+                },
+                "Oem": {
+                    "$ref": "http://redfish.dmtf.org/schemas/v1/Resource.json#/definitions/Oem",
+                    "description": "The OEM extension property.",
+                    "longDescription": "This property shall contain the OEM extensions.  All values for properties that this object contains shall conform to the Redfish Specification-described requirements."
+                },
+                "ReservationTime": {
+                    "description": "The date time the service created the reservation.",
+                    "format": "date-time",
+                    "longDescription": "This property shall indicate the date and time when the reservation was created by the service.",
+                    "readonly": true,
+                    "type": "string"
+                },
+                "ReservedResourceBlocks": {
+                    "description": "The array of links to the reserved resource blocks.",
+                    "items": {
+                        "$ref": "http://redfish.dmtf.org/schemas/v1/ResourceBlock.json#/definitions/ResourceBlock"
+                    },
+                    "longDescription": "This property shall contain an array of links to resources of type ResourceBlock that represent the reserved resource blocks for this reservation.  Upon deletion of the reservation or when the reservation is applied, the Reserved property in the referenced resource blocks shall change to `false`.",
+                    "readonly": true,
+                    "type": "array"
+                },
+                "ReservedResourceBlocks@odata.count": {
+                    "$ref": "http://redfish.dmtf.org/schemas/v1/odata-v4.json#/definitions/count"
+                }
+            },
+            "required": [
+                "@odata.id",
+                "@odata.type",
+                "Id",
+                "Name"
+            ],
+            "type": "object"
+        },
+        "OemActions": {
+            "additionalProperties": true,
+            "description": "The available OEM-specific actions for this resource.",
+            "longDescription": "This type shall contain the available OEM-specific actions for this resource.",
+            "patternProperties": {
+                "^([a-zA-Z_][a-zA-Z0-9_]*)?@(odata|Redfish|Message)\\.[a-zA-Z_][a-zA-Z0-9_]*$": {
+                    "description": "This property shall specify a valid odata or Redfish property.",
+                    "type": [
+                        "array",
+                        "boolean",
+                        "integer",
+                        "number",
+                        "null",
+                        "object",
+                        "string"
+                    ]
+                }
+            },
+            "properties": {},
+            "type": "object"
+        }
+    },
+    "owningEntity": "DMTF",
+    "release": "2021.1",
+    "title": "#CompositionReservation.v1_0_0.CompositionReservation"
+}

--- a/static/redfish/v1/JsonSchemas/CompositionReservation/index.json
+++ b/static/redfish/v1/JsonSchemas/CompositionReservation/index.json
@@ -1,0 +1,21 @@
+{
+    "@odata.context": "/redfish/v1/$metadata#JsonSchemaFile.JsonSchemaFile",
+    "@odata.id": "/redfish/v1/JsonSchemas/CompositionReservation",
+    "@odata.type": "#JsonSchemaFile.v1_0_2.JsonSchemaFile",
+    "Name": "CompositionReservation Schema File",
+    "Schema": "#CompositionReservation.CompositionReservation",
+    "Description": "CompositionReservation Schema File Location",
+    "Id": "CompositionReservation",
+    "Languages": [
+        "en"
+    ],
+    "Languages@odata.count": 1,
+    "Location": [
+        {
+            "Language": "en",
+            "PublicationUri": "http://redfish.dmtf.org/schemas/v1/CompositionReservation.json",
+            "Uri": "/redfish/v1/JsonSchemas/CompositionReservation/CompositionReservation.json"
+        }
+    ],
+    "Location@odata.count": 1
+}

--- a/static/redfish/v1/JsonSchemas/CompositionService/CompositionService.json
+++ b/static/redfish/v1/JsonSchemas/CompositionService/CompositionService.json
@@ -1,0 +1,351 @@
+{
+    "$id": "http://redfish.dmtf.org/schemas/v1/CompositionService.v1_2_0.json",
+    "$ref": "#/definitions/CompositionService",
+    "$schema": "http://redfish.dmtf.org/schemas/v1/redfish-schema-v1.json",
+    "copyright": "Copyright 2014-2021 DMTF. For the full DMTF copyright policy, see http://www.dmtf.org/about/policies/copyright",
+    "definitions": {
+        "Actions": {
+            "additionalProperties": false,
+            "description": "The available actions for this resource.",
+            "longDescription": "This type shall contain the available actions for this resource.",
+            "patternProperties": {
+                "^([a-zA-Z_][a-zA-Z0-9_]*)?@(odata|Redfish|Message)\\.[a-zA-Z_][a-zA-Z0-9_]*$": {
+                    "description": "This property shall specify a valid odata or Redfish property.",
+                    "type": [
+                        "array",
+                        "boolean",
+                        "integer",
+                        "number",
+                        "null",
+                        "object",
+                        "string"
+                    ]
+                }
+            },
+            "properties": {
+                "#CompositionService.Compose": {
+                    "$ref": "#/definitions/Compose"
+                },
+                "Oem": {
+                    "$ref": "#/definitions/OemActions",
+                    "description": "The available OEM-specific actions for this resource.",
+                    "longDescription": "This property shall contain the available OEM-specific actions for this resource."
+                }
+            },
+            "type": "object"
+        },
+        "Compose": {
+            "actionResponse": {
+                "$ref": "#/definitions/ComposeResponse"
+            },
+            "additionalProperties": false,
+            "description": "This action performs a set of operations specified by a manifest.",
+            "longDescription": "This action shall perform a set of operations specified by a manifest.  Services shall not apply any part of the manifest unless all operations specified by the manifest are successful.",
+            "parameters": {
+                "Manifest": {
+                    "$ref": "http://redfish.dmtf.org/schemas/v1/Manifest.json#/definitions/Manifest",
+                    "description": "The manifest containing the compose operation request.",
+                    "longDescription": "This parameter shall contain the manifest containing the compose operation request.  This parameter shall be required if RequestFormat contains the value `Manifest`."
+                },
+                "RequestFormat": {
+                    "$ref": "#/definitions/ComposeRequestFormat",
+                    "description": "The format of the request.",
+                    "longDescription": "This parameter shall contain the format of the request.",
+                    "requiredParameter": true
+                },
+                "RequestType": {
+                    "$ref": "#/definitions/ComposeRequestType",
+                    "description": "The type of request.",
+                    "longDescription": "This parameter shall contain the type of request.",
+                    "requiredParameter": true
+                },
+                "ReservationId": {
+                    "description": "The identifier of the composition reservation if applying a reservation.  The value for this parameter is obtained from the response of a Compose action where the RequestType parameter contains the value `PreviewReserve`.",
+                    "longDescription": "This parameter shall contain the value of the Id property of the CompositionReservation resource for applying a reservation.",
+                    "type": "string"
+                }
+            },
+            "patternProperties": {
+                "^([a-zA-Z_][a-zA-Z0-9_]*)?@(odata|Redfish|Message)\\.[a-zA-Z_][a-zA-Z0-9_]*$": {
+                    "description": "This property shall specify a valid odata or Redfish property.",
+                    "type": [
+                        "array",
+                        "boolean",
+                        "integer",
+                        "number",
+                        "null",
+                        "object",
+                        "string"
+                    ]
+                }
+            },
+            "properties": {
+                "target": {
+                    "description": "Link to invoke action",
+                    "format": "uri-reference",
+                    "type": "string"
+                },
+                "title": {
+                    "description": "Friendly action name",
+                    "type": "string"
+                }
+            },
+            "type": "object",
+            "versionAdded": "v1_2_0"
+        },
+        "ComposeRequestFormat": {
+            "enum": [
+                "Manifest"
+            ],
+            "enumDescriptions": {
+                "Manifest": "The request body contains a manifest."
+            },
+            "enumLongDescriptions": {
+                "Manifest": "This value shall indicate that the request contains a manifest as defined by the Redfish Manifest schema."
+            },
+            "type": "string"
+        },
+        "ComposeRequestType": {
+            "enum": [
+                "Preview",
+                "PreviewReserve",
+                "Apply"
+            ],
+            "enumDescriptions": {
+                "Apply": "Perform the requested operations specified by the manifest and modify resources as needed.",
+                "Preview": "Preview the outcome of the operations specified by the manifest.",
+                "PreviewReserve": "Preview the outcome of the operations specified by the manifest and reserve resources."
+            },
+            "enumLongDescriptions": {
+                "Apply": "This value shall indicate that the request is to apply the requested operations specified by the manifest and modify resources as needed.",
+                "Preview": "This value shall indicate that the request is to preview the outcome of the operations specified by the manifest to show what the service will do based on the contents of the request, and not affect any resources within the service.",
+                "PreviewReserve": "This value shall indicate that the request is to preview the outcome of the operations specified by the manifest to show what the service will do based on the contents of the request.  Resources that would have been affected by this request shall be marked as reserved, but otherwise shall not be affected."
+            },
+            "type": "string"
+        },
+        "ComposeResponse": {
+            "additionalProperties": false,
+            "description": "The response body for the Compose action.",
+            "longDescription": "This type shall contain the properties found in the response body for the Compose action.",
+            "patternProperties": {
+                "^([a-zA-Z_][a-zA-Z0-9_]*)?@(odata|Redfish|Message)\\.[a-zA-Z_][a-zA-Z0-9_]*$": {
+                    "description": "This property shall specify a valid odata or Redfish property.",
+                    "type": [
+                        "array",
+                        "boolean",
+                        "integer",
+                        "number",
+                        "null",
+                        "object",
+                        "string"
+                    ]
+                }
+            },
+            "properties": {
+                "Manifest": {
+                    "$ref": "http://redfish.dmtf.org/schemas/v1/Manifest.json#/definitions/Manifest",
+                    "description": "The manifest containing the compose operation response.",
+                    "longDescription": "This property shall contain the manifest containing the compose operation response.  This property shall be required if RequestFormat contains the value `Manifest`.",
+                    "versionAdded": "v1_2_0"
+                },
+                "RequestFormat": {
+                    "$ref": "#/definitions/ComposeRequestFormat",
+                    "description": "The format of the request.",
+                    "longDescription": "This property shall contain the format of the request.",
+                    "readonly": true,
+                    "versionAdded": "v1_2_0"
+                },
+                "RequestType": {
+                    "$ref": "#/definitions/ComposeRequestType",
+                    "description": "The type of request.",
+                    "longDescription": "This property shall contain the type of request.",
+                    "readonly": true,
+                    "versionAdded": "v1_2_0"
+                },
+                "ReservationId": {
+                    "description": "The identifier of the composition reservation that was created.",
+                    "longDescription": "This property shall contain the value of the Id property of the CompositionReservation resource that was created.  This property shall be required if RequestType contains the value `PreviewReserve`.",
+                    "readonly": true,
+                    "type": "string",
+                    "versionAdded": "v1_2_0"
+                }
+            },
+            "required": [
+                "RequestFormat",
+                "RequestType"
+            ],
+            "type": "object"
+        },
+        "CompositionService": {
+            "additionalProperties": false,
+            "description": "The CompositionService schema describes a composition service and its properties and links to the resources available for composition.",
+            "longDescription": "This resource shall represent the composition service and its properties for a Redfish implementation.",
+            "patternProperties": {
+                "^([a-zA-Z_][a-zA-Z0-9_]*)?@(odata|Redfish|Message)\\.[a-zA-Z_][a-zA-Z0-9_]*$": {
+                    "description": "This property shall specify a valid odata or Redfish property.",
+                    "type": [
+                        "array",
+                        "boolean",
+                        "integer",
+                        "number",
+                        "null",
+                        "object",
+                        "string"
+                    ]
+                }
+            },
+            "properties": {
+                "@odata.context": {
+                    "$ref": "http://redfish.dmtf.org/schemas/v1/odata-v4.json#/definitions/context"
+                },
+                "@odata.etag": {
+                    "$ref": "http://redfish.dmtf.org/schemas/v1/odata-v4.json#/definitions/etag"
+                },
+                "@odata.id": {
+                    "$ref": "http://redfish.dmtf.org/schemas/v1/odata-v4.json#/definitions/id"
+                },
+                "@odata.type": {
+                    "$ref": "http://redfish.dmtf.org/schemas/v1/odata-v4.json#/definitions/type"
+                },
+                "Actions": {
+                    "$ref": "#/definitions/Actions",
+                    "description": "The available actions for this resource.",
+                    "longDescription": "This property shall contain the available actions for this resource."
+                },
+                "ActivePool": {
+                    "$ref": "http://redfish.dmtf.org/schemas/v1/ResourceBlockCollection.json#/definitions/ResourceBlockCollection",
+                    "description": "The link to the collection of resource blocks within the active pool.  Resource blocks in the active pool are contributing to at least one composed resource as a result of a composition request.",
+                    "longDescription": "This property shall contain a link to a resource collection of type ResourceBlockCollection.  The members of this collection shall represent the resource blocks in the active pool.  Services shall filter members of this collection based on the requesting client.",
+                    "readonly": true,
+                    "versionAdded": "v1_2_0"
+                },
+                "AllowOverprovisioning": {
+                    "description": "An indication of whether this service is allowed to overprovision a composition relative to the composition request.",
+                    "longDescription": "This property shall indicate whether this service is allowed to overprovision a composition relative to the composition request.",
+                    "readonly": false,
+                    "type": [
+                        "boolean",
+                        "null"
+                    ],
+                    "versionAdded": "v1_1_0"
+                },
+                "AllowZoneAffinity": {
+                    "description": "An indication of whether a client can request that a specific resource zone fulfill a composition request.",
+                    "longDescription": "This property shall indicate whether a client can request that a specific resource zone fulfill a composition request.",
+                    "readonly": true,
+                    "type": [
+                        "boolean",
+                        "null"
+                    ],
+                    "versionAdded": "v1_1_0"
+                },
+                "CompositionReservations": {
+                    "$ref": "http://redfish.dmtf.org/schemas/v1/CompositionReservationCollection.json#/definitions/CompositionReservationCollection",
+                    "description": "The link to the collection of reservations with the composition reservation collection.",
+                    "longDescription": "This property shall contain a link to a resource collection of type CompositionReservationCollection.  The members of this collection shall contain links to reserved resource blocks and the related document that caused the reservations.  Services shall filter members of this collection based on the requesting client.",
+                    "readonly": true,
+                    "versionAdded": "v1_2_0"
+                },
+                "Description": {
+                    "anyOf": [
+                        {
+                            "$ref": "http://redfish.dmtf.org/schemas/v1/Resource.json#/definitions/Description"
+                        },
+                        {
+                            "type": "null"
+                        }
+                    ],
+                    "readonly": true
+                },
+                "FreePool": {
+                    "$ref": "http://redfish.dmtf.org/schemas/v1/ResourceBlockCollection.json#/definitions/ResourceBlockCollection",
+                    "description": "The link to the collection of resource blocks within the free pool.  Resource blocks in the free pool are not contributing to any composed resources.",
+                    "longDescription": "This property shall contain a link to a resource collection of type ResourceBlockCollection.  The members of this collection shall represent the resource blocks in the free pool.  Services shall filter members of this collection based on the requesting client.",
+                    "readonly": true,
+                    "versionAdded": "v1_2_0"
+                },
+                "Id": {
+                    "$ref": "http://redfish.dmtf.org/schemas/v1/Resource.json#/definitions/Id",
+                    "readonly": true
+                },
+                "Name": {
+                    "$ref": "http://redfish.dmtf.org/schemas/v1/Resource.json#/definitions/Name",
+                    "readonly": true
+                },
+                "Oem": {
+                    "$ref": "http://redfish.dmtf.org/schemas/v1/Resource.json#/definitions/Oem",
+                    "description": "The OEM extension property.",
+                    "longDescription": "This property shall contain the OEM extensions.  All values for properties that this object contains shall conform to the Redfish Specification-described requirements."
+                },
+                "ReservationDuration": {
+                    "description": "The length of time a composition reservation is held before the service deletes the reservation marks any related resource blocks as no longer reserved.",
+                    "longDescription": "This property shall contain the length of time a composition reservation is held before the service deletes the reservation marks any related resource blocks as no longer reserved.",
+                    "pattern": "-?P(\\d+D)?(T(\\d+H)?(\\d+M)?(\\d+(.\\d+)?S)?)?",
+                    "readonly": false,
+                    "type": [
+                        "string",
+                        "null"
+                    ],
+                    "versionAdded": "v1_2_0"
+                },
+                "ResourceBlocks": {
+                    "$ref": "http://redfish.dmtf.org/schemas/v1/ResourceBlockCollection.json#/definitions/ResourceBlockCollection",
+                    "description": "The resource blocks available on the service.",
+                    "longDescription": "This property shall contain a link to a resource collection of type ResourceBlockCollection.",
+                    "readonly": true
+                },
+                "ResourceZones": {
+                    "$ref": "http://redfish.dmtf.org/schemas/v1/ZoneCollection.json#/definitions/ZoneCollection",
+                    "description": "The resource zones available on the service.",
+                    "longDescription": "This property shall contain a link to a resource collection of type ZoneCollection.",
+                    "readonly": true
+                },
+                "ServiceEnabled": {
+                    "description": "An indication of whether this service is enabled.",
+                    "longDescription": "This property shall indicate whether this service is enabled.",
+                    "readonly": false,
+                    "type": [
+                        "boolean",
+                        "null"
+                    ]
+                },
+                "Status": {
+                    "$ref": "http://redfish.dmtf.org/schemas/v1/Resource.json#/definitions/Status",
+                    "description": "The status and health of the resource and its subordinate or dependent resources.",
+                    "longDescription": "This property shall contain any status or health properties of the resource."
+                }
+            },
+            "required": [
+                "@odata.id",
+                "@odata.type",
+                "Id",
+                "Name"
+            ],
+            "type": "object"
+        },
+        "OemActions": {
+            "additionalProperties": true,
+            "description": "The available OEM-specific actions for this resource.",
+            "longDescription": "This type shall contain the available OEM-specific actions for this resource.",
+            "patternProperties": {
+                "^([a-zA-Z_][a-zA-Z0-9_]*)?@(odata|Redfish|Message)\\.[a-zA-Z_][a-zA-Z0-9_]*$": {
+                    "description": "This property shall specify a valid odata or Redfish property.",
+                    "type": [
+                        "array",
+                        "boolean",
+                        "integer",
+                        "number",
+                        "null",
+                        "object",
+                        "string"
+                    ]
+                }
+            },
+            "properties": {},
+            "type": "object"
+        }
+    },
+    "owningEntity": "DMTF",
+    "release": "2021.1",
+    "title": "#CompositionService.v1_2_0.CompositionService"
+}

--- a/static/redfish/v1/JsonSchemas/CompositionService/index.json
+++ b/static/redfish/v1/JsonSchemas/CompositionService/index.json
@@ -1,0 +1,21 @@
+{
+    "@odata.context": "/redfish/v1/$metadata#JsonSchemaFile.JsonSchemaFile",
+    "@odata.id": "/redfish/v1/JsonSchemas/CompositionService",
+    "@odata.type": "#JsonSchemaFile.v1_0_2.JsonSchemaFile",
+    "Name": "CompositionService Schema File",
+    "Schema": "#CompositionService.CompositionService",
+    "Description": "CompositionService Schema File Location",
+    "Id": "CompositionService",
+    "Languages": [
+        "en"
+    ],
+    "Languages@odata.count": 1,
+    "Location": [
+        {
+            "Language": "en",
+            "PublicationUri": "http://redfish.dmtf.org/schemas/v1/CompositionService.json",
+            "Uri": "/redfish/v1/JsonSchemas/CompositionService/CompositionService.json"
+        }
+    ],
+    "Location@odata.count": 1
+}

--- a/static/redfish/v1/JsonSchemas/Connection/Connection.json
+++ b/static/redfish/v1/JsonSchemas/Connection/Connection.json
@@ -1,0 +1,516 @@
+{
+    "$id": "http://redfish.dmtf.org/schemas/v1/Connection.v1_1_0.json",
+    "$ref": "#/definitions/Connection",
+    "$schema": "http://redfish.dmtf.org/schemas/v1/redfish-schema-v1.json",
+    "copyright": "Copyright 2014-2021 DMTF. For the full DMTF copyright policy, see http://www.dmtf.org/about/policies/copyright",
+    "definitions": {
+        "AccessCapability": {
+            "enum": [
+                "Read",
+                "Write"
+            ],
+            "enumDescriptions": {
+                "Read": "Endpoints are allowed to perform reads from the specified resource.",
+                "Write": "Endpoints are allowed to perform writes to the specified resource."
+            },
+            "type": "string"
+        },
+        "AccessState": {
+            "description": "Describes the options for the access characteristics of a resource.",
+            "enum": [
+                "Optimized",
+                "NonOptimized",
+                "Standby",
+                "Unavailable",
+                "Transitioning"
+            ],
+            "enumDescriptions": {
+                "NonOptimized": "The resource is in an active and non-optimized state.",
+                "Optimized": "The resource is in an active and optimized state.",
+                "Standby": "The resource is in a standby state.",
+                "Transitioning": "The resource is transitioning to a new state.",
+                "Unavailable": "The resource is in an unavailable state."
+            },
+            "enumLongDescriptions": {
+                "NonOptimized": "This value shall indicate the resource is in an active and non-optimized state.",
+                "Optimized": "This value shall indicate the resource is in an active and optimized state.",
+                "Standby": "This value shall indicate the resource is in a standby state.",
+                "Transitioning": "This value shall indicate the resource is transitioning to a new state.",
+                "Unavailable": "This value shall indicate the resource is in an unavailable state."
+            },
+            "longDescription": "This type shall describe the access to the associated resource in this connection.",
+            "type": "string"
+        },
+        "Actions": {
+            "additionalProperties": false,
+            "description": "The available actions for this resource.",
+            "longDescription": "This type shall contain the available actions for this resource.",
+            "patternProperties": {
+                "^([a-zA-Z_][a-zA-Z0-9_]*)?@(odata|Redfish|Message)\\.[a-zA-Z_][a-zA-Z0-9_]*$": {
+                    "description": "This property shall specify a valid odata or Redfish property.",
+                    "type": [
+                        "array",
+                        "boolean",
+                        "integer",
+                        "number",
+                        "null",
+                        "object",
+                        "string"
+                    ]
+                }
+            },
+            "properties": {
+                "Oem": {
+                    "$ref": "#/definitions/OemActions",
+                    "description": "The available OEM-specific actions for this resource.",
+                    "longDescription": "This property shall contain the available OEM-specific actions for this resource."
+                }
+            },
+            "type": "object"
+        },
+        "Connection": {
+            "additionalProperties": false,
+            "description": "The Connection schema describes the access permissions endpoints, or groups of endpoints, have with other resources in the service.",
+            "longDescription": "This resource shall represent a connection information in the Redfish Specification.",
+            "patternProperties": {
+                "^([a-zA-Z_][a-zA-Z0-9_]*)?@(odata|Redfish|Message)\\.[a-zA-Z_][a-zA-Z0-9_]*$": {
+                    "description": "This property shall specify a valid odata or Redfish property.",
+                    "type": [
+                        "array",
+                        "boolean",
+                        "integer",
+                        "number",
+                        "null",
+                        "object",
+                        "string"
+                    ]
+                }
+            },
+            "properties": {
+                "@odata.context": {
+                    "$ref": "http://redfish.dmtf.org/schemas/v1/odata-v4.json#/definitions/context"
+                },
+                "@odata.etag": {
+                    "$ref": "http://redfish.dmtf.org/schemas/v1/odata-v4.json#/definitions/etag"
+                },
+                "@odata.id": {
+                    "$ref": "http://redfish.dmtf.org/schemas/v1/odata-v4.json#/definitions/id"
+                },
+                "@odata.type": {
+                    "$ref": "http://redfish.dmtf.org/schemas/v1/odata-v4.json#/definitions/type"
+                },
+                "Actions": {
+                    "$ref": "#/definitions/Actions",
+                    "description": "The available actions for this resource.",
+                    "longDescription": "This property shall contain the available actions for this resource."
+                },
+                "ConnectionKeys": {
+                    "$ref": "#/definitions/ConnectionKey",
+                    "description": "The permission keys required to access the specified resources for this connection.",
+                    "longDescription": "This property shall contain the permissions keys required to access the specified resources for this connection.  Some fabrics require permission checks on transactions from authorized initiators.",
+                    "versionAdded": "v1_1_0"
+                },
+                "ConnectionType": {
+                    "anyOf": [
+                        {
+                            "$ref": "#/definitions/ConnectionType"
+                        },
+                        {
+                            "type": "null"
+                        }
+                    ],
+                    "description": "The type of resources this connection specifies.",
+                    "longDescription": "This property shall contain the type of resources this connection specifies.",
+                    "readonly": true
+                },
+                "Description": {
+                    "anyOf": [
+                        {
+                            "$ref": "http://redfish.dmtf.org/schemas/v1/Resource.json#/definitions/Description"
+                        },
+                        {
+                            "type": "null"
+                        }
+                    ],
+                    "readonly": true
+                },
+                "Id": {
+                    "$ref": "http://redfish.dmtf.org/schemas/v1/Resource.json#/definitions/Id",
+                    "readonly": true
+                },
+                "Links": {
+                    "$ref": "#/definitions/Links",
+                    "description": "The links to other resources that are related to this resource.",
+                    "longDescription": "This property shall contain links to resources that are related to but are not contained by, or subordinate to, this resource."
+                },
+                "MemoryChunkInfo": {
+                    "description": "The set of memory chunks and access capabilities specified for this connection.",
+                    "items": {
+                        "$ref": "#/definitions/MemoryChunkInfo"
+                    },
+                    "longDescription": "This property shall contain the set of memory chunks and access capabilities specified for this connection.",
+                    "type": "array",
+                    "versionAdded": "v1_1_0"
+                },
+                "Name": {
+                    "$ref": "http://redfish.dmtf.org/schemas/v1/Resource.json#/definitions/Name",
+                    "readonly": true
+                },
+                "Oem": {
+                    "$ref": "http://redfish.dmtf.org/schemas/v1/Resource.json#/definitions/Oem",
+                    "description": "The OEM extension property.",
+                    "longDescription": "This property shall contain the OEM extensions.  All values for properties that this object contains shall conform to the Redfish Specification-described requirements."
+                },
+                "Status": {
+                    "$ref": "http://redfish.dmtf.org/schemas/v1/Resource.json#/definitions/Status",
+                    "description": "The status and health of the resource and its subordinate or dependent resources.",
+                    "longDescription": "This property shall contain any status or health properties of the resource."
+                },
+                "VolumeInfo": {
+                    "description": "The set of volumes and access capabilities specified for this connection.",
+                    "items": {
+                        "anyOf": [
+                            {
+                                "$ref": "#/definitions/VolumeInfo"
+                            },
+                            {
+                                "type": "null"
+                            }
+                        ]
+                    },
+                    "longDescription": "This property shall contain the set of volumes and access capabilities specified for this connection.",
+                    "type": "array"
+                }
+            },
+            "required": [
+                "@odata.id",
+                "@odata.type",
+                "Id",
+                "Name"
+            ],
+            "type": "object"
+        },
+        "ConnectionKey": {
+            "additionalProperties": false,
+            "description": "The permission key information required to access the target resources for a connection.",
+            "longDescription": "This type shall contain the permission key information required to access the target resources for a connection.",
+            "patternProperties": {
+                "^([a-zA-Z_][a-zA-Z0-9_]*)?@(odata|Redfish|Message)\\.[a-zA-Z_][a-zA-Z0-9_]*$": {
+                    "description": "This property shall specify a valid odata or Redfish property.",
+                    "type": [
+                        "array",
+                        "boolean",
+                        "integer",
+                        "number",
+                        "null",
+                        "object",
+                        "string"
+                    ]
+                }
+            },
+            "properties": {
+                "GenZ": {
+                    "anyOf": [
+                        {
+                            "$ref": "#/definitions/GenZConnectionKey"
+                        },
+                        {
+                            "type": "null"
+                        }
+                    ],
+                    "description": "The Gen-Z-specific permission key information for this connection.",
+                    "longDescription": "This property shall contain the Gen-Z-specific permission key information for this connection.",
+                    "versionAdded": "v1_1_0"
+                }
+            },
+            "type": "object"
+        },
+        "ConnectionType": {
+            "enum": [
+                "Storage",
+                "Memory"
+            ],
+            "enumDescriptions": {
+                "Memory": "A connection to memory related resources.",
+                "Storage": "A connection to storage related resources, such as volumes."
+            },
+            "type": "string"
+        },
+        "GenZConnectionKey": {
+            "additionalProperties": false,
+            "description": "The Gen-Z-specific permission key information for a connection.",
+            "longDescription": "This type shall contain the Gen-Z-specific permission key information for a connection.",
+            "patternProperties": {
+                "^([a-zA-Z_][a-zA-Z0-9_]*)?@(odata|Redfish|Message)\\.[a-zA-Z_][a-zA-Z0-9_]*$": {
+                    "description": "This property shall specify a valid odata or Redfish property.",
+                    "type": [
+                        "array",
+                        "boolean",
+                        "integer",
+                        "number",
+                        "null",
+                        "object",
+                        "string"
+                    ]
+                }
+            },
+            "properties": {
+                "AccessKey": {
+                    "description": "The Access Key for this connection.",
+                    "longDescription": "This property shall contain the Gen-Z Core Specification-defined Access Key for this connection.",
+                    "pattern": "^0[xX]([a-fA-F]|[0-9]){2}$",
+                    "readonly": false,
+                    "type": "string",
+                    "versionAdded": "v1_1_0"
+                },
+                "RKeyDomainCheckingEnabled": {
+                    "description": "Indicates whether Region Key domain checking is enabled for this connection.",
+                    "longDescription": "This property shall indicate whether Region Key domain checking is enabled for this connection.",
+                    "readonly": false,
+                    "type": "boolean",
+                    "versionAdded": "v1_1_0"
+                },
+                "RKeyReadOnlyKey": {
+                    "description": "The read-only Region Key for this connection.",
+                    "longDescription": "This property shall contain the Gen-Z Core Specification-defined read-only Region Key for this connection.",
+                    "pattern": "^0[xX](([a-fA-F]|[0-9]){2}){4}$",
+                    "readonly": false,
+                    "type": "string",
+                    "versionAdded": "v1_1_0"
+                },
+                "RKeyReadWriteKey": {
+                    "description": "The read-write Region Key for this connection.",
+                    "longDescription": "This property shall contain the Gen-Z Core Specification-defined read-write Region Key for this connection.",
+                    "pattern": "^0[xX](([a-fA-F]|[0-9]){2}){4}$",
+                    "readonly": false,
+                    "type": "string",
+                    "versionAdded": "v1_1_0"
+                }
+            },
+            "type": "object"
+        },
+        "Links": {
+            "additionalProperties": false,
+            "description": "The links to other resources that are related to this resource.",
+            "longDescription": "This Redfish Specification-described type shall contain links to resources that are related to but are not contained by, or subordinate to, this resource.",
+            "patternProperties": {
+                "^([a-zA-Z_][a-zA-Z0-9_]*)?@(odata|Redfish|Message)\\.[a-zA-Z_][a-zA-Z0-9_]*$": {
+                    "description": "This property shall specify a valid odata or Redfish property.",
+                    "type": [
+                        "array",
+                        "boolean",
+                        "integer",
+                        "number",
+                        "null",
+                        "object",
+                        "string"
+                    ]
+                }
+            },
+            "properties": {
+                "InitiatorEndpointGroups": {
+                    "description": "An array of links to the initiator endpoint groups that are associated with this connection.",
+                    "items": {
+                        "$ref": "http://redfish.dmtf.org/schemas/v1/EndpointGroup.json#/definitions/EndpointGroup"
+                    },
+                    "longDescription": "This property shall contain an array of links to resources of type EndpointGroup that are the initiator endpoint groups associated with this connection.  If the referenced endpoint groups contain the GroupType property, the GroupType property shall contain the value `Initiator` or `Client`.  This property shall not be present if InitiatorEndpoints is present.",
+                    "readonly": false,
+                    "type": "array"
+                },
+                "InitiatorEndpointGroups@odata.count": {
+                    "$ref": "http://redfish.dmtf.org/schemas/v1/odata-v4.json#/definitions/count"
+                },
+                "InitiatorEndpoints": {
+                    "description": "An array of links to the initiator endpoints that are associated with this connection.",
+                    "items": {
+                        "$ref": "http://redfish.dmtf.org/schemas/v1/Endpoint.json#/definitions/Endpoint"
+                    },
+                    "longDescription": "This property shall contain an array of links to resources of type Endpoint that are the initiator endpoints associated with this connection.  If the referenced endpoints contain the EntityRole property, the EntityRole property shall contain the value `Initiator` or `Both`.  This property shall not be present if InitiatorEndpointGroups is present.",
+                    "readonly": false,
+                    "type": "array"
+                },
+                "InitiatorEndpoints@odata.count": {
+                    "$ref": "http://redfish.dmtf.org/schemas/v1/odata-v4.json#/definitions/count"
+                },
+                "Oem": {
+                    "$ref": "http://redfish.dmtf.org/schemas/v1/Resource.json#/definitions/Oem",
+                    "description": "The OEM extension property.",
+                    "longDescription": "This property shall contain the OEM extensions.  All values for properties contained in this object shall conform to the Redfish Specification-described requirements."
+                },
+                "TargetEndpointGroups": {
+                    "description": "An array of links to the target endpoint groups that are associated with this connection.",
+                    "items": {
+                        "$ref": "http://redfish.dmtf.org/schemas/v1/EndpointGroup.json#/definitions/EndpointGroup"
+                    },
+                    "longDescription": "This property shall contain an array of links to resources of type EndpointGroup that are the target endpoint groups associated with this connection.  If the referenced endpoint groups contain the GroupType property, the GroupType property shall contain the value `Target` or `Server`.  This property shall not be present if TargetEndpoints is present.",
+                    "readonly": false,
+                    "type": "array"
+                },
+                "TargetEndpointGroups@odata.count": {
+                    "$ref": "http://redfish.dmtf.org/schemas/v1/odata-v4.json#/definitions/count"
+                },
+                "TargetEndpoints": {
+                    "description": "An array of links to the target endpoints that are associated with this connection.",
+                    "items": {
+                        "$ref": "http://redfish.dmtf.org/schemas/v1/Endpoint.json#/definitions/Endpoint"
+                    },
+                    "longDescription": "This property shall contain an array of links to resources of type Endpoint that are the target endpoints associated with this connection.  If the referenced endpoints contain the EntityRole property, the EntityRole property shall contain the value `Target` or `Both`.  This property shall not be present if TargetEndpointGroups is present.",
+                    "readonly": false,
+                    "type": "array"
+                },
+                "TargetEndpoints@odata.count": {
+                    "$ref": "http://redfish.dmtf.org/schemas/v1/odata-v4.json#/definitions/count"
+                }
+            },
+            "type": "object"
+        },
+        "MemoryChunkInfo": {
+            "additionalProperties": false,
+            "description": "The combination of permissions and memory chunk information.",
+            "longDescription": "This type shall contain the combination of permissions and memory chunk information.",
+            "patternProperties": {
+                "^([a-zA-Z_][a-zA-Z0-9_]*)?@(odata|Redfish|Message)\\.[a-zA-Z_][a-zA-Z0-9_]*$": {
+                    "description": "This property shall specify a valid odata or Redfish property.",
+                    "type": [
+                        "array",
+                        "boolean",
+                        "integer",
+                        "number",
+                        "null",
+                        "object",
+                        "string"
+                    ]
+                }
+            },
+            "properties": {
+                "AccessCapabilities": {
+                    "description": "Supported IO access capabilities.",
+                    "items": {
+                        "anyOf": [
+                            {
+                                "$ref": "#/definitions/AccessCapability"
+                            },
+                            {
+                                "type": "null"
+                            }
+                        ]
+                    },
+                    "longDescription": "Each entry shall specify a current memory access capability.",
+                    "readonly": false,
+                    "type": "array",
+                    "versionAdded": "v1_1_0"
+                },
+                "AccessState": {
+                    "anyOf": [
+                        {
+                            "$ref": "#/definitions/AccessState"
+                        },
+                        {
+                            "type": "null"
+                        }
+                    ],
+                    "description": "The access state for this connection.",
+                    "longDescription": "The value of this property shall contain the access state for the associated resource in this connection.",
+                    "readonly": false,
+                    "versionAdded": "v1_1_0"
+                },
+                "MemoryChunk": {
+                    "anyOf": [
+                        {
+                            "$ref": "http://redfish.dmtf.org/schemas/v1/MemoryChunks.json#/definitions/MemoryChunks"
+                        },
+                        {
+                            "type": "null"
+                        }
+                    ],
+                    "description": "The specified memory chunk.",
+                    "longDescription": "This property shall contain a link to a resource of type MemoryChunk.  The endpoints referenced by the InitiatorEndpoints or InitiatorEndpointGroups properties shall be given access to this memory chunk as described by this object.  If TargetEndpoints or TargetEndpointGroups is present, the referenced initiator endpoints shall be required to access the referenced memory chunk through one of the referenced target endpoints.",
+                    "readonly": false,
+                    "versionAdded": "v1_1_0"
+                }
+            },
+            "type": "object"
+        },
+        "OemActions": {
+            "additionalProperties": true,
+            "description": "The available OEM-specific actions for this resource.",
+            "longDescription": "This type shall contain the available OEM-specific actions for this resource.",
+            "patternProperties": {
+                "^([a-zA-Z_][a-zA-Z0-9_]*)?@(odata|Redfish|Message)\\.[a-zA-Z_][a-zA-Z0-9_]*$": {
+                    "description": "This property shall specify a valid odata or Redfish property.",
+                    "type": [
+                        "array",
+                        "boolean",
+                        "integer",
+                        "number",
+                        "null",
+                        "object",
+                        "string"
+                    ]
+                }
+            },
+            "properties": {},
+            "type": "object"
+        },
+        "VolumeInfo": {
+            "additionalProperties": false,
+            "description": "The combination of permissions and volume information.",
+            "longDescription": "This type shall contain the combination of permissions and volume information.",
+            "patternProperties": {
+                "^([a-zA-Z_][a-zA-Z0-9_]*)?@(odata|Redfish|Message)\\.[a-zA-Z_][a-zA-Z0-9_]*$": {
+                    "description": "This property shall specify a valid odata or Redfish property.",
+                    "type": [
+                        "array",
+                        "boolean",
+                        "integer",
+                        "number",
+                        "null",
+                        "object",
+                        "string"
+                    ]
+                }
+            },
+            "properties": {
+                "AccessCapabilities": {
+                    "description": "Supported IO access capabilities.",
+                    "items": {
+                        "anyOf": [
+                            {
+                                "$ref": "#/definitions/AccessCapability"
+                            },
+                            {
+                                "type": "null"
+                            }
+                        ]
+                    },
+                    "longDescription": "Each entry shall specify a current storage access capability.",
+                    "readonly": false,
+                    "type": "array"
+                },
+                "AccessState": {
+                    "anyOf": [
+                        {
+                            "$ref": "#/definitions/AccessState"
+                        },
+                        {
+                            "type": "null"
+                        }
+                    ],
+                    "description": "The access state for this connection.",
+                    "longDescription": "The value of this property shall contain the access state for the associated resource in this connection.",
+                    "readonly": false
+                },
+                "Volume": {
+                    "$ref": "http://redfish.dmtf.org/schemas/swordfish/v1/Volume.json#/definitions/Volume",
+                    "description": "The specified volume.",
+                    "longDescription": "This property shall contain a link to a resource of type Volume.  The endpoints referenced by the InitiatorEndpoints or InitiatorEndpointGroups properties shall be given access to this volume as described by this object.  If TargetEndpoints or TargetEndpointGroups is present, the referenced initiator endpoints shall be required to access the referenced volume through one of the referenced target endpoints.",
+                    "readonly": false
+                }
+            },
+            "type": "object"
+        }
+    },
+    "owningEntity": "DMTF",
+    "release": "2021.1",
+    "title": "#Connection.v1_1_0.Connection"
+}

--- a/static/redfish/v1/JsonSchemas/Connection/index.json
+++ b/static/redfish/v1/JsonSchemas/Connection/index.json
@@ -1,0 +1,21 @@
+{
+    "@odata.context": "/redfish/v1/$metadata#JsonSchemaFile.JsonSchemaFile",
+    "@odata.id": "/redfish/v1/JsonSchemas/Connection",
+    "@odata.type": "#JsonSchemaFile.v1_0_2.JsonSchemaFile",
+    "Name": "Connection Schema File",
+    "Schema": "#Connection.Connection",
+    "Description": "Connection Schema File Location",
+    "Id": "Connection",
+    "Languages": [
+        "en"
+    ],
+    "Languages@odata.count": 1,
+    "Location": [
+        {
+            "Language": "en",
+            "PublicationUri": "http://redfish.dmtf.org/schemas/v1/Connection.json",
+            "Uri": "/redfish/v1/JsonSchemas/Connection/Connection.json"
+        }
+    ],
+    "Location@odata.count": 1
+}

--- a/static/redfish/v1/JsonSchemas/ConnectionMethod/ConnectionMethod.json
+++ b/static/redfish/v1/JsonSchemas/ConnectionMethod/ConnectionMethod.json
@@ -1,0 +1,221 @@
+{
+    "$id": "http://redfish.dmtf.org/schemas/v1/ConnectionMethod.v1_0_0.json",
+    "$ref": "#/definitions/ConnectionMethod",
+    "$schema": "http://redfish.dmtf.org/schemas/v1/redfish-schema-v1.json",
+    "copyright": "Copyright 2014-2020 DMTF. For the full DMTF copyright policy, see http://www.dmtf.org/about/policies/copyright",
+    "definitions": {
+        "Actions": {
+            "additionalProperties": false,
+            "description": "The available actions for this resource.",
+            "longDescription": "This type shall contain the available actions for this resource.",
+            "patternProperties": {
+                "^([a-zA-Z_][a-zA-Z0-9_]*)?@(odata|Redfish|Message)\\.[a-zA-Z_][a-zA-Z0-9_]*$": {
+                    "description": "This property shall specify a valid odata or Redfish property.",
+                    "type": [
+                        "array",
+                        "boolean",
+                        "integer",
+                        "number",
+                        "null",
+                        "object",
+                        "string"
+                    ]
+                }
+            },
+            "properties": {
+                "Oem": {
+                    "$ref": "#/definitions/OemActions",
+                    "description": "The available OEM-specific actions for this resource.",
+                    "longDescription": "This property shall contain the available OEM-specific actions for this resource."
+                }
+            },
+            "type": "object"
+        },
+        "ConnectionMethod": {
+            "additionalProperties": false,
+            "description": "The ConnectionMethod schema describes the protocol, provider, or other method used to communicate to a given access point for a Redfish aggregation service.",
+            "longDescription": "This resource shall represent a connection method for a Redfish implementation.",
+            "patternProperties": {
+                "^([a-zA-Z_][a-zA-Z0-9_]*)?@(odata|Redfish|Message)\\.[a-zA-Z_][a-zA-Z0-9_]*$": {
+                    "description": "This property shall specify a valid odata or Redfish property.",
+                    "type": [
+                        "array",
+                        "boolean",
+                        "integer",
+                        "number",
+                        "null",
+                        "object",
+                        "string"
+                    ]
+                }
+            },
+            "properties": {
+                "@odata.context": {
+                    "$ref": "http://redfish.dmtf.org/schemas/v1/odata-v4.json#/definitions/context"
+                },
+                "@odata.etag": {
+                    "$ref": "http://redfish.dmtf.org/schemas/v1/odata-v4.json#/definitions/etag"
+                },
+                "@odata.id": {
+                    "$ref": "http://redfish.dmtf.org/schemas/v1/odata-v4.json#/definitions/id"
+                },
+                "@odata.type": {
+                    "$ref": "http://redfish.dmtf.org/schemas/v1/odata-v4.json#/definitions/type"
+                },
+                "Actions": {
+                    "$ref": "#/definitions/Actions",
+                    "description": "The available actions for this resource.",
+                    "longDescription": "This property shall contain the available actions for this resource."
+                },
+                "ConnectionMethodType": {
+                    "anyOf": [
+                        {
+                            "$ref": "#/definitions/ConnectionMethodType"
+                        },
+                        {
+                            "type": "null"
+                        }
+                    ],
+                    "description": "The type of connection method.",
+                    "longDescription": "This property shall contain an identifier of the connection method.",
+                    "readonly": true
+                },
+                "ConnectionMethodVariant": {
+                    "description": "The variant of connection method.",
+                    "longDescription": "This property shall contain an additional identifier of the connection method.  This property shall be present if ConnectionMethodType is `OEM`.",
+                    "readonly": true,
+                    "type": [
+                        "string",
+                        "null"
+                    ]
+                },
+                "Description": {
+                    "anyOf": [
+                        {
+                            "$ref": "http://redfish.dmtf.org/schemas/v1/Resource.json#/definitions/Description"
+                        },
+                        {
+                            "type": "null"
+                        }
+                    ],
+                    "readonly": true
+                },
+                "Id": {
+                    "$ref": "http://redfish.dmtf.org/schemas/v1/Resource.json#/definitions/Id",
+                    "readonly": true
+                },
+                "Links": {
+                    "$ref": "#/definitions/Links",
+                    "description": "The links to other resources that are related to this resource.",
+                    "longDescription": "This property shall contain links to resources that are related to but are not contained by, or subordinate to, this resource."
+                },
+                "Name": {
+                    "$ref": "http://redfish.dmtf.org/schemas/v1/Resource.json#/definitions/Name",
+                    "readonly": true
+                },
+                "Oem": {
+                    "$ref": "http://redfish.dmtf.org/schemas/v1/Resource.json#/definitions/Oem",
+                    "description": "The OEM extension property.",
+                    "longDescription": "This property shall contain the OEM extensions.  All values for properties that this object contains shall conform to the Redfish Specification-described requirements."
+                }
+            },
+            "required": [
+                "@odata.id",
+                "@odata.type",
+                "Id",
+                "Name"
+            ],
+            "type": "object"
+        },
+        "ConnectionMethodType": {
+            "enum": [
+                "Redfish",
+                "SNMP",
+                "IPMI15",
+                "IPMI20",
+                "NETCONF",
+                "OEM"
+            ],
+            "enumDescriptions": {
+                "IPMI15": "IPMI 1.5 connection method.",
+                "IPMI20": "IPMI 2.0 connection method.",
+                "NETCONF": "NETCONF connection method.",
+                "OEM": "OEM connection method.",
+                "Redfish": "Redfish connection method.",
+                "SNMP": "SNMP connection method."
+            },
+            "enumLongDescriptions": {
+                "IPMI15": "This value shall indicate the connection method is IPMI 1.5.",
+                "IPMI20": "This value shall indicate the connection method is IPMI 2.0.",
+                "NETCONF": "This value shall indicate the connection method is NETCONF.",
+                "OEM": "This value shall indicate the connection method is OEM.  The ConnectionMethodVariant property shall contain further identification information.",
+                "Redfish": "This value shall indicate the connection method is Redfish.",
+                "SNMP": "This value shall indicate the connection method is SNMP."
+            },
+            "type": "string"
+        },
+        "Links": {
+            "additionalProperties": false,
+            "description": "The links to other resources that are related to this resource.",
+            "longDescription": "This Redfish Specification-described type shall contain links to resources that are related to but are not contained by, or subordinate to, this resource.",
+            "patternProperties": {
+                "^([a-zA-Z_][a-zA-Z0-9_]*)?@(odata|Redfish|Message)\\.[a-zA-Z_][a-zA-Z0-9_]*$": {
+                    "description": "This property shall specify a valid odata or Redfish property.",
+                    "type": [
+                        "array",
+                        "boolean",
+                        "integer",
+                        "number",
+                        "null",
+                        "object",
+                        "string"
+                    ]
+                }
+            },
+            "properties": {
+                "AggregationSources": {
+                    "description": "An array of links to the access points using this connection method.",
+                    "items": {
+                        "$ref": "http://redfish.dmtf.org/schemas/v1/AggregationSource.json#/definitions/AggregationSource"
+                    },
+                    "longDescription": "This property shall contain an array of links to resources of type AggregationSource that are using this connection method.",
+                    "readonly": true,
+                    "type": "array"
+                },
+                "AggregationSources@odata.count": {
+                    "$ref": "http://redfish.dmtf.org/schemas/v1/odata-v4.json#/definitions/count"
+                },
+                "Oem": {
+                    "$ref": "http://redfish.dmtf.org/schemas/v1/Resource.json#/definitions/Oem",
+                    "description": "The OEM extension property.",
+                    "longDescription": "This property shall contain the OEM extensions.  All values for properties contained in this object shall conform to the Redfish Specification-described requirements."
+                }
+            },
+            "type": "object"
+        },
+        "OemActions": {
+            "additionalProperties": true,
+            "description": "The available OEM-specific actions for this resource.",
+            "longDescription": "This type shall contain the available OEM-specific actions for this resource.",
+            "patternProperties": {
+                "^([a-zA-Z_][a-zA-Z0-9_]*)?@(odata|Redfish|Message)\\.[a-zA-Z_][a-zA-Z0-9_]*$": {
+                    "description": "This property shall specify a valid odata or Redfish property.",
+                    "type": [
+                        "array",
+                        "boolean",
+                        "integer",
+                        "number",
+                        "null",
+                        "object",
+                        "string"
+                    ]
+                }
+            },
+            "properties": {},
+            "type": "object"
+        }
+    },
+    "owningEntity": "DMTF",
+    "release": "2020.2",
+    "title": "#ConnectionMethod.v1_0_0.ConnectionMethod"
+}

--- a/static/redfish/v1/JsonSchemas/ConnectionMethod/index.json
+++ b/static/redfish/v1/JsonSchemas/ConnectionMethod/index.json
@@ -1,0 +1,21 @@
+{
+    "@odata.context": "/redfish/v1/$metadata#JsonSchemaFile.JsonSchemaFile",
+    "@odata.id": "/redfish/v1/JsonSchemas/ConnectionMethod",
+    "@odata.type": "#JsonSchemaFile.v1_0_2.JsonSchemaFile",
+    "Name": "ConnectionMethod Schema File",
+    "Schema": "#ConnectionMethod.ConnectionMethod",
+    "Description": "ConnectionMethod Schema File Location",
+    "Id": "ConnectionMethod",
+    "Languages": [
+        "en"
+    ],
+    "Languages@odata.count": 1,
+    "Location": [
+        {
+            "Language": "en",
+            "PublicationUri": "http://redfish.dmtf.org/schemas/v1/ConnectionMethod.json",
+            "Uri": "/redfish/v1/JsonSchemas/ConnectionMethod/ConnectionMethod.json"
+        }
+    ],
+    "Location@odata.count": 1
+}

--- a/static/redfish/v1/JsonSchemas/Control/Control.json
+++ b/static/redfish/v1/JsonSchemas/Control/Control.json
@@ -1,0 +1,813 @@
+{
+    "$id": "http://redfish.dmtf.org/schemas/v1/Control.v1_0_0.json",
+    "$ref": "#/definitions/Control",
+    "$schema": "http://redfish.dmtf.org/schemas/v1/redfish-schema-v1.json",
+    "copyright": "Copyright 2014-2021 DMTF. For the full DMTF copyright policy, see http://www.dmtf.org/about/policies/copyright",
+    "definitions": {
+        "Actions": {
+            "additionalProperties": false,
+            "description": "The available actions for this resource.",
+            "longDescription": "This type shall contain the available actions for this resource.",
+            "patternProperties": {
+                "^([a-zA-Z_][a-zA-Z0-9_]*)?@(odata|Redfish|Message)\\.[a-zA-Z_][a-zA-Z0-9_]*$": {
+                    "description": "This property shall specify a valid odata or Redfish property.",
+                    "type": [
+                        "array",
+                        "boolean",
+                        "integer",
+                        "number",
+                        "null",
+                        "object",
+                        "string"
+                    ]
+                }
+            },
+            "properties": {
+                "Oem": {
+                    "$ref": "#/definitions/OemActions",
+                    "description": "The available OEM-specific actions for this resource.",
+                    "longDescription": "This property shall contain the available OEM-specific actions for this resource."
+                }
+            },
+            "type": "object"
+        },
+        "Control": {
+            "additionalProperties": false,
+            "description": "The Control schema describes a control point and its properties.",
+            "longDescription": "This resource shall represent a control point for a Redfish implementation.",
+            "patternProperties": {
+                "^([a-zA-Z_][a-zA-Z0-9_]*)?@(odata|Redfish|Message)\\.[a-zA-Z_][a-zA-Z0-9_]*$": {
+                    "description": "This property shall specify a valid odata or Redfish property.",
+                    "type": [
+                        "array",
+                        "boolean",
+                        "integer",
+                        "number",
+                        "null",
+                        "object",
+                        "string"
+                    ]
+                }
+            },
+            "properties": {
+                "@odata.context": {
+                    "$ref": "http://redfish.dmtf.org/schemas/v1/odata-v4.json#/definitions/context"
+                },
+                "@odata.etag": {
+                    "$ref": "http://redfish.dmtf.org/schemas/v1/odata-v4.json#/definitions/etag"
+                },
+                "@odata.id": {
+                    "$ref": "http://redfish.dmtf.org/schemas/v1/odata-v4.json#/definitions/id"
+                },
+                "@odata.type": {
+                    "$ref": "http://redfish.dmtf.org/schemas/v1/odata-v4.json#/definitions/type"
+                },
+                "Accuracy": {
+                    "description": "The estimated percent error of measured versus actual values.",
+                    "longDescription": "This property shall contain the percent error of the measured versus actual values of the SetPoint property.",
+                    "readonly": true,
+                    "type": [
+                        "number",
+                        "null"
+                    ],
+                    "units": "%"
+                },
+                "Actions": {
+                    "$ref": "#/definitions/Actions",
+                    "description": "The available actions for this resource.",
+                    "longDescription": "This property shall contain the available actions for this resource."
+                },
+                "AllowableMax": {
+                    "description": "The maximum possible setting for this control.",
+                    "excerpt": "Control",
+                    "longDescription": "This property shall indicate the maximum possible value of the SetPoint or SettingMax properties for this control.  Services shall not accept values for SetPoint or SettingMax above this value.",
+                    "readonly": true,
+                    "type": [
+                        "number",
+                        "null"
+                    ]
+                },
+                "AllowableMin": {
+                    "description": "The minimum possible setting for this control.",
+                    "excerpt": "Control",
+                    "longDescription": "This property shall indicate the minimum possible value of the SetPoint or SettingMin properties for this control.  Services shall not accept values for SetPoint or SettingMin below this value.",
+                    "readonly": true,
+                    "type": [
+                        "number",
+                        "null"
+                    ]
+                },
+                "AllowableNumericValues": {
+                    "description": "The supported values for the set point.",
+                    "excerpt": "ControlRange",
+                    "items": {
+                        "type": [
+                            "number",
+                            "null"
+                        ]
+                    },
+                    "longDescription": "This property shall contain the supported values for this control.  The units shall follow the value of SetPointUnits.  This property should only be present when the set point or range has a limited set of supported values that cannot be accurately described using the Increment property.",
+                    "readonly": true,
+                    "type": "array"
+                },
+                "AssociatedSensors": {
+                    "description": "An array of links to the sensors associated with this control.",
+                    "items": {
+                        "$ref": "http://redfish.dmtf.org/schemas/v1/Sensor.json#/definitions/Sensor"
+                    },
+                    "longDescription": "This property shall contain an array of links to resources of type Sensor that represent the sensors related to this control.",
+                    "readonly": true,
+                    "type": "array"
+                },
+                "AssociatedSensors@odata.count": {
+                    "$ref": "http://redfish.dmtf.org/schemas/v1/odata-v4.json#/definitions/count"
+                },
+                "ControlDelaySeconds": {
+                    "description": "The time delay in seconds before the control will activate once the value has deviated from the set point.",
+                    "longDescription": "This property shall contain the time in seconds that will elapse after the control value deviates above or below the value of SetPoint before the control will activate.",
+                    "readonly": false,
+                    "type": [
+                        "number",
+                        "null"
+                    ]
+                },
+                "ControlLoop": {
+                    "anyOf": [
+                        {
+                            "$ref": "#/definitions/ControlLoop"
+                        },
+                        {
+                            "type": "null"
+                        }
+                    ],
+                    "description": "The control loop details.",
+                    "longDescription": "This property shall contain the details for the control loop described by this resource."
+                },
+                "ControlMode": {
+                    "anyOf": [
+                        {
+                            "$ref": "#/definitions/ControlMode"
+                        },
+                        {
+                            "type": "null"
+                        }
+                    ],
+                    "description": "The current operating mode of the control.",
+                    "excerpt": "Control",
+                    "longDescription": "This property shall contain the operating mode of the control.",
+                    "readonly": false
+                },
+                "ControlType": {
+                    "anyOf": [
+                        {
+                            "$ref": "#/definitions/ControlType"
+                        },
+                        {
+                            "type": "null"
+                        }
+                    ],
+                    "description": "The type of control.",
+                    "longDescription": "This property shall contain the type of the control.",
+                    "readonly": true
+                },
+                "DeadBand": {
+                    "description": "The maximum deviation from the set point allowed before the control will activate.",
+                    "longDescription": "This property shall contain the maximum deviation value allowed above or below the value of SetPoint before the control will activate.",
+                    "readonly": false,
+                    "type": [
+                        "number",
+                        "null"
+                    ]
+                },
+                "Description": {
+                    "anyOf": [
+                        {
+                            "$ref": "http://redfish.dmtf.org/schemas/v1/Resource.json#/definitions/Description"
+                        },
+                        {
+                            "type": "null"
+                        }
+                    ],
+                    "readonly": true
+                },
+                "Id": {
+                    "$ref": "http://redfish.dmtf.org/schemas/v1/Resource.json#/definitions/Id",
+                    "readonly": true
+                },
+                "Implementation": {
+                    "anyOf": [
+                        {
+                            "$ref": "#/definitions/ImplementationType"
+                        },
+                        {
+                            "type": "null"
+                        }
+                    ],
+                    "description": "The implementation of the control.",
+                    "longDescription": "This property shall contain the implementation of the control.",
+                    "readonly": true
+                },
+                "Increment": {
+                    "description": "The smallest increment supported for the set point.",
+                    "longDescription": "This property shall contain the smallest change allowed to the value of the SetPoint, SettingMin, or SettingMax properties.  The units shall follow the value of SetPointUnits.",
+                    "readonly": true,
+                    "type": [
+                        "number",
+                        "null"
+                    ]
+                },
+                "Location": {
+                    "$ref": "http://redfish.dmtf.org/schemas/v1/Resource.json#/definitions/Location",
+                    "description": "The location information for this control.",
+                    "longDescription": "This property shall indicate the location information for this control."
+                },
+                "Name": {
+                    "$ref": "http://redfish.dmtf.org/schemas/v1/Resource.json#/definitions/Name",
+                    "readonly": true
+                },
+                "Oem": {
+                    "$ref": "http://redfish.dmtf.org/schemas/v1/Resource.json#/definitions/Oem",
+                    "description": "The OEM extension property.",
+                    "longDescription": "This property shall contain the OEM extensions.  All values for properties that this object contains shall conform to the Redfish Specification-described requirements."
+                },
+                "PhysicalContext": {
+                    "anyOf": [
+                        {
+                            "$ref": "http://redfish.dmtf.org/schemas/v1/PhysicalContext.json#/definitions/PhysicalContext"
+                        },
+                        {
+                            "type": "null"
+                        }
+                    ],
+                    "description": "The area or device to which this control applies.",
+                    "longDescription": "This property shall contain a description of the affected component or region within the equipment to which this control applies.",
+                    "readonly": true
+                },
+                "PhysicalSubContext": {
+                    "anyOf": [
+                        {
+                            "$ref": "http://redfish.dmtf.org/schemas/v1/PhysicalContext.json#/definitions/PhysicalSubContext"
+                        },
+                        {
+                            "type": "null"
+                        }
+                    ],
+                    "description": "The usage or location within a device to which this control applies.",
+                    "longDescription": "This property shall contain a description of the usage or sub-region within the equipment to which this control applies.  This property generally differentiates multiple controls within the same PhysicalContext instance.",
+                    "readonly": true
+                },
+                "RelatedItem": {
+                    "description": "An array of links to resources that this control services.",
+                    "items": {
+                        "$ref": "http://redfish.dmtf.org/schemas/v1/odata-v4.json#/definitions/idRef"
+                    },
+                    "longDescription": "This property shall contain an array of links to resources that this control services.",
+                    "readonly": true,
+                    "type": "array"
+                },
+                "RelatedItem@odata.count": {
+                    "$ref": "http://redfish.dmtf.org/schemas/v1/odata-v4.json#/definitions/count"
+                },
+                "Sensor": {
+                    "anyOf": [
+                        {
+                            "$ref": "http://redfish.dmtf.org/schemas/v1/Sensor.json#/definitions/SensorExcerpt"
+                        },
+                        {
+                            "type": "null"
+                        }
+                    ],
+                    "description": "The sensor reading associated with this control.",
+                    "excerptCopy": "SensorExcerpt",
+                    "longDescription": "This property shall contain the Sensor excerpt directly associated with this control.  This property shall not be present if multiple sensors are associated with a single control.",
+                    "readonly": true
+                },
+                "SetPoint": {
+                    "description": "The desired set point of the control.",
+                    "excerpt": "ControlSingle",
+                    "longDescription": "This property shall contain the desired set point control value.  The units shall follow the value of SetPointUnits.",
+                    "readonly": false,
+                    "type": [
+                        "number",
+                        "null"
+                    ]
+                },
+                "SetPointType": {
+                    "anyOf": [
+                        {
+                            "$ref": "#/definitions/SetPointType"
+                        },
+                        {
+                            "type": "null"
+                        }
+                    ],
+                    "description": "The set point type used to operate the control.",
+                    "longDescription": "This property shall contain the type of set point definitions used to describe this control.",
+                    "readonly": true
+                },
+                "SetPointUnits": {
+                    "description": "The units of the set point.",
+                    "longDescription": "This property shall contain the units of the control's set point.",
+                    "readonly": true,
+                    "type": [
+                        "string",
+                        "null"
+                    ]
+                },
+                "SetPointUpdateTime": {
+                    "description": "The date and time that the set point was changed.",
+                    "format": "date-time",
+                    "longDescription": "This property shall contain the date and time that the value of SetPoint was last changed.",
+                    "readonly": true,
+                    "type": [
+                        "string",
+                        "null"
+                    ]
+                },
+                "SettingMax": {
+                    "description": "The maximum set point in the allowed range.",
+                    "excerpt": "ControlRange",
+                    "longDescription": "This property shall contain the maximum desired set point within the acceptable range.  The service shall reject values greater than the value of AllowableMax.  The units shall follow the value of SetPointUnits.",
+                    "readonly": false,
+                    "type": [
+                        "number",
+                        "null"
+                    ]
+                },
+                "SettingMin": {
+                    "description": "The minimum set point in the allowed range.",
+                    "excerpt": "ControlRange",
+                    "longDescription": "This property shall contain the minimum desired set point within the acceptable range.  The service shall reject values less than the value of AllowableMin.  The units shall follow the value of SetPointUnits.",
+                    "readonly": false,
+                    "type": [
+                        "number",
+                        "null"
+                    ]
+                },
+                "Status": {
+                    "$ref": "http://redfish.dmtf.org/schemas/v1/Resource.json#/definitions/Status",
+                    "description": "The status and health of the resource and its subordinate or dependent resources.",
+                    "longDescription": "This property shall contain any status or health properties of the resource."
+                }
+            },
+            "required": [
+                "@odata.id",
+                "@odata.type",
+                "Id",
+                "Name"
+            ],
+            "type": "object"
+        },
+        "ControlExcerpt": {
+            "additionalProperties": false,
+            "description": "The Control schema describes a control point and its properties.",
+            "excerpt": "Control",
+            "longDescription": "This resource shall represent a control point for a Redfish implementation.",
+            "patternProperties": {
+                "^([a-zA-Z_][a-zA-Z0-9_]*)?@(odata|Redfish|Message)\\.[a-zA-Z_][a-zA-Z0-9_]*$": {
+                    "description": "This property shall specify a valid odata or Redfish property.",
+                    "type": [
+                        "array",
+                        "boolean",
+                        "integer",
+                        "number",
+                        "null",
+                        "object",
+                        "string"
+                    ]
+                }
+            },
+            "properties": {
+                "AllowableMax": {
+                    "description": "The maximum possible setting for this control.",
+                    "excerpt": "Control",
+                    "longDescription": "This property shall indicate the maximum possible value of the SetPoint or SettingMax properties for this control.  Services shall not accept values for SetPoint or SettingMax above this value.",
+                    "readonly": true,
+                    "type": [
+                        "number",
+                        "null"
+                    ]
+                },
+                "AllowableMin": {
+                    "description": "The minimum possible setting for this control.",
+                    "excerpt": "Control",
+                    "longDescription": "This property shall indicate the minimum possible value of the SetPoint or SettingMin properties for this control.  Services shall not accept values for SetPoint or SettingMin below this value.",
+                    "readonly": true,
+                    "type": [
+                        "number",
+                        "null"
+                    ]
+                },
+                "ControlMode": {
+                    "anyOf": [
+                        {
+                            "$ref": "#/definitions/ControlMode"
+                        },
+                        {
+                            "type": "null"
+                        }
+                    ],
+                    "description": "The current operating mode of the control.",
+                    "excerpt": "Control",
+                    "longDescription": "This property shall contain the operating mode of the control.",
+                    "readonly": false
+                },
+                "DataSourceUri": {
+                    "description": "The link to the resource that provides the data for this control.",
+                    "excerptCopyOnly": true,
+                    "format": "uri-reference",
+                    "longDescription": "This property shall contain a URI to the resource that provides the source of the excerpt contained within this copy.  If no source resource is implemented, meaning the excerpt represents the only available data, this property shall not be present.",
+                    "readonly": true,
+                    "type": [
+                        "string",
+                        "null"
+                    ]
+                },
+                "Reading": {
+                    "description": "The reading of the sensor associated with this control.",
+                    "excerptCopyOnly": true,
+                    "longDescription": "This property shall contain the value of the Reading property of the Sensor resource directly associated with this control.  This property shall not be present if multiple sensors are associated with a single control.",
+                    "readonly": true,
+                    "type": [
+                        "number",
+                        "null"
+                    ]
+                },
+                "ReadingUnits": {
+                    "description": "The units of the sensor reading associated with this control.",
+                    "excerptCopyOnly": true,
+                    "longDescription": "This property shall contain the units of the sensor's reading and thresholds.  This property shall not be present if multiple sensors are associated with a single control.",
+                    "readonly": true,
+                    "type": [
+                        "string",
+                        "null"
+                    ]
+                }
+            },
+            "type": "object"
+        },
+        "ControlLoop": {
+            "additionalProperties": false,
+            "description": "The details and coefficients used to operate a control loop.",
+            "longDescription": "This type shall describe the details of a control loop.",
+            "patternProperties": {
+                "^([a-zA-Z_][a-zA-Z0-9_]*)?@(odata|Redfish|Message)\\.[a-zA-Z_][a-zA-Z0-9_]*$": {
+                    "description": "This property shall specify a valid odata or Redfish property.",
+                    "type": [
+                        "array",
+                        "boolean",
+                        "integer",
+                        "number",
+                        "null",
+                        "object",
+                        "string"
+                    ]
+                }
+            },
+            "properties": {
+                "CoefficientUpdateTime": {
+                    "description": "The date and time that the control loop coefficients were changed.",
+                    "format": "date-time",
+                    "longDescription": "This property shall contain the date and time that any of the coefficients for the control loop were last changed.",
+                    "readonly": true,
+                    "type": [
+                        "string",
+                        "null"
+                    ]
+                },
+                "Differential": {
+                    "description": "The differential coefficient.",
+                    "longDescription": "This property shall contain the coefficient for the differential factor in a control loop.",
+                    "readonly": false,
+                    "type": [
+                        "number",
+                        "null"
+                    ]
+                },
+                "Integral": {
+                    "description": "The integral coefficient.",
+                    "longDescription": "This property shall contain the coefficient for the integral factor in a control loop.",
+                    "readonly": false,
+                    "type": [
+                        "number",
+                        "null"
+                    ]
+                },
+                "Proportional": {
+                    "description": "The proportional coefficient.",
+                    "longDescription": "This property shall contain the coefficient for the proportional factor in a control loop.",
+                    "readonly": false,
+                    "type": [
+                        "number",
+                        "null"
+                    ]
+                }
+            },
+            "type": "object"
+        },
+        "ControlMode": {
+            "enum": [
+                "Automatic",
+                "Override",
+                "Manual",
+                "Disabled"
+            ],
+            "enumDescriptions": {
+                "Automatic": "Automatically adjust control to meet the set point.",
+                "Disabled": "The control has been disabled.",
+                "Manual": "No automatic adjustments are made to the control.",
+                "Override": "User override of the automatic set point value."
+            },
+            "type": "string"
+        },
+        "ControlRangeExcerpt": {
+            "additionalProperties": false,
+            "description": "The Control schema describes a control point and its properties.",
+            "excerpt": "ControlRange",
+            "longDescription": "This resource shall represent a control point for a Redfish implementation.",
+            "patternProperties": {
+                "^([a-zA-Z_][a-zA-Z0-9_]*)?@(odata|Redfish|Message)\\.[a-zA-Z_][a-zA-Z0-9_]*$": {
+                    "description": "This property shall specify a valid odata or Redfish property.",
+                    "type": [
+                        "array",
+                        "boolean",
+                        "integer",
+                        "number",
+                        "null",
+                        "object",
+                        "string"
+                    ]
+                }
+            },
+            "properties": {
+                "AllowableMax": {
+                    "description": "The maximum possible setting for this control.",
+                    "excerpt": "Control",
+                    "longDescription": "This property shall indicate the maximum possible value of the SetPoint or SettingMax properties for this control.  Services shall not accept values for SetPoint or SettingMax above this value.",
+                    "readonly": true,
+                    "type": [
+                        "number",
+                        "null"
+                    ]
+                },
+                "AllowableMin": {
+                    "description": "The minimum possible setting for this control.",
+                    "excerpt": "Control",
+                    "longDescription": "This property shall indicate the minimum possible value of the SetPoint or SettingMin properties for this control.  Services shall not accept values for SetPoint or SettingMin below this value.",
+                    "readonly": true,
+                    "type": [
+                        "number",
+                        "null"
+                    ]
+                },
+                "AllowableNumericValues": {
+                    "description": "The supported values for the set point.",
+                    "excerpt": "ControlRange",
+                    "items": {
+                        "type": [
+                            "number",
+                            "null"
+                        ]
+                    },
+                    "longDescription": "This property shall contain the supported values for this control.  The units shall follow the value of SetPointUnits.  This property should only be present when the set point or range has a limited set of supported values that cannot be accurately described using the Increment property.",
+                    "readonly": true,
+                    "type": "array"
+                },
+                "ControlMode": {
+                    "anyOf": [
+                        {
+                            "$ref": "#/definitions/ControlMode"
+                        },
+                        {
+                            "type": "null"
+                        }
+                    ],
+                    "description": "The current operating mode of the control.",
+                    "excerpt": "Control",
+                    "longDescription": "This property shall contain the operating mode of the control.",
+                    "readonly": false
+                },
+                "DataSourceUri": {
+                    "description": "The link to the resource that provides the data for this control.",
+                    "excerptCopyOnly": true,
+                    "format": "uri-reference",
+                    "longDescription": "This property shall contain a URI to the resource that provides the source of the excerpt contained within this copy.  If no source resource is implemented, meaning the excerpt represents the only available data, this property shall not be present.",
+                    "readonly": true,
+                    "type": [
+                        "string",
+                        "null"
+                    ]
+                },
+                "Reading": {
+                    "description": "The reading of the sensor associated with this control.",
+                    "excerptCopyOnly": true,
+                    "longDescription": "This property shall contain the value of the Reading property of the Sensor resource directly associated with this control.  This property shall not be present if multiple sensors are associated with a single control.",
+                    "readonly": true,
+                    "type": [
+                        "number",
+                        "null"
+                    ]
+                },
+                "ReadingUnits": {
+                    "description": "The units of the sensor reading associated with this control.",
+                    "excerptCopyOnly": true,
+                    "longDescription": "This property shall contain the units of the sensor's reading and thresholds.  This property shall not be present if multiple sensors are associated with a single control.",
+                    "readonly": true,
+                    "type": [
+                        "string",
+                        "null"
+                    ]
+                },
+                "SettingMax": {
+                    "description": "The maximum set point in the allowed range.",
+                    "excerpt": "ControlRange",
+                    "longDescription": "This property shall contain the maximum desired set point within the acceptable range.  The service shall reject values greater than the value of AllowableMax.  The units shall follow the value of SetPointUnits.",
+                    "readonly": false,
+                    "type": [
+                        "number",
+                        "null"
+                    ]
+                },
+                "SettingMin": {
+                    "description": "The minimum set point in the allowed range.",
+                    "excerpt": "ControlRange",
+                    "longDescription": "This property shall contain the minimum desired set point within the acceptable range.  The service shall reject values less than the value of AllowableMin.  The units shall follow the value of SetPointUnits.",
+                    "readonly": false,
+                    "type": [
+                        "number",
+                        "null"
+                    ]
+                }
+            },
+            "type": "object"
+        },
+        "ControlSingleExcerpt": {
+            "additionalProperties": false,
+            "description": "The Control schema describes a control point and its properties.",
+            "excerpt": "ControlSingle",
+            "longDescription": "This resource shall represent a control point for a Redfish implementation.",
+            "patternProperties": {
+                "^([a-zA-Z_][a-zA-Z0-9_]*)?@(odata|Redfish|Message)\\.[a-zA-Z_][a-zA-Z0-9_]*$": {
+                    "description": "This property shall specify a valid odata or Redfish property.",
+                    "type": [
+                        "array",
+                        "boolean",
+                        "integer",
+                        "number",
+                        "null",
+                        "object",
+                        "string"
+                    ]
+                }
+            },
+            "properties": {
+                "AllowableMax": {
+                    "description": "The maximum possible setting for this control.",
+                    "excerpt": "Control",
+                    "longDescription": "This property shall indicate the maximum possible value of the SetPoint or SettingMax properties for this control.  Services shall not accept values for SetPoint or SettingMax above this value.",
+                    "readonly": true,
+                    "type": [
+                        "number",
+                        "null"
+                    ]
+                },
+                "AllowableMin": {
+                    "description": "The minimum possible setting for this control.",
+                    "excerpt": "Control",
+                    "longDescription": "This property shall indicate the minimum possible value of the SetPoint or SettingMin properties for this control.  Services shall not accept values for SetPoint or SettingMin below this value.",
+                    "readonly": true,
+                    "type": [
+                        "number",
+                        "null"
+                    ]
+                },
+                "ControlMode": {
+                    "anyOf": [
+                        {
+                            "$ref": "#/definitions/ControlMode"
+                        },
+                        {
+                            "type": "null"
+                        }
+                    ],
+                    "description": "The current operating mode of the control.",
+                    "excerpt": "Control",
+                    "longDescription": "This property shall contain the operating mode of the control.",
+                    "readonly": false
+                },
+                "DataSourceUri": {
+                    "description": "The link to the resource that provides the data for this control.",
+                    "excerptCopyOnly": true,
+                    "format": "uri-reference",
+                    "longDescription": "This property shall contain a URI to the resource that provides the source of the excerpt contained within this copy.  If no source resource is implemented, meaning the excerpt represents the only available data, this property shall not be present.",
+                    "readonly": true,
+                    "type": [
+                        "string",
+                        "null"
+                    ]
+                },
+                "Reading": {
+                    "description": "The reading of the sensor associated with this control.",
+                    "excerptCopyOnly": true,
+                    "longDescription": "This property shall contain the value of the Reading property of the Sensor resource directly associated with this control.  This property shall not be present if multiple sensors are associated with a single control.",
+                    "readonly": true,
+                    "type": [
+                        "number",
+                        "null"
+                    ]
+                },
+                "ReadingUnits": {
+                    "description": "The units of the sensor reading associated with this control.",
+                    "excerptCopyOnly": true,
+                    "longDescription": "This property shall contain the units of the sensor's reading and thresholds.  This property shall not be present if multiple sensors are associated with a single control.",
+                    "readonly": true,
+                    "type": [
+                        "string",
+                        "null"
+                    ]
+                },
+                "SetPoint": {
+                    "description": "The desired set point of the control.",
+                    "excerpt": "ControlSingle",
+                    "longDescription": "This property shall contain the desired set point control value.  The units shall follow the value of SetPointUnits.",
+                    "readonly": false,
+                    "type": [
+                        "number",
+                        "null"
+                    ]
+                }
+            },
+            "type": "object"
+        },
+        "ControlType": {
+            "enum": [
+                "Temperature",
+                "Power",
+                "Frequency"
+            ],
+            "enumDescriptions": {
+                "Frequency": "Frequency control.",
+                "Power": "Power control or power limit.",
+                "Temperature": "Temperature control or thermostat."
+            },
+            "enumLongDescriptions": {
+                "Frequency": "This value shall indicate a control used to limit the operating frequency, measured in Hertz units, of a device, either to a single set point or within a range, and the SetPointUnits property shall contain `Hz`.",
+                "Power": "This value shall indicate a control used to regulate or limit maximum power consumption, in Watts units, either to a single set point or within a range, and the SetPointUnits property shall contain `W`.",
+                "Temperature": "This value shall indicate a control used to regulate temperature, in units of degrees Celsius, either to a single set point or within a range, and the SetPointUnits property shall contain `Cel`."
+            },
+            "type": "string"
+        },
+        "ImplementationType": {
+            "enum": [
+                "Programmable",
+                "Direct",
+                "Monitored"
+            ],
+            "enumDescriptions": {
+                "Direct": "The set point directly affects the control value.",
+                "Monitored": "A physical control that cannot be adjusted through this interface.",
+                "Programmable": "The set point can be adjusted through this interface."
+            },
+            "type": "string"
+        },
+        "OemActions": {
+            "additionalProperties": true,
+            "description": "The available OEM-specific actions for this resource.",
+            "longDescription": "This type shall contain the available OEM-specific actions for this resource.",
+            "patternProperties": {
+                "^([a-zA-Z_][a-zA-Z0-9_]*)?@(odata|Redfish|Message)\\.[a-zA-Z_][a-zA-Z0-9_]*$": {
+                    "description": "This property shall specify a valid odata or Redfish property.",
+                    "type": [
+                        "array",
+                        "boolean",
+                        "integer",
+                        "number",
+                        "null",
+                        "object",
+                        "string"
+                    ]
+                }
+            },
+            "properties": {},
+            "type": "object"
+        },
+        "SetPointType": {
+            "enum": [
+                "Single",
+                "Range"
+            ],
+            "enumDescriptions": {
+                "Range": "Control uses a range of values.",
+                "Single": "Control uses a single set point."
+            },
+            "enumLongDescriptions": {
+                "Range": "This value shall indicate the control utilizes a set point range for its operation.  The SettingMin and SettingMax properties shall be present for this control type.  The SetPoint property shall not be present for this control type.",
+                "Single": "This value shall indicate the control utilizes a single set point for its operation.  The SetPoint property shall be present for this control type.  The SettingMin and SettingMax properties shall not be present for this control type."
+            },
+            "type": "string"
+        }
+    },
+    "owningEntity": "DMTF",
+    "release": "2021.2",
+    "title": "#Control.v1_0_0.Control"
+}

--- a/static/redfish/v1/JsonSchemas/Control/index.json
+++ b/static/redfish/v1/JsonSchemas/Control/index.json
@@ -1,0 +1,21 @@
+{
+    "@odata.context": "/redfish/v1/$metadata#JsonSchemaFile.JsonSchemaFile",
+    "@odata.id": "/redfish/v1/JsonSchemas/Control",
+    "@odata.type": "#JsonSchemaFile.v1_0_2.JsonSchemaFile",
+    "Name": "Control Schema File",
+    "Schema": "#Control.Control",
+    "Description": "Control Schema File Location",
+    "Id": "Control",
+    "Languages": [
+        "en"
+    ],
+    "Languages@odata.count": 1,
+    "Location": [
+        {
+            "Language": "en",
+            "PublicationUri": "http://redfish.dmtf.org/schemas/v1/Control.json",
+            "Uri": "/redfish/v1/JsonSchemas/Control/Control.json"
+        }
+    ],
+    "Location@odata.count": 1
+}

--- a/static/redfish/v1/JsonSchemas/Endpoint/Endpoint.json
+++ b/static/redfish/v1/JsonSchemas/Endpoint/Endpoint.json
@@ -1,0 +1,745 @@
+{
+    "$id": "http://redfish.dmtf.org/schemas/v1/Endpoint.v1_6_1.json",
+    "$ref": "#/definitions/Endpoint",
+    "$schema": "http://redfish.dmtf.org/schemas/v1/redfish-schema-v1.json",
+    "copyright": "Copyright 2014-2021 DMTF. For the full DMTF copyright policy, see http://www.dmtf.org/about/policies/copyright",
+    "definitions": {
+        "Actions": {
+            "additionalProperties": false,
+            "description": "The available actions for this resource.",
+            "longDescription": "This type shall contain the available actions for this resource.",
+            "patternProperties": {
+                "^([a-zA-Z_][a-zA-Z0-9_]*)?@(odata|Redfish|Message)\\.[a-zA-Z_][a-zA-Z0-9_]*$": {
+                    "description": "This property shall specify a valid odata or Redfish property.",
+                    "type": [
+                        "array",
+                        "boolean",
+                        "integer",
+                        "number",
+                        "null",
+                        "object",
+                        "string"
+                    ]
+                }
+            },
+            "properties": {
+                "Oem": {
+                    "$ref": "#/definitions/OemActions",
+                    "description": "The available OEM-specific actions for this resource.",
+                    "longDescription": "This property shall contain the available OEM-specific actions for this resource."
+                }
+            },
+            "type": "object"
+        },
+        "ConnectedEntity": {
+            "additionalProperties": false,
+            "description": "Represents a remote resource that is connected to the network accessible to this endpoint.",
+            "longDescription": "This type shall represent a remote resource that is connected to a network accessible to an endpoint.",
+            "patternProperties": {
+                "^([a-zA-Z_][a-zA-Z0-9_]*)?@(odata|Redfish|Message)\\.[a-zA-Z_][a-zA-Z0-9_]*$": {
+                    "description": "This property shall specify a valid odata or Redfish property.",
+                    "type": [
+                        "array",
+                        "boolean",
+                        "integer",
+                        "number",
+                        "null",
+                        "object",
+                        "string"
+                    ]
+                }
+            },
+            "properties": {
+                "EntityLink": {
+                    "$ref": "http://redfish.dmtf.org/schemas/v1/Resource.json#/definitions/Resource",
+                    "description": "The link to the associated entity.",
+                    "longDescription": "This property shall contain a link to an entity of the type specified by the description of the EntityType property value.",
+                    "readonly": true
+                },
+                "EntityPciId": {
+                    "$ref": "#/definitions/PciId",
+                    "description": "The PCI ID of the connected entity.",
+                    "longDescription": "This property shall contain the PCI ID of the connected PCIe entity."
+                },
+                "EntityRole": {
+                    "anyOf": [
+                        {
+                            "$ref": "#/definitions/EntityRole"
+                        },
+                        {
+                            "type": "null"
+                        }
+                    ],
+                    "description": "The role of the connected entity.",
+                    "longDescription": "This property shall indicate if the specified entity is an initiator, target, or both.",
+                    "readonly": true
+                },
+                "EntityType": {
+                    "anyOf": [
+                        {
+                            "$ref": "#/definitions/EntityType"
+                        },
+                        {
+                            "type": "null"
+                        }
+                    ],
+                    "description": "The type of the connected entity.",
+                    "longDescription": "This property shall indicate if type of connected entity.",
+                    "readonly": true
+                },
+                "GenZ": {
+                    "anyOf": [
+                        {
+                            "$ref": "#/definitions/GenZ"
+                        },
+                        {
+                            "type": "null"
+                        }
+                    ],
+                    "description": "The Gen-Z related properties for the entity.",
+                    "longDescription": "This property shall contain the Gen-Z related properties for the entity.",
+                    "versionAdded": "v1_4_0"
+                },
+                "Identifiers": {
+                    "description": "Identifiers for the remote entity.",
+                    "items": {
+                        "$ref": "http://redfish.dmtf.org/schemas/v1/Resource.json#/definitions/Identifier"
+                    },
+                    "longDescription": "Identifiers for the remote entity shall be unique in the context of other resources that can reached over the connected network.",
+                    "type": "array"
+                },
+                "Oem": {
+                    "$ref": "http://redfish.dmtf.org/schemas/v1/Resource.json#/definitions/Oem",
+                    "description": "The OEM extension property.",
+                    "longDescription": "This property shall contain the OEM extensions.  All values for properties contained in this object shall conform to the Redfish Specification-described requirements."
+                },
+                "PciClassCode": {
+                    "deprecated": "This property has been deprecated in favor of the ClassCode property inside the EntityPciId object.",
+                    "description": "The Class Code, Subclass, and Programming Interface code of this PCIe function.",
+                    "longDescription": "This property shall contain the PCI Class Code, Subclass, and Programming Interface of the PCIe device function.",
+                    "pattern": "^0[xX](([a-fA-F]|[0-9]){2}){3}$",
+                    "readonly": true,
+                    "type": [
+                        "string",
+                        "null"
+                    ],
+                    "versionDeprecated": "v1_2_0"
+                },
+                "PciFunctionNumber": {
+                    "deprecated": "This property has been deprecated in favor of the FunctionNumber property inside the EntityPciId object.",
+                    "description": "The PCI ID of the connected entity.",
+                    "longDescription": "This property shall contain the PCI Function Number of the connected PCIe entity.",
+                    "readonly": true,
+                    "type": [
+                        "integer",
+                        "null"
+                    ],
+                    "versionDeprecated": "v1_2_0"
+                }
+            },
+            "type": "object"
+        },
+        "Endpoint": {
+            "additionalProperties": false,
+            "description": "The Endpoint schema contains the properties of an endpoint resource that represents the properties of an entity that sends or receives protocol-defined messages over a transport.",
+            "longDescription": "This resource contains a fabric endpoint for a Redfish implementation.",
+            "patternProperties": {
+                "^([a-zA-Z_][a-zA-Z0-9_]*)?@(odata|Redfish|Message)\\.[a-zA-Z_][a-zA-Z0-9_]*$": {
+                    "description": "This property shall specify a valid odata or Redfish property.",
+                    "type": [
+                        "array",
+                        "boolean",
+                        "integer",
+                        "number",
+                        "null",
+                        "object",
+                        "string"
+                    ]
+                }
+            },
+            "properties": {
+                "@odata.context": {
+                    "$ref": "http://redfish.dmtf.org/schemas/v1/odata-v4.json#/definitions/context"
+                },
+                "@odata.etag": {
+                    "$ref": "http://redfish.dmtf.org/schemas/v1/odata-v4.json#/definitions/etag"
+                },
+                "@odata.id": {
+                    "$ref": "http://redfish.dmtf.org/schemas/v1/odata-v4.json#/definitions/id"
+                },
+                "@odata.type": {
+                    "$ref": "http://redfish.dmtf.org/schemas/v1/odata-v4.json#/definitions/type"
+                },
+                "Actions": {
+                    "$ref": "#/definitions/Actions",
+                    "description": "The available actions for this resource.",
+                    "longDescription": "This property shall contain the available actions for this resource."
+                },
+                "ConnectedEntities": {
+                    "description": "All the entities connected to this endpoint.",
+                    "items": {
+                        "$ref": "#/definitions/ConnectedEntity"
+                    },
+                    "longDescription": "This property shall contain all entities to which this endpoint allows access.",
+                    "type": "array"
+                },
+                "Description": {
+                    "anyOf": [
+                        {
+                            "$ref": "http://redfish.dmtf.org/schemas/v1/Resource.json#/definitions/Description"
+                        },
+                        {
+                            "type": "null"
+                        }
+                    ],
+                    "readonly": true
+                },
+                "EndpointProtocol": {
+                    "anyOf": [
+                        {
+                            "$ref": "http://redfish.dmtf.org/schemas/v1/Protocol.json#/definitions/Protocol"
+                        },
+                        {
+                            "type": "null"
+                        }
+                    ],
+                    "description": "The protocol supported by this endpoint.",
+                    "longDescription": "This property shall contain the protocol this endpoint uses to communicate with other endpoints on this fabric.",
+                    "readonly": true
+                },
+                "HostReservationMemoryBytes": {
+                    "description": "The amount of memory in bytes that the host should allocate to connect to this endpoint.",
+                    "longDescription": "This property shall contain the amount of memory in bytes that the host should allocate to connect to this endpoint.",
+                    "readonly": true,
+                    "type": [
+                        "integer",
+                        "null"
+                    ],
+                    "units": "By"
+                },
+                "IPTransportDetails": {
+                    "description": "An array of details for each IP transport supported by this endpoint.  The array structure can model multiple IP addresses for this endpoint.",
+                    "items": {
+                        "$ref": "#/definitions/IPTransportDetails"
+                    },
+                    "longDescription": "This array shall contain the details for each IP transport supported by this endpoint.",
+                    "type": "array",
+                    "versionAdded": "v1_1_0"
+                },
+                "Id": {
+                    "$ref": "http://redfish.dmtf.org/schemas/v1/Resource.json#/definitions/Id",
+                    "readonly": true
+                },
+                "Identifiers": {
+                    "description": "Identifiers for this endpoint.",
+                    "items": {
+                        "$ref": "http://redfish.dmtf.org/schemas/v1/Resource.json#/definitions/Identifier"
+                    },
+                    "longDescription": "Identifiers for this endpoint shall be unique in the context of other endpoints that can reached over the connected network.",
+                    "type": "array"
+                },
+                "Links": {
+                    "$ref": "#/definitions/Links",
+                    "description": "The links to other resources that are related to this resource.",
+                    "longDescription": "This property shall contain links to resources that are related to but are not contained by, or subordinate to, this resource."
+                },
+                "Name": {
+                    "$ref": "http://redfish.dmtf.org/schemas/v1/Resource.json#/definitions/Name",
+                    "readonly": true
+                },
+                "Oem": {
+                    "$ref": "http://redfish.dmtf.org/schemas/v1/Resource.json#/definitions/Oem",
+                    "description": "The OEM extension property.",
+                    "longDescription": "This property shall contain the OEM extensions.  All values for properties that this object contains shall conform to the Redfish Specification-described requirements."
+                },
+                "PciId": {
+                    "$ref": "#/definitions/PciId",
+                    "description": "The PCI ID of the endpoint.",
+                    "longDescription": "This property shall contain the PCI ID of the endpoint."
+                },
+                "Redundancy": {
+                    "autoExpand": true,
+                    "description": "Redundancy information for the lower-level endpoints supporting this endpoint.",
+                    "items": {
+                        "$ref": "http://redfish.dmtf.org/schemas/v1/Redundancy.json#/definitions/Redundancy"
+                    },
+                    "longDescription": "The values of the properties in this array shall show how this endpoint is grouped with other endpoints for form redundancy sets.",
+                    "type": "array"
+                },
+                "Redundancy@odata.count": {
+                    "$ref": "http://redfish.dmtf.org/schemas/v1/odata-v4.json#/definitions/count"
+                },
+                "Status": {
+                    "$ref": "http://redfish.dmtf.org/schemas/v1/Resource.json#/definitions/Status",
+                    "description": "The status and health of the resource and its subordinate or dependent resources.",
+                    "longDescription": "This property shall contain any status or health properties of the resource."
+                }
+            },
+            "required": [
+                "@odata.id",
+                "@odata.type",
+                "Id",
+                "Name"
+            ],
+            "type": "object"
+        },
+        "EntityRole": {
+            "enum": [
+                "Initiator",
+                "Target",
+                "Both"
+            ],
+            "enumDescriptions": {
+                "Both": "The entity can both send and receive commands, messages, and other requests to or from other entities on the fabric.",
+                "Initiator": "The entity sends commands, messages, or other types of requests to other entities on the fabric, but cannot receive commands from other entities.",
+                "Target": "The entity receives commands, messages, or other types of requests from other entities on the fabric, but cannot send commands to other entities."
+            },
+            "type": "string"
+        },
+        "EntityType": {
+            "enum": [
+                "StorageInitiator",
+                "RootComplex",
+                "NetworkController",
+                "Drive",
+                "StorageExpander",
+                "DisplayController",
+                "Bridge",
+                "Processor",
+                "Volume",
+                "AccelerationFunction",
+                "MediaController",
+                "MemoryChunk",
+                "Switch",
+                "FabricBridge",
+                "Manager",
+                "StorageSubsystem"
+            ],
+            "enumDescriptions": {
+                "AccelerationFunction": "The entity is an acceleration function realized through a device, such as an FPGA.",
+                "Bridge": "The entity is a PCI(e) bridge.",
+                "DisplayController": "The entity is a display controller.",
+                "Drive": "The entity is a drive.",
+                "FabricBridge": "The entity is a fabric bridge.",
+                "Manager": "The entity is a manager.",
+                "MediaController": "The entity is a media controller.",
+                "MemoryChunk": "The entity is a memory chunk.",
+                "NetworkController": "The entity is a network controller.",
+                "Processor": "The entity is a processor.",
+                "RootComplex": "The entity is a PCI(e) root complex.",
+                "StorageExpander": "The entity is a storage expander.",
+                "StorageInitiator": "The entity is a storage initiator.",
+                "StorageSubsystem": "The entity is a storage subsystem.",
+                "Switch": "The entity is a switch, not an expander.  Use `Expander` for expanders.",
+                "Volume": "The entity is a volume."
+            },
+            "enumLongDescriptions": {
+                "AccelerationFunction": "This value shall indicate the entity this endpoint represents is an acceleration function.  The EntityLink property, if present, should be of type AccelerationFunction.",
+                "Bridge": "This value shall indicate the entity this endpoint represents is a PCI(e) bridge.",
+                "DisplayController": "This value shall indicate the entity this endpoint represents is a display controller.",
+                "Drive": "This value shall indicate the entity this endpoint represents is a drive.  The EntityLink property, if present, should be of type Drive.",
+                "FabricBridge": "This value shall indicate the entity this endpoint represents is a fabric bridge.  The EntityLink property, if present, should be of type FabricAdapter.",
+                "Manager": "This value shall indicate the entity this endpoint represents is a manager.  The EntityLink property, if present, should be of type Manager.",
+                "MediaController": "This value shall indicate the entity this endpoint represents is a media controller.  The EntityLink property, if present, should be of type MediaController.",
+                "MemoryChunk": "This value shall indicate the entity this endpoint represents is a memory chunk.  The EntityLink property, if present, should be of type MemoryChunk.",
+                "NetworkController": "This value shall indicate the entity this endpoint represents is a network controller.  The EntityLink property, if present, should be of type NetworkDeviceFunction or EthernetInterface.",
+                "Processor": "This value shall indicate the entity this endpoint represents is a processor.  The EntityLink property, if present, should be of type Processor.",
+                "RootComplex": "This value shall indicate the entity this endpoint represents is a PCI(e) root complex.  The EntityLink property, if present, should be of type ComputerSystem.",
+                "StorageExpander": "This value shall indicate the entity this endpoint represents is a storage expander.  The EntityLink property, if present, should be of type Chassis.",
+                "StorageInitiator": "This value shall indicate the entity this endpoint represents is a storage initiator.  The EntityLink property, if present, should be of type StorageController.",
+                "StorageSubsystem": "This value shall indicate the entity this endpoint represents is a storage subsystem.  The EntityLink property, if present, should be of type Storage.",
+                "Switch": "This value shall indicate the entity this endpoint represents is a switch and not an expander.  The EntityLink property, if present, should be of type Switch.",
+                "Volume": "This value shall indicate the entity this endpoint represents is a volume.  The EntityLink property, if present, should be of type Volume."
+            },
+            "enumVersionAdded": {
+                "AccelerationFunction": "v1_3_0",
+                "FabricBridge": "v1_4_0",
+                "Manager": "v1_5_0",
+                "MediaController": "v1_4_0",
+                "MemoryChunk": "v1_4_0",
+                "StorageSubsystem": "v1_6_0",
+                "Switch": "v1_4_0",
+                "Volume": "v1_1_0"
+            },
+            "type": "string"
+        },
+        "GCID": {
+            "additionalProperties": false,
+            "description": "The Global Component ID (GCID).",
+            "longDescription": "This type shall contain the Gen-Z Core Specification-defined Global Component ID.",
+            "patternProperties": {
+                "^([a-zA-Z_][a-zA-Z0-9_]*)?@(odata|Redfish|Message)\\.[a-zA-Z_][a-zA-Z0-9_]*$": {
+                    "description": "This property shall specify a valid odata or Redfish property.",
+                    "type": [
+                        "array",
+                        "boolean",
+                        "integer",
+                        "number",
+                        "null",
+                        "object",
+                        "string"
+                    ]
+                }
+            },
+            "properties": {
+                "CID": {
+                    "description": "The component identifier portion of the GCID for the entity.",
+                    "longDescription": "This property shall contain the 12 bit component identifier portion of the GCID of the entity.",
+                    "pattern": "^0[xX]([a-fA-F]|[0-9]){3}$",
+                    "readonly": false,
+                    "type": [
+                        "string",
+                        "null"
+                    ],
+                    "versionAdded": "v1_4_0"
+                },
+                "SID": {
+                    "description": "The subnet identifier portion of the GCID for the entity.",
+                    "longDescription": "This property shall contain the 16 bit subnet identifier portion of the GCID of the entity.",
+                    "pattern": "^0[xX](([a-fA-F]|[0-9]){2}){2}$",
+                    "readonly": false,
+                    "type": [
+                        "string",
+                        "null"
+                    ],
+                    "versionAdded": "v1_4_0"
+                }
+            },
+            "type": "object"
+        },
+        "GenZ": {
+            "additionalProperties": false,
+            "description": "The Gen-Z related properties for an entity.",
+            "longDescription": "This type shall contain the Gen-Z related properties for an entity.",
+            "patternProperties": {
+                "^([a-zA-Z_][a-zA-Z0-9_]*)?@(odata|Redfish|Message)\\.[a-zA-Z_][a-zA-Z0-9_]*$": {
+                    "description": "This property shall specify a valid odata or Redfish property.",
+                    "type": [
+                        "array",
+                        "boolean",
+                        "integer",
+                        "number",
+                        "null",
+                        "object",
+                        "string"
+                    ]
+                }
+            },
+            "properties": {
+                "AccessKey": {
+                    "deprecated": "This property has been deprecated in favor of the ConnectionKeys property in the Connection resource.",
+                    "description": "The Access Key for the entity.",
+                    "longDescription": "This property shall contain the Gen-Z Core Specification-defined 6 bit Access Key for the entity.",
+                    "pattern": "^0[xX]([a-fA-F]|[0-9]){2}$",
+                    "readonly": false,
+                    "type": [
+                        "string",
+                        "null"
+                    ],
+                    "versionAdded": "v1_4_0",
+                    "versionDeprecated": "v1_6_0"
+                },
+                "GCID": {
+                    "anyOf": [
+                        {
+                            "$ref": "#/definitions/GCID"
+                        },
+                        {
+                            "type": "null"
+                        }
+                    ],
+                    "description": "The Global Component ID (GCID) for the entity.",
+                    "longDescription": "This property shall contain the Gen-Z Core Specification-defined Global Component ID for the entity.",
+                    "versionAdded": "v1_4_0"
+                },
+                "RegionKey": {
+                    "deprecated": "This property has been deprecated in favor of the ConnectionKeys property in the Connection resource.",
+                    "description": "The Region Key for the entity.",
+                    "longDescription": "This property shall contain the Gen-Z Core Specification-defined 32 bit Region Key for the entity.",
+                    "pattern": "^0[xX](([a-fA-F]|[0-9]){2}){4}$",
+                    "readonly": false,
+                    "type": [
+                        "string",
+                        "null"
+                    ],
+                    "versionAdded": "v1_4_0",
+                    "versionDeprecated": "v1_6_0"
+                }
+            },
+            "type": "object"
+        },
+        "IPTransportDetails": {
+            "additionalProperties": false,
+            "description": "This type specifies the details of the transport supported by the endpoint.  The properties that are present are dependent on the type of transport supported by the endpoint.",
+            "longDescription": "The type shall contain properties that specify the details of the transport supported by the endpoint.",
+            "patternProperties": {
+                "^([a-zA-Z_][a-zA-Z0-9_]*)?@(odata|Redfish|Message)\\.[a-zA-Z_][a-zA-Z0-9_]*$": {
+                    "description": "This property shall specify a valid odata or Redfish property.",
+                    "type": [
+                        "array",
+                        "boolean",
+                        "integer",
+                        "number",
+                        "null",
+                        "object",
+                        "string"
+                    ]
+                }
+            },
+            "properties": {
+                "IPv4Address": {
+                    "$ref": "http://redfish.dmtf.org/schemas/v1/IPAddresses.json#/definitions/IPv4Address",
+                    "description": "The IPv4 addresses assigned to the endpoint.",
+                    "longDescription": "This property shall contain the IPv4Address.",
+                    "versionAdded": "v1_1_0"
+                },
+                "IPv6Address": {
+                    "$ref": "http://redfish.dmtf.org/schemas/v1/IPAddresses.json#/definitions/IPv6Address",
+                    "description": "The IPv6 addresses assigned to the endpoint.",
+                    "longDescription": "This property shall contain the IPv6Address.",
+                    "versionAdded": "v1_1_0"
+                },
+                "Port": {
+                    "description": "The UDP or TCP port number used by the endpoint.",
+                    "longDescription": "This property shall contain an specify UDP or TCP port number used for communication with the endpoint.",
+                    "maximum": 65535,
+                    "minimum": 0,
+                    "readonly": true,
+                    "type": "number",
+                    "versionAdded": "v1_1_0"
+                },
+                "TransportProtocol": {
+                    "$ref": "http://redfish.dmtf.org/schemas/v1/Protocol.json#/definitions/Protocol",
+                    "description": "The protocol used by the connection entity.",
+                    "longDescription": "This property shall contain the protocol used by the connection entity.",
+                    "readonly": true,
+                    "versionAdded": "v1_1_0"
+                }
+            },
+            "type": "object"
+        },
+        "Links": {
+            "additionalProperties": false,
+            "description": "The links to other resources that are related to this resource.",
+            "longDescription": "This Redfish Specification-described type shall contain links to resources that are related to but are not contained by, or subordinate to, this resource.",
+            "patternProperties": {
+                "^([a-zA-Z_][a-zA-Z0-9_]*)?@(odata|Redfish|Message)\\.[a-zA-Z_][a-zA-Z0-9_]*$": {
+                    "description": "This property shall specify a valid odata or Redfish property.",
+                    "type": [
+                        "array",
+                        "boolean",
+                        "integer",
+                        "number",
+                        "null",
+                        "object",
+                        "string"
+                    ]
+                }
+            },
+            "properties": {
+                "AddressPools": {
+                    "description": "An array of links to the address pools associated with this endpoint.",
+                    "items": {
+                        "$ref": "http://redfish.dmtf.org/schemas/v1/AddressPool.json#/definitions/AddressPool"
+                    },
+                    "longDescription": "This property shall contain an array of links to resources of type AddressPool with which this endpoint is associated.",
+                    "readonly": false,
+                    "type": "array",
+                    "versionAdded": "v1_4_0"
+                },
+                "AddressPools@odata.count": {
+                    "$ref": "http://redfish.dmtf.org/schemas/v1/odata-v4.json#/definitions/count"
+                },
+                "ConnectedPorts": {
+                    "description": "An array of links to the ports that connect to this endpoint.",
+                    "items": {
+                        "$ref": "http://redfish.dmtf.org/schemas/v1/Port.json#/definitions/Port"
+                    },
+                    "longDescription": "This property shall contain an array of links to resources of type Port that represent ports associated with this endpoint.",
+                    "readonly": true,
+                    "type": "array",
+                    "versionAdded": "v1_4_0"
+                },
+                "ConnectedPorts@odata.count": {
+                    "$ref": "http://redfish.dmtf.org/schemas/v1/odata-v4.json#/definitions/count"
+                },
+                "Connections": {
+                    "description": "The connections to which this endpoint belongs.",
+                    "items": {
+                        "$ref": "http://redfish.dmtf.org/schemas/v1/Connection.json#/definitions/Connection"
+                    },
+                    "longDescription": "This property shall contain an array of links to resources of type Connection that represent the connections to which this endpoint belongs.",
+                    "readonly": true,
+                    "type": "array",
+                    "versionAdded": "v1_5_0"
+                },
+                "Connections@odata.count": {
+                    "$ref": "http://redfish.dmtf.org/schemas/v1/odata-v4.json#/definitions/count"
+                },
+                "MutuallyExclusiveEndpoints": {
+                    "description": "An array of links to the endpoints that cannot be used in zones if this endpoint is in a zone.",
+                    "items": {
+                        "$ref": "http://redfish.dmtf.org/schemas/v1/Endpoint.json#/definitions/Endpoint"
+                    },
+                    "longDescription": "This property shall contain an array of links to resources of type Endpoint that cannot be used in a zone if this endpoint is in a zone.",
+                    "readonly": true,
+                    "type": "array"
+                },
+                "MutuallyExclusiveEndpoints@odata.count": {
+                    "$ref": "http://redfish.dmtf.org/schemas/v1/odata-v4.json#/definitions/count"
+                },
+                "NetworkDeviceFunction": {
+                    "description": "When NetworkDeviceFunction resources are present, this array contains links to the network device functions that connect to this endpoint.",
+                    "items": {
+                        "$ref": "http://redfish.dmtf.org/schemas/v1/NetworkDeviceFunction.json#/definitions/NetworkDeviceFunction"
+                    },
+                    "longDescription": "This property shall contain an array of links to resources of type NetworkDeviceFunction with which this endpoint is associated.",
+                    "readonly": true,
+                    "type": "array",
+                    "versionAdded": "v1_1_0"
+                },
+                "NetworkDeviceFunction@odata.count": {
+                    "$ref": "http://redfish.dmtf.org/schemas/v1/odata-v4.json#/definitions/count"
+                },
+                "Oem": {
+                    "$ref": "http://redfish.dmtf.org/schemas/v1/Resource.json#/definitions/Oem",
+                    "description": "The OEM extension property.",
+                    "longDescription": "This property shall contain the OEM extensions.  All values for properties contained in this object shall conform to the Redfish Specification-described requirements."
+                },
+                "Ports": {
+                    "description": "An array of links to the physical ports associated with this endpoint.",
+                    "items": {
+                        "$ref": "http://redfish.dmtf.org/schemas/v1/Port.json#/definitions/Port"
+                    },
+                    "longDescription": "This property shall contain an array of links to resources of type Port that are utilized by this endpoint.",
+                    "readonly": true,
+                    "type": "array"
+                },
+                "Ports@odata.count": {
+                    "$ref": "http://redfish.dmtf.org/schemas/v1/odata-v4.json#/definitions/count"
+                },
+                "Zones": {
+                    "description": "The zones to which this endpoint belongs.",
+                    "items": {
+                        "$ref": "http://redfish.dmtf.org/schemas/v1/Zone.json#/definitions/Zone"
+                    },
+                    "longDescription": "This property shall contain an array of links to resources of type Zone that represent the zones to which this endpoint belongs.",
+                    "readonly": true,
+                    "type": "array",
+                    "versionAdded": "v1_6_0"
+                },
+                "Zones@odata.count": {
+                    "$ref": "http://redfish.dmtf.org/schemas/v1/odata-v4.json#/definitions/count"
+                }
+            },
+            "type": "object"
+        },
+        "OemActions": {
+            "additionalProperties": true,
+            "description": "The available OEM-specific actions for this resource.",
+            "longDescription": "This type shall contain the available OEM-specific actions for this resource.",
+            "patternProperties": {
+                "^([a-zA-Z_][a-zA-Z0-9_]*)?@(odata|Redfish|Message)\\.[a-zA-Z_][a-zA-Z0-9_]*$": {
+                    "description": "This property shall specify a valid odata or Redfish property.",
+                    "type": [
+                        "array",
+                        "boolean",
+                        "integer",
+                        "number",
+                        "null",
+                        "object",
+                        "string"
+                    ]
+                }
+            },
+            "properties": {},
+            "type": "object"
+        },
+        "PciId": {
+            "additionalProperties": false,
+            "description": "A PCI ID.",
+            "longDescription": "This type shall describe a PCI ID.",
+            "patternProperties": {
+                "^([a-zA-Z_][a-zA-Z0-9_]*)?@(odata|Redfish|Message)\\.[a-zA-Z_][a-zA-Z0-9_]*$": {
+                    "description": "This property shall specify a valid odata or Redfish property.",
+                    "type": [
+                        "array",
+                        "boolean",
+                        "integer",
+                        "number",
+                        "null",
+                        "object",
+                        "string"
+                    ]
+                }
+            },
+            "properties": {
+                "ClassCode": {
+                    "description": "The Class Code, Subclass, and Programming Interface code of this PCIe function.",
+                    "longDescription": "This property shall contain the PCI Class Code, Subclass, and Programming Interface of the PCIe device function.",
+                    "pattern": "^0[xX](([a-fA-F]|[0-9]){2}){3}$",
+                    "readonly": true,
+                    "type": [
+                        "string",
+                        "null"
+                    ],
+                    "versionAdded": "v1_2_0"
+                },
+                "DeviceId": {
+                    "description": "The Device ID of this PCIe function.",
+                    "longDescription": "This property shall contain the PCI Device ID of the PCIe device function.",
+                    "pattern": "^0[xX](([a-fA-F]|[0-9]){2}){2}$",
+                    "readonly": true,
+                    "type": [
+                        "string",
+                        "null"
+                    ]
+                },
+                "FunctionNumber": {
+                    "description": "The PCI ID of the connected entity.",
+                    "longDescription": "This property shall contain the PCI Function Number of the connected PCIe entity.",
+                    "readonly": true,
+                    "type": [
+                        "integer",
+                        "null"
+                    ],
+                    "versionAdded": "v1_2_0"
+                },
+                "SubsystemId": {
+                    "description": "The Subsystem ID of this PCIe function.",
+                    "longDescription": "This property shall contain the PCI Subsystem ID of the PCIe device function.",
+                    "pattern": "^0[xX](([a-fA-F]|[0-9]){2}){2}$",
+                    "readonly": true,
+                    "type": [
+                        "string",
+                        "null"
+                    ]
+                },
+                "SubsystemVendorId": {
+                    "description": "The Subsystem Vendor ID of this PCIe function.",
+                    "longDescription": "This property shall contain the PCI Subsystem Vendor ID of the PCIe device function.",
+                    "pattern": "^0[xX](([a-fA-F]|[0-9]){2}){2}$",
+                    "readonly": true,
+                    "type": [
+                        "string",
+                        "null"
+                    ]
+                },
+                "VendorId": {
+                    "description": "The Vendor ID of this PCIe function.",
+                    "longDescription": "This property shall contain the PCI Vendor ID of the PCIe device function.",
+                    "pattern": "^0[xX](([a-fA-F]|[0-9]){2}){2}$",
+                    "readonly": true,
+                    "type": [
+                        "string",
+                        "null"
+                    ]
+                }
+            },
+            "type": "object"
+        }
+    },
+    "owningEntity": "DMTF",
+    "release": "2021.1",
+    "title": "#Endpoint.v1_6_1.Endpoint"
+}

--- a/static/redfish/v1/JsonSchemas/Endpoint/index.json
+++ b/static/redfish/v1/JsonSchemas/Endpoint/index.json
@@ -1,0 +1,21 @@
+{
+    "@odata.context": "/redfish/v1/$metadata#JsonSchemaFile.JsonSchemaFile",
+    "@odata.id": "/redfish/v1/JsonSchemas/Endpoint",
+    "@odata.type": "#JsonSchemaFile.v1_0_2.JsonSchemaFile",
+    "Name": "Endpoint Schema File",
+    "Schema": "#Endpoint.Endpoint",
+    "Description": "Endpoint Schema File Location",
+    "Id": "Endpoint",
+    "Languages": [
+        "en"
+    ],
+    "Languages@odata.count": 1,
+    "Location": [
+        {
+            "Language": "en",
+            "PublicationUri": "http://redfish.dmtf.org/schemas/v1/Endpoint.json",
+            "Uri": "/redfish/v1/JsonSchemas/Endpoint/Endpoint.json"
+        }
+    ],
+    "Location@odata.count": 1
+}

--- a/static/redfish/v1/JsonSchemas/EndpointGroup/EndpointGroup.json
+++ b/static/redfish/v1/JsonSchemas/EndpointGroup/EndpointGroup.json
@@ -1,0 +1,288 @@
+{
+    "$id": "http://redfish.dmtf.org/schemas/v1/EndpointGroup.v1_3_2.json",
+    "$ref": "#/definitions/EndpointGroup",
+    "$schema": "http://redfish.dmtf.org/schemas/v1/redfish-schema-v1.json",
+    "copyright": "Copyright 2014-2021 DMTF. For the full DMTF copyright policy, see http://www.dmtf.org/about/policies/copyright",
+    "definitions": {
+        "Actions": {
+            "additionalProperties": false,
+            "description": "The available actions for this resource.",
+            "longDescription": "This type shall contain the available actions for this resource.",
+            "patternProperties": {
+                "^([a-zA-Z_][a-zA-Z0-9_]*)?@(odata|Redfish|Message)\\.[a-zA-Z_][a-zA-Z0-9_]*$": {
+                    "description": "This property shall specify a valid odata or Redfish property.",
+                    "type": [
+                        "array",
+                        "boolean",
+                        "integer",
+                        "number",
+                        "null",
+                        "object",
+                        "string"
+                    ]
+                }
+            },
+            "properties": {
+                "Oem": {
+                    "$ref": "#/definitions/OemActions",
+                    "description": "The available OEM-specific actions for this resource.",
+                    "longDescription": "This property shall contain the available OEM-specific actions for this resource.",
+                    "versionAdded": "v1_1_0"
+                }
+            },
+            "type": "object"
+        },
+        "EndpointGroup": {
+            "additionalProperties": false,
+            "description": "The EndpointGroup schema describes group of endpoints that are managed as a unit.",
+            "longDescription": "This resource shall represent a group of endpoints that are managed as a unit for a Redfish implementation.",
+            "patternProperties": {
+                "^([a-zA-Z_][a-zA-Z0-9_]*)?@(odata|Redfish|Message)\\.[a-zA-Z_][a-zA-Z0-9_]*$": {
+                    "description": "This property shall specify a valid odata or Redfish property.",
+                    "type": [
+                        "array",
+                        "boolean",
+                        "integer",
+                        "number",
+                        "null",
+                        "object",
+                        "string"
+                    ]
+                }
+            },
+            "properties": {
+                "@odata.context": {
+                    "$ref": "http://redfish.dmtf.org/schemas/v1/odata-v4.json#/definitions/context"
+                },
+                "@odata.etag": {
+                    "$ref": "http://redfish.dmtf.org/schemas/v1/odata-v4.json#/definitions/etag"
+                },
+                "@odata.id": {
+                    "$ref": "http://redfish.dmtf.org/schemas/v1/odata-v4.json#/definitions/id"
+                },
+                "@odata.type": {
+                    "$ref": "http://redfish.dmtf.org/schemas/v1/odata-v4.json#/definitions/type"
+                },
+                "AccessState": {
+                    "anyOf": [
+                        {
+                            "$ref": "http://redfish.dmtf.org/schemas/v1/EndpointGroup.json#/definitions/AccessState"
+                        },
+                        {
+                            "type": "null"
+                        }
+                    ],
+                    "deprecated": "This property has been deprecated in favor of the AccessState property in the connection resource.",
+                    "description": "The access state for this group.",
+                    "longDescription": "The value of this property shall contain the access state for all associated resources in this endpoint group.",
+                    "readonly": false,
+                    "versionDeprecated": "v1_3_0"
+                },
+                "Actions": {
+                    "$ref": "#/definitions/Actions",
+                    "description": "The available actions for this resource.",
+                    "longDescription": "This property shall contain the available actions for this resource.",
+                    "versionAdded": "v1_1_0"
+                },
+                "Description": {
+                    "anyOf": [
+                        {
+                            "$ref": "http://redfish.dmtf.org/schemas/v1/Resource.json#/definitions/Description"
+                        },
+                        {
+                            "type": "null"
+                        }
+                    ],
+                    "readonly": true
+                },
+                "Endpoints": {
+                    "deprecated": "This property has been deprecated in favor of the Endpoints property within Links.",
+                    "description": "The endpoints in this endpoint group.",
+                    "items": {
+                        "$ref": "http://redfish.dmtf.org/schemas/v1/Endpoint.json#/definitions/Endpoint"
+                    },
+                    "longDescription": "This property shall contain an array of links to resources of type Endpoint that represent the endpoints that are in this endpoint group.",
+                    "readonly": false,
+                    "type": "array",
+                    "versionDeprecated": "v1_3_0"
+                },
+                "Endpoints@odata.count": {
+                    "$ref": "http://redfish.dmtf.org/schemas/v1/odata-v4.json#/definitions/count"
+                },
+                "GroupType": {
+                    "anyOf": [
+                        {
+                            "$ref": "#/definitions/GroupType"
+                        },
+                        {
+                            "type": "null"
+                        }
+                    ],
+                    "description": "The endpoint group type.",
+                    "longDescription": "The value of this property shall contain the endpoint group type.  If this endpoint group represents a SCSI target group, the value of this property shall contain `Server` or `Target`.",
+                    "readonly": false
+                },
+                "Id": {
+                    "$ref": "http://redfish.dmtf.org/schemas/v1/Resource.json#/definitions/Id",
+                    "readonly": true
+                },
+                "Identifier": {
+                    "$ref": "http://redfish.dmtf.org/schemas/v1/Resource.json#/definitions/Identifier",
+                    "description": "The durable name for the endpoint group.",
+                    "longDescription": "This property shall contain the durable name for the endpoint group."
+                },
+                "Links": {
+                    "$ref": "#/definitions/Links",
+                    "description": "The links to other resources that are related to this resource.",
+                    "longDescription": "This property shall contain links to resources that are related to but are not contained by, or subordinate to, this resource."
+                },
+                "Name": {
+                    "$ref": "http://redfish.dmtf.org/schemas/v1/Resource.json#/definitions/Name",
+                    "readonly": true
+                },
+                "Oem": {
+                    "$ref": "http://redfish.dmtf.org/schemas/v1/Resource.json#/definitions/Oem",
+                    "description": "The OEM extension property.",
+                    "longDescription": "This property shall contain the OEM extensions.  All values for properties that this object contains shall conform to the Redfish Specification-described requirements."
+                },
+                "Preferred": {
+                    "deprecated": "This property has been deprecated in favor of the AccessState property in the connection resource.",
+                    "description": "An indication if access to the resources through the endpoint group is preferred.",
+                    "longDescription": "The value of this property shall indicate if access to the resources through the endpoint group is preferred over access through other endpoints.  The default value for this property is `false`.",
+                    "readonly": false,
+                    "type": [
+                        "boolean",
+                        "null"
+                    ],
+                    "versionDeprecated": "v1_2_0"
+                },
+                "TargetEndpointGroupIdentifier": {
+                    "description": "The SCSI-defined identifier for this group.",
+                    "longDescription": "The value of this property shall contain a SCSI-defined identifier for this group that corresponds to the TARGET PORT GROUP field in the REPORT TARGET PORT GROUPS response and the TARGET PORT GROUP field in an INQUIRY VPD page 85 response, type 5h identifier.  See the INCITS SAM-5 specification.  This property may not be present if the endpoint group does not represent a SCSI target group.",
+                    "readonly": false,
+                    "type": [
+                        "integer",
+                        "null"
+                    ]
+                }
+            },
+            "required": [
+                "@odata.id",
+                "@odata.type",
+                "Id",
+                "Name"
+            ],
+            "type": "object"
+        },
+        "GroupType": {
+            "enum": [
+                "Client",
+                "Server",
+                "Initiator",
+                "Target"
+            ],
+            "enumDeprecated": {
+                "Client": "This value has been deprecated in favor of `Initiator`.",
+                "Server": "This value has been deprecated in favor of `Target`."
+            },
+            "enumDescriptions": {
+                "Client": "The group contains the client (initiator) endpoints.",
+                "Initiator": "The group contains the initiator endpoints.",
+                "Server": "The group contains the server (target) endpoints.",
+                "Target": "The group contains the target endpoints."
+            },
+            "enumLongDescriptions": {
+                "Client": "This value shall indicate that the endpoint group contains client (initiator) endpoints.  If the associated endpoints contain the EntityRole property, the EntityRole property shall contain the value `Initiator` or `Both`.",
+                "Initiator": "This value shall indicate that the endpoint group contains initiator endpoints.  If the associated endpoints contain the EntityRole property, the EntityRole property shall contain the value `Initiator` or `Both`.",
+                "Server": "This value shall indicate that the endpoint group contains server (target) endpoints.  If the associated endpoints contain the EntityRole property, the EntityRole property shall contain the value `Target` or `Both`.",
+                "Target": "This value shall indicate that the endpoint group contains target endpoints.  If the associated endpoints contain the EntityRole property, the EntityRole property shall contain the value `Target` or `Both`."
+            },
+            "enumVersionAdded": {
+                "Initiator": "v1_3_0",
+                "Target": "v1_3_0"
+            },
+            "enumVersionDeprecated": {
+                "Client": "v1_3_0",
+                "Server": "v1_3_0"
+            },
+            "type": "string"
+        },
+        "Links": {
+            "additionalProperties": false,
+            "description": "The links to other resources that are related to this resource.",
+            "longDescription": "This Redfish Specification-described type shall contain links to resources that are related to but are not contained by, or subordinate to, this resource.",
+            "patternProperties": {
+                "^([a-zA-Z_][a-zA-Z0-9_]*)?@(odata|Redfish|Message)\\.[a-zA-Z_][a-zA-Z0-9_]*$": {
+                    "description": "This property shall specify a valid odata or Redfish property.",
+                    "type": [
+                        "array",
+                        "boolean",
+                        "integer",
+                        "number",
+                        "null",
+                        "object",
+                        "string"
+                    ]
+                }
+            },
+            "properties": {
+                "Connections": {
+                    "description": "The connections to which this endpoint group belongs.",
+                    "items": {
+                        "$ref": "http://redfish.dmtf.org/schemas/v1/Connection.json#/definitions/Connection"
+                    },
+                    "longDescription": "This property shall contain an array of links to resources of type Connection that represent the connections to which this endpoint group belongs.",
+                    "readonly": true,
+                    "type": "array",
+                    "versionAdded": "v1_3_0"
+                },
+                "Connections@odata.count": {
+                    "$ref": "http://redfish.dmtf.org/schemas/v1/odata-v4.json#/definitions/count"
+                },
+                "Endpoints": {
+                    "description": "The endpoints in this endpoint group.",
+                    "items": {
+                        "$ref": "http://redfish.dmtf.org/schemas/v1/Endpoint.json#/definitions/Endpoint"
+                    },
+                    "longDescription": "This property shall contain an array of links to resources of type Endpoint that represent the endpoints that are in this endpoint group.",
+                    "readonly": false,
+                    "type": "array",
+                    "versionAdded": "v1_3_0"
+                },
+                "Endpoints@odata.count": {
+                    "$ref": "http://redfish.dmtf.org/schemas/v1/odata-v4.json#/definitions/count"
+                },
+                "Oem": {
+                    "$ref": "http://redfish.dmtf.org/schemas/v1/Resource.json#/definitions/Oem",
+                    "description": "The OEM extension property.",
+                    "longDescription": "This property shall contain the OEM extensions.  All values for properties contained in this object shall conform to the Redfish Specification-described requirements."
+                }
+            },
+            "type": "object"
+        },
+        "OemActions": {
+            "additionalProperties": true,
+            "description": "The available OEM-specific actions for this resource.",
+            "longDescription": "This type shall contain the available OEM-specific actions for this resource.",
+            "patternProperties": {
+                "^([a-zA-Z_][a-zA-Z0-9_]*)?@(odata|Redfish|Message)\\.[a-zA-Z_][a-zA-Z0-9_]*$": {
+                    "description": "This property shall specify a valid odata or Redfish property.",
+                    "type": [
+                        "array",
+                        "boolean",
+                        "integer",
+                        "number",
+                        "null",
+                        "object",
+                        "string"
+                    ]
+                }
+            },
+            "properties": {},
+            "type": "object"
+        }
+    },
+    "owningEntity": "DMTF",
+    "release": "2020.3",
+    "title": "#EndpointGroup.v1_3_2.EndpointGroup"
+}

--- a/static/redfish/v1/JsonSchemas/EndpointGroup/index.json
+++ b/static/redfish/v1/JsonSchemas/EndpointGroup/index.json
@@ -1,0 +1,21 @@
+{
+    "@odata.context": "/redfish/v1/$metadata#JsonSchemaFile.JsonSchemaFile",
+    "@odata.id": "/redfish/v1/JsonSchemas/EndpointGroup",
+    "@odata.type": "#JsonSchemaFile.v1_0_2.JsonSchemaFile",
+    "Name": "EndpointGroup Schema File",
+    "Schema": "#EndpointGroup.EndpointGroup",
+    "Description": "EndpointGroup Schema File Location",
+    "Id": "EndpointGroup",
+    "Languages": [
+        "en"
+    ],
+    "Languages@odata.count": 1,
+    "Location": [
+        {
+            "Language": "en",
+            "PublicationUri": "http://redfish.dmtf.org/schemas/v1/EndpointGroup.json",
+            "Uri": "/redfish/v1/JsonSchemas/EndpointGroup/EndpointGroup.json"
+        }
+    ],
+    "Location@odata.count": 1
+}

--- a/static/redfish/v1/JsonSchemas/EnvironmentMetrics/EnvironmentMetrics.json
+++ b/static/redfish/v1/JsonSchemas/EnvironmentMetrics/EnvironmentMetrics.json
@@ -1,0 +1,270 @@
+{
+    "$id": "http://redfish.dmtf.org/schemas/v1/EnvironmentMetrics.v1_1_0.json",
+    "$ref": "#/definitions/EnvironmentMetrics",
+    "$schema": "http://redfish.dmtf.org/schemas/v1/redfish-schema-v1.json",
+    "copyright": "Copyright 2014-2021 DMTF. For the full DMTF copyright policy, see http://www.dmtf.org/about/policies/copyright",
+    "definitions": {
+        "Actions": {
+            "additionalProperties": false,
+            "description": "The available actions for this resource.",
+            "longDescription": "This type shall contain the available actions for this resource.",
+            "patternProperties": {
+                "^([a-zA-Z_][a-zA-Z0-9_]*)?@(odata|Redfish|Message)\\.[a-zA-Z_][a-zA-Z0-9_]*$": {
+                    "description": "This property shall specify a valid odata or Redfish property.",
+                    "type": [
+                        "array",
+                        "boolean",
+                        "integer",
+                        "number",
+                        "null",
+                        "object",
+                        "string"
+                    ]
+                }
+            },
+            "properties": {
+                "#EnvironmentMetrics.ResetMetrics": {
+                    "$ref": "#/definitions/ResetMetrics"
+                },
+                "Oem": {
+                    "$ref": "#/definitions/OemActions",
+                    "description": "The available OEM-specific actions for this resource.",
+                    "longDescription": "This property shall contain the available OEM-specific actions for this resource."
+                }
+            },
+            "type": "object"
+        },
+        "EnvironmentMetrics": {
+            "additionalProperties": false,
+            "description": "The EnvironmentMetrics schema represents the environmental metrics of a device.",
+            "longDescription": "This resource shall represent the environmental metrics for a Redfish implementation.",
+            "patternProperties": {
+                "^([a-zA-Z_][a-zA-Z0-9_]*)?@(odata|Redfish|Message)\\.[a-zA-Z_][a-zA-Z0-9_]*$": {
+                    "description": "This property shall specify a valid odata or Redfish property.",
+                    "type": [
+                        "array",
+                        "boolean",
+                        "integer",
+                        "number",
+                        "null",
+                        "object",
+                        "string"
+                    ]
+                }
+            },
+            "properties": {
+                "@odata.context": {
+                    "$ref": "http://redfish.dmtf.org/schemas/v1/odata-v4.json#/definitions/context"
+                },
+                "@odata.etag": {
+                    "$ref": "http://redfish.dmtf.org/schemas/v1/odata-v4.json#/definitions/etag"
+                },
+                "@odata.id": {
+                    "$ref": "http://redfish.dmtf.org/schemas/v1/odata-v4.json#/definitions/id"
+                },
+                "@odata.type": {
+                    "$ref": "http://redfish.dmtf.org/schemas/v1/odata-v4.json#/definitions/type"
+                },
+                "Actions": {
+                    "$ref": "#/definitions/Actions",
+                    "description": "The available actions for this resource.",
+                    "longDescription": "This property shall contain the available actions for this resource."
+                },
+                "Description": {
+                    "anyOf": [
+                        {
+                            "$ref": "http://redfish.dmtf.org/schemas/v1/Resource.json#/definitions/Description"
+                        },
+                        {
+                            "type": "null"
+                        }
+                    ],
+                    "readonly": true
+                },
+                "DewPointCelsius": {
+                    "anyOf": [
+                        {
+                            "$ref": "http://redfish.dmtf.org/schemas/v1/Sensor.json#/definitions/SensorExcerpt"
+                        },
+                        {
+                            "type": "null"
+                        }
+                    ],
+                    "description": "The dew point temperature (C).",
+                    "excerptCopy": "SensorExcerpt",
+                    "longDescription": "This property shall contain the dew point, measured in degrees Celsius, based on the temperature and humidity values for this resource.",
+                    "versionAdded": "v1_1_0"
+                },
+                "EnergykWh": {
+                    "anyOf": [
+                        {
+                            "$ref": "http://redfish.dmtf.org/schemas/v1/Sensor.json#/definitions/SensorEnergykWhExcerpt"
+                        },
+                        {
+                            "type": "null"
+                        }
+                    ],
+                    "description": "Energy consumption (kWh).",
+                    "excerptCopy": "SensorEnergykWhExcerpt",
+                    "longDescription": "This property shall contain the total energy, measured in kilowatt-hours (kW.h), for this resource."
+                },
+                "FanSpeedsPercent": {
+                    "description": "Fan speeds (percent).",
+                    "excerptCopy": "SensorFanArrayExcerpt",
+                    "items": {
+                        "$ref": "http://redfish.dmtf.org/schemas/v1/Sensor.json#/definitions/SensorFanArrayExcerpt"
+                    },
+                    "longDescription": "This property shall contain the fan speed readings for this resource.",
+                    "type": "array"
+                },
+                "FanSpeedsPercent@odata.count": {
+                    "$ref": "http://redfish.dmtf.org/schemas/v1/odata-v4.json#/definitions/count"
+                },
+                "HumidityPercent": {
+                    "anyOf": [
+                        {
+                            "$ref": "http://redfish.dmtf.org/schemas/v1/Sensor.json#/definitions/SensorExcerpt"
+                        },
+                        {
+                            "type": "null"
+                        }
+                    ],
+                    "description": "Humidity (percent).",
+                    "excerptCopy": "SensorExcerpt",
+                    "longDescription": "This property shall contain the humidity sensor reading for this resource."
+                },
+                "Id": {
+                    "$ref": "http://redfish.dmtf.org/schemas/v1/Resource.json#/definitions/Id",
+                    "readonly": true
+                },
+                "Name": {
+                    "$ref": "http://redfish.dmtf.org/schemas/v1/Resource.json#/definitions/Name",
+                    "readonly": true
+                },
+                "Oem": {
+                    "$ref": "http://redfish.dmtf.org/schemas/v1/Resource.json#/definitions/Oem",
+                    "description": "The OEM extension property.",
+                    "longDescription": "This property shall contain the OEM extensions.  All values for properties that this object contains shall conform to the Redfish Specification-described requirements."
+                },
+                "PowerLimitWatts": {
+                    "anyOf": [
+                        {
+                            "$ref": "http://redfish.dmtf.org/schemas/v1/Control.json#/definitions/ControlSingleExcerpt"
+                        },
+                        {
+                            "type": "null"
+                        }
+                    ],
+                    "description": "Power limit (Watts).",
+                    "excerptCopy": "ControlSingleExcerpt",
+                    "longDescription": "This property shall contain the power limit control for this resource.",
+                    "readonly": false,
+                    "versionAdded": "v1_1_0"
+                },
+                "PowerLoadPercent": {
+                    "anyOf": [
+                        {
+                            "$ref": "http://redfish.dmtf.org/schemas/v1/Sensor.json#/definitions/SensorExcerpt"
+                        },
+                        {
+                            "type": "null"
+                        }
+                    ],
+                    "description": "The power load (%) for this device.",
+                    "excerptCopy": "SensorExcerpt",
+                    "longDescription": "This property shall contain the power load, measured in percent, for this device, that represents the `Total` ElectricalContext for this device.",
+                    "versionAdded": "v1_1_0"
+                },
+                "PowerWatts": {
+                    "anyOf": [
+                        {
+                            "$ref": "http://redfish.dmtf.org/schemas/v1/Sensor.json#/definitions/SensorPowerExcerpt"
+                        },
+                        {
+                            "type": "null"
+                        }
+                    ],
+                    "description": "Power consumption (Watts).",
+                    "excerptCopy": "SensorPowerExcerpt",
+                    "longDescription": "This property shall contain the total power, measured in Watts, for this resource."
+                },
+                "TemperatureCelsius": {
+                    "anyOf": [
+                        {
+                            "$ref": "http://redfish.dmtf.org/schemas/v1/Sensor.json#/definitions/SensorExcerpt"
+                        },
+                        {
+                            "type": "null"
+                        }
+                    ],
+                    "description": "Temperature (Celsius).",
+                    "excerptCopy": "SensorExcerpt",
+                    "longDescription": "This property shall contain the temperature sensor reading for this resource."
+                }
+            },
+            "required": [
+                "@odata.id",
+                "@odata.type",
+                "Id",
+                "Name"
+            ],
+            "type": "object"
+        },
+        "OemActions": {
+            "additionalProperties": true,
+            "description": "The available OEM-specific actions for this resource.",
+            "longDescription": "This type shall contain the available OEM-specific actions for this resource.",
+            "patternProperties": {
+                "^([a-zA-Z_][a-zA-Z0-9_]*)?@(odata|Redfish|Message)\\.[a-zA-Z_][a-zA-Z0-9_]*$": {
+                    "description": "This property shall specify a valid odata or Redfish property.",
+                    "type": [
+                        "array",
+                        "boolean",
+                        "integer",
+                        "number",
+                        "null",
+                        "object",
+                        "string"
+                    ]
+                }
+            },
+            "properties": {},
+            "type": "object"
+        },
+        "ResetMetrics": {
+            "additionalProperties": false,
+            "description": "This action resets the summary metrics related to this equipment.",
+            "longDescription": "This action shall reset any time intervals or counted values for this equipment.",
+            "parameters": {},
+            "patternProperties": {
+                "^([a-zA-Z_][a-zA-Z0-9_]*)?@(odata|Redfish|Message)\\.[a-zA-Z_][a-zA-Z0-9_]*$": {
+                    "description": "This property shall specify a valid odata or Redfish property.",
+                    "type": [
+                        "array",
+                        "boolean",
+                        "integer",
+                        "number",
+                        "null",
+                        "object",
+                        "string"
+                    ]
+                }
+            },
+            "properties": {
+                "target": {
+                    "description": "Link to invoke action",
+                    "format": "uri-reference",
+                    "type": "string"
+                },
+                "title": {
+                    "description": "Friendly action name",
+                    "type": "string"
+                }
+            },
+            "type": "object"
+        }
+    },
+    "owningEntity": "DMTF",
+    "release": "2021.2",
+    "title": "#EnvironmentMetrics.v1_1_0.EnvironmentMetrics"
+}

--- a/static/redfish/v1/JsonSchemas/EnvironmentMetrics/index.json
+++ b/static/redfish/v1/JsonSchemas/EnvironmentMetrics/index.json
@@ -1,0 +1,21 @@
+{
+    "@odata.context": "/redfish/v1/$metadata#JsonSchemaFile.JsonSchemaFile",
+    "@odata.id": "/redfish/v1/JsonSchemas/EnvironmentMetrics",
+    "@odata.type": "#JsonSchemaFile.v1_0_2.JsonSchemaFile",
+    "Name": "EnvironmentMetrics Schema File",
+    "Schema": "#EnvironmentMetrics.EnvironmentMetrics",
+    "Description": "EnvironmentMetrics Schema File Location",
+    "Id": "EnvironmentMetrics",
+    "Languages": [
+        "en"
+    ],
+    "Languages@odata.count": 1,
+    "Location": [
+        {
+            "Language": "en",
+            "PublicationUri": "http://redfish.dmtf.org/schemas/v1/EnvironmentMetrics.json",
+            "Uri": "/redfish/v1/JsonSchemas/EnvironmentMetrics/EnvironmentMetrics.json"
+        }
+    ],
+    "Location@odata.count": 1
+}

--- a/static/redfish/v1/JsonSchemas/ExternalAccountProvider/ExternalAccountProvider.json
+++ b/static/redfish/v1/JsonSchemas/ExternalAccountProvider/ExternalAccountProvider.json
@@ -1,0 +1,699 @@
+{
+    "$id": "http://redfish.dmtf.org/schemas/v1/ExternalAccountProvider.v1_3_0.json",
+    "$ref": "#/definitions/ExternalAccountProvider",
+    "$schema": "http://redfish.dmtf.org/schemas/v1/redfish-schema-v1.json",
+    "copyright": "Copyright 2014-2021 DMTF. For the full DMTF copyright policy, see http://www.dmtf.org/about/policies/copyright",
+    "definitions": {
+        "AccountProviderTypes": {
+            "enum": [
+                "RedfishService",
+                "ActiveDirectoryService",
+                "LDAPService",
+                "OEM",
+                "TACACSplus",
+                "OAuth2"
+            ],
+            "enumDescriptions": {
+                "ActiveDirectoryService": "An external Active Directory service.",
+                "LDAPService": "A generic external LDAP service.",
+                "OAuth2": "An external OAuth 2.0 service.",
+                "OEM": "An OEM-specific external authentication or directory service.",
+                "RedfishService": "An external Redfish service.",
+                "TACACSplus": "An external TACACS+ service."
+            },
+            "enumLongDescriptions": {
+                "ActiveDirectoryService": "The external account provider shall be a Microsoft Active Directory Technical Specification-conformant service.  The ServiceAddresses format shall contain a set of fully qualified domain names (FQDN) or NetBIOS names that links to the set of domain servers for the Active Directory service.",
+                "LDAPService": "The external account provider shall be an RFC4511-conformant service.  The ServiceAddresses format shall contain a set of fully qualified domain names (FQDN) that links to the set of LDAP servers for the service.",
+                "OAuth2": "The external account provider shall be an RFC6749-conformant service.  The ServiceAddresses format shall contain a set of URIs that correspond to the RFC8414-defined metadata for the OAuth 2.0 service.",
+                "RedfishService": "The external account provider shall be a DMTF Redfish Specification-conformant service.  The ServiceAddresses format shall contain a set of URIs that correspond to a Redfish account service.",
+                "TACACSplus": "The external account provider shall be an RFC8907-conformant service.  The ServiceAddresses format shall contain a set of host:port that correspond to a TACACS+ service and where the format for host and port are defined in RFC3986."
+            },
+            "enumVersionAdded": {
+                "OAuth2": "v1_3_0",
+                "TACACSplus": "v1_3_0"
+            },
+            "type": "string"
+        },
+        "Actions": {
+            "additionalProperties": false,
+            "description": "The available actions for this resource.",
+            "longDescription": "This type shall contain the available actions for this resource.",
+            "patternProperties": {
+                "^([a-zA-Z_][a-zA-Z0-9_]*)?@(odata|Redfish|Message)\\.[a-zA-Z_][a-zA-Z0-9_]*$": {
+                    "description": "This property shall specify a valid odata or Redfish property.",
+                    "type": [
+                        "array",
+                        "boolean",
+                        "integer",
+                        "number",
+                        "null",
+                        "object",
+                        "string"
+                    ]
+                }
+            },
+            "properties": {
+                "Oem": {
+                    "$ref": "#/definitions/OemActions",
+                    "description": "The available OEM-specific actions for this resource.",
+                    "longDescription": "This property shall contain the available OEM-specific actions for this resource."
+                }
+            },
+            "type": "object"
+        },
+        "Authentication": {
+            "additionalProperties": false,
+            "description": "The information required to authenticate to the external service.",
+            "longDescription": "This type shall contain the information required to authenticate to the external service.",
+            "patternProperties": {
+                "^([a-zA-Z_][a-zA-Z0-9_]*)?@(odata|Redfish|Message)\\.[a-zA-Z_][a-zA-Z0-9_]*$": {
+                    "description": "This property shall specify a valid odata or Redfish property.",
+                    "type": [
+                        "array",
+                        "boolean",
+                        "integer",
+                        "number",
+                        "null",
+                        "object",
+                        "string"
+                    ]
+                }
+            },
+            "properties": {
+                "AuthenticationType": {
+                    "anyOf": [
+                        {
+                            "$ref": "#/definitions/AuthenticationTypes"
+                        },
+                        {
+                            "type": "null"
+                        }
+                    ],
+                    "description": "The type of authentication used to connect to the external account provider.",
+                    "longDescription": "This property shall contain the type of authentication used to connect to the external account provider.",
+                    "readonly": false
+                },
+                "EncryptionKey": {
+                    "description": "Specifies the encryption key.",
+                    "longDescription": "This property shall contain the value of a symmetric encryption key for account services that support some form of encryption, obfuscation, or authentication such as TACACS+.  The value shall be `null` in responses.  The property shall accept a hexadecimal string whose length depends on the external account service, such as TACACS+.  A TACACS+ service shall use this property to specify the secret key as defined in RFC8907.",
+                    "pattern": "^[0-9a-fA-F]+$",
+                    "readonly": false,
+                    "type": [
+                        "string",
+                        "null"
+                    ],
+                    "versionAdded": "v1_2_0"
+                },
+                "EncryptionKeySet": {
+                    "description": "Indicates if the EncryptionKey property is set.",
+                    "longDescription": "This property shall contain `true` if a valid value was provided for the EncryptionKey property.  Otherwise, the property shall contain `false`.  For a TACACS+ service, the value `false` shall indicate data obfuscation, as defined in section 4.5 of RFC8907, is disabled.",
+                    "readonly": true,
+                    "type": [
+                        "boolean",
+                        "null"
+                    ],
+                    "versionAdded": "v1_2_0"
+                },
+                "KerberosKeytab": {
+                    "description": "The Base64-encoded version of the Kerberos keytab for this service.  A PATCH or PUT operation writes the keytab.  This property is `null` in responses.",
+                    "longDescription": "This property shall contain a Base64-encoded version of the Kerberos keytab for this service.  A PATCH or PUT operation writes the keytab.  The value shall be `null` in responses.",
+                    "readonly": false,
+                    "type": [
+                        "string",
+                        "null"
+                    ]
+                },
+                "Oem": {
+                    "$ref": "http://redfish.dmtf.org/schemas/v1/Resource.json#/definitions/Oem",
+                    "description": "The OEM extension property.",
+                    "longDescription": "This property shall contain the OEM extensions.  All values for properties contained in this object shall conform to the Redfish Specification-described requirements."
+                },
+                "Password": {
+                    "description": "The password for this service.  A PATCH or PUT request writes the password.  This property is `null` in responses.",
+                    "longDescription": "This property shall contain the password for this service.  A PATCH or PUT operation writes the password.  The value shall be `null` in responses.",
+                    "readonly": false,
+                    "type": [
+                        "string",
+                        "null"
+                    ]
+                },
+                "Token": {
+                    "description": "The token for this service.  A PATCH or PUT operation writes the token.  This property is `null` in responses.",
+                    "longDescription": "This property shall contain the token for this service.  A PATCH or PUT operation writes the token.  The value shall be `null` in responses.",
+                    "readonly": false,
+                    "type": [
+                        "string",
+                        "null"
+                    ]
+                },
+                "Username": {
+                    "description": "The user name for the service.",
+                    "longDescription": "This property shall contain the user name for this service.",
+                    "readonly": false,
+                    "type": "string"
+                }
+            },
+            "type": "object"
+        },
+        "AuthenticationTypes": {
+            "enum": [
+                "Token",
+                "KerberosKeytab",
+                "UsernameAndPassword",
+                "OEM"
+            ],
+            "enumDescriptions": {
+                "KerberosKeytab": "A Kerberos keytab.",
+                "OEM": "An OEM-specific authentication mechanism.",
+                "Token": "An opaque authentication token.",
+                "UsernameAndPassword": "A user name and password combination."
+            },
+            "type": "string"
+        },
+        "ExternalAccountProvider": {
+            "additionalProperties": false,
+            "description": "The ExternalAccountProvider schema represents a remote service that provides accounts for this manager to use for authentication.",
+            "longDescription": "This resource shall represent a remote authentication service in the Redfish Specification.",
+            "patternProperties": {
+                "^([a-zA-Z_][a-zA-Z0-9_]*)?@(odata|Redfish|Message)\\.[a-zA-Z_][a-zA-Z0-9_]*$": {
+                    "description": "This property shall specify a valid odata or Redfish property.",
+                    "type": [
+                        "array",
+                        "boolean",
+                        "integer",
+                        "number",
+                        "null",
+                        "object",
+                        "string"
+                    ]
+                }
+            },
+            "properties": {
+                "@odata.context": {
+                    "$ref": "http://redfish.dmtf.org/schemas/v1/odata-v4.json#/definitions/context"
+                },
+                "@odata.etag": {
+                    "$ref": "http://redfish.dmtf.org/schemas/v1/odata-v4.json#/definitions/etag"
+                },
+                "@odata.id": {
+                    "$ref": "http://redfish.dmtf.org/schemas/v1/odata-v4.json#/definitions/id"
+                },
+                "@odata.type": {
+                    "$ref": "http://redfish.dmtf.org/schemas/v1/odata-v4.json#/definitions/type"
+                },
+                "AccountProviderType": {
+                    "anyOf": [
+                        {
+                            "$ref": "#/definitions/AccountProviderTypes"
+                        },
+                        {
+                            "type": "null"
+                        }
+                    ],
+                    "description": "The type of external account provider to which this service connects.",
+                    "longDescription": "This property shall contain the type of external account provider to which this service connects.",
+                    "readonly": true
+                },
+                "Actions": {
+                    "$ref": "#/definitions/Actions",
+                    "description": "The available actions for this resource.",
+                    "longDescription": "This property shall contain the available actions for this resource."
+                },
+                "Authentication": {
+                    "$ref": "#/definitions/Authentication",
+                    "description": "The authentication information for the external account provider.",
+                    "longDescription": "This property shall contain the authentication information for the external account provider."
+                },
+                "Certificates": {
+                    "$ref": "http://redfish.dmtf.org/schemas/v1/CertificateCollection.json#/definitions/CertificateCollection",
+                    "description": "The link to a collection of certificates that the external account provider uses.",
+                    "longDescription": "This property shall contain a link to a resource collection of type CertificateCollection that contains certificates the external account provider uses.",
+                    "readonly": true,
+                    "versionAdded": "v1_1_0"
+                },
+                "Description": {
+                    "anyOf": [
+                        {
+                            "$ref": "http://redfish.dmtf.org/schemas/v1/Resource.json#/definitions/Description"
+                        },
+                        {
+                            "type": "null"
+                        }
+                    ],
+                    "readonly": true
+                },
+                "Id": {
+                    "$ref": "http://redfish.dmtf.org/schemas/v1/Resource.json#/definitions/Id",
+                    "readonly": true
+                },
+                "LDAPService": {
+                    "$ref": "#/definitions/LDAPService",
+                    "description": "The additional mapping information needed to parse a generic LDAP service.",
+                    "longDescription": "This property shall contain any additional mapping information needed to parse a generic LDAP service.  This property should only be present if AccountProviderType is `LDAPService`."
+                },
+                "Links": {
+                    "$ref": "#/definitions/Links",
+                    "description": "The links to other resources that are related to this resource.",
+                    "longDescription": "This property shall contain links to resources that are related to but are not contained by, or subordinate to, this resource."
+                },
+                "Name": {
+                    "$ref": "http://redfish.dmtf.org/schemas/v1/Resource.json#/definitions/Name",
+                    "readonly": true
+                },
+                "OAuth2Service": {
+                    "anyOf": [
+                        {
+                            "$ref": "#/definitions/OAuth2Service"
+                        },
+                        {
+                            "type": "null"
+                        }
+                    ],
+                    "description": "The additional information needed to parse an OAuth 2.0 service.",
+                    "longDescription": "This property shall contain additional information needed to parse an OAuth 2.0 service.  This property should only be present inside an OAuth2 property.",
+                    "versionAdded": "v1_3_0"
+                },
+                "Oem": {
+                    "$ref": "http://redfish.dmtf.org/schemas/v1/Resource.json#/definitions/Oem",
+                    "description": "The OEM extension property.",
+                    "longDescription": "This property shall contain the OEM extensions.  All values for properties that this object contains shall conform to the Redfish Specification-described requirements."
+                },
+                "Priority": {
+                    "description": "The authentication priority for the external account provider.",
+                    "longDescription": "This property shall contain the assigned priority for the specified external account provider.  The value `0` value shall indicate the highest priority.  Increasing values shall represent decreasing priority.  If an external provider does not have a priority assignment or two or more external providers have the same priority, the behavior shall be determined by the Redfish service.  The priority is used to determine the order of authentication and authorization for each external account provider.",
+                    "minimum": 0,
+                    "readonly": false,
+                    "type": [
+                        "integer",
+                        "null"
+                    ],
+                    "versionAdded": "v1_2_0"
+                },
+                "RemoteRoleMapping": {
+                    "description": "The mapping rules to convert the external account providers account information to the local Redfish role.",
+                    "items": {
+                        "anyOf": [
+                            {
+                                "$ref": "#/definitions/RoleMapping"
+                            },
+                            {
+                                "type": "null"
+                            }
+                        ]
+                    },
+                    "longDescription": "This property shall contain a set of the mapping rules that are used to convert the external account providers account information to the local Redfish role.",
+                    "type": "array"
+                },
+                "ServiceAddresses": {
+                    "description": "The addresses of the user account providers to which this external account provider links.  The format of this field depends on the type of external account provider.",
+                    "items": {
+                        "type": [
+                            "string",
+                            "null"
+                        ]
+                    },
+                    "longDescription": "This property shall contain the addresses of the account providers to which this external account provider links.  The format of this field depends on the type of external account provider.  Each item in the array shall contain a single address.  Services can define their own behavior for managing multiple addresses.",
+                    "readonly": false,
+                    "type": "array"
+                },
+                "ServiceEnabled": {
+                    "description": "An indication of whether this service is enabled.",
+                    "longDescription": "This property shall indicate whether this service is enabled.",
+                    "readonly": false,
+                    "type": [
+                        "boolean",
+                        "null"
+                    ]
+                },
+                "TACACSplusService": {
+                    "anyOf": [
+                        {
+                            "$ref": "#/definitions/TACACSplusService"
+                        },
+                        {
+                            "type": "null"
+                        }
+                    ],
+                    "description": "The additional information needed to parse a TACACS+ services.",
+                    "longDescription": "This property shall contain additional information needed to parse a TACACS+ services.  This property should only be present inside a TACACSplus property.",
+                    "versionAdded": "v1_2_0"
+                }
+            },
+            "required": [
+                "@odata.id",
+                "@odata.type",
+                "Id",
+                "Name"
+            ],
+            "requiredOnCreate": [
+                "AccountProviderType"
+            ],
+            "type": "object"
+        },
+        "LDAPSearchSettings": {
+            "additionalProperties": false,
+            "description": "The settings to search a generic LDAP service.",
+            "longDescription": "This type shall contain all required settings to search a generic LDAP service.",
+            "patternProperties": {
+                "^([a-zA-Z_][a-zA-Z0-9_]*)?@(odata|Redfish|Message)\\.[a-zA-Z_][a-zA-Z0-9_]*$": {
+                    "description": "This property shall specify a valid odata or Redfish property.",
+                    "type": [
+                        "array",
+                        "boolean",
+                        "integer",
+                        "number",
+                        "null",
+                        "object",
+                        "string"
+                    ]
+                }
+            },
+            "properties": {
+                "BaseDistinguishedNames": {
+                    "description": "The base distinguished names to use to search an external LDAP service.",
+                    "items": {
+                        "type": [
+                            "string",
+                            "null"
+                        ]
+                    },
+                    "longDescription": "This property shall contain an array of base distinguished names to use to search an external LDAP service.",
+                    "readonly": false,
+                    "type": "array"
+                },
+                "GroupNameAttribute": {
+                    "description": "The attribute name that contains the LDAP group name entry.",
+                    "longDescription": "This property shall contain the attribute name that contains the LDAP group name.",
+                    "readonly": false,
+                    "type": [
+                        "string",
+                        "null"
+                    ]
+                },
+                "GroupsAttribute": {
+                    "description": "The attribute name that contains the groups for a user on the LDAP user entry.",
+                    "longDescription": "This property shall contain the attribute name that contains the groups for an LDAP user entry.",
+                    "readonly": false,
+                    "type": [
+                        "string",
+                        "null"
+                    ]
+                },
+                "UsernameAttribute": {
+                    "description": "The attribute name that contains the LDAP user name entry.",
+                    "longDescription": "This property shall contain the attribute name that contains the LDAP user name.",
+                    "readonly": false,
+                    "type": [
+                        "string",
+                        "null"
+                    ]
+                }
+            },
+            "type": "object"
+        },
+        "LDAPService": {
+            "additionalProperties": false,
+            "description": "The settings required to parse a generic LDAP service.",
+            "longDescription": "This type shall contain all required settings to parse a generic LDAP service.",
+            "patternProperties": {
+                "^([a-zA-Z_][a-zA-Z0-9_]*)?@(odata|Redfish|Message)\\.[a-zA-Z_][a-zA-Z0-9_]*$": {
+                    "description": "This property shall specify a valid odata or Redfish property.",
+                    "type": [
+                        "array",
+                        "boolean",
+                        "integer",
+                        "number",
+                        "null",
+                        "object",
+                        "string"
+                    ]
+                }
+            },
+            "properties": {
+                "Oem": {
+                    "$ref": "http://redfish.dmtf.org/schemas/v1/Resource.json#/definitions/Oem",
+                    "description": "The OEM extension property.",
+                    "longDescription": "This property shall contain the OEM extensions.  All values for properties contained in this object shall conform to the Redfish Specification-described requirements."
+                },
+                "SearchSettings": {
+                    "$ref": "#/definitions/LDAPSearchSettings",
+                    "description": "The required settings to search an external LDAP service.",
+                    "longDescription": "This property shall contain the required settings to search an external LDAP service."
+                }
+            },
+            "type": "object"
+        },
+        "Links": {
+            "additionalProperties": false,
+            "description": "The links to other resources that are related to this resource.",
+            "longDescription": "This Redfish Specification-described type shall contain links to resources that are related to but are not contained by, or subordinate to, this resource.",
+            "patternProperties": {
+                "^([a-zA-Z_][a-zA-Z0-9_]*)?@(odata|Redfish|Message)\\.[a-zA-Z_][a-zA-Z0-9_]*$": {
+                    "description": "This property shall specify a valid odata or Redfish property.",
+                    "type": [
+                        "array",
+                        "boolean",
+                        "integer",
+                        "number",
+                        "null",
+                        "object",
+                        "string"
+                    ]
+                }
+            },
+            "properties": {
+                "Oem": {
+                    "$ref": "http://redfish.dmtf.org/schemas/v1/Resource.json#/definitions/Oem",
+                    "description": "The OEM extension property.",
+                    "longDescription": "This property shall contain the OEM extensions.  All values for properties contained in this object shall conform to the Redfish Specification-described requirements."
+                }
+            },
+            "type": "object"
+        },
+        "OAuth2Mode": {
+            "enum": [
+                "Discovery",
+                "Offline"
+            ],
+            "enumDescriptions": {
+                "Discovery": "OAuth 2.0 service information for token validation is downloaded by the service.",
+                "Offline": "OAuth 2.0 service information for token validation is configured by a client."
+            },
+            "enumLongDescriptions": {
+                "Discovery": "This value shall indicate the service performs token validation from information found at the URIs specified by the ServiceAddresses property.  Services shall implement a caching method of this information so it's not necessary to retrieve metadata and key information for every request containing a token.",
+                "Offline": "This value shall indicate the service performs token validation from properties configured by a client."
+            },
+            "type": "string"
+        },
+        "OAuth2Service": {
+            "additionalProperties": false,
+            "description": "Various settings to parse an OAuth 2.0 service.",
+            "longDescription": "This type shall contain settings for parsing an OAuth 2.0 service.",
+            "patternProperties": {
+                "^([a-zA-Z_][a-zA-Z0-9_]*)?@(odata|Redfish|Message)\\.[a-zA-Z_][a-zA-Z0-9_]*$": {
+                    "description": "This property shall specify a valid odata or Redfish property.",
+                    "type": [
+                        "array",
+                        "boolean",
+                        "integer",
+                        "number",
+                        "null",
+                        "object",
+                        "string"
+                    ]
+                }
+            },
+            "properties": {
+                "Audience": {
+                    "description": "The allowable audience strings of the Redfish service.",
+                    "items": {
+                        "type": "string"
+                    },
+                    "longDescription": "This property shall contain an array of allowable RFC7519-defined audience strings of the Redfish service.  The values shall uniquely identify the Redfish service.  For example, a MAC address or UUID for the manager can uniquely identify the service.",
+                    "readonly": true,
+                    "type": "array",
+                    "versionAdded": "v1_3_0"
+                },
+                "Issuer": {
+                    "description": "The issuer string of the OAuth 2.0 service.",
+                    "longDescription": "This property shall contain the RFC8414-defined issuer string of the OAuth 2.0 service.  If the Mode property contains the value `Discovery`, this property shall contain the value of the `issuer` string from the OAuth 2.0 service's metadata and this property shall be read-only.",
+                    "readonly": false,
+                    "type": [
+                        "string",
+                        "null"
+                    ],
+                    "versionAdded": "v1_3_0"
+                },
+                "Mode": {
+                    "$ref": "#/definitions/OAuth2Mode",
+                    "description": "The mode of operation for token validation.",
+                    "longDescription": "This property shall contain the mode of operation for token validation.",
+                    "readonly": false,
+                    "versionAdded": "v1_3_0"
+                },
+                "OAuthServiceSigningKeys": {
+                    "description": "The Base64-encoded signing keys of the issuer of the OAuth 2.0 service.",
+                    "longDescription": "This property shall contain a Base64-encoded string of the RFC7517-defined signing keys of the issuer of the OAuth 2.0 service.  If the Mode property contains the value `Discovery`, this property shall contain the keys found at the URI specified by the `jwks_uri` string from the OAuth 2.0 service's metadata and this property shall be read-only.",
+                    "readonly": false,
+                    "type": [
+                        "string",
+                        "null"
+                    ],
+                    "versionAdded": "v1_3_0"
+                }
+            },
+            "type": "object"
+        },
+        "OemActions": {
+            "additionalProperties": true,
+            "description": "The available OEM-specific actions for this resource.",
+            "longDescription": "This type shall contain the available OEM-specific actions for this resource.",
+            "patternProperties": {
+                "^([a-zA-Z_][a-zA-Z0-9_]*)?@(odata|Redfish|Message)\\.[a-zA-Z_][a-zA-Z0-9_]*$": {
+                    "description": "This property shall specify a valid odata or Redfish property.",
+                    "type": [
+                        "array",
+                        "boolean",
+                        "integer",
+                        "number",
+                        "null",
+                        "object",
+                        "string"
+                    ]
+                }
+            },
+            "properties": {},
+            "type": "object"
+        },
+        "RoleMapping": {
+            "additionalProperties": false,
+            "description": "The mapping rules that are used to convert the external account providers account information to the local Redfish role.",
+            "longDescription": "This type shall contain mapping rules that are used to convert the external account providers account information to the local Redfish role.",
+            "patternProperties": {
+                "^([a-zA-Z_][a-zA-Z0-9_]*)?@(odata|Redfish|Message)\\.[a-zA-Z_][a-zA-Z0-9_]*$": {
+                    "description": "This property shall specify a valid odata or Redfish property.",
+                    "type": [
+                        "array",
+                        "boolean",
+                        "integer",
+                        "number",
+                        "null",
+                        "object",
+                        "string"
+                    ]
+                }
+            },
+            "properties": {
+                "LocalRole": {
+                    "description": "The name of the local Redfish role to which to map the remote user or group.",
+                    "longDescription": "This property shall contain the RoleId property value within a role resource on this Redfish service to which to map the remote user or group.",
+                    "readonly": false,
+                    "type": [
+                        "string",
+                        "null"
+                    ]
+                },
+                "Oem": {
+                    "$ref": "http://redfish.dmtf.org/schemas/v1/Resource.json#/definitions/Oem",
+                    "description": "The OEM extension property.",
+                    "longDescription": "This property shall contain the OEM extensions.  All values for properties contained in this object shall conform to the Redfish Specification-described requirements."
+                },
+                "RemoteGroup": {
+                    "description": "The name of the remote group, or the remote role in the case of a Redfish service, that maps to the local Redfish role to which this entity links.",
+                    "longDescription": "This property shall contain the name of the remote group, or the remote role in the case of a Redfish service, that maps to the local Redfish role to which this entity links.",
+                    "readonly": false,
+                    "type": [
+                        "string",
+                        "null"
+                    ]
+                },
+                "RemoteUser": {
+                    "description": "The name of the remote user that maps to the local Redfish role to which this entity links.",
+                    "longDescription": "This property shall contain the name of the remote user that maps to the local Redfish role to which this entity links.",
+                    "readonly": false,
+                    "type": [
+                        "string",
+                        "null"
+                    ]
+                }
+            },
+            "type": "object"
+        },
+        "TACACSplusPasswordExchangeProtocol": {
+            "enum": [
+                "ASCII",
+                "PAP",
+                "CHAP",
+                "MSCHAPv1",
+                "MSCHAPv2"
+            ],
+            "enumDescriptions": {
+                "ASCII": "The ASCII Login method.",
+                "CHAP": "The CHAP Login method.",
+                "MSCHAPv1": "The MS-CHAP v1 Login method.",
+                "MSCHAPv2": "The MS-CHAP v2 Login method.",
+                "PAP": "The PAP Login method."
+            },
+            "enumLongDescriptions": {
+                "ASCII": "This value shall indicate the ASCII Login flow as described under section 5.4.2 of RFC8907.",
+                "CHAP": "This value shall indicate the CHAP Login flow as described under section 5.4.2 of RFC8907.",
+                "MSCHAPv1": "This value shall indicate the MS-CHAP v1 Login flow as described under section 5.4.2 of RFC8907.",
+                "MSCHAPv2": "This value shall indicate the MS-CHAP v2 Login flow as described under section 5.4.2 of RFC8907.",
+                "PAP": "This value shall indicate the PAP Login flow as described under section 5.4.2 of RFC8907."
+            },
+            "type": "string"
+        },
+        "TACACSplusService": {
+            "additionalProperties": false,
+            "description": "Various settings to parse a TACACS+ service.",
+            "longDescription": "This type shall contain settings for parsing a TACACS+ service.",
+            "patternProperties": {
+                "^([a-zA-Z_][a-zA-Z0-9_]*)?@(odata|Redfish|Message)\\.[a-zA-Z_][a-zA-Z0-9_]*$": {
+                    "description": "This property shall specify a valid odata or Redfish property.",
+                    "type": [
+                        "array",
+                        "boolean",
+                        "integer",
+                        "number",
+                        "null",
+                        "object",
+                        "string"
+                    ]
+                }
+            },
+            "properties": {
+                "PasswordExchangeProtocols": {
+                    "description": "Indicates the allowed TACACS+ password exchange protocols.",
+                    "items": {
+                        "anyOf": [
+                            {
+                                "$ref": "#/definitions/TACACSplusPasswordExchangeProtocol"
+                            },
+                            {
+                                "type": "null"
+                            }
+                        ]
+                    },
+                    "longDescription": "This property shall indicate all the allowed TACACS+ password exchange protocol described under section 5.4.2 of RFC8907.",
+                    "readonly": false,
+                    "type": "array",
+                    "versionAdded": "v1_2_0"
+                },
+                "PrivilegeLevelArgument": {
+                    "description": "Indicates the name of the TACACS+ argument name in an authorization request.",
+                    "longDescription": "This property shall specify the name of the argument in a TACACS+ Authorization REPLY packet body, as defined in RFC8907, that contains the user's privilege level.",
+                    "readonly": false,
+                    "type": [
+                        "string",
+                        "null"
+                    ],
+                    "versionAdded": "v1_2_0"
+                }
+            },
+            "type": "object"
+        }
+    },
+    "owningEntity": "DMTF",
+    "release": "2021.2",
+    "title": "#ExternalAccountProvider.v1_3_0.ExternalAccountProvider"
+}

--- a/static/redfish/v1/JsonSchemas/ExternalAccountProvider/index.json
+++ b/static/redfish/v1/JsonSchemas/ExternalAccountProvider/index.json
@@ -1,0 +1,21 @@
+{
+    "@odata.context": "/redfish/v1/$metadata#JsonSchemaFile.JsonSchemaFile",
+    "@odata.id": "/redfish/v1/JsonSchemas/ExternalAccountProvider",
+    "@odata.type": "#JsonSchemaFile.v1_0_2.JsonSchemaFile",
+    "Name": "ExternalAccountProvider Schema File",
+    "Schema": "#ExternalAccountProvider.ExternalAccountProvider",
+    "Description": "ExternalAccountProvider Schema File Location",
+    "Id": "ExternalAccountProvider",
+    "Languages": [
+        "en"
+    ],
+    "Languages@odata.count": 1,
+    "Location": [
+        {
+            "Language": "en",
+            "PublicationUri": "http://redfish.dmtf.org/schemas/v1/ExternalAccountProvider.json",
+            "Uri": "/redfish/v1/JsonSchemas/ExternalAccountProvider/ExternalAccountProvider.json"
+        }
+    ],
+    "Location@odata.count": 1
+}

--- a/static/redfish/v1/JsonSchemas/Fabric/Fabric.json
+++ b/static/redfish/v1/JsonSchemas/Fabric/Fabric.json
@@ -1,0 +1,226 @@
+{
+    "$id": "http://redfish.dmtf.org/schemas/v1/Fabric.v1_2_2.json",
+    "$ref": "#/definitions/Fabric",
+    "$schema": "http://redfish.dmtf.org/schemas/v1/redfish-schema-v1.json",
+    "copyright": "Copyright 2014-2021 DMTF. For the full DMTF copyright policy, see http://www.dmtf.org/about/policies/copyright",
+    "definitions": {
+        "Actions": {
+            "additionalProperties": false,
+            "description": "The available actions for this resource.",
+            "longDescription": "This type shall contain the available actions for this resource.",
+            "patternProperties": {
+                "^([a-zA-Z_][a-zA-Z0-9_]*)?@(odata|Redfish|Message)\\.[a-zA-Z_][a-zA-Z0-9_]*$": {
+                    "description": "This property shall specify a valid odata or Redfish property.",
+                    "type": [
+                        "array",
+                        "boolean",
+                        "integer",
+                        "number",
+                        "null",
+                        "object",
+                        "string"
+                    ]
+                }
+            },
+            "properties": {
+                "Oem": {
+                    "$ref": "#/definitions/OemActions",
+                    "description": "The available OEM-specific actions for this resource.",
+                    "longDescription": "This property shall contain the available OEM-specific actions for this resource."
+                }
+            },
+            "type": "object"
+        },
+        "Fabric": {
+            "additionalProperties": false,
+            "description": "The Fabric schema represents a simple fabric consisting of one or more switches, zero or more endpoints, and zero or more zones.",
+            "longDescription": "This resource shall represent a simple switchable fabric for a Redfish implementation.",
+            "patternProperties": {
+                "^([a-zA-Z_][a-zA-Z0-9_]*)?@(odata|Redfish|Message)\\.[a-zA-Z_][a-zA-Z0-9_]*$": {
+                    "description": "This property shall specify a valid odata or Redfish property.",
+                    "type": [
+                        "array",
+                        "boolean",
+                        "integer",
+                        "number",
+                        "null",
+                        "object",
+                        "string"
+                    ]
+                }
+            },
+            "properties": {
+                "@odata.context": {
+                    "$ref": "http://redfish.dmtf.org/schemas/v1/odata-v4.json#/definitions/context"
+                },
+                "@odata.etag": {
+                    "$ref": "http://redfish.dmtf.org/schemas/v1/odata-v4.json#/definitions/etag"
+                },
+                "@odata.id": {
+                    "$ref": "http://redfish.dmtf.org/schemas/v1/odata-v4.json#/definitions/id"
+                },
+                "@odata.type": {
+                    "$ref": "http://redfish.dmtf.org/schemas/v1/odata-v4.json#/definitions/type"
+                },
+                "Actions": {
+                    "$ref": "#/definitions/Actions",
+                    "description": "The available actions for this Resource.",
+                    "longDescription": "This property shall contain the available actions for this Resource."
+                },
+                "AddressPools": {
+                    "$ref": "http://redfish.dmtf.org/schemas/v1/AddressPoolCollection.json#/definitions/AddressPoolCollection",
+                    "description": "The collection of links to the address pools that this fabric contains.",
+                    "longDescription": "This property shall contain a link to a resource collection of type AddressPoolCollection.",
+                    "readonly": true,
+                    "versionAdded": "v1_1_0"
+                },
+                "Connections": {
+                    "$ref": "http://redfish.dmtf.org/schemas/v1/ConnectionCollection.json#/definitions/ConnectionCollection",
+                    "description": "The collection of links to the connections that this fabric contains.",
+                    "longDescription": "This property shall contain a link to a resource collection of type ConnectionCollection.",
+                    "readonly": true,
+                    "versionAdded": "v1_2_0"
+                },
+                "Description": {
+                    "anyOf": [
+                        {
+                            "$ref": "http://redfish.dmtf.org/schemas/v1/Resource.json#/definitions/Description"
+                        },
+                        {
+                            "type": "null"
+                        }
+                    ],
+                    "readonly": true
+                },
+                "EndpointGroups": {
+                    "$ref": "http://redfish.dmtf.org/schemas/v1/EndpointGroupCollection.json#/definitions/EndpointGroupCollection",
+                    "description": "The collection of links to the endpoint groups that this fabric contains.",
+                    "longDescription": "This property shall contain a link to a resource collection of type EndpointGroupCollection.",
+                    "readonly": true,
+                    "versionAdded": "v1_2_0"
+                },
+                "Endpoints": {
+                    "$ref": "http://redfish.dmtf.org/schemas/v1/EndpointCollection.json#/definitions/EndpointCollection",
+                    "description": "The collection of links to the endpoints that this fabric contains.",
+                    "longDescription": "This property shall contain a link to a resource collection of type EndpointCollection.",
+                    "readonly": true
+                },
+                "FabricType": {
+                    "anyOf": [
+                        {
+                            "$ref": "http://redfish.dmtf.org/schemas/v1/Protocol.json#/definitions/Protocol"
+                        },
+                        {
+                            "type": "null"
+                        }
+                    ],
+                    "description": "The protocol being sent over this fabric.",
+                    "longDescription": "This property shall contain the type of fabric being represented by this simple fabric.",
+                    "readonly": true
+                },
+                "Id": {
+                    "$ref": "http://redfish.dmtf.org/schemas/v1/Resource.json#/definitions/Id",
+                    "readonly": true
+                },
+                "Links": {
+                    "$ref": "#/definitions/Links",
+                    "description": "The links to other resources that are related to this resource.",
+                    "longDescription": "This property shall contain links to resources that are related to but are not contained by, or subordinate to, this resource."
+                },
+                "MaxZones": {
+                    "description": "The maximum number of zones the switch can currently configure.",
+                    "longDescription": "This property shall contain the maximum number of zones the switch can currently configure.  Changes in the logical or physical configuration of the system can change this value.",
+                    "readonly": true,
+                    "type": [
+                        "integer",
+                        "null"
+                    ]
+                },
+                "Name": {
+                    "$ref": "http://redfish.dmtf.org/schemas/v1/Resource.json#/definitions/Name",
+                    "readonly": true
+                },
+                "Oem": {
+                    "$ref": "http://redfish.dmtf.org/schemas/v1/Resource.json#/definitions/Oem",
+                    "description": "The OEM extension property.",
+                    "longDescription": "This property shall contain the OEM extensions.  All values for properties that this object contains shall conform to the Redfish Specification-described requirements."
+                },
+                "Status": {
+                    "$ref": "http://redfish.dmtf.org/schemas/v1/Resource.json#/definitions/Status",
+                    "description": "The status and health of the resource and its subordinate or dependent resources.",
+                    "longDescription": "This property shall contain any status or health properties of the resource."
+                },
+                "Switches": {
+                    "$ref": "http://redfish.dmtf.org/schemas/v1/SwitchCollection.json#/definitions/SwitchCollection",
+                    "description": "The collection of links to the switches that this fabric contains.",
+                    "longDescription": "This property shall contain a link to a resource collection of type SwitchCollection.",
+                    "readonly": true
+                },
+                "Zones": {
+                    "$ref": "http://redfish.dmtf.org/schemas/v1/ZoneCollection.json#/definitions/ZoneCollection",
+                    "description": "The collection of links to the zones that this fabric contains.",
+                    "longDescription": "This property shall contain a link to a resource collection of type ZoneCollection.",
+                    "readonly": true
+                }
+            },
+            "required": [
+                "@odata.id",
+                "@odata.type",
+                "Id",
+                "Name"
+            ],
+            "type": "object"
+        },
+        "Links": {
+            "additionalProperties": false,
+            "description": "The links to other resources that are related to this resource.",
+            "longDescription": "This Redfish Specification-described type shall contain links to resources that are related to but are not contained by, or subordinate to, this resource.",
+            "patternProperties": {
+                "^([a-zA-Z_][a-zA-Z0-9_]*)?@(odata|Redfish|Message)\\.[a-zA-Z_][a-zA-Z0-9_]*$": {
+                    "description": "This property shall specify a valid odata or Redfish property.",
+                    "type": [
+                        "array",
+                        "boolean",
+                        "integer",
+                        "number",
+                        "null",
+                        "object",
+                        "string"
+                    ]
+                }
+            },
+            "properties": {
+                "Oem": {
+                    "$ref": "http://redfish.dmtf.org/schemas/v1/Resource.json#/definitions/Oem",
+                    "description": "The OEM extension property.",
+                    "longDescription": "This property shall contain the OEM extensions.  All values for properties contained in this object shall conform to the Redfish Specification-described requirements."
+                }
+            },
+            "type": "object"
+        },
+        "OemActions": {
+            "additionalProperties": true,
+            "description": "The available OEM-specific actions for this resource.",
+            "longDescription": "This type shall contain the available OEM-specific actions for this resource.",
+            "patternProperties": {
+                "^([a-zA-Z_][a-zA-Z0-9_]*)?@(odata|Redfish|Message)\\.[a-zA-Z_][a-zA-Z0-9_]*$": {
+                    "description": "This property shall specify a valid odata or Redfish property.",
+                    "type": [
+                        "array",
+                        "boolean",
+                        "integer",
+                        "number",
+                        "null",
+                        "object",
+                        "string"
+                    ]
+                }
+            },
+            "properties": {},
+            "type": "object"
+        }
+    },
+    "owningEntity": "DMTF",
+    "release": "2020.3",
+    "title": "#Fabric.v1_2_2.Fabric"
+}

--- a/static/redfish/v1/JsonSchemas/Fabric/index.json
+++ b/static/redfish/v1/JsonSchemas/Fabric/index.json
@@ -1,0 +1,21 @@
+{
+    "@odata.context": "/redfish/v1/$metadata#JsonSchemaFile.JsonSchemaFile",
+    "@odata.id": "/redfish/v1/JsonSchemas/Fabric",
+    "@odata.type": "#JsonSchemaFile.v1_0_2.JsonSchemaFile",
+    "Name": "Fabric Schema File",
+    "Schema": "#Fabric.Fabric",
+    "Description": "Fabric Schema File Location",
+    "Id": "Fabric",
+    "Languages": [
+        "en"
+    ],
+    "Languages@odata.count": 1,
+    "Location": [
+        {
+            "Language": "en",
+            "PublicationUri": "http://redfish.dmtf.org/schemas/v1/Fabric.json",
+            "Uri": "/redfish/v1/JsonSchemas/Fabric/Fabric.json"
+        }
+    ],
+    "Location@odata.count": 1
+}

--- a/static/redfish/v1/JsonSchemas/FabricAdapter/FabricAdapter.json
+++ b/static/redfish/v1/JsonSchemas/FabricAdapter/FabricAdapter.json
@@ -1,8 +1,8 @@
 {
-    "$id": "http://redfish.dmtf.org/schemas/v1/FabricAdapter.v1_0_0.json",
+    "$id": "http://redfish.dmtf.org/schemas/v1/FabricAdapter.v1_1_0.json",
     "$ref": "#/definitions/FabricAdapter",
     "$schema": "http://redfish.dmtf.org/schemas/v1/redfish-schema-v1.json",
-    "copyright": "Copyright 2014-2019 DMTF. For the full DMTF copyright policy, see http://www.dmtf.org/about/policies/copyright",
+    "copyright": "Copyright 2014-2021 DMTF. For the full DMTF copyright policy, see http://www.dmtf.org/about/policies/copyright",
     "definitions": {
         "Actions": {
             "additionalProperties": false,
@@ -127,6 +127,12 @@
                     "$ref": "#/definitions/Links",
                     "description": "The links to other Resources that are related to this Resource.",
                     "longDescription": "The Redfish Specification-described Links Property shall contain links to Resources related to but not subordinate to this Resource."
+                },
+                "Location": {
+                    "$ref": "http://redfish.dmtf.org/schemas/v1/Resource.json#/definitions/Location",
+                    "description": "The location of the fabric adapter.",
+                    "longDescription": "This property shall contain location information for the fabric adapter.",
+                    "versionAdded": "v1_1_0"
                 },
                 "Manufacturer": {
                     "description": "The manufacturer or OEM of this fabric adapter.",
@@ -361,6 +367,6 @@
         }
     },
     "owningEntity": "DMTF",
-    "release": "2019.4",
-    "title": "#FabricAdapter.v1_0_0.FabricAdapter"
+    "release": "2021.2",
+    "title": "#FabricAdapter.v1_1_0.FabricAdapter"
 }

--- a/static/redfish/v1/JsonSchemas/Facility/Facility.json
+++ b/static/redfish/v1/JsonSchemas/Facility/Facility.json
@@ -1,0 +1,315 @@
+{
+    "$id": "http://redfish.dmtf.org/schemas/v1/Facility.v1_2_0.json",
+    "$ref": "#/definitions/Facility",
+    "$schema": "http://redfish.dmtf.org/schemas/v1/redfish-schema-v1.json",
+    "copyright": "Copyright 2014-2021 DMTF. For the full DMTF copyright policy, see http://www.dmtf.org/about/policies/copyright",
+    "definitions": {
+        "Actions": {
+            "additionalProperties": false,
+            "description": "The available actions for this resource.",
+            "longDescription": "This type shall contain the available actions for this resource.",
+            "patternProperties": {
+                "^([a-zA-Z_][a-zA-Z0-9_]*)?@(odata|Redfish|Message)\\.[a-zA-Z_][a-zA-Z0-9_]*$": {
+                    "description": "This property shall specify a valid odata or Redfish property.",
+                    "type": [
+                        "array",
+                        "boolean",
+                        "integer",
+                        "number",
+                        "null",
+                        "object",
+                        "string"
+                    ]
+                }
+            },
+            "properties": {
+                "Oem": {
+                    "$ref": "#/definitions/OemActions",
+                    "description": "The available OEM-specific actions for this resource.",
+                    "longDescription": "This property shall contain the available OEM-specific actions for this resource."
+                }
+            },
+            "type": "object"
+        },
+        "Facility": {
+            "additionalProperties": false,
+            "description": "The Facility schema represents the physical location containing equipment, such as a room, building, or campus.",
+            "longDescription": "This resource shall be used to represent a location containing equipment, such as a room, building, or campus, for a Redfish implementation.",
+            "patternProperties": {
+                "^([a-zA-Z_][a-zA-Z0-9_]*)?@(odata|Redfish|Message)\\.[a-zA-Z_][a-zA-Z0-9_]*$": {
+                    "description": "This property shall specify a valid odata or Redfish property.",
+                    "type": [
+                        "array",
+                        "boolean",
+                        "integer",
+                        "number",
+                        "null",
+                        "object",
+                        "string"
+                    ]
+                }
+            },
+            "properties": {
+                "@odata.context": {
+                    "$ref": "http://redfish.dmtf.org/schemas/v1/odata-v4.json#/definitions/context"
+                },
+                "@odata.etag": {
+                    "$ref": "http://redfish.dmtf.org/schemas/v1/odata-v4.json#/definitions/etag"
+                },
+                "@odata.id": {
+                    "$ref": "http://redfish.dmtf.org/schemas/v1/odata-v4.json#/definitions/id"
+                },
+                "@odata.type": {
+                    "$ref": "http://redfish.dmtf.org/schemas/v1/odata-v4.json#/definitions/type"
+                },
+                "Actions": {
+                    "$ref": "#/definitions/Actions",
+                    "description": "The available actions for this resource.",
+                    "longDescription": "This property shall contain the available actions for this resource."
+                },
+                "AmbientMetrics": {
+                    "$ref": "http://redfish.dmtf.org/schemas/v1/EnvironmentMetrics.json#/definitions/EnvironmentMetrics",
+                    "description": "The link to the ambient environment metrics for this facility.",
+                    "longDescription": "This property shall contain a link to a resource of type EnvironmentMetrics that specifies the outdoor environment metrics for this facility.",
+                    "readonly": true,
+                    "versionAdded": "v1_1_0"
+                },
+                "Description": {
+                    "anyOf": [
+                        {
+                            "$ref": "http://redfish.dmtf.org/schemas/v1/Resource.json#/definitions/Description"
+                        },
+                        {
+                            "type": "null"
+                        }
+                    ],
+                    "readonly": true
+                },
+                "EnvironmentMetrics": {
+                    "$ref": "http://redfish.dmtf.org/schemas/v1/EnvironmentMetrics.json#/definitions/EnvironmentMetrics",
+                    "description": "The link to the environment metrics for this facility.",
+                    "longDescription": "This property shall contain a link to a resource of type EnvironmentMetrics that specifies the environment metrics for this facility.",
+                    "readonly": true,
+                    "versionAdded": "v1_1_0"
+                },
+                "FacilityType": {
+                    "$ref": "#/definitions/FacilityType",
+                    "description": "The type of location this resource represents.",
+                    "longDescription": "This property shall contain the type of location this resource represents.",
+                    "readonly": true
+                },
+                "Id": {
+                    "$ref": "http://redfish.dmtf.org/schemas/v1/Resource.json#/definitions/Id",
+                    "readonly": true
+                },
+                "Links": {
+                    "$ref": "#/definitions/Links",
+                    "description": "The links to other resources that are related to this resource.",
+                    "longDescription": "This property shall contain links to resources that are related to but are not contained by, or subordinate to, this resource."
+                },
+                "Location": {
+                    "$ref": "http://redfish.dmtf.org/schemas/v1/Resource.json#/definitions/Location",
+                    "description": "The location of the facility.",
+                    "longDescription": "This property shall contain location information of the associated facility."
+                },
+                "Name": {
+                    "$ref": "http://redfish.dmtf.org/schemas/v1/Resource.json#/definitions/Name",
+                    "readonly": true
+                },
+                "Oem": {
+                    "$ref": "http://redfish.dmtf.org/schemas/v1/Resource.json#/definitions/Oem",
+                    "description": "The OEM extension property.",
+                    "longDescription": "This property shall contain the OEM extensions.  All values for properties that this object contains shall conform to the Redfish Specification-described requirements."
+                },
+                "PowerDomains": {
+                    "$ref": "http://redfish.dmtf.org/schemas/v1/PowerDomainCollection.json#/definitions/PowerDomainCollection",
+                    "description": "Link to the power domains in this facility.",
+                    "longDescription": "This property shall contain a link to a resource collection of type PowerDomainCollection that contains the power domains associated with this facility.",
+                    "readonly": true
+                },
+                "Status": {
+                    "$ref": "http://redfish.dmtf.org/schemas/v1/Resource.json#/definitions/Status",
+                    "description": "The status and health of the resource and its subordinate or dependent resources.",
+                    "longDescription": "This property shall contain any status or health properties of the resource."
+                }
+            },
+            "required": [
+                "FacilityType",
+                "@odata.id",
+                "@odata.type",
+                "Id",
+                "Name"
+            ],
+            "type": "object"
+        },
+        "FacilityType": {
+            "enum": [
+                "Room",
+                "Floor",
+                "Building",
+                "Site"
+            ],
+            "enumDescriptions": {
+                "Building": "A structure with a roof and walls.",
+                "Floor": "A floor inside of a building.",
+                "Room": "A room inside of a building or floor.",
+                "Site": "A small area consisting of several buildings."
+            },
+            "type": "string"
+        },
+        "Links": {
+            "additionalProperties": false,
+            "description": "The links to other resources that are related to this resource.",
+            "longDescription": "This Redfish Specification-described type shall contain links to resources that are related to but are not contained by, or subordinate to, this resource.",
+            "patternProperties": {
+                "^([a-zA-Z_][a-zA-Z0-9_]*)?@(odata|Redfish|Message)\\.[a-zA-Z_][a-zA-Z0-9_]*$": {
+                    "description": "This property shall specify a valid odata or Redfish property.",
+                    "type": [
+                        "array",
+                        "boolean",
+                        "integer",
+                        "number",
+                        "null",
+                        "object",
+                        "string"
+                    ]
+                }
+            },
+            "properties": {
+                "ContainedByFacility": {
+                    "$ref": "http://redfish.dmtf.org/schemas/v1/Facility.json#/definitions/Facility",
+                    "description": "The link to the facility that contains this facility.",
+                    "longDescription": "This property shall contain a link to a resource of type Facility that represents the facility that contains this facility.",
+                    "readonly": false
+                },
+                "ContainsChassis": {
+                    "description": "An array of links to outermost chassis contained within this facility.",
+                    "items": {
+                        "$ref": "http://redfish.dmtf.org/schemas/v1/Chassis.json#/definitions/Chassis"
+                    },
+                    "longDescription": "The value of this property shall be an array of links to resources of type Chassis that represent the outermost chassis that this facility contains.  This array shall only contain chassis instances that do not include a ContainedBy property within the Links property.  That is, only chassis instances that are not contained by another chassis.",
+                    "readonly": false,
+                    "type": "array"
+                },
+                "ContainsChassis@odata.count": {
+                    "$ref": "http://redfish.dmtf.org/schemas/v1/odata-v4.json#/definitions/count"
+                },
+                "ContainsFacilities": {
+                    "description": "An array of links to other facilities contained within this facility.",
+                    "items": {
+                        "$ref": "http://redfish.dmtf.org/schemas/v1/Facility.json#/definitions/Facility"
+                    },
+                    "longDescription": "The value of this property shall be an array of links to resources of type Facility that represent the facilities that this facility contains.",
+                    "readonly": false,
+                    "type": "array"
+                },
+                "ContainsFacilities@odata.count": {
+                    "$ref": "http://redfish.dmtf.org/schemas/v1/odata-v4.json#/definitions/count"
+                },
+                "FloorPDUs": {
+                    "description": "An array of links to the floor power distribution units in this facility.",
+                    "items": {
+                        "$ref": "http://redfish.dmtf.org/schemas/v1/PowerDistribution.json#/definitions/PowerDistribution"
+                    },
+                    "longDescription": "The value of this property shall be an array of links to resources of type PowerDistribution that represent the floor power distribution units in this facility.",
+                    "readonly": false,
+                    "type": "array"
+                },
+                "FloorPDUs@odata.count": {
+                    "$ref": "http://redfish.dmtf.org/schemas/v1/odata-v4.json#/definitions/count"
+                },
+                "ManagedBy": {
+                    "description": "An array of links to the managers responsible for managing this facility.",
+                    "items": {
+                        "$ref": "http://redfish.dmtf.org/schemas/v1/Manager.json#/definitions/Manager"
+                    },
+                    "longDescription": "The value of this property shall be an array of links to resources of type Manager that represent the managers that manager this facility.",
+                    "readonly": true,
+                    "type": "array"
+                },
+                "ManagedBy@odata.count": {
+                    "$ref": "http://redfish.dmtf.org/schemas/v1/odata-v4.json#/definitions/count"
+                },
+                "Oem": {
+                    "$ref": "http://redfish.dmtf.org/schemas/v1/Resource.json#/definitions/Oem",
+                    "description": "The OEM extension property.",
+                    "longDescription": "This property shall contain the OEM extensions.  All values for properties contained in this object shall conform to the Redfish Specification-described requirements."
+                },
+                "PowerShelves": {
+                    "description": "An array of links to the power shelves in this facility.",
+                    "items": {
+                        "$ref": "http://redfish.dmtf.org/schemas/v1/PowerDistribution.json#/definitions/PowerDistribution"
+                    },
+                    "longDescription": "The value of this property shall be an array of links to resources of type PowerDistribution that represent the power shelves in this facility.",
+                    "readonly": false,
+                    "type": "array",
+                    "versionAdded": "v1_2_0"
+                },
+                "PowerShelves@odata.count": {
+                    "$ref": "http://redfish.dmtf.org/schemas/v1/odata-v4.json#/definitions/count"
+                },
+                "RackPDUs": {
+                    "description": "An array of links to the rack-level power distribution units in this facility.",
+                    "items": {
+                        "$ref": "http://redfish.dmtf.org/schemas/v1/PowerDistribution.json#/definitions/PowerDistribution"
+                    },
+                    "longDescription": "The value of this property shall be an array of links to resources of type PowerDistribution that represent the rack-level power distribution units in this facility.",
+                    "readonly": false,
+                    "type": "array"
+                },
+                "RackPDUs@odata.count": {
+                    "$ref": "http://redfish.dmtf.org/schemas/v1/odata-v4.json#/definitions/count"
+                },
+                "Switchgear": {
+                    "description": "An array of links to the switchgear in this facility.",
+                    "items": {
+                        "$ref": "http://redfish.dmtf.org/schemas/v1/PowerDistribution.json#/definitions/PowerDistribution"
+                    },
+                    "longDescription": "The value of this property shall be an array of links to resources of type PowerDistribution that represent the switchgear in this facility.",
+                    "readonly": false,
+                    "type": "array"
+                },
+                "Switchgear@odata.count": {
+                    "$ref": "http://redfish.dmtf.org/schemas/v1/odata-v4.json#/definitions/count"
+                },
+                "TransferSwitches": {
+                    "description": "An array of links to the transfer switches in this facility.",
+                    "items": {
+                        "$ref": "http://redfish.dmtf.org/schemas/v1/PowerDistribution.json#/definitions/PowerDistribution"
+                    },
+                    "longDescription": "The value of this property shall be an array of links to resources of type PowerDistribution that represent the transfer switches in this facility.",
+                    "readonly": false,
+                    "type": "array"
+                },
+                "TransferSwitches@odata.count": {
+                    "$ref": "http://redfish.dmtf.org/schemas/v1/odata-v4.json#/definitions/count"
+                }
+            },
+            "type": "object"
+        },
+        "OemActions": {
+            "additionalProperties": true,
+            "description": "The available OEM-specific actions for this resource.",
+            "longDescription": "This type shall contain the available OEM-specific actions for this resource.",
+            "patternProperties": {
+                "^([a-zA-Z_][a-zA-Z0-9_]*)?@(odata|Redfish|Message)\\.[a-zA-Z_][a-zA-Z0-9_]*$": {
+                    "description": "This property shall specify a valid odata or Redfish property.",
+                    "type": [
+                        "array",
+                        "boolean",
+                        "integer",
+                        "number",
+                        "null",
+                        "object",
+                        "string"
+                    ]
+                }
+            },
+            "properties": {},
+            "type": "object"
+        }
+    },
+    "owningEntity": "DMTF",
+    "release": "2021.2",
+    "title": "#Facility.v1_2_0.Facility"
+}

--- a/static/redfish/v1/JsonSchemas/Facility/index.json
+++ b/static/redfish/v1/JsonSchemas/Facility/index.json
@@ -1,0 +1,21 @@
+{
+    "@odata.context": "/redfish/v1/$metadata#JsonSchemaFile.JsonSchemaFile",
+    "@odata.id": "/redfish/v1/JsonSchemas/Facility",
+    "@odata.type": "#JsonSchemaFile.v1_0_2.JsonSchemaFile",
+    "Name": "Facility Schema File",
+    "Schema": "#Facility.Facility",
+    "Description": "Facility Schema File Location",
+    "Id": "Facility",
+    "Languages": [
+        "en"
+    ],
+    "Languages@odata.count": 1,
+    "Location": [
+        {
+            "Language": "en",
+            "PublicationUri": "http://redfish.dmtf.org/schemas/v1/Facility.json",
+            "Uri": "/redfish/v1/JsonSchemas/Facility/Facility.json"
+        }
+    ],
+    "Location@odata.count": 1
+}

--- a/static/redfish/v1/JsonSchemas/Fan/Fan.json
+++ b/static/redfish/v1/JsonSchemas/Fan/Fan.json
@@ -1,8 +1,8 @@
 {
-    "$id": "http://redfish.dmtf.org/schemas/v1/Fan.v1_0_0.json",
+    "$id": "http://redfish.dmtf.org/schemas/v1/Fan.v1_1_0.json",
     "$ref": "#/definitions/Fan",
     "$schema": "http://redfish.dmtf.org/schemas/v1/redfish-schema-v1.json",
-    "copyright": "Copyright 2014-2020 DMTF. For the full DMTF copyright policy, see http://www.dmtf.org/about/policies/copyright",
+    "copyright": "Copyright 2014-2021 DMTF. For the full DMTF copyright policy, see http://www.dmtf.org/about/policies/copyright",
     "definitions": {
         "Actions": {
             "additionalProperties": false,
@@ -113,7 +113,7 @@
                 },
                 "Manufacturer": {
                     "description": "The manufacturer of this fan.",
-                    "longDescription": "This property shall contain the name of the organization responsible for producing the fan.  This organization might be the entity from whom the fan is purchased, but this is not necessarily true.",
+                    "longDescription": "This property shall contain the name of the organization responsible for producing the fan.  This organization may be the entity from whom the fan is purchased, but this is not necessarily true.",
                     "readonly": true,
                     "type": [
                         "string",
@@ -152,6 +152,21 @@
                     "description": "The area or device associated with this fan.",
                     "longDescription": "This property shall contain a description of the affected device or region within the chassis with which this fan is associated.",
                     "readonly": true
+                },
+                "PowerWatts": {
+                    "anyOf": [
+                        {
+                            "$ref": "http://redfish.dmtf.org/schemas/v1/Sensor.json#/definitions/SensorPowerExcerpt"
+                        },
+                        {
+                            "type": "null"
+                        }
+                    ],
+                    "description": "Power consumption (Watts).",
+                    "excerptCopy": "SensorPowerExcerpt",
+                    "longDescription": "This property shall contain the total power, measured in Watts, for this resource.",
+                    "readonly": true,
+                    "versionAdded": "v1_1_0"
                 },
                 "SerialNumber": {
                     "description": "The serial number for this fan.",
@@ -222,6 +237,6 @@
         }
     },
     "owningEntity": "DMTF",
-    "release": "2020.4",
-    "title": "#Fan.v1_0_0.Fan"
+    "release": "2021.1",
+    "title": "#Fan.v1_1_0.Fan"
 }

--- a/static/redfish/v1/JsonSchemas/GraphicsController/GraphicsController.json
+++ b/static/redfish/v1/JsonSchemas/GraphicsController/GraphicsController.json
@@ -1,0 +1,281 @@
+{
+    "$id": "http://redfish.dmtf.org/schemas/v1/GraphicsController.v1_0_0.json",
+    "$ref": "#/definitions/GraphicsController",
+    "$schema": "http://redfish.dmtf.org/schemas/v1/redfish-schema-v1.json",
+    "copyright": "Copyright 2014-2021 DMTF. For the full DMTF copyright policy, see http://www.dmtf.org/about/policies/copyright",
+    "definitions": {
+        "Actions": {
+            "additionalProperties": false,
+            "description": "The available actions for this resource.",
+            "longDescription": "This type shall contain the available actions for this resource.",
+            "patternProperties": {
+                "^([a-zA-Z_][a-zA-Z0-9_]*)?@(odata|Redfish|Message)\\.[a-zA-Z_][a-zA-Z0-9_]*$": {
+                    "description": "This property shall specify a valid odata or Redfish property.",
+                    "type": [
+                        "array",
+                        "boolean",
+                        "integer",
+                        "number",
+                        "null",
+                        "object",
+                        "string"
+                    ]
+                }
+            },
+            "properties": {
+                "Oem": {
+                    "$ref": "#/definitions/OemActions",
+                    "description": "The available OEM-specific actions for this resource.",
+                    "longDescription": "This property shall contain the available OEM-specific actions for this resource."
+                }
+            },
+            "type": "object"
+        },
+        "GraphicsController": {
+            "additionalProperties": false,
+            "description": "The GraphicsController schema defines a graphics controller that can be used to drive one or more display devices.",
+            "longDescription": "This resource shall represent a graphics output device in a Redfish implementation.",
+            "patternProperties": {
+                "^([a-zA-Z_][a-zA-Z0-9_]*)?@(odata|Redfish|Message)\\.[a-zA-Z_][a-zA-Z0-9_]*$": {
+                    "description": "This property shall specify a valid odata or Redfish property.",
+                    "type": [
+                        "array",
+                        "boolean",
+                        "integer",
+                        "number",
+                        "null",
+                        "object",
+                        "string"
+                    ]
+                }
+            },
+            "properties": {
+                "@odata.context": {
+                    "$ref": "http://redfish.dmtf.org/schemas/v1/odata-v4.json#/definitions/context"
+                },
+                "@odata.etag": {
+                    "$ref": "http://redfish.dmtf.org/schemas/v1/odata-v4.json#/definitions/etag"
+                },
+                "@odata.id": {
+                    "$ref": "http://redfish.dmtf.org/schemas/v1/odata-v4.json#/definitions/id"
+                },
+                "@odata.type": {
+                    "$ref": "http://redfish.dmtf.org/schemas/v1/odata-v4.json#/definitions/type"
+                },
+                "Actions": {
+                    "$ref": "#/definitions/Actions",
+                    "description": "The available actions for this resource.",
+                    "longDescription": "This property shall contain the available actions for this resource."
+                },
+                "AssetTag": {
+                    "description": "The user-assigned asset tag for this graphics controller.",
+                    "longDescription": "This property shall contain the user-assigned asset tag, which is an identifying string that tracks the drive for inventory purposes.",
+                    "readonly": false,
+                    "type": [
+                        "string",
+                        "null"
+                    ]
+                },
+                "BiosVersion": {
+                    "description": "The version of the graphics controller BIOS or primary graphics controller firmware.",
+                    "longDescription": "This property shall contain the version string of the currently installed and running BIOS or firmware for the graphics controller.",
+                    "readonly": true,
+                    "type": [
+                        "string",
+                        "null"
+                    ]
+                },
+                "Description": {
+                    "anyOf": [
+                        {
+                            "$ref": "http://redfish.dmtf.org/schemas/v1/Resource.json#/definitions/Description"
+                        },
+                        {
+                            "type": "null"
+                        }
+                    ],
+                    "readonly": true
+                },
+                "DriverVersion": {
+                    "description": "The version of the graphics controller driver loaded in the operating system.",
+                    "longDescription": "This property shall contain the version string of the currently loaded driver for this graphics controller.",
+                    "readonly": true,
+                    "type": [
+                        "string",
+                        "null"
+                    ]
+                },
+                "Id": {
+                    "$ref": "http://redfish.dmtf.org/schemas/v1/Resource.json#/definitions/Id",
+                    "readonly": true
+                },
+                "Links": {
+                    "$ref": "#/definitions/Links",
+                    "description": "The links to other resources that are related to this resource.",
+                    "longDescription": "This property shall contain links to resources that are related to but are not contained by, or subordinate to, this resource."
+                },
+                "Location": {
+                    "$ref": "http://redfish.dmtf.org/schemas/v1/Resource.json#/definitions/Location",
+                    "description": "The location of the graphics controller.",
+                    "longDescription": "This property shall contain location information of the associated graphics controller."
+                },
+                "Manufacturer": {
+                    "description": "The manufacturer of this graphics controller.",
+                    "longDescription": "This property shall contain the name of the organization responsible for producing the graphics controller.  This organization may be the entity from which the graphics controller is purchased, but this is not necessarily true.",
+                    "readonly": true,
+                    "type": [
+                        "string",
+                        "null"
+                    ]
+                },
+                "Model": {
+                    "description": "The product model number of this graphics controller.",
+                    "longDescription": "This property shall contain the manufacturer-provided model information of this graphics controller.",
+                    "readonly": true,
+                    "type": [
+                        "string",
+                        "null"
+                    ]
+                },
+                "Name": {
+                    "$ref": "http://redfish.dmtf.org/schemas/v1/Resource.json#/definitions/Name",
+                    "readonly": true
+                },
+                "Oem": {
+                    "$ref": "http://redfish.dmtf.org/schemas/v1/Resource.json#/definitions/Oem",
+                    "description": "The OEM extension property.",
+                    "longDescription": "This property shall contain the OEM extensions.  All values for properties that this object contains shall conform to the Redfish Specification-described requirements."
+                },
+                "PartNumber": {
+                    "description": "The part number for this graphics controller.",
+                    "longDescription": "This property shall contain the manufacturer-provided part number for the graphics controller.",
+                    "readonly": true,
+                    "type": [
+                        "string",
+                        "null"
+                    ]
+                },
+                "Ports": {
+                    "$ref": "http://redfish.dmtf.org/schemas/v1/PortCollection.json#/definitions/PortCollection",
+                    "description": "The ports of the graphics controller.",
+                    "longDescription": "This property shall contain a link to a resource collection of type PortCollection."
+                },
+                "SKU": {
+                    "description": "The SKU for this graphics controller.",
+                    "longDescription": "This property shall contain the SKU number for this graphics controller.",
+                    "readonly": true,
+                    "type": [
+                        "string",
+                        "null"
+                    ]
+                },
+                "SerialNumber": {
+                    "description": "The serial number for this graphics controller.",
+                    "longDescription": "This property shall contain a manufacturer-allocated number that identifies the graphics controller.",
+                    "readonly": true,
+                    "type": [
+                        "string",
+                        "null"
+                    ]
+                },
+                "SparePartNumber": {
+                    "description": "The spare part number of the graphics controller.",
+                    "longDescription": "This property shall contain the spare part number of the graphics controller.",
+                    "readonly": true,
+                    "type": [
+                        "string",
+                        "null"
+                    ]
+                },
+                "Status": {
+                    "$ref": "http://redfish.dmtf.org/schemas/v1/Resource.json#/definitions/Status",
+                    "description": "The status and health of the resource and its subordinate or dependent resources.",
+                    "longDescription": "This property shall contain any status or health properties of the resource."
+                }
+            },
+            "required": [
+                "@odata.id",
+                "@odata.type",
+                "Id",
+                "Name"
+            ],
+            "type": "object"
+        },
+        "Links": {
+            "additionalProperties": false,
+            "description": "The links to other resources that are related to this resource.",
+            "longDescription": "This Redfish Specification-described type shall contain links to resources that are related to but are not contained by, or subordinate to, this resource.",
+            "patternProperties": {
+                "^([a-zA-Z_][a-zA-Z0-9_]*)?@(odata|Redfish|Message)\\.[a-zA-Z_][a-zA-Z0-9_]*$": {
+                    "description": "This property shall specify a valid odata or Redfish property.",
+                    "type": [
+                        "array",
+                        "boolean",
+                        "integer",
+                        "number",
+                        "null",
+                        "object",
+                        "string"
+                    ]
+                }
+            },
+            "properties": {
+                "Oem": {
+                    "$ref": "http://redfish.dmtf.org/schemas/v1/Resource.json#/definitions/Oem",
+                    "description": "The OEM extension property.",
+                    "longDescription": "This property shall contain the OEM extensions.  All values for properties contained in this object shall conform to the Redfish Specification-described requirements."
+                },
+                "PCIeDevice": {
+                    "anyOf": [
+                        {
+                            "$ref": "http://redfish.dmtf.org/schemas/v1/PCIeDevice.json#/definitions/PCIeDevice"
+                        },
+                        {
+                            "type": "null"
+                        }
+                    ],
+                    "description": "A link to the PCIe device that represents this graphics controller.",
+                    "longDescription": "This property shall contain a link to a resource of type PCIeDevice that represents this graphics controller.",
+                    "readonly": true
+                },
+                "Processors": {
+                    "description": "An array of links to the processors that are a part of this graphics controller.",
+                    "items": {
+                        "$ref": "http://redfish.dmtf.org/schemas/v1/Processor.json#/definitions/Processor"
+                    },
+                    "longDescription": "This property shall contain an array of links to resources of type Processor that represent the processors that this graphics controller contains.",
+                    "readonly": true,
+                    "type": "array"
+                },
+                "Processors@odata.count": {
+                    "$ref": "http://redfish.dmtf.org/schemas/v1/odata-v4.json#/definitions/count"
+                }
+            },
+            "type": "object"
+        },
+        "OemActions": {
+            "additionalProperties": true,
+            "description": "The available OEM-specific actions for this resource.",
+            "longDescription": "This type shall contain the available OEM-specific actions for this resource.",
+            "patternProperties": {
+                "^([a-zA-Z_][a-zA-Z0-9_]*)?@(odata|Redfish|Message)\\.[a-zA-Z_][a-zA-Z0-9_]*$": {
+                    "description": "This property shall specify a valid odata or Redfish property.",
+                    "type": [
+                        "array",
+                        "boolean",
+                        "integer",
+                        "number",
+                        "null",
+                        "object",
+                        "string"
+                    ]
+                }
+            },
+            "properties": {},
+            "type": "object"
+        }
+    },
+    "owningEntity": "DMTF",
+    "release": "2021.1",
+    "title": "#GraphicsController.v1_0_0.GraphicsController"
+}

--- a/static/redfish/v1/JsonSchemas/GraphicsController/index.json
+++ b/static/redfish/v1/JsonSchemas/GraphicsController/index.json
@@ -1,0 +1,21 @@
+{
+    "@odata.context": "/redfish/v1/$metadata#JsonSchemaFile.JsonSchemaFile",
+    "@odata.id": "/redfish/v1/JsonSchemas/GraphicsController",
+    "@odata.type": "#JsonSchemaFile.v1_0_2.JsonSchemaFile",
+    "Name": "GraphicsController Schema File",
+    "Schema": "#GraphicsController.GraphicsController",
+    "Description": "GraphicsController Schema File Location",
+    "Id": "GraphicsController",
+    "Languages": [
+        "en"
+    ],
+    "Languages@odata.count": 1,
+    "Location": [
+        {
+            "Language": "en",
+            "PublicationUri": "http://redfish.dmtf.org/schemas/v1/GraphicsController.json",
+            "Uri": "/redfish/v1/JsonSchemas/GraphicsController/GraphicsController.json"
+        }
+    ],
+    "Location@odata.count": 1
+}

--- a/static/redfish/v1/JsonSchemas/HostInterface/HostInterface.json
+++ b/static/redfish/v1/JsonSchemas/HostInterface/HostInterface.json
@@ -1,0 +1,391 @@
+{
+    "$id": "http://redfish.dmtf.org/schemas/v1/HostInterface.v1_3_0.json",
+    "$ref": "#/definitions/HostInterface",
+    "$schema": "http://redfish.dmtf.org/schemas/v1/redfish-schema-v1.json",
+    "copyright": "Copyright 2014-2020 DMTF. For the full DMTF copyright policy, see http://www.dmtf.org/about/policies/copyright",
+    "definitions": {
+        "Actions": {
+            "additionalProperties": false,
+            "description": "The available actions for this Resource.",
+            "longDescription": "This type shall contain the available actions for this Resource.",
+            "patternProperties": {
+                "^([a-zA-Z_][a-zA-Z0-9_]*)?@(odata|Redfish|Message)\\.[a-zA-Z_][a-zA-Z0-9_]*$": {
+                    "description": "This property shall specify a valid odata or Redfish property.",
+                    "type": [
+                        "array",
+                        "boolean",
+                        "integer",
+                        "number",
+                        "null",
+                        "object",
+                        "string"
+                    ]
+                }
+            },
+            "properties": {
+                "Oem": {
+                    "$ref": "#/definitions/OemActions",
+                    "description": "The available OEM-specific actions for this Resource.",
+                    "longDescription": "This property shall contain the available OEM-specific actions for this Resource.",
+                    "versionAdded": "v1_1_0"
+                }
+            },
+            "type": "object"
+        },
+        "AuthenticationMode": {
+            "enum": [
+                "AuthNone",
+                "BasicAuth",
+                "RedfishSessionAuth",
+                "OemAuth"
+            ],
+            "enumDescriptions": {
+                "AuthNone": "Requests without any sort of authentication are allowed.",
+                "BasicAuth": "Requests using HTTP Basic Authentication are allowed.",
+                "OemAuth": "Requests using OEM authentication mechanisms are allowed.",
+                "RedfishSessionAuth": "Requests using Redfish Session Authentication are allowed."
+            },
+            "type": "string"
+        },
+        "CredentialBootstrapping": {
+            "additionalProperties": false,
+            "description": "The credential bootstrapping settings for this interface.",
+            "longDescription": "This type shall contain settings for the Redfish Host Interface Specification-defined 'credential bootstrapping via IPMI commands' feature for this interface.",
+            "patternProperties": {
+                "^([a-zA-Z_][a-zA-Z0-9_]*)?@(odata|Redfish|Message)\\.[a-zA-Z_][a-zA-Z0-9_]*$": {
+                    "description": "This property shall specify a valid odata or Redfish property.",
+                    "type": [
+                        "array",
+                        "boolean",
+                        "integer",
+                        "number",
+                        "null",
+                        "object",
+                        "string"
+                    ]
+                }
+            },
+            "properties": {
+                "EnableAfterReset": {
+                    "description": "An indication of whether credential bootstrapping is enabled after a reset for this interface.",
+                    "longDescription": "This property shall indicate whether credential bootstrapping is enabled after a reset for this interface.  If `true`, services shall set the Enabled property to `true` after a reset of the host or the service.",
+                    "readonly": false,
+                    "type": [
+                        "boolean",
+                        "null"
+                    ],
+                    "versionAdded": "v1_3_0"
+                },
+                "Enabled": {
+                    "description": "An indication of whether credential bootstrapping is enabled for this interface.",
+                    "longDescription": "This property shall indicate whether credential bootstrapping is enabled for this interface.",
+                    "readonly": false,
+                    "type": [
+                        "boolean",
+                        "null"
+                    ],
+                    "versionAdded": "v1_3_0"
+                },
+                "RoleId": {
+                    "description": "The role used for the bootstrap account created for this interface.",
+                    "longDescription": "This property shall contain the Id property of the role resource that is used for the bootstrap account created for this interface.",
+                    "readonly": false,
+                    "type": "string",
+                    "versionAdded": "v1_3_0"
+                }
+            },
+            "type": "object"
+        },
+        "HostInterface": {
+            "additionalProperties": false,
+            "description": "The properties associated with a Host Interface.  A Host Interface is a connection between host software and a Redfish Service.",
+            "longDescription": "This Resource shall represent a Host Interface as part of the Redfish Specification.",
+            "patternProperties": {
+                "^([a-zA-Z_][a-zA-Z0-9_]*)?@(odata|Redfish|Message)\\.[a-zA-Z_][a-zA-Z0-9_]*$": {
+                    "description": "This property shall specify a valid odata or Redfish property.",
+                    "type": [
+                        "array",
+                        "boolean",
+                        "integer",
+                        "number",
+                        "null",
+                        "object",
+                        "string"
+                    ]
+                }
+            },
+            "properties": {
+                "@odata.context": {
+                    "$ref": "http://redfish.dmtf.org/schemas/v1/odata-v4.json#/definitions/context"
+                },
+                "@odata.etag": {
+                    "$ref": "http://redfish.dmtf.org/schemas/v1/odata-v4.json#/definitions/etag"
+                },
+                "@odata.id": {
+                    "$ref": "http://redfish.dmtf.org/schemas/v1/odata-v4.json#/definitions/id"
+                },
+                "@odata.type": {
+                    "$ref": "http://redfish.dmtf.org/schemas/v1/odata-v4.json#/definitions/type"
+                },
+                "Actions": {
+                    "$ref": "#/definitions/Actions",
+                    "description": "The available actions for this Resource.",
+                    "longDescription": "This property shall contain the available actions for this Resource.",
+                    "versionAdded": "v1_1_0"
+                },
+                "AuthNoneRoleId": {
+                    "description": "The role when no authentication on this interface is used.",
+                    "longDescription": "This property shall contain the Id property of the Role Resource that is used when no authentication on this interface is performed.  This property shall contain absent if AuthNone is not supported by the service for the AuthenticationModes property.",
+                    "readonly": false,
+                    "type": "string",
+                    "versionAdded": "v1_2_0"
+                },
+                "AuthenticationModes": {
+                    "description": "The authentication modes available on this interface.",
+                    "items": {
+                        "$ref": "#/definitions/AuthenticationMode"
+                    },
+                    "longDescription": "This property shall contain an array consisting of the authentication modes allowed on this interface.",
+                    "readonly": false,
+                    "type": "array"
+                },
+                "CredentialBootstrapping": {
+                    "$ref": "#/definitions/CredentialBootstrapping",
+                    "description": "The credential bootstrapping settings for this interface.",
+                    "longDescription": "This property shall contain settings for the Redfish Host Interface Specification-defined 'credential bootstrapping via IPMI commands' feature for this interface.  This property shall be absent if credential bootstrapping is not supported by the service.",
+                    "versionAdded": "v1_3_0"
+                },
+                "Description": {
+                    "anyOf": [
+                        {
+                            "$ref": "http://redfish.dmtf.org/schemas/v1/Resource.json#/definitions/Description"
+                        },
+                        {
+                            "type": "null"
+                        }
+                    ],
+                    "readonly": true
+                },
+                "ExternallyAccessible": {
+                    "description": "An indication of whether external entities can access this interface.  External entities are non-host entities.  For example, if the host and manager are connected through a switch and the switch also exposes an external port on the system, external clients can also use the interface, and this property value is `true`.",
+                    "longDescription": "This property shall indicate whether external entities can access this interface.  External entities are non-host entities.  For example, if the host and manager are connected through a switch and the switch also exposes an external port on the system, external clients can also use the interface, and this property value is `true`.",
+                    "readonly": true,
+                    "type": [
+                        "boolean",
+                        "null"
+                    ]
+                },
+                "FirmwareAuthEnabled": {
+                    "deprecated": "This property has been deprecated in favor of newer methods of negotiating credentials.",
+                    "description": "An indication of whether this firmware authentication is enabled for this interface.",
+                    "longDescription": "This property shall indicate whether firmware authentication is enabled for this interface.",
+                    "readonly": false,
+                    "type": [
+                        "boolean",
+                        "null"
+                    ],
+                    "versionDeprecated": "v1_3_0"
+                },
+                "FirmwareAuthRoleId": {
+                    "deprecated": "This property has been deprecated in favor of newer methods of negotiating credentials.",
+                    "description": "The Role used for firmware authentication on this interface.",
+                    "longDescription": "This property shall contain the Id property of the Role Resource that is configured for firmware authentication on this interface.",
+                    "readonly": false,
+                    "type": "string",
+                    "versionDeprecated": "v1_3_0"
+                },
+                "HostEthernetInterfaces": {
+                    "$ref": "http://redfish.dmtf.org/schemas/v1/EthernetInterfaceCollection.json#/definitions/EthernetInterfaceCollection",
+                    "description": "A link to the collection of network interface controllers or cards (NICs) that a computer system uses to communicate with this Host Interface.",
+                    "longDescription": "This property shall contain a link to a Resource Collection of type EthernetInterface that computer systems use as the Host Interface to this manager.",
+                    "readonly": true
+                },
+                "HostInterfaceType": {
+                    "anyOf": [
+                        {
+                            "$ref": "#/definitions/HostInterfaceType"
+                        },
+                        {
+                            "type": "null"
+                        }
+                    ],
+                    "description": "The Host Interface type for this interface.",
+                    "longDescription": "This property shall contain an enumeration that describes the type of the interface.",
+                    "readonly": true
+                },
+                "Id": {
+                    "$ref": "http://redfish.dmtf.org/schemas/v1/Resource.json#/definitions/Id",
+                    "readonly": true
+                },
+                "InterfaceEnabled": {
+                    "description": "An indication of whether this interface is enabled.",
+                    "longDescription": "This property shall indicate whether this interface is enabled.",
+                    "readonly": false,
+                    "type": [
+                        "boolean",
+                        "null"
+                    ]
+                },
+                "KernelAuthEnabled": {
+                    "deprecated": "This property has been deprecated in favor of newer methods of negotiating credentials.",
+                    "description": "An indication of whether this kernel authentication is enabled for this interface.",
+                    "longDescription": "This property shall indicate whether kernel authentication is enabled for this interface.",
+                    "readonly": false,
+                    "type": [
+                        "boolean",
+                        "null"
+                    ],
+                    "versionDeprecated": "v1_3_0"
+                },
+                "KernelAuthRoleId": {
+                    "deprecated": "This property has been deprecated in favor of newer methods of negotiating credentials.",
+                    "description": "The Role used for kernel authentication on this interface.",
+                    "longDescription": "This property shall contain the Id property of the Role Resource that is configured for kernel authentication on this interface.",
+                    "readonly": false,
+                    "type": "string",
+                    "versionDeprecated": "v1_3_0"
+                },
+                "Links": {
+                    "$ref": "#/definitions/Links",
+                    "description": "The links to other Resources that are related to this Resource.",
+                    "longDescription": "The Redfish Specification-described Links Property shall contain links to Resources related to but not subordinate to this Resource."
+                },
+                "ManagerEthernetInterface": {
+                    "$ref": "http://redfish.dmtf.org/schemas/v1/EthernetInterface.json#/definitions/EthernetInterface",
+                    "description": "A link to a single network interface controllers or cards (NIC) that this manager uses for network communication with this Host Interface.",
+                    "longDescription": "This property shall contain a link to a Resource of type EthernetInterface that represents the network interface that this manager uses as the Host Interface.",
+                    "readonly": true
+                },
+                "Name": {
+                    "$ref": "http://redfish.dmtf.org/schemas/v1/Resource.json#/definitions/Name",
+                    "readonly": true
+                },
+                "NetworkProtocol": {
+                    "$ref": "http://redfish.dmtf.org/schemas/v1/ManagerNetworkProtocol.json#/definitions/ManagerNetworkProtocol",
+                    "description": "A link to the network services and their settings that the manager controls.  In this property, clients find configuration options for the network and network services.",
+                    "longDescription": "This property shall contain a link to a Resource of type ManagerNetworkProtocol that represents the network services for this manager.",
+                    "readonly": true
+                },
+                "Oem": {
+                    "$ref": "http://redfish.dmtf.org/schemas/v1/Resource.json#/definitions/Oem",
+                    "description": "The OEM extension property.",
+                    "longDescription": "This property shall contain the OEM extensions.  All values for properties that this object contains shall conform to the Redfish Specification-described requirements."
+                },
+                "Status": {
+                    "$ref": "http://redfish.dmtf.org/schemas/v1/Resource.json#/definitions/Status",
+                    "description": "The status and health of the Resource and its subordinate or dependent Resources.",
+                    "longDescription": "This property shall contain any status or health properties of the Resource."
+                }
+            },
+            "required": [
+                "@odata.id",
+                "@odata.type",
+                "Id",
+                "Name"
+            ],
+            "type": "object"
+        },
+        "HostInterfaceType": {
+            "enum": [
+                "NetworkHostInterface"
+            ],
+            "enumDescriptions": {
+                "NetworkHostInterface": "This interface is a Network Host Interface."
+            },
+            "type": "string"
+        },
+        "Links": {
+            "additionalProperties": false,
+            "description": "References to other Resources related to this Resource.",
+            "longDescription": "The Redfish Specification-described type shall contain links to Resources related to but not subordinate to this Resource.",
+            "patternProperties": {
+                "^([a-zA-Z_][a-zA-Z0-9_]*)?@(odata|Redfish|Message)\\.[a-zA-Z_][a-zA-Z0-9_]*$": {
+                    "description": "This property shall specify a valid odata or Redfish property.",
+                    "type": [
+                        "array",
+                        "boolean",
+                        "integer",
+                        "number",
+                        "null",
+                        "object",
+                        "string"
+                    ]
+                }
+            },
+            "properties": {
+                "AuthNoneRole": {
+                    "$ref": "http://redfish.dmtf.org/schemas/v1/Role.json#/definitions/Role",
+                    "description": "The link to the Redfish Role that contains the privileges on this Host Interface when no authentication is performed.",
+                    "longDescription": "This property shall contain a link to a Resource of type Role, and should link to the Resource identified by property AuthNoneRoleId.  This property shall be absent if AuthNone is not supported by the service for the AuthenticationModes property.",
+                    "readonly": true,
+                    "versionAdded": "v1_2_0"
+                },
+                "ComputerSystems": {
+                    "description": "An array of links to the computer systems connected to this Host Interface.",
+                    "items": {
+                        "$ref": "http://redfish.dmtf.org/schemas/v1/ComputerSystem.json#/definitions/ComputerSystem"
+                    },
+                    "longDescription": "This property shall contain an array of links to Resources of the ComputerSystem type that are connected to this Host Interface.",
+                    "readonly": true,
+                    "type": "array"
+                },
+                "ComputerSystems@odata.count": {
+                    "$ref": "http://redfish.dmtf.org/schemas/v1/odata-v4.json#/definitions/count"
+                },
+                "CredentialBootstrappingRole": {
+                    "$ref": "http://redfish.dmtf.org/schemas/v1/Role.json#/definitions/Role",
+                    "description": "The link to the role that contains the privileges for the bootstrap account created for this interface.",
+                    "longDescription": "This property shall contain a link to a resource of type Role, and should link to the resource identified by the RoleId property within CredentialBootstrapping.  This property shall be absent if the Redfish Host Interface Specification-defined 'credential bootstrapping via IPMI commands' feature is not supported by the service.",
+                    "readonly": true,
+                    "versionAdded": "v1_3_0"
+                },
+                "FirmwareAuthRole": {
+                    "$ref": "http://redfish.dmtf.org/schemas/v1/Role.json#/definitions/Role",
+                    "deprecated": "This property has been deprecated in favor of newer methods of negotiating credentials.",
+                    "description": "The link to the Redfish Role that has firmware authentication privileges on this Host Interface.",
+                    "longDescription": "This property shall contain a link to a Resource of type Role, and should link to the Resource identified by property FirmwareAuthRoleId.",
+                    "readonly": true,
+                    "versionDeprecated": "v1_3_0"
+                },
+                "KernelAuthRole": {
+                    "$ref": "http://redfish.dmtf.org/schemas/v1/Role.json#/definitions/Role",
+                    "deprecated": "This property has been deprecated in favor of newer methods of negotiating credentials.",
+                    "description": "The link to the Redfish Role defining privileges for this Host Interface when using kernel authentication.",
+                    "longDescription": "This property shall contain a link to a Resource of type Role, and should link to the Resource identified by property KernelAuthRoleId.",
+                    "readonly": true,
+                    "versionDeprecated": "v1_3_0"
+                },
+                "Oem": {
+                    "$ref": "http://redfish.dmtf.org/schemas/v1/Resource.json#/definitions/Oem",
+                    "description": "The OEM extension property.",
+                    "longDescription": "This property shall contain the OEM extensions.  All values for properties contained in this object shall conform to the Redfish Specification-described requirements."
+                }
+            },
+            "type": "object"
+        },
+        "OemActions": {
+            "additionalProperties": true,
+            "description": "The available OEM-specific actions for this Resource.",
+            "longDescription": "This type shall contain the available OEM-specific actions for this Resource.",
+            "patternProperties": {
+                "^([a-zA-Z_][a-zA-Z0-9_]*)?@(odata|Redfish|Message)\\.[a-zA-Z_][a-zA-Z0-9_]*$": {
+                    "description": "This property shall specify a valid odata or Redfish property.",
+                    "type": [
+                        "array",
+                        "boolean",
+                        "integer",
+                        "number",
+                        "null",
+                        "object",
+                        "string"
+                    ]
+                }
+            },
+            "properties": {},
+            "type": "object"
+        }
+    },
+    "owningEntity": "DMTF",
+    "release": "2020.3",
+    "title": "#HostInterface.v1_3_0.HostInterface"
+}

--- a/static/redfish/v1/JsonSchemas/HostInterface/index.json
+++ b/static/redfish/v1/JsonSchemas/HostInterface/index.json
@@ -1,0 +1,21 @@
+{
+    "@odata.context": "/redfish/v1/$metadata#JsonSchemaFile.JsonSchemaFile",
+    "@odata.id": "/redfish/v1/JsonSchemas/HostInterface",
+    "@odata.type": "#JsonSchemaFile.v1_0_2.JsonSchemaFile",
+    "Name": "HostInterface Schema File",
+    "Schema": "#HostInterface.HostInterface",
+    "Description": "HostInterface Schema File Location",
+    "Id": "HostInterface",
+    "Languages": [
+        "en"
+    ],
+    "Languages@odata.count": 1,
+    "Location": [
+        {
+            "Language": "en",
+            "PublicationUri": "http://redfish.dmtf.org/schemas/v1/HostInterface.json",
+            "Uri": "/redfish/v1/JsonSchemas/HostInterface/HostInterface.json"
+        }
+    ],
+    "Location@odata.count": 1
+}

--- a/static/redfish/v1/JsonSchemas/Job/Job.json
+++ b/static/redfish/v1/JsonSchemas/Job/Job.json
@@ -1,0 +1,316 @@
+{
+    "$id": "http://redfish.dmtf.org/schemas/v1/Job.v1_0_7.json",
+    "$ref": "#/definitions/Job",
+    "$schema": "http://redfish.dmtf.org/schemas/v1/redfish-schema-v1.json",
+    "copyright": "Copyright 2014-2021 DMTF. For the full DMTF copyright policy, see http://www.dmtf.org/about/policies/copyright",
+    "definitions": {
+        "Actions": {
+            "additionalProperties": false,
+            "description": "The available actions for this resource.",
+            "longDescription": "This type shall contain the available actions for this resource.",
+            "patternProperties": {
+                "^([a-zA-Z_][a-zA-Z0-9_]*)?@(odata|Redfish|Message)\\.[a-zA-Z_][a-zA-Z0-9_]*$": {
+                    "description": "This property shall specify a valid odata or Redfish property.",
+                    "type": [
+                        "array",
+                        "boolean",
+                        "integer",
+                        "number",
+                        "null",
+                        "object",
+                        "string"
+                    ]
+                }
+            },
+            "properties": {
+                "Oem": {
+                    "$ref": "#/definitions/OemActions",
+                    "description": "The available OEM-specific actions for this resource.",
+                    "longDescription": "This property shall contain the available OEM-specific actions for this resource."
+                }
+            },
+            "type": "object"
+        },
+        "Job": {
+            "additionalProperties": false,
+            "description": "The Job schema contains information about a job that a Redfish job service schedules or executes.  Clients create jobs to describe a series of operations that occur at periodic intervals.",
+            "longDescription": "This resource shall contain a job in a Redfish implementation.",
+            "patternProperties": {
+                "^([a-zA-Z_][a-zA-Z0-9_]*)?@(odata|Redfish|Message)\\.[a-zA-Z_][a-zA-Z0-9_]*$": {
+                    "description": "This property shall specify a valid odata or Redfish property.",
+                    "type": [
+                        "array",
+                        "boolean",
+                        "integer",
+                        "number",
+                        "null",
+                        "object",
+                        "string"
+                    ]
+                }
+            },
+            "properties": {
+                "@odata.context": {
+                    "$ref": "http://redfish.dmtf.org/schemas/v1/odata-v4.json#/definitions/context"
+                },
+                "@odata.etag": {
+                    "$ref": "http://redfish.dmtf.org/schemas/v1/odata-v4.json#/definitions/etag"
+                },
+                "@odata.id": {
+                    "$ref": "http://redfish.dmtf.org/schemas/v1/odata-v4.json#/definitions/id"
+                },
+                "@odata.type": {
+                    "$ref": "http://redfish.dmtf.org/schemas/v1/odata-v4.json#/definitions/type"
+                },
+                "Actions": {
+                    "$ref": "#/definitions/Actions",
+                    "description": "The available actions for this resource.",
+                    "longDescription": "This property shall contain the available actions for this resource."
+                },
+                "CreatedBy": {
+                    "description": "The person or program that created this job entry.",
+                    "longDescription": "This property shall contain the user name, software program name, or other identifier indicating the creator of this job.",
+                    "readonly": true,
+                    "type": "string"
+                },
+                "Description": {
+                    "anyOf": [
+                        {
+                            "$ref": "http://redfish.dmtf.org/schemas/v1/Resource.json#/definitions/Description"
+                        },
+                        {
+                            "type": "null"
+                        }
+                    ],
+                    "readonly": true
+                },
+                "EndTime": {
+                    "description": "The date and time when the job was completed.",
+                    "format": "date-time",
+                    "longDescription": "This property shall indicate the date and time when the job was completed.  This property shall not appear if the job is running or was not completed.  This property shall appear only if the JobState is Completed, Cancelled, or Exception.",
+                    "readonly": true,
+                    "type": "string"
+                },
+                "HidePayload": {
+                    "description": "An indication of whether the contents of the payload should be hidden from view after the job has been created.  If `true`, responses do not return the payload.  If `false`, responses return the payload.  If this property is not present when the job is created, the default is `false`.",
+                    "longDescription": "This property shall indicate whether the contents of the payload should be hidden from view after the job has been created.  If `true`, responses shall not return the Payload property.  If `false`, responses shall return the Payload property.  If this property is not present when the job is created, the default is `false`.",
+                    "readonly": true,
+                    "type": "boolean"
+                },
+                "Id": {
+                    "$ref": "http://redfish.dmtf.org/schemas/v1/Resource.json#/definitions/Id",
+                    "readonly": true
+                },
+                "JobState": {
+                    "$ref": "#/definitions/JobState",
+                    "description": "The state of the job.",
+                    "longDescription": "This property shall indicate the state of the job.",
+                    "readonly": false
+                },
+                "JobStatus": {
+                    "$ref": "http://redfish.dmtf.org/schemas/v1/Resource.json#/definitions/Health",
+                    "description": "The status of the job.",
+                    "longDescription": "This property shall indicate the health status of the job.",
+                    "readonly": true
+                },
+                "MaxExecutionTime": {
+                    "description": "The maximum amount of time the job is allowed to execute.",
+                    "longDescription": "The value shall be an ISO 8601 conformant duration describing the maximum duration the job is allowed to execute before being stopped by the service.",
+                    "readonly": false,
+                    "type": [
+                        "string",
+                        "null"
+                    ]
+                },
+                "Messages": {
+                    "description": "An array of messages associated with the job.",
+                    "items": {
+                        "$ref": "http://redfish.dmtf.org/schemas/v1/Message.json#/definitions/Message"
+                    },
+                    "longDescription": "This property shall contain an array of messages associated with the job.",
+                    "type": "array"
+                },
+                "Name": {
+                    "$ref": "http://redfish.dmtf.org/schemas/v1/Resource.json#/definitions/Name",
+                    "readonly": true
+                },
+                "Oem": {
+                    "$ref": "http://redfish.dmtf.org/schemas/v1/Resource.json#/definitions/Oem",
+                    "description": "The OEM extension property.",
+                    "longDescription": "This property shall contain the OEM extensions.  All values for properties that this object contains shall conform to the Redfish Specification-described requirements."
+                },
+                "Payload": {
+                    "$ref": "#/definitions/Payload",
+                    "description": "The HTTP and JSON payload details for this job.",
+                    "longDescription": "This property shall contain the HTTP and JSON payload information for executing this job.  This property shall not be included in the response if the HidePayload property is `true`."
+                },
+                "PercentComplete": {
+                    "description": "The completion percentage of this job.",
+                    "longDescription": "This property shall indicate the completion progress of the job, reported in percent of completion.  If the job has not been started, the value shall be zero.",
+                    "readonly": true,
+                    "type": [
+                        "integer",
+                        "null"
+                    ],
+                    "units": "%"
+                },
+                "Schedule": {
+                    "$ref": "http://redfish.dmtf.org/schemas/v1/Schedule.json#/definitions/Schedule",
+                    "description": "The schedule settings for this job.",
+                    "longDescription": "This object shall contain the scheduling details for this job and the recurrence frequency for future instances of this job."
+                },
+                "StartTime": {
+                    "description": "The date and time when the job was started or is scheduled to start.",
+                    "format": "date-time",
+                    "longDescription": "This property shall indicate the date and time when the job was last started or is scheduled to start.",
+                    "readonly": true,
+                    "type": "string"
+                },
+                "StepOrder": {
+                    "description": "The serialized execution order of the job steps.",
+                    "items": {
+                        "type": "string"
+                    },
+                    "longDescription": "This property shall contain an array of IDs for the job steps in the order that they shall be executed.  Each step shall be completed prior to the execution of the next step in array order.  An incomplete list of steps shall be considered an invalid configuration.  If this property is not present or contains an empty array it shall indicate that the step execution order is omitted and may occur in parallel or in series as determined by the service.",
+                    "readonly": true,
+                    "type": "array"
+                },
+                "Steps": {
+                    "$ref": "http://redfish.dmtf.org/schemas/v1/JobCollection.json#/definitions/JobCollection",
+                    "description": "The link to a collection of steps for this job.",
+                    "longDescription": "This property shall contain the link to a resource collection of type JobCollection.  This property shall not be present if this resource represents a step for a job.",
+                    "readonly": true
+                }
+            },
+            "required": [
+                "@odata.id",
+                "@odata.type",
+                "Id",
+                "Name"
+            ],
+            "type": "object"
+        },
+        "JobState": {
+            "enum": [
+                "New",
+                "Starting",
+                "Running",
+                "Suspended",
+                "Interrupted",
+                "Pending",
+                "Stopping",
+                "Completed",
+                "Cancelled",
+                "Exception",
+                "Service",
+                "UserIntervention",
+                "Continue"
+            ],
+            "enumDescriptions": {
+                "Cancelled": "Job was cancelled.",
+                "Completed": "Job was completed.",
+                "Continue": "Job is to resume operation.",
+                "Exception": "Job has stopped due to an exception condition.",
+                "Interrupted": "Job has been interrupted.",
+                "New": "A new job.",
+                "Pending": "Job is pending and has not started.",
+                "Running": "Job is running normally.",
+                "Service": "Job is running as a service.",
+                "Starting": "Job is starting.",
+                "Stopping": "Job is in the process of stopping.",
+                "Suspended": "Job has been suspended.",
+                "UserIntervention": "Job is waiting for user intervention."
+            },
+            "enumLongDescriptions": {
+                "Cancelled": "This value shall represent that the operation completed because the job was cancelled by an operator.",
+                "Completed": "This value shall represent that the operation completed successfully or with warnings.",
+                "Continue": "This value shall represent that the operation has been resumed from a paused condition and should return to a Running state.",
+                "Exception": "This value shall represent that the operation completed with errors.",
+                "Interrupted": "This value shall represent that the operation has been interrupted but is expected to restart and is therefore not complete.",
+                "New": "This value shall represent that this job is newly created but the operation has not yet started.",
+                "Pending": "This value shall represent that the operation is pending some condition and has not yet begun to execute.",
+                "Running": "This value shall represent that the operation is executing.",
+                "Service": "This value shall represent that the operation is now running as a service and expected to continue operation until stopped or killed.",
+                "Starting": "This value shall represent that the operation is starting.",
+                "Stopping": "This value shall represent that the operation is stopping but is not yet complete.",
+                "Suspended": "This value shall represent that the operation has been suspended but is expected to restart and is therefore not complete.",
+                "UserIntervention": "This value shall represent that the operation is waiting for a user to intervene and needs to be manually continued, stopped, or cancelled."
+            },
+            "type": "string"
+        },
+        "OemActions": {
+            "additionalProperties": true,
+            "description": "The available OEM-specific actions for this resource.",
+            "longDescription": "This type shall contain the available OEM-specific actions for this resource.",
+            "patternProperties": {
+                "^([a-zA-Z_][a-zA-Z0-9_]*)?@(odata|Redfish|Message)\\.[a-zA-Z_][a-zA-Z0-9_]*$": {
+                    "description": "This property shall specify a valid odata or Redfish property.",
+                    "type": [
+                        "array",
+                        "boolean",
+                        "integer",
+                        "number",
+                        "null",
+                        "object",
+                        "string"
+                    ]
+                }
+            },
+            "properties": {},
+            "type": "object"
+        },
+        "Payload": {
+            "additionalProperties": false,
+            "description": "The HTTP and JSON payload details for this job.",
+            "longDescription": "This object shall contain information detailing the HTTP and JSON payload information for executing this job.",
+            "patternProperties": {
+                "^([a-zA-Z_][a-zA-Z0-9_]*)?@(odata|Redfish|Message)\\.[a-zA-Z_][a-zA-Z0-9_]*$": {
+                    "description": "This property shall specify a valid odata or Redfish property.",
+                    "type": [
+                        "array",
+                        "boolean",
+                        "integer",
+                        "number",
+                        "null",
+                        "object",
+                        "string"
+                    ]
+                }
+            },
+            "properties": {
+                "HttpHeaders": {
+                    "description": "An array of HTTP headers in this job.",
+                    "items": {
+                        "type": "string"
+                    },
+                    "longDescription": "This property shall contain an array of HTTP headers in this job.",
+                    "readonly": true,
+                    "type": "array"
+                },
+                "HttpOperation": {
+                    "description": "The HTTP operation that executes this job.",
+                    "longDescription": "This property shall contain the HTTP operation that executes this job.",
+                    "readonly": true,
+                    "type": "string"
+                },
+                "JsonBody": {
+                    "description": "The JSON payload to use in the execution of this job.",
+                    "longDescription": "This property shall contain JSON-formatted payload for this job.",
+                    "readonly": true,
+                    "type": "string"
+                },
+                "TargetUri": {
+                    "description": "The link to the target for this job.",
+                    "format": "uri-reference",
+                    "longDescription": "This property shall contain link to a target location for an HTTP operation.",
+                    "readonly": true,
+                    "type": "string"
+                }
+            },
+            "type": "object"
+        }
+    },
+    "owningEntity": "DMTF",
+    "release": "2018.2",
+    "title": "#Job.v1_0_7.Job"
+}

--- a/static/redfish/v1/JsonSchemas/Job/index.json
+++ b/static/redfish/v1/JsonSchemas/Job/index.json
@@ -1,0 +1,21 @@
+{
+    "@odata.context": "/redfish/v1/$metadata#JsonSchemaFile.JsonSchemaFile",
+    "@odata.id": "/redfish/v1/JsonSchemas/Job",
+    "@odata.type": "#JsonSchemaFile.v1_0_2.JsonSchemaFile",
+    "Name": "Job Schema File",
+    "Schema": "#Job.Job",
+    "Description": "Job Schema File Location",
+    "Id": "Job",
+    "Languages": [
+        "en"
+    ],
+    "Languages@odata.count": 1,
+    "Location": [
+        {
+            "Language": "en",
+            "PublicationUri": "http://redfish.dmtf.org/schemas/v1/Job.json",
+            "Uri": "/redfish/v1/JsonSchemas/Job/Job.json"
+        }
+    ],
+    "Location@odata.count": 1
+}

--- a/static/redfish/v1/JsonSchemas/JobService/JobService.json
+++ b/static/redfish/v1/JsonSchemas/JobService/JobService.json
@@ -1,0 +1,218 @@
+{
+    "$id": "http://redfish.dmtf.org/schemas/v1/JobService.v1_0_4.json",
+    "$ref": "#/definitions/JobService",
+    "$schema": "http://redfish.dmtf.org/schemas/v1/redfish-schema-v1.json",
+    "copyright": "Copyright 2014-2020 DMTF. For the full DMTF copyright policy, see http://www.dmtf.org/about/policies/copyright",
+    "definitions": {
+        "Actions": {
+            "additionalProperties": false,
+            "description": "The available actions for this resource.",
+            "longDescription": "This type shall contain the available actions for this resource.",
+            "patternProperties": {
+                "^([a-zA-Z_][a-zA-Z0-9_]*)?@(odata|Redfish|Message)\\.[a-zA-Z_][a-zA-Z0-9_]*$": {
+                    "description": "This property shall specify a valid odata or Redfish property.",
+                    "type": [
+                        "array",
+                        "boolean",
+                        "integer",
+                        "number",
+                        "null",
+                        "object",
+                        "string"
+                    ]
+                }
+            },
+            "properties": {
+                "Oem": {
+                    "$ref": "#/definitions/OemActions",
+                    "description": "The available OEM-specific actions for this resource.",
+                    "longDescription": "This property shall contain the available OEM-specific actions for this resource."
+                }
+            },
+            "type": "object"
+        },
+        "JobService": {
+            "additionalProperties": false,
+            "description": "The JobService schema contains properties for scheduling and execution of operations, represents the properties for the job service itself, and has links to jobs managed by the job service.",
+            "longDescription": "This resource shall represent a job service for a Redfish implementation.",
+            "patternProperties": {
+                "^([a-zA-Z_][a-zA-Z0-9_]*)?@(odata|Redfish|Message)\\.[a-zA-Z_][a-zA-Z0-9_]*$": {
+                    "description": "This property shall specify a valid odata or Redfish property.",
+                    "type": [
+                        "array",
+                        "boolean",
+                        "integer",
+                        "number",
+                        "null",
+                        "object",
+                        "string"
+                    ]
+                }
+            },
+            "properties": {
+                "@odata.context": {
+                    "$ref": "http://redfish.dmtf.org/schemas/v1/odata-v4.json#/definitions/context"
+                },
+                "@odata.etag": {
+                    "$ref": "http://redfish.dmtf.org/schemas/v1/odata-v4.json#/definitions/etag"
+                },
+                "@odata.id": {
+                    "$ref": "http://redfish.dmtf.org/schemas/v1/odata-v4.json#/definitions/id"
+                },
+                "@odata.type": {
+                    "$ref": "http://redfish.dmtf.org/schemas/v1/odata-v4.json#/definitions/type"
+                },
+                "Actions": {
+                    "$ref": "#/definitions/Actions",
+                    "description": "The available actions for this resource.",
+                    "longDescription": "This property shall contain the available actions for this resource."
+                },
+                "DateTime": {
+                    "description": "The current date and time setting for the job service.",
+                    "format": "date-time",
+                    "longDescription": "This property shall contain the current date and time setting for the job service.",
+                    "readonly": true,
+                    "type": [
+                        "string",
+                        "null"
+                    ]
+                },
+                "Description": {
+                    "anyOf": [
+                        {
+                            "$ref": "http://redfish.dmtf.org/schemas/v1/Resource.json#/definitions/Description"
+                        },
+                        {
+                            "type": "null"
+                        }
+                    ],
+                    "readonly": true
+                },
+                "Id": {
+                    "$ref": "http://redfish.dmtf.org/schemas/v1/Resource.json#/definitions/Id",
+                    "readonly": true
+                },
+                "Jobs": {
+                    "$ref": "http://redfish.dmtf.org/schemas/v1/JobCollection.json#/definitions/JobCollection",
+                    "description": "The links to the jobs collection.",
+                    "longDescription": "This property shall contain a link to a resource collection of type JobCollection.",
+                    "readonly": true
+                },
+                "Log": {
+                    "$ref": "http://redfish.dmtf.org/schemas/v1/LogService.json#/definitions/LogService",
+                    "description": "The link to a log service that the job service uses.  This service can be a dedicated log service or a pointer a log service under another resource, such as a manager.",
+                    "longDescription": "This property shall contain a link to a resource of type LogService that this job service uses.",
+                    "readonly": true
+                },
+                "Name": {
+                    "$ref": "http://redfish.dmtf.org/schemas/v1/Resource.json#/definitions/Name",
+                    "readonly": true
+                },
+                "Oem": {
+                    "$ref": "http://redfish.dmtf.org/schemas/v1/Resource.json#/definitions/Oem",
+                    "description": "The OEM extension property.",
+                    "longDescription": "This property shall contain the OEM extensions.  All values for properties that this object contains shall conform to the Redfish Specification-described requirements."
+                },
+                "ServiceCapabilities": {
+                    "$ref": "#/definitions/JobServiceCapabilities",
+                    "description": "The supported capabilities of this job service implementation.",
+                    "longDescription": "This type shall contain properties that describe the capabilities or supported features of this implementation of a job service."
+                },
+                "ServiceEnabled": {
+                    "description": "An indication of whether this service is enabled.",
+                    "longDescription": "This property shall indicate whether this service is enabled.",
+                    "readonly": false,
+                    "type": [
+                        "boolean",
+                        "null"
+                    ]
+                },
+                "Status": {
+                    "$ref": "http://redfish.dmtf.org/schemas/v1/Resource.json#/definitions/Status",
+                    "description": "The status and health of the resource and its subordinate or dependent resources.",
+                    "longDescription": "This property shall contain any status or health properties of the resource."
+                }
+            },
+            "required": [
+                "@odata.id",
+                "@odata.type",
+                "Id",
+                "Name"
+            ],
+            "type": "object"
+        },
+        "JobServiceCapabilities": {
+            "additionalProperties": false,
+            "description": "The supported capabilities of this job service implementation.",
+            "longDescription": "This type shall contain properties that describe the capabilities or supported features of this implementation of a job service.",
+            "patternProperties": {
+                "^([a-zA-Z_][a-zA-Z0-9_]*)?@(odata|Redfish|Message)\\.[a-zA-Z_][a-zA-Z0-9_]*$": {
+                    "description": "This property shall specify a valid odata or Redfish property.",
+                    "type": [
+                        "array",
+                        "boolean",
+                        "integer",
+                        "number",
+                        "null",
+                        "object",
+                        "string"
+                    ]
+                }
+            },
+            "properties": {
+                "MaxJobs": {
+                    "description": "The maximum number of jobs supported.",
+                    "longDescription": "This property shall contain the maximum number of jobs supported by the implementation.",
+                    "readonly": true,
+                    "type": [
+                        "integer",
+                        "null"
+                    ]
+                },
+                "MaxSteps": {
+                    "description": "The maximum number of job steps supported.",
+                    "longDescription": "This property shall contain the maximum number of steps supported by a single job instance.",
+                    "readonly": true,
+                    "type": [
+                        "integer",
+                        "null"
+                    ]
+                },
+                "Scheduling": {
+                    "description": "An indication of whether scheduling of jobs is supported.",
+                    "longDescription": "This property shall indicate whether the Schedule property within the job supports scheduling of jobs.",
+                    "readonly": true,
+                    "type": [
+                        "boolean",
+                        "null"
+                    ]
+                }
+            },
+            "type": "object"
+        },
+        "OemActions": {
+            "additionalProperties": true,
+            "description": "The available OEM-specific actions for this resource.",
+            "longDescription": "This type shall contain the available OEM-specific actions for this resource.",
+            "patternProperties": {
+                "^([a-zA-Z_][a-zA-Z0-9_]*)?@(odata|Redfish|Message)\\.[a-zA-Z_][a-zA-Z0-9_]*$": {
+                    "description": "This property shall specify a valid odata or Redfish property.",
+                    "type": [
+                        "array",
+                        "boolean",
+                        "integer",
+                        "number",
+                        "null",
+                        "object",
+                        "string"
+                    ]
+                }
+            },
+            "properties": {},
+            "type": "object"
+        }
+    },
+    "owningEntity": "DMTF",
+    "release": "2018.2",
+    "title": "#JobService.v1_0_4.JobService"
+}

--- a/static/redfish/v1/JsonSchemas/JobService/index.json
+++ b/static/redfish/v1/JsonSchemas/JobService/index.json
@@ -1,0 +1,21 @@
+{
+    "@odata.context": "/redfish/v1/$metadata#JsonSchemaFile.JsonSchemaFile",
+    "@odata.id": "/redfish/v1/JsonSchemas/JobService",
+    "@odata.type": "#JsonSchemaFile.v1_0_2.JsonSchemaFile",
+    "Name": "JobService Schema File",
+    "Schema": "#JobService.JobService",
+    "Description": "JobService Schema File Location",
+    "Id": "JobService",
+    "Languages": [
+        "en"
+    ],
+    "Languages@odata.count": 1,
+    "Location": [
+        {
+            "Language": "en",
+            "PublicationUri": "http://redfish.dmtf.org/schemas/v1/JobService.json",
+            "Uri": "/redfish/v1/JsonSchemas/JobService/JobService.json"
+        }
+    ],
+    "Location@odata.count": 1
+}

--- a/static/redfish/v1/JsonSchemas/Key/Key.json
+++ b/static/redfish/v1/JsonSchemas/Key/Key.json
@@ -1,0 +1,299 @@
+{
+    "$id": "http://redfish.dmtf.org/schemas/v1/Key.v1_0_0.json",
+    "$ref": "#/definitions/Key",
+    "$schema": "http://redfish.dmtf.org/schemas/v1/redfish-schema-v1.json",
+    "copyright": "Copyright 2014-2021 DMTF. For the full DMTF copyright policy, see http://www.dmtf.org/about/policies/copyright",
+    "definitions": {
+        "Actions": {
+            "additionalProperties": false,
+            "description": "The available actions for this resource.",
+            "longDescription": "This type shall contain the available actions for this resource.",
+            "patternProperties": {
+                "^([a-zA-Z_][a-zA-Z0-9_]*)?@(odata|Redfish|Message)\\.[a-zA-Z_][a-zA-Z0-9_]*$": {
+                    "description": "This property shall specify a valid odata or Redfish property.",
+                    "type": [
+                        "array",
+                        "boolean",
+                        "integer",
+                        "number",
+                        "null",
+                        "object",
+                        "string"
+                    ]
+                }
+            },
+            "properties": {
+                "Oem": {
+                    "$ref": "#/definitions/OemActions",
+                    "description": "The available OEM-specific actions for this resource.",
+                    "longDescription": "This property shall contain the available OEM-specific actions for this resource."
+                }
+            },
+            "type": "object"
+        },
+        "Key": {
+            "additionalProperties": false,
+            "description": "The Key schema describes sensitive data for accessing devices or services.",
+            "longDescription": "This resource shall represent a key for a Redfish implementation.",
+            "patternProperties": {
+                "^([a-zA-Z_][a-zA-Z0-9_]*)?@(odata|Redfish|Message)\\.[a-zA-Z_][a-zA-Z0-9_]*$": {
+                    "description": "This property shall specify a valid odata or Redfish property.",
+                    "type": [
+                        "array",
+                        "boolean",
+                        "integer",
+                        "number",
+                        "null",
+                        "object",
+                        "string"
+                    ]
+                }
+            },
+            "properties": {
+                "@odata.context": {
+                    "$ref": "http://redfish.dmtf.org/schemas/v1/odata-v4.json#/definitions/context"
+                },
+                "@odata.etag": {
+                    "$ref": "http://redfish.dmtf.org/schemas/v1/odata-v4.json#/definitions/etag"
+                },
+                "@odata.id": {
+                    "$ref": "http://redfish.dmtf.org/schemas/v1/odata-v4.json#/definitions/id"
+                },
+                "@odata.type": {
+                    "$ref": "http://redfish.dmtf.org/schemas/v1/odata-v4.json#/definitions/type"
+                },
+                "Actions": {
+                    "$ref": "#/definitions/Actions",
+                    "description": "The available actions for this resource.",
+                    "longDescription": "This property shall contain the available actions for this resource."
+                },
+                "Description": {
+                    "anyOf": [
+                        {
+                            "$ref": "http://redfish.dmtf.org/schemas/v1/Resource.json#/definitions/Description"
+                        },
+                        {
+                            "type": "null"
+                        }
+                    ],
+                    "readonly": true
+                },
+                "Id": {
+                    "$ref": "http://redfish.dmtf.org/schemas/v1/Resource.json#/definitions/Id",
+                    "readonly": true
+                },
+                "KeyString": {
+                    "description": "The string for the key.",
+                    "longDescription": "This property shall contain the key, and the format shall follow the requirements specified by the KeyType property value.",
+                    "readonly": true,
+                    "type": [
+                        "string",
+                        "null"
+                    ]
+                },
+                "KeyType": {
+                    "anyOf": [
+                        {
+                            "$ref": "#/definitions/KeyType"
+                        },
+                        {
+                            "type": "null"
+                        }
+                    ],
+                    "description": "The format of the key.",
+                    "longDescription": "This property shall contain the format type for the key.",
+                    "readonly": true
+                },
+                "NVMeoF": {
+                    "anyOf": [
+                        {
+                            "$ref": "#/definitions/NVMeoF"
+                        },
+                        {
+                            "type": "null"
+                        }
+                    ],
+                    "description": "NVMe-oF specific properties.",
+                    "longDescription": "This property shall contain NVMe-oF specific properties for this key.  This property shall be present if KeyType contains the value `NVMeoF`."
+                },
+                "Name": {
+                    "$ref": "http://redfish.dmtf.org/schemas/v1/Resource.json#/definitions/Name",
+                    "readonly": true
+                },
+                "Oem": {
+                    "$ref": "http://redfish.dmtf.org/schemas/v1/Resource.json#/definitions/Oem",
+                    "description": "The OEM extension property.",
+                    "longDescription": "This property shall contain the OEM extensions.  All values for properties that this object contains shall conform to the Redfish Specification-described requirements."
+                }
+            },
+            "required": [
+                "@odata.id",
+                "@odata.type",
+                "Id",
+                "Name"
+            ],
+            "requiredOnCreate": [
+                "KeyString",
+                "KeyType"
+            ],
+            "type": "object"
+        },
+        "KeyType": {
+            "enum": [
+                "NVMeoF"
+            ],
+            "enumDescriptions": {
+                "NVMeoF": "An NVMe-oF key."
+            },
+            "enumLongDescriptions": {
+                "NVMeoF": "This value shall indicate the format of the key is defined by one of the NVMe specifications."
+            },
+            "type": "string"
+        },
+        "NVMeoF": {
+            "additionalProperties": false,
+            "description": "NVMe-oF specific properties.",
+            "longDescription": "This type shall contain NVMe-oF specific properties for a key.",
+            "patternProperties": {
+                "^([a-zA-Z_][a-zA-Z0-9_]*)?@(odata|Redfish|Message)\\.[a-zA-Z_][a-zA-Z0-9_]*$": {
+                    "description": "This property shall specify a valid odata or Redfish property.",
+                    "type": [
+                        "array",
+                        "boolean",
+                        "integer",
+                        "number",
+                        "null",
+                        "object",
+                        "string"
+                    ]
+                }
+            },
+            "properties": {
+                "HostKeyId": {
+                    "description": "The identifier of the host key paired with this target key.",
+                    "longDescription": "This property shall contain the value of the Id property of the Key resource representing the host key paired with this target key.  An empty string shall indicate the key is not paired.  This property shall be absent for host keys.",
+                    "readonly": false,
+                    "type": [
+                        "string",
+                        "null"
+                    ]
+                },
+                "NQN": {
+                    "description": "The NVMe Qualified Name (NQN) of the host or target subsystem associated with this key.",
+                    "longDescription": "This property shall contain the NVMe Qualified Name (NQN) of the host or target subsystem associated with this key.  The value of this property shall follow the NQN format defined by the NVMe Base Specification.",
+                    "readonly": true,
+                    "type": [
+                        "string",
+                        "null"
+                    ]
+                },
+                "OEMSecurityProtocolType": {
+                    "description": "The OEM security protocol that this key uses.",
+                    "longDescription": "This property shall contain the OEM-defined security protocol that this key uses.  The value shall be derived from the contents of the KeyString property.  This property shall be present if SecurityProtocolType contains the value `OEM`.",
+                    "readonly": true,
+                    "type": [
+                        "string",
+                        "null"
+                    ]
+                },
+                "SecureHashAllowList": {
+                    "description": "The secure hash algorithms allowed with the usage of this key.",
+                    "items": {
+                        "anyOf": [
+                            {
+                                "$ref": "#/definitions/NVMeoFSecureHashType"
+                            },
+                            {
+                                "type": "null"
+                            }
+                        ]
+                    },
+                    "longDescription": "This property shall contain the secure hash algorithms allowed with the usage of this key.  An empty list or the absence of this property shall indicate any secure hash algorithms are allowed with this key.",
+                    "readonly": true,
+                    "type": "array"
+                },
+                "SecurityProtocolType": {
+                    "anyOf": [
+                        {
+                            "$ref": "#/definitions/NVMeoFSecurityProtocolType"
+                        },
+                        {
+                            "type": "null"
+                        }
+                    ],
+                    "description": "The security protocol that this key uses.",
+                    "longDescription": "This property shall contain the security protocol that this key uses.  The value shall be derived from the contents of the KeyString property.",
+                    "readonly": true
+                }
+            },
+            "requiredOnCreate": [
+                "NQN"
+            ],
+            "type": "object"
+        },
+        "NVMeoFSecureHashType": {
+            "description": "The NVMe secure hash algorithms that a key is allowed to use.",
+            "enum": [
+                "SHA256",
+                "SHA384",
+                "SHA512"
+            ],
+            "enumDescriptions": {
+                "SHA256": "SHA-256.",
+                "SHA384": "SHA-384.",
+                "SHA512": "SHA-512."
+            },
+            "enumLongDescriptions": {
+                "SHA256": "This value shall indicate the SHA-256 hash function as defined by the 'DH-HMAC-CHAP hash function identifiers' figure in the NVMe Base Specification.",
+                "SHA384": "This value shall indicate the SHA-384 hash function as defined by the 'DH-HMAC-CHAP hash function identifiers' figure in the NVMe Base Specification.",
+                "SHA512": "This value shall indicate the SHA-512 hash function as defined by the 'DH-HMAC-CHAP hash function identifiers' figure in the NVMe Base Specification."
+            },
+            "longDescription": "This enumeration shall list the NVMe secure hash algorithms that a key is allowed to use.",
+            "type": "string"
+        },
+        "NVMeoFSecurityProtocolType": {
+            "description": "The NVMe security protocols that a key protects.",
+            "enum": [
+                "DHHC",
+                "TLS_PSK",
+                "OEM"
+            ],
+            "enumDescriptions": {
+                "DHHC": "Diffie-Hellman Hashed Message Authentication Code Challenge Handshake Authentication Protocol (DH-HMAC-CHAP).",
+                "OEM": "OEM.",
+                "TLS_PSK": "Transport Layer Security Pre-Shared Key (TLS PSK)."
+            },
+            "enumLongDescriptions": {
+                "DHHC": "This value shall indicate the Diffie-Hellman Hashed Message Authentication Code Challenge Handshake Authentication Protocol (DH-HMAC-CHAP) as defined by the NVMe Base Specification.",
+                "OEM": "This value shall indicate an OEM-defined security protocol.  The OEMSecurityProtocolType property shall contain the specific OEM protocol.",
+                "TLS_PSK": "This value shall indicate Transport Layer Security Pre-Shared Key (TLS PSK) as defined by the NVMe TCP Transport Specification."
+            },
+            "longDescription": "This enumeration shall list the NVMe security protocols that a key protects.",
+            "type": "string"
+        },
+        "OemActions": {
+            "additionalProperties": true,
+            "description": "The available OEM-specific actions for this resource.",
+            "longDescription": "This type shall contain the available OEM-specific actions for this resource.",
+            "patternProperties": {
+                "^([a-zA-Z_][a-zA-Z0-9_]*)?@(odata|Redfish|Message)\\.[a-zA-Z_][a-zA-Z0-9_]*$": {
+                    "description": "This property shall specify a valid odata or Redfish property.",
+                    "type": [
+                        "array",
+                        "boolean",
+                        "integer",
+                        "number",
+                        "null",
+                        "object",
+                        "string"
+                    ]
+                }
+            },
+            "properties": {},
+            "type": "object"
+        }
+    },
+    "owningEntity": "DMTF",
+    "release": "2021.2",
+    "title": "#Key.v1_0_0.Key"
+}

--- a/static/redfish/v1/JsonSchemas/Key/index.json
+++ b/static/redfish/v1/JsonSchemas/Key/index.json
@@ -1,0 +1,21 @@
+{
+    "@odata.context": "/redfish/v1/$metadata#JsonSchemaFile.JsonSchemaFile",
+    "@odata.id": "/redfish/v1/JsonSchemas/Key",
+    "@odata.type": "#JsonSchemaFile.v1_0_2.JsonSchemaFile",
+    "Name": "Key Schema File",
+    "Schema": "#Key.Key",
+    "Description": "Key Schema File Location",
+    "Id": "Key",
+    "Languages": [
+        "en"
+    ],
+    "Languages@odata.count": 1,
+    "Location": [
+        {
+            "Language": "en",
+            "PublicationUri": "http://redfish.dmtf.org/schemas/v1/Key.json",
+            "Uri": "/redfish/v1/JsonSchemas/Key/Key.json"
+        }
+    ],
+    "Location@odata.count": 1
+}

--- a/static/redfish/v1/JsonSchemas/KeyPolicy/KeyPolicy.json
+++ b/static/redfish/v1/JsonSchemas/KeyPolicy/KeyPolicy.json
@@ -1,0 +1,391 @@
+{
+    "$id": "http://redfish.dmtf.org/schemas/v1/KeyPolicy.v1_0_0.json",
+    "$ref": "#/definitions/KeyPolicy",
+    "$schema": "http://redfish.dmtf.org/schemas/v1/redfish-schema-v1.json",
+    "copyright": "Copyright 2014-2021 DMTF. For the full DMTF copyright policy, see http://www.dmtf.org/about/policies/copyright",
+    "definitions": {
+        "Actions": {
+            "additionalProperties": false,
+            "description": "The available actions for this resource.",
+            "longDescription": "This type shall contain the available actions for this resource.",
+            "patternProperties": {
+                "^([a-zA-Z_][a-zA-Z0-9_]*)?@(odata|Redfish|Message)\\.[a-zA-Z_][a-zA-Z0-9_]*$": {
+                    "description": "This property shall specify a valid odata or Redfish property.",
+                    "type": [
+                        "array",
+                        "boolean",
+                        "integer",
+                        "number",
+                        "null",
+                        "object",
+                        "string"
+                    ]
+                }
+            },
+            "properties": {
+                "Oem": {
+                    "$ref": "#/definitions/OemActions",
+                    "description": "The available OEM-specific actions for this resource.",
+                    "longDescription": "This property shall contain the available OEM-specific actions for this resource."
+                }
+            },
+            "type": "object"
+        },
+        "KeyPolicy": {
+            "additionalProperties": false,
+            "description": "The KeyPolicy schema describes settings for how keys are allowed to be used for accessing devices or services.",
+            "longDescription": "This resource shall represent a key policy for a Redfish implementation.",
+            "patternProperties": {
+                "^([a-zA-Z_][a-zA-Z0-9_]*)?@(odata|Redfish|Message)\\.[a-zA-Z_][a-zA-Z0-9_]*$": {
+                    "description": "This property shall specify a valid odata or Redfish property.",
+                    "type": [
+                        "array",
+                        "boolean",
+                        "integer",
+                        "number",
+                        "null",
+                        "object",
+                        "string"
+                    ]
+                }
+            },
+            "properties": {
+                "@odata.context": {
+                    "$ref": "http://redfish.dmtf.org/schemas/v1/odata-v4.json#/definitions/context"
+                },
+                "@odata.etag": {
+                    "$ref": "http://redfish.dmtf.org/schemas/v1/odata-v4.json#/definitions/etag"
+                },
+                "@odata.id": {
+                    "$ref": "http://redfish.dmtf.org/schemas/v1/odata-v4.json#/definitions/id"
+                },
+                "@odata.type": {
+                    "$ref": "http://redfish.dmtf.org/schemas/v1/odata-v4.json#/definitions/type"
+                },
+                "Actions": {
+                    "$ref": "#/definitions/Actions",
+                    "description": "The available actions for this resource.",
+                    "longDescription": "This property shall contain the available actions for this resource."
+                },
+                "Description": {
+                    "anyOf": [
+                        {
+                            "$ref": "http://redfish.dmtf.org/schemas/v1/Resource.json#/definitions/Description"
+                        },
+                        {
+                            "type": "null"
+                        }
+                    ],
+                    "readonly": true
+                },
+                "Id": {
+                    "$ref": "http://redfish.dmtf.org/schemas/v1/Resource.json#/definitions/Id",
+                    "readonly": true
+                },
+                "IsDefault": {
+                    "description": "Indicates if this is the default key policy.",
+                    "longDescription": "This property shall indicate if this key policy is the policy applied when no other policies are specified.",
+                    "readonly": false,
+                    "type": [
+                        "boolean",
+                        "null"
+                    ]
+                },
+                "KeyPolicyType": {
+                    "anyOf": [
+                        {
+                            "$ref": "#/definitions/KeyPolicyType"
+                        },
+                        {
+                            "type": "null"
+                        }
+                    ],
+                    "description": "The type of key policy.",
+                    "longDescription": "This property shall contain the type of key policy.",
+                    "readonly": true
+                },
+                "NVMeoF": {
+                    "anyOf": [
+                        {
+                            "$ref": "#/definitions/NVMeoF"
+                        },
+                        {
+                            "type": "null"
+                        }
+                    ],
+                    "description": "NVMe-oF specific properties.",
+                    "longDescription": "This property shall contain NVMe-oF specific properties for this key policy.  This property shall be present if KeyPolicyType contains the value `NVMeoF`."
+                },
+                "Name": {
+                    "$ref": "http://redfish.dmtf.org/schemas/v1/Resource.json#/definitions/Name",
+                    "readonly": true
+                },
+                "Oem": {
+                    "$ref": "http://redfish.dmtf.org/schemas/v1/Resource.json#/definitions/Oem",
+                    "description": "The OEM extension property.",
+                    "longDescription": "This property shall contain the OEM extensions.  All values for properties that this object contains shall conform to the Redfish Specification-described requirements."
+                }
+            },
+            "required": [
+                "@odata.id",
+                "@odata.type",
+                "Id",
+                "Name"
+            ],
+            "requiredOnCreate": [
+                "KeyPolicyType"
+            ],
+            "type": "object"
+        },
+        "KeyPolicyType": {
+            "enum": [
+                "NVMeoF"
+            ],
+            "enumDescriptions": {
+                "NVMeoF": "An NVMe-oF key policy."
+            },
+            "enumLongDescriptions": {
+                "NVMeoF": "This value shall indicate the key policy is for an NVMe-oF key."
+            },
+            "type": "string"
+        },
+        "NVMeoF": {
+            "additionalProperties": false,
+            "description": "NVMe-oF specific properties.",
+            "longDescription": "This type shall contain NVMe-oF specific properties for a key policy.",
+            "patternProperties": {
+                "^([a-zA-Z_][a-zA-Z0-9_]*)?@(odata|Redfish|Message)\\.[a-zA-Z_][a-zA-Z0-9_]*$": {
+                    "description": "This property shall specify a valid odata or Redfish property.",
+                    "type": [
+                        "array",
+                        "boolean",
+                        "integer",
+                        "number",
+                        "null",
+                        "object",
+                        "string"
+                    ]
+                }
+            },
+            "properties": {
+                "CipherSuiteAllowList": {
+                    "description": "The cipher suites that this key policy allows.",
+                    "items": {
+                        "anyOf": [
+                            {
+                                "$ref": "#/definitions/NVMeoFCipherSuiteType"
+                            },
+                            {
+                                "type": "null"
+                            }
+                        ]
+                    },
+                    "longDescription": "This property shall contain the cipher suites that this key policy allows.  The absence of the property shall indicate any cipher suite is allowed.  An empty list shall indicate no cipher suites are allowed.",
+                    "readonly": false,
+                    "type": "array"
+                },
+                "DHGroupAllowList": {
+                    "description": "The Diffie-Hellman (DH) groups that this key policy allows.",
+                    "items": {
+                        "anyOf": [
+                            {
+                                "$ref": "#/definitions/NVMeoFDHGroupType"
+                            },
+                            {
+                                "type": "null"
+                            }
+                        ]
+                    },
+                    "longDescription": "This property shall contain the Diffie-Hellman (DH) groups that this key policy allows.  The absence of the property shall indicate any DH group is allowed.  An empty list shall indicate no DH groups are allowed.",
+                    "readonly": false,
+                    "type": "array"
+                },
+                "OEMSecurityProtocolAllowList": {
+                    "description": "The OEM security protocols that this key policy allows.",
+                    "items": {
+                        "type": [
+                            "string",
+                            "null"
+                        ]
+                    },
+                    "longDescription": "This property shall contain the OEM-defined security protocols that this key policy allows.  NVMe-oF channels are restricted to OEM-defined security protocols in this list.  An empty list shall indicate no security protocols are allowed.  This property shall be present if SecurityProtocolAllowList contains `OEM`.",
+                    "readonly": false,
+                    "type": "array"
+                },
+                "SecureHashAllowList": {
+                    "description": "The secure hash algorithms that this key policy allows.",
+                    "items": {
+                        "anyOf": [
+                            {
+                                "$ref": "#/definitions/NVMeoFSecureHashType"
+                            },
+                            {
+                                "type": "null"
+                            }
+                        ]
+                    },
+                    "longDescription": "This property shall contain the secure hash algorithms that this key policy allows.  The absence of the property shall indicate any secure hash algorithm is allowed.  An empty list shall indicate no secure hash algorithms are allowed.",
+                    "readonly": false,
+                    "type": "array"
+                },
+                "SecurityProtocolAllowList": {
+                    "description": "The security protocols that this key policy allows.",
+                    "items": {
+                        "anyOf": [
+                            {
+                                "$ref": "#/definitions/NVMeoFSecurityProtocolType"
+                            },
+                            {
+                                "type": "null"
+                            }
+                        ]
+                    },
+                    "longDescription": "This property shall contain the security protocols that this key policy allows.  NVMe-oF channels are restricted to security protocols in this list.  The absence of the property shall indicate any security protocol is allowed.  An empty list shall indicate no security protocols are allowed.",
+                    "readonly": false,
+                    "type": "array"
+                },
+                "SecurityTransportAllowList": {
+                    "description": "The security transports that this key policy allows.",
+                    "items": {
+                        "anyOf": [
+                            {
+                                "$ref": "#/definitions/NVMeoFSecurityTransportType"
+                            },
+                            {
+                                "type": "null"
+                            }
+                        ]
+                    },
+                    "longDescription": "This property shall contain the security transports that this key policy allows.  The absence of the property shall indicate any security transport is allowed.  An empty list shall indicate no security transports are allowed.",
+                    "readonly": false,
+                    "type": "array"
+                }
+            },
+            "type": "object"
+        },
+        "NVMeoFCipherSuiteType": {
+            "description": "The NVMe cipher suites that a key is allowed to use.",
+            "enum": [
+                "TLS_AES_128_GCM_SHA256",
+                "TLS_AES_256_GCM_SHA384"
+            ],
+            "enumDescriptions": {
+                "TLS_AES_128_GCM_SHA256": "TLS_AES_128_GCM_SHA256.",
+                "TLS_AES_256_GCM_SHA384": "TLS_AES_256_GCM_SHA384."
+            },
+            "enumLongDescriptions": {
+                "TLS_AES_128_GCM_SHA256": "This value shall indicate TLS_AES_128_GCM_SHA256 as defined by the 'Mandatory and Recommended Cipher Suites' clause in the NVMe TCP Transport Specification.",
+                "TLS_AES_256_GCM_SHA384": "This value shall indicate TLS_AES_256_GCM_SHA384 as defined by the 'Mandatory and Recommended Cipher Suites' clause in the NVMe TCP Transport Specification."
+            },
+            "longDescription": "This enumeration shall list the NVMe cipher suites that a key is allowed to use.",
+            "type": "string"
+        },
+        "NVMeoFDHGroupType": {
+            "description": "The NVMe Diffie-Hellman (DH) groups that a key is allowed to use.",
+            "enum": [
+                "FFDHE2048",
+                "FFDHE3072",
+                "FFDHE4096",
+                "FFDHE6144",
+                "FFDHE8192"
+            ],
+            "enumDescriptions": {
+                "FFDHE2048": "2048-bit Diffie-Hellman (DH) group.",
+                "FFDHE3072": "3072-bit Diffie-Hellman (DH) group.",
+                "FFDHE4096": "4096-bit Diffie-Hellman (DH) group.",
+                "FFDHE6144": "6144-bit Diffie-Hellman (DH) group.",
+                "FFDHE8192": "8192-bit Diffie-Hellman (DH) group."
+            },
+            "enumLongDescriptions": {
+                "FFDHE2048": "This value shall indicate the 2048-bit Diffie-Hellman (DH) group as defined by the 'DH-HMAC-CHAP Diffie-Hellman group identifiers' figure in the NVMe Base Specification.",
+                "FFDHE3072": "This value shall indicate the 3072-bit Diffie-Hellman (DH) group as defined by the 'DH-HMAC-CHAP Diffie-Hellman group identifiers' figure in the NVMe Base Specification.",
+                "FFDHE4096": "This value shall indicate the 4096-bit Diffie-Hellman (DH) group as defined by the 'DH-HMAC-CHAP Diffie-Hellman group identifiers' figure in the NVMe Base Specification.",
+                "FFDHE6144": "This value shall indicate the 2048-bit Diffie-Hellman (DH) group as defined by the 'DH-HMAC-CHAP Diffie-Hellman group identifiers' figure in the NVMe Base Specification.",
+                "FFDHE8192": "This value shall indicate the 8192-bit Diffie-Hellman (DH) group as defined by the 'DH-HMAC-CHAP Diffie-Hellman group identifiers' figure in the NVMe Base Specification."
+            },
+            "longDescription": "This enumeration shall list the Diffie-Hellman (DH) groups that a key is allowed to use.",
+            "type": "string"
+        },
+        "NVMeoFSecureHashType": {
+            "description": "The NVMe secure hash algorithms that a key is allowed to use.",
+            "enum": [
+                "SHA256",
+                "SHA384",
+                "SHA512"
+            ],
+            "enumDescriptions": {
+                "SHA256": "SHA-256.",
+                "SHA384": "SHA-384.",
+                "SHA512": "SHA-512."
+            },
+            "enumLongDescriptions": {
+                "SHA256": "This value shall indicate the SHA-256 hash function as defined by the 'DH-HMAC-CHAP hash function identifiers' figure in the NVMe Base Specification.",
+                "SHA384": "This value shall indicate the SHA-384 hash function as defined by the 'DH-HMAC-CHAP hash function identifiers' figure in the NVMe Base Specification.",
+                "SHA512": "This value shall indicate the SHA-512 hash function as defined by the 'DH-HMAC-CHAP hash function identifiers' figure in the NVMe Base Specification."
+            },
+            "longDescription": "This enumeration shall list the NVMe secure hash algorithms that a key is allowed to use.",
+            "type": "string"
+        },
+        "NVMeoFSecurityProtocolType": {
+            "description": "The NVMe security protocols that a key is allowed to use.",
+            "enum": [
+                "DHHC",
+                "TLS_PSK",
+                "OEM"
+            ],
+            "enumDescriptions": {
+                "DHHC": "Diffie-Hellman Hashed Message Authentication Code Challenge Handshake Authentication Protocol (DH-HMAC-CHAP).",
+                "OEM": "OEM.",
+                "TLS_PSK": "Transport Layer Security Pre-Shared Key (TLS PSK)."
+            },
+            "enumLongDescriptions": {
+                "DHHC": "This value shall indicate the Diffie-Hellman Hashed Message Authentication Code Challenge Handshake Authentication Protocol (DH-HMAC-CHAP) as defined by the NVMe Base Specification.",
+                "OEM": "This value shall indicate an OEM-defined security protocol.  The OEMSecurityProtocolAllowList property shall contain the specific OEM protocol.",
+                "TLS_PSK": "This value shall indicate Transport Layer Security Pre-Shared Key (TLS PSK) as defined by the NVMe TCP Transport Specification."
+            },
+            "longDescription": "This enumeration shall list the NVMe security protocols that a key is allowed to use.",
+            "type": "string"
+        },
+        "NVMeoFSecurityTransportType": {
+            "description": "The NVMe security transports that a key is allowed to use.",
+            "enum": [
+                "TLSv2",
+                "TLSv3"
+            ],
+            "enumDescriptions": {
+                "TLSv2": "Transport Layer Security (TLS) v2.",
+                "TLSv3": "Transport Layer Security (TLS) v3."
+            },
+            "enumLongDescriptions": {
+                "TLSv2": "This value shall indicate Transport Layer Security (TLS) v2 as defined by the 'Transport Specific Address Subtype Definition for NVMe/TCP Transport' figure in the NVMe TCP Transport Specification.",
+                "TLSv3": "This value shall indicate Transport Layer Security (TLS) v3 as defined by the 'Transport Specific Address Subtype Definition for NVMe/TCP Transport' figure in the NVMe TCP Transport Specification."
+            },
+            "longDescription": "This enumeration shall list the NVMe security transports that a key is allowed to use.",
+            "type": "string"
+        },
+        "OemActions": {
+            "additionalProperties": true,
+            "description": "The available OEM-specific actions for this resource.",
+            "longDescription": "This type shall contain the available OEM-specific actions for this resource.",
+            "patternProperties": {
+                "^([a-zA-Z_][a-zA-Z0-9_]*)?@(odata|Redfish|Message)\\.[a-zA-Z_][a-zA-Z0-9_]*$": {
+                    "description": "This property shall specify a valid odata or Redfish property.",
+                    "type": [
+                        "array",
+                        "boolean",
+                        "integer",
+                        "number",
+                        "null",
+                        "object",
+                        "string"
+                    ]
+                }
+            },
+            "properties": {},
+            "type": "object"
+        }
+    },
+    "owningEntity": "DMTF",
+    "release": "2021.2",
+    "title": "#KeyPolicy.v1_0_0.KeyPolicy"
+}

--- a/static/redfish/v1/JsonSchemas/KeyPolicy/index.json
+++ b/static/redfish/v1/JsonSchemas/KeyPolicy/index.json
@@ -1,0 +1,21 @@
+{
+    "@odata.context": "/redfish/v1/$metadata#JsonSchemaFile.JsonSchemaFile",
+    "@odata.id": "/redfish/v1/JsonSchemas/KeyPolicy",
+    "@odata.type": "#JsonSchemaFile.v1_0_2.JsonSchemaFile",
+    "Name": "KeyPolicy Schema File",
+    "Schema": "#KeyPolicy.KeyPolicy",
+    "Description": "KeyPolicy Schema File Location",
+    "Id": "KeyPolicy",
+    "Languages": [
+        "en"
+    ],
+    "Languages@odata.count": 1,
+    "Location": [
+        {
+            "Language": "en",
+            "PublicationUri": "http://redfish.dmtf.org/schemas/v1/KeyPolicy.json",
+            "Uri": "/redfish/v1/JsonSchemas/KeyPolicy/KeyPolicy.json"
+        }
+    ],
+    "Location@odata.count": 1
+}

--- a/static/redfish/v1/JsonSchemas/KeyService/KeyService.json
+++ b/static/redfish/v1/JsonSchemas/KeyService/KeyService.json
@@ -1,0 +1,140 @@
+{
+    "$id": "http://redfish.dmtf.org/schemas/v1/KeyService.v1_0_0.json",
+    "$ref": "#/definitions/KeyService",
+    "$schema": "http://redfish.dmtf.org/schemas/v1/redfish-schema-v1.json",
+    "copyright": "Copyright 2014-2021 DMTF. For the full DMTF copyright policy, see http://www.dmtf.org/about/policies/copyright",
+    "definitions": {
+        "Actions": {
+            "additionalProperties": false,
+            "description": "The available actions for this resource.",
+            "longDescription": "This type shall contain the available actions for this resource.",
+            "patternProperties": {
+                "^([a-zA-Z_][a-zA-Z0-9_]*)?@(odata|Redfish|Message)\\.[a-zA-Z_][a-zA-Z0-9_]*$": {
+                    "description": "This property shall specify a valid odata or Redfish property.",
+                    "type": [
+                        "array",
+                        "boolean",
+                        "integer",
+                        "number",
+                        "null",
+                        "object",
+                        "string"
+                    ]
+                }
+            },
+            "properties": {
+                "Oem": {
+                    "$ref": "#/definitions/OemActions",
+                    "description": "The available OEM-specific actions for this resource.",
+                    "longDescription": "This property shall contain the available OEM-specific actions for this resource."
+                }
+            },
+            "type": "object"
+        },
+        "KeyService": {
+            "additionalProperties": false,
+            "description": "The KeyService schema describes a key service that represents the actions available to manage keys.",
+            "longDescription": "This resource shall represent the key service properties for a Redfish implementation.",
+            "patternProperties": {
+                "^([a-zA-Z_][a-zA-Z0-9_]*)?@(odata|Redfish|Message)\\.[a-zA-Z_][a-zA-Z0-9_]*$": {
+                    "description": "This property shall specify a valid odata or Redfish property.",
+                    "type": [
+                        "array",
+                        "boolean",
+                        "integer",
+                        "number",
+                        "null",
+                        "object",
+                        "string"
+                    ]
+                }
+            },
+            "properties": {
+                "@odata.context": {
+                    "$ref": "http://redfish.dmtf.org/schemas/v1/odata-v4.json#/definitions/context"
+                },
+                "@odata.etag": {
+                    "$ref": "http://redfish.dmtf.org/schemas/v1/odata-v4.json#/definitions/etag"
+                },
+                "@odata.id": {
+                    "$ref": "http://redfish.dmtf.org/schemas/v1/odata-v4.json#/definitions/id"
+                },
+                "@odata.type": {
+                    "$ref": "http://redfish.dmtf.org/schemas/v1/odata-v4.json#/definitions/type"
+                },
+                "Actions": {
+                    "$ref": "#/definitions/Actions",
+                    "description": "The available actions for this resource.",
+                    "longDescription": "This property shall contain the available actions for this resource."
+                },
+                "Description": {
+                    "anyOf": [
+                        {
+                            "$ref": "http://redfish.dmtf.org/schemas/v1/Resource.json#/definitions/Description"
+                        },
+                        {
+                            "type": "null"
+                        }
+                    ],
+                    "readonly": true
+                },
+                "Id": {
+                    "$ref": "http://redfish.dmtf.org/schemas/v1/Resource.json#/definitions/Id",
+                    "readonly": true
+                },
+                "NVMeoFKeyPolicies": {
+                    "$ref": "http://redfish.dmtf.org/schemas/v1/KeyPolicyCollection.json#/definitions/KeyPolicyCollection",
+                    "description": "The NVMe-oF key policies maintained by this service.",
+                    "longDescription": "This property shall contain a link to a resource collection of type KeyPolicyCollection that contains the NVMe-oF key policies maintained by this service.  The KeyPolicyType property for all members of this collection shall contain the value `NVMeoF`.",
+                    "readonly": true
+                },
+                "NVMeoFSecrets": {
+                    "$ref": "http://redfish.dmtf.org/schemas/v1/KeyCollection.json#/definitions/KeyCollection",
+                    "description": "The NVMe-oF keys maintained by this service.",
+                    "longDescription": "This property shall contain a link to a resource collection of type KeyCollection that contains the NVMe-oF keys maintained by this service.  The KeyType property for all members of this collection shall contain the value `NVMeoF`.",
+                    "readonly": true
+                },
+                "Name": {
+                    "$ref": "http://redfish.dmtf.org/schemas/v1/Resource.json#/definitions/Name",
+                    "readonly": true
+                },
+                "Oem": {
+                    "$ref": "http://redfish.dmtf.org/schemas/v1/Resource.json#/definitions/Oem",
+                    "description": "The OEM extension property.",
+                    "longDescription": "This property shall contain the OEM extensions.  All values for properties that this object contains shall conform to the Redfish Specification-described requirements."
+                }
+            },
+            "required": [
+                "@odata.id",
+                "@odata.type",
+                "Id",
+                "Name"
+            ],
+            "type": "object"
+        },
+        "OemActions": {
+            "additionalProperties": true,
+            "description": "The available OEM-specific actions for this resource.",
+            "longDescription": "This type shall contain the available OEM-specific actions for this resource.",
+            "patternProperties": {
+                "^([a-zA-Z_][a-zA-Z0-9_]*)?@(odata|Redfish|Message)\\.[a-zA-Z_][a-zA-Z0-9_]*$": {
+                    "description": "This property shall specify a valid odata or Redfish property.",
+                    "type": [
+                        "array",
+                        "boolean",
+                        "integer",
+                        "number",
+                        "null",
+                        "object",
+                        "string"
+                    ]
+                }
+            },
+            "properties": {},
+            "type": "object"
+        }
+    },
+    "owningEntity": "DMTF",
+    "release": "2021.2",
+    "title": "#KeyService.v1_0_0.KeyService"
+}

--- a/static/redfish/v1/JsonSchemas/KeyService/index.json
+++ b/static/redfish/v1/JsonSchemas/KeyService/index.json
@@ -1,0 +1,21 @@
+{
+    "@odata.context": "/redfish/v1/$metadata#JsonSchemaFile.JsonSchemaFile",
+    "@odata.id": "/redfish/v1/JsonSchemas/KeyService",
+    "@odata.type": "#JsonSchemaFile.v1_0_2.JsonSchemaFile",
+    "Name": "KeyService Schema File",
+    "Schema": "#KeyService.KeyService",
+    "Description": "KeyService Schema File Location",
+    "Id": "KeyService",
+    "Languages": [
+        "en"
+    ],
+    "Languages@odata.count": 1,
+    "Location": [
+        {
+            "Language": "en",
+            "PublicationUri": "http://redfish.dmtf.org/schemas/v1/KeyService.json",
+            "Uri": "/redfish/v1/JsonSchemas/KeyService/KeyService.json"
+        }
+    ],
+    "Location@odata.count": 1
+}

--- a/static/redfish/v1/JsonSchemas/Manifest/Manifest.json
+++ b/static/redfish/v1/JsonSchemas/Manifest/Manifest.json
@@ -1,0 +1,240 @@
+{
+    "$id": "http://redfish.dmtf.org/schemas/v1/Manifest.v1_0_0.json",
+    "$schema": "http://redfish.dmtf.org/schemas/v1/redfish-schema-v1.json",
+    "copyright": "Copyright 2014-2021 DMTF. For the full DMTF copyright policy, see http://www.dmtf.org/about/policies/copyright",
+    "definitions": {
+        "Expand": {
+            "enum": [
+                "None",
+                "All",
+                "Relevant"
+            ],
+            "enumDescriptions": {
+                "All": "Expand all subordinate references.",
+                "None": "Do not expand any references.",
+                "Relevant": "Expand relevant subordinate references.  Relevant references are those that are tied to a constrained composition request, such as a request for a quantity of processors."
+            },
+            "enumLongDescriptions": {
+                "All": "This value shall indicate that all subordinate references in the manifest response will be expanded.",
+                "None": "This value shall indicate that references in the manifest response will not be expanded.",
+                "Relevant": "This value shall indicate that relevant subordinate references in the manifest response will be expanded."
+            },
+            "type": "string"
+        },
+        "Manifest": {
+            "additionalProperties": false,
+            "description": "This type describes a manifest containing a set of requests to be fulfilled.  The manifest contains a set of stanzas, where each stanza describes a single request.",
+            "longDescription": "This type shall describe a manifest containing a set of requests to be fulfilled.",
+            "patternProperties": {
+                "^([a-zA-Z_][a-zA-Z0-9_]*)?@(odata|Redfish|Message)\\.[a-zA-Z_][a-zA-Z0-9_]*$": {
+                    "description": "This property shall specify a valid odata or Redfish property.",
+                    "type": [
+                        "array",
+                        "boolean",
+                        "integer",
+                        "number",
+                        "null",
+                        "object",
+                        "string"
+                    ]
+                }
+            },
+            "properties": {
+                "Description": {
+                    "description": "The description of this manifest.",
+                    "longDescription": "This property shall contain the description of this manifest.",
+                    "readonly": false,
+                    "type": [
+                        "string",
+                        "null"
+                    ]
+                },
+                "Expand": {
+                    "anyOf": [
+                        {
+                            "$ref": "#/definitions/Expand"
+                        },
+                        {
+                            "type": "null"
+                        }
+                    ],
+                    "description": "The expansion control for references in manifest responses, similar to the `$expand=.` query parameter.",
+                    "longDescription": "This property shall contain the expansion control for references in manifest responses.",
+                    "readonly": false
+                },
+                "Stanzas": {
+                    "description": "An array of stanzas that describe the requests specified by this manifest.",
+                    "items": {
+                        "anyOf": [
+                            {
+                                "$ref": "#/definitions/Stanza"
+                            },
+                            {
+                                "type": "null"
+                            }
+                        ]
+                    },
+                    "longDescription": "This property shall contain an array of stanzas that describe the requests specified by this manifest.",
+                    "type": "array"
+                },
+                "Timestamp": {
+                    "description": "The date and time when the manifest was created.",
+                    "format": "date-time",
+                    "longDescription": "This property shall contain the date and time when the manifest was created.",
+                    "readonly": false,
+                    "type": [
+                        "string",
+                        "null"
+                    ]
+                }
+            },
+            "type": "object"
+        },
+        "Request": {
+            "additionalProperties": true,
+            "description": "The content of the request for the stanza.",
+            "longDescription": "This type shall describe the request details of a stanza within a manifest.  Its contents vary depending on the value of the StanzaType property of the stanza.",
+            "patternProperties": {
+                "^([a-zA-Z_][a-zA-Z0-9_]*)?@(odata|Redfish|Message)\\.[a-zA-Z_][a-zA-Z0-9_]*$": {
+                    "description": "This property shall specify a valid odata or Redfish property.",
+                    "type": [
+                        "array",
+                        "boolean",
+                        "integer",
+                        "number",
+                        "null",
+                        "object",
+                        "string"
+                    ]
+                }
+            },
+            "properties": {},
+            "type": "object"
+        },
+        "Response": {
+            "additionalProperties": true,
+            "description": "The content of the response for the stanza.",
+            "longDescription": "This type shall describe the response details of a stanza within a manifest.  Its contents vary depending on the value of the StanzaType property of the stanza.",
+            "patternProperties": {
+                "^([a-zA-Z_][a-zA-Z0-9_]*)?@(odata|Redfish|Message)\\.[a-zA-Z_][a-zA-Z0-9_]*$": {
+                    "description": "This property shall specify a valid odata or Redfish property.",
+                    "type": [
+                        "array",
+                        "boolean",
+                        "integer",
+                        "number",
+                        "null",
+                        "object",
+                        "string"
+                    ]
+                }
+            },
+            "properties": {},
+            "type": "object"
+        },
+        "Stanza": {
+            "additionalProperties": false,
+            "description": "A stanza contains properties that describe a request to be fulfilled within a manifest.",
+            "longDescription": "This type shall contain properties that describe a request to be fulfilled within a manifest.",
+            "patternProperties": {
+                "^([a-zA-Z_][a-zA-Z0-9_]*)?@(odata|Redfish|Message)\\.[a-zA-Z_][a-zA-Z0-9_]*$": {
+                    "description": "This property shall specify a valid odata or Redfish property.",
+                    "type": [
+                        "array",
+                        "boolean",
+                        "integer",
+                        "number",
+                        "null",
+                        "object",
+                        "string"
+                    ]
+                }
+            },
+            "properties": {
+                "OEMStanzaType": {
+                    "description": "The OEM-defined type of stanza.",
+                    "longDescription": "This property shall contain the OEM-defined type of stanza.  This property shall be present if StanzaType is `OEM`.",
+                    "readonly": false,
+                    "type": [
+                        "string",
+                        "null"
+                    ]
+                },
+                "Request": {
+                    "anyOf": [
+                        {
+                            "$ref": "#/definitions/Request"
+                        },
+                        {
+                            "type": "null"
+                        }
+                    ],
+                    "description": "The request details for the stanza.",
+                    "longDescription": "This property shall contain the request details for the stanza and the contents vary based depending on the value of the StanzaType property."
+                },
+                "Response": {
+                    "anyOf": [
+                        {
+                            "$ref": "#/definitions/Response"
+                        },
+                        {
+                            "type": "null"
+                        }
+                    ],
+                    "description": "The response details for the stanza.",
+                    "longDescription": "This property shall contain the response details for the stanza and the contents vary based depending on the value of the StanzaType property."
+                },
+                "StanzaId": {
+                    "description": "The identifier of the stanza.  This is a unique identifier specified by the client and is not used by the service.",
+                    "longDescription": "This property shall contain the identifier of the stanza.",
+                    "readonly": false,
+                    "type": [
+                        "string",
+                        "null"
+                    ]
+                },
+                "StanzaType": {
+                    "anyOf": [
+                        {
+                            "$ref": "#/definitions/StanzaType"
+                        },
+                        {
+                            "type": "null"
+                        }
+                    ],
+                    "description": "The type of stanza.",
+                    "longDescription": "This property shall contain the type of stanza.",
+                    "readonly": false
+                }
+            },
+            "type": "object"
+        },
+        "StanzaType": {
+            "enum": [
+                "ComposeSystem",
+                "DecomposeSystem",
+                "ComposeResource",
+                "DecomposeResource",
+                "OEM"
+            ],
+            "enumDescriptions": {
+                "ComposeResource": "A stanza that describes the desired end state for a composed resource block.  The resources consumed by the composed resource block are moved to the active pool.",
+                "ComposeSystem": "A stanza that describes the desired end state for computer system composition operation.  The resources consumed by the composed computer system are moved to the active pool.",
+                "DecomposeResource": "A stanza that references a composed resource block to decompose and return resources to the free pool.",
+                "DecomposeSystem": "A stanza that references a computer system to decompose and return resources to the free pool.",
+                "OEM": "A stanza that describes an OEM-specific request."
+            },
+            "enumLongDescriptions": {
+                "ComposeResource": "This value shall indicate a stanza that describes a composed resource block.  The resource blocks assigned to the composed resource block shall be moved to the active pool.  The Request property of the stanza shall contain a resource of type ResourceBlock that represents the composition request.  The Response property of the stanza shall contain a resource of type ResourceBlock that represents the composed resource block or a Redfish Specification-defined error response.",
+                "ComposeSystem": "This value shall indicate a stanza that describes the specific, constrained, or mixed resources required to compose a computer system.  The resource blocks assigned to the computer system shall be moved to the active pool.  The Request property of the stanza shall contain a resource of type ComputerSystem that represents the composition request.  The Response property of the stanza shall contain a resource of type ComputerSystem that represents the composed system or a Redfish Specification-defined error response.",
+                "DecomposeResource": "This value shall indicate a stanza that references a composed resource block to decompose and return the resource blocks to the free pool that are no longer contributing to composed resources.  The Request property of the stanza shall be a reference object as defined by the 'Reference properties' clause of the Redfish Specification containing a reference to the resource of type ResourceBlock to decompose.  The Response property of the stanza shall contain a resource of type ResourceBlock that represents the decomposed resource block or a Redfish Specification-defined error response.",
+                "DecomposeSystem": "This value shall indicate a stanza that references a computer system to decompose and return the resource blocks to the free pool that are no longer contributing to composed resources.  The Request property of the stanza shall be a Redfish Specification-defined reference object containing a reference to the resource of type ComputerSystem to decompose.  The Response property of the stanza shall contain a resource of type ComputerSystem that represents the decomposed system or a Redfish Specification-defined error response.",
+                "OEM": "This value shall indicate a stanza that describes an OEM-specific request.  The OEMStanzaType property shall contain the specific OEM stanza type."
+            },
+            "type": "string"
+        }
+    },
+    "owningEntity": "DMTF",
+    "release": "2020.4",
+    "title": "#Manifest.v1_0_0"
+}

--- a/static/redfish/v1/JsonSchemas/Manifest/index.json
+++ b/static/redfish/v1/JsonSchemas/Manifest/index.json
@@ -1,0 +1,21 @@
+{
+    "@odata.context": "/redfish/v1/$metadata#JsonSchemaFile.JsonSchemaFile",
+    "@odata.id": "/redfish/v1/JsonSchemas/Manifest",
+    "@odata.type": "#JsonSchemaFile.v1_0_2.JsonSchemaFile",
+    "Name": "Manifest Schema File",
+    "Schema": "#Manifest.Manifest",
+    "Description": "Manifest Schema File Location",
+    "Id": "Manifest",
+    "Languages": [
+        "en"
+    ],
+    "Languages@odata.count": 1,
+    "Location": [
+        {
+            "Language": "en",
+            "PublicationUri": "http://redfish.dmtf.org/schemas/v1/Manifest.json",
+            "Uri": "/redfish/v1/JsonSchemas/Manifest/Manifest.json"
+        }
+    ],
+    "Location@odata.count": 1
+}

--- a/static/redfish/v1/JsonSchemas/MediaController/MediaController.json
+++ b/static/redfish/v1/JsonSchemas/MediaController/MediaController.json
@@ -1,0 +1,318 @@
+{
+    "$id": "http://redfish.dmtf.org/schemas/v1/MediaController.v1_2_0.json",
+    "$ref": "#/definitions/MediaController",
+    "$schema": "http://redfish.dmtf.org/schemas/v1/redfish-schema-v1.json",
+    "copyright": "Copyright 2014-2021 DMTF. For the full DMTF copyright policy, see http://www.dmtf.org/about/policies/copyright",
+    "definitions": {
+        "Actions": {
+            "additionalProperties": false,
+            "description": "The available actions for this resource.",
+            "longDescription": "This type shall contain the available actions for this resource.",
+            "patternProperties": {
+                "^([a-zA-Z_][a-zA-Z0-9_]*)?@(odata|Redfish|Message)\\.[a-zA-Z_][a-zA-Z0-9_]*$": {
+                    "description": "This property shall specify a valid odata or Redfish property.",
+                    "type": [
+                        "array",
+                        "boolean",
+                        "integer",
+                        "number",
+                        "null",
+                        "object",
+                        "string"
+                    ]
+                }
+            },
+            "properties": {
+                "#MediaController.Reset": {
+                    "$ref": "#/definitions/Reset"
+                },
+                "Oem": {
+                    "$ref": "#/definitions/OemActions",
+                    "description": "The available OEM-specific actions for this resource.",
+                    "longDescription": "This property shall contain the available OEM-specific actions for this resource."
+                }
+            },
+            "type": "object"
+        },
+        "Links": {
+            "additionalProperties": false,
+            "description": "The links to other resources that are related to this resource.",
+            "longDescription": "This Redfish Specification-described type shall contain links to resources that are related to but are not contained by, or subordinate to, this resource.",
+            "patternProperties": {
+                "^([a-zA-Z_][a-zA-Z0-9_]*)?@(odata|Redfish|Message)\\.[a-zA-Z_][a-zA-Z0-9_]*$": {
+                    "description": "This property shall specify a valid odata or Redfish property.",
+                    "type": [
+                        "array",
+                        "boolean",
+                        "integer",
+                        "number",
+                        "null",
+                        "object",
+                        "string"
+                    ]
+                }
+            },
+            "properties": {
+                "Endpoints": {
+                    "description": "An array of links to the endpoints that connect to this media controller.",
+                    "items": {
+                        "$ref": "http://redfish.dmtf.org/schemas/v1/Endpoint.json#/definitions/Endpoint"
+                    },
+                    "longDescription": "This property shall contain an array of links to resources of type Endpoint with which this media controller is associated.",
+                    "readonly": true,
+                    "type": "array"
+                },
+                "Endpoints@odata.count": {
+                    "$ref": "http://redfish.dmtf.org/schemas/v1/odata-v4.json#/definitions/count"
+                },
+                "MemoryDomains": {
+                    "description": "An array of links to the memory domains associated with this media controller.",
+                    "items": {
+                        "$ref": "http://redfish.dmtf.org/schemas/v1/MemoryDomain.json#/definitions/MemoryDomain"
+                    },
+                    "longDescription": "This property shall contain an array of links to resources of type MemoryDomain that represent the memory domains associated with this memory controller.",
+                    "readonly": true,
+                    "type": "array"
+                },
+                "MemoryDomains@odata.count": {
+                    "$ref": "http://redfish.dmtf.org/schemas/v1/odata-v4.json#/definitions/count"
+                },
+                "Oem": {
+                    "$ref": "http://redfish.dmtf.org/schemas/v1/Resource.json#/definitions/Oem",
+                    "description": "The OEM extension property.",
+                    "longDescription": "This property shall contain the OEM extensions.  All values for properties contained in this object shall conform to the Redfish Specification-described requirements."
+                }
+            },
+            "type": "object"
+        },
+        "MediaController": {
+            "additionalProperties": false,
+            "description": "The MediaController schema contains the definition of the media controller and its configuration.",
+            "longDescription": "This resource contains the media controller in a Redfish implementation.",
+            "patternProperties": {
+                "^([a-zA-Z_][a-zA-Z0-9_]*)?@(odata|Redfish|Message)\\.[a-zA-Z_][a-zA-Z0-9_]*$": {
+                    "description": "This property shall specify a valid odata or Redfish property.",
+                    "type": [
+                        "array",
+                        "boolean",
+                        "integer",
+                        "number",
+                        "null",
+                        "object",
+                        "string"
+                    ]
+                }
+            },
+            "properties": {
+                "@odata.context": {
+                    "$ref": "http://redfish.dmtf.org/schemas/v1/odata-v4.json#/definitions/context"
+                },
+                "@odata.etag": {
+                    "$ref": "http://redfish.dmtf.org/schemas/v1/odata-v4.json#/definitions/etag"
+                },
+                "@odata.id": {
+                    "$ref": "http://redfish.dmtf.org/schemas/v1/odata-v4.json#/definitions/id"
+                },
+                "@odata.type": {
+                    "$ref": "http://redfish.dmtf.org/schemas/v1/odata-v4.json#/definitions/type"
+                },
+                "Actions": {
+                    "$ref": "#/definitions/Actions",
+                    "description": "The available actions for this resource.",
+                    "longDescription": "This property shall contain the available actions for this resource."
+                },
+                "Description": {
+                    "anyOf": [
+                        {
+                            "$ref": "http://redfish.dmtf.org/schemas/v1/Resource.json#/definitions/Description"
+                        },
+                        {
+                            "type": "null"
+                        }
+                    ],
+                    "readonly": true
+                },
+                "EnvironmentMetrics": {
+                    "$ref": "http://redfish.dmtf.org/schemas/v1/EnvironmentMetrics.json#/definitions/EnvironmentMetrics",
+                    "description": "The link to the environment metrics for this media controller.",
+                    "longDescription": "This property shall contain a link to a resource of type EnvironmentMetrics that specifies the environment metrics for this media controller.",
+                    "readonly": true,
+                    "versionAdded": "v1_2_0"
+                },
+                "Id": {
+                    "$ref": "http://redfish.dmtf.org/schemas/v1/Resource.json#/definitions/Id",
+                    "readonly": true
+                },
+                "Links": {
+                    "$ref": "#/definitions/Links",
+                    "description": "The links to other resources that are related to this resource.",
+                    "longDescription": "This property shall contain links to resources that are related to but are not contained by, or subordinate to, this resource."
+                },
+                "Manufacturer": {
+                    "description": "The manufacturer of this media controller.",
+                    "longDescription": "This property shall contain the manufacturer of the media controller.",
+                    "readonly": true,
+                    "type": [
+                        "string",
+                        "null"
+                    ]
+                },
+                "MediaControllerType": {
+                    "anyOf": [
+                        {
+                            "$ref": "#/definitions/MediaControllerType"
+                        },
+                        {
+                            "type": "null"
+                        }
+                    ],
+                    "description": "The type of media controller.",
+                    "longDescription": "This property shall contain the type of media controller.",
+                    "readonly": true
+                },
+                "Model": {
+                    "description": "The model of this media controller.",
+                    "longDescription": "This property shall contain the model of the media controller.",
+                    "readonly": true,
+                    "type": [
+                        "string",
+                        "null"
+                    ]
+                },
+                "Name": {
+                    "$ref": "http://redfish.dmtf.org/schemas/v1/Resource.json#/definitions/Name",
+                    "readonly": true
+                },
+                "Oem": {
+                    "$ref": "http://redfish.dmtf.org/schemas/v1/Resource.json#/definitions/Oem",
+                    "description": "The OEM extension property.",
+                    "longDescription": "This property shall contain the OEM extensions.  All values for properties that this object contains shall conform to the Redfish Specification-described requirements."
+                },
+                "PartNumber": {
+                    "description": "The part number of this media controller.",
+                    "longDescription": "This property shall indicate the part number as provided by the manufacturer of this media controller.",
+                    "readonly": true,
+                    "type": [
+                        "string",
+                        "null"
+                    ]
+                },
+                "Ports": {
+                    "$ref": "http://redfish.dmtf.org/schemas/v1/PortCollection.json#/definitions/PortCollection",
+                    "description": "The link to the collection of ports associated with this media controller.",
+                    "longDescription": "This property shall contain a link to a resource collection of type PortCollection.",
+                    "readonly": true
+                },
+                "SerialNumber": {
+                    "description": "The serial number of this media controller.",
+                    "longDescription": "This property shall indicate the serial number as provided by the manufacturer of this media controller.",
+                    "readonly": true,
+                    "type": [
+                        "string",
+                        "null"
+                    ]
+                },
+                "Status": {
+                    "$ref": "http://redfish.dmtf.org/schemas/v1/Resource.json#/definitions/Status",
+                    "description": "The status and health of the resource and its subordinate or dependent resources.",
+                    "longDescription": "This property shall contain any status or health properties of the resource."
+                },
+                "UUID": {
+                    "anyOf": [
+                        {
+                            "$ref": "http://redfish.dmtf.org/schemas/v1/Resource.json#/definitions/UUID"
+                        },
+                        {
+                            "type": "null"
+                        }
+                    ],
+                    "description": "The UUID for this media controller.",
+                    "longDescription": "This property shall contain a universal unique identifier number for the media controller.",
+                    "readonly": true,
+                    "versionAdded": "v1_1_0"
+                }
+            },
+            "required": [
+                "@odata.id",
+                "@odata.type",
+                "Id",
+                "Name"
+            ],
+            "type": "object"
+        },
+        "MediaControllerType": {
+            "enum": [
+                "Memory"
+            ],
+            "enumDescriptions": {
+                "Memory": "The media controller is for memory."
+            },
+            "enumLongDescriptions": {
+                "Memory": "This value shall indicate the media controller is for memory."
+            },
+            "type": "string"
+        },
+        "OemActions": {
+            "additionalProperties": true,
+            "description": "The available OEM-specific actions for this resource.",
+            "longDescription": "This type shall contain the available OEM-specific actions for this resource.",
+            "patternProperties": {
+                "^([a-zA-Z_][a-zA-Z0-9_]*)?@(odata|Redfish|Message)\\.[a-zA-Z_][a-zA-Z0-9_]*$": {
+                    "description": "This property shall specify a valid odata or Redfish property.",
+                    "type": [
+                        "array",
+                        "boolean",
+                        "integer",
+                        "number",
+                        "null",
+                        "object",
+                        "string"
+                    ]
+                }
+            },
+            "properties": {},
+            "type": "object"
+        },
+        "Reset": {
+            "additionalProperties": false,
+            "description": "This action resets this media controller.",
+            "longDescription": "This action shall reset this media controller.",
+            "parameters": {
+                "ResetType": {
+                    "$ref": "http://redfish.dmtf.org/schemas/v1/Resource.json#/definitions/ResetType",
+                    "description": "The type of reset.",
+                    "longDescription": "This parameter shall contain the type of reset.  The service can accept a request without the parameter and perform an implementation-specific default reset."
+                }
+            },
+            "patternProperties": {
+                "^([a-zA-Z_][a-zA-Z0-9_]*)?@(odata|Redfish|Message)\\.[a-zA-Z_][a-zA-Z0-9_]*$": {
+                    "description": "This property shall specify a valid odata or Redfish property.",
+                    "type": [
+                        "array",
+                        "boolean",
+                        "integer",
+                        "number",
+                        "null",
+                        "object",
+                        "string"
+                    ]
+                }
+            },
+            "properties": {
+                "target": {
+                    "description": "Link to invoke action",
+                    "format": "uri-reference",
+                    "type": "string"
+                },
+                "title": {
+                    "description": "Friendly action name",
+                    "type": "string"
+                }
+            },
+            "type": "object"
+        }
+    },
+    "owningEntity": "DMTF",
+    "release": "2021.1",
+    "title": "#MediaController.v1_2_0.MediaController"
+}

--- a/static/redfish/v1/JsonSchemas/MediaController/index.json
+++ b/static/redfish/v1/JsonSchemas/MediaController/index.json
@@ -1,0 +1,21 @@
+{
+    "@odata.context": "/redfish/v1/$metadata#JsonSchemaFile.JsonSchemaFile",
+    "@odata.id": "/redfish/v1/JsonSchemas/MediaController",
+    "@odata.type": "#JsonSchemaFile.v1_0_2.JsonSchemaFile",
+    "Name": "MediaController Schema File",
+    "Schema": "#MediaController.MediaController",
+    "Description": "MediaController Schema File Location",
+    "Id": "MediaController",
+    "Languages": [
+        "en"
+    ],
+    "Languages@odata.count": 1,
+    "Location": [
+        {
+            "Language": "en",
+            "PublicationUri": "http://redfish.dmtf.org/schemas/v1/MediaController.json",
+            "Uri": "/redfish/v1/JsonSchemas/MediaController/MediaController.json"
+        }
+    ],
+    "Location@odata.count": 1
+}

--- a/static/redfish/v1/JsonSchemas/MemoryChunks/MemoryChunks.json
+++ b/static/redfish/v1/JsonSchemas/MemoryChunks/MemoryChunks.json
@@ -1,0 +1,331 @@
+{
+    "$id": "http://redfish.dmtf.org/schemas/v1/MemoryChunks.v1_4_1.json",
+    "$ref": "#/definitions/MemoryChunks",
+    "$schema": "http://redfish.dmtf.org/schemas/v1/redfish-schema-v1.json",
+    "copyright": "Copyright 2014-2020 DMTF. For the full DMTF copyright policy, see http://www.dmtf.org/about/policies/copyright",
+    "definitions": {
+        "Actions": {
+            "additionalProperties": false,
+            "description": "The available actions for this resource.",
+            "longDescription": "This type shall contain the available actions for this resource.",
+            "patternProperties": {
+                "^([a-zA-Z_][a-zA-Z0-9_]*)?@(odata|Redfish|Message)\\.[a-zA-Z_][a-zA-Z0-9_]*$": {
+                    "description": "This property shall specify a valid odata or Redfish property.",
+                    "type": [
+                        "array",
+                        "boolean",
+                        "integer",
+                        "number",
+                        "null",
+                        "object",
+                        "string"
+                    ]
+                }
+            },
+            "properties": {
+                "Oem": {
+                    "$ref": "#/definitions/OemActions",
+                    "description": "The available OEM-specific actions for this resource.",
+                    "longDescription": "This property shall contain the available OEM-specific actions for this resource.",
+                    "versionAdded": "v1_1_0"
+                }
+            },
+            "type": "object"
+        },
+        "AddressRangeType": {
+            "enum": [
+                "Volatile",
+                "PMEM",
+                "Block"
+            ],
+            "enumDescriptions": {
+                "Block": "Block accessible memory.",
+                "PMEM": "Byte accessible persistent memory.",
+                "Volatile": "Volatile memory."
+            },
+            "type": "string"
+        },
+        "InterleaveSet": {
+            "additionalProperties": false,
+            "description": "This an interleave set for a memory chunk.",
+            "longDescription": "This type shall describe an interleave set of which the memory chunk is a part.",
+            "patternProperties": {
+                "^([a-zA-Z_][a-zA-Z0-9_]*)?@(odata|Redfish|Message)\\.[a-zA-Z_][a-zA-Z0-9_]*$": {
+                    "description": "This property shall specify a valid odata or Redfish property.",
+                    "type": [
+                        "array",
+                        "boolean",
+                        "integer",
+                        "number",
+                        "null",
+                        "object",
+                        "string"
+                    ]
+                }
+            },
+            "properties": {
+                "Memory": {
+                    "$ref": "http://redfish.dmtf.org/schemas/v1/odata-v4.json#/definitions/idRef",
+                    "description": "Describes a memory device of the interleave set.",
+                    "longDescription": "This property shall contain the memory device to which these settings apply.",
+                    "readonly": true
+                },
+                "MemoryLevel": {
+                    "description": "Level of the interleave set for multi-level tiered memory.",
+                    "longDescription": "This property shall contain the level of this interleave set for multi-level tiered memory.",
+                    "readonly": true,
+                    "type": [
+                        "integer",
+                        "null"
+                    ]
+                },
+                "OffsetMiB": {
+                    "description": "Offset within the DIMM that corresponds to the start of this memory region, measured in mebibytes (MiB).",
+                    "longDescription": "This property shall contain the offset within the DIMM that corresponds to the start of this memory region, with units in MiB.",
+                    "readonly": true,
+                    "type": [
+                        "integer",
+                        "null"
+                    ],
+                    "units": "MiBy"
+                },
+                "RegionId": {
+                    "description": "DIMM region identifier.",
+                    "longDescription": "This property shall contain the DIMM region identifier.",
+                    "readonly": true,
+                    "type": [
+                        "string",
+                        "null"
+                    ]
+                },
+                "SizeMiB": {
+                    "description": "Size of this memory region measured in mebibytes (MiB).",
+                    "longDescription": "This property shall contain the size of this memory region, with units in MiB.",
+                    "readonly": true,
+                    "type": [
+                        "integer",
+                        "null"
+                    ],
+                    "units": "MiBy"
+                }
+            },
+            "type": "object"
+        },
+        "Links": {
+            "additionalProperties": false,
+            "description": "The links to other resources that are related to this resource.",
+            "longDescription": "This Redfish Specification-described type shall contain links to resources that are related to but are not contained by, or subordinate to, this resource.",
+            "patternProperties": {
+                "^([a-zA-Z_][a-zA-Z0-9_]*)?@(odata|Redfish|Message)\\.[a-zA-Z_][a-zA-Z0-9_]*$": {
+                    "description": "This property shall specify a valid odata or Redfish property.",
+                    "type": [
+                        "array",
+                        "boolean",
+                        "integer",
+                        "number",
+                        "null",
+                        "object",
+                        "string"
+                    ]
+                }
+            },
+            "properties": {
+                "Endpoints": {
+                    "description": "An array of links to the endpoints that connect to this memory chunk.",
+                    "items": {
+                        "$ref": "http://redfish.dmtf.org/schemas/v1/Endpoint.json#/definitions/Endpoint"
+                    },
+                    "longDescription": "This property shall contain a link to the resources of type Endpoint with which this memory chunk is associated.",
+                    "readonly": true,
+                    "type": "array",
+                    "versionAdded": "v1_3_0"
+                },
+                "Endpoints@odata.count": {
+                    "$ref": "http://redfish.dmtf.org/schemas/v1/odata-v4.json#/definitions/count"
+                },
+                "Oem": {
+                    "$ref": "http://redfish.dmtf.org/schemas/v1/Resource.json#/definitions/Oem",
+                    "description": "The OEM extension property.",
+                    "longDescription": "This property shall contain the OEM extensions.  All values for properties contained in this object shall conform to the Redfish Specification-described requirements."
+                }
+            },
+            "type": "object"
+        },
+        "MemoryChunks": {
+            "additionalProperties": false,
+            "description": "The schema definition of a memory chunk and its configuration.",
+            "longDescription": "This resource shall represent memory chunks and interleave sets in a Redfish implementation.",
+            "patternProperties": {
+                "^([a-zA-Z_][a-zA-Z0-9_]*)?@(odata|Redfish|Message)\\.[a-zA-Z_][a-zA-Z0-9_]*$": {
+                    "description": "This property shall specify a valid odata or Redfish property.",
+                    "type": [
+                        "array",
+                        "boolean",
+                        "integer",
+                        "number",
+                        "null",
+                        "object",
+                        "string"
+                    ]
+                }
+            },
+            "properties": {
+                "@odata.context": {
+                    "$ref": "http://redfish.dmtf.org/schemas/v1/odata-v4.json#/definitions/context"
+                },
+                "@odata.etag": {
+                    "$ref": "http://redfish.dmtf.org/schemas/v1/odata-v4.json#/definitions/etag"
+                },
+                "@odata.id": {
+                    "$ref": "http://redfish.dmtf.org/schemas/v1/odata-v4.json#/definitions/id"
+                },
+                "@odata.type": {
+                    "$ref": "http://redfish.dmtf.org/schemas/v1/odata-v4.json#/definitions/type"
+                },
+                "Actions": {
+                    "$ref": "#/definitions/Actions",
+                    "description": "The available actions for this resource.",
+                    "longDescription": "This property shall contain the available actions for this resource.",
+                    "versionAdded": "v1_1_0"
+                },
+                "AddressRangeOffsetMiB": {
+                    "description": "Offset of the memory chunk in the address range in MiB.",
+                    "longDescription": "The value of this property shall be the offset of the memory chunk in the address range in MiB.",
+                    "readonly": true,
+                    "type": [
+                        "integer",
+                        "null"
+                    ],
+                    "units": "MiBy",
+                    "versionAdded": "v1_3_0"
+                },
+                "AddressRangeType": {
+                    "anyOf": [
+                        {
+                            "$ref": "#/definitions/AddressRangeType"
+                        },
+                        {
+                            "type": "null"
+                        }
+                    ],
+                    "description": "Memory type of this memory chunk.",
+                    "longDescription": "This property shall contain the type of memory chunk.",
+                    "readonly": true
+                },
+                "Description": {
+                    "anyOf": [
+                        {
+                            "$ref": "http://redfish.dmtf.org/schemas/v1/Resource.json#/definitions/Description"
+                        },
+                        {
+                            "type": "null"
+                        }
+                    ],
+                    "readonly": true
+                },
+                "DisplayName": {
+                    "description": "A user-configurable string to name the memory chunk.",
+                    "longDescription": "This property shall contain a user-configurable string to name the memory chunk.",
+                    "readonly": false,
+                    "type": [
+                        "string",
+                        "null"
+                    ],
+                    "versionAdded": "v1_4_0"
+                },
+                "Id": {
+                    "$ref": "http://redfish.dmtf.org/schemas/v1/Resource.json#/definitions/Id",
+                    "readonly": true
+                },
+                "InterleaveSets": {
+                    "description": "The interleave sets for the memory chunk.",
+                    "items": {
+                        "$ref": "#/definitions/InterleaveSet"
+                    },
+                    "longDescription": "These properties shall represent the interleave sets for the memory chunk.",
+                    "type": "array"
+                },
+                "IsMirrorEnabled": {
+                    "description": "An indication of whether memory mirroring is enabled for this memory chunk.",
+                    "longDescription": "This property shall indicate whether memory mirroring is enabled for this memory chunk.",
+                    "readonly": true,
+                    "type": [
+                        "boolean",
+                        "null"
+                    ]
+                },
+                "IsSpare": {
+                    "description": "An indication of whether sparing is enabled for this memory chunk.",
+                    "longDescription": "This property shall indicate whether sparing is enabled for this memory chunk.",
+                    "readonly": true,
+                    "type": [
+                        "boolean",
+                        "null"
+                    ]
+                },
+                "Links": {
+                    "$ref": "#/definitions/Links",
+                    "description": "The links to other resources that are related to this resource.",
+                    "longDescription": "This property shall contain links to resources that are related to but are not contained by or subordinate to this resource.",
+                    "versionAdded": "v1_3_0"
+                },
+                "MemoryChunkSizeMiB": {
+                    "description": "Size of the memory chunk measured in mebibytes (MiB).",
+                    "longDescription": "This property shall contain the size of the memory chunk in MiB.",
+                    "readonly": true,
+                    "type": [
+                        "integer",
+                        "null"
+                    ],
+                    "units": "MiBy"
+                },
+                "Name": {
+                    "$ref": "http://redfish.dmtf.org/schemas/v1/Resource.json#/definitions/Name",
+                    "readonly": true
+                },
+                "Oem": {
+                    "$ref": "http://redfish.dmtf.org/schemas/v1/Resource.json#/definitions/Oem",
+                    "description": "The OEM extension property.",
+                    "longDescription": "This property shall contain the OEM extensions.  All values for properties that this object contains shall conform to the Redfish Specification-described requirements."
+                },
+                "Status": {
+                    "$ref": "http://redfish.dmtf.org/schemas/v1/Resource.json#/definitions/Status",
+                    "description": "The status and health of the resource and its subordinate or dependent resources.",
+                    "longDescription": "This property shall contain any status or health properties of the resource.",
+                    "versionAdded": "v1_2_0"
+                }
+            },
+            "required": [
+                "@odata.id",
+                "@odata.type",
+                "Id",
+                "Name"
+            ],
+            "type": "object"
+        },
+        "OemActions": {
+            "additionalProperties": true,
+            "description": "The available OEM-specific actions for this resource.",
+            "longDescription": "This type shall contain the available OEM-specific actions for this resource.",
+            "patternProperties": {
+                "^([a-zA-Z_][a-zA-Z0-9_]*)?@(odata|Redfish|Message)\\.[a-zA-Z_][a-zA-Z0-9_]*$": {
+                    "description": "This property shall specify a valid odata or Redfish property.",
+                    "type": [
+                        "array",
+                        "boolean",
+                        "integer",
+                        "number",
+                        "null",
+                        "object",
+                        "string"
+                    ]
+                }
+            },
+            "properties": {},
+            "type": "object"
+        }
+    },
+    "owningEntity": "DMTF",
+    "release": "2020.3",
+    "title": "#MemoryChunks.v1_4_1.MemoryChunks"
+}

--- a/static/redfish/v1/JsonSchemas/MemoryChunks/index.json
+++ b/static/redfish/v1/JsonSchemas/MemoryChunks/index.json
@@ -1,0 +1,21 @@
+{
+    "@odata.context": "/redfish/v1/$metadata#JsonSchemaFile.JsonSchemaFile",
+    "@odata.id": "/redfish/v1/JsonSchemas/MemoryChunks",
+    "@odata.type": "#JsonSchemaFile.v1_0_2.JsonSchemaFile",
+    "Name": "MemoryChunks Schema File",
+    "Schema": "#MemoryChunks.MemoryChunks",
+    "Description": "MemoryChunks Schema File Location",
+    "Id": "MemoryChunks",
+    "Languages": [
+        "en"
+    ],
+    "Languages@odata.count": 1,
+    "Location": [
+        {
+            "Language": "en",
+            "PublicationUri": "http://redfish.dmtf.org/schemas/v1/MemoryChunks.json",
+            "Uri": "/redfish/v1/JsonSchemas/MemoryChunks/MemoryChunks.json"
+        }
+    ],
+    "Location@odata.count": 1
+}

--- a/static/redfish/v1/JsonSchemas/MemoryDomain/MemoryDomain.json
+++ b/static/redfish/v1/JsonSchemas/MemoryDomain/MemoryDomain.json
@@ -1,0 +1,262 @@
+{
+    "$id": "http://redfish.dmtf.org/schemas/v1/MemoryDomain.v1_3_0.json",
+    "$ref": "#/definitions/MemoryDomain",
+    "$schema": "http://redfish.dmtf.org/schemas/v1/redfish-schema-v1.json",
+    "copyright": "Copyright 2014-2019 DMTF. For the full DMTF copyright policy, see http://www.dmtf.org/about/policies/copyright",
+    "definitions": {
+        "Actions": {
+            "additionalProperties": false,
+            "description": "The available actions for this Resource.",
+            "longDescription": "This type shall contain the available actions for this Resource.",
+            "patternProperties": {
+                "^([a-zA-Z_][a-zA-Z0-9_]*)?@(odata|Redfish|Message)\\.[a-zA-Z_][a-zA-Z0-9_]*$": {
+                    "description": "This property shall specify a valid odata or Redfish property.",
+                    "type": [
+                        "array",
+                        "boolean",
+                        "integer",
+                        "number",
+                        "null",
+                        "object",
+                        "string"
+                    ]
+                }
+            },
+            "properties": {
+                "Oem": {
+                    "$ref": "#/definitions/OemActions",
+                    "description": "The available OEM-specific actions for this Resource.",
+                    "longDescription": "This property shall contain the available OEM-specific actions for this Resource.",
+                    "versionAdded": "v1_2_0"
+                }
+            },
+            "type": "object"
+        },
+        "Links": {
+            "additionalProperties": false,
+            "description": "The links to other Resources that are related to this Resource.",
+            "longDescription": "The Redfish Specification-described type shall contain links to Resources related to but not subordinate to this Resource.",
+            "patternProperties": {
+                "^([a-zA-Z_][a-zA-Z0-9_]*)?@(odata|Redfish|Message)\\.[a-zA-Z_][a-zA-Z0-9_]*$": {
+                    "description": "This property shall specify a valid odata or Redfish property.",
+                    "type": [
+                        "array",
+                        "boolean",
+                        "integer",
+                        "number",
+                        "null",
+                        "object",
+                        "string"
+                    ]
+                }
+            },
+            "properties": {
+                "MediaControllers": {
+                    "description": "An array of links to the media controllers for this memory domain.",
+                    "items": {
+                        "$ref": "http://redfish.dmtf.org/schemas/v1/MediaController.json#/definitions/MediaController"
+                    },
+                    "longDescription": "This property shall contain an array of links to Resources of type MediaController that are associated with this memory domain.",
+                    "readonly": true,
+                    "type": "array",
+                    "versionAdded": "v1_3_0"
+                },
+                "MediaControllers@odata.count": {
+                    "$ref": "http://redfish.dmtf.org/schemas/v1/odata-v4.json#/definitions/count"
+                },
+                "Oem": {
+                    "$ref": "http://redfish.dmtf.org/schemas/v1/Resource.json#/definitions/Oem",
+                    "description": "The OEM extension property.",
+                    "longDescription": "This property shall contain the OEM extensions.  All values for properties contained in this object shall conform to the Redfish Specification-described requirements."
+                }
+            },
+            "type": "object"
+        },
+        "MemoryDomain": {
+            "additionalProperties": false,
+            "description": "The MemoryDomain schema describes a memory domain and its configuration.  Memory domains indicate to the client which memory, or DIMMs, can be grouped together in memory chunks to represent addressable memory.",
+            "longDescription": "This Resource shall represent memory domains in a Redfish implementation.",
+            "patternProperties": {
+                "^([a-zA-Z_][a-zA-Z0-9_]*)?@(odata|Redfish|Message)\\.[a-zA-Z_][a-zA-Z0-9_]*$": {
+                    "description": "This property shall specify a valid odata or Redfish property.",
+                    "type": [
+                        "array",
+                        "boolean",
+                        "integer",
+                        "number",
+                        "null",
+                        "object",
+                        "string"
+                    ]
+                }
+            },
+            "properties": {
+                "@odata.context": {
+                    "$ref": "http://redfish.dmtf.org/schemas/v1/odata-v4.json#/definitions/context"
+                },
+                "@odata.etag": {
+                    "$ref": "http://redfish.dmtf.org/schemas/v1/odata-v4.json#/definitions/etag"
+                },
+                "@odata.id": {
+                    "$ref": "http://redfish.dmtf.org/schemas/v1/odata-v4.json#/definitions/id"
+                },
+                "@odata.type": {
+                    "$ref": "http://redfish.dmtf.org/schemas/v1/odata-v4.json#/definitions/type"
+                },
+                "Actions": {
+                    "$ref": "#/definitions/Actions",
+                    "description": "The available actions for this Resource.",
+                    "longDescription": "This property shall contain the available actions for this Resource.",
+                    "versionAdded": "v1_2_0"
+                },
+                "AllowsBlockProvisioning": {
+                    "description": "An indication of whether this memory domain supports the provisioning of blocks of memory.",
+                    "longDescription": "This property shall indicate whether this memory domain supports the creation of blocks of memory.",
+                    "readonly": true,
+                    "type": [
+                        "boolean",
+                        "null"
+                    ]
+                },
+                "AllowsMemoryChunkCreation": {
+                    "description": "An indication of whether this memory domain supports the creation of memory chunks.",
+                    "longDescription": "This property shall indicate whether this memory domain supports the creation of memory chunks.",
+                    "readonly": true,
+                    "type": [
+                        "boolean",
+                        "null"
+                    ]
+                },
+                "AllowsMirroring": {
+                    "description": "An indication of whether this memory domain supports the creation of memory chunks with mirroring enabled.",
+                    "longDescription": "This property shall indicate whether this memory domain supports the creation of memory chunks with mirroring enabled.",
+                    "readonly": true,
+                    "type": [
+                        "boolean",
+                        "null"
+                    ],
+                    "versionAdded": "v1_1_0"
+                },
+                "AllowsSparing": {
+                    "description": "An indication of whether this memory domain supports the creation of memory chunks with sparing enabled.",
+                    "longDescription": "This property shall indicate whether this memory domain supports the creation of memory chunks with sparing enabled.",
+                    "readonly": true,
+                    "type": [
+                        "boolean",
+                        "null"
+                    ],
+                    "versionAdded": "v1_1_0"
+                },
+                "Description": {
+                    "anyOf": [
+                        {
+                            "$ref": "http://redfish.dmtf.org/schemas/v1/Resource.json#/definitions/Description"
+                        },
+                        {
+                            "type": "null"
+                        }
+                    ],
+                    "readonly": true
+                },
+                "Id": {
+                    "$ref": "http://redfish.dmtf.org/schemas/v1/Resource.json#/definitions/Id",
+                    "readonly": true
+                },
+                "InterleavableMemorySets": {
+                    "description": "The interleave sets for the memory chunk.",
+                    "items": {
+                        "$ref": "#/definitions/MemorySet"
+                    },
+                    "longDescription": "This property shall represent the interleave sets for the memory chunk.",
+                    "type": "array"
+                },
+                "Links": {
+                    "$ref": "#/definitions/Links",
+                    "description": "The links to other Resources that are related to this Resource.",
+                    "longDescription": "The Redfish Specification-described Links Property shall contain links to Resources related to but not subordinate to this Resource.",
+                    "versionAdded": "v1_3_0"
+                },
+                "MemoryChunks": {
+                    "$ref": "http://redfish.dmtf.org/schemas/v1/MemoryChunksCollection.json#/definitions/MemoryChunksCollection",
+                    "description": "The link to the collection of memory chunks associated with this memory domain.",
+                    "longDescription": "This property shall contain a link to a Resource Collection of type MemoryChunkCollection.",
+                    "readonly": true
+                },
+                "Name": {
+                    "$ref": "http://redfish.dmtf.org/schemas/v1/Resource.json#/definitions/Name",
+                    "readonly": true
+                },
+                "Oem": {
+                    "$ref": "http://redfish.dmtf.org/schemas/v1/Resource.json#/definitions/Oem",
+                    "description": "The OEM extension property.",
+                    "longDescription": "This property shall contain the OEM extensions.  All values for properties that this object contains shall conform to the Redfish Specification-described requirements."
+                }
+            },
+            "required": [
+                "@odata.id",
+                "@odata.type",
+                "Id",
+                "Name"
+            ],
+            "type": "object"
+        },
+        "MemorySet": {
+            "additionalProperties": false,
+            "description": "The interleave sets for a memory chunk.",
+            "longDescription": "This type shall represent the interleave sets for a memory chunk.",
+            "patternProperties": {
+                "^([a-zA-Z_][a-zA-Z0-9_]*)?@(odata|Redfish|Message)\\.[a-zA-Z_][a-zA-Z0-9_]*$": {
+                    "description": "This property shall specify a valid odata or Redfish property.",
+                    "type": [
+                        "array",
+                        "boolean",
+                        "integer",
+                        "number",
+                        "null",
+                        "object",
+                        "string"
+                    ]
+                }
+            },
+            "properties": {
+                "MemorySet": {
+                    "description": "The set of memory for a particular interleave set.",
+                    "items": {
+                        "$ref": "http://redfish.dmtf.org/schemas/v1/Memory.json#/definitions/Memory"
+                    },
+                    "longDescription": "The values in this array shall be links to Resources of the Memory type.",
+                    "readonly": true,
+                    "type": "array"
+                },
+                "MemorySet@odata.count": {
+                    "$ref": "http://redfish.dmtf.org/schemas/v1/odata-v4.json#/definitions/count"
+                }
+            },
+            "type": "object"
+        },
+        "OemActions": {
+            "additionalProperties": true,
+            "description": "The available OEM-specific actions for this Resource.",
+            "longDescription": "This type shall contain the available OEM-specific actions for this Resource.",
+            "patternProperties": {
+                "^([a-zA-Z_][a-zA-Z0-9_]*)?@(odata|Redfish|Message)\\.[a-zA-Z_][a-zA-Z0-9_]*$": {
+                    "description": "This property shall specify a valid odata or Redfish property.",
+                    "type": [
+                        "array",
+                        "boolean",
+                        "integer",
+                        "number",
+                        "null",
+                        "object",
+                        "string"
+                    ]
+                }
+            },
+            "properties": {},
+            "type": "object"
+        }
+    },
+    "owningEntity": "DMTF",
+    "release": "2019.4",
+    "title": "#MemoryDomain.v1_3_0.MemoryDomain"
+}

--- a/static/redfish/v1/JsonSchemas/MemoryDomain/index.json
+++ b/static/redfish/v1/JsonSchemas/MemoryDomain/index.json
@@ -1,0 +1,21 @@
+{
+    "@odata.context": "/redfish/v1/$metadata#JsonSchemaFile.JsonSchemaFile",
+    "@odata.id": "/redfish/v1/JsonSchemas/MemoryDomain",
+    "@odata.type": "#JsonSchemaFile.v1_0_2.JsonSchemaFile",
+    "Name": "MemoryDomain Schema File",
+    "Schema": "#MemoryDomain.MemoryDomain",
+    "Description": "MemoryDomain Schema File Location",
+    "Id": "MemoryDomain",
+    "Languages": [
+        "en"
+    ],
+    "Languages@odata.count": 1,
+    "Location": [
+        {
+            "Language": "en",
+            "PublicationUri": "http://redfish.dmtf.org/schemas/v1/MemoryDomain.json",
+            "Uri": "/redfish/v1/JsonSchemas/MemoryDomain/MemoryDomain.json"
+        }
+    ],
+    "Location@odata.count": 1
+}

--- a/static/redfish/v1/JsonSchemas/MemoryMetrics/MemoryMetrics.json
+++ b/static/redfish/v1/JsonSchemas/MemoryMetrics/MemoryMetrics.json
@@ -1,0 +1,473 @@
+{
+    "$id": "http://redfish.dmtf.org/schemas/v1/MemoryMetrics.v1_4_1.json",
+    "$ref": "#/definitions/MemoryMetrics",
+    "$schema": "http://redfish.dmtf.org/schemas/v1/redfish-schema-v1.json",
+    "copyright": "Copyright 2014-2020 DMTF. For the full DMTF copyright policy, see http://www.dmtf.org/about/policies/copyright",
+    "definitions": {
+        "Actions": {
+            "additionalProperties": false,
+            "description": "The available actions for this resource.",
+            "longDescription": "This type shall contain the available actions for this resource.",
+            "patternProperties": {
+                "^([a-zA-Z_][a-zA-Z0-9_]*)?@(odata|Redfish|Message)\\.[a-zA-Z_][a-zA-Z0-9_]*$": {
+                    "description": "This property shall specify a valid odata or Redfish property.",
+                    "type": [
+                        "array",
+                        "boolean",
+                        "integer",
+                        "number",
+                        "null",
+                        "object",
+                        "string"
+                    ]
+                }
+            },
+            "properties": {
+                "#MemoryMetrics.ClearCurrentPeriod": {
+                    "$ref": "#/definitions/ClearCurrentPeriod"
+                },
+                "Oem": {
+                    "$ref": "#/definitions/OemActions",
+                    "description": "The available OEM-specific actions for this resource.",
+                    "longDescription": "This property shall contain the available OEM-specific actions for this resource."
+                }
+            },
+            "type": "object"
+        },
+        "AlarmTrips": {
+            "additionalProperties": false,
+            "description": "The alarm trip information about the memory.  These alarms are reset when the system resets.  Note that if they are re-discovered they can be reasserted.",
+            "longDescription": "This type shall contain properties that describe the types of alarms that have been raised by the memory.  These alarms shall be reset when the system resets.  Note that if they are re-discovered they can be reasserted.",
+            "patternProperties": {
+                "^([a-zA-Z_][a-zA-Z0-9_]*)?@(odata|Redfish|Message)\\.[a-zA-Z_][a-zA-Z0-9_]*$": {
+                    "description": "This property shall specify a valid odata or Redfish property.",
+                    "type": [
+                        "array",
+                        "boolean",
+                        "integer",
+                        "number",
+                        "null",
+                        "object",
+                        "string"
+                    ]
+                }
+            },
+            "properties": {
+                "AddressParityError": {
+                    "description": "An indication of whether an address parity error was detected that a retry could not correct.",
+                    "longDescription": "This property shall indicate whether an address parity error was detected that a retry could not correct.",
+                    "readonly": true,
+                    "type": [
+                        "boolean",
+                        "null"
+                    ]
+                },
+                "CorrectableECCError": {
+                    "description": "An indication of whether the correctable error threshold crossing alarm trip was detected.",
+                    "longDescription": "This property shall indicate whether the correctable error threshold crossing alarm trip was detected.",
+                    "readonly": true,
+                    "type": [
+                        "boolean",
+                        "null"
+                    ]
+                },
+                "SpareBlock": {
+                    "description": "An indication of whether the spare block capacity crossing alarm trip was detected.",
+                    "longDescription": "This property shall indicate whether the spare block capacity crossing alarm trip was detected.",
+                    "readonly": true,
+                    "type": [
+                        "boolean",
+                        "null"
+                    ]
+                },
+                "Temperature": {
+                    "description": "An indication of whether a temperature threshold alarm trip was detected.",
+                    "longDescription": "This property shall indicates whether a temperature threshold alarm trip was detected.",
+                    "readonly": true,
+                    "type": [
+                        "boolean",
+                        "null"
+                    ]
+                },
+                "UncorrectableECCError": {
+                    "description": "An indication of whether the uncorrectable error threshold alarm trip was detected.",
+                    "longDescription": "This property shall indicate whether the uncorrectable error threshold alarm trip was detected.",
+                    "readonly": true,
+                    "type": [
+                        "boolean",
+                        "null"
+                    ]
+                }
+            },
+            "type": "object"
+        },
+        "ClearCurrentPeriod": {
+            "additionalProperties": false,
+            "description": "This action sets the CurrentPeriod property's values to 0.",
+            "longDescription": "This action shall set the CurrentPeriod property's values to 0.",
+            "parameters": {},
+            "patternProperties": {
+                "^([a-zA-Z_][a-zA-Z0-9_]*)?@(odata|Redfish|Message)\\.[a-zA-Z_][a-zA-Z0-9_]*$": {
+                    "description": "This property shall specify a valid odata or Redfish property.",
+                    "type": [
+                        "array",
+                        "boolean",
+                        "integer",
+                        "number",
+                        "null",
+                        "object",
+                        "string"
+                    ]
+                }
+            },
+            "properties": {
+                "target": {
+                    "description": "Link to invoke action",
+                    "format": "uri-reference",
+                    "type": "string"
+                },
+                "title": {
+                    "description": "Friendly action name",
+                    "type": "string"
+                }
+            },
+            "type": "object"
+        },
+        "CurrentPeriod": {
+            "additionalProperties": false,
+            "description": "The memory metrics since the last system reset or ClearCurrentPeriod action.",
+            "longDescription": "This type shall describe the memory metrics since last system reset or ClearCurrentPeriod action.",
+            "patternProperties": {
+                "^([a-zA-Z_][a-zA-Z0-9_]*)?@(odata|Redfish|Message)\\.[a-zA-Z_][a-zA-Z0-9_]*$": {
+                    "description": "This property shall specify a valid odata or Redfish property.",
+                    "type": [
+                        "array",
+                        "boolean",
+                        "integer",
+                        "number",
+                        "null",
+                        "object",
+                        "string"
+                    ]
+                }
+            },
+            "properties": {
+                "BlocksRead": {
+                    "description": "The number of blocks read since reset.",
+                    "longDescription": "This property shall contain the number of blocks read since reset.  When this resource is subordinate to the MemorySummary object, this property shall be the sum of BlocksRead over all memory.",
+                    "readonly": true,
+                    "type": [
+                        "integer",
+                        "null"
+                    ]
+                },
+                "BlocksWritten": {
+                    "description": "The number of blocks written since reset.",
+                    "longDescription": "This property shall contain the number of blocks written since reset.  When this resource is subordinate to the MemorySummary object, this property shall be the sum of BlocksWritten over all memory.",
+                    "readonly": true,
+                    "type": [
+                        "integer",
+                        "null"
+                    ]
+                },
+                "CorrectableECCErrorCount": {
+                    "description": "The number of the correctable errors since reset.",
+                    "longDescription": "This property shall contain the number of correctable errors since reset.  When this resource is subordinate to the MemorySummary object, this property shall be the sum of CorrectableECCErrorCount over all memory.",
+                    "readonly": true,
+                    "type": [
+                        "integer",
+                        "null"
+                    ],
+                    "versionAdded": "v1_4_0"
+                },
+                "UncorrectableECCErrorCount": {
+                    "description": "The number of the uncorrectable errors since reset.",
+                    "longDescription": "This property shall contain the number of uncorrectable errors since reset.  When this resource is subordinate to the MemorySummary object, this property shall be the sum of UncorrectableECCErrorCount over all memory.",
+                    "readonly": true,
+                    "type": [
+                        "integer",
+                        "null"
+                    ],
+                    "versionAdded": "v1_4_0"
+                }
+            },
+            "type": "object"
+        },
+        "HealthData": {
+            "additionalProperties": false,
+            "description": "The health information of the memory.",
+            "longDescription": "This type shall contain properties that describe the HealthData metrics for this resource.",
+            "patternProperties": {
+                "^([a-zA-Z_][a-zA-Z0-9_]*)?@(odata|Redfish|Message)\\.[a-zA-Z_][a-zA-Z0-9_]*$": {
+                    "description": "This property shall specify a valid odata or Redfish property.",
+                    "type": [
+                        "array",
+                        "boolean",
+                        "integer",
+                        "number",
+                        "null",
+                        "object",
+                        "string"
+                    ]
+                }
+            },
+            "properties": {
+                "AlarmTrips": {
+                    "$ref": "#/definitions/AlarmTrips",
+                    "description": "Alarm trip information about the memory.",
+                    "longDescription": "This object shall contain properties describe the types of alarms that have been raised by the memory.  When this resource is subordinate to the MemorySummary object, this property shall indicate whether an alarm of a given type have been raised by any area of memory."
+                },
+                "DataLossDetected": {
+                    "description": "An indication of whether data loss was detected.",
+                    "longDescription": "This property shall indicate whether data loss was detected.  When this resource is subordinate to the MemorySummary object, this property shall indicate whether any data loss was detected in any area of memory.",
+                    "readonly": true,
+                    "type": [
+                        "boolean",
+                        "null"
+                    ]
+                },
+                "LastShutdownSuccess": {
+                    "description": "An indication of whether the last shutdown succeeded.",
+                    "longDescription": "This property shall indicate whether the last shutdown succeeded.",
+                    "readonly": true,
+                    "type": [
+                        "boolean",
+                        "null"
+                    ]
+                },
+                "PerformanceDegraded": {
+                    "description": "An indication of whether performance has degraded.",
+                    "longDescription": "This property shall indicate whether performance has degraded.  When this resource is subordinate to the MemorySummary object, this property shall indicate whether degraded performance mode status is detected in any area of memory.",
+                    "readonly": true,
+                    "type": [
+                        "boolean",
+                        "null"
+                    ]
+                },
+                "PredictedMediaLifeLeftPercent": {
+                    "description": "The percentage of reads and writes that are predicted to still be available for the media.",
+                    "longDescription": "This property shall contain an indicator of the percentage of life remaining in the media.",
+                    "readonly": true,
+                    "type": [
+                        "number",
+                        "null"
+                    ],
+                    "units": "%",
+                    "versionAdded": "v1_1_0"
+                },
+                "RemainingSpareBlockPercentage": {
+                    "description": "The remaining spare blocks, as a percentage.",
+                    "longDescription": "This property shall contain the remaining spare blocks as a percentage.  When this resource is subordinate to the MemorySummary object, this property shall be the RemainingSpareBlockPercentage over all memory.",
+                    "readonly": true,
+                    "type": [
+                        "number",
+                        "null"
+                    ],
+                    "units": "%"
+                }
+            },
+            "type": "object"
+        },
+        "LifeTime": {
+            "additionalProperties": false,
+            "description": "The memory metrics for the lifetime of the memory.",
+            "longDescription": "This type shall describe the memory metrics since manufacturing.",
+            "patternProperties": {
+                "^([a-zA-Z_][a-zA-Z0-9_]*)?@(odata|Redfish|Message)\\.[a-zA-Z_][a-zA-Z0-9_]*$": {
+                    "description": "This property shall specify a valid odata or Redfish property.",
+                    "type": [
+                        "array",
+                        "boolean",
+                        "integer",
+                        "number",
+                        "null",
+                        "object",
+                        "string"
+                    ]
+                }
+            },
+            "properties": {
+                "BlocksRead": {
+                    "description": "The number of blocks read for the lifetime of the memory.",
+                    "longDescription": "This property shall contain the number of blocks read for the lifetime of the memory.  When this resource is subordinate to the MemorySummary object, this property shall be the sum of BlocksRead over all memory.",
+                    "readonly": true,
+                    "type": [
+                        "integer",
+                        "null"
+                    ]
+                },
+                "BlocksWritten": {
+                    "description": "The number of blocks written for the lifetime of the memory.",
+                    "longDescription": "This property shall contain the number of blocks written for the lifetime of the memory.  When this resource is subordinate to the MemorySummary object, this property shall be the sum of BlocksWritten over all memory.",
+                    "readonly": true,
+                    "type": [
+                        "integer",
+                        "null"
+                    ]
+                },
+                "CorrectableECCErrorCount": {
+                    "description": "The number of the correctable errors for the lifetime of the memory.",
+                    "longDescription": "This property shall contain the number of the correctable errors for the lifetime of the memory.  When this resource is subordinate to the MemorySummary object, this property shall be the sum of CorrectableECCErrorCount over all memory.",
+                    "readonly": true,
+                    "type": [
+                        "integer",
+                        "null"
+                    ],
+                    "versionAdded": "v1_4_0"
+                },
+                "UncorrectableECCErrorCount": {
+                    "description": "The number of the uncorrectable errors for the lifetime of the memory.",
+                    "longDescription": "This property shall contain the number of the uncorrectable errors for the lifetime of the memory.  When this resource is subordinate to the MemorySummary object, this property shall be the sum of UncorrectableECCErrorCount over all memory.",
+                    "readonly": true,
+                    "type": [
+                        "integer",
+                        "null"
+                    ],
+                    "versionAdded": "v1_4_0"
+                }
+            },
+            "type": "object"
+        },
+        "MemoryMetrics": {
+            "additionalProperties": false,
+            "description": "The usage and health statistics for a memory device or system memory summary.",
+            "longDescription": "The MemoryMetrics schema shall contain the memory metrics for a memory device or system memory summary in a Redfish implementation.",
+            "patternProperties": {
+                "^([a-zA-Z_][a-zA-Z0-9_]*)?@(odata|Redfish|Message)\\.[a-zA-Z_][a-zA-Z0-9_]*$": {
+                    "description": "This property shall specify a valid odata or Redfish property.",
+                    "type": [
+                        "array",
+                        "boolean",
+                        "integer",
+                        "number",
+                        "null",
+                        "object",
+                        "string"
+                    ]
+                }
+            },
+            "properties": {
+                "@odata.context": {
+                    "$ref": "http://redfish.dmtf.org/schemas/v1/odata-v4.json#/definitions/context"
+                },
+                "@odata.etag": {
+                    "$ref": "http://redfish.dmtf.org/schemas/v1/odata-v4.json#/definitions/etag"
+                },
+                "@odata.id": {
+                    "$ref": "http://redfish.dmtf.org/schemas/v1/odata-v4.json#/definitions/id"
+                },
+                "@odata.type": {
+                    "$ref": "http://redfish.dmtf.org/schemas/v1/odata-v4.json#/definitions/type"
+                },
+                "Actions": {
+                    "$ref": "#/definitions/Actions",
+                    "description": "The available actions for this resource.",
+                    "longDescription": "This property shall contain the available actions for this resource."
+                },
+                "BandwidthPercent": {
+                    "description": "The memory bandwidth utilization as a percentage.",
+                    "longDescription": "This property shall contain memory bandwidth utilization as a percentage.  When this resource is subordinate to the MemorySummary object, this property shall be the memory bandwidth utilization over all memory as a percentage.",
+                    "minimum": 0,
+                    "readonly": true,
+                    "type": [
+                        "number",
+                        "null"
+                    ],
+                    "units": "%",
+                    "versionAdded": "v1_2_0"
+                },
+                "BlockSizeBytes": {
+                    "description": "The block size, in bytes.",
+                    "longDescription": "This property shall contain the block size, in bytes, of all structure elements.  When this resource is subordinate to the MemorySummary object, this property is not applicable.",
+                    "readonly": true,
+                    "type": [
+                        "integer",
+                        "null"
+                    ],
+                    "units": "By"
+                },
+                "CurrentPeriod": {
+                    "$ref": "#/definitions/CurrentPeriod",
+                    "description": "The memory metrics since the last reset or ClearCurrentPeriod action.",
+                    "longDescription": "This property shall contain properties that describe the memory metrics for the current period."
+                },
+                "Description": {
+                    "anyOf": [
+                        {
+                            "$ref": "http://redfish.dmtf.org/schemas/v1/Resource.json#/definitions/Description"
+                        },
+                        {
+                            "type": "null"
+                        }
+                    ],
+                    "readonly": true
+                },
+                "HealthData": {
+                    "$ref": "#/definitions/HealthData",
+                    "description": "The health information of the memory.",
+                    "longDescription": "This property shall contain properties that describe the health data memory metrics for the memory."
+                },
+                "Id": {
+                    "$ref": "http://redfish.dmtf.org/schemas/v1/Resource.json#/definitions/Id",
+                    "readonly": true
+                },
+                "LifeTime": {
+                    "$ref": "#/definitions/LifeTime",
+                    "description": "The memory metrics for the lifetime of the memory.",
+                    "longDescription": "This property shall contain properties that describe the memory metrics for the lifetime of the memory."
+                },
+                "Name": {
+                    "$ref": "http://redfish.dmtf.org/schemas/v1/Resource.json#/definitions/Name",
+                    "readonly": true
+                },
+                "Oem": {
+                    "$ref": "http://redfish.dmtf.org/schemas/v1/Resource.json#/definitions/Oem",
+                    "description": "The OEM extension property.",
+                    "longDescription": "This property shall contain the OEM extensions.  All values for properties that this object contains shall conform to the Redfish Specification-described requirements."
+                },
+                "OperatingSpeedMHz": {
+                    "description": "Operating speed of memory in MHz or MT/s as appropriate.",
+                    "longDescription": "This property shall contain the operating speed of memory in MHz or MT/s (mega-transfers per second) as reported by the memory device.  Memory devices that operate at their bus speed shall report the operating speed in MHz (bus speed), while memory devices that transfer data faster than their bus speed, such as DDR memory, shall report the operating speed in MT/s (mega-transfers/second).  The reported value shall match the conventionally reported values for the technology used by the memory device.",
+                    "readonly": true,
+                    "type": [
+                        "integer",
+                        "null"
+                    ],
+                    "units": "MHz",
+                    "versionAdded": "v1_3_0"
+                }
+            },
+            "required": [
+                "@odata.id",
+                "@odata.type",
+                "Id",
+                "Name"
+            ],
+            "type": "object"
+        },
+        "OemActions": {
+            "additionalProperties": true,
+            "description": "The available OEM-specific actions for this resource.",
+            "longDescription": "This type shall contain the available OEM-specific actions for this resource.",
+            "patternProperties": {
+                "^([a-zA-Z_][a-zA-Z0-9_]*)?@(odata|Redfish|Message)\\.[a-zA-Z_][a-zA-Z0-9_]*$": {
+                    "description": "This property shall specify a valid odata or Redfish property.",
+                    "type": [
+                        "array",
+                        "boolean",
+                        "integer",
+                        "number",
+                        "null",
+                        "object",
+                        "string"
+                    ]
+                }
+            },
+            "properties": {},
+            "type": "object"
+        }
+    },
+    "owningEntity": "DMTF",
+    "release": "2020.3",
+    "title": "#MemoryMetrics.v1_4_1.MemoryMetrics"
+}

--- a/static/redfish/v1/JsonSchemas/MemoryMetrics/index.json
+++ b/static/redfish/v1/JsonSchemas/MemoryMetrics/index.json
@@ -1,0 +1,21 @@
+{
+    "@odata.context": "/redfish/v1/$metadata#JsonSchemaFile.JsonSchemaFile",
+    "@odata.id": "/redfish/v1/JsonSchemas/MemoryMetrics",
+    "@odata.type": "#JsonSchemaFile.v1_0_2.JsonSchemaFile",
+    "Name": "MemoryMetrics Schema File",
+    "Schema": "#MemoryMetrics.MemoryMetrics",
+    "Description": "MemoryMetrics Schema File Location",
+    "Id": "MemoryMetrics",
+    "Languages": [
+        "en"
+    ],
+    "Languages@odata.count": 1,
+    "Location": [
+        {
+            "Language": "en",
+            "PublicationUri": "http://redfish.dmtf.org/schemas/v1/MemoryMetrics.json",
+            "Uri": "/redfish/v1/JsonSchemas/MemoryMetrics/MemoryMetrics.json"
+        }
+    ],
+    "Location@odata.count": 1
+}

--- a/static/redfish/v1/JsonSchemas/NetworkAdapter/NetworkAdapter.json
+++ b/static/redfish/v1/JsonSchemas/NetworkAdapter/NetworkAdapter.json
@@ -1,0 +1,741 @@
+{
+    "$id": "http://redfish.dmtf.org/schemas/v1/NetworkAdapter.v1_8_0.json",
+    "$ref": "#/definitions/NetworkAdapter",
+    "$schema": "http://redfish.dmtf.org/schemas/v1/redfish-schema-v1.json",
+    "copyright": "Copyright 2014-2021 DMTF. For the full DMTF copyright policy, see http://www.dmtf.org/about/policies/copyright",
+    "definitions": {
+        "Actions": {
+            "additionalProperties": false,
+            "description": "The available actions for this resource.",
+            "longDescription": "This type shall contain the available actions for this resource.",
+            "patternProperties": {
+                "^([a-zA-Z_][a-zA-Z0-9_]*)?@(odata|Redfish|Message)\\.[a-zA-Z_][a-zA-Z0-9_]*$": {
+                    "description": "This property shall specify a valid odata or Redfish property.",
+                    "type": [
+                        "array",
+                        "boolean",
+                        "integer",
+                        "number",
+                        "null",
+                        "object",
+                        "string"
+                    ]
+                }
+            },
+            "properties": {
+                "#NetworkAdapter.ResetSettingsToDefault": {
+                    "$ref": "#/definitions/ResetSettingsToDefault"
+                },
+                "Oem": {
+                    "$ref": "#/definitions/OemActions",
+                    "description": "The available OEM-specific actions for this resource.",
+                    "longDescription": "This property shall contain the available OEM-specific actions for this resource."
+                }
+            },
+            "type": "object"
+        },
+        "ControllerCapabilities": {
+            "additionalProperties": false,
+            "description": "The capabilities of a controller.",
+            "longDescription": "This type shall describe the capabilities of a controller.",
+            "patternProperties": {
+                "^([a-zA-Z_][a-zA-Z0-9_]*)?@(odata|Redfish|Message)\\.[a-zA-Z_][a-zA-Z0-9_]*$": {
+                    "description": "This property shall specify a valid odata or Redfish property.",
+                    "type": [
+                        "array",
+                        "boolean",
+                        "integer",
+                        "number",
+                        "null",
+                        "object",
+                        "string"
+                    ]
+                }
+            },
+            "properties": {
+                "DataCenterBridging": {
+                    "$ref": "#/definitions/DataCenterBridging",
+                    "description": "Data center bridging (DCB) for this controller.",
+                    "longDescription": "This property shall contain capability, status, and configuration values related to data center bridging (DCB) for this controller."
+                },
+                "NPAR": {
+                    "$ref": "#/definitions/NicPartitioning",
+                    "description": "NIC Partitioning (NPAR) capabilities for this controller.",
+                    "longDescription": "This property shall contain capability, status, and configuration values related to NIC partitioning for this controller.",
+                    "versionAdded": "v1_2_0"
+                },
+                "NPIV": {
+                    "$ref": "#/definitions/NPIV",
+                    "description": "N_Port ID Virtualization (NPIV) capabilities for this controller.",
+                    "longDescription": "This property shall contain N_Port ID Virtualization (NPIV) capabilities for this controller."
+                },
+                "NetworkDeviceFunctionCount": {
+                    "description": "The maximum number of physical functions available on this controller.",
+                    "longDescription": "This property shall contain the number of physical functions available on this controller.",
+                    "readonly": true,
+                    "type": [
+                        "integer",
+                        "null"
+                    ]
+                },
+                "NetworkPortCount": {
+                    "description": "The number of physical ports on this controller.",
+                    "longDescription": "This property shall contain the number of physical ports on this controller.",
+                    "readonly": true,
+                    "type": [
+                        "integer",
+                        "null"
+                    ]
+                },
+                "VirtualizationOffload": {
+                    "$ref": "#/definitions/VirtualizationOffload",
+                    "description": "Virtualization offload for this controller.",
+                    "longDescription": "This property shall contain capability, status, and configuration values related to virtualization offload for this controller."
+                }
+            },
+            "type": "object"
+        },
+        "ControllerLinks": {
+            "additionalProperties": false,
+            "description": "The links to other resources that are related to this resource.",
+            "longDescription": "This Redfish Specification-described type shall contain links to resources that are related to but are not contained by, or subordinate to, this resource.",
+            "patternProperties": {
+                "^([a-zA-Z_][a-zA-Z0-9_]*)?@(odata|Redfish|Message)\\.[a-zA-Z_][a-zA-Z0-9_]*$": {
+                    "description": "This property shall specify a valid odata or Redfish property.",
+                    "type": [
+                        "array",
+                        "boolean",
+                        "integer",
+                        "number",
+                        "null",
+                        "object",
+                        "string"
+                    ]
+                }
+            },
+            "properties": {
+                "NetworkDeviceFunctions": {
+                    "description": "An array of links to the network device functions associated with this network controller.",
+                    "items": {
+                        "$ref": "http://redfish.dmtf.org/schemas/v1/NetworkDeviceFunction.json#/definitions/NetworkDeviceFunction"
+                    },
+                    "longDescription": "This property shall contain an array of links to resources of type NetworkDeviceFunction that represent the network device functions associated with this network controller.",
+                    "readonly": true,
+                    "type": "array"
+                },
+                "NetworkDeviceFunctions@odata.count": {
+                    "$ref": "http://redfish.dmtf.org/schemas/v1/odata-v4.json#/definitions/count"
+                },
+                "NetworkPorts": {
+                    "deprecated": "This property has been deprecated in favor of the Ports property.",
+                    "description": "An array of links to the network ports associated with this network controller.",
+                    "items": {
+                        "$ref": "http://redfish.dmtf.org/schemas/v1/NetworkPort.json#/definitions/NetworkPort"
+                    },
+                    "longDescription": "This property shall contain an array of links to resources of type NetworkPort that represent the network ports associated with this network controller.",
+                    "readonly": true,
+                    "type": "array",
+                    "versionDeprecated": "v1_5_0"
+                },
+                "NetworkPorts@odata.count": {
+                    "$ref": "http://redfish.dmtf.org/schemas/v1/odata-v4.json#/definitions/count"
+                },
+                "Oem": {
+                    "$ref": "http://redfish.dmtf.org/schemas/v1/Resource.json#/definitions/Oem",
+                    "description": "The OEM extension property.",
+                    "longDescription": "This property shall contain the OEM extensions.  All values for properties contained in this object shall conform to the Redfish Specification-described requirements."
+                },
+                "PCIeDevices": {
+                    "description": "An array of links to the PCIe devices associated with this network controller.",
+                    "items": {
+                        "$ref": "http://redfish.dmtf.org/schemas/v1/PCIeDevice.json#/definitions/PCIeDevice"
+                    },
+                    "longDescription": "This property shall contain an array of links to resources of type PCIeDevice that represent the PCIe devices associated with this network controller.",
+                    "readonly": true,
+                    "type": "array"
+                },
+                "PCIeDevices@odata.count": {
+                    "$ref": "http://redfish.dmtf.org/schemas/v1/odata-v4.json#/definitions/count"
+                },
+                "Ports": {
+                    "description": "An array of links to the ports associated with this network controller.",
+                    "items": {
+                        "$ref": "http://redfish.dmtf.org/schemas/v1/Port.json#/definitions/Port"
+                    },
+                    "longDescription": "This property shall contain an array of links to resources of type Port that represent the ports associated with this network controller.",
+                    "readonly": true,
+                    "type": "array",
+                    "versionAdded": "v1_5_0"
+                },
+                "Ports@odata.count": {
+                    "$ref": "http://redfish.dmtf.org/schemas/v1/odata-v4.json#/definitions/count"
+                }
+            },
+            "type": "object"
+        },
+        "Controllers": {
+            "additionalProperties": false,
+            "description": "A network controller ASIC that makes up part of a network adapter.",
+            "longDescription": "This type shall describe a network controller ASIC that makes up part of a network adapter.",
+            "patternProperties": {
+                "^([a-zA-Z_][a-zA-Z0-9_]*)?@(odata|Redfish|Message)\\.[a-zA-Z_][a-zA-Z0-9_]*$": {
+                    "description": "This property shall specify a valid odata or Redfish property.",
+                    "type": [
+                        "array",
+                        "boolean",
+                        "integer",
+                        "number",
+                        "null",
+                        "object",
+                        "string"
+                    ]
+                }
+            },
+            "properties": {
+                "ControllerCapabilities": {
+                    "$ref": "#/definitions/ControllerCapabilities",
+                    "description": "The capabilities of this controller.",
+                    "longDescription": "This property shall contain the capabilities of this controller."
+                },
+                "FirmwarePackageVersion": {
+                    "description": "The version of the user-facing firmware package.",
+                    "longDescription": "This property shall contain the version number of the user-facing firmware package.",
+                    "readonly": true,
+                    "type": [
+                        "string",
+                        "null"
+                    ]
+                },
+                "Identifiers": {
+                    "description": "The durable names for the network adapter controller.",
+                    "items": {
+                        "$ref": "http://redfish.dmtf.org/schemas/v1/Resource.json#/definitions/Identifier"
+                    },
+                    "longDescription": "This property shall contain a list of all known durable names for the controller associated with the network adapter.",
+                    "type": "array",
+                    "versionAdded": "v1_3_0"
+                },
+                "Links": {
+                    "$ref": "#/definitions/ControllerLinks",
+                    "description": "The links to other resources that are related to this resource.",
+                    "longDescription": "This property shall contain links to resources that are related to but are not contained by, or subordinate to, this resource."
+                },
+                "Location": {
+                    "$ref": "http://redfish.dmtf.org/schemas/v1/Resource.json#/definitions/Location",
+                    "description": "The location of the network adapter controller.",
+                    "longDescription": "This property shall contain location information of the controller associated with the network adapter.",
+                    "versionAdded": "v1_1_0"
+                },
+                "PCIeInterface": {
+                    "$ref": "http://redfish.dmtf.org/schemas/v1/PCIeDevice.json#/definitions/PCIeInterface",
+                    "description": "The PCIe interface details for this controller.",
+                    "longDescription": "This property shall contain details for the PCIe interface that connects this PCIe-based controller to its host.",
+                    "versionAdded": "v1_2_0"
+                }
+            },
+            "type": "object"
+        },
+        "DataCenterBridging": {
+            "additionalProperties": false,
+            "description": "Data center bridging (DCB) for capabilities of a controller.",
+            "longDescription": "This type shall describe the capability, status, and configuration values related to data center bridging (DCB) for a controller.",
+            "patternProperties": {
+                "^([a-zA-Z_][a-zA-Z0-9_]*)?@(odata|Redfish|Message)\\.[a-zA-Z_][a-zA-Z0-9_]*$": {
+                    "description": "This property shall specify a valid odata or Redfish property.",
+                    "type": [
+                        "array",
+                        "boolean",
+                        "integer",
+                        "number",
+                        "null",
+                        "object",
+                        "string"
+                    ]
+                }
+            },
+            "properties": {
+                "Capable": {
+                    "description": "An indication of whether this controller is capable of data center bridging (DCB).",
+                    "longDescription": "This property shall indicate whether this controller is capable of data center bridging (DCB).",
+                    "readonly": true,
+                    "type": [
+                        "boolean",
+                        "null"
+                    ]
+                }
+            },
+            "type": "object"
+        },
+        "NPIV": {
+            "additionalProperties": false,
+            "description": "N_Port ID Virtualization (NPIV) capabilities for a controller.",
+            "longDescription": "This type shall contain N_Port ID Virtualization (NPIV) capabilities for a controller.",
+            "patternProperties": {
+                "^([a-zA-Z_][a-zA-Z0-9_]*)?@(odata|Redfish|Message)\\.[a-zA-Z_][a-zA-Z0-9_]*$": {
+                    "description": "This property shall specify a valid odata or Redfish property.",
+                    "type": [
+                        "array",
+                        "boolean",
+                        "integer",
+                        "number",
+                        "null",
+                        "object",
+                        "string"
+                    ]
+                }
+            },
+            "properties": {
+                "MaxDeviceLogins": {
+                    "description": "The maximum number of N_Port ID Virtualization (NPIV) logins allowed simultaneously from all ports on this controller.",
+                    "longDescription": "This property shall contain the maximum number of N_Port ID Virtualization (NPIV) logins allowed simultaneously from all ports on this controller.",
+                    "readonly": true,
+                    "type": [
+                        "integer",
+                        "null"
+                    ]
+                },
+                "MaxPortLogins": {
+                    "description": "The maximum number of N_Port ID Virtualization (NPIV) logins allowed per physical port on this controller.",
+                    "longDescription": "This property shall contain the maximum number of N_Port ID Virtualization (NPIV) logins allowed per physical port on this controller.",
+                    "readonly": true,
+                    "type": [
+                        "integer",
+                        "null"
+                    ]
+                }
+            },
+            "type": "object"
+        },
+        "NetworkAdapter": {
+            "additionalProperties": false,
+            "description": "The NetworkAdapter schema represents a physical network adapter capable of connecting to a computer network.  Examples include but are not limited to Ethernet, Fibre Channel, and converged network adapters.",
+            "longDescription": "This resource shall represent a physical network adapter capable of connecting to a computer network in a Redfish implementation.",
+            "patternProperties": {
+                "^([a-zA-Z_][a-zA-Z0-9_]*)?@(odata|Redfish|Message)\\.[a-zA-Z_][a-zA-Z0-9_]*$": {
+                    "description": "This property shall specify a valid odata or Redfish property.",
+                    "type": [
+                        "array",
+                        "boolean",
+                        "integer",
+                        "number",
+                        "null",
+                        "object",
+                        "string"
+                    ]
+                }
+            },
+            "properties": {
+                "@odata.context": {
+                    "$ref": "http://redfish.dmtf.org/schemas/v1/odata-v4.json#/definitions/context"
+                },
+                "@odata.etag": {
+                    "$ref": "http://redfish.dmtf.org/schemas/v1/odata-v4.json#/definitions/etag"
+                },
+                "@odata.id": {
+                    "$ref": "http://redfish.dmtf.org/schemas/v1/odata-v4.json#/definitions/id"
+                },
+                "@odata.type": {
+                    "$ref": "http://redfish.dmtf.org/schemas/v1/odata-v4.json#/definitions/type"
+                },
+                "Actions": {
+                    "$ref": "#/definitions/Actions",
+                    "description": "The available actions for this resource.",
+                    "longDescription": "This property shall contain the available actions for this resource."
+                },
+                "Assembly": {
+                    "$ref": "http://redfish.dmtf.org/schemas/v1/Assembly.json#/definitions/Assembly",
+                    "description": "The link to the assembly resource associated with this adapter.",
+                    "longDescription": "This property shall contain a link to a resource of type Assembly.",
+                    "readonly": true,
+                    "versionAdded": "v1_1_0"
+                },
+                "Certificates": {
+                    "$ref": "http://redfish.dmtf.org/schemas/v1/CertificateCollection.json#/definitions/CertificateCollection",
+                    "description": "The link to a collection of certificates for device identity and attestation.",
+                    "longDescription": "This property shall contain a link to a resource collection of type CertificateCollection that contains certificates for device identity and attestation.",
+                    "readonly": true,
+                    "versionAdded": "v1_6_0"
+                },
+                "Controllers": {
+                    "description": "The set of network controllers ASICs that make up this NetworkAdapter.",
+                    "items": {
+                        "$ref": "#/definitions/Controllers"
+                    },
+                    "longDescription": "This property shall contain the set of network controllers ASICs that make up this network adapter.",
+                    "type": "array"
+                },
+                "Description": {
+                    "anyOf": [
+                        {
+                            "$ref": "http://redfish.dmtf.org/schemas/v1/Resource.json#/definitions/Description"
+                        },
+                        {
+                            "type": "null"
+                        }
+                    ],
+                    "readonly": true
+                },
+                "EnvironmentMetrics": {
+                    "$ref": "http://redfish.dmtf.org/schemas/v1/EnvironmentMetrics.json#/definitions/EnvironmentMetrics",
+                    "description": "The link to the environment metrics for this network adapter.",
+                    "longDescription": "This property shall contain a link to a resource of type EnvironmentMetrics that specifies the environment metrics for this network adapter.",
+                    "readonly": true,
+                    "versionAdded": "v1_7_0"
+                },
+                "Id": {
+                    "$ref": "http://redfish.dmtf.org/schemas/v1/Resource.json#/definitions/Id",
+                    "readonly": true
+                },
+                "Identifiers": {
+                    "description": "The durable names for the network adapter.",
+                    "items": {
+                        "$ref": "http://redfish.dmtf.org/schemas/v1/Resource.json#/definitions/Identifier"
+                    },
+                    "longDescription": "This property shall contain a list of all known durable names for the network adapter.",
+                    "type": "array",
+                    "versionAdded": "v1_4_0"
+                },
+                "LLDPEnabled": {
+                    "description": "Enable or disable LLDP globally for an adapter.",
+                    "longDescription": "This property shall contain the state indicating whether LLDP is globally enabled on a network adapter.  If set to `false`, the LLDPEnabled value for the ports associated with this adapter shall be disregarded.",
+                    "readonly": false,
+                    "type": "boolean",
+                    "versionAdded": "v1_7_0"
+                },
+                "Location": {
+                    "$ref": "http://redfish.dmtf.org/schemas/v1/Resource.json#/definitions/Location",
+                    "description": "The location of the network adapter.",
+                    "longDescription": "This property shall contain location information of the network adapter.",
+                    "versionAdded": "v1_4_0"
+                },
+                "Manufacturer": {
+                    "description": "The manufacturer or OEM of this network adapter.",
+                    "longDescription": "This property shall contain a value that represents the manufacturer of the network adapter.",
+                    "readonly": true,
+                    "type": [
+                        "string",
+                        "null"
+                    ]
+                },
+                "Measurements": {
+                    "description": "An array of DSP0274-defined measurement blocks.",
+                    "items": {
+                        "$ref": "http://redfish.dmtf.org/schemas/v1/SoftwareInventory.json#/definitions/MeasurementBlock"
+                    },
+                    "longDescription": "This property shall contain an array of DSP0274-defined measurement blocks.",
+                    "type": "array",
+                    "versionAdded": "v1_6_0"
+                },
+                "Metrics": {
+                    "anyOf": [
+                        {
+                            "$ref": "http://redfish.dmtf.org/schemas/v1/NetworkAdapterMetrics.json#/definitions/NetworkAdapterMetrics"
+                        },
+                        {
+                            "type": "null"
+                        }
+                    ],
+                    "description": "The link to the metrics associated with this adapter.",
+                    "longDescription": "This property shall contain a link to a resource of type NetworkAdapterMetrics that contains the metrics associated with this adapter.",
+                    "readonly": true,
+                    "versionAdded": "v1_7_0"
+                },
+                "Model": {
+                    "description": "The model string for this network adapter.",
+                    "longDescription": "This property shall contain the information about how the manufacturer refers to this network adapter.",
+                    "readonly": true,
+                    "type": [
+                        "string",
+                        "null"
+                    ]
+                },
+                "Name": {
+                    "$ref": "http://redfish.dmtf.org/schemas/v1/Resource.json#/definitions/Name",
+                    "readonly": true
+                },
+                "NetworkDeviceFunctions": {
+                    "$ref": "http://redfish.dmtf.org/schemas/v1/NetworkDeviceFunctionCollection.json#/definitions/NetworkDeviceFunctionCollection",
+                    "description": "The link to the collection of network device functions associated with this network adapter.",
+                    "longDescription": "This property shall contain a link to a resource collection of type NetworkDeviceFunctionCollection.",
+                    "readonly": true
+                },
+                "NetworkPorts": {
+                    "$ref": "http://redfish.dmtf.org/schemas/v1/NetworkPortCollection.json#/definitions/NetworkPortCollection",
+                    "deprecated": "This property has been deprecated in favor of the Ports property.",
+                    "description": "The link to the collection of network ports associated with this network adapter.",
+                    "longDescription": "This property shall contain a link to a resource collection of type NetworkPortCollection.",
+                    "readonly": true,
+                    "versionDeprecated": "v1_5_0"
+                },
+                "Oem": {
+                    "$ref": "http://redfish.dmtf.org/schemas/v1/Resource.json#/definitions/Oem",
+                    "description": "The OEM extension property.",
+                    "longDescription": "This property shall contain the OEM extensions.  All values for properties that this object contains shall conform to the Redfish Specification-described requirements."
+                },
+                "PartNumber": {
+                    "description": "Part number for this network adapter.",
+                    "longDescription": "This property shall contain the part number for the network adapter as defined by the manufacturer.",
+                    "readonly": true,
+                    "type": [
+                        "string",
+                        "null"
+                    ]
+                },
+                "Ports": {
+                    "$ref": "http://redfish.dmtf.org/schemas/v1/PortCollection.json#/definitions/PortCollection",
+                    "description": "The link to the collection of ports associated with this network adapter.",
+                    "longDescription": "This property shall contain a link to a resource collection of type PortCollection.",
+                    "readonly": true,
+                    "versionAdded": "v1_5_0"
+                },
+                "Processors": {
+                    "$ref": "http://redfish.dmtf.org/schemas/v1/ProcessorCollection.json#/definitions/ProcessorCollection",
+                    "description": "The link to the collection of offload processors contained in this network adapter.",
+                    "longDescription": "This property shall contain a link to a resource collection of type ProcessorCollection that represent the offload processors contained in this network adapter.",
+                    "readonly": true,
+                    "versionAdded": "v1_8_0"
+                },
+                "SKU": {
+                    "description": "The manufacturer SKU for this network adapter.",
+                    "longDescription": "This property shall contain the SKU for the network adapter.",
+                    "readonly": true,
+                    "type": [
+                        "string",
+                        "null"
+                    ]
+                },
+                "SerialNumber": {
+                    "description": "The serial number for this network adapter.",
+                    "longDescription": "This property shall contain the serial number for the network adapter.",
+                    "readonly": true,
+                    "type": [
+                        "string",
+                        "null"
+                    ]
+                },
+                "Status": {
+                    "$ref": "http://redfish.dmtf.org/schemas/v1/Resource.json#/definitions/Status",
+                    "description": "The status and health of the resource and its subordinate or dependent resources.",
+                    "longDescription": "This property shall contain any status or health properties of the resource."
+                }
+            },
+            "required": [
+                "@odata.id",
+                "@odata.type",
+                "Id",
+                "Name"
+            ],
+            "type": "object"
+        },
+        "NicPartitioning": {
+            "additionalProperties": false,
+            "description": "NIC Partitioning capability, status, and configuration for a controller.",
+            "longDescription": "This type shall contain the capability, status, and configuration values for a controller.",
+            "patternProperties": {
+                "^([a-zA-Z_][a-zA-Z0-9_]*)?@(odata|Redfish|Message)\\.[a-zA-Z_][a-zA-Z0-9_]*$": {
+                    "description": "This property shall specify a valid odata or Redfish property.",
+                    "type": [
+                        "array",
+                        "boolean",
+                        "integer",
+                        "number",
+                        "null",
+                        "object",
+                        "string"
+                    ]
+                }
+            },
+            "properties": {
+                "NparCapable": {
+                    "description": "An indication of whether the controller supports NIC function partitioning.",
+                    "longDescription": "This property shall indicate whether the controller supports NIC function partitioning.",
+                    "readonly": true,
+                    "type": [
+                        "boolean",
+                        "null"
+                    ],
+                    "versionAdded": "v1_2_0"
+                },
+                "NparEnabled": {
+                    "description": "An indication of whether NIC function partitioning is active on this controller.",
+                    "longDescription": "This property shall indicate whether NIC function partitioning is active on this controller.",
+                    "readonly": false,
+                    "type": [
+                        "boolean",
+                        "null"
+                    ],
+                    "versionAdded": "v1_2_0"
+                }
+            },
+            "type": "object"
+        },
+        "OemActions": {
+            "additionalProperties": true,
+            "description": "The available OEM-specific actions for this resource.",
+            "longDescription": "This type shall contain the available OEM-specific actions for this resource.",
+            "patternProperties": {
+                "^([a-zA-Z_][a-zA-Z0-9_]*)?@(odata|Redfish|Message)\\.[a-zA-Z_][a-zA-Z0-9_]*$": {
+                    "description": "This property shall specify a valid odata or Redfish property.",
+                    "type": [
+                        "array",
+                        "boolean",
+                        "integer",
+                        "number",
+                        "null",
+                        "object",
+                        "string"
+                    ]
+                }
+            },
+            "properties": {},
+            "type": "object"
+        },
+        "ResetSettingsToDefault": {
+            "additionalProperties": false,
+            "description": "This action is to clear the settings back to factory defaults.",
+            "longDescription": "This action shall reset of all active and pending settings back to factory default settings upon reset of the network adapter.",
+            "parameters": {},
+            "patternProperties": {
+                "^([a-zA-Z_][a-zA-Z0-9_]*)?@(odata|Redfish|Message)\\.[a-zA-Z_][a-zA-Z0-9_]*$": {
+                    "description": "This property shall specify a valid odata or Redfish property.",
+                    "type": [
+                        "array",
+                        "boolean",
+                        "integer",
+                        "number",
+                        "null",
+                        "object",
+                        "string"
+                    ]
+                }
+            },
+            "properties": {
+                "target": {
+                    "description": "Link to invoke action",
+                    "format": "uri-reference",
+                    "type": "string"
+                },
+                "title": {
+                    "description": "Friendly action name",
+                    "type": "string"
+                }
+            },
+            "type": "object"
+        },
+        "SRIOV": {
+            "additionalProperties": false,
+            "description": "Single-root input/output virtualization (SR-IOV) capabilities.",
+            "longDescription": "This type shall contain single-root input/output virtualization (SR-IOV) capabilities.",
+            "patternProperties": {
+                "^([a-zA-Z_][a-zA-Z0-9_]*)?@(odata|Redfish|Message)\\.[a-zA-Z_][a-zA-Z0-9_]*$": {
+                    "description": "This property shall specify a valid odata or Redfish property.",
+                    "type": [
+                        "array",
+                        "boolean",
+                        "integer",
+                        "number",
+                        "null",
+                        "object",
+                        "string"
+                    ]
+                }
+            },
+            "properties": {
+                "SRIOVVEPACapable": {
+                    "description": "An indication of whether this controller supports single root input/output virtualization (SR-IOV) in Virtual Ethernet Port Aggregator (VEPA) mode.",
+                    "longDescription": "This property shall indicate whether this controller supports single root input/output virtualization (SR-IOV) in Virtual Ethernet Port Aggregator (VEPA) mode.",
+                    "readonly": true,
+                    "type": [
+                        "boolean",
+                        "null"
+                    ]
+                }
+            },
+            "type": "object"
+        },
+        "VirtualFunction": {
+            "additionalProperties": false,
+            "description": "A virtual function of a controller.",
+            "longDescription": "This type shall describe the capability, status, and configuration values related to a virtual function for a controller.",
+            "patternProperties": {
+                "^([a-zA-Z_][a-zA-Z0-9_]*)?@(odata|Redfish|Message)\\.[a-zA-Z_][a-zA-Z0-9_]*$": {
+                    "description": "This property shall specify a valid odata or Redfish property.",
+                    "type": [
+                        "array",
+                        "boolean",
+                        "integer",
+                        "number",
+                        "null",
+                        "object",
+                        "string"
+                    ]
+                }
+            },
+            "properties": {
+                "DeviceMaxCount": {
+                    "description": "The maximum number of virtual functions supported by this controller.",
+                    "longDescription": "This property shall contain the maximum number of virtual functions supported by this controller.",
+                    "readonly": true,
+                    "type": [
+                        "integer",
+                        "null"
+                    ]
+                },
+                "MinAssignmentGroupSize": {
+                    "description": "The minimum number of virtual functions that can be allocated or moved between physical functions for this controller.",
+                    "longDescription": "This property shall contain the minimum number of virtual functions that can be allocated or moved between physical functions for this controller.",
+                    "readonly": true,
+                    "type": [
+                        "integer",
+                        "null"
+                    ]
+                },
+                "NetworkPortMaxCount": {
+                    "description": "The maximum number of virtual functions supported per network port for this controller.",
+                    "longDescription": "This property shall contain the maximum number of virtual functions supported per network port for this controller.",
+                    "readonly": true,
+                    "type": [
+                        "integer",
+                        "null"
+                    ]
+                }
+            },
+            "type": "object"
+        },
+        "VirtualizationOffload": {
+            "additionalProperties": false,
+            "description": "A Virtualization offload capability of a controller.",
+            "longDescription": "This type shall describe the capability, status, and configuration values related to a virtualization offload for a controller.",
+            "patternProperties": {
+                "^([a-zA-Z_][a-zA-Z0-9_]*)?@(odata|Redfish|Message)\\.[a-zA-Z_][a-zA-Z0-9_]*$": {
+                    "description": "This property shall specify a valid odata or Redfish property.",
+                    "type": [
+                        "array",
+                        "boolean",
+                        "integer",
+                        "number",
+                        "null",
+                        "object",
+                        "string"
+                    ]
+                }
+            },
+            "properties": {
+                "SRIOV": {
+                    "$ref": "#/definitions/SRIOV",
+                    "description": "Single-root input/output virtualization (SR-IOV) capabilities.",
+                    "longDescription": "This property shall contain single-root input/output virtualization (SR-IOV) capabilities."
+                },
+                "VirtualFunction": {
+                    "$ref": "#/definitions/VirtualFunction",
+                    "description": "The virtual function of the controller.",
+                    "longDescription": "This property shall describe the capability, status, and configuration values related to the virtual function for this controller."
+                }
+            },
+            "type": "object"
+        }
+    },
+    "owningEntity": "DMTF",
+    "release": "2021.2",
+    "title": "#NetworkAdapter.v1_8_0.NetworkAdapter"
+}

--- a/static/redfish/v1/JsonSchemas/NetworkAdapter/index.json
+++ b/static/redfish/v1/JsonSchemas/NetworkAdapter/index.json
@@ -1,0 +1,21 @@
+{
+    "@odata.context": "/redfish/v1/$metadata#JsonSchemaFile.JsonSchemaFile",
+    "@odata.id": "/redfish/v1/JsonSchemas/NetworkAdapter",
+    "@odata.type": "#JsonSchemaFile.v1_0_2.JsonSchemaFile",
+    "Name": "NetworkAdapter Schema File",
+    "Schema": "#NetworkAdapter.NetworkAdapter",
+    "Description": "NetworkAdapter Schema File Location",
+    "Id": "NetworkAdapter",
+    "Languages": [
+        "en"
+    ],
+    "Languages@odata.count": 1,
+    "Location": [
+        {
+            "Language": "en",
+            "PublicationUri": "http://redfish.dmtf.org/schemas/v1/NetworkAdapter.json",
+            "Uri": "/redfish/v1/JsonSchemas/NetworkAdapter/NetworkAdapter.json"
+        }
+    ],
+    "Location@odata.count": 1
+}

--- a/static/redfish/v1/JsonSchemas/NetworkAdapterMetrics/NetworkAdapterMetrics.json
+++ b/static/redfish/v1/JsonSchemas/NetworkAdapterMetrics/NetworkAdapterMetrics.json
@@ -1,0 +1,255 @@
+{
+    "$id": "http://redfish.dmtf.org/schemas/v1/NetworkAdapterMetrics.v1_0_0.json",
+    "$ref": "#/definitions/NetworkAdapterMetrics",
+    "$schema": "http://redfish.dmtf.org/schemas/v1/redfish-schema-v1.json",
+    "copyright": "Copyright 2014-2021 DMTF. For the full DMTF copyright policy, see http://www.dmtf.org/about/policies/copyright",
+    "definitions": {
+        "Actions": {
+            "additionalProperties": false,
+            "description": "The available actions for this resource.",
+            "longDescription": "This type shall contain the available actions for this resource.",
+            "patternProperties": {
+                "^([a-zA-Z_][a-zA-Z0-9_]*)?@(odata|Redfish|Message)\\.[a-zA-Z_][a-zA-Z0-9_]*$": {
+                    "description": "This property shall specify a valid odata or Redfish property.",
+                    "type": [
+                        "array",
+                        "boolean",
+                        "integer",
+                        "number",
+                        "null",
+                        "object",
+                        "string"
+                    ]
+                }
+            },
+            "properties": {
+                "Oem": {
+                    "$ref": "#/definitions/OemActions",
+                    "description": "The available OEM-specific actions for this resource.",
+                    "longDescription": "This property shall contain the available OEM-specific actions for this resource."
+                }
+            },
+            "type": "object"
+        },
+        "NetworkAdapterMetrics": {
+            "additionalProperties": false,
+            "description": "The NetworkAdapterMetrics schema contains usage and health statistics for a network adapter.",
+            "longDescription": "This resource shall represent the network metrics for a single network adapter in a Redfish implementation.",
+            "patternProperties": {
+                "^([a-zA-Z_][a-zA-Z0-9_]*)?@(odata|Redfish|Message)\\.[a-zA-Z_][a-zA-Z0-9_]*$": {
+                    "description": "This property shall specify a valid odata or Redfish property.",
+                    "type": [
+                        "array",
+                        "boolean",
+                        "integer",
+                        "number",
+                        "null",
+                        "object",
+                        "string"
+                    ]
+                }
+            },
+            "properties": {
+                "@odata.context": {
+                    "$ref": "http://redfish.dmtf.org/schemas/v1/odata-v4.json#/definitions/context"
+                },
+                "@odata.etag": {
+                    "$ref": "http://redfish.dmtf.org/schemas/v1/odata-v4.json#/definitions/etag"
+                },
+                "@odata.id": {
+                    "$ref": "http://redfish.dmtf.org/schemas/v1/odata-v4.json#/definitions/id"
+                },
+                "@odata.type": {
+                    "$ref": "http://redfish.dmtf.org/schemas/v1/odata-v4.json#/definitions/type"
+                },
+                "Actions": {
+                    "$ref": "#/definitions/Actions",
+                    "description": "The available actions for this resource.",
+                    "longDescription": "This property shall contain the available actions for this resource."
+                },
+                "CPUCorePercent": {
+                    "description": "The device CPU core utilization as a percentage.",
+                    "longDescription": "This property shall contain the device CPU core utilization as a percentage.",
+                    "minimum": 0,
+                    "readonly": true,
+                    "type": [
+                        "number",
+                        "null"
+                    ],
+                    "units": "%"
+                },
+                "Description": {
+                    "anyOf": [
+                        {
+                            "$ref": "http://redfish.dmtf.org/schemas/v1/Resource.json#/definitions/Description"
+                        },
+                        {
+                            "type": "null"
+                        }
+                    ],
+                    "readonly": true
+                },
+                "HostBusRXPercent": {
+                    "description": "The host bus, such as PCIe, RX utilization as a percentage.",
+                    "longDescription": "This property shall contain the host bus, such as PCIe, RX utilization as a percentage, which is calculated by dividing the total bytes received by the theoretical max.",
+                    "minimum": 0,
+                    "readonly": true,
+                    "type": [
+                        "number",
+                        "null"
+                    ],
+                    "units": "%"
+                },
+                "HostBusTXPercent": {
+                    "description": "The host bus, such as PCIe, TX utilization as a percentage.",
+                    "longDescription": "This property shall contain the host bus, such as PCIe, TX utilization as a percentage, which is calculated by dividing the total bytes transmitted by the theoretical max.",
+                    "minimum": 0,
+                    "readonly": true,
+                    "type": [
+                        "number",
+                        "null"
+                    ],
+                    "units": "%"
+                },
+                "Id": {
+                    "$ref": "http://redfish.dmtf.org/schemas/v1/Resource.json#/definitions/Id",
+                    "readonly": true
+                },
+                "NCSIRXBytes": {
+                    "description": "The total number of NC-SI bytes received since reset.",
+                    "longDescription": "This property shall contain the total number of NC-SI bytes received since reset, including both passthrough and non-passthrough traffic.",
+                    "readonly": true,
+                    "type": [
+                        "integer",
+                        "null"
+                    ],
+                    "units": "By"
+                },
+                "NCSIRXFrames": {
+                    "description": "The total number of NC-SI frames received since reset.",
+                    "longDescription": "This property shall contain the total number of NC-SI frames received since reset, including both passthrough and non-passthrough traffic.",
+                    "readonly": true,
+                    "type": [
+                        "integer",
+                        "null"
+                    ]
+                },
+                "NCSITXBytes": {
+                    "description": "The total number of NC-SI bytes sent since reset.",
+                    "longDescription": "This property shall contain the total number of NC-SI bytes sent since reset, including both passthrough and non-passthrough traffic.",
+                    "readonly": true,
+                    "type": [
+                        "integer",
+                        "null"
+                    ],
+                    "units": "By"
+                },
+                "NCSITXFrames": {
+                    "description": "The total number of NC-SI frames sent since reset.",
+                    "longDescription": "This property shall contain the total number of NC-SI frames sent since reset, including both passthrough and non-passthrough traffic.",
+                    "readonly": true,
+                    "type": [
+                        "integer",
+                        "null"
+                    ]
+                },
+                "Name": {
+                    "$ref": "http://redfish.dmtf.org/schemas/v1/Resource.json#/definitions/Name",
+                    "readonly": true
+                },
+                "Oem": {
+                    "$ref": "http://redfish.dmtf.org/schemas/v1/Resource.json#/definitions/Oem",
+                    "description": "The OEM extension property.",
+                    "longDescription": "This property shall contain the OEM extensions.  All values for properties that this object contains shall conform to the Redfish Specification-described requirements."
+                },
+                "RXBytes": {
+                    "description": "The total number of bytes received since reset.",
+                    "longDescription": "This property shall contain the total number of bytes received since reset, including host and remote management passthrough traffic, and inclusive of all protocol overhead.",
+                    "readonly": true,
+                    "type": [
+                        "integer",
+                        "null"
+                    ],
+                    "units": "By"
+                },
+                "RXMulticastFrames": {
+                    "description": "The total number of good multicast frames received since reset.",
+                    "longDescription": "This property shall contain the total number of good multicast frames received since reset.",
+                    "readonly": true,
+                    "type": [
+                        "integer",
+                        "null"
+                    ]
+                },
+                "RXUnicastFrames": {
+                    "description": "The total number of good unicast frames received since reset.",
+                    "longDescription": "This property shall contain the total number of good unicast frames received since reset.",
+                    "readonly": true,
+                    "type": [
+                        "integer",
+                        "null"
+                    ]
+                },
+                "TXBytes": {
+                    "description": "The total number of bytes transmitted since reset.",
+                    "longDescription": "This property shall contain the total number of bytes transmitted since reset, including host and remote management passthrough traffic, and inclusive of all protocol overhead.",
+                    "readonly": true,
+                    "type": [
+                        "integer",
+                        "null"
+                    ],
+                    "units": "By"
+                },
+                "TXMulticastFrames": {
+                    "description": "The total number of good multicast frames transmitted since reset.",
+                    "longDescription": "This property shall contain the total number of good multicast frames transmitted since reset.",
+                    "readonly": true,
+                    "type": [
+                        "integer",
+                        "null"
+                    ]
+                },
+                "TXUnicastFrames": {
+                    "description": "The total number of good unicast frames transmitted since reset.",
+                    "longDescription": "This property shall contain the total number of good unicast frames transmitted since reset.",
+                    "readonly": true,
+                    "type": [
+                        "integer",
+                        "null"
+                    ]
+                }
+            },
+            "required": [
+                "@odata.id",
+                "@odata.type",
+                "Id",
+                "Name"
+            ],
+            "type": "object"
+        },
+        "OemActions": {
+            "additionalProperties": true,
+            "description": "The available OEM-specific actions for this resource.",
+            "longDescription": "This type shall contain the available OEM-specific actions for this resource.",
+            "patternProperties": {
+                "^([a-zA-Z_][a-zA-Z0-9_]*)?@(odata|Redfish|Message)\\.[a-zA-Z_][a-zA-Z0-9_]*$": {
+                    "description": "This property shall specify a valid odata or Redfish property.",
+                    "type": [
+                        "array",
+                        "boolean",
+                        "integer",
+                        "number",
+                        "null",
+                        "object",
+                        "string"
+                    ]
+                }
+            },
+            "properties": {},
+            "type": "object"
+        }
+    },
+    "owningEntity": "DMTF",
+    "release": "2021.1",
+    "title": "#NetworkAdapterMetrics.v1_0_0.NetworkAdapterMetrics"
+}

--- a/static/redfish/v1/JsonSchemas/NetworkAdapterMetrics/index.json
+++ b/static/redfish/v1/JsonSchemas/NetworkAdapterMetrics/index.json
@@ -1,0 +1,21 @@
+{
+    "@odata.context": "/redfish/v1/$metadata#JsonSchemaFile.JsonSchemaFile",
+    "@odata.id": "/redfish/v1/JsonSchemas/NetworkAdapterMetrics",
+    "@odata.type": "#JsonSchemaFile.v1_0_2.JsonSchemaFile",
+    "Name": "NetworkAdapterMetrics Schema File",
+    "Schema": "#NetworkAdapterMetrics.NetworkAdapterMetrics",
+    "Description": "NetworkAdapterMetrics Schema File Location",
+    "Id": "NetworkAdapterMetrics",
+    "Languages": [
+        "en"
+    ],
+    "Languages@odata.count": 1,
+    "Location": [
+        {
+            "Language": "en",
+            "PublicationUri": "http://redfish.dmtf.org/schemas/v1/NetworkAdapterMetrics.json",
+            "Uri": "/redfish/v1/JsonSchemas/NetworkAdapterMetrics/NetworkAdapterMetrics.json"
+        }
+    ],
+    "Location@odata.count": 1
+}

--- a/static/redfish/v1/JsonSchemas/NetworkDeviceFunction/NetworkDeviceFunction.json
+++ b/static/redfish/v1/JsonSchemas/NetworkDeviceFunction/NetworkDeviceFunction.json
@@ -1,0 +1,1239 @@
+{
+    "$id": "http://redfish.dmtf.org/schemas/v1/NetworkDeviceFunction.v1_7_0.json",
+    "$ref": "#/definitions/NetworkDeviceFunction",
+    "$schema": "http://redfish.dmtf.org/schemas/v1/redfish-schema-v1.json",
+    "copyright": "Copyright 2014-2021 DMTF. For the full DMTF copyright policy, see http://www.dmtf.org/about/policies/copyright",
+    "definitions": {
+        "Actions": {
+            "additionalProperties": false,
+            "description": "The available actions for this resource.",
+            "longDescription": "This type shall contain the available actions for this resource.",
+            "patternProperties": {
+                "^([a-zA-Z_][a-zA-Z0-9_]*)?@(odata|Redfish|Message)\\.[a-zA-Z_][a-zA-Z0-9_]*$": {
+                    "description": "This property shall specify a valid odata or Redfish property.",
+                    "type": [
+                        "array",
+                        "boolean",
+                        "integer",
+                        "number",
+                        "null",
+                        "object",
+                        "string"
+                    ]
+                }
+            },
+            "properties": {
+                "Oem": {
+                    "$ref": "#/definitions/OemActions",
+                    "description": "The available OEM-specific actions for this resource.",
+                    "longDescription": "This property shall contain the available OEM-specific actions for this resource.",
+                    "versionAdded": "v1_1_0"
+                }
+            },
+            "type": "object"
+        },
+        "AuthenticationMethod": {
+            "enum": [
+                "None",
+                "CHAP",
+                "MutualCHAP"
+            ],
+            "enumDescriptions": {
+                "CHAP": "iSCSI Challenge Handshake Authentication Protocol (CHAP) authentication is used.",
+                "MutualCHAP": "iSCSI Mutual Challenge Handshake Authentication Protocol (CHAP) authentication is used.",
+                "None": "No iSCSI authentication is used."
+            },
+            "type": "string"
+        },
+        "BootMode": {
+            "enum": [
+                "Disabled",
+                "PXE",
+                "iSCSI",
+                "FibreChannel",
+                "FibreChannelOverEthernet"
+            ],
+            "enumDescriptions": {
+                "Disabled": "Do not indicate to UEFI/BIOS that this device is bootable.",
+                "FibreChannel": "Boot this device by using the embedded Fibre Channel support and configuration.  Only applicable if the NetDevFuncType is `FibreChannel`.",
+                "FibreChannelOverEthernet": "Boot this device by using the embedded Fibre Channel over Ethernet (FCoE) boot support and configuration.  Only applicable if the NetDevFuncType is `FibreChannelOverEthernet`.",
+                "PXE": "Boot this device by using the embedded PXE support.  Only applicable if the NetDevFuncType is `Ethernet` or `InfiniBand`.",
+                "iSCSI": "Boot this device by using the embedded iSCSI boot support and configuration.  Only applicable if the NetDevFuncType is `iSCSI` or `Ethernet`."
+            },
+            "type": "string"
+        },
+        "BootTargets": {
+            "additionalProperties": false,
+            "description": "A Fibre Channel boot target configured for a network device function.",
+            "longDescription": "This type shall describe a Fibre Channel boot target configured for a network device function.",
+            "patternProperties": {
+                "^([a-zA-Z_][a-zA-Z0-9_]*)?@(odata|Redfish|Message)\\.[a-zA-Z_][a-zA-Z0-9_]*$": {
+                    "description": "This property shall specify a valid odata or Redfish property.",
+                    "type": [
+                        "array",
+                        "boolean",
+                        "integer",
+                        "number",
+                        "null",
+                        "object",
+                        "string"
+                    ]
+                }
+            },
+            "properties": {
+                "BootPriority": {
+                    "description": "The relative priority for this entry in the boot targets array.",
+                    "longDescription": "This property shall contain the relative priority for this entry in the boot targets array.  Lower numbers shall represent higher priority, with zero being the highest priority.  The BootPriority shall be unique for all entries of the BootTargets array.",
+                    "readonly": false,
+                    "type": [
+                        "integer",
+                        "null"
+                    ]
+                },
+                "LUNID": {
+                    "description": "The logical unit number (LUN) ID from which to boot on the device to which the corresponding WWPN refers.",
+                    "longDescription": "This property shall contain the logical unit number (LUN) ID from which to boot on the device to which the corresponding WWPN refers.",
+                    "readonly": false,
+                    "type": [
+                        "string",
+                        "null"
+                    ]
+                },
+                "WWPN": {
+                    "description": "The World Wide Port Name (WWPN) from which to boot.",
+                    "longDescription": "This property shall contain World Wide Port Name (WWPN) from which to boot.",
+                    "readonly": false,
+                    "type": [
+                        "string",
+                        "null"
+                    ]
+                }
+            },
+            "type": "object"
+        },
+        "DataDirection": {
+            "enum": [
+                "None",
+                "Ingress",
+                "Egress"
+            ],
+            "enumDescriptions": {
+                "Egress": "Indicates that this limit is enforced on packets and bytes transmitted by the network device function.",
+                "Ingress": "Indicates that this limit is enforced on packets and bytes received by the network device function.",
+                "None": "Indicates that this limit not enforced."
+            },
+            "type": "string"
+        },
+        "Ethernet": {
+            "additionalProperties": false,
+            "description": "This type describes Ethernet capabilities, status, and configuration for a network device function.",
+            "longDescription": "This type shall describe the Ethernet capabilities, status, and configuration values for a network device function.",
+            "patternProperties": {
+                "^([a-zA-Z_][a-zA-Z0-9_]*)?@(odata|Redfish|Message)\\.[a-zA-Z_][a-zA-Z0-9_]*$": {
+                    "description": "This property shall specify a valid odata or Redfish property.",
+                    "type": [
+                        "array",
+                        "boolean",
+                        "integer",
+                        "number",
+                        "null",
+                        "object",
+                        "string"
+                    ]
+                }
+            },
+            "properties": {
+                "EthernetInterfaces": {
+                    "anyOf": [
+                        {
+                            "$ref": "http://redfish.dmtf.org/schemas/v1/EthernetInterfaceCollection.json#/definitions/EthernetInterfaceCollection"
+                        },
+                        {
+                            "type": "null"
+                        }
+                    ],
+                    "description": "The Ethernet interface collection that represents all the Ethernet Interfaces on this network device function.",
+                    "longDescription": "This property shall contain a link to a collection of type EthernetInterfaceCollection that represent the Ethernet interfaces present on this network device function.  This property shall not be present if this network device function is not referenced by a NetworkInterface resource.",
+                    "readonly": true,
+                    "versionAdded": "v1_7_0"
+                },
+                "MACAddress": {
+                    "description": "The currently configured MAC address.",
+                    "longDescription": "This property shall contain the effective current MAC address of this network device function.  If an assignable MAC address is not supported, this is a read-only alias of the PermanentMACAddress.",
+                    "pattern": "^([0-9A-Fa-f]{2}[:-]){5}([0-9A-Fa-f]{2})$",
+                    "readonly": false,
+                    "type": [
+                        "string",
+                        "null"
+                    ]
+                },
+                "MTUSize": {
+                    "description": "The maximum transmission unit (MTU) configured for this network device function.",
+                    "longDescription": "The maximum transmission unit (MTU) configured for this network device function.  This value serves as a default for the OS driver when booting.  The value only takes effect on boot.",
+                    "readonly": false,
+                    "type": [
+                        "integer",
+                        "null"
+                    ]
+                },
+                "MTUSizeMaximum": {
+                    "description": "The largest maximum transmission unit (MTU) size supported for this network device function.",
+                    "longDescription": "This property shall contain the largest maximum transmission unit (MTU) size supported for this network device function.",
+                    "readonly": true,
+                    "type": [
+                        "integer",
+                        "null"
+                    ],
+                    "versionAdded": "v1_5_0"
+                },
+                "PermanentMACAddress": {
+                    "description": "The permanent MAC address assigned to this function.",
+                    "longDescription": "This property shall contain the permanent MAC Address of this function.  Typically, this value is programmed during manufacturing.  This address is not assignable.",
+                    "pattern": "^([0-9A-Fa-f]{2}[:-]){5}([0-9A-Fa-f]{2})$",
+                    "readonly": true,
+                    "type": [
+                        "string",
+                        "null"
+                    ]
+                },
+                "VLAN": {
+                    "$ref": "http://redfish.dmtf.org/schemas/v1/VLanNetworkInterface.json#/definitions/VLAN",
+                    "description": "The VLAN information for this interface.  If this network interface supports more than one VLAN, this property is not present.",
+                    "longDescription": "This property shall contain the VLAN for this interface.  If this interface supports more than one VLAN, the VLAN property shall not be present and the VLANs property shall be present instead.",
+                    "versionAdded": "v1_3_0"
+                },
+                "VLANs": {
+                    "$ref": "http://redfish.dmtf.org/schemas/v1/VLanNetworkInterfaceCollection.json#/definitions/VLanNetworkInterfaceCollection",
+                    "deprecated": "This property has been deprecated in favor of representing multiple VLANs as EthernetInterface resources.",
+                    "description": "The link to a collection of VLANs.  This property is used only if the interface supports more than one VLAN.",
+                    "longDescription": "This property shall contain a link to a resource collection of type VLanNetworkInterfaceCollection.  If this property is used, the VLANEnabled and VLANId property shall not be used.",
+                    "readonly": true,
+                    "versionAdded": "v1_3_0",
+                    "versionDeprecated": "v1_7_0"
+                }
+            },
+            "type": "object"
+        },
+        "FibreChannel": {
+            "additionalProperties": false,
+            "description": "This type describes Fibre Channel capabilities, status, and configuration for a network device function.",
+            "longDescription": "This type shall describe the Fibre Channel capabilities, status, and configuration values for a network device function.",
+            "patternProperties": {
+                "^([a-zA-Z_][a-zA-Z0-9_]*)?@(odata|Redfish|Message)\\.[a-zA-Z_][a-zA-Z0-9_]*$": {
+                    "description": "This property shall specify a valid odata or Redfish property.",
+                    "type": [
+                        "array",
+                        "boolean",
+                        "integer",
+                        "number",
+                        "null",
+                        "object",
+                        "string"
+                    ]
+                }
+            },
+            "properties": {
+                "AllowFIPVLANDiscovery": {
+                    "description": "An indication of whether the FCoE Initialization Protocol (FIP) populates the FCoE VLAN ID.",
+                    "longDescription": "For FCoE connections, this boolean property shall indicate whether the FIP VLAN Discovery Protocol determines the FCoE VLAN ID selected by the network device function for the FCoE connection.  If `true` and the FIP VLAN discovery succeeds, the FCoEActiveVLANId property shall reflect the FCoE VLAN ID to use for all FCoE traffic.  If `false` or if the FIP VLAN Discovery protocol fails, the FCoELocalVLANId shall be used for all FCoE traffic and the FCoEActiveVLANId shall reflect the FCoELocalVLANId.",
+                    "readonly": false,
+                    "type": [
+                        "boolean",
+                        "null"
+                    ]
+                },
+                "BootTargets": {
+                    "description": "An array of Fibre Channel boot targets configured for this network device function.",
+                    "items": {
+                        "anyOf": [
+                            {
+                                "$ref": "#/definitions/BootTargets"
+                            },
+                            {
+                                "type": "null"
+                            }
+                        ]
+                    },
+                    "longDescription": "This property shall contain an array of Fibre Channel boot targets configured for this network device function.",
+                    "type": "array"
+                },
+                "FCoEActiveVLANId": {
+                    "description": "The active FCoE VLAN ID.",
+                    "longDescription": "For FCoE connections, this property shall contain `null` or a VLAN ID currently being used for FCoE traffic.  When the FCoE link is down this value shall be null.  When the FCoE link is up this value shall be either the FCoELocalVLANId property or a VLAN discovered through the FIP protocol.",
+                    "maximum": 4094,
+                    "minimum": 0,
+                    "readonly": true,
+                    "type": [
+                        "integer",
+                        "null"
+                    ]
+                },
+                "FCoELocalVLANId": {
+                    "description": "The locally configured FCoE VLAN ID.",
+                    "longDescription": "For FCoE connections, this property shall contain the VLAN ID configured locally by setting this property.  This value shall be used for FCoE traffic to this network device function during boot unless AllowFIPVLANDiscovery is `true` and a valid FCoE VLAN ID is found through the FIP VLAN Discovery Protocol.",
+                    "maximum": 4094,
+                    "minimum": 0,
+                    "readonly": false,
+                    "type": [
+                        "integer",
+                        "null"
+                    ]
+                },
+                "FibreChannelId": {
+                    "description": "The Fibre Channel ID that the switch assigns for this interface.",
+                    "longDescription": "This property shall indicate the Fibre Channel ID that the switch assigns for this interface.",
+                    "readonly": true,
+                    "type": [
+                        "string",
+                        "null"
+                    ],
+                    "versionAdded": "v1_3_0"
+                },
+                "PermanentWWNN": {
+                    "description": "The permanent World Wide Node Name (WWNN) address assigned to this function.",
+                    "longDescription": "This property shall contain the permanent World Wide Node Name (WWNN) of this function.  Typically, this value is programmed during manufacturing.  This address is not assignable.",
+                    "pattern": "^([0-9A-Fa-f]{2}[:-]){7}([0-9A-Fa-f]{2})$",
+                    "readonly": true,
+                    "type": [
+                        "string",
+                        "null"
+                    ]
+                },
+                "PermanentWWPN": {
+                    "description": "The permanent World Wide Port Name (WWPN) address assigned to this function.",
+                    "longDescription": "This property shall contain the permanent World Wide Port Name (WWPN) of this function.  Typically, this value is programmed during manufacturing.  This address is not assignable.",
+                    "readonly": true,
+                    "type": [
+                        "string",
+                        "null"
+                    ]
+                },
+                "WWNN": {
+                    "description": "The currently configured World Wide Node Name (WWNN) address of this function.",
+                    "longDescription": "This property shall contain the effective current World Wide Node Name (WWNN) of this function.  If an assignable WWNN is not supported, this is a read-only alias of the permanent WWNN.",
+                    "pattern": "^([0-9A-Fa-f]{2}[:-]){7}([0-9A-Fa-f]{2})$",
+                    "readonly": false,
+                    "type": [
+                        "string",
+                        "null"
+                    ]
+                },
+                "WWNSource": {
+                    "anyOf": [
+                        {
+                            "$ref": "#/definitions/WWNSource"
+                        },
+                        {
+                            "type": "null"
+                        }
+                    ],
+                    "description": "The configuration source of the World Wide Names (WWN) for this World Wide Node Name (WWNN) and World Wide Port Name (WWPN) connection.",
+                    "longDescription": "This property shall contain the configuration source of the World Wide Name (WWN) for this World Wide Node Name (WWNN) and World Wide Port Name (WWPN) connection.",
+                    "readonly": false
+                },
+                "WWPN": {
+                    "description": "The currently configured World Wide Port Name (WWPN) address of this function.",
+                    "longDescription": "This property shall contain the effective current World Wide Port Name (WWPN) of this function.  If an assignable WWPN is not supported, this is a read-only alias of the permanent WWPN.",
+                    "pattern": "^([0-9A-Fa-f]{2}[:-]){7}([0-9A-Fa-f]{2})$",
+                    "readonly": false,
+                    "type": [
+                        "string",
+                        "null"
+                    ]
+                }
+            },
+            "type": "object"
+        },
+        "IPAddressType": {
+            "enum": [
+                "IPv4",
+                "IPv6"
+            ],
+            "enumDescriptions": {
+                "IPv4": "IPv4 addressing is used for all IP-fields in this object.",
+                "IPv6": "IPv6 addressing is used for all IP-fields in this object."
+            },
+            "type": "string"
+        },
+        "InfiniBand": {
+            "additionalProperties": false,
+            "description": "This type describes InfiniBand capabilities, status, and configuration of a network device function.",
+            "longDescription": "This type shall describe the InfiniBand capabilities, status, and configuration values for a network device function.",
+            "patternProperties": {
+                "^([a-zA-Z_][a-zA-Z0-9_]*)?@(odata|Redfish|Message)\\.[a-zA-Z_][a-zA-Z0-9_]*$": {
+                    "description": "This property shall specify a valid odata or Redfish property.",
+                    "type": [
+                        "array",
+                        "boolean",
+                        "integer",
+                        "number",
+                        "null",
+                        "object",
+                        "string"
+                    ]
+                }
+            },
+            "properties": {
+                "MTUSize": {
+                    "description": "The maximum transmission unit (MTU) configured for this network device function.",
+                    "longDescription": "The maximum transmission unit (MTU) configured for this network device function.",
+                    "readonly": false,
+                    "type": [
+                        "integer",
+                        "null"
+                    ],
+                    "versionAdded": "v1_5_0"
+                },
+                "NodeGUID": {
+                    "description": "This is the currently configured node GUID of the network device function.",
+                    "longDescription": "This property shall contain the effective current node GUID of this virtual port of this network device function.  If an assignable node GUID is not supported, this is a read-only alias of the PermanentNodeGUID.",
+                    "pattern": "^([0-9A-Fa-f]{4}[:-]){3}([0-9A-Fa-f]{4})$",
+                    "readonly": true,
+                    "type": [
+                        "string",
+                        "null"
+                    ],
+                    "versionAdded": "v1_5_0"
+                },
+                "PermanentNodeGUID": {
+                    "description": "The permanent node GUID assigned to this network device function.",
+                    "longDescription": "This property shall contain the permanent node GUID of this network device function.  Typically, this value is programmed during manufacturing.  This address is not assignable.",
+                    "pattern": "^([0-9A-Fa-f]{4}[:-]){3}([0-9A-Fa-f]{4})$",
+                    "readonly": true,
+                    "type": [
+                        "string",
+                        "null"
+                    ],
+                    "versionAdded": "v1_5_0"
+                },
+                "PermanentPortGUID": {
+                    "description": "The permanent port GUID assigned to this network device function.",
+                    "longDescription": "This property shall contain the permanent port GUID of this network device function.  Typically, this value is programmed during manufacturing.  This address is not assignable.",
+                    "pattern": "^([0-9A-Fa-f]{4}[:-]){3}([0-9A-Fa-f]{4})$",
+                    "readonly": true,
+                    "type": [
+                        "string",
+                        "null"
+                    ],
+                    "versionAdded": "v1_5_0"
+                },
+                "PermanentSystemGUID": {
+                    "description": "The permanent system GUID assigned to this network device function.",
+                    "longDescription": "This property shall contain the permanent system GUID of this network device function.  Typically, this value is programmed during manufacturing.  This address is not assignable.",
+                    "pattern": "^([0-9A-Fa-f]{4}[:-]){3}([0-9A-Fa-f]{4})$",
+                    "readonly": true,
+                    "type": [
+                        "string",
+                        "null"
+                    ],
+                    "versionAdded": "v1_5_0"
+                },
+                "PortGUID": {
+                    "description": "The currently configured port GUID of the network device function.",
+                    "longDescription": "This property shall contain the effective current virtual port GUID of this network device function.  If an assignable port GUID is not supported, this is a read-only alias of the PermanentPortGUID.",
+                    "pattern": "^([0-9A-Fa-f]{4}[:-]){3}([0-9A-Fa-f]{4})$",
+                    "readonly": true,
+                    "type": [
+                        "string",
+                        "null"
+                    ],
+                    "versionAdded": "v1_5_0"
+                },
+                "SupportedMTUSizes": {
+                    "description": "The maximum transmission unit (MTU) sizes supported for this network device function.",
+                    "items": {
+                        "type": [
+                            "integer",
+                            "null"
+                        ]
+                    },
+                    "longDescription": "This property shall contain an array of the maximum transmission unit (MTU) sizes supported for this network device function.",
+                    "readonly": true,
+                    "type": "array",
+                    "versionAdded": "v1_5_0"
+                },
+                "SystemGUID": {
+                    "description": "This is the currently configured system GUID of the network device function.",
+                    "longDescription": "This property shall contain the effective current system GUID of this virtual port of this network device function.  If an assignable system GUID is not supported, this is a read-only alias of the PermanentSystemGUID.",
+                    "pattern": "^([0-9A-Fa-f]{4}[:-]){3}([0-9A-Fa-f]{4})$",
+                    "readonly": true,
+                    "type": [
+                        "string",
+                        "null"
+                    ],
+                    "versionAdded": "v1_5_0"
+                }
+            },
+            "type": "object"
+        },
+        "Limit": {
+            "additionalProperties": false,
+            "description": "This type describes the packet and byte limit of a network device function.",
+            "longDescription": "This type shall describe a single array element of the packet and byte limits of a network device function.",
+            "patternProperties": {
+                "^([a-zA-Z_][a-zA-Z0-9_]*)?@(odata|Redfish|Message)\\.[a-zA-Z_][a-zA-Z0-9_]*$": {
+                    "description": "This property shall specify a valid odata or Redfish property.",
+                    "type": [
+                        "array",
+                        "boolean",
+                        "integer",
+                        "number",
+                        "null",
+                        "object",
+                        "string"
+                    ]
+                }
+            },
+            "properties": {
+                "BurstBytesPerSecond": {
+                    "description": "The maximum number of bytes per second in a burst for this network device function.",
+                    "longDescription": "This property shall contain the maximum number of bytes per second in a burst allowed for this network device function.",
+                    "readonly": false,
+                    "type": [
+                        "integer",
+                        "null"
+                    ],
+                    "versionAdded": "v1_7_0"
+                },
+                "BurstPacketsPerSecond": {
+                    "description": "The maximum number of packets per second in a burst for this network device function.",
+                    "longDescription": "This property shall contain the maximum number of packets per second in a burst allowed for this network device function.",
+                    "readonly": false,
+                    "type": [
+                        "integer",
+                        "null"
+                    ],
+                    "versionAdded": "v1_7_0"
+                },
+                "Direction": {
+                    "anyOf": [
+                        {
+                            "$ref": "#/definitions/DataDirection"
+                        },
+                        {
+                            "type": "null"
+                        }
+                    ],
+                    "description": "Indicates the direction of the data to which this limit applies.",
+                    "longDescription": "This property shall indicate the direction of the data to which this limit applies for this network device function.",
+                    "readonly": false,
+                    "versionAdded": "v1_7_0"
+                },
+                "SustainedBytesPerSecond": {
+                    "description": "The maximum number of sustained bytes per second for this network device function.",
+                    "longDescription": "This property shall contain the maximum number of sustained bytes per second allowed for this network device function.",
+                    "readonly": false,
+                    "type": [
+                        "integer",
+                        "null"
+                    ],
+                    "versionAdded": "v1_7_0"
+                },
+                "SustainedPacketsPerSecond": {
+                    "description": "The maximum number of sustained packets per second for this network device function.",
+                    "longDescription": "This property shall contain the maximum number of sustained packets per second allowed for this network device function.",
+                    "readonly": false,
+                    "type": [
+                        "integer",
+                        "null"
+                    ],
+                    "versionAdded": "v1_7_0"
+                }
+            },
+            "type": "object"
+        },
+        "Links": {
+            "additionalProperties": false,
+            "description": "The links to other resources that are related to this resource.",
+            "longDescription": "This Redfish Specification-described type shall contain links to resources that are related to but are not contained by, or subordinate to, this resource.",
+            "patternProperties": {
+                "^([a-zA-Z_][a-zA-Z0-9_]*)?@(odata|Redfish|Message)\\.[a-zA-Z_][a-zA-Z0-9_]*$": {
+                    "description": "This property shall specify a valid odata or Redfish property.",
+                    "type": [
+                        "array",
+                        "boolean",
+                        "integer",
+                        "number",
+                        "null",
+                        "object",
+                        "string"
+                    ]
+                }
+            },
+            "properties": {
+                "Endpoints": {
+                    "description": "An array of links to endpoints associated with this network device function.",
+                    "items": {
+                        "$ref": "http://redfish.dmtf.org/schemas/v1/Endpoint.json#/definitions/Endpoint"
+                    },
+                    "longDescription": "This property shall contain an array of links to resources of type Endpoint that are associated with this network device function.",
+                    "readonly": true,
+                    "type": "array",
+                    "versionAdded": "v1_2_0"
+                },
+                "Endpoints@odata.count": {
+                    "$ref": "http://redfish.dmtf.org/schemas/v1/odata-v4.json#/definitions/count"
+                },
+                "EthernetInterface": {
+                    "$ref": "http://redfish.dmtf.org/schemas/v1/EthernetInterface.json#/definitions/EthernetInterface",
+                    "deprecated": "This property has been deprecated in favor of EthernetInterfaces as each NetworkDeviceFunction could have more than one EthernetInterface.",
+                    "description": "The link to a virtual Ethernet interface that was created when one of the network device function VLANs is represented as a virtual NIC for the purpose of showing the IP address associated with that VLAN.",
+                    "longDescription": "This property shall contain a link to a resource of type EthernetInterface that represents a virtual interface that was created when one of the network device function VLANs is represented as a virtual NIC for the purpose of showing the IP address associated with that VLAN.  The EthernetInterfaceType property of that resource shall contain the value `Virtual`.",
+                    "versionAdded": "v1_4_0",
+                    "versionDeprecated": "v1_7_0"
+                },
+                "EthernetInterfaces": {
+                    "description": "The links to Ethernet interfaces that were created when one of the network device function VLANs is represented as a virtual NIC for the purpose of showing the IP address associated with that VLAN.",
+                    "items": {
+                        "$ref": "http://redfish.dmtf.org/schemas/v1/EthernetInterface.json#/definitions/EthernetInterface"
+                    },
+                    "longDescription": "This property shall contain an array of links to resources of type EthernetInterface that represent the virtual interfaces that were created when one of the network device function VLANs is represented as a virtual NIC for the purpose of showing the IP address associated with that VLAN.",
+                    "type": "array",
+                    "versionAdded": "v1_7_0"
+                },
+                "EthernetInterfaces@odata.count": {
+                    "$ref": "http://redfish.dmtf.org/schemas/v1/odata-v4.json#/definitions/count"
+                },
+                "Oem": {
+                    "$ref": "http://redfish.dmtf.org/schemas/v1/Resource.json#/definitions/Oem",
+                    "description": "The OEM extension property.",
+                    "longDescription": "This property shall contain the OEM extensions.  All values for properties contained in this object shall conform to the Redfish Specification-described requirements."
+                },
+                "OffloadProcessors": {
+                    "description": "The processors that perform offload computation for this network function, such as with a SmartNIC.",
+                    "items": {
+                        "$ref": "http://redfish.dmtf.org/schemas/v1/Processor.json#/definitions/Processor"
+                    },
+                    "longDescription": "This property shall contain an array of links to resources of type Processor that represent the processors that performs offload computation for this network function, such as with a SmartNIC.  This property shall not be present if OffloadSystem is present.",
+                    "readonly": true,
+                    "type": "array",
+                    "versionAdded": "v1_7_0"
+                },
+                "OffloadProcessors@odata.count": {
+                    "$ref": "http://redfish.dmtf.org/schemas/v1/odata-v4.json#/definitions/count"
+                },
+                "OffloadSystem": {
+                    "$ref": "http://redfish.dmtf.org/schemas/v1/ComputerSystem.json#/definitions/ComputerSystem",
+                    "description": "The system that performs offload computation for this network function, such as with a SmartNIC.",
+                    "longDescription": "This property shall contain a link to a resource of type ComputerSystem that represents the system that performs offload computation for this network function, such as with a SmartNIC.  The SystemType property contained in the referenced ComputerSystem resource should contain the value `DPU`.  This property shall not be present if OffloadProcessors is present.",
+                    "readonly": true,
+                    "versionAdded": "v1_7_0"
+                },
+                "PCIeFunction": {
+                    "$ref": "http://redfish.dmtf.org/schemas/v1/PCIeFunction.json#/definitions/PCIeFunction",
+                    "description": "The link to the PCIe function associated with this network device function.",
+                    "longDescription": "This property shall contain a link to a resource of type PCIeFunction that represents the PCIe function associated with this network device function.",
+                    "readonly": true
+                },
+                "PhysicalNetworkPortAssignment": {
+                    "$ref": "http://redfish.dmtf.org/schemas/v1/Port.json#/definitions/Port",
+                    "description": "The physical port to which this network device function is currently assigned.",
+                    "longDescription": "This property shall contain a link to a resource of type Port to which this network device function is currently assigned.  This value shall be one of the AssignablePhysicalPorts array members.",
+                    "versionAdded": "v1_5_0"
+                },
+                "PhysicalPortAssignment": {
+                    "$ref": "http://redfish.dmtf.org/schemas/v1/NetworkPort.json#/definitions/NetworkPort",
+                    "deprecated": "This property has been deprecated in favor of the PhysicalNetworkPortAssignment property.",
+                    "description": "The physical port to which this network device function is currently assigned.",
+                    "longDescription": "This property shall contain a link to a resource of type NetworkPort to which this network device function is currently assigned.  This value shall be one of the AssignablePhysicalPorts array members.",
+                    "versionAdded": "v1_3_0",
+                    "versionDeprecated": "v1_5_0"
+                }
+            },
+            "type": "object"
+        },
+        "NetworkDeviceFunction": {
+            "additionalProperties": false,
+            "description": "The NetworkDeviceFunction schema represents a logical interface that a network adapter exposes.",
+            "longDescription": "This resource shall represent a logical interface that a network adapter exposes in a Redfish implementation.",
+            "patternProperties": {
+                "^([a-zA-Z_][a-zA-Z0-9_]*)?@(odata|Redfish|Message)\\.[a-zA-Z_][a-zA-Z0-9_]*$": {
+                    "description": "This property shall specify a valid odata or Redfish property.",
+                    "type": [
+                        "array",
+                        "boolean",
+                        "integer",
+                        "number",
+                        "null",
+                        "object",
+                        "string"
+                    ]
+                }
+            },
+            "properties": {
+                "@odata.context": {
+                    "$ref": "http://redfish.dmtf.org/schemas/v1/odata-v4.json#/definitions/context"
+                },
+                "@odata.etag": {
+                    "$ref": "http://redfish.dmtf.org/schemas/v1/odata-v4.json#/definitions/etag"
+                },
+                "@odata.id": {
+                    "$ref": "http://redfish.dmtf.org/schemas/v1/odata-v4.json#/definitions/id"
+                },
+                "@odata.type": {
+                    "$ref": "http://redfish.dmtf.org/schemas/v1/odata-v4.json#/definitions/type"
+                },
+                "Actions": {
+                    "$ref": "#/definitions/Actions",
+                    "description": "The available actions for this resource.",
+                    "longDescription": "This property shall contain the available actions for this resource.",
+                    "versionAdded": "v1_1_0"
+                },
+                "AllowDeny": {
+                    "$ref": "http://redfish.dmtf.org/schemas/v1/AllowDenyCollection.json#/definitions/AllowDenyCollection",
+                    "description": "The link to the collection of allow and deny permissions for packets leaving and arriving to this network device function.",
+                    "longDescription": "This property shall contain a link to a resource collection of type AllowDenyCollection that contains the permissions for packets leaving and arriving to this network device function.",
+                    "readonly": true,
+                    "versionAdded": "v1_7_0"
+                },
+                "AssignablePhysicalNetworkPorts": {
+                    "description": "An array of physical ports to which this network device function can be assigned.",
+                    "items": {
+                        "$ref": "http://redfish.dmtf.org/schemas/v1/Port.json#/definitions/Port"
+                    },
+                    "longDescription": "This property shall contain an array of links to resources of type Port that are the physical ports to which this network device function can be assigned.",
+                    "readonly": true,
+                    "type": "array",
+                    "versionAdded": "v1_5_0"
+                },
+                "AssignablePhysicalNetworkPorts@odata.count": {
+                    "$ref": "http://redfish.dmtf.org/schemas/v1/odata-v4.json#/definitions/count"
+                },
+                "AssignablePhysicalPorts": {
+                    "deprecated": "This property has been deprecated in favor of the AssignablePhysicalNetworkPorts property.",
+                    "description": "An array of physical ports to which this network device function can be assigned.",
+                    "items": {
+                        "$ref": "http://redfish.dmtf.org/schemas/v1/NetworkPort.json#/definitions/NetworkPort"
+                    },
+                    "longDescription": "This property shall contain an array of links to resources of type NetworkPort that are the physical ports to which this network device function can be assigned.",
+                    "readonly": true,
+                    "type": "array",
+                    "versionDeprecated": "v1_5_0"
+                },
+                "AssignablePhysicalPorts@odata.count": {
+                    "$ref": "http://redfish.dmtf.org/schemas/v1/odata-v4.json#/definitions/count"
+                },
+                "BootMode": {
+                    "anyOf": [
+                        {
+                            "$ref": "#/definitions/BootMode"
+                        },
+                        {
+                            "type": "null"
+                        }
+                    ],
+                    "description": "The boot mode configured for this network device function.",
+                    "longDescription": "This property shall contain the boot mode configured for this network device function.  If the value is not `Disabled`, this network device function shall be configured for boot by using the specified technology.",
+                    "readonly": false
+                },
+                "Description": {
+                    "anyOf": [
+                        {
+                            "$ref": "http://redfish.dmtf.org/schemas/v1/Resource.json#/definitions/Description"
+                        },
+                        {
+                            "type": "null"
+                        }
+                    ],
+                    "readonly": true
+                },
+                "DeviceEnabled": {
+                    "description": "An indication of whether the network device function is enabled.",
+                    "longDescription": "This property shall indicate whether the network device function is enabled.  The operating system shall not enumerate or see disabled network device functions.",
+                    "readonly": false,
+                    "type": [
+                        "boolean",
+                        "null"
+                    ]
+                },
+                "Ethernet": {
+                    "$ref": "#/definitions/Ethernet",
+                    "description": "The Ethernet capabilities, status, and configuration values for this network device function.",
+                    "longDescription": "This property shall contain Ethernet capabilities, status, and configuration values for this network device function."
+                },
+                "FibreChannel": {
+                    "$ref": "#/definitions/FibreChannel",
+                    "description": "The Fibre Channel capabilities, status, and configuration values for this network device function.",
+                    "longDescription": "This property shall contain Fibre Channel capabilities, status, and configuration values for this network device function."
+                },
+                "Id": {
+                    "$ref": "http://redfish.dmtf.org/schemas/v1/Resource.json#/definitions/Id",
+                    "readonly": true
+                },
+                "InfiniBand": {
+                    "$ref": "#/definitions/InfiniBand",
+                    "description": "The InfiniBand capabilities, status, and configuration values for this network device function.",
+                    "longDescription": "This property shall contain InfiniBand capabilities, status, and configuration values for this network device function.",
+                    "versionAdded": "v1_5_0"
+                },
+                "Limits": {
+                    "description": "The byte and packet limits for this network device function.",
+                    "items": {
+                        "anyOf": [
+                            {
+                                "$ref": "#/definitions/Limit"
+                            },
+                            {
+                                "type": "null"
+                            }
+                        ]
+                    },
+                    "longDescription": "This property shall contain an array of byte and packet limits for this network device function.",
+                    "type": "array",
+                    "versionAdded": "v1_7_0"
+                },
+                "Links": {
+                    "$ref": "#/definitions/Links",
+                    "description": "The links to other resources that are related to this resource.",
+                    "longDescription": "This property shall contain links to resources that are related to but are not contained by, or subordinate to, this resource."
+                },
+                "MaxVirtualFunctions": {
+                    "description": "The number of virtual functions that are available for this network device function.",
+                    "longDescription": "This property shall contain the number of virtual functions that are available for this network device function.",
+                    "readonly": true,
+                    "type": [
+                        "integer",
+                        "null"
+                    ]
+                },
+                "Metrics": {
+                    "anyOf": [
+                        {
+                            "$ref": "http://redfish.dmtf.org/schemas/v1/NetworkDeviceFunctionMetrics.json#/definitions/NetworkDeviceFunctionMetrics"
+                        },
+                        {
+                            "type": "null"
+                        }
+                    ],
+                    "description": "The link to the metrics associated with this network function.",
+                    "longDescription": "This property shall contain a link to a resource of type NetworkDeviceFunctionMetrics that contains the metrics associated with this network function.",
+                    "readonly": true,
+                    "versionAdded": "v1_6_0"
+                },
+                "Name": {
+                    "$ref": "http://redfish.dmtf.org/schemas/v1/Resource.json#/definitions/Name",
+                    "readonly": true
+                },
+                "NetDevFuncCapabilities": {
+                    "description": "An array of capabilities for this network device function.",
+                    "items": {
+                        "anyOf": [
+                            {
+                                "$ref": "#/definitions/NetworkDeviceTechnology"
+                            },
+                            {
+                                "type": "null"
+                            }
+                        ]
+                    },
+                    "longDescription": "This property shall contain an array of capabilities for this network device function.",
+                    "readonly": true,
+                    "type": "array"
+                },
+                "NetDevFuncType": {
+                    "anyOf": [
+                        {
+                            "$ref": "#/definitions/NetworkDeviceTechnology"
+                        },
+                        {
+                            "type": "null"
+                        }
+                    ],
+                    "description": "The configured capability of this network device function.",
+                    "longDescription": "This property shall contain the configured capability of this network device function.",
+                    "readonly": false
+                },
+                "Oem": {
+                    "$ref": "http://redfish.dmtf.org/schemas/v1/Resource.json#/definitions/Oem",
+                    "description": "The OEM extension property.",
+                    "longDescription": "This property shall contain the OEM extensions.  All values for properties that this object contains shall conform to the Redfish Specification-described requirements."
+                },
+                "PhysicalNetworkPortAssignment": {
+                    "$ref": "http://redfish.dmtf.org/schemas/v1/Port.json#/definitions/Port",
+                    "description": "The physical port to which this network device function is currently assigned.",
+                    "longDescription": "This property shall contain a link to a resource of type Port that is the physical port to which this network device function is currently assigned.  This value shall be one of the AssignablePhysicalNetworkPorts array members.",
+                    "readonly": true,
+                    "versionAdded": "v1_5_0"
+                },
+                "PhysicalPortAssignment": {
+                    "$ref": "http://redfish.dmtf.org/schemas/v1/NetworkPort.json#/definitions/NetworkPort",
+                    "deprecated": "This property has been deprecated and moved to the Links property to avoid loops on expand.",
+                    "description": "The physical port to which this network device function is currently assigned.",
+                    "longDescription": "This property shall contain a link to a resource of type NetworkPort that is the physical port to which this network device function is currently assigned.  This value shall be one of the AssignablePhysicalPorts array members.",
+                    "readonly": true,
+                    "versionDeprecated": "v1_3_0"
+                },
+                "SAVIEnabled": {
+                    "description": "Indicates if Source Address Validation Improvement (SAVI) is enabled for this network device function.",
+                    "longDescription": "This property shall indicate if the RFC7039-defined Source Address Validation Improvement (SAVI) is enabled for this network device function.",
+                    "readonly": false,
+                    "type": [
+                        "boolean",
+                        "null"
+                    ],
+                    "versionAdded": "v1_7_0"
+                },
+                "Status": {
+                    "$ref": "http://redfish.dmtf.org/schemas/v1/Resource.json#/definitions/Status",
+                    "description": "The status and health of the resource and its subordinate or dependent resources.",
+                    "longDescription": "This property shall contain any status or health properties of the resource."
+                },
+                "VirtualFunctionsEnabled": {
+                    "description": "An indication of whether single root input/output virtualization (SR-IOV) virtual functions are enabled for this network device function.",
+                    "longDescription": "This property shall indicate whether single root input/output virtualization (SR-IOV) virtual functions are enabled for this network device function.",
+                    "readonly": true,
+                    "type": [
+                        "boolean",
+                        "null"
+                    ]
+                },
+                "iSCSIBoot": {
+                    "$ref": "#/definitions/iSCSIBoot",
+                    "description": "The iSCSI boot capabilities, status, and configuration values for this network device function.",
+                    "longDescription": "This property shall contain iSCSI boot capabilities, status, and configuration values for this network device function."
+                }
+            },
+            "required": [
+                "@odata.id",
+                "@odata.type",
+                "Id",
+                "Name"
+            ],
+            "type": "object"
+        },
+        "NetworkDeviceTechnology": {
+            "enum": [
+                "Disabled",
+                "Ethernet",
+                "FibreChannel",
+                "iSCSI",
+                "FibreChannelOverEthernet",
+                "InfiniBand"
+            ],
+            "enumDescriptions": {
+                "Disabled": "Neither enumerated nor visible to the operating system.",
+                "Ethernet": "Appears to the operating system as an Ethernet device.",
+                "FibreChannel": "Appears to the operating system as a Fibre Channel device.",
+                "FibreChannelOverEthernet": "Appears to the operating system as an FCoE device.",
+                "InfiniBand": "Appears to the operating system as an InfiniBand device.",
+                "iSCSI": "Appears to the operating system as an iSCSI device."
+            },
+            "enumVersionAdded": {
+                "InfiniBand": "v1_5_0"
+            },
+            "type": "string"
+        },
+        "OemActions": {
+            "additionalProperties": true,
+            "description": "The available OEM-specific actions for this resource.",
+            "longDescription": "This type shall contain the available OEM-specific actions for this resource.",
+            "patternProperties": {
+                "^([a-zA-Z_][a-zA-Z0-9_]*)?@(odata|Redfish|Message)\\.[a-zA-Z_][a-zA-Z0-9_]*$": {
+                    "description": "This property shall specify a valid odata or Redfish property.",
+                    "type": [
+                        "array",
+                        "boolean",
+                        "integer",
+                        "number",
+                        "null",
+                        "object",
+                        "string"
+                    ]
+                }
+            },
+            "properties": {},
+            "type": "object"
+        },
+        "WWNSource": {
+            "enum": [
+                "ConfiguredLocally",
+                "ProvidedByFabric"
+            ],
+            "enumDescriptions": {
+                "ConfiguredLocally": "The set of FC/FCoE boot targets was applied locally through API or UI.",
+                "ProvidedByFabric": "The set of FC/FCoE boot targets was applied by the Fibre Channel fabric."
+            },
+            "type": "string"
+        },
+        "iSCSIBoot": {
+            "additionalProperties": false,
+            "description": "The iSCSI boot capabilities, status, and configuration for a network device function.",
+            "longDescription": "This type shall describe the iSCSI boot capabilities, status, and configuration values for a network device function.",
+            "patternProperties": {
+                "^([a-zA-Z_][a-zA-Z0-9_]*)?@(odata|Redfish|Message)\\.[a-zA-Z_][a-zA-Z0-9_]*$": {
+                    "description": "This property shall specify a valid odata or Redfish property.",
+                    "type": [
+                        "array",
+                        "boolean",
+                        "integer",
+                        "number",
+                        "null",
+                        "object",
+                        "string"
+                    ]
+                }
+            },
+            "properties": {
+                "AuthenticationMethod": {
+                    "anyOf": [
+                        {
+                            "$ref": "#/definitions/AuthenticationMethod"
+                        },
+                        {
+                            "type": "null"
+                        }
+                    ],
+                    "description": "The iSCSI boot authentication method for this network device function.",
+                    "longDescription": "This property shall contain the iSCSI boot authentication method for this network device function.",
+                    "readonly": false
+                },
+                "CHAPSecret": {
+                    "description": "The shared secret for CHAP authentication.",
+                    "longDescription": "This property shall contain the shared secret for CHAP authentication.",
+                    "readonly": false,
+                    "type": [
+                        "string",
+                        "null"
+                    ]
+                },
+                "CHAPUsername": {
+                    "description": "The user name for CHAP authentication.",
+                    "longDescription": "This property shall contain the user name for CHAP authentication.",
+                    "readonly": false,
+                    "type": [
+                        "string",
+                        "null"
+                    ]
+                },
+                "IPAddressType": {
+                    "anyOf": [
+                        {
+                            "$ref": "#/definitions/IPAddressType"
+                        },
+                        {
+                            "type": "null"
+                        }
+                    ],
+                    "description": "The type of IP address being populated in the iSCSIBoot IP address fields.",
+                    "longDescription": "This property shall contain the type of IP address being populated in the iSCSIBoot IP address fields.  Mixing IPv6 and IPv4 addresses on the same network device function shall not be permissible.",
+                    "readonly": false
+                },
+                "IPMaskDNSViaDHCP": {
+                    "description": "An indication of whether the iSCSI boot initiator uses DHCP to obtain the initiator name, IP address, and netmask.",
+                    "longDescription": "This property shall indicate whether the iSCSI boot initiator uses DHCP to obtain the initiator name, IP address, and netmask.",
+                    "readonly": false,
+                    "type": [
+                        "boolean",
+                        "null"
+                    ]
+                },
+                "InitiatorDefaultGateway": {
+                    "description": "The IPv6 or IPv4 iSCSI boot default gateway.",
+                    "longDescription": "This property shall contain the IPv6 or IPv4 iSCSI boot default gateway.",
+                    "readonly": false,
+                    "type": [
+                        "string",
+                        "null"
+                    ]
+                },
+                "InitiatorIPAddress": {
+                    "description": "The IPv6 or IPv4 address of the iSCSI initiator.",
+                    "longDescription": "This property shall contain the IPv6 or IPv4 address of the iSCSI boot initiator.",
+                    "readonly": false,
+                    "type": [
+                        "string",
+                        "null"
+                    ]
+                },
+                "InitiatorName": {
+                    "description": "The iSCSI initiator name.",
+                    "longDescription": "This property shall contain the iSCSI boot initiator name.  This property should match formats defined in RFC3720 or RFC3721.",
+                    "readonly": false,
+                    "type": [
+                        "string",
+                        "null"
+                    ]
+                },
+                "InitiatorNetmask": {
+                    "description": "The IPv6 or IPv4 netmask of the iSCSI boot initiator.",
+                    "longDescription": "This property shall contain the IPv6 or IPv4 netmask of the iSCSI boot initiator.",
+                    "readonly": false,
+                    "type": [
+                        "string",
+                        "null"
+                    ]
+                },
+                "MutualCHAPSecret": {
+                    "description": "The CHAP secret for two-way CHAP authentication.",
+                    "longDescription": "This property shall contain the CHAP secret for two-way CHAP authentication.",
+                    "readonly": false,
+                    "type": [
+                        "string",
+                        "null"
+                    ]
+                },
+                "MutualCHAPUsername": {
+                    "description": "The CHAP user name for two-way CHAP authentication.",
+                    "longDescription": "This property shall contain the CHAP user name for two-way CHAP authentication.",
+                    "readonly": false,
+                    "type": [
+                        "string",
+                        "null"
+                    ]
+                },
+                "PrimaryDNS": {
+                    "description": "The IPv6 or IPv4 address of the primary DNS server for the iSCSI boot initiator.",
+                    "longDescription": "This property shall contain the IPv6 or IPv4 address of the primary DNS server for the iSCSI boot initiator.",
+                    "readonly": false,
+                    "type": [
+                        "string",
+                        "null"
+                    ]
+                },
+                "PrimaryLUN": {
+                    "description": "The logical unit number (LUN) for the primary iSCSI boot target.",
+                    "longDescription": "This property shall contain the logical unit number (LUN) for the primary iSCSI boot target.",
+                    "readonly": false,
+                    "type": [
+                        "integer",
+                        "null"
+                    ]
+                },
+                "PrimaryTargetIPAddress": {
+                    "description": "The IPv4 or IPv6 address for the primary iSCSI boot target.",
+                    "longDescription": "This property shall contain the IPv4 or IPv6 address for the primary iSCSI boot target.",
+                    "readonly": false,
+                    "type": [
+                        "string",
+                        "null"
+                    ]
+                },
+                "PrimaryTargetName": {
+                    "description": "The name of the iSCSI primary boot target.",
+                    "longDescription": "This property shall contain the name of the primary iSCSI boot target.  This property should match formats defined in RFC3720 or RFC3721.",
+                    "readonly": false,
+                    "type": [
+                        "string",
+                        "null"
+                    ]
+                },
+                "PrimaryTargetTCPPort": {
+                    "description": "The TCP port for the primary iSCSI boot target.",
+                    "longDescription": "This property shall contain the TCP port for the primary iSCSI boot target.",
+                    "readonly": false,
+                    "type": [
+                        "integer",
+                        "null"
+                    ]
+                },
+                "PrimaryVLANEnable": {
+                    "description": "An indication of whether the primary VLAN is enabled.",
+                    "longDescription": "This property shall indicate whether this VLAN is enabled for the primary iSCSI boot target.",
+                    "readonly": false,
+                    "type": [
+                        "boolean",
+                        "null"
+                    ]
+                },
+                "PrimaryVLANId": {
+                    "description": "The 802.1q VLAN ID to use for iSCSI boot from the primary target.",
+                    "longDescription": "This property shall contain the 802.1q VLAN ID to use for iSCSI boot from the primary target.  This VLAN ID is only used if PrimaryVLANEnable is true.",
+                    "maximum": 4094,
+                    "minimum": 0,
+                    "readonly": false,
+                    "type": [
+                        "integer",
+                        "null"
+                    ]
+                },
+                "RouterAdvertisementEnabled": {
+                    "description": "An indication of whether IPv6 router advertisement is enabled for the iSCSI boot target.",
+                    "longDescription": "This property shall indicate whether IPv6 router advertisement is enabled for the iSCSI boot target.  This setting shall apply to only IPv6 configurations.",
+                    "readonly": false,
+                    "type": [
+                        "boolean",
+                        "null"
+                    ]
+                },
+                "SecondaryDNS": {
+                    "description": "The IPv6 or IPv4 address of the secondary DNS server for the iSCSI boot initiator.",
+                    "longDescription": "This property shall contain the IPv6 or IPv4 address of the secondary DNS server for the iSCSI boot initiator.",
+                    "readonly": false,
+                    "type": [
+                        "string",
+                        "null"
+                    ]
+                },
+                "SecondaryLUN": {
+                    "description": "The logical unit number (LUN) for the secondary iSCSI boot target.",
+                    "longDescription": "This property shall contain the logical unit number (LUN) for the secondary iSCSI boot target.",
+                    "readonly": false,
+                    "type": [
+                        "integer",
+                        "null"
+                    ]
+                },
+                "SecondaryTargetIPAddress": {
+                    "description": "The IPv4 or IPv6 address for the secondary iSCSI boot target.",
+                    "longDescription": "This property shall contain the IPv4 or IPv6 address for the secondary iSCSI boot target.",
+                    "readonly": false,
+                    "type": [
+                        "string",
+                        "null"
+                    ]
+                },
+                "SecondaryTargetName": {
+                    "description": "The name of the iSCSI secondary boot target.",
+                    "longDescription": "This property shall contain the name of the secondary iSCSI boot target.  This property should match formats defined in RFC3720 or RFC3721.",
+                    "readonly": false,
+                    "type": [
+                        "string",
+                        "null"
+                    ]
+                },
+                "SecondaryTargetTCPPort": {
+                    "description": "The TCP port for the secondary iSCSI boot target.",
+                    "longDescription": "This property shall contain the TCP port for the secondary iSCSI boot target.",
+                    "readonly": false,
+                    "type": [
+                        "integer",
+                        "null"
+                    ]
+                },
+                "SecondaryVLANEnable": {
+                    "description": "An indication of whether the secondary VLAN is enabled.",
+                    "longDescription": "This property shall indicate whether this VLAN is enabled for the secondary iSCSI boot target.",
+                    "readonly": false,
+                    "type": [
+                        "boolean",
+                        "null"
+                    ]
+                },
+                "SecondaryVLANId": {
+                    "description": "The 802.1q VLAN ID to use for iSCSI boot from the secondary target.",
+                    "longDescription": "This property shall contain the 802.1q VLAN ID to use for iSCSI boot from the secondary target.  This VLAN ID is only used if SecondaryVLANEnable is `true`.",
+                    "maximum": 4094,
+                    "minimum": 0,
+                    "readonly": false,
+                    "type": [
+                        "integer",
+                        "null"
+                    ]
+                },
+                "TargetInfoViaDHCP": {
+                    "description": "An indication of whether the iSCSI boot target name, LUN, IP address, and netmask should be obtained from DHCP.",
+                    "longDescription": "This property shall indicate whether the iSCSI boot target name, LUN, IP address, and netmask should be obtained from DHCP.",
+                    "readonly": false,
+                    "type": [
+                        "boolean",
+                        "null"
+                    ]
+                }
+            },
+            "type": "object"
+        }
+    },
+    "owningEntity": "DMTF",
+    "release": "2021.2",
+    "title": "#NetworkDeviceFunction.v1_7_0.NetworkDeviceFunction"
+}

--- a/static/redfish/v1/JsonSchemas/NetworkDeviceFunction/index.json
+++ b/static/redfish/v1/JsonSchemas/NetworkDeviceFunction/index.json
@@ -1,0 +1,21 @@
+{
+    "@odata.context": "/redfish/v1/$metadata#JsonSchemaFile.JsonSchemaFile",
+    "@odata.id": "/redfish/v1/JsonSchemas/NetworkDeviceFunction",
+    "@odata.type": "#JsonSchemaFile.v1_0_2.JsonSchemaFile",
+    "Name": "NetworkDeviceFunction Schema File",
+    "Schema": "#NetworkDeviceFunction.NetworkDeviceFunction",
+    "Description": "NetworkDeviceFunction Schema File Location",
+    "Id": "NetworkDeviceFunction",
+    "Languages": [
+        "en"
+    ],
+    "Languages@odata.count": 1,
+    "Location": [
+        {
+            "Language": "en",
+            "PublicationUri": "http://redfish.dmtf.org/schemas/v1/NetworkDeviceFunction.json",
+            "Uri": "/redfish/v1/JsonSchemas/NetworkDeviceFunction/NetworkDeviceFunction.json"
+        }
+    ],
+    "Location@odata.count": 1
+}

--- a/static/redfish/v1/JsonSchemas/NetworkDeviceFunctionMetrics/NetworkDeviceFunctionMetrics.json
+++ b/static/redfish/v1/JsonSchemas/NetworkDeviceFunctionMetrics/NetworkDeviceFunctionMetrics.json
@@ -1,0 +1,483 @@
+{
+    "$id": "http://redfish.dmtf.org/schemas/v1/NetworkDeviceFunctionMetrics.v1_1_0.json",
+    "$ref": "#/definitions/NetworkDeviceFunctionMetrics",
+    "$schema": "http://redfish.dmtf.org/schemas/v1/redfish-schema-v1.json",
+    "copyright": "Copyright 2014-2021 DMTF. For the full DMTF copyright policy, see http://www.dmtf.org/about/policies/copyright",
+    "definitions": {
+        "Actions": {
+            "additionalProperties": false,
+            "description": "The available actions for this resource.",
+            "longDescription": "This type shall contain the available actions for this resource.",
+            "patternProperties": {
+                "^([a-zA-Z_][a-zA-Z0-9_]*)?@(odata|Redfish|Message)\\.[a-zA-Z_][a-zA-Z0-9_]*$": {
+                    "description": "This property shall specify a valid odata or Redfish property.",
+                    "type": [
+                        "array",
+                        "boolean",
+                        "integer",
+                        "number",
+                        "null",
+                        "object",
+                        "string"
+                    ]
+                }
+            },
+            "properties": {
+                "Oem": {
+                    "$ref": "#/definitions/OemActions",
+                    "description": "The available OEM-specific actions for this resource.",
+                    "longDescription": "This property shall contain the available OEM-specific actions for this resource."
+                }
+            },
+            "type": "object"
+        },
+        "Ethernet": {
+            "additionalProperties": false,
+            "description": "The network function metrics for an Ethernet interface.",
+            "longDescription": "This type shall describe the Ethernet related network function metrics.",
+            "patternProperties": {
+                "^([a-zA-Z_][a-zA-Z0-9_]*)?@(odata|Redfish|Message)\\.[a-zA-Z_][a-zA-Z0-9_]*$": {
+                    "description": "This property shall specify a valid odata or Redfish property.",
+                    "type": [
+                        "array",
+                        "boolean",
+                        "integer",
+                        "number",
+                        "null",
+                        "object",
+                        "string"
+                    ]
+                }
+            },
+            "properties": {
+                "NumOffloadedIPv4Conns": {
+                    "description": "The total number of offloaded TCP/IPv4 connections.",
+                    "longDescription": "This property shall contain the total number of offloaded TCP/IPv4 connections.",
+                    "readonly": true,
+                    "type": [
+                        "integer",
+                        "null"
+                    ]
+                },
+                "NumOffloadedIPv6Conns": {
+                    "description": "The total number of offloaded TCP/IPv6 connections.",
+                    "longDescription": "This property shall contain the total number of offloaded TCP/IPv6 connections.",
+                    "readonly": true,
+                    "type": [
+                        "integer",
+                        "null"
+                    ]
+                }
+            },
+            "type": "object"
+        },
+        "FibreChannel": {
+            "additionalProperties": false,
+            "description": "The network function metrics for a Fibre Channel interface.",
+            "longDescription": "This type shall describe the Fibre Channel related network function metrics.",
+            "patternProperties": {
+                "^([a-zA-Z_][a-zA-Z0-9_]*)?@(odata|Redfish|Message)\\.[a-zA-Z_][a-zA-Z0-9_]*$": {
+                    "description": "This property shall specify a valid odata or Redfish property.",
+                    "type": [
+                        "array",
+                        "boolean",
+                        "integer",
+                        "number",
+                        "null",
+                        "object",
+                        "string"
+                    ]
+                }
+            },
+            "properties": {
+                "PortLoginAccepts": {
+                    "description": "The total number of port login (PLOGI) accept (ACC) responses.",
+                    "longDescription": "This property shall contain the total number of PLOGI ACC responses received by this Fibre Channel function.",
+                    "readonly": true,
+                    "type": [
+                        "integer",
+                        "null"
+                    ],
+                    "versionAdded": "v1_1_0"
+                },
+                "PortLoginRejects": {
+                    "description": "The total number of port login (PLOGI) reject (RJT) responses.",
+                    "longDescription": "This property shall contain the total number of PLOGI RJT responses received by this Fibre Channel function.",
+                    "readonly": true,
+                    "type": [
+                        "integer",
+                        "null"
+                    ],
+                    "versionAdded": "v1_1_0"
+                },
+                "PortLoginRequests": {
+                    "description": "The total number of port login (PLOGI) requests transmitted.",
+                    "longDescription": "This property shall contain the total number of PLOGI requests sent by this function.",
+                    "readonly": true,
+                    "type": [
+                        "integer",
+                        "null"
+                    ],
+                    "versionAdded": "v1_1_0"
+                },
+                "RXCongestionFPINs": {
+                    "description": "The total number of Congestion Fabric Performance Impact Notifications (FPINs) received.",
+                    "longDescription": "This property shall contain the total number of Congestion FPINs received by this Fibre Channel function.",
+                    "readonly": true,
+                    "type": [
+                        "integer",
+                        "null"
+                    ],
+                    "versionAdded": "v1_1_0"
+                },
+                "RXDeliveryFPINs": {
+                    "description": "The total number of Delivery Fabric Performance Impact Notifications (FPINs) received.",
+                    "longDescription": "This property shall contain the total number of Delivery FPINs received by this Fibre Channel function.",
+                    "readonly": true,
+                    "type": [
+                        "integer",
+                        "null"
+                    ],
+                    "versionAdded": "v1_1_0"
+                },
+                "RXExchanges": {
+                    "description": "The total number of Fibre Channel exchanges received.",
+                    "longDescription": "This property shall contain the total number of Fibre Channel exchanges received.",
+                    "readonly": true,
+                    "type": [
+                        "integer",
+                        "null"
+                    ],
+                    "versionAdded": "v1_1_0"
+                },
+                "RXLinkIntegrityFPINs": {
+                    "description": "The total number of Link Integrity Fabric Performance Impact Notifications (FPINs) received.",
+                    "longDescription": "This property shall contain the total number of Link Integrity FPINs received by this Fibre Channel function.",
+                    "readonly": true,
+                    "type": [
+                        "integer",
+                        "null"
+                    ],
+                    "versionAdded": "v1_1_0"
+                },
+                "RXPeerCongestionFPINs": {
+                    "description": "The total number of Peer Congestion Fabric Performance Impact Notifications (FPINs) received.",
+                    "longDescription": "This property shall contain the total number of Peer Congestion FPINs received by this Fibre Channel function.",
+                    "readonly": true,
+                    "type": [
+                        "integer",
+                        "null"
+                    ],
+                    "versionAdded": "v1_1_0"
+                },
+                "RXSequences": {
+                    "description": "The total number of Fibre Channel sequences received.",
+                    "longDescription": "This property shall contain the total number of Fibre Channel sequences received.",
+                    "readonly": true,
+                    "type": [
+                        "integer",
+                        "null"
+                    ],
+                    "versionAdded": "v1_1_0"
+                },
+                "TXCongestionFPINs": {
+                    "description": "The total number of Congestion Fabric Performance Impact Notifications (FPINs) sent.",
+                    "longDescription": "This property shall contain the total number of Congestion FPINs sent by this Fibre Channel function.",
+                    "readonly": true,
+                    "type": [
+                        "integer",
+                        "null"
+                    ],
+                    "versionAdded": "v1_1_0"
+                },
+                "TXDeliveryFPINs": {
+                    "description": "The total number of Delivery Fabric Performance Impact Notifications (FPINs) sent.",
+                    "longDescription": "This property shall contain the total number of Delivery FPINs sent by this Fibre Channel function.",
+                    "readonly": true,
+                    "type": [
+                        "integer",
+                        "null"
+                    ],
+                    "versionAdded": "v1_1_0"
+                },
+                "TXExchanges": {
+                    "description": "The total number of Fibre Channel exchanges transmitted.",
+                    "longDescription": "This property shall contain the total number of Fibre Channel exchanges transmitted.",
+                    "readonly": true,
+                    "type": [
+                        "integer",
+                        "null"
+                    ],
+                    "versionAdded": "v1_1_0"
+                },
+                "TXLinkIntegrityFPINs": {
+                    "description": "The total number of Link Integrity Fabric Performance Impact Notifications (FPINs) sent.",
+                    "longDescription": "This property shall contain the total number of Link Integrity FPINs sent by this Fibre Channel function.",
+                    "readonly": true,
+                    "type": [
+                        "integer",
+                        "null"
+                    ],
+                    "versionAdded": "v1_1_0"
+                },
+                "TXPeerCongestionFPINs": {
+                    "description": "The total number of Peer Congestion Fabric Performance Impact Notifications (FPINs) sent.",
+                    "longDescription": "This property shall contain the total number of Peer Congestion FPINs sent by this Fibre Channel function.",
+                    "readonly": true,
+                    "type": [
+                        "integer",
+                        "null"
+                    ],
+                    "versionAdded": "v1_1_0"
+                },
+                "TXSequences": {
+                    "description": "The total number of Fibre Channel sequences transmitted.",
+                    "longDescription": "This property shall contain the total number of Fibre Channel sequences transmitted.",
+                    "readonly": true,
+                    "type": [
+                        "integer",
+                        "null"
+                    ],
+                    "versionAdded": "v1_1_0"
+                }
+            },
+            "type": "object"
+        },
+        "NetworkDeviceFunctionMetrics": {
+            "additionalProperties": false,
+            "description": "The NetworkDeviceFunctionMetrics schema contains usage and health statistics for a network function of a network adapter.",
+            "longDescription": "This resource shall represent the network metrics for a single network function of a network adapter in a Redfish implementation.",
+            "patternProperties": {
+                "^([a-zA-Z_][a-zA-Z0-9_]*)?@(odata|Redfish|Message)\\.[a-zA-Z_][a-zA-Z0-9_]*$": {
+                    "description": "This property shall specify a valid odata or Redfish property.",
+                    "type": [
+                        "array",
+                        "boolean",
+                        "integer",
+                        "number",
+                        "null",
+                        "object",
+                        "string"
+                    ]
+                }
+            },
+            "properties": {
+                "@odata.context": {
+                    "$ref": "http://redfish.dmtf.org/schemas/v1/odata-v4.json#/definitions/context"
+                },
+                "@odata.etag": {
+                    "$ref": "http://redfish.dmtf.org/schemas/v1/odata-v4.json#/definitions/etag"
+                },
+                "@odata.id": {
+                    "$ref": "http://redfish.dmtf.org/schemas/v1/odata-v4.json#/definitions/id"
+                },
+                "@odata.type": {
+                    "$ref": "http://redfish.dmtf.org/schemas/v1/odata-v4.json#/definitions/type"
+                },
+                "Actions": {
+                    "$ref": "#/definitions/Actions",
+                    "description": "The available actions for this resource.",
+                    "longDescription": "This property shall contain the available actions for this resource."
+                },
+                "Description": {
+                    "anyOf": [
+                        {
+                            "$ref": "http://redfish.dmtf.org/schemas/v1/Resource.json#/definitions/Description"
+                        },
+                        {
+                            "type": "null"
+                        }
+                    ],
+                    "readonly": true
+                },
+                "Ethernet": {
+                    "$ref": "#/definitions/Ethernet",
+                    "description": "The network function metrics specific to Ethernet adapters.",
+                    "longDescription": "This property shall contain network function metrics specific to Ethernet adapters."
+                },
+                "FibreChannel": {
+                    "$ref": "#/definitions/FibreChannel",
+                    "description": "The network function metrics specific to Fibre Channel adapters.",
+                    "longDescription": "This property shall contain network function metrics specific to Fibre Channel adapters.",
+                    "versionAdded": "v1_1_0"
+                },
+                "Id": {
+                    "$ref": "http://redfish.dmtf.org/schemas/v1/Resource.json#/definitions/Id",
+                    "readonly": true
+                },
+                "Name": {
+                    "$ref": "http://redfish.dmtf.org/schemas/v1/Resource.json#/definitions/Name",
+                    "readonly": true
+                },
+                "Oem": {
+                    "$ref": "http://redfish.dmtf.org/schemas/v1/Resource.json#/definitions/Oem",
+                    "description": "The OEM extension property.",
+                    "longDescription": "This property shall contain the OEM extensions.  All values for properties that this object contains shall conform to the Redfish Specification-described requirements."
+                },
+                "RXAvgQueueDepthPercent": {
+                    "description": "The average RX queue depth as the percentage.",
+                    "longDescription": "This property shall contain the average RX queue depth as the percentage.",
+                    "minimum": 0,
+                    "readonly": true,
+                    "type": [
+                        "number",
+                        "null"
+                    ],
+                    "units": "%"
+                },
+                "RXBytes": {
+                    "description": "The total number of bytes received on a network function.",
+                    "longDescription": "This property shall contain the total number of bytes received on a network function, inclusive of all protocol overhead.",
+                    "readonly": true,
+                    "type": [
+                        "integer",
+                        "null"
+                    ],
+                    "units": "By"
+                },
+                "RXFrames": {
+                    "description": "The total number of frames received on a network function.",
+                    "longDescription": "This property shall contain the total number of frames received on a network function.",
+                    "readonly": true,
+                    "type": [
+                        "integer",
+                        "null"
+                    ]
+                },
+                "RXMulticastFrames": {
+                    "description": "The total number of good multicast frames received on a network function since reset.",
+                    "longDescription": "This property shall contain the total number of good multicast frames received on a network function since reset, including host and remote management passthrough traffic.",
+                    "readonly": true,
+                    "type": [
+                        "integer",
+                        "null"
+                    ]
+                },
+                "RXQueuesEmpty": {
+                    "description": "Whether nothing is in a network function's RX queues to DMA.",
+                    "longDescription": "This property shall indicate whether nothing is in a network function's RX queues to DMA.",
+                    "readonly": true,
+                    "type": [
+                        "boolean",
+                        "null"
+                    ]
+                },
+                "RXQueuesFull": {
+                    "description": "The number of RX queues that are full.",
+                    "longDescription": "This property shall contain the number of RX queues that are full.",
+                    "readonly": true,
+                    "type": [
+                        "integer",
+                        "null"
+                    ]
+                },
+                "RXUnicastFrames": {
+                    "description": "The total number of good unicast frames received on a network function since reset.",
+                    "longDescription": "This property shall contain the total number of good unicast frames received on a network function since reset.",
+                    "readonly": true,
+                    "type": [
+                        "integer",
+                        "null"
+                    ]
+                },
+                "TXAvgQueueDepthPercent": {
+                    "description": "The average TX queue depth as the percentage.",
+                    "longDescription": "This property shall contain the average TX queue depth as the percentage.",
+                    "minimum": 0,
+                    "readonly": true,
+                    "type": [
+                        "number",
+                        "null"
+                    ],
+                    "units": "%"
+                },
+                "TXBytes": {
+                    "description": "The total number of bytes sent on a network function.",
+                    "longDescription": "This property shall contain the total number of bytes sent on a network function, inclusive of all protocol overhead.",
+                    "readonly": true,
+                    "type": [
+                        "integer",
+                        "null"
+                    ],
+                    "units": "By"
+                },
+                "TXFrames": {
+                    "description": "The total number of frames sent on a network function.",
+                    "longDescription": "This property shall contain the total number of frames sent on a network function.",
+                    "readonly": true,
+                    "type": [
+                        "integer",
+                        "null"
+                    ]
+                },
+                "TXMulticastFrames": {
+                    "description": "The total number of good multicast frames transmitted on a network function since reset.",
+                    "longDescription": "This property shall contain the total number of good multicast frames transmitted on a network function since reset, including host and remote management passthrough traffic.",
+                    "readonly": true,
+                    "type": [
+                        "integer",
+                        "null"
+                    ]
+                },
+                "TXQueuesEmpty": {
+                    "description": "Whether all TX queues for a network function are empty.",
+                    "longDescription": "This property shall indicate whether all TX queues for a network function are empty.",
+                    "readonly": true,
+                    "type": [
+                        "boolean",
+                        "null"
+                    ]
+                },
+                "TXQueuesFull": {
+                    "description": "The number of TX queues that are full.",
+                    "longDescription": "This property shall contain the number of TX queues that are full.",
+                    "readonly": true,
+                    "type": [
+                        "integer",
+                        "null"
+                    ]
+                },
+                "TXUnicastFrames": {
+                    "description": "The total number of good unicast frames transmitted on a network function since reset.",
+                    "longDescription": "This property shall contain the total number of good unicast frames transmitted on a network function since reset, including host and remote management passthrough traffic.",
+                    "readonly": true,
+                    "type": [
+                        "integer",
+                        "null"
+                    ]
+                }
+            },
+            "required": [
+                "@odata.id",
+                "@odata.type",
+                "Id",
+                "Name"
+            ],
+            "type": "object"
+        },
+        "OemActions": {
+            "additionalProperties": true,
+            "description": "The available OEM-specific actions for this resource.",
+            "longDescription": "This type shall contain the available OEM-specific actions for this resource.",
+            "patternProperties": {
+                "^([a-zA-Z_][a-zA-Z0-9_]*)?@(odata|Redfish|Message)\\.[a-zA-Z_][a-zA-Z0-9_]*$": {
+                    "description": "This property shall specify a valid odata or Redfish property.",
+                    "type": [
+                        "array",
+                        "boolean",
+                        "integer",
+                        "number",
+                        "null",
+                        "object",
+                        "string"
+                    ]
+                }
+            },
+            "properties": {},
+            "type": "object"
+        }
+    },
+    "owningEntity": "DMTF",
+    "release": "2021.2",
+    "title": "#NetworkDeviceFunctionMetrics.v1_1_0.NetworkDeviceFunctionMetrics"
+}

--- a/static/redfish/v1/JsonSchemas/NetworkDeviceFunctionMetrics/index.json
+++ b/static/redfish/v1/JsonSchemas/NetworkDeviceFunctionMetrics/index.json
@@ -1,0 +1,21 @@
+{
+    "@odata.context": "/redfish/v1/$metadata#JsonSchemaFile.JsonSchemaFile",
+    "@odata.id": "/redfish/v1/JsonSchemas/NetworkDeviceFunctionMetrics",
+    "@odata.type": "#JsonSchemaFile.v1_0_2.JsonSchemaFile",
+    "Name": "NetworkDeviceFunctionMetrics Schema File",
+    "Schema": "#NetworkDeviceFunctionMetrics.NetworkDeviceFunctionMetrics",
+    "Description": "NetworkDeviceFunctionMetrics Schema File Location",
+    "Id": "NetworkDeviceFunctionMetrics",
+    "Languages": [
+        "en"
+    ],
+    "Languages@odata.count": 1,
+    "Location": [
+        {
+            "Language": "en",
+            "PublicationUri": "http://redfish.dmtf.org/schemas/v1/NetworkDeviceFunctionMetrics.json",
+            "Uri": "/redfish/v1/JsonSchemas/NetworkDeviceFunctionMetrics/NetworkDeviceFunctionMetrics.json"
+        }
+    ],
+    "Location@odata.count": 1
+}

--- a/static/redfish/v1/JsonSchemas/NetworkInterface/NetworkInterface.json
+++ b/static/redfish/v1/JsonSchemas/NetworkInterface/NetworkInterface.json
@@ -1,0 +1,194 @@
+{
+    "$id": "http://redfish.dmtf.org/schemas/v1/NetworkInterface.v1_2_1.json",
+    "$ref": "#/definitions/NetworkInterface",
+    "$schema": "http://redfish.dmtf.org/schemas/v1/redfish-schema-v1.json",
+    "copyright": "Copyright 2014-2020 DMTF. For the full DMTF copyright policy, see http://www.dmtf.org/about/policies/copyright",
+    "definitions": {
+        "Actions": {
+            "additionalProperties": false,
+            "description": "The available actions for this resource.",
+            "longDescription": "This type shall contain the available actions for this resource.",
+            "patternProperties": {
+                "^([a-zA-Z_][a-zA-Z0-9_]*)?@(odata|Redfish|Message)\\.[a-zA-Z_][a-zA-Z0-9_]*$": {
+                    "description": "This property shall specify a valid odata or Redfish property.",
+                    "type": [
+                        "array",
+                        "boolean",
+                        "integer",
+                        "number",
+                        "null",
+                        "object",
+                        "string"
+                    ]
+                }
+            },
+            "properties": {
+                "Oem": {
+                    "$ref": "#/definitions/OemActions",
+                    "description": "The available OEM-specific actions for this resource.",
+                    "longDescription": "This property shall contain the available OEM-specific actions for this resource.",
+                    "versionAdded": "v1_1_0"
+                }
+            },
+            "type": "object"
+        },
+        "Links": {
+            "additionalProperties": false,
+            "description": "The links to other resources that are related to this resource.",
+            "longDescription": "This Redfish Specification-described type shall contain links to resources that are related to but are not contained by, or subordinate to, this resource.",
+            "patternProperties": {
+                "^([a-zA-Z_][a-zA-Z0-9_]*)?@(odata|Redfish|Message)\\.[a-zA-Z_][a-zA-Z0-9_]*$": {
+                    "description": "This property shall specify a valid odata or Redfish property.",
+                    "type": [
+                        "array",
+                        "boolean",
+                        "integer",
+                        "number",
+                        "null",
+                        "object",
+                        "string"
+                    ]
+                }
+            },
+            "properties": {
+                "NetworkAdapter": {
+                    "$ref": "http://redfish.dmtf.org/schemas/v1/NetworkAdapter.json#/definitions/NetworkAdapter",
+                    "description": "The link to the network adapter that contains this network interface.",
+                    "longDescription": "This property shall contain a link to a resource of type NetworkAdapter that represents the physical container associated with this network interface.",
+                    "readonly": true
+                },
+                "Oem": {
+                    "$ref": "http://redfish.dmtf.org/schemas/v1/Resource.json#/definitions/Oem",
+                    "description": "The OEM extension property.",
+                    "longDescription": "This property shall contain the OEM extensions.  All values for properties contained in this object shall conform to the Redfish Specification-described requirements."
+                }
+            },
+            "type": "object"
+        },
+        "NetworkInterface": {
+            "additionalProperties": false,
+            "description": "The NetworkInterface schema describes links to the network adapters, network ports, and network device functions, and represents the functionality available to the containing system.",
+            "longDescription": "This resource contains links to the network adapters, network ports, and network device functions, and represents the functionality available to the containing system.",
+            "patternProperties": {
+                "^([a-zA-Z_][a-zA-Z0-9_]*)?@(odata|Redfish|Message)\\.[a-zA-Z_][a-zA-Z0-9_]*$": {
+                    "description": "This property shall specify a valid odata or Redfish property.",
+                    "type": [
+                        "array",
+                        "boolean",
+                        "integer",
+                        "number",
+                        "null",
+                        "object",
+                        "string"
+                    ]
+                }
+            },
+            "properties": {
+                "@odata.context": {
+                    "$ref": "http://redfish.dmtf.org/schemas/v1/odata-v4.json#/definitions/context"
+                },
+                "@odata.etag": {
+                    "$ref": "http://redfish.dmtf.org/schemas/v1/odata-v4.json#/definitions/etag"
+                },
+                "@odata.id": {
+                    "$ref": "http://redfish.dmtf.org/schemas/v1/odata-v4.json#/definitions/id"
+                },
+                "@odata.type": {
+                    "$ref": "http://redfish.dmtf.org/schemas/v1/odata-v4.json#/definitions/type"
+                },
+                "Actions": {
+                    "$ref": "#/definitions/Actions",
+                    "description": "The available actions for this resource.",
+                    "longDescription": "This property shall contain the available actions for this resource.",
+                    "versionAdded": "v1_1_0"
+                },
+                "Description": {
+                    "anyOf": [
+                        {
+                            "$ref": "http://redfish.dmtf.org/schemas/v1/Resource.json#/definitions/Description"
+                        },
+                        {
+                            "type": "null"
+                        }
+                    ],
+                    "readonly": true
+                },
+                "Id": {
+                    "$ref": "http://redfish.dmtf.org/schemas/v1/Resource.json#/definitions/Id",
+                    "readonly": true
+                },
+                "Links": {
+                    "$ref": "#/definitions/Links",
+                    "description": "The links to other resources that are related to this resource.",
+                    "longDescription": "This property shall contain links to resources that are related to but are not contained by, or subordinate to, this resource."
+                },
+                "Name": {
+                    "$ref": "http://redfish.dmtf.org/schemas/v1/Resource.json#/definitions/Name",
+                    "readonly": true
+                },
+                "NetworkDeviceFunctions": {
+                    "$ref": "http://redfish.dmtf.org/schemas/v1/NetworkDeviceFunctionCollection.json#/definitions/NetworkDeviceFunctionCollection",
+                    "description": "The link to the network device functions associated with this network interface.",
+                    "longDescription": "This property shall contain a link to a resource collection of type NetworkDeviceFunctionCollection.",
+                    "readonly": true
+                },
+                "NetworkPorts": {
+                    "$ref": "http://redfish.dmtf.org/schemas/v1/NetworkPortCollection.json#/definitions/NetworkPortCollection",
+                    "deprecated": "This property has been deprecated in favor of the Ports property.",
+                    "description": "The link to the network ports associated with this network interface.",
+                    "longDescription": "This property shall contain a link to a resource collection of type NetworkPortCollection.",
+                    "readonly": true,
+                    "versionDeprecated": "v1_2_0"
+                },
+                "Oem": {
+                    "$ref": "http://redfish.dmtf.org/schemas/v1/Resource.json#/definitions/Oem",
+                    "description": "The OEM extension property.",
+                    "longDescription": "This property shall contain the OEM extensions.  All values for properties that this object contains shall conform to the Redfish Specification-described requirements."
+                },
+                "Ports": {
+                    "$ref": "http://redfish.dmtf.org/schemas/v1/PortCollection.json#/definitions/PortCollection",
+                    "description": "The link to the ports associated with this network interface.",
+                    "longDescription": "This property shall contain a link to a resource collection of type PortCollection.",
+                    "readonly": true,
+                    "versionAdded": "v1_2_0"
+                },
+                "Status": {
+                    "$ref": "http://redfish.dmtf.org/schemas/v1/Resource.json#/definitions/Status",
+                    "description": "The status and health of the resource and its subordinate or dependent resources.",
+                    "longDescription": "This property shall contain any status or health properties of the resource."
+                }
+            },
+            "required": [
+                "@odata.id",
+                "@odata.type",
+                "Id",
+                "Name"
+            ],
+            "type": "object"
+        },
+        "OemActions": {
+            "additionalProperties": true,
+            "description": "The available OEM-specific actions for this resource.",
+            "longDescription": "This type shall contain the available OEM-specific actions for this resource.",
+            "patternProperties": {
+                "^([a-zA-Z_][a-zA-Z0-9_]*)?@(odata|Redfish|Message)\\.[a-zA-Z_][a-zA-Z0-9_]*$": {
+                    "description": "This property shall specify a valid odata or Redfish property.",
+                    "type": [
+                        "array",
+                        "boolean",
+                        "integer",
+                        "number",
+                        "null",
+                        "object",
+                        "string"
+                    ]
+                }
+            },
+            "properties": {},
+            "type": "object"
+        }
+    },
+    "owningEntity": "DMTF",
+    "release": "2020.3",
+    "title": "#NetworkInterface.v1_2_1.NetworkInterface"
+}

--- a/static/redfish/v1/JsonSchemas/NetworkInterface/index.json
+++ b/static/redfish/v1/JsonSchemas/NetworkInterface/index.json
@@ -1,0 +1,21 @@
+{
+    "@odata.context": "/redfish/v1/$metadata#JsonSchemaFile.JsonSchemaFile",
+    "@odata.id": "/redfish/v1/JsonSchemas/NetworkInterface",
+    "@odata.type": "#JsonSchemaFile.v1_0_2.JsonSchemaFile",
+    "Name": "NetworkInterface Schema File",
+    "Schema": "#NetworkInterface.NetworkInterface",
+    "Description": "NetworkInterface Schema File Location",
+    "Id": "NetworkInterface",
+    "Languages": [
+        "en"
+    ],
+    "Languages@odata.count": 1,
+    "Location": [
+        {
+            "Language": "en",
+            "PublicationUri": "http://redfish.dmtf.org/schemas/v1/NetworkInterface.json",
+            "Uri": "/redfish/v1/JsonSchemas/NetworkInterface/NetworkInterface.json"
+        }
+    ],
+    "Location@odata.count": 1
+}

--- a/static/redfish/v1/JsonSchemas/NetworkPort/NetworkPort.json
+++ b/static/redfish/v1/JsonSchemas/NetworkPort/NetworkPort.json
@@ -1,0 +1,577 @@
+{
+    "$id": "http://redfish.dmtf.org/schemas/v1/NetworkPort.v1_4_1.json",
+    "$ref": "#/definitions/NetworkPort",
+    "$schema": "http://redfish.dmtf.org/schemas/v1/redfish-schema-v1.json",
+    "copyright": "Copyright 2014-2021 DMTF. For the full DMTF copyright policy, see http://www.dmtf.org/about/policies/copyright",
+    "definitions": {
+        "Actions": {
+            "additionalProperties": false,
+            "description": "The available actions for this resource.",
+            "longDescription": "This type shall contain the available actions for this resource.",
+            "patternProperties": {
+                "^([a-zA-Z_][a-zA-Z0-9_]*)?@(odata|Redfish|Message)\\.[a-zA-Z_][a-zA-Z0-9_]*$": {
+                    "description": "This property shall specify a valid odata or Redfish property.",
+                    "type": [
+                        "array",
+                        "boolean",
+                        "integer",
+                        "number",
+                        "null",
+                        "object",
+                        "string"
+                    ]
+                }
+            },
+            "properties": {
+                "Oem": {
+                    "$ref": "#/definitions/OemActions",
+                    "description": "The available OEM-specific actions for this resource.",
+                    "longDescription": "This property shall contain the available OEM-specific actions for this resource.",
+                    "versionAdded": "v1_1_0"
+                }
+            },
+            "type": "object"
+        },
+        "FlowControl": {
+            "enum": [
+                "None",
+                "TX",
+                "RX",
+                "TX_RX"
+            ],
+            "enumDescriptions": {
+                "None": "No IEEE 802.3x flow control is enabled on this port.",
+                "RX": "The link partner can initiate IEEE 802.3x flow control.",
+                "TX": "This station can initiate IEEE 802.3x flow control.",
+                "TX_RX": "This station or the link partner can initiate IEEE 802.3x flow control."
+            },
+            "type": "string"
+        },
+        "LinkNetworkTechnology": {
+            "enum": [
+                "Ethernet",
+                "InfiniBand",
+                "FibreChannel"
+            ],
+            "enumDescriptions": {
+                "Ethernet": "The port is capable of connecting to an Ethernet network.",
+                "FibreChannel": "The port is capable of connecting to a Fibre Channel network.",
+                "InfiniBand": "The port is capable of connecting to an InfiniBand network."
+            },
+            "type": "string"
+        },
+        "LinkStatus": {
+            "enum": [
+                "Down",
+                "Up",
+                "Starting",
+                "Training"
+            ],
+            "enumDescriptions": {
+                "Down": "The port is enabled but link is down.",
+                "Starting": "This link on this interface is starting.  A physical link has been established, but the port is not able to transfer data.",
+                "Training": "This physical link on this interface is training.",
+                "Up": "The port is enabled and link is good (up)."
+            },
+            "enumVersionAdded": {
+                "Starting": "v1_3_0",
+                "Training": "v1_3_0"
+            },
+            "type": "string"
+        },
+        "NetDevFuncMaxBWAlloc": {
+            "additionalProperties": false,
+            "description": "A maximum bandwidth allocation percentage for a network device functions associated a port.",
+            "longDescription": "This type shall describe a maximum bandwidth percentage allocation for a network device function associated with a port.",
+            "patternProperties": {
+                "^([a-zA-Z_][a-zA-Z0-9_]*)?@(odata|Redfish|Message)\\.[a-zA-Z_][a-zA-Z0-9_]*$": {
+                    "description": "This property shall specify a valid odata or Redfish property.",
+                    "type": [
+                        "array",
+                        "boolean",
+                        "integer",
+                        "number",
+                        "null",
+                        "object",
+                        "string"
+                    ]
+                }
+            },
+            "properties": {
+                "MaxBWAllocPercent": {
+                    "description": "The maximum bandwidth allocation percentage allocated to the corresponding network device function instance.",
+                    "longDescription": "This property shall contain the maximum bandwidth percentage allocation for the associated network device function.",
+                    "readonly": false,
+                    "type": [
+                        "integer",
+                        "null"
+                    ],
+                    "units": "%"
+                },
+                "NetworkDeviceFunction": {
+                    "$ref": "http://redfish.dmtf.org/schemas/v1/NetworkDeviceFunction.json#/definitions/NetworkDeviceFunction",
+                    "description": "The link to the network device function associated with this bandwidth setting of this network port.",
+                    "longDescription": "This property shall contain a link to a resource of type NetworkDeviceFunction that represents the network device function associated with this bandwidth setting of this network port.",
+                    "readonly": true
+                }
+            },
+            "type": "object"
+        },
+        "NetDevFuncMinBWAlloc": {
+            "additionalProperties": false,
+            "description": "A minimum bandwidth allocation percentage for a network device functions associated a port.",
+            "longDescription": "This type shall describe a minimum bandwidth percentage allocation for a network device function associated with a port.",
+            "patternProperties": {
+                "^([a-zA-Z_][a-zA-Z0-9_]*)?@(odata|Redfish|Message)\\.[a-zA-Z_][a-zA-Z0-9_]*$": {
+                    "description": "This property shall specify a valid odata or Redfish property.",
+                    "type": [
+                        "array",
+                        "boolean",
+                        "integer",
+                        "number",
+                        "null",
+                        "object",
+                        "string"
+                    ]
+                }
+            },
+            "properties": {
+                "MinBWAllocPercent": {
+                    "description": "The minimum bandwidth allocation percentage allocated to the corresponding network device function instance.",
+                    "longDescription": "This property shall contain the minimum bandwidth percentage allocation for the associated network device function.  The sum total of all minimum percentages shall not exceed 100.",
+                    "readonly": false,
+                    "type": [
+                        "integer",
+                        "null"
+                    ],
+                    "units": "%"
+                },
+                "NetworkDeviceFunction": {
+                    "$ref": "http://redfish.dmtf.org/schemas/v1/NetworkDeviceFunction.json#/definitions/NetworkDeviceFunction",
+                    "description": "The link to the network device function associated with this bandwidth setting of this network port.",
+                    "longDescription": "This property shall contain a link to a resource of type NetworkDeviceFunction that represents the network device function associated with this bandwidth setting of this network port.",
+                    "readonly": true
+                }
+            },
+            "type": "object"
+        },
+        "NetworkPort": {
+            "additionalProperties": false,
+            "deprecated": "This schema has been deprecated in favor of the Port schema.",
+            "description": "The NetworkPort schema describes a network port, which is a discrete physical port that can connect to a network.",
+            "longDescription": "This resource shall represent a discrete physical port that can connect to a network in a Redfish implementation.",
+            "patternProperties": {
+                "^([a-zA-Z_][a-zA-Z0-9_]*)?@(odata|Redfish|Message)\\.[a-zA-Z_][a-zA-Z0-9_]*$": {
+                    "description": "This property shall specify a valid odata or Redfish property.",
+                    "type": [
+                        "array",
+                        "boolean",
+                        "integer",
+                        "number",
+                        "null",
+                        "object",
+                        "string"
+                    ]
+                }
+            },
+            "properties": {
+                "@odata.context": {
+                    "$ref": "http://redfish.dmtf.org/schemas/v1/odata-v4.json#/definitions/context"
+                },
+                "@odata.etag": {
+                    "$ref": "http://redfish.dmtf.org/schemas/v1/odata-v4.json#/definitions/etag"
+                },
+                "@odata.id": {
+                    "$ref": "http://redfish.dmtf.org/schemas/v1/odata-v4.json#/definitions/id"
+                },
+                "@odata.type": {
+                    "$ref": "http://redfish.dmtf.org/schemas/v1/odata-v4.json#/definitions/type"
+                },
+                "Actions": {
+                    "$ref": "#/definitions/Actions",
+                    "description": "The available actions for this resource.",
+                    "longDescription": "This property shall contain the available actions for this resource.",
+                    "versionAdded": "v1_1_0"
+                },
+                "ActiveLinkTechnology": {
+                    "anyOf": [
+                        {
+                            "$ref": "#/definitions/LinkNetworkTechnology"
+                        },
+                        {
+                            "type": "null"
+                        }
+                    ],
+                    "description": "Network port active link technology.",
+                    "longDescription": "This property shall contain the configured link technology of this port.",
+                    "readonly": false
+                },
+                "AssociatedNetworkAddresses": {
+                    "description": "An array of configured MAC or WWN network addresses that are associated with this network port, including the programmed address of the lowest numbered network device function, the configured but not active address, if applicable, the address for hardware port teaming, or other network addresses.",
+                    "items": {
+                        "type": [
+                            "string",
+                            "null"
+                        ]
+                    },
+                    "longDescription": "This property shall contain an array of configured network addresses that are associated with this network port, including the programmed address of the lowest numbered network device function, the configured but not active address if applicable, the address for hardware port teaming, or other network addresses.",
+                    "readonly": true,
+                    "type": "array"
+                },
+                "CurrentLinkSpeedMbps": {
+                    "description": "Network port current link speed.",
+                    "longDescription": "This property shall contain the current configured link speed of this port.",
+                    "readonly": false,
+                    "type": [
+                        "integer",
+                        "null"
+                    ],
+                    "units": "Mbit/s",
+                    "versionAdded": "v1_2_0"
+                },
+                "Description": {
+                    "anyOf": [
+                        {
+                            "$ref": "http://redfish.dmtf.org/schemas/v1/Resource.json#/definitions/Description"
+                        },
+                        {
+                            "type": "null"
+                        }
+                    ],
+                    "readonly": true
+                },
+                "EEEEnabled": {
+                    "description": "An indication of whether IEEE 802.3az Energy-Efficient Ethernet (EEE) is enabled for this network port.",
+                    "longDescription": "This property shall indicate whether IEEE 802.3az Energy-Efficient Ethernet (EEE) is enabled for this network port.",
+                    "readonly": false,
+                    "type": [
+                        "boolean",
+                        "null"
+                    ]
+                },
+                "FCFabricName": {
+                    "description": "The FC Fabric Name provided by the switch.",
+                    "longDescription": "This property shall indicate the FC Fabric Name provided by the switch.",
+                    "readonly": true,
+                    "type": [
+                        "string",
+                        "null"
+                    ],
+                    "versionAdded": "v1_2_0"
+                },
+                "FCPortConnectionType": {
+                    "anyOf": [
+                        {
+                            "$ref": "#/definitions/PortConnectionType"
+                        },
+                        {
+                            "type": "null"
+                        }
+                    ],
+                    "description": "The connection type of this port.",
+                    "longDescription": "This property shall contain the connection type for this port.",
+                    "readonly": true,
+                    "versionAdded": "v1_2_0"
+                },
+                "FlowControlConfiguration": {
+                    "anyOf": [
+                        {
+                            "$ref": "#/definitions/FlowControl"
+                        },
+                        {
+                            "type": "null"
+                        }
+                    ],
+                    "description": "The locally configured 802.3x flow control setting for this network port.",
+                    "longDescription": "This property shall contain the locally configured 802.3x flow control setting for this network port.",
+                    "readonly": false
+                },
+                "FlowControlStatus": {
+                    "anyOf": [
+                        {
+                            "$ref": "#/definitions/FlowControl"
+                        },
+                        {
+                            "type": "null"
+                        }
+                    ],
+                    "description": "The 802.3x flow control behavior negotiated with the link partner for this network port (Ethernet-only).",
+                    "longDescription": "This property shall contain the 802.3x flow control behavior negotiated with the link partner for this network port (Ethernet-only).",
+                    "readonly": true
+                },
+                "Id": {
+                    "$ref": "http://redfish.dmtf.org/schemas/v1/Resource.json#/definitions/Id",
+                    "readonly": true
+                },
+                "LinkStatus": {
+                    "anyOf": [
+                        {
+                            "$ref": "#/definitions/LinkStatus"
+                        },
+                        {
+                            "type": "null"
+                        }
+                    ],
+                    "description": "The status of the link between this port and its link partner.",
+                    "longDescription": "This property shall contain the link status between this port and its link partner.",
+                    "readonly": true
+                },
+                "MaxFrameSize": {
+                    "description": "The maximum frame size supported by the port.",
+                    "longDescription": "This property shall contain the maximum frame size supported by the port.",
+                    "readonly": true,
+                    "type": [
+                        "integer",
+                        "null"
+                    ],
+                    "units": "By",
+                    "versionAdded": "v1_2_0"
+                },
+                "Name": {
+                    "$ref": "http://redfish.dmtf.org/schemas/v1/Resource.json#/definitions/Name",
+                    "readonly": true
+                },
+                "NetDevFuncMaxBWAlloc": {
+                    "description": "An array of maximum bandwidth allocation percentages for the network device functions associated with this port.",
+                    "items": {
+                        "$ref": "#/definitions/NetDevFuncMaxBWAlloc"
+                    },
+                    "longDescription": "This property shall contain an array of maximum bandwidth allocation percentages for the network device functions associated with this port.",
+                    "type": "array"
+                },
+                "NetDevFuncMinBWAlloc": {
+                    "description": "An array of minimum bandwidth allocation percentages for the network device functions associated with this port.",
+                    "items": {
+                        "$ref": "#/definitions/NetDevFuncMinBWAlloc"
+                    },
+                    "longDescription": "This property shall contain an array of minimum bandwidth percentage allocations for each of the network device functions associated with this port.",
+                    "type": "array"
+                },
+                "NumberDiscoveredRemotePorts": {
+                    "description": "The number of ports not on this adapter that this port has discovered.",
+                    "longDescription": "This property shall contain the number of ports not on this adapter that this port has discovered.",
+                    "readonly": true,
+                    "type": [
+                        "integer",
+                        "null"
+                    ],
+                    "versionAdded": "v1_2_0"
+                },
+                "Oem": {
+                    "$ref": "http://redfish.dmtf.org/schemas/v1/Resource.json#/definitions/Oem",
+                    "description": "The OEM extension property.",
+                    "longDescription": "This property shall contain the OEM extensions.  All values for properties that this object contains shall conform to the Redfish Specification-described requirements."
+                },
+                "PhysicalPortNumber": {
+                    "description": "The physical port number label for this port.",
+                    "longDescription": "This property shall contain the physical port number on the network adapter hardware that this network port corresponds to.  This value should match a value visible on the hardware.",
+                    "readonly": true,
+                    "type": [
+                        "string",
+                        "null"
+                    ]
+                },
+                "PortMaximumMTU": {
+                    "description": "The largest maximum transmission unit (MTU) that can be configured for this network port.",
+                    "longDescription": "This property shall contain the largest maximum transmission unit (MTU) that can be configured for this network port.",
+                    "readonly": true,
+                    "type": [
+                        "integer",
+                        "null"
+                    ]
+                },
+                "SignalDetected": {
+                    "description": "An indication of whether the port has detected enough signal on enough lanes to establish a link.",
+                    "longDescription": "This property shall indicate whether the port has detected enough signal on enough lanes to establish a link.",
+                    "readonly": true,
+                    "type": [
+                        "boolean",
+                        "null"
+                    ]
+                },
+                "Status": {
+                    "$ref": "http://redfish.dmtf.org/schemas/v1/Resource.json#/definitions/Status",
+                    "description": "The status and health of the resource and its subordinate or dependent resources.",
+                    "longDescription": "This property shall contain any status or health properties of the resource."
+                },
+                "SupportedEthernetCapabilities": {
+                    "description": "The set of Ethernet capabilities that this port supports.",
+                    "items": {
+                        "anyOf": [
+                            {
+                                "$ref": "#/definitions/SupportedEthernetCapabilities"
+                            },
+                            {
+                                "type": "null"
+                            }
+                        ]
+                    },
+                    "longDescription": "This property shall contain an array of zero or more Ethernet capabilities supported by this port.",
+                    "readonly": true,
+                    "type": "array"
+                },
+                "SupportedLinkCapabilities": {
+                    "description": "The link capabilities of this port.",
+                    "items": {
+                        "$ref": "#/definitions/SupportedLinkCapabilities"
+                    },
+                    "longDescription": "This property shall describe the static capabilities of the port, irrespective of transient conditions such as cabling, interface module presence, or remote link partner status or configuration.",
+                    "type": "array"
+                },
+                "VendorId": {
+                    "description": "The vendor Identification for this port.",
+                    "longDescription": "This property shall indicate the vendor identification string information as provided by the manufacturer of this port.",
+                    "readonly": true,
+                    "type": [
+                        "string",
+                        "null"
+                    ],
+                    "versionAdded": "v1_2_0"
+                },
+                "WakeOnLANEnabled": {
+                    "description": "An indication of whether Wake on LAN (WoL) is enabled for this network port.",
+                    "longDescription": "This property shall indicate whether Wake on LAN (WoL) is enabled for this network port.",
+                    "readonly": false,
+                    "type": [
+                        "boolean",
+                        "null"
+                    ]
+                }
+            },
+            "required": [
+                "@odata.id",
+                "@odata.type",
+                "Id",
+                "Name"
+            ],
+            "type": "object",
+            "versionDeprecated": "v1_4_0"
+        },
+        "OemActions": {
+            "additionalProperties": true,
+            "description": "The available OEM-specific actions for this resource.",
+            "longDescription": "This type shall contain the available OEM-specific actions for this resource.",
+            "patternProperties": {
+                "^([a-zA-Z_][a-zA-Z0-9_]*)?@(odata|Redfish|Message)\\.[a-zA-Z_][a-zA-Z0-9_]*$": {
+                    "description": "This property shall specify a valid odata or Redfish property.",
+                    "type": [
+                        "array",
+                        "boolean",
+                        "integer",
+                        "number",
+                        "null",
+                        "object",
+                        "string"
+                    ]
+                }
+            },
+            "properties": {},
+            "type": "object"
+        },
+        "PortConnectionType": {
+            "enum": [
+                "NotConnected",
+                "NPort",
+                "PointToPoint",
+                "PrivateLoop",
+                "PublicLoop",
+                "Generic",
+                "ExtenderFabric"
+            ],
+            "enumDescriptions": {
+                "ExtenderFabric": "This port connection type is an extender fabric port.",
+                "Generic": "This port connection type is a generic fabric port.",
+                "NPort": "This port connects through an N-port to a switch.",
+                "NotConnected": "This port is not connected.",
+                "PointToPoint": "This port connects in a point-to-point configuration.",
+                "PrivateLoop": "This port connects in a private loop configuration.",
+                "PublicLoop": "This port connects in a public configuration."
+            },
+            "type": "string"
+        },
+        "SupportedEthernetCapabilities": {
+            "enum": [
+                "WakeOnLAN",
+                "EEE"
+            ],
+            "enumDescriptions": {
+                "EEE": "IEEE 802.3az Energy-Efficient Ethernet (EEE) is supported on this port.",
+                "WakeOnLAN": "Wake on LAN (WoL) is supported on this port."
+            },
+            "type": "string"
+        },
+        "SupportedLinkCapabilities": {
+            "additionalProperties": false,
+            "description": "The link capabilities of an associated port.",
+            "longDescription": "This type shall describe the static capabilities of an associated port, irrespective of transient conditions such as cabling, interface module presence, or remote link partner status or configuration.",
+            "patternProperties": {
+                "^([a-zA-Z_][a-zA-Z0-9_]*)?@(odata|Redfish|Message)\\.[a-zA-Z_][a-zA-Z0-9_]*$": {
+                    "description": "This property shall specify a valid odata or Redfish property.",
+                    "type": [
+                        "array",
+                        "boolean",
+                        "integer",
+                        "number",
+                        "null",
+                        "object",
+                        "string"
+                    ]
+                }
+            },
+            "properties": {
+                "AutoSpeedNegotiation": {
+                    "description": "An indication of whether the port is capable of autonegotiating speed.",
+                    "longDescription": "This property shall indicate whether the port is capable of autonegotiating speed.",
+                    "readonly": true,
+                    "type": [
+                        "boolean",
+                        "null"
+                    ],
+                    "versionAdded": "v1_2_0"
+                },
+                "CapableLinkSpeedMbps": {
+                    "description": "The set of link speed capabilities of this port.",
+                    "items": {
+                        "type": [
+                            "integer",
+                            "null"
+                        ]
+                    },
+                    "longDescription": "This property shall contain all of the possible network link speed capabilities of this port.",
+                    "readonly": true,
+                    "type": "array",
+                    "versionAdded": "v1_2_0"
+                },
+                "LinkNetworkTechnology": {
+                    "anyOf": [
+                        {
+                            "$ref": "#/definitions/LinkNetworkTechnology"
+                        },
+                        {
+                            "type": "null"
+                        }
+                    ],
+                    "description": "The link network technology capabilities of this port.",
+                    "longDescription": "This property shall contain a network technology capability of this port.",
+                    "readonly": true
+                },
+                "LinkSpeedMbps": {
+                    "deprecated": "This property has been deprecated in favor of the CapableLinkSpeedMbps.",
+                    "description": "The speed of the link in Mbit/s when this link network technology is active.",
+                    "longDescription": "This property shall contain the speed of the link in megabits per second (Mbit/s) for this port when this link network technology is active.",
+                    "readonly": true,
+                    "type": [
+                        "integer",
+                        "null"
+                    ],
+                    "units": "Mbit/s",
+                    "versionDeprecated": "v1_2_0"
+                }
+            },
+            "type": "object"
+        }
+    },
+    "owningEntity": "DMTF",
+    "release": "2020.4",
+    "title": "#NetworkPort.v1_4_1.NetworkPort"
+}

--- a/static/redfish/v1/JsonSchemas/NetworkPort/index.json
+++ b/static/redfish/v1/JsonSchemas/NetworkPort/index.json
@@ -1,0 +1,21 @@
+{
+    "@odata.context": "/redfish/v1/$metadata#JsonSchemaFile.JsonSchemaFile",
+    "@odata.id": "/redfish/v1/JsonSchemas/NetworkPort",
+    "@odata.type": "#JsonSchemaFile.v1_0_2.JsonSchemaFile",
+    "Name": "NetworkPort Schema File",
+    "Schema": "#NetworkPort.NetworkPort",
+    "Description": "NetworkPort Schema File Location",
+    "Id": "NetworkPort",
+    "Languages": [
+        "en"
+    ],
+    "Languages@odata.count": 1,
+    "Location": [
+        {
+            "Language": "en",
+            "PublicationUri": "http://redfish.dmtf.org/schemas/v1/NetworkPort.json",
+            "Uri": "/redfish/v1/JsonSchemas/NetworkPort/NetworkPort.json"
+        }
+    ],
+    "Location@odata.count": 1
+}

--- a/static/redfish/v1/JsonSchemas/Outlet/Outlet.json
+++ b/static/redfish/v1/JsonSchemas/Outlet/Outlet.json
@@ -1,0 +1,707 @@
+{
+    "$id": "http://redfish.dmtf.org/schemas/v1/Outlet.v1_2_0.json",
+    "$ref": "#/definitions/Outlet",
+    "$schema": "http://redfish.dmtf.org/schemas/v1/redfish-schema-v1.json",
+    "copyright": "Copyright 2014-2021 DMTF. For the full DMTF copyright policy, see http://www.dmtf.org/about/policies/copyright",
+    "definitions": {
+        "Actions": {
+            "additionalProperties": false,
+            "description": "The available actions for this resource.",
+            "longDescription": "This type shall contain the available actions for this resource.",
+            "patternProperties": {
+                "^([a-zA-Z_][a-zA-Z0-9_]*)?@(odata|Redfish|Message)\\.[a-zA-Z_][a-zA-Z0-9_]*$": {
+                    "description": "This property shall specify a valid odata or Redfish property.",
+                    "type": [
+                        "array",
+                        "boolean",
+                        "integer",
+                        "number",
+                        "null",
+                        "object",
+                        "string"
+                    ]
+                }
+            },
+            "properties": {
+                "#Outlet.PowerControl": {
+                    "$ref": "#/definitions/PowerControl"
+                },
+                "#Outlet.ResetMetrics": {
+                    "$ref": "#/definitions/ResetMetrics"
+                },
+                "Oem": {
+                    "$ref": "#/definitions/OemActions",
+                    "description": "The available OEM-specific actions for this resource.",
+                    "longDescription": "This property shall contain the available OEM-specific actions for this resource."
+                }
+            },
+            "type": "object"
+        },
+        "CurrentSensors": {
+            "additionalProperties": false,
+            "description": "The current sensors for this outlet.",
+            "longDescription": "This type shall contain properties that describe current sensor readings for an outlet.",
+            "patternProperties": {
+                "^([a-zA-Z_][a-zA-Z0-9_]*)?@(odata|Redfish|Message)\\.[a-zA-Z_][a-zA-Z0-9_]*$": {
+                    "description": "This property shall specify a valid odata or Redfish property.",
+                    "type": [
+                        "array",
+                        "boolean",
+                        "integer",
+                        "number",
+                        "null",
+                        "object",
+                        "string"
+                    ]
+                }
+            },
+            "properties": {
+                "Line1": {
+                    "anyOf": [
+                        {
+                            "$ref": "http://redfish.dmtf.org/schemas/v1/Sensor.json#/definitions/SensorCurrentExcerpt"
+                        },
+                        {
+                            "type": "null"
+                        }
+                    ],
+                    "description": "Line 1 current sensor.",
+                    "excerptCopy": "SensorCurrentExcerpt",
+                    "longDescription": "This property shall contain a Sensor excerpt of type Current that measures current for L1.  This property shall not be present if the outlet does not include an L1 measurement."
+                },
+                "Line2": {
+                    "anyOf": [
+                        {
+                            "$ref": "http://redfish.dmtf.org/schemas/v1/Sensor.json#/definitions/SensorCurrentExcerpt"
+                        },
+                        {
+                            "type": "null"
+                        }
+                    ],
+                    "description": "Line 2 current sensor.",
+                    "excerptCopy": "SensorCurrentExcerpt",
+                    "longDescription": "This property shall contain a Sensor excerpt of type Current that measures current for L2.  This property shall not be present if the outlet does not include an L2 measurement."
+                },
+                "Line3": {
+                    "anyOf": [
+                        {
+                            "$ref": "http://redfish.dmtf.org/schemas/v1/Sensor.json#/definitions/SensorCurrentExcerpt"
+                        },
+                        {
+                            "type": "null"
+                        }
+                    ],
+                    "description": "Line 3 current sensor.",
+                    "excerptCopy": "SensorCurrentExcerpt",
+                    "longDescription": "This property shall contain a Sensor excerpt of type Current that measures current for L3.  This property shall not be present if the outlet does not include an L3 measurement."
+                },
+                "Neutral": {
+                    "anyOf": [
+                        {
+                            "$ref": "http://redfish.dmtf.org/schemas/v1/Sensor.json#/definitions/SensorCurrentExcerpt"
+                        },
+                        {
+                            "type": "null"
+                        }
+                    ],
+                    "description": "Neutral line current sensor.",
+                    "excerptCopy": "SensorCurrentExcerpt",
+                    "longDescription": "This property shall contain a Sensor excerpt of type Current that measures current for the Neutral line.  This property shall not be present if the outlet does not include a Neutral measurement."
+                }
+            },
+            "type": "object"
+        },
+        "Links": {
+            "additionalProperties": false,
+            "description": "The links to other resources that are related to this resource.",
+            "longDescription": "This Redfish Specification-described type shall contain links to resources that are related to but are not contained by, or subordinate to, this resource.",
+            "patternProperties": {
+                "^([a-zA-Z_][a-zA-Z0-9_]*)?@(odata|Redfish|Message)\\.[a-zA-Z_][a-zA-Z0-9_]*$": {
+                    "description": "This property shall specify a valid odata or Redfish property.",
+                    "type": [
+                        "array",
+                        "boolean",
+                        "integer",
+                        "number",
+                        "null",
+                        "object",
+                        "string"
+                    ]
+                }
+            },
+            "properties": {
+                "BranchCircuit": {
+                    "anyOf": [
+                        {
+                            "$ref": "http://redfish.dmtf.org/schemas/v1/Circuit.json#/definitions/Circuit"
+                        },
+                        {
+                            "type": "null"
+                        }
+                    ],
+                    "description": "A reference to the branch circuit related to this outlet.",
+                    "longDescription": "This property shall contain a link to a resource of type Circuit that represent the branch circuit associated with this outlet.",
+                    "readonly": true
+                },
+                "Oem": {
+                    "$ref": "http://redfish.dmtf.org/schemas/v1/Resource.json#/definitions/Oem",
+                    "description": "The OEM extension property.",
+                    "longDescription": "This property shall contain the OEM extensions.  All values for properties contained in this object shall conform to the Redfish Specification-described requirements."
+                }
+            },
+            "type": "object"
+        },
+        "OemActions": {
+            "additionalProperties": true,
+            "description": "The available OEM-specific actions for this resource.",
+            "longDescription": "This type shall contain the available OEM-specific actions for this resource.",
+            "patternProperties": {
+                "^([a-zA-Z_][a-zA-Z0-9_]*)?@(odata|Redfish|Message)\\.[a-zA-Z_][a-zA-Z0-9_]*$": {
+                    "description": "This property shall specify a valid odata or Redfish property.",
+                    "type": [
+                        "array",
+                        "boolean",
+                        "integer",
+                        "number",
+                        "null",
+                        "object",
+                        "string"
+                    ]
+                }
+            },
+            "properties": {},
+            "type": "object"
+        },
+        "Outlet": {
+            "additionalProperties": false,
+            "description": "The Outlet schema contains definition for an electrical outlet.",
+            "longDescription": "This resource shall be used to represent an electrical outlet for a Redfish implementation.",
+            "patternProperties": {
+                "^([a-zA-Z_][a-zA-Z0-9_]*)?@(odata|Redfish|Message)\\.[a-zA-Z_][a-zA-Z0-9_]*$": {
+                    "description": "This property shall specify a valid odata or Redfish property.",
+                    "type": [
+                        "array",
+                        "boolean",
+                        "integer",
+                        "number",
+                        "null",
+                        "object",
+                        "string"
+                    ]
+                }
+            },
+            "properties": {
+                "@odata.context": {
+                    "$ref": "http://redfish.dmtf.org/schemas/v1/odata-v4.json#/definitions/context"
+                },
+                "@odata.etag": {
+                    "$ref": "http://redfish.dmtf.org/schemas/v1/odata-v4.json#/definitions/etag"
+                },
+                "@odata.id": {
+                    "$ref": "http://redfish.dmtf.org/schemas/v1/odata-v4.json#/definitions/id"
+                },
+                "@odata.type": {
+                    "$ref": "http://redfish.dmtf.org/schemas/v1/odata-v4.json#/definitions/type"
+                },
+                "Actions": {
+                    "$ref": "#/definitions/Actions",
+                    "description": "The available actions for this resource.",
+                    "longDescription": "This property shall contain the available actions for this resource."
+                },
+                "CurrentAmps": {
+                    "anyOf": [
+                        {
+                            "$ref": "http://redfish.dmtf.org/schemas/v1/Sensor.json#/definitions/SensorCurrentExcerpt"
+                        },
+                        {
+                            "type": "null"
+                        }
+                    ],
+                    "description": "The current reading for this single phase outlet.",
+                    "excerptCopy": "SensorCurrentExcerpt",
+                    "longDescription": "This property shall contain the current, measured in Amperes, for this single phase outlet.  This property shall not appear in resource instances representing poly-phase outlets."
+                },
+                "Description": {
+                    "anyOf": [
+                        {
+                            "$ref": "http://redfish.dmtf.org/schemas/v1/Resource.json#/definitions/Description"
+                        },
+                        {
+                            "type": "null"
+                        }
+                    ],
+                    "readonly": true
+                },
+                "ElectricalContext": {
+                    "anyOf": [
+                        {
+                            "$ref": "http://redfish.dmtf.org/schemas/v1/Sensor.json#/definitions/ElectricalContext"
+                        },
+                        {
+                            "type": "null"
+                        }
+                    ],
+                    "description": "The combination of current-carrying conductors.",
+                    "longDescription": "This property shall contain the combination of current-carrying conductors that distribute power.",
+                    "readonly": true
+                },
+                "EnergykWh": {
+                    "anyOf": [
+                        {
+                            "$ref": "http://redfish.dmtf.org/schemas/v1/Sensor.json#/definitions/SensorEnergykWhExcerpt"
+                        },
+                        {
+                            "type": "null"
+                        }
+                    ],
+                    "description": "The energy reading for this outlet.",
+                    "excerptCopy": "SensorEnergykWhExcerpt",
+                    "longDescription": "This property shall contain the total energy, measured in kilowatt-hours (kW.h), for this outlet, that represents the `Total` ElectricalContext sensor when multiple energy sensors exist for this outlet."
+                },
+                "FrequencyHz": {
+                    "anyOf": [
+                        {
+                            "$ref": "http://redfish.dmtf.org/schemas/v1/Sensor.json#/definitions/SensorExcerpt"
+                        },
+                        {
+                            "type": "null"
+                        }
+                    ],
+                    "description": "The frequency reading for this outlet.",
+                    "excerptCopy": "SensorExcerpt",
+                    "longDescription": "This property shall contain the frequency sensor for this outlet."
+                },
+                "Id": {
+                    "$ref": "http://redfish.dmtf.org/schemas/v1/Resource.json#/definitions/Id",
+                    "readonly": true
+                },
+                "IndicatorLED": {
+                    "anyOf": [
+                        {
+                            "$ref": "http://redfish.dmtf.org/schemas/v1/Resource.json#/definitions/IndicatorLED"
+                        },
+                        {
+                            "type": "null"
+                        }
+                    ],
+                    "deprecated": "This property has been deprecated in favor of the LocationIndicatorActive property.",
+                    "description": "The state of the indicator LED, which identifies the outlet.",
+                    "longDescription": "This property shall contain the indicator light state for the indicator light associated with this outlet.",
+                    "readonly": false,
+                    "versionDeprecated": "v1_1_0"
+                },
+                "Links": {
+                    "$ref": "#/definitions/Links",
+                    "description": "The links to other resources that are related to this resource.",
+                    "longDescription": "This property shall contain links to resources that are related to but are not contained by, or subordinate to, this resource."
+                },
+                "LocationIndicatorActive": {
+                    "description": "An indicator allowing an operator to physically locate this resource.",
+                    "longDescription": "This property shall contain the state of the indicator used to physically identify or locate this resource.  A write to this property shall update the value of IndicatorLED in this resource, if supported, to reflect the implementation of the locating function.",
+                    "readonly": false,
+                    "type": [
+                        "boolean",
+                        "null"
+                    ],
+                    "versionAdded": "v1_1_0"
+                },
+                "Name": {
+                    "$ref": "http://redfish.dmtf.org/schemas/v1/Resource.json#/definitions/Name",
+                    "readonly": true
+                },
+                "NominalVoltage": {
+                    "anyOf": [
+                        {
+                            "$ref": "http://redfish.dmtf.org/schemas/v1/Circuit.json#/definitions/NominalVoltageType"
+                        },
+                        {
+                            "type": "null"
+                        }
+                    ],
+                    "description": "The nominal voltage for this outlet.",
+                    "longDescription": "This property shall contain the nominal voltage for this outlet, in Volts.",
+                    "readonly": true
+                },
+                "Oem": {
+                    "$ref": "http://redfish.dmtf.org/schemas/v1/Resource.json#/definitions/Oem",
+                    "description": "The OEM extension property.",
+                    "longDescription": "This property shall contain the OEM extensions.  All values for properties that this object contains shall conform to the Redfish Specification-described requirements."
+                },
+                "OutletType": {
+                    "anyOf": [
+                        {
+                            "$ref": "http://redfish.dmtf.org/schemas/v1/Outlet.json#/definitions/ReceptacleType"
+                        },
+                        {
+                            "type": "null"
+                        }
+                    ],
+                    "description": "The type of receptacle according to NEMA, IEC, or regional standards.",
+                    "longDescription": "This property shall contain the type of physical receptacle used for this outlet, as defined by IEC, NEMA, or regional standard.",
+                    "readonly": true
+                },
+                "PhaseWiringType": {
+                    "anyOf": [
+                        {
+                            "$ref": "http://redfish.dmtf.org/schemas/v1/Circuit.json#/definitions/PhaseWiringType"
+                        },
+                        {
+                            "type": "null"
+                        }
+                    ],
+                    "description": "The number of ungrounded current-carrying conductors (phases) and the total number of conductors (wires).",
+                    "longDescription": "This property shall contain the number of ungrounded current-carrying conductors (phases) and the total number of conductors (wires).",
+                    "readonly": true
+                },
+                "PolyPhaseCurrentAmps": {
+                    "anyOf": [
+                        {
+                            "$ref": "#/definitions/CurrentSensors"
+                        },
+                        {
+                            "type": "null"
+                        }
+                    ],
+                    "description": "The current readings for this outlet.",
+                    "longDescription": "This property shall contain the current sensor(s) for this outlet.  For single phase outlets this property shall contain a duplicate copy of the current sensor referenced in the CurrentSensor property, if present.  For poly-phase outlets this property should contain multiple current sensor readings used to fully describe the outlet."
+                },
+                "PolyPhaseVoltage": {
+                    "anyOf": [
+                        {
+                            "$ref": "#/definitions/VoltageSensors"
+                        },
+                        {
+                            "type": "null"
+                        }
+                    ],
+                    "description": "The voltage readings for this outlet.",
+                    "longDescription": "This property shall contain the voltage sensor(s) for this outlet.  For single phase outlets this property shall contain a duplicate copy of the voltage sensor referenced in the VoltageSensor property, if present.  For poly-phase outlets this property should contain multiple voltage sensor readings used to fully describe the outlet."
+                },
+                "PowerCycleDelaySeconds": {
+                    "description": "The number of seconds to delay power on after a PowerControl action to cycle power.  Zero seconds indicates no delay.",
+                    "longDescription": "This property shall contain the number of seconds to delay power on after a PowerControl action to cycle power.  The value `0` shall indicate no delay to power on.",
+                    "readonly": false,
+                    "type": [
+                        "number",
+                        "null"
+                    ]
+                },
+                "PowerEnabled": {
+                    "description": "Indicates if the outlet can be powered.",
+                    "longDescription": "This property shall indicate the power enable state of the outlet.  The value `true` shall indicate that the outlet can be powered on, and `false` shall indicate that the outlet cannot be powered.",
+                    "readonly": true,
+                    "type": [
+                        "boolean",
+                        "null"
+                    ]
+                },
+                "PowerLoadPercent": {
+                    "anyOf": [
+                        {
+                            "$ref": "http://redfish.dmtf.org/schemas/v1/Sensor.json#/definitions/SensorExcerpt"
+                        },
+                        {
+                            "type": "null"
+                        }
+                    ],
+                    "description": "The power load (%) for this outlet.",
+                    "excerptCopy": "SensorExcerpt",
+                    "longDescription": "This property shall contain the power load, measured in percent, for this outlet, that represents the `Total` ElectricalContext for this outlet.",
+                    "versionAdded": "v1_2_0"
+                },
+                "PowerOffDelaySeconds": {
+                    "description": "The number of seconds to delay power off after a PowerControl action.  Zero seconds indicates no delay to power off.",
+                    "longDescription": "This property shall contain the number of seconds to delay power off after a PowerControl action.  The value `0` shall indicate no delay to power off.",
+                    "readonly": false,
+                    "type": [
+                        "number",
+                        "null"
+                    ]
+                },
+                "PowerOnDelaySeconds": {
+                    "description": "The number of seconds to delay power up after a power cycle or a PowerControl action.  Zero seconds indicates no delay to power up.",
+                    "longDescription": "This property shall contain the number of seconds to delay power up after a power cycle or a PowerControl action.  The value `0` shall indicate no delay to power up.",
+                    "readonly": false,
+                    "type": [
+                        "number",
+                        "null"
+                    ]
+                },
+                "PowerRestoreDelaySeconds": {
+                    "description": "The number of seconds to delay power on after power has been restored.  Zero seconds indicates no delay.",
+                    "longDescription": "This property shall contain the number of seconds to delay power on after a power fault.  The value `0` shall indicate no delay to power on.",
+                    "readonly": false,
+                    "type": [
+                        "number",
+                        "null"
+                    ]
+                },
+                "PowerRestorePolicy": {
+                    "$ref": "http://redfish.dmtf.org/schemas/v1/Circuit.json#/definitions/PowerRestorePolicyTypes",
+                    "description": "The desired power state of the outlet when power is restored after a power loss.",
+                    "longDescription": "This property shall contain the desired PowerState of the outlet when power is applied.  The value `LastState` shall return the outlet to the PowerState it was in when power was lost.",
+                    "readonly": false
+                },
+                "PowerState": {
+                    "anyOf": [
+                        {
+                            "$ref": "http://redfish.dmtf.org/schemas/v1/Resource.json#/definitions/PowerState"
+                        },
+                        {
+                            "type": "null"
+                        }
+                    ],
+                    "description": "The power state of the outlet.",
+                    "longDescription": "This property shall contain the power state of the outlet.",
+                    "readonly": true
+                },
+                "PowerWatts": {
+                    "anyOf": [
+                        {
+                            "$ref": "http://redfish.dmtf.org/schemas/v1/Sensor.json#/definitions/SensorPowerExcerpt"
+                        },
+                        {
+                            "type": "null"
+                        }
+                    ],
+                    "description": "The power reading for this outlet.",
+                    "excerptCopy": "SensorPowerExcerpt",
+                    "longDescription": "This property shall contain the total power, measured in Watts, for this outlet, that represents the `Total` ElectricalContext sensor when multiple power sensors exist for this outlet."
+                },
+                "RatedCurrentAmps": {
+                    "description": "The rated maximum current allowed for this outlet.",
+                    "longDescription": "This property shall contain the rated maximum current for this outlet, in Amps, after any required de-rating, due to safety agency or other regulatory requirements, has been applied.",
+                    "minimum": 0,
+                    "readonly": true,
+                    "type": [
+                        "number",
+                        "null"
+                    ],
+                    "units": "A"
+                },
+                "Status": {
+                    "$ref": "http://redfish.dmtf.org/schemas/v1/Resource.json#/definitions/Status",
+                    "description": "The status and health of the resource and its subordinate or dependent resources.",
+                    "longDescription": "This property shall contain any status or health properties of the resource."
+                },
+                "Voltage": {
+                    "anyOf": [
+                        {
+                            "$ref": "http://redfish.dmtf.org/schemas/v1/Sensor.json#/definitions/SensorVoltageExcerpt"
+                        },
+                        {
+                            "type": "null"
+                        }
+                    ],
+                    "description": "The voltage reading for this single phase outlet.",
+                    "excerptCopy": "SensorVoltageExcerpt",
+                    "longDescription": "This property shall contain the voltage, measured in Volts, for this single phase outlet.  This property shall not appear in resource instances representing poly-phase outlets."
+                },
+                "VoltageType": {
+                    "anyOf": [
+                        {
+                            "$ref": "#/definitions/VoltageType"
+                        },
+                        {
+                            "type": "null"
+                        }
+                    ],
+                    "description": "The type of voltage applied to the outlet.",
+                    "longDescription": "This property shall contain the type of voltage applied to the outlet.",
+                    "readonly": true
+                }
+            },
+            "required": [
+                "@odata.id",
+                "@odata.type",
+                "Id",
+                "Name"
+            ],
+            "type": "object"
+        },
+        "PowerControl": {
+            "additionalProperties": false,
+            "description": "This action turns the outlet on or off.",
+            "longDescription": "This action shall control the power state of the outlet.",
+            "parameters": {
+                "PowerState": {
+                    "$ref": "http://redfish.dmtf.org/schemas/v1/Outlet.json#/definitions/PowerState",
+                    "description": "The desired power state of the outlet.",
+                    "longDescription": "This parameter shall contain the desired power state of the outlet."
+                }
+            },
+            "patternProperties": {
+                "^([a-zA-Z_][a-zA-Z0-9_]*)?@(odata|Redfish|Message)\\.[a-zA-Z_][a-zA-Z0-9_]*$": {
+                    "description": "This property shall specify a valid odata or Redfish property.",
+                    "type": [
+                        "array",
+                        "boolean",
+                        "integer",
+                        "number",
+                        "null",
+                        "object",
+                        "string"
+                    ]
+                }
+            },
+            "properties": {
+                "target": {
+                    "description": "Link to invoke action",
+                    "format": "uri-reference",
+                    "type": "string"
+                },
+                "title": {
+                    "description": "Friendly action name",
+                    "type": "string"
+                }
+            },
+            "type": "object"
+        },
+        "ResetMetrics": {
+            "additionalProperties": false,
+            "description": "This action resets metrics related to this outlet.",
+            "longDescription": "This action shall reset any time intervals or counted values for this outlet.",
+            "parameters": {},
+            "patternProperties": {
+                "^([a-zA-Z_][a-zA-Z0-9_]*)?@(odata|Redfish|Message)\\.[a-zA-Z_][a-zA-Z0-9_]*$": {
+                    "description": "This property shall specify a valid odata or Redfish property.",
+                    "type": [
+                        "array",
+                        "boolean",
+                        "integer",
+                        "number",
+                        "null",
+                        "object",
+                        "string"
+                    ]
+                }
+            },
+            "properties": {
+                "target": {
+                    "description": "Link to invoke action",
+                    "format": "uri-reference",
+                    "type": "string"
+                },
+                "title": {
+                    "description": "Friendly action name",
+                    "type": "string"
+                }
+            },
+            "type": "object"
+        },
+        "VoltageSensors": {
+            "additionalProperties": false,
+            "description": "The voltage readings for this outlet.",
+            "longDescription": "This type shall contain properties that describe voltage sensor readings for an outlet.",
+            "patternProperties": {
+                "^([a-zA-Z_][a-zA-Z0-9_]*)?@(odata|Redfish|Message)\\.[a-zA-Z_][a-zA-Z0-9_]*$": {
+                    "description": "This property shall specify a valid odata or Redfish property.",
+                    "type": [
+                        "array",
+                        "boolean",
+                        "integer",
+                        "number",
+                        "null",
+                        "object",
+                        "string"
+                    ]
+                }
+            },
+            "properties": {
+                "Line1ToLine2": {
+                    "anyOf": [
+                        {
+                            "$ref": "http://redfish.dmtf.org/schemas/v1/Sensor.json#/definitions/SensorVoltageExcerpt"
+                        },
+                        {
+                            "type": "null"
+                        }
+                    ],
+                    "description": "The Line 1 to Line 2 voltage reading for this outlet.",
+                    "excerptCopy": "SensorVoltageExcerpt",
+                    "longDescription": "This property shall contain a Sensor excerpt of type Voltage that measures voltage between L1 and L2.  This property shall not be present if the outlet does not include an L1-L2 measurement."
+                },
+                "Line1ToNeutral": {
+                    "anyOf": [
+                        {
+                            "$ref": "http://redfish.dmtf.org/schemas/v1/Sensor.json#/definitions/SensorVoltageExcerpt"
+                        },
+                        {
+                            "type": "null"
+                        }
+                    ],
+                    "description": "The Line 1 to Neutral voltage reading for this outlet.",
+                    "excerptCopy": "SensorVoltageExcerpt",
+                    "longDescription": "This property shall contain a Sensor excerpt of type Voltage that measures voltage between L1 and Neutral.  This property shall not be present if the outlet does not include an L1-Neutral measurement."
+                },
+                "Line2ToLine3": {
+                    "anyOf": [
+                        {
+                            "$ref": "http://redfish.dmtf.org/schemas/v1/Sensor.json#/definitions/SensorVoltageExcerpt"
+                        },
+                        {
+                            "type": "null"
+                        }
+                    ],
+                    "description": "The Line 2 to Line 3 voltage reading for this outlet.",
+                    "excerptCopy": "SensorVoltageExcerpt",
+                    "longDescription": "This property shall contain a Sensor excerpt of type Voltage that measures voltage between L2 and L3.  This property shall not be present if the outlet does not include an L2-L3 measurement."
+                },
+                "Line2ToNeutral": {
+                    "anyOf": [
+                        {
+                            "$ref": "http://redfish.dmtf.org/schemas/v1/Sensor.json#/definitions/SensorVoltageExcerpt"
+                        },
+                        {
+                            "type": "null"
+                        }
+                    ],
+                    "description": "The Line 2 to Neutral voltage reading for this outlet.",
+                    "excerptCopy": "SensorVoltageExcerpt",
+                    "longDescription": "This property shall contain a Sensor excerpt of type Voltage that measures voltage between L2 and Neutral.  This property shall not be present if the outlet does not include an L2-Neutral measurement."
+                },
+                "Line3ToLine1": {
+                    "anyOf": [
+                        {
+                            "$ref": "http://redfish.dmtf.org/schemas/v1/Sensor.json#/definitions/SensorVoltageExcerpt"
+                        },
+                        {
+                            "type": "null"
+                        }
+                    ],
+                    "description": "The Line 3 to Line 1 voltage reading for this outlet.",
+                    "excerptCopy": "SensorVoltageExcerpt",
+                    "longDescription": "This property shall contain a Sensor excerpt of type Voltage that measures voltage between L3 and L1.  This property shall not be present if the outlet does not include an L3-L1 measurement."
+                },
+                "Line3ToNeutral": {
+                    "anyOf": [
+                        {
+                            "$ref": "http://redfish.dmtf.org/schemas/v1/Sensor.json#/definitions/SensorVoltageExcerpt"
+                        },
+                        {
+                            "type": "null"
+                        }
+                    ],
+                    "description": "The Line 3 to Neutral voltage reading for this outlet.",
+                    "excerptCopy": "SensorVoltageExcerpt",
+                    "longDescription": "This property shall contain a Sensor excerpt of type Voltage that measures voltage between L3 and Neutral.  This property shall not be present if the outlet does not include an L3-Neutral measurement."
+                }
+            },
+            "type": "object"
+        },
+        "VoltageType": {
+            "enum": [
+                "AC",
+                "DC"
+            ],
+            "enumDescriptions": {
+                "AC": "Alternating Current (AC) outlet.",
+                "DC": "Direct Current (DC) outlet."
+            },
+            "type": "string"
+        }
+    },
+    "owningEntity": "DMTF",
+    "release": "2021.2",
+    "title": "#Outlet.v1_2_0.Outlet"
+}

--- a/static/redfish/v1/JsonSchemas/Outlet/index.json
+++ b/static/redfish/v1/JsonSchemas/Outlet/index.json
@@ -1,0 +1,21 @@
+{
+    "@odata.context": "/redfish/v1/$metadata#JsonSchemaFile.JsonSchemaFile",
+    "@odata.id": "/redfish/v1/JsonSchemas/Outlet",
+    "@odata.type": "#JsonSchemaFile.v1_0_2.JsonSchemaFile",
+    "Name": "Outlet Schema File",
+    "Schema": "#Outlet.Outlet",
+    "Description": "Outlet Schema File Location",
+    "Id": "Outlet",
+    "Languages": [
+        "en"
+    ],
+    "Languages@odata.count": 1,
+    "Location": [
+        {
+            "Language": "en",
+            "PublicationUri": "http://redfish.dmtf.org/schemas/v1/Outlet.json",
+            "Uri": "/redfish/v1/JsonSchemas/Outlet/Outlet.json"
+        }
+    ],
+    "Location@odata.count": 1
+}

--- a/static/redfish/v1/JsonSchemas/OutletGroup/OutletGroup.json
+++ b/static/redfish/v1/JsonSchemas/OutletGroup/OutletGroup.json
@@ -1,0 +1,354 @@
+{
+    "$id": "http://redfish.dmtf.org/schemas/v1/OutletGroup.v1_0_1.json",
+    "$ref": "#/definitions/OutletGroup",
+    "$schema": "http://redfish.dmtf.org/schemas/v1/redfish-schema-v1.json",
+    "copyright": "Copyright 2014-2020 DMTF. For the full DMTF copyright policy, see http://www.dmtf.org/about/policies/copyright",
+    "definitions": {
+        "Actions": {
+            "additionalProperties": false,
+            "description": "The available actions for this resource.",
+            "longDescription": "This type shall contain the available actions for this resource.",
+            "patternProperties": {
+                "^([a-zA-Z_][a-zA-Z0-9_]*)?@(odata|Redfish|Message)\\.[a-zA-Z_][a-zA-Z0-9_]*$": {
+                    "description": "This property shall specify a valid odata or Redfish property.",
+                    "type": [
+                        "array",
+                        "boolean",
+                        "integer",
+                        "number",
+                        "null",
+                        "object",
+                        "string"
+                    ]
+                }
+            },
+            "properties": {
+                "#OutletGroup.PowerControl": {
+                    "$ref": "#/definitions/PowerControl"
+                },
+                "#OutletGroup.ResetMetrics": {
+                    "$ref": "#/definitions/ResetMetrics"
+                },
+                "Oem": {
+                    "$ref": "#/definitions/OemActions",
+                    "description": "The available OEM-specific actions for this resource.",
+                    "longDescription": "This property shall contain the available OEM-specific actions for this resource."
+                }
+            },
+            "type": "object"
+        },
+        "Links": {
+            "additionalProperties": false,
+            "description": "The links to other resources that are related to this resource.",
+            "longDescription": "This Redfish Specification-described type shall contain links to resources that are related to but are not contained by, or subordinate to, this resource.",
+            "patternProperties": {
+                "^([a-zA-Z_][a-zA-Z0-9_]*)?@(odata|Redfish|Message)\\.[a-zA-Z_][a-zA-Z0-9_]*$": {
+                    "description": "This property shall specify a valid odata or Redfish property.",
+                    "type": [
+                        "array",
+                        "boolean",
+                        "integer",
+                        "number",
+                        "null",
+                        "object",
+                        "string"
+                    ]
+                }
+            },
+            "properties": {
+                "Oem": {
+                    "$ref": "http://redfish.dmtf.org/schemas/v1/Resource.json#/definitions/Oem",
+                    "description": "The OEM extension property.",
+                    "longDescription": "This property shall contain the OEM extensions.  All values for properties contained in this object shall conform to the Redfish Specification-described requirements."
+                },
+                "Outlets": {
+                    "description": "The set of outlets in this outlet group.",
+                    "items": {
+                        "$ref": "http://redfish.dmtf.org/schemas/v1/Outlet.json#/definitions/Outlet"
+                    },
+                    "longDescription": "This property shall be an array of links to resources of type Outlet that represent the outlets in this outlet group.",
+                    "readonly": false,
+                    "type": "array"
+                },
+                "Outlets@odata.count": {
+                    "$ref": "http://redfish.dmtf.org/schemas/v1/odata-v4.json#/definitions/count"
+                }
+            },
+            "type": "object"
+        },
+        "OemActions": {
+            "additionalProperties": true,
+            "description": "The available OEM-specific actions for this resource.",
+            "longDescription": "This type shall contain the available OEM-specific actions for this resource.",
+            "patternProperties": {
+                "^([a-zA-Z_][a-zA-Z0-9_]*)?@(odata|Redfish|Message)\\.[a-zA-Z_][a-zA-Z0-9_]*$": {
+                    "description": "This property shall specify a valid odata or Redfish property.",
+                    "type": [
+                        "array",
+                        "boolean",
+                        "integer",
+                        "number",
+                        "null",
+                        "object",
+                        "string"
+                    ]
+                }
+            },
+            "properties": {},
+            "type": "object"
+        },
+        "OutletGroup": {
+            "additionalProperties": false,
+            "description": "The OutletGroup schema contains definitions for an electrical outlet group.",
+            "longDescription": "This resource shall be used to represent an electrical outlet group for a Redfish implementation.",
+            "patternProperties": {
+                "^([a-zA-Z_][a-zA-Z0-9_]*)?@(odata|Redfish|Message)\\.[a-zA-Z_][a-zA-Z0-9_]*$": {
+                    "description": "This property shall specify a valid odata or Redfish property.",
+                    "type": [
+                        "array",
+                        "boolean",
+                        "integer",
+                        "number",
+                        "null",
+                        "object",
+                        "string"
+                    ]
+                }
+            },
+            "properties": {
+                "@odata.context": {
+                    "$ref": "http://redfish.dmtf.org/schemas/v1/odata-v4.json#/definitions/context"
+                },
+                "@odata.etag": {
+                    "$ref": "http://redfish.dmtf.org/schemas/v1/odata-v4.json#/definitions/etag"
+                },
+                "@odata.id": {
+                    "$ref": "http://redfish.dmtf.org/schemas/v1/odata-v4.json#/definitions/id"
+                },
+                "@odata.type": {
+                    "$ref": "http://redfish.dmtf.org/schemas/v1/odata-v4.json#/definitions/type"
+                },
+                "Actions": {
+                    "$ref": "#/definitions/Actions",
+                    "description": "The available actions for this resource.",
+                    "longDescription": "This property shall contain the available actions for this resource."
+                },
+                "CreatedBy": {
+                    "description": "The creator of this outlet group.",
+                    "longDescription": "This property shall contain the name of the person or application that created this outlet group.",
+                    "readonly": false,
+                    "type": [
+                        "string",
+                        "null"
+                    ]
+                },
+                "Description": {
+                    "anyOf": [
+                        {
+                            "$ref": "http://redfish.dmtf.org/schemas/v1/Resource.json#/definitions/Description"
+                        },
+                        {
+                            "type": "null"
+                        }
+                    ],
+                    "readonly": true
+                },
+                "EnergykWh": {
+                    "anyOf": [
+                        {
+                            "$ref": "http://redfish.dmtf.org/schemas/v1/Sensor.json#/definitions/SensorEnergykWhExcerpt"
+                        },
+                        {
+                            "type": "null"
+                        }
+                    ],
+                    "description": "The energy reading for this outlet group.",
+                    "excerptCopy": "SensorEnergykWhExcerpt",
+                    "longDescription": "This property shall contain the total energy, measured in kilowatt-hours (kW.h), for this outlet group, that represents the `Total` ElectricalContext sensor when multiple energy sensors exist for this outlet group.",
+                    "readonly": true
+                },
+                "Id": {
+                    "$ref": "http://redfish.dmtf.org/schemas/v1/Resource.json#/definitions/Id",
+                    "readonly": true
+                },
+                "Links": {
+                    "$ref": "#/definitions/Links",
+                    "description": "The links to other resources that are related to this resource.",
+                    "longDescription": "This property shall contain links to resources that are related to but are not contained by, or subordinate to, this resource."
+                },
+                "Name": {
+                    "$ref": "http://redfish.dmtf.org/schemas/v1/Resource.json#/definitions/Name",
+                    "readonly": true
+                },
+                "Oem": {
+                    "$ref": "http://redfish.dmtf.org/schemas/v1/Resource.json#/definitions/Oem",
+                    "description": "The OEM extension property.",
+                    "longDescription": "This property shall contain the OEM extensions.  All values for properties that this object contains shall conform to the Redfish Specification-described requirements."
+                },
+                "PowerCycleDelaySeconds": {
+                    "description": "The number of seconds to delay power on after a PowerControl action to cycle power.  Zero seconds indicates no delay.",
+                    "longDescription": "This property shall contain the number of seconds to delay power on after a PowerControl action to cycle power.  The value `0` shall indicate no delay to power on.",
+                    "readonly": false,
+                    "type": [
+                        "number",
+                        "null"
+                    ]
+                },
+                "PowerEnabled": {
+                    "description": "Indicates if the outlet group can be powered.",
+                    "longDescription": "This property shall contain the power enable state of the outlet group.  True shall indicate that the group can be powered on, and false shall indicate that the group cannot be powered.",
+                    "readonly": true,
+                    "type": [
+                        "boolean",
+                        "null"
+                    ]
+                },
+                "PowerOffDelaySeconds": {
+                    "description": "The number of seconds to delay power off after a PowerControl action.  Zero seconds indicates no delay to power off.",
+                    "longDescription": "This property shall contain the number of seconds to delay power off after a PowerControl action.  The value `0` shall indicate no delay to power off.",
+                    "readonly": false,
+                    "type": [
+                        "number",
+                        "null"
+                    ]
+                },
+                "PowerOnDelaySeconds": {
+                    "description": "The number of seconds to delay power up after a power cycle or a PowerControl action.  Zero seconds indicates no delay to power up.",
+                    "longDescription": "This property shall contain the number of seconds to delay power up after a power cycle or a PowerControl action.  The value `0` shall indicate no delay to power up.",
+                    "readonly": false,
+                    "type": [
+                        "number",
+                        "null"
+                    ]
+                },
+                "PowerRestoreDelaySeconds": {
+                    "description": "The number of seconds to delay power on after power has been restored.  Zero seconds indicates no delay.",
+                    "longDescription": "This property shall contain the number of seconds to delay power on after a power fault.  The value `0` shall indicate no delay to power on.",
+                    "readonly": false,
+                    "type": [
+                        "number",
+                        "null"
+                    ]
+                },
+                "PowerRestorePolicy": {
+                    "$ref": "http://redfish.dmtf.org/schemas/v1/Circuit.json#/definitions/PowerRestorePolicyTypes",
+                    "description": "The desired power state of the outlet group when power is restored after a power loss.",
+                    "longDescription": "This property shall contain the desired PowerState of the outlet group when power is applied.  The value `LastState` shall return the outlet group to the PowerState it was in when power was lost.",
+                    "readonly": false
+                },
+                "PowerState": {
+                    "anyOf": [
+                        {
+                            "$ref": "http://redfish.dmtf.org/schemas/v1/Resource.json#/definitions/PowerState"
+                        },
+                        {
+                            "type": "null"
+                        }
+                    ],
+                    "description": "The power state of the outlet group.",
+                    "longDescription": "This property shall contain the power state of the outlet group.",
+                    "readonly": true
+                },
+                "PowerWatts": {
+                    "anyOf": [
+                        {
+                            "$ref": "http://redfish.dmtf.org/schemas/v1/Sensor.json#/definitions/SensorPowerExcerpt"
+                        },
+                        {
+                            "type": "null"
+                        }
+                    ],
+                    "description": "The power reading for this outlet group.",
+                    "excerptCopy": "SensorPowerExcerpt",
+                    "longDescription": "This property shall contain the total power, measured in Watts, for this outlet group, that represents the `Total` ElectricalContext sensor when multiple power sensors exist for this outlet group.",
+                    "readonly": true
+                },
+                "Status": {
+                    "$ref": "http://redfish.dmtf.org/schemas/v1/Resource.json#/definitions/Status",
+                    "description": "The status and health of the resource and its subordinate or dependent resources.",
+                    "longDescription": "This property shall contain any status or health properties of the resource."
+                }
+            },
+            "required": [
+                "@odata.id",
+                "@odata.type",
+                "Id",
+                "Name"
+            ],
+            "type": "object"
+        },
+        "PowerControl": {
+            "additionalProperties": false,
+            "description": "This action turns the outlet group on or off.",
+            "longDescription": "This action shall control the power state of the outlet group.",
+            "parameters": {
+                "PowerState": {
+                    "$ref": "http://redfish.dmtf.org/schemas/v1/OutletGroup.json#/definitions/PowerState",
+                    "description": "The desired power state of the outlet group.",
+                    "longDescription": "This parameter shall contain the desired power state of the outlet group."
+                }
+            },
+            "patternProperties": {
+                "^([a-zA-Z_][a-zA-Z0-9_]*)?@(odata|Redfish|Message)\\.[a-zA-Z_][a-zA-Z0-9_]*$": {
+                    "description": "This property shall specify a valid odata or Redfish property.",
+                    "type": [
+                        "array",
+                        "boolean",
+                        "integer",
+                        "number",
+                        "null",
+                        "object",
+                        "string"
+                    ]
+                }
+            },
+            "properties": {
+                "target": {
+                    "description": "Link to invoke action",
+                    "format": "uri-reference",
+                    "type": "string"
+                },
+                "title": {
+                    "description": "Friendly action name",
+                    "type": "string"
+                }
+            },
+            "type": "object"
+        },
+        "ResetMetrics": {
+            "additionalProperties": false,
+            "description": "This action resets metrics related to this outlet group.",
+            "longDescription": "This action shall reset any time intervals or counted values for this outlet group.",
+            "parameters": {},
+            "patternProperties": {
+                "^([a-zA-Z_][a-zA-Z0-9_]*)?@(odata|Redfish|Message)\\.[a-zA-Z_][a-zA-Z0-9_]*$": {
+                    "description": "This property shall specify a valid odata or Redfish property.",
+                    "type": [
+                        "array",
+                        "boolean",
+                        "integer",
+                        "number",
+                        "null",
+                        "object",
+                        "string"
+                    ]
+                }
+            },
+            "properties": {
+                "target": {
+                    "description": "Link to invoke action",
+                    "format": "uri-reference",
+                    "type": "string"
+                },
+                "title": {
+                    "description": "Friendly action name",
+                    "type": "string"
+                }
+            },
+            "type": "object"
+        }
+    },
+    "owningEntity": "DMTF",
+    "release": "2019.4",
+    "title": "#OutletGroup.v1_0_1.OutletGroup"
+}

--- a/static/redfish/v1/JsonSchemas/OutletGroup/index.json
+++ b/static/redfish/v1/JsonSchemas/OutletGroup/index.json
@@ -1,0 +1,21 @@
+{
+    "@odata.context": "/redfish/v1/$metadata#JsonSchemaFile.JsonSchemaFile",
+    "@odata.id": "/redfish/v1/JsonSchemas/OutletGroup",
+    "@odata.type": "#JsonSchemaFile.v1_0_2.JsonSchemaFile",
+    "Name": "OutletGroup Schema File",
+    "Schema": "#OutletGroup.OutletGroup",
+    "Description": "OutletGroup Schema File Location",
+    "Id": "OutletGroup",
+    "Languages": [
+        "en"
+    ],
+    "Languages@odata.count": 1,
+    "Location": [
+        {
+            "Language": "en",
+            "PublicationUri": "http://redfish.dmtf.org/schemas/v1/OutletGroup.json",
+            "Uri": "/redfish/v1/JsonSchemas/OutletGroup/OutletGroup.json"
+        }
+    ],
+    "Location@odata.count": 1
+}

--- a/static/redfish/v1/JsonSchemas/PhysicalContext/PhysicalContext.json
+++ b/static/redfish/v1/JsonSchemas/PhysicalContext/PhysicalContext.json
@@ -1,0 +1,61 @@
+{
+    "$schema": "http://redfish.dmtf.org/schemas/v1/redfish-schema.v1_3_0.json",
+    "copyright": "Copyright 2014-2017 Distributed Management Task Force, Inc. (DMTF). For the full DMTF copyright policy, see http://www.dmtf.org/about/policies/copyright",
+    "definitions": {
+        "PhysicalContext": {
+            "deprecated": "This definition has been moved to the unversioned namespace so that external references can pick up changes over time.",
+            "enum": [
+                "Room",
+                "Intake",
+                "Exhaust",
+                "Front",
+                "Back",
+                "Upper",
+                "Lower",
+                "CPU",
+                "GPU",
+                "Backplane",
+                "SystemBoard",
+                "PowerSupply",
+                "VoltageRegulator",
+                "StorageDevice",
+                "NetworkingDevice",
+                "ComputeBay",
+                "StorageBay",
+                "NetworkBay",
+                "ExpansionBay",
+                "PowerSupplyBay",
+                "Memory",
+                "Chassis",
+                "Fan"
+            ],
+            "enumDescriptions": {
+                "Back": "The back of the chassis.",
+                "Backplane": "A backplane within the chassis.",
+                "CPU": "A Processor (CPU).",
+                "Chassis": "The entire chassis.",
+                "ComputeBay": "Within a compute bay.",
+                "Exhaust": "The exhaust point of the chassis.",
+                "ExpansionBay": "Within an expansion bay.",
+                "Fan": "A fan.",
+                "Front": "The front of the chassis.",
+                "GPU": "A Graphics Processor (GPU).",
+                "Intake": "The intake point of the chassis.",
+                "Lower": "The lower portion of the chassis.",
+                "Memory": "A memory device.",
+                "NetworkBay": "Within a networking bay.",
+                "NetworkingDevice": "A networking device.",
+                "PowerSupply": "A power supply.",
+                "PowerSupplyBay": "Within a power supply bay.",
+                "Room": "The room.",
+                "StorageBay": "Within a storage bay.",
+                "StorageDevice": "A storage device.",
+                "SystemBoard": "The system board (PCB).",
+                "Upper": "The upper portion of the chassis.",
+                "VoltageRegulator": "A voltage regulator device."
+            },
+            "type": "string"
+        }
+    },
+    "title": "#PhysicalContext.v1_3_0"
+}

--- a/static/redfish/v1/JsonSchemas/PhysicalContext/index.json
+++ b/static/redfish/v1/JsonSchemas/PhysicalContext/index.json
@@ -1,0 +1,21 @@
+{
+    "@odata.context": "/redfish/v1/$metadata#JsonSchemaFile.JsonSchemaFile",
+    "@odata.id": "/redfish/v1/JsonSchemas/PhysicalContext",
+    "@odata.type": "#JsonSchemaFile.v1_0_2.JsonSchemaFile",
+    "Name": "PhysicalContext Schema File",
+    "Schema": "#PhysicalContext.PhysicalContext",
+    "Description": "PhysicalContext Schema File Location",
+    "Id": "PhysicalContext",
+    "Languages": [
+        "en"
+    ],
+    "Languages@odata.count": 1,
+    "Location": [
+        {
+            "Language": "en",
+            "PublicationUri": "http://redfish.dmtf.org/schemas/v1/PhysicalContext.json",
+            "Uri": "/redfish/v1/JsonSchemas/PhysicalContext/PhysicalContext.json"
+        }
+    ],
+    "Location@odata.count": 1
+}

--- a/static/redfish/v1/JsonSchemas/Port/Port.json
+++ b/static/redfish/v1/JsonSchemas/Port/Port.json
@@ -1,5 +1,5 @@
 {
-    "$id": "http://redfish.dmtf.org/schemas/v1/Port.v1_4_0.json",
+    "$id": "http://redfish.dmtf.org/schemas/v1/Port.v1_5_0.json",
     "$ref": "#/definitions/Port",
     "$schema": "http://redfish.dmtf.org/schemas/v1/redfish-schema-v1.json",
     "copyright": "Copyright 2014-2021 DMTF. For the full DMTF copyright policy, see http://www.dmtf.org/about/policies/copyright",
@@ -110,6 +110,16 @@
                     "type": "array",
                     "versionAdded": "v1_4_0"
                 },
+                "EEEEnabled": {
+                    "description": "Indicates whether IEEE 802.3az Energy-Efficient Ethernet (EEE) is enabled on this port.",
+                    "longDescription": "This property shall indicate whether IEEE 802.3az Energy-Efficient Ethernet (EEE) is enabled on this port.",
+                    "readonly": false,
+                    "type": [
+                        "boolean",
+                        "null"
+                    ],
+                    "versionAdded": "v1_5_0"
+                },
                 "FlowControlConfiguration": {
                     "anyOf": [
                         {
@@ -172,6 +182,7 @@
                     "versionAdded": "v1_4_0"
                 },
                 "SupportedEthernetCapabilities": {
+                    "deprecated": "This property has been deprecated in favor of individual fields for the various properties.",
                     "description": "The set of Ethernet capabilities that this port supports.",
                     "items": {
                         "anyOf": [
@@ -186,7 +197,18 @@
                     "longDescription": "This property shall contain an array of Ethernet capabilities supported by this port.",
                     "readonly": true,
                     "type": "array",
-                    "versionAdded": "v1_3_0"
+                    "versionAdded": "v1_3_0",
+                    "versionDeprecated": "v1_5_0"
+                },
+                "WakeOnLANEnabled": {
+                    "description": "Indicates whether Wake on LAN (WoL) is enabled on this port.",
+                    "longDescription": "This property shall indicate whether Wake on LAN (WoL) is enabled on this port.",
+                    "readonly": false,
+                    "type": [
+                        "boolean",
+                        "null"
+                    ],
+                    "versionAdded": "v1_5_0"
                 }
             },
             "type": "object"
@@ -811,6 +833,19 @@
                 "AssociatedEndpoints@odata.count": {
                     "$ref": "http://redfish.dmtf.org/schemas/v1/odata-v4.json#/definitions/count"
                 },
+                "Cables": {
+                    "description": "An array of links to the cables connected to this port.",
+                    "items": {
+                        "$ref": "http://redfish.dmtf.org/schemas/v1/Cable.json#/definitions/Cable"
+                    },
+                    "longDescription": "This property shall contain an array of links to resources of type Cable that represent the cables connected to this port.",
+                    "readonly": true,
+                    "type": "array",
+                    "versionAdded": "v1_5_0"
+                },
+                "Cables@odata.count": {
+                    "$ref": "http://redfish.dmtf.org/schemas/v1/odata-v4.json#/definitions/count"
+                },
                 "ConnectedPorts": {
                     "description": "An array of links to the remote ports connected to this port.",
                     "items": {
@@ -1085,9 +1120,9 @@
                 },
                 "LinkStatus": {
                     "$ref": "#/definitions/LinkStatus",
-                    "description": "The desired link status for this interface.",
-                    "longDescription": "This property shall contain the desired link status for this interface.",
-                    "readonly": false,
+                    "description": "The link status for this interface.",
+                    "longDescription": "This property shall contain the link status for this interface.",
+                    "readonly": true,
                     "versionAdded": "v1_2_0"
                 },
                 "LinkTransitionIndicator": {
@@ -1265,16 +1300,48 @@
                 "PrivateLoop",
                 "PublicLoop",
                 "Generic",
-                "ExtenderFabric"
+                "ExtenderFabric",
+                "FPort",
+                "EPort",
+                "TEPort",
+                "NPPort",
+                "GPort",
+                "NLPort",
+                "FLPort",
+                "EXPort",
+                "UPort",
+                "DPort"
             ],
             "enumDescriptions": {
+                "DPort": "This port connection type is a diagnostic port.",
+                "EPort": "This port connection type is an extender fabric port.",
+                "EXPort": "This port connection type is an external fabric port.",
                 "ExtenderFabric": "This port connection type is an extender fabric port.",
+                "FLPort": "This port connects in a fabric loop configuration.",
+                "FPort": "This port connection type is a fabric port.",
+                "GPort": "This port connection type is a generic fabric port.",
                 "Generic": "This port connection type is a generic fabric port.",
+                "NLPort": "This port connects in a node loop configuration.",
+                "NPPort": "This port connection type is a proxy N port for N-Port virtualization.",
                 "NPort": "This port connects through an N-Port to a switch.",
                 "NotConnected": "This port is not connected.",
                 "PointToPoint": "This port connects in a Point-to-point configuration.",
                 "PrivateLoop": "This port connects in a private loop configuration.",
-                "PublicLoop": "This port connects in a public configuration."
+                "PublicLoop": "This port connects in a public configuration.",
+                "TEPort": "This port connection type is an trunking extender fabric port.",
+                "UPort": "This port connection type is unassigned."
+            },
+            "enumVersionAdded": {
+                "DPort": "v1_5_0",
+                "EPort": "v1_5_0",
+                "EXPort": "v1_5_0",
+                "FLPort": "v1_5_0",
+                "FPort": "v1_5_0",
+                "GPort": "v1_5_0",
+                "NLPort": "v1_5_0",
+                "NPPort": "v1_5_0",
+                "TEPort": "v1_5_0",
+                "UPort": "v1_5_0"
             },
             "type": "string"
         },
@@ -1505,6 +1572,6 @@
         }
     },
     "owningEntity": "DMTF",
-    "release": "2021.1",
-    "title": "#Port.v1_4_0.Port"
+    "release": "2021.2",
+    "title": "#Port.v1_5_0.Port"
 }

--- a/static/redfish/v1/JsonSchemas/PortMetrics/PortMetrics.json
+++ b/static/redfish/v1/JsonSchemas/PortMetrics/PortMetrics.json
@@ -1,0 +1,982 @@
+{
+    "$id": "http://redfish.dmtf.org/schemas/v1/PortMetrics.v1_2_0.json",
+    "$ref": "#/definitions/PortMetrics",
+    "$schema": "http://redfish.dmtf.org/schemas/v1/redfish-schema-v1.json",
+    "copyright": "Copyright 2014-2021 DMTF. For the full DMTF copyright policy, see http://www.dmtf.org/about/policies/copyright",
+    "definitions": {
+        "Actions": {
+            "additionalProperties": false,
+            "description": "The available actions for this resource.",
+            "longDescription": "This type shall contain the available actions for this resource.",
+            "patternProperties": {
+                "^([a-zA-Z_][a-zA-Z0-9_]*)?@(odata|Redfish|Message)\\.[a-zA-Z_][a-zA-Z0-9_]*$": {
+                    "description": "This property shall specify a valid odata or Redfish property.",
+                    "type": [
+                        "array",
+                        "boolean",
+                        "integer",
+                        "number",
+                        "null",
+                        "object",
+                        "string"
+                    ]
+                }
+            },
+            "properties": {
+                "Oem": {
+                    "$ref": "#/definitions/OemActions",
+                    "description": "The available OEM-specific actions for this resource.",
+                    "longDescription": "This property shall contain the available OEM-specific actions for this resource."
+                }
+            },
+            "type": "object"
+        },
+        "FibreChannel": {
+            "additionalProperties": false,
+            "description": "The Fibre Channel-specific port metrics for network ports.",
+            "longDescription": "This type shall describe Fibre Channel-specific metrics for network ports.",
+            "patternProperties": {
+                "^([a-zA-Z_][a-zA-Z0-9_]*)?@(odata|Redfish|Message)\\.[a-zA-Z_][a-zA-Z0-9_]*$": {
+                    "description": "This property shall specify a valid odata or Redfish property.",
+                    "type": [
+                        "array",
+                        "boolean",
+                        "integer",
+                        "number",
+                        "null",
+                        "object",
+                        "string"
+                    ]
+                }
+            },
+            "properties": {
+                "CorrectableFECErrors": {
+                    "description": "The total number of correctable forward error correction (FEC) errors.",
+                    "longDescription": "This property shall contain the total number of times this port has received traffic with correctable forward error correction (FEC) errors.",
+                    "readonly": true,
+                    "type": [
+                        "integer",
+                        "null"
+                    ],
+                    "versionAdded": "v1_2_0"
+                },
+                "InvalidCRCs": {
+                    "description": "The total number of invalid cyclic redundancy checks (CRCs).",
+                    "longDescription": "This property shall contain the total number of invalid cyclic redundancy checks (CRCs) observed on this port.",
+                    "readonly": true,
+                    "type": [
+                        "integer",
+                        "null"
+                    ],
+                    "versionAdded": "v1_2_0"
+                },
+                "InvalidTXWords": {
+                    "description": "The total number of invalid transmission words.",
+                    "longDescription": "This property shall contain the total number of times this port has received invalid transmission words.",
+                    "readonly": true,
+                    "type": [
+                        "integer",
+                        "null"
+                    ],
+                    "versionAdded": "v1_2_0"
+                },
+                "LinkFailures": {
+                    "description": "The total number of link failures.",
+                    "longDescription": "This property shall contain the total number of link failures observed on this port.",
+                    "readonly": true,
+                    "type": [
+                        "integer",
+                        "null"
+                    ],
+                    "versionAdded": "v1_2_0"
+                },
+                "LossesOfSignal": {
+                    "description": "The total number of losses of signal.",
+                    "longDescription": "This property shall contain the total number of times this port has lost signal.",
+                    "readonly": true,
+                    "type": [
+                        "integer",
+                        "null"
+                    ],
+                    "versionAdded": "v1_2_0"
+                },
+                "LossesOfSync": {
+                    "description": "The total number of losses of sync.",
+                    "longDescription": "This property shall contain the total number of times this port has lost sync.",
+                    "readonly": true,
+                    "type": [
+                        "integer",
+                        "null"
+                    ],
+                    "versionAdded": "v1_2_0"
+                },
+                "RXBBCreditZero": {
+                    "description": "The number of times the receive buffer-to-buffer credit count transitioned to zero.",
+                    "longDescription": "This property shall contain the number of times the receive buffer-to-buffer credit count transitioned to zero since last counter reset.",
+                    "readonly": true,
+                    "type": [
+                        "integer",
+                        "null"
+                    ],
+                    "versionAdded": "v1_2_0"
+                },
+                "RXExchanges": {
+                    "description": "The total number of Fibre Channel exchanges received.",
+                    "longDescription": "This property shall contain the total number of Fibre Channel exchanges received.",
+                    "readonly": true,
+                    "type": [
+                        "integer",
+                        "null"
+                    ],
+                    "versionAdded": "v1_2_0"
+                },
+                "RXSequences": {
+                    "description": "The total number of Fibre Channel sequences received.",
+                    "longDescription": "This property shall contain the total number of Fibre Channel sequences received.",
+                    "readonly": true,
+                    "type": [
+                        "integer",
+                        "null"
+                    ],
+                    "versionAdded": "v1_2_0"
+                },
+                "TXBBCreditZero": {
+                    "description": "The number of times the transmit buffer-to-buffer credit count transitioned to zero.",
+                    "longDescription": "This property shall contain the number of times the transmit buffer-to-buffer credit count transitioned to zero since last counter reset.",
+                    "readonly": true,
+                    "type": [
+                        "integer",
+                        "null"
+                    ],
+                    "versionAdded": "v1_2_0"
+                },
+                "TXBBCreditZeroDurationMilliseconds": {
+                    "description": "The total amount of time the port has been blocked from transmitting due to lack of buffer credits.",
+                    "longDescription": "This property shall contain the total amount of time in milliseconds the port has been blocked from transmitting due to lack of buffer credits since the last counter reset.",
+                    "readonly": true,
+                    "type": [
+                        "integer",
+                        "null"
+                    ],
+                    "units": "ms",
+                    "versionAdded": "v1_2_0"
+                },
+                "TXBBCredits": {
+                    "description": "The number of transmit buffer-to-buffer credits the port is configured to use.",
+                    "longDescription": "This property shall contain the number of transmit buffer-to-buffer credits the port is configured to use.",
+                    "readonly": true,
+                    "type": [
+                        "integer",
+                        "null"
+                    ],
+                    "versionAdded": "v1_2_0"
+                },
+                "TXExchanges": {
+                    "description": "The total number of Fibre Channel exchanges transmitted.",
+                    "longDescription": "This property shall contain the total number of Fibre Channel exchanges transmitted.",
+                    "readonly": true,
+                    "type": [
+                        "integer",
+                        "null"
+                    ],
+                    "versionAdded": "v1_2_0"
+                },
+                "TXSequences": {
+                    "description": "The total number of Fibre Channel sequences transmitted.",
+                    "longDescription": "This property shall contain the total number of Fibre Channel sequences transmitted.",
+                    "readonly": true,
+                    "type": [
+                        "integer",
+                        "null"
+                    ],
+                    "versionAdded": "v1_2_0"
+                },
+                "UncorrectableFECErrors": {
+                    "description": "The total number of uncorrectable forward error correction (FEC) errors.",
+                    "longDescription": "This property shall contain the total number of times this port has received traffic with uncorrectable forward error correction (FEC) errors.",
+                    "readonly": true,
+                    "type": [
+                        "integer",
+                        "null"
+                    ],
+                    "versionAdded": "v1_2_0"
+                }
+            },
+            "type": "object"
+        },
+        "GenZ": {
+            "additionalProperties": false,
+            "description": "The port metrics for a Gen-Z interface.",
+            "longDescription": "This type shall describe the Gen-Z related port metrics.",
+            "patternProperties": {
+                "^([a-zA-Z_][a-zA-Z0-9_]*)?@(odata|Redfish|Message)\\.[a-zA-Z_][a-zA-Z0-9_]*$": {
+                    "description": "This property shall specify a valid odata or Redfish property.",
+                    "type": [
+                        "array",
+                        "boolean",
+                        "integer",
+                        "number",
+                        "null",
+                        "object",
+                        "string"
+                    ]
+                }
+            },
+            "properties": {
+                "AccessKeyViolations": {
+                    "description": "The total number of Access Key Violations detected.",
+                    "longDescription": "This property shall contain the total number of Access Key Violations detected for packets received or transmitted on this interface.",
+                    "readonly": true,
+                    "type": [
+                        "integer",
+                        "null"
+                    ]
+                },
+                "EndToEndCRCErrors": {
+                    "description": "The total number of ECRC transient errors detected.",
+                    "longDescription": "This property shall contain total number of ECRC transient errors detected in received link-local and end-to-end packets.",
+                    "readonly": true,
+                    "type": [
+                        "integer",
+                        "null"
+                    ]
+                },
+                "LLRRecovery": {
+                    "description": "The total number of times Link-Level Reliability (LLR) recovery has been initiated.",
+                    "longDescription": "This property shall contain the total number of times Link-level Reliability (LLR) recovery has been initiated by this interface.  This is not to be confused with the number of packets retransmitted due to initiating LLR recovery.",
+                    "readonly": true,
+                    "type": [
+                        "integer",
+                        "null"
+                    ]
+                },
+                "LinkNTE": {
+                    "description": "The total number of link-local non-transient errors detected.",
+                    "longDescription": "This property shall contain the total number of link-local non-transient errors detected on this interface.",
+                    "readonly": true,
+                    "type": [
+                        "integer",
+                        "null"
+                    ]
+                },
+                "MarkedECN": {
+                    "description": "The number of packets with the Congestion ECN bit set.",
+                    "longDescription": "This property shall contain the number of packets that the component set the Congestion ECN bit prior to transmission through this interface.",
+                    "readonly": true,
+                    "type": [
+                        "integer",
+                        "null"
+                    ]
+                },
+                "NonCRCTransientErrors": {
+                    "description": "The total number transient errors detected that are unrelated to CRC validation.",
+                    "longDescription": "This property shall contain the total number of transient errors detected that are unrelated to CRC validation, which covers link-local and end-to-end packets, such as malformed Link Idle packets or PLA signal errors.",
+                    "readonly": true,
+                    "type": [
+                        "integer",
+                        "null"
+                    ]
+                },
+                "PacketCRCErrors": {
+                    "description": "The total number of PCRC transient errors detected.",
+                    "longDescription": "This property shall contain the total number of PCRC transient errors detected in received link-local and end-to-end packets.",
+                    "readonly": true,
+                    "type": [
+                        "integer",
+                        "null"
+                    ]
+                },
+                "PacketDeadlineDiscards": {
+                    "description": "The number of packets discarded due to the Congestion Deadline sub-field reaching zero.",
+                    "longDescription": "This property shall contain the number of packets discarded by this interface due to the Congestion Deadline sub-field reaching zero prior to packet transmission.",
+                    "readonly": true,
+                    "type": [
+                        "integer",
+                        "null"
+                    ]
+                },
+                "RXStompedECRC": {
+                    "description": "The total number of packets received with a stomped ECRC field.",
+                    "longDescription": "This property shall contain the total number of packets that this interface received with a stomped ECRC field.",
+                    "readonly": true,
+                    "type": [
+                        "integer",
+                        "null"
+                    ]
+                },
+                "ReceivedECN": {
+                    "description": "The number of packets received on this interface with the Congestion ECN bit set.",
+                    "longDescription": "This property shall contain the number of packets received on this interface with the Congestion ECN bit set.",
+                    "readonly": true,
+                    "type": [
+                        "integer",
+                        "null"
+                    ]
+                },
+                "TXStompedECRC": {
+                    "description": "The total number of packets that this interface stomped the ECRC field.",
+                    "longDescription": "This property shall contain the total number of packets that this interfaced stomped the ECRC field.",
+                    "readonly": true,
+                    "type": [
+                        "integer",
+                        "null"
+                    ]
+                }
+            },
+            "type": "object"
+        },
+        "Networking": {
+            "additionalProperties": false,
+            "description": "The port metrics for network ports, including Ethernet, Fibre Channel, and InfiniBand, that are not specific to one of these protocols.",
+            "longDescription": "This type shall describe the metrics for network ports, including Ethernet, Fibre Channel, and InfiniBand, that are not specific to one of these protocols.",
+            "patternProperties": {
+                "^([a-zA-Z_][a-zA-Z0-9_]*)?@(odata|Redfish|Message)\\.[a-zA-Z_][a-zA-Z0-9_]*$": {
+                    "description": "This property shall specify a valid odata or Redfish property.",
+                    "type": [
+                        "array",
+                        "boolean",
+                        "integer",
+                        "number",
+                        "null",
+                        "object",
+                        "string"
+                    ]
+                }
+            },
+            "properties": {
+                "RDMAProtectionErrors": {
+                    "description": "The total number of RDMA protection errors.",
+                    "longDescription": "This property shall contain the total number of RDMA protection errors.",
+                    "readonly": true,
+                    "type": [
+                        "integer",
+                        "null"
+                    ],
+                    "versionAdded": "v1_1_0"
+                },
+                "RDMAProtocolErrors": {
+                    "description": "The total number of RDMA protocol errors.",
+                    "longDescription": "This property shall contain the total number of RDMA protocol errors.",
+                    "readonly": true,
+                    "type": [
+                        "integer",
+                        "null"
+                    ],
+                    "versionAdded": "v1_1_0"
+                },
+                "RDMARXBytes": {
+                    "description": "The total number of RDMA bytes received on a port since reset.",
+                    "longDescription": "This property shall contain the total number of RDMA bytes received on a port since reset.",
+                    "readonly": true,
+                    "type": [
+                        "integer",
+                        "null"
+                    ],
+                    "versionAdded": "v1_1_0"
+                },
+                "RDMARXRequests": {
+                    "description": "The total number of RDMA requests received on a port since reset.",
+                    "longDescription": "This property shall contain the total number of RDMA requests received on a port since reset.",
+                    "readonly": true,
+                    "type": [
+                        "integer",
+                        "null"
+                    ],
+                    "versionAdded": "v1_1_0"
+                },
+                "RDMATXBytes": {
+                    "description": "The total number of RDMA bytes transmitted on a port since reset.",
+                    "longDescription": "This property shall contain the total number of RDMA bytes transmitted on a port since reset.",
+                    "readonly": true,
+                    "type": [
+                        "integer",
+                        "null"
+                    ],
+                    "versionAdded": "v1_1_0"
+                },
+                "RDMATXReadRequests": {
+                    "description": "The total number of RDMA read requests transmitted on a port since reset.",
+                    "longDescription": "This property shall contain the total number of RDMA read requests transmitted on a port since reset.",
+                    "readonly": true,
+                    "type": [
+                        "integer",
+                        "null"
+                    ],
+                    "versionAdded": "v1_1_0"
+                },
+                "RDMATXRequests": {
+                    "description": "The total number of RDMA requests transmitted on a port since reset.",
+                    "longDescription": "This property shall contain the total number of RDMA requests transmitted on a port since reset.",
+                    "readonly": true,
+                    "type": [
+                        "integer",
+                        "null"
+                    ],
+                    "versionAdded": "v1_1_0"
+                },
+                "RDMATXSendRequests": {
+                    "description": "The total number of RDMA send requests transmitted on a port since reset.",
+                    "longDescription": "This property shall contain the total number of RDMA send requests transmitted on a port since reset.",
+                    "readonly": true,
+                    "type": [
+                        "integer",
+                        "null"
+                    ],
+                    "versionAdded": "v1_1_0"
+                },
+                "RDMATXWriteRequests": {
+                    "description": "The total number of RDMA write requests transmitted on a port since reset.",
+                    "longDescription": "This property shall contain the total number of RDMA write requests transmitted on a port since reset.",
+                    "readonly": true,
+                    "type": [
+                        "integer",
+                        "null"
+                    ],
+                    "versionAdded": "v1_1_0"
+                },
+                "RXBroadcastFrames": {
+                    "description": "The total number of valid broadcast frames received on a port since reset.",
+                    "longDescription": "This property shall contain the total number of valid broadcast frames received on a port since reset, including host and remote management passthrough traffic.",
+                    "readonly": true,
+                    "type": [
+                        "integer",
+                        "null"
+                    ],
+                    "versionAdded": "v1_1_0"
+                },
+                "RXDiscards": {
+                    "description": "The total number of frames discarded in a port's receive path since reset.",
+                    "longDescription": "This property shall contain the total number of frames discarded in a port's receive path since reset.",
+                    "readonly": true,
+                    "type": [
+                        "integer",
+                        "null"
+                    ],
+                    "versionAdded": "v1_1_0"
+                },
+                "RXFCSErrors": {
+                    "description": "The total number of frames received with frame check sequence (FCS) errors on a port since reset.",
+                    "longDescription": "This property shall contain the total number of frames received with frame check sequence (FCS) errors on a port since reset.",
+                    "readonly": true,
+                    "type": [
+                        "integer",
+                        "null"
+                    ],
+                    "versionAdded": "v1_1_0"
+                },
+                "RXFalseCarrierErrors": {
+                    "description": "The total number of false carrier errors received from phy on a port since reset.",
+                    "longDescription": "This property shall contain the total number of false carrier errors received from phy on a port since reset.",
+                    "readonly": true,
+                    "type": [
+                        "integer",
+                        "null"
+                    ],
+                    "versionAdded": "v1_1_0"
+                },
+                "RXFrameAlignmentErrors": {
+                    "description": "The total number of frames received with alignment errors on a port since reset.",
+                    "longDescription": "This property shall contain the total number of frames received with alignment errors on a port since reset.",
+                    "readonly": true,
+                    "type": [
+                        "integer",
+                        "null"
+                    ],
+                    "versionAdded": "v1_1_0"
+                },
+                "RXFrames": {
+                    "description": "The total number of frames received on a port since reset.",
+                    "longDescription": "This property shall contain the total number of frames received on a port since reset.",
+                    "readonly": true,
+                    "type": [
+                        "integer",
+                        "null"
+                    ],
+                    "versionAdded": "v1_1_0"
+                },
+                "RXMulticastFrames": {
+                    "description": "The total number of valid multicast frames received on a port since reset.",
+                    "longDescription": "This property shall contain the total number of valid multicast frames received on a port since reset, including host and remote management passthrough traffic.",
+                    "readonly": true,
+                    "type": [
+                        "integer",
+                        "null"
+                    ],
+                    "versionAdded": "v1_1_0"
+                },
+                "RXOversizeFrames": {
+                    "description": "The total number of frames that exceed the maximum frame size.",
+                    "longDescription": "This property shall contain the total number of frames that exceed the maximum frame size.",
+                    "readonly": true,
+                    "type": [
+                        "integer",
+                        "null"
+                    ],
+                    "versionAdded": "v1_1_0"
+                },
+                "RXPFCFrames": {
+                    "description": "The total number of priority flow control (PFC) frames received on a port since reset.",
+                    "longDescription": "This property shall contain the total number of priority flow control (PFC) frames received on a port since reset.",
+                    "readonly": true,
+                    "type": [
+                        "integer",
+                        "null"
+                    ],
+                    "versionAdded": "v1_1_0"
+                },
+                "RXPauseXOFFFrames": {
+                    "description": "The total number of flow control frames from the network to pause transmission.",
+                    "longDescription": "This property shall contain the total number of flow control frames from the network to pause transmission.",
+                    "readonly": true,
+                    "type": [
+                        "integer",
+                        "null"
+                    ],
+                    "versionAdded": "v1_1_0"
+                },
+                "RXPauseXONFrames": {
+                    "description": "The total number of flow control frames from the network to resume transmission.",
+                    "longDescription": "This property shall contain the total number of flow control frames from the network to resume transmission.",
+                    "readonly": true,
+                    "type": [
+                        "integer",
+                        "null"
+                    ],
+                    "versionAdded": "v1_1_0"
+                },
+                "RXUndersizeFrames": {
+                    "description": "The total number of frames that are smaller than the minimum frame size of 64 bytes.",
+                    "longDescription": "This property shall contain the total number of frames that are smaller than the minimum frame size of 64 bytes.",
+                    "readonly": true,
+                    "type": [
+                        "integer",
+                        "null"
+                    ],
+                    "versionAdded": "v1_1_0"
+                },
+                "RXUnicastFrames": {
+                    "description": "The total number of valid unicast frames received on a port since reset.",
+                    "longDescription": "This property shall contain the total number of valid unicast frames received on a port since reset.",
+                    "readonly": true,
+                    "type": [
+                        "integer",
+                        "null"
+                    ],
+                    "versionAdded": "v1_1_0"
+                },
+                "TXBroadcastFrames": {
+                    "description": "The total number of good broadcast frames transmitted on a port since reset.",
+                    "longDescription": "This property shall contain the total number of good broadcast frames transmitted on a port since reset, including host and remote management passthrough traffic.",
+                    "readonly": true,
+                    "type": [
+                        "integer",
+                        "null"
+                    ],
+                    "versionAdded": "v1_1_0"
+                },
+                "TXDiscards": {
+                    "description": "The total number of frames discarded in a port's transmit path since reset.",
+                    "longDescription": "This property shall contain the total number of frames discarded in a port's transmit path since reset.",
+                    "readonly": true,
+                    "type": [
+                        "integer",
+                        "null"
+                    ],
+                    "versionAdded": "v1_1_0"
+                },
+                "TXExcessiveCollisions": {
+                    "description": "The number of times a single transmitted frame encountered more than 15 collisions.",
+                    "longDescription": "This property shall contain the number of times a single transmitted frame encountered more than 15 collisions.",
+                    "readonly": true,
+                    "type": [
+                        "integer",
+                        "null"
+                    ],
+                    "versionAdded": "v1_1_0"
+                },
+                "TXFrames": {
+                    "description": "The total number of frames transmitted on a port since reset.",
+                    "longDescription": "This property shall contain the total number of frames transmitted on a port since reset.",
+                    "readonly": true,
+                    "type": [
+                        "integer",
+                        "null"
+                    ],
+                    "versionAdded": "v1_1_0"
+                },
+                "TXLateCollisions": {
+                    "description": "The total number of collisions that occurred after one slot time as defined by IEEE 802.3.",
+                    "longDescription": "This property shall contain the total number of collisions that occurred after one slot time as defined by IEEE 802.3.",
+                    "readonly": true,
+                    "type": [
+                        "integer",
+                        "null"
+                    ],
+                    "versionAdded": "v1_1_0"
+                },
+                "TXMulticastFrames": {
+                    "description": "The total number of good multicast frames transmitted on a port since reset.",
+                    "longDescription": "This property shall contain the total number of good multicast frames transmitted on a port since reset, including host and remote management passthrough traffic.",
+                    "readonly": true,
+                    "type": [
+                        "integer",
+                        "null"
+                    ],
+                    "versionAdded": "v1_1_0"
+                },
+                "TXMultipleCollisions": {
+                    "description": "The times that a transmitted frame encountered 2-15 collisions.",
+                    "longDescription": "This property shall contain the times that a transmitted frame encountered 2-15 collisions.",
+                    "readonly": true,
+                    "type": [
+                        "integer",
+                        "null"
+                    ],
+                    "versionAdded": "v1_1_0"
+                },
+                "TXPFCFrames": {
+                    "description": "The total number of priority flow control (PFC) frames sent on a port since reset.",
+                    "longDescription": "This property shall contain the total number of priority flow control (PFC) frames sent on a port since reset.",
+                    "readonly": true,
+                    "type": [
+                        "integer",
+                        "null"
+                    ],
+                    "versionAdded": "v1_1_0"
+                },
+                "TXPauseXOFFFrames": {
+                    "description": "The total number of XOFF frames transmitted to the network.",
+                    "longDescription": "This property shall contain the total number of XOFF frames transmitted to the network.",
+                    "readonly": true,
+                    "type": [
+                        "integer",
+                        "null"
+                    ],
+                    "versionAdded": "v1_1_0"
+                },
+                "TXPauseXONFrames": {
+                    "description": "The total number of XON frames transmitted to the network.",
+                    "longDescription": "This property shall contain the total number of XON frames transmitted to the network.",
+                    "readonly": true,
+                    "type": [
+                        "integer",
+                        "null"
+                    ],
+                    "versionAdded": "v1_1_0"
+                },
+                "TXSingleCollisions": {
+                    "description": "The times that a successfully transmitted frame encountered a single collision.",
+                    "longDescription": "This property shall contain the times that a successfully transmitted frame encountered a single collision.",
+                    "readonly": true,
+                    "type": [
+                        "integer",
+                        "null"
+                    ],
+                    "versionAdded": "v1_1_0"
+                },
+                "TXUnicastFrames": {
+                    "description": "The total number of good unicast frames transmitted on a port since reset.",
+                    "longDescription": "This property shall contain the total number of good unicast frames transmitted on a port since reset, including host and remote management passthrough traffic.",
+                    "readonly": true,
+                    "type": [
+                        "integer",
+                        "null"
+                    ],
+                    "versionAdded": "v1_1_0"
+                }
+            },
+            "type": "object"
+        },
+        "OemActions": {
+            "additionalProperties": true,
+            "description": "The available OEM-specific actions for this resource.",
+            "longDescription": "This type shall contain the available OEM-specific actions for this resource.",
+            "patternProperties": {
+                "^([a-zA-Z_][a-zA-Z0-9_]*)?@(odata|Redfish|Message)\\.[a-zA-Z_][a-zA-Z0-9_]*$": {
+                    "description": "This property shall specify a valid odata or Redfish property.",
+                    "type": [
+                        "array",
+                        "boolean",
+                        "integer",
+                        "number",
+                        "null",
+                        "object",
+                        "string"
+                    ]
+                }
+            },
+            "properties": {},
+            "type": "object"
+        },
+        "PortMetrics": {
+            "additionalProperties": false,
+            "description": "The PortMetrics schema contains usage and health statistics for a switch device or component port summary.",
+            "longDescription": "This resource shall represent the port metrics for a switch device or component port summary in a Redfish implementation.",
+            "patternProperties": {
+                "^([a-zA-Z_][a-zA-Z0-9_]*)?@(odata|Redfish|Message)\\.[a-zA-Z_][a-zA-Z0-9_]*$": {
+                    "description": "This property shall specify a valid odata or Redfish property.",
+                    "type": [
+                        "array",
+                        "boolean",
+                        "integer",
+                        "number",
+                        "null",
+                        "object",
+                        "string"
+                    ]
+                }
+            },
+            "properties": {
+                "@odata.context": {
+                    "$ref": "http://redfish.dmtf.org/schemas/v1/odata-v4.json#/definitions/context"
+                },
+                "@odata.etag": {
+                    "$ref": "http://redfish.dmtf.org/schemas/v1/odata-v4.json#/definitions/etag"
+                },
+                "@odata.id": {
+                    "$ref": "http://redfish.dmtf.org/schemas/v1/odata-v4.json#/definitions/id"
+                },
+                "@odata.type": {
+                    "$ref": "http://redfish.dmtf.org/schemas/v1/odata-v4.json#/definitions/type"
+                },
+                "Actions": {
+                    "$ref": "#/definitions/Actions",
+                    "description": "The available actions for this resource.",
+                    "longDescription": "This property shall contain the available actions for this resource."
+                },
+                "Description": {
+                    "anyOf": [
+                        {
+                            "$ref": "http://redfish.dmtf.org/schemas/v1/Resource.json#/definitions/Description"
+                        },
+                        {
+                            "type": "null"
+                        }
+                    ],
+                    "readonly": true
+                },
+                "FibreChannel": {
+                    "$ref": "#/definitions/FibreChannel",
+                    "description": "The Fibre Channel-specific port metrics for network ports.",
+                    "longDescription": "This property shall contain Fibre Channel-specific port metrics for network ports.",
+                    "versionAdded": "v1_2_0"
+                },
+                "GenZ": {
+                    "$ref": "#/definitions/GenZ",
+                    "description": "The port metrics specific to Gen-Z ports.",
+                    "longDescription": "This property shall contain the port metrics specific to Gen-Z ports."
+                },
+                "Id": {
+                    "$ref": "http://redfish.dmtf.org/schemas/v1/Resource.json#/definitions/Id",
+                    "readonly": true
+                },
+                "Name": {
+                    "$ref": "http://redfish.dmtf.org/schemas/v1/Resource.json#/definitions/Name",
+                    "readonly": true
+                },
+                "Networking": {
+                    "$ref": "#/definitions/Networking",
+                    "description": "The port metrics for network ports, including Ethernet, Fibre Channel, and InfiniBand, that are not specific to one of these protocols.",
+                    "longDescription": "This property shall contain port metrics for network ports, including Ethernet, Fibre Channel, and InfiniBand, that are not specific to one of these protocols.",
+                    "versionAdded": "v1_1_0"
+                },
+                "Oem": {
+                    "$ref": "http://redfish.dmtf.org/schemas/v1/Resource.json#/definitions/Oem",
+                    "description": "The OEM extension property.",
+                    "longDescription": "This property shall contain the OEM extensions.  All values for properties that this object contains shall conform to the Redfish Specification-described requirements."
+                },
+                "RXBytes": {
+                    "description": "The total number of bytes received on a port since reset.",
+                    "longDescription": "This property shall contain the total number of bytes received on a port since reset, including host and remote management passthrough traffic, and inclusive of all protocol overhead.",
+                    "readonly": true,
+                    "type": [
+                        "integer",
+                        "null"
+                    ],
+                    "units": "By",
+                    "versionAdded": "v1_1_0"
+                },
+                "RXErrors": {
+                    "description": "The total number of received errors on a port since reset.",
+                    "longDescription": "This property shall contain the total number of received errors on a port since reset.",
+                    "readonly": true,
+                    "type": [
+                        "integer",
+                        "null"
+                    ],
+                    "versionAdded": "v1_1_0"
+                },
+                "SAS": {
+                    "description": "The physical (phy) metrics for Serial Attached SCSI (SAS).  Each member represents a single phy.",
+                    "items": {
+                        "$ref": "#/definitions/SAS"
+                    },
+                    "longDescription": "This property shall contain an array of physical related metrics for Serial Attached SCSI (SAS).  Each member in the array shall represent a single phy.",
+                    "type": "array",
+                    "versionAdded": "v1_1_0"
+                },
+                "TXBytes": {
+                    "description": "The total number of bytes transmitted on a port since reset.",
+                    "longDescription": "This property shall contain the total number of bytes transmitted on a port since reset, including host and remote management passthrough traffic, and inclusive of all protocol overhead.",
+                    "readonly": true,
+                    "type": [
+                        "integer",
+                        "null"
+                    ],
+                    "units": "By",
+                    "versionAdded": "v1_1_0"
+                },
+                "TXErrors": {
+                    "description": "The total number of transmission errors on a port since reset.",
+                    "longDescription": "This property shall contain the total number of transmission errors on a port since reset.",
+                    "readonly": true,
+                    "type": [
+                        "integer",
+                        "null"
+                    ],
+                    "versionAdded": "v1_1_0"
+                },
+                "Transceivers": {
+                    "description": "The metrics for the transceivers in this port.  Each member represents a single transceiver.",
+                    "items": {
+                        "$ref": "#/definitions/Transceiver"
+                    },
+                    "longDescription": "This property shall contain an array of transceiver related metrics for this port.  Each member in the array shall represent a single transceiver.",
+                    "type": "array",
+                    "versionAdded": "v1_1_0"
+                }
+            },
+            "required": [
+                "@odata.id",
+                "@odata.type",
+                "Id",
+                "Name"
+            ],
+            "type": "object"
+        },
+        "SAS": {
+            "additionalProperties": false,
+            "description": "The physical metrics for Serial Attached SCSI (SAS).",
+            "longDescription": "This type shall describe physical (phy) related metrics for Serial Attached SCSI (SAS).",
+            "patternProperties": {
+                "^([a-zA-Z_][a-zA-Z0-9_]*)?@(odata|Redfish|Message)\\.[a-zA-Z_][a-zA-Z0-9_]*$": {
+                    "description": "This property shall specify a valid odata or Redfish property.",
+                    "type": [
+                        "array",
+                        "boolean",
+                        "integer",
+                        "number",
+                        "null",
+                        "object",
+                        "string"
+                    ]
+                }
+            },
+            "properties": {
+                "InvalidDwordCount": {
+                    "description": "The number of invalid dwords that have been received by the phy outside of phy reset sequences.",
+                    "longDescription": "This property shall contain the number of invalid dwords that have been received by the phy outside of phy reset sequences.",
+                    "readonly": true,
+                    "type": [
+                        "integer",
+                        "null"
+                    ],
+                    "versionAdded": "v1_1_0"
+                },
+                "LossOfDwordSynchronizationCount": {
+                    "description": "The number of times the phy has restarted the link reset sequence because it lost dword synchronization.",
+                    "longDescription": "This property shall contain the number of times the phy has restarted the link reset sequence because it lost dword synchronization.",
+                    "readonly": true,
+                    "type": [
+                        "integer",
+                        "null"
+                    ],
+                    "versionAdded": "v1_1_0"
+                },
+                "RunningDisparityErrorCount": {
+                    "description": "The number of dwords containing running disparity errors that have been received by the phy outside of phy reset sequences.",
+                    "longDescription": "This property shall contain the number of dwords containing running disparity errors that have been received by the phy outside of phy reset sequences.",
+                    "readonly": true,
+                    "type": [
+                        "integer",
+                        "null"
+                    ],
+                    "versionAdded": "v1_1_0"
+                }
+            },
+            "type": "object"
+        },
+        "Transceiver": {
+            "additionalProperties": false,
+            "description": "The transceiver metrics.",
+            "longDescription": "This type shall describe the transceiver related metrics.",
+            "patternProperties": {
+                "^([a-zA-Z_][a-zA-Z0-9_]*)?@(odata|Redfish|Message)\\.[a-zA-Z_][a-zA-Z0-9_]*$": {
+                    "description": "This property shall specify a valid odata or Redfish property.",
+                    "type": [
+                        "array",
+                        "boolean",
+                        "integer",
+                        "number",
+                        "null",
+                        "object",
+                        "string"
+                    ]
+                }
+            },
+            "properties": {
+                "RXInputPowerMilliWatts": {
+                    "description": "The RX input power value of a small form-factor pluggable (SFP) transceiver.",
+                    "longDescription": "This property shall contain the RX input power value of a small form-factor pluggable (SFP) transceiver.",
+                    "minimum": 0,
+                    "readonly": true,
+                    "type": [
+                        "number",
+                        "null"
+                    ],
+                    "units": "mW",
+                    "versionAdded": "v1_1_0"
+                },
+                "SupplyVoltage": {
+                    "description": "The supply voltage of a small form-factor pluggable (SFP) transceiver.",
+                    "longDescription": "This property shall contain the supply voltage of a small form-factor pluggable (SFP) transceiver.",
+                    "readonly": true,
+                    "type": [
+                        "number",
+                        "null"
+                    ],
+                    "units": "V",
+                    "versionAdded": "v1_1_0"
+                },
+                "TXBiasCurrentMilliAmps": {
+                    "description": "The TX bias current value of a small form-factor pluggable (SFP) transceiver.",
+                    "longDescription": "This property shall contain the TX bias current value of a small form-factor pluggable (SFP) transceiver.",
+                    "minimum": 0,
+                    "readonly": true,
+                    "type": [
+                        "number",
+                        "null"
+                    ],
+                    "units": "mA",
+                    "versionAdded": "v1_1_0"
+                },
+                "TXOutputPowerMilliWatts": {
+                    "description": "The TX output power value of a small form-factor pluggable (SFP) transceiver.",
+                    "longDescription": "This property shall contain the TX output power value of a small form-factor pluggable (SFP) transceiver.",
+                    "minimum": 0,
+                    "readonly": true,
+                    "type": [
+                        "number",
+                        "null"
+                    ],
+                    "units": "mW",
+                    "versionAdded": "v1_1_0"
+                }
+            },
+            "type": "object"
+        }
+    },
+    "owningEntity": "DMTF",
+    "release": "2021.2",
+    "title": "#PortMetrics.v1_2_0.PortMetrics"
+}

--- a/static/redfish/v1/JsonSchemas/PortMetrics/index.json
+++ b/static/redfish/v1/JsonSchemas/PortMetrics/index.json
@@ -1,0 +1,21 @@
+{
+    "@odata.context": "/redfish/v1/$metadata#JsonSchemaFile.JsonSchemaFile",
+    "@odata.id": "/redfish/v1/JsonSchemas/PortMetrics",
+    "@odata.type": "#JsonSchemaFile.v1_0_2.JsonSchemaFile",
+    "Name": "PortMetrics Schema File",
+    "Schema": "#PortMetrics.PortMetrics",
+    "Description": "PortMetrics Schema File Location",
+    "Id": "PortMetrics",
+    "Languages": [
+        "en"
+    ],
+    "Languages@odata.count": 1,
+    "Location": [
+        {
+            "Language": "en",
+            "PublicationUri": "http://redfish.dmtf.org/schemas/v1/PortMetrics.json",
+            "Uri": "/redfish/v1/JsonSchemas/PortMetrics/PortMetrics.json"
+        }
+    ],
+    "Location@odata.count": 1
+}

--- a/static/redfish/v1/JsonSchemas/PowerDistribution/PowerDistribution.json
+++ b/static/redfish/v1/JsonSchemas/PowerDistribution/PowerDistribution.json
@@ -1,0 +1,632 @@
+{
+    "$id": "http://redfish.dmtf.org/schemas/v1/PowerDistribution.v1_1_0.json",
+    "$ref": "#/definitions/PowerDistribution",
+    "$schema": "http://redfish.dmtf.org/schemas/v1/redfish-schema-v1.json",
+    "copyright": "Copyright 2014-2021 DMTF. For the full DMTF copyright policy, see http://www.dmtf.org/about/policies/copyright",
+    "definitions": {
+        "Actions": {
+            "additionalProperties": false,
+            "description": "The available actions for this resource.",
+            "longDescription": "This type shall contain the available actions for this resource.",
+            "patternProperties": {
+                "^([a-zA-Z_][a-zA-Z0-9_]*)?@(odata|Redfish|Message)\\.[a-zA-Z_][a-zA-Z0-9_]*$": {
+                    "description": "This property shall specify a valid odata or Redfish property.",
+                    "type": [
+                        "array",
+                        "boolean",
+                        "integer",
+                        "number",
+                        "null",
+                        "object",
+                        "string"
+                    ]
+                }
+            },
+            "properties": {
+                "#PowerDistribution.TransferControl": {
+                    "$ref": "#/definitions/TransferControl"
+                },
+                "Oem": {
+                    "$ref": "#/definitions/OemActions",
+                    "description": "The available OEM-specific actions for this resource.",
+                    "longDescription": "This property shall contain the available OEM-specific actions for this resource."
+                }
+            },
+            "type": "object"
+        },
+        "Links": {
+            "additionalProperties": false,
+            "description": "The links to other resources that are related to this resource.",
+            "longDescription": "This Redfish Specification-described type shall contain links to resources that are related to but are not contained by, or subordinate to, this resource.",
+            "patternProperties": {
+                "^([a-zA-Z_][a-zA-Z0-9_]*)?@(odata|Redfish|Message)\\.[a-zA-Z_][a-zA-Z0-9_]*$": {
+                    "description": "This property shall specify a valid odata or Redfish property.",
+                    "type": [
+                        "array",
+                        "boolean",
+                        "integer",
+                        "number",
+                        "null",
+                        "object",
+                        "string"
+                    ]
+                }
+            },
+            "properties": {
+                "Chassis": {
+                    "description": "An array of links to the chassis that contain this equipment.",
+                    "items": {
+                        "$ref": "http://redfish.dmtf.org/schemas/v1/Chassis.json#/definitions/Chassis"
+                    },
+                    "longDescription": "This property shall contain an array of links to resources of type Chassis that represents the physical container associated with this resource.  This property should only be populated for modular and/or multi-chassis power distribution equipment.",
+                    "readonly": true,
+                    "type": "array"
+                },
+                "Chassis@odata.count": {
+                    "$ref": "http://redfish.dmtf.org/schemas/v1/odata-v4.json#/definitions/count"
+                },
+                "Facility": {
+                    "$ref": "http://redfish.dmtf.org/schemas/v1/Facility.json#/definitions/Facility",
+                    "description": "A link to the facility that contains this equipment.",
+                    "longDescription": "This property shall contain a link to a resource of type Facility that represents the facility that contains this equipment.",
+                    "readonly": true
+                },
+                "ManagedBy": {
+                    "description": "An array of links to the managers responsible for managing this equipment.",
+                    "items": {
+                        "$ref": "http://redfish.dmtf.org/schemas/v1/Manager.json#/definitions/Manager"
+                    },
+                    "longDescription": "This property shall contain an array of links to resources of type Manager that represent the managers that manage this equipment.",
+                    "readonly": true,
+                    "type": "array"
+                },
+                "ManagedBy@odata.count": {
+                    "$ref": "http://redfish.dmtf.org/schemas/v1/odata-v4.json#/definitions/count"
+                },
+                "Oem": {
+                    "$ref": "http://redfish.dmtf.org/schemas/v1/Resource.json#/definitions/Oem",
+                    "description": "The OEM extension property.",
+                    "longDescription": "This property shall contain the OEM extensions.  All values for properties contained in this object shall conform to the Redfish Specification-described requirements."
+                }
+            },
+            "type": "object"
+        },
+        "OemActions": {
+            "additionalProperties": true,
+            "description": "The available OEM-specific actions for this resource.",
+            "longDescription": "This type shall contain the available OEM-specific actions for this resource.",
+            "patternProperties": {
+                "^([a-zA-Z_][a-zA-Z0-9_]*)?@(odata|Redfish|Message)\\.[a-zA-Z_][a-zA-Z0-9_]*$": {
+                    "description": "This property shall specify a valid odata or Redfish property.",
+                    "type": [
+                        "array",
+                        "boolean",
+                        "integer",
+                        "number",
+                        "null",
+                        "object",
+                        "string"
+                    ]
+                }
+            },
+            "properties": {},
+            "type": "object"
+        },
+        "PowerDistribution": {
+            "additionalProperties": false,
+            "description": "This is the schema definition for a power distribution component or unit, such as a floor power distribution unit (PDU) or switchgear.",
+            "longDescription": "This resource shall be used to represent a power distribution component or unit for a Redfish implementation.",
+            "patternProperties": {
+                "^([a-zA-Z_][a-zA-Z0-9_]*)?@(odata|Redfish|Message)\\.[a-zA-Z_][a-zA-Z0-9_]*$": {
+                    "description": "This property shall specify a valid odata or Redfish property.",
+                    "type": [
+                        "array",
+                        "boolean",
+                        "integer",
+                        "number",
+                        "null",
+                        "object",
+                        "string"
+                    ]
+                }
+            },
+            "properties": {
+                "@odata.context": {
+                    "$ref": "http://redfish.dmtf.org/schemas/v1/odata-v4.json#/definitions/context"
+                },
+                "@odata.etag": {
+                    "$ref": "http://redfish.dmtf.org/schemas/v1/odata-v4.json#/definitions/etag"
+                },
+                "@odata.id": {
+                    "$ref": "http://redfish.dmtf.org/schemas/v1/odata-v4.json#/definitions/id"
+                },
+                "@odata.type": {
+                    "$ref": "http://redfish.dmtf.org/schemas/v1/odata-v4.json#/definitions/type"
+                },
+                "Actions": {
+                    "$ref": "#/definitions/Actions",
+                    "description": "The available actions for this resource.",
+                    "longDescription": "This property shall contain the available actions for this resource."
+                },
+                "AssetTag": {
+                    "description": "The user-assigned asset tag for this equipment.",
+                    "longDescription": "This property shall contain the user-assigned asset tag, which is an identifying string that tracks the equipment for inventory purposes.",
+                    "readonly": false,
+                    "type": [
+                        "string",
+                        "null"
+                    ]
+                },
+                "Branches": {
+                    "$ref": "http://redfish.dmtf.org/schemas/v1/CircuitCollection.json#/definitions/CircuitCollection",
+                    "description": "A link to the branch circuits for this equipment.",
+                    "longDescription": "This property shall contain a link to a resource collection of type CircuitCollection that contains the branch circuits for this equipment.",
+                    "readonly": true
+                },
+                "Description": {
+                    "anyOf": [
+                        {
+                            "$ref": "http://redfish.dmtf.org/schemas/v1/Resource.json#/definitions/Description"
+                        },
+                        {
+                            "type": "null"
+                        }
+                    ],
+                    "readonly": true
+                },
+                "EquipmentType": {
+                    "$ref": "#/definitions/PowerEquipmentType",
+                    "description": "The type of equipment this resource represents.",
+                    "longDescription": "This property shall contain the type of equipment this resource represents.",
+                    "readonly": true
+                },
+                "Feeders": {
+                    "$ref": "http://redfish.dmtf.org/schemas/v1/CircuitCollection.json#/definitions/CircuitCollection",
+                    "description": "A link to the feeder circuits for this equipment.",
+                    "longDescription": "This property shall contain a link to a resource collection of type CircuitCollection that contains the feeder circuits for this equipment.",
+                    "readonly": true
+                },
+                "FirmwareVersion": {
+                    "description": "The firmware version of this equipment.",
+                    "longDescription": "This property shall contain a string describing the firmware version of this equipment as provided by the manufacturer.",
+                    "readonly": true,
+                    "type": "string"
+                },
+                "Id": {
+                    "$ref": "http://redfish.dmtf.org/schemas/v1/Resource.json#/definitions/Id",
+                    "readonly": true
+                },
+                "Links": {
+                    "$ref": "#/definitions/Links",
+                    "description": "The links to other resources that are related to this resource.",
+                    "longDescription": "This property shall contain links to resources that are related to but are not contained by, or subordinate to, this resource."
+                },
+                "Location": {
+                    "$ref": "http://redfish.dmtf.org/schemas/v1/Resource.json#/definitions/Location",
+                    "description": "The location of the equipment.",
+                    "longDescription": "This property shall contain location information of the associated equipment."
+                },
+                "Mains": {
+                    "$ref": "http://redfish.dmtf.org/schemas/v1/CircuitCollection.json#/definitions/CircuitCollection",
+                    "description": "A link to the power input circuits for this equipment.",
+                    "longDescription": "This property shall contain a link to a resource collection of type CircuitCollection that contains the power input circuits for this equipment.",
+                    "readonly": true
+                },
+                "MainsRedundancy": {
+                    "$ref": "http://redfish.dmtf.org/schemas/v1/Redundancy.json#/definitions/RedundantGroup",
+                    "description": "The redundancy information for the mains (input) circuits for this equipment.",
+                    "longDescription": "This property shall contain redundancy information for the mains (input) circuits for this equipment.  The values of the RedundancyGroup array shall reference resources of type Circuit.",
+                    "versionAdded": "v1_1_0"
+                },
+                "Manufacturer": {
+                    "description": "The manufacturer of this equipment.",
+                    "longDescription": "This property shall contain the name of the organization responsible for producing the equipment.  This organization may be the entity from which the equipment is purchased, but this is not necessarily true.",
+                    "readonly": true,
+                    "type": [
+                        "string",
+                        "null"
+                    ]
+                },
+                "Metrics": {
+                    "$ref": "http://redfish.dmtf.org/schemas/v1/PowerDistributionMetrics.json#/definitions/PowerDistributionMetrics",
+                    "description": "A link to the summary metrics for this equipment.",
+                    "longDescription": "This property shall contain a link to a resource of type PowerDistributionMetrics.",
+                    "readonly": true
+                },
+                "Model": {
+                    "description": "The product model number of this equipment.",
+                    "longDescription": "This property shall contain the manufacturer-provided model information of this equipment.",
+                    "readonly": true,
+                    "type": [
+                        "string",
+                        "null"
+                    ]
+                },
+                "Name": {
+                    "$ref": "http://redfish.dmtf.org/schemas/v1/Resource.json#/definitions/Name",
+                    "readonly": true
+                },
+                "Oem": {
+                    "$ref": "http://redfish.dmtf.org/schemas/v1/Resource.json#/definitions/Oem",
+                    "description": "The OEM extension property.",
+                    "longDescription": "This property shall contain the OEM extensions.  All values for properties that this object contains shall conform to the Redfish Specification-described requirements."
+                },
+                "OutletGroups": {
+                    "$ref": "http://redfish.dmtf.org/schemas/v1/OutletGroupCollection.json#/definitions/OutletGroupCollection",
+                    "description": "A link to the outlet groups for this equipment.",
+                    "longDescription": "This property shall contain a link to a resource collection of type OutletCollection that contains the outlet groups for this equipment.",
+                    "readonly": true
+                },
+                "Outlets": {
+                    "$ref": "http://redfish.dmtf.org/schemas/v1/OutletCollection.json#/definitions/OutletCollection",
+                    "description": "A link to the outlets for this equipment.",
+                    "longDescription": "This property shall contain a link to a resource collection of type OutletCollection that contains the outlets for this equipment.",
+                    "readonly": true
+                },
+                "PartNumber": {
+                    "description": "The part number for this equipment.",
+                    "longDescription": "This property shall contain the manufacturer-provided part number for the equipment.",
+                    "readonly": true,
+                    "type": [
+                        "string",
+                        "null"
+                    ]
+                },
+                "PowerSupplies": {
+                    "$ref": "http://redfish.dmtf.org/schemas/v1/PowerSupplyCollection.json#/definitions/PowerSupplyCollection",
+                    "description": "The link to the collection of power supplies for this equipment.",
+                    "longDescription": "This property shall contain a link to a resource collection of type PowerSupplyCollection.",
+                    "readonly": true,
+                    "versionAdded": "v1_1_0"
+                },
+                "PowerSupplyRedundancy": {
+                    "description": "The redundancy information for the set of power supplies for this equipment.",
+                    "items": {
+                        "$ref": "http://redfish.dmtf.org/schemas/v1/Redundancy.json#/definitions/RedundantGroup"
+                    },
+                    "longDescription": "This property shall contain redundancy information for the set of power supplies for this equipment.  The values of the RedundancyGroup array shall reference resources of type PowerSupply.",
+                    "type": "array",
+                    "versionAdded": "v1_1_0"
+                },
+                "ProductionDate": {
+                    "description": "The production or manufacturing date of this equipment.",
+                    "format": "date-time",
+                    "longDescription": "This property shall contain the date of production or manufacture for this equipment.",
+                    "readonly": true,
+                    "type": [
+                        "string",
+                        "null"
+                    ]
+                },
+                "Sensors": {
+                    "$ref": "http://redfish.dmtf.org/schemas/v1/SensorCollection.json#/definitions/SensorCollection",
+                    "description": "A link to the collection of sensors located in the equipment and sub-components.",
+                    "longDescription": "This property shall be a link to a resource collection of type SensorCollection that contains the sensors located in the equipment and sub-components.",
+                    "readonly": true
+                },
+                "SerialNumber": {
+                    "description": "The serial number for this equipment.",
+                    "longDescription": "This property shall contain a manufacturer-allocated number that identifies the equipment.",
+                    "readonly": true,
+                    "type": [
+                        "string",
+                        "null"
+                    ]
+                },
+                "Status": {
+                    "$ref": "http://redfish.dmtf.org/schemas/v1/Resource.json#/definitions/Status",
+                    "description": "The status and health of the resource and its subordinate or dependent resources.",
+                    "longDescription": "This property shall contain any status or health properties of the resource."
+                },
+                "Subfeeds": {
+                    "$ref": "http://redfish.dmtf.org/schemas/v1/CircuitCollection.json#/definitions/CircuitCollection",
+                    "description": "A link to the subfeed circuits for this equipment.",
+                    "longDescription": "This property shall contain a link to a resource collection of type CircuitCollection that contains the subfeed circuits for this equipment.",
+                    "readonly": true
+                },
+                "TransferConfiguration": {
+                    "anyOf": [
+                        {
+                            "$ref": "#/definitions/TransferConfiguration"
+                        },
+                        {
+                            "type": "null"
+                        }
+                    ],
+                    "description": "The configuration settings for an automatic transfer switch.",
+                    "longDescription": "This property shall contain the configuration information regarding an automatic transfer switch function for this resource."
+                },
+                "TransferCriteria": {
+                    "anyOf": [
+                        {
+                            "$ref": "#/definitions/TransferCriteria"
+                        },
+                        {
+                            "type": "null"
+                        }
+                    ],
+                    "description": "The criteria used to initiate a transfer for an automatic transfer switch.",
+                    "longDescription": "This property shall contain the criteria for initiating a transfer within an automatic transfer switch function for this resource."
+                },
+                "UUID": {
+                    "anyOf": [
+                        {
+                            "$ref": "http://redfish.dmtf.org/schemas/v1/Resource.json#/definitions/UUID"
+                        },
+                        {
+                            "type": "null"
+                        }
+                    ],
+                    "description": "The UUID for this equipment.",
+                    "longDescription": "This property shall contain the UUID for the equipment.",
+                    "readonly": true
+                },
+                "Version": {
+                    "description": "The hardware version of this equipment.",
+                    "longDescription": "This property shall contain the hardware version of this equipment as determined by the vendor or supplier.",
+                    "readonly": true,
+                    "type": [
+                        "string",
+                        "null"
+                    ]
+                }
+            },
+            "required": [
+                "EquipmentType",
+                "@odata.id",
+                "@odata.type",
+                "Id",
+                "Name"
+            ],
+            "type": "object"
+        },
+        "PowerEquipmentType": {
+            "enum": [
+                "RackPDU",
+                "FloorPDU",
+                "ManualTransferSwitch",
+                "AutomaticTransferSwitch",
+                "Switchgear",
+                "PowerShelf"
+            ],
+            "enumDescriptions": {
+                "AutomaticTransferSwitch": "An automatic power transfer switch.",
+                "FloorPDU": "A power distribution unit providing feeder circuits for further power distribution.",
+                "ManualTransferSwitch": "A manual power transfer switch.",
+                "PowerShelf": "A power shelf.",
+                "RackPDU": "A power distribution unit providing outlets for a rack or similar quantity of devices.",
+                "Switchgear": "Electrical switchgear."
+            },
+            "enumVersionAdded": {
+                "PowerShelf": "v1_1_0"
+            },
+            "type": "string"
+        },
+        "TransferConfiguration": {
+            "additionalProperties": false,
+            "description": "The configuration settings for an automatic transfer switch.",
+            "longDescription": "This type shall contain the configuration information regarding an automatic transfer switch function for this resource.",
+            "patternProperties": {
+                "^([a-zA-Z_][a-zA-Z0-9_]*)?@(odata|Redfish|Message)\\.[a-zA-Z_][a-zA-Z0-9_]*$": {
+                    "description": "This property shall specify a valid odata or Redfish property.",
+                    "type": [
+                        "array",
+                        "boolean",
+                        "integer",
+                        "number",
+                        "null",
+                        "object",
+                        "string"
+                    ]
+                }
+            },
+            "properties": {
+                "ActiveMainsId": {
+                    "description": "The mains circuit that is switched on and qualified to supply power to the output circuit.",
+                    "longDescription": "This property shall contain the mains circuit that is switched on and qualified to supply power to the output circuit.  The value shall be a string that matches the Id property value of a circuit contained in the collection referenced by the Mains property.",
+                    "readonly": false,
+                    "type": [
+                        "string",
+                        "null"
+                    ]
+                },
+                "AutoTransferEnabled": {
+                    "description": "Indicates if the qualified alternate mains circuit is automatically switched on when the preferred mains circuit becomes unqualified and is automatically switched off.",
+                    "longDescription": "This property shall indicate if the qualified alternate mains circuit is automatically switched on when the preferred mains circuit becomes unqualified and is automatically switched off.",
+                    "readonly": false,
+                    "type": [
+                        "boolean",
+                        "null"
+                    ]
+                },
+                "ClosedTransitionAllowed": {
+                    "description": "Indicates if a make-before-break switching sequence of the mains circuits is permitted when they are both qualified and in synchronization.",
+                    "longDescription": "This property shall indicate if a make-before-break switching sequence of the mains circuits is permitted when they are both qualified and in synchronization.",
+                    "readonly": false,
+                    "type": [
+                        "boolean",
+                        "null"
+                    ]
+                },
+                "ClosedTransitionTimeoutSeconds": {
+                    "description": "The time in seconds to wait for a closed transition to occur.",
+                    "longDescription": "This property shall contain the time in seconds to wait for a closed transition to occur.",
+                    "readonly": false,
+                    "type": [
+                        "integer",
+                        "null"
+                    ]
+                },
+                "PreferredMainsId": {
+                    "description": "The preferred source for the mains circuit to this equipment.",
+                    "longDescription": "This property shall contain the preferred source for mains circuit to this equipment.  The value shall be a string that matches the Id property value of a circuit contained in the collection referenced by the Mains property.",
+                    "readonly": false,
+                    "type": [
+                        "string",
+                        "null"
+                    ]
+                },
+                "RetransferDelaySeconds": {
+                    "description": "The time in seconds to delay the automatic transfer from the alternate mains circuit back to the preferred mains circuit.",
+                    "longDescription": "This property shall contain the time in seconds to delay the automatic transfer from the alternate mains circuit back to the preferred mains circuit.",
+                    "readonly": false,
+                    "type": [
+                        "integer",
+                        "null"
+                    ]
+                },
+                "RetransferEnabled": {
+                    "description": "Indicates if the automatic transfer is permitted from the alternate mains circuit back to the preferred mains circuit after the preferred mains circuit is qualified again and the Retransfer Delay time has expired.",
+                    "longDescription": "This property shall indicate if the automatic transfer is permitted from the alternate mains circuit back to the preferred mains circuit after the preferred mains circuit is qualified again and the RetransferDelaySeconds time has expired.",
+                    "readonly": false,
+                    "type": [
+                        "boolean",
+                        "null"
+                    ]
+                },
+                "TransferDelaySeconds": {
+                    "description": "The time in seconds to delay the automatic transfer from the preferred mains circuit to the alternate mains circuit when the preferred mains circuit is disqualified.",
+                    "longDescription": "This property shall contain the time in seconds to delay the automatic transfer from the preferred mains circuit to the alternate mains circuit when the preferred mains circuit is disqualified.  A value of zero shall mean it transfers as fast as possible.",
+                    "readonly": false,
+                    "type": [
+                        "integer",
+                        "null"
+                    ]
+                },
+                "TransferInhibit": {
+                    "description": "Indicates if any transfer is inhibited.",
+                    "longDescription": "This property shall indicate if any transfer is inhibited.",
+                    "readonly": false,
+                    "type": [
+                        "boolean",
+                        "null"
+                    ]
+                }
+            },
+            "type": "object"
+        },
+        "TransferControl": {
+            "additionalProperties": false,
+            "description": "This action transfers control to the alternative input circuit.",
+            "longDescription": "This action shall transfer power input from the existing mains circuit to the alternative mains circuit.",
+            "parameters": {},
+            "patternProperties": {
+                "^([a-zA-Z_][a-zA-Z0-9_]*)?@(odata|Redfish|Message)\\.[a-zA-Z_][a-zA-Z0-9_]*$": {
+                    "description": "This property shall specify a valid odata or Redfish property.",
+                    "type": [
+                        "array",
+                        "boolean",
+                        "integer",
+                        "number",
+                        "null",
+                        "object",
+                        "string"
+                    ]
+                }
+            },
+            "properties": {
+                "target": {
+                    "description": "Link to invoke action",
+                    "format": "uri-reference",
+                    "type": "string"
+                },
+                "title": {
+                    "description": "Friendly action name",
+                    "type": "string"
+                }
+            },
+            "type": "object"
+        },
+        "TransferCriteria": {
+            "additionalProperties": false,
+            "description": "The criteria used to initiate a transfer for an automatic transfer switch.",
+            "longDescription": "This type shall contain the criteria for initiating a transfer within an automatic transfer switch function for this resource.",
+            "patternProperties": {
+                "^([a-zA-Z_][a-zA-Z0-9_]*)?@(odata|Redfish|Message)\\.[a-zA-Z_][a-zA-Z0-9_]*$": {
+                    "description": "This property shall specify a valid odata or Redfish property.",
+                    "type": [
+                        "array",
+                        "boolean",
+                        "integer",
+                        "number",
+                        "null",
+                        "object",
+                        "string"
+                    ]
+                }
+            },
+            "properties": {
+                "OverNominalFrequencyHz": {
+                    "description": "The frequency in Hertz over the nominal value that satisfies a criterion for transfer.",
+                    "longDescription": "This property shall contain the frequency in Hertz over the nominal value that satisfies a criterion for transfer.",
+                    "readonly": false,
+                    "type": [
+                        "number",
+                        "null"
+                    ],
+                    "units": "Hz"
+                },
+                "OverVoltageRMSPercentage": {
+                    "description": "The positive percentage of voltage RMS over the nominal value that satisfies a criterion for transfer.",
+                    "longDescription": "This property shall contain the positive percentage of voltage RMS over the nominal value that satisfies a criterion for transfer.",
+                    "readonly": false,
+                    "type": [
+                        "number",
+                        "null"
+                    ],
+                    "units": "%"
+                },
+                "TransferSensitivity": {
+                    "anyOf": [
+                        {
+                            "$ref": "#/definitions/TransferSensitivityType"
+                        },
+                        {
+                            "type": "null"
+                        }
+                    ],
+                    "description": "The sensitivity to voltage waveform quality to satisfy the criterion for initiating a transfer.",
+                    "longDescription": "This property shall contain the setting that adjusts the analytical sensitivity of the detection of the quality of voltage waveform that satisfies a criterion for transfer.",
+                    "readonly": false
+                },
+                "UnderNominalFrequencyHz": {
+                    "description": "The frequency in Hertz under the nominal value that satisfies a criterion for transfer.",
+                    "longDescription": "This property shall contain the frequency in Hertz under the nominal value that satisfies a criterion for transfer.",
+                    "readonly": false,
+                    "type": [
+                        "number",
+                        "null"
+                    ],
+                    "units": "Hz"
+                },
+                "UnderVoltageRMSPercentage": {
+                    "description": "The negative percentage of voltage RMS under the nominal value that satisfies a criterion for transfer.",
+                    "longDescription": "This property shall contain the negative percentage of voltage RMS under the nominal value that satisfies a criterion for transfer.",
+                    "readonly": false,
+                    "type": [
+                        "number",
+                        "null"
+                    ],
+                    "units": "%"
+                }
+            },
+            "type": "object"
+        },
+        "TransferSensitivityType": {
+            "enum": [
+                "High",
+                "Medium",
+                "Low"
+            ],
+            "enumDescriptions": {
+                "High": "High sensitivity for initiating a transfer.",
+                "Low": "Low sensitivity for initiating a transfer.",
+                "Medium": "Medium sensitivity for initiating a transfer."
+            },
+            "type": "string"
+        }
+    },
+    "owningEntity": "DMTF",
+    "release": "2021.2",
+    "title": "#PowerDistribution.v1_1_0.PowerDistribution"
+}

--- a/static/redfish/v1/JsonSchemas/PowerDistribution/index.json
+++ b/static/redfish/v1/JsonSchemas/PowerDistribution/index.json
@@ -1,0 +1,21 @@
+{
+    "@odata.context": "/redfish/v1/$metadata#JsonSchemaFile.JsonSchemaFile",
+    "@odata.id": "/redfish/v1/JsonSchemas/PowerDistribution",
+    "@odata.type": "#JsonSchemaFile.v1_0_2.JsonSchemaFile",
+    "Name": "PowerDistribution Schema File",
+    "Schema": "#PowerDistribution.PowerDistribution",
+    "Description": "PowerDistribution Schema File Location",
+    "Id": "PowerDistribution",
+    "Languages": [
+        "en"
+    ],
+    "Languages@odata.count": 1,
+    "Location": [
+        {
+            "Language": "en",
+            "PublicationUri": "http://redfish.dmtf.org/schemas/v1/PowerDistribution.json",
+            "Uri": "/redfish/v1/JsonSchemas/PowerDistribution/PowerDistribution.json"
+        }
+    ],
+    "Location@odata.count": 1
+}

--- a/static/redfish/v1/JsonSchemas/PowerDistributionMetrics/PowerDistributionMetrics.json
+++ b/static/redfish/v1/JsonSchemas/PowerDistributionMetrics/PowerDistributionMetrics.json
@@ -1,0 +1,231 @@
+{
+    "$id": "http://redfish.dmtf.org/schemas/v1/PowerDistributionMetrics.v1_2_0.json",
+    "$ref": "#/definitions/PowerDistributionMetrics",
+    "$schema": "http://redfish.dmtf.org/schemas/v1/redfish-schema-v1.json",
+    "copyright": "Copyright 2014-2021 DMTF. For the full DMTF copyright policy, see http://www.dmtf.org/about/policies/copyright",
+    "definitions": {
+        "Actions": {
+            "additionalProperties": false,
+            "description": "The available actions for this resource.",
+            "longDescription": "This type shall contain the available actions for this resource.",
+            "patternProperties": {
+                "^([a-zA-Z_][a-zA-Z0-9_]*)?@(odata|Redfish|Message)\\.[a-zA-Z_][a-zA-Z0-9_]*$": {
+                    "description": "This property shall specify a valid odata or Redfish property.",
+                    "type": [
+                        "array",
+                        "boolean",
+                        "integer",
+                        "number",
+                        "null",
+                        "object",
+                        "string"
+                    ]
+                }
+            },
+            "properties": {
+                "#PowerDistributionMetrics.ResetMetrics": {
+                    "$ref": "#/definitions/ResetMetrics"
+                },
+                "Oem": {
+                    "$ref": "#/definitions/OemActions",
+                    "description": "The available OEM-specific actions for this resource.",
+                    "longDescription": "This property shall contain the available OEM-specific actions for this resource."
+                }
+            },
+            "type": "object"
+        },
+        "OemActions": {
+            "additionalProperties": true,
+            "description": "The available OEM-specific actions for this resource.",
+            "longDescription": "This type shall contain the available OEM-specific actions for this resource.",
+            "patternProperties": {
+                "^([a-zA-Z_][a-zA-Z0-9_]*)?@(odata|Redfish|Message)\\.[a-zA-Z_][a-zA-Z0-9_]*$": {
+                    "description": "This property shall specify a valid odata or Redfish property.",
+                    "type": [
+                        "array",
+                        "boolean",
+                        "integer",
+                        "number",
+                        "null",
+                        "object",
+                        "string"
+                    ]
+                }
+            },
+            "properties": {},
+            "type": "object"
+        },
+        "PowerDistributionMetrics": {
+            "additionalProperties": false,
+            "description": "This is the schema definition for the metrics of a power distribution component or unit, such as a floor power distribution unit (PDU) or switchgear.",
+            "longDescription": "This resource shall be used to represent the metrics of a power distribution component or unit for a Redfish implementation.",
+            "patternProperties": {
+                "^([a-zA-Z_][a-zA-Z0-9_]*)?@(odata|Redfish|Message)\\.[a-zA-Z_][a-zA-Z0-9_]*$": {
+                    "description": "This property shall specify a valid odata or Redfish property.",
+                    "type": [
+                        "array",
+                        "boolean",
+                        "integer",
+                        "number",
+                        "null",
+                        "object",
+                        "string"
+                    ]
+                }
+            },
+            "properties": {
+                "@odata.context": {
+                    "$ref": "http://redfish.dmtf.org/schemas/v1/odata-v4.json#/definitions/context"
+                },
+                "@odata.etag": {
+                    "$ref": "http://redfish.dmtf.org/schemas/v1/odata-v4.json#/definitions/etag"
+                },
+                "@odata.id": {
+                    "$ref": "http://redfish.dmtf.org/schemas/v1/odata-v4.json#/definitions/id"
+                },
+                "@odata.type": {
+                    "$ref": "http://redfish.dmtf.org/schemas/v1/odata-v4.json#/definitions/type"
+                },
+                "Actions": {
+                    "$ref": "#/definitions/Actions",
+                    "description": "The available actions for this resource.",
+                    "longDescription": "This property shall contain the available actions for this resource."
+                },
+                "Description": {
+                    "anyOf": [
+                        {
+                            "$ref": "http://redfish.dmtf.org/schemas/v1/Resource.json#/definitions/Description"
+                        },
+                        {
+                            "type": "null"
+                        }
+                    ],
+                    "readonly": true
+                },
+                "EnergykWh": {
+                    "anyOf": [
+                        {
+                            "$ref": "http://redfish.dmtf.org/schemas/v1/Sensor.json#/definitions/SensorEnergykWhExcerpt"
+                        },
+                        {
+                            "type": "null"
+                        }
+                    ],
+                    "description": "Energy consumption (kWh).",
+                    "excerptCopy": "SensorEnergykWhExcerpt",
+                    "longDescription": "This property shall contain the total energy, measured in kilowatt-hours (kWh), for this unit, that represents the `Total` ElectricalContext sensor when multiple energy sensors exist."
+                },
+                "HumidityPercent": {
+                    "anyOf": [
+                        {
+                            "$ref": "http://redfish.dmtf.org/schemas/v1/Sensor.json#/definitions/SensorExcerpt"
+                        },
+                        {
+                            "type": "null"
+                        }
+                    ],
+                    "description": "Humidity (percent).",
+                    "excerptCopy": "SensorExcerpt",
+                    "longDescription": "This property shall contain the humidity sensor reading for this resource.",
+                    "versionAdded": "v1_1_0"
+                },
+                "Id": {
+                    "$ref": "http://redfish.dmtf.org/schemas/v1/Resource.json#/definitions/Id",
+                    "readonly": true
+                },
+                "Name": {
+                    "$ref": "http://redfish.dmtf.org/schemas/v1/Resource.json#/definitions/Name",
+                    "readonly": true
+                },
+                "Oem": {
+                    "$ref": "http://redfish.dmtf.org/schemas/v1/Resource.json#/definitions/Oem",
+                    "description": "The OEM extension property.",
+                    "longDescription": "This property shall contain the OEM extensions.  All values for properties that this object contains shall conform to the Redfish Specification-described requirements."
+                },
+                "PowerLoadPercent": {
+                    "anyOf": [
+                        {
+                            "$ref": "http://redfish.dmtf.org/schemas/v1/Sensor.json#/definitions/SensorExcerpt"
+                        },
+                        {
+                            "type": "null"
+                        }
+                    ],
+                    "description": "The power load (%) for this equipment.",
+                    "excerptCopy": "SensorExcerpt",
+                    "longDescription": "This property shall contain the power load, measured in percent, for this equipment, that represents the `Total` ElectricalContext for this equipment.",
+                    "versionAdded": "v1_2_0"
+                },
+                "PowerWatts": {
+                    "anyOf": [
+                        {
+                            "$ref": "http://redfish.dmtf.org/schemas/v1/Sensor.json#/definitions/SensorPowerExcerpt"
+                        },
+                        {
+                            "type": "null"
+                        }
+                    ],
+                    "description": "Power consumption (Watts).",
+                    "excerptCopy": "SensorPowerExcerpt",
+                    "longDescription": "This property shall contain the total power, measured in Watts, for this unit, that represents the `Total` ElectricalContext sensor when multiple power sensors exist."
+                },
+                "TemperatureCelsius": {
+                    "anyOf": [
+                        {
+                            "$ref": "http://redfish.dmtf.org/schemas/v1/Sensor.json#/definitions/SensorExcerpt"
+                        },
+                        {
+                            "type": "null"
+                        }
+                    ],
+                    "description": "Temperature (Celsius).",
+                    "excerptCopy": "SensorExcerpt",
+                    "longDescription": "This property shall contain the temperature sensor reading for this resource.",
+                    "versionAdded": "v1_1_0"
+                }
+            },
+            "required": [
+                "@odata.id",
+                "@odata.type",
+                "Id",
+                "Name"
+            ],
+            "type": "object"
+        },
+        "ResetMetrics": {
+            "additionalProperties": false,
+            "description": "This action resets the summary metrics related to this equipment.",
+            "longDescription": "This action shall reset any time intervals or counted values for this equipment.",
+            "parameters": {},
+            "patternProperties": {
+                "^([a-zA-Z_][a-zA-Z0-9_]*)?@(odata|Redfish|Message)\\.[a-zA-Z_][a-zA-Z0-9_]*$": {
+                    "description": "This property shall specify a valid odata or Redfish property.",
+                    "type": [
+                        "array",
+                        "boolean",
+                        "integer",
+                        "number",
+                        "null",
+                        "object",
+                        "string"
+                    ]
+                }
+            },
+            "properties": {
+                "target": {
+                    "description": "Link to invoke action",
+                    "format": "uri-reference",
+                    "type": "string"
+                },
+                "title": {
+                    "description": "Friendly action name",
+                    "type": "string"
+                }
+            },
+            "type": "object"
+        }
+    },
+    "owningEntity": "DMTF",
+    "release": "2021.2",
+    "title": "#PowerDistributionMetrics.v1_2_0.PowerDistributionMetrics"
+}

--- a/static/redfish/v1/JsonSchemas/PowerDistributionMetrics/index.json
+++ b/static/redfish/v1/JsonSchemas/PowerDistributionMetrics/index.json
@@ -1,0 +1,21 @@
+{
+    "@odata.context": "/redfish/v1/$metadata#JsonSchemaFile.JsonSchemaFile",
+    "@odata.id": "/redfish/v1/JsonSchemas/PowerDistributionMetrics",
+    "@odata.type": "#JsonSchemaFile.v1_0_2.JsonSchemaFile",
+    "Name": "PowerDistributionMetrics Schema File",
+    "Schema": "#PowerDistributionMetrics.PowerDistributionMetrics",
+    "Description": "PowerDistributionMetrics Schema File Location",
+    "Id": "PowerDistributionMetrics",
+    "Languages": [
+        "en"
+    ],
+    "Languages@odata.count": 1,
+    "Location": [
+        {
+            "Language": "en",
+            "PublicationUri": "http://redfish.dmtf.org/schemas/v1/PowerDistributionMetrics.json",
+            "Uri": "/redfish/v1/JsonSchemas/PowerDistributionMetrics/PowerDistributionMetrics.json"
+        }
+    ],
+    "Location@odata.count": 1
+}

--- a/static/redfish/v1/JsonSchemas/PowerDomain/PowerDomain.json
+++ b/static/redfish/v1/JsonSchemas/PowerDomain/PowerDomain.json
@@ -1,0 +1,238 @@
+{
+    "$id": "http://redfish.dmtf.org/schemas/v1/PowerDomain.v1_1_0.json",
+    "$ref": "#/definitions/PowerDomain",
+    "$schema": "http://redfish.dmtf.org/schemas/v1/redfish-schema-v1.json",
+    "copyright": "Copyright 2014-2021 DMTF. For the full DMTF copyright policy, see http://www.dmtf.org/about/policies/copyright",
+    "definitions": {
+        "Actions": {
+            "additionalProperties": false,
+            "description": "The available actions for this resource.",
+            "longDescription": "This type shall contain the available actions for this resource.",
+            "patternProperties": {
+                "^([a-zA-Z_][a-zA-Z0-9_]*)?@(odata|Redfish|Message)\\.[a-zA-Z_][a-zA-Z0-9_]*$": {
+                    "description": "This property shall specify a valid odata or Redfish property.",
+                    "type": [
+                        "array",
+                        "boolean",
+                        "integer",
+                        "number",
+                        "null",
+                        "object",
+                        "string"
+                    ]
+                }
+            },
+            "properties": {
+                "Oem": {
+                    "$ref": "#/definitions/OemActions",
+                    "description": "The available OEM-specific actions for this resource.",
+                    "longDescription": "This property shall contain the available OEM-specific actions for this resource."
+                }
+            },
+            "type": "object"
+        },
+        "Links": {
+            "additionalProperties": false,
+            "description": "The links to other resources that are related to this resource.",
+            "longDescription": "This Redfish Specification-described type shall contain links to resources that are related to but are not contained by, or subordinate to, this resource.",
+            "patternProperties": {
+                "^([a-zA-Z_][a-zA-Z0-9_]*)?@(odata|Redfish|Message)\\.[a-zA-Z_][a-zA-Z0-9_]*$": {
+                    "description": "This property shall specify a valid odata or Redfish property.",
+                    "type": [
+                        "array",
+                        "boolean",
+                        "integer",
+                        "number",
+                        "null",
+                        "object",
+                        "string"
+                    ]
+                }
+            },
+            "properties": {
+                "FloorPDUs": {
+                    "description": "An array of links to the floor power distribution units in this power domain.",
+                    "items": {
+                        "$ref": "http://redfish.dmtf.org/schemas/v1/PowerDistribution.json#/definitions/PowerDistribution"
+                    },
+                    "longDescription": "This property shall contain an array of links to resources of type PowerDistribution that represents the floor power distribution units in this power domain.",
+                    "readonly": false,
+                    "type": "array"
+                },
+                "FloorPDUs@odata.count": {
+                    "$ref": "http://redfish.dmtf.org/schemas/v1/odata-v4.json#/definitions/count"
+                },
+                "ManagedBy": {
+                    "description": "An array of links to the managers responsible for managing this power domain.",
+                    "items": {
+                        "$ref": "http://redfish.dmtf.org/schemas/v1/Manager.json#/definitions/Manager"
+                    },
+                    "longDescription": "This property shall contain an array of links to resources of type Manager that represent the managers that manage this power domain.",
+                    "readonly": true,
+                    "type": "array"
+                },
+                "ManagedBy@odata.count": {
+                    "$ref": "http://redfish.dmtf.org/schemas/v1/odata-v4.json#/definitions/count"
+                },
+                "Oem": {
+                    "$ref": "http://redfish.dmtf.org/schemas/v1/Resource.json#/definitions/Oem",
+                    "description": "The OEM extension property.",
+                    "longDescription": "This property shall contain the OEM extensions.  All values for properties contained in this object shall conform to the Redfish Specification-described requirements."
+                },
+                "PowerShelves": {
+                    "description": "An array of links to the power shelves in this power domain.",
+                    "items": {
+                        "$ref": "http://redfish.dmtf.org/schemas/v1/PowerDistribution.json#/definitions/PowerDistribution"
+                    },
+                    "longDescription": "This property shall contain an array of links to resources of type PowerDistribution that represents the power shelves in this power domain.",
+                    "readonly": false,
+                    "type": "array",
+                    "versionAdded": "v1_1_0"
+                },
+                "PowerShelves@odata.count": {
+                    "$ref": "http://redfish.dmtf.org/schemas/v1/odata-v4.json#/definitions/count"
+                },
+                "RackPDUs": {
+                    "description": "An array of links to the rack-level power distribution units in this power domain.",
+                    "items": {
+                        "$ref": "http://redfish.dmtf.org/schemas/v1/PowerDistribution.json#/definitions/PowerDistribution"
+                    },
+                    "longDescription": "This property shall contain an array of links to resources of type PowerDistribution that represents the rack-level power distribution units in this power domain.",
+                    "readonly": false,
+                    "type": "array"
+                },
+                "RackPDUs@odata.count": {
+                    "$ref": "http://redfish.dmtf.org/schemas/v1/odata-v4.json#/definitions/count"
+                },
+                "Switchgear": {
+                    "description": "An array of links to the switchgear in this power domain.",
+                    "items": {
+                        "$ref": "http://redfish.dmtf.org/schemas/v1/PowerDistribution.json#/definitions/PowerDistribution"
+                    },
+                    "longDescription": "This property shall contain an array of links to resources of type PowerDistribution that represents the switchgear in this power domain.",
+                    "readonly": false,
+                    "type": "array"
+                },
+                "Switchgear@odata.count": {
+                    "$ref": "http://redfish.dmtf.org/schemas/v1/odata-v4.json#/definitions/count"
+                },
+                "TransferSwitches": {
+                    "description": "An array of links to the transfer switches in this power domain.",
+                    "items": {
+                        "$ref": "http://redfish.dmtf.org/schemas/v1/PowerDistribution.json#/definitions/PowerDistribution"
+                    },
+                    "longDescription": "This property shall contain an array of links to resources of type PowerDistribution that represents the transfer switches in this power domain.",
+                    "readonly": false,
+                    "type": "array"
+                },
+                "TransferSwitches@odata.count": {
+                    "$ref": "http://redfish.dmtf.org/schemas/v1/odata-v4.json#/definitions/count"
+                }
+            },
+            "type": "object"
+        },
+        "OemActions": {
+            "additionalProperties": true,
+            "description": "The available OEM-specific actions for this resource.",
+            "longDescription": "This type shall contain the available OEM-specific actions for this resource.",
+            "patternProperties": {
+                "^([a-zA-Z_][a-zA-Z0-9_]*)?@(odata|Redfish|Message)\\.[a-zA-Z_][a-zA-Z0-9_]*$": {
+                    "description": "This property shall specify a valid odata or Redfish property.",
+                    "type": [
+                        "array",
+                        "boolean",
+                        "integer",
+                        "number",
+                        "null",
+                        "object",
+                        "string"
+                    ]
+                }
+            },
+            "properties": {},
+            "type": "object"
+        },
+        "PowerDomain": {
+            "additionalProperties": false,
+            "description": "The PowerDomain schema contains definition for the DCIM power domain.",
+            "longDescription": "This resource shall be used to represent a DCIM power domain for a Redfish implementation.",
+            "patternProperties": {
+                "^([a-zA-Z_][a-zA-Z0-9_]*)?@(odata|Redfish|Message)\\.[a-zA-Z_][a-zA-Z0-9_]*$": {
+                    "description": "This property shall specify a valid odata or Redfish property.",
+                    "type": [
+                        "array",
+                        "boolean",
+                        "integer",
+                        "number",
+                        "null",
+                        "object",
+                        "string"
+                    ]
+                }
+            },
+            "properties": {
+                "@odata.context": {
+                    "$ref": "http://redfish.dmtf.org/schemas/v1/odata-v4.json#/definitions/context"
+                },
+                "@odata.etag": {
+                    "$ref": "http://redfish.dmtf.org/schemas/v1/odata-v4.json#/definitions/etag"
+                },
+                "@odata.id": {
+                    "$ref": "http://redfish.dmtf.org/schemas/v1/odata-v4.json#/definitions/id"
+                },
+                "@odata.type": {
+                    "$ref": "http://redfish.dmtf.org/schemas/v1/odata-v4.json#/definitions/type"
+                },
+                "Actions": {
+                    "$ref": "#/definitions/Actions",
+                    "description": "The available actions for this resource.",
+                    "longDescription": "This property shall contain the available actions for this resource."
+                },
+                "Description": {
+                    "anyOf": [
+                        {
+                            "$ref": "http://redfish.dmtf.org/schemas/v1/Resource.json#/definitions/Description"
+                        },
+                        {
+                            "type": "null"
+                        }
+                    ],
+                    "readonly": true
+                },
+                "Id": {
+                    "$ref": "http://redfish.dmtf.org/schemas/v1/Resource.json#/definitions/Id",
+                    "readonly": true
+                },
+                "Links": {
+                    "$ref": "#/definitions/Links",
+                    "description": "The links to other resources that are related to this resource.",
+                    "longDescription": "This property shall contain links to resources that are related to but are not contained by, or subordinate to, this resource."
+                },
+                "Name": {
+                    "$ref": "http://redfish.dmtf.org/schemas/v1/Resource.json#/definitions/Name",
+                    "readonly": true
+                },
+                "Oem": {
+                    "$ref": "http://redfish.dmtf.org/schemas/v1/Resource.json#/definitions/Oem",
+                    "description": "The OEM extension property.",
+                    "longDescription": "This property shall contain the OEM extensions.  All values for properties that this object contains shall conform to the Redfish Specification-described requirements."
+                },
+                "Status": {
+                    "$ref": "http://redfish.dmtf.org/schemas/v1/Resource.json#/definitions/Status",
+                    "description": "The status and health of the resource and its subordinate or dependent resources.",
+                    "longDescription": "This property shall contain any status or health properties of the resource."
+                }
+            },
+            "required": [
+                "@odata.id",
+                "@odata.type",
+                "Id",
+                "Name"
+            ],
+            "type": "object"
+        }
+    },
+    "owningEntity": "DMTF",
+    "release": "2021.2",
+    "title": "#PowerDomain.v1_1_0.PowerDomain"
+}

--- a/static/redfish/v1/JsonSchemas/PowerDomain/index.json
+++ b/static/redfish/v1/JsonSchemas/PowerDomain/index.json
@@ -1,0 +1,21 @@
+{
+    "@odata.context": "/redfish/v1/$metadata#JsonSchemaFile.JsonSchemaFile",
+    "@odata.id": "/redfish/v1/JsonSchemas/PowerDomain",
+    "@odata.type": "#JsonSchemaFile.v1_0_2.JsonSchemaFile",
+    "Name": "PowerDomain Schema File",
+    "Schema": "#PowerDomain.PowerDomain",
+    "Description": "PowerDomain Schema File Location",
+    "Id": "PowerDomain",
+    "Languages": [
+        "en"
+    ],
+    "Languages@odata.count": 1,
+    "Location": [
+        {
+            "Language": "en",
+            "PublicationUri": "http://redfish.dmtf.org/schemas/v1/PowerDomain.json",
+            "Uri": "/redfish/v1/JsonSchemas/PowerDomain/PowerDomain.json"
+        }
+    ],
+    "Location@odata.count": 1
+}

--- a/static/redfish/v1/JsonSchemas/PowerEquipment/PowerEquipment.json
+++ b/static/redfish/v1/JsonSchemas/PowerEquipment/PowerEquipment.json
@@ -1,0 +1,208 @@
+{
+    "$id": "http://redfish.dmtf.org/schemas/v1/PowerEquipment.v1_1_0.json",
+    "$ref": "#/definitions/PowerEquipment",
+    "$schema": "http://redfish.dmtf.org/schemas/v1/redfish-schema-v1.json",
+    "copyright": "Copyright 2014-2021 DMTF. For the full DMTF copyright policy, see http://www.dmtf.org/about/policies/copyright",
+    "definitions": {
+        "Actions": {
+            "additionalProperties": false,
+            "description": "The available actions for this resource.",
+            "longDescription": "This type shall contain the available actions for this resource.",
+            "patternProperties": {
+                "^([a-zA-Z_][a-zA-Z0-9_]*)?@(odata|Redfish|Message)\\.[a-zA-Z_][a-zA-Z0-9_]*$": {
+                    "description": "This property shall specify a valid odata or Redfish property.",
+                    "type": [
+                        "array",
+                        "boolean",
+                        "integer",
+                        "number",
+                        "null",
+                        "object",
+                        "string"
+                    ]
+                }
+            },
+            "properties": {
+                "Oem": {
+                    "$ref": "#/definitions/OemActions",
+                    "description": "The available OEM-specific actions for this resource.",
+                    "longDescription": "This property shall contain the available OEM-specific actions for this resource."
+                }
+            },
+            "type": "object"
+        },
+        "Links": {
+            "additionalProperties": false,
+            "description": "The links to other resources that are related to this resource.",
+            "longDescription": "This Redfish Specification-described type shall contain links to resources that are related to but are not contained by or subordinate to this resource.",
+            "patternProperties": {
+                "^([a-zA-Z_][a-zA-Z0-9_]*)?@(odata|Redfish|Message)\\.[a-zA-Z_][a-zA-Z0-9_]*$": {
+                    "description": "This property shall specify a valid odata or Redfish property.",
+                    "type": [
+                        "array",
+                        "boolean",
+                        "integer",
+                        "number",
+                        "null",
+                        "object",
+                        "string"
+                    ]
+                }
+            },
+            "properties": {
+                "ManagedBy": {
+                    "description": "An array of links to the managers responsible for managing this power equipment.",
+                    "items": {
+                        "$ref": "http://redfish.dmtf.org/schemas/v1/Manager.json#/definitions/Manager"
+                    },
+                    "longDescription": "This property shall contain an array of links to resources of type Manager that represent the managers that manage this power equipment.",
+                    "readonly": true,
+                    "type": "array"
+                },
+                "ManagedBy@odata.count": {
+                    "$ref": "http://redfish.dmtf.org/schemas/v1/odata-v4.json#/definitions/count"
+                },
+                "Oem": {
+                    "$ref": "http://redfish.dmtf.org/schemas/v1/Resource.json#/definitions/Oem",
+                    "description": "The OEM extension property.",
+                    "longDescription": "This property shall contain the OEM extensions.  All values for properties contained in this object shall conform to the Redfish Specification-described requirements."
+                }
+            },
+            "type": "object"
+        },
+        "OemActions": {
+            "additionalProperties": true,
+            "description": "The available OEM-specific actions for this resource.",
+            "longDescription": "This type shall contain the available OEM-specific actions for this resource.",
+            "patternProperties": {
+                "^([a-zA-Z_][a-zA-Z0-9_]*)?@(odata|Redfish|Message)\\.[a-zA-Z_][a-zA-Z0-9_]*$": {
+                    "description": "This property shall specify a valid odata or Redfish property.",
+                    "type": [
+                        "array",
+                        "boolean",
+                        "integer",
+                        "number",
+                        "null",
+                        "object",
+                        "string"
+                    ]
+                }
+            },
+            "properties": {},
+            "type": "object"
+        },
+        "PowerEquipment": {
+            "additionalProperties": false,
+            "description": "This is the schema definition for the set of power equipment.",
+            "longDescription": "This resource shall be used to represent the set of power equipment for a Redfish implementation.",
+            "patternProperties": {
+                "^([a-zA-Z_][a-zA-Z0-9_]*)?@(odata|Redfish|Message)\\.[a-zA-Z_][a-zA-Z0-9_]*$": {
+                    "description": "This property shall specify a valid odata or Redfish property.",
+                    "type": [
+                        "array",
+                        "boolean",
+                        "integer",
+                        "number",
+                        "null",
+                        "object",
+                        "string"
+                    ]
+                }
+            },
+            "properties": {
+                "@odata.context": {
+                    "$ref": "http://redfish.dmtf.org/schemas/v1/odata-v4.json#/definitions/context"
+                },
+                "@odata.etag": {
+                    "$ref": "http://redfish.dmtf.org/schemas/v1/odata-v4.json#/definitions/etag"
+                },
+                "@odata.id": {
+                    "$ref": "http://redfish.dmtf.org/schemas/v1/odata-v4.json#/definitions/id"
+                },
+                "@odata.type": {
+                    "$ref": "http://redfish.dmtf.org/schemas/v1/odata-v4.json#/definitions/type"
+                },
+                "Actions": {
+                    "$ref": "#/definitions/Actions",
+                    "description": "The available actions for this resource.",
+                    "longDescription": "This property shall contain the available actions for this resource."
+                },
+                "Description": {
+                    "anyOf": [
+                        {
+                            "$ref": "http://redfish.dmtf.org/schemas/v1/Resource.json#/definitions/Description"
+                        },
+                        {
+                            "type": "null"
+                        }
+                    ],
+                    "readonly": true
+                },
+                "FloorPDUs": {
+                    "$ref": "http://redfish.dmtf.org/schemas/v1/PowerDistributionCollection.json#/definitions/PowerDistributionCollection",
+                    "description": "A link to a collection of floor power distribution units.",
+                    "longDescription": "This property shall contain a link to a resource collection of type PowerDistributionCollection that contains a set of floor power distribution units.",
+                    "readonly": true
+                },
+                "Id": {
+                    "$ref": "http://redfish.dmtf.org/schemas/v1/Resource.json#/definitions/Id",
+                    "readonly": true
+                },
+                "Links": {
+                    "$ref": "#/definitions/Links",
+                    "description": "The links to other resources that are related to this resource.",
+                    "longDescription": "This property shall contain links to resources that are related to but are not contained by or subordinate to this resource."
+                },
+                "Name": {
+                    "$ref": "http://redfish.dmtf.org/schemas/v1/Resource.json#/definitions/Name",
+                    "readonly": true
+                },
+                "Oem": {
+                    "$ref": "http://redfish.dmtf.org/schemas/v1/Resource.json#/definitions/Oem",
+                    "description": "The OEM extension property.",
+                    "longDescription": "This property shall contain the OEM extensions.  All values for properties that this object contains shall conform to the Redfish Specification-described requirements."
+                },
+                "PowerShelves": {
+                    "$ref": "http://redfish.dmtf.org/schemas/v1/PowerDistributionCollection.json#/definitions/PowerDistributionCollection",
+                    "description": "A link to a collection of power shelves.",
+                    "longDescription": "This property shall contain a link to a resource collection of type PowerDistributionCollection that contains a set of power shelves.",
+                    "readonly": true,
+                    "versionAdded": "v1_1_0"
+                },
+                "RackPDUs": {
+                    "$ref": "http://redfish.dmtf.org/schemas/v1/PowerDistributionCollection.json#/definitions/PowerDistributionCollection",
+                    "description": "A link to a collection of rack-level power distribution units.",
+                    "longDescription": "This property shall contain a link to a resource collection of type PowerDistributionCollection that contains a set of rack-level power distribution units.",
+                    "readonly": true
+                },
+                "Status": {
+                    "$ref": "http://redfish.dmtf.org/schemas/v1/Resource.json#/definitions/Status",
+                    "description": "The status and health of the resource and its subordinate or dependent resources.",
+                    "longDescription": "This property shall contain any status or health properties of the resource."
+                },
+                "Switchgear": {
+                    "$ref": "http://redfish.dmtf.org/schemas/v1/PowerDistributionCollection.json#/definitions/PowerDistributionCollection",
+                    "description": "A link to a collection of switchgear.",
+                    "longDescription": "This property shall contain a link to a resource collection of type PowerDistributionCollection that contains a set of switchgear.",
+                    "readonly": true
+                },
+                "TransferSwitches": {
+                    "$ref": "http://redfish.dmtf.org/schemas/v1/PowerDistributionCollection.json#/definitions/PowerDistributionCollection",
+                    "description": "A link to a collection of transfer switches.",
+                    "longDescription": "This property shall contain a link to a resource collection of type PowerDistributionCollection that contains a set of transfer switches.",
+                    "readonly": true
+                }
+            },
+            "required": [
+                "@odata.id",
+                "@odata.type",
+                "Id",
+                "Name"
+            ],
+            "type": "object"
+        }
+    },
+    "owningEntity": "DMTF",
+    "release": "2021.2",
+    "title": "#PowerEquipment.v1_1_0.PowerEquipment"
+}

--- a/static/redfish/v1/JsonSchemas/PowerEquipment/index.json
+++ b/static/redfish/v1/JsonSchemas/PowerEquipment/index.json
@@ -1,0 +1,21 @@
+{
+    "@odata.context": "/redfish/v1/$metadata#JsonSchemaFile.JsonSchemaFile",
+    "@odata.id": "/redfish/v1/JsonSchemas/PowerEquipment",
+    "@odata.type": "#JsonSchemaFile.v1_0_2.JsonSchemaFile",
+    "Name": "PowerEquipment Schema File",
+    "Schema": "#PowerEquipment.PowerEquipment",
+    "Description": "PowerEquipment Schema File Location",
+    "Id": "PowerEquipment",
+    "Languages": [
+        "en"
+    ],
+    "Languages@odata.count": 1,
+    "Location": [
+        {
+            "Language": "en",
+            "PublicationUri": "http://redfish.dmtf.org/schemas/v1/PowerEquipment.json",
+            "Uri": "/redfish/v1/JsonSchemas/PowerEquipment/PowerEquipment.json"
+        }
+    ],
+    "Location@odata.count": 1
+}

--- a/static/redfish/v1/JsonSchemas/PowerSubsystem/PowerSubsystem.json
+++ b/static/redfish/v1/JsonSchemas/PowerSubsystem/PowerSubsystem.json
@@ -1,8 +1,8 @@
 {
-    "$id": "http://redfish.dmtf.org/schemas/v1/PowerSubsystem.v1_0_0.json",
+    "$id": "http://redfish.dmtf.org/schemas/v1/PowerSubsystem.v1_1_0.json",
     "$ref": "#/definitions/PowerSubsystem",
     "$schema": "http://redfish.dmtf.org/schemas/v1/redfish-schema-v1.json",
-    "copyright": "Copyright 2014-2020 DMTF. For the full DMTF copyright policy, see http://www.dmtf.org/about/policies/copyright",
+    "copyright": "Copyright 2014-2021 DMTF. For the full DMTF copyright policy, see http://www.dmtf.org/about/policies/copyright",
     "definitions": {
         "Actions": {
             "additionalProperties": false,
@@ -137,6 +137,13 @@
                     "description": "Power allocation for this subsystem.",
                     "longDescription": "This property shall contain the set of properties describing the allocation of power for this subsystem."
                 },
+                "Batteries": {
+                    "$ref": "http://redfish.dmtf.org/schemas/v1/BatteryCollection.json#/definitions/BatteryCollection",
+                    "description": "The link to the collection of batteries within this subsystem.",
+                    "longDescription": "This property shall contain a link to a resource collection of type BatteryCollection.",
+                    "readonly": true,
+                    "versionAdded": "v1_1_0"
+                },
                 "CapacityWatts": {
                     "description": "The total amount of power that can be allocated to this subsystem.  This value can be either the power supply capacity or the power budget that an upstream chassis assigns to this subsystem.",
                     "longDescription": "This property shall represent the total power capacity that can be allocated to this subsystem.",
@@ -202,6 +209,6 @@
         }
     },
     "owningEntity": "DMTF",
-    "release": "2020.4",
-    "title": "#PowerSubsystem.v1_0_0.PowerSubsystem"
+    "release": "2021.2",
+    "title": "#PowerSubsystem.v1_1_0.PowerSubsystem"
 }

--- a/static/redfish/v1/JsonSchemas/PowerSupply/PowerSupply.json
+++ b/static/redfish/v1/JsonSchemas/PowerSupply/PowerSupply.json
@@ -1,8 +1,8 @@
 {
-    "$id": "http://redfish.dmtf.org/schemas/v1/PowerSupply.v1_0_0.json",
+    "$id": "http://redfish.dmtf.org/schemas/v1/PowerSupply.v1_1_0.json",
     "$ref": "#/definitions/PowerSupply",
     "$schema": "http://redfish.dmtf.org/schemas/v1/redfish-schema-v1.json",
-    "copyright": "Copyright 2014-2020 DMTF. For the full DMTF copyright policy, see http://www.dmtf.org/about/policies/copyright",
+    "copyright": "Copyright 2014-2021 DMTF. For the full DMTF copyright policy, see http://www.dmtf.org/about/policies/copyright",
     "definitions": {
         "Actions": {
             "additionalProperties": false,
@@ -349,7 +349,7 @@
                 },
                 "Manufacturer": {
                     "description": "The manufacturer of this power supply.",
-                    "longDescription": "This property shall contain the name of the organization responsible for producing the power supply.  This organization might be the entity from whom the power supply is purchased, but this is not necessarily true.",
+                    "longDescription": "This property shall contain the name of the organization responsible for producing the power supply.  This organization may be the entity from whom the power supply is purchased, but this is not necessarily true.",
                     "readonly": true,
                     "type": [
                         "string",
@@ -447,6 +447,17 @@
                     "longDescription": "This property shall contain the input power type (AC or DC) of this power supply.",
                     "readonly": true
                 },
+                "ProductionDate": {
+                    "description": "The production or manufacturing date of this power supply.",
+                    "format": "date-time",
+                    "longDescription": "This property shall contain the date of production or manufacture for this power supply.",
+                    "readonly": true,
+                    "type": [
+                        "string",
+                        "null"
+                    ],
+                    "versionAdded": "v1_1_0"
+                },
                 "SerialNumber": {
                     "description": "The serial number for this power supply.",
                     "longDescription": "This property shall contain the serial number as defined by the manufacturer for this power supply.",
@@ -469,6 +480,16 @@
                     "$ref": "http://redfish.dmtf.org/schemas/v1/Resource.json#/definitions/Status",
                     "description": "The status and health of the resource and its subordinate or dependent resources.",
                     "longDescription": "This property shall contain any status or health properties of the resource."
+                },
+                "Version": {
+                    "description": "The hardware version of this power supply.",
+                    "longDescription": "This property shall contain the hardware version of this power supply as determined by the vendor or supplier.",
+                    "readonly": true,
+                    "type": [
+                        "string",
+                        "null"
+                    ],
+                    "versionAdded": "v1_1_0"
                 }
             },
             "required": [
@@ -495,7 +516,7 @@
         "Reset": {
             "additionalProperties": false,
             "description": "This action resets the power supply.",
-            "longDescription": "This action shall reset a power supply.  A `GracefulRestart` ResetType shall reset the power supply but shall not affect the power output.  A `ForceRestart` ResetType might affect the power supply output.",
+            "longDescription": "This action shall reset a power supply.  A `GracefulRestart` ResetType shall reset the power supply but shall not affect the power output.  A `ForceRestart` ResetType can affect the power supply output.",
             "parameters": {
                 "ResetType": {
                     "$ref": "http://redfish.dmtf.org/schemas/v1/Resource.json#/definitions/ResetType",
@@ -532,6 +553,6 @@
         }
     },
     "owningEntity": "DMTF",
-    "release": "2020.4",
-    "title": "#PowerSupply.v1_0_0.PowerSupply"
+    "release": "2021.1",
+    "title": "#PowerSupply.v1_1_0.PowerSupply"
 }

--- a/static/redfish/v1/JsonSchemas/PowerSupplyMetrics/PowerSupplyMetrics.json
+++ b/static/redfish/v1/JsonSchemas/PowerSupplyMetrics/PowerSupplyMetrics.json
@@ -1,0 +1,623 @@
+{
+    "$id": "http://redfish.dmtf.org/schemas/v1/PowerSupplyMetrics.v1_0_0.json",
+    "$ref": "#/definitions/PowerSupplyMetrics",
+    "$schema": "http://redfish.dmtf.org/schemas/v1/redfish-schema-v1.json",
+    "copyright": "Copyright 2014-2020 DMTF. For the full DMTF copyright policy, see http://www.dmtf.org/about/policies/copyright",
+    "definitions": {
+        "Actions": {
+            "additionalProperties": false,
+            "description": "The available actions for this resource.",
+            "longDescription": "This type shall contain the available actions for this resource.",
+            "patternProperties": {
+                "^([a-zA-Z_][a-zA-Z0-9_]*)?@(odata|Redfish|Message)\\.[a-zA-Z_][a-zA-Z0-9_]*$": {
+                    "description": "This property shall specify a valid odata or Redfish property.",
+                    "type": [
+                        "array",
+                        "boolean",
+                        "integer",
+                        "number",
+                        "null",
+                        "object",
+                        "string"
+                    ]
+                }
+            },
+            "properties": {
+                "#PowerSupplyMetrics.ResetMetrics": {
+                    "$ref": "#/definitions/ResetMetrics"
+                },
+                "Oem": {
+                    "$ref": "#/definitions/OemActions",
+                    "description": "The available OEM-specific actions for this resource.",
+                    "longDescription": "This property shall contain the available OEM-specific actions for this resource."
+                }
+            },
+            "type": "object"
+        },
+        "CurrentSensors": {
+            "additionalProperties": false,
+            "description": "The current sensors for this power supply.",
+            "longDescription": "This type shall contain properties that describe current sensor readings for a power supply.",
+            "patternProperties": {
+                "^([a-zA-Z_][a-zA-Z0-9_]*)?@(odata|Redfish|Message)\\.[a-zA-Z_][a-zA-Z0-9_]*$": {
+                    "description": "This property shall specify a valid odata or Redfish property.",
+                    "type": [
+                        "array",
+                        "boolean",
+                        "integer",
+                        "number",
+                        "null",
+                        "object",
+                        "string"
+                    ]
+                }
+            },
+            "properties": {
+                "Input": {
+                    "anyOf": [
+                        {
+                            "$ref": "http://redfish.dmtf.org/schemas/v1/Sensor.json#/definitions/SensorCurrentExcerpt"
+                        },
+                        {
+                            "type": "null"
+                        }
+                    ],
+                    "description": "The power supply input.",
+                    "excerptCopy": "SensorCurrentExcerpt",
+                    "longDescription": "This property shall contain the current sensor that measures current at the input of the power supply.",
+                    "readonly": true
+                },
+                "InputSecondary": {
+                    "anyOf": [
+                        {
+                            "$ref": "http://redfish.dmtf.org/schemas/v1/Sensor.json#/definitions/SensorCurrentExcerpt"
+                        },
+                        {
+                            "type": "null"
+                        }
+                    ],
+                    "description": "The power supply secondary input.",
+                    "excerptCopy": "SensorCurrentExcerpt",
+                    "longDescription": "This property shall contain the current sensor that measures current at the secondary input of the power supply.  This property shall not be present if the power supply does not include a secondary input.",
+                    "readonly": true
+                },
+                "Output12Volt": {
+                    "anyOf": [
+                        {
+                            "$ref": "http://redfish.dmtf.org/schemas/v1/Sensor.json#/definitions/SensorCurrentExcerpt"
+                        },
+                        {
+                            "type": "null"
+                        }
+                    ],
+                    "description": "The 12V nominal output.",
+                    "excerptCopy": "SensorCurrentExcerpt",
+                    "longDescription": "This property shall contain the current sensor that measures current on a 12 Volt nominal output power rail.  This property shall not be present if the power supply does not include a 12V output.",
+                    "readonly": true
+                },
+                "Output3Volt": {
+                    "anyOf": [
+                        {
+                            "$ref": "http://redfish.dmtf.org/schemas/v1/Sensor.json#/definitions/SensorCurrentExcerpt"
+                        },
+                        {
+                            "type": "null"
+                        }
+                    ],
+                    "description": "The 3V nominal output.",
+                    "excerptCopy": "SensorCurrentExcerpt",
+                    "longDescription": "This property shall contain the current sensor that measures current on a 3 Volt nominal output power rail.  This property shall not be present if the power supply does not include a 3V output.",
+                    "readonly": true
+                },
+                "Output48Volt": {
+                    "anyOf": [
+                        {
+                            "$ref": "http://redfish.dmtf.org/schemas/v1/Sensor.json#/definitions/SensorCurrentExcerpt"
+                        },
+                        {
+                            "type": "null"
+                        }
+                    ],
+                    "description": "The 48V nominal output.",
+                    "excerptCopy": "SensorCurrentExcerpt",
+                    "longDescription": "This property shall contain the current sensor that measures current on a 48 Volt nominal output power rail.  This property shall not be present if the power supply does not include a 48V output.",
+                    "readonly": true
+                },
+                "Output5Volt": {
+                    "anyOf": [
+                        {
+                            "$ref": "http://redfish.dmtf.org/schemas/v1/Sensor.json#/definitions/SensorCurrentExcerpt"
+                        },
+                        {
+                            "type": "null"
+                        }
+                    ],
+                    "description": "The 5V nominal output.",
+                    "excerptCopy": "SensorCurrentExcerpt",
+                    "longDescription": "This property shall contain the current sensor that measures current on a 5 Volt nominal output power rail.  This property shall not be present if the power supply does not include a 5V output.",
+                    "readonly": true
+                },
+                "OutputAux": {
+                    "anyOf": [
+                        {
+                            "$ref": "http://redfish.dmtf.org/schemas/v1/Sensor.json#/definitions/SensorCurrentExcerpt"
+                        },
+                        {
+                            "type": "null"
+                        }
+                    ],
+                    "description": "The auxiliary (AUX) output.",
+                    "excerptCopy": "SensorCurrentExcerpt",
+                    "longDescription": "This property shall contain the current sensor that measures current on an auxiliary (AUX) output power rail.  This property shall not be present if the power supply does not include an auxiliary output.",
+                    "readonly": true
+                }
+            },
+            "type": "object"
+        },
+        "OemActions": {
+            "additionalProperties": true,
+            "description": "The available OEM-specific actions for this resource.",
+            "longDescription": "This type shall contain the available OEM-specific actions for this resource.",
+            "patternProperties": {
+                "^([a-zA-Z_][a-zA-Z0-9_]*)?@(odata|Redfish|Message)\\.[a-zA-Z_][a-zA-Z0-9_]*$": {
+                    "description": "This property shall specify a valid odata or Redfish property.",
+                    "type": [
+                        "array",
+                        "boolean",
+                        "integer",
+                        "number",
+                        "null",
+                        "object",
+                        "string"
+                    ]
+                }
+            },
+            "properties": {},
+            "type": "object"
+        },
+        "PowerSensors": {
+            "additionalProperties": false,
+            "description": "The power sensors for this power supply.",
+            "longDescription": "This type shall contain properties that describe power sensor readings for a power supply.",
+            "patternProperties": {
+                "^([a-zA-Z_][a-zA-Z0-9_]*)?@(odata|Redfish|Message)\\.[a-zA-Z_][a-zA-Z0-9_]*$": {
+                    "description": "This property shall specify a valid odata or Redfish property.",
+                    "type": [
+                        "array",
+                        "boolean",
+                        "integer",
+                        "number",
+                        "null",
+                        "object",
+                        "string"
+                    ]
+                }
+            },
+            "properties": {
+                "Input": {
+                    "anyOf": [
+                        {
+                            "$ref": "http://redfish.dmtf.org/schemas/v1/Sensor.json#/definitions/SensorPowerExcerpt"
+                        },
+                        {
+                            "type": "null"
+                        }
+                    ],
+                    "description": "The input power reading for the power supply.",
+                    "excerptCopy": "SensorPowerExcerpt",
+                    "longDescription": "This property shall contain the power, measured in Watts, for this power supply unit, as measured at the input of the power supply.",
+                    "readonly": true
+                },
+                "InputSecondary": {
+                    "anyOf": [
+                        {
+                            "$ref": "http://redfish.dmtf.org/schemas/v1/Sensor.json#/definitions/SensorPowerExcerpt"
+                        },
+                        {
+                            "type": "null"
+                        }
+                    ],
+                    "description": "The secondary input power reading for the power supply.",
+                    "excerptCopy": "SensorPowerExcerpt",
+                    "longDescription": "This property shall contain the power, measured in Watts, for this power supply unit, as measured at the secondary input of the power supply.  This property shall not appear if the power supply does not contain a secondary input.",
+                    "readonly": true
+                },
+                "Output": {
+                    "anyOf": [
+                        {
+                            "$ref": "http://redfish.dmtf.org/schemas/v1/Sensor.json#/definitions/SensorPowerExcerpt"
+                        },
+                        {
+                            "type": "null"
+                        }
+                    ],
+                    "description": "The output power reading for the power supply.",
+                    "excerptCopy": "SensorPowerExcerpt",
+                    "longDescription": "This property shall contain the power, measured in Watts, for this power supply unit, as measured at the output of the power supply.",
+                    "readonly": true
+                }
+            },
+            "type": "object"
+        },
+        "PowerSupplyMetrics": {
+            "additionalProperties": false,
+            "description": "The PowerSupplyMetrics schema contains definitions for the metrics of a power supply.",
+            "longDescription": "This resource shall be used to represent the metrics of a power supply unit for a Redfish implementation.",
+            "patternProperties": {
+                "^([a-zA-Z_][a-zA-Z0-9_]*)?@(odata|Redfish|Message)\\.[a-zA-Z_][a-zA-Z0-9_]*$": {
+                    "description": "This property shall specify a valid odata or Redfish property.",
+                    "type": [
+                        "array",
+                        "boolean",
+                        "integer",
+                        "number",
+                        "null",
+                        "object",
+                        "string"
+                    ]
+                }
+            },
+            "properties": {
+                "@odata.context": {
+                    "$ref": "http://redfish.dmtf.org/schemas/v1/odata-v4.json#/definitions/context"
+                },
+                "@odata.etag": {
+                    "$ref": "http://redfish.dmtf.org/schemas/v1/odata-v4.json#/definitions/etag"
+                },
+                "@odata.id": {
+                    "$ref": "http://redfish.dmtf.org/schemas/v1/odata-v4.json#/definitions/id"
+                },
+                "@odata.type": {
+                    "$ref": "http://redfish.dmtf.org/schemas/v1/odata-v4.json#/definitions/type"
+                },
+                "Actions": {
+                    "$ref": "#/definitions/Actions",
+                    "description": "The available actions for this resource.",
+                    "longDescription": "This property shall contain the available actions for this resource."
+                },
+                "Description": {
+                    "anyOf": [
+                        {
+                            "$ref": "http://redfish.dmtf.org/schemas/v1/Resource.json#/definitions/Description"
+                        },
+                        {
+                            "type": "null"
+                        }
+                    ],
+                    "readonly": true
+                },
+                "EnergykWh": {
+                    "anyOf": [
+                        {
+                            "$ref": "http://redfish.dmtf.org/schemas/v1/Sensor.json#/definitions/SensorEnergykWhExcerpt"
+                        },
+                        {
+                            "type": "null"
+                        }
+                    ],
+                    "description": "The energy consumption of this unit.",
+                    "excerptCopy": "SensorEnergykWhExcerpt",
+                    "longDescription": "This property shall contain the total energy, measured in kilowatt-hours (kWh), for this unit, that represents the `Total` ElectricalContext sensor when multiple energy sensors exist.",
+                    "readonly": true
+                },
+                "FanSpeedPercent": {
+                    "anyOf": [
+                        {
+                            "$ref": "http://redfish.dmtf.org/schemas/v1/Sensor.json#/definitions/SensorFanExcerpt"
+                        },
+                        {
+                            "type": "null"
+                        }
+                    ],
+                    "description": "The fan speed reading for this power supply.",
+                    "excerptCopy": "SensorFanExcerpt",
+                    "longDescription": "This property shall contain the fan speed sensor for this power supply.",
+                    "readonly": true
+                },
+                "FrequencyHz": {
+                    "anyOf": [
+                        {
+                            "$ref": "http://redfish.dmtf.org/schemas/v1/Sensor.json#/definitions/SensorExcerpt"
+                        },
+                        {
+                            "type": "null"
+                        }
+                    ],
+                    "description": "The frequency reading for this power supply.",
+                    "excerptCopy": "SensorExcerpt",
+                    "longDescription": "This property shall contain the frequency sensor for this power supply.",
+                    "readonly": true
+                },
+                "Id": {
+                    "$ref": "http://redfish.dmtf.org/schemas/v1/Resource.json#/definitions/Id",
+                    "readonly": true
+                },
+                "InputCurrentAmps": {
+                    "anyOf": [
+                        {
+                            "$ref": "http://redfish.dmtf.org/schemas/v1/Sensor.json#/definitions/SensorCurrentExcerpt"
+                        },
+                        {
+                            "type": "null"
+                        }
+                    ],
+                    "description": "The input current reading for this power supply.",
+                    "excerptCopy": "SensorCurrentExcerpt",
+                    "longDescription": "This property shall contain the sensor measuring the input current for this power supply.",
+                    "readonly": true
+                },
+                "InputPowerWatts": {
+                    "anyOf": [
+                        {
+                            "$ref": "http://redfish.dmtf.org/schemas/v1/Sensor.json#/definitions/SensorPowerExcerpt"
+                        },
+                        {
+                            "type": "null"
+                        }
+                    ],
+                    "description": "The input power reading for this power supply.",
+                    "excerptCopy": "SensorPowerExcerpt",
+                    "longDescription": "This property shall contain the sensor measuring the input power for this power supply.",
+                    "readonly": true
+                },
+                "InputVoltage": {
+                    "anyOf": [
+                        {
+                            "$ref": "http://redfish.dmtf.org/schemas/v1/Sensor.json#/definitions/SensorVoltageExcerpt"
+                        },
+                        {
+                            "type": "null"
+                        }
+                    ],
+                    "description": "The input voltage reading for this power supply.",
+                    "excerptCopy": "SensorVoltageExcerpt",
+                    "longDescription": "This property shall contain the sensor measuring the input voltage for this power supply.",
+                    "readonly": true
+                },
+                "Name": {
+                    "$ref": "http://redfish.dmtf.org/schemas/v1/Resource.json#/definitions/Name",
+                    "readonly": true
+                },
+                "Oem": {
+                    "$ref": "http://redfish.dmtf.org/schemas/v1/Resource.json#/definitions/Oem",
+                    "description": "The OEM extension property.",
+                    "longDescription": "This property shall contain the OEM extensions.  All values for properties that this object contains shall conform to the Redfish Specification-described requirements."
+                },
+                "OutputPowerWatts": {
+                    "anyOf": [
+                        {
+                            "$ref": "http://redfish.dmtf.org/schemas/v1/Sensor.json#/definitions/SensorPowerExcerpt"
+                        },
+                        {
+                            "type": "null"
+                        }
+                    ],
+                    "description": "The total power output reading for this power supply.",
+                    "excerptCopy": "SensorPowerExcerpt",
+                    "longDescription": "This property shall contain the sensor measuring the total output power for this power supply.",
+                    "readonly": true
+                },
+                "RailCurrentAmps": {
+                    "description": "The current readings for this power supply.",
+                    "excerptCopy": "SensorCurrentExcerpt",
+                    "items": {
+                        "$ref": "http://redfish.dmtf.org/schemas/v1/Sensor.json#/definitions/SensorCurrentExcerpt"
+                    },
+                    "longDescription": "This property shall contain the output current sensors for this power supply.  The sensors shall appear in the same array order as the OutputRails property in the associated PowerSupply resource.",
+                    "readonly": true,
+                    "type": "array"
+                },
+                "RailCurrentAmps@odata.count": {
+                    "$ref": "http://redfish.dmtf.org/schemas/v1/odata-v4.json#/definitions/count"
+                },
+                "RailPowerWatts": {
+                    "description": "The power readings for this power supply.",
+                    "excerptCopy": "SensorPowerExcerpt",
+                    "items": {
+                        "$ref": "http://redfish.dmtf.org/schemas/v1/Sensor.json#/definitions/SensorPowerExcerpt"
+                    },
+                    "longDescription": "This property shall contain the output power sensors for this power supply.  The sensors shall appear in the same array order as the OutputRails property in the associated PowerSupply resource.",
+                    "readonly": true,
+                    "type": "array"
+                },
+                "RailPowerWatts@odata.count": {
+                    "$ref": "http://redfish.dmtf.org/schemas/v1/odata-v4.json#/definitions/count"
+                },
+                "RailVoltage": {
+                    "description": "The voltage readings for this power supply.",
+                    "excerptCopy": "SensorVoltageExcerpt",
+                    "items": {
+                        "$ref": "http://redfish.dmtf.org/schemas/v1/Sensor.json#/definitions/SensorVoltageExcerpt"
+                    },
+                    "longDescription": "This property shall contain the output voltage sensors for this power supply.  The sensors shall appear in the same array order as the OutputRails property in the associated PowerSupply resource.",
+                    "readonly": true,
+                    "type": "array"
+                },
+                "RailVoltage@odata.count": {
+                    "$ref": "http://redfish.dmtf.org/schemas/v1/odata-v4.json#/definitions/count"
+                },
+                "Status": {
+                    "$ref": "http://redfish.dmtf.org/schemas/v1/Resource.json#/definitions/Status",
+                    "description": "The status and health of the resource and its subordinate or dependent resources.",
+                    "longDescription": "This property shall contain any status or health properties of the resource."
+                },
+                "TemperatureCelsius": {
+                    "anyOf": [
+                        {
+                            "$ref": "http://redfish.dmtf.org/schemas/v1/Sensor.json#/definitions/SensorExcerpt"
+                        },
+                        {
+                            "type": "null"
+                        }
+                    ],
+                    "description": "The temperature reading for this power supply.",
+                    "excerptCopy": "SensorExcerpt",
+                    "longDescription": "This property shall contain the temperature sensor for this power supply.",
+                    "readonly": true
+                }
+            },
+            "required": [
+                "@odata.id",
+                "@odata.type",
+                "Id",
+                "Name"
+            ],
+            "type": "object"
+        },
+        "ResetMetrics": {
+            "additionalProperties": false,
+            "description": "This action resets the summary metrics related to this equipment.",
+            "longDescription": "This action shall reset any time intervals or counted values for this equipment.",
+            "parameters": {},
+            "patternProperties": {
+                "^([a-zA-Z_][a-zA-Z0-9_]*)?@(odata|Redfish|Message)\\.[a-zA-Z_][a-zA-Z0-9_]*$": {
+                    "description": "This property shall specify a valid odata or Redfish property.",
+                    "type": [
+                        "array",
+                        "boolean",
+                        "integer",
+                        "number",
+                        "null",
+                        "object",
+                        "string"
+                    ]
+                }
+            },
+            "properties": {
+                "target": {
+                    "description": "Link to invoke action",
+                    "format": "uri-reference",
+                    "type": "string"
+                },
+                "title": {
+                    "description": "Friendly action name",
+                    "type": "string"
+                }
+            },
+            "type": "object"
+        },
+        "VoltageSensors": {
+            "additionalProperties": false,
+            "description": "The voltage readings for a power supply.",
+            "longDescription": "This type shall contain properties that describe voltage sensor readings for a power supply.",
+            "patternProperties": {
+                "^([a-zA-Z_][a-zA-Z0-9_]*)?@(odata|Redfish|Message)\\.[a-zA-Z_][a-zA-Z0-9_]*$": {
+                    "description": "This property shall specify a valid odata or Redfish property.",
+                    "type": [
+                        "array",
+                        "boolean",
+                        "integer",
+                        "number",
+                        "null",
+                        "object",
+                        "string"
+                    ]
+                }
+            },
+            "properties": {
+                "Input": {
+                    "anyOf": [
+                        {
+                            "$ref": "http://redfish.dmtf.org/schemas/v1/Sensor.json#/definitions/SensorVoltageExcerpt"
+                        },
+                        {
+                            "type": "null"
+                        }
+                    ],
+                    "description": "The power supply input.",
+                    "excerptCopy": "SensorVoltageExcerpt",
+                    "longDescription": "This property shall contain the voltage sensor that measures voltage at the input to the power supply.",
+                    "readonly": true
+                },
+                "InputSecondary": {
+                    "anyOf": [
+                        {
+                            "$ref": "http://redfish.dmtf.org/schemas/v1/Sensor.json#/definitions/SensorVoltageExcerpt"
+                        },
+                        {
+                            "type": "null"
+                        }
+                    ],
+                    "description": "The power supply secondary input.",
+                    "excerptCopy": "SensorVoltageExcerpt",
+                    "longDescription": "This property shall contain the voltage sensor that measures voltage at a secondary input to the power supply.  This property shall not be present if the power supply does not include a secondary input.",
+                    "readonly": true
+                },
+                "Output12Volt": {
+                    "anyOf": [
+                        {
+                            "$ref": "http://redfish.dmtf.org/schemas/v1/Sensor.json#/definitions/SensorVoltageExcerpt"
+                        },
+                        {
+                            "type": "null"
+                        }
+                    ],
+                    "description": "The 12V nominal output.",
+                    "excerptCopy": "SensorVoltageExcerpt",
+                    "longDescription": "This property shall contain the voltage sensor that measures voltage on a 12 Volt nominal output power rail.  This property shall not be present if the power supply does not include a 12V output.",
+                    "readonly": true
+                },
+                "Output3Volt": {
+                    "anyOf": [
+                        {
+                            "$ref": "http://redfish.dmtf.org/schemas/v1/Sensor.json#/definitions/SensorVoltageExcerpt"
+                        },
+                        {
+                            "type": "null"
+                        }
+                    ],
+                    "description": "The 3V nominal output.",
+                    "excerptCopy": "SensorVoltageExcerpt",
+                    "longDescription": "This property shall contain the voltage sensor that measures voltage on a 3 Volt nominal output power rail.  This property shall not be present if the power supply does not include a 3V output.",
+                    "readonly": true
+                },
+                "Output48Volt": {
+                    "anyOf": [
+                        {
+                            "$ref": "http://redfish.dmtf.org/schemas/v1/Sensor.json#/definitions/SensorVoltageExcerpt"
+                        },
+                        {
+                            "type": "null"
+                        }
+                    ],
+                    "description": "The 48V nominal output.",
+                    "excerptCopy": "SensorVoltageExcerpt",
+                    "longDescription": "This property shall contain the voltage sensor that measures voltage on a 48 Volt nominal output power rail.  This property shall not be present if the power supply does not include a 48V output.",
+                    "readonly": true
+                },
+                "Output5Volt": {
+                    "anyOf": [
+                        {
+                            "$ref": "http://redfish.dmtf.org/schemas/v1/Sensor.json#/definitions/SensorVoltageExcerpt"
+                        },
+                        {
+                            "type": "null"
+                        }
+                    ],
+                    "description": "The 5V nominal output.",
+                    "excerptCopy": "SensorVoltageExcerpt",
+                    "longDescription": "This property shall contain the voltage sensor that measures voltage on a 3 Volt nominal output power rail.  This property shall not be present if the power supply does not include a 3V output.",
+                    "readonly": true
+                },
+                "OutputAux": {
+                    "anyOf": [
+                        {
+                            "$ref": "http://redfish.dmtf.org/schemas/v1/Sensor.json#/definitions/SensorVoltageExcerpt"
+                        },
+                        {
+                            "type": "null"
+                        }
+                    ],
+                    "description": "The auxiliary (AUX) output.",
+                    "excerptCopy": "SensorVoltageExcerpt",
+                    "longDescription": "This property shall contain the voltage sensor that measures current on an auxiliary (AUX) output power rail.  This property shall not be present if the power supply does not include an auxiliary output.",
+                    "readonly": true
+                }
+            },
+            "type": "object"
+        }
+    },
+    "owningEntity": "DMTF",
+    "release": "2020.4",
+    "title": "#PowerSupplyMetrics.v1_0_0.PowerSupplyMetrics"
+}

--- a/static/redfish/v1/JsonSchemas/PowerSupplyMetrics/index.json
+++ b/static/redfish/v1/JsonSchemas/PowerSupplyMetrics/index.json
@@ -1,0 +1,21 @@
+{
+    "@odata.context": "/redfish/v1/$metadata#JsonSchemaFile.JsonSchemaFile",
+    "@odata.id": "/redfish/v1/JsonSchemas/PowerSupplyMetrics",
+    "@odata.type": "#JsonSchemaFile.v1_0_2.JsonSchemaFile",
+    "Name": "PowerSupplyMetrics Schema File",
+    "Schema": "#PowerSupplyMetrics.PowerSupplyMetrics",
+    "Description": "PowerSupplyMetrics Schema File Location",
+    "Id": "PowerSupplyMetrics",
+    "Languages": [
+        "en"
+    ],
+    "Languages@odata.count": 1,
+    "Location": [
+        {
+            "Language": "en",
+            "PublicationUri": "http://redfish.dmtf.org/schemas/v1/PowerSupplyMetrics.json",
+            "Uri": "/redfish/v1/JsonSchemas/PowerSupplyMetrics/PowerSupplyMetrics.json"
+        }
+    ],
+    "Location@odata.count": 1
+}

--- a/static/redfish/v1/JsonSchemas/PrivilegeRegistry/PrivilegeRegistry.json
+++ b/static/redfish/v1/JsonSchemas/PrivilegeRegistry/PrivilegeRegistry.json
@@ -1,0 +1,343 @@
+{
+    "$id": "http://redfish.dmtf.org/schemas/v1/PrivilegeRegistry.v1_1_4.json",
+    "$ref": "#/definitions/PrivilegeRegistry",
+    "$schema": "http://redfish.dmtf.org/schemas/v1/redfish-schema-v1.json",
+    "copyright": "Copyright 2014-2019 DMTF. For the full DMTF copyright policy, see http://www.dmtf.org/about/policies/copyright",
+    "definitions": {
+        "Actions": {
+            "additionalProperties": false,
+            "description": "The available actions for this Resource.",
+            "longDescription": "This type shall contain the available actions for this Resource.",
+            "patternProperties": {
+                "^([a-zA-Z_][a-zA-Z0-9_]*)?@(odata|Redfish|Message)\\.[a-zA-Z_][a-zA-Z0-9_]*$": {
+                    "description": "This property shall specify a valid odata or Redfish property.",
+                    "type": [
+                        "array",
+                        "boolean",
+                        "integer",
+                        "number",
+                        "null",
+                        "object",
+                        "string"
+                    ]
+                }
+            },
+            "properties": {
+                "Oem": {
+                    "$ref": "#/definitions/OemActions",
+                    "description": "The available OEM-specific actions for this Resource.",
+                    "longDescription": "This property shall contain the available OEM-specific actions for this Resource.",
+                    "versionAdded": "v1_1_0"
+                }
+            },
+            "type": "object"
+        },
+        "Mapping": {
+            "additionalProperties": false,
+            "description": "The mapping between a Resource type and the relevant privileges that accesses the Resource.",
+            "longDescription": "This type shall describe a mapping between a Resource type and the relevant privileges that accesses the Resource.",
+            "patternProperties": {
+                "^([a-zA-Z_][a-zA-Z0-9_]*)?@(odata|Redfish|Message)\\.[a-zA-Z_][a-zA-Z0-9_]*$": {
+                    "description": "This property shall specify a valid odata or Redfish property.",
+                    "type": [
+                        "array",
+                        "boolean",
+                        "integer",
+                        "number",
+                        "null",
+                        "object",
+                        "string"
+                    ]
+                }
+            },
+            "properties": {
+                "Entity": {
+                    "description": "The Resource name, such as `Manager`.",
+                    "longDescription": "This property shall contain the Resource name, such as `Manager`.",
+                    "readonly": true,
+                    "type": "string"
+                },
+                "OperationMap": {
+                    "$ref": "#/definitions/OperationMap",
+                    "description": "List mapping between HTTP methods and privilege required for the Resource.",
+                    "longDescription": "This property shall list the mapping between HTTP methods and the privilege required for the Resource."
+                },
+                "PropertyOverrides": {
+                    "description": "The privilege overrides of properties within a Resource.",
+                    "items": {
+                        "$ref": "#/definitions/Target_PrivilegeMap"
+                    },
+                    "longDescription": "This property shall contain the privilege overrides of properties, such as the `Password` property in the `ManagerAccount` Resource.",
+                    "type": "array"
+                },
+                "ResourceURIOverrides": {
+                    "description": "The privilege overrides of Resource URIs.",
+                    "items": {
+                        "$ref": "#/definitions/Target_PrivilegeMap"
+                    },
+                    "longDescription": "This property shall contain the privilege overrides of Resource URIs.  The target lists the Resource URI and the new privileges.",
+                    "type": "array"
+                },
+                "SubordinateOverrides": {
+                    "description": "The privilege overrides of the subordinate Resource.",
+                    "items": {
+                        "$ref": "#/definitions/Target_PrivilegeMap"
+                    },
+                    "longDescription": "This property shall contain the privilege overrides of the subordinate Resource.  The target lists are identified by Resource type.",
+                    "type": "array"
+                }
+            },
+            "type": "object"
+        },
+        "OemActions": {
+            "additionalProperties": true,
+            "description": "The available OEM-specific actions for this Resource.",
+            "longDescription": "This type shall contain the available OEM-specific actions for this Resource.",
+            "patternProperties": {
+                "^([a-zA-Z_][a-zA-Z0-9_]*)?@(odata|Redfish|Message)\\.[a-zA-Z_][a-zA-Z0-9_]*$": {
+                    "description": "This property shall specify a valid odata or Redfish property.",
+                    "type": [
+                        "array",
+                        "boolean",
+                        "integer",
+                        "number",
+                        "null",
+                        "object",
+                        "string"
+                    ]
+                }
+            },
+            "properties": {},
+            "type": "object"
+        },
+        "OperationMap": {
+            "additionalProperties": false,
+            "description": "The specific privileges required to complete a set of HTTP operations.",
+            "longDescription": "This type shall describe the specific privileges required to complete a set of HTTP operations.",
+            "patternProperties": {
+                "^([a-zA-Z_][a-zA-Z0-9_]*)?@(odata|Redfish|Message)\\.[a-zA-Z_][a-zA-Z0-9_]*$": {
+                    "description": "This property shall specify a valid odata or Redfish property.",
+                    "type": [
+                        "array",
+                        "boolean",
+                        "integer",
+                        "number",
+                        "null",
+                        "object",
+                        "string"
+                    ]
+                }
+            },
+            "properties": {
+                "DELETE": {
+                    "description": "The privilege required to complete an HTTP DELETE operation.",
+                    "items": {
+                        "$ref": "#/definitions/OperationPrivilege"
+                    },
+                    "longDescription": "This property shall contain the privilege required to complete an HTTP DELETE operation.",
+                    "type": "array"
+                },
+                "GET": {
+                    "description": "The privilege required to complete an HTTP GET operation.",
+                    "items": {
+                        "$ref": "#/definitions/OperationPrivilege"
+                    },
+                    "longDescription": "This property shall contain the privilege required to complete an HTTP GET operation.",
+                    "type": "array"
+                },
+                "HEAD": {
+                    "description": "The privilege required to complete an HTTP HEAD operation.",
+                    "items": {
+                        "$ref": "#/definitions/OperationPrivilege"
+                    },
+                    "longDescription": "This property shall contain the privilege required to complete an HTTP HEAD operation.",
+                    "type": "array"
+                },
+                "PATCH": {
+                    "description": "The privilege required to complete an HTTP PATCH operation.",
+                    "items": {
+                        "$ref": "#/definitions/OperationPrivilege"
+                    },
+                    "longDescription": "This property shall contain the privilege required to complete an HTTP PATCH operation.",
+                    "type": "array"
+                },
+                "POST": {
+                    "description": "The privilege required to complete an HTTP POST operation.",
+                    "items": {
+                        "$ref": "#/definitions/OperationPrivilege"
+                    },
+                    "longDescription": "This property shall contain the privilege required to complete an HTTP POST operation.",
+                    "type": "array"
+                },
+                "PUT": {
+                    "description": "The privilege required to complete an HTTP PUT operation.",
+                    "items": {
+                        "$ref": "#/definitions/OperationPrivilege"
+                    },
+                    "longDescription": "This property shall contain the privilege required to complete an HTTP PUT operation.",
+                    "type": "array"
+                }
+            },
+            "type": "object"
+        },
+        "OperationPrivilege": {
+            "additionalProperties": false,
+            "description": "The privileges for a specific HTTP operation.",
+            "longDescription": "This type shall describe the privileges required to complete a specific HTTP operation.",
+            "patternProperties": {
+                "^([a-zA-Z_][a-zA-Z0-9_]*)?@(odata|Redfish|Message)\\.[a-zA-Z_][a-zA-Z0-9_]*$": {
+                    "description": "This property shall specify a valid odata or Redfish property.",
+                    "type": [
+                        "array",
+                        "boolean",
+                        "integer",
+                        "number",
+                        "null",
+                        "object",
+                        "string"
+                    ]
+                }
+            },
+            "properties": {
+                "Privilege": {
+                    "description": "An array of privileges that are required to complete a specific HTTP operation on a Resource.",
+                    "items": {
+                        "type": "string"
+                    },
+                    "longDescription": "This array shall contain an array of privileges that are required to complete a specific HTTP operation on a Resource.  This set of strings match zero or more strings in the PrivilegesUsed and OEMPrivilegesUsed properties.",
+                    "readonly": true,
+                    "type": "array"
+                }
+            },
+            "type": "object"
+        },
+        "PrivilegeRegistry": {
+            "additionalProperties": false,
+            "description": "The PrivilegeRegistry schema describes the operation-to-privilege mappings.",
+            "longDescription": "This Resource contains operation-to-privilege mappings.",
+            "patternProperties": {
+                "^([a-zA-Z_][a-zA-Z0-9_]*)?@(odata|Redfish|Message)\\.[a-zA-Z_][a-zA-Z0-9_]*$": {
+                    "description": "This property shall specify a valid odata or Redfish property.",
+                    "type": [
+                        "array",
+                        "boolean",
+                        "integer",
+                        "number",
+                        "null",
+                        "object",
+                        "string"
+                    ]
+                }
+            },
+            "properties": {
+                "@odata.type": {
+                    "$ref": "http://redfish.dmtf.org/schemas/v1/odata-v4.json#/definitions/type"
+                },
+                "Actions": {
+                    "$ref": "#/definitions/Actions",
+                    "description": "The available actions for this Resource.",
+                    "longDescription": "This property shall contain the available actions for this Resource.",
+                    "versionAdded": "v1_1_0"
+                },
+                "Description": {
+                    "anyOf": [
+                        {
+                            "$ref": "http://redfish.dmtf.org/schemas/v1/Resource.json#/definitions/Description"
+                        },
+                        {
+                            "type": "null"
+                        }
+                    ],
+                    "readonly": true
+                },
+                "Id": {
+                    "$ref": "http://redfish.dmtf.org/schemas/v1/Resource.json#/definitions/Id",
+                    "readonly": true
+                },
+                "Mappings": {
+                    "description": "The mappings between entities and the relevant privileges that access those entities.",
+                    "items": {
+                        "$ref": "#/definitions/Mapping"
+                    },
+                    "longDescription": "This property shall describe the mappings between entities and the relevant privileges that access those entities.",
+                    "type": "array"
+                },
+                "Name": {
+                    "$ref": "http://redfish.dmtf.org/schemas/v1/Resource.json#/definitions/Name",
+                    "readonly": true
+                },
+                "OEMPrivilegesUsed": {
+                    "description": "The set of OEM privileges used in this mapping.",
+                    "items": {
+                        "type": "string"
+                    },
+                    "longDescription": "This property shall contain an array of OEM privileges used in this mapping.",
+                    "readonly": true,
+                    "type": "array"
+                },
+                "Oem": {
+                    "$ref": "http://redfish.dmtf.org/schemas/v1/Resource.json#/definitions/Oem",
+                    "description": "The OEM extension property.",
+                    "longDescription": "This property shall contain the OEM extensions.  All values for properties that this object contains shall conform to the Redfish Specification-described requirements."
+                },
+                "PrivilegesUsed": {
+                    "description": "The set of Redfish standard privileges used in this mapping.",
+                    "items": {
+                        "$ref": "http://redfish.dmtf.org/schemas/v1/Privileges.json#/definitions/PrivilegeType"
+                    },
+                    "longDescription": "This property shall contain an array of Redfish standard privileges used in this mapping.",
+                    "readonly": true,
+                    "type": "array"
+                }
+            },
+            "required": [
+                "@odata.type",
+                "Id",
+                "Name"
+            ],
+            "type": "object"
+        },
+        "Target_PrivilegeMap": {
+            "additionalProperties": false,
+            "description": "This type describes a mapping between one or more targets and the HTTP operations associated with them.",
+            "longDescription": "This type shall describe a mapping between one or more targets and the HTTP operations associated with them.",
+            "patternProperties": {
+                "^([a-zA-Z_][a-zA-Z0-9_]*)?@(odata|Redfish|Message)\\.[a-zA-Z_][a-zA-Z0-9_]*$": {
+                    "description": "This property shall specify a valid odata or Redfish property.",
+                    "type": [
+                        "array",
+                        "boolean",
+                        "integer",
+                        "number",
+                        "null",
+                        "object",
+                        "string"
+                    ]
+                }
+            },
+            "properties": {
+                "OperationMap": {
+                    "$ref": "#/definitions/OperationMap",
+                    "description": "The mapping between the HTTP operation and the privilege required to complete the operation.",
+                    "longDescription": "This property shall contain the mapping between the HTTP operation and the privilege required to complete the operation."
+                },
+                "Targets": {
+                    "description": "The set of URIs, Resource types, or properties.",
+                    "items": {
+                        "type": [
+                            "string",
+                            "null"
+                        ]
+                    },
+                    "longDescription": "This property shall contain the array of URIs, Resource types, or properties.  For example, `/redfish/v1/Systems/1`, `Manager`, or `Password`.  When the Targets property is not present, no override is specified.",
+                    "readonly": true,
+                    "type": "array"
+                }
+            },
+            "type": "object"
+        }
+    },
+    "owningEntity": "DMTF",
+    "release": "2017.1",
+    "title": "#PrivilegeRegistry.v1_1_4.PrivilegeRegistry"
+}

--- a/static/redfish/v1/JsonSchemas/PrivilegeRegistry/index.json
+++ b/static/redfish/v1/JsonSchemas/PrivilegeRegistry/index.json
@@ -1,0 +1,21 @@
+{
+    "@odata.context": "/redfish/v1/$metadata#JsonSchemaFile.JsonSchemaFile",
+    "@odata.id": "/redfish/v1/JsonSchemas/PrivilegeRegistry",
+    "@odata.type": "#JsonSchemaFile.v1_0_2.JsonSchemaFile",
+    "Name": "PrivilegeRegistry Schema File",
+    "Schema": "#PrivilegeRegistry.PrivilegeRegistry",
+    "Description": "PrivilegeRegistry Schema File Location",
+    "Id": "PrivilegeRegistry",
+    "Languages": [
+        "en"
+    ],
+    "Languages@odata.count": 1,
+    "Location": [
+        {
+            "Language": "en",
+            "PublicationUri": "http://redfish.dmtf.org/schemas/v1/PrivilegeRegistry.json",
+            "Uri": "/redfish/v1/JsonSchemas/PrivilegeRegistry/PrivilegeRegistry.json"
+        }
+    ],
+    "Location@odata.count": 1
+}

--- a/static/redfish/v1/JsonSchemas/ProcessorMetrics/ProcessorMetrics.json
+++ b/static/redfish/v1/JsonSchemas/ProcessorMetrics/ProcessorMetrics.json
@@ -1,0 +1,642 @@
+{
+    "$id": "http://redfish.dmtf.org/schemas/v1/ProcessorMetrics.v1_3_0.json",
+    "$ref": "#/definitions/ProcessorMetrics",
+    "$schema": "http://redfish.dmtf.org/schemas/v1/redfish-schema-v1.json",
+    "copyright": "Copyright 2014-2021 DMTF. For the full DMTF copyright policy, see http://www.dmtf.org/about/policies/copyright",
+    "definitions": {
+        "Actions": {
+            "additionalProperties": false,
+            "description": "The available actions for this resource.",
+            "longDescription": "This type shall contain the available actions for this resource.",
+            "patternProperties": {
+                "^([a-zA-Z_][a-zA-Z0-9_]*)?@(odata|Redfish|Message)\\.[a-zA-Z_][a-zA-Z0-9_]*$": {
+                    "description": "This property shall specify a valid odata or Redfish property.",
+                    "type": [
+                        "array",
+                        "boolean",
+                        "integer",
+                        "number",
+                        "null",
+                        "object",
+                        "string"
+                    ]
+                }
+            },
+            "properties": {
+                "#ProcessorMetrics.ClearCurrentPeriod": {
+                    "$ref": "#/definitions/ClearCurrentPeriod"
+                },
+                "Oem": {
+                    "$ref": "#/definitions/OemActions",
+                    "description": "The available OEM-specific actions for this resource.",
+                    "longDescription": "This property shall contain the available OEM-specific actions for this resource."
+                }
+            },
+            "type": "object"
+        },
+        "CStateResidency": {
+            "additionalProperties": false,
+            "description": "The C-state residency of the processor.",
+            "longDescription": "This type shall contain properties that describe the C-state residency of the processor or core.",
+            "patternProperties": {
+                "^([a-zA-Z_][a-zA-Z0-9_]*)?@(odata|Redfish|Message)\\.[a-zA-Z_][a-zA-Z0-9_]*$": {
+                    "description": "This property shall specify a valid odata or Redfish property.",
+                    "type": [
+                        "array",
+                        "boolean",
+                        "integer",
+                        "number",
+                        "null",
+                        "object",
+                        "string"
+                    ]
+                }
+            },
+            "properties": {
+                "Level": {
+                    "description": "The C-state level, such as C0, C1, or C2.",
+                    "longDescription": "This property shall contain the C-state level, such as C0, C1, or C2.  When this resource is subordinate to the ProcessorSummary object, this property is not applicable.",
+                    "readonly": true,
+                    "type": [
+                        "string",
+                        "null"
+                    ]
+                },
+                "ResidencyPercent": {
+                    "description": "The percentage of time that the processor or core has spent in this particular level of C-state.",
+                    "longDescription": "This property shall contain the percentage of time that the processor or core has spent in this particular level of C-state.  When this resource is subordinate to the ProcessorSummary object, this property is not applicable.",
+                    "minimum": 0,
+                    "readonly": true,
+                    "type": [
+                        "number",
+                        "null"
+                    ],
+                    "units": "%"
+                }
+            },
+            "type": "object"
+        },
+        "CacheMetrics": {
+            "additionalProperties": false,
+            "description": "The processor core metrics.",
+            "longDescription": "This type shall contain properties that describe cache metrics of a processor or core.",
+            "patternProperties": {
+                "^([a-zA-Z_][a-zA-Z0-9_]*)?@(odata|Redfish|Message)\\.[a-zA-Z_][a-zA-Z0-9_]*$": {
+                    "description": "This property shall specify a valid odata or Redfish property.",
+                    "type": [
+                        "array",
+                        "boolean",
+                        "integer",
+                        "number",
+                        "null",
+                        "object",
+                        "string"
+                    ]
+                }
+            },
+            "properties": {
+                "CacheMiss": {
+                    "description": "The number of cache line misses in millions.",
+                    "longDescription": "This property shall contain the number of cache line misses of the processor or core in millions.",
+                    "readonly": true,
+                    "type": [
+                        "number",
+                        "null"
+                    ]
+                },
+                "CacheMissesPerInstruction": {
+                    "description": "The number of cache misses per instruction.",
+                    "longDescription": "This property shall contain the number of cache misses per instruction of the processor or core.",
+                    "readonly": true,
+                    "type": [
+                        "number",
+                        "null"
+                    ]
+                },
+                "HitRatio": {
+                    "description": "The cache line hit ratio.",
+                    "longDescription": "This property shall contain the cache hit ratio of the processor or core.",
+                    "readonly": true,
+                    "type": [
+                        "number",
+                        "null"
+                    ]
+                },
+                "Level": {
+                    "description": "The cache level.",
+                    "longDescription": "This property shall contain the level of the cache in the processor or core.",
+                    "readonly": true,
+                    "type": [
+                        "string",
+                        "null"
+                    ]
+                },
+                "OccupancyBytes": {
+                    "description": "The total cache level occupancy in bytes.",
+                    "longDescription": "This property shall contain the total cache occupancy of the processor or core in bytes.",
+                    "readonly": true,
+                    "type": [
+                        "integer",
+                        "null"
+                    ],
+                    "units": "By"
+                },
+                "OccupancyPercent": {
+                    "description": "The total cache occupancy percentage.",
+                    "longDescription": "This property shall contain the total cache occupancy percentage of the processor or core.",
+                    "minimum": 0,
+                    "readonly": true,
+                    "type": [
+                        "number",
+                        "null"
+                    ],
+                    "units": "%"
+                }
+            },
+            "type": "object"
+        },
+        "CacheMetricsTotal": {
+            "additionalProperties": false,
+            "description": "The total cache metrics for a processor.",
+            "longDescription": "This property shall contain properties that describe the metrics for all of the cache memory for a processor.",
+            "patternProperties": {
+                "^([a-zA-Z_][a-zA-Z0-9_]*)?@(odata|Redfish|Message)\\.[a-zA-Z_][a-zA-Z0-9_]*$": {
+                    "description": "This property shall specify a valid odata or Redfish property.",
+                    "type": [
+                        "array",
+                        "boolean",
+                        "integer",
+                        "number",
+                        "null",
+                        "object",
+                        "string"
+                    ]
+                }
+            },
+            "properties": {
+                "CurrentPeriod": {
+                    "$ref": "#/definitions/CurrentPeriod",
+                    "description": "The cache metrics since the last reset for this processor.",
+                    "longDescription": "This property shall contain properties that describe the metrics for the current period of cache memory for this processor.",
+                    "versionAdded": "v1_2_0"
+                },
+                "LifeTime": {
+                    "$ref": "#/definitions/LifeTime",
+                    "description": "The cache metrics for the lifetime of this processor.",
+                    "longDescription": "This property shall contain properties that describe the metrics for the lifetime of cache memory for this processor.",
+                    "versionAdded": "v1_2_0"
+                }
+            },
+            "type": "object"
+        },
+        "ClearCurrentPeriod": {
+            "additionalProperties": false,
+            "description": "This action sets the CurrentPeriod property's values to 0.",
+            "longDescription": "This action shall set the CurrentPeriod property's values to 0.",
+            "parameters": {},
+            "patternProperties": {
+                "^([a-zA-Z_][a-zA-Z0-9_]*)?@(odata|Redfish|Message)\\.[a-zA-Z_][a-zA-Z0-9_]*$": {
+                    "description": "This property shall specify a valid odata or Redfish property.",
+                    "type": [
+                        "array",
+                        "boolean",
+                        "integer",
+                        "number",
+                        "null",
+                        "object",
+                        "string"
+                    ]
+                }
+            },
+            "properties": {
+                "target": {
+                    "description": "Link to invoke action",
+                    "format": "uri-reference",
+                    "type": "string"
+                },
+                "title": {
+                    "description": "Friendly action name",
+                    "type": "string"
+                }
+            },
+            "type": "object",
+            "versionAdded": "v1_2_0"
+        },
+        "CoreMetrics": {
+            "additionalProperties": false,
+            "description": "The processor core metrics.",
+            "longDescription": "This type shall contain properties that describe the cores of a processor.",
+            "patternProperties": {
+                "^([a-zA-Z_][a-zA-Z0-9_]*)?@(odata|Redfish|Message)\\.[a-zA-Z_][a-zA-Z0-9_]*$": {
+                    "description": "This property shall specify a valid odata or Redfish property.",
+                    "type": [
+                        "array",
+                        "boolean",
+                        "integer",
+                        "number",
+                        "null",
+                        "object",
+                        "string"
+                    ]
+                }
+            },
+            "properties": {
+                "CStateResidency": {
+                    "description": "The C-state residency of this core in the processor.",
+                    "items": {
+                        "$ref": "#/definitions/CStateResidency"
+                    },
+                    "longDescription": "This property shall contain properties that describe the C-state residency of this core in the processor.",
+                    "type": "array"
+                },
+                "CoreCache": {
+                    "description": "The cache metrics of this core in the processor.",
+                    "items": {
+                        "$ref": "#/definitions/CacheMetrics"
+                    },
+                    "longDescription": "This property shall contain properties that describe the cache metrics of this core in the processor.",
+                    "type": "array"
+                },
+                "CoreId": {
+                    "description": "The processor core identifier.",
+                    "longDescription": "This property shall contain the identifier of the core within the processor.",
+                    "readonly": true,
+                    "type": [
+                        "string",
+                        "null"
+                    ]
+                },
+                "IOStallCount": {
+                    "description": "The number of stalled cycles due to I/O operations.",
+                    "longDescription": "This property shall contain the number of stalled cycles due to I/O operations of this core in the processor.",
+                    "readonly": true,
+                    "type": [
+                        "number",
+                        "null"
+                    ]
+                },
+                "InstructionsPerCycle": {
+                    "description": "The number of instructions per clock cycle of this core.",
+                    "longDescription": "This property shall contain the number of instructions per clock cycle of this core in the processor.",
+                    "readonly": true,
+                    "type": [
+                        "number",
+                        "null"
+                    ]
+                },
+                "MemoryStallCount": {
+                    "description": "The number of stalled cycles due to memory operations.",
+                    "longDescription": "This property shall contain the number of stalled cycles due to memory operations of this core in the processor.",
+                    "readonly": true,
+                    "type": [
+                        "number",
+                        "null"
+                    ]
+                },
+                "UnhaltedCycles": {
+                    "description": "The unhalted cycles count of this core.",
+                    "longDescription": "This property shall contain the number of unhalted cycles of this core in the processor.",
+                    "readonly": true,
+                    "type": [
+                        "number",
+                        "null"
+                    ]
+                }
+            },
+            "type": "object"
+        },
+        "CurrentPeriod": {
+            "additionalProperties": false,
+            "description": "The cache memory metrics since the last system reset or ClearCurrentPeriod action for a processor.",
+            "longDescription": "This type shall describe the cache memory metrics since last system reset or ClearCurrentPeriod action for a processor.",
+            "patternProperties": {
+                "^([a-zA-Z_][a-zA-Z0-9_]*)?@(odata|Redfish|Message)\\.[a-zA-Z_][a-zA-Z0-9_]*$": {
+                    "description": "This property shall specify a valid odata or Redfish property.",
+                    "type": [
+                        "array",
+                        "boolean",
+                        "integer",
+                        "number",
+                        "null",
+                        "object",
+                        "string"
+                    ]
+                }
+            },
+            "properties": {
+                "CorrectableECCErrorCount": {
+                    "description": "The number of the correctable errors of cache memory since reset.",
+                    "longDescription": "This property shall contain the number of correctable errors of cache memory since reset.  When this resource is subordinate to the ProcessorSummary object, this property shall be the sum of CorrectableECCErrorCount over all processors.",
+                    "readonly": true,
+                    "type": [
+                        "integer",
+                        "null"
+                    ],
+                    "versionAdded": "v1_2_0"
+                },
+                "UncorrectableECCErrorCount": {
+                    "description": "The number of the uncorrectable errors of cache memory since reset.",
+                    "longDescription": "This property shall contain the number of uncorrectable errors of cache memory since reset.  When this resource is subordinate to the ProcessorSummary object, this property shall be the sum of UncorrectableECCErrorCount over all processors.",
+                    "readonly": true,
+                    "type": [
+                        "integer",
+                        "null"
+                    ],
+                    "versionAdded": "v1_2_0"
+                }
+            },
+            "type": "object"
+        },
+        "LifeTime": {
+            "additionalProperties": false,
+            "description": "The cache memory metrics for the lifetime for a processor.",
+            "longDescription": "This type shall describe the cache memory metrics since manufacturing for a processor.",
+            "patternProperties": {
+                "^([a-zA-Z_][a-zA-Z0-9_]*)?@(odata|Redfish|Message)\\.[a-zA-Z_][a-zA-Z0-9_]*$": {
+                    "description": "This property shall specify a valid odata or Redfish property.",
+                    "type": [
+                        "array",
+                        "boolean",
+                        "integer",
+                        "number",
+                        "null",
+                        "object",
+                        "string"
+                    ]
+                }
+            },
+            "properties": {
+                "CorrectableECCErrorCount": {
+                    "description": "The number of the correctable errors for the lifetime of the cache memory.",
+                    "longDescription": "This property shall contain the number of the correctable errors for the lifetime of cache memory.  When this resource is subordinate to the ProcessorSummary object, this property shall be the sum of CorrectableECCErrorCount over all processors.",
+                    "readonly": true,
+                    "type": [
+                        "integer",
+                        "null"
+                    ],
+                    "versionAdded": "v1_2_0"
+                },
+                "UncorrectableECCErrorCount": {
+                    "description": "The number of the uncorrectable errors for the lifetime of the cache memory.",
+                    "longDescription": "This property shall contain the number of the uncorrectable errors for the lifetime of cache memory.  When this resource is subordinate to the ProcessorSummary object, this property shall be the sum of UncorrectableECCErrorCount over all processors.",
+                    "readonly": true,
+                    "type": [
+                        "integer",
+                        "null"
+                    ],
+                    "versionAdded": "v1_2_0"
+                }
+            },
+            "type": "object"
+        },
+        "OemActions": {
+            "additionalProperties": true,
+            "description": "The available OEM-specific actions for this resource.",
+            "longDescription": "This type shall contain the available OEM-specific actions for this resource.",
+            "patternProperties": {
+                "^([a-zA-Z_][a-zA-Z0-9_]*)?@(odata|Redfish|Message)\\.[a-zA-Z_][a-zA-Z0-9_]*$": {
+                    "description": "This property shall specify a valid odata or Redfish property.",
+                    "type": [
+                        "array",
+                        "boolean",
+                        "integer",
+                        "number",
+                        "null",
+                        "object",
+                        "string"
+                    ]
+                }
+            },
+            "properties": {},
+            "type": "object"
+        },
+        "ProcessorMetrics": {
+            "additionalProperties": false,
+            "description": "The ProcessorMetrics schema contains usage and health statistics for a processor.",
+            "longDescription": "This resource contains the processor metrics for a single processor in a Redfish implementation.",
+            "patternProperties": {
+                "^([a-zA-Z_][a-zA-Z0-9_]*)?@(odata|Redfish|Message)\\.[a-zA-Z_][a-zA-Z0-9_]*$": {
+                    "description": "This property shall specify a valid odata or Redfish property.",
+                    "type": [
+                        "array",
+                        "boolean",
+                        "integer",
+                        "number",
+                        "null",
+                        "object",
+                        "string"
+                    ]
+                }
+            },
+            "properties": {
+                "@odata.context": {
+                    "$ref": "http://redfish.dmtf.org/schemas/v1/odata-v4.json#/definitions/context"
+                },
+                "@odata.etag": {
+                    "$ref": "http://redfish.dmtf.org/schemas/v1/odata-v4.json#/definitions/etag"
+                },
+                "@odata.id": {
+                    "$ref": "http://redfish.dmtf.org/schemas/v1/odata-v4.json#/definitions/id"
+                },
+                "@odata.type": {
+                    "$ref": "http://redfish.dmtf.org/schemas/v1/odata-v4.json#/definitions/type"
+                },
+                "Actions": {
+                    "$ref": "#/definitions/Actions",
+                    "description": "The available actions for this resource.",
+                    "longDescription": "This property shall contain the available actions for this resource."
+                },
+                "AverageFrequencyMHz": {
+                    "deprecated": "This property has been deprecated in favor of OperatingSpeedMHz property.",
+                    "description": "The average frequency of the processor.",
+                    "longDescription": "This property shall contain average frequency in MHz, across all enabled cores in the processor.  When this resource is subordinate to the ProcessorSummary object, this property is not applicable.",
+                    "readonly": true,
+                    "type": [
+                        "number",
+                        "null"
+                    ],
+                    "units": "MHz",
+                    "versionDeprecated": "v1_1_0"
+                },
+                "BandwidthPercent": {
+                    "description": "The bandwidth usage of this processor as a percentage.",
+                    "longDescription": "This property shall contain the bandwidth usage of the processor as a percentage.  When this resource is subordinate to the ProcessorSummary object, this property shall be the CPU utilization over all processors as a percentage.",
+                    "minimum": 0,
+                    "readonly": true,
+                    "type": [
+                        "number",
+                        "null"
+                    ],
+                    "units": "%"
+                },
+                "Cache": {
+                    "description": "The processor cache metrics.",
+                    "items": {
+                        "$ref": "#/definitions/CacheMetrics"
+                    },
+                    "longDescription": "This property shall contain properties that describe this processor's cache.  When this resource is subordinate to the ProcessorSummary object, this property is not applicable.",
+                    "type": "array"
+                },
+                "CacheMetricsTotal": {
+                    "$ref": "#/definitions/CacheMetricsTotal",
+                    "description": "The total cache metrics for this processor.",
+                    "longDescription": "This property shall contain properties that describe the metrics for all of the cache memory of this processor.",
+                    "versionAdded": "v1_2_0"
+                },
+                "ConsumedPowerWatt": {
+                    "deprecated": "This property has been deprecated in favor of the properties in EnvironmentMetrics.",
+                    "description": "The power, in watts, that the processor has consumed.",
+                    "longDescription": "This property shall contain the power, in watts, that the processor has consumed.  When this resource is subordinate to the ProcessorSummary object, this property shall be the sum of power, in watts, that all processors have consumed.",
+                    "readonly": true,
+                    "type": [
+                        "number",
+                        "null"
+                    ],
+                    "units": "W",
+                    "versionDeprecated": "v1_2_0"
+                },
+                "CoreMetrics": {
+                    "description": "The processor core metrics.",
+                    "items": {
+                        "$ref": "#/definitions/CoreMetrics"
+                    },
+                    "longDescription": "This property shall contain properties that describe the cores of this processor.  When this resource is subordinate to the ProcessorSummary object, this property is not applicable.",
+                    "type": "array"
+                },
+                "CoreVoltage": {
+                    "anyOf": [
+                        {
+                            "$ref": "http://redfish.dmtf.org/schemas/v1/Sensor.json#/definitions/SensorVoltageExcerpt"
+                        },
+                        {
+                            "type": "null"
+                        }
+                    ],
+                    "description": "The core voltage of this processor in Volts.",
+                    "excerptCopy": "SensorVoltageExcerpt",
+                    "longDescription": "The value of this property shall contain the sensor measuring the core voltage of this processor in Volts.  The core voltage of the processor may change more frequently than the manager is able to monitor.",
+                    "readonly": true,
+                    "versionAdded": "v1_3_0"
+                },
+                "Description": {
+                    "anyOf": [
+                        {
+                            "$ref": "http://redfish.dmtf.org/schemas/v1/Resource.json#/definitions/Description"
+                        },
+                        {
+                            "type": "null"
+                        }
+                    ],
+                    "readonly": true
+                },
+                "FrequencyRatio": {
+                    "description": "The frequency relative to the nominal processor frequency ratio.",
+                    "longDescription": "This property shall contain the frequency relative to the nominal processor frequency ratio of this processor.  When this resource is subordinate to the ProcessorSummary object, this property shall be the average FrequencyRatio over all processors.",
+                    "readonly": true,
+                    "type": [
+                        "number",
+                        "null"
+                    ]
+                },
+                "Id": {
+                    "$ref": "http://redfish.dmtf.org/schemas/v1/Resource.json#/definitions/Id",
+                    "readonly": true
+                },
+                "KernelPercent": {
+                    "description": "The percentage of time spent in kernel mode.",
+                    "longDescription": "This property shall contain total percentage of time the processor has spent in kernel mode.  When this resource is subordinate to the ProcessorSummary object, this property shall be the average KernelPercent over all processors.",
+                    "minimum": 0,
+                    "readonly": true,
+                    "type": [
+                        "number",
+                        "null"
+                    ],
+                    "units": "%"
+                },
+                "LocalMemoryBandwidthBytes": {
+                    "description": "The local memory bandwidth usage in bytes.",
+                    "longDescription": "This property shall contain the local memory bandwidth usage of this processor in bytes.  When this resource is subordinate to the ProcessorSummary object, this property shall be the sum of LocalMemoryBandwidthBytes over all processors.",
+                    "readonly": true,
+                    "type": [
+                        "integer",
+                        "null"
+                    ],
+                    "units": "By"
+                },
+                "Name": {
+                    "$ref": "http://redfish.dmtf.org/schemas/v1/Resource.json#/definitions/Name",
+                    "readonly": true
+                },
+                "Oem": {
+                    "$ref": "http://redfish.dmtf.org/schemas/v1/Resource.json#/definitions/Oem",
+                    "description": "The OEM extension property.",
+                    "longDescription": "This property shall contain the OEM extensions.  All values for properties that this object contains shall conform to the Redfish Specification-described requirements."
+                },
+                "OperatingSpeedMHz": {
+                    "description": "Operating speed of the processor in MHz.",
+                    "longDescription": "This property shall contain the operating speed of the processor in MHz.  The operating speed of the processor may change more frequently than the manager is able to monitor.",
+                    "readonly": true,
+                    "type": [
+                        "integer",
+                        "null"
+                    ],
+                    "units": "MHz",
+                    "versionAdded": "v1_1_0"
+                },
+                "RemoteMemoryBandwidthBytes": {
+                    "description": "The remote memory bandwidth usage in bytes.",
+                    "longDescription": "This property shall contain the remote memory bandwidth usage of this processor in bytes.  When this resource is subordinate to the ProcessorSummary object, this property shall be the sum of RemoteMemoryBandwidthBytes over all processors.",
+                    "readonly": true,
+                    "type": [
+                        "integer",
+                        "null"
+                    ],
+                    "units": "By"
+                },
+                "TemperatureCelsius": {
+                    "deprecated": "This property has been deprecated in favor of the properties in EnvironmentMetrics.",
+                    "description": "The temperature of the processor.",
+                    "longDescription": "This property shall contain the temperature, in Celsius, of the processor.  When this resource is subordinate to the ProcessorSummary object, this property shall be the average temperature, in Celsius, over all processors.",
+                    "readonly": true,
+                    "type": [
+                        "number",
+                        "null"
+                    ],
+                    "units": "Cel",
+                    "versionDeprecated": "v1_2_0"
+                },
+                "ThrottlingCelsius": {
+                    "description": "The CPU margin to throttle (temperature offset in degree Celsius).",
+                    "longDescription": "This property shall contain the CPU margin to throttle based on an offset between the maximum temperature in which the processor can operate, and the processor's current temperature.  When this resource is subordinate to the ProcessorSummary object, this property is not applicable.",
+                    "readonly": true,
+                    "type": [
+                        "number",
+                        "null"
+                    ],
+                    "units": "Cel"
+                },
+                "UserPercent": {
+                    "description": "The percentage of time spent in user mode.",
+                    "longDescription": "This property shall contain total percentage of time the processor has spent in user mode.  When this resource is subordinate to the ProcessorSummary object, this property shall be the average UserPercent over all processors.",
+                    "minimum": 0,
+                    "readonly": true,
+                    "type": [
+                        "number",
+                        "null"
+                    ],
+                    "units": "%"
+                }
+            },
+            "required": [
+                "@odata.id",
+                "@odata.type",
+                "Id",
+                "Name"
+            ],
+            "type": "object"
+        }
+    },
+    "owningEntity": "DMTF",
+    "release": "2021.2",
+    "title": "#ProcessorMetrics.v1_3_0.ProcessorMetrics"
+}

--- a/static/redfish/v1/JsonSchemas/ProcessorMetrics/index.json
+++ b/static/redfish/v1/JsonSchemas/ProcessorMetrics/index.json
@@ -1,0 +1,21 @@
+{
+    "@odata.context": "/redfish/v1/$metadata#JsonSchemaFile.JsonSchemaFile",
+    "@odata.id": "/redfish/v1/JsonSchemas/ProcessorMetrics",
+    "@odata.type": "#JsonSchemaFile.v1_0_2.JsonSchemaFile",
+    "Name": "ProcessorMetrics Schema File",
+    "Schema": "#ProcessorMetrics.ProcessorMetrics",
+    "Description": "ProcessorMetrics Schema File Location",
+    "Id": "ProcessorMetrics",
+    "Languages": [
+        "en"
+    ],
+    "Languages@odata.count": 1,
+    "Location": [
+        {
+            "Language": "en",
+            "PublicationUri": "http://redfish.dmtf.org/schemas/v1/ProcessorMetrics.json",
+            "Uri": "/redfish/v1/JsonSchemas/ProcessorMetrics/ProcessorMetrics.json"
+        }
+    ],
+    "Location@odata.count": 1
+}

--- a/static/redfish/v1/JsonSchemas/ResourceBlock/ResourceBlock.json
+++ b/static/redfish/v1/JsonSchemas/ResourceBlock/ResourceBlock.json
@@ -1,0 +1,692 @@
+{
+    "$id": "http://redfish.dmtf.org/schemas/v1/ResourceBlock.v1_4_0.json",
+    "$ref": "#/definitions/ResourceBlock",
+    "$schema": "http://redfish.dmtf.org/schemas/v1/redfish-schema-v1.json",
+    "copyright": "Copyright 2014-2021 DMTF. For the full DMTF copyright policy, see http://www.dmtf.org/about/policies/copyright",
+    "definitions": {
+        "Actions": {
+            "additionalProperties": false,
+            "description": "The available actions for this resource.",
+            "longDescription": "This type shall contain the available actions for this resource.",
+            "patternProperties": {
+                "^([a-zA-Z_][a-zA-Z0-9_]*)?@(odata|Redfish|Message)\\.[a-zA-Z_][a-zA-Z0-9_]*$": {
+                    "description": "This property shall specify a valid odata or Redfish property.",
+                    "type": [
+                        "array",
+                        "boolean",
+                        "integer",
+                        "number",
+                        "null",
+                        "object",
+                        "string"
+                    ]
+                }
+            },
+            "properties": {
+                "Oem": {
+                    "$ref": "#/definitions/OemActions",
+                    "description": "The available OEM-specific actions for this resource.",
+                    "longDescription": "This property shall contain the available OEM-specific actions for this resource."
+                }
+            },
+            "type": "object"
+        },
+        "CompositionState": {
+            "enum": [
+                "Composing",
+                "ComposedAndAvailable",
+                "Composed",
+                "Unused",
+                "Failed",
+                "Unavailable"
+            ],
+            "enumDescriptions": {
+                "Composed": "Final successful state of a resource block that has participated in composition.",
+                "ComposedAndAvailable": "The resource block is currently participating in one or more compositions, and is available to use in more compositions.",
+                "Composing": "Intermediate state indicating composition is in progress.",
+                "Failed": "The final composition resulted in failure and manual intervention might be required to fix it.",
+                "Unavailable": "The resource block has been made unavailable by the service, such as due to maintenance being performed on the resource block.",
+                "Unused": "The resource block is free and can participate in composition."
+            },
+            "enumVersionAdded": {
+                "ComposedAndAvailable": "v1_1_0",
+                "Unavailable": "v1_2_0"
+            },
+            "type": "string"
+        },
+        "CompositionStatus": {
+            "additionalProperties": false,
+            "description": "Composition status of the resource block.",
+            "longDescription": "This type shall contain properties that describe the high level composition status of the resource block.",
+            "patternProperties": {
+                "^([a-zA-Z_][a-zA-Z0-9_]*)?@(odata|Redfish|Message)\\.[a-zA-Z_][a-zA-Z0-9_]*$": {
+                    "description": "This property shall specify a valid odata or Redfish property.",
+                    "type": [
+                        "array",
+                        "boolean",
+                        "integer",
+                        "number",
+                        "null",
+                        "object",
+                        "string"
+                    ]
+                }
+            },
+            "properties": {
+                "CompositionState": {
+                    "anyOf": [
+                        {
+                            "$ref": "#/definitions/CompositionState"
+                        },
+                        {
+                            "type": "null"
+                        }
+                    ],
+                    "description": "The current state of the resource block from a composition perspective.",
+                    "longDescription": "This property shall contain an enumerated value that describes the composition state of the resource block.",
+                    "readonly": true
+                },
+                "MaxCompositions": {
+                    "description": "The maximum number of compositions in which this resource block can participate simultaneously.",
+                    "longDescription": "This property shall contain a number indicating the maximum number of compositions in which this resource block can participate simultaneously.  Services can have additional constraints that prevent this value from being achieved, such as due to system topology and current composed resource utilization.  If SharingCapable is `false`, this value shall be set to `1`.  The service shall support this property if SharingCapable supported.",
+                    "minimum": 1,
+                    "readonly": true,
+                    "type": [
+                        "integer",
+                        "null"
+                    ],
+                    "versionAdded": "v1_1_0"
+                },
+                "NumberOfCompositions": {
+                    "description": "The number of compositions in which this resource block is currently participating.",
+                    "longDescription": "This property shall contain the number of compositions in which this resource block is currently participating.",
+                    "minimum": 0,
+                    "readonly": true,
+                    "type": [
+                        "integer",
+                        "null"
+                    ],
+                    "versionAdded": "v1_1_0"
+                },
+                "Reserved": {
+                    "description": "An indication of whether any client has reserved the resource block.",
+                    "longDescription": "This property shall indicate whether any client has reserved the resource block.  A client sets this property after the resource block is identified as composed.  It shall provide a way for multiple clients to negotiate the ownership of the resource block.",
+                    "readonly": false,
+                    "type": [
+                        "boolean",
+                        "null"
+                    ]
+                },
+                "SharingCapable": {
+                    "description": "An indication of whether this resource block can participate in multiple compositions simultaneously.",
+                    "longDescription": "This property shall indicate whether this resource block can participate in multiple compositions simultaneously.  If this property is not provided, it shall be assumed that this resource block is not capable of being shared.",
+                    "readonly": true,
+                    "type": [
+                        "boolean",
+                        "null"
+                    ],
+                    "versionAdded": "v1_1_0"
+                },
+                "SharingEnabled": {
+                    "description": "An indication of whether this resource block is allowed to participate in multiple compositions simultaneously.",
+                    "longDescription": "This property shall indicate whether this resource block can participate in multiple compositions simultaneously.  The service shall reject modifications of this property with HTTP 400 Bad Request if this resource block is already being used as part of a composed resource.  If `false`, the service shall not use the `ComposedAndAvailable` state for this resource block.",
+                    "readonly": false,
+                    "type": [
+                        "boolean",
+                        "null"
+                    ],
+                    "versionAdded": "v1_1_0"
+                }
+            },
+            "required": [
+                "CompositionState"
+            ],
+            "type": "object"
+        },
+        "Links": {
+            "additionalProperties": false,
+            "description": "The links to other resources that are related to this resource.",
+            "longDescription": "This Redfish Specification-described type shall contain links to resources that are related to but are not contained by, or subordinate to, this resource.",
+            "patternProperties": {
+                "^([a-zA-Z_][a-zA-Z0-9_]*)?@(odata|Redfish|Message)\\.[a-zA-Z_][a-zA-Z0-9_]*$": {
+                    "description": "This property shall specify a valid odata or Redfish property.",
+                    "type": [
+                        "array",
+                        "boolean",
+                        "integer",
+                        "number",
+                        "null",
+                        "object",
+                        "string"
+                    ]
+                }
+            },
+            "properties": {
+                "Chassis": {
+                    "description": "An array of links to the chassis in which this resource block is contained.",
+                    "items": {
+                        "$ref": "http://redfish.dmtf.org/schemas/v1/Chassis.json#/definitions/Chassis"
+                    },
+                    "longDescription": "This property shall contain an array of links to resources of type Chassis that represent the physical container associated with this resource block.",
+                    "readonly": true,
+                    "type": "array"
+                },
+                "Chassis@odata.count": {
+                    "$ref": "http://redfish.dmtf.org/schemas/v1/odata-v4.json#/definitions/count"
+                },
+                "ComputerSystems": {
+                    "description": "An array of links to the computer systems that are composed from this resource block.",
+                    "items": {
+                        "$ref": "http://redfish.dmtf.org/schemas/v1/ComputerSystem.json#/definitions/ComputerSystem"
+                    },
+                    "longDescription": "This property shall contain an array of links to resources of type ComputerSystem that represent the computer systems composed from this resource block.",
+                    "readonly": true,
+                    "type": "array"
+                },
+                "ComputerSystems@odata.count": {
+                    "$ref": "http://redfish.dmtf.org/schemas/v1/odata-v4.json#/definitions/count"
+                },
+                "ConsumingResourceBlocks": {
+                    "description": "An array of links to resource blocks that depend on this resource block.",
+                    "items": {
+                        "$ref": "http://redfish.dmtf.org/schemas/v1/ResourceBlock.json#/definitions/ResourceBlock"
+                    },
+                    "longDescription": "This property shall contain an array of links to resources of type ResourceBlock that represent the resource blocks that depend on this resource block as a component.",
+                    "readonly": true,
+                    "type": "array",
+                    "versionAdded": "v1_4_0"
+                },
+                "ConsumingResourceBlocks@odata.count": {
+                    "$ref": "http://redfish.dmtf.org/schemas/v1/odata-v4.json#/definitions/count"
+                },
+                "Oem": {
+                    "$ref": "http://redfish.dmtf.org/schemas/v1/Resource.json#/definitions/Oem",
+                    "description": "The OEM extension property.",
+                    "longDescription": "This property shall contain the OEM extensions.  All values for properties contained in this object shall conform to the Redfish Specification-described requirements."
+                },
+                "SupplyingResourceBlocks": {
+                    "description": "An array of links to resource blocks that this resource block depends on.",
+                    "items": {
+                        "$ref": "http://redfish.dmtf.org/schemas/v1/ResourceBlock.json#/definitions/ResourceBlock"
+                    },
+                    "longDescription": "This property shall contain an array of links to resources of type ResourceBlock that represent the resource blocks that this resource block depends on as components.",
+                    "readonly": true,
+                    "type": "array",
+                    "versionAdded": "v1_4_0"
+                },
+                "SupplyingResourceBlocks@odata.count": {
+                    "$ref": "http://redfish.dmtf.org/schemas/v1/odata-v4.json#/definitions/count"
+                },
+                "Zones": {
+                    "description": "An array of links to the zones in which this resource block is bound.",
+                    "items": {
+                        "$ref": "http://redfish.dmtf.org/schemas/v1/Zone.json#/definitions/Zone"
+                    },
+                    "longDescription": "This property shall contain an array of links to resources of type Zone that represent the binding constraints associated with this resource block.",
+                    "readonly": true,
+                    "type": "array"
+                },
+                "Zones@odata.count": {
+                    "$ref": "http://redfish.dmtf.org/schemas/v1/odata-v4.json#/definitions/count"
+                }
+            },
+            "type": "object"
+        },
+        "OemActions": {
+            "additionalProperties": true,
+            "description": "The available OEM-specific actions for this resource.",
+            "longDescription": "This type shall contain the available OEM-specific actions for this resource.",
+            "patternProperties": {
+                "^([a-zA-Z_][a-zA-Z0-9_]*)?@(odata|Redfish|Message)\\.[a-zA-Z_][a-zA-Z0-9_]*$": {
+                    "description": "This property shall specify a valid odata or Redfish property.",
+                    "type": [
+                        "array",
+                        "boolean",
+                        "integer",
+                        "number",
+                        "null",
+                        "object",
+                        "string"
+                    ]
+                }
+            },
+            "properties": {},
+            "type": "object"
+        },
+        "PoolType": {
+            "enum": [
+                "Free",
+                "Active",
+                "Unassigned"
+            ],
+            "enumDescriptions": {
+                "Active": "This resource block is in the active pool and is contributing to at least one composed resource as a result of a composition request.",
+                "Free": "This resource block is in the free pool and is not contributing to any composed resources.",
+                "Unassigned": "This resource block is not assigned to any pools."
+            },
+            "type": "string"
+        },
+        "ResourceBlock": {
+            "additionalProperties": false,
+            "description": "The ResourceBlock schema contains definitions resource blocks, its components, and affinity to composed devices.",
+            "longDescription": "This resource shall represent a resource block for a Redfish implementation.",
+            "patternProperties": {
+                "^([a-zA-Z_][a-zA-Z0-9_]*)?@(odata|Redfish|Message)\\.[a-zA-Z_][a-zA-Z0-9_]*$": {
+                    "description": "This property shall specify a valid odata or Redfish property.",
+                    "type": [
+                        "array",
+                        "boolean",
+                        "integer",
+                        "number",
+                        "null",
+                        "object",
+                        "string"
+                    ]
+                }
+            },
+            "properties": {
+                "@odata.context": {
+                    "$ref": "http://redfish.dmtf.org/schemas/v1/odata-v4.json#/definitions/context"
+                },
+                "@odata.etag": {
+                    "$ref": "http://redfish.dmtf.org/schemas/v1/odata-v4.json#/definitions/etag"
+                },
+                "@odata.id": {
+                    "$ref": "http://redfish.dmtf.org/schemas/v1/odata-v4.json#/definitions/id"
+                },
+                "@odata.type": {
+                    "$ref": "http://redfish.dmtf.org/schemas/v1/odata-v4.json#/definitions/type"
+                },
+                "Actions": {
+                    "$ref": "#/definitions/Actions",
+                    "description": "The available actions for this resource.",
+                    "longDescription": "This property shall contain the available actions for this resource."
+                },
+                "Client": {
+                    "description": "The client to which this resource block is assigned.",
+                    "longDescription": "This property shall contain the client to which this resource block is assigned.",
+                    "readonly": false,
+                    "type": [
+                        "string",
+                        "null"
+                    ],
+                    "versionAdded": "v1_4_0"
+                },
+                "CompositionStatus": {
+                    "$ref": "#/definitions/CompositionStatus",
+                    "description": "The composition status details for this resource block.",
+                    "longDescription": "This property shall contain composition status information about this resource block."
+                },
+                "ComputerSystems": {
+                    "description": "An array of links to the computer systems available in this resource block.",
+                    "items": {
+                        "$ref": "http://redfish.dmtf.org/schemas/v1/ComputerSystem.json#/definitions/ComputerSystem"
+                    },
+                    "longDescription": "This property shall contain an array of links to resource of type ComputerSystem that this resource block contains.",
+                    "readonly": true,
+                    "type": "array"
+                },
+                "ComputerSystems@odata.count": {
+                    "$ref": "http://redfish.dmtf.org/schemas/v1/odata-v4.json#/definitions/count"
+                },
+                "Description": {
+                    "anyOf": [
+                        {
+                            "$ref": "http://redfish.dmtf.org/schemas/v1/Resource.json#/definitions/Description"
+                        },
+                        {
+                            "type": "null"
+                        }
+                    ],
+                    "readonly": true
+                },
+                "Drives": {
+                    "description": "An array of links to the drives available in this resource block.",
+                    "items": {
+                        "$ref": "http://redfish.dmtf.org/schemas/v1/Drive.json#/definitions/Drive"
+                    },
+                    "longDescription": "This property shall contain an array of links to resource of type Drive that this resource block contains.",
+                    "readonly": true,
+                    "type": "array",
+                    "versionAdded": "v1_3_0"
+                },
+                "Drives@odata.count": {
+                    "$ref": "http://redfish.dmtf.org/schemas/v1/odata-v4.json#/definitions/count"
+                },
+                "EthernetInterfaces": {
+                    "description": "An array of links to the Ethernet interfaces available in this resource block.",
+                    "items": {
+                        "$ref": "http://redfish.dmtf.org/schemas/v1/EthernetInterface.json#/definitions/EthernetInterface"
+                    },
+                    "longDescription": "This property shall contain an array of links to resource of type EthernetInterface that this resource block contains.",
+                    "readonly": true,
+                    "type": "array"
+                },
+                "EthernetInterfaces@odata.count": {
+                    "$ref": "http://redfish.dmtf.org/schemas/v1/odata-v4.json#/definitions/count"
+                },
+                "Id": {
+                    "$ref": "http://redfish.dmtf.org/schemas/v1/Resource.json#/definitions/Id",
+                    "readonly": true
+                },
+                "Links": {
+                    "$ref": "#/definitions/Links",
+                    "description": "The links to other resources that are related to this resource.",
+                    "longDescription": "This property shall contain links to resources that are related to but are not contained by, or subordinate to, this resource."
+                },
+                "Memory": {
+                    "description": "An array of links to the memory available in this resource block.",
+                    "items": {
+                        "$ref": "http://redfish.dmtf.org/schemas/v1/Memory.json#/definitions/Memory"
+                    },
+                    "longDescription": "This property shall contain an array of links to resource of type Memory that this resource block contains.",
+                    "readonly": true,
+                    "type": "array"
+                },
+                "Memory@odata.count": {
+                    "$ref": "http://redfish.dmtf.org/schemas/v1/odata-v4.json#/definitions/count"
+                },
+                "Name": {
+                    "$ref": "http://redfish.dmtf.org/schemas/v1/Resource.json#/definitions/Name",
+                    "readonly": true
+                },
+                "NetworkInterfaces": {
+                    "description": "An array of links to the Network Interfaces available in this resource block.",
+                    "items": {
+                        "$ref": "http://redfish.dmtf.org/schemas/v1/NetworkInterface.json#/definitions/NetworkInterface"
+                    },
+                    "longDescription": "This property shall contain an array of links to resource of type NetworkInterface that this resource block contains.",
+                    "readonly": true,
+                    "type": "array"
+                },
+                "NetworkInterfaces@odata.count": {
+                    "$ref": "http://redfish.dmtf.org/schemas/v1/odata-v4.json#/definitions/count"
+                },
+                "Oem": {
+                    "$ref": "http://redfish.dmtf.org/schemas/v1/Resource.json#/definitions/Oem",
+                    "description": "The OEM extension property.",
+                    "longDescription": "This property shall contain the OEM extensions.  All values for properties that this object contains shall conform to the Redfish Specification-described requirements."
+                },
+                "Pool": {
+                    "anyOf": [
+                        {
+                            "$ref": "#/definitions/PoolType"
+                        },
+                        {
+                            "type": "null"
+                        }
+                    ],
+                    "description": "The pool to which this resource block belongs.",
+                    "longDescription": "This property shall contain the pool to which this resource block belongs.  If this resource block is not assigned to a client, this property shall contain the value `Unassigned`.  If this resource block is assigned to a client, this property shall not contain the value `Unassigned`.",
+                    "readonly": false,
+                    "versionAdded": "v1_4_0"
+                },
+                "Processors": {
+                    "description": "An array of links to the processors available in this resource block.",
+                    "items": {
+                        "$ref": "http://redfish.dmtf.org/schemas/v1/Processor.json#/definitions/Processor"
+                    },
+                    "longDescription": "This property shall contain an array of links to resource of type Processor that this resource block contains.",
+                    "readonly": true,
+                    "type": "array"
+                },
+                "Processors@odata.count": {
+                    "$ref": "http://redfish.dmtf.org/schemas/v1/odata-v4.json#/definitions/count"
+                },
+                "ResourceBlockType": {
+                    "description": "The types of resources available on this resource block.",
+                    "items": {
+                        "$ref": "#/definitions/ResourceBlockType"
+                    },
+                    "longDescription": "This property shall contain an array of enumerated values that describe the type of resources available.",
+                    "readonly": true,
+                    "type": "array"
+                },
+                "SimpleStorage": {
+                    "description": "An array of links to the simple storage available in this resource block.",
+                    "items": {
+                        "$ref": "http://redfish.dmtf.org/schemas/v1/SimpleStorage.json#/definitions/SimpleStorage"
+                    },
+                    "longDescription": "This property shall contain an array of links to resource of type SimpleStorage that this resource block contains.",
+                    "readonly": true,
+                    "type": "array"
+                },
+                "SimpleStorage@odata.count": {
+                    "$ref": "http://redfish.dmtf.org/schemas/v1/odata-v4.json#/definitions/count"
+                },
+                "Status": {
+                    "$ref": "http://redfish.dmtf.org/schemas/v1/Resource.json#/definitions/Status",
+                    "description": "The status and health of the resource and its subordinate or dependent resources.",
+                    "longDescription": "This property shall contain any status or health properties of the resource."
+                },
+                "Storage": {
+                    "description": "An array of links to the storage available in this resource block.",
+                    "items": {
+                        "$ref": "http://redfish.dmtf.org/schemas/v1/Storage.json#/definitions/Storage"
+                    },
+                    "longDescription": "This property shall contain an array of links to resource of type Storage that this resource block contains.",
+                    "readonly": true,
+                    "type": "array"
+                },
+                "Storage@odata.count": {
+                    "$ref": "http://redfish.dmtf.org/schemas/v1/odata-v4.json#/definitions/count"
+                }
+            },
+            "required": [
+                "CompositionStatus",
+                "ResourceBlockType",
+                "@odata.id",
+                "@odata.type",
+                "Id",
+                "Name"
+            ],
+            "type": "object"
+        },
+        "ResourceBlockLimits": {
+            "additionalProperties": false,
+            "description": "This type specifies the allowable quantities of types of resource blocks for a composition request.",
+            "longDescription": "This object shall specify the allowable quantities of types of resource blocks for a given composition request.",
+            "patternProperties": {
+                "^([a-zA-Z_][a-zA-Z0-9_]*)?@(odata|Redfish|Message)\\.[a-zA-Z_][a-zA-Z0-9_]*$": {
+                    "description": "This property shall specify a valid odata or Redfish property.",
+                    "type": [
+                        "array",
+                        "boolean",
+                        "integer",
+                        "number",
+                        "null",
+                        "object",
+                        "string"
+                    ]
+                }
+            },
+            "properties": {
+                "MaxCompute": {
+                    "description": "The maximum number of resource blocks of type `Compute` allowed for the composition request.",
+                    "longDescription": "This property shall contain an integer that specifies the maximum number of resource blocks of type `Compute` allowed for the composition request.",
+                    "minimum": 1,
+                    "readonly": true,
+                    "type": [
+                        "integer",
+                        "null"
+                    ],
+                    "versionAdded": "v1_3_0"
+                },
+                "MaxComputerSystem": {
+                    "description": "The maximum number of resource blocks of type `ComputerSystem` allowed for the composition request.",
+                    "longDescription": "This property shall contain an integer that specifies the maximum number of resource blocks of type `ComputerSystem` allowed for the composition request.",
+                    "minimum": 1,
+                    "readonly": true,
+                    "type": [
+                        "integer",
+                        "null"
+                    ],
+                    "versionAdded": "v1_3_0"
+                },
+                "MaxExpansion": {
+                    "description": "The maximum number of resource blocks of type `Expansion` allowed for the composition request.",
+                    "longDescription": "This property shall contain an integer that specifies the maximum number of resource blocks of type `Expansion` allowed for the composition request.",
+                    "minimum": 1,
+                    "readonly": true,
+                    "type": [
+                        "integer",
+                        "null"
+                    ],
+                    "versionAdded": "v1_3_0"
+                },
+                "MaxMemory": {
+                    "description": "The maximum number of resource blocks of type `Memory` allowed for the composition request.",
+                    "longDescription": "This property shall contain an integer that specifies the maximum number of resource blocks of type `Memory` allowed for the composition request.",
+                    "minimum": 1,
+                    "readonly": true,
+                    "type": [
+                        "integer",
+                        "null"
+                    ],
+                    "versionAdded": "v1_3_0"
+                },
+                "MaxNetwork": {
+                    "description": "The maximum number of resource blocks of type `Network` allowed for the composition request.",
+                    "longDescription": "This property shall contain an integer that specifies the maximum number of resource blocks of type `Network` allowed for the composition request.",
+                    "minimum": 1,
+                    "readonly": true,
+                    "type": [
+                        "integer",
+                        "null"
+                    ],
+                    "versionAdded": "v1_3_0"
+                },
+                "MaxProcessor": {
+                    "description": "The maximum number of resource blocks of type `Processor` allowed for the composition request.",
+                    "longDescription": "This property shall contain an integer that specifies the maximum number of resource blocks of type `Processor` allowed for the composition request.",
+                    "minimum": 1,
+                    "readonly": true,
+                    "type": [
+                        "integer",
+                        "null"
+                    ],
+                    "versionAdded": "v1_3_0"
+                },
+                "MaxStorage": {
+                    "description": "The maximum number of resource blocks of type `Storage` allowed for the composition request.",
+                    "longDescription": "This property shall contain an integer that specifies the maximum number of resource blocks of type `Storage` allowed for the composition request.",
+                    "minimum": 1,
+                    "readonly": true,
+                    "type": [
+                        "integer",
+                        "null"
+                    ],
+                    "versionAdded": "v1_3_0"
+                },
+                "MinCompute": {
+                    "description": "The minimum number of resource blocks of type `Compute` required for the composition request.",
+                    "longDescription": "This property shall contain an integer that specifies the minimum number of resource blocks of type `Compute` required for the composition request.",
+                    "minimum": 0,
+                    "readonly": true,
+                    "type": [
+                        "integer",
+                        "null"
+                    ],
+                    "versionAdded": "v1_3_0"
+                },
+                "MinComputerSystem": {
+                    "description": "The minimum number of resource blocks of type `ComputerSystem` required for the composition request.",
+                    "longDescription": "This property shall contain an integer that specifies the minimum number of resource blocks of type `ComputerSystem` required for the composition request.",
+                    "minimum": 0,
+                    "readonly": true,
+                    "type": [
+                        "integer",
+                        "null"
+                    ],
+                    "versionAdded": "v1_3_0"
+                },
+                "MinExpansion": {
+                    "description": "The minimum number of resource blocks of type `Expansion` required for the composition request.",
+                    "longDescription": "This property shall contain an integer that specifies the minimum number of resource blocks of type `Expansion` required for the composition request.",
+                    "minimum": 0,
+                    "readonly": true,
+                    "type": [
+                        "integer",
+                        "null"
+                    ],
+                    "versionAdded": "v1_3_0"
+                },
+                "MinMemory": {
+                    "description": "The minimum number of resource blocks of type `Memory` required for the composition request.",
+                    "longDescription": "This property shall contain an integer that specifies the minimum number of resource blocks of type `Memory` required for the composition request.",
+                    "minimum": 0,
+                    "readonly": true,
+                    "type": [
+                        "integer",
+                        "null"
+                    ],
+                    "versionAdded": "v1_3_0"
+                },
+                "MinNetwork": {
+                    "description": "The minimum number of resource blocks of type `Network` required for the composition request.",
+                    "longDescription": "This property shall contain an integer that specifies the minimum number of resource blocks of type `Network` required for the composition request.",
+                    "minimum": 0,
+                    "readonly": true,
+                    "type": [
+                        "integer",
+                        "null"
+                    ],
+                    "versionAdded": "v1_3_0"
+                },
+                "MinProcessor": {
+                    "description": "The minimum number of resource blocks of type `Processor` required for the composition request.",
+                    "longDescription": "This property shall contain an integer that specifies the minimum number of resource blocks of type `Processor` required for the composition request.",
+                    "minimum": 0,
+                    "readonly": true,
+                    "type": [
+                        "integer",
+                        "null"
+                    ],
+                    "versionAdded": "v1_3_0"
+                },
+                "MinStorage": {
+                    "description": "The minimum number of resource blocks of type `Storage` required for the composition request.",
+                    "longDescription": "This property shall contain an integer that specifies the minimum number of resource blocks of type `Storage` required for the composition request.",
+                    "minimum": 0,
+                    "readonly": true,
+                    "type": [
+                        "integer",
+                        "null"
+                    ],
+                    "versionAdded": "v1_3_0"
+                }
+            },
+            "type": "object"
+        },
+        "ResourceBlockType": {
+            "enum": [
+                "Compute",
+                "Processor",
+                "Memory",
+                "Network",
+                "Storage",
+                "ComputerSystem",
+                "Expansion",
+                "IndependentResource"
+            ],
+            "enumDescriptions": {
+                "Compute": "This resource block contains resources of type `Processor` and `Memory` in a manner that creates a compute complex.",
+                "ComputerSystem": "This resource block contains resources of type `ComputerSystem`.",
+                "Expansion": "This resource block is capable of changing over time based on its configuration.  Different types of devices within this resource block can be added and removed over time.",
+                "IndependentResource": "This resource block is capable of being consumed as a standalone component.  This resource block can represent things such as a software platform on one or more computer systems or an appliance that provides composable resources and other services, and can be managed independently of the Redfish service.",
+                "Memory": "This resource block contains resources of type `Memory`.",
+                "Network": "This resource block contains network resources, such as resource of type `EthernetInterface` and `NetworkInterface`.",
+                "Processor": "This resource block contains resources of type `Processor`.",
+                "Storage": "This resource block contains storage resources, such as resources of type `Storage` and `SimpleStorage`."
+            },
+            "enumVersionAdded": {
+                "Expansion": "v1_2_0",
+                "IndependentResource": "v1_4_0"
+            },
+            "type": "string"
+        }
+    },
+    "owningEntity": "DMTF",
+    "release": "2020.4",
+    "title": "#ResourceBlock.v1_4_0.ResourceBlock"
+}

--- a/static/redfish/v1/JsonSchemas/ResourceBlock/index.json
+++ b/static/redfish/v1/JsonSchemas/ResourceBlock/index.json
@@ -1,0 +1,21 @@
+{
+    "@odata.context": "/redfish/v1/$metadata#JsonSchemaFile.JsonSchemaFile",
+    "@odata.id": "/redfish/v1/JsonSchemas/ResourceBlock",
+    "@odata.type": "#JsonSchemaFile.v1_0_2.JsonSchemaFile",
+    "Name": "ResourceBlock Schema File",
+    "Schema": "#ResourceBlock.ResourceBlock",
+    "Description": "ResourceBlock Schema File Location",
+    "Id": "ResourceBlock",
+    "Languages": [
+        "en"
+    ],
+    "Languages@odata.count": 1,
+    "Location": [
+        {
+            "Language": "en",
+            "PublicationUri": "http://redfish.dmtf.org/schemas/v1/ResourceBlock.json",
+            "Uri": "/redfish/v1/JsonSchemas/ResourceBlock/ResourceBlock.json"
+        }
+    ],
+    "Location@odata.count": 1
+}

--- a/static/redfish/v1/JsonSchemas/RouteEntry/RouteEntry.json
+++ b/static/redfish/v1/JsonSchemas/RouteEntry/RouteEntry.json
@@ -1,0 +1,147 @@
+{
+    "$id": "http://redfish.dmtf.org/schemas/v1/RouteEntry.v1_0_1.json",
+    "$ref": "#/definitions/RouteEntry",
+    "$schema": "http://redfish.dmtf.org/schemas/v1/redfish-schema-v1.json",
+    "copyright": "Copyright 2014-2020 DMTF. For the full DMTF copyright policy, see http://www.dmtf.org/about/policies/copyright",
+    "definitions": {
+        "Actions": {
+            "additionalProperties": false,
+            "description": "The available actions for this Resource.",
+            "longDescription": "This type shall contain the available actions for this Resource.",
+            "patternProperties": {
+                "^([a-zA-Z_][a-zA-Z0-9_]*)?@(odata|Redfish|Message)\\.[a-zA-Z_][a-zA-Z0-9_]*$": {
+                    "description": "This property shall specify a valid odata or Redfish property.",
+                    "type": [
+                        "array",
+                        "boolean",
+                        "integer",
+                        "number",
+                        "null",
+                        "object",
+                        "string"
+                    ]
+                }
+            },
+            "properties": {
+                "Oem": {
+                    "$ref": "#/definitions/OemActions",
+                    "description": "The available OEM-specific actions for this Resource.",
+                    "longDescription": "This property shall contain the available OEM-specific actions for this Resource."
+                }
+            },
+            "type": "object"
+        },
+        "OemActions": {
+            "additionalProperties": true,
+            "description": "The available OEM-specific actions for this Resource.",
+            "longDescription": "This type shall contain the available OEM-specific actions for this Resource.",
+            "patternProperties": {
+                "^([a-zA-Z_][a-zA-Z0-9_]*)?@(odata|Redfish|Message)\\.[a-zA-Z_][a-zA-Z0-9_]*$": {
+                    "description": "This property shall specify a valid odata or Redfish property.",
+                    "type": [
+                        "array",
+                        "boolean",
+                        "integer",
+                        "number",
+                        "null",
+                        "object",
+                        "string"
+                    ]
+                }
+            },
+            "properties": {},
+            "type": "object"
+        },
+        "RouteEntry": {
+            "additionalProperties": false,
+            "description": "The RouteEntry schema describes the content of route entry rows.  Each route entry contains route sets that list the possible routes for the route entry.",
+            "longDescription": "This Resource shall represent the content of route entry rows in the Redfish Specification.",
+            "patternProperties": {
+                "^([a-zA-Z_][a-zA-Z0-9_]*)?@(odata|Redfish|Message)\\.[a-zA-Z_][a-zA-Z0-9_]*$": {
+                    "description": "This property shall specify a valid odata or Redfish property.",
+                    "type": [
+                        "array",
+                        "boolean",
+                        "integer",
+                        "number",
+                        "null",
+                        "object",
+                        "string"
+                    ]
+                }
+            },
+            "properties": {
+                "@odata.context": {
+                    "$ref": "http://redfish.dmtf.org/schemas/v1/odata-v4.json#/definitions/context"
+                },
+                "@odata.etag": {
+                    "$ref": "http://redfish.dmtf.org/schemas/v1/odata-v4.json#/definitions/etag"
+                },
+                "@odata.id": {
+                    "$ref": "http://redfish.dmtf.org/schemas/v1/odata-v4.json#/definitions/id"
+                },
+                "@odata.type": {
+                    "$ref": "http://redfish.dmtf.org/schemas/v1/odata-v4.json#/definitions/type"
+                },
+                "Actions": {
+                    "$ref": "#/definitions/Actions",
+                    "description": "The available actions for this Resource.",
+                    "longDescription": "This property shall contain the available actions for this Resource."
+                },
+                "Description": {
+                    "anyOf": [
+                        {
+                            "$ref": "http://redfish.dmtf.org/schemas/v1/Resource.json#/definitions/Description"
+                        },
+                        {
+                            "type": "null"
+                        }
+                    ],
+                    "readonly": true
+                },
+                "Id": {
+                    "$ref": "http://redfish.dmtf.org/schemas/v1/Resource.json#/definitions/Id",
+                    "readonly": true
+                },
+                "MinimumHopCount": {
+                    "description": "The minimum number of hops.",
+                    "longDescription": "This property shall indicate the minimum hop count used to calculate the computed hop count.",
+                    "readonly": false,
+                    "type": "integer"
+                },
+                "Name": {
+                    "$ref": "http://redfish.dmtf.org/schemas/v1/Resource.json#/definitions/Name",
+                    "readonly": true
+                },
+                "Oem": {
+                    "$ref": "http://redfish.dmtf.org/schemas/v1/Resource.json#/definitions/Oem",
+                    "description": "The OEM extension property.",
+                    "longDescription": "This property shall contain the OEM extensions.  All values for properties that this object contains shall conform to the Redfish Specification-described requirements."
+                },
+                "RawEntryHex": {
+                    "description": "The raw data of route entry rows.",
+                    "longDescription": "This property shall contain a binary data that represents the content of route entry rows.",
+                    "pattern": "^0[xX](([a-fA-F]|[0-9]){2}){8}$",
+                    "readonly": false,
+                    "type": "string"
+                },
+                "RouteSet": {
+                    "$ref": "http://redfish.dmtf.org/schemas/v1/RouteSetEntryCollection.json#/definitions/RouteSetEntryCollection",
+                    "description": "The link to the collection of route set entries associated with this route.",
+                    "longDescription": "This property shall contain a link to a Resource Collection of type RouteSetEntryCollection.",
+                    "readonly": true
+                }
+            },
+            "required": [
+                "@odata.id",
+                "@odata.type",
+                "Id",
+                "Name"
+            ],
+            "type": "object"
+        }
+    },
+    "owningEntity": "DMTF",
+    "release": "2019.4",
+    "title": "#RouteEntry.v1_0_1.RouteEntry"
+}

--- a/static/redfish/v1/JsonSchemas/RouteEntry/index.json
+++ b/static/redfish/v1/JsonSchemas/RouteEntry/index.json
@@ -1,0 +1,21 @@
+{
+    "@odata.context": "/redfish/v1/$metadata#JsonSchemaFile.JsonSchemaFile",
+    "@odata.id": "/redfish/v1/JsonSchemas/RouteEntry",
+    "@odata.type": "#JsonSchemaFile.v1_0_2.JsonSchemaFile",
+    "Name": "RouteEntry Schema File",
+    "Schema": "#RouteEntry.RouteEntry",
+    "Description": "RouteEntry Schema File Location",
+    "Id": "RouteEntry",
+    "Languages": [
+        "en"
+    ],
+    "Languages@odata.count": 1,
+    "Location": [
+        {
+            "Language": "en",
+            "PublicationUri": "http://redfish.dmtf.org/schemas/v1/RouteEntry.json",
+            "Uri": "/redfish/v1/JsonSchemas/RouteEntry/RouteEntry.json"
+        }
+    ],
+    "Location@odata.count": 1
+}

--- a/static/redfish/v1/JsonSchemas/RouteSetEntry/RouteSetEntry.json
+++ b/static/redfish/v1/JsonSchemas/RouteSetEntry/RouteSetEntry.json
@@ -1,0 +1,152 @@
+{
+    "$id": "http://redfish.dmtf.org/schemas/v1/RouteSetEntry.v1_0_1.json",
+    "$ref": "#/definitions/RouteSetEntry",
+    "$schema": "http://redfish.dmtf.org/schemas/v1/redfish-schema-v1.json",
+    "copyright": "Copyright 2014-2020 DMTF. For the full DMTF copyright policy, see http://www.dmtf.org/about/policies/copyright",
+    "definitions": {
+        "Actions": {
+            "additionalProperties": false,
+            "description": "The available actions for this Resource.",
+            "longDescription": "This type shall contain the available actions for this Resource.",
+            "patternProperties": {
+                "^([a-zA-Z_][a-zA-Z0-9_]*)?@(odata|Redfish|Message)\\.[a-zA-Z_][a-zA-Z0-9_]*$": {
+                    "description": "This property shall specify a valid odata or Redfish property.",
+                    "type": [
+                        "array",
+                        "boolean",
+                        "integer",
+                        "number",
+                        "null",
+                        "object",
+                        "string"
+                    ]
+                }
+            },
+            "properties": {
+                "Oem": {
+                    "$ref": "#/definitions/OemActions",
+                    "description": "The available OEM-specific actions for this Resource.",
+                    "longDescription": "This property shall contain the available OEM-specific actions for this Resource."
+                }
+            },
+            "type": "object"
+        },
+        "OemActions": {
+            "additionalProperties": true,
+            "description": "The available OEM-specific actions for this Resource.",
+            "longDescription": "This type shall contain the available OEM-specific actions for this Resource.",
+            "patternProperties": {
+                "^([a-zA-Z_][a-zA-Z0-9_]*)?@(odata|Redfish|Message)\\.[a-zA-Z_][a-zA-Z0-9_]*$": {
+                    "description": "This property shall specify a valid odata or Redfish property.",
+                    "type": [
+                        "array",
+                        "boolean",
+                        "integer",
+                        "number",
+                        "null",
+                        "object",
+                        "string"
+                    ]
+                }
+            },
+            "properties": {},
+            "type": "object"
+        },
+        "RouteSetEntry": {
+            "additionalProperties": false,
+            "description": "The RouteSetEntry schema contains the information about a route.  It is part of a larger set that contains possible routes for a particular route entry.",
+            "longDescription": "This Resource contains the content of a route set in the Redfish Specification.",
+            "patternProperties": {
+                "^([a-zA-Z_][a-zA-Z0-9_]*)?@(odata|Redfish|Message)\\.[a-zA-Z_][a-zA-Z0-9_]*$": {
+                    "description": "This property shall specify a valid odata or Redfish property.",
+                    "type": [
+                        "array",
+                        "boolean",
+                        "integer",
+                        "number",
+                        "null",
+                        "object",
+                        "string"
+                    ]
+                }
+            },
+            "properties": {
+                "@odata.context": {
+                    "$ref": "http://redfish.dmtf.org/schemas/v1/odata-v4.json#/definitions/context"
+                },
+                "@odata.etag": {
+                    "$ref": "http://redfish.dmtf.org/schemas/v1/odata-v4.json#/definitions/etag"
+                },
+                "@odata.id": {
+                    "$ref": "http://redfish.dmtf.org/schemas/v1/odata-v4.json#/definitions/id"
+                },
+                "@odata.type": {
+                    "$ref": "http://redfish.dmtf.org/schemas/v1/odata-v4.json#/definitions/type"
+                },
+                "Actions": {
+                    "$ref": "#/definitions/Actions",
+                    "description": "The available actions for this Resource.",
+                    "longDescription": "This property shall contain the available actions for this Resource."
+                },
+                "Description": {
+                    "anyOf": [
+                        {
+                            "$ref": "http://redfish.dmtf.org/schemas/v1/Resource.json#/definitions/Description"
+                        },
+                        {
+                            "type": "null"
+                        }
+                    ],
+                    "readonly": true
+                },
+                "EgressIdentifier": {
+                    "description": "The egress interface identifier.",
+                    "longDescription": "This property shall contain the interface identifier corresponding to this route.",
+                    "readonly": false,
+                    "type": "integer"
+                },
+                "HopCount": {
+                    "description": "The number of hops.",
+                    "longDescription": "This property shall contain the number of hops to the destination component from the indicated egress interface.",
+                    "readonly": false,
+                    "type": "integer"
+                },
+                "Id": {
+                    "$ref": "http://redfish.dmtf.org/schemas/v1/Resource.json#/definitions/Id",
+                    "readonly": true
+                },
+                "Name": {
+                    "$ref": "http://redfish.dmtf.org/schemas/v1/Resource.json#/definitions/Name",
+                    "readonly": true
+                },
+                "Oem": {
+                    "$ref": "http://redfish.dmtf.org/schemas/v1/Resource.json#/definitions/Oem",
+                    "description": "The OEM extension property.",
+                    "longDescription": "This property shall contain the OEM extensions.  All values for properties that this object contains shall conform to the Redfish Specification-described requirements."
+                },
+                "VCAction": {
+                    "description": "The Virtual Channel Action index.",
+                    "longDescription": "This property shall contain the index to the VCAT entry corresponding to this route.",
+                    "readonly": false,
+                    "type": "integer"
+                },
+                "Valid": {
+                    "description": "An indication of whether the entry is valid.",
+                    "longDescription": "This property shall indicate whether the entry is valid.",
+                    "readonly": false,
+                    "type": "boolean"
+                }
+            },
+            "required": [
+                "@odata.id",
+                "@odata.type",
+                "Id",
+                "Name"
+            ],
+            "type": "object"
+        }
+    },
+    "owningEntity": "DMTF",
+    "release": "2019.4",
+    "title": "#RouteSetEntry.v1_0_1.RouteSetEntry"
+}

--- a/static/redfish/v1/JsonSchemas/RouteSetEntry/index.json
+++ b/static/redfish/v1/JsonSchemas/RouteSetEntry/index.json
@@ -1,0 +1,21 @@
+{
+    "@odata.context": "/redfish/v1/$metadata#JsonSchemaFile.JsonSchemaFile",
+    "@odata.id": "/redfish/v1/JsonSchemas/RouteSetEntry",
+    "@odata.type": "#JsonSchemaFile.v1_0_2.JsonSchemaFile",
+    "Name": "RouteSetEntry Schema File",
+    "Schema": "#RouteSetEntry.RouteSetEntry",
+    "Description": "RouteSetEntry Schema File Location",
+    "Id": "RouteSetEntry",
+    "Languages": [
+        "en"
+    ],
+    "Languages@odata.count": 1,
+    "Location": [
+        {
+            "Language": "en",
+            "PublicationUri": "http://redfish.dmtf.org/schemas/v1/RouteSetEntry.json",
+            "Uri": "/redfish/v1/JsonSchemas/RouteSetEntry/RouteSetEntry.json"
+        }
+    ],
+    "Location@odata.count": 1
+}

--- a/static/redfish/v1/JsonSchemas/Schedule/Schedule.json
+++ b/static/redfish/v1/JsonSchemas/Schedule/Schedule.json
@@ -1,0 +1,205 @@
+{
+    "$id": "http://redfish.dmtf.org/schemas/v1/Schedule.v1_2_2.json",
+    "$schema": "http://redfish.dmtf.org/schemas/v1/redfish-schema-v1.json",
+    "copyright": "Copyright 2014-2020 DMTF. For the full DMTF copyright policy, see http://www.dmtf.org/about/policies/copyright",
+    "definitions": {
+        "DayOfWeek": {
+            "description": "Days of the week.",
+            "enum": [
+                "Monday",
+                "Tuesday",
+                "Wednesday",
+                "Thursday",
+                "Friday",
+                "Saturday",
+                "Sunday",
+                "Every"
+            ],
+            "enumDescriptions": {
+                "Every": "Every day of the week.",
+                "Friday": "Friday.",
+                "Monday": "Monday.",
+                "Saturday": "Saturday.",
+                "Sunday": "Sunday.",
+                "Thursday": "Thursday.",
+                "Tuesday": "Tuesday.",
+                "Wednesday": "Wednesday."
+            },
+            "enumLongDescriptions": {
+                "Every": "This value indicates that every day of the week has been selected.  When used in array properties, such as for enabling a function on certain days, it shall be the only member in the array."
+            },
+            "longDescription": "Days of the week.",
+            "type": "string"
+        },
+        "MonthOfYear": {
+            "description": "Months of the year.",
+            "enum": [
+                "January",
+                "February",
+                "March",
+                "April",
+                "May",
+                "June",
+                "July",
+                "August",
+                "September",
+                "October",
+                "November",
+                "December",
+                "Every"
+            ],
+            "enumDescriptions": {
+                "April": "April.",
+                "August": "August.",
+                "December": "December.",
+                "Every": "Every month of the year.",
+                "February": "February.",
+                "January": "January.",
+                "July": "July.",
+                "June": "June.",
+                "March": "March.",
+                "May": "May.",
+                "November": "November.",
+                "October": "October.",
+                "September": "September."
+            },
+            "enumLongDescriptions": {
+                "Every": "This value indicates that every month of the year has been selected.  When used in array properties, such as for enabling a function for certain months, it shall be the only member in the array."
+            },
+            "longDescription": "Months of the year.",
+            "type": "string"
+        },
+        "Schedule": {
+            "additionalProperties": false,
+            "description": "Schedule a series of occurrences.",
+            "longDescription": "The properties of this type shall schedule a series of occurrences.",
+            "patternProperties": {
+                "^([a-zA-Z_][a-zA-Z0-9_]*)?@(odata|Redfish|Message)\\.[a-zA-Z_][a-zA-Z0-9_]*$": {
+                    "description": "This property shall specify a valid odata or Redfish property.",
+                    "type": [
+                        "array",
+                        "boolean",
+                        "integer",
+                        "number",
+                        "null",
+                        "object",
+                        "string"
+                    ]
+                }
+            },
+            "properties": {
+                "EnabledDaysOfMonth": {
+                    "description": "Days of the month when scheduled occurrences are enabled.  `0` indicates that every day of the month is enabled.",
+                    "items": {
+                        "type": [
+                            "integer",
+                            "null"
+                        ]
+                    },
+                    "longDescription": "This property shall contain the days of the month when scheduled occurrences are enabled, for enabled days of week and months of year.  If the array contains a single value of `0`, or if the property is not present, all days of the month shall be enabled.",
+                    "maximum": 31,
+                    "minimum": 0,
+                    "readonly": false,
+                    "type": "array"
+                },
+                "EnabledDaysOfWeek": {
+                    "description": "Days of the week when scheduled occurrences are enabled, for enabled days of the month and months of the year.  If not present, all days of the week are enabled.",
+                    "items": {
+                        "anyOf": [
+                            {
+                                "$ref": "#/definitions/DayOfWeek"
+                            },
+                            {
+                                "type": "null"
+                            }
+                        ]
+                    },
+                    "longDescription": "Days of the week when scheduled occurrences are enabled.  If not present, all days of the week shall be enabled.",
+                    "readonly": false,
+                    "type": "array"
+                },
+                "EnabledIntervals": {
+                    "description": "Intervals when scheduled occurrences are enabled.",
+                    "items": {
+                        "type": [
+                            "string",
+                            "null"
+                        ]
+                    },
+                    "longDescription": "Each value shall be an ISO 8601 conformant interval specifying when occurrences are enabled.",
+                    "readonly": false,
+                    "type": "array",
+                    "versionAdded": "v1_1_0"
+                },
+                "EnabledMonthsOfYear": {
+                    "description": "The months of the year when scheduled occurrences are enabled.  If not present, all months of the year are enabled.",
+                    "items": {
+                        "anyOf": [
+                            {
+                                "$ref": "#/definitions/MonthOfYear"
+                            },
+                            {
+                                "type": "null"
+                            }
+                        ]
+                    },
+                    "longDescription": "This property shall contain the months of the year when scheduled occurrences are enabled, for enabled days of week and days of month.  If not present, all months of the year shall be enabled.",
+                    "readonly": false,
+                    "type": "array"
+                },
+                "InitialStartTime": {
+                    "description": "The date and time when the initial occurrence is scheduled to occur.",
+                    "format": "date-time",
+                    "longDescription": "This property shall contain the date and time when the initial occurrence is scheduled to occur.",
+                    "readonly": false,
+                    "type": [
+                        "string",
+                        "null"
+                    ]
+                },
+                "Lifetime": {
+                    "description": "The time after provisioning when the schedule as a whole expires.",
+                    "longDescription": "This property shall contain a Redfish Duration that describes the time after provisioning when the schedule expires.",
+                    "pattern": "-?P(\\d+D)?(T(\\d+H)?(\\d+M)?(\\d+(.\\d+)?S)?)?",
+                    "readonly": false,
+                    "type": [
+                        "string",
+                        "null"
+                    ]
+                },
+                "MaxOccurrences": {
+                    "description": "The maximum number of scheduled occurrences.",
+                    "longDescription": "This property shall contain the maximum number of scheduled occurrences.",
+                    "readonly": false,
+                    "type": [
+                        "integer",
+                        "null"
+                    ]
+                },
+                "Name": {
+                    "description": "The schedule name.",
+                    "longDescription": "The name of the schedule, which is constructed as OrgID:ScheduleName.  Examples include ACME:Daily, ACME:Weekly, and ACME:FirstTuesday.",
+                    "readonly": false,
+                    "type": [
+                        "string",
+                        "null"
+                    ]
+                },
+                "RecurrenceInterval": {
+                    "description": "The amount of time until the next occurrence occurs.",
+                    "longDescription": "This property shall contain a Redfish Duration that describes the time until the next occurrence.",
+                    "pattern": "-?P(\\d+D)?(T(\\d+H)?(\\d+M)?(\\d+(.\\d+)?S)?)?",
+                    "readonly": false,
+                    "type": [
+                        "string",
+                        "null"
+                    ]
+                }
+            },
+            "type": "object"
+        }
+    },
+    "owningEntity": "DMTF",
+    "release": "2018.2",
+    "title": "#Schedule.v1_2_2"
+}

--- a/static/redfish/v1/JsonSchemas/Schedule/index.json
+++ b/static/redfish/v1/JsonSchemas/Schedule/index.json
@@ -1,0 +1,21 @@
+{
+    "@odata.context": "/redfish/v1/$metadata#JsonSchemaFile.JsonSchemaFile",
+    "@odata.id": "/redfish/v1/JsonSchemas/Schedule",
+    "@odata.type": "#JsonSchemaFile.v1_0_2.JsonSchemaFile",
+    "Name": "Schedule Schema File",
+    "Schema": "#Schedule.Schedule",
+    "Description": "Schedule Schema File Location",
+    "Id": "Schedule",
+    "Languages": [
+        "en"
+    ],
+    "Languages@odata.count": 1,
+    "Location": [
+        {
+            "Language": "en",
+            "PublicationUri": "http://redfish.dmtf.org/schemas/v1/Schedule.json",
+            "Uri": "/redfish/v1/JsonSchemas/Schedule/Schedule.json"
+        }
+    ],
+    "Location@odata.count": 1
+}

--- a/static/redfish/v1/JsonSchemas/SecureBoot/SecureBoot.json
+++ b/static/redfish/v1/JsonSchemas/SecureBoot/SecureBoot.json
@@ -1,0 +1,251 @@
+{
+    "$id": "http://redfish.dmtf.org/schemas/v1/SecureBoot.v1_1_0.json",
+    "$ref": "#/definitions/SecureBoot",
+    "$schema": "http://redfish.dmtf.org/schemas/v1/redfish-schema-v1.json",
+    "copyright": "Copyright 2014-2020 DMTF. For the full DMTF copyright policy, see http://www.dmtf.org/about/policies/copyright",
+    "definitions": {
+        "Actions": {
+            "additionalProperties": false,
+            "description": "The available actions for this resource.",
+            "longDescription": "This type shall contain the available actions for this resource.",
+            "patternProperties": {
+                "^([a-zA-Z_][a-zA-Z0-9_]*)?@(odata|Redfish|Message)\\.[a-zA-Z_][a-zA-Z0-9_]*$": {
+                    "description": "This property shall specify a valid odata or Redfish property.",
+                    "type": [
+                        "array",
+                        "boolean",
+                        "integer",
+                        "number",
+                        "null",
+                        "object",
+                        "string"
+                    ]
+                }
+            },
+            "properties": {
+                "#SecureBoot.ResetKeys": {
+                    "$ref": "#/definitions/ResetKeys"
+                },
+                "Oem": {
+                    "$ref": "#/definitions/OemActions",
+                    "description": "The available OEM-specific actions for this resource.",
+                    "longDescription": "This property shall contain the available OEM-specific actions for this resource."
+                }
+            },
+            "type": "object"
+        },
+        "OemActions": {
+            "additionalProperties": true,
+            "description": "The available OEM-specific actions for this resource.",
+            "longDescription": "This type shall contain the available OEM-specific actions for this resource.",
+            "patternProperties": {
+                "^([a-zA-Z_][a-zA-Z0-9_]*)?@(odata|Redfish|Message)\\.[a-zA-Z_][a-zA-Z0-9_]*$": {
+                    "description": "This property shall specify a valid odata or Redfish property.",
+                    "type": [
+                        "array",
+                        "boolean",
+                        "integer",
+                        "number",
+                        "null",
+                        "object",
+                        "string"
+                    ]
+                }
+            },
+            "properties": {},
+            "type": "object"
+        },
+        "ResetKeys": {
+            "additionalProperties": false,
+            "description": "This action resets the UEFI Secure Boot keys.",
+            "longDescription": "This action shall reset the UEFI Secure Boot key databases.  The `ResetAllKeysToDefault` value shall reset all UEFI Secure Boot key databases to their default values.  The `DeleteAllKeys` value shall delete the content of all UEFI Secure Boot key databases.  The `DeletePK` value shall delete the content of the PK Secure Boot key database.",
+            "parameters": {
+                "ResetKeysType": {
+                    "$ref": "#/definitions/ResetKeysType",
+                    "description": "The type of reset or delete to perform on the UEFI Secure Boot databases.",
+                    "longDescription": "This parameter shall specify the type of reset or delete to perform on the UEFI Secure Boot databases.",
+                    "requiredParameter": true
+                }
+            },
+            "patternProperties": {
+                "^([a-zA-Z_][a-zA-Z0-9_]*)?@(odata|Redfish|Message)\\.[a-zA-Z_][a-zA-Z0-9_]*$": {
+                    "description": "This property shall specify a valid odata or Redfish property.",
+                    "type": [
+                        "array",
+                        "boolean",
+                        "integer",
+                        "number",
+                        "null",
+                        "object",
+                        "string"
+                    ]
+                }
+            },
+            "properties": {
+                "target": {
+                    "description": "Link to invoke action",
+                    "format": "uri-reference",
+                    "type": "string"
+                },
+                "title": {
+                    "description": "Friendly action name",
+                    "type": "string"
+                }
+            },
+            "type": "object"
+        },
+        "ResetKeysType": {
+            "enum": [
+                "ResetAllKeysToDefault",
+                "DeleteAllKeys",
+                "DeletePK"
+            ],
+            "enumDescriptions": {
+                "DeleteAllKeys": "Delete the contents of all UEFI Secure Boot key databases, including the PK key database.  This puts the system in Setup Mode.",
+                "DeletePK": "Delete the contents of the PK UEFI Secure Boot database.  This puts the system in Setup Mode.",
+                "ResetAllKeysToDefault": "Reset the contents of all UEFI Secure Boot key databases, including the PK key database, to the default values."
+            },
+            "type": "string"
+        },
+        "SecureBoot": {
+            "additionalProperties": false,
+            "description": "The SecureBoot schema contains UEFI Secure Boot information and represents properties for managing the UEFI Secure Boot functionality of a system.",
+            "longDescription": "This resource contains UEFI Secure Boot information for a Redfish implementation.",
+            "patternProperties": {
+                "^([a-zA-Z_][a-zA-Z0-9_]*)?@(odata|Redfish|Message)\\.[a-zA-Z_][a-zA-Z0-9_]*$": {
+                    "description": "This property shall specify a valid odata or Redfish property.",
+                    "type": [
+                        "array",
+                        "boolean",
+                        "integer",
+                        "number",
+                        "null",
+                        "object",
+                        "string"
+                    ]
+                }
+            },
+            "properties": {
+                "@odata.context": {
+                    "$ref": "http://redfish.dmtf.org/schemas/v1/odata-v4.json#/definitions/context"
+                },
+                "@odata.etag": {
+                    "$ref": "http://redfish.dmtf.org/schemas/v1/odata-v4.json#/definitions/etag"
+                },
+                "@odata.id": {
+                    "$ref": "http://redfish.dmtf.org/schemas/v1/odata-v4.json#/definitions/id"
+                },
+                "@odata.type": {
+                    "$ref": "http://redfish.dmtf.org/schemas/v1/odata-v4.json#/definitions/type"
+                },
+                "Actions": {
+                    "$ref": "#/definitions/Actions",
+                    "description": "The available actions for this resource.",
+                    "longDescription": "This property shall contain the available actions for this resource."
+                },
+                "Description": {
+                    "anyOf": [
+                        {
+                            "$ref": "http://redfish.dmtf.org/schemas/v1/Resource.json#/definitions/Description"
+                        },
+                        {
+                            "type": "null"
+                        }
+                    ],
+                    "readonly": true
+                },
+                "Id": {
+                    "$ref": "http://redfish.dmtf.org/schemas/v1/Resource.json#/definitions/Id",
+                    "readonly": true
+                },
+                "Name": {
+                    "$ref": "http://redfish.dmtf.org/schemas/v1/Resource.json#/definitions/Name",
+                    "readonly": true
+                },
+                "Oem": {
+                    "$ref": "http://redfish.dmtf.org/schemas/v1/Resource.json#/definitions/Oem",
+                    "description": "The OEM extension property.",
+                    "longDescription": "This property shall contain the OEM extensions.  All values for properties that this object contains shall conform to the Redfish Specification-described requirements."
+                },
+                "SecureBootCurrentBoot": {
+                    "anyOf": [
+                        {
+                            "$ref": "#/definitions/SecureBootCurrentBootType"
+                        },
+                        {
+                            "type": "null"
+                        }
+                    ],
+                    "description": "The UEFI Secure Boot state during the current boot cycle.",
+                    "longDescription": "This property shall indicate the UEFI Secure Boot state during the current boot cycle.",
+                    "readonly": true
+                },
+                "SecureBootDatabases": {
+                    "$ref": "http://redfish.dmtf.org/schemas/v1/SecureBootDatabaseCollection.json#/definitions/SecureBootDatabaseCollection",
+                    "description": "A link to the collection of UEFI Secure Boot databases.",
+                    "longDescription": "The value of this property shall be a link to a resource collection of type SecureBootDatabaseCollection.",
+                    "readonly": true,
+                    "versionAdded": "v1_1_0"
+                },
+                "SecureBootEnable": {
+                    "description": "An indication of whether UEFI Secure Boot is enabled.",
+                    "longDescription": "This property shall indicate whether the UEFI Secure Boot takes effect on next boot.  This property can be enabled in UEFI boot mode only.",
+                    "readonly": false,
+                    "type": [
+                        "boolean",
+                        "null"
+                    ]
+                },
+                "SecureBootMode": {
+                    "anyOf": [
+                        {
+                            "$ref": "#/definitions/SecureBootModeType"
+                        },
+                        {
+                            "type": "null"
+                        }
+                    ],
+                    "description": "The current UEFI Secure Boot Mode.",
+                    "longDescription": "This property shall contain the current UEFI Secure Boot mode, as defined in the UEFI Specification.",
+                    "readonly": true
+                }
+            },
+            "required": [
+                "@odata.id",
+                "@odata.type",
+                "Id",
+                "Name"
+            ],
+            "type": "object"
+        },
+        "SecureBootCurrentBootType": {
+            "enum": [
+                "Enabled",
+                "Disabled"
+            ],
+            "enumDescriptions": {
+                "Disabled": "UEFI Secure Boot is currently disabled.",
+                "Enabled": "UEFI Secure Boot is currently enabled."
+            },
+            "type": "string"
+        },
+        "SecureBootModeType": {
+            "enum": [
+                "SetupMode",
+                "UserMode",
+                "AuditMode",
+                "DeployedMode"
+            ],
+            "enumDescriptions": {
+                "AuditMode": "UEFI Secure Boot is currently in Audit Mode.",
+                "DeployedMode": "UEFI Secure Boot is currently in Deployed Mode.",
+                "SetupMode": "UEFI Secure Boot is currently in Setup Mode.",
+                "UserMode": "UEFI Secure Boot is currently in User Mode."
+            },
+            "type": "string"
+        }
+    },
+    "owningEntity": "DMTF",
+    "release": "2020.1",
+    "title": "#SecureBoot.v1_1_0.SecureBoot"
+}

--- a/static/redfish/v1/JsonSchemas/SecureBoot/index.json
+++ b/static/redfish/v1/JsonSchemas/SecureBoot/index.json
@@ -1,0 +1,21 @@
+{
+    "@odata.context": "/redfish/v1/$metadata#JsonSchemaFile.JsonSchemaFile",
+    "@odata.id": "/redfish/v1/JsonSchemas/SecureBoot",
+    "@odata.type": "#JsonSchemaFile.v1_0_2.JsonSchemaFile",
+    "Name": "SecureBoot Schema File",
+    "Schema": "#SecureBoot.SecureBoot",
+    "Description": "SecureBoot Schema File Location",
+    "Id": "SecureBoot",
+    "Languages": [
+        "en"
+    ],
+    "Languages@odata.count": 1,
+    "Location": [
+        {
+            "Language": "en",
+            "PublicationUri": "http://redfish.dmtf.org/schemas/v1/SecureBoot.json",
+            "Uri": "/redfish/v1/JsonSchemas/SecureBoot/SecureBoot.json"
+        }
+    ],
+    "Location@odata.count": 1
+}

--- a/static/redfish/v1/JsonSchemas/SecureBootDatabase/SecureBootDatabase.json
+++ b/static/redfish/v1/JsonSchemas/SecureBootDatabase/SecureBootDatabase.json
@@ -1,0 +1,199 @@
+{
+    "$id": "http://redfish.dmtf.org/schemas/v1/SecureBootDatabase.v1_0_1.json",
+    "$ref": "#/definitions/SecureBootDatabase",
+    "$schema": "http://redfish.dmtf.org/schemas/v1/redfish-schema-v1.json",
+    "copyright": "Copyright 2014-2021 DMTF. For the full DMTF copyright policy, see http://www.dmtf.org/about/policies/copyright",
+    "definitions": {
+        "Actions": {
+            "additionalProperties": false,
+            "description": "The available actions for this resource.",
+            "longDescription": "This type shall contain the available actions for this resource.",
+            "patternProperties": {
+                "^([a-zA-Z_][a-zA-Z0-9_]*)?@(odata|Redfish|Message)\\.[a-zA-Z_][a-zA-Z0-9_]*$": {
+                    "description": "This property shall specify a valid odata or Redfish property.",
+                    "type": [
+                        "array",
+                        "boolean",
+                        "integer",
+                        "number",
+                        "null",
+                        "object",
+                        "string"
+                    ]
+                }
+            },
+            "properties": {
+                "#SecureBootDatabase.ResetKeys": {
+                    "$ref": "#/definitions/ResetKeys"
+                },
+                "Oem": {
+                    "$ref": "#/definitions/OemActions",
+                    "description": "The available OEM-specific actions for this resource.",
+                    "longDescription": "This property shall contain the available OEM-specific actions for this resource."
+                }
+            },
+            "type": "object"
+        },
+        "OemActions": {
+            "additionalProperties": true,
+            "description": "The available OEM-specific actions for this resource.",
+            "longDescription": "This type shall contain the available OEM-specific actions for this resource.",
+            "patternProperties": {
+                "^([a-zA-Z_][a-zA-Z0-9_]*)?@(odata|Redfish|Message)\\.[a-zA-Z_][a-zA-Z0-9_]*$": {
+                    "description": "This property shall specify a valid odata or Redfish property.",
+                    "type": [
+                        "array",
+                        "boolean",
+                        "integer",
+                        "number",
+                        "null",
+                        "object",
+                        "string"
+                    ]
+                }
+            },
+            "properties": {},
+            "type": "object"
+        },
+        "ResetKeys": {
+            "additionalProperties": false,
+            "description": "This action is used to reset the UEFI Secure Boot keys of this database.",
+            "longDescription": "This action shall perform a reset of this UEFI Secure Boot key database.  The `ResetAllKeysToDefault` value shall reset this UEFI Secure Boot key database to the default values.  The `DeleteAllKeys` value shall delete the content of this UEFI Secure Boot key database.",
+            "parameters": {
+                "ResetKeysType": {
+                    "$ref": "#/definitions/ResetKeysType",
+                    "description": "The type of reset or delete to perform on this UEFI Secure Boot database.",
+                    "longDescription": "This parameter shall specify the type of reset or delete to perform on this UEFI Secure Boot database.",
+                    "requiredParameter": true
+                }
+            },
+            "patternProperties": {
+                "^([a-zA-Z_][a-zA-Z0-9_]*)?@(odata|Redfish|Message)\\.[a-zA-Z_][a-zA-Z0-9_]*$": {
+                    "description": "This property shall specify a valid odata or Redfish property.",
+                    "type": [
+                        "array",
+                        "boolean",
+                        "integer",
+                        "number",
+                        "null",
+                        "object",
+                        "string"
+                    ]
+                }
+            },
+            "properties": {
+                "target": {
+                    "description": "Link to invoke action",
+                    "format": "uri-reference",
+                    "type": "string"
+                },
+                "title": {
+                    "description": "Friendly action name",
+                    "type": "string"
+                }
+            },
+            "type": "object"
+        },
+        "ResetKeysType": {
+            "enum": [
+                "ResetAllKeysToDefault",
+                "DeleteAllKeys"
+            ],
+            "enumDescriptions": {
+                "DeleteAllKeys": "Delete the content of this UEFI Secure Boot key database.",
+                "ResetAllKeysToDefault": "Reset the content of this UEFI Secure Boot key database to the default values."
+            },
+            "type": "string"
+        },
+        "SecureBootDatabase": {
+            "additionalProperties": false,
+            "description": "The SecureBootDatabase schema describes a UEFI Secure Boot database used to store certificates or hashes.",
+            "longDescription": "This resource shall be used to represent a UEFI Secure Boot database for a Redfish implementation.",
+            "patternProperties": {
+                "^([a-zA-Z_][a-zA-Z0-9_]*)?@(odata|Redfish|Message)\\.[a-zA-Z_][a-zA-Z0-9_]*$": {
+                    "description": "This property shall specify a valid odata or Redfish property.",
+                    "type": [
+                        "array",
+                        "boolean",
+                        "integer",
+                        "number",
+                        "null",
+                        "object",
+                        "string"
+                    ]
+                }
+            },
+            "properties": {
+                "@odata.context": {
+                    "$ref": "http://redfish.dmtf.org/schemas/v1/odata-v4.json#/definitions/context"
+                },
+                "@odata.etag": {
+                    "$ref": "http://redfish.dmtf.org/schemas/v1/odata-v4.json#/definitions/etag"
+                },
+                "@odata.id": {
+                    "$ref": "http://redfish.dmtf.org/schemas/v1/odata-v4.json#/definitions/id"
+                },
+                "@odata.type": {
+                    "$ref": "http://redfish.dmtf.org/schemas/v1/odata-v4.json#/definitions/type"
+                },
+                "Actions": {
+                    "$ref": "#/definitions/Actions",
+                    "description": "The available actions for this resource.",
+                    "longDescription": "This property shall contain the available actions for this resource."
+                },
+                "Certificates": {
+                    "$ref": "http://redfish.dmtf.org/schemas/v1/CertificateCollection.json#/definitions/CertificateCollection",
+                    "description": "A link to the collection of certificates contained in this UEFI Secure Boot database.",
+                    "longDescription": "The value of this property shall be a link to a resource collection of type CertificateCollection.",
+                    "readonly": true
+                },
+                "DatabaseId": {
+                    "description": "This property contains the name of the UEFI Secure Boot database.",
+                    "longDescription": "This property shall contain the name of the UEFI Secure Boot database.  This property shall contain the same value as the Id property.  The value shall be one of the UEFI-defined Secure Boot databases: `PK`, `KEK` `db`, `dbx`, `dbr`, `dbt`, `PKDefault`, `KEKDefault`, `dbDefault`, `dbxDefault`, `dbrDefault`, or `dbtDefault`.",
+                    "readonly": true,
+                    "type": "string"
+                },
+                "Description": {
+                    "anyOf": [
+                        {
+                            "$ref": "http://redfish.dmtf.org/schemas/v1/Resource.json#/definitions/Description"
+                        },
+                        {
+                            "type": "null"
+                        }
+                    ],
+                    "readonly": true
+                },
+                "Id": {
+                    "$ref": "http://redfish.dmtf.org/schemas/v1/Resource.json#/definitions/Id",
+                    "readonly": true
+                },
+                "Name": {
+                    "$ref": "http://redfish.dmtf.org/schemas/v1/Resource.json#/definitions/Name",
+                    "readonly": true
+                },
+                "Oem": {
+                    "$ref": "http://redfish.dmtf.org/schemas/v1/Resource.json#/definitions/Oem",
+                    "description": "The OEM extension property.",
+                    "longDescription": "This property shall contain the OEM extensions.  All values for properties that this object contains shall conform to the Redfish Specification-described requirements."
+                },
+                "Signatures": {
+                    "$ref": "http://redfish.dmtf.org/schemas/v1/SignatureCollection.json#/definitions/SignatureCollection",
+                    "description": "A link to the collection of signatures contained in this UEFI Secure Boot database.",
+                    "longDescription": "The value of this property shall be a link to a resource collection of type SignatureCollection.",
+                    "readonly": true
+                }
+            },
+            "required": [
+                "@odata.id",
+                "@odata.type",
+                "Id",
+                "Name"
+            ],
+            "type": "object"
+        }
+    },
+    "owningEntity": "DMTF",
+    "release": "2020.1",
+    "title": "#SecureBootDatabase.v1_0_1.SecureBootDatabase"
+}

--- a/static/redfish/v1/JsonSchemas/SecureBootDatabase/index.json
+++ b/static/redfish/v1/JsonSchemas/SecureBootDatabase/index.json
@@ -1,0 +1,21 @@
+{
+    "@odata.context": "/redfish/v1/$metadata#JsonSchemaFile.JsonSchemaFile",
+    "@odata.id": "/redfish/v1/JsonSchemas/SecureBootDatabase",
+    "@odata.type": "#JsonSchemaFile.v1_0_2.JsonSchemaFile",
+    "Name": "SecureBootDatabase Schema File",
+    "Schema": "#SecureBootDatabase.SecureBootDatabase",
+    "Description": "SecureBootDatabase Schema File Location",
+    "Id": "SecureBootDatabase",
+    "Languages": [
+        "en"
+    ],
+    "Languages@odata.count": 1,
+    "Location": [
+        {
+            "Language": "en",
+            "PublicationUri": "http://redfish.dmtf.org/schemas/v1/SecureBootDatabase.json",
+            "Uri": "/redfish/v1/JsonSchemas/SecureBootDatabase/SecureBootDatabase.json"
+        }
+    ],
+    "Location@odata.count": 1
+}

--- a/static/redfish/v1/JsonSchemas/SerialInterface/SerialInterface.json
+++ b/static/redfish/v1/JsonSchemas/SerialInterface/SerialInterface.json
@@ -1,0 +1,324 @@
+{
+    "$id": "http://redfish.dmtf.org/schemas/v1/SerialInterface.v1_1_8.json",
+    "$ref": "#/definitions/SerialInterface",
+    "$schema": "http://redfish.dmtf.org/schemas/v1/redfish-schema-v1.json",
+    "copyright": "Copyright 2014-2021 DMTF. For the full DMTF copyright policy, see http://www.dmtf.org/about/policies/copyright",
+    "definitions": {
+        "Actions": {
+            "additionalProperties": false,
+            "description": "The available actions for this resource.",
+            "longDescription": "This type shall contain the available actions for this resource.",
+            "patternProperties": {
+                "^([a-zA-Z_][a-zA-Z0-9_]*)?@(odata|Redfish|Message)\\.[a-zA-Z_][a-zA-Z0-9_]*$": {
+                    "description": "This property shall specify a valid odata or Redfish property.",
+                    "type": [
+                        "array",
+                        "boolean",
+                        "integer",
+                        "number",
+                        "null",
+                        "object",
+                        "string"
+                    ]
+                }
+            },
+            "properties": {
+                "Oem": {
+                    "$ref": "#/definitions/OemActions",
+                    "description": "The available OEM-specific actions for this resource.",
+                    "longDescription": "This property shall contain the available OEM-specific actions for this resource.",
+                    "versionAdded": "v1_1_0"
+                }
+            },
+            "type": "object"
+        },
+        "BitRate": {
+            "enum": [
+                "1200",
+                "2400",
+                "4800",
+                "9600",
+                "19200",
+                "38400",
+                "57600",
+                "115200",
+                "230400"
+            ],
+            "enumDescriptions": {
+                "115200": "A bit rate of 115200 bit/s.",
+                "1200": "A bit rate of 1200 bit/s.",
+                "19200": "A bit rate of 19200 bit/s.",
+                "230400": "A bit rate of 230400 bit/s.",
+                "2400": "A bit rate of 2400 bit/s.",
+                "38400": "A bit rate of 38400 bit/s.",
+                "4800": "A bit rate of 4800 bit/s.",
+                "57600": "A bit rate of 57600 bit/s.",
+                "9600": "A bit rate of 9600 bit/s."
+            },
+            "type": "string"
+        },
+        "ConnectorType": {
+            "enum": [
+                "RJ45",
+                "RJ11",
+                "DB9 Female",
+                "DB9 Male",
+                "DB25 Female",
+                "DB25 Male",
+                "USB",
+                "mUSB",
+                "uUSB"
+            ],
+            "enumDescriptions": {
+                "DB25 Female": "A DB25 Female connector.",
+                "DB25 Male": "A DB25 Male connector.",
+                "DB9 Female": "A DB9 Female connector.",
+                "DB9 Male": "A DB9 Male connector.",
+                "RJ11": "An RJ11 connector.",
+                "RJ45": "An RJ45 connector.",
+                "USB": "A USB connector.",
+                "mUSB": "A mUSB connector.",
+                "uUSB": "A uUSB connector."
+            },
+            "type": "string"
+        },
+        "DataBits": {
+            "enum": [
+                "5",
+                "6",
+                "7",
+                "8"
+            ],
+            "enumDescriptions": {
+                "5": "Five bits of data following the start bit.",
+                "6": "Six bits of data following the start bit.",
+                "7": "Seven bits of data following the start bit.",
+                "8": "Eight bits of data following the start bit."
+            },
+            "type": "string"
+        },
+        "FlowControl": {
+            "enum": [
+                "None",
+                "Software",
+                "Hardware"
+            ],
+            "enumDescriptions": {
+                "Hardware": "Out-of-band flow control imposed.",
+                "None": "No flow control imposed.",
+                "Software": "XON/XOFF in-band flow control imposed."
+            },
+            "type": "string"
+        },
+        "OemActions": {
+            "additionalProperties": true,
+            "description": "The available OEM-specific actions for this resource.",
+            "longDescription": "This type shall contain the available OEM-specific actions for this resource.",
+            "patternProperties": {
+                "^([a-zA-Z_][a-zA-Z0-9_]*)?@(odata|Redfish|Message)\\.[a-zA-Z_][a-zA-Z0-9_]*$": {
+                    "description": "This property shall specify a valid odata or Redfish property.",
+                    "type": [
+                        "array",
+                        "boolean",
+                        "integer",
+                        "number",
+                        "null",
+                        "object",
+                        "string"
+                    ]
+                }
+            },
+            "properties": {},
+            "type": "object"
+        },
+        "Parity": {
+            "enum": [
+                "None",
+                "Even",
+                "Odd",
+                "Mark",
+                "Space"
+            ],
+            "enumDescriptions": {
+                "Even": "An even parity bit.",
+                "Mark": "A mark parity bit.",
+                "None": "No parity bit.",
+                "Odd": "An odd parity bit.",
+                "Space": "A space parity bit."
+            },
+            "type": "string"
+        },
+        "PinOut": {
+            "enum": [
+                "Cisco",
+                "Cyclades",
+                "Digi"
+            ],
+            "enumDescriptions": {
+                "Cisco": "The Cisco pinout configuration.",
+                "Cyclades": "The Cyclades pinout configuration.",
+                "Digi": "The Digi pinout configuration."
+            },
+            "type": "string"
+        },
+        "SerialInterface": {
+            "additionalProperties": false,
+            "description": "The SerialInterface schema describes an asynchronous serial interface, such as an RS-232 interface, available to a system or device.",
+            "longDescription": "This resource shall represent a serial interface as part of the Redfish Specification.",
+            "patternProperties": {
+                "^([a-zA-Z_][a-zA-Z0-9_]*)?@(odata|Redfish|Message)\\.[a-zA-Z_][a-zA-Z0-9_]*$": {
+                    "description": "This property shall specify a valid odata or Redfish property.",
+                    "type": [
+                        "array",
+                        "boolean",
+                        "integer",
+                        "number",
+                        "null",
+                        "object",
+                        "string"
+                    ]
+                }
+            },
+            "properties": {
+                "@odata.context": {
+                    "$ref": "http://redfish.dmtf.org/schemas/v1/odata-v4.json#/definitions/context"
+                },
+                "@odata.etag": {
+                    "$ref": "http://redfish.dmtf.org/schemas/v1/odata-v4.json#/definitions/etag"
+                },
+                "@odata.id": {
+                    "$ref": "http://redfish.dmtf.org/schemas/v1/odata-v4.json#/definitions/id"
+                },
+                "@odata.type": {
+                    "$ref": "http://redfish.dmtf.org/schemas/v1/odata-v4.json#/definitions/type"
+                },
+                "Actions": {
+                    "$ref": "#/definitions/Actions",
+                    "description": "The available actions for this resource.",
+                    "longDescription": "This property shall contain the available actions for this resource.",
+                    "versionAdded": "v1_1_0"
+                },
+                "BitRate": {
+                    "$ref": "#/definitions/BitRate",
+                    "description": "The receive and transmit rate of data flow, typically in bits per second (bit/s), over the serial connection.",
+                    "longDescription": "This property shall indicate the transmit and receive speed of the serial connection.",
+                    "readonly": false
+                },
+                "ConnectorType": {
+                    "$ref": "#/definitions/ConnectorType",
+                    "description": "The type of connector used for this interface.",
+                    "longDescription": "This property shall indicate the type of physical connector used for this serial connection.",
+                    "readonly": true
+                },
+                "DataBits": {
+                    "$ref": "#/definitions/DataBits",
+                    "description": "The number of data bits that follow the start bit over the serial connection.",
+                    "longDescription": "This property shall indicate number of data bits for the serial connection.",
+                    "readonly": false
+                },
+                "Description": {
+                    "anyOf": [
+                        {
+                            "$ref": "http://redfish.dmtf.org/schemas/v1/Resource.json#/definitions/Description"
+                        },
+                        {
+                            "type": "null"
+                        }
+                    ],
+                    "readonly": true
+                },
+                "FlowControl": {
+                    "$ref": "#/definitions/FlowControl",
+                    "description": "The type of flow control, if any, that is imposed on the serial connection.",
+                    "longDescription": "This property shall indicate the flow control mechanism for the serial connection.",
+                    "readonly": false
+                },
+                "Id": {
+                    "$ref": "http://redfish.dmtf.org/schemas/v1/Resource.json#/definitions/Id",
+                    "readonly": true
+                },
+                "InterfaceEnabled": {
+                    "description": "An indication of whether this interface is enabled.",
+                    "longDescription": "This property shall indicate whether this interface is enabled.",
+                    "readonly": false,
+                    "type": [
+                        "boolean",
+                        "null"
+                    ]
+                },
+                "Name": {
+                    "$ref": "http://redfish.dmtf.org/schemas/v1/Resource.json#/definitions/Name",
+                    "readonly": true
+                },
+                "Oem": {
+                    "$ref": "http://redfish.dmtf.org/schemas/v1/Resource.json#/definitions/Oem",
+                    "description": "The OEM extension property.",
+                    "longDescription": "This property shall contain the OEM extensions.  All values for properties that this object contains shall conform to the Redfish Specification-described requirements."
+                },
+                "Parity": {
+                    "$ref": "#/definitions/Parity",
+                    "description": "The type of parity used by the sender and receiver to detect errors over the serial connection.",
+                    "longDescription": "This property shall indicate parity information for a serial connection.",
+                    "readonly": false
+                },
+                "PinOut": {
+                    "anyOf": [
+                        {
+                            "$ref": "#/definitions/PinOut"
+                        },
+                        {
+                            "type": "null"
+                        }
+                    ],
+                    "description": "The physical pinout configuration for a serial connector.",
+                    "longDescription": "This property shall indicate the physical pinout for the serial connector.",
+                    "readonly": true
+                },
+                "SignalType": {
+                    "$ref": "#/definitions/SignalType",
+                    "description": "The type of signal used for the communication connection.",
+                    "longDescription": "This property shall contain the type of serial signaling in use for the serial connection.",
+                    "readonly": true
+                },
+                "StopBits": {
+                    "$ref": "#/definitions/StopBits",
+                    "description": "The period of time before the next start bit is transmitted.",
+                    "longDescription": "This property shall indicate the stop bits for the serial connection.",
+                    "readonly": false
+                }
+            },
+            "required": [
+                "@odata.id",
+                "@odata.type",
+                "Id",
+                "Name"
+            ],
+            "type": "object"
+        },
+        "SignalType": {
+            "enum": [
+                "Rs232",
+                "Rs485"
+            ],
+            "enumDescriptions": {
+                "Rs232": "The serial interface follows RS232.",
+                "Rs485": "The serial interface follows RS485."
+            },
+            "type": "string"
+        },
+        "StopBits": {
+            "enum": [
+                "1",
+                "2"
+            ],
+            "enumDescriptions": {
+                "1": "One stop bit following the data bits.",
+                "2": "Two stop bits following the data bits."
+            },
+            "type": "string"
+        }
+    },
+    "owningEntity": "DMTF",
+    "release": "2017.1",
+    "title": "#SerialInterface.v1_1_8.SerialInterface"
+}

--- a/static/redfish/v1/JsonSchemas/SerialInterface/index.json
+++ b/static/redfish/v1/JsonSchemas/SerialInterface/index.json
@@ -1,0 +1,21 @@
+{
+    "@odata.context": "/redfish/v1/$metadata#JsonSchemaFile.JsonSchemaFile",
+    "@odata.id": "/redfish/v1/JsonSchemas/SerialInterface",
+    "@odata.type": "#JsonSchemaFile.v1_0_2.JsonSchemaFile",
+    "Name": "SerialInterface Schema File",
+    "Schema": "#SerialInterface.SerialInterface",
+    "Description": "SerialInterface Schema File Location",
+    "Id": "SerialInterface",
+    "Languages": [
+        "en"
+    ],
+    "Languages@odata.count": 1,
+    "Location": [
+        {
+            "Language": "en",
+            "PublicationUri": "http://redfish.dmtf.org/schemas/v1/SerialInterface.json",
+            "Uri": "/redfish/v1/JsonSchemas/SerialInterface/SerialInterface.json"
+        }
+    ],
+    "Location@odata.count": 1
+}

--- a/static/redfish/v1/JsonSchemas/Signature/Signature.json
+++ b/static/redfish/v1/JsonSchemas/Signature/Signature.json
@@ -1,0 +1,174 @@
+{
+    "$id": "http://redfish.dmtf.org/schemas/v1/Signature.v1_0_2.json",
+    "$ref": "#/definitions/Signature",
+    "$schema": "http://redfish.dmtf.org/schemas/v1/redfish-schema-v1.json",
+    "copyright": "Copyright 2014-2020 DMTF. For the full DMTF copyright policy, see http://www.dmtf.org/about/policies/copyright",
+    "definitions": {
+        "Actions": {
+            "additionalProperties": false,
+            "description": "The available actions for this resource.",
+            "longDescription": "This type shall contain the available actions for this resource.",
+            "patternProperties": {
+                "^([a-zA-Z_][a-zA-Z0-9_]*)?@(odata|Redfish|Message)\\.[a-zA-Z_][a-zA-Z0-9_]*$": {
+                    "description": "This property shall specify a valid odata or Redfish property.",
+                    "type": [
+                        "array",
+                        "boolean",
+                        "integer",
+                        "number",
+                        "null",
+                        "object",
+                        "string"
+                    ]
+                }
+            },
+            "properties": {
+                "Oem": {
+                    "$ref": "#/definitions/OemActions",
+                    "description": "The available OEM-specific actions for this resource.",
+                    "longDescription": "This property shall contain the available OEM-specific actions for this resource."
+                }
+            },
+            "type": "object"
+        },
+        "OemActions": {
+            "additionalProperties": true,
+            "description": "The available OEM-specific actions for this resource.",
+            "longDescription": "This type shall contain the available OEM-specific actions for this resource.",
+            "patternProperties": {
+                "^([a-zA-Z_][a-zA-Z0-9_]*)?@(odata|Redfish|Message)\\.[a-zA-Z_][a-zA-Z0-9_]*$": {
+                    "description": "This property shall specify a valid odata or Redfish property.",
+                    "type": [
+                        "array",
+                        "boolean",
+                        "integer",
+                        "number",
+                        "null",
+                        "object",
+                        "string"
+                    ]
+                }
+            },
+            "properties": {},
+            "type": "object"
+        },
+        "Signature": {
+            "additionalProperties": false,
+            "description": "The Signature schema describes a signature or a hash.",
+            "longDescription": "This resource contains a signature for a Redfish implementation.",
+            "patternProperties": {
+                "^([a-zA-Z_][a-zA-Z0-9_]*)?@(odata|Redfish|Message)\\.[a-zA-Z_][a-zA-Z0-9_]*$": {
+                    "description": "This property shall specify a valid odata or Redfish property.",
+                    "type": [
+                        "array",
+                        "boolean",
+                        "integer",
+                        "number",
+                        "null",
+                        "object",
+                        "string"
+                    ]
+                }
+            },
+            "properties": {
+                "@odata.context": {
+                    "$ref": "http://redfish.dmtf.org/schemas/v1/odata-v4.json#/definitions/context"
+                },
+                "@odata.etag": {
+                    "$ref": "http://redfish.dmtf.org/schemas/v1/odata-v4.json#/definitions/etag"
+                },
+                "@odata.id": {
+                    "$ref": "http://redfish.dmtf.org/schemas/v1/odata-v4.json#/definitions/id"
+                },
+                "@odata.type": {
+                    "$ref": "http://redfish.dmtf.org/schemas/v1/odata-v4.json#/definitions/type"
+                },
+                "Actions": {
+                    "$ref": "#/definitions/Actions",
+                    "description": "The available actions for this resource.",
+                    "longDescription": "This property shall contain the available actions for this resource."
+                },
+                "Description": {
+                    "anyOf": [
+                        {
+                            "$ref": "http://redfish.dmtf.org/schemas/v1/Resource.json#/definitions/Description"
+                        },
+                        {
+                            "type": "null"
+                        }
+                    ],
+                    "readonly": true
+                },
+                "Id": {
+                    "$ref": "http://redfish.dmtf.org/schemas/v1/Resource.json#/definitions/Id",
+                    "readonly": true
+                },
+                "Name": {
+                    "$ref": "http://redfish.dmtf.org/schemas/v1/Resource.json#/definitions/Name",
+                    "readonly": true
+                },
+                "Oem": {
+                    "$ref": "http://redfish.dmtf.org/schemas/v1/Resource.json#/definitions/Oem",
+                    "description": "The OEM extension property.",
+                    "longDescription": "This property shall contain the OEM extensions.  All values for properties that this object contains shall conform to the Redfish Specification-described requirements."
+                },
+                "SignatureString": {
+                    "description": "The string for the signature.",
+                    "longDescription": "This property shall contain the string of the signature, and the format shall follow the requirements specified by the value of the SignatureType property.  If the signature contains any private keys, they shall be removed from the string in responses.  If the private key for the signature is not known by the service and is needed to use the signature, the client shall provide the private key as part of the string in the POST request.",
+                    "readonly": true,
+                    "type": [
+                        "string",
+                        "null"
+                    ]
+                },
+                "SignatureType": {
+                    "description": "The format of the signature.",
+                    "longDescription": "This property shall contain the format type for the signature.  The format is qualified by the value of the SignatureTypeRegistry property.",
+                    "readonly": true,
+                    "type": [
+                        "string",
+                        "null"
+                    ]
+                },
+                "SignatureTypeRegistry": {
+                    "anyOf": [
+                        {
+                            "$ref": "http://redfish.dmtf.org/schemas/v1/Signature.json#/definitions/SignatureTypeRegistry"
+                        },
+                        {
+                            "type": "null"
+                        }
+                    ],
+                    "description": "The type of the signature.",
+                    "longDescription": "This property shall contain the type for the signature.",
+                    "readonly": true
+                },
+                "UefiSignatureOwner": {
+                    "description": "The UEFI signature owner for this signature.",
+                    "longDescription": "The value of this property shall contain the GUID of the UEFI signature owner for this signature as defined by the UEFI Specification.  This property shall only be present if the SignatureTypeRegistry property is `UEFI`.",
+                    "pattern": "([0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12})",
+                    "readonly": true,
+                    "type": [
+                        "string",
+                        "null"
+                    ]
+                }
+            },
+            "required": [
+                "@odata.id",
+                "@odata.type",
+                "Id",
+                "Name"
+            ],
+            "requiredOnCreate": [
+                "SignatureTypeRegistry",
+                "SignatureType",
+                "SignatureString"
+            ],
+            "type": "object"
+        }
+    },
+    "owningEntity": "DMTF",
+    "release": "2020.1",
+    "title": "#Signature.v1_0_2.Signature"
+}

--- a/static/redfish/v1/JsonSchemas/Signature/index.json
+++ b/static/redfish/v1/JsonSchemas/Signature/index.json
@@ -1,0 +1,21 @@
+{
+    "@odata.context": "/redfish/v1/$metadata#JsonSchemaFile.JsonSchemaFile",
+    "@odata.id": "/redfish/v1/JsonSchemas/Signature",
+    "@odata.type": "#JsonSchemaFile.v1_0_2.JsonSchemaFile",
+    "Name": "Signature Schema File",
+    "Schema": "#Signature.Signature",
+    "Description": "Signature Schema File Location",
+    "Id": "Signature",
+    "Languages": [
+        "en"
+    ],
+    "Languages@odata.count": 1,
+    "Location": [
+        {
+            "Language": "en",
+            "PublicationUri": "http://redfish.dmtf.org/schemas/v1/Signature.json",
+            "Uri": "/redfish/v1/JsonSchemas/Signature/Signature.json"
+        }
+    ],
+    "Location@odata.count": 1
+}

--- a/static/redfish/v1/JsonSchemas/SimpleStorage/SimpleStorage.json
+++ b/static/redfish/v1/JsonSchemas/SimpleStorage/SimpleStorage.json
@@ -1,0 +1,270 @@
+{
+    "$id": "http://redfish.dmtf.org/schemas/v1/SimpleStorage.v1_3_1.json",
+    "$ref": "#/definitions/SimpleStorage",
+    "$schema": "http://redfish.dmtf.org/schemas/v1/redfish-schema-v1.json",
+    "copyright": "Copyright 2014-2020 DMTF. For the full DMTF copyright policy, see http://www.dmtf.org/about/policies/copyright",
+    "definitions": {
+        "Actions": {
+            "additionalProperties": false,
+            "description": "The available actions for this Resource.",
+            "longDescription": "This type shall contain the available actions for this Resource.",
+            "patternProperties": {
+                "^([a-zA-Z_][a-zA-Z0-9_]*)?@(odata|Redfish|Message)\\.[a-zA-Z_][a-zA-Z0-9_]*$": {
+                    "description": "This property shall specify a valid odata or Redfish property.",
+                    "type": [
+                        "array",
+                        "boolean",
+                        "integer",
+                        "number",
+                        "null",
+                        "object",
+                        "string"
+                    ]
+                }
+            },
+            "properties": {
+                "Oem": {
+                    "$ref": "#/definitions/OemActions",
+                    "description": "The available OEM-specific actions for this Resource.",
+                    "longDescription": "This property shall contain the available OEM-specific actions for this Resource.",
+                    "versionAdded": "v1_2_0"
+                }
+            },
+            "type": "object"
+        },
+        "Device": {
+            "additionalProperties": false,
+            "description": "A storage device, such as a disk drive or optical media device.",
+            "longDescription": "This type shall describe a storage device visible to simple storage.",
+            "patternProperties": {
+                "^([a-zA-Z_][a-zA-Z0-9_]*)?@(odata|Redfish|Message)\\.[a-zA-Z_][a-zA-Z0-9_]*$": {
+                    "description": "This property shall specify a valid odata or Redfish property.",
+                    "type": [
+                        "array",
+                        "boolean",
+                        "integer",
+                        "number",
+                        "null",
+                        "object",
+                        "string"
+                    ]
+                }
+            },
+            "properties": {
+                "CapacityBytes": {
+                    "description": "The size, in bytes, of the storage device.",
+                    "longDescription": "This property shall represent the size, in bytes, of the storage device.",
+                    "minimum": 0,
+                    "readonly": true,
+                    "type": [
+                        "integer",
+                        "null"
+                    ],
+                    "units": "By",
+                    "versionAdded": "v1_1_0"
+                },
+                "Manufacturer": {
+                    "description": "The name of the manufacturer of this device.",
+                    "longDescription": "This property shall indicate the name of the manufacturer of this storage device.",
+                    "readonly": true,
+                    "type": [
+                        "string",
+                        "null"
+                    ]
+                },
+                "Model": {
+                    "description": "The product model number of this device.",
+                    "longDescription": "This property shall indicate the model information as provided by the manufacturer of this storage device.",
+                    "readonly": true,
+                    "type": [
+                        "string",
+                        "null"
+                    ]
+                },
+                "Name": {
+                    "description": "The name of the Resource or array member.",
+                    "longDescription": "This object represents the name of this Resource or array member.  The Resource values shall comply with the Redfish Specification-described requirements.  This string value shall be of the 'Name' reserved word format.",
+                    "readonly": true,
+                    "type": "string"
+                },
+                "Oem": {
+                    "$ref": "http://redfish.dmtf.org/schemas/v1/Resource.json#/definitions/Oem",
+                    "description": "The OEM extension property.",
+                    "longDescription": "This property shall contain the OEM extensions.  All values for properties contained in this object shall conform to the Redfish Specification-described requirements."
+                },
+                "Status": {
+                    "$ref": "http://redfish.dmtf.org/schemas/v1/Resource.json#/definitions/Status",
+                    "description": "The status and health of the Resource and its subordinate or dependent Resources.",
+                    "longDescription": "This property shall contain any status or health properties of the Resource."
+                }
+            },
+            "required": [
+                "Name"
+            ],
+            "type": "object"
+        },
+        "Links": {
+            "additionalProperties": false,
+            "description": "The links to other Resources that are related to this Resource.",
+            "longDescription": "The Redfish Specification-described type shall contain links to Resources related to but not subordinate to this Resource.",
+            "patternProperties": {
+                "^([a-zA-Z_][a-zA-Z0-9_]*)?@(odata|Redfish|Message)\\.[a-zA-Z_][a-zA-Z0-9_]*$": {
+                    "description": "This property shall specify a valid odata or Redfish property.",
+                    "type": [
+                        "array",
+                        "boolean",
+                        "integer",
+                        "number",
+                        "null",
+                        "object",
+                        "string"
+                    ]
+                }
+            },
+            "properties": {
+                "Chassis": {
+                    "$ref": "http://redfish.dmtf.org/schemas/v1/Chassis.json#/definitions/Chassis",
+                    "description": "The link to the chassis that contains this simple storage.",
+                    "longDescription": "This property shall contain a link to a Resource of type Chassis that represents the physical container associated with this Resource.",
+                    "readonly": true,
+                    "versionAdded": "v1_2_0"
+                },
+                "Oem": {
+                    "$ref": "http://redfish.dmtf.org/schemas/v1/Resource.json#/definitions/Oem",
+                    "description": "The OEM extension property.",
+                    "longDescription": "This property shall contain the OEM extensions.  All values for properties contained in this object shall conform to the Redfish Specification-described requirements."
+                },
+                "Storage": {
+                    "$ref": "http://redfish.dmtf.org/schemas/v1/Storage.json#/definitions/Storage",
+                    "description": "The link to the storage instance that corresponds to this simple storage.",
+                    "longDescription": "This property shall contain a link to a Resource of type Storage that represents the same storage subsystem as this Resource.",
+                    "readonly": true,
+                    "versionAdded": "v1_3_0"
+                }
+            },
+            "type": "object"
+        },
+        "OemActions": {
+            "additionalProperties": true,
+            "description": "The available OEM-specific actions for this Resource.",
+            "longDescription": "This type shall contain the available OEM-specific actions for this Resource.",
+            "patternProperties": {
+                "^([a-zA-Z_][a-zA-Z0-9_]*)?@(odata|Redfish|Message)\\.[a-zA-Z_][a-zA-Z0-9_]*$": {
+                    "description": "This property shall specify a valid odata or Redfish property.",
+                    "type": [
+                        "array",
+                        "boolean",
+                        "integer",
+                        "number",
+                        "null",
+                        "object",
+                        "string"
+                    ]
+                }
+            },
+            "properties": {},
+            "type": "object"
+        },
+        "SimpleStorage": {
+            "additionalProperties": false,
+            "description": "The SimpleStorage schema represents the properties of a storage controller and its directly-attached devices.",
+            "longDescription": "This Resource contains a storage controller and its directly-attached devices.",
+            "patternProperties": {
+                "^([a-zA-Z_][a-zA-Z0-9_]*)?@(odata|Redfish|Message)\\.[a-zA-Z_][a-zA-Z0-9_]*$": {
+                    "description": "This property shall specify a valid odata or Redfish property.",
+                    "type": [
+                        "array",
+                        "boolean",
+                        "integer",
+                        "number",
+                        "null",
+                        "object",
+                        "string"
+                    ]
+                }
+            },
+            "properties": {
+                "@odata.context": {
+                    "$ref": "http://redfish.dmtf.org/schemas/v1/odata-v4.json#/definitions/context"
+                },
+                "@odata.etag": {
+                    "$ref": "http://redfish.dmtf.org/schemas/v1/odata-v4.json#/definitions/etag"
+                },
+                "@odata.id": {
+                    "$ref": "http://redfish.dmtf.org/schemas/v1/odata-v4.json#/definitions/id"
+                },
+                "@odata.type": {
+                    "$ref": "http://redfish.dmtf.org/schemas/v1/odata-v4.json#/definitions/type"
+                },
+                "Actions": {
+                    "$ref": "#/definitions/Actions",
+                    "description": "The available actions for this Resource.",
+                    "longDescription": "This property shall contain the available actions for this Resource.",
+                    "versionAdded": "v1_2_0"
+                },
+                "Description": {
+                    "anyOf": [
+                        {
+                            "$ref": "http://redfish.dmtf.org/schemas/v1/Resource.json#/definitions/Description"
+                        },
+                        {
+                            "type": "null"
+                        }
+                    ],
+                    "readonly": true
+                },
+                "Devices": {
+                    "description": "The storage devices.",
+                    "items": {
+                        "$ref": "#/definitions/Device"
+                    },
+                    "longDescription": "This property shall contain a list of storage devices related to this Resource.",
+                    "type": "array"
+                },
+                "Id": {
+                    "$ref": "http://redfish.dmtf.org/schemas/v1/Resource.json#/definitions/Id",
+                    "readonly": true
+                },
+                "Links": {
+                    "$ref": "#/definitions/Links",
+                    "description": "The links to other Resources that are related to this Resource.",
+                    "longDescription": "The Redfish Specification-described Links Property shall contain links to Resources related to but not subordinate to this Resource.",
+                    "versionAdded": "v1_2_0"
+                },
+                "Name": {
+                    "$ref": "http://redfish.dmtf.org/schemas/v1/Resource.json#/definitions/Name",
+                    "readonly": true
+                },
+                "Oem": {
+                    "$ref": "http://redfish.dmtf.org/schemas/v1/Resource.json#/definitions/Oem",
+                    "description": "The OEM extension property.",
+                    "longDescription": "This property shall contain the OEM extensions.  All values for properties that this object contains shall conform to the Redfish Specification-described requirements."
+                },
+                "Status": {
+                    "$ref": "http://redfish.dmtf.org/schemas/v1/Resource.json#/definitions/Status",
+                    "description": "The status and health of the Resource and its subordinate or dependent Resources.",
+                    "longDescription": "This property shall contain any status or health properties of the Resource."
+                },
+                "UefiDevicePath": {
+                    "description": "The UEFI device path to access this storage controller.",
+                    "longDescription": "This property shall contain the UEFI device path that identifies and locates the specific storage controller.",
+                    "readonly": true,
+                    "type": [
+                        "string",
+                        "null"
+                    ]
+                }
+            },
+            "required": [
+                "@odata.id",
+                "@odata.type",
+                "Id",
+                "Name"
+            ],
+            "type": "object"
+        }
+    },
+    "owningEntity": "DMTF",
+    "release": "2020.3",
+    "title": "#SimpleStorage.v1_3_1.SimpleStorage"
+}

--- a/static/redfish/v1/JsonSchemas/SimpleStorage/index.json
+++ b/static/redfish/v1/JsonSchemas/SimpleStorage/index.json
@@ -1,0 +1,21 @@
+{
+    "@odata.context": "/redfish/v1/$metadata#JsonSchemaFile.JsonSchemaFile",
+    "@odata.id": "/redfish/v1/JsonSchemas/SimpleStorage",
+    "@odata.type": "#JsonSchemaFile.v1_0_2.JsonSchemaFile",
+    "Name": "SimpleStorage Schema File",
+    "Schema": "#SimpleStorage.SimpleStorage",
+    "Description": "SimpleStorage Schema File Location",
+    "Id": "SimpleStorage",
+    "Languages": [
+        "en"
+    ],
+    "Languages@odata.count": 1,
+    "Location": [
+        {
+            "Language": "en",
+            "PublicationUri": "http://redfish.dmtf.org/schemas/v1/SimpleStorage.json",
+            "Uri": "/redfish/v1/JsonSchemas/SimpleStorage/SimpleStorage.json"
+        }
+    ],
+    "Location@odata.count": 1
+}

--- a/static/redfish/v1/JsonSchemas/Switch/Switch.json
+++ b/static/redfish/v1/JsonSchemas/Switch/Switch.json
@@ -1,0 +1,499 @@
+{
+    "$id": "http://redfish.dmtf.org/schemas/v1/Switch.v1_6_0.json",
+    "$ref": "#/definitions/Switch",
+    "$schema": "http://redfish.dmtf.org/schemas/v1/redfish-schema-v1.json",
+    "copyright": "Copyright 2014-2021 DMTF. For the full DMTF copyright policy, see http://www.dmtf.org/about/policies/copyright",
+    "definitions": {
+        "Actions": {
+            "additionalProperties": false,
+            "description": "The available actions for this resource.",
+            "longDescription": "This type shall contain the available actions for this resource.",
+            "patternProperties": {
+                "^([a-zA-Z_][a-zA-Z0-9_]*)?@(odata|Redfish|Message)\\.[a-zA-Z_][a-zA-Z0-9_]*$": {
+                    "description": "This property shall specify a valid odata or Redfish property.",
+                    "type": [
+                        "array",
+                        "boolean",
+                        "integer",
+                        "number",
+                        "null",
+                        "object",
+                        "string"
+                    ]
+                }
+            },
+            "properties": {
+                "#Switch.Reset": {
+                    "$ref": "#/definitions/Reset"
+                },
+                "Oem": {
+                    "$ref": "#/definitions/OemActions",
+                    "description": "The available OEM-specific actions for this resource.",
+                    "longDescription": "This property shall contain the available OEM-specific actions for this resource."
+                }
+            },
+            "type": "object"
+        },
+        "Links": {
+            "additionalProperties": false,
+            "description": "The links to other resources that are related to this resource.",
+            "longDescription": "This Redfish Specification-described type shall contain links to resources that are related to but are not contained by, or subordinate to, this resource.",
+            "patternProperties": {
+                "^([a-zA-Z_][a-zA-Z0-9_]*)?@(odata|Redfish|Message)\\.[a-zA-Z_][a-zA-Z0-9_]*$": {
+                    "description": "This property shall specify a valid odata or Redfish property.",
+                    "type": [
+                        "array",
+                        "boolean",
+                        "integer",
+                        "number",
+                        "null",
+                        "object",
+                        "string"
+                    ]
+                }
+            },
+            "properties": {
+                "Chassis": {
+                    "$ref": "http://redfish.dmtf.org/schemas/v1/Chassis.json#/definitions/Chassis",
+                    "description": "The link to the chassis that contains this switch.",
+                    "longDescription": "This property shall contain a link to a resource of type Chassis with which this switch is associated.",
+                    "readonly": true
+                },
+                "Endpoints": {
+                    "description": "An array of links to the endpoints that connect to this switch.",
+                    "items": {
+                        "$ref": "http://redfish.dmtf.org/schemas/v1/Endpoint.json#/definitions/Endpoint"
+                    },
+                    "longDescription": "This property shall contain an array of links to resources of type Endpoint with which this switch is associated.",
+                    "readonly": true,
+                    "type": "array",
+                    "versionAdded": "v1_3_0"
+                },
+                "Endpoints@odata.count": {
+                    "$ref": "http://redfish.dmtf.org/schemas/v1/odata-v4.json#/definitions/count"
+                },
+                "ManagedBy": {
+                    "description": "An array of links to the managers that manage this switch.",
+                    "items": {
+                        "$ref": "http://redfish.dmtf.org/schemas/v1/Manager.json#/definitions/Manager"
+                    },
+                    "longDescription": "This property shall contain an array of links to resources of type Manager with which this switch is associated.",
+                    "readonly": true,
+                    "type": "array"
+                },
+                "ManagedBy@odata.count": {
+                    "$ref": "http://redfish.dmtf.org/schemas/v1/odata-v4.json#/definitions/count"
+                },
+                "Oem": {
+                    "$ref": "http://redfish.dmtf.org/schemas/v1/Resource.json#/definitions/Oem",
+                    "description": "The OEM extension property.",
+                    "longDescription": "This property shall contain the OEM extensions.  All values for properties contained in this object shall conform to the Redfish Specification-described requirements."
+                },
+                "PCIeDevice": {
+                    "anyOf": [
+                        {
+                            "$ref": "http://redfish.dmtf.org/schemas/v1/PCIeDevice.json#/definitions/PCIeDevice"
+                        },
+                        {
+                            "type": "null"
+                        }
+                    ],
+                    "description": "The link to the PCIe device providing this switch.",
+                    "longDescription": "This property shall contain a link to a resource of type PCIeDevice that represents the PCIe device providing this switch.",
+                    "readonly": true,
+                    "versionAdded": "v1_4_0"
+                }
+            },
+            "type": "object"
+        },
+        "OemActions": {
+            "additionalProperties": true,
+            "description": "The available OEM-specific actions for this resource.",
+            "longDescription": "This type shall contain the available OEM-specific actions for this resource.",
+            "patternProperties": {
+                "^([a-zA-Z_][a-zA-Z0-9_]*)?@(odata|Redfish|Message)\\.[a-zA-Z_][a-zA-Z0-9_]*$": {
+                    "description": "This property shall specify a valid odata or Redfish property.",
+                    "type": [
+                        "array",
+                        "boolean",
+                        "integer",
+                        "number",
+                        "null",
+                        "object",
+                        "string"
+                    ]
+                }
+            },
+            "properties": {},
+            "type": "object"
+        },
+        "Reset": {
+            "additionalProperties": false,
+            "description": "This action resets this switch.",
+            "longDescription": "This action shall reset this switch.",
+            "parameters": {
+                "ResetType": {
+                    "$ref": "http://redfish.dmtf.org/schemas/v1/Resource.json#/definitions/ResetType",
+                    "description": "The type of reset.",
+                    "longDescription": "This parameter shall contain the type of reset.  The service can accept a request without this parameter and can complete an implementation-specific default reset."
+                }
+            },
+            "patternProperties": {
+                "^([a-zA-Z_][a-zA-Z0-9_]*)?@(odata|Redfish|Message)\\.[a-zA-Z_][a-zA-Z0-9_]*$": {
+                    "description": "This property shall specify a valid odata or Redfish property.",
+                    "type": [
+                        "array",
+                        "boolean",
+                        "integer",
+                        "number",
+                        "null",
+                        "object",
+                        "string"
+                    ]
+                }
+            },
+            "properties": {
+                "target": {
+                    "description": "Link to invoke action",
+                    "format": "uri-reference",
+                    "type": "string"
+                },
+                "title": {
+                    "description": "Friendly action name",
+                    "type": "string"
+                }
+            },
+            "type": "object"
+        },
+        "Switch": {
+            "additionalProperties": false,
+            "description": "The Switch schema contains properties that describe a fabric switch.",
+            "longDescription": "This resource contains a switch for a Redfish implementation.",
+            "patternProperties": {
+                "^([a-zA-Z_][a-zA-Z0-9_]*)?@(odata|Redfish|Message)\\.[a-zA-Z_][a-zA-Z0-9_]*$": {
+                    "description": "This property shall specify a valid odata or Redfish property.",
+                    "type": [
+                        "array",
+                        "boolean",
+                        "integer",
+                        "number",
+                        "null",
+                        "object",
+                        "string"
+                    ]
+                }
+            },
+            "properties": {
+                "@odata.context": {
+                    "$ref": "http://redfish.dmtf.org/schemas/v1/odata-v4.json#/definitions/context"
+                },
+                "@odata.etag": {
+                    "$ref": "http://redfish.dmtf.org/schemas/v1/odata-v4.json#/definitions/etag"
+                },
+                "@odata.id": {
+                    "$ref": "http://redfish.dmtf.org/schemas/v1/odata-v4.json#/definitions/id"
+                },
+                "@odata.type": {
+                    "$ref": "http://redfish.dmtf.org/schemas/v1/odata-v4.json#/definitions/type"
+                },
+                "Actions": {
+                    "$ref": "#/definitions/Actions",
+                    "description": "The available actions for this resource.",
+                    "longDescription": "This property shall contain the available actions for this resource."
+                },
+                "AssetTag": {
+                    "description": "The user-assigned asset tag for this switch.",
+                    "longDescription": "This property shall contain the user-assigned asset tag, which is an identifying string that tracks the drive for inventory purposes.",
+                    "readonly": false,
+                    "type": [
+                        "string",
+                        "null"
+                    ]
+                },
+                "Certificates": {
+                    "$ref": "http://redfish.dmtf.org/schemas/v1/CertificateCollection.json#/definitions/CertificateCollection",
+                    "description": "The link to a collection of certificates for device identity and attestation.",
+                    "longDescription": "This property shall contain a link to a resource collection of type CertificateCollection that contains certificates for device identity and attestation.",
+                    "readonly": true,
+                    "versionAdded": "v1_5_0"
+                },
+                "CurrentBandwidthGbps": {
+                    "description": "The current internal bandwidth of this switch.",
+                    "longDescription": "This property shall contain the internal bandwidth of this switch currently negotiated and running.",
+                    "readonly": true,
+                    "type": [
+                        "number",
+                        "null"
+                    ],
+                    "units": "Gbit/s",
+                    "versionAdded": "v1_4_0"
+                },
+                "Description": {
+                    "anyOf": [
+                        {
+                            "$ref": "http://redfish.dmtf.org/schemas/v1/Resource.json#/definitions/Description"
+                        },
+                        {
+                            "type": "null"
+                        }
+                    ],
+                    "readonly": true
+                },
+                "DomainID": {
+                    "description": "The domain ID for this switch.",
+                    "longDescription": "This property shall contain The domain ID for this switch.  This property has a scope of uniqueness within the fabric of which the switch is a member.",
+                    "readonly": true,
+                    "type": [
+                        "integer",
+                        "null"
+                    ]
+                },
+                "Enabled": {
+                    "description": "An indication of whether this switch is enabled.",
+                    "longDescription": "The value of this property shall indicate if this switch is enabled.",
+                    "readonly": false,
+                    "type": "boolean",
+                    "versionAdded": "v1_6_0"
+                },
+                "EnvironmentMetrics": {
+                    "$ref": "http://redfish.dmtf.org/schemas/v1/EnvironmentMetrics.json#/definitions/EnvironmentMetrics",
+                    "description": "The link to the environment metrics for this switch.",
+                    "longDescription": "This property shall contain a link to a resource of type EnvironmentMetrics that specifies the environment metrics for this switch.",
+                    "readonly": true,
+                    "versionAdded": "v1_6_0"
+                },
+                "FirmwareVersion": {
+                    "description": "The firmware version of this switch.",
+                    "longDescription": "This property shall contain the firmware version as defined by the manufacturer for the associated switch.",
+                    "readonly": true,
+                    "type": [
+                        "string",
+                        "null"
+                    ],
+                    "versionAdded": "v1_2_0"
+                },
+                "Id": {
+                    "$ref": "http://redfish.dmtf.org/schemas/v1/Resource.json#/definitions/Id",
+                    "readonly": true
+                },
+                "IndicatorLED": {
+                    "anyOf": [
+                        {
+                            "$ref": "http://redfish.dmtf.org/schemas/v1/Resource.json#/definitions/IndicatorLED"
+                        },
+                        {
+                            "type": "null"
+                        }
+                    ],
+                    "deprecated": "This property has been deprecated in favor of the LocationIndicatorActive property.",
+                    "description": "The state of the indicator LED, which identifies the switch.",
+                    "longDescription": "This property shall contain the state of the indicator light associated with this switch.",
+                    "readonly": false,
+                    "versionDeprecated": "v1_4_0"
+                },
+                "IsManaged": {
+                    "description": "An indication of whether the switch is in a managed or unmanaged state.",
+                    "longDescription": "This property shall indicate whether this switch is in a managed or unmanaged state.",
+                    "readonly": false,
+                    "type": [
+                        "boolean",
+                        "null"
+                    ]
+                },
+                "Links": {
+                    "$ref": "#/definitions/Links",
+                    "description": "The links to other resources that are related to this resource.",
+                    "longDescription": "This property shall contain links to resources that are related to but are not contained by, or subordinate to, this resource."
+                },
+                "Location": {
+                    "$ref": "http://redfish.dmtf.org/schemas/v1/Resource.json#/definitions/Location",
+                    "description": "The location of the switch.",
+                    "longDescription": "This property shall contain location information of the associated switch.",
+                    "versionAdded": "v1_1_0"
+                },
+                "LocationIndicatorActive": {
+                    "description": "An indicator allowing an operator to physically locate this resource.",
+                    "longDescription": "This property shall contain the state of the indicator used to physically identify or locate this resource.  A write to this property shall update the value of IndicatorLED in this resource, if supported, to reflect the implementation of the locating function.",
+                    "readonly": false,
+                    "type": [
+                        "boolean",
+                        "null"
+                    ],
+                    "versionAdded": "v1_4_0"
+                },
+                "LogServices": {
+                    "$ref": "http://redfish.dmtf.org/schemas/v1/LogServiceCollection.json#/definitions/LogServiceCollection",
+                    "description": "The link to the collection of log services associated with this switch.",
+                    "longDescription": "This property shall contain a link to a resource collection of type LogServiceCollection.",
+                    "readonly": true
+                },
+                "Manufacturer": {
+                    "description": "The manufacturer of this switch.",
+                    "longDescription": "This property shall contain the name of the organization responsible for producing the switch.  This organization may be the entity from which the switch is purchased, but this is not necessarily true.",
+                    "readonly": true,
+                    "type": [
+                        "string",
+                        "null"
+                    ]
+                },
+                "MaxBandwidthGbps": {
+                    "description": "The maximum internal bandwidth of this switch as currently configured.",
+                    "longDescription": "This property shall contain the maximum internal bandwidth this switch is capable of being configured.  If capable of autonegotiation, the switch shall attempt to negotiate to the specified maximum bandwidth.",
+                    "readonly": true,
+                    "type": [
+                        "number",
+                        "null"
+                    ],
+                    "units": "Gbit/s",
+                    "versionAdded": "v1_4_0"
+                },
+                "Measurements": {
+                    "description": "An array of DSP0274-defined measurement blocks.",
+                    "items": {
+                        "$ref": "http://redfish.dmtf.org/schemas/v1/SoftwareInventory.json#/definitions/MeasurementBlock"
+                    },
+                    "longDescription": "This property shall contain an array of DSP0274-defined measurement blocks.",
+                    "type": "array",
+                    "versionAdded": "v1_5_0"
+                },
+                "Model": {
+                    "description": "The product model number of this switch.",
+                    "longDescription": "This property shall contain the manufacturer-provided model information of this switch.",
+                    "readonly": true,
+                    "type": [
+                        "string",
+                        "null"
+                    ]
+                },
+                "Name": {
+                    "$ref": "http://redfish.dmtf.org/schemas/v1/Resource.json#/definitions/Name",
+                    "readonly": true
+                },
+                "Oem": {
+                    "$ref": "http://redfish.dmtf.org/schemas/v1/Resource.json#/definitions/Oem",
+                    "description": "The OEM extension property.",
+                    "longDescription": "This property shall contain the OEM extensions.  All values for properties that this object contains shall conform to the Redfish Specification-described requirements."
+                },
+                "PartNumber": {
+                    "description": "The part number for this switch.",
+                    "longDescription": "This property shall contain the manufacturer-provided part number for the switch.",
+                    "readonly": true,
+                    "type": [
+                        "string",
+                        "null"
+                    ]
+                },
+                "Ports": {
+                    "$ref": "http://redfish.dmtf.org/schemas/v1/PortCollection.json#/definitions/PortCollection",
+                    "description": "The link to the collection ports for this switch.",
+                    "longDescription": "This property shall contain a link to a resource collection of type PortCollection.",
+                    "readonly": true
+                },
+                "PowerState": {
+                    "anyOf": [
+                        {
+                            "$ref": "http://redfish.dmtf.org/schemas/v1/Resource.json#/definitions/PowerState"
+                        },
+                        {
+                            "type": "null"
+                        }
+                    ],
+                    "description": "The current power state of the switch.",
+                    "longDescription": "This property shall contain the power state of the switch.",
+                    "readonly": true
+                },
+                "Redundancy": {
+                    "autoExpand": true,
+                    "description": "Redundancy information for the switches.",
+                    "items": {
+                        "$ref": "http://redfish.dmtf.org/schemas/v1/Redundancy.json#/definitions/Redundancy"
+                    },
+                    "longDescription": "This property shall contain an array that shows how this switch is grouped with other switches for form redundancy sets.",
+                    "type": "array"
+                },
+                "Redundancy@odata.count": {
+                    "$ref": "http://redfish.dmtf.org/schemas/v1/odata-v4.json#/definitions/count"
+                },
+                "SKU": {
+                    "description": "The SKU for this switch.",
+                    "longDescription": "This property shall contain the SKU number for this switch.",
+                    "readonly": true,
+                    "type": [
+                        "string",
+                        "null"
+                    ]
+                },
+                "SerialNumber": {
+                    "description": "The serial number for this switch.",
+                    "longDescription": "This property shall contain a manufacturer-allocated number that identifies the switch.",
+                    "readonly": true,
+                    "type": [
+                        "string",
+                        "null"
+                    ]
+                },
+                "Status": {
+                    "$ref": "http://redfish.dmtf.org/schemas/v1/Resource.json#/definitions/Status",
+                    "description": "The status and health of the resource and its subordinate or dependent resources.",
+                    "longDescription": "This property shall contain any status or health properties of the resource."
+                },
+                "SupportedProtocols": {
+                    "description": "The protocols this switch supports.",
+                    "items": {
+                        "$ref": "http://redfish.dmtf.org/schemas/v1/Protocol.json#/definitions/Protocol"
+                    },
+                    "longDescription": "The property shall contain an array of protocols this switch supports.  If the value of SwitchType is `MultiProtocol`, this property shall be required.",
+                    "readonly": true,
+                    "type": "array",
+                    "versionAdded": "v1_3_0"
+                },
+                "SwitchType": {
+                    "anyOf": [
+                        {
+                            "$ref": "http://redfish.dmtf.org/schemas/v1/Protocol.json#/definitions/Protocol"
+                        },
+                        {
+                            "type": "null"
+                        }
+                    ],
+                    "description": "The protocol being sent over this switch.",
+                    "longDescription": "This property shall contain the protocol being sent over this switch.  For a switch that supports multiple protocols, the value should be `MultiProtocol` and the SupportedProtocols property should be used to describe the supported protocols.",
+                    "readonly": true
+                },
+                "TotalSwitchWidth": {
+                    "description": "The total number of lanes, phys, or other physical transport links that this switch contains.",
+                    "longDescription": "This property shall contain the number of physical transport lanes, phys, or other physical transport links that this switch contains.  For PCIe, this value shall be the lane count.",
+                    "readonly": true,
+                    "type": [
+                        "integer",
+                        "null"
+                    ]
+                },
+                "UUID": {
+                    "anyOf": [
+                        {
+                            "$ref": "http://redfish.dmtf.org/schemas/v1/Resource.json#/definitions/UUID"
+                        },
+                        {
+                            "type": "null"
+                        }
+                    ],
+                    "description": "The UUID for this switch.",
+                    "longDescription": "This property shall contain a universal unique identifier number for the switch.",
+                    "readonly": true,
+                    "versionAdded": "v1_3_0"
+                }
+            },
+            "required": [
+                "@odata.id",
+                "@odata.type",
+                "Id",
+                "Name"
+            ],
+            "type": "object"
+        }
+    },
+    "owningEntity": "DMTF",
+    "release": "2021.1",
+    "title": "#Switch.v1_6_0.Switch"
+}

--- a/static/redfish/v1/JsonSchemas/Switch/index.json
+++ b/static/redfish/v1/JsonSchemas/Switch/index.json
@@ -1,0 +1,21 @@
+{
+    "@odata.context": "/redfish/v1/$metadata#JsonSchemaFile.JsonSchemaFile",
+    "@odata.id": "/redfish/v1/JsonSchemas/Switch",
+    "@odata.type": "#JsonSchemaFile.v1_0_2.JsonSchemaFile",
+    "Name": "Switch Schema File",
+    "Schema": "#Switch.Switch",
+    "Description": "Switch Schema File Location",
+    "Id": "Switch",
+    "Languages": [
+        "en"
+    ],
+    "Languages@odata.count": 1,
+    "Location": [
+        {
+            "Language": "en",
+            "PublicationUri": "http://redfish.dmtf.org/schemas/v1/Switch.json",
+            "Uri": "/redfish/v1/JsonSchemas/Switch/Switch.json"
+        }
+    ],
+    "Location@odata.count": 1
+}

--- a/static/redfish/v1/JsonSchemas/Triggers/Triggers.json
+++ b/static/redfish/v1/JsonSchemas/Triggers/Triggers.json
@@ -1,0 +1,557 @@
+{
+    "$id": "http://redfish.dmtf.org/schemas/v1/Triggers.v1_2_0.json",
+    "$ref": "#/definitions/Triggers",
+    "$schema": "http://redfish.dmtf.org/schemas/v1/redfish-schema-v1.json",
+    "copyright": "Copyright 2014-2021 DMTF. For the full DMTF copyright policy, see http://www.dmtf.org/about/policies/copyright",
+    "definitions": {
+        "Actions": {
+            "additionalProperties": false,
+            "description": "The available actions for this resource.",
+            "longDescription": "This type shall contain the available actions for this resource.",
+            "patternProperties": {
+                "^([a-zA-Z_][a-zA-Z0-9_]*)?@(odata|Redfish|Message)\\.[a-zA-Z_][a-zA-Z0-9_]*$": {
+                    "description": "This property shall specify a valid odata or Redfish property.",
+                    "type": [
+                        "array",
+                        "boolean",
+                        "integer",
+                        "number",
+                        "null",
+                        "object",
+                        "string"
+                    ]
+                }
+            },
+            "properties": {
+                "Oem": {
+                    "$ref": "#/definitions/OemActions",
+                    "description": "The available OEM-specific actions for this resource.",
+                    "longDescription": "This property shall contain the available OEM-specific actions for this resource."
+                }
+            },
+            "type": "object"
+        },
+        "DirectionOfCrossingEnum": {
+            "description": "The direction of crossing that corresponds to a trigger.",
+            "enum": [
+                "Increasing",
+                "Decreasing"
+            ],
+            "enumDescriptions": {
+                "Decreasing": "A trigger is met when the metric value crosses the trigger value while decreasing.",
+                "Increasing": "A trigger condition is met when the metric value crosses the trigger value while increasing."
+            },
+            "longDescription": "The value shall indicate the direction of crossing that corresponds to a trigger.",
+            "type": "string"
+        },
+        "DiscreteTrigger": {
+            "additionalProperties": false,
+            "description": "The characteristics of the discrete trigger.",
+            "longDescription": "This object shall contain the characteristics of the discrete trigger.",
+            "patternProperties": {
+                "^([a-zA-Z_][a-zA-Z0-9_]*)?@(odata|Redfish|Message)\\.[a-zA-Z_][a-zA-Z0-9_]*$": {
+                    "description": "This property shall specify a valid odata or Redfish property.",
+                    "type": [
+                        "array",
+                        "boolean",
+                        "integer",
+                        "number",
+                        "null",
+                        "object",
+                        "string"
+                    ]
+                }
+            },
+            "properties": {
+                "DwellTime": {
+                    "description": "The amount of time that a trigger event persists before the metric action is performed.",
+                    "longDescription": "This property shall contain the amount of time that a trigger event persists before the TriggerActions are performed.",
+                    "pattern": "-?P(\\d+D)?(T(\\d+H)?(\\d+M)?(\\d+(.\\d+)?S)?)?",
+                    "readonly": false,
+                    "type": [
+                        "string",
+                        "null"
+                    ]
+                },
+                "Name": {
+                    "description": "The name of trigger.",
+                    "longDescription": "This property shall contain a name for the trigger.",
+                    "readonly": true,
+                    "type": [
+                        "string",
+                        "null"
+                    ]
+                },
+                "Severity": {
+                    "anyOf": [
+                        {
+                            "$ref": "http://redfish.dmtf.org/schemas/v1/Resource.json#/definitions/Health"
+                        },
+                        {
+                            "type": "null"
+                        }
+                    ],
+                    "description": "The severity of the event message.",
+                    "longDescription": "This property shall contain the Severity property to be used in the event message.",
+                    "readonly": false
+                },
+                "Value": {
+                    "description": "The discrete metric value that constitutes a trigger event.",
+                    "longDescription": "This property shall contain the value discrete metric that constitutes a trigger event.  The DwellTime shall be measured from this point in time.",
+                    "readonly": false,
+                    "type": [
+                        "string",
+                        "null"
+                    ]
+                }
+            },
+            "type": "object"
+        },
+        "DiscreteTriggerConditionEnum": {
+            "description": "The condition, in relationship to the discrete trigger values, which constitutes a trigger.",
+            "enum": [
+                "Specified",
+                "Changed"
+            ],
+            "enumDescriptions": {
+                "Changed": "A discrete trigger condition is met whenever the metric value changes.",
+                "Specified": "A discrete trigger condition is met when the metric value becomes one of the values that the DiscreteTriggers property lists."
+            },
+            "longDescription": "This type shall specify the condition, in relationship to the discrete trigger values, which constitutes a trigger.",
+            "type": "string"
+        },
+        "Links": {
+            "additionalProperties": false,
+            "description": "The links to other resources that are related to this resource.",
+            "longDescription": "This Redfish Specification-described type shall contain links to resources that are related to but are not contained by, or subordinate to, this resource.",
+            "patternProperties": {
+                "^([a-zA-Z_][a-zA-Z0-9_]*)?@(odata|Redfish|Message)\\.[a-zA-Z_][a-zA-Z0-9_]*$": {
+                    "description": "This property shall specify a valid odata or Redfish property.",
+                    "type": [
+                        "array",
+                        "boolean",
+                        "integer",
+                        "number",
+                        "null",
+                        "object",
+                        "string"
+                    ]
+                }
+            },
+            "properties": {
+                "MetricReportDefinitions": {
+                    "description": "The metric report definitions that generate new metric reports when a trigger condition is met and when the TriggerActions property contains `RedfishMetricReport`.",
+                    "items": {
+                        "$ref": "http://redfish.dmtf.org/schemas/v1/MetricReportDefinition.json#/definitions/MetricReportDefinition"
+                    },
+                    "longDescription": "This property shall contain a set of links to metric report definitions that generate new metric reports when a trigger condition is met and when the TriggerActions property contains `RedfishMetricReport`.",
+                    "readonly": false,
+                    "type": "array",
+                    "versionAdded": "v1_1_0"
+                },
+                "MetricReportDefinitions@odata.count": {
+                    "$ref": "http://redfish.dmtf.org/schemas/v1/odata-v4.json#/definitions/count"
+                },
+                "Oem": {
+                    "$ref": "http://redfish.dmtf.org/schemas/v1/Resource.json#/definitions/Oem",
+                    "description": "The OEM extension property.",
+                    "longDescription": "This property shall contain the OEM extensions.  All values for properties contained in this object shall conform to the Redfish Specification-described requirements."
+                }
+            },
+            "type": "object"
+        },
+        "MetricTypeEnum": {
+            "description": "The type of metric for which the trigger is configured.",
+            "enum": [
+                "Numeric",
+                "Discrete"
+            ],
+            "enumDescriptions": {
+                "Discrete": "The trigger is for a discrete sensor.",
+                "Numeric": "The trigger is for numeric sensor."
+            },
+            "longDescription": "This type shall specify the type of metric for which the trigger is configured.",
+            "type": "string"
+        },
+        "OemActions": {
+            "additionalProperties": true,
+            "description": "The available OEM-specific actions for this resource.",
+            "longDescription": "This type shall contain the available OEM-specific actions for this resource.",
+            "patternProperties": {
+                "^([a-zA-Z_][a-zA-Z0-9_]*)?@(odata|Redfish|Message)\\.[a-zA-Z_][a-zA-Z0-9_]*$": {
+                    "description": "This property shall specify a valid odata or Redfish property.",
+                    "type": [
+                        "array",
+                        "boolean",
+                        "integer",
+                        "number",
+                        "null",
+                        "object",
+                        "string"
+                    ]
+                }
+            },
+            "properties": {},
+            "type": "object"
+        },
+        "Threshold": {
+            "additionalProperties": false,
+            "description": "A threshold definition for a sensor.",
+            "longDescription": "This type shall contain the properties for an individual threshold for this sensor.",
+            "patternProperties": {
+                "^([a-zA-Z_][a-zA-Z0-9_]*)?@(odata|Redfish|Message)\\.[a-zA-Z_][a-zA-Z0-9_]*$": {
+                    "description": "This property shall specify a valid odata or Redfish property.",
+                    "type": [
+                        "array",
+                        "boolean",
+                        "integer",
+                        "number",
+                        "null",
+                        "object",
+                        "string"
+                    ]
+                }
+            },
+            "properties": {
+                "Activation": {
+                    "anyOf": [
+                        {
+                            "$ref": "#/definitions/ThresholdActivation"
+                        },
+                        {
+                            "type": "null"
+                        }
+                    ],
+                    "description": "The direction of crossing that activates this threshold.",
+                    "longDescription": "This property shall indicate the direction of crossing of the reading for this sensor that activates the threshold.",
+                    "readonly": false
+                },
+                "DwellTime": {
+                    "description": "The duration the sensor value must violate the threshold before the threshold is activated.",
+                    "longDescription": "This property shall indicate the duration the sensor value violates the threshold before the threshold is activated.",
+                    "pattern": "-?P(\\d+D)?(T(\\d+H)?(\\d+M)?(\\d+(.\\d+)?S)?)?",
+                    "readonly": false,
+                    "type": [
+                        "string",
+                        "null"
+                    ]
+                },
+                "Reading": {
+                    "description": "The threshold value.",
+                    "longDescription": "This property shall indicate the reading for this sensor that activates the threshold.  The value of the property shall use the same units as the MetricProperties property.",
+                    "readonly": false,
+                    "type": [
+                        "number",
+                        "null"
+                    ]
+                }
+            },
+            "type": "object"
+        },
+        "ThresholdActivation": {
+            "enum": [
+                "Increasing",
+                "Decreasing",
+                "Either"
+            ],
+            "enumDescriptions": {
+                "Decreasing": "Value decreases below the threshold.",
+                "Either": "Value crosses the threshold in either direction.",
+                "Increasing": "Value increases above the threshold."
+            },
+            "enumLongDescriptions": {
+                "Decreasing": "This threshold is activated when the reading changes from a value higher than the threshold to a value lower than the threshold.",
+                "Either": "This threshold is activated when either the Increasing or Decreasing conditions are met.",
+                "Increasing": "This threshold is activated when the reading changes from a value lower than the threshold to a value higher than the threshold."
+            },
+            "type": "string"
+        },
+        "Thresholds": {
+            "additionalProperties": false,
+            "description": "The set of thresholds for a sensor.",
+            "longDescription": "This type shall contain a set of thresholds for a sensor.",
+            "patternProperties": {
+                "^([a-zA-Z_][a-zA-Z0-9_]*)?@(odata|Redfish|Message)\\.[a-zA-Z_][a-zA-Z0-9_]*$": {
+                    "description": "This property shall specify a valid odata or Redfish property.",
+                    "type": [
+                        "array",
+                        "boolean",
+                        "integer",
+                        "number",
+                        "null",
+                        "object",
+                        "string"
+                    ]
+                }
+            },
+            "properties": {
+                "LowerCritical": {
+                    "$ref": "#/definitions/Threshold",
+                    "description": "The value at which the reading is below normal range and requires attention.",
+                    "longDescription": "This property shall contain the value at which the MetricProperties property is below the normal range and may require attention.  The value of the property shall use the same units as the MetricProperties property."
+                },
+                "LowerWarning": {
+                    "$ref": "#/definitions/Threshold",
+                    "description": "The value at which the reading is below normal range.",
+                    "longDescription": "This property shall contain the value at which the MetricProperties property is below the normal range.  The value of the property shall use the same units as the MetricProperties property."
+                },
+                "UpperCritical": {
+                    "$ref": "#/definitions/Threshold",
+                    "description": "The value at which the reading is above normal range and requires attention.",
+                    "longDescription": "This property shall contain the value at which the MetricProperties property is above the normal range and may require attention.  The value of the property shall use the same units as the MetricProperties property."
+                },
+                "UpperWarning": {
+                    "$ref": "#/definitions/Threshold",
+                    "description": "The value at which the reading is above normal range.",
+                    "longDescription": "This property shall contain the value at which the MetricProperties property is above the normal range.  The value of the property shall use the same units as the MetricProperties property."
+                }
+            },
+            "type": "object"
+        },
+        "TriggerActionEnum": {
+            "description": "The actions to perform when a trigger condition is met.",
+            "enum": [
+                "LogToLogService",
+                "RedfishEvent",
+                "RedfishMetricReport"
+            ],
+            "enumDescriptions": {
+                "LogToLogService": "When a trigger condition is met, record in a log.",
+                "RedfishEvent": "When a trigger condition is met, the service sends an event to subscribers.",
+                "RedfishMetricReport": "When a trigger condition is met, force an update of the specified metric reports."
+            },
+            "enumLongDescriptions": {
+                "LogToLogService": "This value indicates that when a trigger condition is met, the service shall log the occurrence of the condition to the log that the LogService property in the telemetry service resource describes.",
+                "RedfishEvent": "This value indicates that when a trigger condition is met, the service shall send an event to subscribers.",
+                "RedfishMetricReport": "This value indicates that when a trigger condition is met, the service shall force the metric reports managed by the MetricReportDefinitions specified by the MetricReportDefinitions property to be updated, regardless of the MetricReportDefinitionType property value.  The actions specified in the ReportActions property of each MetricReportDefinition shall be performed."
+            },
+            "enumVersionAdded": {
+                "RedfishMetricReport": "v1_1_0"
+            },
+            "longDescription": "This type shall specify the actions to perform when a trigger condition is met.",
+            "type": "string"
+        },
+        "Triggers": {
+            "additionalProperties": false,
+            "description": "The Triggers schema describes a trigger that applies to metrics.",
+            "longDescription": "This resource shall contain a trigger that applies to metrics.",
+            "patternProperties": {
+                "^([a-zA-Z_][a-zA-Z0-9_]*)?@(odata|Redfish|Message)\\.[a-zA-Z_][a-zA-Z0-9_]*$": {
+                    "description": "This property shall specify a valid odata or Redfish property.",
+                    "type": [
+                        "array",
+                        "boolean",
+                        "integer",
+                        "number",
+                        "null",
+                        "object",
+                        "string"
+                    ]
+                }
+            },
+            "properties": {
+                "@odata.context": {
+                    "$ref": "http://redfish.dmtf.org/schemas/v1/odata-v4.json#/definitions/context"
+                },
+                "@odata.etag": {
+                    "$ref": "http://redfish.dmtf.org/schemas/v1/odata-v4.json#/definitions/etag"
+                },
+                "@odata.id": {
+                    "$ref": "http://redfish.dmtf.org/schemas/v1/odata-v4.json#/definitions/id"
+                },
+                "@odata.type": {
+                    "$ref": "http://redfish.dmtf.org/schemas/v1/odata-v4.json#/definitions/type"
+                },
+                "Actions": {
+                    "$ref": "#/definitions/Actions",
+                    "description": "The available actions for this resource.",
+                    "longDescription": "This property shall contain the available actions for this resource."
+                },
+                "Description": {
+                    "anyOf": [
+                        {
+                            "$ref": "http://redfish.dmtf.org/schemas/v1/Resource.json#/definitions/Description"
+                        },
+                        {
+                            "type": "null"
+                        }
+                    ],
+                    "readonly": true
+                },
+                "DiscreteTriggerCondition": {
+                    "anyOf": [
+                        {
+                            "$ref": "#/definitions/DiscreteTriggerConditionEnum"
+                        },
+                        {
+                            "type": "null"
+                        }
+                    ],
+                    "description": "The conditions when a discrete metric triggers.",
+                    "longDescription": "This property shall contain the conditions when a discrete metric triggers.",
+                    "readonly": true
+                },
+                "DiscreteTriggers": {
+                    "description": "The list of discrete triggers.",
+                    "items": {
+                        "$ref": "#/definitions/DiscreteTrigger"
+                    },
+                    "longDescription": "This property shall contain a list of values to which to compare a metric reading.  This property shall be present when the DiscreteTriggerCondition property is `Specified`.",
+                    "type": "array"
+                },
+                "EventTriggers": {
+                    "description": "The array of MessageIds that specify when a trigger condition is met based on an event.",
+                    "items": {
+                        "type": [
+                            "string",
+                            "null"
+                        ]
+                    },
+                    "longDescription": "This property shall contain an array of MessageIds that specify when a trigger condition is met based on an event.  When the service generates an event and if it contains a MessageId within this array, a trigger condition shall be met.  The MetricType property should not be present if this resource is configured for event-based triggers.",
+                    "pattern": "^[A-Za-z0-9]+\\.\\d+\\.\\d+\\.[A-Za-z0-9.]+$",
+                    "readonly": false,
+                    "type": "array",
+                    "versionAdded": "v1_1_0"
+                },
+                "Id": {
+                    "$ref": "http://redfish.dmtf.org/schemas/v1/Resource.json#/definitions/Id",
+                    "readonly": true
+                },
+                "Links": {
+                    "$ref": "#/definitions/Links",
+                    "description": "The links to other resources that are related to this resource.",
+                    "longDescription": "This property shall contain links to resources that are related to but are not contained by, or subordinate to, this resource.",
+                    "versionAdded": "v1_1_0"
+                },
+                "MetricIds": {
+                    "description": "The label for the metric definitions that contain the property identifiers for this trigger.  It matches the Id property of the corresponding metric definition.",
+                    "items": {
+                        "type": [
+                            "string",
+                            "null"
+                        ]
+                    },
+                    "longDescription": "This property shall contain the labels for the metric definitions that contain the property identifiers for this trigger.  This property shall match the value of the Id property of the corresponding metric definitions.",
+                    "readonly": false,
+                    "type": "array",
+                    "versionAdded": "v1_2_0"
+                },
+                "MetricProperties": {
+                    "description": "An array of URIs with wildcards and property identifiers for this trigger.  Each wildcard shall be replaced with its corresponding entry in the Wildcard array property.",
+                    "format": "uri-reference",
+                    "items": {
+                        "type": [
+                            "string",
+                            "null"
+                        ]
+                    },
+                    "longDescription": "This property shall contain an array of URIs with wildcards and property identifiers for this trigger.  Use a set of curly braces to delimit each wildcard in the URI.  Replace each wildcard with its corresponding entry in the Wildcard array property.  A URI that contains wildcards shall link to a resource property to which the metric definition applies after all wildcards are replaced with their corresponding entries in the Wildcard array property.  The property identifiers portion of the URI shall follow the RFC6901-defined JSON fragment notation rules.",
+                    "readonly": false,
+                    "type": "array"
+                },
+                "MetricType": {
+                    "anyOf": [
+                        {
+                            "$ref": "#/definitions/MetricTypeEnum"
+                        },
+                        {
+                            "type": "null"
+                        }
+                    ],
+                    "description": "The metric type of the trigger.",
+                    "longDescription": "This property shall contain the metric type of the trigger.",
+                    "readonly": true
+                },
+                "Name": {
+                    "$ref": "http://redfish.dmtf.org/schemas/v1/Resource.json#/definitions/Name",
+                    "readonly": true
+                },
+                "NumericThresholds": {
+                    "$ref": "#/definitions/Thresholds",
+                    "description": "The thresholds when a numeric metric triggers.",
+                    "longDescription": "This property shall contain the list of thresholds to which to compare a numeric metric value."
+                },
+                "Oem": {
+                    "$ref": "http://redfish.dmtf.org/schemas/v1/Resource.json#/definitions/Oem",
+                    "description": "The OEM extension property.",
+                    "longDescription": "This property shall contain the OEM extensions.  All values for properties that this object contains shall conform to the Redfish Specification-described requirements."
+                },
+                "Status": {
+                    "$ref": "http://redfish.dmtf.org/schemas/v1/Resource.json#/definitions/Status",
+                    "description": "The status and health of the resource and its subordinate or dependent resources.",
+                    "longDescription": "This property shall contain any status or health properties of the resource."
+                },
+                "TriggerActions": {
+                    "description": "The actions that the trigger initiates.",
+                    "items": {
+                        "$ref": "#/definitions/TriggerActionEnum"
+                    },
+                    "longDescription": "This property shall contain the actions that the trigger initiates.",
+                    "readonly": true,
+                    "type": "array"
+                },
+                "Wildcards": {
+                    "description": "The wildcards and their substitution values for the entries in the MetricProperties array property.",
+                    "items": {
+                        "$ref": "#/definitions/Wildcard"
+                    },
+                    "longDescription": "This property shall contain the wildcards and their substitution values for the entries in the MetricProperties array property.  Each wildcard shall have a corresponding entry in this array property.",
+                    "type": "array"
+                }
+            },
+            "required": [
+                "@odata.id",
+                "@odata.type",
+                "Id",
+                "Name"
+            ],
+            "type": "object"
+        },
+        "Wildcard": {
+            "additionalProperties": false,
+            "description": "The wildcard and its substitution values.",
+            "longDescription": "This property shall contain a wildcard and its substitution values.",
+            "patternProperties": {
+                "^([a-zA-Z_][a-zA-Z0-9_]*)?@(odata|Redfish|Message)\\.[a-zA-Z_][a-zA-Z0-9_]*$": {
+                    "description": "This property shall specify a valid odata or Redfish property.",
+                    "type": [
+                        "array",
+                        "boolean",
+                        "integer",
+                        "number",
+                        "null",
+                        "object",
+                        "string"
+                    ]
+                }
+            },
+            "properties": {
+                "Name": {
+                    "description": "The wildcard.",
+                    "longDescription": "This property shall contain the string used as a wildcard.",
+                    "readonly": true,
+                    "type": [
+                        "string",
+                        "null"
+                    ]
+                },
+                "Values": {
+                    "description": "An array of values to substitute for the wildcard.",
+                    "items": {
+                        "type": [
+                            "string",
+                            "null"
+                        ]
+                    },
+                    "longDescription": "This array property shall contain the list of values to substitute for the wildcard.",
+                    "readonly": true,
+                    "type": "array"
+                }
+            },
+            "type": "object"
+        }
+    },
+    "owningEntity": "DMTF",
+    "release": "2021.2",
+    "title": "#Triggers.v1_2_0.Triggers"
+}

--- a/static/redfish/v1/JsonSchemas/Triggers/index.json
+++ b/static/redfish/v1/JsonSchemas/Triggers/index.json
@@ -1,0 +1,21 @@
+{
+    "@odata.context": "/redfish/v1/$metadata#JsonSchemaFile.JsonSchemaFile",
+    "@odata.id": "/redfish/v1/JsonSchemas/Triggers",
+    "@odata.type": "#JsonSchemaFile.v1_0_2.JsonSchemaFile",
+    "Name": "Triggers Schema File",
+    "Schema": "#Triggers.Triggers",
+    "Description": "Triggers Schema File Location",
+    "Id": "Triggers",
+    "Languages": [
+        "en"
+    ],
+    "Languages@odata.count": 1,
+    "Location": [
+        {
+            "Language": "en",
+            "PublicationUri": "http://redfish.dmtf.org/schemas/v1/Triggers.json",
+            "Uri": "/redfish/v1/JsonSchemas/Triggers/Triggers.json"
+        }
+    ],
+    "Location@odata.count": 1
+}

--- a/static/redfish/v1/JsonSchemas/USBController/USBController.json
+++ b/static/redfish/v1/JsonSchemas/USBController/USBController.json
@@ -1,0 +1,249 @@
+{
+    "$id": "http://redfish.dmtf.org/schemas/v1/USBController.v1_0_0.json",
+    "$ref": "#/definitions/USBController",
+    "$schema": "http://redfish.dmtf.org/schemas/v1/redfish-schema-v1.json",
+    "copyright": "Copyright 2014-2021 DMTF. For the full DMTF copyright policy, see http://www.dmtf.org/about/policies/copyright",
+    "definitions": {
+        "Actions": {
+            "additionalProperties": false,
+            "description": "The available actions for this resource.",
+            "longDescription": "This type shall contain the available actions for this resource.",
+            "patternProperties": {
+                "^([a-zA-Z_][a-zA-Z0-9_]*)?@(odata|Redfish|Message)\\.[a-zA-Z_][a-zA-Z0-9_]*$": {
+                    "description": "This property shall specify a valid odata or Redfish property.",
+                    "type": [
+                        "array",
+                        "boolean",
+                        "integer",
+                        "number",
+                        "null",
+                        "object",
+                        "string"
+                    ]
+                }
+            },
+            "properties": {
+                "Oem": {
+                    "$ref": "#/definitions/OemActions",
+                    "description": "The available OEM-specific actions for this resource.",
+                    "longDescription": "This property shall contain the available OEM-specific actions for this resource."
+                }
+            },
+            "type": "object"
+        },
+        "Links": {
+            "additionalProperties": false,
+            "description": "The links to other resources that are related to this resource.",
+            "longDescription": "This Redfish Specification-described type shall contain links to resources that are related to but are not contained by, or subordinate to, this resource.",
+            "patternProperties": {
+                "^([a-zA-Z_][a-zA-Z0-9_]*)?@(odata|Redfish|Message)\\.[a-zA-Z_][a-zA-Z0-9_]*$": {
+                    "description": "This property shall specify a valid odata or Redfish property.",
+                    "type": [
+                        "array",
+                        "boolean",
+                        "integer",
+                        "number",
+                        "null",
+                        "object",
+                        "string"
+                    ]
+                }
+            },
+            "properties": {
+                "Oem": {
+                    "$ref": "http://redfish.dmtf.org/schemas/v1/Resource.json#/definitions/Oem",
+                    "description": "The OEM extension property.",
+                    "longDescription": "This property shall contain the OEM extensions.  All values for properties contained in this object shall conform to the Redfish Specification-described requirements."
+                },
+                "PCIeDevice": {
+                    "anyOf": [
+                        {
+                            "$ref": "http://redfish.dmtf.org/schemas/v1/PCIeDevice.json#/definitions/PCIeDevice"
+                        },
+                        {
+                            "type": "null"
+                        }
+                    ],
+                    "description": "A link to the PCIe device that represents this USB controller.",
+                    "longDescription": "This property shall contain a link to a resource of type PCIeDevice that represents this USB controller.",
+                    "readonly": true
+                },
+                "Processors": {
+                    "description": "An array of links to the processors that can utilize this USB controller.",
+                    "items": {
+                        "$ref": "http://redfish.dmtf.org/schemas/v1/Processor.json#/definitions/Processor"
+                    },
+                    "longDescription": "This property shall contain an array of links to resources of type Processor that represent processors that can utilize this USB controller.",
+                    "readonly": true,
+                    "type": "array"
+                },
+                "Processors@odata.count": {
+                    "$ref": "http://redfish.dmtf.org/schemas/v1/odata-v4.json#/definitions/count"
+                }
+            },
+            "type": "object"
+        },
+        "OemActions": {
+            "additionalProperties": true,
+            "description": "The available OEM-specific actions for this resource.",
+            "longDescription": "This type shall contain the available OEM-specific actions for this resource.",
+            "patternProperties": {
+                "^([a-zA-Z_][a-zA-Z0-9_]*)?@(odata|Redfish|Message)\\.[a-zA-Z_][a-zA-Z0-9_]*$": {
+                    "description": "This property shall specify a valid odata or Redfish property.",
+                    "type": [
+                        "array",
+                        "boolean",
+                        "integer",
+                        "number",
+                        "null",
+                        "object",
+                        "string"
+                    ]
+                }
+            },
+            "properties": {},
+            "type": "object"
+        },
+        "USBController": {
+            "additionalProperties": false,
+            "description": "The USBController schema defines a Universal Serial Bus controller.",
+            "longDescription": "This resource shall represent a USB controller in a Redfish implementation.",
+            "patternProperties": {
+                "^([a-zA-Z_][a-zA-Z0-9_]*)?@(odata|Redfish|Message)\\.[a-zA-Z_][a-zA-Z0-9_]*$": {
+                    "description": "This property shall specify a valid odata or Redfish property.",
+                    "type": [
+                        "array",
+                        "boolean",
+                        "integer",
+                        "number",
+                        "null",
+                        "object",
+                        "string"
+                    ]
+                }
+            },
+            "properties": {
+                "@odata.context": {
+                    "$ref": "http://redfish.dmtf.org/schemas/v1/odata-v4.json#/definitions/context"
+                },
+                "@odata.etag": {
+                    "$ref": "http://redfish.dmtf.org/schemas/v1/odata-v4.json#/definitions/etag"
+                },
+                "@odata.id": {
+                    "$ref": "http://redfish.dmtf.org/schemas/v1/odata-v4.json#/definitions/id"
+                },
+                "@odata.type": {
+                    "$ref": "http://redfish.dmtf.org/schemas/v1/odata-v4.json#/definitions/type"
+                },
+                "Actions": {
+                    "$ref": "#/definitions/Actions",
+                    "description": "The available actions for this resource.",
+                    "longDescription": "This property shall contain the available actions for this resource."
+                },
+                "Description": {
+                    "anyOf": [
+                        {
+                            "$ref": "http://redfish.dmtf.org/schemas/v1/Resource.json#/definitions/Description"
+                        },
+                        {
+                            "type": "null"
+                        }
+                    ],
+                    "readonly": true
+                },
+                "Id": {
+                    "$ref": "http://redfish.dmtf.org/schemas/v1/Resource.json#/definitions/Id",
+                    "readonly": true
+                },
+                "Links": {
+                    "$ref": "#/definitions/Links",
+                    "description": "The links to other resources that are related to this resource.",
+                    "longDescription": "This property shall contain links to resources that are related to but are not contained by, or subordinate to, this resource."
+                },
+                "Manufacturer": {
+                    "description": "The manufacturer of this USB controller.",
+                    "longDescription": "This property shall contain the name of the organization responsible for producing the USB controller.  This organization may be the entity from which the USB controller is purchased, but this is not necessarily true.",
+                    "readonly": true,
+                    "type": [
+                        "string",
+                        "null"
+                    ]
+                },
+                "Model": {
+                    "description": "The product model number of this USB controller.",
+                    "longDescription": "This property shall contain the manufacturer-provided model information of this USB controller.",
+                    "readonly": true,
+                    "type": [
+                        "string",
+                        "null"
+                    ]
+                },
+                "Name": {
+                    "$ref": "http://redfish.dmtf.org/schemas/v1/Resource.json#/definitions/Name",
+                    "readonly": true
+                },
+                "Oem": {
+                    "$ref": "http://redfish.dmtf.org/schemas/v1/Resource.json#/definitions/Oem",
+                    "description": "The OEM extension property.",
+                    "longDescription": "This property shall contain the OEM extensions.  All values for properties that this object contains shall conform to the Redfish Specification-described requirements."
+                },
+                "PartNumber": {
+                    "description": "The part number for this USB controller.",
+                    "longDescription": "This property shall contain the manufacturer-provided part number for the USB controller.",
+                    "readonly": true,
+                    "type": [
+                        "string",
+                        "null"
+                    ]
+                },
+                "Ports": {
+                    "$ref": "http://redfish.dmtf.org/schemas/v1/PortCollection.json#/definitions/PortCollection",
+                    "description": "The ports of the USB controller.",
+                    "longDescription": "This property shall contain a link to a resource collection of type PortCollection."
+                },
+                "SKU": {
+                    "description": "The SKU for this USB controller.",
+                    "longDescription": "This property shall contain the SKU number for this USB controller.",
+                    "readonly": true,
+                    "type": [
+                        "string",
+                        "null"
+                    ]
+                },
+                "SerialNumber": {
+                    "description": "The serial number for this USB controller.",
+                    "longDescription": "This property shall contain a manufacturer-allocated number that identifies the USB controller.",
+                    "readonly": true,
+                    "type": [
+                        "string",
+                        "null"
+                    ]
+                },
+                "SparePartNumber": {
+                    "description": "The spare part number of the USB controller.",
+                    "longDescription": "This property shall contain the spare part number of the USB controller.",
+                    "readonly": true,
+                    "type": [
+                        "string",
+                        "null"
+                    ]
+                },
+                "Status": {
+                    "$ref": "http://redfish.dmtf.org/schemas/v1/Resource.json#/definitions/Status",
+                    "description": "The status and health of the resource and its subordinate or dependent resources.",
+                    "longDescription": "This property shall contain any status or health properties of the resource."
+                }
+            },
+            "required": [
+                "@odata.id",
+                "@odata.type",
+                "Id",
+                "Name"
+            ],
+            "type": "object"
+        }
+    },
+    "owningEntity": "DMTF",
+    "release": "2021.1",
+    "title": "#USBController.v1_0_0.USBController"
+}

--- a/static/redfish/v1/JsonSchemas/USBController/index.json
+++ b/static/redfish/v1/JsonSchemas/USBController/index.json
@@ -1,0 +1,21 @@
+{
+    "@odata.context": "/redfish/v1/$metadata#JsonSchemaFile.JsonSchemaFile",
+    "@odata.id": "/redfish/v1/JsonSchemas/USBController",
+    "@odata.type": "#JsonSchemaFile.v1_0_2.JsonSchemaFile",
+    "Name": "USBController Schema File",
+    "Schema": "#USBController.USBController",
+    "Description": "USBController Schema File Location",
+    "Id": "USBController",
+    "Languages": [
+        "en"
+    ],
+    "Languages@odata.count": 1,
+    "Location": [
+        {
+            "Language": "en",
+            "PublicationUri": "http://redfish.dmtf.org/schemas/v1/USBController.json",
+            "Uri": "/redfish/v1/JsonSchemas/USBController/USBController.json"
+        }
+    ],
+    "Location@odata.count": 1
+}

--- a/static/redfish/v1/JsonSchemas/VCATEntry/VCATEntry.json
+++ b/static/redfish/v1/JsonSchemas/VCATEntry/VCATEntry.json
@@ -1,0 +1,188 @@
+{
+    "$id": "http://redfish.dmtf.org/schemas/v1/VCATEntry.v1_0_1.json",
+    "$ref": "#/definitions/VCATEntry",
+    "$schema": "http://redfish.dmtf.org/schemas/v1/redfish-schema-v1.json",
+    "copyright": "Copyright 2014-2020 DMTF. For the full DMTF copyright policy, see http://www.dmtf.org/about/policies/copyright",
+    "definitions": {
+        "Actions": {
+            "additionalProperties": false,
+            "description": "The available actions for this resource.",
+            "longDescription": "This type shall contain the available actions for this resource.",
+            "patternProperties": {
+                "^([a-zA-Z_][a-zA-Z0-9_]*)?@(odata|Redfish|Message)\\.[a-zA-Z_][a-zA-Z0-9_]*$": {
+                    "description": "This property shall specify a valid odata or Redfish property.",
+                    "type": [
+                        "array",
+                        "boolean",
+                        "integer",
+                        "number",
+                        "null",
+                        "object",
+                        "string"
+                    ]
+                }
+            },
+            "properties": {
+                "Oem": {
+                    "$ref": "#/definitions/OemActions",
+                    "description": "The available OEM-specific actions for this resource.",
+                    "longDescription": "This property shall contain the available OEM-specific actions for this resource."
+                }
+            },
+            "type": "object"
+        },
+        "OemActions": {
+            "additionalProperties": true,
+            "description": "The available OEM-specific actions for this resource.",
+            "longDescription": "This type shall contain the available OEM-specific actions for this resource.",
+            "patternProperties": {
+                "^([a-zA-Z_][a-zA-Z0-9_]*)?@(odata|Redfish|Message)\\.[a-zA-Z_][a-zA-Z0-9_]*$": {
+                    "description": "This property shall specify a valid odata or Redfish property.",
+                    "type": [
+                        "array",
+                        "boolean",
+                        "integer",
+                        "number",
+                        "null",
+                        "object",
+                        "string"
+                    ]
+                }
+            },
+            "properties": {},
+            "type": "object"
+        },
+        "VCATEntry": {
+            "additionalProperties": false,
+            "description": "The VCATEntry schema defines an entry in a Virtual Channel Action Table.  A Virtual Channel is a mechanism used to create multiple, logical communication streams across a physical link.",
+            "longDescription": "This resource shall represent and entry of Virtual Channel Action Table in a Redfish implementation.",
+            "patternProperties": {
+                "^([a-zA-Z_][a-zA-Z0-9_]*)?@(odata|Redfish|Message)\\.[a-zA-Z_][a-zA-Z0-9_]*$": {
+                    "description": "This property shall specify a valid odata or Redfish property.",
+                    "type": [
+                        "array",
+                        "boolean",
+                        "integer",
+                        "number",
+                        "null",
+                        "object",
+                        "string"
+                    ]
+                }
+            },
+            "properties": {
+                "@odata.context": {
+                    "$ref": "http://redfish.dmtf.org/schemas/v1/odata-v4.json#/definitions/context"
+                },
+                "@odata.etag": {
+                    "$ref": "http://redfish.dmtf.org/schemas/v1/odata-v4.json#/definitions/etag"
+                },
+                "@odata.id": {
+                    "$ref": "http://redfish.dmtf.org/schemas/v1/odata-v4.json#/definitions/id"
+                },
+                "@odata.type": {
+                    "$ref": "http://redfish.dmtf.org/schemas/v1/odata-v4.json#/definitions/type"
+                },
+                "Actions": {
+                    "$ref": "#/definitions/Actions",
+                    "description": "The available actions for this resource.",
+                    "longDescription": "This property shall contain the available actions for this resource."
+                },
+                "Description": {
+                    "anyOf": [
+                        {
+                            "$ref": "http://redfish.dmtf.org/schemas/v1/Resource.json#/definitions/Description"
+                        },
+                        {
+                            "type": "null"
+                        }
+                    ],
+                    "readonly": true
+                },
+                "Id": {
+                    "$ref": "http://redfish.dmtf.org/schemas/v1/Resource.json#/definitions/Id",
+                    "readonly": true
+                },
+                "Name": {
+                    "$ref": "http://redfish.dmtf.org/schemas/v1/Resource.json#/definitions/Name",
+                    "readonly": true
+                },
+                "Oem": {
+                    "$ref": "http://redfish.dmtf.org/schemas/v1/Resource.json#/definitions/Oem",
+                    "description": "The OEM extension property.",
+                    "longDescription": "This property shall contain the OEM extensions.  All values for properties that this object contains shall conform to the Redfish Specification-described requirements."
+                },
+                "RawEntryHex": {
+                    "description": "The hexadecimal value of the Virtual Channel Action Table entries.",
+                    "longDescription": "This property shall contain the hexadecimal value of the Virtual Channel Action Table entries.  The length of hexadecimal value depends on the number of Virtual Channel Action entries supported by the component.",
+                    "pattern": "^0[xX](([a-fA-F]|[0-9])*)$",
+                    "readonly": false,
+                    "type": [
+                        "string",
+                        "null"
+                    ]
+                },
+                "VCEntries": {
+                    "description": "An array of entries of the Virtual Channel Action Table.",
+                    "items": {
+                        "$ref": "#/definitions/VCATableEntry"
+                    },
+                    "longDescription": "This property shall contain an array of entries of the Virtual Channel Action Table.  The length of the array depends on the number of Virtual Channel Action entries supported by the component.",
+                    "type": "array"
+                }
+            },
+            "required": [
+                "@odata.id",
+                "@odata.type",
+                "Id",
+                "Name"
+            ],
+            "type": "object"
+        },
+        "VCATableEntry": {
+            "additionalProperties": false,
+            "description": "The Virtual Channel Action Table entry corresponding to a specific Virtual Channel.",
+            "longDescription": "This type shall contain a Virtual Channel entry definition that describes a specific Virtual Channel.",
+            "patternProperties": {
+                "^([a-zA-Z_][a-zA-Z0-9_]*)?@(odata|Redfish|Message)\\.[a-zA-Z_][a-zA-Z0-9_]*$": {
+                    "description": "This property shall specify a valid odata or Redfish property.",
+                    "type": [
+                        "array",
+                        "boolean",
+                        "integer",
+                        "number",
+                        "null",
+                        "object",
+                        "string"
+                    ]
+                }
+            },
+            "properties": {
+                "Threshold": {
+                    "description": "The configured threshold.",
+                    "longDescription": "This property shall contain the Gen-Z Core Specification-defined 'TH' 7-bit threshold.",
+                    "pattern": "^0[xX]([a-fA-F]|[0-9]){2}$",
+                    "readonly": false,
+                    "type": [
+                        "string",
+                        "null"
+                    ]
+                },
+                "VCMask": {
+                    "description": "The bits corresponding to the supported Virtual Channel.",
+                    "longDescription": "This property shall contain a 32-bit value where the bits correspond to a supported Virtual Channel.",
+                    "pattern": "^0[xX](([a-fA-F]|[0-9]){2}){4}$",
+                    "readonly": false,
+                    "type": [
+                        "string",
+                        "null"
+                    ]
+                }
+            },
+            "type": "object"
+        }
+    },
+    "owningEntity": "DMTF",
+    "release": "2019.4",
+    "title": "#VCATEntry.v1_0_1.VCATEntry"
+}

--- a/static/redfish/v1/JsonSchemas/VCATEntry/index.json
+++ b/static/redfish/v1/JsonSchemas/VCATEntry/index.json
@@ -1,0 +1,21 @@
+{
+    "@odata.context": "/redfish/v1/$metadata#JsonSchemaFile.JsonSchemaFile",
+    "@odata.id": "/redfish/v1/JsonSchemas/VCATEntry",
+    "@odata.type": "#JsonSchemaFile.v1_0_2.JsonSchemaFile",
+    "Name": "VCATEntry Schema File",
+    "Schema": "#VCATEntry.VCATEntry",
+    "Description": "VCATEntry Schema File Location",
+    "Id": "VCATEntry",
+    "Languages": [
+        "en"
+    ],
+    "Languages@odata.count": 1,
+    "Location": [
+        {
+            "Language": "en",
+            "PublicationUri": "http://redfish.dmtf.org/schemas/v1/VCATEntry.json",
+            "Uri": "/redfish/v1/JsonSchemas/VCATEntry/VCATEntry.json"
+        }
+    ],
+    "Location@odata.count": 1
+}

--- a/static/redfish/v1/JsonSchemas/Volume/Volume.json
+++ b/static/redfish/v1/JsonSchemas/Volume/Volume.json
@@ -1,0 +1,1441 @@
+{
+    "$id": "http://redfish.dmtf.org/schemas/swordfish/v1/Volume.v1_6_2.json",
+    "$ref": "#/definitions/Volume",
+    "$schema": "http://redfish.dmtf.org/schemas/v1/redfish-schema-v1.json",
+    "copyright": "Copyright 2016-2020 Storage Networking Industry Association (SNIA), USA. All rights reserved. For the full SNIA copyright policy, see http://www.snia.org/about/corporate_info/copyright",
+    "definitions": {
+        "Actions": {
+            "additionalProperties": false,
+            "patternProperties": {
+                "^([a-zA-Z_][a-zA-Z0-9_]*)?@(odata|Redfish|Message)\\.[a-zA-Z_][a-zA-Z0-9_]*$": {
+                    "description": "This property shall specify a valid odata or Redfish property.",
+                    "type": [
+                        "array",
+                        "boolean",
+                        "integer",
+                        "number",
+                        "null",
+                        "object",
+                        "string"
+                    ]
+                }
+            },
+            "properties": {
+                "#Volume.AssignReplicaTarget": {
+                    "$ref": "#/definitions/AssignReplicaTarget"
+                },
+                "#Volume.ChangeRAIDLayout": {
+                    "$ref": "#/definitions/ChangeRAIDLayout"
+                },
+                "#Volume.CheckConsistency": {
+                    "$ref": "#/definitions/CheckConsistency"
+                },
+                "#Volume.CreateReplicaTarget": {
+                    "$ref": "#/definitions/CreateReplicaTarget"
+                },
+                "#Volume.ForceEnable": {
+                    "$ref": "#/definitions/ForceEnable"
+                },
+                "#Volume.Initialize": {
+                    "$ref": "#/definitions/Initialize"
+                },
+                "#Volume.RemoveReplicaRelationship": {
+                    "$ref": "#/definitions/RemoveReplicaRelationship"
+                },
+                "#Volume.ResumeReplication": {
+                    "$ref": "#/definitions/ResumeReplication"
+                },
+                "#Volume.ReverseReplicationRelationship": {
+                    "$ref": "#/definitions/ReverseReplicationRelationship"
+                },
+                "#Volume.SplitReplication": {
+                    "$ref": "#/definitions/SplitReplication"
+                },
+                "#Volume.SuspendReplication": {
+                    "$ref": "#/definitions/SuspendReplication"
+                },
+                "Oem": {
+                    "$ref": "#/definitions/OemActions"
+                }
+            },
+            "type": "object"
+        },
+        "AssignReplicaTarget": {
+            "additionalProperties": false,
+            "description": "This action is used to establish a replication relationship by assigning an existing volume to serve as a target replica for an existing source volume.",
+            "longDescription": "This action shall be used to establish a replication relationship by assigning an existing volume to serve as a target replica for an existing source volume.",
+            "parameters": {
+                "ReplicaType": {
+                    "$ref": "http://redfish.dmtf.org/schemas/swordfish/v1/StorageReplicaInfo.json#/definitions/ReplicaType",
+                    "description": "The type of replica relationship to be created.",
+                    "longDescription": "This parameter shall contain the type of replica relationship to be created (e.g., Clone, Mirror, Snap).",
+                    "requiredParameter": true
+                },
+                "ReplicaUpdateMode": {
+                    "$ref": "http://redfish.dmtf.org/schemas/swordfish/v1/StorageReplicaInfo.json#/definitions/ReplicaUpdateMode",
+                    "description": "The replica update mode (synchronous vs asynchronous).",
+                    "longDescription": "This parameter shall specify the replica update mode.",
+                    "requiredParameter": true
+                },
+                "TargetVolume": {
+                    "description": "The Uri to the existing target volume.",
+                    "longDescription": "This parameter shall contain the Uri to the existing target volume.",
+                    "requiredParameter": true,
+                    "type": "string"
+                }
+            },
+            "patternProperties": {
+                "^([a-zA-Z_][a-zA-Z0-9_]*)?@(odata|Redfish|Message)\\.[a-zA-Z_][a-zA-Z0-9_]*$": {
+                    "description": "This property shall specify a valid odata or Redfish property.",
+                    "type": [
+                        "array",
+                        "boolean",
+                        "integer",
+                        "number",
+                        "null",
+                        "object",
+                        "string"
+                    ]
+                }
+            },
+            "properties": {
+                "target": {
+                    "description": "Link to invoke action",
+                    "format": "uri-reference",
+                    "type": "string"
+                },
+                "title": {
+                    "description": "Friendly action name",
+                    "type": "string"
+                }
+            },
+            "type": "object",
+            "versionAdded": "v1_4_0"
+        },
+        "ChangeRAIDLayout": {
+            "additionalProperties": false,
+            "description": "Request system change the RAID layout of the volume.",
+            "longDescription": "This action shall request the system to change the RAID layout of the volume.  Depending on the combination of the submitted parameters, this could be changing the RAID type, changing the span count, changing the number of drives used by the volume, or another configuration change supported by the system. Note that usage of this action while online may potentially cause data loss if the available capacity is reduced.",
+            "parameters": {
+                "Drives": {
+                    "description": "An array of the drives to be used by the volume.",
+                    "items": {
+                        "$ref": "http://redfish.dmtf.org/schemas/v1/Drive.json#/definitions/Drive"
+                    },
+                    "longDescription": "This parameter shall contain an array of the drives to be used by the volume.",
+                    "type": "array"
+                },
+                "MediaSpanCount": {
+                    "description": "The requested number of media elements used per span in the secondary RAID for a hierarchical RAID type.",
+                    "longDescription": "This parameter shall contain the requested number of media elements used per span in the secondary RAID for a hierarchical RAID type.",
+                    "type": "integer"
+                },
+                "RAIDType": {
+                    "$ref": "http://redfish.dmtf.org/schemas/swordfish/v1/Volume.json#/definitions/RAIDType",
+                    "description": "The requested RAID type for the volume.",
+                    "longDescription": "This parameter shall contain the requested RAID type for the volume."
+                },
+                "StripSizeBytes": {
+                    "description": "The number of blocks (bytes) requested for new strip size.",
+                    "longDescription": "This parameter shall contain the number of blocks (bytes) requested for the strip size.",
+                    "type": "integer"
+                }
+            },
+            "patternProperties": {
+                "^([a-zA-Z_][a-zA-Z0-9_]*)?@(odata|Redfish|Message)\\.[a-zA-Z_][a-zA-Z0-9_]*$": {
+                    "description": "This property shall specify a valid odata or Redfish property.",
+                    "type": [
+                        "array",
+                        "boolean",
+                        "integer",
+                        "number",
+                        "null",
+                        "object",
+                        "string"
+                    ]
+                }
+            },
+            "properties": {
+                "target": {
+                    "description": "Link to invoke action",
+                    "format": "uri-reference",
+                    "type": "string"
+                },
+                "title": {
+                    "description": "Friendly action name",
+                    "type": "string"
+                }
+            },
+            "type": "object",
+            "versionAdded": "v1_5_0"
+        },
+        "CheckConsistency": {
+            "additionalProperties": false,
+            "description": "This action is used to force a check of the Volume's parity or redundant data to ensure it matches calculated values.",
+            "longDescription": "This defines the name of the custom action supported on this resource.",
+            "parameters": {},
+            "patternProperties": {
+                "^([a-zA-Z_][a-zA-Z0-9_]*)?@(odata|Redfish|Message)\\.[a-zA-Z_][a-zA-Z0-9_]*$": {
+                    "description": "This property shall specify a valid odata or Redfish property.",
+                    "type": [
+                        "array",
+                        "boolean",
+                        "integer",
+                        "number",
+                        "null",
+                        "object",
+                        "string"
+                    ]
+                }
+            },
+            "properties": {
+                "target": {
+                    "description": "Link to invoke action",
+                    "format": "uri-reference",
+                    "type": "string"
+                },
+                "title": {
+                    "description": "Friendly action name",
+                    "type": "string"
+                }
+            },
+            "type": "object"
+        },
+        "CreateReplicaTarget": {
+            "additionalProperties": false,
+            "description": "This action is used to create a new volume resource to provide expanded data protection through a replica relationship with the specified source volume.",
+            "longDescription": "This action shall be used to create a new volume resource to provide expanded data protection through a replica relationship with the specified source volume.",
+            "parameters": {
+                "ReplicaType": {
+                    "$ref": "http://redfish.dmtf.org/schemas/swordfish/v1/StorageReplicaInfo.json#/definitions/ReplicaType",
+                    "description": "The type of replica relationship to be created.",
+                    "longDescription": "This parameter shall contain the type of replica relationship to be created (e.g., Clone, Mirror, Snap).",
+                    "requiredParameter": true
+                },
+                "ReplicaUpdateMode": {
+                    "$ref": "http://redfish.dmtf.org/schemas/swordfish/v1/StorageReplicaInfo.json#/definitions/ReplicaUpdateMode",
+                    "description": "The replica update mode (synchronous vs asynchronous).",
+                    "longDescription": "This parameter shall specify the replica update mode.",
+                    "requiredParameter": true
+                },
+                "TargetStoragePool": {
+                    "description": "The Uri to the existing target Storage Pool.",
+                    "longDescription": "This parameter shall contain the Uri to the existing StoragePool in which to create the target volume.",
+                    "requiredParameter": true,
+                    "type": "string"
+                },
+                "VolumeName": {
+                    "description": "The Name for the new target volume.",
+                    "longDescription": "This parameter shall contain the Name for the target volume.",
+                    "type": "string"
+                }
+            },
+            "patternProperties": {
+                "^([a-zA-Z_][a-zA-Z0-9_]*)?@(odata|Redfish|Message)\\.[a-zA-Z_][a-zA-Z0-9_]*$": {
+                    "description": "This property shall specify a valid odata or Redfish property.",
+                    "type": [
+                        "array",
+                        "boolean",
+                        "integer",
+                        "number",
+                        "null",
+                        "object",
+                        "string"
+                    ]
+                }
+            },
+            "properties": {
+                "target": {
+                    "description": "Link to invoke action",
+                    "format": "uri-reference",
+                    "type": "string"
+                },
+                "title": {
+                    "description": "Friendly action name",
+                    "type": "string"
+                }
+            },
+            "type": "object",
+            "versionAdded": "v1_4_0"
+        },
+        "ForceEnable": {
+            "additionalProperties": false,
+            "description": "Request system force the volume to an enabled state regardless of data loss.",
+            "longDescription": "This action shall request the system to force the volume to enabled state regardless of data loss scenarios.",
+            "parameters": {},
+            "patternProperties": {
+                "^([a-zA-Z_][a-zA-Z0-9_]*)?@(odata|Redfish|Message)\\.[a-zA-Z_][a-zA-Z0-9_]*$": {
+                    "description": "This property shall specify a valid odata or Redfish property.",
+                    "type": [
+                        "array",
+                        "boolean",
+                        "integer",
+                        "number",
+                        "null",
+                        "object",
+                        "string"
+                    ]
+                }
+            },
+            "properties": {
+                "target": {
+                    "description": "Link to invoke action",
+                    "format": "uri-reference",
+                    "type": "string"
+                },
+                "title": {
+                    "description": "Friendly action name",
+                    "type": "string"
+                }
+            },
+            "type": "object",
+            "versionAdded": "v1_5_0"
+        },
+        "Initialize": {
+            "additionalProperties": false,
+            "description": "This action is used to prepare the contents of the volume for use by the system. If InitializeMethod is not specified in the request body, but the property InitializeMethod is specified, the property InitializeMethod value should be used. If neither is specified, the InitializeMethod should be Foreground.",
+            "longDescription": "This defines the name of the custom action supported on this resource. If InitializeMethod is not specified in the request body, but the property InitializeMethod is specified, the property InitializeMethod value should be used. If neither is specified, the InitializeMethod should be Foreground.",
+            "parameters": {
+                "InitializeMethod": {
+                    "$ref": "http://redfish.dmtf.org/schemas/swordfish/v1/Volume.json#/definitions/InitializeMethod",
+                    "description": "The type of initialization to be performed.",
+                    "longDescription": "This defines the property name for the action."
+                },
+                "InitializeType": {
+                    "$ref": "http://redfish.dmtf.org/schemas/swordfish/v1/Volume.json#/definitions/InitializeType",
+                    "deprecated": "Deprecated in favor of the InitializeMethod property.",
+                    "description": "The type of initialization to be performed.",
+                    "longDescription": "This defines the property name for the action."
+                }
+            },
+            "patternProperties": {
+                "^([a-zA-Z_][a-zA-Z0-9_]*)?@(odata|Redfish|Message)\\.[a-zA-Z_][a-zA-Z0-9_]*$": {
+                    "description": "This property shall specify a valid odata or Redfish property.",
+                    "type": [
+                        "array",
+                        "boolean",
+                        "integer",
+                        "number",
+                        "null",
+                        "object",
+                        "string"
+                    ]
+                }
+            },
+            "properties": {
+                "target": {
+                    "description": "Link to invoke action",
+                    "format": "uri-reference",
+                    "type": "string"
+                },
+                "title": {
+                    "description": "Friendly action name",
+                    "type": "string"
+                }
+            },
+            "type": "object",
+            "versionAdded": "v1_5_0"
+        },
+        "Links": {
+            "additionalProperties": false,
+            "description": "Add ability to manage spare capacity.",
+            "patternProperties": {
+                "^([a-zA-Z_][a-zA-Z0-9_]*)?@(odata|Redfish|Message)\\.[a-zA-Z_][a-zA-Z0-9_]*$": {
+                    "description": "This property shall specify a valid odata or Redfish property.",
+                    "type": [
+                        "array",
+                        "boolean",
+                        "integer",
+                        "number",
+                        "null",
+                        "object",
+                        "string"
+                    ]
+                }
+            },
+            "properties": {
+                "CacheDataVolumes": {
+                    "description": "A pointer to the data volumes this volume serves as a cache volume.",
+                    "items": {
+                        "$ref": "http://redfish.dmtf.org/schemas/swordfish/v1/Volume.json#/definitions/Volume"
+                    },
+                    "longDescription": "This shall be a pointer to the cache data volumes this volume serves as a cache volume.  The corresponding VolumeUsage property shall be set to CacheOnly when this property is used.",
+                    "readonly": true,
+                    "type": "array",
+                    "versionAdded": "v1_6_0"
+                },
+                "CacheDataVolumes@odata.count": {
+                    "$ref": "http://redfish.dmtf.org/schemas/v1/odata-v4.json#/definitions/count"
+                },
+                "CacheVolumeSource": {
+                    "anyOf": [
+                        {
+                            "$ref": "http://redfish.dmtf.org/schemas/swordfish/v1/Volume.json#/definitions/Volume"
+                        },
+                        {
+                            "type": "null"
+                        }
+                    ],
+                    "description": "A pointer to the cache volume source for this volume.",
+                    "longDescription": "This shall be a pointer to the cache volume source for this volume. The corresponding VolumeUsage property shall be set to Data when this property is used.",
+                    "readonly": true,
+                    "versionAdded": "v1_6_0"
+                },
+                "ClassOfService": {
+                    "$ref": "http://redfish.dmtf.org/schemas/swordfish/v1/ClassOfService.json#/definitions/ClassOfService",
+                    "description": "The ClassOfService that this storage volume conforms to.",
+                    "longDescription": "This property shall contain a reference to the ClassOfService that this storage volume conforms to.",
+                    "readonly": true,
+                    "versionAdded": "v1_1_0"
+                },
+                "ClientEndpoints": {
+                    "description": "An array of references to the client Endpoints associated with this volume.",
+                    "items": {
+                        "$ref": "http://redfish.dmtf.org/schemas/v1/Endpoint.json#/definitions/Endpoint"
+                    },
+                    "longDescription": "The value of this property shall be references to the client Endpoints this volume is associated with.",
+                    "readonly": true,
+                    "type": "array",
+                    "versionAdded": "v1_4_0"
+                },
+                "ClientEndpoints@odata.count": {
+                    "$ref": "http://redfish.dmtf.org/schemas/v1/odata-v4.json#/definitions/count"
+                },
+                "ConsistencyGroups": {
+                    "description": "An array of references to the ConsistencyGroups associated with this volume.",
+                    "items": {
+                        "$ref": "http://redfish.dmtf.org/schemas/swordfish/v1/ConsistencyGroup.json#/definitions/ConsistencyGroup"
+                    },
+                    "longDescription": "The value of this property shall be references to the ConsistencyGroups this volume is associated with.",
+                    "readonly": true,
+                    "type": "array",
+                    "versionAdded": "v1_4_0"
+                },
+                "ConsistencyGroups@odata.count": {
+                    "$ref": "http://redfish.dmtf.org/schemas/v1/odata-v4.json#/definitions/count"
+                },
+                "DedicatedSpareDrives": {
+                    "description": "An array of references to the drives which are dedicated spares for this volume.",
+                    "items": {
+                        "$ref": "http://redfish.dmtf.org/schemas/v1/Drive.json#/definitions/Drive"
+                    },
+                    "longDescription": "The value of this property shall be a reference to the resources that this volume is associated with and shall reference resources of type Drive. This property shall only contain references to Drive entities which are currently assigned as a dedicated spare and are able to support this Volume.",
+                    "readonly": false,
+                    "type": "array",
+                    "versionAdded": "v1_2_0"
+                },
+                "DedicatedSpareDrives@odata.count": {
+                    "$ref": "http://redfish.dmtf.org/schemas/v1/odata-v4.json#/definitions/count"
+                },
+                "Drives": {
+                    "description": "An array of references to the drives which contain this volume. This will reference Drives that either wholly or only partly contain this volume.",
+                    "items": {
+                        "$ref": "http://redfish.dmtf.org/schemas/v1/Drive.json#/definitions/Drive"
+                    },
+                    "longDescription": "The value of this property shall be a reference to the resources that this volume is associated with and shall reference resources of type Drive. This property shall only contain references to Drive entities which are currently members of the Volume, not hot spare Drives which are not currently a member of the volume.",
+                    "readonly": true,
+                    "type": "array"
+                },
+                "Drives@odata.count": {
+                    "$ref": "http://redfish.dmtf.org/schemas/v1/odata-v4.json#/definitions/count"
+                },
+                "JournalingMedia": {
+                    "anyOf": [
+                        {
+                            "$ref": "http://redfish.dmtf.org/schemas/v1/Resource.json#/definitions/Resource"
+                        },
+                        {
+                            "type": "null"
+                        }
+                    ],
+                    "description": "A pointer to the Resource that serves as a journaling media for this volume.",
+                    "longDescription": "This shall be a pointer to the journaling media used for this Volume to address the write hole issue. Valid when WriteHoleProtectionPolicy property is set to 'Journaling'.",
+                    "readonly": false,
+                    "versionAdded": "v1_5_0"
+                },
+                "Oem": {
+                    "$ref": "http://redfish.dmtf.org/schemas/v1/Resource.json#/definitions/Oem",
+                    "description": "The OEM extension property.",
+                    "longDescription": "This property shall contain the OEM extensions.  All values for properties contained in this object shall conform to the Redfish Specification-described requirements."
+                },
+                "OwningStorageResource": {
+                    "$ref": "http://redfish.dmtf.org/schemas/v1/Storage.json#/definitions/Storage",
+                    "description": "A pointer to the Storage resource that owns or contains this volume.",
+                    "longDescription": "This shall be a pointer to the Storage resource that owns or contains this volume.",
+                    "readonly": true,
+                    "versionAdded": "v1_5_0"
+                },
+                "OwningStorageService": {
+                    "$ref": "http://redfish.dmtf.org/schemas/swordfish/v1/StorageService.json#/definitions/StorageService",
+                    "description": "A pointer to the StorageService that owns or contains this volume.",
+                    "longDescription": "This shall be a pointer to the StorageService that owns or contains this volume.",
+                    "readonly": true,
+                    "versionAdded": "v1_4_0"
+                },
+                "ServerEndpoints": {
+                    "description": "An array of references to the server Endpoints associated with this volume.",
+                    "items": {
+                        "$ref": "http://redfish.dmtf.org/schemas/v1/Endpoint.json#/definitions/Endpoint"
+                    },
+                    "longDescription": "The value of this property shall be references to the server Endpoints this volume is associated with.",
+                    "readonly": true,
+                    "type": "array",
+                    "versionAdded": "v1_4_0"
+                },
+                "ServerEndpoints@odata.count": {
+                    "$ref": "http://redfish.dmtf.org/schemas/v1/odata-v4.json#/definitions/count"
+                },
+                "SpareResourceSets": {
+                    "description": "An array of references to SpareResourceSets.",
+                    "items": {
+                        "$ref": "http://redfish.dmtf.org/schemas/swordfish/v1/SpareResourceSet.json#/definitions/SpareResourceSet"
+                    },
+                    "longDescription": "Each referenced SpareResourceSet shall contain resources that may be utilized to replace the capacity provided by a failed resource having a compatible type.",
+                    "readonly": false,
+                    "type": "array",
+                    "versionAdded": "v1_3_0"
+                },
+                "SpareResourceSets@odata.count": {
+                    "$ref": "http://redfish.dmtf.org/schemas/v1/odata-v4.json#/definitions/count"
+                },
+                "StorageGroups": {
+                    "description": "An array of references to the StorageGroups associated with this volume.",
+                    "items": {
+                        "$ref": "http://redfish.dmtf.org/schemas/swordfish/v1/StorageGroup.json#/definitions/StorageGroup"
+                    },
+                    "longDescription": "The value of this property shall be references to the StorageGroups this volume is associated with.",
+                    "readonly": true,
+                    "type": "array",
+                    "versionAdded": "v1_4_0"
+                },
+                "StorageGroups@odata.count": {
+                    "$ref": "http://redfish.dmtf.org/schemas/v1/odata-v4.json#/definitions/count"
+                }
+            },
+            "type": "object"
+        },
+        "NVMeNamespaceProperties": {
+            "additionalProperties": false,
+            "description": "This contains properties to use when Volume is used to describe an NVMe Namespace.",
+            "longDescription": "This contains properties to use when Volume is used to describe an NVMe Namespace.",
+            "patternProperties": {
+                "^([a-zA-Z_][a-zA-Z0-9_]*)?@(odata|Redfish|Message)\\.[a-zA-Z_][a-zA-Z0-9_]*$": {
+                    "description": "This property shall specify a valid odata or Redfish property.",
+                    "type": [
+                        "array",
+                        "boolean",
+                        "integer",
+                        "number",
+                        "null",
+                        "object",
+                        "string"
+                    ]
+                }
+            },
+            "properties": {
+                "FormattedLBASize": {
+                    "description": "The LBA data size and metadata size combination that the namespace has been formatted with.",
+                    "longDescription": "This property shall contain the LBA data size and metadata size combination that the namespace has been formatted with. This is a 4-bit data structure.",
+                    "readonly": true,
+                    "type": [
+                        "string",
+                        "null"
+                    ],
+                    "versionAdded": "v1_5_0"
+                },
+                "IsShareable": {
+                    "description": "Indicates the namespace is shareable.",
+                    "longDescription": "This property shall indicate whether the namespace is shareable.",
+                    "readonly": false,
+                    "type": [
+                        "boolean",
+                        "null"
+                    ],
+                    "versionAdded": "v1_5_0"
+                },
+                "MetadataTransferredAtEndOfDataLBA": {
+                    "description": "This property indicates whether or not the metadata is transferred at the end of the LBA creating an extended data LBA.",
+                    "longDescription": "This property shall indicate whether or not the metadata is transferred at the end of the LBA creating an extended data LBA.",
+                    "readonly": true,
+                    "type": [
+                        "boolean",
+                        "null"
+                    ],
+                    "versionAdded": "v1_5_0"
+                },
+                "NVMeVersion": {
+                    "description": "The version of the NVMe Base Specification supported.",
+                    "longDescription": "This property shall contain the version of the NVMe Base Specification supported.",
+                    "readonly": true,
+                    "type": [
+                        "string",
+                        "null"
+                    ],
+                    "versionAdded": "v1_5_0"
+                },
+                "NamespaceFeatures": {
+                    "anyOf": [
+                        {
+                            "$ref": "#/definitions/NamespaceFeatures"
+                        },
+                        {
+                            "type": "null"
+                        }
+                    ],
+                    "description": "This property contains a set of Namespace Features.",
+                    "longDescription": "This property shall contain a set of Namespace Features.",
+                    "versionAdded": "v1_5_0"
+                },
+                "NamespaceId": {
+                    "description": "The NVMe Namespace Identifier for this namespace.",
+                    "longDescription": "This property shall contain the NVMe Namespace Identifier for this namespace. This property shall be a hex value. Namespace identifiers are not durable and do not have meaning outside the scope of the NVMe subsystem. NSID 0x0, 0xFFFFFFFF, 0xFFFFFFFE are special purpose values.",
+                    "pattern": "^0[xX](([a-fA-F]|[0-9])*)$",
+                    "readonly": true,
+                    "type": [
+                        "string",
+                        "null"
+                    ],
+                    "versionAdded": "v1_5_0"
+                },
+                "NumberLBAFormats": {
+                    "description": "The number of LBA data size and metadata size combinations supported by this namespace. The value of this property is between 0 and 16.",
+                    "longDescription": "This property shall contain the number of LBA data size and metadata size combinations supported by this namespace. The value of this property is between 0 and 16. LBA formats with an index set beyond this value will not be supported.",
+                    "minimum": 0,
+                    "readonly": true,
+                    "type": [
+                        "integer",
+                        "null"
+                    ],
+                    "units": "By",
+                    "versionAdded": "v1_5_0"
+                }
+            },
+            "type": "object"
+        },
+        "NamespaceFeatures": {
+            "additionalProperties": false,
+            "patternProperties": {
+                "^([a-zA-Z_][a-zA-Z0-9_]*)?@(odata|Redfish|Message)\\.[a-zA-Z_][a-zA-Z0-9_]*$": {
+                    "description": "This property shall specify a valid odata or Redfish property.",
+                    "type": [
+                        "array",
+                        "boolean",
+                        "integer",
+                        "number",
+                        "null",
+                        "object",
+                        "string"
+                    ]
+                }
+            },
+            "properties": {
+                "SupportsAtomicTransactionSize": {
+                    "description": "Indicates that the NVM fields for Namespace preferred write granularity (NPWG), write alignment (NPWA), deallocate granularity (NPDG), deallocate alignment (NPDA) and optimal write size (NOWS)  are defined for this namespace and should be used by the host for I/O optimization.",
+                    "longDescription": "This property shall indicate whether or not the NVM fields for Namespace preferred write granularity (NPWG), write alignment (NPWA), deallocate granularity (NPDG), deallocate alignment (NPDA) and optimal write size (NOWS)  are defined for this namespace and should be used by the host for I/O optimization.",
+                    "readonly": true,
+                    "type": [
+                        "boolean",
+                        "null"
+                    ],
+                    "versionAdded": "v1_5_0"
+                },
+                "SupportsDeallocatedOrUnwrittenLBError": {
+                    "description": "This property indicates that the controller supports deallocated or unwritten logical block error for this namespace.",
+                    "longDescription": "This property shall indicate that the controller supports deallocated or unwritten logical block error for this namespace. .",
+                    "readonly": true,
+                    "type": [
+                        "boolean",
+                        "null"
+                    ],
+                    "versionAdded": "v1_5_0"
+                },
+                "SupportsIOPerformanceHints": {
+                    "description": "Indicates that the Namespace Atomic Write Unit Normal (NAWUN), Namespace Atomic Write Unit Power Fail (NAWUPF), and Namespace Atomic Compare and Write Unit (NACWU) fields are defined for this namespace and should be used by the host for this namespace instead of the controller-level properties AWUN, AWUPF, and ACWU.",
+                    "longDescription": "This property shall indicate that the Namespace Atomic Write Unit Normal (NAWUN), Namespace Atomic Write Unit Power Fail (NAWUPF), and Namespace Atomic Compare and Write Unit (NACWU) fields are defined for this namespace and should be used by the host for this namespace instead of the controller-level properties AWUN, AWUPF, and ACWU.",
+                    "readonly": true,
+                    "type": [
+                        "boolean",
+                        "null"
+                    ],
+                    "versionAdded": "v1_5_0"
+                },
+                "SupportsNGUIDReuse": {
+                    "description": "This property indicates that the namespace supports the use of an NGUID (namespace globally unique identifier) value.",
+                    "longDescription": "This property shall indicate that the namespace supports the use of an NGUID (namespace globally unique identifier) value.",
+                    "readonly": true,
+                    "type": [
+                        "boolean",
+                        "null"
+                    ],
+                    "versionAdded": "v1_5_0"
+                },
+                "SupportsThinProvisioning": {
+                    "description": "This property indicates whether or not the NVMe Namespace supports thin provisioning.",
+                    "longDescription": "This property shall indicate whether or not the NVMe Namespace supports thin provisioning. Specifically, the namespace capacity reported may be less than the namespace size.",
+                    "readonly": true,
+                    "type": [
+                        "boolean",
+                        "null"
+                    ],
+                    "versionAdded": "v1_5_0"
+                }
+            },
+            "type": "object"
+        },
+        "OemActions": {
+            "additionalProperties": true,
+            "patternProperties": {
+                "^([a-zA-Z_][a-zA-Z0-9_]*)?@(odata|Redfish|Message)\\.[a-zA-Z_][a-zA-Z0-9_]*$": {
+                    "description": "This property shall specify a valid odata or Redfish property.",
+                    "type": [
+                        "array",
+                        "boolean",
+                        "integer",
+                        "number",
+                        "null",
+                        "object",
+                        "string"
+                    ]
+                }
+            },
+            "properties": {},
+            "type": "object"
+        },
+        "Operation": {
+            "additionalProperties": false,
+            "patternProperties": {
+                "^([a-zA-Z_][a-zA-Z0-9_]*)?@(odata|Redfish|Message)\\.[a-zA-Z_][a-zA-Z0-9_]*$": {
+                    "description": "This property shall specify a valid odata or Redfish property.",
+                    "type": [
+                        "array",
+                        "boolean",
+                        "integer",
+                        "number",
+                        "null",
+                        "object",
+                        "string"
+                    ]
+                }
+            },
+            "properties": {
+                "AssociatedFeaturesRegistry": {
+                    "$ref": "http://redfish.dmtf.org/schemas/swordfish/v1/FeaturesRegistry.json#/definitions/FeaturesRegistry",
+                    "description": "A reference to the task associated with the operation if any.",
+                    "readonly": true
+                },
+                "OperationName": {
+                    "description": "The name of the operation.",
+                    "readonly": true,
+                    "type": [
+                        "string",
+                        "null"
+                    ]
+                },
+                "PercentageComplete": {
+                    "description": "The percentage of the operation that has been completed.",
+                    "readonly": true,
+                    "type": [
+                        "integer",
+                        "null"
+                    ]
+                }
+            },
+            "type": "object"
+        },
+        "RemoveReplicaRelationship": {
+            "additionalProperties": false,
+            "description": "This action is used to disable data synchronization between a source and target volume, remove the replication relationship, and optionally delete the target volume.",
+            "longDescription": "This action shall be used to disable data synchronization between a source and target volume, remove the replication relationship, and optionally delete the target volume.",
+            "parameters": {
+                "DeleteTargetVolume": {
+                    "description": "Indicate whether or not to delete the target volume as part of the operation.",
+                    "longDescription": "This parameter shall indicate whether or not to delete the target volume as part of the operation. If not defined, the system should use its default behavior.",
+                    "type": "boolean"
+                },
+                "TargetVolume": {
+                    "description": "The Uri to the existing target volume.",
+                    "longDescription": "This parameter shall contain the Uri to the existing target volume.",
+                    "requiredParameter": true,
+                    "type": "string"
+                }
+            },
+            "patternProperties": {
+                "^([a-zA-Z_][a-zA-Z0-9_]*)?@(odata|Redfish|Message)\\.[a-zA-Z_][a-zA-Z0-9_]*$": {
+                    "description": "This property shall specify a valid odata or Redfish property.",
+                    "type": [
+                        "array",
+                        "boolean",
+                        "integer",
+                        "number",
+                        "null",
+                        "object",
+                        "string"
+                    ]
+                }
+            },
+            "properties": {
+                "target": {
+                    "description": "Link to invoke action",
+                    "format": "uri-reference",
+                    "type": "string"
+                },
+                "title": {
+                    "description": "Friendly action name",
+                    "type": "string"
+                }
+            },
+            "type": "object",
+            "versionAdded": "v1_4_0"
+        },
+        "ResumeReplication": {
+            "additionalProperties": false,
+            "description": "This action is used to resume the active data synchronization between a source and target volume, without otherwise altering the replication relationship.",
+            "longDescription": "This action shall be used to resume the active data synchronization between a source and target volume, without otherwise altering the replication relationship.",
+            "parameters": {
+                "TargetVolume": {
+                    "description": "The Uri to the existing target volume.",
+                    "longDescription": "This parameter shall contain the Uri to the existing target volume.",
+                    "requiredParameter": true,
+                    "type": "string"
+                }
+            },
+            "patternProperties": {
+                "^([a-zA-Z_][a-zA-Z0-9_]*)?@(odata|Redfish|Message)\\.[a-zA-Z_][a-zA-Z0-9_]*$": {
+                    "description": "This property shall specify a valid odata or Redfish property.",
+                    "type": [
+                        "array",
+                        "boolean",
+                        "integer",
+                        "number",
+                        "null",
+                        "object",
+                        "string"
+                    ]
+                }
+            },
+            "properties": {
+                "target": {
+                    "description": "Link to invoke action",
+                    "format": "uri-reference",
+                    "type": "string"
+                },
+                "title": {
+                    "description": "Friendly action name",
+                    "type": "string"
+                }
+            },
+            "type": "object",
+            "versionAdded": "v1_4_0"
+        },
+        "ReverseReplicationRelationship": {
+            "additionalProperties": false,
+            "description": "This action is used to reverse the replication relationship between a source and target volume.",
+            "longDescription": "This action shall be used to reverse the replication relationship between a source and target volume.",
+            "parameters": {
+                "TargetVolume": {
+                    "description": "The Uri to the existing target volume.",
+                    "longDescription": "This parameter shall contain the Uri to the existing target volume.",
+                    "requiredParameter": true,
+                    "type": "string"
+                }
+            },
+            "patternProperties": {
+                "^([a-zA-Z_][a-zA-Z0-9_]*)?@(odata|Redfish|Message)\\.[a-zA-Z_][a-zA-Z0-9_]*$": {
+                    "description": "This property shall specify a valid odata or Redfish property.",
+                    "type": [
+                        "array",
+                        "boolean",
+                        "integer",
+                        "number",
+                        "null",
+                        "object",
+                        "string"
+                    ]
+                }
+            },
+            "properties": {
+                "target": {
+                    "description": "Link to invoke action",
+                    "format": "uri-reference",
+                    "type": "string"
+                },
+                "title": {
+                    "description": "Friendly action name",
+                    "type": "string"
+                }
+            },
+            "type": "object",
+            "versionAdded": "v1_4_0"
+        },
+        "SplitReplication": {
+            "additionalProperties": false,
+            "description": "This action is used to split the replication relationship and suspend data synchronization between a source and target volume.",
+            "longDescription": "This action shall be used to split the replication relationship and suspend data synchronization between a source and target volume.",
+            "parameters": {
+                "TargetVolume": {
+                    "description": "The Uri to the existing target volume.",
+                    "longDescription": "This parameter shall contain the Uri to the existing target volume.",
+                    "requiredParameter": true,
+                    "type": "string"
+                }
+            },
+            "patternProperties": {
+                "^([a-zA-Z_][a-zA-Z0-9_]*)?@(odata|Redfish|Message)\\.[a-zA-Z_][a-zA-Z0-9_]*$": {
+                    "description": "This property shall specify a valid odata or Redfish property.",
+                    "type": [
+                        "array",
+                        "boolean",
+                        "integer",
+                        "number",
+                        "null",
+                        "object",
+                        "string"
+                    ]
+                }
+            },
+            "properties": {
+                "target": {
+                    "description": "Link to invoke action",
+                    "format": "uri-reference",
+                    "type": "string"
+                },
+                "title": {
+                    "description": "Friendly action name",
+                    "type": "string"
+                }
+            },
+            "type": "object",
+            "versionAdded": "v1_4_0"
+        },
+        "SuspendReplication": {
+            "additionalProperties": false,
+            "description": "This action is used to suspend active data synchronization between a source and target volume, without otherwise altering the replication relationship.",
+            "longDescription": "This action shall be used to suspend active data synchronization between a source and target volume, without otherwise altering the replication relationship.",
+            "parameters": {
+                "TargetVolume": {
+                    "description": "The Uri to the existing target volume.",
+                    "longDescription": "This parameter shall contain the Uri to the existing target volume.",
+                    "requiredParameter": true,
+                    "type": "string"
+                }
+            },
+            "patternProperties": {
+                "^([a-zA-Z_][a-zA-Z0-9_]*)?@(odata|Redfish|Message)\\.[a-zA-Z_][a-zA-Z0-9_]*$": {
+                    "description": "This property shall specify a valid odata or Redfish property.",
+                    "type": [
+                        "array",
+                        "boolean",
+                        "integer",
+                        "number",
+                        "null",
+                        "object",
+                        "string"
+                    ]
+                }
+            },
+            "properties": {
+                "target": {
+                    "description": "Link to invoke action",
+                    "format": "uri-reference",
+                    "type": "string"
+                },
+                "title": {
+                    "description": "Friendly action name",
+                    "type": "string"
+                }
+            },
+            "type": "object",
+            "versionAdded": "v1_4_0"
+        },
+        "Volume": {
+            "additionalProperties": false,
+            "description": "Volume contains properties used to describe a volume, virtual disk, LUN, or other logical storage entity for any system.",
+            "longDescription": "This resource shall be used to represent a volume, virtual disk, logical disk, LUN, or other logical storage for a Redfish implementation.",
+            "patternProperties": {
+                "^([a-zA-Z_][a-zA-Z0-9_]*)?@(odata|Redfish|Message)\\.[a-zA-Z_][a-zA-Z0-9_]*$": {
+                    "description": "This property shall specify a valid odata or Redfish property.",
+                    "type": [
+                        "array",
+                        "boolean",
+                        "integer",
+                        "number",
+                        "null",
+                        "object",
+                        "string"
+                    ]
+                }
+            },
+            "properties": {
+                "@odata.context": {
+                    "$ref": "http://redfish.dmtf.org/schemas/v1/odata-v4.json#/definitions/context"
+                },
+                "@odata.etag": {
+                    "$ref": "http://redfish.dmtf.org/schemas/v1/odata-v4.json#/definitions/etag"
+                },
+                "@odata.id": {
+                    "$ref": "http://redfish.dmtf.org/schemas/v1/odata-v4.json#/definitions/id"
+                },
+                "@odata.type": {
+                    "$ref": "http://redfish.dmtf.org/schemas/v1/odata-v4.json#/definitions/type"
+                },
+                "AccessCapabilities": {
+                    "description": "Supported IO access capabilities.",
+                    "items": {
+                        "anyOf": [
+                            {
+                                "$ref": "http://redfish.dmtf.org/schemas/swordfish/v1/DataStorageLoSCapabilities.json#/definitions/StorageAccessCapability"
+                            },
+                            {
+                                "type": "null"
+                            }
+                        ]
+                    },
+                    "longDescription": "Each entry shall specify a current storage access capability.",
+                    "readonly": false,
+                    "type": "array",
+                    "versionAdded": "v1_1_0"
+                },
+                "Actions": {
+                    "$ref": "#/definitions/Actions",
+                    "description": "The available actions for this resource.",
+                    "longDescription": "The Actions property shall contain the available actions for this resource."
+                },
+                "AllocatedPools": {
+                    "$ref": "http://redfish.dmtf.org/schemas/swordfish/v1/StoragePoolCollection.json#/definitions/StoragePoolCollection",
+                    "description": "An array of references to StoragePools allocated from this Volume.",
+                    "longDescription": "The value of this property shall contain references to all storage pools allocated from this volume.",
+                    "readonly": true,
+                    "versionAdded": "v1_1_0"
+                },
+                "BlockSizeBytes": {
+                    "description": "The size of the smallest addressable unit (Block) of this volume in bytes.",
+                    "longDescription": "This property shall contain size of the smallest addressable unit of the associated volume.",
+                    "readonly": true,
+                    "type": [
+                        "integer",
+                        "null"
+                    ],
+                    "units": "By"
+                },
+                "Capacity": {
+                    "$ref": "http://redfish.dmtf.org/schemas/swordfish/v1/Capacity.v1_0_0.json#/definitions/Capacity",
+                    "description": "Capacity utilization.",
+                    "longDescription": "Information about the utilization of capacity allocated to this storage volume.",
+                    "versionAdded": "v1_1_0"
+                },
+                "CapacityBytes": {
+                    "description": "The size in bytes of this Volume.",
+                    "longDescription": "This property shall contain the size in bytes of the associated volume.",
+                    "readonly": false,
+                    "type": [
+                        "integer",
+                        "null"
+                    ],
+                    "units": "By"
+                },
+                "CapacitySources": {
+                    "autoExpand": true,
+                    "description": "An array of space allocations to this volume.",
+                    "items": {
+                        "$ref": "http://redfish.dmtf.org/schemas/swordfish/v1/Capacity.json#/definitions/CapacitySource"
+                    },
+                    "longDescription": "Fully or partially consumed storage from a source resource. Each entry provides capacity allocation information from a named source resource.",
+                    "readonly": false,
+                    "type": "array",
+                    "versionAdded": "v1_1_0"
+                },
+                "CapacitySources@odata.count": {
+                    "$ref": "http://redfish.dmtf.org/schemas/v1/odata-v4.json#/definitions/count"
+                },
+                "Compressed": {
+                    "description": "Indicator of whether or not the Volume has compression enabled.",
+                    "longDescription": "This property shall contain a boolean indicator if the Volume is currently utilizing compression or not.",
+                    "readonly": false,
+                    "type": [
+                        "boolean",
+                        "null"
+                    ],
+                    "versionAdded": "v1_4_0"
+                },
+                "Deduplicated": {
+                    "description": "Indicator of whether or not the Volume has deduplication enabled.",
+                    "longDescription": "This property shall contain a boolean indicator if the Volume is currently utilizing deduplication or not.",
+                    "readonly": false,
+                    "type": [
+                        "boolean",
+                        "null"
+                    ],
+                    "versionAdded": "v1_4_0"
+                },
+                "Description": {
+                    "anyOf": [
+                        {
+                            "$ref": "http://redfish.dmtf.org/schemas/v1/Resource.json#/definitions/Description"
+                        },
+                        {
+                            "type": "null"
+                        }
+                    ],
+                    "readonly": true
+                },
+                "DisplayName": {
+                    "description": "A user-configurable string to name the volume.",
+                    "longDescription": "This property shall contain a user-configurable string to name the volume.",
+                    "readonly": false,
+                    "type": [
+                        "string",
+                        "null"
+                    ],
+                    "versionAdded": "v1_4_0"
+                },
+                "Encrypted": {
+                    "description": "Is this Volume encrypted.",
+                    "longDescription": "This property shall contain a boolean indicator if the Volume is currently utilizing encryption or not.",
+                    "readonly": false,
+                    "type": [
+                        "boolean",
+                        "null"
+                    ]
+                },
+                "EncryptionTypes": {
+                    "description": "The types of encryption used by this Volume.",
+                    "items": {
+                        "$ref": "http://redfish.dmtf.org/schemas/swordfish/v1/Volume.json#/definitions/EncryptionTypes"
+                    },
+                    "longDescription": "This property shall contain the types of encryption used by this Volume.",
+                    "readonly": false,
+                    "type": "array"
+                },
+                "IOPerfModeEnabled": {
+                    "description": "Indicates the IO performance mode setting for the volume.",
+                    "longDescription": "This property shall indicate whether IO performance mode is enabled for the volume.",
+                    "readonly": false,
+                    "type": [
+                        "boolean",
+                        "null"
+                    ],
+                    "versionAdded": "v1_5_0"
+                },
+                "IOStatistics": {
+                    "$ref": "http://redfish.dmtf.org/schemas/swordfish/v1/IOStatistics.json#/definitions/IOStatistics",
+                    "description": "Statistics for this volume.",
+                    "longDescription": "The value shall represent IO statistics for this volume.",
+                    "versionAdded": "v1_2_0"
+                },
+                "Id": {
+                    "$ref": "http://redfish.dmtf.org/schemas/v1/Resource.json#/definitions/Id",
+                    "readonly": true
+                },
+                "Identifiers": {
+                    "description": "The Durable names for the volume.",
+                    "items": {
+                        "$ref": "http://redfish.dmtf.org/schemas/v1/Resource.json#/definitions/Identifier"
+                    },
+                    "longDescription": "This property shall contain a list of all known durable names for the associated volume.",
+                    "type": "array"
+                },
+                "InitializeMethod": {
+                    "anyOf": [
+                        {
+                            "$ref": "http://redfish.dmtf.org/schemas/swordfish/v1/Volume.json#/definitions/InitializeMethod"
+                        },
+                        {
+                            "type": "null"
+                        }
+                    ],
+                    "description": "Indicates the Initialization Method used for this volume. If InitializeMethod is not specified, the InitializeMethod should be Foreground.",
+                    "longDescription": "This property shall indicate the initialization method used for this volume. If InitializeMethod is not specified, the InitializeMethod should be Foreground. This value reflects the most recently used Initialization Method, and may be changed using the Initialize Action.",
+                    "readonly": true,
+                    "versionAdded": "v1_6_0"
+                },
+                "Links": {
+                    "$ref": "#/definitions/Links",
+                    "description": "Contains references to other resources that are related to this resource.",
+                    "longDescription": "The Links property, as described by the Redfish Specification, shall contain references to resources that are related to, but not contained by (subordinate to), this resource."
+                },
+                "LogicalUnitNumber": {
+                    "description": "Indicates the host-visible LogicalUnitNumber assigned to this Volume.",
+                    "longDescription": "This property shall contain host-visible LogicalUnitNumber assigned to this Volume. This property shall only be used when in a single connect configuration and no StorageGroup configuration is used.",
+                    "readonly": true,
+                    "type": [
+                        "integer",
+                        "null"
+                    ],
+                    "versionAdded": "v1_4_0"
+                },
+                "LowSpaceWarningThresholdPercents": {
+                    "description": "Low space warning.",
+                    "items": {
+                        "type": [
+                            "integer",
+                            "null"
+                        ]
+                    },
+                    "longDescription": "Each time the following value is less than one of the values in the array the LOW_SPACE_THRESHOLD_WARNING event shall be triggered: Across all CapacitySources entries, percent = (SUM(AllocatedBytes) - SUM(ConsumedBytes))/SUM(AllocatedBytes).",
+                    "readonly": false,
+                    "type": "array",
+                    "units": "%",
+                    "versionAdded": "v1_1_0"
+                },
+                "Manufacturer": {
+                    "description": "The manufacturer or OEM of this storage volume.",
+                    "longDescription": "This property shall contain a value that represents the manufacturer or implementer of the storage volume.",
+                    "readonly": true,
+                    "type": [
+                        "string",
+                        "null"
+                    ],
+                    "versionAdded": "v1_1_0"
+                },
+                "MaxBlockSizeBytes": {
+                    "description": "Max Block size in bytes.",
+                    "longDescription": "This property shall contain size of the largest addressable unit of this storage volume.",
+                    "readonly": true,
+                    "type": [
+                        "integer",
+                        "null"
+                    ],
+                    "units": "By",
+                    "versionAdded": "v1_1_0"
+                },
+                "MediaSpanCount": {
+                    "description": "Indicates the number of media elements used per span in the secondary RAID for a hierarchical RAID type.",
+                    "longDescription": "This property shall indicate the number of media elements used per span in the secondary RAID for a hierarchical RAID type.",
+                    "readonly": true,
+                    "type": [
+                        "integer",
+                        "null"
+                    ],
+                    "versionAdded": "v1_4_0"
+                },
+                "Model": {
+                    "description": "The model number for this storage volume.",
+                    "longDescription": "The value is assigned by the manufacturer and shall represents a specific storage volume implementation.",
+                    "readonly": true,
+                    "type": [
+                        "string",
+                        "null"
+                    ],
+                    "versionAdded": "v1_1_0"
+                },
+                "NVMeNamespaceProperties": {
+                    "anyOf": [
+                        {
+                            "$ref": "#/definitions/NVMeNamespaceProperties"
+                        },
+                        {
+                            "type": "null"
+                        }
+                    ],
+                    "description": "This property contains properties to use when Volume is used to describe an NVMe Namespace.",
+                    "longDescription": "This property shall contain properties to use when Volume is used to describe an NVMe Namespace.",
+                    "versionAdded": "v1_5_0"
+                },
+                "Name": {
+                    "$ref": "http://redfish.dmtf.org/schemas/v1/Resource.json#/definitions/Name",
+                    "readonly": true
+                },
+                "Oem": {
+                    "$ref": "http://redfish.dmtf.org/schemas/v1/Resource.json#/definitions/Oem",
+                    "description": "The OEM extension property.",
+                    "longDescription": "This property shall contain the OEM extensions.  All values for properties that this object contains shall conform to the Redfish Specification-described requirements."
+                },
+                "Operations": {
+                    "description": "The operations currently running on the Volume.",
+                    "items": {
+                        "$ref": "#/definitions/Operation"
+                    },
+                    "longDescription": "This property shall contain a list of all currently running on the Volume.",
+                    "type": "array"
+                },
+                "OptimumIOSizeBytes": {
+                    "description": "The size in bytes of this Volume's optimum IO size.",
+                    "longDescription": "This property shall contain the optimum IO size to use when performing IO on this volume. For logical disks, this is the stripe size. For physical disks, this describes the physical sector size.",
+                    "readonly": true,
+                    "type": [
+                        "integer",
+                        "null"
+                    ],
+                    "units": "By"
+                },
+                "ProvisioningPolicy": {
+                    "anyOf": [
+                        {
+                            "$ref": "http://redfish.dmtf.org/schemas/swordfish/v1/DataStorageLoSCapabilities.json#/definitions/ProvisioningPolicy"
+                        },
+                        {
+                            "type": "null"
+                        }
+                    ],
+                    "description": "This property specifies the volume's storage allocation, or provisioning policy.",
+                    "longDescription": "This property shall specify the volume's supported storage allocation policy.",
+                    "readonly": false,
+                    "versionAdded": "v1_4_0"
+                },
+                "RAIDType": {
+                    "anyOf": [
+                        {
+                            "$ref": "http://redfish.dmtf.org/schemas/swordfish/v1/Volume.json#/definitions/RAIDType"
+                        },
+                        {
+                            "type": "null"
+                        }
+                    ],
+                    "description": "The RAID type of this volume.",
+                    "longDescription": "This property shall contain the RAID type of the associated Volume.",
+                    "readonly": true,
+                    "versionAdded": "v1_3_1"
+                },
+                "ReadCachePolicy": {
+                    "anyOf": [
+                        {
+                            "$ref": "http://redfish.dmtf.org/schemas/swordfish/v1/Volume.json#/definitions/ReadCachePolicyType"
+                        },
+                        {
+                            "type": "null"
+                        }
+                    ],
+                    "description": "Indicates the read cache policy setting for the Volume.",
+                    "longDescription": "This property shall contain a boolean indicator of the read cache policy for the Volume.",
+                    "readonly": false,
+                    "versionAdded": "v1_4_0"
+                },
+                "RecoverableCapacitySourceCount": {
+                    "description": "Current number of capacity source resources that are available as replacements.",
+                    "longDescription": "The value is the number of available capacity source resources currently available in the event that an equivalent capacity source resource fails.",
+                    "readonly": false,
+                    "type": [
+                        "integer",
+                        "null"
+                    ],
+                    "versionAdded": "v1_3_0"
+                },
+                "RemainingCapacityPercent": {
+                    "description": "The percentage of the capacity remaining in the Volume.",
+                    "longDescription": "If present, this value shall return  {[(SUM(AllocatedBytes) - SUM(ConsumedBytes)]/SUM(AllocatedBytes)}*100 represented as an integer value.",
+                    "readonly": true,
+                    "type": [
+                        "integer",
+                        "null"
+                    ],
+                    "versionAdded": "v1_2_0"
+                },
+                "ReplicaInfo": {
+                    "$ref": "http://redfish.dmtf.org/schemas/swordfish/v1/StorageReplicaInfo.v1_3_0.json#/definitions/ReplicaInfo",
+                    "description": "Describes this storage volume in its role as a target replica.",
+                    "longDescription": "This property shall describe the replica relationship between this storage volume and a corresponding source volume.",
+                    "versionAdded": "v1_1_0"
+                },
+                "ReplicaTargets": {
+                    "description": "The resources that are target replicas of this source.",
+                    "items": {
+                        "$ref": "http://redfish.dmtf.org/schemas/v1/odata-v4.json#/definitions/idRef"
+                    },
+                    "longDescription": "The value shall reference the target replicas that are sourced by this replica.",
+                    "readonly": true,
+                    "type": "array",
+                    "versionAdded": "v1_3_0"
+                },
+                "ReplicaTargets@odata.count": {
+                    "$ref": "http://redfish.dmtf.org/schemas/v1/odata-v4.json#/definitions/count"
+                },
+                "Status": {
+                    "$ref": "http://redfish.dmtf.org/schemas/v1/Resource.json#/definitions/Status",
+                    "description": "The property contains the status of the Volume.",
+                    "longDescription": "The property shall contain the status of the Volume."
+                },
+                "StorageGroups": {
+                    "$ref": "http://redfish.dmtf.org/schemas/swordfish/v1/StorageGroupCollection.json#/definitions/StorageGroupCollection",
+                    "description": "An array of references to Storage Groups that includes this volume.",
+                    "longDescription": "The value of this property shall contain references to all storage groups that include this volume.",
+                    "readonly": true,
+                    "versionAdded": "v1_1_0"
+                },
+                "StripSizeBytes": {
+                    "description": "The number of blocks (bytes) in a strip in a disk array that uses striped data mapping.",
+                    "longDescription": "The number of consecutively addressed virtual disk blocks (bytes) mapped to consecutively addressed blocks on a single member extent of a disk array. Synonym for stripe depth and chunk size.",
+                    "readonly": false,
+                    "type": [
+                        "integer",
+                        "null"
+                    ],
+                    "units": "By",
+                    "versionAdded": "v1_4_0"
+                },
+                "VolumeType": {
+                    "anyOf": [
+                        {
+                            "$ref": "http://redfish.dmtf.org/schemas/swordfish/v1/Volume.json#/definitions/VolumeType"
+                        },
+                        {
+                            "type": "null"
+                        }
+                    ],
+                    "deprecated": "Deprecated in favor of explicit use of RAIDType.",
+                    "description": "The type of this volume.",
+                    "longDescription": "This property shall contain the type of the associated Volume.",
+                    "readonly": true
+                },
+                "VolumeUsage": {
+                    "anyOf": [
+                        {
+                            "$ref": "http://redfish.dmtf.org/schemas/swordfish/v1/Volume.json#/definitions/VolumeUsageType"
+                        },
+                        {
+                            "type": "null"
+                        }
+                    ],
+                    "description": "Indicates the Volume usage type setting for the Volume.",
+                    "longDescription": "This property shall contain the volume usage type for the Volume.",
+                    "readonly": true,
+                    "versionAdded": "v1_4_0"
+                },
+                "WriteCachePolicy": {
+                    "anyOf": [
+                        {
+                            "$ref": "http://redfish.dmtf.org/schemas/swordfish/v1/Volume.json#/definitions/WriteCachePolicyType"
+                        },
+                        {
+                            "type": "null"
+                        }
+                    ],
+                    "description": "Indicates the write cache policy setting for the Volume.",
+                    "longDescription": "This property shall contain a boolean indicator of the write cache policy for the Volume.",
+                    "readonly": false,
+                    "versionAdded": "v1_4_0"
+                },
+                "WriteCacheState": {
+                    "anyOf": [
+                        {
+                            "$ref": "http://redfish.dmtf.org/schemas/swordfish/v1/Volume.json#/definitions/WriteCacheStateType"
+                        },
+                        {
+                            "type": "null"
+                        }
+                    ],
+                    "description": "Indicates the WriteCacheState policy setting for the Volume.",
+                    "longDescription": "This property shall contain the WriteCacheState policy setting for the Volume.",
+                    "readonly": true,
+                    "versionAdded": "v1_4_0"
+                },
+                "WriteHoleProtectionPolicy": {
+                    "$ref": "http://redfish.dmtf.org/schemas/swordfish/v1/Volume.json#/definitions/WriteHoleProtectionPolicyType",
+                    "description": "The policy that the RAID volume is using to address the write hole issue.",
+                    "longDescription": "This property specifies the policy that is enabled to address the write hole issue on the RAID volume. If no policy is enabled at the moment, this property shall be set to 'Off'.",
+                    "readonly": false,
+                    "versionAdded": "v1_4_0"
+                }
+            },
+            "required": [
+                "@odata.id",
+                "@odata.type",
+                "Id",
+                "Name"
+            ],
+            "type": "object"
+        }
+    },
+    "owningEntity": "SNIA",
+    "release": "TP v1.2.1",
+    "title": "#Volume.v1_6_2.Volume"
+}

--- a/static/redfish/v1/JsonSchemas/Volume/index.json
+++ b/static/redfish/v1/JsonSchemas/Volume/index.json
@@ -1,0 +1,21 @@
+{
+    "@odata.context": "/redfish/v1/$metadata#JsonSchemaFile.JsonSchemaFile",
+    "@odata.id": "/redfish/v1/JsonSchemas/Volume",
+    "@odata.type": "#JsonSchemaFile.v1_0_2.JsonSchemaFile",
+    "Name": "Volume Schema File",
+    "Schema": "#Volume.Volume",
+    "Description": "Volume Schema File Location",
+    "Id": "Volume",
+    "Languages": [
+        "en"
+    ],
+    "Languages@odata.count": 1,
+    "Location": [
+        {
+            "Language": "en",
+            "PublicationUri": "http://redfish.dmtf.org/schemas/v1/Volume.json",
+            "Uri": "/redfish/v1/JsonSchemas/Volume/Volume.json"
+        }
+    ],
+    "Location@odata.count": 1
+}

--- a/static/redfish/v1/JsonSchemas/Zone/Zone.json
+++ b/static/redfish/v1/JsonSchemas/Zone/Zone.json
@@ -1,0 +1,441 @@
+{
+    "$id": "http://redfish.dmtf.org/schemas/v1/Zone.v1_6_1.json",
+    "$ref": "#/definitions/Zone",
+    "$schema": "http://redfish.dmtf.org/schemas/v1/redfish-schema-v1.json",
+    "copyright": "Copyright 2014-2021 DMTF. For the full DMTF copyright policy, see http://www.dmtf.org/about/policies/copyright",
+    "definitions": {
+        "Actions": {
+            "additionalProperties": false,
+            "description": "The available actions for this resource.",
+            "longDescription": "This type shall contain the available actions for this resource.",
+            "patternProperties": {
+                "^([a-zA-Z_][a-zA-Z0-9_]*)?@(odata|Redfish|Message)\\.[a-zA-Z_][a-zA-Z0-9_]*$": {
+                    "description": "This property shall specify a valid odata or Redfish property.",
+                    "type": [
+                        "array",
+                        "boolean",
+                        "integer",
+                        "number",
+                        "null",
+                        "object",
+                        "string"
+                    ]
+                }
+            },
+            "properties": {
+                "#Zone.AddEndpoint": {
+                    "$ref": "#/definitions/AddEndpoint"
+                },
+                "#Zone.RemoveEndpoint": {
+                    "$ref": "#/definitions/RemoveEndpoint"
+                },
+                "Oem": {
+                    "$ref": "#/definitions/OemActions",
+                    "description": "The available OEM-specific actions for this resource.",
+                    "longDescription": "This property shall contain the available OEM-specific actions for this resource.",
+                    "versionAdded": "v1_1_0"
+                }
+            },
+            "type": "object"
+        },
+        "AddEndpoint": {
+            "additionalProperties": false,
+            "description": "This action adds an endpoint to a zone.",
+            "longDescription": "This action shall add an endpoint to a zone.",
+            "parameters": {
+                "Endpoint": {
+                    "$ref": "http://redfish.dmtf.org/schemas/v1/Endpoint.json#/definitions/Endpoint",
+                    "description": "The endpoint to add to the zone.",
+                    "longDescription": "This parameter shall contain a link to the specified endpoint to add to the zone.",
+                    "requiredParameter": true
+                },
+                "EndpointETag": {
+                    "description": "The current ETag of the endpoint to add to the zone.",
+                    "longDescription": "This parameter shall contain the current ETag of the endpoint to add to the zone.  If the client-provided ETag does not match the current ETag of the endpoint that the Endpoint parameter specifies, the service shall return the HTTP 428 (Precondition Required) status code to reject the request.",
+                    "type": "string"
+                },
+                "ZoneETag": {
+                    "description": "The current ETag of the zone.",
+                    "longDescription": "This parameter shall contain the current ETag of the zone.  If the client-provided ETag does not match the current ETag of the zone, the service shall return the HTTP 428 (Precondition Required) status code to reject the request.",
+                    "type": "string"
+                }
+            },
+            "patternProperties": {
+                "^([a-zA-Z_][a-zA-Z0-9_]*)?@(odata|Redfish|Message)\\.[a-zA-Z_][a-zA-Z0-9_]*$": {
+                    "description": "This property shall specify a valid odata or Redfish property.",
+                    "type": [
+                        "array",
+                        "boolean",
+                        "integer",
+                        "number",
+                        "null",
+                        "object",
+                        "string"
+                    ]
+                }
+            },
+            "properties": {
+                "target": {
+                    "description": "Link to invoke action",
+                    "format": "uri-reference",
+                    "type": "string"
+                },
+                "title": {
+                    "description": "Friendly action name",
+                    "type": "string"
+                }
+            },
+            "type": "object",
+            "versionAdded": "v1_5_0"
+        },
+        "ExternalAccessibility": {
+            "enum": [
+                "GloballyAccessible",
+                "NonZonedAccessible",
+                "ZoneOnly",
+                "NoInternalRouting"
+            ],
+            "enumDescriptions": {
+                "GloballyAccessible": "Any external entity with the correct access details, which may include authorization information, can access the endpoints that this zone lists.",
+                "NoInternalRouting": "Routing is not enabled within this zone.",
+                "NonZonedAccessible": "Any external entity that another zone does not explicitly list can access the endpoints that this zone lists.",
+                "ZoneOnly": "Only accessible by endpoints that this zone explicitly lists."
+            },
+            "enumLongDescriptions": {
+                "GloballyAccessible": "This value shall indicate that any external entity with the correct access details, which may include authorization information, can access the endpoints that this zone lists, regardless of zone.",
+                "NoInternalRouting": "This value shall indicate that implicit routing within this zone is not defined.",
+                "NonZonedAccessible": "This value shall indicate that any external entity that another zone does not explicitly list can access the endpoints that this zone lists.",
+                "ZoneOnly": "This value shall indicate that endpoints in this zone are only accessible by endpoints that this zone explicitly lists."
+            },
+            "type": "string"
+        },
+        "Links": {
+            "additionalProperties": false,
+            "description": "The links to other resources that are related to this resource.",
+            "longDescription": "This Redfish Specification-described type shall contain links to resources that are related to but are not contained by, or subordinate to, this resource.",
+            "patternProperties": {
+                "^([a-zA-Z_][a-zA-Z0-9_]*)?@(odata|Redfish|Message)\\.[a-zA-Z_][a-zA-Z0-9_]*$": {
+                    "description": "This property shall specify a valid odata or Redfish property.",
+                    "type": [
+                        "array",
+                        "boolean",
+                        "integer",
+                        "number",
+                        "null",
+                        "object",
+                        "string"
+                    ]
+                }
+            },
+            "properties": {
+                "AddressPools": {
+                    "description": "An array of links to the address pools associated with this zone.",
+                    "items": {
+                        "$ref": "http://redfish.dmtf.org/schemas/v1/AddressPool.json#/definitions/AddressPool"
+                    },
+                    "longDescription": "This property shall contain an array of links to resources of type AddressPool with which this zone is associated.",
+                    "readonly": true,
+                    "type": "array",
+                    "versionAdded": "v1_4_0"
+                },
+                "AddressPools@odata.count": {
+                    "$ref": "http://redfish.dmtf.org/schemas/v1/odata-v4.json#/definitions/count"
+                },
+                "ContainedByZones": {
+                    "description": "An array of links to the zone that contain this zone.",
+                    "items": {
+                        "$ref": "http://redfish.dmtf.org/schemas/v1/Zone.json#/definitions/Zone"
+                    },
+                    "longDescription": "This property shall contain an array of links to resources of type Zone that represent the zones that contain this zone.  The zones referenced by this property shall not be contained by other zones.",
+                    "readonly": true,
+                    "type": "array",
+                    "versionAdded": "v1_4_0"
+                },
+                "ContainedByZones@odata.count": {
+                    "$ref": "http://redfish.dmtf.org/schemas/v1/odata-v4.json#/definitions/count"
+                },
+                "ContainsZones": {
+                    "description": "An array of links to the zones that are contained by this zone.",
+                    "items": {
+                        "$ref": "http://redfish.dmtf.org/schemas/v1/Zone.json#/definitions/Zone"
+                    },
+                    "longDescription": "This property shall contain an array of links to resources of type Zone that represent the zones that are contained by this zone.  The zones referenced by this property shall not contain other zones.",
+                    "readonly": false,
+                    "type": "array",
+                    "versionAdded": "v1_4_0"
+                },
+                "ContainsZones@odata.count": {
+                    "$ref": "http://redfish.dmtf.org/schemas/v1/odata-v4.json#/definitions/count"
+                },
+                "Endpoints": {
+                    "description": "The links to the endpoints that this zone contains.",
+                    "items": {
+                        "$ref": "http://redfish.dmtf.org/schemas/v1/Endpoint.json#/definitions/Endpoint"
+                    },
+                    "longDescription": "This property shall contain an array of links to resources of type Endpoint that this zone contains.",
+                    "readonly": true,
+                    "type": "array"
+                },
+                "Endpoints@odata.count": {
+                    "$ref": "http://redfish.dmtf.org/schemas/v1/odata-v4.json#/definitions/count"
+                },
+                "InvolvedSwitches": {
+                    "description": "The links to the collection of switches in this zone.",
+                    "items": {
+                        "$ref": "http://redfish.dmtf.org/schemas/v1/Switch.json#/definitions/Switch"
+                    },
+                    "longDescription": "This property shall contain an array of links to resources of type Switch in this zone.",
+                    "readonly": true,
+                    "type": "array"
+                },
+                "InvolvedSwitches@odata.count": {
+                    "$ref": "http://redfish.dmtf.org/schemas/v1/odata-v4.json#/definitions/count"
+                },
+                "Oem": {
+                    "$ref": "http://redfish.dmtf.org/schemas/v1/Resource.json#/definitions/Oem",
+                    "description": "The OEM extension property.",
+                    "longDescription": "This property shall contain the OEM extensions.  All values for properties contained in this object shall conform to the Redfish Specification-described requirements."
+                },
+                "ResourceBlocks": {
+                    "description": "The links to the resource blocks with which this zone is associated.",
+                    "items": {
+                        "$ref": "http://redfish.dmtf.org/schemas/v1/ResourceBlock.json#/definitions/ResourceBlock"
+                    },
+                    "longDescription": "This property shall contain an array of links to resources of type ResourceBlock with which this zone is associated.",
+                    "readonly": true,
+                    "type": "array",
+                    "versionAdded": "v1_1_0"
+                },
+                "ResourceBlocks@odata.count": {
+                    "$ref": "http://redfish.dmtf.org/schemas/v1/odata-v4.json#/definitions/count"
+                }
+            },
+            "type": "object"
+        },
+        "OemActions": {
+            "additionalProperties": true,
+            "description": "The available OEM-specific actions for this resource.",
+            "longDescription": "This type shall contain the available OEM-specific actions for this resource.",
+            "patternProperties": {
+                "^([a-zA-Z_][a-zA-Z0-9_]*)?@(odata|Redfish|Message)\\.[a-zA-Z_][a-zA-Z0-9_]*$": {
+                    "description": "This property shall specify a valid odata or Redfish property.",
+                    "type": [
+                        "array",
+                        "boolean",
+                        "integer",
+                        "number",
+                        "null",
+                        "object",
+                        "string"
+                    ]
+                }
+            },
+            "properties": {},
+            "type": "object"
+        },
+        "RemoveEndpoint": {
+            "additionalProperties": false,
+            "description": "This action removes an endpoint from a zone.",
+            "longDescription": "This action shall remove an endpoint from a zone.",
+            "parameters": {
+                "Endpoint": {
+                    "$ref": "http://redfish.dmtf.org/schemas/v1/Endpoint.json#/definitions/Endpoint",
+                    "description": "The endpoint to remove from the zone.",
+                    "longDescription": "This parameter shall contain a link to the specified endpoint to remove from the zone.",
+                    "requiredParameter": true
+                },
+                "EndpointETag": {
+                    "description": "The current ETag of the endpoint to remove from the system.",
+                    "longDescription": "This parameter shall contain the current ETag of the endpoint to remove from the system.  If the client-provided ETag does not match the current ETag of the endpoint that the Endpoint parameter specifies, the service shall return the HTTP 428 (Precondition Required) status code to reject the request.",
+                    "type": "string"
+                },
+                "ZoneETag": {
+                    "description": "The current ETag of the zone.",
+                    "longDescription": "This parameter shall contain the current ETag of the zone.  If the client-provided ETag does not match the current ETag of the zone, the service shall return the HTTP 428 (Precondition Required) status code to reject the request.",
+                    "type": "string"
+                }
+            },
+            "patternProperties": {
+                "^([a-zA-Z_][a-zA-Z0-9_]*)?@(odata|Redfish|Message)\\.[a-zA-Z_][a-zA-Z0-9_]*$": {
+                    "description": "This property shall specify a valid odata or Redfish property.",
+                    "type": [
+                        "array",
+                        "boolean",
+                        "integer",
+                        "number",
+                        "null",
+                        "object",
+                        "string"
+                    ]
+                }
+            },
+            "properties": {
+                "target": {
+                    "description": "Link to invoke action",
+                    "format": "uri-reference",
+                    "type": "string"
+                },
+                "title": {
+                    "description": "Friendly action name",
+                    "type": "string"
+                }
+            },
+            "type": "object",
+            "versionAdded": "v1_5_0"
+        },
+        "Zone": {
+            "additionalProperties": false,
+            "description": "The Zone schema describes a simple fabric zone for a Redfish implementation.",
+            "longDescription": "This resource shall represent a simple fabric zone for a Redfish implementation.",
+            "patternProperties": {
+                "^([a-zA-Z_][a-zA-Z0-9_]*)?@(odata|Redfish|Message)\\.[a-zA-Z_][a-zA-Z0-9_]*$": {
+                    "description": "This property shall specify a valid odata or Redfish property.",
+                    "type": [
+                        "array",
+                        "boolean",
+                        "integer",
+                        "number",
+                        "null",
+                        "object",
+                        "string"
+                    ]
+                }
+            },
+            "properties": {
+                "@odata.context": {
+                    "$ref": "http://redfish.dmtf.org/schemas/v1/odata-v4.json#/definitions/context"
+                },
+                "@odata.etag": {
+                    "$ref": "http://redfish.dmtf.org/schemas/v1/odata-v4.json#/definitions/etag"
+                },
+                "@odata.id": {
+                    "$ref": "http://redfish.dmtf.org/schemas/v1/odata-v4.json#/definitions/id"
+                },
+                "@odata.type": {
+                    "$ref": "http://redfish.dmtf.org/schemas/v1/odata-v4.json#/definitions/type"
+                },
+                "Actions": {
+                    "$ref": "#/definitions/Actions",
+                    "description": "The available actions for this resource.",
+                    "longDescription": "This property shall contain the available actions for this resource.",
+                    "versionAdded": "v1_1_0"
+                },
+                "DefaultRoutingEnabled": {
+                    "description": "This property indicates whether routing within this zone is enabled.",
+                    "longDescription": "This property shall indicate whether routing within this zone is enabled.",
+                    "readonly": false,
+                    "type": [
+                        "boolean",
+                        "null"
+                    ],
+                    "versionAdded": "v1_4_0"
+                },
+                "Description": {
+                    "anyOf": [
+                        {
+                            "$ref": "http://redfish.dmtf.org/schemas/v1/Resource.json#/definitions/Description"
+                        },
+                        {
+                            "type": "null"
+                        }
+                    ],
+                    "readonly": true
+                },
+                "ExternalAccessibility": {
+                    "anyOf": [
+                        {
+                            "$ref": "#/definitions/ExternalAccessibility"
+                        },
+                        {
+                            "type": "null"
+                        }
+                    ],
+                    "description": "Indicates accessibility of endpoints in this zone to endpoints outside of this zone.",
+                    "longDescription": "This property shall contain and indication of accessibility of endpoints in this zone to endpoints outside of this zone.",
+                    "readonly": false,
+                    "versionAdded": "v1_3_0"
+                },
+                "Id": {
+                    "$ref": "http://redfish.dmtf.org/schemas/v1/Resource.json#/definitions/Id",
+                    "readonly": true
+                },
+                "Identifiers": {
+                    "description": "The durable names for the zone.",
+                    "items": {
+                        "$ref": "http://redfish.dmtf.org/schemas/v1/Resource.json#/definitions/Identifier"
+                    },
+                    "longDescription": "This property shall contain a list of all known durable names for the associated zone.",
+                    "type": "array",
+                    "versionAdded": "v1_2_0"
+                },
+                "Links": {
+                    "$ref": "#/definitions/Links",
+                    "description": "The links to other resources that are related to this resource.",
+                    "longDescription": "This property shall contain links to resources that are related to but are not contained by, or subordinate to, this resource."
+                },
+                "Name": {
+                    "$ref": "http://redfish.dmtf.org/schemas/v1/Resource.json#/definitions/Name",
+                    "readonly": true
+                },
+                "Oem": {
+                    "$ref": "http://redfish.dmtf.org/schemas/v1/Resource.json#/definitions/Oem",
+                    "description": "The OEM extension property.",
+                    "longDescription": "This property shall contain the OEM extensions.  All values for properties that this object contains shall conform to the Redfish Specification-described requirements."
+                },
+                "Status": {
+                    "$ref": "http://redfish.dmtf.org/schemas/v1/Resource.json#/definitions/Status",
+                    "description": "The status and health of the resource and its subordinate or dependent resources.",
+                    "longDescription": "This property shall contain any status or health properties of the resource."
+                },
+                "ZoneType": {
+                    "anyOf": [
+                        {
+                            "$ref": "#/definitions/ZoneType"
+                        },
+                        {
+                            "type": "null"
+                        }
+                    ],
+                    "description": "The type of zone.",
+                    "longDescription": "This property shall contain the type of zone that this zone represents.",
+                    "readonly": false,
+                    "versionAdded": "v1_4_0"
+                }
+            },
+            "required": [
+                "@odata.id",
+                "@odata.type",
+                "Id",
+                "Name"
+            ],
+            "type": "object"
+        },
+        "ZoneType": {
+            "enum": [
+                "Default",
+                "ZoneOfEndpoints",
+                "ZoneOfZones",
+                "ZoneOfResourceBlocks"
+            ],
+            "enumDescriptions": {
+                "Default": "The zone in which all endpoints are added by default when instantiated.",
+                "ZoneOfEndpoints": "A zone that contains endpoints.",
+                "ZoneOfResourceBlocks": "A zone that contains resource blocks.",
+                "ZoneOfZones": "A zone that contains zones."
+            },
+            "enumLongDescriptions": {
+                "Default": "This value shall indicate a zone in which all endpoints are added by default when instantiated.  This value shall only be used for zones subordinate to the fabric collection.",
+                "ZoneOfEndpoints": "This value shall indicate a zone that contains resources of type Endpoint.  This value shall only be used for zones subordinate to the fabric collection.",
+                "ZoneOfResourceBlocks": "This value shall indicate a zone that contains resources of type ResourceBlock.  This value shall only be used for zones subordinate to the composition service.",
+                "ZoneOfZones": "This value shall indicate a zone that contains resources of type Zone.  This value shall only be used for zones subordinate to the fabric collection."
+            },
+            "enumVersionAdded": {
+                "ZoneOfResourceBlocks": "v1_6_0"
+            },
+            "type": "string"
+        }
+    },
+    "owningEntity": "DMTF",
+    "release": "2020.4",
+    "title": "#Zone.v1_6_1.Zone"
+}

--- a/static/redfish/v1/JsonSchemas/Zone/index.json
+++ b/static/redfish/v1/JsonSchemas/Zone/index.json
@@ -1,0 +1,21 @@
+{
+    "@odata.context": "/redfish/v1/$metadata#JsonSchemaFile.JsonSchemaFile",
+    "@odata.id": "/redfish/v1/JsonSchemas/Zone",
+    "@odata.type": "#JsonSchemaFile.v1_0_2.JsonSchemaFile",
+    "Name": "Zone Schema File",
+    "Schema": "#Zone.Zone",
+    "Description": "Zone Schema File Location",
+    "Id": "Zone",
+    "Languages": [
+        "en"
+    ],
+    "Languages@odata.count": 1,
+    "Location": [
+        {
+            "Language": "en",
+            "PublicationUri": "http://redfish.dmtf.org/schemas/v1/Zone.json",
+            "Uri": "/redfish/v1/JsonSchemas/Zone/Zone.json"
+        }
+    ],
+    "Location@odata.count": 1
+}

--- a/static/redfish/v1/JsonSchemas/index.json
+++ b/static/redfish/v1/JsonSchemas/index.json
@@ -4,13 +4,31 @@
   "@odata.type": "#JsonSchemaFileCollection.JsonSchemaFileCollection",
   "Name": "JsonSchemaFile Collection",
   "Description": "Collection of JsonSchemaFiles",
-  "Members@odata.count": 65,
+  "Members@odata.count": 132,
   "Members": [
+    {
+      "@odata.id": "/redfish/v1/JsonSchemas/AccelerationFunction"
+    },
     {
       "@odata.id": "/redfish/v1/JsonSchemas/AccountService"
     },
     {
       "@odata.id": "/redfish/v1/JsonSchemas/ActionInfo"
+    },
+    {
+      "@odata.id": "/redfish/v1/JsonSchemas/AddressPool"
+    },
+    {
+      "@odata.id": "/redfish/v1/JsonSchemas/Aggregate"
+    },
+    {
+      "@odata.id": "/redfish/v1/JsonSchemas/AggregationService"
+    },
+    {
+      "@odata.id": "/redfish/v1/JsonSchemas/AggregationSource"
+    },
+    {
+      "@odata.id": "/redfish/v1/JsonSchemas/AllowDeny"
     },
     {
       "@odata.id": "/redfish/v1/JsonSchemas/Assembly"
@@ -19,7 +37,19 @@
       "@odata.id": "/redfish/v1/JsonSchemas/AttributeRegistry"
     },
     {
+      "@odata.id": "/redfish/v1/JsonSchemas/Battery"
+    },
+    {
+      "@odata.id": "/redfish/v1/JsonSchemas/BatteryMetrics"
+    },
+    {
       "@odata.id": "/redfish/v1/JsonSchemas/Bios"
+    },
+    {
+      "@odata.id": "/redfish/v1/JsonSchemas/BootOption"
+    },
+    {
+      "@odata.id": "/redfish/v1/JsonSchemas/Cable"
     },
     {
       "@odata.id": "/redfish/v1/JsonSchemas/Certificate"
@@ -34,10 +64,40 @@
       "@odata.id": "/redfish/v1/JsonSchemas/Chassis"
     },
     {
+      "@odata.id": "/redfish/v1/JsonSchemas/Circuit"
+    },
+    {
+      "@odata.id": "/redfish/v1/JsonSchemas/CollectionCapabilities"
+    },
+    {
+      "@odata.id": "/redfish/v1/JsonSchemas/CompositionReservation"
+    },
+    {
+      "@odata.id": "/redfish/v1/JsonSchemas/CompositionService"
+    },
+    {
       "@odata.id": "/redfish/v1/JsonSchemas/ComputerSystem"
     },
     {
+      "@odata.id": "/redfish/v1/JsonSchemas/Connection"
+    },
+    {
+      "@odata.id": "/redfish/v1/JsonSchemas/ConnectionMethod"
+    },
+    {
+      "@odata.id": "/redfish/v1/JsonSchemas/Control"
+    },
+    {
       "@odata.id": "/redfish/v1/JsonSchemas/Drive"
+    },
+    {
+      "@odata.id": "/redfish/v1/JsonSchemas/Endpoint"
+    },
+    {
+      "@odata.id": "/redfish/v1/JsonSchemas/EndpointGroup"
+    },
+    {
+      "@odata.id": "/redfish/v1/JsonSchemas/EnvironmentMetrics"
     },
     {
       "@odata.id": "/redfish/v1/JsonSchemas/EthernetInterface"
@@ -52,16 +112,46 @@
       "@odata.id": "/redfish/v1/JsonSchemas/EventService"
     },
     {
+      "@odata.id": "/redfish/v1/JsonSchemas/ExternalAccountProvider"
+    },
+    {
+      "@odata.id": "/redfish/v1/JsonSchemas/Fabric"
+    },
+    {
       "@odata.id": "/redfish/v1/JsonSchemas/FabricAdapter"
+    },
+    {
+      "@odata.id": "/redfish/v1/JsonSchemas/Facility"
     },
     {
       "@odata.id": "/redfish/v1/JsonSchemas/Fan"
     },
     {
+      "@odata.id": "/redfish/v1/JsonSchemas/GraphicsController"
+    },
+    {
+      "@odata.id": "/redfish/v1/JsonSchemas/HostInterface"
+    },
+    {
       "@odata.id": "/redfish/v1/JsonSchemas/IPAddresses"
     },
     {
+      "@odata.id": "/redfish/v1/JsonSchemas/Job"
+    },
+    {
+      "@odata.id": "/redfish/v1/JsonSchemas/JobService"
+    },
+    {
       "@odata.id": "/redfish/v1/JsonSchemas/JsonSchemaFile"
+    },
+    {
+      "@odata.id": "/redfish/v1/JsonSchemas/Key"
+    },
+    {
+      "@odata.id": "/redfish/v1/JsonSchemas/KeyPolicy"
+    },
+    {
+      "@odata.id": "/redfish/v1/JsonSchemas/KeyService"
     },
     {
       "@odata.id": "/redfish/v1/JsonSchemas/LogEntry"
@@ -79,7 +169,22 @@
       "@odata.id": "/redfish/v1/JsonSchemas/ManagerNetworkProtocol"
     },
     {
+      "@odata.id": "/redfish/v1/JsonSchemas/Manifest"
+    },
+    {
+      "@odata.id": "/redfish/v1/JsonSchemas/MediaController"
+    },
+    {
       "@odata.id": "/redfish/v1/JsonSchemas/Memory"
+    },
+    {
+      "@odata.id": "/redfish/v1/JsonSchemas/MemoryChunks"
+    },
+    {
+      "@odata.id": "/redfish/v1/JsonSchemas/MemoryDomain"
+    },
+    {
+      "@odata.id": "/redfish/v1/JsonSchemas/MemoryMetrics"
     },
     {
       "@odata.id": "/redfish/v1/JsonSchemas/Message"
@@ -100,7 +205,31 @@
       "@odata.id": "/redfish/v1/JsonSchemas/MetricReportDefinition"
     },
     {
+      "@odata.id": "/redfish/v1/JsonSchemas/NetworkAdapter"
+    },
+    {
+      "@odata.id": "/redfish/v1/JsonSchemas/NetworkAdapterMetrics"
+    },
+    {
+      "@odata.id": "/redfish/v1/JsonSchemas/NetworkDeviceFunction"
+    },
+    {
+      "@odata.id": "/redfish/v1/JsonSchemas/NetworkDeviceFunctionMetrics"
+    },
+    {
+      "@odata.id": "/redfish/v1/JsonSchemas/NetworkInterface"
+    },
+    {
+      "@odata.id": "/redfish/v1/JsonSchemas/NetworkPort"
+    },
+    {
       "@odata.id": "/redfish/v1/JsonSchemas/OperatingConfig"
+    },
+    {
+      "@odata.id": "/redfish/v1/JsonSchemas/Outlet"
+    },
+    {
+      "@odata.id": "/redfish/v1/JsonSchemas/OutletGroup"
     },
     {
       "@odata.id": "/redfish/v1/JsonSchemas/PCIeDevice"
@@ -112,10 +241,28 @@
       "@odata.id": "/redfish/v1/JsonSchemas/PCIeSlots"
     },
     {
+      "@odata.id": "/redfish/v1/JsonSchemas/PhysicalContext"
+    },
+    {
       "@odata.id": "/redfish/v1/JsonSchemas/Port"
     },
     {
+      "@odata.id": "/redfish/v1/JsonSchemas/PortMetrics"
+    },
+    {
       "@odata.id": "/redfish/v1/JsonSchemas/Power"
+    },
+    {
+      "@odata.id": "/redfish/v1/JsonSchemas/PowerDistribution"
+    },
+    {
+      "@odata.id": "/redfish/v1/JsonSchemas/PowerDistributionMetrics"
+    },
+    {
+      "@odata.id": "/redfish/v1/JsonSchemas/PowerDomain"
+    },
+    {
+      "@odata.id": "/redfish/v1/JsonSchemas/PowerEquipment"
     },
     {
       "@odata.id": "/redfish/v1/JsonSchemas/PowerSubsystem"
@@ -124,10 +271,19 @@
       "@odata.id": "/redfish/v1/JsonSchemas/PowerSupply"
     },
     {
+      "@odata.id": "/redfish/v1/JsonSchemas/PowerSupplyMetrics"
+    },
+    {
+      "@odata.id": "/redfish/v1/JsonSchemas/PrivilegeRegistry"
+    },
+    {
       "@odata.id": "/redfish/v1/JsonSchemas/Privileges"
     },
     {
       "@odata.id": "/redfish/v1/JsonSchemas/Processor"
+    },
+    {
+      "@odata.id": "/redfish/v1/JsonSchemas/ProcessorMetrics"
     },
     {
       "@odata.id": "/redfish/v1/JsonSchemas/Redundancy"
@@ -136,10 +292,31 @@
       "@odata.id": "/redfish/v1/JsonSchemas/Resource"
     },
     {
+      "@odata.id": "/redfish/v1/JsonSchemas/ResourceBlock"
+    },
+    {
       "@odata.id": "/redfish/v1/JsonSchemas/Role"
     },
     {
+      "@odata.id": "/redfish/v1/JsonSchemas/RouteEntry"
+    },
+    {
+      "@odata.id": "/redfish/v1/JsonSchemas/RouteSetEntry"
+    },
+    {
+      "@odata.id": "/redfish/v1/JsonSchemas/Schedule"
+    },
+    {
+      "@odata.id": "/redfish/v1/JsonSchemas/SecureBoot"
+    },
+    {
+      "@odata.id": "/redfish/v1/JsonSchemas/SecureBootDatabase"
+    },
+    {
       "@odata.id": "/redfish/v1/JsonSchemas/Sensor"
+    },
+    {
+      "@odata.id": "/redfish/v1/JsonSchemas/SerialInterface"
     },
     {
       "@odata.id": "/redfish/v1/JsonSchemas/ServiceRoot"
@@ -154,6 +331,12 @@
       "@odata.id": "/redfish/v1/JsonSchemas/Settings"
     },
     {
+      "@odata.id": "/redfish/v1/JsonSchemas/Signature"
+    },
+    {
+      "@odata.id": "/redfish/v1/JsonSchemas/SimpleStorage"
+    },
+    {
       "@odata.id": "/redfish/v1/JsonSchemas/SoftwareInventory"
     },
     {
@@ -161,6 +344,9 @@
     },
     {
       "@odata.id": "/redfish/v1/JsonSchemas/StorageController"
+    },
+    {
+      "@odata.id": "/redfish/v1/JsonSchemas/Switch"
     },
     {
       "@odata.id": "/redfish/v1/JsonSchemas/Task"
@@ -181,13 +367,28 @@
       "@odata.id": "/redfish/v1/JsonSchemas/ThermalSubsystem"
     },
     {
+      "@odata.id": "/redfish/v1/JsonSchemas/Triggers"
+    },
+    {
+      "@odata.id": "/redfish/v1/JsonSchemas/USBController"
+    },
+    {
       "@odata.id": "/redfish/v1/JsonSchemas/UpdateService"
+    },
+    {
+      "@odata.id": "/redfish/v1/JsonSchemas/VCATEntry"
     },
     {
       "@odata.id": "/redfish/v1/JsonSchemas/VLanNetworkInterface"
     },
     {
       "@odata.id": "/redfish/v1/JsonSchemas/VirtualMedia"
+    },
+    {
+      "@odata.id": "/redfish/v1/JsonSchemas/Volume"
+    },
+    {
+      "@odata.id": "/redfish/v1/JsonSchemas/Zone"
     },
     {
       "@odata.id": "/redfish/v1/JsonSchemas/odata"

--- a/static/redfish/v1/schema/AccelerationFunctionCollection_v1.xml
+++ b/static/redfish/v1/schema/AccelerationFunctionCollection_v1.xml
@@ -1,0 +1,73 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!---->
+<!--################################################################################       -->
+<!--# Redfish Schema:  AccelerationFunctionCollection                                      -->
+<!--#                                                                                      -->
+<!--# For a detailed change log, see the README file contained in the DSP8010 bundle,      -->
+<!--# available at http://www.dmtf.org/standards/redfish                                   -->
+<!--# Copyright 2014-2021 DMTF.                                                            -->
+<!--# For the full DMTF copyright policy, see http://www.dmtf.org/about/policies/copyright -->
+<!--################################################################################       -->
+<!---->
+<edmx:Edmx xmlns:edmx="http://docs.oasis-open.org/odata/ns/edmx" Version="4.0">
+
+  <edmx:Reference Uri="http://docs.oasis-open.org/odata/odata/v4.0/errata03/csd01/complete/vocabularies/Org.OData.Core.V1.xml">
+    <edmx:Include Namespace="Org.OData.Core.V1" Alias="OData"/>
+  </edmx:Reference>
+  <edmx:Reference Uri="http://docs.oasis-open.org/odata/odata/v4.0/errata03/csd01/complete/vocabularies/Org.OData.Capabilities.V1.xml">
+    <edmx:Include Namespace="Org.OData.Capabilities.V1" Alias="Capabilities"/>
+  </edmx:Reference>
+  <edmx:Reference Uri="http://redfish.dmtf.org/schemas/v1/RedfishExtensions_v1.xml">
+    <edmx:Include Namespace="RedfishExtensions.v1_0_0" Alias="Redfish"/>
+  </edmx:Reference>
+  <edmx:Reference Uri="http://redfish.dmtf.org/schemas/v1/Resource_v1.xml">
+    <edmx:Include Namespace="Resource.v1_0_0"/>
+  </edmx:Reference>
+  <edmx:Reference Uri="http://redfish.dmtf.org/schemas/v1/AccelerationFunction_v1.xml">
+    <edmx:Include Namespace="AccelerationFunction"/>
+  </edmx:Reference>
+
+  <edmx:DataServices>
+
+    <Schema xmlns="http://docs.oasis-open.org/odata/ns/edm" Namespace="AccelerationFunctionCollection">
+      <Annotation Term="Redfish.OwningEntity" String="DMTF"/>
+
+      <EntityType Name="AccelerationFunctionCollection" BaseType="Resource.v1_0_0.ResourceCollection">
+        <Annotation Term="OData.Description" String="The AccelerationFunctionCollection schema defines a collection of acceleration functions."/>
+        <Annotation Term="OData.LongDescription" String="This Resource shall represent a Resource Collection of AccelerationFunction instances for a Redfish implementation."/>
+        <Annotation Term="Capabilities.InsertRestrictions">
+          <Record>
+            <PropertyValue Property="Insertable" Bool="false"/>
+          </Record>
+        </Annotation>
+        <Annotation Term="Capabilities.UpdateRestrictions">
+          <Record>
+            <PropertyValue Property="Updatable" Bool="false"/>
+          </Record>
+        </Annotation>
+        <Annotation Term="Capabilities.DeleteRestrictions">
+          <Record>
+            <PropertyValue Property="Deletable" Bool="false"/>
+          </Record>
+        </Annotation>
+        <Annotation Term="Redfish.Uris">
+          <Collection>
+            <String>/redfish/v1/Systems/{ComputerSystemId}/Processors/{ProcessorId}/AccelerationFunctions</String>
+            <String>/redfish/v1/CompositionService/ResourceBlocks/{ResourceBlockId}/Processors/{ProcessorId}/AccelerationFunctions</String>
+            <String>/redfish/v1/CompositionService/ResourceBlocks/{ResourceBlockId}/Systems/{ComputerSystemId}/Processors/{ProcessorId}/AccelerationFunctions</String>
+            <String>/redfish/v1/ResourceBlocks/{ResourceBlockId}/Processors/{ProcessorId}/AccelerationFunctions</String>
+            <String>/redfish/v1/ResourceBlocks/{ResourceBlockId}/Systems/{ComputerSystemId}/Processors/{ProcessorId}/AccelerationFunctions</String>
+          </Collection>
+        </Annotation>
+        <NavigationProperty Name="Members" Type="Collection(AccelerationFunction.AccelerationFunction)">
+          <Annotation Term="OData.Permissions" EnumMember="OData.Permission/Read"/>
+          <Annotation Term="OData.Description" String="The members of this collection."/>
+          <Annotation Term="OData.LongDescription" String="This property shall contain an array of links to the members of this Resource Collection."/>
+          <Annotation Term="OData.AutoExpandReferences"/>
+          <Annotation Term="Redfish.Required"/>
+        </NavigationProperty>
+      </EntityType>
+
+    </Schema>
+  </edmx:DataServices>
+</edmx:Edmx>

--- a/static/redfish/v1/schema/AccelerationFunction_v1.xml
+++ b/static/redfish/v1/schema/AccelerationFunction_v1.xml
@@ -1,0 +1,203 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!---->
+<!--################################################################################       -->
+<!--# Redfish Schema:  AccelerationFunction v1.0.3                                         -->
+<!--#                                                                                      -->
+<!--# For a detailed change log, see the README file contained in the DSP8010 bundle,      -->
+<!--# available at http://www.dmtf.org/standards/redfish                                   -->
+<!--# Copyright 2014-2021 DMTF.                                                            -->
+<!--# For the full DMTF copyright policy, see http://www.dmtf.org/about/policies/copyright -->
+<!--################################################################################       -->
+<!---->
+<edmx:Edmx xmlns:edmx="http://docs.oasis-open.org/odata/ns/edmx" Version="4.0">
+
+  <edmx:Reference Uri="http://docs.oasis-open.org/odata/odata/v4.0/errata03/csd01/complete/vocabularies/Org.OData.Core.V1.xml">
+    <edmx:Include Namespace="Org.OData.Core.V1" Alias="OData"/>
+  </edmx:Reference>
+  <edmx:Reference Uri="http://docs.oasis-open.org/odata/odata/v4.0/errata03/csd01/complete/vocabularies/Org.OData.Capabilities.V1.xml">
+    <edmx:Include Namespace="Org.OData.Capabilities.V1" Alias="Capabilities"/>
+  </edmx:Reference>
+  <edmx:Reference Uri="http://docs.oasis-open.org/odata/odata/v4.0/errata03/csd01/complete/vocabularies/Org.OData.Measures.V1.xml">
+    <edmx:Include Namespace="Org.OData.Measures.V1" Alias="Measures"/>
+  </edmx:Reference>
+  <edmx:Reference Uri="http://redfish.dmtf.org/schemas/v1/RedfishExtensions_v1.xml">
+    <edmx:Include Namespace="RedfishExtensions.v1_0_0" Alias="Redfish"/>
+  </edmx:Reference>
+  <edmx:Reference Uri="http://redfish.dmtf.org/schemas/v1/Resource_v1.xml">
+    <edmx:Include Namespace="Resource"/>
+    <edmx:Include Namespace="Resource.v1_0_0"/>
+  </edmx:Reference>
+  <edmx:Reference Uri="http://redfish.dmtf.org/schemas/v1/Endpoint_v1.xml">
+    <edmx:Include Namespace="Endpoint"/>
+  </edmx:Reference>
+  <edmx:Reference Uri="http://redfish.dmtf.org/schemas/v1/PCIeFunction_v1.xml">
+    <edmx:Include Namespace="PCIeFunction"/>
+  </edmx:Reference>
+
+  <edmx:DataServices>
+
+    <Schema xmlns="http://docs.oasis-open.org/odata/ns/edm" Namespace="AccelerationFunction">
+      <Annotation Term="Redfish.OwningEntity" String="DMTF"/>
+
+      <EntityType Name="AccelerationFunction" BaseType="Resource.v1_0_0.Resource" Abstract="true">
+        <Annotation Term="OData.Description" String="The AccelerationFunction schema describes an acceleration function that a processor implements.  This can include functions such as audio processing, compression, encryption, packet inspection, packet switching, scheduling, or video processing."/>
+        <Annotation Term="OData.LongDescription" String="This Resource shall represent the acceleration function that a processor implements in a Redfish implementation.  This can include functions such as audio processing, compression, encryption, packet inspection, packet switching, scheduling, or video processing."/>
+        <Annotation Term="OData.AdditionalProperties" Bool="false"/>
+        <Annotation Term="Capabilities.InsertRestrictions">
+          <Record>
+            <PropertyValue Property="Insertable" Bool="false"/>
+          </Record>
+        </Annotation>
+        <Annotation Term="Capabilities.UpdateRestrictions">
+          <Record>
+            <PropertyValue Property="Updatable" Bool="false"/>
+          </Record>
+        </Annotation>
+        <Annotation Term="Capabilities.DeleteRestrictions">
+          <Record>
+            <PropertyValue Property="Deletable" Bool="false"/>
+          </Record>
+        </Annotation>
+        <Annotation Term="Redfish.Uris">
+          <Collection>
+            <String>/redfish/v1/Systems/{ComputerSystemId}/Processors/{ProcessorId}/AccelerationFunctions/{AccelerationFunctionId}</String>
+            <String>/redfish/v1/CompositionService/ResourceBlocks/{ResourceBlockId}/Processors/{ProcessorId}/AccelerationFunctions/{AccelerationFunctionId}</String>
+            <String>/redfish/v1/CompositionService/ResourceBlocks/{ResourceBlockId}/Systems/{ComputerSystemId}/Processors/{ProcessorId}/AccelerationFunctions/{AccelerationFunctionId}</String>
+            <String>/redfish/v1/ResourceBlocks/{ResourceBlockId}/Processors/{ProcessorId}/AccelerationFunctions/{AccelerationFunctionId}</String>
+            <String>/redfish/v1/ResourceBlocks/{ResourceBlockId}/Systems/{ComputerSystemId}/Processors/{ProcessorId}/AccelerationFunctions/{AccelerationFunctionId}</String>
+          </Collection>
+        </Annotation>
+      </EntityType>
+    </Schema>
+
+    <Schema xmlns="http://docs.oasis-open.org/odata/ns/edm" Namespace="AccelerationFunction.v1_0_0">
+      <Annotation Term="Redfish.OwningEntity" String="DMTF"/>
+      <Annotation Term="Redfish.Release" String="2018.3"/>
+
+      <EntityType Name="AccelerationFunction" BaseType="AccelerationFunction.AccelerationFunction">
+        <Property Name="Status" Type="Resource.Status" Nullable="false">
+          <Annotation Term="OData.Description" String="The status and health of the Resource and its subordinate or dependent Resources."/>
+          <Annotation Term="OData.LongDescription" String="This property shall contain any status or health properties of the Resource."/>
+        </Property>
+        <Property Name="UUID" Type="Resource.UUID">
+          <Annotation Term="OData.Permissions" EnumMember="OData.Permission/Read"/>
+          <Annotation Term="OData.Description" String="The UUID for this acceleration function."/>
+          <Annotation Term="OData.LongDescription" String="This property shall contain a UUID for the acceleration function.  RFC4122 describes methods that can create the value.  The value should be considered to be opaque.  Client software should only treat the overall value as a UUID and should not interpret any sub-fields within the UUID."/>
+        </Property>
+        <Property Name="FpgaReconfigurationSlots" Type="Collection(Edm.String)" Nullable="false">
+          <Annotation Term="OData.Permissions" EnumMember="OData.Permission/Read"/>
+          <Annotation Term="OData.Description" String="An array of the reconfiguration slot identifiers of the FPGA that this acceleration function occupies."/>
+          <Annotation Term="OData.LongDescription" String="This property shall contain an array of the FPGA reconfiguration slot identifiers that this acceleration function occupies."/>
+        </Property>
+        <Property Name="AccelerationFunctionType" Type="AccelerationFunction.v1_0_0.AccelerationFunctionType">
+          <Annotation Term="OData.Permissions" EnumMember="OData.Permission/Read"/>
+          <Annotation Term="OData.Description" String="The acceleration function type."/>
+          <Annotation Term="OData.LongDescription" String="This property shall contain the string that identifies the acceleration function type."/>
+        </Property>
+        <Property Name="Manufacturer" Type="Edm.String" Nullable="false">
+          <Annotation Term="OData.Permissions" EnumMember="OData.Permission/Read"/>
+          <Annotation Term="OData.Description" String="The acceleration function code manufacturer."/>
+          <Annotation Term="OData.LongDescription" String="This property shall contain a string that identifies the manufacturer of the acceleration function."/>
+        </Property>
+        <Property Name="Version" Type="Edm.String" Nullable="false">
+          <Annotation Term="OData.Permissions" EnumMember="OData.Permission/Read"/>
+          <Annotation Term="OData.Description" String="The acceleration function version."/>
+          <Annotation Term="OData.LongDescription" String="This property shall describe the acceleration function version."/>
+        </Property>
+        <Property Name="PowerWatts" Type="Edm.Int64" Nullable="false">
+          <Annotation Term="OData.Permissions" EnumMember="OData.Permission/Read"/>
+          <Annotation Term="OData.Description" String="The acceleration function power consumption, in watts."/>
+          <Annotation Term="OData.LongDescription" String="This property shall contain the total acceleration function power consumption, in watts."/>
+          <Annotation Term="Measures.Unit" String="W"/>
+        </Property>
+        <Property Name="Links" Type="AccelerationFunction.v1_0_0.Links" Nullable="false">
+          <Annotation Term="OData.Description" String="The links to other Resources that are related to this Resource."/>
+          <Annotation Term="OData.LongDescription" String="This property shall contain links to Resources that are related to but are not contained by, or subordinate to, this Resource."/>
+        </Property>
+        <Property Name="Actions" Type="AccelerationFunction.v1_0_0.Actions" Nullable="false">
+          <Annotation Term="OData.Description" String="The available actions for this Resource."/>
+          <Annotation Term="OData.LongDescription" String="This property shall contain the available actions for this Resource."/>
+        </Property>
+      </EntityType>
+
+      <ComplexType Name="Links" BaseType="Resource.Links">
+        <Annotation Term="OData.Description" String="The links to other Resources that are related to this Resource."/>
+        <Annotation Term="OData.LongDescription" String="This Redfish Specification-described type shall contain links to Resources that are related to but are not contained by, or subordinate to, this Resource."/>
+        <NavigationProperty Name="Endpoints" Type="Collection(Endpoint.Endpoint)">
+          <Annotation Term="OData.Permissions" EnumMember="OData.Permission/Read"/>
+          <Annotation Term="OData.Description" String="An array of links to the endpoints that connect to this acceleration function."/>
+          <Annotation Term="OData.LongDescription" String="This property shall contain an array of links to Resources of the Endpoint type that are associated with this acceleration function."/>
+          <Annotation Term="OData.AutoExpandReferences"/>
+        </NavigationProperty>
+        <NavigationProperty Name="PCIeFunctions" Type="Collection(PCIeFunction.PCIeFunction)">
+          <Annotation Term="OData.Permissions" EnumMember="OData.Permission/Read"/>
+          <Annotation Term="OData.Description" String="An array of links to the PCIeFunctions associated with this acceleration function."/>
+          <Annotation Term="OData.LongDescription" String="This property shall contain an array of links of the PCIeFunction type that represent the PCIe functions associated with this acceleration function."/>
+          <Annotation Term="OData.AutoExpandReferences"/>
+        </NavigationProperty>
+      </ComplexType>
+
+      <ComplexType Name="Actions">
+        <Annotation Term="OData.AdditionalProperties" Bool="false"/>
+        <Annotation Term="OData.Description" String="The available actions for this Resource."/>
+        <Annotation Term="OData.LongDescription" String="This type shall contain the available actions for this Resource."/>
+        <Property Name="Oem" Type="AccelerationFunction.v1_0_0.OemActions" Nullable="false">
+          <Annotation Term="OData.Description" String="The available OEM-specific actions for this Resource."/>
+          <Annotation Term="OData.LongDescription" String="This property shall contain the available OEM-specific actions for this Resource."/>
+        </Property>
+      </ComplexType>
+
+      <ComplexType Name="OemActions">
+        <Annotation Term="OData.AdditionalProperties" Bool="true"/>
+        <Annotation Term="OData.Description" String="The available OEM-specific actions for this Resource."/>
+        <Annotation Term="OData.LongDescription" String="This type shall contain the available OEM-specific actions for this Resource."/>
+      </ComplexType>
+
+      <EnumType Name="AccelerationFunctionType">
+        <Member Name="Encryption">
+          <Annotation Term="OData.Description" String="An encryption function."/>
+        </Member>
+        <Member Name="Compression">
+          <Annotation Term="OData.Description" String="A compression function."/>
+        </Member>
+        <Member Name="PacketInspection">
+          <Annotation Term="OData.Description" String="A packet inspection function."/>
+        </Member>
+        <Member Name="PacketSwitch">
+          <Annotation Term="OData.Description" String="A packet switch function."/>
+        </Member>
+        <Member Name="Scheduler">
+          <Annotation Term="OData.Description" String="A scheduler function."/>
+        </Member>
+        <Member Name="AudioProcessing">
+          <Annotation Term="OData.Description" String="An audio processing function."/>
+        </Member>
+        <Member Name="VideoProcessing">
+          <Annotation Term="OData.Description" String="A video processing function."/>
+        </Member>
+        <Member Name="OEM">
+          <Annotation Term="OData.Description" String="An OEM-defined acceleration function."/>
+        </Member>
+      </EnumType>
+    </Schema>
+
+    <Schema xmlns="http://docs.oasis-open.org/odata/ns/edm" Namespace="AccelerationFunction.v1_0_1">
+      <Annotation Term="Redfish.OwningEntity" String="DMTF"/>
+      <Annotation Term="OData.Description" String="This version was created to force the regeneration of JSON Schema so that URI properties use the uri-reference format."/>
+      <EntityType Name="AccelerationFunction" BaseType="AccelerationFunction.v1_0_0.AccelerationFunction"/>
+    </Schema>
+
+    <Schema xmlns="http://docs.oasis-open.org/odata/ns/edm" Namespace="AccelerationFunction.v1_0_2">
+      <Annotation Term="Redfish.OwningEntity" String="DMTF"/>
+      <Annotation Term="OData.Description" String="This version was created to update descriptions that this schema defines."/>
+      <EntityType Name="AccelerationFunction" BaseType="AccelerationFunction.v1_0_1.AccelerationFunction"/>
+    </Schema>
+
+    <Schema xmlns="http://docs.oasis-open.org/odata/ns/edm" Namespace="AccelerationFunction.v1_0_3">
+      <Annotation Term="Redfish.OwningEntity" String="DMTF"/>
+      <Annotation Term="OData.Description" String="This version was created specify 64-bit integers in OpenAPI."/>
+      <EntityType Name="AccelerationFunction" BaseType="AccelerationFunction.v1_0_2.AccelerationFunction"/>
+    </Schema>
+
+  </edmx:DataServices>
+</edmx:Edmx>

--- a/static/redfish/v1/schema/AddressPoolCollection_v1.xml
+++ b/static/redfish/v1/schema/AddressPoolCollection_v1.xml
@@ -1,0 +1,70 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!---->
+<!--################################################################################       -->
+<!--# Redfish Schema:  AddressPoolCollection                                               -->
+<!--#                                                                                      -->
+<!--# For a detailed change log, see the README file contained in the DSP8010 bundle,      -->
+<!--# available at http://www.dmtf.org/standards/redfish                                   -->
+<!--# Copyright 2014-2021 DMTF.                                                            -->
+<!--# For the full DMTF copyright policy, see http://www.dmtf.org/about/policies/copyright -->
+<!--################################################################################       -->
+<!---->
+<edmx:Edmx xmlns:edmx="http://docs.oasis-open.org/odata/ns/edmx" Version="4.0">
+
+  <edmx:Reference Uri="http://docs.oasis-open.org/odata/odata/v4.0/errata03/csd01/complete/vocabularies/Org.OData.Core.V1.xml">
+    <edmx:Include Namespace="Org.OData.Core.V1" Alias="OData"/>
+  </edmx:Reference>
+  <edmx:Reference Uri="http://docs.oasis-open.org/odata/odata/v4.0/errata03/csd01/complete/vocabularies/Org.OData.Capabilities.V1.xml">
+    <edmx:Include Namespace="Org.OData.Capabilities.V1" Alias="Capabilities"/>
+  </edmx:Reference>
+  <edmx:Reference Uri="http://redfish.dmtf.org/schemas/v1/Resource_v1.xml">
+    <edmx:Include Namespace="Resource.v1_0_0"/>
+  </edmx:Reference>
+  <edmx:Reference Uri="http://redfish.dmtf.org/schemas/v1/RedfishExtensions_v1.xml">
+    <edmx:Include Namespace="RedfishExtensions.v1_0_0" Alias="Redfish"/>
+  </edmx:Reference>
+  <edmx:Reference Uri="http://redfish.dmtf.org/schemas/v1/AddressPool_v1.xml">
+    <edmx:Include Namespace="AddressPool"/>
+  </edmx:Reference>
+
+  <edmx:DataServices>
+
+    <Schema xmlns="http://docs.oasis-open.org/odata/ns/edm" Namespace="AddressPoolCollection">
+      <Annotation Term="Redfish.OwningEntity" String="DMTF"/>
+
+      <EntityType Name="AddressPoolCollection" BaseType="Resource.v1_0_0.ResourceCollection">
+        <Annotation Term="OData.Description" String="The collection of AddressPool resource instances."/>
+        <Annotation Term="OData.LongDescription" String="This resource shall represent a resource collection of AddressPool instances for a Redfish implementation."/>
+        <Annotation Term="Capabilities.InsertRestrictions">
+          <Record>
+            <PropertyValue Property="Insertable" Bool="true"/>
+            <Annotation Term="OData.Description" String="Create address pools through a POST to the address pool collection."/>
+          </Record>
+        </Annotation>
+        <Annotation Term="Capabilities.UpdateRestrictions">
+          <Record>
+            <PropertyValue Property="Updatable" Bool="false"/>
+          </Record>
+        </Annotation>
+        <Annotation Term="Capabilities.DeleteRestrictions">
+          <Record>
+            <PropertyValue Property="Deletable" Bool="false"/>
+          </Record>
+        </Annotation>
+        <Annotation Term="Redfish.Uris">
+          <Collection>
+            <String>/redfish/v1/Fabrics/{FabricId}/AddressPools</String>
+          </Collection>
+        </Annotation>
+        <NavigationProperty Name="Members" Type="Collection(AddressPool.AddressPool)">
+          <Annotation Term="OData.Permissions" EnumMember="OData.Permission/Read"/>
+          <Annotation Term="OData.Description" String="The members of this collection."/>
+          <Annotation Term="OData.LongDescription" String="This property shall contain an array of links to the members of this collection."/>
+          <Annotation Term="OData.AutoExpandReferences"/>
+          <Annotation Term="Redfish.Required"/>
+        </NavigationProperty>
+      </EntityType>
+    </Schema>
+
+  </edmx:DataServices>
+</edmx:Edmx>

--- a/static/redfish/v1/schema/AddressPool_v1.xml
+++ b/static/redfish/v1/schema/AddressPool_v1.xml
@@ -1,0 +1,933 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!---->
+<!--################################################################################       -->
+<!--# Redfish Schema:  AddressPool v1.2.0                                                  -->
+<!--#                                                                                      -->
+<!--# For a detailed change log, see the README file contained in the DSP8010 bundle,      -->
+<!--# available at http://www.dmtf.org/standards/redfish                                   -->
+<!--# Copyright 2014-2021 DMTF.                                                            -->
+<!--# For the full DMTF copyright policy, see http://www.dmtf.org/about/policies/copyright -->
+<!--################################################################################       -->
+<!---->
+<edmx:Edmx xmlns:edmx="http://docs.oasis-open.org/odata/ns/edmx" Version="4.0">
+
+  <edmx:Reference Uri="http://docs.oasis-open.org/odata/odata/v4.0/errata03/csd01/complete/vocabularies/Org.OData.Core.V1.xml">
+    <edmx:Include Namespace="Org.OData.Core.V1" Alias="OData"/>
+  </edmx:Reference>
+  <edmx:Reference Uri="http://docs.oasis-open.org/odata/odata/v4.0/errata03/csd01/complete/vocabularies/Org.OData.Capabilities.V1.xml">
+    <edmx:Include Namespace="Org.OData.Capabilities.V1" Alias="Capabilities"/>
+  </edmx:Reference>
+  <edmx:Reference Uri="http://docs.oasis-open.org/odata/odata/v4.0/errata03/csd01/complete/vocabularies/Org.OData.Measures.V1.xml">
+    <edmx:Include Namespace="Org.OData.Measures.V1" Alias="Measures"/>
+  </edmx:Reference>
+  <edmx:Reference Uri="http://redfish.dmtf.org/schemas/v1/Resource_v1.xml">
+    <edmx:Include Namespace="Resource"/>
+    <edmx:Include Namespace="Resource.v1_0_0"/>
+  </edmx:Reference>
+  <edmx:Reference Uri="http://redfish.dmtf.org/schemas/v1/RedfishExtensions_v1.xml">
+    <edmx:Include Namespace="RedfishExtensions.v1_0_0" Alias="Redfish"/>
+    <edmx:Include Namespace="Validation.v1_0_0" Alias="Validation"/>
+  </edmx:Reference>
+  <edmx:Reference Uri="http://redfish.dmtf.org/schemas/v1/Endpoint_v1.xml">
+    <edmx:Include Namespace="Endpoint"/>
+  </edmx:Reference>
+  <edmx:Reference Uri="http://redfish.dmtf.org/schemas/v1/Zone_v1.xml">
+    <edmx:Include Namespace="Zone"/>
+  </edmx:Reference>
+
+  <edmx:DataServices>
+
+    <Schema xmlns="http://docs.oasis-open.org/odata/ns/edm" Namespace="AddressPool">
+      <Annotation Term="Redfish.OwningEntity" String="DMTF"/>
+
+      <EntityType Name="AddressPool" BaseType="Resource.v1_0_0.Resource" Abstract="true">
+        <Annotation Term="OData.Description" String="The schema definition of an address pool and its configuration."/>
+        <Annotation Term="OData.LongDescription" String="This resource shall represent an address pool in a Redfish implementation."/>
+        <Annotation Term="OData.AdditionalProperties" Bool="false"/>
+        <Annotation Term="Capabilities.InsertRestrictions">
+          <Record>
+            <PropertyValue Property="Insertable" Bool="false"/>
+          </Record>
+        </Annotation>
+        <Annotation Term="Capabilities.UpdateRestrictions">
+          <Record>
+            <PropertyValue Property="Updatable" Bool="true"/>
+            <Annotation Term="OData.Description" String="Any writable properties can be updated for address pools."/>
+          </Record>
+        </Annotation>
+        <Annotation Term="Capabilities.DeleteRestrictions">
+          <Record>
+            <PropertyValue Property="Deletable" Bool="true"/>
+            <Annotation Term="OData.Description" String="Address pools can be deleted."/>
+          </Record>
+        </Annotation>
+        <Annotation Term="Redfish.Uris">
+          <Collection>
+            <String>/redfish/v1/Fabrics/{FabricId}/AddressPools/{AddressPoolId}</String>
+          </Collection>
+        </Annotation>
+      </EntityType>
+    </Schema>
+
+    <Schema xmlns="http://docs.oasis-open.org/odata/ns/edm" Namespace="AddressPool.v1_0_0">
+      <Annotation Term="Redfish.OwningEntity" String="DMTF"/>
+      <Annotation Term="Redfish.Release" String="2019.4"/>
+
+      <EntityType Name="AddressPool" BaseType="AddressPool.AddressPool">
+        <Property Name="Status" Type="Resource.Status" Nullable="false">
+          <Annotation Term="OData.Description" String="The status and health of the resource and its subordinate or dependent resources."/>
+          <Annotation Term="OData.LongDescription" String="This property shall contain any status or health properties of the resource."/>
+        </Property>
+        <Property Name="GenZ" Type="AddressPool.v1_0_0.GenZ" Nullable="false">
+          <Annotation Term="OData.Description" String="The Gen-Z related properties for this address pool."/>
+          <Annotation Term="OData.LongDescription" String="This property shall contain the Gen-Z related properties to this address pool."/>
+        </Property>
+        <Property Name="Links" Type="AddressPool.v1_0_0.Links" Nullable="false">
+          <Annotation Term="OData.Description" String="The links to other resources that are related to this resource."/>
+          <Annotation Term="OData.LongDescription" String="This property shall contain links to resources that are related to but are not contained by, or subordinate to, this resource."/>
+        </Property>
+        <Property Name="Actions" Type="AddressPool.v1_0_0.Actions" Nullable="false">
+          <Annotation Term="OData.Description" String="The available actions for this resource."/>
+          <Annotation Term="OData.LongDescription" String="This property shall contain the available actions for this resource."/>
+        </Property>
+      </EntityType>
+
+      <ComplexType Name="Links" BaseType="Resource.Links">
+        <Annotation Term="OData.Description" String="The links to other resources that are related to this resource."/>
+        <Annotation Term="OData.LongDescription" String="This Redfish Specification-described type shall contain links to resources that are related to but are not contained by, or subordinate to, this resource."/>
+        <NavigationProperty Name="Endpoints" Type="Collection(Endpoint.Endpoint)">
+          <Annotation Term="OData.Permissions" EnumMember="OData.Permission/ReadWrite"/>
+          <Annotation Term="OData.Description" String="An array of links to the endpoints that this address pool contains."/>
+          <Annotation Term="OData.LongDescription" String="This property shall contain an array of links to resources of type Endpoint that this address pool contains."/>
+          <Annotation Term="OData.AutoExpandReferences"/>
+        </NavigationProperty>
+        <NavigationProperty Name="Zones" Type="Collection(Zone.Zone)">
+          <Annotation Term="OData.Permissions" EnumMember="OData.Permission/ReadWrite"/>
+          <Annotation Term="OData.Description" String="An array of links to the zones that this address pool contains."/>
+          <Annotation Term="OData.LongDescription" String="This property shall contain an array of links to resources of type Zone that this address pool contains."/>
+          <Annotation Term="OData.AutoExpandReferences"/>
+        </NavigationProperty>
+      </ComplexType>
+
+      <ComplexType Name="GenZ">
+        <Annotation Term="OData.AdditionalProperties" Bool="false"/>
+        <Annotation Term="OData.Description" String="Gen-Z related properties for an address pool."/>
+        <Annotation Term="OData.LongDescription" String="This type shall contain Gen-Z related properties for an address pool."/>
+        <Property Name="MinCID" Type="Edm.Int64">
+          <Annotation Term="OData.Permissions" EnumMember="OData.Permission/ReadWrite"/>
+          <Annotation Term="OData.Description" String="The minimum value for the Component Identifier (CID)."/>
+          <Annotation Term="OData.LongDescription" String="This property shall contain the minimum value for the Gen-Z Core Specification-defined Component Identifier (CID)."/>
+        </Property>
+        <Property Name="MaxCID" Type="Edm.Int64">
+          <Annotation Term="OData.Permissions" EnumMember="OData.Permission/ReadWrite"/>
+          <Annotation Term="OData.Description" String="The maximum value for the Component Identifier (CID)."/>
+          <Annotation Term="OData.LongDescription" String="This property shall contain the maximum value for the Gen-Z Core Specification-defined Component Identifier (CID)."/>
+        </Property>
+        <Property Name="MinSID" Type="Edm.Int64">
+          <Annotation Term="OData.Permissions" EnumMember="OData.Permission/ReadWrite"/>
+          <Annotation Term="OData.Description" String="The minimum value for the Subnet Identifier (SID)."/>
+          <Annotation Term="OData.LongDescription" String="This property shall contain the minimum value for the Gen-Z Core Specification-defined Subnet Identifier (SID)."/>
+        </Property>
+        <Property Name="MaxSID" Type="Edm.Int64">
+          <Annotation Term="OData.Permissions" EnumMember="OData.Permission/ReadWrite"/>
+          <Annotation Term="OData.Description" String="The maximum value for the Subnet Identifier (SID)."/>
+          <Annotation Term="OData.LongDescription" String="This property shall contain the maximum value for the Gen-Z Core Specification-defined Subnet Identifier (SID)."/>
+        </Property>
+        <Property Name="AccessKey" Type="Edm.String">
+          <Annotation Term="OData.Permissions" EnumMember="OData.Permission/ReadWrite"/>
+          <Annotation Term="OData.Description" String="The Access Key required for this address pool."/>
+          <Annotation Term="OData.LongDescription" String="This property shall contain the Gen-Z Core Specification-defined Access Key required for this address pool."/>
+          <Annotation Term="Validation.Pattern" String="^0[xX]([a-fA-F]|[0-9]){2}$"/>
+        </Property>
+      </ComplexType>
+
+      <ComplexType Name="Actions">
+        <Annotation Term="OData.AdditionalProperties" Bool="false"/>
+        <Annotation Term="OData.Description" String="The available actions for this resource."/>
+        <Annotation Term="OData.LongDescription" String="This type shall contain the available actions for this resource."/>
+        <Property Name="Oem" Type="AddressPool.v1_0_0.OemActions" Nullable="false">
+          <Annotation Term="OData.Description" String="The available OEM-specific actions for this resource."/>
+          <Annotation Term="OData.LongDescription" String="This property shall contain the available OEM-specific actions for this resource."/>
+        </Property>
+      </ComplexType>
+
+      <ComplexType Name="OemActions">
+        <Annotation Term="OData.AdditionalProperties" Bool="true"/>
+        <Annotation Term="OData.Description" String="The available OEM-specific actions for this resource."/>
+        <Annotation Term="OData.LongDescription" String="This type shall contain the available OEM-specific actions for this resource."/>
+      </ComplexType>
+    </Schema>
+
+    <Schema xmlns="http://docs.oasis-open.org/odata/ns/edm" Namespace="AddressPool.v1_0_1">
+      <Annotation Term="Redfish.OwningEntity" String="DMTF"/>
+      <Annotation Term="OData.Description" String="This version was created to correct various typographical errors."/>
+      <EntityType Name="AddressPool" BaseType="AddressPool.v1_0_0.AddressPool"/>
+    </Schema>
+
+    <Schema xmlns="http://docs.oasis-open.org/odata/ns/edm" Namespace="AddressPool.v1_0_2">
+      <Annotation Term="Redfish.OwningEntity" String="DMTF"/>
+      <Annotation Term="OData.Description" String="This version was created to correct various typographical errors."/>
+      <EntityType Name="AddressPool" BaseType="AddressPool.v1_0_1.AddressPool"/>
+    </Schema>
+
+    <Schema xmlns="http://docs.oasis-open.org/odata/ns/edm" Namespace="AddressPool.v1_1_0">
+      <Annotation Term="Redfish.OwningEntity" String="DMTF"/>
+      <Annotation Term="OData.Description" String="This version was created to add Ethernet address pool definitions and update permissions for Endpoints and Zones."/>
+      <Annotation Term="Redfish.Release" String="2020.3"/>
+
+      <EntityType Name="AddressPool" BaseType="AddressPool.v1_0_0.AddressPool">
+        <Property Name="Ethernet" Type="AddressPool.v1_1_0.Ethernet" Nullable="false">
+          <Annotation Term="OData.Description" String="The Ethernet related properties for this address pool."/>
+          <Annotation Term="OData.LongDescription" String="This property shall contain the Ethernet related properties to this address pool."/>
+        </Property>
+      </EntityType>
+
+      <ComplexType Name="Ethernet">
+        <Annotation Term="OData.AdditionalProperties" Bool="false"/>
+        <Annotation Term="OData.Description" String="Ethernet related properties for an address pool."/>
+        <Annotation Term="OData.LongDescription" String="This type shall contain the Ethernet related properties for an address pool."/>
+        <Property Name="IPv4" Type="AddressPool.v1_1_0.IPv4">
+          <Annotation Term="OData.Description" String="IPv4 and Virtual LAN (VLAN) related addressing for this Ethernet fabric."/>
+          <Annotation Term="OData.LongDescription" String="This property shall contain IPv4 and Virtual LAN (VLAN) addressing related properties for this Ethernet fabric."/>
+        </Property>
+        <Property Name="BGPEvpn" Type="AddressPool.v1_1_0.BGPEvpn">
+          <Annotation Term="OData.Description" String="BGP Ethernet Virtual Private Network (EVPN) related properties for this Ethernet fabric."/>
+          <Annotation Term="OData.LongDescription" String="This property shall contain the BGP Ethernet Virtual Private Network (EVPN) related properties for this Ethernet fabric."/>
+        </Property>
+        <Property Name="EBGP" Type="AddressPool.v1_1_0.EBGP">
+          <Annotation Term="OData.Description" String="External BGP (eBGP) related properties for this Ethernet fabric."/>
+          <Annotation Term="OData.LongDescription" String="This property shall contain the External BGP (eBGP) related properties for this Ethernet fabric."/>
+        </Property>
+        <Property Name="MultiProtocolIBGP" Type="AddressPool.v1_1_0.CommonBGPProperties">
+          <Annotation Term="OData.Description" String="Multi Protocol iBGP (MP iBGP) related properties for this Ethernet fabric."/>
+          <Annotation Term="OData.LongDescription" String="This property shall contain the Multi Protocol iBGP (MP iBGP) related properties for this Ethernet fabric."/>
+        </Property>
+        <Property Name="MultiProtocolEBGP" Type="AddressPool.v1_1_0.EBGP">
+          <Annotation Term="OData.Description" String="Multi Protocol eBGP (MP eBGP) related properties for this Ethernet fabric."/>
+          <Annotation Term="OData.LongDescription" String="This property shall contain the Multi Protocol eBGP (MP eBGP) related properties for this Ethernet fabric."/>
+        </Property>
+        <Property Name="BFDSingleHopOnly" Type="AddressPool.v1_1_0.BFDSingleHopOnly">
+          <Annotation Term="OData.Description" String="Bidirectional Forwarding Detection (BFD) related properties for this Ethernet fabric."/>
+          <Annotation Term="OData.LongDescription" String="This property shall contain the Bidirectional Forwarding Detection (BFD) related properties for this Ethernet fabric."/>
+        </Property>
+      </ComplexType>
+
+      <ComplexType Name="IPv4">
+        <Annotation Term="OData.AdditionalProperties" Bool="false"/>
+        <Annotation Term="OData.Description" String="IPv4 and Virtual LAN (VLAN) related addressing for an Ethernet fabric."/>
+        <Annotation Term="OData.LongDescription" String="This type shall contain IPv4 and Virtual LAN (VLAN) addressing related properties for an Ethernet fabric."/>
+        <Property Name="VLANIdentifierAddressRange" Type="AddressPool.v1_1_0.VLANIdentifierAddressRange">
+          <Annotation Term="OData.Description" String="Virtual LAN (VLAN) tag related addressing for this Ethernet fabric or for end host networks."/>
+          <Annotation Term="OData.LongDescription" String="This property shall contain Virtual LAN (VLAN) tags for the entire fabric as well as to end hosts."/>
+        </Property>
+        <Property Name="HostAddressRange" Type="AddressPool.v1_1_0.IPv4AddressRange">
+          <Annotation Term="OData.Description" String="IPv4 related end host subnet addressing for this Ethernet fabric."/>
+          <Annotation Term="OData.LongDescription" String="This property shall contain the range of IP subnets used for host addressing."/>
+        </Property>
+        <Property Name="LoopbackAddressRange" Type="AddressPool.v1_1_0.IPv4AddressRange">
+          <Annotation Term="OData.Description" String="Loopback related addressing for this Ethernet fabric."/>
+          <Annotation Term="OData.LongDescription" String="This property shall contain the range of loopback addresses assigned to Ethernet switches."/>
+        </Property>
+        <Property Name="FabricLinkAddressRange" Type="AddressPool.v1_1_0.IPv4AddressRange">
+          <Annotation Term="OData.Description" String="Link related addressing for this Ethernet fabric."/>
+          <Annotation Term="OData.LongDescription" String="This property shall contain the range of link IPv4 addressing between Ethernet switches."/>
+        </Property>
+        <Property Name="ManagementAddressRange" Type="AddressPool.v1_1_0.IPv4AddressRange">
+          <Annotation Term="OData.Description" String="Management related addressing for this Ethernet fabric."/>
+          <Annotation Term="OData.LongDescription" String="This property shall contain the range of management IPv4 addresses assigned to Ethernet switches."/>
+        </Property>
+        <Property Name="IBGPAddressRange" Type="AddressPool.v1_1_0.IPv4AddressRange">
+          <Annotation Term="OData.Description" String="Internal BGP (iBGP) related addressing for this Ethernet fabric."/>
+          <Annotation Term="OData.LongDescription" String="This property shall contain the range of IPv4 addresses assigned to Internal BGP (iBGP)."/>
+        </Property>
+        <Property Name="EBGPAddressRange" Type="AddressPool.v1_1_0.IPv4AddressRange">
+          <Annotation Term="OData.Description" String="External BGP (eBGP) related addressing for this Ethernet fabric."/>
+          <Annotation Term="OData.LongDescription" String="This property shall contain the range of IPv4 addresses assigned to External BGP (eBGP)."/>
+        </Property>
+        <Property Name="DNSServer" Type="Collection(Edm.String)">
+          <Annotation Term="OData.Permissions" EnumMember="OData.Permission/ReadWrite"/>
+          <Annotation Term="OData.Description" String="The Domain Name Service (DNS) servers for this Ethernet fabric."/>
+          <Annotation Term="OData.LongDescription" String="This property shall contain an array of the Domain Name Service (DNS) servers for this Ethernet fabric."/>
+          <Annotation Term="Validation.Pattern" String="^(?:[0-9]{1,3}\.){3}[0-9]{1,3}$"/>
+        </Property>
+        <Property Name="NTPServer" Type="Collection(Edm.String)">
+          <Annotation Term="OData.Permissions" EnumMember="OData.Permission/ReadWrite"/>
+          <Annotation Term="OData.Description" String="The Network Time Protocol (NTP) servers for this Ethernet fabric."/>
+          <Annotation Term="OData.LongDescription" String="This property shall contain an array of the Network Time Protocol (NTP) servers for this Ethernet fabric."/>
+        </Property>
+        <Property Name="DHCP" Type="AddressPool.v1_1_0.DHCP">
+          <Annotation Term="OData.Description" String="The Dynamic Host Configuration Protocol (DHCP) related addressing for this Ethernet fabric."/>
+          <Annotation Term="OData.LongDescription" String="This property shall contain the primary and secondary Dynamic Host Configuration Protocol (DHCP) server addressing for this Ethernet fabric."/>
+        </Property>
+        <Property Name="NativeVLAN" Type="Edm.Int64">
+          <Annotation Term="OData.Permissions" EnumMember="OData.Permission/ReadWrite"/>
+          <Annotation Term="OData.Description" String="The native Virtual LAN (VLAN) tag value."/>
+          <Annotation Term="OData.LongDescription" String="This property shall contain native Virtual LAN (VLAN) tag value for untagged traffic."/>
+          <Annotation Term="Validation.Minimum" Int="1"/>
+          <Annotation Term="Validation.Maximum" Int="4094"/>
+        </Property>
+        <Property Name="DNSDomainName" Type="Edm.String">
+          <Annotation Term="OData.Permissions" EnumMember="OData.Permission/ReadWrite"/>
+          <Annotation Term="OData.Description" String="The Domain Name Service (DNS) domain name for this Ethernet fabric."/>
+          <Annotation Term="OData.LongDescription" String="This property shall contain the Domain Name Service (DNS) domain name for this Ethernet fabric."/>
+        </Property>
+        <Property Name="DistributeIntoUnderlayEnabled" Type="Edm.Boolean">
+          <Annotation Term="OData.Permissions" EnumMember="OData.Permission/ReadWrite"/>
+          <Annotation Term="OData.Description" String="Indicates if host subnets should be distributed into the fabric underlay."/>
+          <Annotation Term="OData.LongDescription" String="This property shall indicate whether host subnets are distributed into the fabric underlay."/>
+        </Property>
+        <Property Name="NTPTimezone" Type="Edm.String">
+          <Annotation Term="OData.Permissions" EnumMember="OData.Permission/ReadWrite"/>
+          <Annotation Term="OData.Description" String="The Network Time Protocol (NTP) timezone for this Ethernet fabric."/>
+          <Annotation Term="OData.LongDescription" String="This property shall contain the Network Time Protocol (NTP) timezone name assigned to this Ethernet fabric."/>
+        </Property>
+        <Property Name="NTPOffsetHoursMinutes" Type="Edm.Int64">
+          <Annotation Term="OData.Permissions" EnumMember="OData.Permission/ReadWrite"/>
+          <Annotation Term="OData.Description" String="The Network Time Protocol (NTP) offset configuration."/>
+          <Annotation Term="OData.LongDescription" String="This property shall contain the Network Time Protocol (NTP) offset.  The NTP offset property is used to calculate the time from UTC (Universal Time Coordinated) time in hours and minutes."/>
+        </Property>
+        <Property Name="GatewayIPAddress" Type="Edm.String">
+          <Annotation Term="OData.Permissions" EnumMember="OData.Permission/ReadWrite"/>
+          <Annotation Term="OData.Description" String="The gateway IPv4 address."/>
+          <Annotation Term="OData.LongDescription" String="This property shall contain the gateway IPv4 address for a host subnet."/>
+          <Annotation Term="Validation.Pattern" String="^(?:[0-9]{1,3}\.){3}[0-9]{1,3}$"/>
+        </Property>
+        <Property Name="AnycastGatewayIPAddress" Type="Edm.String">
+          <Annotation Term="OData.Permissions" EnumMember="OData.Permission/ReadWrite"/>
+          <Annotation Term="OData.Description" String="The anycast gateway IPv4 address."/>
+          <Annotation Term="OData.LongDescription" String="This property shall contain the anycast gateway IPv4 address for a host subnet."/>
+          <Annotation Term="Validation.Pattern" String="^(?:[0-9]{1,3}\.){3}[0-9]{1,3}$"/>
+        </Property>
+        <Property Name="AnycastGatewayMACAddress" Type="Edm.String">
+          <Annotation Term="OData.Permissions" EnumMember="OData.Permission/ReadWrite"/>
+          <Annotation Term="OData.Description" String="The anycast gateway MAC address."/>
+          <Annotation Term="OData.LongDescription" String="This property shall contain the anycast gateway MAC address for a host subnet."/>
+          <Annotation Term="Validation.Pattern" String="^([0-9A-Fa-f]{2}[:-]){5}([0-9A-Fa-f]{2})$"/>
+        </Property>
+      </ComplexType>
+
+      <ComplexType Name="BGPEvpn">
+        <Annotation Term="OData.AdditionalProperties" Bool="false"/>
+        <Annotation Term="OData.Description" String="BGP Ethernet Virtual Private Network (BGP EVPN) related properties for an Ethernet fabric."/>
+        <Annotation Term="OData.LongDescription" String="This type shall contain the EVPN related properties for an Ethernet fabric that uses an IETF defined Ethernet Virtual Private Network (EVPN) based control plane specification based on RFC7432."/>
+        <Property Name="VLANIdentifierAddressRange" Type="AddressPool.v1_1_0.VLANIdentifierAddressRange">
+          <Annotation Term="OData.Description" String="The VLAN tag range for the fabric."/>
+          <Annotation Term="OData.LongDescription" String="This property shall contain Virtual LAN (VLAN) tag range for host addresses."/>
+        </Property>
+        <Property Name="ESINumberRange" Type="AddressPool.v1_1_0.ESINumberRange">
+          <Annotation Term="OData.Description" String="The Ethernet Segment Identifier (ESI) number range for the fabric."/>
+          <Annotation Term="OData.LongDescription" String="This property shall contain Ethernet Segment Identifier (ESI) number ranges for allocation in supporting functions such as multihoming."/>
+        </Property>
+         <Property Name="EVINumberRange" Type="AddressPool.v1_1_0.EVINumberRange">
+          <Annotation Term="OData.Description" String="The Ethernet Virtual Private Network (EVPN) Instance number (EVI) number range for the fabric."/>
+          <Annotation Term="OData.LongDescription" String="This property shall contain the Ethernet Virtual Private Network (EVPN) Instance number (EVI) range for EVPN based fabrics."/>
+        </Property>
+        <Property Name="RouteDistinguisherRange" Type="AddressPool.v1_1_0.RouteDistinguisherRange">
+          <Annotation Term="OData.Description" String="The Route Distinguisher (RD) number range for the fabric."/>
+          <Annotation Term="OData.LongDescription" String="This property shall contain the Route Distinguisher (RD) Instance number range for Ethernet Virtual Private Network (EVPN) based fabrics."/>
+        </Property>
+        <Property Name="RouteTargetRange" Type="AddressPool.v1_1_0.RouteTargetRange">
+          <Annotation Term="OData.Description" String="The Route Target (RT) number range for the fabric."/>
+          <Annotation Term="OData.LongDescription" String="This property shall contain the Route Target (RT) Instance number range for Ethernet Virtual Private Network (EVPN) based fabrics."/>
+        </Property>
+        <Property Name="GatewayIPAddress" Type="Edm.String">
+          <Annotation Term="OData.Permissions" EnumMember="OData.Permission/ReadWrite"/>
+          <Annotation Term="OData.Description" String="The gateway IPv4 address."/>
+          <Annotation Term="OData.LongDescription" String="This property shall contain the Gateway IPv4 address for a host subnet."/>
+          <Annotation Term="Validation.Pattern" String="^(?:[0-9]{1,3}\.){3}[0-9]{1,3}$"/>
+        </Property>
+        <Property Name="AnycastGatewayIPAddress" Type="Edm.String">
+          <Annotation Term="OData.Permissions" EnumMember="OData.Permission/ReadWrite"/>
+          <Annotation Term="OData.Description" String="The anycast gateway IPv4 address."/>
+          <Annotation Term="OData.LongDescription" String="This property shall contain the anycast gateway IPv4 address for a host subnet."/>
+          <Annotation Term="Validation.Pattern" String="^(?:[0-9]{1,3}\.){3}[0-9]{1,3}$"/>
+        </Property>
+        <Property Name="AnycastGatewayMACAddress" Type="Edm.String">
+          <Annotation Term="OData.Permissions" EnumMember="OData.Permission/ReadWrite"/>
+          <Annotation Term="OData.Description" String="The anycast gateway MAC address."/>
+          <Annotation Term="OData.LongDescription" String="This property shall contain the anycast gateway MAC address for a host subnet."/>
+          <Annotation Term="Validation.Pattern" String="^([0-9A-Fa-f]{2}[:-]){5}([0-9A-Fa-f]{2})$"/>
+        </Property>
+        <Property Name="ARPProxyEnabled" Type="Edm.Boolean">
+          <Annotation Term="OData.Permissions" EnumMember="OData.Permission/ReadWrite"/>
+          <Annotation Term="OData.Description" String="Address Resolution Protocol (ARP) proxy status."/>
+          <Annotation Term="OData.LongDescription" String="This property shall indicate whether proxy Address Resolution Protocol (ARP) is enabled."/>
+        </Property>
+        <Property Name="ARPSupressionEnabled" Type="Edm.Boolean">
+          <Annotation Term="OData.Permissions" EnumMember="OData.Permission/ReadWrite"/>
+          <Annotation Term="OData.Description" String="Address Resolution Protocol (ARP) suppression status."/>
+          <Annotation Term="OData.LongDescription" String="This property shall indicate whether Address Resolution Protocol (ARP) suppression is enabled."/>
+        </Property>
+        <Property Name="NDPSupressionEnabled" Type="Edm.Boolean">
+          <Annotation Term="OData.Permissions" EnumMember="OData.Permission/ReadWrite"/>
+          <Annotation Term="OData.Description" String="Network Discovery Protocol (NDP) suppression status."/>
+          <Annotation Term="OData.LongDescription" String="This property shall indicate whether Network Discovery Protocol (NDP) suppression is enabled."/>
+        </Property>
+        <Property Name="NDPProxyEnabled" Type="Edm.Boolean">
+          <Annotation Term="OData.Permissions" EnumMember="OData.Permission/ReadWrite"/>
+          <Annotation Term="OData.Description" String="Network Discovery Protocol (NDP) proxy status."/>
+          <Annotation Term="OData.LongDescription" String="This property shall indicate whether Network Discovery Protocol (NDP) proxy is enabled."/>
+        </Property>
+        <Property Name="UnderlayMulticastEnabled" Type="Edm.Boolean">
+          <Annotation Term="OData.Permissions" EnumMember="OData.Permission/ReadWrite"/>
+          <Annotation Term="OData.Description" String="Underlay multicast status."/>
+          <Annotation Term="OData.LongDescription" String="This property shall indicate whether multicast is enabled on the Ethernet fabric underlay."/>
+        </Property>
+        <Property Name="UnknownUnicastSuppressionEnabled" Type="Edm.Boolean">
+          <Annotation Term="OData.Permissions" EnumMember="OData.Permission/ReadWrite"/>
+          <Annotation Term="OData.Description" String="Suppression of unknown unicast packets."/>
+          <Annotation Term="OData.LongDescription" String="This property shall indicate whether unknown unicast packets should be suppressed."/>
+        </Property>
+      </ComplexType>
+
+      <ComplexType Name="EBGP" BaseType="AddressPool.v1_1_0.CommonBGPProperties">
+        <Annotation Term="OData.Description" String="External BGP (eBGP) related properties for an Ethernet fabric."/>
+        <Annotation Term="OData.LongDescription" String="This type shall contain the External BGP (eBGP) related properties for an Ethernet fabric."/>
+        <Property Name="AlwaysCompareMEDEnabled" Type="Edm.Boolean">
+          <Annotation Term="OData.Permissions" EnumMember="OData.Permission/ReadWrite"/>
+          <Annotation Term="OData.Description" String="Compare Multi Exit Discriminator (MED) status."/>
+          <Annotation Term="OData.LongDescription" String="This property shall indicate whether neighbor Multi Exit Discriminator (MED) attributes should be compared."/>
+        </Property>
+        <Property Name="MED" Type="Edm.Int64">
+          <Annotation Term="OData.Permissions" EnumMember="OData.Permission/ReadWrite"/>
+          <Annotation Term="OData.Description" String="BGP Multi Exit Discriminator (MED) value."/>
+          <Annotation Term="OData.LongDescription" String="This property shall contain the Border Gateway Protocol (BGP) Multi Exit Discriminator (MED) value.  A lower MED value is preferred for BGP best path selection."/>
+        </Property>
+        <Property Name="BGPWeight" Type="Edm.Int64">
+          <Annotation Term="OData.Permissions" EnumMember="OData.Permission/ReadWrite"/>
+          <Annotation Term="OData.Description" String="BGP weight attribute."/>
+          <Annotation Term="OData.LongDescription" String="This property shall contain the Border Gateway Protocol (BGP) weight attribute value for external peers.  A higher BGP weight value is preferred for BGP best path selection."/>
+        </Property>
+        <Property Name="BGPLocalPreference" Type="Edm.Int64">
+          <Annotation Term="OData.Permissions" EnumMember="OData.Permission/ReadWrite"/>
+          <Annotation Term="OData.Description" String="Local preference value."/>
+          <Annotation Term="OData.LongDescription" String="This property shall contain the local preference value.  Highest local preference value is preferred for Border Gateway Protocol (BGP) best path selection."/>
+        </Property>
+        <Property Name="AllowDuplicateASEnabled" Type="Edm.Boolean">
+          <Annotation Term="OData.Permissions" EnumMember="OData.Permission/ReadWrite"/>
+          <Annotation Term="OData.Description" String="Allow duplicate Autonomous System (AS) path."/>
+          <Annotation Term="OData.LongDescription" String="This property shall indicate whether duplicate Autonomous System (AS) numbers are allowed.  If `true`, routes with the same AS number as the receiving router should be allowed.  If `false`,routes should be dropped if the router receives its own AS number in a Border Gateway Protocol (BGP) update."/>
+        </Property>
+        <Property Name="AllowOverrideASEnabled" Type="Edm.Boolean">
+          <Annotation Term="OData.Permissions" EnumMember="OData.Permission/ReadWrite"/>
+          <Annotation Term="OData.Description" String="Option to override an Autonomous System (AS) number with the AS number of the sending peer ."/>
+          <Annotation Term="OData.LongDescription" String="This property shall indicate whether Autonomous System (AS) numbers should be overridden.  If `true`, AS number should be overridden with the AS number of the sending peer.  If `false`, AS number override is disabled."/>
+        </Property>
+        <Property Name="MultihopEnabled" Type="Edm.Boolean">
+          <Annotation Term="OData.Permissions" EnumMember="OData.Permission/ReadWrite"/>
+          <Annotation Term="OData.Description" String="External BGP (eBGP) multihop status."/>
+          <Annotation Term="OData.LongDescription" String="This property shall indicate whether External BGP (eBGP) multihop is enabled."/>
+        </Property>
+        <Property Name="MultihopTTL" Type="Edm.Int64">
+          <Annotation Term="OData.Permissions" EnumMember="OData.Permission/ReadWrite"/>
+          <Annotation Term="OData.Description" String="External BGP (eBGP) multihop Time to Live (TTL) value."/>
+          <Annotation Term="OData.LongDescription" String="This property shall contain the External BGP (eBGP) multihop Time to Live (TTL) value."/>
+        </Property>
+      </ComplexType>
+
+      <ComplexType Name="CommonBGPProperties">
+        <Annotation Term="OData.AdditionalProperties" Bool="false"/>
+        <Annotation Term="OData.Description" String="Common BGP properties."/>
+        <Annotation Term="OData.LongDescription" String="This property shall contain properties shared across both External and Internal Border Gateway Protocol (BGP) related properties."/>
+        <Property Name="ASNumberRange" Type="AddressPool.v1_1_0.ASNumberRange">
+          <Annotation Term="OData.Description" String="Autonomous System (AS) number range."/>
+          <Annotation Term="OData.LongDescription" String="This property shall contain the range of Autonomous System (AS) numbers assigned to each Border Gateway Protocol (BGP) peer within the fabric."/>
+        </Property>
+        <Property Name="BGPNeighbor" Type="AddressPool.v1_1_0.BGPNeighbor">
+          <Annotation Term="OData.Description" String="Border Gateway Protocol (BGP) neighbor related properties."/>
+          <Annotation Term="OData.LongDescription" String="This property shall contain all Border Gateway Protocol (BGP) neighbor related properties."/>
+        </Property>
+        <Property Name="GracefulRestart" Type="AddressPool.v1_1_0.GracefulRestart">
+          <Annotation Term="OData.Description" String="Graceful restart related properties."/>
+          <Annotation Term="OData.LongDescription" String="This property shall contain all graceful restart related properties."/>
+        </Property>
+        <Property Name="MultiplePaths" Type="AddressPool.v1_1_0.MultiplePaths">
+          <Annotation Term="OData.Description" String="Multiple path related properties."/>
+          <Annotation Term="OData.LongDescription" String="This property shall contain all multiple path related properties."/>
+        </Property>
+        <Property Name="BGPRoute" Type="AddressPool.v1_1_0.BGPRoute">
+          <Annotation Term="OData.Description" String="Border Gateway Protocol (BGP) route related properties."/>
+          <Annotation Term="OData.LongDescription" String="This property shall contain Border Gateway Protocol (BGP) route related properties."/>
+        </Property>
+        <Property Name="SendCommunityEnabled" Type="Edm.Boolean">
+          <Annotation Term="OData.Permissions" EnumMember="OData.Permission/ReadWrite"/>
+          <Annotation Term="OData.Description" String="This property shall indicate whether community attributes are sent."/>
+          <Annotation Term="OData.LongDescription" String="This property shall indicate whether community attributes are sent to BGP neighbors."/>
+        </Property>
+      </ComplexType>
+
+      <ComplexType Name="BFDSingleHopOnly">
+        <Annotation Term="OData.AdditionalProperties" Bool="false"/>
+        <Annotation Term="OData.Description" String="Bidirectional Forwarding Detection (BFD) related properties for an Ethernet fabric."/>
+        <Annotation Term="OData.LongDescription" String="This type shall contain the BFD related properties for an Ethernet fabric that uses Bidirectional Forwarding Detection (BFD) for link fault detection."/>
+        <Property Name="LocalMultiplier" Type="Edm.Int64">
+          <Annotation Term="OData.Permissions" EnumMember="OData.Permission/ReadWrite"/>
+          <Annotation Term="OData.Description" String="Bidirectional Forwarding Detection (BFD) multiplier value."/>
+          <Annotation Term="OData.LongDescription" String="This property shall contain the Bidirectional Forwarding Detection (BFD) multiplier value.  A BFD multiplier consists of the number of consecutive BFD packets that shall be missed from a BFD peer before declaring that peer unavailable, and informing the higher-layer protocols of the failure."/>
+        </Property>
+        <Property Name="DesiredMinTxIntervalMilliseconds" Type="Edm.Int64">
+          <Annotation Term="OData.Permissions" EnumMember="OData.Permission/ReadWrite"/>
+          <Annotation Term="OData.Description" String="Desired Bidirectional Forwarding Detection (BFD) minimal transmit interval."/>
+          <Annotation Term="OData.LongDescription" String="This property shall contain the minimum interval, in milliseconds, that the local system would like to use when transmitting Bidirectional Forwarding Detection (BFD) Control packets, less any jitter applied."/>
+        </Property>
+        <Property Name="RequiredMinRxIntervalMilliseconds" Type="Edm.Int64">
+          <Annotation Term="OData.Permissions" EnumMember="OData.Permission/ReadWrite"/>
+          <Annotation Term="OData.Description" String="Bidirectional Forwarding Detection (BFD) receive value."/>
+          <Annotation Term="OData.LongDescription" String="This property shall contain the Bidirectional Forwarding Detection (BFD) receive value.  The BFD receive value determines how frequently (in milliseconds) BFD packets will be expected to be received from BFD peers."/>
+        </Property>
+        <Property Name="DemandModeEnabled" Type="Edm.Boolean">
+          <Annotation Term="OData.Permissions" EnumMember="OData.Permission/ReadWrite"/>
+          <Annotation Term="OData.Description" String="Bidirectional Forwarding Detection (BFD) Demand Mode status."/>
+          <Annotation Term="OData.LongDescription" String="This property shall indicate if Bidirectional Forwarding Detection (BFD) Demand Mode is enabled.  In Demand mode, no periodic BFD Control packets will flow in either direction."/>
+        </Property>
+        <Property Name="KeyChain" Type="Edm.String">
+          <Annotation Term="OData.Permissions" EnumMember="OData.Permission/ReadWrite"/>
+          <Annotation Term="OData.Description" String="Bidirectional Forwarding Detection (BFD) Key Chain name."/>
+          <Annotation Term="OData.LongDescription" String="This property shall contain the name of the Bidirectional Forwarding Detection (BFD) Key Chain."/>
+        </Property>
+        <Property Name="MeticulousModeEnabled" Type="Edm.Boolean">
+          <Annotation Term="OData.Permissions" EnumMember="OData.Permission/ReadWrite"/>
+          <Annotation Term="OData.Description" String="Meticulous MD5 authentication of the Bidirectional Forwarding Detection (BFD) session."/>
+          <Annotation Term="OData.LongDescription" String="This property shall indicate whether the keyed MD5 sequence number is updated with every packet.  If `true`, the keyed MD5 sequence number is updated with every packet, if `false` it is updated periodically."/>
+        </Property>
+        <Property Name="SourcePort" Type="Edm.Int64">
+          <Annotation Term="OData.Permissions" EnumMember="OData.Permission/ReadWrite"/>
+          <Annotation Term="OData.Description" String="Bidirectional Forwarding Detection (BFD) source port."/>
+          <Annotation Term="OData.LongDescription" String="This property shall contain the Bidirectional Forwarding Detection (BFD) source port."/>
+          <Annotation Term="Validation.Minimum" Int="49152"/>
+          <Annotation Term="Validation.Maximum" Int="65535"/>
+        </Property>
+      </ComplexType>
+
+      <ComplexType Name="VLANIdentifierAddressRange">
+        <Annotation Term="OData.AdditionalProperties" Bool="false"/>
+        <Annotation Term="OData.Description" String="VLAN tag related addressing for an Ethernet fabric or for end host networks."/>
+        <Annotation Term="OData.LongDescription" String="This type shall contain for assigning Virtual LAN (VLAN) tags for the entire fabric as well as for end hosts."/>
+        <Property Name="Lower" Type="Edm.Int64">
+          <Annotation Term="OData.Permissions" EnumMember="OData.Permission/ReadWrite"/>
+          <Annotation Term="OData.Description" String="Virtual LAN (VLAN) tag lower value."/>
+          <Annotation Term="OData.LongDescription" String="This property shall contain the Virtual LAN (VLAN) tag lower value."/>
+          <Annotation Term="Validation.Minimum" Int="1"/>
+          <Annotation Term="Validation.Maximum" Int="4094"/>
+        </Property>
+        <Property Name="Upper" Type="Edm.Int64">
+          <Annotation Term="OData.Permissions" EnumMember="OData.Permission/ReadWrite"/>
+          <Annotation Term="OData.Description" String="Virtual LAN (VLAN) tag upper value."/>
+          <Annotation Term="OData.LongDescription" String="This property shall contain the Virtual LAN (VLAN) tag upper value."/>
+          <Annotation Term="Validation.Minimum" Int="1"/>
+          <Annotation Term="Validation.Maximum" Int="4094"/>
+        </Property>
+      </ComplexType>
+
+      <ComplexType Name="IPv4AddressRange">
+        <Annotation Term="OData.AdditionalProperties" Bool="false"/>
+        <Annotation Term="OData.Description" String="IPv4 related address range for an Ethernet fabric."/>
+        <Annotation Term="OData.LongDescription" String="This type shall contain an IPv4 related address range for an Ethernet fabric."/>
+        <Property Name="Lower" Type="Edm.String">
+          <Annotation Term="OData.Permissions" EnumMember="OData.Permission/ReadWrite"/>
+          <Annotation Term="OData.Description" String="Lower IPv4 network address."/>
+          <Annotation Term="OData.LongDescription" String="This property shall contain the lower IPv4 network address to be used as part of a subnet."/>
+          <Annotation Term="Validation.Pattern" String="^(?:[0-9]{1,3}\.){3}[0-9]{1,3}$"/>
+        </Property>
+        <Property Name="Upper" Type="Edm.String">
+          <Annotation Term="OData.Permissions" EnumMember="OData.Permission/ReadWrite"/>
+          <Annotation Term="OData.Description" String="Upper IPv4 network address."/>
+          <Annotation Term="OData.LongDescription" String="This property shall contain the upper IPv4 network address to be used as part of a host subnet."/>
+          <Annotation Term="Validation.Pattern" String="^(?:[0-9]{1,3}\.){3}[0-9]{1,3}$"/>
+        </Property>
+      </ComplexType>
+
+      <ComplexType Name="DHCP">
+        <Annotation Term="OData.AdditionalProperties" Bool="false"/>
+        <Annotation Term="OData.Description" String="DHCP related properties for an Ethernet fabric."/>
+        <Annotation Term="OData.LongDescription" String="This type shall contain for assigning DHCP related properties to the Ethernet fabric."/>
+        <Property Name="DHCPRelayEnabled" Type="Edm.Boolean">
+          <Annotation Term="OData.Permissions" EnumMember="OData.Permission/ReadWrite"/>
+          <Annotation Term="OData.Description" String="Dynamic Host Configuration Protocol (DHCP) relay status."/>
+          <Annotation Term="OData.LongDescription" String="This property shall indicate whether Dynamic Host Configuration Protocol (DHCP) Relay is enabled."/>
+        </Property>
+        <Property Name="DHCPInterfaceMTUBytes" Type="Edm.Int64">
+          <Annotation Term="OData.Permissions" EnumMember="OData.Permission/ReadWrite"/>
+          <Annotation Term="OData.Description" String="Dynamic Host Configuration Protocol (DHCP) interface Maximum Transmission Unit (MTU)."/>
+          <Annotation Term="OData.LongDescription" String="This property shall contain the Maximum Transmission Unit (MTU) to use on this interface in bytes."/>
+          <Annotation Term="Validation.Minimum" Int="68"/>
+          <Annotation Term="Validation.Maximum" Int="9194"/>
+        </Property>
+        <Property Name="DHCPServer" Type="Collection(Edm.String)">
+          <Annotation Term="OData.Permissions" EnumMember="OData.Permission/ReadWrite"/>
+          <Annotation Term="OData.Description" String="The Dynamic Host Configuration Protocol (DHCP) IPv4 addresses for this Ethernet fabric."/>
+          <Annotation Term="OData.LongDescription" String="This property shall contain an array of addresses assigned to the Dynamic Host Configuration Protocol (DHCP) server for this Ethernet fabric."/>
+        </Property>
+      </ComplexType>
+
+      <ComplexType Name="ESINumberRange">
+        <Annotation Term="OData.AdditionalProperties" Bool="false"/>
+        <Annotation Term="OData.Description" String="The Ethernet Segment Identifier (ESI) number range for an Ethernet fabric."/>
+        <Annotation Term="OData.LongDescription" String="This type shall contain Ethernet Segment Identifier (ESI) number ranges for allocation in supporting functions such as multihoming."/>
+        <Property Name="Lower" Type="Edm.Int64" Nullable="false">
+          <Annotation Term="OData.Permissions" EnumMember="OData.Permission/ReadWrite"/>
+          <Annotation Term="OData.Description" String="Lower Ethernet Segment Identifier (ESI) number."/>
+          <Annotation Term="OData.LongDescription" String="This property shall contain the lower Ethernet Segment Identifier (ESI) number to be used as part of a range of ESI numbers."/>
+        </Property>
+        <Property Name="Upper" Type="Edm.Int64" Nullable="false">
+          <Annotation Term="OData.Permissions" EnumMember="OData.Permission/ReadWrite"/>
+          <Annotation Term="OData.Description" String="Upper Ethernet Segment Identifier (ESI) number."/>
+          <Annotation Term="OData.LongDescription" String="This property shall contain the upper Ethernet Segment Identifier (ESI) number to be used as part of a range of ESI numbers."/>
+        </Property>
+      </ComplexType>
+
+      <ComplexType Name="EVINumberRange">
+        <Annotation Term="OData.AdditionalProperties" Bool="false"/>
+        <Annotation Term="OData.Description" String="The Ethernet Virtual Private Network (EVPN) Instance (EVI) number range for an Ethernet fabric."/>
+        <Annotation Term="OData.LongDescription" String="This type shall contain the Ethernet Virtual Private Network (EVPN) Instance (EVI) number range for EVPN based fabrics."/>
+        <Property Name="Lower" Type="Edm.Int64" Nullable="false">
+          <Annotation Term="OData.Permissions" EnumMember="OData.Permission/ReadWrite"/>
+          <Annotation Term="OData.Description" String="Lower Ethernet Virtual Private Network (EVPN) Instance (EVI) number."/>
+          <Annotation Term="OData.LongDescription" String="This property shall contain the lower Ethernet Virtual Private Network (EVPN) Instance (EVI) number to be used as part of a range of EVI numbers."/>
+        </Property>
+        <Property Name="Upper" Type="Edm.Int64" Nullable="false">
+          <Annotation Term="OData.Permissions" EnumMember="OData.Permission/ReadWrite"/>
+          <Annotation Term="OData.Description" String="Upper Ethernet Virtual Private Network (EVPN) Instance (EVI) number."/>
+          <Annotation Term="OData.LongDescription" String="This property shall contain the upper Ethernet Virtual Private Network (EVPN) Instance (EVI) number to be used as part of a range of EVI numbers."/>
+        </Property>
+      </ComplexType>
+
+      <ComplexType Name="RouteDistinguisherRange">
+        <Annotation Term="OData.AdditionalProperties" Bool="false"/>
+        <Annotation Term="OData.Description" String="The Route Distinguisher (RD) number range for an Ethernet fabric."/>
+        <Annotation Term="OData.LongDescription" String="This type shall contain the Route Distinguisher (RD) Instance number range for Ethernet Virtual Private Network (EVPN) based fabrics."/>
+        <Property Name="Lower" Type="Edm.Int64" Nullable="false">
+          <Annotation Term="OData.Permissions" EnumMember="OData.Permission/ReadWrite"/>
+          <Annotation Term="OData.Description" String="Lower Route Distinguisher (RD) number."/>
+          <Annotation Term="OData.LongDescription" String="This property shall contain the lower Route Distinguisher (RD) number to be used as part of a range of Route Distinguisher values."/>
+        </Property>
+        <Property Name="Upper" Type="Edm.Int64" Nullable="false">
+          <Annotation Term="OData.Permissions" EnumMember="OData.Permission/ReadWrite"/>
+          <Annotation Term="OData.Description" String="Upper Route Distinguisher (RD) number."/>
+          <Annotation Term="OData.LongDescription" String="This property shall contain the upper Route Distinguisher (RD) number to be used as part of a range of Route Distinguisher values."/>
+        </Property>
+      </ComplexType>
+
+      <ComplexType Name="RouteTargetRange">
+        <Annotation Term="OData.AdditionalProperties" Bool="false"/>
+        <Annotation Term="OData.Description" String="The Route Target (RT) number range for the fabric."/>
+        <Annotation Term="OData.LongDescription" String="This type shall contain the Route Target (RT) Instance number range for Ethernet Virtual Private Network (EVPN) based fabrics."/>
+        <Property Name="Lower" Type="Edm.Int64">
+          <Annotation Term="OData.Permissions" EnumMember="OData.Permission/ReadWrite"/>
+          <Annotation Term="OData.Description" String="Lower Route Target (RT) number."/>
+          <Annotation Term="OData.LongDescription" String="This property shall contain the lower Route Target (RT) number to be used as part of a range of Route Target values."/>
+        </Property>
+        <Property Name="Upper" Type="Edm.Int64">
+          <Annotation Term="OData.Permissions" EnumMember="OData.Permission/ReadWrite"/>
+          <Annotation Term="OData.Description" String="Upper Route Target (RT) number."/>
+          <Annotation Term="OData.LongDescription" String="This property shall contain the upper Route Target (RT) number to be used as part of a range of Route Target values."/>
+        </Property>
+      </ComplexType>
+
+      <ComplexType Name="ASNumberRange">
+        <Annotation Term="OData.AdditionalProperties" Bool="false"/>
+        <Annotation Term="OData.Description" String="Autonomous System (AS) number range."/>
+        <Annotation Term="OData.LongDescription" String="This type shall contain the Autonomous System (AS) number range."/>
+        <Property Name="Lower" Type="Edm.Int64" Nullable="false">
+          <Annotation Term="OData.Permissions" EnumMember="OData.Permission/ReadWrite"/>
+          <Annotation Term="OData.Description" String="Lower Autonomous System (AS) number."/>
+          <Annotation Term="OData.LongDescription" String="This property shall contain the lower Autonomous System (AS) number to be used as part of a range of ASN values."/>
+          <Annotation Term="Validation.Minimum" Int="1"/>
+          <Annotation Term="Validation.Maximum" Int="65535"/>
+        </Property>
+        <Property Name="Upper" Type="Edm.Int64" Nullable="false">
+          <Annotation Term="OData.Permissions" EnumMember="OData.Permission/ReadWrite"/>
+          <Annotation Term="OData.Description" String="Upper Autonomous System (AS) number."/>
+          <Annotation Term="OData.LongDescription" String="This property shall contain the upper Autonomous System (AS) number to be used as part of a range of ASN values."/>
+          <Annotation Term="Validation.Minimum" Int="1"/>
+          <Annotation Term="Validation.Maximum" Int="65535"/>
+        </Property>
+      </ComplexType>
+
+      <ComplexType Name="BGPNeighbor">
+        <Annotation Term="OData.AdditionalProperties" Bool="false"/>
+        <Annotation Term="OData.Description" String="Border Gateway Protocol (BGP) neighbor related properties."/>
+        <Annotation Term="OData.LongDescription" String="This type shall contain all Border Gateway Protocol (BGP) neighbor related properties."/>
+        <Property Name="Address" Type="Edm.String">
+          <Annotation Term="OData.Permissions" EnumMember="OData.Permission/ReadWrite"/>
+          <Annotation Term="OData.Description" String="Border Gateway Protocol (BGP) neighbor address."/>
+          <Annotation Term="OData.LongDescription" String="This property shall contain the IPv4 address assigned to a Border Gateway Protocol (BGP) neighbor."/>
+          <Annotation Term="Validation.Pattern" String="^(?:[0-9]{1,3}\.){3}[0-9]{1,3}$"/>
+        </Property>
+        <Property Name="AllowOwnASEnabled" Type="Edm.Boolean">
+          <Annotation Term="OData.Permissions" EnumMember="OData.Permission/ReadWrite"/>
+          <Annotation Term="OData.Description" String="Allow own Autonomous System (AS) status."/>
+          <Annotation Term="OData.LongDescription" String="This property shall indicate whether the Autonomous System (AS) of the receiving router is permitted in a Border Gateway Protocol (BGP) update.  If `true`, routes should be received and processed even if the router detects its own ASN in the AS-Path.  If `false`, they should be dropped."/>
+        </Property>
+        <Property Name="ConnectRetrySeconds" Type="Edm.Int64">
+          <Annotation Term="OData.Permissions" EnumMember="OData.Permission/ReadWrite"/>
+          <Annotation Term="OData.Description" String="Border Gateway Protocol (BGP) retry timer in seconds."/>
+          <Annotation Term="OData.LongDescription" String="This property shall contain the Border Gateway Protocol (BGP) Retry Timer.  The BGP Retry Timer allows the administrator to set the amount of time in seconds between retries to establish a connection to configured peers which have gone down."/>
+        </Property>
+        <Property Name="HoldTimeSeconds" Type="Edm.Int64">
+          <Annotation Term="OData.Permissions" EnumMember="OData.Permission/ReadWrite"/>
+          <Annotation Term="OData.Description" String="Border Gateway Protocol (BGP) hold timer in seconds."/>
+          <Annotation Term="OData.LongDescription" String="This property shall contain the Border Gateway Protocol (BGP) Hold Timer agreed upon between peers."/>
+        </Property>
+        <Property Name="KeepaliveIntervalSeconds" Type="Edm.Int64">
+          <Annotation Term="OData.Permissions" EnumMember="OData.Permission/ReadWrite"/>
+          <Annotation Term="OData.Description" String="Border Gateway Protocol (BGP) Keepalive timer in seconds."/>
+          <Annotation Term="OData.LongDescription" String="This property shall contain the Keepalive timer in seconds.  It is used in conjunction with the Border Gateway Protocol (BGP) hold timer."/>
+        </Property>
+        <Property Name="MinimumAdvertisementIntervalSeconds" Type="Edm.Int64">
+          <Annotation Term="OData.Permissions" EnumMember="OData.Permission/ReadWrite"/>
+          <Annotation Term="OData.Description" String="Minimum Border Gateway Protocol (BGP) advertisement interval in seconds."/>
+          <Annotation Term="OData.LongDescription" String="This property shall contain the minimum time between Border Gateway Protocol (BGP) route advertisements in seconds."/>
+        </Property>
+        <Property Name="TCPMaxSegmentSizeBytes" Type="Edm.Int64">
+          <Annotation Term="OData.Permissions" EnumMember="OData.Permission/ReadWrite"/>
+          <Annotation Term="OData.Description" String="TCP max segment size in Bytes."/>
+          <Annotation Term="OData.LongDescription" String="This property shall contain the TCP max segment size in Bytes signifying the number of bytes that shall be transported in a single packet."/>
+        </Property>
+        <Property Name="PathMTUDiscoveryEnabled" Type="Edm.Boolean">
+          <Annotation Term="OData.Permissions" EnumMember="OData.Permission/ReadWrite"/>
+          <Annotation Term="OData.Description" String="Path MTU discovery status."/>
+          <Annotation Term="OData.LongDescription" String="This property shall indicate whether MTU discovery is permitted."/>
+        </Property>
+        <Property Name="PassiveModeEnabled" Type="Edm.Boolean">
+          <Annotation Term="OData.Permissions" EnumMember="OData.Permission/ReadWrite"/>
+          <Annotation Term="OData.Description" String="Border Gateway Protocol (BGP) passive mode status."/>
+          <Annotation Term="OData.LongDescription" String="This property shall indicate whether Border Gateway Protocol (BGP) passive mode is enabled."/>
+        </Property>
+        <Property Name="TreatAsWithdrawEnabled" Type="Edm.Boolean">
+          <Annotation Term="OData.Permissions" EnumMember="OData.Permission/ReadWrite"/>
+          <Annotation Term="OData.Description" String="Border Gateway Protocol (BGP) treat as withdraw status."/>
+          <Annotation Term="OData.LongDescription" String="This property shall indicate Border Gateway Protocol (BGP) withdraw status.  If `true`, the UPDATE message containing the path attribute shall be treated as though all contained routes had been withdrawn.  If `false`, they should remain."/>
+        </Property>
+        <Property Name="ReplacePeerASEnabled" Type="Edm.Boolean">
+          <Annotation Term="OData.Permissions" EnumMember="OData.Permission/ReadWrite"/>
+          <Annotation Term="OData.Description" String="Replace Border Gateway Protocol (BGP) peer Autonomous System (AS) status."/>
+          <Annotation Term="OData.LongDescription" String="This property shall indicate whether peer Autonomous System (AS) numbers should be replaced.  If `true`, private ASNs are removed and replaced with the peer AS.  If `false`, they remain unchanged."/>
+        </Property>
+        <Property Name="PeerAS" Type="Edm.Int64">
+          <Annotation Term="OData.Permissions" EnumMember="OData.Permission/ReadWrite"/>
+          <Annotation Term="OData.Description" String="Peer Autonomous System (AS) number."/>
+          <Annotation Term="OData.LongDescription" String="This property shall contain the Autonomous System (AS) number of the external Border Gateway Protocol (BGP) peer."/>
+          <Annotation Term="Validation.Minimum" Int="1"/>
+          <Annotation Term="Validation.Maximum" Int="65535"/>
+        </Property>
+        <Property Name="LocalAS" Type="Edm.Int64">
+          <Annotation Term="OData.Permissions" EnumMember="OData.Permission/ReadWrite"/>
+          <Annotation Term="OData.Description" String="Local Autonomous System (AS) number."/>
+          <Annotation Term="OData.LongDescription" String="This property shall contain the Autonomous System (AS) number of the local Border Gateway Protocol (BGP) peer."/>
+          <Annotation Term="Validation.Minimum" Int="1"/>
+          <Annotation Term="Validation.Maximum" Int="65535"/>
+        </Property>
+        <Property Name="LogStateChangesEnabled" Type="Edm.Boolean">
+          <Annotation Term="OData.Permissions" EnumMember="OData.Permission/ReadWrite"/>
+          <Annotation Term="OData.Description" String="Border Gateway Protocol (BGP) neighbor log state change status."/>
+          <Annotation Term="OData.LongDescription" String="This property shall indicate whether Border Gateway Protocol (BGP) neighbor state changes are logged."/>
+        </Property>
+        <Property Name="MaxPrefix" Type="AddressPool.v1_1_0.MaxPrefix">
+          <Annotation Term="OData.Description" String="Border Gateway Protocol (BGP) max prefix properties."/>
+          <Annotation Term="OData.LongDescription" String="These properties are applicable to configuring Border Gateway Protocol (BGP) max prefix related properties."/>
+        </Property>
+      </ComplexType>
+
+      <ComplexType Name="MaxPrefix">
+        <Annotation Term="OData.AdditionalProperties" Bool="false"/>
+        <Annotation Term="OData.Description" String="Border Gateway Protocol (BGP) max prefix properties."/>
+        <Annotation Term="OData.LongDescription" String="This type shall contain properties that are applicable to configuring Border Gateway Protocol (BGP) max prefix related properties."/>
+        <Property Name="MaxPrefixNumber" Type="Edm.Int64">
+          <Annotation Term="OData.Permissions" EnumMember="OData.Permission/ReadWrite"/>
+          <Annotation Term="OData.Description" String="Maximum prefix number."/>
+          <Annotation Term="OData.LongDescription" String="This property shall contain the maximum number of prefixes allowed from the neighbor."/>
+        </Property>
+        <Property Name="ThresholdWarningOnlyEnabled" Type="Edm.Boolean">
+          <Annotation Term="OData.Permissions" EnumMember="OData.Permission/ReadWrite"/>
+          <Annotation Term="OData.Description" String="Threshold warning only status."/>
+          <Annotation Term="OData.LongDescription" String="This property shall indicate what action to take if the Border Gateway Protocol (BGP) route threshold is reached.  If `true`, when the Maximum-Prefix limit is exceeded, a log message is generated.  If `false`, when the Maximum-Prefix limit is exceeded, the peer session is terminated."/>
+        </Property>
+        <Property Name="ShutdownThresholdPercentage" Type="Edm.Decimal">
+          <Annotation Term="OData.Permissions" EnumMember="OData.Permission/ReadWrite"/>
+          <Annotation Term="OData.Description" String="Shutdown threshold status."/>
+          <Annotation Term="OData.LongDescription" String="This property shall contain the percentage of the maximum prefix received value at which the router starts to generate a warning message."/>
+          <Annotation Term="Validation.Minimum" Int="1"/>
+          <Annotation Term="Validation.Maximum" Int="100"/>
+          <Annotation Term="Measures.Unit" String="%"/>
+        </Property>
+        <Property Name="RestartTimerSeconds" Type="Edm.Int64">
+          <Annotation Term="OData.Permissions" EnumMember="OData.Permission/ReadWrite"/>
+          <Annotation Term="OData.Description" String="Border Gateway Protocol (BGP) restart timer in seconds."/>
+          <Annotation Term="OData.LongDescription" String="This property determines how long peer routers will wait to delete stale routes before a Border Gateway Protocol (BGP) open message is received.  This timer should be less than the BGP HoldTimeSeconds property."/>
+        </Property>
+      </ComplexType>
+
+      <ComplexType Name="GracefulRestart">
+        <Annotation Term="OData.AdditionalProperties" Bool="false"/>
+        <Annotation Term="OData.Description" String="Border Gateway Protocol (BGP) graceful restart properties."/>
+        <Annotation Term="OData.LongDescription" String="This type shall contain properties that are applicable to configuring Border Gateway Protocol (BGP) graceful restart related properties."/>
+        <Property Name="GracefulRestartEnabled" Type="Edm.Boolean">
+          <Annotation Term="OData.Permissions" EnumMember="OData.Permission/ReadWrite"/>
+          <Annotation Term="OData.Description" String="Border Gateway Protocol (BGP) graceful restart status."/>
+          <Annotation Term="OData.LongDescription" String="This property shall indicate whether to enable Border Gateway Protocol (BGP) graceful restart features."/>
+        </Property>
+        <Property Name="TimeSeconds" Type="Edm.Int64">
+          <Annotation Term="OData.Permissions" EnumMember="OData.Permission/ReadWrite"/>
+          <Annotation Term="OData.Description" String="Graceful restart timer in seconds."/>
+          <Annotation Term="OData.LongDescription" String="This property shall contain the time in seconds to wait for a graceful restart capable neighbor to re-establish Border Gateway Protocol (BGP) peering."/>
+        </Property>
+        <Property Name="StaleRoutesTimeSeconds" Type="Edm.Int64">
+          <Annotation Term="OData.Permissions" EnumMember="OData.Permission/ReadWrite"/>
+          <Annotation Term="OData.Description" String="Stale route timer in seconds."/>
+          <Annotation Term="OData.LongDescription" String="This property shall contain the time in seconds to hold stale routes for a restarting peer."/>
+        </Property>
+        <Property Name="HelperModeEnabled" Type="Edm.Boolean">
+          <Annotation Term="OData.Permissions" EnumMember="OData.Permission/ReadWrite"/>
+          <Annotation Term="OData.Description" String="Graceful restart helper mode status."/>
+          <Annotation Term="OData.LongDescription" String="This property shall indicate what to do with stale routes.  If `true`, the router continues to be forward packets to stale routes, if `false`, it does not forward packets to stale routes."/>
+        </Property>
+      </ComplexType>
+
+      <ComplexType Name="MultiplePaths">
+        <Annotation Term="OData.AdditionalProperties" Bool="false"/>
+        <Annotation Term="OData.Description" String="Border Gateway Protocol (BGP) multiple path properties."/>
+        <Annotation Term="OData.LongDescription" String="This type shall contain properties that are applicable to configuring Border Gateway Protocol (BGP) multiple path related properties."/>
+        <Property Name="UseMultiplePathsEnabled" Type="Edm.Boolean">
+          <Annotation Term="OData.Permissions" EnumMember="OData.Permission/ReadWrite"/>
+          <Annotation Term="OData.Description" String="Border Gateway Protocol (BGP) multiple paths status."/>
+          <Annotation Term="OData.LongDescription" String="This property shall indicate whether multiple paths should be advertised.  If `true`, Border Gateway Protocol (BGP) advertises multiple paths for the same prefix for path diversity.  If `false`, it advertises based on best path selection."/>
+        </Property>
+        <Property Name="MaximumPaths" Type="Edm.Int64">
+          <Annotation Term="OData.Permissions" EnumMember="OData.Permission/ReadWrite"/>
+          <Annotation Term="OData.Description" String="Maximum paths number."/>
+          <Annotation Term="OData.LongDescription" String="This property shall contain the maximum number of paths for multi path operation."/>
+        </Property>
+      </ComplexType>
+
+      <ComplexType Name="BGPRoute">
+        <Annotation Term="OData.AdditionalProperties" Bool="false"/>
+        <Annotation Term="OData.Description" String="Border Gateway Protocol (BGP) route properties."/>
+        <Annotation Term="OData.LongDescription" String="This type shall contain properties that are applicable to configuring Border Gateway Protocol (BGP) route related properties."/>
+        <Property Name="FlapDampingEnabled" Type="Edm.Boolean">
+          <Annotation Term="OData.Permissions" EnumMember="OData.Permission/ReadWrite"/>
+          <Annotation Term="OData.Description" String="Route flap dampening status."/>
+          <Annotation Term="OData.LongDescription" String="This property shall indicate whether route flap dampening should be enabled."/>
+        </Property>
+        <Property Name="ExternalCompareRouterIdEnabled" Type="Edm.Boolean">
+          <Annotation Term="OData.Permissions" EnumMember="OData.Permission/ReadWrite"/>
+          <Annotation Term="OData.Description" String="Compare router id status."/>
+          <Annotation Term="OData.LongDescription" String="This property shall indicate whether external router ids should be compared.  If `true`, prefer the route that comes from the Border Gateway Protocol (BGP) router with the lowest router ID.  If `false`, do not use as part of BGP best path selection."/>
+        </Property>
+        <Property Name="AdvertiseInactiveRoutesEnabled" Type="Edm.Boolean">
+          <Annotation Term="OData.Permissions" EnumMember="OData.Permission/ReadWrite"/>
+          <Annotation Term="OData.Description" String="Advertise inactive route status."/>
+          <Annotation Term="OData.LongDescription" String="This property shall indicate whether inactive routes should be advertised.  If `true`, advertise the best Border Gateway Protocol (BGP) route that is inactive because of Interior Gateway Protocol (IGP) preference.  If `false`, do not use as part of BGP best path selection."/>
+        </Property>
+        <Property Name="SendDefaultRouteEnabled" Type="Edm.Boolean">
+          <Annotation Term="OData.Permissions" EnumMember="OData.Permission/ReadWrite"/>
+          <Annotation Term="OData.Description" String="Send default route status."/>
+          <Annotation Term="OData.LongDescription" String="This property shall indicate whether the default route should be advertised.  If `true`, the default route is advertised to all Border Gateway Protocol (BGP) neighbors unless specifically denied.  If `false`, the default route is not advertised."/>
+        </Property>
+        <Property Name="DistanceExternal" Type="Edm.Int64">
+          <Annotation Term="OData.Permissions" EnumMember="OData.Permission/ReadWrite"/>
+          <Annotation Term="OData.Description" String="Route distance for external routes."/>
+          <Annotation Term="OData.LongDescription" String="This property shall modify the administrative distance for routes learned via External BGP (eBGP)."/>
+        </Property>
+        <Property Name="DistanceInternal" Type="Edm.Int64">
+          <Annotation Term="OData.Permissions" EnumMember="OData.Permission/ReadWrite"/>
+          <Annotation Term="OData.Description" String="Route distance for internal routes."/>
+          <Annotation Term="OData.LongDescription" String="This property shall modify the administrative distance for routes learned via Internal BGP (iBGP)."/>
+        </Property>
+        <Property Name="DistanceLocal" Type="Edm.Int64">
+          <Annotation Term="OData.Permissions" EnumMember="OData.Permission/ReadWrite"/>
+          <Annotation Term="OData.Description" String="Route distance for local routes."/>
+          <Annotation Term="OData.LongDescription" String="This property shall modify the administrative distance for routes configured on a local router."/>
+        </Property>
+      </ComplexType>
+    </Schema>
+
+    <Schema xmlns="http://docs.oasis-open.org/odata/ns/edm" Namespace="AddressPool.v1_1_1">
+      <Annotation Term="Redfish.OwningEntity" String="DMTF"/>
+      <Annotation Term="OData.Description" String="This version was created to correct various typographical errors."/>
+      <EntityType Name="AddressPool" BaseType="AddressPool.v1_1_0.AddressPool"/>
+    </Schema>
+
+    <Schema xmlns="http://docs.oasis-open.org/odata/ns/edm" Namespace="AddressPool.v1_2_0">
+      <Annotation Term="Redfish.OwningEntity" String="DMTF"/>
+      <Annotation Term="Redfish.Release" String="2021.2"/>
+      <Annotation Term="OData.Description" String="This version was created to add CIDR and Enabled to BGPNeighbor."/>
+
+      <EntityType Name="AddressPool" BaseType="AddressPool.v1_1_1.AddressPool"/>
+
+      <ComplexType Name="BGPNeighbor" BaseType="AddressPool.v1_1_0.BGPNeighbor">
+        <Property Name="Enabled" Type="Edm.Boolean" Nullable="false">
+          <Annotation Term="OData.Permissions" EnumMember="OData.Permission/ReadWrite"/>
+          <Annotation Term="OData.Description" String="An indication of whether BGP neighbor communication is enabled."/>
+          <Annotation Term="OData.LongDescription" String="The value of this property shall indicate whether BGP neighbor communication is enabled."/>
+        </Property>
+        <Property Name="CIDR" Type="Edm.Int64" Nullable="false">
+          <Annotation Term="OData.Permissions" EnumMember="OData.Permission/ReadWrite"/>
+          <Annotation Term="OData.Description" String="The Classless Inter-Domain Routing (CIDR) value used for neighbor communication.  This is the number of ones before the first zero in the subnet mask."/>
+          <Annotation Term="OData.LongDescription" String="The value of this property shall contain the RFC4271-defined Classless Inter-Domain Routing (CIDR) value."/>
+        </Property>
+      </ComplexType>
+
+      <ComplexType Name="BGPEvpn" BaseType="AddressPool.v1_1_0.BGPEvpn">
+        <Property Name="RouteDistinguisherAdministratorSubfield" Type="Edm.String">
+          <Annotation Term="OData.Permissions" EnumMember="OData.Permission/ReadWrite"/>
+          <Annotation Term="OData.Description" String="The Route Distinguisher (RD) Administrator subfield."/>
+          <Annotation Term="OData.LongDescription" String="This property shall contain the RFC4364-defined Route Distinguisher (RD) Administrator subfield."/>
+        </Property>
+        <Property Name="RouteTargetAdministratorSubfield" Type="Edm.String">
+          <Annotation Term="OData.Permissions" EnumMember="OData.Permission/ReadWrite"/>
+          <Annotation Term="OData.Description" String="The Route Target (RT) Administrator Subfield."/>
+          <Annotation Term="OData.LongDescription" String="This property shall contain the RFC4364-defined Route Target (RT) Administrator subfield."/>
+        </Property>
+        <Property Name="GatewayIPAddressRange" Type="AddressPool.v1_2_0.GatewayIPAddressRange">
+          <Annotation Term="OData.Description" String="The IPv4 address range for gateways."/>
+          <Annotation Term="OData.LongDescription" String="This property shall contain the IPv4 address range for gateway nodes on this subnet."/>
+        </Property>
+      </ComplexType>
+
+      <ComplexType Name="IPv4" BaseType="AddressPool.v1_1_0.IPv4">
+        <Property Name="SystemMACRange" Type="AddressPool.v1_2_0.SystemMACRange">
+          <Annotation Term="OData.Description" String="The MAC address range for systems in this subnet."/>
+          <Annotation Term="OData.LongDescription" String="This property shall contain the Media Access Control (MAC) address range for systems in Ethernet Virtual Private Network (EVPN) based fabrics."/>
+        </Property>
+      </ComplexType>
+
+      <ComplexType Name="SystemMACRange">
+        <Annotation Term="OData.AdditionalProperties" Bool="false"/>
+        <Annotation Term="OData.Description" String="The Media Access Control (MAC) address range for the EVPN based fabrics."/>
+        <Annotation Term="OData.LongDescription" String="This type shall contain the Media Access Control (MAC) address range for Ethernet Virtual Private Network (EVPN) based fabrics."/>
+        <Property Name="Lower" Type="Edm.String">
+          <Annotation Term="OData.Permissions" EnumMember="OData.Permission/ReadWrite"/>
+          <Annotation Term="OData.Description" String="The lower system MAC address."/>
+          <Annotation Term="OData.LongDescription" String="This property shall contain the lower system Media Access Control (MAC) address to be used as part of a range of system MAC addresses."/>
+          <Annotation Term="Validation.Pattern" String="^([0-9A-Fa-f]{2}[:-]){5}([0-9A-Fa-f]{2})$"/>
+        </Property>
+        <Property Name="Upper" Type="Edm.String">
+          <Annotation Term="OData.Permissions" EnumMember="OData.Permission/ReadWrite"/>
+          <Annotation Term="OData.Description" String="The upper system MAC address."/>
+          <Annotation Term="OData.LongDescription" String="This property shall contain the upper system Media Access Control (MAC) address to be used as part of a range of system MAC addresses."/>
+          <Annotation Term="Validation.Pattern" String="^([0-9A-Fa-f]{2}[:-]){5}([0-9A-Fa-f]{2})$"/>
+        </Property>
+      </ComplexType>
+
+      <ComplexType Name="GatewayIPAddressRange">
+        <Annotation Term="OData.AdditionalProperties" Bool="false"/>
+        <Annotation Term="OData.Description" String="The IPv4 address range for gateway nodes for Ethernet Virtual Private Network (EVPN) based fabrics."/>
+        <Annotation Term="OData.LongDescription" String="This type shall contain the IPv4 address range for gateway nodes for Ethernet Virtual Private Network (EVPN) based fabrics."/>
+        <Property Name="Lower" Type="Edm.String">
+          <Annotation Term="OData.Permissions" EnumMember="OData.Permission/ReadWrite"/>
+          <Annotation Term="OData.Description" String="The lower IPv4 address."/>
+          <Annotation Term="OData.LongDescription" String="This property shall contain the lower IP address to be used as part of a range of addresses for gateway nodes in Ethernet Virtual Private Network (EVPN) based fabrics."/>
+          <Annotation Term="Validation.Pattern" String="^(?:[0-9]{1,3}\.){3}[0-9]{1,3}$"/>
+        </Property>
+        <Property Name="Upper" Type="Edm.String">
+          <Annotation Term="OData.Permissions" EnumMember="OData.Permission/ReadWrite"/>
+          <Annotation Term="OData.Description" String="The upper IPv4 address."/>
+          <Annotation Term="OData.LongDescription" String="This property shall contain the upper IP address to be used as part of a range of addresses for gateway nodes in Ethernet Virtual Private Network (EVPN) based fabrics."/>
+          <Annotation Term="Validation.Pattern" String="^(?:[0-9]{1,3}\.){3}[0-9]{1,3}$"/>
+        </Property>
+      </ComplexType>
+    </Schema>
+
+  </edmx:DataServices>
+</edmx:Edmx>

--- a/static/redfish/v1/schema/AggregateCollection_v1.xml
+++ b/static/redfish/v1/schema/AggregateCollection_v1.xml
@@ -1,0 +1,69 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!---->
+<!--################################################################################       -->
+<!--# Redfish Schema:  AggregateCollection                                                 -->
+<!--#                                                                                      -->
+<!--# For a detailed change log, see the README file contained in the DSP8010 bundle,      -->
+<!--# available at http://www.dmtf.org/standards/redfish                                   -->
+<!--# Copyright 2014-2021 DMTF.                                                            -->
+<!--# For the full DMTF copyright policy, see http://www.dmtf.org/about/policies/copyright -->
+<!--################################################################################       -->
+<!---->
+<edmx:Edmx xmlns:edmx="http://docs.oasis-open.org/odata/ns/edmx" Version="4.0">
+
+  <edmx:Reference Uri="http://docs.oasis-open.org/odata/odata/v4.0/errata03/csd01/complete/vocabularies/Org.OData.Core.V1.xml">
+    <edmx:Include Namespace="Org.OData.Core.V1" Alias="OData"/>
+  </edmx:Reference>
+  <edmx:Reference Uri="http://docs.oasis-open.org/odata/odata/v4.0/errata03/csd01/complete/vocabularies/Org.OData.Capabilities.V1.xml">
+    <edmx:Include Namespace="Org.OData.Capabilities.V1" Alias="Capabilities"/>
+  </edmx:Reference>
+  <edmx:Reference Uri="http://redfish.dmtf.org/schemas/v1/Resource_v1.xml">
+    <edmx:Include Namespace="Resource.v1_0_0"/>
+  </edmx:Reference>
+  <edmx:Reference Uri="http://redfish.dmtf.org/schemas/v1/RedfishExtensions_v1.xml">
+    <edmx:Include Namespace="RedfishExtensions.v1_0_0" Alias="Redfish"/>
+  </edmx:Reference>
+  <edmx:Reference Uri="http://redfish.dmtf.org/schemas/v1/Aggregate_v1.xml">
+    <edmx:Include Namespace="Aggregate"/>
+  </edmx:Reference>
+
+  <edmx:DataServices>
+
+    <Schema xmlns="http://docs.oasis-open.org/odata/ns/edm" Namespace="AggregateCollection">
+      <Annotation Term="Redfish.OwningEntity" String="DMTF"/>
+
+      <EntityType Name="AggregateCollection" BaseType="Resource.v1_0_0.ResourceCollection">
+        <Annotation Term="OData.Description" String="The collection of Aggregate resource instances."/>
+        <Annotation Term="OData.LongDescription" String="This resource shall represent a resource collection of Aggregate instances for a Redfish implementation."/>
+        <Annotation Term="Capabilities.InsertRestrictions">
+          <Record>
+            <PropertyValue Property="Insertable" Bool="true"/>
+          </Record>
+        </Annotation>
+        <Annotation Term="Capabilities.UpdateRestrictions">
+          <Record>
+            <PropertyValue Property="Updatable" Bool="false"/>
+          </Record>
+        </Annotation>
+        <Annotation Term="Capabilities.DeleteRestrictions">
+          <Record>
+            <PropertyValue Property="Deletable" Bool="false"/>
+          </Record>
+        </Annotation>
+        <Annotation Term="Redfish.Uris">
+          <Collection>
+            <String>/redfish/v1/AggregationService/Aggregates</String>
+          </Collection>
+        </Annotation>
+        <NavigationProperty Name="Members" Type="Collection(Aggregate.Aggregate)">
+          <Annotation Term="OData.Permissions" EnumMember="OData.Permission/Read"/>
+          <Annotation Term="OData.Description" String="The members of this collection."/>
+          <Annotation Term="OData.LongDescription" String="This property shall contain an array of links to the members of this collection."/>
+          <Annotation Term="OData.AutoExpandReferences"/>
+          <Annotation Term="Redfish.Required"/>
+        </NavigationProperty>
+      </EntityType>
+    </Schema>
+
+  </edmx:DataServices>
+</edmx:Edmx>

--- a/static/redfish/v1/schema/Aggregate_v1.xml
+++ b/static/redfish/v1/schema/Aggregate_v1.xml
@@ -1,0 +1,160 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!---->
+<!--################################################################################       -->
+<!--# Redfish Schema:  Aggregate v1.0.1                                                    -->
+<!--#                                                                                      -->
+<!--# For a detailed change log, see the README file contained in the DSP8010 bundle,      -->
+<!--# available at http://www.dmtf.org/standards/redfish                                   -->
+<!--# Copyright 2014-2021 DMTF.                                                            -->
+<!--# For the full DMTF copyright policy, see http://www.dmtf.org/about/policies/copyright -->
+<!--################################################################################       -->
+<!---->
+<edmx:Edmx xmlns:edmx="http://docs.oasis-open.org/odata/ns/edmx" Version="4.0">
+
+  <edmx:Reference Uri="http://docs.oasis-open.org/odata/odata/v4.0/errata03/csd01/complete/vocabularies/Org.OData.Core.V1.xml">
+    <edmx:Include Namespace="Org.OData.Core.V1" Alias="OData"/>
+  </edmx:Reference>
+  <edmx:Reference Uri="http://docs.oasis-open.org/odata/odata/v4.0/errata03/csd01/complete/vocabularies/Org.OData.Capabilities.V1.xml">
+    <edmx:Include Namespace="Org.OData.Capabilities.V1" Alias="Capabilities"/>
+  </edmx:Reference>
+  <edmx:Reference Uri="http://docs.oasis-open.org/odata/odata/v4.0/errata03/csd01/complete/vocabularies/Org.OData.Measures.V1.xml">
+    <edmx:Include Namespace="Org.OData.Measures.V1" Alias="Measures"/>
+  </edmx:Reference>
+  <edmx:Reference Uri="http://redfish.dmtf.org/schemas/v1/Resource_v1.xml">
+    <edmx:Include Namespace="Resource"/>
+    <edmx:Include Namespace="Resource.v1_0_0"/>
+  </edmx:Reference>
+  <edmx:Reference Uri="http://redfish.dmtf.org/schemas/v1/RedfishExtensions_v1.xml">
+    <edmx:Include Namespace="RedfishExtensions.v1_0_0" Alias="Redfish"/>
+    <edmx:Include Namespace="Validation.v1_0_0" Alias="Validation"/>
+  </edmx:Reference>
+
+  <edmx:DataServices>
+
+    <Schema xmlns="http://docs.oasis-open.org/odata/ns/edm" Namespace="Aggregate">
+      <Annotation Term="Redfish.OwningEntity" String="DMTF"/>
+
+      <EntityType Name="Aggregate" BaseType="Resource.v1_0_0.Resource" Abstract="true">
+        <Annotation Term="OData.Description" String="The Aggregate schema describes a grouping method for an aggregation service.  Aggregates are formal groups of resources that are more persistent than ad hoc groupings."/>
+        <Annotation Term="OData.LongDescription" String="This resource shall represent an aggregation service grouping method for a Redfish implementation."/>
+        <Annotation Term="OData.AdditionalProperties" Bool="false"/>
+        <Annotation Term="Capabilities.InsertRestrictions">
+          <Record>
+            <PropertyValue Property="Insertable" Bool="false"/>
+          </Record>
+        </Annotation>
+        <Annotation Term="Capabilities.UpdateRestrictions">
+          <Record>
+            <PropertyValue Property="Updatable" Bool="false"/>
+          </Record>
+        </Annotation>
+        <Annotation Term="Capabilities.DeleteRestrictions">
+          <Record>
+            <PropertyValue Property="Deletable" Bool="true"/>
+          </Record>
+        </Annotation>
+        <Annotation Term="Redfish.Uris">
+          <Collection>
+            <String>/redfish/v1/AggregationService/Aggregates/{AggregateId}</String>
+          </Collection>
+        </Annotation>
+      </EntityType>
+
+      <Action Name="Reset" IsBound="true">
+        <Annotation Term="OData.Description" String="This action is used to reset a collection of resources.  For example, this could be an aggregate or a list of computer systems."/>
+        <Annotation Term="OData.LongDescription" String="This action shall perform a reset of a collection of resources."/>
+        <Parameter Name="Aggregate" Type="Aggregate.v1_0_0.Actions"/>
+        <Parameter Name="DelayBetweenBatchesInSeconds" Type="Edm.Int64">
+          <Annotation Term="OData.Description" String="The delay of the batches of elements being reset in seconds."/>
+          <Annotation Term="OData.LongDescription" String="This parameter shall contain the delay of the batches of elements being reset in seconds."/>
+          <Annotation Term="Validation.Minimum" Int="0"/>
+          <Annotation Term="Measures.Unit" String="s"/>
+        </Parameter>
+        <Parameter Name="BatchSize" Type="Edm.Int64">
+          <Annotation Term="OData.Description" String="The number of elements in each batch being reset."/>
+          <Annotation Term="OData.LongDescription" String="This parameter shall contain the number of elements in each batch simultaneously being issued a reset."/>
+          <Annotation Term="Validation.Minimum" Int="0"/>
+        </Parameter>
+        <Parameter Name="ResetType" Type="Resource.ResetType">
+          <Annotation Term="OData.Description" String="The type of reset."/>
+          <Annotation Term="OData.LongDescription" String="This parameter shall contain the type of reset.  The service can accept a request without the parameter and perform an implementation-specific default reset."/>
+        </Parameter>
+      </Action>
+
+      <Action Name="SetDefaultBootOrder" IsBound="true">
+        <Annotation Term="OData.Description" String="This action is used to restore the boot order to the default state for the computer systems that are members of this aggregate."/>
+        <Annotation Term="OData.LongDescription" String="This action shall restore the boot order to the default state for the computer systems that are members of this aggregate."/>
+        <Parameter Name="Aggregate" Type="Aggregate.v1_0_0.Actions"/>
+      </Action>
+
+      <Action Name="AddElements" IsBound="true">
+        <Annotation Term="OData.Description" String="This action is used to add one or more resources to the aggregate."/>
+        <Annotation Term="OData.LongDescription" String="This action shall add one or more resources to the aggregate, resulting in that the resources are included in the Elements array of the aggregate."/>
+        <Parameter Name="Aggregate" Type="Aggregate.v1_0_0.Actions"/>
+        <Parameter Name="Elements" Type="Collection(Resource.Resource)" Nullable="false">
+          <Annotation Term="OData.Description" String="An array of resource links to add to the Elements array."/>
+          <Annotation Term="OData.LongDescription" String="This parameter shall contain an array of links to the specified resources to add to the aggregate's Elements array."/>
+        </Parameter>
+      </Action>
+
+      <Action Name="RemoveElements" IsBound="true">
+        <Annotation Term="OData.Description" String="This action is used to remove one or more resources from the aggregate."/>
+        <Annotation Term="OData.LongDescription" String="This action shall remove one or more resources from the aggregate, resulting in that the resources are removed from the Elements array of the aggregate."/>
+        <Parameter Name="Aggregate" Type="Aggregate.v1_0_0.Actions"/>
+        <Parameter Name="Elements" Type="Collection(Resource.Resource)" Nullable="false">
+          <Annotation Term="OData.Description" String="An array of resource links to remove from the Elements array."/>
+          <Annotation Term="OData.LongDescription" String="This parameter shall contain an array of links to the specified resources to remove from the aggregate's Elements array."/>
+        </Parameter>
+      </Action>
+    </Schema>
+
+    <Schema xmlns="http://docs.oasis-open.org/odata/ns/edm" Namespace="Aggregate.v1_0_0">
+      <Annotation Term="Redfish.OwningEntity" String="DMTF"/>
+      <Annotation Term="Redfish.Release" String="2020.2"/>
+
+      <EntityType Name="Aggregate" BaseType="Aggregate.Aggregate">
+        <NavigationProperty Name="Elements" Type="Collection(Resource.Resource)">
+          <Annotation Term="OData.Permissions" EnumMember="OData.Permission/Read"/>
+          <Annotation Term="OData.Description" String="The elements of this aggregate."/>
+          <Annotation Term="OData.LongDescription" String="This property shall contain an array of links to the elements of this aggregate."/>
+          <Annotation Term="OData.AutoExpandReferences"/>
+          <Annotation Term="Redfish.Required"/>
+          <Annotation Term="Redfish.RequiredOnCreate"/>
+        </NavigationProperty>
+        <Property Name="ElementsCount" Type="Edm.Int64">
+          <Annotation Term="OData.Permissions" EnumMember="OData.Permission/Read"/>
+          <Annotation Term="OData.Description" String="The number of entries in the Elements array."/>
+          <Annotation Term="OData.LongDescription" String="This property shall contain the number of entries in the Elements array."/>
+          <Annotation Term="Validation.Minimum" Int="0"/>
+        </Property>
+        <Property Name="Actions" Type="Aggregate.v1_0_0.Actions" Nullable="false">
+          <Annotation Term="OData.Description" String="The available actions for this resource."/>
+          <Annotation Term="OData.LongDescription" String="This property shall contain the available actions for this resource."/>
+        </Property>
+      </EntityType>
+
+      <ComplexType Name="Actions">
+        <Annotation Term="OData.AdditionalProperties" Bool="false"/>
+        <Annotation Term="OData.Description" String="The available actions for this resource."/>
+        <Annotation Term="OData.LongDescription" String="This type shall contain the available actions for this resource."/>
+        <Property Name="Oem" Type="Aggregate.v1_0_0.OemActions" Nullable="false">
+          <Annotation Term="OData.Description" String="The available OEM-specific actions for this resource."/>
+          <Annotation Term="OData.LongDescription" String="This property shall contain the available OEM-specific actions for this resource."/>
+        </Property>
+      </ComplexType>
+
+      <ComplexType Name="OemActions">
+        <Annotation Term="OData.AdditionalProperties" Bool="true"/>
+        <Annotation Term="OData.Description" String="The available OEM-specific actions for this resource."/>
+        <Annotation Term="OData.LongDescription" String="This type shall contain the available OEM-specific actions for this resource."/>
+      </ComplexType>
+    </Schema>
+
+    <Schema xmlns="http://docs.oasis-open.org/odata/ns/edm" Namespace="Aggregate.v1_0_1">
+      <Annotation Term="Redfish.OwningEntity" String="DMTF"/>
+      <Annotation Term="OData.Description" String="This version was created specify 64-bit integers in OpenAPI."/>
+      <EntityType Name="Aggregate" BaseType="Aggregate.v1_0_0.Aggregate"/>
+    </Schema>
+
+  </edmx:DataServices>
+</edmx:Edmx>

--- a/static/redfish/v1/schema/AggregationService_v1.xml
+++ b/static/redfish/v1/schema/AggregationService_v1.xml
@@ -1,0 +1,174 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!---->
+<!--################################################################################       -->
+<!--# Redfish Schema:  AggregationService v1.0.1                                           -->
+<!--#                                                                                      -->
+<!--# For a detailed change log, see the README file contained in the DSP8010 bundle,      -->
+<!--# available at http://www.dmtf.org/standards/redfish                                   -->
+<!--# Copyright 2014-2021 DMTF.                                                            -->
+<!--# For the full DMTF copyright policy, see http://www.dmtf.org/about/policies/copyright -->
+<!--################################################################################       -->
+<!---->
+<edmx:Edmx xmlns:edmx="http://docs.oasis-open.org/odata/ns/edmx" Version="4.0">
+
+  <edmx:Reference Uri="http://docs.oasis-open.org/odata/odata/v4.0/errata03/csd01/complete/vocabularies/Org.OData.Core.V1.xml">
+   <edmx:Include Namespace="Org.OData.Core.V1" Alias="OData"/>
+  </edmx:Reference>
+  <edmx:Reference Uri="http://docs.oasis-open.org/odata/odata/v4.0/errata03/csd01/complete/vocabularies/Org.OData.Measures.V1.xml">
+    <edmx:Include Namespace="Org.OData.Measures.V1" Alias="Measures"/>
+  </edmx:Reference>
+  <edmx:Reference Uri="http://docs.oasis-open.org/odata/odata/v4.0/errata03/csd01/complete/vocabularies/Org.OData.Capabilities.V1.xml">
+    <edmx:Include Namespace="Org.OData.Capabilities.V1" Alias="Capabilities"/>
+  </edmx:Reference>
+  <edmx:Reference Uri="http://redfish.dmtf.org/schemas/v1/RedfishExtensions_v1.xml">
+    <edmx:Include Namespace="Validation.v1_0_0" Alias="Validation"/>
+    <edmx:Include Namespace="RedfishExtensions.v1_0_0" Alias="Redfish"/>
+  </edmx:Reference>
+  <edmx:Reference Uri="http://redfish.dmtf.org/schemas/v1/Resource_v1.xml">
+    <edmx:Include Namespace="Resource"/>
+    <edmx:Include Namespace="Resource.v1_0_0"/>
+  </edmx:Reference>
+  <edmx:Reference Uri="http://redfish.dmtf.org/schemas/v1/AggregationSourceCollection_v1.xml">
+    <edmx:Include Namespace="AggregationSourceCollection"/>
+  </edmx:Reference>
+  <edmx:Reference Uri="http://redfish.dmtf.org/schemas/v1/AggregateCollection_v1.xml">
+    <edmx:Include Namespace="AggregateCollection"/>
+  </edmx:Reference>
+  <edmx:Reference Uri="http://redfish.dmtf.org/schemas/v1/ConnectionMethodCollection_v1.xml">
+    <edmx:Include Namespace="ConnectionMethodCollection"/>
+  </edmx:Reference>
+  <edmx:Reference Uri="http://redfish.dmtf.org/schemas/v1/ComputerSystem_v1.xml">
+    <edmx:Include Namespace="ComputerSystem"/>
+  </edmx:Reference>
+
+  <edmx:DataServices>
+
+    <Schema xmlns="http://docs.oasis-open.org/odata/ns/edm" Namespace="AggregationService">
+      <Annotation Term="Redfish.OwningEntity" String="DMTF"/>
+
+      <EntityType Name="AggregationService" BaseType="Resource.v1_0_0.Resource" Abstract="true">
+        <Annotation Term="OData.Description" String="The AggregationService schema contains properties for managing aggregation operations, either on ad hoc combinations of resources or on defined sets of resources called aggregates.  Access points define the properties needed to access the entity being aggregated and connection methods describe the protocol or other semantics of the connection."/>
+        <Annotation Term="OData.LongDescription" String="This resource shall represent an aggregation service for a Redfish implementation."/>
+        <Annotation Term="OData.AdditionalProperties" Bool="true"/>
+        <Annotation Term="Capabilities.InsertRestrictions">
+          <Record>
+            <PropertyValue Property="Insertable" Bool="false"/>
+          </Record>
+        </Annotation>
+        <Annotation Term="Capabilities.UpdateRestrictions">
+          <Record>
+            <PropertyValue Property="Updatable" Bool="true"/>
+            <Annotation Term="OData.Description" String="The aggregation service can be updated to change some properties"/>
+          </Record>
+        </Annotation>
+        <Annotation Term="Capabilities.DeleteRestrictions">
+          <Record>
+            <PropertyValue Property="Deletable" Bool="false"/>
+          </Record>
+        </Annotation>
+        <Annotation Term="Redfish.Uris">
+          <Collection>
+            <String>/redfish/v1/AggregationService</String>
+          </Collection>
+        </Annotation>
+      </EntityType>
+
+      <Action Name="Reset" IsBound="true">
+        <Annotation Term="OData.Description" String="This action is used to reset a set of resources.  For example this could be a list of computer systems."/>
+        <Annotation Term="OData.LongDescription" String="This action shall perform a reset of a set of resources."/>
+        <Parameter Name="Aggregate" Type="AggregationService.v1_0_0.Actions"/>
+        <Parameter Name="DelayBetweenBatchesInSeconds" Type="Edm.Int64">
+          <Annotation Term="OData.Description" String="The delay of the batches of elements being reset in seconds."/>
+          <Annotation Term="OData.LongDescription" String="This parameter shall contain the delay of the batches of elements being reset in seconds."/>
+          <Annotation Term="Validation.Minimum" Int="0"/>
+          <Annotation Term="Measures.Unit" String="s"/>
+        </Parameter>
+        <Parameter Name="BatchSize" Type="Edm.Int64">
+          <Annotation Term="OData.Description" String="The number of elements in each batch being reset."/>
+          <Annotation Term="OData.LongDescription" String="This parameter shall contain the number of elements in each batch simultaneously being issued a reset."/>
+          <Annotation Term="Validation.Minimum" Int="0"/>
+        </Parameter>
+        <Parameter Name="ResetType" Type="Resource.ResetType">
+          <Annotation Term="OData.Description" String="The type of reset."/>
+          <Annotation Term="OData.LongDescription" String="This parameter shall contain the type of reset.  The service can accept a request without the parameter and perform an implementation-specific default reset."/>
+        </Parameter>
+        <Parameter Name="TargetURIs" Type="Collection(Resource.Resource)" Nullable="false">
+          <Annotation Term="OData.Description" String="An array of links to the resources being reset."/>
+          <Annotation Term="OData.LongDescription" String="This parameter shall contain an array of links to the resources being reset."/>
+        </Parameter>
+      </Action>
+
+      <Action Name="SetDefaultBootOrder" IsBound="true">
+        <Annotation Term="OData.Description" String="This action is used to restore the boot order to the default state for the specified computer systems."/>
+        <Annotation Term="OData.LongDescription" String="This action shall restore the boot order to the default state for the specified computer systems."/>
+        <Parameter Name="AggregationService" Type="AggregationService.v1_0_0.Actions" />
+        <Parameter Name="Systems" Type="Collection(ComputerSystem.ComputerSystem)" Nullable="false">
+          <Annotation Term="OData.Description" String="The computer systems to restore."/>
+          <Annotation Term="OData.LongDescription" String="This parameter shall contain an array of links to resources of type ComputerSystem."/>
+        </Parameter>
+      </Action>
+    </Schema>
+
+    <Schema xmlns="http://docs.oasis-open.org/odata/ns/edm" Namespace="AggregationService.v1_0_0">
+      <Annotation Term="Redfish.OwningEntity" String="DMTF"/>
+      <Annotation Term="Redfish.Release" String="2020.2"/>
+
+      <EntityType Name="AggregationService" BaseType="AggregationService.AggregationService">
+        <Property Name="ServiceEnabled" Type="Edm.Boolean">
+          <Annotation Term="OData.Permissions" EnumMember="OData.Permission/ReadWrite"/>
+          <Annotation Term="OData.Description" String="An indication of whether the aggregation service is enabled."/>
+          <Annotation Term="OData.LongDescription" String="This property shall indicate whether the aggregation service is enabled."/>
+        </Property>
+        <Property Name="Status" Type="Resource.Status" Nullable="false">
+          <Annotation Term="OData.Description" String="The status and health of the resource and its subordinate or dependent resources."/>
+          <Annotation Term="OData.LongDescription" String="This property shall contain any status or health properties of the resource."/>
+        </Property>
+        <NavigationProperty Name="Aggregates" Type="AggregateCollection.AggregateCollection" ContainsTarget="true" Nullable="false">
+          <Annotation Term="OData.Permissions" EnumMember="OData.Permission/Read"/>
+          <Annotation Term="OData.Description" String="The link to the collection of aggregates associated with this service."/>
+          <Annotation Term="OData.LongDescription" String="This property shall contain a link to a resource collection of type AggregateCollection."/>
+          <Annotation Term="OData.AutoExpandReferences"/>
+        </NavigationProperty>
+        <NavigationProperty Name="AggregationSources" Type="AggregationSourceCollection.AggregationSourceCollection" ContainsTarget="true" Nullable="false">
+          <Annotation Term="OData.Permissions" EnumMember="OData.Permission/Read"/>
+          <Annotation Term="OData.Description" String="The link to the collection of aggregation sources associated with this service."/>
+          <Annotation Term="OData.LongDescription" String="This property shall contain a link to a resource collection of type AggregationSourceCollection."/>
+          <Annotation Term="OData.AutoExpandReferences"/>
+        </NavigationProperty>
+        <NavigationProperty Name="ConnectionMethods" Type="ConnectionMethodCollection.ConnectionMethodCollection" ContainsTarget="true" Nullable="false">
+          <Annotation Term="OData.Permissions" EnumMember="OData.Permission/Read"/>
+          <Annotation Term="OData.Description" String="The link to the collection of connection methods associated with this service."/>
+          <Annotation Term="OData.LongDescription" String="This property shall contain a link to a resource collection of type ConnectionMethodCollection."/>
+          <Annotation Term="OData.AutoExpandReferences"/>
+        </NavigationProperty>
+        <Property Name="Actions" Type="AggregationService.v1_0_0.Actions" Nullable="false">
+          <Annotation Term="OData.Description" String="The available actions for this resource."/>
+          <Annotation Term="OData.LongDescription" String="This property shall contain the available actions for this resource."/>
+        </Property>
+      </EntityType>
+
+      <ComplexType Name="Actions">
+        <Annotation Term="OData.AdditionalProperties" Bool="false"/>
+        <Annotation Term="OData.Description" String="The available actions for this resource."/>
+        <Annotation Term="OData.LongDescription" String="This type shall contain the available actions for this resource."/>
+        <Property Name="Oem" Type="AggregationService.v1_0_0.OemActions" Nullable="false">
+          <Annotation Term="OData.Description" String="The available OEM-specific actions for this resource."/>
+          <Annotation Term="OData.LongDescription" String="This property shall contain the available OEM-specific actions for this resource."/>
+        </Property>
+      </ComplexType>
+
+      <ComplexType Name="OemActions">
+        <Annotation Term="OData.AdditionalProperties" Bool="true"/>
+        <Annotation Term="OData.Description" String="The available OEM-specific actions for this resource."/>
+        <Annotation Term="OData.LongDescription" String="This type shall contain the available OEM-specific actions for this resource."/>
+      </ComplexType>
+    </Schema>
+
+    <Schema xmlns="http://docs.oasis-open.org/odata/ns/edm" Namespace="AggregationService.v1_0_1">
+      <Annotation Term="Redfish.OwningEntity" String="DMTF"/>
+      <Annotation Term="OData.Description" String="This version was created specify 64-bit integers in OpenAPI."/>
+      <EntityType Name="AggregationService" BaseType="AggregationService.v1_0_0.AggregationService"/>
+    </Schema>
+
+  </edmx:DataServices>
+</edmx:Edmx>

--- a/static/redfish/v1/schema/AggregationSourceCollection_v1.xml
+++ b/static/redfish/v1/schema/AggregationSourceCollection_v1.xml
@@ -1,0 +1,69 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!---->
+<!--################################################################################       -->
+<!--# Redfish Schema:  AggregationSourceCollection                                         -->
+<!--#                                                                                      -->
+<!--# For a detailed change log, see the README file contained in the DSP8010 bundle,      -->
+<!--# available at http://www.dmtf.org/standards/redfish                                   -->
+<!--# Copyright 2014-2021 DMTF.                                                            -->
+<!--# For the full DMTF copyright policy, see http://www.dmtf.org/about/policies/copyright -->
+<!--################################################################################       -->
+<!---->
+<edmx:Edmx xmlns:edmx="http://docs.oasis-open.org/odata/ns/edmx" Version="4.0">
+
+  <edmx:Reference Uri="http://docs.oasis-open.org/odata/odata/v4.0/errata03/csd01/complete/vocabularies/Org.OData.Core.V1.xml">
+    <edmx:Include Namespace="Org.OData.Core.V1" Alias="OData"/>
+  </edmx:Reference>
+  <edmx:Reference Uri="http://docs.oasis-open.org/odata/odata/v4.0/errata03/csd01/complete/vocabularies/Org.OData.Capabilities.V1.xml">
+    <edmx:Include Namespace="Org.OData.Capabilities.V1" Alias="Capabilities"/>
+  </edmx:Reference>
+  <edmx:Reference Uri="http://redfish.dmtf.org/schemas/v1/Resource_v1.xml">
+    <edmx:Include Namespace="Resource.v1_0_0"/>
+  </edmx:Reference>
+  <edmx:Reference Uri="http://redfish.dmtf.org/schemas/v1/RedfishExtensions_v1.xml">
+    <edmx:Include Namespace="RedfishExtensions.v1_0_0" Alias="Redfish"/>
+  </edmx:Reference>
+  <edmx:Reference Uri="http://redfish.dmtf.org/schemas/v1/AggregationSource_v1.xml">
+    <edmx:Include Namespace="AggregationSource"/>
+  </edmx:Reference>
+
+  <edmx:DataServices>
+
+    <Schema xmlns="http://docs.oasis-open.org/odata/ns/edm" Namespace="AggregationSourceCollection">
+      <Annotation Term="Redfish.OwningEntity" String="DMTF"/>
+
+      <EntityType Name="AggregationSourceCollection" BaseType="Resource.v1_0_0.ResourceCollection">
+        <Annotation Term="OData.Description" String="The collection of AggregationSource resource instances."/>
+        <Annotation Term="OData.LongDescription" String="This resource shall represent a resource collection of AggregationSource instances for a Redfish implementation."/>
+        <Annotation Term="Capabilities.InsertRestrictions">
+          <Record>
+            <PropertyValue Property="Insertable" Bool="true"/>
+          </Record>
+        </Annotation>
+        <Annotation Term="Capabilities.UpdateRestrictions">
+          <Record>
+            <PropertyValue Property="Updatable" Bool="false"/>
+          </Record>
+        </Annotation>
+        <Annotation Term="Capabilities.DeleteRestrictions">
+          <Record>
+            <PropertyValue Property="Deletable" Bool="false"/>
+          </Record>
+        </Annotation>
+        <Annotation Term="Redfish.Uris">
+          <Collection>
+            <String>/redfish/v1/AggregationService/AggregationSources</String>
+          </Collection>
+        </Annotation>
+        <NavigationProperty Name="Members" Type="Collection(AggregationSource.AggregationSource)">
+          <Annotation Term="OData.Permissions" EnumMember="OData.Permission/Read"/>
+          <Annotation Term="OData.Description" String="The members of this collection."/>
+          <Annotation Term="OData.LongDescription" String="This property shall contain an array of links to the members of this collection."/>
+          <Annotation Term="OData.AutoExpandReferences"/>
+          <Annotation Term="Redfish.Required"/>
+        </NavigationProperty>
+      </EntityType>
+    </Schema>
+
+  </edmx:DataServices>
+</edmx:Edmx>

--- a/static/redfish/v1/schema/AggregationSource_v1.xml
+++ b/static/redfish/v1/schema/AggregationSource_v1.xml
@@ -1,0 +1,232 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!---->
+<!--################################################################################       -->
+<!--# Redfish Schema:  AggregationSource v1.1.0                                            -->
+<!--#                                                                                      -->
+<!--# For a detailed change log, see the README file contained in the DSP8010 bundle,      -->
+<!--# available at http://www.dmtf.org/standards/redfish                                   -->
+<!--# Copyright 2014-2021 DMTF.                                                            -->
+<!--# For the full DMTF copyright policy, see http://www.dmtf.org/about/policies/copyright -->
+<!--################################################################################       -->
+<!---->
+<edmx:Edmx xmlns:edmx="http://docs.oasis-open.org/odata/ns/edmx" Version="4.0">
+
+  <edmx:Reference Uri="http://docs.oasis-open.org/odata/odata/v4.0/errata03/csd01/complete/vocabularies/Org.OData.Core.V1.xml">
+    <edmx:Include Namespace="Org.OData.Core.V1" Alias="OData"/>
+  </edmx:Reference>
+  <edmx:Reference Uri="http://docs.oasis-open.org/odata/odata/v4.0/errata03/csd01/complete/vocabularies/Org.OData.Capabilities.V1.xml">
+    <edmx:Include Namespace="Org.OData.Capabilities.V1" Alias="Capabilities"/>
+  </edmx:Reference>
+  <edmx:Reference Uri="http://redfish.dmtf.org/schemas/v1/Resource_v1.xml">
+    <edmx:Include Namespace="Resource"/>
+    <edmx:Include Namespace="Resource.v1_0_0"/>
+  </edmx:Reference>
+  <edmx:Reference Uri="http://redfish.dmtf.org/schemas/v1/RedfishExtensions_v1.xml">
+    <edmx:Include Namespace="RedfishExtensions.v1_0_0" Alias="Redfish"/>
+    <edmx:Include Namespace="Validation.v1_0_0" Alias="Validation"/>
+  </edmx:Reference>
+  <edmx:Reference Uri="http://redfish.dmtf.org/schemas/v1/ConnectionMethod_v1.xml">
+    <edmx:Include Namespace="ConnectionMethod"/>
+  </edmx:Reference>
+
+  <edmx:DataServices>
+
+    <Schema xmlns="http://docs.oasis-open.org/odata/ns/edm" Namespace="AggregationSource">
+      <Annotation Term="Redfish.OwningEntity" String="DMTF"/>
+
+      <EntityType Name="AggregationSource" BaseType="Resource.v1_0_0.Resource" Abstract="true">
+        <Annotation Term="OData.Description" String="The AggregationSource schema is used to represent the source of information for a subset of the resources provided by a Redfish service.  It can be thought of as a provider of information.  As such, most such interfaces have requirements to support the gathering of information like address and account used to access the information."/>
+        <Annotation Term="OData.LongDescription" String="This resource shall represent an aggregation source for a Redfish implementation."/>
+        <Annotation Term="Capabilities.InsertRestrictions">
+          <Record>
+            <PropertyValue Property="Insertable" Bool="false"/>
+          </Record>
+        </Annotation>
+        <Annotation Term="Capabilities.UpdateRestrictions">
+          <Record>
+            <PropertyValue Property="Updatable" Bool="true"/>
+          </Record>
+        </Annotation>
+        <Annotation Term="Capabilities.DeleteRestrictions">
+          <Record>
+            <PropertyValue Property="Deletable" Bool="true"/>
+          </Record>
+        </Annotation>
+        <Annotation Term="Redfish.Uris">
+          <Collection>
+            <String>/redfish/v1/AggregationService/AggregationSources/{AggregationSourceId}</String>
+          </Collection>
+        </Annotation>
+      </EntityType>
+    </Schema>
+
+    <Schema xmlns="http://docs.oasis-open.org/odata/ns/edm" Namespace="AggregationSource.v1_0_0">
+      <Annotation Term="Redfish.OwningEntity" String="DMTF"/>
+      <Annotation Term="Redfish.Release" String="2020.2"/>
+
+      <EntityType Name="AggregationSource" BaseType="AggregationSource.AggregationSource">
+        <Property Name="HostName" Type="Edm.String">
+          <Annotation Term="OData.Permissions" EnumMember="OData.Permission/ReadWrite"/>
+          <Annotation Term="OData.Description" String="The URI of the system to be accessed."/>
+          <Annotation Term="OData.LongDescription" String="This property shall contain the URI of the system to be accessed."/>
+          <Annotation Term="OData.IsURL"/>
+          <Annotation Term="Redfish.Required"/>
+          <Annotation Term="Redfish.RequiredOnCreate"/>
+        </Property>
+        <Property Name="UserName" Type="Edm.String">
+          <Annotation Term="OData.Permissions" EnumMember="OData.Permission/ReadWrite"/>
+          <Annotation Term="OData.Description" String="The user name for accessing the aggregation source."/>
+          <Annotation Term="OData.LongDescription" String="This property shall contain the user name for accessing the aggregation source."/>
+        </Property>
+        <Property Name="Password" Type="Edm.String">
+          <Annotation Term="OData.Permissions" EnumMember="OData.Permission/ReadWrite"/>
+          <Annotation Term="OData.Description" String="The password for accessing the aggregation source.  The value is `null` in responses."/>
+          <Annotation Term="OData.LongDescription" String="This property shall contain a password for accessing the aggregation source.  The value shall be `null` in responses."/>
+        </Property>
+        <Property Name="Links" Type="AggregationSource.v1_0_0.Links" Nullable="false">
+          <Annotation Term="OData.Description" String="The links to other resources that are related to this resource."/>
+          <Annotation Term="OData.LongDescription" String="This property shall contain links to resources that are related to but are not contained by, or subordinate to, this resource."/>
+        </Property>
+        <Property Name="Actions" Type="AggregationSource.v1_0_0.Actions" Nullable="false">
+          <Annotation Term="OData.Description" String="The available actions for this resource."/>
+          <Annotation Term="OData.LongDescription" String="This property shall contain the available actions for this resource."/>
+        </Property>
+      </EntityType>
+
+      <ComplexType Name="Links" BaseType="Resource.Links">
+        <Annotation Term="OData.Description" String="The links to other resources that are related to this resource."/>
+        <Annotation Term="OData.LongDescription" String="This Redfish Specification-described type shall contain links to resources that are related to but are not contained by, or subordinate to, this resource."/>
+        <NavigationProperty Name="ConnectionMethod" Type="ConnectionMethod.ConnectionMethod">
+          <Annotation Term="OData.Permissions" EnumMember="OData.Permission/Read"/>
+          <Annotation Term="OData.Description" String="An array of links to the connection methods used to contact this aggregation source."/>
+          <Annotation Term="OData.LongDescription" String="This property shall contain an array of links to resources of type ConnectionMethod that are used to connect to the aggregation source."/>
+          <Annotation Term="OData.AutoExpandReferences"/>
+        </NavigationProperty>
+        <NavigationProperty Name="ResourcesAccessed" Type="Collection(Resource.Resource)">
+          <Annotation Term="OData.Permissions" EnumMember="OData.Permission/Read"/>
+          <Annotation Term="OData.Description" String="An array links to the resources added to the service through this aggregation source.  It is recommended that this be the minimal number of properties needed to find the resources that would be lost when the aggregation source is deleted."/>
+          <Annotation Term="OData.LongDescription" String="This property shall contain an array of links to the resources added to the service through the aggregation source.  It is recommended that this be the minimal number of properties needed to find the resources that would be lost when the aggregation source is deleted.  For example, this could be the pointers to the members of the root level collections or the manager of a BMC."/>
+          <Annotation Term="OData.AutoExpandReferences"/>
+        </NavigationProperty>
+      </ComplexType>
+
+      <ComplexType Name="Actions">
+        <Annotation Term="OData.AdditionalProperties" Bool="false"/>
+        <Annotation Term="OData.Description" String="The available actions for this resource."/>
+        <Annotation Term="OData.LongDescription" String="This type shall contain the available actions for this resource."/>
+        <Property Name="Oem" Type="AggregationSource.v1_0_0.OemActions" Nullable="false">
+          <Annotation Term="OData.Description" String="The available OEM-specific actions for this resource."/>
+          <Annotation Term="OData.LongDescription" String="This property shall contain the available OEM-specific actions for this resource."/>
+        </Property>
+      </ComplexType>
+
+      <ComplexType Name="OemActions">
+        <Annotation Term="OData.AdditionalProperties" Bool="true"/>
+        <Annotation Term="OData.Description" String="The available OEM-specific actions for this resource."/>
+        <Annotation Term="OData.LongDescription" String="This type shall contain the available OEM-specific actions for this resource."/>
+      </ComplexType>
+    </Schema>
+
+    <Schema xmlns="http://docs.oasis-open.org/odata/ns/edm" Namespace="AggregationSource.v1_1_0">
+      <Annotation Term="Redfish.OwningEntity" String="DMTF"/>
+      <Annotation Term="Redfish.Release" String="2020.4"/>
+      <Annotation Term="OData.Description" String="This version was created to add SNMP settings to the AggregationSource."/>
+
+      <EntityType Name="AggregationSource" BaseType="AggregationSource.v1_0_0.AggregationSource">
+        <Property Name="SNMP" Type="AggregationSource.v1_1_0.SNMPSettings">
+          <Annotation Term="OData.Description" String="SNMP settings of the aggregation source."/>
+          <Annotation Term="OData.LongDescription" String="This property shall contain the SNMP settings of the aggregation source."/>
+        </Property>
+      </EntityType>
+
+      <ComplexType Name="SNMPSettings">
+        <Annotation Term="OData.AdditionalProperties" Bool="false"/>
+        <Annotation Term="OData.Description" String="Settings for an SNMP aggregation source."/>
+        <Annotation Term="OData.LongDescription" String="This type shall contain the settings for an SNMP aggregation source."/>
+        <Property Name="AuthenticationKey" Type="Edm.String">
+          <Annotation Term="OData.Permissions" EnumMember="OData.Permission/ReadWrite"/>
+          <Annotation Term="OData.Description" String="The secret authentication key for SNMPv3."/>
+          <Annotation Term="OData.LongDescription" String="This property shall contain the key for SNMPv3 authentication.  The value shall be `null` in responses.  This property accepts a passphrase or a hex-encoded key.  If the string starts with `Passphrase:`, the remainder of the string shall be the passphrase and shall be converted to the key as described in the 'Password to Key Algorithm' section of RFC3414.  If the string starts with `Hex:`, then the remainder of the string shall be the key encoded in hexadecimal notation.  If the string starts with neither, the full string shall be a passphrase and shall be converted to the key as described in the 'Password to Key Algorithm' section of RFC3414.  The passphrase can contain any printable characters except for the double quotation mark."/>
+          <Annotation Term="Validation.Pattern" String="(^[ !#-~]+$)|(^Passphrase:[ ^[ !#-~]+$)|(^Hex:[0-9A-Fa-f]{24,96})|(^\*+$)"/>
+        </Property>
+        <Property Name="AuthenticationProtocol" Type="AggregationSource.v1_1_0.SNMPAuthenticationProtocols">
+          <Annotation Term="OData.Permissions" EnumMember="OData.Permission/ReadWrite"/>
+          <Annotation Term="OData.Description" String="The authentication protocol for SNMPv3."/>
+          <Annotation Term="OData.LongDescription" String="This property shall contain the SNMPv3 authentication protocol."/>
+        </Property>
+        <Property Name="EncryptionKey" Type="Edm.String">
+          <Annotation Term="OData.Permissions" EnumMember="OData.Permission/ReadWrite"/>
+          <Annotation Term="OData.Description" String="The secret authentication key for SNMPv3."/>
+          <Annotation Term="OData.LongDescription" String="This property shall contain the key for SNMPv3 encryption.  The value shall be `null` in responses.  This property accepts a passphrase or a hex-encoded key.  If the string starts with `Passphrase:`, the remainder of the string shall be the passphrase and shall be converted to the key as described in the 'Password to Key Algorithm' section of RFC3414.  If the string starts with `Hex:`, then the remainder of the string shall be the key encoded in hexadecimal notation.  If the string starts with neither, the full string shall be a passphrase and shall be converted to the key as described in the 'Password to Key Algorithm' section of RFC3414.  The passphrase can contain any printable characters except for the double quotation mark."/>
+          <Annotation Term="Validation.Pattern" String="(^[A-Za-z0-9]+$)|(^\*+$)"/>
+        </Property>
+        <Property Name="EncryptionProtocol" Type="AggregationSource.v1_1_0.SNMPEncryptionProtocols">
+          <Annotation Term="OData.Permissions" EnumMember="OData.Permission/ReadWrite"/>
+          <Annotation Term="OData.Description" String="The encryption protocol for SNMPv3."/>
+          <Annotation Term="OData.LongDescription" String="This property shall contain the SNMPv3 encryption protocol."/>
+        </Property>
+        <Property Name="AuthenticationKeySet" Type="Edm.Boolean" Nullable="false">
+          <Annotation Term="OData.Permissions" EnumMember="OData.Permission/Read"/>
+          <Annotation Term="OData.Description" String="Indicates if the AuthenticationKey property is set."/>
+          <Annotation Term="OData.LongDescription" String="This property shall contain `true` if a valid value was provided for the AuthenticationKey property.  Otherwise, the property shall contain `false`."/>
+        </Property>
+        <Property Name="EncryptionKeySet" Type="Edm.Boolean" Nullable="false">
+          <Annotation Term="OData.Permissions" EnumMember="OData.Permission/Read"/>
+          <Annotation Term="OData.Description" String="Indicates if the EncryptionKey property is set."/>
+          <Annotation Term="OData.LongDescription" String="This property shall contain `true` if a valid value was provided for the EncryptionKey property.  Otherwise, the property shall contain `false`."/>
+        </Property>
+      </ComplexType>
+
+      <EnumType Name="SNMPAuthenticationProtocols">
+        <Member Name="None">
+          <Annotation Term="OData.Description" String="No authentication."/>
+          <Annotation Term="OData.LongDescription" String="This value shall indicate authentication is not required."/>
+        </Member>
+        <Member Name="CommunityString">
+          <Annotation Term="OData.Description" String="Trap community string authentication."/>
+          <Annotation Term="OData.LongDescription" String="This value shall indicate authentication using SNMP community strings and the value of TrapCommunity."/>
+        </Member>
+        <Member Name="HMAC_MD5">
+          <Annotation Term="OData.Description" String="HMAC-MD5-96 authentication."/>
+          <Annotation Term="OData.LongDescription" String="This value shall indicate authentication conforms to the RFC3414-defined HMAC-MD5-96 authentication protocol."/>
+        </Member>
+        <Member Name="HMAC_SHA96">
+          <Annotation Term="OData.Description" String="HMAC-SHA-96 authentication."/>
+          <Annotation Term="OData.LongDescription" String="This value shall indicate authentication conforms to the RFC3414-defined HMAC-SHA-96 authentication protocol."/>
+        </Member>
+        <Member Name="HMAC128_SHA224">
+          <Annotation Term="OData.Description" String="HMAC-128-SHA-224 authentication."/>
+          <Annotation Term="OData.LongDescription" String="This value shall indicate authentication for SNMPv3 access conforms to the RFC7860-defined usmHMAC128SHA224AuthProtocol."/>
+        </Member>
+        <Member Name="HMAC192_SHA256">
+          <Annotation Term="OData.Description" String="HMAC-192-SHA-256 authentication."/>
+          <Annotation Term="OData.LongDescription" String="This value shall indicate authentication for SNMPv3 access conforms to the RFC7860-defined usmHMAC192SHA256AuthProtocol."/>
+        </Member>
+        <Member Name="HMAC256_SHA384">
+          <Annotation Term="OData.Description" String="HMAC-256-SHA-384 authentication."/>
+          <Annotation Term="OData.LongDescription" String="This value shall indicate authentication for SNMPv3 access conforms to the RFC7860-defined usmHMAC256SHA384AuthProtocol."/>
+        </Member>
+        <Member Name="HMAC384_SHA512">
+          <Annotation Term="OData.Description" String="HMAC-384-SHA-512 authentication."/>
+          <Annotation Term="OData.LongDescription" String="This value shall indicate authentication for SNMPv3 access conforms to the RFC7860-defined usmHMAC384SHA512AuthProtocol."/>
+        </Member>
+      </EnumType>
+
+      <EnumType Name="SNMPEncryptionProtocols">
+        <Member Name="None">
+          <Annotation Term="OData.Description" String="No encryption."/>
+          <Annotation Term="OData.LongDescription" String="This value shall indicate there is no encryption."/>
+        </Member>
+        <Member Name="CBC_DES">
+          <Annotation Term="OData.Description" String="CBC-DES encryption."/>
+          <Annotation Term="OData.LongDescription" String="This value shall indicate encryption conforms to the RFC3414-defined CBC-DES encryption protocol."/>
+        </Member>
+        <Member Name="CFB128_AES128">
+          <Annotation Term="OData.Description" String="CFB128-AES-128 encryption."/>
+          <Annotation Term="OData.LongDescription" String="This value shall indicate encryption conforms to the RFC3414-defined CFB128-AES-128 encryption protocol."/>
+        </Member>
+      </EnumType>
+    </Schema>
+
+  </edmx:DataServices>
+</edmx:Edmx>

--- a/static/redfish/v1/schema/AllowDenyCollection_v1.xml
+++ b/static/redfish/v1/schema/AllowDenyCollection_v1.xml
@@ -1,0 +1,74 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!---->
+<!--################################################################################       -->
+<!--# Redfish Schema:  AllowDenyCollection                                                 -->
+<!--#                                                                                      -->
+<!--# For a detailed change log, see the README file contained in the DSP8010 bundle,      -->
+<!--# available at http://www.dmtf.org/standards/redfish                                   -->
+<!--# Copyright 2014-2021 DMTF.                                                            -->
+<!--# For the full DMTF copyright policy, see http://www.dmtf.org/about/policies/copyright -->
+<!--################################################################################       -->
+<!---->
+<edmx:Edmx xmlns:edmx="http://docs.oasis-open.org/odata/ns/edmx" Version="4.0">
+
+  <edmx:Reference Uri="http://docs.oasis-open.org/odata/odata/v4.0/errata03/csd01/complete/vocabularies/Org.OData.Core.V1.xml">
+    <edmx:Include Namespace="Org.OData.Core.V1" Alias="OData"/>
+  </edmx:Reference>
+  <edmx:Reference Uri="http://docs.oasis-open.org/odata/odata/v4.0/errata03/csd01/complete/vocabularies/Org.OData.Capabilities.V1.xml">
+    <edmx:Include Namespace="Org.OData.Capabilities.V1" Alias="Capabilities"/>
+  </edmx:Reference>
+  <edmx:Reference Uri="http://redfish.dmtf.org/schemas/v1/Resource_v1.xml">
+    <edmx:Include Namespace="Resource.v1_0_0"/>
+  </edmx:Reference>
+  <edmx:Reference Uri="http://redfish.dmtf.org/schemas/v1/RedfishExtensions_v1.xml">
+    <edmx:Include Namespace="RedfishExtensions.v1_0_0" Alias="Redfish"/>
+  </edmx:Reference>
+  <edmx:Reference Uri="http://redfish.dmtf.org/schemas/v1/AllowDeny_v1.xml">
+    <edmx:Include Namespace="AllowDeny"/>
+  </edmx:Reference>
+
+  <edmx:DataServices>
+
+    <Schema xmlns="http://docs.oasis-open.org/odata/ns/edm" Namespace="AllowDenyCollection">
+      <Annotation Term="Redfish.OwningEntity" String="DMTF"/>
+
+      <EntityType Name="AllowDenyCollection" BaseType="Resource.v1_0_0.ResourceCollection">
+        <Annotation Term="OData.Description" String="The collection of AllowDeny resource instances."/>
+        <Annotation Term="OData.LongDescription" String="This resource shall represent a resource collection of AllowDeny instances for a Redfish implementation."/>
+        <Annotation Term="Capabilities.InsertRestrictions">
+          <Record>
+            <PropertyValue Property="Insertable" Bool="true"/>
+          </Record>
+        </Annotation>
+        <Annotation Term="Capabilities.UpdateRestrictions">
+          <Record>
+            <PropertyValue Property="Updatable" Bool="false"/>
+          </Record>
+        </Annotation>
+        <Annotation Term="Capabilities.DeleteRestrictions">
+          <Record>
+            <PropertyValue Property="Deletable" Bool="false"/>
+          </Record>
+        </Annotation>
+        <Annotation Term="Redfish.Uris">
+          <Collection>
+            <String>/redfish/v1/Chassis/{ChassisId}/NetworkAdapters/{NetworkAdapterId}/NetworkDeviceFunctions/{NetworkDeviceFunctionId}/AllowDeny</String>
+            <String>/redfish/v1/Systems/{ComputerSystemId}/NetworkInterfaces/{NetworkInterfaceId}/NetworkDeviceFunctions{NetworkDeviceFunctionId}/AllowDeny</String>
+            <String>/redfish/v1/CompositionService/ResourceBlocks/{ResourceBlockId}/NetworkInterfaces/{NetworkInterfaceId}/NetworkDeviceFunctions{NetworkDeviceFunctionId}/AllowDeny</String>
+            <String>/redfish/v1/CompositionService/ResourceBlocks/{ResourceBlockId}/Systems/{ComputerSystemId}/NetworkInterfaces/{NetworkInterfaceId}/NetworkDeviceFunctions{NetworkDeviceFunctionId}/AllowDeny</String>
+            <String>/redfish/v1/ResourceBlocks/{ResourceBlockId}/NetworkInterfaces/{NetworkInterfaceId}/NetworkDeviceFunctions{NetworkDeviceFunctionId}/AllowDeny</String>
+            <String>/redfish/v1/ResourceBlocks/{ResourceBlockId}/Systems/{ComputerSystemId}/NetworkInterfaces/{NetworkInterfaceId}/NetworkDeviceFunctions{NetworkDeviceFunctionId}/AllowDeny</String>
+          </Collection>
+        </Annotation>
+        <NavigationProperty Name="Members" Type="Collection(AllowDeny.AllowDeny)">
+          <Annotation Term="OData.Permissions" EnumMember="OData.Permission/Read"/>
+          <Annotation Term="OData.Description" String="The members of this collection."/>
+          <Annotation Term="OData.LongDescription" String="This property shall contain an array of links to the members of this collection."/>
+          <Annotation Term="OData.AutoExpandReferences"/>
+          <Annotation Term="Redfish.Required"/>
+        </NavigationProperty>
+      </EntityType>
+    </Schema>
+
+  </edmx:DataServices>
+</edmx:Edmx>

--- a/static/redfish/v1/schema/AllowDeny_v1.xml
+++ b/static/redfish/v1/schema/AllowDeny_v1.xml
@@ -1,0 +1,180 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!---->
+<!--################################################################################       -->
+<!--# Redfish Schema:  AllowDeny v1.0.0                                                  -->
+<!--#                                                                                      -->
+<!--# For a detailed change log, see the README file contained in the DSP8010 bundle,      -->
+<!--# available at http://www.dmtf.org/standards/redfish                                   -->
+<!--# Copyright 2014-2021 DMTF.                                                            -->
+<!--# For the full DMTF copyright policy, see http://www.dmtf.org/about/policies/copyright -->
+<!--################################################################################       -->
+<!---->
+<edmx:Edmx xmlns:edmx="http://docs.oasis-open.org/odata/ns/edmx" Version="4.0">
+
+  <edmx:Reference Uri="http://docs.oasis-open.org/odata/odata/v4.0/errata03/csd01/complete/vocabularies/Org.OData.Core.V1.xml">
+    <edmx:Include Namespace="Org.OData.Core.V1" Alias="OData"/>
+  </edmx:Reference>
+  <edmx:Reference Uri="http://docs.oasis-open.org/odata/odata/v4.0/errata03/csd01/complete/vocabularies/Org.OData.Capabilities.V1.xml">
+    <edmx:Include Namespace="Org.OData.Capabilities.V1" Alias="Capabilities"/>
+  </edmx:Reference>
+  <edmx:Reference Uri="http://docs.oasis-open.org/odata/odata/v4.0/errata03/csd01/complete/vocabularies/Org.OData.Measures.V1.xml">
+    <edmx:Include Namespace="Org.OData.Measures.V1" Alias="Measures"/>
+  </edmx:Reference>
+  <edmx:Reference Uri="http://redfish.dmtf.org/schemas/v1/Resource_v1.xml">
+    <edmx:Include Namespace="Resource"/>
+    <edmx:Include Namespace="Resource.v1_0_0"/>
+  </edmx:Reference>
+  <edmx:Reference Uri="http://redfish.dmtf.org/schemas/v1/RedfishExtensions_v1.xml">
+    <edmx:Include Namespace="RedfishExtensions.v1_0_0" Alias="Redfish"/>
+    <edmx:Include Namespace="Validation.v1_0_0" Alias="Validation"/>
+  </edmx:Reference>
+
+  <edmx:DataServices>
+
+    <Schema xmlns="http://docs.oasis-open.org/odata/ns/edm" Namespace="AllowDeny">
+      <Annotation Term="Redfish.OwningEntity" String="DMTF"/>
+
+      <EntityType Name="AllowDeny" BaseType="Resource.v1_0_0.Resource" Abstract="true">
+        <Annotation Term="OData.Description" String="The AllowDeny schema represents a set of allow or deny configurations."/>
+        <Annotation Term="OData.LongDescription" String="This resource shall represent an AllowDeny resource in a Redfish implementation."/>
+        <Annotation Term="OData.AdditionalProperties" Bool="false"/>
+        <Annotation Term="Capabilities.InsertRestrictions">
+          <Record>
+            <PropertyValue Property="Insertable" Bool="false"/>
+          </Record>
+        </Annotation>
+        <Annotation Term="Capabilities.UpdateRestrictions">
+          <Record>
+            <PropertyValue Property="Updatable" Bool="true"/>
+          </Record>
+        </Annotation>
+        <Annotation Term="Capabilities.DeleteRestrictions">
+          <Record>
+            <PropertyValue Property="Deletable" Bool="true"/>
+          </Record>
+        </Annotation>
+        <Annotation Term="Redfish.Uris">
+          <Collection>
+            <String>/redfish/v1/Chassis/{ChassisId}/NetworkAdapters/{NetworkAdapterId}/NetworkDeviceFunctions/{NetworkDeviceFunctionId}/AllowDeny/{AllowDenyId}</String>
+            <String>/redfish/v1/Systems/{ComputerSystemId}/NetworkInterfaces/{NetworkInterfaceId}/NetworkDeviceFunctions{NetworkDeviceFunctionId}/AllowDeny/{AllowDenyId}</String>
+            <String>/redfish/v1/CompositionService/ResourceBlocks/{ResourceBlockId}/NetworkInterfaces/{NetworkInterfaceId}/NetworkDeviceFunctions{NetworkDeviceFunctionId}/AllowDeny/{AllowDenyId}</String>
+            <String>/redfish/v1/CompositionService/ResourceBlocks/{ResourceBlockId}/Systems/{ComputerSystemId}/NetworkInterfaces/{NetworkInterfaceId}/NetworkDeviceFunctions{NetworkDeviceFunctionId}/AllowDeny/{AllowDenyId}</String>
+            <String>/redfish/v1/ResourceBlocks/{ResourceBlockId}/NetworkInterfaces/{NetworkInterfaceId}/NetworkDeviceFunctions{NetworkDeviceFunctionId}/AllowDeny/{AllowDenyId}</String>
+            <String>/redfish/v1/ResourceBlocks/{ResourceBlockId}/Systems/{ComputerSystemId}/NetworkInterfaces/{NetworkInterfaceId}/NetworkDeviceFunctions{NetworkDeviceFunctionId}/AllowDeny/{AllowDenyId}</String>
+          </Collection>
+        </Annotation>
+      </EntityType>
+    </Schema>
+
+    <Schema xmlns="http://docs.oasis-open.org/odata/ns/edm" Namespace="AllowDeny.v1_0_0">
+      <Annotation Term="Redfish.OwningEntity" String="DMTF"/>
+      <Annotation Term="Redfish.Release" String="2021.2"/>
+
+      <EntityType Name="AllowDeny" BaseType="AllowDeny.AllowDeny">
+        <Property Name="Direction" Type="AllowDeny.v1_0_0.DataDirection">
+          <Annotation Term="OData.Permissions" EnumMember="OData.Permission/ReadWrite"/>
+          <Annotation Term="OData.Description" String="Indicates the direction of the data to which this permission applies."/>
+          <Annotation Term="OData.LongDescription" String="This value shall indicate the direction of the data to which this permission applies for this network device function."/>
+        </Property>
+        <Property Name="AllowType" Type="AllowDeny.v1_0_0.AllowType">
+          <Annotation Term="OData.Permissions" EnumMember="OData.Permission/ReadWrite"/>
+          <Annotation Term="OData.Description" String="Indicates the type of permission."/>
+          <Annotation Term="OData.LongDescription" String="This property shall indicate the type of permission."/>
+        </Property>
+        <Property Name="StatefulSession" Type="Edm.Boolean">
+          <Annotation Term="OData.Permissions" EnumMember="OData.Permission/ReadWrite"/>
+          <Annotation Term="OData.Description" String="Indicates if this is a permission that only applies to stateful connection."/>
+          <Annotation Term="OData.LongDescription" String="This property shall indicate if this permission only applies to stateful connection, which are those using SYN, ACK, and FIN."/>
+        </Property>
+        <Property Name="IPAddressType" Type="AllowDeny.v1_0_0.IPAddressType">
+          <Annotation Term="OData.Permissions" EnumMember="OData.Permission/ReadWrite"/>
+          <Annotation Term="OData.Description" String="The type of IP address populated in the IPAddressLower and IPAddressUpper properties."/>
+          <Annotation Term="OData.LongDescription" String="This property shall contain the type of IP address populated in the IPAddressLower and IPAddressUpper properties.  Services shall not permit mixing IPv6 and IPv4 addresses on the same resource."/>
+        </Property>
+        <Property Name="IPAddressLower" Type="Edm.String">
+          <Annotation Term="OData.Permissions" EnumMember="OData.Permission/ReadWrite"/>
+          <Annotation Term="OData.Description" String="The lower IP address to which this permission applies."/>
+          <Annotation Term="OData.LongDescription" String="This property shall contain the lower IP address to which this permission applies."/>
+        </Property>
+        <Property Name="IPAddressUpper" Type="Edm.String">
+          <Annotation Term="OData.Permissions" EnumMember="OData.Permission/ReadWrite"/>
+          <Annotation Term="OData.Description" String="The upper IP address to which this permission applies."/>
+          <Annotation Term="OData.LongDescription" String="This property shall contain the upper IP address to which this permission applies."/>
+        </Property>
+        <Property Name="IANAProtocolNumber" Type="Edm.Int64">
+          <Annotation Term="OData.Permissions" EnumMember="OData.Permission/ReadWrite"/>
+          <Annotation Term="OData.Description" String="The IANA protocol number to which this permission applies.  For TCP, this is `6`.  For UDP, this is `17`."/>
+          <Annotation Term="OData.LongDescription" String="This property shall contain the IANA protocol number to which this permission applies."/>
+        </Property>
+        <Property Name="SourcePortLower" Type="Edm.Int64">
+          <Annotation Term="OData.Permissions" EnumMember="OData.Permission/ReadWrite"/>
+          <Annotation Term="OData.Description" String="The TCP, UDP, or other source port to which this rule begins application, inclusive."/>
+          <Annotation Term="OData.LongDescription" String="This property shall contain the TCP, UDP, or other source port to which this rule begins application, inclusive."/>
+        </Property>
+        <Property Name="SourcePortUpper" Type="Edm.Int64">
+          <Annotation Term="OData.Permissions" EnumMember="OData.Permission/ReadWrite"/>
+          <Annotation Term="OData.Description" String="The TCP, UDP or other source port to which this rule ends application, inclusive."/>
+          <Annotation Term="OData.LongDescription" String="This property shall contain the TCP, UDP, or other source port to which this rule ends application, inclusive."/>
+        </Property>
+        <Property Name="DestinationPortLower" Type="Edm.Int64">
+          <Annotation Term="OData.Permissions" EnumMember="OData.Permission/ReadWrite"/>
+          <Annotation Term="OData.Description" String="The TCP, UDP, or other destination port to which this rule begins to application, inclusive."/>
+          <Annotation Term="OData.LongDescription" String="This property shall contain the TCP, UDP, or other destination port to which this rule begins application, inclusive."/>
+        </Property>
+        <Property Name="DestinationPortUpper" Type="Edm.Int64">
+          <Annotation Term="OData.Permissions" EnumMember="OData.Permission/ReadWrite"/>
+          <Annotation Term="OData.Description" String="The TCP, UDP, or other destination port to which this rule ends application, inclusive."/>
+          <Annotation Term="OData.LongDescription" String="This property shall contain the TCP, UDP, or other destination port to which this rule ends application, inclusive."/>
+        </Property>
+        <Property Name="Actions" Type="AllowDeny.v1_0_0.Actions" Nullable="false">
+          <Annotation Term="OData.Description" String="The available actions for this resource."/>
+          <Annotation Term="OData.LongDescription" String="This property shall contain the available actions for this resource."/>
+        </Property>
+      </EntityType>
+
+      <ComplexType Name="Actions">
+        <Annotation Term="OData.AdditionalProperties" Bool="false"/>
+        <Annotation Term="OData.Description" String="The available actions for this resource."/>
+        <Annotation Term="OData.LongDescription" String="This type shall contain the available actions for this resource."/>
+        <Property Name="Oem" Type="AllowDeny.v1_0_0.OemActions" Nullable="false">
+          <Annotation Term="OData.Description" String="The available OEM-specific actions for this resource."/>
+          <Annotation Term="OData.LongDescription" String="This property shall contain the available OEM-specific actions for this resource."/>
+        </Property>
+      </ComplexType>
+
+      <ComplexType Name="OemActions">
+        <Annotation Term="OData.AdditionalProperties" Bool="true"/>
+        <Annotation Term="OData.Description" String="The available OEM-specific actions for this resource."/>
+        <Annotation Term="OData.LongDescription" String="This type shall contain the available OEM-specific actions for this resource."/>
+      </ComplexType>
+
+      <EnumType Name="IPAddressType">
+        <Member Name="IPv4">
+          <Annotation Term="OData.Description" String="IPv4 addressing is used for all IP-fields in this object."/>
+        </Member>
+        <Member Name="IPv6">
+          <Annotation Term="OData.Description" String="IPv6 addressing is used for all IP-fields in this object."/>
+        </Member>
+      </EnumType>
+
+      <EnumType Name="AllowType">
+        <Member Name="Allow">
+          <Annotation Term="OData.Description" String="Indicates that traffic that matches the criteria in this resource shall be permitted."/>
+        </Member>
+        <Member Name="Deny">
+          <Annotation Term="OData.Description" String="Indicates that traffic that matches the criteria in this resource shall not be permitted."/>
+        </Member>
+      </EnumType>
+
+      <EnumType Name="DataDirection">
+        <Member Name="Ingress">
+          <Annotation Term="OData.Description" String="Indicates that this limit is enforced on packets and bytes received by the network device function."/>
+        </Member>
+        <Member Name="Egress">
+          <Annotation Term="OData.Description" String="Indicates that this limit is enforced on packets and bytes transmitted by the network device function."/>
+        </Member>
+      </EnumType>
+    </Schema>
+
+  </edmx:DataServices>
+</edmx:Edmx>

--- a/static/redfish/v1/schema/BatteryCollection_v1.xml
+++ b/static/redfish/v1/schema/BatteryCollection_v1.xml
@@ -1,0 +1,69 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!---->
+<!--################################################################################       -->
+<!--# Redfish Schema:  BatteryCollection                                                   -->
+<!--#                                                                                      -->
+<!--# For a detailed change log, see the README file contained in the DSP8010 bundle,      -->
+<!--# available at http://www.dmtf.org/standards/redfish                                   -->
+<!--# Copyright 2014-2021 DMTF.                                                            -->
+<!--# For the full DMTF copyright policy, see http://www.dmtf.org/about/policies/copyright -->
+<!--################################################################################       -->
+<!---->
+<edmx:Edmx xmlns:edmx="http://docs.oasis-open.org/odata/ns/edmx" Version="4.0">
+
+  <edmx:Reference Uri="http://docs.oasis-open.org/odata/odata/v4.0/errata03/csd01/complete/vocabularies/Org.OData.Core.V1.xml">
+    <edmx:Include Namespace="Org.OData.Core.V1" Alias="OData"/>
+  </edmx:Reference>
+  <edmx:Reference Uri="http://docs.oasis-open.org/odata/odata/v4.0/errata03/csd01/complete/vocabularies/Org.OData.Capabilities.V1.xml">
+    <edmx:Include Namespace="Org.OData.Capabilities.V1" Alias="Capabilities"/>
+  </edmx:Reference>
+  <edmx:Reference Uri="http://redfish.dmtf.org/schemas/v1/Resource_v1.xml">
+    <edmx:Include Namespace="Resource.v1_0_0"/>
+  </edmx:Reference>
+  <edmx:Reference Uri="http://redfish.dmtf.org/schemas/v1/RedfishExtensions_v1.xml">
+    <edmx:Include Namespace="RedfishExtensions.v1_0_0" Alias="Redfish"/>
+  </edmx:Reference>
+  <edmx:Reference Uri="http://redfish.dmtf.org/schemas/v1/Battery_v1.xml">
+    <edmx:Include Namespace="Battery"/>
+  </edmx:Reference>
+
+  <edmx:DataServices>
+
+    <Schema xmlns="http://docs.oasis-open.org/odata/ns/edm" Namespace="BatteryCollection">
+      <Annotation Term="Redfish.OwningEntity" String="DMTF"/>
+
+      <EntityType Name="BatteryCollection" BaseType="Resource.v1_0_0.ResourceCollection">
+        <Annotation Term="OData.Description" String="The collection of Battery resource instances."/>
+        <Annotation Term="OData.LongDescription" String="This resource shall represent a resource collection of Battery instances for a Redfish implementation."/>
+        <Annotation Term="Capabilities.InsertRestrictions">
+          <Record>
+            <PropertyValue Property="Insertable" Bool="false"/>
+          </Record>
+        </Annotation>
+        <Annotation Term="Capabilities.UpdateRestrictions">
+          <Record>
+            <PropertyValue Property="Updatable" Bool="false"/>
+          </Record>
+        </Annotation>
+        <Annotation Term="Capabilities.DeleteRestrictions">
+          <Record>
+            <PropertyValue Property="Deletable" Bool="false"/>
+          </Record>
+        </Annotation>
+        <Annotation Term="Redfish.Uris">
+          <Collection>
+            <String>/redfish/v1/Chassis/{ChassisId}/PowerSubsystem/Batteries</String>
+          </Collection>
+        </Annotation>
+        <NavigationProperty Name="Members" Type="Collection(Battery.Battery)">
+          <Annotation Term="OData.Permissions" EnumMember="OData.Permission/Read"/>
+          <Annotation Term="OData.Description" String="The members of this collection."/>
+          <Annotation Term="OData.LongDescription" String="This property shall contain an array of links to the members of this collection."/>
+          <Annotation Term="OData.AutoExpandReferences"/>
+          <Annotation Term="Redfish.Required"/>
+        </NavigationProperty>
+      </EntityType>
+    </Schema>
+
+  </edmx:DataServices>
+</edmx:Edmx>

--- a/static/redfish/v1/schema/BatteryMetrics_v1.xml
+++ b/static/redfish/v1/schema/BatteryMetrics_v1.xml
@@ -1,0 +1,148 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!---->
+<!--################################################################################       -->
+<!--# Redfish Schema:  BatteryMetrics v1.0.0                                               -->
+<!--#                                                                                      -->
+<!--# For a detailed change log, see the README file contained in the DSP8010 bundle,      -->
+<!--# available at http://www.dmtf.org/standards/redfish                                   -->
+<!--# Copyright 2014-2021 DMTF.                                                            -->
+<!--# For the full DMTF copyright policy, see http://www.dmtf.org/about/policies/copyright -->
+<!--################################################################################       -->
+<!---->
+<edmx:Edmx xmlns:edmx="http://docs.oasis-open.org/odata/ns/edmx" Version="4.0">
+
+  <edmx:Reference Uri="http://docs.oasis-open.org/odata/odata/v4.0/errata03/csd01/complete/vocabularies/Org.OData.Core.V1.xml">
+    <edmx:Include Namespace="Org.OData.Core.V1" Alias="OData"/>
+  </edmx:Reference>
+  <edmx:Reference Uri="http://docs.oasis-open.org/odata/odata/v4.0/errata03/csd01/complete/vocabularies/Org.OData.Capabilities.V1.xml">
+    <edmx:Include Namespace="Org.OData.Capabilities.V1" Alias="Capabilities"/>
+  </edmx:Reference>
+  <edmx:Reference Uri="http://redfish.dmtf.org/schemas/v1/RedfishExtensions_v1.xml">
+    <edmx:Include Namespace="RedfishExtensions.v1_0_0" Alias="Redfish"/>
+    <edmx:Include Namespace="Validation.v1_0_0" Alias="Validation"/>
+  </edmx:Reference>
+  <edmx:Reference Uri="http://redfish.dmtf.org/schemas/v1/Resource_v1.xml">
+    <edmx:Include Namespace="Resource"/>
+    <edmx:Include Namespace="Resource.v1_0_0"/>
+  </edmx:Reference>
+  <edmx:Reference Uri="http://redfish.dmtf.org/schemas/v1/Sensor_v1.xml">
+    <edmx:Include Namespace="Sensor"/>
+  </edmx:Reference>
+
+  <edmx:DataServices>
+
+    <Schema xmlns="http://docs.oasis-open.org/odata/ns/edm" Namespace="BatteryMetrics">
+      <Annotation Term="Redfish.OwningEntity" String="DMTF"/>
+
+      <EntityType Name="BatteryMetrics" BaseType="Resource.v1_0_0.Resource" Abstract="true">
+        <Annotation Term="OData.Description" String="The BatteryMetrics schema contains definitions for the metrics of a battery unit."/>
+        <Annotation Term="OData.LongDescription" String="This resource shall be used to represent the metrics of a battery unit for a Redfish implementation."/>
+        <Annotation Term="OData.AdditionalProperties" Bool="false"/>
+        <Annotation Term="Capabilities.InsertRestrictions">
+          <Record>
+            <PropertyValue Property="Insertable" Bool="false"/>
+          </Record>
+        </Annotation>
+        <Annotation Term="Capabilities.UpdateRestrictions">
+          <Record>
+            <PropertyValue Property="Updatable" Bool="false"/>
+          </Record>
+        </Annotation>
+        <Annotation Term="Capabilities.DeleteRestrictions">
+          <Record>
+            <PropertyValue Property="Deletable" Bool="false"/>
+          </Record>
+        </Annotation>
+        <Annotation Term="Redfish.Uris">
+          <Collection>
+            <String>/redfish/v1/Chassis/{ChassisId}/PowerSubsystem/Batteries/{BatteryId}/Metrics</String>
+          </Collection>
+        </Annotation>
+      </EntityType>
+    </Schema>
+
+    <Schema xmlns="http://docs.oasis-open.org/odata/ns/edm" Namespace="BatteryMetrics.v1_0_0">
+      <Annotation Term="Redfish.OwningEntity" String="DMTF"/>
+      <Annotation Term="Redfish.Release" String="2021.2"/>
+
+      <EntityType Name="BatteryMetrics" BaseType="BatteryMetrics.BatteryMetrics">
+        <Property Name="Status" Type="Resource.Status" Nullable="false">
+          <Annotation Term="OData.Description" String="The status and health of the resource and its subordinate or dependent resources."/>
+          <Annotation Term="OData.LongDescription" String="This property shall contain any status or health properties of the resource."/>
+        </Property>
+        <Property Name="DischargeCycles" Type="Edm.Decimal">
+          <Annotation Term="OData.Permissions" EnumMember="OData.Permission/Read"/>
+          <Annotation Term="OData.Description" String="The number of discharges this battery sustained."/>
+          <Annotation Term="OData.LongDescription" String="This property shall contain the number of discharges this battery sustained."/>
+          <Annotation Term="Validation.Minimum" Int="0"/>
+        </Property>
+        <NavigationProperty Name="InputVoltage" Type="Sensor.Sensor" Nullable="false">
+          <Annotation Term="OData.Description" String="The input voltage reading for this battery."/>
+          <Annotation Term="OData.LongDescription" String="This property shall contain the input voltage sensor for this battery."/>
+          <Annotation Term="Redfish.ExcerptCopy" String="Voltage"/>
+        </NavigationProperty>
+        <NavigationProperty Name="InputCurrentAmps" Type="Sensor.Sensor" Nullable="false">
+          <Annotation Term="OData.Description" String="The input current reading for this battery."/>
+          <Annotation Term="OData.LongDescription" String="This property shall contain the input current sensor for this battery."/>
+          <Annotation Term="Redfish.ExcerptCopy" String="Current"/>
+        </NavigationProperty>
+        <NavigationProperty Name="OutputVoltages" Type="Collection(Sensor.Sensor)">
+          <Annotation Term="OData.Description" String="The output voltage readings for this battery."/>
+          <Annotation Term="OData.LongDescription" String="This property shall contain the output voltage sensors for this battery.  The sensors shall appear in the same array order as the OutputCurrentAmps property."/>
+          <Annotation Term="Redfish.ExcerptCopy" String="Voltage"/>
+        </NavigationProperty>
+        <NavigationProperty Name="OutputCurrentAmps" Type="Collection(Sensor.Sensor)">
+          <Annotation Term="OData.Description" String="The output current readings for this battery."/>
+          <Annotation Term="OData.LongDescription" String="This property shall contain the output current sensors for this battery.  The sensors shall appear in the same array order as the OutputVoltages property."/>
+          <Annotation Term="Redfish.ExcerptCopy" String="Current"/>
+        </NavigationProperty>
+        <NavigationProperty Name="StoredEnergyWattHours" Type="Sensor.Sensor" Nullable="false">
+          <Annotation Term="OData.Description" String="The energy stored in this battery in watt-hours."/>
+          <Annotation Term="OData.LongDescription" String="This property shall contain the energy sensor for this battery in watt-hours."/>
+          <Annotation Term="Redfish.ExcerptCopy"/>
+        </NavigationProperty>
+        <NavigationProperty Name="StoredChargeAmpHours" Type="Sensor.Sensor" Nullable="false">
+          <Annotation Term="OData.Description" String="The charge stored in this battery in amp-hours."/>
+          <Annotation Term="OData.LongDescription" String="This property shall contain the charge sensor for this battery in amp-hours."/>
+          <Annotation Term="Redfish.ExcerptCopy"/>
+        </NavigationProperty>
+        <NavigationProperty Name="TemperatureCelsius" Type="Sensor.Sensor" Nullable="false">
+          <Annotation Term="OData.Description" String="The temperature reading for this battery."/>
+          <Annotation Term="OData.LongDescription" String="This property shall contain the temperature sensor for this battery."/>
+          <Annotation Term="Redfish.ExcerptCopy"/>
+        </NavigationProperty>
+        <NavigationProperty Name="ChargePercent" Type="Sensor.Sensor" Nullable="false">
+          <Annotation Term="OData.Description" String="The amount of charge available in this battery as a percentage."/>
+          <Annotation Term="OData.LongDescription" String="This property shall contain the amount of charge available in this battery as a percentage."/>
+          <Annotation Term="Redfish.ExcerptCopy"/>
+        </NavigationProperty>
+        <NavigationProperty Name="CellVoltages" Type="Collection(Sensor.Sensor)">
+          <Annotation Term="OData.Description" String="The cell voltage readings for this battery."/>
+          <Annotation Term="OData.LongDescription" String="This property shall contain the cell voltage sensors for this battery."/>
+          <Annotation Term="Redfish.ExcerptCopy" String="Voltage"/>
+        </NavigationProperty>
+        <Property Name="Actions" Type="BatteryMetrics.v1_0_0.Actions" Nullable="false">
+          <Annotation Term="OData.Description" String="The available actions for this resource."/>
+          <Annotation Term="OData.LongDescription" String="This property shall contain the available actions for this resource."/>
+        </Property>
+      </EntityType>
+
+      <ComplexType Name="Actions">
+        <Annotation Term="OData.AdditionalProperties" Bool="false"/>
+        <Annotation Term="OData.Description" String="The available actions for this resource."/>
+        <Annotation Term="OData.LongDescription" String="This type shall contain the available actions for this resource."/>
+        <Property Name="Oem" Type="BatteryMetrics.v1_0_0.OemActions" Nullable="false">
+          <Annotation Term="OData.Description" String="The available OEM-specific actions for this resource."/>
+          <Annotation Term="OData.LongDescription" String="This property shall contain the available OEM-specific actions for this resource."/>
+        </Property>
+      </ComplexType>
+
+      <ComplexType Name="OemActions">
+        <Annotation Term="OData.AdditionalProperties" Bool="true"/>
+        <Annotation Term="OData.Description" String="The available OEM-specific actions for this resource."/>
+        <Annotation Term="OData.LongDescription" String="This type shall contain the available OEM-specific actions for this resource."/>
+      </ComplexType>
+    </Schema>
+
+  </edmx:DataServices>
+</edmx:Edmx>

--- a/static/redfish/v1/schema/Battery_v1.xml
+++ b/static/redfish/v1/schema/Battery_v1.xml
@@ -1,0 +1,267 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!---->
+<!--################################################################################       -->
+<!--# Redfish Schema:  Battery v1.0.0                                                      -->
+<!--#                                                                                      -->
+<!--# For a detailed change log, see the README file contained in the DSP8010 bundle,      -->
+<!--# available at http://www.dmtf.org/standards/redfish                                   -->
+<!--# Copyright 2014-2021 DMTF.                                                            -->
+<!--# For the full DMTF copyright policy, see http://www.dmtf.org/about/policies/copyright -->
+<!--################################################################################       -->
+<!---->
+<edmx:Edmx xmlns:edmx="http://docs.oasis-open.org/odata/ns/edmx" Version="4.0">
+
+  <edmx:Reference Uri="http://docs.oasis-open.org/odata/odata/v4.0/errata03/csd01/complete/vocabularies/Org.OData.Core.V1.xml">
+    <edmx:Include Namespace="Org.OData.Core.V1" Alias="OData"/>
+  </edmx:Reference>
+  <edmx:Reference Uri="http://docs.oasis-open.org/odata/odata/v4.0/errata03/csd01/complete/vocabularies/Org.OData.Capabilities.V1.xml">
+    <edmx:Include Namespace="Org.OData.Capabilities.V1" Alias="Capabilities"/>
+  </edmx:Reference>
+  <edmx:Reference Uri="http://docs.oasis-open.org/odata/odata/v4.0/errata03/csd01/complete/vocabularies/Org.OData.Measures.V1.xml">
+    <edmx:Include Namespace="Org.OData.Measures.V1" Alias="Measures"/>
+  </edmx:Reference>
+  <edmx:Reference Uri="http://redfish.dmtf.org/schemas/v1/RedfishExtensions_v1.xml">
+    <edmx:Include Namespace="RedfishExtensions.v1_0_0" Alias="Redfish"/>
+    <edmx:Include Namespace="Validation.v1_0_0" Alias="Validation"/>
+  </edmx:Reference>
+  <edmx:Reference Uri="http://redfish.dmtf.org/schemas/v1/Resource_v1.xml">
+    <edmx:Include Namespace="Resource"/>
+    <edmx:Include Namespace="Resource.v1_0_0"/>
+  </edmx:Reference>
+  <edmx:Reference Uri="http://redfish.dmtf.org/schemas/v1/Assembly_v1.xml">
+    <edmx:Include Namespace="Assembly"/>
+  </edmx:Reference>
+  <edmx:Reference Uri="http://redfish.dmtf.org/schemas/v1/BatteryMetrics_v1.xml">
+    <edmx:Include Namespace="BatteryMetrics"/>
+  </edmx:Reference>
+  <edmx:Reference Uri="http://redfish.dmtf.org/schemas/v1/Sensor_v1.xml">
+    <edmx:Include Namespace="Sensor"/>
+  </edmx:Reference>
+
+  <edmx:DataServices>
+
+    <Schema xmlns="http://docs.oasis-open.org/odata/ns/edm" Namespace="Battery">
+      <Annotation Term="Redfish.OwningEntity" String="DMTF"/>
+
+      <EntityType Name="Battery" BaseType="Resource.v1_0_0.Resource" Abstract="true">
+        <Annotation Term="OData.Description" String="The Battery schema describes a battery unit, such as those used to provide systems with power during a power loss event."/>
+        <Annotation Term="OData.LongDescription" String="This resource shall represent a battery for a Redfish implementation."/>
+        <Annotation Term="Capabilities.InsertRestrictions">
+          <Record>
+            <PropertyValue Property="Insertable" Bool="false"/>
+          </Record>
+        </Annotation>
+        <Annotation Term="Capabilities.UpdateRestrictions">
+          <Record>
+            <PropertyValue Property="Updatable" Bool="true"/>
+          </Record>
+        </Annotation>
+        <Annotation Term="Capabilities.DeleteRestrictions">
+          <Record>
+            <PropertyValue Property="Deletable" Bool="false"/>
+          </Record>
+        </Annotation>
+        <Annotation Term="Redfish.Uris">
+          <Collection>
+            <String>/redfish/v1/Chassis/{ChassisId}/PowerSubsystem/Batteries/{BatteryId}</String>
+          </Collection>
+        </Annotation>
+      </EntityType>
+
+      <Action Name="Reset" IsBound="true">
+        <Annotation Term="OData.Description" String="This action resets the battery."/>
+        <Annotation Term="OData.LongDescription" String="This action shall reset the battery."/>
+        <Parameter Name="Battery" Type="Battery.v1_0_0.Actions"/>
+        <Parameter Name="ResetType" Type="Resource.ResetType">
+          <Annotation Term="OData.Description" String="The type of reset."/>
+          <Annotation Term="OData.LongDescription" String="This parameter shall contain the type of reset.  The service can accept a request without the parameter and shall perform a `GracefulRestart`."/>
+        </Parameter>
+      </Action>
+
+      <Action Name="SelfTest" IsBound="true">
+        <Annotation Term="OData.Description" String="This action performs a self-test of the battery."/>
+        <Annotation Term="OData.LongDescription" String="This action shall perform a self-test of the battery."/>
+        <Parameter Name="Battery" Type="Battery.v1_0_0.Actions"/>
+      </Action>
+
+      <Action Name="Calibrate" IsBound="true">
+        <Annotation Term="OData.Description" String="This action performs a self-calibration, or learn cycle, of the battery."/>
+        <Annotation Term="OData.LongDescription" String="This action shall perform a self-calibration, or learn cycle, of the battery."/>
+        <Parameter Name="Battery" Type="Battery.v1_0_0.Actions"/>
+      </Action>
+    </Schema>
+
+    <Schema xmlns="http://docs.oasis-open.org/odata/ns/edm" Namespace="Battery.v1_0_0">
+      <Annotation Term="Redfish.OwningEntity" String="DMTF"/>
+      <Annotation Term="Redfish.Release" String="2021.2"/>
+
+      <EntityType Name="Battery" BaseType="Battery.Battery">
+        <Property Name="Manufacturer" Type="Edm.String">
+          <Annotation Term="OData.Permissions" EnumMember="OData.Permission/Read"/>
+          <Annotation Term="OData.Description" String="The manufacturer of this battery."/>
+          <Annotation Term="OData.LongDescription" String="This property shall contain the name of the organization responsible for producing the battery.  This organization may be the entity from whom the battery is purchased, but this is not necessarily true."/>
+        </Property>
+        <Property Name="Model" Type="Edm.String">
+          <Annotation Term="OData.Permissions" EnumMember="OData.Permission/Read"/>
+          <Annotation Term="OData.Description" String="The model number for this battery."/>
+          <Annotation Term="OData.LongDescription" String="This property shall contain the model information as defined by the manufacturer for this battery."/>
+        </Property>
+        <Property Name="FirmwareVersion" Type="Edm.String">
+          <Annotation Term="OData.Permissions" EnumMember="OData.Permission/Read"/>
+          <Annotation Term="OData.Description" String="The firmware version for this battery."/>
+          <Annotation Term="OData.LongDescription" String="This property shall contain the firmware version as defined by the manufacturer for this battery."/>
+        </Property>
+        <Property Name="Version" Type="Edm.String">
+          <Annotation Term="OData.Permissions" EnumMember="OData.Permission/Read"/>
+          <Annotation Term="OData.Description" String="The hardware version of this battery."/>
+          <Annotation Term="OData.LongDescription" String="This property shall contain the hardware version of this battery as determined by the vendor or supplier."/>
+        </Property>
+        <Property Name="ProductionDate" Type="Edm.DateTimeOffset">
+          <Annotation Term="OData.Permissions" EnumMember="OData.Permission/Read"/>
+          <Annotation Term="OData.Description" String="The production or manufacturing date of this battery."/>
+          <Annotation Term="OData.LongDescription" String="This property shall contain the date of production or manufacture for this battery."/>
+        </Property>
+        <Property Name="SerialNumber" Type="Edm.String">
+          <Annotation Term="OData.Permissions" EnumMember="OData.Permission/Read"/>
+          <Annotation Term="OData.Description" String="The serial number for this battery."/>
+          <Annotation Term="OData.LongDescription" String="This property shall contain the serial number as defined by the manufacturer for this battery."/>
+        </Property>
+        <Property Name="PartNumber" Type="Edm.String">
+          <Annotation Term="OData.Permissions" EnumMember="OData.Permission/Read"/>
+          <Annotation Term="OData.Description" String="The part number for this battery."/>
+          <Annotation Term="OData.LongDescription" String="This property shall contain the part number as defined by the manufacturer for this battery."/>
+        </Property>
+        <Property Name="SparePartNumber" Type="Edm.String">
+          <Annotation Term="OData.Permissions" EnumMember="OData.Permission/Read"/>
+          <Annotation Term="OData.Description" String="The spare part number for this battery."/>
+          <Annotation Term="OData.LongDescription" String="This property shall contain the spare or replacement part number as defined by the manufacturer for this battery."/>
+        </Property>
+        <Property Name="Status" Type="Resource.Status" Nullable="false">
+          <Annotation Term="OData.Description" String="The status and health of the resource and its subordinate or dependent resources."/>
+          <Annotation Term="OData.LongDescription" String="This property shall contain any status or health properties of the resource."/>
+        </Property>
+        <Property Name="Location" Type="Resource.Location" Nullable="false">
+          <Annotation Term="OData.Description" String="The location of the battery."/>
+          <Annotation Term="OData.LongDescription" String="This property shall contain location information of this battery."/>
+        </Property>
+        <Property Name="LocationIndicatorActive" Type="Edm.Boolean">
+          <Annotation Term="OData.Permissions" EnumMember="OData.Permission/ReadWrite"/>
+          <Annotation Term="OData.Description" String="An indicator allowing an operator to physically locate this resource."/>
+          <Annotation Term="OData.LongDescription" String="This property shall contain the state of the indicator used to physically identify or locate this resource."/>
+        </Property>
+        <Property Name="HotPluggable" Type="Edm.Boolean">
+          <Annotation Term="OData.Permissions" EnumMember="OData.Permission/Read"/>
+          <Annotation Term="OData.Description" String="An indication of whether this device can be inserted or removed while the equipment is in operation."/>
+          <Annotation Term="OData.LongDescription" String="This property shall indicate whether the device can be inserted or removed while the underlying equipment otherwise remains in its current operational state.  Devices indicated as hot-pluggable shall allow the device to become operable without altering the operational state of the underlying equipment.  Devices that cannot be inserted or removed from equipment in operation, or devices that cannot become operable without affecting the operational state of that equipment, shall be indicated as not hot-pluggable."/>
+        </Property>
+        <Property Name="CapacityRatedWattHours" Type="Edm.Decimal">
+          <Annotation Term="OData.Permissions" EnumMember="OData.Permission/Read"/>
+          <Annotation Term="OData.Description" String="The rated maximum capacity of this battery in watt-hours."/>
+          <Annotation Term="OData.LongDescription" String="This property shall contain the rated maximum capacity of this battery in watt-hours."/>
+          <Annotation Term="Measures.Unit" String="W.h"/>
+          <Annotation Term="Validation.Minimum" Int="0"/>
+        </Property>
+        <Property Name="CapacityActualWattHours" Type="Edm.Decimal">
+          <Annotation Term="OData.Permissions" EnumMember="OData.Permission/Read"/>
+          <Annotation Term="OData.Description" String="The actual maximum capacity of this battery in watt-hours."/>
+          <Annotation Term="OData.LongDescription" String="This property shall contain the actual maximum capacity of this battery in watt-hours."/>
+          <Annotation Term="Measures.Unit" String="W.h"/>
+          <Annotation Term="Validation.Minimum" Int="0"/>
+        </Property>
+        <Property Name="CapacityRatedAmpHours" Type="Edm.Decimal">
+          <Annotation Term="OData.Permissions" EnumMember="OData.Permission/Read"/>
+          <Annotation Term="OData.Description" String="The rated maximum capacity of this battery in amp-hours."/>
+          <Annotation Term="OData.LongDescription" String="This property shall contain the rated maximum capacity of this battery in amp-hours."/>
+          <Annotation Term="Measures.Unit" String="A.h"/>
+          <Annotation Term="Validation.Minimum" Int="0"/>
+        </Property>
+        <Property Name="CapacityActualAmpHours" Type="Edm.Decimal">
+          <Annotation Term="OData.Permissions" EnumMember="OData.Permission/Read"/>
+          <Annotation Term="OData.Description" String="The actual maximum capacity of this battery in amp-hours."/>
+          <Annotation Term="OData.LongDescription" String="This property shall contain the actual maximum capacity of this battery in amp-hours."/>
+          <Annotation Term="Measures.Unit" String="A.h"/>
+          <Annotation Term="Validation.Minimum" Int="0"/>
+        </Property>
+        <Property Name="MaxDischargeRateAmps" Type="Edm.Decimal">
+          <Annotation Term="OData.Permissions" EnumMember="OData.Permission/Read"/>
+          <Annotation Term="OData.Description" String="The maximum discharge rate of this battery in amps."/>
+          <Annotation Term="OData.LongDescription" String="This property shall contain the maximum discharge rate of this battery in amps."/>
+          <Annotation Term="Measures.Unit" String="A"/>
+          <Annotation Term="Validation.Minimum" Int="0"/>
+        </Property>
+        <Property Name="MaxChargeRateAmps" Type="Edm.Decimal">
+          <Annotation Term="OData.Permissions" EnumMember="OData.Permission/Read"/>
+          <Annotation Term="OData.Description" String="The maximum charge rate of this battery in amps."/>
+          <Annotation Term="OData.LongDescription" String="This property shall contain the maximum charge rate of this battery in amps."/>
+          <Annotation Term="Measures.Unit" String="A"/>
+          <Annotation Term="Validation.Minimum" Int="0"/>
+        </Property>
+        <Property Name="MaxChargeVoltage" Type="Edm.Decimal">
+          <Annotation Term="OData.Permissions" EnumMember="OData.Permission/Read"/>
+          <Annotation Term="OData.Description" String="The maximum charge voltage of this battery."/>
+          <Annotation Term="OData.LongDescription" String="This property shall contain the maximum charge voltage of this battery."/>
+          <Annotation Term="Measures.Unit" String="V"/>
+          <Annotation Term="Validation.Minimum" Int="0"/>
+        </Property>
+        <Property Name="ChargeState" Type="Battery.v1_0_0.ChargeState">
+          <Annotation Term="OData.Permissions" EnumMember="OData.Permission/Read"/>
+          <Annotation Term="OData.Description" String="The charge state of this battery."/>
+          <Annotation Term="OData.LongDescription" String="This property shall contain the charge state of this battery."/>
+        </Property>
+        <NavigationProperty Name="StateOfHealthPercent" Type="Sensor.Sensor" Nullable="false">
+          <Annotation Term="OData.Description" String="The state of health of this battery."/>
+          <Annotation Term="OData.LongDescription" String="This property shall contain the state of health of this battery as a percentage."/>
+          <Annotation Term="Redfish.ExcerptCopy"/>
+        </NavigationProperty>
+        <NavigationProperty Name="Assembly" Type="Assembly.Assembly" ContainsTarget="true" Nullable="false">
+          <Annotation Term="OData.Permissions" EnumMember="OData.Permission/Read"/>
+          <Annotation Term="OData.Description" String="The link to the assembly associated with this battery."/>
+          <Annotation Term="OData.LongDescription" String="This property shall contain a link to a resource of type Assembly."/>
+          <Annotation Term="OData.AutoExpandReferences"/>
+        </NavigationProperty>
+        <NavigationProperty Name="Metrics" Type="BatteryMetrics.BatteryMetrics" ContainsTarget="true" Nullable="false">
+          <Annotation Term="OData.Permissions" EnumMember="OData.Permission/Read"/>
+          <Annotation Term="OData.Description" String="The link to the battery metrics resource associated with this battery."/>
+          <Annotation Term="OData.LongDescription" String="This property shall contain a link to a resource of type BatteryMetrics."/>
+          <Annotation Term="OData.AutoExpandReferences"/>
+        </NavigationProperty>
+        <Property Name="Actions" Type="Battery.v1_0_0.Actions" Nullable="false">
+          <Annotation Term="OData.Description" String="The available actions for this resource."/>
+          <Annotation Term="OData.LongDescription" String="This property shall contain the available actions for this resource."/>
+        </Property>
+      </EntityType>
+
+      <ComplexType Name="Actions">
+        <Annotation Term="OData.AdditionalProperties" Bool="false"/>
+        <Annotation Term="OData.Description" String="The available actions for this resource."/>
+        <Annotation Term="OData.LongDescription" String="This type shall contain the available actions for this resource."/>
+        <Property Name="Oem" Type="Battery.v1_0_0.OemActions" Nullable="false">
+          <Annotation Term="OData.Description" String="The available OEM-specific actions for this resource."/>
+          <Annotation Term="OData.LongDescription" String="This property shall contain the available OEM-specific actions for this resource."/>
+        </Property>
+      </ComplexType>
+
+      <ComplexType Name="OemActions">
+        <Annotation Term="OData.AdditionalProperties" Bool="true"/>
+        <Annotation Term="OData.Description" String="The available OEM-specific actions for this resource."/>
+        <Annotation Term="OData.LongDescription" String="This type shall contain the available OEM-specific actions for this resource."/>
+      </ComplexType>
+
+      <EnumType Name="ChargeState">
+        <Member Name="Idle">
+          <Annotation Term="OData.Description" String="The battery is idle."/>
+          <Annotation Term="OData.LongDescription" String="This value shall indicate the battery is idle and energy is not entering or leaving the battery.  Small amounts of energy may enter or leave the battery while in this state if the battery is regulating itself."/>
+        </Member>
+        <Member Name="Charging">
+          <Annotation Term="OData.Description" String="The battery is charging."/>
+          <Annotation Term="OData.LongDescription" String="This value shall indicate the battery is charging and energy is entering the battery."/>
+        </Member>
+        <Member Name="Discharging">
+          <Annotation Term="OData.Description" String="The battery is discharging."/>
+          <Annotation Term="OData.LongDescription" String="This value shall indicate the battery is discharging and energy is leaving the battery."/>
+        </Member>
+      </EnumType>
+    </Schema>
+
+  </edmx:DataServices>
+</edmx:Edmx>

--- a/static/redfish/v1/schema/BootOptionCollection_v1.xml
+++ b/static/redfish/v1/schema/BootOptionCollection_v1.xml
@@ -1,0 +1,72 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!---->
+<!--################################################################################       -->
+<!--# Redfish Schema:  BootOptionCollection                                                -->
+<!--#                                                                                      -->
+<!--# For a detailed change log, see the README file contained in the DSP8010 bundle,      -->
+<!--# available at http://www.dmtf.org/standards/redfish                                   -->
+<!--# Copyright 2014-2021 DMTF.                                                            -->
+<!--# For the full DMTF copyright policy, see http://www.dmtf.org/about/policies/copyright -->
+<!--################################################################################       -->
+<!---->
+<edmx:Edmx xmlns:edmx="http://docs.oasis-open.org/odata/ns/edmx" Version="4.0">
+
+  <edmx:Reference Uri="http://docs.oasis-open.org/odata/odata/v4.0/errata03/csd01/complete/vocabularies/Org.OData.Core.V1.xml">
+    <edmx:Include Namespace="Org.OData.Core.V1" Alias="OData"/>
+  </edmx:Reference>
+  <edmx:Reference Uri="http://docs.oasis-open.org/odata/odata/v4.0/errata03/csd01/complete/vocabularies/Org.OData.Capabilities.V1.xml">
+    <edmx:Include Namespace="Org.OData.Capabilities.V1" Alias="Capabilities"/>
+  </edmx:Reference>
+  <edmx:Reference Uri="http://redfish.dmtf.org/schemas/v1/Resource_v1.xml">
+    <edmx:Include Namespace="Resource.v1_0_0"/>
+  </edmx:Reference>
+  <edmx:Reference Uri="http://redfish.dmtf.org/schemas/v1/RedfishExtensions_v1.xml">
+    <edmx:Include Namespace="RedfishExtensions.v1_0_0" Alias="Redfish"/>
+  </edmx:Reference>
+  <edmx:Reference Uri="http://redfish.dmtf.org/schemas/v1/BootOption_v1.xml">
+    <edmx:Include Namespace="BootOption"/>
+  </edmx:Reference>
+
+  <edmx:DataServices>
+
+    <Schema xmlns="http://docs.oasis-open.org/odata/ns/edm" Namespace="BootOptionCollection">
+      <Annotation Term="Redfish.OwningEntity" String="DMTF"/>
+
+      <EntityType Name="BootOptionCollection" BaseType="Resource.v1_0_0.ResourceCollection">
+        <Annotation Term="OData.Description" String="The collection of BootOption resource instances."/>
+        <Annotation Term="OData.LongDescription" String="This resource shall represent a resource collection of BootOption instances for a Redfish implementation."/>
+        <Annotation Term="Capabilities.InsertRestrictions">
+          <Record>
+            <PropertyValue Property="Insertable" Bool="true"/>
+            <Annotation Term="OData.Description" String="Some implementations might allow the creation of boot option entries through a POST to the boot options collection."/>
+          </Record>
+        </Annotation>
+        <Annotation Term="Capabilities.UpdateRestrictions">
+          <Record>
+            <PropertyValue Property="Updatable" Bool="false"/>
+          </Record>
+        </Annotation>
+        <Annotation Term="Capabilities.DeleteRestrictions">
+          <Record>
+            <PropertyValue Property="Deletable" Bool="false"/>
+          </Record>
+        </Annotation>
+        <Annotation Term="Redfish.Uris">
+          <Collection>
+            <String>/redfish/v1/Systems/{ComputerSystemId}/BootOptions</String>
+            <String>/redfish/v1/CompositionService/ResourceBlocks/{ResourceBlockId}/Systems/{ComputerSystemId}/BootOptions</String>
+            <String>/redfish/v1/ResourceBlocks/{ResourceBlockId}/Systems/{ComputerSystemId}/BootOptions</String>
+          </Collection>
+        </Annotation>
+        <NavigationProperty Name="Members" Type="Collection(BootOption.BootOption)">
+          <Annotation Term="OData.Permissions" EnumMember="OData.Permission/Read"/>
+          <Annotation Term="OData.Description" String="The members of this collection."/>
+          <Annotation Term="OData.LongDescription" String="This property shall contain an array of links to the members of this collection."/>
+          <Annotation Term="OData.AutoExpandReferences"/>
+          <Annotation Term="Redfish.Required"/>
+        </NavigationProperty>
+      </EntityType>
+    </Schema>
+
+  </edmx:DataServices>
+</edmx:Edmx>

--- a/static/redfish/v1/schema/BootOption_v1.xml
+++ b/static/redfish/v1/schema/BootOption_v1.xml
@@ -1,0 +1,153 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!---->
+<!--################################################################################       -->
+<!--# Redfish Schema:  BootOption v1.0.4                                                   -->
+<!--#                                                                                      -->
+<!--# For a detailed change log, see the README file contained in the DSP8010 bundle,      -->
+<!--# available at http://www.dmtf.org/standards/redfish                                   -->
+<!--# Copyright 2014-2021 DMTF.                                                            -->
+<!--# For the full DMTF copyright policy, see http://www.dmtf.org/about/policies/copyright -->
+<!--################################################################################       -->
+<!---->
+<edmx:Edmx xmlns:edmx="http://docs.oasis-open.org/odata/ns/edmx" Version="4.0">
+
+  <edmx:Reference Uri="http://docs.oasis-open.org/odata/odata/v4.0/errata03/csd01/complete/vocabularies/Org.OData.Core.V1.xml">
+    <edmx:Include Namespace="Org.OData.Core.V1" Alias="OData"/>
+  </edmx:Reference>
+  <edmx:Reference Uri="http://docs.oasis-open.org/odata/odata/v4.0/errata03/csd01/complete/vocabularies/Org.OData.Capabilities.V1.xml">
+    <edmx:Include Namespace="Org.OData.Capabilities.V1" Alias="Capabilities"/>
+  </edmx:Reference>
+  <edmx:Reference Uri="http://redfish.dmtf.org/schemas/v1/Resource_v1.xml">
+    <edmx:Include Namespace="Resource"/>
+    <edmx:Include Namespace="Resource.v1_0_0"/>
+  </edmx:Reference>
+  <edmx:Reference Uri="http://redfish.dmtf.org/schemas/v1/RedfishExtensions_v1.xml">
+    <edmx:Include Namespace="RedfishExtensions.v1_0_0" Alias="Redfish"/>
+  </edmx:Reference>
+  <edmx:Reference Uri="http://redfish.dmtf.org/schemas/v1/ComputerSystem_v1.xml">
+    <edmx:Include Namespace="ComputerSystem"/>
+  </edmx:Reference>
+
+  <edmx:DataServices>
+
+    <Schema xmlns="http://docs.oasis-open.org/odata/ns/edm" Namespace="BootOption">
+      <Annotation Term="Redfish.OwningEntity" String="DMTF"/>
+
+      <EntityType Name="BootOption" BaseType="Resource.v1_0_0.Resource" Abstract="true">
+        <Annotation Term="OData.Description" String="The BootOption schema reports information about a single boot option in a system.  It represents the properties of a bootable device available in the system."/>
+        <Annotation Term="OData.LongDescription" String="This resource shall represent a single boot option within a system."/>
+        <Annotation Term="OData.AdditionalProperties" Bool="false"/>
+        <Annotation Term="Capabilities.InsertRestrictions">
+          <Record>
+            <PropertyValue Property="Insertable" Bool="false"/>
+          </Record>
+        </Annotation>
+        <Annotation Term="Capabilities.UpdateRestrictions">
+          <Record>
+            <PropertyValue Property="Updatable" Bool="true"/>
+            <Annotation Term="OData.Description" String="Any writable properties can be updated for boot options."/>
+          </Record>
+        </Annotation>
+        <Annotation Term="Capabilities.DeleteRestrictions">
+          <Record>
+            <PropertyValue Property="Deletable" Bool="true"/>
+            <Annotation Term="OData.Description" String="Some implementations might allow the deletion of individual boot options."/>
+          </Record>
+        </Annotation>
+        <Annotation Term="Redfish.Uris">
+          <Collection>
+            <String>/redfish/v1/Systems/{ComputerSystemId}/BootOptions/{BootOptionId}</String>
+            <String>/redfish/v1/CompositionService/ResourceBlocks/{ResourceBlockId}/Systems/{ComputerSystemId}/BootOptions/{BootOptionId}</String>
+            <String>/redfish/v1/ResourceBlocks/{ResourceBlockId}/Systems/{ComputerSystemId}/BootOptions/{BootOptionId}</String>
+          </Collection>
+        </Annotation>
+      </EntityType>
+    </Schema>
+
+    <Schema xmlns="http://docs.oasis-open.org/odata/ns/edm" Namespace="BootOption.v1_0_0">
+      <Annotation Term="Redfish.OwningEntity" String="DMTF"/>
+      <Annotation Term="Redfish.Release" String="2017.3"/>
+
+      <EntityType Name="BootOption" BaseType="BootOption.BootOption">
+        <Annotation Term="OData.AdditionalProperties" Bool="false"/>
+        <Property Name="BootOptionReference" Type="Edm.String">
+          <Annotation Term="OData.Permissions" EnumMember="OData.Permission/Read"/>
+          <Annotation Term="OData.Description" String="The unique boot option."/>
+          <Annotation Term="OData.LongDescription" String="This property shall correspond to the boot option or device.  For UEFI systems, this string shall match the UEFI boot option variable name, such as `Boot####`.  The BootOrder array of a computer system resource contains this value."/>
+          <Annotation Term="Redfish.Required"/>
+        </Property>
+        <Property Name="DisplayName" Type="Edm.String">
+          <Annotation Term="OData.Permissions" EnumMember="OData.Permission/Read"/>
+          <Annotation Term="OData.Description" String="The user-readable display name of the boot option that appears in the boot order list in the user interface."/>
+          <Annotation Term="OData.LongDescription" String="This property shall contain a user-readable boot option name, as it should appear in the boot order list in the user interface."/>
+        </Property>
+        <Property Name="BootOptionEnabled" Type="Edm.Boolean">
+          <Annotation Term="OData.Permissions" EnumMember="OData.Permission/ReadWrite"/>
+          <Annotation Term="OData.Description" String="An indication of whether the boot option is enabled.  If `true`, it is enabled.  If `false`, the boot option that the boot order array on the computer system contains is skipped.  In the UEFI context, this property shall influence the load option active flag for the boot option."/>
+          <Annotation Term="OData.LongDescription" String="This property shall indicate whether the boot option is enabled.  If `true`, it is enabled.  If `false`, the boot option that the boot order array on the computer system contains shall be skipped.  In the UEFI context, this property shall influence the load option active flag for the boot option."/>
+        </Property>
+        <Property Name="UefiDevicePath" Type="Edm.String">
+          <Annotation Term="OData.Permissions" EnumMember="OData.Permission/Read"/>
+          <Annotation Term="OData.Description" String="The UEFI device path to access this UEFI boot option."/>
+          <Annotation Term="OData.LongDescription" String="This property shall contain the UEFI Specification-defined UEFI device path that identifies and locates the device for this boot option."/>
+        </Property>
+        <Property Name="Alias" Type="ComputerSystem.BootSource">
+          <Annotation Term="OData.Permissions" EnumMember="OData.Permission/Read"/>
+          <Annotation Term="OData.Description" String="The alias of this boot source."/>
+          <Annotation Term="OData.LongDescription" String="This property shall contain the string alias of this boot source that describes the type of boot."/>
+        </Property>
+        <NavigationProperty Name="RelatedItem" Type="Collection(Resource.Item)">
+          <Annotation Term="OData.Permissions" EnumMember="OData.Permission/Read"/>
+          <Annotation Term="OData.Description" String="An array of links to resources or objects associated with this boot option."/>
+          <Annotation Term="OData.LongDescription" String="This property shall contain an array of links to resources or objects that are associated with this boot option."/>
+          <Annotation Term="OData.AutoExpandReferences"/>
+        </NavigationProperty>
+        <Property Name="Actions" Type="BootOption.v1_0_0.Actions" Nullable="false">
+          <Annotation Term="OData.Description" String="The available actions for this resource."/>
+          <Annotation Term="OData.LongDescription" String="This property shall contain the available actions for this resource."/>
+        </Property>
+      </EntityType>
+
+      <ComplexType Name="Actions">
+        <Annotation Term="OData.AdditionalProperties" Bool="false"/>
+        <Annotation Term="OData.Description" String="The available actions for this resource."/>
+        <Annotation Term="OData.LongDescription" String="This type shall contain the available actions for this resource."/>
+        <Property Name="Oem" Type="BootOption.v1_0_0.OemActions" Nullable="false">
+          <Annotation Term="OData.Description" String="The available OEM-specific actions for this resource."/>
+          <Annotation Term="OData.LongDescription" String="This property shall contain the available OEM-specific actions for this resource."/>
+        </Property>
+      </ComplexType>
+
+      <ComplexType Name="OemActions">
+        <Annotation Term="OData.AdditionalProperties" Bool="true"/>
+        <Annotation Term="OData.Description" String="The available OEM-specific actions for this resource."/>
+        <Annotation Term="OData.LongDescription" String="This type shall contain the available OEM-specific actions for this resource."/>
+      </ComplexType>
+    </Schema>
+
+    <Schema xmlns="http://docs.oasis-open.org/odata/ns/edm" Namespace="BootOption.v1_0_1">
+      <Annotation Term="Redfish.OwningEntity" String="DMTF"/>
+      <Annotation Term="OData.Description" String="This version was created to force the regeneration of JSON Schema so that OData properties are marked as required, and integer properties are marked as integer rather than number."/>
+      <EntityType Name="BootOption" BaseType="BootOption.v1_0_0.BootOption"/>
+    </Schema>
+
+    <Schema xmlns="http://docs.oasis-open.org/odata/ns/edm" Namespace="BootOption.v1_0_2">
+      <Annotation Term="Redfish.OwningEntity" String="DMTF"/>
+      <Annotation Term="OData.Description" String="This version was created to force the regeneration of JSON Schema so that URI properties use the uri-reference format."/>
+      <EntityType Name="BootOption" BaseType="BootOption.v1_0_1.BootOption"/>
+    </Schema>
+
+    <Schema xmlns="http://docs.oasis-open.org/odata/ns/edm" Namespace="BootOption.v1_0_3">
+      <Annotation Term="Redfish.OwningEntity" String="DMTF"/>
+      <Annotation Term="OData.Description" String="This version was created to update descriptions that this schema defines."/>
+      <EntityType Name="BootOption" BaseType="BootOption.v1_0_2.BootOption"/>
+    </Schema>
+
+    <Schema xmlns="http://docs.oasis-open.org/odata/ns/edm" Namespace="BootOption.v1_0_4">
+      <Annotation Term="Redfish.OwningEntity" String="DMTF"/>
+      <Annotation Term="OData.Description" String="This version was created to correct various typographical errors."/>
+      <EntityType Name="BootOption" BaseType="BootOption.v1_0_3.BootOption"/>
+    </Schema>
+
+  </edmx:DataServices>
+</edmx:Edmx>

--- a/static/redfish/v1/schema/CableCollection_v1.xml
+++ b/static/redfish/v1/schema/CableCollection_v1.xml
@@ -1,0 +1,70 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!---->
+<!--################################################################################       -->
+<!--# Redfish Schema:  CableCollection                                                     -->
+<!--#                                                                                      -->
+<!--# For a detailed change log, see the README file contained in the DSP8010 bundle,      -->
+<!--# available at http://www.dmtf.org/standards/redfish                                   -->
+<!--# Copyright 2014-2021 DMTF.                                                            -->
+<!--# For the full DMTF copyright policy, see http://www.dmtf.org/about/policies/copyright -->
+<!--################################################################################       -->
+<!---->
+<edmx:Edmx xmlns:edmx="http://docs.oasis-open.org/odata/ns/edmx" Version="4.0">
+
+  <edmx:Reference Uri="http://docs.oasis-open.org/odata/odata/v4.0/errata03/csd01/complete/vocabularies/Org.OData.Core.V1.xml">
+    <edmx:Include Namespace="Org.OData.Core.V1" Alias="OData"/>
+  </edmx:Reference>
+  <edmx:Reference Uri="http://docs.oasis-open.org/odata/odata/v4.0/errata03/csd01/complete/vocabularies/Org.OData.Capabilities.V1.xml">
+    <edmx:Include Namespace="Org.OData.Capabilities.V1" Alias="Capabilities"/>
+  </edmx:Reference>
+  <edmx:Reference Uri="http://redfish.dmtf.org/schemas/v1/Resource_v1.xml">
+    <edmx:Include Namespace="Resource.v1_0_0"/>
+  </edmx:Reference>
+  <edmx:Reference Uri="http://redfish.dmtf.org/schemas/v1/RedfishExtensions_v1.xml">
+    <edmx:Include Namespace="RedfishExtensions.v1_0_0" Alias="Redfish"/>
+  </edmx:Reference>
+  <edmx:Reference Uri="http://redfish.dmtf.org/schemas/v1/Cable_v1.xml">
+    <edmx:Include Namespace="Cable"/>
+  </edmx:Reference>
+
+  <edmx:DataServices>
+
+    <Schema xmlns="http://docs.oasis-open.org/odata/ns/edm" Namespace="CableCollection">
+      <Annotation Term="Redfish.OwningEntity" String="DMTF"/>
+
+      <EntityType Name="CableCollection" BaseType="Resource.v1_0_0.ResourceCollection">
+        <Annotation Term="OData.Description" String="The collection of Cable resource instances."/>
+        <Annotation Term="OData.LongDescription" String="This resource shall represent a resource collection of Cable instances for a Redfish implementation."/>
+        <Annotation Term="Capabilities.InsertRestrictions">
+          <Record>
+            <PropertyValue Property="Insertable" Bool="true"/>
+            <Annotation Term="OData.Description" String="Cables can be added through a POST to the cable collection."/>
+          </Record>
+        </Annotation>
+        <Annotation Term="Capabilities.UpdateRestrictions">
+          <Record>
+            <PropertyValue Property="Updatable" Bool="false"/>
+          </Record>
+        </Annotation>
+        <Annotation Term="Capabilities.DeleteRestrictions">
+          <Record>
+            <PropertyValue Property="Deletable" Bool="false"/>
+          </Record>
+        </Annotation>
+        <Annotation Term="Redfish.Uris">
+          <Collection>
+            <String>/redfish/v1/Cables</String>
+          </Collection>
+        </Annotation>
+        <NavigationProperty Name="Members" Type="Collection(Cable.Cable)">
+          <Annotation Term="OData.Permissions" EnumMember="OData.Permission/Read"/>
+          <Annotation Term="OData.Description" String="The members of this collection."/>
+          <Annotation Term="OData.LongDescription" String="This property shall contain an array of links to the members of this collection."/>
+          <Annotation Term="OData.AutoExpandReferences"/>
+          <Annotation Term="Redfish.Required"/>
+        </NavigationProperty>
+      </EntityType>
+    </Schema>
+
+  </edmx:DataServices>
+</edmx:Edmx>

--- a/static/redfish/v1/schema/Cable_v1.xml
+++ b/static/redfish/v1/schema/Cable_v1.xml
@@ -1,0 +1,354 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!---->
+<!--################################################################################       -->
+<!--# Redfish Schema:  Cable v1.0.0                                                        -->
+<!--#                                                                                      -->
+<!--# For a detailed change log, see the README file contained in the DSP8010 bundle,      -->
+<!--# available at http://www.dmtf.org/standards/redfish                                   -->
+<!--# Copyright 2014-2021 DMTF.                                                            -->
+<!--# For the full DMTF copyright policy, see http://www.dmtf.org/about/policies/copyright -->
+<!--################################################################################       -->
+<!---->
+<edmx:Edmx xmlns:edmx="http://docs.oasis-open.org/odata/ns/edmx" Version="4.0">
+
+  <edmx:Reference Uri="http://docs.oasis-open.org/odata/odata/v4.0/errata03/csd01/complete/vocabularies/Org.OData.Core.V1.xml">
+    <edmx:Include Namespace="Org.OData.Core.V1" Alias="OData"/>
+  </edmx:Reference>
+  <edmx:Reference Uri="http://docs.oasis-open.org/odata/odata/v4.0/errata03/csd01/complete/vocabularies/Org.OData.Capabilities.V1.xml">
+    <edmx:Include Namespace="Org.OData.Capabilities.V1" Alias="Capabilities"/>
+  </edmx:Reference>
+  <edmx:Reference Uri="http://redfish.dmtf.org/schemas/v1/RedfishExtensions_v1.xml">
+    <edmx:Include Namespace="RedfishExtensions.v1_0_0" Alias="Redfish"/>
+  </edmx:Reference>
+  <edmx:Reference Uri="http://redfish.dmtf.org/schemas/v1/Resource_v1.xml">
+    <edmx:Include Namespace="Resource"/>
+    <edmx:Include Namespace="Resource.v1_0_0"/>
+  </edmx:Reference>
+  <edmx:Reference Uri="http://redfish.dmtf.org/schemas/v1/Chassis_v1.xml">
+    <edmx:Include Namespace="Chassis"/>
+  </edmx:Reference>
+  <edmx:Reference Uri="http://redfish.dmtf.org/schemas/v1/Port_v1.xml">
+    <edmx:Include Namespace="Port"/>
+  </edmx:Reference>
+  <edmx:Reference Uri="http://redfish.dmtf.org/schemas/v1/Assembly_v1.xml">
+    <edmx:Include Namespace="Assembly"/>
+  </edmx:Reference>
+
+  <edmx:DataServices>
+
+    <Schema xmlns="http://docs.oasis-open.org/odata/ns/edm" Namespace="Cable">
+      <Annotation Term="Redfish.OwningEntity" String="DMTF"/>
+
+      <EntityType Name="Cable" BaseType="Resource.v1_0_0.Resource" Abstract="true">
+        <Annotation Term="OData.AdditionalProperties" Bool="true"/>
+        <Annotation Term="OData.Description" String="The Cable schema contains properties that describe a cable connecting endpoints of a chassis, port, or any other cable-compatible endpoint."/>
+        <Annotation Term="OData.LongDescription" String="This resource contains a simple cable for a Redfish implementation."/>
+        <Annotation Term="Capabilities.InsertRestrictions">
+          <Record>
+            <PropertyValue Property="Insertable" Bool="false"/>
+          </Record>
+        </Annotation>
+        <Annotation Term="Capabilities.UpdateRestrictions">
+          <Record>
+            <PropertyValue Property="Updatable" Bool="true"/>
+          </Record>
+        </Annotation>
+        <Annotation Term="Capabilities.DeleteRestrictions">
+          <Record>
+            <PropertyValue Property="Deletable" Bool="true"/>
+          </Record>
+        </Annotation>
+        <Annotation Term="Redfish.Uris">
+          <Collection>
+            <String>/redfish/v1/Cables/{CableId}</String>
+          </Collection>
+        </Annotation>
+      </EntityType>
+    </Schema>
+
+    <Schema xmlns="http://docs.oasis-open.org/odata/ns/edm" Namespace="Cable.v1_0_0">
+      <Annotation Term="Redfish.OwningEntity" String="DMTF"/>
+      <Annotation Term="Redfish.Release" String="2021.2"/>
+
+      <EntityType Name="Cable" BaseType="Cable.Cable">
+        <Property Name="UserDescription" Type="Edm.String">
+          <Annotation Term="OData.Permissions" EnumMember="OData.Permission/ReadWrite"/>
+          <Annotation Term="OData.Description" String="The description of this cable."/>
+          <Annotation Term="OData.LongDescription" String="This property shall contain a user-defined description for this cable."/>
+        </Property>
+        <Property Name="CableType" Type="Edm.String">
+          <Annotation Term="OData.Permissions" EnumMember="OData.Permission/ReadWrite"/>
+          <Annotation Term="OData.Description" String="The type of this cable."/>
+          <Annotation Term="OData.LongDescription" String="This property shall contain a user-defined type for this cable."/>
+        </Property>
+        <Property Name="LengthMeters" Type="Edm.Decimal">
+          <Annotation Term="OData.Permissions" EnumMember="OData.Permission/ReadWrite"/>
+          <Annotation Term="OData.Description" String="The length of the cable in meters."/>
+          <Annotation Term="OData.LongDescription" String="This property shall contain the length of the cable in meters."/>
+        </Property>
+        <Property Name="DownstreamName" Type="Edm.String">
+          <Annotation Term="OData.Permissions" EnumMember="OData.Permission/ReadWrite"/>
+          <Annotation Term="OData.Description" String="The identifier for the downstream resource."/>
+          <Annotation Term="OData.LongDescription" String="This property shall contain any identifier for a downstream resource."/>
+        </Property>
+        <Property Name="UpstreamName" Type="Edm.String">
+          <Annotation Term="OData.Permissions" EnumMember="OData.Permission/ReadWrite"/>
+          <Annotation Term="OData.Description" String="The identifier for the downstream resource."/>
+          <Annotation Term="OData.LongDescription" String="This property shall contain any identifier for an upstream resource."/>
+        </Property>
+        <Property Name="Actions" Type="Cable.v1_0_0.Actions" Nullable="false">
+          <Annotation Term="OData.Description" String="The available actions for this resource."/>
+          <Annotation Term="OData.LongDescription" String="This property shall contain the available actions for this resource."/>
+        </Property>
+        <Property Name="Model" Type="Edm.String">
+          <Annotation Term="OData.Permissions" EnumMember="OData.Permission/ReadWrite"/>
+          <Annotation Term="OData.Description" String="The model number of the cable."/>
+          <Annotation Term="OData.LongDescription" String="This property shall contain the name by which the manufacturer generally refers to the cable."/>
+        </Property>
+        <Property Name="Manufacturer" Type="Edm.String">
+          <Annotation Term="OData.Permissions" EnumMember="OData.Permission/ReadWrite"/>
+          <Annotation Term="OData.Description" String="The manufacturer of this cable."/>
+          <Annotation Term="OData.LongDescription" String="This property shall contain the name of the organization responsible for producing the cable.  This organization might be the entity from whom the cable is purchased, but this is not necessarily true."/>
+        </Property>
+        <Property Name="Vendor" Type="Edm.String">
+          <Annotation Term="OData.Permissions" EnumMember="OData.Permission/ReadWrite"/>
+          <Annotation Term="OData.Description" String="The manufacturer of this cable."/>
+          <Annotation Term="OData.LongDescription" String="This property shall contain the name of the company that provides the final product that includes this cable."/>
+        </Property>
+        <Property Name="SKU" Type="Edm.String">
+          <Annotation Term="OData.Permissions" EnumMember="OData.Permission/ReadWrite"/>
+          <Annotation Term="OData.Description" String="The SKU for this cable."/>
+          <Annotation Term="OData.LongDescription" String="This property shall contain the stock-keeping unit (SKU) number for this cable."/>
+        </Property>
+        <Property Name="SerialNumber" Type="Edm.String">
+          <Annotation Term="OData.Permissions" EnumMember="OData.Permission/ReadWrite"/>
+          <Annotation Term="OData.Description" String="The serial number for this cable."/>
+          <Annotation Term="OData.LongDescription" String="This property shall contain the manufacturer-allocated number that identifies the cable."/>
+        </Property>
+        <Property Name="PartNumber" Type="Edm.String">
+          <Annotation Term="OData.Permissions" EnumMember="OData.Permission/ReadWrite"/>
+          <Annotation Term="OData.Description" String="The part number for this cable."/>
+          <Annotation Term="OData.LongDescription" String="This property shall contain the part number assigned by the organization that is responsible for producing or manufacturing the cable."/>
+        </Property>
+        <Property Name="AssetTag" Type="Edm.String">
+          <Annotation Term="OData.Permissions" EnumMember="OData.Permission/ReadWrite"/>
+          <Annotation Term="OData.Description" String="The user-assigned asset tag for this cable."/>
+          <Annotation Term="OData.LongDescription" String="This property shall track the cable for inventory purposes."/>
+        </Property>
+        <Property Name="CableClass" Type="Cable.v1_0_0.CableClass">
+          <Annotation Term="OData.Permissions" EnumMember="OData.Permission/ReadWrite"/>
+          <Annotation Term="OData.Description" String="The identifier for the downstream resource."/>
+          <Annotation Term="OData.LongDescription" String="The property shall contain the cable class for this cable."/>
+        </Property>
+        <Property Name="DownstreamConnectorTypes" Type="Collection(Cable.v1_0_0.ConnectorType)" Nullable="false">
+          <Annotation Term="OData.Permissions" EnumMember="OData.Permission/ReadWrite"/>
+          <Annotation Term="OData.Description" String="The connector types this cable supports."/>
+          <Annotation Term="OData.LongDescription" String="The property shall contain an array of connector types this cable supports."/>
+        </Property>
+        <Property Name="UpstreamConnectorTypes" Type="Collection(Cable.v1_0_0.ConnectorType)" Nullable="false">
+          <Annotation Term="OData.Permissions" EnumMember="OData.Permission/ReadWrite"/>
+          <Annotation Term="OData.Description" String="The connector types this cable supports."/>
+          <Annotation Term="OData.LongDescription" String="The property shall contain an array of connector types this cable supports."/>
+        </Property>
+        <Property Name="Links" Type="Cable.v1_0_0.Links" Nullable="false">
+          <Annotation Term="OData.Description" String="The links to other resources that are related to this resource."/>
+          <Annotation Term="OData.LongDescription" String="This property shall contain links to resources that are related to but are not contained by, or subordinate to, this resource."/>
+        </Property>
+        <Property Name="CableStatus" Type="Cable.v1_0_0.CableStatus" Nullable="false">
+          <Annotation Term="OData.Permissions" EnumMember="OData.Permission/ReadWrite"/>
+          <Annotation Term="OData.Description" String="The user-reported status of this resource."/>
+          <Annotation Term="OData.LongDescription" String="This property shall contain the user-reported status of this resource."/>
+        </Property>
+        <Property Name="Status" Type="Resource.Status" Nullable="false">
+          <Annotation Term="OData.Description" String="The status and health of the resource and its subordinate or dependent resources."/>
+          <Annotation Term="OData.LongDescription" String="This property shall contain any status or health properties of the resource."/>
+        </Property>
+        <Property Name="Location" Type="Resource.Location" Nullable="false">
+          <Annotation Term="OData.Description" String="The location of the assembly."/>
+          <Annotation Term="OData.LongDescription" String="This property shall contain location information of the associated assembly."/>
+        </Property>
+        <NavigationProperty Name="Assembly" Type="Assembly.Assembly" ContainsTarget="true" Nullable="false">
+          <Annotation Term="OData.Permissions" EnumMember="OData.Permission/Read"/>
+          <Annotation Term="OData.Description" String="The link to the assembly associated with this cable."/>
+          <Annotation Term="OData.LongDescription" String="This property shall contain a link to a resource of type Assembly."/>
+          <Annotation Term="OData.AutoExpandReferences"/>
+        </NavigationProperty>
+      </EntityType>
+
+      <EnumType Name="CableClass">
+        <Member Name="Power">
+          <Annotation Term="OData.Description" String="This cable is used for connecting to a power system."/>
+        </Member>
+        <Member Name="Network">
+          <Annotation Term="OData.Description" String="This cable is used for connecting to a networking system."/>
+        </Member>
+        <Member Name="Storage">
+          <Annotation Term="OData.Description" String="This cable is used for connecting to a storage system."/>
+        </Member>
+        <Member Name="Fan">
+          <Annotation Term="OData.Description" String="This cable is used for connecting to a fan system."/>
+        </Member>
+        <Member Name="PCIe">
+          <Annotation Term="OData.Description" String="This cable is used for connecting to a PCIe endpoint."/>
+        </Member>
+        <Member Name="USB">
+          <Annotation Term="OData.Description" String="This cable is used for connecting to a USB endpoint."/>
+        </Member>
+        <Member Name="Video">
+          <Annotation Term="OData.Description" String="This cable is used for connecting to a video system."/>
+        </Member>
+        <Member Name="Fabric">
+          <Annotation Term="OData.Description" String="This cable is used for connecting to a fabric."/>
+        </Member>
+        <Member Name="Serial">
+          <Annotation Term="OData.Description" String="This cable is used for connecting to a serial endpoint."/>
+        </Member>
+        <Member Name="General">
+          <Annotation Term="OData.Description" String="This cable is used for providing general connectivity."/>
+        </Member>
+      </EnumType>
+
+      <EnumType Name="ConnectorType">
+        <Member Name="ACPower">
+          <Annotation Term="OData.Description" String="This cable connects to a AC power connector."/>
+        </Member>
+        <Member Name="DB9">
+          <Annotation Term="OData.Description" String="This cable connects to a DB9 connector."/>
+        </Member>
+        <Member Name="DCPower">
+          <Annotation Term="OData.Description" String="This cable connects to a DC power connector."/>
+        </Member>
+        <Member Name="DisplayPort">
+          <Annotation Term="OData.Description" String="This cable connects to a DisplayPort power connector."/>
+        </Member>
+        <Member Name="HDMI">
+          <Annotation Term="OData.Description" String="This cable connects to an HDMI connector."/>
+        </Member>
+        <Member Name="ICI">
+          <Annotation Term="OData.Description" String="This cable connects to an ICI connector."/>
+        </Member>
+        <Member Name="IPASS">
+          <Annotation Term="OData.Description" String="This cable connects to an IPASS connector."/>
+        </Member>
+        <Member Name="PCIe">
+          <Annotation Term="OData.Description" String="This cable connects to a PCIe connector."/>
+        </Member>
+        <Member Name="Proprietary">
+          <Annotation Term="OData.Description" String="This cable connects to a proprietary connector."/>
+        </Member>
+        <Member Name="RJ45">
+          <Annotation Term="OData.Description" String="This cable connects to an RJ45 connector."/>
+        </Member>
+        <Member Name="SATA">
+          <Annotation Term="OData.Description" String="This cable connects to a SATA connector."/>
+        </Member>
+        <Member Name="SCSI">
+          <Annotation Term="OData.Description" String="This cable connects to a SCSI connector."/>
+        </Member>
+        <Member Name="SlimSAS">
+          <Annotation Term="OData.Description" String="This cable connects to a SlimSAS connector."/>
+        </Member>
+        <Member Name="SFP">
+          <Annotation Term="OData.Description" String="This cable connects to a SFP connector."/>
+        </Member>
+        <Member Name="SFPPlus">
+          <Annotation Term="OData.Description" String="This cable connects to a SFPPlus connector."/>
+        </Member>
+        <Member Name="USBA">
+          <Annotation Term="OData.Description" String="This cable connects to a USB-A connector."/>
+        </Member>
+        <Member Name="USBC">
+          <Annotation Term="OData.Description" String="This cable connects to a USB-C connector."/>
+        </Member>
+        <Member Name="QSFP">
+          <Annotation Term="OData.Description" String="This cable connects to a QSFP connector."/>
+        </Member>
+      </EnumType>
+
+      <EnumType Name="CableStatus">
+        <Member Name="Normal">
+          <Annotation Term="OData.Description" String="The cable is operating normally."/>
+          <Annotation Term="OData.LongDescription" String="This value shall indicate the cable is operating normally.  The State property in Status shall contain the value `Enabled` and The Health property in Status shall contain the value `OK`."/>
+        </Member>
+        <Member Name="Degraded">
+          <Annotation Term="OData.Description" String="The cable is degraded."/>
+          <Annotation Term="OData.LongDescription" String="This value shall indicate the cable is degraded.  The State property in Status shall contain the value `Enabled` and The Health property in Status shall contain the value `Warning`."/>
+        </Member>
+        <Member Name="Failed">
+          <Annotation Term="OData.Description" String="The cable has failed."/>
+          <Annotation Term="OData.LongDescription" String="This value shall indicate the cable has failed.  The State property in Status shall contain the value `Enabled` and The Health property in Status shall contain the value `Critical`."/>
+        </Member>
+        <Member Name="Testing">
+          <Annotation Term="OData.Description" String="The cable is under test."/>
+          <Annotation Term="OData.LongDescription" String="This value shall indicate the cable is under test.  The State property in Status shall contain the value `InTest`."/>
+        </Member>
+        <Member Name="Disabled">
+          <Annotation Term="OData.Description" String="The cable is disabled."/>
+          <Annotation Term="OData.LongDescription" String="This value shall indicate the cable is disabled.  The State property in Status shall contain the value `Disabled`."/>
+        </Member>
+        <Member Name="SetByService">
+          <Annotation Term="OData.Description" String="The cable status is set by the service."/>
+          <Annotation Term="OData.LongDescription" String="This value shall indicate the status for the cable is not defined by the user.  If implemented, the service shall determine the value of the State and Health properties in Status."/>
+        </Member>
+      </EnumType>
+
+      <ComplexType Name="Actions">
+        <Annotation Term="OData.AdditionalProperties" Bool="false"/>
+        <Annotation Term="OData.Description" String="The available actions for this resource."/>
+        <Annotation Term="OData.LongDescription" String="This type shall contain the available actions for this resource."/>
+        <Property Name="Oem" Type="Cable.v1_0_0.OemActions" Nullable="false">
+          <Annotation Term="OData.Description" String="The available OEM-specific actions for this resource."/>
+          <Annotation Term="OData.LongDescription" String="This property shall contain the available OEM-specific actions for this resource."/>
+        </Property>
+      </ComplexType>
+
+      <ComplexType Name="OemActions">
+        <Annotation Term="OData.AdditionalProperties" Bool="true"/>
+        <Annotation Term="OData.Description" String="The available OEM-specific actions for this resource."/>
+        <Annotation Term="OData.LongDescription" String="This type shall contain the available OEM-specific actions for this resource."/>
+      </ComplexType>
+
+      <ComplexType Name="Links" BaseType="Resource.Links">
+        <Annotation Term="OData.Description" String="The links to other resources that are related to this resource."/>
+        <Annotation Term="OData.LongDescription" String="This Redfish Specification-described type shall contain links to resources that are related to but are not contained by, or subordinate to, this resource."/>
+        <NavigationProperty Name="DownstreamChassis" Type="Collection(Chassis.Chassis)">
+          <Annotation Term="OData.Permissions" EnumMember="OData.Permission/ReadWrite"/>
+          <Annotation Term="OData.Description" String="An array of links to the downstream chassis connected to this cable."/>
+          <Annotation Term="OData.LongDescription" String="This property shall contain an array of links to resources of type Chassis that represent the physical downstream containers connected to this cable."/>
+          <Annotation Term="OData.AutoExpandReferences"/>
+        </NavigationProperty>
+        <NavigationProperty Name="UpstreamChassis" Type="Collection(Chassis.Chassis)">
+          <Annotation Term="OData.Permissions" EnumMember="OData.Permission/ReadWrite"/>
+          <Annotation Term="OData.Description" String="An array of links to the upstream chassis connected to this cable."/>
+          <Annotation Term="OData.LongDescription" String="This property shall contain an array of links to resources of type Chassis that represent the physical upstream containers connected to this cable."/>
+          <Annotation Term="OData.AutoExpandReferences"/>
+        </NavigationProperty>
+        <NavigationProperty Name="DownstreamPorts" Type="Collection(Port.Port)">
+          <Annotation Term="OData.Permissions" EnumMember="OData.Permission/ReadWrite"/>
+          <Annotation Term="OData.Description" String="An array of links to the downstream ports connected to this cable."/>
+          <Annotation Term="OData.LongDescription" String="This property shall contain an array of links to resources of type Port that represent the physical downstream connections connected to this cable."/>
+          <Annotation Term="OData.AutoExpandReferences"/>
+        </NavigationProperty>
+        <NavigationProperty Name="UpstreamPorts" Type="Collection(Port.Port)">
+          <Annotation Term="OData.Permissions" EnumMember="OData.Permission/ReadWrite"/>
+          <Annotation Term="OData.Description" String="An array of links to the upstream ports connected to this cable."/>
+          <Annotation Term="OData.LongDescription" String="This property shall contain an array of links to resources of type Port that represent the physical upstream connections connected to this cable."/>
+          <Annotation Term="OData.AutoExpandReferences"/>
+        </NavigationProperty>
+        <NavigationProperty Name="DownstreamResources" Type="Collection(Resource.Resource)">
+          <Annotation Term="OData.Permissions" EnumMember="OData.Permission/ReadWrite"/>
+          <Annotation Term="OData.Description" String="An array of links to the downstream resources connected to this cable."/>
+          <Annotation Term="OData.LongDescription" String="This property shall contain an array of links to resources that represent the physical downstream connections connected to this cable.  Even if the resource is already referenced in another property within Links, such as DownstreamPorts or DownstreamChassis, it shall also be referenced in this property."/>
+          <Annotation Term="OData.AutoExpandReferences"/>
+        </NavigationProperty>
+        <NavigationProperty Name="UpstreamResources" Type="Collection(Resource.Resource)">
+          <Annotation Term="OData.Permissions" EnumMember="OData.Permission/ReadWrite"/>
+          <Annotation Term="OData.Description" String="An array of links to the upstream resources connected to this cable."/>
+          <Annotation Term="OData.LongDescription" String="This property shall contain an array of links to resources that represent the physical upstream connections connected to this cable.  Even if the resource is already referenced in another property within Links, such as UpstreamPorts or UpstreamChassis, it shall also be referenced in this property."/>
+          <Annotation Term="OData.AutoExpandReferences"/>
+        </NavigationProperty>
+      </ComplexType>
+    </Schema>
+
+  </edmx:DataServices>
+</edmx:Edmx>

--- a/static/redfish/v1/schema/CircuitCollection_v1.xml
+++ b/static/redfish/v1/schema/CircuitCollection_v1.xml
@@ -1,0 +1,78 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!---->
+<!--################################################################################       -->
+<!--# Redfish Schema:  CircuitCollection                                                   -->
+<!--#                                                                                      -->
+<!--# For a detailed change log, see the README file contained in the DSP8010 bundle,      -->
+<!--# available at http://www.dmtf.org/standards/redfish                                   -->
+<!--# Copyright 2014-2021 DMTF.                                                            -->
+<!--# For the full DMTF copyright policy, see http://www.dmtf.org/about/policies/copyright -->
+<!--################################################################################       -->
+<!---->
+<edmx:Edmx xmlns:edmx="http://docs.oasis-open.org/odata/ns/edmx" Version="4.0">
+
+  <edmx:Reference Uri="http://docs.oasis-open.org/odata/odata/v4.0/errata03/csd01/complete/vocabularies/Org.OData.Core.V1.xml">
+    <edmx:Include Namespace="Org.OData.Core.V1" Alias="OData"/>
+  </edmx:Reference>
+  <edmx:Reference Uri="http://docs.oasis-open.org/odata/odata/v4.0/errata03/csd01/complete/vocabularies/Org.OData.Capabilities.V1.xml">
+    <edmx:Include Namespace="Org.OData.Capabilities.V1" Alias="Capabilities"/>
+  </edmx:Reference>
+  <edmx:Reference Uri="http://redfish.dmtf.org/schemas/v1/RedfishExtensions_v1.xml">
+    <edmx:Include Namespace="RedfishExtensions.v1_0_0" Alias="Redfish"/>
+  </edmx:Reference>
+  <edmx:Reference Uri="http://redfish.dmtf.org/schemas/v1/Resource_v1.xml">
+    <edmx:Include Namespace="Resource.v1_0_0"/>
+  </edmx:Reference>
+  <edmx:Reference Uri="http://redfish.dmtf.org/schemas/v1/Circuit_v1.xml">
+    <edmx:Include Namespace="Circuit"/>
+  </edmx:Reference>
+
+  <edmx:DataServices>
+
+    <Schema xmlns="http://docs.oasis-open.org/odata/ns/edm" Namespace="CircuitCollection">
+      <Annotation Term="Redfish.OwningEntity" String="DMTF"/>
+
+      <EntityType Name="CircuitCollection" BaseType="Resource.v1_0_0.ResourceCollection">
+        <Annotation Term="OData.Description" String="The collection of Circuit resource instances."/>
+        <Annotation Term="OData.LongDescription" String="This resource shall represent a resource collection of Circuit instances for a Redfish implementation."/>
+        <Annotation Term="Capabilities.InsertRestrictions">
+          <Record>
+            <PropertyValue Property="Insertable" Bool="false"/>
+          </Record>
+        </Annotation>
+        <Annotation Term="Capabilities.UpdateRestrictions">
+          <Record>
+            <PropertyValue Property="Updatable" Bool="false"/>
+          </Record>
+        </Annotation>
+        <Annotation Term="Capabilities.DeleteRestrictions">
+          <Record>
+            <PropertyValue Property="Deletable" Bool="false"/>
+          </Record>
+        </Annotation>
+        <Annotation Term="Redfish.Uris">
+          <Collection>
+            <String>/redfish/v1/PowerEquipment/RackPDUs/{PowerDistributionId}/Mains</String>
+            <String>/redfish/v1/PowerEquipment/RackPDUs/{PowerDistributionId}/Branches</String>
+            <String>/redfish/v1/PowerEquipment/FloorPDUs/{PowerDistributionId}/Mains</String>
+            <String>/redfish/v1/PowerEquipment/FloorPDUs/{PowerDistributionId}/Branches</String>
+            <String>/redfish/v1/PowerEquipment/FloorPDUs/{PowerDistributionId}/Subfeeds</String>
+            <String>/redfish/v1/PowerEquipment/TransferSwitches/{PowerDistributionId}/Mains</String>
+            <String>/redfish/v1/PowerEquipment/TransferSwitches/{PowerDistributionId}/Branches</String>
+            <String>/redfish/v1/PowerEquipment/TransferSwitches/{PowerDistributionId}/Feeders</String>
+            <String>/redfish/v1/PowerEquipment/PowerShelves/{PowerDistributionId}/Mains</String>
+            <String>/redfish/v1/PowerEquipment/PowerShelves/{PowerDistributionId}/Branches</String>
+          </Collection>
+        </Annotation>
+        <NavigationProperty Name="Members" Type="Collection(Circuit.Circuit)">
+          <Annotation Term="OData.Permissions" EnumMember="OData.Permission/Read"/>
+          <Annotation Term="OData.Description" String="The members of this collection."/>
+          <Annotation Term="OData.LongDescription" String="This property shall contain an array of links to the members of this collection."/>
+          <Annotation Term="OData.AutoExpandReferences"/>
+          <Annotation Term="Redfish.Required"/>
+        </NavigationProperty>
+      </EntityType>
+    </Schema>
+
+  </edmx:DataServices>
+</edmx:Edmx>

--- a/static/redfish/v1/schema/Circuit_v1.xml
+++ b/static/redfish/v1/schema/Circuit_v1.xml
@@ -1,0 +1,760 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!---->
+<!--################################################################################       -->
+<!--# Redfish Schema:  Circuit v1.3.0                                                      -->
+<!--#                                                                                      -->
+<!--# For a detailed change log, see the README file contained in the DSP8010 bundle,      -->
+<!--# available at http://www.dmtf.org/standards/redfish                                   -->
+<!--# Copyright 2014-2021 DMTF.                                                            -->
+<!--# For the full DMTF copyright policy, see http://www.dmtf.org/about/policies/copyright -->
+<!--################################################################################       -->
+<!---->
+<edmx:Edmx xmlns:edmx="http://docs.oasis-open.org/odata/ns/edmx" Version="4.0">
+
+  <edmx:Reference Uri="http://docs.oasis-open.org/odata/odata/v4.0/errata03/csd01/complete/vocabularies/Org.OData.Core.V1.xml">
+    <edmx:Include Namespace="Org.OData.Core.V1" Alias="OData"/>
+  </edmx:Reference>
+  <edmx:Reference Uri="http://docs.oasis-open.org/odata/odata/v4.0/errata03/csd01/complete/vocabularies/Org.OData.Capabilities.V1.xml">
+    <edmx:Include Namespace="Org.OData.Capabilities.V1" Alias="Capabilities"/>
+  </edmx:Reference>
+  <edmx:Reference Uri="http://docs.oasis-open.org/odata/odata/v4.0/errata03/csd01/complete/vocabularies/Org.OData.Measures.V1.xml">
+    <edmx:Include Namespace="Org.OData.Measures.V1" Alias="Measures"/>
+  </edmx:Reference>
+  <edmx:Reference Uri="http://redfish.dmtf.org/schemas/v1/RedfishExtensions_v1.xml">
+    <edmx:Include Namespace="RedfishExtensions.v1_0_0" Alias="Redfish"/>
+    <edmx:Include Namespace="Validation.v1_0_0" Alias="Validation"/>
+  </edmx:Reference>
+  <edmx:Reference Uri="http://redfish.dmtf.org/schemas/v1/Resource_v1.xml">
+    <edmx:Include Namespace="Resource"/>
+    <edmx:Include Namespace="Resource.v1_0_0"/>
+  </edmx:Reference>
+  <edmx:Reference Uri="http://redfish.dmtf.org/schemas/v1/Sensor_v1.xml">
+    <edmx:Include Namespace="Sensor"/>
+  </edmx:Reference>
+  <edmx:Reference Uri="http://redfish.dmtf.org/schemas/v1/Outlet_v1.xml">
+    <edmx:Include Namespace="Outlet"/>
+  </edmx:Reference>
+
+  <edmx:DataServices>
+
+    <Schema xmlns="http://docs.oasis-open.org/odata/ns/edm" Namespace="Circuit">
+      <Annotation Term="Redfish.OwningEntity" String="DMTF"/>
+
+      <EntityType Name="Circuit" BaseType="Resource.v1_0_0.Resource" Abstract="true">
+        <Annotation Term="OData.Description" String="This is the schema definition for an electrical circuit."/>
+        <Annotation Term="OData.LongDescription" String="This resource shall be used to represent an electrical circuit for a Redfish implementation."/>
+        <Annotation Term="Capabilities.InsertRestrictions">
+          <Record>
+            <PropertyValue Property="Insertable" Bool="false"/>
+          </Record>
+        </Annotation>
+        <Annotation Term="Capabilities.UpdateRestrictions">
+          <Record>
+            <PropertyValue Property="Updatable" Bool="true"/>
+            <Annotation Term="OData.Description" String="Any writable properties can be updated."/>
+          </Record>
+        </Annotation>
+        <Annotation Term="Capabilities.DeleteRestrictions">
+          <Record>
+            <PropertyValue Property="Deletable" Bool="false"/>
+          </Record>
+        </Annotation>
+        <Annotation Term="Redfish.Uris">
+          <Collection>
+            <String>/redfish/v1/PowerEquipment/RackPDUs/{PowerDistributionId}/Mains/{CircuitId}</String>
+            <String>/redfish/v1/PowerEquipment/RackPDUs/{PowerDistributionId}/Branches/{CircuitId}</String>
+            <String>/redfish/v1/PowerEquipment/FloorPDUs/{PowerDistributionId}/Mains/{CircuitId}</String>
+            <String>/redfish/v1/PowerEquipment/FloorPDUs/{PowerDistributionId}/Branches/{CircuitId}</String>
+            <String>/redfish/v1/PowerEquipment/FloorPDUs/{PowerDistributionId}/Subfeeds/{CircuitId}</String>
+            <String>/redfish/v1/PowerEquipment/TransferSwitches/{PowerDistributionId}/Mains/{CircuitId}</String>
+            <String>/redfish/v1/PowerEquipment/TransferSwitches/{PowerDistributionId}/Branches/{CircuitId}</String>
+            <String>/redfish/v1/PowerEquipment/TransferSwitches/{PowerDistributionId}/Feeders/{CircuitId}</String>
+            <String>/redfish/v1/PowerEquipment/PowerShelves/{PowerDistributionId}/Mains/{CircuitId}</String>
+            <String>/redfish/v1/PowerEquipment/PowerShelves/{PowerDistributionId}/Branches/{CircuitId}</String>
+          </Collection>
+        </Annotation>
+      </EntityType>
+
+      <Action Name="PowerControl" IsBound="true">
+        <Annotation Term="OData.Description" String="This action turns the circuit on or off."/>
+        <Annotation Term="OData.LongDescription" String="This action shall control the power state of the circuit."/>
+        <Parameter Name="Circuit" Type="Circuit.v1_0_0.Actions"/>
+        <Parameter Name="PowerState" Type="Resource.PowerState">
+          <Annotation Term="OData.Description" String="The desired power state of the circuit."/>
+          <Annotation Term="OData.LongDescription" String="This parameter shall contain the desired power state of the circuit."/>
+        </Parameter>
+      </Action>
+
+      <Action Name="BreakerControl" IsBound="true">
+        <Annotation Term="OData.Description" String="This action attempts to reset the circuit breaker."/>
+        <Annotation Term="OData.LongDescription" String="This action shall control the state of the circuit breaker or over-current protection device."/>
+        <Parameter Name="Circuit" Type="Circuit.v1_0_0.Actions"/>
+        <Parameter Name="PowerState" Type="Circuit.PowerState">
+          <Annotation Term="OData.Description" String="The desired power state of the circuit if the breaker is reset successfully."/>
+          <Annotation Term="OData.LongDescription" String="This parameter shall contain the desired power state of the circuit."/>
+        </Parameter>
+      </Action>
+
+      <Action Name="ResetMetrics" IsBound="true">
+        <Annotation Term="OData.Description" String="This action resets metrics related to this circuit."/>
+        <Annotation Term="OData.LongDescription" String="This action shall reset any time intervals or counted values for this circuit."/>
+        <Parameter Name="Circuit" Type="Circuit.v1_0_0.Actions"/>
+      </Action>
+
+      <EnumType Name="PowerState">
+        <Member Name="On">
+          <Annotation Term="OData.Description" String="The circuit is powered on."/>
+        </Member>
+        <Member Name="Off">
+          <Annotation Term="OData.Description" String="The circuit is powered off."/>
+        </Member>
+      </EnumType>
+
+      <EnumType Name="BreakerStates">
+        <Member Name="Normal">
+          <Annotation Term="OData.Description" String="The breaker is powered on."/>
+        </Member>
+        <Member Name="Tripped">
+          <Annotation Term="OData.Description" String="The breaker has been tripped."/>
+        </Member>
+        <Member Name="Off">
+          <Annotation Term="OData.Description" String="The breaker is off."/>
+        </Member>
+      </EnumType>
+
+      <EnumType Name="PowerRestorePolicyTypes">
+        <Annotation Term="OData.Description" String="The enumerations of PowerRestorePolicyTypes specify the choice of power state when power is applied."/>
+        <Member Name="AlwaysOn">
+          <Annotation Term="OData.Description" String="Always power on when external power is applied."/>
+        </Member>
+        <Member Name="AlwaysOff">
+          <Annotation Term="OData.Description" String="Always remain powered off when external power is applied."/>
+        </Member>
+        <Member Name="LastState">
+          <Annotation Term="OData.Description" String="Return to the last power state (on or off) when external power is applied."/>
+        </Member>
+      </EnumType>
+
+      <EnumType Name="PhaseWiringType">
+        <Member Name="OnePhase3Wire">
+          <Annotation Term="OData.Description" String="Single-phase / 3-Wire (Line1, Neutral, Protective Earth)."/>
+          <Annotation Term="OData.LongDescription" String="This value shall represent a Single-phase / 3-Wire (Line1, Neutral, Protective Earth) wiring."/>
+        </Member>
+        <Member Name="TwoPhase3Wire">
+          <Annotation Term="OData.Description" String="Two-phase / 3-Wire (Line1, Line2, Protective Earth)."/>
+          <Annotation Term="OData.LongDescription" String="This value shall represent a Two-phase / 3-Wire (Line1, Line2, Protective Earth) wiring."/>
+        </Member>
+        <Member Name="OneOrTwoPhase3Wire">
+          <Annotation Term="OData.Description" String="Single or Two-Phase / 3-Wire (Line1, Line2 or Neutral, Protective Earth)."/>
+          <Annotation Term="OData.LongDescription" String="This value shall represent a Single or Two-Phase / 3-Wire (Line1, Line2 or Neutral, Protective Earth) wiring.  This value shall be used when both phase configurations are supported.  This is most common where detachable cordsets are used."/>
+        </Member>
+        <Member Name="TwoPhase4Wire">
+          <Annotation Term="OData.Description" String="Two-phase / 4-Wire (Line1, Line2, Neutral, Protective Earth)."/>
+          <Annotation Term="OData.LongDescription" String="This value shall represent a Two-phase / 4-Wire (Line1, Line2, Neutral, Protective Earth) wiring."/>
+        </Member>
+        <Member Name="ThreePhase4Wire">
+          <Annotation Term="OData.Description" String="Three-phase / 4-Wire (Line1, Line2, Line3, Protective Earth)."/>
+          <Annotation Term="OData.LongDescription" String="This value shall represent a Three-phase / 4-Wire (Line1, Line2, Line3, Protective Earth) wiring."/>
+        </Member>
+        <Member Name="ThreePhase5Wire">
+          <Annotation Term="OData.Description" String="Three-phase / 5-Wire (Line1, Line2, Line3, Neutral, Protective Earth)."/>
+          <Annotation Term="OData.LongDescription" String="This value shall represent a Three-phase / 5-Wire (Line1, Line2, Line3, Neutral, Protective Earth) wiring."/>
+        </Member>
+      </EnumType>
+
+      <EnumType Name="NominalVoltageType">
+        <Member Name="AC100To240V">
+          <Annotation Term="OData.Description" String="AC 100-240V nominal."/>
+        </Member>
+        <Member Name="AC100To277V">
+          <Annotation Term="OData.Description" String="AC 100-277V nominal."/>
+        </Member>
+        <Member Name="AC120V">
+          <Annotation Term="OData.Description" String="AC 120V nominal."/>
+        </Member>
+        <Member Name="AC200To240V">
+          <Annotation Term="OData.Description" String="AC 200-240V nominal."/>
+        </Member>
+        <Member Name="AC200To277V">
+          <Annotation Term="OData.Description" String="AC 200-277V nominal."/>
+        </Member>
+        <Member Name="AC208V">
+          <Annotation Term="OData.Description" String="AC 208V nominal."/>
+        </Member>
+        <Member Name="AC230V">
+          <Annotation Term="OData.Description" String="AC 230V nominal."/>
+        </Member>
+        <Member Name="AC240V">
+          <Annotation Term="OData.Description" String="AC 240V nominal."/>
+        </Member>
+        <Member Name="AC240AndDC380V">
+          <Annotation Term="OData.Description" String="AC 200-240V and DC 380V."/>
+        </Member>
+        <Member Name="AC277V">
+          <Annotation Term="OData.Description" String="AC 277V nominal."/>
+        </Member>
+        <Member Name="AC277AndDC380V">
+          <Annotation Term="OData.Description" String="AC 200-277V and DC 380V."/>
+        </Member>
+        <Member Name="AC400V">
+          <Annotation Term="OData.Description" String="AC 400V or 415V nominal."/>
+        </Member>
+        <Member Name="AC480V">
+          <Annotation Term="OData.Description" String="AC 480V nominal."/>
+        </Member>
+        <Member Name="DC48V">
+          <Annotation Term="OData.Description" String="DC 48V nominal."/>
+          <Annotation Term="Redfish.Revisions">
+            <Collection>
+              <Record>
+                <PropertyValue Property="Kind" EnumMember="Redfish.RevisionKind/Added"/>
+                <PropertyValue Property="Version" String="v1_2_0"/>
+              </Record>
+            </Collection>
+          </Annotation>
+        </Member>
+        <Member Name="DC240V">
+          <Annotation Term="OData.Description" String="DC 240V nominal."/>
+        </Member>
+        <Member Name="DC380V">
+          <Annotation Term="OData.Description" String="High Voltage DC (380V)."/>
+        </Member>
+        <Member Name="DCNeg48V">
+          <Annotation Term="OData.Description" String="-48V DC."/>
+        </Member>
+      </EnumType>
+
+      <EnumType Name="PlugType">
+        <Member Name="NEMA_5_15P">
+          <Annotation Term="OData.Description" String="NEMA 5-15P (Single-phase 125V; 15A; 1P3W)."/>
+          <Annotation Term="OData.LongDescription" String="This value shall represent a plug that matches the NEMA specified 5-15 straight (non-locking) plug (Single-phase 125V; 15A; 1P3W)."/>
+        </Member>
+        <Member Name="NEMA_L5_15P">
+          <Annotation Term="OData.Description" String="NEMA L5-15P (Single-phase 125V; 15A; 1P3W)."/>
+          <Annotation Term="OData.LongDescription" String="This value shall represent a plug that matches the NEMA specified locking L5-15 plug (Single-phase 125V; 15A; 1P3W)."/>
+        </Member>
+        <Member Name="NEMA_5_20P">
+          <Annotation Term="OData.Description" String="NEMA 5-20P (Single-phase 125V; 20A; 1P3W)."/>
+          <Annotation Term="OData.LongDescription" String="This value shall represent a plug that matches the NEMA specified 5-20 straight (non-locking) plug that exhibits a T-slot (Single-phase 125V; 20A; 1P3W)."/>
+        </Member>
+        <Member Name="NEMA_L5_20P">
+          <Annotation Term="OData.Description" String="NEMA L5-20P (Single-phase 125V; 20A; 1P3W)."/>
+          <Annotation Term="OData.LongDescription" String="This value shall represent a plug that matches the NEMA specified locking L5-20 plug (Single-phase 125V; 20A; 1P3W)."/>
+        </Member>
+        <Member Name="NEMA_L5_30P">
+          <Annotation Term="OData.Description" String="NEMA L5-30P (Single-phase 125V; 30A; 1P3W)."/>
+          <Annotation Term="OData.LongDescription" String="This value shall represent a plug that matches the NEMA specified locking L5-30 plug (Single-phase 125V; 30A; 1P3W)."/>
+        </Member>
+        <Member Name="NEMA_6_15P">
+          <Annotation Term="OData.Description" String="NEMA 6-15P (Single-phase 250V; 15A; 2P3W)."/>
+          <Annotation Term="OData.LongDescription" String="This value shall represent a plug that matches the NEMA specified 6-15 straight (non-locking) plug (Single-phase 250V; 15A; 2P3W)."/>
+        </Member>
+        <Member Name="NEMA_L6_15P">
+          <Annotation Term="OData.Description" String="NEMA L6-15P (Single-phase 250V; 15A; 2P3W)."/>
+          <Annotation Term="OData.LongDescription" String="This value shall represent a plug that matches the NEMA specified locking L6-15 plug (Single-phase 250V; 15A; 2P3W)."/>
+        </Member>
+        <Member Name="NEMA_6_20P">
+          <Annotation Term="OData.Description" String="NEMA 6-20P (Single-phase 250V; 20A; 2P3W)."/>
+          <Annotation Term="OData.LongDescription" String="This value shall represent a plug that matches the NEMA specified 6-20 straight (non-locking) plug (Single-phase 250V; 20A; 2P3W)."/>
+        </Member>
+        <Member Name="NEMA_L6_20P">
+          <Annotation Term="OData.Description" String="NEMA L6-20P (Single-phase 250V; 20A; 2P3W)."/>
+          <Annotation Term="OData.LongDescription" String="This value shall represent a plug that matches the NEMA specified locking L6-20 plug (Single-phase 250V; 20A; 2P3W)."/>
+        </Member>
+        <Member Name="NEMA_L6_30P">
+          <Annotation Term="OData.Description" String="NEMA L6-30P (Single-phase 250V; 30A; 2P3W)."/>
+          <Annotation Term="OData.LongDescription" String="This value shall represent a plug that matches the NEMA specified locking L6-30 plug (Single-phase 250V; 30A; 2P3W)."/>
+        </Member>
+        <Member Name="NEMA_L14_20P">
+          <Annotation Term="OData.Description" String="NEMA L14-20P (Split-phase 125/250V; 20A; 2P4W)."/>
+          <Annotation Term="OData.LongDescription" String="This value shall represent a plug that matches the NEMA specified locking L14-20 plug (Split-phase 125/250V; 20A; 2P4W)."/>
+        </Member>
+        <Member Name="NEMA_L14_30P">
+          <Annotation Term="OData.Description" String="NEMA L14-30P (Split-phase 125/250V; 30A; 2P4W)."/>
+          <Annotation Term="OData.LongDescription" String="This value shall represent a plug that matches the NEMA specified locking L14-30 plug (Split-phase 125/250V; 30A; 2P4W)."/>
+        </Member>
+        <Member Name="NEMA_L15_20P">
+          <Annotation Term="OData.Description" String="NEMA L15-20P (Three-phase 250V; 20A; 3P4W)."/>
+          <Annotation Term="OData.LongDescription" String="This value shall represent a plug that matches the NEMA specified locking L15-20 plug (Three-phase 250V; 20A; 3P4W)."/>
+        </Member>
+        <Member Name="NEMA_L15_30P">
+          <Annotation Term="OData.Description" String="NEMA L15-30P (Three-phase 250V; 30A; 3P4W)."/>
+          <Annotation Term="OData.LongDescription" String="This value shall represent a plug that matches the NEMA specified locking L15-30 plug (Three-phase 250V; 30A; 3P4W)."/>
+        </Member>
+        <Member Name="NEMA_L21_20P">
+          <Annotation Term="OData.Description" String="NEMA L21-20P (Three-phase 120/208V; 20A; 3P5W)."/>
+          <Annotation Term="OData.LongDescription" String="This value shall represent a plug that matches the NEMA specified locking L21-20 plug (Three-phase 120/208V; 20A; 3P5W)."/>
+        </Member>
+        <Member Name="NEMA_L21_30P">
+          <Annotation Term="OData.Description" String="NEMA L21-30P (Three-phase 120/208V; 30A; 3P5W)."/>
+          <Annotation Term="OData.LongDescription" String="This value shall represent a plug that matches the NEMA specified locking L21-30 plug (Three-phase 120/208V; 30A; 3P5W)."/>
+        </Member>
+        <Member Name="NEMA_L22_20P">
+          <Annotation Term="OData.Description" String="NEMA L22-20P (Three-phase 277/480V; 20A; 3P5W)."/>
+          <Annotation Term="OData.LongDescription" String="This value shall represent a plug that matches the NEMA specified locking L22-20 plug (Three-phase 277/480V; 20A; 3P5W)."/>
+        </Member>
+        <Member Name="NEMA_L22_30P">
+          <Annotation Term="OData.Description" String="NEMA L22-30P (Three-phase 277/480V; 30A; 3P5W)."/>
+          <Annotation Term="OData.LongDescription" String="This value shall represent a plug that matches the NEMA specified locking L22-30 plug (Three-phase 277/480V; 30A; 3P5W)."/>
+        </Member>
+        <Member Name="California_CS8265">
+          <Annotation Term="OData.Description" String="California Standard CS8265 (Single-phase 250V; 50A; 2P3W)."/>
+          <Annotation Term="OData.LongDescription" String="This value shall represent a plug that matches the 'California Standard' CS8265 style plug (Three-phase 250V; 50A; 3P4W)."/>
+        </Member>
+        <Member Name="California_CS8365">
+          <Annotation Term="OData.Description" String="California Standard CS8365 (Three-phase 250V; 50A; 3P4W)."/>
+          <Annotation Term="OData.LongDescription" String="This value shall represent a plug that matches the 'California Standard' CS8365 style plug (Three-phase 250V; 50A; 3P4W)."/>
+        </Member>
+        <Member Name="IEC_60320_C14">
+          <Annotation Term="OData.Description" String="IEC C14 (Single-phase 250V; 10A; 1P3W)."/>
+          <Annotation Term="OData.LongDescription" String="This value shall represent a plug that matches the IEC 60320 specified C14 input (Single-phase 250V; 10A; 1P3W)."/>
+        </Member>
+        <Member Name="IEC_60320_C20">
+          <Annotation Term="OData.Description" String="IEC C20 (Single-phase 250V; 16A; 1P3W)."/>
+          <Annotation Term="OData.LongDescription" String="This value shall represent a plug that matches the IEC 60320 specified C20 input (Single-phase 250V; 16A; 1P3W)."/>
+        </Member>
+        <Member Name="IEC_60309_316P6">
+          <Annotation Term="OData.Description" String="IEC 60309 316P6 (Single-phase 200-250V; 16A; 1P3W; Blue, 6-hour)."/>
+          <Annotation Term="OData.LongDescription" String="This value shall represent a plug that matches the IEC 60309 316P6 plug (Single-phase 200-250V; 16A; 1P3W; Blue, 6-hour)."/>
+        </Member>
+        <Member Name="IEC_60309_332P6">
+          <Annotation Term="OData.Description" String="IEC 60309 332P6 (Single-phase 200-250V; 32A; 1P3W; Blue, 6-hour)."/>
+          <Annotation Term="OData.LongDescription" String="This value shall represent a plug that matches the IEC 60309 332P6 plug (Single-phase 200-250V; 32A; 1P3W; Blue, 6-hour)."/>
+        </Member>
+        <Member Name="IEC_60309_363P6">
+          <Annotation Term="OData.Description" String="IEC 60309 363P6 (Single-phase 200-250V; 63A; 1P3W; Blue, 6-hour)."/>
+          <Annotation Term="OData.LongDescription" String="This value shall represent a plug that matches the IEC 60309 363P6 plug (Single-phase 200-250V; 63A; 1P3W; Blue, 6-hour)."/>
+        </Member>
+        <Member Name="IEC_60309_516P6">
+          <Annotation Term="OData.Description" String="IEC 60309 516P6 (Three-phase 200-240/346-415V; 16A; 3P5W; Red; 6-hour)."/>
+          <Annotation Term="OData.LongDescription" String="This value shall represent a plug that matches the IEC 60309 516P6 plug (Three-phase 200-240/346-415V; 16A; 3P5W; Red; 6-hour)."/>
+        </Member>
+        <Member Name="IEC_60309_532P6">
+          <Annotation Term="OData.Description" String="IEC 60309 532P6 (Three-phase 200-240/346-415V; 32A; 3P5W; Red; 6-hour)."/>
+          <Annotation Term="OData.LongDescription" String="This value shall represent a plug that matches the IEC 60309 plug 532P6 (Three-phase 200-240/346-415V; 32A; 3P5W; Red; 6-hour)."/>
+        </Member>
+        <Member Name="IEC_60309_563P6">
+          <Annotation Term="OData.Description" String="IEC 60309 563P6 (Three-phase 200-240/346-415V; 63A; 3P5W; Red; 6-hour)."/>
+          <Annotation Term="OData.LongDescription" String="This value shall represent a plug that matches the IEC 60309 563P6 plug (Three-phase 200-240/346-415V; 63A; 3P5W; Red; 6-hour)."/>
+        </Member>
+        <Member Name="IEC_60309_460P9">
+          <Annotation Term="OData.Description" String="IEC 60309 460P9 (Three-phase 200-250V; 60A; 3P4W; Blue; 9-hour)."/>
+          <Annotation Term="OData.LongDescription" String="This value shall represent a plug that matches the IEC 60309 460P9 plug (Three-phase 200-250V; 60A; 3P4W; Blue; 9-hour)."/>
+        </Member>
+        <Member Name="IEC_60309_560P9">
+          <Annotation Term="OData.Description" String="IEC 60309 560P9 (Three-phase 120-144/208-250V; 60A; 3P5W; Blue; 9-hour)."/>
+          <Annotation Term="OData.LongDescription" String="This value shall represent a plug that matches the IEC 60309 plug 560P9 (Three-phase 120-144/208-250V; 60A; 3P5W; Blue; 9-hour)."/>
+        </Member>
+        <Member Name="Field_208V_3P4W_60A">
+          <Annotation Term="OData.Description" String="Field-wired; Three-phase 200-250V; 60A; 3P4W."/>
+          <Annotation Term="OData.LongDescription" String="This value shall represent field-wired input is three-phase 200-250V; 60A; 3P4W.  It is appropriate for use on a 60A branch circuit."/>
+        </Member>
+        <Member Name="Field_400V_3P5W_32A">
+          <Annotation Term="OData.Description" String="Field-wired; Three-phase 200-240/346-415V; 32A; 3P5W."/>
+          <Annotation Term="OData.LongDescription" String="This value shall represent field-wired input is three-phase 200-240/346-415V; 32A; 3P5W.  It is appropriate for use on a 30, 32A, or 40A branch circuit."/>
+        </Member>
+      </EnumType>
+    </Schema>
+
+    <Schema xmlns="http://docs.oasis-open.org/odata/ns/edm" Namespace="Circuit.v1_0_0">
+      <Annotation Term="Redfish.OwningEntity" String="DMTF"/>
+      <Annotation Term="Redfish.Release" String="2019.4"/>
+      <EntityType Name="Circuit" BaseType="Circuit.Circuit">
+        <Property Name="Status" Type="Resource.Status" Nullable="false">
+          <Annotation Term="OData.Description" String="The status and health of the resource and its subordinate or dependent resources."/>
+          <Annotation Term="OData.LongDescription" String="This property shall contain any status or health properties of the resource."/>
+        </Property>
+        <Property Name="CircuitType" Type="Circuit.v1_0_0.CircuitType">
+          <Annotation Term="OData.Permissions" EnumMember="OData.Permission/Read"/>
+          <Annotation Term="OData.Description" String="The type of circuit."/>
+          <Annotation Term="OData.LongDescription" String="This property shall contain the type of circuit."/>
+        </Property>
+        <Property Name="CriticalCircuit" Type="Edm.Boolean">
+          <Annotation Term="OData.Permissions" EnumMember="OData.Permission/ReadWrite"/>
+          <Annotation Term="OData.Description" String="Designates if this is a critical circuit."/>
+          <Annotation Term="OData.LongDescription" String="This property shall indicate whether the circuit is designated as a critical circuit, and therefore is excluded from autonomous logic that could affect the state of the circuit.  The value shall be `true` if the circuit is deemed critical, and `false` if the circuit is not critical."/>
+        </Property>
+        <Property Name="ElectricalContext" Type="Sensor.ElectricalContext">
+          <Annotation Term="OData.Permissions" EnumMember="OData.Permission/Read"/>
+          <Annotation Term="OData.Description" String="The combination of current-carrying conductors."/>
+          <Annotation Term="OData.LongDescription" String="This property shall contain the combination of current-carrying conductors that distribute power."/>
+        </Property>
+        <Property Name="PhaseWiringType" Type="Circuit.PhaseWiringType">
+          <Annotation Term="OData.Permissions" EnumMember="OData.Permission/Read"/>
+          <Annotation Term="OData.Description" String="The number of ungrounded current-carrying conductors (phases) and the total number of conductors (wires)."/>
+          <Annotation Term="OData.LongDescription" String="This property shall contain the number of ungrounded current-carrying conductors (phases) and the total number of conductors (wires)."/>
+        </Property>
+        <Property Name="VoltageType" Type="Circuit.v1_0_0.VoltageType">
+          <Annotation Term="OData.Permissions" EnumMember="OData.Permission/Read"/>
+          <Annotation Term="OData.Description" String="The type of voltage applied to the circuit."/>
+          <Annotation Term="OData.LongDescription" String="This property shall contain the type of voltage applied to the circuit."/>
+        </Property>
+        <Property Name="PlugType" Type="Circuit.PlugType">
+          <Annotation Term="OData.Permissions" EnumMember="OData.Permission/Read"/>
+          <Annotation Term="OData.Description" String="The type of plug according to NEMA, IEC, or regional standards."/>
+          <Annotation Term="OData.LongDescription" String="This property shall contain the type of physical plug used for this circuit, as defined by IEC, NEMA, or regional standard."/>
+        </Property>
+        <Property Name="NominalVoltage" Type="Circuit.NominalVoltageType">
+          <Annotation Term="OData.Permissions" EnumMember="OData.Permission/Read"/>
+          <Annotation Term="OData.Description" String="The nominal voltage for this circuit."/>
+          <Annotation Term="OData.LongDescription" String="This property shall contain the nominal voltage for this circuit, in Volts."/>
+        </Property>
+        <Property Name="RatedCurrentAmps" Type="Edm.Decimal">
+          <Annotation Term="OData.Permissions" EnumMember="OData.Permission/Read"/>
+          <Annotation Term="OData.Description" String="The rated maximum current allowed for this circuit."/>
+          <Annotation Term="OData.LongDescription" String="This property shall contain the rated maximum current for this circuit, in Amps, after any required de-rating, due to safety agency or other regulatory requirements, has been applied."/>
+          <Annotation Term="Measures.Unit" String="A"/>
+          <Annotation Term="Validation.Minimum" Int="0"/>
+        </Property>
+        <Property Name="IndicatorLED" Type="Resource.IndicatorLED">
+          <Annotation Term="OData.Permissions" EnumMember="OData.Permission/ReadWrite"/>
+          <Annotation Term="OData.Description" String="The state of the indicator LED, which identifies the circuit."/>
+          <Annotation Term="OData.LongDescription" String="This property shall contain the indicator light state for the indicator light associated with this circuit."/>
+          <Annotation Term="Redfish.Revisions">
+            <Collection>
+              <Record>
+                <PropertyValue Property="Kind" EnumMember="Redfish.RevisionKind/Deprecated"/>
+                <PropertyValue Property="Version" String="v1_1_0"/>
+                <PropertyValue Property="Description" String="This property has been deprecated in favor of the LocationIndicatorActive property."/>
+              </Record>
+            </Collection>
+          </Annotation>
+        </Property>
+        <Property Name="BreakerState" Type="Circuit.BreakerStates">
+          <Annotation Term="OData.Permissions" EnumMember="OData.Permission/Read"/>
+          <Annotation Term="OData.Description" String="The state of the over current protection device."/>
+          <Annotation Term="OData.LongDescription" String="This property shall contain the state of the over current protection device."/>
+        </Property>
+        <Property Name="PowerOnDelaySeconds" Type="Edm.Decimal">
+          <Annotation Term="OData.Permissions" EnumMember="OData.Permission/ReadWrite"/>
+          <Annotation Term="OData.Description" String="The number of seconds to delay power up after a power cycle or a PowerControl action.  Zero seconds indicates no delay to power up."/>
+          <Annotation Term="OData.LongDescription" String="This property shall contain the number of seconds to delay power up after a power cycle or a PowerControl action.  The value `0` shall indicate no delay to power up."/>
+        </Property>
+        <Property Name="PowerOffDelaySeconds" Type="Edm.Decimal">
+          <Annotation Term="OData.Permissions" EnumMember="OData.Permission/ReadWrite"/>
+          <Annotation Term="OData.Description" String="The number of seconds to delay power off after a PowerControl action.  Zero seconds indicates no delay to power off."/>
+          <Annotation Term="OData.LongDescription" String="This property shall contain the number of seconds to delay power off after a PowerControl action.  The value `0` shall indicate no delay to power off."/>
+        </Property>
+        <Property Name="PowerCycleDelaySeconds" Type="Edm.Decimal">
+          <Annotation Term="OData.Permissions" EnumMember="OData.Permission/ReadWrite"/>
+          <Annotation Term="OData.Description" String="The number of seconds to delay power on after a PowerControl action to cycle power.  Zero seconds indicates no delay."/>
+          <Annotation Term="OData.LongDescription" String="This property shall contain the number of seconds to delay power on after a PowerControl action to cycle power.  The value `0` shall indicate no delay to power on."/>
+        </Property>
+        <Property Name="PowerRestoreDelaySeconds" Type="Edm.Decimal">
+          <Annotation Term="OData.Permissions" EnumMember="OData.Permission/ReadWrite"/>
+          <Annotation Term="OData.Description" String="The number of seconds to delay power on after power has been restored.  Zero seconds indicates no delay."/>
+          <Annotation Term="OData.LongDescription" String="This property shall contain the number of seconds to delay power on after a power fault.  The value `0` shall indicate no delay to power on."/>
+        </Property>
+        <Property Name="PowerRestorePolicy" Type="Circuit.PowerRestorePolicyTypes" Nullable="false">
+          <Annotation Term="OData.Permissions" EnumMember="OData.Permission/ReadWrite"/>
+          <Annotation Term="OData.Description" String="The desired power state of the circuit when power is restored after a power loss."/>
+          <Annotation Term="OData.LongDescription" String="This property shall contain the desired PowerState of the circuit when power is applied.  The value `LastState` shall return the circuit to the PowerState it was in when power was lost."/>
+        </Property>
+        <Property Name="PowerState" Type="Resource.PowerState">
+          <Annotation Term="OData.Permissions" EnumMember="OData.Permission/Read"/>
+          <Annotation Term="OData.Description" String="The power state of the circuit."/>
+          <Annotation Term="OData.LongDescription" String="This property shall contain the power state of the circuit."/>
+        </Property>
+        <Property Name="PowerEnabled" Type="Edm.Boolean">
+          <Annotation Term="OData.Permissions" EnumMember="OData.Permission/Read"/>
+          <Annotation Term="OData.Description" String="Indicates if the circuit can be powered."/>
+          <Annotation Term="OData.LongDescription" String="This property shall indicate the power enable state of the circuit.  The value `true` shall indicate that the circuit can be powered on, and `false` shall indicate that the circuit cannot be powered."/>
+        </Property>
+        <NavigationProperty Name="Voltage" Type="Sensor.Sensor">
+          <Annotation Term="Redfish.ExcerptCopy" String="Voltage"/>
+          <Annotation Term="OData.Description" String="The voltage reading for this single phase circuit."/>
+          <Annotation Term="OData.LongDescription" String="This property shall contain the voltage, measured in Volts, for this single phase circuit.  This property shall not appear in resource instances representing poly-phase circuits."/>
+        </NavigationProperty>
+        <NavigationProperty Name="CurrentAmps" Type="Sensor.Sensor">
+          <Annotation Term="Redfish.ExcerptCopy" String="Current"/>
+          <Annotation Term="OData.Description" String="The current reading for this single phase circuit."/>
+          <Annotation Term="OData.LongDescription" String="This property shall contain the current, measured in Amperes, for this single phase circuit.  This property shall not appear in resource instances representing poly-phase circuits."/>
+        </NavigationProperty>
+        <NavigationProperty Name="PowerWatts" Type="Sensor.Sensor">
+          <Annotation Term="Redfish.ExcerptCopy" String="Power"/>
+          <Annotation Term="OData.Description" String="The power reading for this circuit."/>
+          <Annotation Term="OData.LongDescription" String="This property shall contain the total power, measured in Watts, for this circuit, that represents the `Total` ElectricalContext sensor when multiple power sensors exist for this circuit."/>
+        </NavigationProperty>
+        <NavigationProperty Name="EnergykWh" Type="Sensor.Sensor">
+          <Annotation Term="Redfish.ExcerptCopy" String="EnergykWh"/>
+          <Annotation Term="OData.Description" String="The energy reading for this circuit."/>
+          <Annotation Term="OData.LongDescription" String="This property shall contain the total energy, measured in kilowatt-hours (kW.h), for this circuit, that represents the `Total` ElectricalContext sensor when multiple energy sensors exist for this circuit."/>
+        </NavigationProperty>
+        <NavigationProperty Name="FrequencyHz" Type="Sensor.Sensor">
+          <Annotation Term="Redfish.ExcerptCopy"/>
+          <Annotation Term="OData.Description" String="The frequency reading for this circuit."/>
+          <Annotation Term="OData.LongDescription" String="This property shall contain the frequency sensor for this circuit."/>
+        </NavigationProperty>
+        <Property Name="PolyPhaseVoltage" Type="Circuit.v1_0_0.VoltageSensors">
+          <Annotation Term="OData.Description" String="The voltage readings for this circuit."/>
+          <Annotation Term="OData.LongDescription" String="This property shall contain the voltage sensor(s) for this circuit.  For single phase circuits this property shall contain a duplicate copy of the voltage sensor referenced in the VoltageSensor property, if present.  For poly-phase circuits this property should contain multiple voltage sensor readings used to fully describe the circuit."/>
+        </Property>
+        <Property Name="PolyPhaseCurrentAmps" Type="Circuit.v1_0_0.CurrentSensors">
+          <Annotation Term="OData.Description" String="The current readings for this circuit."/>
+          <Annotation Term="OData.LongDescription" String="This property shall contain the current sensor(s) for this circuit.  For single phase circuits this property shall contain a duplicate copy of the current sensor referenced in the CurrentSensor property, if present.  For poly-phase circuits this property should contain multiple current sensor readings used to fully describe the circuit."/>
+        </Property>
+        <Property Name="PolyPhasePowerWatts" Type="Circuit.v1_0_0.PowerSensors">
+          <Annotation Term="OData.Description" String="The power readings for this circuit."/>
+          <Annotation Term="OData.LongDescription" String="This property shall contain the power sensor(s) for this circuit.  For single phase circuits this property shall contain a duplicate copy of the power sensor referenced in the PowerSensor property, if present.  For poly-phase circuits this property should contain multiple power sensor readings used to fully describe the circuit."/>
+        </Property>
+        <Property Name="PolyPhaseEnergykWh" Type="Circuit.v1_0_0.EnergySensors">
+          <Annotation Term="OData.Description" String="The energy readings for this circuit."/>
+          <Annotation Term="OData.LongDescription" String="This property shall contain the energy sensor(s) for this circuit.  For single phase circuits this property shall contain a duplicate copy of the energy sensor referenced in the EnergySensor property, if present.  For poly-phase circuits this property should contain multiple energy sensor readings used to fully describe the circuit."/>
+        </Property>
+        <Property Name="Links" Type="Circuit.v1_0_0.Links" Nullable="false">
+          <Annotation Term="OData.Description" String="The links to other resources that are related to this resource."/>
+          <Annotation Term="OData.LongDescription" String="This property shall contain links to resources that are related to but are not contained by, or subordinate to, this resource."/>
+        </Property>
+        <Property Name="Actions" Type="Circuit.v1_0_0.Actions" Nullable="false">
+          <Annotation Term="OData.Description" String="The available actions for this resource."/>
+          <Annotation Term="OData.LongDescription" String="This property shall contain the available actions for this resource."/>
+        </Property>
+      </EntityType>
+
+      <ComplexType Name="Links" BaseType="Resource.Links">
+        <Annotation Term="OData.Description" String="The links to other resources that are related to this resource."/>
+        <Annotation Term="OData.LongDescription" String="This Redfish Specification-described type shall contain links to resources that are related to but are not contained by, or subordinate to, this resource."/>
+        <NavigationProperty Name="BranchCircuit" Type="Circuit.Circuit">
+          <Annotation Term="OData.Permissions" EnumMember="OData.Permission/Read"/>
+          <Annotation Term="OData.Description" String="A reference to the branch circuit related to this circuit."/>
+          <Annotation Term="OData.LongDescription" String="This property shall contain a link to a resource of type Circuit that represents the branch circuit associated with this circuit."/>
+          <Annotation Term="OData.AutoExpandReferences"/>
+        </NavigationProperty>
+        <NavigationProperty Name="Outlets" Type="Collection(Outlet.Outlet)">
+          <Annotation Term="OData.Permissions" EnumMember="OData.Permission/Read"/>
+          <Annotation Term="OData.Description" String="An array of references to the outlets contained by this circuit."/>
+          <Annotation Term="OData.LongDescription" String="This property shall contain an array of links to resources of type Outlet that represent the outlets associated with this circuit."/>
+          <Annotation Term="OData.AutoExpandReferences"/>
+        </NavigationProperty>
+      </ComplexType>
+
+      <ComplexType Name="Actions">
+        <Annotation Term="OData.AdditionalProperties" Bool="false"/>
+        <Annotation Term="OData.Description" String="The available actions for this resource."/>
+        <Annotation Term="OData.LongDescription" String="This type shall contain the available actions for this resource."/>
+        <Property Name="Oem" Type="Circuit.v1_0_0.OemActions" Nullable="false">
+          <Annotation Term="OData.Description" String="The available OEM-specific actions for this resource."/>
+          <Annotation Term="OData.LongDescription" String="This property shall contain the available OEM-specific actions for this resource."/>
+        </Property>
+      </ComplexType>
+
+      <ComplexType Name="OemActions">
+        <Annotation Term="OData.AdditionalProperties" Bool="true"/>
+        <Annotation Term="OData.Description" String="The available OEM-specific actions for this resource."/>
+        <Annotation Term="OData.LongDescription" String="This type shall contain the available OEM-specific actions for this resource."/>
+      </ComplexType>
+
+      <ComplexType Name="VoltageSensors">
+        <Annotation Term="OData.AdditionalProperties" Bool="false"/>
+        <Annotation Term="OData.Description" String="The voltage readings for this circuit."/>
+        <Annotation Term="OData.LongDescription" String="This type shall contain properties that describe voltage sensor readings for a circuit."/>
+        <NavigationProperty Name="Line1ToLine2" Type="Sensor.Sensor">
+          <Annotation Term="Redfish.ExcerptCopy" String="Voltage"/>
+          <Annotation Term="OData.Description" String="The Line 1 to Line 2 voltage reading for this circuit."/>
+          <Annotation Term="OData.LongDescription" String="This property shall contain a Sensor excerpt of type Voltage that measures voltage between L1 and L2.  This property shall not be present if the circuit does not include an L1-L2 measurement."/>
+        </NavigationProperty>
+        <NavigationProperty Name="Line2ToLine3" Type="Sensor.Sensor">
+          <Annotation Term="Redfish.ExcerptCopy" String="Voltage"/>
+          <Annotation Term="OData.Description" String="The Line 2 to Line 3 voltage reading for this circuit."/>
+          <Annotation Term="OData.LongDescription" String="This property shall contain a Sensor excerpt of type Voltage that measures voltage between L2 and L3.  This property shall not be present if the circuit does not include an L2-L3 measurement."/>
+        </NavigationProperty>
+        <NavigationProperty Name="Line3ToLine1" Type="Sensor.Sensor">
+          <Annotation Term="Redfish.ExcerptCopy" String="Voltage"/>
+          <Annotation Term="OData.Description" String="The Line 3 to Line 1 voltage reading for this circuit."/>
+          <Annotation Term="OData.LongDescription" String="This property shall contain a Sensor excerpt of type Voltage that measures voltage between L3 and L1.  This property shall not be present if the circuit does not include an L3-L1 measurement."/>
+        </NavigationProperty>
+        <NavigationProperty Name="Line1ToNeutral" Type="Sensor.Sensor">
+          <Annotation Term="Redfish.ExcerptCopy" String="Voltage"/>
+          <Annotation Term="OData.Description" String="The Line 1 to Neutral voltage reading for this circuit."/>
+          <Annotation Term="OData.LongDescription" String="This property shall contain a Sensor excerpt of type Voltage that measures voltage between L1 and Neutral.  This property shall not be present if the circuit does not include an L1-Neutral measurement."/>
+        </NavigationProperty>
+        <NavigationProperty Name="Line2ToNeutral" Type="Sensor.Sensor">
+          <Annotation Term="Redfish.ExcerptCopy" String="Voltage"/>
+          <Annotation Term="OData.Description" String="The Line 2 to Neutral voltage reading for this circuit."/>
+          <Annotation Term="OData.LongDescription" String="This property shall contain a Sensor excerpt of type Voltage that measures voltage between L2 and Neutral.  This property shall not be present if the circuit does not include an L2-Neutral measurement."/>
+        </NavigationProperty>
+        <NavigationProperty Name="Line3ToNeutral" Type="Sensor.Sensor">
+          <Annotation Term="Redfish.ExcerptCopy" String="Voltage"/>
+          <Annotation Term="OData.Description" String="The Line 3 to Neutral voltage reading for this circuit."/>
+          <Annotation Term="OData.LongDescription" String="This property shall contain a Sensor excerpt of type Voltage that measures voltage between L3 and Neutral.  This property shall not be present if the circuit does not include an L3-Neutral measurement."/>
+        </NavigationProperty>
+      </ComplexType>
+
+      <ComplexType Name="CurrentSensors">
+        <Annotation Term="OData.AdditionalProperties" Bool="false"/>
+        <Annotation Term="OData.Description" String="The current sensors for this circuit."/>
+        <Annotation Term="OData.LongDescription" String="This type shall contain properties that describe current sensor readings for a circuit."/>
+        <NavigationProperty Name="Line1" Type="Sensor.Sensor">
+          <Annotation Term="Redfish.ExcerptCopy" String="Current"/>
+          <Annotation Term="OData.Description" String="Line 1 current sensor."/>
+          <Annotation Term="OData.LongDescription" String="This property shall contain a Sensor excerpt of type Current that measures current for L1.  This property shall not be present if the circuit does not include an L1 measurement."/>
+        </NavigationProperty>
+        <NavigationProperty Name="Line2" Type="Sensor.Sensor">
+          <Annotation Term="Redfish.ExcerptCopy" String="Current"/>
+          <Annotation Term="OData.Description" String="Line 2 current sensor."/>
+          <Annotation Term="OData.LongDescription" String="This property shall contain a Sensor excerpt of type Current that measures current for L2.  This property shall not be present if the circuit does not include an L2 measurement."/>
+        </NavigationProperty>
+        <NavigationProperty Name="Line3" Type="Sensor.Sensor">
+          <Annotation Term="Redfish.ExcerptCopy" String="Current"/>
+          <Annotation Term="OData.Description" String="Line 3 current sensor."/>
+          <Annotation Term="OData.LongDescription" String="This property shall contain a Sensor excerpt of type Current that measures current for L3.  This property shall not be present if the circuit does not include an L3 measurement."/>
+        </NavigationProperty>
+        <NavigationProperty Name="Neutral" Type="Sensor.Sensor">
+          <Annotation Term="Redfish.ExcerptCopy" String="Current"/>
+          <Annotation Term="OData.Description" String="Neutral line current sensor."/>
+          <Annotation Term="OData.LongDescription" String="This property shall contain a Sensor excerpt of type Current that measures current for the Neutral line.  This property shall not be present if the circuit does not include a Neutral measurement."/>
+        </NavigationProperty>
+      </ComplexType>
+
+      <ComplexType Name="EnergySensors">
+        <Annotation Term="OData.AdditionalProperties" Bool="false"/>
+        <Annotation Term="OData.Description" String="The energy readings for this circuit."/>
+        <Annotation Term="OData.LongDescription" String="This type shall contain properties that describe energy sensor readings for a circuit."/>
+        <NavigationProperty Name="Line1ToLine2" Type="Sensor.Sensor">
+          <Annotation Term="Redfish.ExcerptCopy" String="EnergykWh"/>
+          <Annotation Term="OData.Description" String="The Line 1 to Line 2 energy reading for this circuit."/>
+          <Annotation Term="OData.LongDescription" String="This property shall contain a Sensor excerpt of type EnergykWh that measures energy between L1 and L2.  This property shall not be present if the circuit does not include an L1-L2 measurement."/>
+        </NavigationProperty>
+        <NavigationProperty Name="Line2ToLine3" Type="Sensor.Sensor">
+          <Annotation Term="Redfish.ExcerptCopy" String="EnergykWh"/>
+          <Annotation Term="OData.Description" String="The Line 2 to Line 3 energy reading for this circuit."/>
+          <Annotation Term="OData.LongDescription" String="This property shall contain a Sensor excerpt of type EnergykWh that measures energy between L2 and L3.  This property shall not be present if the circuit does not include an L2-L3 measurement."/>
+        </NavigationProperty>
+        <NavigationProperty Name="Line3ToLine1" Type="Sensor.Sensor">
+          <Annotation Term="Redfish.ExcerptCopy" String="EnergykWh"/>
+          <Annotation Term="OData.Description" String="The Line 3 to Line 1 energy reading for this circuit."/>
+          <Annotation Term="OData.LongDescription" String="This property shall contain a Sensor excerpt of type EnergykWh that measures energy between L3 and L1.  This property shall not be present if the circuit does not include an L3-L1 measurement."/>
+        </NavigationProperty>
+        <NavigationProperty Name="Line1ToNeutral" Type="Sensor.Sensor">
+          <Annotation Term="Redfish.ExcerptCopy" String="EnergykWh"/>
+          <Annotation Term="OData.Description" String="The Line 1 to Neutral energy reading for this circuit."/>
+          <Annotation Term="OData.LongDescription" String="This property shall contain a Sensor excerpt of type EnergykWh that measures energy between L1 and Neutral.  This property shall not be present if the circuit does not include an L1-Neutral measurement."/>
+        </NavigationProperty>
+        <NavigationProperty Name="Line2ToNeutral" Type="Sensor.Sensor">
+          <Annotation Term="Redfish.ExcerptCopy" String="EnergykWh"/>
+          <Annotation Term="OData.Description" String="The Line 2 to Neutral energy reading for this circuit."/>
+          <Annotation Term="OData.LongDescription" String="This property shall contain a Sensor excerpt of type EnergykWh that measures energy between L2 and Neutral.  This property shall not be present if the circuit does not include an L2-Neutral measurement."/>
+        </NavigationProperty>
+        <NavigationProperty Name="Line3ToNeutral" Type="Sensor.Sensor">
+          <Annotation Term="Redfish.ExcerptCopy" String="EnergykWh"/>
+          <Annotation Term="OData.Description" String="The Line 3 to Neutral energy reading for this circuit."/>
+          <Annotation Term="OData.LongDescription" String="This property shall contain a Sensor excerpt of type EnergykWh that measures energy between L3 and Neutral.  This property shall not be present if the circuit does not include an L3-Neutral measurement."/>
+        </NavigationProperty>
+      </ComplexType>
+
+      <ComplexType Name="PowerSensors">
+        <Annotation Term="OData.AdditionalProperties" Bool="false"/>
+        <Annotation Term="OData.Description" String="This property contains the power sensors."/>
+        <Annotation Term="OData.LongDescription" String="This type shall contain properties that describe power sensor readings for a circuit."/>
+        <NavigationProperty Name="Line1ToLine2" Type="Sensor.Sensor">
+          <Annotation Term="Redfish.ExcerptCopy" String="Power"/>
+          <Annotation Term="OData.Description" String="The Line 1 to Line 2 power reading for this circuit."/>
+          <Annotation Term="OData.LongDescription" String="This property shall contain a Sensor excerpt of type Power that measures power between L1 and L2.  This property shall not be present if the circuit does not include an L1-L2 measurement."/>
+        </NavigationProperty>
+        <NavigationProperty Name="Line2ToLine3" Type="Sensor.Sensor">
+          <Annotation Term="Redfish.ExcerptCopy" String="Power"/>
+          <Annotation Term="OData.Description" String="The Line 2 to Line 3 power reading for this circuit."/>
+          <Annotation Term="OData.LongDescription" String="This property shall contain a sensor excerpt of type Power that measures power between L2 and L3.  This property shall not be present if the circuit does not include an L2-L3 measurement."/>
+        </NavigationProperty>
+        <NavigationProperty Name="Line3ToLine1" Type="Sensor.Sensor">
+          <Annotation Term="Redfish.ExcerptCopy" String="Power"/>
+          <Annotation Term="OData.Description" String="The Line 3 to Line 1 power reading for this circuit."/>
+          <Annotation Term="OData.LongDescription" String="This property shall contain a Sensor excerpt of type Power that measures power between L3 and L1.  This property shall not be present if the circuit does not include an L3-L1 measurement."/>
+        </NavigationProperty>
+        <NavigationProperty Name="Line1ToNeutral" Type="Sensor.Sensor">
+          <Annotation Term="Redfish.ExcerptCopy" String="Power"/>
+          <Annotation Term="OData.Description" String="The Line 1 to Neutral power reading for this circuit."/>
+          <Annotation Term="OData.LongDescription" String="This property shall contain a Sensor excerpt of type Power that measures power between L1 and Neutral.  This property shall not be present if the circuit does not include an L1-Neutral measurement."/>
+        </NavigationProperty>
+        <NavigationProperty Name="Line2ToNeutral" Type="Sensor.Sensor">
+          <Annotation Term="Redfish.ExcerptCopy" String="Power"/>
+          <Annotation Term="OData.Description" String="The Line 2 to Neutral power reading for this circuit."/>
+          <Annotation Term="OData.LongDescription" String="This property shall contain a Sensor excerpt of type Power that measures power between L2 and Neutral.  This property shall not be present if the circuit does not include an L2-Neutral measurement."/>
+        </NavigationProperty>
+        <NavigationProperty Name="Line3ToNeutral" Type="Sensor.Sensor">
+          <Annotation Term="Redfish.ExcerptCopy" String="Power"/>
+          <Annotation Term="OData.Description" String="The Line 3 to Neutral power reading for this circuit."/>
+          <Annotation Term="OData.LongDescription" String="This property shall contain a Sensor excerpt of type Power that measures power between L3 and Neutral.  This property shall not be present if the circuit does not include an L3-Neutral measurement."/>
+        </NavigationProperty>
+      </ComplexType>
+
+      <EnumType Name="CircuitType">
+        <Member Name="Mains">
+          <Annotation Term="OData.Description" String="A mains input or utility circuit."/>
+        </Member>
+        <Member Name="Branch">
+          <Annotation Term="OData.Description" String="A branch (output) circuit."/>
+        </Member>
+        <Member Name="Subfeed">
+          <Annotation Term="OData.Description" String="A subfeed (output) circuit."/>
+        </Member>
+        <Member Name="Feeder">
+          <Annotation Term="OData.Description" String="A feeder (output) circuit."/>
+        </Member>
+      </EnumType>
+
+      <EnumType Name="VoltageType">
+        <Member Name="AC">
+          <Annotation Term="OData.Description" String="Alternating Current (AC) circuit."/>
+        </Member>
+        <Member Name="DC">
+          <Annotation Term="OData.Description" String="Direct Current (DC) circuit."/>
+        </Member>
+      </EnumType>
+    </Schema>
+
+    <Schema xmlns="http://docs.oasis-open.org/odata/ns/edm" Namespace="Circuit.v1_0_1">
+      <Annotation Term="Redfish.OwningEntity" String="DMTF"/>
+      <Annotation Term="OData.Description" String="This version was created to correct various typographical errors."/>
+      <EntityType Name="Circuit" BaseType="Circuit.v1_0_0.Circuit"/>
+    </Schema>
+
+    <Schema xmlns="http://docs.oasis-open.org/odata/ns/edm" Namespace="Circuit.v1_0_2">
+      <Annotation Term="Redfish.OwningEntity" String="DMTF"/>
+      <Annotation Term="OData.Description" String="This version was created to correct various typographical errors."/>
+      <EntityType Name="Circuit" BaseType="Circuit.v1_0_1.Circuit"/>
+    </Schema>
+
+    <Schema xmlns="http://docs.oasis-open.org/odata/ns/edm" Namespace="Circuit.v1_1_0">
+      <Annotation Term="Redfish.OwningEntity" String="DMTF"/>
+      <Annotation Term="Redfish.Release" String="2020.3"/>
+      <Annotation Term="OData.Description" String="This version was created to add LocationIndicatorActive and to deprecate IndicatorLED properties."/>
+
+      <EntityType Name="Circuit" BaseType="Circuit.v1_0_1.Circuit">
+        <Property Name="LocationIndicatorActive" Type="Edm.Boolean">
+          <Annotation Term="OData.Permissions" EnumMember="OData.Permission/ReadWrite"/>
+          <Annotation Term="OData.Description" String="An indicator allowing an operator to physically locate this resource."/>
+          <Annotation Term="OData.LongDescription" String="This property shall contain the state of the indicator used to physically identify or locate this resource.  A write to this property shall update the value of IndicatorLED in this resource, if supported, to reflect the implementation of the locating function."/>
+        </Property>
+      </EntityType>
+    </Schema>
+
+    <Schema xmlns="http://docs.oasis-open.org/odata/ns/edm" Namespace="Circuit.v1_1_1">
+      <Annotation Term="Redfish.OwningEntity" String="DMTF"/>
+      <Annotation Term="OData.Description" String="This version was created to correct various typographical errors."/>
+      <EntityType Name="Circuit" BaseType="Circuit.v1_1_0.Circuit"/>
+    </Schema>
+
+    <Schema xmlns="http://docs.oasis-open.org/odata/ns/edm" Namespace="Circuit.v1_2_0">
+      <Annotation Term="Redfish.OwningEntity" String="DMTF"/>
+      <Annotation Term="Redfish.Release" String="2020.4"/>
+      <Annotation Term="OData.Description" String="This version was created to add DC50V to NominalVoltageType."/>
+
+      <EntityType Name="Circuit" BaseType="Circuit.v1_1_1.Circuit"/>
+    </Schema>
+
+    <Schema xmlns="http://docs.oasis-open.org/odata/ns/edm" Namespace="Circuit.v1_3_0">
+      <Annotation Term="Redfish.OwningEntity" String="DMTF"/>
+      <Annotation Term="Redfish.Release" String="2021.2"/>
+
+      <EntityType Name="Circuit" BaseType="Circuit.v1_2_0.Circuit">
+        <NavigationProperty Name="PowerLoadPercent" Type="Sensor.Sensor">
+          <Annotation Term="Redfish.ExcerptCopy"/>
+          <Annotation Term="OData.Description" String="The power load (%) for this circuit."/>
+          <Annotation Term="OData.LongDescription" String="This property shall contain the power load, measured in percent, for this circuit, that represents the `Total` ElectricalContext for this circuit."/>
+        </NavigationProperty>
+      </EntityType>
+    </Schema>
+
+  </edmx:DataServices>
+</edmx:Edmx>

--- a/static/redfish/v1/schema/CollectionCapabilities_v1.xml
+++ b/static/redfish/v1/schema/CollectionCapabilities_v1.xml
@@ -1,0 +1,218 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!---->
+<!--################################################################################       -->
+<!--# Redfish Schema:  CollectionCapabilities v1.3.0                                       -->
+<!--#                                                                                      -->
+<!--# For a detailed change log, see the README file contained in the DSP8010 bundle,      -->
+<!--# available at http://www.dmtf.org/standards/redfish                                   -->
+<!--# Copyright 2014-2021 DMTF.                                                            -->
+<!--# For the full DMTF copyright policy, see http://www.dmtf.org/about/policies/copyright -->
+<!--################################################################################       -->
+<!---->
+<edmx:Edmx xmlns:edmx="http://docs.oasis-open.org/odata/ns/edmx" Version="4.0">
+
+  <edmx:Reference Uri="http://docs.oasis-open.org/odata/odata/v4.0/errata03/csd01/complete/vocabularies/Org.OData.Core.V1.xml">
+    <edmx:Include Namespace="Org.OData.Core.V1" Alias="OData"/>
+  </edmx:Reference>
+  <edmx:Reference Uri="http://redfish.dmtf.org/schemas/v1/RedfishExtensions_v1.xml">
+    <edmx:Include Namespace="RedfishExtensions.v1_0_0" Alias="Redfish"/>
+    <edmx:Include Namespace="Validation.v1_0_0" Alias="Validation"/>
+  </edmx:Reference>
+  <edmx:Reference Uri="http://redfish.dmtf.org/schemas/v1/Resource_v1.xml">
+    <edmx:Include Namespace="Resource"/>
+  </edmx:Reference>
+
+  <edmx:DataServices>
+
+    <Schema xmlns="http://docs.oasis-open.org/odata/ns/edm" Namespace="CollectionCapabilities">
+      <Annotation Term="Redfish.OwningEntity" String="DMTF"/>
+
+      <ComplexType Name="CollectionCapabilities" Abstract="true">
+        <Annotation Term="OData.AdditionalProperties" Bool="false"/>
+        <Annotation Term="OData.Description" String="This type describes the capabilities of a collection."/>
+        <Annotation Term="OData.LongDescription" String="This type shall describe any capabilities of a resource collection in terms of how a client can create resources within the resource collection."/>
+      </ComplexType>
+    </Schema>
+
+    <Schema xmlns="http://docs.oasis-open.org/odata/ns/edm" Namespace="CollectionCapabilities.v1_0_0">
+      <Annotation Term="Redfish.OwningEntity" String="DMTF"/>
+      <Annotation Term="Redfish.Release" String="2017.1"/>
+
+      <ComplexType Name="CollectionCapabilities" BaseType="CollectionCapabilities.CollectionCapabilities">
+        <Property Name="Capabilities" Type="Collection(CollectionCapabilities.v1_0_0.Capability)" Nullable="false">
+          <Annotation Term="OData.Description" String="The list of capabilities supported by this resource."/>
+          <Annotation Term="OData.LongDescription" String="This property shall contain an array of objects that describe the capabilities of this resource collection."/>
+        </Property>
+      </ComplexType>
+
+      <ComplexType Name="Capability">
+        <Annotation Term="OData.AdditionalProperties" Bool="false"/>
+        <Annotation Term="OData.Description" String="This type describes a capability of a collection for a specific use case."/>
+        <Annotation Term="OData.LongDescription" String="This type shall describe a capability of a resource collection in terms of how a client can create resources within the collection for the specified use case."/>
+        <NavigationProperty Name="CapabilitiesObject" Type="Resource.Item" Nullable="false">
+          <Annotation Term="OData.Permissions" EnumMember="OData.Permission/Read"/>
+          <Annotation Term="OData.Description" String="The link to the resource the client can issue a GET request against to understand how to form a POST request for a collection."/>
+          <Annotation Term="OData.LongDescription" String="This property shall contain a link to a resource that matches the type for a resource collection and shall contain annotations that describe the properties allowed in the POST request."/>
+          <Annotation Term="OData.AutoExpandReferences"/>
+          <Annotation Term="Redfish.Required"/>
+        </NavigationProperty>
+        <Property Name="UseCase" Type="CollectionCapabilities.v1_0_0.UseCase" Nullable="false">
+          <Annotation Term="OData.Permissions" EnumMember="OData.Permission/Read"/>
+          <Annotation Term="OData.Description" String="The use case in which a client can issue a POST request to the collection."/>
+          <Annotation Term="OData.LongDescription" String="This property shall contain an enumerated value that describes the use case for this capability instance."/>
+          <Annotation Term="Redfish.Required"/>
+        </Property>
+        <Property Name="Links" Type="CollectionCapabilities.v1_0_0.Links" Nullable="false">
+          <Annotation Term="OData.Description" String="The links to other resources that are related to this resource."/>
+          <Annotation Term="OData.LongDescription" String="This property shall contain links to resources that are related to but are not contained by, or subordinate to, this resource."/>
+          <Annotation Term="Redfish.Required"/>
+        </Property>
+      </ComplexType>
+
+      <EnumType Name="UseCase">
+        <Member Name="ComputerSystemComposition">
+          <Annotation Term="OData.Description" String="This capability describes a client creating a new computer system resource from a set of disaggregated hardware."/>
+        </Member>
+        <Member Name="ComputerSystemConstrainedComposition">
+          <Annotation Term="OData.Description" String="This capability describes a client creating a new computer system resource from a set of constraints."/>
+          <Annotation Term="Redfish.Revisions">
+            <Collection>
+              <Record>
+                <PropertyValue Property="Kind" EnumMember="Redfish.RevisionKind/Added"/>
+                <PropertyValue Property="Version" String="v1_1_0"/>
+              </Record>
+            </Collection>
+          </Annotation>
+        </Member>
+        <Member Name="VolumeCreation">
+          <Annotation Term="OData.Description" String="This capability describes a client creating a new volume resource as part of an existing storage subsystem."/>
+        </Member>
+        <Member Name="ResourceBlockComposition">
+          <Annotation Term="OData.Description" String="This capability describes a client creating a new resource block from a set of other resource blocks."/>
+          <Annotation Term="Redfish.Revisions">
+            <Collection>
+              <Record>
+                <PropertyValue Property="Kind" EnumMember="Redfish.RevisionKind/Added"/>
+                <PropertyValue Property="Version" String="v1_3_0"/>
+              </Record>
+            </Collection>
+          </Annotation>
+        </Member>
+        <Member Name="ResourceBlockConstrainedComposition">
+          <Annotation Term="OData.Description" String="This capability describes a client creating a new resource block from a set of constraints."/>
+          <Annotation Term="Redfish.Revisions">
+            <Collection>
+              <Record>
+                <PropertyValue Property="Kind" EnumMember="Redfish.RevisionKind/Added"/>
+                <PropertyValue Property="Version" String="v1_3_0"/>
+              </Record>
+            </Collection>
+          </Annotation>
+        </Member>
+      </EnumType>
+
+      <ComplexType Name="Links" BaseType="Resource.Links">
+        <Annotation Term="OData.Description" String="The links to other resources that are related to this resource."/>
+        <Annotation Term="OData.LongDescription" String="This Redfish Specification-described type shall contain links to resources that are related to but are not contained by, or subordinate to, this resource."/>
+        <NavigationProperty Name="TargetCollection" Type="Resource.ResourceCollection" Nullable="false">
+          <Annotation Term="OData.Permissions" EnumMember="OData.Permission/Read"/>
+          <Annotation Term="OData.Description" String="The link to the collection that this capabilities structure is describing."/>
+          <Annotation Term="OData.LongDescription" String="This property shall contain a link to a resource collection that this structure describes.  A client can use this structure to understand how to form the POST request for the collection."/>
+          <Annotation Term="OData.AutoExpandReferences"/>
+          <Annotation Term="Redfish.Required"/>
+        </NavigationProperty>
+        <NavigationProperty Name="RelatedItem" Type="Collection(Resource.Item)">
+          <Annotation Term="OData.Permissions" EnumMember="OData.Permission/Read"/>
+          <Annotation Term="OData.Description" String="An array of links to resources associated with this capability."/>
+          <Annotation Term="OData.LongDescription" String="This property shall contain an array of links to resources that are related to this capability."/>
+          <Annotation Term="OData.AutoExpandReferences"/>
+        </NavigationProperty>
+      </ComplexType>
+    </Schema>
+
+    <Schema xmlns="http://docs.oasis-open.org/odata/ns/edm" Namespace="CollectionCapabilities.v1_0_1">
+      <Annotation Term="Redfish.OwningEntity" String="DMTF"/>
+      <Annotation Term="OData.Description" String="This version was created to force the regeneration of JSON Schema so that OData properties are marked as required, and integer properties are marked as integer rather than number."/>
+      <ComplexType Name="CollectionCapabilities" BaseType="CollectionCapabilities.v1_0_0.CollectionCapabilities"/>
+    </Schema>
+
+    <Schema xmlns="http://docs.oasis-open.org/odata/ns/edm" Namespace="CollectionCapabilities.v1_0_2">
+      <Annotation Term="Redfish.OwningEntity" String="DMTF"/>
+      <Annotation Term="OData.Description" String="This version was created to use the new revisions annotation."/>
+      <ComplexType Name="CollectionCapabilities" BaseType="CollectionCapabilities.v1_0_1.CollectionCapabilities"/>
+    </Schema>
+
+    <Schema xmlns="http://docs.oasis-open.org/odata/ns/edm" Namespace="CollectionCapabilities.v1_0_3">
+      <Annotation Term="Redfish.OwningEntity" String="DMTF"/>
+      <Annotation Term="OData.Description" String="This version was created to update descriptions that this schema defines."/>
+      <ComplexType Name="CollectionCapabilities" BaseType="CollectionCapabilities.v1_0_2.CollectionCapabilities"/>
+    </Schema>
+
+    <Schema xmlns="http://docs.oasis-open.org/odata/ns/edm" Namespace="CollectionCapabilities.v1_0_4">
+      <Annotation Term="Redfish.OwningEntity" String="DMTF"/>
+      <Annotation Term="OData.Description" String="This version was created to correct various typographical errors."/>
+      <ComplexType Name="CollectionCapabilities" BaseType="CollectionCapabilities.v1_0_3.CollectionCapabilities"/>
+    </Schema>
+
+    <Schema xmlns="http://docs.oasis-open.org/odata/ns/edm" Namespace="CollectionCapabilities.v1_1_0">
+      <Annotation Term="Redfish.OwningEntity" String="DMTF"/>
+      <Annotation Term="Redfish.Release" String="2018.2"/>
+      <Annotation Term="OData.Description" String="This version was created to add `ComputerSystemConstrainedComposition` to the UseCase enumeration."/>
+
+      <ComplexType Name="CollectionCapabilities" BaseType="CollectionCapabilities.v1_0_1.CollectionCapabilities"/>
+    </Schema>
+
+    <Schema xmlns="http://docs.oasis-open.org/odata/ns/edm" Namespace="CollectionCapabilities.v1_1_1">
+      <Annotation Term="Redfish.OwningEntity" String="DMTF"/>
+      <Annotation Term="OData.Description" String="This version was created to use the new revisions annotation."/>
+      <ComplexType Name="CollectionCapabilities" BaseType="CollectionCapabilities.v1_1_0.CollectionCapabilities"/>
+    </Schema>
+
+    <Schema xmlns="http://docs.oasis-open.org/odata/ns/edm" Namespace="CollectionCapabilities.v1_1_2">
+      <Annotation Term="Redfish.OwningEntity" String="DMTF"/>
+      <Annotation Term="OData.Description" String="This version was created to update descriptions that this schema defines."/>
+      <ComplexType Name="CollectionCapabilities" BaseType="CollectionCapabilities.v1_1_1.CollectionCapabilities"/>
+    </Schema>
+
+    <Schema xmlns="http://docs.oasis-open.org/odata/ns/edm" Namespace="CollectionCapabilities.v1_1_3">
+      <Annotation Term="Redfish.OwningEntity" String="DMTF"/>
+      <Annotation Term="OData.Description" String="This version was created to correct various typographical errors."/>
+      <ComplexType Name="CollectionCapabilities" BaseType="CollectionCapabilities.v1_1_2.CollectionCapabilities"/>
+    </Schema>
+
+    <Schema xmlns="http://docs.oasis-open.org/odata/ns/edm" Namespace="CollectionCapabilities.v1_2_0">
+      <Annotation Term="Redfish.OwningEntity" String="DMTF"/>
+      <Annotation Term="Redfish.Release" String="2019.2"/>
+
+      <ComplexType Name="CollectionCapabilities" BaseType="CollectionCapabilities.v1_1_2.CollectionCapabilities">
+        <Property Name="MaxMembers" Type="Edm.Int64" Nullable="false">
+          <Annotation Term="OData.Permissions" EnumMember="OData.Permission/Read"/>
+          <Annotation Term="OData.Description" String="The maximum number of members allowed in this collection."/>
+          <Annotation Term="OData.LongDescription" String="This property shall contain the maximum number of members allowed in this resource collection."/>
+          <Annotation Term="Validation.Minimum" Int="1"/>
+        </Property>
+      </ComplexType>
+    </Schema>
+
+    <Schema xmlns="http://docs.oasis-open.org/odata/ns/edm" Namespace="CollectionCapabilities.v1_2_1">
+      <Annotation Term="Redfish.OwningEntity" String="DMTF"/>
+      <Annotation Term="OData.Description" String="This version was created to correct various typographical errors."/>
+      <ComplexType Name="CollectionCapabilities" BaseType="CollectionCapabilities.v1_2_0.CollectionCapabilities"/>
+    </Schema>
+
+    <Schema xmlns="http://docs.oasis-open.org/odata/ns/edm" Namespace="CollectionCapabilities.v1_2_2">
+      <Annotation Term="Redfish.OwningEntity" String="DMTF"/>
+      <Annotation Term="OData.Description" String="This version was created specify 64-bit integers in OpenAPI."/>
+      <ComplexType Name="CollectionCapabilities" BaseType="CollectionCapabilities.v1_2_1.CollectionCapabilities"/>
+    </Schema>
+
+    <Schema xmlns="http://docs.oasis-open.org/odata/ns/edm" Namespace="CollectionCapabilities.v1_3_0">
+      <Annotation Term="Redfish.OwningEntity" String="DMTF"/>
+      <Annotation Term="Redfish.Release" String="2020.4"/>
+      <Annotation Term="OData.Description" String="This version was created to add `ResourceBlockComposition` and `ResourceBlockConstrainedComposition` to the UseCase enumeration."/>
+
+      <ComplexType Name="CollectionCapabilities" BaseType="CollectionCapabilities.v1_2_2.CollectionCapabilities"/>
+    </Schema>
+
+  </edmx:DataServices>
+</edmx:Edmx>

--- a/static/redfish/v1/schema/CompositionReservationCollection_v1.xml
+++ b/static/redfish/v1/schema/CompositionReservationCollection_v1.xml
@@ -1,0 +1,69 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!---->
+<!--################################################################################       -->
+<!--# Redfish Schema:  CompositionReservationCollection                                    -->
+<!--#                                                                                      -->
+<!--# For a detailed change log, see the README file contained in the DSP8010 bundle,      -->
+<!--# available at http://www.dmtf.org/standards/redfish                                   -->
+<!--# Copyright 2014-2021 DMTF.                                                            -->
+<!--# For the full DMTF copyright policy, see http://www.dmtf.org/about/policies/copyright -->
+<!--################################################################################       -->
+<!---->
+<edmx:Edmx xmlns:edmx="http://docs.oasis-open.org/odata/ns/edmx" Version="4.0">
+
+  <edmx:Reference Uri="http://docs.oasis-open.org/odata/odata/v4.0/errata03/csd01/complete/vocabularies/Org.OData.Core.V1.xml">
+    <edmx:Include Namespace="Org.OData.Core.V1" Alias="OData"/>
+  </edmx:Reference>
+  <edmx:Reference Uri="http://docs.oasis-open.org/odata/odata/v4.0/errata03/csd01/complete/vocabularies/Org.OData.Capabilities.V1.xml">
+    <edmx:Include Namespace="Org.OData.Capabilities.V1" Alias="Capabilities"/>
+  </edmx:Reference>
+  <edmx:Reference Uri="http://redfish.dmtf.org/schemas/v1/Resource_v1.xml">
+    <edmx:Include Namespace="Resource.v1_0_0"/>
+  </edmx:Reference>
+  <edmx:Reference Uri="http://redfish.dmtf.org/schemas/v1/RedfishExtensions_v1.xml">
+    <edmx:Include Namespace="RedfishExtensions.v1_0_0" Alias="Redfish"/>
+  </edmx:Reference>
+  <edmx:Reference Uri="http://redfish.dmtf.org/schemas/v1/CompositionReservation_v1.xml">
+    <edmx:Include Namespace="CompositionReservation"/>
+  </edmx:Reference>
+
+  <edmx:DataServices>
+
+    <Schema xmlns="http://docs.oasis-open.org/odata/ns/edm" Namespace="CompositionReservationCollection">
+      <Annotation Term="Redfish.OwningEntity" String="DMTF"/>
+
+      <EntityType Name="CompositionReservationCollection" BaseType="Resource.v1_0_0.ResourceCollection">
+        <Annotation Term="OData.Description" String="The collection of CompositionReservation resource instances."/>
+        <Annotation Term="OData.LongDescription" String="This resource shall represent a resource collection of CompositionReservation instances for a Redfish implementation."/>
+        <Annotation Term="Capabilities.InsertRestrictions">
+          <Record>
+            <PropertyValue Property="Insertable" Bool="false"/>
+          </Record>
+        </Annotation>
+        <Annotation Term="Capabilities.UpdateRestrictions">
+          <Record>
+            <PropertyValue Property="Updatable" Bool="false"/>
+          </Record>
+        </Annotation>
+        <Annotation Term="Capabilities.DeleteRestrictions">
+          <Record>
+            <PropertyValue Property="Deletable" Bool="false"/>
+          </Record>
+        </Annotation>
+        <Annotation Term="Redfish.Uris">
+          <Collection>
+            <String>/redfish/v1/CompositionService/CompositionReservations</String>
+          </Collection>
+        </Annotation>
+        <NavigationProperty Name="Members" Type="Collection(CompositionReservation.CompositionReservation)">
+          <Annotation Term="OData.Permissions" EnumMember="OData.Permission/Read"/>
+          <Annotation Term="OData.Description" String="The members of this collection."/>
+          <Annotation Term="OData.LongDescription" String="This property shall contain an array of links to the members of this collection."/>
+          <Annotation Term="OData.AutoExpandReferences"/>
+          <Annotation Term="Redfish.Required"/>
+        </NavigationProperty>
+      </EntityType>
+    </Schema>
+
+  </edmx:DataServices>
+</edmx:Edmx>

--- a/static/redfish/v1/schema/CompositionReservation_v1.xml
+++ b/static/redfish/v1/schema/CompositionReservation_v1.xml
@@ -1,0 +1,112 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!---->
+<!--################################################################################       -->
+<!--# Redfish Schema:  CompositionReservation v1.0.0                                       -->
+<!--#                                                                                      -->
+<!--# For a detailed change log, see the README file contained in the DSP8010 bundle,      -->
+<!--# available at http://www.dmtf.org/standards/redfish                                   -->
+<!--# Copyright 2014-2021 DMTF.                                                            -->
+<!--# For the full DMTF copyright policy, see http://www.dmtf.org/about/policies/copyright -->
+<!--################################################################################       -->
+<!---->
+<edmx:Edmx xmlns:edmx="http://docs.oasis-open.org/odata/ns/edmx" Version="4.0">
+
+  <edmx:Reference Uri="http://docs.oasis-open.org/odata/odata/v4.0/errata03/csd01/complete/vocabularies/Org.OData.Core.V1.xml">
+    <edmx:Include Namespace="Org.OData.Core.V1" Alias="OData"/>
+  </edmx:Reference>
+  <edmx:Reference Uri="http://docs.oasis-open.org/odata/odata/v4.0/errata03/csd01/complete/vocabularies/Org.OData.Capabilities.V1.xml">
+    <edmx:Include Namespace="Org.OData.Capabilities.V1" Alias="Capabilities"/>
+  </edmx:Reference>
+  <edmx:Reference Uri="http://redfish.dmtf.org/schemas/v1/RedfishExtensions_v1.xml">
+    <edmx:Include Namespace="RedfishExtensions.v1_0_0" Alias="Redfish"/>
+  </edmx:Reference>
+  <edmx:Reference Uri="http://redfish.dmtf.org/schemas/v1/Resource_v1.xml">
+    <edmx:Include Namespace="Resource.v1_0_0"/>
+  </edmx:Reference>
+  <edmx:Reference Uri="http://redfish.dmtf.org/schemas/v1/Manifest_v1.xml">
+    <edmx:Include Namespace="Manifest"/>
+  </edmx:Reference>
+  <edmx:Reference Uri="http://redfish.dmtf.org/schemas/v1/ResourceBlock_v1.xml">
+    <edmx:Include Namespace="ResourceBlock"/>
+  </edmx:Reference>
+
+  <edmx:DataServices>
+
+    <Schema xmlns="http://docs.oasis-open.org/odata/ns/edm" Namespace="CompositionReservation">
+      <Annotation Term="Redfish.OwningEntity" String="DMTF"/>
+
+      <EntityType Name="CompositionReservation" BaseType="Resource.v1_0_0.Resource" Abstract="true">
+        <Annotation Term="OData.Description" String="The CompositionReservation schema contains reservation information related to the Compose action defined in the CompositionService resource when the of RequestType parameter contains the value `PreviewReserve`."/>
+        <Annotation Term="OData.LongDescription" String="This resource represents the composition reservation of the composition service for a Redfish implementation."/>
+        <Annotation Term="Capabilities.InsertRestrictions">
+          <Record>
+            <PropertyValue Property="Insertable" Bool="false"/>
+          </Record>
+        </Annotation>
+        <Annotation Term="Capabilities.UpdateRestrictions">
+          <Record>
+            <PropertyValue Property="Updatable" Bool="false"/>
+          </Record>
+        </Annotation>
+        <Annotation Term="Capabilities.DeleteRestrictions">
+          <Record>
+            <PropertyValue Property="Deletable" Bool="true"/>
+          </Record>
+        </Annotation>
+        <Annotation Term="Redfish.Uris">
+          <Collection>
+            <String>/redfish/v1/CompositionService/CompositionReservations/{CompositionReservationId}</String>
+          </Collection>
+        </Annotation>
+      </EntityType>
+    </Schema>
+
+    <Schema xmlns="http://docs.oasis-open.org/odata/ns/edm" Namespace="CompositionReservation.v1_0_0">
+      <Annotation Term="Redfish.OwningEntity" String="DMTF"/>
+      <Annotation Term="Redfish.Release" String="2021.1"/>
+
+      <EntityType Name="CompositionReservation" BaseType="CompositionReservation.CompositionReservation">
+        <Property Name="ReservationTime" Type="Edm.DateTimeOffset" Nullable="false">
+          <Annotation Term="OData.Permissions" EnumMember="OData.Permission/Read"/>
+          <Annotation Term="OData.Description" String="The date time the service created the reservation."/>
+          <Annotation Term="OData.LongDescription" String="This property shall indicate the date and time when the reservation was created by the service."/>
+        </Property>
+        <Property Name="Client" Type="Edm.String" Nullable="false">
+          <Annotation Term="OData.Permissions" EnumMember="OData.Permission/Read"/>
+          <Annotation Term="OData.Description" String="The client that owns the reservation."/>
+          <Annotation Term="OData.LongDescription" String="This property shall contain the client that owns the reservation.  The service shall determine this value based on the client that invoked the Compose action that resulted in the creation of this reservation."/>
+        </Property>
+        <NavigationProperty Name="ReservedResourceBlocks" Type="Collection(ResourceBlock.ResourceBlock)">
+          <Annotation Term="OData.Permissions" EnumMember="OData.Permission/Read"/>
+          <Annotation Term="OData.Description" String="The array of links to the reserved resource blocks."/>
+          <Annotation Term="OData.LongDescription" String="This property shall contain an array of links to resources of type ResourceBlock that represent the reserved resource blocks for this reservation.  Upon deletion of the reservation or when the reservation is applied, the Reserved property in the referenced resource blocks shall change to `false`."/>
+        </NavigationProperty>
+        <Property Name="Manifest" Type="Manifest.Manifest" Nullable="false">
+          <Annotation Term="OData.Description" String="The manifest document processed by the service that resulted in this reservation."/>
+          <Annotation Term="OData.LongDescription" String="This property shall contain the manifest document processed by the service that resulted in this reservation.  This property shall be required if the RequestFormat parameter in the Compose action request contained the value `Manifest`."/>
+        </Property>
+        <Property Name="Actions" Type="CompositionReservation.v1_0_0.Actions" Nullable="false">
+          <Annotation Term="OData.Description" String="The available actions for this resource."/>
+          <Annotation Term="OData.LongDescription" String="This property shall contain the available actions for this resource."/>
+        </Property>
+      </EntityType>
+
+      <ComplexType Name="Actions">
+        <Annotation Term="OData.AdditionalProperties" Bool="false"/>
+        <Annotation Term="OData.Description" String="The available actions for this resource."/>
+        <Annotation Term="OData.LongDescription" String="This type shall contain the available actions for this resource."/>
+        <Property Name="Oem" Type="CompositionReservation.v1_0_0.OemActions" Nullable="false">
+          <Annotation Term="OData.Description" String="The available OEM-specific actions for this resource."/>
+          <Annotation Term="OData.LongDescription" String="This property shall contain the available OEM-specific actions for this resource."/>
+        </Property>
+      </ComplexType>
+
+      <ComplexType Name="OemActions">
+        <Annotation Term="OData.AdditionalProperties" Bool="true"/>
+        <Annotation Term="OData.Description" String="The available OEM-specific actions for this resource."/>
+        <Annotation Term="OData.LongDescription" String="This type shall contain the available OEM-specific actions for this resource."/>
+      </ComplexType>
+    </Schema>
+
+  </edmx:DataServices>
+</edmx:Edmx>

--- a/static/redfish/v1/schema/CompositionService_v1.xml
+++ b/static/redfish/v1/schema/CompositionService_v1.xml
@@ -1,0 +1,296 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!---->
+<!--################################################################################       -->
+<!--# Redfish Schema:  CompositionService v1.2.0                                           -->
+<!--#                                                                                      -->
+<!--# For a detailed change log, see the README file contained in the DSP8010 bundle,      -->
+<!--# available at http://www.dmtf.org/standards/redfish                                   -->
+<!--# Copyright 2014-2021 DMTF.                                                            -->
+<!--# For the full DMTF copyright policy, see http://www.dmtf.org/about/policies/copyright -->
+<!--################################################################################       -->
+<!---->
+<edmx:Edmx xmlns:edmx="http://docs.oasis-open.org/odata/ns/edmx" Version="4.0">
+
+  <edmx:Reference Uri="http://docs.oasis-open.org/odata/odata/v4.0/errata03/csd01/complete/vocabularies/Org.OData.Core.V1.xml">
+    <edmx:Include Namespace="Org.OData.Core.V1" Alias="OData"/>
+  </edmx:Reference>
+  <edmx:Reference Uri="http://docs.oasis-open.org/odata/odata/v4.0/errata03/csd01/complete/vocabularies/Org.OData.Capabilities.V1.xml">
+    <edmx:Include Namespace="Org.OData.Capabilities.V1" Alias="Capabilities"/>
+  </edmx:Reference>
+  <edmx:Reference Uri="http://redfish.dmtf.org/schemas/v1/RedfishExtensions_v1.xml">
+    <edmx:Include Namespace="RedfishExtensions.v1_0_0" Alias="Redfish"/>
+  </edmx:Reference>
+  <edmx:Reference Uri="http://redfish.dmtf.org/schemas/v1/Resource_v1.xml">
+    <edmx:Include Namespace="Resource"/>
+    <edmx:Include Namespace="Resource.v1_0_0"/>
+  </edmx:Reference>
+  <edmx:Reference Uri="http://redfish.dmtf.org/schemas/v1/ResourceBlockCollection_v1.xml">
+    <edmx:Include Namespace="ResourceBlockCollection"/>
+  </edmx:Reference>
+  <edmx:Reference Uri="http://redfish.dmtf.org/schemas/v1/ZoneCollection_v1.xml">
+    <edmx:Include Namespace="ZoneCollection"/>
+  </edmx:Reference>
+  <edmx:Reference Uri="http://redfish.dmtf.org/schemas/v1/Manifest_v1.xml">
+    <edmx:Include Namespace="Manifest"/>
+  </edmx:Reference>
+  <edmx:Reference Uri="http://redfish.dmtf.org/schemas/v1/CompositionReservationCollection_v1.xml">
+    <edmx:Include Namespace="CompositionReservationCollection"/>
+  </edmx:Reference>
+
+  <edmx:DataServices>
+
+    <Schema xmlns="http://docs.oasis-open.org/odata/ns/edm" Namespace="CompositionService">
+      <Annotation Term="Redfish.OwningEntity" String="DMTF"/>
+
+      <EntityType Name="CompositionService" BaseType="Resource.v1_0_0.Resource" Abstract="true">
+        <Annotation Term="OData.Description" String="The CompositionService schema describes a composition service and its properties and links to the resources available for composition."/>
+        <Annotation Term="OData.LongDescription" String="This resource shall represent the composition service and its properties for a Redfish implementation."/>
+        <Annotation Term="Capabilities.InsertRestrictions">
+          <Record>
+            <PropertyValue Property="Insertable" Bool="false"/>
+          </Record>
+        </Annotation>
+        <Annotation Term="Capabilities.UpdateRestrictions">
+          <Record>
+            <PropertyValue Property="Updatable" Bool="true"/>
+            <Annotation Term="OData.Description" String="Some properties, such as ServiceEnabled, can be updated for the composition service."/>
+          </Record>
+        </Annotation>
+        <Annotation Term="Capabilities.DeleteRestrictions">
+          <Record>
+            <PropertyValue Property="Deletable" Bool="false"/>
+          </Record>
+        </Annotation>
+        <Annotation Term="Redfish.Uris">
+          <Collection>
+            <String>/redfish/v1/CompositionService</String>
+          </Collection>
+        </Annotation>
+      </EntityType>
+
+      <Action Name="Compose" IsBound="true">
+        <Annotation Term="OData.Description" String="This action performs a set of operations specified by a manifest."/>
+        <Annotation Term="OData.LongDescription" String="This action shall perform a set of operations specified by a manifest.  Services shall not apply any part of the manifest unless all operations specified by the manifest are successful."/>
+        <Parameter Name="CompositionService" Type="CompositionService.v1_0_0.Actions"/>
+        <Parameter Name="RequestFormat" Type="CompositionService.v1_2_0.ComposeRequestFormat" Nullable="false">
+          <Annotation Term="OData.Description" String="The format of the request."/>
+          <Annotation Term="OData.LongDescription" String="This parameter shall contain the format of the request."/>
+        </Parameter>
+        <Parameter Name="RequestType" Type="CompositionService.v1_2_0.ComposeRequestType" Nullable="false">
+          <Annotation Term="OData.Description" String="The type of request."/>
+          <Annotation Term="OData.LongDescription" String="This parameter shall contain the type of request."/>
+        </Parameter>
+        <Parameter Name="Manifest" Type="Manifest.Manifest">
+          <Annotation Term="OData.Description" String="The manifest containing the compose operation request."/>
+          <Annotation Term="OData.LongDescription" String="This parameter shall contain the manifest containing the compose operation request.  This parameter shall be required if RequestFormat contains the value `Manifest`."/>
+        </Parameter>
+        <Parameter Name="ReservationId" Type="Edm.String">
+          <Annotation Term="OData.Description" String="The identifier of the composition reservation if applying a reservation.  The value for this parameter is obtained from the response of a Compose action where the RequestType parameter contains the value `PreviewReserve`."/>
+          <Annotation Term="OData.LongDescription" String="This parameter shall contain the value of the Id property of the CompositionReservation resource for applying a reservation."/>
+        </Parameter>
+        <ReturnType Type="CompositionService.v1_2_0.ComposeResponse" Nullable="false"/>
+        <Annotation Term="Redfish.Revisions">
+          <Collection>
+            <Record>
+              <PropertyValue Property="Kind" EnumMember="Redfish.RevisionKind/Added"/>
+              <PropertyValue Property="Version" String="v1_2_0"/>
+            </Record>
+          </Collection>
+        </Annotation>
+      </Action>
+    </Schema>
+
+    <Schema xmlns="http://docs.oasis-open.org/odata/ns/edm" Namespace="CompositionService.v1_0_0">
+      <Annotation Term="Redfish.OwningEntity" String="DMTF"/>
+      <Annotation Term="Redfish.Release" String="2017.1"/>
+
+      <EntityType Name="CompositionService" BaseType="CompositionService.CompositionService">
+        <Property Name="Status" Type="Resource.Status" Nullable="false">
+          <Annotation Term="OData.Description" String="The status and health of the resource and its subordinate or dependent resources."/>
+          <Annotation Term="OData.LongDescription" String="This property shall contain any status or health properties of the resource."/>
+        </Property>
+        <Property Name="ServiceEnabled" Type="Edm.Boolean">
+          <Annotation Term="OData.Permissions" EnumMember="OData.Permission/ReadWrite"/>
+          <Annotation Term="OData.Description" String="An indication of whether this service is enabled."/>
+          <Annotation Term="OData.LongDescription" String="This property shall indicate whether this service is enabled."/>
+        </Property>
+        <Property Name="Actions" Type="CompositionService.v1_0_0.Actions" Nullable="false">
+          <Annotation Term="OData.Description" String="The available actions for this resource."/>
+          <Annotation Term="OData.LongDescription" String="This property shall contain the available actions for this resource."/>
+        </Property>
+        <NavigationProperty Name="ResourceBlocks" Type="ResourceBlockCollection.ResourceBlockCollection" ContainsTarget="true" Nullable="false">
+          <Annotation Term="OData.Permissions" EnumMember="OData.Permission/Read"/>
+          <Annotation Term="OData.Description" String="The resource blocks available on the service."/>
+          <Annotation Term="OData.LongDescription" String="This property shall contain a link to a resource collection of type ResourceBlockCollection."/>
+          <Annotation Term="OData.AutoExpandReferences"/>
+        </NavigationProperty>
+        <NavigationProperty Name="ResourceZones" Type="ZoneCollection.ZoneCollection" ContainsTarget="true" Nullable="false">
+          <Annotation Term="OData.Permissions" EnumMember="OData.Permission/Read"/>
+          <Annotation Term="OData.Description" String="The resource zones available on the service."/>
+          <Annotation Term="OData.LongDescription" String="This property shall contain a link to a resource collection of type ZoneCollection."/>
+          <Annotation Term="OData.AutoExpandReferences"/>
+        </NavigationProperty>
+      </EntityType>
+
+      <ComplexType Name="Actions">
+        <Annotation Term="OData.AdditionalProperties" Bool="false"/>
+        <Annotation Term="OData.Description" String="The available actions for this resource."/>
+        <Annotation Term="OData.LongDescription" String="This type shall contain the available actions for this resource."/>
+        <Property Name="Oem" Type="CompositionService.v1_0_0.OemActions" Nullable="false">
+          <Annotation Term="OData.Description" String="The available OEM-specific actions for this resource."/>
+          <Annotation Term="OData.LongDescription" String="This property shall contain the available OEM-specific actions for this resource."/>
+        </Property>
+      </ComplexType>
+
+      <ComplexType Name="OemActions">
+        <Annotation Term="OData.AdditionalProperties" Bool="true"/>
+        <Annotation Term="OData.Description" String="The available OEM-specific actions for this resource."/>
+        <Annotation Term="OData.LongDescription" String="This type shall contain the available OEM-specific actions for this resource."/>
+      </ComplexType>
+    </Schema>
+
+    <Schema xmlns="http://docs.oasis-open.org/odata/ns/edm" Namespace="CompositionService.v1_0_1">
+      <Annotation Term="Redfish.OwningEntity" String="DMTF"/>
+      <Annotation Term="OData.Description" String="This version was created to update the descriptions that this schema defines."/>
+      <EntityType Name="CompositionService" BaseType="CompositionService.v1_0_0.CompositionService"/>
+    </Schema>
+
+    <Schema xmlns="http://docs.oasis-open.org/odata/ns/edm" Namespace="CompositionService.v1_0_2">
+      <Annotation Term="Redfish.OwningEntity" String="DMTF"/>
+      <Annotation Term="OData.Description" String="This version was created to force the regeneration of JSON Schema so that OData properties are marked as required, and integer properties are marked as integer rather than number."/>
+      <EntityType Name="CompositionService" BaseType="CompositionService.v1_0_1.CompositionService"/>
+    </Schema>
+
+    <Schema xmlns="http://docs.oasis-open.org/odata/ns/edm" Namespace="CompositionService.v1_0_3">
+      <Annotation Term="Redfish.OwningEntity" String="DMTF"/>
+      <Annotation Term="OData.Description" String="This version was created to force the regeneration of JSON Schema so that URI properties use the uri-reference format."/>
+      <EntityType Name="CompositionService" BaseType="CompositionService.v1_0_2.CompositionService"/>
+    </Schema>
+
+    <Schema xmlns="http://docs.oasis-open.org/odata/ns/edm" Namespace="CompositionService.v1_0_4">
+      <Annotation Term="Redfish.OwningEntity" String="DMTF"/>
+      <Annotation Term="OData.Description" String="This version was created to update descriptions that this schema defines."/>
+      <EntityType Name="CompositionService" BaseType="CompositionService.v1_0_3.CompositionService"/>
+    </Schema>
+
+    <Schema xmlns="http://docs.oasis-open.org/odata/ns/edm" Namespace="CompositionService.v1_0_5">
+      <Annotation Term="Redfish.OwningEntity" String="DMTF"/>
+      <Annotation Term="OData.Description" String="This version was created to correct various typographical errors."/>
+      <EntityType Name="CompositionService" BaseType="CompositionService.v1_0_4.CompositionService"/>
+    </Schema>
+
+    <Schema xmlns="http://docs.oasis-open.org/odata/ns/edm" Namespace="CompositionService.v1_1_0">
+      <Annotation Term="Redfish.OwningEntity" String="DMTF"/>
+      <Annotation Term="Redfish.Release" String="2018.2"/>
+      <EntityType Name="CompositionService" BaseType="CompositionService.v1_0_2.CompositionService">
+        <Property Name="AllowOverprovisioning" Type="Edm.Boolean">
+          <Annotation Term="OData.Permissions" EnumMember="OData.Permission/ReadWrite"/>
+          <Annotation Term="OData.Description" String="An indication of whether this service is allowed to overprovision a composition relative to the composition request."/>
+          <Annotation Term="OData.LongDescription" String="This property shall indicate whether this service is allowed to overprovision a composition relative to the composition request."/>
+        </Property>
+        <Property Name="AllowZoneAffinity" Type="Edm.Boolean">
+          <Annotation Term="OData.Permissions" EnumMember="OData.Permission/Read"/>
+          <Annotation Term="OData.Description" String="An indication of whether a client can request that a specific resource zone fulfill a composition request."/>
+          <Annotation Term="OData.LongDescription" String="This property shall indicate whether a client can request that a specific resource zone fulfill a composition request."/>
+        </Property>
+      </EntityType>
+    </Schema>
+
+    <Schema xmlns="http://docs.oasis-open.org/odata/ns/edm" Namespace="CompositionService.v1_1_1">
+      <Annotation Term="Redfish.OwningEntity" String="DMTF"/>
+      <Annotation Term="OData.Description" String="This version was created to force the regeneration of JSON Schema so that URI properties use the uri-reference format."/>
+      <EntityType Name="CompositionService" BaseType="CompositionService.v1_1_0.CompositionService"/>
+    </Schema>
+
+    <Schema xmlns="http://docs.oasis-open.org/odata/ns/edm" Namespace="CompositionService.v1_1_2">
+      <Annotation Term="Redfish.OwningEntity" String="DMTF"/>
+      <Annotation Term="OData.Description" String="This version was created to update descriptions that this schema defines."/>
+      <EntityType Name="CompositionService" BaseType="CompositionService.v1_1_1.CompositionService"/>
+    </Schema>
+
+    <Schema xmlns="http://docs.oasis-open.org/odata/ns/edm" Namespace="CompositionService.v1_1_3">
+      <Annotation Term="Redfish.OwningEntity" String="DMTF"/>
+      <Annotation Term="OData.Description" String="This version was created to correct various typographical errors."/>
+      <EntityType Name="CompositionService" BaseType="CompositionService.v1_1_2.CompositionService"/>
+    </Schema>
+
+    <Schema xmlns="http://docs.oasis-open.org/odata/ns/edm" Namespace="CompositionService.v1_2_0">
+      <Annotation Term="Redfish.OwningEntity" String="DMTF"/>
+      <Annotation Term="Redfish.Release" String="2021.1"/>
+      <Annotation Term="OData.Description" String="This version was created to add the ActivePool and FreePool properties, and the Compose action."/>
+
+      <EntityType Name="CompositionService" BaseType="CompositionService.v1_1_3.CompositionService">
+        <NavigationProperty Name="ActivePool" Type="ResourceBlockCollection.ResourceBlockCollection" ContainsTarget="true" Nullable="false">
+          <Annotation Term="OData.Permissions" EnumMember="OData.Permission/Read"/>
+          <Annotation Term="OData.Description" String="The link to the collection of resource blocks within the active pool.  Resource blocks in the active pool are contributing to at least one composed resource as a result of a composition request."/>
+          <Annotation Term="OData.LongDescription" String="This property shall contain a link to a resource collection of type ResourceBlockCollection.  The members of this collection shall represent the resource blocks in the active pool.  Services shall filter members of this collection based on the requesting client."/>
+        </NavigationProperty>
+        <NavigationProperty Name="FreePool" Type="ResourceBlockCollection.ResourceBlockCollection" ContainsTarget="true" Nullable="false">
+          <Annotation Term="OData.Permissions" EnumMember="OData.Permission/Read"/>
+          <Annotation Term="OData.Description" String="The link to the collection of resource blocks within the free pool.  Resource blocks in the free pool are not contributing to any composed resources."/>
+          <Annotation Term="OData.LongDescription" String="This property shall contain a link to a resource collection of type ResourceBlockCollection.  The members of this collection shall represent the resource blocks in the free pool.  Services shall filter members of this collection based on the requesting client."/>
+        </NavigationProperty>
+        <NavigationProperty Name="CompositionReservations" Type="CompositionReservationCollection.CompositionReservationCollection" ContainsTarget="true" Nullable="false">
+          <Annotation Term="OData.Permissions" EnumMember="OData.Permission/Read"/>
+          <Annotation Term="OData.Description" String="The link to the collection of reservations with the composition reservation collection."/>
+          <Annotation Term="OData.LongDescription" String="This property shall contain a link to a resource collection of type CompositionReservationCollection.  The members of this collection shall contain links to reserved resource blocks and the related document that caused the reservations.  Services shall filter members of this collection based on the requesting client."/>
+        </NavigationProperty>
+        <Property Name="ReservationDuration" Type="Edm.Duration">
+          <Annotation Term="OData.Permissions" EnumMember="OData.Permission/ReadWrite"/>
+          <Annotation Term="OData.Description" String="The length of time a composition reservation is held before the service deletes the reservation marks any related resource blocks as no longer reserved."/>
+          <Annotation Term="OData.LongDescription" String="This property shall contain the length of time a composition reservation is held before the service deletes the reservation marks any related resource blocks as no longer reserved."/>
+        </Property>
+      </EntityType>
+
+      <ComplexType Name="ComposeResponse">
+        <Annotation Term="OData.AdditionalProperties" Bool="false"/>
+        <Annotation Term="OData.Description" String="The response body for the Compose action."/>
+        <Annotation Term="OData.LongDescription" String="This type shall contain the properties found in the response body for the Compose action."/>
+        <Property Name="RequestFormat" Type="CompositionService.v1_2_0.ComposeRequestFormat" Nullable="false">
+          <Annotation Term="OData.Permissions" EnumMember="OData.Permission/Read"/>
+          <Annotation Term="OData.Description" String="The format of the request."/>
+          <Annotation Term="OData.LongDescription" String="This property shall contain the format of the request."/>
+          <Annotation Term="Redfish.Required"/>
+        </Property>
+        <Property Name="RequestType" Type="CompositionService.v1_2_0.ComposeRequestType" Nullable="false">
+          <Annotation Term="OData.Permissions" EnumMember="OData.Permission/Read"/>
+          <Annotation Term="OData.Description" String="The type of request."/>
+          <Annotation Term="OData.LongDescription" String="This property shall contain the type of request."/>
+          <Annotation Term="Redfish.Required"/>
+        </Property>
+        <Property Name="Manifest" Type="Manifest.Manifest" Nullable="false">
+          <Annotation Term="OData.Description" String="The manifest containing the compose operation response."/>
+          <Annotation Term="OData.LongDescription" String="This property shall contain the manifest containing the compose operation response.  This property shall be required if RequestFormat contains the value `Manifest`."/>
+        </Property>
+        <Property Name="ReservationId" Type="Edm.String" Nullable="false">
+          <Annotation Term="OData.Permissions" EnumMember="OData.Permission/Read"/>
+          <Annotation Term="OData.Description" String="The identifier of the composition reservation that was created."/>
+          <Annotation Term="OData.LongDescription" String="This property shall contain the value of the Id property of the CompositionReservation resource that was created.  This property shall be required if RequestType contains the value `PreviewReserve`."/>
+        </Property>
+      </ComplexType>
+
+      <EnumType Name="ComposeRequestType">
+        <Member Name="Preview">
+          <Annotation Term="OData.Description" String="Preview the outcome of the operations specified by the manifest."/>
+          <Annotation Term="OData.LongDescription" String="This value shall indicate that the request is to preview the outcome of the operations specified by the manifest to show what the service will do based on the contents of the request, and not affect any resources within the service."/>
+        </Member>
+        <Member Name="PreviewReserve">
+          <Annotation Term="OData.Description" String="Preview the outcome of the operations specified by the manifest and reserve resources."/>
+          <Annotation Term="OData.LongDescription" String="This value shall indicate that the request is to preview the outcome of the operations specified by the manifest to show what the service will do based on the contents of the request.  Resources that would have been affected by this request shall be marked as reserved, but otherwise shall not be affected."/>
+        </Member>
+        <Member Name="Apply">
+          <Annotation Term="OData.Description" String="Perform the requested operations specified by the manifest and modify resources as needed."/>
+          <Annotation Term="OData.LongDescription" String="This value shall indicate that the request is to apply the requested operations specified by the manifest and modify resources as needed."/>
+        </Member>
+      </EnumType>
+
+      <EnumType Name="ComposeRequestFormat">
+        <Member Name="Manifest">
+          <Annotation Term="OData.Description" String="The request body contains a manifest."/>
+          <Annotation Term="OData.LongDescription" String="This value shall indicate that the request contains a manifest as defined by the Redfish Manifest schema."/>
+        </Member>
+      </EnumType>
+    </Schema>
+
+  </edmx:DataServices>
+</edmx:Edmx>

--- a/static/redfish/v1/schema/ConnectionCollection_v1.xml
+++ b/static/redfish/v1/schema/ConnectionCollection_v1.xml
@@ -1,0 +1,69 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!---->
+<!--################################################################################       -->
+<!--# Redfish Schema:  ConnectionCollection                                                -->
+<!--#                                                                                      -->
+<!--# For a detailed change log, see the README file contained in the DSP8010 bundle,      -->
+<!--# available at http://www.dmtf.org/standards/redfish                                   -->
+<!--# Copyright 2014-2021 DMTF.                                                            -->
+<!--# For the full DMTF copyright policy, see http://www.dmtf.org/about/policies/copyright -->
+<!--################################################################################       -->
+<!---->
+<edmx:Edmx xmlns:edmx="http://docs.oasis-open.org/odata/ns/edmx" Version="4.0">
+
+  <edmx:Reference Uri="http://docs.oasis-open.org/odata/odata/v4.0/errata03/csd01/complete/vocabularies/Org.OData.Core.V1.xml">
+    <edmx:Include Namespace="Org.OData.Core.V1" Alias="OData"/>
+  </edmx:Reference>
+  <edmx:Reference Uri="http://docs.oasis-open.org/odata/odata/v4.0/errata03/csd01/complete/vocabularies/Org.OData.Capabilities.V1.xml">
+    <edmx:Include Namespace="Org.OData.Capabilities.V1" Alias="Capabilities"/>
+  </edmx:Reference>
+  <edmx:Reference Uri="http://redfish.dmtf.org/schemas/v1/Resource_v1.xml">
+    <edmx:Include Namespace="Resource.v1_0_0"/>
+  </edmx:Reference>
+  <edmx:Reference Uri="http://redfish.dmtf.org/schemas/v1/RedfishExtensions_v1.xml">
+    <edmx:Include Namespace="RedfishExtensions.v1_0_0" Alias="Redfish"/>
+  </edmx:Reference>
+  <edmx:Reference Uri="http://redfish.dmtf.org/schemas/v1/Connection_v1.xml">
+    <edmx:Include Namespace="Connection"/>
+  </edmx:Reference>
+
+  <edmx:DataServices>
+
+    <Schema xmlns="http://docs.oasis-open.org/odata/ns/edm" Namespace="ConnectionCollection">
+      <Annotation Term="Redfish.OwningEntity" String="DMTF"/>
+
+      <EntityType Name="ConnectionCollection" BaseType="Resource.v1_0_0.ResourceCollection">
+        <Annotation Term="OData.Description" String="The collection of Connection resource instances."/>
+        <Annotation Term="OData.LongDescription" String="This resource shall represent a resource collection of Connection instances for a Redfish implementation."/>
+        <Annotation Term="Capabilities.InsertRestrictions">
+          <Record>
+            <PropertyValue Property="Insertable" Bool="true"/>
+          </Record>
+        </Annotation>
+        <Annotation Term="Capabilities.UpdateRestrictions">
+          <Record>
+            <PropertyValue Property="Updatable" Bool="false"/>
+          </Record>
+        </Annotation>
+        <Annotation Term="Capabilities.DeleteRestrictions">
+          <Record>
+            <PropertyValue Property="Deletable" Bool="false"/>
+          </Record>
+        </Annotation>
+        <Annotation Term="Redfish.Uris">
+          <Collection>
+            <String>/redfish/v1/Fabrics/{FabricId}/Connections</String>
+          </Collection>
+        </Annotation>
+        <NavigationProperty Name="Members" Type="Collection(Connection.Connection)">
+          <Annotation Term="OData.Permissions" EnumMember="OData.Permission/Read"/>
+          <Annotation Term="OData.Description" String="The members of this collection."/>
+          <Annotation Term="OData.LongDescription" String="This property shall contain an array of links to the members of this collection."/>
+          <Annotation Term="OData.AutoExpandReferences"/>
+          <Annotation Term="Redfish.Required"/>
+        </NavigationProperty>
+      </EntityType>
+    </Schema>
+
+  </edmx:DataServices>
+</edmx:Edmx>

--- a/static/redfish/v1/schema/ConnectionMethodCollection_v1.xml
+++ b/static/redfish/v1/schema/ConnectionMethodCollection_v1.xml
@@ -1,0 +1,69 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!---->
+<!--################################################################################       -->
+<!--# Redfish Schema:  ConnectionMethodCollection                                          -->
+<!--#                                                                                      -->
+<!--# For a detailed change log, see the README file contained in the DSP8010 bundle,      -->
+<!--# available at http://www.dmtf.org/standards/redfish                                   -->
+<!--# Copyright 2014-2021 DMTF.                                                            -->
+<!--# For the full DMTF copyright policy, see http://www.dmtf.org/about/policies/copyright -->
+<!--################################################################################       -->
+<!---->
+<edmx:Edmx xmlns:edmx="http://docs.oasis-open.org/odata/ns/edmx" Version="4.0">
+
+  <edmx:Reference Uri="http://docs.oasis-open.org/odata/odata/v4.0/errata03/csd01/complete/vocabularies/Org.OData.Core.V1.xml">
+    <edmx:Include Namespace="Org.OData.Core.V1" Alias="OData"/>
+  </edmx:Reference>
+  <edmx:Reference Uri="http://docs.oasis-open.org/odata/odata/v4.0/errata03/csd01/complete/vocabularies/Org.OData.Capabilities.V1.xml">
+    <edmx:Include Namespace="Org.OData.Capabilities.V1" Alias="Capabilities"/>
+  </edmx:Reference>
+  <edmx:Reference Uri="http://redfish.dmtf.org/schemas/v1/Resource_v1.xml">
+    <edmx:Include Namespace="Resource.v1_0_0"/>
+  </edmx:Reference>
+  <edmx:Reference Uri="http://redfish.dmtf.org/schemas/v1/RedfishExtensions_v1.xml">
+    <edmx:Include Namespace="RedfishExtensions.v1_0_0" Alias="Redfish"/>
+  </edmx:Reference>
+  <edmx:Reference Uri="http://redfish.dmtf.org/schemas/v1/ConnectionMethod_v1.xml">
+    <edmx:Include Namespace="ConnectionMethod"/>
+  </edmx:Reference>
+
+  <edmx:DataServices>
+
+    <Schema xmlns="http://docs.oasis-open.org/odata/ns/edm" Namespace="ConnectionMethodCollection">
+      <Annotation Term="Redfish.OwningEntity" String="DMTF"/>
+
+      <EntityType Name="ConnectionMethodCollection" BaseType="Resource.v1_0_0.ResourceCollection">
+        <Annotation Term="OData.Description" String="The collection of ConnectionMethod resource instances."/>
+        <Annotation Term="OData.LongDescription" String="This resource shall represent a resource collection of ConnectionMethod instances for a Redfish implementation."/>
+        <Annotation Term="Capabilities.InsertRestrictions">
+          <Record>
+            <PropertyValue Property="Insertable" Bool="true"/>
+          </Record>
+        </Annotation>
+        <Annotation Term="Capabilities.UpdateRestrictions">
+          <Record>
+            <PropertyValue Property="Updatable" Bool="false"/>
+          </Record>
+        </Annotation>
+        <Annotation Term="Capabilities.DeleteRestrictions">
+          <Record>
+            <PropertyValue Property="Deletable" Bool="false"/>
+          </Record>
+        </Annotation>
+        <Annotation Term="Redfish.Uris">
+          <Collection>
+            <String>/redfish/v1/AggregationService/ConnectionMethods</String>
+          </Collection>
+        </Annotation>
+        <NavigationProperty Name="Members" Type="Collection(ConnectionMethod.ConnectionMethod)">
+          <Annotation Term="OData.Permissions" EnumMember="OData.Permission/Read"/>
+          <Annotation Term="OData.Description" String="The members of this collection."/>
+          <Annotation Term="OData.LongDescription" String="This property shall contain an array of links to the members of this collection."/>
+          <Annotation Term="OData.AutoExpandReferences"/>
+          <Annotation Term="Redfish.Required"/>
+        </NavigationProperty>
+      </EntityType>
+    </Schema>
+
+  </edmx:DataServices>
+</edmx:Edmx>

--- a/static/redfish/v1/schema/ConnectionMethod_v1.xml
+++ b/static/redfish/v1/schema/ConnectionMethod_v1.xml
@@ -1,0 +1,144 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!---->
+<!--################################################################################       -->
+<!--# Redfish Schema:  ConnectionMethod v1.0.0                                             -->
+<!--#                                                                                      -->
+<!--# For a detailed change log, see the README file contained in the DSP8010 bundle,      -->
+<!--# available at http://www.dmtf.org/standards/redfish                                   -->
+<!--# Copyright 2014-2021 DMTF.                                                            -->
+<!--# For the full DMTF copyright policy, see http://www.dmtf.org/about/policies/copyright -->
+<!--################################################################################       -->
+<!---->
+<edmx:Edmx xmlns:edmx="http://docs.oasis-open.org/odata/ns/edmx" Version="4.0">
+
+  <edmx:Reference Uri="http://docs.oasis-open.org/odata/odata/v4.0/errata03/csd01/complete/vocabularies/Org.OData.Core.V1.xml">
+    <edmx:Include Namespace="Org.OData.Core.V1" Alias="OData"/>
+  </edmx:Reference>
+  <edmx:Reference Uri="http://docs.oasis-open.org/odata/odata/v4.0/errata03/csd01/complete/vocabularies/Org.OData.Capabilities.V1.xml">
+    <edmx:Include Namespace="Org.OData.Capabilities.V1" Alias="Capabilities"/>
+  </edmx:Reference>
+  <edmx:Reference Uri="http://redfish.dmtf.org/schemas/v1/Resource_v1.xml">
+    <edmx:Include Namespace="Resource"/>
+    <edmx:Include Namespace="Resource.v1_0_0"/>
+  </edmx:Reference>
+  <edmx:Reference Uri="http://redfish.dmtf.org/schemas/v1/RedfishExtensions_v1.xml">
+    <edmx:Include Namespace="RedfishExtensions.v1_0_0" Alias="Redfish"/>
+  </edmx:Reference>
+  <edmx:Reference Uri="http://redfish.dmtf.org/schemas/v1/AggregationSource_v1.xml">
+    <edmx:Include Namespace="AggregationSource"/>
+  </edmx:Reference>
+
+  <edmx:DataServices>
+
+    <Schema xmlns="http://docs.oasis-open.org/odata/ns/edm" Namespace="ConnectionMethod">
+      <Annotation Term="Redfish.OwningEntity" String="DMTF"/>
+
+      <EntityType Name="ConnectionMethod" BaseType="Resource.v1_0_0.Resource" Abstract="true">
+        <Annotation Term="OData.Description" String="The ConnectionMethod schema describes the protocol, provider, or other method used to communicate to a given access point for a Redfish aggregation service."/>
+        <Annotation Term="OData.LongDescription" String="This resource shall represent a connection method for a Redfish implementation."/>
+        <Annotation Term="Capabilities.InsertRestrictions">
+          <Record>
+            <PropertyValue Property="Insertable" Bool="false"/>
+          </Record>
+        </Annotation>
+        <Annotation Term="Capabilities.UpdateRestrictions">
+          <Record>
+            <PropertyValue Property="Updatable" Bool="false"/>
+          </Record>
+        </Annotation>
+        <Annotation Term="Capabilities.DeleteRestrictions">
+          <Record>
+            <PropertyValue Property="Deletable" Bool="false"/>
+          </Record>
+        </Annotation>
+        <Annotation Term="Redfish.Uris">
+          <Collection>
+            <String>/redfish/v1/AggregationService/ConnectionMethods/{ConnectionMethodId}</String>
+          </Collection>
+        </Annotation>
+      </EntityType>
+
+    </Schema>
+
+    <Schema xmlns="http://docs.oasis-open.org/odata/ns/edm" Namespace="ConnectionMethod.v1_0_0">
+      <Annotation Term="Redfish.OwningEntity" String="DMTF"/>
+      <Annotation Term="Redfish.Release" String="2020.2"/>
+
+      <EntityType Name="ConnectionMethod" BaseType="ConnectionMethod.ConnectionMethod">
+        <Property Name="ConnectionMethodType" Type="ConnectionMethod.v1_0_0.ConnectionMethodType">
+          <Annotation Term="OData.Permissions" EnumMember="OData.Permission/Read"/>
+          <Annotation Term="OData.Description" String="The type of connection method."/>
+          <Annotation Term="OData.LongDescription" String="This property shall contain an identifier of the connection method."/>
+        </Property>
+        <Property Name="ConnectionMethodVariant" Type="Edm.String">
+          <Annotation Term="OData.Permissions" EnumMember="OData.Permission/Read"/>
+          <Annotation Term="OData.Description" String="The variant of connection method."/>
+          <Annotation Term="OData.LongDescription" String="This property shall contain an additional identifier of the connection method.  This property shall be present if ConnectionMethodType is `OEM`."/>
+        </Property>
+        <Property Name="Links" Type="ConnectionMethod.v1_0_0.Links" Nullable="false">
+          <Annotation Term="OData.Description" String="The links to other resources that are related to this resource."/>
+          <Annotation Term="OData.LongDescription" String="This property shall contain links to resources that are related to but are not contained by, or subordinate to, this resource."/>
+        </Property>
+        <Property Name="Actions" Type="ConnectionMethod.v1_0_0.Actions" Nullable="false">
+          <Annotation Term="OData.Description" String="The available actions for this resource."/>
+          <Annotation Term="OData.LongDescription" String="This property shall contain the available actions for this resource."/>
+        </Property>
+      </EntityType>
+
+      <ComplexType Name="Links" BaseType="Resource.Links">
+        <Annotation Term="OData.Description" String="The links to other resources that are related to this resource."/>
+        <Annotation Term="OData.LongDescription" String="This Redfish Specification-described type shall contain links to resources that are related to but are not contained by, or subordinate to, this resource."/>
+        <NavigationProperty Name="AggregationSources" Type="Collection(AggregationSource.AggregationSource)">
+          <Annotation Term="OData.Permissions" EnumMember="OData.Permission/Read"/>
+          <Annotation Term="OData.Description" String="An array of links to the access points using this connection method."/>
+          <Annotation Term="OData.LongDescription" String="This property shall contain an array of links to resources of type AggregationSource that are using this connection method."/>
+          <Annotation Term="OData.AutoExpandReferences"/>
+        </NavigationProperty>
+      </ComplexType>
+
+      <ComplexType Name="Actions">
+        <Annotation Term="OData.AdditionalProperties" Bool="false"/>
+        <Annotation Term="OData.Description" String="The available actions for this resource."/>
+        <Annotation Term="OData.LongDescription" String="This type shall contain the available actions for this resource."/>
+        <Property Name="Oem" Type="ConnectionMethod.v1_0_0.OemActions" Nullable="false">
+          <Annotation Term="OData.Description" String="The available OEM-specific actions for this resource."/>
+          <Annotation Term="OData.LongDescription" String="This property shall contain the available OEM-specific actions for this resource."/>
+        </Property>
+      </ComplexType>
+
+      <ComplexType Name="OemActions">
+        <Annotation Term="OData.AdditionalProperties" Bool="true"/>
+        <Annotation Term="OData.Description" String="The available OEM-specific actions for this resource."/>
+        <Annotation Term="OData.LongDescription" String="This type shall contain the available OEM-specific actions for this resource."/>
+      </ComplexType>
+
+      <EnumType Name="ConnectionMethodType">
+        <Member Name="Redfish">
+          <Annotation Term="OData.Description" String="Redfish connection method."/>
+          <Annotation Term="OData.LongDescription" String="This value shall indicate the connection method is Redfish."/>
+        </Member>
+        <Member Name="SNMP">
+          <Annotation Term="OData.Description" String="SNMP connection method."/>
+          <Annotation Term="OData.LongDescription" String="This value shall indicate the connection method is SNMP."/>
+        </Member>
+        <Member Name="IPMI15">
+          <Annotation Term="OData.Description" String="IPMI 1.5 connection method."/>
+          <Annotation Term="OData.LongDescription" String="This value shall indicate the connection method is IPMI 1.5."/>
+        </Member>
+        <Member Name="IPMI20">
+          <Annotation Term="OData.Description" String="IPMI 2.0 connection method."/>
+          <Annotation Term="OData.LongDescription" String="This value shall indicate the connection method is IPMI 2.0."/>
+        </Member>
+        <Member Name="NETCONF">
+          <Annotation Term="OData.Description" String="NETCONF connection method."/>
+          <Annotation Term="OData.LongDescription" String="This value shall indicate the connection method is NETCONF."/>
+        </Member>
+        <Member Name="OEM">
+          <Annotation Term="OData.Description" String="OEM connection method."/>
+          <Annotation Term="OData.LongDescription" String="This value shall indicate the connection method is OEM.  The ConnectionMethodVariant property shall contain further identification information."/>
+        </Member>
+      </EnumType>
+    </Schema>
+
+  </edmx:DataServices>
+</edmx:Edmx>

--- a/static/redfish/v1/schema/Connection_v1.xml
+++ b/static/redfish/v1/schema/Connection_v1.xml
@@ -1,0 +1,292 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!---->
+<!--################################################################################       -->
+<!--# Redfish Schema:  Connection v1.1.0                                                   -->
+<!--#                                                                                      -->
+<!--# For a detailed change log, see the README file contained in the DSP8010 bundle,      -->
+<!--# available at http://www.dmtf.org/standards/redfish                                   -->
+<!--# Copyright 2014-2021 DMTF.                                                            -->
+<!--# For the full DMTF copyright policy, see http://www.dmtf.org/about/policies/copyright -->
+<!--################################################################################       -->
+<!---->
+<edmx:Edmx xmlns:edmx="http://docs.oasis-open.org/odata/ns/edmx" Version="4.0">
+
+  <edmx:Reference Uri="http://docs.oasis-open.org/odata/odata/v4.0/errata03/csd01/complete/vocabularies/Org.OData.Core.V1.xml">
+    <edmx:Include Namespace="Org.OData.Core.V1" Alias="OData"/>
+  </edmx:Reference>
+  <edmx:Reference Uri="http://docs.oasis-open.org/odata/odata/v4.0/errata03/csd01/complete/vocabularies/Org.OData.Capabilities.V1.xml">
+    <edmx:Include Namespace="Org.OData.Capabilities.V1" Alias="Capabilities"/>
+  </edmx:Reference>
+  <edmx:Reference Uri="http://docs.oasis-open.org/odata/odata/v4.0/errata03/csd01/complete/vocabularies/Org.OData.Measures.V1.xml">
+    <edmx:Include Namespace="Org.OData.Measures.V1" Alias="Measures"/>
+  </edmx:Reference>
+  <edmx:Reference Uri="http://redfish.dmtf.org/schemas/v1/RedfishExtensions_v1.xml">
+    <edmx:Include Namespace="RedfishExtensions.v1_0_0" Alias="Redfish"/>
+    <edmx:Include Namespace="Validation.v1_0_0" Alias="Validation"/>
+  </edmx:Reference>
+  <edmx:Reference Uri="http://redfish.dmtf.org/schemas/v1/Resource_v1.xml">
+    <edmx:Include Namespace="Resource"/>
+    <edmx:Include Namespace="Resource.v1_0_0"/>
+  </edmx:Reference>
+  <edmx:Reference Uri="http://redfish.dmtf.org/schemas/swordfish/v1/Volume_v1.xml">
+    <edmx:Include Namespace="Volume"/>
+  </edmx:Reference>
+  <edmx:Reference Uri="http://redfish.dmtf.org/schemas/v1/Endpoint_v1.xml">
+    <edmx:Include Namespace="Endpoint"/>
+  </edmx:Reference>
+  <edmx:Reference Uri="http://redfish.dmtf.org/schemas/v1/EndpointGroup_v1.xml">
+    <edmx:Include Namespace="EndpointGroup"/>
+  </edmx:Reference>
+  <edmx:Reference Uri="http://redfish.dmtf.org/schemas/v1/MemoryChunks_v1.xml">
+    <edmx:Include Namespace="MemoryChunks"/>
+  </edmx:Reference>
+
+  <edmx:DataServices>
+
+    <Schema xmlns="http://docs.oasis-open.org/odata/ns/edm" Namespace="Connection">
+      <Annotation Term="Redfish.OwningEntity" String="DMTF"/>
+
+      <EntityType Name="Connection" BaseType="Resource.v1_0_0.Resource" Abstract="true">
+        <Annotation Term="OData.Description" String="The Connection schema describes the access permissions endpoints, or groups of endpoints, have with other resources in the service."/>
+        <Annotation Term="OData.LongDescription" String="This resource shall represent a connection information in the Redfish Specification."/>
+        <Annotation Term="Capabilities.InsertRestrictions">
+          <Record>
+            <PropertyValue Property="Insertable" Bool="false"/>
+          </Record>
+        </Annotation>
+        <Annotation Term="Capabilities.UpdateRestrictions">
+          <Record>
+            <PropertyValue Property="Updatable" Bool="true"/>
+          </Record>
+        </Annotation>
+        <Annotation Term="Capabilities.DeleteRestrictions">
+          <Record>
+            <PropertyValue Property="Deletable" Bool="true"/>
+          </Record>
+        </Annotation>
+        <Annotation Term="Redfish.Uris">
+          <Collection>
+            <String>/redfish/v1/Fabrics/{FabricId}/Connections/{ConnectionId}</String>
+          </Collection>
+        </Annotation>
+      </EntityType>
+    </Schema>
+
+    <Schema xmlns="http://docs.oasis-open.org/odata/ns/edm" Namespace="Connection.v1_0_0">
+      <Annotation Term="Redfish.OwningEntity" String="DMTF"/>
+      <Annotation Term="Redfish.Release" String="2020.3"/>
+
+      <EntityType Name="Connection" BaseType="Connection.Connection">
+        <Property Name="Status" Type="Resource.Status" Nullable="false">
+          <Annotation Term="OData.Description" String="The status and health of the resource and its subordinate or dependent resources."/>
+          <Annotation Term="OData.LongDescription" String="This property shall contain any status or health properties of the resource."/>
+        </Property>
+        <Property Name="ConnectionType" Type="Connection.v1_0_0.ConnectionType">
+          <Annotation Term="OData.Permissions" EnumMember="OData.Permission/Read"/>
+          <Annotation Term="OData.Description" String="The type of resources this connection specifies."/>
+          <Annotation Term="OData.LongDescription" String="This property shall contain the type of resources this connection specifies."/>
+        </Property>
+        <Property Name="VolumeInfo" Type="Collection(Connection.v1_0_0.VolumeInfo)">
+          <Annotation Term="OData.Description" String="The set of volumes and access capabilities specified for this connection."/>
+          <Annotation Term="OData.LongDescription" String="This property shall contain the set of volumes and access capabilities specified for this connection."/>
+        </Property>
+        <Property Name="Links" Type="Connection.v1_0_0.Links" Nullable="false">
+          <Annotation Term="OData.Description" String="The links to other resources that are related to this resource."/>
+          <Annotation Term="OData.LongDescription" String="This property shall contain links to resources that are related to but are not contained by, or subordinate to, this resource."/>
+        </Property>
+        <Property Name="Actions" Type="Connection.v1_0_0.Actions" Nullable="false">
+          <Annotation Term="OData.Description" String="The available actions for this resource."/>
+          <Annotation Term="OData.LongDescription" String="This property shall contain the available actions for this resource."/>
+        </Property>
+      </EntityType>
+
+      <ComplexType Name="VolumeInfo">
+        <Annotation Term="OData.AdditionalProperties" Bool="false"/>
+        <Annotation Term="OData.Description" String="The combination of permissions and volume information."/>
+        <Annotation Term="OData.LongDescription" String="This type shall contain the combination of permissions and volume information."/>
+        <Property Name="AccessCapabilities" Type="Collection(Connection.v1_0_0.AccessCapability)">
+          <Annotation Term="OData.Permissions" EnumMember="OData.Permission/ReadWrite"/>
+          <Annotation Term="OData.Description" String="Supported IO access capabilities."/>
+          <Annotation Term="OData.LongDescription" String="Each entry shall specify a current storage access capability."/>
+        </Property>
+        <Property Name="AccessState" Type="Connection.v1_0_0.AccessState">
+          <Annotation Term="OData.Permissions" EnumMember="OData.Permission/ReadWrite"/>
+          <Annotation Term="OData.Description" String="The access state for this connection."/>
+          <Annotation Term="OData.LongDescription" String="The value of this property shall contain the access state for the associated resource in this connection."/>
+        </Property>
+        <NavigationProperty Name="Volume" Type="Volume.Volume" Nullable="false">
+          <Annotation Term="OData.Permissions" EnumMember="OData.Permission/ReadWrite"/>
+          <Annotation Term="OData.Description" String="The specified volume."/>
+          <Annotation Term="OData.LongDescription" String="This property shall contain a link to a resource of type Volume.  The endpoints referenced by the InitiatorEndpoints or InitiatorEndpointGroups properties shall be given access to this volume as described by this object.  If TargetEndpoints or TargetEndpointGroups is present, the referenced initiator endpoints shall be required to access the referenced volume through one of the referenced target endpoints."/>
+        </NavigationProperty>
+      </ComplexType>
+
+      <EnumType Name="ConnectionType">
+        <Member Name="Storage">
+          <Annotation Term="OData.Description" String="A connection to storage related resources, such as volumes."/>
+        </Member>
+        <Member Name="Memory">
+          <Annotation Term="OData.Description" String="A connection to memory related resources."/>
+        </Member>
+      </EnumType>
+
+      <EnumType Name="AccessCapability">
+        <Member Name="Read">
+          <Annotation Term="OData.Description" String="Endpoints are allowed to perform reads from the specified resource."/>
+        </Member>
+        <Member Name="Write">
+          <Annotation Term="OData.Description" String="Endpoints are allowed to perform writes to the specified resource."/>
+        </Member>
+      </EnumType>
+
+      <EnumType Name="AccessState">
+        <Annotation Term="OData.Description" String="Describes the options for the access characteristics of a resource."/>
+        <Annotation Term="OData.LongDescription" String="This type shall describe the access to the associated resource in this connection."/>
+        <Member Name="Optimized">
+          <Annotation Term="OData.Description" String="The resource is in an active and optimized state."/>
+          <Annotation Term="OData.LongDescription" String="This value shall indicate the resource is in an active and optimized state."/>
+        </Member>
+        <Member Name="NonOptimized">
+          <Annotation Term="OData.Description" String="The resource is in an active and non-optimized state."/>
+          <Annotation Term="OData.LongDescription" String="This value shall indicate the resource is in an active and non-optimized state."/>
+        </Member>
+        <Member Name="Standby">
+          <Annotation Term="OData.Description" String="The resource is in a standby state."/>
+          <Annotation Term="OData.LongDescription" String="This value shall indicate the resource is in a standby state."/>
+        </Member>
+        <Member Name="Unavailable">
+          <Annotation Term="OData.Description" String="The resource is in an unavailable state."/>
+          <Annotation Term="OData.LongDescription" String="This value shall indicate the resource is in an unavailable state."/>
+        </Member>
+        <Member Name="Transitioning">
+          <Annotation Term="OData.Description" String="The resource is transitioning to a new state."/>
+          <Annotation Term="OData.LongDescription" String="This value shall indicate the resource is transitioning to a new state."/>
+        </Member>
+      </EnumType>
+
+      <ComplexType Name="Links" BaseType="Resource.Links">
+        <Annotation Term="OData.Description" String="The links to other resources that are related to this resource."/>
+        <Annotation Term="OData.LongDescription" String="This Redfish Specification-described type shall contain links to resources that are related to but are not contained by, or subordinate to, this resource."/>
+        <NavigationProperty Name="InitiatorEndpoints" Type="Collection(Endpoint.Endpoint)">
+          <Annotation Term="OData.Permissions" EnumMember="OData.Permission/ReadWrite"/>
+          <Annotation Term="OData.Description" String="An array of links to the initiator endpoints that are associated with this connection."/>
+          <Annotation Term="OData.LongDescription" String="This property shall contain an array of links to resources of type Endpoint that are the initiator endpoints associated with this connection.  If the referenced endpoints contain the EntityRole property, the EntityRole property shall contain the value `Initiator` or `Both`.  This property shall not be present if InitiatorEndpointGroups is present."/>
+          <Annotation Term="OData.AutoExpandReferences"/>
+        </NavigationProperty>
+        <NavigationProperty Name="TargetEndpoints" Type="Collection(Endpoint.Endpoint)">
+          <Annotation Term="OData.Permissions" EnumMember="OData.Permission/ReadWrite"/>
+          <Annotation Term="OData.Description" String="An array of links to the target endpoints that are associated with this connection."/>
+          <Annotation Term="OData.LongDescription" String="This property shall contain an array of links to resources of type Endpoint that are the target endpoints associated with this connection.  If the referenced endpoints contain the EntityRole property, the EntityRole property shall contain the value `Target` or `Both`.  This property shall not be present if TargetEndpointGroups is present."/>
+          <Annotation Term="OData.AutoExpandReferences"/>
+        </NavigationProperty>
+        <NavigationProperty Name="InitiatorEndpointGroups" Type="Collection(EndpointGroup.EndpointGroup)">
+          <Annotation Term="OData.Permissions" EnumMember="OData.Permission/ReadWrite"/>
+          <Annotation Term="OData.Description" String="An array of links to the initiator endpoint groups that are associated with this connection."/>
+          <Annotation Term="OData.LongDescription" String="This property shall contain an array of links to resources of type EndpointGroup that are the initiator endpoint groups associated with this connection.  If the referenced endpoint groups contain the GroupType property, the GroupType property shall contain the value `Initiator` or `Client`.  This property shall not be present if InitiatorEndpoints is present."/>
+          <Annotation Term="OData.AutoExpandReferences"/>
+        </NavigationProperty>
+        <NavigationProperty Name="TargetEndpointGroups" Type="Collection(EndpointGroup.EndpointGroup)">
+          <Annotation Term="OData.Permissions" EnumMember="OData.Permission/ReadWrite"/>
+          <Annotation Term="OData.Description" String="An array of links to the target endpoint groups that are associated with this connection."/>
+          <Annotation Term="OData.LongDescription" String="This property shall contain an array of links to resources of type EndpointGroup that are the target endpoint groups associated with this connection.  If the referenced endpoint groups contain the GroupType property, the GroupType property shall contain the value `Target` or `Server`.  This property shall not be present if TargetEndpoints is present."/>
+          <Annotation Term="OData.AutoExpandReferences"/>
+        </NavigationProperty>
+      </ComplexType>
+
+      <ComplexType Name="Actions">
+        <Annotation Term="OData.AdditionalProperties" Bool="false"/>
+        <Annotation Term="OData.Description" String="The available actions for this resource."/>
+        <Annotation Term="OData.LongDescription" String="This type shall contain the available actions for this resource."/>
+        <Property Name="Oem" Type="Connection.v1_0_0.OemActions" Nullable="false">
+          <Annotation Term="OData.Description" String="The available OEM-specific actions for this resource."/>
+          <Annotation Term="OData.LongDescription" String="This property shall contain the available OEM-specific actions for this resource."/>
+        </Property>
+      </ComplexType>
+
+      <ComplexType Name="OemActions">
+        <Annotation Term="OData.AdditionalProperties" Bool="true"/>
+        <Annotation Term="OData.Description" String="The available OEM-specific actions for this resource."/>
+        <Annotation Term="OData.LongDescription" String="This type shall contain the available OEM-specific actions for this resource."/>
+      </ComplexType>
+    </Schema>
+
+    <Schema xmlns="http://docs.oasis-open.org/odata/ns/edm" Namespace="Connection.v1_1_0">
+      <Annotation Term="Redfish.OwningEntity" String="DMTF"/>
+      <Annotation Term="Redfish.Release" String="2021.1"/>
+
+      <EntityType Name="Connection" BaseType="Connection.v1_0_0.Connection">
+        <Property Name="MemoryChunkInfo" Type="Collection(Connection.v1_1_0.MemoryChunkInfo)" Nullable="false">
+          <Annotation Term="OData.AdditionalProperties" Bool="false"/>
+          <Annotation Term="OData.Description" String="The set of memory chunks and access capabilities specified for this connection."/>
+          <Annotation Term="OData.LongDescription" String="This property shall contain the set of memory chunks and access capabilities specified for this connection."/>
+        </Property>
+        <Property Name="ConnectionKeys" Type="Connection.v1_1_0.ConnectionKey" Nullable="false">
+          <Annotation Term="OData.AdditionalProperties" Bool="false"/>
+          <Annotation Term="OData.Description" String="The permission keys required to access the specified resources for this connection."/>
+          <Annotation Term="OData.LongDescription" String="This property shall contain the permissions keys required to access the specified resources for this connection.  Some fabrics require permission checks on transactions from authorized initiators."/>
+        </Property>
+      </EntityType>
+
+      <ComplexType Name="MemoryChunkInfo">
+        <Annotation Term="OData.AdditionalProperties" Bool="false"/>
+        <Annotation Term="OData.Description" String="The combination of permissions and memory chunk information."/>
+        <Annotation Term="OData.LongDescription" String="This type shall contain the combination of permissions and memory chunk information."/>
+        <Property Name="AccessCapabilities" Type="Collection(Connection.v1_0_0.AccessCapability)">
+          <Annotation Term="OData.Permissions" EnumMember="OData.Permission/ReadWrite"/>
+          <Annotation Term="OData.Description" String="Supported IO access capabilities."/>
+          <Annotation Term="OData.LongDescription" String="Each entry shall specify a current memory access capability."/>
+        </Property>
+        <Property Name="AccessState" Type="Connection.v1_0_0.AccessState">
+          <Annotation Term="OData.Permissions" EnumMember="OData.Permission/ReadWrite"/>
+          <Annotation Term="OData.Description" String="The access state for this connection."/>
+          <Annotation Term="OData.LongDescription" String="The value of this property shall contain the access state for the associated resource in this connection."/>
+        </Property>
+        <NavigationProperty Name="MemoryChunk" Type="MemoryChunks.MemoryChunks">
+          <Annotation Term="OData.Permissions" EnumMember="OData.Permission/ReadWrite"/>
+          <Annotation Term="OData.Description" String="The specified memory chunk."/>
+          <Annotation Term="OData.LongDescription" String="This property shall contain a link to a resource of type MemoryChunk.  The endpoints referenced by the InitiatorEndpoints or InitiatorEndpointGroups properties shall be given access to this memory chunk as described by this object.  If TargetEndpoints or TargetEndpointGroups is present, the referenced initiator endpoints shall be required to access the referenced memory chunk through one of the referenced target endpoints."/>
+        </NavigationProperty>
+      </ComplexType>
+
+      <ComplexType Name="ConnectionKey">
+        <Annotation Term="OData.AdditionalProperties" Bool="false"/>
+        <Annotation Term="OData.Description" String="The permission key information required to access the target resources for a connection."/>
+        <Annotation Term="OData.LongDescription" String="This type shall contain the permission key information required to access the target resources for a connection."/>
+        <Property Name="GenZ" Type="Connection.v1_1_0.GenZConnectionKey">
+          <Annotation Term="OData.Description" String="The Gen-Z-specific permission key information for this connection."/>
+          <Annotation Term="OData.LongDescription" String="This property shall contain the Gen-Z-specific permission key information for this connection."/>
+        </Property>
+      </ComplexType>
+
+      <ComplexType Name="GenZConnectionKey">
+        <Annotation Term="OData.AdditionalProperties" Bool="false"/>
+        <Annotation Term="OData.Description" String="The Gen-Z-specific permission key information for a connection."/>
+        <Annotation Term="OData.LongDescription" String="This type shall contain the Gen-Z-specific permission key information for a connection."/>
+        <Property Name="RKeyDomainCheckingEnabled" Type="Edm.Boolean" Nullable="false">
+          <Annotation Term="OData.Permissions" EnumMember="OData.Permission/ReadWrite"/>
+          <Annotation Term="OData.Description" String="Indicates whether Region Key domain checking is enabled for this connection."/>
+          <Annotation Term="OData.LongDescription" String="This property shall indicate whether Region Key domain checking is enabled for this connection."/>
+        </Property>
+        <Property Name="AccessKey" Type="Edm.String" Nullable="false">
+          <Annotation Term="OData.Permissions" EnumMember="OData.Permission/ReadWrite"/>
+          <Annotation Term="OData.Description" String="The Access Key for this connection."/>
+          <Annotation Term="OData.LongDescription" String="This property shall contain the Gen-Z Core Specification-defined Access Key for this connection."/>
+          <Annotation Term="Validation.Pattern" String="^0[xX]([a-fA-F]|[0-9]){2}$"/>
+        </Property>
+        <Property Name="RKeyReadOnlyKey" Type="Edm.String" Nullable="false">
+          <Annotation Term="OData.Permissions" EnumMember="OData.Permission/ReadWrite"/>
+          <Annotation Term="OData.Description" String="The read-only Region Key for this connection."/>
+          <Annotation Term="OData.LongDescription" String="This property shall contain the Gen-Z Core Specification-defined read-only Region Key for this connection."/>
+          <Annotation Term="Validation.Pattern" String="^0[xX](([a-fA-F]|[0-9]){2}){4}$"/>
+        </Property>
+        <Property Name="RKeyReadWriteKey" Type="Edm.String" Nullable="false">
+          <Annotation Term="OData.Permissions" EnumMember="OData.Permission/ReadWrite"/>
+          <Annotation Term="OData.Description" String="The read-write Region Key for this connection."/>
+          <Annotation Term="OData.LongDescription" String="This property shall contain the Gen-Z Core Specification-defined read-write Region Key for this connection."/>
+          <Annotation Term="Validation.Pattern" String="^0[xX](([a-fA-F]|[0-9]){2}){4}$"/>
+        </Property>
+      </ComplexType>
+    </Schema>
+
+  </edmx:DataServices>
+</edmx:Edmx>

--- a/static/redfish/v1/schema/ControlCollection_v1.xml
+++ b/static/redfish/v1/schema/ControlCollection_v1.xml
@@ -1,0 +1,74 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!---->
+<!--################################################################################       -->
+<!--# Redfish Schema:  ControlCollection                                                   -->
+<!--#                                                                                      -->
+<!--# For a detailed change log, see the README file contained in the DSP8010 bundle,      -->
+<!--# available at http://www.dmtf.org/standards/redfish                                   -->
+<!--# Copyright 2014-2021 DMTF.                                                            -->
+<!--# For the full DMTF copyright policy, see http://www.dmtf.org/about/policies/copyright -->
+<!--################################################################################       -->
+<!---->
+<edmx:Edmx xmlns:edmx="http://docs.oasis-open.org/odata/ns/edmx" Version="4.0">
+
+  <edmx:Reference Uri="http://docs.oasis-open.org/odata/odata/v4.0/errata03/csd01/complete/vocabularies/Org.OData.Core.V1.xml">
+    <edmx:Include Namespace="Org.OData.Core.V1" Alias="OData"/>
+  </edmx:Reference>
+  <edmx:Reference Uri="http://docs.oasis-open.org/odata/odata/v4.0/errata03/csd01/complete/vocabularies/Org.OData.Capabilities.V1.xml">
+    <edmx:Include Namespace="Org.OData.Capabilities.V1" Alias="Capabilities"/>
+  </edmx:Reference>
+  <edmx:Reference Uri="http://redfish.dmtf.org/schemas/v1/RedfishExtensions_v1.xml">
+    <edmx:Include Namespace="RedfishExtensions.v1_0_0" Alias="Redfish"/>
+  </edmx:Reference>
+  <edmx:Reference Uri="http://redfish.dmtf.org/schemas/v1/Resource_v1.xml">
+    <edmx:Include Namespace="Resource.v1_0_0"/>
+  </edmx:Reference>
+  <edmx:Reference Uri="http://redfish.dmtf.org/schemas/v1/Control_v1.xml">
+    <edmx:Include Namespace="Control"/>
+  </edmx:Reference>
+
+  <edmx:DataServices>
+
+    <Schema xmlns="http://docs.oasis-open.org/odata/ns/edm" Namespace="ControlCollection">
+      <Annotation Term="Redfish.OwningEntity" String="DMTF"/>
+
+      <EntityType Name="ControlCollection" BaseType="Resource.v1_0_0.ResourceCollection">
+        <Annotation Term="OData.Description" String="The collection of Control resource instances."/>
+        <Annotation Term="OData.LongDescription" String="This resource shall represent a resource collection of Control instances for a Redfish implementation."/>
+        <Annotation Term="Capabilities.InsertRestrictions">
+          <Record>
+            <PropertyValue Property="Insertable" Bool="false"/>
+          </Record>
+        </Annotation>
+        <Annotation Term="Capabilities.UpdateRestrictions">
+          <Record>
+            <PropertyValue Property="Updatable" Bool="false"/>
+          </Record>
+        </Annotation>
+        <Annotation Term="Capabilities.DeleteRestrictions">
+          <Record>
+            <PropertyValue Property="Deletable" Bool="false"/>
+          </Record>
+        </Annotation>
+        <Annotation Term="Redfish.Uris">
+          <Collection>
+            <String>/redfish/v1/Chassis/{ChassisId}/Controls</String>
+            <String>/redfish/v1/PowerEquipment/RackPDUs/{PowerDistributionId}/Controls</String>
+            <String>/redfish/v1/PowerEquipment/FloorPDUs/{PowerDistributionId}/Controls</String>
+            <String>/redfish/v1/PowerEquipment/Switchgear/{PowerDistributionId}/Controls</String>
+            <String>/redfish/v1/PowerEquipment/TransferSwitches/{PowerDistributionId}/Controls</String>
+            <String>/redfish/v1/PowerEquipment/PowerShelves/{PowerDistributionId}/Controls</String>
+          </Collection>
+        </Annotation>
+        <NavigationProperty Name="Members" Type="Collection(Control.Control)">
+          <Annotation Term="OData.Permissions" EnumMember="OData.Permission/Read"/>
+          <Annotation Term="OData.Description" String="The members of this collection."/>
+          <Annotation Term="OData.LongDescription" String="This property shall contain an array of links to the members of this collection."/>
+          <Annotation Term="OData.AutoExpandReferences"/>
+          <Annotation Term="Redfish.Required"/>
+        </NavigationProperty>
+      </EntityType>
+    </Schema>
+
+  </edmx:DataServices>
+</edmx:Edmx>

--- a/static/redfish/v1/schema/Control_v1.xml
+++ b/static/redfish/v1/schema/Control_v1.xml
@@ -1,0 +1,336 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!---->
+<!--################################################################################       -->
+<!--# Redfish Schema:  Control v1.0.0                                                      -->
+<!--#                                                                                      -->
+<!--# For a detailed change log, see the README file contained in the DSP8010 bundle,      -->
+<!--# available at http://www.dmtf.org/standards/redfish                                   -->
+<!--# Copyright 2014-2021 DMTF.                                                            -->
+<!--# For the full DMTF copyright policy, see http://www.dmtf.org/about/policies/copyright -->
+<!--################################################################################       -->
+<!---->
+<edmx:Edmx xmlns:edmx="http://docs.oasis-open.org/odata/ns/edmx" Version="4.0">
+
+  <edmx:Reference Uri="http://docs.oasis-open.org/odata/odata/v4.0/errata03/csd01/complete/vocabularies/Org.OData.Core.V1.xml">
+    <edmx:Include Namespace="Org.OData.Core.V1" Alias="OData"/>
+  </edmx:Reference>
+  <edmx:Reference Uri="http://docs.oasis-open.org/odata/odata/v4.0/errata03/csd01/complete/vocabularies/Org.OData.Capabilities.V1.xml">
+    <edmx:Include Namespace="Org.OData.Capabilities.V1" Alias="Capabilities"/>
+  </edmx:Reference>
+  <edmx:Reference Uri="http://docs.oasis-open.org/odata/odata/v4.0/errata03/csd01/complete/vocabularies/Org.OData.Measures.V1.xml">
+    <edmx:Include Namespace="Org.OData.Measures.V1" Alias="Measures"/>
+  </edmx:Reference>
+  <edmx:Reference Uri="http://redfish.dmtf.org/schemas/v1/RedfishExtensions_v1.xml">
+    <edmx:Include Namespace="RedfishExtensions.v1_0_0" Alias="Redfish"/>
+    <edmx:Include Namespace="Validation.v1_0_0" Alias="Validation"/>
+  </edmx:Reference>
+  <edmx:Reference Uri="http://redfish.dmtf.org/schemas/v1/Resource_v1.xml">
+    <edmx:Include Namespace="Resource"/>
+    <edmx:Include Namespace="Resource.v1_0_0"/>
+  </edmx:Reference>
+  <edmx:Reference Uri="http://redfish.dmtf.org/schemas/v1/Sensor_v1.xml">
+    <edmx:Include Namespace="Sensor"/>
+  </edmx:Reference>
+  <edmx:Reference Uri="http://redfish.dmtf.org/schemas/v1/PhysicalContext_v1.xml">
+    <edmx:Include Namespace="PhysicalContext"/>
+  </edmx:Reference>
+
+  <edmx:DataServices>
+
+    <Schema xmlns="http://docs.oasis-open.org/odata/ns/edm" Namespace="Control">
+      <Annotation Term="Redfish.OwningEntity" String="DMTF"/>
+
+      <EntityType Name="Control" BaseType="Resource.v1_0_0.Resource" Abstract="true">
+        <Annotation Term="OData.Description" String="The Control schema describes a control point and its properties."/>
+        <Annotation Term="OData.LongDescription" String="This resource shall represent a control point for a Redfish implementation."/>
+        <Annotation Term="Capabilities.InsertRestrictions">
+          <Record>
+            <PropertyValue Property="Insertable" Bool="false"/>
+          </Record>
+        </Annotation>
+        <Annotation Term="Capabilities.UpdateRestrictions">
+          <Record>
+            <PropertyValue Property="Updatable" Bool="true"/>
+            <Annotation Term="OData.Description" String="Any writable properties, such as limits and exceptions, can be updated for controls."/>
+          </Record>
+        </Annotation>
+        <Annotation Term="Capabilities.DeleteRestrictions">
+          <Record>
+            <PropertyValue Property="Deletable" Bool="false"/>
+          </Record>
+        </Annotation>
+        <Annotation Term="Redfish.Uris">
+          <Collection>
+            <String>/redfish/v1/Chassis/{ChassisId}/Controls/{ControlId}</String>
+            <String>/redfish/v1/PowerEquipment/RackPDUs/{PowerDistributionId}/Controls/{ControlId}</String>
+            <String>/redfish/v1/PowerEquipment/FloorPDUs/{PowerDistributionId}/Controls/{ControlId}</String>
+            <String>/redfish/v1/PowerEquipment/Switchgear/{PowerDistributionId}/Controls/{ControlId}</String>
+            <String>/redfish/v1/PowerEquipment/TransferSwitches/{PowerDistributionId}/Controls/{ControlId}</String>
+            <String>/redfish/v1/PowerEquipment/PowerShelves/{PowerDistributionId}/Controls/{ControlId}</String>
+          </Collection>
+        </Annotation>
+      </EntityType>
+    </Schema>
+
+    <Schema xmlns="http://docs.oasis-open.org/odata/ns/edm" Namespace="Control.v1_0_0">
+      <Annotation Term="Redfish.OwningEntity" String="DMTF"/>
+      <Annotation Term="Redfish.Release" String="2021.2"/>
+
+      <EntityType Name="Control" BaseType="Control.Control">
+        <Property Name="ControlType" Type="Control.v1_0_0.ControlType">
+          <Annotation Term="OData.Permissions" EnumMember="OData.Permission/Read"/>
+          <Annotation Term="OData.Description" String="The type of control."/>
+          <Annotation Term="OData.LongDescription" String="This property shall contain the type of the control."/>
+        </Property>
+        <Property Name="SetPointType" Type="Control.v1_0_0.SetPointType">
+          <Annotation Term="OData.Permissions" EnumMember="OData.Permission/Read"/>
+          <Annotation Term="OData.Description" String="The set point type used to operate the control."/>
+          <Annotation Term="OData.LongDescription" String="This property shall contain the type of set point definitions used to describe this control."/>
+        </Property>
+        <Property Name="DataSourceUri" Type="Edm.String">
+          <Annotation Term="OData.Permissions" EnumMember="OData.Permission/Read"/>
+          <Annotation Term="OData.Description" String="The link to the resource that provides the data for this control."/>
+          <Annotation Term="OData.LongDescription" String="This property shall contain a URI to the resource that provides the source of the excerpt contained within this copy.  If no source resource is implemented, meaning the excerpt represents the only available data, this property shall not be present."/>
+          <Annotation Term="OData.IsURL"/>
+          <Annotation Term="Redfish.ExcerptCopyOnly"/>
+        </Property>
+
+        <Property Name="Status" Type="Resource.Status" Nullable="false">
+          <Annotation Term="OData.Description" String="The status and health of the resource and its subordinate or dependent resources."/>
+          <Annotation Term="OData.LongDescription" String="This property shall contain any status or health properties of the resource."/>
+        </Property>
+
+        <Property Name="ControlMode" Type="Control.v1_0_0.ControlMode">
+          <Annotation Term="OData.Permissions" EnumMember="OData.Permission/ReadWrite"/>
+          <Annotation Term="OData.Description" String="The current operating mode of the control."/>
+          <Annotation Term="OData.LongDescription" String="This property shall contain the operating mode of the control."/>
+          <Annotation Term="Redfish.Excerpt"/>
+        </Property>
+        <Property Name="SetPoint" Type="Edm.Decimal">
+          <Annotation Term="OData.Permissions" EnumMember="OData.Permission/ReadWrite"/>
+          <Annotation Term="OData.Description" String="The desired set point of the control."/>
+          <Annotation Term="OData.LongDescription" String="This property shall contain the desired set point control value.  The units shall follow the value of SetPointUnits."/>
+          <Annotation Term="Redfish.Excerpt" String="Single"/>
+        </Property>
+        <Property Name="SettingMin" Type="Edm.Decimal">
+          <Annotation Term="OData.Permissions" EnumMember="OData.Permission/ReadWrite"/>
+          <Annotation Term="OData.Description" String="The minimum set point in the allowed range."/>
+          <Annotation Term="OData.LongDescription" String="This property shall contain the minimum desired set point within the acceptable range.  The service shall reject values less than the value of AllowableMin.  The units shall follow the value of SetPointUnits."/>
+          <Annotation Term="Redfish.Excerpt" String="Range"/>
+        </Property>
+        <Property Name="SettingMax" Type="Edm.Decimal">
+          <Annotation Term="OData.Permissions" EnumMember="OData.Permission/ReadWrite"/>
+          <Annotation Term="OData.Description" String="The maximum set point in the allowed range."/>
+          <Annotation Term="OData.LongDescription" String="This property shall contain the maximum desired set point within the acceptable range.  The service shall reject values greater than the value of AllowableMax.  The units shall follow the value of SetPointUnits."/>
+          <Annotation Term="Redfish.Excerpt" String="Range"/>
+        </Property>
+        <Property Name="AllowableNumericValues" Type="Collection(Edm.Decimal)">
+          <Annotation Term="OData.Permissions" EnumMember="OData.Permission/Read"/>
+          <Annotation Term="OData.Description" String="The supported values for the set point."/>
+          <Annotation Term="OData.LongDescription" String="This property shall contain the supported values for this control.  The units shall follow the value of SetPointUnits.  This property should only be present when the set point or range has a limited set of supported values that cannot be accurately described using the Increment property."/>
+          <Annotation Term="Redfish.Excerpt" String="Range"/>
+        </Property>
+        <Property Name="SetPointUnits" Type="Edm.String">
+          <Annotation Term="OData.Permissions" EnumMember="OData.Permission/Read"/>
+          <Annotation Term="OData.Description" String="The units of the set point."/>
+          <Annotation Term="OData.LongDescription" String="This property shall contain the units of the control's set point."/>
+        </Property>
+        <Property Name="DeadBand" Type="Edm.Decimal">
+          <Annotation Term="OData.Permissions" EnumMember="OData.Permission/ReadWrite"/>
+          <Annotation Term="OData.Description" String="The maximum deviation from the set point allowed before the control will activate."/>
+          <Annotation Term="OData.LongDescription" String="This property shall contain the maximum deviation value allowed above or below the value of SetPoint before the control will activate."/>
+        </Property>
+        <Property Name="ControlDelaySeconds" Type="Edm.Decimal">
+          <Annotation Term="OData.Permissions" EnumMember="OData.Permission/ReadWrite"/>
+          <Annotation Term="OData.Description" String="The time delay in seconds before the control will activate once the value has deviated from the set point."/>
+          <Annotation Term="OData.LongDescription" String="This property shall contain the time in seconds that will elapse after the control value deviates above or below the value of SetPoint before the control will activate."/>
+        </Property>
+        <Property Name="AllowableMax" Type="Edm.Decimal">
+          <Annotation Term="OData.Permissions" EnumMember="OData.Permission/Read"/>
+          <Annotation Term="OData.Description" String="The maximum possible setting for this control."/>
+          <Annotation Term="OData.LongDescription" String="This property shall indicate the maximum possible value of the SetPoint or SettingMax properties for this control.  Services shall not accept values for SetPoint or SettingMax above this value."/>
+          <Annotation Term="Redfish.Excerpt"/>
+        </Property>
+        <Property Name="AllowableMin" Type="Edm.Decimal">
+          <Annotation Term="OData.Permissions" EnumMember="OData.Permission/Read"/>
+          <Annotation Term="OData.Description" String="The minimum possible setting for this control."/>
+          <Annotation Term="OData.LongDescription" String="This property shall indicate the minimum possible value of the SetPoint or SettingMin properties for this control.  Services shall not accept values for SetPoint or SettingMin below this value."/>
+          <Annotation Term="Redfish.Excerpt"/>
+        </Property>
+        <Property Name="Increment" Type="Edm.Decimal">
+          <Annotation Term="OData.Permissions" EnumMember="OData.Permission/Read"/>
+          <Annotation Term="OData.Description" String="The smallest increment supported for the set point."/>
+          <Annotation Term="OData.LongDescription" String="This property shall contain the smallest change allowed to the value of the SetPoint, SettingMin, or SettingMax properties.  The units shall follow the value of SetPointUnits."/>
+        </Property>
+        <Property Name="Accuracy" Type="Edm.Decimal">
+          <Annotation Term="OData.Permissions" EnumMember="OData.Permission/Read"/>
+          <Annotation Term="OData.Description" String="The estimated percent error of measured versus actual values."/>
+          <Annotation Term="OData.LongDescription" String="This property shall contain the percent error of the measured versus actual values of the SetPoint property."/>
+          <Annotation Term="Measures.Unit" String="%"/>
+        </Property>
+        <Property Name="PhysicalContext" Type="PhysicalContext.PhysicalContext">
+          <Annotation Term="OData.Permissions" EnumMember="OData.Permission/Read"/>
+          <Annotation Term="OData.Description" String="The area or device to which this control applies."/>
+          <Annotation Term="OData.LongDescription" String="This property shall contain a description of the affected component or region within the equipment to which this control applies."/>
+        </Property>
+        <Property Name="PhysicalSubContext" Type="PhysicalContext.PhysicalSubContext">
+          <Annotation Term="OData.Permissions" EnumMember="OData.Permission/Read"/>
+          <Annotation Term="OData.Description" String="The usage or location within a device to which this control applies."/>
+          <Annotation Term="OData.LongDescription" String="This property shall contain a description of the usage or sub-region within the equipment to which this control applies.  This property generally differentiates multiple controls within the same PhysicalContext instance."/>
+        </Property>
+        <Property Name="Implementation" Type="Control.v1_0_0.ImplementationType">
+          <Annotation Term="OData.Permissions" EnumMember="OData.Permission/Read"/>
+          <Annotation Term="OData.Description" String="The implementation of the control."/>
+          <Annotation Term="OData.LongDescription" String="This property shall contain the implementation of the control."/>
+        </Property>
+        <Property Name="SetPointUpdateTime" Type="Edm.DateTimeOffset">
+          <Annotation Term="OData.Permissions" EnumMember="OData.Permission/Read"/>
+          <Annotation Term="OData.Description" String="The date and time that the set point was changed."/>
+          <Annotation Term="OData.LongDescription" String="This property shall contain the date and time that the value of SetPoint was last changed."/>
+        </Property>
+        <NavigationProperty Name="RelatedItem" Type="Collection(Resource.Item)">
+          <Annotation Term="OData.Permissions" EnumMember="OData.Permission/Read"/>
+          <Annotation Term="OData.Description" String="An array of links to resources that this control services."/>
+          <Annotation Term="OData.LongDescription" String="This property shall contain an array of links to resources that this control services."/>
+          <Annotation Term="OData.AutoExpandReferences"/>
+        </NavigationProperty>
+        <Property Name="ControlLoop" Type="Control.v1_0_0.ControlLoop">
+          <Annotation Term="OData.Description" String="The control loop details."/>
+          <Annotation Term="OData.LongDescription" String="This property shall contain the details for the control loop described by this resource."/>
+        </Property>
+
+        <Property Name="Reading" Type="Edm.Decimal">
+          <Annotation Term="OData.Permissions" EnumMember="OData.Permission/Read"/>
+          <Annotation Term="OData.Description" String="The reading of the sensor associated with this control."/>
+          <Annotation Term="OData.LongDescription" String="This property shall contain the value of the Reading property of the Sensor resource directly associated with this control.  This property shall not be present if multiple sensors are associated with a single control."/>
+          <Annotation Term="Redfish.ExcerptCopyOnly"/>
+        </Property>
+        <Property Name="ReadingUnits" Type="Edm.String">
+          <Annotation Term="OData.Permissions" EnumMember="OData.Permission/Read"/>
+          <Annotation Term="OData.Description" String="The units of the sensor reading associated with this control."/>
+          <Annotation Term="OData.LongDescription" String="This property shall contain the units of the sensor's reading and thresholds.  This property shall not be present if multiple sensors are associated with a single control."/>
+          <Annotation Term="Redfish.ExcerptCopyOnly"/>
+        </Property>
+
+        <NavigationProperty Name="Sensor" Type="Sensor.Sensor">
+          <Annotation Term="OData.Permissions" EnumMember="OData.Permission/Read"/>
+          <Annotation Term="Redfish.ExcerptCopy"/>
+          <Annotation Term="OData.Description" String="The sensor reading associated with this control."/>
+          <Annotation Term="OData.LongDescription" String="This property shall contain the Sensor excerpt directly associated with this control.  This property shall not be present if multiple sensors are associated with a single control."/>
+        </NavigationProperty>
+        <NavigationProperty Name="AssociatedSensors" Type="Collection(Sensor.Sensor)">
+          <Annotation Term="OData.Permissions" EnumMember="OData.Permission/Read"/>
+          <Annotation Term="OData.Description" String="An array of links to the sensors associated with this control."/>
+          <Annotation Term="OData.LongDescription" String="This property shall contain an array of links to resources of type Sensor that represent the sensors related to this control."/>
+          <Annotation Term="OData.AutoExpandReferences"/>
+        </NavigationProperty>
+
+        <Property Name="Location" Type="Resource.Location" Nullable="false">
+          <Annotation Term="OData.Description" String="The location information for this control."/>
+          <Annotation Term="OData.LongDescription" String="This property shall indicate the location information for this control."/>
+        </Property>
+
+        <Property Name="Actions" Type="Control.v1_0_0.Actions" Nullable="false">
+          <Annotation Term="OData.Description" String="The available actions for this resource."/>
+          <Annotation Term="OData.LongDescription" String="This property shall contain the available actions for this resource."/>
+        </Property>
+      </EntityType>
+
+      <ComplexType Name="ControlLoop">
+        <Annotation Term="OData.AdditionalProperties" Bool="false"/>
+        <Annotation Term="OData.Description" String="The details and coefficients used to operate a control loop."/>
+        <Annotation Term="OData.LongDescription" String="This type shall describe the details of a control loop."/>
+        <Property Name="Proportional" Type="Edm.Decimal">
+          <Annotation Term="OData.Permissions" EnumMember="OData.Permission/ReadWrite"/>
+          <Annotation Term="OData.Description" String="The proportional coefficient."/>
+          <Annotation Term="OData.LongDescription" String="This property shall contain the coefficient for the proportional factor in a control loop."/>
+        </Property>
+        <Property Name="Integral" Type="Edm.Decimal">
+          <Annotation Term="OData.Permissions" EnumMember="OData.Permission/ReadWrite"/>
+          <Annotation Term="OData.Description" String="The integral coefficient."/>
+          <Annotation Term="OData.LongDescription" String="This property shall contain the coefficient for the integral factor in a control loop."/>
+        </Property>
+        <Property Name="Differential" Type="Edm.Decimal">
+          <Annotation Term="OData.Permissions" EnumMember="OData.Permission/ReadWrite"/>
+          <Annotation Term="OData.Description" String="The differential coefficient."/>
+          <Annotation Term="OData.LongDescription" String="This property shall contain the coefficient for the differential factor in a control loop."/>
+        </Property>
+        <Property Name="CoefficientUpdateTime" Type="Edm.DateTimeOffset">
+          <Annotation Term="OData.Permissions" EnumMember="OData.Permission/Read"/>
+          <Annotation Term="OData.Description" String="The date and time that the control loop coefficients were changed."/>
+          <Annotation Term="OData.LongDescription" String="This property shall contain the date and time that any of the coefficients for the control loop were last changed."/>
+        </Property>
+      </ComplexType>
+
+      <EnumType Name="ControlType">
+        <Member Name="Temperature">
+          <Annotation Term="OData.Description" String="Temperature control or thermostat."/>
+          <Annotation Term="OData.LongDescription" String="This value shall indicate a control used to regulate temperature, in units of degrees Celsius, either to a single set point or within a range, and the SetPointUnits property shall contain `Cel`."/>
+        </Member>
+        <Member Name="Power">
+          <Annotation Term="OData.Description" String="Power control or power limit."/>
+          <Annotation Term="OData.LongDescription" String="This value shall indicate a control used to regulate or limit maximum power consumption, in Watts units, either to a single set point or within a range, and the SetPointUnits property shall contain `W`."/>
+        </Member>
+        <Member Name="Frequency">
+          <Annotation Term="OData.Description" String="Frequency control."/>
+          <Annotation Term="OData.LongDescription" String="This value shall indicate a control used to limit the operating frequency, measured in Hertz units, of a device, either to a single set point or within a range, and the SetPointUnits property shall contain `Hz`."/>
+        </Member>
+      </EnumType>
+
+      <EnumType Name="SetPointType">
+        <Member Name="Single">
+          <Annotation Term="OData.Description" String="Control uses a single set point."/>
+          <Annotation Term="OData.LongDescription" String="This value shall indicate the control utilizes a single set point for its operation.  The SetPoint property shall be present for this control type.  The SettingMin and SettingMax properties shall not be present for this control type."/>
+        </Member>
+        <Member Name="Range">
+          <Annotation Term="OData.Description" String="Control uses a range of values."/>
+          <Annotation Term="OData.LongDescription" String="This value shall indicate the control utilizes a set point range for its operation.  The SettingMin and SettingMax properties shall be present for this control type.  The SetPoint property shall not be present for this control type."/>
+        </Member>
+      </EnumType>
+
+      <EnumType Name="ControlMode">
+        <Member Name="Automatic">
+          <Annotation Term="OData.Description" String="Automatically adjust control to meet the set point."/>
+        </Member>
+        <Member Name="Override">
+          <Annotation Term="OData.Description" String="User override of the automatic set point value."/>
+        </Member>
+        <Member Name="Manual">
+          <Annotation Term="OData.Description" String="No automatic adjustments are made to the control."/>
+        </Member>
+        <Member Name="Disabled">
+          <Annotation Term="OData.Description" String="The control has been disabled."/>
+        </Member>
+      </EnumType>
+
+      <EnumType Name="ImplementationType">
+        <Member Name="Programmable">
+          <Annotation Term="OData.Description" String="The set point can be adjusted through this interface."/>
+        </Member>
+        <Member Name="Direct">
+          <Annotation Term="OData.Description" String="The set point directly affects the control value."/>
+        </Member>
+        <Member Name="Monitored">
+          <Annotation Term="OData.Description" String="A physical control that cannot be adjusted through this interface."/>
+        </Member>
+      </EnumType>
+
+      <ComplexType Name="Actions">
+        <Annotation Term="OData.AdditionalProperties" Bool="false"/>
+        <Annotation Term="OData.Description" String="The available actions for this resource."/>
+        <Annotation Term="OData.LongDescription" String="This type shall contain the available actions for this resource."/>
+        <Property Name="Oem" Type="Control.v1_0_0.OemActions" Nullable="false">
+          <Annotation Term="OData.Description" String="The available OEM-specific actions for this resource."/>
+          <Annotation Term="OData.LongDescription" String="This property shall contain the available OEM-specific actions for this resource."/>
+        </Property>
+      </ComplexType>
+
+      <ComplexType Name="OemActions">
+        <Annotation Term="OData.AdditionalProperties" Bool="true"/>
+        <Annotation Term="OData.Description" String="The available OEM-specific actions for this resource."/>
+        <Annotation Term="OData.LongDescription" String="This type shall contain the available OEM-specific actions for this resource."/>
+      </ComplexType>
+    </Schema>
+
+  </edmx:DataServices>
+</edmx:Edmx>

--- a/static/redfish/v1/schema/EndpointCollection_v1.xml
+++ b/static/redfish/v1/schema/EndpointCollection_v1.xml
@@ -1,0 +1,72 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!---->
+<!--################################################################################       -->
+<!--# Redfish Schema:  EndpointCollection                                                  -->
+<!--#                                                                                      -->
+<!--# For a detailed change log, see the README file contained in the DSP8010 bundle,      -->
+<!--# available at http://www.dmtf.org/standards/redfish                                   -->
+<!--# Copyright 2014-2021 DMTF.                                                            -->
+<!--# For the full DMTF copyright policy, see http://www.dmtf.org/about/policies/copyright -->
+<!--################################################################################       -->
+<!---->
+<edmx:Edmx xmlns:edmx="http://docs.oasis-open.org/odata/ns/edmx" Version="4.0">
+
+  <edmx:Reference Uri="http://docs.oasis-open.org/odata/odata/v4.0/errata03/csd01/complete/vocabularies/Org.OData.Core.V1.xml">
+    <edmx:Include Namespace="Org.OData.Core.V1" Alias="OData"/>
+  </edmx:Reference>
+  <edmx:Reference Uri="http://docs.oasis-open.org/odata/odata/v4.0/errata03/csd01/complete/vocabularies/Org.OData.Capabilities.V1.xml">
+    <edmx:Include Namespace="Org.OData.Capabilities.V1" Alias="Capabilities"/>
+  </edmx:Reference>
+  <edmx:Reference Uri="http://redfish.dmtf.org/schemas/v1/Resource_v1.xml">
+    <edmx:Include Namespace="Resource.v1_0_0"/>
+  </edmx:Reference>
+  <edmx:Reference Uri="http://redfish.dmtf.org/schemas/v1/RedfishExtensions_v1.xml">
+    <edmx:Include Namespace="RedfishExtensions.v1_0_0" Alias="Redfish"/>
+  </edmx:Reference>
+  <edmx:Reference Uri="http://redfish.dmtf.org/schemas/v1/Endpoint_v1.xml">
+    <edmx:Include Namespace="Endpoint"/>
+  </edmx:Reference>
+
+  <edmx:DataServices>
+
+    <Schema xmlns="http://docs.oasis-open.org/odata/ns/edm" Namespace="EndpointCollection">
+      <Annotation Term="Redfish.OwningEntity" String="DMTF"/>
+
+      <EntityType Name="EndpointCollection" BaseType="Resource.v1_0_0.ResourceCollection">
+        <Annotation Term="OData.Description" String="The collection of Endpoint resource instances."/>
+        <Annotation Term="OData.LongDescription" String="This resource shall represent a resource collection of Endpoint instances for a Redfish implementation."/>
+        <Annotation Term="Capabilities.InsertRestrictions">
+          <Record>
+            <PropertyValue Property="Insertable" Bool="true"/>
+            <Annotation Term="OData.Description" String="The endpoints that the service does not automatically discover can be enumerated through a POST to the endpoint collection."/>
+          </Record>
+        </Annotation>
+        <Annotation Term="Capabilities.UpdateRestrictions">
+          <Record>
+            <PropertyValue Property="Updatable" Bool="false"/>
+          </Record>
+        </Annotation>
+        <Annotation Term="Capabilities.DeleteRestrictions">
+          <Record>
+            <PropertyValue Property="Deletable" Bool="false"/>
+          </Record>
+        </Annotation>
+        <Annotation Term="Redfish.Uris">
+          <Collection>
+            <String>/redfish/v1/Fabrics/{FabricId}/Endpoints</String>
+            <String>/redfish/v1/StorageServices/{StorageServiceId}/Endpoints</String>
+            <String>/redfish/v1/Storage/{StorageId}/Endpoints</String>
+          </Collection>
+        </Annotation>
+        <NavigationProperty Name="Members" Type="Collection(Endpoint.Endpoint)">
+          <Annotation Term="OData.Permissions" EnumMember="OData.Permission/Read"/>
+          <Annotation Term="OData.Description" String="The members of this collection."/>
+          <Annotation Term="OData.LongDescription" String="This property shall contain an array of links to the members of this collection."/>
+          <Annotation Term="OData.AutoExpandReferences"/>
+          <Annotation Term="Redfish.Required"/>
+        </NavigationProperty>
+      </EntityType>
+    </Schema>
+
+  </edmx:DataServices>
+</edmx:Edmx>

--- a/static/redfish/v1/schema/EndpointGroupCollection_v1.xml
+++ b/static/redfish/v1/schema/EndpointGroupCollection_v1.xml
@@ -1,0 +1,74 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!---->
+<!--################################################################################       -->
+<!--# Redfish Schema:  EndpointGroupCollection                                             -->
+<!--#                                                                                      -->
+<!--# For a detailed change log, see the README file contained in the DSP8010 bundle,      -->
+<!--# available at http://www.dmtf.org/standards/redfish                                   -->
+<!--# Copyright 2014-2021 DMTF.                                                            -->
+<!--# Portions Copyright 2015-2020 Storage Networking Industry Association (SNIA), USA.    -->
+<!--# For the full DMTF copyright policy, see http://www.dmtf.org/about/policies/copyright -->
+<!--################################################################################       -->
+<!---->
+<edmx:Edmx xmlns:edmx="http://docs.oasis-open.org/odata/ns/edmx" Version="4.0">
+
+  <edmx:Reference Uri="http://docs.oasis-open.org/odata/odata/v4.0/errata03/csd01/complete/vocabularies/Org.OData.Core.V1.xml">
+    <edmx:Include Namespace="Org.OData.Core.V1" Alias="OData"/>
+  </edmx:Reference>
+  <edmx:Reference Uri="http://docs.oasis-open.org/odata/odata/v4.0/errata03/csd01/complete/vocabularies/Org.OData.Capabilities.V1.xml">
+    <edmx:Include Namespace="Org.OData.Capabilities.V1" Alias="Capabilities"/>
+  </edmx:Reference>
+  <edmx:Reference Uri="http://redfish.dmtf.org/schemas/v1/Resource_v1.xml">
+    <edmx:Include Namespace="Resource.v1_0_0"/>
+  </edmx:Reference>
+  <edmx:Reference Uri="http://redfish.dmtf.org/schemas/v1/RedfishExtensions_v1.xml">
+    <edmx:Include Namespace="RedfishExtensions.v1_0_0" Alias="Redfish"/>
+  </edmx:Reference>
+  <edmx:Reference Uri="http://redfish.dmtf.org/schemas/v1/EndpointGroup_v1.xml">
+    <edmx:Include Namespace="EndpointGroup"/>
+  </edmx:Reference>
+
+  <edmx:DataServices>
+
+    <Schema xmlns="http://docs.oasis-open.org/odata/ns/edm" Namespace="EndpointGroupCollection">
+      <Annotation Term="Redfish.OwningEntity" String="DMTF"/>
+
+      <EntityType Name="EndpointGroupCollection" BaseType="Resource.v1_0_0.ResourceCollection">
+        <Annotation Term="OData.Description" String="The collection of EndpointGroup resource instances."/>
+        <Annotation Term="OData.LongDescription" String="This resource shall represent a resource collection of EndpointGroup instances for a Redfish implementation."/>
+        <Annotation Term="Capabilities.InsertRestrictions">
+          <Record>
+            <PropertyValue Property="Insertable" Bool="true"/>
+            <Annotation Term="OData.Description" String="Clients can POST to the endpoint group collection to add a new endpoint group."/>
+          </Record>
+        </Annotation>
+        <Annotation Term="Capabilities.UpdateRestrictions">
+          <Record>
+            <PropertyValue Property="Updatable" Bool="false"/>
+          </Record>
+        </Annotation>
+        <Annotation Term="Capabilities.DeleteRestrictions">
+          <Record>
+            <PropertyValue Property="Deletable" Bool="false"/>
+          </Record>
+        </Annotation>
+        <Annotation Term="Redfish.Uris">
+          <Collection>
+            <String>/redfish/v1/Storage/{StorageId}/EndpointGroups</String>
+            <String>/redfish/v1/Systems/{ComputerSystemId}/Storage/{StorageId}/EndpointGroups</String>
+            <String>/redfish/v1/StorageServices/{StorageServiceId}/EndpointGroups</String>
+            <String>/redfish/v1/Fabrics/{FabricId}/EndpointGroups</String>
+          </Collection>
+        </Annotation>
+        <NavigationProperty Name="Members" Type="Collection(EndpointGroup.EndpointGroup)">
+          <Annotation Term="OData.Permissions" EnumMember="OData.Permission/Read"/>
+          <Annotation Term="OData.Description" String="The members of this collection."/>
+          <Annotation Term="OData.LongDescription" String="This property shall contain an array of links to the members of this collection."/>
+          <Annotation Term="OData.AutoExpandReferences"/>
+          <Annotation Term="Redfish.Required"/>
+        </NavigationProperty>
+      </EntityType>
+    </Schema>
+
+  </edmx:DataServices>
+</edmx:Edmx>

--- a/static/redfish/v1/schema/EndpointGroup_v1.xml
+++ b/static/redfish/v1/schema/EndpointGroup_v1.xml
@@ -1,0 +1,387 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!---->
+<!--################################################################################       -->
+<!--# Redfish Schema:  EndpointGroup v1.3.2                                                -->
+<!--#                                                                                      -->
+<!--# For a detailed change log, see the README file contained in the DSP8010 bundle,      -->
+<!--# available at http://www.dmtf.org/standards/redfish                                   -->
+<!--# Copyright 2014-2021 DMTF.                                                            -->
+<!--# Portions Copyright 2015-2020 Storage Networking Industry Association (SNIA), USA.    -->
+<!--# For the full DMTF copyright policy, see http://www.dmtf.org/about/policies/copyright -->
+<!--################################################################################       -->
+<!---->
+<edmx:Edmx xmlns:edmx="http://docs.oasis-open.org/odata/ns/edmx" Version="4.0">
+
+  <edmx:Reference Uri="http://docs.oasis-open.org/odata/odata/v4.0/errata03/csd01/complete/vocabularies/Org.OData.Core.V1.xml">
+    <edmx:Include Namespace="Org.OData.Core.V1" Alias="OData"/>
+  </edmx:Reference>
+  <edmx:Reference Uri="http://docs.oasis-open.org/odata/odata/v4.0/errata03/csd01/complete/vocabularies/Org.OData.Capabilities.V1.xml">
+    <edmx:Include Namespace="Org.OData.Capabilities.V1" Alias="Capabilities"/>
+  </edmx:Reference>
+  <edmx:Reference Uri="http://redfish.dmtf.org/schemas/v1/RedfishExtensions_v1.xml">
+    <edmx:Include Namespace="RedfishExtensions.v1_0_0" Alias="Redfish"/>
+  </edmx:Reference>
+  <edmx:Reference Uri="http://redfish.dmtf.org/schemas/v1/Resource_v1.xml">
+    <edmx:Include Namespace="Resource"/>
+    <edmx:Include Namespace="Resource.v1_0_0"/>
+  </edmx:Reference>
+  <edmx:Reference Uri="http://redfish.dmtf.org/schemas/v1/Endpoint_v1.xml">
+    <edmx:Include Namespace="Endpoint"/>
+  </edmx:Reference>
+  <edmx:Reference Uri="http://redfish.dmtf.org/schemas/v1/EndpointCollection_v1.xml">
+    <edmx:Include Namespace="EndpointCollection"/>
+  </edmx:Reference>
+  <edmx:Reference Uri="http://redfish.dmtf.org/schemas/v1/Connection_v1.xml">
+    <edmx:Include Namespace="Connection"/>
+  </edmx:Reference>
+
+  <edmx:DataServices>
+
+    <Schema xmlns="http://docs.oasis-open.org/odata/ns/edm" Namespace="EndpointGroup">
+      <Annotation Term="Redfish.OwningEntity" String="DMTF"/>
+
+      <EntityType Name="EndpointGroup" BaseType="Resource.v1_0_0.Resource" Abstract="true">
+        <Annotation Term="OData.Description" String="The EndpointGroup schema describes group of endpoints that are managed as a unit."/>
+        <Annotation Term="OData.LongDescription" String="This resource shall represent a group of endpoints that are managed as a unit for a Redfish implementation."/>
+
+        <Annotation Term="Capabilities.InsertRestrictions">
+          <Record>
+            <PropertyValue Property="Insertable" Bool="false"/>
+          </Record>
+        </Annotation>
+        <Annotation Term="Capabilities.UpdateRestrictions">
+          <Record>
+            <PropertyValue Property="Updatable" Bool="true"/>
+            <Annotation Term="OData.Description" String="Writable properties can be updated for endpoint groups."/>
+          </Record>
+        </Annotation>
+        <Annotation Term="Capabilities.DeleteRestrictions">
+          <Record>
+            <PropertyValue Property="Deletable" Bool="true"/>
+            <Annotation Term="OData.Description" String="Endpoint groups can be deleted by clients."/>
+          </Record>
+        </Annotation>
+
+        <Annotation Term="Redfish.Uris">
+          <Collection>
+            <String>/redfish/v1/Storage/{StorageId}/EndpointGroups/{EndpointGroupId}</String>
+            <String>/redfish/v1/Systems/{ComputerSystemId}/Storage/{StorageId}/EndpointGroups/{EndpointGroupId}</String>
+            <String>/redfish/v1/StorageServices/{StorageServiceId}/EndpointGroups/{EndpointGroupId}</String>
+            <String>/redfish/v1/Fabrics/{FabricId}/EndpointGroups/{EndpointGroupId}</String>
+          </Collection>
+        </Annotation>
+      </EntityType>
+
+      <EnumType Name="AccessState">
+        <Annotation Term="OData.Description" String="Describes the options for the access characteristics of an endpoint."/>
+        <Annotation Term="OData.LongDescription" String="This type shall describe the access to all associated resources through all aggregated endpoints."/>
+        <Member Name="Optimized">
+          <Annotation Term="OData.Description" String="The endpoints are in an active and optimized state."/>
+          <Annotation Term="OData.LongDescription" String="This value shall indicate each endpoint is in an active and optimized state."/>
+        </Member>
+        <Member Name="NonOptimized">
+          <Annotation Term="OData.Description" String="The endpoints are in an active and non-optimized state."/>
+          <Annotation Term="OData.LongDescription" String="This value shall indicate each endpoint is in an active and non-optimized state."/>
+        </Member>
+        <Member Name="Standby">
+          <Annotation Term="OData.Description" String="The endpoints are in a standby state."/>
+          <Annotation Term="OData.LongDescription" String="This value shall indicate each endpoint is in a standby state."/>
+        </Member>
+        <Member Name="Unavailable">
+          <Annotation Term="OData.Description" String="The endpoints are in an unavailable state."/>
+          <Annotation Term="OData.LongDescription" String="This value shall indicate each endpoint is in an unavailable state."/>
+        </Member>
+        <Member Name="Transitioning">
+          <Annotation Term="OData.Description" String="The endpoints are transitioning to a new state."/>
+          <Annotation Term="OData.LongDescription" String="This value shall indicate each endpoint is transitioning to a new state."/>
+        </Member>
+      </EnumType>
+    </Schema>
+
+    <Schema xmlns="http://docs.oasis-open.org/odata/ns/edm" Namespace="EndpointGroup.v1_0_0">
+      <Annotation Term="Redfish.OwningEntity" String="SNIA"/>
+      <Annotation Term="Redfish.Release" String="TP v1.0.3"/>
+
+      <EntityType Name="EndpointGroup" BaseType="EndpointGroup.EndpointGroup">
+        <Property Name="Identifier" Type="Resource.Identifier" Nullable="false">
+          <Annotation Term="OData.Description" String="The durable name for the endpoint group."/>
+          <Annotation Term="OData.LongDescription" String="This property shall contain the durable name for the endpoint group."/>
+        </Property>
+        <Property Name="GroupType" Type="EndpointGroup.v1_0_0.GroupType">
+          <Annotation Term="OData.Permissions" EnumMember="OData.Permission/ReadWrite"/>
+          <Annotation Term="OData.Description" String="The endpoint group type."/>
+          <Annotation Term="OData.LongDescription" String="The value of this property shall contain the endpoint group type.  If this endpoint group represents a SCSI target group, the value of this property shall contain `Server` or `Target`."/>
+        </Property>
+        <Property Name="AccessState" Type="EndpointGroup.AccessState">
+          <Annotation Term="OData.Permissions" EnumMember="OData.Permission/ReadWrite"/>
+          <Annotation Term="OData.Description" String="The access state for this group."/>
+          <Annotation Term="OData.LongDescription" String="The value of this property shall contain the access state for all associated resources in this endpoint group."/>
+          <Annotation Term="Redfish.Revisions">
+            <Collection>
+              <Record>
+                <PropertyValue Property="Kind" EnumMember="Redfish.RevisionKind/Deprecated"/>
+                <PropertyValue Property="Version" String="v1_3_0"/>
+                <PropertyValue Property="Description" String="This property has been deprecated in favor of the AccessState property in the connection resource."/>
+              </Record>
+            </Collection>
+          </Annotation>
+        </Property>
+        <Property Name="TargetEndpointGroupIdentifier" Type="Edm.Int64">
+          <Annotation Term="OData.Permissions" EnumMember="OData.Permission/ReadWrite"/>
+          <Annotation Term="OData.Description" String="The SCSI-defined identifier for this group."/>
+          <Annotation Term="OData.LongDescription" String="The value of this property shall contain a SCSI-defined identifier for this group that corresponds to the TARGET PORT GROUP field in the REPORT TARGET PORT GROUPS response and the TARGET PORT GROUP field in an INQUIRY VPD page 85 response, type 5h identifier.  See the INCITS SAM-5 specification.  This property may not be present if the endpoint group does not represent a SCSI target group."/>
+        </Property>
+        <Property Name="Preferred" Type="Edm.Boolean" DefaultValue="false">
+          <Annotation Term="OData.Permissions" EnumMember="OData.Permission/ReadWrite"/>
+          <Annotation Term="OData.Description" String="An indication if access to the resources through the endpoint group is preferred."/>
+          <Annotation Term="OData.LongDescription" String="The value of this property shall indicate if access to the resources through the endpoint group is preferred over access through other endpoints.  The default value for this property is `false`."/>
+          <Annotation Term="Redfish.Revisions">
+            <Collection>
+              <Record>
+                <PropertyValue Property="Kind" EnumMember="Redfish.RevisionKind/Deprecated"/>
+                <PropertyValue Property="Version" String="v1_2_0"/>
+                <PropertyValue Property="Description" String="This property has been deprecated in favor of the AccessState property in the connection resource."/>
+              </Record>
+            </Collection>
+          </Annotation>
+        </Property>
+        <NavigationProperty Name="Endpoints" Type="Collection(Endpoint.Endpoint)">
+          <Annotation Term="OData.Permissions" EnumMember="OData.Permission/ReadWrite"/>
+          <Annotation Term="OData.Description" String="The endpoints in this endpoint group."/>
+          <Annotation Term="OData.LongDescription" String="This property shall contain an array of links to resources of type Endpoint that represent the endpoints that are in this endpoint group."/>
+          <Annotation Term="Redfish.Revisions">
+            <Collection>
+              <Record>
+                <PropertyValue Property="Kind" EnumMember="Redfish.RevisionKind/Deprecated"/>
+                <PropertyValue Property="Version" String="v1_3_0"/>
+                <PropertyValue Property="Description" String="This property has been deprecated in favor of the Endpoints property within Links."/>
+              </Record>
+            </Collection>
+          </Annotation>
+        </NavigationProperty>
+        <Property Name="Links" Type="EndpointGroup.v1_0_0.Links" Nullable="false">
+          <Annotation Term="OData.Description" String="The links to other resources that are related to this resource."/>
+          <Annotation Term="OData.LongDescription" String="This property shall contain links to resources that are related to but are not contained by, or subordinate to, this resource."/>
+        </Property>
+      </EntityType>
+
+      <ComplexType Name="Links" BaseType="Resource.Links">
+        <Annotation Term="OData.Description" String="The links to other resources that are related to this resource."/>
+        <Annotation Term="OData.LongDescription" String="This Redfish Specification-described type shall contain links to resources that are related to but are not contained by, or subordinate to, this resource."/>
+      </ComplexType>
+
+      <EnumType Name="GroupType">
+        <Member Name="Client">
+          <Annotation Term="OData.Description" String="The group contains the client (initiator) endpoints."/>
+          <Annotation Term="OData.LongDescription" String="This value shall indicate that the endpoint group contains client (initiator) endpoints.  If the associated endpoints contain the EntityRole property, the EntityRole property shall contain the value `Initiator` or `Both`."/>
+          <Annotation Term="Redfish.Revisions">
+            <Collection>
+              <Record>
+                <PropertyValue Property="Kind" EnumMember="Redfish.RevisionKind/Deprecated"/>
+                <PropertyValue Property="Version" String="v1_3_0"/>
+                <PropertyValue Property="Description" String="This value has been deprecated in favor of `Initiator`."/>
+              </Record>
+            </Collection>
+          </Annotation>
+        </Member>
+        <Member Name="Server">
+          <Annotation Term="OData.Description" String="The group contains the server (target) endpoints."/>
+          <Annotation Term="OData.LongDescription" String="This value shall indicate that the endpoint group contains server (target) endpoints.  If the associated endpoints contain the EntityRole property, the EntityRole property shall contain the value `Target` or `Both`."/>
+          <Annotation Term="Redfish.Revisions">
+            <Collection>
+              <Record>
+                <PropertyValue Property="Kind" EnumMember="Redfish.RevisionKind/Deprecated"/>
+                <PropertyValue Property="Version" String="v1_3_0"/>
+                <PropertyValue Property="Description" String="This value has been deprecated in favor of `Target`."/>
+              </Record>
+            </Collection>
+          </Annotation>
+        </Member>
+        <Member Name="Initiator">
+          <Annotation Term="OData.Description" String="The group contains the initiator endpoints."/>
+          <Annotation Term="OData.LongDescription" String="This value shall indicate that the endpoint group contains initiator endpoints.  If the associated endpoints contain the EntityRole property, the EntityRole property shall contain the value `Initiator` or `Both`."/>
+          <Annotation Term="Redfish.Revisions">
+            <Collection>
+              <Record>
+                <PropertyValue Property="Kind" EnumMember="Redfish.RevisionKind/Added"/>
+                <PropertyValue Property="Version" String="v1_3_0"/>
+              </Record>
+            </Collection>
+          </Annotation>
+        </Member>
+        <Member Name="Target">
+          <Annotation Term="OData.Description" String="The group contains the target endpoints."/>
+          <Annotation Term="OData.LongDescription" String="This value shall indicate that the endpoint group contains target endpoints.  If the associated endpoints contain the EntityRole property, the EntityRole property shall contain the value `Target` or `Both`."/>
+          <Annotation Term="Redfish.Revisions">
+            <Collection>
+              <Record>
+                <PropertyValue Property="Kind" EnumMember="Redfish.RevisionKind/Added"/>
+                <PropertyValue Property="Version" String="v1_3_0"/>
+              </Record>
+            </Collection>
+          </Annotation>
+        </Member>
+      </EnumType>
+    </Schema>
+
+    <Schema xmlns="http://docs.oasis-open.org/odata/ns/edm" Namespace="EndpointGroup.v1_0_1">
+      <Annotation Term="Redfish.OwningEntity" String="SNIA"/>
+      <Annotation Term="OData.Description" String="This version was created to force the regeneration of JSON Schema so that OData properties are marked as required, and integer properties are marked as integer rather than number."/>
+      <EntityType Name="EndpointGroup" BaseType="EndpointGroup.v1_0_0.EndpointGroup"/>
+    </Schema>
+
+    <Schema xmlns="http://docs.oasis-open.org/odata/ns/edm" Namespace="EndpointGroup.v1_0_2">
+      <Annotation Term="Redfish.OwningEntity" String="SNIA"/>
+      <Annotation Term="OData.Description" String="This version was created to fix CSDL errors and adds both resource URI patterns and resource capabilities annotations."/>
+      <EntityType Name="EndpointGroup" BaseType="EndpointGroup.v1_0_1.EndpointGroup"/>
+    </Schema>
+
+    <Schema xmlns="http://docs.oasis-open.org/odata/ns/edm" Namespace="EndpointGroup.v1_0_3">
+      <Annotation Term="Redfish.OwningEntity" String="DMTF"/>
+      <Annotation Term="OData.Description" String="This version was created to clarify descriptions for consistency."/>
+      <EntityType Name="EndpointGroup" BaseType="EndpointGroup.v1_0_2.EndpointGroup"/>
+    </Schema>
+
+    <Schema xmlns="http://docs.oasis-open.org/odata/ns/edm" Namespace="EndpointGroup.v1_0_4">
+      <Annotation Term="Redfish.OwningEntity" String="DMTF"/>
+      <Annotation Term="OData.Description" String="This version was created specify 64-bit integers in OpenAPI."/>
+      <EntityType Name="EndpointGroup" BaseType="EndpointGroup.v1_0_3.EndpointGroup"/>
+    </Schema>
+
+    <Schema xmlns="http://docs.oasis-open.org/odata/ns/edm" Namespace="EndpointGroup.v1_0_5">
+      <Annotation Term="Redfish.OwningEntity" String="DMTF"/>
+      <Annotation Term="OData.Description" String="This version was created to correct various description to use proper normative terminology."/>
+      <EntityType Name="EndpointGroup" BaseType="EndpointGroup.v1_0_4.EndpointGroup"/>
+    </Schema>
+
+    <Schema xmlns="http://docs.oasis-open.org/odata/ns/edm" Namespace="EndpointGroup.v1_1_0">
+      <Annotation Term="Redfish.OwningEntity" String="SNIA"/>
+      <Annotation Term="Redfish.Release" String="WIP v1.0.5"/>
+
+      <EntityType Name="EndpointGroup" BaseType="EndpointGroup.v1_0_0.EndpointGroup">
+        <Property Name="Actions" Type="EndpointGroup.v1_1_0.Actions" Nullable="false">
+          <Annotation Term="OData.Description" String="The available actions for this resource."/>
+          <Annotation Term="OData.LongDescription" String="This property shall contain the available actions for this resource."/>
+        </Property>
+      </EntityType>
+
+      <ComplexType Name="Actions">
+        <Annotation Term="OData.AdditionalProperties" Bool="false"/>
+        <Annotation Term="OData.Description" String="The available actions for this resource."/>
+        <Annotation Term="OData.LongDescription" String="This type shall contain the available actions for this resource."/>
+        <Property Name="Oem" Type="EndpointGroup.v1_1_0.OemActions" Nullable="false">
+          <Annotation Term="OData.Description" String="The available OEM-specific actions for this resource."/>
+          <Annotation Term="OData.LongDescription" String="This property shall contain the available OEM-specific actions for this resource."/>
+        </Property>
+      </ComplexType>
+
+      <ComplexType Name="OemActions">
+        <Annotation Term="OData.AdditionalProperties" Bool="true"/>
+        <Annotation Term="OData.Description" String="The available OEM-specific actions for this resource."/>
+        <Annotation Term="OData.LongDescription" String="This type shall contain the available OEM-specific actions for this resource."/>
+      </ComplexType>
+    </Schema>
+
+    <Schema xmlns="http://docs.oasis-open.org/odata/ns/edm" Namespace="EndpointGroup.v1_1_1">
+      <Annotation Term="Redfish.OwningEntity" String="SNIA"/>
+      <Annotation Term="OData.Description" String="This version was created to move several enumerations to the unversioned namespace."/>
+      <EntityType Name="EndpointGroup" BaseType="EndpointGroup.v1_1_0.EndpointGroup"/>
+    </Schema>
+
+    <Schema xmlns="http://docs.oasis-open.org/odata/ns/edm" Namespace="EndpointGroup.v1_1_2">
+      <Annotation Term="Redfish.OwningEntity" String="SNIA"/>
+      <Annotation Term="OData.Description" String="This version was created to force the regeneration of JSON Schema so that OData properties are marked as required, and integer properties are marked as integer rather than number."/>
+      <EntityType Name="EndpointGroup" BaseType="EndpointGroup.v1_1_1.EndpointGroup"/>
+    </Schema>
+
+    <Schema xmlns="http://docs.oasis-open.org/odata/ns/edm" Namespace="EndpointGroup.v1_1_3">
+      <Annotation Term="Redfish.OwningEntity" String="SNIA"/>
+      <Annotation Term="OData.Description" String="This version was created to fix CSDL errors and adds both resource URI patterns and resource capabilities annotations."/>
+      <EntityType Name="EndpointGroup" BaseType="EndpointGroup.v1_1_2.EndpointGroup"/>
+    </Schema>
+
+    <Schema xmlns="http://docs.oasis-open.org/odata/ns/edm" Namespace="EndpointGroup.v1_1_4">
+      <Annotation Term="Redfish.OwningEntity" String="DMTF"/>
+      <Annotation Term="OData.Description" String="This version was created to clarify descriptions for consistency."/>
+      <EntityType Name="EndpointGroup" BaseType="EndpointGroup.v1_1_3.EndpointGroup"/>
+    </Schema>
+
+    <Schema xmlns="http://docs.oasis-open.org/odata/ns/edm" Namespace="EndpointGroup.v1_1_5">
+      <Annotation Term="Redfish.OwningEntity" String="DMTF"/>
+      <Annotation Term="OData.Description" String="This version was created specify 64-bit integers in OpenAPI."/>
+      <EntityType Name="EndpointGroup" BaseType="EndpointGroup.v1_1_4.EndpointGroup"/>
+    </Schema>
+
+    <Schema xmlns="http://docs.oasis-open.org/odata/ns/edm" Namespace="EndpointGroup.v1_1_6">
+      <Annotation Term="Redfish.OwningEntity" String="DMTF"/>
+      <Annotation Term="OData.Description" String="This version was created to correct various description to use proper normative terminology."/>
+      <EntityType Name="EndpointGroup" BaseType="EndpointGroup.v1_1_5.EndpointGroup"/>
+    </Schema>
+
+    <Schema xmlns="http://docs.oasis-open.org/odata/ns/edm" Namespace="EndpointGroup.v1_2_0">
+      <Annotation Term="Redfish.OwningEntity" String="SNIA"/>
+      <Annotation Term="Redfish.Release" String="WIP v1.1.0"/>
+      <Annotation Term="OData.Description" String="This version was created to change Endpoints to an array instead of a resource collection.  This version was also created to fix CSDL errors and adds both resource URI patterns and resource capabilities annotations."/>
+
+      <EntityType Name="EndpointGroup" BaseType="EndpointGroup.v1_1_1.EndpointGroup"/>
+    </Schema>
+
+    <Schema xmlns="http://docs.oasis-open.org/odata/ns/edm" Namespace="EndpointGroup.v1_2_1">
+      <Annotation Term="Redfish.OwningEntity" String="SNIA"/>
+      <Annotation Term="OData.Description" String="This version was created to deprecated Preferred in favor of AccessState."/>
+      <EntityType Name="EndpointGroup" BaseType="EndpointGroup.v1_2_0.EndpointGroup"/>
+    </Schema>
+
+    <Schema xmlns="http://docs.oasis-open.org/odata/ns/edm" Namespace="EndpointGroup.v1_2_2">
+      <Annotation Term="Redfish.OwningEntity" String="DMTF"/>
+      <Annotation Term="OData.Description" String="This version was created to clarify descriptions for consistency."/>
+      <EntityType Name="EndpointGroup" BaseType="EndpointGroup.v1_2_1.EndpointGroup"/>
+    </Schema>
+
+    <Schema xmlns="http://docs.oasis-open.org/odata/ns/edm" Namespace="EndpointGroup.v1_2_3">
+      <Annotation Term="Redfish.OwningEntity" String="DMTF"/>
+      <Annotation Term="OData.Description" String="This version was created specify 64-bit integers in OpenAPI."/>
+      <EntityType Name="EndpointGroup" BaseType="EndpointGroup.v1_2_2.EndpointGroup"/>
+    </Schema>
+
+    <Schema xmlns="http://docs.oasis-open.org/odata/ns/edm" Namespace="EndpointGroup.v1_2_4">
+      <Annotation Term="Redfish.OwningEntity" String="DMTF"/>
+      <Annotation Term="OData.Description" String="This version was created to correct various description to use proper normative terminology."/>
+      <EntityType Name="EndpointGroup" BaseType="EndpointGroup.v1_2_3.EndpointGroup"/>
+    </Schema>
+
+    <Schema xmlns="http://docs.oasis-open.org/odata/ns/edm" Namespace="EndpointGroup.v1_3_0">
+      <Annotation Term="Redfish.OwningEntity" String="DMTF"/>
+      <Annotation Term="Redfish.Release" String="2020.3"/>
+      <Annotation Term="OData.Description" String="This version was created to migrate AccessState to the connection resource, deprecate Endpoints in favor of Endpoints in Links, and add `Target` and `Initiator` to GroupType."/>
+
+      <EntityType Name="EndpointGroup" BaseType="EndpointGroup.v1_2_2.EndpointGroup"/>
+
+      <ComplexType Name="Links" BaseType="EndpointGroup.v1_0_0.Links">
+        <NavigationProperty Name="Endpoints" Type="Collection(Endpoint.Endpoint)">
+          <Annotation Term="OData.Permissions" EnumMember="OData.Permission/ReadWrite"/>
+          <Annotation Term="OData.Description" String="The endpoints in this endpoint group."/>
+          <Annotation Term="OData.LongDescription" String="This property shall contain an array of links to resources of type Endpoint that represent the endpoints that are in this endpoint group."/>
+        </NavigationProperty>
+        <NavigationProperty Name="Connections" Type="Collection(Connection.Connection)">
+          <Annotation Term="OData.Permissions" EnumMember="OData.Permission/Read"/>
+          <Annotation Term="OData.Description" String="The connections to which this endpoint group belongs."/>
+          <Annotation Term="OData.LongDescription" String="This property shall contain an array of links to resources of type Connection that represent the connections to which this endpoint group belongs."/>
+        </NavigationProperty>
+      </ComplexType>
+    </Schema>
+
+    <Schema xmlns="http://docs.oasis-open.org/odata/ns/edm" Namespace="EndpointGroup.v1_3_1">
+      <Annotation Term="Redfish.OwningEntity" String="DMTF"/>
+      <Annotation Term="OData.Description" String="This version was created specify 64-bit integers in OpenAPI."/>
+      <EntityType Name="EndpointGroup" BaseType="EndpointGroup.v1_3_0.EndpointGroup"/>
+    </Schema>
+
+    <Schema xmlns="http://docs.oasis-open.org/odata/ns/edm" Namespace="EndpointGroup.v1_3_2">
+      <Annotation Term="Redfish.OwningEntity" String="DMTF"/>
+      <Annotation Term="OData.Description" String="This version was created to correct various description to use proper normative terminology."/>
+      <EntityType Name="EndpointGroup" BaseType="EndpointGroup.v1_3_1.EndpointGroup"/>
+    </Schema>
+
+  </edmx:DataServices>
+</edmx:Edmx>

--- a/static/redfish/v1/schema/Endpoint_v1.xml
+++ b/static/redfish/v1/schema/Endpoint_v1.xml
@@ -1,0 +1,876 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!---->
+<!--################################################################################       -->
+<!--# Redfish Schema:  Endpoint v1.6.1                                                     -->
+<!--#                                                                                      -->
+<!--# For a detailed change log, see the README file contained in the DSP8010 bundle,      -->
+<!--# available at http://www.dmtf.org/standards/redfish                                   -->
+<!--# Copyright 2014-2021 DMTF.                                                            -->
+<!--# For the full DMTF copyright policy, see http://www.dmtf.org/about/policies/copyright -->
+<!--################################################################################       -->
+<!---->
+<edmx:Edmx xmlns:edmx="http://docs.oasis-open.org/odata/ns/edmx" Version="4.0">
+
+  <edmx:Reference Uri="http://docs.oasis-open.org/odata/odata/v4.0/errata03/csd01/complete/vocabularies/Org.OData.Core.V1.xml">
+    <edmx:Include Namespace="Org.OData.Core.V1" Alias="OData"/>
+  </edmx:Reference>
+  <edmx:Reference Uri="http://docs.oasis-open.org/odata/odata/v4.0/errata03/csd01/complete/vocabularies/Org.OData.Capabilities.V1.xml">
+    <edmx:Include Namespace="Org.OData.Capabilities.V1" Alias="Capabilities"/>
+  </edmx:Reference>
+  <edmx:Reference Uri="http://docs.oasis-open.org/odata/odata/v4.0/errata03/csd01/complete/vocabularies/Org.OData.Measures.V1.xml">
+    <edmx:Include Namespace="Org.OData.Measures.V1" Alias="Measures"/>
+  </edmx:Reference>
+  <edmx:Reference Uri="http://redfish.dmtf.org/schemas/v1/RedfishExtensions_v1.xml">
+    <edmx:Include Namespace="Validation.v1_0_0" Alias="Validation"/>
+  </edmx:Reference>
+  <edmx:Reference Uri="http://redfish.dmtf.org/schemas/v1/Resource_v1.xml">
+    <edmx:Include Namespace="Resource"/>
+    <edmx:Include Namespace="Resource.v1_0_0"/>
+  </edmx:Reference>
+  <edmx:Reference Uri="http://redfish.dmtf.org/schemas/v1/RedfishExtensions_v1.xml">
+    <edmx:Include Namespace="RedfishExtensions.v1_0_0" Alias="Redfish"/>
+  </edmx:Reference>
+  <edmx:Reference Uri="http://redfish.dmtf.org/schemas/v1/Redundancy_v1.xml">
+    <edmx:Include Namespace="Redundancy"/>
+  </edmx:Reference>
+  <edmx:Reference Uri="http://redfish.dmtf.org/schemas/v1/IPAddresses_v1.xml">
+    <edmx:Include Namespace="IPAddresses"/>
+  </edmx:Reference>
+  <edmx:Reference Uri="http://redfish.dmtf.org/schemas/v1/Port_v1.xml">
+    <edmx:Include Namespace="Port"/>
+  </edmx:Reference>
+  <edmx:Reference Uri="http://redfish.dmtf.org/schemas/v1/Protocol_v1.xml">
+    <edmx:Include Namespace="Protocol"/>
+  </edmx:Reference>
+  <edmx:Reference Uri="http://redfish.dmtf.org/schemas/v1/NetworkDeviceFunction_v1.xml">
+    <edmx:Include Namespace="NetworkDeviceFunction"/>
+  </edmx:Reference>
+  <edmx:Reference Uri="http://redfish.dmtf.org/schemas/v1/AddressPool_v1.xml">
+    <edmx:Include Namespace="AddressPool"/>
+  </edmx:Reference>
+  <edmx:Reference Uri="http://redfish.dmtf.org/schemas/v1/Connection_v1.xml">
+    <edmx:Include Namespace="Connection"/>
+  </edmx:Reference>
+  <edmx:Reference Uri="http://redfish.dmtf.org/schemas/v1/Zone_v1.xml">
+    <edmx:Include Namespace="Zone"/>
+  </edmx:Reference>
+
+  <edmx:DataServices>
+
+    <Schema xmlns="http://docs.oasis-open.org/odata/ns/edm" Namespace="Endpoint">
+      <Annotation Term="Redfish.OwningEntity" String="DMTF"/>
+
+      <EntityType Name="Endpoint" BaseType="Resource.v1_0_0.Resource" Abstract="true">
+        <Annotation Term="OData.Description" String="The Endpoint schema contains the properties of an endpoint resource that represents the properties of an entity that sends or receives protocol-defined messages over a transport."/>
+        <Annotation Term="OData.LongDescription" String="This resource contains a fabric endpoint for a Redfish implementation."/>
+        <Annotation Term="Capabilities.InsertRestrictions">
+          <Record>
+            <PropertyValue Property="Insertable" Bool="false"/>
+          </Record>
+        </Annotation>
+        <Annotation Term="Capabilities.UpdateRestrictions">
+          <Record>
+            <PropertyValue Property="Updatable" Bool="true"/>
+          </Record>
+        </Annotation>
+        <Annotation Term="Capabilities.DeleteRestrictions">
+          <Record>
+            <PropertyValue Property="Deletable" Bool="true"/>
+            <Annotation Term="OData.Description" String="To unenumerate an endpoint that a service does not automatically discover, delete the endpoint."/>
+          </Record>
+        </Annotation>
+        <Annotation Term="Redfish.Uris">
+          <Collection>
+            <String>/redfish/v1/Fabrics/{FabricId}/Endpoints/{EndpointId}</String>
+            <String>/redfish/v1/StorageServices/{StorageServiceId}/Endpoints/{EndpointId}</String>
+            <String>/redfish/v1/Storage/{StorageId}/Endpoints/{EndpointId}</String>
+          </Collection>
+        </Annotation>
+      </EntityType>
+    </Schema>
+
+    <Schema xmlns="http://docs.oasis-open.org/odata/ns/edm" Namespace="Endpoint.v1_0_0">
+      <Annotation Term="Redfish.OwningEntity" String="DMTF"/>
+      <Annotation Term="Redfish.Release" String="2016.2"/>
+
+      <EntityType Name="Endpoint" BaseType="Endpoint.Endpoint">
+        <Property Name="Status" Type="Resource.Status" Nullable="false">
+          <Annotation Term="OData.Description" String="The status and health of the resource and its subordinate or dependent resources."/>
+          <Annotation Term="OData.LongDescription" String="This property shall contain any status or health properties of the resource."/>
+        </Property>
+        <Property Name="EndpointProtocol" Type="Protocol.Protocol">
+          <Annotation Term="OData.Permissions" EnumMember="OData.Permission/Read"/>
+          <Annotation Term="OData.Description" String="The protocol supported by this endpoint."/>
+          <Annotation Term="OData.LongDescription" String="This property shall contain the protocol this endpoint uses to communicate with other endpoints on this fabric."/>
+        </Property>
+        <Property Name="ConnectedEntities" Type="Collection(Endpoint.v1_0_0.ConnectedEntity)" Nullable="false">
+          <Annotation Term="OData.Description" String="All the entities connected to this endpoint."/>
+          <Annotation Term="OData.LongDescription" String="This property shall contain all entities to which this endpoint allows access."/>
+        </Property>
+        <Property Name="Identifiers" Type="Collection(Resource.Identifier)" Nullable="false">
+          <Annotation Term="OData.Description" String="Identifiers for this endpoint."/>
+          <Annotation Term="OData.LongDescription" String="Identifiers for this endpoint shall be unique in the context of other endpoints that can reached over the connected network."/>
+        </Property>
+
+        <Property Name="PciId" Type="Endpoint.v1_0_0.PciId" Nullable="false">
+          <Annotation Term="OData.Description" String="The PCI ID of the endpoint."/>
+          <Annotation Term="OData.LongDescription" String="This property shall contain the PCI ID of the endpoint."/>
+        </Property>
+        <NavigationProperty Name="Redundancy" Type="Collection(Redundancy.Redundancy)" ContainsTarget="true">
+          <Annotation Term="OData.Description" String="Redundancy information for the lower-level endpoints supporting this endpoint."/>
+          <Annotation Term="OData.LongDescription" String="The values of the properties in this array shall show how this endpoint is grouped with other endpoints for form redundancy sets."/>
+          <Annotation Term="OData.AutoExpand"/>
+        </NavigationProperty>
+        <Property Name="HostReservationMemoryBytes" Type="Edm.Int64">
+          <Annotation Term="Measures.Unit" String="By"/>
+          <Annotation Term="OData.Permissions" EnumMember="OData.Permission/Read"/>
+          <Annotation Term="OData.Description" String="The amount of memory in bytes that the host should allocate to connect to this endpoint."/>
+          <Annotation Term="OData.LongDescription" String="This property shall contain the amount of memory in bytes that the host should allocate to connect to this endpoint."/>
+        </Property>
+
+        <Property Name="Links" Type="Endpoint.v1_0_0.Links" Nullable="false">
+          <Annotation Term="OData.Description" String="The links to other resources that are related to this resource."/>
+          <Annotation Term="OData.LongDescription" String="This property shall contain links to resources that are related to but are not contained by, or subordinate to, this resource."/>
+        </Property>
+        <Property Name="Actions" Type="Endpoint.v1_0_0.Actions" Nullable="false">
+          <Annotation Term="OData.Description" String="The available actions for this resource."/>
+          <Annotation Term="OData.LongDescription" String="This property shall contain the available actions for this resource."/>
+        </Property>
+      </EntityType>
+
+      <ComplexType Name="Links" BaseType="Resource.Links">
+        <Annotation Term="OData.Description" String="The links to other resources that are related to this resource."/>
+        <Annotation Term="OData.LongDescription" String="This Redfish Specification-described type shall contain links to resources that are related to but are not contained by, or subordinate to, this resource."/>
+        <NavigationProperty Name="MutuallyExclusiveEndpoints" Type="Collection(Endpoint.Endpoint)">
+          <Annotation Term="OData.Permissions" EnumMember="OData.Permission/Read"/>
+          <Annotation Term="OData.Description" String="An array of links to the endpoints that cannot be used in zones if this endpoint is in a zone."/>
+          <Annotation Term="OData.LongDescription" String="This property shall contain an array of links to resources of type Endpoint that cannot be used in a zone if this endpoint is in a zone."/>
+          <Annotation Term="OData.AutoExpandReferences"/>
+        </NavigationProperty>
+        <NavigationProperty Name="Ports" Type="Collection(Port.Port)">
+          <Annotation Term="OData.Permissions" EnumMember="OData.Permission/Read"/>
+          <Annotation Term="OData.Description" String="An array of links to the physical ports associated with this endpoint."/>
+          <Annotation Term="OData.LongDescription" String="This property shall contain an array of links to resources of type Port that are utilized by this endpoint."/>
+          <Annotation Term="OData.AutoExpandReferences"/>
+        </NavigationProperty>
+      </ComplexType>
+
+      <ComplexType Name="Actions">
+        <Annotation Term="OData.AdditionalProperties" Bool="false"/>
+        <Annotation Term="OData.Description" String="The available actions for this resource."/>
+        <Annotation Term="OData.LongDescription" String="This type shall contain the available actions for this resource."/>
+        <Property Name="Oem" Type="Endpoint.v1_0_0.OemActions" Nullable="false">
+          <Annotation Term="OData.Description" String="The available OEM-specific actions for this resource."/>
+          <Annotation Term="OData.LongDescription" String="This property shall contain the available OEM-specific actions for this resource."/>
+        </Property>
+      </ComplexType>
+
+      <ComplexType Name="OemActions">
+        <Annotation Term="OData.AdditionalProperties" Bool="true"/>
+        <Annotation Term="OData.Description" String="The available OEM-specific actions for this resource."/>
+        <Annotation Term="OData.LongDescription" String="This type shall contain the available OEM-specific actions for this resource."/>
+      </ComplexType>
+
+      <ComplexType Name="ConnectedEntity">
+        <Annotation Term="OData.AdditionalProperties" Bool="false"/>
+        <Annotation Term="OData.Description" String="Represents a remote resource that is connected to the network accessible to this endpoint."/>
+        <Annotation Term="OData.LongDescription" String="This type shall represent a remote resource that is connected to a network accessible to an endpoint."/>
+        <Property Name="EntityType" Type="Endpoint.v1_0_0.EntityType">
+          <Annotation Term="OData.Permissions" EnumMember="OData.Permission/Read"/>
+          <Annotation Term="OData.Description" String="The type of the connected entity."/>
+          <Annotation Term="OData.LongDescription" String="This property shall indicate if type of connected entity."/>
+        </Property>
+        <Property Name="EntityRole" Type="Endpoint.v1_0_0.EntityRole">
+          <Annotation Term="OData.Permissions" EnumMember="OData.Permission/Read"/>
+          <Annotation Term="OData.Description" String="The role of the connected entity."/>
+          <Annotation Term="OData.LongDescription" String="This property shall indicate if the specified entity is an initiator, target, or both."/>
+        </Property>
+        <Property Name="EntityPciId" Type="Endpoint.v1_0_0.PciId" Nullable="false">
+          <Annotation Term="OData.Description" String="The PCI ID of the connected entity."/>
+          <Annotation Term="OData.LongDescription" String="This property shall contain the PCI ID of the connected PCIe entity."/>
+        </Property>
+        <Property Name="PciFunctionNumber" Type="Edm.Int64">
+          <Annotation Term="OData.Permissions" EnumMember="OData.Permission/Read"/>
+          <Annotation Term="OData.Description" String="The PCI ID of the connected entity."/>
+          <Annotation Term="OData.LongDescription" String="This property shall contain the PCI Function Number of the connected PCIe entity."/>
+          <Annotation Term="Redfish.Revisions">
+            <Collection>
+              <Record>
+                <PropertyValue Property="Kind" EnumMember="Redfish.RevisionKind/Deprecated"/>
+                <PropertyValue Property="Version" String="v1_2_0"/>
+                <PropertyValue Property="Description" String="This property has been deprecated in favor of the FunctionNumber property inside the EntityPciId object."/>
+              </Record>
+            </Collection>
+          </Annotation>
+        </Property>
+        <Property Name="PciClassCode" Type="Edm.String">
+          <Annotation Term="OData.Permissions" EnumMember="OData.Permission/Read"/>
+          <Annotation Term="OData.Description" String="The Class Code, Subclass, and Programming Interface code of this PCIe function."/>
+          <Annotation Term="OData.LongDescription" String="This property shall contain the PCI Class Code, Subclass, and Programming Interface of the PCIe device function."/>
+          <Annotation Term="Validation.Pattern" String="^0[xX](([a-fA-F]|[0-9]){2}){3}$"/>
+          <Annotation Term="Redfish.Revisions">
+            <Collection>
+              <Record>
+                <PropertyValue Property="Kind" EnumMember="Redfish.RevisionKind/Deprecated"/>
+                <PropertyValue Property="Version" String="v1_2_0"/>
+                <PropertyValue Property="Description" String="This property has been deprecated in favor of the ClassCode property inside the EntityPciId object."/>
+              </Record>
+            </Collection>
+          </Annotation>
+        </Property>
+        <Property Name="Identifiers" Type="Collection(Resource.Identifier)" Nullable="false">
+          <Annotation Term="OData.Description" String="Identifiers for the remote entity."/>
+          <Annotation Term="OData.LongDescription" String="Identifiers for the remote entity shall be unique in the context of other resources that can reached over the connected network."/>
+        </Property>
+        <NavigationProperty Name="EntityLink" Type="Resource.Resource" Nullable="false">
+          <Annotation Term="OData.Permissions" EnumMember="OData.Permission/Read"/>
+          <Annotation Term="OData.Description" String="The link to the associated entity."/>
+          <Annotation Term="OData.LongDescription" String="This property shall contain a link to an entity of the type specified by the description of the EntityType property value."/>
+        </NavigationProperty>
+
+        <Property Name="Oem" Type="Resource.Oem" Nullable="false">
+          <Annotation Term="OData.Description" String="The OEM extension property."/>
+          <Annotation Term="OData.LongDescription" String="This property shall contain the OEM extensions.  All values for properties contained in this object shall conform to the Redfish Specification-described requirements."/>
+        </Property>
+      </ComplexType>
+
+      <EnumType Name="EntityType">
+        <Member Name="StorageInitiator">
+          <Annotation Term="OData.Description" String="The entity is a storage initiator."/>
+          <Annotation Term="OData.LongDescription" String="This value shall indicate the entity this endpoint represents is a storage initiator.  The EntityLink property, if present, should be of type StorageController."/>
+        </Member>
+        <Member Name="RootComplex">
+          <Annotation Term="OData.Description" String="The entity is a PCI(e) root complex."/>
+          <Annotation Term="OData.LongDescription" String="This value shall indicate the entity this endpoint represents is a PCI(e) root complex.  The EntityLink property, if present, should be of type ComputerSystem."/>
+        </Member>
+        <Member Name="NetworkController">
+          <Annotation Term="OData.Description" String="The entity is a network controller."/>
+          <Annotation Term="OData.LongDescription" String="This value shall indicate the entity this endpoint represents is a network controller.  The EntityLink property, if present, should be of type NetworkDeviceFunction or EthernetInterface."/>
+        </Member>
+        <Member Name="Drive">
+          <Annotation Term="OData.Description" String="The entity is a drive."/>
+          <Annotation Term="OData.LongDescription" String="This value shall indicate the entity this endpoint represents is a drive.  The EntityLink property, if present, should be of type Drive."/>
+        </Member>
+        <Member Name="StorageExpander">
+          <Annotation Term="OData.Description" String="The entity is a storage expander."/>
+          <Annotation Term="OData.LongDescription" String="This value shall indicate the entity this endpoint represents is a storage expander.  The EntityLink property, if present, should be of type Chassis."/>
+        </Member>
+        <Member Name="DisplayController">
+          <Annotation Term="OData.Description" String="The entity is a display controller."/>
+          <Annotation Term="OData.LongDescription" String="This value shall indicate the entity this endpoint represents is a display controller."/>
+        </Member>
+        <Member Name="Bridge">
+          <Annotation Term="OData.Description" String="The entity is a PCI(e) bridge."/>
+          <Annotation Term="OData.LongDescription" String="This value shall indicate the entity this endpoint represents is a PCI(e) bridge."/>
+        </Member>
+        <Member Name="Processor">
+          <Annotation Term="OData.Description" String="The entity is a processor."/>
+          <Annotation Term="OData.LongDescription" String="This value shall indicate the entity this endpoint represents is a processor.  The EntityLink property, if present, should be of type Processor."/>
+        </Member>
+        <Member Name="Volume">
+          <Annotation Term="OData.Description" String="The entity is a volume."/>
+          <Annotation Term="OData.LongDescription" String="This value shall indicate the entity this endpoint represents is a volume.  The EntityLink property, if present, should be of type Volume."/>
+          <Annotation Term="Redfish.Revisions">
+            <Collection>
+              <Record>
+                <PropertyValue Property="Kind" EnumMember="Redfish.RevisionKind/Added"/>
+                <PropertyValue Property="Version" String="v1_1_0"/>
+              </Record>
+            </Collection>
+          </Annotation>
+        </Member>
+        <Member Name="AccelerationFunction">
+          <Annotation Term="OData.Description" String="The entity is an acceleration function realized through a device, such as an FPGA."/>
+          <Annotation Term="OData.LongDescription" String="This value shall indicate the entity this endpoint represents is an acceleration function.  The EntityLink property, if present, should be of type AccelerationFunction."/>
+          <Annotation Term="Redfish.Revisions">
+            <Collection>
+              <Record>
+                <PropertyValue Property="Kind" EnumMember="Redfish.RevisionKind/Added"/>
+                <PropertyValue Property="Version" String="v1_3_0"/>
+              </Record>
+            </Collection>
+          </Annotation>
+        </Member>
+        <Member Name="MediaController">
+          <Annotation Term="OData.Description" String="The entity is a media controller."/>
+          <Annotation Term="OData.LongDescription" String="This value shall indicate the entity this endpoint represents is a media controller.  The EntityLink property, if present, should be of type MediaController."/>
+          <Annotation Term="Redfish.Revisions">
+            <Collection>
+              <Record>
+                <PropertyValue Property="Kind" EnumMember="Redfish.RevisionKind/Added"/>
+                <PropertyValue Property="Version" String="v1_4_0"/>
+              </Record>
+            </Collection>
+          </Annotation>
+        </Member>
+        <Member Name="MemoryChunk">
+          <Annotation Term="OData.Description" String="The entity is a memory chunk."/>
+          <Annotation Term="OData.LongDescription" String="This value shall indicate the entity this endpoint represents is a memory chunk.  The EntityLink property, if present, should be of type MemoryChunk."/>
+          <Annotation Term="Redfish.Revisions">
+            <Collection>
+              <Record>
+                <PropertyValue Property="Kind" EnumMember="Redfish.RevisionKind/Added"/>
+                <PropertyValue Property="Version" String="v1_4_0"/>
+              </Record>
+            </Collection>
+          </Annotation>
+        </Member>
+        <Member Name="Switch">
+          <Annotation Term="OData.Description" String="The entity is a switch, not an expander.  Use `Expander` for expanders."/>
+          <Annotation Term="OData.LongDescription" String="This value shall indicate the entity this endpoint represents is a switch and not an expander.  The EntityLink property, if present, should be of type Switch."/>
+          <Annotation Term="Redfish.Revisions">
+            <Collection>
+              <Record>
+                <PropertyValue Property="Kind" EnumMember="Redfish.RevisionKind/Added"/>
+                <PropertyValue Property="Version" String="v1_4_0"/>
+              </Record>
+            </Collection>
+          </Annotation>
+        </Member>
+        <Member Name="FabricBridge">
+          <Annotation Term="OData.Description" String="The entity is a fabric bridge."/>
+          <Annotation Term="OData.LongDescription" String="This value shall indicate the entity this endpoint represents is a fabric bridge.  The EntityLink property, if present, should be of type FabricAdapter."/>
+          <Annotation Term="Redfish.Revisions">
+            <Collection>
+              <Record>
+                <PropertyValue Property="Kind" EnumMember="Redfish.RevisionKind/Added"/>
+                <PropertyValue Property="Version" String="v1_4_0"/>
+              </Record>
+            </Collection>
+          </Annotation>
+        </Member>
+        <Member Name="Manager">
+          <Annotation Term="OData.Description" String="The entity is a manager."/>
+          <Annotation Term="OData.LongDescription" String="This value shall indicate the entity this endpoint represents is a manager.  The EntityLink property, if present, should be of type Manager."/>
+          <Annotation Term="Redfish.Revisions">
+            <Collection>
+              <Record>
+                <PropertyValue Property="Kind" EnumMember="Redfish.RevisionKind/Added"/>
+                <PropertyValue Property="Version" String="v1_5_0"/>
+              </Record>
+            </Collection>
+          </Annotation>
+        </Member>
+        <Member Name="StorageSubsystem">
+          <Annotation Term="OData.Description" String="The entity is a storage subsystem."/>
+          <Annotation Term="OData.LongDescription" String="This value shall indicate the entity this endpoint represents is a storage subsystem.  The EntityLink property, if present, should be of type Storage."/>
+          <Annotation Term="Redfish.Revisions">
+            <Collection>
+              <Record>
+                <PropertyValue Property="Kind" EnumMember="Redfish.RevisionKind/Added"/>
+                <PropertyValue Property="Version" String="v1_6_0"/>
+              </Record>
+            </Collection>
+          </Annotation>
+        </Member>
+      </EnumType>
+
+      <EnumType Name="EntityRole">
+        <Member Name="Initiator">
+          <Annotation Term="OData.Description" String="The entity sends commands, messages, or other types of requests to other entities on the fabric, but cannot receive commands from other entities."/>
+        </Member>
+        <Member Name="Target">
+          <Annotation Term="OData.Description" String="The entity receives commands, messages, or other types of requests from other entities on the fabric, but cannot send commands to other entities."/>
+        </Member>
+        <Member Name="Both">
+          <Annotation Term="OData.Description" String="The entity can both send and receive commands, messages, and other requests to or from other entities on the fabric."/>
+        </Member>
+      </EnumType>
+
+      <ComplexType Name="PciId">
+        <Annotation Term="OData.AdditionalProperties" Bool="false"/>
+        <Annotation Term="OData.Description" String="A PCI ID."/>
+        <Annotation Term="OData.LongDescription" String="This type shall describe a PCI ID."/>
+        <Property Name="DeviceId" Type="Edm.String">
+          <Annotation Term="OData.Permissions" EnumMember="OData.Permission/Read"/>
+          <Annotation Term="OData.Description" String="The Device ID of this PCIe function."/>
+          <Annotation Term="OData.LongDescription" String="This property shall contain the PCI Device ID of the PCIe device function."/>
+          <Annotation Term="Validation.Pattern" String="^0[xX](([a-fA-F]|[0-9]){2}){2}$"/>
+        </Property>
+        <Property Name="VendorId" Type="Edm.String">
+          <Annotation Term="OData.Permissions" EnumMember="OData.Permission/Read"/>
+          <Annotation Term="OData.Description" String="The Vendor ID of this PCIe function."/>
+          <Annotation Term="OData.LongDescription" String="This property shall contain the PCI Vendor ID of the PCIe device function."/>
+          <Annotation Term="Validation.Pattern" String="^0[xX](([a-fA-F]|[0-9]){2}){2}$"/>
+        </Property>
+        <Property Name="SubsystemId" Type="Edm.String">
+          <Annotation Term="OData.Permissions" EnumMember="OData.Permission/Read"/>
+          <Annotation Term="OData.Description" String="The Subsystem ID of this PCIe function."/>
+          <Annotation Term="OData.LongDescription" String="This property shall contain the PCI Subsystem ID of the PCIe device function."/>
+          <Annotation Term="Validation.Pattern" String="^0[xX](([a-fA-F]|[0-9]){2}){2}$"/>
+        </Property>
+        <Property Name="SubsystemVendorId" Type="Edm.String">
+          <Annotation Term="OData.Permissions" EnumMember="OData.Permission/Read"/>
+          <Annotation Term="OData.Description" String="The Subsystem Vendor ID of this PCIe function."/>
+          <Annotation Term="OData.LongDescription" String="This property shall contain the PCI Subsystem Vendor ID of the PCIe device function."/>
+          <Annotation Term="Validation.Pattern" String="^0[xX](([a-fA-F]|[0-9]){2}){2}$"/>
+        </Property>
+      </ComplexType>
+    </Schema>
+
+    <Schema xmlns="http://docs.oasis-open.org/odata/ns/edm" Namespace="Endpoint.v1_0_1">
+      <Annotation Term="Redfish.OwningEntity" String="DMTF"/>
+      <Annotation Term="OData.Description" String="This version was created to add explicit permissions annotations to all properties for clarity."/>
+      <EntityType Name="Endpoint" BaseType="Endpoint.v1_0_0.Endpoint"/>
+    </Schema>
+
+    <Schema xmlns="http://docs.oasis-open.org/odata/ns/edm" Namespace="Endpoint.v1_0_2">
+      <Annotation Term="Redfish.OwningEntity" String="DMTF"/>
+      <Annotation Term="OData.Description" String="This version was created to show that annotations in previous namespaces were updated and to remove the Nullable facet on NavigationProperties of the Collection type."/>
+      <EntityType Name="Endpoint" BaseType="Endpoint.v1_0_1.Endpoint"/>
+    </Schema>
+
+    <Schema xmlns="http://docs.oasis-open.org/odata/ns/edm" Namespace="Endpoint.v1_0_3">
+      <Annotation Term="Redfish.OwningEntity" String="DMTF"/>
+      <Annotation Term="OData.Description" String="This version was created to add the OData.AdditionalProperties annotation to the ConnectedEntity and PciId definitions, and to change Identifier to its abstract base type, and Protocol to use the unversioned definition."/>
+      <EntityType Name="Endpoint" BaseType="Endpoint.v1_0_2.Endpoint"/>
+    </Schema>
+
+    <Schema xmlns="http://docs.oasis-open.org/odata/ns/edm" Namespace="Endpoint.v1_0_4">
+      <Annotation Term="Redfish.OwningEntity" String="DMTF"/>
+      <Annotation Term="OData.Description" String="This version was created to force the regeneration of JSON Schema so that OData properties are marked as required, and integer properties are marked as integer rather than number."/>
+      <EntityType Name="Endpoint" BaseType="Endpoint.v1_0_3.Endpoint"/>
+    </Schema>
+
+    <Schema xmlns="http://docs.oasis-open.org/odata/ns/edm" Namespace="Endpoint.v1_0_5">
+      <Annotation Term="Redfish.OwningEntity" String="DMTF"/>
+      <Annotation Term="OData.Description" String="This version was created to use the new revisions annotation."/>
+      <EntityType Name="Endpoint" BaseType="Endpoint.v1_0_4.Endpoint"/>
+    </Schema>
+
+    <Schema xmlns="http://docs.oasis-open.org/odata/ns/edm" Namespace="Endpoint.v1_0_6">
+      <Annotation Term="Redfish.OwningEntity" String="DMTF"/>
+      <Annotation Term="OData.Description" String="This version was created to force the regeneration of JSON Schema so that URI properties use the uri-reference format, clarifies the EntityRole enumeration descriptions, and adds a missing term to several properties to disallow them from being null."/>
+      <EntityType Name="Endpoint" BaseType="Endpoint.v1_0_5.Endpoint"/>
+    </Schema>
+
+    <Schema xmlns="http://docs.oasis-open.org/odata/ns/edm" Namespace="Endpoint.v1_0_7">
+      <Annotation Term="Redfish.OwningEntity" String="DMTF"/>
+      <Annotation Term="OData.Description" String="This version was created to update descriptions that this schema defines."/>
+      <EntityType Name="Endpoint" BaseType="Endpoint.v1_0_6.Endpoint"/>
+    </Schema>
+
+    <Schema xmlns="http://docs.oasis-open.org/odata/ns/edm" Namespace="Endpoint.v1_0_8">
+      <Annotation Term="Redfish.OwningEntity" String="DMTF"/>
+      <Annotation Term="OData.Description" String="This version was created to correct various typographical errors."/>
+      <EntityType Name="Endpoint" BaseType="Endpoint.v1_0_7.Endpoint"/>
+    </Schema>
+
+    <Schema xmlns="http://docs.oasis-open.org/odata/ns/edm" Namespace="Endpoint.v1_0_9">
+      <Annotation Term="Redfish.OwningEntity" String="DMTF"/>
+      <Annotation Term="OData.Description" String="This version was created to correct various typographical errors."/>
+      <EntityType Name="Endpoint" BaseType="Endpoint.v1_0_8.Endpoint"/>
+    </Schema>
+
+    <Schema xmlns="http://docs.oasis-open.org/odata/ns/edm" Namespace="Endpoint.v1_0_10">
+      <Annotation Term="Redfish.OwningEntity" String="DMTF"/>
+      <Annotation Term="OData.Description" String="This version was created specify 64-bit integers in OpenAPI."/>
+      <EntityType Name="Endpoint" BaseType="Endpoint.v1_0_9.Endpoint"/>
+    </Schema>
+
+    <Schema xmlns="http://docs.oasis-open.org/odata/ns/edm" Namespace="Endpoint.v1_0_11">
+      <Annotation Term="Redfish.OwningEntity" String="DMTF"/>
+      <Annotation Term="OData.Description" String="This version was created to clarify the descriptions for the EntityType enumeration values."/>
+      <EntityType Name="Endpoint" BaseType="Endpoint.v1_0_10.Endpoint"/>
+    </Schema>
+
+    <Schema xmlns="http://docs.oasis-open.org/odata/ns/edm" Namespace="Endpoint.v1_0_12">
+      <Annotation Term="Redfish.OwningEntity" String="DMTF"/>
+      <Annotation Term="OData.Description" String="This version was created to correct a typographical error in the SubsystemId long description."/>
+      <EntityType Name="Endpoint" BaseType="Endpoint.v1_0_11.Endpoint"/>
+    </Schema>
+
+    <Schema xmlns="http://docs.oasis-open.org/odata/ns/edm" Namespace="Endpoint.v1_1_0">
+      <Annotation Term="Redfish.OwningEntity" String="DMTF"/>
+      <Annotation Term="Redfish.Release" String="2017.3"/>
+      <EntityType Name="Endpoint" BaseType="Endpoint.v1_0_3.Endpoint">
+        <Property Name="IPTransportDetails" Type="Collection(Endpoint.v1_1_0.IPTransportDetails)" Nullable="false">
+          <Annotation Term="OData.Description" String="An array of details for each IP transport supported by this endpoint.  The array structure can model multiple IP addresses for this endpoint."/>
+          <Annotation Term="OData.LongDescription" String="This array shall contain the details for each IP transport supported by this endpoint."/>
+          <Annotation Term="OData.AutoExpandReferences"/>
+        </Property>
+      </EntityType>
+
+      <ComplexType Name="Links" BaseType="Endpoint.v1_0_0.Links">
+        <NavigationProperty Name="NetworkDeviceFunction" Type="Collection(NetworkDeviceFunction.NetworkDeviceFunction)">
+          <Annotation Term="OData.Permissions" EnumMember="OData.Permission/Read"/>
+          <Annotation Term="OData.Description" String="When NetworkDeviceFunction resources are present, this array contains links to the network device functions that connect to this endpoint."/>
+          <Annotation Term="OData.LongDescription" String="This property shall contain an array of links to resources of type NetworkDeviceFunction with which this endpoint is associated."/>
+          <Annotation Term="OData.AutoExpandReferences"/>
+        </NavigationProperty>
+      </ComplexType>
+
+      <ComplexType Name="IPTransportDetails">
+        <Annotation Term="OData.Description" String="This type specifies the details of the transport supported by the endpoint.  The properties that are present are dependent on the type of transport supported by the endpoint."/>
+        <Annotation Term="OData.LongDescription" String="The type shall contain properties that specify the details of the transport supported by the endpoint."/>
+        <Annotation Term="OData.AdditionalProperties" Bool="false"/>
+        <Property Name="TransportProtocol" Type="Protocol.Protocol" Nullable="false">
+          <Annotation Term="OData.Permissions" EnumMember="OData.Permission/Read"/>
+          <Annotation Term="OData.Description" String="The protocol used by the connection entity."/>
+          <Annotation Term="OData.LongDescription" String="This property shall contain the protocol used by the connection entity."/>
+        </Property>
+        <Property Name="IPv4Address" Type="IPAddresses.IPv4Address" Nullable="false">
+          <Annotation Term="OData.Description" String="The IPv4 addresses assigned to the endpoint."/>
+          <Annotation Term="OData.LongDescription" String="This property shall contain the IPv4Address."/>
+        </Property>
+        <Property Name="IPv6Address" Type="IPAddresses.IPv6Address" Nullable="false">
+          <Annotation Term="OData.Description" String="The IPv6 addresses assigned to the endpoint."/>
+          <Annotation Term="OData.LongDescription" String="This property shall contain the IPv6Address."/>
+        </Property>
+        <Property Name="Port" Type="Edm.Decimal" Nullable="false">
+          <Annotation Term="OData.Permissions" EnumMember="OData.Permission/Read"/>
+          <Annotation Term="OData.Description" String="The UDP or TCP port number used by the endpoint."/>
+          <Annotation Term="OData.LongDescription" String="This property shall contain an specify UDP or TCP port number used for communication with the endpoint."/>
+          <Annotation Term="Validation.Minimum" Int="0"/>
+          <Annotation Term="Validation.Maximum" Int="65535"/>
+        </Property>
+      </ComplexType>
+    </Schema>
+
+    <Schema xmlns="http://docs.oasis-open.org/odata/ns/edm" Namespace="Endpoint.v1_1_1">
+      <Annotation Term="Redfish.OwningEntity" String="DMTF"/>
+      <Annotation Term="OData.Description" String="This version was created to force the regeneration of JSON Schema so that OData properties are marked as required, and integer properties are marked as integer rather than number."/>
+      <EntityType Name="Endpoint" BaseType="Endpoint.v1_1_0.Endpoint"/>
+    </Schema>
+
+    <Schema xmlns="http://docs.oasis-open.org/odata/ns/edm" Namespace="Endpoint.v1_1_2">
+      <Annotation Term="Redfish.OwningEntity" String="DMTF"/>
+      <Annotation Term="OData.Description" String="This version was created to use the new revisions annotation."/>
+      <EntityType Name="Endpoint" BaseType="Endpoint.v1_1_1.Endpoint"/>
+    </Schema>
+
+    <Schema xmlns="http://docs.oasis-open.org/odata/ns/edm" Namespace="Endpoint.v1_1_3">
+      <Annotation Term="Redfish.OwningEntity" String="DMTF"/>
+      <Annotation Term="OData.Description" String="This version was created to force the regeneration of JSON Schema so that URI properties use the uri-reference format, clarifies the EntityRole enumeration descriptions, and adds a missing term to several properties to disallow them from being null."/>
+      <EntityType Name="Endpoint" BaseType="Endpoint.v1_1_2.Endpoint"/>
+    </Schema>
+
+    <Schema xmlns="http://docs.oasis-open.org/odata/ns/edm" Namespace="Endpoint.v1_1_4">
+      <Annotation Term="Redfish.OwningEntity" String="DMTF"/>
+      <Annotation Term="OData.Description" String="This version was created to update descriptions that this schema defines."/>
+      <EntityType Name="Endpoint" BaseType="Endpoint.v1_1_3.Endpoint"/>
+    </Schema>
+
+    <Schema xmlns="http://docs.oasis-open.org/odata/ns/edm" Namespace="Endpoint.v1_1_5">
+      <Annotation Term="Redfish.OwningEntity" String="DMTF"/>
+      <Annotation Term="OData.Description" String="This version was created to correct various typographical errors."/>
+      <EntityType Name="Endpoint" BaseType="Endpoint.v1_1_4.Endpoint"/>
+    </Schema>
+
+    <Schema xmlns="http://docs.oasis-open.org/odata/ns/edm" Namespace="Endpoint.v1_1_6">
+      <Annotation Term="Redfish.OwningEntity" String="DMTF"/>
+      <Annotation Term="OData.Description" String="This version was created to correct various typographical errors."/>
+      <EntityType Name="Endpoint" BaseType="Endpoint.v1_1_5.Endpoint"/>
+    </Schema>
+
+    <Schema xmlns="http://docs.oasis-open.org/odata/ns/edm" Namespace="Endpoint.v1_1_7">
+      <Annotation Term="Redfish.OwningEntity" String="DMTF"/>
+      <Annotation Term="OData.Description" String="This version was created specify 64-bit integers in OpenAPI."/>
+      <EntityType Name="Endpoint" BaseType="Endpoint.v1_1_6.Endpoint"/>
+    </Schema>
+
+    <Schema xmlns="http://docs.oasis-open.org/odata/ns/edm" Namespace="Endpoint.v1_1_8">
+      <Annotation Term="Redfish.OwningEntity" String="DMTF"/>
+      <Annotation Term="OData.Description" String="This version was created to clarify the descriptions for the EntityType enumeration values."/>
+      <EntityType Name="Endpoint" BaseType="Endpoint.v1_1_7.Endpoint"/>
+    </Schema>
+
+    <Schema xmlns="http://docs.oasis-open.org/odata/ns/edm" Namespace="Endpoint.v1_1_9">
+      <Annotation Term="Redfish.OwningEntity" String="DMTF"/>
+      <Annotation Term="OData.Description" String="This version was created to correct a typographical error in the SubsystemId long description."/>
+      <EntityType Name="Endpoint" BaseType="Endpoint.v1_1_8.Endpoint"/>
+    </Schema>
+
+    <Schema xmlns="http://docs.oasis-open.org/odata/ns/edm" Namespace="Endpoint.v1_2_0">
+      <Annotation Term="Redfish.OwningEntity" String="DMTF"/>
+      <Annotation Term="Redfish.Release" String="2018.2"/>
+      <EntityType Name="Endpoint" BaseType="Endpoint.v1_1_1.Endpoint"/>
+
+      <ComplexType Name="PciId" BaseType="Endpoint.v1_0_0.PciId">
+        <Property Name="FunctionNumber" Type="Edm.Int64">
+          <Annotation Term="OData.Permissions" EnumMember="OData.Permission/Read"/>
+          <Annotation Term="OData.Description" String="The PCI ID of the connected entity."/>
+          <Annotation Term="OData.LongDescription" String="This property shall contain the PCI Function Number of the connected PCIe entity."/>
+        </Property>
+        <Property Name="ClassCode" Type="Edm.String">
+          <Annotation Term="OData.Permissions" EnumMember="OData.Permission/Read"/>
+          <Annotation Term="OData.Description" String="The Class Code, Subclass, and Programming Interface code of this PCIe function."/>
+          <Annotation Term="OData.LongDescription" String="This property shall contain the PCI Class Code, Subclass, and Programming Interface of the PCIe device function."/>
+          <Annotation Term="Validation.Pattern" String="^0[xX](([a-fA-F]|[0-9]){2}){3}$"/>
+        </Property>
+      </ComplexType>
+    </Schema>
+
+    <Schema xmlns="http://docs.oasis-open.org/odata/ns/edm" Namespace="Endpoint.v1_2_1">
+      <Annotation Term="Redfish.OwningEntity" String="DMTF"/>
+      <Annotation Term="OData.Description" String="This version was created to use the new revisions annotation."/>
+      <EntityType Name="Endpoint" BaseType="Endpoint.v1_2_0.Endpoint"/>
+    </Schema>
+
+    <Schema xmlns="http://docs.oasis-open.org/odata/ns/edm" Namespace="Endpoint.v1_2_2">
+      <Annotation Term="Redfish.OwningEntity" String="DMTF"/>
+      <Annotation Term="OData.Description" String="This version was created to force the regeneration of JSON Schema so that URI properties use the uri-reference format, clarifies the EntityRole enumeration descriptions, and adds a missing term to several properties to disallow them from being null."/>
+      <EntityType Name="Endpoint" BaseType="Endpoint.v1_2_1.Endpoint"/>
+    </Schema>
+
+    <Schema xmlns="http://docs.oasis-open.org/odata/ns/edm" Namespace="Endpoint.v1_2_3">
+      <Annotation Term="Redfish.OwningEntity" String="DMTF"/>
+      <Annotation Term="OData.Description" String="This version was created to update descriptions that this schema defines."/>
+      <EntityType Name="Endpoint" BaseType="Endpoint.v1_2_2.Endpoint"/>
+    </Schema>
+
+    <Schema xmlns="http://docs.oasis-open.org/odata/ns/edm" Namespace="Endpoint.v1_2_4">
+      <Annotation Term="Redfish.OwningEntity" String="DMTF"/>
+      <Annotation Term="OData.Description" String="This version was created to correct various typographical errors."/>
+      <EntityType Name="Endpoint" BaseType="Endpoint.v1_2_3.Endpoint"/>
+    </Schema>
+
+    <Schema xmlns="http://docs.oasis-open.org/odata/ns/edm" Namespace="Endpoint.v1_2_5">
+      <Annotation Term="Redfish.OwningEntity" String="DMTF"/>
+      <Annotation Term="OData.Description" String="This version was created to correct various typographical errors."/>
+      <EntityType Name="Endpoint" BaseType="Endpoint.v1_2_4.Endpoint"/>
+    </Schema>
+
+    <Schema xmlns="http://docs.oasis-open.org/odata/ns/edm" Namespace="Endpoint.v1_2_6">
+      <Annotation Term="Redfish.OwningEntity" String="DMTF"/>
+      <Annotation Term="OData.Description" String="This version was created specify 64-bit integers in OpenAPI."/>
+      <EntityType Name="Endpoint" BaseType="Endpoint.v1_2_5.Endpoint"/>
+    </Schema>
+
+    <Schema xmlns="http://docs.oasis-open.org/odata/ns/edm" Namespace="Endpoint.v1_2_7">
+      <Annotation Term="Redfish.OwningEntity" String="DMTF"/>
+      <Annotation Term="OData.Description" String="This version was created to clarify the descriptions for the EntityType enumeration values."/>
+      <EntityType Name="Endpoint" BaseType="Endpoint.v1_2_6.Endpoint"/>
+    </Schema>
+
+    <Schema xmlns="http://docs.oasis-open.org/odata/ns/edm" Namespace="Endpoint.v1_2_8">
+      <Annotation Term="Redfish.OwningEntity" String="DMTF"/>
+      <Annotation Term="OData.Description" String="This version was created to correct a typographical error in the SubsystemId long description."/>
+      <EntityType Name="Endpoint" BaseType="Endpoint.v1_2_7.Endpoint"/>
+    </Schema>
+
+    <Schema xmlns="http://docs.oasis-open.org/odata/ns/edm" Namespace="Endpoint.v1_3_0">
+      <Annotation Term="Redfish.OwningEntity" String="DMTF"/>
+      <Annotation Term="Redfish.Release" String="2018.3"/>
+      <Annotation Term="OData.Description" String="This version was created to add AccelerationFunction to the EntityType enumeration."/>
+
+      <EntityType Name="Endpoint" BaseType="Endpoint.v1_2_1.Endpoint"/>
+    </Schema>
+
+    <Schema xmlns="http://docs.oasis-open.org/odata/ns/edm" Namespace="Endpoint.v1_3_1">
+      <Annotation Term="Redfish.OwningEntity" String="DMTF"/>
+      <Annotation Term="OData.Description" String="This version was created to force the regeneration of JSON Schema so that URI properties use the uri-reference format, clarifies the EntityRole enumeration descriptions, and adds a missing term to several properties to disallow them from being null."/>
+      <EntityType Name="Endpoint" BaseType="Endpoint.v1_3_0.Endpoint"/>
+    </Schema>
+
+    <Schema xmlns="http://docs.oasis-open.org/odata/ns/edm" Namespace="Endpoint.v1_3_2">
+      <Annotation Term="Redfish.OwningEntity" String="DMTF"/>
+      <Annotation Term="OData.Description" String="This version was created to update descriptions that this schema defines."/>
+      <EntityType Name="Endpoint" BaseType="Endpoint.v1_3_1.Endpoint"/>
+    </Schema>
+
+    <Schema xmlns="http://docs.oasis-open.org/odata/ns/edm" Namespace="Endpoint.v1_3_3">
+      <Annotation Term="Redfish.OwningEntity" String="DMTF"/>
+      <Annotation Term="OData.Description" String="This version was created to correct various typographical errors."/>
+      <EntityType Name="Endpoint" BaseType="Endpoint.v1_3_2.Endpoint"/>
+    </Schema>
+
+    <Schema xmlns="http://docs.oasis-open.org/odata/ns/edm" Namespace="Endpoint.v1_3_4">
+      <Annotation Term="Redfish.OwningEntity" String="DMTF"/>
+      <Annotation Term="OData.Description" String="This version was created to correct various typographical errors."/>
+      <EntityType Name="Endpoint" BaseType="Endpoint.v1_3_3.Endpoint"/>
+    </Schema>
+
+    <Schema xmlns="http://docs.oasis-open.org/odata/ns/edm" Namespace="Endpoint.v1_3_5">
+      <Annotation Term="Redfish.OwningEntity" String="DMTF"/>
+      <Annotation Term="OData.Description" String="This version was created specify 64-bit integers in OpenAPI."/>
+      <EntityType Name="Endpoint" BaseType="Endpoint.v1_3_4.Endpoint"/>
+    </Schema>
+
+    <Schema xmlns="http://docs.oasis-open.org/odata/ns/edm" Namespace="Endpoint.v1_3_6">
+      <Annotation Term="Redfish.OwningEntity" String="DMTF"/>
+      <Annotation Term="OData.Description" String="This version was created to clarify the descriptions for the EntityType enumeration values."/>
+      <EntityType Name="Endpoint" BaseType="Endpoint.v1_3_5.Endpoint"/>
+    </Schema>
+
+    <Schema xmlns="http://docs.oasis-open.org/odata/ns/edm" Namespace="Endpoint.v1_3_7">
+      <Annotation Term="Redfish.OwningEntity" String="DMTF"/>
+      <Annotation Term="OData.Description" String="This version was created to correct a typographical error in the SubsystemId long description."/>
+      <EntityType Name="Endpoint" BaseType="Endpoint.v1_3_6.Endpoint"/>
+    </Schema>
+
+    <Schema xmlns="http://docs.oasis-open.org/odata/ns/edm" Namespace="Endpoint.v1_4_0">
+      <Annotation Term="Redfish.OwningEntity" String="DMTF"/>
+      <Annotation Term="Redfish.Release" String="2019.4"/>
+
+      <EntityType Name="Endpoint" BaseType="Endpoint.v1_3_2.Endpoint"/>
+
+      <ComplexType Name="ConnectedEntity" BaseType="Endpoint.v1_0_0.ConnectedEntity">
+        <Property Name="GenZ" Type="Endpoint.v1_4_0.GenZ">
+          <Annotation Term="OData.Description" String="The Gen-Z related properties for the entity."/>
+          <Annotation Term="OData.LongDescription" String="This property shall contain the Gen-Z related properties for the entity."/>
+        </Property>
+      </ComplexType>
+
+      <ComplexType Name="GenZ">
+        <Annotation Term="OData.AdditionalProperties" Bool="false"/>
+        <Annotation Term="OData.Description" String="The Gen-Z related properties for an entity."/>
+        <Annotation Term="OData.LongDescription" String="This type shall contain the Gen-Z related properties for an entity."/>
+        <Property Name="GCID" Type="Endpoint.v1_4_0.GCID">
+          <Annotation Term="OData.Description" String="The Global Component ID (GCID) for the entity."/>
+          <Annotation Term="OData.LongDescription" String="This property shall contain the Gen-Z Core Specification-defined Global Component ID for the entity."/>
+        </Property>
+        <Property Name="AccessKey" Type="Edm.String">
+          <Annotation Term="OData.Permissions" EnumMember="OData.Permission/ReadWrite"/>
+          <Annotation Term="OData.Description" String="The Access Key for the entity."/>
+          <Annotation Term="OData.LongDescription" String="This property shall contain the Gen-Z Core Specification-defined 6 bit Access Key for the entity."/>
+          <Annotation Term="Validation.Pattern" String="^0[xX]([a-fA-F]|[0-9]){2}$"/>
+          <Annotation Term="Redfish.Revisions">
+            <Collection>
+              <Record>
+                <PropertyValue Property="Kind" EnumMember="Redfish.RevisionKind/Deprecated"/>
+                <PropertyValue Property="Version" String="v1_6_0"/>
+                <PropertyValue Property="Description" String="This property has been deprecated in favor of the ConnectionKeys property in the Connection resource."/>
+              </Record>
+            </Collection>
+          </Annotation>
+        </Property>
+        <Property Name="RegionKey" Type="Edm.String">
+          <Annotation Term="OData.Permissions" EnumMember="OData.Permission/ReadWrite"/>
+          <Annotation Term="OData.Description" String="The Region Key for the entity."/>
+          <Annotation Term="OData.LongDescription" String="This property shall contain the Gen-Z Core Specification-defined 32 bit Region Key for the entity."/>
+          <Annotation Term="Validation.Pattern" String="^0[xX](([a-fA-F]|[0-9]){2}){4}$"/>
+          <Annotation Term="Redfish.Revisions">
+            <Collection>
+              <Record>
+                <PropertyValue Property="Kind" EnumMember="Redfish.RevisionKind/Deprecated"/>
+                <PropertyValue Property="Version" String="v1_6_0"/>
+                <PropertyValue Property="Description" String="This property has been deprecated in favor of the ConnectionKeys property in the Connection resource."/>
+              </Record>
+            </Collection>
+          </Annotation>
+        </Property>
+      </ComplexType>
+
+      <ComplexType Name="GCID">
+        <Annotation Term="OData.AdditionalProperties" Bool="false"/>
+        <Annotation Term="OData.Description" String="The Global Component ID (GCID)."/>
+        <Annotation Term="OData.LongDescription" String="This type shall contain the Gen-Z Core Specification-defined Global Component ID."/>
+        <Property Name="CID" Type="Edm.String">
+          <Annotation Term="OData.Permissions" EnumMember="OData.Permission/ReadWrite"/>
+          <Annotation Term="OData.Description" String="The component identifier portion of the GCID for the entity."/>
+          <Annotation Term="OData.LongDescription" String="This property shall contain the 12 bit component identifier portion of the GCID of the entity."/>
+          <Annotation Term="Validation.Pattern" String="^0[xX]([a-fA-F]|[0-9]){3}$"/>
+        </Property>
+        <Property Name="SID" Type="Edm.String">
+          <Annotation Term="OData.Permissions" EnumMember="OData.Permission/ReadWrite"/>
+          <Annotation Term="OData.Description" String="The subnet identifier portion of the GCID for the entity."/>
+          <Annotation Term="OData.LongDescription" String="This property shall contain the 16 bit subnet identifier portion of the GCID of the entity."/>
+          <Annotation Term="Validation.Pattern" String="^0[xX](([a-fA-F]|[0-9]){2}){2}$"/>
+        </Property>
+      </ComplexType>
+
+      <ComplexType Name="Links" BaseType="Endpoint.v1_1_0.Links">
+        <NavigationProperty Name="ConnectedPorts" Type="Collection(Port.Port)">
+          <Annotation Term="OData.Permissions" EnumMember="OData.Permission/Read"/>
+          <Annotation Term="OData.Description" String="An array of links to the ports that connect to this endpoint."/>
+          <Annotation Term="OData.LongDescription" String="This property shall contain an array of links to resources of type Port that represent ports associated with this endpoint."/>
+          <Annotation Term="OData.AutoExpandReferences"/>
+        </NavigationProperty>
+        <NavigationProperty Name="AddressPools" Type="Collection(AddressPool.AddressPool)">
+          <Annotation Term="OData.Permissions" EnumMember="OData.Permission/ReadWrite"/>
+          <Annotation Term="OData.Description" String="An array of links to the address pools associated with this endpoint."/>
+          <Annotation Term="OData.LongDescription" String="This property shall contain an array of links to resources of type AddressPool with which this endpoint is associated."/>
+          <Annotation Term="OData.AutoExpandReferences"/>
+        </NavigationProperty>
+      </ComplexType>
+    </Schema>
+
+    <Schema xmlns="http://docs.oasis-open.org/odata/ns/edm" Namespace="Endpoint.v1_4_1">
+      <Annotation Term="Redfish.OwningEntity" String="DMTF"/>
+      <Annotation Term="OData.Description" String="This version was created to correct various typographical errors."/>
+      <EntityType Name="Endpoint" BaseType="Endpoint.v1_4_0.Endpoint"/>
+    </Schema>
+
+    <Schema xmlns="http://docs.oasis-open.org/odata/ns/edm" Namespace="Endpoint.v1_4_2">
+      <Annotation Term="Redfish.OwningEntity" String="DMTF"/>
+      <Annotation Term="OData.Description" String="This version was created to correct various typographical errors."/>
+      <EntityType Name="Endpoint" BaseType="Endpoint.v1_4_1.Endpoint"/>
+    </Schema>
+
+    <Schema xmlns="http://docs.oasis-open.org/odata/ns/edm" Namespace="Endpoint.v1_4_3">
+      <Annotation Term="Redfish.OwningEntity" String="DMTF"/>
+      <Annotation Term="OData.Description" String="This version was created specify 64-bit integers in OpenAPI."/>
+      <EntityType Name="Endpoint" BaseType="Endpoint.v1_4_2.Endpoint"/>
+    </Schema>
+
+    <Schema xmlns="http://docs.oasis-open.org/odata/ns/edm" Namespace="Endpoint.v1_4_4">
+      <Annotation Term="Redfish.OwningEntity" String="DMTF"/>
+      <Annotation Term="OData.Description" String="This version was created to clarify the descriptions for the EntityType enumeration values."/>
+      <EntityType Name="Endpoint" BaseType="Endpoint.v1_4_3.Endpoint"/>
+    </Schema>
+
+    <Schema xmlns="http://docs.oasis-open.org/odata/ns/edm" Namespace="Endpoint.v1_4_5">
+      <Annotation Term="Redfish.OwningEntity" String="DMTF"/>
+      <Annotation Term="OData.Description" String="This version was created to correct a typographical error in the SubsystemId long description."/>
+      <EntityType Name="Endpoint" BaseType="Endpoint.v1_4_4.Endpoint"/>
+    </Schema>
+
+    <Schema xmlns="http://docs.oasis-open.org/odata/ns/edm" Namespace="Endpoint.v1_5_0">
+      <Annotation Term="Redfish.OwningEntity" String="DMTF"/>
+      <Annotation Term="Redfish.Release" String="2020.3"/>
+      <Annotation Term="OData.Description" String="This version was created to add `Manager` to the EntityType enumeration."/>
+
+      <EntityType Name="Endpoint" BaseType="Endpoint.v1_4_2.Endpoint"/>
+
+      <ComplexType Name="Links" BaseType="Endpoint.v1_4_0.Links">
+        <NavigationProperty Name="Connections" Type="Collection(Connection.Connection)">
+          <Annotation Term="OData.Permissions" EnumMember="OData.Permission/Read"/>
+          <Annotation Term="OData.Description" String="The connections to which this endpoint belongs."/>
+          <Annotation Term="OData.LongDescription" String="This property shall contain an array of links to resources of type Connection that represent the connections to which this endpoint belongs."/>
+        </NavigationProperty>
+      </ComplexType>
+    </Schema>
+
+    <Schema xmlns="http://docs.oasis-open.org/odata/ns/edm" Namespace="Endpoint.v1_5_1">
+      <Annotation Term="Redfish.OwningEntity" String="DMTF"/>
+      <Annotation Term="OData.Description" String="This version was created specify 64-bit integers in OpenAPI."/>
+      <EntityType Name="Endpoint" BaseType="Endpoint.v1_5_0.Endpoint"/>
+    </Schema>
+
+    <Schema xmlns="http://docs.oasis-open.org/odata/ns/edm" Namespace="Endpoint.v1_5_2">
+      <Annotation Term="Redfish.OwningEntity" String="DMTF"/>
+      <Annotation Term="OData.Description" String="This version was created to clarify the descriptions for the EntityType enumeration values."/>
+      <EntityType Name="Endpoint" BaseType="Endpoint.v1_5_1.Endpoint"/>
+    </Schema>
+
+    <Schema xmlns="http://docs.oasis-open.org/odata/ns/edm" Namespace="Endpoint.v1_5_3">
+      <Annotation Term="Redfish.OwningEntity" String="DMTF"/>
+      <Annotation Term="OData.Description" String="This version was created to correct a typographical error in the SubsystemId long description."/>
+      <EntityType Name="Endpoint" BaseType="Endpoint.v1_5_2.Endpoint"/>
+    </Schema>
+
+    <Schema xmlns="http://docs.oasis-open.org/odata/ns/edm" Namespace="Endpoint.v1_6_0">
+      <Annotation Term="Redfish.OwningEntity" String="DMTF"/>
+      <Annotation Term="Redfish.Release" String="2021.1"/>
+      <Annotation Term="OData.Description" String="This version was created to add `StorageSubsystem` to the EntityType enumeration.  It was also created to deprecate the Gen-Z RegionKey and AccessKey properties.  It was also created to add Zones to Links."/>
+
+      <EntityType Name="Endpoint" BaseType="Endpoint.v1_5_2.Endpoint"/>
+
+      <ComplexType Name="Links" BaseType="Endpoint.v1_5_0.Links">
+        <NavigationProperty Name="Zones" Type="Collection(Zone.Zone)">
+          <Annotation Term="OData.Permissions" EnumMember="OData.Permission/Read"/>
+          <Annotation Term="OData.Description" String="The zones to which this endpoint belongs."/>
+          <Annotation Term="OData.LongDescription" String="This property shall contain an array of links to resources of type Zone that represent the zones to which this endpoint belongs."/>
+        </NavigationProperty>
+      </ComplexType>
+    </Schema>
+
+    <Schema xmlns="http://docs.oasis-open.org/odata/ns/edm" Namespace="Endpoint.v1_6_1">
+      <Annotation Term="Redfish.OwningEntity" String="DMTF"/>
+      <Annotation Term="OData.Description" String="This version was created to correct a typographical error in the SubsystemId long description."/>
+      <EntityType Name="Endpoint" BaseType="Endpoint.v1_6_0.Endpoint"/>
+    </Schema>
+
+  </edmx:DataServices>
+</edmx:Edmx>

--- a/static/redfish/v1/schema/EnvironmentMetrics_v1.xml
+++ b/static/redfish/v1/schema/EnvironmentMetrics_v1.xml
@@ -1,0 +1,200 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!---->
+<!--################################################################################       -->
+<!--# Redfish Schema:  EnvironmentMetrics v1.1.0                                           -->
+<!--#                                                                                      -->
+<!--# For a detailed change log, see the README file contained in the DSP8010 bundle,      -->
+<!--# available at http://www.dmtf.org/standards/redfish                                   -->
+<!--# Copyright 2014-2021 DMTF.                                                            -->
+<!--# For the full DMTF copyright policy, see http://www.dmtf.org/about/policies/copyright -->
+<!--################################################################################       -->
+<!---->
+<edmx:Edmx xmlns:edmx="http://docs.oasis-open.org/odata/ns/edmx" Version="4.0">
+
+  <edmx:Reference Uri="http://docs.oasis-open.org/odata/odata/v4.0/errata03/csd01/complete/vocabularies/Org.OData.Core.V1.xml">
+    <edmx:Include Namespace="Org.OData.Core.V1" Alias="OData"/>
+  </edmx:Reference>
+  <edmx:Reference Uri="http://docs.oasis-open.org/odata/odata/v4.0/errata03/csd01/complete/vocabularies/Org.OData.Capabilities.V1.xml">
+    <edmx:Include Namespace="Org.OData.Capabilities.V1" Alias="Capabilities"/>
+  </edmx:Reference>
+  <edmx:Reference Uri="http://redfish.dmtf.org/schemas/v1/RedfishExtensions_v1.xml">
+    <edmx:Include Namespace="RedfishExtensions.v1_0_0" Alias="Redfish"/>
+  </edmx:Reference>
+  <edmx:Reference Uri="http://redfish.dmtf.org/schemas/v1/Resource_v1.xml">
+    <edmx:Include Namespace="Resource.v1_0_0"/>
+  </edmx:Reference>
+  <edmx:Reference Uri="http://redfish.dmtf.org/schemas/v1/Sensor_v1.xml">
+    <edmx:Include Namespace="Sensor"/>
+  </edmx:Reference>
+  <edmx:Reference Uri="http://redfish.dmtf.org/schemas/v1/Control_v1.xml">
+    <edmx:Include Namespace="Control"/>
+  </edmx:Reference>
+
+  <edmx:DataServices>
+
+    <Schema xmlns="http://docs.oasis-open.org/odata/ns/edm" Namespace="EnvironmentMetrics">
+      <Annotation Term="Redfish.OwningEntity" String="DMTF"/>
+
+      <EntityType Name="EnvironmentMetrics" BaseType="Resource.v1_0_0.Resource" Abstract="true">
+        <Annotation Term="OData.Description" String="The EnvironmentMetrics schema represents the environmental metrics of a device."/>
+        <Annotation Term="OData.LongDescription" String="This resource shall represent the environmental metrics for a Redfish implementation."/>
+        <Annotation Term="OData.AdditionalProperties" Bool="false"/>
+        <Annotation Term="Capabilities.InsertRestrictions">
+          <Record>
+            <PropertyValue Property="Insertable" Bool="false"/>
+          </Record>
+        </Annotation>
+        <Annotation Term="Capabilities.UpdateRestrictions">
+          <Record>
+            <PropertyValue Property="Updatable" Bool="true"/>
+          </Record>
+        </Annotation>
+        <Annotation Term="Capabilities.DeleteRestrictions">
+          <Record>
+            <PropertyValue Property="Deletable" Bool="false"/>
+          </Record>
+        </Annotation>
+        <Annotation Term="Redfish.Uris">
+          <Collection>
+            <String>/redfish/v1/Systems/{ComputerSystemId}/Processors/{ProcessorId}/EnvironmentMetrics</String>
+            <String>/redfish/v1/Systems/{ComputerSystemId}/Memory/{MemoryId}/EnvironmentMetrics</String>
+            <String>/redfish/v1/Systems/{ComputerSystemId}/Storage/{StorageId}/Drives/{DriveId}/EnvironmentMetrics</String>
+            <String>/redfish/v1/Systems/{ComputerSystemId}/PCIeDevices/{PCIeDeviceId}/EnvironmentMetrics</String>
+            <String>/redfish/v1/Systems/{ComputerSystemId}/Storage/{StorageId}/Controllers/{ControllerId}/EnvironmentMetrics</String>
+            <String>/redfish/v1/CompositionService/ResourceBlocks/{ResourceBlockId}/Processors/{ProcessorId}/EnvironmentMetrics</String>
+            <String>/redfish/v1/CompositionService/ResourceBlocks/{ResourceBlockId}/Memory/{MemoryId}/EnvironmentMetrics</String>
+            <String>/redfish/v1/CompositionService/ResourceBlocks/{ResourceBlockId}/Storage/{StorageId}/Drives/{DriveId}/EnvironmentMetrics</String>
+            <String>/redfish/v1/CompositionService/ResourceBlocks/{ResourceBlockId}/Drives/{DriveId}/EnvironmentMetrics</String>
+            <String>/redfish/v1/CompositionService/ResourceBlocks/{ResourceBlockId}/Systems/{ComputerSystemId}/Processors/{ProcessorId}/EnvironmentMetrics</String>
+            <String>/redfish/v1/CompositionService/ResourceBlocks/{ResourceBlockId}/Systems/{ComputerSystemId}/Memory/{MemoryId}/EnvironmentMetrics</String>
+            <String>/redfish/v1/CompositionService/ResourceBlocks/{ResourceBlockId}/Systems/{ComputerSystemId}/PCIeDevices/{PCIeDeviceId}/EnvironmentMetrics</String>
+            <String>/redfish/v1/CompositionService/ResourceBlocks/{ResourceBlockId}/Systems/{ComputerSystemId}/Storage/{StorageId}/Drives/{DriveId}/EnvironmentMetrics</String>
+            <String>/redfish/v1/CompositionService/ResourceBlocks/{ResourceBlockId}/Systems/{ComputerSystemId}/Storage/{StorageId}/Controllers/{ControllerId}/EnvironmentMetrics</String>
+            <String>/redfish/v1/CompositionService/ResourceBlocks/{ResourceBlockId}/Storage/{StorageId}/Controllers/{ControllerId}/EnvironmentMetrics</String>
+            <String>/redfish/v1/ResourceBlocks/{ResourceBlockId}/Processors/{ProcessorId}/EnvironmentMetrics</String>
+            <String>/redfish/v1/ResourceBlocks/{ResourceBlockId}/Memory/{MemoryId}/EnvironmentMetrics</String>
+            <String>/redfish/v1/ResourceBlocks/{ResourceBlockId}/Storage/{StorageId}/Drives/{DriveId}/EnvironmentMetrics</String>
+            <String>/redfish/v1/ResourceBlocks/{ResourceBlockId}/Storage/{StorageId}/Controllers/{ControllerId}/EnvironmentMetrics</String>
+            <String>/redfish/v1/ResourceBlocks/{ResourceBlockId}/Drives/{DriveId}/EnvironmentMetrics</String>
+            <String>/redfish/v1/ResourceBlocks/{ResourceBlockId}/Systems/{ComputerSystemId}/Processors/{ProcessorId}/EnvironmentMetrics</String>
+            <String>/redfish/v1/ResourceBlocks/{ResourceBlockId}/Systems/{ComputerSystemId}/Memory/{MemoryId}/EnvironmentMetrics</String>
+            <String>/redfish/v1/ResourceBlocks/{ResourceBlockId}/Systems/{ComputerSystemId}/PCIeDevices/{PCIeDeviceId}/EnvironmentMetrics</String>
+            <String>/redfish/v1/ResourceBlocks/{ResourceBlockId}/Systems/{ComputerSystemId}/Storage/{StorageId}/Drives/{DriveId}/EnvironmentMetrics</String>
+            <String>/redfish/v1/ResourceBlocks/{ResourceBlockId}/Systems/{ComputerSystemId}/Storage/{StorageId}/Controllers/{ControllerId}/EnvironmentMetrics</String>
+            <String>/redfish/v1/Chassis/{ChassisId}/Memory/{MemoryId}/EnvironmentMetrics</String>
+            <String>/redfish/v1/Chassis/{ChassisId}/Drives/{DriveId}/EnvironmentMetrics</String>
+            <String>/redfish/v1/Chassis/{ChassisId}/EnvironmentMetrics</String>
+            <String>/redfish/v1/Chassis/{ChassisId}/PCIeDevices/{PCIeDeviceId}/EnvironmentMetrics</String>
+            <String>/redfish/v1/Chassis/{ChassisId}/NetworkAdapters/{NetworkAdapterId}/EnvironmentMetrics</String>
+            <String>/redfish/v1/Chassis/{ChassisId}/MediaControllers/{MediaControllerId}/EnvironmentMetrics</String>
+            <String>/redfish/v1/Facilities/{FacilityId}/EnvironmentMetrics</String>
+            <String>/redfish/v1/Facilities/{FacilityId}/AmbientMetrics</String>
+            <String>/redfish/v1/Fabrics/{FabricId}/Switches/{SwitchId}/EnvironmentMetrics</String>
+            <String>/redfish/v1/Storage/{StorageId}/Controllers/{ControllerId}/EnvironmentMetrics</String>
+            <String>/redfish/v1/Fabrics/{FabricId}/Switches/{SwitchId}/Ports/{PortId}/EnvironmentMetrics</String>
+            <String>/redfish/v1/Systems/{ComputerSystemId}/Storage/{StorageId}/StorageControllers/{StorageControllerId}/Ports/{PortId}/EnvironmentMetrics</String>
+            <String>/redfish/v1/Systems/{ComputerSystemId}/Storage/{StorageId}/Controllers/{StorageControllerId}/Ports/{PortId}/EnvironmentMetrics</String>
+            <String>/redfish/v1/Systems/{ComputerSystemId}/FabricAdapters/{FabricAdapterId}/Ports/{PortId}/EnvironmentMetrics</String>
+            <String>/redfish/v1/CompositionService/ResourceBlocks/{ResourceBlockId}/Storage/{StorageId}/StorageControllers/{StorageControllerId}/Ports/{PortId}/EnvironmentMetrics</String>
+            <String>/redfish/v1/CompositionService/ResourceBlocks/{ResourceBlockId}/Storage/{StorageId}/Controllers/{StorageControllerId}/Ports/{PortId}/EnvironmentMetrics</String>
+            <String>/redfish/v1/CompositionService/ResourceBlocks/{ResourceBlockId}/Systems/{ComputerSystemId}/Storage/{StorageId}/StorageControllers/{StorageControllerId}/Ports/{PortId}/EnvironmentMetrics</String>
+            <String>/redfish/v1/CompositionService/ResourceBlocks/{ResourceBlockId}/Systems/{ComputerSystemId}/Storage/{StorageId}/Controllers/{StorageControllerId}/Ports/{PortId}/EnvironmentMetrics</String>
+            <String>/redfish/v1/ResourceBlocks/{ResourceBlockId}/Storage/{StorageId}/StorageControllers/{StorageControllerId}/Ports/{PortId}/EnvironmentMetrics</String>
+            <String>/redfish/v1/ResourceBlocks/{ResourceBlockId}/Storage/{StorageId}/Controllers/{StorageControllerId}/Ports/{PortId}/EnvironmentMetrics</String>
+            <String>/redfish/v1/ResourceBlocks/{ResourceBlockId}/Systems/{ComputerSystemId}/Storage/{StorageId}/StorageControllers/{StorageControllerId}/Ports/{PortId}/EnvironmentMetrics</String>
+            <String>/redfish/v1/ResourceBlocks/{ResourceBlockId}/Systems/{ComputerSystemId}/Storage/{StorageId}/Controllers/{StorageControllerId}/Ports/{PortId}/EnvironmentMetrics</String>
+            <String>/redfish/v1/Chassis/{ChassisId}/MediaControllers/{MediaControllerId}/Ports/{PortId}/EnvironmentMetrics</String>
+            <String>/redfish/v1/Chassis/{ChassisId}/NetworkAdapters/{NetworkAdapterId}/Ports/{PortId}/EnvironmentMetrics</String>
+            <String>/redfish/v1/Storage/{StorageId}/StorageControllers/{StorageControllerId}/Ports/{PortId}/EnvironmentMetrics</String>
+            <String>/redfish/v1/Storage/{StorageId}/Controllers/{StorageControllerId}/Ports/{PortId}/EnvironmentMetrics</String>
+          </Collection>
+        </Annotation>
+      </EntityType>
+
+      <Action Name="ResetMetrics" IsBound="true">
+        <Parameter Name="EnvironmentMetrics" Type="EnvironmentMetrics.v1_0_0.Actions"/>
+        <Annotation Term="OData.Description" String="This action resets the summary metrics related to this equipment."/>
+        <Annotation Term="OData.LongDescription" String="This action shall reset any time intervals or counted values for this equipment."/>
+      </Action>
+    </Schema>
+
+    <Schema xmlns="http://docs.oasis-open.org/odata/ns/edm" Namespace="EnvironmentMetrics.v1_0_0">
+      <Annotation Term="Redfish.OwningEntity" String="DMTF"/>
+      <Annotation Term="Redfish.Release" String="2020.4"/>
+
+      <EntityType Name="EnvironmentMetrics" BaseType="EnvironmentMetrics.EnvironmentMetrics">
+        <NavigationProperty Name="TemperatureCelsius" Type="Sensor.Sensor">
+          <Annotation Term="Redfish.ExcerptCopy"/>
+          <Annotation Term="OData.Description" String="Temperature (Celsius)."/>
+          <Annotation Term="OData.LongDescription" String="This property shall contain the temperature sensor reading for this resource."/>
+        </NavigationProperty>
+        <NavigationProperty Name="HumidityPercent" Type="Sensor.Sensor">
+          <Annotation Term="Redfish.ExcerptCopy"/>
+          <Annotation Term="OData.Description" String="Humidity (percent)."/>
+          <Annotation Term="OData.LongDescription" String="This property shall contain the humidity sensor reading for this resource."/>
+        </NavigationProperty>
+        <NavigationProperty Name="FanSpeedsPercent" Type="Collection(Sensor.Sensor)">
+          <Annotation Term="Redfish.ExcerptCopy" String="FanArray"/>
+          <Annotation Term="OData.Description" String="Fan speeds (percent)."/>
+          <Annotation Term="OData.LongDescription" String="This property shall contain the fan speed readings for this resource."/>
+        </NavigationProperty>
+        <NavigationProperty Name="PowerWatts" Type="Sensor.Sensor">
+          <Annotation Term="Redfish.ExcerptCopy" String="Power"/>
+          <Annotation Term="OData.Description" String="Power consumption (Watts)."/>
+          <Annotation Term="OData.LongDescription" String="This property shall contain the total power, measured in Watts, for this resource."/>
+        </NavigationProperty>
+        <NavigationProperty Name="EnergykWh" Type="Sensor.Sensor">
+          <Annotation Term="Redfish.ExcerptCopy" String="EnergykWh"/>
+          <Annotation Term="OData.Description" String="Energy consumption (kWh)."/>
+          <Annotation Term="OData.LongDescription" String="This property shall contain the total energy, measured in kilowatt-hours (kW.h), for this resource."/>
+        </NavigationProperty>
+        <Property Name="Actions" Type="EnvironmentMetrics.v1_0_0.Actions" Nullable="false">
+          <Annotation Term="OData.Description" String="The available actions for this resource."/>
+          <Annotation Term="OData.LongDescription" String="This property shall contain the available actions for this resource."/>
+        </Property>
+      </EntityType>
+
+      <ComplexType Name="Actions">
+        <Annotation Term="OData.AdditionalProperties" Bool="false"/>
+        <Annotation Term="OData.Description" String="The available actions for this resource."/>
+        <Annotation Term="OData.LongDescription" String="This type shall contain the available actions for this resource."/>
+        <Property Name="Oem" Type="EnvironmentMetrics.v1_0_0.OemActions" Nullable="false">
+          <Annotation Term="OData.Description" String="The available OEM-specific actions for this resource."/>
+          <Annotation Term="OData.LongDescription" String="This property shall contain the available OEM-specific actions for this resource."/>
+        </Property>
+      </ComplexType>
+
+      <ComplexType Name="OemActions">
+        <Annotation Term="OData.AdditionalProperties" Bool="true"/>
+        <Annotation Term="OData.Description" String="The available OEM-specific actions for this resource."/>
+        <Annotation Term="OData.LongDescription" String="This type shall contain the available OEM-specific actions for this resource."/>
+      </ComplexType>
+    </Schema>
+
+    <Schema xmlns="http://docs.oasis-open.org/odata/ns/edm" Namespace="EnvironmentMetrics.v1_1_0">
+      <Annotation Term="Redfish.OwningEntity" String="DMTF"/>
+      <Annotation Term="Redfish.Release" String="2021.2"/>
+      <Annotation Term="OData.Description" String="This version was created to add PowerLoadPercent, PowerLimitWatts, and DewPointCelsius."/>
+
+      <EntityType Name="EnvironmentMetrics" BaseType="EnvironmentMetrics.v1_0_0.EnvironmentMetrics">
+        <NavigationProperty Name="PowerLoadPercent" Type="Sensor.Sensor">
+          <Annotation Term="Redfish.ExcerptCopy"/>
+          <Annotation Term="OData.Description" String="The power load (%) for this device."/>
+          <Annotation Term="OData.LongDescription" String="This property shall contain the power load, measured in percent, for this device, that represents the `Total` ElectricalContext for this device."/>
+        </NavigationProperty>
+        <NavigationProperty Name="PowerLimitWatts" Type="Control.Control">
+          <Annotation Term="OData.Permissions" EnumMember="OData.Permission/ReadWrite"/>
+          <Annotation Term="Redfish.ExcerptCopy" String="Single"/>
+          <Annotation Term="OData.Description" String="Power limit (Watts)."/>
+          <Annotation Term="OData.LongDescription" String="This property shall contain the power limit control for this resource."/>
+        </NavigationProperty>
+        <NavigationProperty Name="DewPointCelsius" Type="Sensor.Sensor">
+          <Annotation Term="Redfish.ExcerptCopy"/>
+          <Annotation Term="OData.Description" String="The dew point temperature (C)."/>
+          <Annotation Term="OData.LongDescription" String="This property shall contain the dew point, measured in degrees Celsius, based on the temperature and humidity values for this resource."/>
+        </NavigationProperty>
+      </EntityType>
+    </Schema>
+
+  </edmx:DataServices>
+</edmx:Edmx>

--- a/static/redfish/v1/schema/ExternalAccountProviderCollection_v1.xml
+++ b/static/redfish/v1/schema/ExternalAccountProviderCollection_v1.xml
@@ -1,0 +1,71 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!---->
+<!--################################################################################       -->
+<!--# Redfish Schema:  ExternalAccountProviderCollection                                   -->
+<!--#                                                                                      -->
+<!--# For a detailed change log, see the README file contained in the DSP8010 bundle,      -->
+<!--# available at http://www.dmtf.org/standards/redfish                                   -->
+<!--# Copyright 2014-2021 DMTF.                                                            -->
+<!--# For the full DMTF copyright policy, see http://www.dmtf.org/about/policies/copyright -->
+<!--################################################################################       -->
+<!---->
+<edmx:Edmx xmlns:edmx="http://docs.oasis-open.org/odata/ns/edmx" Version="4.0">
+
+  <edmx:Reference Uri="http://docs.oasis-open.org/odata/odata/v4.0/errata03/csd01/complete/vocabularies/Org.OData.Core.V1.xml">
+    <edmx:Include Namespace="Org.OData.Core.V1" Alias="OData"/>
+  </edmx:Reference>
+  <edmx:Reference Uri="http://docs.oasis-open.org/odata/odata/v4.0/errata03/csd01/complete/vocabularies/Org.OData.Capabilities.V1.xml">
+    <edmx:Include Namespace="Org.OData.Capabilities.V1" Alias="Capabilities"/>
+  </edmx:Reference>
+  <edmx:Reference Uri="http://redfish.dmtf.org/schemas/v1/RedfishExtensions_v1.xml">
+    <edmx:Include Namespace="RedfishExtensions.v1_0_0" Alias="Redfish"/>
+  </edmx:Reference>
+  <edmx:Reference Uri="http://redfish.dmtf.org/schemas/v1/Resource_v1.xml">
+    <edmx:Include Namespace="Resource.v1_0_0"/>
+  </edmx:Reference>
+  <edmx:Reference Uri="http://redfish.dmtf.org/schemas/v1/ExternalAccountProvider_v1.xml">
+    <edmx:Include Namespace="ExternalAccountProvider"/>
+  </edmx:Reference>
+
+  <edmx:DataServices>
+
+    <Schema xmlns="http://docs.oasis-open.org/odata/ns/edm" Namespace="ExternalAccountProviderCollection">
+      <Annotation Term="Redfish.OwningEntity" String="DMTF"/>
+
+      <EntityType Name="ExternalAccountProviderCollection" BaseType="Resource.v1_0_0.ResourceCollection">
+        <Annotation Term="OData.Description" String="The collection of ExternalAccountProvider resource instances."/>
+        <Annotation Term="OData.LongDescription" String="This resource shall represent a resource collection of ExternalAccountProvider instances for a Redfish implementation."/>
+        <Annotation Term="Capabilities.InsertRestrictions">
+          <Record>
+            <PropertyValue Property="Insertable" Bool="true"/>
+            <Annotation Term="OData.Description" String="Create external account providers through a POST to the external account provider collection."/>
+          </Record>
+        </Annotation>
+        <Annotation Term="Capabilities.UpdateRestrictions">
+          <Record>
+            <PropertyValue Property="Updatable" Bool="false"/>
+          </Record>
+        </Annotation>
+        <Annotation Term="Capabilities.DeleteRestrictions">
+          <Record>
+            <PropertyValue Property="Deletable" Bool="false"/>
+          </Record>
+        </Annotation>
+        <Annotation Term="Redfish.Uris">
+          <Collection>
+            <String>/redfish/v1/AccountService/ExternalAccountProviders</String>
+            <String>/redfish/v1/Managers/{ManagerId}/RemoteAccountService/ExternalAccountProviders</String>
+          </Collection>
+        </Annotation>
+        <NavigationProperty Name="Members" Type="Collection(ExternalAccountProvider.ExternalAccountProvider)">
+          <Annotation Term="OData.Permissions" EnumMember="OData.Permission/Read"/>
+          <Annotation Term="OData.Description" String="The members of this collection."/>
+          <Annotation Term="OData.LongDescription" String="This property shall contain an array of links to the members of this collection."/>
+          <Annotation Term="OData.AutoExpandReferences"/>
+          <Annotation Term="Redfish.Required"/>
+        </NavigationProperty>
+      </EntityType>
+    </Schema>
+
+  </edmx:DataServices>
+</edmx:Edmx>

--- a/static/redfish/v1/schema/ExternalAccountProvider_v1.xml
+++ b/static/redfish/v1/schema/ExternalAccountProvider_v1.xml
@@ -1,0 +1,474 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!---->
+<!--################################################################################       -->
+<!--# Redfish Schema:  ExternalAccountProvider v1.3.0                                      -->
+<!--#                                                                                      -->
+<!--# For a detailed change log, see the README file contained in the DSP8010 bundle,      -->
+<!--# available at http://www.dmtf.org/standards/redfish                                   -->
+<!--# Copyright 2014-2021 DMTF.                                                            -->
+<!--# For the full DMTF copyright policy, see http://www.dmtf.org/about/policies/copyright -->
+<!--################################################################################       -->
+<!---->
+<edmx:Edmx xmlns:edmx="http://docs.oasis-open.org/odata/ns/edmx" Version="4.0">
+
+  <edmx:Reference Uri="http://docs.oasis-open.org/odata/odata/v4.0/errata03/csd01/complete/vocabularies/Org.OData.Core.V1.xml">
+    <edmx:Include Namespace="Org.OData.Core.V1" Alias="OData"/>
+  </edmx:Reference>
+  <edmx:Reference Uri="http://docs.oasis-open.org/odata/odata/v4.0/errata03/csd01/complete/vocabularies/Org.OData.Capabilities.V1.xml">
+    <edmx:Include Namespace="Org.OData.Capabilities.V1" Alias="Capabilities"/>
+  </edmx:Reference>
+  <edmx:Reference Uri="http://redfish.dmtf.org/schemas/v1/RedfishExtensions_v1.xml">
+    <edmx:Include Namespace="Validation.v1_0_0" Alias="Validation"/>
+    <edmx:Include Namespace="RedfishExtensions.v1_0_0" Alias="Redfish"/>
+  </edmx:Reference>
+  <edmx:Reference Uri="http://redfish.dmtf.org/schemas/v1/Resource_v1.xml">
+    <edmx:Include Namespace="Resource"/>
+    <edmx:Include Namespace="Resource.v1_0_0"/>
+  </edmx:Reference>
+  <edmx:Reference Uri="http://redfish.dmtf.org/schemas/v1/CertificateCollection_v1.xml">
+    <edmx:Include Namespace="CertificateCollection"/>
+  </edmx:Reference>
+
+  <edmx:DataServices>
+
+    <Schema xmlns="http://docs.oasis-open.org/odata/ns/edm" Namespace="ExternalAccountProvider">
+      <Annotation Term="Redfish.OwningEntity" String="DMTF"/>
+
+      <EntityType Name="ExternalAccountProvider" BaseType="Resource.v1_0_0.Resource" Abstract="true">
+        <Annotation Term="OData.Description" String="The ExternalAccountProvider schema represents a remote service that provides accounts for this manager to use for authentication."/>
+        <Annotation Term="OData.LongDescription" String="This resource shall represent a remote authentication service in the Redfish Specification."/>
+        <Annotation Term="Capabilities.InsertRestrictions">
+          <Record>
+            <PropertyValue Property="Insertable" Bool="false"/>
+          </Record>
+        </Annotation>
+        <Annotation Term="Capabilities.UpdateRestrictions">
+          <Record>
+            <PropertyValue Property="Updatable" Bool="true"/>
+            <Annotation Term="OData.Description" String="Any writable properties, such as Authentication, can be updated for external account providers."/>
+          </Record>
+        </Annotation>
+        <Annotation Term="Capabilities.DeleteRestrictions">
+          <Record>
+            <PropertyValue Property="Deletable" Bool="true"/>
+            <Annotation Term="OData.Description" String="The external account providers can be deleted."/>
+          </Record>
+        </Annotation>
+        <Annotation Term="Redfish.Uris">
+          <Collection>
+            <String>/redfish/v1/AccountService/ExternalAccountProviders/{ExternalAccountProviderId}</String>
+            <String>/redfish/v1/Managers/{ManagerId}/RemoteAccountService/ExternalAccountProviders/{ExternalAccountProviderId}</String>
+          </Collection>
+        </Annotation>
+      </EntityType>
+
+    </Schema>
+
+    <Schema xmlns="http://docs.oasis-open.org/odata/ns/edm" Namespace="ExternalAccountProvider.v1_0_0">
+      <Annotation Term="Redfish.OwningEntity" String="DMTF"/>
+      <Annotation Term="Redfish.Release" String="2018.1"/>
+
+      <EntityType Name="ExternalAccountProvider" BaseType="ExternalAccountProvider.ExternalAccountProvider">
+        <Property Name="AccountProviderType" Type="ExternalAccountProvider.v1_0_0.AccountProviderTypes">
+          <Annotation Term="Redfish.RequiredOnCreate"/>
+          <Annotation Term="OData.Permissions" EnumMember="OData.Permission/Read"/>
+          <Annotation Term="OData.Description" String="The type of external account provider to which this service connects."/>
+          <Annotation Term="OData.LongDescription" String="This property shall contain the type of external account provider to which this service connects."/>
+        </Property>
+        <Property Name="ServiceEnabled" Type="Edm.Boolean">
+          <Annotation Term="OData.Permissions" EnumMember="OData.Permission/ReadWrite"/>
+          <Annotation Term="OData.Description" String="An indication of whether this service is enabled."/>
+          <Annotation Term="OData.LongDescription" String="This property shall indicate whether this service is enabled."/>
+        </Property>
+        <Property Name="ServiceAddresses" Type="Collection(Edm.String)">
+          <Annotation Term="OData.Permissions" EnumMember="OData.Permission/ReadWrite"/>
+          <Annotation Term="OData.Description" String="The addresses of the user account providers to which this external account provider links.  The format of this field depends on the type of external account provider."/>
+          <Annotation Term="OData.LongDescription" String="This property shall contain the addresses of the account providers to which this external account provider links.  The format of this field depends on the type of external account provider.  Each item in the array shall contain a single address.  Services can define their own behavior for managing multiple addresses."/>
+        </Property>
+        <Property Name="Authentication" Type="ExternalAccountProvider.v1_0_0.Authentication" Nullable="false">
+          <Annotation Term="OData.Description" String="The authentication information for the external account provider."/>
+          <Annotation Term="OData.LongDescription" String="This property shall contain the authentication information for the external account provider."/>
+        </Property>
+        <Property Name="LDAPService" Type="ExternalAccountProvider.v1_0_0.LDAPService" Nullable="false">
+          <Annotation Term="OData.Description" String="The additional mapping information needed to parse a generic LDAP service."/>
+          <Annotation Term="OData.LongDescription" String="This property shall contain any additional mapping information needed to parse a generic LDAP service.  This property should only be present if AccountProviderType is `LDAPService`."/>
+        </Property>
+        <Property Name="RemoteRoleMapping" Type="Collection(ExternalAccountProvider.v1_0_0.RoleMapping)">
+          <Annotation Term="OData.Description" String="The mapping rules to convert the external account providers account information to the local Redfish role."/>
+          <Annotation Term="OData.LongDescription" String="This property shall contain a set of the mapping rules that are used to convert the external account providers account information to the local Redfish role."/>
+        </Property>
+        <Property Name="Links" Type="ExternalAccountProvider.v1_0_0.Links" Nullable="false">
+          <Annotation Term="OData.Description" String="The links to other resources that are related to this resource."/>
+          <Annotation Term="OData.LongDescription" String="This property shall contain links to resources that are related to but are not contained by, or subordinate to, this resource."/>
+        </Property>
+        <Property Name="Actions" Type="ExternalAccountProvider.v1_0_0.Actions" Nullable="false">
+          <Annotation Term="OData.Description" String="The available actions for this resource."/>
+          <Annotation Term="OData.LongDescription" String="This property shall contain the available actions for this resource."/>
+        </Property>
+      </EntityType>
+
+      <EnumType Name="AccountProviderTypes">
+        <Member Name="RedfishService">
+          <Annotation Term="OData.Description" String="An external Redfish service."/>
+          <Annotation Term="OData.LongDescription" String="The external account provider shall be a DMTF Redfish Specification-conformant service.  The ServiceAddresses format shall contain a set of URIs that correspond to a Redfish account service."/>
+        </Member>
+        <Member Name="ActiveDirectoryService">
+          <Annotation Term="OData.Description" String="An external Active Directory service."/>
+          <Annotation Term="OData.LongDescription" String="The external account provider shall be a Microsoft Active Directory Technical Specification-conformant service.  The ServiceAddresses format shall contain a set of fully qualified domain names (FQDN) or NetBIOS names that links to the set of domain servers for the Active Directory service."/>
+        </Member>
+        <Member Name="LDAPService">
+          <Annotation Term="OData.Description" String="A generic external LDAP service."/>
+          <Annotation Term="OData.LongDescription" String="The external account provider shall be an RFC4511-conformant service.  The ServiceAddresses format shall contain a set of fully qualified domain names (FQDN) that links to the set of LDAP servers for the service."/>
+        </Member>
+        <Member Name="OEM">
+          <Annotation Term="OData.Description" String="An OEM-specific external authentication or directory service."/>
+        </Member>
+        <Member Name="TACACSplus">
+          <Annotation Term="OData.Description" String="An external TACACS+ service."/>
+          <Annotation Term="OData.LongDescription" String="The external account provider shall be an RFC8907-conformant service.  The ServiceAddresses format shall contain a set of host:port that correspond to a TACACS+ service and where the format for host and port are defined in RFC3986."/>
+          <Annotation Term="Redfish.Revisions">
+            <Collection>
+              <Record>
+                <PropertyValue Property="Kind" EnumMember="Redfish.RevisionKind/Added"/>
+                <PropertyValue Property="Version" String="v1_3_0"/>
+              </Record>
+            </Collection>
+          </Annotation>
+        </Member>
+        <Member Name="OAuth2">
+          <Annotation Term="OData.Description" String="An external OAuth 2.0 service."/>
+          <Annotation Term="OData.LongDescription" String="The external account provider shall be an RFC6749-conformant service.  The ServiceAddresses format shall contain a set of URIs that correspond to the RFC8414-defined metadata for the OAuth 2.0 service."/>
+          <Annotation Term="Redfish.Revisions">
+            <Collection>
+              <Record>
+                <PropertyValue Property="Kind" EnumMember="Redfish.RevisionKind/Added"/>
+                <PropertyValue Property="Version" String="v1_3_0"/>
+              </Record>
+            </Collection>
+          </Annotation>
+        </Member>
+      </EnumType>
+
+      <ComplexType Name="Authentication">
+        <Annotation Term="OData.Description" String="The information required to authenticate to the external service."/>
+        <Annotation Term="OData.LongDescription" String="This type shall contain the information required to authenticate to the external service."/>
+        <Property Name="AuthenticationType" Type="ExternalAccountProvider.v1_0_0.AuthenticationTypes">
+          <Annotation Term="OData.Permissions" EnumMember="OData.Permission/ReadWrite"/>
+          <Annotation Term="OData.Description" String="The type of authentication used to connect to the external account provider."/>
+          <Annotation Term="OData.LongDescription" String="This property shall contain the type of authentication used to connect to the external account provider."/>
+        </Property>
+        <Property Name="Username" Type="Edm.String" Nullable="false">
+          <Annotation Term="OData.Permissions" EnumMember="OData.Permission/ReadWrite"/>
+          <Annotation Term="OData.Description" String="The user name for the service."/>
+          <Annotation Term="OData.LongDescription" String="This property shall contain the user name for this service."/>
+        </Property>
+        <Property Name="Password" Type="Edm.String">
+          <Annotation Term="OData.Permissions" EnumMember="OData.Permission/ReadWrite"/>
+          <Annotation Term="OData.Description" String="The password for this service.  A PATCH or PUT request writes the password.  This property is `null` in responses."/>
+          <Annotation Term="OData.LongDescription" String="This property shall contain the password for this service.  A PATCH or PUT operation writes the password.  The value shall be `null` in responses."/>
+        </Property>
+        <Property Name="Token" Type="Edm.String">
+          <Annotation Term="OData.Permissions" EnumMember="OData.Permission/ReadWrite"/>
+          <Annotation Term="OData.Description" String="The token for this service.  A PATCH or PUT operation writes the token.  This property is `null` in responses."/>
+          <Annotation Term="OData.LongDescription" String="This property shall contain the token for this service.  A PATCH or PUT operation writes the token.  The value shall be `null` in responses."/>
+        </Property>
+        <Property Name="KerberosKeytab" Type="Edm.String">
+          <Annotation Term="OData.Permissions" EnumMember="OData.Permission/ReadWrite"/>
+          <Annotation Term="OData.Description" String="The Base64-encoded version of the Kerberos keytab for this service.  A PATCH or PUT operation writes the keytab.  This property is `null` in responses."/>
+          <Annotation Term="OData.LongDescription" String="This property shall contain a Base64-encoded version of the Kerberos keytab for this service.  A PATCH or PUT operation writes the keytab.  The value shall be `null` in responses."/>
+        </Property>
+        <Property Name="Oem" Type="Resource.Oem" Nullable="false">
+          <Annotation Term="OData.Description" String="The OEM extension property."/>
+          <Annotation Term="OData.LongDescription" String="This property shall contain the OEM extensions.  All values for properties contained in this object shall conform to the Redfish Specification-described requirements."/>
+        </Property>
+      </ComplexType>
+
+      <EnumType Name="AuthenticationTypes">
+        <Member Name="Token">
+          <Annotation Term="OData.Description" String="An opaque authentication token."/>
+        </Member>
+        <Member Name="KerberosKeytab">
+          <Annotation Term="OData.Description" String="A Kerberos keytab."/>
+        </Member>
+        <Member Name="UsernameAndPassword">
+          <Annotation Term="OData.Description" String="A user name and password combination."/>
+        </Member>
+        <Member Name="OEM">
+          <Annotation Term="OData.Description" String="An OEM-specific authentication mechanism."/>
+        </Member>
+      </EnumType>
+
+      <ComplexType Name="LDAPService">
+        <Annotation Term="OData.Description" String="The settings required to parse a generic LDAP service."/>
+        <Annotation Term="OData.LongDescription" String="This type shall contain all required settings to parse a generic LDAP service."/>
+        <Property Name="SearchSettings" Type="ExternalAccountProvider.v1_0_0.LDAPSearchSettings" Nullable="false">
+          <Annotation Term="OData.Description" String="The required settings to search an external LDAP service."/>
+          <Annotation Term="OData.LongDescription" String="This property shall contain the required settings to search an external LDAP service."/>
+        </Property>
+        <Property Name="Oem" Type="Resource.Oem" Nullable="false">
+          <Annotation Term="OData.Description" String="The OEM extension property."/>
+          <Annotation Term="OData.LongDescription" String="This property shall contain the OEM extensions.  All values for properties contained in this object shall conform to the Redfish Specification-described requirements."/>
+        </Property>
+      </ComplexType>
+
+      <ComplexType Name="LDAPSearchSettings">
+        <Annotation Term="OData.Description" String="The settings to search a generic LDAP service."/>
+        <Annotation Term="OData.LongDescription" String="This type shall contain all required settings to search a generic LDAP service."/>
+        <Property Name="BaseDistinguishedNames" Type="Collection(Edm.String)">
+          <Annotation Term="OData.Permissions" EnumMember="OData.Permission/ReadWrite"/>
+          <Annotation Term="OData.Description" String="The base distinguished names to use to search an external LDAP service."/>
+          <Annotation Term="OData.LongDescription" String="This property shall contain an array of base distinguished names to use to search an external LDAP service."/>
+        </Property>
+        <Property Name="UsernameAttribute" Type="Edm.String">
+          <Annotation Term="OData.Permissions" EnumMember="OData.Permission/ReadWrite"/>
+          <Annotation Term="OData.Description" String="The attribute name that contains the LDAP user name entry."/>
+          <Annotation Term="OData.LongDescription" String="This property shall contain the attribute name that contains the LDAP user name."/>
+        </Property>
+        <Property Name="GroupNameAttribute" Type="Edm.String">
+          <Annotation Term="OData.Permissions" EnumMember="OData.Permission/ReadWrite"/>
+          <Annotation Term="OData.Description" String="The attribute name that contains the LDAP group name entry."/>
+          <Annotation Term="OData.LongDescription" String="This property shall contain the attribute name that contains the LDAP group name."/>
+        </Property>
+        <Property Name="GroupsAttribute" Type="Edm.String">
+          <Annotation Term="OData.Permissions" EnumMember="OData.Permission/ReadWrite"/>
+          <Annotation Term="OData.Description" String="The attribute name that contains the groups for a user on the LDAP user entry."/>
+          <Annotation Term="OData.LongDescription" String="This property shall contain the attribute name that contains the groups for an LDAP user entry."/>
+        </Property>
+      </ComplexType>
+
+      <ComplexType Name="RoleMapping">
+        <Annotation Term="OData.Description" String="The mapping rules that are used to convert the external account providers account information to the local Redfish role."/>
+        <Annotation Term="OData.LongDescription" String="This type shall contain mapping rules that are used to convert the external account providers account information to the local Redfish role."/>
+        <Property Name="RemoteGroup" Type="Edm.String">
+          <Annotation Term="OData.Permissions" EnumMember="OData.Permission/ReadWrite"/>
+          <Annotation Term="OData.Description" String="The name of the remote group, or the remote role in the case of a Redfish service, that maps to the local Redfish role to which this entity links."/>
+          <Annotation Term="OData.LongDescription" String="This property shall contain the name of the remote group, or the remote role in the case of a Redfish service, that maps to the local Redfish role to which this entity links."/>
+        </Property>
+        <Property Name="RemoteUser" Type="Edm.String">
+          <Annotation Term="OData.Permissions" EnumMember="OData.Permission/ReadWrite"/>
+          <Annotation Term="OData.Description" String="The name of the remote user that maps to the local Redfish role to which this entity links."/>
+          <Annotation Term="OData.LongDescription" String="This property shall contain the name of the remote user that maps to the local Redfish role to which this entity links."/>
+        </Property>
+        <Property Name="LocalRole" Type="Edm.String">
+          <Annotation Term="OData.Permissions" EnumMember="OData.Permission/ReadWrite"/>
+          <Annotation Term="OData.Description" String="The name of the local Redfish role to which to map the remote user or group."/>
+          <Annotation Term="OData.LongDescription" String="This property shall contain the RoleId property value within a role resource on this Redfish service to which to map the remote user or group."/>
+        </Property>
+        <Property Name="Oem" Type="Resource.Oem" Nullable="false">
+          <Annotation Term="OData.Description" String="The OEM extension property."/>
+          <Annotation Term="OData.LongDescription" String="This property shall contain the OEM extensions.  All values for properties contained in this object shall conform to the Redfish Specification-described requirements."/>
+        </Property>
+      </ComplexType>
+
+      <ComplexType Name="Links" BaseType="Resource.Links">
+        <Annotation Term="OData.Description" String="The links to other resources that are related to this resource."/>
+        <Annotation Term="OData.LongDescription" String="This Redfish Specification-described type shall contain links to resources that are related to but are not contained by, or subordinate to, this resource."/>
+      </ComplexType>
+
+      <ComplexType Name="Actions">
+        <Annotation Term="OData.AdditionalProperties" Bool="false"/>
+        <Annotation Term="OData.Description" String="The available actions for this resource."/>
+        <Annotation Term="OData.LongDescription" String="This type shall contain the available actions for this resource."/>
+        <Property Name="Oem" Type="ExternalAccountProvider.v1_0_0.OemActions" Nullable="false">
+          <Annotation Term="OData.Description" String="The available OEM-specific actions for this resource."/>
+          <Annotation Term="OData.LongDescription" String="This property shall contain the available OEM-specific actions for this resource."/>
+        </Property>
+      </ComplexType>
+
+      <ComplexType Name="OemActions">
+        <Annotation Term="OData.AdditionalProperties" Bool="true"/>
+        <Annotation Term="OData.Description" String="The available OEM-specific actions for this resource."/>
+        <Annotation Term="OData.LongDescription" String="This type shall contain the available OEM-specific actions for this resource."/>
+      </ComplexType>
+    </Schema>
+
+    <Schema xmlns="http://docs.oasis-open.org/odata/ns/edm" Namespace="ExternalAccountProvider.v1_0_1">
+      <Annotation Term="Redfish.OwningEntity" String="DMTF"/>
+      <Annotation Term="OData.Description" String="This version was created to force the regeneration of JSON Schema so that OData properties are marked as required, and integer properties are marked as integer rather than number."/>
+      <EntityType Name="ExternalAccountProvider" BaseType="ExternalAccountProvider.v1_0_0.ExternalAccountProvider"/>
+    </Schema>
+
+    <Schema xmlns="http://docs.oasis-open.org/odata/ns/edm" Namespace="ExternalAccountProvider.v1_0_2">
+      <Annotation Term="Redfish.OwningEntity" String="DMTF"/>
+      <Annotation Term="OData.Description" String="This version was created to force the regeneration of JSON Schema so that URI properties use the uri-reference format, clarifies the LDAPSearchSettings property descriptions, and adds a missing term to several properties to disallow them from being `null`."/>
+      <EntityType Name="ExternalAccountProvider" BaseType="ExternalAccountProvider.v1_0_1.ExternalAccountProvider"/>
+    </Schema>
+
+    <Schema xmlns="http://docs.oasis-open.org/odata/ns/edm" Namespace="ExternalAccountProvider.v1_0_3">
+      <Annotation Term="Redfish.OwningEntity" String="DMTF"/>
+      <Annotation Term="OData.Description" String="This version was created to update the descriptions of Password, Token, and KerberosKeytab properties.  It was also created to clarify the usage of the LDAPService property."/>
+      <EntityType Name="ExternalAccountProvider" BaseType="ExternalAccountProvider.v1_0_2.ExternalAccountProvider"/>
+    </Schema>
+
+    <Schema xmlns="http://docs.oasis-open.org/odata/ns/edm" Namespace="ExternalAccountProvider.v1_0_4">
+      <Annotation Term="Redfish.OwningEntity" String="DMTF"/>
+      <Annotation Term="OData.Description" String="This version was created to correct various typographical errors."/>
+      <EntityType Name="ExternalAccountProvider" BaseType="ExternalAccountProvider.v1_0_3.ExternalAccountProvider"/>
+    </Schema>
+
+    <Schema xmlns="http://docs.oasis-open.org/odata/ns/edm" Namespace="ExternalAccountProvider.v1_0_5">
+      <Annotation Term="Redfish.OwningEntity" String="DMTF"/>
+      <Annotation Term="OData.Description" String="This version was created to correct various typographical errors."/>
+      <EntityType Name="ExternalAccountProvider" BaseType="ExternalAccountProvider.v1_0_4.ExternalAccountProvider"/>
+    </Schema>
+
+    <Schema xmlns="http://docs.oasis-open.org/odata/ns/edm" Namespace="ExternalAccountProvider.v1_1_0">
+      <Annotation Term="Redfish.OwningEntity" String="DMTF"/>
+      <Annotation Term="Redfish.Release" String="2018.3"/>
+      <EntityType Name="ExternalAccountProvider" BaseType="ExternalAccountProvider.v1_0_1.ExternalAccountProvider">
+        <NavigationProperty Name="Certificates" Type="CertificateCollection.CertificateCollection" ContainsTarget="true" Nullable="false">
+          <Annotation Term="OData.Permissions" EnumMember="OData.Permission/Read"/>
+          <Annotation Term="OData.Description" String="The link to a collection of certificates that the external account provider uses."/>
+          <Annotation Term="OData.LongDescription" String="This property shall contain a link to a resource collection of type CertificateCollection that contains certificates the external account provider uses."/>
+          <Annotation Term="OData.AutoExpandReferences"/>
+        </NavigationProperty>
+      </EntityType>
+    </Schema>
+
+    <Schema xmlns="http://docs.oasis-open.org/odata/ns/edm" Namespace="ExternalAccountProvider.v1_1_1">
+      <Annotation Term="Redfish.OwningEntity" String="DMTF"/>
+      <Annotation Term="OData.Description" String="This version was created to force the regeneration of JSON Schema so that URI properties use the uri-reference format, clarifies the LDAPSearchSettings property descriptions, and adds a missing term to several properties to disallow them from being `null`."/>
+      <EntityType Name="ExternalAccountProvider" BaseType="ExternalAccountProvider.v1_1_0.ExternalAccountProvider"/>
+    </Schema>
+
+    <Schema xmlns="http://docs.oasis-open.org/odata/ns/edm" Namespace="ExternalAccountProvider.v1_1_2">
+      <Annotation Term="Redfish.OwningEntity" String="DMTF"/>
+      <Annotation Term="OData.Description" String="This version was created to update the descriptions of Password, Token, and KerberosKeytab properties.  It was also created to clarify the usage of the LDAPService property."/>
+      <EntityType Name="ExternalAccountProvider" BaseType="ExternalAccountProvider.v1_1_1.ExternalAccountProvider"/>
+    </Schema>
+
+    <Schema xmlns="http://docs.oasis-open.org/odata/ns/edm" Namespace="ExternalAccountProvider.v1_1_3">
+      <Annotation Term="Redfish.OwningEntity" String="DMTF"/>
+      <Annotation Term="OData.Description" String="This version was created to correct various typographical errors."/>
+      <EntityType Name="ExternalAccountProvider" BaseType="ExternalAccountProvider.v1_1_2.ExternalAccountProvider"/>
+    </Schema>
+
+    <Schema xmlns="http://docs.oasis-open.org/odata/ns/edm" Namespace="ExternalAccountProvider.v1_1_4">
+      <Annotation Term="Redfish.OwningEntity" String="DMTF"/>
+      <Annotation Term="OData.Description" String="This version was created to correct various typographical errors."/>
+      <EntityType Name="ExternalAccountProvider" BaseType="ExternalAccountProvider.v1_1_3.ExternalAccountProvider"/>
+    </Schema>
+
+    <Schema xmlns="http://docs.oasis-open.org/odata/ns/edm" Namespace="ExternalAccountProvider.v1_2_0">
+      <Annotation Term="Redfish.OwningEntity" String="DMTF"/>
+      <Annotation Term="Redfish.Release" String="2020.4"/>
+      <Annotation Term="OData.Description" String="This version was created to add TACACS+ support."/>
+
+      <EntityType Name="ExternalAccountProvider" BaseType="ExternalAccountProvider.v1_1_4.ExternalAccountProvider">
+        <Property Name="TACACSplusService" Type="ExternalAccountProvider.v1_2_0.TACACSplusService">
+          <Annotation Term="OData.Description" String="The additional information needed to parse a TACACS+ services."/>
+          <Annotation Term="OData.LongDescription" String="This property shall contain additional information needed to parse a TACACS+ services.  This property should only be present inside a TACACSplus property."/>
+        </Property>
+        <Property Name="Priority" Type="Edm.Int64">
+          <Annotation Term="OData.Permissions" EnumMember="OData.Permission/ReadWrite"/>
+          <Annotation Term="OData.Description" String="The authentication priority for the external account provider."/>
+          <Annotation Term="OData.LongDescription" String="This property shall contain the assigned priority for the specified external account provider.  The value `0` value shall indicate the highest priority.  Increasing values shall represent decreasing priority.  If an external provider does not have a priority assignment or two or more external providers have the same priority, the behavior shall be determined by the Redfish service.  The priority is used to determine the order of authentication and authorization for each external account provider."/>
+          <Annotation Term="Validation.Minimum" Int="0"/>
+        </Property>
+      </EntityType>
+
+      <ComplexType Name="Authentication" BaseType="ExternalAccountProvider.v1_0_0.Authentication">
+        <Property Name="EncryptionKey" Type="Edm.String">
+          <Annotation Term="OData.Permissions" EnumMember="OData.Permission/ReadWrite"/>
+          <Annotation Term="OData.Description" String="Specifies the encryption key."/>
+          <Annotation Term="OData.LongDescription" String="This property shall contain the value of a symmetric encryption key for account services that support some form of encryption, obfuscation, or authentication such as TACACS+.  The value shall be `null` in responses.  The property shall accept a hexadecimal string whose length depends on the external account service, such as TACACS+.  A TACACS+ service shall use this property to specify the secret key as defined in RFC8907."/>
+          <Annotation Term="Validation.Pattern" String="^[0-9a-fA-F]+$"/>
+        </Property>
+       <Property Name="EncryptionKeySet" Type="Edm.Boolean">
+          <Annotation Term="OData.Permissions" EnumMember="OData.Permission/Read"/>
+          <Annotation Term="OData.Description" String="Indicates if the EncryptionKey property is set."/>
+          <Annotation Term="OData.LongDescription" String="This property shall contain `true` if a valid value was provided for the EncryptionKey property.  Otherwise, the property shall contain `false`.  For a TACACS+ service, the value `false` shall indicate data obfuscation, as defined in section 4.5 of RFC8907, is disabled."/>
+        </Property>
+      </ComplexType>
+
+      <ComplexType Name="TACACSplusService">
+        <Annotation Term="OData.AdditionalProperties" Bool="false"/>
+        <Annotation Term="OData.Description" String="Various settings to parse a TACACS+ service."/>
+        <Annotation Term="OData.LongDescription" String="This type shall contain settings for parsing a TACACS+ service."/>
+        <Property Name="PrivilegeLevelArgument" Type="Edm.String">
+          <Annotation Term="OData.Permissions" EnumMember="OData.Permission/ReadWrite"/>
+          <Annotation Term="OData.Description" String="Indicates the name of the TACACS+ argument name in an authorization request."/>
+          <Annotation Term="OData.LongDescription" String="This property shall specify the name of the argument in a TACACS+ Authorization REPLY packet body, as defined in RFC8907, that contains the user's privilege level."/>
+        </Property>
+        <Property Name="PasswordExchangeProtocols" Type="Collection(ExternalAccountProvider.v1_2_0.TACACSplusPasswordExchangeProtocol)">
+          <Annotation Term="OData.Permissions" EnumMember="OData.Permission/ReadWrite"/>
+          <Annotation Term="OData.Description" String="Indicates the allowed TACACS+ password exchange protocols."/>
+          <Annotation Term="OData.LongDescription" String="This property shall indicate all the allowed TACACS+ password exchange protocol described under section 5.4.2 of RFC8907."/>
+        </Property>
+      </ComplexType>
+
+      <EnumType Name="TACACSplusPasswordExchangeProtocol">
+        <Member Name="ASCII">
+          <Annotation Term="OData.Description" String="The ASCII Login method."/>
+          <Annotation Term="OData.LongDescription" String="This value shall indicate the ASCII Login flow as described under section 5.4.2 of RFC8907."/>
+        </Member>
+        <Member Name="PAP">
+          <Annotation Term="OData.Description" String="The PAP Login method."/>
+          <Annotation Term="OData.LongDescription" String="This value shall indicate the PAP Login flow as described under section 5.4.2 of RFC8907."/>
+        </Member>
+        <Member Name="CHAP">
+          <Annotation Term="OData.Description" String="The CHAP Login method."/>
+          <Annotation Term="OData.LongDescription" String="This value shall indicate the CHAP Login flow as described under section 5.4.2 of RFC8907."/>
+        </Member>
+        <Member Name="MSCHAPv1">
+          <Annotation Term="OData.Description" String="The MS-CHAP v1 Login method."/>
+          <Annotation Term="OData.LongDescription" String="This value shall indicate the MS-CHAP v1 Login flow as described under section 5.4.2 of RFC8907."/>
+        </Member>
+        <Member Name="MSCHAPv2">
+          <Annotation Term="OData.Description" String="The MS-CHAP v2 Login method."/>
+          <Annotation Term="OData.LongDescription" String="This value shall indicate the MS-CHAP v2 Login flow as described under section 5.4.2 of RFC8907."/>
+        </Member>
+      </EnumType>
+    </Schema>
+
+    <Schema xmlns="http://docs.oasis-open.org/odata/ns/edm" Namespace="ExternalAccountProvider.v1_3_0">
+      <Annotation Term="Redfish.OwningEntity" String="DMTF"/>
+      <Annotation Term="Redfish.Release" String="2021.2"/>
+
+      <EntityType Name="ExternalAccountProvider" BaseType="ExternalAccountProvider.v1_2_0.ExternalAccountProvider">
+        <Property Name="OAuth2Service" Type="ExternalAccountProvider.v1_3_0.OAuth2Service">
+          <Annotation Term="OData.Description" String="The additional information needed to parse an OAuth 2.0 service."/>
+          <Annotation Term="OData.LongDescription" String="This property shall contain additional information needed to parse an OAuth 2.0 service.  This property should only be present inside an OAuth2 property."/>
+        </Property>
+      </EntityType>
+
+      <ComplexType Name="OAuth2Service">
+        <Annotation Term="OData.AdditionalProperties" Bool="false"/>
+        <Annotation Term="OData.Description" String="Various settings to parse an OAuth 2.0 service."/>
+        <Annotation Term="OData.LongDescription" String="This type shall contain settings for parsing an OAuth 2.0 service."/>
+        <Property Name="Mode" Type="ExternalAccountProvider.v1_3_0.OAuth2Mode" Nullable="false">
+          <Annotation Term="OData.Permissions" EnumMember="OData.Permission/ReadWrite"/>
+          <Annotation Term="OData.Description" String="The mode of operation for token validation."/>
+          <Annotation Term="OData.LongDescription" String="This property shall contain the mode of operation for token validation."/>
+        </Property>
+        <Property Name="Issuer" Type="Edm.String">
+          <Annotation Term="OData.Permissions" EnumMember="OData.Permission/ReadWrite"/>
+          <Annotation Term="OData.Description" String="The issuer string of the OAuth 2.0 service."/>
+          <Annotation Term="OData.LongDescription" String="This property shall contain the RFC8414-defined issuer string of the OAuth 2.0 service.  If the Mode property contains the value `Discovery`, this property shall contain the value of the `issuer` string from the OAuth 2.0 service's metadata and this property shall be read-only."/>
+        </Property>
+        <Property Name="Audience" Type="Collection(Edm.String)" Nullable="false">
+          <Annotation Term="OData.Permissions" EnumMember="OData.Permission/Read"/>
+          <Annotation Term="OData.Description" String="The allowable audience strings of the Redfish service."/>
+          <Annotation Term="OData.LongDescription" String="This property shall contain an array of allowable RFC7519-defined audience strings of the Redfish service.  The values shall uniquely identify the Redfish service.  For example, a MAC address or UUID for the manager can uniquely identify the service."/>
+        </Property>
+        <Property Name="OAuthServiceSigningKeys" Type="Edm.String">
+          <Annotation Term="OData.Permissions" EnumMember="OData.Permission/ReadWrite"/>
+          <Annotation Term="OData.Description" String="The Base64-encoded signing keys of the issuer of the OAuth 2.0 service."/>
+          <Annotation Term="OData.LongDescription" String="This property shall contain a Base64-encoded string of the RFC7517-defined signing keys of the issuer of the OAuth 2.0 service.  If the Mode property contains the value `Discovery`, this property shall contain the keys found at the URI specified by the `jwks_uri` string from the OAuth 2.0 service's metadata and this property shall be read-only."/>
+        </Property>
+      </ComplexType>
+
+      <EnumType Name="OAuth2Mode">
+        <Member Name="Discovery">
+          <Annotation Term="OData.Description" String="OAuth 2.0 service information for token validation is downloaded by the service."/>
+          <Annotation Term="OData.LongDescription" String="This value shall indicate the service performs token validation from information found at the URIs specified by the ServiceAddresses property.  Services shall implement a caching method of this information so it's not necessary to retrieve metadata and key information for every request containing a token."/>
+        </Member>
+        <Member Name="Offline">
+          <Annotation Term="OData.Description" String="OAuth 2.0 service information for token validation is configured by a client."/>
+          <Annotation Term="OData.LongDescription" String="This value shall indicate the service performs token validation from properties configured by a client."/>
+        </Member>
+      </EnumType>
+    </Schema>
+
+  </edmx:DataServices>
+</edmx:Edmx>

--- a/static/redfish/v1/schema/FabricAdapter_v1.xml
+++ b/static/redfish/v1/schema/FabricAdapter_v1.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!---->
 <!--################################################################################       -->
-<!--# Redfish Schema:  FabricAdapter v1.0.0                                                -->
+<!--# Redfish Schema:  FabricAdapter v1.1.0                                                -->
 <!--#                                                                                      -->
 <!--# For a detailed change log, see the README file contained in the DSP8010 bundle,      -->
 <!--# available at http://www.dmtf.org/standards/redfish                                   -->
@@ -229,6 +229,18 @@
           <Annotation Term="OData.AutoExpandReferences"/>
         </NavigationProperty>
       </ComplexType>
+    </Schema>
+
+    <Schema xmlns="http://docs.oasis-open.org/odata/ns/edm" Namespace="FabricAdapter.v1_1_0">
+      <Annotation Term="Redfish.OwningEntity" String="DMTF"/>
+      <Annotation Term="Redfish.Release" String="2021.2"/>
+
+      <EntityType Name="FabricAdapter" BaseType="FabricAdapter.v1_0_0.FabricAdapter">
+        <Property Name="Location" Type="Resource.Location" Nullable="false">
+          <Annotation Term="OData.Description" String="The location of the fabric adapter."/>
+          <Annotation Term="OData.LongDescription" String="This property shall contain location information for the fabric adapter."/>
+        </Property>
+      </EntityType>
     </Schema>
 
   </edmx:DataServices>

--- a/static/redfish/v1/schema/FabricCollection_v1.xml
+++ b/static/redfish/v1/schema/FabricCollection_v1.xml
@@ -1,0 +1,68 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!---->
+<!--################################################################################       -->
+<!--# Redfish Schema:  FabricCollection                                                    -->
+<!--#                                                                                      -->
+<!--# For a detailed change log, see the README file contained in the DSP8010 bundle,      -->
+<!--# available at http://www.dmtf.org/standards/redfish                                   -->
+<!--# Copyright 2014-2021 DMTF.                                                            -->
+<!--# For the full DMTF copyright policy, see http://www.dmtf.org/about/policies/copyright -->
+<!--################################################################################       -->
+<!---->
+<edmx:Edmx xmlns:edmx="http://docs.oasis-open.org/odata/ns/edmx" Version="4.0">
+
+  <edmx:Reference Uri="http://docs.oasis-open.org/odata/odata/v4.0/errata03/csd01/complete/vocabularies/Org.OData.Core.V1.xml">
+    <edmx:Include Namespace="Org.OData.Core.V1" Alias="OData"/>
+  </edmx:Reference>
+  <edmx:Reference Uri="http://docs.oasis-open.org/odata/odata/v4.0/errata03/csd01/complete/vocabularies/Org.OData.Capabilities.V1.xml">
+    <edmx:Include Namespace="Org.OData.Capabilities.V1" Alias="Capabilities"/>
+  </edmx:Reference>
+  <edmx:Reference Uri="http://redfish.dmtf.org/schemas/v1/Resource_v1.xml">
+    <edmx:Include Namespace="Resource.v1_0_0"/>
+  </edmx:Reference>
+  <edmx:Reference Uri="http://redfish.dmtf.org/schemas/v1/RedfishExtensions_v1.xml">
+    <edmx:Include Namespace="RedfishExtensions.v1_0_0" Alias="Redfish"/>
+  </edmx:Reference>
+  <edmx:Reference Uri="http://redfish.dmtf.org/schemas/v1/Fabric_v1.xml">
+    <edmx:Include Namespace="Fabric"/>
+  </edmx:Reference>
+
+  <edmx:DataServices>
+    <Schema xmlns="http://docs.oasis-open.org/odata/ns/edm" Namespace="FabricCollection">
+      <Annotation Term="Redfish.OwningEntity" String="DMTF"/>
+
+      <EntityType Name="FabricCollection" BaseType="Resource.v1_0_0.ResourceCollection">
+        <Annotation Term="OData.Description" String="A Collection of Fabric Resource instances."/>
+        <Annotation Term="OData.LongDescription" String="This Resource shall represent a Resource Collection of Fabric instances for a Redfish implementation."/>
+        <Annotation Term="Capabilities.InsertRestrictions">
+          <Record>
+            <PropertyValue Property="Insertable" Bool="false"/>
+          </Record>
+        </Annotation>
+        <Annotation Term="Capabilities.UpdateRestrictions">
+          <Record>
+            <PropertyValue Property="Updatable" Bool="false"/>
+          </Record>
+        </Annotation>
+        <Annotation Term="Capabilities.DeleteRestrictions">
+          <Record>
+            <PropertyValue Property="Deletable" Bool="false"/>
+          </Record>
+        </Annotation>
+        <Annotation Term="Redfish.Uris">
+          <Collection>
+            <String>/redfish/v1/Fabrics</String>
+          </Collection>
+        </Annotation>
+        <NavigationProperty Name="Members" Type="Collection(Fabric.Fabric)">
+          <Annotation Term="OData.Permissions" EnumMember="OData.Permission/Read"/>
+          <Annotation Term="OData.Description" String="The members of this collection."/>
+          <Annotation Term="OData.LongDescription" String="This property shall contain an array of links to the members of this collection."/>
+          <Annotation Term="OData.AutoExpandReferences"/>
+          <Annotation Term="Redfish.Required"/>
+        </NavigationProperty>
+      </EntityType>
+
+    </Schema>
+  </edmx:DataServices>
+</edmx:Edmx>

--- a/static/redfish/v1/schema/Fabric_v1.xml
+++ b/static/redfish/v1/schema/Fabric_v1.xml
@@ -1,0 +1,268 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!---->
+<!--################################################################################       -->
+<!--# Redfish Schema:  Fabric v1.2.2                                                       -->
+<!--#                                                                                      -->
+<!--# For a detailed change log, see the README file contained in the DSP8010 bundle,      -->
+<!--# available at http://www.dmtf.org/standards/redfish                                   -->
+<!--# Copyright 2014-2021 DMTF.                                                            -->
+<!--# For the full DMTF copyright policy, see http://www.dmtf.org/about/policies/copyright -->
+<!--################################################################################       -->
+<!---->
+<edmx:Edmx xmlns:edmx="http://docs.oasis-open.org/odata/ns/edmx" Version="4.0">
+
+  <edmx:Reference Uri="http://docs.oasis-open.org/odata/odata/v4.0/errata03/csd01/complete/vocabularies/Org.OData.Core.V1.xml">
+    <edmx:Include Namespace="Org.OData.Core.V1" Alias="OData"/>
+  </edmx:Reference>
+  <edmx:Reference Uri="http://docs.oasis-open.org/odata/odata/v4.0/errata03/csd01/complete/vocabularies/Org.OData.Capabilities.V1.xml">
+    <edmx:Include Namespace="Org.OData.Capabilities.V1" Alias="Capabilities"/>
+  </edmx:Reference>
+  <edmx:Reference Uri="http://redfish.dmtf.org/schemas/v1/Resource_v1.xml">
+    <edmx:Include Namespace="Resource"/>
+    <edmx:Include Namespace="Resource.v1_0_0"/>
+  </edmx:Reference>
+  <edmx:Reference Uri="http://redfish.dmtf.org/schemas/v1/RedfishExtensions_v1.xml">
+    <edmx:Include Namespace="RedfishExtensions.v1_0_0" Alias="Redfish"/>
+  </edmx:Reference>
+  <edmx:Reference Uri="http://redfish.dmtf.org/schemas/v1/ZoneCollection_v1.xml">
+    <edmx:Include Namespace="ZoneCollection"/>
+  </edmx:Reference>
+  <edmx:Reference Uri="http://redfish.dmtf.org/schemas/v1/EndpointCollection_v1.xml">
+    <edmx:Include Namespace="EndpointCollection"/>
+  </edmx:Reference>
+  <edmx:Reference Uri="http://redfish.dmtf.org/schemas/v1/EndpointGroupCollection_v1.xml">
+    <edmx:Include Namespace="EndpointGroupCollection"/>
+  </edmx:Reference>
+  <edmx:Reference Uri="http://redfish.dmtf.org/schemas/v1/SwitchCollection_v1.xml">
+    <edmx:Include Namespace="SwitchCollection"/>
+  </edmx:Reference>
+  <edmx:Reference Uri="http://redfish.dmtf.org/schemas/v1/Protocol_v1.xml">
+    <edmx:Include Namespace="Protocol"/>
+  </edmx:Reference>
+  <edmx:Reference Uri="http://redfish.dmtf.org/schemas/v1/AddressPoolCollection_v1.xml">
+    <edmx:Include Namespace="AddressPoolCollection"/>
+  </edmx:Reference>
+  <edmx:Reference Uri="http://redfish.dmtf.org/schemas/v1/ConnectionCollection_v1.xml">
+    <edmx:Include Namespace="ConnectionCollection"/>
+  </edmx:Reference>
+
+  <edmx:DataServices>
+
+    <Schema xmlns="http://docs.oasis-open.org/odata/ns/edm" Namespace="Fabric">
+      <Annotation Term="Redfish.OwningEntity" String="DMTF"/>
+
+      <EntityType Name="Fabric" BaseType="Resource.v1_0_0.Resource" Abstract="true">
+        <Annotation Term="OData.Description" String="The Fabric schema represents a simple fabric consisting of one or more switches, zero or more endpoints, and zero or more zones."/>
+        <Annotation Term="OData.LongDescription" String="This resource shall represent a simple switchable fabric for a Redfish implementation."/>
+        <Annotation Term="Capabilities.InsertRestrictions">
+          <Record>
+            <PropertyValue Property="Insertable" Bool="false"/>
+          </Record>
+        </Annotation>
+        <Annotation Term="Capabilities.UpdateRestrictions">
+          <Record>
+            <PropertyValue Property="Updatable" Bool="false"/>
+          </Record>
+        </Annotation>
+        <Annotation Term="Capabilities.DeleteRestrictions">
+          <Record>
+            <PropertyValue Property="Deletable" Bool="false"/>
+          </Record>
+        </Annotation>
+        <Annotation Term="Redfish.Uris">
+          <Collection>
+            <String>/redfish/v1/Fabrics/{FabricId}</String>
+          </Collection>
+        </Annotation>
+      </EntityType>
+    </Schema>
+
+    <Schema xmlns="http://docs.oasis-open.org/odata/ns/edm" Namespace="Fabric.v1_0_0">
+      <Annotation Term="Redfish.OwningEntity" String="DMTF"/>
+      <Annotation Term="Redfish.Release" String="2016.2"/>
+
+      <EntityType Name="Fabric" BaseType="Fabric.Fabric">
+        <Property Name="FabricType" Type="Protocol.Protocol">
+          <Annotation Term="OData.Permissions" EnumMember="OData.Permission/Read"/>
+          <Annotation Term="OData.Description" String="The protocol being sent over this fabric."/>
+          <Annotation Term="OData.LongDescription" String="This property shall contain the type of fabric being represented by this simple fabric."/>
+        </Property>
+        <Property Name="Status" Type="Resource.Status" Nullable="false">
+          <Annotation Term="OData.Description" String="The status and health of the resource and its subordinate or dependent resources."/>
+          <Annotation Term="OData.LongDescription" String="This property shall contain any status or health properties of the resource."/>
+        </Property>
+        <Property Name="MaxZones" Type="Edm.Int64">
+          <Annotation Term="OData.Permissions" EnumMember="OData.Permission/Read"/>
+          <Annotation Term="OData.Description" String="The maximum number of zones the switch can currently configure."/>
+          <Annotation Term="OData.LongDescription" String="This property shall contain the maximum number of zones the switch can currently configure.  Changes in the logical or physical configuration of the system can change this value."/>
+        </Property>
+        <NavigationProperty Name="Zones" Type="ZoneCollection.ZoneCollection" ContainsTarget="true" Nullable="false">
+          <Annotation Term="OData.Permissions" EnumMember="OData.Permission/Read"/>
+          <Annotation Term="OData.Description" String="The collection of links to the zones that this fabric contains."/>
+          <Annotation Term="OData.LongDescription" String="This property shall contain a link to a resource collection of type ZoneCollection."/>
+          <Annotation Term="OData.AutoExpandReferences"/>
+        </NavigationProperty>
+        <NavigationProperty Name="Endpoints" Type="EndpointCollection.EndpointCollection" ContainsTarget="true" Nullable="false">
+          <Annotation Term="OData.Permissions" EnumMember="OData.Permission/Read"/>
+          <Annotation Term="OData.Description" String="The collection of links to the endpoints that this fabric contains."/>
+          <Annotation Term="OData.LongDescription" String="This property shall contain a link to a resource collection of type EndpointCollection."/>
+          <Annotation Term="OData.AutoExpandReferences"/>
+        </NavigationProperty>
+        <NavigationProperty Name="Switches" Type="SwitchCollection.SwitchCollection" ContainsTarget="true" Nullable="false">
+          <Annotation Term="OData.Permissions" EnumMember="OData.Permission/Read"/>
+          <Annotation Term="OData.Description" String="The collection of links to the switches that this fabric contains."/>
+          <Annotation Term="OData.LongDescription" String="This property shall contain a link to a resource collection of type SwitchCollection."/>
+          <Annotation Term="OData.AutoExpandReferences"/>
+        </NavigationProperty>
+        <Property Name="Links" Type="Fabric.v1_0_0.Links" Nullable="false">
+          <Annotation Term="OData.Description" String="The links to other resources that are related to this resource."/>
+          <Annotation Term="OData.LongDescription" String="This property shall contain links to resources that are related to but are not contained by, or subordinate to, this resource."/>
+        </Property>
+        <Property Name="Actions" Type="Fabric.v1_0_0.Actions" Nullable="false">
+          <Annotation Term="OData.Description" String="The available actions for this Resource."/>
+          <Annotation Term="OData.LongDescription" String="This property shall contain the available actions for this Resource."/>
+        </Property>
+      </EntityType>
+
+      <ComplexType Name="Links" BaseType="Resource.Links">
+        <Annotation Term="OData.Description" String="The links to other resources that are related to this resource."/>
+        <Annotation Term="OData.LongDescription" String="This Redfish Specification-described type shall contain links to resources that are related to but are not contained by, or subordinate to, this resource."/>
+      </ComplexType>
+
+      <ComplexType Name="Actions">
+        <Annotation Term="OData.AdditionalProperties" Bool="false"/>
+        <Annotation Term="OData.Description" String="The available actions for this resource."/>
+        <Annotation Term="OData.LongDescription" String="This type shall contain the available actions for this resource."/>
+        <Property Name="Oem" Type="Fabric.v1_0_0.OemActions" Nullable="false">
+          <Annotation Term="OData.Description" String="The available OEM-specific actions for this resource."/>
+          <Annotation Term="OData.LongDescription" String="This property shall contain the available OEM-specific actions for this resource."/>
+        </Property>
+      </ComplexType>
+
+      <ComplexType Name="OemActions">
+        <Annotation Term="OData.AdditionalProperties" Bool="true"/>
+        <Annotation Term="OData.Description" String="The available OEM-specific actions for this resource."/>
+        <Annotation Term="OData.LongDescription" String="This type shall contain the available OEM-specific actions for this resource."/>
+      </ComplexType>
+    </Schema>
+
+    <Schema xmlns="http://docs.oasis-open.org/odata/ns/edm" Namespace="Fabric.v1_0_1">
+      <Annotation Term="Redfish.OwningEntity" String="DMTF"/>
+      <Annotation Term="OData.Description" String="This version was created to add explicit Permissions annotations to all properties for clarity."/>
+      <EntityType Name="Fabric" BaseType="Fabric.v1_0_0.Fabric"/>
+    </Schema>
+
+    <Schema xmlns="http://docs.oasis-open.org/odata/ns/edm" Namespace="Fabric.v1_0_2">
+      <Annotation Term="Redfish.OwningEntity" String="DMTF"/>
+      <Annotation Term="OData.Description" String="This version was created to show annotations in previous namespaces were updated."/>
+      <EntityType Name="Fabric" BaseType="Fabric.v1_0_1.Fabric"/>
+    </Schema>
+
+    <Schema xmlns="http://docs.oasis-open.org/odata/ns/edm" Namespace="Fabric.v1_0_3">
+      <Annotation Term="Redfish.OwningEntity" String="DMTF"/>
+      <Annotation Term="OData.Description" String="This version was created to change FabricType to use the unversioned definition.  It was also created to update the descriptions that this schema defines."/>
+      <EntityType Name="Fabric" BaseType="Fabric.v1_0_2.Fabric"/>
+    </Schema>
+
+    <Schema xmlns="http://docs.oasis-open.org/odata/ns/edm" Namespace="Fabric.v1_0_4">
+      <Annotation Term="Redfish.OwningEntity" String="DMTF"/>
+      <Annotation Term="OData.Description" String="This version was created to force the regeneration of JSON Schema so that OData properties are marked as required, and integer properties are marked as integer rather than number."/>
+      <EntityType Name="Fabric" BaseType="Fabric.v1_0_3.Fabric"/>
+    </Schema>
+
+    <Schema xmlns="http://docs.oasis-open.org/odata/ns/edm" Namespace="Fabric.v1_0_5">
+      <Annotation Term="Redfish.OwningEntity" String="DMTF"/>
+      <Annotation Term="OData.Description" String="This version was created to force the regeneration of JSON Schema so that URI properties use the uri-reference format."/>
+      <EntityType Name="Fabric" BaseType="Fabric.v1_0_4.Fabric"/>
+    </Schema>
+
+    <Schema xmlns="http://docs.oasis-open.org/odata/ns/edm" Namespace="Fabric.v1_0_6">
+      <Annotation Term="Redfish.OwningEntity" String="DMTF"/>
+      <Annotation Term="OData.Description" String="This version was created to update descriptions that this schema defines."/>
+      <EntityType Name="Fabric" BaseType="Fabric.v1_0_5.Fabric"/>
+    </Schema>
+
+    <Schema xmlns="http://docs.oasis-open.org/odata/ns/edm" Namespace="Fabric.v1_0_7">
+      <Annotation Term="Redfish.OwningEntity" String="DMTF"/>
+      <Annotation Term="OData.Description" String="This version was created to correct various typographical errors."/>
+      <EntityType Name="Fabric" BaseType="Fabric.v1_0_6.Fabric"/>
+    </Schema>
+
+    <Schema xmlns="http://docs.oasis-open.org/odata/ns/edm" Namespace="Fabric.v1_0_8">
+      <Annotation Term="Redfish.OwningEntity" String="DMTF"/>
+      <Annotation Term="OData.Description" String="This version was created specify 64-bit integers in OpenAPI."/>
+      <EntityType Name="Fabric" BaseType="Fabric.v1_0_7.Fabric"/>
+    </Schema>
+
+    <Schema xmlns="http://docs.oasis-open.org/odata/ns/edm" Namespace="Fabric.v1_0_9">
+      <Annotation Term="Redfish.OwningEntity" String="DMTF"/>
+      <Annotation Term="OData.Description" String="This version was created to correct various description to use proper normative terminology."/>
+      <EntityType Name="Fabric" BaseType="Fabric.v1_0_8.Fabric"/>
+    </Schema>
+
+    <Schema xmlns="http://docs.oasis-open.org/odata/ns/edm" Namespace="Fabric.v1_1_0">
+      <Annotation Term="Redfish.OwningEntity" String="DMTF"/>
+      <Annotation Term="Redfish.Release" String="2019.4"/>
+
+      <EntityType Name="Fabric" BaseType="Fabric.v1_0_6.Fabric">
+        <NavigationProperty Name="AddressPools" Type="AddressPoolCollection.AddressPoolCollection" ContainsTarget="true" Nullable="false">
+          <Annotation Term="OData.Permissions" EnumMember="OData.Permission/Read"/>
+          <Annotation Term="OData.Description" String="The collection of links to the address pools that this fabric contains."/>
+          <Annotation Term="OData.LongDescription" String="This property shall contain a link to a resource collection of type AddressPoolCollection."/>
+          <Annotation Term="OData.AutoExpandReferences"/>
+        </NavigationProperty>
+      </EntityType>
+    </Schema>
+
+    <Schema xmlns="http://docs.oasis-open.org/odata/ns/edm" Namespace="Fabric.v1_1_1">
+      <Annotation Term="Redfish.OwningEntity" String="DMTF"/>
+      <Annotation Term="OData.Description" String="This version was created to correct various typographical errors."/>
+      <EntityType Name="Fabric" BaseType="Fabric.v1_1_0.Fabric"/>
+    </Schema>
+
+    <Schema xmlns="http://docs.oasis-open.org/odata/ns/edm" Namespace="Fabric.v1_1_2">
+      <Annotation Term="Redfish.OwningEntity" String="DMTF"/>
+      <Annotation Term="OData.Description" String="This version was created specify 64-bit integers in OpenAPI."/>
+      <EntityType Name="Fabric" BaseType="Fabric.v1_1_1.Fabric"/>
+    </Schema>
+
+    <Schema xmlns="http://docs.oasis-open.org/odata/ns/edm" Namespace="Fabric.v1_1_3">
+      <Annotation Term="Redfish.OwningEntity" String="DMTF"/>
+      <Annotation Term="OData.Description" String="This version was created to correct various description to use proper normative terminology."/>
+      <EntityType Name="Fabric" BaseType="Fabric.v1_1_2.Fabric"/>
+    </Schema>
+
+    <Schema xmlns="http://docs.oasis-open.org/odata/ns/edm" Namespace="Fabric.v1_2_0">
+      <Annotation Term="Redfish.OwningEntity" String="DMTF"/>
+      <Annotation Term="Redfish.Release" String="2020.3"/>
+
+      <EntityType Name="Fabric" BaseType="Fabric.v1_1_1.Fabric">
+        <NavigationProperty Name="Connections" Type="ConnectionCollection.ConnectionCollection" ContainsTarget="true" Nullable="false">
+          <Annotation Term="OData.Permissions" EnumMember="OData.Permission/Read"/>
+          <Annotation Term="OData.Description" String="The collection of links to the connections that this fabric contains."/>
+          <Annotation Term="OData.LongDescription" String="This property shall contain a link to a resource collection of type ConnectionCollection."/>
+          <Annotation Term="OData.AutoExpandReferences"/>
+        </NavigationProperty>
+        <NavigationProperty Name="EndpointGroups" Type="EndpointGroupCollection.EndpointGroupCollection" ContainsTarget="true" Nullable="false">
+          <Annotation Term="OData.Permissions" EnumMember="OData.Permission/Read"/>
+          <Annotation Term="OData.Description" String="The collection of links to the endpoint groups that this fabric contains."/>
+          <Annotation Term="OData.LongDescription" String="This property shall contain a link to a resource collection of type EndpointGroupCollection."/>
+          <Annotation Term="OData.AutoExpandReferences"/>
+        </NavigationProperty>
+      </EntityType>
+    </Schema>
+
+    <Schema xmlns="http://docs.oasis-open.org/odata/ns/edm" Namespace="Fabric.v1_2_1">
+      <Annotation Term="Redfish.OwningEntity" String="DMTF"/>
+      <Annotation Term="OData.Description" String="This version was created specify 64-bit integers in OpenAPI."/>
+      <EntityType Name="Fabric" BaseType="Fabric.v1_2_0.Fabric"/>
+    </Schema>
+
+    <Schema xmlns="http://docs.oasis-open.org/odata/ns/edm" Namespace="Fabric.v1_2_2">
+      <Annotation Term="Redfish.OwningEntity" String="DMTF"/>
+      <Annotation Term="OData.Description" String="This version was created to correct various description to use proper normative terminology."/>
+      <EntityType Name="Fabric" BaseType="Fabric.v1_2_1.Fabric"/>
+    </Schema>
+
+  </edmx:DataServices>
+</edmx:Edmx>

--- a/static/redfish/v1/schema/FacilityCollection_v1.xml
+++ b/static/redfish/v1/schema/FacilityCollection_v1.xml
@@ -1,0 +1,70 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!---->
+<!--################################################################################       -->
+<!--# Redfish Schema:  FacilityCollection                                                  -->
+<!--#                                                                                      -->
+<!--# For a detailed change log, see the README file contained in the DSP8010 bundle,      -->
+<!--# available at http://www.dmtf.org/standards/redfish                                   -->
+<!--# Copyright 2014-2021 DMTF.                                                            -->
+<!--# For the full DMTF copyright policy, see http://www.dmtf.org/about/policies/copyright -->
+<!--################################################################################       -->
+<!---->
+<edmx:Edmx xmlns:edmx="http://docs.oasis-open.org/odata/ns/edmx" Version="4.0">
+
+  <edmx:Reference Uri="http://docs.oasis-open.org/odata/odata/v4.0/errata03/csd01/complete/vocabularies/Org.OData.Core.V1.xml">
+    <edmx:Include Namespace="Org.OData.Core.V1" Alias="OData"/>
+  </edmx:Reference>
+  <edmx:Reference Uri="http://docs.oasis-open.org/odata/odata/v4.0/errata03/csd01/complete/vocabularies/Org.OData.Capabilities.V1.xml">
+    <edmx:Include Namespace="Org.OData.Capabilities.V1" Alias="Capabilities"/>
+  </edmx:Reference>
+  <edmx:Reference Uri="http://redfish.dmtf.org/schemas/v1/RedfishExtensions_v1.xml">
+    <edmx:Include Namespace="RedfishExtensions.v1_0_0" Alias="Redfish"/>
+  </edmx:Reference>
+  <edmx:Reference Uri="http://redfish.dmtf.org/schemas/v1/Resource_v1.xml">
+    <edmx:Include Namespace="Resource.v1_0_0"/>
+  </edmx:Reference>
+  <edmx:Reference Uri="http://redfish.dmtf.org/schemas/v1/Facility_v1.xml">
+    <edmx:Include Namespace="Facility"/>
+  </edmx:Reference>
+
+  <edmx:DataServices>
+
+    <Schema xmlns="http://docs.oasis-open.org/odata/ns/edm" Namespace="FacilityCollection">
+      <Annotation Term="Redfish.OwningEntity" String="DMTF"/>
+
+      <EntityType Name="FacilityCollection" BaseType="Resource.v1_0_0.ResourceCollection">
+        <Annotation Term="OData.Description" String="The collection of Facility resource instances."/>
+        <Annotation Term="OData.LongDescription" String="This resource shall represent a resource collection of Facility instances for a Redfish implementation."/>
+        <Annotation Term="Capabilities.InsertRestrictions">
+          <Record>
+            <PropertyValue Property="Insertable" Bool="true"/>
+            <Annotation Term="OData.Description" String="In some implementations, facilities can be added through a POST to the facility collection.  In other implementations, the collection might be pre-populated with a fixed number of facilities."/>
+          </Record>
+        </Annotation>
+        <Annotation Term="Capabilities.UpdateRestrictions">
+          <Record>
+            <PropertyValue Property="Updatable" Bool="false"/>
+          </Record>
+        </Annotation>
+        <Annotation Term="Capabilities.DeleteRestrictions">
+          <Record>
+            <PropertyValue Property="Deletable" Bool="false"/>
+          </Record>
+        </Annotation>
+        <Annotation Term="Redfish.Uris">
+          <Collection>
+            <String>/redfish/v1/Facilities</String>
+          </Collection>
+        </Annotation>
+        <NavigationProperty Name="Members" Type="Collection(Facility.Facility)">
+          <Annotation Term="OData.Permissions" EnumMember="OData.Permission/Read"/>
+          <Annotation Term="OData.Description" String="The members of this collection."/>
+          <Annotation Term="OData.LongDescription" String="This property shall contain an array of links to the members of this collection."/>
+          <Annotation Term="OData.AutoExpandReferences"/>
+          <Annotation Term="Redfish.Required"/>
+        </NavigationProperty>
+      </EntityType>
+    </Schema>
+
+  </edmx:DataServices>
+</edmx:Edmx>

--- a/static/redfish/v1/schema/Facility_v1.xml
+++ b/static/redfish/v1/schema/Facility_v1.xml
@@ -1,0 +1,239 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!---->
+<!--################################################################################       -->
+<!--# Redfish Schema:  Facility v1.2.0                                                     -->
+<!--#                                                                                      -->
+<!--# For a detailed change log, see the README file contained in the DSP8010 bundle,      -->
+<!--# available at http://www.dmtf.org/standards/redfish                                   -->
+<!--# Copyright 2014-2021 DMTF.                                                            -->
+<!--# For the full DMTF copyright policy, see http://www.dmtf.org/about/policies/copyright -->
+<!--################################################################################       -->
+<!---->
+<edmx:Edmx xmlns:edmx="http://docs.oasis-open.org/odata/ns/edmx" Version="4.0">
+
+  <edmx:Reference Uri="http://docs.oasis-open.org/odata/odata/v4.0/errata03/csd01/complete/vocabularies/Org.OData.Core.V1.xml">
+    <edmx:Include Namespace="Org.OData.Core.V1" Alias="OData"/>
+  </edmx:Reference>
+  <edmx:Reference Uri="http://docs.oasis-open.org/odata/odata/v4.0/errata03/csd01/complete/vocabularies/Org.OData.Capabilities.V1.xml">
+    <edmx:Include Namespace="Org.OData.Capabilities.V1" Alias="Capabilities"/>
+  </edmx:Reference>
+  <edmx:Reference Uri="http://redfish.dmtf.org/schemas/v1/RedfishExtensions_v1.xml">
+    <edmx:Include Namespace="RedfishExtensions.v1_0_0" Alias="Redfish"/>
+  </edmx:Reference>
+  <edmx:Reference Uri="http://redfish.dmtf.org/schemas/v1/Resource_v1.xml">
+    <edmx:Include Namespace="Resource"/>
+    <edmx:Include Namespace="Resource.v1_0_0"/>
+  </edmx:Reference>
+  <edmx:Reference Uri="http://redfish.dmtf.org/schemas/v1/Chassis_v1.xml">
+    <edmx:Include Namespace="Chassis"/>
+  </edmx:Reference>
+  <edmx:Reference Uri="http://redfish.dmtf.org/schemas/v1/Manager_v1.xml">
+    <edmx:Include Namespace="Manager"/>
+  </edmx:Reference>
+  <edmx:Reference Uri="http://redfish.dmtf.org/schemas/v1/PowerDomainCollection_v1.xml">
+    <edmx:Include Namespace="PowerDomainCollection"/>
+  </edmx:Reference>
+  <edmx:Reference Uri="http://redfish.dmtf.org/schemas/v1/PowerDistribution_v1.xml">
+    <edmx:Include Namespace="PowerDistribution"/>
+  </edmx:Reference>
+  <edmx:Reference Uri="http://redfish.dmtf.org/schemas/v1/EnvironmentMetrics_v1.xml">
+    <edmx:Include Namespace="EnvironmentMetrics"/>
+  </edmx:Reference>
+
+  <edmx:DataServices>
+
+    <Schema xmlns="http://docs.oasis-open.org/odata/ns/edm" Namespace="Facility">
+      <Annotation Term="Redfish.OwningEntity" String="DMTF"/>
+
+      <EntityType Name="Facility" BaseType="Resource.v1_0_0.Resource" Abstract="true">
+        <Annotation Term="OData.Description" String="The Facility schema represents the physical location containing equipment, such as a room, building, or campus."/>
+        <Annotation Term="OData.LongDescription" String="This resource shall be used to represent a location containing equipment, such as a room, building, or campus, for a Redfish implementation."/>
+        <Annotation Term="Capabilities.InsertRestrictions">
+          <Record>
+            <PropertyValue Property="Insertable" Bool="false"/>
+          </Record>
+        </Annotation>
+        <Annotation Term="Capabilities.UpdateRestrictions">
+          <Record>
+            <PropertyValue Property="Updatable" Bool="true"/>
+            <Annotation Term="OData.Description" String="Any writable properties can be updated."/>
+          </Record>
+        </Annotation>
+        <Annotation Term="Capabilities.DeleteRestrictions">
+          <Record>
+            <PropertyValue Property="Deletable" Bool="true"/>
+            <Annotation Term="OData.Description" String="Implemenations can allow deletion of facilities from the collection."/>
+          </Record>
+        </Annotation>
+        <Annotation Term="Redfish.Uris">
+          <Collection>
+            <String>/redfish/v1/Facilities/{FacilityId}</String>
+          </Collection>
+        </Annotation>
+      </EntityType>
+    </Schema>
+
+    <Schema xmlns="http://docs.oasis-open.org/odata/ns/edm" Namespace="Facility.v1_0_0">
+      <Annotation Term="Redfish.OwningEntity" String="DMTF"/>
+      <Annotation Term="Redfish.Release" String="2019.4"/>
+
+      <EntityType Name="Facility" BaseType="Facility.Facility">
+        <Property Name="FacilityType" Nullable="false" Type="Facility.v1_0_0.FacilityType">
+          <Annotation Term="OData.Permissions" EnumMember="OData.Permission/Read"/>
+          <Annotation Term="OData.Description" String="The type of location this resource represents."/>
+          <Annotation Term="OData.LongDescription" String="This property shall contain the type of location this resource represents."/>
+          <Annotation Term="Redfish.Required"/>
+        </Property>
+        <Property Name="Status" Type="Resource.Status" Nullable="false">
+          <Annotation Term="OData.Description" String="The status and health of the resource and its subordinate or dependent resources."/>
+          <Annotation Term="OData.LongDescription" String="This property shall contain any status or health properties of the resource."/>
+        </Property>
+        <Property Name="Location" Type="Resource.Location" Nullable="false">
+          <Annotation Term="OData.Description" String="The location of the facility."/>
+          <Annotation Term="OData.LongDescription" String="This property shall contain location information of the associated facility."/>
+        </Property>
+        <NavigationProperty Name="PowerDomains" Type="PowerDomainCollection.PowerDomainCollection" Nullable="false">
+          <Annotation Term="OData.Permissions" EnumMember="OData.Permission/Read"/>
+          <Annotation Term="OData.Description" String="Link to the power domains in this facility."/>
+          <Annotation Term="OData.LongDescription" String="This property shall contain a link to a resource collection of type PowerDomainCollection that contains the power domains associated with this facility."/>
+          <Annotation Term="OData.AutoExpandReferences"/>
+        </NavigationProperty>
+        <Property Name="Links" Type="Facility.v1_0_0.Links" Nullable="false">
+          <Annotation Term="OData.Description" String="The links to other resources that are related to this resource."/>
+          <Annotation Term="OData.LongDescription" String="This property shall contain links to resources that are related to but are not contained by, or subordinate to, this resource."/>
+        </Property>
+        <Property Name="Actions" Type="Facility.v1_0_0.Actions" Nullable="false">
+          <Annotation Term="OData.Description" String="The available actions for this resource."/>
+          <Annotation Term="OData.LongDescription" String="This property shall contain the available actions for this resource."/>
+        </Property>
+      </EntityType>
+
+      <EnumType Name="FacilityType">
+        <Member Name="Room">
+          <Annotation Term="OData.Description" String="A room inside of a building or floor."/>
+        </Member>
+        <Member Name="Floor">
+          <Annotation Term="OData.Description" String="A floor inside of a building."/>
+        </Member>
+        <Member Name="Building">
+          <Annotation Term="OData.Description" String="A structure with a roof and walls."/>
+        </Member>
+        <Member Name="Site">
+          <Annotation Term="OData.Description" String="A small area consisting of several buildings."/>
+        </Member>
+      </EnumType>
+
+      <ComplexType Name="Links" BaseType="Resource.Links">
+        <Annotation Term="OData.Description" String="The links to other resources that are related to this resource."/>
+        <Annotation Term="OData.LongDescription" String="This Redfish Specification-described type shall contain links to resources that are related to but are not contained by, or subordinate to, this resource."/>
+        <NavigationProperty Name="ContainedByFacility" Type="Facility.Facility" Nullable="false">
+          <Annotation Term="OData.Permissions" EnumMember="OData.Permission/ReadWrite"/>
+          <Annotation Term="OData.Description" String="The link to the facility that contains this facility."/>
+          <Annotation Term="OData.LongDescription" String="This property shall contain a link to a resource of type Facility that represents the facility that contains this facility."/>
+          <Annotation Term="OData.AutoExpandReferences"/>
+        </NavigationProperty>
+        <NavigationProperty Name="ContainsFacilities" Type="Collection(Facility.Facility)">
+          <Annotation Term="OData.Permissions" EnumMember="OData.Permission/ReadWrite"/>
+          <Annotation Term="OData.Description" String="An array of links to other facilities contained within this facility."/>
+          <Annotation Term="OData.LongDescription" String="The value of this property shall be an array of links to resources of type Facility that represent the facilities that this facility contains."/>
+          <Annotation Term="OData.AutoExpandReferences"/>
+        </NavigationProperty>
+        <NavigationProperty Name="ManagedBy" Type="Collection(Manager.Manager)">
+          <Annotation Term="OData.Permissions" EnumMember="OData.Permission/Read"/>
+          <Annotation Term="OData.Description" String="An array of links to the managers responsible for managing this facility."/>
+          <Annotation Term="OData.LongDescription" String="The value of this property shall be an array of links to resources of type Manager that represent the managers that manager this facility."/>
+          <Annotation Term="OData.AutoExpandReferences"/>
+        </NavigationProperty>
+        <NavigationProperty Name="ContainsChassis" Type="Collection(Chassis.Chassis)">
+          <Annotation Term="OData.Permissions" EnumMember="OData.Permission/ReadWrite"/>
+          <Annotation Term="OData.Description" String="An array of links to outermost chassis contained within this facility."/>
+          <Annotation Term="OData.LongDescription" String="The value of this property shall be an array of links to resources of type Chassis that represent the outermost chassis that this facility contains.  This array shall only contain chassis instances that do not include a ContainedBy property within the Links property.  That is, only chassis instances that are not contained by another chassis."/>
+          <Annotation Term="OData.AutoExpandReferences"/>
+        </NavigationProperty>
+        <NavigationProperty Name="FloorPDUs" Type="Collection(PowerDistribution.PowerDistribution)">
+          <Annotation Term="OData.Permissions" EnumMember="OData.Permission/ReadWrite"/>
+          <Annotation Term="OData.Description" String="An array of links to the floor power distribution units in this facility."/>
+          <Annotation Term="OData.LongDescription" String="The value of this property shall be an array of links to resources of type PowerDistribution that represent the floor power distribution units in this facility."/>
+          <Annotation Term="OData.AutoExpandReferences"/>
+        </NavigationProperty>
+        <NavigationProperty Name="RackPDUs" Type="Collection(PowerDistribution.PowerDistribution)">
+          <Annotation Term="OData.Permissions" EnumMember="OData.Permission/ReadWrite"/>
+          <Annotation Term="OData.Description" String="An array of links to the rack-level power distribution units in this facility."/>
+          <Annotation Term="OData.LongDescription" String="The value of this property shall be an array of links to resources of type PowerDistribution that represent the rack-level power distribution units in this facility."/>
+          <Annotation Term="OData.AutoExpandReferences"/>
+        </NavigationProperty>
+        <NavigationProperty Name="TransferSwitches" Type="Collection(PowerDistribution.PowerDistribution)">
+          <Annotation Term="OData.Permissions" EnumMember="OData.Permission/ReadWrite"/>
+          <Annotation Term="OData.Description" String="An array of links to the transfer switches in this facility."/>
+          <Annotation Term="OData.LongDescription" String="The value of this property shall be an array of links to resources of type PowerDistribution that represent the transfer switches in this facility."/>
+          <Annotation Term="OData.AutoExpandReferences"/>
+        </NavigationProperty>
+        <NavigationProperty Name="Switchgear" Type="Collection(PowerDistribution.PowerDistribution)">
+          <Annotation Term="OData.Permissions" EnumMember="OData.Permission/ReadWrite"/>
+          <Annotation Term="OData.Description" String="An array of links to the switchgear in this facility."/>
+          <Annotation Term="OData.LongDescription" String="The value of this property shall be an array of links to resources of type PowerDistribution that represent the switchgear in this facility."/>
+          <Annotation Term="OData.AutoExpandReferences"/>
+        </NavigationProperty>
+      </ComplexType>
+
+      <ComplexType Name="Actions">
+        <Annotation Term="OData.AdditionalProperties" Bool="false"/>
+        <Annotation Term="OData.Description" String="The available actions for this resource."/>
+        <Annotation Term="OData.LongDescription" String="This type shall contain the available actions for this resource."/>
+        <Property Name="Oem" Type="Facility.v1_0_0.OemActions" Nullable="false">
+          <Annotation Term="OData.Description" String="The available OEM-specific actions for this resource."/>
+          <Annotation Term="OData.LongDescription" String="This property shall contain the available OEM-specific actions for this resource."/>
+        </Property>
+      </ComplexType>
+
+      <ComplexType Name="OemActions">
+        <Annotation Term="OData.AdditionalProperties" Bool="true"/>
+        <Annotation Term="OData.Description" String="The available OEM-specific actions for this resource."/>
+        <Annotation Term="OData.LongDescription" String="This type shall contain the available OEM-specific actions for this resource."/>
+      </ComplexType>
+    </Schema>
+
+    <Schema xmlns="http://docs.oasis-open.org/odata/ns/edm" Namespace="Facility.v1_0_1">
+      <Annotation Term="Redfish.OwningEntity" String="DMTF"/>
+      <Annotation Term="OData.Description" String="This version was created to correct various typographical errors."/>
+      <EntityType Name="Facility" BaseType="Facility.v1_0_0.Facility"/>
+    </Schema>
+
+    <Schema xmlns="http://docs.oasis-open.org/odata/ns/edm" Namespace="Facility.v1_1_0">
+      <Annotation Term="Redfish.OwningEntity" String="DMTF"/>
+      <Annotation Term="Redfish.Release" String="2020.4"/>
+
+      <EntityType Name="Facility" BaseType="Facility.v1_0_1.Facility">
+        <NavigationProperty Name="EnvironmentMetrics" Type="EnvironmentMetrics.EnvironmentMetrics" Nullable="false">
+          <Annotation Term="OData.Permissions" EnumMember="OData.Permission/Read"/>
+          <Annotation Term="OData.Description" String="The link to the environment metrics for this facility."/>
+          <Annotation Term="OData.LongDescription" String="This property shall contain a link to a resource of type EnvironmentMetrics that specifies the environment metrics for this facility."/>
+          <Annotation Term="OData.AutoExpandReferences"/>
+        </NavigationProperty>
+        <NavigationProperty Name="AmbientMetrics" Type="EnvironmentMetrics.EnvironmentMetrics" Nullable="false">
+          <Annotation Term="OData.Permissions" EnumMember="OData.Permission/Read"/>
+          <Annotation Term="OData.Description" String="The link to the ambient environment metrics for this facility."/>
+          <Annotation Term="OData.LongDescription" String="This property shall contain a link to a resource of type EnvironmentMetrics that specifies the outdoor environment metrics for this facility."/>
+          <Annotation Term="OData.AutoExpandReferences"/>
+        </NavigationProperty>
+      </EntityType>
+    </Schema>
+
+    <Schema xmlns="http://docs.oasis-open.org/odata/ns/edm" Namespace="Facility.v1_2_0">
+      <Annotation Term="Redfish.OwningEntity" String="DMTF"/>
+      <Annotation Term="Redfish.Release" String="2021.2"/>
+
+      <EntityType Name="Facility" BaseType="Facility.v1_1_0.Facility"/>
+
+      <ComplexType Name="Links" BaseType="Facility.v1_0_0.Links">
+        <NavigationProperty Name="PowerShelves" Type="Collection(PowerDistribution.PowerDistribution)">
+          <Annotation Term="OData.Permissions" EnumMember="OData.Permission/ReadWrite"/>
+          <Annotation Term="OData.Description" String="An array of links to the power shelves in this facility."/>
+          <Annotation Term="OData.LongDescription" String="The value of this property shall be an array of links to resources of type PowerDistribution that represent the power shelves in this facility."/>
+          <Annotation Term="OData.AutoExpandReferences"/>
+        </NavigationProperty>
+      </ComplexType>
+    </Schema>
+
+  </edmx:DataServices>
+</edmx:Edmx>

--- a/static/redfish/v1/schema/Fan_v1.xml
+++ b/static/redfish/v1/schema/Fan_v1.xml
@@ -1,11 +1,11 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!---->
 <!--################################################################################       -->
-<!--# Redfish Schema:  Fan v1.0.0                                                          -->
+<!--# Redfish Schema:  Fan v1.1.0                                                          -->
 <!--#                                                                                      -->
 <!--# For a detailed change log, see the README file contained in the DSP8010 bundle,      -->
 <!--# available at http://www.dmtf.org/standards/redfish                                   -->
-<!--# Copyright 2014-2020 DMTF.                                                            -->
+<!--# Copyright 2014-2021 DMTF.                                                            -->
 <!--# For the full DMTF copyright policy, see http://www.dmtf.org/about/policies/copyright -->
 <!--################################################################################       -->
 <!---->
@@ -95,7 +95,7 @@
         <Property Name="Manufacturer" Type="Edm.String">
           <Annotation Term="OData.Permissions" EnumMember="OData.Permission/Read"/>
           <Annotation Term="OData.Description" String="The manufacturer of this fan."/>
-          <Annotation Term="OData.LongDescription" String="This property shall contain the name of the organization responsible for producing the fan.  This organization might be the entity from whom the fan is purchased, but this is not necessarily true."/>
+          <Annotation Term="OData.LongDescription" String="This property shall contain the name of the organization responsible for producing the fan.  This organization may be the entity from whom the fan is purchased, but this is not necessarily true."/>
         </Property>
         <Property Name="Model" Type="Edm.String">
           <Annotation Term="OData.Permissions" EnumMember="OData.Permission/Read"/>
@@ -158,6 +158,26 @@
         <Annotation Term="OData.Description" String="The available OEM-specific actions for this resource."/>
         <Annotation Term="OData.LongDescription" String="This type shall contain the available OEM-specific actions for this resource."/>
       </ComplexType>
+    </Schema>
+
+    <Schema xmlns="http://docs.oasis-open.org/odata/ns/edm" Namespace="Fan.v1_0_1">
+      <Annotation Term="Redfish.OwningEntity" String="DMTF"/>
+      <Annotation Term="OData.Description" String="This version was created to correct various description to use proper normative terminology."/>
+      <EntityType Name="Fan" BaseType="Fan.v1_0_0.Fan"/>
+    </Schema>
+
+    <Schema xmlns="http://docs.oasis-open.org/odata/ns/edm" Namespace="Fan.v1_1_0">
+      <Annotation Term="Redfish.OwningEntity" String="DMTF"/>
+      <Annotation Term="Redfish.Release" String="2021.1"/>
+
+      <EntityType Name="Fan" BaseType="Fan.v1_0_1.Fan">
+        <NavigationProperty Name="PowerWatts" Type="Sensor.Sensor">
+          <Annotation Term="OData.Permissions" EnumMember="OData.Permission/Read"/>
+          <Annotation Term="Redfish.ExcerptCopy" String="Power"/>
+          <Annotation Term="OData.Description" String="Power consumption (Watts)."/>
+          <Annotation Term="OData.LongDescription" String="This property shall contain the total power, measured in Watts, for this resource."/>
+        </NavigationProperty>
+      </EntityType>
     </Schema>
 
   </edmx:DataServices>

--- a/static/redfish/v1/schema/GraphicsControllerCollection_v1.xml
+++ b/static/redfish/v1/schema/GraphicsControllerCollection_v1.xml
@@ -1,0 +1,69 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!---->
+<!--################################################################################       -->
+<!--# Redfish Schema:  GraphicsControllerCollection                                        -->
+<!--#                                                                                      -->
+<!--# For a detailed change log, see the README file contained in the DSP8010 bundle,      -->
+<!--# available at http://www.dmtf.org/standards/redfish                                   -->
+<!--# Copyright 2014-2021 DMTF.                                                            -->
+<!--# For the full DMTF copyright policy, see http://www.dmtf.org/about/policies/copyright -->
+<!--################################################################################       -->
+<!---->
+<edmx:Edmx xmlns:edmx="http://docs.oasis-open.org/odata/ns/edmx" Version="4.0">
+
+  <edmx:Reference Uri="http://docs.oasis-open.org/odata/odata/v4.0/errata03/csd01/complete/vocabularies/Org.OData.Core.V1.xml">
+    <edmx:Include Namespace="Org.OData.Core.V1" Alias="OData"/>
+  </edmx:Reference>
+  <edmx:Reference Uri="http://docs.oasis-open.org/odata/odata/v4.0/errata03/csd01/complete/vocabularies/Org.OData.Capabilities.V1.xml">
+    <edmx:Include Namespace="Org.OData.Capabilities.V1" Alias="Capabilities"/>
+  </edmx:Reference>
+  <edmx:Reference Uri="http://redfish.dmtf.org/schemas/v1/Resource_v1.xml">
+    <edmx:Include Namespace="Resource.v1_0_0"/>
+  </edmx:Reference>
+  <edmx:Reference Uri="http://redfish.dmtf.org/schemas/v1/RedfishExtensions_v1.xml">
+    <edmx:Include Namespace="RedfishExtensions.v1_0_0" Alias="Redfish"/>
+  </edmx:Reference>
+  <edmx:Reference Uri="http://redfish.dmtf.org/schemas/v1/GraphicsController_v1.xml">
+    <edmx:Include Namespace="GraphicsController"/>
+  </edmx:Reference>
+
+  <edmx:DataServices>
+
+    <Schema xmlns="http://docs.oasis-open.org/odata/ns/edm" Namespace="GraphicsControllerCollection">
+      <Annotation Term="Redfish.OwningEntity" String="DMTF"/>
+
+      <EntityType Name="GraphicsControllerCollection" BaseType="Resource.v1_0_0.ResourceCollection">
+        <Annotation Term="OData.Description" String="The collection of GraphicsController resource instances."/>
+        <Annotation Term="OData.LongDescription" String="This resource shall represent a resource collection of GraphicsController instances for a Redfish implementation."/>
+        <Annotation Term="Capabilities.InsertRestrictions">
+          <Record>
+            <PropertyValue Property="Insertable" Bool="false"/>
+          </Record>
+        </Annotation>
+        <Annotation Term="Capabilities.UpdateRestrictions">
+          <Record>
+            <PropertyValue Property="Updatable" Bool="false"/>
+          </Record>
+        </Annotation>
+        <Annotation Term="Capabilities.DeleteRestrictions">
+          <Record>
+            <PropertyValue Property="Deletable" Bool="false"/>
+          </Record>
+        </Annotation>
+        <Annotation Term="Redfish.Uris">
+          <Collection>
+            <String>/redfish/v1/Systems/{ComputerSystemId}/GraphicsControllers</String>
+          </Collection>
+        </Annotation>
+        <NavigationProperty Name="Members" Type="Collection(GraphicsController.GraphicsController)">
+          <Annotation Term="OData.Permissions" EnumMember="OData.Permission/Read"/>
+          <Annotation Term="OData.Description" String="The members of this collection."/>
+          <Annotation Term="OData.LongDescription" String="This property shall contain an array of links to the members of this collection."/>
+          <Annotation Term="OData.AutoExpandReferences"/>
+          <Annotation Term="Redfish.Required"/>
+        </NavigationProperty>
+      </EntityType>
+    </Schema>
+
+  </edmx:DataServices>
+</edmx:Edmx>

--- a/static/redfish/v1/schema/GraphicsController_v1.xml
+++ b/static/redfish/v1/schema/GraphicsController_v1.xml
@@ -1,0 +1,177 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!---->
+<!--################################################################################       -->
+<!--# Redfish Schema:  GraphicsController v1.0.0                                           -->
+<!--#                                                                                      -->
+<!--# For a detailed change log, see the README file contained in the DSP8010 bundle,      -->
+<!--# available at http://www.dmtf.org/standards/redfish                                   -->
+<!--# Copyright 2014-2021 DMTF.                                                            -->
+<!--# For the full DMTF copyright policy, see http://www.dmtf.org/about/policies/copyright -->
+<!--################################################################################       -->
+<!---->
+<edmx:Edmx xmlns:edmx="http://docs.oasis-open.org/odata/ns/edmx" Version="4.0">
+
+  <edmx:Reference Uri="http://docs.oasis-open.org/odata/odata/v4.0/errata03/csd01/complete/vocabularies/Org.OData.Core.V1.xml">
+    <edmx:Include Namespace="Org.OData.Core.V1" Alias="OData"/>
+  </edmx:Reference>
+  <edmx:Reference Uri="http://redfish.dmtf.org/schemas/v1/RedfishExtensions_v1.xml">
+    <edmx:Include Namespace="RedfishExtensions.v1_0_0" Alias="Redfish"/>
+    <edmx:Include Namespace="Validation.v1_0_0" Alias="Validation"/>
+  </edmx:Reference>
+  <edmx:Reference Uri="http://docs.oasis-open.org/odata/odata/v4.0/errata03/csd01/complete/vocabularies/Org.OData.Capabilities.V1.xml">
+    <edmx:Include Namespace="Org.OData.Capabilities.V1" Alias="Capabilities"/>
+  </edmx:Reference>
+  <edmx:Reference Uri="http://redfish.dmtf.org/schemas/v1/Resource_v1.xml">
+    <edmx:Include Namespace="Resource"/>
+    <edmx:Include Namespace="Resource.v1_0_0"/>
+  </edmx:Reference>
+  <edmx:Reference Uri="http://redfish.dmtf.org/schemas/v1/PortCollection_v1.xml">
+    <edmx:Include Namespace="PortCollection"/>
+  </edmx:Reference>
+  <edmx:Reference Uri="http://redfish.dmtf.org/schemas/v1/Processor_v1.xml">
+    <edmx:Include Namespace="Processor"/>
+  </edmx:Reference>
+  <edmx:Reference Uri="http://redfish.dmtf.org/schemas/v1/PCIeDevice_v1.xml">
+    <edmx:Include Namespace="PCIeDevice"/>
+  </edmx:Reference>
+
+  <edmx:DataServices>
+
+    <Schema xmlns="http://docs.oasis-open.org/odata/ns/edm" Namespace="GraphicsController">
+      <Annotation Term="Redfish.OwningEntity" String="DMTF"/>
+
+      <EntityType Name="GraphicsController" BaseType="Resource.v1_0_0.Resource" Abstract="true">
+        <Annotation Term="OData.Description" String="The GraphicsController schema defines a graphics controller that can be used to drive one or more display devices."/>
+        <Annotation Term="OData.LongDescription" String="This resource shall represent a graphics output device in a Redfish implementation."/>
+        <Annotation Term="OData.AdditionalProperties" Bool="false"/>
+        <Annotation Term="Capabilities.InsertRestrictions">
+          <Record>
+            <PropertyValue Property="Insertable" Bool="false"/>
+          </Record>
+        </Annotation>
+        <Annotation Term="Capabilities.UpdateRestrictions">
+          <Record>
+            <PropertyValue Property="Updatable" Bool="true"/>
+          </Record>
+        </Annotation>
+        <Annotation Term="Capabilities.DeleteRestrictions">
+          <Record>
+            <PropertyValue Property="Deletable" Bool="true"/>
+          </Record>
+        </Annotation>
+        <Annotation Term="Redfish.Uris">
+          <Collection>
+            <String>/redfish/v1/Systems/{ComputerSystemId}/GraphicsControllers/{ControllerId}</String>
+          </Collection>
+        </Annotation>
+      </EntityType>
+    </Schema>
+
+    <Schema xmlns="http://docs.oasis-open.org/odata/ns/edm" Namespace="GraphicsController.v1_0_0">
+      <Annotation Term="Redfish.OwningEntity" String="DMTF"/>
+      <Annotation Term="Redfish.Release" String="2021.1"/>
+
+      <EntityType Name="GraphicsController" BaseType="GraphicsController.GraphicsController">
+        <Property Name="AssetTag" Type="Edm.String">
+          <Annotation Term="OData.Permissions" EnumMember="OData.Permission/ReadWrite"/>
+          <Annotation Term="OData.Description" String="The user-assigned asset tag for this graphics controller."/>
+          <Annotation Term="OData.LongDescription" String="This property shall contain the user-assigned asset tag, which is an identifying string that tracks the drive for inventory purposes."/>
+        </Property>
+        <Property Name="Manufacturer" Type="Edm.String">
+          <Annotation Term="OData.Permissions" EnumMember="OData.Permission/Read"/>
+          <Annotation Term="OData.Description" String="The manufacturer of this graphics controller."/>
+          <Annotation Term="OData.LongDescription" String="This property shall contain the name of the organization responsible for producing the graphics controller.  This organization may be the entity from which the graphics controller is purchased, but this is not necessarily true."/>
+        </Property>
+        <Property Name="Model" Type="Edm.String">
+          <Annotation Term="OData.Permissions" EnumMember="OData.Permission/Read"/>
+          <Annotation Term="OData.Description" String="The product model number of this graphics controller."/>
+          <Annotation Term="OData.LongDescription" String="This property shall contain the manufacturer-provided model information of this graphics controller."/>
+        </Property>
+        <Property Name="SKU" Type="Edm.String">
+          <Annotation Term="OData.Permissions" EnumMember="OData.Permission/Read"/>
+          <Annotation Term="OData.Description" String="The SKU for this graphics controller."/>
+          <Annotation Term="OData.LongDescription" String="This property shall contain the SKU number for this graphics controller."/>
+        </Property>
+        <Property Name="SerialNumber" Type="Edm.String">
+          <Annotation Term="OData.Permissions" EnumMember="OData.Permission/Read"/>
+          <Annotation Term="OData.Description" String="The serial number for this graphics controller."/>
+          <Annotation Term="OData.LongDescription" String="This property shall contain a manufacturer-allocated number that identifies the graphics controller."/>
+        </Property>
+        <Property Name="PartNumber" Type="Edm.String">
+          <Annotation Term="OData.Permissions" EnumMember="OData.Permission/Read"/>
+          <Annotation Term="OData.Description" String="The part number for this graphics controller."/>
+          <Annotation Term="OData.LongDescription" String="This property shall contain the manufacturer-provided part number for the graphics controller."/>
+        </Property>
+        <Property Name="SparePartNumber" Type="Edm.String">
+          <Annotation Term="OData.Permissions" EnumMember="OData.Permission/Read"/>
+          <Annotation Term="OData.Description" String="The spare part number of the graphics controller."/>
+          <Annotation Term="OData.LongDescription" String="This property shall contain the spare part number of the graphics controller."/>
+        </Property>
+        <Property Name="BiosVersion" Type="Edm.String">
+          <Annotation Term="OData.Permissions" EnumMember="OData.Permission/Read"/>
+          <Annotation Term="OData.Description" String="The version of the graphics controller BIOS or primary graphics controller firmware."/>
+          <Annotation Term="OData.LongDescription" String="This property shall contain the version string of the currently installed and running BIOS or firmware for the graphics controller."/>
+        </Property>
+        <Property Name="DriverVersion" Type="Edm.String">
+          <Annotation Term="OData.Permissions" EnumMember="OData.Permission/Read"/>
+          <Annotation Term="OData.Description" String="The version of the graphics controller driver loaded in the operating system."/>
+          <Annotation Term="OData.LongDescription" String="This property shall contain the version string of the currently loaded driver for this graphics controller."/>
+        </Property>
+        <Property Name="Status" Type="Resource.Status" Nullable="false">
+          <Annotation Term="OData.Description" String="The status and health of the resource and its subordinate or dependent resources."/>
+          <Annotation Term="OData.LongDescription" String="This property shall contain any status or health properties of the resource."/>
+        </Property>
+        <Property Name="Location" Type="Resource.Location" Nullable="false">
+          <Annotation Term="OData.Description" String="The location of the graphics controller."/>
+          <Annotation Term="OData.LongDescription" String="This property shall contain location information of the associated graphics controller."/>
+        </Property>
+        <NavigationProperty Name="Ports" Type="PortCollection.PortCollection" Nullable="false">
+          <Annotation Term="OData.Description" String="The ports of the graphics controller."/>
+          <Annotation Term="OData.LongDescription" String="This property shall contain a link to a resource collection of type PortCollection."/>
+        </NavigationProperty>
+        <Property Name="Links" Type="GraphicsController.v1_0_0.Links" Nullable="false">
+          <Annotation Term="OData.Description" String="The links to other resources that are related to this resource."/>
+          <Annotation Term="OData.LongDescription" String="This property shall contain links to resources that are related to but are not contained by, or subordinate to, this resource."/>
+        </Property>
+        <Property Name="Actions" Type="GraphicsController.v1_0_0.Actions" Nullable="false">
+          <Annotation Term="OData.Description" String="The available actions for this resource."/>
+          <Annotation Term="OData.LongDescription" String="This property shall contain the available actions for this resource."/>
+        </Property>
+      </EntityType>
+
+      <ComplexType Name="Links" BaseType="Resource.Links">
+        <Annotation Term="OData.Description" String="The links to other resources that are related to this resource."/>
+        <Annotation Term="OData.LongDescription" String="This Redfish Specification-described type shall contain links to resources that are related to but are not contained by, or subordinate to, this resource."/>
+        <NavigationProperty Name="Processors" Type="Collection(Processor.Processor)">
+          <Annotation Term="OData.Permissions" EnumMember="OData.Permission/Read"/>
+          <Annotation Term="OData.Description" String="An array of links to the processors that are a part of this graphics controller."/>
+          <Annotation Term="OData.LongDescription" String="This property shall contain an array of links to resources of type Processor that represent the processors that this graphics controller contains."/>
+          <Annotation Term="OData.AutoExpandReferences"/>
+        </NavigationProperty>
+        <NavigationProperty Name="PCIeDevice" Type="PCIeDevice.PCIeDevice">
+          <Annotation Term="OData.Permissions" EnumMember="OData.Permission/Read"/>
+          <Annotation Term="OData.Description" String="A link to the PCIe device that represents this graphics controller."/>
+          <Annotation Term="OData.LongDescription" String="This property shall contain a link to a resource of type PCIeDevice that represents this graphics controller."/>
+          <Annotation Term="OData.AutoExpandReferences"/>
+        </NavigationProperty>
+      </ComplexType>
+
+      <ComplexType Name="Actions">
+        <Annotation Term="OData.AdditionalProperties" Bool="false"/>
+        <Annotation Term="OData.Description" String="The available actions for this resource."/>
+        <Annotation Term="OData.LongDescription" String="This type shall contain the available actions for this resource."/>
+        <Property Name="Oem" Type="GraphicsController.v1_0_0.OemActions" Nullable="false">
+          <Annotation Term="OData.Description" String="The available OEM-specific actions for this resource."/>
+          <Annotation Term="OData.LongDescription" String="This property shall contain the available OEM-specific actions for this resource."/>
+        </Property>
+      </ComplexType>
+
+      <ComplexType Name="OemActions">
+        <Annotation Term="OData.AdditionalProperties" Bool="true"/>
+        <Annotation Term="OData.Description" String="The available OEM-specific actions for this resource."/>
+        <Annotation Term="OData.LongDescription" String="This type shall contain the available OEM-specific actions for this resource."/>
+      </ComplexType>
+    </Schema>
+
+  </edmx:DataServices>
+</edmx:Edmx>

--- a/static/redfish/v1/schema/HostInterfaceCollection_v1.xml
+++ b/static/redfish/v1/schema/HostInterfaceCollection_v1.xml
@@ -1,0 +1,69 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!---->
+<!--################################################################################       -->
+<!--# Redfish Schema:  HostInterfaceCollection                                             -->
+<!--#                                                                                      -->
+<!--# For a detailed change log, see the README file contained in the DSP8010 bundle,      -->
+<!--# available at http://www.dmtf.org/standards/redfish                                   -->
+<!--# Copyright 2014-2021 DMTF.                                                            -->
+<!--# For the full DMTF copyright policy, see http://www.dmtf.org/about/policies/copyright -->
+<!--################################################################################       -->
+<!---->
+<edmx:Edmx xmlns:edmx="http://docs.oasis-open.org/odata/ns/edmx" Version="4.0">
+
+  <edmx:Reference Uri="http://docs.oasis-open.org/odata/odata/v4.0/errata03/csd01/complete/vocabularies/Org.OData.Core.V1.xml">
+    <edmx:Include Namespace="Org.OData.Core.V1" Alias="OData"/>
+  </edmx:Reference>
+  <edmx:Reference Uri="http://docs.oasis-open.org/odata/odata/v4.0/errata03/csd01/complete/vocabularies/Org.OData.Capabilities.V1.xml">
+    <edmx:Include Namespace="Org.OData.Capabilities.V1" Alias="Capabilities"/>
+  </edmx:Reference>
+  <edmx:Reference Uri="http://redfish.dmtf.org/schemas/v1/Resource_v1.xml">
+    <edmx:Include Namespace="Resource.v1_0_0"/>
+  </edmx:Reference>
+  <edmx:Reference Uri="http://redfish.dmtf.org/schemas/v1/RedfishExtensions_v1.xml">
+    <edmx:Include Namespace="RedfishExtensions.v1_0_0" Alias="Redfish"/>
+  </edmx:Reference>
+  <edmx:Reference Uri="http://redfish.dmtf.org/schemas/v1/HostInterface_v1.xml">
+    <edmx:Include Namespace="HostInterface"/>
+  </edmx:Reference>
+
+  <edmx:DataServices>
+
+    <Schema xmlns="http://docs.oasis-open.org/odata/ns/edm" Namespace="HostInterfaceCollection">
+      <Annotation Term="Redfish.OwningEntity" String="DMTF"/>
+
+      <EntityType Name="HostInterfaceCollection" BaseType="Resource.v1_0_0.ResourceCollection">
+        <Annotation Term="OData.Description" String="The collection of HostInterface Resource instances."/>
+        <Annotation Term="OData.LongDescription" String="This Resource shall represent a Resource Collection of HostInterface instances for a Redfish implementation."/>
+        <Annotation Term="Capabilities.InsertRestrictions">
+          <Record>
+            <PropertyValue Property="Insertable" Bool="false"/>
+          </Record>
+        </Annotation>
+        <Annotation Term="Capabilities.UpdateRestrictions">
+          <Record>
+            <PropertyValue Property="Updatable" Bool="false"/>
+          </Record>
+        </Annotation>
+        <Annotation Term="Capabilities.DeleteRestrictions">
+          <Record>
+            <PropertyValue Property="Deletable" Bool="false"/>
+          </Record>
+        </Annotation>
+        <Annotation Term="Redfish.Uris">
+          <Collection>
+            <String>/redfish/v1/Managers/{ManagerId}/HostInterfaces</String>
+          </Collection>
+        </Annotation>
+        <NavigationProperty Name="Members" Type="Collection(HostInterface.HostInterface)">
+          <Annotation Term="OData.Permissions" EnumMember="OData.Permission/Read"/>
+          <Annotation Term="OData.Description" String="The members of this collection."/>
+          <Annotation Term="OData.LongDescription" String="This property shall contain an array of links to the members of this collection."/>
+          <Annotation Term="OData.AutoExpandReferences"/>
+          <Annotation Term="Redfish.Required"/>
+        </NavigationProperty>
+      </EntityType>
+
+    </Schema>
+  </edmx:DataServices>
+</edmx:Edmx>

--- a/static/redfish/v1/schema/HostInterface_v1.xml
+++ b/static/redfish/v1/schema/HostInterface_v1.xml
@@ -1,0 +1,414 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!---->
+<!--################################################################################       -->
+<!--# Redfish Schema:  HostInterface v1.3.0                                                -->
+<!--#                                                                                      -->
+<!--# For a detailed change log, see the README file contained in the DSP8010 bundle,      -->
+<!--# available at http://www.dmtf.org/standards/redfish                                   -->
+<!--# Copyright 2014-2021 DMTF.                                                            -->
+<!--# For the full DMTF copyright policy, see http://www.dmtf.org/about/policies/copyright -->
+<!--################################################################################       -->
+<!---->
+<edmx:Edmx xmlns:edmx="http://docs.oasis-open.org/odata/ns/edmx" Version="4.0">
+
+  <edmx:Reference Uri="http://docs.oasis-open.org/odata/odata/v4.0/errata03/csd01/complete/vocabularies/Org.OData.Core.V1.xml">
+    <edmx:Include Namespace="Org.OData.Core.V1" Alias="OData"/>
+  </edmx:Reference>
+  <edmx:Reference Uri="http://docs.oasis-open.org/odata/odata/v4.0/errata03/csd01/complete/vocabularies/Org.OData.Capabilities.V1.xml">
+    <edmx:Include Namespace="Org.OData.Capabilities.V1" Alias="Capabilities"/>
+  </edmx:Reference>
+  <edmx:Reference Uri="http://redfish.dmtf.org/schemas/v1/Resource_v1.xml">
+    <edmx:Include Namespace="Resource"/>
+    <edmx:Include Namespace="Resource.v1_0_0"/>
+  </edmx:Reference>
+  <edmx:Reference Uri="http://redfish.dmtf.org/schemas/v1/RedfishExtensions_v1.xml">
+    <edmx:Include Namespace="RedfishExtensions.v1_0_0" Alias="Redfish"/>
+  </edmx:Reference>
+  <edmx:Reference Uri="http://redfish.dmtf.org/schemas/v1/ComputerSystem_v1.xml">
+    <edmx:Include Namespace="ComputerSystem"/>
+  </edmx:Reference>
+  <edmx:Reference Uri="http://redfish.dmtf.org/schemas/v1/EthernetInterface_v1.xml">
+    <edmx:Include Namespace="EthernetInterface"/>
+  </edmx:Reference>
+  <edmx:Reference Uri="http://redfish.dmtf.org/schemas/v1/EthernetInterfaceCollection_v1.xml">
+    <edmx:Include Namespace="EthernetInterfaceCollection"/>
+  </edmx:Reference>
+  <edmx:Reference Uri="http://redfish.dmtf.org/schemas/v1/ManagerNetworkProtocol_v1.xml">
+    <edmx:Include Namespace="ManagerNetworkProtocol"/>
+  </edmx:Reference>
+  <edmx:Reference Uri="http://redfish.dmtf.org/schemas/v1/Role_v1.xml">
+    <edmx:Include Namespace="Role"/>
+  </edmx:Reference>
+
+  <edmx:DataServices>
+
+    <Schema xmlns="http://docs.oasis-open.org/odata/ns/edm" Namespace="HostInterface">
+      <Annotation Term="Redfish.OwningEntity" String="DMTF"/>
+
+      <EntityType Name="HostInterface" BaseType="Resource.v1_0_0.Resource" Abstract="true">
+        <Annotation Term="OData.Description" String="The properties associated with a Host Interface.  A Host Interface is a connection between host software and a Redfish Service."/>
+        <Annotation Term="OData.LongDescription" String="This Resource shall represent a Host Interface as part of the Redfish Specification."/>
+        <Annotation Term="Capabilities.InsertRestrictions">
+          <Record>
+            <PropertyValue Property="Insertable" Bool="false"/>
+          </Record>
+        </Annotation>
+        <Annotation Term="Capabilities.UpdateRestrictions">
+          <Record>
+            <PropertyValue Property="Updatable" Bool="true"/>
+            <Annotation Term="OData.Description" String="Any writable properties, such as authentication settings, can be updated for Host Interfaces."/>
+          </Record>
+        </Annotation>
+        <Annotation Term="Capabilities.DeleteRestrictions">
+          <Record>
+            <PropertyValue Property="Deletable" Bool="false"/>
+          </Record>
+        </Annotation>
+        <Annotation Term="Redfish.Uris">
+          <Collection>
+            <String>/redfish/v1/Managers/{ManagerId}/HostInterfaces/{HostInterfaceId}</String>
+          </Collection>
+        </Annotation>
+      </EntityType>
+    </Schema>
+
+    <Schema xmlns="http://docs.oasis-open.org/odata/ns/edm" Namespace="HostInterface.v1_0_0">
+      <Annotation Term="Redfish.OwningEntity" String="DMTF"/>
+      <Annotation Term="Redfish.Release" String="2016.3"/>
+
+      <EntityType Name="HostInterface" BaseType="HostInterface.HostInterface">
+        <Property Name="HostInterfaceType" Type="HostInterface.v1_0_0.HostInterfaceType">
+          <Annotation Term="OData.Permissions" EnumMember="OData.Permission/Read"/>
+          <Annotation Term="OData.Description" String="The Host Interface type for this interface."/>
+          <Annotation Term="OData.LongDescription" String="This property shall contain an enumeration that describes the type of the interface."/>
+        </Property>
+        <Property Name="Status" Type="Resource.Status" Nullable="false">
+          <Annotation Term="OData.Description" String="The status and health of the Resource and its subordinate or dependent Resources."/>
+          <Annotation Term="OData.LongDescription" String="This property shall contain any status or health properties of the Resource."/>
+        </Property>
+        <Property Name="InterfaceEnabled" Type="Edm.Boolean">
+          <Annotation Term="OData.Permissions" EnumMember="OData.Permission/ReadWrite"/>
+          <Annotation Term="OData.Description" String="An indication of whether this interface is enabled."/>
+          <Annotation Term="OData.LongDescription" String="This property shall indicate whether this interface is enabled."/>
+        </Property>
+        <Property Name="ExternallyAccessible" Type="Edm.Boolean">
+          <Annotation Term="OData.Permissions" EnumMember="OData.Permission/Read"/>
+          <Annotation Term="OData.Description" String="An indication of whether external entities can access this interface.  External entities are non-host entities.  For example, if the host and manager are connected through a switch and the switch also exposes an external port on the system, external clients can also use the interface, and this property value is `true`."/>
+          <Annotation Term="OData.LongDescription" String="This property shall indicate whether external entities can access this interface.  External entities are non-host entities.  For example, if the host and manager are connected through a switch and the switch also exposes an external port on the system, external clients can also use the interface, and this property value is `true`."/>
+        </Property>
+        <Property Name="AuthenticationModes" Type="Collection(HostInterface.v1_0_0.AuthenticationMode)" Nullable="false">
+          <Annotation Term="OData.Permissions" EnumMember="OData.Permission/ReadWrite"/>
+          <Annotation Term="OData.Description" String="The authentication modes available on this interface."/>
+          <Annotation Term="OData.LongDescription" String="This property shall contain an array consisting of the authentication modes allowed on this interface."/>
+        </Property>
+        <Property Name="KernelAuthRoleId" Type="Edm.String" Nullable="false">
+          <Annotation Term="OData.Permissions" EnumMember="OData.Permission/ReadWrite"/>
+          <Annotation Term="OData.Description" String="The Role used for kernel authentication on this interface."/>
+          <Annotation Term="OData.LongDescription" String="This property shall contain the Id property of the Role Resource that is configured for kernel authentication on this interface."/>
+          <Annotation Term="Redfish.Revisions">
+            <Collection>
+              <Record>
+                <PropertyValue Property="Kind" EnumMember="Redfish.RevisionKind/Deprecated"/>
+                <PropertyValue Property="Version" String="v1_3_0"/>
+                <PropertyValue Property="Description" String="This property has been deprecated in favor of newer methods of negotiating credentials."/>
+              </Record>
+            </Collection>
+          </Annotation>
+        </Property>
+        <Property Name="KernelAuthEnabled" Type="Edm.Boolean">
+          <Annotation Term="OData.Permissions" EnumMember="OData.Permission/ReadWrite"/>
+          <Annotation Term="OData.Description" String="An indication of whether this kernel authentication is enabled for this interface."/>
+          <Annotation Term="OData.LongDescription" String="This property shall indicate whether kernel authentication is enabled for this interface."/>
+          <Annotation Term="Redfish.Revisions">
+            <Collection>
+              <Record>
+                <PropertyValue Property="Kind" EnumMember="Redfish.RevisionKind/Deprecated"/>
+                <PropertyValue Property="Version" String="v1_3_0"/>
+                <PropertyValue Property="Description" String="This property has been deprecated in favor of newer methods of negotiating credentials."/>
+              </Record>
+            </Collection>
+          </Annotation>
+        </Property>
+        <Property Name="FirmwareAuthRoleId" Type="Edm.String" Nullable="false">
+          <Annotation Term="OData.Permissions" EnumMember="OData.Permission/ReadWrite"/>
+          <Annotation Term="OData.Description" String="The Role used for firmware authentication on this interface."/>
+          <Annotation Term="OData.LongDescription" String="This property shall contain the Id property of the Role Resource that is configured for firmware authentication on this interface."/>
+          <Annotation Term="Redfish.Revisions">
+            <Collection>
+              <Record>
+                <PropertyValue Property="Kind" EnumMember="Redfish.RevisionKind/Deprecated"/>
+                <PropertyValue Property="Version" String="v1_3_0"/>
+                <PropertyValue Property="Description" String="This property has been deprecated in favor of newer methods of negotiating credentials."/>
+              </Record>
+            </Collection>
+          </Annotation>
+        </Property>
+        <Property Name="FirmwareAuthEnabled" Type="Edm.Boolean">
+          <Annotation Term="OData.Permissions" EnumMember="OData.Permission/ReadWrite"/>
+          <Annotation Term="OData.Description" String="An indication of whether this firmware authentication is enabled for this interface."/>
+          <Annotation Term="OData.LongDescription" String="This property shall indicate whether firmware authentication is enabled for this interface."/>
+          <Annotation Term="Redfish.Revisions">
+            <Collection>
+              <Record>
+                <PropertyValue Property="Kind" EnumMember="Redfish.RevisionKind/Deprecated"/>
+                <PropertyValue Property="Version" String="v1_3_0"/>
+                <PropertyValue Property="Description" String="This property has been deprecated in favor of newer methods of negotiating credentials."/>
+              </Record>
+            </Collection>
+          </Annotation>
+        </Property>
+
+        <NavigationProperty Name="HostEthernetInterfaces" Type="EthernetInterfaceCollection.EthernetInterfaceCollection" ContainsTarget="true" Nullable="false">
+          <Annotation Term="OData.Permissions" EnumMember="OData.Permission/Read"/>
+          <Annotation Term="OData.Description" String="A link to the collection of network interface controllers or cards (NICs) that a computer system uses to communicate with this Host Interface."/>
+          <Annotation Term="OData.LongDescription" String="This property shall contain a link to a Resource Collection of type EthernetInterface that computer systems use as the Host Interface to this manager."/>
+          <Annotation Term="OData.AutoExpandReferences"/>
+        </NavigationProperty>
+        <NavigationProperty Name="ManagerEthernetInterface" Type="EthernetInterface.EthernetInterface" Nullable="false">
+          <Annotation Term="OData.Permissions" EnumMember="OData.Permission/Read"/>
+          <Annotation Term="OData.Description" String="A link to a single network interface controllers or cards (NIC) that this manager uses for network communication with this Host Interface."/>
+          <Annotation Term="OData.LongDescription" String="This property shall contain a link to a Resource of type EthernetInterface that represents the network interface that this manager uses as the Host Interface."/>
+          <Annotation Term="OData.AutoExpandReferences"/>
+        </NavigationProperty>
+        <NavigationProperty Name="NetworkProtocol" Type="ManagerNetworkProtocol.ManagerNetworkProtocol" Nullable="false">
+          <Annotation Term="OData.Permissions" EnumMember="OData.Permission/Read"/>
+          <Annotation Term="OData.Description" String="A link to the network services and their settings that the manager controls.  In this property, clients find configuration options for the network and network services."/>
+          <Annotation Term="OData.LongDescription" String="This property shall contain a link to a Resource of type ManagerNetworkProtocol that represents the network services for this manager."/>
+          <Annotation Term="OData.AutoExpandReferences"/>
+        </NavigationProperty>
+
+        <Property Name="Links" Type="HostInterface.v1_0_0.Links" Nullable="false">
+          <Annotation Term="OData.Description" String="The links to other Resources that are related to this Resource."/>
+          <Annotation Term="OData.LongDescription" String="The Redfish Specification-described Links Property shall contain links to Resources related to but not subordinate to this Resource."/>
+        </Property>
+      </EntityType>
+
+      <EnumType Name="HostInterfaceType">
+        <Member Name="NetworkHostInterface">
+          <Annotation Term="OData.Description" String="This interface is a Network Host Interface."/>
+        </Member>
+      </EnumType>
+
+      <EnumType Name="AuthenticationMode">
+        <Member Name="AuthNone">
+          <Annotation Term="OData.Description" String="Requests without any sort of authentication are allowed."/>
+        </Member>
+        <Member Name="BasicAuth">
+          <Annotation Term="OData.Description" String="Requests using HTTP Basic Authentication are allowed."/>
+        </Member>
+        <Member Name="RedfishSessionAuth">
+          <Annotation Term="OData.Description" String="Requests using Redfish Session Authentication are allowed."/>
+        </Member>
+        <Member Name="OemAuth">
+          <Annotation Term="OData.Description" String="Requests using OEM authentication mechanisms are allowed."/>
+        </Member>
+      </EnumType>
+
+      <ComplexType Name="Links" BaseType="Resource.Links">
+        <Annotation Term="OData.Description" String="References to other Resources related to this Resource."/>
+        <Annotation Term="OData.LongDescription" String="The Redfish Specification-described type shall contain links to Resources related to but not subordinate to this Resource."/>
+        <NavigationProperty Name="ComputerSystems" Type="Collection(ComputerSystem.ComputerSystem)">
+          <Annotation Term="OData.Permissions" EnumMember="OData.Permission/Read"/>
+          <Annotation Term="OData.Description" String="An array of links to the computer systems connected to this Host Interface."/>
+          <Annotation Term="OData.LongDescription" String="This property shall contain an array of links to Resources of the ComputerSystem type that are connected to this Host Interface."/>
+          <Annotation Term="OData.AutoExpandReferences"/>
+        </NavigationProperty>
+        <NavigationProperty Name="KernelAuthRole" Type="Role.Role" Nullable="false">
+          <Annotation Term="OData.Permissions" EnumMember="OData.Permission/Read"/>
+          <Annotation Term="OData.Description" String="The link to the Redfish Role defining privileges for this Host Interface when using kernel authentication."/>
+          <Annotation Term="OData.LongDescription" String="This property shall contain a link to a Resource of type Role, and should link to the Resource identified by property KernelAuthRoleId."/>
+          <Annotation Term="OData.AutoExpandReferences"/>
+          <Annotation Term="Redfish.Revisions">
+            <Collection>
+              <Record>
+                <PropertyValue Property="Kind" EnumMember="Redfish.RevisionKind/Deprecated"/>
+                <PropertyValue Property="Version" String="v1_3_0"/>
+                <PropertyValue Property="Description" String="This property has been deprecated in favor of newer methods of negotiating credentials."/>
+              </Record>
+            </Collection>
+          </Annotation>
+        </NavigationProperty>
+        <NavigationProperty Name="FirmwareAuthRole" Type="Role.Role" Nullable="false">
+          <Annotation Term="OData.Permissions" EnumMember="OData.Permission/Read"/>
+          <Annotation Term="OData.Description" String="The link to the Redfish Role that has firmware authentication privileges on this Host Interface."/>
+          <Annotation Term="OData.LongDescription" String="This property shall contain a link to a Resource of type Role, and should link to the Resource identified by property FirmwareAuthRoleId."/>
+          <Annotation Term="OData.AutoExpandReferences"/>
+          <Annotation Term="Redfish.Revisions">
+            <Collection>
+              <Record>
+                <PropertyValue Property="Kind" EnumMember="Redfish.RevisionKind/Deprecated"/>
+                <PropertyValue Property="Version" String="v1_3_0"/>
+                <PropertyValue Property="Description" String="This property has been deprecated in favor of newer methods of negotiating credentials."/>
+              </Record>
+            </Collection>
+          </Annotation>
+        </NavigationProperty>
+      </ComplexType>
+    </Schema>
+
+    <Schema xmlns="http://docs.oasis-open.org/odata/ns/edm" Namespace="HostInterface.v1_0_1">
+      <Annotation Term="Redfish.OwningEntity" String="DMTF"/>
+      <Annotation Term="OData.Description" String="This version was created to remove the Nullable facet on NavigationProperties of the Collection type."/>
+      <EntityType Name="HostInterface" BaseType="HostInterface.v1_0_0.HostInterface"/>
+    </Schema>
+
+    <Schema xmlns="http://docs.oasis-open.org/odata/ns/edm" Namespace="HostInterface.v1_0_2">
+      <Annotation Term="Redfish.OwningEntity" String="DMTF"/>
+      <Annotation Term="OData.Description" String="This version was created to clarify the description of ExternallyAccessible."/>
+      <EntityType Name="HostInterface" BaseType="HostInterface.v1_0_1.HostInterface"/>
+    </Schema>
+
+    <Schema xmlns="http://docs.oasis-open.org/odata/ns/edm" Namespace="HostInterface.v1_0_3">
+      <Annotation Term="Redfish.OwningEntity" String="DMTF"/>
+      <Annotation Term="OData.Description" String="This version was created to force the regeneration of JSON Schema so that OData properties are marked as required, and integer properties are marked as integer rather than number."/>
+      <EntityType Name="HostInterface" BaseType="HostInterface.v1_0_2.HostInterface"/>
+    </Schema>
+
+    <Schema xmlns="http://docs.oasis-open.org/odata/ns/edm" Namespace="HostInterface.v1_0_4">
+      <Annotation Term="Redfish.OwningEntity" String="DMTF"/>
+      <Annotation Term="OData.Description" String="This version was created to force the regeneration of JSON Schema so that URI properties use the uri-reference format."/>
+      <EntityType Name="HostInterface" BaseType="HostInterface.v1_0_3.HostInterface"/>
+    </Schema>
+
+    <Schema xmlns="http://docs.oasis-open.org/odata/ns/edm" Namespace="HostInterface.v1_0_5">
+      <Annotation Term="Redfish.OwningEntity" String="DMTF"/>
+      <Annotation Term="OData.Description" String="This version was created to update descriptions that this schema defines."/>
+      <EntityType Name="HostInterface" BaseType="HostInterface.v1_0_4.HostInterface"/>
+    </Schema>
+
+    <Schema xmlns="http://docs.oasis-open.org/odata/ns/edm" Namespace="HostInterface.v1_1_0">
+      <Annotation Term="Redfish.OwningEntity" String="DMTF"/>
+      <Annotation Term="Redfish.Release" String="2017.1"/>
+
+      <EntityType Name="HostInterface" BaseType="HostInterface.v1_0_1.HostInterface">
+        <Property Name="Actions" Type="HostInterface.v1_1_0.Actions" Nullable="false">
+          <Annotation Term="OData.Description" String="The available actions for this Resource."/>
+          <Annotation Term="OData.LongDescription" String="This property shall contain the available actions for this Resource."/>
+        </Property>
+      </EntityType>
+
+      <ComplexType Name="Actions">
+        <Annotation Term="OData.AdditionalProperties" Bool="false"/>
+        <Annotation Term="OData.Description" String="The available actions for this Resource."/>
+        <Annotation Term="OData.LongDescription" String="This type shall contain the available actions for this Resource."/>
+        <Property Name="Oem" Type="HostInterface.v1_1_0.OemActions" Nullable="false">
+          <Annotation Term="OData.Description" String="The available OEM-specific actions for this Resource."/>
+          <Annotation Term="OData.LongDescription" String="This property shall contain the available OEM-specific actions for this Resource."/>
+        </Property>
+      </ComplexType>
+
+      <ComplexType Name="OemActions">
+        <Annotation Term="OData.AdditionalProperties" Bool="true"/>
+        <Annotation Term="OData.Description" String="The available OEM-specific actions for this Resource."/>
+        <Annotation Term="OData.LongDescription" String="This type shall contain the available OEM-specific actions for this Resource."/>
+      </ComplexType>
+    </Schema>
+
+    <Schema xmlns="http://docs.oasis-open.org/odata/ns/edm" Namespace="HostInterface.v1_1_1">
+      <Annotation Term="Redfish.OwningEntity" String="DMTF"/>
+      <Annotation Term="OData.Description" String="This version was created to update the descriptions in this schema."/>
+      <EntityType Name="HostInterface" BaseType="HostInterface.v1_1_0.HostInterface"/>
+    </Schema>
+
+    <Schema xmlns="http://docs.oasis-open.org/odata/ns/edm" Namespace="HostInterface.v1_1_2">
+      <Annotation Term="Redfish.OwningEntity" String="DMTF"/>
+      <Annotation Term="OData.Description" String="This version was created to clarify the description of ExternallyAccessible and to update other descriptions to match the editorial style used in other Redfish schemas."/>
+      <EntityType Name="HostInterface" BaseType="HostInterface.v1_1_1.HostInterface"/>
+    </Schema>
+
+    <Schema xmlns="http://docs.oasis-open.org/odata/ns/edm" Namespace="HostInterface.v1_1_3">
+      <Annotation Term="Redfish.OwningEntity" String="DMTF"/>
+      <Annotation Term="OData.Description" String="This version was created to force the regeneration of JSON Schema so that OData properties are marked as required, and integer properties are marked as integer rather than number."/>
+      <EntityType Name="HostInterface" BaseType="HostInterface.v1_1_2.HostInterface"/>
+    </Schema>
+
+    <Schema xmlns="http://docs.oasis-open.org/odata/ns/edm" Namespace="HostInterface.v1_1_4">
+      <Annotation Term="Redfish.OwningEntity" String="DMTF"/>
+      <Annotation Term="OData.Description" String="This version was created to force the regeneration of JSON Schema so that URI properties use the uri-reference format."/>
+      <EntityType Name="HostInterface" BaseType="HostInterface.v1_1_3.HostInterface"/>
+    </Schema>
+
+    <Schema xmlns="http://docs.oasis-open.org/odata/ns/edm" Namespace="HostInterface.v1_1_5">
+      <Annotation Term="Redfish.OwningEntity" String="DMTF"/>
+      <Annotation Term="OData.Description" String="This version was created to update descriptions that this schema defines."/>
+      <EntityType Name="HostInterface" BaseType="HostInterface.v1_1_4.HostInterface"/>
+    </Schema>
+
+    <Schema xmlns="http://docs.oasis-open.org/odata/ns/edm" Namespace="HostInterface.v1_2_0">
+      <Annotation Term="Redfish.OwningEntity" String="DMTF"/>
+      <Annotation Term="Redfish.Release" String="2018.2"/>
+
+      <EntityType Name="HostInterface" BaseType="HostInterface.v1_1_3.HostInterface">
+        <Property Name="AuthNoneRoleId" Type="Edm.String" Nullable="false">
+          <Annotation Term="OData.Permissions" EnumMember="OData.Permission/ReadWrite"/>
+          <Annotation Term="OData.Description" String="The role when no authentication on this interface is used."/>
+          <Annotation Term="OData.LongDescription" String="This property shall contain the Id property of the Role Resource that is used when no authentication on this interface is performed.  This property shall contain absent if AuthNone is not supported by the service for the AuthenticationModes property."/>
+        </Property>
+      </EntityType>
+
+      <ComplexType Name="Links" BaseType="HostInterface.v1_0_0.Links">
+        <NavigationProperty Name="AuthNoneRole" Type="Role.Role" Nullable="false">
+          <Annotation Term="OData.Permissions" EnumMember="OData.Permission/Read"/>
+          <Annotation Term="OData.Description" String="The link to the Redfish Role that contains the privileges on this Host Interface when no authentication is performed."/>
+          <Annotation Term="OData.LongDescription" String="This property shall contain a link to a Resource of type Role, and should link to the Resource identified by property AuthNoneRoleId.  This property shall be absent if AuthNone is not supported by the service for the AuthenticationModes property."/>
+          <Annotation Term="OData.AutoExpandReferences"/>
+        </NavigationProperty>
+      </ComplexType>
+    </Schema>
+
+    <Schema xmlns="http://docs.oasis-open.org/odata/ns/edm" Namespace="HostInterface.v1_2_1">
+      <Annotation Term="Redfish.OwningEntity" String="DMTF"/>
+      <Annotation Term="OData.Description" String="This version was created to force the regeneration of JSON Schema so that URI properties use the uri-reference format."/>
+      <EntityType Name="HostInterface" BaseType="HostInterface.v1_2_0.HostInterface"/>
+    </Schema>
+
+    <Schema xmlns="http://docs.oasis-open.org/odata/ns/edm" Namespace="HostInterface.v1_2_2">
+      <Annotation Term="Redfish.OwningEntity" String="DMTF"/>
+      <Annotation Term="OData.Description" String="This version was created to update descriptions that this schema defines."/>
+      <EntityType Name="HostInterface" BaseType="HostInterface.v1_2_1.HostInterface"/>
+    </Schema>
+
+    <Schema xmlns="http://docs.oasis-open.org/odata/ns/edm" Namespace="HostInterface.v1_3_0">
+      <Annotation Term="Redfish.OwningEntity" String="DMTF"/>
+      <Annotation Term="Redfish.Release" String="2020.3"/>
+
+      <EntityType Name="HostInterface" BaseType="HostInterface.v1_2_2.HostInterface">
+        <Property Name="CredentialBootstrapping" Type="HostInterface.v1_3_0.CredentialBootstrapping" Nullable="false">
+          <Annotation Term="OData.Description" String="The credential bootstrapping settings for this interface."/>
+          <Annotation Term="OData.LongDescription" String="This property shall contain settings for the Redfish Host Interface Specification-defined 'credential bootstrapping via IPMI commands' feature for this interface.  This property shall be absent if credential bootstrapping is not supported by the service."/>
+        </Property>
+      </EntityType>
+
+      <ComplexType Name="CredentialBootstrapping">
+        <Annotation Term="OData.AdditionalProperties" Bool="false"/>
+        <Annotation Term="OData.Description" String="The credential bootstrapping settings for this interface."/>
+        <Annotation Term="OData.LongDescription" String="This type shall contain settings for the Redfish Host Interface Specification-defined 'credential bootstrapping via IPMI commands' feature for this interface."/>
+        <Property Name="Enabled" Type="Edm.Boolean">
+          <Annotation Term="OData.Permissions" EnumMember="OData.Permission/ReadWrite"/>
+          <Annotation Term="OData.Description" String="An indication of whether credential bootstrapping is enabled for this interface."/>
+          <Annotation Term="OData.LongDescription" String="This property shall indicate whether credential bootstrapping is enabled for this interface."/>
+        </Property>
+        <Property Name="EnableAfterReset" Type="Edm.Boolean">
+          <Annotation Term="OData.Permissions" EnumMember="OData.Permission/ReadWrite"/>
+          <Annotation Term="OData.Description" String="An indication of whether credential bootstrapping is enabled after a reset for this interface."/>
+          <Annotation Term="OData.LongDescription" String="This property shall indicate whether credential bootstrapping is enabled after a reset for this interface.  If `true`, services shall set the Enabled property to `true` after a reset of the host or the service."/>
+        </Property>
+        <Property Name="RoleId" Type="Edm.String" Nullable="false">
+          <Annotation Term="OData.Permissions" EnumMember="OData.Permission/ReadWrite"/>
+          <Annotation Term="OData.Description" String="The role used for the bootstrap account created for this interface."/>
+          <Annotation Term="OData.LongDescription" String="This property shall contain the Id property of the role resource that is used for the bootstrap account created for this interface."/>
+        </Property>
+      </ComplexType>
+
+      <ComplexType Name="Links" BaseType="HostInterface.v1_2_0.Links">
+        <NavigationProperty Name="CredentialBootstrappingRole" Type="Role.Role" Nullable="false">
+          <Annotation Term="OData.Permissions" EnumMember="OData.Permission/Read"/>
+          <Annotation Term="OData.Description" String="The link to the role that contains the privileges for the bootstrap account created for this interface."/>
+          <Annotation Term="OData.LongDescription" String="This property shall contain a link to a resource of type Role, and should link to the resource identified by the RoleId property within CredentialBootstrapping.  This property shall be absent if the Redfish Host Interface Specification-defined 'credential bootstrapping via IPMI commands' feature is not supported by the service."/>
+          <Annotation Term="OData.AutoExpandReferences"/>
+        </NavigationProperty>
+      </ComplexType>
+    </Schema>
+
+  </edmx:DataServices>
+</edmx:Edmx>

--- a/static/redfish/v1/schema/JobCollection_v1.xml
+++ b/static/redfish/v1/schema/JobCollection_v1.xml
@@ -1,0 +1,71 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!---->
+<!--################################################################################       -->
+<!--# Redfish Schema:  JobCollection                                                       -->
+<!--#                                                                                      -->
+<!--# For a detailed change log, see the README file contained in the DSP8010 bundle,      -->
+<!--# available at http://www.dmtf.org/standards/redfish                                   -->
+<!--# Copyright 2014-2021 DMTF.                                                            -->
+<!--# For the full DMTF copyright policy, see http://www.dmtf.org/about/policies/copyright -->
+<!--################################################################################       -->
+<!---->
+<edmx:Edmx xmlns:edmx="http://docs.oasis-open.org/odata/ns/edmx" Version="4.0">
+
+  <edmx:Reference Uri="http://docs.oasis-open.org/odata/odata/v4.0/errata03/csd01/complete/vocabularies/Org.OData.Core.V1.xml">
+    <edmx:Include Namespace="Org.OData.Core.V1" Alias="OData"/>
+  </edmx:Reference>
+  <edmx:Reference Uri="http://docs.oasis-open.org/odata/odata/v4.0/errata03/csd01/complete/vocabularies/Org.OData.Capabilities.V1.xml">
+    <edmx:Include Namespace="Org.OData.Capabilities.V1" Alias="Capabilities"/>
+  </edmx:Reference>
+  <edmx:Reference Uri="http://redfish.dmtf.org/schemas/v1/Resource_v1.xml">
+    <edmx:Include Namespace="Resource.v1_0_0"/>
+  </edmx:Reference>
+  <edmx:Reference Uri="http://redfish.dmtf.org/schemas/v1/RedfishExtensions_v1.xml">
+    <edmx:Include Namespace="RedfishExtensions.v1_0_0" Alias="Redfish"/>
+  </edmx:Reference>
+  <edmx:Reference Uri="http://redfish.dmtf.org/schemas/v1/Job_v1.xml">
+    <edmx:Include Namespace="Job"/>
+  </edmx:Reference>
+
+  <edmx:DataServices>
+
+    <Schema xmlns="http://docs.oasis-open.org/odata/ns/edm" Namespace="JobCollection">
+      <Annotation Term="Redfish.OwningEntity" String="DMTF"/>
+
+      <EntityType Name="JobCollection" BaseType="Resource.v1_0_0.ResourceCollection">
+        <Annotation Term="OData.Description" String="The collection of Job resource instances."/>
+        <Annotation Term="OData.LongDescription" String="This resource shall represent a resource collection of Job instances for a Redfish implementation."/>
+        <Annotation Term="Capabilities.InsertRestrictions">
+          <Record>
+            <PropertyValue Property="Insertable" Bool="true"/>
+            <Annotation Term="OData.Description" String="Create jobs through a POST to the job collection."/>
+          </Record>
+        </Annotation>
+        <Annotation Term="Capabilities.UpdateRestrictions">
+          <Record>
+            <PropertyValue Property="Updatable" Bool="false"/>
+          </Record>
+        </Annotation>
+        <Annotation Term="Capabilities.DeleteRestrictions">
+          <Record>
+            <PropertyValue Property="Deletable" Bool="false"/>
+          </Record>
+        </Annotation>
+        <Annotation Term="Redfish.Uris">
+          <Collection>
+            <String>/redfish/v1/JobService/Jobs</String>
+            <String>/redfish/v1/JobService/Jobs/{JobId}/Steps</String>
+          </Collection>
+        </Annotation>
+        <NavigationProperty Name="Members" Type="Collection(Job.Job)">
+          <Annotation Term="OData.Permissions" EnumMember="OData.Permission/Read"/>
+          <Annotation Term="OData.Description" String="The members of this collection."/>
+          <Annotation Term="OData.LongDescription" String="This property shall contain an array of links to the members of this collection."/>
+          <Annotation Term="OData.AutoExpandReferences"/>
+          <Annotation Term="Redfish.Required"/>
+        </NavigationProperty>
+      </EntityType>
+    </Schema>
+
+  </edmx:DataServices>
+</edmx:Edmx>

--- a/static/redfish/v1/schema/JobService_v1.xml
+++ b/static/redfish/v1/schema/JobService_v1.xml
@@ -1,0 +1,170 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!---->
+<!--################################################################################       -->
+<!--# Redfish Schema:  JobService v1.0.4                                                   -->
+<!--#                                                                                      -->
+<!--# For a detailed change log, see the README file contained in the DSP8010 bundle,      -->
+<!--# available at http://www.dmtf.org/standards/redfish                                   -->
+<!--# Copyright 2014-2021 DMTF.                                                            -->
+<!--# For the full DMTF copyright policy, see http://www.dmtf.org/about/policies/copyright -->
+<!--################################################################################       -->
+<!---->
+<edmx:Edmx xmlns:edmx="http://docs.oasis-open.org/odata/ns/edmx" Version="4.0">
+
+  <edmx:Reference Uri="http://docs.oasis-open.org/odata/odata/v4.0/errata03/csd01/complete/vocabularies/Org.OData.Core.V1.xml">
+    <edmx:Include Namespace="Org.OData.Core.V1" Alias="OData"/>
+  </edmx:Reference>
+  <edmx:Reference Uri="http://docs.oasis-open.org/odata/odata/v4.0/errata03/csd01/complete/vocabularies/Org.OData.Capabilities.V1.xml">
+    <edmx:Include Namespace="Org.OData.Capabilities.V1" Alias="Capabilities"/>
+  </edmx:Reference>
+  <edmx:Reference Uri="http://redfish.dmtf.org/schemas/v1/RedfishExtensions_v1.xml">
+    <edmx:Include Namespace="RedfishExtensions.v1_0_0" Alias="Redfish"/>
+  </edmx:Reference>
+  <edmx:Reference Uri="http://redfish.dmtf.org/schemas/v1/Resource_v1.xml">
+    <edmx:Include Namespace="Resource"/>
+    <edmx:Include Namespace="Resource.v1_0_0"/>
+  </edmx:Reference>
+  <edmx:Reference Uri="http://redfish.dmtf.org/schemas/v1/JobCollection_v1.xml">
+    <edmx:Include Namespace="JobCollection"/>
+  </edmx:Reference>
+  <edmx:Reference Uri="http://redfish.dmtf.org/schemas/v1/LogService_v1.xml">
+    <edmx:Include Namespace="LogService"/>
+  </edmx:Reference>
+
+  <edmx:DataServices>
+
+    <Schema xmlns="http://docs.oasis-open.org/odata/ns/edm" Namespace="JobService">
+      <Annotation Term="Redfish.OwningEntity" String="DMTF"/>
+
+      <EntityType Name="JobService" BaseType="Resource.v1_0_0.Resource" Abstract="true">
+        <Annotation Term="OData.Description" String="The JobService schema contains properties for scheduling and execution of operations, represents the properties for the job service itself, and has links to jobs managed by the job service."/>
+        <Annotation Term="OData.LongDescription" String="This resource shall represent a job service for a Redfish implementation."/>
+        <Annotation Term="Capabilities.InsertRestrictions">
+          <Record>
+            <PropertyValue Property="Insertable" Bool="false"/>
+          </Record>
+        </Annotation>
+        <Annotation Term="Capabilities.UpdateRestrictions">
+          <Record>
+            <PropertyValue Property="Updatable" Bool="true"/>
+            <Annotation Term="OData.Description" String="The job service can be updated to enable or disable the service, though some implementations might fail the update operation."/>
+          </Record>
+        </Annotation>
+        <Annotation Term="Capabilities.DeleteRestrictions">
+          <Record>
+            <PropertyValue Property="Deletable" Bool="false"/>
+          </Record>
+        </Annotation>
+        <Annotation Term="Redfish.Uris">
+          <Collection>
+            <String>/redfish/v1/JobService</String>
+          </Collection>
+        </Annotation>
+      </EntityType>
+    </Schema>
+
+    <Schema xmlns="http://docs.oasis-open.org/odata/ns/edm" Namespace="JobService.v1_0_0">
+      <Annotation Term="Redfish.OwningEntity" String="DMTF"/>
+      <Annotation Term="Redfish.Release" String="2018.2"/>
+
+      <EntityType Name="JobService" BaseType="JobService.JobService">
+        <Property Name="DateTime" Type="Edm.DateTimeOffset">
+          <Annotation Term="OData.Permissions" EnumMember="OData.Permission/Read"/>
+          <Annotation Term="OData.Description" String="The current date and time setting for the job service."/>
+          <Annotation Term="OData.LongDescription" String="This property shall contain the current date and time setting for the job service."/>
+        </Property>
+        <Property Name="ServiceEnabled" Type="Edm.Boolean">
+          <Annotation Term="OData.Permissions" EnumMember="OData.Permission/ReadWrite"/>
+          <Annotation Term="OData.Description" String="An indication of whether this service is enabled."/>
+          <Annotation Term="OData.LongDescription" String="This property shall indicate whether this service is enabled."/>
+        </Property>
+        <Property Name="ServiceCapabilities" Type="JobService.v1_0_0.JobServiceCapabilities" Nullable="false">
+          <Annotation Term="OData.Description" String="The supported capabilities of this job service implementation."/>
+          <Annotation Term="OData.LongDescription" String="This type shall contain properties that describe the capabilities or supported features of this implementation of a job service."/>
+        </Property>
+        <Property Name="Status" Type="Resource.Status" Nullable="false">
+          <Annotation Term="OData.Description" String="The status and health of the resource and its subordinate or dependent resources."/>
+          <Annotation Term="OData.LongDescription" String="This property shall contain any status or health properties of the resource."/>
+        </Property>
+        <NavigationProperty Name="Log" Type="LogService.LogService" Nullable="false">
+          <Annotation Term="OData.Permissions" EnumMember="OData.Permission/Read"/>
+          <Annotation Term="OData.Description" String="The link to a log service that the job service uses.  This service can be a dedicated log service or a pointer a log service under another resource, such as a manager."/>
+          <Annotation Term="OData.LongDescription" String="This property shall contain a link to a resource of type LogService that this job service uses."/>
+          <Annotation Term="OData.AutoExpandReferences"/>
+        </NavigationProperty>
+        <NavigationProperty Name="Jobs" Type="JobCollection.JobCollection" ContainsTarget="true" Nullable="false">
+          <Annotation Term="OData.Permissions" EnumMember="OData.Permission/Read"/>
+          <Annotation Term="OData.Description" String="The links to the jobs collection."/>
+          <Annotation Term="OData.LongDescription" String="This property shall contain a link to a resource collection of type JobCollection."/>
+          <Annotation Term="OData.AutoExpandReferences"/>
+        </NavigationProperty>
+        <Property Name="Actions" Type="JobService.v1_0_0.Actions" Nullable="false">
+          <Annotation Term="OData.Description" String="The available actions for this resource."/>
+          <Annotation Term="OData.LongDescription" String="This property shall contain the available actions for this resource."/>
+        </Property>
+      </EntityType>
+
+      <ComplexType Name="JobServiceCapabilities">
+        <Annotation Term="OData.Description" String="The supported capabilities of this job service implementation."/>
+        <Annotation Term="OData.LongDescription" String="This type shall contain properties that describe the capabilities or supported features of this implementation of a job service."/>
+        <Annotation Term="OData.AdditionalProperties" Bool="false"/>
+        <Property Name="MaxJobs" Type="Edm.Int64">
+          <Annotation Term="OData.Permissions" EnumMember="OData.Permission/Read"/>
+          <Annotation Term="OData.Description" String="The maximum number of jobs supported."/>
+          <Annotation Term="OData.LongDescription" String="This property shall contain the maximum number of jobs supported by the implementation."/>
+        </Property>
+        <Property Name="MaxSteps" Type="Edm.Int64">
+          <Annotation Term="OData.Permissions" EnumMember="OData.Permission/Read"/>
+          <Annotation Term="OData.Description" String="The maximum number of job steps supported."/>
+          <Annotation Term="OData.LongDescription" String="This property shall contain the maximum number of steps supported by a single job instance."/>
+        </Property>
+        <Property Name="Scheduling" Type="Edm.Boolean">
+          <Annotation Term="OData.Permissions" EnumMember="OData.Permission/Read"/>
+          <Annotation Term="OData.Description" String="An indication of whether scheduling of jobs is supported."/>
+          <Annotation Term="OData.LongDescription" String="This property shall indicate whether the Schedule property within the job supports scheduling of jobs."/>
+        </Property>
+      </ComplexType>
+
+      <ComplexType Name="Actions">
+        <Annotation Term="OData.AdditionalProperties" Bool="false"/>
+        <Annotation Term="OData.Description" String="The available actions for this resource."/>
+        <Annotation Term="OData.LongDescription" String="This type shall contain the available actions for this resource."/>
+        <Property Name="Oem" Type="JobService.v1_0_0.OemActions" Nullable="false">
+          <Annotation Term="OData.Description" String="The available OEM-specific actions for this resource."/>
+          <Annotation Term="OData.LongDescription" String="This property shall contain the available OEM-specific actions for this resource."/>
+        </Property>
+      </ComplexType>
+
+      <ComplexType Name="OemActions">
+        <Annotation Term="OData.AdditionalProperties" Bool="true"/>
+        <Annotation Term="OData.Description" String="The available OEM-specific actions for this resource."/>
+        <Annotation Term="OData.LongDescription" String="This type shall contain the available OEM-specific actions for this resource."/>
+      </ComplexType>
+    </Schema>
+
+    <Schema xmlns="http://docs.oasis-open.org/odata/ns/edm" Namespace="JobService.v1_0_1">
+      <Annotation Term="Redfish.OwningEntity" String="DMTF"/>
+      <Annotation Term="OData.Description" String="This version was created to force the regeneration of JSON Schema so that URI properties use the uri-reference format.  It was also created to correct the resource description."/>
+      <EntityType Name="JobService" BaseType="JobService.v1_0_0.JobService"/>
+    </Schema>
+
+    <Schema xmlns="http://docs.oasis-open.org/odata/ns/edm" Namespace="JobService.v1_0_2">
+      <Annotation Term="Redfish.OwningEntity" String="DMTF"/>
+      <Annotation Term="OData.Description" String="This version was created to update the description of the Log property.  It was also created to update descriptions that this schema defines."/>
+      <EntityType Name="JobService" BaseType="JobService.v1_0_1.JobService"/>
+    </Schema>
+
+    <Schema xmlns="http://docs.oasis-open.org/odata/ns/edm" Namespace="JobService.v1_0_3">
+      <Annotation Term="Redfish.OwningEntity" String="DMTF"/>
+      <Annotation Term="OData.Description" String="This version was created to correct various typographical errors."/>
+      <EntityType Name="JobService" BaseType="JobService.v1_0_2.JobService"/>
+    </Schema>
+
+    <Schema xmlns="http://docs.oasis-open.org/odata/ns/edm" Namespace="JobService.v1_0_4">
+      <Annotation Term="Redfish.OwningEntity" String="DMTF"/>
+      <Annotation Term="OData.Description" String="This version was created specify 64-bit integers in OpenAPI."/>
+      <EntityType Name="JobService" BaseType="JobService.v1_0_3.JobService"/>
+    </Schema>
+
+  </edmx:DataServices>
+</edmx:Edmx>

--- a/static/redfish/v1/schema/Job_v1.xml
+++ b/static/redfish/v1/schema/Job_v1.xml
@@ -1,0 +1,292 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!---->
+<!--################################################################################       -->
+<!--# Redfish Schema:  Job v1.0.7                                                          -->
+<!--#                                                                                      -->
+<!--# For a detailed change log, see the README file contained in the DSP8010 bundle,      -->
+<!--# available at http://www.dmtf.org/standards/redfish                                   -->
+<!--# Copyright 2014-2021 DMTF.                                                            -->
+<!--# For the full DMTF copyright policy, see http://www.dmtf.org/about/policies/copyright -->
+<!--################################################################################       -->
+<!---->
+<edmx:Edmx xmlns:edmx="http://docs.oasis-open.org/odata/ns/edmx" Version="4.0">
+
+  <edmx:Reference Uri="http://docs.oasis-open.org/odata/odata/v4.0/errata03/csd01/complete/vocabularies/Org.OData.Core.V1.xml">
+    <edmx:Include Namespace="Org.OData.Core.V1" Alias="OData"/>
+  </edmx:Reference>
+  <edmx:Reference Uri="http://docs.oasis-open.org/odata/odata/v4.0/errata03/csd01/complete/vocabularies/Org.OData.Capabilities.V1.xml">
+    <edmx:Include Namespace="Org.OData.Capabilities.V1" Alias="Capabilities"/>
+  </edmx:Reference>
+  <edmx:Reference Uri="http://docs.oasis-open.org/odata/odata/v4.0/errata03/csd01/complete/vocabularies/Org.OData.Measures.V1.xml">
+    <edmx:Include Namespace="Org.OData.Measures.V1" Alias="Measures"/>
+  </edmx:Reference>
+  <edmx:Reference Uri="http://redfish.dmtf.org/schemas/v1/RedfishExtensions_v1.xml">
+    <edmx:Include Namespace="RedfishExtensions.v1_0_0" Alias="Redfish"/>
+  </edmx:Reference>
+  <edmx:Reference Uri="http://redfish.dmtf.org/schemas/v1/Resource_v1.xml">
+    <edmx:Include Namespace="Resource"/>
+    <edmx:Include Namespace="Resource.v1_0_0"/>
+  </edmx:Reference>
+  <edmx:Reference Uri="http://redfish.dmtf.org/schemas/v1/JobCollection_v1.xml">
+    <edmx:Include Namespace="JobCollection"/>
+  </edmx:Reference>
+  <edmx:Reference Uri="http://redfish.dmtf.org/schemas/v1/Schedule_v1.xml">
+    <edmx:Include Namespace="Schedule"/>
+  </edmx:Reference>
+  <edmx:Reference Uri="http://redfish.dmtf.org/schemas/v1/Message_v1.xml">
+    <edmx:Include Namespace="Message"/>
+  </edmx:Reference>
+
+  <edmx:DataServices>
+
+    <Schema xmlns="http://docs.oasis-open.org/odata/ns/edm" Namespace="Job">
+      <Annotation Term="Redfish.OwningEntity" String="DMTF"/>
+
+      <EntityType Name="Job" BaseType="Resource.v1_0_0.Resource" Abstract="true">
+        <Annotation Term="OData.Description" String="The Job schema contains information about a job that a Redfish job service schedules or executes.  Clients create jobs to describe a series of operations that occur at periodic intervals."/>
+        <Annotation Term="OData.LongDescription" String="This resource shall contain a job in a Redfish implementation."/>
+        <Annotation Term="Capabilities.InsertRestrictions">
+          <Record>
+            <PropertyValue Property="Insertable" Bool="false"/>
+          </Record>
+        </Annotation>
+        <Annotation Term="Capabilities.UpdateRestrictions">
+          <Record>
+            <PropertyValue Property="Updatable" Bool="true"/>
+            <Annotation Term="OData.Description" String="Any writable properties can be updated for jobs."/>
+          </Record>
+        </Annotation>
+        <Annotation Term="Capabilities.DeleteRestrictions">
+          <Record>
+            <PropertyValue Property="Deletable" Bool="true"/>
+            <Annotation Term="OData.Description" String="Jobs can be deleted."/>
+          </Record>
+        </Annotation>
+        <Annotation Term="Redfish.Uris">
+          <Collection>
+            <String>/redfish/v1/JobService/Jobs/{JobId}</String>
+            <String>/redfish/v1/JobService/Jobs/{JobId}/Steps/{JobId2}</String>
+          </Collection>
+        </Annotation>
+      </EntityType>
+
+    </Schema>
+
+    <Schema xmlns="http://docs.oasis-open.org/odata/ns/edm" Namespace="Job.v1_0_0">
+      <Annotation Term="Redfish.OwningEntity" String="DMTF"/>
+      <Annotation Term="Redfish.Release" String="2018.2"/>
+
+      <EntityType Name="Job" BaseType="Job.Job">
+        <Property Name="JobStatus" Type="Resource.Health" Nullable="false">
+          <Annotation Term="OData.Permissions" EnumMember="OData.Permission/Read"/>
+          <Annotation Term="OData.Description" String="The status of the job."/>
+          <Annotation Term="OData.LongDescription" String="This property shall indicate the health status of the job."/>
+        </Property>
+        <Property Name="JobState" Type="Job.v1_0_0.JobState" Nullable="false">
+          <Annotation Term="OData.Permissions" EnumMember="OData.Permission/ReadWrite"/>
+          <Annotation Term="OData.Description" String="The state of the job."/>
+          <Annotation Term="OData.LongDescription" String="This property shall indicate the state of the job."/>
+        </Property>
+        <Property Name="StartTime" Type="Edm.DateTimeOffset" Nullable="false">
+          <Annotation Term="OData.Permissions" EnumMember="OData.Permission/Read"/>
+          <Annotation Term="OData.Description" String="The date and time when the job was started or is scheduled to start."/>
+          <Annotation Term="OData.LongDescription" String="This property shall indicate the date and time when the job was last started or is scheduled to start."/>
+        </Property>
+        <Property Name="EndTime" Type="Edm.DateTimeOffset" Nullable="false">
+          <Annotation Term="OData.Permissions" EnumMember="OData.Permission/Read"/>
+          <Annotation Term="OData.Description" String="The date and time when the job was completed."/>
+          <Annotation Term="OData.LongDescription" String="This property shall indicate the date and time when the job was completed.  This property shall not appear if the job is running or was not completed.  This property shall appear only if the JobState is Completed, Cancelled, or Exception."/>
+        </Property>
+        <Property Name="MaxExecutionTime" Type="Edm.String">
+          <Annotation Term="OData.Permissions" EnumMember="OData.Permission/ReadWrite"/>
+          <Annotation Term="OData.Description" String="The maximum amount of time the job is allowed to execute."/>
+          <Annotation Term="OData.LongDescription" String="The value shall be an ISO 8601 conformant duration describing the maximum duration the job is allowed to execute before being stopped by the service."/>
+        </Property>
+        <Property Name="PercentComplete" Type="Edm.Int64">
+          <Annotation Term="OData.Permissions" EnumMember="OData.Permission/Read"/>
+          <Annotation Term="OData.Description" String="The completion percentage of this job."/>
+          <Annotation Term="OData.LongDescription" String="This property shall indicate the completion progress of the job, reported in percent of completion.  If the job has not been started, the value shall be zero."/>
+          <Annotation Term="Measures.Unit" String="%"/>
+        </Property>
+        <Property Name="CreatedBy" Type="Edm.String" Nullable="false">
+          <Annotation Term="OData.Permissions" EnumMember="OData.Permission/Read"/>
+          <Annotation Term="OData.Description" String="The person or program that created this job entry."/>
+          <Annotation Term="OData.LongDescription" String="This property shall contain the user name, software program name, or other identifier indicating the creator of this job."/>
+        </Property>
+        <Property Name="Schedule" Type="Schedule.Schedule" Nullable="false">
+          <Annotation Term="OData.Description" String="The schedule settings for this job."/>
+          <Annotation Term="OData.LongDescription" String="This object shall contain the scheduling details for this job and the recurrence frequency for future instances of this job."/>
+        </Property>
+        <Property Name="HidePayload" Type="Edm.Boolean" Nullable="false">
+          <Annotation Term="OData.Permissions" EnumMember="OData.Permission/Read"/>
+          <Annotation Term="OData.Description" String="An indication of whether the contents of the payload should be hidden from view after the job has been created.  If `true`, responses do not return the payload.  If `false`, responses return the payload.  If this property is not present when the job is created, the default is `false`."/>
+          <Annotation Term="OData.LongDescription" String="This property shall indicate whether the contents of the payload should be hidden from view after the job has been created.  If `true`, responses shall not return the Payload property.  If `false`, responses shall return the Payload property.  If this property is not present when the job is created, the default is `false`."/>
+        </Property>
+        <Property Name="Payload" Type="Job.v1_0_0.Payload" Nullable="false">
+          <Annotation Term="OData.Description" String="The HTTP and JSON payload details for this job."/>
+          <Annotation Term="OData.LongDescription" String="This property shall contain the HTTP and JSON payload information for executing this job.  This property shall not be included in the response if the HidePayload property is `true`."/>
+        </Property>
+        <NavigationProperty Name="Steps" Type="JobCollection.JobCollection" ContainsTarget="true" Nullable="false">
+          <Annotation Term="OData.Permissions" EnumMember="OData.Permission/Read"/>
+          <Annotation Term="OData.Description" String="The link to a collection of steps for this job."/>
+          <Annotation Term="OData.LongDescription" String="This property shall contain the link to a resource collection of type JobCollection.  This property shall not be present if this resource represents a step for a job."/>
+          <Annotation Term="OData.AutoExpandReferences"/>
+        </NavigationProperty>
+        <Property Name="StepOrder" Type="Collection(Edm.String)" Nullable="false">
+          <Annotation Term="OData.Permissions" EnumMember="OData.Permission/Read"/>
+          <Annotation Term="OData.Description" String="The serialized execution order of the job steps."/>
+          <Annotation Term="OData.LongDescription" String="This property shall contain an array of IDs for the job steps in the order that they shall be executed.  Each step shall be completed prior to the execution of the next step in array order.  An incomplete list of steps shall be considered an invalid configuration.  If this property is not present or contains an empty array it shall indicate that the step execution order is omitted and may occur in parallel or in series as determined by the service."/>
+        </Property>
+        <Property Name="Messages" Type="Collection(Message.Message)" Nullable="false">
+          <Annotation Term="OData.Description" String="An array of messages associated with the job."/>
+          <Annotation Term="OData.LongDescription" String="This property shall contain an array of messages associated with the job."/>
+        </Property>
+        <Property Name="Actions" Type="Job.v1_0_0.Actions" Nullable="false">
+          <Annotation Term="OData.Description" String="The available actions for this resource."/>
+          <Annotation Term="OData.LongDescription" String="This property shall contain the available actions for this resource."/>
+        </Property>
+      </EntityType>
+
+      <EnumType Name="JobState">
+        <Member Name="New">
+          <Annotation Term="OData.Description" String="A new job."/>
+          <Annotation Term="OData.LongDescription" String="This value shall represent that this job is newly created but the operation has not yet started."/>
+        </Member>
+        <Member Name="Starting">
+          <Annotation Term="OData.Description" String="Job is starting."/>
+          <Annotation Term="OData.LongDescription" String="This value shall represent that the operation is starting."/>
+        </Member>
+        <Member Name="Running">
+          <Annotation Term="OData.Description" String="Job is running normally."/>
+          <Annotation Term="OData.LongDescription" String="This value shall represent that the operation is executing."/>
+        </Member>
+        <Member Name="Suspended">
+          <Annotation Term="OData.Description" String="Job has been suspended."/>
+          <Annotation Term="OData.LongDescription" String="This value shall represent that the operation has been suspended but is expected to restart and is therefore not complete."/>
+        </Member>
+        <Member Name="Interrupted">
+          <Annotation Term="OData.Description" String="Job has been interrupted."/>
+          <Annotation Term="OData.LongDescription" String="This value shall represent that the operation has been interrupted but is expected to restart and is therefore not complete."/>
+        </Member>
+        <Member Name="Pending">
+          <Annotation Term="OData.Description" String="Job is pending and has not started."/>
+          <Annotation Term="OData.LongDescription" String="This value shall represent that the operation is pending some condition and has not yet begun to execute."/>
+        </Member>
+        <Member Name="Stopping">
+          <Annotation Term="OData.Description" String="Job is in the process of stopping."/>
+          <Annotation Term="OData.LongDescription" String="This value shall represent that the operation is stopping but is not yet complete."/>
+        </Member>
+        <Member Name="Completed">
+          <Annotation Term="OData.Description" String="Job was completed."/>
+          <Annotation Term="OData.LongDescription" String="This value shall represent that the operation completed successfully or with warnings."/>
+        </Member>
+        <Member Name="Cancelled">
+          <Annotation Term="OData.Description" String="Job was cancelled."/>
+          <Annotation Term="OData.LongDescription" String="This value shall represent that the operation completed because the job was cancelled by an operator."/>
+        </Member>
+        <Member Name="Exception">
+          <Annotation Term="OData.Description" String="Job has stopped due to an exception condition."/>
+          <Annotation Term="OData.LongDescription" String="This value shall represent that the operation completed with errors."/>
+        </Member>
+        <Member Name="Service">
+          <Annotation Term="OData.Description" String="Job is running as a service."/>
+          <Annotation Term="OData.LongDescription" String="This value shall represent that the operation is now running as a service and expected to continue operation until stopped or killed."/>
+        </Member>
+        <Member Name="UserIntervention">
+          <Annotation Term="OData.Description" String="Job is waiting for user intervention."/>
+          <Annotation Term="OData.LongDescription" String="This value shall represent that the operation is waiting for a user to intervene and needs to be manually continued, stopped, or cancelled."/>
+        </Member>
+        <Member Name="Continue">
+          <Annotation Term="OData.Description" String="Job is to resume operation."/>
+          <Annotation Term="OData.LongDescription" String="This value shall represent that the operation has been resumed from a paused condition and should return to a Running state."/>
+        </Member>
+      </EnumType>
+
+      <ComplexType Name="Payload">
+        <Annotation Term="OData.Description" String="The HTTP and JSON payload details for this job."/>
+        <Annotation Term="OData.LongDescription" String="This object shall contain information detailing the HTTP and JSON payload information for executing this job."/>
+        <Annotation Term="OData.AdditionalProperties" Bool="false"/>
+        <Property Name="TargetUri" Type="Edm.String" Nullable="false">
+          <Annotation Term="OData.Permissions" EnumMember="OData.Permission/Read"/>
+          <Annotation Term="OData.Description" String="The link to the target for this job."/>
+          <Annotation Term="OData.LongDescription" String="This property shall contain link to a target location for an HTTP operation."/>
+          <Annotation Term="OData.IsURL"/>
+        </Property>
+        <Property Name="HttpOperation" Type="Edm.String" Nullable="false">
+          <Annotation Term="OData.Permissions" EnumMember="OData.Permission/Read"/>
+          <Annotation Term="OData.Description" String="The HTTP operation that executes this job."/>
+          <Annotation Term="OData.LongDescription" String="This property shall contain the HTTP operation that executes this job."/>
+        </Property>
+        <Property Name="HttpHeaders" Type="Collection(Edm.String)" Nullable="false">
+          <Annotation Term="OData.Permissions" EnumMember="OData.Permission/Read"/>
+          <Annotation Term="OData.Description" String="An array of HTTP headers in this job."/>
+          <Annotation Term="OData.LongDescription" String="This property shall contain an array of HTTP headers in this job."/>
+        </Property>
+        <Property Name="JsonBody" Type="Edm.String" Nullable="false">
+          <Annotation Term="OData.Permissions" EnumMember="OData.Permission/Read"/>
+          <Annotation Term="OData.Description" String="The JSON payload to use in the execution of this job."/>
+          <Annotation Term="OData.LongDescription" String="This property shall contain JSON-formatted payload for this job."/>
+        </Property>
+      </ComplexType>
+
+      <ComplexType Name="Actions">
+        <Annotation Term="OData.AdditionalProperties" Bool="false"/>
+        <Annotation Term="OData.Description" String="The available actions for this resource."/>
+        <Annotation Term="OData.LongDescription" String="This type shall contain the available actions for this resource."/>
+        <Property Name="Oem" Type="Job.v1_0_0.OemActions" Nullable="false">
+          <Annotation Term="OData.Description" String="The available OEM-specific actions for this resource."/>
+          <Annotation Term="OData.LongDescription" String="This property shall contain the available OEM-specific actions for this resource."/>
+        </Property>
+      </ComplexType>
+
+      <ComplexType Name="OemActions">
+        <Annotation Term="OData.AdditionalProperties" Bool="true"/>
+        <Annotation Term="OData.Description" String="The available OEM-specific actions for this resource."/>
+        <Annotation Term="OData.LongDescription" String="This type shall contain the available OEM-specific actions for this resource."/>
+      </ComplexType>
+    </Schema>
+
+    <Schema xmlns="http://docs.oasis-open.org/odata/ns/edm" Namespace="Job.v1_0_1">
+      <Annotation Term="Redfish.OwningEntity" String="DMTF"/>
+      <Annotation Term="OData.Description" String="This version was created to add the Measures.Unit annotation to PercentComplete."/>
+      <EntityType Name="Job" BaseType="Job.v1_0_0.Job"/>
+    </Schema>
+
+    <Schema xmlns="http://docs.oasis-open.org/odata/ns/edm" Namespace="Job.v1_0_2">
+      <Annotation Term="Redfish.OwningEntity" String="DMTF"/>
+      <Annotation Term="OData.Description" String="This version was created to force the regeneration of JSON Schema so that URI properties use the uri-reference format.  It was also created to correct the resource description."/>
+      <EntityType Name="Job" BaseType="Job.v1_0_1.Job"/>
+    </Schema>
+
+    <Schema xmlns="http://docs.oasis-open.org/odata/ns/edm" Namespace="Job.v1_0_3">
+      <Annotation Term="Redfish.OwningEntity" String="DMTF"/>
+      <Annotation Term="OData.Description" String="This version was created to update the description of the HidePayload property.  It was also created to make the EndTime property not nullable.  It was also created to update descriptions that this schema defines."/>
+      <EntityType Name="Job" BaseType="Job.v1_0_2.Job"/>
+    </Schema>
+
+    <Schema xmlns="http://docs.oasis-open.org/odata/ns/edm" Namespace="Job.v1_0_4">
+      <Annotation Term="Redfish.OwningEntity" String="DMTF"/>
+      <Annotation Term="OData.Description" String="This version was created to correct various typographical errors."/>
+      <EntityType Name="Job" BaseType="Job.v1_0_3.Job"/>
+    </Schema>
+
+    <Schema xmlns="http://docs.oasis-open.org/odata/ns/edm" Namespace="Job.v1_0_5">
+      <Annotation Term="Redfish.OwningEntity" String="DMTF"/>
+      <Annotation Term="OData.Description" String="This version was created to clarify that steps cannot have their own steps."/>
+      <EntityType Name="Job" BaseType="Job.v1_0_4.Job"/>
+    </Schema>
+
+    <Schema xmlns="http://docs.oasis-open.org/odata/ns/edm" Namespace="Job.v1_0_6">
+      <Annotation Term="Redfish.OwningEntity" String="DMTF"/>
+      <Annotation Term="OData.Description" String="This version was created to correct various typographical errors."/>
+      <EntityType Name="Job" BaseType="Job.v1_0_5.Job"/>
+    </Schema>
+
+    <Schema xmlns="http://docs.oasis-open.org/odata/ns/edm" Namespace="Job.v1_0_7">
+      <Annotation Term="Redfish.OwningEntity" String="DMTF"/>
+      <Annotation Term="OData.Description" String="This version was created to correct various description to use proper normative terminology."/>
+      <EntityType Name="Job" BaseType="Job.v1_0_6.Job"/>
+    </Schema>
+
+  </edmx:DataServices>
+</edmx:Edmx>

--- a/static/redfish/v1/schema/KeyCollection_v1.xml
+++ b/static/redfish/v1/schema/KeyCollection_v1.xml
@@ -1,0 +1,69 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!---->
+<!--################################################################################       -->
+<!--# Redfish Schema:  KeyCollection                                                       -->
+<!--#                                                                                      -->
+<!--# For a detailed change log, see the README file contained in the DSP8010 bundle,      -->
+<!--# available at http://www.dmtf.org/standards/redfish                                   -->
+<!--# Copyright 2014-2021 DMTF.                                                            -->
+<!--# For the full DMTF copyright policy, see http://www.dmtf.org/about/policies/copyright -->
+<!--################################################################################       -->
+<!---->
+<edmx:Edmx xmlns:edmx="http://docs.oasis-open.org/odata/ns/edmx" Version="4.0">
+
+  <edmx:Reference Uri="http://docs.oasis-open.org/odata/odata/v4.0/errata03/csd01/complete/vocabularies/Org.OData.Core.V1.xml">
+    <edmx:Include Namespace="Org.OData.Core.V1" Alias="OData"/>
+  </edmx:Reference>
+  <edmx:Reference Uri="http://docs.oasis-open.org/odata/odata/v4.0/errata03/csd01/complete/vocabularies/Org.OData.Capabilities.V1.xml">
+    <edmx:Include Namespace="Org.OData.Capabilities.V1" Alias="Capabilities"/>
+  </edmx:Reference>
+  <edmx:Reference Uri="http://redfish.dmtf.org/schemas/v1/Resource_v1.xml">
+    <edmx:Include Namespace="Resource.v1_0_0"/>
+  </edmx:Reference>
+  <edmx:Reference Uri="http://redfish.dmtf.org/schemas/v1/RedfishExtensions_v1.xml">
+    <edmx:Include Namespace="RedfishExtensions.v1_0_0" Alias="Redfish"/>
+  </edmx:Reference>
+  <edmx:Reference Uri="http://redfish.dmtf.org/schemas/v1/Key_v1.xml">
+    <edmx:Include Namespace="Key"/>
+  </edmx:Reference>
+
+  <edmx:DataServices>
+
+    <Schema xmlns="http://docs.oasis-open.org/odata/ns/edm" Namespace="KeyCollection">
+      <Annotation Term="Redfish.OwningEntity" String="DMTF"/>
+
+      <EntityType Name="KeyCollection" BaseType="Resource.v1_0_0.ResourceCollection">
+        <Annotation Term="OData.Description" String="The collection of Key resource instances."/>
+        <Annotation Term="OData.LongDescription" String="This resource shall represent a resource collection of Key instances for a Redfish implementation."/>
+        <Annotation Term="Capabilities.InsertRestrictions">
+          <Record>
+            <PropertyValue Property="Insertable" Bool="true"/>
+          </Record>
+        </Annotation>
+        <Annotation Term="Capabilities.UpdateRestrictions">
+          <Record>
+            <PropertyValue Property="Updatable" Bool="false"/>
+          </Record>
+        </Annotation>
+        <Annotation Term="Capabilities.DeleteRestrictions">
+          <Record>
+            <PropertyValue Property="Deletable" Bool="false"/>
+          </Record>
+        </Annotation>
+        <Annotation Term="Redfish.Uris">
+          <Collection>
+            <String>/redfish/v1/KeyService/NVMeoFSecrets</String>
+          </Collection>
+        </Annotation>
+        <NavigationProperty Name="Members" Type="Collection(Key.Key)">
+          <Annotation Term="OData.Permissions" EnumMember="OData.Permission/Read"/>
+          <Annotation Term="OData.Description" String="The members of this collection."/>
+          <Annotation Term="OData.LongDescription" String="This property shall contain an array of links to the members of this collection."/>
+          <Annotation Term="OData.AutoExpandReferences"/>
+          <Annotation Term="Redfish.Required"/>
+        </NavigationProperty>
+      </EntityType>
+    </Schema>
+
+  </edmx:DataServices>
+</edmx:Edmx>

--- a/static/redfish/v1/schema/KeyPolicyCollection_v1.xml
+++ b/static/redfish/v1/schema/KeyPolicyCollection_v1.xml
@@ -1,0 +1,69 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!---->
+<!--################################################################################       -->
+<!--# Redfish Schema:  KeyPolicyCollection                                                 -->
+<!--#                                                                                      -->
+<!--# For a detailed change log, see the README file contained in the DSP8010 bundle,      -->
+<!--# available at http://www.dmtf.org/standards/redfish                                   -->
+<!--# Copyright 2014-2021 DMTF.                                                            -->
+<!--# For the full DMTF copyright policy, see http://www.dmtf.org/about/policies/copyright -->
+<!--################################################################################       -->
+<!---->
+<edmx:Edmx xmlns:edmx="http://docs.oasis-open.org/odata/ns/edmx" Version="4.0">
+
+  <edmx:Reference Uri="http://docs.oasis-open.org/odata/odata/v4.0/errata03/csd01/complete/vocabularies/Org.OData.Core.V1.xml">
+    <edmx:Include Namespace="Org.OData.Core.V1" Alias="OData"/>
+  </edmx:Reference>
+  <edmx:Reference Uri="http://docs.oasis-open.org/odata/odata/v4.0/errata03/csd01/complete/vocabularies/Org.OData.Capabilities.V1.xml">
+    <edmx:Include Namespace="Org.OData.Capabilities.V1" Alias="Capabilities"/>
+  </edmx:Reference>
+  <edmx:Reference Uri="http://redfish.dmtf.org/schemas/v1/Resource_v1.xml">
+    <edmx:Include Namespace="Resource.v1_0_0"/>
+  </edmx:Reference>
+  <edmx:Reference Uri="http://redfish.dmtf.org/schemas/v1/RedfishExtensions_v1.xml">
+    <edmx:Include Namespace="RedfishExtensions.v1_0_0" Alias="Redfish"/>
+  </edmx:Reference>
+  <edmx:Reference Uri="http://redfish.dmtf.org/schemas/v1/KeyPolicy_v1.xml">
+    <edmx:Include Namespace="KeyPolicy"/>
+  </edmx:Reference>
+
+  <edmx:DataServices>
+
+    <Schema xmlns="http://docs.oasis-open.org/odata/ns/edm" Namespace="KeyPolicyCollection">
+      <Annotation Term="Redfish.OwningEntity" String="DMTF"/>
+
+      <EntityType Name="KeyPolicyCollection" BaseType="Resource.v1_0_0.ResourceCollection">
+        <Annotation Term="OData.Description" String="The collection of KeyPolicy resource instances."/>
+        <Annotation Term="OData.LongDescription" String="This resource shall represent a resource collection of KeyPolicy instances for a Redfish implementation."/>
+        <Annotation Term="Capabilities.InsertRestrictions">
+          <Record>
+            <PropertyValue Property="Insertable" Bool="true"/>
+          </Record>
+        </Annotation>
+        <Annotation Term="Capabilities.UpdateRestrictions">
+          <Record>
+            <PropertyValue Property="Updatable" Bool="false"/>
+          </Record>
+        </Annotation>
+        <Annotation Term="Capabilities.DeleteRestrictions">
+          <Record>
+            <PropertyValue Property="Deletable" Bool="false"/>
+          </Record>
+        </Annotation>
+        <Annotation Term="Redfish.Uris">
+          <Collection>
+            <String>/redfish/v1/KeyService/NVMeoFKeyPolicies</String>
+          </Collection>
+        </Annotation>
+        <NavigationProperty Name="Members" Type="Collection(KeyPolicy.KeyPolicy)">
+          <Annotation Term="OData.Permissions" EnumMember="OData.Permission/Read"/>
+          <Annotation Term="OData.Description" String="The members of this collection."/>
+          <Annotation Term="OData.LongDescription" String="This property shall contain an array of links to the members of this collection."/>
+          <Annotation Term="OData.AutoExpandReferences"/>
+          <Annotation Term="Redfish.Required"/>
+        </NavigationProperty>
+      </EntityType>
+    </Schema>
+
+  </edmx:DataServices>
+</edmx:Edmx>

--- a/static/redfish/v1/schema/KeyPolicy_v1.xml
+++ b/static/redfish/v1/schema/KeyPolicy_v1.xml
@@ -1,0 +1,231 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!---->
+<!--################################################################################       -->
+<!--# Redfish Schema:  KeyPolicy v1.0.0                                                    -->
+<!--#                                                                                      -->
+<!--# For a detailed change log, see the README file contained in the DSP8010 bundle,      -->
+<!--# available at http://www.dmtf.org/standards/redfish                                   -->
+<!--# Copyright 2014-2021 DMTF.                                                            -->
+<!--# For the full DMTF copyright policy, see http://www.dmtf.org/about/policies/copyright -->
+<!--################################################################################       -->
+<!---->
+<edmx:Edmx xmlns:edmx="http://docs.oasis-open.org/odata/ns/edmx" Version="4.0">
+
+  <edmx:Reference Uri="http://docs.oasis-open.org/odata/odata/v4.0/errata03/csd01/complete/vocabularies/Org.OData.Core.V1.xml">
+    <edmx:Include Namespace="Org.OData.Core.V1" Alias="OData"/>
+  </edmx:Reference>
+  <edmx:Reference Uri="http://docs.oasis-open.org/odata/odata/v4.0/errata03/csd01/complete/vocabularies/Org.OData.Capabilities.V1.xml">
+    <edmx:Include Namespace="Org.OData.Capabilities.V1" Alias="Capabilities"/>
+  </edmx:Reference>
+  <edmx:Reference Uri="http://redfish.dmtf.org/schemas/v1/Resource_v1.xml">
+    <edmx:Include Namespace="Resource.v1_0_0"/>
+  </edmx:Reference>
+  <edmx:Reference Uri="http://redfish.dmtf.org/schemas/v1/RedfishExtensions_v1.xml">
+    <edmx:Include Namespace="RedfishExtensions.v1_0_0" Alias="Redfish"/>
+    <edmx:Include Namespace="Validation.v1_0_0" Alias="Validation"/>
+  </edmx:Reference>
+
+  <edmx:DataServices>
+
+    <Schema xmlns="http://docs.oasis-open.org/odata/ns/edm" Namespace="KeyPolicy">
+      <Annotation Term="Redfish.OwningEntity" String="DMTF"/>
+
+      <EntityType Name="KeyPolicy" BaseType="Resource.v1_0_0.Resource" Abstract="true">
+        <Annotation Term="OData.Description" String="The KeyPolicy schema describes settings for how keys are allowed to be used for accessing devices or services."/>
+        <Annotation Term="OData.LongDescription" String="This resource shall represent a key policy for a Redfish implementation."/>
+        <Annotation Term="Capabilities.InsertRestrictions">
+          <Record>
+            <PropertyValue Property="Insertable" Bool="false"/>
+          </Record>
+        </Annotation>
+        <Annotation Term="Capabilities.UpdateRestrictions">
+          <Record>
+            <PropertyValue Property="Updatable" Bool="true"/>
+          </Record>
+        </Annotation>
+        <Annotation Term="Capabilities.DeleteRestrictions">
+          <Record>
+            <PropertyValue Property="Deletable" Bool="true"/>
+          </Record>
+        </Annotation>
+        <Annotation Term="Redfish.Uris">
+          <Collection>
+            <String>/redfish/v1/KeyService/NVMeoFKeyPolicies/{KeyPolicyId}</String>
+          </Collection>
+        </Annotation>
+      </EntityType>
+    </Schema>
+
+    <Schema xmlns="http://docs.oasis-open.org/odata/ns/edm" Namespace="KeyPolicy.v1_0_0">
+      <Annotation Term="Redfish.OwningEntity" String="DMTF"/>
+      <Annotation Term="Redfish.Release" String="2021.2"/>
+
+      <EntityType Name="KeyPolicy" BaseType="KeyPolicy.KeyPolicy">
+        <Property Name="KeyPolicyType" Type="KeyPolicy.v1_0_0.KeyPolicyType">
+          <Annotation Term="OData.Permissions" EnumMember="OData.Permission/Read"/>
+          <Annotation Term="OData.Description" String="The type of key policy."/>
+          <Annotation Term="OData.LongDescription" String="This property shall contain the type of key policy."/>
+          <Annotation Term="Redfish.RequiredOnCreate"/>
+        </Property>
+        <Property Name="IsDefault" Type="Edm.Boolean">
+          <Annotation Term="OData.Permissions" EnumMember="OData.Permission/ReadWrite"/>
+          <Annotation Term="OData.Description" String="Indicates if this is the default key policy."/>
+          <Annotation Term="OData.LongDescription" String="This property shall indicate if this key policy is the policy applied when no other policies are specified."/>
+        </Property>
+        <Property Name="NVMeoF" Type="KeyPolicy.v1_0_0.NVMeoF">
+          <Annotation Term="OData.Description" String="NVMe-oF specific properties."/>
+          <Annotation Term="OData.LongDescription" String="This property shall contain NVMe-oF specific properties for this key policy.  This property shall be present if KeyPolicyType contains the value `NVMeoF`."/>
+        </Property>
+        <Property Name="Actions" Type="KeyPolicy.v1_0_0.Actions" Nullable="false">
+          <Annotation Term="OData.Description" String="The available actions for this resource."/>
+          <Annotation Term="OData.LongDescription" String="This property shall contain the available actions for this resource."/>
+        </Property>
+      </EntityType>
+
+      <EnumType Name="KeyPolicyType">
+        <Member Name="NVMeoF">
+          <Annotation Term="OData.Description" String="An NVMe-oF key policy."/>
+          <Annotation Term="OData.LongDescription" String="This value shall indicate the key policy is for an NVMe-oF key."/>
+        </Member>
+      </EnumType>
+
+      <ComplexType Name="NVMeoF">
+        <Annotation Term="OData.AdditionalProperties" Bool="false"/>
+        <Annotation Term="OData.Description" String="NVMe-oF specific properties."/>
+        <Annotation Term="OData.LongDescription" String="This type shall contain NVMe-oF specific properties for a key policy."/>
+        <Property Name="SecurityProtocolAllowList" Type="Collection(KeyPolicy.v1_0_0.NVMeoFSecurityProtocolType)">
+          <Annotation Term="OData.Permissions" EnumMember="OData.Permission/ReadWrite"/>
+          <Annotation Term="OData.Description" String="The security protocols that this key policy allows."/>
+          <Annotation Term="OData.LongDescription" String="This property shall contain the security protocols that this key policy allows.  NVMe-oF channels are restricted to security protocols in this list.  The absence of the property shall indicate any security protocol is allowed.  An empty list shall indicate no security protocols are allowed."/>
+        </Property>
+        <Property Name="OEMSecurityProtocolAllowList" Type="Collection(Edm.String)">
+          <Annotation Term="OData.Permissions" EnumMember="OData.Permission/ReadWrite"/>
+          <Annotation Term="OData.Description" String="The OEM security protocols that this key policy allows."/>
+          <Annotation Term="OData.LongDescription" String="This property shall contain the OEM-defined security protocols that this key policy allows.  NVMe-oF channels are restricted to OEM-defined security protocols in this list.  An empty list shall indicate no security protocols are allowed.  This property shall be present if SecurityProtocolAllowList contains `OEM`."/>
+        </Property>
+        <Property Name="SecureHashAllowList" Type="Collection(KeyPolicy.v1_0_0.NVMeoFSecureHashType)">
+          <Annotation Term="OData.Permissions" EnumMember="OData.Permission/ReadWrite"/>
+          <Annotation Term="OData.Description" String="The secure hash algorithms that this key policy allows."/>
+          <Annotation Term="OData.LongDescription" String="This property shall contain the secure hash algorithms that this key policy allows.  The absence of the property shall indicate any secure hash algorithm is allowed.  An empty list shall indicate no secure hash algorithms are allowed."/>
+        </Property>
+        <Property Name="SecurityTransportAllowList" Type="Collection(KeyPolicy.v1_0_0.NVMeoFSecurityTransportType)">
+          <Annotation Term="OData.Permissions" EnumMember="OData.Permission/ReadWrite"/>
+          <Annotation Term="OData.Description" String="The security transports that this key policy allows."/>
+          <Annotation Term="OData.LongDescription" String="This property shall contain the security transports that this key policy allows.  The absence of the property shall indicate any security transport is allowed.  An empty list shall indicate no security transports are allowed."/>
+        </Property>
+        <Property Name="CipherSuiteAllowList" Type="Collection(KeyPolicy.v1_0_0.NVMeoFCipherSuiteType)">
+          <Annotation Term="OData.Permissions" EnumMember="OData.Permission/ReadWrite"/>
+          <Annotation Term="OData.Description" String="The cipher suites that this key policy allows."/>
+          <Annotation Term="OData.LongDescription" String="This property shall contain the cipher suites that this key policy allows.  The absence of the property shall indicate any cipher suite is allowed.  An empty list shall indicate no cipher suites are allowed."/>
+        </Property>
+        <Property Name="DHGroupAllowList" Type="Collection(KeyPolicy.v1_0_0.NVMeoFDHGroupType)">
+          <Annotation Term="OData.Permissions" EnumMember="OData.Permission/ReadWrite"/>
+          <Annotation Term="OData.Description" String="The Diffie-Hellman (DH) groups that this key policy allows."/>
+          <Annotation Term="OData.LongDescription" String="This property shall contain the Diffie-Hellman (DH) groups that this key policy allows.  The absence of the property shall indicate any DH group is allowed.  An empty list shall indicate no DH groups are allowed."/>
+        </Property>
+      </ComplexType>
+
+      <EnumType Name="NVMeoFSecurityProtocolType">
+        <Annotation Term="OData.Description" String="The NVMe security protocols that a key is allowed to use."/>
+        <Annotation Term="OData.LongDescription" String="This enumeration shall list the NVMe security protocols that a key is allowed to use."/>
+        <Member Name="DHHC">
+          <Annotation Term="OData.Description" String="Diffie-Hellman Hashed Message Authentication Code Challenge Handshake Authentication Protocol (DH-HMAC-CHAP)."/>
+          <Annotation Term="OData.LongDescription" String="This value shall indicate the Diffie-Hellman Hashed Message Authentication Code Challenge Handshake Authentication Protocol (DH-HMAC-CHAP) as defined by the NVMe Base Specification."/>
+        </Member>
+        <Member Name="TLS_PSK">
+          <Annotation Term="OData.Description" String="Transport Layer Security Pre-Shared Key (TLS PSK)."/>
+          <Annotation Term="OData.LongDescription" String="This value shall indicate Transport Layer Security Pre-Shared Key (TLS PSK) as defined by the NVMe TCP Transport Specification."/>
+        </Member>
+        <Member Name="OEM">
+          <Annotation Term="OData.Description" String="OEM."/>
+          <Annotation Term="OData.LongDescription" String="This value shall indicate an OEM-defined security protocol.  The OEMSecurityProtocolAllowList property shall contain the specific OEM protocol."/>
+        </Member>
+      </EnumType>
+
+      <EnumType Name="NVMeoFSecureHashType">
+        <Annotation Term="OData.Description" String="The NVMe secure hash algorithms that a key is allowed to use."/>
+        <Annotation Term="OData.LongDescription" String="This enumeration shall list the NVMe secure hash algorithms that a key is allowed to use."/>
+        <Member Name="SHA256">
+          <Annotation Term="OData.Description" String="SHA-256."/>
+          <Annotation Term="OData.LongDescription" String="This value shall indicate the SHA-256 hash function as defined by the 'DH-HMAC-CHAP hash function identifiers' figure in the NVMe Base Specification."/>
+        </Member>
+        <Member Name="SHA384">
+          <Annotation Term="OData.Description" String="SHA-384."/>
+          <Annotation Term="OData.LongDescription" String="This value shall indicate the SHA-384 hash function as defined by the 'DH-HMAC-CHAP hash function identifiers' figure in the NVMe Base Specification."/>
+        </Member>
+        <Member Name="SHA512">
+          <Annotation Term="OData.Description" String="SHA-512."/>
+          <Annotation Term="OData.LongDescription" String="This value shall indicate the SHA-512 hash function as defined by the 'DH-HMAC-CHAP hash function identifiers' figure in the NVMe Base Specification."/>
+        </Member>
+      </EnumType>
+
+      <EnumType Name="NVMeoFSecurityTransportType">
+        <Annotation Term="OData.Description" String="The NVMe security transports that a key is allowed to use."/>
+        <Annotation Term="OData.LongDescription" String="This enumeration shall list the NVMe security transports that a key is allowed to use."/>
+        <Member Name="TLSv2">
+          <Annotation Term="OData.Description" String="Transport Layer Security (TLS) v2."/>
+          <Annotation Term="OData.LongDescription" String="This value shall indicate Transport Layer Security (TLS) v2 as defined by the 'Transport Specific Address Subtype Definition for NVMe/TCP Transport' figure in the NVMe TCP Transport Specification."/>
+        </Member>
+        <Member Name="TLSv3">
+          <Annotation Term="OData.Description" String="Transport Layer Security (TLS) v3."/>
+          <Annotation Term="OData.LongDescription" String="This value shall indicate Transport Layer Security (TLS) v3 as defined by the 'Transport Specific Address Subtype Definition for NVMe/TCP Transport' figure in the NVMe TCP Transport Specification."/>
+        </Member>
+      </EnumType>
+
+      <EnumType Name="NVMeoFCipherSuiteType">
+        <Annotation Term="OData.Description" String="The NVMe cipher suites that a key is allowed to use."/>
+        <Annotation Term="OData.LongDescription" String="This enumeration shall list the NVMe cipher suites that a key is allowed to use."/>
+        <Member Name="TLS_AES_128_GCM_SHA256">
+          <Annotation Term="OData.Description" String="TLS_AES_128_GCM_SHA256."/>
+          <Annotation Term="OData.LongDescription" String="This value shall indicate TLS_AES_128_GCM_SHA256 as defined by the 'Mandatory and Recommended Cipher Suites' clause in the NVMe TCP Transport Specification."/>
+        </Member>
+        <Member Name="TLS_AES_256_GCM_SHA384">
+          <Annotation Term="OData.Description" String="TLS_AES_256_GCM_SHA384."/>
+          <Annotation Term="OData.LongDescription" String="This value shall indicate TLS_AES_256_GCM_SHA384 as defined by the 'Mandatory and Recommended Cipher Suites' clause in the NVMe TCP Transport Specification."/>
+        </Member>
+      </EnumType>
+
+      <EnumType Name="NVMeoFDHGroupType">
+        <Annotation Term="OData.Description" String="The NVMe Diffie-Hellman (DH) groups that a key is allowed to use."/>
+        <Annotation Term="OData.LongDescription" String="This enumeration shall list the Diffie-Hellman (DH) groups that a key is allowed to use."/>
+        <Member Name="FFDHE2048">
+          <Annotation Term="OData.Description" String="2048-bit Diffie-Hellman (DH) group."/>
+          <Annotation Term="OData.LongDescription" String="This value shall indicate the 2048-bit Diffie-Hellman (DH) group as defined by the 'DH-HMAC-CHAP Diffie-Hellman group identifiers' figure in the NVMe Base Specification."/>
+        </Member>
+        <Member Name="FFDHE3072">
+          <Annotation Term="OData.Description" String="3072-bit Diffie-Hellman (DH) group."/>
+          <Annotation Term="OData.LongDescription" String="This value shall indicate the 3072-bit Diffie-Hellman (DH) group as defined by the 'DH-HMAC-CHAP Diffie-Hellman group identifiers' figure in the NVMe Base Specification."/>
+        </Member>
+        <Member Name="FFDHE4096">
+          <Annotation Term="OData.Description" String="4096-bit Diffie-Hellman (DH) group."/>
+          <Annotation Term="OData.LongDescription" String="This value shall indicate the 4096-bit Diffie-Hellman (DH) group as defined by the 'DH-HMAC-CHAP Diffie-Hellman group identifiers' figure in the NVMe Base Specification."/>
+        </Member>
+        <Member Name="FFDHE6144">
+          <Annotation Term="OData.Description" String="6144-bit Diffie-Hellman (DH) group."/>
+          <Annotation Term="OData.LongDescription" String="This value shall indicate the 2048-bit Diffie-Hellman (DH) group as defined by the 'DH-HMAC-CHAP Diffie-Hellman group identifiers' figure in the NVMe Base Specification."/>
+        </Member>
+        <Member Name="FFDHE8192">
+          <Annotation Term="OData.Description" String="8192-bit Diffie-Hellman (DH) group."/>
+          <Annotation Term="OData.LongDescription" String="This value shall indicate the 8192-bit Diffie-Hellman (DH) group as defined by the 'DH-HMAC-CHAP Diffie-Hellman group identifiers' figure in the NVMe Base Specification."/>
+        </Member>
+      </EnumType>
+
+      <ComplexType Name="Actions">
+        <Annotation Term="OData.AdditionalProperties" Bool="false"/>
+        <Annotation Term="OData.Description" String="The available actions for this resource."/>
+        <Annotation Term="OData.LongDescription" String="This type shall contain the available actions for this resource."/>
+        <Property Name="Oem" Type="KeyPolicy.v1_0_0.OemActions" Nullable="false">
+          <Annotation Term="OData.Description" String="The available OEM-specific actions for this resource."/>
+          <Annotation Term="OData.LongDescription" String="This property shall contain the available OEM-specific actions for this resource."/>
+        </Property>
+      </ComplexType>
+
+      <ComplexType Name="OemActions">
+        <Annotation Term="OData.AdditionalProperties" Bool="true"/>
+        <Annotation Term="OData.Description" String="The available OEM-specific actions for this resource."/>
+        <Annotation Term="OData.LongDescription" String="This type shall contain the available OEM-specific actions for this resource."/>
+      </ComplexType>
+    </Schema>
+
+  </edmx:DataServices>
+</edmx:Edmx>

--- a/static/redfish/v1/schema/KeyService_v1.xml
+++ b/static/redfish/v1/schema/KeyService_v1.xml
@@ -1,0 +1,105 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!---->
+<!--################################################################################       -->
+<!--# Redfish Schema:  KeyService v1.0.0                                                   -->
+<!--#                                                                                      -->
+<!--# For a detailed change log, see the README file contained in the DSP8010 bundle,      -->
+<!--# available at http://www.dmtf.org/standards/redfish                                   -->
+<!--# Copyright 2014-2021 DMTF.                                                            -->
+<!--# For the full DMTF copyright policy, see http://www.dmtf.org/about/policies/copyright -->
+<!--################################################################################       -->
+<!---->
+<edmx:Edmx xmlns:edmx="http://docs.oasis-open.org/odata/ns/edmx" Version="4.0">
+
+  <edmx:Reference Uri="http://docs.oasis-open.org/odata/odata/v4.0/errata03/csd01/complete/vocabularies/Org.OData.Core.V1.xml">
+    <edmx:Include Namespace="Org.OData.Core.V1" Alias="OData"/>
+  </edmx:Reference>
+  <edmx:Reference Uri="http://docs.oasis-open.org/odata/odata/v4.0/errata03/csd01/complete/vocabularies/Org.OData.Capabilities.V1.xml">
+    <edmx:Include Namespace="Org.OData.Capabilities.V1" Alias="Capabilities"/>
+  </edmx:Reference>
+  <edmx:Reference Uri="http://redfish.dmtf.org/schemas/v1/RedfishExtensions_v1.xml">
+    <edmx:Include Namespace="RedfishExtensions.v1_0_0" Alias="Redfish"/>
+  </edmx:Reference>
+  <edmx:Reference Uri="http://redfish.dmtf.org/schemas/v1/Resource_v1.xml">
+    <edmx:Include Namespace="Resource.v1_0_0"/>
+  </edmx:Reference>
+  <edmx:Reference Uri="http://redfish.dmtf.org/schemas/v1/KeyCollection_v1.xml">
+    <edmx:Include Namespace="KeyCollection"/>
+  </edmx:Reference>
+  <edmx:Reference Uri="http://redfish.dmtf.org/schemas/v1/KeyPolicyCollection_v1.xml">
+    <edmx:Include Namespace="KeyPolicyCollection"/>
+  </edmx:Reference>
+
+  <edmx:DataServices>
+
+    <Schema xmlns="http://docs.oasis-open.org/odata/ns/edm" Namespace="KeyService">
+      <Annotation Term="Redfish.OwningEntity" String="DMTF"/>
+
+      <EntityType Name="KeyService" BaseType="Resource.v1_0_0.Resource" Abstract="true">
+        <Annotation Term="OData.Description" String="The KeyService schema describes a key service that represents the actions available to manage keys."/>
+        <Annotation Term="OData.LongDescription" String="This resource shall represent the key service properties for a Redfish implementation."/>
+        <Annotation Term="Capabilities.InsertRestrictions">
+          <Record>
+            <PropertyValue Property="Insertable" Bool="false"/>
+          </Record>
+        </Annotation>
+        <Annotation Term="Capabilities.UpdateRestrictions">
+          <Record>
+            <PropertyValue Property="Updatable" Bool="false"/>
+          </Record>
+        </Annotation>
+        <Annotation Term="Capabilities.DeleteRestrictions">
+          <Record>
+            <PropertyValue Property="Deletable" Bool="false"/>
+          </Record>
+        </Annotation>
+        <Annotation Term="Redfish.Uris">
+          <Collection>
+            <String>/redfish/v1/KeyService</String>
+          </Collection>
+        </Annotation>
+      </EntityType>
+    </Schema>
+
+    <Schema xmlns="http://docs.oasis-open.org/odata/ns/edm" Namespace="KeyService.v1_0_0">
+      <Annotation Term="Redfish.OwningEntity" String="DMTF"/>
+      <Annotation Term="Redfish.Release" String="2021.2"/>
+
+      <EntityType Name="KeyService" BaseType="KeyService.KeyService">
+        <Property Name="Actions" Type="KeyService.v1_0_0.Actions" Nullable="false">
+          <Annotation Term="OData.Description" String="The available actions for this resource."/>
+          <Annotation Term="OData.LongDescription" String="This property shall contain the available actions for this resource."/>
+        </Property>
+        <NavigationProperty Name="NVMeoFSecrets" Type="KeyCollection.KeyCollection" ContainsTarget="true" Nullable="false">
+          <Annotation Term="OData.Permissions" EnumMember="OData.Permission/Read"/>
+          <Annotation Term="OData.Description" String="The NVMe-oF keys maintained by this service."/>
+          <Annotation Term="OData.LongDescription" String="This property shall contain a link to a resource collection of type KeyCollection that contains the NVMe-oF keys maintained by this service.  The KeyType property for all members of this collection shall contain the value `NVMeoF`."/>
+          <Annotation Term="OData.AutoExpandReferences"/>
+        </NavigationProperty>
+        <NavigationProperty Name="NVMeoFKeyPolicies" Type="KeyPolicyCollection.KeyPolicyCollection" ContainsTarget="true" Nullable="false">
+          <Annotation Term="OData.Permissions" EnumMember="OData.Permission/Read"/>
+          <Annotation Term="OData.Description" String="The NVMe-oF key policies maintained by this service."/>
+          <Annotation Term="OData.LongDescription" String="This property shall contain a link to a resource collection of type KeyPolicyCollection that contains the NVMe-oF key policies maintained by this service.  The KeyPolicyType property for all members of this collection shall contain the value `NVMeoF`."/>
+          <Annotation Term="OData.AutoExpandReferences"/>
+        </NavigationProperty>
+      </EntityType>
+
+      <ComplexType Name="Actions">
+        <Annotation Term="OData.AdditionalProperties" Bool="false"/>
+        <Annotation Term="OData.Description" String="The available actions for this resource."/>
+        <Annotation Term="OData.LongDescription" String="This type shall contain the available actions for this resource."/>
+        <Property Name="Oem" Type="KeyService.v1_0_0.OemActions" Nullable="false">
+          <Annotation Term="OData.Description" String="The available OEM-specific actions for this resource."/>
+          <Annotation Term="OData.LongDescription" String="This property shall contain the available OEM-specific actions for this resource."/>
+        </Property>
+      </ComplexType>
+
+      <ComplexType Name="OemActions">
+        <Annotation Term="OData.AdditionalProperties" Bool="true"/>
+        <Annotation Term="OData.Description" String="The available OEM-specific actions for this resource."/>
+        <Annotation Term="OData.LongDescription" String="This type shall contain the available OEM-specific actions for this resource."/>
+      </ComplexType>
+    </Schema>
+
+  </edmx:DataServices>
+</edmx:Edmx>

--- a/static/redfish/v1/schema/Key_v1.xml
+++ b/static/redfish/v1/schema/Key_v1.xml
@@ -1,0 +1,177 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!---->
+<!--################################################################################       -->
+<!--# Redfish Schema:  Key v1.0.0                                                          -->
+<!--#                                                                                      -->
+<!--# For a detailed change log, see the README file contained in the DSP8010 bundle,      -->
+<!--# available at http://www.dmtf.org/standards/redfish                                   -->
+<!--# Copyright 2014-2021 DMTF.                                                            -->
+<!--# For the full DMTF copyright policy, see http://www.dmtf.org/about/policies/copyright -->
+<!--################################################################################       -->
+<!---->
+<edmx:Edmx xmlns:edmx="http://docs.oasis-open.org/odata/ns/edmx" Version="4.0">
+
+  <edmx:Reference Uri="http://docs.oasis-open.org/odata/odata/v4.0/errata03/csd01/complete/vocabularies/Org.OData.Core.V1.xml">
+    <edmx:Include Namespace="Org.OData.Core.V1" Alias="OData"/>
+  </edmx:Reference>
+  <edmx:Reference Uri="http://docs.oasis-open.org/odata/odata/v4.0/errata03/csd01/complete/vocabularies/Org.OData.Capabilities.V1.xml">
+    <edmx:Include Namespace="Org.OData.Capabilities.V1" Alias="Capabilities"/>
+  </edmx:Reference>
+  <edmx:Reference Uri="http://redfish.dmtf.org/schemas/v1/Resource_v1.xml">
+    <edmx:Include Namespace="Resource.v1_0_0"/>
+  </edmx:Reference>
+  <edmx:Reference Uri="http://redfish.dmtf.org/schemas/v1/RedfishExtensions_v1.xml">
+    <edmx:Include Namespace="RedfishExtensions.v1_0_0" Alias="Redfish"/>
+    <edmx:Include Namespace="Validation.v1_0_0" Alias="Validation"/>
+  </edmx:Reference>
+
+  <edmx:DataServices>
+
+    <Schema xmlns="http://docs.oasis-open.org/odata/ns/edm" Namespace="Key">
+      <Annotation Term="Redfish.OwningEntity" String="DMTF"/>
+
+      <EntityType Name="Key" BaseType="Resource.v1_0_0.Resource" Abstract="true">
+        <Annotation Term="OData.Description" String="The Key schema describes sensitive data for accessing devices or services."/>
+        <Annotation Term="OData.LongDescription" String="This resource shall represent a key for a Redfish implementation."/>
+        <Annotation Term="Capabilities.InsertRestrictions">
+          <Record>
+            <PropertyValue Property="Insertable" Bool="false"/>
+          </Record>
+        </Annotation>
+        <Annotation Term="Capabilities.UpdateRestrictions">
+          <Record>
+            <PropertyValue Property="Updatable" Bool="true"/>
+          </Record>
+        </Annotation>
+        <Annotation Term="Capabilities.DeleteRestrictions">
+          <Record>
+            <PropertyValue Property="Deletable" Bool="true"/>
+          </Record>
+        </Annotation>
+        <Annotation Term="Redfish.Uris">
+          <Collection>
+            <String>/redfish/v1/KeyService/NVMeoFSecrets/{KeyId}</String>
+          </Collection>
+        </Annotation>
+      </EntityType>
+    </Schema>
+
+    <Schema xmlns="http://docs.oasis-open.org/odata/ns/edm" Namespace="Key.v1_0_0">
+      <Annotation Term="Redfish.OwningEntity" String="DMTF"/>
+      <Annotation Term="Redfish.Release" String="2021.2"/>
+
+      <EntityType Name="Key" BaseType="Key.Key">
+        <Property Name="KeyString" Type="Edm.String">
+          <Annotation Term="OData.Permissions" EnumMember="OData.Permission/Read"/>
+          <Annotation Term="OData.Description" String="The string for the key."/>
+          <Annotation Term="OData.LongDescription" String="This property shall contain the key, and the format shall follow the requirements specified by the KeyType property value."/>
+          <Annotation Term="Redfish.RequiredOnCreate"/>
+        </Property>
+        <Property Name="KeyType" Type="Key.v1_0_0.KeyType">
+          <Annotation Term="OData.Permissions" EnumMember="OData.Permission/Read"/>
+          <Annotation Term="OData.Description" String="The format of the key."/>
+          <Annotation Term="OData.LongDescription" String="This property shall contain the format type for the key."/>
+          <Annotation Term="Redfish.RequiredOnCreate"/>
+        </Property>
+        <Property Name="NVMeoF" Type="Key.v1_0_0.NVMeoF">
+          <Annotation Term="OData.Description" String="NVMe-oF specific properties."/>
+          <Annotation Term="OData.LongDescription" String="This property shall contain NVMe-oF specific properties for this key.  This property shall be present if KeyType contains the value `NVMeoF`."/>
+        </Property>
+        <Property Name="Actions" Type="Key.v1_0_0.Actions" Nullable="false">
+          <Annotation Term="OData.Description" String="The available actions for this resource."/>
+          <Annotation Term="OData.LongDescription" String="This property shall contain the available actions for this resource."/>
+        </Property>
+      </EntityType>
+
+      <EnumType Name="KeyType">
+        <Member Name="NVMeoF">
+          <Annotation Term="OData.Description" String="An NVMe-oF key."/>
+          <Annotation Term="OData.LongDescription" String="This value shall indicate the format of the key is defined by one of the NVMe specifications."/>
+        </Member>
+      </EnumType>
+
+      <ComplexType Name="NVMeoF">
+        <Annotation Term="OData.AdditionalProperties" Bool="false"/>
+        <Annotation Term="OData.Description" String="NVMe-oF specific properties."/>
+        <Annotation Term="OData.LongDescription" String="This type shall contain NVMe-oF specific properties for a key."/>
+        <Property Name="NQN" Type="Edm.String">
+          <Annotation Term="OData.Permissions" EnumMember="OData.Permission/Read"/>
+          <Annotation Term="OData.Description" String="The NVMe Qualified Name (NQN) of the host or target subsystem associated with this key."/>
+          <Annotation Term="OData.LongDescription" String="This property shall contain the NVMe Qualified Name (NQN) of the host or target subsystem associated with this key.  The value of this property shall follow the NQN format defined by the NVMe Base Specification."/>
+          <Annotation Term="Redfish.RequiredOnCreate"/>
+        </Property>
+        <Property Name="SecurityProtocolType" Type="Key.v1_0_0.NVMeoFSecurityProtocolType">
+          <Annotation Term="OData.Permissions" EnumMember="OData.Permission/Read"/>
+          <Annotation Term="OData.Description" String="The security protocol that this key uses."/>
+          <Annotation Term="OData.LongDescription" String="This property shall contain the security protocol that this key uses.  The value shall be derived from the contents of the KeyString property."/>
+        </Property>
+        <Property Name="OEMSecurityProtocolType" Type="Edm.String">
+          <Annotation Term="OData.Permissions" EnumMember="OData.Permission/Read"/>
+          <Annotation Term="OData.Description" String="The OEM security protocol that this key uses."/>
+          <Annotation Term="OData.LongDescription" String="This property shall contain the OEM-defined security protocol that this key uses.  The value shall be derived from the contents of the KeyString property.  This property shall be present if SecurityProtocolType contains the value `OEM`."/>
+        </Property>
+        <Property Name="SecureHashAllowList" Type="Collection(Key.v1_0_0.NVMeoFSecureHashType)">
+          <Annotation Term="OData.Permissions" EnumMember="OData.Permission/Read"/>
+          <Annotation Term="OData.Description" String="The secure hash algorithms allowed with the usage of this key."/>
+          <Annotation Term="OData.LongDescription" String="This property shall contain the secure hash algorithms allowed with the usage of this key.  An empty list or the absence of this property shall indicate any secure hash algorithms are allowed with this key."/>
+        </Property>
+        <Property Name="HostKeyId" Type="Edm.String">
+          <Annotation Term="OData.Permissions" EnumMember="OData.Permission/ReadWrite"/>
+          <Annotation Term="OData.Description" String="The identifier of the host key paired with this target key."/>
+          <Annotation Term="OData.LongDescription" String="This property shall contain the value of the Id property of the Key resource representing the host key paired with this target key.  An empty string shall indicate the key is not paired.  This property shall be absent for host keys."/>
+        </Property>
+      </ComplexType>
+
+      <EnumType Name="NVMeoFSecurityProtocolType">
+        <Annotation Term="OData.Description" String="The NVMe security protocols that a key protects."/>
+        <Annotation Term="OData.LongDescription" String="This enumeration shall list the NVMe security protocols that a key protects."/>
+        <Member Name="DHHC">
+          <Annotation Term="OData.Description" String="Diffie-Hellman Hashed Message Authentication Code Challenge Handshake Authentication Protocol (DH-HMAC-CHAP)."/>
+          <Annotation Term="OData.LongDescription" String="This value shall indicate the Diffie-Hellman Hashed Message Authentication Code Challenge Handshake Authentication Protocol (DH-HMAC-CHAP) as defined by the NVMe Base Specification."/>
+        </Member>
+        <Member Name="TLS_PSK">
+          <Annotation Term="OData.Description" String="Transport Layer Security Pre-Shared Key (TLS PSK)."/>
+          <Annotation Term="OData.LongDescription" String="This value shall indicate Transport Layer Security Pre-Shared Key (TLS PSK) as defined by the NVMe TCP Transport Specification."/>
+        </Member>
+        <Member Name="OEM">
+          <Annotation Term="OData.Description" String="OEM."/>
+          <Annotation Term="OData.LongDescription" String="This value shall indicate an OEM-defined security protocol.  The OEMSecurityProtocolType property shall contain the specific OEM protocol."/>
+        </Member>
+      </EnumType>
+
+      <EnumType Name="NVMeoFSecureHashType">
+        <Annotation Term="OData.Description" String="The NVMe secure hash algorithms that a key is allowed to use."/>
+        <Annotation Term="OData.LongDescription" String="This enumeration shall list the NVMe secure hash algorithms that a key is allowed to use."/>
+        <Member Name="SHA256">
+          <Annotation Term="OData.Description" String="SHA-256."/>
+          <Annotation Term="OData.LongDescription" String="This value shall indicate the SHA-256 hash function as defined by the 'DH-HMAC-CHAP hash function identifiers' figure in the NVMe Base Specification."/>
+        </Member>
+        <Member Name="SHA384">
+          <Annotation Term="OData.Description" String="SHA-384."/>
+          <Annotation Term="OData.LongDescription" String="This value shall indicate the SHA-384 hash function as defined by the 'DH-HMAC-CHAP hash function identifiers' figure in the NVMe Base Specification."/>
+        </Member>
+        <Member Name="SHA512">
+          <Annotation Term="OData.Description" String="SHA-512."/>
+          <Annotation Term="OData.LongDescription" String="This value shall indicate the SHA-512 hash function as defined by the 'DH-HMAC-CHAP hash function identifiers' figure in the NVMe Base Specification."/>
+        </Member>
+      </EnumType>
+
+      <ComplexType Name="Actions">
+        <Annotation Term="OData.AdditionalProperties" Bool="false"/>
+        <Annotation Term="OData.Description" String="The available actions for this resource."/>
+        <Annotation Term="OData.LongDescription" String="This type shall contain the available actions for this resource."/>
+        <Property Name="Oem" Type="Key.v1_0_0.OemActions" Nullable="false">
+          <Annotation Term="OData.Description" String="The available OEM-specific actions for this resource."/>
+          <Annotation Term="OData.LongDescription" String="This property shall contain the available OEM-specific actions for this resource."/>
+        </Property>
+      </ComplexType>
+
+      <ComplexType Name="OemActions">
+        <Annotation Term="OData.AdditionalProperties" Bool="true"/>
+        <Annotation Term="OData.Description" String="The available OEM-specific actions for this resource."/>
+        <Annotation Term="OData.LongDescription" String="This type shall contain the available OEM-specific actions for this resource."/>
+      </ComplexType>
+    </Schema>
+
+  </edmx:DataServices>
+</edmx:Edmx>

--- a/static/redfish/v1/schema/Manifest_v1.xml
+++ b/static/redfish/v1/schema/Manifest_v1.xml
@@ -1,0 +1,140 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!---->
+<!--################################################################################       -->
+<!--# Redfish Schema:  Manifest v1.0.0                                                     -->
+<!--#                                                                                      -->
+<!--# For a detailed change log, see the README file contained in the DSP8010 bundle,      -->
+<!--# available at http://www.dmtf.org/standards/redfish                                   -->
+<!--# Copyright 2014-2021 DMTF.                                                            -->
+<!--# For the full DMTF copyright policy, see http://www.dmtf.org/about/policies/copyright -->
+<!--################################################################################       -->
+<!---->
+<edmx:Edmx xmlns:edmx="http://docs.oasis-open.org/odata/ns/edmx" Version="4.0">
+
+  <edmx:Reference Uri="http://docs.oasis-open.org/odata/odata/v4.0/errata03/csd01/complete/vocabularies/Org.OData.Core.V1.xml">
+    <edmx:Include Namespace="Org.OData.Core.V1" Alias="OData"/>
+  </edmx:Reference>
+  <edmx:Reference Uri="http://redfish.dmtf.org/schemas/v1/RedfishExtensions_v1.xml">
+    <edmx:Include Namespace="RedfishExtensions.v1_0_0" Alias="Redfish"/>
+  </edmx:Reference>
+
+  <edmx:DataServices>
+
+    <Schema xmlns="http://docs.oasis-open.org/odata/ns/edm" Namespace="Manifest">
+      <Annotation Term="Redfish.OwningEntity" String="DMTF"/>
+
+      <ComplexType Name="Manifest" Abstract="true">
+        <Annotation Term="OData.AdditionalProperties" Bool="false"/>
+        <Annotation Term="OData.Description" String="This type describes a manifest containing a set of requests to be fulfilled.  The manifest contains a set of stanzas, where each stanza describes a single request."/>
+        <Annotation Term="OData.LongDescription" String="This type shall describe a manifest containing a set of requests to be fulfilled."/>
+      </ComplexType>
+    </Schema>
+
+    <Schema xmlns="http://docs.oasis-open.org/odata/ns/edm" Namespace="Manifest.v1_0_0">
+      <Annotation Term="Redfish.OwningEntity" String="DMTF"/>
+      <Annotation Term="Redfish.Release" String="2020.4"/>
+
+      <ComplexType Name="Manifest" BaseType="Manifest.Manifest">
+        <Property Name="Description" Type="Edm.String">
+          <Annotation Term="OData.Permissions" EnumMember="OData.Permission/ReadWrite"/>
+          <Annotation Term="OData.Description" String="The description of this manifest."/>
+          <Annotation Term="OData.LongDescription" String="This property shall contain the description of this manifest."/>
+        </Property>
+        <Property Name="Timestamp" Type="Edm.DateTimeOffset">
+          <Annotation Term="OData.Permissions" EnumMember="OData.Permission/ReadWrite"/>
+          <Annotation Term="OData.Description" String="The date and time when the manifest was created."/>
+          <Annotation Term="OData.LongDescription" String="This property shall contain the date and time when the manifest was created."/>
+        </Property>
+        <Property Name="Expand" Type="Manifest.v1_0_0.Expand">
+          <Annotation Term="OData.Permissions" EnumMember="OData.Permission/ReadWrite"/>
+          <Annotation Term="OData.Description" String="The expansion control for references in manifest responses, similar to the `$expand=.` query parameter."/>
+          <Annotation Term="OData.LongDescription" String="This property shall contain the expansion control for references in manifest responses."/>
+        </Property>
+        <Property Name="Stanzas" Type="Collection(Manifest.v1_0_0.Stanza)">
+          <Annotation Term="OData.Description" String="An array of stanzas that describe the requests specified by this manifest."/>
+          <Annotation Term="OData.LongDescription" String="This property shall contain an array of stanzas that describe the requests specified by this manifest."/>
+        </Property>
+      </ComplexType>
+
+      <EnumType Name="Expand">
+        <Member Name="None">
+          <Annotation Term="OData.Description" String="Do not expand any references."/>
+          <Annotation Term="OData.LongDescription" String="This value shall indicate that references in the manifest response will not be expanded."/>
+        </Member>
+        <Member Name="All">
+          <Annotation Term="OData.Description" String="Expand all subordinate references."/>
+          <Annotation Term="OData.LongDescription" String="This value shall indicate that all subordinate references in the manifest response will be expanded."/>
+        </Member>
+        <Member Name="Relevant">
+          <Annotation Term="OData.Description" String="Expand relevant subordinate references.  Relevant references are those that are tied to a constrained composition request, such as a request for a quantity of processors."/>
+          <Annotation Term="OData.LongDescription" String="This value shall indicate that relevant subordinate references in the manifest response will be expanded."/>
+        </Member>
+      </EnumType>
+
+      <ComplexType Name="Stanza">
+        <Annotation Term="OData.AdditionalProperties" Bool="false"/>
+        <Annotation Term="OData.Description" String="A stanza contains properties that describe a request to be fulfilled within a manifest."/>
+        <Annotation Term="OData.LongDescription" String="This type shall contain properties that describe a request to be fulfilled within a manifest."/>
+        <Property Name="StanzaType" Type="Manifest.v1_0_0.StanzaType">
+          <Annotation Term="OData.Permissions" EnumMember="OData.Permission/ReadWrite"/>
+          <Annotation Term="OData.Description" String="The type of stanza."/>
+          <Annotation Term="OData.LongDescription" String="This property shall contain the type of stanza."/>
+        </Property>
+        <Property Name="OEMStanzaType" Type="Edm.String">
+          <Annotation Term="OData.Permissions" EnumMember="OData.Permission/ReadWrite"/>
+          <Annotation Term="OData.Description" String="The OEM-defined type of stanza."/>
+          <Annotation Term="OData.LongDescription" String="This property shall contain the OEM-defined type of stanza.  This property shall be present if StanzaType is `OEM`."/>
+        </Property>
+        <Property Name="StanzaId" Type="Edm.String">
+          <Annotation Term="OData.Permissions" EnumMember="OData.Permission/ReadWrite"/>
+          <Annotation Term="OData.Description" String="The identifier of the stanza.  This is a unique identifier specified by the client and is not used by the service."/>
+          <Annotation Term="OData.LongDescription" String="This property shall contain the identifier of the stanza."/>
+        </Property>
+        <Property Name="Request" Type="Manifest.v1_0_0.Request">
+          <Annotation Term="OData.Description" String="The request details for the stanza."/>
+          <Annotation Term="OData.LongDescription" String="This property shall contain the request details for the stanza and the contents vary based depending on the value of the StanzaType property."/>
+        </Property>
+        <Property Name="Response" Type="Manifest.v1_0_0.Response">
+          <Annotation Term="OData.Description" String="The response details for the stanza."/>
+          <Annotation Term="OData.LongDescription" String="This property shall contain the response details for the stanza and the contents vary based depending on the value of the StanzaType property."/>
+        </Property>
+      </ComplexType>
+
+      <EnumType Name="StanzaType">
+        <Member Name="ComposeSystem">
+          <Annotation Term="OData.Description" String="A stanza that describes the desired end state for computer system composition operation.  The resources consumed by the composed computer system are moved to the active pool."/>
+          <Annotation Term="OData.LongDescription" String="This value shall indicate a stanza that describes the specific, constrained, or mixed resources required to compose a computer system.  The resource blocks assigned to the computer system shall be moved to the active pool.  The Request property of the stanza shall contain a resource of type ComputerSystem that represents the composition request.  The Response property of the stanza shall contain a resource of type ComputerSystem that represents the composed system or a Redfish Specification-defined error response."/>
+        </Member>
+        <Member Name="DecomposeSystem">
+          <Annotation Term="OData.Description" String="A stanza that references a computer system to decompose and return resources to the free pool."/>
+          <Annotation Term="OData.LongDescription" String="This value shall indicate a stanza that references a computer system to decompose and return the resource blocks to the free pool that are no longer contributing to composed resources.  The Request property of the stanza shall be a Redfish Specification-defined reference object containing a reference to the resource of type ComputerSystem to decompose.  The Response property of the stanza shall contain a resource of type ComputerSystem that represents the decomposed system or a Redfish Specification-defined error response."/>
+        </Member>
+        <Member Name="ComposeResource">
+          <Annotation Term="OData.Description" String="A stanza that describes the desired end state for a composed resource block.  The resources consumed by the composed resource block are moved to the active pool."/>
+          <Annotation Term="OData.LongDescription" String="This value shall indicate a stanza that describes a composed resource block.  The resource blocks assigned to the composed resource block shall be moved to the active pool.  The Request property of the stanza shall contain a resource of type ResourceBlock that represents the composition request.  The Response property of the stanza shall contain a resource of type ResourceBlock that represents the composed resource block or a Redfish Specification-defined error response."/>
+        </Member>
+        <Member Name="DecomposeResource">
+          <Annotation Term="OData.Description" String="A stanza that references a composed resource block to decompose and return resources to the free pool."/>
+          <Annotation Term="OData.LongDescription" String="This value shall indicate a stanza that references a composed resource block to decompose and return the resource blocks to the free pool that are no longer contributing to composed resources.  The Request property of the stanza shall be a reference object as defined by the 'Reference properties' clause of the Redfish Specification containing a reference to the resource of type ResourceBlock to decompose.  The Response property of the stanza shall contain a resource of type ResourceBlock that represents the decomposed resource block or a Redfish Specification-defined error response."/>
+        </Member>
+        <Member Name="OEM">
+          <Annotation Term="OData.Description" String="A stanza that describes an OEM-specific request."/>
+          <Annotation Term="OData.LongDescription" String="This value shall indicate a stanza that describes an OEM-specific request.  The OEMStanzaType property shall contain the specific OEM stanza type."/>
+        </Member>
+      </EnumType>
+
+      <ComplexType Name="Request">
+        <Annotation Term="OData.AdditionalProperties" Bool="true"/>
+        <Annotation Term="OData.Description" String="The content of the request for the stanza."/>
+        <Annotation Term="OData.LongDescription" String="This type shall describe the request details of a stanza within a manifest.  Its contents vary depending on the value of the StanzaType property of the stanza."/>
+      </ComplexType>
+
+      <ComplexType Name="Response">
+        <Annotation Term="OData.AdditionalProperties" Bool="true"/>
+        <Annotation Term="OData.Description" String="The content of the response for the stanza."/>
+        <Annotation Term="OData.LongDescription" String="This type shall describe the response details of a stanza within a manifest.  Its contents vary depending on the value of the StanzaType property of the stanza."/>
+      </ComplexType>
+    </Schema>
+
+  </edmx:DataServices>
+</edmx:Edmx>

--- a/static/redfish/v1/schema/MediaControllerCollection_v1.xml
+++ b/static/redfish/v1/schema/MediaControllerCollection_v1.xml
@@ -1,0 +1,69 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!---->
+<!--################################################################################       -->
+<!--# Redfish Schema:  MediaControllerCollection                                           -->
+<!--#                                                                                      -->
+<!--# For a detailed change log, see the README file contained in the DSP8010 bundle,      -->
+<!--# available at http://www.dmtf.org/standards/redfish                                   -->
+<!--# Copyright 2014-2021 DMTF.                                                            -->
+<!--# For the full DMTF copyright policy, see http://www.dmtf.org/about/policies/copyright -->
+<!--################################################################################       -->
+<!---->
+<edmx:Edmx xmlns:edmx="http://docs.oasis-open.org/odata/ns/edmx" Version="4.0">
+
+  <edmx:Reference Uri="http://docs.oasis-open.org/odata/odata/v4.0/errata03/csd01/complete/vocabularies/Org.OData.Core.V1.xml">
+    <edmx:Include Namespace="Org.OData.Core.V1" Alias="OData"/>
+  </edmx:Reference>
+  <edmx:Reference Uri="http://docs.oasis-open.org/odata/odata/v4.0/errata03/csd01/complete/vocabularies/Org.OData.Capabilities.V1.xml">
+    <edmx:Include Namespace="Org.OData.Capabilities.V1" Alias="Capabilities"/>
+  </edmx:Reference>
+  <edmx:Reference Uri="http://redfish.dmtf.org/schemas/v1/Resource_v1.xml">
+    <edmx:Include Namespace="Resource.v1_0_0"/>
+  </edmx:Reference>
+  <edmx:Reference Uri="http://redfish.dmtf.org/schemas/v1/RedfishExtensions_v1.xml">
+    <edmx:Include Namespace="RedfishExtensions.v1_0_0" Alias="Redfish"/>
+  </edmx:Reference>
+  <edmx:Reference Uri="http://redfish.dmtf.org/schemas/v1/MediaController_v1.xml">
+    <edmx:Include Namespace="MediaController"/>
+  </edmx:Reference>
+
+  <edmx:DataServices>
+
+    <Schema xmlns="http://docs.oasis-open.org/odata/ns/edm" Namespace="MediaControllerCollection">
+      <Annotation Term="Redfish.OwningEntity" String="DMTF"/>
+
+      <EntityType Name="MediaControllerCollection" BaseType="Resource.v1_0_0.ResourceCollection">
+        <Annotation Term="OData.Description" String="The collection of MediaController resource instances."/>
+        <Annotation Term="OData.LongDescription" String="This resource shall represent a resource collection of MediaController instances for a Redfish implementation."/>
+        <Annotation Term="Capabilities.InsertRestrictions">
+          <Record>
+            <PropertyValue Property="Insertable" Bool="false"/>
+          </Record>
+        </Annotation>
+        <Annotation Term="Capabilities.UpdateRestrictions">
+          <Record>
+            <PropertyValue Property="Updatable" Bool="false"/>
+          </Record>
+        </Annotation>
+        <Annotation Term="Capabilities.DeleteRestrictions">
+          <Record>
+            <PropertyValue Property="Deletable" Bool="false"/>
+          </Record>
+        </Annotation>
+        <Annotation Term="Redfish.Uris">
+          <Collection>
+            <String>/redfish/v1/Chassis/{ChassisId}/MediaControllers</String>
+          </Collection>
+        </Annotation>
+        <NavigationProperty Name="Members" Type="Collection(MediaController.MediaController)">
+          <Annotation Term="OData.Permissions" EnumMember="OData.Permission/Read"/>
+          <Annotation Term="OData.Description" String="The members of this collection."/>
+          <Annotation Term="OData.LongDescription" String="This property shall contain an array of links to the members of this collection."/>
+          <Annotation Term="OData.AutoExpandReferences"/>
+          <Annotation Term="Redfish.Required"/>
+        </NavigationProperty>
+      </EntityType>
+    </Schema>
+
+  </edmx:DataServices>
+</edmx:Edmx>

--- a/static/redfish/v1/schema/MediaController_v1.xml
+++ b/static/redfish/v1/schema/MediaController_v1.xml
@@ -1,0 +1,218 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!---->
+<!--################################################################################       -->
+<!--# Redfish Schema:  MediaController v1.2.0                                              -->
+<!--#                                                                                      -->
+<!--# For a detailed change log, see the README file contained in the DSP8010 bundle,      -->
+<!--# available at http://www.dmtf.org/standards/redfish                                   -->
+<!--# Copyright 2014-2021 DMTF.                                                            -->
+<!--# For the full DMTF copyright policy, see http://www.dmtf.org/about/policies/copyright -->
+<!--################################################################################       -->
+<!---->
+<edmx:Edmx xmlns:edmx="http://docs.oasis-open.org/odata/ns/edmx" Version="4.0">
+
+  <edmx:Reference Uri="http://docs.oasis-open.org/odata/odata/v4.0/errata03/csd01/complete/vocabularies/Org.OData.Core.V1.xml">
+    <edmx:Include Namespace="Org.OData.Core.V1" Alias="OData"/>
+  </edmx:Reference>
+  <edmx:Reference Uri="http://docs.oasis-open.org/odata/odata/v4.0/errata03/csd01/complete/vocabularies/Org.OData.Measures.V1.xml">
+    <edmx:Include Namespace="Org.OData.Measures.V1" Alias="Measures"/>
+  </edmx:Reference>
+  <edmx:Reference Uri="http://redfish.dmtf.org/schemas/v1/RedfishExtensions_v1.xml">
+    <edmx:Include Namespace="RedfishExtensions.v1_0_0" Alias="Redfish"/>
+    <edmx:Include Namespace="Validation.v1_0_0" Alias="Validation"/>
+  </edmx:Reference>
+  <edmx:Reference Uri="http://docs.oasis-open.org/odata/odata/v4.0/errata03/csd01/complete/vocabularies/Org.OData.Capabilities.V1.xml">
+    <edmx:Include Namespace="Org.OData.Capabilities.V1" Alias="Capabilities"/>
+  </edmx:Reference>
+  <edmx:Reference Uri="http://redfish.dmtf.org/schemas/v1/Resource_v1.xml">
+    <edmx:Include Namespace="Resource"/>
+    <edmx:Include Namespace="Resource.v1_0_0"/>
+  </edmx:Reference>
+  <edmx:Reference Uri="http://redfish.dmtf.org/schemas/v1/Chassis_v1.xml">
+    <edmx:Include Namespace="Chassis"/>
+  </edmx:Reference>
+  <edmx:Reference Uri="http://redfish.dmtf.org/schemas/v1/Assembly_v1.xml">
+    <edmx:Include Namespace="Assembly"/>
+  </edmx:Reference>
+  <edmx:Reference Uri="http://redfish.dmtf.org/schemas/v1/PortCollection_v1.xml">
+    <edmx:Include Namespace="PortCollection"/>
+  </edmx:Reference>
+  <edmx:Reference Uri="http://redfish.dmtf.org/schemas/v1/Endpoint_v1.xml">
+    <edmx:Include Namespace="Endpoint"/>
+  </edmx:Reference>
+  <edmx:Reference Uri="http://redfish.dmtf.org/schemas/v1/MemoryDomain_v1.xml">
+    <edmx:Include Namespace="MemoryDomain"/>
+  </edmx:Reference>
+  <edmx:Reference Uri="http://redfish.dmtf.org/schemas/v1/EnvironmentMetrics_v1.xml">
+    <edmx:Include Namespace="EnvironmentMetrics"/>
+  </edmx:Reference>
+
+  <edmx:DataServices>
+
+    <Schema xmlns="http://docs.oasis-open.org/odata/ns/edm" Namespace="MediaController">
+      <Annotation Term="Redfish.OwningEntity" String="DMTF"/>
+
+      <EntityType Name="MediaController" BaseType="Resource.v1_0_0.Resource" Abstract="true">
+        <Annotation Term="OData.Description" String="The MediaController schema contains the definition of the media controller and its configuration."/>
+        <Annotation Term="OData.LongDescription" String="This resource contains the media controller in a Redfish implementation."/>
+        <Annotation Term="OData.AdditionalProperties" Bool="false"/>
+        <Annotation Term="Capabilities.InsertRestrictions">
+          <Record>
+            <PropertyValue Property="Insertable" Bool="false"/>
+          </Record>
+        </Annotation>
+        <Annotation Term="Capabilities.UpdateRestrictions">
+          <Record>
+            <PropertyValue Property="Updatable" Bool="false"/>
+          </Record>
+        </Annotation>
+        <Annotation Term="Capabilities.DeleteRestrictions">
+          <Record>
+            <PropertyValue Property="Deletable" Bool="false"/>
+          </Record>
+        </Annotation>
+        <Annotation Term="Redfish.Uris">
+          <Collection>
+            <String>/redfish/v1/Chassis/{ChassisId}/MediaControllers/{MediaControllerId}</String>
+          </Collection>
+        </Annotation>
+      </EntityType>
+
+      <Action Name="Reset" IsBound="true">
+        <Annotation Term="OData.Description" String="This action resets this media controller."/>
+        <Annotation Term="OData.LongDescription" String="This action shall reset this media controller."/>
+        <Parameter Name="MediaController" Type="MediaController.v1_0_0.Actions"/>
+        <Parameter Name="ResetType" Type="Resource.ResetType">
+          <Annotation Term="OData.Description" String="The type of reset."/>
+          <Annotation Term="OData.LongDescription" String="This parameter shall contain the type of reset.  The service can accept a request without the parameter and perform an implementation-specific default reset."/>
+        </Parameter>
+      </Action>
+    </Schema>
+
+    <Schema xmlns="http://docs.oasis-open.org/odata/ns/edm" Namespace="MediaController.v1_0_0">
+      <Annotation Term="Redfish.OwningEntity" String="DMTF"/>
+      <Annotation Term="Redfish.Release" String="2019.4"/>
+
+      <EntityType Name="MediaController" BaseType="MediaController.MediaController">
+        <Property Name="Links" Type="MediaController.v1_0_0.Links" Nullable="false">
+          <Annotation Term="OData.Description" String="The links to other resources that are related to this resource."/>
+          <Annotation Term="OData.LongDescription" String="This property shall contain links to resources that are related to but are not contained by, or subordinate to, this resource."/>
+        </Property>
+        <Property Name="Manufacturer" Type="Edm.String">
+          <Annotation Term="OData.Permissions" EnumMember="OData.Permission/Read"/>
+          <Annotation Term="OData.Description" String="The manufacturer of this media controller."/>
+          <Annotation Term="OData.LongDescription" String="This property shall contain the manufacturer of the media controller."/>
+        </Property>
+        <Property Name="Model" Type="Edm.String">
+          <Annotation Term="OData.Permissions" EnumMember="OData.Permission/Read"/>
+          <Annotation Term="OData.Description" String="The model of this media controller."/>
+          <Annotation Term="OData.LongDescription" String="This property shall contain the model of the media controller."/>
+        </Property>
+        <Property Name="SerialNumber" Type="Edm.String">
+          <Annotation Term="OData.Permissions" EnumMember="OData.Permission/Read"/>
+          <Annotation Term="OData.Description" String="The serial number of this media controller."/>
+          <Annotation Term="OData.LongDescription" String="This property shall indicate the serial number as provided by the manufacturer of this media controller."/>
+        </Property>
+        <Property Name="PartNumber" Type="Edm.String">
+          <Annotation Term="OData.Permissions" EnumMember="OData.Permission/Read"/>
+          <Annotation Term="OData.Description" String="The part number of this media controller."/>
+          <Annotation Term="OData.LongDescription" String="This property shall indicate the part number as provided by the manufacturer of this media controller."/>
+        </Property>
+        <Property Name="Status" Type="Resource.Status" Nullable="false">
+          <Annotation Term="OData.Description" String="The status and health of the resource and its subordinate or dependent resources."/>
+          <Annotation Term="OData.LongDescription" String="This property shall contain any status or health properties of the resource."/>
+        </Property>
+        <NavigationProperty Name="Ports" Type="PortCollection.PortCollection" ContainsTarget="true" Nullable="false">
+          <Annotation Term="OData.Permissions" EnumMember="OData.Permission/Read"/>
+          <Annotation Term="OData.Description" String="The link to the collection of ports associated with this media controller."/>
+          <Annotation Term="OData.LongDescription" String="This property shall contain a link to a resource collection of type PortCollection."/>
+          <Annotation Term="OData.AutoExpandReferences"/>
+        </NavigationProperty>
+        <Property Name="MediaControllerType" Type="MediaController.v1_0_0.MediaControllerType">
+          <Annotation Term="OData.Permissions" EnumMember="OData.Permission/Read"/>
+          <Annotation Term="OData.Description" String="The type of media controller."/>
+          <Annotation Term="OData.LongDescription" String="This property shall contain the type of media controller."/>
+        </Property>
+        <Property Name="Actions" Type="MediaController.v1_0_0.Actions" Nullable="false">
+          <Annotation Term="OData.Description" String="The available actions for this resource."/>
+          <Annotation Term="OData.LongDescription" String="This property shall contain the available actions for this resource."/>
+        </Property>
+      </EntityType>
+
+      <ComplexType Name="Actions">
+        <Annotation Term="OData.AdditionalProperties" Bool="false"/>
+        <Annotation Term="OData.Description" String="The available actions for this resource."/>
+        <Annotation Term="OData.LongDescription" String="This type shall contain the available actions for this resource."/>
+        <Property Name="Oem" Type="MediaController.v1_0_0.OemActions" Nullable="false">
+          <Annotation Term="OData.Description" String="The available OEM-specific actions for this resource."/>
+          <Annotation Term="OData.LongDescription" String="This property shall contain the available OEM-specific actions for this resource."/>
+        </Property>
+      </ComplexType>
+
+      <ComplexType Name="OemActions">
+        <Annotation Term="OData.AdditionalProperties" Bool="true"/>
+        <Annotation Term="OData.Description" String="The available OEM-specific actions for this resource."/>
+        <Annotation Term="OData.LongDescription" String="This type shall contain the available OEM-specific actions for this resource."/>
+      </ComplexType>
+
+      <EnumType Name="MediaControllerType">
+        <Member Name="Memory">
+          <Annotation Term="OData.Description" String="The media controller is for memory."/>
+          <Annotation Term="OData.LongDescription" String="This value shall indicate the media controller is for memory."/>
+        </Member>
+      </EnumType>
+
+      <ComplexType Name="Links" BaseType="Resource.Links">
+        <Annotation Term="OData.Description" String="The links to other resources that are related to this resource."/>
+        <Annotation Term="OData.LongDescription" String="This Redfish Specification-described type shall contain links to resources that are related to but are not contained by, or subordinate to, this resource."/>
+        <NavigationProperty Name="Endpoints" Type="Collection(Endpoint.Endpoint)">
+          <Annotation Term="OData.Permissions" EnumMember="OData.Permission/Read"/>
+          <Annotation Term="OData.Description" String="An array of links to the endpoints that connect to this media controller."/>
+          <Annotation Term="OData.LongDescription" String="This property shall contain an array of links to resources of type Endpoint with which this media controller is associated."/>
+          <Annotation Term="OData.AutoExpandReferences"/>
+        </NavigationProperty>
+        <NavigationProperty Name="MemoryDomains" Type="Collection(MemoryDomain.MemoryDomain)">
+          <Annotation Term="OData.Permissions" EnumMember="OData.Permission/Read"/>
+          <Annotation Term="OData.Description" String="An array of links to the memory domains associated with this media controller."/>
+          <Annotation Term="OData.LongDescription" String="This property shall contain an array of links to resources of type MemoryDomain that represent the memory domains associated with this memory controller."/>
+          <Annotation Term="OData.AutoExpandReferences"/>
+        </NavigationProperty>
+      </ComplexType>
+    </Schema>
+
+    <Schema xmlns="http://docs.oasis-open.org/odata/ns/edm" Namespace="MediaController.v1_0_1">
+      <Annotation Term="Redfish.OwningEntity" String="DMTF"/>
+      <Annotation Term="OData.Description" String="This version was created to correct various typographical errors."/>
+      <EntityType Name="MediaController" BaseType="MediaController.v1_0_0.MediaController"/>
+    </Schema>
+
+    <Schema xmlns="http://docs.oasis-open.org/odata/ns/edm" Namespace="MediaController.v1_1_0">
+      <Annotation Term="Redfish.OwningEntity" String="DMTF"/>
+      <Annotation Term="Redfish.Release" String="2020.2"/>
+
+      <EntityType Name="MediaController" BaseType="MediaController.v1_0_1.MediaController">
+        <Property Name="UUID" Type="Resource.UUID">
+           <Annotation Term="OData.Permissions" EnumMember="OData.Permission/Read"/>
+           <Annotation Term="OData.Description" String="The UUID for this media controller."/>
+           <Annotation Term="OData.LongDescription" String="This property shall contain a universal unique identifier number for the media controller."/>
+        </Property>
+      </EntityType>
+    </Schema>
+
+    <Schema xmlns="http://docs.oasis-open.org/odata/ns/edm" Namespace="MediaController.v1_2_0">
+      <Annotation Term="Redfish.OwningEntity" String="DMTF"/>
+      <Annotation Term="Redfish.Release" String="2021.1"/>
+      <Annotation Term="OData.Description" String="This version was created to add a link for EnvironmentMetrics."/>
+
+      <EntityType Name="MediaController" BaseType="MediaController.v1_1_0.MediaController">
+        <NavigationProperty Name="EnvironmentMetrics" Type="EnvironmentMetrics.EnvironmentMetrics" Nullable="false">
+          <Annotation Term="OData.Permissions" EnumMember="OData.Permission/Read"/>
+          <Annotation Term="OData.Description" String="The link to the environment metrics for this media controller."/>
+          <Annotation Term="OData.LongDescription" String="This property shall contain a link to a resource of type EnvironmentMetrics that specifies the environment metrics for this media controller."/>
+          <Annotation Term="OData.AutoExpandReferences"/>
+        </NavigationProperty>
+      </EntityType>
+    </Schema>
+
+  </edmx:DataServices>
+</edmx:Edmx>

--- a/static/redfish/v1/schema/MemoryChunksCollection_v1.xml
+++ b/static/redfish/v1/schema/MemoryChunksCollection_v1.xml
@@ -1,0 +1,72 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!---->
+<!--################################################################################       -->
+<!--# Redfish Schema:  MemoryChunksCollection                                              -->
+<!--#                                                                                      -->
+<!--# For a detailed change log, see the README file contained in the DSP8010 bundle,      -->
+<!--# available at http://www.dmtf.org/standards/redfish                                   -->
+<!--# Copyright 2014-2021 DMTF.                                                            -->
+<!--# For the full DMTF copyright policy, see http://www.dmtf.org/about/policies/copyright -->
+<!--################################################################################       -->
+<!---->
+<edmx:Edmx xmlns:edmx="http://docs.oasis-open.org/odata/ns/edmx" Version="4.0">
+
+  <edmx:Reference Uri="http://docs.oasis-open.org/odata/odata/v4.0/errata03/csd01/complete/vocabularies/Org.OData.Core.V1.xml">
+    <edmx:Include Namespace="Org.OData.Core.V1" Alias="OData"/>
+  </edmx:Reference>
+  <edmx:Reference Uri="http://docs.oasis-open.org/odata/odata/v4.0/errata03/csd01/complete/vocabularies/Org.OData.Capabilities.V1.xml">
+    <edmx:Include Namespace="Org.OData.Capabilities.V1" Alias="Capabilities"/>
+  </edmx:Reference>
+  <edmx:Reference Uri="http://redfish.dmtf.org/schemas/v1/Resource_v1.xml">
+    <edmx:Include Namespace="Resource.v1_0_0"/>
+  </edmx:Reference>
+  <edmx:Reference Uri="http://redfish.dmtf.org/schemas/v1/RedfishExtensions_v1.xml">
+    <edmx:Include Namespace="RedfishExtensions.v1_0_0" Alias="Redfish"/>
+  </edmx:Reference>
+  <edmx:Reference Uri="http://redfish.dmtf.org/schemas/v1/MemoryChunks_v1.xml">
+    <edmx:Include Namespace="MemoryChunks"/>
+  </edmx:Reference>
+
+  <edmx:DataServices>
+    <Schema xmlns="http://docs.oasis-open.org/odata/ns/edm" Namespace="MemoryChunksCollection">
+      <Annotation Term="Redfish.OwningEntity" String="DMTF"/>
+
+      <EntityType Name="MemoryChunksCollection" BaseType="Resource.v1_0_0.ResourceCollection">
+        <Annotation Term="OData.Description" String="The collection of MemoryChunks resource instances."/>
+        <Annotation Term="OData.LongDescription" String="This resource shall represent a resource collection of MemoryChunks instances for a Redfish implementation."/>
+        <Annotation Term="Capabilities.InsertRestrictions">
+          <Record>
+            <PropertyValue Property="Insertable" Bool="true"/>
+            <Annotation Term="OData.Description" String="Create memory chunks through a POST to the memory chunk collection."/>
+          </Record>
+        </Annotation>
+        <Annotation Term="Capabilities.UpdateRestrictions">
+          <Record>
+            <PropertyValue Property="Updatable" Bool="false"/>
+          </Record>
+        </Annotation>
+        <Annotation Term="Capabilities.DeleteRestrictions">
+          <Record>
+            <PropertyValue Property="Deletable" Bool="false"/>
+          </Record>
+        </Annotation>
+        <Annotation Term="Redfish.Uris">
+          <Collection>
+            <String>/redfish/v1/Systems/{ComputerSystemId}/MemoryDomains/{MemoryDomainId}/MemoryChunks</String>
+            <String>/redfish/v1/Chassis/{ChassisId}/MemoryDomains/{MemoryDomainId}/MemoryChunks</String>
+            <String>/redfish/v1/CompositionService/ResourceBlocks/{ResourceBlockId}/Systems/{ComputerSystemId}/MemoryDomains/{MemoryDomainId}/MemoryChunks</String>
+            <String>/redfish/v1/ResourceBlocks/{ResourceBlockId}/Systems/{ComputerSystemId}/MemoryDomains/{MemoryDomainId}/MemoryChunks</String>
+          </Collection>
+        </Annotation>
+        <NavigationProperty Name="Members" Type="Collection(MemoryChunks.MemoryChunks)">
+          <Annotation Term="OData.Permissions" EnumMember="OData.Permission/Read"/>
+          <Annotation Term="OData.Description" String="The members of this collection."/>
+          <Annotation Term="OData.LongDescription" String="This property shall contain an array of links to the members of this collection."/>
+          <Annotation Term="OData.AutoExpandReferences"/>
+          <Annotation Term="Redfish.Required"/>
+        </NavigationProperty>
+      </EntityType>
+
+    </Schema>
+  </edmx:DataServices>
+</edmx:Edmx>

--- a/static/redfish/v1/schema/MemoryChunks_v1.xml
+++ b/static/redfish/v1/schema/MemoryChunks_v1.xml
@@ -1,0 +1,358 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!---->
+<!--################################################################################       -->
+<!--# Redfish Schema:  MemoryChunks v1.4.1                                                 -->
+<!--#                                                                                      -->
+<!--# For a detailed change log, see the README file contained in the DSP8010 bundle,      -->
+<!--# available at http://www.dmtf.org/standards/redfish                                   -->
+<!--# Copyright 2014-2021 DMTF.                                                            -->
+<!--# For the full DMTF copyright policy, see http://www.dmtf.org/about/policies/copyright -->
+<!--################################################################################       -->
+<!---->
+<edmx:Edmx xmlns:edmx="http://docs.oasis-open.org/odata/ns/edmx" Version="4.0">
+
+  <edmx:Reference Uri="http://docs.oasis-open.org/odata/odata/v4.0/errata03/csd01/complete/vocabularies/Org.OData.Core.V1.xml">
+    <edmx:Include Namespace="Org.OData.Core.V1" Alias="OData"/>
+  </edmx:Reference>
+  <edmx:Reference Uri="http://docs.oasis-open.org/odata/odata/v4.0/errata03/csd01/complete/vocabularies/Org.OData.Capabilities.V1.xml">
+    <edmx:Include Namespace="Org.OData.Capabilities.V1" Alias="Capabilities"/>
+  </edmx:Reference>
+  <edmx:Reference Uri="http://docs.oasis-open.org/odata/odata/v4.0/errata03/csd01/complete/vocabularies/Org.OData.Measures.V1.xml">
+    <edmx:Include Namespace="Org.OData.Measures.V1" Alias="Measures"/>
+  </edmx:Reference>
+  <edmx:Reference Uri="http://redfish.dmtf.org/schemas/v1/Resource_v1.xml">
+    <edmx:Include Namespace="Resource"/>
+    <edmx:Include Namespace="Resource.v1_0_0"/>
+  </edmx:Reference>
+  <edmx:Reference Uri="http://redfish.dmtf.org/schemas/v1/RedfishExtensions_v1.xml">
+    <edmx:Include Namespace="RedfishExtensions.v1_0_0" Alias="Redfish"/>
+  </edmx:Reference>
+  <edmx:Reference Uri="http://redfish.dmtf.org/schemas/v1/Endpoint_v1.xml">
+    <edmx:Include Namespace="Endpoint"/>
+  </edmx:Reference>
+
+  <edmx:DataServices>
+
+    <Schema xmlns="http://docs.oasis-open.org/odata/ns/edm" Namespace="MemoryChunks">
+      <Annotation Term="Redfish.OwningEntity" String="DMTF"/>
+
+      <EntityType Name="MemoryChunks" BaseType="Resource.v1_0_0.Resource" Abstract="true">
+        <Annotation Term="OData.Description" String="The schema definition of a memory chunk and its configuration."/>
+        <Annotation Term="OData.LongDescription" String="This resource shall represent memory chunks and interleave sets in a Redfish implementation."/>
+        <Annotation Term="OData.AdditionalProperties" Bool="false"/>
+        <Annotation Term="Capabilities.InsertRestrictions">
+          <Record>
+            <PropertyValue Property="Insertable" Bool="false"/>
+          </Record>
+        </Annotation>
+        <Annotation Term="Capabilities.UpdateRestrictions">
+          <Record>
+            <PropertyValue Property="Updatable" Bool="true"/>
+            <Annotation Term="OData.Description" String="Any writable properties can be updated for memory chunks."/>
+          </Record>
+        </Annotation>
+        <Annotation Term="Capabilities.DeleteRestrictions">
+          <Record>
+            <PropertyValue Property="Deletable" Bool="true"/>
+            <Annotation Term="OData.Description" String="Memory chunks can be deleted."/>
+          </Record>
+        </Annotation>
+        <Annotation Term="Redfish.Uris">
+          <Collection>
+            <String>/redfish/v1/Systems/{ComputerSystemId}/MemoryDomains/{MemoryDomainId}/MemoryChunks/{MemoryChunksId}</String>
+            <String>/redfish/v1/Chassis/{ChassisId}/MemoryDomains/{MemoryDomainId}/MemoryChunks/{MemoryChunksId}</String>
+            <String>/redfish/v1/CompositionService/ResourceBlocks/{ResourceBlockId}/Systems/{ComputerSystemId}/MemoryDomains/{MemoryDomainId}/MemoryChunks/{MemoryChunksId}</String>
+            <String>/redfish/v1/ResourceBlocks/{ResourceBlockId}/Systems/{ComputerSystemId}/MemoryDomains/{MemoryDomainId}/MemoryChunks/{MemoryChunksId}</String>
+          </Collection>
+        </Annotation>
+      </EntityType>
+    </Schema>
+
+    <Schema xmlns="http://docs.oasis-open.org/odata/ns/edm" Namespace="MemoryChunks.v1_0_0">
+      <Annotation Term="Redfish.OwningEntity" String="DMTF"/>
+      <Annotation Term="Redfish.Release" String="2016.2"/>
+
+      <EntityType Name="MemoryChunks" BaseType="MemoryChunks.MemoryChunks">
+        <Property Name="MemoryChunkSizeMiB" Type="Edm.Int64">
+          <Annotation Term="OData.Permissions" EnumMember="OData.Permission/Read"/>
+          <Annotation Term="OData.Description" String="Size of the memory chunk measured in mebibytes (MiB)."/>
+          <Annotation Term="OData.LongDescription" String="This property shall contain the size of the memory chunk in MiB."/>
+          <Annotation Term="Measures.Unit" String="MiBy"/>
+        </Property>
+        <Property Name="AddressRangeType" Type="MemoryChunks.v1_0_0.AddressRangeType">
+          <Annotation Term="OData.Permissions" EnumMember="OData.Permission/Read"/>
+          <Annotation Term="OData.Description" String="Memory type of this memory chunk."/>
+          <Annotation Term="OData.LongDescription" String="This property shall contain the type of memory chunk."/>
+        </Property>
+        <Property Name="IsMirrorEnabled" Type="Edm.Boolean" DefaultValue="false">
+          <Annotation Term="OData.Permissions" EnumMember="OData.Permission/Read"/>
+          <Annotation Term="OData.Description" String="An indication of whether memory mirroring is enabled for this memory chunk."/>
+          <Annotation Term="OData.LongDescription" String="This property shall indicate whether memory mirroring is enabled for this memory chunk."/>
+        </Property>
+        <Property Name="IsSpare" Type="Edm.Boolean" DefaultValue="false">
+          <Annotation Term="OData.Permissions" EnumMember="OData.Permission/Read"/>
+          <Annotation Term="OData.Description" String="An indication of whether sparing is enabled for this memory chunk."/>
+          <Annotation Term="OData.LongDescription" String="This property shall indicate whether sparing is enabled for this memory chunk."/>
+        </Property>
+        <Property Name="InterleaveSets" Type="Collection(MemoryChunks.v1_0_0.InterleaveSet)" Nullable="false">
+          <Annotation Term="OData.Description" String="The interleave sets for the memory chunk."/>
+          <Annotation Term="OData.LongDescription" String="These properties shall represent the interleave sets for the memory chunk."/>
+        </Property>
+      </EntityType>
+
+      <ComplexType Name="InterleaveSet">
+        <Annotation Term="OData.AdditionalProperties" Bool="false"/>
+        <Annotation Term="OData.Description" String="This an interleave set for a memory chunk."/>
+        <Annotation Term="OData.LongDescription" String="This type shall describe an interleave set of which the memory chunk is a part."/>
+        <NavigationProperty Name="Memory" Type="Resource.Item" Nullable="false">
+          <Annotation Term="OData.Permissions" EnumMember="OData.Permission/Read"/>
+          <Annotation Term="OData.Description" String="Describes a memory device of the interleave set."/>
+          <Annotation Term="OData.LongDescription" String="This property shall contain the memory device to which these settings apply."/>
+          <Annotation Term="OData.AutoExpandReferences"/>
+        </NavigationProperty>
+        <Property Name="RegionId" Type="Edm.String">
+          <Annotation Term="OData.Permissions" EnumMember="OData.Permission/Read"/>
+          <Annotation Term="OData.Description" String="DIMM region identifier."/>
+          <Annotation Term="OData.LongDescription" String="This property shall contain the DIMM region identifier."/>
+        </Property>
+        <Property Name="OffsetMiB" Type="Edm.Int64">
+          <Annotation Term="OData.Permissions" EnumMember="OData.Permission/Read"/>
+          <Annotation Term="OData.Description" String="Offset within the DIMM that corresponds to the start of this memory region, measured in mebibytes (MiB)."/>
+          <Annotation Term="OData.LongDescription" String="This property shall contain the offset within the DIMM that corresponds to the start of this memory region, with units in MiB."/>
+          <Annotation Term="Measures.Unit" String="MiBy"/>
+        </Property>
+        <Property Name="SizeMiB" Type="Edm.Int64">
+          <Annotation Term="OData.Permissions" EnumMember="OData.Permission/Read"/>
+          <Annotation Term="OData.Description" String="Size of this memory region measured in mebibytes (MiB)."/>
+          <Annotation Term="OData.LongDescription" String="This property shall contain the size of this memory region, with units in MiB."/>
+          <Annotation Term="Measures.Unit" String="MiBy"/>
+        </Property>
+        <Property Name="MemoryLevel" Type="Edm.Int64" DefaultValue="1">
+          <Annotation Term="OData.Permissions" EnumMember="OData.Permission/Read"/>
+          <Annotation Term="OData.Description" String="Level of the interleave set for multi-level tiered memory."/>
+          <Annotation Term="OData.LongDescription" String="This property shall contain the level of this interleave set for multi-level tiered memory."/>
+        </Property>
+      </ComplexType>
+
+      <EnumType Name="AddressRangeType">
+        <Member Name="Volatile">
+          <Annotation Term="OData.Description" String="Volatile memory."/>
+        </Member>
+        <Member Name="PMEM">
+          <Annotation Term="OData.Description" String="Byte accessible persistent memory."/>
+        </Member>
+        <Member Name="Block">
+          <Annotation Term="OData.Description" String="Block accessible memory."/>
+        </Member>
+      </EnumType>
+
+    </Schema>
+
+    <Schema xmlns="http://docs.oasis-open.org/odata/ns/edm" Namespace="MemoryChunks.v1_0_1">
+      <Annotation Term="Redfish.OwningEntity" String="DMTF"/>
+      <Annotation Term="OData.Description" String="This version was created to show that annotations in previous namespaces were updated."/>
+      <EntityType Name="MemoryChunks" BaseType="MemoryChunks.v1_0_0.MemoryChunks"/>
+    </Schema>
+
+    <Schema xmlns="http://docs.oasis-open.org/odata/ns/edm" Namespace="MemoryChunks.v1_0_2">
+      <Annotation Term="Redfish.OwningEntity" String="DMTF"/>
+      <Annotation Term="OData.Description" String="This version was created to show that annotations in previous namespaces were updated."/>
+      <EntityType Name="MemoryChunks" BaseType="MemoryChunks.v1_0_1.MemoryChunks"/>
+    </Schema>
+
+    <Schema xmlns="http://docs.oasis-open.org/odata/ns/edm" Namespace="MemoryChunks.v1_0_3">
+      <Annotation Term="Redfish.OwningEntity" String="DMTF"/>
+      <Annotation Term="OData.Description" String="This version was created to add units annotations on various properties.  It was also created to force the regeneration of JSON Schema so that OData properties are marked as required, and integer properties are marked as integer rather than number."/>
+      <EntityType Name="MemoryChunks" BaseType="MemoryChunks.v1_0_2.MemoryChunks"/>
+    </Schema>
+
+    <Schema xmlns="http://docs.oasis-open.org/odata/ns/edm" Namespace="MemoryChunks.v1_0_4">
+      <Annotation Term="Redfish.OwningEntity" String="DMTF"/>
+      <Annotation Term="OData.Description" String="This version was created to force the regeneration of JSON Schema so that URI properties use the uri-reference format.  It was also created to add a missing term on InterleaveSets to not allow it to be null."/>
+      <EntityType Name="MemoryChunks" BaseType="MemoryChunks.v1_0_3.MemoryChunks"/>
+    </Schema>
+
+    <Schema xmlns="http://docs.oasis-open.org/odata/ns/edm" Namespace="MemoryChunks.v1_0_5">
+      <Annotation Term="Redfish.OwningEntity" String="DMTF"/>
+      <Annotation Term="OData.Description" String="This version was created to update descriptions that this schema defines."/>
+      <EntityType Name="MemoryChunks" BaseType="MemoryChunks.v1_0_4.MemoryChunks"/>
+    </Schema>
+
+    <Schema xmlns="http://docs.oasis-open.org/odata/ns/edm" Namespace="MemoryChunks.v1_0_6">
+      <Annotation Term="Redfish.OwningEntity" String="DMTF"/>
+      <Annotation Term="OData.Description" String="This version was created to correct various typographical errors."/>
+      <EntityType Name="MemoryChunks" BaseType="MemoryChunks.v1_0_5.MemoryChunks"/>
+    </Schema>
+
+    <Schema xmlns="http://docs.oasis-open.org/odata/ns/edm" Namespace="MemoryChunks.v1_0_7">
+      <Annotation Term="Redfish.OwningEntity" String="DMTF"/>
+      <Annotation Term="OData.Description" String="This version was created specify 64-bit integers in OpenAPI."/>
+      <EntityType Name="MemoryChunks" BaseType="MemoryChunks.v1_0_6.MemoryChunks"/>
+    </Schema>
+
+    <Schema xmlns="http://docs.oasis-open.org/odata/ns/edm" Namespace="MemoryChunks.v1_1_0">
+      <Annotation Term="Redfish.OwningEntity" String="DMTF"/>
+      <Annotation Term="Redfish.Release" String="2017.1"/>
+      <EntityType Name="MemoryChunks" BaseType="MemoryChunks.v1_0_2.MemoryChunks">
+        <Property Name="Actions" Type="MemoryChunks.v1_1_0.Actions" Nullable="false">
+          <Annotation Term="OData.Description" String="The available actions for this resource."/>
+          <Annotation Term="OData.LongDescription" String="This property shall contain the available actions for this resource."/>
+        </Property>
+      </EntityType>
+
+      <ComplexType Name="Actions">
+        <Annotation Term="OData.AdditionalProperties" Bool="false"/>
+        <Annotation Term="OData.Description" String="The available actions for this resource."/>
+        <Annotation Term="OData.LongDescription" String="This type shall contain the available actions for this resource."/>
+        <Property Name="Oem" Type="MemoryChunks.v1_1_0.OemActions" Nullable="false">
+          <Annotation Term="OData.Description" String="The available OEM-specific actions for this resource."/>
+          <Annotation Term="OData.LongDescription" String="This property shall contain the available OEM-specific actions for this resource."/>
+        </Property>
+      </ComplexType>
+
+      <ComplexType Name="OemActions">
+        <Annotation Term="OData.AdditionalProperties" Bool="true"/>
+        <Annotation Term="OData.Description" String="The available OEM-specific actions for this resource."/>
+        <Annotation Term="OData.LongDescription" String="This type shall contain the available OEM-specific actions for this resource."/>
+      </ComplexType>
+    </Schema>
+
+    <Schema xmlns="http://docs.oasis-open.org/odata/ns/edm" Namespace="MemoryChunks.v1_1_1">
+      <Annotation Term="Redfish.OwningEntity" String="DMTF"/>
+      <Annotation Term="OData.Description" String="This version was created to add units annotations on various properties.  It was also created to force the regeneration of JSON Schema so that OData properties are marked as required, and integer properties are marked as integer rather than number."/>
+      <EntityType Name="MemoryChunks" BaseType="MemoryChunks.v1_1_0.MemoryChunks"/>
+    </Schema>
+
+    <Schema xmlns="http://docs.oasis-open.org/odata/ns/edm" Namespace="MemoryChunks.v1_1_2">
+      <Annotation Term="Redfish.OwningEntity" String="DMTF"/>
+      <Annotation Term="OData.Description" String="This version was created to force the regeneration of JSON Schema so that URI properties use the uri-reference format.  It was also created to add a missing term on InterleaveSets to not allow it to be null."/>
+      <EntityType Name="MemoryChunks" BaseType="MemoryChunks.v1_1_1.MemoryChunks"/>
+    </Schema>
+
+    <Schema xmlns="http://docs.oasis-open.org/odata/ns/edm" Namespace="MemoryChunks.v1_1_3">
+      <Annotation Term="Redfish.OwningEntity" String="DMTF"/>
+      <Annotation Term="OData.Description" String="This version was created to update descriptions that this schema defines."/>
+      <EntityType Name="MemoryChunks" BaseType="MemoryChunks.v1_1_2.MemoryChunks"/>
+    </Schema>
+
+    <Schema xmlns="http://docs.oasis-open.org/odata/ns/edm" Namespace="MemoryChunks.v1_1_4">
+      <Annotation Term="Redfish.OwningEntity" String="DMTF"/>
+      <Annotation Term="OData.Description" String="This version was created to correct various typographical errors."/>
+      <EntityType Name="MemoryChunks" BaseType="MemoryChunks.v1_1_3.MemoryChunks"/>
+    </Schema>
+
+    <Schema xmlns="http://docs.oasis-open.org/odata/ns/edm" Namespace="MemoryChunks.v1_1_5">
+      <Annotation Term="Redfish.OwningEntity" String="DMTF"/>
+      <Annotation Term="OData.Description" String="This version was created specify 64-bit integers in OpenAPI."/>
+      <EntityType Name="MemoryChunks" BaseType="MemoryChunks.v1_1_4.MemoryChunks"/>
+    </Schema>
+
+    <Schema xmlns="http://docs.oasis-open.org/odata/ns/edm" Namespace="MemoryChunks.v1_2_0">
+      <Annotation Term="Redfish.OwningEntity" String="DMTF"/>
+      <Annotation Term="Redfish.Release" String="2017.3"/>
+      <EntityType Name="MemoryChunks" BaseType="MemoryChunks.v1_1_0.MemoryChunks">
+        <Property Name="Status" Type="Resource.Status" Nullable="false">
+          <Annotation Term="OData.Description" String="The status and health of the resource and its subordinate or dependent resources."/>
+          <Annotation Term="OData.LongDescription" String="This property shall contain any status or health properties of the resource."/>
+        </Property>
+      </EntityType>
+    </Schema>
+
+    <Schema xmlns="http://docs.oasis-open.org/odata/ns/edm" Namespace="MemoryChunks.v1_2_1">
+      <Annotation Term="Redfish.OwningEntity" String="DMTF"/>
+      <Annotation Term="OData.Description" String="This version was created to update descriptions to match the editorial style used in other Redfish schemas."/>
+      <EntityType Name="MemoryChunks" BaseType="MemoryChunks.v1_2_0.MemoryChunks"/>
+    </Schema>
+
+    <Schema xmlns="http://docs.oasis-open.org/odata/ns/edm" Namespace="MemoryChunks.v1_2_2">
+      <Annotation Term="Redfish.OwningEntity" String="DMTF"/>
+      <Annotation Term="OData.Description" String="This version was created to add units annotations on various properties.  It was also created to force the regeneration of JSON Schema so that OData properties are marked as required, and integer properties are marked as integer rather than number."/>
+      <EntityType Name="MemoryChunks" BaseType="MemoryChunks.v1_2_1.MemoryChunks"/>
+    </Schema>
+
+    <Schema xmlns="http://docs.oasis-open.org/odata/ns/edm" Namespace="MemoryChunks.v1_2_3">
+      <Annotation Term="Redfish.OwningEntity" String="DMTF"/>
+      <Annotation Term="OData.Description" String="This version was created to force the regeneration of JSON Schema so that URI properties use the uri-reference format.  It was also created to add a missing term on InterleaveSets to not allow it to be null."/>
+      <EntityType Name="MemoryChunks" BaseType="MemoryChunks.v1_2_2.MemoryChunks"/>
+    </Schema>
+
+    <Schema xmlns="http://docs.oasis-open.org/odata/ns/edm" Namespace="MemoryChunks.v1_2_4">
+      <Annotation Term="Redfish.OwningEntity" String="DMTF"/>
+      <Annotation Term="OData.Description" String="This version was created to update descriptions that this schema defines."/>
+      <EntityType Name="MemoryChunks" BaseType="MemoryChunks.v1_2_3.MemoryChunks"/>
+    </Schema>
+
+    <Schema xmlns="http://docs.oasis-open.org/odata/ns/edm" Namespace="MemoryChunks.v1_2_5">
+      <Annotation Term="Redfish.OwningEntity" String="DMTF"/>
+      <Annotation Term="OData.Description" String="This version was created to correct various typographical errors."/>
+      <EntityType Name="MemoryChunks" BaseType="MemoryChunks.v1_2_4.MemoryChunks"/>
+    </Schema>
+
+    <Schema xmlns="http://docs.oasis-open.org/odata/ns/edm" Namespace="MemoryChunks.v1_2_6">
+      <Annotation Term="Redfish.OwningEntity" String="DMTF"/>
+      <Annotation Term="OData.Description" String="This version was created specify 64-bit integers in OpenAPI."/>
+      <EntityType Name="MemoryChunks" BaseType="MemoryChunks.v1_2_5.MemoryChunks"/>
+    </Schema>
+
+    <Schema xmlns="http://docs.oasis-open.org/odata/ns/edm" Namespace="MemoryChunks.v1_3_0">
+      <Annotation Term="Redfish.OwningEntity" String="DMTF"/>
+      <Annotation Term="Redfish.Release" String="2019.4"/>
+
+      <EntityType Name="MemoryChunks" BaseType="MemoryChunks.v1_2_4.MemoryChunks">
+        <Property Name="AddressRangeOffsetMiB" Type="Edm.Int64">
+          <Annotation Term="OData.Permissions" EnumMember="OData.Permission/Read"/>
+          <Annotation Term="OData.Description" String="Offset of the memory chunk in the address range in MiB."/>
+          <Annotation Term="OData.LongDescription" String="The value of this property shall be the offset of the memory chunk in the address range in MiB."/>
+          <Annotation Term="Measures.Unit" String="MiBy"/>
+        </Property>
+         <Property Name="Links" Type="MemoryChunks.v1_3_0.Links" Nullable="false">
+          <Annotation Term="OData.Description" String="The links to other resources that are related to this resource."/>
+          <Annotation Term="OData.LongDescription" String="This property shall contain links to resources that are related to but are not contained by or subordinate to this resource."/>
+        </Property>
+      </EntityType>
+
+      <ComplexType Name="Links" BaseType="Resource.Links">
+        <Annotation Term="OData.Description" String="The links to other resources that are related to this resource."/>
+        <Annotation Term="OData.LongDescription" String="This Redfish Specification-described type shall contain links to resources that are related to but are not contained by, or subordinate to, this resource."/>
+        <NavigationProperty Name="Endpoints" Type="Collection(Endpoint.Endpoint)">
+          <Annotation Term="OData.Permissions" EnumMember="OData.Permission/Read"/>
+          <Annotation Term="OData.Description" String="An array of links to the endpoints that connect to this memory chunk."/>
+          <Annotation Term="OData.LongDescription" String="This property shall contain a link to the resources of type Endpoint with which this memory chunk is associated."/>
+          <Annotation Term="OData.AutoExpandReferences"/>
+        </NavigationProperty>
+      </ComplexType>
+    </Schema>
+
+    <Schema xmlns="http://docs.oasis-open.org/odata/ns/edm" Namespace="MemoryChunks.v1_3_1">
+      <Annotation Term="Redfish.OwningEntity" String="DMTF"/>
+      <Annotation Term="OData.Description" String="This version was created to correct various typographical errors."/>
+      <EntityType Name="MemoryChunks" BaseType="MemoryChunks.v1_3_0.MemoryChunks"/>
+    </Schema>
+
+    <Schema xmlns="http://docs.oasis-open.org/odata/ns/edm" Namespace="MemoryChunks.v1_3_2">
+      <Annotation Term="Redfish.OwningEntity" String="DMTF"/>
+      <Annotation Term="OData.Description" String="This version was created specify 64-bit integers in OpenAPI."/>
+      <EntityType Name="MemoryChunks" BaseType="MemoryChunks.v1_3_1.MemoryChunks"/>
+    </Schema>
+
+    <Schema xmlns="http://docs.oasis-open.org/odata/ns/edm" Namespace="MemoryChunks.v1_4_0">
+      <Annotation Term="Redfish.OwningEntity" String="DMTF"/>
+      <Annotation Term="Redfish.Release" String="2020.3"/>
+
+      <EntityType Name="MemoryChunks" BaseType="MemoryChunks.v1_3_1.MemoryChunks">
+        <Property Name="DisplayName" Type="Edm.String">
+          <Annotation Term="OData.Permissions" EnumMember="OData.Permission/ReadWrite"/>
+          <Annotation Term="OData.Description" String="A user-configurable string to name the memory chunk."/>
+          <Annotation Term="OData.LongDescription" String="This property shall contain a user-configurable string to name the memory chunk."/>
+        </Property>
+      </EntityType>
+    </Schema>
+
+    <Schema xmlns="http://docs.oasis-open.org/odata/ns/edm" Namespace="MemoryChunks.v1_4_1">
+      <Annotation Term="Redfish.OwningEntity" String="DMTF"/>
+      <Annotation Term="OData.Description" String="This version was created specify 64-bit integers in OpenAPI."/>
+      <EntityType Name="MemoryChunks" BaseType="MemoryChunks.v1_4_0.MemoryChunks"/>
+    </Schema>
+
+  </edmx:DataServices>
+</edmx:Edmx>

--- a/static/redfish/v1/schema/MemoryDomainCollection_v1.xml
+++ b/static/redfish/v1/schema/MemoryDomainCollection_v1.xml
@@ -1,0 +1,71 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!---->
+<!--################################################################################       -->
+<!--# Redfish Schema:  MemoryDomainCollection                                              -->
+<!--#                                                                                      -->
+<!--# For a detailed change log, see the README file contained in the DSP8010 bundle,      -->
+<!--# available at http://www.dmtf.org/standards/redfish                                   -->
+<!--# Copyright 2014-2021 DMTF.                                                            -->
+<!--# For the full DMTF copyright policy, see http://www.dmtf.org/about/policies/copyright -->
+<!--################################################################################       -->
+<!---->
+<edmx:Edmx xmlns:edmx="http://docs.oasis-open.org/odata/ns/edmx" Version="4.0">
+
+  <edmx:Reference Uri="http://docs.oasis-open.org/odata/odata/v4.0/errata03/csd01/complete/vocabularies/Org.OData.Core.V1.xml">
+    <edmx:Include Namespace="Org.OData.Core.V1" Alias="OData"/>
+  </edmx:Reference>
+  <edmx:Reference Uri="http://docs.oasis-open.org/odata/odata/v4.0/errata03/csd01/complete/vocabularies/Org.OData.Capabilities.V1.xml">
+    <edmx:Include Namespace="Org.OData.Capabilities.V1" Alias="Capabilities"/>
+  </edmx:Reference>
+  <edmx:Reference Uri="http://redfish.dmtf.org/schemas/v1/Resource_v1.xml">
+    <edmx:Include Namespace="Resource.v1_0_0"/>
+  </edmx:Reference>
+  <edmx:Reference Uri="http://redfish.dmtf.org/schemas/v1/RedfishExtensions_v1.xml">
+    <edmx:Include Namespace="RedfishExtensions.v1_0_0" Alias="Redfish"/>
+  </edmx:Reference>
+  <edmx:Reference Uri="http://redfish.dmtf.org/schemas/v1/MemoryDomain_v1.xml">
+    <edmx:Include Namespace="MemoryDomain"/>
+  </edmx:Reference>
+
+  <edmx:DataServices>
+    <Schema xmlns="http://docs.oasis-open.org/odata/ns/edm" Namespace="MemoryDomainCollection">
+      <Annotation Term="Redfish.OwningEntity" String="DMTF"/>
+
+      <EntityType Name="MemoryDomainCollection" BaseType="Resource.v1_0_0.ResourceCollection">
+        <Annotation Term="OData.Description" String="The collection of MemoryDomain Resource instances."/>
+        <Annotation Term="OData.LongDescription" String="This Resource shall represent a Resource Collection of MemoryDomain instances for a Redfish implementation."/>
+        <Annotation Term="Capabilities.InsertRestrictions">
+          <Record>
+            <PropertyValue Property="Insertable" Bool="false"/>
+          </Record>
+        </Annotation>
+        <Annotation Term="Capabilities.UpdateRestrictions">
+          <Record>
+            <PropertyValue Property="Updatable" Bool="false"/>
+          </Record>
+        </Annotation>
+        <Annotation Term="Capabilities.DeleteRestrictions">
+          <Record>
+            <PropertyValue Property="Deletable" Bool="false"/>
+          </Record>
+        </Annotation>
+        <Annotation Term="Redfish.Uris">
+          <Collection>
+            <String>/redfish/v1/Systems/{ComputerSystemId}/MemoryDomains</String>
+            <String>/redfish/v1/Chassis/{ChassisId}/MemoryDomains</String>
+            <String>/redfish/v1/CompositionService/ResourceBlocks/{ResourceBlockId}/Systems/{ComputerSystemId}/MemoryDomains</String>
+            <String>/redfish/v1/ResourceBlocks/{ResourceBlockId}/Systems/{ComputerSystemId}/MemoryDomains</String>
+          </Collection>
+        </Annotation>
+        <NavigationProperty Name="Members" Type="Collection(MemoryDomain.MemoryDomain)">
+          <Annotation Term="OData.Permissions" EnumMember="OData.Permission/Read"/>
+          <Annotation Term="OData.Description" String="The members of this collection."/>
+          <Annotation Term="OData.LongDescription" String="This property shall contain an array of links to the members of this collection."/>
+          <Annotation Term="OData.AutoExpandReferences"/>
+          <Annotation Term="Redfish.Required"/>
+        </NavigationProperty>
+      </EntityType>
+
+    </Schema>
+  </edmx:DataServices>
+</edmx:Edmx>

--- a/static/redfish/v1/schema/MemoryDomain_v1.xml
+++ b/static/redfish/v1/schema/MemoryDomain_v1.xml
@@ -1,0 +1,254 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!---->
+<!--################################################################################       -->
+<!--# Redfish Schema:  MemoryDomain v1.3.0                                                 -->
+<!--#                                                                                      -->
+<!--# For a detailed change log, see the README file contained in the DSP8010 bundle,      -->
+<!--# available at http://www.dmtf.org/standards/redfish                                   -->
+<!--# Copyright 2014-2021 DMTF.                                                            -->
+<!--# For the full DMTF copyright policy, see http://www.dmtf.org/about/policies/copyright -->
+<!--################################################################################       -->
+<!---->
+<edmx:Edmx xmlns:edmx="http://docs.oasis-open.org/odata/ns/edmx" Version="4.0">
+
+  <edmx:Reference Uri="http://docs.oasis-open.org/odata/odata/v4.0/errata03/csd01/complete/vocabularies/Org.OData.Core.V1.xml">
+    <edmx:Include Namespace="Org.OData.Core.V1" Alias="OData"/>
+  </edmx:Reference>
+  <edmx:Reference Uri="http://docs.oasis-open.org/odata/odata/v4.0/errata03/csd01/complete/vocabularies/Org.OData.Capabilities.V1.xml">
+    <edmx:Include Namespace="Org.OData.Capabilities.V1" Alias="Capabilities"/>
+  </edmx:Reference>
+  <edmx:Reference Uri="http://redfish.dmtf.org/schemas/v1/Resource_v1.xml">
+    <edmx:Include Namespace="Resource"/>
+    <edmx:Include Namespace="Resource.v1_0_0"/>
+  </edmx:Reference>
+  <edmx:Reference Uri="http://redfish.dmtf.org/schemas/v1/RedfishExtensions_v1.xml">
+    <edmx:Include Namespace="RedfishExtensions.v1_0_0" Alias="Redfish"/>
+  </edmx:Reference>
+  <edmx:Reference Uri="http://redfish.dmtf.org/schemas/v1/Memory_v1.xml">
+    <edmx:Include Namespace="Memory"/>
+  </edmx:Reference>
+  <edmx:Reference Uri="http://redfish.dmtf.org/schemas/v1/MemoryChunksCollection_v1.xml">
+    <edmx:Include Namespace="MemoryChunksCollection"/>
+  </edmx:Reference>
+  <edmx:Reference Uri="http://redfish.dmtf.org/schemas/v1/MediaController_v1.xml">
+    <edmx:Include Namespace="MediaController"/>
+  </edmx:Reference>
+
+  <edmx:DataServices>
+
+    <Schema xmlns="http://docs.oasis-open.org/odata/ns/edm" Namespace="MemoryDomain">
+      <Annotation Term="Redfish.OwningEntity" String="DMTF"/>
+
+      <EntityType Name="MemoryDomain" BaseType="Resource.v1_0_0.Resource" Abstract="true">
+        <Annotation Term="OData.Description" String="The MemoryDomain schema describes a memory domain and its configuration.  Memory domains indicate to the client which memory, or DIMMs, can be grouped together in memory chunks to represent addressable memory."/>
+        <Annotation Term="OData.LongDescription" String="This Resource shall represent memory domains in a Redfish implementation."/>
+        <Annotation Term="OData.AdditionalProperties" Bool="false"/>
+        <Annotation Term="Capabilities.InsertRestrictions">
+          <Record>
+            <PropertyValue Property="Insertable" Bool="false"/>
+          </Record>
+        </Annotation>
+        <Annotation Term="Capabilities.UpdateRestrictions">
+          <Record>
+            <PropertyValue Property="Updatable" Bool="false"/>
+          </Record>
+        </Annotation>
+        <Annotation Term="Capabilities.DeleteRestrictions">
+          <Record>
+            <PropertyValue Property="Deletable" Bool="false"/>
+          </Record>
+        </Annotation>
+        <Annotation Term="Redfish.Uris">
+          <Collection>
+            <String>/redfish/v1/Systems/{ComputerSystemId}/MemoryDomains/{MemoryDomainId}</String>
+            <String>/redfish/v1/Chassis/{ChassisId}/MemoryDomains/{MemoryDomainId}</String>
+            <String>/redfish/v1/CompositionService/ResourceBlocks/{ResourceBlockId}/Systems/{ComputerSystemId}/MemoryDomains/{MemoryDomainId}</String>
+            <String>/redfish/v1/ResourceBlocks/{ResourceBlockId}/Systems/{ComputerSystemId}/MemoryDomains/{MemoryDomainId}</String>
+          </Collection>
+        </Annotation>
+      </EntityType>
+
+    </Schema>
+
+    <Schema xmlns="http://docs.oasis-open.org/odata/ns/edm" Namespace="MemoryDomain.v1_0_0">
+      <Annotation Term="Redfish.OwningEntity" String="DMTF"/>
+      <Annotation Term="Redfish.Release" String="2016.2"/>
+
+      <EntityType Name="MemoryDomain" BaseType="MemoryDomain.MemoryDomain">
+
+        <Property Name="AllowsMemoryChunkCreation" Type="Edm.Boolean" DefaultValue="false">
+          <Annotation Term="OData.Permissions" EnumMember="OData.Permission/Read"/>
+          <Annotation Term="OData.Description" String="An indication of whether this memory domain supports the creation of memory chunks."/>
+          <Annotation Term="OData.LongDescription" String="This property shall indicate whether this memory domain supports the creation of memory chunks."/>
+        </Property>
+        <Property Name="AllowsBlockProvisioning" Type="Edm.Boolean" DefaultValue="false">
+          <Annotation Term="OData.Permissions" EnumMember="OData.Permission/Read"/>
+          <Annotation Term="OData.Description" String="An indication of whether this memory domain supports the provisioning of blocks of memory."/>
+          <Annotation Term="OData.LongDescription" String="This property shall indicate whether this memory domain supports the creation of blocks of memory."/>
+        </Property>
+        <NavigationProperty Name="MemoryChunks" Type="MemoryChunksCollection.MemoryChunksCollection" ContainsTarget="true" Nullable="false">
+          <Annotation Term="OData.Permissions" EnumMember="OData.Permission/Read"/>
+          <Annotation Term="OData.Description" String="The link to the collection of memory chunks associated with this memory domain."/>
+          <Annotation Term="OData.LongDescription" String="This property shall contain a link to a Resource Collection of type MemoryChunkCollection."/>
+          <Annotation Term="OData.AutoExpandReferences"/>
+        </NavigationProperty>
+        <Property Name="InterleavableMemorySets" Type="Collection(MemoryDomain.v1_0_0.MemorySet)" Nullable="false">
+          <Annotation Term="OData.Description" String="The interleave sets for the memory chunk."/>
+          <Annotation Term="OData.LongDescription" String="This property shall represent the interleave sets for the memory chunk."/>
+        </Property>
+      </EntityType>
+
+      <ComplexType Name="MemorySet">
+        <Annotation Term="OData.Description" String="The interleave sets for a memory chunk."/>
+        <Annotation Term="OData.LongDescription" String="This type shall represent the interleave sets for a memory chunk."/>
+        <NavigationProperty Name="MemorySet" Type="Collection(Memory.Memory)">
+          <Annotation Term="OData.Permissions" EnumMember="OData.Permission/Read"/>
+          <Annotation Term="OData.Description" String="The set of memory for a particular interleave set."/>
+          <Annotation Term="OData.LongDescription" String="The values in this array shall be links to Resources of the Memory type."/>
+          <Annotation Term="OData.AutoExpandReferences"/>
+        </NavigationProperty>
+      </ComplexType>
+
+    </Schema>
+
+    <Schema xmlns="http://docs.oasis-open.org/odata/ns/edm" Namespace="MemoryDomain.v1_0_1">
+      <Annotation Term="Redfish.OwningEntity" String="DMTF"/>
+      <Annotation Term="OData.Description" String="This version was created to show that annotations in previous namespaces were updated."/>
+      <EntityType Name="MemoryDomain" BaseType="MemoryDomain.v1_0_0.MemoryDomain"/>
+    </Schema>
+
+    <Schema xmlns="http://docs.oasis-open.org/odata/ns/edm" Namespace="MemoryDomain.v1_0_2">
+      <Annotation Term="Redfish.OwningEntity" String="DMTF"/>
+      <Annotation Term="OData.Description" String="This version was created to show that annotations in previous namespaces were updated."/>
+      <EntityType Name="MemoryDomain" BaseType="MemoryDomain.v1_0_1.MemoryDomain"/>
+    </Schema>
+
+    <Schema xmlns="http://docs.oasis-open.org/odata/ns/edm" Namespace="MemoryDomain.v1_0_3">
+      <Annotation Term="Redfish.OwningEntity" String="DMTF"/>
+      <Annotation Term="OData.Description" String="This version was created to force the regeneration of JSON Schema so that OData properties are marked as required, and integer properties are marked as integer rather than number."/>
+      <EntityType Name="MemoryDomain" BaseType="MemoryDomain.v1_0_2.MemoryDomain"/>
+    </Schema>
+
+    <Schema xmlns="http://docs.oasis-open.org/odata/ns/edm" Namespace="MemoryDomain.v1_0_4">
+      <Annotation Term="Redfish.OwningEntity" String="DMTF"/>
+      <Annotation Term="OData.Description" String="This version was created to force the regeneration of JSON Schema so that URI properties use the uri-reference format.  It was also created to add a missing term on MemoryChunks and InterleavableMemorySets to not allow them to be null."/>
+      <EntityType Name="MemoryDomain" BaseType="MemoryDomain.v1_0_3.MemoryDomain"/>
+    </Schema>
+
+    <Schema xmlns="http://docs.oasis-open.org/odata/ns/edm" Namespace="MemoryDomain.v1_0_5">
+      <Annotation Term="Redfish.OwningEntity" String="DMTF"/>
+      <Annotation Term="OData.Description" String="This version was created to update descriptions that this schema defines."/>
+      <EntityType Name="MemoryDomain" BaseType="MemoryDomain.v1_0_4.MemoryDomain"/>
+    </Schema>
+
+    <Schema xmlns="http://docs.oasis-open.org/odata/ns/edm" Namespace="MemoryDomain.v1_1_0">
+      <Annotation Term="Redfish.OwningEntity" String="DMTF"/>
+      <Annotation Term="Redfish.Release" String="2016.3"/>
+      <EntityType Name="MemoryDomain" BaseType="MemoryDomain.v1_0_1.MemoryDomain">
+        <Property Name="AllowsMirroring" Type="Edm.Boolean" DefaultValue="false">
+          <Annotation Term="OData.Permissions" EnumMember="OData.Permission/Read"/>
+          <Annotation Term="OData.Description" String="An indication of whether this memory domain supports the creation of memory chunks with mirroring enabled."/>
+          <Annotation Term="OData.LongDescription" String="This property shall indicate whether this memory domain supports the creation of memory chunks with mirroring enabled."/>
+        </Property>
+        <Property Name="AllowsSparing" Type="Edm.Boolean" DefaultValue="false">
+          <Annotation Term="OData.Permissions" EnumMember="OData.Permission/Read"/>
+          <Annotation Term="OData.Description" String="An indication of whether this memory domain supports the creation of memory chunks with sparing enabled."/>
+          <Annotation Term="OData.LongDescription" String="This property shall indicate whether this memory domain supports the creation of memory chunks with sparing enabled."/>
+        </Property>
+      </EntityType>
+    </Schema>
+
+    <Schema xmlns="http://docs.oasis-open.org/odata/ns/edm" Namespace="MemoryDomain.v1_1_1">
+      <Annotation Term="Redfish.OwningEntity" String="DMTF"/>
+      <Annotation Term="OData.Description" String="This version was created to show that annotations in previous namespaces were updated."/>
+      <EntityType Name="MemoryDomain" BaseType="MemoryDomain.v1_1_0.MemoryDomain"/>
+    </Schema>
+
+    <Schema xmlns="http://docs.oasis-open.org/odata/ns/edm" Namespace="MemoryDomain.v1_1_2">
+      <Annotation Term="Redfish.OwningEntity" String="DMTF"/>
+      <Annotation Term="OData.Description" String="This version was created to force the regeneration of JSON Schema so that OData properties are marked as required, and integer properties are marked as integer rather than number."/>
+      <EntityType Name="MemoryDomain" BaseType="MemoryDomain.v1_1_1.MemoryDomain"/>
+    </Schema>
+
+    <Schema xmlns="http://docs.oasis-open.org/odata/ns/edm" Namespace="MemoryDomain.v1_1_3">
+      <Annotation Term="Redfish.OwningEntity" String="DMTF"/>
+      <Annotation Term="OData.Description" String="This version was created to force the regeneration of JSON Schema so that URI properties use the uri-reference format.  It was also created to add a missing term on MemoryChunks and InterleavableMemorySets to not allow them to be null."/>
+      <EntityType Name="MemoryDomain" BaseType="MemoryDomain.v1_1_2.MemoryDomain"/>
+    </Schema>
+
+    <Schema xmlns="http://docs.oasis-open.org/odata/ns/edm" Namespace="MemoryDomain.v1_1_4">
+      <Annotation Term="Redfish.OwningEntity" String="DMTF"/>
+      <Annotation Term="OData.Description" String="This version was created to update descriptions that this schema defines."/>
+      <EntityType Name="MemoryDomain" BaseType="MemoryDomain.v1_1_3.MemoryDomain"/>
+    </Schema>
+
+    <Schema xmlns="http://docs.oasis-open.org/odata/ns/edm" Namespace="MemoryDomain.v1_2_0">
+      <Annotation Term="Redfish.OwningEntity" String="DMTF"/>
+      <Annotation Term="Redfish.Release" String="2017.1"/>
+      <EntityType Name="MemoryDomain" BaseType="MemoryDomain.v1_1_1.MemoryDomain">
+        <Property Name="Actions" Type="MemoryDomain.v1_2_0.Actions" Nullable="false">
+          <Annotation Term="OData.Description" String="The available actions for this Resource."/>
+          <Annotation Term="OData.LongDescription" String="This property shall contain the available actions for this Resource."/>
+        </Property>
+      </EntityType>
+
+      <ComplexType Name="Actions">
+        <Annotation Term="OData.AdditionalProperties" Bool="false"/>
+        <Annotation Term="OData.Description" String="The available actions for this Resource."/>
+        <Annotation Term="OData.LongDescription" String="This type shall contain the available actions for this Resource."/>
+        <Property Name="Oem" Type="MemoryDomain.v1_2_0.OemActions" Nullable="false">
+          <Annotation Term="OData.Description" String="The available OEM-specific actions for this Resource."/>
+          <Annotation Term="OData.LongDescription" String="This property shall contain the available OEM-specific actions for this Resource."/>
+        </Property>
+      </ComplexType>
+
+      <ComplexType Name="OemActions">
+        <Annotation Term="OData.AdditionalProperties" Bool="true"/>
+        <Annotation Term="OData.Description" String="The available OEM-specific actions for this Resource."/>
+        <Annotation Term="OData.LongDescription" String="This type shall contain the available OEM-specific actions for this Resource."/>
+      </ComplexType>
+    </Schema>
+
+    <Schema xmlns="http://docs.oasis-open.org/odata/ns/edm" Namespace="MemoryDomain.v1_2_1">
+      <Annotation Term="Redfish.OwningEntity" String="DMTF"/>
+      <Annotation Term="OData.Description" String="This version was created to force the regeneration of JSON Schema so that OData properties are marked as required, and integer properties are marked as integer rather than number."/>
+      <EntityType Name="MemoryDomain" BaseType="MemoryDomain.v1_2_0.MemoryDomain"/>
+    </Schema>
+
+    <Schema xmlns="http://docs.oasis-open.org/odata/ns/edm" Namespace="MemoryDomain.v1_2_2">
+      <Annotation Term="Redfish.OwningEntity" String="DMTF"/>
+      <Annotation Term="OData.Description" String="This version was created to force the regeneration of JSON Schema so that URI properties use the uri-reference format.  It was also created to add a missing term on MemoryChunks and InterleavableMemorySets to not allow them to be null."/>
+      <EntityType Name="MemoryDomain" BaseType="MemoryDomain.v1_2_1.MemoryDomain"/>
+    </Schema>
+
+    <Schema xmlns="http://docs.oasis-open.org/odata/ns/edm" Namespace="MemoryDomain.v1_2_3">
+      <Annotation Term="Redfish.OwningEntity" String="DMTF"/>
+      <Annotation Term="OData.Description" String="This version was created to update descriptions that this schema defines."/>
+      <EntityType Name="MemoryDomain" BaseType="MemoryDomain.v1_2_2.MemoryDomain"/>
+    </Schema>
+
+    <Schema xmlns="http://docs.oasis-open.org/odata/ns/edm" Namespace="MemoryDomain.v1_3_0">
+      <Annotation Term="Redfish.OwningEntity" String="DMTF"/>
+      <Annotation Term="Redfish.Release" String="2019.4"/>
+
+      <EntityType Name="MemoryDomain" BaseType="MemoryDomain.v1_2_3.MemoryDomain">
+        <Property Name="Links" Type="MemoryDomain.v1_3_0.Links" Nullable="false">
+          <Annotation Term="OData.Description" String="The links to other Resources that are related to this Resource."/>
+          <Annotation Term="OData.LongDescription" String="The Redfish Specification-described Links Property shall contain links to Resources related to but not subordinate to this Resource."/>
+        </Property>
+      </EntityType>
+
+      <ComplexType Name="Links" BaseType="Resource.Links">
+        <Annotation Term="OData.Description" String="The links to other Resources that are related to this Resource."/>
+        <Annotation Term="OData.LongDescription" String="The Redfish Specification-described type shall contain links to Resources related to but not subordinate to this Resource."/>
+        <NavigationProperty Name="MediaControllers" Type="Collection(MediaController.MediaController)">
+          <Annotation Term="OData.Permissions" EnumMember="OData.Permission/Read"/>
+          <Annotation Term="OData.Description" String="An array of links to the media controllers for this memory domain."/>
+          <Annotation Term="OData.LongDescription" String="This property shall contain an array of links to Resources of type MediaController that are associated with this memory domain."/>
+          <Annotation Term="OData.AutoExpandReferences"/>
+        </NavigationProperty>
+      </ComplexType>
+    </Schema>
+
+  </edmx:DataServices>
+</edmx:Edmx>

--- a/static/redfish/v1/schema/MemoryMetrics_v1.xml
+++ b/static/redfish/v1/schema/MemoryMetrics_v1.xml
@@ -1,0 +1,424 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!---->
+<!--################################################################################       -->
+<!--# Redfish Schema:  MemoryMetrics v1.4.1                                                -->
+<!--#                                                                                      -->
+<!--# For a detailed change log, see the README file contained in the DSP8010 bundle,      -->
+<!--# available at http://www.dmtf.org/standards/redfish                                   -->
+<!--# Copyright 2014-2021 DMTF.                                                            -->
+<!--# For the full DMTF copyright policy, see http://www.dmtf.org/about/policies/copyright -->
+<!--################################################################################       -->
+<!---->
+<edmx:Edmx xmlns:edmx="http://docs.oasis-open.org/odata/ns/edmx" Version="4.0">
+
+  <edmx:Reference Uri="http://docs.oasis-open.org/odata/odata/v4.0/errata03/csd01/complete/vocabularies/Org.OData.Core.V1.xml">
+    <edmx:Include Namespace="Org.OData.Core.V1" Alias="OData"/>
+  </edmx:Reference>
+  <edmx:Reference Uri="http://docs.oasis-open.org/odata/odata/v4.0/errata03/csd01/complete/vocabularies/Org.OData.Capabilities.V1.xml">
+    <edmx:Include Namespace="Org.OData.Capabilities.V1" Alias="Capabilities"/>
+  </edmx:Reference>
+  <edmx:Reference Uri="http://redfish.dmtf.org/schemas/v1/Resource_v1.xml">
+    <edmx:Include Namespace="Resource.v1_0_0"/>
+  </edmx:Reference>
+  <edmx:Reference Uri="http://redfish.dmtf.org/schemas/v1/RedfishExtensions_v1.xml">
+    <edmx:Include Namespace="RedfishExtensions.v1_0_0" Alias="Redfish"/>
+    <edmx:Include Namespace="Validation.v1_0_0" Alias="Validation"/>
+  </edmx:Reference>
+  <edmx:Reference Uri="http://docs.oasis-open.org/odata/odata/v4.0/errata03/csd01/complete/vocabularies/Org.OData.Measures.V1.xml">
+    <edmx:Include Namespace="Org.OData.Measures.V1" Alias="Measures"/>
+  </edmx:Reference>
+
+  <edmx:DataServices>
+
+    <Schema xmlns="http://docs.oasis-open.org/odata/ns/edm" Namespace="MemoryMetrics">
+      <Annotation Term="Redfish.OwningEntity" String="DMTF"/>
+
+      <EntityType Name="MemoryMetrics" BaseType="Resource.v1_0_0.Resource" Abstract="true">
+        <Annotation Term="OData.Description" String="The usage and health statistics for a memory device or system memory summary."/>
+        <Annotation Term="OData.LongDescription" String="The MemoryMetrics schema shall contain the memory metrics for a memory device or system memory summary in a Redfish implementation."/>
+        <Annotation Term="OData.AdditionalProperties" Bool="false"/>
+        <Annotation Term="Capabilities.InsertRestrictions">
+          <Record>
+            <PropertyValue Property="Insertable" Bool="false"/>
+          </Record>
+        </Annotation>
+        <Annotation Term="Capabilities.UpdateRestrictions">
+          <Record>
+            <PropertyValue Property="Updatable" Bool="false"/>
+          </Record>
+        </Annotation>
+        <Annotation Term="Capabilities.DeleteRestrictions">
+          <Record>
+            <PropertyValue Property="Deletable" Bool="false"/>
+          </Record>
+        </Annotation>
+        <Annotation Term="Redfish.Uris">
+          <Collection>
+            <String>/redfish/v1/Systems/{ComputerSystemId}/MemorySummary/MemoryMetrics</String>
+            <String>/redfish/v1/Systems/{ComputerSystemId}/Memory/{MemoryId}/MemoryMetrics</String>
+            <String>/redfish/v1/Systems/{ComputerSystemId}/Processors/{ProcessorId}/MemorySummary/MemoryMetrics</String>
+            <String>/redfish/v1/CompositionService/ResourceBlocks/{ResourceBlockId}/Memory/{MemoryId}/MemoryMetrics</String>
+            <String>/redfish/v1/CompositionService/ResourceBlocks/{ResourceBlockId}/Processors/{ProcessorId}/MemorySummary/MemoryMetrics</String>
+            <String>/redfish/v1/CompositionService/ResourceBlocks/{ResourceBlockId}/Systems/{ComputerSystemId}/Memory/{MemoryId}/MemoryMetrics</String>
+            <String>/redfish/v1/CompositionService/ResourceBlocks/{ResourceBlockId}/Systems/{ComputerSystemId}/MemorySummary/MemoryMetrics</String>
+            <String>/redfish/v1/CompositionService/ResourceBlocks/{ResourceBlockId}/Systems/{ComputerSystemId}/Processors/{ProcessorId}/MemorySummary/MemoryMetrics</String>
+            <String>/redfish/v1/ResourceBlocks/{ResourceBlockId}/Memory/{MemoryId}/MemoryMetrics</String>
+            <String>/redfish/v1/ResourceBlocks/{ResourceBlockId}/Processors/{ProcessorId}/MemorySummary/MemoryMetrics</String>
+            <String>/redfish/v1/ResourceBlocks/{ResourceBlockId}/Systems/{ComputerSystemId}/Memory/{MemoryId}/MemoryMetrics</String>
+            <String>/redfish/v1/ResourceBlocks/{ResourceBlockId}/Systems/{ComputerSystemId}/MemorySummary/MemoryMetrics</String>
+            <String>/redfish/v1/ResourceBlocks/{ResourceBlockId}/Systems/{ComputerSystemId}/Processors/{ProcessorId}/MemorySummary/MemoryMetrics</String>
+          </Collection>
+        </Annotation>
+      </EntityType>
+
+      <Action Name="ClearCurrentPeriod" IsBound="true">
+        <Parameter Name="MemoryMetrics" Type="MemoryMetrics.v1_0_0.Actions"/>
+        <Annotation Term="OData.Description" String="This action sets the CurrentPeriod property's values to 0."/>
+        <Annotation Term="OData.LongDescription" String="This action shall set the CurrentPeriod property's values to 0."/>
+      </Action>
+
+    </Schema>
+
+    <Schema xmlns="http://docs.oasis-open.org/odata/ns/edm" Namespace="MemoryMetrics.v1_0_0">
+      <Annotation Term="Redfish.OwningEntity" String="DMTF"/>
+      <Annotation Term="Redfish.Release" String="2016.1"/>
+
+      <EntityType Name="MemoryMetrics" BaseType="MemoryMetrics.MemoryMetrics">
+        <Property Name="BlockSizeBytes" Type="Edm.Int64">
+          <Annotation Term="OData.Permissions" EnumMember="OData.Permission/Read"/>
+          <Annotation Term="OData.Description" String="The block size, in bytes."/>
+          <Annotation Term="OData.LongDescription" String="This property shall contain the block size, in bytes, of all structure elements.  When this resource is subordinate to the MemorySummary object, this property is not applicable."/>
+          <Annotation Term="Measures.Unit" String="By"/>
+        </Property>
+        <Property Name="CurrentPeriod" Type="MemoryMetrics.v1_0_0.CurrentPeriod" Nullable="false">
+          <Annotation Term="OData.Description" String="The memory metrics since the last reset or ClearCurrentPeriod action."/>
+          <Annotation Term="OData.LongDescription" String="This property shall contain properties that describe the memory metrics for the current period."/>
+        </Property>
+        <Property Name="LifeTime" Type="MemoryMetrics.v1_0_0.LifeTime" Nullable="false">
+          <Annotation Term="OData.Description" String="The memory metrics for the lifetime of the memory."/>
+          <Annotation Term="OData.LongDescription" String="This property shall contain properties that describe the memory metrics for the lifetime of the memory."/>
+        </Property>
+        <Property Name="HealthData" Type="MemoryMetrics.v1_0_0.HealthData" Nullable="false">
+          <Annotation Term="OData.Description" String="The health information of the memory."/>
+          <Annotation Term="OData.LongDescription" String="This property shall contain properties that describe the health data memory metrics for the memory."/>
+        </Property>
+        <Property Name="Actions" Type="MemoryMetrics.v1_0_0.Actions" Nullable="false">
+          <Annotation Term="OData.Description" String="The available actions for this resource."/>
+          <Annotation Term="OData.LongDescription" String="This property shall contain the available actions for this resource."/>
+        </Property>
+      </EntityType>
+
+      <ComplexType Name="CurrentPeriod">
+        <Annotation Term="OData.AdditionalProperties" Bool="false"/>
+        <Annotation Term="OData.Description" String="The memory metrics since the last system reset or ClearCurrentPeriod action."/>
+        <Annotation Term="OData.LongDescription" String="This type shall describe the memory metrics since last system reset or ClearCurrentPeriod action."/>
+        <Property Name="BlocksRead" Type="Edm.Int64">
+          <Annotation Term="OData.Permissions" EnumMember="OData.Permission/Read"/>
+          <Annotation Term="OData.Description" String="The number of blocks read since reset."/>
+          <Annotation Term="OData.LongDescription" String="This property shall contain the number of blocks read since reset.  When this resource is subordinate to the MemorySummary object, this property shall be the sum of BlocksRead over all memory."/>
+        </Property>
+        <Property Name="BlocksWritten" Type="Edm.Int64">
+          <Annotation Term="OData.Permissions" EnumMember="OData.Permission/Read"/>
+          <Annotation Term="OData.Description" String="The number of blocks written since reset."/>
+          <Annotation Term="OData.LongDescription" String="This property shall contain the number of blocks written since reset.  When this resource is subordinate to the MemorySummary object, this property shall be the sum of BlocksWritten over all memory."/>
+        </Property>
+      </ComplexType>
+
+      <ComplexType Name="LifeTime">
+        <Annotation Term="OData.AdditionalProperties" Bool="false"/>
+        <Annotation Term="OData.Description" String="The memory metrics for the lifetime of the memory."/>
+        <Annotation Term="OData.LongDescription" String="This type shall describe the memory metrics since manufacturing."/>
+        <Property Name="BlocksRead" Type="Edm.Int64">
+          <Annotation Term="OData.Permissions" EnumMember="OData.Permission/Read"/>
+          <Annotation Term="OData.Description" String="The number of blocks read for the lifetime of the memory."/>
+          <Annotation Term="OData.LongDescription" String="This property shall contain the number of blocks read for the lifetime of the memory.  When this resource is subordinate to the MemorySummary object, this property shall be the sum of BlocksRead over all memory."/>
+        </Property>
+        <Property Name="BlocksWritten" Type="Edm.Int64">
+          <Annotation Term="OData.Permissions" EnumMember="OData.Permission/Read"/>
+          <Annotation Term="OData.Description" String="The number of blocks written for the lifetime of the memory."/>
+          <Annotation Term="OData.LongDescription" String="This property shall contain the number of blocks written for the lifetime of the memory.  When this resource is subordinate to the MemorySummary object, this property shall be the sum of BlocksWritten over all memory."/>
+        </Property>
+      </ComplexType>
+
+      <ComplexType Name="HealthData">
+        <Annotation Term="OData.AdditionalProperties" Bool="false"/>
+        <Annotation Term="OData.Description" String="The health information of the memory."/>
+        <Annotation Term="OData.LongDescription" String="This type shall contain properties that describe the HealthData metrics for this resource."/>
+        <Property Name="RemainingSpareBlockPercentage" Type="Edm.Decimal">
+          <Annotation Term="OData.Permissions" EnumMember="OData.Permission/Read"/>
+          <Annotation Term="OData.Description" String="The remaining spare blocks, as a percentage."/>
+          <Annotation Term="OData.LongDescription" String="This property shall contain the remaining spare blocks as a percentage.  When this resource is subordinate to the MemorySummary object, this property shall be the RemainingSpareBlockPercentage over all memory."/>
+          <Annotation Term="Measures.Unit" String="%"/>
+        </Property>
+        <Property Name="LastShutdownSuccess" Type="Edm.Boolean">
+          <Annotation Term="OData.Permissions" EnumMember="OData.Permission/Read"/>
+          <Annotation Term="OData.Description" String="An indication of whether the last shutdown succeeded."/>
+          <Annotation Term="OData.LongDescription" String="This property shall indicate whether the last shutdown succeeded."/>
+        </Property>
+        <Property Name="DataLossDetected" Type="Edm.Boolean">
+          <Annotation Term="OData.Permissions" EnumMember="OData.Permission/Read"/>
+          <Annotation Term="OData.Description" String="An indication of whether data loss was detected."/>
+          <Annotation Term="OData.LongDescription" String="This property shall indicate whether data loss was detected.  When this resource is subordinate to the MemorySummary object, this property shall indicate whether any data loss was detected in any area of memory."/>
+        </Property>
+        <Property Name="PerformanceDegraded" Type="Edm.Boolean">
+          <Annotation Term="OData.Permissions" EnumMember="OData.Permission/Read"/>
+          <Annotation Term="OData.Description" String="An indication of whether performance has degraded."/>
+          <Annotation Term="OData.LongDescription" String="This property shall indicate whether performance has degraded.  When this resource is subordinate to the MemorySummary object, this property shall indicate whether degraded performance mode status is detected in any area of memory."/>
+        </Property>
+        <Property Name="AlarmTrips" Type="MemoryMetrics.v1_0_0.AlarmTrips" Nullable="false">
+          <Annotation Term="OData.Description" String="Alarm trip information about the memory."/>
+          <Annotation Term="OData.LongDescription" String="This object shall contain properties describe the types of alarms that have been raised by the memory.  When this resource is subordinate to the MemorySummary object, this property shall indicate whether an alarm of a given type have been raised by any area of memory."/>
+        </Property>
+      </ComplexType>
+
+      <ComplexType Name="AlarmTrips">
+        <Annotation Term="OData.AdditionalProperties" Bool="false"/>
+        <Annotation Term="OData.Description" String="The alarm trip information about the memory.  These alarms are reset when the system resets.  Note that if they are re-discovered they can be reasserted."/>
+        <Annotation Term="OData.LongDescription" String="This type shall contain properties that describe the types of alarms that have been raised by the memory.  These alarms shall be reset when the system resets.  Note that if they are re-discovered they can be reasserted."/>
+        <Property Name="Temperature" Type="Edm.Boolean">
+          <Annotation Term="OData.Permissions" EnumMember="OData.Permission/Read"/>
+          <Annotation Term="OData.Description" String="An indication of whether a temperature threshold alarm trip was detected."/>
+          <Annotation Term="OData.LongDescription" String="This property shall indicates whether a temperature threshold alarm trip was detected."/>
+        </Property>
+        <Property Name="SpareBlock" Type="Edm.Boolean">
+          <Annotation Term="OData.Permissions" EnumMember="OData.Permission/Read"/>
+          <Annotation Term="OData.Description" String="An indication of whether the spare block capacity crossing alarm trip was detected."/>
+          <Annotation Term="OData.LongDescription" String="This property shall indicate whether the spare block capacity crossing alarm trip was detected."/>
+        </Property>
+        <Property Name="UncorrectableECCError" Type="Edm.Boolean">
+          <Annotation Term="OData.Permissions" EnumMember="OData.Permission/Read"/>
+          <Annotation Term="OData.Description" String="An indication of whether the uncorrectable error threshold alarm trip was detected."/>
+          <Annotation Term="OData.LongDescription" String="This property shall indicate whether the uncorrectable error threshold alarm trip was detected."/>
+        </Property>
+        <Property Name="CorrectableECCError" Type="Edm.Boolean">
+          <Annotation Term="OData.Permissions" EnumMember="OData.Permission/Read"/>
+          <Annotation Term="OData.Description" String="An indication of whether the correctable error threshold crossing alarm trip was detected."/>
+          <Annotation Term="OData.LongDescription" String="This property shall indicate whether the correctable error threshold crossing alarm trip was detected."/>
+        </Property>
+        <Property Name="AddressParityError" Type="Edm.Boolean">
+          <Annotation Term="OData.Permissions" EnumMember="OData.Permission/Read"/>
+          <Annotation Term="OData.Description" String="An indication of whether an address parity error was detected that a retry could not correct."/>
+          <Annotation Term="OData.LongDescription" String="This property shall indicate whether an address parity error was detected that a retry could not correct."/>
+        </Property>
+      </ComplexType>
+
+      <ComplexType Name="Actions">
+        <Annotation Term="OData.AdditionalProperties" Bool="false"/>
+        <Annotation Term="OData.Description" String="The available actions for this resource."/>
+        <Annotation Term="OData.LongDescription" String="This type shall contain the available actions for this resource."/>
+        <Property Name="Oem" Type="MemoryMetrics.v1_0_0.OemActions" Nullable="false">
+          <Annotation Term="OData.Description" String="The available OEM-specific actions for this resource."/>
+          <Annotation Term="OData.LongDescription" String="This property shall contain the available OEM-specific actions for this resource."/>
+        </Property>
+      </ComplexType>
+
+      <ComplexType Name="OemActions">
+        <Annotation Term="OData.AdditionalProperties" Bool="true"/>
+        <Annotation Term="OData.Description" String="The available OEM-specific actions for this resource."/>
+        <Annotation Term="OData.LongDescription" String="This type shall contain the available OEM-specific actions for this resource."/>
+      </ComplexType>
+
+    </Schema>
+
+    <Schema xmlns="http://docs.oasis-open.org/odata/ns/edm" Namespace="MemoryMetrics.v1_0_1">
+      <Annotation Term="Redfish.OwningEntity" String="DMTF"/>
+      <Annotation Term="OData.Description" String="This version was created to show that annotations in previous namespaces were updated."/>
+      <EntityType Name="MemoryMetrics" BaseType="MemoryMetrics.v1_0_0.MemoryMetrics"/>
+    </Schema>
+
+    <Schema xmlns="http://docs.oasis-open.org/odata/ns/edm" Namespace="MemoryMetrics.v1_0_2">
+      <Annotation Term="Redfish.OwningEntity" String="DMTF"/>
+      <Annotation Term="OData.Description" String="This version was created to show BlocksWritten in CurrentPeriod and LifeTime ComplexTypes, and to update annotations in earlier versions of namespaces."/>
+      <EntityType Name="MemoryMetrics" BaseType="MemoryMetrics.v1_0_1.MemoryMetrics"/>
+    </Schema>
+
+    <Schema xmlns="http://docs.oasis-open.org/odata/ns/edm" Namespace="MemoryMetrics.v1_0_3">
+      <Annotation Term="Redfish.OwningEntity" String="DMTF"/>
+      <Annotation Term="OData.Description" String="This version shows that AlarmTrips was modified to add semantics about AlarmTrips resets upon system reset."/>
+      <EntityType Name="MemoryMetrics" BaseType="MemoryMetrics.v1_0_2.MemoryMetrics"/>
+    </Schema>
+
+    <Schema xmlns="http://docs.oasis-open.org/odata/ns/edm" Namespace="MemoryMetrics.v1_0_4">
+      <Annotation Term="Redfish.OwningEntity" String="DMTF"/>
+      <Annotation Term="OData.Description" String="This version was created to force the regeneration of JSON Schema so that OData properties are marked as required, and integer properties are marked as integer rather than number.  It was also created to add missing percent units onto existing properties."/>
+      <EntityType Name="MemoryMetrics" BaseType="MemoryMetrics.v1_0_3.MemoryMetrics"/>
+    </Schema>
+
+    <Schema xmlns="http://docs.oasis-open.org/odata/ns/edm" Namespace="MemoryMetrics.v1_0_5">
+      <Annotation Term="Redfish.OwningEntity" String="DMTF"/>
+      <Annotation Term="OData.Description" String="This version was created to force the regeneration of JSON Schema so that URI properties use the uri-reference format."/>
+      <EntityType Name="MemoryMetrics" BaseType="MemoryMetrics.v1_0_4.MemoryMetrics"/>
+    </Schema>
+
+    <Schema xmlns="http://docs.oasis-open.org/odata/ns/edm" Namespace="MemoryMetrics.v1_0_6">
+      <Annotation Term="Redfish.OwningEntity" String="DMTF"/>
+      <Annotation Term="OData.Description" String="This version was created to update descriptions to give guidance to the usage of certain properties when the metrics is used for a summary of all memory in a system.  It was also created to update descriptions that this schema defines."/>
+      <EntityType Name="MemoryMetrics" BaseType="MemoryMetrics.v1_0_5.MemoryMetrics"/>
+    </Schema>
+
+    <Schema xmlns="http://docs.oasis-open.org/odata/ns/edm" Namespace="MemoryMetrics.v1_0_7">
+      <Annotation Term="Redfish.OwningEntity" String="DMTF"/>
+      <Annotation Term="OData.Description" String="This version was created to update description HealthData to allow for usage when this resource is subordinate to the MemorySummary object."/>
+      <EntityType Name="MemoryMetrics" BaseType="MemoryMetrics.v1_0_6.MemoryMetrics"/>
+    </Schema>
+
+    <Schema xmlns="http://docs.oasis-open.org/odata/ns/edm" Namespace="MemoryMetrics.v1_0_8">
+      <Annotation Term="Redfish.OwningEntity" String="DMTF"/>
+      <Annotation Term="OData.Description" String="This version was created to fix typos in descriptions and long descriptions."/>
+      <EntityType Name="MemoryMetrics" BaseType="MemoryMetrics.v1_0_7.MemoryMetrics"/>
+    </Schema>
+
+    <Schema xmlns="http://docs.oasis-open.org/odata/ns/edm" Namespace="MemoryMetrics.v1_1_0">
+      <Annotation Term="Redfish.OwningEntity" String="DMTF"/>
+      <Annotation Term="Redfish.Release" String="2016.2"/>
+      <EntityType Name="MemoryMetrics" BaseType="MemoryMetrics.v1_0_0.MemoryMetrics"/>
+
+      <ComplexType Name="HealthData" BaseType="MemoryMetrics.v1_0_0.HealthData">
+        <Property Name="PredictedMediaLifeLeftPercent" Type="Edm.Decimal">
+          <Annotation Term="OData.Permissions" EnumMember="OData.Permission/Read"/>
+          <Annotation Term="OData.Description" String="The percentage of reads and writes that are predicted to still be available for the media."/>
+          <Annotation Term="OData.LongDescription" String="This property shall contain an indicator of the percentage of life remaining in the media."/>
+          <Annotation Term="Measures.Unit" String="%"/>
+        </Property>
+      </ComplexType>
+    </Schema>
+
+    <Schema xmlns="http://docs.oasis-open.org/odata/ns/edm" Namespace="MemoryMetrics.v1_1_1">
+      <Annotation Term="Redfish.OwningEntity" String="DMTF"/>
+      <Annotation Term="OData.Description" String="This version was created to show that annotations in previous namespaces were updated."/>
+      <EntityType Name="MemoryMetrics" BaseType="MemoryMetrics.v1_1_0.MemoryMetrics"/>
+    </Schema>
+
+    <Schema xmlns="http://docs.oasis-open.org/odata/ns/edm" Namespace="MemoryMetrics.v1_1_2">
+      <Annotation Term="Redfish.OwningEntity" String="DMTF"/>
+      <Annotation Term="OData.Description" String="This version was created to show BlocksWritten in CurrentPeriod and LifeTime ComplexTypes, and to update annotations in earlier versions of namespaces."/>
+      <EntityType Name="MemoryMetrics" BaseType="MemoryMetrics.v1_1_1.MemoryMetrics"/>
+    </Schema>
+
+    <Schema xmlns="http://docs.oasis-open.org/odata/ns/edm" Namespace="MemoryMetrics.v1_1_3">
+      <Annotation Term="Redfish.OwningEntity" String="DMTF"/>
+      <Annotation Term="OData.Description" String="This version shows that AlarmTrips was modified to add semantics about AlarmTrips resets upon system reset."/>
+      <EntityType Name="MemoryMetrics" BaseType="MemoryMetrics.v1_1_2.MemoryMetrics"/>
+    </Schema>
+
+    <Schema xmlns="http://docs.oasis-open.org/odata/ns/edm" Namespace="MemoryMetrics.v1_1_4">
+      <Annotation Term="Redfish.OwningEntity" String="DMTF"/>
+      <Annotation Term="OData.Description" String="This version was created to force the regeneration of JSON Schema so that OData properties are marked as required, and integer properties are marked as integer rather than number.  It was also created to add missing percent units onto existing properties."/>
+      <EntityType Name="MemoryMetrics" BaseType="MemoryMetrics.v1_1_3.MemoryMetrics"/>
+    </Schema>
+
+    <Schema xmlns="http://docs.oasis-open.org/odata/ns/edm" Namespace="MemoryMetrics.v1_1_5">
+      <Annotation Term="Redfish.OwningEntity" String="DMTF"/>
+      <Annotation Term="OData.Description" String="This version was created to force the regeneration of JSON Schema so that URI properties use the uri-reference format."/>
+      <EntityType Name="MemoryMetrics" BaseType="MemoryMetrics.v1_1_4.MemoryMetrics"/>
+    </Schema>
+
+    <Schema xmlns="http://docs.oasis-open.org/odata/ns/edm" Namespace="MemoryMetrics.v1_1_6">
+      <Annotation Term="Redfish.OwningEntity" String="DMTF"/>
+      <Annotation Term="OData.Description" String="This version was created to update descriptions to give guidance to the usage of certain properties when the metrics is used for a summary of all memory in a system.  It was also created to update descriptions that this schema defines."/>
+      <EntityType Name="MemoryMetrics" BaseType="MemoryMetrics.v1_1_5.MemoryMetrics"/>
+    </Schema>
+
+    <Schema xmlns="http://docs.oasis-open.org/odata/ns/edm" Namespace="MemoryMetrics.v1_1_7">
+      <Annotation Term="Redfish.OwningEntity" String="DMTF"/>
+      <Annotation Term="OData.Description" String="This version was created to update description HealthData to allow for usage when this resource is subordinate to the MemorySummary object."/>
+      <EntityType Name="MemoryMetrics" BaseType="MemoryMetrics.v1_1_6.MemoryMetrics"/>
+    </Schema>
+
+    <Schema xmlns="http://docs.oasis-open.org/odata/ns/edm" Namespace="MemoryMetrics.v1_1_8">
+      <Annotation Term="Redfish.OwningEntity" String="DMTF"/>
+      <Annotation Term="OData.Description" String="This version was created to fix typos in descriptions and long descriptions."/>
+      <EntityType Name="MemoryMetrics" BaseType="MemoryMetrics.v1_1_7.MemoryMetrics"/>
+    </Schema>
+
+    <Schema xmlns="http://docs.oasis-open.org/odata/ns/edm" Namespace="MemoryMetrics.v1_2_0">
+      <Annotation Term="Redfish.OwningEntity" String="DMTF"/>
+      <Annotation Term="Redfish.Release" String="2019.2"/>
+      <Annotation Term="OData.Description" String="This version was created to add the BandwidthPercent property.  It was also created to update property descriptions for cases when the metrics are used in a summary of all memory in a system."/>
+
+      <EntityType Name="MemoryMetrics" BaseType="MemoryMetrics.v1_1_6.MemoryMetrics">
+        <Property Name="BandwidthPercent" Type="Edm.Decimal">
+          <Annotation Term="OData.Permissions" EnumMember="OData.Permission/Read"/>
+          <Annotation Term="OData.Description" String="The memory bandwidth utilization as a percentage."/>
+          <Annotation Term="OData.LongDescription" String="This property shall contain memory bandwidth utilization as a percentage.  When this resource is subordinate to the MemorySummary object, this property shall be the memory bandwidth utilization over all memory as a percentage."/>
+          <Annotation Term="Validation.Minimum" Int="0"/>
+          <Annotation Term="Measures.Unit" String="%"/>
+        </Property>
+      </EntityType>
+    </Schema>
+
+    <Schema xmlns="http://docs.oasis-open.org/odata/ns/edm" Namespace="MemoryMetrics.v1_2_1">
+      <Annotation Term="Redfish.OwningEntity" String="DMTF"/>
+      <Annotation Term="OData.Description" String="This version was created to update description HealthData to allow for usage when this resource is subordinate to the MemorySummary object."/>
+      <EntityType Name="MemoryMetrics" BaseType="MemoryMetrics.v1_2_0.MemoryMetrics"/>
+    </Schema>
+
+    <Schema xmlns="http://docs.oasis-open.org/odata/ns/edm" Namespace="MemoryMetrics.v1_2_2">
+      <Annotation Term="Redfish.OwningEntity" String="DMTF"/>
+      <Annotation Term="OData.Description" String="This version was created to fix typos in descriptions and long descriptions."/>
+      <EntityType Name="MemoryMetrics" BaseType="MemoryMetrics.v1_2_1.MemoryMetrics"/>
+    </Schema>
+
+    <Schema xmlns="http://docs.oasis-open.org/odata/ns/edm" Namespace="MemoryMetrics.v1_3_0">
+      <Annotation Term="Redfish.OwningEntity" String="DMTF"/>
+      <Annotation Term="Redfish.Release" String="2020.1"/>
+      <Annotation Term="OData.Description" String="This version was created to add OperatingSpeedMHz property."/>
+
+      <EntityType Name="MemoryMetrics" BaseType="MemoryMetrics.v1_2_1.MemoryMetrics">
+        <Property Name="OperatingSpeedMHz" Type="Edm.Int64">
+          <Annotation Term="OData.Permissions" EnumMember="OData.Permission/Read"/>
+          <Annotation Term="OData.Description" String="Operating speed of memory in MHz or MT/s as appropriate."/>
+          <Annotation Term="OData.LongDescription" String="This property shall contain the operating speed of memory in MHz or MT/s (mega-transfers per second) as reported by the memory device.  Memory devices that operate at their bus speed shall report the operating speed in MHz (bus speed), while memory devices that transfer data faster than their bus speed, such as DDR memory, shall report the operating speed in MT/s (mega-transfers/second).  The reported value shall match the conventionally reported values for the technology used by the memory device."/>
+          <Annotation Term="Measures.Unit" String="MHz"/>
+        </Property>
+      </EntityType>
+    </Schema>
+
+    <Schema xmlns="http://docs.oasis-open.org/odata/ns/edm" Namespace="MemoryMetrics.v1_3_1">
+      <Annotation Term="Redfish.OwningEntity" String="DMTF"/>
+      <Annotation Term="OData.Description" String="This version was created to fix typos in descriptions and long descriptions."/>
+      <EntityType Name="MemoryMetrics" BaseType="MemoryMetrics.v1_3_0.MemoryMetrics"/>
+    </Schema>
+
+    <Schema xmlns="http://docs.oasis-open.org/odata/ns/edm" Namespace="MemoryMetrics.v1_4_0">
+      <Annotation Term="Redfish.OwningEntity" String="DMTF"/>
+      <Annotation Term="Redfish.Release" String="2020.3"/>
+      <Annotation Term="OData.Description" String="This version was created to add CorrectableECCErrorCount and UncorrectableECCErrorCount properties for CurrentPeriod and LifeTime of the memory."/>
+
+      <EntityType Name="MemoryMetrics" BaseType="MemoryMetrics.v1_3_0.MemoryMetrics"/>
+
+      <ComplexType Name="CurrentPeriod" BaseType="MemoryMetrics.v1_0_0.CurrentPeriod">
+        <Property Name="CorrectableECCErrorCount" Type="Edm.Int64">
+          <Annotation Term="OData.Permissions" EnumMember="OData.Permission/Read"/>
+          <Annotation Term="OData.Description" String="The number of the correctable errors since reset."/>
+          <Annotation Term="OData.LongDescription" String="This property shall contain the number of correctable errors since reset.  When this resource is subordinate to the MemorySummary object, this property shall be the sum of CorrectableECCErrorCount over all memory."/>
+        </Property>
+        <Property Name="UncorrectableECCErrorCount" Type="Edm.Int64">
+          <Annotation Term="OData.Permissions" EnumMember="OData.Permission/Read"/>
+          <Annotation Term="OData.Description" String="The number of the uncorrectable errors since reset."/>
+          <Annotation Term="OData.LongDescription" String="This property shall contain the number of uncorrectable errors since reset.  When this resource is subordinate to the MemorySummary object, this property shall be the sum of UncorrectableECCErrorCount over all memory."/>
+        </Property>
+      </ComplexType>
+
+      <ComplexType Name="LifeTime" BaseType="MemoryMetrics.v1_0_0.LifeTime">
+        <Property Name="CorrectableECCErrorCount" Type="Edm.Int64">
+          <Annotation Term="OData.Permissions" EnumMember="OData.Permission/Read"/>
+          <Annotation Term="OData.Description" String="The number of the correctable errors for the lifetime of the memory."/>
+          <Annotation Term="OData.LongDescription" String="This property shall contain the number of the correctable errors for the lifetime of the memory.  When this resource is subordinate to the MemorySummary object, this property shall be the sum of CorrectableECCErrorCount over all memory."/>
+        </Property>
+        <Property Name="UncorrectableECCErrorCount" Type="Edm.Int64">
+          <Annotation Term="OData.Permissions" EnumMember="OData.Permission/Read"/>
+          <Annotation Term="OData.Description" String="The number of the uncorrectable errors for the lifetime of the memory."/>
+          <Annotation Term="OData.LongDescription" String="This property shall contain the number of the uncorrectable errors for the lifetime of the memory.  When this resource is subordinate to the MemorySummary object, this property shall be the sum of UncorrectableECCErrorCount over all memory."/>
+        </Property>
+      </ComplexType>
+    </Schema>
+
+    <Schema xmlns="http://docs.oasis-open.org/odata/ns/edm" Namespace="MemoryMetrics.v1_4_1">
+      <Annotation Term="Redfish.OwningEntity" String="DMTF"/>
+      <Annotation Term="OData.Description" String="This version was created to fix typos in descriptions and long descriptions."/>
+      <EntityType Name="MemoryMetrics" BaseType="MemoryMetrics.v1_4_0.MemoryMetrics"/>
+    </Schema>
+
+  </edmx:DataServices>
+</edmx:Edmx>

--- a/static/redfish/v1/schema/NetworkAdapterCollection_v1.xml
+++ b/static/redfish/v1/schema/NetworkAdapterCollection_v1.xml
@@ -1,0 +1,69 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!---->
+<!--################################################################################       -->
+<!--# Redfish Schema:  NetworkAdapterCollection                                            -->
+<!--#                                                                                      -->
+<!--# For a detailed change log, see the README file contained in the DSP8010 bundle,      -->
+<!--# available at http://www.dmtf.org/standards/redfish                                   -->
+<!--# Copyright 2014-2021 DMTF.                                                            -->
+<!--# For the full DMTF copyright policy, see http://www.dmtf.org/about/policies/copyright -->
+<!--################################################################################       -->
+<!---->
+<edmx:Edmx xmlns:edmx="http://docs.oasis-open.org/odata/ns/edmx" Version="4.0">
+
+  <edmx:Reference Uri="http://docs.oasis-open.org/odata/odata/v4.0/errata03/csd01/complete/vocabularies/Org.OData.Core.V1.xml">
+    <edmx:Include Namespace="Org.OData.Core.V1" Alias="OData"/>
+  </edmx:Reference>
+  <edmx:Reference Uri="http://docs.oasis-open.org/odata/odata/v4.0/errata03/csd01/complete/vocabularies/Org.OData.Capabilities.V1.xml">
+    <edmx:Include Namespace="Org.OData.Capabilities.V1" Alias="Capabilities"/>
+  </edmx:Reference>
+  <edmx:Reference Uri="http://redfish.dmtf.org/schemas/v1/Resource_v1.xml">
+    <edmx:Include Namespace="Resource.v1_0_0"/>
+  </edmx:Reference>
+  <edmx:Reference Uri="http://redfish.dmtf.org/schemas/v1/RedfishExtensions_v1.xml">
+    <edmx:Include Namespace="RedfishExtensions.v1_0_0" Alias="Redfish"/>
+  </edmx:Reference>
+  <edmx:Reference Uri="http://redfish.dmtf.org/schemas/v1/NetworkAdapter_v1.xml">
+    <edmx:Include Namespace="NetworkAdapter"/>
+  </edmx:Reference>
+
+  <edmx:DataServices>
+
+    <Schema xmlns="http://docs.oasis-open.org/odata/ns/edm" Namespace="NetworkAdapterCollection">
+      <Annotation Term="Redfish.OwningEntity" String="DMTF"/>
+
+      <EntityType Name="NetworkAdapterCollection" BaseType="Resource.v1_0_0.ResourceCollection">
+        <Annotation Term="OData.Description" String="The collection of NetworkAdapter resource instances."/>
+        <Annotation Term="OData.LongDescription" String="This resource shall represent a resource collection of NetworkAdapter instances for a Redfish implementation."/>
+        <Annotation Term="Capabilities.InsertRestrictions">
+          <Record>
+            <PropertyValue Property="Insertable" Bool="false"/>
+          </Record>
+        </Annotation>
+        <Annotation Term="Capabilities.UpdateRestrictions">
+          <Record>
+            <PropertyValue Property="Updatable" Bool="false"/>
+          </Record>
+        </Annotation>
+        <Annotation Term="Capabilities.DeleteRestrictions">
+          <Record>
+            <PropertyValue Property="Deletable" Bool="false"/>
+          </Record>
+        </Annotation>
+        <Annotation Term="Redfish.Uris">
+          <Collection>
+            <String>/redfish/v1/Chassis/{ChassisId}/NetworkAdapters</String>
+          </Collection>
+        </Annotation>
+        <NavigationProperty Name="Members" Type="Collection(NetworkAdapter.NetworkAdapter)">
+          <Annotation Term="OData.Permissions" EnumMember="OData.Permission/Read"/>
+          <Annotation Term="OData.Description" String="The members of this collection."/>
+          <Annotation Term="OData.LongDescription" String="This property shall contain an array of links to the members of this collection."/>
+          <Annotation Term="OData.AutoExpandReferences"/>
+          <Annotation Term="Redfish.Required"/>
+        </NavigationProperty>
+      </EntityType>
+    </Schema>
+
+  </edmx:DataServices>
+</edmx:Edmx>

--- a/static/redfish/v1/schema/NetworkAdapterMetrics_v1.xml
+++ b/static/redfish/v1/schema/NetworkAdapterMetrics_v1.xml
@@ -1,0 +1,167 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!---->
+<!--################################################################################       -->
+<!--# Redfish Schema:  NetworkAdapterMetrics v1.0.0                                        -->
+<!--#                                                                                      -->
+<!--# For a detailed change log, see the README file contained in the DSP8010 bundle,      -->
+<!--# available at http://www.dmtf.org/standards/redfish                                   -->
+<!--# Copyright 2014-2021 DMTF.                                                            -->
+<!--# For the full DMTF copyright policy, see http://www.dmtf.org/about/policies/copyright -->
+<!--################################################################################       -->
+<!---->
+<edmx:Edmx xmlns:edmx="http://docs.oasis-open.org/odata/ns/edmx" Version="4.0">
+
+  <edmx:Reference Uri="http://docs.oasis-open.org/odata/odata/v4.0/errata03/csd01/complete/vocabularies/Org.OData.Core.V1.xml">
+    <edmx:Include Namespace="Org.OData.Core.V1" Alias="OData"/>
+  </edmx:Reference>
+  <edmx:Reference Uri="http://docs.oasis-open.org/odata/odata/v4.0/errata03/csd01/complete/vocabularies/Org.OData.Capabilities.V1.xml">
+    <edmx:Include Namespace="Org.OData.Capabilities.V1" Alias="Capabilities"/>
+  </edmx:Reference>
+  <edmx:Reference Uri="http://docs.oasis-open.org/odata/odata/v4.0/errata03/csd01/complete/vocabularies/Org.OData.Measures.V1.xml">
+    <edmx:Include Namespace="Org.OData.Measures.V1" Alias="Measures"/>
+  </edmx:Reference>
+  <edmx:Reference Uri="http://redfish.dmtf.org/schemas/v1/RedfishExtensions_v1.xml">
+    <edmx:Include Namespace="RedfishExtensions.v1_0_0" Alias="Redfish"/>
+    <edmx:Include Namespace="Validation.v1_0_0" Alias="Validation"/>
+  </edmx:Reference>
+  <edmx:Reference Uri="http://redfish.dmtf.org/schemas/v1/Resource_v1.xml">
+    <edmx:Include Namespace="Resource.v1_0_0"/>
+  </edmx:Reference>
+
+  <edmx:DataServices>
+
+    <Schema xmlns="http://docs.oasis-open.org/odata/ns/edm" Namespace="NetworkAdapterMetrics">
+      <Annotation Term="Redfish.OwningEntity" String="DMTF"/>
+
+      <EntityType Name="NetworkAdapterMetrics" BaseType="Resource.v1_0_0.Resource" Abstract="true">
+        <Annotation Term="OData.Description" String="The NetworkAdapterMetrics schema contains usage and health statistics for a network adapter."/>
+        <Annotation Term="OData.LongDescription" String="This resource shall represent the network metrics for a single network adapter in a Redfish implementation."/>
+        <Annotation Term="OData.AdditionalProperties" Bool="false"/>
+        <Annotation Term="Capabilities.InsertRestrictions">
+          <Record>
+            <PropertyValue Property="Insertable" Bool="false"/>
+          </Record>
+        </Annotation>
+        <Annotation Term="Capabilities.UpdateRestrictions">
+          <Record>
+            <PropertyValue Property="Updatable" Bool="false"/>
+          </Record>
+        </Annotation>
+        <Annotation Term="Capabilities.DeleteRestrictions">
+          <Record>
+            <PropertyValue Property="Deletable" Bool="false"/>
+          </Record>
+        </Annotation>
+        <Annotation Term="Redfish.Uris">
+          <Collection>
+            <String>/redfish/v1/Chassis/{ChassisId}/NetworkAdapters/{NetworkAdapterId}/Metrics</String>
+          </Collection>
+        </Annotation>
+      </EntityType>
+    </Schema>
+
+    <Schema xmlns="http://docs.oasis-open.org/odata/ns/edm" Namespace="NetworkAdapterMetrics.v1_0_0">
+      <Annotation Term="Redfish.OwningEntity" String="DMTF"/>
+      <Annotation Term="Redfish.Release" String="2021.1"/>
+
+      <EntityType Name="NetworkAdapterMetrics" BaseType="NetworkAdapterMetrics.NetworkAdapterMetrics">
+        <Property Name="HostBusRXPercent" Type="Edm.Decimal">
+          <Annotation Term="OData.Permissions" EnumMember="OData.Permission/Read"/>
+          <Annotation Term="OData.Description" String="The host bus, such as PCIe, RX utilization as a percentage."/>
+          <Annotation Term="OData.LongDescription" String="This property shall contain the host bus, such as PCIe, RX utilization as a percentage, which is calculated by dividing the total bytes received by the theoretical max."/>
+          <Annotation Term="Validation.Minimum" Int="0"/>
+          <Annotation Term="Measures.Unit" String="%"/>
+        </Property>
+        <Property Name="HostBusTXPercent" Type="Edm.Decimal">
+          <Annotation Term="OData.Permissions" EnumMember="OData.Permission/Read"/>
+          <Annotation Term="OData.Description" String="The host bus, such as PCIe, TX utilization as a percentage."/>
+          <Annotation Term="OData.LongDescription" String="This property shall contain the host bus, such as PCIe, TX utilization as a percentage, which is calculated by dividing the total bytes transmitted by the theoretical max."/>
+          <Annotation Term="Validation.Minimum" Int="0"/>
+          <Annotation Term="Measures.Unit" String="%"/>
+        </Property>
+        <Property Name="CPUCorePercent" Type="Edm.Decimal">
+          <Annotation Term="OData.Permissions" EnumMember="OData.Permission/Read"/>
+          <Annotation Term="OData.Description" String="The device CPU core utilization as a percentage."/>
+          <Annotation Term="OData.LongDescription" String="This property shall contain the device CPU core utilization as a percentage."/>
+          <Annotation Term="Validation.Minimum" Int="0"/>
+          <Annotation Term="Measures.Unit" String="%"/>
+        </Property>
+        <Property Name="NCSIRXFrames" Type="Edm.Int64">
+          <Annotation Term="OData.Permissions" EnumMember="OData.Permission/Read"/>
+          <Annotation Term="OData.Description" String="The total number of NC-SI frames received since reset."/>
+          <Annotation Term="OData.LongDescription" String="This property shall contain the total number of NC-SI frames received since reset, including both passthrough and non-passthrough traffic."/>
+        </Property>
+        <Property Name="NCSITXFrames" Type="Edm.Int64">
+          <Annotation Term="OData.Permissions" EnumMember="OData.Permission/Read"/>
+          <Annotation Term="OData.Description" String="The total number of NC-SI frames sent since reset."/>
+          <Annotation Term="OData.LongDescription" String="This property shall contain the total number of NC-SI frames sent since reset, including both passthrough and non-passthrough traffic."/>
+        </Property>
+        <Property Name="NCSIRXBytes" Type="Edm.Int64">
+          <Annotation Term="OData.Permissions" EnumMember="OData.Permission/Read"/>
+          <Annotation Term="OData.Description" String="The total number of NC-SI bytes received since reset."/>
+          <Annotation Term="OData.LongDescription" String="This property shall contain the total number of NC-SI bytes received since reset, including both passthrough and non-passthrough traffic."/>
+          <Annotation Term="Measures.Unit" String="By"/>
+        </Property>
+        <Property Name="NCSITXBytes" Type="Edm.Int64">
+          <Annotation Term="OData.Permissions" EnumMember="OData.Permission/Read"/>
+          <Annotation Term="OData.Description" String="The total number of NC-SI bytes sent since reset."/>
+          <Annotation Term="OData.LongDescription" String="This property shall contain the total number of NC-SI bytes sent since reset, including both passthrough and non-passthrough traffic."/>
+          <Annotation Term="Measures.Unit" String="By"/>
+        </Property>
+        <Property Name="RXBytes" Type="Edm.Int64">
+          <Annotation Term="OData.Permissions" EnumMember="OData.Permission/Read"/>
+          <Annotation Term="OData.Description" String="The total number of bytes received since reset."/>
+          <Annotation Term="OData.LongDescription" String="This property shall contain the total number of bytes received since reset, including host and remote management passthrough traffic, and inclusive of all protocol overhead."/>
+          <Annotation Term="Measures.Unit" String="By"/>
+        </Property>
+        <Property Name="RXMulticastFrames" Type="Edm.Int64">
+          <Annotation Term="OData.Permissions" EnumMember="OData.Permission/Read"/>
+          <Annotation Term="OData.Description" String="The total number of good multicast frames received since reset."/>
+          <Annotation Term="OData.LongDescription" String="This property shall contain the total number of good multicast frames received since reset."/>
+        </Property>
+        <Property Name="RXUnicastFrames" Type="Edm.Int64">
+          <Annotation Term="OData.Permissions" EnumMember="OData.Permission/Read"/>
+          <Annotation Term="OData.Description" String="The total number of good unicast frames received since reset."/>
+          <Annotation Term="OData.LongDescription" String="This property shall contain the total number of good unicast frames received since reset."/>
+        </Property>
+        <Property Name="TXBytes" Type="Edm.Int64">
+          <Annotation Term="OData.Permissions" EnumMember="OData.Permission/Read"/>
+          <Annotation Term="OData.Description" String="The total number of bytes transmitted since reset."/>
+          <Annotation Term="OData.LongDescription" String="This property shall contain the total number of bytes transmitted since reset, including host and remote management passthrough traffic, and inclusive of all protocol overhead."/>
+          <Annotation Term="Measures.Unit" String="By"/>
+        </Property>
+        <Property Name="TXMulticastFrames" Type="Edm.Int64">
+          <Annotation Term="OData.Permissions" EnumMember="OData.Permission/Read"/>
+          <Annotation Term="OData.Description" String="The total number of good multicast frames transmitted since reset."/>
+          <Annotation Term="OData.LongDescription" String="This property shall contain the total number of good multicast frames transmitted since reset."/>
+        </Property>
+        <Property Name="TXUnicastFrames" Type="Edm.Int64">
+          <Annotation Term="OData.Permissions" EnumMember="OData.Permission/Read"/>
+          <Annotation Term="OData.Description" String="The total number of good unicast frames transmitted since reset."/>
+          <Annotation Term="OData.LongDescription" String="This property shall contain the total number of good unicast frames transmitted since reset."/>
+        </Property>
+        <Property Name="Actions" Type="NetworkAdapterMetrics.v1_0_0.Actions" Nullable="false">
+          <Annotation Term="OData.Description" String="The available actions for this resource."/>
+          <Annotation Term="OData.LongDescription" String="This property shall contain the available actions for this resource."/>
+        </Property>
+      </EntityType>
+
+      <ComplexType Name="Actions">
+        <Annotation Term="OData.AdditionalProperties" Bool="false"/>
+        <Annotation Term="OData.Description" String="The available actions for this resource."/>
+        <Annotation Term="OData.LongDescription" String="This type shall contain the available actions for this resource."/>
+        <Property Name="Oem" Type="NetworkAdapterMetrics.v1_0_0.OemActions" Nullable="false">
+          <Annotation Term="OData.Description" String="The available OEM-specific actions for this resource."/>
+          <Annotation Term="OData.LongDescription" String="This property shall contain the available OEM-specific actions for this resource."/>
+        </Property>
+      </ComplexType>
+
+      <ComplexType Name="OemActions">
+        <Annotation Term="OData.AdditionalProperties" Bool="true"/>
+        <Annotation Term="OData.Description" String="The available OEM-specific actions for this resource."/>
+        <Annotation Term="OData.LongDescription" String="This type shall contain the available OEM-specific actions for this resource."/>
+      </ComplexType>
+    </Schema>
+
+  </edmx:DataServices>
+</edmx:Edmx>

--- a/static/redfish/v1/schema/NetworkAdapter_v1.xml
+++ b/static/redfish/v1/schema/NetworkAdapter_v1.xml
@@ -1,0 +1,643 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!---->
+<!--################################################################################       -->
+<!--# Redfish Schema:  NetworkAdapter v1.8.0                                               -->
+<!--#                                                                                      -->
+<!--# For a detailed change log, see the README file contained in the DSP8010 bundle,      -->
+<!--# available at http://www.dmtf.org/standards/redfish                                   -->
+<!--# Copyright 2014-2021 DMTF.                                                            -->
+<!--# For the full DMTF copyright policy, see http://www.dmtf.org/about/policies/copyright -->
+<!--################################################################################       -->
+<!---->
+<edmx:Edmx xmlns:edmx="http://docs.oasis-open.org/odata/ns/edmx" Version="4.0">
+
+  <edmx:Reference Uri="http://docs.oasis-open.org/odata/odata/v4.0/errata03/csd01/complete/vocabularies/Org.OData.Core.V1.xml">
+    <edmx:Include Namespace="Org.OData.Core.V1" Alias="OData"/>
+  </edmx:Reference>
+  <edmx:Reference Uri="http://docs.oasis-open.org/odata/odata/v4.0/errata03/csd01/complete/vocabularies/Org.OData.Capabilities.V1.xml">
+    <edmx:Include Namespace="Org.OData.Capabilities.V1" Alias="Capabilities"/>
+  </edmx:Reference>
+  <edmx:Reference Uri="http://redfish.dmtf.org/schemas/v1/Resource_v1.xml">
+    <edmx:Include Namespace="Resource"/>
+    <edmx:Include Namespace="Resource.v1_0_0"/>
+  </edmx:Reference>
+  <edmx:Reference Uri="http://redfish.dmtf.org/schemas/v1/RedfishExtensions_v1.xml">
+    <edmx:Include Namespace="RedfishExtensions.v1_0_0" Alias="Redfish"/>
+  </edmx:Reference>
+  <edmx:Reference Uri="http://redfish.dmtf.org/schemas/v1/NetworkPortCollection_v1.xml">
+    <edmx:Include Namespace="NetworkPortCollection"/>
+  </edmx:Reference>
+  <edmx:Reference Uri="http://redfish.dmtf.org/schemas/v1/NetworkPort_v1.xml">
+    <edmx:Include Namespace="NetworkPort"/>
+  </edmx:Reference>
+  <edmx:Reference Uri="http://redfish.dmtf.org/schemas/v1/NetworkDeviceFunctionCollection_v1.xml">
+    <edmx:Include Namespace="NetworkDeviceFunctionCollection"/>
+  </edmx:Reference>
+  <edmx:Reference Uri="http://redfish.dmtf.org/schemas/v1/NetworkDeviceFunction_v1.xml">
+    <edmx:Include Namespace="NetworkDeviceFunction"/>
+  </edmx:Reference>
+  <edmx:Reference Uri="http://redfish.dmtf.org/schemas/v1/NetworkAdapterMetrics_v1.xml">
+    <edmx:Include Namespace="NetworkAdapterMetrics"/>
+  </edmx:Reference>
+  <edmx:Reference Uri="http://redfish.dmtf.org/schemas/v1/PCIeDevice_v1.xml">
+    <edmx:Include Namespace="PCIeDevice"/>
+  </edmx:Reference>
+  <edmx:Reference Uri="http://redfish.dmtf.org/schemas/v1/Assembly_v1.xml">
+    <edmx:Include Namespace="Assembly"/>
+  </edmx:Reference>
+  <edmx:Reference Uri="http://redfish.dmtf.org/schemas/v1/PortCollection_v1.xml">
+    <edmx:Include Namespace="PortCollection"/>
+  </edmx:Reference>
+  <edmx:Reference Uri="http://redfish.dmtf.org/schemas/v1/Port_v1.xml">
+    <edmx:Include Namespace="Port"/>
+  </edmx:Reference>
+  <edmx:Reference Uri="http://redfish.dmtf.org/schemas/v1/CertificateCollection_v1.xml">
+    <edmx:Include Namespace="CertificateCollection"/>
+  </edmx:Reference>
+  <edmx:Reference Uri="http://redfish.dmtf.org/schemas/v1/SoftwareInventory_v1.xml">
+    <edmx:Include Namespace="SoftwareInventory"/>
+  </edmx:Reference>
+  <edmx:Reference Uri="http://redfish.dmtf.org/schemas/v1/EnvironmentMetrics_v1.xml">
+    <edmx:Include Namespace="EnvironmentMetrics"/>
+  </edmx:Reference>
+  <edmx:Reference Uri="http://redfish.dmtf.org/schemas/v1/ProcessorCollection_v1.xml">
+    <edmx:Include Namespace="ProcessorCollection"/>
+  </edmx:Reference>
+
+  <edmx:DataServices>
+
+    <Schema xmlns="http://docs.oasis-open.org/odata/ns/edm" Namespace="NetworkAdapter">
+      <Annotation Term="Redfish.OwningEntity" String="DMTF"/>
+
+      <EntityType Name="NetworkAdapter" BaseType="Resource.v1_0_0.Resource" Abstract="true">
+        <Annotation Term="OData.Description" String="The NetworkAdapter schema represents a physical network adapter capable of connecting to a computer network.  Examples include but are not limited to Ethernet, Fibre Channel, and converged network adapters."/>
+        <Annotation Term="OData.LongDescription" String="This resource shall represent a physical network adapter capable of connecting to a computer network in a Redfish implementation."/>
+        <Annotation Term="Capabilities.InsertRestrictions">
+          <Record>
+            <PropertyValue Property="Insertable" Bool="false"/>
+          </Record>
+        </Annotation>
+        <Annotation Term="Capabilities.UpdateRestrictions">
+          <Record>
+            <PropertyValue Property="Updatable" Bool="true"/>
+          </Record>
+        </Annotation>
+        <Annotation Term="Capabilities.DeleteRestrictions">
+          <Record>
+            <PropertyValue Property="Deletable" Bool="false"/>
+          </Record>
+        </Annotation>
+        <Annotation Term="Redfish.Uris">
+          <Collection>
+            <String>/redfish/v1/Chassis/{ChassisId}/NetworkAdapters/{NetworkAdapterId}</String>
+          </Collection>
+        </Annotation>
+      </EntityType>
+
+      <Action Name="ResetSettingsToDefault" IsBound="true">
+        <Annotation Term="OData.Description" String="This action is to clear the settings back to factory defaults."/>
+        <Annotation Term="OData.LongDescription" String="This action shall reset of all active and pending settings back to factory default settings upon reset of the network adapter."/>
+        <Parameter Name="NetworkAdapter" Type="NetworkAdapter.v1_0_0.Actions"/>
+      </Action>
+    </Schema>
+
+    <Schema xmlns="http://docs.oasis-open.org/odata/ns/edm" Namespace="NetworkAdapter.v1_0_0">
+      <Annotation Term="Redfish.OwningEntity" String="DMTF"/>
+      <Annotation Term="Redfish.Release" String="2016.3"/>
+
+      <EntityType Name="NetworkAdapter" BaseType="NetworkAdapter.NetworkAdapter">
+        <Property Name="Status" Type="Resource.Status" Nullable="false">
+          <Annotation Term="OData.Description" String="The status and health of the resource and its subordinate or dependent resources."/>
+          <Annotation Term="OData.LongDescription" String="This property shall contain any status or health properties of the resource."/>
+        </Property>
+        <NavigationProperty Name="NetworkPorts" Type="NetworkPortCollection.NetworkPortCollection" ContainsTarget="true" Nullable="false">
+          <Annotation Term="OData.Permissions" EnumMember="OData.Permission/Read"/>
+          <Annotation Term="OData.Description" String="The link to the collection of network ports associated with this network adapter."/>
+          <Annotation Term="OData.LongDescription" String="This property shall contain a link to a resource collection of type NetworkPortCollection."/>
+          <Annotation Term="OData.AutoExpandReferences"/>
+          <Annotation Term="Redfish.Revisions">
+            <Collection>
+              <Record>
+                <PropertyValue Property="Kind" EnumMember="Redfish.RevisionKind/Deprecated"/>
+                <PropertyValue Property="Version" String="v1_5_0"/>
+                <PropertyValue Property="Description" String="This property has been deprecated in favor of the Ports property."/>
+              </Record>
+            </Collection>
+          </Annotation>
+        </NavigationProperty>
+        <NavigationProperty Name="NetworkDeviceFunctions" Type="NetworkDeviceFunctionCollection.NetworkDeviceFunctionCollection" ContainsTarget="true" Nullable="false">
+          <Annotation Term="OData.Permissions" EnumMember="OData.Permission/Read"/>
+          <Annotation Term="OData.Description" String="The link to the collection of network device functions associated with this network adapter."/>
+          <Annotation Term="OData.LongDescription" String="This property shall contain a link to a resource collection of type NetworkDeviceFunctionCollection."/>
+          <Annotation Term="OData.AutoExpandReferences"/>
+        </NavigationProperty>
+        <Property Name="Manufacturer" Type="Edm.String">
+          <Annotation Term="OData.Permissions" EnumMember="OData.Permission/Read"/>
+          <Annotation Term="OData.Description" String="The manufacturer or OEM of this network adapter."/>
+          <Annotation Term="OData.LongDescription" String="This property shall contain a value that represents the manufacturer of the network adapter."/>
+        </Property>
+        <Property Name="Model" Type="Edm.String">
+          <Annotation Term="OData.Permissions" EnumMember="OData.Permission/Read"/>
+          <Annotation Term="OData.Description" String="The model string for this network adapter."/>
+          <Annotation Term="OData.LongDescription" String="This property shall contain the information about how the manufacturer refers to this network adapter."/>
+        </Property>
+        <Property Name="SKU" Type="Edm.String">
+          <Annotation Term="OData.Permissions" EnumMember="OData.Permission/Read"/>
+          <Annotation Term="OData.Description" String="The manufacturer SKU for this network adapter."/>
+          <Annotation Term="OData.LongDescription" String="This property shall contain the SKU for the network adapter."/>
+        </Property>
+        <Property Name="SerialNumber" Type="Edm.String">
+          <Annotation Term="OData.Permissions" EnumMember="OData.Permission/Read"/>
+          <Annotation Term="OData.Description" String="The serial number for this network adapter."/>
+          <Annotation Term="OData.LongDescription" String="This property shall contain the serial number for the network adapter."/>
+        </Property>
+        <Property Name="PartNumber" Type="Edm.String">
+          <Annotation Term="OData.Permissions" EnumMember="OData.Permission/Read"/>
+          <Annotation Term="OData.Description" String="Part number for this network adapter."/>
+          <Annotation Term="OData.LongDescription" String="This property shall contain the part number for the network adapter as defined by the manufacturer."/>
+        </Property>
+        <Property Name="Controllers" Type="Collection(NetworkAdapter.v1_0_0.Controllers)" Nullable="false">
+          <Annotation Term="OData.Description" String="The set of network controllers ASICs that make up this NetworkAdapter."/>
+          <Annotation Term="OData.LongDescription" String="This property shall contain the set of network controllers ASICs that make up this network adapter."/>
+        </Property>
+        <Property Name="Actions" Type="NetworkAdapter.v1_0_0.Actions" Nullable="false">
+          <Annotation Term="OData.Description" String="The available actions for this resource."/>
+          <Annotation Term="OData.LongDescription" String="This property shall contain the available actions for this resource."/>
+        </Property>
+      </EntityType>
+
+      <ComplexType Name="Actions">
+        <Annotation Term="OData.AdditionalProperties" Bool="false"/>
+        <Annotation Term="OData.Description" String="The available actions for this resource."/>
+        <Annotation Term="OData.LongDescription" String="This type shall contain the available actions for this resource."/>
+        <Property Name="Oem" Type="NetworkAdapter.v1_0_0.OemActions" Nullable="false">
+          <Annotation Term="OData.Description" String="The available OEM-specific actions for this resource."/>
+          <Annotation Term="OData.LongDescription" String="This property shall contain the available OEM-specific actions for this resource."/>
+        </Property>
+      </ComplexType>
+
+      <ComplexType Name="OemActions">
+        <Annotation Term="OData.AdditionalProperties" Bool="true"/>
+        <Annotation Term="OData.Description" String="The available OEM-specific actions for this resource."/>
+        <Annotation Term="OData.LongDescription" String="This type shall contain the available OEM-specific actions for this resource."/>
+      </ComplexType>
+
+      <ComplexType Name="Controllers">
+        <Annotation Term="OData.Description" String="A network controller ASIC that makes up part of a network adapter."/>
+        <Annotation Term="OData.LongDescription" String="This type shall describe a network controller ASIC that makes up part of a network adapter."/>
+        <Property Name="FirmwarePackageVersion" Type="Edm.String">
+          <Annotation Term="OData.Permissions" EnumMember="OData.Permission/Read"/>
+          <Annotation Term="OData.Description" String="The version of the user-facing firmware package."/>
+          <Annotation Term="OData.LongDescription" String="This property shall contain the version number of the user-facing firmware package."/>
+        </Property>
+        <Property Name="Links" Type="NetworkAdapter.v1_0_0.ControllerLinks" Nullable="false">
+          <Annotation Term="OData.Description" String="The links to other resources that are related to this resource."/>
+          <Annotation Term="OData.LongDescription" String="This property shall contain links to resources that are related to but are not contained by, or subordinate to, this resource."/>
+        </Property>
+        <Property Name="ControllerCapabilities" Type="NetworkAdapter.v1_0_0.ControllerCapabilities" Nullable="false">
+          <Annotation Term="OData.Description" String="The capabilities of this controller."/>
+          <Annotation Term="OData.LongDescription" String="This property shall contain the capabilities of this controller."/>
+        </Property>
+      </ComplexType>
+
+      <ComplexType Name="ControllerCapabilities">
+        <Annotation Term="OData.Description" String="The capabilities of a controller."/>
+        <Annotation Term="OData.LongDescription" String="This type shall describe the capabilities of a controller."/>
+        <Property Name="NetworkPortCount" Type="Edm.Int64">
+          <Annotation Term="OData.Permissions" EnumMember="OData.Permission/Read"/>
+          <Annotation Term="OData.Description" String="The number of physical ports on this controller."/>
+          <Annotation Term="OData.LongDescription" String="This property shall contain the number of physical ports on this controller."/>
+        </Property>
+        <Property Name="NetworkDeviceFunctionCount" Type="Edm.Int64">
+          <Annotation Term="OData.Permissions" EnumMember="OData.Permission/Read"/>
+          <Annotation Term="OData.Description" String="The maximum number of physical functions available on this controller."/>
+          <Annotation Term="OData.LongDescription" String="This property shall contain the number of physical functions available on this controller."/>
+        </Property>
+        <Property Name="DataCenterBridging" Type="NetworkAdapter.v1_0_0.DataCenterBridging" Nullable="false">
+          <Annotation Term="OData.Description" String="Data center bridging (DCB) for this controller."/>
+          <Annotation Term="OData.LongDescription" String="This property shall contain capability, status, and configuration values related to data center bridging (DCB) for this controller."/>
+        </Property>
+        <Property Name="VirtualizationOffload" Type="NetworkAdapter.v1_0_0.VirtualizationOffload" Nullable="false">
+          <Annotation Term="OData.Description" String="Virtualization offload for this controller."/>
+          <Annotation Term="OData.LongDescription" String="This property shall contain capability, status, and configuration values related to virtualization offload for this controller."/>
+        </Property>
+        <Property Name="NPIV" Type="NetworkAdapter.v1_0_0.NPIV" Nullable="false">
+          <Annotation Term="OData.Description" String="N_Port ID Virtualization (NPIV) capabilities for this controller."/>
+          <Annotation Term="OData.LongDescription" String="This property shall contain N_Port ID Virtualization (NPIV) capabilities for this controller."/>
+        </Property>
+      </ComplexType>
+
+      <ComplexType Name="DataCenterBridging">
+        <Annotation Term="OData.Description" String="Data center bridging (DCB) for capabilities of a controller."/>
+        <Annotation Term="OData.LongDescription" String="This type shall describe the capability, status, and configuration values related to data center bridging (DCB) for a controller."/>
+        <Property Name="Capable" Type="Edm.Boolean">
+          <Annotation Term="OData.Permissions" EnumMember="OData.Permission/Read"/>
+          <Annotation Term="OData.Description" String="An indication of whether this controller is capable of data center bridging (DCB)."/>
+          <Annotation Term="OData.LongDescription" String="This property shall indicate whether this controller is capable of data center bridging (DCB)."/>
+        </Property>
+      </ComplexType>
+
+      <ComplexType Name="VirtualFunction">
+        <Annotation Term="OData.Description" String="A virtual function of a controller."/>
+        <Annotation Term="OData.LongDescription" String="This type shall describe the capability, status, and configuration values related to a virtual function for a controller."/>
+        <Property Name="DeviceMaxCount" Type="Edm.Int64">
+          <Annotation Term="OData.Permissions" EnumMember="OData.Permission/Read"/>
+          <Annotation Term="OData.Description" String="The maximum number of virtual functions supported by this controller."/>
+          <Annotation Term="OData.LongDescription" String="This property shall contain the maximum number of virtual functions supported by this controller."/>
+        </Property>
+        <Property Name="NetworkPortMaxCount" Type="Edm.Int64">
+          <Annotation Term="OData.Permissions" EnumMember="OData.Permission/Read"/>
+          <Annotation Term="OData.Description" String="The maximum number of virtual functions supported per network port for this controller."/>
+          <Annotation Term="OData.LongDescription" String="This property shall contain the maximum number of virtual functions supported per network port for this controller."/>
+        </Property>
+        <Property Name="MinAssignmentGroupSize" Type="Edm.Int64">
+          <Annotation Term="OData.Permissions" EnumMember="OData.Permission/Read"/>
+          <Annotation Term="OData.Description" String="The minimum number of virtual functions that can be allocated or moved between physical functions for this controller."/>
+          <Annotation Term="OData.LongDescription" String="This property shall contain the minimum number of virtual functions that can be allocated or moved between physical functions for this controller."/>
+        </Property>
+      </ComplexType>
+
+      <ComplexType Name="ControllerLinks" BaseType="Resource.Links">
+        <Annotation Term="OData.Description" String="The links to other resources that are related to this resource."/>
+        <Annotation Term="OData.LongDescription" String="This Redfish Specification-described type shall contain links to resources that are related to but are not contained by, or subordinate to, this resource."/>
+        <NavigationProperty Name="PCIeDevices" Type="Collection(PCIeDevice.PCIeDevice)">
+          <Annotation Term="OData.Permissions" EnumMember="OData.Permission/Read"/>
+          <Annotation Term="OData.Description" String="An array of links to the PCIe devices associated with this network controller."/>
+          <Annotation Term="OData.LongDescription" String="This property shall contain an array of links to resources of type PCIeDevice that represent the PCIe devices associated with this network controller."/>
+          <Annotation Term="OData.AutoExpandReferences"/>
+        </NavigationProperty>
+        <NavigationProperty Name="NetworkPorts" Type="Collection(NetworkPort.NetworkPort)">
+          <Annotation Term="OData.Permissions" EnumMember="OData.Permission/Read"/>
+          <Annotation Term="OData.Description" String="An array of links to the network ports associated with this network controller."/>
+          <Annotation Term="OData.LongDescription" String="This property shall contain an array of links to resources of type NetworkPort that represent the network ports associated with this network controller."/>
+          <Annotation Term="OData.AutoExpandReferences"/>
+          <Annotation Term="Redfish.Revisions">
+            <Collection>
+              <Record>
+                <PropertyValue Property="Kind" EnumMember="Redfish.RevisionKind/Deprecated"/>
+                <PropertyValue Property="Version" String="v1_5_0"/>
+                <PropertyValue Property="Description" String="This property has been deprecated in favor of the Ports property."/>
+              </Record>
+            </Collection>
+          </Annotation>
+        </NavigationProperty>
+        <NavigationProperty Name="NetworkDeviceFunctions" Type="Collection(NetworkDeviceFunction.NetworkDeviceFunction)">
+          <Annotation Term="OData.Permissions" EnumMember="OData.Permission/Read"/>
+          <Annotation Term="OData.Description" String="An array of links to the network device functions associated with this network controller."/>
+          <Annotation Term="OData.LongDescription" String="This property shall contain an array of links to resources of type NetworkDeviceFunction that represent the network device functions associated with this network controller."/>
+          <Annotation Term="OData.AutoExpandReferences"/>
+        </NavigationProperty>
+      </ComplexType>
+
+      <ComplexType Name="SRIOV">
+        <Annotation Term="OData.Description" String="Single-root input/output virtualization (SR-IOV) capabilities."/>
+        <Annotation Term="OData.LongDescription" String="This type shall contain single-root input/output virtualization (SR-IOV) capabilities."/>
+        <Property Name="SRIOVVEPACapable" Type="Edm.Boolean">
+          <Annotation Term="OData.Permissions" EnumMember="OData.Permission/Read"/>
+          <Annotation Term="OData.Description" String="An indication of whether this controller supports single root input/output virtualization (SR-IOV) in Virtual Ethernet Port Aggregator (VEPA) mode."/>
+          <Annotation Term="OData.LongDescription" String="This property shall indicate whether this controller supports single root input/output virtualization (SR-IOV) in Virtual Ethernet Port Aggregator (VEPA) mode."/>
+        </Property>
+      </ComplexType>
+
+      <ComplexType Name="VirtualizationOffload">
+        <Annotation Term="OData.Description" String="A Virtualization offload capability of a controller."/>
+        <Annotation Term="OData.LongDescription" String="This type shall describe the capability, status, and configuration values related to a virtualization offload for a controller."/>
+        <Property Name="VirtualFunction" Type="NetworkAdapter.v1_0_0.VirtualFunction" Nullable="false">
+          <Annotation Term="OData.Description" String="The virtual function of the controller."/>
+          <Annotation Term="OData.LongDescription" String="This property shall describe the capability, status, and configuration values related to the virtual function for this controller."/>
+        </Property>
+        <Property Name="SRIOV" Type="NetworkAdapter.v1_0_0.SRIOV" Nullable="false">
+          <Annotation Term="OData.Description" String="Single-root input/output virtualization (SR-IOV) capabilities."/>
+          <Annotation Term="OData.LongDescription" String="This property shall contain single-root input/output virtualization (SR-IOV) capabilities."/>
+        </Property>
+      </ComplexType>
+
+      <ComplexType Name="NPIV">
+        <Annotation Term="OData.Description" String="N_Port ID Virtualization (NPIV) capabilities for a controller."/>
+        <Annotation Term="OData.LongDescription" String="This type shall contain N_Port ID Virtualization (NPIV) capabilities for a controller."/>
+        <Property Name="MaxDeviceLogins" Type="Edm.Int64">
+          <Annotation Term="OData.Permissions" EnumMember="OData.Permission/Read"/>
+          <Annotation Term="OData.Description" String="The maximum number of N_Port ID Virtualization (NPIV) logins allowed simultaneously from all ports on this controller."/>
+          <Annotation Term="OData.LongDescription" String="This property shall contain the maximum number of N_Port ID Virtualization (NPIV) logins allowed simultaneously from all ports on this controller."/>
+        </Property>
+        <Property Name="MaxPortLogins" Type="Edm.Int64">
+          <Annotation Term="OData.Permissions" EnumMember="OData.Permission/Read"/>
+          <Annotation Term="OData.Description" String="The maximum number of N_Port ID Virtualization (NPIV) logins allowed per physical port on this controller."/>
+          <Annotation Term="OData.LongDescription" String="This property shall contain the maximum number of N_Port ID Virtualization (NPIV) logins allowed per physical port on this controller."/>
+        </Property>
+      </ComplexType>
+    </Schema>
+
+    <Schema xmlns="http://docs.oasis-open.org/odata/ns/edm" Namespace="NetworkAdapter.v1_0_1">
+      <Annotation Term="Redfish.OwningEntity" String="DMTF"/>
+      <Annotation Term="OData.Description" String="This version was created to remove the Nullable facet on NavigationProperties of the Collection type."/>
+      <EntityType Name="NetworkAdapter" BaseType="NetworkAdapter.v1_0_0.NetworkAdapter"/>
+    </Schema>
+
+    <Schema xmlns="http://docs.oasis-open.org/odata/ns/edm" Namespace="NetworkAdapter.v1_0_2">
+      <Annotation Term="Redfish.OwningEntity" String="DMTF"/>
+      <Annotation Term="OData.Description" String="This version was created to force the regeneration of JSON Schema so that OData properties are marked as required, and integer properties are marked as integer rather than number."/>
+      <EntityType Name="NetworkAdapter" BaseType="NetworkAdapter.v1_0_1.NetworkAdapter"/>
+    </Schema>
+
+    <Schema xmlns="http://docs.oasis-open.org/odata/ns/edm" Namespace="NetworkAdapter.v1_0_3">
+      <Annotation Term="Redfish.OwningEntity" String="DMTF"/>
+      <Annotation Term="OData.Description" String="This version was created to force the regeneration of JSON Schema so that URI properties use the uri-reference format and adds a missing term to several properties to disallow them from being null."/>
+      <EntityType Name="NetworkAdapter" BaseType="NetworkAdapter.v1_0_2.NetworkAdapter"/>
+    </Schema>
+
+    <Schema xmlns="http://docs.oasis-open.org/odata/ns/edm" Namespace="NetworkAdapter.v1_0_4">
+      <Annotation Term="Redfish.OwningEntity" String="DMTF"/>
+      <Annotation Term="OData.Description" String="This version was created to update descriptions that this schema defines."/>
+      <EntityType Name="NetworkAdapter" BaseType="NetworkAdapter.v1_0_3.NetworkAdapter"/>
+    </Schema>
+
+    <Schema xmlns="http://docs.oasis-open.org/odata/ns/edm" Namespace="NetworkAdapter.v1_0_5">
+      <Annotation Term="Redfish.OwningEntity" String="DMTF"/>
+      <Annotation Term="OData.Description" String="This version was created to correct various typographical errors."/>
+      <EntityType Name="NetworkAdapter" BaseType="NetworkAdapter.v1_0_4.NetworkAdapter"/>
+    </Schema>
+
+    <Schema xmlns="http://docs.oasis-open.org/odata/ns/edm" Namespace="NetworkAdapter.v1_0_6">
+      <Annotation Term="Redfish.OwningEntity" String="DMTF"/>
+      <Annotation Term="OData.Description" String="This version was created to correct inconsistencies with the descriptions of Identifiers and Location."/>
+      <EntityType Name="NetworkAdapter" BaseType="NetworkAdapter.v1_0_5.NetworkAdapter"/>
+    </Schema>
+
+    <Schema xmlns="http://docs.oasis-open.org/odata/ns/edm" Namespace="NetworkAdapter.v1_0_7">
+      <Annotation Term="Redfish.OwningEntity" String="DMTF"/>
+      <Annotation Term="OData.Description" String="This version was created specify 64-bit integers in OpenAPI."/>
+      <EntityType Name="NetworkAdapter" BaseType="NetworkAdapter.v1_0_6.NetworkAdapter"/>
+    </Schema>
+
+    <Schema xmlns="http://docs.oasis-open.org/odata/ns/edm" Namespace="NetworkAdapter.v1_1_0">
+      <Annotation Term="Redfish.OwningEntity" String="DMTF"/>
+      <Annotation Term="Redfish.Release" String="2017.3"/>
+
+      <EntityType Name="NetworkAdapter" BaseType="NetworkAdapter.v1_0_1.NetworkAdapter">
+        <NavigationProperty Name="Assembly" Type="Assembly.Assembly" ContainsTarget="true" Nullable="false">
+          <Annotation Term="OData.Permissions" EnumMember="OData.Permission/Read"/>
+          <Annotation Term="OData.Description" String="The link to the assembly resource associated with this adapter."/>
+          <Annotation Term="OData.LongDescription" String="This property shall contain a link to a resource of type Assembly."/>
+          <Annotation Term="OData.AutoExpandReferences"/>
+        </NavigationProperty>
+      </EntityType>
+
+      <ComplexType Name="Controllers" BaseType="NetworkAdapter.v1_0_0.Controllers">
+        <Property Name="Location" Type="Resource.Location" Nullable="false">
+          <Annotation Term="OData.Description" String="The location of the network adapter controller."/>
+          <Annotation Term="OData.LongDescription" String="This property shall contain location information of the controller associated with the network adapter."/>
+        </Property>
+      </ComplexType>
+    </Schema>
+
+    <Schema xmlns="http://docs.oasis-open.org/odata/ns/edm" Namespace="NetworkAdapter.v1_1_1">
+      <Annotation Term="Redfish.OwningEntity" String="DMTF"/>
+      <Annotation Term="OData.Description" String="This version was created to force the regeneration of JSON Schema so that OData properties are marked as required, and integer properties are marked as integer rather than number."/>
+      <EntityType Name="NetworkAdapter" BaseType="NetworkAdapter.v1_1_0.NetworkAdapter"/>
+    </Schema>
+
+    <Schema xmlns="http://docs.oasis-open.org/odata/ns/edm" Namespace="NetworkAdapter.v1_1_2">
+      <Annotation Term="Redfish.OwningEntity" String="DMTF"/>
+      <Annotation Term="OData.Description" String="This version was created to force the regeneration of JSON Schema so that URI properties use the uri-reference format, and to add a missing term to several properties to disallow them from being null."/>
+      <EntityType Name="NetworkAdapter" BaseType="NetworkAdapter.v1_1_1.NetworkAdapter"/>
+    </Schema>
+
+    <Schema xmlns="http://docs.oasis-open.org/odata/ns/edm" Namespace="NetworkAdapter.v1_1_3">
+      <Annotation Term="Redfish.OwningEntity" String="DMTF"/>
+      <Annotation Term="OData.Description" String="This version was created to update descriptions that this schema defines."/>
+      <EntityType Name="NetworkAdapter" BaseType="NetworkAdapter.v1_1_2.NetworkAdapter"/>
+    </Schema>
+
+    <Schema xmlns="http://docs.oasis-open.org/odata/ns/edm" Namespace="NetworkAdapter.v1_1_4">
+      <Annotation Term="Redfish.OwningEntity" String="DMTF"/>
+      <Annotation Term="OData.Description" String="This version was created to correct various typographical errors."/>
+      <EntityType Name="NetworkAdapter" BaseType="NetworkAdapter.v1_1_3.NetworkAdapter"/>
+    </Schema>
+
+    <Schema xmlns="http://docs.oasis-open.org/odata/ns/edm" Namespace="NetworkAdapter.v1_1_5">
+      <Annotation Term="Redfish.OwningEntity" String="DMTF"/>
+      <Annotation Term="OData.Description" String="This version was created to correct inconsistencies with the descriptions of Identifiers and Location."/>
+      <EntityType Name="NetworkAdapter" BaseType="NetworkAdapter.v1_1_4.NetworkAdapter"/>
+    </Schema>
+
+    <Schema xmlns="http://docs.oasis-open.org/odata/ns/edm" Namespace="NetworkAdapter.v1_1_6">
+      <Annotation Term="Redfish.OwningEntity" String="DMTF"/>
+      <Annotation Term="OData.Description" String="This version was created specify 64-bit integers in OpenAPI."/>
+      <EntityType Name="NetworkAdapter" BaseType="NetworkAdapter.v1_1_5.NetworkAdapter"/>
+    </Schema>
+
+    <Schema xmlns="http://docs.oasis-open.org/odata/ns/edm" Namespace="NetworkAdapter.v1_2_0">
+      <Annotation Term="Redfish.OwningEntity" String="DMTF"/>
+      <Annotation Term="Redfish.Release" String="2018.2"/>
+      <EntityType Name="NetworkAdapter" BaseType="NetworkAdapter.v1_1_1.NetworkAdapter"/>
+
+      <ComplexType Name="Controllers" BaseType="NetworkAdapter.v1_1_0.Controllers">
+        <Property Name="PCIeInterface" Type="PCIeDevice.PCIeInterface" Nullable="false">
+          <Annotation Term="OData.Description" String="The PCIe interface details for this controller."/>
+          <Annotation Term="OData.LongDescription" String="This property shall contain details for the PCIe interface that connects this PCIe-based controller to its host."/>
+        </Property>
+      </ComplexType>
+
+      <ComplexType Name="ControllerCapabilities" BaseType="NetworkAdapter.v1_0_0.ControllerCapabilities">
+        <Property Name="NPAR" Type="NetworkAdapter.v1_2_0.NicPartitioning" Nullable="false">
+          <Annotation Term="OData.Description" String="NIC Partitioning (NPAR) capabilities for this controller."/>
+          <Annotation Term="OData.LongDescription" String="This property shall contain capability, status, and configuration values related to NIC partitioning for this controller."/>
+        </Property>
+      </ComplexType>
+
+      <ComplexType Name="NicPartitioning">
+        <Annotation Term="OData.Description" String="NIC Partitioning capability, status, and configuration for a controller."/>
+        <Annotation Term="OData.LongDescription" String="This type shall contain the capability, status, and configuration values for a controller."/>
+        <Property Name="NparCapable" Type="Edm.Boolean">
+          <Annotation Term="OData.Permissions" EnumMember="OData.Permission/Read"/>
+          <Annotation Term="OData.Description" String="An indication of whether the controller supports NIC function partitioning."/>
+          <Annotation Term="OData.LongDescription" String="This property shall indicate whether the controller supports NIC function partitioning."/>
+        </Property>
+        <Property Name="NparEnabled" Type="Edm.Boolean">
+          <Annotation Term="OData.Permissions" EnumMember="OData.Permission/ReadWrite"/>
+          <Annotation Term="OData.Description" String="An indication of whether NIC function partitioning is active on this controller."/>
+          <Annotation Term="OData.LongDescription" String="This property shall indicate whether NIC function partitioning is active on this controller."/>
+        </Property>
+      </ComplexType>
+    </Schema>
+
+    <Schema xmlns="http://docs.oasis-open.org/odata/ns/edm" Namespace="NetworkAdapter.v1_2_1">
+      <Annotation Term="Redfish.OwningEntity" String="DMTF"/>
+      <Annotation Term="OData.Description" String="This version was created to force the regeneration of JSON Schema so that URI properties use the uri-reference format, and to add a missing term to several properties to disallow them from being null."/>
+      <EntityType Name="NetworkAdapter" BaseType="NetworkAdapter.v1_2_0.NetworkAdapter"/>
+    </Schema>
+
+    <Schema xmlns="http://docs.oasis-open.org/odata/ns/edm" Namespace="NetworkAdapter.v1_2_2">
+      <Annotation Term="Redfish.OwningEntity" String="DMTF"/>
+      <Annotation Term="OData.Description" String="This version was created to update descriptions that this schema defines."/>
+      <EntityType Name="NetworkAdapter" BaseType="NetworkAdapter.v1_2_1.NetworkAdapter"/>
+    </Schema>
+
+    <Schema xmlns="http://docs.oasis-open.org/odata/ns/edm" Namespace="NetworkAdapter.v1_2_3">
+      <Annotation Term="Redfish.OwningEntity" String="DMTF"/>
+      <Annotation Term="OData.Description" String="This version was created to correct various typographical errors."/>
+      <EntityType Name="NetworkAdapter" BaseType="NetworkAdapter.v1_2_2.NetworkAdapter"/>
+    </Schema>
+
+    <Schema xmlns="http://docs.oasis-open.org/odata/ns/edm" Namespace="NetworkAdapter.v1_2_4">
+      <Annotation Term="Redfish.OwningEntity" String="DMTF"/>
+      <Annotation Term="OData.Description" String="This version was created to correct inconsistencies with the descriptions of Identifiers and Location."/>
+      <EntityType Name="NetworkAdapter" BaseType="NetworkAdapter.v1_2_3.NetworkAdapter"/>
+    </Schema>
+
+    <Schema xmlns="http://docs.oasis-open.org/odata/ns/edm" Namespace="NetworkAdapter.v1_2_5">
+      <Annotation Term="Redfish.OwningEntity" String="DMTF"/>
+      <Annotation Term="OData.Description" String="This version was created specify 64-bit integers in OpenAPI."/>
+      <EntityType Name="NetworkAdapter" BaseType="NetworkAdapter.v1_2_4.NetworkAdapter"/>
+    </Schema>
+
+    <Schema xmlns="http://docs.oasis-open.org/odata/ns/edm" Namespace="NetworkAdapter.v1_3_0">
+      <Annotation Term="Redfish.OwningEntity" String="DMTF"/>
+      <Annotation Term="Redfish.Release" String="2019.2"/>
+      <EntityType Name="NetworkAdapter" BaseType="NetworkAdapter.v1_2_2.NetworkAdapter"/>
+
+      <ComplexType Name="Controllers" BaseType="NetworkAdapter.v1_2_0.Controllers">
+        <Property Name="Identifiers" Type="Collection(Resource.Identifier)" Nullable="false">
+          <Annotation Term="OData.Description" String="The durable names for the network adapter controller."/>
+          <Annotation Term="OData.LongDescription" String="This property shall contain a list of all known durable names for the controller associated with the network adapter."/>
+        </Property>
+      </ComplexType>
+    </Schema>
+
+    <Schema xmlns="http://docs.oasis-open.org/odata/ns/edm" Namespace="NetworkAdapter.v1_3_1">
+      <Annotation Term="Redfish.OwningEntity" String="DMTF"/>
+      <Annotation Term="OData.Description" String="This version was created to correct various typographical errors."/>
+      <EntityType Name="NetworkAdapter" BaseType="NetworkAdapter.v1_3_0.NetworkAdapter"/>
+    </Schema>
+
+    <Schema xmlns="http://docs.oasis-open.org/odata/ns/edm" Namespace="NetworkAdapter.v1_3_2">
+      <Annotation Term="Redfish.OwningEntity" String="DMTF"/>
+      <Annotation Term="OData.Description" String="This version was created to correct various typographical errors."/>
+      <EntityType Name="NetworkAdapter" BaseType="NetworkAdapter.v1_3_1.NetworkAdapter"/>
+    </Schema>
+
+    <Schema xmlns="http://docs.oasis-open.org/odata/ns/edm" Namespace="NetworkAdapter.v1_3_3">
+      <Annotation Term="Redfish.OwningEntity" String="DMTF"/>
+      <Annotation Term="OData.Description" String="This version was created to correct inconsistencies with the descriptions of Identifiers and Location."/>
+      <EntityType Name="NetworkAdapter" BaseType="NetworkAdapter.v1_3_2.NetworkAdapter"/>
+    </Schema>
+
+    <Schema xmlns="http://docs.oasis-open.org/odata/ns/edm" Namespace="NetworkAdapter.v1_3_4">
+      <Annotation Term="Redfish.OwningEntity" String="DMTF"/>
+      <Annotation Term="OData.Description" String="This version was created specify 64-bit integers in OpenAPI."/>
+      <EntityType Name="NetworkAdapter" BaseType="NetworkAdapter.v1_3_3.NetworkAdapter"/>
+    </Schema>
+
+    <Schema xmlns="http://docs.oasis-open.org/odata/ns/edm" Namespace="NetworkAdapter.v1_4_0">
+      <Annotation Term="Redfish.OwningEntity" String="DMTF"/>
+      <Annotation Term="Redfish.Release" String="2020.2"/>
+
+      <EntityType Name="NetworkAdapter" BaseType="NetworkAdapter.v1_3_3.NetworkAdapter">
+        <Property Name="Location" Type="Resource.Location" Nullable="false">
+          <Annotation Term="OData.Description" String="The location of the network adapter."/>
+          <Annotation Term="OData.LongDescription" String="This property shall contain location information of the network adapter."/>
+        </Property>
+        <Property Name="Identifiers" Type="Collection(Resource.Identifier)" Nullable="false">
+          <Annotation Term="OData.Description" String="The durable names for the network adapter."/>
+          <Annotation Term="OData.LongDescription" String="This property shall contain a list of all known durable names for the network adapter."/>
+        </Property>
+      </EntityType>
+    </Schema>
+
+    <Schema xmlns="http://docs.oasis-open.org/odata/ns/edm" Namespace="NetworkAdapter.v1_4_1">
+      <Annotation Term="Redfish.OwningEntity" String="DMTF"/>
+      <Annotation Term="OData.Description" String="This version was created specify 64-bit integers in OpenAPI."/>
+      <EntityType Name="NetworkAdapter" BaseType="NetworkAdapter.v1_4_0.NetworkAdapter"/>
+    </Schema>
+
+    <Schema xmlns="http://docs.oasis-open.org/odata/ns/edm" Namespace="NetworkAdapter.v1_5_0">
+      <Annotation Term="Redfish.OwningEntity" String="DMTF"/>
+      <Annotation Term="Redfish.Release" String="2020.3"/>
+
+      <EntityType Name="NetworkAdapter" BaseType="NetworkAdapter.v1_4_0.NetworkAdapter">
+        <NavigationProperty Name="Ports" Type="PortCollection.PortCollection" ContainsTarget="true" Nullable="false">
+          <Annotation Term="OData.Permissions" EnumMember="OData.Permission/Read"/>
+          <Annotation Term="OData.Description" String="The link to the collection of ports associated with this network adapter."/>
+          <Annotation Term="OData.LongDescription" String="This property shall contain a link to a resource collection of type PortCollection."/>
+          <Annotation Term="OData.AutoExpandReferences"/>
+        </NavigationProperty>
+      </EntityType>
+
+      <ComplexType Name="ControllerLinks" BaseType="NetworkAdapter.v1_0_0.ControllerLinks">
+        <NavigationProperty Name="Ports" Type="Collection(Port.Port)">
+          <Annotation Term="OData.Permissions" EnumMember="OData.Permission/Read"/>
+          <Annotation Term="OData.Description" String="An array of links to the ports associated with this network controller."/>
+          <Annotation Term="OData.LongDescription" String="This property shall contain an array of links to resources of type Port that represent the ports associated with this network controller."/>
+          <Annotation Term="OData.AutoExpandReferences"/>
+        </NavigationProperty>
+      </ComplexType>
+    </Schema>
+
+    <Schema xmlns="http://docs.oasis-open.org/odata/ns/edm" Namespace="NetworkAdapter.v1_5_1">
+      <Annotation Term="Redfish.OwningEntity" String="DMTF"/>
+      <Annotation Term="OData.Description" String="This version was created specify 64-bit integers in OpenAPI."/>
+      <EntityType Name="NetworkAdapter" BaseType="NetworkAdapter.v1_5_0.NetworkAdapter"/>
+    </Schema>
+
+    <Schema xmlns="http://docs.oasis-open.org/odata/ns/edm" Namespace="NetworkAdapter.v1_6_0">
+      <Annotation Term="Redfish.OwningEntity" String="DMTF"/>
+      <Annotation Term="Redfish.Release" String="2020.4"/>
+      <Annotation Term="OData.Description" String="This version was created to add Certificates and Measurements to devices for attestation and identity management."/>
+
+      <EntityType Name="NetworkAdapter" BaseType="NetworkAdapter.v1_5_1.NetworkAdapter">
+        <NavigationProperty Name="Certificates" Type="CertificateCollection.CertificateCollection" ContainsTarget="true" Nullable="false">
+          <Annotation Term="OData.Permissions" EnumMember="OData.Permission/Read"/>
+          <Annotation Term="OData.Description" String="The link to a collection of certificates for device identity and attestation."/>
+          <Annotation Term="OData.LongDescription" String="This property shall contain a link to a resource collection of type CertificateCollection that contains certificates for device identity and attestation."/>
+          <Annotation Term="OData.AutoExpandReferences"/>
+        </NavigationProperty>
+        <Property Name="Measurements" Type="Collection(SoftwareInventory.MeasurementBlock)" Nullable="false">
+          <Annotation Term="OData.Description" String="An array of DSP0274-defined measurement blocks."/>
+          <Annotation Term="OData.LongDescription" String="This property shall contain an array of DSP0274-defined measurement blocks."/>
+        </Property>
+      </EntityType>
+    </Schema>
+
+    <Schema xmlns="http://docs.oasis-open.org/odata/ns/edm" Namespace="NetworkAdapter.v1_7_0">
+      <Annotation Term="Redfish.OwningEntity" String="DMTF"/>
+      <Annotation Term="Redfish.Release" String="2021.1"/>
+      <Annotation Term="OData.Description" String="This version was created to add the Metrics, EnvironmentMetrics, and LLDPEnabled properties."/>
+
+      <EntityType Name="NetworkAdapter" BaseType="NetworkAdapter.v1_6_0.NetworkAdapter">
+        <NavigationProperty Name="Metrics" Type="NetworkAdapterMetrics.NetworkAdapterMetrics">
+          <Annotation Term="OData.Permissions" EnumMember="OData.Permission/Read"/>
+          <Annotation Term="OData.Description" String="The link to the metrics associated with this adapter."/>
+          <Annotation Term="OData.LongDescription" String="This property shall contain a link to a resource of type NetworkAdapterMetrics that contains the metrics associated with this adapter."/>
+          <Annotation Term="OData.AutoExpandReferences"/>
+        </NavigationProperty>
+        <NavigationProperty Name="EnvironmentMetrics" Type="EnvironmentMetrics.EnvironmentMetrics" Nullable="false">
+          <Annotation Term="OData.Permissions" EnumMember="OData.Permission/Read"/>
+          <Annotation Term="OData.Description" String="The link to the environment metrics for this network adapter."/>
+          <Annotation Term="OData.LongDescription" String="This property shall contain a link to a resource of type EnvironmentMetrics that specifies the environment metrics for this network adapter."/>
+          <Annotation Term="OData.AutoExpandReferences"/>
+        </NavigationProperty>
+        <Property Name="LLDPEnabled" Type="Edm.Boolean" Nullable="false">
+          <Annotation Term="OData.Permissions" EnumMember="OData.Permission/ReadWrite" />
+          <Annotation Term="OData.Description" String="Enable or disable LLDP globally for an adapter." />
+          <Annotation Term="OData.LongDescription" String="This property shall contain the state indicating whether LLDP is globally enabled on a network adapter.  If set to `false`, the LLDPEnabled value for the ports associated with this adapter shall be disregarded."/>
+        </Property>
+      </EntityType>
+    </Schema>
+
+    <Schema xmlns="http://docs.oasis-open.org/odata/ns/edm" Namespace="NetworkAdapter.v1_8_0">
+      <Annotation Term="Redfish.OwningEntity" String="DMTF"/>
+      <Annotation Term="Redfish.Release" String="2021.2"/>
+
+      <EntityType Name="NetworkAdapter" BaseType="NetworkAdapter.v1_7_0.NetworkAdapter">
+        <NavigationProperty Name="Processors" Type="ProcessorCollection.ProcessorCollection" ContainsTarget="true" Nullable="false">
+          <Annotation Term="OData.Permissions" EnumMember="OData.Permission/Read"/>
+          <Annotation Term="OData.Description" String="The link to the collection of offload processors contained in this network adapter."/>
+          <Annotation Term="OData.LongDescription" String="This property shall contain a link to a resource collection of type ProcessorCollection that represent the offload processors contained in this network adapter."/>
+          <Annotation Term="OData.AutoExpandReferences"/>
+        </NavigationProperty>
+      </EntityType>
+    </Schema>
+
+  </edmx:DataServices>
+</edmx:Edmx>

--- a/static/redfish/v1/schema/NetworkDeviceFunctionCollection_v1.xml
+++ b/static/redfish/v1/schema/NetworkDeviceFunctionCollection_v1.xml
@@ -1,0 +1,74 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!---->
+<!--################################################################################       -->
+<!--# Redfish Schema:  NetworkDeviceFunctionCollection                                     -->
+<!--#                                                                                      -->
+<!--# For a detailed change log, see the README file contained in the DSP8010 bundle,      -->
+<!--# available at http://www.dmtf.org/standards/redfish                                   -->
+<!--# Copyright 2014-2021 DMTF.                                                            -->
+<!--# For the full DMTF copyright policy, see http://www.dmtf.org/about/policies/copyright -->
+<!--################################################################################       -->
+<!---->
+<edmx:Edmx xmlns:edmx="http://docs.oasis-open.org/odata/ns/edmx" Version="4.0">
+
+  <edmx:Reference Uri="http://docs.oasis-open.org/odata/odata/v4.0/errata03/csd01/complete/vocabularies/Org.OData.Core.V1.xml">
+    <edmx:Include Namespace="Org.OData.Core.V1" Alias="OData"/>
+  </edmx:Reference>
+  <edmx:Reference Uri="http://docs.oasis-open.org/odata/odata/v4.0/errata03/csd01/complete/vocabularies/Org.OData.Capabilities.V1.xml">
+    <edmx:Include Namespace="Org.OData.Capabilities.V1" Alias="Capabilities"/>
+  </edmx:Reference>
+  <edmx:Reference Uri="http://redfish.dmtf.org/schemas/v1/Resource_v1.xml">
+    <edmx:Include Namespace="Resource.v1_0_0"/>
+  </edmx:Reference>
+  <edmx:Reference Uri="http://redfish.dmtf.org/schemas/v1/RedfishExtensions_v1.xml">
+    <edmx:Include Namespace="RedfishExtensions.v1_0_0" Alias="Redfish"/>
+  </edmx:Reference>
+  <edmx:Reference Uri="http://redfish.dmtf.org/schemas/v1/NetworkDeviceFunction_v1.xml">
+    <edmx:Include Namespace="NetworkDeviceFunction"/>
+  </edmx:Reference>
+
+  <edmx:DataServices>
+
+    <Schema xmlns="http://docs.oasis-open.org/odata/ns/edm" Namespace="NetworkDeviceFunctionCollection">
+      <Annotation Term="Redfish.OwningEntity" String="DMTF"/>
+
+      <EntityType Name="NetworkDeviceFunctionCollection" BaseType="Resource.v1_0_0.ResourceCollection">
+        <Annotation Term="OData.Description" String="The collection of NetworkDeviceFunction resource instances."/>
+        <Annotation Term="OData.LongDescription" String="This resource shall represent a resource collection of NetworkDeviceFunction instances for a Redfish implementation."/>
+        <Annotation Term="Capabilities.InsertRestrictions">
+          <Record>
+            <PropertyValue Property="Insertable" Bool="false"/>
+          </Record>
+        </Annotation>
+        <Annotation Term="Capabilities.UpdateRestrictions">
+          <Record>
+            <PropertyValue Property="Updatable" Bool="false"/>
+          </Record>
+        </Annotation>
+        <Annotation Term="Capabilities.DeleteRestrictions">
+          <Record>
+            <PropertyValue Property="Deletable" Bool="false"/>
+          </Record>
+        </Annotation>
+        <Annotation Term="Redfish.Uris">
+          <Collection>
+            <String>/redfish/v1/Chassis/{ChassisId}/NetworkAdapters/{NetworkAdapterId}/NetworkDeviceFunctions</String>
+            <String>/redfish/v1/Systems/{ComputerSystemId}/NetworkInterfaces/{NetworkInterfaceId}/NetworkDeviceFunctions</String>
+            <String>/redfish/v1/CompositionService/ResourceBlocks/{ResourceBlockId}/NetworkInterfaces/{NetworkInterfaceId}/NetworkDeviceFunctions</String>
+            <String>/redfish/v1/CompositionService/ResourceBlocks/{ResourceBlockId}/Systems/{ComputerSystemId}/NetworkInterfaces/{NetworkInterfaceId}/NetworkDeviceFunctions</String>
+            <String>/redfish/v1/ResourceBlocks/{ResourceBlockId}/NetworkInterfaces/{NetworkInterfaceId}/NetworkDeviceFunctions</String>
+            <String>/redfish/v1/ResourceBlocks/{ResourceBlockId}/Systems/{ComputerSystemId}/NetworkInterfaces/{NetworkInterfaceId}/NetworkDeviceFunctions</String>
+          </Collection>
+        </Annotation>
+        <NavigationProperty Name="Members" Type="Collection(NetworkDeviceFunction.NetworkDeviceFunction)">
+          <Annotation Term="OData.Permissions" EnumMember="OData.Permission/Read"/>
+          <Annotation Term="OData.Description" String="The members of this collection."/>
+          <Annotation Term="OData.LongDescription" String="This property shall contain an array of links to the members of this collection."/>
+          <Annotation Term="OData.AutoExpandReferences"/>
+          <Annotation Term="Redfish.Required"/>
+        </NavigationProperty>
+      </EntityType>
+    </Schema>
+
+  </edmx:DataServices>
+</edmx:Edmx>

--- a/static/redfish/v1/schema/NetworkDeviceFunctionMetrics_v1.xml
+++ b/static/redfish/v1/schema/NetworkDeviceFunctionMetrics_v1.xml
@@ -1,0 +1,282 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!---->
+<!--################################################################################       -->
+<!--# Redfish Schema:  NetworkDeviceFunctionMetrics v1.1.0                                 -->
+<!--#                                                                                      -->
+<!--# For a detailed change log, see the README file contained in the DSP8010 bundle,      -->
+<!--# available at http://www.dmtf.org/standards/redfish                                   -->
+<!--# Copyright 2014-2021 DMTF.                                                            -->
+<!--# For the full DMTF copyright policy, see http://www.dmtf.org/about/policies/copyright -->
+<!--################################################################################       -->
+<!---->
+<edmx:Edmx xmlns:edmx="http://docs.oasis-open.org/odata/ns/edmx" Version="4.0">
+
+  <edmx:Reference Uri="http://docs.oasis-open.org/odata/odata/v4.0/errata03/csd01/complete/vocabularies/Org.OData.Core.V1.xml">
+    <edmx:Include Namespace="Org.OData.Core.V1" Alias="OData"/>
+  </edmx:Reference>
+  <edmx:Reference Uri="http://docs.oasis-open.org/odata/odata/v4.0/errata03/csd01/complete/vocabularies/Org.OData.Capabilities.V1.xml">
+    <edmx:Include Namespace="Org.OData.Capabilities.V1" Alias="Capabilities"/>
+  </edmx:Reference>
+  <edmx:Reference Uri="http://docs.oasis-open.org/odata/odata/v4.0/errata03/csd01/complete/vocabularies/Org.OData.Measures.V1.xml">
+    <edmx:Include Namespace="Org.OData.Measures.V1" Alias="Measures"/>
+  </edmx:Reference>
+  <edmx:Reference Uri="http://redfish.dmtf.org/schemas/v1/RedfishExtensions_v1.xml">
+    <edmx:Include Namespace="RedfishExtensions.v1_0_0" Alias="Redfish"/>
+    <edmx:Include Namespace="Validation.v1_0_0" Alias="Validation"/>
+  </edmx:Reference>
+  <edmx:Reference Uri="http://redfish.dmtf.org/schemas/v1/Resource_v1.xml">
+    <edmx:Include Namespace="Resource.v1_0_0"/>
+  </edmx:Reference>
+
+  <edmx:DataServices>
+
+    <Schema xmlns="http://docs.oasis-open.org/odata/ns/edm" Namespace="NetworkDeviceFunctionMetrics">
+      <Annotation Term="Redfish.OwningEntity" String="DMTF"/>
+
+      <EntityType Name="NetworkDeviceFunctionMetrics" BaseType="Resource.v1_0_0.Resource" Abstract="true">
+        <Annotation Term="OData.Description" String="The NetworkDeviceFunctionMetrics schema contains usage and health statistics for a network function of a network adapter."/>
+        <Annotation Term="OData.LongDescription" String="This resource shall represent the network metrics for a single network function of a network adapter in a Redfish implementation."/>
+        <Annotation Term="OData.AdditionalProperties" Bool="false"/>
+        <Annotation Term="Capabilities.InsertRestrictions">
+          <Record>
+            <PropertyValue Property="Insertable" Bool="false"/>
+          </Record>
+        </Annotation>
+        <Annotation Term="Capabilities.UpdateRestrictions">
+          <Record>
+            <PropertyValue Property="Updatable" Bool="false"/>
+          </Record>
+        </Annotation>
+        <Annotation Term="Capabilities.DeleteRestrictions">
+          <Record>
+            <PropertyValue Property="Deletable" Bool="false"/>
+          </Record>
+        </Annotation>
+        <Annotation Term="Redfish.Uris">
+          <Collection>
+            <String>/redfish/v1/Chassis/{ChassisId}/NetworkAdapters/{NetworkAdapterId}/NetworkDeviceFunctions/{NetworkDeviceFunctionId}/Metrics</String>
+          </Collection>
+        </Annotation>
+      </EntityType>
+    </Schema>
+
+    <Schema xmlns="http://docs.oasis-open.org/odata/ns/edm" Namespace="NetworkDeviceFunctionMetrics.v1_0_0">
+      <Annotation Term="Redfish.OwningEntity" String="DMTF"/>
+      <Annotation Term="Redfish.Release" String="2021.1"/>
+
+      <EntityType Name="NetworkDeviceFunctionMetrics" BaseType="NetworkDeviceFunctionMetrics.NetworkDeviceFunctionMetrics">
+        <Property Name="Ethernet" Type="NetworkDeviceFunctionMetrics.v1_0_0.Ethernet" Nullable="false">
+          <Annotation Term="OData.Description" String="The network function metrics specific to Ethernet adapters."/>
+          <Annotation Term="OData.LongDescription" String="This property shall contain network function metrics specific to Ethernet adapters."/>
+        </Property>
+        <Property Name="TXAvgQueueDepthPercent" Type="Edm.Decimal">
+          <Annotation Term="OData.Permissions" EnumMember="OData.Permission/Read"/>
+          <Annotation Term="OData.Description" String="The average TX queue depth as the percentage."/>
+          <Annotation Term="OData.LongDescription" String="This property shall contain the average TX queue depth as the percentage."/>
+          <Annotation Term="Validation.Minimum" Int="0"/>
+          <Annotation Term="Measures.Unit" String="%"/>
+        </Property>
+        <Property Name="RXAvgQueueDepthPercent" Type="Edm.Decimal">
+          <Annotation Term="OData.Permissions" EnumMember="OData.Permission/Read"/>
+          <Annotation Term="OData.Description" String="The average RX queue depth as the percentage."/>
+          <Annotation Term="OData.LongDescription" String="This property shall contain the average RX queue depth as the percentage."/>
+          <Annotation Term="Validation.Minimum" Int="0"/>
+          <Annotation Term="Measures.Unit" String="%"/>
+        </Property>
+        <Property Name="RXFrames" Type="Edm.Int64">
+          <Annotation Term="OData.Permissions" EnumMember="OData.Permission/Read"/>
+          <Annotation Term="OData.Description" String="The total number of frames received on a network function."/>
+          <Annotation Term="OData.LongDescription" String="This property shall contain the total number of frames received on a network function."/>
+        </Property>
+        <Property Name="RXBytes" Type="Edm.Int64">
+          <Annotation Term="OData.Permissions" EnumMember="OData.Permission/Read"/>
+          <Annotation Term="OData.Description" String="The total number of bytes received on a network function."/>
+          <Annotation Term="OData.LongDescription" String="This property shall contain the total number of bytes received on a network function, inclusive of all protocol overhead."/>
+          <Annotation Term="Measures.Unit" String="By"/>
+        </Property>
+        <Property Name="RXUnicastFrames" Type="Edm.Int64">
+          <Annotation Term="OData.Permissions" EnumMember="OData.Permission/Read"/>
+          <Annotation Term="OData.Description" String="The total number of good unicast frames received on a network function since reset."/>
+          <Annotation Term="OData.LongDescription" String="This property shall contain the total number of good unicast frames received on a network function since reset."/>
+        </Property>
+        <Property Name="RXMulticastFrames" Type="Edm.Int64">
+          <Annotation Term="OData.Permissions" EnumMember="OData.Permission/Read"/>
+          <Annotation Term="OData.Description" String="The total number of good multicast frames received on a network function since reset."/>
+          <Annotation Term="OData.LongDescription" String="This property shall contain the total number of good multicast frames received on a network function since reset, including host and remote management passthrough traffic."/>
+        </Property>
+        <Property Name="TXFrames" Type="Edm.Int64">
+          <Annotation Term="OData.Permissions" EnumMember="OData.Permission/Read"/>
+          <Annotation Term="OData.Description" String="The total number of frames sent on a network function."/>
+          <Annotation Term="OData.LongDescription" String="This property shall contain the total number of frames sent on a network function."/>
+        </Property>
+        <Property Name="TXBytes" Type="Edm.Int64">
+          <Annotation Term="OData.Permissions" EnumMember="OData.Permission/Read"/>
+          <Annotation Term="OData.Description" String="The total number of bytes sent on a network function."/>
+          <Annotation Term="OData.LongDescription" String="This property shall contain the total number of bytes sent on a network function, inclusive of all protocol overhead."/>
+          <Annotation Term="Measures.Unit" String="By"/>
+        </Property>
+        <Property Name="TXUnicastFrames" Type="Edm.Int64">
+          <Annotation Term="OData.Permissions" EnumMember="OData.Permission/Read"/>
+          <Annotation Term="OData.Description" String="The total number of good unicast frames transmitted on a network function since reset."/>
+          <Annotation Term="OData.LongDescription" String="This property shall contain the total number of good unicast frames transmitted on a network function since reset, including host and remote management passthrough traffic."/>
+        </Property>
+        <Property Name="TXMulticastFrames" Type="Edm.Int64">
+          <Annotation Term="OData.Permissions" EnumMember="OData.Permission/Read"/>
+          <Annotation Term="OData.Description" String="The total number of good multicast frames transmitted on a network function since reset."/>
+          <Annotation Term="OData.LongDescription" String="This property shall contain the total number of good multicast frames transmitted on a network function since reset, including host and remote management passthrough traffic."/>
+        </Property>
+        <Property Name="TXQueuesEmpty" Type="Edm.Boolean">
+          <Annotation Term="OData.Permissions" EnumMember="OData.Permission/Read"/>
+          <Annotation Term="OData.Description" String="Whether all TX queues for a network function are empty."/>
+          <Annotation Term="OData.LongDescription" String="This property shall indicate whether all TX queues for a network function are empty."/>
+        </Property>
+        <Property Name="RXQueuesEmpty" Type="Edm.Boolean">
+          <Annotation Term="OData.Permissions" EnumMember="OData.Permission/Read"/>
+          <Annotation Term="OData.Description" String="Whether nothing is in a network function's RX queues to DMA."/>
+          <Annotation Term="OData.LongDescription" String="This property shall indicate whether nothing is in a network function's RX queues to DMA."/>
+        </Property>
+        <Property Name="TXQueuesFull" Type="Edm.Int64">
+          <Annotation Term="OData.Permissions" EnumMember="OData.Permission/Read"/>
+          <Annotation Term="OData.Description" String="The number of TX queues that are full."/>
+          <Annotation Term="OData.LongDescription" String="This property shall contain the number of TX queues that are full."/>
+        </Property>
+        <Property Name="RXQueuesFull" Type="Edm.Int64">
+          <Annotation Term="OData.Permissions" EnumMember="OData.Permission/Read"/>
+          <Annotation Term="OData.Description" String="The number of RX queues that are full."/>
+          <Annotation Term="OData.LongDescription" String="This property shall contain the number of RX queues that are full."/>
+        </Property>
+        <Property Name="Actions" Type="NetworkDeviceFunctionMetrics.v1_0_0.Actions" Nullable="false">
+          <Annotation Term="OData.Description" String="The available actions for this resource."/>
+          <Annotation Term="OData.LongDescription" String="This property shall contain the available actions for this resource."/>
+        </Property>
+      </EntityType>
+
+      <ComplexType Name="Ethernet">
+        <Annotation Term="OData.AdditionalProperties" Bool="false"/>
+        <Annotation Term="OData.Description" String="The network function metrics for an Ethernet interface."/>
+        <Annotation Term="OData.LongDescription" String="This type shall describe the Ethernet related network function metrics."/>
+        <Property Name="NumOffloadedIPv4Conns" Type="Edm.Int64">
+          <Annotation Term="OData.Permissions" EnumMember="OData.Permission/Read"/>
+          <Annotation Term="OData.Description" String="The total number of offloaded TCP/IPv4 connections."/>
+          <Annotation Term="OData.LongDescription" String="This property shall contain the total number of offloaded TCP/IPv4 connections."/>
+        </Property>
+        <Property Name="NumOffloadedIPv6Conns" Type="Edm.Int64">
+          <Annotation Term="OData.Permissions" EnumMember="OData.Permission/Read"/>
+          <Annotation Term="OData.Description" String="The total number of offloaded TCP/IPv6 connections."/>
+          <Annotation Term="OData.LongDescription" String="This property shall contain the total number of offloaded TCP/IPv6 connections."/>
+        </Property>
+      </ComplexType>
+
+      <ComplexType Name="Actions">
+        <Annotation Term="OData.AdditionalProperties" Bool="false"/>
+        <Annotation Term="OData.Description" String="The available actions for this resource."/>
+        <Annotation Term="OData.LongDescription" String="This type shall contain the available actions for this resource."/>
+        <Property Name="Oem" Type="NetworkDeviceFunctionMetrics.v1_0_0.OemActions" Nullable="false">
+          <Annotation Term="OData.Description" String="The available OEM-specific actions for this resource."/>
+          <Annotation Term="OData.LongDescription" String="This property shall contain the available OEM-specific actions for this resource."/>
+        </Property>
+      </ComplexType>
+
+      <ComplexType Name="OemActions">
+        <Annotation Term="OData.AdditionalProperties" Bool="true"/>
+        <Annotation Term="OData.Description" String="The available OEM-specific actions for this resource."/>
+        <Annotation Term="OData.LongDescription" String="This type shall contain the available OEM-specific actions for this resource."/>
+      </ComplexType>
+    </Schema>
+
+    <Schema xmlns="http://docs.oasis-open.org/odata/ns/edm" Namespace="NetworkDeviceFunctionMetrics.v1_1_0">
+      <Annotation Term="Redfish.OwningEntity" String="DMTF"/>
+      <Annotation Term="Redfish.Release" String="2021.2"/>
+      <Annotation Term="OData.Description" String="This version was created to add FibreChannel function metrics."/>
+
+      <EntityType Name="NetworkDeviceFunctionMetrics" BaseType="NetworkDeviceFunctionMetrics.v1_0_0.NetworkDeviceFunctionMetrics">
+        <Property Name="FibreChannel" Type="NetworkDeviceFunctionMetrics.v1_1_0.FibreChannel" Nullable="false">
+          <Annotation Term="OData.Description" String="The network function metrics specific to Fibre Channel adapters."/>
+          <Annotation Term="OData.LongDescription" String="This property shall contain network function metrics specific to Fibre Channel adapters."/>
+        </Property>
+      </EntityType>
+
+      <ComplexType Name="FibreChannel">
+        <Annotation Term="OData.AdditionalProperties" Bool="false"/>
+        <Annotation Term="OData.Description" String="The network function metrics for a Fibre Channel interface."/>
+        <Annotation Term="OData.LongDescription" String="This type shall describe the Fibre Channel related network function metrics."/>
+        <Property Name="RXSequences" Type="Edm.Int64">
+          <Annotation Term="OData.Permissions" EnumMember="OData.Permission/Read"/>
+          <Annotation Term="OData.Description" String="The total number of Fibre Channel sequences received."/>
+          <Annotation Term="OData.LongDescription" String="This property shall contain the total number of Fibre Channel sequences received."/>
+        </Property>
+        <Property Name="TXSequences" Type="Edm.Int64">
+          <Annotation Term="OData.Permissions" EnumMember="OData.Permission/Read"/>
+          <Annotation Term="OData.Description" String="The total number of Fibre Channel sequences transmitted."/>
+          <Annotation Term="OData.LongDescription" String="This property shall contain the total number of Fibre Channel sequences transmitted."/>
+        </Property>
+        <Property Name="TXExchanges" Type="Edm.Int64">
+          <Annotation Term="OData.Permissions" EnumMember="OData.Permission/Read"/>
+          <Annotation Term="OData.Description" String="The total number of Fibre Channel exchanges transmitted."/>
+          <Annotation Term="OData.LongDescription" String="This property shall contain the total number of Fibre Channel exchanges transmitted."/>
+        </Property>
+        <Property Name="RXExchanges" Type="Edm.Int64">
+          <Annotation Term="OData.Permissions" EnumMember="OData.Permission/Read"/>
+          <Annotation Term="OData.Description" String="The total number of Fibre Channel exchanges received."/>
+          <Annotation Term="OData.LongDescription" String="This property shall contain the total number of Fibre Channel exchanges received."/>
+        </Property>
+        <Property Name="PortLoginRequests" Type="Edm.Int64">
+          <Annotation Term="OData.Permissions" EnumMember="OData.Permission/Read"/>
+          <Annotation Term="OData.Description" String="The total number of port login (PLOGI) requests transmitted."/>
+          <Annotation Term="OData.LongDescription" String="This property shall contain the total number of PLOGI requests sent by this function."/>
+        </Property>
+        <Property Name="PortLoginAccepts" Type="Edm.Int64">
+          <Annotation Term="OData.Permissions" EnumMember="OData.Permission/Read"/>
+          <Annotation Term="OData.Description" String="The total number of port login (PLOGI) accept (ACC) responses."/>
+          <Annotation Term="OData.LongDescription" String="This property shall contain the total number of PLOGI ACC responses received by this Fibre Channel function."/>
+        </Property>
+        <Property Name="PortLoginRejects" Type="Edm.Int64">
+          <Annotation Term="OData.Permissions" EnumMember="OData.Permission/Read"/>
+          <Annotation Term="OData.Description" String="The total number of port login (PLOGI) reject (RJT) responses."/>
+          <Annotation Term="OData.LongDescription" String="This property shall contain the total number of PLOGI RJT responses received by this Fibre Channel function."/>
+        </Property>
+        <Property Name="RXPeerCongestionFPINs" Type="Edm.Int64">
+          <Annotation Term="OData.Permissions" EnumMember="OData.Permission/Read"/>
+          <Annotation Term="OData.Description" String="The total number of Peer Congestion Fabric Performance Impact Notifications (FPINs) received."/>
+          <Annotation Term="OData.LongDescription" String="This property shall contain the total number of Peer Congestion FPINs received by this Fibre Channel function."/>
+        </Property>
+        <Property Name="TXPeerCongestionFPINs" Type="Edm.Int64">
+          <Annotation Term="OData.Permissions" EnumMember="OData.Permission/Read"/>
+          <Annotation Term="OData.Description" String="The total number of Peer Congestion Fabric Performance Impact Notifications (FPINs) sent."/>
+          <Annotation Term="OData.LongDescription" String="This property shall contain the total number of Peer Congestion FPINs sent by this Fibre Channel function."/>
+        </Property>
+        <Property Name="RXCongestionFPINs" Type="Edm.Int64">
+          <Annotation Term="OData.Permissions" EnumMember="OData.Permission/Read"/>
+          <Annotation Term="OData.Description" String="The total number of Congestion Fabric Performance Impact Notifications (FPINs) received."/>
+          <Annotation Term="OData.LongDescription" String="This property shall contain the total number of Congestion FPINs received by this Fibre Channel function."/>
+        </Property>
+        <Property Name="TXCongestionFPINs" Type="Edm.Int64">
+          <Annotation Term="OData.Permissions" EnumMember="OData.Permission/Read"/>
+          <Annotation Term="OData.Description" String="The total number of Congestion Fabric Performance Impact Notifications (FPINs) sent."/>
+          <Annotation Term="OData.LongDescription" String="This property shall contain the total number of Congestion FPINs sent by this Fibre Channel function."/>
+        </Property>
+        <Property Name="RXLinkIntegrityFPINs" Type="Edm.Int64">
+          <Annotation Term="OData.Permissions" EnumMember="OData.Permission/Read"/>
+          <Annotation Term="OData.Description" String="The total number of Link Integrity Fabric Performance Impact Notifications (FPINs) received."/>
+          <Annotation Term="OData.LongDescription" String="This property shall contain the total number of Link Integrity FPINs received by this Fibre Channel function."/>
+        </Property>
+        <Property Name="TXLinkIntegrityFPINs" Type="Edm.Int64">
+          <Annotation Term="OData.Permissions" EnumMember="OData.Permission/Read"/>
+          <Annotation Term="OData.Description" String="The total number of Link Integrity Fabric Performance Impact Notifications (FPINs) sent."/>
+          <Annotation Term="OData.LongDescription" String="This property shall contain the total number of Link Integrity FPINs sent by this Fibre Channel function."/>
+        </Property>
+        <Property Name="RXDeliveryFPINs" Type="Edm.Int64">
+          <Annotation Term="OData.Permissions" EnumMember="OData.Permission/Read"/>
+          <Annotation Term="OData.Description" String="The total number of Delivery Fabric Performance Impact Notifications (FPINs) received."/>
+          <Annotation Term="OData.LongDescription" String="This property shall contain the total number of Delivery FPINs received by this Fibre Channel function."/>
+        </Property>
+        <Property Name="TXDeliveryFPINs" Type="Edm.Int64">
+          <Annotation Term="OData.Permissions" EnumMember="OData.Permission/Read"/>
+          <Annotation Term="OData.Description" String="The total number of Delivery Fabric Performance Impact Notifications (FPINs) sent."/>
+          <Annotation Term="OData.LongDescription" String="This property shall contain the total number of Delivery FPINs sent by this Fibre Channel function."/>
+        </Property>
+      </ComplexType>
+    </Schema>
+
+  </edmx:DataServices>
+</edmx:Edmx>

--- a/static/redfish/v1/schema/NetworkDeviceFunction_v1.xml
+++ b/static/redfish/v1/schema/NetworkDeviceFunction_v1.xml
@@ -1,0 +1,1062 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!---->
+<!--################################################################################       -->
+<!--# Redfish Schema:  NetworkDeviceFunction v1.7.0                                        -->
+<!--#                                                                                      -->
+<!--# For a detailed change log, see the README file contained in the DSP8010 bundle,      -->
+<!--# available at http://www.dmtf.org/standards/redfish                                   -->
+<!--# Copyright 2014-2021 DMTF.                                                            -->
+<!--# For the full DMTF copyright policy, see http://www.dmtf.org/about/policies/copyright -->
+<!--################################################################################       -->
+<!---->
+<edmx:Edmx xmlns:edmx="http://docs.oasis-open.org/odata/ns/edmx" Version="4.0">
+
+  <edmx:Reference Uri="http://docs.oasis-open.org/odata/odata/v4.0/errata03/csd01/complete/vocabularies/Org.OData.Core.V1.xml">
+    <edmx:Include Namespace="Org.OData.Core.V1" Alias="OData"/>
+  </edmx:Reference>
+  <edmx:Reference Uri="http://docs.oasis-open.org/odata/odata/v4.0/errata03/csd01/complete/vocabularies/Org.OData.Capabilities.V1.xml">
+    <edmx:Include Namespace="Org.OData.Capabilities.V1" Alias="Capabilities"/>
+  </edmx:Reference>
+  <edmx:Reference Uri="http://redfish.dmtf.org/schemas/v1/Resource_v1.xml">
+    <edmx:Include Namespace="Resource"/>
+    <edmx:Include Namespace="Resource.v1_0_0"/>
+  </edmx:Reference>
+  <edmx:Reference Uri="http://redfish.dmtf.org/schemas/v1/RedfishExtensions_v1.xml">
+    <edmx:Include Namespace="RedfishExtensions.v1_0_0" Alias="Redfish"/>
+    <edmx:Include Namespace="Validation.v1_0_0" Alias="Validation"/>
+  </edmx:Reference>
+  <edmx:Reference Uri="http://redfish.dmtf.org/schemas/v1/Endpoint_v1.xml">
+    <edmx:Include Namespace="Endpoint"/>
+  </edmx:Reference>
+  <edmx:Reference Uri="http://redfish.dmtf.org/schemas/v1/NetworkPort_v1.xml">
+    <edmx:Include Namespace="NetworkPort"/>
+  </edmx:Reference>
+  <edmx:Reference Uri="http://redfish.dmtf.org/schemas/v1/PCIeFunction_v1.xml">
+    <edmx:Include Namespace="PCIeFunction"/>
+  </edmx:Reference>
+  <edmx:Reference Uri="http://redfish.dmtf.org/schemas/v1/VLanNetworkInterface_v1.xml">
+    <edmx:Include Namespace="VLanNetworkInterface"/>
+  </edmx:Reference>
+  <edmx:Reference Uri="http://redfish.dmtf.org/schemas/v1/VLanNetworkInterfaceCollection_v1.xml">
+    <edmx:Include Namespace="VLanNetworkInterfaceCollection"/>
+  </edmx:Reference>
+  <edmx:Reference Uri="http://redfish.dmtf.org/schemas/v1/NetworkDeviceFunctionMetrics_v1.xml">
+    <edmx:Include Namespace="NetworkDeviceFunctionMetrics"/>
+  </edmx:Reference>
+  <edmx:Reference Uri="http://redfish.dmtf.org/schemas/v1/EthernetInterface_v1.xml">
+    <edmx:Include Namespace="EthernetInterface"/>
+  </edmx:Reference>
+  <edmx:Reference Uri="http://redfish.dmtf.org/schemas/v1/EthernetInterfaceCollection_v1.xml">
+    <edmx:Include Namespace="EthernetInterfaceCollection"/>
+  </edmx:Reference>
+  <edmx:Reference Uri="http://redfish.dmtf.org/schemas/v1/Port_v1.xml">
+    <edmx:Include Namespace="Port"/>
+  </edmx:Reference>
+  <edmx:Reference Uri="http://redfish.dmtf.org/schemas/v1/ComputerSystem_v1.xml">
+    <edmx:Include Namespace="ComputerSystem"/>
+  </edmx:Reference>
+  <edmx:Reference Uri="http://redfish.dmtf.org/schemas/v1/Processor_v1.xml">
+    <edmx:Include Namespace="Processor"/>
+  </edmx:Reference>
+  <edmx:Reference Uri="http://redfish.dmtf.org/schemas/v1/AllowDenyCollection_v1.xml">
+    <edmx:Include Namespace="AllowDenyCollection"/>
+  </edmx:Reference>
+
+  <edmx:DataServices>
+
+    <Schema xmlns="http://docs.oasis-open.org/odata/ns/edm" Namespace="NetworkDeviceFunction">
+      <Annotation Term="Redfish.OwningEntity" String="DMTF"/>
+
+      <EntityType Name="NetworkDeviceFunction" BaseType="Resource.v1_0_0.Resource" Abstract="true">
+        <Annotation Term="OData.Description" String="The NetworkDeviceFunction schema represents a logical interface that a network adapter exposes."/>
+        <Annotation Term="OData.LongDescription" String="This resource shall represent a logical interface that a network adapter exposes in a Redfish implementation."/>
+        <Annotation Term="Capabilities.InsertRestrictions">
+          <Record>
+            <PropertyValue Property="Insertable" Bool="false"/>
+          </Record>
+        </Annotation>
+        <Annotation Term="Capabilities.UpdateRestrictions">
+          <Record>
+            <PropertyValue Property="Updatable" Bool="true"/>
+            <Annotation Term="OData.Description" String="Properties, such as WWN and MAC address information for this device, can be updated for a network device function."/>
+          </Record>
+        </Annotation>
+        <Annotation Term="Capabilities.DeleteRestrictions">
+          <Record>
+            <PropertyValue Property="Deletable" Bool="false"/>
+          </Record>
+        </Annotation>
+        <Annotation Term="Redfish.Uris">
+          <Collection>
+            <String>/redfish/v1/Chassis/{ChassisId}/NetworkAdapters/{NetworkAdapterId}/NetworkDeviceFunctions/{NetworkDeviceFunctionId}</String>
+          </Collection>
+        </Annotation>
+      </EntityType>
+    </Schema>
+
+    <Schema xmlns="http://docs.oasis-open.org/odata/ns/edm" Namespace="NetworkDeviceFunction.v1_0_0">
+      <Annotation Term="Redfish.OwningEntity" String="DMTF"/>
+      <Annotation Term="Redfish.Release" String="2016.3"/>
+
+      <EntityType Name="NetworkDeviceFunction" BaseType="NetworkDeviceFunction.NetworkDeviceFunction">
+        <Property Name="Status" Type="Resource.Status" Nullable="false">
+          <Annotation Term="OData.Description" String="The status and health of the resource and its subordinate or dependent resources."/>
+          <Annotation Term="OData.LongDescription" String="This property shall contain any status or health properties of the resource."/>
+        </Property>
+        <Property Name="NetDevFuncType" Type="NetworkDeviceFunction.v1_0_0.NetworkDeviceTechnology">
+          <Annotation Term="OData.Permissions" EnumMember="OData.Permission/ReadWrite"/>
+          <Annotation Term="OData.Description" String="The configured capability of this network device function."/>
+          <Annotation Term="OData.LongDescription" String="This property shall contain the configured capability of this network device function."/>
+        </Property>
+        <Property Name="DeviceEnabled" Type="Edm.Boolean">
+          <Annotation Term="OData.Permissions" EnumMember="OData.Permission/ReadWrite"/>
+          <Annotation Term="OData.Description" String="An indication of whether the network device function is enabled."/>
+          <Annotation Term="OData.LongDescription" String="This property shall indicate whether the network device function is enabled.  The operating system shall not enumerate or see disabled network device functions."/>
+        </Property>
+        <Property Name="NetDevFuncCapabilities" Type="Collection(NetworkDeviceFunction.v1_0_0.NetworkDeviceTechnology)">
+          <Annotation Term="OData.Permissions" EnumMember="OData.Permission/Read"/>
+          <Annotation Term="OData.Description" String="An array of capabilities for this network device function."/>
+          <Annotation Term="OData.LongDescription" String="This property shall contain an array of capabilities for this network device function."/>
+        </Property>
+        <Property Name="Ethernet" Type="NetworkDeviceFunction.v1_0_0.Ethernet" Nullable="false">
+          <Annotation Term="OData.Description" String="The Ethernet capabilities, status, and configuration values for this network device function."/>
+          <Annotation Term="OData.LongDescription" String="This property shall contain Ethernet capabilities, status, and configuration values for this network device function."/>
+        </Property>
+        <Property Name="iSCSIBoot" Type="NetworkDeviceFunction.v1_0_0.iSCSIBoot" Nullable="false">
+          <Annotation Term="OData.Description" String="The iSCSI boot capabilities, status, and configuration values for this network device function."/>
+          <Annotation Term="OData.LongDescription" String="This property shall contain iSCSI boot capabilities, status, and configuration values for this network device function."/>
+        </Property>
+        <Property Name="FibreChannel" Type="NetworkDeviceFunction.v1_0_0.FibreChannel" Nullable="false">
+          <Annotation Term="OData.Description" String="The Fibre Channel capabilities, status, and configuration values for this network device function."/>
+          <Annotation Term="OData.LongDescription" String="This property shall contain Fibre Channel capabilities, status, and configuration values for this network device function."/>
+        </Property>
+        <NavigationProperty Name="AssignablePhysicalPorts" Type="Collection(NetworkPort.NetworkPort)">
+          <Annotation Term="OData.Permissions" EnumMember="OData.Permission/Read"/>
+          <Annotation Term="OData.Description" String="An array of physical ports to which this network device function can be assigned."/>
+          <Annotation Term="OData.LongDescription" String="This property shall contain an array of links to resources of type NetworkPort that are the physical ports to which this network device function can be assigned."/>
+          <Annotation Term="OData.AutoExpandReferences"/>
+          <Annotation Term="Redfish.Revisions">
+            <Collection>
+              <Record>
+                <PropertyValue Property="Kind" EnumMember="Redfish.RevisionKind/Deprecated"/>
+                <PropertyValue Property="Version" String="v1_5_0"/>
+                <PropertyValue Property="Description" String="This property has been deprecated in favor of the AssignablePhysicalNetworkPorts property."/>
+              </Record>
+            </Collection>
+          </Annotation>
+        </NavigationProperty>
+        <NavigationProperty Name="PhysicalPortAssignment" Type="NetworkPort.NetworkPort" Nullable="false">
+          <Annotation Term="OData.Permissions" EnumMember="OData.Permission/Read"/>
+          <Annotation Term="OData.Description" String="The physical port to which this network device function is currently assigned."/>
+          <Annotation Term="OData.LongDescription" String="This property shall contain a link to a resource of type NetworkPort that is the physical port to which this network device function is currently assigned.  This value shall be one of the AssignablePhysicalPorts array members."/>
+          <Annotation Term="OData.AutoExpandReferences"/>
+          <Annotation Term="Redfish.Revisions">
+            <Collection>
+              <Record>
+                <PropertyValue Property="Kind" EnumMember="Redfish.RevisionKind/Deprecated"/>
+                <PropertyValue Property="Version" String="v1_3_0"/>
+                <PropertyValue Property="Description" String="This property has been deprecated and moved to the Links property to avoid loops on expand."/>
+              </Record>
+            </Collection>
+          </Annotation>
+        </NavigationProperty>
+        <Property Name="BootMode" Type="NetworkDeviceFunction.v1_0_0.BootMode">
+          <Annotation Term="OData.Permissions" EnumMember="OData.Permission/ReadWrite"/>
+          <Annotation Term="OData.Description" String="The boot mode configured for this network device function."/>
+          <Annotation Term="OData.LongDescription" String="This property shall contain the boot mode configured for this network device function.  If the value is not `Disabled`, this network device function shall be configured for boot by using the specified technology."/>
+        </Property>
+        <Property Name="VirtualFunctionsEnabled" Type="Edm.Boolean">
+          <Annotation Term="OData.Permissions" EnumMember="OData.Permission/Read"/>
+          <Annotation Term="OData.Description" String="An indication of whether single root input/output virtualization (SR-IOV) virtual functions are enabled for this network device function."/>
+          <Annotation Term="OData.LongDescription" String="This property shall indicate whether single root input/output virtualization (SR-IOV) virtual functions are enabled for this network device function."/>
+        </Property>
+        <Property Name="MaxVirtualFunctions" Type="Edm.Int64">
+          <Annotation Term="OData.Permissions" EnumMember="OData.Permission/Read"/>
+          <Annotation Term="OData.Description" String="The number of virtual functions that are available for this network device function."/>
+          <Annotation Term="OData.LongDescription" String="This property shall contain the number of virtual functions that are available for this network device function."/>
+        </Property>
+        <Property Name="Links" Type="NetworkDeviceFunction.v1_0_0.Links" Nullable="false">
+          <Annotation Term="OData.Description" String="The links to other resources that are related to this resource."/>
+          <Annotation Term="OData.LongDescription" String="This property shall contain links to resources that are related to but are not contained by, or subordinate to, this resource."/>
+        </Property>
+      </EntityType>
+
+      <ComplexType Name="FibreChannel">
+        <Annotation Term="OData.AdditionalProperties" Bool="false"/>
+        <Annotation Term="OData.Description" String="This type describes Fibre Channel capabilities, status, and configuration for a network device function."/>
+        <Annotation Term="OData.LongDescription" String="This type shall describe the Fibre Channel capabilities, status, and configuration values for a network device function."/>
+        <Property Name="PermanentWWPN" Type="Edm.String">
+          <Annotation Term="OData.Permissions" EnumMember="OData.Permission/Read"/>
+          <Annotation Term="OData.Description" String="The permanent World Wide Port Name (WWPN) address assigned to this function."/>
+          <Annotation Term="OData.LongDescription" String="This property shall contain the permanent World Wide Port Name (WWPN) of this function.  Typically, this value is programmed during manufacturing.  This address is not assignable."/>
+        </Property>
+        <Property Name="PermanentWWNN" Type="Edm.String">
+          <Annotation Term="OData.Permissions" EnumMember="OData.Permission/Read"/>
+          <Annotation Term="OData.Description" String="The permanent World Wide Node Name (WWNN) address assigned to this function."/>
+          <Annotation Term="OData.LongDescription" String="This property shall contain the permanent World Wide Node Name (WWNN) of this function.  Typically, this value is programmed during manufacturing.  This address is not assignable."/>
+          <Annotation Term="Validation.Pattern" String="^([0-9A-Fa-f]{2}[:-]){7}([0-9A-Fa-f]{2})$"/>
+        </Property>
+        <Property Name="WWPN" Type="Edm.String">
+          <Annotation Term="OData.Permissions" EnumMember="OData.Permission/ReadWrite"/>
+          <Annotation Term="OData.Description" String="The currently configured World Wide Port Name (WWPN) address of this function."/>
+          <Annotation Term="OData.LongDescription" String="This property shall contain the effective current World Wide Port Name (WWPN) of this function.  If an assignable WWPN is not supported, this is a read-only alias of the permanent WWPN."/>
+          <Annotation Term="Validation.Pattern" String="^([0-9A-Fa-f]{2}[:-]){7}([0-9A-Fa-f]{2})$"/>
+        </Property>
+        <Property Name="WWNN" Type="Edm.String">
+          <Annotation Term="OData.Permissions" EnumMember="OData.Permission/ReadWrite"/>
+          <Annotation Term="OData.Description" String="The currently configured World Wide Node Name (WWNN) address of this function."/>
+          <Annotation Term="OData.LongDescription" String="This property shall contain the effective current World Wide Node Name (WWNN) of this function.  If an assignable WWNN is not supported, this is a read-only alias of the permanent WWNN."/>
+          <Annotation Term="Validation.Pattern" String="^([0-9A-Fa-f]{2}[:-]){7}([0-9A-Fa-f]{2})$"/>
+        </Property>
+        <Property Name="WWNSource" Type="NetworkDeviceFunction.v1_0_0.WWNSource">
+          <Annotation Term="OData.Permissions" EnumMember="OData.Permission/ReadWrite"/>
+          <Annotation Term="OData.Description" String="The configuration source of the World Wide Names (WWN) for this World Wide Node Name (WWNN) and World Wide Port Name (WWPN) connection."/>
+          <Annotation Term="OData.LongDescription" String="This property shall contain the configuration source of the World Wide Name (WWN) for this World Wide Node Name (WWNN) and World Wide Port Name (WWPN) connection."/>
+        </Property>
+        <Property Name="FCoELocalVLANId" Type="Edm.Int64">
+          <Annotation Term="OData.Permissions" EnumMember="OData.Permission/ReadWrite"/>
+          <Annotation Term="OData.Description" String="The locally configured FCoE VLAN ID."/>
+          <Annotation Term="OData.LongDescription" String="For FCoE connections, this property shall contain the VLAN ID configured locally by setting this property.  This value shall be used for FCoE traffic to this network device function during boot unless AllowFIPVLANDiscovery is `true` and a valid FCoE VLAN ID is found through the FIP VLAN Discovery Protocol."/>
+          <Annotation Term="Validation.Minimum" Int="0"/>
+          <Annotation Term="Validation.Maximum" Int="4094"/>
+        </Property>
+        <Property Name="AllowFIPVLANDiscovery" Type="Edm.Boolean">
+          <Annotation Term="OData.Permissions" EnumMember="OData.Permission/ReadWrite"/>
+          <Annotation Term="OData.Description" String="An indication of whether the FCoE Initialization Protocol (FIP) populates the FCoE VLAN ID."/>
+          <Annotation Term="OData.LongDescription" String="For FCoE connections, this boolean property shall indicate whether the FIP VLAN Discovery Protocol determines the FCoE VLAN ID selected by the network device function for the FCoE connection.  If `true` and the FIP VLAN discovery succeeds, the FCoEActiveVLANId property shall reflect the FCoE VLAN ID to use for all FCoE traffic.  If `false` or if the FIP VLAN Discovery protocol fails, the FCoELocalVLANId shall be used for all FCoE traffic and the FCoEActiveVLANId shall reflect the FCoELocalVLANId."/>
+        </Property>
+        <Property Name="FCoEActiveVLANId" Type="Edm.Int64">
+          <Annotation Term="OData.Permissions" EnumMember="OData.Permission/Read"/>
+          <Annotation Term="OData.Description" String="The active FCoE VLAN ID."/>
+          <Annotation Term="OData.LongDescription" String="For FCoE connections, this property shall contain `null` or a VLAN ID currently being used for FCoE traffic.  When the FCoE link is down this value shall be null.  When the FCoE link is up this value shall be either the FCoELocalVLANId property or a VLAN discovered through the FIP protocol."/>
+          <Annotation Term="Validation.Minimum" Int="0"/>
+          <Annotation Term="Validation.Maximum" Int="4094"/>
+        </Property>
+        <Property Name="BootTargets" Type="Collection(NetworkDeviceFunction.v1_0_0.BootTargets)">
+          <Annotation Term="OData.Description" String="An array of Fibre Channel boot targets configured for this network device function."/>
+          <Annotation Term="OData.LongDescription" String="This property shall contain an array of Fibre Channel boot targets configured for this network device function."/>
+        </Property>
+      </ComplexType>
+
+      <ComplexType Name="Ethernet">
+        <Annotation Term="OData.AdditionalProperties" Bool="false"/>
+        <Annotation Term="OData.Description" String="This type describes Ethernet capabilities, status, and configuration for a network device function."/>
+        <Annotation Term="OData.LongDescription" String="This type shall describe the Ethernet capabilities, status, and configuration values for a network device function."/>
+        <Property Name="PermanentMACAddress" Type="Edm.String">
+          <Annotation Term="OData.Permissions" EnumMember="OData.Permission/Read"/>
+          <Annotation Term="OData.Description" String="The permanent MAC address assigned to this function."/>
+          <Annotation Term="OData.LongDescription" String="This property shall contain the permanent MAC Address of this function.  Typically, this value is programmed during manufacturing.  This address is not assignable."/>
+          <Annotation Term="Validation.Pattern" String="^([0-9A-Fa-f]{2}[:-]){5}([0-9A-Fa-f]{2})$"/>
+        </Property>
+        <Property Name="MACAddress" Type="Edm.String">
+          <Annotation Term="OData.Permissions" EnumMember="OData.Permission/ReadWrite"/>
+          <Annotation Term="OData.Description" String="The currently configured MAC address."/>
+          <Annotation Term="OData.LongDescription" String="This property shall contain the effective current MAC address of this network device function.  If an assignable MAC address is not supported, this is a read-only alias of the PermanentMACAddress."/>
+          <Annotation Term="Validation.Pattern" String="^([0-9A-Fa-f]{2}[:-]){5}([0-9A-Fa-f]{2})$"/>
+        </Property>
+        <Property Name="MTUSize" Type="Edm.Int64">
+          <Annotation Term="OData.Permissions" EnumMember="OData.Permission/ReadWrite"/>
+          <Annotation Term="OData.Description" String="The maximum transmission unit (MTU) configured for this network device function."/>
+          <Annotation Term="OData.LongDescription" String="The maximum transmission unit (MTU) configured for this network device function.  This value serves as a default for the OS driver when booting.  The value only takes effect on boot."/>
+        </Property>
+      </ComplexType>
+
+      <ComplexType Name="Links" BaseType="Resource.Links">
+        <Annotation Term="OData.Description" String="The links to other resources that are related to this resource."/>
+        <Annotation Term="OData.LongDescription" String="This Redfish Specification-described type shall contain links to resources that are related to but are not contained by, or subordinate to, this resource."/>
+        <NavigationProperty Name="PCIeFunction" Type="PCIeFunction.PCIeFunction" Nullable="false">
+          <Annotation Term="OData.Permissions" EnumMember="OData.Permission/Read"/>
+          <Annotation Term="OData.Description" String="The link to the PCIe function associated with this network device function."/>
+          <Annotation Term="OData.LongDescription" String="This property shall contain a link to a resource of type PCIeFunction that represents the PCIe function associated with this network device function."/>
+          <Annotation Term="OData.AutoExpandReferences"/>
+        </NavigationProperty>
+      </ComplexType>
+
+      <ComplexType Name="iSCSIBoot">
+        <Annotation Term="OData.AdditionalProperties" Bool="false"/>
+        <Annotation Term="OData.Description" String="The iSCSI boot capabilities, status, and configuration for a network device function."/>
+        <Annotation Term="OData.LongDescription" String="This type shall describe the iSCSI boot capabilities, status, and configuration values for a network device function."/>
+        <Property Name="IPAddressType" Type="NetworkDeviceFunction.v1_0_0.IPAddressType">
+          <Annotation Term="OData.Permissions" EnumMember="OData.Permission/ReadWrite"/>
+          <Annotation Term="OData.Description" String="The type of IP address being populated in the iSCSIBoot IP address fields."/>
+          <Annotation Term="OData.LongDescription" String="This property shall contain the type of IP address being populated in the iSCSIBoot IP address fields.  Mixing IPv6 and IPv4 addresses on the same network device function shall not be permissible."/>
+        </Property>
+        <Property Name="InitiatorIPAddress" Type="Edm.String">
+          <Annotation Term="OData.Permissions" EnumMember="OData.Permission/ReadWrite"/>
+          <Annotation Term="OData.Description" String="The IPv6 or IPv4 address of the iSCSI initiator."/>
+          <Annotation Term="OData.LongDescription" String="This property shall contain the IPv6 or IPv4 address of the iSCSI boot initiator."/>
+        </Property>
+        <Property Name="InitiatorName" Type="Edm.String">
+          <Annotation Term="OData.Permissions" EnumMember="OData.Permission/ReadWrite"/>
+          <Annotation Term="OData.Description" String="The iSCSI initiator name."/>
+          <Annotation Term="OData.LongDescription" String="This property shall contain the iSCSI boot initiator name.  This property should match formats defined in RFC3720 or RFC3721."/>
+        </Property>
+        <Property Name="InitiatorDefaultGateway" Type="Edm.String">
+          <Annotation Term="OData.Permissions" EnumMember="OData.Permission/ReadWrite"/>
+          <Annotation Term="OData.Description" String="The IPv6 or IPv4 iSCSI boot default gateway."/>
+          <Annotation Term="OData.LongDescription" String="This property shall contain the IPv6 or IPv4 iSCSI boot default gateway."/>
+        </Property>
+        <Property Name="InitiatorNetmask" Type="Edm.String">
+          <Annotation Term="OData.Permissions" EnumMember="OData.Permission/ReadWrite"/>
+          <Annotation Term="OData.Description" String="The IPv6 or IPv4 netmask of the iSCSI boot initiator."/>
+          <Annotation Term="OData.LongDescription" String="This property shall contain the IPv6 or IPv4 netmask of the iSCSI boot initiator."/>
+        </Property>
+        <Property Name="TargetInfoViaDHCP" Type="Edm.Boolean">
+          <Annotation Term="OData.Permissions" EnumMember="OData.Permission/ReadWrite"/>
+          <Annotation Term="OData.Description" String="An indication of whether the iSCSI boot target name, LUN, IP address, and netmask should be obtained from DHCP."/>
+          <Annotation Term="OData.LongDescription" String="This property shall indicate whether the iSCSI boot target name, LUN, IP address, and netmask should be obtained from DHCP."/>
+        </Property>
+        <Property Name="PrimaryTargetName" Type="Edm.String">
+          <Annotation Term="OData.Permissions" EnumMember="OData.Permission/ReadWrite"/>
+          <Annotation Term="OData.Description" String="The name of the iSCSI primary boot target."/>
+          <Annotation Term="OData.LongDescription" String="This property shall contain the name of the primary iSCSI boot target.  This property should match formats defined in RFC3720 or RFC3721."/>
+        </Property>
+        <Property Name="PrimaryTargetIPAddress" Type="Edm.String">
+          <Annotation Term="OData.Permissions" EnumMember="OData.Permission/ReadWrite"/>
+          <Annotation Term="OData.Description" String="The IPv4 or IPv6 address for the primary iSCSI boot target."/>
+          <Annotation Term="OData.LongDescription" String="This property shall contain the IPv4 or IPv6 address for the primary iSCSI boot target."/>
+        </Property>
+        <Property Name="PrimaryTargetTCPPort" Type="Edm.Int64">
+          <Annotation Term="OData.Permissions" EnumMember="OData.Permission/ReadWrite"/>
+          <Annotation Term="OData.Description" String="The TCP port for the primary iSCSI boot target."/>
+          <Annotation Term="OData.LongDescription" String="This property shall contain the TCP port for the primary iSCSI boot target."/>
+        </Property>
+        <Property Name="PrimaryLUN" Type="Edm.Int64">
+          <Annotation Term="OData.Permissions" EnumMember="OData.Permission/ReadWrite"/>
+          <Annotation Term="OData.Description" String="The logical unit number (LUN) for the primary iSCSI boot target."/>
+          <Annotation Term="OData.LongDescription" String="This property shall contain the logical unit number (LUN) for the primary iSCSI boot target."/>
+        </Property>
+        <Property Name="PrimaryVLANEnable" Type="Edm.Boolean">
+          <Annotation Term="OData.Permissions" EnumMember="OData.Permission/ReadWrite"/>
+          <Annotation Term="OData.Description" String="An indication of whether the primary VLAN is enabled."/>
+          <Annotation Term="OData.LongDescription" String="This property shall indicate whether this VLAN is enabled for the primary iSCSI boot target."/>
+        </Property>
+        <Property Name="PrimaryVLANId" Type="Edm.Int64">
+          <Annotation Term="OData.Permissions" EnumMember="OData.Permission/ReadWrite"/>
+          <Annotation Term="OData.Description" String="The 802.1q VLAN ID to use for iSCSI boot from the primary target."/>
+          <Annotation Term="OData.LongDescription" String="This property shall contain the 802.1q VLAN ID to use for iSCSI boot from the primary target.  This VLAN ID is only used if PrimaryVLANEnable is true."/>
+          <Annotation Term="Validation.Minimum" Int="0"/>
+          <Annotation Term="Validation.Maximum" Int="4094"/>
+        </Property>
+        <Property Name="PrimaryDNS" Type="Edm.String">
+          <Annotation Term="OData.Permissions" EnumMember="OData.Permission/ReadWrite"/>
+          <Annotation Term="OData.Description" String="The IPv6 or IPv4 address of the primary DNS server for the iSCSI boot initiator."/>
+          <Annotation Term="OData.LongDescription" String="This property shall contain the IPv6 or IPv4 address of the primary DNS server for the iSCSI boot initiator."/>
+        </Property>
+        <Property Name="SecondaryTargetName" Type="Edm.String">
+          <Annotation Term="OData.Permissions" EnumMember="OData.Permission/ReadWrite"/>
+          <Annotation Term="OData.Description" String="The name of the iSCSI secondary boot target."/>
+          <Annotation Term="OData.LongDescription" String="This property shall contain the name of the secondary iSCSI boot target.  This property should match formats defined in RFC3720 or RFC3721."/>
+        </Property>
+        <Property Name="SecondaryTargetIPAddress" Type="Edm.String">
+          <Annotation Term="OData.Permissions" EnumMember="OData.Permission/ReadWrite"/>
+          <Annotation Term="OData.Description" String="The IPv4 or IPv6 address for the secondary iSCSI boot target."/>
+          <Annotation Term="OData.LongDescription" String="This property shall contain the IPv4 or IPv6 address for the secondary iSCSI boot target."/>
+        </Property>
+        <Property Name="SecondaryTargetTCPPort" Type="Edm.Int64">
+          <Annotation Term="OData.Permissions" EnumMember="OData.Permission/ReadWrite"/>
+          <Annotation Term="OData.Description" String="The TCP port for the secondary iSCSI boot target."/>
+          <Annotation Term="OData.LongDescription" String="This property shall contain the TCP port for the secondary iSCSI boot target."/>
+        </Property>
+        <Property Name="SecondaryLUN" Type="Edm.Int64">
+          <Annotation Term="OData.Permissions" EnumMember="OData.Permission/ReadWrite"/>
+          <Annotation Term="OData.Description" String="The logical unit number (LUN) for the secondary iSCSI boot target."/>
+          <Annotation Term="OData.LongDescription" String="This property shall contain the logical unit number (LUN) for the secondary iSCSI boot target."/>
+        </Property>
+        <Property Name="SecondaryVLANEnable" Type="Edm.Boolean">
+          <Annotation Term="OData.Permissions" EnumMember="OData.Permission/ReadWrite"/>
+          <Annotation Term="OData.Description" String="An indication of whether the secondary VLAN is enabled."/>
+          <Annotation Term="OData.LongDescription" String="This property shall indicate whether this VLAN is enabled for the secondary iSCSI boot target."/>
+        </Property>
+        <Property Name="SecondaryVLANId" Type="Edm.Int64">
+          <Annotation Term="OData.Permissions" EnumMember="OData.Permission/ReadWrite"/>
+          <Annotation Term="OData.Description" String="The 802.1q VLAN ID to use for iSCSI boot from the secondary target."/>
+          <Annotation Term="OData.LongDescription" String="This property shall contain the 802.1q VLAN ID to use for iSCSI boot from the secondary target.  This VLAN ID is only used if SecondaryVLANEnable is `true`."/>
+          <Annotation Term="Validation.Minimum" Int="0"/>
+          <Annotation Term="Validation.Maximum" Int="4094"/>
+        </Property>
+        <Property Name="SecondaryDNS" Type="Edm.String">
+          <Annotation Term="OData.Permissions" EnumMember="OData.Permission/ReadWrite"/>
+          <Annotation Term="OData.Description" String="The IPv6 or IPv4 address of the secondary DNS server for the iSCSI boot initiator."/>
+          <Annotation Term="OData.LongDescription" String="This property shall contain the IPv6 or IPv4 address of the secondary DNS server for the iSCSI boot initiator."/>
+        </Property>
+        <Property Name="IPMaskDNSViaDHCP" Type="Edm.Boolean">
+          <Annotation Term="OData.Permissions" EnumMember="OData.Permission/ReadWrite"/>
+          <Annotation Term="OData.Description" String="An indication of whether the iSCSI boot initiator uses DHCP to obtain the initiator name, IP address, and netmask."/>
+          <Annotation Term="OData.LongDescription" String="This property shall indicate whether the iSCSI boot initiator uses DHCP to obtain the initiator name, IP address, and netmask."/>
+        </Property>
+        <Property Name="RouterAdvertisementEnabled" Type="Edm.Boolean">
+          <Annotation Term="OData.Permissions" EnumMember="OData.Permission/ReadWrite"/>
+          <Annotation Term="OData.Description" String="An indication of whether IPv6 router advertisement is enabled for the iSCSI boot target."/>
+          <Annotation Term="OData.LongDescription" String="This property shall indicate whether IPv6 router advertisement is enabled for the iSCSI boot target.  This setting shall apply to only IPv6 configurations."/>
+        </Property>
+        <Property Name="AuthenticationMethod" Type="NetworkDeviceFunction.v1_0_0.AuthenticationMethod">
+          <Annotation Term="OData.Permissions" EnumMember="OData.Permission/ReadWrite"/>
+          <Annotation Term="OData.Description" String="The iSCSI boot authentication method for this network device function."/>
+          <Annotation Term="OData.LongDescription" String="This property shall contain the iSCSI boot authentication method for this network device function."/>
+        </Property>
+        <Property Name="CHAPUsername" Type="Edm.String">
+          <Annotation Term="OData.Permissions" EnumMember="OData.Permission/ReadWrite"/>
+          <Annotation Term="OData.Description" String="The user name for CHAP authentication."/>
+          <Annotation Term="OData.LongDescription" String="This property shall contain the user name for CHAP authentication."/>
+        </Property>
+        <Property Name="CHAPSecret" Type="Edm.String">
+          <Annotation Term="OData.Permissions" EnumMember="OData.Permission/ReadWrite"/>
+          <Annotation Term="OData.Description" String="The shared secret for CHAP authentication."/>
+          <Annotation Term="OData.LongDescription" String="This property shall contain the shared secret for CHAP authentication."/>
+        </Property>
+        <Property Name="MutualCHAPUsername" Type="Edm.String">
+          <Annotation Term="OData.Permissions" EnumMember="OData.Permission/ReadWrite"/>
+          <Annotation Term="OData.Description" String="The CHAP user name for two-way CHAP authentication."/>
+          <Annotation Term="OData.LongDescription" String="This property shall contain the CHAP user name for two-way CHAP authentication."/>
+        </Property>
+        <Property Name="MutualCHAPSecret" Type="Edm.String">
+          <Annotation Term="OData.Permissions" EnumMember="OData.Permission/ReadWrite"/>
+          <Annotation Term="OData.Description" String="The CHAP secret for two-way CHAP authentication."/>
+          <Annotation Term="OData.LongDescription" String="This property shall contain the CHAP secret for two-way CHAP authentication."/>
+        </Property>
+      </ComplexType>
+
+      <ComplexType Name="BootTargets">
+        <Annotation Term="OData.AdditionalProperties" Bool="false"/>
+        <Annotation Term="OData.Description" String="A Fibre Channel boot target configured for a network device function."/>
+        <Annotation Term="OData.LongDescription" String="This type shall describe a Fibre Channel boot target configured for a network device function."/>
+        <Property Name="WWPN" Type="Edm.String">
+          <Annotation Term="OData.Permissions" EnumMember="OData.Permission/ReadWrite"/>
+          <Annotation Term="OData.Description" String="The World Wide Port Name (WWPN) from which to boot."/>
+          <Annotation Term="OData.LongDescription" String="This property shall contain World Wide Port Name (WWPN) from which to boot."/>
+        </Property>
+        <Property Name="LUNID" Type="Edm.String">
+          <Annotation Term="OData.Permissions" EnumMember="OData.Permission/ReadWrite"/>
+          <Annotation Term="OData.Description" String="The logical unit number (LUN) ID from which to boot on the device to which the corresponding WWPN refers."/>
+          <Annotation Term="OData.LongDescription" String="This property shall contain the logical unit number (LUN) ID from which to boot on the device to which the corresponding WWPN refers."/>
+        </Property>
+        <Property Name="BootPriority" Type="Edm.Int64">
+          <Annotation Term="OData.Permissions" EnumMember="OData.Permission/ReadWrite"/>
+          <Annotation Term="OData.Description" String="The relative priority for this entry in the boot targets array."/>
+          <Annotation Term="OData.LongDescription" String="This property shall contain the relative priority for this entry in the boot targets array.  Lower numbers shall represent higher priority, with zero being the highest priority.  The BootPriority shall be unique for all entries of the BootTargets array."/>
+        </Property>
+      </ComplexType>
+
+      <EnumType Name="NetworkDeviceTechnology">
+        <Member Name="Disabled">
+          <Annotation Term="OData.Description" String="Neither enumerated nor visible to the operating system."/>
+        </Member>
+        <Member Name="Ethernet">
+          <Annotation Term="OData.Description" String="Appears to the operating system as an Ethernet device."/>
+        </Member>
+        <Member Name="FibreChannel">
+          <Annotation Term="OData.Description" String="Appears to the operating system as a Fibre Channel device."/>
+        </Member>
+        <Member Name="iSCSI">
+          <Annotation Term="OData.Description" String="Appears to the operating system as an iSCSI device."/>
+        </Member>
+        <Member Name="FibreChannelOverEthernet">
+          <Annotation Term="OData.Description" String="Appears to the operating system as an FCoE device."/>
+        </Member>
+        <Member Name="InfiniBand">
+          <Annotation Term="OData.Description" String="Appears to the operating system as an InfiniBand device."/>
+          <Annotation Term="Redfish.Revisions">
+            <Collection>
+              <Record>
+                <PropertyValue Property="Kind" EnumMember="Redfish.RevisionKind/Added"/>
+                <PropertyValue Property="Version" String="v1_5_0"/>
+              </Record>
+            </Collection>
+          </Annotation>
+        </Member>
+      </EnumType>
+
+      <EnumType Name="IPAddressType">
+        <Member Name="IPv4">
+          <Annotation Term="OData.Description" String="IPv4 addressing is used for all IP-fields in this object."/>
+        </Member>
+        <Member Name="IPv6">
+          <Annotation Term="OData.Description" String="IPv6 addressing is used for all IP-fields in this object."/>
+        </Member>
+      </EnumType>
+
+      <EnumType Name="AuthenticationMethod">
+        <Member Name="None">
+          <Annotation Term="OData.Description" String="No iSCSI authentication is used."/>
+        </Member>
+        <Member Name="CHAP">
+          <Annotation Term="OData.Description" String="iSCSI Challenge Handshake Authentication Protocol (CHAP) authentication is used."/>
+        </Member>
+        <Member Name="MutualCHAP">
+          <Annotation Term="OData.Description" String="iSCSI Mutual Challenge Handshake Authentication Protocol (CHAP) authentication is used."/>
+        </Member>
+      </EnumType>
+
+      <EnumType Name="WWNSource">
+        <Member Name="ConfiguredLocally">
+          <Annotation Term="OData.Description" String="The set of FC/FCoE boot targets was applied locally through API or UI."/>
+        </Member>
+        <Member Name="ProvidedByFabric">
+          <Annotation Term="OData.Description" String="The set of FC/FCoE boot targets was applied by the Fibre Channel fabric."/>
+        </Member>
+      </EnumType>
+
+      <EnumType Name="BootMode">
+        <Member Name="Disabled">
+          <Annotation Term="OData.Description" String="Do not indicate to UEFI/BIOS that this device is bootable."/>
+        </Member>
+        <Member Name="PXE">
+          <Annotation Term="OData.Description" String="Boot this device by using the embedded PXE support.  Only applicable if the NetDevFuncType is `Ethernet` or `InfiniBand`."/>
+        </Member>
+        <Member Name="iSCSI">
+          <Annotation Term="OData.Description" String="Boot this device by using the embedded iSCSI boot support and configuration.  Only applicable if the NetDevFuncType is `iSCSI` or `Ethernet`."/>
+        </Member>
+        <Member Name="FibreChannel">
+          <Annotation Term="OData.Description" String="Boot this device by using the embedded Fibre Channel support and configuration.  Only applicable if the NetDevFuncType is `FibreChannel`."/>
+        </Member>
+        <Member Name="FibreChannelOverEthernet">
+          <Annotation Term="OData.Description" String="Boot this device by using the embedded Fibre Channel over Ethernet (FCoE) boot support and configuration.  Only applicable if the NetDevFuncType is `FibreChannelOverEthernet`."/>
+        </Member>
+      </EnumType>
+    </Schema>
+
+    <Schema xmlns="http://docs.oasis-open.org/odata/ns/edm" Namespace="NetworkDeviceFunction.v1_0_1">
+      <Annotation Term="Redfish.OwningEntity" String="DMTF"/>
+      <Annotation Term="OData.Description" String="This version was created to remove the Nullable facet on NavigationProperties of the Collection type."/>
+      <EntityType Name="NetworkDeviceFunction" BaseType="NetworkDeviceFunction.v1_0_0.NetworkDeviceFunction"/>
+    </Schema>
+
+    <Schema xmlns="http://docs.oasis-open.org/odata/ns/edm" Namespace="NetworkDeviceFunction.v1_0_2">
+      <Annotation Term="Redfish.OwningEntity" String="DMTF"/>
+      <Annotation Term="OData.Description" String="This version was created to add normative statements about the format of InitiatorName, PrimaryTargetName, and SecondaryTargetName properties in the iSCSIBoot structure.  It was also created to fix the descriptions for AssignablePhysicalPorts and PhysicalPortAssignment."/>
+      <EntityType Name="NetworkDeviceFunction" BaseType="NetworkDeviceFunction.v1_0_1.NetworkDeviceFunction"/>
+    </Schema>
+
+    <Schema xmlns="http://docs.oasis-open.org/odata/ns/edm" Namespace="NetworkDeviceFunction.v1_0_3">
+      <Annotation Term="Redfish.OwningEntity" String="DMTF"/>
+      <Annotation Term="OData.Description" String="This version was created to force the regeneration of JSON Schema so that OData properties are marked as required, and integer properties are marked as integer rather than number."/>
+      <EntityType Name="NetworkDeviceFunction" BaseType="NetworkDeviceFunction.v1_0_2.NetworkDeviceFunction"/>
+    </Schema>
+
+    <Schema xmlns="http://docs.oasis-open.org/odata/ns/edm" Namespace="NetworkDeviceFunction.v1_0_4">
+      <Annotation Term="Redfish.OwningEntity" String="DMTF"/>
+      <Annotation Term="OData.Description" String="This version was created to use the new Revisions annotation."/>
+      <EntityType Name="NetworkDeviceFunction" BaseType="NetworkDeviceFunction.v1_0_3.NetworkDeviceFunction"/>
+    </Schema>
+
+    <Schema xmlns="http://docs.oasis-open.org/odata/ns/edm" Namespace="NetworkDeviceFunction.v1_0_5">
+      <Annotation Term="Redfish.OwningEntity" String="DMTF"/>
+      <Annotation Term="OData.Description" String="This version was created to force the regeneration of JSON Schema so that URI properties use the uri-reference format.  It was also created to add a missing term on several properties to not allow them to be null."/>
+      <EntityType Name="NetworkDeviceFunction" BaseType="NetworkDeviceFunction.v1_0_4.NetworkDeviceFunction"/>
+    </Schema>
+
+    <Schema xmlns="http://docs.oasis-open.org/odata/ns/edm" Namespace="NetworkDeviceFunction.v1_0_6">
+      <Annotation Term="Redfish.OwningEntity" String="DMTF"/>
+      <Annotation Term="OData.Description" String="This version was created to add a missing pattern term to MAC address properties.  It was also created to update descriptions that this schema defines."/>
+      <EntityType Name="NetworkDeviceFunction" BaseType="NetworkDeviceFunction.v1_0_5.NetworkDeviceFunction"/>
+    </Schema>
+
+    <Schema xmlns="http://docs.oasis-open.org/odata/ns/edm" Namespace="NetworkDeviceFunction.v1_0_7">
+      <Annotation Term="Redfish.OwningEntity" String="DMTF"/>
+      <Annotation Term="OData.Description" String="This version was created to correct various typographical errors."/>
+      <EntityType Name="NetworkDeviceFunction" BaseType="NetworkDeviceFunction.v1_0_6.NetworkDeviceFunction"/>
+    </Schema>
+
+    <Schema xmlns="http://docs.oasis-open.org/odata/ns/edm" Namespace="NetworkDeviceFunction.v1_0_8">
+      <Annotation Term="Redfish.OwningEntity" String="DMTF"/>
+      <Annotation Term="OData.Description" String="This version was created to correct the description of the `iSCSI` boot mode to allow for `Ethernet`.  It was also created to correct the definition for Links to leverage the common definition found in the Resource schema.  It was also created to fix typos in descriptions and long descriptions."/>
+      <EntityType Name="NetworkDeviceFunction" BaseType="NetworkDeviceFunction.v1_0_7.NetworkDeviceFunction"/>
+    </Schema>
+
+    <Schema xmlns="http://docs.oasis-open.org/odata/ns/edm" Namespace="NetworkDeviceFunction.v1_0_9">
+      <Annotation Term="Redfish.OwningEntity" String="DMTF"/>
+      <Annotation Term="OData.Description" String="This version was created to add patterns to WWN properties."/>
+      <EntityType Name="NetworkDeviceFunction" BaseType="NetworkDeviceFunction.v1_0_8.NetworkDeviceFunction"/>
+    </Schema>
+
+    <Schema xmlns="http://docs.oasis-open.org/odata/ns/edm" Namespace="NetworkDeviceFunction.v1_1_0">
+      <Annotation Term="Redfish.OwningEntity" String="DMTF"/>
+      <Annotation Term="Redfish.Release" String="2017.1"/>
+
+      <EntityType Name="NetworkDeviceFunction" BaseType="NetworkDeviceFunction.v1_0_1.NetworkDeviceFunction">
+        <Property Name="Actions" Type="NetworkDeviceFunction.v1_1_0.Actions" Nullable="false">
+          <Annotation Term="OData.Description" String="The available actions for this resource."/>
+          <Annotation Term="OData.LongDescription" String="This property shall contain the available actions for this resource."/>
+        </Property>
+      </EntityType>
+
+      <ComplexType Name="Actions">
+        <Annotation Term="OData.AdditionalProperties" Bool="false"/>
+        <Annotation Term="OData.Description" String="The available actions for this resource."/>
+        <Annotation Term="OData.LongDescription" String="This type shall contain the available actions for this resource."/>
+        <Property Name="Oem" Type="NetworkDeviceFunction.v1_1_0.OemActions" Nullable="false">
+          <Annotation Term="OData.Description" String="The available OEM-specific actions for this resource."/>
+          <Annotation Term="OData.LongDescription" String="This property shall contain the available OEM-specific actions for this resource."/>
+        </Property>
+      </ComplexType>
+
+      <ComplexType Name="OemActions">
+        <Annotation Term="OData.AdditionalProperties" Bool="true"/>
+        <Annotation Term="OData.Description" String="The available OEM-specific actions for this resource."/>
+        <Annotation Term="OData.LongDescription" String="This type shall contain the available OEM-specific actions for this resource."/>
+      </ComplexType>
+    </Schema>
+
+    <Schema xmlns="http://docs.oasis-open.org/odata/ns/edm" Namespace="NetworkDeviceFunction.v1_1_1">
+      <Annotation Term="Redfish.OwningEntity" String="DMTF"/>
+      <Annotation Term="OData.Description" String="This version was created to add normative statements about the format of InitiatorName, PrimaryTargetName, and SecondaryTargetName properties in the iSCSIBoot structure.  It was also created to fix the descriptions for AssignablePhysicalPorts and PhysicalPortAssignment."/>
+      <EntityType Name="NetworkDeviceFunction" BaseType="NetworkDeviceFunction.v1_1_0.NetworkDeviceFunction"/>
+    </Schema>
+
+    <Schema xmlns="http://docs.oasis-open.org/odata/ns/edm" Namespace="NetworkDeviceFunction.v1_1_2">
+      <Annotation Term="Redfish.OwningEntity" String="DMTF"/>
+      <Annotation Term="OData.Description" String="This version was created to force the regeneration of JSON Schema so that OData properties are marked as required, and integer properties are marked as integer rather than number."/>
+      <EntityType Name="NetworkDeviceFunction" BaseType="NetworkDeviceFunction.v1_1_1.NetworkDeviceFunction"/>
+    </Schema>
+
+    <Schema xmlns="http://docs.oasis-open.org/odata/ns/edm" Namespace="NetworkDeviceFunction.v1_1_3">
+      <Annotation Term="Redfish.OwningEntity" String="DMTF"/>
+      <Annotation Term="OData.Description" String="This version was created to use the new Revisions annotation."/>
+      <EntityType Name="NetworkDeviceFunction" BaseType="NetworkDeviceFunction.v1_1_2.NetworkDeviceFunction"/>
+    </Schema>
+
+    <Schema xmlns="http://docs.oasis-open.org/odata/ns/edm" Namespace="NetworkDeviceFunction.v1_1_4">
+      <Annotation Term="Redfish.OwningEntity" String="DMTF"/>
+      <Annotation Term="OData.Description" String="This version was created to force the regeneration of JSON Schema so that URI properties use the uri-reference format.  It was also created to add a missing term on several properties to not allow them to be null."/>
+      <EntityType Name="NetworkDeviceFunction" BaseType="NetworkDeviceFunction.v1_1_3.NetworkDeviceFunction"/>
+    </Schema>
+
+    <Schema xmlns="http://docs.oasis-open.org/odata/ns/edm" Namespace="NetworkDeviceFunction.v1_1_5">
+      <Annotation Term="Redfish.OwningEntity" String="DMTF"/>
+      <Annotation Term="OData.Description" String="This version was created to add a missing pattern term to MAC address properties.  It was also created to update descriptions that this schema defines."/>
+      <EntityType Name="NetworkDeviceFunction" BaseType="NetworkDeviceFunction.v1_1_4.NetworkDeviceFunction"/>
+    </Schema>
+
+    <Schema xmlns="http://docs.oasis-open.org/odata/ns/edm" Namespace="NetworkDeviceFunction.v1_1_6">
+      <Annotation Term="Redfish.OwningEntity" String="DMTF"/>
+      <Annotation Term="OData.Description" String="This version was created to correct various typographical errors."/>
+      <EntityType Name="NetworkDeviceFunction" BaseType="NetworkDeviceFunction.v1_1_5.NetworkDeviceFunction"/>
+    </Schema>
+
+    <Schema xmlns="http://docs.oasis-open.org/odata/ns/edm" Namespace="NetworkDeviceFunction.v1_1_7">
+      <Annotation Term="Redfish.OwningEntity" String="DMTF"/>
+      <Annotation Term="OData.Description" String="This version was created to correct the description of the `iSCSI` boot mode to allow for `Ethernet`.  It was also created to correct the definition for Links to leverage the common definition found in the Resource schema.  It was also created to fix typos in descriptions and long descriptions."/>
+      <EntityType Name="NetworkDeviceFunction" BaseType="NetworkDeviceFunction.v1_1_6.NetworkDeviceFunction"/>
+    </Schema>
+
+    <Schema xmlns="http://docs.oasis-open.org/odata/ns/edm" Namespace="NetworkDeviceFunction.v1_1_8">
+      <Annotation Term="Redfish.OwningEntity" String="DMTF"/>
+      <Annotation Term="OData.Description" String="This version was created to add patterns to WWN properties."/>
+      <EntityType Name="NetworkDeviceFunction" BaseType="NetworkDeviceFunction.v1_1_7.NetworkDeviceFunction"/>
+    </Schema>
+
+    <Schema xmlns="http://docs.oasis-open.org/odata/ns/edm" Namespace="NetworkDeviceFunction.v1_2_0">
+      <Annotation Term="Redfish.OwningEntity" String="DMTF"/>
+      <Annotation Term="Redfish.Release" String="2017.3"/>
+
+      <EntityType Name="NetworkDeviceFunction" BaseType="NetworkDeviceFunction.v1_1_1.NetworkDeviceFunction"/>
+
+      <ComplexType Name="Links" BaseType="NetworkDeviceFunction.v1_0_0.Links">
+        <NavigationProperty Name="Endpoints" Type="Collection(Endpoint.Endpoint)">
+          <Annotation Term="OData.Permissions" EnumMember="OData.Permission/Read"/>
+          <Annotation Term="OData.Description" String="An array of links to endpoints associated with this network device function."/>
+          <Annotation Term="OData.LongDescription" String="This property shall contain an array of links to resources of type Endpoint that are associated with this network device function."/>
+          <Annotation Term="OData.AutoExpandReferences"/>
+        </NavigationProperty>
+      </ComplexType>
+    </Schema>
+
+    <Schema xmlns="http://docs.oasis-open.org/odata/ns/edm" Namespace="NetworkDeviceFunction.v1_2_1">
+      <Annotation Term="Redfish.OwningEntity" String="DMTF"/>
+      <Annotation Term="OData.Description" String="This version was created to add validation terms to the different VLANId properties."/>
+      <EntityType Name="NetworkDeviceFunction" BaseType="NetworkDeviceFunction.v1_2_0.NetworkDeviceFunction"/>
+    </Schema>
+
+    <Schema xmlns="http://docs.oasis-open.org/odata/ns/edm" Namespace="NetworkDeviceFunction.v1_2_2">
+      <Annotation Term="Redfish.OwningEntity" String="DMTF"/>
+      <Annotation Term="OData.Description" String="This version was created to force the regeneration of JSON Schema so that OData properties are marked as required, and integer properties are marked as integer rather than number."/>
+      <EntityType Name="NetworkDeviceFunction" BaseType="NetworkDeviceFunction.v1_2_1.NetworkDeviceFunction"/>
+    </Schema>
+
+    <Schema xmlns="http://docs.oasis-open.org/odata/ns/edm" Namespace="NetworkDeviceFunction.v1_2_3">
+      <Annotation Term="Redfish.OwningEntity" String="DMTF"/>
+      <Annotation Term="OData.Description" String="This version was created to use the new Revisions annotation."/>
+      <EntityType Name="NetworkDeviceFunction" BaseType="NetworkDeviceFunction.v1_2_2.NetworkDeviceFunction"/>
+    </Schema>
+
+    <Schema xmlns="http://docs.oasis-open.org/odata/ns/edm" Namespace="NetworkDeviceFunction.v1_2_4">
+      <Annotation Term="Redfish.OwningEntity" String="DMTF"/>
+      <Annotation Term="OData.Description" String="This version was created to force the regeneration of JSON Schema so that URI properties use the uri-reference format.  It was also created to add a missing term on several properties to not allow them to be null."/>
+      <EntityType Name="NetworkDeviceFunction" BaseType="NetworkDeviceFunction.v1_2_3.NetworkDeviceFunction"/>
+    </Schema>
+
+    <Schema xmlns="http://docs.oasis-open.org/odata/ns/edm" Namespace="NetworkDeviceFunction.v1_2_5">
+      <Annotation Term="Redfish.OwningEntity" String="DMTF"/>
+      <Annotation Term="OData.Description" String="This version was created to add a missing pattern term to MAC address properties.  It was also created to update descriptions that this schema defines."/>
+      <EntityType Name="NetworkDeviceFunction" BaseType="NetworkDeviceFunction.v1_2_4.NetworkDeviceFunction"/>
+    </Schema>
+
+    <Schema xmlns="http://docs.oasis-open.org/odata/ns/edm" Namespace="NetworkDeviceFunction.v1_2_6">
+      <Annotation Term="Redfish.OwningEntity" String="DMTF"/>
+      <Annotation Term="OData.Description" String="This version was created to correct various typographical errors."/>
+      <EntityType Name="NetworkDeviceFunction" BaseType="NetworkDeviceFunction.v1_2_5.NetworkDeviceFunction"/>
+    </Schema>
+
+    <Schema xmlns="http://docs.oasis-open.org/odata/ns/edm" Namespace="NetworkDeviceFunction.v1_2_7">
+      <Annotation Term="Redfish.OwningEntity" String="DMTF"/>
+      <Annotation Term="OData.Description" String="This version was created to correct the description of the `iSCSI` boot mode to allow for `Ethernet`.  It was also created to correct the definition for Links to leverage the common definition found in the Resource schema.  It was also created to fix typos in descriptions and long descriptions."/>
+      <EntityType Name="NetworkDeviceFunction" BaseType="NetworkDeviceFunction.v1_2_6.NetworkDeviceFunction"/>
+    </Schema>
+
+    <Schema xmlns="http://docs.oasis-open.org/odata/ns/edm" Namespace="NetworkDeviceFunction.v1_2_8">
+      <Annotation Term="Redfish.OwningEntity" String="DMTF"/>
+      <Annotation Term="OData.Description" String="This version was created to add patterns to WWN properties."/>
+      <EntityType Name="NetworkDeviceFunction" BaseType="NetworkDeviceFunction.v1_2_7.NetworkDeviceFunction"/>
+    </Schema>
+
+    <Schema xmlns="http://docs.oasis-open.org/odata/ns/edm" Namespace="NetworkDeviceFunction.v1_3_0">
+      <Annotation Term="Redfish.OwningEntity" String="DMTF"/>
+      <Annotation Term="Redfish.Release" String="2018.2"/>
+      <Annotation Term="OData.Description" String="This version was created to force the regeneration of JSON Schema so that OData properties are marked as required, and integer properties are marked as integer rather than number.  Also adds support for VLAN to Ethernet.  Also moving PhysicalPortAssignment to Links.  Also adds FibreChannel Adapter properties."/>
+
+      <EntityType Name="NetworkDeviceFunction" BaseType="NetworkDeviceFunction.v1_2_2.NetworkDeviceFunction"/>
+
+      <ComplexType Name="Links" BaseType="NetworkDeviceFunction.v1_2_0.Links">
+        <NavigationProperty Name="PhysicalPortAssignment" Type="NetworkPort.NetworkPort" Nullable="false">
+          <Annotation Term="OData.Description" String="The physical port to which this network device function is currently assigned."/>
+          <Annotation Term="OData.LongDescription" String="This property shall contain a link to a resource of type NetworkPort to which this network device function is currently assigned.  This value shall be one of the AssignablePhysicalPorts array members."/>
+          <Annotation Term="OData.AutoExpandReferences"/>
+          <Annotation Term="Redfish.Revisions">
+            <Collection>
+              <Record>
+                <PropertyValue Property="Kind" EnumMember="Redfish.RevisionKind/Deprecated"/>
+                <PropertyValue Property="Version" String="v1_5_0"/>
+                <PropertyValue Property="Description" String="This property has been deprecated in favor of the PhysicalNetworkPortAssignment property."/>
+              </Record>
+            </Collection>
+          </Annotation>
+        </NavigationProperty>
+      </ComplexType>
+
+      <ComplexType Name="Ethernet" BaseType="NetworkDeviceFunction.v1_0_0.Ethernet">
+        <Property Name="VLAN" Type="VLanNetworkInterface.VLAN" Nullable="false">
+          <Annotation Term="OData.Description" String="The VLAN information for this interface.  If this network interface supports more than one VLAN, this property is not present."/>
+          <Annotation Term="OData.LongDescription" String="This property shall contain the VLAN for this interface.  If this interface supports more than one VLAN, the VLAN property shall not be present and the VLANs property shall be present instead."/>
+        </Property>
+        <NavigationProperty Name="VLANs" Type="VLanNetworkInterfaceCollection.VLanNetworkInterfaceCollection" ContainsTarget="true" Nullable="false">
+          <Annotation Term="OData.Permissions" EnumMember="OData.Permission/Read"/>
+          <Annotation Term="OData.Description" String="The link to a collection of VLANs.  This property is used only if the interface supports more than one VLAN."/>
+          <Annotation Term="OData.LongDescription" String="This property shall contain a link to a resource collection of type VLanNetworkInterfaceCollection.  If this property is used, the VLANEnabled and VLANId property shall not be used."/>
+          <Annotation Term="OData.AutoExpandReferences"/>
+          <Annotation Term="Redfish.Revisions">
+            <Collection>
+              <Record>
+                <PropertyValue Property="Kind" EnumMember="Redfish.RevisionKind/Deprecated"/>
+                <PropertyValue Property="Version" String="v1_7_0"/>
+                <PropertyValue Property="Description" String="This property has been deprecated in favor of representing multiple VLANs as EthernetInterface resources."/>
+              </Record>
+            </Collection>
+          </Annotation>
+        </NavigationProperty>
+      </ComplexType>
+
+      <ComplexType Name="FibreChannel" BaseType="NetworkDeviceFunction.v1_0_0.FibreChannel">
+        <Property Name="FibreChannelId" Type="Edm.String">
+          <Annotation Term="OData.Permissions" EnumMember="OData.Permission/Read"/>
+          <Annotation Term="OData.Description" String="The Fibre Channel ID that the switch assigns for this interface."/>
+          <Annotation Term="OData.LongDescription" String="This property shall indicate the Fibre Channel ID that the switch assigns for this interface."/>
+        </Property>
+      </ComplexType>
+    </Schema>
+
+    <Schema xmlns="http://docs.oasis-open.org/odata/ns/edm" Namespace="NetworkDeviceFunction.v1_3_1">
+      <Annotation Term="Redfish.OwningEntity" String="DMTF"/>
+      <Annotation Term="OData.Description" String="This version was created to use the new Revisions annotation."/>
+      <EntityType Name="NetworkDeviceFunction" BaseType="NetworkDeviceFunction.v1_3_0.NetworkDeviceFunction"/>
+    </Schema>
+
+    <Schema xmlns="http://docs.oasis-open.org/odata/ns/edm" Namespace="NetworkDeviceFunction.v1_3_2">
+      <Annotation Term="Redfish.OwningEntity" String="DMTF"/>
+      <Annotation Term="OData.Description" String="This version was created to force the regeneration of JSON Schema so that URI properties use the uri-reference format.  It was also created to add a missing term on several properties to not allow them to be null."/>
+      <EntityType Name="NetworkDeviceFunction" BaseType="NetworkDeviceFunction.v1_3_1.NetworkDeviceFunction"/>
+    </Schema>
+
+    <Schema xmlns="http://docs.oasis-open.org/odata/ns/edm" Namespace="NetworkDeviceFunction.v1_3_3">
+      <Annotation Term="Redfish.OwningEntity" String="DMTF"/>
+      <Annotation Term="OData.Description" String="This version was created to add a missing pattern term to MAC address properties.  It was also created to update descriptions that this schema defines."/>
+      <EntityType Name="NetworkDeviceFunction" BaseType="NetworkDeviceFunction.v1_3_2.NetworkDeviceFunction"/>
+    </Schema>
+
+    <Schema xmlns="http://docs.oasis-open.org/odata/ns/edm" Namespace="NetworkDeviceFunction.v1_3_4">
+      <Annotation Term="Redfish.OwningEntity" String="DMTF"/>
+      <Annotation Term="OData.Description" String="This version was created to correct various typographical errors."/>
+      <EntityType Name="NetworkDeviceFunction" BaseType="NetworkDeviceFunction.v1_3_3.NetworkDeviceFunction"/>
+    </Schema>
+
+    <Schema xmlns="http://docs.oasis-open.org/odata/ns/edm" Namespace="NetworkDeviceFunction.v1_3_5">
+      <Annotation Term="Redfish.OwningEntity" String="DMTF"/>
+      <Annotation Term="OData.Description" String="This version was created to correct the description of the `iSCSI` boot mode to allow for `Ethernet`.  It was also created to correct the definition for Links to leverage the common definition found in the Resource schema.  It was also created to fix typos in descriptions and long descriptions."/>
+      <EntityType Name="NetworkDeviceFunction" BaseType="NetworkDeviceFunction.v1_3_4.NetworkDeviceFunction"/>
+    </Schema>
+
+    <Schema xmlns="http://docs.oasis-open.org/odata/ns/edm" Namespace="NetworkDeviceFunction.v1_3_6">
+      <Annotation Term="Redfish.OwningEntity" String="DMTF"/>
+      <Annotation Term="OData.Description" String="This version was created to add patterns to WWN properties."/>
+      <EntityType Name="NetworkDeviceFunction" BaseType="NetworkDeviceFunction.v1_3_5.NetworkDeviceFunction"/>
+    </Schema>
+
+    <Schema xmlns="http://docs.oasis-open.org/odata/ns/edm" Namespace="NetworkDeviceFunction.v1_4_0">
+      <Annotation Term="Redfish.OwningEntity" String="DMTF"/>
+      <Annotation Term="Redfish.Release" String="2020.1"/>
+      <Annotation Term="OData.Description" String="This version was created to add the link to EthernetInterface when one of the NetworkDeviceFunction VLANs has been represented as a virtual NIC for the purpose of showing the IP Address associated with that VLAN."/>
+
+      <EntityType Name="NetworkDeviceFunction" BaseType="NetworkDeviceFunction.v1_3_3.NetworkDeviceFunction"/>
+
+      <ComplexType Name="Links" BaseType="NetworkDeviceFunction.v1_3_0.Links">
+        <NavigationProperty Name="EthernetInterface" Type="EthernetInterface.EthernetInterface" Nullable="false">
+          <Annotation Term="OData.Description" String="The link to a virtual Ethernet interface that was created when one of the network device function VLANs is represented as a virtual NIC for the purpose of showing the IP address associated with that VLAN."/>
+          <Annotation Term="OData.LongDescription" String="This property shall contain a link to a resource of type EthernetInterface that represents a virtual interface that was created when one of the network device function VLANs is represented as a virtual NIC for the purpose of showing the IP address associated with that VLAN.  The EthernetInterfaceType property of that resource shall contain the value `Virtual`."/>
+          <Annotation Term="OData.AutoExpandReferences"/>
+          <Annotation Term="Redfish.Revisions">
+            <Collection>
+              <Record>
+                <PropertyValue Property="Kind" EnumMember="Redfish.RevisionKind/Deprecated"/>
+                <PropertyValue Property="Version" String="v1_7_0"/>
+                <PropertyValue Property="Description" String="This property has been deprecated in favor of EthernetInterfaces as each NetworkDeviceFunction could have more than one EthernetInterface."/>
+              </Record>
+            </Collection>
+          </Annotation>
+        </NavigationProperty>
+      </ComplexType>
+    </Schema>
+
+    <Schema xmlns="http://docs.oasis-open.org/odata/ns/edm" Namespace="NetworkDeviceFunction.v1_4_1">
+      <Annotation Term="Redfish.OwningEntity" String="DMTF"/>
+      <Annotation Term="OData.Description" String="This version was created to correct various typographical errors."/>
+      <EntityType Name="NetworkDeviceFunction" BaseType="NetworkDeviceFunction.v1_4_0.NetworkDeviceFunction"/>
+    </Schema>
+
+    <Schema xmlns="http://docs.oasis-open.org/odata/ns/edm" Namespace="NetworkDeviceFunction.v1_4_2">
+      <Annotation Term="Redfish.OwningEntity" String="DMTF"/>
+      <Annotation Term="OData.Description" String="This version was created to correct the description of the `iSCSI` boot mode to allow for `Ethernet`.  It was also created to correct the definition for Links to leverage the common definition found in the Resource schema.  It was also created to fix typos in descriptions and long descriptions."/>
+      <EntityType Name="NetworkDeviceFunction" BaseType="NetworkDeviceFunction.v1_4_1.NetworkDeviceFunction"/>
+    </Schema>
+
+    <Schema xmlns="http://docs.oasis-open.org/odata/ns/edm" Namespace="NetworkDeviceFunction.v1_4_3">
+      <Annotation Term="Redfish.OwningEntity" String="DMTF"/>
+      <Annotation Term="OData.Description" String="This version was created to add patterns to WWN properties."/>
+      <EntityType Name="NetworkDeviceFunction" BaseType="NetworkDeviceFunction.v1_4_2.NetworkDeviceFunction"/>
+    </Schema>
+
+    <Schema xmlns="http://docs.oasis-open.org/odata/ns/edm" Namespace="NetworkDeviceFunction.v1_5_0">
+      <Annotation Term="Redfish.OwningEntity" String="DMTF"/>
+      <Annotation Term="Redfish.Release" String="2020.3"/>
+
+      <EntityType Name="NetworkDeviceFunction" BaseType="NetworkDeviceFunction.v1_4_1.NetworkDeviceFunction">
+        <NavigationProperty Name="AssignablePhysicalNetworkPorts" Type="Collection(Port.Port)">
+          <Annotation Term="OData.Permissions" EnumMember="OData.Permission/Read"/>
+          <Annotation Term="OData.Description" String="An array of physical ports to which this network device function can be assigned."/>
+          <Annotation Term="OData.LongDescription" String="This property shall contain an array of links to resources of type Port that are the physical ports to which this network device function can be assigned."/>
+          <Annotation Term="OData.AutoExpandReferences"/>
+        </NavigationProperty>
+        <NavigationProperty Name="PhysicalNetworkPortAssignment" Type="Port.Port" Nullable="false">
+          <Annotation Term="OData.Permissions" EnumMember="OData.Permission/Read"/>
+          <Annotation Term="OData.Description" String="The physical port to which this network device function is currently assigned."/>
+          <Annotation Term="OData.LongDescription" String="This property shall contain a link to a resource of type Port that is the physical port to which this network device function is currently assigned.  This value shall be one of the AssignablePhysicalNetworkPorts array members."/>
+          <Annotation Term="OData.AutoExpandReferences"/>
+        </NavigationProperty>
+        <Property Name="InfiniBand" Type="NetworkDeviceFunction.v1_5_0.InfiniBand" Nullable="false">
+          <Annotation Term="OData.Description" String="The InfiniBand capabilities, status, and configuration values for this network device function."/>
+          <Annotation Term="OData.LongDescription" String="This property shall contain InfiniBand capabilities, status, and configuration values for this network device function."/>
+        </Property>
+      </EntityType>
+
+      <ComplexType Name="Links" BaseType="NetworkDeviceFunction.v1_4_0.Links">
+        <NavigationProperty Name="PhysicalNetworkPortAssignment" Type="Port.Port" Nullable="false">
+          <Annotation Term="OData.Description" String="The physical port to which this network device function is currently assigned."/>
+          <Annotation Term="OData.LongDescription" String="This property shall contain a link to a resource of type Port to which this network device function is currently assigned.  This value shall be one of the AssignablePhysicalPorts array members."/>
+          <Annotation Term="OData.AutoExpandReferences"/>
+        </NavigationProperty>
+      </ComplexType>
+
+      <ComplexType Name="Ethernet" BaseType="NetworkDeviceFunction.v1_3_0.Ethernet">
+        <Property Name="MTUSizeMaximum" Type="Edm.Int64">
+          <Annotation Term="OData.Permissions" EnumMember="OData.Permission/Read"/>
+          <Annotation Term="OData.Description" String="The largest maximum transmission unit (MTU) size supported for this network device function."/>
+          <Annotation Term="OData.LongDescription" String="This property shall contain the largest maximum transmission unit (MTU) size supported for this network device function."/>
+        </Property>
+      </ComplexType>
+
+      <ComplexType Name="InfiniBand">
+        <Annotation Term="OData.AdditionalProperties" Bool="false"/>
+        <Annotation Term="OData.Description" String="This type describes InfiniBand capabilities, status, and configuration of a network device function."/>
+        <Annotation Term="OData.LongDescription" String="This type shall describe the InfiniBand capabilities, status, and configuration values for a network device function."/>
+        <Property Name="PermanentPortGUID" Type="Edm.String">
+          <Annotation Term="OData.Permissions" EnumMember="OData.Permission/Read"/>
+          <Annotation Term="OData.Description" String="The permanent port GUID assigned to this network device function."/>
+          <Annotation Term="OData.LongDescription" String="This property shall contain the permanent port GUID of this network device function.  Typically, this value is programmed during manufacturing.  This address is not assignable."/>
+          <Annotation Term="Validation.Pattern" String="^([0-9A-Fa-f]{4}[:-]){3}([0-9A-Fa-f]{4})$"/>
+        </Property>
+        <Property Name="PermanentNodeGUID" Type="Edm.String">
+          <Annotation Term="OData.Permissions" EnumMember="OData.Permission/Read"/>
+          <Annotation Term="OData.Description" String="The permanent node GUID assigned to this network device function."/>
+          <Annotation Term="OData.LongDescription" String="This property shall contain the permanent node GUID of this network device function.  Typically, this value is programmed during manufacturing.  This address is not assignable."/>
+          <Annotation Term="Validation.Pattern" String="^([0-9A-Fa-f]{4}[:-]){3}([0-9A-Fa-f]{4})$"/>
+        </Property>
+        <Property Name="PermanentSystemGUID" Type="Edm.String">
+          <Annotation Term="OData.Permissions" EnumMember="OData.Permission/Read"/>
+          <Annotation Term="OData.Description" String="The permanent system GUID assigned to this network device function."/>
+          <Annotation Term="OData.LongDescription" String="This property shall contain the permanent system GUID of this network device function.  Typically, this value is programmed during manufacturing.  This address is not assignable."/>
+          <Annotation Term="Validation.Pattern" String="^([0-9A-Fa-f]{4}[:-]){3}([0-9A-Fa-f]{4})$"/>
+        </Property>
+        <Property Name="PortGUID" Type="Edm.String">
+          <Annotation Term="OData.Permissions" EnumMember="OData.Permission/Read"/>
+          <Annotation Term="OData.Description" String="The currently configured port GUID of the network device function."/>
+          <Annotation Term="OData.LongDescription" String="This property shall contain the effective current virtual port GUID of this network device function.  If an assignable port GUID is not supported, this is a read-only alias of the PermanentPortGUID."/>
+          <Annotation Term="Validation.Pattern" String="^([0-9A-Fa-f]{4}[:-]){3}([0-9A-Fa-f]{4})$"/>
+        </Property>
+        <Property Name="NodeGUID" Type="Edm.String">
+          <Annotation Term="OData.Permissions" EnumMember="OData.Permission/Read"/>
+          <Annotation Term="OData.Description" String="This is the currently configured node GUID of the network device function."/>
+          <Annotation Term="OData.LongDescription" String="This property shall contain the effective current node GUID of this virtual port of this network device function.  If an assignable node GUID is not supported, this is a read-only alias of the PermanentNodeGUID."/>
+          <Annotation Term="Validation.Pattern" String="^([0-9A-Fa-f]{4}[:-]){3}([0-9A-Fa-f]{4})$"/>
+        </Property>
+        <Property Name="SystemGUID" Type="Edm.String">
+          <Annotation Term="OData.Permissions" EnumMember="OData.Permission/Read"/>
+          <Annotation Term="OData.Description" String="This is the currently configured system GUID of the network device function."/>
+          <Annotation Term="OData.LongDescription" String="This property shall contain the effective current system GUID of this virtual port of this network device function.  If an assignable system GUID is not supported, this is a read-only alias of the PermanentSystemGUID."/>
+          <Annotation Term="Validation.Pattern" String="^([0-9A-Fa-f]{4}[:-]){3}([0-9A-Fa-f]{4})$"/>
+        </Property>
+        <Property Name="SupportedMTUSizes" Type="Collection(Edm.Int64)">
+          <Annotation Term="OData.Permissions" EnumMember="OData.Permission/Read"/>
+          <Annotation Term="OData.Description" String="The maximum transmission unit (MTU) sizes supported for this network device function."/>
+          <Annotation Term="OData.LongDescription" String="This property shall contain an array of the maximum transmission unit (MTU) sizes supported for this network device function."/>
+        </Property>
+        <Property Name="MTUSize" Type="Edm.Int64">
+          <Annotation Term="OData.Permissions" EnumMember="OData.Permission/ReadWrite"/>
+          <Annotation Term="OData.Description" String="The maximum transmission unit (MTU) configured for this network device function."/>
+          <Annotation Term="OData.LongDescription" String="The maximum transmission unit (MTU) configured for this network device function."/>
+        </Property>
+      </ComplexType>
+    </Schema>
+
+    <Schema xmlns="http://docs.oasis-open.org/odata/ns/edm" Namespace="NetworkDeviceFunction.v1_5_1">
+      <Annotation Term="Redfish.OwningEntity" String="DMTF"/>
+      <Annotation Term="OData.Description" String="This version was created to correct the description of the `iSCSI` boot mode to allow for `Ethernet`.  It was also created to correct the definition for Links to leverage the common definition found in the Resource schema.  It was also created to fix typos in descriptions and long descriptions."/>
+      <EntityType Name="NetworkDeviceFunction" BaseType="NetworkDeviceFunction.v1_5_0.NetworkDeviceFunction"/>
+    </Schema>
+
+    <Schema xmlns="http://docs.oasis-open.org/odata/ns/edm" Namespace="NetworkDeviceFunction.v1_5_2">
+      <Annotation Term="Redfish.OwningEntity" String="DMTF"/>
+      <Annotation Term="OData.Description" String="This version was created to add patterns to WWN properties."/>
+      <EntityType Name="NetworkDeviceFunction" BaseType="NetworkDeviceFunction.v1_5_1.NetworkDeviceFunction"/>
+    </Schema>
+
+    <Schema xmlns="http://docs.oasis-open.org/odata/ns/edm" Namespace="NetworkDeviceFunction.v1_6_0">
+      <Annotation Term="Redfish.OwningEntity" String="DMTF"/>
+      <Annotation Term="Redfish.Release" String="2021.1"/>
+      <Annotation Term="OData.Description" String="This version was created to add the Metrics property."/>
+
+      <EntityType Name="NetworkDeviceFunction" BaseType="NetworkDeviceFunction.v1_5_2.NetworkDeviceFunction">
+        <NavigationProperty Name="Metrics" Type="NetworkDeviceFunctionMetrics.NetworkDeviceFunctionMetrics">
+          <Annotation Term="OData.Permissions" EnumMember="OData.Permission/Read"/>
+          <Annotation Term="OData.Description" String="The link to the metrics associated with this network function."/>
+          <Annotation Term="OData.LongDescription" String="This property shall contain a link to a resource of type NetworkDeviceFunctionMetrics that contains the metrics associated with this network function."/>
+          <Annotation Term="OData.AutoExpandReferences"/>
+        </NavigationProperty>
+      </EntityType>
+    </Schema>
+
+    <Schema xmlns="http://docs.oasis-open.org/odata/ns/edm" Namespace="NetworkDeviceFunction.v1_7_0">
+      <Annotation Term="Redfish.OwningEntity" String="DMTF"/>
+      <Annotation Term="Redfish.Release" String="2021.2"/>
+      <Annotation Term="OData.Description" String="This version was created to deprecate the EthernetInterface link and introduce the EthernetInterfaces array of links.  It was also created to add AllowDeny, Limits, and SAVI."/>
+
+      <EntityType Name="NetworkDeviceFunction" BaseType="NetworkDeviceFunction.v1_6_0.NetworkDeviceFunction">
+        <Property Name="SAVIEnabled" Type="Edm.Boolean">
+          <Annotation Term="OData.Permissions" EnumMember="OData.Permission/ReadWrite"/>
+          <Annotation Term="OData.Description" String="Indicates if Source Address Validation Improvement (SAVI) is enabled for this network device function."/>
+          <Annotation Term="OData.LongDescription" String="This property shall indicate if the RFC7039-defined Source Address Validation Improvement (SAVI) is enabled for this network device function."/>
+        </Property>
+        <Property Name="Limits" Type="Collection(NetworkDeviceFunction.v1_7_0.Limit)">
+          <Annotation Term="OData.Description" String="The byte and packet limits for this network device function."/>
+          <Annotation Term="OData.LongDescription" String="This property shall contain an array of byte and packet limits for this network device function."/>
+        </Property>
+        <NavigationProperty Name="AllowDeny" Type="AllowDenyCollection.AllowDenyCollection" Nullable="false">
+          <Annotation Term="OData.Permissions" EnumMember="OData.Permission/Read"/>
+          <Annotation Term="OData.Description" String="The link to the collection of allow and deny permissions for packets leaving and arriving to this network device function."/>
+          <Annotation Term="OData.LongDescription" String="This property shall contain a link to a resource collection of type AllowDenyCollection that contains the permissions for packets leaving and arriving to this network device function."/>
+          <Annotation Term="OData.AutoExpandReferences"/>
+        </NavigationProperty>
+      </EntityType>
+
+      <ComplexType Name="Limit">
+        <Annotation Term="OData.AdditionalProperties" Bool="false"/>
+        <Annotation Term="OData.Description" String="This type describes the packet and byte limit of a network device function."/>
+        <Annotation Term="OData.LongDescription" String="This type shall describe a single array element of the packet and byte limits of a network device function."/>
+        <Property Name="Direction" Type="NetworkDeviceFunction.v1_7_0.DataDirection">
+          <Annotation Term="OData.Permissions" EnumMember="OData.Permission/ReadWrite"/>
+          <Annotation Term="OData.Description" String="Indicates the direction of the data to which this limit applies."/>
+          <Annotation Term="OData.LongDescription" String="This property shall indicate the direction of the data to which this limit applies for this network device function."/>
+        </Property>
+        <Property Name="SustainedPacketsPerSecond" Type="Edm.Int64">
+          <Annotation Term="OData.Permissions" EnumMember="OData.Permission/ReadWrite"/>
+          <Annotation Term="OData.Description" String="The maximum number of sustained packets per second for this network device function."/>
+          <Annotation Term="OData.LongDescription" String="This property shall contain the maximum number of sustained packets per second allowed for this network device function."/>
+        </Property>
+        <Property Name="BurstPacketsPerSecond" Type="Edm.Int64">
+          <Annotation Term="OData.Permissions" EnumMember="OData.Permission/ReadWrite"/>
+          <Annotation Term="OData.Description" String="The maximum number of packets per second in a burst for this network device function."/>
+          <Annotation Term="OData.LongDescription" String="This property shall contain the maximum number of packets per second in a burst allowed for this network device function."/>
+        </Property>
+        <Property Name="SustainedBytesPerSecond" Type="Edm.Int64">
+          <Annotation Term="OData.Permissions" EnumMember="OData.Permission/ReadWrite"/>
+          <Annotation Term="OData.Description" String="The maximum number of sustained bytes per second for this network device function."/>
+          <Annotation Term="OData.LongDescription" String="This property shall contain the maximum number of sustained bytes per second allowed for this network device function."/>
+        </Property>
+        <Property Name="BurstBytesPerSecond" Type="Edm.Int64">
+          <Annotation Term="OData.Permissions" EnumMember="OData.Permission/ReadWrite"/>
+          <Annotation Term="OData.Description" String="The maximum number of bytes per second in a burst for this network device function."/>
+          <Annotation Term="OData.LongDescription" String="This property shall contain the maximum number of bytes per second in a burst allowed for this network device function."/>
+        </Property>
+      </ComplexType>
+
+      <ComplexType Name="Links" BaseType="NetworkDeviceFunction.v1_5_0.Links">
+        <NavigationProperty Name="EthernetInterfaces" Type="Collection(EthernetInterface.EthernetInterface)">
+          <Annotation Term="OData.Description" String="The links to Ethernet interfaces that were created when one of the network device function VLANs is represented as a virtual NIC for the purpose of showing the IP address associated with that VLAN."/>
+          <Annotation Term="OData.LongDescription" String="This property shall contain an array of links to resources of type EthernetInterface that represent the virtual interfaces that were created when one of the network device function VLANs is represented as a virtual NIC for the purpose of showing the IP address associated with that VLAN."/>
+          <Annotation Term="OData.AutoExpandReferences"/>
+        </NavigationProperty>
+        <NavigationProperty Name="OffloadSystem" Type="ComputerSystem.ComputerSystem" Nullable="false">
+          <Annotation Term="OData.Permissions" EnumMember="OData.Permission/Read"/>
+          <Annotation Term="OData.Description" String="The system that performs offload computation for this network function, such as with a SmartNIC."/>
+          <Annotation Term="OData.LongDescription" String="This property shall contain a link to a resource of type ComputerSystem that represents the system that performs offload computation for this network function, such as with a SmartNIC.  The SystemType property contained in the referenced ComputerSystem resource should contain the value `DPU`.  This property shall not be present if OffloadProcessors is present."/>
+          <Annotation Term="OData.AutoExpandReferences"/>
+        </NavigationProperty>
+        <NavigationProperty Name="OffloadProcessors" Type="Collection(Processor.Processor)">
+          <Annotation Term="OData.Permissions" EnumMember="OData.Permission/Read"/>
+          <Annotation Term="OData.Description" String="The processors that perform offload computation for this network function, such as with a SmartNIC."/>
+          <Annotation Term="OData.LongDescription" String="This property shall contain an array of links to resources of type Processor that represent the processors that performs offload computation for this network function, such as with a SmartNIC.  This property shall not be present if OffloadSystem is present."/>
+          <Annotation Term="OData.AutoExpandReferences"/>
+        </NavigationProperty>
+      </ComplexType>
+
+      <EnumType Name="DataDirection">
+        <Member Name="None">
+          <Annotation Term="OData.Description" String="Indicates that this limit not enforced."/>
+        </Member>
+        <Member Name="Ingress">
+          <Annotation Term="OData.Description" String="Indicates that this limit is enforced on packets and bytes received by the network device function."/>
+        </Member>
+        <Member Name="Egress">
+          <Annotation Term="OData.Description" String="Indicates that this limit is enforced on packets and bytes transmitted by the network device function."/>
+        </Member>
+      </EnumType>
+
+      <ComplexType Name="Ethernet" BaseType="NetworkDeviceFunction.v1_5_0.Ethernet">
+        <NavigationProperty Name="EthernetInterfaces" Type="EthernetInterfaceCollection.EthernetInterfaceCollection">
+          <Annotation Term="OData.Permissions" EnumMember="OData.Permission/Read"/>
+          <Annotation Term="OData.Description" String="The Ethernet interface collection that represents all the Ethernet Interfaces on this network device function."/>
+          <Annotation Term="OData.LongDescription" String="This property shall contain a link to a collection of type EthernetInterfaceCollection that represent the Ethernet interfaces present on this network device function.  This property shall not be present if this network device function is not referenced by a NetworkInterface resource."/>
+        </NavigationProperty>
+      </ComplexType>
+    </Schema>
+
+  </edmx:DataServices>
+</edmx:Edmx>

--- a/static/redfish/v1/schema/NetworkInterfaceCollection_v1.xml
+++ b/static/redfish/v1/schema/NetworkInterfaceCollection_v1.xml
@@ -1,0 +1,71 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!---->
+<!--################################################################################       -->
+<!--# Redfish Schema:  NetworkInterfaceCollection                                          -->
+<!--#                                                                                      -->
+<!--# For a detailed change log, see the README file contained in the DSP8010 bundle,      -->
+<!--# available at http://www.dmtf.org/standards/redfish                                   -->
+<!--# Copyright 2014-2021 DMTF.                                                            -->
+<!--# For the full DMTF copyright policy, see http://www.dmtf.org/about/policies/copyright -->
+<!--################################################################################       -->
+<!---->
+<edmx:Edmx xmlns:edmx="http://docs.oasis-open.org/odata/ns/edmx" Version="4.0">
+
+  <edmx:Reference Uri="http://docs.oasis-open.org/odata/odata/v4.0/errata03/csd01/complete/vocabularies/Org.OData.Core.V1.xml">
+    <edmx:Include Namespace="Org.OData.Core.V1" Alias="OData"/>
+  </edmx:Reference>
+  <edmx:Reference Uri="http://docs.oasis-open.org/odata/odata/v4.0/errata03/csd01/complete/vocabularies/Org.OData.Capabilities.V1.xml">
+    <edmx:Include Namespace="Org.OData.Capabilities.V1" Alias="Capabilities"/>
+  </edmx:Reference>
+  <edmx:Reference Uri="http://redfish.dmtf.org/schemas/v1/Resource_v1.xml">
+    <edmx:Include Namespace="Resource.v1_0_0"/>
+  </edmx:Reference>
+  <edmx:Reference Uri="http://redfish.dmtf.org/schemas/v1/RedfishExtensions_v1.xml">
+    <edmx:Include Namespace="RedfishExtensions.v1_0_0" Alias="Redfish"/>
+  </edmx:Reference>
+  <edmx:Reference Uri="http://redfish.dmtf.org/schemas/v1/NetworkInterface_v1.xml">
+    <edmx:Include Namespace="NetworkInterface"/>
+  </edmx:Reference>
+
+  <edmx:DataServices>
+
+    <Schema xmlns="http://docs.oasis-open.org/odata/ns/edm" Namespace="NetworkInterfaceCollection">
+      <Annotation Term="Redfish.OwningEntity" String="DMTF"/>
+
+      <EntityType Name="NetworkInterfaceCollection" BaseType="Resource.v1_0_0.ResourceCollection">
+        <Annotation Term="OData.Description" String="The collection of NetworkAdapter resource instances."/>
+        <Annotation Term="OData.LongDescription" String="This resource shall represent a resource collection of NetworkAdapter instances for a Redfish implementation."/>
+        <Annotation Term="Capabilities.InsertRestrictions">
+          <Record>
+            <PropertyValue Property="Insertable" Bool="false"/>
+          </Record>
+        </Annotation>
+        <Annotation Term="Capabilities.UpdateRestrictions">
+          <Record>
+            <PropertyValue Property="Updatable" Bool="false"/>
+          </Record>
+        </Annotation>
+        <Annotation Term="Capabilities.DeleteRestrictions">
+          <Record>
+            <PropertyValue Property="Deletable" Bool="false"/>
+          </Record>
+        </Annotation>
+        <Annotation Term="Redfish.Uris">
+          <Collection>
+            <String>/redfish/v1/Systems/{ComputerSystemId}/NetworkInterfaces</String>
+            <String>/redfish/v1/CompositionService/ResourceBlocks/{ResourceBlockId}/Systems/{ComputerSystemId}/NetworkInterfaces</String>
+            <String>/redfish/v1/ResourceBlocks/{ResourceBlockId}/Systems/{ComputerSystemId}/NetworkInterfaces</String>
+          </Collection>
+        </Annotation>
+        <NavigationProperty Name="Members" Type="Collection(NetworkInterface.NetworkInterface)">
+          <Annotation Term="OData.Permissions" EnumMember="OData.Permission/Read"/>
+          <Annotation Term="OData.Description" String="The members of this collection."/>
+          <Annotation Term="OData.LongDescription" String="This property shall contain an array of links to the members of this collection."/>
+          <Annotation Term="OData.AutoExpandReferences"/>
+          <Annotation Term="Redfish.Required"/>
+        </NavigationProperty>
+      </EntityType>
+    </Schema>
+
+  </edmx:DataServices>
+</edmx:Edmx>

--- a/static/redfish/v1/schema/NetworkInterface_v1.xml
+++ b/static/redfish/v1/schema/NetworkInterface_v1.xml
@@ -1,0 +1,237 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!---->
+<!--################################################################################       -->
+<!--# Redfish Schema:  NetworkInterface v1.2.1                                             -->
+<!--#                                                                                      -->
+<!--# For a detailed change log, see the README file contained in the DSP8010 bundle,      -->
+<!--# available at http://www.dmtf.org/standards/redfish                                   -->
+<!--# Copyright 2014-2021 DMTF.                                                            -->
+<!--# For the full DMTF copyright policy, see http://www.dmtf.org/about/policies/copyright -->
+<!--################################################################################       -->
+<!---->
+<edmx:Edmx xmlns:edmx="http://docs.oasis-open.org/odata/ns/edmx" Version="4.0">
+  <edmx:Reference Uri="http://docs.oasis-open.org/odata/odata/v4.0/errata03/csd01/complete/vocabularies/Org.OData.Core.V1.xml">
+    <edmx:Include Namespace="Org.OData.Core.V1" Alias="OData"/>
+  </edmx:Reference>
+  <edmx:Reference Uri="http://docs.oasis-open.org/odata/odata/v4.0/errata03/csd01/complete/vocabularies/Org.OData.Capabilities.V1.xml">
+    <edmx:Include Namespace="Org.OData.Capabilities.V1" Alias="Capabilities"/>
+  </edmx:Reference>
+  <edmx:Reference Uri="http://redfish.dmtf.org/schemas/v1/Resource_v1.xml">
+    <edmx:Include Namespace="Resource"/>
+    <edmx:Include Namespace="Resource.v1_0_0"/>
+  </edmx:Reference>
+  <edmx:Reference Uri="http://redfish.dmtf.org/schemas/v1/RedfishExtensions_v1.xml">
+    <edmx:Include Namespace="RedfishExtensions.v1_0_0" Alias="Redfish"/>
+  </edmx:Reference>
+  <edmx:Reference Uri="http://redfish.dmtf.org/schemas/v1/NetworkAdapter_v1.xml">
+    <edmx:Include Namespace="NetworkAdapter"/>
+  </edmx:Reference>
+  <edmx:Reference Uri="http://redfish.dmtf.org/schemas/v1/NetworkPortCollection_v1.xml">
+    <edmx:Include Namespace="NetworkPortCollection"/>
+  </edmx:Reference>
+  <edmx:Reference Uri="http://redfish.dmtf.org/schemas/v1/NetworkDeviceFunctionCollection_v1.xml">
+    <edmx:Include Namespace="NetworkDeviceFunctionCollection"/>
+  </edmx:Reference>
+  <edmx:Reference Uri="http://redfish.dmtf.org/schemas/v1/PortCollection_v1.xml">
+    <edmx:Include Namespace="PortCollection"/>
+  </edmx:Reference>
+
+  <edmx:DataServices>
+
+    <Schema xmlns="http://docs.oasis-open.org/odata/ns/edm" Namespace="NetworkInterface">
+      <Annotation Term="Redfish.OwningEntity" String="DMTF"/>
+
+      <EntityType Name="NetworkInterface" BaseType="Resource.v1_0_0.Resource" Abstract="true">
+        <Annotation Term="OData.Description" String="The NetworkInterface schema describes links to the network adapters, network ports, and network device functions, and represents the functionality available to the containing system."/>
+        <Annotation Term="OData.LongDescription" String="This resource contains links to the network adapters, network ports, and network device functions, and represents the functionality available to the containing system."/>
+        <Annotation Term="Capabilities.InsertRestrictions">
+          <Record>
+            <PropertyValue Property="Insertable" Bool="false"/>
+          </Record>
+        </Annotation>
+        <Annotation Term="Capabilities.UpdateRestrictions">
+          <Record>
+            <PropertyValue Property="Updatable" Bool="false"/>
+          </Record>
+        </Annotation>
+        <Annotation Term="Capabilities.DeleteRestrictions">
+          <Record>
+            <PropertyValue Property="Deletable" Bool="false"/>
+          </Record>
+        </Annotation>
+        <Annotation Term="Redfish.Uris">
+          <Collection>
+            <String>/redfish/v1/Systems/{ComputerSystemId}/NetworkInterfaces/{NetworkInterfaceId}</String>
+            <String>/redfish/v1/CompositionService/ResourceBlocks/{ResourceBlockId}/NetworkInterfaces/{NetworkInterfaceId}</String>
+            <String>/redfish/v1/CompositionService/ResourceBlocks/{ResourceBlockId}/Systems/{ComputerSystemId}/NetworkInterfaces/{NetworkInterfaceId}</String>
+            <String>/redfish/v1/ResourceBlocks/{ResourceBlockId}/NetworkInterfaces/{NetworkInterfaceId}</String>
+            <String>/redfish/v1/ResourceBlocks/{ResourceBlockId}/Systems/{ComputerSystemId}/NetworkInterfaces/{NetworkInterfaceId}</String>
+          </Collection>
+        </Annotation>
+      </EntityType>
+    </Schema>
+
+    <Schema xmlns="http://docs.oasis-open.org/odata/ns/edm" Namespace="NetworkInterface.v1_0_0">
+      <Annotation Term="Redfish.OwningEntity" String="DMTF"/>
+      <Annotation Term="Redfish.Release" String="2016.3"/>
+
+      <EntityType Name="NetworkInterface" BaseType="NetworkInterface.NetworkInterface">
+        <Property Name="Status" Type="Resource.Status" Nullable="false">
+          <Annotation Term="OData.Description" String="The status and health of the resource and its subordinate or dependent resources."/>
+          <Annotation Term="OData.LongDescription" String="This property shall contain any status or health properties of the resource."/>
+        </Property>
+        <Property Name="Links" Type="NetworkInterface.v1_0_0.Links" Nullable="false">
+          <Annotation Term="OData.Description" String="The links to other resources that are related to this resource."/>
+          <Annotation Term="OData.LongDescription" String="This property shall contain links to resources that are related to but are not contained by, or subordinate to, this resource."/>
+        </Property>
+        <NavigationProperty Name="NetworkPorts" Type="NetworkPortCollection.NetworkPortCollection" ContainsTarget="true" Nullable="false">
+          <Annotation Term="OData.Permissions" EnumMember="OData.Permission/Read"/>
+          <Annotation Term="OData.Description" String="The link to the network ports associated with this network interface."/>
+          <Annotation Term="OData.LongDescription" String="This property shall contain a link to a resource collection of type NetworkPortCollection."/>
+          <Annotation Term="OData.AutoExpandReferences"/>
+          <Annotation Term="Redfish.Revisions">
+            <Collection>
+              <Record>
+                <PropertyValue Property="Kind" EnumMember="Redfish.RevisionKind/Deprecated"/>
+                <PropertyValue Property="Version" String="v1_2_0"/>
+                <PropertyValue Property="Description" String="This property has been deprecated in favor of the Ports property."/>
+              </Record>
+            </Collection>
+          </Annotation>          
+        </NavigationProperty>
+        <NavigationProperty Name="NetworkDeviceFunctions" Type="NetworkDeviceFunctionCollection.NetworkDeviceFunctionCollection" ContainsTarget="true" Nullable="false">
+          <Annotation Term="OData.Permissions" EnumMember="OData.Permission/Read"/>
+          <Annotation Term="OData.Description" String="The link to the network device functions associated with this network interface."/>
+          <Annotation Term="OData.LongDescription" String="This property shall contain a link to a resource collection of type NetworkDeviceFunctionCollection."/>
+          <Annotation Term="OData.AutoExpandReferences"/>
+        </NavigationProperty>
+      </EntityType>
+
+      <ComplexType Name="Links" BaseType="Resource.Links">
+        <Annotation Term="OData.Description" String="The links to other resources that are related to this resource."/>
+        <Annotation Term="OData.LongDescription" String="This Redfish Specification-described type shall contain links to resources that are related to but are not contained by, or subordinate to, this resource."/>
+        <NavigationProperty Name="NetworkAdapter" Type="NetworkAdapter.NetworkAdapter" Nullable="false">
+          <Annotation Term="OData.Permissions" EnumMember="OData.Permission/Read"/>
+          <Annotation Term="OData.Description" String="The link to the network adapter that contains this network interface."/>
+          <Annotation Term="OData.LongDescription" String="This property shall contain a link to a resource of type NetworkAdapter that represents the physical container associated with this network interface."/>
+          <Annotation Term="OData.AutoExpandReferences"/>
+        </NavigationProperty>
+      </ComplexType>
+    </Schema>
+
+    <Schema xmlns="http://docs.oasis-open.org/odata/ns/edm" Namespace="NetworkInterface.v1_0_1">
+      <Annotation Term="Redfish.OwningEntity" String="DMTF"/>
+      <Annotation Term="OData.Description" String="This version was created to show that annotations in previous namespaces were updated."/>
+      <EntityType Name="NetworkInterface" BaseType="NetworkInterface.v1_0_0.NetworkInterface"/>
+    </Schema>
+
+    <Schema xmlns="http://docs.oasis-open.org/odata/ns/edm" Namespace="NetworkInterface.v1_0_2">
+      <Annotation Term="Redfish.OwningEntity" String="DMTF"/>
+      <Annotation Term="OData.Description" String="This version was created to force the regeneration of JSON Schema so that OData properties are marked as required, and integer properties are marked as integer rather than number."/>
+      <EntityType Name="NetworkInterface" BaseType="NetworkInterface.v1_0_1.NetworkInterface"/>
+    </Schema>
+
+    <Schema xmlns="http://docs.oasis-open.org/odata/ns/edm" Namespace="NetworkInterface.v1_0_3">
+      <Annotation Term="Redfish.OwningEntity" String="DMTF"/>
+      <Annotation Term="OData.Description" String="This version was created to force the regeneration of JSON Schema so that URI properties use the uri-reference format."/>
+      <EntityType Name="NetworkInterface" BaseType="NetworkInterface.v1_0_2.NetworkInterface"/>
+    </Schema>
+
+    <Schema xmlns="http://docs.oasis-open.org/odata/ns/edm" Namespace="NetworkInterface.v1_0_4">
+      <Annotation Term="Redfish.OwningEntity" String="DMTF"/>
+      <Annotation Term="OData.Description" String="This version was created to update descriptions that this schema defines."/>
+      <EntityType Name="NetworkInterface" BaseType="NetworkInterface.v1_0_3.NetworkInterface"/>
+    </Schema>
+
+    <Schema xmlns="http://docs.oasis-open.org/odata/ns/edm" Namespace="NetworkInterface.v1_0_5">
+      <Annotation Term="Redfish.OwningEntity" String="DMTF"/>
+      <Annotation Term="OData.Description" String="This version was created to correct various typographical errors."/>
+      <EntityType Name="NetworkInterface" BaseType="NetworkInterface.v1_0_4.NetworkInterface"/>
+    </Schema>
+    
+    <Schema xmlns="http://docs.oasis-open.org/odata/ns/edm" Namespace="NetworkInterface.v1_0_6">
+      <Annotation Term="Redfish.OwningEntity" String="DMTF"/>
+      <Annotation Term="OData.Description" String="This version was created to correct various typographical errors."/>
+      <EntityType Name="NetworkInterface" BaseType="NetworkInterface.v1_0_5.NetworkInterface"/>
+    </Schema>
+
+    <Schema xmlns="http://docs.oasis-open.org/odata/ns/edm" Namespace="NetworkInterface.v1_1_0">
+      <Annotation Term="Redfish.OwningEntity" String="DMTF"/>
+      <Annotation Term="Redfish.Release" String="2017.1"/>
+
+      <EntityType Name="NetworkInterface" BaseType="NetworkInterface.v1_0_1.NetworkInterface">
+        <Property Name="Actions" Type="NetworkInterface.v1_1_0.Actions" Nullable="false">
+          <Annotation Term="OData.Description" String="The available actions for this resource."/>
+          <Annotation Term="OData.LongDescription" String="This property shall contain the available actions for this resource."/>
+        </Property>
+      </EntityType>
+
+      <ComplexType Name="Actions">
+        <Annotation Term="OData.AdditionalProperties" Bool="false"/>
+        <Annotation Term="OData.Description" String="The available actions for this resource."/>
+        <Annotation Term="OData.LongDescription" String="This type shall contain the available actions for this resource."/>
+        <Property Name="Oem" Type="NetworkInterface.v1_1_0.OemActions" Nullable="false">
+          <Annotation Term="OData.Description" String="The available OEM-specific actions for this resource."/>
+          <Annotation Term="OData.LongDescription" String="This property shall contain the available OEM-specific actions for this resource."/>
+        </Property>
+      </ComplexType>
+
+      <ComplexType Name="OemActions">
+        <Annotation Term="OData.AdditionalProperties" Bool="true"/>
+        <Annotation Term="OData.Description" String="The available OEM-specific actions for this resource."/>
+        <Annotation Term="OData.LongDescription" String="This type shall contain the available OEM-specific actions for this resource."/>
+      </ComplexType>
+    </Schema>
+
+    <Schema xmlns="http://docs.oasis-open.org/odata/ns/edm" Namespace="NetworkInterface.v1_1_1">
+      <Annotation Term="Redfish.OwningEntity" String="DMTF"/>
+      <Annotation Term="OData.Description" String="This version was created to force the regeneration of JSON Schema so that OData properties are marked as required, and integer properties are marked as integer rather than number."/>
+      <EntityType Name="NetworkInterface" BaseType="NetworkInterface.v1_1_0.NetworkInterface"/>
+    </Schema>
+
+    <Schema xmlns="http://docs.oasis-open.org/odata/ns/edm" Namespace="NetworkInterface.v1_1_2">
+      <Annotation Term="Redfish.OwningEntity" String="DMTF"/>
+      <Annotation Term="OData.Description" String="This version was created to force the regeneration of JSON Schema so that URI properties use the uri-reference format."/>
+      <EntityType Name="NetworkInterface" BaseType="NetworkInterface.v1_1_1.NetworkInterface"/>
+    </Schema>
+
+    <Schema xmlns="http://docs.oasis-open.org/odata/ns/edm" Namespace="NetworkInterface.v1_1_3">
+      <Annotation Term="Redfish.OwningEntity" String="DMTF"/>
+      <Annotation Term="OData.Description" String="This version was created to update descriptions that this schema defines."/>
+      <EntityType Name="NetworkInterface" BaseType="NetworkInterface.v1_1_2.NetworkInterface"/>
+    </Schema>
+
+    <Schema xmlns="http://docs.oasis-open.org/odata/ns/edm" Namespace="NetworkInterface.v1_1_4">
+      <Annotation Term="Redfish.OwningEntity" String="DMTF"/>
+      <Annotation Term="OData.Description" String="This version was created to correct various typographical errors."/>
+      <EntityType Name="NetworkInterface" BaseType="NetworkInterface.v1_1_3.NetworkInterface"/>
+    </Schema>
+    
+    <Schema xmlns="http://docs.oasis-open.org/odata/ns/edm" Namespace="NetworkInterface.v1_1_5">
+      <Annotation Term="Redfish.OwningEntity" String="DMTF"/>
+      <Annotation Term="OData.Description" String="This version was created to correct various typographical errors."/>
+      <EntityType Name="NetworkInterface" BaseType="NetworkInterface.v1_1_4.NetworkInterface"/>
+    </Schema>
+
+    <Schema xmlns="http://docs.oasis-open.org/odata/ns/edm" Namespace="NetworkInterface.v1_2_0">
+      <Annotation Term="Redfish.OwningEntity" String="DMTF"/>
+      <Annotation Term="Redfish.Release" String="2020.3"/>
+
+      <EntityType Name="NetworkInterface" BaseType="NetworkInterface.v1_1_4.NetworkInterface">
+        <NavigationProperty Name="Ports" Type="PortCollection.PortCollection" ContainsTarget="true" Nullable="false">
+          <Annotation Term="OData.Permissions" EnumMember="OData.Permission/Read"/>
+          <Annotation Term="OData.Description" String="The link to the ports associated with this network interface."/>
+          <Annotation Term="OData.LongDescription" String="This property shall contain a link to a resource collection of type PortCollection."/>
+          <Annotation Term="OData.AutoExpandReferences"/>
+        </NavigationProperty>
+      </EntityType>
+    </Schema>
+    
+    <Schema xmlns="http://docs.oasis-open.org/odata/ns/edm" Namespace="NetworkInterface.v1_2_1">
+      <Annotation Term="Redfish.OwningEntity" String="DMTF"/>
+      <Annotation Term="OData.Description" String="This version was created to correct various typographical errors."/>
+      <EntityType Name="NetworkInterface" BaseType="NetworkInterface.v1_2_0.NetworkInterface"/>
+    </Schema>
+
+  </edmx:DataServices>
+</edmx:Edmx>

--- a/static/redfish/v1/schema/NetworkPortCollection_v1.xml
+++ b/static/redfish/v1/schema/NetworkPortCollection_v1.xml
@@ -1,0 +1,83 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!---->
+<!--################################################################################       -->
+<!--# Redfish Schema:  NetworkPortCollection                                               -->
+<!--#                                                                                      -->
+<!--# For a detailed change log, see the README file contained in the DSP8010 bundle,      -->
+<!--# available at http://www.dmtf.org/standards/redfish                                   -->
+<!--# Copyright 2014-2021 DMTF.                                                            -->
+<!--# For the full DMTF copyright policy, see http://www.dmtf.org/about/policies/copyright -->
+<!--################################################################################       -->
+<!---->
+<edmx:Edmx xmlns:edmx="http://docs.oasis-open.org/odata/ns/edmx" Version="4.0">
+
+  <edmx:Reference Uri="http://docs.oasis-open.org/odata/odata/v4.0/errata03/csd01/complete/vocabularies/Org.OData.Core.V1.xml">
+    <edmx:Include Namespace="Org.OData.Core.V1" Alias="OData"/>
+  </edmx:Reference>
+  <edmx:Reference Uri="http://docs.oasis-open.org/odata/odata/v4.0/errata03/csd01/complete/vocabularies/Org.OData.Capabilities.V1.xml">
+    <edmx:Include Namespace="Org.OData.Capabilities.V1" Alias="Capabilities"/>
+  </edmx:Reference>
+  <edmx:Reference Uri="http://redfish.dmtf.org/schemas/v1/Resource_v1.xml">
+    <edmx:Include Namespace="Resource.v1_0_0"/>
+  </edmx:Reference>
+  <edmx:Reference Uri="http://redfish.dmtf.org/schemas/v1/RedfishExtensions_v1.xml">
+    <edmx:Include Namespace="RedfishExtensions.v1_0_0" Alias="Redfish"/>
+  </edmx:Reference>
+  <edmx:Reference Uri="http://redfish.dmtf.org/schemas/v1/NetworkPort_v1.xml">
+    <edmx:Include Namespace="NetworkPort"/>
+  </edmx:Reference>
+
+  <edmx:DataServices>
+
+    <Schema xmlns="http://docs.oasis-open.org/odata/ns/edm" Namespace="NetworkPortCollection">
+      <Annotation Term="Redfish.OwningEntity" String="DMTF"/>
+
+      <EntityType Name="NetworkPortCollection" BaseType="Resource.v1_0_0.ResourceCollection">
+        <Annotation Term="OData.Description" String="The collection of NetworkPort resource instances."/>
+        <Annotation Term="OData.LongDescription" String="This resource shall represent a resource collection of NetworkPort instances for a Redfish implementation."/>
+        <Annotation Term="Capabilities.InsertRestrictions">
+          <Record>
+            <PropertyValue Property="Insertable" Bool="false"/>
+          </Record>
+        </Annotation>
+        <Annotation Term="Capabilities.UpdateRestrictions">
+          <Record>
+            <PropertyValue Property="Updatable" Bool="false"/>
+          </Record>
+        </Annotation>
+        <Annotation Term="Capabilities.DeleteRestrictions">
+          <Record>
+            <PropertyValue Property="Deletable" Bool="false"/>
+          </Record>
+        </Annotation>
+        <Annotation Term="Redfish.Uris">
+          <Collection>
+            <String>/redfish/v1/Chassis/{ChassisId}/NetworkAdapters/{NetworkAdapterId}/NetworkPorts</String>
+            <String>/redfish/v1/Systems/{ComputerSystemId}/NetworkInterfaces/{NetworkInterfaceId}/NetworkPorts</String>
+            <String>/redfish/v1/CompositionService/ResourceBlocks/{ResourceBlockId}/NetworkInterfaces/{NetworkInterfaceId}/NetworkPorts</String>
+            <String>/redfish/v1/CompositionService/ResourceBlocks/{ResourceBlockId}/Systems/{ComputerSystemId}/NetworkInterfaces/{NetworkInterfaceId}/NetworkPorts</String>
+            <String>/redfish/v1/ResourceBlocks/{ResourceBlockId}/NetworkInterfaces/{NetworkInterfaceId}/NetworkPorts</String>
+            <String>/redfish/v1/ResourceBlocks/{ResourceBlockId}/Systems/{ComputerSystemId}/NetworkInterfaces/{NetworkInterfaceId}/NetworkPorts</String>
+          </Collection>
+        </Annotation>
+        <Annotation Term="Redfish.Revisions">
+          <Collection>
+            <Record>
+              <PropertyValue Property="Kind" EnumMember="Redfish.RevisionKind/Deprecated"/>
+              <PropertyValue Property="Version" String="2020.4"/>
+              <PropertyValue Property="Description" String="This schema has been deprecated in favor of the PortCollection schema."/>
+            </Record>
+          </Collection>
+        </Annotation>
+        <NavigationProperty Name="Members" Type="Collection(NetworkPort.NetworkPort)">
+          <Annotation Term="OData.Permissions" EnumMember="OData.Permission/Read"/>
+          <Annotation Term="OData.Description" String="The members of this collection."/>
+          <Annotation Term="OData.LongDescription" String="This property shall contain an array of links to the members of this collection."/>
+          <Annotation Term="OData.AutoExpandReferences"/>
+          <Annotation Term="Redfish.Required"/>
+        </NavigationProperty>
+      </EntityType>
+    </Schema>
+
+  </edmx:DataServices>
+</edmx:Edmx>

--- a/static/redfish/v1/schema/NetworkPort_v1.xml
+++ b/static/redfish/v1/schema/NetworkPort_v1.xml
@@ -1,0 +1,553 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!---->
+<!--################################################################################       -->
+<!--# Redfish Schema:  NetworkPort v1.4.1                                                  -->
+<!--#                                                                                      -->
+<!--# For a detailed change log, see the README file contained in the DSP8010 bundle,      -->
+<!--# available at http://www.dmtf.org/standards/redfish                                   -->
+<!--# Copyright 2014-2021 DMTF.                                                            -->
+<!--# For the full DMTF copyright policy, see http://www.dmtf.org/about/policies/copyright -->
+<!--################################################################################       -->
+<!---->
+<edmx:Edmx xmlns:edmx="http://docs.oasis-open.org/odata/ns/edmx" Version="4.0">
+
+  <edmx:Reference Uri="http://docs.oasis-open.org/odata/odata/v4.0/errata03/csd01/complete/vocabularies/Org.OData.Core.V1.xml">
+    <edmx:Include Namespace="Org.OData.Core.V1" Alias="OData"/>
+  </edmx:Reference>
+  <edmx:Reference Uri="http://docs.oasis-open.org/odata/odata/v4.0/errata03/csd01/complete/vocabularies/Org.OData.Capabilities.V1.xml">
+    <edmx:Include Namespace="Org.OData.Capabilities.V1" Alias="Capabilities"/>
+  </edmx:Reference>
+  <edmx:Reference Uri="http://docs.oasis-open.org/odata/odata/v4.0/errata03/csd01/complete/vocabularies/Org.OData.Measures.V1.xml">
+    <edmx:Include Namespace="Org.OData.Measures.V1" Alias="Measures"/>
+  </edmx:Reference>
+  <edmx:Reference Uri="http://redfish.dmtf.org/schemas/v1/Resource_v1.xml">
+    <edmx:Include Namespace="Resource"/>
+    <edmx:Include Namespace="Resource.v1_0_0"/>
+  </edmx:Reference>
+  <edmx:Reference Uri="http://redfish.dmtf.org/schemas/v1/RedfishExtensions_v1.xml">
+    <edmx:Include Namespace="RedfishExtensions.v1_0_0" Alias="Redfish"/>
+  </edmx:Reference>
+  <edmx:Reference Uri="http://redfish.dmtf.org/schemas/v1/NetworkDeviceFunction_v1.xml">
+    <edmx:Include Namespace="NetworkDeviceFunction"/>
+  </edmx:Reference>
+
+  <edmx:DataServices>
+
+    <Schema xmlns="http://docs.oasis-open.org/odata/ns/edm" Namespace="NetworkPort">
+      <Annotation Term="Redfish.OwningEntity" String="DMTF"/>
+
+      <EntityType Name="NetworkPort" BaseType="Resource.v1_0_0.Resource" Abstract="true">
+        <Annotation Term="OData.Description" String="The NetworkPort schema describes a network port, which is a discrete physical port that can connect to a network."/>
+        <Annotation Term="OData.LongDescription" String="This resource shall represent a discrete physical port that can connect to a network in a Redfish implementation."/>
+        <Annotation Term="Capabilities.InsertRestrictions">
+          <Record>
+            <PropertyValue Property="Insertable" Bool="false"/>
+          </Record>
+        </Annotation>
+        <Annotation Term="Capabilities.UpdateRestrictions">
+          <Record>
+            <PropertyValue Property="Updatable" Bool="true"/>
+            <Annotation Term="OData.Description" String="Any writable properties, such as the bandwidth allocation and flow control configuration, can be updated for network ports."/>
+          </Record>
+        </Annotation>
+        <Annotation Term="Capabilities.DeleteRestrictions">
+          <Record>
+            <PropertyValue Property="Deletable" Bool="false"/>
+          </Record>
+        </Annotation>
+        <Annotation Term="Redfish.Uris">
+          <Collection>
+            <String>/redfish/v1/Chassis/{ChassisId}/NetworkAdapters/{NetworkAdapterId}/NetworkPorts/{NetworkPortId}</String>
+          </Collection>
+        </Annotation>
+        <Annotation Term="Redfish.Revisions">
+          <Collection>
+            <Record>
+              <PropertyValue Property="Kind" EnumMember="Redfish.RevisionKind/Deprecated"/>
+              <PropertyValue Property="Version" String="v1_4_0"/>
+              <PropertyValue Property="Description" String="This schema has been deprecated in favor of the Port schema."/>
+            </Record>
+          </Collection>
+        </Annotation>
+      </EntityType>
+    </Schema>
+
+    <Schema xmlns="http://docs.oasis-open.org/odata/ns/edm" Namespace="NetworkPort.v1_0_0">
+      <Annotation Term="Redfish.OwningEntity" String="DMTF"/>
+      <Annotation Term="Redfish.Release" String="2016.3"/>
+
+      <EntityType Name="NetworkPort" BaseType="NetworkPort.NetworkPort">
+        <Property Name="Status" Type="Resource.Status" Nullable="false">
+          <Annotation Term="OData.Description" String="The status and health of the resource and its subordinate or dependent resources."/>
+          <Annotation Term="OData.LongDescription" String="This property shall contain any status or health properties of the resource."/>
+        </Property>
+        <Property Name="PhysicalPortNumber" Type="Edm.String">
+          <Annotation Term="OData.Permissions" EnumMember="OData.Permission/Read"/>
+          <Annotation Term="OData.Description" String="The physical port number label for this port."/>
+          <Annotation Term="OData.LongDescription" String="This property shall contain the physical port number on the network adapter hardware that this network port corresponds to.  This value should match a value visible on the hardware."/>
+        </Property>
+        <Property Name="LinkStatus" Type="NetworkPort.v1_0_0.LinkStatus">
+          <Annotation Term="OData.Permissions" EnumMember="OData.Permission/Read"/>
+          <Annotation Term="OData.Description" String="The status of the link between this port and its link partner."/>
+          <Annotation Term="OData.LongDescription" String="This property shall contain the link status between this port and its link partner."/>
+        </Property>
+        <Property Name="SupportedLinkCapabilities" Type="Collection(NetworkPort.v1_0_0.SupportedLinkCapabilities)" Nullable="false">
+          <Annotation Term="OData.Description" String="The link capabilities of this port."/>
+          <Annotation Term="OData.LongDescription" String="This property shall describe the static capabilities of the port, irrespective of transient conditions such as cabling, interface module presence, or remote link partner status or configuration."/>
+        </Property>
+        <Property Name="ActiveLinkTechnology" Type="NetworkPort.v1_0_0.LinkNetworkTechnology">
+          <Annotation Term="OData.Permissions" EnumMember="OData.Permission/ReadWrite"/>
+          <Annotation Term="OData.Description" String="Network port active link technology."/>
+          <Annotation Term="OData.LongDescription" String="This property shall contain the configured link technology of this port."/>
+        </Property>
+        <Property Name="SupportedEthernetCapabilities" Type="Collection(NetworkPort.v1_0_0.SupportedEthernetCapabilities)">
+          <Annotation Term="OData.Permissions" EnumMember="OData.Permission/Read"/>
+          <Annotation Term="OData.Description" String="The set of Ethernet capabilities that this port supports."/>
+          <Annotation Term="OData.LongDescription" String="This property shall contain an array of zero or more Ethernet capabilities supported by this port."/>
+        </Property>
+        <Property Name="NetDevFuncMinBWAlloc" Type="Collection(NetworkPort.v1_0_0.NetDevFuncMinBWAlloc)" Nullable="false">
+          <Annotation Term="OData.Description" String="An array of minimum bandwidth allocation percentages for the network device functions associated with this port."/>
+          <Annotation Term="OData.LongDescription" String="This property shall contain an array of minimum bandwidth percentage allocations for each of the network device functions associated with this port."/>
+        </Property>
+        <Property Name="NetDevFuncMaxBWAlloc" Type="Collection(NetworkPort.v1_0_0.NetDevFuncMaxBWAlloc)" Nullable="false">
+          <Annotation Term="OData.Description" String="An array of maximum bandwidth allocation percentages for the network device functions associated with this port."/>
+          <Annotation Term="OData.LongDescription" String="This property shall contain an array of maximum bandwidth allocation percentages for the network device functions associated with this port."/>
+        </Property>
+        <Property Name="AssociatedNetworkAddresses" Type="Collection(Edm.String)">
+          <Annotation Term="OData.Permissions" EnumMember="OData.Permission/Read"/>
+          <Annotation Term="OData.Description" String="An array of configured MAC or WWN network addresses that are associated with this network port, including the programmed address of the lowest numbered network device function, the configured but not active address, if applicable, the address for hardware port teaming, or other network addresses."/>
+          <Annotation Term="OData.LongDescription" String="This property shall contain an array of configured network addresses that are associated with this network port, including the programmed address of the lowest numbered network device function, the configured but not active address if applicable, the address for hardware port teaming, or other network addresses."/>
+        </Property>
+        <Property Name="EEEEnabled" Type="Edm.Boolean">
+          <Annotation Term="OData.Permissions" EnumMember="OData.Permission/ReadWrite"/>
+          <Annotation Term="OData.Description" String="An indication of whether IEEE 802.3az Energy-Efficient Ethernet (EEE) is enabled for this network port."/>
+          <Annotation Term="OData.LongDescription" String="This property shall indicate whether IEEE 802.3az Energy-Efficient Ethernet (EEE) is enabled for this network port."/>
+        </Property>
+        <Property Name="WakeOnLANEnabled" Type="Edm.Boolean">
+          <Annotation Term="OData.Permissions" EnumMember="OData.Permission/ReadWrite"/>
+          <Annotation Term="OData.Description" String="An indication of whether Wake on LAN (WoL) is enabled for this network port."/>
+          <Annotation Term="OData.LongDescription" String="This property shall indicate whether Wake on LAN (WoL) is enabled for this network port."/>
+        </Property>
+        <Property Name="PortMaximumMTU" Type="Edm.Int64">
+          <Annotation Term="OData.Permissions" EnumMember="OData.Permission/Read"/>
+          <Annotation Term="OData.Description" String="The largest maximum transmission unit (MTU) that can be configured for this network port."/>
+          <Annotation Term="OData.LongDescription" String="This property shall contain the largest maximum transmission unit (MTU) that can be configured for this network port."/>
+        </Property>
+        <Property Name="FlowControlStatus" Type="NetworkPort.v1_0_0.FlowControl">
+          <Annotation Term="OData.Permissions" EnumMember="OData.Permission/Read"/>
+          <Annotation Term="OData.Description" String="The 802.3x flow control behavior negotiated with the link partner for this network port (Ethernet-only)."/>
+          <Annotation Term="OData.LongDescription" String="This property shall contain the 802.3x flow control behavior negotiated with the link partner for this network port (Ethernet-only)."/>
+        </Property>
+        <Property Name="FlowControlConfiguration" Type="NetworkPort.v1_0_0.FlowControl">
+          <Annotation Term="OData.Permissions" EnumMember="OData.Permission/ReadWrite"/>
+          <Annotation Term="OData.Description" String="The locally configured 802.3x flow control setting for this network port."/>
+          <Annotation Term="OData.LongDescription" String="This property shall contain the locally configured 802.3x flow control setting for this network port."/>
+        </Property>
+        <Property Name="SignalDetected" Type="Edm.Boolean">
+          <Annotation Term="OData.Permissions" EnumMember="OData.Permission/Read"/>
+          <Annotation Term="OData.Description" String="An indication of whether the port has detected enough signal on enough lanes to establish a link."/>
+          <Annotation Term="OData.LongDescription" String="This property shall indicate whether the port has detected enough signal on enough lanes to establish a link."/>
+        </Property>
+      </EntityType>
+
+      <ComplexType Name="SupportedLinkCapabilities">
+        <Annotation Term="OData.Description" String="The link capabilities of an associated port."/>
+        <Annotation Term="OData.LongDescription" String="This type shall describe the static capabilities of an associated port, irrespective of transient conditions such as cabling, interface module presence, or remote link partner status or configuration."/>
+        <Property Name="LinkNetworkTechnology" Type="NetworkPort.v1_0_0.LinkNetworkTechnology">
+          <Annotation Term="OData.Permissions" EnumMember="OData.Permission/Read"/>
+          <Annotation Term="OData.Description" String="The link network technology capabilities of this port."/>
+          <Annotation Term="OData.LongDescription" String="This property shall contain a network technology capability of this port."/>
+        </Property>
+        <Property Name="LinkSpeedMbps" Type="Edm.Int64">
+          <Annotation Term="OData.Permissions" EnumMember="OData.Permission/Read"/>
+          <Annotation Term="OData.Description" String="The speed of the link in Mbit/s when this link network technology is active."/>
+          <Annotation Term="OData.LongDescription" String="This property shall contain the speed of the link in megabits per second (Mbit/s) for this port when this link network technology is active."/>
+          <Annotation Term="Measures.Unit" String="Mbit/s"/>
+          <Annotation Term="Redfish.Revisions">
+            <Collection>
+              <Record>
+                <PropertyValue Property="Kind" EnumMember="Redfish.RevisionKind/Deprecated"/>
+                <PropertyValue Property="Version" String="v1_2_0"/>
+                <PropertyValue Property="Description" String="This property has been deprecated in favor of the CapableLinkSpeedMbps."/>
+              </Record>
+            </Collection>
+          </Annotation>
+        </Property>
+      </ComplexType>
+
+      <ComplexType Name="NetDevFuncMinBWAlloc">
+        <Annotation Term="OData.Description" String="A minimum bandwidth allocation percentage for a network device functions associated a port."/>
+        <Annotation Term="OData.LongDescription" String="This type shall describe a minimum bandwidth percentage allocation for a network device function associated with a port."/>
+        <NavigationProperty Name="NetworkDeviceFunction" Type="NetworkDeviceFunction.NetworkDeviceFunction" Nullable="false">
+          <Annotation Term="OData.Permissions" EnumMember="OData.Permission/Read"/>
+          <Annotation Term="OData.Description" String="The link to the network device function associated with this bandwidth setting of this network port."/>
+          <Annotation Term="OData.LongDescription" String="This property shall contain a link to a resource of type NetworkDeviceFunction that represents the network device function associated with this bandwidth setting of this network port."/>
+          <Annotation Term="OData.AutoExpandReferences"/>
+        </NavigationProperty>
+        <Property Name="MinBWAllocPercent" Type="Edm.Int64">
+          <Annotation Term="OData.Permissions" EnumMember="OData.Permission/ReadWrite"/>
+          <Annotation Term="OData.Description" String="The minimum bandwidth allocation percentage allocated to the corresponding network device function instance."/>
+          <Annotation Term="OData.LongDescription" String="This property shall contain the minimum bandwidth percentage allocation for the associated network device function.  The sum total of all minimum percentages shall not exceed 100."/>
+          <Annotation Term="Measures.Unit" String="%"/>
+        </Property>
+      </ComplexType>
+
+      <ComplexType Name="NetDevFuncMaxBWAlloc">
+        <Annotation Term="OData.Description" String="A maximum bandwidth allocation percentage for a network device functions associated a port."/>
+        <Annotation Term="OData.LongDescription" String="This type shall describe a maximum bandwidth percentage allocation for a network device function associated with a port."/>
+        <NavigationProperty Name="NetworkDeviceFunction" Type="NetworkDeviceFunction.NetworkDeviceFunction" Nullable="false">
+          <Annotation Term="OData.Permissions" EnumMember="OData.Permission/Read"/>
+          <Annotation Term="OData.Description" String="The link to the network device function associated with this bandwidth setting of this network port."/>
+          <Annotation Term="OData.LongDescription" String="This property shall contain a link to a resource of type NetworkDeviceFunction that represents the network device function associated with this bandwidth setting of this network port."/>
+          <Annotation Term="OData.AutoExpandReferences"/>
+        </NavigationProperty>
+        <Property Name="MaxBWAllocPercent" Type="Edm.Int64">
+          <Annotation Term="OData.Permissions" EnumMember="OData.Permission/ReadWrite"/>
+          <Annotation Term="OData.Description" String="The maximum bandwidth allocation percentage allocated to the corresponding network device function instance."/>
+          <Annotation Term="OData.LongDescription" String="This property shall contain the maximum bandwidth percentage allocation for the associated network device function."/>
+          <Annotation Term="Measures.Unit" String="%"/>
+        </Property>
+      </ComplexType>
+
+      <EnumType Name="LinkStatus">
+        <Member Name="Down">
+          <Annotation Term="OData.Description" String="The port is enabled but link is down." />
+        </Member>
+        <Member Name="Up">
+          <Annotation Term="OData.Description" String="The port is enabled and link is good (up)." />
+        </Member>
+        <Member Name="Starting">
+          <Annotation Term="OData.Description" String="This link on this interface is starting.  A physical link has been established, but the port is not able to transfer data."/>
+          <Annotation Term="Redfish.Revisions">
+            <Collection>
+              <Record>
+                <PropertyValue Property="Kind" EnumMember="Redfish.RevisionKind/Added"/>
+                <PropertyValue Property="Version" String="v1_3_0"/>
+              </Record>
+            </Collection>
+          </Annotation>
+        </Member>
+        <Member Name="Training">
+          <Annotation Term="OData.Description" String="This physical link on this interface is training."/>
+          <Annotation Term="Redfish.Revisions">
+            <Collection>
+              <Record>
+                <PropertyValue Property="Kind" EnumMember="Redfish.RevisionKind/Added"/>
+                <PropertyValue Property="Version" String="v1_3_0"/>
+              </Record>
+            </Collection>
+          </Annotation>
+        </Member>
+      </EnumType>
+
+      <EnumType Name="LinkNetworkTechnology">
+        <Member Name="Ethernet">
+          <Annotation Term="OData.Description" String="The port is capable of connecting to an Ethernet network." />
+        </Member>
+        <Member Name="InfiniBand">
+          <Annotation Term="OData.Description" String="The port is capable of connecting to an InfiniBand network." />
+        </Member>
+        <Member Name="FibreChannel">
+          <Annotation Term="OData.Description" String="The port is capable of connecting to a Fibre Channel network." />
+        </Member>
+      </EnumType>
+
+      <EnumType Name="SupportedEthernetCapabilities">
+        <Member Name="WakeOnLAN">
+          <Annotation Term="OData.Description" String="Wake on LAN (WoL) is supported on this port." />
+        </Member>
+        <Member Name="EEE">
+          <Annotation Term="OData.Description" String="IEEE 802.3az Energy-Efficient Ethernet (EEE) is supported on this port." />
+        </Member>
+      </EnumType>
+
+      <EnumType Name="FlowControl">
+        <Member Name="None">
+          <Annotation Term="OData.Description" String="No IEEE 802.3x flow control is enabled on this port." />
+        </Member>
+        <Member Name="TX">
+          <Annotation Term="OData.Description" String="This station can initiate IEEE 802.3x flow control." />
+        </Member>
+        <Member Name="RX">
+          <Annotation Term="OData.Description" String="The link partner can initiate IEEE 802.3x flow control." />
+        </Member>
+        <Member Name="TX_RX">
+          <Annotation Term="OData.Description" String="This station or the link partner can initiate IEEE 802.3x flow control." />
+        </Member>
+      </EnumType>
+    </Schema>
+
+    <Schema xmlns="http://docs.oasis-open.org/odata/ns/edm" Namespace="NetworkPort.v1_0_1">
+      <Annotation Term="Redfish.OwningEntity" String="DMTF"/>
+      <Annotation Term="OData.Description" String="This version was created to show that annotations in previous namespaces were updated."/>
+      <EntityType Name="NetworkPort" BaseType="NetworkPort.v1_0_0.NetworkPort"/>
+    </Schema>
+
+    <Schema xmlns="http://docs.oasis-open.org/odata/ns/edm" Namespace="NetworkPort.v1_0_2">
+      <Annotation Term="Redfish.OwningEntity" String="DMTF"/>
+      <Annotation Term="OData.Description" String="This version was created to add units annotations on the LinkSpeedMbps property.  It was also created to force the regeneration of JSON Schema so that OData properties are marked as required, and integer properties are marked as integer rather than number.  It was also created to add missing percent units onto existing properties."/>
+      <EntityType Name="NetworkPort" BaseType="NetworkPort.v1_0_1.NetworkPort"/>
+    </Schema>
+
+    <Schema xmlns="http://docs.oasis-open.org/odata/ns/edm" Namespace="NetworkPort.v1_0_3">
+      <Annotation Term="Redfish.OwningEntity" String="DMTF"/>
+      <Annotation Term="OData.Description" String="This version was created to use the new revisions annotation."/>
+      <EntityType Name="NetworkPort" BaseType="NetworkPort.v1_0_2.NetworkPort"/>
+    </Schema>
+
+    <Schema xmlns="http://docs.oasis-open.org/odata/ns/edm" Namespace="NetworkPort.v1_0_4">
+      <Annotation Term="Redfish.OwningEntity" String="DMTF"/>
+      <Annotation Term="OData.Description" String="This version was created to force the regeneration of JSON Schema so that URI properties use the uri-reference format, and to add a missing term to several properties to disallow them from being null."/>
+      <EntityType Name="NetworkPort" BaseType="NetworkPort.v1_0_3.NetworkPort"/>
+    </Schema>
+
+    <Schema xmlns="http://docs.oasis-open.org/odata/ns/edm" Namespace="NetworkPort.v1_0_5">
+      <Annotation Term="Redfish.OwningEntity" String="DMTF"/>
+      <Annotation Term="OData.Description" String="This version was created to update descriptions that this schema defines."/>
+      <EntityType Name="NetworkPort" BaseType="NetworkPort.v1_0_4.NetworkPort"/>
+    </Schema>
+
+    <Schema xmlns="http://docs.oasis-open.org/odata/ns/edm" Namespace="NetworkPort.v1_0_6">
+      <Annotation Term="Redfish.OwningEntity" String="DMTF"/>
+      <Annotation Term="OData.Description" String="This version was created to correct various typographical errors."/>
+      <EntityType Name="NetworkPort" BaseType="NetworkPort.v1_0_5.NetworkPort"/>
+    </Schema>
+
+    <Schema xmlns="http://docs.oasis-open.org/odata/ns/edm" Namespace="NetworkPort.v1_0_7">
+      <Annotation Term="Redfish.OwningEntity" String="DMTF"/>
+      <Annotation Term="OData.Description" String="This version was created to correct various typographical errors."/>
+      <EntityType Name="NetworkPort" BaseType="NetworkPort.v1_0_6.NetworkPort"/>
+    </Schema>
+
+    <Schema xmlns="http://docs.oasis-open.org/odata/ns/edm" Namespace="NetworkPort.v1_0_8">
+      <Annotation Term="Redfish.OwningEntity" String="DMTF"/>
+      <Annotation Term="OData.Description" String="This version was created to correct various typographical errors."/>
+      <EntityType Name="NetworkPort" BaseType="NetworkPort.v1_0_7.NetworkPort"/>
+    </Schema>
+
+    <Schema xmlns="http://docs.oasis-open.org/odata/ns/edm" Namespace="NetworkPort.v1_1_0">
+      <Annotation Term="Redfish.OwningEntity" String="DMTF"/>
+      <Annotation Term="Redfish.Release" String="2017.1"/>
+
+      <EntityType Name="NetworkPort" BaseType="NetworkPort.v1_0_1.NetworkPort">
+        <Property Name="Actions" Type="NetworkPort.v1_1_0.Actions" Nullable="false">
+          <Annotation Term="OData.Description" String="The available actions for this resource."/>
+          <Annotation Term="OData.LongDescription" String="This property shall contain the available actions for this resource."/>
+        </Property>
+      </EntityType>
+
+      <ComplexType Name="Actions">
+        <Annotation Term="OData.AdditionalProperties" Bool="false"/>
+        <Annotation Term="OData.Description" String="The available actions for this resource."/>
+        <Annotation Term="OData.LongDescription" String="This type shall contain the available actions for this resource."/>
+        <Property Name="Oem" Type="NetworkPort.v1_1_0.OemActions" Nullable="false">
+          <Annotation Term="OData.Description" String="The available OEM-specific actions for this resource."/>
+          <Annotation Term="OData.LongDescription" String="This property shall contain the available OEM-specific actions for this resource."/>
+        </Property>
+      </ComplexType>
+
+      <ComplexType Name="OemActions">
+        <Annotation Term="OData.AdditionalProperties" Bool="true"/>
+        <Annotation Term="OData.Description" String="The available OEM-specific actions for this resource."/>
+        <Annotation Term="OData.LongDescription" String="This type shall contain the available OEM-specific actions for this resource."/>
+      </ComplexType>
+    </Schema>
+
+    <Schema xmlns="http://docs.oasis-open.org/odata/ns/edm" Namespace="NetworkPort.v1_1_1">
+      <Annotation Term="Redfish.OwningEntity" String="DMTF"/>
+      <Annotation Term="OData.Description" String="This version was created to add units annotations on the LinkSpeedMbps property.  It was also created to force the regeneration of JSON Schema so that OData properties are marked as required, and integer properties are marked as integer rather than number.  It was also created to add missing percent units onto existing properties."/>
+      <EntityType Name="NetworkPort" BaseType="NetworkPort.v1_1_0.NetworkPort"/>
+    </Schema>
+
+    <Schema xmlns="http://docs.oasis-open.org/odata/ns/edm" Namespace="NetworkPort.v1_1_2">
+      <Annotation Term="Redfish.OwningEntity" String="DMTF"/>
+      <Annotation Term="OData.Description" String="This version was created to use the new revisions annotation."/>
+      <EntityType Name="NetworkPort" BaseType="NetworkPort.v1_1_1.NetworkPort"/>
+    </Schema>
+
+    <Schema xmlns="http://docs.oasis-open.org/odata/ns/edm" Namespace="NetworkPort.v1_1_3">
+      <Annotation Term="Redfish.OwningEntity" String="DMTF"/>
+      <Annotation Term="OData.Description" String="This version was created to force the regeneration of JSON Schema so that URI properties use the uri-reference format, and to add a missing term to several properties to disallow them from being null."/>
+      <EntityType Name="NetworkPort" BaseType="NetworkPort.v1_1_2.NetworkPort"/>
+    </Schema>
+
+    <Schema xmlns="http://docs.oasis-open.org/odata/ns/edm" Namespace="NetworkPort.v1_1_4">
+      <Annotation Term="Redfish.OwningEntity" String="DMTF"/>
+      <Annotation Term="OData.Description" String="This version was created to update descriptions that this schema defines."/>
+      <EntityType Name="NetworkPort" BaseType="NetworkPort.v1_1_3.NetworkPort"/>
+    </Schema>
+
+    <Schema xmlns="http://docs.oasis-open.org/odata/ns/edm" Namespace="NetworkPort.v1_1_5">
+      <Annotation Term="Redfish.OwningEntity" String="DMTF"/>
+      <Annotation Term="OData.Description" String="This version was created to correct various typographical errors."/>
+      <EntityType Name="NetworkPort" BaseType="NetworkPort.v1_1_4.NetworkPort"/>
+    </Schema>
+
+    <Schema xmlns="http://docs.oasis-open.org/odata/ns/edm" Namespace="NetworkPort.v1_1_6">
+      <Annotation Term="Redfish.OwningEntity" String="DMTF"/>
+      <Annotation Term="OData.Description" String="This version was created to correct various typographical errors."/>
+      <EntityType Name="NetworkPort" BaseType="NetworkPort.v1_1_5.NetworkPort"/>
+    </Schema>
+
+    <Schema xmlns="http://docs.oasis-open.org/odata/ns/edm" Namespace="NetworkPort.v1_1_7">
+      <Annotation Term="Redfish.OwningEntity" String="DMTF"/>
+      <Annotation Term="OData.Description" String="This version was created to correct various typographical errors."/>
+      <EntityType Name="NetworkPort" BaseType="NetworkPort.v1_1_6.NetworkPort"/>
+    </Schema>
+
+    <Schema xmlns="http://docs.oasis-open.org/odata/ns/edm" Namespace="NetworkPort.v1_2_0">
+      <Annotation Term="Redfish.OwningEntity" String="DMTF"/>
+      <Annotation Term="Redfish.Release" String="2018.2"/>
+      <Annotation Term="OData.Description" String="This version was created to add FibreChannel properties."/>
+
+      <EntityType Name="NetworkPort" BaseType="NetworkPort.v1_1_1.NetworkPort">
+        <Property Name="FCPortConnectionType" Type="NetworkPort.v1_2_0.PortConnectionType">
+          <Annotation Term="OData.Permissions" EnumMember="OData.Permission/Read"/>
+          <Annotation Term="OData.Description" String="The connection type of this port."/>
+          <Annotation Term="OData.LongDescription" String="This property shall contain the connection type for this port."/>
+        </Property>
+        <Property Name="NumberDiscoveredRemotePorts" Type="Edm.Int64">
+          <Annotation Term="OData.Permissions" EnumMember="OData.Permission/Read"/>
+          <Annotation Term="OData.Description" String="The number of ports not on this adapter that this port has discovered."/>
+          <Annotation Term="OData.LongDescription" String="This property shall contain the number of ports not on this adapter that this port has discovered."/>
+        </Property>
+        <Property Name="MaxFrameSize" Type="Edm.Int64">
+          <Annotation Term="OData.Permissions" EnumMember="OData.Permission/Read"/>
+          <Annotation Term="OData.Description" String="The maximum frame size supported by the port."/>
+          <Annotation Term="OData.LongDescription" String="This property shall contain the maximum frame size supported by the port."/>
+          <Annotation Term="Measures.Unit" String="By"/>
+        </Property>
+        <Property Name="VendorId" Type="Edm.String">
+          <Annotation Term="OData.Permissions" EnumMember="OData.Permission/Read"/>
+          <Annotation Term="OData.Description" String="The vendor Identification for this port."/>
+          <Annotation Term="OData.LongDescription" String="This property shall indicate the vendor identification string information as provided by the manufacturer of this port."/>
+        </Property>
+        <Property Name="FCFabricName" Type="Edm.String">
+          <Annotation Term="OData.Permissions" EnumMember="OData.Permission/Read"/>
+          <Annotation Term="OData.Description" String="The FC Fabric Name provided by the switch."/>
+          <Annotation Term="OData.LongDescription" String="This property shall indicate the FC Fabric Name provided by the switch."/>
+        </Property>
+        <Property Name="CurrentLinkSpeedMbps" Type="Edm.Int64">
+          <Annotation Term="OData.Permissions" EnumMember="OData.Permission/ReadWrite"/>
+          <Annotation Term="OData.Description" String="Network port current link speed."/>
+          <Annotation Term="OData.LongDescription" String="This property shall contain the current configured link speed of this port."/>
+          <Annotation Term="Measures.Unit" String="Mbit/s"/>
+        </Property>
+      </EntityType>
+
+      <EnumType Name="PortConnectionType">
+        <Member Name="NotConnected">
+          <Annotation Term="OData.Description" String="This port is not connected."/>
+        </Member>
+        <Member Name="NPort">
+          <Annotation Term="OData.Description" String="This port connects through an N-port to a switch."/>
+        </Member>
+        <Member Name="PointToPoint">
+          <Annotation Term="OData.Description" String="This port connects in a point-to-point configuration."/>
+        </Member>
+        <Member Name="PrivateLoop">
+          <Annotation Term="OData.Description" String="This port connects in a private loop configuration."/>
+        </Member>
+        <Member Name="PublicLoop">
+          <Annotation Term="OData.Description" String="This port connects in a public configuration."/>
+        </Member>
+        <Member Name="Generic">
+          <Annotation Term="OData.Description" String="This port connection type is a generic fabric port."/>
+        </Member>
+        <Member Name="ExtenderFabric">
+          <Annotation Term="OData.Description" String="This port connection type is an extender fabric port."/>
+        </Member>
+      </EnumType>
+
+      <ComplexType Name="SupportedLinkCapabilities" BaseType="NetworkPort.v1_0_0.SupportedLinkCapabilities">
+        <Property Name="CapableLinkSpeedMbps" Type="Collection(Edm.Int64)">
+          <Annotation Term="OData.Permissions" EnumMember="OData.Permission/Read"/>
+          <Annotation Term="OData.Description" String="The set of link speed capabilities of this port."/>
+          <Annotation Term="OData.LongDescription" String="This property shall contain all of the possible network link speed capabilities of this port."/>
+        </Property>
+        <Property Name="AutoSpeedNegotiation" Type="Edm.Boolean">
+          <Annotation Term="OData.Permissions" EnumMember="OData.Permission/Read"/>
+          <Annotation Term="OData.Description" String="An indication of whether the port is capable of autonegotiating speed."/>
+          <Annotation Term="OData.LongDescription" String="This property shall indicate whether the port is capable of autonegotiating speed."/>
+        </Property>
+      </ComplexType>
+    </Schema>
+
+    <Schema xmlns="http://docs.oasis-open.org/odata/ns/edm" Namespace="NetworkPort.v1_2_1">
+      <Annotation Term="Redfish.OwningEntity" String="DMTF"/>
+      <Annotation Term="OData.Description" String="This version was created to use the new revisions annotation."/>
+      <EntityType Name="NetworkPort" BaseType="NetworkPort.v1_2_0.NetworkPort"/>
+    </Schema>
+
+    <Schema xmlns="http://docs.oasis-open.org/odata/ns/edm" Namespace="NetworkPort.v1_2_2">
+      <Annotation Term="Redfish.OwningEntity" String="DMTF"/>
+      <Annotation Term="OData.Description" String="This version was created to force the regeneration of JSON Schema so that URI properties use the uri-reference format, and to add a missing term to several properties to disallow them from being null."/>
+      <EntityType Name="NetworkPort" BaseType="NetworkPort.v1_2_1.NetworkPort"/>
+    </Schema>
+
+    <Schema xmlns="http://docs.oasis-open.org/odata/ns/edm" Namespace="NetworkPort.v1_2_3">
+      <Annotation Term="Redfish.OwningEntity" String="DMTF"/>
+      <Annotation Term="OData.Description" String="This version was created to update descriptions that this schema defines."/>
+      <EntityType Name="NetworkPort" BaseType="NetworkPort.v1_2_2.NetworkPort"/>
+    </Schema>
+
+    <Schema xmlns="http://docs.oasis-open.org/odata/ns/edm" Namespace="NetworkPort.v1_2_4">
+      <Annotation Term="Redfish.OwningEntity" String="DMTF"/>
+      <Annotation Term="OData.Description" String="This version was created to correct various typographical errors."/>
+      <EntityType Name="NetworkPort" BaseType="NetworkPort.v1_2_3.NetworkPort"/>
+    </Schema>
+
+    <Schema xmlns="http://docs.oasis-open.org/odata/ns/edm" Namespace="NetworkPort.v1_2_5">
+      <Annotation Term="Redfish.OwningEntity" String="DMTF"/>
+      <Annotation Term="OData.Description" String="This version was created to correct various typographical errors."/>
+      <EntityType Name="NetworkPort" BaseType="NetworkPort.v1_2_4.NetworkPort"/>
+    </Schema>
+
+    <Schema xmlns="http://docs.oasis-open.org/odata/ns/edm" Namespace="NetworkPort.v1_2_6">
+      <Annotation Term="Redfish.OwningEntity" String="DMTF"/>
+      <Annotation Term="OData.Description" String="This version was created to correct various typographical errors."/>
+      <EntityType Name="NetworkPort" BaseType="NetworkPort.v1_2_5.NetworkPort"/>
+    </Schema>
+
+    <Schema xmlns="http://docs.oasis-open.org/odata/ns/edm" Namespace="NetworkPort.v1_2_7">
+      <Annotation Term="Redfish.OwningEntity" String="DMTF"/>
+      <Annotation Term="OData.Description" String="This version was created to correct various typographical errors."/>
+      <EntityType Name="NetworkPort" BaseType="NetworkPort.v1_2_6.NetworkPort"/>
+    </Schema>
+
+    <Schema xmlns="http://docs.oasis-open.org/odata/ns/edm" Namespace="NetworkPort.v1_3_0">
+      <Annotation Term="Redfish.OwningEntity" String="DMTF"/>
+      <Annotation Term="Redfish.Release" String="2020.3"/>
+      <Annotation Term="OData.Description" String="This version was created to add `Starting` and `Training` to LinkStatus."/>
+
+      <EntityType Name="NetworkPort" BaseType="NetworkPort.v1_2_4.NetworkPort"/>
+    </Schema>
+
+    <Schema xmlns="http://docs.oasis-open.org/odata/ns/edm" Namespace="NetworkPort.v1_3_1">
+      <Annotation Term="Redfish.OwningEntity" String="DMTF"/>
+      <Annotation Term="OData.Description" String="This version was created to correct various typographical errors."/>
+      <EntityType Name="NetworkPort" BaseType="NetworkPort.v1_3_0.NetworkPort"/>
+    </Schema>
+
+    <Schema xmlns="http://docs.oasis-open.org/odata/ns/edm" Namespace="NetworkPort.v1_3_2">
+      <Annotation Term="Redfish.OwningEntity" String="DMTF"/>
+      <Annotation Term="OData.Description" String="This version was created to correct various typographical errors."/>
+      <EntityType Name="NetworkPort" BaseType="NetworkPort.v1_3_1.NetworkPort"/>
+    </Schema>
+
+    <Schema xmlns="http://docs.oasis-open.org/odata/ns/edm" Namespace="NetworkPort.v1_4_0">
+      <Annotation Term="Redfish.OwningEntity" String="DMTF"/>
+      <Annotation Term="Redfish.Release" String="2020.4"/>
+      <Annotation Term="OData.Description" String="This version was created to deprecate the schema."/>
+
+      <EntityType Name="NetworkPort" BaseType="NetworkPort.v1_3_1.NetworkPort"/>
+    </Schema>
+
+    <Schema xmlns="http://docs.oasis-open.org/odata/ns/edm" Namespace="NetworkPort.v1_4_1">
+      <Annotation Term="Redfish.OwningEntity" String="DMTF"/>
+      <Annotation Term="OData.Description" String="This version was created to correct various typographical errors."/>
+      <EntityType Name="NetworkPort" BaseType="NetworkPort.v1_4_0.NetworkPort"/>
+    </Schema>
+
+  </edmx:DataServices>
+</edmx:Edmx>

--- a/static/redfish/v1/schema/OutletCollection_v1.xml
+++ b/static/redfish/v1/schema/OutletCollection_v1.xml
@@ -1,0 +1,71 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!---->
+<!--################################################################################       -->
+<!--# Redfish Schema:  OutletCollection                                                    -->
+<!--#                                                                                      -->
+<!--# For a detailed change log, see the README file contained in the DSP8010 bundle,      -->
+<!--# available at http://www.dmtf.org/standards/redfish                                   -->
+<!--# Copyright 2014-2021 DMTF.                                                            -->
+<!--# For the full DMTF copyright policy, see http://www.dmtf.org/about/policies/copyright -->
+<!--################################################################################       -->
+<!---->
+<edmx:Edmx xmlns:edmx="http://docs.oasis-open.org/odata/ns/edmx" Version="4.0">
+
+  <edmx:Reference Uri="http://docs.oasis-open.org/odata/odata/v4.0/errata03/csd01/complete/vocabularies/Org.OData.Core.V1.xml">
+    <edmx:Include Namespace="Org.OData.Core.V1" Alias="OData"/>
+  </edmx:Reference>
+  <edmx:Reference Uri="http://docs.oasis-open.org/odata/odata/v4.0/errata03/csd01/complete/vocabularies/Org.OData.Capabilities.V1.xml">
+    <edmx:Include Namespace="Org.OData.Capabilities.V1" Alias="Capabilities"/>
+  </edmx:Reference>
+  <edmx:Reference Uri="http://redfish.dmtf.org/schemas/v1/RedfishExtensions_v1.xml">
+    <edmx:Include Namespace="RedfishExtensions.v1_0_0" Alias="Redfish"/>
+  </edmx:Reference>
+  <edmx:Reference Uri="http://redfish.dmtf.org/schemas/v1/Resource_v1.xml">
+    <edmx:Include Namespace="Resource.v1_0_0"/>
+  </edmx:Reference>
+  <edmx:Reference Uri="http://redfish.dmtf.org/schemas/v1/Outlet_v1.xml">
+    <edmx:Include Namespace="Outlet"/>
+  </edmx:Reference>
+
+  <edmx:DataServices>
+
+    <Schema xmlns="http://docs.oasis-open.org/odata/ns/edm" Namespace="OutletCollection">
+      <Annotation Term="Redfish.OwningEntity" String="DMTF"/>
+
+      <EntityType Name="OutletCollection" BaseType="Resource.v1_0_0.ResourceCollection">
+        <Annotation Term="OData.Description" String="The collection of Outlet resource instances."/>
+        <Annotation Term="OData.LongDescription" String="This resource shall represent a resource collection of Outlet instances for a Redfish implementation."/>
+        <Annotation Term="Capabilities.InsertRestrictions">
+          <Record>
+            <PropertyValue Property="Insertable" Bool="false"/>
+          </Record>
+        </Annotation>
+        <Annotation Term="Capabilities.UpdateRestrictions">
+          <Record>
+            <PropertyValue Property="Updatable" Bool="false"/>
+          </Record>
+        </Annotation>
+        <Annotation Term="Capabilities.DeleteRestrictions">
+          <Record>
+            <PropertyValue Property="Deletable" Bool="false"/>
+          </Record>
+        </Annotation>
+        <Annotation Term="Redfish.Uris">
+          <Collection>
+            <String>/redfish/v1/PowerEquipment/RackPDUs/{PowerDistributionId}/Outlets</String>
+            <String>/redfish/v1/PowerEquipment/TransferSwitches/{PowerDistributionId}/Outlets</String>
+            <String>/redfish/v1/PowerEquipment/PowerShelves/{PowerDistributionId}/Outlets</String>
+          </Collection>
+        </Annotation>
+        <NavigationProperty Name="Members" Type="Collection(Outlet.Outlet)">
+          <Annotation Term="OData.Permissions" EnumMember="OData.Permission/Read"/>
+          <Annotation Term="OData.Description" String="The members of this collection."/>
+          <Annotation Term="OData.LongDescription" String="This property shall contain an array of links to the members of this collection."/>
+          <Annotation Term="OData.AutoExpandReferences"/>
+          <Annotation Term="Redfish.Required"/>
+        </NavigationProperty>
+      </EntityType>
+    </Schema>
+
+  </edmx:DataServices>
+</edmx:Edmx>

--- a/static/redfish/v1/schema/OutletGroupCollection_v1.xml
+++ b/static/redfish/v1/schema/OutletGroupCollection_v1.xml
@@ -1,0 +1,71 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!---->
+<!--################################################################################       -->
+<!--# Redfish Schema:  OutletGroupCollection                                               -->
+<!--#                                                                                      -->
+<!--# For a detailed change log, see the README file contained in the DSP8010 bundle,      -->
+<!--# available at http://www.dmtf.org/standards/redfish                                   -->
+<!--# Copyright 2014-2021 DMTF.                                                            -->
+<!--# For the full DMTF copyright policy, see http://www.dmtf.org/about/policies/copyright -->
+<!--################################################################################       -->
+<!---->
+<edmx:Edmx xmlns:edmx="http://docs.oasis-open.org/odata/ns/edmx" Version="4.0">
+
+  <edmx:Reference Uri="http://docs.oasis-open.org/odata/odata/v4.0/errata03/csd01/complete/vocabularies/Org.OData.Core.V1.xml">
+    <edmx:Include Namespace="Org.OData.Core.V1" Alias="OData"/>
+  </edmx:Reference>
+  <edmx:Reference Uri="http://docs.oasis-open.org/odata/odata/v4.0/errata03/csd01/complete/vocabularies/Org.OData.Capabilities.V1.xml">
+    <edmx:Include Namespace="Org.OData.Capabilities.V1" Alias="Capabilities"/>
+  </edmx:Reference>
+  <edmx:Reference Uri="http://redfish.dmtf.org/schemas/v1/RedfishExtensions_v1.xml">
+    <edmx:Include Namespace="RedfishExtensions.v1_0_0" Alias="Redfish"/>
+  </edmx:Reference>
+  <edmx:Reference Uri="http://redfish.dmtf.org/schemas/v1/Resource_v1.xml">
+    <edmx:Include Namespace="Resource.v1_0_0"/>
+  </edmx:Reference>
+  <edmx:Reference Uri="http://redfish.dmtf.org/schemas/v1/OutletGroup_v1.xml">
+    <edmx:Include Namespace="OutletGroup"/>
+  </edmx:Reference>
+
+  <edmx:DataServices>
+
+    <Schema xmlns="http://docs.oasis-open.org/odata/ns/edm" Namespace="OutletGroupCollection">
+      <Annotation Term="Redfish.OwningEntity" String="DMTF"/>
+
+      <EntityType Name="OutletGroupCollection" BaseType="Resource.v1_0_0.ResourceCollection">
+        <Annotation Term="OData.Description" String="The collection of OutletGroup resource instances."/>
+        <Annotation Term="OData.LongDescription" String="This resource shall represent a resource collection of OutletGroup instances for a Redfish implementation."/>
+        <Annotation Term="Capabilities.InsertRestrictions">
+          <Record>
+            <PropertyValue Property="Insertable" Bool="true"/>
+            <Annotation Term="OData.Description" String="In some implementations, outlet groups can be added through a POST to the outlet group collection.  In other implementations, the collection might be pre-populated with a fixed number of outlet groups."/>
+          </Record>
+        </Annotation>
+        <Annotation Term="Capabilities.UpdateRestrictions">
+          <Record>
+            <PropertyValue Property="Updatable" Bool="false"/>
+          </Record>
+        </Annotation>
+        <Annotation Term="Capabilities.DeleteRestrictions">
+          <Record>
+            <PropertyValue Property="Deletable" Bool="false"/>
+          </Record>
+        </Annotation>
+        <Annotation Term="Redfish.Uris">
+          <Collection>
+            <String>/redfish/v1/PowerEquipment/RackPDUs/{PowerDistributionId}/OutletGroups</String>
+            <String>/redfish/v1/PowerEquipment/TransferSwitches/{PowerDistributionId}/OutletGroups</String>
+          </Collection>
+        </Annotation>
+        <NavigationProperty Name="Members" Type="Collection(OutletGroup.OutletGroup)">
+          <Annotation Term="OData.Permissions" EnumMember="OData.Permission/Read"/>
+          <Annotation Term="OData.Description" String="The members of this collection."/>
+          <Annotation Term="OData.LongDescription" String="This property shall contain an array of links to the members of this collection."/>
+          <Annotation Term="OData.AutoExpandReferences"/>
+          <Annotation Term="Redfish.Required"/>
+        </NavigationProperty>
+      </EntityType>
+    </Schema>
+
+  </edmx:DataServices>
+</edmx:Edmx>

--- a/static/redfish/v1/schema/OutletGroup_v1.xml
+++ b/static/redfish/v1/schema/OutletGroup_v1.xml
@@ -1,0 +1,204 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!---->
+<!--################################################################################       -->
+<!--# Redfish Schema:  OutletGroup v1.0.1                                                  -->
+<!--#                                                                                      -->
+<!--# For a detailed change log, see the README file contained in the DSP8010 bundle,      -->
+<!--# available at http://www.dmtf.org/standards/redfish                                   -->
+<!--# Copyright 2014-2021 DMTF.                                                            -->
+<!--# For the full DMTF copyright policy, see http://www.dmtf.org/about/policies/copyright -->
+<!--################################################################################       -->
+<!---->
+<edmx:Edmx xmlns:edmx="http://docs.oasis-open.org/odata/ns/edmx" Version="4.0">
+
+  <edmx:Reference Uri="http://docs.oasis-open.org/odata/odata/v4.0/errata03/csd01/complete/vocabularies/Org.OData.Core.V1.xml">
+    <edmx:Include Namespace="Org.OData.Core.V1" Alias="OData"/>
+  </edmx:Reference>
+  <edmx:Reference Uri="http://docs.oasis-open.org/odata/odata/v4.0/errata03/csd01/complete/vocabularies/Org.OData.Capabilities.V1.xml">
+    <edmx:Include Namespace="Org.OData.Capabilities.V1" Alias="Capabilities"/>
+  </edmx:Reference>
+  <edmx:Reference Uri="http://redfish.dmtf.org/schemas/v1/RedfishExtensions_v1.xml">
+    <edmx:Include Namespace="RedfishExtensions.v1_0_0" Alias="Redfish"/>
+  </edmx:Reference>
+  <edmx:Reference Uri="http://redfish.dmtf.org/schemas/v1/Resource_v1.xml">
+    <edmx:Include Namespace="Resource"/>
+    <edmx:Include Namespace="Resource.v1_0_0"/>
+  </edmx:Reference>
+  <edmx:Reference Uri="http://redfish.dmtf.org/schemas/v1/Sensor_v1.xml">
+    <edmx:Include Namespace="Sensor"/>
+  </edmx:Reference>
+  <edmx:Reference Uri="http://redfish.dmtf.org/schemas/v1/Circuit_v1.xml">
+    <edmx:Include Namespace="Circuit"/>
+  </edmx:Reference>
+  <edmx:Reference Uri="http://redfish.dmtf.org/schemas/v1/Outlet_v1.xml">
+    <edmx:Include Namespace="Outlet"/>
+  </edmx:Reference>
+
+  <edmx:DataServices>
+
+    <Schema xmlns="http://docs.oasis-open.org/odata/ns/edm" Namespace="OutletGroup">
+      <Annotation Term="Redfish.OwningEntity" String="DMTF"/>
+
+      <EntityType Name="OutletGroup" BaseType="Resource.v1_0_0.Resource" Abstract="true">
+        <Annotation Term="OData.Description" String="The OutletGroup schema contains definitions for an electrical outlet group."/>
+        <Annotation Term="OData.LongDescription" String="This resource shall be used to represent an electrical outlet group for a Redfish implementation."/>
+        <Annotation Term="Capabilities.InsertRestrictions">
+          <Record>
+            <PropertyValue Property="Insertable" Bool="false"/>
+          </Record>
+        </Annotation>
+        <Annotation Term="Capabilities.UpdateRestrictions">
+          <Record>
+            <PropertyValue Property="Updatable" Bool="true"/>
+            <Annotation Term="OData.Description" String="Outlet group properties can be updated to change limits, exceptions and other writable properties."/>
+          </Record>
+        </Annotation>
+        <Annotation Term="Capabilities.DeleteRestrictions">
+          <Record>
+            <PropertyValue Property="Deletable" Bool="true"/>
+            <Annotation Term="OData.Description" String="Some implementations can allow outlet groups to be deleted."/>
+          </Record>
+        </Annotation>
+        <Annotation Term="Redfish.Uris">
+          <Collection>
+            <String>/redfish/v1/PowerEquipment/RackPDUs/{PowerDistributionId}/OutletGroups/{OutletGroupId}</String>
+            <String>/redfish/v1/PowerEquipment/TransferSwitches/{PowerDistributionId}/OutletGroups/{OutletGroupId}</String>
+          </Collection>
+        </Annotation>
+      </EntityType>
+
+      <Action Name="PowerControl" IsBound="true">
+        <Annotation Term="OData.Description" String="This action turns the outlet group on or off."/>
+        <Annotation Term="OData.LongDescription" String="This action shall control the power state of the outlet group."/>
+        <Parameter Name="OutletGroup" Type="OutletGroup.v1_0_0.Actions"/>
+        <Parameter Name="PowerState" Type="OutletGroup.PowerState">
+          <Annotation Term="OData.Description" String="The desired power state of the outlet group."/>
+          <Annotation Term="OData.LongDescription" String="This parameter shall contain the desired power state of the outlet group."/>
+        </Parameter>
+      </Action>
+
+      <Action Name="ResetMetrics" IsBound="true">
+        <Parameter Name="OutletGroup" Type="OutletGroup.v1_0_0.Actions"/>
+        <Annotation Term="OData.Description" String="This action resets metrics related to this outlet group."/>
+        <Annotation Term="OData.LongDescription" String="This action shall reset any time intervals or counted values for this outlet group."/>
+      </Action>
+
+      <EnumType Name="PowerState">
+        <Member Name="On">
+          <Annotation Term="OData.Description" String="The outlet group is powered on."/>
+        </Member>
+        <Member Name="Off">
+          <Annotation Term="OData.Description" String="The outlet group is powered off."/>
+        </Member>
+      </EnumType>
+    </Schema>
+
+    <Schema xmlns="http://docs.oasis-open.org/odata/ns/edm" Namespace="OutletGroup.v1_0_0">
+      <Annotation Term="Redfish.OwningEntity" String="DMTF"/>
+      <Annotation Term="Redfish.Release" String="2019.4"/>
+
+      <EntityType Name="OutletGroup" BaseType="OutletGroup.OutletGroup">
+        <Property Name="Status" Type="Resource.Status" Nullable="false">
+          <Annotation Term="OData.Description" String="The status and health of the resource and its subordinate or dependent resources."/>
+          <Annotation Term="OData.LongDescription" String="This property shall contain any status or health properties of the resource."/>
+        </Property>
+        <Property Name="CreatedBy" Type="Edm.String">
+          <Annotation Term="OData.Permissions" EnumMember="OData.Permission/ReadWrite"/>
+          <Annotation Term="OData.Description" String="The creator of this outlet group."/>
+          <Annotation Term="OData.LongDescription" String="This property shall contain the name of the person or application that created this outlet group."/>
+        </Property>
+        <Property Name="PowerOnDelaySeconds" Type="Edm.Decimal">
+          <Annotation Term="OData.Permissions" EnumMember="OData.Permission/ReadWrite"/>
+          <Annotation Term="OData.Description" String="The number of seconds to delay power up after a power cycle or a PowerControl action.  Zero seconds indicates no delay to power up."/>
+          <Annotation Term="OData.LongDescription" String="This property shall contain the number of seconds to delay power up after a power cycle or a PowerControl action.  The value `0` shall indicate no delay to power up."/>
+        </Property>
+        <Property Name="PowerOffDelaySeconds" Type="Edm.Decimal">
+          <Annotation Term="OData.Permissions" EnumMember="OData.Permission/ReadWrite"/>
+          <Annotation Term="OData.Description" String="The number of seconds to delay power off after a PowerControl action.  Zero seconds indicates no delay to power off."/>
+          <Annotation Term="OData.LongDescription" String="This property shall contain the number of seconds to delay power off after a PowerControl action.  The value `0` shall indicate no delay to power off."/>
+        </Property>
+        <Property Name="PowerCycleDelaySeconds" Type="Edm.Decimal">
+          <Annotation Term="OData.Permissions" EnumMember="OData.Permission/ReadWrite"/>
+          <Annotation Term="OData.Description" String="The number of seconds to delay power on after a PowerControl action to cycle power.  Zero seconds indicates no delay."/>
+          <Annotation Term="OData.LongDescription" String="This property shall contain the number of seconds to delay power on after a PowerControl action to cycle power.  The value `0` shall indicate no delay to power on."/>
+        </Property>
+        <Property Name="PowerRestoreDelaySeconds" Type="Edm.Decimal">
+          <Annotation Term="OData.Permissions" EnumMember="OData.Permission/ReadWrite"/>
+          <Annotation Term="OData.Description" String="The number of seconds to delay power on after power has been restored.  Zero seconds indicates no delay."/>
+          <Annotation Term="OData.LongDescription" String="This property shall contain the number of seconds to delay power on after a power fault.  The value `0` shall indicate no delay to power on."/>
+        </Property>
+        <Property Name="PowerRestorePolicy" Type="Circuit.PowerRestorePolicyTypes" Nullable="false">
+          <Annotation Term="OData.Permissions" EnumMember="OData.Permission/ReadWrite"/>
+          <Annotation Term="OData.Description" String="The desired power state of the outlet group when power is restored after a power loss."/>
+          <Annotation Term="OData.LongDescription" String="This property shall contain the desired PowerState of the outlet group when power is applied.  The value `LastState` shall return the outlet group to the PowerState it was in when power was lost."/>
+        </Property>
+        <Property Name="PowerState" Type="Resource.PowerState">
+          <Annotation Term="OData.Permissions" EnumMember="OData.Permission/Read"/>
+          <Annotation Term="OData.Description" String="The power state of the outlet group."/>
+          <Annotation Term="OData.LongDescription" String="This property shall contain the power state of the outlet group."/>
+        </Property>
+        <Property Name="PowerEnabled" Type="Edm.Boolean">
+          <Annotation Term="OData.Permissions" EnumMember="OData.Permission/Read"/>
+          <Annotation Term="OData.Description" String="Indicates if the outlet group can be powered."/>
+          <Annotation Term="OData.LongDescription" String="This property shall contain the power enable state of the outlet group.  True shall indicate that the group can be powered on, and false shall indicate that the group cannot be powered."/>
+        </Property>
+
+        <NavigationProperty Name="PowerWatts" Type="Sensor.Sensor">
+          <Annotation Term="OData.Permissions" EnumMember="OData.Permission/Read"/>
+          <Annotation Term="Redfish.ExcerptCopy" String="Power"/>
+          <Annotation Term="OData.Description" String="The power reading for this outlet group."/>
+          <Annotation Term="OData.LongDescription" String="This property shall contain the total power, measured in Watts, for this outlet group, that represents the `Total` ElectricalContext sensor when multiple power sensors exist for this outlet group."/>
+        </NavigationProperty>
+        <NavigationProperty Name="EnergykWh" Type="Sensor.Sensor">
+          <Annotation Term="OData.Permissions" EnumMember="OData.Permission/Read"/>
+          <Annotation Term="Redfish.ExcerptCopy" String="EnergykWh"/>
+          <Annotation Term="OData.Description" String="The energy reading for this outlet group."/>
+          <Annotation Term="OData.LongDescription" String="This property shall contain the total energy, measured in kilowatt-hours (kW.h), for this outlet group, that represents the `Total` ElectricalContext sensor when multiple energy sensors exist for this outlet group."/>
+        </NavigationProperty>
+
+        <Property Name="Links" Type="OutletGroup.v1_0_0.Links" Nullable="false">
+          <Annotation Term="OData.Description" String="The links to other resources that are related to this resource."/>
+          <Annotation Term="OData.LongDescription" String="This property shall contain links to resources that are related to but are not contained by, or subordinate to, this resource."/>
+        </Property>
+        <Property Name="Actions" Type="OutletGroup.v1_0_0.Actions" Nullable="false">
+          <Annotation Term="OData.Description" String="The available actions for this resource."/>
+          <Annotation Term="OData.LongDescription" String="This property shall contain the available actions for this resource."/>
+        </Property>
+      </EntityType>
+
+      <ComplexType Name="Links" BaseType="Resource.Links">
+        <Annotation Term="OData.Description" String="The links to other resources that are related to this resource."/>
+        <Annotation Term="OData.LongDescription" String="This Redfish Specification-described type shall contain links to resources that are related to but are not contained by, or subordinate to, this resource."/>
+        <NavigationProperty Name="Outlets" Type="Collection(Outlet.Outlet)" ContainsTarget="true">
+          <Annotation Term="OData.Permissions" EnumMember="OData.Permission/ReadWrite"/>
+          <Annotation Term="OData.Description" String="The set of outlets in this outlet group."/>
+          <Annotation Term="OData.LongDescription" String="This property shall be an array of links to resources of type Outlet that represent the outlets in this outlet group."/>
+          <Annotation Term="OData.AutoExpandReferences"/>
+        </NavigationProperty>
+      </ComplexType>
+
+      <ComplexType Name="Actions">
+        <Annotation Term="OData.AdditionalProperties" Bool="false"/>
+        <Annotation Term="OData.Description" String="The available actions for this resource."/>
+        <Annotation Term="OData.LongDescription" String="This type shall contain the available actions for this resource."/>
+        <Property Name="Oem" Type="OutletGroup.v1_0_0.OemActions" Nullable="false">
+          <Annotation Term="OData.Description" String="The available OEM-specific actions for this resource."/>
+          <Annotation Term="OData.LongDescription" String="This property shall contain the available OEM-specific actions for this resource."/>
+        </Property>
+      </ComplexType>
+
+      <ComplexType Name="OemActions">
+        <Annotation Term="OData.AdditionalProperties" Bool="true"/>
+        <Annotation Term="OData.Description" String="The available OEM-specific actions for this resource."/>
+        <Annotation Term="OData.LongDescription" String="This type shall contain the available OEM-specific actions for this resource."/>
+      </ComplexType>
+    </Schema>
+
+    <Schema xmlns="http://docs.oasis-open.org/odata/ns/edm" Namespace="OutletGroup.v1_0_1">
+      <Annotation Term="Redfish.OwningEntity" String="DMTF"/>
+      <Annotation Term="OData.Description" String="This version was created to correct various typographical errors."/>
+      <EntityType Name="OutletGroup" BaseType="OutletGroup.v1_0_0.OutletGroup"/>
+    </Schema>
+
+  </edmx:DataServices>
+</edmx:Edmx>

--- a/static/redfish/v1/schema/Outlet_v1.xml
+++ b/static/redfish/v1/schema/Outlet_v1.xml
@@ -1,0 +1,434 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!---->
+<!--################################################################################       -->
+<!--# Redfish Schema:  Outlet v1.2.0                                                       -->
+<!--#                                                                                      -->
+<!--# For a detailed change log, see the README file contained in the DSP8010 bundle,      -->
+<!--# available at http://www.dmtf.org/standards/redfish                                   -->
+<!--# Copyright 2014-2021 DMTF.                                                            -->
+<!--# For the full DMTF copyright policy, see http://www.dmtf.org/about/policies/copyright -->
+<!--################################################################################       -->
+<!---->
+<edmx:Edmx xmlns:edmx="http://docs.oasis-open.org/odata/ns/edmx" Version="4.0">
+
+  <edmx:Reference Uri="http://docs.oasis-open.org/odata/odata/v4.0/errata03/csd01/complete/vocabularies/Org.OData.Core.V1.xml">
+    <edmx:Include Namespace="Org.OData.Core.V1" Alias="OData"/>
+  </edmx:Reference>
+  <edmx:Reference Uri="http://docs.oasis-open.org/odata/odata/v4.0/errata03/csd01/complete/vocabularies/Org.OData.Capabilities.V1.xml">
+    <edmx:Include Namespace="Org.OData.Capabilities.V1" Alias="Capabilities"/>
+  </edmx:Reference>
+  <edmx:Reference Uri="http://docs.oasis-open.org/odata/odata/v4.0/errata03/csd01/complete/vocabularies/Org.OData.Measures.V1.xml">
+    <edmx:Include Namespace="Org.OData.Measures.V1" Alias="Measures"/>
+  </edmx:Reference>
+  <edmx:Reference Uri="http://redfish.dmtf.org/schemas/v1/RedfishExtensions_v1.xml">
+    <edmx:Include Namespace="RedfishExtensions.v1_0_0" Alias="Redfish"/>
+    <edmx:Include Namespace="Validation.v1_0_0" Alias="Validation"/>
+  </edmx:Reference>
+  <edmx:Reference Uri="http://redfish.dmtf.org/schemas/v1/Resource_v1.xml">
+    <edmx:Include Namespace="Resource"/>
+    <edmx:Include Namespace="Resource.v1_0_0"/>
+  </edmx:Reference>
+  <edmx:Reference Uri="http://redfish.dmtf.org/schemas/v1/Sensor_v1.xml">
+    <edmx:Include Namespace="Sensor"/>
+  </edmx:Reference>
+  <edmx:Reference Uri="http://redfish.dmtf.org/schemas/v1/Circuit_v1.xml">
+    <edmx:Include Namespace="Circuit"/>
+  </edmx:Reference>
+
+  <edmx:DataServices>
+
+    <Schema xmlns="http://docs.oasis-open.org/odata/ns/edm" Namespace="Outlet">
+      <Annotation Term="Redfish.OwningEntity" String="DMTF"/>
+
+      <EntityType Name="Outlet" BaseType="Resource.v1_0_0.Resource" Abstract="true">
+        <Annotation Term="OData.Description" String="The Outlet schema contains definition for an electrical outlet."/>
+        <Annotation Term="OData.LongDescription" String="This resource shall be used to represent an electrical outlet for a Redfish implementation."/>
+        <Annotation Term="Capabilities.InsertRestrictions">
+          <Record>
+            <PropertyValue Property="Insertable" Bool="false"/>
+          </Record>
+        </Annotation>
+        <Annotation Term="Capabilities.UpdateRestrictions">
+          <Record>
+            <PropertyValue Property="Updatable" Bool="true"/>
+            <Annotation Term="OData.Description" String="Any writable properties can be updated."/>
+          </Record>
+        </Annotation>
+        <Annotation Term="Capabilities.DeleteRestrictions">
+          <Record>
+            <PropertyValue Property="Deletable" Bool="false"/>
+          </Record>
+        </Annotation>
+        <Annotation Term="Redfish.Uris">
+          <Collection>
+            <String>/redfish/v1/PowerEquipment/RackPDUs/{PowerDistributionId}/Outlets/{OutletId}</String>
+            <String>/redfish/v1/PowerEquipment/FloorPDUs/{PowerDistributionId}/Outlets/{OutletId}</String>
+            <String>/redfish/v1/PowerEquipment/TransferSwitches/{PowerDistributionId}/Outlets/{OutletId}</String>
+            <String>/redfish/v1/PowerEquipment/PowerShelves/{PowerDistributionId}/Outlets/{OutletId}</String>
+          </Collection>
+        </Annotation>
+      </EntityType>
+
+      <Action Name="PowerControl" IsBound="true">
+        <Annotation Term="OData.Description" String="This action turns the outlet on or off."/>
+        <Annotation Term="OData.LongDescription" String="This action shall control the power state of the outlet."/>
+        <Parameter Name="Outlet" Type="Outlet.v1_0_0.Actions"/>
+        <Parameter Name="PowerState" Type="Outlet.PowerState">
+          <Annotation Term="OData.Description" String="The desired power state of the outlet."/>
+          <Annotation Term="OData.LongDescription" String="This parameter shall contain the desired power state of the outlet."/>
+        </Parameter>
+      </Action>
+
+      <Action Name="ResetMetrics" IsBound="true">
+        <Annotation Term="OData.Description" String="This action resets metrics related to this outlet."/>
+        <Annotation Term="OData.LongDescription" String="This action shall reset any time intervals or counted values for this outlet."/>
+        <Parameter Name="Outlet" Type="Outlet.v1_0_0.Actions"/>
+      </Action>
+
+      <EnumType Name="PowerState">
+        <Member Name="On">
+          <Annotation Term="OData.Description" String="The outlet is powered on."/>
+        </Member>
+        <Member Name="Off">
+          <Annotation Term="OData.Description" String="The outlet is powered off."/>
+        </Member>
+      </EnumType>
+
+      <EnumType Name="ReceptacleType">
+        <Member Name="NEMA_5_15R">
+          <Annotation Term="OData.Description" String="NEMA 5-15R (120V; 15A)."/>
+          <Annotation Term="OData.LongDescription" String="This value shall represent a receptacle that matches the NEMA specified 5-15 receptacle (120V; 15A).  The current is commonly de-rated to 12A if it is protected by a 15A breaker."/>
+        </Member>
+        <Member Name="NEMA_5_20R">
+          <Annotation Term="OData.Description" String="NEMA 5-20R (120V; 20A)."/>
+          <Annotation Term="OData.LongDescription" String="This value shall represent a receptacle that matches the NEMA specified 5-20 receptacle that exhibits a T-slot (120V; 20A).  The current is commonly de-rated to 16A if it is protected by a 20A breaker."/>
+        </Member>
+        <Member Name="NEMA_L5_20R">
+          <Annotation Term="OData.Description" String="NEMA L5-20R (120V; 20A)."/>
+          <Annotation Term="OData.LongDescription" String="This value shall represent a receptacle that matches the NEMA specified locking L5-20 receptacle (120V; 20A).  The current is commonly de-rated to 16A if it is protected by a 20A breaker."/>
+        </Member>
+        <Member Name="NEMA_L5_30R">
+          <Annotation Term="OData.Description" String="NEMA L5-30R (120V; 30A)."/>
+          <Annotation Term="OData.LongDescription" String="This value shall represent a receptacle that matches the NEMA specified locking L5-30 receptacle (120V; 30A).  The current is commonly de-rated to 24A if it is protected by a 30A breaker."/>
+        </Member>
+        <Member Name="NEMA_L6_20R">
+          <Annotation Term="OData.Description" String="NEMA L6-20R (250V; 20A)."/>
+          <Annotation Term="OData.LongDescription" String="This value shall represent a receptacle that matches the NEMA specified locking L6-20 receptacle (250V; 20A).  The current is commonly de-rated to 16A if it is protected by a 20A breaker."/>
+        </Member>
+        <Member Name="NEMA_L6_30R">
+          <Annotation Term="OData.Description" String="NEMA L6-30R (250V; 30A)."/>
+          <Annotation Term="OData.LongDescription" String="This value shall represent a receptacle that matches the NEMA specified locking L6-30 receptacle (250V; 30A).  The current is commonly de-rated to 24A if it is protected by a 30A breaker."/>
+        </Member>
+        <Member Name="IEC_60320_C13">
+          <Annotation Term="OData.Description" String="IEC C13 (250V; 10A or 15A)."/>
+          <Annotation Term="OData.LongDescription" String="This value shall represent a receptacle that matches the IEC 60320 Sheet F C13 specified receptacle (250V; 10A per IEC, 15A per UL)."/>
+        </Member>
+        <Member Name="IEC_60320_C19">
+          <Annotation Term="OData.Description" String="IEC C19 (250V; 16A or 20A)."/>
+          <Annotation Term="OData.LongDescription" String="This value shall represent a receptacle that matches the IEC 60320 Sheet J C19 specified receptacle (250V; 16A per IEC, 20A per UL)."/>
+        </Member>
+        <Member Name="CEE_7_Type_E">
+          <Annotation Term="OData.Description" String="CEE 7/7 Type E (250V; 16A)."/>
+          <Annotation Term="OData.LongDescription" String="This value shall represent a receptacle that matches the French specified CEE 7/7 Type E receptacle (250V; 16A)."/>
+        </Member>
+        <Member Name="CEE_7_Type_F">
+          <Annotation Term="OData.Description" String="CEE 7/7 Type F (250V; 16A)."/>
+          <Annotation Term="OData.LongDescription" String="This value shall represent a receptacle that matches the Schuko specified CEE 7/7 Type F receptacle (250V; 16A)."/>
+        </Member>
+        <Member Name="SEV_1011_TYPE_12">
+          <Annotation Term="OData.Description" String="SEV 1011 Type 12 (250V; 10A)."/>
+          <Annotation Term="OData.LongDescription" String="This value shall represent a receptacle that matches the SEV 1011 specified Type 12 receptacle (250V; 10A)."/>
+        </Member>
+        <Member Name="SEV_1011_TYPE_23">
+          <Annotation Term="OData.Description" String="SEV 1011 Type 23 (250V; 16A)."/>
+          <Annotation Term="OData.LongDescription" String="This value shall represent a receptacle that matches the SEV 1011 specified Type 23 receptacle (250V; 16A)."/>
+        </Member>
+        <Member Name="BS_1363_Type_G">
+          <Annotation Term="OData.Description" String="BS 1363 Type G (250V; 13A)."/>
+          <Annotation Term="OData.LongDescription" String="This value shall represent a receptacle that matches the British BS 1363 Type G receptacle (250V; 13A)."/>
+        </Member>
+      </EnumType>
+    </Schema>
+
+    <Schema xmlns="http://docs.oasis-open.org/odata/ns/edm" Namespace="Outlet.v1_0_0">
+      <Annotation Term="Redfish.OwningEntity" String="DMTF"/>
+      <Annotation Term="Redfish.Release" String="2019.4"/>
+
+      <EntityType Name="Outlet" BaseType="Outlet.Outlet">
+        <Property Name="Status" Type="Resource.Status" Nullable="false">
+          <Annotation Term="OData.Description" String="The status and health of the resource and its subordinate or dependent resources."/>
+          <Annotation Term="OData.LongDescription" String="This property shall contain any status or health properties of the resource."/>
+        </Property>
+        <Property Name="ElectricalContext" Type="Sensor.ElectricalContext">
+          <Annotation Term="OData.Permissions" EnumMember="OData.Permission/Read"/>
+          <Annotation Term="OData.Description" String="The combination of current-carrying conductors."/>
+          <Annotation Term="OData.LongDescription" String="This property shall contain the combination of current-carrying conductors that distribute power."/>
+        </Property>
+        <Property Name="PhaseWiringType" Type="Circuit.PhaseWiringType">
+          <Annotation Term="OData.Permissions" EnumMember="OData.Permission/Read"/>
+          <Annotation Term="OData.Description" String="The number of ungrounded current-carrying conductors (phases) and the total number of conductors (wires)."/>
+          <Annotation Term="OData.LongDescription" String="This property shall contain the number of ungrounded current-carrying conductors (phases) and the total number of conductors (wires)."/>
+        </Property>
+        <Property Name="VoltageType" Type="Outlet.v1_0_0.VoltageType">
+          <Annotation Term="OData.Permissions" EnumMember="OData.Permission/Read"/>
+          <Annotation Term="OData.Description" String="The type of voltage applied to the outlet."/>
+          <Annotation Term="OData.LongDescription" String="This property shall contain the type of voltage applied to the outlet."/>
+        </Property>
+        <Property Name="OutletType" Type="Outlet.ReceptacleType">
+          <Annotation Term="OData.Permissions" EnumMember="OData.Permission/Read"/>
+          <Annotation Term="OData.Description" String="The type of receptacle according to NEMA, IEC, or regional standards."/>
+          <Annotation Term="OData.LongDescription" String="This property shall contain the type of physical receptacle used for this outlet, as defined by IEC, NEMA, or regional standard."/>
+        </Property>
+        <Property Name="NominalVoltage" Type="Circuit.NominalVoltageType">
+          <Annotation Term="OData.Permissions" EnumMember="OData.Permission/Read"/>
+          <Annotation Term="OData.Description" String="The nominal voltage for this outlet."/>
+          <Annotation Term="OData.LongDescription" String="This property shall contain the nominal voltage for this outlet, in Volts."/>
+        </Property>
+        <Property Name="RatedCurrentAmps" Type="Edm.Decimal">
+          <Annotation Term="OData.Permissions" EnumMember="OData.Permission/Read"/>
+          <Annotation Term="OData.Description" String="The rated maximum current allowed for this outlet."/>
+          <Annotation Term="OData.LongDescription" String="This property shall contain the rated maximum current for this outlet, in Amps, after any required de-rating, due to safety agency or other regulatory requirements, has been applied."/>
+          <Annotation Term="Measures.Unit" String="A"/>
+          <Annotation Term="Validation.Minimum" Int="0"/>
+        </Property>
+        <Property Name="IndicatorLED" Type="Resource.IndicatorLED">
+          <Annotation Term="OData.Permissions" EnumMember="OData.Permission/ReadWrite"/>
+          <Annotation Term="OData.Description" String="The state of the indicator LED, which identifies the outlet."/>
+          <Annotation Term="OData.LongDescription" String="This property shall contain the indicator light state for the indicator light associated with this outlet."/>
+          <Annotation Term="Redfish.Revisions">
+            <Collection>
+              <Record>
+                <PropertyValue Property="Kind" EnumMember="Redfish.RevisionKind/Deprecated"/>
+                <PropertyValue Property="Version" String="v1_1_0"/>
+                <PropertyValue Property="Description" String="This property has been deprecated in favor of the LocationIndicatorActive property."/>
+              </Record>
+            </Collection>
+          </Annotation>
+        </Property>
+        <Property Name="PowerOnDelaySeconds" Type="Edm.Decimal">
+          <Annotation Term="OData.Permissions" EnumMember="OData.Permission/ReadWrite"/>
+          <Annotation Term="OData.Description" String="The number of seconds to delay power up after a power cycle or a PowerControl action.  Zero seconds indicates no delay to power up."/>
+          <Annotation Term="OData.LongDescription" String="This property shall contain the number of seconds to delay power up after a power cycle or a PowerControl action.  The value `0` shall indicate no delay to power up."/>
+        </Property>
+        <Property Name="PowerOffDelaySeconds" Type="Edm.Decimal">
+          <Annotation Term="OData.Permissions" EnumMember="OData.Permission/ReadWrite"/>
+          <Annotation Term="OData.Description" String="The number of seconds to delay power off after a PowerControl action.  Zero seconds indicates no delay to power off."/>
+          <Annotation Term="OData.LongDescription" String="This property shall contain the number of seconds to delay power off after a PowerControl action.  The value `0` shall indicate no delay to power off."/>
+        </Property>
+        <Property Name="PowerCycleDelaySeconds" Type="Edm.Decimal">
+          <Annotation Term="OData.Permissions" EnumMember="OData.Permission/ReadWrite"/>
+          <Annotation Term="OData.Description" String="The number of seconds to delay power on after a PowerControl action to cycle power.  Zero seconds indicates no delay."/>
+          <Annotation Term="OData.LongDescription" String="This property shall contain the number of seconds to delay power on after a PowerControl action to cycle power.  The value `0` shall indicate no delay to power on."/>
+        </Property>
+        <Property Name="PowerRestoreDelaySeconds" Type="Edm.Decimal">
+          <Annotation Term="OData.Permissions" EnumMember="OData.Permission/ReadWrite"/>
+          <Annotation Term="OData.Description" String="The number of seconds to delay power on after power has been restored.  Zero seconds indicates no delay."/>
+          <Annotation Term="OData.LongDescription" String="This property shall contain the number of seconds to delay power on after a power fault.  The value `0` shall indicate no delay to power on."/>
+        </Property>
+        <Property Name="PowerRestorePolicy" Type="Circuit.PowerRestorePolicyTypes" Nullable="false">
+          <Annotation Term="OData.Permissions" EnumMember="OData.Permission/ReadWrite"/>
+          <Annotation Term="OData.Description" String="The desired power state of the outlet when power is restored after a power loss."/>
+          <Annotation Term="OData.LongDescription" String="This property shall contain the desired PowerState of the outlet when power is applied.  The value `LastState` shall return the outlet to the PowerState it was in when power was lost."/>
+        </Property>
+        <Property Name="PowerState" Type="Resource.PowerState">
+          <Annotation Term="OData.Permissions" EnumMember="OData.Permission/Read"/>
+          <Annotation Term="OData.Description" String="The power state of the outlet."/>
+          <Annotation Term="OData.LongDescription" String="This property shall contain the power state of the outlet."/>
+        </Property>
+        <Property Name="PowerEnabled" Type="Edm.Boolean">
+          <Annotation Term="OData.Permissions" EnumMember="OData.Permission/Read"/>
+          <Annotation Term="OData.Description" String="Indicates if the outlet can be powered."/>
+          <Annotation Term="OData.LongDescription" String="This property shall indicate the power enable state of the outlet.  The value `true` shall indicate that the outlet can be powered on, and `false` shall indicate that the outlet cannot be powered."/>
+        </Property>
+        <NavigationProperty Name="Voltage" Type="Sensor.Sensor">
+          <Annotation Term="Redfish.ExcerptCopy" String="Voltage"/>
+          <Annotation Term="OData.Description" String="The voltage reading for this single phase outlet."/>
+          <Annotation Term="OData.LongDescription" String="This property shall contain the voltage, measured in Volts, for this single phase outlet.  This property shall not appear in resource instances representing poly-phase outlets."/>
+        </NavigationProperty>
+        <NavigationProperty Name="CurrentAmps" Type="Sensor.Sensor">
+          <Annotation Term="Redfish.ExcerptCopy" String="Current"/>
+          <Annotation Term="OData.Description" String="The current reading for this single phase outlet."/>
+          <Annotation Term="OData.LongDescription" String="This property shall contain the current, measured in Amperes, for this single phase outlet.  This property shall not appear in resource instances representing poly-phase outlets."/>
+        </NavigationProperty>
+        <NavigationProperty Name="PowerWatts" Type="Sensor.Sensor">
+          <Annotation Term="Redfish.ExcerptCopy" String="Power"/>
+          <Annotation Term="OData.Description" String="The power reading for this outlet."/>
+          <Annotation Term="OData.LongDescription" String="This property shall contain the total power, measured in Watts, for this outlet, that represents the `Total` ElectricalContext sensor when multiple power sensors exist for this outlet."/>
+        </NavigationProperty>
+        <NavigationProperty Name="EnergykWh" Type="Sensor.Sensor">
+          <Annotation Term="Redfish.ExcerptCopy" String="EnergykWh"/>
+          <Annotation Term="OData.Description" String="The energy reading for this outlet."/>
+          <Annotation Term="OData.LongDescription" String="This property shall contain the total energy, measured in kilowatt-hours (kW.h), for this outlet, that represents the `Total` ElectricalContext sensor when multiple energy sensors exist for this outlet."/>
+        </NavigationProperty>
+        <NavigationProperty Name="FrequencyHz" Type="Sensor.Sensor">
+          <Annotation Term="Redfish.ExcerptCopy"/>
+          <Annotation Term="OData.Description" String="The frequency reading for this outlet."/>
+          <Annotation Term="OData.LongDescription" String="This property shall contain the frequency sensor for this outlet."/>
+        </NavigationProperty>
+
+        <Property Name="PolyPhaseVoltage" Type="Outlet.v1_0_0.VoltageSensors">
+          <Annotation Term="OData.Description" String="The voltage readings for this outlet."/>
+          <Annotation Term="OData.LongDescription" String="This property shall contain the voltage sensor(s) for this outlet.  For single phase outlets this property shall contain a duplicate copy of the voltage sensor referenced in the VoltageSensor property, if present.  For poly-phase outlets this property should contain multiple voltage sensor readings used to fully describe the outlet."/>
+        </Property>
+        <Property Name="PolyPhaseCurrentAmps" Type="Outlet.v1_0_0.CurrentSensors">
+          <Annotation Term="OData.Description" String="The current readings for this outlet."/>
+          <Annotation Term="OData.LongDescription" String="This property shall contain the current sensor(s) for this outlet.  For single phase outlets this property shall contain a duplicate copy of the current sensor referenced in the CurrentSensor property, if present.  For poly-phase outlets this property should contain multiple current sensor readings used to fully describe the outlet."/>
+        </Property>
+
+        <Property Name="Links" Type="Outlet.v1_0_0.Links" Nullable="false">
+          <Annotation Term="OData.Description" String="The links to other resources that are related to this resource."/>
+          <Annotation Term="OData.LongDescription" String="This property shall contain links to resources that are related to but are not contained by, or subordinate to, this resource."/>
+        </Property>
+        <Property Name="Actions" Type="Outlet.v1_0_0.Actions" Nullable="false">
+          <Annotation Term="OData.Description" String="The available actions for this resource."/>
+          <Annotation Term="OData.LongDescription" String="This property shall contain the available actions for this resource."/>
+        </Property>
+      </EntityType>
+
+      <ComplexType Name="Links" BaseType="Resource.Links">
+        <Annotation Term="OData.Description" String="The links to other resources that are related to this resource."/>
+        <Annotation Term="OData.LongDescription" String="This Redfish Specification-described type shall contain links to resources that are related to but are not contained by, or subordinate to, this resource."/>
+        <NavigationProperty Name="BranchCircuit" Type="Circuit.Circuit">
+          <Annotation Term="OData.Permissions" EnumMember="OData.Permission/Read"/>
+          <Annotation Term="OData.Description" String="A reference to the branch circuit related to this outlet."/>
+          <Annotation Term="OData.LongDescription" String="This property shall contain a link to a resource of type Circuit that represent the branch circuit associated with this outlet."/>
+          <Annotation Term="OData.AutoExpandReferences"/>
+        </NavigationProperty>
+      </ComplexType>
+
+      <ComplexType Name="Actions">
+        <Annotation Term="OData.AdditionalProperties" Bool="false"/>
+        <Annotation Term="OData.Description" String="The available actions for this resource."/>
+        <Annotation Term="OData.LongDescription" String="This type shall contain the available actions for this resource."/>
+        <Property Name="Oem" Type="Outlet.v1_0_0.OemActions" Nullable="false">
+          <Annotation Term="OData.Description" String="The available OEM-specific actions for this resource."/>
+          <Annotation Term="OData.LongDescription" String="This property shall contain the available OEM-specific actions for this resource."/>
+        </Property>
+      </ComplexType>
+
+      <ComplexType Name="OemActions">
+        <Annotation Term="OData.AdditionalProperties" Bool="true"/>
+        <Annotation Term="OData.Description" String="The available OEM-specific actions for this resource."/>
+        <Annotation Term="OData.LongDescription" String="This type shall contain the available OEM-specific actions for this resource."/>
+      </ComplexType>
+
+      <ComplexType Name="VoltageSensors">
+        <Annotation Term="OData.AdditionalProperties" Bool="false"/>
+        <Annotation Term="OData.Description" String="The voltage readings for this outlet."/>
+        <Annotation Term="OData.LongDescription" String="This type shall contain properties that describe voltage sensor readings for an outlet."/>
+        <NavigationProperty Name="Line1ToLine2" Type="Sensor.Sensor">
+          <Annotation Term="Redfish.ExcerptCopy" String="Voltage"/>
+          <Annotation Term="OData.Description" String="The Line 1 to Line 2 voltage reading for this outlet."/>
+          <Annotation Term="OData.LongDescription" String="This property shall contain a Sensor excerpt of type Voltage that measures voltage between L1 and L2.  This property shall not be present if the outlet does not include an L1-L2 measurement."/>
+        </NavigationProperty>
+        <NavigationProperty Name="Line2ToLine3" Type="Sensor.Sensor">
+          <Annotation Term="Redfish.ExcerptCopy" String="Voltage"/>
+          <Annotation Term="OData.Description" String="The Line 2 to Line 3 voltage reading for this outlet."/>
+          <Annotation Term="OData.LongDescription" String="This property shall contain a Sensor excerpt of type Voltage that measures voltage between L2 and L3.  This property shall not be present if the outlet does not include an L2-L3 measurement."/>
+        </NavigationProperty>
+        <NavigationProperty Name="Line3ToLine1" Type="Sensor.Sensor">
+          <Annotation Term="Redfish.ExcerptCopy" String="Voltage"/>
+          <Annotation Term="OData.Description" String="The Line 3 to Line 1 voltage reading for this outlet."/>
+          <Annotation Term="OData.LongDescription" String="This property shall contain a Sensor excerpt of type Voltage that measures voltage between L3 and L1.  This property shall not be present if the outlet does not include an L3-L1 measurement."/>
+        </NavigationProperty>
+        <NavigationProperty Name="Line1ToNeutral" Type="Sensor.Sensor">
+          <Annotation Term="Redfish.ExcerptCopy" String="Voltage"/>
+          <Annotation Term="OData.Description" String="The Line 1 to Neutral voltage reading for this outlet."/>
+          <Annotation Term="OData.LongDescription" String="This property shall contain a Sensor excerpt of type Voltage that measures voltage between L1 and Neutral.  This property shall not be present if the outlet does not include an L1-Neutral measurement."/>
+        </NavigationProperty>
+        <NavigationProperty Name="Line2ToNeutral" Type="Sensor.Sensor">
+          <Annotation Term="Redfish.ExcerptCopy" String="Voltage"/>
+          <Annotation Term="OData.Description" String="The Line 2 to Neutral voltage reading for this outlet."/>
+          <Annotation Term="OData.LongDescription" String="This property shall contain a Sensor excerpt of type Voltage that measures voltage between L2 and Neutral.  This property shall not be present if the outlet does not include an L2-Neutral measurement."/>
+        </NavigationProperty>
+        <NavigationProperty Name="Line3ToNeutral" Type="Sensor.Sensor">
+          <Annotation Term="Redfish.ExcerptCopy" String="Voltage"/>
+          <Annotation Term="OData.Description" String="The Line 3 to Neutral voltage reading for this outlet."/>
+          <Annotation Term="OData.LongDescription" String="This property shall contain a Sensor excerpt of type Voltage that measures voltage between L3 and Neutral.  This property shall not be present if the outlet does not include an L3-Neutral measurement."/>
+        </NavigationProperty>
+      </ComplexType>
+
+      <ComplexType Name="CurrentSensors">
+        <Annotation Term="OData.AdditionalProperties" Bool="false"/>
+        <Annotation Term="OData.Description" String="The current sensors for this outlet."/>
+        <Annotation Term="OData.LongDescription" String="This type shall contain properties that describe current sensor readings for an outlet."/>
+        <NavigationProperty Name="Line1" Type="Sensor.Sensor">
+          <Annotation Term="Redfish.ExcerptCopy" String="Current"/>
+          <Annotation Term="OData.Description" String="Line 1 current sensor."/>
+          <Annotation Term="OData.LongDescription" String="This property shall contain a Sensor excerpt of type Current that measures current for L1.  This property shall not be present if the outlet does not include an L1 measurement."/>
+        </NavigationProperty>
+        <NavigationProperty Name="Line2" Type="Sensor.Sensor">
+          <Annotation Term="Redfish.ExcerptCopy" String="Current"/>
+          <Annotation Term="OData.Description" String="Line 2 current sensor."/>
+          <Annotation Term="OData.LongDescription" String="This property shall contain a Sensor excerpt of type Current that measures current for L2.  This property shall not be present if the outlet does not include an L2 measurement."/>
+        </NavigationProperty>
+        <NavigationProperty Name="Line3" Type="Sensor.Sensor">
+          <Annotation Term="Redfish.ExcerptCopy" String="Current"/>
+          <Annotation Term="OData.Description" String="Line 3 current sensor."/>
+          <Annotation Term="OData.LongDescription" String="This property shall contain a Sensor excerpt of type Current that measures current for L3.  This property shall not be present if the outlet does not include an L3 measurement."/>
+        </NavigationProperty>
+        <NavigationProperty Name="Neutral" Type="Sensor.Sensor">
+          <Annotation Term="Redfish.ExcerptCopy" String="Current"/>
+          <Annotation Term="OData.Description" String="Neutral line current sensor."/>
+          <Annotation Term="OData.LongDescription" String="This property shall contain a Sensor excerpt of type Current that measures current for the Neutral line.  This property shall not be present if the outlet does not include a Neutral measurement."/>
+        </NavigationProperty>
+      </ComplexType>
+
+      <EnumType Name="VoltageType">
+        <Member Name="AC">
+          <Annotation Term="OData.Description" String="Alternating Current (AC) outlet."/>
+        </Member>
+        <Member Name="DC">
+          <Annotation Term="OData.Description" String="Direct Current (DC) outlet."/>
+        </Member>
+      </EnumType>
+    </Schema>
+
+    <Schema xmlns="http://docs.oasis-open.org/odata/ns/edm" Namespace="Outlet.v1_0_1">
+      <Annotation Term="Redfish.OwningEntity" String="DMTF"/>
+      <Annotation Term="OData.Description" String="This version was created to correct various typographical errors."/>
+      <EntityType Name="Outlet" BaseType="Outlet.v1_0_0.Outlet"/>
+    </Schema>
+
+    <Schema xmlns="http://docs.oasis-open.org/odata/ns/edm" Namespace="Outlet.v1_0_2">
+      <Annotation Term="Redfish.OwningEntity" String="DMTF"/>
+      <Annotation Term="OData.Description" String="This version was created to correct various typographical errors."/>
+      <EntityType Name="Outlet" BaseType="Outlet.v1_0_1.Outlet"/>
+    </Schema>
+
+    <Schema xmlns="http://docs.oasis-open.org/odata/ns/edm" Namespace="Outlet.v1_1_0">
+      <Annotation Term="Redfish.OwningEntity" String="DMTF"/>
+      <Annotation Term="Redfish.Release" String="2020.3"/>
+      <Annotation Term="OData.Description" String="This version was created to add LocationIndicatorActive and to deprecate IndicatorLED properties."/>
+
+      <EntityType Name="Outlet" BaseType="Outlet.v1_0_1.Outlet">
+        <Property Name="LocationIndicatorActive" Type="Edm.Boolean">
+          <Annotation Term="OData.Permissions" EnumMember="OData.Permission/ReadWrite"/>
+          <Annotation Term="OData.Description" String="An indicator allowing an operator to physically locate this resource."/>
+          <Annotation Term="OData.LongDescription" String="This property shall contain the state of the indicator used to physically identify or locate this resource.  A write to this property shall update the value of IndicatorLED in this resource, if supported, to reflect the implementation of the locating function."/>
+        </Property>
+      </EntityType>
+
+    </Schema>
+
+    <Schema xmlns="http://docs.oasis-open.org/odata/ns/edm" Namespace="Outlet.v1_1_1">
+      <Annotation Term="Redfish.OwningEntity" String="DMTF"/>
+      <Annotation Term="OData.Description" String="This version was created to correct various typographical errors."/>
+      <EntityType Name="Outlet" BaseType="Outlet.v1_1_0.Outlet"/>
+    </Schema>
+
+    <Schema xmlns="http://docs.oasis-open.org/odata/ns/edm" Namespace="Outlet.v1_2_0">
+      <Annotation Term="Redfish.OwningEntity" String="DMTF"/>
+      <Annotation Term="Redfish.Release" String="2021.2"/>
+
+      <EntityType Name="Outlet" BaseType="Outlet.v1_1_1.Outlet">
+        <NavigationProperty Name="PowerLoadPercent" Type="Sensor.Sensor">
+          <Annotation Term="Redfish.ExcerptCopy"/>
+          <Annotation Term="OData.Description" String="The power load (%) for this outlet."/>
+          <Annotation Term="OData.LongDescription" String="This property shall contain the power load, measured in percent, for this outlet, that represents the `Total` ElectricalContext for this outlet."/>
+        </NavigationProperty>
+      </EntityType>
+    </Schema>
+
+  </edmx:DataServices>
+</edmx:Edmx>

--- a/static/redfish/v1/schema/PhysicalContext_v1.xml
+++ b/static/redfish/v1/schema/PhysicalContext_v1.xml
@@ -1,0 +1,398 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!---->
+<!--################################################################################       -->
+<!--# Redfish Schema:  PhysicalContext                                                     -->
+<!--#                                                                                      -->
+<!--# For a detailed change log, see the README file contained in the DSP8010 bundle,      -->
+<!--# available at http://www.dmtf.org/standards/redfish                                   -->
+<!--# Copyright 2014-2021 DMTF.                                                            -->
+<!--# For the full DMTF copyright policy, see http://www.dmtf.org/about/policies/copyright -->
+<!--################################################################################       -->
+<!---->
+<edmx:Edmx xmlns:edmx="http://docs.oasis-open.org/odata/ns/edmx" Version="4.0">
+
+  <edmx:Reference Uri="http://docs.oasis-open.org/odata/odata/v4.0/errata03/csd01/complete/vocabularies/Org.OData.Core.V1.xml">
+    <edmx:Include Namespace="Org.OData.Core.V1" Alias="OData"/>
+  </edmx:Reference>
+  <edmx:Reference Uri="http://redfish.dmtf.org/schemas/v1/RedfishExtensions_v1.xml">
+    <edmx:Include Namespace="RedfishExtensions.v1_0_0" Alias="Redfish"/>
+  </edmx:Reference>
+
+  <edmx:DataServices>
+
+    <Schema xmlns="http://docs.oasis-open.org/odata/ns/edm" Namespace="PhysicalContext">
+      <Annotation Term="Redfish.OwningEntity" String="DMTF"/>
+      <Annotation Term="Redfish.Release" String="1.0"/>
+
+      <EnumType Name="PhysicalContext">
+        <Member Name="Room">
+          <Annotation Term="OData.Description" String="The room."/>
+        </Member>
+        <Member Name="Intake">
+          <Annotation Term="OData.Description" String="The air intake point or points or region of the chassis."/>
+        </Member>
+        <Member Name="Exhaust">
+          <Annotation Term="OData.Description" String="The air exhaust point or points or region of the chassis."/>
+        </Member>
+        <Member Name="LiquidInlet">
+          <Annotation Term="OData.Description" String="The liquid inlet point of the chassis."/>
+          <Annotation Term="Redfish.Revisions">
+            <Collection>
+              <Record>
+                <PropertyValue Property="Kind" EnumMember="Redfish.RevisionKind/Added"/>
+                <PropertyValue Property="Version" String="2017.3"/>
+              </Record>
+            </Collection>
+          </Annotation>
+        </Member>
+        <Member Name="LiquidOutlet">
+          <Annotation Term="OData.Description" String="The liquid outlet point of the chassis."/>
+          <Annotation Term="Redfish.Revisions">
+            <Collection>
+              <Record>
+                <PropertyValue Property="Kind" EnumMember="Redfish.RevisionKind/Added"/>
+                <PropertyValue Property="Version" String="2017.3"/>
+              </Record>
+            </Collection>
+          </Annotation>
+        </Member>
+        <Member Name="Front">
+          <Annotation Term="OData.Description" String="The front of the chassis."/>
+        </Member>
+        <Member Name="Back">
+          <Annotation Term="OData.Description" String="The back of the chassis."/>
+        </Member>
+        <Member Name="Upper">
+          <Annotation Term="OData.Description" String="The upper portion of the chassis."/>
+        </Member>
+        <Member Name="Lower">
+          <Annotation Term="OData.Description" String="The lower portion of the chassis."/>
+        </Member>
+        <Member Name="CPU">
+          <Annotation Term="OData.Description" String="A processor (CPU)."/>
+        </Member>
+        <Member Name="CPUSubsystem">
+          <Annotation Term="OData.Description" String="The entire processor (CPU) subsystem."/>
+          <Annotation Term="Redfish.Revisions">
+            <Collection>
+              <Record>
+                <PropertyValue Property="Kind" EnumMember="Redfish.RevisionKind/Added"/>
+                <PropertyValue Property="Version" String="2018.3"/>
+              </Record>
+            </Collection>
+          </Annotation>
+        </Member>
+        <Member Name="GPU">
+          <Annotation Term="OData.Description" String="A graphics processor (GPU)."/>
+        </Member>
+        <Member Name="GPUSubsystem">
+          <Annotation Term="OData.Description" String="The entire graphics processor (GPU) subsystem."/>
+          <Annotation Term="Redfish.Revisions">
+            <Collection>
+              <Record>
+                <PropertyValue Property="Kind" EnumMember="Redfish.RevisionKind/Added"/>
+                <PropertyValue Property="Version" String="2018.3"/>
+              </Record>
+            </Collection>
+          </Annotation>
+        </Member>
+        <Member Name="FPGA">
+          <Annotation Term="OData.Description" String="An FPGA."/>
+          <Annotation Term="Redfish.Revisions">
+            <Collection>
+              <Record>
+                <PropertyValue Property="Kind" EnumMember="Redfish.RevisionKind/Added"/>
+                <PropertyValue Property="Version" String="2018.3"/>
+              </Record>
+            </Collection>
+          </Annotation>
+        </Member>
+        <Member Name="Accelerator">
+          <Annotation Term="OData.Description" String="An accelerator."/>
+          <Annotation Term="Redfish.Revisions">
+            <Collection>
+              <Record>
+                <PropertyValue Property="Kind" EnumMember="Redfish.RevisionKind/Added"/>
+                <PropertyValue Property="Version" String="2018.3"/>
+              </Record>
+            </Collection>
+          </Annotation>
+        </Member>
+        <Member Name="ASIC">
+          <Annotation Term="OData.Description" String="An ASIC device, such as a networking chip or chipset component."/>
+          <Annotation Term="Redfish.Revisions">
+            <Collection>
+              <Record>
+                <PropertyValue Property="Kind" EnumMember="Redfish.RevisionKind/Added"/>
+                <PropertyValue Property="Version" String="2017.3"/>
+              </Record>
+            </Collection>
+          </Annotation>
+        </Member>
+        <Member Name="Backplane">
+          <Annotation Term="OData.Description" String="A backplane within the chassis."/>
+        </Member>
+        <Member Name="SystemBoard">
+          <Annotation Term="OData.Description" String="The system board (PCB)."/>
+        </Member>
+        <Member Name="PowerSupply">
+          <Annotation Term="OData.Description" String="A power supply."/>
+        </Member>
+        <Member Name="PowerSubsystem">
+          <Annotation Term="OData.Description" String="The entire power subsystem."/>
+          <Annotation Term="Redfish.Revisions">
+            <Collection>
+              <Record>
+                <PropertyValue Property="Kind" EnumMember="Redfish.RevisionKind/Added"/>
+                <PropertyValue Property="Version" String="2019.1"/>
+              </Record>
+            </Collection>
+          </Annotation>
+        </Member>
+        <Member Name="VoltageRegulator">
+          <Annotation Term="OData.Description" String="A voltage regulator device."/>
+        </Member>
+        <Member Name="Rectifier">
+          <Annotation Term="OData.Description" String="A rectifier device."/>
+          <Annotation Term="Redfish.Revisions">
+            <Collection>
+              <Record>
+                <PropertyValue Property="Kind" EnumMember="Redfish.RevisionKind/Added"/>
+                <PropertyValue Property="Version" String="2019.1"/>
+              </Record>
+            </Collection>
+          </Annotation>
+        </Member>
+        <Member Name="StorageDevice">
+          <Annotation Term="OData.Description" String="A storage device."/>
+        </Member>
+        <Member Name="NetworkingDevice">
+          <Annotation Term="OData.Description" String="A networking device."/>
+        </Member>
+        <Member Name="ComputeBay">
+          <Annotation Term="OData.Description" String="Within a compute bay."/>
+        </Member>
+        <Member Name="StorageBay">
+          <Annotation Term="OData.Description" String="Within a storage bay."/>
+        </Member>
+        <Member Name="NetworkBay">
+          <Annotation Term="OData.Description" String="Within a networking bay."/>
+        </Member>
+        <Member Name="ExpansionBay">
+          <Annotation Term="OData.Description" String="Within an expansion bay."/>
+        </Member>
+        <Member Name="PowerSupplyBay">
+          <Annotation Term="OData.Description" String="Within a power supply bay."/>
+        </Member>
+        <Member Name="Memory">
+          <Annotation Term="OData.Description" String="A memory device."/>
+          <Annotation Term="Redfish.Revisions">
+            <Collection>
+              <Record>
+                <PropertyValue Property="Kind" EnumMember="Redfish.RevisionKind/Added"/>
+                <PropertyValue Property="Version" String="2017.1"/>
+              </Record>
+            </Collection>
+          </Annotation>
+        </Member>
+        <Member Name="MemorySubsystem">
+          <Annotation Term="OData.Description" String="The entire memory subsystem."/>
+          <Annotation Term="Redfish.Revisions">
+            <Collection>
+              <Record>
+                <PropertyValue Property="Kind" EnumMember="Redfish.RevisionKind/Added"/>
+                <PropertyValue Property="Version" String="2018.3"/>
+              </Record>
+            </Collection>
+          </Annotation>
+        </Member>
+        <Member Name="Chassis">
+          <Annotation Term="OData.Description" String="The entire chassis."/>
+          <Annotation Term="Redfish.Revisions">
+            <Collection>
+              <Record>
+                <PropertyValue Property="Kind" EnumMember="Redfish.RevisionKind/Added"/>
+                <PropertyValue Property="Version" String="2017.2"/>
+              </Record>
+            </Collection>
+          </Annotation>
+        </Member>
+        <Member Name="Fan">
+          <Annotation Term="OData.Description" String="A fan."/>
+          <Annotation Term="Redfish.Revisions">
+            <Collection>
+              <Record>
+                <PropertyValue Property="Kind" EnumMember="Redfish.RevisionKind/Added"/>
+                <PropertyValue Property="Version" String="2017.2"/>
+              </Record>
+            </Collection>
+          </Annotation>
+        </Member>
+        <Member Name="CoolingSubsystem">
+          <Annotation Term="OData.Description" String="The entire cooling, or air and liquid, subsystem."/>
+          <Annotation Term="Redfish.Revisions">
+            <Collection>
+              <Record>
+                <PropertyValue Property="Kind" EnumMember="Redfish.RevisionKind/Added"/>
+                <PropertyValue Property="Version" String="2018.3"/>
+              </Record>
+            </Collection>
+          </Annotation>
+        </Member>
+        <Member Name="Motor">
+          <Annotation Term="OData.Description" String="A motor."/>
+          <Annotation Term="Redfish.Revisions">
+            <Collection>
+              <Record>
+                <PropertyValue Property="Kind" EnumMember="Redfish.RevisionKind/Added"/>
+                <PropertyValue Property="Version" String="2018.3"/>
+              </Record>
+            </Collection>
+          </Annotation>
+        </Member>
+        <Member Name="Transformer">
+          <Annotation Term="OData.Description" String="A transformer."/>
+          <Annotation Term="Redfish.Revisions">
+            <Collection>
+              <Record>
+                <PropertyValue Property="Kind" EnumMember="Redfish.RevisionKind/Added"/>
+                <PropertyValue Property="Version" String="2018.3"/>
+              </Record>
+            </Collection>
+          </Annotation>
+        </Member>
+        <Member Name="ACUtilityInput">
+          <Annotation Term="OData.Description" String="An AC utility input."/>
+          <Annotation Term="Redfish.Revisions">
+            <Collection>
+              <Record>
+                <PropertyValue Property="Kind" EnumMember="Redfish.RevisionKind/Added"/>
+                <PropertyValue Property="Version" String="2018.3"/>
+              </Record>
+            </Collection>
+          </Annotation>
+        </Member>
+        <Member Name="ACStaticBypassInput">
+          <Annotation Term="OData.Description" String="An AC static bypass input."/>
+          <Annotation Term="Redfish.Revisions">
+            <Collection>
+              <Record>
+                <PropertyValue Property="Kind" EnumMember="Redfish.RevisionKind/Added"/>
+                <PropertyValue Property="Version" String="2018.3"/>
+              </Record>
+            </Collection>
+          </Annotation>
+        </Member>
+        <Member Name="ACMaintenanceBypassInput">
+          <Annotation Term="OData.Description" String="An AC maintenance bypass input."/>
+          <Annotation Term="Redfish.Revisions">
+            <Collection>
+              <Record>
+                <PropertyValue Property="Kind" EnumMember="Redfish.RevisionKind/Added"/>
+                <PropertyValue Property="Version" String="2018.3"/>
+              </Record>
+            </Collection>
+          </Annotation>
+        </Member>
+        <Member Name="DCBus">
+          <Annotation Term="OData.Description" String="A DC bus."/>
+          <Annotation Term="Redfish.Revisions">
+            <Collection>
+              <Record>
+                <PropertyValue Property="Kind" EnumMember="Redfish.RevisionKind/Added"/>
+                <PropertyValue Property="Version" String="2018.3"/>
+              </Record>
+            </Collection>
+          </Annotation>
+        </Member>
+        <Member Name="ACOutput">
+          <Annotation Term="OData.Description" String="An AC output."/>
+          <Annotation Term="Redfish.Revisions">
+            <Collection>
+              <Record>
+                <PropertyValue Property="Kind" EnumMember="Redfish.RevisionKind/Added"/>
+                <PropertyValue Property="Version" String="2018.3"/>
+              </Record>
+            </Collection>
+          </Annotation>
+        </Member>
+        <Member Name="ACInput">
+          <Annotation Term="OData.Description" String="An AC input."/>
+          <Annotation Term="Redfish.Revisions">
+            <Collection>
+              <Record>
+                <PropertyValue Property="Kind" EnumMember="Redfish.RevisionKind/Added"/>
+                <PropertyValue Property="Version" String="2018.3"/>
+              </Record>
+            </Collection>
+          </Annotation>
+        </Member>
+        <Member Name="TrustedModule">
+          <Annotation Term="OData.Description" String="A trusted module."/>
+          <Annotation Term="Redfish.Revisions">
+            <Collection>
+              <Record>
+                <PropertyValue Property="Kind" EnumMember="Redfish.RevisionKind/Added"/>
+                <PropertyValue Property="Version" String="2020.4"/>
+              </Record>
+            </Collection>
+          </Annotation>
+        </Member>
+        <Member Name="Board">
+          <Annotation Term="OData.Description" String="A circuit board."/>
+          <Annotation Term="OData.LongDescription" String="This value shall indicate a circuit board that is not the primary or system board within a context that cannot be described by other defined values."/>
+          <Annotation Term="Redfish.Revisions">
+            <Collection>
+              <Record>
+                <PropertyValue Property="Kind" EnumMember="Redfish.RevisionKind/Added"/>
+                <PropertyValue Property="Version" String="2021.1"/>
+              </Record>
+            </Collection>
+          </Annotation>
+        </Member>
+        <Member Name="Transceiver">
+          <Annotation Term="OData.Description" String="A transceiver."/>
+          <Annotation Term="OData.LongDescription" String="This value shall indicate a transceiver attached to a device."/>
+          <Annotation Term="Redfish.Revisions">
+            <Collection>
+              <Record>
+                <PropertyValue Property="Kind" EnumMember="Redfish.RevisionKind/Added"/>
+                <PropertyValue Property="Version" String="2021.1"/>
+              </Record>
+            </Collection>
+          </Annotation>
+        </Member>
+        <Member Name="Battery">
+          <Annotation Term="OData.Description" String="A battery."/>
+          <Annotation Term="Redfish.Revisions">
+            <Collection>
+              <Record>
+                <PropertyValue Property="Kind" EnumMember="Redfish.RevisionKind/Added"/>
+                <PropertyValue Property="Version" String="2021.2"/>
+              </Record>
+            </Collection>
+          </Annotation>
+        </Member>
+      </EnumType>
+
+      <EnumType Name="PhysicalSubContext">
+        <Annotation Term="Redfish.Revisions">
+          <Collection>
+            <Record>
+              <PropertyValue Property="Kind" EnumMember="Redfish.RevisionKind/Added"/>
+              <PropertyValue Property="Version" String="2018.3"/>
+            </Record>
+          </Collection>
+        </Annotation>
+        <Member Name="Input">
+          <Annotation Term="OData.Description" String="The input."/>
+        </Member>
+        <Member Name="Output">
+          <Annotation Term="OData.Description" String="The output."/>
+        </Member>
+      </EnumType>
+
+    </Schema>
+
+  </edmx:DataServices>
+</edmx:Edmx>

--- a/static/redfish/v1/schema/PortCollection_v1.xml
+++ b/static/redfish/v1/schema/PortCollection_v1.xml
@@ -59,6 +59,7 @@
             <String>/redfish/v1/Systems/{ComputerSystemId}/NetworkInterfaces/{NetworkInterfaceId}/Ports</String>
             <String>/redfish/v1/Systems/{ComputerSystemId}/GraphicsControllers/{ControllerId}/Ports</String>
             <String>/redfish/v1/Systems/{ComputerSystemId}/USBControllers/{ControllerId}/Ports</String>
+            <String>/redfish/v1/Systems/{ComputerSystemId}/Processors/{ProcessorId}/Ports</String>
             <String>/redfish/v1/Chassis/{ChassisId}/MediaControllers/{MediaControllerId}/Ports</String>
             <String>/redfish/v1/Chassis/{ChassisId}/NetworkAdapters/{NetworkAdapterId}/Ports</String>
             <String>/redfish/v1/CompositionService/ResourceBlocks/{ResourceBlockId}/Storage/{StorageId}/StorageControllers/{StorageControllerId}/Ports</String>

--- a/static/redfish/v1/schema/PortMetrics_v1.xml
+++ b/static/redfish/v1/schema/PortMetrics_v1.xml
@@ -1,0 +1,562 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!---->
+<!--################################################################################       -->
+<!--# Redfish Schema:  PortMetrics v1.2.0                                                  -->
+<!--#                                                                                      -->
+<!--# For a detailed change log, see the README file contained in the DSP8010 bundle,      -->
+<!--# available at http://www.dmtf.org/standards/redfish                                   -->
+<!--# Copyright 2014-2021 DMTF.                                                            -->
+<!--# For the full DMTF copyright policy, see http://www.dmtf.org/about/policies/copyright -->
+<!--################################################################################       -->
+<!---->
+<edmx:Edmx xmlns:edmx="http://docs.oasis-open.org/odata/ns/edmx" Version="4.0">
+
+  <edmx:Reference Uri="http://docs.oasis-open.org/odata/odata/v4.0/errata03/csd01/complete/vocabularies/Org.OData.Core.V1.xml">
+    <edmx:Include Namespace="Org.OData.Core.V1" Alias="OData"/>
+  </edmx:Reference>
+  <edmx:Reference Uri="http://docs.oasis-open.org/odata/odata/v4.0/errata03/csd01/complete/vocabularies/Org.OData.Capabilities.V1.xml">
+    <edmx:Include Namespace="Org.OData.Capabilities.V1" Alias="Capabilities"/>
+  </edmx:Reference>
+  <edmx:Reference Uri="http://docs.oasis-open.org/odata/odata/v4.0/errata03/csd01/complete/vocabularies/Org.OData.Measures.V1.xml">
+    <edmx:Include Namespace="Org.OData.Measures.V1" Alias="Measures"/>
+  </edmx:Reference>
+  <edmx:Reference Uri="http://redfish.dmtf.org/schemas/v1/Resource_v1.xml">
+    <edmx:Include Namespace="Resource.v1_0_0"/>
+  </edmx:Reference>
+  <edmx:Reference Uri="http://redfish.dmtf.org/schemas/v1/RedfishExtensions_v1.xml">
+    <edmx:Include Namespace="RedfishExtensions.v1_0_0" Alias="Redfish"/>
+    <edmx:Include Namespace="Validation.v1_0_0" Alias="Validation"/>
+  </edmx:Reference>
+
+  <edmx:DataServices>
+
+    <Schema xmlns="http://docs.oasis-open.org/odata/ns/edm" Namespace="PortMetrics">
+      <Annotation Term="Redfish.OwningEntity" String="DMTF"/>
+
+      <EntityType Name="PortMetrics" BaseType="Resource.v1_0_0.Resource" Abstract="true">
+        <Annotation Term="OData.Description" String="The PortMetrics schema contains usage and health statistics for a switch device or component port summary."/>
+        <Annotation Term="OData.LongDescription" String="This resource shall represent the port metrics for a switch device or component port summary in a Redfish implementation."/>
+        <Annotation Term="OData.AdditionalProperties" Bool="false"/>
+        <Annotation Term="Capabilities.InsertRestrictions">
+          <Record>
+            <PropertyValue Property="Insertable" Bool="false"/>
+          </Record>
+        </Annotation>
+        <Annotation Term="Capabilities.UpdateRestrictions">
+          <Record>
+            <PropertyValue Property="Updatable" Bool="false"/>
+          </Record>
+        </Annotation>
+        <Annotation Term="Capabilities.DeleteRestrictions">
+          <Record>
+            <PropertyValue Property="Deletable" Bool="false"/>
+          </Record>
+        </Annotation>
+        <Annotation Term="Redfish.Uris">
+          <Collection>
+            <String>/redfish/v1/Fabrics/{FabricId}/Switches/{SwitchId}/Ports/{PortId}/Metrics</String>
+            <String>/redfish/v1/Systems/{ComputerSystemId}/Storage/{StorageId}/StorageControllers/{StorageControllerId}/Ports/{PortId}/Metrics</String>
+            <String>/redfish/v1/Systems/{ComputerSystemId}/Storage/{StorageId}/Controllers/{StorageControllerId}/Ports/{PortId}/Metrics</String>
+            <String>/redfish/v1/Systems/{ComputerSystemId}/FabricAdapters/{FabricAdapterId}/Ports/{PortId}/Metrics</String>
+            <String>/redfish/v1/Systems/{ComputerSystemId}/GraphicsControllers/{ControllerId}/Ports/{PortId}/Metrics</String>
+            <String>/redfish/v1/Systems/{ComputerSystemId}/USBControllers/{ControllerId}/Ports/{PortId}/Metrics</String>
+            <String>/redfish/v1/Systems/{ComputerSystemId}/Processors/{ProcessorId}/Ports/{PortId}/Metrics</String>
+            <String>/redfish/v1/CompositionService/ResourceBlocks/{ResourceBlockId}/Storage/{StorageId}/StorageControllers/{StorageControllerId}/Ports/{PortId}/Metrics</String>
+            <String>/redfish/v1/CompositionService/ResourceBlocks/{ResourceBlockId}/Storage/{StorageId}/Controllers/{StorageControllerId}/Ports/{PortId}/Metrics</String>
+            <String>/redfish/v1/CompositionService/ResourceBlocks/{ResourceBlockId}/Systems/{ComputerSystemId}/Storage/{StorageId}/StorageControllers/{StorageControllerId}/Ports/{PortId}/Metrics</String>
+            <String>/redfish/v1/CompositionService/ResourceBlocks/{ResourceBlockId}/Systems/{ComputerSystemId}/Storage/{StorageId}/Controllers/{StorageControllerId}/Ports/{PortId}/Metrics</String>
+            <String>/redfish/v1/ResourceBlocks/{ResourceBlockId}/Storage/{StorageId}/StorageControllers/{StorageControllerId}/Ports/{PortId}/Metrics</String>
+            <String>/redfish/v1/ResourceBlocks/{ResourceBlockId}/Storage/{StorageId}/Controllers/{StorageControllerId}/Ports/{PortId}/Metrics</String>
+            <String>/redfish/v1/ResourceBlocks/{ResourceBlockId}/Systems/{ComputerSystemId}/Storage/{StorageId}/StorageControllers/{StorageControllerId}/Ports/{PortId}/Metrics</String>
+            <String>/redfish/v1/ResourceBlocks/{ResourceBlockId}/Systems/{ComputerSystemId}/Storage/{StorageId}/Controllers/{StorageControllerId}/Ports/{PortId}/Metrics</String>
+            <String>/redfish/v1/Chassis/{ChassisId}/MediaControllers/{MediaControllerId}/Ports/{PortId}/Metrics</String>
+            <String>/redfish/v1/Chassis/{ChassisId}/NetworkAdapters/{NetworkAdapterId}/Ports/{PortId}/Metrics</String>
+            <String>/redfish/v1/Storage/{StorageId}/StorageControllers/{StorageControllerId}/Ports/{PortId}/Metrics</String>
+            <String>/redfish/v1/Storage/{StorageId}/Controllers/{StorageControllerId}/Ports/{PortId}/Metrics</String>
+            <String>/redfish/v1/Managers/{ManagerId}/USBPorts/{PortId}/Metrics</String>
+          </Collection>
+        </Annotation>
+      </EntityType>
+    </Schema>
+
+    <Schema xmlns="http://docs.oasis-open.org/odata/ns/edm" Namespace="PortMetrics.v1_0_0">
+      <Annotation Term="Redfish.OwningEntity" String="DMTF"/>
+      <Annotation Term="Redfish.Release" String="2019.4"/>
+
+      <EntityType Name="PortMetrics" BaseType="PortMetrics.PortMetrics">
+        <Property Name="GenZ" Type="PortMetrics.v1_0_0.GenZ" Nullable="false">
+          <Annotation Term="OData.Description" String="The port metrics specific to Gen-Z ports."/>
+          <Annotation Term="OData.LongDescription" String="This property shall contain the port metrics specific to Gen-Z ports."/>
+        </Property>
+        <Property Name="Actions" Type="PortMetrics.v1_0_0.Actions" Nullable="false">
+          <Annotation Term="OData.Description" String="The available actions for this resource."/>
+          <Annotation Term="OData.LongDescription" String="This property shall contain the available actions for this resource."/>
+        </Property>
+      </EntityType>
+
+      <ComplexType Name="GenZ">
+        <Annotation Term="OData.AdditionalProperties" Bool="false"/>
+        <Annotation Term="OData.Description" String="The port metrics for a Gen-Z interface."/>
+        <Annotation Term="OData.LongDescription" String="This type shall describe the Gen-Z related port metrics."/>
+        <Property Name="PacketCRCErrors" Type="Edm.Int64">
+          <Annotation Term="OData.Permissions" EnumMember="OData.Permission/Read"/>
+          <Annotation Term="OData.Description" String="The total number of PCRC transient errors detected."/>
+          <Annotation Term="OData.LongDescription" String="This property shall contain the total number of PCRC transient errors detected in received link-local and end-to-end packets."/>
+        </Property>
+        <Property Name="EndToEndCRCErrors" Type="Edm.Int64">
+          <Annotation Term="OData.Permissions" EnumMember="OData.Permission/Read"/>
+          <Annotation Term="OData.Description" String="The total number of ECRC transient errors detected."/>
+          <Annotation Term="OData.LongDescription" String="This property shall contain total number of ECRC transient errors detected in received link-local and end-to-end packets."/>
+        </Property>
+        <Property Name="RXStompedECRC" Type="Edm.Int64">
+          <Annotation Term="OData.Permissions" EnumMember="OData.Permission/Read"/>
+          <Annotation Term="OData.Description" String="The total number of packets received with a stomped ECRC field."/>
+          <Annotation Term="OData.LongDescription" String="This property shall contain the total number of packets that this interface received with a stomped ECRC field."/>
+        </Property>
+        <Property Name="TXStompedECRC" Type="Edm.Int64">
+          <Annotation Term="OData.Permissions" EnumMember="OData.Permission/Read"/>
+          <Annotation Term="OData.Description" String="The total number of packets that this interface stomped the ECRC field."/>
+          <Annotation Term="OData.LongDescription" String="This property shall contain the total number of packets that this interfaced stomped the ECRC field."/>
+        </Property>
+        <Property Name="NonCRCTransientErrors" Type="Edm.Int64">
+          <Annotation Term="OData.Permissions" EnumMember="OData.Permission/Read"/>
+          <Annotation Term="OData.Description" String="The total number transient errors detected that are unrelated to CRC validation."/>
+          <Annotation Term="OData.LongDescription" String="This property shall contain the total number of transient errors detected that are unrelated to CRC validation, which covers link-local and end-to-end packets, such as malformed Link Idle packets or PLA signal errors."/>
+        </Property>
+        <Property Name="LLRRecovery" Type="Edm.Int64">
+          <Annotation Term="OData.Permissions" EnumMember="OData.Permission/Read"/>
+          <Annotation Term="OData.Description" String="The total number of times Link-Level Reliability (LLR) recovery has been initiated."/>
+          <Annotation Term="OData.LongDescription" String="This property shall contain the total number of times Link-level Reliability (LLR) recovery has been initiated by this interface.  This is not to be confused with the number of packets retransmitted due to initiating LLR recovery."/>
+        </Property>
+        <Property Name="MarkedECN" Type="Edm.Int64">
+          <Annotation Term="OData.Permissions" EnumMember="OData.Permission/Read"/>
+          <Annotation Term="OData.Description" String="The number of packets with the Congestion ECN bit set."/>
+          <Annotation Term="OData.LongDescription" String="This property shall contain the number of packets that the component set the Congestion ECN bit prior to transmission through this interface."/>
+        </Property>
+        <Property Name="PacketDeadlineDiscards" Type="Edm.Int64">
+          <Annotation Term="OData.Permissions" EnumMember="OData.Permission/Read"/>
+          <Annotation Term="OData.Description" String="The number of packets discarded due to the Congestion Deadline sub-field reaching zero."/>
+          <Annotation Term="OData.LongDescription" String="This property shall contain the number of packets discarded by this interface due to the Congestion Deadline sub-field reaching zero prior to packet transmission."/>
+        </Property>
+        <Property Name="AccessKeyViolations" Type="Edm.Int64">
+          <Annotation Term="OData.Permissions" EnumMember="OData.Permission/Read"/>
+          <Annotation Term="OData.Description" String="The total number of Access Key Violations detected."/>
+          <Annotation Term="OData.LongDescription" String="This property shall contain the total number of Access Key Violations detected for packets received or transmitted on this interface."/>
+        </Property>
+        <Property Name="LinkNTE" Type="Edm.Int64">
+          <Annotation Term="OData.Permissions" EnumMember="OData.Permission/Read"/>
+          <Annotation Term="OData.Description" String="The total number of link-local non-transient errors detected."/>
+          <Annotation Term="OData.LongDescription" String="This property shall contain the total number of link-local non-transient errors detected on this interface."/>
+        </Property>
+        <Property Name="ReceivedECN" Type="Edm.Int64">
+          <Annotation Term="OData.Permissions" EnumMember="OData.Permission/Read"/>
+          <Annotation Term="OData.Description" String="The number of packets received on this interface with the Congestion ECN bit set."/>
+          <Annotation Term="OData.LongDescription" String="This property shall contain the number of packets received on this interface with the Congestion ECN bit set."/>
+        </Property>
+      </ComplexType>
+
+      <ComplexType Name="Actions">
+        <Annotation Term="OData.AdditionalProperties" Bool="false"/>
+        <Annotation Term="OData.Description" String="The available actions for this resource."/>
+        <Annotation Term="OData.LongDescription" String="This type shall contain the available actions for this resource."/>
+        <Property Name="Oem" Type="PortMetrics.v1_0_0.OemActions" Nullable="false">
+          <Annotation Term="OData.Description" String="The available OEM-specific actions for this resource."/>
+          <Annotation Term="OData.LongDescription" String="This property shall contain the available OEM-specific actions for this resource."/>
+        </Property>
+      </ComplexType>
+
+      <ComplexType Name="OemActions">
+        <Annotation Term="OData.AdditionalProperties" Bool="true"/>
+        <Annotation Term="OData.Description" String="The available OEM-specific actions for this resource."/>
+        <Annotation Term="OData.LongDescription" String="This type shall contain the available OEM-specific actions for this resource."/>
+      </ComplexType>
+    </Schema>
+
+    <Schema xmlns="http://docs.oasis-open.org/odata/ns/edm" Namespace="PortMetrics.v1_0_1">
+      <Annotation Term="Redfish.OwningEntity" String="DMTF"/>
+      <Annotation Term="OData.Description" String="This version was created to correct various typographical errors."/>
+      <EntityType Name="PortMetrics" BaseType="PortMetrics.v1_0_0.PortMetrics"/>
+    </Schema>
+
+    <Schema xmlns="http://docs.oasis-open.org/odata/ns/edm" Namespace="PortMetrics.v1_0_2">
+      <Annotation Term="Redfish.OwningEntity" String="DMTF"/>
+      <Annotation Term="OData.Description" String="This version was created to correct various typographical errors."/>
+      <EntityType Name="PortMetrics" BaseType="PortMetrics.v1_0_1.PortMetrics"/>
+    </Schema>
+
+    <Schema xmlns="http://docs.oasis-open.org/odata/ns/edm" Namespace="PortMetrics.v1_1_0">
+      <Annotation Term="Redfish.OwningEntity" String="DMTF"/>
+      <Annotation Term="Redfish.Release" String="2021.1"/>
+      <Annotation Term="OData.Description" String="This version was created to add Ethernet and storage port metrics."/>
+
+      <EntityType Name="PortMetrics" BaseType="PortMetrics.v1_0_0.PortMetrics">
+        <Property Name="RXBytes" Type="Edm.Int64">
+          <Annotation Term="OData.Permissions" EnumMember="OData.Permission/Read"/>
+          <Annotation Term="OData.Description" String="The total number of bytes received on a port since reset."/>
+          <Annotation Term="OData.LongDescription" String="This property shall contain the total number of bytes received on a port since reset, including host and remote management passthrough traffic, and inclusive of all protocol overhead."/>
+          <Annotation Term="Measures.Unit" String="By"/>
+        </Property>
+        <Property Name="TXBytes" Type="Edm.Int64">
+          <Annotation Term="OData.Permissions" EnumMember="OData.Permission/Read"/>
+          <Annotation Term="OData.Description" String="The total number of bytes transmitted on a port since reset."/>
+          <Annotation Term="OData.LongDescription" String="This property shall contain the total number of bytes transmitted on a port since reset, including host and remote management passthrough traffic, and inclusive of all protocol overhead."/>
+          <Annotation Term="Measures.Unit" String="By"/>
+        </Property>
+        <Property Name="RXErrors" Type="Edm.Int64">
+          <Annotation Term="OData.Permissions" EnumMember="OData.Permission/Read"/>
+          <Annotation Term="OData.Description" String="The total number of received errors on a port since reset."/>
+          <Annotation Term="OData.LongDescription" String="This property shall contain the total number of received errors on a port since reset."/>
+        </Property>
+        <Property Name="TXErrors" Type="Edm.Int64">
+          <Annotation Term="OData.Permissions" EnumMember="OData.Permission/Read"/>
+          <Annotation Term="OData.Description" String="The total number of transmission errors on a port since reset."/>
+          <Annotation Term="OData.LongDescription" String="This property shall contain the total number of transmission errors on a port since reset."/>
+        </Property>
+        <Property Name="Networking" Type="PortMetrics.v1_1_0.Networking" Nullable="false">
+          <Annotation Term="OData.Description" String="The port metrics for network ports, including Ethernet, Fibre Channel, and InfiniBand, that are not specific to one of these protocols."/>
+          <Annotation Term="OData.LongDescription" String="This property shall contain port metrics for network ports, including Ethernet, Fibre Channel, and InfiniBand, that are not specific to one of these protocols."/>
+        </Property>
+        <Property Name="Transceivers" Type="Collection(PortMetrics.v1_1_0.Transceiver)" Nullable="false">
+          <Annotation Term="OData.Description" String="The metrics for the transceivers in this port.  Each member represents a single transceiver."/>
+          <Annotation Term="OData.LongDescription" String="This property shall contain an array of transceiver related metrics for this port.  Each member in the array shall represent a single transceiver."/>
+        </Property>
+        <Property Name="SAS" Type="Collection(PortMetrics.v1_1_0.SAS)" Nullable="false">
+          <Annotation Term="OData.Description" String="The physical (phy) metrics for Serial Attached SCSI (SAS).  Each member represents a single phy."/>
+          <Annotation Term="OData.LongDescription" String="This property shall contain an array of physical related metrics for Serial Attached SCSI (SAS).  Each member in the array shall represent a single phy."/>
+        </Property>
+      </EntityType>
+
+      <ComplexType Name="Networking">
+        <Annotation Term="OData.AdditionalProperties" Bool="false"/>
+        <Annotation Term="OData.Description" String="The port metrics for network ports, including Ethernet, Fibre Channel, and InfiniBand, that are not specific to one of these protocols."/>
+        <Annotation Term="OData.LongDescription" String="This type shall describe the metrics for network ports, including Ethernet, Fibre Channel, and InfiniBand, that are not specific to one of these protocols."/>
+        <Property Name="RXFrames" Type="Edm.Int64">
+          <Annotation Term="OData.Permissions" EnumMember="OData.Permission/Read"/>
+          <Annotation Term="OData.Description" String="The total number of frames received on a port since reset."/>
+          <Annotation Term="OData.LongDescription" String="This property shall contain the total number of frames received on a port since reset."/>
+        </Property>
+        <Property Name="RXUnicastFrames" Type="Edm.Int64">
+          <Annotation Term="OData.Permissions" EnumMember="OData.Permission/Read"/>
+          <Annotation Term="OData.Description" String="The total number of valid unicast frames received on a port since reset."/>
+          <Annotation Term="OData.LongDescription" String="This property shall contain the total number of valid unicast frames received on a port since reset."/>
+        </Property>
+        <Property Name="RXMulticastFrames" Type="Edm.Int64">
+          <Annotation Term="OData.Permissions" EnumMember="OData.Permission/Read"/>
+          <Annotation Term="OData.Description" String="The total number of valid multicast frames received on a port since reset."/>
+          <Annotation Term="OData.LongDescription" String="This property shall contain the total number of valid multicast frames received on a port since reset, including host and remote management passthrough traffic."/>
+        </Property>
+        <Property Name="RXBroadcastFrames" Type="Edm.Int64">
+          <Annotation Term="OData.Permissions" EnumMember="OData.Permission/Read"/>
+          <Annotation Term="OData.Description" String="The total number of valid broadcast frames received on a port since reset."/>
+          <Annotation Term="OData.LongDescription" String="This property shall contain the total number of valid broadcast frames received on a port since reset, including host and remote management passthrough traffic."/>
+        </Property>
+        <Property Name="TXFrames" Type="Edm.Int64">
+          <Annotation Term="OData.Permissions" EnumMember="OData.Permission/Read"/>
+          <Annotation Term="OData.Description" String="The total number of frames transmitted on a port since reset."/>
+          <Annotation Term="OData.LongDescription" String="This property shall contain the total number of frames transmitted on a port since reset."/>
+        </Property>
+        <Property Name="TXUnicastFrames" Type="Edm.Int64">
+          <Annotation Term="OData.Permissions" EnumMember="OData.Permission/Read"/>
+          <Annotation Term="OData.Description" String="The total number of good unicast frames transmitted on a port since reset."/>
+          <Annotation Term="OData.LongDescription" String="This property shall contain the total number of good unicast frames transmitted on a port since reset, including host and remote management passthrough traffic."/>
+        </Property>
+        <Property Name="TXMulticastFrames" Type="Edm.Int64">
+          <Annotation Term="OData.Permissions" EnumMember="OData.Permission/Read"/>
+          <Annotation Term="OData.Description" String="The total number of good multicast frames transmitted on a port since reset."/>
+          <Annotation Term="OData.LongDescription" String="This property shall contain the total number of good multicast frames transmitted on a port since reset, including host and remote management passthrough traffic."/>
+        </Property>
+        <Property Name="TXBroadcastFrames" Type="Edm.Int64">
+          <Annotation Term="OData.Permissions" EnumMember="OData.Permission/Read"/>
+          <Annotation Term="OData.Description" String="The total number of good broadcast frames transmitted on a port since reset."/>
+          <Annotation Term="OData.LongDescription" String="This property shall contain the total number of good broadcast frames transmitted on a port since reset, including host and remote management passthrough traffic."/>
+        </Property>
+        <Property Name="RXDiscards" Type="Edm.Int64">
+          <Annotation Term="OData.Permissions" EnumMember="OData.Permission/Read"/>
+          <Annotation Term="OData.Description" String="The total number of frames discarded in a port's receive path since reset."/>
+          <Annotation Term="OData.LongDescription" String="This property shall contain the total number of frames discarded in a port's receive path since reset."/>
+        </Property>
+        <Property Name="RXFrameAlignmentErrors" Type="Edm.Int64">
+          <Annotation Term="OData.Permissions" EnumMember="OData.Permission/Read"/>
+          <Annotation Term="OData.Description" String="The total number of frames received with alignment errors on a port since reset."/>
+          <Annotation Term="OData.LongDescription" String="This property shall contain the total number of frames received with alignment errors on a port since reset."/>
+        </Property>
+        <Property Name="RXFCSErrors" Type="Edm.Int64">
+          <Annotation Term="OData.Permissions" EnumMember="OData.Permission/Read"/>
+          <Annotation Term="OData.Description" String="The total number of frames received with frame check sequence (FCS) errors on a port since reset."/>
+          <Annotation Term="OData.LongDescription" String="This property shall contain the total number of frames received with frame check sequence (FCS) errors on a port since reset."/>
+        </Property>
+        <Property Name="RXFalseCarrierErrors" Type="Edm.Int64">
+          <Annotation Term="OData.Permissions" EnumMember="OData.Permission/Read"/>
+          <Annotation Term="OData.Description" String="The total number of false carrier errors received from phy on a port since reset."/>
+          <Annotation Term="OData.LongDescription" String="This property shall contain the total number of false carrier errors received from phy on a port since reset."/>
+        </Property>
+        <Property Name="RXOversizeFrames" Type="Edm.Int64">
+          <Annotation Term="OData.Permissions" EnumMember="OData.Permission/Read"/>
+          <Annotation Term="OData.Description" String="The total number of frames that exceed the maximum frame size."/>
+          <Annotation Term="OData.LongDescription" String="This property shall contain the total number of frames that exceed the maximum frame size."/>
+        </Property>
+        <Property Name="RXUndersizeFrames" Type="Edm.Int64">
+          <Annotation Term="OData.Permissions" EnumMember="OData.Permission/Read"/>
+          <Annotation Term="OData.Description" String="The total number of frames that are smaller than the minimum frame size of 64 bytes."/>
+          <Annotation Term="OData.LongDescription" String="This property shall contain the total number of frames that are smaller than the minimum frame size of 64 bytes."/>
+        </Property>
+        <Property Name="TXDiscards" Type="Edm.Int64">
+          <Annotation Term="OData.Permissions" EnumMember="OData.Permission/Read"/>
+          <Annotation Term="OData.Description" String="The total number of frames discarded in a port's transmit path since reset."/>
+          <Annotation Term="OData.LongDescription" String="This property shall contain the total number of frames discarded in a port's transmit path since reset."/>
+        </Property>
+        <Property Name="TXExcessiveCollisions" Type="Edm.Int64">
+          <Annotation Term="OData.Permissions" EnumMember="OData.Permission/Read"/>
+          <Annotation Term="OData.Description" String="The number of times a single transmitted frame encountered more than 15 collisions."/>
+          <Annotation Term="OData.LongDescription" String="This property shall contain the number of times a single transmitted frame encountered more than 15 collisions."/>
+        </Property>
+        <Property Name="TXLateCollisions" Type="Edm.Int64">
+          <Annotation Term="OData.Permissions" EnumMember="OData.Permission/Read"/>
+          <Annotation Term="OData.Description" String="The total number of collisions that occurred after one slot time as defined by IEEE 802.3."/>
+          <Annotation Term="OData.LongDescription" String="This property shall contain the total number of collisions that occurred after one slot time as defined by IEEE 802.3."/>
+        </Property>
+        <Property Name="TXMultipleCollisions" Type="Edm.Int64">
+          <Annotation Term="OData.Permissions" EnumMember="OData.Permission/Read"/>
+          <Annotation Term="OData.Description" String="The times that a transmitted frame encountered 2-15 collisions."/>
+          <Annotation Term="OData.LongDescription" String="This property shall contain the times that a transmitted frame encountered 2-15 collisions."/>
+        </Property>
+        <Property Name="TXSingleCollisions" Type="Edm.Int64">
+          <Annotation Term="OData.Permissions" EnumMember="OData.Permission/Read"/>
+          <Annotation Term="OData.Description" String="The times that a successfully transmitted frame encountered a single collision."/>
+          <Annotation Term="OData.LongDescription" String="This property shall contain the times that a successfully transmitted frame encountered a single collision."/>
+        </Property>
+        <Property Name="RXPFCFrames" Type="Edm.Int64">
+          <Annotation Term="OData.Permissions" EnumMember="OData.Permission/Read"/>
+          <Annotation Term="OData.Description" String="The total number of priority flow control (PFC) frames received on a port since reset."/>
+          <Annotation Term="OData.LongDescription" String="This property shall contain the total number of priority flow control (PFC) frames received on a port since reset."/>
+        </Property>
+        <Property Name="TXPFCFrames" Type="Edm.Int64">
+          <Annotation Term="OData.Permissions" EnumMember="OData.Permission/Read"/>
+          <Annotation Term="OData.Description" String="The total number of priority flow control (PFC) frames sent on a port since reset."/>
+          <Annotation Term="OData.LongDescription" String="This property shall contain the total number of priority flow control (PFC) frames sent on a port since reset."/>
+        </Property>
+        <Property Name="RXPauseXOFFFrames" Type="Edm.Int64">
+          <Annotation Term="OData.Permissions" EnumMember="OData.Permission/Read"/>
+          <Annotation Term="OData.Description" String="The total number of flow control frames from the network to pause transmission."/>
+          <Annotation Term="OData.LongDescription" String="This property shall contain the total number of flow control frames from the network to pause transmission."/>
+        </Property>
+        <Property Name="RXPauseXONFrames" Type="Edm.Int64">
+          <Annotation Term="OData.Permissions" EnumMember="OData.Permission/Read"/>
+          <Annotation Term="OData.Description" String="The total number of flow control frames from the network to resume transmission."/>
+          <Annotation Term="OData.LongDescription" String="This property shall contain the total number of flow control frames from the network to resume transmission."/>
+        </Property>
+        <Property Name="TXPauseXOFFFrames" Type="Edm.Int64">
+          <Annotation Term="OData.Permissions" EnumMember="OData.Permission/Read"/>
+          <Annotation Term="OData.Description" String="The total number of XOFF frames transmitted to the network."/>
+          <Annotation Term="OData.LongDescription" String="This property shall contain the total number of XOFF frames transmitted to the network."/>
+        </Property>
+        <Property Name="TXPauseXONFrames" Type="Edm.Int64">
+          <Annotation Term="OData.Permissions" EnumMember="OData.Permission/Read"/>
+          <Annotation Term="OData.Description" String="The total number of XON frames transmitted to the network."/>
+          <Annotation Term="OData.LongDescription" String="This property shall contain the total number of XON frames transmitted to the network."/>
+        </Property>
+        <Property Name="RDMARXBytes" Type="Edm.Int64">
+          <Annotation Term="OData.Permissions" EnumMember="OData.Permission/Read"/>
+          <Annotation Term="OData.Description" String="The total number of RDMA bytes received on a port since reset."/>
+          <Annotation Term="OData.LongDescription" String="This property shall contain the total number of RDMA bytes received on a port since reset."/>
+        </Property>
+        <Property Name="RDMARXRequests" Type="Edm.Int64">
+          <Annotation Term="OData.Permissions" EnumMember="OData.Permission/Read"/>
+          <Annotation Term="OData.Description" String="The total number of RDMA requests received on a port since reset."/>
+          <Annotation Term="OData.LongDescription" String="This property shall contain the total number of RDMA requests received on a port since reset."/>
+        </Property>
+        <Property Name="RDMAProtectionErrors" Type="Edm.Int64">
+          <Annotation Term="OData.Permissions" EnumMember="OData.Permission/Read"/>
+          <Annotation Term="OData.Description" String="The total number of RDMA protection errors."/>
+          <Annotation Term="OData.LongDescription" String="This property shall contain the total number of RDMA protection errors."/>
+        </Property>
+        <Property Name="RDMAProtocolErrors" Type="Edm.Int64">
+          <Annotation Term="OData.Permissions" EnumMember="OData.Permission/Read"/>
+          <Annotation Term="OData.Description" String="The total number of RDMA protocol errors."/>
+          <Annotation Term="OData.LongDescription" String="This property shall contain the total number of RDMA protocol errors."/>
+        </Property>
+        <Property Name="RDMATXBytes" Type="Edm.Int64">
+          <Annotation Term="OData.Permissions" EnumMember="OData.Permission/Read"/>
+          <Annotation Term="OData.Description" String="The total number of RDMA bytes transmitted on a port since reset."/>
+          <Annotation Term="OData.LongDescription" String="This property shall contain the total number of RDMA bytes transmitted on a port since reset."/>
+        </Property>
+        <Property Name="RDMATXRequests" Type="Edm.Int64">
+          <Annotation Term="OData.Permissions" EnumMember="OData.Permission/Read"/>
+          <Annotation Term="OData.Description" String="The total number of RDMA requests transmitted on a port since reset."/>
+          <Annotation Term="OData.LongDescription" String="This property shall contain the total number of RDMA requests transmitted on a port since reset."/>
+        </Property>
+        <Property Name="RDMATXReadRequests" Type="Edm.Int64">
+          <Annotation Term="OData.Permissions" EnumMember="OData.Permission/Read"/>
+          <Annotation Term="OData.Description" String="The total number of RDMA read requests transmitted on a port since reset."/>
+          <Annotation Term="OData.LongDescription" String="This property shall contain the total number of RDMA read requests transmitted on a port since reset."/>
+        </Property>
+        <Property Name="RDMATXSendRequests" Type="Edm.Int64">
+          <Annotation Term="OData.Permissions" EnumMember="OData.Permission/Read"/>
+          <Annotation Term="OData.Description" String="The total number of RDMA send requests transmitted on a port since reset."/>
+          <Annotation Term="OData.LongDescription" String="This property shall contain the total number of RDMA send requests transmitted on a port since reset."/>
+        </Property>
+        <Property Name="RDMATXWriteRequests" Type="Edm.Int64">
+          <Annotation Term="OData.Permissions" EnumMember="OData.Permission/Read"/>
+          <Annotation Term="OData.Description" String="The total number of RDMA write requests transmitted on a port since reset."/>
+          <Annotation Term="OData.LongDescription" String="This property shall contain the total number of RDMA write requests transmitted on a port since reset."/>
+        </Property>
+      </ComplexType>
+
+      <ComplexType Name="Transceiver">
+        <Annotation Term="OData.AdditionalProperties" Bool="false"/>
+        <Annotation Term="OData.Description" String="The transceiver metrics."/>
+        <Annotation Term="OData.LongDescription" String="This type shall describe the transceiver related metrics."/>
+        <Property Name="RXInputPowerMilliWatts" Type="Edm.Decimal">
+          <Annotation Term="OData.Permissions" EnumMember="OData.Permission/Read"/>
+          <Annotation Term="OData.Description" String="The RX input power value of a small form-factor pluggable (SFP) transceiver."/>
+          <Annotation Term="OData.LongDescription" String="This property shall contain the RX input power value of a small form-factor pluggable (SFP) transceiver."/>
+          <Annotation Term="Measures.Unit" String="mW"/>
+          <Annotation Term="Validation.Minimum" Int="0"/>
+        </Property>
+        <Property Name="TXBiasCurrentMilliAmps" Type="Edm.Decimal">
+          <Annotation Term="OData.Permissions" EnumMember="OData.Permission/Read"/>
+          <Annotation Term="OData.Description" String="The TX bias current value of a small form-factor pluggable (SFP) transceiver."/>
+          <Annotation Term="OData.LongDescription" String="This property shall contain the TX bias current value of a small form-factor pluggable (SFP) transceiver."/>
+          <Annotation Term="Measures.Unit" String="mA"/>
+          <Annotation Term="Validation.Minimum" Int="0"/>
+        </Property>
+        <Property Name="TXOutputPowerMilliWatts" Type="Edm.Decimal">
+          <Annotation Term="OData.Permissions" EnumMember="OData.Permission/Read"/>
+          <Annotation Term="OData.Description" String="The TX output power value of a small form-factor pluggable (SFP) transceiver."/>
+          <Annotation Term="OData.LongDescription" String="This property shall contain the TX output power value of a small form-factor pluggable (SFP) transceiver."/>
+          <Annotation Term="Measures.Unit" String="mW"/>
+          <Annotation Term="Validation.Minimum" Int="0"/>
+        </Property>
+        <Property Name="SupplyVoltage" Type="Edm.Decimal">
+          <Annotation Term="OData.Permissions" EnumMember="OData.Permission/Read"/>
+          <Annotation Term="OData.Description" String="The supply voltage of a small form-factor pluggable (SFP) transceiver."/>
+          <Annotation Term="OData.LongDescription" String="This property shall contain the supply voltage of a small form-factor pluggable (SFP) transceiver."/>
+          <Annotation Term="Measures.Unit" String="V"/>
+        </Property>
+      </ComplexType>
+
+      <ComplexType Name="SAS">
+        <Annotation Term="OData.AdditionalProperties" Bool="false"/>
+        <Annotation Term="OData.Description" String="The physical metrics for Serial Attached SCSI (SAS)."/>
+        <Annotation Term="OData.LongDescription" String="This type shall describe physical (phy) related metrics for Serial Attached SCSI (SAS)."/>
+        <Property Name="InvalidDwordCount" Type="Edm.Int64">
+          <Annotation Term="OData.Permissions" EnumMember="OData.Permission/Read"/>
+          <Annotation Term="OData.Description" String="The number of invalid dwords that have been received by the phy outside of phy reset sequences."/>
+          <Annotation Term="OData.LongDescription" String="This property shall contain the number of invalid dwords that have been received by the phy outside of phy reset sequences."/>
+        </Property>
+        <Property Name="RunningDisparityErrorCount" Type="Edm.Int64">
+          <Annotation Term="OData.Permissions" EnumMember="OData.Permission/Read"/>
+          <Annotation Term="OData.Description" String="The number of dwords containing running disparity errors that have been received by the phy outside of phy reset sequences."/>
+          <Annotation Term="OData.LongDescription" String="This property shall contain the number of dwords containing running disparity errors that have been received by the phy outside of phy reset sequences."/>
+        </Property>
+        <Property Name="LossOfDwordSynchronizationCount" Type="Edm.Int64">
+          <Annotation Term="OData.Permissions" EnumMember="OData.Permission/Read"/>
+          <Annotation Term="OData.Description" String="The number of times the phy has restarted the link reset sequence because it lost dword synchronization."/>
+          <Annotation Term="OData.LongDescription" String="This property shall contain the number of times the phy has restarted the link reset sequence because it lost dword synchronization."/>
+        </Property>
+      </ComplexType>
+    </Schema>
+
+    <Schema xmlns="http://docs.oasis-open.org/odata/ns/edm" Namespace="PortMetrics.v1_1_1">
+      <Annotation Term="Redfish.OwningEntity" String="DMTF"/>
+      <Annotation Term="OData.Description" String="This version was created to correct various typographical errors."/>
+      <EntityType Name="PortMetrics" BaseType="PortMetrics.v1_1_0.PortMetrics"/>
+    </Schema>
+
+    <Schema xmlns="http://docs.oasis-open.org/odata/ns/edm" Namespace="PortMetrics.v1_2_0">
+      <Annotation Term="Redfish.OwningEntity" String="DMTF"/>
+      <Annotation Term="Redfish.Release" String="2021.2"/>
+      <Annotation Term="OData.Description" String="This version was created to add Fibre Channel port metrics."/>
+
+      <EntityType Name="PortMetrics" BaseType="PortMetrics.v1_1_1.PortMetrics">
+        <Property Name="FibreChannel" Type="PortMetrics.v1_2_0.FibreChannel" Nullable="false">
+          <Annotation Term="OData.Description" String="The Fibre Channel-specific port metrics for network ports."/>
+          <Annotation Term="OData.LongDescription" String="This property shall contain Fibre Channel-specific port metrics for network ports."/>
+        </Property>
+      </EntityType>
+
+      <ComplexType Name="FibreChannel">
+        <Annotation Term="OData.AdditionalProperties" Bool="false"/>
+        <Annotation Term="OData.Description" String="The Fibre Channel-specific port metrics for network ports."/>
+        <Annotation Term="OData.LongDescription" String="This type shall describe Fibre Channel-specific metrics for network ports."/>
+        <Property Name="InvalidCRCs" Type="Edm.Int64">
+          <Annotation Term="OData.Permissions" EnumMember="OData.Permission/Read"/>
+          <Annotation Term="OData.Description" String="The total number of invalid cyclic redundancy checks (CRCs)."/>
+          <Annotation Term="OData.LongDescription" String="This property shall contain the total number of invalid cyclic redundancy checks (CRCs) observed on this port."/>
+        </Property>
+        <Property Name="LinkFailures" Type="Edm.Int64">
+          <Annotation Term="OData.Permissions" EnumMember="OData.Permission/Read"/>
+          <Annotation Term="OData.Description" String="The total number of link failures."/>
+          <Annotation Term="OData.LongDescription" String="This property shall contain the total number of link failures observed on this port."/>
+        </Property>
+        <Property Name="LossesOfSignal" Type="Edm.Int64">
+          <Annotation Term="OData.Permissions" EnumMember="OData.Permission/Read"/>
+          <Annotation Term="OData.Description" String="The total number of losses of signal."/>
+          <Annotation Term="OData.LongDescription" String="This property shall contain the total number of times this port has lost signal."/>
+        </Property>
+        <Property Name="LossesOfSync" Type="Edm.Int64">
+          <Annotation Term="OData.Permissions" EnumMember="OData.Permission/Read"/>
+          <Annotation Term="OData.Description" String="The total number of losses of sync."/>
+          <Annotation Term="OData.LongDescription" String="This property shall contain the total number of times this port has lost sync."/>
+        </Property>
+        <Property Name="InvalidTXWords" Type="Edm.Int64">
+          <Annotation Term="OData.Permissions" EnumMember="OData.Permission/Read"/>
+          <Annotation Term="OData.Description" String="The total number of invalid transmission words."/>
+          <Annotation Term="OData.LongDescription" String="This property shall contain the total number of times this port has received invalid transmission words."/>
+        </Property>
+        <Property Name="CorrectableFECErrors" Type="Edm.Int64">
+          <Annotation Term="OData.Permissions" EnumMember="OData.Permission/Read"/>
+          <Annotation Term="OData.Description" String="The total number of correctable forward error correction (FEC) errors."/>
+          <Annotation Term="OData.LongDescription" String="This property shall contain the total number of times this port has received traffic with correctable forward error correction (FEC) errors."/>
+        </Property>
+        <Property Name="UncorrectableFECErrors" Type="Edm.Int64">
+          <Annotation Term="OData.Permissions" EnumMember="OData.Permission/Read"/>
+          <Annotation Term="OData.Description" String="The total number of uncorrectable forward error correction (FEC) errors."/>
+          <Annotation Term="OData.LongDescription" String="This property shall contain the total number of times this port has received traffic with uncorrectable forward error correction (FEC) errors."/>
+        </Property>
+        <Property Name="RXSequences" Type="Edm.Int64">
+          <Annotation Term="OData.Permissions" EnumMember="OData.Permission/Read"/>
+          <Annotation Term="OData.Description" String="The total number of Fibre Channel sequences received."/>
+          <Annotation Term="OData.LongDescription" String="This property shall contain the total number of Fibre Channel sequences received."/>
+        </Property>
+        <Property Name="TXSequences" Type="Edm.Int64">
+          <Annotation Term="OData.Permissions" EnumMember="OData.Permission/Read"/>
+          <Annotation Term="OData.Description" String="The total number of Fibre Channel sequences transmitted."/>
+          <Annotation Term="OData.LongDescription" String="This property shall contain the total number of Fibre Channel sequences transmitted."/>
+        </Property>
+        <Property Name="TXExchanges" Type="Edm.Int64">
+          <Annotation Term="OData.Permissions" EnumMember="OData.Permission/Read"/>
+          <Annotation Term="OData.Description" String="The total number of Fibre Channel exchanges transmitted."/>
+          <Annotation Term="OData.LongDescription" String="This property shall contain the total number of Fibre Channel exchanges transmitted."/>
+        </Property>
+        <Property Name="RXExchanges" Type="Edm.Int64">
+          <Annotation Term="OData.Permissions" EnumMember="OData.Permission/Read"/>
+          <Annotation Term="OData.Description" String="The total number of Fibre Channel exchanges received."/>
+          <Annotation Term="OData.LongDescription" String="This property shall contain the total number of Fibre Channel exchanges received."/>
+        </Property>
+        <Property Name="RXBBCreditZero" Type="Edm.Int64">
+          <Annotation Term="OData.Permissions" EnumMember="OData.Permission/Read"/>
+          <Annotation Term="OData.Description" String="The number of times the receive buffer-to-buffer credit count transitioned to zero."/>
+          <Annotation Term="OData.LongDescription" String="This property shall contain the number of times the receive buffer-to-buffer credit count transitioned to zero since last counter reset."/>
+        </Property>
+        <Property Name="TXBBCreditZero" Type="Edm.Int64">
+          <Annotation Term="OData.Permissions" EnumMember="OData.Permission/Read"/>
+          <Annotation Term="OData.Description" String="The number of times the transmit buffer-to-buffer credit count transitioned to zero."/>
+          <Annotation Term="OData.LongDescription" String="This property shall contain the number of times the transmit buffer-to-buffer credit count transitioned to zero since last counter reset."/>
+        </Property>
+        <Property Name="TXBBCreditZeroDurationMilliseconds" Type="Edm.Int64">
+          <Annotation Term="OData.Permissions" EnumMember="OData.Permission/Read"/>
+          <Annotation Term="OData.Description" String="The total amount of time the port has been blocked from transmitting due to lack of buffer credits."/>
+          <Annotation Term="OData.LongDescription" String="This property shall contain the total amount of time in milliseconds the port has been blocked from transmitting due to lack of buffer credits since the last counter reset."/>
+          <Annotation Term="Measures.Unit" String="ms"/>
+        </Property>
+        <Property Name="TXBBCredits" Type="Edm.Int64">
+          <Annotation Term="OData.Permissions" EnumMember="OData.Permission/Read"/>
+          <Annotation Term="OData.Description" String="The number of transmit buffer-to-buffer credits the port is configured to use."/>
+          <Annotation Term="OData.LongDescription" String="This property shall contain the number of transmit buffer-to-buffer credits the port is configured to use."/>
+        </Property>
+      </ComplexType>
+    </Schema>
+
+  </edmx:DataServices>
+</edmx:Edmx>

--- a/static/redfish/v1/schema/Port_v1.xml
+++ b/static/redfish/v1/schema/Port_v1.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!---->
 <!--################################################################################       -->
-<!--# Redfish Schema:  Port v1.4.0                                                         -->
+<!--# Redfish Schema:  Port v1.5.0                                                         -->
 <!--#                                                                                      -->
 <!--# For a detailed change log, see the README file contained in the DSP8010 bundle,      -->
 <!--# available at http://www.dmtf.org/standards/redfish                                   -->
@@ -52,6 +52,9 @@
   <edmx:Reference Uri="http://redfish.dmtf.org/schemas/v1/EnvironmentMetrics_v1.xml">
     <edmx:Include Namespace="EnvironmentMetrics"/>
   </edmx:Reference>
+  <edmx:Reference Uri="http://redfish.dmtf.org/schemas/v1/Cable_v1.xml">
+    <edmx:Include Namespace="Cable"/>
+  </edmx:Reference>
 
   <edmx:DataServices>
 
@@ -84,6 +87,7 @@
             <String>/redfish/v1/Systems/{ComputerSystemId}/FabricAdapters/{FabricAdapterId}/Ports/{PortId}</String>
             <String>/redfish/v1/Systems/{ComputerSystemId}/GraphicsControllers/{ControllerId}/Ports/{PortId}</String>
             <String>/redfish/v1/Systems/{ComputerSystemId}/USBControllers/{ControllerId}/Ports/{PortId}</String>
+            <String>/redfish/v1/Systems/{ComputerSystemId}/Processors/{ProcessorId}/Ports/{PortId}</String>
             <String>/redfish/v1/CompositionService/ResourceBlocks/{ResourceBlockId}/Storage/{StorageId}/StorageControllers/{StorageControllerId}/Ports/{PortId}</String>
             <String>/redfish/v1/CompositionService/ResourceBlocks/{ResourceBlockId}/Storage/{StorageId}/Controllers/{StorageControllerId}/Ports/{PortId}</String>
             <String>/redfish/v1/CompositionService/ResourceBlocks/{ResourceBlockId}/Systems/{ComputerSystemId}/Storage/{StorageId}/StorageControllers/{StorageControllerId}/Ports/{PortId}</String>
@@ -367,9 +371,9 @@
           <Annotation Term="OData.LongDescription" String="This property shall contain the desired link state for this interface."/>
         </Property>
         <Property Name="LinkStatus" Type="Port.v1_2_0.LinkStatus" Nullable="false">
-          <Annotation Term="OData.Permissions" EnumMember="OData.Permission/ReadWrite"/>
-          <Annotation Term="OData.Description" String="The desired link status for this interface."/>
-          <Annotation Term="OData.LongDescription" String="This property shall contain the desired link status for this interface."/>
+          <Annotation Term="OData.Permissions" EnumMember="OData.Permission/Read"/>
+          <Annotation Term="OData.Description" String="The link status for this interface."/>
+          <Annotation Term="OData.LongDescription" String="This property shall contain the link status for this interface."/>
         </Property>
         <Property Name="GenZ" Type="Port.v1_2_0.GenZ" Nullable="false">
           <Annotation Term="OData.Description" String="Gen-Z specific properties."/>
@@ -492,6 +496,12 @@
       <EntityType Name="Port" BaseType="Port.v1_2_3.Port"/>
     </Schema>
 
+    <Schema xmlns="http://docs.oasis-open.org/odata/ns/edm" Namespace="Port.v1_2_5">
+      <Annotation Term="Redfish.OwningEntity" String="DMTF"/>
+      <Annotation Term="OData.Description" String="This version was created to correct the permissions for LinkStatus."/>
+      <EntityType Name="Port" BaseType="Port.v1_2_4.Port"/>
+    </Schema>
+
     <Schema xmlns="http://docs.oasis-open.org/odata/ns/edm" Namespace="Port.v1_3_0">
       <Annotation Term="Redfish.OwningEntity" String="DMTF"/>
       <Annotation Term="Redfish.Release" String="2020.3"/>
@@ -551,6 +561,15 @@
           <Annotation Term="OData.Permissions" EnumMember="OData.Permission/Read"/>
           <Annotation Term="OData.Description" String="The set of Ethernet capabilities that this port supports."/>
           <Annotation Term="OData.LongDescription" String="This property shall contain an array of Ethernet capabilities supported by this port."/>
+          <Annotation Term="Redfish.Revisions">
+            <Collection>
+              <Record>
+                <PropertyValue Property="Kind" EnumMember="Redfish.RevisionKind/Deprecated"/>
+                <PropertyValue Property="Version" String="v1_5_0"/>
+                <PropertyValue Property="Description" String="This property has been deprecated in favor of individual fields for the various properties."/>
+              </Record>
+            </Collection>
+          </Annotation>
         </Property>
         <Property Name="FlowControlStatus" Type="Port.v1_3_0.FlowControl">
           <Annotation Term="OData.Permissions" EnumMember="OData.Permission/Read"/>
@@ -585,6 +604,116 @@
         </Member>
         <Member Name="ExtenderFabric">
           <Annotation Term="OData.Description" String="This port connection type is an extender fabric port."/>
+        </Member>
+        <Member Name="FPort">
+          <Annotation Term="OData.Description" String="This port connection type is a fabric port."/>
+          <Annotation Term="Redfish.Revisions">
+            <Collection>
+              <Record>
+                <PropertyValue Property="Kind" EnumMember="Redfish.RevisionKind/Added"/>
+                <PropertyValue Property="Version" String="v1_5_0"/>
+              </Record>
+            </Collection>
+          </Annotation>
+        </Member>
+        <Member Name="EPort">
+          <Annotation Term="OData.Description" String="This port connection type is an extender fabric port."/>
+          <Annotation Term="Redfish.Revisions">
+            <Collection>
+              <Record>
+                <PropertyValue Property="Kind" EnumMember="Redfish.RevisionKind/Added"/>
+                <PropertyValue Property="Version" String="v1_5_0"/>
+              </Record>
+            </Collection>
+          </Annotation>
+        </Member>
+        <Member Name="TEPort">
+          <Annotation Term="OData.Description" String="This port connection type is an trunking extender fabric port."/>
+          <Annotation Term="Redfish.Revisions">
+            <Collection>
+              <Record>
+                <PropertyValue Property="Kind" EnumMember="Redfish.RevisionKind/Added"/>
+                <PropertyValue Property="Version" String="v1_5_0"/>
+              </Record>
+            </Collection>
+          </Annotation>
+        </Member>
+        <Member Name="NPPort">
+          <Annotation Term="OData.Description" String="This port connection type is a proxy N port for N-Port virtualization."/>
+          <Annotation Term="Redfish.Revisions">
+            <Collection>
+              <Record>
+                <PropertyValue Property="Kind" EnumMember="Redfish.RevisionKind/Added"/>
+                <PropertyValue Property="Version" String="v1_5_0"/>
+              </Record>
+            </Collection>
+          </Annotation>
+        </Member>
+        <Member Name="GPort">
+          <Annotation Term="OData.Description" String="This port connection type is a generic fabric port."/>
+          <Annotation Term="Redfish.Revisions">
+            <Collection>
+              <Record>
+                <PropertyValue Property="Kind" EnumMember="Redfish.RevisionKind/Added"/>
+                <PropertyValue Property="Version" String="v1_5_0"/>
+              </Record>
+            </Collection>
+          </Annotation>
+        </Member>
+        <Member Name="NLPort">
+          <Annotation Term="OData.Description" String="This port connects in a node loop configuration."/>
+          <Annotation Term="Redfish.Revisions">
+            <Collection>
+              <Record>
+                <PropertyValue Property="Kind" EnumMember="Redfish.RevisionKind/Added"/>
+                <PropertyValue Property="Version" String="v1_5_0"/>
+              </Record>
+            </Collection>
+          </Annotation>
+        </Member>
+        <Member Name="FLPort">
+          <Annotation Term="OData.Description" String="This port connects in a fabric loop configuration."/>
+          <Annotation Term="Redfish.Revisions">
+            <Collection>
+              <Record>
+                <PropertyValue Property="Kind" EnumMember="Redfish.RevisionKind/Added"/>
+                <PropertyValue Property="Version" String="v1_5_0"/>
+              </Record>
+            </Collection>
+          </Annotation>
+        </Member>
+        <Member Name="EXPort">
+          <Annotation Term="OData.Description" String="This port connection type is an external fabric port."/>
+          <Annotation Term="Redfish.Revisions">
+            <Collection>
+              <Record>
+                <PropertyValue Property="Kind" EnumMember="Redfish.RevisionKind/Added"/>
+                <PropertyValue Property="Version" String="v1_5_0"/>
+              </Record>
+            </Collection>
+          </Annotation>
+        </Member>
+        <Member Name="UPort">
+          <Annotation Term="OData.Description" String="This port connection type is unassigned."/>
+          <Annotation Term="Redfish.Revisions">
+            <Collection>
+              <Record>
+                <PropertyValue Property="Kind" EnumMember="Redfish.RevisionKind/Added"/>
+                <PropertyValue Property="Version" String="v1_5_0"/>
+              </Record>
+            </Collection>
+          </Annotation>
+        </Member>
+        <Member Name="DPort">
+          <Annotation Term="OData.Description" String="This port connection type is a diagnostic port."/>
+          <Annotation Term="Redfish.Revisions">
+            <Collection>
+              <Record>
+                <PropertyValue Property="Kind" EnumMember="Redfish.RevisionKind/Added"/>
+                <PropertyValue Property="Version" String="v1_5_0"/>
+              </Record>
+            </Collection>
+          </Annotation>
         </Member>
       </EnumType>
 
@@ -666,6 +795,12 @@
       <Annotation Term="Redfish.OwningEntity" String="DMTF"/>
       <Annotation Term="OData.Description" String="Clarified that speed properties include protocol overhead."/>
       <EntityType Name="Port" BaseType="Port.v1_3_1.Port"/>
+    </Schema>
+
+    <Schema xmlns="http://docs.oasis-open.org/odata/ns/edm" Namespace="Port.v1_3_3">
+      <Annotation Term="Redfish.OwningEntity" String="DMTF"/>
+      <Annotation Term="OData.Description" String="This version was created to correct the permissions for LinkStatus."/>
+      <EntityType Name="Port" BaseType="Port.v1_3_2.Port"/>
     </Schema>
 
     <Schema xmlns="http://docs.oasis-open.org/odata/ns/edm" Namespace="Port.v1_4_0">
@@ -1001,6 +1136,42 @@
           <Annotation Term="OData.Description" String="The connection is using multi mode operation."/>
         </Member>
       </EnumType>
+    </Schema>
+
+    <Schema xmlns="http://docs.oasis-open.org/odata/ns/edm" Namespace="Port.v1_4_1">
+      <Annotation Term="Redfish.OwningEntity" String="DMTF"/>
+      <Annotation Term="OData.Description" String="This version was created to correct the permissions for LinkStatus."/>
+      <EntityType Name="Port" BaseType="Port.v1_4_0.Port"/>
+    </Schema>
+
+    <Schema xmlns="http://docs.oasis-open.org/odata/ns/edm" Namespace="Port.v1_5_0">
+      <Annotation Term="Redfish.OwningEntity" String="DMTF"/>
+      <Annotation Term="Redfish.Release" String="2021.2"/>
+      <Annotation Term="OData.Description" String="This version was created to add new values to the PortConnectionType property."/>
+
+      <EntityType Name="Port" BaseType="Port.v1_4_1.Port"/>
+
+      <ComplexType Name="EthernetProperties" BaseType="Port.v1_4_0.EthernetProperties">
+        <Property Name="WakeOnLANEnabled" Type="Edm.Boolean">
+          <Annotation Term="OData.Permissions" EnumMember="OData.Permission/ReadWrite"/>
+          <Annotation Term="OData.Description" String="Indicates whether Wake on LAN (WoL) is enabled on this port."/>
+          <Annotation Term="OData.LongDescription" String="This property shall indicate whether Wake on LAN (WoL) is enabled on this port."/>
+        </Property>
+        <Property Name="EEEEnabled" Type="Edm.Boolean">
+          <Annotation Term="OData.Permissions" EnumMember="OData.Permission/ReadWrite"/>
+          <Annotation Term="OData.Description" String="Indicates whether IEEE 802.3az Energy-Efficient Ethernet (EEE) is enabled on this port."/>
+          <Annotation Term="OData.LongDescription" String="This property shall indicate whether IEEE 802.3az Energy-Efficient Ethernet (EEE) is enabled on this port."/>
+        </Property>
+      </ComplexType>
+
+      <ComplexType Name="Links" BaseType="Port.v1_2_0.Links">
+        <NavigationProperty Name="Cables" Type="Collection(Cable.Cable)">
+          <Annotation Term="OData.Permissions" EnumMember="OData.Permission/Read"/>
+          <Annotation Term="OData.Description" String="An array of links to the cables connected to this port."/>
+          <Annotation Term="OData.LongDescription" String="This property shall contain an array of links to resources of type Cable that represent the cables connected to this port."/>
+          <Annotation Term="OData.AutoExpandReferences"/>
+        </NavigationProperty>
+      </ComplexType>
     </Schema>
 
   </edmx:DataServices>

--- a/static/redfish/v1/schema/PowerDistributionCollection_v1.xml
+++ b/static/redfish/v1/schema/PowerDistributionCollection_v1.xml
@@ -1,0 +1,73 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!---->
+<!--################################################################################       -->
+<!--# Redfish Schema:  PowerDistributionCollection                                         -->
+<!--#                                                                                      -->
+<!--# For a detailed change log, see the README file contained in the DSP8010 bundle,      -->
+<!--# available at http://www.dmtf.org/standards/redfish                                   -->
+<!--# Copyright 2014-2021 DMTF.                                                            -->
+<!--# For the full DMTF copyright policy, see http://www.dmtf.org/about/policies/copyright -->
+<!--################################################################################       -->
+<!---->
+<edmx:Edmx xmlns:edmx="http://docs.oasis-open.org/odata/ns/edmx" Version="4.0">
+
+  <edmx:Reference Uri="http://docs.oasis-open.org/odata/odata/v4.0/errata03/csd01/complete/vocabularies/Org.OData.Core.V1.xml">
+    <edmx:Include Namespace="Org.OData.Core.V1" Alias="OData"/>
+  </edmx:Reference>
+  <edmx:Reference Uri="http://docs.oasis-open.org/odata/odata/v4.0/errata03/csd01/complete/vocabularies/Org.OData.Capabilities.V1.xml">
+    <edmx:Include Namespace="Org.OData.Capabilities.V1" Alias="Capabilities"/>
+  </edmx:Reference>
+  <edmx:Reference Uri="http://redfish.dmtf.org/schemas/v1/RedfishExtensions_v1.xml">
+    <edmx:Include Namespace="RedfishExtensions.v1_0_0" Alias="Redfish"/>
+  </edmx:Reference>
+  <edmx:Reference Uri="http://redfish.dmtf.org/schemas/v1/Resource_v1.xml">
+    <edmx:Include Namespace="Resource.v1_0_0"/>
+  </edmx:Reference>
+  <edmx:Reference Uri="http://redfish.dmtf.org/schemas/v1/PowerDistribution_v1.xml">
+    <edmx:Include Namespace="PowerDistribution"/>
+  </edmx:Reference>
+
+  <edmx:DataServices>
+
+    <Schema xmlns="http://docs.oasis-open.org/odata/ns/edm" Namespace="PowerDistributionCollection">
+      <Annotation Term="Redfish.OwningEntity" String="DMTF"/>
+
+      <EntityType Name="PowerDistributionCollection" BaseType="Resource.v1_0_0.ResourceCollection">
+        <Annotation Term="OData.Description" String="The collection of PowerDistribution resource instances."/>
+        <Annotation Term="OData.LongDescription" String="This resource shall represent a resource collection of PowerDistribution instances for a Redfish implementation."/>
+        <Annotation Term="Capabilities.InsertRestrictions">
+          <Record>
+            <PropertyValue Property="Insertable" Bool="false"/>
+          </Record>
+        </Annotation>
+        <Annotation Term="Capabilities.UpdateRestrictions">
+          <Record>
+            <PropertyValue Property="Updatable" Bool="false"/>
+          </Record>
+        </Annotation>
+        <Annotation Term="Capabilities.DeleteRestrictions">
+          <Record>
+            <PropertyValue Property="Deletable" Bool="false"/>
+          </Record>
+        </Annotation>
+        <Annotation Term="Redfish.Uris">
+          <Collection>
+            <String>/redfish/v1/PowerEquipment/FloorPDUs</String>
+            <String>/redfish/v1/PowerEquipment/RackPDUs</String>
+            <String>/redfish/v1/PowerEquipment/Switchgear</String>
+            <String>/redfish/v1/PowerEquipment/TransferSwitches</String>
+            <String>/redfish/v1/PowerEquipment/PowerShelves</String>
+          </Collection>
+        </Annotation>
+        <NavigationProperty Name="Members" Type="Collection(PowerDistribution.PowerDistribution)">
+          <Annotation Term="OData.Permissions" EnumMember="OData.Permission/Read"/>
+          <Annotation Term="OData.Description" String="The members of this collection."/>
+          <Annotation Term="OData.LongDescription" String="This property shall contain an array of links to the members of this collection."/>
+          <Annotation Term="OData.AutoExpandReferences"/>
+          <Annotation Term="Redfish.Required"/>
+        </NavigationProperty>
+      </EntityType>
+    </Schema>
+
+  </edmx:DataServices>
+</edmx:Edmx>

--- a/static/redfish/v1/schema/PowerDistributionMetrics_v1.xml
+++ b/static/redfish/v1/schema/PowerDistributionMetrics_v1.xml
@@ -1,0 +1,150 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!---->
+<!--################################################################################       -->
+<!--# Redfish Schema:  PowerDistributionMetrics v1.2.0                                     -->
+<!--#                                                                                      -->
+<!--# For a detailed change log, see the README file contained in the DSP8010 bundle,      -->
+<!--# available at http://www.dmtf.org/standards/redfish                                   -->
+<!--# Copyright 2014-2021 DMTF.                                                            -->
+<!--# For the full DMTF copyright policy, see http://www.dmtf.org/about/policies/copyright -->
+<!--################################################################################       -->
+<!---->
+<edmx:Edmx xmlns:edmx="http://docs.oasis-open.org/odata/ns/edmx" Version="4.0">
+
+  <edmx:Reference Uri="http://docs.oasis-open.org/odata/odata/v4.0/errata03/csd01/complete/vocabularies/Org.OData.Core.V1.xml">
+    <edmx:Include Namespace="Org.OData.Core.V1" Alias="OData"/>
+  </edmx:Reference>
+  <edmx:Reference Uri="http://docs.oasis-open.org/odata/odata/v4.0/errata03/csd01/complete/vocabularies/Org.OData.Capabilities.V1.xml">
+    <edmx:Include Namespace="Org.OData.Capabilities.V1" Alias="Capabilities"/>
+  </edmx:Reference>
+  <edmx:Reference Uri="http://redfish.dmtf.org/schemas/v1/RedfishExtensions_v1.xml">
+    <edmx:Include Namespace="RedfishExtensions.v1_0_0" Alias="Redfish"/>
+  </edmx:Reference>
+  <edmx:Reference Uri="http://redfish.dmtf.org/schemas/v1/Resource_v1.xml">
+    <edmx:Include Namespace="Resource.v1_0_0"/>
+  </edmx:Reference>
+  <edmx:Reference Uri="http://redfish.dmtf.org/schemas/v1/Sensor_v1.xml">
+    <edmx:Include Namespace="Sensor"/>
+  </edmx:Reference>
+
+  <edmx:DataServices>
+
+    <Schema xmlns="http://docs.oasis-open.org/odata/ns/edm" Namespace="PowerDistributionMetrics">
+      <Annotation Term="Redfish.OwningEntity" String="DMTF"/>
+
+      <EntityType Name="PowerDistributionMetrics" BaseType="Resource.v1_0_0.Resource" Abstract="true">
+        <Annotation Term="OData.Description" String="This is the schema definition for the metrics of a power distribution component or unit, such as a floor power distribution unit (PDU) or switchgear."/>
+        <Annotation Term="OData.LongDescription" String="This resource shall be used to represent the metrics of a power distribution component or unit for a Redfish implementation."/>
+        <Annotation Term="OData.AdditionalProperties" Bool="false"/>
+        <Annotation Term="Capabilities.InsertRestrictions">
+          <Record>
+            <PropertyValue Property="Insertable" Bool="false"/>
+          </Record>
+        </Annotation>
+        <Annotation Term="Capabilities.UpdateRestrictions">
+          <Record>
+            <PropertyValue Property="Updatable" Bool="false"/>
+          </Record>
+        </Annotation>
+        <Annotation Term="Capabilities.DeleteRestrictions">
+          <Record>
+            <PropertyValue Property="Deletable" Bool="false"/>
+          </Record>
+        </Annotation>
+        <Annotation Term="Redfish.Uris">
+          <Collection>
+            <String>/redfish/v1/PowerEquipment/RackPDUs/{PowerDistributionId}/Metrics</String>
+            <String>/redfish/v1/PowerEquipment/FloorPDUs/{PowerDistributionId}/Metrics</String>
+            <String>/redfish/v1/PowerEquipment/TransferSwitches/{PowerDistributionId}/Metrics</String>
+            <String>/redfish/v1/PowerEquipment/PowerShelves/{PowerDistributionId}/Metrics</String>
+          </Collection>
+        </Annotation>
+      </EntityType>
+
+      <Action Name="ResetMetrics" IsBound="true">
+        <Parameter Name="PowerDistributionMetrics" Type="PowerDistributionMetrics.v1_0_0.Actions"/>
+        <Annotation Term="OData.Description" String="This action resets the summary metrics related to this equipment."/>
+        <Annotation Term="OData.LongDescription" String="This action shall reset any time intervals or counted values for this equipment."/>
+      </Action>
+    </Schema>
+
+    <Schema xmlns="http://docs.oasis-open.org/odata/ns/edm" Namespace="PowerDistributionMetrics.v1_0_0">
+      <Annotation Term="Redfish.OwningEntity" String="DMTF"/>
+      <Annotation Term="Redfish.Release" String="2019.4"/>
+
+      <EntityType Name="PowerDistributionMetrics" BaseType="PowerDistributionMetrics.PowerDistributionMetrics">
+        <NavigationProperty Name="PowerWatts" Type="Sensor.Sensor">
+          <Annotation Term="Redfish.ExcerptCopy" String="Power"/>
+          <Annotation Term="OData.Description" String="Power consumption (Watts)."/>
+          <Annotation Term="OData.LongDescription" String="This property shall contain the total power, measured in Watts, for this unit, that represents the `Total` ElectricalContext sensor when multiple power sensors exist."/>
+        </NavigationProperty>
+
+        <NavigationProperty Name="EnergykWh" Type="Sensor.Sensor">
+          <Annotation Term="Redfish.ExcerptCopy" String="EnergykWh"/>
+          <Annotation Term="OData.Description" String="Energy consumption (kWh)."/>
+          <Annotation Term="OData.LongDescription" String="This property shall contain the total energy, measured in kilowatt-hours (kWh), for this unit, that represents the `Total` ElectricalContext sensor when multiple energy sensors exist."/>
+        </NavigationProperty>
+
+        <Property Name="Actions" Type="PowerDistributionMetrics.v1_0_0.Actions" Nullable="false">
+          <Annotation Term="OData.Description" String="The available actions for this resource."/>
+          <Annotation Term="OData.LongDescription" String="This property shall contain the available actions for this resource."/>
+        </Property>
+      </EntityType>
+
+      <ComplexType Name="Actions">
+        <Annotation Term="OData.AdditionalProperties" Bool="false"/>
+        <Annotation Term="OData.Description" String="The available actions for this resource."/>
+        <Annotation Term="OData.LongDescription" String="This type shall contain the available actions for this resource."/>
+        <Property Name="Oem" Type="PowerDistributionMetrics.v1_0_0.OemActions" Nullable="false">
+          <Annotation Term="OData.Description" String="The available OEM-specific actions for this resource."/>
+          <Annotation Term="OData.LongDescription" String="This property shall contain the available OEM-specific actions for this resource."/>
+        </Property>
+      </ComplexType>
+
+      <ComplexType Name="OemActions">
+        <Annotation Term="OData.AdditionalProperties" Bool="true"/>
+        <Annotation Term="OData.Description" String="The available OEM-specific actions for this resource."/>
+        <Annotation Term="OData.LongDescription" String="This type shall contain the available OEM-specific actions for this resource."/>
+      </ComplexType>
+    </Schema>
+
+    <Schema xmlns="http://docs.oasis-open.org/odata/ns/edm" Namespace="PowerDistributionMetrics.v1_0_1">
+      <Annotation Term="Redfish.OwningEntity" String="DMTF"/>
+      <Annotation Term="OData.Description" String="This version was created to update the descriptions for Power and Energy sensors."/>
+      <EntityType Name="PowerDistributionMetrics" BaseType="PowerDistributionMetrics.v1_0_0.PowerDistributionMetrics"/>
+    </Schema>
+
+    <Schema xmlns="http://docs.oasis-open.org/odata/ns/edm" Namespace="PowerDistributionMetrics.v1_1_0">
+      <Annotation Term="Redfish.OwningEntity" String="DMTF"/>
+      <Annotation Term="Redfish.Release" String="2021.1"/>
+
+      <EntityType Name="PowerDistributionMetrics" BaseType="PowerDistributionMetrics.v1_0_1.PowerDistributionMetrics">
+        <NavigationProperty Name="TemperatureCelsius" Type="Sensor.Sensor">
+          <Annotation Term="Redfish.ExcerptCopy"/>
+          <Annotation Term="OData.Description" String="Temperature (Celsius)."/>
+          <Annotation Term="OData.LongDescription" String="This property shall contain the temperature sensor reading for this resource."/>
+        </NavigationProperty>
+        <NavigationProperty Name="HumidityPercent" Type="Sensor.Sensor">
+          <Annotation Term="Redfish.ExcerptCopy"/>
+          <Annotation Term="OData.Description" String="Humidity (percent)."/>
+          <Annotation Term="OData.LongDescription" String="This property shall contain the humidity sensor reading for this resource."/>
+        </NavigationProperty>
+      </EntityType>
+    </Schema>
+
+    <Schema xmlns="http://docs.oasis-open.org/odata/ns/edm" Namespace="PowerDistributionMetrics.v1_2_0">
+      <Annotation Term="Redfish.OwningEntity" String="DMTF"/>
+      <Annotation Term="Redfish.Release" String="2021.2"/>
+      <Annotation Term="OData.Description" String="This version was created to add PowerLoadPercent."/>
+
+      <EntityType Name="PowerDistributionMetrics" BaseType="PowerDistributionMetrics.v1_1_0.PowerDistributionMetrics">
+        <NavigationProperty Name="PowerLoadPercent" Type="Sensor.Sensor">
+          <Annotation Term="Redfish.ExcerptCopy"/>
+          <Annotation Term="OData.Description" String="The power load (%) for this equipment."/>
+          <Annotation Term="OData.LongDescription" String="This property shall contain the power load, measured in percent, for this equipment, that represents the `Total` ElectricalContext for this equipment."/>
+        </NavigationProperty>
+      </EntityType>
+    </Schema>
+
+  </edmx:DataServices>
+</edmx:Edmx>

--- a/static/redfish/v1/schema/PowerDistribution_v1.xml
+++ b/static/redfish/v1/schema/PowerDistribution_v1.xml
@@ -1,0 +1,454 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!---->
+<!--################################################################################       -->
+<!--# Redfish Schema:  PowerDistribution v1.1.0                                            -->
+<!--#                                                                                      -->
+<!--# For a detailed change log, see the README file contained in the DSP8010 bundle,      -->
+<!--# available at http://www.dmtf.org/standards/redfish                                   -->
+<!--# Copyright 2014-2021 DMTF.                                                            -->
+<!--# For the full DMTF copyright policy, see http://www.dmtf.org/about/policies/copyright -->
+<!--################################################################################       -->
+<!---->
+<edmx:Edmx xmlns:edmx="http://docs.oasis-open.org/odata/ns/edmx" Version="4.0">
+
+  <edmx:Reference Uri="http://docs.oasis-open.org/odata/odata/v4.0/errata03/csd01/complete/vocabularies/Org.OData.Core.V1.xml">
+    <edmx:Include Namespace="Org.OData.Core.V1" Alias="OData"/>
+  </edmx:Reference>
+  <edmx:Reference Uri="http://docs.oasis-open.org/odata/odata/v4.0/errata03/csd01/complete/vocabularies/Org.OData.Capabilities.V1.xml">
+    <edmx:Include Namespace="Org.OData.Capabilities.V1" Alias="Capabilities"/>
+  </edmx:Reference>
+  <edmx:Reference Uri="http://docs.oasis-open.org/odata/odata/v4.0/errata03/csd01/complete/vocabularies/Org.OData.Measures.V1.xml">
+    <edmx:Include Namespace="Org.OData.Measures.V1" Alias="Measures"/>
+  </edmx:Reference>
+  <edmx:Reference Uri="http://redfish.dmtf.org/schemas/v1/RedfishExtensions_v1.xml">
+    <edmx:Include Namespace="RedfishExtensions.v1_0_0" Alias="Redfish"/>
+    <edmx:Include Namespace="Validation.v1_0_0" Alias="Validation"/>
+  </edmx:Reference>
+  <edmx:Reference Uri="http://redfish.dmtf.org/schemas/v1/Resource_v1.xml">
+    <edmx:Include Namespace="Resource"/>
+    <edmx:Include Namespace="Resource.v1_0_0"/>
+  </edmx:Reference>
+  <edmx:Reference Uri="http://redfish.dmtf.org/schemas/v1/Chassis_v1.xml">
+    <edmx:Include Namespace="Chassis"/>
+  </edmx:Reference>
+  <edmx:Reference Uri="http://redfish.dmtf.org/schemas/v1/Manager_v1.xml">
+    <edmx:Include Namespace="Manager"/>
+  </edmx:Reference>
+  <edmx:Reference Uri="http://redfish.dmtf.org/schemas/v1/Facility_v1.xml">
+    <edmx:Include Namespace="Facility"/>
+  </edmx:Reference>
+  <edmx:Reference Uri="http://redfish.dmtf.org/schemas/v1/SensorCollection_v1.xml">
+    <edmx:Include Namespace="SensorCollection"/>
+  </edmx:Reference>
+  <edmx:Reference Uri="http://redfish.dmtf.org/schemas/v1/CircuitCollection_v1.xml">
+    <edmx:Include Namespace="CircuitCollection"/>
+  </edmx:Reference>
+  <edmx:Reference Uri="http://redfish.dmtf.org/schemas/v1/OutletCollection_v1.xml">
+    <edmx:Include Namespace="OutletCollection"/>
+  </edmx:Reference>
+  <edmx:Reference Uri="http://redfish.dmtf.org/schemas/v1/OutletGroupCollection_v1.xml">
+    <edmx:Include Namespace="OutletGroupCollection"/>
+  </edmx:Reference>
+  <edmx:Reference Uri="http://redfish.dmtf.org/schemas/v1/PowerDistributionMetrics_v1.xml">
+    <edmx:Include Namespace="PowerDistributionMetrics"/>
+  </edmx:Reference>
+  <edmx:Reference Uri="http://redfish.dmtf.org/schemas/v1/PowerSupplyCollection_v1.xml">
+    <edmx:Include Namespace="PowerSupplyCollection"/>
+  </edmx:Reference>
+  <edmx:Reference Uri="http://redfish.dmtf.org/schemas/v1/Redundancy_v1.xml">
+    <edmx:Include Namespace="Redundancy"/>
+  </edmx:Reference>
+
+  <edmx:DataServices>
+
+    <Schema xmlns="http://docs.oasis-open.org/odata/ns/edm" Namespace="PowerDistribution">
+      <Annotation Term="Redfish.OwningEntity" String="DMTF"/>
+
+      <EntityType Name="PowerDistribution" BaseType="Resource.v1_0_0.Resource" Abstract="true">
+        <Annotation Term="OData.Description" String="This is the schema definition for a power distribution component or unit, such as a floor power distribution unit (PDU) or switchgear."/>
+        <Annotation Term="OData.LongDescription" String="This resource shall be used to represent a power distribution component or unit for a Redfish implementation."/>
+        <Annotation Term="OData.AdditionalProperties" Bool="false"/>
+        <Annotation Term="Capabilities.InsertRestrictions">
+          <Record>
+            <PropertyValue Property="Insertable" Bool="false"/>
+          </Record>
+        </Annotation>
+        <Annotation Term="Capabilities.UpdateRestrictions">
+          <Record>
+            <PropertyValue Property="Updatable" Bool="true"/>
+            <Annotation Term="OData.Description" String="Any writable properties can be updated."/>
+          </Record>
+        </Annotation>
+        <Annotation Term="Capabilities.DeleteRestrictions">
+          <Record>
+            <PropertyValue Property="Deletable" Bool="false"/>
+          </Record>
+        </Annotation>
+        <Annotation Term="Redfish.Uris">
+          <Collection>
+            <String>/redfish/v1/PowerEquipment/RackPDUs/{PowerDistributionId}</String>
+            <String>/redfish/v1/PowerEquipment/FloorPDUs/{PowerDistributionId}</String>
+            <String>/redfish/v1/PowerEquipment/TransferSwitches/{PowerDistributionId}</String>
+            <String>/redfish/v1/PowerEquipment/PowerShelves/{PowerDistributionId}</String>
+          </Collection>
+        </Annotation>
+      </EntityType>
+
+      <Action Name="TransferControl" IsBound="true">
+        <Parameter Name="PowerDistribution" Type="PowerDistribution.v1_0_0.Actions"/>
+        <Annotation Term="OData.Description" String="This action transfers control to the alternative input circuit."/>
+        <Annotation Term="OData.LongDescription" String="This action shall transfer power input from the existing mains circuit to the alternative mains circuit."/>
+      </Action>
+    </Schema>
+
+    <Schema xmlns="http://docs.oasis-open.org/odata/ns/edm" Namespace="PowerDistribution.v1_0_0">
+      <Annotation Term="Redfish.OwningEntity" String="DMTF"/>
+      <Annotation Term="Redfish.Release" String="2019.4"/>
+
+      <EntityType Name="PowerDistribution" BaseType="PowerDistribution.PowerDistribution">
+        <Property Name="EquipmentType" Nullable="false" Type="PowerDistribution.v1_0_0.PowerEquipmentType">
+          <Annotation Term="OData.Permissions" EnumMember="OData.Permission/Read"/>
+          <Annotation Term="OData.Description" String="The type of equipment this resource represents."/>
+          <Annotation Term="OData.LongDescription" String="This property shall contain the type of equipment this resource represents."/>
+          <Annotation Term="Redfish.Required"/>
+        </Property>
+        <Property Name="Model" Type="Edm.String">
+          <Annotation Term="OData.Permissions" EnumMember="OData.Permission/Read"/>
+          <Annotation Term="OData.Description" String="The product model number of this equipment."/>
+          <Annotation Term="OData.LongDescription" String="This property shall contain the manufacturer-provided model information of this equipment."/>
+        </Property>
+        <Property Name="Manufacturer" Type="Edm.String">
+          <Annotation Term="OData.Permissions" EnumMember="OData.Permission/Read"/>
+          <Annotation Term="OData.Description" String="The manufacturer of this equipment."/>
+          <Annotation Term="OData.LongDescription" String="This property shall contain the name of the organization responsible for producing the equipment.  This organization may be the entity from which the equipment is purchased, but this is not necessarily true."/>
+        </Property>
+        <Property Name="SerialNumber" Type="Edm.String">
+          <Annotation Term="OData.Permissions" EnumMember="OData.Permission/Read"/>
+          <Annotation Term="OData.Description" String="The serial number for this equipment."/>
+          <Annotation Term="OData.LongDescription" String="This property shall contain a manufacturer-allocated number that identifies the equipment."/>
+        </Property>
+        <Property Name="PartNumber" Type="Edm.String">
+          <Annotation Term="OData.Permissions" EnumMember="OData.Permission/Read"/>
+          <Annotation Term="OData.Description" String="The part number for this equipment."/>
+          <Annotation Term="OData.LongDescription" String="This property shall contain the manufacturer-provided part number for the equipment."/>
+        </Property>
+        <Property Name="Version" Type="Edm.String">
+          <Annotation Term="OData.Permissions" EnumMember="OData.Permission/Read"/>
+          <Annotation Term="OData.Description" String="The hardware version of this equipment."/>
+          <Annotation Term="OData.LongDescription" String="This property shall contain the hardware version of this equipment as determined by the vendor or supplier."/>
+        </Property>
+        <Property Name="FirmwareVersion" Type="Edm.String" Nullable="false">
+          <Annotation Term="OData.Permissions" EnumMember="OData.Permission/Read"/>
+          <Annotation Term="OData.Description" String="The firmware version of this equipment."/>
+          <Annotation Term="OData.LongDescription" String="This property shall contain a string describing the firmware version of this equipment as provided by the manufacturer."/>
+        </Property>
+        <Property Name="ProductionDate" Type="Edm.DateTimeOffset">
+          <Annotation Term="OData.Permissions" EnumMember="OData.Permission/Read"/>
+          <Annotation Term="OData.Description" String="The production or manufacturing date of this equipment."/>
+          <Annotation Term="OData.LongDescription" String="This property shall contain the date of production or manufacture for this equipment."/>
+        </Property>
+        <Property Name="AssetTag" Type="Edm.String">
+          <Annotation Term="OData.Permissions" EnumMember="OData.Permission/ReadWrite"/>
+          <Annotation Term="OData.Description" String="The user-assigned asset tag for this equipment."/>
+          <Annotation Term="OData.LongDescription" String="This property shall contain the user-assigned asset tag, which is an identifying string that tracks the equipment for inventory purposes."/>
+        </Property>
+        <Property Name="UUID" Type="Resource.UUID">
+          <Annotation Term="OData.Permissions" EnumMember="OData.Permission/Read"/>
+          <Annotation Term="OData.Description" String="The UUID for this equipment."/>
+          <Annotation Term="OData.LongDescription" String="This property shall contain the UUID for the equipment."/>
+        </Property>
+        <Property Name="Location" Type="Resource.Location" Nullable="false">
+          <Annotation Term="OData.Description" String="The location of the equipment."/>
+          <Annotation Term="OData.LongDescription" String="This property shall contain location information of the associated equipment."/>
+        </Property>
+        <Property Name="TransferConfiguration" Type="PowerDistribution.v1_0_0.TransferConfiguration">
+          <Annotation Term="OData.Description" String="The configuration settings for an automatic transfer switch."/>
+          <Annotation Term="OData.LongDescription" String="This property shall contain the configuration information regarding an automatic transfer switch function for this resource."/>
+        </Property>
+        <Property Name="TransferCriteria" Type="PowerDistribution.v1_0_0.TransferCriteria">
+          <Annotation Term="OData.Description" String="The criteria used to initiate a transfer for an automatic transfer switch."/>
+          <Annotation Term="OData.LongDescription" String="This property shall contain the criteria for initiating a transfer within an automatic transfer switch function for this resource."/>
+        </Property>
+
+        <NavigationProperty Name="Sensors" Type="SensorCollection.SensorCollection" Nullable="false">
+          <Annotation Term="OData.Permissions" EnumMember="OData.Permission/Read"/>
+          <Annotation Term="OData.Description" String="A link to the collection of sensors located in the equipment and sub-components."/>
+          <Annotation Term="OData.LongDescription" String="This property shall be a link to a resource collection of type SensorCollection that contains the sensors located in the equipment and sub-components."/>
+          <Annotation Term="OData.AutoExpandReferences"/>
+        </NavigationProperty>
+
+        <Property Name="Status" Type="Resource.Status" Nullable="false">
+          <Annotation Term="OData.Description" String="The status and health of the resource and its subordinate or dependent resources."/>
+          <Annotation Term="OData.LongDescription" String="This property shall contain any status or health properties of the resource."/>
+        </Property>
+
+        <NavigationProperty Name="Mains" Type="CircuitCollection.CircuitCollection" Nullable="false">
+          <Annotation Term="OData.Permissions" EnumMember="OData.Permission/Read"/>
+          <Annotation Term="OData.Description" String="A link to the power input circuits for this equipment."/>
+          <Annotation Term="OData.LongDescription" String="This property shall contain a link to a resource collection of type CircuitCollection that contains the power input circuits for this equipment."/>
+          <Annotation Term="OData.AutoExpandReferences"/>
+        </NavigationProperty>
+
+        <NavigationProperty Name="Branches" Type="CircuitCollection.CircuitCollection" Nullable="false">
+          <Annotation Term="OData.Permissions" EnumMember="OData.Permission/Read"/>
+          <Annotation Term="OData.Description" String="A link to the branch circuits for this equipment."/>
+          <Annotation Term="OData.LongDescription" String="This property shall contain a link to a resource collection of type CircuitCollection that contains the branch circuits for this equipment."/>
+          <Annotation Term="OData.AutoExpandReferences"/>
+        </NavigationProperty>
+
+        <NavigationProperty Name="Feeders" Type="CircuitCollection.CircuitCollection" Nullable="false">
+          <Annotation Term="OData.Permissions" EnumMember="OData.Permission/Read"/>
+          <Annotation Term="OData.Description" String="A link to the feeder circuits for this equipment."/>
+          <Annotation Term="OData.LongDescription" String="This property shall contain a link to a resource collection of type CircuitCollection that contains the feeder circuits for this equipment."/>
+          <Annotation Term="OData.AutoExpandReferences"/>
+        </NavigationProperty>
+
+        <NavigationProperty Name="Subfeeds" Type="CircuitCollection.CircuitCollection" Nullable="false">
+          <Annotation Term="OData.Permissions" EnumMember="OData.Permission/Read"/>
+          <Annotation Term="OData.Description" String="A link to the subfeed circuits for this equipment."/>
+          <Annotation Term="OData.LongDescription" String="This property shall contain a link to a resource collection of type CircuitCollection that contains the subfeed circuits for this equipment."/>
+          <Annotation Term="OData.AutoExpandReferences"/>
+        </NavigationProperty>
+
+        <NavigationProperty Name="Outlets" Type="OutletCollection.OutletCollection" Nullable="false">
+          <Annotation Term="OData.Permissions" EnumMember="OData.Permission/Read"/>
+          <Annotation Term="OData.Description" String="A link to the outlets for this equipment."/>
+          <Annotation Term="OData.LongDescription" String="This property shall contain a link to a resource collection of type OutletCollection that contains the outlets for this equipment."/>
+          <Annotation Term="OData.AutoExpandReferences"/>
+        </NavigationProperty>
+
+        <NavigationProperty Name="OutletGroups" Type="OutletGroupCollection.OutletGroupCollection" Nullable="false">
+          <Annotation Term="OData.Permissions" EnumMember="OData.Permission/Read"/>
+          <Annotation Term="OData.Description" String="A link to the outlet groups for this equipment."/>
+          <Annotation Term="OData.LongDescription" String="This property shall contain a link to a resource collection of type OutletCollection that contains the outlet groups for this equipment."/>
+          <Annotation Term="OData.AutoExpandReferences"/>
+        </NavigationProperty>
+
+        <NavigationProperty Name="Metrics" Type="PowerDistributionMetrics.PowerDistributionMetrics" Nullable="false">
+          <Annotation Term="OData.Permissions" EnumMember="OData.Permission/Read"/>
+          <Annotation Term="OData.Description" String="A link to the summary metrics for this equipment."/>
+          <Annotation Term="OData.LongDescription" String="This property shall contain a link to a resource of type PowerDistributionMetrics."/>
+          <Annotation Term="OData.AutoExpandReferences"/>
+        </NavigationProperty>
+
+        <Property Name="Links" Type="PowerDistribution.v1_0_0.Links" Nullable="false">
+          <Annotation Term="OData.Description" String="The links to other resources that are related to this resource."/>
+          <Annotation Term="OData.LongDescription" String="This property shall contain links to resources that are related to but are not contained by, or subordinate to, this resource."/>
+        </Property>
+
+        <Property Name="Actions" Type="PowerDistribution.v1_0_0.Actions" Nullable="false">
+          <Annotation Term="OData.Description" String="The available actions for this resource."/>
+          <Annotation Term="OData.LongDescription" String="This property shall contain the available actions for this resource."/>
+        </Property>
+      </EntityType>
+
+      <ComplexType Name="Links" BaseType="Resource.Links">
+        <Annotation Term="OData.Description" String="The links to other resources that are related to this resource."/>
+        <Annotation Term="OData.LongDescription" String="This Redfish Specification-described type shall contain links to resources that are related to but are not contained by, or subordinate to, this resource."/>
+        <NavigationProperty Name="Chassis" Type="Collection(Chassis.Chassis)">
+          <Annotation Term="OData.Permissions" EnumMember="OData.Permission/Read"/>
+          <Annotation Term="OData.Description" String="An array of links to the chassis that contain this equipment."/>
+          <Annotation Term="OData.LongDescription" String="This property shall contain an array of links to resources of type Chassis that represents the physical container associated with this resource.  This property should only be populated for modular and/or multi-chassis power distribution equipment."/>
+          <Annotation Term="OData.AutoExpandReferences"/>
+        </NavigationProperty>
+        <NavigationProperty Name="Facility" Type="Facility.Facility" Nullable="false">
+          <Annotation Term="OData.Permissions" EnumMember="OData.Permission/Read"/>
+          <Annotation Term="OData.Description" String="A link to the facility that contains this equipment."/>
+          <Annotation Term="OData.LongDescription" String="This property shall contain a link to a resource of type Facility that represents the facility that contains this equipment."/>
+          <Annotation Term="OData.AutoExpandReferences"/>
+        </NavigationProperty>
+        <NavigationProperty Name="ManagedBy" Type="Collection(Manager.Manager)">
+          <Annotation Term="OData.Permissions" EnumMember="OData.Permission/Read"/>
+          <Annotation Term="OData.Description" String="An array of links to the managers responsible for managing this equipment."/>
+          <Annotation Term="OData.LongDescription" String="This property shall contain an array of links to resources of type Manager that represent the managers that manage this equipment."/>
+          <Annotation Term="OData.AutoExpandReferences"/>
+        </NavigationProperty>
+      </ComplexType>
+
+      <EnumType Name="PowerEquipmentType">
+        <Member Name="RackPDU">
+          <Annotation Term="OData.Description" String="A power distribution unit providing outlets for a rack or similar quantity of devices."/>
+        </Member>
+        <Member Name="FloorPDU">
+          <Annotation Term="OData.Description" String="A power distribution unit providing feeder circuits for further power distribution."/>
+        </Member>
+        <Member Name="ManualTransferSwitch">
+          <Annotation Term="OData.Description" String="A manual power transfer switch."/>
+        </Member>
+        <Member Name="AutomaticTransferSwitch">
+          <Annotation Term="OData.Description" String="An automatic power transfer switch."/>
+        </Member>
+        <Member Name="Switchgear">
+          <Annotation Term="OData.Description" String="Electrical switchgear."/>
+        </Member>
+        <Member Name="PowerShelf">
+          <Annotation Term="OData.Description" String="A power shelf."/>
+          <Annotation Term="Redfish.Revisions">
+            <Collection>
+              <Record>
+                <PropertyValue Property="Kind" EnumMember="Redfish.RevisionKind/Added"/>
+                <PropertyValue Property="Version" String="v1_1_0"/>
+              </Record>
+            </Collection>
+          </Annotation>
+        </Member>
+      </EnumType>
+
+      <ComplexType Name="TransferConfiguration">
+        <Annotation Term="OData.AdditionalProperties" Bool="false"/>
+        <Annotation Term="OData.Description" String="The configuration settings for an automatic transfer switch."/>
+        <Annotation Term="OData.LongDescription" String="This type shall contain the configuration information regarding an automatic transfer switch function for this resource."/>
+        <Property Name="ActiveMainsId" Type="Edm.String">
+          <Annotation Term="OData.Permissions" EnumMember="OData.Permission/ReadWrite"/>
+          <Annotation Term="OData.Description" String="The mains circuit that is switched on and qualified to supply power to the output circuit."/>
+          <Annotation Term="OData.LongDescription" String="This property shall contain the mains circuit that is switched on and qualified to supply power to the output circuit.  The value shall be a string that matches the Id property value of a circuit contained in the collection referenced by the Mains property."/>
+        </Property>
+        <Property Name="AutoTransferEnabled" Type="Edm.Boolean">
+          <Annotation Term="OData.Permissions" EnumMember="OData.Permission/ReadWrite"/>
+          <Annotation Term="OData.Description" String="Indicates if the qualified alternate mains circuit is automatically switched on when the preferred mains circuit becomes unqualified and is automatically switched off."/>
+          <Annotation Term="OData.LongDescription" String="This property shall indicate if the qualified alternate mains circuit is automatically switched on when the preferred mains circuit becomes unqualified and is automatically switched off."/>
+        </Property>
+        <Property Name="ClosedTransitionAllowed" Type="Edm.Boolean">
+          <Annotation Term="OData.Permissions" EnumMember="OData.Permission/ReadWrite"/>
+          <Annotation Term="OData.Description" String="Indicates if a make-before-break switching sequence of the mains circuits is permitted when they are both qualified and in synchronization."/>
+          <Annotation Term="OData.LongDescription" String="This property shall indicate if a make-before-break switching sequence of the mains circuits is permitted when they are both qualified and in synchronization."/>
+        </Property>
+        <Property Name="ClosedTransitionTimeoutSeconds" Type="Edm.Int64">
+          <Annotation Term="OData.Permissions" EnumMember="OData.Permission/ReadWrite"/>
+          <Annotation Term="OData.Description" String="The time in seconds to wait for a closed transition to occur."/>
+          <Annotation Term="OData.LongDescription" String="This property shall contain the time in seconds to wait for a closed transition to occur."/>
+        </Property>
+        <Property Name="PreferredMainsId" Type="Edm.String">
+          <Annotation Term="OData.Permissions" EnumMember="OData.Permission/ReadWrite"/>
+          <Annotation Term="OData.Description" String="The preferred source for the mains circuit to this equipment."/>
+          <Annotation Term="OData.LongDescription" String="This property shall contain the preferred source for mains circuit to this equipment.  The value shall be a string that matches the Id property value of a circuit contained in the collection referenced by the Mains property."/>
+        </Property>
+        <Property Name="RetransferDelaySeconds" Type="Edm.Int64">
+          <Annotation Term="OData.Permissions" EnumMember="OData.Permission/ReadWrite"/>
+          <Annotation Term="OData.Description" String="The time in seconds to delay the automatic transfer from the alternate mains circuit back to the preferred mains circuit."/>
+          <Annotation Term="OData.LongDescription" String="This property shall contain the time in seconds to delay the automatic transfer from the alternate mains circuit back to the preferred mains circuit."/>
+        </Property>
+        <Property Name="RetransferEnabled" Type="Edm.Boolean">
+          <Annotation Term="OData.Permissions" EnumMember="OData.Permission/ReadWrite"/>
+          <Annotation Term="OData.Description" String="Indicates if the automatic transfer is permitted from the alternate mains circuit back to the preferred mains circuit after the preferred mains circuit is qualified again and the Retransfer Delay time has expired."/>
+          <Annotation Term="OData.LongDescription" String="This property shall indicate if the automatic transfer is permitted from the alternate mains circuit back to the preferred mains circuit after the preferred mains circuit is qualified again and the RetransferDelaySeconds time has expired."/>
+        </Property>
+        <Property Name="TransferDelaySeconds" Type="Edm.Int64">
+          <Annotation Term="OData.Permissions" EnumMember="OData.Permission/ReadWrite"/>
+          <Annotation Term="OData.Description" String="The time in seconds to delay the automatic transfer from the preferred mains circuit to the alternate mains circuit when the preferred mains circuit is disqualified."/>
+          <Annotation Term="OData.LongDescription" String="This property shall contain the time in seconds to delay the automatic transfer from the preferred mains circuit to the alternate mains circuit when the preferred mains circuit is disqualified.  A value of zero shall mean it transfers as fast as possible."/>
+        </Property>
+        <Property Name="TransferInhibit" Type="Edm.Boolean">
+          <Annotation Term="OData.Permissions" EnumMember="OData.Permission/ReadWrite"/>
+          <Annotation Term="OData.Description" String="Indicates if any transfer is inhibited."/>
+          <Annotation Term="OData.LongDescription" String="This property shall indicate if any transfer is inhibited."/>
+        </Property>
+      </ComplexType>
+
+      <ComplexType Name="TransferCriteria">
+        <Annotation Term="OData.AdditionalProperties" Bool="false"/>
+        <Annotation Term="OData.Description" String="The criteria used to initiate a transfer for an automatic transfer switch."/>
+        <Annotation Term="OData.LongDescription" String="This type shall contain the criteria for initiating a transfer within an automatic transfer switch function for this resource."/>
+        <Property Name="TransferSensitivity" Type="PowerDistribution.v1_0_0.TransferSensitivityType">
+          <Annotation Term="OData.Permissions" EnumMember="OData.Permission/ReadWrite"/>
+          <Annotation Term="OData.Description" String="The sensitivity to voltage waveform quality to satisfy the criterion for initiating a transfer."/>
+          <Annotation Term="OData.LongDescription" String="This property shall contain the setting that adjusts the analytical sensitivity of the detection of the quality of voltage waveform that satisfies a criterion for transfer."/>
+        </Property>
+        <Property Name="OverVoltageRMSPercentage" Type="Edm.Decimal">
+          <Annotation Term="OData.Permissions" EnumMember="OData.Permission/ReadWrite"/>
+          <Annotation Term="OData.Description" String="The positive percentage of voltage RMS over the nominal value that satisfies a criterion for transfer."/>
+          <Annotation Term="OData.LongDescription" String="This property shall contain the positive percentage of voltage RMS over the nominal value that satisfies a criterion for transfer."/>
+          <Annotation Term="Measures.Unit" String="%"/>
+        </Property>
+        <Property Name="UnderVoltageRMSPercentage" Type="Edm.Decimal">
+          <Annotation Term="OData.Permissions" EnumMember="OData.Permission/ReadWrite"/>
+          <Annotation Term="OData.Description" String="The negative percentage of voltage RMS under the nominal value that satisfies a criterion for transfer."/>
+          <Annotation Term="OData.LongDescription" String="This property shall contain the negative percentage of voltage RMS under the nominal value that satisfies a criterion for transfer."/>
+          <Annotation Term="Measures.Unit" String="%"/>
+        </Property>
+        <Property Name="OverNominalFrequencyHz" Type="Edm.Decimal">
+          <Annotation Term="OData.Permissions" EnumMember="OData.Permission/ReadWrite"/>
+          <Annotation Term="OData.Description" String="The frequency in Hertz over the nominal value that satisfies a criterion for transfer."/>
+          <Annotation Term="OData.LongDescription" String="This property shall contain the frequency in Hertz over the nominal value that satisfies a criterion for transfer."/>
+          <Annotation Term="Measures.Unit" String="Hz"/>
+        </Property>
+        <Property Name="UnderNominalFrequencyHz" Type="Edm.Decimal">
+          <Annotation Term="OData.Permissions" EnumMember="OData.Permission/ReadWrite"/>
+          <Annotation Term="OData.Description" String="The frequency in Hertz under the nominal value that satisfies a criterion for transfer."/>
+          <Annotation Term="OData.LongDescription" String="This property shall contain the frequency in Hertz under the nominal value that satisfies a criterion for transfer."/>
+          <Annotation Term="Measures.Unit" String="Hz"/>
+        </Property>
+      </ComplexType>
+
+      <EnumType Name="TransferSensitivityType">
+        <Member Name="High">
+          <Annotation Term="OData.Description" String="High sensitivity for initiating a transfer."/>
+        </Member>
+        <Member Name="Medium">
+          <Annotation Term="OData.Description" String="Medium sensitivity for initiating a transfer."/>
+        </Member>
+        <Member Name="Low">
+          <Annotation Term="OData.Description" String="Low sensitivity for initiating a transfer."/>
+        </Member>
+      </EnumType>
+
+      <ComplexType Name="Actions">
+        <Annotation Term="OData.AdditionalProperties" Bool="false"/>
+        <Annotation Term="OData.Description" String="The available actions for this resource."/>
+        <Annotation Term="OData.LongDescription" String="This type shall contain the available actions for this resource."/>
+        <Property Name="Oem" Type="PowerDistribution.v1_0_0.OemActions" Nullable="false">
+          <Annotation Term="OData.Description" String="The available OEM-specific actions for this resource."/>
+          <Annotation Term="OData.LongDescription" String="This property shall contain the available OEM-specific actions for this resource."/>
+        </Property>
+      </ComplexType>
+
+      <ComplexType Name="OemActions">
+        <Annotation Term="OData.AdditionalProperties" Bool="true"/>
+        <Annotation Term="OData.Description" String="The available OEM-specific actions for this resource."/>
+        <Annotation Term="OData.LongDescription" String="This type shall contain the available OEM-specific actions for this resource."/>
+      </ComplexType>
+    </Schema>
+
+    <Schema xmlns="http://docs.oasis-open.org/odata/ns/edm" Namespace="PowerDistribution.v1_0_1">
+      <Annotation Term="Redfish.OwningEntity" String="DMTF"/>
+      <Annotation Term="OData.Description" String="This version was created to correct various typographical errors."/>
+      <EntityType Name="PowerDistribution" BaseType="PowerDistribution.v1_0_0.PowerDistribution"/>
+    </Schema>
+
+    <Schema xmlns="http://docs.oasis-open.org/odata/ns/edm" Namespace="PowerDistribution.v1_0_2">
+      <Annotation Term="Redfish.OwningEntity" String="DMTF"/>
+      <Annotation Term="OData.Description" String="This version was created specify 64-bit integers in OpenAPI."/>
+      <EntityType Name="PowerDistribution" BaseType="PowerDistribution.v1_0_1.PowerDistribution"/>
+    </Schema>
+
+    <Schema xmlns="http://docs.oasis-open.org/odata/ns/edm" Namespace="PowerDistribution.v1_0_3">
+      <Annotation Term="Redfish.OwningEntity" String="DMTF"/>
+      <Annotation Term="OData.Description" String="This version was created to correct various description to use proper normative terminology."/>
+      <EntityType Name="PowerDistribution" BaseType="PowerDistribution.v1_0_2.PowerDistribution"/>
+    </Schema>
+
+    <Schema xmlns="http://docs.oasis-open.org/odata/ns/edm" Namespace="PowerDistribution.v1_1_0">
+      <Annotation Term="Redfish.OwningEntity" String="DMTF"/>
+      <Annotation Term="Redfish.Release" String="2021.2"/>
+      <Annotation Term="OData.Description" String="This version was created to add `PowerShelf` to EquipmentType."/>
+
+      <EntityType Name="PowerDistribution" BaseType="PowerDistribution.v1_0_3.PowerDistribution">
+        <NavigationProperty Name="PowerSupplies" Type="PowerSupplyCollection.PowerSupplyCollection" Nullable="false">
+          <Annotation Term="OData.Permissions" EnumMember="OData.Permission/Read"/>
+          <Annotation Term="OData.Description" String="The link to the collection of power supplies for this equipment."/>
+          <Annotation Term="OData.LongDescription" String="This property shall contain a link to a resource collection of type PowerSupplyCollection."/>
+          <Annotation Term="OData.AutoExpandReferences"/>
+        </NavigationProperty>
+        <Property Name="PowerSupplyRedundancy" Type="Collection(Redundancy.RedundantGroup)" Nullable="false">
+          <Annotation Term="OData.Description" String="The redundancy information for the set of power supplies for this equipment."/>
+          <Annotation Term="OData.LongDescription" String="This property shall contain redundancy information for the set of power supplies for this equipment.  The values of the RedundancyGroup array shall reference resources of type PowerSupply."/>
+        </Property>
+        <Property Name="MainsRedundancy" Type="Redundancy.RedundantGroup" Nullable="false">
+          <Annotation Term="OData.Description" String="The redundancy information for the mains (input) circuits for this equipment."/>
+          <Annotation Term="OData.LongDescription" String="This property shall contain redundancy information for the mains (input) circuits for this equipment.  The values of the RedundancyGroup array shall reference resources of type Circuit."/>
+        </Property>
+      </EntityType>
+    </Schema>
+
+  </edmx:DataServices>
+</edmx:Edmx>

--- a/static/redfish/v1/schema/PowerDomainCollection_v1.xml
+++ b/static/redfish/v1/schema/PowerDomainCollection_v1.xml
@@ -1,0 +1,70 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!---->
+<!--################################################################################       -->
+<!--# Redfish Schema:  PowerDomainCollection                                               -->
+<!--#                                                                                      -->
+<!--# For a detailed change log, see the README file contained in the DSP8010 bundle,      -->
+<!--# available at http://www.dmtf.org/standards/redfish                                   -->
+<!--# Copyright 2014-2021 DMTF.                                                            -->
+<!--# For the full DMTF copyright policy, see http://www.dmtf.org/about/policies/copyright -->
+<!--################################################################################       -->
+<!---->
+<edmx:Edmx xmlns:edmx="http://docs.oasis-open.org/odata/ns/edmx" Version="4.0">
+
+  <edmx:Reference Uri="http://docs.oasis-open.org/odata/odata/v4.0/errata03/csd01/complete/vocabularies/Org.OData.Core.V1.xml">
+    <edmx:Include Namespace="Org.OData.Core.V1" Alias="OData"/>
+  </edmx:Reference>
+  <edmx:Reference Uri="http://docs.oasis-open.org/odata/odata/v4.0/errata03/csd01/complete/vocabularies/Org.OData.Capabilities.V1.xml">
+    <edmx:Include Namespace="Org.OData.Capabilities.V1" Alias="Capabilities"/>
+  </edmx:Reference>
+  <edmx:Reference Uri="http://redfish.dmtf.org/schemas/v1/RedfishExtensions_v1.xml">
+    <edmx:Include Namespace="RedfishExtensions.v1_0_0" Alias="Redfish"/>
+  </edmx:Reference>
+  <edmx:Reference Uri="http://redfish.dmtf.org/schemas/v1/Resource_v1.xml">
+    <edmx:Include Namespace="Resource.v1_0_0"/>
+  </edmx:Reference>
+  <edmx:Reference Uri="http://redfish.dmtf.org/schemas/v1/PowerDomain_v1.xml">
+    <edmx:Include Namespace="PowerDomain"/>
+  </edmx:Reference>
+
+  <edmx:DataServices>
+
+    <Schema xmlns="http://docs.oasis-open.org/odata/ns/edm" Namespace="PowerDomainCollection">
+      <Annotation Term="Redfish.OwningEntity" String="DMTF"/>
+
+      <EntityType Name="PowerDomainCollection" BaseType="Resource.v1_0_0.ResourceCollection">
+        <Annotation Term="OData.Description" String="The collection of PowerDomain resource instances."/>
+        <Annotation Term="OData.LongDescription" String="This resource shall represent a resource collection of PowerDomain instances for a Redfish implementation."/>
+        <Annotation Term="Capabilities.InsertRestrictions">
+          <Record>
+            <PropertyValue Property="Insertable" Bool="true"/>
+            <Annotation Term="OData.Description" String="Some implementations might allow power domains to be created through a POST to the power domain collection."/>
+          </Record>
+        </Annotation>
+        <Annotation Term="Capabilities.UpdateRestrictions">
+          <Record>
+            <PropertyValue Property="Updatable" Bool="false"/>
+          </Record>
+        </Annotation>
+        <Annotation Term="Capabilities.DeleteRestrictions">
+          <Record>
+            <PropertyValue Property="Deletable" Bool="false"/>
+          </Record>
+        </Annotation>
+        <Annotation Term="Redfish.Uris">
+          <Collection>
+            <String>/redfish/v1/Facilities/{FacilityId}/PowerDomains</String>
+          </Collection>
+        </Annotation>
+        <NavigationProperty Name="Members" Type="Collection(PowerDomain.PowerDomain)">
+          <Annotation Term="OData.Permissions" EnumMember="OData.Permission/Read"/>
+          <Annotation Term="OData.Description" String="The members of this collection."/>
+          <Annotation Term="OData.LongDescription" String="This property shall contain an array of links to the members of this collection."/>
+          <Annotation Term="OData.AutoExpandReferences"/>
+          <Annotation Term="Redfish.Required"/>
+        </NavigationProperty>
+      </EntityType>
+    </Schema>
+
+  </edmx:DataServices>
+</edmx:Edmx>

--- a/static/redfish/v1/schema/PowerDomain_v1.xml
+++ b/static/redfish/v1/schema/PowerDomain_v1.xml
@@ -1,0 +1,160 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!---->
+<!--################################################################################       -->
+<!--# Redfish Schema:  PowerDomain v1.1.0                                                  -->
+<!--#                                                                                      -->
+<!--# For a detailed change log, see the README file contained in the DSP8010 bundle,      -->
+<!--# available at http://www.dmtf.org/standards/redfish                                   -->
+<!--# Copyright 2014-2021 DMTF.                                                            -->
+<!--# For the full DMTF copyright policy, see http://www.dmtf.org/about/policies/copyright -->
+<!--################################################################################       -->
+<!---->
+<edmx:Edmx xmlns:edmx="http://docs.oasis-open.org/odata/ns/edmx" Version="4.0">
+
+  <edmx:Reference Uri="http://docs.oasis-open.org/odata/odata/v4.0/errata03/csd01/complete/vocabularies/Org.OData.Core.V1.xml">
+    <edmx:Include Namespace="Org.OData.Core.V1" Alias="OData"/>
+  </edmx:Reference>
+  <edmx:Reference Uri="http://docs.oasis-open.org/odata/odata/v4.0/errata03/csd01/complete/vocabularies/Org.OData.Capabilities.V1.xml">
+    <edmx:Include Namespace="Org.OData.Capabilities.V1" Alias="Capabilities"/>
+  </edmx:Reference>
+  <edmx:Reference Uri="http://redfish.dmtf.org/schemas/v1/RedfishExtensions_v1.xml">
+    <edmx:Include Namespace="RedfishExtensions.v1_0_0" Alias="Redfish"/>
+  </edmx:Reference>
+  <edmx:Reference Uri="http://redfish.dmtf.org/schemas/v1/Resource_v1.xml">
+    <edmx:Include Namespace="Resource"/>
+    <edmx:Include Namespace="Resource.v1_0_0"/>
+  </edmx:Reference>
+  <edmx:Reference Uri="http://redfish.dmtf.org/schemas/v1/PowerDistribution_v1.xml">
+    <edmx:Include Namespace="PowerDistribution"/>
+  </edmx:Reference>
+  <edmx:Reference Uri="http://redfish.dmtf.org/schemas/v1/Manager_v1.xml">
+    <edmx:Include Namespace="Manager"/>
+  </edmx:Reference>
+
+  <edmx:DataServices>
+
+    <Schema xmlns="http://docs.oasis-open.org/odata/ns/edm" Namespace="PowerDomain">
+      <Annotation Term="Redfish.OwningEntity" String="DMTF"/>
+
+      <EntityType Name="PowerDomain" BaseType="Resource.v1_0_0.Resource" Abstract="true">
+        <Annotation Term="OData.Description" String="The PowerDomain schema contains definition for the DCIM power domain."/>
+        <Annotation Term="OData.LongDescription" String="This resource shall be used to represent a DCIM power domain for a Redfish implementation."/>
+        <Annotation Term="Capabilities.InsertRestrictions">
+          <Record>
+            <PropertyValue Property="Insertable" Bool="false"/>
+          </Record>
+        </Annotation>
+        <Annotation Term="Capabilities.UpdateRestrictions">
+          <Record>
+            <PropertyValue Property="Updatable" Bool="true"/>
+            <Annotation Term="OData.Description" String="Any writable properties can be updated."/>
+          </Record>
+        </Annotation>
+        <Annotation Term="Capabilities.DeleteRestrictions">
+          <Record>
+            <PropertyValue Property="Deletable" Bool="true"/>
+            <Annotation Term="OData.Description" String="Some implementations might allow power domains to be deleted."/>
+          </Record>
+        </Annotation>
+        <Annotation Term="Redfish.Uris">
+          <Collection>
+            <String>/redfish/v1/Facilities/{FacilityId}/PowerDomains/{PowerDomainId}</String>
+          </Collection>
+        </Annotation>
+      </EntityType>
+    </Schema>
+
+    <Schema xmlns="http://docs.oasis-open.org/odata/ns/edm" Namespace="PowerDomain.v1_0_0">
+      <Annotation Term="Redfish.OwningEntity" String="DMTF"/>
+      <Annotation Term="Redfish.Release" String="2019.4"/>
+
+      <EntityType Name="PowerDomain" BaseType="PowerDomain.PowerDomain">
+        <Property Name="Status" Type="Resource.Status" Nullable="false">
+          <Annotation Term="OData.Description" String="The status and health of the resource and its subordinate or dependent resources."/>
+          <Annotation Term="OData.LongDescription" String="This property shall contain any status or health properties of the resource."/>
+        </Property>
+        <Property Name="Links" Type="PowerDomain.v1_0_0.Links" Nullable="false">
+          <Annotation Term="OData.Description" String="The links to other resources that are related to this resource."/>
+          <Annotation Term="OData.LongDescription" String="This property shall contain links to resources that are related to but are not contained by, or subordinate to, this resource."/>
+        </Property>
+        <Property Name="Actions" Type="PowerDomain.v1_0_0.Actions" Nullable="false">
+          <Annotation Term="OData.Description" String="The available actions for this resource."/>
+          <Annotation Term="OData.LongDescription" String="This property shall contain the available actions for this resource."/>
+        </Property>
+      </EntityType>
+
+      <ComplexType Name="Links" BaseType="Resource.Links">
+        <Annotation Term="OData.Description" String="The links to other resources that are related to this resource."/>
+        <Annotation Term="OData.LongDescription" String="This Redfish Specification-described type shall contain links to resources that are related to but are not contained by, or subordinate to, this resource."/>
+        <NavigationProperty Name="FloorPDUs" Type="Collection(PowerDistribution.PowerDistribution)">
+          <Annotation Term="OData.Permissions" EnumMember="OData.Permission/ReadWrite"/>
+          <Annotation Term="OData.Description" String="An array of links to the floor power distribution units in this power domain."/>
+          <Annotation Term="OData.LongDescription" String="This property shall contain an array of links to resources of type PowerDistribution that represents the floor power distribution units in this power domain."/>
+          <Annotation Term="OData.AutoExpandReferences"/>
+        </NavigationProperty>
+        <NavigationProperty Name="RackPDUs" Type="Collection(PowerDistribution.PowerDistribution)">
+          <Annotation Term="OData.Permissions" EnumMember="OData.Permission/ReadWrite"/>
+          <Annotation Term="OData.Description" String="An array of links to the rack-level power distribution units in this power domain."/>
+          <Annotation Term="OData.LongDescription" String="This property shall contain an array of links to resources of type PowerDistribution that represents the rack-level power distribution units in this power domain."/>
+          <Annotation Term="OData.AutoExpandReferences"/>
+        </NavigationProperty>
+        <NavigationProperty Name="TransferSwitches" Type="Collection(PowerDistribution.PowerDistribution)">
+          <Annotation Term="OData.Permissions" EnumMember="OData.Permission/ReadWrite"/>
+          <Annotation Term="OData.Description" String="An array of links to the transfer switches in this power domain."/>
+          <Annotation Term="OData.LongDescription" String="This property shall contain an array of links to resources of type PowerDistribution that represents the transfer switches in this power domain."/>
+          <Annotation Term="OData.AutoExpandReferences"/>
+        </NavigationProperty>
+        <NavigationProperty Name="Switchgear" Type="Collection(PowerDistribution.PowerDistribution)">
+          <Annotation Term="OData.Permissions" EnumMember="OData.Permission/ReadWrite"/>
+          <Annotation Term="OData.Description" String="An array of links to the switchgear in this power domain."/>
+          <Annotation Term="OData.LongDescription" String="This property shall contain an array of links to resources of type PowerDistribution that represents the switchgear in this power domain."/>
+          <Annotation Term="OData.AutoExpandReferences"/>
+        </NavigationProperty>
+        <NavigationProperty Name="ManagedBy" Type="Collection(Manager.Manager)">
+          <Annotation Term="OData.Permissions" EnumMember="OData.Permission/Read"/>
+          <Annotation Term="OData.Description" String="An array of links to the managers responsible for managing this power domain."/>
+          <Annotation Term="OData.LongDescription" String="This property shall contain an array of links to resources of type Manager that represent the managers that manage this power domain."/>
+          <Annotation Term="OData.AutoExpandReferences"/>
+        </NavigationProperty>
+      </ComplexType>
+
+      <ComplexType Name="Actions">
+        <Annotation Term="OData.AdditionalProperties" Bool="false"/>
+        <Annotation Term="OData.Description" String="The available actions for this resource."/>
+        <Annotation Term="OData.LongDescription" String="This type shall contain the available actions for this resource."/>
+        <Property Name="Oem" Type="PowerDomain.v1_0_0.OemActions" Nullable="false">
+          <Annotation Term="OData.Description" String="The available OEM-specific actions for this resource."/>
+          <Annotation Term="OData.LongDescription" String="This property shall contain the available OEM-specific actions for this resource."/>
+        </Property>
+      </ComplexType>
+
+      <ComplexType Name="OemActions">
+        <Annotation Term="OData.AdditionalProperties" Bool="true"/>
+        <Annotation Term="OData.Description" String="The available OEM-specific actions for this resource."/>
+        <Annotation Term="OData.LongDescription" String="This type shall contain the available OEM-specific actions for this resource."/>
+      </ComplexType>
+    </Schema>
+
+    <Schema xmlns="http://docs.oasis-open.org/odata/ns/edm" Namespace="PowerDomain.v1_0_1">
+      <Annotation Term="Redfish.OwningEntity" String="DMTF"/>
+      <Annotation Term="OData.Description" String="This version was created to correct various typographical errors."/>
+      <EntityType Name="PowerDomain" BaseType="PowerDomain.v1_0_0.PowerDomain"/>
+    </Schema>
+
+    <Schema xmlns="http://docs.oasis-open.org/odata/ns/edm" Namespace="PowerDomain.v1_1_0">
+      <Annotation Term="Redfish.OwningEntity" String="DMTF"/>
+      <Annotation Term="Redfish.Release" String="2021.2"/>
+      <EntityType Name="PowerDomain" BaseType="PowerDomain.v1_0_1.PowerDomain"/>
+
+      <ComplexType Name="Links" BaseType="PowerDomain.v1_0_0.Links">
+        <NavigationProperty Name="PowerShelves" Type="Collection(PowerDistribution.PowerDistribution)">
+          <Annotation Term="OData.Permissions" EnumMember="OData.Permission/ReadWrite"/>
+          <Annotation Term="OData.Description" String="An array of links to the power shelves in this power domain."/>
+          <Annotation Term="OData.LongDescription" String="This property shall contain an array of links to resources of type PowerDistribution that represents the power shelves in this power domain."/>
+          <Annotation Term="OData.AutoExpandReferences"/>
+        </NavigationProperty>
+      </ComplexType>
+    </Schema>
+
+  </edmx:DataServices>
+</edmx:Edmx>

--- a/static/redfish/v1/schema/PowerEquipment_v1.xml
+++ b/static/redfish/v1/schema/PowerEquipment_v1.xml
@@ -1,0 +1,155 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!---->
+<!--################################################################################       -->
+<!--# Redfish Schema:  PowerEquipment v1.1.0                                               -->
+<!--#                                                                                      -->
+<!--# For a detailed change log, see the README file contained in the DSP8010 bundle,      -->
+<!--# available at http://www.dmtf.org/standards/redfish                                   -->
+<!--# Copyright 2014-2021 DMTF.                                                            -->
+<!--# For the full DMTF copyright policy, see http://www.dmtf.org/about/policies/copyright -->
+<!--################################################################################       -->
+<!---->
+<edmx:Edmx xmlns:edmx="http://docs.oasis-open.org/odata/ns/edmx" Version="4.0">
+
+  <edmx:Reference Uri="http://docs.oasis-open.org/odata/odata/v4.0/errata03/csd01/complete/vocabularies/Org.OData.Core.V1.xml">
+    <edmx:Include Namespace="Org.OData.Core.V1" Alias="OData"/>
+  </edmx:Reference>
+  <edmx:Reference Uri="http://docs.oasis-open.org/odata/odata/v4.0/errata03/csd01/complete/vocabularies/Org.OData.Capabilities.V1.xml">
+    <edmx:Include Namespace="Org.OData.Capabilities.V1" Alias="Capabilities"/>
+  </edmx:Reference>
+  <edmx:Reference Uri="http://redfish.dmtf.org/schemas/v1/RedfishExtensions_v1.xml">
+    <edmx:Include Namespace="RedfishExtensions.v1_0_0" Alias="Redfish"/>
+  </edmx:Reference>
+  <edmx:Reference Uri="http://redfish.dmtf.org/schemas/v1/Resource_v1.xml">
+    <edmx:Include Namespace="Resource"/>
+    <edmx:Include Namespace="Resource.v1_0_0"/>
+  </edmx:Reference>
+  <edmx:Reference Uri="http://redfish.dmtf.org/schemas/v1/PowerDistributionCollection_v1.xml">
+    <edmx:Include Namespace="PowerDistributionCollection"/>
+  </edmx:Reference>
+  <edmx:Reference Uri="http://redfish.dmtf.org/schemas/v1/Manager_v1.xml">
+    <edmx:Include Namespace="Manager"/>
+  </edmx:Reference>
+  <edmx:Reference Uri="http://redfish.dmtf.org/schemas/v1/SensorCollection_v1.xml">
+    <edmx:Include Namespace="SensorCollection"/>
+  </edmx:Reference>
+
+  <edmx:DataServices>
+
+    <Schema xmlns="http://docs.oasis-open.org/odata/ns/edm" Namespace="PowerEquipment">
+      <Annotation Term="Redfish.OwningEntity" String="DMTF"/>
+
+      <EntityType Name="PowerEquipment" BaseType="Resource.v1_0_0.Resource" Abstract="true">
+        <Annotation Term="OData.Description" String="This is the schema definition for the set of power equipment."/>
+        <Annotation Term="OData.LongDescription" String="This resource shall be used to represent the set of power equipment for a Redfish implementation."/>
+        <Annotation Term="Capabilities.InsertRestrictions">
+          <Record>
+            <PropertyValue Property="Insertable" Bool="false"/>
+          </Record>
+        </Annotation>
+        <Annotation Term="Capabilities.UpdateRestrictions">
+          <Record>
+            <PropertyValue Property="Updatable" Bool="false"/>
+          </Record>
+        </Annotation>
+        <Annotation Term="Capabilities.DeleteRestrictions">
+          <Record>
+            <PropertyValue Property="Deletable" Bool="false"/>
+          </Record>
+        </Annotation>
+        <Annotation Term="Redfish.Uris">
+          <Collection>
+            <String>/redfish/v1/PowerEquipment</String>
+          </Collection>
+        </Annotation>
+      </EntityType>
+    </Schema>
+
+    <Schema xmlns="http://docs.oasis-open.org/odata/ns/edm" Namespace="PowerEquipment.v1_0_0">
+      <Annotation Term="Redfish.OwningEntity" String="DMTF"/>
+      <Annotation Term="Redfish.Release" String="2019.4"/>
+
+      <EntityType Name="PowerEquipment" BaseType="PowerEquipment.PowerEquipment">
+        <Property Name="Status" Type="Resource.Status" Nullable="false">
+          <Annotation Term="OData.Description" String="The status and health of the resource and its subordinate or dependent resources."/>
+          <Annotation Term="OData.LongDescription" String="This property shall contain any status or health properties of the resource."/>
+        </Property>
+        <NavigationProperty Name="FloorPDUs" Type="PowerDistributionCollection.PowerDistributionCollection" Nullable="false">
+          <Annotation Term="OData.Permissions" EnumMember="OData.Permission/Read"/>
+          <Annotation Term="OData.Description" String="A link to a collection of floor power distribution units."/>
+          <Annotation Term="OData.LongDescription" String="This property shall contain a link to a resource collection of type PowerDistributionCollection that contains a set of floor power distribution units."/>
+          <Annotation Term="OData.AutoExpandReferences"/>
+        </NavigationProperty>
+        <NavigationProperty Name="RackPDUs" Type="PowerDistributionCollection.PowerDistributionCollection" Nullable="false">
+          <Annotation Term="OData.Permissions" EnumMember="OData.Permission/Read"/>
+          <Annotation Term="OData.Description" String="A link to a collection of rack-level power distribution units."/>
+          <Annotation Term="OData.LongDescription" String="This property shall contain a link to a resource collection of type PowerDistributionCollection that contains a set of rack-level power distribution units."/>
+          <Annotation Term="OData.AutoExpandReferences"/>
+        </NavigationProperty>
+        <NavigationProperty Name="Switchgear" Type="PowerDistributionCollection.PowerDistributionCollection" Nullable="false">
+          <Annotation Term="OData.Permissions" EnumMember="OData.Permission/Read"/>
+          <Annotation Term="OData.Description" String="A link to a collection of switchgear."/>
+          <Annotation Term="OData.LongDescription" String="This property shall contain a link to a resource collection of type PowerDistributionCollection that contains a set of switchgear."/>
+          <Annotation Term="OData.AutoExpandReferences"/>
+        </NavigationProperty>
+        <NavigationProperty Name="TransferSwitches" Type="PowerDistributionCollection.PowerDistributionCollection" Nullable="false">
+          <Annotation Term="OData.Permissions" EnumMember="OData.Permission/Read"/>
+          <Annotation Term="OData.Description" String="A link to a collection of transfer switches."/>
+          <Annotation Term="OData.LongDescription" String="This property shall contain a link to a resource collection of type PowerDistributionCollection that contains a set of transfer switches."/>
+          <Annotation Term="OData.AutoExpandReferences"/>
+        </NavigationProperty>
+
+        <Property Name="Links" Type="PowerEquipment.v1_0_0.Links" Nullable="false">
+          <Annotation Term="OData.Description" String="The links to other resources that are related to this resource."/>
+          <Annotation Term="OData.LongDescription" String="This property shall contain links to resources that are related to but are not contained by or subordinate to this resource."/>
+        </Property>
+        <Property Name="Actions" Type="PowerEquipment.v1_0_0.Actions" Nullable="false">
+          <Annotation Term="OData.Description" String="The available actions for this resource."/>
+          <Annotation Term="OData.LongDescription" String="This property shall contain the available actions for this resource."/>
+        </Property>
+      </EntityType>
+
+      <ComplexType Name="Links" BaseType="Resource.Links">
+        <Annotation Term="OData.Description" String="The links to other resources that are related to this resource."/>
+        <Annotation Term="OData.LongDescription" String="This Redfish Specification-described type shall contain links to resources that are related to but are not contained by or subordinate to this resource."/>
+        <NavigationProperty Name="ManagedBy" Type="Collection(Manager.Manager)">
+          <Annotation Term="OData.Permissions" EnumMember="OData.Permission/Read"/>
+          <Annotation Term="OData.Description" String="An array of links to the managers responsible for managing this power equipment."/>
+          <Annotation Term="OData.LongDescription" String="This property shall contain an array of links to resources of type Manager that represent the managers that manage this power equipment."/>
+          <Annotation Term="OData.AutoExpandReferences"/>
+        </NavigationProperty>
+      </ComplexType>
+
+      <ComplexType Name="Actions">
+        <Annotation Term="OData.AdditionalProperties" Bool="false"/>
+        <Annotation Term="OData.Description" String="The available actions for this resource."/>
+        <Annotation Term="OData.LongDescription" String="This type shall contain the available actions for this resource."/>
+        <Property Name="Oem" Type="PowerEquipment.v1_0_0.OemActions" Nullable="false">
+          <Annotation Term="OData.Description" String="The available OEM-specific actions for this resource."/>
+          <Annotation Term="OData.LongDescription" String="This property shall contain the available OEM-specific actions for this resource."/>
+        </Property>
+      </ComplexType>
+
+      <ComplexType Name="OemActions">
+        <Annotation Term="OData.AdditionalProperties" Bool="true"/>
+        <Annotation Term="OData.Description" String="The available OEM-specific actions for this resource."/>
+        <Annotation Term="OData.LongDescription" String="This type shall contain the available OEM-specific actions for this resource."/>
+      </ComplexType>
+    </Schema>
+
+    <Schema xmlns="http://docs.oasis-open.org/odata/ns/edm" Namespace="PowerEquipment.v1_1_0">
+      <Annotation Term="Redfish.OwningEntity" String="DMTF"/>
+      <Annotation Term="Redfish.Release" String="2021.2"/>
+
+      <EntityType Name="PowerEquipment" BaseType="PowerEquipment.v1_0_0.PowerEquipment">
+        <NavigationProperty Name="PowerShelves" Type="PowerDistributionCollection.PowerDistributionCollection" Nullable="false">
+          <Annotation Term="OData.Permissions" EnumMember="OData.Permission/Read"/>
+          <Annotation Term="OData.Description" String="A link to a collection of power shelves."/>
+          <Annotation Term="OData.LongDescription" String="This property shall contain a link to a resource collection of type PowerDistributionCollection that contains a set of power shelves."/>
+          <Annotation Term="OData.AutoExpandReferences"/>
+        </NavigationProperty>
+      </EntityType>
+    </Schema>
+
+  </edmx:DataServices>
+</edmx:Edmx>

--- a/static/redfish/v1/schema/PowerSubsystem_v1.xml
+++ b/static/redfish/v1/schema/PowerSubsystem_v1.xml
@@ -1,11 +1,11 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!---->
 <!--################################################################################       -->
-<!--# Redfish Schema:  PowerSubsystem v1.0.0                                               -->
+<!--# Redfish Schema:  PowerSubsystem v1.1.0                                               -->
 <!--#                                                                                      -->
 <!--# For a detailed change log, see the README file contained in the DSP8010 bundle,      -->
 <!--# available at http://www.dmtf.org/standards/redfish                                   -->
-<!--# Copyright 2014-2020 DMTF.                                                            -->
+<!--# Copyright 2014-2021 DMTF.                                                            -->
 <!--# For the full DMTF copyright policy, see http://www.dmtf.org/about/policies/copyright -->
 <!--################################################################################       -->
 <!---->
@@ -30,6 +30,9 @@
   </edmx:Reference>
   <edmx:Reference Uri="http://redfish.dmtf.org/schemas/v1/PowerSupplyCollection_v1.xml">
     <edmx:Include Namespace="PowerSupplyCollection"/>
+  </edmx:Reference>
+  <edmx:Reference Uri="http://redfish.dmtf.org/schemas/v1/BatteryCollection_v1.xml">
+    <edmx:Include Namespace="BatteryCollection"/>
   </edmx:Reference>
   <edmx:Reference Uri="http://redfish.dmtf.org/schemas/v1/Redundancy_v1.xml">
     <edmx:Include Namespace="Redundancy"/>
@@ -137,6 +140,20 @@
         <Annotation Term="OData.Description" String="The available OEM specific actions for this resource."/>
         <Annotation Term="OData.LongDescription" String="This type shall contain any additional OEM actions for this resource."/>
       </ComplexType>
+    </Schema>
+
+    <Schema xmlns="http://docs.oasis-open.org/odata/ns/edm" Namespace="PowerSubsystem.v1_1_0">
+      <Annotation Term="Redfish.OwningEntity" String="DMTF"/>
+      <Annotation Term="Redfish.Release" String="2021.2"/>
+
+      <EntityType Name="PowerSubsystem" BaseType="PowerSubsystem.v1_0_0.PowerSubsystem">
+        <NavigationProperty Name="Batteries" Type="BatteryCollection.BatteryCollection" Nullable="false">
+          <Annotation Term="OData.Permissions" EnumMember="OData.Permission/Read"/>
+          <Annotation Term="OData.Description" String="The link to the collection of batteries within this subsystem."/>
+          <Annotation Term="OData.LongDescription" String="This property shall contain a link to a resource collection of type BatteryCollection."/>
+          <Annotation Term="OData.AutoExpandReferences"/>
+        </NavigationProperty>
+      </EntityType>
     </Schema>
 
   </edmx:DataServices>

--- a/static/redfish/v1/schema/PowerSupplyCollection_v1.xml
+++ b/static/redfish/v1/schema/PowerSupplyCollection_v1.xml
@@ -5,7 +5,7 @@
 <!--#                                                                                      -->
 <!--# For a detailed change log, see the README file contained in the DSP8010 bundle,      -->
 <!--# available at http://www.dmtf.org/standards/redfish                                   -->
-<!--# Copyright 2014-2020 DMTF.                                                            -->
+<!--# Copyright 2014-2021 DMTF.                                                            -->
 <!--# For the full DMTF copyright policy, see http://www.dmtf.org/about/policies/copyright -->
 <!--################################################################################       -->
 <!---->
@@ -53,6 +53,7 @@
         <Annotation Term="Redfish.Uris">
           <Collection>
             <String>/redfish/v1/Chassis/{ChassisId}/PowerSubsystem/PowerSupplies</String>
+            <String>/redfish/v1/PowerEquipment/PowerShelves/{PowerDistributionId}/PowerSupplies</String>
           </Collection>
         </Annotation>
         <NavigationProperty Name="Members" Type="Collection(PowerSupply.PowerSupply)">

--- a/static/redfish/v1/schema/PowerSupplyMetrics_v1.xml
+++ b/static/redfish/v1/schema/PowerSupplyMetrics_v1.xml
@@ -1,0 +1,290 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!---->
+<!--################################################################################       -->
+<!--# Redfish Schema:  PowerSupplyMetrics v1.0.0                                           -->
+<!--#                                                                                      -->
+<!--# For a detailed change log, see the README file contained in the DSP8010 bundle,      -->
+<!--# available at http://www.dmtf.org/standards/redfish                                   -->
+<!--# Copyright 2014-2021 DMTF.                                                            -->
+<!--# For the full DMTF copyright policy, see http://www.dmtf.org/about/policies/copyright -->
+<!--################################################################################       -->
+<!---->
+<edmx:Edmx xmlns:edmx="http://docs.oasis-open.org/odata/ns/edmx" Version="4.0">
+
+  <edmx:Reference Uri="http://docs.oasis-open.org/odata/odata/v4.0/errata03/csd01/complete/vocabularies/Org.OData.Core.V1.xml">
+    <edmx:Include Namespace="Org.OData.Core.V1" Alias="OData"/>
+  </edmx:Reference>
+  <edmx:Reference Uri="http://docs.oasis-open.org/odata/odata/v4.0/errata03/csd01/complete/vocabularies/Org.OData.Capabilities.V1.xml">
+    <edmx:Include Namespace="Org.OData.Capabilities.V1" Alias="Capabilities"/>
+  </edmx:Reference>
+  <edmx:Reference Uri="http://redfish.dmtf.org/schemas/v1/RedfishExtensions_v1.xml">
+    <edmx:Include Namespace="RedfishExtensions.v1_0_0" Alias="Redfish"/>
+  </edmx:Reference>
+  <edmx:Reference Uri="http://redfish.dmtf.org/schemas/v1/Resource_v1.xml">
+    <edmx:Include Namespace="Resource"/>
+    <edmx:Include Namespace="Resource.v1_0_0"/>
+  </edmx:Reference>
+  <edmx:Reference Uri="http://redfish.dmtf.org/schemas/v1/Sensor_v1.xml">
+    <edmx:Include Namespace="Sensor"/>
+  </edmx:Reference>
+
+  <edmx:DataServices>
+
+    <Schema xmlns="http://docs.oasis-open.org/odata/ns/edm" Namespace="PowerSupplyMetrics">
+      <Annotation Term="Redfish.OwningEntity" String="DMTF"/>
+
+      <EntityType Name="PowerSupplyMetrics" BaseType="Resource.v1_0_0.Resource" Abstract="true">
+        <Annotation Term="OData.Description" String="The PowerSupplyMetrics schema contains definitions for the metrics of a power supply."/>
+        <Annotation Term="OData.LongDescription" String="This resource shall be used to represent the metrics of a power supply unit for a Redfish implementation."/>
+        <Annotation Term="OData.AdditionalProperties" Bool="false"/>
+        <Annotation Term="Capabilities.InsertRestrictions">
+          <Record>
+            <PropertyValue Property="Insertable" Bool="false"/>
+          </Record>
+        </Annotation>
+        <Annotation Term="Capabilities.UpdateRestrictions">
+          <Record>
+            <PropertyValue Property="Updatable" Bool="false"/>
+          </Record>
+        </Annotation>
+        <Annotation Term="Capabilities.DeleteRestrictions">
+          <Record>
+            <PropertyValue Property="Deletable" Bool="false"/>
+          </Record>
+        </Annotation>
+        <Annotation Term="Redfish.Uris">
+          <Collection>
+            <String>/redfish/v1/Chassis/{ChassisId}/PowerSubsystem/PowerSupplies/{PowerSupplyId}/Metrics</String>
+            <String>/redfish/v1/PowerEquipment/PowerShelves/{PowerDistributionId}/PowerSupplies/{PowerSupplyId}/Metrics</String>
+          </Collection>
+        </Annotation>
+      </EntityType>
+
+      <Action Name="ResetMetrics" IsBound="true">
+        <Parameter Name="PowerSupplyMetrics" Type="PowerSupplyMetrics.v1_0_0.Actions"/>
+        <Annotation Term="OData.Description" String="This action resets the summary metrics related to this equipment."/>
+        <Annotation Term="OData.LongDescription" String="This action shall reset any time intervals or counted values for this equipment."/>
+      </Action>
+    </Schema>
+
+    <Schema xmlns="http://docs.oasis-open.org/odata/ns/edm" Namespace="PowerSupplyMetrics.v1_0_0">
+      <Annotation Term="Redfish.OwningEntity" String="DMTF"/>
+      <Annotation Term="Redfish.Release" String="2020.4"/>
+
+      <EntityType Name="PowerSupplyMetrics" BaseType="PowerSupplyMetrics.PowerSupplyMetrics">
+        <Property Name="Status" Type="Resource.Status" Nullable="false">
+          <Annotation Term="OData.Description" String="The status and health of the resource and its subordinate or dependent resources."/>
+          <Annotation Term="OData.LongDescription" String="This property shall contain any status or health properties of the resource."/>
+        </Property>
+        <NavigationProperty Name="InputVoltage" Type="Sensor.Sensor">
+          <Annotation Term="OData.Permissions" EnumMember="OData.Permission/Read"/>
+          <Annotation Term="OData.Description" String="The input voltage reading for this power supply."/>
+          <Annotation Term="OData.LongDescription" String="This property shall contain the sensor measuring the input voltage for this power supply."/>
+          <Annotation Term="Redfish.ExcerptCopy" String="Voltage"/>
+        </NavigationProperty>
+        <NavigationProperty Name="InputCurrentAmps" Type="Sensor.Sensor">
+          <Annotation Term="OData.Permissions" EnumMember="OData.Permission/Read"/>
+          <Annotation Term="OData.Description" String="The input current reading for this power supply."/>
+          <Annotation Term="OData.LongDescription" String="This property shall contain the sensor measuring the input current for this power supply."/>
+          <Annotation Term="Redfish.ExcerptCopy" String="Current"/>
+        </NavigationProperty>
+        <NavigationProperty Name="InputPowerWatts" Type="Sensor.Sensor">
+          <Annotation Term="OData.Permissions" EnumMember="OData.Permission/Read"/>
+          <Annotation Term="OData.Description" String="The input power reading for this power supply."/>
+          <Annotation Term="OData.LongDescription" String="This property shall contain the sensor measuring the input power for this power supply."/>
+          <Annotation Term="Redfish.ExcerptCopy" String="Power"/>
+        </NavigationProperty>
+        <NavigationProperty Name="EnergykWh" Type="Sensor.Sensor">
+          <Annotation Term="OData.Permissions" EnumMember="OData.Permission/Read"/>
+          <Annotation Term="Redfish.ExcerptCopy" String="EnergykWh"/>
+          <Annotation Term="OData.Description" String="The energy consumption of this unit."/>
+          <Annotation Term="OData.LongDescription" String="This property shall contain the total energy, measured in kilowatt-hours (kWh), for this unit, that represents the `Total` ElectricalContext sensor when multiple energy sensors exist."/>
+        </NavigationProperty>
+        <NavigationProperty Name="FrequencyHz" Type="Sensor.Sensor">
+          <Annotation Term="OData.Permissions" EnumMember="OData.Permission/Read"/>
+          <Annotation Term="Redfish.ExcerptCopy"/>
+          <Annotation Term="OData.Description" String="The frequency reading for this power supply."/>
+          <Annotation Term="OData.LongDescription" String="This property shall contain the frequency sensor for this power supply."/>
+        </NavigationProperty>
+        <NavigationProperty Name="OutputPowerWatts" Type="Sensor.Sensor">
+          <Annotation Term="OData.Permissions" EnumMember="OData.Permission/Read"/>
+          <Annotation Term="OData.Description" String="The total power output reading for this power supply."/>
+          <Annotation Term="OData.LongDescription" String="This property shall contain the sensor measuring the total output power for this power supply."/>
+          <Annotation Term="Redfish.ExcerptCopy" String="Power"/>
+        </NavigationProperty>
+        <NavigationProperty Name="RailVoltage" Type="Collection(Sensor.Sensor)">
+          <Annotation Term="OData.Permissions" EnumMember="OData.Permission/Read"/>
+          <Annotation Term="OData.Description" String="The voltage readings for this power supply."/>
+          <Annotation Term="OData.LongDescription" String="This property shall contain the output voltage sensors for this power supply.  The sensors shall appear in the same array order as the OutputRails property in the associated PowerSupply resource."/>
+          <Annotation Term="Redfish.ExcerptCopy" String="Voltage"/>
+        </NavigationProperty>
+        <NavigationProperty Name="RailCurrentAmps" Type="Collection(Sensor.Sensor)">
+          <Annotation Term="OData.Permissions" EnumMember="OData.Permission/Read"/>
+          <Annotation Term="OData.Description" String="The current readings for this power supply."/>
+          <Annotation Term="OData.LongDescription" String="This property shall contain the output current sensors for this power supply.  The sensors shall appear in the same array order as the OutputRails property in the associated PowerSupply resource."/>
+          <Annotation Term="Redfish.ExcerptCopy" String="Current"/>
+        </NavigationProperty>
+        <NavigationProperty Name="RailPowerWatts" Type="Collection(Sensor.Sensor)">
+          <Annotation Term="OData.Permissions" EnumMember="OData.Permission/Read"/>
+          <Annotation Term="OData.Description" String="The power readings for this power supply."/>
+          <Annotation Term="OData.LongDescription" String="This property shall contain the output power sensors for this power supply.  The sensors shall appear in the same array order as the OutputRails property in the associated PowerSupply resource."/>
+          <Annotation Term="Redfish.ExcerptCopy" String="Power"/>
+        </NavigationProperty>
+        <NavigationProperty Name="TemperatureCelsius" Type="Sensor.Sensor">
+          <Annotation Term="OData.Permissions" EnumMember="OData.Permission/Read"/>
+          <Annotation Term="Redfish.ExcerptCopy"/>
+          <Annotation Term="OData.Description" String="The temperature reading for this power supply."/>
+          <Annotation Term="OData.LongDescription" String="This property shall contain the temperature sensor for this power supply."/>
+        </NavigationProperty>
+        <NavigationProperty Name="FanSpeedPercent" Type="Sensor.Sensor">
+          <Annotation Term="OData.Permissions" EnumMember="OData.Permission/Read"/>
+          <Annotation Term="Redfish.ExcerptCopy" String="Fan"/>
+          <Annotation Term="OData.Description" String="The fan speed reading for this power supply."/>
+          <Annotation Term="OData.LongDescription" String="This property shall contain the fan speed sensor for this power supply."/>
+        </NavigationProperty>
+
+        <Property Name="Actions" Type="PowerSupplyMetrics.v1_0_0.Actions" Nullable="false">
+          <Annotation Term="OData.Description" String="The available actions for this resource."/>
+          <Annotation Term="OData.LongDescription" String="This property shall contain the available actions for this resource."/>
+        </Property>
+      </EntityType>
+
+      <ComplexType Name="VoltageSensors">
+        <Annotation Term="OData.AdditionalProperties" Bool="false"/>
+        <Annotation Term="OData.Description" String="The voltage readings for a power supply."/>
+        <Annotation Term="OData.LongDescription" String="This type shall contain properties that describe voltage sensor readings for a power supply."/>
+        <NavigationProperty Name="Input" Type="Sensor.Sensor">
+          <Annotation Term="OData.Permissions" EnumMember="OData.Permission/Read"/>
+          <Annotation Term="Redfish.ExcerptCopy" String="Voltage"/>
+          <Annotation Term="OData.Description" String="The power supply input."/>
+          <Annotation Term="OData.LongDescription" String="This property shall contain the voltage sensor that measures voltage at the input to the power supply."/>
+        </NavigationProperty>
+        <NavigationProperty Name="InputSecondary" Type="Sensor.Sensor">
+          <Annotation Term="OData.Permissions" EnumMember="OData.Permission/Read"/>
+          <Annotation Term="Redfish.ExcerptCopy" String="Voltage"/>
+          <Annotation Term="OData.Description" String="The power supply secondary input."/>
+          <Annotation Term="OData.LongDescription" String="This property shall contain the voltage sensor that measures voltage at a secondary input to the power supply.  This property shall not be present if the power supply does not include a secondary input."/>
+        </NavigationProperty>
+        <NavigationProperty Name="Output3Volt" Type="Sensor.Sensor">
+          <Annotation Term="OData.Permissions" EnumMember="OData.Permission/Read"/>
+          <Annotation Term="Redfish.ExcerptCopy" String="Voltage"/>
+          <Annotation Term="OData.Description" String="The 3V nominal output."/>
+          <Annotation Term="OData.LongDescription" String="This property shall contain the voltage sensor that measures voltage on a 3 Volt nominal output power rail.  This property shall not be present if the power supply does not include a 3V output."/>
+        </NavigationProperty>
+        <NavigationProperty Name="Output5Volt" Type="Sensor.Sensor">
+          <Annotation Term="OData.Permissions" EnumMember="OData.Permission/Read"/>
+          <Annotation Term="Redfish.ExcerptCopy" String="Voltage"/>
+          <Annotation Term="OData.Description" String="The 5V nominal output."/>
+          <Annotation Term="OData.LongDescription" String="This property shall contain the voltage sensor that measures voltage on a 3 Volt nominal output power rail.  This property shall not be present if the power supply does not include a 3V output."/>
+        </NavigationProperty>
+        <NavigationProperty Name="Output12Volt" Type="Sensor.Sensor">
+          <Annotation Term="OData.Permissions" EnumMember="OData.Permission/Read"/>
+          <Annotation Term="Redfish.ExcerptCopy" String="Voltage"/>
+          <Annotation Term="OData.Description" String="The 12V nominal output."/>
+          <Annotation Term="OData.LongDescription" String="This property shall contain the voltage sensor that measures voltage on a 12 Volt nominal output power rail.  This property shall not be present if the power supply does not include a 12V output."/>
+        </NavigationProperty>
+        <NavigationProperty Name="Output48Volt" Type="Sensor.Sensor">
+          <Annotation Term="OData.Permissions" EnumMember="OData.Permission/Read"/>
+          <Annotation Term="Redfish.ExcerptCopy" String="Voltage"/>
+          <Annotation Term="OData.Description" String="The 48V nominal output."/>
+          <Annotation Term="OData.LongDescription" String="This property shall contain the voltage sensor that measures voltage on a 48 Volt nominal output power rail.  This property shall not be present if the power supply does not include a 48V output."/>
+        </NavigationProperty>
+        <NavigationProperty Name="OutputAux" Type="Sensor.Sensor">
+          <Annotation Term="OData.Permissions" EnumMember="OData.Permission/Read"/>
+          <Annotation Term="Redfish.ExcerptCopy" String="Voltage"/>
+          <Annotation Term="OData.Description" String="The auxiliary (AUX) output."/>
+          <Annotation Term="OData.LongDescription" String="This property shall contain the voltage sensor that measures current on an auxiliary (AUX) output power rail.  This property shall not be present if the power supply does not include an auxiliary output."/>
+        </NavigationProperty>
+      </ComplexType>
+
+      <ComplexType Name="CurrentSensors">
+        <Annotation Term="OData.AdditionalProperties" Bool="false"/>
+        <Annotation Term="OData.Description" String="The current sensors for this power supply."/>
+        <Annotation Term="OData.LongDescription" String="This type shall contain properties that describe current sensor readings for a power supply."/>
+        <NavigationProperty Name="Input" Type="Sensor.Sensor">
+          <Annotation Term="OData.Permissions" EnumMember="OData.Permission/Read"/>
+          <Annotation Term="Redfish.ExcerptCopy" String="Current"/>
+          <Annotation Term="OData.Description" String="The power supply input."/>
+          <Annotation Term="OData.LongDescription" String="This property shall contain the current sensor that measures current at the input of the power supply."/>
+        </NavigationProperty>
+        <NavigationProperty Name="InputSecondary" Type="Sensor.Sensor">
+          <Annotation Term="OData.Permissions" EnumMember="OData.Permission/Read"/>
+          <Annotation Term="Redfish.ExcerptCopy" String="Current"/>
+          <Annotation Term="OData.Description" String="The power supply secondary input."/>
+          <Annotation Term="OData.LongDescription" String="This property shall contain the current sensor that measures current at the secondary input of the power supply.  This property shall not be present if the power supply does not include a secondary input."/>
+        </NavigationProperty>
+        <NavigationProperty Name="Output3Volt" Type="Sensor.Sensor">
+          <Annotation Term="OData.Permissions" EnumMember="OData.Permission/Read"/>
+          <Annotation Term="Redfish.ExcerptCopy" String="Current"/>
+          <Annotation Term="OData.Description" String="The 3V nominal output."/>
+          <Annotation Term="OData.LongDescription" String="This property shall contain the current sensor that measures current on a 3 Volt nominal output power rail.  This property shall not be present if the power supply does not include a 3V output."/>
+        </NavigationProperty>
+        <NavigationProperty Name="Output5Volt" Type="Sensor.Sensor">
+          <Annotation Term="OData.Permissions" EnumMember="OData.Permission/Read"/>
+          <Annotation Term="Redfish.ExcerptCopy" String="Current"/>
+          <Annotation Term="OData.Description" String="The 5V nominal output."/>
+          <Annotation Term="OData.LongDescription" String="This property shall contain the current sensor that measures current on a 5 Volt nominal output power rail.  This property shall not be present if the power supply does not include a 5V output."/>
+        </NavigationProperty>
+        <NavigationProperty Name="Output12Volt" Type="Sensor.Sensor">
+          <Annotation Term="OData.Permissions" EnumMember="OData.Permission/Read"/>
+          <Annotation Term="Redfish.ExcerptCopy" String="Current"/>
+          <Annotation Term="OData.Description" String="The 12V nominal output."/>
+          <Annotation Term="OData.LongDescription" String="This property shall contain the current sensor that measures current on a 12 Volt nominal output power rail.  This property shall not be present if the power supply does not include a 12V output."/>
+        </NavigationProperty>
+        <NavigationProperty Name="Output48Volt" Type="Sensor.Sensor">
+          <Annotation Term="OData.Permissions" EnumMember="OData.Permission/Read"/>
+          <Annotation Term="Redfish.ExcerptCopy" String="Current"/>
+          <Annotation Term="OData.Description" String="The 48V nominal output."/>
+          <Annotation Term="OData.LongDescription" String="This property shall contain the current sensor that measures current on a 48 Volt nominal output power rail.  This property shall not be present if the power supply does not include a 48V output."/>
+        </NavigationProperty>
+        <NavigationProperty Name="OutputAux" Type="Sensor.Sensor">
+          <Annotation Term="OData.Permissions" EnumMember="OData.Permission/Read"/>
+          <Annotation Term="Redfish.ExcerptCopy" String="Current"/>
+          <Annotation Term="OData.Description" String="The auxiliary (AUX) output."/>
+          <Annotation Term="OData.LongDescription" String="This property shall contain the current sensor that measures current on an auxiliary (AUX) output power rail.  This property shall not be present if the power supply does not include an auxiliary output."/>
+        </NavigationProperty>
+      </ComplexType>
+
+      <ComplexType Name="PowerSensors">
+        <Annotation Term="OData.AdditionalProperties" Bool="false"/>
+        <Annotation Term="OData.Description" String="The power sensors for this power supply."/>
+        <Annotation Term="OData.LongDescription" String="This type shall contain properties that describe power sensor readings for a power supply."/>
+        <NavigationProperty Name="Input" Type="Sensor.Sensor">
+          <Annotation Term="OData.Permissions" EnumMember="OData.Permission/Read"/>
+          <Annotation Term="Redfish.ExcerptCopy" String="Power"/>
+          <Annotation Term="OData.Description" String="The input power reading for the power supply."/>
+          <Annotation Term="OData.LongDescription" String="This property shall contain the power, measured in Watts, for this power supply unit, as measured at the input of the power supply."/>
+        </NavigationProperty>
+        <NavigationProperty Name="InputSecondary" Type="Sensor.Sensor">
+          <Annotation Term="OData.Permissions" EnumMember="OData.Permission/Read"/>
+          <Annotation Term="Redfish.ExcerptCopy" String="Power"/>
+          <Annotation Term="OData.Description" String="The secondary input power reading for the power supply."/>
+          <Annotation Term="OData.LongDescription" String="This property shall contain the power, measured in Watts, for this power supply unit, as measured at the secondary input of the power supply.  This property shall not appear if the power supply does not contain a secondary input."/>
+        </NavigationProperty>
+        <NavigationProperty Name="Output" Type="Sensor.Sensor">
+          <Annotation Term="OData.Permissions" EnumMember="OData.Permission/Read"/>
+          <Annotation Term="Redfish.ExcerptCopy" String="Power"/>
+          <Annotation Term="OData.Description" String="The output power reading for the power supply."/>
+          <Annotation Term="OData.LongDescription" String="This property shall contain the power, measured in Watts, for this power supply unit, as measured at the output of the power supply."/>
+        </NavigationProperty>
+      </ComplexType>
+
+      <ComplexType Name="Actions">
+        <Annotation Term="OData.AdditionalProperties" Bool="false"/>
+        <Annotation Term="OData.Description" String="The available actions for this resource."/>
+        <Annotation Term="OData.LongDescription" String="This type shall contain the available actions for this resource."/>
+        <Property Name="Oem" Type="PowerSupplyMetrics.v1_0_0.OemActions" Nullable="false">
+          <Annotation Term="OData.Description" String="The available OEM-specific actions for this resource."/>
+          <Annotation Term="OData.LongDescription" String="This property shall contain the available OEM-specific actions for this resource."/>
+        </Property>
+      </ComplexType>
+
+      <ComplexType Name="OemActions">
+        <Annotation Term="OData.AdditionalProperties" Bool="true"/>
+        <Annotation Term="OData.Description" String="The available OEM-specific actions for this resource."/>
+        <Annotation Term="OData.LongDescription" String="This type shall contain the available OEM-specific actions for this resource."/>
+      </ComplexType>
+    </Schema>
+
+  </edmx:DataServices>
+</edmx:Edmx>

--- a/static/redfish/v1/schema/PowerSupply_v1.xml
+++ b/static/redfish/v1/schema/PowerSupply_v1.xml
@@ -1,11 +1,11 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!---->
 <!--################################################################################       -->
-<!--# Redfish Schema:  PowerSupply v1.0.0                                                  -->
+<!--# Redfish Schema:  PowerSupply v1.1.0                                                  -->
 <!--#                                                                                      -->
 <!--# For a detailed change log, see the README file contained in the DSP8010 bundle,      -->
 <!--# available at http://www.dmtf.org/standards/redfish                                   -->
-<!--# Copyright 2014-2020 DMTF.                                                            -->
+<!--# Copyright 2014-2021 DMTF.                                                            -->
 <!--# For the full DMTF copyright policy, see http://www.dmtf.org/about/policies/copyright -->
 <!--################################################################################       -->
 <!---->
@@ -74,14 +74,15 @@
         <Annotation Term="Redfish.Uris">
           <Collection>
             <String>/redfish/v1/Chassis/{ChassisId}/PowerSubsystem/PowerSupplies/{PowerSupplyId}</String>
+            <String>/redfish/v1/PowerEquipment/PowerShelves/{PowerDistributionId}/PowerSupplies/{PowerSupplyId}</String>
           </Collection>
         </Annotation>
       </EntityType>
 
       <Action Name="Reset" IsBound="true">
         <Annotation Term="OData.Description" String="This action resets the power supply."/>
-        <Annotation Term="OData.LongDescription" String="This action shall reset a power supply.  A `GracefulRestart` ResetType shall reset the power supply but shall not affect the power output.  A `ForceRestart` ResetType might affect the power supply output."/>
-        <Parameter Name="Power" Type="PowerSupply.v1_0_0.Actions"/>
+        <Annotation Term="OData.LongDescription" String="This action shall reset a power supply.  A `GracefulRestart` ResetType shall reset the power supply but shall not affect the power output.  A `ForceRestart` ResetType can affect the power supply output."/>
+        <Parameter Name="PowerSupply" Type="PowerSupply.v1_0_0.Actions"/>
         <Parameter Name="ResetType" Type="Resource.ResetType">
           <Annotation Term="OData.Description" String="The type of reset."/>
           <Annotation Term="OData.LongDescription" String="This parameter shall contain the type of reset.  The service can accept a request without the parameter and shall perform a `GracefulRestart`."/>
@@ -114,7 +115,7 @@
         <Property Name="Manufacturer" Type="Edm.String">
           <Annotation Term="OData.Permissions" EnumMember="OData.Permission/Read"/>
           <Annotation Term="OData.Description" String="The manufacturer of this power supply."/>
-          <Annotation Term="OData.LongDescription" String="This property shall contain the name of the organization responsible for producing the power supply.  This organization might be the entity from whom the power supply is purchased, but this is not necessarily true."/>
+          <Annotation Term="OData.LongDescription" String="This property shall contain the name of the organization responsible for producing the power supply.  This organization may be the entity from whom the power supply is purchased, but this is not necessarily true."/>
         </Property>
         <Property Name="Model" Type="Edm.String">
           <Annotation Term="OData.Permissions" EnumMember="OData.Permission/Read"/>
@@ -297,6 +298,32 @@
         <Annotation Term="OData.Description" String="The available OEM-specific actions for this resource."/>
         <Annotation Term="OData.LongDescription" String="This type shall contain the available OEM-specific actions for this resource."/>
       </ComplexType>
+    </Schema>
+
+
+    <Schema xmlns="http://docs.oasis-open.org/odata/ns/edm" Namespace="PowerSupply.v1_0_1">
+      <Annotation Term="Redfish.OwningEntity" String="DMTF"/>
+      <Annotation Term="OData.Description" String="This version was created to correct various description to use proper normative terminology."/>
+      <EntityType Name="PowerSupply" BaseType="PowerSupply.v1_0_0.PowerSupply"/>
+    </Schema>
+
+    <Schema xmlns="http://docs.oasis-open.org/odata/ns/edm" Namespace="PowerSupply.v1_1_0">
+      <Annotation Term="Redfish.OwningEntity" String="DMTF"/>
+      <Annotation Term="Redfish.Release" String="2021.1"/>
+
+      <EntityType Name="PowerSupply" BaseType="PowerSupply.v1_0_0.PowerSupply">
+        <Property Name="Version" Type="Edm.String">
+          <Annotation Term="OData.Permissions" EnumMember="OData.Permission/Read"/>
+          <Annotation Term="OData.Description" String="The hardware version of this power supply."/>
+          <Annotation Term="OData.LongDescription" String="This property shall contain the hardware version of this power supply as determined by the vendor or supplier."/>
+        </Property>
+        <Property Name="ProductionDate" Type="Edm.DateTimeOffset">
+          <Annotation Term="OData.Permissions" EnumMember="OData.Permission/Read"/>
+          <Annotation Term="OData.Description" String="The production or manufacturing date of this power supply."/>
+          <Annotation Term="OData.LongDescription" String="This property shall contain the date of production or manufacture for this power supply."/>
+        </Property>
+      </EntityType>
+
     </Schema>
 
   </edmx:DataServices>

--- a/static/redfish/v1/schema/PrivilegeRegistry_v1.xml
+++ b/static/redfish/v1/schema/PrivilegeRegistry_v1.xml
@@ -1,0 +1,242 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!---->
+<!--################################################################################       -->
+<!--# Redfish Schema:  PrivilegeRegistry v1.1.4                                            -->
+<!--#                                                                                      -->
+<!--# For a detailed change log, see the README file contained in the DSP8010 bundle,      -->
+<!--# available at http://www.dmtf.org/standards/redfish                                   -->
+<!--# Copyright 2014-2021 DMTF.                                                            -->
+<!--# For the full DMTF copyright policy, see http://www.dmtf.org/about/policies/copyright -->
+<!--################################################################################       -->
+<!---->
+<edmx:Edmx xmlns:edmx="http://docs.oasis-open.org/odata/ns/edmx" Version="4.0">
+
+  <edmx:Reference Uri="http://docs.oasis-open.org/odata/odata/v4.0/errata03/csd01/complete/vocabularies/Org.OData.Core.V1.xml">
+    <edmx:Include Namespace="Org.OData.Core.V1" Alias="OData"/>
+  </edmx:Reference>
+  <edmx:Reference Uri="http://docs.oasis-open.org/odata/odata/v4.0/errata03/csd01/complete/vocabularies/Org.OData.Capabilities.V1.xml">
+    <edmx:Include Namespace="Org.OData.Capabilities.V1" Alias="Capabilities"/>
+  </edmx:Reference>
+  <edmx:Reference Uri="http://redfish.dmtf.org/schemas/v1/Resource_v1.xml">
+    <edmx:Include Namespace="Resource.v1_0_0"/>
+  </edmx:Reference>
+  <edmx:Reference Uri="http://redfish.dmtf.org/schemas/v1/RedfishExtensions_v1.xml">
+    <edmx:Include Namespace="RedfishExtensions.v1_0_0" Alias="Redfish"/>
+  </edmx:Reference>
+  <edmx:Reference Uri="http://redfish.dmtf.org/schemas/v1/Privileges_v1.xml">
+    <edmx:Include Namespace="Privileges"/>
+  </edmx:Reference>
+
+  <edmx:DataServices>
+
+    <Schema xmlns="http://docs.oasis-open.org/odata/ns/edm" Namespace="PrivilegeRegistry">
+      <Annotation Term="Redfish.OwningEntity" String="DMTF"/>
+
+      <EntityType Name="PrivilegeRegistry" BaseType="Resource.v1_0_0.Resource" Abstract="true">
+        <Annotation Term="OData.Description" String="The PrivilegeRegistry schema describes the operation-to-privilege mappings."/>
+        <Annotation Term="OData.LongDescription" String="This Resource contains operation-to-privilege mappings."/>
+        <Annotation Term="Capabilities.InsertRestrictions">
+          <Record>
+            <PropertyValue Property="Insertable" Bool="false"/>
+          </Record>
+        </Annotation>
+        <Annotation Term="Capabilities.UpdateRestrictions">
+          <Record>
+            <PropertyValue Property="Updatable" Bool="false"/>
+          </Record>
+        </Annotation>
+        <Annotation Term="Capabilities.DeleteRestrictions">
+          <Record>
+            <PropertyValue Property="Deletable" Bool="false"/>
+          </Record>
+        </Annotation>
+      </EntityType>
+
+    </Schema>
+
+    <Schema xmlns="http://docs.oasis-open.org/odata/ns/edm" Namespace="PrivilegeRegistry.v1_0_0">
+      <Annotation Term="Redfish.OwningEntity" String="DMTF"/>
+      <Annotation Term="Redfish.Release" String="2016.3"/>
+
+      <EntityType Name="PrivilegeRegistry" BaseType="PrivilegeRegistry.PrivilegeRegistry">
+        <Property Name="PrivilegesUsed" Type="Collection(Privileges.PrivilegeType)" Nullable="false">
+          <Annotation Term="OData.Permissions" EnumMember="OData.Permission/Read"/>
+          <Annotation Term="OData.Description" String="The set of Redfish standard privileges used in this mapping."/>
+          <Annotation Term="OData.LongDescription" String="This property shall contain an array of Redfish standard privileges used in this mapping."/>
+        </Property>
+        <Property Name="OEMPrivilegesUsed" Type="Collection(Edm.String)" Nullable="false">
+          <Annotation Term="OData.Permissions" EnumMember="OData.Permission/Read"/>
+          <Annotation Term="OData.Description" String="The set of OEM privileges used in this mapping."/>
+          <Annotation Term="OData.LongDescription" String="This property shall contain an array of OEM privileges used in this mapping."/>
+        </Property>
+        <Property Name="Mappings" Type="Collection(PrivilegeRegistry.v1_0_0.Mapping)" Nullable="false">
+          <Annotation Term="OData.Description" String="The mappings between entities and the relevant privileges that access those entities."/>
+          <Annotation Term="OData.LongDescription" String="This property shall describe the mappings between entities and the relevant privileges that access those entities."/>
+        </Property>
+      </EntityType>
+
+      <ComplexType Name="Mapping">
+        <Annotation Term="OData.Description" String="The mapping between a Resource type and the relevant privileges that accesses the Resource."/>
+        <Annotation Term="OData.LongDescription" String="This type shall describe a mapping between a Resource type and the relevant privileges that accesses the Resource."/>
+        <Property Name="Entity" Type="Edm.String" Nullable="false">
+          <Annotation Term="OData.Permissions" EnumMember="OData.Permission/Read"/>
+          <Annotation Term="OData.Description" String="The Resource name, such as `Manager`."/>
+          <Annotation Term="OData.LongDescription" String="This property shall contain the Resource name, such as `Manager`."/>
+        </Property>
+        <Property Name="SubordinateOverrides" Type="Collection(PrivilegeRegistry.v1_0_0.Target_PrivilegeMap)" Nullable="false">
+          <Annotation Term="OData.Description" String="The privilege overrides of the subordinate Resource."/>
+          <Annotation Term="OData.LongDescription" String="This property shall contain the privilege overrides of the subordinate Resource.  The target lists are identified by Resource type."/>
+        </Property>
+        <Property Name="ResourceURIOverrides" Type="Collection(PrivilegeRegistry.v1_0_0.Target_PrivilegeMap)" Nullable="false">
+          <Annotation Term="OData.Description" String="The privilege overrides of Resource URIs."/>
+          <Annotation Term="OData.LongDescription" String="This property shall contain the privilege overrides of Resource URIs.  The target lists the Resource URI and the new privileges."/>
+        </Property>
+        <Property Name="PropertyOverrides" Type="Collection(PrivilegeRegistry.v1_0_0.Target_PrivilegeMap)" Nullable="false">
+          <Annotation Term="OData.Description" String="The privilege overrides of properties within a Resource."/>
+          <Annotation Term="OData.LongDescription" String="This property shall contain the privilege overrides of properties, such as the `Password` property in the `ManagerAccount` Resource."/>
+        </Property>
+        <Property Name="OperationMap" Type="PrivilegeRegistry.v1_0_0.OperationMap" Nullable="false">
+          <Annotation Term="OData.Description" String="List mapping between HTTP methods and privilege required for the Resource."/>
+          <Annotation Term="OData.LongDescription" String="This property shall list the mapping between HTTP methods and the privilege required for the Resource."/>
+        </Property>
+      </ComplexType>
+
+      <ComplexType Name="Target_PrivilegeMap">
+        <Annotation Term="OData.Description" String="This type describes a mapping between one or more targets and the HTTP operations associated with them."/>
+        <Annotation Term="OData.LongDescription" String="This type shall describe a mapping between one or more targets and the HTTP operations associated with them."/>
+        <Property Name="Targets" Type="Collection(Edm.String)">
+          <Annotation Term="OData.Permissions" EnumMember="OData.Permission/Read"/>
+          <Annotation Term="OData.Description" String="The set of URIs, Resource types, or properties."/>
+          <Annotation Term="OData.LongDescription" String="This property shall contain the array of URIs, Resource types, or properties.  For example, `/redfish/v1/Systems/1`, `Manager`, or `Password`.  When the Targets property is not present, no override is specified."/>
+        </Property>
+        <Property Name="OperationMap" Type="PrivilegeRegistry.v1_0_0.OperationMap" Nullable="false">
+          <Annotation Term="OData.Description" String="The mapping between the HTTP operation and the privilege required to complete the operation."/>
+          <Annotation Term="OData.LongDescription" String="This property shall contain the mapping between the HTTP operation and the privilege required to complete the operation."/>
+        </Property>
+      </ComplexType>
+
+      <ComplexType Name="OperationMap">
+        <Annotation Term="OData.Description" String="The specific privileges required to complete a set of HTTP operations."/>
+        <Annotation Term="OData.LongDescription" String="This type shall describe the specific privileges required to complete a set of HTTP operations."/>
+        <Annotation Term="OData.AdditionalProperties" Bool="false"/>
+        <Property Name="GET" Type="Collection(PrivilegeRegistry.v1_0_0.OperationPrivilege)" Nullable="false">
+          <Annotation Term="OData.Description" String="The privilege required to complete an HTTP GET operation."/>
+          <Annotation Term="OData.LongDescription" String="This property shall contain the privilege required to complete an HTTP GET operation."/>
+        </Property>
+        <Property Name="HEAD" Type="Collection(PrivilegeRegistry.v1_0_0.OperationPrivilege)" Nullable="false">
+          <Annotation Term="OData.Description" String="The privilege required to complete an HTTP HEAD operation."/>
+          <Annotation Term="OData.LongDescription" String="This property shall contain the privilege required to complete an HTTP HEAD operation."/>
+        </Property>
+        <Property Name="PATCH" Type="Collection(PrivilegeRegistry.v1_0_0.OperationPrivilege)" Nullable="false">
+          <Annotation Term="OData.Description" String="The privilege required to complete an HTTP PATCH operation."/>
+          <Annotation Term="OData.LongDescription" String="This property shall contain the privilege required to complete an HTTP PATCH operation."/>
+        </Property>
+        <Property Name="POST" Type="Collection(PrivilegeRegistry.v1_0_0.OperationPrivilege)" Nullable="false">
+          <Annotation Term="OData.Description" String="The privilege required to complete an HTTP POST operation."/>
+          <Annotation Term="OData.LongDescription" String="This property shall contain the privilege required to complete an HTTP POST operation."/>
+        </Property>
+        <Property Name="PUT" Type="Collection(PrivilegeRegistry.v1_0_0.OperationPrivilege)" Nullable="false">
+          <Annotation Term="OData.Description" String="The privilege required to complete an HTTP PUT operation."/>
+          <Annotation Term="OData.LongDescription" String="This property shall contain the privilege required to complete an HTTP PUT operation."/>
+        </Property>
+        <Property Name="DELETE" Type="Collection(PrivilegeRegistry.v1_0_0.OperationPrivilege)" Nullable="false">
+          <Annotation Term="OData.Description" String="The privilege required to complete an HTTP DELETE operation."/>
+          <Annotation Term="OData.LongDescription" String="This property shall contain the privilege required to complete an HTTP DELETE operation."/>
+        </Property>
+      </ComplexType>
+
+      <ComplexType Name="OperationPrivilege">
+        <Annotation Term="OData.Description" String="The privileges for a specific HTTP operation."/>
+        <Annotation Term="OData.LongDescription" String="This type shall describe the privileges required to complete a specific HTTP operation."/>
+        <Property Name="Privilege" Type="Collection(Edm.String)" Nullable="false">
+          <Annotation Term="OData.Permissions" EnumMember="OData.Permission/Read"/>
+          <Annotation Term="OData.Description" String="An array of privileges that are required to complete a specific HTTP operation on a Resource."/>
+          <Annotation Term="OData.LongDescription" String="This array shall contain an array of privileges that are required to complete a specific HTTP operation on a Resource.  This set of strings match zero or more strings in the PrivilegesUsed and OEMPrivilegesUsed properties."/>
+        </Property>
+      </ComplexType>
+
+    </Schema>
+
+    <Schema xmlns="http://docs.oasis-open.org/odata/ns/edm" Namespace="PrivilegeRegistry.v1_0_1">
+      <Annotation Term="Redfish.OwningEntity" String="DMTF"/>
+      <Annotation Term="OData.Description" String="This version was created to show that annotations in previous namespaces were updated."/>
+      <EntityType Name="PrivilegeRegistry" BaseType="PrivilegeRegistry.v1_0_0.PrivilegeRegistry"/>
+    </Schema>
+
+    <Schema xmlns="http://docs.oasis-open.org/odata/ns/edm" Namespace="PrivilegeRegistry.v1_0_2">
+      <Annotation Term="Redfish.OwningEntity" String="DMTF"/>
+      <Annotation Term="OData.Description" String="This version was created to change references to PrivilegeType to use the unversioned definition."/>
+      <EntityType Name="PrivilegeRegistry" BaseType="PrivilegeRegistry.v1_0_1.PrivilegeRegistry"/>
+    </Schema>
+
+    <Schema xmlns="http://docs.oasis-open.org/odata/ns/edm" Namespace="PrivilegeRegistry.v1_0_3">
+      <Annotation Term="Redfish.OwningEntity" String="DMTF"/>
+      <Annotation Term="OData.Description" String="This version was created to force the regeneration of JSON Schema so that OData properties are marked as required, and integer properties are marked as integer rather than number."/>
+      <EntityType Name="PrivilegeRegistry" BaseType="PrivilegeRegistry.v1_0_2.PrivilegeRegistry"/>
+    </Schema>
+
+    <Schema xmlns="http://docs.oasis-open.org/odata/ns/edm" Namespace="PrivilegeRegistry.v1_0_4">
+      <Annotation Term="Redfish.OwningEntity" String="DMTF"/>
+      <Annotation Term="OData.Description" String="This version was created to force the regeneration of JSON Schema so that URI properties use the uri-reference format, and to add a missing term to several properties to disallow them from being null."/>
+      <EntityType Name="PrivilegeRegistry" BaseType="PrivilegeRegistry.v1_0_3.PrivilegeRegistry"/>
+    </Schema>
+
+    <Schema xmlns="http://docs.oasis-open.org/odata/ns/edm" Namespace="PrivilegeRegistry.v1_0_5">
+      <Annotation Term="Redfish.OwningEntity" String="DMTF"/>
+      <Annotation Term="OData.Description" String="This version was created to force the regeneration of JSON Schema so that OData properties are not included.  It was also created to update descriptions that this schema defines."/>
+      <EntityType Name="PrivilegeRegistry" BaseType="PrivilegeRegistry.v1_0_4.PrivilegeRegistry"/>
+    </Schema>
+
+    <Schema xmlns="http://docs.oasis-open.org/odata/ns/edm" Namespace="PrivilegeRegistry.v1_1_0">
+      <Annotation Term="Redfish.OwningEntity" String="DMTF"/>
+      <Annotation Term="Redfish.Release" String="2017.1"/>
+      <EntityType Name="PrivilegeRegistry" BaseType="PrivilegeRegistry.v1_0_1.PrivilegeRegistry">
+        <Property Name="Actions" Type="PrivilegeRegistry.v1_1_0.Actions" Nullable="false">
+          <Annotation Term="OData.Description" String="The available actions for this Resource."/>
+          <Annotation Term="OData.LongDescription" String="This property shall contain the available actions for this Resource."/>
+        </Property>
+      </EntityType>
+
+      <ComplexType Name="Actions">
+        <Annotation Term="OData.AdditionalProperties" Bool="false"/>
+        <Annotation Term="OData.Description" String="The available actions for this Resource."/>
+        <Annotation Term="OData.LongDescription" String="This type shall contain the available actions for this Resource."/>
+        <Property Name="Oem" Type="PrivilegeRegistry.v1_1_0.OemActions" Nullable="false">
+          <Annotation Term="OData.Description" String="The available OEM-specific actions for this Resource."/>
+          <Annotation Term="OData.LongDescription" String="This property shall contain the available OEM-specific actions for this Resource."/>
+        </Property>
+      </ComplexType>
+
+      <ComplexType Name="OemActions">
+        <Annotation Term="OData.AdditionalProperties" Bool="true"/>
+        <Annotation Term="OData.Description" String="The available OEM-specific actions for this Resource."/>
+        <Annotation Term="OData.LongDescription" String="This type shall contain the available OEM-specific actions for this Resource."/>
+      </ComplexType>
+    </Schema>
+
+    <Schema xmlns="http://docs.oasis-open.org/odata/ns/edm" Namespace="PrivilegeRegistry.v1_1_1">
+      <Annotation Term="Redfish.OwningEntity" String="DMTF"/>
+      <Annotation Term="OData.Description" String="This version was created to change references to PrivilegeType to use the unversioned definition."/>
+      <EntityType Name="PrivilegeRegistry" BaseType="PrivilegeRegistry.v1_1_0.PrivilegeRegistry"/>
+    </Schema>
+
+    <Schema xmlns="http://docs.oasis-open.org/odata/ns/edm" Namespace="PrivilegeRegistry.v1_1_2">
+      <Annotation Term="Redfish.OwningEntity" String="DMTF"/>
+      <Annotation Term="OData.Description" String="This version was created to force the regeneration of JSON Schema so that OData properties are marked as required, and integer properties are marked as integer rather than number.  It was also created to fix the Permission term in several properties."/>
+      <EntityType Name="PrivilegeRegistry" BaseType="PrivilegeRegistry.v1_1_1.PrivilegeRegistry"/>
+    </Schema>
+
+    <Schema xmlns="http://docs.oasis-open.org/odata/ns/edm" Namespace="PrivilegeRegistry.v1_1_3">
+      <Annotation Term="Redfish.OwningEntity" String="DMTF"/>
+      <Annotation Term="OData.Description" String="This version was created to force the regeneration of JSON Schema so that URI properties use the uri-reference format, and to add a missing term to several properties to disallow them from being null."/>
+      <EntityType Name="PrivilegeRegistry" BaseType="PrivilegeRegistry.v1_1_2.PrivilegeRegistry"/>
+    </Schema>
+
+    <Schema xmlns="http://docs.oasis-open.org/odata/ns/edm" Namespace="PrivilegeRegistry.v1_1_4">
+      <Annotation Term="Redfish.OwningEntity" String="DMTF"/>
+      <Annotation Term="OData.Description" String="This version was created to force the regeneration of JSON Schema so that OData properties are not included.  It was also created to update descriptions that this schema defines."/>
+      <EntityType Name="PrivilegeRegistry" BaseType="PrivilegeRegistry.v1_1_3.PrivilegeRegistry"/>
+    </Schema>
+
+  </edmx:DataServices>
+</edmx:Edmx>

--- a/static/redfish/v1/schema/ProcessorMetrics_v1.xml
+++ b/static/redfish/v1/schema/ProcessorMetrics_v1.xml
@@ -1,0 +1,465 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!---->
+<!--################################################################################       -->
+<!--# Redfish Schema:  ProcessorMetrics v1.3.0                                             -->
+<!--#                                                                                      -->
+<!--# For a detailed change log, see the README file contained in the DSP8010 bundle,      -->
+<!--# available at http://www.dmtf.org/standards/redfish                                   -->
+<!--# Copyright 2014-2021 DMTF.                                                            -->
+<!--# For the full DMTF copyright policy, see http://www.dmtf.org/about/policies/copyright -->
+<!--################################################################################       -->
+<!---->
+<edmx:Edmx xmlns:edmx="http://docs.oasis-open.org/odata/ns/edmx" Version="4.0">
+
+  <edmx:Reference Uri="http://docs.oasis-open.org/odata/odata/v4.0/errata03/csd01/complete/vocabularies/Org.OData.Core.V1.xml">
+    <edmx:Include Namespace="Org.OData.Core.V1" Alias="OData"/>
+  </edmx:Reference>
+  <edmx:Reference Uri="http://docs.oasis-open.org/odata/odata/v4.0/errata03/csd01/complete/vocabularies/Org.OData.Capabilities.V1.xml">
+    <edmx:Include Namespace="Org.OData.Capabilities.V1" Alias="Capabilities"/>
+  </edmx:Reference>
+  <edmx:Reference Uri="http://docs.oasis-open.org/odata/odata/v4.0/errata03/csd01/complete/vocabularies/Org.OData.Measures.V1.xml">
+    <edmx:Include Namespace="Org.OData.Measures.V1" Alias="Measures"/>
+  </edmx:Reference>
+  <edmx:Reference Uri="http://redfish.dmtf.org/schemas/v1/RedfishExtensions_v1.xml">
+    <edmx:Include Namespace="RedfishExtensions.v1_0_0" Alias="Redfish"/>
+    <edmx:Include Namespace="Validation.v1_0_0" Alias="Validation"/>
+  </edmx:Reference>
+  <edmx:Reference Uri="http://redfish.dmtf.org/schemas/v1/Resource_v1.xml">
+    <edmx:Include Namespace="Resource.v1_0_0"/>
+  </edmx:Reference>
+  <edmx:Reference Uri="http://redfish.dmtf.org/schemas/v1/Sensor_v1.xml">
+    <edmx:Include Namespace="Sensor"/>
+  </edmx:Reference>
+
+  <edmx:DataServices>
+
+    <Schema xmlns="http://docs.oasis-open.org/odata/ns/edm" Namespace="ProcessorMetrics">
+      <Annotation Term="Redfish.OwningEntity" String="DMTF"/>
+
+      <EntityType Name="ProcessorMetrics" BaseType="Resource.v1_0_0.Resource" Abstract="true">
+        <Annotation Term="OData.Description" String="The ProcessorMetrics schema contains usage and health statistics for a processor."/>
+        <Annotation Term="OData.LongDescription" String="This resource contains the processor metrics for a single processor in a Redfish implementation."/>
+        <Annotation Term="OData.AdditionalProperties" Bool="false"/>
+        <Annotation Term="Capabilities.InsertRestrictions">
+          <Record>
+            <PropertyValue Property="Insertable" Bool="false"/>
+          </Record>
+        </Annotation>
+        <Annotation Term="Capabilities.UpdateRestrictions">
+          <Record>
+            <PropertyValue Property="Updatable" Bool="false"/>
+          </Record>
+        </Annotation>
+        <Annotation Term="Capabilities.DeleteRestrictions">
+          <Record>
+            <PropertyValue Property="Deletable" Bool="false"/>
+          </Record>
+        </Annotation>
+        <Annotation Term="Redfish.Uris">
+          <Collection>
+            <String>/redfish/v1/Systems/{ComputerSystemId}/ProcessorSummary/ProcessorMetrics</String>
+            <String>/redfish/v1/Systems/{ComputerSystemId}/Processors/{ProcessorId}/ProcessorMetrics</String>
+            <String>/redfish/v1/Systems/{ComputerSystemId}/Processors/{ProcessorId}/SubProcessors/{ProcessorId2}/ProcessorMetrics</String>
+            <String>/redfish/v1/CompositionService/ResourceBlocks/{ResourceBlockId}/Processors/{ProcessorId}/ProcessorMetrics</String>
+            <String>/redfish/v1/CompositionService/ResourceBlocks/{ResourceBlockId}/Processors/{ProcessorId}/SubProcessors/{ProcessorId2}/ProcessorMetrics</String>
+            <String>/redfish/v1/CompositionService/ResourceBlocks/{ResourceBlockId}/Systems/{ComputerSystemId}/ProcessorSummary/ProcessorMetrics</String>
+            <String>/redfish/v1/CompositionService/ResourceBlocks/{ResourceBlockId}/Systems/{ComputerSystemId}/Processors/{ProcessorId}/ProcessorMetrics</String>
+            <String>/redfish/v1/CompositionService/ResourceBlocks/{ResourceBlockId}/Systems/{ComputerSystemId}/Processors/{ProcessorId}/SubProcessors/{ProcessorId2}/ProcessorMetrics</String>
+            <String>/redfish/v1/ResourceBlocks/{ResourceBlockId}/Processors/{ProcessorId}/ProcessorMetrics</String>
+            <String>/redfish/v1/ResourceBlocks/{ResourceBlockId}/Processors/{ProcessorId}/SubProcessors/{ProcessorId2}/ProcessorMetrics</String>
+            <String>/redfish/v1/ResourceBlocks/{ResourceBlockId}/Systems/{ComputerSystemId}/ProcessorSummary/ProcessorMetrics</String>
+            <String>/redfish/v1/ResourceBlocks/{ResourceBlockId}/Systems/{ComputerSystemId}/Processors/{ProcessorId}/ProcessorMetrics</String>
+            <String>/redfish/v1/ResourceBlocks/{ResourceBlockId}/Systems/{ComputerSystemId}/Processors/{ProcessorId}/SubProcessors/{ProcessorId2}/ProcessorMetrics</String>
+          </Collection>
+        </Annotation>
+      </EntityType>
+
+      <Action Name="ClearCurrentPeriod" IsBound="true">
+        <Annotation Term="OData.Description" String="This action sets the CurrentPeriod property's values to 0."/>
+        <Annotation Term="OData.LongDescription" String="This action shall set the CurrentPeriod property's values to 0."/>
+        <Parameter Name="ProcessorMetrics" Type="ProcessorMetrics.v1_0_0.Actions"/>
+        <Annotation Term="Redfish.Revisions">
+          <Collection>
+            <Record>
+              <PropertyValue Property="Kind" EnumMember="Redfish.RevisionKind/Added"/>
+              <PropertyValue Property="Version" String="v1_2_0"/>
+            </Record>
+          </Collection>
+        </Annotation>
+      </Action>
+    </Schema>
+
+    <Schema xmlns="http://docs.oasis-open.org/odata/ns/edm" Namespace="ProcessorMetrics.v1_0_0">
+      <Annotation Term="Redfish.OwningEntity" String="DMTF"/>
+      <Annotation Term="Redfish.Release" String="2018.3"/>
+
+      <EntityType Name="ProcessorMetrics" BaseType="ProcessorMetrics.ProcessorMetrics">
+        <Property Name="BandwidthPercent" Type="Edm.Decimal">
+          <Annotation Term="OData.Permissions" EnumMember="OData.Permission/Read"/>
+          <Annotation Term="OData.Description" String="The bandwidth usage of this processor as a percentage."/>
+          <Annotation Term="OData.LongDescription" String="This property shall contain the bandwidth usage of the processor as a percentage.  When this resource is subordinate to the ProcessorSummary object, this property shall be the CPU utilization over all processors as a percentage."/>
+          <Annotation Term="Validation.Minimum" Int="0"/>
+          <Annotation Term="Measures.Unit" String="%"/>
+        </Property>
+        <Property Name="AverageFrequencyMHz" Type="Edm.Decimal">
+          <Annotation Term="OData.Permissions" EnumMember="OData.Permission/Read"/>
+          <Annotation Term="OData.Description" String="The average frequency of the processor."/>
+          <Annotation Term="OData.LongDescription" String="This property shall contain average frequency in MHz, across all enabled cores in the processor.  When this resource is subordinate to the ProcessorSummary object, this property is not applicable."/>
+          <Annotation Term="Measures.Unit" String="MHz"/>
+          <Annotation Term="Redfish.Revisions">
+            <Collection>
+              <Record>
+                <PropertyValue Property="Kind" EnumMember="Redfish.RevisionKind/Deprecated"/>
+                <PropertyValue Property="Version" String="v1_1_0"/>
+                <PropertyValue Property="Description" String="This property has been deprecated in favor of OperatingSpeedMHz property."/>
+              </Record>
+            </Collection>
+          </Annotation>
+        </Property>
+        <Property Name="ThrottlingCelsius" Type="Edm.Decimal">
+          <Annotation Term="OData.Permissions" EnumMember="OData.Permission/Read"/>
+          <Annotation Term="OData.Description" String="The CPU margin to throttle (temperature offset in degree Celsius)."/>
+          <Annotation Term="OData.LongDescription" String="This property shall contain the CPU margin to throttle based on an offset between the maximum temperature in which the processor can operate, and the processor's current temperature.  When this resource is subordinate to the ProcessorSummary object, this property is not applicable."/>
+          <Annotation Term="Measures.Unit" String="Cel"/>
+        </Property>
+        <Property Name="TemperatureCelsius" Type="Edm.Decimal">
+          <Annotation Term="OData.Permissions" EnumMember="OData.Permission/Read"/>
+          <Annotation Term="OData.Description" String="The temperature of the processor."/>
+          <Annotation Term="OData.LongDescription" String="This property shall contain the temperature, in Celsius, of the processor.  When this resource is subordinate to the ProcessorSummary object, this property shall be the average temperature, in Celsius, over all processors."/>
+          <Annotation Term="Measures.Unit" String="Cel"/>
+          <Annotation Term="Redfish.Revisions">
+            <Collection>
+              <Record>
+                <PropertyValue Property="Kind" EnumMember="Redfish.RevisionKind/Deprecated"/>
+                <PropertyValue Property="Version" String="v1_2_0"/>
+                <PropertyValue Property="Description" String="This property has been deprecated in favor of the properties in EnvironmentMetrics."/>
+              </Record>
+            </Collection>
+          </Annotation>
+        </Property>
+        <Property Name="ConsumedPowerWatt" Type="Edm.Decimal">
+          <Annotation Term="OData.Permissions" EnumMember="OData.Permission/Read"/>
+          <Annotation Term="OData.Description" String="The power, in watts, that the processor has consumed."/>
+          <Annotation Term="OData.LongDescription" String="This property shall contain the power, in watts, that the processor has consumed.  When this resource is subordinate to the ProcessorSummary object, this property shall be the sum of power, in watts, that all processors have consumed."/>
+          <Annotation Term="Measures.Unit" String="W"/>
+          <Annotation Term="Redfish.Revisions">
+            <Collection>
+              <Record>
+                <PropertyValue Property="Kind" EnumMember="Redfish.RevisionKind/Deprecated"/>
+                <PropertyValue Property="Version" String="v1_2_0"/>
+                <PropertyValue Property="Description" String="This property has been deprecated in favor of the properties in EnvironmentMetrics."/>
+              </Record>
+            </Collection>
+          </Annotation>
+        </Property>
+        <Property Name="FrequencyRatio" Type="Edm.Decimal">
+          <Annotation Term="OData.Permissions" EnumMember="OData.Permission/Read"/>
+          <Annotation Term="OData.Description" String="The frequency relative to the nominal processor frequency ratio."/>
+          <Annotation Term="OData.LongDescription" String="This property shall contain the frequency relative to the nominal processor frequency ratio of this processor.  When this resource is subordinate to the ProcessorSummary object, this property shall be the average FrequencyRatio over all processors."/>
+        </Property>
+        <Property Name="Cache" Type="Collection(ProcessorMetrics.v1_0_0.CacheMetrics)" Nullable="false">
+          <Annotation Term="OData.Description" String="The processor cache metrics."/>
+          <Annotation Term="OData.LongDescription" String="This property shall contain properties that describe this processor's cache.  When this resource is subordinate to the ProcessorSummary object, this property is not applicable."/>
+        </Property>
+        <Property Name="LocalMemoryBandwidthBytes" Type="Edm.Int64">
+          <Annotation Term="OData.Permissions" EnumMember="OData.Permission/Read"/>
+          <Annotation Term="OData.Description" String="The local memory bandwidth usage in bytes."/>
+          <Annotation Term="OData.LongDescription" String="This property shall contain the local memory bandwidth usage of this processor in bytes.  When this resource is subordinate to the ProcessorSummary object, this property shall be the sum of LocalMemoryBandwidthBytes over all processors."/>
+          <Annotation Term="Measures.Unit" String="By"/>
+        </Property>
+        <Property Name="RemoteMemoryBandwidthBytes" Type="Edm.Int64">
+          <Annotation Term="OData.Permissions" EnumMember="OData.Permission/Read"/>
+          <Annotation Term="OData.Description" String="The remote memory bandwidth usage in bytes."/>
+          <Annotation Term="OData.LongDescription" String="This property shall contain the remote memory bandwidth usage of this processor in bytes.  When this resource is subordinate to the ProcessorSummary object, this property shall be the sum of RemoteMemoryBandwidthBytes over all processors."/>
+          <Annotation Term="Measures.Unit" String="By"/>
+        </Property>
+        <Property Name="KernelPercent" Type="Edm.Decimal">
+          <Annotation Term="OData.Permissions" EnumMember="OData.Permission/Read"/>
+          <Annotation Term="OData.Description" String="The percentage of time spent in kernel mode."/>
+          <Annotation Term="OData.LongDescription" String="This property shall contain total percentage of time the processor has spent in kernel mode.  When this resource is subordinate to the ProcessorSummary object, this property shall be the average KernelPercent over all processors."/>
+          <Annotation Term="Validation.Minimum" Int="0"/>
+          <Annotation Term="Measures.Unit" String="%"/>
+        </Property>
+        <Property Name="UserPercent" Type="Edm.Decimal">
+          <Annotation Term="OData.Permissions" EnumMember="OData.Permission/Read"/>
+          <Annotation Term="OData.Description" String="The percentage of time spent in user mode."/>
+          <Annotation Term="OData.LongDescription" String="This property shall contain total percentage of time the processor has spent in user mode.  When this resource is subordinate to the ProcessorSummary object, this property shall be the average UserPercent over all processors."/>
+          <Annotation Term="Validation.Minimum" Int="0"/>
+          <Annotation Term="Measures.Unit" String="%"/>
+        </Property>
+        <Property Name="CoreMetrics" Type="Collection(ProcessorMetrics.v1_0_0.CoreMetrics)" Nullable="false">
+          <Annotation Term="OData.Description" String="The processor core metrics."/>
+          <Annotation Term="OData.LongDescription" String="This property shall contain properties that describe the cores of this processor.  When this resource is subordinate to the ProcessorSummary object, this property is not applicable."/>
+        </Property>
+        <Property Name="Actions" Type="ProcessorMetrics.v1_0_0.Actions" Nullable="false">
+          <Annotation Term="OData.Description" String="The available actions for this resource."/>
+          <Annotation Term="OData.LongDescription" String="This property shall contain the available actions for this resource."/>
+        </Property>
+      </EntityType>
+
+      <ComplexType Name="CoreMetrics">
+        <Annotation Term="OData.Description" String="The processor core metrics."/>
+        <Annotation Term="OData.LongDescription" String="This type shall contain properties that describe the cores of a processor."/>
+        <Property Name="CoreId" Type="Edm.String">
+          <Annotation Term="OData.Permissions" EnumMember="OData.Permission/Read"/>
+          <Annotation Term="OData.Description" String="The processor core identifier."/>
+          <Annotation Term="OData.LongDescription" String="This property shall contain the identifier of the core within the processor."/>
+        </Property>
+        <Property Name="InstructionsPerCycle" Type="Edm.Decimal">
+          <Annotation Term="OData.Permissions" EnumMember="OData.Permission/Read"/>
+          <Annotation Term="OData.Description" String="The number of instructions per clock cycle of this core."/>
+          <Annotation Term="OData.LongDescription" String="This property shall contain the number of instructions per clock cycle of this core in the processor."/>
+        </Property>
+        <Property Name="UnhaltedCycles" Type="Edm.Decimal">
+          <Annotation Term="OData.Permissions" EnumMember="OData.Permission/Read"/>
+          <Annotation Term="OData.Description" String="The unhalted cycles count of this core."/>
+          <Annotation Term="OData.LongDescription" String="This property shall contain the number of unhalted cycles of this core in the processor."/>
+        </Property>
+        <Property Name="MemoryStallCount" Type="Edm.Decimal">
+          <Annotation Term="OData.Permissions" EnumMember="OData.Permission/Read"/>
+          <Annotation Term="OData.Description" String="The number of stalled cycles due to memory operations."/>
+          <Annotation Term="OData.LongDescription" String="This property shall contain the number of stalled cycles due to memory operations of this core in the processor."/>
+        </Property>
+        <Property Name="IOStallCount" Type="Edm.Decimal">
+          <Annotation Term="OData.Permissions" EnumMember="OData.Permission/Read"/>
+          <Annotation Term="OData.Description" String="The number of stalled cycles due to I/O operations."/>
+          <Annotation Term="OData.LongDescription" String="This property shall contain the number of stalled cycles due to I/O operations of this core in the processor."/>
+        </Property>
+        <Property Name="CoreCache" Type="Collection(ProcessorMetrics.v1_0_0.CacheMetrics)" Nullable="false">
+          <Annotation Term="OData.Description" String="The cache metrics of this core in the processor."/>
+          <Annotation Term="OData.LongDescription" String="This property shall contain properties that describe the cache metrics of this core in the processor."/>
+        </Property>
+        <Property Name="CStateResidency" Type="Collection(ProcessorMetrics.v1_0_0.CStateResidency)" Nullable="false">
+          <Annotation Term="OData.Description" String="The C-state residency of this core in the processor."/>
+          <Annotation Term="OData.LongDescription" String="This property shall contain properties that describe the C-state residency of this core in the processor."/>
+        </Property>
+      </ComplexType>
+
+      <ComplexType Name="CacheMetrics">
+        <Annotation Term="OData.Description" String="The processor core metrics."/>
+        <Annotation Term="OData.LongDescription" String="This type shall contain properties that describe cache metrics of a processor or core."/>
+        <Property Name="Level" Type="Edm.String">
+          <Annotation Term="OData.Permissions" EnumMember="OData.Permission/Read"/>
+          <Annotation Term="OData.Description" String="The cache level."/>
+          <Annotation Term="OData.LongDescription" String="This property shall contain the level of the cache in the processor or core."/>
+        </Property>
+        <Property Name="CacheMiss" Type="Edm.Decimal">
+          <Annotation Term="OData.Permissions" EnumMember="OData.Permission/Read"/>
+          <Annotation Term="OData.Description" String="The number of cache line misses in millions."/>
+          <Annotation Term="OData.LongDescription" String="This property shall contain the number of cache line misses of the processor or core in millions."/>
+        </Property>
+        <Property Name="HitRatio" Type="Edm.Decimal">
+          <Annotation Term="OData.Permissions" EnumMember="OData.Permission/Read"/>
+          <Annotation Term="OData.Description" String="The cache line hit ratio."/>
+          <Annotation Term="OData.LongDescription" String="This property shall contain the cache hit ratio of the processor or core."/>
+        </Property>
+        <Property Name="CacheMissesPerInstruction" Type="Edm.Decimal">
+          <Annotation Term="OData.Permissions" EnumMember="OData.Permission/Read"/>
+          <Annotation Term="OData.Description" String="The number of cache misses per instruction."/>
+          <Annotation Term="OData.LongDescription" String="This property shall contain the number of cache misses per instruction of the processor or core."/>
+        </Property>
+        <Property Name="OccupancyBytes" Type="Edm.Int64">
+          <Annotation Term="OData.Permissions" EnumMember="OData.Permission/Read"/>
+          <Annotation Term="OData.Description" String="The total cache level occupancy in bytes."/>
+          <Annotation Term="OData.LongDescription" String="This property shall contain the total cache occupancy of the processor or core in bytes."/>
+          <Annotation Term="Measures.Unit" String="By"/>
+        </Property>
+        <Property Name="OccupancyPercent" Type="Edm.Decimal">
+          <Annotation Term="OData.Permissions" EnumMember="OData.Permission/Read"/>
+          <Annotation Term="OData.Description" String="The total cache occupancy percentage."/>
+          <Annotation Term="OData.LongDescription" String="This property shall contain the total cache occupancy percentage of the processor or core."/>
+          <Annotation Term="Validation.Minimum" Int="0"/>
+          <Annotation Term="Measures.Unit" String="%"/>
+        </Property>
+      </ComplexType>
+
+      <ComplexType Name="CStateResidency">
+        <Annotation Term="OData.Description" String="The C-state residency of the processor."/>
+        <Annotation Term="OData.LongDescription" String="This type shall contain properties that describe the C-state residency of the processor or core."/>
+        <Property Name="Level" Type="Edm.String">
+          <Annotation Term="OData.Permissions" EnumMember="OData.Permission/Read"/>
+          <Annotation Term="OData.Description" String="The C-state level, such as C0, C1, or C2."/>
+          <Annotation Term="OData.LongDescription" String="This property shall contain the C-state level, such as C0, C1, or C2.  When this resource is subordinate to the ProcessorSummary object, this property is not applicable."/>
+        </Property>
+        <Property Name="ResidencyPercent" Type="Edm.Decimal">
+          <Annotation Term="OData.Permissions" EnumMember="OData.Permission/Read"/>
+          <Annotation Term="OData.Description" String="The percentage of time that the processor or core has spent in this particular level of C-state."/>
+          <Annotation Term="OData.LongDescription" String="This property shall contain the percentage of time that the processor or core has spent in this particular level of C-state.  When this resource is subordinate to the ProcessorSummary object, this property is not applicable."/>
+          <Annotation Term="Validation.Minimum" Int="0"/>
+          <Annotation Term="Measures.Unit" String="%"/>
+        </Property>
+      </ComplexType>
+
+      <ComplexType Name="Actions">
+        <Annotation Term="OData.AdditionalProperties" Bool="false"/>
+        <Annotation Term="OData.Description" String="The available actions for this resource."/>
+        <Annotation Term="OData.LongDescription" String="This type shall contain the available actions for this resource."/>
+        <Property Name="Oem" Type="ProcessorMetrics.v1_0_0.OemActions" Nullable="false">
+          <Annotation Term="OData.Description" String="The available OEM-specific actions for this resource."/>
+          <Annotation Term="OData.LongDescription" String="This property shall contain the available OEM-specific actions for this resource."/>
+        </Property>
+      </ComplexType>
+
+      <ComplexType Name="OemActions">
+        <Annotation Term="OData.AdditionalProperties" Bool="true"/>
+        <Annotation Term="OData.Description" String="The available OEM-specific actions for this resource."/>
+        <Annotation Term="OData.LongDescription" String="This type shall contain the available OEM-specific actions for this resource."/>
+      </ComplexType>
+    </Schema>
+
+    <Schema xmlns="http://docs.oasis-open.org/odata/ns/edm" Namespace="ProcessorMetrics.v1_0_1">
+      <Annotation Term="Redfish.OwningEntity" String="DMTF"/>
+      <Annotation Term="OData.Description" String="This version was created to force the regeneration of JSON Schema so that URI properties use the uri-reference format, and to add a missing term to several properties to disallow them from being null."/>
+      <EntityType Name="ProcessorMetrics" BaseType="ProcessorMetrics.v1_0_0.ProcessorMetrics"/>
+    </Schema>
+
+    <Schema xmlns="http://docs.oasis-open.org/odata/ns/edm" Namespace="ProcessorMetrics.v1_0_2">
+      <Annotation Term="Redfish.OwningEntity" String="DMTF"/>
+      <Annotation Term="OData.Description" String="This version was created to update descriptions to give guidance to the usage of certain properties when the metrics is used for a summary of all processors in a system.  It was also created to update descriptions that this schema defines."/>
+      <EntityType Name="ProcessorMetrics" BaseType="ProcessorMetrics.v1_0_1.ProcessorMetrics"/>
+    </Schema>
+
+    <Schema xmlns="http://docs.oasis-open.org/odata/ns/edm" Namespace="ProcessorMetrics.v1_0_3">
+      <Annotation Term="Redfish.OwningEntity" String="DMTF"/>
+      <Annotation Term="OData.Description" String="This version was created to correct various typographical errors."/>
+      <EntityType Name="ProcessorMetrics" BaseType="ProcessorMetrics.v1_0_2.ProcessorMetrics"/>
+    </Schema>
+
+    <Schema xmlns="http://docs.oasis-open.org/odata/ns/edm" Namespace="ProcessorMetrics.v1_0_4">
+      <Annotation Term="Redfish.OwningEntity" String="DMTF"/>
+      <Annotation Term="OData.Description" String="This version was created to correct various typographical errors."/>
+      <EntityType Name="ProcessorMetrics" BaseType="ProcessorMetrics.v1_0_3.ProcessorMetrics"/>
+    </Schema>
+
+    <Schema xmlns="http://docs.oasis-open.org/odata/ns/edm" Namespace="ProcessorMetrics.v1_0_5">
+      <Annotation Term="Redfish.OwningEntity" String="DMTF"/>
+      <Annotation Term="OData.Description" String="This version was created to update the descriptions of BandwidthPercent that allows for various types of processors."/>
+      <EntityType Name="ProcessorMetrics" BaseType="ProcessorMetrics.v1_0_4.ProcessorMetrics"/>
+    </Schema>
+
+    <Schema xmlns="http://docs.oasis-open.org/odata/ns/edm" Namespace="ProcessorMetrics.v1_1_0">
+      <Annotation Term="Redfish.OwningEntity" String="DMTF"/>
+      <Annotation Term="Redfish.Release" String="2020.1"/>
+      <Annotation Term="OData.Description" String="This version was created to deprecate AverageFrequencyMHz in favor of OperatingSpeedMHz property."/>
+
+      <EntityType Name="ProcessorMetrics" BaseType="ProcessorMetrics.v1_0_2.ProcessorMetrics">
+        <Property Name="OperatingSpeedMHz" Type="Edm.Int64">
+          <Annotation Term="OData.Permissions" EnumMember="OData.Permission/Read"/>
+          <Annotation Term="OData.Description" String="Operating speed of the processor in MHz."/>
+          <Annotation Term="OData.LongDescription" String="This property shall contain the operating speed of the processor in MHz.  The operating speed of the processor may change more frequently than the manager is able to monitor."/>
+          <Annotation Term="Measures.Unit" String="MHz"/>
+        </Property>
+      </EntityType>
+    </Schema>
+
+    <Schema xmlns="http://docs.oasis-open.org/odata/ns/edm" Namespace="ProcessorMetrics.v1_1_1">
+      <Annotation Term="Redfish.OwningEntity" String="DMTF"/>
+      <Annotation Term="OData.Description" String="This version was created to correct various typographical errors."/>
+      <EntityType Name="ProcessorMetrics" BaseType="ProcessorMetrics.v1_1_0.ProcessorMetrics"/>
+    </Schema>
+
+    <Schema xmlns="http://docs.oasis-open.org/odata/ns/edm" Namespace="ProcessorMetrics.v1_1_2">
+      <Annotation Term="Redfish.OwningEntity" String="DMTF"/>
+      <Annotation Term="OData.Description" String="This version was created to correct various typographical errors."/>
+      <EntityType Name="ProcessorMetrics" BaseType="ProcessorMetrics.v1_1_1.ProcessorMetrics"/>
+    </Schema>
+
+    <Schema xmlns="http://docs.oasis-open.org/odata/ns/edm" Namespace="ProcessorMetrics.v1_1_3">
+      <Annotation Term="Redfish.OwningEntity" String="DMTF"/>
+      <Annotation Term="OData.Description" String="This version was created to correct various description to use proper normative terminology."/>
+      <EntityType Name="ProcessorMetrics" BaseType="ProcessorMetrics.v1_1_2.ProcessorMetrics"/>
+    </Schema>
+
+    <Schema xmlns="http://docs.oasis-open.org/odata/ns/edm" Namespace="ProcessorMetrics.v1_1_4">
+      <Annotation Term="Redfish.OwningEntity" String="DMTF"/>
+      <Annotation Term="OData.Description" String="This version was created to update the descriptions of BandwidthPercent that allows for various types of processors."/>
+      <EntityType Name="ProcessorMetrics" BaseType="ProcessorMetrics.v1_1_3.ProcessorMetrics"/>
+    </Schema>
+
+    <Schema xmlns="http://docs.oasis-open.org/odata/ns/edm" Namespace="ProcessorMetrics.v1_2_0">
+      <Annotation Term="Redfish.OwningEntity" String="DMTF"/>
+      <Annotation Term="Redfish.Release" String="2020.4"/>
+      <Annotation Term="OData.Description" String="This version was created to add CorrectableECCErrorCount and UncorrectableECCErrorCount properties for CurrentPeriod and LifeTime of the processor cache memory.  It was also was created to deprecate TemperatureCelsius and ConsumedPowerWatt in favor of Sensor properties in EnvironmentMetrics."/>
+
+      <EntityType Name="ProcessorMetrics" BaseType="ProcessorMetrics.v1_1_2.ProcessorMetrics">
+        <Property Name="CacheMetricsTotal" Type="ProcessorMetrics.v1_2_0.CacheMetricsTotal" Nullable="false">
+          <Annotation Term="OData.Description" String="The total cache metrics for this processor."/>
+          <Annotation Term="OData.LongDescription" String="This property shall contain properties that describe the metrics for all of the cache memory of this processor."/>
+        </Property>
+      </EntityType>
+
+      <ComplexType Name="CacheMetricsTotal">
+        <Annotation Term="OData.AdditionalProperties" Bool="false"/>
+        <Annotation Term="OData.Description" String="The total cache metrics for a processor."/>
+        <Annotation Term="OData.LongDescription" String="This property shall contain properties that describe the metrics for all of the cache memory for a processor."/>
+        <Property Name="CurrentPeriod" Type="ProcessorMetrics.v1_2_0.CurrentPeriod" Nullable="false">
+          <Annotation Term="OData.Description" String="The cache metrics since the last reset for this processor."/>
+          <Annotation Term="OData.LongDescription" String="This property shall contain properties that describe the metrics for the current period of cache memory for this processor."/>
+        </Property>
+        <Property Name="LifeTime" Type="ProcessorMetrics.v1_2_0.LifeTime" Nullable="false">
+          <Annotation Term="OData.Description" String="The cache metrics for the lifetime of this processor."/>
+          <Annotation Term="OData.LongDescription" String="This property shall contain properties that describe the metrics for the lifetime of cache memory for this processor."/>
+        </Property>
+      </ComplexType>
+
+      <ComplexType Name="CurrentPeriod">
+        <Annotation Term="OData.AdditionalProperties" Bool="false"/>
+        <Annotation Term="OData.Description" String="The cache memory metrics since the last system reset or ClearCurrentPeriod action for a processor."/>
+        <Annotation Term="OData.LongDescription" String="This type shall describe the cache memory metrics since last system reset or ClearCurrentPeriod action for a processor."/>
+        <Property Name="CorrectableECCErrorCount" Type="Edm.Int64">
+          <Annotation Term="OData.Permissions" EnumMember="OData.Permission/Read"/>
+          <Annotation Term="OData.Description" String="The number of the correctable errors of cache memory since reset."/>
+          <Annotation Term="OData.LongDescription" String="This property shall contain the number of correctable errors of cache memory since reset.  When this resource is subordinate to the ProcessorSummary object, this property shall be the sum of CorrectableECCErrorCount over all processors."/>
+        </Property>
+        <Property Name="UncorrectableECCErrorCount" Type="Edm.Int64">
+          <Annotation Term="OData.Permissions" EnumMember="OData.Permission/Read"/>
+          <Annotation Term="OData.Description" String="The number of the uncorrectable errors of cache memory since reset."/>
+          <Annotation Term="OData.LongDescription" String="This property shall contain the number of uncorrectable errors of cache memory since reset.  When this resource is subordinate to the ProcessorSummary object, this property shall be the sum of UncorrectableECCErrorCount over all processors."/>
+        </Property>
+      </ComplexType>
+
+      <ComplexType Name="LifeTime">
+        <Annotation Term="OData.AdditionalProperties" Bool="false"/>
+        <Annotation Term="OData.Description" String="The cache memory metrics for the lifetime for a processor."/>
+        <Annotation Term="OData.LongDescription" String="This type shall describe the cache memory metrics since manufacturing for a processor."/>
+        <Property Name="CorrectableECCErrorCount" Type="Edm.Int64">
+          <Annotation Term="OData.Permissions" EnumMember="OData.Permission/Read"/>
+          <Annotation Term="OData.Description" String="The number of the correctable errors for the lifetime of the cache memory."/>
+          <Annotation Term="OData.LongDescription" String="This property shall contain the number of the correctable errors for the lifetime of cache memory.  When this resource is subordinate to the ProcessorSummary object, this property shall be the sum of CorrectableECCErrorCount over all processors."/>
+        </Property>
+        <Property Name="UncorrectableECCErrorCount" Type="Edm.Int64">
+          <Annotation Term="OData.Permissions" EnumMember="OData.Permission/Read"/>
+          <Annotation Term="OData.Description" String="The number of the uncorrectable errors for the lifetime of the cache memory."/>
+          <Annotation Term="OData.LongDescription" String="This property shall contain the number of the uncorrectable errors for the lifetime of cache memory.  When this resource is subordinate to the ProcessorSummary object, this property shall be the sum of UncorrectableECCErrorCount over all processors."/>
+        </Property>
+      </ComplexType>
+    </Schema>
+
+    <Schema xmlns="http://docs.oasis-open.org/odata/ns/edm" Namespace="ProcessorMetrics.v1_2_1">
+      <Annotation Term="Redfish.OwningEntity" String="DMTF"/>
+      <Annotation Term="OData.Description" String="This version was created to correct various description to use proper normative terminology."/>
+      <EntityType Name="ProcessorMetrics" BaseType="ProcessorMetrics.v1_2_0.ProcessorMetrics"/>
+    </Schema>
+
+    <Schema xmlns="http://docs.oasis-open.org/odata/ns/edm" Namespace="ProcessorMetrics.v1_2_2">
+      <Annotation Term="Redfish.OwningEntity" String="DMTF"/>
+      <Annotation Term="OData.Description" String="This version was created to update the descriptions of BandwidthPercent that allows for various types of processors."/>
+      <EntityType Name="ProcessorMetrics" BaseType="ProcessorMetrics.v1_2_1.ProcessorMetrics"/>
+    </Schema>
+
+    <Schema xmlns="http://docs.oasis-open.org/odata/ns/edm" Namespace="ProcessorMetrics.v1_3_0">
+      <Annotation Term="Redfish.OwningEntity" String="DMTF"/>
+      <Annotation Term="Redfish.Release" String="2021.2"/>
+
+      <EntityType Name="ProcessorMetrics" BaseType="ProcessorMetrics.v1_2_2.ProcessorMetrics">
+        <NavigationProperty Name="CoreVoltage" Type="Sensor.Sensor">
+          <Annotation Term="OData.Permissions" EnumMember="OData.Permission/Read"/>
+          <Annotation Term="OData.Description" String="The core voltage of this processor in Volts."/>
+          <Annotation Term="OData.LongDescription" String="The value of this property shall contain the sensor measuring the core voltage of this processor in Volts.  The core voltage of the processor may change more frequently than the manager is able to monitor."/>
+          <Annotation Term="Redfish.ExcerptCopy" String="Voltage"/>
+        </NavigationProperty>
+      </EntityType>
+    </Schema>
+
+  </edmx:DataServices>
+</edmx:Edmx>

--- a/static/redfish/v1/schema/Protocol_v1.xml
+++ b/static/redfish/v1/schema/Protocol_v1.xml
@@ -1,0 +1,332 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!---->
+<!--################################################################################       -->
+<!--# Redfish Schema:  Protocol                                                            -->
+<!--#                                                                                      -->
+<!--# For a detailed change log, see the README file contained in the DSP8010 bundle,      -->
+<!--# available at http://www.dmtf.org/standards/redfish                                   -->
+<!--# Copyright 2014-2021 DMTF.                                                            -->
+<!--# For the full DMTF copyright policy, see http://www.dmtf.org/about/policies/copyright -->
+<!--################################################################################       -->
+<!---->
+<edmx:Edmx xmlns:edmx="http://docs.oasis-open.org/odata/ns/edmx" Version="4.0">
+
+  <edmx:Reference Uri="http://docs.oasis-open.org/odata/odata/v4.0/errata03/csd01/complete/vocabularies/Org.OData.Core.V1.xml">
+    <edmx:Include Namespace="Org.OData.Core.V1" Alias="OData"/>
+  </edmx:Reference>
+  <edmx:Reference Uri="http://redfish.dmtf.org/schemas/v1/RedfishExtensions_v1.xml">
+    <edmx:Include Namespace="RedfishExtensions.v1_0_0" Alias="Redfish"/>
+  </edmx:Reference>
+
+  <edmx:DataServices>
+
+    <Schema xmlns="http://docs.oasis-open.org/odata/ns/edm" Namespace="Protocol">
+      <Annotation Term="Redfish.OwningEntity" String="DMTF"/>
+      <Annotation Term="Redfish.Release" String="2017.3"/>
+
+      <Annotation Term="OData.Description" String="This enumeration describes all protocols that devices in the storage and fabric models support."/>
+      <EnumType Name="Protocol">
+        <Member Name="PCIe">
+          <Annotation Term="OData.Description" String="PCI Express."/>
+          <Annotation Term="OData.LongDescription" String="This value shall indicate conformance to the PCI-SIG PCI Express Base Specification."/>
+        </Member>
+        <Member Name="AHCI">
+          <Annotation Term="OData.Description" String="Advanced Host Controller Interface (AHCI)."/>
+          <Annotation Term="OData.LongDescription" String="This value shall indicate conformance to the Intel Advanced Host Controller Interface (AHCI) Specification."/>
+        </Member>
+        <Member Name="UHCI">
+          <Annotation Term="OData.Description" String="Universal Host Controller Interface (UHCI)."/>
+          <Annotation Term="OData.LongDescription" String="This value shall indicate conformance to the Intel Universal Host Controller Interface (UHCI) Specification, Enhanced Host Controller Interface Specification, or the Extensible Host Controller Interface Specification."/>
+        </Member>
+        <Member Name="SAS">
+          <Annotation Term="OData.Description" String="Serial Attached SCSI."/>
+          <Annotation Term="OData.LongDescription" String="This value shall indicate conformance to the T10 SAS Protocol Layer Specification."/>
+        </Member>
+        <Member Name="SATA">
+          <Annotation Term="OData.Description" String="Serial AT Attachment."/>
+          <Annotation Term="OData.LongDescription" String="This value shall indicate conformance to the Serial ATA International Organization Serial ATA Specification."/>
+        </Member>
+        <Member Name="USB">
+          <Annotation Term="OData.Description" String="Universal Serial Bus (USB)."/>
+          <Annotation Term="OData.LongDescription" String="This value shall indicate conformance to the USB Implementers Forum Universal Serial Bus Specification."/>
+        </Member>
+        <Member Name="NVMe">
+          <Annotation Term="OData.Description" String="Non-Volatile Memory Express (NVMe)."/>
+          <Annotation Term="OData.LongDescription" String="This value shall indicate conformance to the Non-Volatile Memory Host Controller Interface Specification."/>
+        </Member>
+        <Member Name="FC">
+          <Annotation Term="OData.Description" String="Fibre Channel."/>
+          <Annotation Term="OData.LongDescription" String="This value shall indicate conformance to the T11 Fibre Channel Physical and Signaling Interface Specification."/>
+        </Member>
+        <Member Name="iSCSI">
+          <Annotation Term="OData.Description" String="Internet SCSI."/>
+          <Annotation Term="OData.LongDescription" String="This value shall indicate conformance to the IETF Internet Small Computer Systems Interface (iSCSI) Specification."/>
+        </Member>
+        <Member Name="FCoE">
+          <Annotation Term="OData.Description" String="Fibre Channel over Ethernet (FCoE)."/>
+          <Annotation Term="OData.LongDescription" String="This value shall indicate conformance to the T11 FC-BB-5 Specification."/>
+        </Member>
+        <Member Name="FCP">
+          <Annotation Term="OData.Description" String="Fibre Channel Protocol for SCSI."/>
+          <Annotation Term="OData.LongDescription" String="This value shall indicate conformance to the INCITS 481: Information Technology - Fibre Channel Protocol for SCSI."/>
+          <Annotation Term="Redfish.Revisions">
+            <Collection>
+              <Record>
+                <PropertyValue Property="Kind" EnumMember="Redfish.RevisionKind/Added"/>
+                <PropertyValue Property="Version" String="2017.1"/>
+              </Record>
+            </Collection>
+          </Annotation>
+        </Member>
+        <Member Name="FICON">
+          <Annotation Term="OData.Description" String="FIbre CONnection (FICON)."/>
+          <Annotation Term="OData.LongDescription" String="This value shall indicate conformance to the ANSI FC-SB-3 Single-Byte Command Code Sets-3 Mapping Protocol for the Fibre Channel (FC) protocol.  Fibre Connection (FICON) is the IBM-proprietary name for this protocol."/>
+          <Annotation Term="Redfish.Revisions">
+            <Collection>
+              <Record>
+                <PropertyValue Property="Kind" EnumMember="Redfish.RevisionKind/Added"/>
+                <PropertyValue Property="Version" String="2017.1"/>
+              </Record>
+            </Collection>
+          </Annotation>
+        </Member>
+        <Member Name="NVMeOverFabrics">
+          <Annotation Term="OData.Description" String="NVMe over Fabrics."/>
+          <Annotation Term="OData.LongDescription" String="This value shall indicate conformance to the NVM Express over Fabrics Specification."/>
+        </Member>
+        <Member Name="SMB">
+          <Annotation Term="OData.Description" String="Server Message Block (SMB).  Also known as the Common Internet File System (CIFS)."/>
+          <Annotation Term="OData.LongDescription" String="This value shall indicate conformance to the Server Message Block (SMB), or Common Internet File System (CIFS), protocol."/>
+        </Member>
+        <Member Name="NFSv3">
+          <Annotation Term="OData.Description" String="Network File System (NFS) version 3."/>
+          <Annotation Term="OData.LongDescription" String="This value shall indicate conformance to the RFC1813-defined Network File System (NFS) protocol."/>
+        </Member>
+        <Member Name="NFSv4">
+          <Annotation Term="OData.Description" String="Network File System (NFS) version 4."/>
+        </Member>
+        <Member Name="HTTP">
+          <Annotation Term="OData.Description" String="Hypertext Transport Protocol (HTTP)."/>
+          <Annotation Term="OData.LongDescription" String="This value shall indicate conformance to the Hypertext Transport Protocol (HTTP) as defined by RFC3010 or RFC5661."/>
+        </Member>
+        <Member Name="HTTPS">
+          <Annotation Term="OData.Description" String="Hypertext Transfer Protocol Secure (HTTPS)."/>
+          <Annotation Term="OData.LongDescription" String="This value shall indicate conformance to the Hypertext Transfer Protocol Secure (HTTPS) as defined by RFC2068 or RFC2616, which uses Transport Layer Security (TLS) as defined by RFC5246 or RFC6176."/>
+        </Member>
+        <Member Name="FTP">
+          <Annotation Term="OData.Description" String="File Transfer Protocol (FTP)."/>
+          <Annotation Term="OData.LongDescription" String="This value shall indicate conformance to the RFC114-defined File Transfer Protocol (FTP)."/>
+        </Member>
+        <Member Name="SFTP">
+          <Annotation Term="OData.Description" String="SSH File Transfer Protocol (SFTP)."/>
+          <Annotation Term="OData.LongDescription" String="This value shall indicate conformance to the RFC114-defined SSH File Transfer Protocol (SFTP) that uses Transport Layer Security (TLS) as defined by RFC5246 or RFC6176."/>
+        </Member>
+        <Member Name="iWARP">
+          <Annotation Term="OData.Description" String="Internet Wide Area RDMA Protocol (iWARP)."/>
+          <Annotation Term="OData.LongDescription" String="This value shall indicate conformance to the RFC5042-defined Internet Wide Area RDMA Protocol (iWARP) that uses the transport layer mechanisms as defined by RFC5043 or RFC5044."/>
+          <Annotation Term="Redfish.Revisions">
+            <Collection>
+              <Record>
+                <PropertyValue Property="Kind" EnumMember="Redfish.RevisionKind/Added"/>
+                <PropertyValue Property="Version" String="2017.3"/>
+              </Record>
+            </Collection>
+          </Annotation>
+        </Member>
+        <Member Name="RoCE">
+          <Annotation Term="OData.Description" String="RDMA over Converged Ethernet Protocol."/>
+          <Annotation Term="OData.LongDescription" String="This value shall indicate conformance to the InfiniBand Architecture Specification-defined RDMA over Converged Ethernet Protocol."/>
+          <Annotation Term="Redfish.Revisions">
+            <Collection>
+              <Record>
+                <PropertyValue Property="Kind" EnumMember="Redfish.RevisionKind/Added"/>
+                <PropertyValue Property="Version" String="2017.3"/>
+              </Record>
+            </Collection>
+          </Annotation>
+        </Member>
+        <Member Name="RoCEv2">
+          <Annotation Term="OData.Description" String="RDMA over Converged Ethernet Protocol Version 2."/>
+          <Annotation Term="OData.LongDescription" String="This value shall indicate conformance to the InfiniBand Architecture Specification-defined RDMA over Converged Ethernet Protocol version 2."/>
+          <Annotation Term="Redfish.Revisions">
+            <Collection>
+              <Record>
+                <PropertyValue Property="Kind" EnumMember="Redfish.RevisionKind/Added"/>
+                <PropertyValue Property="Version" String="2017.3"/>
+              </Record>
+            </Collection>
+          </Annotation>
+        </Member>
+        <Member Name="I2C">
+          <Annotation Term="OData.Description" String="Inter-Integrated Circuit Bus."/>
+          <Annotation Term="OData.LongDescription" String="This value shall indicate conformance to the NXP Semiconductors I2C-bus Specification."/>
+          <Annotation Term="Redfish.Revisions">
+            <Collection>
+              <Record>
+                <PropertyValue Property="Kind" EnumMember="Redfish.RevisionKind/Added"/>
+                <PropertyValue Property="Version" String="2018.2"/>
+              </Record>
+            </Collection>
+          </Annotation>
+        </Member>
+        <Member Name="TCP">
+          <Annotation Term="OData.Description" String="Transmission Control Protocol (TCP)."/>
+          <Annotation Term="OData.LongDescription" String="This value shall indicate conformance to the IETF-defined Transmission Control Protocol (TCP).  For example, RFC7414 defines the roadmap of the TCP specification."/>
+          <Annotation Term="Redfish.Revisions">
+            <Collection>
+              <Record>
+                <PropertyValue Property="Kind" EnumMember="Redfish.RevisionKind/Added"/>
+                <PropertyValue Property="Version" String="2019.3"/>
+              </Record>
+            </Collection>
+          </Annotation>
+        </Member>
+        <Member Name="UDP">
+          <Annotation Term="OData.Description" String="User Datagram Protocol (UDP)."/>
+          <Annotation Term="OData.LongDescription" String="This value shall indicate conformance to the IETF-defined User Datagram Protocol (UDP).  For example, RFC768 defines the core UDP specification."/>
+          <Annotation Term="Redfish.Revisions">
+            <Collection>
+              <Record>
+                <PropertyValue Property="Kind" EnumMember="Redfish.RevisionKind/Added"/>
+                <PropertyValue Property="Version" String="2019.3"/>
+              </Record>
+            </Collection>
+          </Annotation>
+        </Member>
+        <Member Name="TFTP">
+          <Annotation Term="OData.Description" String="Trivial File Transfer Protocol (TFTP)."/>
+          <Annotation Term="OData.LongDescription" String="This value shall indicate conformance to the IETF-defined Trivial File Transfer Protocol (TFTP).  For example, RFC1350 defines the core TFTP version 2 specification."/>
+          <Annotation Term="Redfish.Revisions">
+            <Collection>
+              <Record>
+                <PropertyValue Property="Kind" EnumMember="Redfish.RevisionKind/Added"/>
+                <PropertyValue Property="Version" String="2019.3"/>
+              </Record>
+            </Collection>
+          </Annotation>
+        </Member>
+        <Member Name="GenZ">
+          <Annotation Term="OData.Description" String="GenZ."/>
+          <Annotation Term="OData.LongDescription" String="This value shall indicate conformance to the Gen-Z Core Specification."/>
+          <Annotation Term="Redfish.Revisions">
+            <Collection>
+              <Record>
+                <PropertyValue Property="Kind" EnumMember="Redfish.RevisionKind/Added"/>
+                <PropertyValue Property="Version" String="2019.4"/>
+              </Record>
+            </Collection>
+          </Annotation>
+        </Member>
+        <Member Name="MultiProtocol">
+          <Annotation Term="OData.Description" String="Multiple Protocols."/>
+          <Annotation Term="OData.LongDescription" String="This value shall indicate conformance to multiple protocols."/>
+          <Annotation Term="Redfish.Revisions">
+            <Collection>
+              <Record>
+                <PropertyValue Property="Kind" EnumMember="Redfish.RevisionKind/Added"/>
+                <PropertyValue Property="Version" String="2019.4"/>
+              </Record>
+            </Collection>
+          </Annotation>
+        </Member>
+        <Member Name="InfiniBand">
+          <Annotation Term="OData.Description" String="InfiniBand."/>
+          <Annotation Term="OData.LongDescription" String="This value shall indicate conformance to the InfiniBand Architecture Specification-defined InfiniBand protocol."/>
+          <Annotation Term="Redfish.Revisions">
+            <Collection>
+              <Record>
+                <PropertyValue Property="Kind" EnumMember="Redfish.RevisionKind/Added"/>
+                <PropertyValue Property="Version" String="2020.3"/>
+              </Record>
+            </Collection>
+          </Annotation>
+        </Member>
+        <Member Name="Ethernet">
+          <Annotation Term="OData.Description" String="Ethernet."/>
+          <Annotation Term="OData.LongDescription" String="This value shall indicate conformance to the IEEE 802.3 Ethernet specification."/>
+          <Annotation Term="Redfish.Revisions">
+            <Collection>
+              <Record>
+                <PropertyValue Property="Kind" EnumMember="Redfish.RevisionKind/Added"/>
+                <PropertyValue Property="Version" String="2020.3"/>
+              </Record>
+            </Collection>
+          </Annotation>
+        </Member>
+        <Member Name="NVLink">
+          <Annotation Term="OData.Description" String="NVLink."/>
+          <Annotation Term="OData.LongDescription" String="This value shall indicate conformance to the NVIDIA NVLink protocol."/>
+          <Annotation Term="Redfish.Revisions">
+            <Collection>
+              <Record>
+                <PropertyValue Property="Kind" EnumMember="Redfish.RevisionKind/Added"/>
+                <PropertyValue Property="Version" String="2021.1"/>
+              </Record>
+            </Collection>
+          </Annotation>
+        </Member>
+        <Member Name="OEM">
+          <Annotation Term="OData.Description" String="OEM-specific."/>
+          <Annotation Term="OData.LongDescription" String="This value shall indicate conformance to an OEM-specific architecture and the OEM section may include additional information."/>
+          <Annotation Term="Redfish.Revisions">
+            <Collection>
+              <Record>
+                <PropertyValue Property="Kind" EnumMember="Redfish.RevisionKind/Added"/>
+                <PropertyValue Property="Version" String="2018.1"/>
+              </Record>
+            </Collection>
+          </Annotation>
+        </Member>
+        <Member Name="DisplayPort">
+          <Annotation Term="OData.Description" String="DisplayPort."/>
+          <Annotation Term="OData.LongDescription" String="This value shall indicate conformance to the VESA DisplayPort Specification."/>
+          <Annotation Term="Redfish.Revisions">
+            <Collection>
+              <Record>
+                <PropertyValue Property="Kind" EnumMember="Redfish.RevisionKind/Added"/>
+                <PropertyValue Property="Version" String="2021.1"/>
+              </Record>
+            </Collection>
+          </Annotation>
+        </Member>
+        <Member Name="HDMI">
+          <Annotation Term="OData.Description" String="HDMI."/>
+          <Annotation Term="OData.LongDescription" String="This value shall indicate conformance to the HDMI Forum HDMI Specification."/>
+          <Annotation Term="Redfish.Revisions">
+            <Collection>
+              <Record>
+                <PropertyValue Property="Kind" EnumMember="Redfish.RevisionKind/Added"/>
+                <PropertyValue Property="Version" String="2021.1"/>
+              </Record>
+            </Collection>
+          </Annotation>
+        </Member>
+        <Member Name="VGA">
+          <Annotation Term="OData.Description" String="VGA."/>
+          <Annotation Term="OData.LongDescription" String="This value shall indicate conformance to the VESA SVGA Specification."/>
+          <Annotation Term="Redfish.Revisions">
+            <Collection>
+              <Record>
+                <PropertyValue Property="Kind" EnumMember="Redfish.RevisionKind/Added"/>
+                <PropertyValue Property="Version" String="2021.1"/>
+              </Record>
+            </Collection>
+          </Annotation>
+        </Member>
+        <Member Name="DVI">
+          <Annotation Term="OData.Description" String="DVI."/>
+          <Annotation Term="OData.LongDescription" String="This value shall indicate conformance to the Digital Display Working Group DVI-A, DVI-D, or DVI-I Specification."/>
+          <Annotation Term="Redfish.Revisions">
+            <Collection>
+              <Record>
+                <PropertyValue Property="Kind" EnumMember="Redfish.RevisionKind/Added"/>
+                <PropertyValue Property="Version" String="2021.1"/>
+              </Record>
+            </Collection>
+          </Annotation>
+        </Member>
+      </EnumType>
+    </Schema>
+
+  </edmx:DataServices>
+</edmx:Edmx>

--- a/static/redfish/v1/schema/ResourceBlockCollection_v1.xml
+++ b/static/redfish/v1/schema/ResourceBlockCollection_v1.xml
@@ -1,0 +1,72 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!---->
+<!--################################################################################       -->
+<!--# Redfish Schema:  ResourceBlockCollection                                             -->
+<!--#                                                                                      -->
+<!--# For a detailed change log, see the README file contained in the DSP8010 bundle,      -->
+<!--# available at http://www.dmtf.org/standards/redfish                                   -->
+<!--# Copyright 2014-2021 DMTF.                                                            -->
+<!--# For the full DMTF copyright policy, see http://www.dmtf.org/about/policies/copyright -->
+<!--################################################################################       -->
+<!---->
+<edmx:Edmx xmlns:edmx="http://docs.oasis-open.org/odata/ns/edmx" Version="4.0">
+
+  <edmx:Reference Uri="http://docs.oasis-open.org/odata/odata/v4.0/errata03/csd01/complete/vocabularies/Org.OData.Core.V1.xml">
+    <edmx:Include Namespace="Org.OData.Core.V1" Alias="OData"/>
+  </edmx:Reference>
+  <edmx:Reference Uri="http://docs.oasis-open.org/odata/odata/v4.0/errata03/csd01/complete/vocabularies/Org.OData.Capabilities.V1.xml">
+    <edmx:Include Namespace="Org.OData.Capabilities.V1" Alias="Capabilities"/>
+  </edmx:Reference>
+  <edmx:Reference Uri="http://redfish.dmtf.org/schemas/v1/Resource_v1.xml">
+    <edmx:Include Namespace="Resource.v1_0_0"/>
+  </edmx:Reference>
+  <edmx:Reference Uri="http://redfish.dmtf.org/schemas/v1/RedfishExtensions_v1.xml">
+    <edmx:Include Namespace="RedfishExtensions.v1_0_0" Alias="Redfish"/>
+  </edmx:Reference>
+  <edmx:Reference Uri="http://redfish.dmtf.org/schemas/v1/ResourceBlock_v1.xml">
+    <edmx:Include Namespace="ResourceBlock"/>
+  </edmx:Reference>
+
+  <edmx:DataServices>
+
+    <Schema xmlns="http://docs.oasis-open.org/odata/ns/edm" Namespace="ResourceBlockCollection">
+      <Annotation Term="Redfish.OwningEntity" String="DMTF"/>
+
+      <EntityType Name="ResourceBlockCollection" BaseType="Resource.v1_0_0.ResourceCollection">
+        <Annotation Term="OData.Description" String="The collection of ResourceBlock resource instances."/>
+        <Annotation Term="OData.LongDescription" String="This resource shall represent a resource collection of ResourceBlock instances for a Redfish implementation."/>
+        <Annotation Term="Capabilities.InsertRestrictions">
+          <Record>
+            <PropertyValue Property="Insertable" Bool="true"/>
+          </Record>
+        </Annotation>
+        <Annotation Term="Capabilities.UpdateRestrictions">
+          <Record>
+            <PropertyValue Property="Updatable" Bool="false"/>
+          </Record>
+        </Annotation>
+        <Annotation Term="Capabilities.DeleteRestrictions">
+          <Record>
+            <PropertyValue Property="Deletable" Bool="false"/>
+          </Record>
+        </Annotation>
+        <Annotation Term="Redfish.Uris">
+          <Collection>
+            <String>/redfish/v1/CompositionService/ActivePool</String>
+            <String>/redfish/v1/CompositionService/FreePool</String>
+            <String>/redfish/v1/CompositionService/ResourceBlocks</String>
+            <String>/redfish/v1/ResourceBlocks</String>
+          </Collection>
+        </Annotation>
+        <NavigationProperty Name="Members" Type="Collection(ResourceBlock.ResourceBlock)">
+          <Annotation Term="OData.Permissions" EnumMember="OData.Permission/Read"/>
+          <Annotation Term="OData.Description" String="The members of this collection."/>
+          <Annotation Term="OData.LongDescription" String="This property shall contain an array of links to the members of this collection."/>
+          <Annotation Term="OData.AutoExpandReferences"/>
+          <Annotation Term="Redfish.Required"/>
+        </NavigationProperty>
+      </EntityType>
+    </Schema>
+
+  </edmx:DataServices>
+</edmx:Edmx>

--- a/static/redfish/v1/schema/ResourceBlock_v1.xml
+++ b/static/redfish/v1/schema/ResourceBlock_v1.xml
@@ -1,0 +1,618 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!---->
+<!--################################################################################       -->
+<!--# Redfish Schema:  ResourceBlock v1.4.0                                                -->
+<!--#                                                                                      -->
+<!--# For a detailed change log, see the README file contained in the DSP8010 bundle,      -->
+<!--# available at http://www.dmtf.org/standards/redfish                                   -->
+<!--# Copyright 2014-2021 DMTF.                                                            -->
+<!--# For the full DMTF copyright policy, see http://www.dmtf.org/about/policies/copyright -->
+<!--################################################################################       -->
+<!---->
+<edmx:Edmx xmlns:edmx="http://docs.oasis-open.org/odata/ns/edmx" Version="4.0">
+
+  <edmx:Reference Uri="http://docs.oasis-open.org/odata/odata/v4.0/errata03/csd01/complete/vocabularies/Org.OData.Core.V1.xml">
+    <edmx:Include Namespace="Org.OData.Core.V1" Alias="OData"/>
+  </edmx:Reference>
+  <edmx:Reference Uri="http://docs.oasis-open.org/odata/odata/v4.0/errata03/csd01/complete/vocabularies/Org.OData.Capabilities.V1.xml">
+    <edmx:Include Namespace="Org.OData.Capabilities.V1" Alias="Capabilities"/>
+  </edmx:Reference>
+  <edmx:Reference Uri="http://redfish.dmtf.org/schemas/v1/RedfishExtensions_v1.xml">
+    <edmx:Include Namespace="RedfishExtensions.v1_0_0" Alias="Redfish"/>
+    <edmx:Include Namespace="Validation.v1_0_0" Alias="Validation"/>
+  </edmx:Reference>
+  <edmx:Reference Uri="http://redfish.dmtf.org/schemas/v1/Resource_v1.xml">
+    <edmx:Include Namespace="Resource"/>
+    <edmx:Include Namespace="Resource.v1_0_0"/>
+  </edmx:Reference>
+  <edmx:Reference Uri="http://redfish.dmtf.org/schemas/v1/Chassis_v1.xml">
+    <edmx:Include Namespace="Chassis"/>
+  </edmx:Reference>
+  <edmx:Reference Uri="http://redfish.dmtf.org/schemas/v1/ComputerSystem_v1.xml">
+    <edmx:Include Namespace="ComputerSystem"/>
+  </edmx:Reference>
+  <edmx:Reference Uri="http://redfish.dmtf.org/schemas/v1/EthernetInterface_v1.xml">
+    <edmx:Include Namespace="EthernetInterface"/>
+  </edmx:Reference>
+  <edmx:Reference Uri="http://redfish.dmtf.org/schemas/v1/Memory_v1.xml">
+    <edmx:Include Namespace="Memory"/>
+  </edmx:Reference>
+  <edmx:Reference Uri="http://redfish.dmtf.org/schemas/v1/NetworkInterface_v1.xml">
+    <edmx:Include Namespace="NetworkInterface"/>
+  </edmx:Reference>
+  <edmx:Reference Uri="http://redfish.dmtf.org/schemas/v1/Processor_v1.xml">
+    <edmx:Include Namespace="Processor"/>
+  </edmx:Reference>
+  <edmx:Reference Uri="http://redfish.dmtf.org/schemas/v1/SimpleStorage_v1.xml">
+    <edmx:Include Namespace="SimpleStorage"/>
+  </edmx:Reference>
+  <edmx:Reference Uri="http://redfish.dmtf.org/schemas/v1/Storage_v1.xml">
+    <edmx:Include Namespace="Storage"/>
+  </edmx:Reference>
+  <edmx:Reference Uri="http://redfish.dmtf.org/schemas/v1/Zone_v1.xml">
+    <edmx:Include Namespace="Zone"/>
+  </edmx:Reference>
+  <edmx:Reference Uri="http://redfish.dmtf.org/schemas/v1/Drive_v1.xml">
+    <edmx:Include Namespace="Drive"/>
+  </edmx:Reference>
+
+  <edmx:DataServices>
+
+    <Schema xmlns="http://docs.oasis-open.org/odata/ns/edm" Namespace="ResourceBlock">
+      <Annotation Term="Redfish.OwningEntity" String="DMTF"/>
+
+      <EntityType Name="ResourceBlock" BaseType="Resource.v1_0_0.Resource" Abstract="true">
+        <Annotation Term="OData.Description" String="The ResourceBlock schema contains definitions resource blocks, its components, and affinity to composed devices."/>
+        <Annotation Term="OData.LongDescription" String="This resource shall represent a resource block for a Redfish implementation."/>
+        <Annotation Term="Capabilities.InsertRestrictions">
+          <Record>
+            <PropertyValue Property="Insertable" Bool="false"/>
+          </Record>
+        </Annotation>
+        <Annotation Term="Capabilities.UpdateRestrictions">
+          <Record>
+            <PropertyValue Property="Updatable" Bool="true"/>
+            <Annotation Term="OData.Description" String="Writable properties, such as the reservation setting, can be updated for resource blocks."/>
+          </Record>
+        </Annotation>
+        <Annotation Term="Capabilities.DeleteRestrictions">
+          <Record>
+            <PropertyValue Property="Deletable" Bool="true"/>
+          </Record>
+        </Annotation>
+        <Annotation Term="Redfish.Uris">
+          <Collection>
+            <String>/redfish/v1/CompositionService/ResourceBlocks/{ResourceBlockId}</String>
+            <String>/redfish/v1/ResourceBlocks/{ResourceBlockId}</String>
+          </Collection>
+        </Annotation>
+      </EntityType>
+
+      <ComplexType Name="ResourceBlockLimits" Abstract="true"/>
+    </Schema>
+
+    <Schema xmlns="http://docs.oasis-open.org/odata/ns/edm" Namespace="ResourceBlock.v1_0_0">
+      <Annotation Term="Redfish.OwningEntity" String="DMTF"/>
+      <Annotation Term="Redfish.Release" String="2017.1"/>
+
+      <EntityType Name="ResourceBlock" BaseType="ResourceBlock.ResourceBlock">
+        <Property Name="Status" Type="Resource.Status" Nullable="false">
+          <Annotation Term="OData.Description" String="The status and health of the resource and its subordinate or dependent resources."/>
+          <Annotation Term="OData.LongDescription" String="This property shall contain any status or health properties of the resource."/>
+        </Property>
+        <Property Name="CompositionStatus" Type="ResourceBlock.v1_0_0.CompositionStatus" Nullable="false">
+          <Annotation Term="OData.Description" String="The composition status details for this resource block."/>
+          <Annotation Term="OData.LongDescription" String="This property shall contain composition status information about this resource block."/>
+          <Annotation Term="Redfish.Required"/>
+        </Property>
+        <Property Name="ResourceBlockType" Type="Collection(ResourceBlock.v1_0_0.ResourceBlockType)" Nullable="false">
+          <Annotation Term="OData.Permissions" EnumMember="OData.Permission/Read"/>
+          <Annotation Term="OData.Description" String="The types of resources available on this resource block."/>
+          <Annotation Term="OData.LongDescription" String="This property shall contain an array of enumerated values that describe the type of resources available."/>
+          <Annotation Term="Redfish.Required"/>
+        </Property>
+        <Property Name="Links" Type="ResourceBlock.v1_0_0.Links" Nullable="false">
+          <Annotation Term="OData.Description" String="The links to other resources that are related to this resource."/>
+          <Annotation Term="OData.LongDescription" String="This property shall contain links to resources that are related to but are not contained by, or subordinate to, this resource."/>
+        </Property>
+        <Property Name="Actions" Type="ResourceBlock.v1_0_0.Actions" Nullable="false">
+          <Annotation Term="OData.Description" String="The available actions for this resource."/>
+          <Annotation Term="OData.LongDescription" String="This property shall contain the available actions for this resource."/>
+        </Property>
+        <NavigationProperty Name="Processors" Type="Collection(Processor.Processor)">
+          <Annotation Term="OData.Permissions" EnumMember="OData.Permission/Read"/>
+          <Annotation Term="OData.Description" String="An array of links to the processors available in this resource block."/>
+          <Annotation Term="OData.LongDescription" String="This property shall contain an array of links to resource of type Processor that this resource block contains."/>
+          <Annotation Term="OData.AutoExpandReferences"/>
+        </NavigationProperty>
+        <NavigationProperty Name="Memory" Type="Collection(Memory.Memory)">
+          <Annotation Term="OData.Permissions" EnumMember="OData.Permission/Read"/>
+          <Annotation Term="OData.Description" String="An array of links to the memory available in this resource block."/>
+          <Annotation Term="OData.LongDescription" String="This property shall contain an array of links to resource of type Memory that this resource block contains."/>
+          <Annotation Term="OData.AutoExpandReferences"/>
+        </NavigationProperty>
+        <NavigationProperty Name="Storage" Type="Collection(Storage.Storage)">
+          <Annotation Term="OData.Permissions" EnumMember="OData.Permission/Read"/>
+          <Annotation Term="OData.Description" String="An array of links to the storage available in this resource block."/>
+          <Annotation Term="OData.LongDescription" String="This property shall contain an array of links to resource of type Storage that this resource block contains."/>
+          <Annotation Term="OData.AutoExpandReferences"/>
+        </NavigationProperty>
+        <NavigationProperty Name="SimpleStorage" Type="Collection(SimpleStorage.SimpleStorage)">
+          <Annotation Term="OData.Permissions" EnumMember="OData.Permission/Read"/>
+          <Annotation Term="OData.Description" String="An array of links to the simple storage available in this resource block."/>
+          <Annotation Term="OData.LongDescription" String="This property shall contain an array of links to resource of type SimpleStorage that this resource block contains."/>
+          <Annotation Term="OData.AutoExpandReferences"/>
+        </NavigationProperty>
+        <NavigationProperty Name="EthernetInterfaces" Type="Collection(EthernetInterface.EthernetInterface)">
+          <Annotation Term="OData.Permissions" EnumMember="OData.Permission/Read"/>
+          <Annotation Term="OData.Description" String="An array of links to the Ethernet interfaces available in this resource block."/>
+          <Annotation Term="OData.LongDescription" String="This property shall contain an array of links to resource of type EthernetInterface that this resource block contains."/>
+          <Annotation Term="OData.AutoExpandReferences"/>
+        </NavigationProperty>
+        <NavigationProperty Name="NetworkInterfaces" Type="Collection(NetworkInterface.NetworkInterface)">
+          <Annotation Term="OData.Permissions" EnumMember="OData.Permission/Read"/>
+          <Annotation Term="OData.Description" String="An array of links to the Network Interfaces available in this resource block."/>
+          <Annotation Term="OData.LongDescription" String="This property shall contain an array of links to resource of type NetworkInterface that this resource block contains."/>
+          <Annotation Term="OData.AutoExpandReferences"/>
+        </NavigationProperty>
+        <NavigationProperty Name="ComputerSystems" Type="Collection(ComputerSystem.ComputerSystem)">
+          <Annotation Term="OData.Permissions" EnumMember="OData.Permission/Read"/>
+          <Annotation Term="OData.Description" String="An array of links to the computer systems available in this resource block."/>
+          <Annotation Term="OData.LongDescription" String="This property shall contain an array of links to resource of type ComputerSystem that this resource block contains."/>
+          <Annotation Term="OData.AutoExpandReferences"/>
+        </NavigationProperty>
+      </EntityType>
+
+      <ComplexType Name="Links" BaseType="Resource.Links">
+        <Annotation Term="OData.Description" String="The links to other resources that are related to this resource."/>
+        <Annotation Term="OData.LongDescription" String="This Redfish Specification-described type shall contain links to resources that are related to but are not contained by, or subordinate to, this resource."/>
+        <NavigationProperty Name="ComputerSystems" Type="Collection(ComputerSystem.ComputerSystem)">
+          <Annotation Term="OData.Permissions" EnumMember="OData.Permission/Read"/>
+          <Annotation Term="OData.Description" String="An array of links to the computer systems that are composed from this resource block."/>
+          <Annotation Term="OData.LongDescription" String="This property shall contain an array of links to resources of type ComputerSystem that represent the computer systems composed from this resource block."/>
+          <Annotation Term="OData.AutoExpandReferences"/>
+        </NavigationProperty>
+        <NavigationProperty Name="Chassis" Type="Collection(Chassis.Chassis)">
+          <Annotation Term="OData.Permissions" EnumMember="OData.Permission/Read"/>
+          <Annotation Term="OData.Description" String="An array of links to the chassis in which this resource block is contained."/>
+          <Annotation Term="OData.LongDescription" String="This property shall contain an array of links to resources of type Chassis that represent the physical container associated with this resource block."/>
+          <Annotation Term="OData.AutoExpandReferences"/>
+        </NavigationProperty>
+        <NavigationProperty Name="Zones" Type="Collection(Zone.Zone)">
+          <Annotation Term="OData.Permissions" EnumMember="OData.Permission/Read"/>
+          <Annotation Term="OData.Description" String="An array of links to the zones in which this resource block is bound."/>
+          <Annotation Term="OData.LongDescription" String="This property shall contain an array of links to resources of type Zone that represent the binding constraints associated with this resource block."/>
+          <Annotation Term="OData.AutoExpandReferences"/>
+        </NavigationProperty>
+      </ComplexType>
+
+      <ComplexType Name="Actions">
+        <Annotation Term="OData.AdditionalProperties" Bool="false"/>
+        <Annotation Term="OData.Description" String="The available actions for this resource."/>
+        <Annotation Term="OData.LongDescription" String="This type shall contain the available actions for this resource."/>
+        <Property Name="Oem" Type="ResourceBlock.v1_0_0.OemActions" Nullable="false">
+          <Annotation Term="OData.Description" String="The available OEM-specific actions for this resource."/>
+          <Annotation Term="OData.LongDescription" String="This property shall contain the available OEM-specific actions for this resource."/>
+        </Property>
+      </ComplexType>
+
+      <ComplexType Name="OemActions">
+        <Annotation Term="OData.AdditionalProperties" Bool="true"/>
+        <Annotation Term="OData.Description" String="The available OEM-specific actions for this resource."/>
+        <Annotation Term="OData.LongDescription" String="This type shall contain the available OEM-specific actions for this resource."/>
+      </ComplexType>
+
+      <EnumType Name="ResourceBlockType">
+        <Member Name="Compute">
+          <Annotation Term="OData.Description" String="This resource block contains resources of type `Processor` and `Memory` in a manner that creates a compute complex."/>
+        </Member>
+        <Member Name="Processor">
+          <Annotation Term="OData.Description" String="This resource block contains resources of type `Processor`."/>
+        </Member>
+        <Member Name="Memory">
+          <Annotation Term="OData.Description" String="This resource block contains resources of type `Memory`."/>
+        </Member>
+        <Member Name="Network">
+          <Annotation Term="OData.Description" String="This resource block contains network resources, such as resource of type `EthernetInterface` and `NetworkInterface`."/>
+        </Member>
+        <Member Name="Storage">
+          <Annotation Term="OData.Description" String="This resource block contains storage resources, such as resources of type `Storage` and `SimpleStorage`."/>
+        </Member>
+        <Member Name="ComputerSystem">
+          <Annotation Term="OData.Description" String="This resource block contains resources of type `ComputerSystem`."/>
+        </Member>
+        <Member Name="Expansion">
+          <Annotation Term="OData.Description" String="This resource block is capable of changing over time based on its configuration.  Different types of devices within this resource block can be added and removed over time."/>
+          <Annotation Term="Redfish.Revisions">
+            <Collection>
+              <Record>
+                <PropertyValue Property="Kind" EnumMember="Redfish.RevisionKind/Added"/>
+                <PropertyValue Property="Version" String="v1_2_0"/>
+              </Record>
+            </Collection>
+          </Annotation>
+        </Member>
+        <Member Name="IndependentResource">
+          <Annotation Term="OData.Description" String="This resource block is capable of being consumed as a standalone component.  This resource block can represent things such as a software platform on one or more computer systems or an appliance that provides composable resources and other services, and can be managed independently of the Redfish service."/>
+          <Annotation Term="Redfish.Revisions">
+            <Collection>
+              <Record>
+                <PropertyValue Property="Kind" EnumMember="Redfish.RevisionKind/Added"/>
+                <PropertyValue Property="Version" String="v1_4_0"/>
+              </Record>
+            </Collection>
+          </Annotation>
+        </Member>
+      </EnumType>
+
+      <ComplexType Name="CompositionStatus">
+        <Annotation Term="OData.Description" String="Composition status of the resource block."/>
+        <Annotation Term="OData.LongDescription" String="This type shall contain properties that describe the high level composition status of the resource block."/>
+        <Property Name="Reserved" Type="Edm.Boolean">
+          <Annotation Term="OData.Permissions" EnumMember="OData.Permission/ReadWrite"/>
+          <Annotation Term="OData.Description" String="An indication of whether any client has reserved the resource block."/>
+          <Annotation Term="OData.LongDescription" String="This property shall indicate whether any client has reserved the resource block.  A client sets this property after the resource block is identified as composed.  It shall provide a way for multiple clients to negotiate the ownership of the resource block."/>
+        </Property>
+        <Property Name="CompositionState" Type="ResourceBlock.v1_0_0.CompositionState">
+          <Annotation Term="OData.Permissions" EnumMember="OData.Permission/Read"/>
+          <Annotation Term="OData.Description" String="The current state of the resource block from a composition perspective."/>
+          <Annotation Term="OData.LongDescription" String="This property shall contain an enumerated value that describes the composition state of the resource block."/>
+          <Annotation Term="Redfish.Required"/>
+        </Property>
+      </ComplexType>
+
+      <EnumType Name="CompositionState">
+        <Member Name="Composing">
+          <Annotation Term="OData.Description" String="Intermediate state indicating composition is in progress."/>
+        </Member>
+        <Member Name="ComposedAndAvailable">
+          <Annotation Term="OData.Description" String="The resource block is currently participating in one or more compositions, and is available to use in more compositions."/>
+          <Annotation Term="Redfish.Revisions">
+            <Collection>
+              <Record>
+                <PropertyValue Property="Kind" EnumMember="Redfish.RevisionKind/Added"/>
+                <PropertyValue Property="Version" String="v1_1_0"/>
+              </Record>
+            </Collection>
+          </Annotation>
+        </Member>
+        <Member Name="Composed">
+          <Annotation Term="OData.Description" String="Final successful state of a resource block that has participated in composition."/>
+        </Member>
+        <Member Name="Unused">
+          <Annotation Term="OData.Description" String="The resource block is free and can participate in composition."/>
+        </Member>
+        <Member Name="Failed">
+          <Annotation Term="OData.Description" String="The final composition resulted in failure and manual intervention might be required to fix it."/>
+        </Member>
+        <Member Name="Unavailable">
+          <Annotation Term="OData.Description" String="The resource block has been made unavailable by the service, such as due to maintenance being performed on the resource block."/>
+          <Annotation Term="Redfish.Revisions">
+            <Collection>
+              <Record>
+                <PropertyValue Property="Kind" EnumMember="Redfish.RevisionKind/Added"/>
+                <PropertyValue Property="Version" String="v1_2_0"/>
+              </Record>
+            </Collection>
+          </Annotation>
+        </Member>
+      </EnumType>
+    </Schema>
+
+    <Schema xmlns="http://docs.oasis-open.org/odata/ns/edm" Namespace="ResourceBlock.v1_0_1">
+      <Annotation Term="Redfish.OwningEntity" String="DMTF"/>
+      <Annotation Term="OData.Description" String="This version was created to force the regeneration of JSON Schema so that OData properties are marked as required, and integer properties are marked as integer rather than number."/>
+      <EntityType Name="ResourceBlock" BaseType="ResourceBlock.v1_0_0.ResourceBlock"/>
+    </Schema>
+
+    <Schema xmlns="http://docs.oasis-open.org/odata/ns/edm" Namespace="ResourceBlock.v1_0_2">
+      <Annotation Term="Redfish.OwningEntity" String="DMTF"/>
+      <Annotation Term="OData.Description" String="This version was created to use the new revisions annotation."/>
+      <EntityType Name="ResourceBlock" BaseType="ResourceBlock.v1_0_1.ResourceBlock"/>
+    </Schema>
+
+    <Schema xmlns="http://docs.oasis-open.org/odata/ns/edm" Namespace="ResourceBlock.v1_0_3">
+      <Annotation Term="Redfish.OwningEntity" String="DMTF"/>
+      <Annotation Term="OData.Description" String="This version was created to force the regeneration of JSON Schema so that URI properties use the uri-reference format."/>
+      <EntityType Name="ResourceBlock" BaseType="ResourceBlock.v1_0_2.ResourceBlock"/>
+    </Schema>
+
+    <Schema xmlns="http://docs.oasis-open.org/odata/ns/edm" Namespace="ResourceBlock.v1_0_4">
+      <Annotation Term="Redfish.OwningEntity" String="DMTF"/>
+      <Annotation Term="OData.Description" String="This version was created to update descriptions that this schema defines."/>
+      <EntityType Name="ResourceBlock" BaseType="ResourceBlock.v1_0_3.ResourceBlock"/>
+    </Schema>
+
+    <Schema xmlns="http://docs.oasis-open.org/odata/ns/edm" Namespace="ResourceBlock.v1_0_5">
+      <Annotation Term="Redfish.OwningEntity" String="DMTF"/>
+      <Annotation Term="OData.Description" String="This version was created to correct various typographical errors."/>
+      <EntityType Name="ResourceBlock" BaseType="ResourceBlock.v1_0_4.ResourceBlock"/>
+    </Schema>
+
+    <Schema xmlns="http://docs.oasis-open.org/odata/ns/edm" Namespace="ResourceBlock.v1_0_6">
+      <Annotation Term="Redfish.OwningEntity" String="DMTF"/>
+      <Annotation Term="OData.Description" String="This version was created specify 64-bit integers in OpenAPI."/>
+      <EntityType Name="ResourceBlock" BaseType="ResourceBlock.v1_0_5.ResourceBlock"/>
+    </Schema>
+
+    <Schema xmlns="http://docs.oasis-open.org/odata/ns/edm" Namespace="ResourceBlock.v1_1_0">
+      <Annotation Term="Redfish.OwningEntity" String="DMTF"/>
+      <Annotation Term="Redfish.Release" String="2018.1"/>
+
+      <EntityType Name="ResourceBlock" BaseType="ResourceBlock.v1_0_0.ResourceBlock"/>
+
+      <ComplexType Name="CompositionStatus" BaseType="ResourceBlock.v1_0_0.CompositionStatus">
+        <Property Name="SharingCapable" Type="Edm.Boolean">
+          <Annotation Term="OData.Permissions" EnumMember="OData.Permission/Read"/>
+          <Annotation Term="OData.Description" String="An indication of whether this resource block can participate in multiple compositions simultaneously."/>
+          <Annotation Term="OData.LongDescription" String="This property shall indicate whether this resource block can participate in multiple compositions simultaneously.  If this property is not provided, it shall be assumed that this resource block is not capable of being shared."/>
+        </Property>
+        <Property Name="SharingEnabled" Type="Edm.Boolean">
+          <Annotation Term="OData.Permissions" EnumMember="OData.Permission/ReadWrite"/>
+          <Annotation Term="OData.Description" String="An indication of whether this resource block is allowed to participate in multiple compositions simultaneously."/>
+          <Annotation Term="OData.LongDescription" String="This property shall indicate whether this resource block can participate in multiple compositions simultaneously.  The service shall reject modifications of this property with HTTP 400 Bad Request if this resource block is already being used as part of a composed resource.  If `false`, the service shall not use the `ComposedAndAvailable` state for this resource block."/>
+        </Property>
+        <Property Name="MaxCompositions" Type="Edm.Int64">
+          <Annotation Term="OData.Permissions" EnumMember="OData.Permission/Read"/>
+          <Annotation Term="OData.Description" String="The maximum number of compositions in which this resource block can participate simultaneously."/>
+          <Annotation Term="OData.LongDescription" String="This property shall contain a number indicating the maximum number of compositions in which this resource block can participate simultaneously.  Services can have additional constraints that prevent this value from being achieved, such as due to system topology and current composed resource utilization.  If SharingCapable is `false`, this value shall be set to `1`.  The service shall support this property if SharingCapable supported."/>
+          <Annotation Term="Validation.Minimum" Int="1"/>
+        </Property>
+        <Property Name="NumberOfCompositions" Type="Edm.Int64">
+          <Annotation Term="OData.Permissions" EnumMember="OData.Permission/Read"/>
+          <Annotation Term="OData.Description" String="The number of compositions in which this resource block is currently participating."/>
+          <Annotation Term="OData.LongDescription" String="This property shall contain the number of compositions in which this resource block is currently participating."/>
+          <Annotation Term="Validation.Minimum" Int="0"/>
+        </Property>
+      </ComplexType>
+    </Schema>
+
+    <Schema xmlns="http://docs.oasis-open.org/odata/ns/edm" Namespace="ResourceBlock.v1_1_1">
+      <Annotation Term="Redfish.OwningEntity" String="DMTF"/>
+      <Annotation Term="OData.Description" String="This version was created to force the regeneration of JSON Schema so that OData properties are marked as required, and integer properties are marked as integer rather than number."/>
+      <EntityType Name="ResourceBlock" BaseType="ResourceBlock.v1_1_0.ResourceBlock"/>
+    </Schema>
+
+    <Schema xmlns="http://docs.oasis-open.org/odata/ns/edm" Namespace="ResourceBlock.v1_1_2">
+      <Annotation Term="Redfish.OwningEntity" String="DMTF"/>
+      <Annotation Term="OData.Description" String="This version was created to use the new revisions annotation."/>
+      <EntityType Name="ResourceBlock" BaseType="ResourceBlock.v1_1_1.ResourceBlock"/>
+    </Schema>
+
+    <Schema xmlns="http://docs.oasis-open.org/odata/ns/edm" Namespace="ResourceBlock.v1_1_3">
+      <Annotation Term="Redfish.OwningEntity" String="DMTF"/>
+      <Annotation Term="OData.Description" String="This version was created to force the regeneration of JSON Schema so that URI properties use the uri-reference format."/>
+      <EntityType Name="ResourceBlock" BaseType="ResourceBlock.v1_1_2.ResourceBlock"/>
+    </Schema>
+
+    <Schema xmlns="http://docs.oasis-open.org/odata/ns/edm" Namespace="ResourceBlock.v1_1_4">
+      <Annotation Term="Redfish.OwningEntity" String="DMTF"/>
+      <Annotation Term="OData.Description" String="This version was created to update descriptions that this schema defines."/>
+      <EntityType Name="ResourceBlock" BaseType="ResourceBlock.v1_1_3.ResourceBlock"/>
+    </Schema>
+
+    <Schema xmlns="http://docs.oasis-open.org/odata/ns/edm" Namespace="ResourceBlock.v1_1_5">
+      <Annotation Term="Redfish.OwningEntity" String="DMTF"/>
+      <Annotation Term="OData.Description" String="This version was created to correct various typographical errors."/>
+      <EntityType Name="ResourceBlock" BaseType="ResourceBlock.v1_1_4.ResourceBlock"/>
+    </Schema>
+
+    <Schema xmlns="http://docs.oasis-open.org/odata/ns/edm" Namespace="ResourceBlock.v1_1_6">
+      <Annotation Term="Redfish.OwningEntity" String="DMTF"/>
+      <Annotation Term="OData.Description" String="This version was created specify 64-bit integers in OpenAPI."/>
+      <EntityType Name="ResourceBlock" BaseType="ResourceBlock.v1_1_5.ResourceBlock"/>
+    </Schema>
+
+    <Schema xmlns="http://docs.oasis-open.org/odata/ns/edm" Namespace="ResourceBlock.v1_2_0">
+      <Annotation Term="Redfish.OwningEntity" String="DMTF"/>
+      <Annotation Term="Redfish.Release" String="2018.2"/>
+      <Annotation Term="OData.Description" String="This version was created to add Expansion to the ResourceBlockType enumeration.  It was also created to add Unavailable to the CompositionState enumeration."/>
+
+      <EntityType Name="ResourceBlock" BaseType="ResourceBlock.v1_1_1.ResourceBlock"/>
+    </Schema>
+
+    <Schema xmlns="http://docs.oasis-open.org/odata/ns/edm" Namespace="ResourceBlock.v1_2_1">
+      <Annotation Term="Redfish.OwningEntity" String="DMTF"/>
+      <Annotation Term="OData.Description" String="This version was created to use the new revisions annotation."/>
+      <EntityType Name="ResourceBlock" BaseType="ResourceBlock.v1_2_0.ResourceBlock"/>
+    </Schema>
+
+    <Schema xmlns="http://docs.oasis-open.org/odata/ns/edm" Namespace="ResourceBlock.v1_2_2">
+      <Annotation Term="Redfish.OwningEntity" String="DMTF"/>
+      <Annotation Term="OData.Description" String="This version was created to force the regeneration of JSON Schema so that URI properties use the uri-reference format."/>
+      <EntityType Name="ResourceBlock" BaseType="ResourceBlock.v1_2_1.ResourceBlock"/>
+    </Schema>
+
+    <Schema xmlns="http://docs.oasis-open.org/odata/ns/edm" Namespace="ResourceBlock.v1_2_3">
+      <Annotation Term="Redfish.OwningEntity" String="DMTF"/>
+      <Annotation Term="OData.Description" String="This version was created to update descriptions that this schema defines."/>
+      <EntityType Name="ResourceBlock" BaseType="ResourceBlock.v1_2_2.ResourceBlock"/>
+    </Schema>
+
+    <Schema xmlns="http://docs.oasis-open.org/odata/ns/edm" Namespace="ResourceBlock.v1_2_4">
+      <Annotation Term="Redfish.OwningEntity" String="DMTF"/>
+      <Annotation Term="OData.Description" String="This version was created to correct various typographical errors."/>
+      <EntityType Name="ResourceBlock" BaseType="ResourceBlock.v1_2_3.ResourceBlock"/>
+    </Schema>
+
+    <Schema xmlns="http://docs.oasis-open.org/odata/ns/edm" Namespace="ResourceBlock.v1_2_5">
+      <Annotation Term="Redfish.OwningEntity" String="DMTF"/>
+      <Annotation Term="OData.Description" String="This version was created specify 64-bit integers in OpenAPI."/>
+      <EntityType Name="ResourceBlock" BaseType="ResourceBlock.v1_2_4.ResourceBlock"/>
+    </Schema>
+
+    <Schema xmlns="http://docs.oasis-open.org/odata/ns/edm" Namespace="ResourceBlock.v1_3_0">
+      <Annotation Term="Redfish.OwningEntity" String="DMTF"/>
+      <Annotation Term="Redfish.Release" String="2018.3"/>
+
+      <EntityType Name="ResourceBlock" BaseType="ResourceBlock.v1_2_1.ResourceBlock">
+        <NavigationProperty Name="Drives" Type="Collection(Drive.Drive)">
+          <Annotation Term="OData.Permissions" EnumMember="OData.Permission/Read"/>
+          <Annotation Term="OData.Description" String="An array of links to the drives available in this resource block."/>
+          <Annotation Term="OData.LongDescription" String="This property shall contain an array of links to resource of type Drive that this resource block contains."/>
+          <Annotation Term="OData.AutoExpandReferences"/>
+        </NavigationProperty>
+      </EntityType>
+
+      <ComplexType Name="ResourceBlockLimits" BaseType="ResourceBlock.ResourceBlockLimits">
+        <Annotation Term="OData.Description" String="This type specifies the allowable quantities of types of resource blocks for a composition request."/>
+        <Annotation Term="OData.LongDescription" String="This object shall specify the allowable quantities of types of resource blocks for a given composition request."/>
+        <Property Name="MinCompute" Type="Edm.Int64">
+          <Annotation Term="OData.Permissions" EnumMember="OData.Permission/Read"/>
+          <Annotation Term="OData.Description" String="The minimum number of resource blocks of type `Compute` required for the composition request."/>
+          <Annotation Term="OData.LongDescription" String="This property shall contain an integer that specifies the minimum number of resource blocks of type `Compute` required for the composition request."/>
+          <Annotation Term="Validation.Minimum" Int="0"/>
+        </Property>
+        <Property Name="MaxCompute" Type="Edm.Int64">
+          <Annotation Term="OData.Permissions" EnumMember="OData.Permission/Read"/>
+          <Annotation Term="OData.Description" String="The maximum number of resource blocks of type `Compute` allowed for the composition request."/>
+          <Annotation Term="OData.LongDescription" String="This property shall contain an integer that specifies the maximum number of resource blocks of type `Compute` allowed for the composition request."/>
+          <Annotation Term="Validation.Minimum" Int="1"/>
+        </Property>
+        <Property Name="MinProcessor" Type="Edm.Int64">
+          <Annotation Term="OData.Permissions" EnumMember="OData.Permission/Read"/>
+          <Annotation Term="OData.Description" String="The minimum number of resource blocks of type `Processor` required for the composition request."/>
+          <Annotation Term="OData.LongDescription" String="This property shall contain an integer that specifies the minimum number of resource blocks of type `Processor` required for the composition request."/>
+          <Annotation Term="Validation.Minimum" Int="0"/>
+        </Property>
+        <Property Name="MaxProcessor" Type="Edm.Int64">
+          <Annotation Term="OData.Permissions" EnumMember="OData.Permission/Read"/>
+          <Annotation Term="OData.Description" String="The maximum number of resource blocks of type `Processor` allowed for the composition request."/>
+          <Annotation Term="OData.LongDescription" String="This property shall contain an integer that specifies the maximum number of resource blocks of type `Processor` allowed for the composition request."/>
+          <Annotation Term="Validation.Minimum" Int="1"/>
+        </Property>
+        <Property Name="MinMemory" Type="Edm.Int64">
+          <Annotation Term="OData.Permissions" EnumMember="OData.Permission/Read"/>
+          <Annotation Term="OData.Description" String="The minimum number of resource blocks of type `Memory` required for the composition request."/>
+          <Annotation Term="OData.LongDescription" String="This property shall contain an integer that specifies the minimum number of resource blocks of type `Memory` required for the composition request."/>
+          <Annotation Term="Validation.Minimum" Int="0"/>
+        </Property>
+        <Property Name="MaxMemory" Type="Edm.Int64">
+          <Annotation Term="OData.Permissions" EnumMember="OData.Permission/Read"/>
+          <Annotation Term="OData.Description" String="The maximum number of resource blocks of type `Memory` allowed for the composition request."/>
+          <Annotation Term="OData.LongDescription" String="This property shall contain an integer that specifies the maximum number of resource blocks of type `Memory` allowed for the composition request."/>
+          <Annotation Term="Validation.Minimum" Int="1"/>
+        </Property>
+        <Property Name="MinNetwork" Type="Edm.Int64">
+          <Annotation Term="OData.Permissions" EnumMember="OData.Permission/Read"/>
+          <Annotation Term="OData.Description" String="The minimum number of resource blocks of type `Network` required for the composition request."/>
+          <Annotation Term="OData.LongDescription" String="This property shall contain an integer that specifies the minimum number of resource blocks of type `Network` required for the composition request."/>
+          <Annotation Term="Validation.Minimum" Int="0"/>
+        </Property>
+        <Property Name="MaxNetwork" Type="Edm.Int64">
+          <Annotation Term="OData.Permissions" EnumMember="OData.Permission/Read"/>
+          <Annotation Term="OData.Description" String="The maximum number of resource blocks of type `Network` allowed for the composition request."/>
+          <Annotation Term="OData.LongDescription" String="This property shall contain an integer that specifies the maximum number of resource blocks of type `Network` allowed for the composition request."/>
+          <Annotation Term="Validation.Minimum" Int="1"/>
+        </Property>
+        <Property Name="MinStorage" Type="Edm.Int64">
+          <Annotation Term="OData.Permissions" EnumMember="OData.Permission/Read"/>
+          <Annotation Term="OData.Description" String="The minimum number of resource blocks of type `Storage` required for the composition request."/>
+          <Annotation Term="OData.LongDescription" String="This property shall contain an integer that specifies the minimum number of resource blocks of type `Storage` required for the composition request."/>
+          <Annotation Term="Validation.Minimum" Int="0"/>
+        </Property>
+        <Property Name="MaxStorage" Type="Edm.Int64">
+          <Annotation Term="OData.Permissions" EnumMember="OData.Permission/Read"/>
+          <Annotation Term="OData.Description" String="The maximum number of resource blocks of type `Storage` allowed for the composition request."/>
+          <Annotation Term="OData.LongDescription" String="This property shall contain an integer that specifies the maximum number of resource blocks of type `Storage` allowed for the composition request."/>
+          <Annotation Term="Validation.Minimum" Int="1"/>
+        </Property>
+        <Property Name="MinComputerSystem" Type="Edm.Int64">
+          <Annotation Term="OData.Permissions" EnumMember="OData.Permission/Read"/>
+          <Annotation Term="OData.Description" String="The minimum number of resource blocks of type `ComputerSystem` required for the composition request."/>
+          <Annotation Term="OData.LongDescription" String="This property shall contain an integer that specifies the minimum number of resource blocks of type `ComputerSystem` required for the composition request."/>
+          <Annotation Term="Validation.Minimum" Int="0"/>
+        </Property>
+        <Property Name="MaxComputerSystem" Type="Edm.Int64">
+          <Annotation Term="OData.Permissions" EnumMember="OData.Permission/Read"/>
+          <Annotation Term="OData.Description" String="The maximum number of resource blocks of type `ComputerSystem` allowed for the composition request."/>
+          <Annotation Term="OData.LongDescription" String="This property shall contain an integer that specifies the maximum number of resource blocks of type `ComputerSystem` allowed for the composition request."/>
+          <Annotation Term="Validation.Minimum" Int="1"/>
+        </Property>
+        <Property Name="MinExpansion" Type="Edm.Int64">
+          <Annotation Term="OData.Permissions" EnumMember="OData.Permission/Read"/>
+          <Annotation Term="OData.Description" String="The minimum number of resource blocks of type `Expansion` required for the composition request."/>
+          <Annotation Term="OData.LongDescription" String="This property shall contain an integer that specifies the minimum number of resource blocks of type `Expansion` required for the composition request."/>
+          <Annotation Term="Validation.Minimum" Int="0"/>
+        </Property>
+        <Property Name="MaxExpansion" Type="Edm.Int64">
+          <Annotation Term="OData.Permissions" EnumMember="OData.Permission/Read"/>
+          <Annotation Term="OData.Description" String="The maximum number of resource blocks of type `Expansion` allowed for the composition request."/>
+          <Annotation Term="OData.LongDescription" String="This property shall contain an integer that specifies the maximum number of resource blocks of type `Expansion` allowed for the composition request."/>
+          <Annotation Term="Validation.Minimum" Int="1"/>
+        </Property>
+      </ComplexType>
+    </Schema>
+
+    <Schema xmlns="http://docs.oasis-open.org/odata/ns/edm" Namespace="ResourceBlock.v1_3_1">
+      <Annotation Term="Redfish.OwningEntity" String="DMTF"/>
+      <Annotation Term="OData.Description" String="This version was created to force the regeneration of JSON Schema so that URI properties use the uri-reference format."/>
+      <EntityType Name="ResourceBlock" BaseType="ResourceBlock.v1_3_0.ResourceBlock"/>
+    </Schema>
+
+    <Schema xmlns="http://docs.oasis-open.org/odata/ns/edm" Namespace="ResourceBlock.v1_3_2">
+      <Annotation Term="Redfish.OwningEntity" String="DMTF"/>
+      <Annotation Term="OData.Description" String="This version was created to update descriptions that this schema defines."/>
+      <EntityType Name="ResourceBlock" BaseType="ResourceBlock.v1_3_1.ResourceBlock"/>
+    </Schema>
+
+    <Schema xmlns="http://docs.oasis-open.org/odata/ns/edm" Namespace="ResourceBlock.v1_3_3">
+      <Annotation Term="Redfish.OwningEntity" String="DMTF"/>
+      <Annotation Term="OData.Description" String="This version was created to correct various typographical errors."/>
+      <EntityType Name="ResourceBlock" BaseType="ResourceBlock.v1_3_2.ResourceBlock"/>
+    </Schema>
+
+    <Schema xmlns="http://docs.oasis-open.org/odata/ns/edm" Namespace="ResourceBlock.v1_3_4">
+      <Annotation Term="Redfish.OwningEntity" String="DMTF"/>
+      <Annotation Term="OData.Description" String="This version was created specify 64-bit integers in OpenAPI."/>
+      <EntityType Name="ResourceBlock" BaseType="ResourceBlock.v1_3_3.ResourceBlock"/>
+    </Schema>
+
+    <Schema xmlns="http://docs.oasis-open.org/odata/ns/edm" Namespace="ResourceBlock.v1_4_0">
+      <Annotation Term="Redfish.OwningEntity" String="DMTF"/>
+      <Annotation Term="Redfish.Release" String="2020.4"/>
+      <Annotation Term="OData.Description" String="This version was created to add the Pool and Client properties.  It was also created to add `IndependentResource` to the ResourceBlockType enumeration.  It was also created to add the ConsumingResourceBlocks and SupplyingResourceBlocks properties to Links."/>
+
+      <EntityType Name="ResourceBlock" BaseType="ResourceBlock.v1_3_4.ResourceBlock">
+        <Property Name="Pool" Type="ResourceBlock.v1_4_0.PoolType">
+          <Annotation Term="OData.Permissions" EnumMember="OData.Permission/ReadWrite"/>
+          <Annotation Term="OData.Description" String="The pool to which this resource block belongs."/>
+          <Annotation Term="OData.LongDescription" String="This property shall contain the pool to which this resource block belongs.  If this resource block is not assigned to a client, this property shall contain the value `Unassigned`.  If this resource block is assigned to a client, this property shall not contain the value `Unassigned`."/>
+        </Property>
+        <Property Name="Client" Type="Edm.String">
+          <Annotation Term="OData.Permissions" EnumMember="OData.Permission/ReadWrite"/>
+          <Annotation Term="OData.Description" String="The client to which this resource block is assigned."/>
+          <Annotation Term="OData.LongDescription" String="This property shall contain the client to which this resource block is assigned."/>
+        </Property>
+      </EntityType>
+
+      <ComplexType Name="Links" BaseType="ResourceBlock.v1_0_0.Links">
+        <NavigationProperty Name="ConsumingResourceBlocks" Type="Collection(ResourceBlock.ResourceBlock)">
+          <Annotation Term="OData.Permissions" EnumMember="OData.Permission/Read"/>
+          <Annotation Term="OData.Description" String="An array of links to resource blocks that depend on this resource block."/>
+          <Annotation Term="OData.LongDescription" String="This property shall contain an array of links to resources of type ResourceBlock that represent the resource blocks that depend on this resource block as a component."/>
+          <Annotation Term="OData.AutoExpandReferences"/>
+        </NavigationProperty>
+        <NavigationProperty Name="SupplyingResourceBlocks" Type="Collection(ResourceBlock.ResourceBlock)">
+          <Annotation Term="OData.Permissions" EnumMember="OData.Permission/Read"/>
+          <Annotation Term="OData.Description" String="An array of links to resource blocks that this resource block depends on."/>
+          <Annotation Term="OData.LongDescription" String="This property shall contain an array of links to resources of type ResourceBlock that represent the resource blocks that this resource block depends on as components."/>
+          <Annotation Term="OData.AutoExpandReferences"/>
+        </NavigationProperty>
+      </ComplexType>
+
+      <EnumType Name="PoolType">
+        <Member Name="Free">
+          <Annotation Term="OData.Description" String="This resource block is in the free pool and is not contributing to any composed resources."/>
+        </Member>
+        <Member Name="Active">
+          <Annotation Term="OData.Description" String="This resource block is in the active pool and is contributing to at least one composed resource as a result of a composition request."/>
+        </Member>
+        <Member Name="Unassigned">
+          <Annotation Term="OData.Description" String="This resource block is not assigned to any pools."/>
+        </Member>
+      </EnumType>
+    </Schema>
+
+  </edmx:DataServices>
+</edmx:Edmx>

--- a/static/redfish/v1/schema/RouteEntryCollection_v1.xml
+++ b/static/redfish/v1/schema/RouteEntryCollection_v1.xml
@@ -1,0 +1,74 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!---->
+<!--################################################################################       -->
+<!--# Redfish Schema:  RouteEntryCollection                                                -->
+<!--#                                                                                      -->
+<!--# For a detailed change log, see the README file contained in the DSP8010 bundle,      -->
+<!--# available at http://www.dmtf.org/standards/redfish                                   -->
+<!--# Copyright 2014-2021 DMTF.                                                            -->
+<!--# For the full DMTF copyright policy, see http://www.dmtf.org/about/policies/copyright -->
+<!--################################################################################       -->
+<!---->
+<edmx:Edmx xmlns:edmx="http://docs.oasis-open.org/odata/ns/edmx" Version="4.0">
+
+  <edmx:Reference Uri="http://docs.oasis-open.org/odata/odata/v4.0/errata03/csd01/complete/vocabularies/Org.OData.Core.V1.xml">
+    <edmx:Include Namespace="Org.OData.Core.V1" Alias="OData"/>
+  </edmx:Reference>
+  <edmx:Reference Uri="http://docs.oasis-open.org/odata/odata/v4.0/errata03/csd01/complete/vocabularies/Org.OData.Capabilities.V1.xml">
+    <edmx:Include Namespace="Org.OData.Capabilities.V1" Alias="Capabilities"/>
+  </edmx:Reference>
+  <edmx:Reference Uri="http://redfish.dmtf.org/schemas/v1/Resource_v1.xml">
+    <edmx:Include Namespace="Resource.v1_0_0"/>
+  </edmx:Reference>
+  <edmx:Reference Uri="http://redfish.dmtf.org/schemas/v1/RedfishExtensions_v1.xml">
+    <edmx:Include Namespace="RedfishExtensions.v1_0_0" Alias="Redfish"/>
+  </edmx:Reference>
+  <edmx:Reference Uri="http://redfish.dmtf.org/schemas/v1/RouteEntry_v1.xml">
+    <edmx:Include Namespace="RouteEntry"/>
+  </edmx:Reference>
+
+  <edmx:DataServices>
+
+    <Schema xmlns="http://docs.oasis-open.org/odata/ns/edm" Namespace="RouteEntryCollection">
+      <Annotation Term="Redfish.OwningEntity" String="DMTF"/>
+
+      <EntityType Name="RouteEntryCollection" BaseType="Resource.v1_0_0.ResourceCollection">
+        <Annotation Term="OData.Description" String="The collection of RouteEntry Resource instances."/>
+        <Annotation Term="OData.LongDescription" String="This Resource shall represent a Resource Collection of RouteEntry instances for a Redfish implementation."/>
+        <Annotation Term="Capabilities.InsertRestrictions">
+          <Record>
+            <PropertyValue Property="Insertable" Bool="true"/>
+          </Record>
+        </Annotation>
+        <Annotation Term="Capabilities.UpdateRestrictions">
+          <Record>
+            <PropertyValue Property="Updatable" Bool="false"/>
+          </Record>
+        </Annotation>
+        <Annotation Term="Capabilities.DeleteRestrictions">
+          <Record>
+            <PropertyValue Property="Deletable" Bool="false"/>
+          </Record>
+        </Annotation>
+        <Annotation Term="Redfish.Uris">
+          <Collection>
+            <String>/redfish/v1/Fabrics/{FabricId}/Switches/{SwitchId}/Ports/{PortId}/LPRT</String>
+            <String>/redfish/v1/Fabrics/{FabricId}/Switches/{SwitchId}/Ports/{PortId}/MPRT</String>
+            <String>/redfish/v1/Systems/{ComputerSystemId}/FabricAdapters/{FabricAdapterId}/MSDT</String>
+            <String>/redfish/v1/Systems/{ComputerSystemId}/FabricAdapters/{FabricAdapterId}/SSDT</String>
+            <String>/redfish/v1/Systems/{ComputerSystemId}/FabricAdapters/{FabricAdapterId}/Ports/{PortId}/LPRT</String>
+            <String>/redfish/v1/Systems/{ComputerSystemId}/FabricAdapters/{FabricAdapterId}/Ports/{PortId}/MPRT</String>
+          </Collection>
+        </Annotation>
+        <NavigationProperty Name="Members" Type="Collection(RouteEntry.RouteEntry)">
+          <Annotation Term="OData.Permissions" EnumMember="OData.Permission/Read"/>
+          <Annotation Term="OData.Description" String="The members of this collection."/>
+          <Annotation Term="OData.LongDescription" String="This property shall contain an array of links to the members of this collection."/>
+          <Annotation Term="OData.AutoExpandReferences"/>
+          <Annotation Term="Redfish.Required"/>
+        </NavigationProperty>
+      </EntityType>
+    </Schema>
+
+  </edmx:DataServices>
+</edmx:Edmx>

--- a/static/redfish/v1/schema/RouteEntry_v1.xml
+++ b/static/redfish/v1/schema/RouteEntry_v1.xml
@@ -1,0 +1,124 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!---->
+<!--################################################################################       -->
+<!--# Redfish Schema:  RouteEntry v1.0.1                                                   -->
+<!--#                                                                                      -->
+<!--# For a detailed change log, see the README file contained in the DSP8010 bundle,      -->
+<!--# available at http://www.dmtf.org/standards/redfish                                   -->
+<!--# Copyright 2014-2021 DMTF.                                                            -->
+<!--# For the full DMTF copyright policy, see http://www.dmtf.org/about/policies/copyright -->
+<!--################################################################################       -->
+<!---->
+<edmx:Edmx xmlns:edmx="http://docs.oasis-open.org/odata/ns/edmx" Version="4.0">
+
+  <edmx:Reference Uri="http://docs.oasis-open.org/odata/odata/v4.0/errata03/csd01/complete/vocabularies/Org.OData.Core.V1.xml">
+    <edmx:Include Namespace="Org.OData.Core.V1" Alias="OData"/>
+  </edmx:Reference>
+  <edmx:Reference Uri="http://docs.oasis-open.org/odata/odata/v4.0/errata03/csd01/complete/vocabularies/Org.OData.Capabilities.V1.xml">
+    <edmx:Include Namespace="Org.OData.Capabilities.V1" Alias="Capabilities"/>
+  </edmx:Reference>
+  <edmx:Reference Uri="http://redfish.dmtf.org/schemas/v1/Resource_v1.xml">
+    <edmx:Include Namespace="Resource"/>
+    <edmx:Include Namespace="Resource.v1_0_0"/>
+  </edmx:Reference>
+  <edmx:Reference Uri="http://redfish.dmtf.org/schemas/v1/RedfishExtensions_v1.xml">
+    <edmx:Include Namespace="RedfishExtensions.v1_0_0" Alias="Redfish"/>
+  </edmx:Reference>
+  <edmx:Reference Uri="http://redfish.dmtf.org/schemas/v1/RedfishExtensions_v1.xml">
+    <edmx:Include Namespace="Validation.v1_0_0" Alias="Validation"/>
+  </edmx:Reference>
+  <edmx:Reference Uri="http://redfish.dmtf.org/schemas/v1/RouteSetEntryCollection_v1.xml">
+    <edmx:Include Namespace="RouteSetEntryCollection"/>
+  </edmx:Reference>
+
+  <edmx:DataServices>
+
+    <Schema xmlns="http://docs.oasis-open.org/odata/ns/edm" Namespace="RouteEntry">
+      <Annotation Term="Redfish.OwningEntity" String="DMTF"/>
+
+      <EntityType Name="RouteEntry" BaseType="Resource.v1_0_0.Resource" Abstract="true">
+        <Annotation Term="OData.Description" String="The RouteEntry schema describes the content of route entry rows.  Each route entry contains route sets that list the possible routes for the route entry."/>
+        <Annotation Term="OData.LongDescription" String="This Resource shall represent the content of route entry rows in the Redfish Specification."/>
+        <Annotation Term="Capabilities.InsertRestrictions">
+          <Record>
+            <PropertyValue Property="Insertable" Bool="false"/>
+          </Record>
+        </Annotation>
+        <Annotation Term="Capabilities.UpdateRestrictions">
+          <Record>
+            <PropertyValue Property="Updatable" Bool="true"/>
+            <Annotation Term="OData.Description" String="The route entry can be updated to enable or disable it."/>
+          </Record>
+        </Annotation>
+        <Annotation Term="Capabilities.DeleteRestrictions">
+          <Record>
+            <PropertyValue Property="Deletable" Bool="true"/>
+          </Record>
+        </Annotation>
+        <Annotation Term="Redfish.Uris">
+          <Collection>
+            <String>/redfish/v1/Fabrics/{FabricId}/Switches/{SwitchId}/Ports/{PortId}/LPRT/{LPRTId}</String>
+            <String>/redfish/v1/Fabrics/{FabricId}/Switches/{SwitchId}/Ports/{PortId}/MPRT/{MPRTId}</String>
+            <String>/redfish/v1/Systems/{ComputerSystemId}/FabricAdapters/{FabricAdapterId}/MSDT/{MSDTId}</String>
+            <String>/redfish/v1/Systems/{ComputerSystemId}/FabricAdapters/{FabricAdapterId}/SSDT/{SSDTId}</String>
+            <String>/redfish/v1/Systems/{ComputerSystemId}/FabricAdapters/{FabricAdapterId}/Ports/{PortId}/LPRT/{LPRTId}</String>
+            <String>/redfish/v1/Systems/{ComputerSystemId}/FabricAdapters/{FabricAdapterId}/Ports/{PortId}/MPRT/{MPRTId}</String>
+          </Collection>
+        </Annotation>
+      </EntityType>
+
+    </Schema>
+
+    <Schema xmlns="http://docs.oasis-open.org/odata/ns/edm" Namespace="RouteEntry.v1_0_0">
+      <Annotation Term="Redfish.OwningEntity" String="DMTF"/>
+      <Annotation Term="Redfish.Release" String="2019.4"/>
+
+      <EntityType Name="RouteEntry" BaseType="RouteEntry.RouteEntry">
+        <NavigationProperty Name="RouteSet" Type="RouteSetEntryCollection.RouteSetEntryCollection" ContainsTarget="true" Nullable="false">
+          <Annotation Term="OData.Permissions" EnumMember="OData.Permission/Read"/>
+          <Annotation Term="OData.Description" String="The link to the collection of route set entries associated with this route."/>
+          <Annotation Term="OData.LongDescription" String="This property shall contain a link to a Resource Collection of type RouteSetEntryCollection."/>
+          <Annotation Term="OData.AutoExpandReferences"/>
+        </NavigationProperty>
+        <Property Name="RawEntryHex" Type="Edm.String" Nullable="false">
+          <Annotation Term="OData.Permissions" EnumMember="OData.Permission/ReadWrite"/>
+          <Annotation Term="OData.Description" String="The raw data of route entry rows."/>
+          <Annotation Term="OData.LongDescription" String="This property shall contain a binary data that represents the content of route entry rows."/>
+          <Annotation Term="Validation.Pattern" String="^0[xX](([a-fA-F]|[0-9]){2}){8}$"/>
+        </Property>
+        <Property Name="MinimumHopCount" Type="Edm.Int64" Nullable="false">
+          <Annotation Term="OData.Permissions" EnumMember="OData.Permission/ReadWrite"/>
+          <Annotation Term="OData.Description" String="The minimum number of hops."/>
+          <Annotation Term="OData.LongDescription" String="This property shall indicate the minimum hop count used to calculate the computed hop count."/>
+        </Property>
+        <Property Name="Actions" Type="RouteEntry.v1_0_0.Actions" Nullable="false">
+          <Annotation Term="OData.Description" String="The available actions for this Resource."/>
+          <Annotation Term="OData.LongDescription" String="This property shall contain the available actions for this Resource."/>
+        </Property>
+      </EntityType>
+
+      <ComplexType Name="Actions">
+        <Annotation Term="OData.AdditionalProperties" Bool="false"/>
+        <Annotation Term="OData.Description" String="The available actions for this Resource."/>
+        <Annotation Term="OData.LongDescription" String="This type shall contain the available actions for this Resource."/>
+        <Property Name="Oem" Type="RouteEntry.v1_0_0.OemActions" Nullable="false">
+          <Annotation Term="OData.Description" String="The available OEM-specific actions for this Resource."/>
+          <Annotation Term="OData.LongDescription" String="This property shall contain the available OEM-specific actions for this Resource."/>
+        </Property>
+      </ComplexType>
+
+      <ComplexType Name="OemActions">
+        <Annotation Term="OData.AdditionalProperties" Bool="true"/>
+        <Annotation Term="OData.Description" String="The available OEM-specific actions for this Resource."/>
+        <Annotation Term="OData.LongDescription" String="This type shall contain the available OEM-specific actions for this Resource."/>
+      </ComplexType>
+    </Schema>
+
+    <Schema xmlns="http://docs.oasis-open.org/odata/ns/edm" Namespace="RouteEntry.v1_0_1">
+      <Annotation Term="Redfish.OwningEntity" String="DMTF"/>
+      <Annotation Term="OData.Description" String="This version was created specify 64-bit integers in OpenAPI."/>
+      <EntityType Name="RouteEntry" BaseType="RouteEntry.v1_0_0.RouteEntry"/>
+    </Schema>
+
+  </edmx:DataServices>
+</edmx:Edmx>

--- a/static/redfish/v1/schema/RouteSetEntryCollection_v1.xml
+++ b/static/redfish/v1/schema/RouteSetEntryCollection_v1.xml
@@ -1,0 +1,74 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!---->
+<!--################################################################################       -->
+<!--# Redfish Schema:  RouteSetEntryCollection                                             -->
+<!--#                                                                                      -->
+<!--# For a detailed change log, see the README file contained in the DSP8010 bundle,      -->
+<!--# available at http://www.dmtf.org/standards/redfish                                   -->
+<!--# Copyright 2014-2021 DMTF.                                                            -->
+<!--# For the full DMTF copyright policy, see http://www.dmtf.org/about/policies/copyright -->
+<!--################################################################################       -->
+<!---->
+<edmx:Edmx xmlns:edmx="http://docs.oasis-open.org/odata/ns/edmx" Version="4.0">
+
+  <edmx:Reference Uri="http://docs.oasis-open.org/odata/odata/v4.0/errata03/csd01/complete/vocabularies/Org.OData.Core.V1.xml">
+    <edmx:Include Namespace="Org.OData.Core.V1" Alias="OData"/>
+  </edmx:Reference>
+  <edmx:Reference Uri="http://docs.oasis-open.org/odata/odata/v4.0/errata03/csd01/complete/vocabularies/Org.OData.Capabilities.V1.xml">
+    <edmx:Include Namespace="Org.OData.Capabilities.V1" Alias="Capabilities"/>
+  </edmx:Reference>
+  <edmx:Reference Uri="http://redfish.dmtf.org/schemas/v1/Resource_v1.xml">
+    <edmx:Include Namespace="Resource.v1_0_0"/>
+  </edmx:Reference>
+  <edmx:Reference Uri="http://redfish.dmtf.org/schemas/v1/RedfishExtensions_v1.xml">
+    <edmx:Include Namespace="RedfishExtensions.v1_0_0" Alias="Redfish"/>
+  </edmx:Reference>
+  <edmx:Reference Uri="http://redfish.dmtf.org/schemas/v1/RouteSetEntry_v1.xml">
+    <edmx:Include Namespace="RouteSetEntry"/>
+  </edmx:Reference>
+
+  <edmx:DataServices>
+
+    <Schema xmlns="http://docs.oasis-open.org/odata/ns/edm" Namespace="RouteSetEntryCollection">
+      <Annotation Term="Redfish.OwningEntity" String="DMTF"/>
+
+      <EntityType Name="RouteSetEntryCollection" BaseType="Resource.v1_0_0.ResourceCollection">
+        <Annotation Term="OData.Description" String="The collection of RouteSetEntry Resource instances."/>
+        <Annotation Term="OData.LongDescription" String="This Resource shall represent a Resource Collection of RouteSetEntry instances for a Redfish implementation."/>
+        <Annotation Term="Capabilities.InsertRestrictions">
+          <Record>
+            <PropertyValue Property="Insertable" Bool="true"/>
+          </Record>
+        </Annotation>
+        <Annotation Term="Capabilities.UpdateRestrictions">
+          <Record>
+            <PropertyValue Property="Updatable" Bool="false"/>
+          </Record>
+        </Annotation>
+        <Annotation Term="Capabilities.DeleteRestrictions">
+          <Record>
+            <PropertyValue Property="Deletable" Bool="false"/>
+          </Record>
+        </Annotation>
+        <Annotation Term="Redfish.Uris">
+          <Collection>
+            <String>/redfish/v1/Fabrics/{FabricId}/Switches/{SwitchId}/Ports/{PortId}/LPRT/{LPRTId}/RouteSet</String>
+            <String>/redfish/v1/Fabrics/{FabricId}/Switches/{SwitchId}/Ports/{PortId}/MPRT/{MPRTId}/RouteSet</String>
+            <String>/redfish/v1/Systems/{ComputerSystemId}/FabricAdapters/{FabricAdapterId}/MSDT/{MSDTId}/RouteSet</String>
+            <String>/redfish/v1/Systems/{ComputerSystemId}/FabricAdapters/{FabricAdapterId}/SSDT/{SSDTId}/RouteSet</String>
+            <String>/redfish/v1/Systems/{ComputerSystemId}/FabricAdapters/{FabricAdapterId}/Ports/{PortId}/LPRT/{LPRTId}/RouteSet</String>
+            <String>/redfish/v1/Systems/{ComputerSystemId}/FabricAdapters/{FabricAdapterId}/Ports/{PortId}/MPRT/{MPRTId}/RouteSet</String>
+          </Collection>
+        </Annotation>
+        <NavigationProperty Name="Members" Type="Collection(RouteSetEntry.RouteSetEntry)">
+          <Annotation Term="OData.Permissions" EnumMember="OData.Permission/Read"/>
+          <Annotation Term="OData.Description" String="The members of this collection."/>
+          <Annotation Term="OData.LongDescription" String="This property shall contain an array of links to the members of this collection."/>
+          <Annotation Term="OData.AutoExpandReferences"/>
+          <Annotation Term="Redfish.Required"/>
+        </NavigationProperty>
+      </EntityType>
+    </Schema>
+
+  </edmx:DataServices>
+</edmx:Edmx>

--- a/static/redfish/v1/schema/RouteSetEntry_v1.xml
+++ b/static/redfish/v1/schema/RouteSetEntry_v1.xml
@@ -1,0 +1,123 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!---->
+<!--################################################################################       -->
+<!--# Redfish Schema:  RouteSetEntry v1.0.1                                                -->
+<!--#                                                                                      -->
+<!--# For a detailed change log, see the README file contained in the DSP8010 bundle,      -->
+<!--# available at http://www.dmtf.org/standards/redfish                                   -->
+<!--# Copyright 2014-2021 DMTF.                                                            -->
+<!--# For the full DMTF copyright policy, see http://www.dmtf.org/about/policies/copyright -->
+<!--################################################################################       -->
+<!---->
+<edmx:Edmx xmlns:edmx="http://docs.oasis-open.org/odata/ns/edmx" Version="4.0">
+
+  <edmx:Reference Uri="http://docs.oasis-open.org/odata/odata/v4.0/errata03/csd01/complete/vocabularies/Org.OData.Core.V1.xml">
+    <edmx:Include Namespace="Org.OData.Core.V1" Alias="OData"/>
+  </edmx:Reference>
+  <edmx:Reference Uri="http://docs.oasis-open.org/odata/odata/v4.0/errata03/csd01/complete/vocabularies/Org.OData.Capabilities.V1.xml">
+    <edmx:Include Namespace="Org.OData.Capabilities.V1" Alias="Capabilities"/>
+  </edmx:Reference>
+  <edmx:Reference Uri="http://docs.oasis-open.org/odata/odata/v4.0/errata03/csd01/complete/vocabularies/Org.OData.Measures.V1.xml">
+    <edmx:Include Namespace="Org.OData.Measures.V1" Alias="Measures"/>
+  </edmx:Reference>
+  <edmx:Reference Uri="http://redfish.dmtf.org/schemas/v1/Resource_v1.xml">
+    <edmx:Include Namespace="Resource"/>
+    <edmx:Include Namespace="Resource.v1_0_0"/>
+  </edmx:Reference>
+  <edmx:Reference Uri="http://redfish.dmtf.org/schemas/v1/RedfishExtensions_v1.xml">
+    <edmx:Include Namespace="RedfishExtensions.v1_0_0" Alias="Redfish"/>
+  </edmx:Reference>
+
+  <edmx:DataServices>
+
+    <Schema xmlns="http://docs.oasis-open.org/odata/ns/edm" Namespace="RouteSetEntry">
+      <Annotation Term="Redfish.OwningEntity" String="DMTF"/>
+
+      <EntityType Name="RouteSetEntry" BaseType="Resource.v1_0_0.Resource" Abstract="true">
+        <Annotation Term="OData.Description" String="The RouteSetEntry schema contains the information about a route.  It is part of a larger set that contains possible routes for a particular route entry."/>
+        <Annotation Term="OData.LongDescription" String="This Resource contains the content of a route set in the Redfish Specification."/>
+        <Annotation Term="Capabilities.InsertRestrictions">
+          <Record>
+            <PropertyValue Property="Insertable" Bool="false"/>
+          </Record>
+        </Annotation>
+        <Annotation Term="Capabilities.UpdateRestrictions">
+          <Record>
+            <PropertyValue Property="Updatable" Bool="true"/>
+          </Record>
+        </Annotation>
+        <Annotation Term="Capabilities.DeleteRestrictions">
+          <Record>
+            <PropertyValue Property="Deletable" Bool="true"/>
+          </Record>
+        </Annotation>
+        <Annotation Term="Redfish.Uris">
+          <Collection>
+            <String>/redfish/v1/Fabrics/{FabricId}/Switches/{SwitchId}/Ports/{PortId}/LPRT/{LPRTId}/RouteSet/{RouteId}</String>
+            <String>/redfish/v1/Fabrics/{FabricId}/Switches/{SwitchId}/Ports/{PortId}/MPRT/{MPRTId}/RouteSet/{RouteId}</String>
+            <String>/redfish/v1/Systems/{ComputerSystemId}/FabricAdapters/{FabricAdapterId}/MSDT/{MSDTId}/RouteSet/{RouteId}</String>
+            <String>/redfish/v1/Systems/{ComputerSystemId}/FabricAdapters/{FabricAdapterId}/SSDT/{SSDTId}/RouteSet/{RouteId}</String>
+            <String>/redfish/v1/Systems/{ComputerSystemId}/FabricAdapters/{FabricAdapterId}/Ports/{PortId}/LPRT/{LPRTId}/RouteSet/{RouteId}</String>
+            <String>/redfish/v1/Systems/{ComputerSystemId}/FabricAdapters/{FabricAdapterId}/Ports/{PortId}/MPRT/{MPRTId}/RouteSet/{RouteId}</String>
+          </Collection>
+        </Annotation>
+      </EntityType>
+
+    </Schema>
+
+    <Schema xmlns="http://docs.oasis-open.org/odata/ns/edm" Namespace="RouteSetEntry.v1_0_0">
+      <Annotation Term="Redfish.OwningEntity" String="DMTF"/>
+      <Annotation Term="Redfish.Release" String="2019.4"/>
+
+      <EntityType Name="RouteSetEntry" BaseType="RouteSetEntry.RouteSetEntry">
+        <Property Name="Valid" Type="Edm.Boolean" Nullable="false">
+          <Annotation Term="OData.Permissions" EnumMember="OData.Permission/ReadWrite"/>
+          <Annotation Term="OData.Description" String="An indication of whether the entry is valid."/>
+          <Annotation Term="OData.LongDescription" String="This property shall indicate whether the entry is valid."/>
+        </Property>
+        <Property Name="VCAction" Type="Edm.Int64" Nullable="false">
+          <Annotation Term="OData.Permissions" EnumMember="OData.Permission/ReadWrite"/>
+          <Annotation Term="OData.Description" String="The Virtual Channel Action index."/>
+          <Annotation Term="OData.LongDescription" String="This property shall contain the index to the VCAT entry corresponding to this route."/>
+        </Property>
+        <Property Name="HopCount" Type="Edm.Int64" Nullable="false">
+          <Annotation Term="OData.Permissions" EnumMember="OData.Permission/ReadWrite"/>
+          <Annotation Term="OData.Description" String="The number of hops."/>
+          <Annotation Term="OData.LongDescription" String="This property shall contain the number of hops to the destination component from the indicated egress interface."/>
+        </Property>
+        <Property Name="EgressIdentifier" Type="Edm.Int64" Nullable="false">
+          <Annotation Term="OData.Permissions" EnumMember="OData.Permission/ReadWrite"/>
+          <Annotation Term="OData.Description" String="The egress interface identifier."/>
+          <Annotation Term="OData.LongDescription" String="This property shall contain the interface identifier corresponding to this route."/>
+        </Property>
+        <Property Name="Actions" Type="RouteSetEntry.v1_0_0.Actions" Nullable="false">
+          <Annotation Term="OData.Description" String="The available actions for this Resource."/>
+          <Annotation Term="OData.LongDescription" String="This property shall contain the available actions for this Resource."/>
+        </Property>
+      </EntityType>
+
+      <ComplexType Name="Actions">
+        <Annotation Term="OData.AdditionalProperties" Bool="false"/>
+        <Annotation Term="OData.Description" String="The available actions for this Resource."/>
+        <Annotation Term="OData.LongDescription" String="This type shall contain the available actions for this Resource."/>
+        <Property Name="Oem" Type="RouteSetEntry.v1_0_0.OemActions" Nullable="false">
+          <Annotation Term="OData.Description" String="The available OEM-specific actions for this Resource."/>
+          <Annotation Term="OData.LongDescription" String="This property shall contain the available OEM-specific actions for this Resource."/>
+        </Property>
+      </ComplexType>
+
+      <ComplexType Name="OemActions">
+        <Annotation Term="OData.AdditionalProperties" Bool="true"/>
+        <Annotation Term="OData.Description" String="The available OEM-specific actions for this Resource."/>
+        <Annotation Term="OData.LongDescription" String="This type shall contain the available OEM-specific actions for this Resource."/>
+      </ComplexType>
+    </Schema>
+
+    <Schema xmlns="http://docs.oasis-open.org/odata/ns/edm" Namespace="RouteSetEntry.v1_0_1">
+      <Annotation Term="Redfish.OwningEntity" String="DMTF"/>
+      <Annotation Term="OData.Description" String="This version was created specify 64-bit integers in OpenAPI."/>
+      <EntityType Name="RouteSetEntry" BaseType="RouteSetEntry.v1_0_0.RouteSetEntry"/>
+    </Schema>
+
+  </edmx:DataServices>
+</edmx:Edmx>

--- a/static/redfish/v1/schema/Schedule_v1.xml
+++ b/static/redfish/v1/schema/Schedule_v1.xml
@@ -1,0 +1,213 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!---->
+<!--################################################################################       -->
+<!--# Redfish Schema:  Schedule v1.2.2                                                     -->
+<!--#                                                                                      -->
+<!--# For a detailed change log, see the README file contained in the DSP8010 bundle,      -->
+<!--# available at http://www.dmtf.org/standards/redfish                                   -->
+<!--# Copyright 2014-2021 DMTF.                                                            -->
+<!--# Portions Copyright 2015-2018 Storage Networking Industry Association (SNIA), USA.    -->
+<!--# For the full DMTF copyright policy, see http://www.dmtf.org/about/policies/copyright -->
+<!--################################################################################       -->
+<!---->
+<edmx:Edmx xmlns:edmx="http://docs.oasis-open.org/odata/ns/edmx" Version="4.0">
+
+  <edmx:Reference Uri="http://docs.oasis-open.org/odata/odata/v4.0/errata03/csd01/complete/vocabularies/Org.OData.Core.V1.xml">
+    <edmx:Include Namespace="Org.OData.Core.V1" Alias="OData"/>
+  </edmx:Reference>
+  <edmx:Reference Uri="http://redfish.dmtf.org/schemas/v1/RedfishExtensions_v1.xml">
+    <edmx:Include Namespace="RedfishExtensions.v1_0_0" Alias="Redfish"/>
+    <edmx:Include Namespace="Validation.v1_0_0" Alias="Validation"/>
+  </edmx:Reference>
+
+  <edmx:DataServices>
+
+    <Schema xmlns="http://docs.oasis-open.org/odata/ns/edm" Namespace="Schedule">
+      <Annotation Term="Redfish.OwningEntity" String="DMTF"/>
+
+      <ComplexType Name="Schedule" Abstract="true">
+        <Annotation Term="OData.AdditionalProperties" Bool="false"/>
+        <Annotation Term="OData.Description" String="Schedules a series of occurrences."/>
+        <Annotation Term="OData.LongDescription" String="The properties of this type shall schedule a series of occurrences."/>
+      </ComplexType>
+
+    </Schema>
+
+    <Schema xmlns="http://docs.oasis-open.org/odata/ns/edm" Namespace="Schedule.v1_0_0">
+      <Annotation Term="Redfish.OwningEntity" String="SNIA"/>
+
+      <ComplexType Name="Schedule" BaseType="Schedule.Schedule">
+        <Annotation Term="OData.Description" String="Schedule a series of occurrences."/>
+        <Annotation Term="OData.LongDescription" String="The properties of this type shall schedule a series of occurrences."/>
+        <Property Name="Name" Type="Edm.String">
+          <Annotation Term="OData.Permissions" EnumMember="OData.Permission/ReadWrite"/>
+          <Annotation Term="OData.Description" String="The schedule name."/>
+          <Annotation Term="OData.LongDescription" String="The name of the schedule, which is constructed as OrgID:ScheduleName.  Examples include ACME:Daily, ACME:Weekly, and ACME:FirstTuesday."/>
+        </Property>
+        <Property Name="Lifetime" Type="Edm.Duration">
+          <Annotation Term="OData.Permissions" EnumMember="OData.Permission/ReadWrite"/>
+          <Annotation Term="OData.Description" String="The time after provisioning when the schedule as a whole expires."/>
+          <Annotation Term="OData.LongDescription" String="This property shall contain a Redfish Duration that describes the time after provisioning when the schedule expires."/>
+        </Property>
+        <Property Name="MaxOccurrences" Type="Edm.Int64">
+          <Annotation Term="OData.Permissions" EnumMember="OData.Permission/ReadWrite"/>
+          <Annotation Term="OData.Description" String="The maximum number of scheduled occurrences."/>
+          <Annotation Term="OData.LongDescription" String="This property shall contain the maximum number of scheduled occurrences."/>
+        </Property>
+        <Property Name="InitialStartTime" Type="Edm.DateTimeOffset">
+          <Annotation Term="OData.Permissions" EnumMember="OData.Permission/ReadWrite"/>
+          <Annotation Term="OData.Description" String="The date and time when the initial occurrence is scheduled to occur."/>
+          <Annotation Term="OData.LongDescription" String="This property shall contain the date and time when the initial occurrence is scheduled to occur."/>
+        </Property>
+        <Property Name="RecurrenceInterval" Type="Edm.Duration">
+          <Annotation Term="OData.Permissions" EnumMember="OData.Permission/ReadWrite"/>
+          <Annotation Term="OData.Description" String="The amount of time until the next occurrence occurs."/>
+          <Annotation Term="OData.LongDescription" String="This property shall contain a Redfish Duration that describes the time until the next occurrence."/>
+        </Property>
+        <Property Name="EnabledDaysOfWeek" Type="Collection(Schedule.v1_0_0.DayOfWeek)">
+          <Annotation Term="OData.Permissions" EnumMember="OData.Permission/ReadWrite"/>
+          <Annotation Term="OData.Description" String="Days of the week when scheduled occurrences are enabled, for enabled days of the month and months of the year.  If not present, all days of the week are enabled."/>
+          <Annotation Term="OData.LongDescription" String="Days of the week when scheduled occurrences are enabled.  If not present, all days of the week shall be enabled."/>
+        </Property>
+        <Property Name="EnabledDaysOfMonth" Type="Collection(Edm.Int64)">
+          <Annotation Term="OData.Permissions" EnumMember="OData.Permission/ReadWrite"/>
+          <Annotation Term="OData.Description" String="Days of the month when scheduled occurrences are enabled.  `0` indicates that every day of the month is enabled."/>
+          <Annotation Term="OData.LongDescription" String="This property shall contain the days of the month when scheduled occurrences are enabled, for enabled days of week and months of year.  If the array contains a single value of `0`, or if the property is not present, all days of the month shall be enabled."/>
+          <Annotation Term="Validation.Minimum" Int="0"/>
+          <Annotation Term="Validation.Maximum" Int="31"/>
+        </Property>
+        <Property Name="EnabledMonthsOfYear" Type="Collection(Schedule.v1_0_0.MonthOfYear)">
+          <Annotation Term="OData.Permissions" EnumMember="OData.Permission/ReadWrite"/>
+          <Annotation Term="OData.Description" String="The months of the year when scheduled occurrences are enabled.  If not present, all months of the year are enabled."/>
+          <Annotation Term="OData.LongDescription" String="This property shall contain the months of the year when scheduled occurrences are enabled, for enabled days of week and days of month.  If not present, all months of the year shall be enabled."/>
+        </Property>
+      </ComplexType>
+
+      <EnumType Name="DayOfWeek">
+        <Annotation Term="OData.Description" String="Days of the week."/>
+        <Annotation Term="OData.LongDescription" String="Days of the week."/>
+        <Member Name="Monday">
+          <Annotation Term="OData.Description" String="Monday."/>
+        </Member>
+        <Member Name="Tuesday">
+          <Annotation Term="OData.Description" String="Tuesday."/>
+        </Member>
+        <Member Name="Wednesday">
+          <Annotation Term="OData.Description" String="Wednesday."/>
+        </Member>
+        <Member Name="Thursday">
+          <Annotation Term="OData.Description" String="Thursday."/>
+        </Member>
+        <Member Name="Friday">
+          <Annotation Term="OData.Description" String="Friday."/>
+        </Member>
+        <Member Name="Saturday">
+          <Annotation Term="OData.Description" String="Saturday."/>
+        </Member>
+        <Member Name="Sunday">
+          <Annotation Term="OData.Description" String="Sunday."/>
+        </Member>
+        <Member Name="Every">
+          <Annotation Term="OData.Description" String="Every day of the week."/>
+          <Annotation Term="OData.LongDescription" String="This value indicates that every day of the week has been selected.  When used in array properties, such as for enabling a function on certain days, it shall be the only member in the array."/>
+        </Member>
+      </EnumType>
+
+      <EnumType Name="MonthOfYear">
+        <Annotation Term="OData.Description" String="Months of the year."/>
+        <Annotation Term="OData.LongDescription" String="Months of the year."/>
+        <Member Name="January">
+          <Annotation Term="OData.Description" String="January."/>
+        </Member>
+        <Member Name="February">
+          <Annotation Term="OData.Description" String="February."/>
+        </Member>
+        <Member Name="March">
+          <Annotation Term="OData.Description" String="March."/>
+        </Member>
+        <Member Name="April">
+          <Annotation Term="OData.Description" String="April."/>
+        </Member>
+        <Member Name="May">
+          <Annotation Term="OData.Description" String="May."/>
+        </Member>
+        <Member Name="June">
+          <Annotation Term="OData.Description" String="June."/>
+        </Member>
+        <Member Name="July">
+          <Annotation Term="OData.Description" String="July."/>
+        </Member>
+        <Member Name="August">
+          <Annotation Term="OData.Description" String="August."/>
+        </Member>
+        <Member Name="September">
+          <Annotation Term="OData.Description" String="September."/>
+        </Member>
+        <Member Name="October">
+          <Annotation Term="OData.Description" String="October."/>
+        </Member>
+        <Member Name="November">
+          <Annotation Term="OData.Description" String="November."/>
+        </Member>
+        <Member Name="December">
+          <Annotation Term="OData.Description" String="December."/>
+        </Member>
+        <Member Name="Every">
+          <Annotation Term="OData.Description" String="Every month of the year."/>
+          <Annotation Term="OData.LongDescription" String="This value indicates that every month of the year has been selected.  When used in array properties, such as for enabling a function for certain months, it shall be the only member in the array."/>
+        </Member>
+      </EnumType>
+
+    </Schema>
+
+    <Schema xmlns="http://docs.oasis-open.org/odata/ns/edm" Namespace="Schedule.v1_0_1">
+      <Annotation Term="Redfish.OwningEntity" String="DMTF"/>
+      <Annotation Term="OData.Description" String="This version was created to update descriptions that this schema defines."/>
+      <ComplexType Name="Schedule" BaseType="Schedule.v1_0_0.Schedule"/>
+    </Schema>
+
+    <Schema xmlns="http://docs.oasis-open.org/odata/ns/edm" Namespace="Schedule.v1_1_0">
+      <Annotation Term="Redfish.OwningEntity" String="SNIA"/>
+
+      <ComplexType Name="Schedule" BaseType="Schedule.v1_0_0.Schedule">
+        <Property Name="EnabledIntervals" Type="Collection(Edm.String)">
+          <Annotation Term="OData.Permissions" EnumMember="OData.Permission/ReadWrite"/>
+          <Annotation Term="OData.Description" String="Intervals when scheduled occurrences are enabled."/>
+          <Annotation Term="OData.LongDescription" String="Each value shall be an ISO 8601 conformant interval specifying when occurrences are enabled."/>
+        </Property>
+      </ComplexType>
+    </Schema>
+
+    <Schema xmlns="http://docs.oasis-open.org/odata/ns/edm" Namespace="Schedule.v1_1_1">
+      <Annotation Term="Redfish.OwningEntity" String="DMTF"/>
+      <Annotation Term="OData.Description" String="This version was created to update descriptions that this schema defines."/>
+      <ComplexType Name="Schedule" BaseType="Schedule.v1_1_0.Schedule"/>
+    </Schema>
+
+    <Schema xmlns="http://docs.oasis-open.org/odata/ns/edm" Namespace="Schedule.v1_1_2">
+      <Annotation Term="Redfish.OwningEntity" String="DMTF"/>
+      <Annotation Term="OData.Description" String="This version was created to fix typos in descriptions and long descriptions."/>
+      <ComplexType Name="Schedule" BaseType="Schedule.v1_1_1.Schedule"/>
+    </Schema>
+
+    <Schema xmlns="http://docs.oasis-open.org/odata/ns/edm" Namespace="Schedule.v1_2_0">
+      <Annotation Term="Redfish.OwningEntity" String="DMTF"/>
+      <Annotation Term="Redfish.Release" String="2018.2"/>
+      <Annotation Term="OData.Description" String="This version was created to correct time and date properties to use DateTimeOffset and Duration formats, add 'Every' enumerations to DayOfWeek and MonthOfYear types, and to incorporate default behavior into descriptions."/>
+      <ComplexType Name="Schedule" BaseType="Schedule.v1_1_0.Schedule"/>
+    </Schema>
+
+    <Schema xmlns="http://docs.oasis-open.org/odata/ns/edm" Namespace="Schedule.v1_2_1">
+      <Annotation Term="Redfish.OwningEntity" String="DMTF"/>
+      <Annotation Term="OData.Description" String="This version was created to update descriptions that this schema defines."/>
+      <ComplexType Name="Schedule" BaseType="Schedule.v1_2_0.Schedule"/>
+    </Schema>
+
+    <Schema xmlns="http://docs.oasis-open.org/odata/ns/edm" Namespace="Schedule.v1_2_2">
+      <Annotation Term="Redfish.OwningEntity" String="DMTF"/>
+      <Annotation Term="OData.Description" String="This version was created to fix typos in descriptions and long descriptions."/>
+      <ComplexType Name="Schedule" BaseType="Schedule.v1_2_1.Schedule"/>
+    </Schema>
+
+  </edmx:DataServices>
+</edmx:Edmx>

--- a/static/redfish/v1/schema/SecureBootDatabaseCollection_v1.xml
+++ b/static/redfish/v1/schema/SecureBootDatabaseCollection_v1.xml
@@ -1,0 +1,71 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!---->
+<!--################################################################################       -->
+<!--# Redfish Schema:  SecureBootDatabaseCollection                                        -->
+<!--#                                                                                      -->
+<!--# For a detailed change log, see the README file contained in the DSP8010 bundle,      -->
+<!--# available at http://www.dmtf.org/standards/redfish                                   -->
+<!--# Copyright 2014-2021 DMTF.                                                            -->
+<!--# For the full DMTF copyright policy, see http://www.dmtf.org/about/policies/copyright -->
+<!--################################################################################       -->
+<!---->
+<edmx:Edmx xmlns:edmx="http://docs.oasis-open.org/odata/ns/edmx" Version="4.0">
+
+  <edmx:Reference Uri="http://docs.oasis-open.org/odata/odata/v4.0/errata03/csd01/complete/vocabularies/Org.OData.Core.V1.xml">
+    <edmx:Include Namespace="Org.OData.Core.V1" Alias="OData"/>
+  </edmx:Reference>
+  <edmx:Reference Uri="http://docs.oasis-open.org/odata/odata/v4.0/errata03/csd01/complete/vocabularies/Org.OData.Capabilities.V1.xml">
+    <edmx:Include Namespace="Org.OData.Capabilities.V1" Alias="Capabilities"/>
+  </edmx:Reference>
+  <edmx:Reference Uri="http://redfish.dmtf.org/schemas/v1/Resource_v1.xml">
+    <edmx:Include Namespace="Resource.v1_0_0"/>
+  </edmx:Reference>
+  <edmx:Reference Uri="http://redfish.dmtf.org/schemas/v1/RedfishExtensions_v1.xml">
+    <edmx:Include Namespace="RedfishExtensions.v1_0_0" Alias="Redfish"/>
+  </edmx:Reference>
+  <edmx:Reference Uri="http://redfish.dmtf.org/schemas/v1/SecureBootDatabase_v1.xml">
+    <edmx:Include Namespace="SecureBootDatabase"/>
+  </edmx:Reference>
+
+  <edmx:DataServices>
+
+    <Schema xmlns="http://docs.oasis-open.org/odata/ns/edm" Namespace="SecureBootDatabaseCollection">
+      <Annotation Term="Redfish.OwningEntity" String="DMTF"/>
+
+      <EntityType Name="SecureBootDatabaseCollection" BaseType="Resource.v1_0_0.ResourceCollection">
+        <Annotation Term="OData.Description" String="The collection of SecureBootDatabase resource instances."/>
+        <Annotation Term="OData.LongDescription" String="This resource shall represent a resource collection of SecureBootDatabase instances for a Redfish implementation."/>
+        <Annotation Term="Capabilities.InsertRestrictions">
+          <Record>
+            <PropertyValue Property="Insertable" Bool="false"/>
+          </Record>
+        </Annotation>
+        <Annotation Term="Capabilities.UpdateRestrictions">
+          <Record>
+            <PropertyValue Property="Updatable" Bool="false"/>
+          </Record>
+        </Annotation>
+        <Annotation Term="Capabilities.DeleteRestrictions">
+          <Record>
+            <PropertyValue Property="Deletable" Bool="false"/>
+          </Record>
+        </Annotation>
+        <Annotation Term="Redfish.Uris">
+          <Collection>
+            <String>/redfish/v1/Systems/{ComputerSystemId}/SecureBoot/SecureBootDatabases</String>
+            <String>/redfish/v1/CompositionService/ResourceBlocks/{ResourceBlockId}/Systems/{ComputerSystemId}/SecureBoot/SecureBootDatabases</String>
+            <String>/redfish/v1/ResourceBlocks/{ResourceBlockId}/Systems/{ComputerSystemId}/SecureBoot/SecureBootDatabases</String>
+          </Collection>
+        </Annotation>
+        <NavigationProperty Name="Members" Type="Collection(SecureBootDatabase.SecureBootDatabase)">
+          <Annotation Term="OData.Permissions" EnumMember="OData.Permission/Read"/>
+          <Annotation Term="OData.Description" String="The members of this collection."/>
+          <Annotation Term="OData.LongDescription" String="This property shall contain an array of links to the members of this collection."/>
+          <Annotation Term="OData.AutoExpandReferences"/>
+          <Annotation Term="Redfish.Required"/>
+        </NavigationProperty>
+      </EntityType>
+    </Schema>
+
+  </edmx:DataServices>
+</edmx:Edmx>

--- a/static/redfish/v1/schema/SecureBootDatabase_v1.xml
+++ b/static/redfish/v1/schema/SecureBootDatabase_v1.xml
@@ -1,0 +1,137 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!---->
+<!--################################################################################       -->
+<!--# Redfish Schema:  SecureBootDatabase v1.0.1                                           -->
+<!--#                                                                                      -->
+<!--# For a detailed change log, see the README file contained in the DSP8010 bundle,      -->
+<!--# available at http://www.dmtf.org/standards/redfish                                   -->
+<!--# Copyright 2014-2021 DMTF.                                                            -->
+<!--# For the full DMTF copyright policy, see http://www.dmtf.org/about/policies/copyright -->
+<!--################################################################################       -->
+<!---->
+<edmx:Edmx xmlns:edmx="http://docs.oasis-open.org/odata/ns/edmx" Version="4.0">
+
+  <edmx:Reference Uri="http://docs.oasis-open.org/odata/odata/v4.0/errata03/csd01/complete/vocabularies/Org.OData.Core.V1.xml">
+    <edmx:Include Namespace="Org.OData.Core.V1" Alias="OData"/>
+  </edmx:Reference>
+  <edmx:Reference Uri="http://docs.oasis-open.org/odata/odata/v4.0/errata03/csd01/complete/vocabularies/Org.OData.Capabilities.V1.xml">
+    <edmx:Include Namespace="Org.OData.Capabilities.V1" Alias="Capabilities"/>
+  </edmx:Reference>
+  <edmx:Reference Uri="http://redfish.dmtf.org/schemas/v1/Resource_v1.xml">
+    <edmx:Include Namespace="Resource.v1_0_0"/>
+  </edmx:Reference>
+  <edmx:Reference Uri="http://redfish.dmtf.org/schemas/v1/RedfishExtensions_v1.xml">
+    <edmx:Include Namespace="RedfishExtensions.v1_0_0" Alias="Redfish"/>
+  </edmx:Reference>
+  <edmx:Reference Uri="http://redfish.dmtf.org/schemas/v1/CertificateCollection_v1.xml">
+    <edmx:Include Namespace="CertificateCollection"/>
+  </edmx:Reference>
+  <edmx:Reference Uri="http://redfish.dmtf.org/schemas/v1/SignatureCollection_v1.xml">
+    <edmx:Include Namespace="SignatureCollection"/>
+  </edmx:Reference>
+
+  <edmx:DataServices>
+
+    <Schema xmlns="http://docs.oasis-open.org/odata/ns/edm" Namespace="SecureBootDatabase">
+      <Annotation Term="Redfish.OwningEntity" String="DMTF"/>
+
+      <EntityType Name="SecureBootDatabase" BaseType="Resource.v1_0_0.Resource" Abstract="true">
+        <Annotation Term="OData.Description" String="The SecureBootDatabase schema describes a UEFI Secure Boot database used to store certificates or hashes."/>
+        <Annotation Term="OData.LongDescription" String="This resource shall be used to represent a UEFI Secure Boot database for a Redfish implementation."/>
+        <Annotation Term="Capabilities.InsertRestrictions">
+          <Record>
+            <PropertyValue Property="Insertable" Bool="false"/>
+          </Record>
+        </Annotation>
+        <Annotation Term="Capabilities.UpdateRestrictions">
+          <Record>
+            <PropertyValue Property="Updatable" Bool="false"/>
+          </Record>
+        </Annotation>
+        <Annotation Term="Capabilities.DeleteRestrictions">
+          <Record>
+            <PropertyValue Property="Deletable" Bool="false"/>
+          </Record>
+        </Annotation>
+        <Annotation Term="Redfish.Uris">
+          <Collection>
+            <String>/redfish/v1/Systems/{ComputerSystemId}/SecureBoot/SecureBootDatabases/{DatabaseId}</String>
+            <String>/redfish/v1/CompositionService/ResourceBlocks/{ResourceBlockId}/Systems/{ComputerSystemId}/SecureBoot/SecureBootDatabases/{DatabaseId}</String>
+            <String>/redfish/v1/ResourceBlocks/{ResourceBlockId}/Systems/{ComputerSystemId}/SecureBoot/SecureBootDatabases/{DatabaseId}</String>
+          </Collection>
+        </Annotation>
+      </EntityType>
+
+      <Action Name="ResetKeys" IsBound="true">
+        <Annotation Term="OData.Description" String="This action is used to reset the UEFI Secure Boot keys of this database."/>
+        <Annotation Term="OData.LongDescription" String="This action shall perform a reset of this UEFI Secure Boot key database.  The `ResetAllKeysToDefault` value shall reset this UEFI Secure Boot key database to the default values.  The `DeleteAllKeys` value shall delete the content of this UEFI Secure Boot key database."/>
+        <Parameter Name="SecureBootDatabase" Type="SecureBootDatabase.v1_0_0.Actions"/>
+        <Parameter Name="ResetKeysType" Type="SecureBootDatabase.v1_0_0.ResetKeysType" Nullable="false">
+          <Annotation Term="OData.Description" String="The type of reset or delete to perform on this UEFI Secure Boot database."/>
+          <Annotation Term="OData.LongDescription" String="This parameter shall specify the type of reset or delete to perform on this UEFI Secure Boot database."/>
+        </Parameter>
+      </Action>
+    </Schema>
+
+    <Schema xmlns="http://docs.oasis-open.org/odata/ns/edm" Namespace="SecureBootDatabase.v1_0_0">
+      <Annotation Term="Redfish.OwningEntity" String="DMTF"/>
+      <Annotation Term="Redfish.Release" String="2020.1"/>
+
+      <EntityType Name="SecureBootDatabase" BaseType="SecureBootDatabase.SecureBootDatabase">
+        <Property Name="DatabaseId" Type="Edm.String" Nullable="false">
+          <Annotation Term="OData.Permissions" EnumMember="OData.Permission/Read"/>
+          <Annotation Term="OData.Description" String="This property contains the name of the UEFI Secure Boot database."/>
+          <Annotation Term="OData.LongDescription" String="This property shall contain the name of the UEFI Secure Boot database.  This property shall contain the same value as the Id property.  The value shall be one of the UEFI-defined Secure Boot databases: `PK`, `KEK` `db`, `dbx`, `dbr`, `dbt`, `PKDefault`, `KEKDefault`, `dbDefault`, `dbxDefault`, `dbrDefault`, or `dbtDefault`."/>
+        </Property>
+        <Property Name="Actions" Type="SecureBootDatabase.v1_0_0.Actions" Nullable="false">
+          <Annotation Term="OData.Description" String="The available actions for this resource."/>
+          <Annotation Term="OData.LongDescription" String="This property shall contain the available actions for this resource."/>
+        </Property>
+        <NavigationProperty Name="Certificates" Type="CertificateCollection.CertificateCollection" ContainsTarget="true" Nullable="false">
+          <Annotation Term="OData.Permissions" EnumMember="OData.Permission/Read"/>
+          <Annotation Term="OData.Description" String="A link to the collection of certificates contained in this UEFI Secure Boot database."/>
+          <Annotation Term="OData.LongDescription" String="The value of this property shall be a link to a resource collection of type CertificateCollection."/>
+          <Annotation Term="OData.AutoExpandReferences"/>
+        </NavigationProperty>
+        <NavigationProperty Name="Signatures" Type="SignatureCollection.SignatureCollection" ContainsTarget="true" Nullable="false">
+          <Annotation Term="OData.Permissions" EnumMember="OData.Permission/Read"/>
+          <Annotation Term="OData.Description" String="A link to the collection of signatures contained in this UEFI Secure Boot database."/>
+          <Annotation Term="OData.LongDescription" String="The value of this property shall be a link to a resource collection of type SignatureCollection."/>
+          <Annotation Term="OData.AutoExpandReferences"/>
+        </NavigationProperty>
+      </EntityType>
+
+      <EnumType Name="ResetKeysType">
+        <Member Name="ResetAllKeysToDefault">
+          <Annotation Term="OData.Description" String="Reset the content of this UEFI Secure Boot key database to the default values."/>
+        </Member>
+        <Member Name="DeleteAllKeys">
+          <Annotation Term="OData.Description" String="Delete the content of this UEFI Secure Boot key database."/>
+        </Member>
+      </EnumType>
+
+      <ComplexType Name="Actions">
+        <Annotation Term="OData.AdditionalProperties" Bool="false"/>
+        <Annotation Term="OData.Description" String="The available actions for this resource."/>
+        <Annotation Term="OData.LongDescription" String="This type shall contain the available actions for this resource."/>
+        <Property Name="Oem" Type="SecureBootDatabase.v1_0_0.OemActions" Nullable="false">
+          <Annotation Term="OData.Description" String="The available OEM-specific actions for this resource."/>
+          <Annotation Term="OData.LongDescription" String="This property shall contain the available OEM-specific actions for this resource."/>
+        </Property>
+      </ComplexType>
+
+      <ComplexType Name="OemActions">
+        <Annotation Term="OData.AdditionalProperties" Bool="true"/>
+        <Annotation Term="OData.Description" String="The available OEM-specific actions for this resource."/>
+        <Annotation Term="OData.LongDescription" String="This type shall contain the available OEM-specific actions for this resource."/>
+      </ComplexType>
+    </Schema>
+
+    <Schema xmlns="http://docs.oasis-open.org/odata/ns/edm" Namespace="SecureBootDatabase.v1_0_1">
+      <Annotation Term="Redfish.OwningEntity" String="DMTF"/>
+      <Annotation Term="OData.Description" String="This version was created to correct the name of the `PKDefault` database in the description of the DatabaseId property."/>
+      <EntityType Name="SecureBootDatabase" BaseType="SecureBootDatabase.v1_0_0.SecureBootDatabase"/>
+    </Schema>
+
+  </edmx:DataServices>
+</edmx:Edmx>

--- a/static/redfish/v1/schema/SecureBoot_v1.xml
+++ b/static/redfish/v1/schema/SecureBoot_v1.xml
@@ -1,0 +1,210 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!---->
+<!--################################################################################       -->
+<!--# Redfish Schema:  SecureBoot v1.1.0                                                   -->
+<!--#                                                                                      -->
+<!--# For a detailed change log, see the README file contained in the DSP8010 bundle,      -->
+<!--# available at http://www.dmtf.org/standards/redfish                                   -->
+<!--# Copyright 2014-2021 DMTF.                                                            -->
+<!--# For the full DMTF copyright policy, see http://www.dmtf.org/about/policies/copyright -->
+<!--################################################################################       -->
+<!---->
+<edmx:Edmx xmlns:edmx="http://docs.oasis-open.org/odata/ns/edmx" Version="4.0">
+
+  <edmx:Reference Uri="http://docs.oasis-open.org/odata/odata/v4.0/errata03/csd01/complete/vocabularies/Org.OData.Core.V1.xml">
+    <edmx:Include Namespace="Org.OData.Core.V1" Alias="OData"/>
+  </edmx:Reference>
+  <edmx:Reference Uri="http://docs.oasis-open.org/odata/odata/v4.0/errata03/csd01/complete/vocabularies/Org.OData.Capabilities.V1.xml">
+    <edmx:Include Namespace="Org.OData.Capabilities.V1" Alias="Capabilities"/>
+  </edmx:Reference>
+  <edmx:Reference Uri="http://redfish.dmtf.org/schemas/v1/Resource_v1.xml">
+    <edmx:Include Namespace="Resource.v1_0_0"/>
+  </edmx:Reference>
+  <edmx:Reference Uri="http://redfish.dmtf.org/schemas/v1/RedfishExtensions_v1.xml">
+    <edmx:Include Namespace="RedfishExtensions.v1_0_0" Alias="Redfish"/>
+  </edmx:Reference>
+  <edmx:Reference Uri="http://redfish.dmtf.org/schemas/v1/SecureBootDatabaseCollection_v1.xml">
+    <edmx:Include Namespace="SecureBootDatabaseCollection"/>
+  </edmx:Reference>
+
+  <edmx:DataServices>
+
+    <Schema xmlns="http://docs.oasis-open.org/odata/ns/edm" Namespace="SecureBoot">
+      <Annotation Term="Redfish.OwningEntity" String="DMTF"/>
+
+      <EntityType Name="SecureBoot" BaseType="Resource.v1_0_0.Resource" Abstract="true">
+        <Annotation Term="OData.Description" String="The SecureBoot schema contains UEFI Secure Boot information and represents properties for managing the UEFI Secure Boot functionality of a system."/>
+        <Annotation Term="OData.LongDescription" String="This resource contains UEFI Secure Boot information for a Redfish implementation."/>
+        <Annotation Term="Capabilities.InsertRestrictions">
+          <Record>
+            <PropertyValue Property="Insertable" Bool="false"/>
+          </Record>
+        </Annotation>
+        <Annotation Term="Capabilities.UpdateRestrictions">
+          <Record>
+            <PropertyValue Property="Updatable" Bool="true"/>
+            <Annotation Term="OData.Description" String="Secure Boot can be updated to enable or disable the service."/>
+          </Record>
+        </Annotation>
+        <Annotation Term="Capabilities.DeleteRestrictions">
+          <Record>
+            <PropertyValue Property="Deletable" Bool="false"/>
+          </Record>
+        </Annotation>
+        <Annotation Term="Redfish.Uris">
+          <Collection>
+            <String>/redfish/v1/Systems/{ComputerSystemId}/SecureBoot</String>
+            <String>/redfish/v1/CompositionService/ResourceBlocks/{ResourceBlockId}/Systems/{ComputerSystemId}/SecureBoot</String>
+            <String>/redfish/v1/ResourceBlocks/{ResourceBlockId}/Systems/{ComputerSystemId}/SecureBoot</String>
+          </Collection>
+        </Annotation>
+      </EntityType>
+
+      <Action Name="ResetKeys" IsBound="true">
+        <Annotation Term="OData.Description" String="This action resets the UEFI Secure Boot keys."/>
+        <Annotation Term="OData.LongDescription" String="This action shall reset the UEFI Secure Boot key databases.  The `ResetAllKeysToDefault` value shall reset all UEFI Secure Boot key databases to their default values.  The `DeleteAllKeys` value shall delete the content of all UEFI Secure Boot key databases.  The `DeletePK` value shall delete the content of the PK Secure Boot key database."/>
+        <Parameter Name="SecureBoot" Type="SecureBoot.v1_0_0.Actions"/>
+        <Parameter Name="ResetKeysType" Type="SecureBoot.v1_0_0.ResetKeysType" Nullable="false">
+          <Annotation Term="OData.Description" String="The type of reset or delete to perform on the UEFI Secure Boot databases."/>
+          <Annotation Term="OData.LongDescription" String="This parameter shall specify the type of reset or delete to perform on the UEFI Secure Boot databases."/>
+        </Parameter>
+      </Action>
+    </Schema>
+
+    <Schema xmlns="http://docs.oasis-open.org/odata/ns/edm" Namespace="SecureBoot.v1_0_0">
+      <Annotation Term="Redfish.OwningEntity" String="DMTF"/>
+      <Annotation Term="Redfish.Release" String="2016.1"/>
+
+      <EntityType Name="SecureBoot" BaseType="SecureBoot.SecureBoot">
+        <Property Name="SecureBootEnable" Type="Edm.Boolean">
+          <Annotation Term="OData.Permissions" EnumMember="OData.Permission/ReadWrite"/>
+          <Annotation Term="OData.Description" String="An indication of whether UEFI Secure Boot is enabled."/>
+          <Annotation Term="OData.LongDescription" String="This property shall indicate whether the UEFI Secure Boot takes effect on next boot.  This property can be enabled in UEFI boot mode only."/>
+        </Property>
+        <Property Name="SecureBootCurrentBoot" Type="SecureBoot.v1_0_0.SecureBootCurrentBootType">
+          <Annotation Term="OData.Permissions" EnumMember="OData.Permission/Read"/>
+          <Annotation Term="OData.Description" String="The UEFI Secure Boot state during the current boot cycle."/>
+          <Annotation Term="OData.LongDescription" String="This property shall indicate the UEFI Secure Boot state during the current boot cycle."/>
+        </Property>
+        <Property Name="SecureBootMode" Type="SecureBoot.v1_0_0.SecureBootModeType">
+          <Annotation Term="OData.Permissions" EnumMember="OData.Permission/Read"/>
+          <Annotation Term="OData.Description" String="The current UEFI Secure Boot Mode."/>
+          <Annotation Term="OData.LongDescription" String="This property shall contain the current UEFI Secure Boot mode, as defined in the UEFI Specification."/>
+        </Property>
+        <Property Name="Actions" Type="SecureBoot.v1_0_0.Actions" Nullable="false">
+          <Annotation Term="OData.Description" String="The available actions for this resource."/>
+          <Annotation Term="OData.LongDescription" String="This property shall contain the available actions for this resource."/>
+        </Property>
+      </EntityType>
+
+      <EnumType Name="SecureBootCurrentBootType">
+        <Member Name="Enabled">
+          <Annotation Term="OData.Description" String="UEFI Secure Boot is currently enabled."/>
+        </Member>
+        <Member Name="Disabled">
+          <Annotation Term="OData.Description" String="UEFI Secure Boot is currently disabled."/>
+        </Member>
+      </EnumType>
+
+      <EnumType Name="SecureBootModeType">
+        <Member Name="SetupMode">
+          <Annotation Term="OData.Description" String="UEFI Secure Boot is currently in Setup Mode."/>
+        </Member>
+        <Member Name="UserMode">
+          <Annotation Term="OData.Description" String="UEFI Secure Boot is currently in User Mode."/>
+        </Member>
+        <Member Name="AuditMode">
+          <Annotation Term="OData.Description" String="UEFI Secure Boot is currently in Audit Mode."/>
+        </Member>
+        <Member Name="DeployedMode">
+          <Annotation Term="OData.Description" String="UEFI Secure Boot is currently in Deployed Mode."/>
+        </Member>
+      </EnumType>
+
+      <EnumType Name="ResetKeysType">
+        <Member Name="ResetAllKeysToDefault">
+          <Annotation Term="OData.Description" String="Reset the contents of all UEFI Secure Boot key databases, including the PK key database, to the default values."/>
+        </Member>
+        <Member Name="DeleteAllKeys">
+          <Annotation Term="OData.Description" String="Delete the contents of all UEFI Secure Boot key databases, including the PK key database.  This puts the system in Setup Mode."/>
+        </Member>
+        <Member Name="DeletePK">
+          <Annotation Term="OData.Description" String="Delete the contents of the PK UEFI Secure Boot database.  This puts the system in Setup Mode."/>
+        </Member>
+      </EnumType>
+
+      <ComplexType Name="Actions">
+        <Annotation Term="OData.AdditionalProperties" Bool="false"/>
+        <Annotation Term="OData.Description" String="The available actions for this resource."/>
+        <Annotation Term="OData.LongDescription" String="This type shall contain the available actions for this resource."/>
+        <Property Name="Oem" Type="SecureBoot.v1_0_0.OemActions" Nullable="false">
+          <Annotation Term="OData.Description" String="The available OEM-specific actions for this resource."/>
+          <Annotation Term="OData.LongDescription" String="This property shall contain the available OEM-specific actions for this resource."/>
+        </Property>
+      </ComplexType>
+
+      <ComplexType Name="OemActions">
+        <Annotation Term="OData.AdditionalProperties" Bool="true"/>
+        <Annotation Term="OData.Description" String="The available OEM-specific actions for this resource."/>
+        <Annotation Term="OData.LongDescription" String="This type shall contain the available OEM-specific actions for this resource."/>
+      </ComplexType>
+    </Schema>
+
+    <Schema xmlns="http://docs.oasis-open.org/odata/ns/edm" Namespace="SecureBoot.v1_0_1">
+      <Annotation Term="Redfish.OwningEntity" String="DMTF"/>
+      <Annotation Term="OData.Description" String="This version was created to show that annotations in previous namespaces were updated."/>
+      <EntityType Name="SecureBoot" BaseType="SecureBoot.v1_0_0.SecureBoot"/>
+    </Schema>
+
+    <Schema xmlns="http://docs.oasis-open.org/odata/ns/edm" Namespace="SecureBoot.v1_0_2">
+      <Annotation Term="Redfish.OwningEntity" String="DMTF"/>
+      <Annotation Term="OData.Description" String="This version was created to show that annotations in previous namespaces were updated."/>
+      <EntityType Name="SecureBoot" BaseType="SecureBoot.v1_0_1.SecureBoot"/>
+    </Schema>
+
+    <Schema xmlns="http://docs.oasis-open.org/odata/ns/edm" Namespace="SecureBoot.v1_0_3">
+      <Annotation Term="Redfish.OwningEntity" String="DMTF"/>
+      <Annotation Term="OData.Description" String="This version was created to add requirements on the action parameters to show they are mandatory through Nullable=false, and corrects the short and long descriptions in the defined actions."/>
+      <EntityType Name="SecureBoot" BaseType="SecureBoot.v1_0_2.SecureBoot"/>
+    </Schema>
+
+    <Schema xmlns="http://docs.oasis-open.org/odata/ns/edm" Namespace="SecureBoot.v1_0_4">
+      <Annotation Term="Redfish.OwningEntity" String="DMTF"/>
+      <Annotation Term="OData.Description" String="This version was created to force the regeneration of JSON Schema so that OData properties are marked as required, and integer properties are marked as integer rather than number."/>
+      <EntityType Name="SecureBoot" BaseType="SecureBoot.v1_0_3.SecureBoot"/>
+    </Schema>
+
+    <Schema xmlns="http://docs.oasis-open.org/odata/ns/edm" Namespace="SecureBoot.v1_0_5">
+      <Annotation Term="Redfish.OwningEntity" String="DMTF"/>
+      <Annotation Term="OData.Description" String="This version was created to force the regeneration of JSON Schema so that URI properties use the uri-reference format."/>
+      <EntityType Name="SecureBoot" BaseType="SecureBoot.v1_0_4.SecureBoot"/>
+    </Schema>
+
+    <Schema xmlns="http://docs.oasis-open.org/odata/ns/edm" Namespace="SecureBoot.v1_0_6">
+      <Annotation Term="Redfish.OwningEntity" String="DMTF"/>
+      <Annotation Term="OData.Description" String="This version was created to update descriptions that this schema defines."/>
+      <EntityType Name="SecureBoot" BaseType="SecureBoot.v1_0_5.SecureBoot"/>
+    </Schema>
+
+    <Schema xmlns="http://docs.oasis-open.org/odata/ns/edm" Namespace="SecureBoot.v1_0_7">
+      <Annotation Term="Redfish.OwningEntity" String="DMTF"/>
+      <Annotation Term="OData.Description" String="This version was created to update descriptions as needed to reference UEFI Secure Boot databases."/>
+      <EntityType Name="SecureBoot" BaseType="SecureBoot.v1_0_6.SecureBoot"/>
+    </Schema>
+
+    <Schema xmlns="http://docs.oasis-open.org/odata/ns/edm" Namespace="SecureBoot.v1_1_0">
+      <Annotation Term="Redfish.OwningEntity" String="DMTF"/>
+      <Annotation Term="Redfish.Release" String="2020.1"/>
+
+      <EntityType Name="SecureBoot" BaseType="SecureBoot.v1_0_7.SecureBoot">
+        <NavigationProperty Name="SecureBootDatabases" Type="SecureBootDatabaseCollection.SecureBootDatabaseCollection" ContainsTarget="true" Nullable="false">
+          <Annotation Term="OData.Permissions" EnumMember="OData.Permission/Read"/>
+          <Annotation Term="OData.Description" String="A link to the collection of UEFI Secure Boot databases."/>
+          <Annotation Term="OData.LongDescription" String="The value of this property shall be a link to a resource collection of type SecureBootDatabaseCollection."/>
+          <Annotation Term="OData.AutoExpandReferences"/>
+        </NavigationProperty>
+      </EntityType>
+    </Schema>
+
+  </edmx:DataServices>
+</edmx:Edmx>

--- a/static/redfish/v1/schema/SerialInterfaceCollection_v1.xml
+++ b/static/redfish/v1/schema/SerialInterfaceCollection_v1.xml
@@ -1,0 +1,69 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!---->
+<!--################################################################################       -->
+<!--# Redfish Schema:  SerialInterfaceCollection                                           -->
+<!--#                                                                                      -->
+<!--# For a detailed change log, see the README file contained in the DSP8010 bundle,      -->
+<!--# available at http://www.dmtf.org/standards/redfish                                   -->
+<!--# Copyright 2014-2021 DMTF.                                                            -->
+<!--# For the full DMTF copyright policy, see http://www.dmtf.org/about/policies/copyright -->
+<!--################################################################################       -->
+<!---->
+<edmx:Edmx xmlns:edmx="http://docs.oasis-open.org/odata/ns/edmx" Version="4.0">
+
+  <edmx:Reference Uri="http://docs.oasis-open.org/odata/odata/v4.0/errata03/csd01/complete/vocabularies/Org.OData.Core.V1.xml">
+    <edmx:Include Namespace="Org.OData.Core.V1" Alias="OData"/>
+  </edmx:Reference>
+  <edmx:Reference Uri="http://docs.oasis-open.org/odata/odata/v4.0/errata03/csd01/complete/vocabularies/Org.OData.Capabilities.V1.xml">
+    <edmx:Include Namespace="Org.OData.Capabilities.V1" Alias="Capabilities"/>
+  </edmx:Reference>
+  <edmx:Reference Uri="http://redfish.dmtf.org/schemas/v1/Resource_v1.xml">
+    <edmx:Include Namespace="Resource.v1_0_0"/>
+  </edmx:Reference>
+  <edmx:Reference Uri="http://redfish.dmtf.org/schemas/v1/RedfishExtensions_v1.xml">
+    <edmx:Include Namespace="RedfishExtensions.v1_0_0" Alias="Redfish"/>
+  </edmx:Reference>
+  <edmx:Reference Uri="http://redfish.dmtf.org/schemas/v1/SerialInterface_v1.xml">
+    <edmx:Include Namespace="SerialInterface"/>
+  </edmx:Reference>
+
+  <edmx:DataServices>
+
+    <Schema xmlns="http://docs.oasis-open.org/odata/ns/edm" Namespace="SerialInterfaceCollection">
+      <Annotation Term="Redfish.OwningEntity" String="DMTF"/>
+
+      <EntityType Name="SerialInterfaceCollection" BaseType="Resource.v1_0_0.ResourceCollection">
+        <Annotation Term="OData.Description" String="The collection of SerialInterface resource instances."/>
+        <Annotation Term="OData.LongDescription" String="This resource shall represent a resource collection of SerialInterface instances for a Redfish implementation."/>
+        <Annotation Term="Capabilities.InsertRestrictions">
+          <Record>
+            <PropertyValue Property="Insertable" Bool="false"/>
+          </Record>
+        </Annotation>
+        <Annotation Term="Capabilities.UpdateRestrictions">
+          <Record>
+            <PropertyValue Property="Updatable" Bool="false"/>
+          </Record>
+        </Annotation>
+        <Annotation Term="Capabilities.DeleteRestrictions">
+          <Record>
+            <PropertyValue Property="Deletable" Bool="false"/>
+          </Record>
+        </Annotation>
+        <Annotation Term="Redfish.Uris">
+          <Collection>
+            <String>/redfish/v1/Managers/{ManagerId}/SerialInterfaces</String>
+          </Collection>
+        </Annotation>
+        <NavigationProperty Name="Members" Type="Collection(SerialInterface.SerialInterface)">
+          <Annotation Term="OData.Permissions" EnumMember="OData.Permission/Read"/>
+          <Annotation Term="OData.Description" String="The members of this collection."/>
+          <Annotation Term="OData.LongDescription" String="This property shall contain an array of links to the members of this collection."/>
+          <Annotation Term="OData.AutoExpandReferences"/>
+          <Annotation Term="Redfish.Required"/>
+        </NavigationProperty>
+      </EntityType>
+    </Schema>
+
+  </edmx:DataServices>
+</edmx:Edmx>

--- a/static/redfish/v1/schema/SerialInterface_v1.xml
+++ b/static/redfish/v1/schema/SerialInterface_v1.xml
@@ -1,0 +1,424 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!---->
+<!--################################################################################       -->
+<!--# Redfish Schema:  SerialInterface v1.1.7                                              -->
+<!--#                                                                                      -->
+<!--# For a detailed change log, see the README file contained in the DSP8010 bundle,      -->
+<!--# available at http://www.dmtf.org/standards/redfish                                   -->
+<!--# Copyright 2014-2021 DMTF.                                                            -->
+<!--# For the full DMTF copyright policy, see http://www.dmtf.org/about/policies/copyright -->
+<!--################################################################################       -->
+<!---->
+<edmx:Edmx xmlns:edmx="http://docs.oasis-open.org/odata/ns/edmx" Version="4.0">
+
+  <edmx:Reference Uri="http://docs.oasis-open.org/odata/odata/v4.0/errata03/csd01/complete/vocabularies/Org.OData.Core.V1.xml">
+    <edmx:Include Namespace="Org.OData.Core.V1" Alias="OData"/>
+  </edmx:Reference>
+  <edmx:Reference Uri="http://docs.oasis-open.org/odata/odata/v4.0/errata03/csd01/complete/vocabularies/Org.OData.Capabilities.V1.xml">
+    <edmx:Include Namespace="Org.OData.Capabilities.V1" Alias="Capabilities"/>
+  </edmx:Reference>
+  <edmx:Reference Uri="http://redfish.dmtf.org/schemas/v1/RedfishExtensions_v1.xml">
+    <edmx:Include Namespace="RedfishExtensions.v1_0_0" Alias="Redfish"/>
+  </edmx:Reference>
+  <edmx:Reference Uri="http://redfish.dmtf.org/schemas/v1/Resource_v1.xml">
+    <edmx:Include Namespace="Resource.v1_0_0"/>
+  </edmx:Reference>
+
+  <edmx:DataServices>
+
+    <Schema xmlns="http://docs.oasis-open.org/odata/ns/edm" Namespace="SerialInterface">
+      <Annotation Term="Redfish.OwningEntity" String="DMTF"/>
+
+      <EntityType Name="SerialInterface" BaseType="Resource.v1_0_0.Resource" Abstract="true">
+        <Annotation Term="OData.Description" String="The SerialInterface schema describes an asynchronous serial interface, such as an RS-232 interface, available to a system or device."/>
+        <Annotation Term="OData.LongDescription" String="This resource shall represent a serial interface as part of the Redfish Specification."/>
+        <Annotation Term="Capabilities.InsertRestrictions">
+          <Record>
+            <PropertyValue Property="Insertable" Bool="false"/>
+          </Record>
+        </Annotation>
+        <Annotation Term="Capabilities.UpdateRestrictions">
+          <Record>
+            <PropertyValue Property="Updatable" Bool="true"/>
+            <Annotation Term="OData.Description" String="Serial interfaces can be updated to enable or disable them or change their configuration."/>
+          </Record>
+        </Annotation>
+        <Annotation Term="Capabilities.DeleteRestrictions">
+          <Record>
+            <PropertyValue Property="Deletable" Bool="false"/>
+          </Record>
+        </Annotation>
+        <Annotation Term="Redfish.Uris">
+          <Collection>
+            <String>/redfish/v1/Managers/{ManagerId}/SerialInterfaces/{SerialInterfaceId}</String>
+          </Collection>
+        </Annotation>
+      </EntityType>
+    </Schema>
+
+    <Schema xmlns="http://docs.oasis-open.org/odata/ns/edm" Namespace="SerialInterface.v1_0_0">
+      <Annotation Term="Redfish.OwningEntity" String="DMTF"/>
+      <Annotation Term="Redfish.Release" String="1.0"/>
+
+      <EntityType Name="SerialInterface" BaseType="SerialInterface.SerialInterface">
+        <Property Name="InterfaceEnabled" Type="Edm.Boolean">
+          <Annotation Term="OData.Permissions" EnumMember="OData.Permission/ReadWrite"/>
+          <Annotation Term="OData.Description" String="An indication of whether this interface is enabled."/>
+          <Annotation Term="OData.LongDescription" String="This property shall indicate whether this interface is enabled."/>
+        </Property>
+        <Property Name="SignalType" Type="SerialInterface.v1_0_0.SignalType" Nullable="false">
+          <Annotation Term="OData.Permissions" EnumMember="OData.Permission/Read"/>
+          <Annotation Term="OData.Description" String="The type of signal used for the communication connection."/>
+          <Annotation Term="OData.LongDescription" String="This property shall contain the type of serial signaling in use for the serial connection."/>
+        </Property>
+        <Property Name="BitRate" Type="SerialInterface.v1_0_0.BitRate" Nullable="false">
+          <Annotation Term="OData.Permissions" EnumMember="OData.Permission/ReadWrite"/>
+          <Annotation Term="OData.Description" String="The receive and transmit rate of data flow, typically in bits per second (bit/s), over the serial connection."/>
+          <Annotation Term="OData.LongDescription" String="This property shall indicate the transmit and receive speed of the serial connection."/>
+        </Property>
+        <Property Name="Parity" Type="SerialInterface.v1_0_0.Parity" Nullable="false">
+          <Annotation Term="OData.Permissions" EnumMember="OData.Permission/ReadWrite"/>
+          <Annotation Term="OData.Description" String="The type of parity used by the sender and receiver to detect errors over the serial connection."/>
+          <Annotation Term="OData.LongDescription" String="This property shall indicate parity information for a serial connection."/>
+        </Property>
+        <Property Name="DataBits" Type="SerialInterface.v1_0_0.DataBits" Nullable="false">
+          <Annotation Term="OData.Permissions" EnumMember="OData.Permission/ReadWrite"/>
+          <Annotation Term="OData.Description" String="The number of data bits that follow the start bit over the serial connection."/>
+          <Annotation Term="OData.LongDescription" String="This property shall indicate number of data bits for the serial connection."/>
+        </Property>
+        <Property Name="StopBits" Type="SerialInterface.v1_0_0.StopBits" Nullable="false">
+          <Annotation Term="OData.Permissions" EnumMember="OData.Permission/ReadWrite"/>
+          <Annotation Term="OData.Description" String="The period of time before the next start bit is transmitted."/>
+          <Annotation Term="OData.LongDescription" String="This property shall indicate the stop bits for the serial connection."/>
+        </Property>
+        <Property Name="FlowControl" Type="SerialInterface.v1_0_0.FlowControl" Nullable="false">
+          <Annotation Term="OData.Permissions" EnumMember="OData.Permission/ReadWrite"/>
+          <Annotation Term="OData.Description" String="The type of flow control, if any, that is imposed on the serial connection."/>
+          <Annotation Term="OData.LongDescription" String="This property shall indicate the flow control mechanism for the serial connection."/>
+        </Property>
+        <Property Name="ConnectorType" Type="SerialInterface.v1_0_0.ConnectorType" Nullable="false">
+          <Annotation Term="OData.Permissions" EnumMember="OData.Permission/Read"/>
+          <Annotation Term="OData.Description" String="The type of connector used for this interface."/>
+          <Annotation Term="OData.LongDescription" String="This property shall indicate the type of physical connector used for this serial connection."/>
+        </Property>
+        <Property Name="PinOut" Type="SerialInterface.v1_0_0.PinOut">
+          <Annotation Term="OData.Permissions" EnumMember="OData.Permission/Read"/>
+          <Annotation Term="OData.Description" String="The physical pinout configuration for a serial connector."/>
+          <Annotation Term="OData.LongDescription" String="This property shall indicate the physical pinout for the serial connector."/>
+        </Property>
+      </EntityType>
+
+      <EnumType Name="SignalType">
+        <Member Name="Rs232">
+          <Annotation Term="OData.Description" String="The serial interface follows RS232."/>
+        </Member>
+        <Member Name="Rs485">
+          <Annotation Term="OData.Description" String="The serial interface follows RS485."/>
+        </Member>
+      </EnumType>
+
+      <TypeDefinition Name="BitRate" UnderlyingType="Edm.String">
+        <Annotation Term="Redfish.Enumeration">
+          <Collection>
+            <Record>
+              <PropertyValue Property="Member" String="1200"/>
+              <Annotation Term="OData.Description" String="A bit rate of 1200 bit/s."/>
+            </Record>
+            <Record>
+              <PropertyValue Property="Member" String="2400"/>
+              <Annotation Term="OData.Description" String="A bit rate of 2400 bit/s."/>
+            </Record>
+            <Record>
+              <PropertyValue Property="Member" String="4800"/>
+              <Annotation Term="OData.Description" String="A bit rate of 4800 bit/s."/>
+            </Record>
+            <Record>
+              <PropertyValue Property="Member" String="9600"/>
+              <Annotation Term="OData.Description" String="A bit rate of 9600 bit/s."/>
+            </Record>
+            <Record>
+              <PropertyValue Property="Member" String="19200"/>
+              <Annotation Term="OData.Description" String="A bit rate of 19200 bit/s."/>
+            </Record>
+            <Record>
+              <PropertyValue Property="Member" String="38400"/>
+              <Annotation Term="OData.Description" String="A bit rate of 38400 bit/s."/>
+            </Record>
+            <Record>
+              <PropertyValue Property="Member" String="57600"/>
+              <Annotation Term="OData.Description" String="A bit rate of 57600 bit/s."/>
+            </Record>
+            <Record>
+              <PropertyValue Property="Member" String="115200"/>
+              <Annotation Term="OData.Description" String="A bit rate of 115200 bit/s."/>
+            </Record>
+            <Record>
+              <PropertyValue Property="Member" String="230400"/>
+              <Annotation Term="OData.Description" String="A bit rate of 230400 bit/s."/>
+            </Record>
+          </Collection>
+        </Annotation>
+      </TypeDefinition>
+
+      <EnumType Name="Parity">
+        <Member Name="None">
+          <Annotation Term="OData.Description" String="No parity bit."/>
+        </Member>
+        <Member Name="Even">
+          <Annotation Term="OData.Description" String="An even parity bit."/>
+        </Member>
+        <Member Name="Odd">
+          <Annotation Term="OData.Description" String="An odd parity bit."/>
+        </Member>
+        <Member Name="Mark">
+          <Annotation Term="OData.Description" String="A mark parity bit."/>
+        </Member>
+        <Member Name="Space">
+          <Annotation Term="OData.Description" String="A space parity bit."/>
+        </Member>
+      </EnumType>
+
+      <TypeDefinition Name="DataBits" UnderlyingType="Edm.String">
+        <Annotation Term="Redfish.Enumeration">
+          <Collection>
+            <Record>
+              <PropertyValue Property="Member" String="5"/>
+              <Annotation Term="OData.Description" String="Five bits of data following the start bit."/>
+            </Record>
+            <Record>
+              <PropertyValue Property="Member" String="6"/>
+              <Annotation Term="OData.Description" String="Six bits of data following the start bit."/>
+            </Record>
+            <Record>
+              <PropertyValue Property="Member" String="7"/>
+              <Annotation Term="OData.Description" String="Seven bits of data following the start bit."/>
+            </Record>
+            <Record>
+              <PropertyValue Property="Member" String="8"/>
+              <Annotation Term="OData.Description" String="Eight bits of data following the start bit."/>
+            </Record>
+          </Collection>
+        </Annotation>
+      </TypeDefinition>
+
+      <TypeDefinition Name="StopBits" UnderlyingType="Edm.String">
+        <Annotation Term="Redfish.Enumeration">
+          <Collection>
+            <Record>
+              <PropertyValue Property="Member" String="1"/>
+              <Annotation Term="OData.Description" String="One stop bit following the data bits."/>
+            </Record>
+            <Record>
+              <PropertyValue Property="Member" String="2"/>
+              <Annotation Term="OData.Description" String="Two stop bits following the data bits."/>
+            </Record>
+          </Collection>
+        </Annotation>
+      </TypeDefinition>
+
+      <EnumType Name="FlowControl">
+        <Member Name="None">
+          <Annotation Term="OData.Description" String="No flow control imposed."/>
+        </Member>
+        <Member Name="Software">
+          <Annotation Term="OData.Description" String="XON/XOFF in-band flow control imposed."/>
+        </Member>
+        <Member Name="Hardware">
+          <Annotation Term="OData.Description" String="Out-of-band flow control imposed."/>
+        </Member>
+      </EnumType>
+
+      <EnumType Name="PinOut">
+        <Member Name="Cisco">
+          <Annotation Term="OData.Description" String="The Cisco pinout configuration."/>
+        </Member>
+        <Member Name="Cyclades">
+          <Annotation Term="OData.Description" String="The Cyclades pinout configuration."/>
+        </Member>
+        <Member Name="Digi">
+          <Annotation Term="OData.Description" String="The Digi pinout configuration."/>
+        </Member>
+      </EnumType>
+
+      <TypeDefinition Name="ConnectorType" UnderlyingType="Edm.String">
+        <Annotation Term="Redfish.Enumeration">
+          <Collection>
+            <Record>
+              <PropertyValue Property="Member" String="RJ45"/>
+              <Annotation Term="OData.Description" String="An RJ45 connector."/>
+            </Record>
+            <Record>
+              <PropertyValue Property="Member" String="RJ11"/>
+              <Annotation Term="OData.Description" String="An RJ11 connector."/>
+            </Record>
+            <Record>
+              <PropertyValue Property="Member" String="DB9 Female"/>
+              <Annotation Term="OData.Description" String="A DB9 Female connector."/>
+            </Record>
+            <Record>
+              <PropertyValue Property="Member" String="DB9 Male"/>
+              <Annotation Term="OData.Description" String="A DB9 Male connector."/>
+            </Record>
+            <Record>
+              <PropertyValue Property="Member" String="DB25 Female"/>
+              <Annotation Term="OData.Description" String="A DB25 Female connector."/>
+            </Record>
+            <Record>
+              <PropertyValue Property="Member" String="DB25 Male"/>
+              <Annotation Term="OData.Description" String="A DB25 Male connector."/>
+            </Record>
+            <Record>
+              <PropertyValue Property="Member" String="USB"/>
+              <Annotation Term="OData.Description" String="A USB connector."/>
+            </Record>
+            <Record>
+              <PropertyValue Property="Member" String="mUSB"/>
+              <Annotation Term="OData.Description" String="A mUSB connector."/>
+            </Record>
+            <Record>
+              <PropertyValue Property="Member" String="uUSB"/>
+              <Annotation Term="OData.Description" String="A uUSB connector."/>
+            </Record>
+          </Collection>
+        </Annotation>
+      </TypeDefinition>
+    </Schema>
+
+    <Schema xmlns="http://docs.oasis-open.org/odata/ns/edm" Namespace="SerialInterface.v1_0_2">
+      <Annotation Term="Redfish.OwningEntity" String="DMTF"/>
+      <Annotation Term="OData.Description" String="This version was created to show that annotations in previous namespaces were updated."/>
+      <EntityType Name="SerialInterface" BaseType="SerialInterface.v1_0_0.SerialInterface"/>
+    </Schema>
+
+    <Schema xmlns="http://docs.oasis-open.org/odata/ns/edm" Namespace="SerialInterface.v1_0_3">
+      <Annotation Term="Redfish.OwningEntity" String="DMTF"/>
+      <Annotation Term="OData.Description" String="This version was created to show that annotations in previous namespaces were updated."/>
+      <EntityType Name="SerialInterface" BaseType="SerialInterface.v1_0_2.SerialInterface"/>
+    </Schema>
+
+    <Schema xmlns="http://docs.oasis-open.org/odata/ns/edm" Namespace="SerialInterface.v1_0_4">
+      <Annotation Term="Redfish.OwningEntity" String="DMTF"/>
+      <Annotation Term="OData.Description" String="This version was created to correct the ConnectorType enumerated values to match original publication."/>
+      <EntityType Name="SerialInterface" BaseType="SerialInterface.v1_0_3.SerialInterface"/>
+    </Schema>
+
+    <Schema xmlns="http://docs.oasis-open.org/odata/ns/edm" Namespace="SerialInterface.v1_0_5">
+      <Annotation Term="Redfish.OwningEntity" String="DMTF"/>
+      <Annotation Term="OData.Description" String="This version was created to add descriptions to various enumerated values."/>
+      <EntityType Name="SerialInterface" BaseType="SerialInterface.v1_0_4.SerialInterface"/>
+    </Schema>
+
+    <Schema xmlns="http://docs.oasis-open.org/odata/ns/edm" Namespace="SerialInterface.v1_0_6">
+      <Annotation Term="Redfish.OwningEntity" String="DMTF"/>
+      <Annotation Term="OData.Description" String="This version was created to force the regeneration of JSON Schema so that OData properties are marked as required, and integer properties are marked as integer rather than number."/>
+      <EntityType Name="SerialInterface" BaseType="SerialInterface.v1_0_5.SerialInterface"/>
+    </Schema>
+
+    <Schema xmlns="http://docs.oasis-open.org/odata/ns/edm" Namespace="SerialInterface.v1_0_7">
+      <Annotation Term="Redfish.OwningEntity" String="DMTF"/>
+      <Annotation Term="OData.Description" String="This version was created to force the regeneration of JSON Schema so that URI properties use the uri-reference format."/>
+      <EntityType Name="SerialInterface" BaseType="SerialInterface.v1_0_6.SerialInterface"/>
+    </Schema>
+
+    <Schema xmlns="http://docs.oasis-open.org/odata/ns/edm" Namespace="SerialInterface.v1_0_8">
+      <Annotation Term="Redfish.OwningEntity" String="DMTF"/>
+      <Annotation Term="OData.Description" String="This version was created to update descriptions that this schema defines."/>
+      <EntityType Name="SerialInterface" BaseType="SerialInterface.v1_0_7.SerialInterface"/>
+    </Schema>
+
+    <Schema xmlns="http://docs.oasis-open.org/odata/ns/edm" Namespace="SerialInterface.v1_0_9">
+      <Annotation Term="Redfish.OwningEntity" String="DMTF"/>
+      <Annotation Term="OData.Description" String="This version was created to correct various typographical errors."/>
+      <EntityType Name="SerialInterface" BaseType="SerialInterface.v1_0_8.SerialInterface"/>
+    </Schema>
+
+    <Schema xmlns="http://docs.oasis-open.org/odata/ns/edm" Namespace="SerialInterface.v1_0_10">
+      <Annotation Term="Redfish.OwningEntity" String="DMTF"/>
+      <Annotation Term="OData.Description" String="This version was created to correct various typographical errors."/>
+      <EntityType Name="SerialInterface" BaseType="SerialInterface.v1_0_9.SerialInterface"/>
+    </Schema>
+
+    <Schema xmlns="http://docs.oasis-open.org/odata/ns/edm" Namespace="SerialInterface.v1_0_11">
+      <Annotation Term="Redfish.OwningEntity" String="DMTF"/>
+      <Annotation Term="OData.Description" String="This version was created to correct various typographical errors."/>
+      <EntityType Name="SerialInterface" BaseType="SerialInterface.v1_0_10.SerialInterface"/>
+    </Schema>
+
+    <Schema xmlns="http://docs.oasis-open.org/odata/ns/edm" Namespace="SerialInterface.v1_1_0">
+      <Annotation Term="Redfish.OwningEntity" String="DMTF"/>
+      <Annotation Term="Redfish.Release" String="2017.1"/>
+
+      <EntityType Name="SerialInterface" BaseType="SerialInterface.v1_0_3.SerialInterface">
+        <Property Name="Actions" Type="SerialInterface.v1_1_0.Actions" Nullable="false">
+          <Annotation Term="OData.Description" String="The available actions for this resource."/>
+          <Annotation Term="OData.LongDescription" String="This property shall contain the available actions for this resource."/>
+        </Property>
+      </EntityType>
+
+      <ComplexType Name="Actions">
+        <Annotation Term="OData.AdditionalProperties" Bool="false"/>
+        <Annotation Term="OData.Description" String="The available actions for this resource."/>
+        <Annotation Term="OData.LongDescription" String="This type shall contain the available actions for this resource."/>
+        <Property Name="Oem" Type="SerialInterface.v1_1_0.OemActions" Nullable="false">
+          <Annotation Term="OData.Description" String="The available OEM-specific actions for this resource."/>
+          <Annotation Term="OData.LongDescription" String="This property shall contain the available OEM-specific actions for this resource."/>
+        </Property>
+      </ComplexType>
+
+      <ComplexType Name="OemActions">
+        <Annotation Term="OData.AdditionalProperties" Bool="true"/>
+        <Annotation Term="OData.Description" String="The available OEM-specific actions for this resource."/>
+        <Annotation Term="OData.LongDescription" String="This type shall contain the available OEM-specific actions for this resource."/>
+      </ComplexType>
+    </Schema>
+
+    <Schema xmlns="http://docs.oasis-open.org/odata/ns/edm" Namespace="SerialInterface.v1_1_1">
+      <Annotation Term="Redfish.OwningEntity" String="DMTF"/>
+      <Annotation Term="OData.Description" String="This version was created to correct the ConnectorType enumerated values to match original publication."/>
+      <EntityType Name="SerialInterface" BaseType="SerialInterface.v1_1_0.SerialInterface"/>
+    </Schema>
+
+    <Schema xmlns="http://docs.oasis-open.org/odata/ns/edm" Namespace="SerialInterface.v1_1_2">
+      <Annotation Term="Redfish.OwningEntity" String="DMTF"/>
+      <Annotation Term="OData.Description" String="This version was created to add descriptions to various enumerated values."/>
+      <EntityType Name="SerialInterface" BaseType="SerialInterface.v1_1_1.SerialInterface"/>
+    </Schema>
+
+    <Schema xmlns="http://docs.oasis-open.org/odata/ns/edm" Namespace="SerialInterface.v1_1_3">
+      <Annotation Term="Redfish.OwningEntity" String="DMTF"/>
+      <Annotation Term="OData.Description" String="This version was created to force the regeneration of JSON Schema so that OData properties are marked as required, and integer properties are marked as integer rather than number."/>
+      <EntityType Name="SerialInterface" BaseType="SerialInterface.v1_1_2.SerialInterface"/>
+    </Schema>
+
+    <Schema xmlns="http://docs.oasis-open.org/odata/ns/edm" Namespace="SerialInterface.v1_1_4">
+      <Annotation Term="Redfish.OwningEntity" String="DMTF"/>
+      <Annotation Term="OData.Description" String="This version was created to force the regeneration of JSON Schema so that URI properties use the uri-reference format."/>
+      <EntityType Name="SerialInterface" BaseType="SerialInterface.v1_1_3.SerialInterface"/>
+    </Schema>
+
+    <Schema xmlns="http://docs.oasis-open.org/odata/ns/edm" Namespace="SerialInterface.v1_1_5">
+      <Annotation Term="Redfish.OwningEntity" String="DMTF"/>
+      <Annotation Term="OData.Description" String="This version was created to update descriptions that this schema defines."/>
+      <EntityType Name="SerialInterface" BaseType="SerialInterface.v1_1_4.SerialInterface"/>
+    </Schema>
+
+    <Schema xmlns="http://docs.oasis-open.org/odata/ns/edm" Namespace="SerialInterface.v1_1_6">
+      <Annotation Term="Redfish.OwningEntity" String="DMTF"/>
+      <Annotation Term="OData.Description" String="This version was created to correct various typographical errors."/>
+      <EntityType Name="SerialInterface" BaseType="SerialInterface.v1_1_5.SerialInterface"/>
+    </Schema>
+
+    <Schema xmlns="http://docs.oasis-open.org/odata/ns/edm" Namespace="SerialInterface.v1_1_7">
+      <Annotation Term="Redfish.OwningEntity" String="DMTF"/>
+      <Annotation Term="OData.Description" String="This version was created to correct various typographical errors."/>
+      <EntityType Name="SerialInterface" BaseType="SerialInterface.v1_1_6.SerialInterface"/>
+    </Schema>
+
+    <Schema xmlns="http://docs.oasis-open.org/odata/ns/edm" Namespace="SerialInterface.v1_1_8">
+      <Annotation Term="Redfish.OwningEntity" String="DMTF"/>
+      <Annotation Term="OData.Description" String="This version was created to correct various typographical errors."/>
+      <EntityType Name="SerialInterface" BaseType="SerialInterface.v1_1_7.SerialInterface"/>
+    </Schema>
+
+  </edmx:DataServices>
+</edmx:Edmx>

--- a/static/redfish/v1/schema/SignatureCollection_v1.xml
+++ b/static/redfish/v1/schema/SignatureCollection_v1.xml
@@ -1,0 +1,72 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!---->
+<!--################################################################################       -->
+<!--# Redfish Schema:  SignatureCollection                                                 -->
+<!--#                                                                                      -->
+<!--# For a detailed change log, see the README file contained in the DSP8010 bundle,      -->
+<!--# available at http://www.dmtf.org/standards/redfish                                   -->
+<!--# Copyright 2014-2021 DMTF.                                                            -->
+<!--# For the full DMTF copyright policy, see http://www.dmtf.org/about/policies/copyright -->
+<!--################################################################################       -->
+<!---->
+<edmx:Edmx xmlns:edmx="http://docs.oasis-open.org/odata/ns/edmx" Version="4.0">
+
+  <edmx:Reference Uri="http://docs.oasis-open.org/odata/odata/v4.0/errata03/csd01/complete/vocabularies/Org.OData.Core.V1.xml">
+    <edmx:Include Namespace="Org.OData.Core.V1" Alias="OData"/>
+  </edmx:Reference>
+  <edmx:Reference Uri="http://docs.oasis-open.org/odata/odata/v4.0/errata03/csd01/complete/vocabularies/Org.OData.Capabilities.V1.xml">
+    <edmx:Include Namespace="Org.OData.Capabilities.V1" Alias="Capabilities"/>
+  </edmx:Reference>
+  <edmx:Reference Uri="http://redfish.dmtf.org/schemas/v1/Resource_v1.xml">
+    <edmx:Include Namespace="Resource.v1_0_0"/>
+  </edmx:Reference>
+  <edmx:Reference Uri="http://redfish.dmtf.org/schemas/v1/RedfishExtensions_v1.xml">
+    <edmx:Include Namespace="RedfishExtensions.v1_0_0" Alias="Redfish"/>
+  </edmx:Reference>
+  <edmx:Reference Uri="http://redfish.dmtf.org/schemas/v1/Signature_v1.xml">
+    <edmx:Include Namespace="Signature"/>
+  </edmx:Reference>
+
+  <edmx:DataServices>
+
+    <Schema xmlns="http://docs.oasis-open.org/odata/ns/edm" Namespace="SignatureCollection">
+      <Annotation Term="Redfish.OwningEntity" String="DMTF"/>
+
+      <EntityType Name="SignatureCollection" BaseType="Resource.v1_0_0.ResourceCollection">
+        <Annotation Term="OData.Description" String="The collection of Signature resource instances."/>
+        <Annotation Term="OData.LongDescription" String="This resource shall represent a resource collection of Signature instances for a Redfish implementation."/>
+        <Annotation Term="Capabilities.InsertRestrictions">
+          <Record>
+            <PropertyValue Property="Insertable" Bool="true"/>
+            <Annotation Term="OData.Description" String="Signatures can be installed through a POST to the signature collection."/>
+          </Record>
+        </Annotation>
+        <Annotation Term="Capabilities.UpdateRestrictions">
+          <Record>
+            <PropertyValue Property="Updatable" Bool="false"/>
+          </Record>
+        </Annotation>
+        <Annotation Term="Capabilities.DeleteRestrictions">
+          <Record>
+            <PropertyValue Property="Deletable" Bool="false"/>
+          </Record>
+        </Annotation>
+        <Annotation Term="Redfish.Uris">
+          <Collection>
+            <String>/redfish/v1/Systems/{ComputerSystemId}/SecureBoot/SecureBootDatabases/{DatabaseId}/Signatures</String>
+            <String>/redfish/v1/CompositionService/ResourceBlocks/{ResourceBlockId}/Systems/{ComputerSystemId}/SecureBoot/SecureBootDatabases/{DatabaseId}/Signatures</String>
+            <String>/redfish/v1/ResourceBlocks/{ResourceBlockId}/Systems/{ComputerSystemId}/SecureBoot/SecureBootDatabases/{DatabaseId}/Signatures</String>
+          </Collection>
+        </Annotation>
+        <NavigationProperty Name="Members" Type="Collection(Signature.Signature)">
+          <Annotation Term="OData.Permissions" EnumMember="OData.Permission/Read"/>
+          <Annotation Term="OData.Description" String="The members of this collection."/>
+          <Annotation Term="OData.LongDescription" String="This property shall contain an array of links to the members of this collection."/>
+          <Annotation Term="OData.AutoExpandReferences"/>
+          <Annotation Term="Redfish.Required"/>
+        </NavigationProperty>
+      </EntityType>
+    </Schema>
+
+  </edmx:DataServices>
+</edmx:Edmx>

--- a/static/redfish/v1/schema/Signature_v1.xml
+++ b/static/redfish/v1/schema/Signature_v1.xml
@@ -1,0 +1,132 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!---->
+<!--################################################################################       -->
+<!--# Redfish Schema:  Signature v1.0.2                                                    -->
+<!--#                                                                                      -->
+<!--# For a detailed change log, see the README file contained in the DSP8010 bundle,      -->
+<!--# available at http://www.dmtf.org/standards/redfish                                   -->
+<!--# Copyright 2014-2021 DMTF.                                                            -->
+<!--# For the full DMTF copyright policy, see http://www.dmtf.org/about/policies/copyright -->
+<!--################################################################################       -->
+<!---->
+<edmx:Edmx xmlns:edmx="http://docs.oasis-open.org/odata/ns/edmx" Version="4.0">
+
+  <edmx:Reference Uri="http://docs.oasis-open.org/odata/odata/v4.0/errata03/csd01/complete/vocabularies/Org.OData.Core.V1.xml">
+    <edmx:Include Namespace="Org.OData.Core.V1" Alias="OData"/>
+  </edmx:Reference>
+  <edmx:Reference Uri="http://docs.oasis-open.org/odata/odata/v4.0/errata03/csd01/complete/vocabularies/Org.OData.Capabilities.V1.xml">
+    <edmx:Include Namespace="Org.OData.Capabilities.V1" Alias="Capabilities"/>
+  </edmx:Reference>
+  <edmx:Reference Uri="http://redfish.dmtf.org/schemas/v1/Resource_v1.xml">
+    <edmx:Include Namespace="Resource.v1_0_0"/>
+  </edmx:Reference>
+  <edmx:Reference Uri="http://redfish.dmtf.org/schemas/v1/RedfishExtensions_v1.xml">
+    <edmx:Include Namespace="RedfishExtensions.v1_0_0" Alias="Redfish"/>
+  </edmx:Reference>
+
+  <edmx:DataServices>
+
+    <Schema xmlns="http://docs.oasis-open.org/odata/ns/edm" Namespace="Signature">
+      <Annotation Term="Redfish.OwningEntity" String="DMTF"/>
+
+      <EntityType Name="Signature" BaseType="Resource.v1_0_0.Resource" Abstract="true">
+        <Annotation Term="OData.Description" String="The Signature schema describes a signature or a hash."/>
+        <Annotation Term="OData.LongDescription" String="This resource contains a signature for a Redfish implementation."/>
+        <Annotation Term="Capabilities.InsertRestrictions">
+          <Record>
+            <PropertyValue Property="Insertable" Bool="false"/>
+          </Record>
+        </Annotation>
+        <Annotation Term="Capabilities.UpdateRestrictions">
+          <Record>
+            <PropertyValue Property="Updatable" Bool="false"/>
+          </Record>
+        </Annotation>
+        <Annotation Term="Capabilities.DeleteRestrictions">
+          <Record>
+            <PropertyValue Property="Deletable" Bool="true"/>
+            <Annotation Term="OData.Description" String="Use the DELETE operation to remove signatures."/>
+          </Record>
+        </Annotation>
+        <Annotation Term="Redfish.Uris">
+          <Collection>
+            <String>/redfish/v1/Systems/{ComputerSystemId}/SecureBoot/SecureBootDatabases/{DatabaseId}/Signatures/{SignatureId}</String>
+            <String>/redfish/v1/CompositionService/ResourceBlocks/{ResourceBlockId}/Systems/{ComputerSystemId}/SecureBoot/SecureBootDatabases/{DatabaseId}/Signatures/{SignatureId}</String>
+            <String>/redfish/v1/ResourceBlocks/{ResourceBlockId}/Systems/{ComputerSystemId}/SecureBoot/SecureBootDatabases/{DatabaseId}/Signatures/{SignatureId}</String>
+          </Collection>
+        </Annotation>
+      </EntityType>
+
+      <EnumType Name="SignatureTypeRegistry">
+        <Member Name="UEFI">
+          <Annotation Term="OData.Description" String="A signature defined in the UEFI Specification."/>
+          <Annotation Term="OData.LongDescription" String="This value shall indicate that the SignatureType string contains the #define name of the SignatureType member of the EFI_SIGNATURE_LIST, as defined by the UEFI Specification.  This value shall also indicate that the format of the SignatureString is a big-endian hex-encoded string of the binary value specified in the UEFI SignatureData array in EFI_SIGNATURE_DATA, as defined by the UEFI Specification."/>
+        </Member>
+      </EnumType>
+    </Schema>
+
+    <Schema xmlns="http://docs.oasis-open.org/odata/ns/edm" Namespace="Signature.v1_0_0">
+      <Annotation Term="Redfish.OwningEntity" String="DMTF"/>
+      <Annotation Term="Redfish.Release" String="2020.1"/>
+
+      <EntityType Name="Signature" BaseType="Signature.Signature">
+        <Property Name="SignatureTypeRegistry" Type="Signature.SignatureTypeRegistry">
+          <Annotation Term="OData.Permissions" EnumMember="OData.Permission/Read"/>
+          <Annotation Term="OData.Description" String="The type of the signature."/>
+          <Annotation Term="OData.LongDescription" String="This property shall contain the type for the signature."/>
+          <Annotation Term="Redfish.RequiredOnCreate"/>
+        </Property>
+        <Property Name="SignatureType" Type="Edm.String">
+          <Annotation Term="OData.Permissions" EnumMember="OData.Permission/Read"/>
+          <Annotation Term="OData.Description" String="The format of the signature."/>
+          <Annotation Term="OData.LongDescription" String="This property shall contain the format type for the signature.  The format is qualified by the value of the SignatureTypeRegistry property."/>
+          <Annotation Term="Redfish.RequiredOnCreate"/>
+        </Property>
+        <Property Name="SignatureString" Type="Edm.String">
+          <Annotation Term="OData.Permissions" EnumMember="OData.Permission/Read"/>
+          <Annotation Term="OData.Description" String="The string for the signature."/>
+          <Annotation Term="OData.LongDescription" String="This property shall contain the string of the signature, and the format shall follow the requirements specified by the value of the SignatureType property.  If the signature contains any private keys, they shall be removed from the string in responses.  If the private key for the signature is not known by the service and is needed to use the signature, the client shall provide the private key as part of the string in the POST request."/>
+          <Annotation Term="Redfish.RequiredOnCreate"/>
+        </Property>
+        <Property Name="UefiSignatureOwner" Type="Edm.Guid">
+          <Annotation Term="OData.Permissions" EnumMember="OData.Permission/Read"/>
+          <Annotation Term="OData.Description" String="The UEFI signature owner for this signature."/>
+          <Annotation Term="OData.LongDescription" String="The value of this property shall contain the GUID of the UEFI signature owner for this signature as defined by the UEFI Specification.  This property shall only be present if the SignatureTypeRegistry property is `UEFI`."/>
+        </Property>
+        <Property Name="Actions" Type="Signature.v1_0_0.Actions" Nullable="false">
+          <Annotation Term="OData.Description" String="The available actions for this resource."/>
+          <Annotation Term="OData.LongDescription" String="This property shall contain the available actions for this resource."/>
+        </Property>
+      </EntityType>
+
+      <ComplexType Name="Actions">
+        <Annotation Term="OData.AdditionalProperties" Bool="false"/>
+        <Annotation Term="OData.Description" String="The available actions for this resource."/>
+        <Annotation Term="OData.LongDescription" String="This type shall contain the available actions for this resource."/>
+        <Property Name="Oem" Type="Signature.v1_0_0.OemActions" Nullable="false">
+          <Annotation Term="OData.Description" String="The available OEM-specific actions for this resource."/>
+          <Annotation Term="OData.LongDescription" String="This property shall contain the available OEM-specific actions for this resource."/>
+        </Property>
+      </ComplexType>
+
+      <ComplexType Name="OemActions">
+        <Annotation Term="OData.AdditionalProperties" Bool="true"/>
+        <Annotation Term="OData.Description" String="The available OEM-specific actions for this resource."/>
+        <Annotation Term="OData.LongDescription" String="This type shall contain the available OEM-specific actions for this resource."/>
+      </ComplexType>
+    </Schema>
+
+    <Schema xmlns="http://docs.oasis-open.org/odata/ns/edm" Namespace="Signature.v1_0_1">
+      <Annotation Term="Redfish.OwningEntity" String="DMTF"/>
+      <Annotation Term="OData.Description" String="This version was created to correct various typographical errors."/>
+      <EntityType Name="Signature" BaseType="Signature.v1_0_0.Signature"/>
+    </Schema>
+
+    <Schema xmlns="http://docs.oasis-open.org/odata/ns/edm" Namespace="Signature.v1_0_2">
+      <Annotation Term="Redfish.OwningEntity" String="DMTF"/>
+      <Annotation Term="OData.Description" String="This version was created to correct various typographical errors."/>
+      <EntityType Name="Signature" BaseType="Signature.v1_0_1.Signature"/>
+    </Schema>
+
+  </edmx:DataServices>
+</edmx:Edmx>

--- a/static/redfish/v1/schema/SimpleStorageCollection_v1.xml
+++ b/static/redfish/v1/schema/SimpleStorageCollection_v1.xml
@@ -1,0 +1,72 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!---->
+<!--################################################################################       -->
+<!--# Redfish Schema:  SimpleStorageCollection                                             -->
+<!--#                                                                                      -->
+<!--# For a detailed change log, see the README file contained in the DSP8010 bundle,      -->
+<!--# available at http://www.dmtf.org/standards/redfish                                   -->
+<!--# Copyright 2014-2021 DMTF.                                                            -->
+<!--# For the full DMTF copyright policy, see http://www.dmtf.org/about/policies/copyright -->
+<!--################################################################################       -->
+<!---->
+<edmx:Edmx xmlns:edmx="http://docs.oasis-open.org/odata/ns/edmx" Version="4.0">
+
+  <edmx:Reference Uri="http://docs.oasis-open.org/odata/odata/v4.0/errata03/csd01/complete/vocabularies/Org.OData.Core.V1.xml">
+    <edmx:Include Namespace="Org.OData.Core.V1" Alias="OData"/>
+  </edmx:Reference>
+  <edmx:Reference Uri="http://docs.oasis-open.org/odata/odata/v4.0/errata03/csd01/complete/vocabularies/Org.OData.Capabilities.V1.xml">
+    <edmx:Include Namespace="Org.OData.Capabilities.V1" Alias="Capabilities"/>
+  </edmx:Reference>
+  <edmx:Reference Uri="http://redfish.dmtf.org/schemas/v1/Resource_v1.xml">
+    <edmx:Include Namespace="Resource.v1_0_0"/>
+  </edmx:Reference>
+  <edmx:Reference Uri="http://redfish.dmtf.org/schemas/v1/RedfishExtensions_v1.xml">
+    <edmx:Include Namespace="RedfishExtensions.v1_0_0" Alias="Redfish"/>
+  </edmx:Reference>
+  <edmx:Reference Uri="http://redfish.dmtf.org/schemas/v1/SimpleStorage_v1.xml">
+    <edmx:Include Namespace="SimpleStorage"/>
+  </edmx:Reference>
+
+  <edmx:DataServices>
+
+    <Schema xmlns="http://docs.oasis-open.org/odata/ns/edm" Namespace="SimpleStorageCollection">
+      <Annotation Term="Redfish.OwningEntity" String="DMTF"/>
+
+      <EntityType Name="SimpleStorageCollection" BaseType="Resource.v1_0_0.ResourceCollection">
+        <Annotation Term="OData.Description" String="The SimpleStorageCollection schema contains a collection of simple storage instances."/>
+        <Annotation Term="OData.LongDescription" String="This Resource shall represent a Resource Collection of SimpleStorage instances for a Redfish implementation."/>
+        <Annotation Term="Capabilities.InsertRestrictions">
+          <Record>
+            <PropertyValue Property="Insertable" Bool="false"/>
+          </Record>
+        </Annotation>
+        <Annotation Term="Capabilities.UpdateRestrictions">
+          <Record>
+            <PropertyValue Property="Updatable" Bool="false"/>
+          </Record>
+        </Annotation>
+        <Annotation Term="Capabilities.DeleteRestrictions">
+          <Record>
+            <PropertyValue Property="Deletable" Bool="false"/>
+          </Record>
+        </Annotation>
+        <Annotation Term="Redfish.Uris">
+          <Collection>
+            <String>/redfish/v1/Systems/{ComputerSystemId}/SimpleStorage</String>
+            <String>/redfish/v1/CompositionService/ResourceBlocks/{ResourceBlockId}/Systems/{ComputerSystemId}/SimpleStorage</String>
+            <String>/redfish/v1/ResourceBlocks/{ResourceBlockId}/Systems/{ComputerSystemId}/SimpleStorage</String>
+          </Collection>
+        </Annotation>
+        <NavigationProperty Name="Members" Type="Collection(SimpleStorage.SimpleStorage)">
+          <Annotation Term="OData.Permissions" EnumMember="OData.Permission/Read"/>
+          <Annotation Term="OData.Description" String="The members of this collection."/>
+          <Annotation Term="OData.LongDescription" String="This property shall contain an array of links to the members of this collection."/>
+          <Annotation Term="OData.AutoExpandReferences"/>
+          <Annotation Term="Redfish.Required"/>
+        </NavigationProperty>
+      </EntityType>
+
+    </Schema>
+
+  </edmx:DataServices>
+</edmx:Edmx>

--- a/static/redfish/v1/schema/SimpleStorage_v1.xml
+++ b/static/redfish/v1/schema/SimpleStorage_v1.xml
@@ -1,0 +1,309 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!---->
+<!--################################################################################       -->
+<!--# Redfish Schema:  SimpleStorage v1.3.1                                                -->
+<!--#                                                                                      -->
+<!--# For a detailed change log, see the README file contained in the DSP8010 bundle,      -->
+<!--# available at http://www.dmtf.org/standards/redfish                                   -->
+<!--# Copyright 2014-2021 DMTF.                                                            -->
+<!--# For the full DMTF copyright policy, see http://www.dmtf.org/about/policies/copyright -->
+<!--################################################################################       -->
+<!---->
+<edmx:Edmx xmlns:edmx="http://docs.oasis-open.org/odata/ns/edmx" Version="4.0">
+
+  <edmx:Reference Uri="http://docs.oasis-open.org/odata/odata/v4.0/errata03/csd01/complete/vocabularies/Org.OData.Core.V1.xml">
+    <edmx:Include Namespace="Org.OData.Core.V1" Alias="OData"/>
+  </edmx:Reference>
+  <edmx:Reference Uri="http://docs.oasis-open.org/odata/odata/v4.0/errata03/csd01/complete/vocabularies/Org.OData.Capabilities.V1.xml">
+    <edmx:Include Namespace="Org.OData.Capabilities.V1" Alias="Capabilities"/>
+  </edmx:Reference>
+  <edmx:Reference Uri="http://docs.oasis-open.org/odata/odata/v4.0/errata03/csd01/complete/vocabularies/Org.OData.Measures.V1.xml">
+    <edmx:Include Namespace="Org.OData.Measures.V1" Alias="Measures"/>
+  </edmx:Reference>
+  <edmx:Reference Uri="http://redfish.dmtf.org/schemas/v1/Resource_v1.xml">
+    <edmx:Include Namespace="Resource"/>
+    <edmx:Include Namespace="Resource.v1_0_0"/>
+  </edmx:Reference>
+  <edmx:Reference Uri="http://redfish.dmtf.org/schemas/v1/RedfishExtensions_v1.xml">
+    <edmx:Include Namespace="RedfishExtensions.v1_0_0" Alias="Redfish"/>
+    <edmx:Include Namespace="Validation.v1_0_0" Alias="Validation"/>
+  </edmx:Reference>
+  <edmx:Reference Uri="http://redfish.dmtf.org/schemas/v1/Chassis_v1.xml">
+    <edmx:Include Namespace="Chassis"/>
+  </edmx:Reference>
+  <edmx:Reference Uri="http://redfish.dmtf.org/schemas/v1/Storage_v1.xml">
+    <edmx:Include Namespace="Storage"/>
+  </edmx:Reference>
+
+  <edmx:DataServices>
+
+    <Schema xmlns="http://docs.oasis-open.org/odata/ns/edm" Namespace="SimpleStorage">
+      <Annotation Term="Redfish.OwningEntity" String="DMTF"/>
+
+      <EntityType Name="SimpleStorage" BaseType="Resource.v1_0_0.Resource" Abstract="true">
+        <Annotation Term="OData.Description" String="The SimpleStorage schema represents the properties of a storage controller and its directly-attached devices."/>
+        <Annotation Term="OData.LongDescription" String="This Resource contains a storage controller and its directly-attached devices."/>
+        <Annotation Term="Capabilities.InsertRestrictions">
+          <Record>
+            <PropertyValue Property="Insertable" Bool="false"/>
+          </Record>
+        </Annotation>
+        <Annotation Term="Capabilities.UpdateRestrictions">
+          <Record>
+            <PropertyValue Property="Updatable" Bool="false"/>
+          </Record>
+        </Annotation>
+        <Annotation Term="Capabilities.DeleteRestrictions">
+          <Record>
+            <PropertyValue Property="Deletable" Bool="false"/>
+          </Record>
+        </Annotation>
+        <Annotation Term="Redfish.Uris">
+          <Collection>
+            <String>/redfish/v1/Systems/{ComputerSystemId}/SimpleStorage/{SimpleStorageId}</String>
+            <String>/redfish/v1/CompositionService/ResourceBlocks/{ResourceBlockId}/SimpleStorage/{SimpleStorageId}</String>
+            <String>/redfish/v1/CompositionService/ResourceBlocks/{ResourceBlockId}/Systems/{ComputerSystemId}/SimpleStorage/{SimpleStorageId}</String>
+            <String>/redfish/v1/ResourceBlocks/{ResourceBlockId}/SimpleStorage/{SimpleStorageId}</String>
+            <String>/redfish/v1/ResourceBlocks/{ResourceBlockId}/Systems/{ComputerSystemId}/SimpleStorage/{SimpleStorageId}</String>
+          </Collection>
+        </Annotation>
+      </EntityType>
+    </Schema>
+
+    <Schema xmlns="http://docs.oasis-open.org/odata/ns/edm" Namespace="SimpleStorage.v1_0_0">
+      <Annotation Term="Redfish.OwningEntity" String="DMTF"/>
+      <Annotation Term="Redfish.Release" String="1.0"/>
+
+      <EntityType Name="SimpleStorage" BaseType="SimpleStorage.SimpleStorage">
+        <Property Name="UefiDevicePath" Type="Edm.String">
+          <Annotation Term="OData.Permissions" EnumMember="OData.Permission/Read"/>
+          <Annotation Term="OData.Description" String="The UEFI device path to access this storage controller."/>
+          <Annotation Term="OData.LongDescription" String="This property shall contain the UEFI device path that identifies and locates the specific storage controller."/>
+        </Property>
+        <Property Name="Devices" Type="Collection(SimpleStorage.v1_0_0.Device)" Nullable="false">
+          <Annotation Term="OData.Description" String="The storage devices."/>
+          <Annotation Term="OData.LongDescription" String="This property shall contain a list of storage devices related to this Resource."/>
+        </Property>
+        <Property Name="Status" Type="Resource.Status" Nullable="false">
+          <Annotation Term="OData.Description" String="The status and health of the Resource and its subordinate or dependent Resources."/>
+          <Annotation Term="OData.LongDescription" String="This property shall contain any status or health properties of the Resource."/>
+        </Property>
+      </EntityType>
+
+      <ComplexType Name="Device">
+        <Annotation Term="OData.AdditionalProperties" Bool="false"/>
+        <Annotation Term="OData.Description" String="A storage device, such as a disk drive or optical media device."/>
+        <Annotation Term="OData.LongDescription" String="This type shall describe a storage device visible to simple storage."/>
+        <Property Name="Oem" Type="Resource.Oem" Nullable="false">
+          <Annotation Term="OData.Description" String="The OEM extension property."/>
+          <Annotation Term="OData.LongDescription" String="This property shall contain the OEM extensions.  All values for properties contained in this object shall conform to the Redfish Specification-described requirements."/>
+        </Property>
+        <Property Name="Name" Type="Edm.String" Nullable="false">
+          <Annotation Term="OData.Permissions" EnumMember="OData.Permission/Read"/>
+          <Annotation Term="OData.Description"  String="The name of the Resource or array member."/>
+          <Annotation Term="OData.LongDescription" String="This object represents the name of this Resource or array member.  The Resource values shall comply with the Redfish Specification-described requirements.  This string value shall be of the 'Name' reserved word format."/>
+          <Annotation Term="Redfish.Required"/>
+        </Property>
+        <Property Name="Status" Type="Resource.Status" Nullable="false">
+          <Annotation Term="OData.Description" String="The status and health of the Resource and its subordinate or dependent Resources."/>
+          <Annotation Term="OData.LongDescription" String="This property shall contain any status or health properties of the Resource."/>
+        </Property>
+        <Property Name="Manufacturer" Type="Edm.String">
+          <Annotation Term="OData.Permissions" EnumMember="OData.Permission/Read"/>
+          <Annotation Term="OData.Description" String="The name of the manufacturer of this device."/>
+          <Annotation Term="OData.LongDescription" String="This property shall indicate the name of the manufacturer of this storage device."/>
+        </Property>
+        <Property Name="Model" Type="Edm.String">
+          <Annotation Term="OData.Permissions" EnumMember="OData.Permission/Read"/>
+          <Annotation Term="OData.Description" String="The product model number of this device."/>
+          <Annotation Term="OData.LongDescription" String="This property shall indicate the model information as provided by the manufacturer of this storage device."/>
+        </Property>
+      </ComplexType>
+    </Schema>
+
+    <Schema xmlns="http://docs.oasis-open.org/odata/ns/edm" Namespace="SimpleStorage.v1_0_2">
+      <Annotation Term="Redfish.OwningEntity" String="DMTF"/>
+      <Annotation Term="OData.Description" String="This version was created to show that annotations in previous namespaces were updated."/>
+      <EntityType Name="SimpleStorage" BaseType="SimpleStorage.v1_0_0.SimpleStorage"/>
+    </Schema>
+
+    <Schema xmlns="http://docs.oasis-open.org/odata/ns/edm" Namespace="SimpleStorage.v1_0_3">
+      <Annotation Term="Redfish.OwningEntity" String="DMTF"/>
+      <Annotation Term="OData.Description" String="This version was created to show that annotations in previous namespaces were updated."/>
+      <EntityType Name="SimpleStorage" BaseType="SimpleStorage.v1_0_2.SimpleStorage"/>
+    </Schema>
+
+    <Schema xmlns="http://docs.oasis-open.org/odata/ns/edm" Namespace="SimpleStorage.v1_0_4">
+      <Annotation Term="Redfish.OwningEntity" String="DMTF"/>
+      <Annotation Term="OData.Description" String="This version was created to show that annotations in previous namespaces were updated."/>
+      <EntityType Name="SimpleStorage" BaseType="SimpleStorage.v1_0_3.SimpleStorage"/>
+    </Schema>
+
+    <Schema xmlns="http://docs.oasis-open.org/odata/ns/edm" Namespace="SimpleStorage.v1_0_5">
+      <Annotation Term="Redfish.OwningEntity" String="DMTF"/>
+      <Annotation Term="OData.Description" String="This version was created to force the regeneration of JSON Schema so that OData properties are marked as required, and integer properties are marked as integer rather than number."/>
+      <EntityType Name="SimpleStorage" BaseType="SimpleStorage.v1_0_4.SimpleStorage"/>
+    </Schema>
+
+    <Schema xmlns="http://docs.oasis-open.org/odata/ns/edm" Namespace="SimpleStorage.v1_0_6">
+      <Annotation Term="Redfish.OwningEntity" String="DMTF"/>
+      <Annotation Term="OData.Description" String="This version was created to force the regeneration of JSON Schema so that URI properties use the uri-reference format."/>
+      <EntityType Name="SimpleStorage" BaseType="SimpleStorage.v1_0_5.SimpleStorage"/>
+    </Schema>
+
+    <Schema xmlns="http://docs.oasis-open.org/odata/ns/edm" Namespace="SimpleStorage.v1_0_7">
+      <Annotation Term="Redfish.OwningEntity" String="DMTF"/>
+      <Annotation Term="OData.Description" String="This version was created to update descriptions that this schema defines."/>
+      <EntityType Name="SimpleStorage" BaseType="SimpleStorage.v1_0_6.SimpleStorage"/>
+    </Schema>
+
+    <Schema xmlns="http://docs.oasis-open.org/odata/ns/edm" Namespace="SimpleStorage.v1_0_8">
+      <Annotation Term="Redfish.OwningEntity" String="DMTF"/>
+      <Annotation Term="OData.Description" String="This version was created specify 64-bit integers in OpenAPI."/>
+      <EntityType Name="SimpleStorage" BaseType="SimpleStorage.v1_0_7.SimpleStorage"/>
+    </Schema>
+
+    <Schema xmlns="http://docs.oasis-open.org/odata/ns/edm" Namespace="SimpleStorage.v1_1_0">
+      <Annotation Term="Redfish.OwningEntity" String="DMTF"/>
+      <Annotation Term="Redfish.Release" String="2016.1"/>
+
+      <EntityType Name="SimpleStorage" BaseType="SimpleStorage.v1_0_2.SimpleStorage"/>
+
+      <ComplexType Name="Device" BaseType="SimpleStorage.v1_0_0.Device">
+        <Property Name="CapacityBytes" Type="Edm.Int64">
+          <Annotation Term="OData.Permissions" EnumMember="OData.Permission/Read"/>
+          <Annotation Term="OData.Description" String="The size, in bytes, of the storage device."/>
+          <Annotation Term="OData.LongDescription" String="This property shall represent the size, in bytes, of the storage device."/>
+          <Annotation Term="Validation.Minimum" Int="0"/>
+          <Annotation Term="Measures.Unit" String="By"/>
+        </Property>
+      </ComplexType>
+    </Schema>
+
+    <Schema xmlns="http://docs.oasis-open.org/odata/ns/edm" Namespace="SimpleStorage.v1_1_1">
+      <Annotation Term="Redfish.OwningEntity" String="DMTF"/>
+      <Annotation Term="OData.Description" String="This version was created to show that annotations in previous namespaces were updated."/>
+      <EntityType Name="SimpleStorage" BaseType="SimpleStorage.v1_1_0.SimpleStorage"/>
+    </Schema>
+
+    <Schema xmlns="http://docs.oasis-open.org/odata/ns/edm" Namespace="SimpleStorage.v1_1_2">
+      <Annotation Term="Redfish.OwningEntity" String="DMTF"/>
+      <Annotation Term="OData.Description" String="This version was created to show that annotations in previous namespaces were updated."/>
+      <EntityType Name="SimpleStorage" BaseType="SimpleStorage.v1_1_1.SimpleStorage"/>
+    </Schema>
+
+    <Schema xmlns="http://docs.oasis-open.org/odata/ns/edm" Namespace="SimpleStorage.v1_1_3">
+      <Annotation Term="Redfish.OwningEntity" String="DMTF"/>
+      <Annotation Term="OData.Description" String="This version was created to force the regeneration of JSON Schema so that OData properties are marked as required, and integer properties are marked as integer rather than number."/>
+      <EntityType Name="SimpleStorage" BaseType="SimpleStorage.v1_1_2.SimpleStorage"/>
+    </Schema>
+
+    <Schema xmlns="http://docs.oasis-open.org/odata/ns/edm" Namespace="SimpleStorage.v1_1_4">
+      <Annotation Term="Redfish.OwningEntity" String="DMTF"/>
+      <Annotation Term="OData.Description" String="This version was created to force the regeneration of JSON Schema so that URI properties use the uri-reference format."/>
+      <EntityType Name="SimpleStorage" BaseType="SimpleStorage.v1_1_3.SimpleStorage"/>
+    </Schema>
+
+    <Schema xmlns="http://docs.oasis-open.org/odata/ns/edm" Namespace="SimpleStorage.v1_1_5">
+      <Annotation Term="Redfish.OwningEntity" String="DMTF"/>
+      <Annotation Term="OData.Description" String="This version was created to update descriptions that this schema defines."/>
+      <EntityType Name="SimpleStorage" BaseType="SimpleStorage.v1_1_4.SimpleStorage"/>
+    </Schema>
+
+    <Schema xmlns="http://docs.oasis-open.org/odata/ns/edm" Namespace="SimpleStorage.v1_1_6">
+      <Annotation Term="Redfish.OwningEntity" String="DMTF"/>
+      <Annotation Term="OData.Description" String="This version was created specify 64-bit integers in OpenAPI."/>
+      <EntityType Name="SimpleStorage" BaseType="SimpleStorage.v1_1_5.SimpleStorage"/>
+    </Schema>
+
+    <Schema xmlns="http://docs.oasis-open.org/odata/ns/edm" Namespace="SimpleStorage.v1_2_0">
+      <Annotation Term="Redfish.OwningEntity" String="DMTF"/>
+      <Annotation Term="Redfish.Release" String="2017.1"/>
+
+      <EntityType Name="SimpleStorage" BaseType="SimpleStorage.v1_1_2.SimpleStorage">
+        <Property Name="Links" Type="SimpleStorage.v1_2_0.Links" Nullable="false">
+          <Annotation Term="OData.Description" String="The links to other Resources that are related to this Resource."/>
+          <Annotation Term="OData.LongDescription" String="The Redfish Specification-described Links Property shall contain links to Resources related to but not subordinate to this Resource."/>
+        </Property>
+        <Property Name="Actions" Type="SimpleStorage.v1_2_0.Actions" Nullable="false">
+          <Annotation Term="OData.Description" String="The available actions for this Resource."/>
+          <Annotation Term="OData.LongDescription" String="This property shall contain the available actions for this Resource."/>
+        </Property>
+      </EntityType>
+
+      <ComplexType Name="Links" BaseType="Resource.Links">
+        <Annotation Term="OData.Description" String="The links to other Resources that are related to this Resource."/>
+        <Annotation Term="OData.LongDescription" String="The Redfish Specification-described type shall contain links to Resources related to but not subordinate to this Resource."/>
+        <NavigationProperty Name="Chassis" Type="Chassis.Chassis" Nullable="false">
+          <Annotation Term="OData.Permissions" EnumMember="OData.Permission/Read"/>
+          <Annotation Term="OData.Description" String="The link to the chassis that contains this simple storage."/>
+          <Annotation Term="OData.LongDescription" String="This property shall contain a link to a Resource of type Chassis that represents the physical container associated with this Resource."/>
+          <Annotation Term="OData.AutoExpandReferences"/>
+        </NavigationProperty>
+      </ComplexType>
+
+      <ComplexType Name="Actions">
+        <Annotation Term="OData.AdditionalProperties" Bool="false"/>
+        <Annotation Term="OData.Description" String="The available actions for this Resource."/>
+        <Annotation Term="OData.LongDescription" String="This type shall contain the available actions for this Resource."/>
+        <Property Name="Oem" Type="SimpleStorage.v1_2_0.OemActions" Nullable="false">
+          <Annotation Term="OData.Description" String="The available OEM-specific actions for this Resource."/>
+          <Annotation Term="OData.LongDescription" String="This property shall contain the available OEM-specific actions for this Resource."/>
+        </Property>
+      </ComplexType>
+
+      <ComplexType Name="OemActions">
+        <Annotation Term="OData.AdditionalProperties" Bool="true"/>
+        <Annotation Term="OData.Description" String="The available OEM-specific actions for this Resource."/>
+        <Annotation Term="OData.LongDescription" String="This type shall contain the available OEM-specific actions for this Resource."/>
+      </ComplexType>
+    </Schema>
+
+    <Schema xmlns="http://docs.oasis-open.org/odata/ns/edm" Namespace="SimpleStorage.v1_2_1">
+      <Annotation Term="Redfish.OwningEntity" String="DMTF"/>
+      <Annotation Term="OData.Description" String="This version was created to force the regeneration of JSON Schema so that OData properties are marked as required, and integer properties are marked as integer rather than number."/>
+      <EntityType Name="SimpleStorage" BaseType="SimpleStorage.v1_2_0.SimpleStorage"/>
+    </Schema>
+
+    <Schema xmlns="http://docs.oasis-open.org/odata/ns/edm" Namespace="SimpleStorage.v1_2_2">
+      <Annotation Term="Redfish.OwningEntity" String="DMTF"/>
+      <Annotation Term="OData.Description" String="This version was created to force the regeneration of JSON Schema so that URI properties use the uri-reference format."/>
+      <EntityType Name="SimpleStorage" BaseType="SimpleStorage.v1_2_1.SimpleStorage"/>
+    </Schema>
+
+    <Schema xmlns="http://docs.oasis-open.org/odata/ns/edm" Namespace="SimpleStorage.v1_2_3">
+      <Annotation Term="Redfish.OwningEntity" String="DMTF"/>
+      <Annotation Term="OData.Description" String="This version was created to update descriptions that this schema defines."/>
+      <EntityType Name="SimpleStorage" BaseType="SimpleStorage.v1_2_2.SimpleStorage"/>
+    </Schema>
+
+    <Schema xmlns="http://docs.oasis-open.org/odata/ns/edm" Namespace="SimpleStorage.v1_2_4">
+      <Annotation Term="Redfish.OwningEntity" String="DMTF"/>
+      <Annotation Term="OData.Description" String="This version was created specify 64-bit integers in OpenAPI."/>
+      <EntityType Name="SimpleStorage" BaseType="SimpleStorage.v1_2_3.SimpleStorage"/>
+    </Schema>
+
+    <Schema xmlns="http://docs.oasis-open.org/odata/ns/edm" Namespace="SimpleStorage.v1_3_0">
+      <Annotation Term="Redfish.OwningEntity" String="DMTF"/>
+      <Annotation Term="Redfish.Release" String="2020.3"/>
+
+      <EntityType Name="SimpleStorage" BaseType="SimpleStorage.v1_2_3.SimpleStorage"/>
+
+      <ComplexType Name="Links" BaseType="SimpleStorage.v1_2_0.Links">
+        <NavigationProperty Name="Storage" Type="Storage.Storage" Nullable="false">
+          <Annotation Term="OData.Permissions" EnumMember="OData.Permission/Read"/>
+          <Annotation Term="OData.Description" String="The link to the storage instance that corresponds to this simple storage."/>
+          <Annotation Term="OData.LongDescription" String="This property shall contain a link to a Resource of type Storage that represents the same storage subsystem as this Resource."/>
+          <Annotation Term="OData.AutoExpandReferences"/>
+        </NavigationProperty>
+      </ComplexType>
+    </Schema>
+
+    <Schema xmlns="http://docs.oasis-open.org/odata/ns/edm" Namespace="SimpleStorage.v1_3_1">
+      <Annotation Term="Redfish.OwningEntity" String="DMTF"/>
+      <Annotation Term="OData.Description" String="This version was created specify 64-bit integers in OpenAPI."/>
+      <EntityType Name="SimpleStorage" BaseType="SimpleStorage.v1_3_0.SimpleStorage"/>
+    </Schema>
+
+  </edmx:DataServices>
+</edmx:Edmx>

--- a/static/redfish/v1/schema/SwitchCollection_v1.xml
+++ b/static/redfish/v1/schema/SwitchCollection_v1.xml
@@ -1,0 +1,69 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!---->
+<!--################################################################################       -->
+<!--# Redfish Schema:  SwitchCollection                                                    -->
+<!--#                                                                                      -->
+<!--# For a detailed change log, see the README file contained in the DSP8010 bundle,      -->
+<!--# available at http://www.dmtf.org/standards/redfish                                   -->
+<!--# Copyright 2014-2021 DMTF.                                                            -->
+<!--# For the full DMTF copyright policy, see http://www.dmtf.org/about/policies/copyright -->
+<!--################################################################################       -->
+<!---->
+<edmx:Edmx xmlns:edmx="http://docs.oasis-open.org/odata/ns/edmx" Version="4.0">
+
+  <edmx:Reference Uri="http://docs.oasis-open.org/odata/odata/v4.0/errata03/csd01/complete/vocabularies/Org.OData.Core.V1.xml">
+    <edmx:Include Namespace="Org.OData.Core.V1" Alias="OData"/>
+  </edmx:Reference>
+  <edmx:Reference Uri="http://docs.oasis-open.org/odata/odata/v4.0/errata03/csd01/complete/vocabularies/Org.OData.Capabilities.V1.xml">
+    <edmx:Include Namespace="Org.OData.Capabilities.V1" Alias="Capabilities"/>
+  </edmx:Reference>
+  <edmx:Reference Uri="http://redfish.dmtf.org/schemas/v1/Resource_v1.xml">
+    <edmx:Include Namespace="Resource.v1_0_0"/>
+  </edmx:Reference>
+  <edmx:Reference Uri="http://redfish.dmtf.org/schemas/v1/RedfishExtensions_v1.xml">
+    <edmx:Include Namespace="RedfishExtensions.v1_0_0" Alias="Redfish"/>
+  </edmx:Reference>
+  <edmx:Reference Uri="http://redfish.dmtf.org/schemas/v1/Switch_v1.xml">
+    <edmx:Include Namespace="Switch"/>
+  </edmx:Reference>
+
+  <edmx:DataServices>
+
+    <Schema xmlns="http://docs.oasis-open.org/odata/ns/edm" Namespace="SwitchCollection">
+      <Annotation Term="Redfish.OwningEntity" String="DMTF"/>
+
+      <EntityType Name="SwitchCollection" BaseType="Resource.v1_0_0.ResourceCollection">
+        <Annotation Term="OData.Description" String="The collection of Switch resource instances."/>
+        <Annotation Term="OData.LongDescription" String="This resource shall represent a resource collection of Switch instances for a Redfish implementation."/>
+        <Annotation Term="Capabilities.InsertRestrictions">
+          <Record>
+            <PropertyValue Property="Insertable" Bool="false"/>
+          </Record>
+        </Annotation>
+        <Annotation Term="Capabilities.UpdateRestrictions">
+          <Record>
+            <PropertyValue Property="Updatable" Bool="false"/>
+          </Record>
+        </Annotation>
+        <Annotation Term="Capabilities.DeleteRestrictions">
+          <Record>
+            <PropertyValue Property="Deletable" Bool="false"/>
+          </Record>
+        </Annotation>
+        <Annotation Term="Redfish.Uris">
+          <Collection>
+            <String>/redfish/v1/Fabrics/{FabricId}/Switches</String>
+          </Collection>
+        </Annotation>
+        <NavigationProperty Name="Members" Type="Collection(Switch.Switch)">
+          <Annotation Term="OData.Permissions" EnumMember="OData.Permission/Read"/>
+          <Annotation Term="OData.Description" String="The members of this collection."/>
+          <Annotation Term="OData.LongDescription" String="This property shall contain an array of links to the members of this collection."/>
+          <Annotation Term="OData.AutoExpandReferences"/>
+          <Annotation Term="Redfish.Required"/>
+        </NavigationProperty>
+      </EntityType>
+    </Schema>
+
+  </edmx:DataServices>
+</edmx:Edmx>

--- a/static/redfish/v1/schema/Switch_v1.xml
+++ b/static/redfish/v1/schema/Switch_v1.xml
@@ -1,0 +1,517 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!---->
+<!--################################################################################       -->
+<!--# Redfish Schema:  Switch v1.6.0                                                       -->
+<!--#                                                                                      -->
+<!--# For a detailed change log, see the README file contained in the DSP8010 bundle,      -->
+<!--# available at http://www.dmtf.org/standards/redfish                                   -->
+<!--# Copyright 2014-2021 DMTF.                                                            -->
+<!--# For the full DMTF copyright policy, see http://www.dmtf.org/about/policies/copyright -->
+<!--################################################################################       -->
+<!---->
+<edmx:Edmx xmlns:edmx="http://docs.oasis-open.org/odata/ns/edmx" Version="4.0">
+
+  <edmx:Reference Uri="http://docs.oasis-open.org/odata/odata/v4.0/errata03/csd01/complete/vocabularies/Org.OData.Core.V1.xml">
+    <edmx:Include Namespace="Org.OData.Core.V1" Alias="OData"/>
+  </edmx:Reference>
+  <edmx:Reference Uri="http://docs.oasis-open.org/odata/odata/v4.0/errata03/csd01/complete/vocabularies/Org.OData.Capabilities.V1.xml">
+    <edmx:Include Namespace="Org.OData.Capabilities.V1" Alias="Capabilities"/>
+  </edmx:Reference>
+  <edmx:Reference Uri="http://docs.oasis-open.org/odata/odata/v4.0/errata03/csd01/complete/vocabularies/Org.OData.Measures.V1.xml">
+    <edmx:Include Namespace="Org.OData.Measures.V1" Alias="Measures"/>
+  </edmx:Reference>
+  <edmx:Reference Uri="http://redfish.dmtf.org/schemas/v1/Resource_v1.xml">
+    <edmx:Include Namespace="Resource"/>
+    <edmx:Include Namespace="Resource.v1_0_0"/>
+  </edmx:Reference>
+  <edmx:Reference Uri="http://redfish.dmtf.org/schemas/v1/RedfishExtensions_v1.xml">
+    <edmx:Include Namespace="RedfishExtensions.v1_0_0" Alias="Redfish"/>
+  </edmx:Reference>
+  <edmx:Reference Uri="http://redfish.dmtf.org/schemas/v1/Chassis_v1.xml">
+    <edmx:Include Namespace="Chassis"/>
+  </edmx:Reference>
+  <edmx:Reference Uri="http://redfish.dmtf.org/schemas/v1/Manager_v1.xml">
+    <edmx:Include Namespace="Manager"/>
+  </edmx:Reference>
+  <edmx:Reference Uri="http://redfish.dmtf.org/schemas/v1/Redundancy_v1.xml">
+    <edmx:Include Namespace="Redundancy"/>
+  </edmx:Reference>
+  <edmx:Reference Uri="http://redfish.dmtf.org/schemas/v1/PortCollection_v1.xml">
+    <edmx:Include Namespace="PortCollection"/>
+  </edmx:Reference>
+  <edmx:Reference Uri="http://redfish.dmtf.org/schemas/v1/LogServiceCollection_v1.xml">
+    <edmx:Include Namespace="LogServiceCollection"/>
+  </edmx:Reference>
+  <edmx:Reference Uri="http://redfish.dmtf.org/schemas/v1/Protocol_v1.xml">
+    <edmx:Include Namespace="Protocol"/>
+  </edmx:Reference>
+  <edmx:Reference Uri="http://redfish.dmtf.org/schemas/v1/Endpoint_v1.xml">
+    <edmx:Include Namespace="Endpoint"/>
+  </edmx:Reference>
+  <edmx:Reference Uri="http://redfish.dmtf.org/schemas/v1/PCIeDevice_v1.xml">
+    <edmx:Include Namespace="PCIeDevice"/>
+  </edmx:Reference>
+  <edmx:Reference Uri="http://redfish.dmtf.org/schemas/v1/CertificateCollection_v1.xml">
+    <edmx:Include Namespace="CertificateCollection"/>
+  </edmx:Reference>
+  <edmx:Reference Uri="http://redfish.dmtf.org/schemas/v1/SoftwareInventory_v1.xml">
+    <edmx:Include Namespace="SoftwareInventory"/>
+  </edmx:Reference>
+  <edmx:Reference Uri="http://redfish.dmtf.org/schemas/v1/EnvironmentMetrics_v1.xml">
+    <edmx:Include Namespace="EnvironmentMetrics"/>
+  </edmx:Reference>
+
+  <edmx:DataServices>
+
+    <Schema xmlns="http://docs.oasis-open.org/odata/ns/edm" Namespace="Switch">
+      <Annotation Term="Redfish.OwningEntity" String="DMTF"/>
+
+      <EntityType Name="Switch" BaseType="Resource.v1_0_0.Resource" Abstract="true">
+        <Annotation Term="OData.Description" String="The Switch schema contains properties that describe a fabric switch."/>
+        <Annotation Term="OData.LongDescription" String="This resource contains a switch for a Redfish implementation."/>
+        <Annotation Term="Capabilities.InsertRestrictions">
+          <Record>
+            <PropertyValue Property="Insertable" Bool="false"/>
+          </Record>
+        </Annotation>
+        <Annotation Term="Capabilities.UpdateRestrictions">
+          <Record>
+            <PropertyValue Property="Updatable" Bool="true"/>
+            <Annotation Term="OData.Description" String="Any writable properties, such as AssetTag, can be updated for switches."/>
+          </Record>
+        </Annotation>
+        <Annotation Term="Capabilities.DeleteRestrictions">
+          <Record>
+            <PropertyValue Property="Deletable" Bool="false"/>
+          </Record>
+        </Annotation>
+        <Annotation Term="Redfish.Uris">
+          <Collection>
+            <String>/redfish/v1/Fabrics/{FabricId}/Switches/{SwitchId}</String>
+          </Collection>
+        </Annotation>
+      </EntityType>
+
+      <Action Name="Reset" IsBound="true">
+        <Annotation Term="OData.Description" String="This action resets this switch."/>
+        <Annotation Term="OData.LongDescription" String="This action shall reset this switch."/>
+        <Parameter Name="Switch" Type="Switch.v1_0_0.Actions"/>
+        <Parameter Name="ResetType" Type="Resource.ResetType">
+          <Annotation Term="OData.Description" String="The type of reset."/>
+          <Annotation Term="OData.LongDescription" String="This parameter shall contain the type of reset.  The service can accept a request without this parameter and can complete an implementation-specific default reset."/>
+        </Parameter>
+      </Action>
+    </Schema>
+
+    <Schema xmlns="http://docs.oasis-open.org/odata/ns/edm" Namespace="Switch.v1_0_0">
+      <Annotation Term="Redfish.OwningEntity" String="DMTF"/>
+      <Annotation Term="Redfish.Release" String="2016.2"/>
+
+      <EntityType Name="Switch" BaseType="Switch.Switch">
+        <Property Name="SwitchType" Type="Protocol.Protocol">
+          <Annotation Term="OData.Permissions" EnumMember="OData.Permission/Read"/>
+          <Annotation Term="OData.Description" String="The protocol being sent over this switch."/>
+          <Annotation Term="OData.LongDescription" String="This property shall contain the protocol being sent over this switch.  For a switch that supports multiple protocols, the value should be `MultiProtocol` and the SupportedProtocols property should be used to describe the supported protocols."/>
+        </Property>
+        <Property Name="Status" Type="Resource.Status" Nullable="false">
+          <Annotation Term="OData.Description" String="The status and health of the resource and its subordinate or dependent resources."/>
+          <Annotation Term="OData.LongDescription" String="This property shall contain any status or health properties of the resource."/>
+        </Property>
+        <Property Name="Manufacturer" Type="Edm.String">
+          <Annotation Term="OData.Permissions" EnumMember="OData.Permission/Read"/>
+          <Annotation Term="OData.Description" String="The manufacturer of this switch."/>
+          <Annotation Term="OData.LongDescription" String="This property shall contain the name of the organization responsible for producing the switch.  This organization may be the entity from which the switch is purchased, but this is not necessarily true."/>
+        </Property>
+        <Property Name="Model" Type="Edm.String">
+          <Annotation Term="OData.Permissions" EnumMember="OData.Permission/Read"/>
+          <Annotation Term="OData.Description" String="The product model number of this switch."/>
+          <Annotation Term="OData.LongDescription" String="This property shall contain the manufacturer-provided model information of this switch."/>
+        </Property>
+        <Property Name="SKU" Type="Edm.String">
+          <Annotation Term="OData.Permissions" EnumMember="OData.Permission/Read"/>
+          <Annotation Term="OData.Description" String="The SKU for this switch."/>
+          <Annotation Term="OData.LongDescription" String="This property shall contain the SKU number for this switch."/>
+        </Property>
+        <Property Name="SerialNumber" Type="Edm.String">
+          <Annotation Term="OData.Permissions" EnumMember="OData.Permission/Read"/>
+          <Annotation Term="OData.Description" String="The serial number for this switch."/>
+          <Annotation Term="OData.LongDescription" String="This property shall contain a manufacturer-allocated number that identifies the switch."/>
+        </Property>
+        <Property Name="PartNumber" Type="Edm.String">
+          <Annotation Term="OData.Permissions" EnumMember="OData.Permission/Read"/>
+          <Annotation Term="OData.Description" String="The part number for this switch."/>
+          <Annotation Term="OData.LongDescription" String="This property shall contain the manufacturer-provided part number for the switch."/>
+        </Property>
+        <Property Name="AssetTag" Type="Edm.String">
+          <Annotation Term="OData.Permissions" EnumMember="OData.Permission/ReadWrite"/>
+          <Annotation Term="OData.Description" String="The user-assigned asset tag for this switch."/>
+          <Annotation Term="OData.LongDescription" String="This property shall contain the user-assigned asset tag, which is an identifying string that tracks the drive for inventory purposes."/>
+        </Property>
+        <Property Name="DomainID" Type="Edm.Int64">
+          <Annotation Term="OData.Permissions" EnumMember="OData.Permission/Read"/>
+          <Annotation Term="OData.Description" String="The domain ID for this switch."/>
+          <Annotation Term="OData.LongDescription" String="This property shall contain The domain ID for this switch.  This property has a scope of uniqueness within the fabric of which the switch is a member."/>
+        </Property>
+        <Property Name="IsManaged" Type="Edm.Boolean">
+          <Annotation Term="OData.Permissions" EnumMember="OData.Permission/ReadWrite"/>
+          <Annotation Term="OData.Description" String="An indication of whether the switch is in a managed or unmanaged state."/>
+          <Annotation Term="OData.LongDescription" String="This property shall indicate whether this switch is in a managed or unmanaged state."/>
+        </Property>
+        <Property Name="TotalSwitchWidth" Type="Edm.Int64">
+          <Annotation Term="OData.Permissions" EnumMember="OData.Permission/Read"/>
+          <Annotation Term="OData.Description" String="The total number of lanes, phys, or other physical transport links that this switch contains."/>
+          <Annotation Term="OData.LongDescription" String="This property shall contain the number of physical transport lanes, phys, or other physical transport links that this switch contains.  For PCIe, this value shall be the lane count."/>
+        </Property>
+        <Property Name="IndicatorLED" Type="Resource.IndicatorLED">
+          <Annotation Term="OData.Permissions" EnumMember="OData.Permission/ReadWrite"/>
+          <Annotation Term="OData.Description" String="The state of the indicator LED, which identifies the switch."/>
+          <Annotation Term="OData.LongDescription" String="This property shall contain the state of the indicator light associated with this switch."/>
+          <Annotation Term="Redfish.Revisions">
+            <Collection>
+              <Record>
+                <PropertyValue Property="Kind" EnumMember="Redfish.RevisionKind/Deprecated"/>
+                <PropertyValue Property="Version" String="v1_4_0"/>
+                <PropertyValue Property="Description" String="This property has been deprecated in favor of the LocationIndicatorActive property."/>
+              </Record>
+            </Collection>
+          </Annotation>
+        </Property>
+        <Property Name="PowerState" Type="Resource.PowerState">
+          <Annotation Term="OData.Permissions" EnumMember="OData.Permission/Read"/>
+          <Annotation Term="OData.Description" String="The current power state of the switch."/>
+          <Annotation Term="OData.LongDescription" String="This property shall contain the power state of the switch."/>
+        </Property>
+        <NavigationProperty Name="Ports" Type="PortCollection.PortCollection" ContainsTarget="true" Nullable="false">
+          <Annotation Term="OData.Permissions" EnumMember="OData.Permission/Read"/>
+          <Annotation Term="OData.Description" String="The link to the collection ports for this switch."/>
+          <Annotation Term="OData.LongDescription" String="This property shall contain a link to a resource collection of type PortCollection."/>
+          <Annotation Term="OData.AutoExpandReferences"/>
+        </NavigationProperty>
+        <NavigationProperty Name="Redundancy" Type="Collection(Redundancy.Redundancy)" ContainsTarget="true">
+          <Annotation Term="OData.Description" String="Redundancy information for the switches."/>
+          <Annotation Term="OData.LongDescription" String="This property shall contain an array that shows how this switch is grouped with other switches for form redundancy sets."/>
+          <Annotation Term="OData.AutoExpand"/>
+        </NavigationProperty>
+        <Property Name="Links" Type="Switch.v1_0_0.Links" Nullable="false">
+          <Annotation Term="OData.Description" String="The links to other resources that are related to this resource."/>
+          <Annotation Term="OData.LongDescription" String="This property shall contain links to resources that are related to but are not contained by, or subordinate to, this resource."/>
+        </Property>
+        <NavigationProperty Name="LogServices" Type="LogServiceCollection.LogServiceCollection" ContainsTarget="true" Nullable="false">
+          <Annotation Term="OData.Permissions" EnumMember="OData.Permission/Read"/>
+          <Annotation Term="OData.Description" String="The link to the collection of log services associated with this switch."/>
+          <Annotation Term="OData.LongDescription" String="This property shall contain a link to a resource collection of type LogServiceCollection."/>
+          <Annotation Term="OData.AutoExpandReferences"/>
+        </NavigationProperty>
+        <Property Name="Actions" Type="Switch.v1_0_0.Actions" Nullable="false">
+          <Annotation Term="OData.Description" String="The available actions for this resource."/>
+          <Annotation Term="OData.LongDescription" String="This property shall contain the available actions for this resource."/>
+        </Property>
+      </EntityType>
+
+      <ComplexType Name="Links" BaseType="Resource.Links">
+        <Annotation Term="OData.Description" String="The links to other resources that are related to this resource."/>
+        <Annotation Term="OData.LongDescription" String="This Redfish Specification-described type shall contain links to resources that are related to but are not contained by, or subordinate to, this resource."/>
+        <NavigationProperty Name="Chassis" Type="Chassis.Chassis" Nullable="false">
+          <Annotation Term="OData.Permissions" EnumMember="OData.Permission/Read"/>
+          <Annotation Term="OData.Description" String="The link to the chassis that contains this switch."/>
+          <Annotation Term="OData.LongDescription" String="This property shall contain a link to a resource of type Chassis with which this switch is associated."/>
+          <Annotation Term="OData.AutoExpandReferences"/>
+        </NavigationProperty>
+        <NavigationProperty Name="ManagedBy" Type="Collection(Manager.Manager)">
+          <Annotation Term="OData.Permissions" EnumMember="OData.Permission/Read"/>
+          <Annotation Term="OData.Description" String="An array of links to the managers that manage this switch."/>
+          <Annotation Term="OData.LongDescription" String="This property shall contain an array of links to resources of type Manager with which this switch is associated."/>
+          <Annotation Term="OData.AutoExpandReferences"/>
+        </NavigationProperty>
+      </ComplexType>
+
+      <ComplexType Name="Actions">
+        <Annotation Term="OData.AdditionalProperties" Bool="false"/>
+        <Annotation Term="OData.Description" String="The available actions for this resource."/>
+        <Annotation Term="OData.LongDescription" String="This type shall contain the available actions for this resource."/>
+        <Property Name="Oem" Type="Switch.v1_0_0.OemActions" Nullable="false">
+          <Annotation Term="OData.Description" String="The available OEM-specific actions for this resource."/>
+          <Annotation Term="OData.LongDescription" String="This property shall contain the available OEM-specific actions for this resource."/>
+        </Property>
+      </ComplexType>
+
+      <ComplexType Name="OemActions">
+        <Annotation Term="OData.AdditionalProperties" Bool="true"/>
+        <Annotation Term="OData.Description" String="The available OEM-specific actions for this resource."/>
+        <Annotation Term="OData.LongDescription" String="This type shall contain the available OEM-specific actions for this resource."/>
+      </ComplexType>
+    </Schema>
+
+    <Schema xmlns="http://docs.oasis-open.org/odata/ns/edm" Namespace="Switch.v1_0_1">
+      <Annotation Term="Redfish.OwningEntity" String="DMTF"/>
+      <Annotation Term="OData.Description" String="This version was created to show that annotations in previous namespaces were updated."/>
+      <EntityType Name="Switch" BaseType="Switch.v1_0_0.Switch"/>
+    </Schema>
+
+    <Schema xmlns="http://docs.oasis-open.org/odata/ns/edm" Namespace="Switch.v1_0_2">
+      <Annotation Term="Redfish.OwningEntity" String="DMTF"/>
+      <Annotation Term="OData.Description" String="This version was created to remove the Nullable facet on NavigationProperties of the Collection type."/>
+      <EntityType Name="Switch" BaseType="Switch.v1_0_1.Switch"/>
+    </Schema>
+
+    <Schema xmlns="http://docs.oasis-open.org/odata/ns/edm" Namespace="Switch.v1_0_3">
+      <Annotation Term="Redfish.OwningEntity" String="DMTF"/>
+      <Annotation Term="OData.Description" String="This version was created to change IndicatorLED, PowerState, and Protocol to use the unversioned definition, and correct the short and long descriptions in the defined actions."/>
+      <EntityType Name="Switch" BaseType="Switch.v1_0_2.Switch"/>
+    </Schema>
+
+    <Schema xmlns="http://docs.oasis-open.org/odata/ns/edm" Namespace="Switch.v1_0_4">
+      <Annotation Term="Redfish.OwningEntity" String="DMTF"/>
+      <Annotation Term="OData.Description" String="This version was created to force the regeneration of JSON Schema so that OData properties are marked as required, and integer properties are marked as integer rather than number."/>
+      <EntityType Name="Switch" BaseType="Switch.v1_0_3.Switch"/>
+    </Schema>
+
+    <Schema xmlns="http://docs.oasis-open.org/odata/ns/edm" Namespace="Switch.v1_0_5">
+      <Annotation Term="Redfish.OwningEntity" String="DMTF"/>
+      <Annotation Term="OData.Description" String="This version was created to force the regeneration of JSON Schema so that URI properties use the uri-reference format, and to add a missing term to the LogServices property to disallow it from being `null`."/>
+      <EntityType Name="Switch" BaseType="Switch.v1_0_4.Switch"/>
+    </Schema>
+
+    <Schema xmlns="http://docs.oasis-open.org/odata/ns/edm" Namespace="Switch.v1_0_6">
+      <Annotation Term="Redfish.OwningEntity" String="DMTF"/>
+      <Annotation Term="OData.Description" String="This version was created to update descriptions that this schema defines."/>
+      <EntityType Name="Switch" BaseType="Switch.v1_0_5.Switch"/>
+    </Schema>
+
+    <Schema xmlns="http://docs.oasis-open.org/odata/ns/edm" Namespace="Switch.v1_0_7">
+      <Annotation Term="Redfish.OwningEntity" String="DMTF"/>
+      <Annotation Term="OData.Description" String="This version was created to correct various typographical errors."/>
+      <EntityType Name="Switch" BaseType="Switch.v1_0_6.Switch"/>
+    </Schema>
+
+    <Schema xmlns="http://docs.oasis-open.org/odata/ns/edm" Namespace="Switch.v1_0_8">
+      <Annotation Term="Redfish.OwningEntity" String="DMTF"/>
+      <Annotation Term="OData.Description" String="This version was created specify 64-bit integers in OpenAPI."/>
+      <EntityType Name="Switch" BaseType="Switch.v1_0_7.Switch"/>
+    </Schema>
+
+    <Schema xmlns="http://docs.oasis-open.org/odata/ns/edm" Namespace="Switch.v1_0_9">
+      <Annotation Term="Redfish.OwningEntity" String="DMTF"/>
+      <Annotation Term="OData.Description" String="This version was created to correct various description to use proper normative terminology."/>
+      <EntityType Name="Switch" BaseType="Switch.v1_0_8.Switch"/>
+    </Schema>
+
+    <Schema xmlns="http://docs.oasis-open.org/odata/ns/edm" Namespace="Switch.v1_1_0">
+      <Annotation Term="Redfish.OwningEntity" String="DMTF"/>
+      <Annotation Term="Redfish.Release" String="2017.3"/>
+
+      <EntityType Name="Switch" BaseType="Switch.v1_0_3.Switch">
+        <Property Name="Location" Type="Resource.Location" Nullable="false">
+          <Annotation Term="OData.Description" String="The location of the switch."/>
+          <Annotation Term="OData.LongDescription" String="This property shall contain location information of the associated switch."/>
+        </Property>
+      </EntityType>
+    </Schema>
+
+    <Schema xmlns="http://docs.oasis-open.org/odata/ns/edm" Namespace="Switch.v1_1_1">
+      <Annotation Term="Redfish.OwningEntity" String="DMTF"/>
+      <Annotation Term="OData.Description" String="This version was created to force the regeneration of JSON Schema so that OData properties are marked as required, and integer properties are marked as integer rather than number."/>
+      <EntityType Name="Switch" BaseType="Switch.v1_1_0.Switch"/>
+    </Schema>
+
+    <Schema xmlns="http://docs.oasis-open.org/odata/ns/edm" Namespace="Switch.v1_1_2">
+      <Annotation Term="Redfish.OwningEntity" String="DMTF"/>
+      <Annotation Term="OData.Description" String="This version was created to force the regeneration of JSON Schema so that URI properties use the uri-reference format, and to add a missing term to the LogServices property to disallow it from being null."/>
+      <EntityType Name="Switch" BaseType="Switch.v1_1_1.Switch"/>
+    </Schema>
+
+    <Schema xmlns="http://docs.oasis-open.org/odata/ns/edm" Namespace="Switch.v1_1_3">
+      <Annotation Term="Redfish.OwningEntity" String="DMTF"/>
+      <Annotation Term="OData.Description" String="This version was created to update descriptions that this schema defines."/>
+      <EntityType Name="Switch" BaseType="Switch.v1_1_2.Switch"/>
+    </Schema>
+
+    <Schema xmlns="http://docs.oasis-open.org/odata/ns/edm" Namespace="Switch.v1_1_4">
+      <Annotation Term="Redfish.OwningEntity" String="DMTF"/>
+      <Annotation Term="OData.Description" String="This version was created to correct various typographical errors."/>
+      <EntityType Name="Switch" BaseType="Switch.v1_1_3.Switch"/>
+    </Schema>
+
+    <Schema xmlns="http://docs.oasis-open.org/odata/ns/edm" Namespace="Switch.v1_1_5">
+      <Annotation Term="Redfish.OwningEntity" String="DMTF"/>
+      <Annotation Term="OData.Description" String="This version was created specify 64-bit integers in OpenAPI."/>
+      <EntityType Name="Switch" BaseType="Switch.v1_1_4.Switch"/>
+    </Schema>
+
+    <Schema xmlns="http://docs.oasis-open.org/odata/ns/edm" Namespace="Switch.v1_1_6">
+      <Annotation Term="Redfish.OwningEntity" String="DMTF"/>
+      <Annotation Term="OData.Description" String="This version was created to correct various description to use proper normative terminology."/>
+      <EntityType Name="Switch" BaseType="Switch.v1_1_5.Switch"/>
+    </Schema>
+
+    <Schema xmlns="http://docs.oasis-open.org/odata/ns/edm" Namespace="Switch.v1_2_0">
+      <Annotation Term="Redfish.OwningEntity" String="DMTF"/>
+      <Annotation Term="Redfish.Release" String="2019.2"/>
+
+      <EntityType Name="Switch" BaseType="Switch.v1_1_3.Switch">
+        <Property Name="FirmwareVersion" Type="Edm.String">
+          <Annotation Term="OData.Permissions" EnumMember="OData.Permission/Read"/>
+          <Annotation Term="OData.Description" String="The firmware version of this switch."/>
+          <Annotation Term="OData.LongDescription" String="This property shall contain the firmware version as defined by the manufacturer for the associated switch."/>
+        </Property>
+      </EntityType>
+    </Schema>
+
+    <Schema xmlns="http://docs.oasis-open.org/odata/ns/edm" Namespace="Switch.v1_2_1">
+      <Annotation Term="Redfish.OwningEntity" String="DMTF"/>
+      <Annotation Term="OData.Description" String="This version was created to correct various typographical errors."/>
+      <EntityType Name="Switch" BaseType="Switch.v1_2_0.Switch"/>
+    </Schema>
+
+    <Schema xmlns="http://docs.oasis-open.org/odata/ns/edm" Namespace="Switch.v1_2_2">
+      <Annotation Term="Redfish.OwningEntity" String="DMTF"/>
+      <Annotation Term="OData.Description" String="This version was created to correct various typographical errors."/>
+      <EntityType Name="Switch" BaseType="Switch.v1_2_1.Switch"/>
+    </Schema>
+
+    <Schema xmlns="http://docs.oasis-open.org/odata/ns/edm" Namespace="Switch.v1_2_3">
+      <Annotation Term="Redfish.OwningEntity" String="DMTF"/>
+      <Annotation Term="OData.Description" String="This version was created to correct various description to use proper normative terminology."/>
+      <EntityType Name="Switch" BaseType="Switch.v1_2_2.Switch"/>
+    </Schema>
+
+    <Schema xmlns="http://docs.oasis-open.org/odata/ns/edm" Namespace="Switch.v1_3_0">
+      <Annotation Term="Redfish.OwningEntity" String="DMTF"/>
+      <Annotation Term="Redfish.Release" String="2019.4"/>
+
+      <EntityType Name="Switch" BaseType="Switch.v1_2_0.Switch">
+        <Property Name="SupportedProtocols" Type="Collection(Protocol.Protocol)" Nullable="false">
+          <Annotation Term="OData.Permissions" EnumMember="OData.Permission/Read"/>
+          <Annotation Term="OData.Description" String="The protocols this switch supports."/>
+          <Annotation Term="OData.LongDescription" String="The property shall contain an array of protocols this switch supports.  If the value of SwitchType is `MultiProtocol`, this property shall be required."/>
+        </Property>
+        <Property Name="UUID" Type="Resource.UUID">
+          <Annotation Term="OData.Permissions" EnumMember="OData.Permission/Read"/>
+          <Annotation Term="OData.Description" String="The UUID for this switch."/>
+          <Annotation Term="OData.LongDescription" String="This property shall contain a universal unique identifier number for the switch."/>
+        </Property>
+      </EntityType>
+
+      <ComplexType Name="Links" BaseType="Switch.v1_0_0.Links">
+        <NavigationProperty Name="Endpoints" Type="Collection(Endpoint.Endpoint)">
+          <Annotation Term="OData.Permissions" EnumMember="OData.Permission/Read"/>
+          <Annotation Term="OData.Description" String="An array of links to the endpoints that connect to this switch."/>
+          <Annotation Term="OData.LongDescription" String="This property shall contain an array of links to resources of type Endpoint with which this switch is associated."/>
+          <Annotation Term="OData.AutoExpandReferences"/>
+        </NavigationProperty>
+      </ComplexType>
+    </Schema>
+
+    <Schema xmlns="http://docs.oasis-open.org/odata/ns/edm" Namespace="Switch.v1_3_1">
+      <Annotation Term="Redfish.OwningEntity" String="DMTF"/>
+      <Annotation Term="OData.Description" String="This version was created to correct various typographical errors."/>
+      <EntityType Name="Switch" BaseType="Switch.v1_3_0.Switch"/>
+    </Schema>
+
+    <Schema xmlns="http://docs.oasis-open.org/odata/ns/edm" Namespace="Switch.v1_3_2">
+      <Annotation Term="Redfish.OwningEntity" String="DMTF"/>
+      <Annotation Term="OData.Description" String="This version was created to correct various typographical errors."/>
+      <EntityType Name="Switch" BaseType="Switch.v1_3_1.Switch"/>
+    </Schema>
+
+    <Schema xmlns="http://docs.oasis-open.org/odata/ns/edm" Namespace="Switch.v1_3_3">
+      <Annotation Term="Redfish.OwningEntity" String="DMTF"/>
+      <Annotation Term="OData.Description" String="This version was created to correct various description to use proper normative terminology."/>
+      <EntityType Name="Switch" BaseType="Switch.v1_3_2.Switch"/>
+    </Schema>
+
+    <Schema xmlns="http://docs.oasis-open.org/odata/ns/edm" Namespace="Switch.v1_4_0">
+      <Annotation Term="Redfish.OwningEntity" String="DMTF"/>
+      <Annotation Term="Redfish.Release" String="2020.3"/>
+      <Annotation Term="OData.Description" String="This version was created to add LocationIndicatorActive, CurrentBandwidthGbps, and MaxBandwidthGbps.  It was also created to deprecate IndicatorLED properties."/>
+
+      <EntityType Name="Switch" BaseType="Switch.v1_3_1.Switch">
+        <Property Name="LocationIndicatorActive" Type="Edm.Boolean">
+          <Annotation Term="OData.Permissions" EnumMember="OData.Permission/ReadWrite"/>
+          <Annotation Term="OData.Description" String="An indicator allowing an operator to physically locate this resource."/>
+          <Annotation Term="OData.LongDescription" String="This property shall contain the state of the indicator used to physically identify or locate this resource.  A write to this property shall update the value of IndicatorLED in this resource, if supported, to reflect the implementation of the locating function."/>
+        </Property>
+        <Property Name="CurrentBandwidthGbps" Type="Edm.Decimal">
+          <Annotation Term="OData.Permissions" EnumMember="OData.Permission/Read"/>
+          <Annotation Term="OData.Description" String="The current internal bandwidth of this switch."/>
+          <Annotation Term="OData.LongDescription" String="This property shall contain the internal bandwidth of this switch currently negotiated and running."/>
+          <Annotation Term="Measures.Unit" String="Gbit/s"/>
+        </Property>
+        <Property Name="MaxBandwidthGbps" Type="Edm.Decimal">
+          <Annotation Term="OData.Permissions" EnumMember="OData.Permission/Read"/>
+          <Annotation Term="OData.Description" String="The maximum internal bandwidth of this switch as currently configured."/>
+          <Annotation Term="OData.LongDescription" String="This property shall contain the maximum internal bandwidth this switch is capable of being configured.  If capable of autonegotiation, the switch shall attempt to negotiate to the specified maximum bandwidth."/>
+          <Annotation Term="Measures.Unit" String="Gbit/s"/>
+        </Property>
+      </EntityType>
+
+      <ComplexType Name="Links" BaseType="Switch.v1_3_0.Links">
+        <NavigationProperty Name="PCIeDevice" Type="PCIeDevice.PCIeDevice">
+          <Annotation Term="OData.Permissions" EnumMember="OData.Permission/Read"/>
+          <Annotation Term="OData.Description" String="The link to the PCIe device providing this switch."/>
+          <Annotation Term="OData.LongDescription" String="This property shall contain a link to a resource of type PCIeDevice that represents the PCIe device providing this switch."/>
+          <Annotation Term="OData.AutoExpandReferences"/>
+        </NavigationProperty>
+      </ComplexType>
+    </Schema>
+
+    <Schema xmlns="http://docs.oasis-open.org/odata/ns/edm" Namespace="Switch.v1_4_1">
+      <Annotation Term="Redfish.OwningEntity" String="DMTF"/>
+      <Annotation Term="OData.Description" String="This version was created to correct various typographical errors."/>
+      <EntityType Name="Switch" BaseType="Switch.v1_4_0.Switch"/>
+    </Schema>
+
+    <Schema xmlns="http://docs.oasis-open.org/odata/ns/edm" Namespace="Switch.v1_4_2">
+      <Annotation Term="Redfish.OwningEntity" String="DMTF"/>
+      <Annotation Term="OData.Description" String="This version was created to correct various description to use proper normative terminology."/>
+      <EntityType Name="Switch" BaseType="Switch.v1_4_1.Switch"/>
+    </Schema>
+
+    <Schema xmlns="http://docs.oasis-open.org/odata/ns/edm" Namespace="Switch.v1_5_0">
+      <Annotation Term="Redfish.OwningEntity" String="DMTF"/>
+      <Annotation Term="Redfish.Release" String="2020.3"/>
+      <Annotation Term="OData.Description" String="This version was created to add Certificates and Measurements to devices for attestation and identity management."/>
+
+      <EntityType Name="Switch" BaseType="Switch.v1_4_1.Switch">
+        <NavigationProperty Name="Certificates" Type="CertificateCollection.CertificateCollection" ContainsTarget="true" Nullable="false">
+          <Annotation Term="OData.Permissions" EnumMember="OData.Permission/Read"/>
+          <Annotation Term="OData.Description" String="The link to a collection of certificates for device identity and attestation."/>
+          <Annotation Term="OData.LongDescription" String="This property shall contain a link to a resource collection of type CertificateCollection that contains certificates for device identity and attestation."/>
+          <Annotation Term="OData.AutoExpandReferences"/>
+        </NavigationProperty>
+        <Property Name="Measurements" Type="Collection(SoftwareInventory.MeasurementBlock)" Nullable="false">
+          <Annotation Term="OData.Description" String="An array of DSP0274-defined measurement blocks."/>
+          <Annotation Term="OData.LongDescription" String="This property shall contain an array of DSP0274-defined measurement blocks."/>
+        </Property>
+      </EntityType>
+    </Schema>
+
+
+    <Schema xmlns="http://docs.oasis-open.org/odata/ns/edm" Namespace="Switch.v1_5_1">
+      <Annotation Term="Redfish.OwningEntity" String="DMTF"/>
+      <Annotation Term="OData.Description" String="This version was created to correct various description to use proper normative terminology."/>
+      <EntityType Name="Switch" BaseType="Switch.v1_5_0.Switch"/>
+    </Schema>
+
+    <Schema xmlns="http://docs.oasis-open.org/odata/ns/edm" Namespace="Switch.v1_6_0">
+      <Annotation Term="Redfish.OwningEntity" String="DMTF"/>
+      <Annotation Term="Redfish.Release" String="2021.1"/>
+      <Annotation Term="OData.Description" String="This version was created to add the Enabled property and a link to EnvironmentMetrics."/>
+
+      <EntityType Name="Switch" BaseType="Switch.v1_5_0.Switch">
+        <Property Name="Enabled" Type="Edm.Boolean" Nullable="false">
+          <Annotation Term="OData.Permissions" EnumMember="OData.Permission/ReadWrite"/>
+          <Annotation Term="OData.Description" String="An indication of whether this switch is enabled."/>
+          <Annotation Term="OData.LongDescription" String="The value of this property shall indicate if this switch is enabled."/>
+        </Property>
+        <NavigationProperty Name="EnvironmentMetrics" Type="EnvironmentMetrics.EnvironmentMetrics" Nullable="false">
+          <Annotation Term="OData.Permissions" EnumMember="OData.Permission/Read"/>
+          <Annotation Term="OData.Description" String="The link to the environment metrics for this switch."/>
+          <Annotation Term="OData.LongDescription" String="This property shall contain a link to a resource of type EnvironmentMetrics that specifies the environment metrics for this switch."/>
+          <Annotation Term="OData.AutoExpandReferences"/>
+        </NavigationProperty>
+      </EntityType>
+    </Schema>
+
+  </edmx:DataServices>
+</edmx:Edmx>

--- a/static/redfish/v1/schema/ThermalMetrics_v1.xml
+++ b/static/redfish/v1/schema/ThermalMetrics_v1.xml
@@ -5,7 +5,7 @@
 <!--#                                                                                      -->
 <!--# For a detailed change log, see the README file contained in the DSP8010 bundle,      -->
 <!--# available at http://www.dmtf.org/standards/redfish                                   -->
-<!--# Copyright 2018-2020 DMTF.                                                            -->
+<!--# Copyright 2014-2021 DMTF.                                                            -->
 <!--# For the full DMTF copyright policy, see http://www.dmtf.org/about/policies/copyright -->
 <!--################################################################################       -->
 <!---->

--- a/static/redfish/v1/schema/ThermalSubsystem_v1.xml
+++ b/static/redfish/v1/schema/ThermalSubsystem_v1.xml
@@ -5,7 +5,7 @@
 <!--#                                                                                      -->
 <!--# For a detailed change log, see the README file contained in the DSP8010 bundle,      -->
 <!--# available at http://www.dmtf.org/standards/redfish                                   -->
-<!--# Copyright 2014-2020 DMTF.                                                            -->
+<!--# Copyright 2014-2021 DMTF.                                                            -->
 <!--# For the full DMTF copyright policy, see http://www.dmtf.org/about/policies/copyright -->
 <!--################################################################################       -->
 <!---->

--- a/static/redfish/v1/schema/TriggersCollection_v1.xml
+++ b/static/redfish/v1/schema/TriggersCollection_v1.xml
@@ -1,0 +1,70 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!---->
+<!--################################################################################       -->
+<!--# Redfish Schema:  TriggerSetCollection                                                -->
+<!--#                                                                                      -->
+<!--# For a detailed change log, see the README file contained in the DSP8010 bundle,      -->
+<!--# available at http://www.dmtf.org/standards/redfish                                   -->
+<!--# Copyright 2014-2021 DMTF.                                                            -->
+<!--# For the full DMTF copyright policy, see http://www.dmtf.org/about/policies/copyright -->
+<!--################################################################################       -->
+<!---->
+<edmx:Edmx xmlns:edmx="http://docs.oasis-open.org/odata/ns/edmx" Version="4.0">
+
+  <edmx:Reference Uri="http://docs.oasis-open.org/odata/odata/v4.0/errata03/csd01/complete/vocabularies/Org.OData.Core.V1.xml">
+    <edmx:Include Namespace="Org.OData.Core.V1" Alias="OData"/>
+  </edmx:Reference>
+  <edmx:Reference Uri="http://docs.oasis-open.org/odata/odata/v4.0/errata03/csd01/complete/vocabularies/Org.OData.Capabilities.V1.xml">
+    <edmx:Include Namespace="Org.OData.Capabilities.V1" Alias="Capabilities"/>
+  </edmx:Reference>
+  <edmx:Reference Uri="http://redfish.dmtf.org/schemas/v1/Resource_v1.xml">
+    <edmx:Include Namespace="Resource.v1_0_0"/>
+  </edmx:Reference>
+  <edmx:Reference Uri="http://redfish.dmtf.org/schemas/v1/RedfishExtensions_v1.xml">
+    <edmx:Include Namespace="RedfishExtensions.v1_0_0" Alias="Redfish"/>
+  </edmx:Reference>
+  <edmx:Reference Uri="http://redfish.dmtf.org/schemas/v1/Triggers_v1.xml">
+    <edmx:Include Namespace="Triggers"/>
+  </edmx:Reference>
+
+  <edmx:DataServices>
+
+    <Schema xmlns="http://docs.oasis-open.org/odata/ns/edm" Namespace="TriggersCollection">
+      <Annotation Term="Redfish.OwningEntity" String="DMTF"/>
+
+      <EntityType Name="TriggersCollection" BaseType="Resource.v1_0_0.ResourceCollection">
+        <Annotation Term="OData.Description" String="The collection of Triggers resource instances."/>
+        <Annotation Term="OData.LongDescription" String="This resource shall represent a resource collection of Triggers instances for a Redfish implementation."/>
+        <Annotation Term="Capabilities.InsertRestrictions">
+          <Record>
+            <PropertyValue Property="Insertable" Bool="true"/>
+            <Annotation Term="OData.Description" String="Create triggers through a POST to the trigger collection."/>
+          </Record>
+        </Annotation>
+        <Annotation Term="Capabilities.UpdateRestrictions">
+          <Record>
+            <PropertyValue Property="Updatable" Bool="false"/>
+          </Record>
+        </Annotation>
+        <Annotation Term="Capabilities.DeleteRestrictions">
+          <Record>
+            <PropertyValue Property="Deletable" Bool="false"/>
+          </Record>
+        </Annotation>
+        <Annotation Term="Redfish.Uris">
+          <Collection>
+            <String>/redfish/v1/TelemetryService/Triggers</String>
+          </Collection>
+        </Annotation>
+        <NavigationProperty Name="Members" Type="Collection(Triggers.Triggers)">
+          <Annotation Term="OData.Permissions" EnumMember="OData.Permission/Read"/>
+          <Annotation Term="OData.Description" String="The members of this collection."/>
+          <Annotation Term="OData.LongDescription" String="This property shall contain an array of links to the members of this collection."/>
+          <Annotation Term="OData.AutoExpandReferences"/>
+          <Annotation Term="Redfish.Required"/>
+        </NavigationProperty>
+      </EntityType>
+
+    </Schema>
+  </edmx:DataServices>
+</edmx:Edmx>

--- a/static/redfish/v1/schema/Triggers_v1.xml
+++ b/static/redfish/v1/schema/Triggers_v1.xml
@@ -1,0 +1,393 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!---->
+<!--################################################################################       -->
+<!--# Redfish Schema:  Triggers v1.2.0                                                     -->
+<!--#                                                                                      -->
+<!--# For a detailed change log, see the README file contained in the DSP8010 bundle,      -->
+<!--# available at http://www.dmtf.org/standards/redfish                                   -->
+<!--# Copyright 2014-2021 DMTF.                                                            -->
+<!--# For the full DMTF copyright policy, see http://www.dmtf.org/about/policies/copyright -->
+<!--################################################################################       -->
+<!---->
+<edmx:Edmx xmlns:edmx="http://docs.oasis-open.org/odata/ns/edmx" Version="4.0">
+
+  <edmx:Reference Uri="http://docs.oasis-open.org/odata/odata/v4.0/errata03/csd01/complete/vocabularies/Org.OData.Core.V1.xml">
+    <edmx:Include Namespace="Org.OData.Core.V1" Alias="OData"/>
+  </edmx:Reference>
+  <edmx:Reference Uri="http://docs.oasis-open.org/odata/odata/v4.0/errata03/csd01/complete/vocabularies/Org.OData.Capabilities.V1.xml">
+    <edmx:Include Namespace="Org.OData.Capabilities.V1" Alias="Capabilities"/>
+  </edmx:Reference>
+  <edmx:Reference Uri="http://redfish.dmtf.org/schemas/v1/Resource_v1.xml">
+    <edmx:Include Namespace="Resource"/>
+    <edmx:Include Namespace="Resource.v1_0_0"/>
+  </edmx:Reference>
+  <edmx:Reference Uri="http://redfish.dmtf.org/schemas/v1/RedfishExtensions_v1.xml">
+    <edmx:Include Namespace="RedfishExtensions.v1_0_0" Alias="Redfish"/>
+    <edmx:Include Namespace="Validation.v1_0_0" Alias="Validation"/>
+  </edmx:Reference>
+  <edmx:Reference Uri="http://redfish.dmtf.org/schemas/v1/MetricReportDefinition_v1.xml">
+    <edmx:Include Namespace="MetricReportDefinition"/>
+  </edmx:Reference>
+
+  <edmx:DataServices>
+
+    <Schema xmlns="http://docs.oasis-open.org/odata/ns/edm" Namespace="Triggers">
+      <Annotation Term="Redfish.OwningEntity" String="DMTF"/>
+
+      <EntityType Name="Triggers" BaseType="Resource.v1_0_0.Resource" Abstract="true">
+        <Annotation Term="OData.Description" String="The Triggers schema describes a trigger that applies to metrics."/>
+        <Annotation Term="OData.LongDescription" String="This resource shall contain a trigger that applies to metrics."/>
+        <Annotation Term="Capabilities.InsertRestrictions">
+          <Record>
+            <PropertyValue Property="Insertable" Bool="false"/>
+          </Record>
+        </Annotation>
+        <Annotation Term="Capabilities.UpdateRestrictions">
+          <Record>
+            <PropertyValue Property="Updatable" Bool="true"/>
+            <Annotation Term="OData.Description" String="Triggers can be updated to configure them."/>
+          </Record>
+        </Annotation>
+        <Annotation Term="Capabilities.DeleteRestrictions">
+          <Record>
+            <PropertyValue Property="Deletable" Bool="true"/>
+            <Annotation Term="OData.Description" String="Triggers can be deleted."/>
+          </Record>
+        </Annotation>
+        <Annotation Term="Redfish.Uris">
+          <Collection>
+            <String>/redfish/v1/TelemetryService/Triggers/{TriggersId}</String>
+          </Collection>
+        </Annotation>
+      </EntityType>
+    </Schema>
+
+    <Schema xmlns="http://docs.oasis-open.org/odata/ns/edm" Namespace="Triggers.v1_0_0">
+      <Annotation Term="Redfish.OwningEntity" String="DMTF"/>
+      <Annotation Term="Redfish.Release" String="2018.2"/>
+
+      <EntityType Name="Triggers" BaseType="Triggers.Triggers">
+        <Property Name="MetricType" Type="Triggers.v1_0_0.MetricTypeEnum">
+          <Annotation Term="OData.Permissions" EnumMember="OData.Permission/Read"/>
+          <Annotation Term="OData.Description" String="The metric type of the trigger."/>
+          <Annotation Term="OData.LongDescription" String="This property shall contain the metric type of the trigger."/>
+        </Property>
+        <Property Name="TriggerActions" Type="Collection(Triggers.v1_0_0.TriggerActionEnum)" Nullable="false">
+          <Annotation Term="OData.Permissions" EnumMember="OData.Permission/Read"/>
+          <Annotation Term="OData.Description" String="The actions that the trigger initiates."/>
+          <Annotation Term="OData.LongDescription" String="This property shall contain the actions that the trigger initiates."/>
+        </Property>
+        <Property Name="NumericThresholds" Type="Triggers.v1_0_0.Thresholds" Nullable="false">
+          <Annotation Term="OData.Description" String="The thresholds when a numeric metric triggers."/>
+          <Annotation Term="OData.LongDescription" String="This property shall contain the list of thresholds to which to compare a numeric metric value."/>
+        </Property>
+        <Property Name="DiscreteTriggerCondition" Type="Triggers.v1_0_0.DiscreteTriggerConditionEnum">
+          <Annotation Term="OData.Permissions" EnumMember="OData.Permission/Read"/>
+          <Annotation Term="OData.Description" String="The conditions when a discrete metric triggers."/>
+          <Annotation Term="OData.LongDescription" String="This property shall contain the conditions when a discrete metric triggers."/>
+        </Property>
+        <Property Name="DiscreteTriggers" Type="Collection(Triggers.v1_0_0.DiscreteTrigger)" Nullable="false">
+          <Annotation Term="OData.Description" String="The list of discrete triggers."/>
+          <Annotation Term="OData.LongDescription" String="This property shall contain a list of values to which to compare a metric reading.  This property shall be present when the DiscreteTriggerCondition property is `Specified`."/>
+        </Property>
+
+        <Property Name="Status" Type="Resource.Status" Nullable="false">
+          <Annotation Term="OData.Description" String="The status and health of the resource and its subordinate or dependent resources."/>
+          <Annotation Term="OData.LongDescription" String="This property shall contain any status or health properties of the resource."/>
+        </Property>
+
+        <Property Name="Wildcards" Type="Collection(Triggers.v1_0_0.Wildcard)" Nullable="false">
+          <Annotation Term="OData.Description" String="The wildcards and their substitution values for the entries in the MetricProperties array property."/>
+          <Annotation Term="OData.LongDescription" String="This property shall contain the wildcards and their substitution values for the entries in the MetricProperties array property.  Each wildcard shall have a corresponding entry in this array property."/>
+        </Property>
+        <Property Name="MetricProperties" Type="Collection(Edm.String)">
+          <Annotation Term="OData.Permissions" EnumMember="OData.Permission/ReadWrite"/>
+          <Annotation Term="OData.Description" String="An array of URIs with wildcards and property identifiers for this trigger.  Each wildcard shall be replaced with its corresponding entry in the Wildcard array property."/>
+          <Annotation Term="OData.LongDescription" String="This property shall contain an array of URIs with wildcards and property identifiers for this trigger.  Use a set of curly braces to delimit each wildcard in the URI.  Replace each wildcard with its corresponding entry in the Wildcard array property.  A URI that contains wildcards shall link to a resource property to which the metric definition applies after all wildcards are replaced with their corresponding entries in the Wildcard array property.  The property identifiers portion of the URI shall follow the RFC6901-defined JSON fragment notation rules."/>
+          <Annotation Term="OData.IsURL"/>
+        </Property>
+        <Property Name="Actions" Type="Triggers.v1_0_0.Actions" Nullable="false">
+          <Annotation Term="OData.Description" String="The available actions for this resource."/>
+          <Annotation Term="OData.LongDescription" String="This property shall contain the available actions for this resource."/>
+        </Property>
+      </EntityType>
+
+      <EnumType Name="MetricTypeEnum">
+        <Annotation Term="OData.Description" String="The type of metric for which the trigger is configured."/>
+        <Annotation Term="OData.LongDescription" String="This type shall specify the type of metric for which the trigger is configured."/>
+        <Member Name="Numeric">
+          <Annotation Term="OData.Description" String="The trigger is for numeric sensor."/>
+        </Member>
+        <Member Name="Discrete">
+          <Annotation Term="OData.Description" String="The trigger is for a discrete sensor."/>
+        </Member>
+      </EnumType>
+
+      <EnumType Name="TriggerActionEnum">
+        <Annotation Term="OData.Description" String="The actions to perform when a trigger condition is met."/>
+        <Annotation Term="OData.LongDescription" String="This type shall specify the actions to perform when a trigger condition is met."/>
+        <Member Name="LogToLogService">
+          <Annotation Term="OData.Description" String="When a trigger condition is met, record in a log."/>
+          <Annotation Term="OData.LongDescription" String="This value indicates that when a trigger condition is met, the service shall log the occurrence of the condition to the log that the LogService property in the telemetry service resource describes."/>
+        </Member>
+        <Member Name="RedfishEvent">
+          <Annotation Term="OData.Description" String="When a trigger condition is met, the service sends an event to subscribers."/>
+          <Annotation Term="OData.LongDescription" String="This value indicates that when a trigger condition is met, the service shall send an event to subscribers."/>
+        </Member>
+        <Member Name="RedfishMetricReport">
+          <Annotation Term="OData.Description" String="When a trigger condition is met, force an update of the specified metric reports."/>
+          <Annotation Term="OData.LongDescription" String="This value indicates that when a trigger condition is met, the service shall force the metric reports managed by the MetricReportDefinitions specified by the MetricReportDefinitions property to be updated, regardless of the MetricReportDefinitionType property value.  The actions specified in the ReportActions property of each MetricReportDefinition shall be performed."/>
+          <Annotation Term="Redfish.Revisions">
+            <Collection>
+              <Record>
+                <PropertyValue Property="Kind" EnumMember="Redfish.RevisionKind/Added"/>
+                <PropertyValue Property="Version" String="v1_1_0"/>
+              </Record>
+            </Collection>
+          </Annotation>
+        </Member>
+      </EnumType>
+
+      <EnumType Name="DiscreteTriggerConditionEnum">
+        <Annotation Term="OData.Description" String="The condition, in relationship to the discrete trigger values, which constitutes a trigger."/>
+        <Annotation Term="OData.LongDescription" String="This type shall specify the condition, in relationship to the discrete trigger values, which constitutes a trigger."/>
+        <Member Name="Specified">
+          <Annotation Term="OData.Description" String="A discrete trigger condition is met when the metric value becomes one of the values that the DiscreteTriggers property lists."/>
+        </Member>
+        <Member Name="Changed">
+          <Annotation Term="OData.Description" String="A discrete trigger condition is met whenever the metric value changes."/>
+        </Member>
+      </EnumType>
+
+      <ComplexType Name="Thresholds">
+        <Annotation Term="OData.AdditionalProperties" Bool="false"/>
+        <Annotation Term="OData.Description" String="The set of thresholds for a sensor."/>
+        <Annotation Term="OData.LongDescription" String="This type shall contain a set of thresholds for a sensor."/>
+        <Property Name="UpperWarning" Type="Triggers.v1_0_0.Threshold" Nullable="false">
+          <Annotation Term="OData.Description" String="The value at which the reading is above normal range."/>
+          <Annotation Term="OData.LongDescription" String="This property shall contain the value at which the MetricProperties property is above the normal range.  The value of the property shall use the same units as the MetricProperties property."/>
+        </Property>
+        <Property Name="UpperCritical" Type="Triggers.v1_0_0.Threshold" Nullable="false">
+          <Annotation Term="OData.Description" String="The value at which the reading is above normal range and requires attention."/>
+          <Annotation Term="OData.LongDescription" String="This property shall contain the value at which the MetricProperties property is above the normal range and may require attention.  The value of the property shall use the same units as the MetricProperties property."/>
+        </Property>
+        <Property Name="LowerWarning" Type="Triggers.v1_0_0.Threshold" Nullable="false">
+          <Annotation Term="OData.Description" String="The value at which the reading is below normal range."/>
+          <Annotation Term="OData.LongDescription" String="This property shall contain the value at which the MetricProperties property is below the normal range.  The value of the property shall use the same units as the MetricProperties property."/>
+        </Property>
+        <Property Name="LowerCritical" Type="Triggers.v1_0_0.Threshold" Nullable="false">
+          <Annotation Term="OData.Description" String="The value at which the reading is below normal range and requires attention."/>
+          <Annotation Term="OData.LongDescription" String="This property shall contain the value at which the MetricProperties property is below the normal range and may require attention.  The value of the property shall use the same units as the MetricProperties property."/>
+        </Property>
+      </ComplexType>
+
+      <ComplexType Name="Threshold">
+        <Annotation Term="OData.AdditionalProperties" Bool="false"/>
+        <Annotation Term="OData.Description" String="A threshold definition for a sensor."/>
+        <Annotation Term="OData.LongDescription" String="This type shall contain the properties for an individual threshold for this sensor."/>
+        <Property Name="Reading" Type="Edm.Decimal">
+          <Annotation Term="OData.Permissions" EnumMember="OData.Permission/ReadWrite"/>
+          <Annotation Term="OData.Description" String="The threshold value."/>
+          <Annotation Term="OData.LongDescription" String="This property shall indicate the reading for this sensor that activates the threshold.  The value of the property shall use the same units as the MetricProperties property."/>
+        </Property>
+        <Property Name="Activation" Type="Triggers.v1_0_0.ThresholdActivation">
+          <Annotation Term="OData.Permissions" EnumMember="OData.Permission/ReadWrite"/>
+          <Annotation Term="OData.Description" String="The direction of crossing that activates this threshold."/>
+          <Annotation Term="OData.LongDescription" String="This property shall indicate the direction of crossing of the reading for this sensor that activates the threshold."/>
+        </Property>
+        <Property Name="DwellTime" Type="Edm.Duration">
+          <Annotation Term="OData.Permissions" EnumMember="OData.Permission/ReadWrite"/>
+          <Annotation Term="OData.Description" String="The duration the sensor value must violate the threshold before the threshold is activated."/>
+          <Annotation Term="OData.LongDescription" String="This property shall indicate the duration the sensor value violates the threshold before the threshold is activated."/>
+        </Property>
+      </ComplexType>
+
+      <ComplexType Name="Actions">
+        <Annotation Term="OData.AdditionalProperties" Bool="false"/>
+        <Annotation Term="OData.Description" String="The available actions for this resource."/>
+        <Annotation Term="OData.LongDescription" String="This type shall contain the available actions for this resource."/>
+        <Property Name="Oem" Type="Triggers.v1_0_0.OemActions" Nullable="false">
+          <Annotation Term="OData.Description" String="The available OEM-specific actions for this resource."/>
+          <Annotation Term="OData.LongDescription" String="This property shall contain the available OEM-specific actions for this resource."/>
+        </Property>
+      </ComplexType>
+
+      <ComplexType Name="OemActions">
+        <Annotation Term="OData.AdditionalProperties" Bool="true"/>
+        <Annotation Term="OData.Description" String="The available OEM-specific actions for this resource."/>
+        <Annotation Term="OData.LongDescription" String="This type shall contain the available OEM-specific actions for this resource."/>
+      </ComplexType>
+
+      <EnumType Name="ThresholdActivation">
+        <Member Name="Increasing">
+          <Annotation Term="OData.Description" String="Value increases above the threshold."/>
+          <Annotation Term="OData.LongDescription" String="This threshold is activated when the reading changes from a value lower than the threshold to a value higher than the threshold."/>
+        </Member>
+        <Member Name="Decreasing">
+          <Annotation Term="OData.Description" String="Value decreases below the threshold."/>
+          <Annotation Term="OData.LongDescription" String="This threshold is activated when the reading changes from a value higher than the threshold to a value lower than the threshold."/>
+        </Member>
+        <Member Name="Either">
+          <Annotation Term="OData.Description" String="Value crosses the threshold in either direction."/>
+          <Annotation Term="OData.LongDescription" String="This threshold is activated when either the Increasing or Decreasing conditions are met."/>
+        </Member>
+      </EnumType>
+
+      <EnumType Name="DirectionOfCrossingEnum">
+        <Annotation Term="OData.Description" String="The direction of crossing that corresponds to a trigger."/>
+        <Annotation Term="OData.LongDescription" String="The value shall indicate the direction of crossing that corresponds to a trigger."/>
+        <Member Name="Increasing">
+          <Annotation Term="OData.Description" String="A trigger condition is met when the metric value crosses the trigger value while increasing."/>
+        </Member>
+        <Member Name="Decreasing">
+          <Annotation Term="OData.Description" String="A trigger is met when the metric value crosses the trigger value while decreasing."/>
+        </Member>
+      </EnumType>
+
+      <ComplexType Name="DiscreteTrigger">
+        <Annotation Term="OData.AdditionalProperties" Bool="false"/>
+        <Annotation Term="OData.Description" String="The characteristics of the discrete trigger."/>
+        <Annotation Term="OData.LongDescription" String="This object shall contain the characteristics of the discrete trigger."/>
+        <Property Name="Name" Type="Edm.String">
+          <Annotation Term="OData.Permissions" EnumMember="OData.Permission/Read"/>
+          <Annotation Term="OData.Description" String="The name of trigger."/>
+          <Annotation Term="OData.LongDescription" String="This property shall contain a name for the trigger."/>
+        </Property>
+        <Property Name="Value" Type="Edm.String">
+          <Annotation Term="OData.Permissions" EnumMember="OData.Permission/ReadWrite"/>
+          <Annotation Term="OData.Description" String="The discrete metric value that constitutes a trigger event."/>
+          <Annotation Term="OData.LongDescription" String="This property shall contain the value discrete metric that constitutes a trigger event.  The DwellTime shall be measured from this point in time."/>
+        </Property>
+        <Property Name="DwellTime" Type="Edm.Duration">
+          <Annotation Term="OData.Permissions" EnumMember="OData.Permission/ReadWrite"/>
+          <Annotation Term="OData.Description" String="The amount of time that a trigger event persists before the metric action is performed."/>
+          <Annotation Term="OData.LongDescription" String="This property shall contain the amount of time that a trigger event persists before the TriggerActions are performed."/>
+        </Property>
+        <Property Name="Severity" Type="Resource.Health">
+          <Annotation Term="OData.Permissions" EnumMember="OData.Permission/ReadWrite"/>
+          <Annotation Term="OData.Description" String="The severity of the event message."/>
+          <Annotation Term="OData.LongDescription" String="This property shall contain the Severity property to be used in the event message."/>
+        </Property>
+      </ComplexType>
+
+      <ComplexType Name="Wildcard">
+        <Annotation Term="OData.AdditionalProperties" Bool="false"/>
+        <Annotation Term="OData.Description" String="The wildcard and its substitution values."/>
+        <Annotation Term="OData.LongDescription" String="This property shall contain a wildcard and its substitution values."/>
+        <Property Name="Name" Type="Edm.String">
+          <Annotation Term="OData.Permissions" EnumMember="OData.Permission/Read"/>
+          <Annotation Term="OData.Description" String="The wildcard."/>
+          <Annotation Term="OData.LongDescription" String="This property shall contain the string used as a wildcard."/>
+        </Property>
+        <Property Name="Values" Type="Collection(Edm.String)">
+          <Annotation Term="OData.Permissions" EnumMember="OData.Permission/Read"/>
+          <Annotation Term="OData.Description" String="An array of values to substitute for the wildcard."/>
+          <Annotation Term="OData.LongDescription" String="This array property shall contain the list of values to substitute for the wildcard."/>
+        </Property>
+      </ComplexType>
+    </Schema>
+
+    <Schema xmlns="http://docs.oasis-open.org/odata/ns/edm" Namespace="Triggers.v1_0_1">
+      <Annotation Term="Redfish.OwningEntity" String="DMTF"/>
+      <Annotation Term="OData.Description" String="This version was created to clarify descriptions of several properties."/>
+      <EntityType Name="Triggers" BaseType="Triggers.v1_0_0.Triggers"/>
+    </Schema>
+
+    <Schema xmlns="http://docs.oasis-open.org/odata/ns/edm" Namespace="Triggers.v1_0_2">
+      <Annotation Term="Redfish.OwningEntity" String="DMTF"/>
+      <Annotation Term="OData.Description" String="This version was created to force the regeneration of JSON Schema so that URI properties use the uri-reference format, and to add a missing term to several properties to disallow them from being null."/>
+      <EntityType Name="Triggers" BaseType="Triggers.v1_0_1.Triggers"/>
+    </Schema>
+
+    <Schema xmlns="http://docs.oasis-open.org/odata/ns/edm" Namespace="Triggers.v1_0_3">
+      <Annotation Term="Redfish.OwningEntity" String="DMTF"/>
+      <Annotation Term="OData.Description" String="This version was created to update descriptions that this schema defines."/>
+      <EntityType Name="Triggers" BaseType="Triggers.v1_0_2.Triggers"/>
+    </Schema>
+
+    <Schema xmlns="http://docs.oasis-open.org/odata/ns/edm" Namespace="Triggers.v1_0_4">
+      <Annotation Term="Redfish.OwningEntity" String="DMTF"/>
+      <Annotation Term="OData.Description" String="This version was created to correct various typographical errors."/>
+      <EntityType Name="Triggers" BaseType="Triggers.v1_0_3.Triggers"/>
+    </Schema>
+
+    <Schema xmlns="http://docs.oasis-open.org/odata/ns/edm" Namespace="Triggers.v1_0_5">
+      <Annotation Term="Redfish.OwningEntity" String="DMTF"/>
+      <Annotation Term="OData.Description" String="This version was created to correct various typographical errors."/>
+      <EntityType Name="Triggers" BaseType="Triggers.v1_0_4.Triggers"/>
+    </Schema>
+
+    <Schema xmlns="http://docs.oasis-open.org/odata/ns/edm" Namespace="Triggers.v1_0_6">
+      <Annotation Term="Redfish.OwningEntity" String="DMTF"/>
+      <Annotation Term="OData.Description" String="This version was created to correct various description to use proper normative terminology."/>
+      <EntityType Name="Triggers" BaseType="Triggers.v1_0_5.Triggers"/>
+    </Schema>
+
+    <Schema xmlns="http://docs.oasis-open.org/odata/ns/edm" Namespace="Triggers.v1_1_0">
+      <Annotation Term="Redfish.OwningEntity" String="DMTF"/>
+      <Annotation Term="Redfish.Release" String="2019.1"/>
+
+      <EntityType Name="Triggers" BaseType="Triggers.v1_0_2.Triggers">
+        <Property Name="EventTriggers" Type="Collection(Edm.String)">
+          <Annotation Term="OData.Permissions" EnumMember="OData.Permission/ReadWrite"/>
+          <Annotation Term="OData.Description" String="The array of MessageIds that specify when a trigger condition is met based on an event."/>
+          <Annotation Term="OData.LongDescription" String="This property shall contain an array of MessageIds that specify when a trigger condition is met based on an event.  When the service generates an event and if it contains a MessageId within this array, a trigger condition shall be met.  The MetricType property should not be present if this resource is configured for event-based triggers."/>
+          <Annotation Term="Validation.Pattern" String="^[A-Za-z0-9]+\.\d+\.\d+\.[A-Za-z0-9.]+$"/>
+        </Property>
+        <Property Name="Links" Type="Triggers.v1_1_0.Links" Nullable="false">
+          <Annotation Term="OData.Description" String="The links to other resources that are related to this resource."/>
+          <Annotation Term="OData.LongDescription" String="This property shall contain links to resources that are related to but are not contained by, or subordinate to, this resource."/>
+        </Property>
+      </EntityType>
+
+      <ComplexType Name="Links" BaseType="Resource.Links">
+        <Annotation Term="OData.Description" String="The links to other resources that are related to this resource."/>
+        <Annotation Term="OData.LongDescription" String="This Redfish Specification-described type shall contain links to resources that are related to but are not contained by, or subordinate to, this resource."/>
+        <NavigationProperty Name="MetricReportDefinitions" Type="Collection(MetricReportDefinition.MetricReportDefinition)">
+          <Annotation Term="OData.Permissions" EnumMember="OData.Permission/ReadWrite"/>
+          <Annotation Term="OData.Description" String="The metric report definitions that generate new metric reports when a trigger condition is met and when the TriggerActions property contains `RedfishMetricReport`."/>
+          <Annotation Term="OData.LongDescription" String="This property shall contain a set of links to metric report definitions that generate new metric reports when a trigger condition is met and when the TriggerActions property contains `RedfishMetricReport`."/>
+          <Annotation Term="OData.AutoExpandReferences"/>
+        </NavigationProperty>
+      </ComplexType>
+    </Schema>
+
+    <Schema xmlns="http://docs.oasis-open.org/odata/ns/edm" Namespace="Triggers.v1_1_1">
+      <Annotation Term="Redfish.OwningEntity" String="DMTF"/>
+      <Annotation Term="OData.Description" String="This version was created to update descriptions that this schema defines."/>
+      <EntityType Name="Triggers" BaseType="Triggers.v1_1_0.Triggers"/>
+    </Schema>
+
+    <Schema xmlns="http://docs.oasis-open.org/odata/ns/edm" Namespace="Triggers.v1_1_2">
+      <Annotation Term="Redfish.OwningEntity" String="DMTF"/>
+      <Annotation Term="OData.Description" String="This version was created to correct various typographical errors."/>
+      <EntityType Name="Triggers" BaseType="Triggers.v1_1_1.Triggers"/>
+    </Schema>
+
+    <Schema xmlns="http://docs.oasis-open.org/odata/ns/edm" Namespace="Triggers.v1_1_3">
+      <Annotation Term="Redfish.OwningEntity" String="DMTF"/>
+      <Annotation Term="OData.Description" String="This version was created to correct various typographical errors."/>
+      <EntityType Name="Triggers" BaseType="Triggers.v1_1_2.Triggers"/>
+    </Schema>
+
+    <Schema xmlns="http://docs.oasis-open.org/odata/ns/edm" Namespace="Triggers.v1_1_4">
+      <Annotation Term="Redfish.OwningEntity" String="DMTF"/>
+      <Annotation Term="OData.Description" String="This version was created to correct various description to use proper normative terminology.  It was also created to clarify the usage of MetricType for event-based triggers."/>
+      <EntityType Name="Triggers" BaseType="Triggers.v1_1_3.Triggers"/>
+    </Schema>
+
+    <Schema xmlns="http://docs.oasis-open.org/odata/ns/edm" Namespace="Triggers.v1_2_0">
+      <Annotation Term="Redfish.OwningEntity" String="DMTF"/>
+      <Annotation Term="Redfish.Release" String="2021.2"/>
+
+      <EntityType Name="Triggers" BaseType="Triggers.v1_1_4.Triggers">
+        <Property Name="MetricIds" Type="Collection(Edm.String)">
+          <Annotation Term="OData.Permissions" EnumMember="OData.Permission/ReadWrite"/>
+          <Annotation Term="OData.Description" String="The label for the metric definitions that contain the property identifiers for this trigger.  It matches the Id property of the corresponding metric definition."/>
+          <Annotation Term="OData.LongDescription" String="This property shall contain the labels for the metric definitions that contain the property identifiers for this trigger.  This property shall match the value of the Id property of the corresponding metric definitions."/>
+        </Property>
+      </EntityType>
+    </Schema>
+
+  </edmx:DataServices>
+</edmx:Edmx>

--- a/static/redfish/v1/schema/USBControllerCollection_v1.xml
+++ b/static/redfish/v1/schema/USBControllerCollection_v1.xml
@@ -1,0 +1,69 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!---->
+<!--################################################################################       -->
+<!--# Redfish Schema:  USBControllerCollection                                             -->
+<!--#                                                                                      -->
+<!--# For a detailed change log, see the README file contained in the DSP8010 bundle,      -->
+<!--# available at http://www.dmtf.org/standards/redfish                                   -->
+<!--# Copyright 2014-2021 DMTF.                                                            -->
+<!--# For the full DMTF copyright policy, see http://www.dmtf.org/about/policies/copyright -->
+<!--################################################################################       -->
+<!---->
+<edmx:Edmx xmlns:edmx="http://docs.oasis-open.org/odata/ns/edmx" Version="4.0">
+
+  <edmx:Reference Uri="http://docs.oasis-open.org/odata/odata/v4.0/errata03/csd01/complete/vocabularies/Org.OData.Core.V1.xml">
+    <edmx:Include Namespace="Org.OData.Core.V1" Alias="OData"/>
+  </edmx:Reference>
+  <edmx:Reference Uri="http://docs.oasis-open.org/odata/odata/v4.0/errata03/csd01/complete/vocabularies/Org.OData.Capabilities.V1.xml">
+    <edmx:Include Namespace="Org.OData.Capabilities.V1" Alias="Capabilities"/>
+  </edmx:Reference>
+  <edmx:Reference Uri="http://redfish.dmtf.org/schemas/v1/Resource_v1.xml">
+    <edmx:Include Namespace="Resource.v1_0_0"/>
+  </edmx:Reference>
+  <edmx:Reference Uri="http://redfish.dmtf.org/schemas/v1/RedfishExtensions_v1.xml">
+    <edmx:Include Namespace="RedfishExtensions.v1_0_0" Alias="Redfish"/>
+  </edmx:Reference>
+  <edmx:Reference Uri="http://redfish.dmtf.org/schemas/v1/USBController_v1.xml">
+    <edmx:Include Namespace="USBController"/>
+  </edmx:Reference>
+
+  <edmx:DataServices>
+
+    <Schema xmlns="http://docs.oasis-open.org/odata/ns/edm" Namespace="USBControllerCollection">
+      <Annotation Term="Redfish.OwningEntity" String="DMTF"/>
+
+      <EntityType Name="USBControllerCollection" BaseType="Resource.v1_0_0.ResourceCollection">
+        <Annotation Term="OData.Description" String="The collection of USBController resource instances."/>
+        <Annotation Term="OData.LongDescription" String="This resource shall represent a resource collection of USBController instances for a Redfish implementation."/>
+        <Annotation Term="Capabilities.InsertRestrictions">
+          <Record>
+            <PropertyValue Property="Insertable" Bool="false"/>
+          </Record>
+        </Annotation>
+        <Annotation Term="Capabilities.UpdateRestrictions">
+          <Record>
+            <PropertyValue Property="Updatable" Bool="false"/>
+          </Record>
+        </Annotation>
+        <Annotation Term="Capabilities.DeleteRestrictions">
+          <Record>
+            <PropertyValue Property="Deletable" Bool="false"/>
+          </Record>
+        </Annotation>
+        <Annotation Term="Redfish.Uris">
+          <Collection>
+            <String>/redfish/v1/Systems/{ComputerSystemId}/USBControllers</String>
+          </Collection>
+        </Annotation>
+        <NavigationProperty Name="Members" Type="Collection(USBController.USBController)">
+          <Annotation Term="OData.Permissions" EnumMember="OData.Permission/Read"/>
+          <Annotation Term="OData.Description" String="The members of this collection."/>
+          <Annotation Term="OData.LongDescription" String="This property shall contain an array of links to the members of this collection."/>
+          <Annotation Term="OData.AutoExpandReferences"/>
+          <Annotation Term="Redfish.Required"/>
+        </NavigationProperty>
+      </EntityType>
+    </Schema>
+
+  </edmx:DataServices>
+</edmx:Edmx>

--- a/static/redfish/v1/schema/USBController_v1.xml
+++ b/static/redfish/v1/schema/USBController_v1.xml
@@ -1,0 +1,158 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!---->
+<!--################################################################################       -->
+<!--# Redfish Schema:  USBController v1.0.0                                                -->
+<!--#                                                                                      -->
+<!--# For a detailed change log, see the README file contained in the DSP8010 bundle,      -->
+<!--# available at http://www.dmtf.org/standards/redfish                                   -->
+<!--# Copyright 2014-2021 DMTF.                                                            -->
+<!--# For the full DMTF copyright policy, see http://www.dmtf.org/about/policies/copyright -->
+<!--################################################################################       -->
+<!---->
+<edmx:Edmx xmlns:edmx="http://docs.oasis-open.org/odata/ns/edmx" Version="4.0">
+
+  <edmx:Reference Uri="http://docs.oasis-open.org/odata/odata/v4.0/errata03/csd01/complete/vocabularies/Org.OData.Core.V1.xml">
+    <edmx:Include Namespace="Org.OData.Core.V1" Alias="OData"/>
+  </edmx:Reference>
+  <edmx:Reference Uri="http://redfish.dmtf.org/schemas/v1/RedfishExtensions_v1.xml">
+    <edmx:Include Namespace="RedfishExtensions.v1_0_0" Alias="Redfish"/>
+    <edmx:Include Namespace="Validation.v1_0_0" Alias="Validation"/>
+  </edmx:Reference>
+  <edmx:Reference Uri="http://docs.oasis-open.org/odata/odata/v4.0/errata03/csd01/complete/vocabularies/Org.OData.Capabilities.V1.xml">
+    <edmx:Include Namespace="Org.OData.Capabilities.V1" Alias="Capabilities"/>
+  </edmx:Reference>
+  <edmx:Reference Uri="http://redfish.dmtf.org/schemas/v1/Resource_v1.xml">
+    <edmx:Include Namespace="Resource"/>
+    <edmx:Include Namespace="Resource.v1_0_0"/>
+  </edmx:Reference>
+  <edmx:Reference Uri="http://redfish.dmtf.org/schemas/v1/PortCollection_v1.xml">
+    <edmx:Include Namespace="PortCollection"/>
+  </edmx:Reference>
+  <edmx:Reference Uri="http://redfish.dmtf.org/schemas/v1/Processor_v1.xml">
+    <edmx:Include Namespace="Processor"/>
+  </edmx:Reference>
+  <edmx:Reference Uri="http://redfish.dmtf.org/schemas/v1/PCIeDevice_v1.xml">
+    <edmx:Include Namespace="PCIeDevice"/>
+  </edmx:Reference>
+
+  <edmx:DataServices>
+
+    <Schema xmlns="http://docs.oasis-open.org/odata/ns/edm" Namespace="USBController">
+      <Annotation Term="Redfish.OwningEntity" String="DMTF"/>
+
+      <EntityType Name="USBController" BaseType="Resource.v1_0_0.Resource" Abstract="true">
+        <Annotation Term="OData.Description" String="The USBController schema defines a Universal Serial Bus controller."/>
+        <Annotation Term="OData.LongDescription" String="This resource shall represent a USB controller in a Redfish implementation."/>
+        <Annotation Term="OData.AdditionalProperties" Bool="false"/>
+        <Annotation Term="Capabilities.InsertRestrictions">
+          <Record>
+            <PropertyValue Property="Insertable" Bool="false"/>
+          </Record>
+        </Annotation>
+        <Annotation Term="Capabilities.UpdateRestrictions">
+          <Record>
+            <PropertyValue Property="Updatable" Bool="false"/>
+          </Record>
+        </Annotation>
+        <Annotation Term="Capabilities.DeleteRestrictions">
+          <Record>
+            <PropertyValue Property="Deletable" Bool="false"/>
+          </Record>
+        </Annotation>
+        <Annotation Term="Redfish.Uris">
+          <Collection>
+            <String>/redfish/v1/Systems/{ComputerSystemId}/USBControllers/{ControllerId}</String>
+          </Collection>
+        </Annotation>
+      </EntityType>
+    </Schema>
+
+    <Schema xmlns="http://docs.oasis-open.org/odata/ns/edm" Namespace="USBController.v1_0_0">
+      <Annotation Term="Redfish.OwningEntity" String="DMTF"/>
+      <Annotation Term="Redfish.Release" String="2021.1"/>
+
+      <EntityType Name="USBController" BaseType="USBController.USBController">
+        <Property Name="Manufacturer" Type="Edm.String">
+          <Annotation Term="OData.Permissions" EnumMember="OData.Permission/Read"/>
+          <Annotation Term="OData.Description" String="The manufacturer of this USB controller."/>
+          <Annotation Term="OData.LongDescription" String="This property shall contain the name of the organization responsible for producing the USB controller.  This organization may be the entity from which the USB controller is purchased, but this is not necessarily true."/>
+        </Property>
+        <Property Name="Model" Type="Edm.String">
+          <Annotation Term="OData.Permissions" EnumMember="OData.Permission/Read"/>
+          <Annotation Term="OData.Description" String="The product model number of this USB controller."/>
+          <Annotation Term="OData.LongDescription" String="This property shall contain the manufacturer-provided model information of this USB controller."/>
+        </Property>
+        <Property Name="SKU" Type="Edm.String">
+          <Annotation Term="OData.Permissions" EnumMember="OData.Permission/Read"/>
+          <Annotation Term="OData.Description" String="The SKU for this USB controller."/>
+          <Annotation Term="OData.LongDescription" String="This property shall contain the SKU number for this USB controller."/>
+        </Property>
+        <Property Name="SerialNumber" Type="Edm.String">
+          <Annotation Term="OData.Permissions" EnumMember="OData.Permission/Read"/>
+          <Annotation Term="OData.Description" String="The serial number for this USB controller."/>
+          <Annotation Term="OData.LongDescription" String="This property shall contain a manufacturer-allocated number that identifies the USB controller."/>
+        </Property>
+        <Property Name="PartNumber" Type="Edm.String">
+          <Annotation Term="OData.Permissions" EnumMember="OData.Permission/Read"/>
+          <Annotation Term="OData.Description" String="The part number for this USB controller."/>
+          <Annotation Term="OData.LongDescription" String="This property shall contain the manufacturer-provided part number for the USB controller."/>
+        </Property>
+        <Property Name="SparePartNumber" Type="Edm.String">
+          <Annotation Term="OData.Permissions" EnumMember="OData.Permission/Read"/>
+          <Annotation Term="OData.Description" String="The spare part number of the USB controller."/>
+          <Annotation Term="OData.LongDescription" String="This property shall contain the spare part number of the USB controller."/>
+        </Property>
+        <Property Name="Status" Type="Resource.Status" Nullable="false">
+          <Annotation Term="OData.Description" String="The status and health of the resource and its subordinate or dependent resources."/>
+          <Annotation Term="OData.LongDescription" String="This property shall contain any status or health properties of the resource."/>
+        </Property>
+        <NavigationProperty Name="Ports" Type="PortCollection.PortCollection" Nullable="false">
+          <Annotation Term="OData.Description" String="The ports of the USB controller."/>
+          <Annotation Term="OData.LongDescription" String="This property shall contain a link to a resource collection of type PortCollection."/>
+        </NavigationProperty>
+        <Property Name="Links" Type="USBController.v1_0_0.Links" Nullable="false">
+          <Annotation Term="OData.Description" String="The links to other resources that are related to this resource."/>
+          <Annotation Term="OData.LongDescription" String="This property shall contain links to resources that are related to but are not contained by, or subordinate to, this resource."/>
+        </Property>
+        <Property Name="Actions" Type="USBController.v1_0_0.Actions" Nullable="false">
+          <Annotation Term="OData.Description" String="The available actions for this resource."/>
+          <Annotation Term="OData.LongDescription" String="This property shall contain the available actions for this resource."/>
+        </Property>
+      </EntityType>
+
+      <ComplexType Name="Links" BaseType="Resource.Links">
+        <Annotation Term="OData.Description" String="The links to other resources that are related to this resource."/>
+        <Annotation Term="OData.LongDescription" String="This Redfish Specification-described type shall contain links to resources that are related to but are not contained by, or subordinate to, this resource."/>
+        <NavigationProperty Name="Processors" Type="Collection(Processor.Processor)">
+          <Annotation Term="OData.Permissions" EnumMember="OData.Permission/Read"/>
+          <Annotation Term="OData.Description" String="An array of links to the processors that can utilize this USB controller."/>
+          <Annotation Term="OData.LongDescription" String="This property shall contain an array of links to resources of type Processor that represent processors that can utilize this USB controller."/>
+          <Annotation Term="OData.AutoExpandReferences"/>
+        </NavigationProperty>
+        <NavigationProperty Name="PCIeDevice" Type="PCIeDevice.PCIeDevice">
+          <Annotation Term="OData.Permissions" EnumMember="OData.Permission/Read"/>
+          <Annotation Term="OData.Description" String="A link to the PCIe device that represents this USB controller."/>
+          <Annotation Term="OData.LongDescription" String="This property shall contain a link to a resource of type PCIeDevice that represents this USB controller."/>
+          <Annotation Term="OData.AutoExpandReferences"/>
+        </NavigationProperty>
+      </ComplexType>
+
+      <ComplexType Name="Actions">
+        <Annotation Term="OData.AdditionalProperties" Bool="false"/>
+        <Annotation Term="OData.Description" String="The available actions for this resource."/>
+        <Annotation Term="OData.LongDescription" String="This type shall contain the available actions for this resource."/>
+        <Property Name="Oem" Type="USBController.v1_0_0.OemActions" Nullable="false">
+          <Annotation Term="OData.Description" String="The available OEM-specific actions for this resource."/>
+          <Annotation Term="OData.LongDescription" String="This property shall contain the available OEM-specific actions for this resource."/>
+        </Property>
+      </ComplexType>
+
+      <ComplexType Name="OemActions">
+        <Annotation Term="OData.AdditionalProperties" Bool="true"/>
+        <Annotation Term="OData.Description" String="The available OEM-specific actions for this resource."/>
+        <Annotation Term="OData.LongDescription" String="This type shall contain the available OEM-specific actions for this resource."/>
+      </ComplexType>
+    </Schema>
+
+  </edmx:DataServices>
+</edmx:Edmx>

--- a/static/redfish/v1/schema/VCATEntryCollection_v1.xml
+++ b/static/redfish/v1/schema/VCATEntryCollection_v1.xml
@@ -1,0 +1,72 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!---->
+<!--################################################################################       -->
+<!--# Redfish Schema:  VCATEntryCollection                                                 -->
+<!--#                                                                                      -->
+<!--# For a detailed change log, see the README file contained in the DSP8010 bundle,      -->
+<!--# available at http://www.dmtf.org/standards/redfish                                   -->
+<!--# Copyright 2014-2021 DMTF.                                                            -->
+<!--# For the full DMTF copyright policy, see http://www.dmtf.org/about/policies/copyright -->
+<!--################################################################################       -->
+<!---->
+<edmx:Edmx xmlns:edmx="http://docs.oasis-open.org/odata/ns/edmx" Version="4.0">
+
+  <edmx:Reference Uri="http://docs.oasis-open.org/odata/odata/v4.0/errata03/csd01/complete/vocabularies/Org.OData.Core.V1.xml">
+    <edmx:Include Namespace="Org.OData.Core.V1" Alias="OData"/>
+  </edmx:Reference>
+  <edmx:Reference Uri="http://docs.oasis-open.org/odata/odata/v4.0/errata03/csd01/complete/vocabularies/Org.OData.Capabilities.V1.xml">
+    <edmx:Include Namespace="Org.OData.Capabilities.V1" Alias="Capabilities"/>
+  </edmx:Reference>
+  <edmx:Reference Uri="http://redfish.dmtf.org/schemas/v1/Resource_v1.xml">
+    <edmx:Include Namespace="Resource.v1_0_0"/>
+  </edmx:Reference>
+  <edmx:Reference Uri="http://redfish.dmtf.org/schemas/v1/RedfishExtensions_v1.xml">
+    <edmx:Include Namespace="RedfishExtensions.v1_0_0" Alias="Redfish"/>
+  </edmx:Reference>
+  <edmx:Reference Uri="http://redfish.dmtf.org/schemas/v1/VCATEntry_v1.xml">
+    <edmx:Include Namespace="VCATEntry"/>
+  </edmx:Reference>
+
+   <edmx:DataServices>
+
+    <Schema xmlns="http://docs.oasis-open.org/odata/ns/edm" Namespace="VCATEntryCollection">
+      <Annotation Term="Redfish.OwningEntity" String="DMTF"/>
+
+      <EntityType Name="VCATEntryCollection" BaseType="Resource.v1_0_0.ResourceCollection">
+        <Annotation Term="OData.Description" String="The collection of VCATEntry Resource instances."/>
+        <Annotation Term="OData.LongDescription" String="This Resource shall represent a Resource Collection of VCATEntry instances for a Redfish implementation."/>
+        <Annotation Term="Capabilities.InsertRestrictions">
+          <Record>
+            <PropertyValue Property="Insertable" Bool="true"/>
+          </Record>
+        </Annotation>
+        <Annotation Term="Capabilities.UpdateRestrictions">
+          <Record>
+            <PropertyValue Property="Updatable" Bool="false"/>
+          </Record>
+        </Annotation>
+        <Annotation Term="Capabilities.DeleteRestrictions">
+          <Record>
+            <PropertyValue Property="Deletable" Bool="false"/>
+          </Record>
+        </Annotation>
+        <Annotation Term="Redfish.Uris">
+          <Collection>
+            <String>/redfish/v1/Fabrics/{FabricId}/Switches/{SwitchId}/Ports/{PortId}/VCAT</String>
+            <String>/redfish/v1/Systems/{SystemId}/FabricAdapters/{FabricAdapterId}/Ports/{PortId}/VCAT</String>
+            <String>/redfish/v1/Systems/{SystemId}/FabricAdapters/{FabricAdapterId}/REQ-VCAT</String>
+            <String>/redfish/v1/Systems/{SystemId}/FabricAdapters/{FabricAdapterId}/RSP-VCAT</String>
+          </Collection>
+        </Annotation>
+        <NavigationProperty Name="Members" Type="Collection(VCATEntry.VCATEntry)">
+          <Annotation Term="OData.Permissions" EnumMember="OData.Permission/Read"/>
+          <Annotation Term="OData.Description" String="The members of this collection."/>
+          <Annotation Term="OData.LongDescription" String="This property shall contain an array of links to the members of this collection."/>
+          <Annotation Term="OData.AutoExpandReferences"/>
+          <Annotation Term="Redfish.Required"/>
+        </NavigationProperty>
+      </EntityType>
+    </Schema>
+
+  </edmx:DataServices>
+</edmx:Edmx>

--- a/static/redfish/v1/schema/VCATEntry_v1.xml
+++ b/static/redfish/v1/schema/VCATEntry_v1.xml
@@ -1,0 +1,126 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!---->
+<!--################################################################################       -->
+<!--# Redfish Schema:  VCATEntry v1.0.1                                                    -->
+<!--#                                                                                      -->
+<!--# For a detailed change log, see the README file contained in the DSP8010 bundle,      -->
+<!--# available at http://www.dmtf.org/standards/redfish                                   -->
+<!--# Copyright 2014-2021 DMTF.                                                            -->
+<!--# For the full DMTF copyright policy, see http://www.dmtf.org/about/policies/copyright -->
+<!--################################################################################       -->
+<!---->
+<edmx:Edmx xmlns:edmx="http://docs.oasis-open.org/odata/ns/edmx" Version="4.0">
+
+  <edmx:Reference Uri="http://docs.oasis-open.org/odata/odata/v4.0/errata03/csd01/complete/vocabularies/Org.OData.Core.V1.xml">
+    <edmx:Include Namespace="Org.OData.Core.V1" Alias="OData"/>
+  </edmx:Reference>
+  <edmx:Reference Uri="http://redfish.dmtf.org/schemas/v1/RedfishExtensions_v1.xml">
+    <edmx:Include Namespace="RedfishExtensions.v1_0_0" Alias="Redfish"/>
+    <edmx:Include Namespace="Validation.v1_0_0" Alias="Validation"/>
+  </edmx:Reference>
+  <edmx:Reference Uri="http://docs.oasis-open.org/odata/odata/v4.0/errata03/csd01/complete/vocabularies/Org.OData.Capabilities.V1.xml">
+    <edmx:Include Namespace="Org.OData.Capabilities.V1" Alias="Capabilities"/>
+  </edmx:Reference>
+  <edmx:Reference Uri="http://redfish.dmtf.org/schemas/v1/Resource_v1.xml">
+    <edmx:Include Namespace="Resource"/>
+    <edmx:Include Namespace="Resource.v1_0_0"/>
+  </edmx:Reference>
+
+  <edmx:DataServices>
+
+    <Schema xmlns="http://docs.oasis-open.org/odata/ns/edm" Namespace="VCATEntry">
+      <Annotation Term="Redfish.OwningEntity" String="DMTF"/>
+
+      <EntityType Name="VCATEntry" BaseType="Resource.v1_0_0.Resource" Abstract="true">
+        <Annotation Term="OData.Description" String="The VCATEntry schema defines an entry in a Virtual Channel Action Table.  A Virtual Channel is a mechanism used to create multiple, logical communication streams across a physical link."/>
+        <Annotation Term="OData.LongDescription" String="This resource shall represent and entry of Virtual Channel Action Table in a Redfish implementation."/>
+        <Annotation Term="OData.AdditionalProperties" Bool="false"/>
+        <Annotation Term="Capabilities.InsertRestrictions">
+          <Record>
+            <PropertyValue Property="Insertable" Bool="false"/>
+          </Record>
+        </Annotation>
+        <Annotation Term="Capabilities.UpdateRestrictions">
+          <Record>
+            <PropertyValue Property="Updatable" Bool="true"/>
+          </Record>
+        </Annotation>
+        <Annotation Term="Capabilities.DeleteRestrictions">
+          <Record>
+            <PropertyValue Property="Deletable" Bool="true"/>
+          </Record>
+        </Annotation>
+        <Annotation Term="Redfish.Uris">
+          <Collection>
+            <String>/redfish/v1/Fabrics/{FabricId}/Switches/{SwitchId}/Ports/{PortId}/VCAT/{VCATEntryId}</String>
+            <String>/redfish/v1/Systems/{SystemId}/FabricAdapters/{FabricAdapterId}/Ports/{PortId}/VCAT/{VCATEntryId}</String>
+            <String>/redfish/v1/Systems/{SystemId}/FabricAdapters/{FabricAdapterId}/REQ-VCAT/{VCATEntryId}</String>
+            <String>/redfish/v1/Systems/{SystemId}/FabricAdapters/{FabricAdapterId}/RSP-VCAT/{VCATEntryId}</String>
+          </Collection>
+        </Annotation>
+      </EntityType>
+    </Schema>
+
+    <Schema xmlns="http://docs.oasis-open.org/odata/ns/edm" Namespace="VCATEntry.v1_0_0">
+      <Annotation Term="Redfish.OwningEntity" String="DMTF"/>
+      <Annotation Term="Redfish.Release" String="2019.4"/>
+
+      <EntityType Name="VCATEntry" BaseType="VCATEntry.VCATEntry">
+        <Property Name="RawEntryHex" Type="Edm.String">
+          <Annotation Term="OData.Permissions" EnumMember="OData.Permission/ReadWrite"/>
+          <Annotation Term="OData.Description" String="The hexadecimal value of the Virtual Channel Action Table entries."/>
+          <Annotation Term="OData.LongDescription" String="This property shall contain the hexadecimal value of the Virtual Channel Action Table entries.  The length of hexadecimal value depends on the number of Virtual Channel Action entries supported by the component."/>
+          <Annotation Term="Validation.Pattern" String="^0[xX](([a-fA-F]|[0-9])*)$"/>
+        </Property>
+        <Property Name="VCEntries" Type="Collection(VCATEntry.v1_0_0.VCATableEntry)" Nullable="false">
+          <Annotation Term="OData.Description" String="An array of entries of the Virtual Channel Action Table."/>
+          <Annotation Term="OData.LongDescription" String="This property shall contain an array of entries of the Virtual Channel Action Table.  The length of the array depends on the number of Virtual Channel Action entries supported by the component."/>
+        </Property>
+        <Property Name="Actions" Type="VCATEntry.v1_0_0.Actions" Nullable="false">
+          <Annotation Term="OData.Description" String="The available actions for this resource."/>
+          <Annotation Term="OData.LongDescription" String="This property shall contain the available actions for this resource."/>
+        </Property>
+      </EntityType>
+
+      <ComplexType Name="VCATableEntry">
+        <Annotation Term="OData.Description" String="The Virtual Channel Action Table entry corresponding to a specific Virtual Channel."/>
+        <Annotation Term="OData.LongDescription" String="This type shall contain a Virtual Channel entry definition that describes a specific Virtual Channel."/>
+        <Property Name="VCMask" Type="Edm.String">
+          <Annotation Term="OData.Permissions" EnumMember="OData.Permission/ReadWrite"/>
+          <Annotation Term="OData.Description" String="The bits corresponding to the supported Virtual Channel."/>
+          <Annotation Term="OData.LongDescription" String="This property shall contain a 32-bit value where the bits correspond to a supported Virtual Channel."/>
+          <Annotation Term="Validation.Pattern" String="^0[xX](([a-fA-F]|[0-9]){2}){4}$"/>
+        </Property>
+        <Property Name="Threshold" Type="Edm.String">
+          <Annotation Term="OData.Permissions" EnumMember="OData.Permission/ReadWrite"/>
+          <Annotation Term="OData.Description" String="The configured threshold."/>
+          <Annotation Term="OData.LongDescription" String="This property shall contain the Gen-Z Core Specification-defined 'TH' 7-bit threshold."/>
+          <Annotation Term="Validation.Pattern" String="^0[xX]([a-fA-F]|[0-9]){2}$"/>
+        </Property>
+      </ComplexType>
+
+      <ComplexType Name="Actions">
+        <Annotation Term="OData.AdditionalProperties" Bool="false"/>
+        <Annotation Term="OData.Description" String="The available actions for this resource."/>
+        <Annotation Term="OData.LongDescription" String="This type shall contain the available actions for this resource."/>
+        <Property Name="Oem" Type="VCATEntry.v1_0_0.OemActions" Nullable="false">
+          <Annotation Term="OData.Description" String="The available OEM-specific actions for this resource."/>
+          <Annotation Term="OData.LongDescription" String="This property shall contain the available OEM-specific actions for this resource."/>
+        </Property>
+      </ComplexType>
+
+      <ComplexType Name="OemActions">
+        <Annotation Term="OData.AdditionalProperties" Bool="true"/>
+        <Annotation Term="OData.Description" String="The available OEM-specific actions for this resource."/>
+        <Annotation Term="OData.LongDescription" String="This type shall contain the available OEM-specific actions for this resource."/>
+      </ComplexType>
+    </Schema>
+
+    <Schema xmlns="http://docs.oasis-open.org/odata/ns/edm" Namespace="VCATEntry.v1_0_1">
+      <Annotation Term="Redfish.OwningEntity" String="DMTF"/>
+      <Annotation Term="OData.Description" String="This version was created to correct the permissions for several properties to be writable."/>
+      <EntityType Name="VCATEntry" BaseType="VCATEntry.v1_0_0.VCATEntry"/>
+    </Schema>
+
+  </edmx:DataServices>
+</edmx:Edmx>

--- a/static/redfish/v1/schema/VolumeCollection_v1.xml
+++ b/static/redfish/v1/schema/VolumeCollection_v1.xml
@@ -1,0 +1,79 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!---->
+<!-- Copyright 2015-2019 Storage Networking Industry Association (SNIA), USA. All rights reserved.-->
+<edmx:Edmx xmlns:edmx="http://docs.oasis-open.org/odata/ns/edmx" Version="4.0">
+
+  <edmx:Reference Uri="http://docs.oasis-open.org/odata/odata/v4.0/errata03/csd01/complete/vocabularies/Org.OData.Core.V1.xml">
+    <edmx:Include Namespace="Org.OData.Core.V1" Alias="OData"/>
+  </edmx:Reference>
+  <edmx:Reference Uri="http://docs.oasis-open.org/odata/odata/v4.0/errata03/csd01/complete/vocabularies/Org.OData.Capabilities.V1.xml">
+    <edmx:Include Namespace="Org.OData.Capabilities.V1" Alias="Capabilities"/>
+  </edmx:Reference>
+  <edmx:Reference Uri="http://redfish.dmtf.org/schemas/v1/Resource_v1.xml">
+    <edmx:Include Namespace="Resource.v1_0_0"/>
+  </edmx:Reference>
+  <edmx:Reference Uri="http://redfish.dmtf.org/schemas/v1/RedfishExtensions_v1.xml">
+    <edmx:Include Namespace="RedfishExtensions.v1_0_0" Alias="Redfish"/>
+  </edmx:Reference>
+  <edmx:Reference Uri="http://redfish.dmtf.org/schemas/swordfish/v1/Volume_v1.xml">
+    <edmx:Include Namespace="Volume"/>
+  </edmx:Reference>
+  <edmx:DataServices>
+
+    <Schema xmlns="http://docs.oasis-open.org/odata/ns/edm" Namespace="VolumeCollection">
+      <Annotation Term="Redfish.OwningEntity" String="SNIA"/>
+      <EntityType Name="VolumeCollection" BaseType="Resource.v1_0_0.ResourceCollection">
+        <Annotation Term="OData.Description" String="A Collection of Volume resource instances."/>
+        <Annotation Term="OData.LongDescription" String="This collection shall contain references to all Volume resource instances sharing the same parent resource."/>
+        <Annotation Term="Capabilities.InsertRestrictions">
+          <Record>
+            <PropertyValue Property="Insertable" Bool="true"/>
+            <Annotation Term="OData.Description" String="Volume collections may support adding Volume resources by clients."/>
+          </Record>
+        </Annotation>
+        <Annotation Term="Capabilities.UpdateRestrictions">
+          <Record>
+            <PropertyValue Property="Updatable" Bool="false"/>
+          </Record>
+        </Annotation>
+        <Annotation Term="Capabilities.DeleteRestrictions">
+          <Record>
+            <PropertyValue Property="Deletable" Bool="false"/>
+          </Record>
+        </Annotation>
+        <Annotation Term="Redfish.Uris">
+          <Collection>
+            <String>/redfish/v1/CompositionService/ResourceBlocks/{ResourceBlockId}/Storage/{StorageId}/Volumes</String>
+            <String>/redfish/v1/CompositionService/ResourceBlocks/{ResourceBlockId}/Systems/{ComputerSystemId}/Storage/{StorageId}/Volumes</String>
+            <String>/redfish/v1/ResourceBlocks/{ResourceBlockId}/Storage/{StorageId}/Volumes</String>
+            <String>/redfish/v1/ResourceBlocks/{ResourceBlockId}/Systems/{ComputerSystemId}/Storage/{StorageId}/Volumes</String>
+            <String>/redfish/v1/Storage/{StorageId}/ConsistencyGroups/{ConsistencyGroupId}/Volumes</String>
+            <String>/redfish/v1/Storage/{StorageId}/FileSystems/{FileSystemId}/CapacitySources/{CapacitySourceId}/ProvidingVolumes</String>
+            <String>/redfish/v1/Storage/{StorageId}/StoragePools/{StoragePoolId}/AllocatedVolumes</String>
+            <String>/redfish/v1/Storage/{StorageId}/StoragePools/{StoragePoolId}/CapacitySources/{CapacitySourceId}/ProvidingVolumes</String>
+            <String>/redfish/v1/Storage/{StorageId}/Volumes</String>
+            <String>/redfish/v1/Systems/{ComputerSystemId}/Storage/{StorageId}/ConsistencyGroups/{ConsistencyGroupId}/Volumes</String>
+            <String>/redfish/v1/Systems/{ComputerSystemId}/Storage/{StorageId}/FileSystems/{FileSystemId}/CapacitySources/{CapacitySourceId}/ProvidingVolumes</String>
+            <String>/redfish/v1/Systems/{ComputerSystemId}/Storage/{StorageId}/StoragePools/{StoragePoolId}/AllocatedVolumes</String>
+            <String>/redfish/v1/Systems/{ComputerSystemId}/Storage/{StorageId}/StoragePools/{StoragePoolId}/CapacitySources/{CapacitySourceId}/ProvidingVolumes</String>
+            <String>/redfish/v1/Systems/{ComputerSystemId}/Storage/{StorageId}/Volumes</String>
+            <String>/redfish/v1/StorageServices/{StorageServiceId}/ConsistencyGroups/{ConsistencyGroupId}/Volumes</String>
+            <String>/redfish/v1/StorageServices/{StorageServiceId}/FileSystems/{FileSystemId}/CapacitySources/{CapacitySourceId}/ProvidingVolumes</String>
+            <String>/redfish/v1/StorageServices/{StorageServiceId}/StoragePools/{StoragePoolId}/AllocatedVolumes</String>
+            <String>/redfish/v1/StorageServices/{StorageServiceId}/StoragePools/{StoragePoolId}/CapacitySources/{CapacitySourceId}/ProvidingVolumes</String>
+            <String>/redfish/v1/StorageServices/{StorageServiceId}/Volumes</String>
+            <String>/redfish/v1/StorageServices/{StorageServiceId}/Volumes/{VolumeId}/CapacitySources/{CapacitySourceId}/ProvidingVolumes</String>
+          </Collection>
+        </Annotation>
+        <NavigationProperty Name="Members" Type="Collection(Volume.Volume)">
+          <Annotation Term="OData.Permissions" EnumMember="OData.Permission/Read"/>
+          <Annotation Term="OData.Description" String="The value of each member references a Volume resource."/>
+          <Annotation Term="OData.LongDescription" String="The value of each member entry shall reference a Volume resource."/>
+          <Annotation Term="OData.AutoExpandReferences"/>
+          <Annotation Term="Redfish.Required"/>
+        </NavigationProperty>
+      </EntityType>
+
+    </Schema>
+  </edmx:DataServices>
+</edmx:Edmx>

--- a/static/redfish/v1/schema/Volume_v1.xml
+++ b/static/redfish/v1/schema/Volume_v1.xml
@@ -1,0 +1,1261 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!---->
+<!-- Copyright 2015-2019 Storage Networking Industry Association (SNIA), USA, in cooperation with the DMTF. All rights reserved.-->
+<!---->
+
+<edmx:Edmx xmlns:edmx="http://docs.oasis-open.org/odata/ns/edmx" Version="4.0">
+
+  <edmx:Reference Uri="http://docs.oasis-open.org/odata/odata/v4.0/errata03/csd01/complete/vocabularies/Org.OData.Core.V1.xml">
+    <edmx:Include Namespace="Org.OData.Core.V1" Alias="OData"/>
+  </edmx:Reference>
+  <edmx:Reference Uri="http://docs.oasis-open.org/odata/odata/v4.0/errata03/csd01/complete/vocabularies/Org.OData.Capabilities.V1.xml">
+    <edmx:Include Namespace="Org.OData.Capabilities.V1" Alias="Capabilities"/>
+  </edmx:Reference>
+  <edmx:Reference Uri="http://docs.oasis-open.org/odata/odata/v4.0/errata03/csd01/complete/vocabularies/Org.OData.Measures.V1.xml">
+    <edmx:Include Namespace="Org.OData.Measures.V1" Alias="Measures"/>
+  </edmx:Reference>
+  <edmx:Reference Uri="http://redfish.dmtf.org/schemas/v1/RedfishExtensions_v1.xml">
+    <edmx:Include Namespace="RedfishExtensions.v1_0_0" Alias="Redfish"/>
+    <edmx:Include Namespace="Validation.v1_0_0" Alias="Validation"/>
+  </edmx:Reference>
+  <edmx:Reference Uri="http://redfish.dmtf.org/schemas/v1/Resource_v1.xml">
+    <edmx:Include Namespace="Resource"/>
+    <edmx:Include Namespace="Resource.v1_0_0"/>
+  </edmx:Reference>
+  <edmx:Reference Uri="http://redfish.dmtf.org/schemas/v1/Storage_v1.xml">
+    <edmx:Include Namespace="Storage"/>
+  </edmx:Reference>
+  <edmx:Reference Uri="http://redfish.dmtf.org/schemas/v1/Drive_v1.xml">
+    <edmx:Include Namespace="Drive"/>
+  </edmx:Reference>
+  <edmx:Reference Uri="http://redfish.dmtf.org/schemas/swordfish/v1/FeaturesRegistry_v1.xml">
+    <edmx:Include Namespace="FeaturesRegistry"/>
+  </edmx:Reference>
+  <edmx:Reference Uri="http://redfish.dmtf.org/schemas/v1/Endpoint_v1.xml">
+    <edmx:Include Namespace="Endpoint"/>
+  </edmx:Reference>
+  <edmx:Reference Uri="http://redfish.dmtf.org/schemas/swordfish/v1/DataStorageLoSCapabilities_v1.xml">
+    <edmx:Include Namespace="DataStorageLoSCapabilities"/>
+  </edmx:Reference>
+  <edmx:Reference Uri="http://redfish.dmtf.org/schemas/swordfish/v1/ClassOfService_v1.xml">
+    <edmx:Include Namespace="ClassOfService"/>
+  </edmx:Reference>
+  <edmx:Reference Uri="http://redfish.dmtf.org/schemas/swordfish/v1/Capacity_v1.xml">
+    <edmx:Include Namespace="Capacity"/>
+    <edmx:Include Namespace="Capacity.v1_0_0"/>
+  </edmx:Reference>
+  <edmx:Reference Uri="http://redfish.dmtf.org/schemas/swordfish/v1/StoragePoolCollection_v1.xml">
+    <edmx:Include Namespace="StoragePoolCollection"/>
+  </edmx:Reference>
+  <edmx:Reference Uri="http://redfish.dmtf.org/schemas/swordfish/v1/StorageGroupCollection_v1.xml">
+    <edmx:Include Namespace="StorageGroupCollection"/>
+  </edmx:Reference>
+  <edmx:Reference Uri="http://redfish.dmtf.org/schemas/swordfish/v1/StorageGroup_v1.xml">
+    <edmx:Include Namespace="StorageGroup"/>
+  </edmx:Reference>
+  <edmx:Reference Uri="http://redfish.dmtf.org/schemas/swordfish/v1/ConsistencyGroupCollection_v1.xml">
+    <edmx:Include Namespace="ConsistencyGroupCollection"/>
+  </edmx:Reference>
+  <edmx:Reference Uri="http://redfish.dmtf.org/schemas/swordfish/v1/ConsistencyGroup_v1.xml">
+    <edmx:Include Namespace="ConsistencyGroup"/>
+  </edmx:Reference>
+  <edmx:Reference Uri="http://redfish.dmtf.org/schemas/swordfish/v1/StorageReplicaInfo_v1.xml">
+    <edmx:Include Namespace="StorageReplicaInfo"/>
+    <edmx:Include Namespace="StorageReplicaInfo.v1_3_0"/>
+  </edmx:Reference>
+  <edmx:Reference Uri="http://redfish.dmtf.org/schemas/swordfish/v1/IOStatistics_v1.xml">
+    <edmx:Include Namespace="IOStatistics"/>
+  </edmx:Reference>
+  <edmx:Reference Uri="http://redfish.dmtf.org/schemas/swordfish/v1/SpareResourceSet_v1.xml">
+    <edmx:Include Namespace="SpareResourceSet"/>
+  </edmx:Reference>
+  <edmx:Reference Uri="http://redfish.dmtf.org/schemas/swordfish/v1/StorageService_v1.xml">
+    <edmx:Include Namespace="StorageService"/>
+  </edmx:Reference>
+
+  <edmx:DataServices>
+
+    <Schema xmlns="http://docs.oasis-open.org/odata/ns/edm" Namespace="Volume">
+      <Annotation Term="Redfish.OwningEntity" String="SNIA"/>
+      <EntityType Name="Volume" BaseType="Resource.v1_0_0.Resource" Abstract="true">
+        <Annotation Term="OData.Description" String="Volume contains properties used to describe a volume, virtual disk, LUN, or other logical storage entity for any system."/>
+        <Annotation Term="OData.LongDescription" String="This resource shall be used to represent a volume, virtual disk, logical disk, LUN, or other logical storage for a Redfish implementation."/>
+        <Annotation Term="Capabilities.InsertRestrictions">
+          <Record>
+            <PropertyValue Property="Insertable" Bool="false"/>
+          </Record>
+        </Annotation>
+        <Annotation Term="Capabilities.UpdateRestrictions">
+          <Record>
+            <PropertyValue Property="Updatable" Bool="true"/>
+            <Annotation Term="OData.Description" String="Volumes can be updated to change the writable properties."/>
+          </Record>
+        </Annotation>
+        <Annotation Term="Capabilities.DeleteRestrictions">
+          <Record>
+            <PropertyValue Property="Deletable" Bool="true"/>
+            <Annotation Term="OData.Description" String="Volumes can be deleted by deleting the Volume resource."/>
+          </Record>
+        </Annotation>
+        <Annotation Term="Redfish.Uris">
+          <Collection>
+            <String>/redfish/v1/CompositionService/ResourceBlocks/{ResourceBlockId}/Storage/{StorageId}/Volumes/{VolumeId}</String>
+            <String>/redfish/v1/CompositionService/ResourceBlocks/{ResourceBlockId}/Systems/{ComputerSystemId}/Storage/{StorageId}/Volumes/{VolumeId}</String>
+            <String>/redfish/v1/ResourceBlocks/{ResourceBlockId}/Storage/{StorageId}/Volumes/{VolumeId}</String>
+            <String>/redfish/v1/ResourceBlocks/{ResourceBlockId}/Systems/{ComputerSystemId}/Storage/{StorageId}/Volumes/{VolumeId}</String>
+            <String>/redfish/v1/Storage/{StorageId}/ConsistencyGroups/{ConsistencyGroupId}/Volumes/{VolumeId}</String>
+            <String>/redfish/v1/Storage/{StorageId}/FileSystems/{FileSystemId}/CapacitySources/{CapacitySourceId}/ProvidingVolumes/{VolumeId}</String>
+            <String>/redfish/v1/Storage/{StorageId}/StoragePools/{StoragePoolId}/AllocatedVolumes/{VolumeId}</String>
+            <String>/redfish/v1/Storage/{StorageId}/StoragePools/{StoragePoolId}/CapacitySources/{CapacitySourceId}/ProvidingVolumes/{VolumeId}</String>
+            <String>/redfish/v1/Storage/{StorageId}/Volumes/{VolumeId}</String>
+            <String>/redfish/v1/Systems/{ComputerSystemId}/Storage/{StorageId}/ConsistencyGroups/{ConsistencyGroupId}/Volumes/{VolumeId}</String>
+            <String>/redfish/v1/Systems/{ComputerSystemId}/Storage/{StorageId}/FileSystems/{FileSystemId}/CapacitySources/{CapacitySourceId}/ProvidingVolumes/{VolumeId}</String>
+            <String>/redfish/v1/Systems/{ComputerSystemId}/Storage/{StorageId}/StoragePools/{StoragePoolId}/AllocatedVolumes/{VolumeId}</String>
+            <String>/redfish/v1/Systems/{ComputerSystemId}/Storage/{StorageId}/StoragePools/{StoragePoolId}/CapacitySources/{CapacitySourceId}/ProvidingVolumes/{VolumeId}</String>
+            <String>/redfish/v1/Systems/{ComputerSystemId}/Storage/{StorageId}/Volumes/{VolumeId}</String>
+            <String>/redfish/v1/StorageServices/{StorageServiceId}/ConsistencyGroups/{ConsistencyGroupId}/Volumes/{VolumeId}</String>
+            <String>/redfish/v1/StorageServices/{StorageServiceId}/FileSystems/{FileSystemId}/CapacitySources/{CapacitySourceId}/ProvidingVolumes/{VolumeId}</String>
+            <String>/redfish/v1/StorageServices/{StorageServiceId}/StoragePools/{StoragePoolId}/AllocatedVolumes/{VolumeId}</String>
+            <String>/redfish/v1/StorageServices/{StorageServiceId}/StoragePools/{StoragePoolId}/CapacitySources/{CapacitySourceId}/ProvidingVolumes/{VolumeId}</String>
+            <String>/redfish/v1/StorageServices/{StorageServiceId}/Volumes/{VolumeId}</String>
+            <String>/redfish/v1/StorageServices/{StorageServiceId}/Volumes/{VolumeId}/CapacitySources/{CapacitySourceId}/ProvidingVolumes/{ProvidingVolumeId}</String>
+          </Collection>
+        </Annotation>
+      </EntityType>
+
+      <Action Name="Initialize" IsBound="true">
+        <Annotation
+          Term="OData.Description"
+          String="This action is used to prepare the contents of the volume for use by the system. If InitializeMethod is not specified in the request body, but the property InitializeMethod is specified, the property InitializeMethod value should be used. If neither is specified, the InitializeMethod should be Foreground."/>
+        <Annotation
+          Term="OData.LongDescription"
+          String="This defines the name of the custom action supported on this resource. If InitializeMethod is not specified in the request body, but the property InitializeMethod is specified, the property InitializeMethod value should be used. If neither is specified, the InitializeMethod should be Foreground."/>
+        <Parameter Name="Volume" Type="Volume.v1_0_0.Actions"/>
+        <Parameter Name="InitializeMethod" Type="Volume.InitializeMethod">
+          <Annotation Term="OData.Description" String="The type of initialization to be performed."/>
+          <Annotation Term="OData.LongDescription" String="This defines the property name for the action."/>
+        </Parameter>
+        <Annotation Term="Redfish.Revisions">
+          <Collection>
+            <Record>
+              <PropertyValue Property="Kind" EnumMember="Redfish.RevisionKind/Added"/>
+              <PropertyValue Property="Version" String="v1_5_0"/>
+            </Record>
+          </Collection>
+        </Annotation>
+        <Parameter Name="InitializeType" Type="Volume.InitializeType">
+          <Annotation Term="OData.Description" String="The type of initialization to be performed."/>
+          <Annotation Term="OData.LongDescription" String="This defines the property name for the action."/>
+          <Annotation Term="Redfish.Deprecated" String="Deprecated in favor of the InitializeMethod property."/>
+        </Parameter>
+
+      </Action>
+
+      <Action Name="CheckConsistency">
+        <Parameter Name="Volume" Type="Volume.v1_0_0.Actions"/>
+        <Annotation Term="OData.Description" String="This action is used to force a check of the Volume's parity or redundant data to ensure it matches calculated values."/>
+        <Annotation Term="OData.LongDescription" String="This defines the name of the custom action supported on this resource."/>
+      </Action>
+
+      <Action Name="AssignReplicaTarget" IsBound="true">
+        <Parameter Name="Volume" Type="Volume.v1_0_0.Actions"/>
+        <Parameter Name="ReplicaUpdateMode" Type="StorageReplicaInfo.ReplicaUpdateMode" Nullable="false">
+          <Annotation Term="OData.Description" String="The replica update mode (synchronous vs asynchronous)."/>
+          <Annotation Term="OData.LongDescription" String="This parameter shall specify the replica update mode."/>
+        </Parameter>
+        <Parameter Name="TargetVolume" Type="Edm.String" Nullable="false">
+          <Annotation Term="OData.Description" String="The Uri to the existing target volume."/>
+          <Annotation Term="OData.LongDescription" String="This parameter shall contain the Uri to the existing target volume."/>
+        </Parameter>
+        <Parameter Name="ReplicaType" Type="StorageReplicaInfo.ReplicaType" Nullable="false">
+          <Annotation Term="OData.Description" String="The type of replica relationship to be created."/>
+          <Annotation Term="OData.LongDescription" String="This parameter shall contain the type of replica relationship to be created (e.g., Clone, Mirror, Snap)."/>
+        </Parameter>
+        <Annotation Term="OData.Description" String="This action is used to establish a replication relationship by assigning an existing volume to serve as a target replica for an existing source volume."/>
+        <Annotation Term="OData.LongDescription" String="This action shall be used to establish a replication relationship by assigning an existing volume to serve as a target replica for an existing source volume."/>
+        <Annotation Term="Redfish.Revisions">
+          <Collection>
+            <Record>
+              <PropertyValue Property="Kind" EnumMember="Redfish.RevisionKind/Added"/>
+              <PropertyValue Property="Version" String="v1_4_0"/>
+            </Record>
+          </Collection>
+        </Annotation>
+      </Action>
+
+      <Action Name="CreateReplicaTarget" IsBound="true">
+        <Parameter Name="Volume" Type="Volume.v1_0_0.Actions"/>
+        <Parameter Name="ReplicaUpdateMode" Type="StorageReplicaInfo.ReplicaUpdateMode" Nullable="false">
+          <Annotation Term="OData.Description" String="The replica update mode (synchronous vs asynchronous)."/>
+          <Annotation Term="OData.LongDescription" String="This parameter shall specify the replica update mode."/>
+        </Parameter>
+        <Parameter Name="VolumeName" Type="Edm.String">
+          <Annotation Term="OData.Description" String="The Name for the new target volume."/>
+          <Annotation Term="OData.LongDescription" String="This parameter shall contain the Name for the target volume."/>
+        </Parameter>
+        <Parameter Name="TargetStoragePool" Type="Edm.String" Nullable="false">
+          <Annotation Term="OData.Description" String="The Uri to the existing target Storage Pool."/>
+          <Annotation Term="OData.LongDescription" String="This parameter shall contain the Uri to the existing StoragePool in which to create the target volume."/>
+        </Parameter>
+        <Parameter Name="ReplicaType" Type="StorageReplicaInfo.ReplicaType" Nullable="false">
+          <Annotation Term="OData.Description" String="The type of replica relationship to be created."/>
+          <Annotation Term="OData.LongDescription" String="This parameter shall contain the type of replica relationship to be created (e.g., Clone, Mirror, Snap)."/>
+        </Parameter>
+        <Annotation Term="OData.Description" String="This action is used to create a new volume resource to provide expanded data protection through a replica relationship with the specified source volume."/>
+        <Annotation Term="OData.LongDescription" String="This action shall be used to create a new volume resource to provide expanded data protection through a replica relationship with the specified source volume."/>
+        <Annotation Term="Redfish.Revisions">
+          <Collection>
+            <Record>
+              <PropertyValue Property="Kind" EnumMember="Redfish.RevisionKind/Added"/>
+              <PropertyValue Property="Version" String="v1_4_0"/>
+            </Record>
+          </Collection>
+        </Annotation>
+      </Action>
+
+      <Action Name="RemoveReplicaRelationship" IsBound="true">
+        <Parameter Name="Volume" Type="Volume.v1_0_0.Actions"/>
+        <Parameter Name="TargetVolume" Type="Edm.String" Nullable="false">
+          <Annotation Term="OData.Description" String="The Uri to the existing target volume."/>
+          <Annotation Term="OData.LongDescription" String="This parameter shall contain the Uri to the existing target volume."/>
+        </Parameter>
+        <Parameter Name="DeleteTargetVolume" Type="Edm.Boolean">
+          <Annotation Term="OData.Description" String="Indicate whether or not to delete the target volume as part of the operation."/>
+          <Annotation Term="OData.LongDescription" String="This parameter shall indicate whether or not to delete the target volume as part of the operation. If not defined, the system should use its default behavior."/>
+        </Parameter>
+        <Annotation Term="OData.Description" String="This action is used to disable data synchronization between a source and target volume, remove the replication relationship, and optionally delete the target volume."/>
+        <Annotation Term="OData.LongDescription" String="This action shall be used to disable data synchronization between a source and target volume, remove the replication relationship, and optionally delete the target volume."/>
+        <Annotation Term="Redfish.Revisions">
+          <Collection>
+            <Record>
+              <PropertyValue Property="Kind" EnumMember="Redfish.RevisionKind/Added"/>
+              <PropertyValue Property="Version" String="v1_4_0"/>
+            </Record>
+          </Collection>
+        </Annotation>
+      </Action>
+
+      <Action Name="ResumeReplication" IsBound="true">
+        <Parameter Name="Volume" Type="Volume.v1_0_0.Actions"/>
+        <Parameter Name="TargetVolume" Type="Edm.String" Nullable="false">
+          <Annotation Term="OData.Description" String="The Uri to the existing target volume."/>
+          <Annotation Term="OData.LongDescription" String="This parameter shall contain the Uri to the existing target volume."/>
+        </Parameter>
+        <Annotation Term="OData.Description" String="This action is used to resume the active data synchronization between a source and target volume, without otherwise altering the replication relationship."/>
+        <Annotation Term="OData.LongDescription" String="This action shall be used to resume the active data synchronization between a source and target volume, without otherwise altering the replication relationship."/>
+        <Annotation Term="Redfish.Revisions">
+          <Collection>
+            <Record>
+              <PropertyValue Property="Kind" EnumMember="Redfish.RevisionKind/Added"/>
+              <PropertyValue Property="Version" String="v1_4_0"/>
+            </Record>
+          </Collection>
+        </Annotation>
+      </Action>
+
+      <Action Name="ReverseReplicationRelationship" IsBound="true">
+        <Parameter Name="Volume" Type="Volume.v1_0_0.Actions"/>
+        <Parameter Name="TargetVolume" Type="Edm.String" Nullable="false">
+          <Annotation Term="OData.Description" String="The Uri to the existing target volume."/>
+          <Annotation Term="OData.LongDescription" String="This parameter shall contain the Uri to the existing target volume."/>
+        </Parameter>
+        <Annotation Term="OData.Description" String="This action is used to reverse the replication relationship between a source and target volume."/>
+        <Annotation Term="OData.LongDescription" String="This action shall be used to reverse the replication relationship between a source and target volume."/>
+        <Annotation Term="Redfish.Revisions">
+          <Collection>
+            <Record>
+              <PropertyValue Property="Kind" EnumMember="Redfish.RevisionKind/Added"/>
+              <PropertyValue Property="Version" String="v1_4_0"/>
+            </Record>
+          </Collection>
+        </Annotation>
+      </Action>
+
+      <Action Name="SplitReplication" IsBound="true">
+        <Parameter Name="Volume" Type="Volume.v1_0_0.Actions"/>
+        <Parameter Name="TargetVolume" Type="Edm.String" Nullable="false">
+          <Annotation Term="OData.Description" String="The Uri to the existing target volume."/>
+          <Annotation Term="OData.LongDescription" String="This parameter shall contain the Uri to the existing target volume."/>
+        </Parameter>
+        <Annotation Term="OData.Description" String="This action is used to split the replication relationship and suspend data synchronization between a source and target volume."/>
+        <Annotation Term="OData.LongDescription" String="This action shall be used to split the replication relationship and suspend data synchronization between a source and target volume."/>
+        <Annotation Term="Redfish.Revisions">
+          <Collection>
+            <Record>
+              <PropertyValue Property="Kind" EnumMember="Redfish.RevisionKind/Added"/>
+              <PropertyValue Property="Version" String="v1_4_0"/>
+            </Record>
+          </Collection>
+        </Annotation>
+      </Action>
+
+      <Action Name="SuspendReplication" IsBound="true">
+        <Parameter Name="Volume" Type="Volume.v1_0_0.Actions"/>
+        <Parameter Name="TargetVolume" Type="Edm.String" Nullable="false">
+          <Annotation Term="OData.Description" String="The Uri to the existing target volume."/>
+          <Annotation Term="OData.LongDescription" String="This parameter shall contain the Uri to the existing target volume."/>
+        </Parameter>
+        <Annotation Term="OData.Description" String="This action is used to suspend active data synchronization between a source and target volume, without otherwise altering the replication relationship."/>
+        <Annotation Term="OData.LongDescription" String="This action shall be used to suspend active data synchronization between a source and target volume, without otherwise altering the replication relationship."/>
+        <Annotation Term="Redfish.Revisions">
+          <Collection>
+            <Record>
+              <PropertyValue Property="Kind" EnumMember="Redfish.RevisionKind/Added"/>
+              <PropertyValue Property="Version" String="v1_4_0"/>
+            </Record>
+          </Collection>
+        </Annotation>
+      </Action>
+
+      <Action Name="ChangeRAIDLayout" IsBound="true">
+        <Parameter Name="Volume" Type="Volume.v1_0_0.Actions"/>
+        <Parameter Name="RAIDType" Type="Volume.RAIDType">
+          <Annotation Term="OData.Description" String="The requested RAID type for the volume."/>
+          <Annotation Term="OData.LongDescription" String="This parameter shall contain the requested RAID type for the volume."/>
+        </Parameter>
+        <Parameter Name="StripSizeBytes" Type="Edm.Int64">
+          <Annotation Term="OData.Description" String="The number of blocks (bytes) requested for new strip size."/>
+          <Annotation Term="OData.LongDescription" String="This parameter shall contain the number of blocks (bytes) requested for the strip size."/>
+        </Parameter>
+        <Parameter Name="MediaSpanCount" Type="Edm.Int64">
+          <Annotation Term="OData.Description" String="The requested number of media elements used per span in the secondary RAID for a hierarchical RAID type."/>
+          <Annotation Term="OData.LongDescription" String="This parameter shall contain the requested number of media elements used per span in the secondary RAID for a hierarchical RAID type."/>
+        </Parameter>
+        <Parameter Name="Drives" Type="Collection(Drive.Drive)">
+          <Annotation Term="OData.Description" String="An array of the drives to be used by the volume."/>
+          <Annotation Term="OData.LongDescription" String="This parameter shall contain an array of the drives to be used by the volume."/>
+        </Parameter>
+        <Annotation Term="OData.Description" String="Request system change the RAID layout of the volume."/>
+        <Annotation
+          Term="OData.LongDescription"
+          String="This action shall request the system to change the RAID layout of the volume.  Depending on the combination of the submitted parameters, this could be changing the RAID type, changing the span count, changing the number of drives used by the volume, or another configuration change supported by the system. Note that usage of this action while online may potentially cause data loss if the available capacity is reduced."/>
+        <Annotation Term="Redfish.Revisions">
+          <Collection>
+            <Record>
+              <PropertyValue Property="Kind" EnumMember="Redfish.RevisionKind/Added"/>
+              <PropertyValue Property="Version" String="v1_5_0"/>
+            </Record>
+          </Collection>
+        </Annotation>
+      </Action>
+
+      <Action Name="ForceEnable" IsBound="true">
+        <Parameter Name="Volume" Type="Volume.v1_0_0.Actions"/>
+        <Annotation Term="OData.Description" String="Request system force the volume to an enabled state regardless of data loss."/>
+        <Annotation Term="OData.LongDescription" String="This action shall request the system to force the volume to enabled state regardless of data loss scenarios."/>
+        <Annotation Term="Redfish.Revisions">
+          <Collection>
+            <Record>
+              <PropertyValue Property="Kind" EnumMember="Redfish.RevisionKind/Added"/>
+              <PropertyValue Property="Version" String="v1_5_0"/>
+            </Record>
+          </Collection>
+        </Annotation>
+      </Action>
+
+      <EnumType Name="InitializeType">
+        <Annotation Term="Redfish.Deprecated" String="Deprecated in favor of the InitializeMethod enumerated type."/>
+        <Member Name="Fast">
+          <Annotation Term="OData.Description" String="The volume is prepared for use quickly, typically by erasing just the beginning and end of the space so that partitioning can be performed."/>
+        </Member>
+        <Member Name="Slow">
+          <Annotation Term="OData.Description" String="The volume is prepared for use slowly, typically by completely erasing the volume."/>
+        </Member>
+      </EnumType>
+
+      <EnumType Name="InitializeMethod">
+        <Member Name="Skip">
+          <Annotation Term="OData.Description" String="The volume will be available for use immediately, with no preparation."/>
+        </Member>
+        <Member Name="Background">
+          <Annotation Term="OData.Description" String="The volume will be available for use immediately, with data erasure and preparation to happen as background tasks."/>
+        </Member>
+        <Member Name="Foreground">
+          <Annotation Term="OData.Description" String="Data erasure and preparation tasks will complete before the volume is presented as available for use."/>
+        </Member>
+      </EnumType>
+
+      <EnumType Name="RAIDType">
+        <Member Name="RAID0">
+          <Annotation Term="OData.Description" String="A placement policy where consecutive logical blocks of data are uniformly distributed across a set of independent storage devices without offering any form of redundancy."/>
+          <Annotation
+            Term="OData.LongDescription"
+            String="A placement policy where consecutive logical blocks of data are uniformly distributed across a set of independent storage devices without offering any form of redundancy. This is commonly referred to as data striping. This form of RAID will encounter data loss with the failure of any storage device in the set."/>
+        </Member>
+        <Member Name="RAID1">
+          <Annotation Term="OData.Description" String="A placement policy where each logical block of data is stored on more than one independent storage device."/>
+          <Annotation
+            Term="OData.LongDescription"
+            String="A placement policy where each logical block of data is stored on more than one independent storage device. This is commonly referred to as mirroring. Data stored using this form of RAID is able to survive a single storage device failure without data loss."/>
+        </Member>
+        <Member Name="RAID3">
+          <Annotation
+            Term="OData.Description"
+            String="A placement policy using parity-based protection where logical bytes of data are uniformly distributed across a set of independent storage devices and where the parity is stored on a dedicated independent storage device."/>
+          <Annotation
+            Term="OData.LongDescription"
+            String="A placement policy using parity-based protection where logical bytes of data are uniformly distributed across a set of independent storage devices and where the parity is stored on a dedicated independent storage device. Data stored using this form of RAID is able to survive a single storage device failure without data loss. If the storage devices use rotating media, they are assumed to be rotationally synchronized, and the data stripe size should be no larger than the exported block size."/>
+        </Member>
+        <Member Name="RAID4">
+          <Annotation
+            Term="OData.Description"
+            String="A placement policy using parity-based protection where logical blocks of data are uniformly distributed across a set of independent storage devices and where the parity is stored on a dedicated independent storage device."/>
+          <Annotation
+            Term="OData.LongDescription"
+            String="A placement policy using parity-based protection where logical blocks of data are uniformly distributed across a set of independent storage devices and where the parity is stored on a dedicated independent storage device. Data stored using this form of RAID is able to survive a single storage device failure without data loss."/>
+        </Member>
+        <Member Name="RAID5">
+          <Annotation
+            Term="OData.Description"
+            String="A placement policy using parity-based protection for storing stripes of 'n' logical blocks of data and one logical block of parity across a set of 'n+1' independent storage devices where the parity and data blocks are interleaved across the storage devices."/>
+          <Annotation
+            Term="OData.LongDescription"
+            String="A placement policy using parity-based protection for storing stripes of 'n' logical blocks of data and one logical block of parity across a set of 'n+1' independent storage devices where the parity and data blocks are interleaved across the storage devices. Data stored using this form of RAID is able to survive a single storage device failure without data loss."/>
+        </Member>
+        <Member Name="RAID6">
+          <Annotation
+            Term="OData.Description"
+            String="A placement policy using parity-based protection for storing stripes of 'n' logical blocks of data and two logical blocks of independent parity across a set of 'n+2' independent storage devices where the parity and data blocks are interleaved across the storage devices."/>
+          <Annotation
+            Term="OData.LongDescription"
+            String="A placement policy using parity-based protection for storing stripes of 'n' logical blocks of data and two logical blocks of independent parity across a set of 'n+2' independent storage devices where the parity and data blocks are interleaved across the storage devices. Data stored using this form of RAID is able to survive any two independent storage device failures without data loss."/>
+        </Member>
+        <Member Name="RAID10">
+          <Annotation Term="OData.Description" String="A placement policy that creates a striped device (RAID 0) over a set of mirrored devices (RAID 1)."/>
+          <Annotation
+            Term="OData.LongDescription"
+            String="A placement policy that creates a striped device (RAID 0) over a set of mirrored devices (RAID 1). This is commonly referred to as RAID 1/0. Data stored using this form of RAID is able to survive storage device failures in each RAID 1 set without data loss."/>
+        </Member>
+        <Member Name="RAID01">
+          <Annotation Term="OData.Description" String="A data placement policy that creates a mirrored device (RAID 1) over a set of striped devices (RAID 0)."/>
+          <Annotation
+            Term="OData.LongDescription"
+            String="A data placement policy that creates a mirrored device (RAID 1) over a set of striped devices (RAID 0). This is commonly referred to as RAID 0+1 or RAID 0/1. Data stored using this form of RAID is able to survive a single RAID 0 data set failure without data loss."/>
+        </Member>
+        <Member Name="RAID6TP">
+          <Annotation
+            Term="OData.Description"
+            String="A placement policy that uses parity-based protection for storing stripes of 'n' logical blocks of data and three logical blocks of independent parity across a set of 'n+3' independent storage devices where the parity and data blocks are interleaved across the storage devices."/>
+          <Annotation
+            Term="OData.LongDescription"
+            String="A placement policy that uses parity-based protection for storing stripes of 'n' logical blocks of data and three logical blocks of independent parity across a set of 'n+3' independent storage devices where the parity and data blocks are interleaved across the storage devices. This is commonly referred to as Triple Parity RAID. Data stored using this form of RAID is able to survive any three independent storage device failures without data loss."/>
+        </Member>
+        <Member Name="RAID1E">
+          <Annotation
+            Term="OData.Description"
+            String="A placement policy that uses a form of mirroring implemented over a set of independent storage devices where logical blocks are duplicated on a pair of independent storage devices so that data is uniformly distributed across the storage devices."/>
+          <Annotation
+            Term="OData.LongDescription"
+            String="A placement policy that uses a form of mirroring implemented over a set of independent storage devices where logical blocks are duplicated on a pair of independent storage devices so that data is uniformly distributed across the storage devices. This is commonly referred to as RAID 1 Enhanced. Data stored using this form of RAID is able to survive a single storage device failure without data loss."/>
+        </Member>
+        <Member Name="RAID50">
+          <Annotation Term="OData.Description" String="A placement policy that uses a RAID 0 stripe set over two or more RAID 5 sets of independent storage devices."/>
+          <Annotation
+            Term="OData.LongDescription"
+            String="A placement policy that uses a RAID 0 stripe set over two or more RAID 5 sets of independent storage devices. Data stored using this form of RAID is able to survive a single storage device failure within each RAID 5 set without data loss."/>
+        </Member>
+        <Member Name="RAID60">
+          <Annotation Term="OData.Description" String="A placement policy that uses a RAID 0 stripe set over two or more RAID 6 sets of independent storage devices."/>
+          <Annotation
+            Term="OData.LongDescription"
+            String="A placement policy that uses a RAID 0 stripe set over two or more RAID 6 sets of independent storage devices. Data stored using this form of RAID is able to survive two device failures within each RAID 6 set without data loss."/>
+        </Member>
+        <Member Name="RAID00">
+          <Annotation Term="OData.Description" String="A placement policy that creates a RAID 0 stripe set over two or more RAID 0 sets."/>
+          <Annotation
+            Term="OData.LongDescription"
+            String="A placement policy that creates a RAID 0 stripe set over two or more RAID 0 sets. This is commonly referred to as RAID 0+0. This form of data layout is not fault tolerant; if any storage device fails there will be data loss."/>
+        </Member>
+        <Member Name="RAID10E">
+          <Annotation Term="OData.Description" String="A placement policy that uses a RAID 0 stripe set over two or more RAID 10 sets."/>
+          <Annotation
+            Term="OData.LongDescription"
+            String="A placement policy that uses a RAID 0 stripe set over two or more RAID 10 sets. This is commonly referred to as Enhanced RAID 10. Data stored using this form of RAID is able to survive a single device failure within each nested RAID 1 set without data loss."/>
+        </Member>
+        <Member Name="RAID1Triple">
+          <Annotation Term="OData.Description" String="A placement policy where each logical block of data is mirrored three times across a set of three independent storage devices."/>
+          <Annotation
+            Term="OData.LongDescription"
+            String="A placement policy where each logical block of data is mirrored three times across a set of three independent storage devices. This is commonly referred to as three-way mirroring. This form of RAID can survive two device failures without data loss."/>
+        </Member>
+        <Member Name="RAID10Triple">
+          <Annotation Term="OData.Description" String="A placement policy that uses a striped device (RAID 0) over a set of triple mirrored devices (RAID 1Triple)."/>
+          <Annotation
+            Term="OData.LongDescription"
+            String="A placement policy that uses a striped device (RAID 0) over a set of triple mirrored devices (RAID 1Triple). This form of RAID can survive up to two failures in each triple mirror set without data loss."/>
+        </Member>
+        <Member Name="None">
+          <Annotation Term="OData.Description" String="A placement policy with no redundancy at the device level."/>
+          <Annotation Term="OData.LongDescription" String="A placement policy with no redundancy at the device level."/>
+          <Annotation Term="Redfish.Revisions">
+            <Collection>
+              <Record>
+                <PropertyValue Property="Kind" EnumMember="Redfish.RevisionKind/Added"/>
+                <PropertyValue Property="Version" String="v1_4_2"/>
+              </Record>
+            </Collection>
+          </Annotation>
+        </Member>
+      </EnumType>
+
+      <EnumType Name="VolumeType">
+        <Member Name="RawDevice">
+          <Annotation Term="OData.Description" String="The volume is a raw physical device without any RAID or other virtualization applied."/>
+        </Member>
+        <Member Name="NonRedundant">
+          <Annotation Term="OData.Description" String="The volume is a non-redundant storage device."/>
+        </Member>
+        <Member Name="Mirrored">
+          <Annotation Term="OData.Description" String="The volume is a mirrored device."/>
+        </Member>
+        <Member Name="StripedWithParity">
+          <Annotation Term="OData.Description" String="The volume is a device which uses parity to retain redundant information."/>
+        </Member>
+        <Member Name="SpannedMirrors">
+          <Annotation Term="OData.Description" String="The volume is a spanned set of mirrored devices."/>
+        </Member>
+        <Member Name="SpannedStripesWithParity">
+          <Annotation Term="OData.Description" String="The volume is a spanned set of devices which uses parity to retain redundant information."/>
+        </Member>
+      </EnumType>
+
+      <EnumType Name="EncryptionTypes">
+        <Member Name="NativeDriveEncryption">
+          <Annotation Term="OData.Description" String="The volume is utilizing the native drive encryption capabilities of the drive hardware."/>
+        </Member>
+        <Member Name="ControllerAssisted">
+          <Annotation Term="OData.Description" String="The volume is being encrypted by the storage controller entity."/>
+        </Member>
+        <Member Name="SoftwareAssisted">
+          <Annotation Term="OData.Description" String="The volume is being encrypted by software running on the system or the operating system."/>
+        </Member>
+      </EnumType>
+
+      <EnumType Name="WriteHoleProtectionPolicyType">
+        <Member Name="Off">
+          <Annotation Term="OData.Description" String="The volume is not using any policy to address the write hole issue."/>
+          <Annotation Term="OData.LongDescription" String="The support for addressing the write hole issue is disabled. The volume is not performing any additional activities to close the RAID write hole."/>
+        </Member>
+        <Member Name="Journaling">
+          <Annotation Term="OData.Description" String="The policy that uses separate block device for write-ahead logging to address write hole issue."/>
+          <Annotation
+            Term="OData.LongDescription"
+            String="The policy that uses separate block device for write-ahead logging to address write hole issue. All write operations on the RAID volume are first logged on dedicated journaling device that is not part of the volume."/>
+        </Member>
+        <Member Name="DistributedLog">
+          <Annotation Term="OData.Description" String="The policy that distributes additional log among the volume's capacity sources to address write hole issue."/>
+          <Annotation
+            Term="OData.LongDescription"
+            String="The policy that distributes additional log (e.q. checksum of the parity) among the volume's capacity sources to address write hole issue. Additional data is used to detect data corruption on the volume."/>
+        </Member>
+        <Member Name="Oem">
+          <Annotation Term="OData.Description" String="The policy that is Oem specific."/>
+          <Annotation Term="OData.LongDescription" String="The policy that is Oem specific. The mechanism details are unknown unless provided separately by the Oem."/>
+        </Member>
+      </EnumType>
+
+      <EnumType Name="VolumeUsageType">
+        <Member Name="Data">
+          <Annotation Term="OData.Description" String="The volume is allocated for use as a consumable data volume."/>
+          <Annotation Term="OData.LongDescription" String="The volume shall be allocated for use as a consumable data volume."/>
+        </Member>
+        <Member Name="SystemData">
+          <Annotation Term="OData.Description" String="The volume is allocated for use as a consumable data volume reserved for system use."/>
+          <Annotation Term="OData.LongDescription" String="The volume shall be allocated for use as a consumable data volume reserved for system use."/>
+        </Member>
+        <Member Name="CacheOnly">
+          <Annotation Term="OData.Description" String="The volume is allocated for use as a non-consumable cache only volume."/>
+          <Annotation Term="OData.LongDescription" String="The volume shall be allocated for use as a non-consumable cache only volume."/>
+        </Member>
+        <Member Name="SystemReserve">
+          <Annotation Term="OData.Description" String="The volume is allocated for use as a non-consumable system reserved volume."/>
+          <Annotation Term="OData.LongDescription" String="The volume shall be allocated for use as a non-consumable system reserved volume."/>
+        </Member>
+        <Member Name="ReplicationReserve">
+          <Annotation Term="OData.Description" String="The volume is allocated for use as a non-consumable reserved volume for replication use."/>
+          <Annotation Term="OData.LongDescription" String="The volume shall be allocated for use as a non-consumable reserved volume for replication use."/>
+        </Member>
+      </EnumType>
+
+      <EnumType Name="ReadCachePolicyType">
+        <Member Name="ReadAhead">
+          <Annotation Term="OData.Description" String="A caching technique in which the controller pre-fetches data anticipating future read requests."/>
+        </Member>
+        <Member Name="AdaptiveReadAhead">
+          <Annotation Term="OData.Description" String="A caching technique in which the controller dynamically determines whether to pre-fetch data anticipating future read requests, based on previous cache hit ratio."/>
+        </Member>
+        <Member Name="Off">
+          <Annotation Term="OData.Description" String="The read cache is disabled."/>
+        </Member>
+      </EnumType>
+
+      <EnumType Name="WriteCachePolicyType">
+        <Member Name="WriteThrough">
+          <Annotation Term="OData.Description" String="A caching technique in which the completion of a write request is not signaled until data is safely stored on non-volatile media."/>
+          <Annotation Term="OData.LongDescription" String="A caching technique in which the completion of a write request is not signaled until data is safely stored on non-volatile media."/>
+        </Member>
+        <Member Name="ProtectedWriteBack">
+          <Annotation Term="OData.Description" String="A caching technique in which the completion of a write request is signaled as soon as the data is in cache, and actual writing to non-volatile media is guaranteed to occur at a later time."/>
+          <Annotation Term="OData.LongDescription" String="A caching technique in which the completion of a write request is signaled as soon as the data is in cache, and actual writing to non-volatile media is guaranteed to occur at a later time."/>
+        </Member>
+        <Member Name="UnprotectedWriteBack">
+          <Annotation Term="OData.Description" String="A caching technique in which the completion of a write request is signaled as soon as the data is in cache; actual writing to non-volatile media is not guaranteed to occur at a later time."/>
+          <Annotation Term="OData.LongDescription" String="A caching technique in which the completion of a write request is signaled as soon as the data is in cache; actual writing to non-volatile media is not guaranteed to occur at a later time."/>
+        </Member>
+        <Member Name="Off">
+          <Annotation Term="OData.Description" String="The write cache is disabled."/>
+          <Annotation Term="OData.LongDescription" String="Indicates that the write cache shall be disabled."/>
+          <Annotation Term="Redfish.Revisions">
+            <Collection>
+              <Record>
+                <PropertyValue Property="Kind" EnumMember="Redfish.RevisionKind/Added"/>
+                <PropertyValue Property="Version" String="v1_4_1"/>
+              </Record>
+            </Collection>
+          </Annotation>
+        </Member>
+      </EnumType>
+
+      <EnumType Name="WriteCacheStateType">
+        <Member Name="Unprotected">
+          <Annotation Term="OData.Description" String="Indicates that the cache state type in use generally does not protect write requests on non-volatile media."/>
+          <Annotation Term="OData.LongDescription" String="Indicates that the cache state type in use generally does not protect write requests on non-volatile media."/>
+        </Member>
+        <Member Name="Protected">
+          <Annotation Term="OData.Description" String="Indicates that the cache state type in use generally protects write requests on non-volatile media."/>
+          <Annotation Term="OData.LongDescription" String="Indicates that the cache state type in use generally protects write requests on non-volatile media."/>
+        </Member>
+        <Member Name="Degraded">
+          <Annotation Term="OData.Description" String="Indicates an issue with the cache state in which the cache space is diminished or disabled due to a failure or an outside influence such as a discharged battery."/>
+          <Annotation Term="OData.LongDescription" String="Indicates an issue with the cache state in which the cache space is diminished or disabled due to a failure or an outside influence such as a discharged battery."/>
+        </Member>
+      </EnumType>
+
+    </Schema>
+
+    <Schema xmlns="http://docs.oasis-open.org/odata/ns/edm" Namespace="Volume.v1_0_0">
+      <Annotation Term="Redfish.OwningEntity" String="SNIA"/>
+      <EntityType Name="Volume" BaseType="Volume.Volume">
+        <Property Name="Status" Type="Resource.Status" Nullable="false">
+          <Annotation Term="OData.Description" String="The property contains the status of the Volume."/>
+          <Annotation Term="OData.LongDescription" String="The property shall contain the status of the Volume."/>
+        </Property>
+        <Property Name="CapacityBytes" Type="Edm.Int64">
+          <Annotation Term="OData.Permissions" EnumMember="OData.Permission/ReadWrite"/>
+          <Annotation Term="OData.Description" String="The size in bytes of this Volume."/>
+          <Annotation Term="OData.LongDescription" String="This property shall contain the size in bytes of the associated volume."/>
+          <Annotation Term="Measures.Unit" String="By"/>
+        </Property>
+        <Property Name="VolumeType" Type="Volume.VolumeType">
+          <Annotation Term="OData.Permissions" EnumMember="OData.Permission/Read"/>
+          <Annotation Term="OData.Description" String="The type of this volume."/>
+          <Annotation Term="OData.LongDescription" String="This property shall contain the type of the associated Volume."/>
+          <Annotation Term="Redfish.Deprecated" String="Deprecated in favor of explicit use of RAIDType."/>
+        </Property>
+        <Property Name="Encrypted" Type="Edm.Boolean">
+          <Annotation Term="OData.Permissions" EnumMember="OData.Permission/ReadWrite"/>
+          <Annotation Term="OData.Description" String="Is this Volume encrypted."/>
+          <Annotation Term="OData.LongDescription" String="This property shall contain a boolean indicator if the Volume is currently utilizing encryption or not."/>
+        </Property>
+        <Property Name="EncryptionTypes" Type="Collection(Volume.EncryptionTypes)" Nullable="false">
+          <Annotation Term="OData.Permissions" EnumMember="OData.Permission/ReadWrite"/>
+          <Annotation Term="OData.Description" String="The types of encryption used by this Volume."/>
+          <Annotation Term="OData.LongDescription" String="This property shall contain the types of encryption used by this Volume."/>
+        </Property>
+        <Property Name="Identifiers" Type="Collection(Resource.Identifier)" Nullable="false">
+          <Annotation Term="OData.Description" String="The Durable names for the volume."/>
+          <Annotation Term="OData.LongDescription" String="This property shall contain a list of all known durable names for the associated volume."/>
+        </Property>
+        <Property Name="BlockSizeBytes" Type="Edm.Int64">
+          <Annotation Term="OData.Permissions" EnumMember="OData.Permission/Read"/>
+          <Annotation Term="OData.Description" String="The size of the smallest addressable unit (Block) of this volume in bytes."/>
+          <Annotation Term="OData.LongDescription" String="This property shall contain size of the smallest addressable unit of the associated volume."/>
+          <Annotation Term="Measures.Unit" String="By"/>
+        </Property>
+        <Property Name="Operations" Type="Collection(Volume.v1_0_0.Operation)" Nullable="false">
+          <Annotation Term="OData.Description" String="The operations currently running on the Volume."/>
+          <Annotation Term="OData.LongDescription" String="This property shall contain a list of all currently running on the Volume."/>
+        </Property>
+        <Property Name="OptimumIOSizeBytes" Type="Edm.Int64">
+          <Annotation Term="OData.Permissions" EnumMember="OData.Permission/Read"/>
+          <Annotation Term="OData.Description" String="The size in bytes of this Volume's optimum IO size."/>
+          <Annotation Term="OData.LongDescription" String="This property shall contain the optimum IO size to use when performing IO on this volume. For logical disks, this is the stripe size. For physical disks, this describes the physical sector size."/>
+          <Annotation Term="Measures.Unit" String="By"/>
+        </Property>
+        <Property Name="Links" Type="Volume.v1_0_0.Links" Nullable="false">
+          <Annotation Term="OData.Description" String="Contains references to other resources that are related to this resource."/>
+          <Annotation Term="OData.LongDescription" String="The Links property, as described by the Redfish Specification, shall contain references to resources that are related to, but not contained by (subordinate to), this resource."/>
+        </Property>
+        <Property Name="Actions" Type="Volume.v1_0_0.Actions" Nullable="false">
+          <Annotation Term="OData.Description" String="The available actions for this resource."/>
+          <Annotation Term="OData.LongDescription" String="The Actions property shall contain the available actions for this resource."/>
+        </Property>
+      </EntityType>
+
+      <ComplexType Name="Links" BaseType="Resource.Links">
+        <NavigationProperty Name="Drives" Type="Collection(Drive.Drive)">
+          <Annotation Term="OData.Permissions" EnumMember="OData.Permission/Read"/>
+          <Annotation Term="OData.Description" String="An array of references to the drives which contain this volume. This will reference Drives that either wholly or only partly contain this volume."/>
+          <Annotation
+            Term="OData.LongDescription"
+            String="The value of this property shall be a reference to the resources that this volume is associated with and shall reference resources of type Drive. This property shall only contain references to Drive entities which are currently members of the Volume, not hot spare Drives which are not currently a member of the volume."/>
+          <Annotation Term="OData.AutoExpandReferences"/>
+        </NavigationProperty>
+      </ComplexType>
+
+      <ComplexType Name="Actions">
+        <Annotation Term="OData.AdditionalProperties" Bool="false"/>
+        <Property Name="Oem" Type="Volume.v1_0_0.OemActions" Nullable="false"/>
+      </ComplexType>
+
+      <ComplexType Name="OemActions">
+        <Annotation Term="OData.AdditionalProperties" Bool="true"/>
+      </ComplexType>
+
+      <ComplexType Name="Operation">
+        <Property Name="OperationName" Type="Edm.String">
+          <Annotation Term="OData.Permissions" EnumMember="OData.Permission/Read"/>
+          <Annotation Term="OData.Description" String="The name of the operation."/>
+        </Property>
+        <Property Name="PercentageComplete" Type="Edm.Int64">
+          <Annotation Term="OData.Permissions" EnumMember="OData.Permission/Read"/>
+          <Annotation Term="OData.Description" String="The percentage of the operation that has been completed."/>
+        </Property>
+        <NavigationProperty Name="AssociatedFeaturesRegistry" Type="FeaturesRegistry.FeaturesRegistry" Nullable="false">
+          <Annotation Term="OData.Permissions" EnumMember="OData.Permission/Read"/>
+          <Annotation Term="OData.Description" String="A reference to the task associated with the operation if any."/>
+        </NavigationProperty>
+      </ComplexType>
+
+    </Schema>
+
+    <Schema xmlns="http://docs.oasis-open.org/odata/ns/edm" Namespace="Volume.v1_0_1">
+      <Annotation Term="Redfish.OwningEntity" String="SNIA"/>
+      <Annotation Term="OData.Description" String="This version was created to show annotations in previous namespaces were updated."/>
+      <EntityType Name="Volume" BaseType="Volume.v1_0_0.Volume"/>
+    </Schema>
+
+    <Schema xmlns="http://docs.oasis-open.org/odata/ns/edm" Namespace="Volume.v1_0_2">
+      <Annotation Term="Redfish.OwningEntity" String="SNIA"/>
+      <Annotation Term="OData.Description" String="This version was created to add explicit Permissions annotations to all properties for clarity."/>
+      <EntityType Name="Volume" BaseType="Volume.v1_0_1.Volume"/>
+    </Schema>
+
+    <Schema xmlns="http://docs.oasis-open.org/odata/ns/edm" Namespace="Volume.v1_0_3">
+      <Annotation Term="Redfish.OwningEntity" String="SNIA"/>
+      <Annotation Term="OData.Description" String="This version was created to fix supported types and remove the Nullable facet on NavigationProperties of type Collection."/>
+      <EntityType Name="Volume" BaseType="Volume.v1_0_2.Volume"/>
+    </Schema>
+
+    <Schema xmlns="http://docs.oasis-open.org/odata/ns/edm" Namespace="Volume.v1_0_4">
+      <Annotation Term="Redfish.OwningEntity" String="SNIA"/>
+      <Annotation Term="OData.Description" String="This version was created to force the regeneration of JSON Schema so that OData properties are marked as required, and integer properties are marked as integer rather than number."/>
+      <EntityType Name="Volume" BaseType="Volume.v1_0_3.Volume"/>
+    </Schema>
+
+    <Schema xmlns="http://docs.oasis-open.org/odata/ns/edm" Namespace="Volume.v1_1_0">
+      <Annotation Term="Redfish.OwningEntity" String="SNIA"/>
+      <EntityType Name="Volume" BaseType="Volume.v1_0_0.Volume">
+        <Property Name="AccessCapabilities" Type="Collection(DataStorageLoSCapabilities.StorageAccessCapability)">
+          <Annotation Term="OData.Permissions" EnumMember="OData.Permission/ReadWrite"/>
+          <Annotation Term="OData.Description" String="Supported IO access capabilities."/>
+          <Annotation Term="OData.LongDescription" String="Each entry shall specify a current storage access capability."/>
+        </Property>
+        <Property Name="MaxBlockSizeBytes" Type="Edm.Int64">
+          <Annotation Term="OData.Permissions" EnumMember="OData.Permission/Read"/>
+          <Annotation Term="OData.Description" String="Max Block size in bytes."/>
+          <Annotation Term="OData.LongDescription" String="This property shall contain size of the largest addressable unit of this storage volume."/>
+          <Annotation Term="Measures.Unit" String="By"/>
+        </Property>
+        <Property Name="Capacity" Type="Capacity.v1_0_0.Capacity" Nullable="false">
+          <Annotation Term="OData.Description" String="Capacity utilization."/>
+          <Annotation Term="OData.LongDescription" String="Information about the utilization of capacity allocated to this storage volume."/>
+        </Property>
+        <NavigationProperty Name="CapacitySources" Type="Collection(Capacity.CapacitySource)" ContainsTarget="true">
+          <Annotation Term="OData.Permissions" EnumMember="OData.Permission/ReadWrite"/>
+          <Annotation Term="OData.Description" String="An array of space allocations to this volume."/>
+          <Annotation Term="OData.LongDescription" String="Fully or partially consumed storage from a source resource. Each entry provides capacity allocation information from a named source resource."/>
+          <Annotation Term="OData.AutoExpand"/>
+        </NavigationProperty>
+        <Property Name="LowSpaceWarningThresholdPercents" Type="Collection(Edm.Int64)">
+          <Annotation Term="OData.Permissions" EnumMember="OData.Permission/ReadWrite"/>
+          <Annotation Term="OData.Description" String="Low space warning."/>
+          <Annotation
+            Term="OData.LongDescription"
+            String="Each time the following value is less than one of the values in the array the LOW_SPACE_THRESHOLD_WARNING event shall be triggered: Across all CapacitySources entries, percent = (SUM(AllocatedBytes) - SUM(ConsumedBytes))/SUM(AllocatedBytes)."/>
+          <Annotation Term="Measures.Unit" String="%"/>
+        </Property>
+        <Property Name="Manufacturer" Type="Edm.String">
+          <Annotation Term="OData.Permissions" EnumMember="OData.Permission/Read"/>
+          <Annotation Term="OData.Description" String="The manufacturer or OEM of this storage volume."/>
+          <Annotation Term="OData.LongDescription" String="This property shall contain a value that represents the manufacturer or implementer of the storage volume."/>
+        </Property>
+        <Property Name="Model" Type="Edm.String">
+          <Annotation Term="OData.Permissions" EnumMember="OData.Permission/Read"/>
+          <Annotation Term="OData.Description" String="The model number for this storage volume."/>
+          <Annotation Term="OData.LongDescription" String="The value is assigned by the manufacturer and shall represents a specific storage volume implementation."/>
+        </Property>
+        <Property Name="ReplicaInfo" Type="StorageReplicaInfo.v1_3_0.ReplicaInfo" Nullable="false">
+          <Annotation Term="OData.Description" String="Describes this storage volume in its role as a target replica."/>
+          <Annotation Term="OData.LongDescription" String="This property shall describe the replica relationship between this storage volume and a corresponding source volume."/>
+        </Property>
+        <NavigationProperty Name="StorageGroups" Type="StorageGroupCollection.StorageGroupCollection" Nullable="false" ContainsTarget="true">
+          <Annotation Term="OData.Permissions" EnumMember="OData.Permission/Read"/>
+          <Annotation Term="OData.Description" String="An array of references to Storage Groups that includes this volume."/>
+          <Annotation Term="OData.LongDescription" String="The value of this property shall contain references to all storage groups that include this volume."/>
+          <Annotation Term="OData.AutoExpandReferences"/>
+        </NavigationProperty>
+        <NavigationProperty Name="AllocatedPools" Type="StoragePoolCollection.StoragePoolCollection" Nullable="false" ContainsTarget="true">
+          <Annotation Term="OData.Permissions" EnumMember="OData.Permission/Read"/>
+          <Annotation Term="OData.Description" String="An array of references to StoragePools allocated from this Volume."/>
+          <Annotation Term="OData.LongDescription" String="The value of this property shall contain references to all storage pools allocated from this volume."/>
+          <Annotation Term="OData.AutoExpandReferences"/>
+        </NavigationProperty>
+      </EntityType>
+
+      <ComplexType Name="Links" BaseType="Volume.v1_0_0.Links">
+        <NavigationProperty Name="ClassOfService" Type="ClassOfService.ClassOfService" Nullable="false">
+          <Annotation Term="OData.Permissions" EnumMember="OData.Permission/Read"/>
+          <Annotation Term="OData.Description" String="The ClassOfService that this storage volume conforms to."/>
+          <Annotation Term="OData.LongDescription" String="This property shall contain a reference to the ClassOfService that this storage volume conforms to."/>
+          <Annotation Term="OData.AutoExpandReferences"/>
+        </NavigationProperty>
+      </ComplexType>
+    </Schema>
+
+    <Schema xmlns="http://docs.oasis-open.org/odata/ns/edm" Namespace="Volume.v1_1_1">
+      <Annotation Term="Redfish.OwningEntity" String="SNIA"/>
+      <Annotation Term="OData.Description" String="This version was created to remove the complex type nullable property definition from the drive collection."/>
+      <EntityType Name="Volume" BaseType="Volume.v1_1_0.Volume"/>
+    </Schema>
+
+    <Schema xmlns="http://docs.oasis-open.org/odata/ns/edm" Namespace="Volume.v1_1_2">
+      <Annotation Term="Redfish.OwningEntity" String="SNIA"/>
+      <Annotation Term="OData.Description" String="This version was for errata to Volume."/>
+      <EntityType Name="Volume" BaseType="Volume.v1_1_1.Volume">
+        <Annotation Term="OData.Description" String="Errata to change AllocatedPools and StorageGroups to use ResourceCollections."/>
+      </EntityType>
+    </Schema>
+
+    <Schema xmlns="http://docs.oasis-open.org/odata/ns/edm" Namespace="Volume.v1_1_3">
+      <Annotation Term="Redfish.OwningEntity" String="SNIA"/>
+      <Annotation Term="OData.Description" String="This version was created to force the regeneration of JSON Schema so that OData properties are marked as required, and integer properties are marked as integer rather than number."/>
+      <EntityType Name="Volume" BaseType="Volume.v1_1_2.Volume"/>
+    </Schema>
+
+    <Schema xmlns="http://docs.oasis-open.org/odata/ns/edm" Namespace="Volume.v1_1_4">
+      <Annotation Term="Redfish.OwningEntity" String="SNIA"/>
+      <Annotation Term="OData.Description" String="This version was created to fix CSDL errors and adds both Redfish Uris and Capability Annotations."/>
+      <EntityType Name="Volume" BaseType="Volume.v1_1_3.Volume"/>
+    </Schema>
+
+    <Schema xmlns="http://docs.oasis-open.org/odata/ns/edm" Namespace="Volume.v1_1_5">
+      <Annotation Term="Redfish.OwningEntity" String="SNIA"/>
+      <Annotation Term="OData.Description" String="This version was created to move enums to the unversioned namespace."/>
+      <EntityType Name="Volume" BaseType="Volume.v1_1_4.Volume"/>
+    </Schema>
+
+    <Schema xmlns="http://docs.oasis-open.org/odata/ns/edm" Namespace="Volume.v1_2_0">
+      <Annotation Term="Redfish.OwningEntity" String="SNIA"/>
+      <Annotation Term="Redfish.Release" String="WIP v1.0.5"/>
+      <Annotation Term="OData.Description" String="This version was created to add IO Statistics, and adds the RemainingCapacityPercent property."/>
+      <EntityType Name="Volume" BaseType="Volume.v1_1_1.Volume">
+        <Annotation Term="OData.Description" String="Add volume statistics."/>
+
+        <Property Name="IOStatistics" Type="IOStatistics.IOStatistics" Nullable="false">
+          <Annotation Term="OData.Description" String="Statistics for this volume."/>
+          <Annotation Term="OData.LongDescription" String="The value shall represent IO statistics for this volume."/>
+        </Property>
+        <Property Name="RemainingCapacityPercent" Type="Edm.Int64">
+          <Annotation Term="OData.Permissions" EnumMember="OData.Permission/Read"/>
+          <Annotation Term="OData.Description" String="The percentage of the capacity remaining in the Volume."/>
+          <Annotation Term="OData.LongDescription" String="If present, this value shall return  {[(SUM(AllocatedBytes) - SUM(ConsumedBytes)]/SUM(AllocatedBytes)}*100 represented as an integer value."/>
+        </Property>
+      </EntityType>
+
+      <ComplexType Name="Links" BaseType="Volume.v1_1_0.Links">
+        <NavigationProperty Name="DedicatedSpareDrives" Type="Collection(Drive.Drive)">
+          <Annotation Term="OData.Permissions" EnumMember="OData.Permission/ReadWrite"/>
+          <Annotation Term="OData.Description" String="An array of references to the drives which are dedicated spares for this volume."/>
+          <Annotation
+            Term="OData.LongDescription"
+            String="The value of this property shall be a reference to the resources that this volume is associated with and shall reference resources of type Drive. This property shall only contain references to Drive entities which are currently assigned as a dedicated spare and are able to support this Volume."/>
+          <Annotation Term="OData.AutoExpandReferences"/>
+        </NavigationProperty>
+      </ComplexType>
+    </Schema>
+
+    <Schema xmlns="http://docs.oasis-open.org/odata/ns/edm" Namespace="Volume.v1_2_1">
+      <Annotation Term="Redfish.OwningEntity" String="SNIA"/>
+      <Annotation
+        Term="OData.Description"
+        String="This version was created to show name change from Operations to Operation. The  description and long description for action Initialize have been extended to add a default InitializeType == Fast recommendation. Change references to unversioned."/>
+      <EntityType Name="Volume" BaseType="Volume.v1_2_0.Volume"/>
+    </Schema>
+
+    <Schema xmlns="http://docs.oasis-open.org/odata/ns/edm" Namespace="Volume.v1_2_2">
+      <Annotation Term="Redfish.OwningEntity" String="SNIA"/>
+      <Annotation Term="OData.Description" String="This version was created to force the regeneration of JSON Schema so that OData properties are marked as required, and integer properties are marked as integer rather than number."/>
+      <EntityType Name="Volume" BaseType="Volume.v1_2_1.Volume"/>
+    </Schema>
+
+    <Schema xmlns="http://docs.oasis-open.org/odata/ns/edm" Namespace="Volume.v1_2_3">
+      <Annotation Term="Redfish.OwningEntity" String="SNIA"/>
+      <Annotation Term="OData.Description" String="This version was created to fix CSDL errors and adds both Redfish Uris and Capability Annotations."/>
+      <EntityType Name="Volume" BaseType="Volume.v1_2_2.Volume"/>
+    </Schema>
+
+    <Schema xmlns="http://docs.oasis-open.org/odata/ns/edm" Namespace="Volume.v1_2_4">
+      <Annotation Term="Redfish.OwningEntity" String="SNIA"/>
+      <Annotation Term="OData.Description" String="This version was created to move enums to the unversioned namespace."/>
+      <EntityType Name="Volume" BaseType="Volume.v1_2_3.Volume"/>
+    </Schema>
+
+    <Schema xmlns="http://docs.oasis-open.org/odata/ns/edm" Namespace="Volume.v1_2_5">
+      <Annotation Term="Redfish.OwningEntity" String="SNIA"/>
+      <Annotation Term="OData.Description" String="This version was added to fix typographical errors."/>
+      <EntityType Name="Volume" BaseType="Volume.v1_2_4.Volume"/>
+    </Schema>
+
+    <Schema xmlns="http://docs.oasis-open.org/odata/ns/edm" Namespace="Volume.v1_3_0">
+      <Annotation Term="Redfish.OwningEntity" String="SNIA"/>
+      <Annotation Term="Redfish.Release" String="TP v1.0.6a"/>
+      <Annotation
+        Term="OData.Description"
+        String="This version was created to add RecoverableCapacitySourceCount and SpareResourceSets. This also replaces collection StorageReplicaInfos with scalar StorageReplicaInfo, and adds a ReplicaTargets collection. It also adds the RAIDType enum, which replaces the use of VolumeType for direct Volume characterization."/>
+
+      <EntityType Name="Volume" BaseType="Volume.v1_2_1.Volume">
+        <Annotation Term="OData.Description" String="Add ability to manage spare capacity."/>
+        <Property Name="RecoverableCapacitySourceCount" Type="Edm.Int64">
+          <Annotation Term="OData.Permissions" EnumMember="OData.Permission/ReadWrite"/>
+          <Annotation Term="OData.Description" String="Current number of capacity source resources that are available as replacements."/>
+          <Annotation Term="OData.LongDescription" String="The value is the number of available capacity source resources currently available in the event that an equivalent capacity source resource fails."/>
+        </Property>
+        <NavigationProperty Name="ReplicaTargets" Type="Collection(Resource.Item)">
+          <Annotation Term="OData.Permissions" EnumMember="OData.Permission/Read"/>
+          <Annotation Term="OData.Description" String="The resources that are target replicas of this source."/>
+          <Annotation Term="OData.LongDescription" String="The value shall reference the target replicas that are sourced by this replica."/>
+          <Annotation Term="OData.AutoExpandReferences"/>
+        </NavigationProperty>
+      </EntityType>
+
+      <ComplexType Name="Links" BaseType="Volume.v1_2_0.Links">
+        <Annotation Term="OData.Description" String="Add ability to manage spare capacity."/>
+        <NavigationProperty Name="SpareResourceSets" Type="Collection(SpareResourceSet.SpareResourceSet)">
+          <Annotation Term="OData.Permissions" EnumMember="OData.Permission/ReadWrite"/>
+          <Annotation Term="OData.Description" String="An array of references to SpareResourceSets."/>
+          <Annotation Term="OData.LongDescription" String="Each referenced SpareResourceSet shall contain resources that may be utilized to replace the capacity provided by a failed resource having a compatible type."/>
+          <Annotation Term="OData.AutoExpandReferences"/>
+        </NavigationProperty>
+      </ComplexType>
+    </Schema>
+
+    <Schema xmlns="http://docs.oasis-open.org/odata/ns/edm" Namespace="Volume.v1_3_1">
+      <Annotation Term="Redfish.OwningEntity" String="SNIA"/>
+      <Annotation Term="OData.Description" String="This version was created to add the RAIDType property, which replaces the use of VolumeType for direct Volume characterization."/>
+
+      <EntityType Name="Volume" BaseType="Volume.v1_3_0.Volume">
+        <Annotation Term="OData.Description" String="Add RAIDType property."/>
+        <Property Name="RAIDType" Type="Volume.RAIDType">
+          <Annotation Term="OData.Permissions" EnumMember="OData.Permission/Read"/>
+          <Annotation Term="OData.Description" String="The RAID type of this volume."/>
+          <Annotation Term="OData.LongDescription" String="This property shall contain the RAID type of the associated Volume."/>
+        </Property>
+      </EntityType>
+    </Schema>
+
+    <Schema xmlns="http://docs.oasis-open.org/odata/ns/edm" Namespace="Volume.v1_3_2">
+      <Annotation Term="Redfish.OwningEntity" String="SNIA"/>
+      <Annotation Term="OData.Description" String="This version was created to fix CSDL errors and adds both Redfish Uris and Capability Annotations."/>
+      <EntityType Name="Volume" BaseType="Volume.v1_3_1.Volume"/>
+    </Schema>
+
+    <Schema xmlns="http://docs.oasis-open.org/odata/ns/edm" Namespace="Volume.v1_3_3">
+      <Annotation Term="Redfish.OwningEntity" String="SNIA"/>
+      <Annotation Term="OData.Description" String="This version was created to move enums to the unversioned namespace."/>
+      <EntityType Name="Volume" BaseType="Volume.v1_3_2.Volume"/>
+    </Schema>
+
+    <Schema xmlns="http://docs.oasis-open.org/odata/ns/edm" Namespace="Volume.v1_3_4">
+      <Annotation Term="Redfish.OwningEntity" String="SNIA"/>
+      <Annotation Term="OData.Description" String="This version was added to fix typographical errors."/>
+      <EntityType Name="Volume" BaseType="Volume.v1_3_3.Volume"/>
+    </Schema>
+
+    <Schema xmlns="http://docs.oasis-open.org/odata/ns/edm" Namespace="Volume.v1_4_0">
+      <Annotation Term="Redfish.OwningEntity" String="SNIA"/>
+      <Annotation Term="Redfish.Release" String="WIP v1.1.0"/>
+      <Annotation
+        Term="OData.Description"
+        String="This version was created to add collection of references to Endpoints, StorageGroups and ConsistencyGroups associated with this Volume, and adds a LongDescription to RAID6TP. It also adds AutoExpand to CapacitySources and changes the MaxBlockSizeBytes to 64 bytes. Additionally the following properties have been added: ProvisioningPolicy, OwningStorageService, StripSizeBytes, ReadAheadPolicy, VolumeUsage, WritePolicy, CacheState, LogicalUnitNumber, MediaSpanCount, Deduplicated, Compressed, WriteHoleProtectionPolicy, and DisplayName. This version also adds the following Actions: AssignReplicaTarget, CreateReplicaTarget, RemoveReplicaRelationship, ResumeReplication, ReverseReplicationRelationship, SplitReplication, and SuspendReplication. This version also adds both Redfish Uris and Capability Annotations and fixes CSDL errors."/>
+      <EntityType Name="Volume" BaseType="Volume.v1_3_1.Volume">
+        <Property Name="ProvisioningPolicy" Type="DataStorageLoSCapabilities.ProvisioningPolicy">
+          <Annotation Term="OData.Permissions" EnumMember="OData.Permission/ReadWrite"/>
+          <Annotation Term="OData.Description" String="This property specifies the volume's storage allocation, or provisioning policy."/>
+          <Annotation Term="OData.LongDescription" String="This property shall specify the volume's supported storage allocation policy."/>
+        </Property>
+        <Property Name="StripSizeBytes" Type="Edm.Int64">
+          <Annotation Term="OData.Permissions" EnumMember="OData.Permission/ReadWrite"/>
+          <Annotation Term="OData.Description" String="The number of blocks (bytes) in a strip in a disk array that uses striped data mapping."/>
+          <Annotation Term="OData.LongDescription" String="The number of consecutively addressed virtual disk blocks (bytes) mapped to consecutively addressed blocks on a single member extent of a disk array. Synonym for stripe depth and chunk size."/>
+          <Annotation Term="Measures.Unit" String="By"/>
+        </Property>
+        <Property Name="ReadCachePolicy" Type="Volume.ReadCachePolicyType">
+          <Annotation Term="OData.Permissions" EnumMember="OData.Permission/ReadWrite"/>
+          <Annotation Term="OData.Description" String="Indicates the read cache policy setting for the Volume."/>
+          <Annotation Term="OData.LongDescription" String="This property shall contain a boolean indicator of the read cache policy for the Volume."/>
+        </Property>
+        <Property Name="VolumeUsage" Type="Volume.VolumeUsageType">
+          <Annotation Term="OData.Permissions" EnumMember="OData.Permission/Read"/>
+          <Annotation Term="OData.Description" String="Indicates the Volume usage type setting for the Volume."/>
+          <Annotation Term="OData.LongDescription" String="This property shall contain the volume usage type for the Volume."/>
+        </Property>
+        <Property Name="WriteCachePolicy" Type="Volume.WriteCachePolicyType">
+          <Annotation Term="OData.Permissions" EnumMember="OData.Permission/ReadWrite"/>
+          <Annotation Term="OData.Description" String="Indicates the write cache policy setting for the Volume."/>
+          <Annotation Term="OData.LongDescription" String="This property shall contain a boolean indicator of the write cache policy for the Volume."/>
+        </Property>
+        <Property Name="WriteCacheState" Type="Volume.WriteCacheStateType">
+          <Annotation Term="OData.Permissions" EnumMember="OData.Permission/Read"/>
+          <Annotation Term="OData.Description" String="Indicates the WriteCacheState policy setting for the Volume."/>
+          <Annotation Term="OData.LongDescription" String="This property shall contain the WriteCacheState policy setting for the Volume."/>
+        </Property>
+        <Property Name="LogicalUnitNumber" Type="Edm.Int64">
+          <Annotation Term="OData.Permissions" EnumMember="OData.Permission/Read"/>
+          <Annotation Term="OData.Description" String="Indicates the host-visible LogicalUnitNumber assigned to this Volume."/>
+          <Annotation Term="OData.LongDescription" String="This property shall contain host-visible LogicalUnitNumber assigned to this Volume. This property shall only be used when in a single connect configuration and no StorageGroup configuration is used."/>
+        </Property>
+        <Property Name="MediaSpanCount" Type="Edm.Int64">
+          <Annotation Term="OData.Permissions" EnumMember="OData.Permission/Read"/>
+          <Annotation Term="OData.Description" String="Indicates the number of media elements used per span in the secondary RAID for a hierarchical RAID type."/>
+          <Annotation Term="OData.LongDescription" String="This property shall indicate the number of media elements used per span in the secondary RAID for a hierarchical RAID type."/>
+        </Property>
+        <Property Name="DisplayName" Type="Edm.String">
+          <Annotation Term="OData.Permissions" EnumMember="OData.Permission/ReadWrite"/>
+          <Annotation Term="OData.Description" String="A user-configurable string to name the volume."/>
+          <Annotation Term="OData.LongDescription" String="This property shall contain a user-configurable string to name the volume."/>
+        </Property>
+        <Property Name="WriteHoleProtectionPolicy" Type="Volume.WriteHoleProtectionPolicyType" DefaultValue="Off" Nullable="false">
+          <Annotation Term="OData.Permissions" EnumMember="OData.Permission/ReadWrite"/>
+          <Annotation Term="OData.Description" String="The policy that the RAID volume is using to address the write hole issue."/>
+          <Annotation Term="OData.LongDescription" String="This property specifies the policy that is enabled to address the write hole issue on the RAID volume. If no policy is enabled at the moment, this property shall be set to 'Off'."/>
+        </Property>
+        <Property Name="Deduplicated" Type="Edm.Boolean">
+          <Annotation Term="OData.Permissions" EnumMember="OData.Permission/ReadWrite"/>
+          <Annotation Term="OData.Description" String="Indicator of whether or not the Volume has deduplication enabled."/>
+          <Annotation Term="OData.LongDescription" String="This property shall contain a boolean indicator if the Volume is currently utilizing deduplication or not."/>
+        </Property>
+        <Property Name="Compressed" Type="Edm.Boolean">
+          <Annotation Term="OData.Permissions" EnumMember="OData.Permission/ReadWrite"/>
+          <Annotation Term="OData.Description" String="Indicator of whether or not the Volume has compression enabled."/>
+          <Annotation Term="OData.LongDescription" String="This property shall contain a boolean indicator if the Volume is currently utilizing compression or not."/>
+        </Property>
+      </EntityType>
+
+      <ComplexType Name="Links" BaseType="Volume.v1_3_0.Links">
+        <Annotation Term="OData.Description" String="Add collection of references to Endpoints and StorageGroups associated with this Volume."/>
+        <NavigationProperty Name="ClientEndpoints" Type="Collection(Endpoint.Endpoint)">
+          <Annotation Term="OData.Permissions" EnumMember="OData.Permission/Read"/>
+          <Annotation Term="OData.Description" String="An array of references to the client Endpoints associated with this volume."/>
+          <Annotation Term="OData.LongDescription" String="The value of this property shall be references to the client Endpoints this volume is associated with."/>
+          <Annotation Term="OData.AutoExpandReferences"/>
+        </NavigationProperty>
+        <NavigationProperty Name="ServerEndpoints" Type="Collection(Endpoint.Endpoint)">
+          <Annotation Term="OData.Permissions" EnumMember="OData.Permission/Read"/>
+          <Annotation Term="OData.Description" String="An array of references to the server Endpoints associated with this volume."/>
+          <Annotation Term="OData.LongDescription" String="The value of this property shall be references to the server Endpoints this volume is associated with."/>
+          <Annotation Term="OData.AutoExpandReferences"/>
+        </NavigationProperty>
+        <NavigationProperty Name="StorageGroups" Type="Collection(StorageGroup.StorageGroup)">
+          <Annotation Term="OData.Permissions" EnumMember="OData.Permission/Read"/>
+          <Annotation Term="OData.Description" String="An array of references to the StorageGroups associated with this volume."/>
+          <Annotation Term="OData.LongDescription" String="The value of this property shall be references to the StorageGroups this volume is associated with."/>
+          <Annotation Term="OData.AutoExpandReferences"/>
+        </NavigationProperty>
+        <NavigationProperty Name="ConsistencyGroups" Type="Collection(ConsistencyGroup.ConsistencyGroup)">
+          <Annotation Term="OData.Permissions" EnumMember="OData.Permission/Read"/>
+          <Annotation Term="OData.Description" String="An array of references to the ConsistencyGroups associated with this volume."/>
+          <Annotation Term="OData.LongDescription" String="The value of this property shall be references to the ConsistencyGroups this volume is associated with."/>
+          <Annotation Term="OData.AutoExpandReferences"/>
+        </NavigationProperty>
+        <NavigationProperty Name="OwningStorageService" Type="StorageService.StorageService" Nullable="false">
+          <Annotation Term="OData.Permissions" EnumMember="OData.Permission/Read"/>
+          <Annotation Term="OData.Description" String="A pointer to the StorageService that owns or contains this volume."/>
+          <Annotation Term="OData.LongDescription" String="This shall be a pointer to the StorageService that owns or contains this volume."/>
+        </NavigationProperty>
+      </ComplexType>
+    </Schema>
+
+    <Schema xmlns="http://docs.oasis-open.org/odata/ns/edm" Namespace="Volume.v1_4_1">
+      <Annotation Term="Redfish.OwningEntity" String="SNIA"/>
+      <Annotation
+        Term="OData.Description"
+        String="This version was created to update the reference to StorageReplicaInfo to version 1.3.0. It also adds Redfish.Release and RevisionKind/Added annotations, adds 'Off' to the WriteCachePolicy, and fixes Redfish Uris issues."/>
+      <EntityType Name="Volume" BaseType="Volume.v1_4_0.Volume"/>
+    </Schema>
+
+    <Schema xmlns="http://docs.oasis-open.org/odata/ns/edm" Namespace="Volume.v1_4_2">
+      <Annotation Term="Redfish.OwningEntity" String="SNIA"/>
+      <Annotation Term="OData.Description" String="This version was created to add a type of None to RAIDType. This also moves enums and actions to the unversioned namespace."/>
+      <EntityType Name="Volume" BaseType="Volume.v1_4_1.Volume"/>
+    </Schema>
+
+    <Schema xmlns="http://docs.oasis-open.org/odata/ns/edm" Namespace="Volume.v1_4_3">
+      <Annotation Term="Redfish.OwningEntity" String="SNIA"/>
+      <Annotation Term="OData.Description" String="This version was added to fix typographical errors."/>
+      <EntityType Name="Volume" BaseType="Volume.v1_4_2.Volume"/>
+    </Schema>
+
+    <Schema xmlns="http://docs.oasis-open.org/odata/ns/edm" Namespace="Volume.v1_5_0">
+      <Annotation Term="Redfish.OwningEntity" String="SNIA"/>
+      <Annotation Term="Redfish.Release" String="WIP v1.2.0"/>
+     <Annotation
+        Term="OData.Description"
+        String="This version was created to add the ChangeRAIDLayout and ForceEnable Actions, and moves the replication Actions to the unversioned namespace. It adds InitializeMethod and deprecate InitializeType. It also adds support for NVMe. It also adds the IOPerfModeEnabled property, and references to Journaling Media and OwningStorageResource to Links."/>
+      <EntityType Name="Volume" BaseType="Volume.v1_4_2.Volume">
+        <Property Name="IOPerfModeEnabled" Type="Edm.Boolean">
+          <Annotation Term="OData.Permissions" EnumMember="OData.Permission/ReadWrite"/>
+          <Annotation Term="OData.Description" String="Indicates the IO performance mode setting for the volume."/>
+          <Annotation Term="OData.LongDescription" String="This property shall indicate whether IO performance mode is enabled for the volume."/>
+        </Property>
+        <Property Name="NVMeNamespaceProperties" Type="Volume.v1_5_0.NVMeNamespaceProperties">
+          <Annotation Term="OData.Description" String="This property contains properties to use when Volume is used to describe an NVMe Namespace."/>
+          <Annotation Term="OData.LongDescription" String="This property shall contain properties to use when Volume is used to describe an NVMe Namespace."/>
+        </Property>
+      </EntityType>
+
+      <ComplexType Name="Links" BaseType="Volume.v1_4_0.Links">
+        <Annotation Term="OData.Description" String="Add a reference to Journaling Media and OwningStorageResource associated with this Volume."/>
+        <NavigationProperty Name="JournalingMedia" Type="Resource.Resource">
+          <Annotation Term="OData.Permissions" EnumMember="OData.Permission/ReadWrite"/>
+          <Annotation Term="OData.Description" String="A pointer to the Resource that serves as a journaling media for this volume."/>
+          <Annotation Term="OData.LongDescription" String="This shall be a pointer to the journaling media used for this Volume to address the write hole issue. Valid when WriteHoleProtectionPolicy property is set to 'Journaling'."/>
+        </NavigationProperty>
+        <NavigationProperty Name="OwningStorageResource" Type="Storage.Storage" Nullable="false">
+          <Annotation Term="OData.Permissions" EnumMember="OData.Permission/Read"/>
+          <Annotation Term="OData.Description" String="A pointer to the Storage resource that owns or contains this volume."/>
+          <Annotation Term="OData.LongDescription" String="This shall be a pointer to the Storage resource that owns or contains this volume."/>
+        </NavigationProperty>
+      </ComplexType>
+
+      <ComplexType Name="NVMeNamespaceProperties">
+        <Annotation Term="OData.Description" String="This contains properties to use when Volume is used to describe an NVMe Namespace."/>
+        <Annotation Term="OData.LongDescription" String="This contains properties to use when Volume is used to describe an NVMe Namespace."/>
+        <Property Name="NamespaceId" Type="Edm.String">
+          <Annotation Term="OData.Permissions" EnumMember="OData.Permission/Read"/>
+          <Annotation Term="OData.Description" String="The NVMe Namespace Identifier for this namespace."/>
+          <Annotation Term="OData.LongDescription" String="This property shall contain the NVMe Namespace Identifier for this namespace. This property shall be a hex value. Namespace identifiers are not durable and do not have meaning outside the scope of the NVMe subsystem. NSID 0x0, 0xFFFFFFFF, 0xFFFFFFFE are special purpose values."/>
+          <Annotation Term="Validation.Pattern" String="^0[xX](([a-fA-F]|[0-9])*)$"/>
+        </Property>
+        <Property Name="IsShareable" Type="Edm.Boolean">
+          <Annotation Term="OData.Permissions" EnumMember="OData.Permission/ReadWrite"/>
+          <Annotation Term="OData.Description" String="Indicates the namespace is shareable."/>
+          <Annotation Term="OData.LongDescription" String="This property shall indicate whether the namespace is shareable."/>
+        </Property>
+        <Property Name="NamespaceFeatures" Type="Volume.v1_5_0.NamespaceFeatures">
+          <Annotation Term="OData.Description" String="This property contains a set of Namespace Features."/>
+          <Annotation Term="OData.LongDescription" String="This property shall contain a set of Namespace Features."/>
+        </Property>
+        <Property Name="NumberLBAFormats" Type="Edm.Int64">
+          <Annotation Term="OData.Description" String="The number of LBA data size and metadata size combinations supported by this namespace. The value of this property is between 0 and 16."/>
+          <Annotation Term="OData.LongDescription" String="This property shall contain the number of LBA data size and metadata size combinations supported by this namespace. The value of this property is between 0 and 16. LBA formats with an index set beyond this value will not be supported."/>
+          <Annotation Term="OData.Permissions" EnumMember="OData.Permission/Read"/>
+          <Annotation Term="Measures.Unit" String="By"/>
+          <Annotation Term="Validation.Minimum" Int="0"/>
+        </Property>
+        <Property Name="FormattedLBASize" Type="Edm.String">
+          <Annotation Term="OData.Description" String="The LBA data size and metadata size combination that the namespace has been formatted with."/>
+          <Annotation Term="OData.LongDescription" String="This property shall contain the LBA data size and metadata size combination that the namespace has been formatted with. This is a 4-bit data structure."/>
+          <Annotation Term="OData.Permissions" EnumMember="OData.Permission/Read"/>
+        </Property>
+        <Property Name="MetadataTransferredAtEndOfDataLBA" Type="Edm.Boolean">
+          <Annotation Term="OData.Description" String="This property indicates whether or not the metadata is transferred at the end of the LBA creating an extended data LBA."/>
+          <Annotation Term="OData.LongDescription" String="This property shall indicate whether or not the metadata is transferred at the end of the LBA creating an extended data LBA."/>
+          <Annotation Term="OData.Permissions" EnumMember="OData.Permission/Read"/>
+        </Property>
+        <Property Name="NVMeVersion" Type="Edm.String">
+          <Annotation Term="OData.Description" String="The version of the NVMe Base Specification supported."/>
+          <Annotation Term="OData.LongDescription" String="This property shall contain the version of the NVMe Base Specification supported."/>
+          <Annotation Term="OData.Permissions" EnumMember="OData.Permission/Read"/>
+        </Property>
+      </ComplexType>
+
+      <ComplexType Name="NamespaceFeatures">
+        <Property Name="SupportsThinProvisioning" Type="Edm.Boolean">
+          <Annotation Term="OData.Description" String="This property indicates whether or not the NVMe Namespace supports thin provisioning."/>
+          <Annotation Term="OData.LongDescription" String="This property shall indicate whether or not the NVMe Namespace supports thin provisioning. Specifically, the namespace capacity reported may be less than the namespace size."/>
+          <Annotation Term="OData.Permissions" EnumMember="OData.Permission/Read"/>
+        </Property>
+        <Property Name="SupportsDeallocatedOrUnwrittenLBError" Type="Edm.Boolean">
+          <Annotation Term="OData.Description" String="This property indicates that the controller supports deallocated or unwritten logical block error for this namespace."/>
+          <Annotation Term="OData.LongDescription" String="This property shall indicate that the controller supports deallocated or unwritten logical block error for this namespace. ."/>
+          <Annotation Term="OData.Permissions" EnumMember="OData.Permission/Read"/>
+        </Property>
+        <Property Name="SupportsNGUIDReuse" Type="Edm.Boolean">
+          <Annotation Term="OData.Description" String="This property indicates that the namespace supports the use of an NGUID (namespace globally unique identifier) value."/>
+          <Annotation Term="OData.LongDescription" String="This property shall indicate that the namespace supports the use of an NGUID (namespace globally unique identifier) value."/>
+          <Annotation Term="OData.Permissions" EnumMember="OData.Permission/Read"/>
+        </Property>
+        <Property Name="SupportsAtomicTransactionSize" Type="Edm.Boolean">
+          <Annotation Term="OData.Description" String="Indicates that the NVM fields for Namespace preferred write granularity (NPWG), write alignment (NPWA), deallocate granularity (NPDG), deallocate alignment (NPDA) and optimal write size (NOWS)  are defined for this namespace and should be used by the host for I/O optimization."/>
+          <Annotation Term="OData.LongDescription" String="This property shall indicate whether or not the NVM fields for Namespace preferred write granularity (NPWG), write alignment (NPWA), deallocate granularity (NPDG), deallocate alignment (NPDA) and optimal write size (NOWS)  are defined for this namespace and should be used by the host for I/O optimization."/>
+          <Annotation Term="OData.Permissions" EnumMember="OData.Permission/Read"/>
+        </Property>
+        <Property Name="SupportsIOPerformanceHints" Type="Edm.Boolean">
+          <Annotation Term="OData.Description" String="Indicates that the Namespace Atomic Write Unit Normal (NAWUN), Namespace Atomic Write Unit Power Fail (NAWUPF), and Namespace Atomic Compare and Write Unit (NACWU) fields are defined for this namespace and should be used by the host for this namespace instead of the controller-level properties AWUN, AWUPF, and ACWU."/>
+          <Annotation Term="OData.LongDescription" String="This property shall indicate that the Namespace Atomic Write Unit Normal (NAWUN), Namespace Atomic Write Unit Power Fail (NAWUPF), and Namespace Atomic Compare and Write Unit (NACWU) fields are defined for this namespace and should be used by the host for this namespace instead of the controller-level properties AWUN, AWUPF, and ACWU."/>
+          <Annotation Term="OData.Permissions" EnumMember="OData.Permission/Read"/>
+        </Property>
+      </ComplexType>
+
+    </Schema>
+
+    <Schema xmlns="http://docs.oasis-open.org/odata/ns/edm" Namespace="Volume.v1_5_1">
+      <Annotation Term="Redfish.OwningEntity" String="SNIA"/>
+      <Annotation Term="OData.Description" String="This version was added to fix typographical errors."/>
+      <EntityType Name="Volume" BaseType="Volume.v1_5_0.Volume"/>
+    </Schema>
+
+    <Schema xmlns="http://docs.oasis-open.org/odata/ns/edm" Namespace="Volume.v1_6_0">
+      <Annotation Term="Redfish.OwningEntity" String="SNIA"/>
+      <Annotation Term="Redfish.Release" String="TP v1.2.1"/>
+
+      <Annotation Term="OData.Description" String="This version was created to add the InitializeMethod property. It also changes the DedicatedSpareDrives property in Links to Read/Write."/>
+      <EntityType Name="Volume" BaseType="Volume.v1_5_0.Volume">
+        <Property Name="InitializeMethod" Type="Volume.InitializeMethod">
+          <Annotation Term="OData.Permissions" EnumMember="OData.Permission/Read"/>
+          <Annotation Term="OData.Description" String="Indicates the Initialization Method used for this volume. If InitializeMethod is not specified, the InitializeMethod should be Foreground."/>
+          <Annotation
+            Term="OData.LongDescription"
+            String="This property shall indicate the initialization method used for this volume. If InitializeMethod is not specified, the InitializeMethod should be Foreground. This value reflects the most recently used Initialization Method, and may be changed using the Initialize Action."/>
+        </Property>
+      </EntityType>
+      <ComplexType Name="Links" BaseType="Volume.v1_5_0.Links">
+        <Annotation Term="OData.Description" String="Add a reference to Journaling Media and OwningStorageResource associated with this Volume."/>
+        <NavigationProperty Name="CacheVolumeSource" Type="Volume.Volume">
+          <Annotation Term="OData.Permissions" EnumMember="OData.Permission/Read"/>
+          <Annotation Term="OData.Description" String="A pointer to the cache volume source for this volume."/>
+          <Annotation Term="OData.LongDescription" String="This shall be a pointer to the cache volume source for this volume. The corresponding VolumeUsage property shall be set to Data when this property is used."/>
+        </NavigationProperty>
+        <NavigationProperty Name="CacheDataVolumes" Type="Collection(Volume.Volume)">
+          <Annotation Term="OData.Permissions" EnumMember="OData.Permission/Read"/>
+          <Annotation Term="OData.Description" String="A pointer to the data volumes this volume serves as a cache volume."/>
+          <Annotation Term="OData.LongDescription" String="This shall be a pointer to the cache data volumes this volume serves as a cache volume.  The corresponding VolumeUsage property shall be set to CacheOnly when this property is used."/>
+        </NavigationProperty>
+      </ComplexType>
+    </Schema>
+
+    <Schema xmlns="http://docs.oasis-open.org/odata/ns/edm" Namespace="Volume.v1_6_1">
+      <Annotation Term="Redfish.OwningEntity" String="SNIA"/>
+      <Annotation Term="OData.Description" String="This version was added to fix typographical errors."/>
+      <EntityType Name="Volume" BaseType="Volume.v1_6_0.Volume"/>
+    </Schema>
+
+    <Schema xmlns="http://docs.oasis-open.org/odata/ns/edm" Namespace="Volume.v1_6_2">
+      <Annotation Term="Redfish.OwningEntity" String="SNIA"/>
+      <Annotation Term="OData.Description" String="This version was added to fix typographical errors."/>
+      <EntityType Name="Volume" BaseType="Volume.v1_6_0.Volume"/>
+    </Schema>
+
+  </edmx:DataServices>
+</edmx:Edmx>

--- a/static/redfish/v1/schema/ZoneCollection_v1.xml
+++ b/static/redfish/v1/schema/ZoneCollection_v1.xml
@@ -1,0 +1,70 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!---->
+<!--################################################################################       -->
+<!--# Redfish Schema:  ZoneCollection                                                      -->
+<!--#                                                                                      -->
+<!--# For a detailed change log, see the README file contained in the DSP8010 bundle,      -->
+<!--# available at http://www.dmtf.org/standards/redfish                                   -->
+<!--# Copyright 2014-2021 DMTF.                                                            -->
+<!--# For the full DMTF copyright policy, see http://www.dmtf.org/about/policies/copyright -->
+<!--################################################################################       -->
+<!---->
+<edmx:Edmx xmlns:edmx="http://docs.oasis-open.org/odata/ns/edmx" Version="4.0">
+
+  <edmx:Reference Uri="http://docs.oasis-open.org/odata/odata/v4.0/errata03/csd01/complete/vocabularies/Org.OData.Core.V1.xml">
+    <edmx:Include Namespace="Org.OData.Core.V1" Alias="OData"/>
+  </edmx:Reference>
+  <edmx:Reference Uri="http://docs.oasis-open.org/odata/odata/v4.0/errata03/csd01/complete/vocabularies/Org.OData.Capabilities.V1.xml">
+    <edmx:Include Namespace="Org.OData.Capabilities.V1" Alias="Capabilities"/>
+  </edmx:Reference>
+  <edmx:Reference Uri="http://redfish.dmtf.org/schemas/v1/Resource_v1.xml">
+    <edmx:Include Namespace="Resource.v1_0_0"/>
+  </edmx:Reference>
+  <edmx:Reference Uri="http://redfish.dmtf.org/schemas/v1/RedfishExtensions_v1.xml">
+    <edmx:Include Namespace="RedfishExtensions.v1_0_0" Alias="Redfish"/>
+  </edmx:Reference>
+  <edmx:Reference Uri="http://redfish.dmtf.org/schemas/v1/Zone_v1.xml">
+    <edmx:Include Namespace="Zone"/>
+  </edmx:Reference>
+
+  <edmx:DataServices>
+
+    <Schema xmlns="http://docs.oasis-open.org/odata/ns/edm" Namespace="ZoneCollection">
+      <Annotation Term="Redfish.OwningEntity" String="DMTF"/>
+
+      <EntityType Name="ZoneCollection" BaseType="Resource.v1_0_0.ResourceCollection">
+        <Annotation Term="OData.Description" String="The collection of Zone resource instances."/>
+        <Annotation Term="OData.LongDescription" String="This resource shall represent a resource collection of Zone instances for a Redfish implementation."/>
+        <Annotation Term="Capabilities.InsertRestrictions">
+          <Record>
+            <PropertyValue Property="Insertable" Bool="true"/>
+          </Record>
+        </Annotation>
+        <Annotation Term="Capabilities.UpdateRestrictions">
+          <Record>
+            <PropertyValue Property="Updatable" Bool="false"/>
+          </Record>
+        </Annotation>
+        <Annotation Term="Capabilities.DeleteRestrictions">
+          <Record>
+            <PropertyValue Property="Deletable" Bool="false"/>
+          </Record>
+        </Annotation>
+        <Annotation Term="Redfish.Uris">
+          <Collection>
+            <String>/redfish/v1/Fabrics/{FabricId}/Zones</String>
+            <String>/redfish/v1/CompositionService/ResourceZones</String>
+          </Collection>
+        </Annotation>
+        <NavigationProperty Name="Members" Type="Collection(Zone.Zone)">
+          <Annotation Term="OData.Permissions" EnumMember="OData.Permission/Read"/>
+          <Annotation Term="OData.Description" String="The members of this collection."/>
+          <Annotation Term="OData.LongDescription" String="This property shall contain an array of links to the members of this collection."/>
+          <Annotation Term="OData.AutoExpandReferences"/>
+          <Annotation Term="Redfish.Required"/>
+        </NavigationProperty>
+      </EntityType>
+    </Schema>
+
+  </edmx:DataServices>
+</edmx:Edmx>

--- a/static/redfish/v1/schema/Zone_v1.xml
+++ b/static/redfish/v1/schema/Zone_v1.xml
@@ -1,0 +1,465 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!---->
+<!--################################################################################       -->
+<!--# Redfish Schema:  Zone v1.6.1                                                         -->
+<!--#                                                                                      -->
+<!--# For a detailed change log, see the README file contained in the DSP8010 bundle,      -->
+<!--# available at http://www.dmtf.org/standards/redfish                                   -->
+<!--# Copyright 2014-2021 DMTF.                                                            -->
+<!--# For the full DMTF copyright policy, see http://www.dmtf.org/about/policies/copyright -->
+<!--################################################################################       -->
+<!---->
+<edmx:Edmx xmlns:edmx="http://docs.oasis-open.org/odata/ns/edmx" Version="4.0">
+
+  <edmx:Reference Uri="http://docs.oasis-open.org/odata/odata/v4.0/errata03/csd01/complete/vocabularies/Org.OData.Core.V1.xml">
+    <edmx:Include Namespace="Org.OData.Core.V1" Alias="OData"/>
+  </edmx:Reference>
+  <edmx:Reference Uri="http://docs.oasis-open.org/odata/odata/v4.0/errata03/csd01/complete/vocabularies/Org.OData.Capabilities.V1.xml">
+    <edmx:Include Namespace="Org.OData.Capabilities.V1" Alias="Capabilities"/>
+  </edmx:Reference>
+  <edmx:Reference Uri="http://redfish.dmtf.org/schemas/v1/Resource_v1.xml">
+    <edmx:Include Namespace="Resource"/>
+    <edmx:Include Namespace="Resource.v1_0_0"/>
+  </edmx:Reference>
+  <edmx:Reference Uri="http://redfish.dmtf.org/schemas/v1/RedfishExtensions_v1.xml">
+    <edmx:Include Namespace="RedfishExtensions.v1_0_0" Alias="Redfish"/>
+  </edmx:Reference>
+  <edmx:Reference Uri="http://redfish.dmtf.org/schemas/v1/Switch_v1.xml">
+    <edmx:Include Namespace="Switch"/>
+  </edmx:Reference>
+  <edmx:Reference Uri="http://redfish.dmtf.org/schemas/v1/Endpoint_v1.xml">
+    <edmx:Include Namespace="Endpoint"/>
+  </edmx:Reference>
+  <edmx:Reference Uri="http://redfish.dmtf.org/schemas/v1/ResourceBlock_v1.xml">
+    <edmx:Include Namespace="ResourceBlock"/>
+  </edmx:Reference>
+  <edmx:Reference Uri="http://redfish.dmtf.org/schemas/v1/AddressPool_v1.xml">
+    <edmx:Include Namespace="AddressPool"/>
+  </edmx:Reference>
+
+  <edmx:DataServices>
+
+    <Schema xmlns="http://docs.oasis-open.org/odata/ns/edm" Namespace="Zone">
+      <Annotation Term="Redfish.OwningEntity" String="DMTF"/>
+
+      <EntityType Name="Zone" BaseType="Resource.v1_0_0.Resource" Abstract="true">
+        <Annotation Term="OData.Description" String="The Zone schema describes a simple fabric zone for a Redfish implementation."/>
+        <Annotation Term="OData.LongDescription" String="This resource shall represent a simple fabric zone for a Redfish implementation."/>
+        <Annotation Term="Capabilities.InsertRestrictions">
+          <Record>
+            <PropertyValue Property="Insertable" Bool="false"/>
+          </Record>
+        </Annotation>
+        <Annotation Term="Capabilities.UpdateRestrictions">
+          <Record>
+            <PropertyValue Property="Updatable" Bool="true"/>
+          </Record>
+        </Annotation>
+        <Annotation Term="Capabilities.DeleteRestrictions">
+          <Record>
+            <PropertyValue Property="Deletable" Bool="true"/>
+          </Record>
+        </Annotation>
+        <Annotation Term="Redfish.Uris">
+          <Collection>
+            <String>/redfish/v1/Fabrics/{FabricId}/Zones/{ZoneId}</String>
+            <String>/redfish/v1/CompositionService/ResourceZones/{ZoneId}</String>
+          </Collection>
+        </Annotation>
+      </EntityType>
+
+      <Action Name="AddEndpoint" IsBound="true">
+        <Annotation Term="OData.Description" String="This action adds an endpoint to a zone."/>
+        <Annotation Term="OData.LongDescription" String="This action shall add an endpoint to a zone."/>
+        <Parameter Name="Zone" Type="Zone.v1_1_0.Actions"/>
+        <Parameter Name="Endpoint" Type="Endpoint.Endpoint" Nullable="false">
+          <Annotation Term="OData.Description" String="The endpoint to add to the zone."/>
+          <Annotation Term="OData.LongDescription" String="This parameter shall contain a link to the specified endpoint to add to the zone."/>
+        </Parameter>
+        <Parameter Name="EndpointETag" Type="Edm.String">
+          <Annotation Term="OData.Description" String="The current ETag of the endpoint to add to the zone."/>
+          <Annotation Term="OData.LongDescription" String="This parameter shall contain the current ETag of the endpoint to add to the zone.  If the client-provided ETag does not match the current ETag of the endpoint that the Endpoint parameter specifies, the service shall return the HTTP 428 (Precondition Required) status code to reject the request."/>
+        </Parameter>
+        <Parameter Name="ZoneETag" Type="Edm.String">
+          <Annotation Term="OData.Description" String="The current ETag of the zone."/>
+          <Annotation Term="OData.LongDescription" String="This parameter shall contain the current ETag of the zone.  If the client-provided ETag does not match the current ETag of the zone, the service shall return the HTTP 428 (Precondition Required) status code to reject the request."/>
+        </Parameter>
+        <Annotation Term="Redfish.Revisions">
+          <Collection>
+            <Record>
+              <PropertyValue Property="Kind" EnumMember="Redfish.RevisionKind/Added"/>
+              <PropertyValue Property="Version" String="v1_5_0"/>
+            </Record>
+          </Collection>
+        </Annotation>
+      </Action>
+
+      <Action Name="RemoveEndpoint" IsBound="true">
+        <Annotation Term="OData.Description" String="This action removes an endpoint from a zone."/>
+        <Annotation Term="OData.LongDescription" String="This action shall remove an endpoint from a zone."/>
+        <Parameter Name="Zone" Type="Zone.v1_1_0.Actions"/>
+        <Parameter Name="Endpoint" Type="Endpoint.Endpoint" Nullable="false">
+          <Annotation Term="OData.Description" String="The endpoint to remove from the zone."/>
+          <Annotation Term="OData.LongDescription" String="This parameter shall contain a link to the specified endpoint to remove from the zone."/>
+        </Parameter>
+        <Parameter Name="EndpointETag" Type="Edm.String">
+          <Annotation Term="OData.Description" String="The current ETag of the endpoint to remove from the system."/>
+          <Annotation Term="OData.LongDescription" String="This parameter shall contain the current ETag of the endpoint to remove from the system.  If the client-provided ETag does not match the current ETag of the endpoint that the Endpoint parameter specifies, the service shall return the HTTP 428 (Precondition Required) status code to reject the request."/>
+        </Parameter>
+        <Parameter Name="ZoneETag" Type="Edm.String">
+          <Annotation Term="OData.Description" String="The current ETag of the zone."/>
+          <Annotation Term="OData.LongDescription" String="This parameter shall contain the current ETag of the zone.  If the client-provided ETag does not match the current ETag of the zone, the service shall return the HTTP 428 (Precondition Required) status code to reject the request."/>
+        </Parameter>
+        <Annotation Term="Redfish.Revisions">
+          <Collection>
+            <Record>
+              <PropertyValue Property="Kind" EnumMember="Redfish.RevisionKind/Added"/>
+              <PropertyValue Property="Version" String="v1_5_0"/>
+            </Record>
+          </Collection>
+        </Annotation>
+      </Action>
+    </Schema>
+
+    <Schema xmlns="http://docs.oasis-open.org/odata/ns/edm" Namespace="Zone.v1_0_0">
+      <Annotation Term="Redfish.OwningEntity" String="DMTF"/>
+      <Annotation Term="Redfish.Release" String="2016.2"/>
+
+      <EntityType Name="Zone" BaseType="Zone.Zone">
+        <Property Name="Status" Type="Resource.Status" Nullable="false">
+          <Annotation Term="OData.Description" String="The status and health of the resource and its subordinate or dependent resources."/>
+          <Annotation Term="OData.LongDescription" String="This property shall contain any status or health properties of the resource."/>
+        </Property>
+        <Property Name="Links" Type="Zone.v1_0_0.Links" Nullable="false">
+          <Annotation Term="OData.Description" String="The links to other resources that are related to this resource."/>
+          <Annotation Term="OData.LongDescription" String="This property shall contain links to resources that are related to but are not contained by, or subordinate to, this resource."/>
+        </Property>
+      </EntityType>
+
+      <ComplexType Name="Links" BaseType="Resource.Links">
+        <Annotation Term="OData.Description" String="The links to other resources that are related to this resource."/>
+        <Annotation Term="OData.LongDescription" String="This Redfish Specification-described type shall contain links to resources that are related to but are not contained by, or subordinate to, this resource."/>
+        <NavigationProperty Name="Endpoints" Type="Collection(Endpoint.Endpoint)">
+          <Annotation Term="OData.Permissions" EnumMember="OData.Permission/Read"/>
+          <Annotation Term="OData.Description" String="The links to the endpoints that this zone contains."/>
+          <Annotation Term="OData.LongDescription" String="This property shall contain an array of links to resources of type Endpoint that this zone contains."/>
+          <Annotation Term="OData.AutoExpandReferences"/>
+        </NavigationProperty>
+        <NavigationProperty Name="InvolvedSwitches" Type="Collection(Switch.Switch)">
+          <Annotation Term="OData.Permissions" EnumMember="OData.Permission/Read"/>
+          <Annotation Term="OData.Description" String="The links to the collection of switches in this zone."/>
+          <Annotation Term="OData.LongDescription" String="This property shall contain an array of links to resources of type Switch in this zone."/>
+          <Annotation Term="OData.AutoExpandReferences"/>
+        </NavigationProperty>
+      </ComplexType>
+    </Schema>
+
+    <Schema xmlns="http://docs.oasis-open.org/odata/ns/edm" Namespace="Zone.v1_0_1">
+      <Annotation Term="Redfish.OwningEntity" String="DMTF"/>
+      <Annotation Term="OData.Description" String="This version was created to show that annotations in previous namespaces were updated."/>
+      <EntityType Name="Zone" BaseType="Zone.v1_0_0.Zone"/>
+    </Schema>
+
+    <Schema xmlns="http://docs.oasis-open.org/odata/ns/edm" Namespace="Zone.v1_0_2">
+      <Annotation Term="Redfish.OwningEntity" String="DMTF"/>
+      <Annotation Term="OData.Description" String="This version was created to remove the Nullable facet from NavigationProperties of the Collection type."/>
+      <EntityType Name="Zone" BaseType="Zone.v1_0_1.Zone"/>
+    </Schema>
+
+    <Schema xmlns="http://docs.oasis-open.org/odata/ns/edm" Namespace="Zone.v1_0_3">
+      <Annotation Term="Redfish.OwningEntity" String="DMTF"/>
+      <Annotation Term="OData.Description" String="This version was created to force the regeneration of JSON Schema so that OData properties are marked as required, and integer properties are marked as integer rather than number."/>
+      <EntityType Name="Zone" BaseType="Zone.v1_0_2.Zone"/>
+    </Schema>
+
+    <Schema xmlns="http://docs.oasis-open.org/odata/ns/edm" Namespace="Zone.v1_0_4">
+      <Annotation Term="Redfish.OwningEntity" String="DMTF"/>
+      <Annotation Term="OData.Description" String="This version was created to regenerate the JSON Schema so that URI properties use the uri-reference format."/>
+      <EntityType Name="Zone" BaseType="Zone.v1_0_3.Zone"/>
+    </Schema>
+
+    <Schema xmlns="http://docs.oasis-open.org/odata/ns/edm" Namespace="Zone.v1_0_5">
+      <Annotation Term="Redfish.OwningEntity" String="DMTF"/>
+      <Annotation Term="OData.Description" String="This version was created to update descriptions that this schema defines."/>
+      <EntityType Name="Zone" BaseType="Zone.v1_0_4.Zone"/>
+    </Schema>
+
+    <Schema xmlns="http://docs.oasis-open.org/odata/ns/edm" Namespace="Zone.v1_0_6">
+      <Annotation Term="Redfish.OwningEntity" String="DMTF"/>
+      <Annotation Term="OData.Description" String="This version was created to correct various typographical errors."/>
+      <EntityType Name="Zone" BaseType="Zone.v1_0_5.Zone"/>
+    </Schema>
+
+    <Schema xmlns="http://docs.oasis-open.org/odata/ns/edm" Namespace="Zone.v1_1_0">
+      <Annotation Term="Redfish.OwningEntity" String="DMTF"/>
+      <Annotation Term="Redfish.Release" String="2017.1"/>
+
+      <EntityType Name="Zone" BaseType="Zone.v1_0_2.Zone">
+        <Property Name="Actions" Type="Zone.v1_1_0.Actions" Nullable="false">
+          <Annotation Term="OData.Description" String="The available actions for this resource."/>
+          <Annotation Term="OData.LongDescription" String="This property shall contain the available actions for this resource."/>
+        </Property>
+      </EntityType>
+
+      <ComplexType Name="Links" BaseType="Zone.v1_0_0.Links">
+        <NavigationProperty Name="ResourceBlocks" Type="Collection(ResourceBlock.ResourceBlock)">
+          <Annotation Term="OData.Permissions" EnumMember="OData.Permission/Read"/>
+          <Annotation Term="OData.Description" String="The links to the resource blocks with which this zone is associated."/>
+          <Annotation Term="OData.LongDescription" String="This property shall contain an array of links to resources of type ResourceBlock with which this zone is associated."/>
+          <Annotation Term="OData.AutoExpandReferences"/>
+        </NavigationProperty>
+      </ComplexType>
+
+      <ComplexType Name="Actions">
+        <Annotation Term="OData.AdditionalProperties" Bool="false"/>
+        <Annotation Term="OData.Description" String="The available actions for this resource."/>
+        <Annotation Term="OData.LongDescription" String="This type shall contain the available actions for this resource."/>
+        <Property Name="Oem" Type="Zone.v1_1_0.OemActions" Nullable="false">
+          <Annotation Term="OData.Description" String="The available OEM-specific actions for this resource."/>
+          <Annotation Term="OData.LongDescription" String="This property shall contain the available OEM-specific actions for this resource."/>
+        </Property>
+      </ComplexType>
+
+      <ComplexType Name="OemActions">
+        <Annotation Term="OData.AdditionalProperties" Bool="true"/>
+        <Annotation Term="OData.Description" String="The available OEM-specific actions for this resource."/>
+        <Annotation Term="OData.LongDescription" String="This type shall contain the available OEM-specific actions for this resource."/>
+      </ComplexType>
+    </Schema>
+
+    <Schema xmlns="http://docs.oasis-open.org/odata/ns/edm" Namespace="Zone.v1_1_1">
+      <Annotation Term="Redfish.OwningEntity" String="DMTF"/>
+      <Annotation Term="OData.Description" String="This version was created to edit Schema-defined descriptions."/>
+      <EntityType Name="Zone" BaseType="Zone.v1_1_0.Zone"/>
+    </Schema>
+
+    <Schema xmlns="http://docs.oasis-open.org/odata/ns/edm" Namespace="Zone.v1_1_2">
+      <Annotation Term="Redfish.OwningEntity" String="DMTF"/>
+      <Annotation Term="OData.Description" String="This version was created to force the regeneration of JSON Schema so that OData properties are marked as required, and integer properties are marked as integer rather than number."/>
+      <EntityType Name="Zone" BaseType="Zone.v1_1_1.Zone"/>
+    </Schema>
+
+    <Schema xmlns="http://docs.oasis-open.org/odata/ns/edm" Namespace="Zone.v1_1_3">
+      <Annotation Term="Redfish.OwningEntity" String="DMTF"/>
+      <Annotation Term="OData.Description" String="This version was created to force the regeneration of JSON Schema so that URI properties use the uri-reference format."/>
+      <EntityType Name="Zone" BaseType="Zone.v1_1_2.Zone"/>
+    </Schema>
+
+    <Schema xmlns="http://docs.oasis-open.org/odata/ns/edm" Namespace="Zone.v1_1_4">
+      <Annotation Term="Redfish.OwningEntity" String="DMTF"/>
+      <Annotation Term="OData.Description" String="This version was created to update descriptions that this schema defines."/>
+      <EntityType Name="Zone" BaseType="Zone.v1_1_3.Zone"/>
+    </Schema>
+
+    <Schema xmlns="http://docs.oasis-open.org/odata/ns/edm" Namespace="Zone.v1_1_5">
+      <Annotation Term="Redfish.OwningEntity" String="DMTF"/>
+      <Annotation Term="OData.Description" String="This version was created to correct various typographical errors."/>
+      <EntityType Name="Zone" BaseType="Zone.v1_1_4.Zone"/>
+    </Schema>
+
+    <Schema xmlns="http://docs.oasis-open.org/odata/ns/edm" Namespace="Zone.v1_2_0">
+      <Annotation Term="Redfish.OwningEntity" String="DMTF"/>
+      <Annotation Term="Redfish.Release" String="2017.3"/>
+
+      <EntityType Name="Zone" BaseType="Zone.v1_1_1.Zone">
+        <Property Name="Identifiers" Type="Collection(Resource.Identifier)" Nullable="false">
+          <Annotation Term="OData.Description" String="The durable names for the zone."/>
+          <Annotation Term="OData.LongDescription" String="This property shall contain a list of all known durable names for the associated zone."/>
+        </Property>
+      </EntityType>
+    </Schema>
+
+    <Schema xmlns="http://docs.oasis-open.org/odata/ns/edm" Namespace="Zone.v1_2_1">
+      <Annotation Term="Redfish.OwningEntity" String="DMTF"/>
+      <Annotation Term="OData.Description" String="This version was created to force the regeneration of JSON Schema so that OData properties are marked as required, and integer properties are marked as integer rather than number."/>
+      <EntityType Name="Zone" BaseType="Zone.v1_2_0.Zone"/>
+    </Schema>
+
+    <Schema xmlns="http://docs.oasis-open.org/odata/ns/edm" Namespace="Zone.v1_2_2">
+      <Annotation Term="Redfish.OwningEntity" String="DMTF"/>
+      <Annotation Term="OData.Description" String="This version was created to force the regeneration of JSON Schema so that URI properties use the uri-reference format, and to add a missing term to Identifiers to disallow it from being null."/>
+      <EntityType Name="Zone" BaseType="Zone.v1_2_1.Zone"/>
+    </Schema>
+
+    <Schema xmlns="http://docs.oasis-open.org/odata/ns/edm" Namespace="Zone.v1_2_3">
+      <Annotation Term="Redfish.OwningEntity" String="DMTF"/>
+      <Annotation Term="OData.Description" String="This version was created to update descriptions that this schema defines."/>
+      <EntityType Name="Zone" BaseType="Zone.v1_2_2.Zone"/>
+    </Schema>
+
+    <Schema xmlns="http://docs.oasis-open.org/odata/ns/edm" Namespace="Zone.v1_2_4">
+      <Annotation Term="Redfish.OwningEntity" String="DMTF"/>
+      <Annotation Term="OData.Description" String="This version was created to correct various typographical errors."/>
+      <EntityType Name="Zone" BaseType="Zone.v1_2_3.Zone"/>
+    </Schema>
+
+    <Schema xmlns="http://docs.oasis-open.org/odata/ns/edm" Namespace="Zone.v1_3_0">
+      <Annotation Term="Redfish.OwningEntity" String="DMTF"/>
+      <Annotation Term="Redfish.Release" String="2019.1"/>
+
+      <EntityType Name="Zone" BaseType="Zone.v1_2_2.Zone">
+        <Property Name="ExternalAccessibility" Type="Zone.v1_3_0.ExternalAccessibility">
+          <Annotation Term="OData.Permissions" EnumMember="OData.Permission/ReadWrite"/>
+          <Annotation Term="OData.Description" String="Indicates accessibility of endpoints in this zone to endpoints outside of this zone."/>
+          <Annotation Term="OData.LongDescription" String="This property shall contain and indication of accessibility of endpoints in this zone to endpoints outside of this zone."/>
+        </Property>
+      </EntityType>
+
+      <EnumType Name="ExternalAccessibility">
+        <Member Name="GloballyAccessible">
+          <Annotation Term="OData.Description" String="Any external entity with the correct access details, which may include authorization information, can access the endpoints that this zone lists."/>
+          <Annotation Term="OData.LongDescription" String="This value shall indicate that any external entity with the correct access details, which may include authorization information, can access the endpoints that this zone lists, regardless of zone."/>
+        </Member>
+        <Member Name="NonZonedAccessible">
+          <Annotation Term="OData.Description" String="Any external entity that another zone does not explicitly list can access the endpoints that this zone lists."/>
+          <Annotation Term="OData.LongDescription" String="This value shall indicate that any external entity that another zone does not explicitly list can access the endpoints that this zone lists."/>
+        </Member>
+        <Member Name="ZoneOnly">
+          <Annotation Term="OData.Description" String="Only accessible by endpoints that this zone explicitly lists."/>
+          <Annotation Term="OData.LongDescription" String="This value shall indicate that endpoints in this zone are only accessible by endpoints that this zone explicitly lists."/>
+        </Member>
+        <Member Name="NoInternalRouting">
+          <Annotation Term="OData.Description" String="Routing is not enabled within this zone."/>
+          <Annotation Term="OData.LongDescription" String="This value shall indicate that implicit routing within this zone is not defined."/>
+        </Member>
+      </EnumType>
+    </Schema>
+
+    <Schema xmlns="http://docs.oasis-open.org/odata/ns/edm" Namespace="Zone.v1_3_1">
+      <Annotation Term="Redfish.OwningEntity" String="DMTF"/>
+      <Annotation Term="OData.Description" String="This version was created to update descriptions that this schema defines."/>
+      <EntityType Name="Zone" BaseType="Zone.v1_3_0.Zone"/>
+    </Schema>
+
+    <Schema xmlns="http://docs.oasis-open.org/odata/ns/edm" Namespace="Zone.v1_3_2">
+      <Annotation Term="Redfish.OwningEntity" String="DMTF"/>
+      <Annotation Term="OData.Description" String="This version was created to correct various typographical errors."/>
+      <EntityType Name="Zone" BaseType="Zone.v1_3_1.Zone"/>
+    </Schema>
+
+    <Schema xmlns="http://docs.oasis-open.org/odata/ns/edm" Namespace="Zone.v1_3_3">
+      <Annotation Term="Redfish.OwningEntity" String="DMTF"/>
+      <Annotation Term="OData.Description" String="This version was created to correct various typographical errors."/>
+      <EntityType Name="Zone" BaseType="Zone.v1_3_2.Zone"/>
+    </Schema>
+
+    <Schema xmlns="http://docs.oasis-open.org/odata/ns/edm" Namespace="Zone.v1_3_4">
+      <Annotation Term="Redfish.OwningEntity" String="DMTF"/>
+      <Annotation Term="OData.Description" String="This version was created to correct various description to use proper normative terminology."/>
+      <EntityType Name="Zone" BaseType="Zone.v1_3_3.Zone"/>
+    </Schema>
+
+    <Schema xmlns="http://docs.oasis-open.org/odata/ns/edm" Namespace="Zone.v1_4_0">
+      <Annotation Term="Redfish.OwningEntity" String="DMTF"/>
+      <Annotation Term="Redfish.Release" String="2019.4"/>
+
+      <EntityType Name="Zone" BaseType="Zone.v1_3_1.Zone">
+        <Property Name="ZoneType" Type="Zone.v1_4_0.ZoneType">
+          <Annotation Term="OData.Permissions" EnumMember="OData.Permission/ReadWrite"/>
+          <Annotation Term="OData.Description" String="The type of zone."/>
+          <Annotation Term="OData.LongDescription" String="This property shall contain the type of zone that this zone represents."/>
+        </Property>
+        <Property Name="DefaultRoutingEnabled" Type="Edm.Boolean">
+          <Annotation Term="OData.Permissions" EnumMember="OData.Permission/ReadWrite"/>
+          <Annotation Term="OData.Description" String="This property indicates whether routing within this zone is enabled."/>
+          <Annotation Term="OData.LongDescription" String="This property shall indicate whether routing within this zone is enabled."/>
+        </Property>
+      </EntityType>
+
+      <EnumType Name="ZoneType">
+        <Member Name="Default">
+          <Annotation Term="OData.Description" String="The zone in which all endpoints are added by default when instantiated."/>
+          <Annotation Term="OData.LongDescription" String="This value shall indicate a zone in which all endpoints are added by default when instantiated.  This value shall only be used for zones subordinate to the fabric collection."/>
+        </Member>
+        <Member Name="ZoneOfEndpoints">
+          <Annotation Term="OData.Description" String="A zone that contains endpoints."/>
+          <Annotation Term="OData.LongDescription" String="This value shall indicate a zone that contains resources of type Endpoint.  This value shall only be used for zones subordinate to the fabric collection."/>
+        </Member>
+        <Member Name="ZoneOfZones">
+          <Annotation Term="OData.Description" String="A zone that contains zones."/>
+          <Annotation Term="OData.LongDescription" String="This value shall indicate a zone that contains resources of type Zone.  This value shall only be used for zones subordinate to the fabric collection."/>
+        </Member>
+        <Member Name="ZoneOfResourceBlocks">
+          <Annotation Term="OData.Description" String="A zone that contains resource blocks."/>
+          <Annotation Term="OData.LongDescription" String="This value shall indicate a zone that contains resources of type ResourceBlock.  This value shall only be used for zones subordinate to the composition service."/>
+          <Annotation Term="Redfish.Revisions">
+            <Collection>
+              <Record>
+                <PropertyValue Property="Kind" EnumMember="Redfish.RevisionKind/Added"/>
+                <PropertyValue Property="Version" String="v1_6_0"/>
+              </Record>
+            </Collection>
+          </Annotation>
+        </Member>
+      </EnumType>
+
+      <ComplexType Name="Links" BaseType="Zone.v1_1_0.Links">
+        <NavigationProperty Name="AddressPools" Type="Collection(AddressPool.AddressPool)">
+          <Annotation Term="OData.Permissions" EnumMember="OData.Permission/Read"/>
+          <Annotation Term="OData.Description" String="An array of links to the address pools associated with this zone."/>
+          <Annotation Term="OData.LongDescription" String="This property shall contain an array of links to resources of type AddressPool with which this zone is associated."/>
+          <Annotation Term="OData.AutoExpandReferences"/>
+        </NavigationProperty>
+        <NavigationProperty Name="ContainedByZones" Type="Collection(Zone.Zone)">
+          <Annotation Term="OData.Permissions" EnumMember="OData.Permission/Read"/>
+          <Annotation Term="OData.Description" String="An array of links to the zone that contain this zone."/>
+          <Annotation Term="OData.LongDescription" String="This property shall contain an array of links to resources of type Zone that represent the zones that contain this zone.  The zones referenced by this property shall not be contained by other zones."/>
+          <Annotation Term="OData.AutoExpandReferences"/>
+        </NavigationProperty>
+        <NavigationProperty Name="ContainsZones" Type="Collection(Zone.Zone)">
+          <Annotation Term="OData.Permissions" EnumMember="OData.Permission/ReadWrite"/>
+          <Annotation Term="OData.Description" String="An array of links to the zones that are contained by this zone."/>
+          <Annotation Term="OData.LongDescription" String="This property shall contain an array of links to resources of type Zone that represent the zones that are contained by this zone.  The zones referenced by this property shall not contain other zones."/>
+          <Annotation Term="OData.AutoExpandReferences"/>
+        </NavigationProperty>
+      </ComplexType>
+    </Schema>
+
+    <Schema xmlns="http://docs.oasis-open.org/odata/ns/edm" Namespace="Zone.v1_4_1">
+      <Annotation Term="Redfish.OwningEntity" String="DMTF"/>
+      <Annotation Term="OData.Description" String="This version was created to correct various typographical errors."/>
+      <EntityType Name="Zone" BaseType="Zone.v1_4_0.Zone"/>
+    </Schema>
+
+    <Schema xmlns="http://docs.oasis-open.org/odata/ns/edm" Namespace="Zone.v1_4_2">
+      <Annotation Term="Redfish.OwningEntity" String="DMTF"/>
+      <Annotation Term="OData.Description" String="This version was created to correct various typographical errors."/>
+      <EntityType Name="Zone" BaseType="Zone.v1_4_1.Zone"/>
+    </Schema>
+
+    <Schema xmlns="http://docs.oasis-open.org/odata/ns/edm" Namespace="Zone.v1_4_3">
+      <Annotation Term="Redfish.OwningEntity" String="DMTF"/>
+      <Annotation Term="OData.Description" String="This version was created to correct various description to use proper normative terminology."/>
+      <EntityType Name="Zone" BaseType="Zone.v1_4_2.Zone"/>
+    </Schema>
+
+    <Schema xmlns="http://docs.oasis-open.org/odata/ns/edm" Namespace="Zone.v1_5_0">
+      <Annotation Term="Redfish.OwningEntity" String="DMTF"/>
+      <Annotation Term="Redfish.Release" String="2020.3"/>
+      <Annotation Term="OData.Description" String="This version was created to add AddEndpoint and RemoveEndpoint actions.  It was also created to add `NoInternalRouting` to ExternalAccessibility."/>
+
+      <EntityType Name="Zone" BaseType="Zone.v1_4_2.Zone"/>
+    </Schema>
+
+    <Schema xmlns="http://docs.oasis-open.org/odata/ns/edm" Namespace="Zone.v1_5_1">
+      <Annotation Term="Redfish.OwningEntity" String="DMTF"/>
+      <Annotation Term="OData.Description" String="This version was created to correct various description to use proper normative terminology."/>
+      <EntityType Name="Zone" BaseType="Zone.v1_5_0.Zone"/>
+    </Schema>
+
+    <Schema xmlns="http://docs.oasis-open.org/odata/ns/edm" Namespace="Zone.v1_6_0">
+      <Annotation Term="Redfish.OwningEntity" String="DMTF"/>
+      <Annotation Term="Redfish.Release" String="2020.4"/>
+      <Annotation Term="OData.Description" String="This version was created to add `ZoneOfResourceBlocks` to ZoneType."/>
+
+      <EntityType Name="Zone" BaseType="Zone.v1_5_0.Zone"/>
+    </Schema>
+
+    <Schema xmlns="http://docs.oasis-open.org/odata/ns/edm" Namespace="Zone.v1_6_1">
+      <Annotation Term="Redfish.OwningEntity" String="DMTF"/>
+      <Annotation Term="OData.Description" String="This version was created to correct various description to use proper normative terminology."/>
+      <EntityType Name="Zone" BaseType="Zone.v1_6_0.Zone"/>
+    </Schema>
+
+  </edmx:DataServices>
+</edmx:Edmx>


### PR DESCRIPTION
This commit allows downstream eBMC to list out all the Redfish schemas for all pulls. 

change:
 remove `include_list` from scripts/update_schemas.py file, which builds schemas file for all schemas. 

Why:
So now all pulls have all the schemas.
That allows the user(dev) to run the validator offline and eliminate any network glitch, which is the Redfish recommended way.

This is a downstream commit only