### PR TITLE
Added SubordinateOverrides & Fix Log_services privileges

### DIFF
--- a/redfish-core/include/registries/privilege_registry.hpp
+++ b/redfish-core/include/registries/privilege_registry.hpp
@@ -181,6 +181,20 @@ const static auto& putCertificate = privilegeSetConfigureManager;
 const static auto& deleteCertificate = privilegeSetConfigureManager;
 const static auto& postCertificate = privilegeSetConfigureManager;
 
+// Subordinate override for ComputerSystem -> Certificate
+const static auto& getCertificateSubOverComputerSystem =
+    privilegeSetConfigureComponents;
+const static auto& headCertificateSubOverComputerSystem =
+    privilegeSetConfigureComponents;
+const static auto& patchCertificateSubOverComputerSystem =
+    privilegeSetConfigureComponents;
+const static auto& putCertificateSubOverComputerSystem =
+    privilegeSetConfigureComponents;
+const static auto& deleteCertificateSubOverComputerSystem =
+    privilegeSetConfigureComponents;
+const static auto& postCertificateSubOverComputerSystem =
+    privilegeSetConfigureComponents;
+
 // CertificateCollection
 const static auto& getCertificateCollection = privilegeSetConfigureManager;
 const static auto& headCertificateCollection = privilegeSetConfigureManager;
@@ -188,6 +202,20 @@ const static auto& patchCertificateCollection = privilegeSetConfigureManager;
 const static auto& putCertificateCollection = privilegeSetConfigureManager;
 const static auto& deleteCertificateCollection = privilegeSetConfigureManager;
 const static auto& postCertificateCollection = privilegeSetConfigureManager;
+
+// Subordinate override for ComputerSystem -> CertificateCollection
+const static auto& getCertificateCollectionSubOverComputerSystem =
+    privilegeSetConfigureComponents;
+const static auto& headCertificateCollectionSubOverComputerSystem =
+    privilegeSetConfigureComponents;
+const static auto& patchCertificateCollectionSubOverComputerSystem =
+    privilegeSetConfigureComponents;
+const static auto& putCertificateCollectionSubOverComputerSystem =
+    privilegeSetConfigureComponents;
+const static auto& deleteCertificateCollectionSubOverComputerSystem =
+    privilegeSetConfigureComponents;
+const static auto& postCertificateCollectionSubOverComputerSystem =
+    privilegeSetConfigureComponents;
 
 // CertificateLocations
 const static auto& getCertificateLocations = privilegeSetConfigureManager;
@@ -362,6 +390,31 @@ const static auto& deleteEthernetInterface = privilegeSetConfigureComponents;
 // Restrict the hypervisor ethernet interface PATCH to ConfigureManager
 const static auto& patchOEMHypervisorEthInterface =
     privilegeSetConfigureManager;
+
+// Subordinate override for Manager -> EthernetInterface
+const static auto& patchEthernetInterfaceSubOverManager =
+    privilegeSetConfigureManager;
+const static auto& postEthernetInterfaceSubOverManager =
+    privilegeSetConfigureManager;
+const static auto& putEthernetInterfaceSubOverManager =
+    privilegeSetConfigureManager;
+const static auto& deleteEthernetInterfaceSubOverManager =
+    privilegeSetConfigureManager;
+
+// Subordinate override for Manager -> EthernetInterfaceCollection ->
+// EthernetInterface
+const static auto&
+    patchEthernetInterfaceSubOverManagerEthernetInterfaceCollection =
+        privilegeSetConfigureManager;
+const static auto&
+    postEthernetInterfaceSubOverManagerEthernetInterfaceCollection =
+        privilegeSetConfigureManager;
+const static auto&
+    putEthernetInterfaceSubOverManagerEthernetInterfaceCollection =
+        privilegeSetConfigureManager;
+const static auto&
+    deleteEthernetInterfaceSubOverManagerEthernetInterfaceCollection =
+        privilegeSetConfigureManager;
 
 // EthernetInterfaceCollection
 const static auto& getEthernetInterfaceCollection = privilegeSetLogin;
@@ -543,6 +596,198 @@ const static auto& putLogEntry = privilegeSetConfigureManager;
 const static auto& deleteLogEntry = privilegeSetConfigureManager;
 const static auto& postLogEntry = privilegeSetConfigureManager;
 
