### PR TITLE
Fix certificate_service privileges

### DIFF
--- a/redfish-core/lib/certificate_service.hpp
+++ b/redfish-core/lib/certificate_service.hpp
@@ -237,9 +237,7 @@ inline void requestRoutesCertificateActionGenerateCSR(App& app)
 {
     BMCWEB_ROUTE(app, "/redfish/v1/CertificateService/Actions/"
                       "CertificateService.GenerateCSR/")
-        // Incorrect Privilege;  Should be ConfigureManager
-        //.privileges(redfish::privileges::postCertificateService)
-        .privileges({{"ConfigureComponents"}})
+        .privileges(redfish::privileges::postCertificateService)
         .methods(boost::beast::http::verb::post)(
             [](const crow::Request& req,
                const std::shared_ptr<bmcweb::AsyncResp>& asyncResp) {


### PR DESCRIPTION
  Post method:
    1) /redfish/v1/CertificateService/Actions/
          CertificateService.GenerateCSR/
        ConfigureComponents-> ConfigureManager

    This change allows only Admin users to Generate CSR Certificate and
    restrict Operator user.

Tested: Ran curl Post requests with Admin and Operator privileged users
        Get output as expected.

Email sent to openbmc list:
https://lists.ozlabs.org/pipermail/openbmc/2021-August/027232.html

Signed-off-by: Abhishek Patel <Abhishek.Patel@ibm.com>
Change-Id: I46d505357cfc55a31911e75e8bd9948a0db90555