+// Subordinate override for ComputerSystem -> LogEntry
+const static auto& patchLogEntrySubOverComputerSystem =
+    privilegeSetConfigureComponents;
+const static auto& putLogEntrySubOverComputerSystem =
+    privilegeSetConfigureComponents;
+const static auto& deleteLogEntrySubOverComputerSystem =
+    privilegeSetConfigureComponents;
+const static auto& postLogEntrySubOverComputerSystem =
+    privilegeSetConfigureComponents;
+
+// Subordinate override for ComputerSystem -> LogServiceCollection -> LogEntry
+const static auto& patchLogEntrySubOverComputerSystemLogServiceCollection =
+    privilegeSetConfigureComponents;
+const static auto& putLogEntrySubOverComputerSystemLogServiceCollection =
+    privilegeSetConfigureComponents;
+const static auto& deleteLogEntrySubOverComputerSystemLogServiceCollection =
+    privilegeSetConfigureComponents;
+const static auto& postLogEntrySubOverComputerSystemLogServiceCollection =
+    privilegeSetConfigureComponents;
+
+// Subordinate override for ComputerSystem -> LogService -> LogEntry
+const static auto& patchLogEntrySubOverComputerSystemLogService =
+    privilegeSetConfigureComponents;
+const static auto& putLogEntrySubOverComputerSystemLogService =
+    privilegeSetConfigureComponents;
+const static auto& deleteLogEntrySubOverComputerSystemLogService =
+    privilegeSetConfigureComponents;
+const static auto& postLogEntrySubOverComputerSystemLogService =
+    privilegeSetConfigureComponents;
+
+// Subordinate override for ComputerSystem -> LogEntryCollection -> LogEntry
+const static auto& patchLogEntrySubOverComputerSystemLogEntryCollection =
+    privilegeSetConfigureComponents;
+const static auto& putLogEntrySubOverComputerSystemLogEntryCollection =
+    privilegeSetConfigureComponents;
+const static auto& deleteLogEntrySubOverComputerSystemLogEntryCollection =
+    privilegeSetConfigureComponents;
+const static auto& postLogEntrySubOverComputerSystemLogEntryCollection =
+    privilegeSetConfigureComponents;
+
+// Subordinate override for ComputerSystem -> LogServiceCollection -> LogService
+// -> LogEntry
+const static auto&
+    patchLogEntrySubOverComputerSystemLogServiceCollectionLogService =
+        privilegeSetConfigureComponents;
+const static auto&
+    putLogEntrySubOverComputerSystemLogServiceCollectionLogService =
+        privilegeSetConfigureComponents;
+const static auto&
+    deleteLogEntrySubOverComputerSystemLogServiceCollectionLogService =
+        privilegeSetConfigureComponents;
+const static auto&
+    postLogEntrySubOverComputerSystemLogServiceCollectionLogService =
+        privilegeSetConfigureComponents;
+
+// Subordinate override for ComputerSystem -> LogServiceCollection ->
+// LogEntryCollection -> LogEntry
+const static auto&
+    patchLogEntrySubOverComputerSystemLogServiceCollectionLogEntryCollection =
+        privilegeSetConfigureComponents;
+const static auto&
+    putLogEntrySubOverComputerSystemLogServiceCollectionLogEntryCollection =
+        privilegeSetConfigureComponents;
+const static auto&
+    deleteLogEntrySubOverComputerSystemLogServiceCollectionLogEntryCollection =
+        privilegeSetConfigureComponents;
+const static auto&
+    postLogEntrySubOverComputerSystemLogServiceCollectionLogEntryCollection =
+        privilegeSetConfigureComponents;
+
+// Subordinate override for ComputerSystem -> LogServiceCollection -> LogService
+// -> LogEntryCollection -> LogEntry
+const static auto&
+    patchLogEntrySubOverComputerSystemLogServiceCollectionLogServiceLogEntryCollection =
+        privilegeSetConfigureComponents;
+const static auto&
+    putLogEntrySubOverComputerSystemLogServiceCollectionLogServiceLogEntryCollection =
+        privilegeSetConfigureComponents;
+const static auto&
+    deleteLogEntrySubOverComputerSystemLogServiceCollectionLogServiceLogEntryCollection =
+        privilegeSetConfigureComponents;
+const static auto&
+    postLogEntrySubOverComputerSystemLogServiceCollectionLogServiceLogEntryCollection =
+        privilegeSetConfigureComponents;
+
+// Subordinate override for Chassis -> LogEntry
+const static auto& getLogEntrySubOverChassis = privilegeSetLogin;
+const static auto& headLogEntrySubOverChassis = privilegeSetLogin;
+const static auto& patchLogEntrySubOverChassis =
+    privilegeSetConfigureComponents;
+const static auto& putLogEntrySubOverChassis = privilegeSetConfigureComponents;
+const static auto& deleteLogEntrySubOverChassis =
+    privilegeSetConfigureComponents;
+const static auto& postLogEntrySubOverChassis = privilegeSetConfigureComponents;
+
+// Subordinate override for Chassis -> LogServiceCollection -> LogEntry
+const static auto& getLogEntrySubOverChassisLogServiceCollection =
+    privilegeSetLogin;
+const static auto& headLogEntrySubOverChassisLogServiceCollection =
+    privilegeSetLogin;
+const static auto& patchLogEntrySubOverChassisLogServiceCollection =
+    privilegeSetConfigureComponents;
+const static auto& putLogEntrySubOverChassisLogServiceCollection =
+    privilegeSetConfigureComponents;
+const static auto& deleteLogEntrySubOverChassisLogServiceCollection =
+    privilegeSetConfigureComponents;
+const static auto& postLogEntrySubOverChassisLogServiceCollection =
+    privilegeSetConfigureComponents;
+
+// Subordinate override for Chassis -> LogService -> LogEntry
+const static auto& getLogEntrySubOverChassisLogService = privilegeSetLogin;
+const static auto& headLogEntrySubOverChassisLogService = privilegeSetLogin;
+const static auto& patchLogEntrySubOverChassisLogService =
+    privilegeSetConfigureComponents;
+const static auto& putLogEntrySubOverChassisLogService =
+    privilegeSetConfigureComponents;
+const static auto& deleteLogEntrySubOverChassisLogService =
+    privilegeSetConfigureComponents;
+const static auto& postLogEntrySubOverChassisLogService =
+    privilegeSetConfigureComponents;
+
+// Subordinate override for Chassis -> LogEntryCollection -> LogEntry
+const static auto& getLogEntrySubOverChassisLogEntryCollection =
+    privilegeSetLogin;
+const static auto& headLogEntrySubOverChassisLogEntryCollection =
+    privilegeSetLogin;
+const static auto& patchLogEntrySubOverChassisLogEntryCollection =
+    privilegeSetConfigureComponents;
+const static auto& putLogEntrySubOverChassisLogEntryCollection =
+    privilegeSetConfigureComponents;
+const static auto& deleteLogEntrySubOverChassisLogEntryCollection =
+    privilegeSetConfigureComponents;
+const static auto& postLogEntrySubOverChassisLogEntryCollection =
+    privilegeSetConfigureComponents;
+
+// Subordinate override for Chassis -> LogServiceCollection -> LogService ->
+// LogEntry
+const static auto& getLogEntrySubOverChassisLogServiceCollectionLogService =
+    privilegeSetLogin;
+const static auto& headLogEntrySubOverChassisLogServiceCollectionLogService =
+    privilegeSetLogin;
+const static auto& patchLogEntrySubOverChassisLogServiceCollectionLogService =
+    privilegeSetConfigureComponents;
+const static auto& putLogEntrySubOverChassisLogServiceCollectionLogService =
+    privilegeSetConfigureComponents;
+const static auto& deleteLogEntrySubOverChassisLogServiceCollectionLogService =
+    privilegeSetConfigureComponents;
+const static auto& postLogEntrySubOverChassisLogServiceCollectionLogService =
+    privilegeSetConfigureComponents;
+
+// Subordinate override for Chassis -> LogServiceCollection ->
+// LogEntryCollection -> LogEntry
+const static auto&
+    getLogEntrySubOverChassisLogServiceCollectionLogEntryCollection =
+        privilegeSetLogin;
+const static auto&
+    headLogEntrySubOverChassisLogServiceCollectionLogEntryCollection =
+        privilegeSetLogin;
+const static auto&
+    patchLogEntrySubOverChassisLogServiceCollectionLogEntryCollection =
+        privilegeSetConfigureComponents;
+const static auto&
+    putLogEntrySubOverChassisLogServiceCollectionLogEntryCollection =
+        privilegeSetConfigureComponents;
+const static auto&
+    deleteLogEntrySubOverChassisLogServiceCollectionLogEntryCollection =
+        privilegeSetConfigureComponents;
+const static auto&
+    postLogEntrySubOverChassisLogServiceCollectionLogEntryCollection =
+        privilegeSetConfigureComponents;
+
+// Subordinate override for Chassis -> LogServiceCollection -> LogService ->
+// LogEntryCollection -> LogEntry
+const static auto&
+    getLogEntrySubOverChassisLogServiceCollectionLogServiceLogEntryCollection =
+        privilegeSetLogin;
+const static auto&
+    headLogEntrySubOverChassisLogServiceCollectionLogServiceLogEntryCollection =
+        privilegeSetLogin;
+const static auto&
+    patchLogEntrySubOverChassisLogServiceCollectionLogServiceLogEntryCollection =
+        privilegeSetConfigureComponents;
+const static auto&
+    putLogEntrySubOverChassisLogServiceCollectionLogServiceLogEntryCollection =
+        privilegeSetConfigureComponents;
+const static auto&
+    deleteLogEntrySubOverChassisLogServiceCollectionLogServiceLogEntryCollection =
+        privilegeSetConfigureComponents;
+const static auto&
+    postLogEntrySubOverChassisLogServiceCollectionLogServiceLogEntryCollection =
+        privilegeSetConfigureComponents;
+
 // LogEntryCollection
 const static auto& getLogEntryCollection = privilegeSetLogin;
 const static auto& headLogEntryCollection = privilegeSetLogin;
@@ -550,6 +795,118 @@ const static auto& patchLogEntryCollection = privilegeSetConfigureManager;
 const static auto& putLogEntryCollection = privilegeSetConfigureManager;
 const static auto& deleteLogEntryCollection = privilegeSetConfigureManager;
 const static auto& postLogEntryCollection = privilegeSetConfigureManager;
+
+// Subordinate override for ComputerSystem -> LogEntryCollection
+const static auto& patchLogEntryCollectionSubOverComputerSystem =
+    privilegeSetConfigureComponents;
+const static auto& putLogEntryCollectionSubOverComputerSystem =
+    privilegeSetConfigureComponents;
+const static auto& deleteLogEntryCollectionSubOverComputerSystem =
+    privilegeSetConfigureComponents;
+const static auto& postLogEntryCollectionSubOverComputerSystem =
+    privilegeSetConfigureComponents;
+
+// Subordinate override for ComputerSystem -> LogServiceCollection ->
+// LogEntryCollection
+const static auto&
+    patchLogEntryCollectionSubOverComputerSystemLogServiceCollection =
+        privilegeSetConfigureComponents;
+const static auto&
+    putLogEntryCollectionSubOverComputerSystemLogServiceCollection =
+        privilegeSetConfigureComponents;
+const static auto&
+    deleteLogEntryCollectionSubOverComputerSystemLogServiceCollection =
+        privilegeSetConfigureComponents;
+const static auto&
+    postLogEntryCollectionSubOverComputerSystemLogServiceCollection =
+        privilegeSetConfigureComponents;
+
+// Subordinate override for ComputerSystem -> LogService -> LogEntryCollection
+const static auto& patchLogEntryCollectionSubOverComputerSystemLogService =
+    privilegeSetConfigureComponents;
+const static auto& putLogEntryCollectionSubOverComputerSystemLogService =
+    privilegeSetConfigureComponents;
+const static auto& deleteLogEntryCollectionSubOverComputerSystemLogService =
+    privilegeSetConfigureComponents;
+const static auto& postLogEntryCollectionSubOverComputerSystemLogService =
+    privilegeSetConfigureComponents;
+
+// Subordinate override for ComputerSystem -> LogServiceCollection -> LogService
+// -> LogEntryCollection
+const static auto&
+    patchLogEntryCollectionSubOverComputerSystemLogServiceCollectionLogService =
+        privilegeSetConfigureComponents;
+const static auto&
+    putLogEntryCollectionSubOverComputerSystemLogServiceCollectionLogService =
+        privilegeSetConfigureComponents;
+const static auto&
+    deleteLogEntryCollectionSubOverComputerSystemLogServiceCollectionLogService =
+        privilegeSetConfigureComponents;
+const static auto&
+    postLogEntryCollectionSubOverComputerSystemLogServiceCollectionLogService =
+        privilegeSetConfigureComponents;
+
+// Subordinate override for Chassis -> LogEntryCollection
+const static auto& getLogEntryCollectionSubOverChassis = privilegeSetLogin;
+const static auto& headLogEntryCollectionSubOverChassis = privilegeSetLogin;
+const static auto& patchLogEntryCollectionSubOverChassis =
+    privilegeSetConfigureComponents;
+const static auto& putLogEntryCollectionSubOverChassis =
+    privilegeSetConfigureComponents;
+const static auto& deleteLogEntryCollectionSubOverChassis =
+    privilegeSetConfigureComponents;
+const static auto& postLogEntryCollectionSubOverChassis =
+    privilegeSetConfigureComponents;
+
+// Subordinate override for Chassis -> LogServiceCollection ->
+// LogEntryCollection
+const static auto& getLogEntryCollectionSubOverChassisLogServiceCollection =
+    privilegeSetLogin;
+const static auto& headLogEntryCollectionSubOverChassisLogServiceCollection =
+    privilegeSetLogin;
+const static auto& patchLogEntryCollectionSubOverChassisLogServiceCollection =
+    privilegeSetConfigureComponents;
+const static auto& putLogEntryCollectionSubOverChassisLogServiceCollection =
+    privilegeSetConfigureComponents;
+const static auto& deleteLogEntryCollectionSubOverChassisLogServiceCollection =
+    privilegeSetConfigureComponents;
+const static auto& postLogEntryCollectionSubOverChassisLogServiceCollection =
+    privilegeSetConfigureComponents;
+
+// Subordinate override for Chassis -> LogService -> LogEntryCollection
+const static auto& getLogEntryCollectionSubOverChassisLogService =
+    privilegeSetLogin;
+const static auto& headLogEntryCollectionSubOverChassisLogService =
+    privilegeSetLogin;
+const static auto& patchLogEntryCollectionSubOverChassisLogService =
+    privilegeSetConfigureComponents;
+const static auto& putLogEntryCollectionSubOverChassisLogService =
+    privilegeSetConfigureComponents;
+const static auto& deleteLogEntryCollectionSubOverChassisLogService =
+    privilegeSetConfigureComponents;
+const static auto& postLogEntryCollectionSubOverChassisLogService =
+    privilegeSetConfigureComponents;
+
+// Subordinate override for Chassis -> LogServiceCollection -> LogService ->
+// LogEntryCollection
+const static auto&
+    getLogEntryCollectionSubOverChassisLogServiceCollectionLogService =
+        privilegeSetLogin;
+const static auto&
+    headLogEntryCollectionSubOverChassisLogServiceCollectionLogService =
+        privilegeSetLogin;
+const static auto&
+    patchLogEntryCollectionSubOverChassisLogServiceCollectionLogService =
+        privilegeSetConfigureComponents;
+const static auto&
+    putLogEntryCollectionSubOverChassisLogServiceCollectionLogService =
+        privilegeSetConfigureComponents;
+const static auto&
+    deleteLogEntryCollectionSubOverChassisLogServiceCollectionLogService =
+        privilegeSetConfigureComponents;
+const static auto&
+    postLogEntryCollectionSubOverChassisLogServiceCollectionLogService =
+        privilegeSetConfigureComponents;
 
 // LogService
 const static auto& getLogService = privilegeSetLogin;
@@ -559,6 +916,52 @@ const static auto& putLogService = privilegeSetConfigureManager;
 const static auto& deleteLogService = privilegeSetConfigureManager;
 const static auto& postLogService = privilegeSetConfigureManager;
 
+// Subordinate override for ComputerSystem -> LogService
+const static auto& patchLogServiceSubOverComputerSystem =
+    privilegeSetConfigureComponents;
+const static auto& postLogServiceSubOverComputerSystem =
+    privilegeSetConfigureComponents;
+const static auto& putLogServiceSubOverComputerSystem =
+    privilegeSetConfigureComponents;
+const static auto& deleteLogServiceSubOverComputerSystem =
+    privilegeSetConfigureComponents;
+
+// Subordinate override for ComputerSystem -> LogServiceCollection -> LogService
+const static auto& patchLogServiceSubOverComputerSystemLogServiceCollection =
+    privilegeSetConfigureComponents;
+const static auto& postLogServiceSubOverComputerSystemLogServiceCollection =
+    privilegeSetConfigureComponents;
+const static auto& putLogServiceSubOverComputerSystemLogServiceCollection =
+    privilegeSetConfigureComponents;
+const static auto& deleteLogServiceSubOverComputerSystemLogServiceCollection =
+    privilegeSetConfigureComponents;
+
+// Subordinate override for Chassis -> LogService
+const static auto& getLogServiceSubOverChassis = privilegeSetLogin;
+const static auto& headLogServiceSubOverChassis = privilegeSetLogin;
+const static auto& patchLogServiceSubOverChassis =
+    privilegeSetConfigureComponents;
+const static auto& putLogServiceSubOverChassis =
+    privilegeSetConfigureComponents;
+const static auto& deleteLogServiceSubOverChassis =
+    privilegeSetConfigureComponents;
+const static auto& postLogServiceSubOverChassis =
+    privilegeSetConfigureComponents;
+
+// Subordinate override for Chassis -> LogServiceCollection -> LogService
+const static auto& getLogServiceSubOverChassisLogServiceCollection =
+    privilegeSetLogin;
+const static auto& headLogServiceSubOverChassisLogServiceCollection =
+    privilegeSetLogin;
+const static auto& patchLogServiceSubOverChassisLogServiceCollection =
+    privilegeSetConfigureComponents;
+const static auto& putLogServiceSubOverChassisLogServiceCollection =
+    privilegeSetConfigureComponents;
+const static auto& deleteLogServiceSubOverChassisLogServiceCollection =
+    privilegeSetConfigureComponents;
+const static auto& postLogServiceSubOverChassisLogServiceCollection =
+    privilegeSetConfigureComponents;
+
 // LogServiceCollection
 const static auto& getLogServiceCollection = privilegeSetLogin;
 const static auto& headLogServiceCollection = privilegeSetLogin;
@@ -566,6 +969,28 @@ const static auto& patchLogServiceCollection = privilegeSetConfigureManager;
 const static auto& putLogServiceCollection = privilegeSetConfigureManager;
 const static auto& deleteLogServiceCollection = privilegeSetConfigureManager;
 const static auto& postLogServiceCollection = privilegeSetConfigureManager;
+
+// Subordinate override for ComputerSystem -> LogServiceCollection
+const static auto& patchLogServiceCollectionSubOverComputerSystem =
+    privilegeSetConfigureComponents;
+const static auto& putLogServiceCollectionSubOverComputerSystem =
+    privilegeSetConfigureComponents;
+const static auto& deleteLogServiceCollectionSubOverComputerSystem =
+    privilegeSetConfigureComponents;
+const static auto& postLogServiceCollectionSubOverComputerSystem =
+    privilegeSetConfigureComponents;
+
+// Subordinate override for Chassis -> LogServiceCollection
+const static auto& getLogServiceCollectionSubOverChassis = privilegeSetLogin;
+const static auto& headLogServiceCollectionSubOverChassis = privilegeSetLogin;
+const static auto& patchLogServiceCollectionSubOverChassis =
+    privilegeSetConfigureComponents;
+const static auto& putLogServiceCollectionSubOverChassis =
+    privilegeSetConfigureComponents;
+const static auto& deleteLogServiceCollectionSubOverChassis =
+    privilegeSetConfigureComponents;
+const static auto& postLogServiceCollectionSubOverChassis =
+    privilegeSetConfigureComponents;
 
 // Manager
 const static auto& getManager = privilegeSetLogin;

--- a/redfish-core/lib/ethernet.hpp
+++ b/redfish-core/lib/ethernet.hpp
@@ -1919,7 +1919,9 @@ inline void requestEthernetInterfacesRoutes(App& app)
             });
 
     BMCWEB_ROUTE(app, "/redfish/v1/Managers/bmc/EthernetInterfaces/<str>/")
-        .privileges(redfish::privileges::patchEthernetInterface)
+        .privileges(
+            redfish::privileges::
+                patchEthernetInterfaceSubOverManagerEthernetInterfaceCollection)
 
         .methods(boost::beast::http::verb::patch)(
             [](const crow::Request& req,
@@ -2113,9 +2115,7 @@ inline void requestEthernetInterfacesRoutes(App& app)
 
     BMCWEB_ROUTE(
         app, "/redfish/v1/Managers/bmc/EthernetInterfaces/<str>/VLANs/<str>/")
-        // This privilege is incorrect, it should be ConfigureManager
-        //.privileges(redfish::privileges::patchVLanNetworkInterface)
-        .privileges({{"ConfigureComponents"}})
+        .privileges(redfish::privileges::patchVLanNetworkInterface)
         .methods(boost::beast::http::verb::patch)(
             [](const crow::Request& req,
                const std::shared_ptr<bmcweb::AsyncResp>& asyncResp,
@@ -2195,9 +2195,7 @@ inline void requestEthernetInterfacesRoutes(App& app)
 
     BMCWEB_ROUTE(
         app, "/redfish/v1/Managers/bmc/EthernetInterfaces/<str>/VLANs/<str>/")
-        // This privilege is incorrect, it should be ConfigureManager
-        //.privileges(redfish::privileges::deleteVLanNetworkInterface)
-        .privileges({{"ConfigureComponents"}})
+        .privileges(redfish::privileges::deleteVLanNetworkInterface)
         .methods(boost::beast::http::verb::delete_)(
             [](const crow::Request& /* req */,
                const std::shared_ptr<bmcweb::AsyncResp>& asyncResp,
@@ -2308,9 +2306,7 @@ inline void requestEthernetInterfacesRoutes(App& app)
 
     BMCWEB_ROUTE(app,
                  "/redfish/v1/Managers/bmc/EthernetInterfaces/<str>/VLANs/")
-        // This privilege is wrong, it should be ConfigureManager
-        //.privileges(redfish::privileges::postVLanNetworkInterfaceCollection)
-        .privileges({{"ConfigureComponents"}})
+        .privileges(redfish::privileges::postVLanNetworkInterfaceCollection)
         .methods(boost::beast::http::verb::post)(
             [](const crow::Request& req,
                const std::shared_ptr<bmcweb::AsyncResp>& asyncResp,

--- a/redfish-core/lib/log_services.hpp
+++ b/redfish-core/lib/log_services.hpp
@@ -1222,7 +1222,8 @@ inline void requestRoutesJournalEventLogClear(App& app)
 {
     BMCWEB_ROUTE(app, "/redfish/v1/Systems/system/LogServices/EventLog/Actions/"
                       "LogService.ClearLog/")
-        .privileges({{"ConfigureComponents"}})
+        .privileges(redfish::privileges::
+                        postLogServiceSubOverComputerSystemLogServiceCollection)
         .methods(boost::beast::http::verb::post)(
             [](const crow::Request&,
                const std::shared_ptr<bmcweb::AsyncResp>& asyncResp) {
@@ -2617,9 +2618,7 @@ inline void requestRoutesCrashdumpService(App& app)
      * Functions triggers appropriate requests on DBus
      */
     BMCWEB_ROUTE(app, "/redfish/v1/Systems/system/LogServices/Crashdump/")
-        // This is incorrect, should be:
-        //.privileges(redfish::privileges::getLogService)
-        .privileges({{"ConfigureManager"}})
+        .privileges(redfish::privileges::getLogService)
         .methods(
             boost::beast::http::verb::
                 get)([](const crow::Request&,
@@ -2660,9 +2659,8 @@ void inline requestRoutesCrashdumpClear(App& app)
     BMCWEB_ROUTE(app,
                  "/redfish/v1/Systems/system/LogServices/Crashdump/Actions/"
                  "LogService.ClearLog/")
-        // This is incorrect, should be:
-        //.privileges(redfish::privileges::postLogService)
-        .privileges({{"ConfigureComponents"}})
+        .privileges(redfish::privileges::
+                        postLogServiceSubOverComputerSystemLogServiceCollection)
         .methods(boost::beast::http::verb::post)(
             [](const crow::Request&,
                const std::shared_ptr<bmcweb::AsyncResp>& asyncResp) {
@@ -2746,9 +2744,7 @@ inline void requestRoutesCrashdumpEntryCollection(App& app)
      */
     BMCWEB_ROUTE(app,
                  "/redfish/v1/Systems/system/LogServices/Crashdump/Entries/")
-        // This is incorrect, should be.
-        //.privileges(redfish::privileges::postLogEntryCollection)
-        .privileges({{"ConfigureComponents"}})
+        .privileges(redfish::privileges::getLogEntryCollection)
         .methods(
             boost::beast::http::verb::
                 get)([](const crow::Request&,
@@ -2822,9 +2818,7 @@ inline void requestRoutesCrashdumpEntry(App& app)
 
     BMCWEB_ROUTE(
         app, "/redfish/v1/Systems/system/LogServices/Crashdump/Entries/<str>/")
-        // this is incorrect, should be
-        // .privileges(redfish::privileges::getLogEntry)
-        .privileges({{"ConfigureComponents"}})
+        .privileges(redfish::privileges::getLogEntry)
         .methods(boost::beast::http::verb::get)(
             [](const crow::Request&,
                const std::shared_ptr<bmcweb::AsyncResp>& asyncResp,
@@ -2928,9 +2922,8 @@ inline void requestRoutesCrashdumpCollect(App& app)
     // method for security reasons.
     BMCWEB_ROUTE(app, "/redfish/v1/Systems/system/LogServices/Crashdump/"
                       "Actions/LogService.CollectDiagnosticData/")
-        // The below is incorrect;  Should be ConfigureManager
-        //.privileges(redfish::privileges::postLogService)
-        .privileges({{"ConfigureComponents"}})
+        .privileges(redfish::privileges::
+                        postLogServiceSubOverComputerSystemLogServiceCollection)
         .methods(
             boost::beast::http::verb::
                 post)([](const crow::Request& req,
@@ -3115,9 +3108,8 @@ inline void requestRoutesPostCodesClear(App& app)
     BMCWEB_ROUTE(app,
                  "/redfish/v1/Systems/system/LogServices/PostCodes/Actions/"
                  "LogService.ClearLog/")
-        // The following privilege is incorrect;  It should be ConfigureManager
-        //.privileges(redfish::privileges::postLogService)
-        .privileges({{"ConfigureComponents"}})
+        .privileges(redfish::privileges::
+                        postLogServiceSubOverComputerSystemLogServiceCollection)
         .methods(boost::beast::http::verb::post)(
             [](const crow::Request&,
                const std::shared_ptr<bmcweb::AsyncResp>& asyncResp) {

--- a/scripts/parse_registries.py
+++ b/scripts/parse_registries.py
@@ -140,6 +140,27 @@ def get_variable_name_for_privilege_set(privilege_list):
     return "Or".join(names)
 
 
+def create_Subordinate_Overrides(target_list):
+    target_list_create = []
+    target_list_copy = target_list.copy()
+    target_list_create.append([target_list[0]])
+    targetLength = len(target_list)
+    for i in range(targetLength):
+        # remove firs element
+        # it already get covered
+        target_list_copy.pop(0)
+        target_temp = []
+        for j in range(i + 1):
+            if not (j > 0 and j == (targetLength - 1)):
+                target_temp.append(target_list[j])
+        if target_list_copy:
+            for target_end in target_list_copy:
+                target_temp_copy = target_temp.copy()
+                target_temp_copy.append(target_end)
+                target_list_create.append(target_temp_copy)
+    return target_list_create
+
+
 def make_privilege_registry():
     path, json_file, type_name, url = \
         make_getter('Redfish_1.1.0_PrivilegeRegistry.json',
@@ -185,6 +206,31 @@ def make_privilege_registry():
                         entity,
                         privilege_dict[privilege_string][1]))
             registry.write("\n")
+            if 'SubordinateOverrides' in mapping:
+                for subordinateOverrides in mapping["SubordinateOverrides"]:
+                    target_list_list = create_Subordinate_Overrides(
+                        subordinateOverrides["Targets"])
+                    for target_list in target_list_list:
+                        concateVarName = ""
+                        registry.write("// Subordinate override for ")
+                        for target in target_list:
+                            registry.write(target + " -> ")
+                            concateVarName += target
+                        registry.write(entity)
+                        registry.write("\n")
+                        for operation, privilege_list in subordinateOverrides[
+                                                    "OperationMap"].items():
+                            privilege_string = get_privilege_string_from_list(
+                                privilege_list)
+                            operation = operation.lower()
+                            registry.write("const static auto& {}{}SubOver{} ="
+                                           "privilegeSet{};\n"
+                                           .format(operation, entity,
+                                                   concateVarName,
+                                                   privilege_dict[
+                                                       privilege_string][1]))
+                        registry.write("\n")
+                registry.write("\n")
         registry.write("} // namespace redfish::privileges\n")
     clang_format(path)
 


### PR DESCRIPTION
SubordinateOverrides:
  This commit attempts to automate the creation of SubordinateOverrides
  privileges structures from the redfish privilege registry. In
  addition, it enhances the function of parse_registries.py.

  It read SubordinateOverrides privilege registry from DMTF and
  generates const defines SubordinateOverrides for all the privilege
  registry entries in the same format that the Privileges struct
  accepts.

  Moreover, it generates unique const defines for all
  SubordinateOverrides target levels.
  Ex: EthernetInterface SubordinateOverrides has two "Targets":
      ["Manager", "EthernetInterfaceCollection"]. So
      parse_registries.py generates two unique const

      1) Subordinate override for Manager -> EthernetInterface
      2) Subordinate override for Manager ->
         EthernetInterfaceCollection ->  EthernetInterface

  Note: if SubordinateOverrides privilege gets changed, then it
  automatically updates that route privilege, but if
  SubordinateOverrides target gets change, then the user needs to
  update that manually.

Fix Log_services privileges:
  In Log_services, some of the privileges not following the
  Redfish_1.1.0_PrivilegeRegistry registry.

  privilege Change this commit contains
  Get method:
    1) /redfish/v1/Systems/system/LogServices/Crashdump/
        ConfigureManager -> Login

    2)/redfish/v1/Systems/system/LogServices/Crashdump/Entries/
         ConfigureManager -> Login

    3) /redfish/v1/Systems/system/LogServices/Crashdump/Entries/<str>/
        ConfigureComponents -> Login

    Impact: ConfigureManager -> Login    and
          ConfigureComponents -> Login

    This change allows Admin, Operator, and Readonly users to access
    Crashdump data and related entries.

Tested: manually tested on Witherspoon system, there is no change in
        output. Run Redfish validator, with all different Privileges;
        Error Get: UUID: String '' does not match pattern ''
        this commit doesn't affect UUID

Email sent to openbmc list:
https://lists.ozlabs.org/pipermail/openbmc/2021-August/027232.html

Signed-off-by: Abhishek Patel <Abhishek.Patel@ibm.com>
Change-Id: I37d8a2882f1cfaa59a482083f180fdd0805e2e7d