### PR TITLE
Move to 2021.2

### DIFF
--- a/scripts/update_schemas.py
+++ b/scripts/update_schemas.py
@@ -9,7 +9,7 @@ import json
 
 import xml.etree.ElementTree as ET
 
-VERSION = "DSP8010_2021.1"
+VERSION = "DSP8010_2021.2"
 
 # To use a new schema, add to list and rerun tool
 include_list = [
@@ -161,9 +161,9 @@ with open(metadata_index_path, 'w') as metadata_index:
         " Version=\"4.0\">\n")
 
     for zip_filepath in zip_ref.namelist():
-        if zip_filepath.startswith(VERSION + '/csdl/') and \
+        if zip_filepath.startswith(VERSION + '/' + VERSION + '/csdl/') and \
             (zip_filepath != VERSION + "/csdl/") and \
-                (zip_filepath != VERSION + "/csdl/"):
+                (zip_filepath != VERSION + '/' + VERSION + "/csdl/"):
             filename = os.path.basename(zip_filepath)
 
             # filename looks like Zone_v1.xml
@@ -260,7 +260,7 @@ with open(metadata_index_path, 'w') as metadata_index:
 
 schema_files = {}
 for zip_filepath in zip_ref.namelist():
-    if zip_filepath.startswith(os.path.join(VERSION, 'json-schema/')):
+    if zip_filepath.startswith(os.path.join(VERSION, VERSION, 'json-schema/')):
         filename = os.path.basename(zip_filepath)
         filenamesplit = filename.split(".")
 
@@ -281,7 +281,7 @@ for zip_filepath in zip_ref.namelist():
 
 for schema, version in schema_files.items():
     basename = schema + "." + version + ".json"
-    zip_filepath = os.path.join(VERSION, "json-schema", basename)
+    zip_filepath = os.path.join(VERSION, VERSION, "json-schema", basename)
     schemadir = os.path.join(json_schema_path, schema)
     os.makedirs(schemadir)
     location_json = OrderedDict()

--- a/static/redfish/v1/$metadata/index.xml
+++ b/static/redfish/v1/$metadata/index.xml
@@ -14,6 +14,7 @@
         <edmx:Include Namespace="AccountService.v1_0_10"/>
         <edmx:Include Namespace="AccountService.v1_0_11"/>
         <edmx:Include Namespace="AccountService.v1_0_12"/>
+        <edmx:Include Namespace="AccountService.v1_0_13"/>
         <edmx:Include Namespace="AccountService.v1_1_0"/>
         <edmx:Include Namespace="AccountService.v1_1_1"/>
         <edmx:Include Namespace="AccountService.v1_1_2"/>
@@ -24,6 +25,7 @@
         <edmx:Include Namespace="AccountService.v1_1_7"/>
         <edmx:Include Namespace="AccountService.v1_1_8"/>
         <edmx:Include Namespace="AccountService.v1_1_9"/>
+        <edmx:Include Namespace="AccountService.v1_1_10"/>
         <edmx:Include Namespace="AccountService.v1_2_0"/>
         <edmx:Include Namespace="AccountService.v1_2_1"/>
         <edmx:Include Namespace="AccountService.v1_2_2"/>
@@ -34,6 +36,7 @@
         <edmx:Include Namespace="AccountService.v1_2_7"/>
         <edmx:Include Namespace="AccountService.v1_2_8"/>
         <edmx:Include Namespace="AccountService.v1_2_9"/>
+        <edmx:Include Namespace="AccountService.v1_2_10"/>
         <edmx:Include Namespace="AccountService.v1_3_0"/>
         <edmx:Include Namespace="AccountService.v1_3_1"/>
         <edmx:Include Namespace="AccountService.v1_3_2"/>
@@ -43,6 +46,7 @@
         <edmx:Include Namespace="AccountService.v1_3_6"/>
         <edmx:Include Namespace="AccountService.v1_3_7"/>
         <edmx:Include Namespace="AccountService.v1_3_8"/>
+        <edmx:Include Namespace="AccountService.v1_3_9"/>
         <edmx:Include Namespace="AccountService.v1_4_0"/>
         <edmx:Include Namespace="AccountService.v1_4_1"/>
         <edmx:Include Namespace="AccountService.v1_4_2"/>
@@ -50,25 +54,32 @@
         <edmx:Include Namespace="AccountService.v1_4_4"/>
         <edmx:Include Namespace="AccountService.v1_4_5"/>
         <edmx:Include Namespace="AccountService.v1_4_6"/>
+        <edmx:Include Namespace="AccountService.v1_4_7"/>
         <edmx:Include Namespace="AccountService.v1_5_0"/>
         <edmx:Include Namespace="AccountService.v1_5_1"/>
         <edmx:Include Namespace="AccountService.v1_5_2"/>
         <edmx:Include Namespace="AccountService.v1_5_3"/>
         <edmx:Include Namespace="AccountService.v1_5_4"/>
         <edmx:Include Namespace="AccountService.v1_5_5"/>
+        <edmx:Include Namespace="AccountService.v1_5_6"/>
         <edmx:Include Namespace="AccountService.v1_6_0"/>
         <edmx:Include Namespace="AccountService.v1_6_1"/>
         <edmx:Include Namespace="AccountService.v1_6_2"/>
         <edmx:Include Namespace="AccountService.v1_6_3"/>
         <edmx:Include Namespace="AccountService.v1_6_4"/>
+        <edmx:Include Namespace="AccountService.v1_6_5"/>
         <edmx:Include Namespace="AccountService.v1_7_0"/>
         <edmx:Include Namespace="AccountService.v1_7_1"/>
         <edmx:Include Namespace="AccountService.v1_7_2"/>
         <edmx:Include Namespace="AccountService.v1_7_3"/>
         <edmx:Include Namespace="AccountService.v1_7_4"/>
+        <edmx:Include Namespace="AccountService.v1_7_5"/>
         <edmx:Include Namespace="AccountService.v1_8_0"/>
         <edmx:Include Namespace="AccountService.v1_8_1"/>
+        <edmx:Include Namespace="AccountService.v1_8_2"/>
         <edmx:Include Namespace="AccountService.v1_9_0"/>
+        <edmx:Include Namespace="AccountService.v1_9_1"/>
+        <edmx:Include Namespace="AccountService.v1_10_0"/>
     </edmx:Reference>
     <edmx:Reference Uri="/redfish/v1/schema/ActionInfo_v1.xml">
         <edmx:Include Namespace="ActionInfo"/>
@@ -79,9 +90,12 @@
         <edmx:Include Namespace="ActionInfo.v1_0_4"/>
         <edmx:Include Namespace="ActionInfo.v1_0_5"/>
         <edmx:Include Namespace="ActionInfo.v1_0_6"/>
+        <edmx:Include Namespace="ActionInfo.v1_0_7"/>
         <edmx:Include Namespace="ActionInfo.v1_1_0"/>
         <edmx:Include Namespace="ActionInfo.v1_1_1"/>
         <edmx:Include Namespace="ActionInfo.v1_1_2"/>
+        <edmx:Include Namespace="ActionInfo.v1_1_3"/>
+        <edmx:Include Namespace="ActionInfo.v1_2_0"/>
     </edmx:Reference>
     <edmx:Reference Uri="/redfish/v1/schema/Assembly_v1.xml">
         <edmx:Include Namespace="Assembly"/>
@@ -176,6 +190,7 @@
         <edmx:Include Namespace="Certificate.v1_2_2"/>
         <edmx:Include Namespace="Certificate.v1_2_3"/>
         <edmx:Include Namespace="Certificate.v1_3_0"/>
+        <edmx:Include Namespace="Certificate.v1_4_0"/>
     </edmx:Reference>
     <edmx:Reference Uri="/redfish/v1/schema/CertificateCollection_v1.xml">
         <edmx:Include Namespace="CertificateCollection"/>
@@ -329,6 +344,7 @@
         <edmx:Include Namespace="Chassis.v1_15_0"/>
         <edmx:Include Namespace="Chassis.v1_15_1"/>
         <edmx:Include Namespace="Chassis.v1_16_0"/>
+        <edmx:Include Namespace="Chassis.v1_17_0"/>
     </edmx:Reference>
     <edmx:Reference Uri="/redfish/v1/schema/ChassisCollection_v1.xml">
         <edmx:Include Namespace="ChassisCollection"/>
@@ -474,6 +490,7 @@
         <edmx:Include Namespace="ComputerSystem.v1_14_0"/>
         <edmx:Include Namespace="ComputerSystem.v1_14_1"/>
         <edmx:Include Namespace="ComputerSystem.v1_15_0"/>
+        <edmx:Include Namespace="ComputerSystem.v1_16_0"/>
     </edmx:Reference>
     <edmx:Reference Uri="/redfish/v1/schema/ComputerSystemCollection_v1.xml">
         <edmx:Include Namespace="ComputerSystemCollection"/>
@@ -493,6 +510,7 @@
         <edmx:Include Namespace="Drive.v1_0_10"/>
         <edmx:Include Namespace="Drive.v1_0_11"/>
         <edmx:Include Namespace="Drive.v1_0_12"/>
+        <edmx:Include Namespace="Drive.v1_0_13"/>
         <edmx:Include Namespace="Drive.v1_1_0"/>
         <edmx:Include Namespace="Drive.v1_1_1"/>
         <edmx:Include Namespace="Drive.v1_1_2"/>
@@ -505,6 +523,7 @@
         <edmx:Include Namespace="Drive.v1_1_9"/>
         <edmx:Include Namespace="Drive.v1_1_10"/>
         <edmx:Include Namespace="Drive.v1_1_11"/>
+        <edmx:Include Namespace="Drive.v1_1_12"/>
         <edmx:Include Namespace="Drive.v1_2_0"/>
         <edmx:Include Namespace="Drive.v1_2_1"/>
         <edmx:Include Namespace="Drive.v1_2_2"/>
@@ -515,6 +534,7 @@
         <edmx:Include Namespace="Drive.v1_2_7"/>
         <edmx:Include Namespace="Drive.v1_2_8"/>
         <edmx:Include Namespace="Drive.v1_2_9"/>
+        <edmx:Include Namespace="Drive.v1_2_10"/>
         <edmx:Include Namespace="Drive.v1_3_0"/>
         <edmx:Include Namespace="Drive.v1_3_1"/>
         <edmx:Include Namespace="Drive.v1_3_2"/>
@@ -524,6 +544,7 @@
         <edmx:Include Namespace="Drive.v1_3_6"/>
         <edmx:Include Namespace="Drive.v1_3_7"/>
         <edmx:Include Namespace="Drive.v1_3_8"/>
+        <edmx:Include Namespace="Drive.v1_3_9"/>
         <edmx:Include Namespace="Drive.v1_4_0"/>
         <edmx:Include Namespace="Drive.v1_4_1"/>
         <edmx:Include Namespace="Drive.v1_4_2"/>
@@ -533,6 +554,7 @@
         <edmx:Include Namespace="Drive.v1_4_6"/>
         <edmx:Include Namespace="Drive.v1_4_7"/>
         <edmx:Include Namespace="Drive.v1_4_8"/>
+        <edmx:Include Namespace="Drive.v1_4_9"/>
         <edmx:Include Namespace="Drive.v1_5_0"/>
         <edmx:Include Namespace="Drive.v1_5_1"/>
         <edmx:Include Namespace="Drive.v1_5_2"/>
@@ -541,35 +563,44 @@
         <edmx:Include Namespace="Drive.v1_5_5"/>
         <edmx:Include Namespace="Drive.v1_5_6"/>
         <edmx:Include Namespace="Drive.v1_5_7"/>
+        <edmx:Include Namespace="Drive.v1_5_8"/>
         <edmx:Include Namespace="Drive.v1_6_0"/>
         <edmx:Include Namespace="Drive.v1_6_1"/>
         <edmx:Include Namespace="Drive.v1_6_2"/>
         <edmx:Include Namespace="Drive.v1_6_3"/>
         <edmx:Include Namespace="Drive.v1_6_4"/>
         <edmx:Include Namespace="Drive.v1_6_5"/>
+        <edmx:Include Namespace="Drive.v1_6_6"/>
         <edmx:Include Namespace="Drive.v1_7_0"/>
         <edmx:Include Namespace="Drive.v1_7_1"/>
         <edmx:Include Namespace="Drive.v1_7_2"/>
         <edmx:Include Namespace="Drive.v1_7_3"/>
         <edmx:Include Namespace="Drive.v1_7_4"/>
+        <edmx:Include Namespace="Drive.v1_7_5"/>
         <edmx:Include Namespace="Drive.v1_8_0"/>
         <edmx:Include Namespace="Drive.v1_8_1"/>
         <edmx:Include Namespace="Drive.v1_8_2"/>
         <edmx:Include Namespace="Drive.v1_8_3"/>
         <edmx:Include Namespace="Drive.v1_8_4"/>
+        <edmx:Include Namespace="Drive.v1_8_5"/>
         <edmx:Include Namespace="Drive.v1_9_0"/>
         <edmx:Include Namespace="Drive.v1_9_1"/>
         <edmx:Include Namespace="Drive.v1_9_2"/>
         <edmx:Include Namespace="Drive.v1_9_3"/>
         <edmx:Include Namespace="Drive.v1_9_4"/>
+        <edmx:Include Namespace="Drive.v1_9_5"/>
         <edmx:Include Namespace="Drive.v1_10_0"/>
         <edmx:Include Namespace="Drive.v1_10_1"/>
         <edmx:Include Namespace="Drive.v1_10_2"/>
+        <edmx:Include Namespace="Drive.v1_10_3"/>
         <edmx:Include Namespace="Drive.v1_11_0"/>
         <edmx:Include Namespace="Drive.v1_11_1"/>
         <edmx:Include Namespace="Drive.v1_11_2"/>
+        <edmx:Include Namespace="Drive.v1_11_3"/>
         <edmx:Include Namespace="Drive.v1_12_0"/>
         <edmx:Include Namespace="Drive.v1_12_1"/>
+        <edmx:Include Namespace="Drive.v1_12_2"/>
+        <edmx:Include Namespace="Drive.v1_13_0"/>
     </edmx:Reference>
     <edmx:Reference Uri="/redfish/v1/schema/DriveCollection_v1.xml">
         <edmx:Include Namespace="DriveCollection"/>
@@ -643,6 +674,7 @@
         <edmx:Include Namespace="EthernetInterface.v1_6_2"/>
         <edmx:Include Namespace="EthernetInterface.v1_6_3"/>
         <edmx:Include Namespace="EthernetInterface.v1_6_4"/>
+        <edmx:Include Namespace="EthernetInterface.v1_7_0"/>
     </edmx:Reference>
     <edmx:Reference Uri="/redfish/v1/schema/EthernetInterfaceCollection_v1.xml">
         <edmx:Include Namespace="EthernetInterfaceCollection"/>
@@ -700,6 +732,7 @@
         <edmx:Include Namespace="Event.v1_5_2"/>
         <edmx:Include Namespace="Event.v1_6_0"/>
         <edmx:Include Namespace="Event.v1_6_1"/>
+        <edmx:Include Namespace="Event.v1_7_0"/>
     </edmx:Reference>
     <edmx:Reference Uri="/redfish/v1/schema/EventDestination_v1.xml">
         <edmx:Include Namespace="EventDestination"/>
@@ -755,8 +788,11 @@
         <edmx:Include Namespace="EventDestination.v1_9_0"/>
         <edmx:Include Namespace="EventDestination.v1_9_1"/>
         <edmx:Include Namespace="EventDestination.v1_9_2"/>
+        <edmx:Include Namespace="EventDestination.v1_9_3"/>
         <edmx:Include Namespace="EventDestination.v1_10_0"/>
         <edmx:Include Namespace="EventDestination.v1_10_1"/>
+        <edmx:Include Namespace="EventDestination.v1_10_2"/>
+        <edmx:Include Namespace="EventDestination.v1_11_0"/>
     </edmx:Reference>
     <edmx:Reference Uri="/redfish/v1/schema/EventDestinationCollection_v1.xml">
         <edmx:Include Namespace="EventDestinationCollection"/>
@@ -776,6 +812,7 @@
         <edmx:Include Namespace="EventService.v1_0_11"/>
         <edmx:Include Namespace="EventService.v1_0_12"/>
         <edmx:Include Namespace="EventService.v1_0_13"/>
+        <edmx:Include Namespace="EventService.v1_0_14"/>
         <edmx:Include Namespace="EventService.v1_1_0"/>
         <edmx:Include Namespace="EventService.v1_1_1"/>
         <edmx:Include Namespace="EventService.v1_1_2"/>
@@ -783,30 +820,37 @@
         <edmx:Include Namespace="EventService.v1_1_4"/>
         <edmx:Include Namespace="EventService.v1_1_5"/>
         <edmx:Include Namespace="EventService.v1_1_6"/>
+        <edmx:Include Namespace="EventService.v1_1_7"/>
         <edmx:Include Namespace="EventService.v1_2_0"/>
         <edmx:Include Namespace="EventService.v1_2_1"/>
         <edmx:Include Namespace="EventService.v1_2_2"/>
         <edmx:Include Namespace="EventService.v1_2_3"/>
         <edmx:Include Namespace="EventService.v1_2_4"/>
         <edmx:Include Namespace="EventService.v1_2_5"/>
+        <edmx:Include Namespace="EventService.v1_2_6"/>
         <edmx:Include Namespace="EventService.v1_3_0"/>
         <edmx:Include Namespace="EventService.v1_3_1"/>
         <edmx:Include Namespace="EventService.v1_3_2"/>
         <edmx:Include Namespace="EventService.v1_3_3"/>
         <edmx:Include Namespace="EventService.v1_3_4"/>
+        <edmx:Include Namespace="EventService.v1_3_5"/>
         <edmx:Include Namespace="EventService.v1_4_0"/>
         <edmx:Include Namespace="EventService.v1_4_1"/>
         <edmx:Include Namespace="EventService.v1_4_2"/>
         <edmx:Include Namespace="EventService.v1_4_3"/>
+        <edmx:Include Namespace="EventService.v1_4_5"/>
         <edmx:Include Namespace="EventService.v1_5_0"/>
         <edmx:Include Namespace="EventService.v1_5_1"/>
         <edmx:Include Namespace="EventService.v1_5_2"/>
         <edmx:Include Namespace="EventService.v1_5_3"/>
+        <edmx:Include Namespace="EventService.v1_5_4"/>
         <edmx:Include Namespace="EventService.v1_6_0"/>
         <edmx:Include Namespace="EventService.v1_6_1"/>
         <edmx:Include Namespace="EventService.v1_6_2"/>
+        <edmx:Include Namespace="EventService.v1_6_3"/>
         <edmx:Include Namespace="EventService.v1_7_0"/>
         <edmx:Include Namespace="EventService.v1_7_1"/>
+        <edmx:Include Namespace="EventService.v1_7_2"/>
     </edmx:Reference>
     <edmx:Reference Uri="/redfish/v1/schema/IPAddresses_v1.xml">
         <edmx:Include Namespace="IPAddresses"/>
@@ -930,11 +974,15 @@
         <edmx:Include Namespace="LogService.v1_0_6"/>
         <edmx:Include Namespace="LogService.v1_0_7"/>
         <edmx:Include Namespace="LogService.v1_0_8"/>
+        <edmx:Include Namespace="LogService.v1_0_9"/>
         <edmx:Include Namespace="LogService.v1_1_0"/>
         <edmx:Include Namespace="LogService.v1_1_1"/>
         <edmx:Include Namespace="LogService.v1_1_2"/>
         <edmx:Include Namespace="LogService.v1_1_3"/>
+        <edmx:Include Namespace="LogService.v1_1_4"/>
         <edmx:Include Namespace="LogService.v1_2_0"/>
+        <edmx:Include Namespace="LogService.v1_2_1"/>
+        <edmx:Include Namespace="LogService.v1_3_0"/>
     </edmx:Reference>
     <edmx:Reference Uri="/redfish/v1/schema/LogServiceCollection_v1.xml">
         <edmx:Include Namespace="LogServiceCollection"/>
@@ -957,6 +1005,7 @@
         <edmx:Include Namespace="Manager.v1_0_13"/>
         <edmx:Include Namespace="Manager.v1_0_14"/>
         <edmx:Include Namespace="Manager.v1_0_15"/>
+        <edmx:Include Namespace="Manager.v1_0_16"/>
         <edmx:Include Namespace="Manager.v1_1_0"/>
         <edmx:Include Namespace="Manager.v1_1_1"/>
         <edmx:Include Namespace="Manager.v1_1_2"/>
@@ -971,6 +1020,7 @@
         <edmx:Include Namespace="Manager.v1_1_11"/>
         <edmx:Include Namespace="Manager.v1_1_12"/>
         <edmx:Include Namespace="Manager.v1_1_13"/>
+        <edmx:Include Namespace="Manager.v1_1_14"/>
         <edmx:Include Namespace="Manager.v1_2_0"/>
         <edmx:Include Namespace="Manager.v1_2_1"/>
         <edmx:Include Namespace="Manager.v1_2_2"/>
@@ -985,6 +1035,7 @@
         <edmx:Include Namespace="Manager.v1_2_11"/>
         <edmx:Include Namespace="Manager.v1_2_12"/>
         <edmx:Include Namespace="Manager.v1_2_13"/>
+        <edmx:Include Namespace="Manager.v1_2_14"/>
         <edmx:Include Namespace="Manager.v1_3_0"/>
         <edmx:Include Namespace="Manager.v1_3_1"/>
         <edmx:Include Namespace="Manager.v1_3_2"/>
@@ -998,6 +1049,7 @@
         <edmx:Include Namespace="Manager.v1_3_10"/>
         <edmx:Include Namespace="Manager.v1_3_11"/>
         <edmx:Include Namespace="Manager.v1_3_12"/>
+        <edmx:Include Namespace="Manager.v1_3_13"/>
         <edmx:Include Namespace="Manager.v1_4_0"/>
         <edmx:Include Namespace="Manager.v1_4_1"/>
         <edmx:Include Namespace="Manager.v1_4_2"/>
@@ -1008,6 +1060,7 @@
         <edmx:Include Namespace="Manager.v1_4_7"/>
         <edmx:Include Namespace="Manager.v1_4_8"/>
         <edmx:Include Namespace="Manager.v1_4_9"/>
+        <edmx:Include Namespace="Manager.v1_4_10"/>
         <edmx:Include Namespace="Manager.v1_5_0"/>
         <edmx:Include Namespace="Manager.v1_5_1"/>
         <edmx:Include Namespace="Manager.v1_5_2"/>
@@ -1017,33 +1070,42 @@
         <edmx:Include Namespace="Manager.v1_5_6"/>
         <edmx:Include Namespace="Manager.v1_5_7"/>
         <edmx:Include Namespace="Manager.v1_5_8"/>
+        <edmx:Include Namespace="Manager.v1_5_9"/>
         <edmx:Include Namespace="Manager.v1_6_0"/>
         <edmx:Include Namespace="Manager.v1_6_1"/>
         <edmx:Include Namespace="Manager.v1_6_2"/>
         <edmx:Include Namespace="Manager.v1_6_3"/>
         <edmx:Include Namespace="Manager.v1_6_4"/>
         <edmx:Include Namespace="Manager.v1_6_5"/>
+        <edmx:Include Namespace="Manager.v1_6_6"/>
         <edmx:Include Namespace="Manager.v1_7_0"/>
         <edmx:Include Namespace="Manager.v1_7_1"/>
         <edmx:Include Namespace="Manager.v1_7_2"/>
         <edmx:Include Namespace="Manager.v1_7_3"/>
         <edmx:Include Namespace="Manager.v1_7_4"/>
         <edmx:Include Namespace="Manager.v1_7_5"/>
+        <edmx:Include Namespace="Manager.v1_7_6"/>
         <edmx:Include Namespace="Manager.v1_8_0"/>
         <edmx:Include Namespace="Manager.v1_8_1"/>
         <edmx:Include Namespace="Manager.v1_8_2"/>
         <edmx:Include Namespace="Manager.v1_8_3"/>
         <edmx:Include Namespace="Manager.v1_8_4"/>
+        <edmx:Include Namespace="Manager.v1_8_5"/>
         <edmx:Include Namespace="Manager.v1_9_0"/>
         <edmx:Include Namespace="Manager.v1_9_1"/>
         <edmx:Include Namespace="Manager.v1_9_2"/>
         <edmx:Include Namespace="Manager.v1_9_3"/>
+        <edmx:Include Namespace="Manager.v1_9_4"/>
         <edmx:Include Namespace="Manager.v1_10_0"/>
         <edmx:Include Namespace="Manager.v1_10_1"/>
         <edmx:Include Namespace="Manager.v1_10_2"/>
+        <edmx:Include Namespace="Manager.v1_10_3"/>
         <edmx:Include Namespace="Manager.v1_11_0"/>
         <edmx:Include Namespace="Manager.v1_11_1"/>
+        <edmx:Include Namespace="Manager.v1_11_2"/>
         <edmx:Include Namespace="Manager.v1_12_0"/>
+        <edmx:Include Namespace="Manager.v1_12_1"/>
+        <edmx:Include Namespace="Manager.v1_13_0"/>
     </edmx:Reference>
     <edmx:Reference Uri="/redfish/v1/schema/ManagerAccount_v1.xml">
         <edmx:Include Namespace="ManagerAccount"/>
@@ -1146,6 +1208,7 @@
         <edmx:Include Namespace="ManagerNetworkProtocol.v1_6_1"/>
         <edmx:Include Namespace="ManagerNetworkProtocol.v1_6_2"/>
         <edmx:Include Namespace="ManagerNetworkProtocol.v1_7_0"/>
+        <edmx:Include Namespace="ManagerNetworkProtocol.v1_8_0"/>
     </edmx:Reference>
     <edmx:Reference Uri="/redfish/v1/schema/Memory_v1.xml">
         <edmx:Include Namespace="Memory"/>
@@ -1240,6 +1303,7 @@
         <edmx:Include Namespace="Memory.v1_10_1"/>
         <edmx:Include Namespace="Memory.v1_11_0"/>
         <edmx:Include Namespace="Memory.v1_12_0"/>
+        <edmx:Include Namespace="Memory.v1_13_0"/>
     </edmx:Reference>
     <edmx:Reference Uri="/redfish/v1/schema/MemoryCollection_v1.xml">
         <edmx:Include Namespace="MemoryCollection"/>
@@ -1630,7 +1694,10 @@
         <edmx:Include Namespace="Processor.v1_10_2"/>
         <edmx:Include Namespace="Processor.v1_11_0"/>
         <edmx:Include Namespace="Processor.v1_11_1"/>
+        <edmx:Include Namespace="Processor.v1_11_2"/>
         <edmx:Include Namespace="Processor.v1_12_0"/>
+        <edmx:Include Namespace="Processor.v1_12_1"/>
+        <edmx:Include Namespace="Processor.v1_13_0"/>
     </edmx:Reference>
     <edmx:Reference Uri="/redfish/v1/schema/ProcessorCollection_v1.xml">
         <edmx:Include Namespace="ProcessorCollection"/>
@@ -1695,6 +1762,7 @@
         <edmx:Include Namespace="Resource.v1_0_10"/>
         <edmx:Include Namespace="Resource.v1_0_11"/>
         <edmx:Include Namespace="Resource.v1_0_12"/>
+        <edmx:Include Namespace="Resource.v1_0_13"/>
         <edmx:Include Namespace="Resource.v1_1_0"/>
         <edmx:Include Namespace="Resource.v1_1_1"/>
         <edmx:Include Namespace="Resource.v1_1_2"/>
@@ -1709,6 +1777,7 @@
         <edmx:Include Namespace="Resource.v1_1_11"/>
         <edmx:Include Namespace="Resource.v1_1_12"/>
         <edmx:Include Namespace="Resource.v1_1_13"/>
+        <edmx:Include Namespace="Resource.v1_1_14"/>
         <edmx:Include Namespace="Resource.v1_2_0"/>
         <edmx:Include Namespace="Resource.v1_2_1"/>
         <edmx:Include Namespace="Resource.v1_2_2"/>
@@ -1722,6 +1791,7 @@
         <edmx:Include Namespace="Resource.v1_2_10"/>
         <edmx:Include Namespace="Resource.v1_2_11"/>
         <edmx:Include Namespace="Resource.v1_2_12"/>
+        <edmx:Include Namespace="Resource.v1_2_13"/>
         <edmx:Include Namespace="Resource.v1_3_0"/>
         <edmx:Include Namespace="Resource.v1_3_1"/>
         <edmx:Include Namespace="Resource.v1_3_2"/>
@@ -1734,6 +1804,7 @@
         <edmx:Include Namespace="Resource.v1_3_9"/>
         <edmx:Include Namespace="Resource.v1_3_10"/>
         <edmx:Include Namespace="Resource.v1_3_11"/>
+        <edmx:Include Namespace="Resource.v1_3_12"/>
         <edmx:Include Namespace="Resource.v1_4_0"/>
         <edmx:Include Namespace="Resource.v1_4_1"/>
         <edmx:Include Namespace="Resource.v1_4_2"/>
@@ -1745,6 +1816,7 @@
         <edmx:Include Namespace="Resource.v1_4_8"/>
         <edmx:Include Namespace="Resource.v1_4_9"/>
         <edmx:Include Namespace="Resource.v1_4_10"/>
+        <edmx:Include Namespace="Resource.v1_4_11"/>
         <edmx:Include Namespace="Resource.v1_5_0"/>
         <edmx:Include Namespace="Resource.v1_5_1"/>
         <edmx:Include Namespace="Resource.v1_5_2"/>
@@ -1755,6 +1827,7 @@
         <edmx:Include Namespace="Resource.v1_5_7"/>
         <edmx:Include Namespace="Resource.v1_5_8"/>
         <edmx:Include Namespace="Resource.v1_5_9"/>
+        <edmx:Include Namespace="Resource.v1_5_10"/>
         <edmx:Include Namespace="Resource.v1_6_0"/>
         <edmx:Include Namespace="Resource.v1_6_1"/>
         <edmx:Include Namespace="Resource.v1_6_2"/>
@@ -1764,6 +1837,7 @@
         <edmx:Include Namespace="Resource.v1_6_6"/>
         <edmx:Include Namespace="Resource.v1_6_7"/>
         <edmx:Include Namespace="Resource.v1_6_8"/>
+        <edmx:Include Namespace="Resource.v1_6_9"/>
         <edmx:Include Namespace="Resource.v1_7_0"/>
         <edmx:Include Namespace="Resource.v1_7_1"/>
         <edmx:Include Namespace="Resource.v1_7_2"/>
@@ -1772,6 +1846,7 @@
         <edmx:Include Namespace="Resource.v1_7_5"/>
         <edmx:Include Namespace="Resource.v1_7_6"/>
         <edmx:Include Namespace="Resource.v1_7_7"/>
+        <edmx:Include Namespace="Resource.v1_7_8"/>
         <edmx:Include Namespace="Resource.v1_8_0"/>
         <edmx:Include Namespace="Resource.v1_8_1"/>
         <edmx:Include Namespace="Resource.v1_8_2"/>
@@ -1780,18 +1855,24 @@
         <edmx:Include Namespace="Resource.v1_8_5"/>
         <edmx:Include Namespace="Resource.v1_8_6"/>
         <edmx:Include Namespace="Resource.v1_8_7"/>
+        <edmx:Include Namespace="Resource.v1_8_8"/>
         <edmx:Include Namespace="Resource.v1_9_0"/>
         <edmx:Include Namespace="Resource.v1_9_1"/>
         <edmx:Include Namespace="Resource.v1_9_2"/>
         <edmx:Include Namespace="Resource.v1_9_3"/>
         <edmx:Include Namespace="Resource.v1_9_4"/>
         <edmx:Include Namespace="Resource.v1_9_5"/>
+        <edmx:Include Namespace="Resource.v1_9_6"/>
         <edmx:Include Namespace="Resource.v1_10_0"/>
         <edmx:Include Namespace="Resource.v1_10_1"/>
         <edmx:Include Namespace="Resource.v1_10_2"/>
+        <edmx:Include Namespace="Resource.v1_10_3"/>
         <edmx:Include Namespace="Resource.v1_11_0"/>
         <edmx:Include Namespace="Resource.v1_11_1"/>
+        <edmx:Include Namespace="Resource.v1_11_2"/>
         <edmx:Include Namespace="Resource.v1_12_0"/>
+        <edmx:Include Namespace="Resource.v1_12_1"/>
+        <edmx:Include Namespace="Resource.v1_13_0"/>
     </edmx:Reference>
     <edmx:Reference Uri="/redfish/v1/schema/Role_v1.xml">
         <edmx:Include Namespace="Role"/>
@@ -1832,11 +1913,16 @@
         <edmx:Include Namespace="Sensor.v1_0_4"/>
         <edmx:Include Namespace="Sensor.v1_0_5"/>
         <edmx:Include Namespace="Sensor.v1_0_6"/>
+        <edmx:Include Namespace="Sensor.v1_0_7"/>
         <edmx:Include Namespace="Sensor.v1_1_0"/>
         <edmx:Include Namespace="Sensor.v1_1_1"/>
         <edmx:Include Namespace="Sensor.v1_1_2"/>
+        <edmx:Include Namespace="Sensor.v1_1_3"/>
         <edmx:Include Namespace="Sensor.v1_2_0"/>
+        <edmx:Include Namespace="Sensor.v1_2_1"/>
         <edmx:Include Namespace="Sensor.v1_3_0"/>
+        <edmx:Include Namespace="Sensor.v1_3_1"/>
+        <edmx:Include Namespace="Sensor.v1_4_0"/>
     </edmx:Reference>
     <edmx:Reference Uri="/redfish/v1/schema/SensorCollection_v1.xml">
         <edmx:Include Namespace="SensorCollection"/>
@@ -1882,6 +1968,7 @@
         <edmx:Include Namespace="ServiceRoot.v1_8_0"/>
         <edmx:Include Namespace="ServiceRoot.v1_9_0"/>
         <edmx:Include Namespace="ServiceRoot.v1_10_0"/>
+        <edmx:Include Namespace="ServiceRoot.v1_11_0"/>
     </edmx:Reference>
     <edmx:Reference Uri="/redfish/v1/schema/Session_v1.xml">
         <edmx:Include Namespace="Session"/>
@@ -1968,6 +2055,7 @@
         <edmx:Include Namespace="SoftwareInventory.v1_2_3"/>
         <edmx:Include Namespace="SoftwareInventory.v1_3_0"/>
         <edmx:Include Namespace="SoftwareInventory.v1_4_0"/>
+        <edmx:Include Namespace="SoftwareInventory.v1_5_0"/>
     </edmx:Reference>
     <edmx:Reference Uri="/redfish/v1/schema/SoftwareInventoryCollection_v1.xml">
         <edmx:Include Namespace="SoftwareInventoryCollection"/>
@@ -2050,6 +2138,7 @@
         <edmx:Include Namespace="Storage.v1_9_2"/>
         <edmx:Include Namespace="Storage.v1_10_0"/>
         <edmx:Include Namespace="Storage.v1_10_1"/>
+        <edmx:Include Namespace="Storage.v1_11_0"/>
     </edmx:Reference>
     <edmx:Reference Uri="/redfish/v1/schema/StorageCollection_v1.xml">
         <edmx:Include Namespace="StorageCollection"/>
@@ -2062,6 +2151,7 @@
         <edmx:Include Namespace="StorageController.v1_1_0"/>
         <edmx:Include Namespace="StorageController.v1_1_1"/>
         <edmx:Include Namespace="StorageController.v1_2_0"/>
+        <edmx:Include Namespace="StorageController.v1_3_0"/>
     </edmx:Reference>
     <edmx:Reference Uri="/redfish/v1/schema/StorageControllerCollection_v1.xml">
         <edmx:Include Namespace="StorageControllerCollection"/>
@@ -2283,6 +2373,7 @@
         <edmx:Include Namespace="UpdateService.v1_8_3"/>
         <edmx:Include Namespace="UpdateService.v1_8_4"/>
         <edmx:Include Namespace="UpdateService.v1_9_0"/>
+        <edmx:Include Namespace="UpdateService.v1_10_0"/>
     </edmx:Reference>
     <edmx:Reference Uri="/redfish/v1/schema/VirtualMedia_v1.xml">
         <edmx:Include Namespace="VirtualMedia"/>
@@ -2293,21 +2384,27 @@
         <edmx:Include Namespace="VirtualMedia.v1_0_5"/>
         <edmx:Include Namespace="VirtualMedia.v1_0_6"/>
         <edmx:Include Namespace="VirtualMedia.v1_0_7"/>
+        <edmx:Include Namespace="VirtualMedia.v1_0_8"/>
         <edmx:Include Namespace="VirtualMedia.v1_1_0"/>
         <edmx:Include Namespace="VirtualMedia.v1_1_1"/>
         <edmx:Include Namespace="VirtualMedia.v1_1_2"/>
         <edmx:Include Namespace="VirtualMedia.v1_1_3"/>
         <edmx:Include Namespace="VirtualMedia.v1_1_4"/>
         <edmx:Include Namespace="VirtualMedia.v1_1_5"/>
+        <edmx:Include Namespace="VirtualMedia.v1_1_6"/>
         <edmx:Include Namespace="VirtualMedia.v1_2_0"/>
         <edmx:Include Namespace="VirtualMedia.v1_2_1"/>
         <edmx:Include Namespace="VirtualMedia.v1_2_2"/>
         <edmx:Include Namespace="VirtualMedia.v1_2_3"/>
         <edmx:Include Namespace="VirtualMedia.v1_2_4"/>
+        <edmx:Include Namespace="VirtualMedia.v1_2_5"/>
         <edmx:Include Namespace="VirtualMedia.v1_3_0"/>
         <edmx:Include Namespace="VirtualMedia.v1_3_1"/>
         <edmx:Include Namespace="VirtualMedia.v1_3_2"/>
+        <edmx:Include Namespace="VirtualMedia.v1_3_3"/>
         <edmx:Include Namespace="VirtualMedia.v1_4_0"/>
+        <edmx:Include Namespace="VirtualMedia.v1_4_1"/>
+        <edmx:Include Namespace="VirtualMedia.v1_5_0"/>
     </edmx:Reference>
     <edmx:Reference Uri="/redfish/v1/schema/VirtualMediaCollection_v1.xml">
         <edmx:Include Namespace="VirtualMediaCollection"/>
@@ -2331,6 +2428,7 @@
         <edmx:Include Namespace="VLanNetworkInterface.v1_1_4"/>
         <edmx:Include Namespace="VLanNetworkInterface.v1_1_5"/>
         <edmx:Include Namespace="VLanNetworkInterface.v1_2_0"/>
+        <edmx:Include Namespace="VLanNetworkInterface.v1_3_0"/>
     </edmx:Reference>
     <edmx:Reference Uri="/redfish/v1/schema/VLanNetworkInterfaceCollection_v1.xml">
         <edmx:Include Namespace="VLanNetworkInterfaceCollection"/>

--- a/static/redfish/v1/JsonSchemas/AccountService/AccountService.json
+++ b/static/redfish/v1/JsonSchemas/AccountService/AccountService.json
@@ -1,5 +1,5 @@
 {
-    "$id": "http://redfish.dmtf.org/schemas/v1/AccountService.v1_9_0.json",
+    "$id": "http://redfish.dmtf.org/schemas/v1/AccountService.v1_10_0.json",
     "$ref": "#/definitions/AccountService",
     "$schema": "http://redfish.dmtf.org/schemas/v1/redfish-schema-v1.json",
     "copyright": "Copyright 2014-2021 DMTF. For the full DMTF copyright policy, see http://www.dmtf.org/about/policies/copyright",
@@ -10,11 +10,13 @@
                 "ActiveDirectoryService",
                 "LDAPService",
                 "OEM",
-                "TACACSplus"
+                "TACACSplus",
+                "OAuth2"
             ],
             "enumDescriptions": {
                 "ActiveDirectoryService": "An external Active Directory service.",
                 "LDAPService": "A generic external LDAP service.",
+                "OAuth2": "An external OAuth 2.0 service.",
                 "OEM": "An OEM-specific external authentication or directory service.",
                 "RedfishService": "An external Redfish service.",
                 "TACACSplus": "An external TACACS+ service."
@@ -22,18 +24,20 @@
             "enumLongDescriptions": {
                 "ActiveDirectoryService": "The external account provider shall be a Microsoft Active Directory Technical Specification-conformant service.  The ServiceAddresses format shall contain a set of fully qualified domain names (FQDN) or NetBIOS names that links to the set of domain servers for the Active Directory service.",
                 "LDAPService": "The external account provider shall be an RFC4511-conformant service.  The ServiceAddresses format shall contain a set of fully qualified domain names (FQDN) that links to the set of LDAP servers for the service.",
+                "OAuth2": "The external account provider shall be an RFC6749-conformant service.  The ServiceAddresses format shall contain a set of URIs that correspond to the RFC8414-defined metadata for the OAuth 2.0 service.",
                 "RedfishService": "The external account provider shall be a DMTF Redfish Specification-conformant service.  The ServiceAddresses format shall contain a set of URIs that correspond to a Redfish account service.",
                 "TACACSplus": "The external account provider shall be an RFC8907-conformant service.  The ServiceAddresses format shall contain a set of host:port that correspond to a TACACS+ service and where the format for host and port are defined in RFC3986."
             },
             "enumVersionAdded": {
+                "OAuth2": "v1_10_0",
                 "TACACSplus": "v1_8_0"
             },
             "type": "string"
         },
         "AccountService": {
             "additionalProperties": false,
-            "description": "The AccountService schema defines an account service.  The properties are common to, and enable management of, all user accounts.  The properties include the password requirements and control features, such as account lockout.  The schema also contains links to the manager accounts and roles.",
-            "longDescription": "This resource shall represent an account service for a Redfish implementation.  The properties are common to, and enable management of, all user accounts.  The properties include the password requirements and control features, such as account lockout.",
+            "description": "The AccountService schema defines an account service.  The properties are common to, and enable management of, all user accounts.  The properties include the password requirements and control features, such as account lockout.  Properties and actions in this service specify general behavior that should be followed for typical accounts, however implementations may override these behaviors for special accounts or situations to avoid denial of service or other deadlock situations.",
+            "longDescription": "This resource shall represent an account service for a Redfish implementation.  The properties are common to, and enable management of, all user accounts.  The properties include the password requirements and control features, such as account lockout.  Properties and actions in this service specify general behavior that should be followed for typical accounts, however implementations may override these behaviors for special accounts or situations to avoid denial of service or other deadlock situations.",
             "patternProperties": {
                 "^([a-zA-Z_][a-zA-Z0-9_]*)?@(odata|Redfish|Message)\\.[a-zA-Z_][a-zA-Z0-9_]*$": {
                     "description": "This property shall specify a valid odata or Redfish property.",
@@ -174,6 +178,19 @@
                 "Name": {
                     "$ref": "http://redfish.dmtf.org/schemas/v1/Resource.json#/definitions/Name",
                     "readonly": true
+                },
+                "OAuth2": {
+                    "anyOf": [
+                        {
+                            "$ref": "#/definitions/ExternalAccountProvider"
+                        },
+                        {
+                            "type": "null"
+                        }
+                    ],
+                    "description": "The first OAuth 2.0 external account provider that this account service supports.",
+                    "longDescription": "This property shall contain the first OAuth 2.0 external account provider that this account service supports.  If the account service supports one or more OAuth 2.0 services as an external account provider, this entity shall be populated by default.  This entity shall not be present in the additional external account providers resource collection.",
+                    "versionAdded": "v1_10_0"
                 },
                 "Oem": {
                     "$ref": "http://redfish.dmtf.org/schemas/v1/Resource.json#/definitions/Oem",
@@ -476,6 +493,19 @@
                     "longDescription": "This property shall contain any additional mapping information needed to parse a generic LDAP service.  This property should only be present inside the LDAP property.",
                     "versionAdded": "v1_3_0"
                 },
+                "OAuth2Service": {
+                    "anyOf": [
+                        {
+                            "$ref": "#/definitions/OAuth2Service"
+                        },
+                        {
+                            "type": "null"
+                        }
+                    ],
+                    "description": "The additional information needed to parse an OAuth 2.0 service.",
+                    "longDescription": "This property shall contain additional information needed to parse an OAuth 2.0 service.  This property should only be present inside an OAuth2 property.",
+                    "versionAdded": "v1_10_0"
+                },
                 "PasswordSet": {
                     "description": "Indicates if the Password property is set.",
                     "longDescription": "This property shall contain `true` if a valid value was provided for the Password property.  Otherwise, the property shall contain `false`.",
@@ -672,6 +702,80 @@
             },
             "type": "string"
         },
+        "OAuth2Mode": {
+            "enum": [
+                "Discovery",
+                "Offline"
+            ],
+            "enumDescriptions": {
+                "Discovery": "OAuth 2.0 service information for token validation is downloaded by the service.",
+                "Offline": "OAuth 2.0 service information for token validation is configured by a client."
+            },
+            "enumLongDescriptions": {
+                "Discovery": "This value shall indicate the service performs token validation from information found at the URIs specified by the ServiceAddresses property.  Services shall implement a caching method of this information so it's not necessary to retrieve metadata and key information for every request containing a token.",
+                "Offline": "This value shall indicate the service performs token validation from properties configured by a client."
+            },
+            "type": "string"
+        },
+        "OAuth2Service": {
+            "additionalProperties": false,
+            "description": "Various settings to parse an OAuth 2.0 service.",
+            "longDescription": "This type shall contain settings for parsing an OAuth 2.0 service.",
+            "patternProperties": {
+                "^([a-zA-Z_][a-zA-Z0-9_]*)?@(odata|Redfish|Message)\\.[a-zA-Z_][a-zA-Z0-9_]*$": {
+                    "description": "This property shall specify a valid odata or Redfish property.",
+                    "type": [
+                        "array",
+                        "boolean",
+                        "integer",
+                        "number",
+                        "null",
+                        "object",
+                        "string"
+                    ]
+                }
+            },
+            "properties": {
+                "Audience": {
+                    "description": "The allowable audience strings of the Redfish service.",
+                    "items": {
+                        "type": "string"
+                    },
+                    "longDescription": "This property shall contain an array of allowable RFC7519-defined audience strings of the Redfish service.  The values shall uniquely identify the Redfish service.  For example, a MAC address or UUID for the manager can uniquely identify the service.",
+                    "readonly": true,
+                    "type": "array",
+                    "versionAdded": "v1_10_0"
+                },
+                "Issuer": {
+                    "description": "The issuer string of the OAuth 2.0 service.",
+                    "longDescription": "This property shall contain the RFC8414-defined issuer string of the OAuth 2.0 service.  If the Mode property contains the value `Discovery`, this property shall contain the value of the `issuer` string from the OAuth 2.0 service's metadata and this property shall be read-only.",
+                    "readonly": false,
+                    "type": [
+                        "string",
+                        "null"
+                    ],
+                    "versionAdded": "v1_10_0"
+                },
+                "Mode": {
+                    "$ref": "#/definitions/OAuth2Mode",
+                    "description": "The mode of operation for token validation.",
+                    "longDescription": "This property shall contain the mode of operation for token validation.",
+                    "readonly": false,
+                    "versionAdded": "v1_10_0"
+                },
+                "OAuthServiceSigningKeys": {
+                    "description": "The Base64-encoded signing keys of the issuer of the OAuth 2.0 service.",
+                    "longDescription": "This property shall contain a Base64-encoded string of the RFC7517-defined signing keys of the issuer of the OAuth 2.0 service.  If the Mode property contains the value `Discovery`, this property shall contain the keys found at the URI specified by the `jwks_uri` string from the OAuth 2.0 service's metadata and this property shall be read-only.",
+                    "readonly": false,
+                    "type": [
+                        "string",
+                        "null"
+                    ],
+                    "versionAdded": "v1_10_0"
+                }
+            },
+            "type": "object"
+        },
         "OemActions": {
             "additionalProperties": true,
             "description": "The available OEM-specific actions for this resource.",
@@ -826,6 +930,6 @@
         }
     },
     "owningEntity": "DMTF",
-    "release": "2021.1",
-    "title": "#AccountService.v1_9_0.AccountService"
+    "release": "2021.2",
+    "title": "#AccountService.v1_10_0.AccountService"
 }

--- a/static/redfish/v1/JsonSchemas/ActionInfo/ActionInfo.json
+++ b/static/redfish/v1/JsonSchemas/ActionInfo/ActionInfo.json
@@ -1,13 +1,13 @@
 {
-    "$id": "http://redfish.dmtf.org/schemas/v1/ActionInfo.v1_1_2.json",
+    "$id": "http://redfish.dmtf.org/schemas/v1/ActionInfo.v1_2_0.json",
     "$ref": "#/definitions/ActionInfo",
     "$schema": "http://redfish.dmtf.org/schemas/v1/redfish-schema-v1.json",
-    "copyright": "Copyright 2014-2019 DMTF. For the full DMTF copyright policy, see http://www.dmtf.org/about/policies/copyright",
+    "copyright": "Copyright 2014-2021 DMTF. For the full DMTF copyright policy, see http://www.dmtf.org/about/policies/copyright",
     "definitions": {
         "ActionInfo": {
             "additionalProperties": false,
-            "description": "The ActionInfo schema defines the supported parameters and other information for a Redfish action.  Supported parameters can differ among vendors and even among Resource instances.  This data can ensure that action requests from applications contain supported parameters.",
-            "longDescription": "This Resource shall represent the supported parameters and other information for a Redfish action on a target within a Redfish implementation.  Supported parameters can differ among vendors and even among Resource instances.  This data can ensure that action requests from applications contain supported parameters.",
+            "description": "The ActionInfo schema defines the supported parameters and other information for a Redfish action.  Supported parameters can differ among vendors and even among resource instances.  This data can ensure that action requests from applications contain supported parameters.",
+            "longDescription": "This resource shall represent the supported parameters and other information for a Redfish action on a target within a Redfish implementation.  Supported parameters can differ among vendors and even among resource instances.  This data can ensure that action requests from applications contain supported parameters.",
             "patternProperties": {
                 "^([a-zA-Z_][a-zA-Z0-9_]*)?@(odata|Redfish|Message)\\.[a-zA-Z_][a-zA-Z0-9_]*$": {
                     "description": "This property shall specify a valid odata or Redfish property.",
@@ -64,7 +64,7 @@
                     "items": {
                         "$ref": "#/definitions/Parameters"
                     },
-                    "longDescription": "This property shall list the parameters included in the specified Redfish action for this Resource.",
+                    "longDescription": "This property shall list the parameters included in the specified Redfish action for this resource.",
                     "type": "array"
                 }
             },
@@ -99,8 +99,8 @@
         },
         "Parameters": {
             "additionalProperties": false,
-            "description": "The information about a parameter included in a Redfish action for this Resource.",
-            "longDescription": "This property shall contain information about a parameter included in a Redfish Action for this Resource.",
+            "description": "The information about a parameter included in a Redfish action for this resource.",
+            "longDescription": "This property shall contain information about a parameter included in a Redfish action for this resource.",
             "patternProperties": {
                 "^([a-zA-Z_][a-zA-Z0-9_]*)?@(odata|Redfish|Message)\\.[a-zA-Z_][a-zA-Z0-9_]*$": {
                     "description": "This property shall specify a valid odata or Redfish property.",
@@ -124,9 +124,29 @@
                             "null"
                         ]
                     },
-                    "longDescription": "This property shall indicate the allowable values for this parameter as applied to this action target.",
+                    "longDescription": "This property shall indicate the allowable values for this parameter as applied to this action target.  For arrays, this property shall represent the allowable values for each array member.",
                     "readonly": true,
                     "type": "array"
+                },
+                "ArraySizeMaximum": {
+                    "description": "The maximum number of array elements allowed for this parameter.",
+                    "longDescription": "This property shall contain the maximum number of array elements that this service supports for this parameter.  This property shall not be present for non-array parameters.",
+                    "readonly": true,
+                    "type": [
+                        "integer",
+                        "null"
+                    ],
+                    "versionAdded": "v1_2_0"
+                },
+                "ArraySizeMinimum": {
+                    "description": "The minimum number of array elements required for this parameter.",
+                    "longDescription": "This property shall contain the minimum number of array elements required by this service for this parameter.  This property shall not be present for non-array parameters.",
+                    "readonly": true,
+                    "type": [
+                        "integer",
+                        "null"
+                    ],
+                    "versionAdded": "v1_2_0"
                 },
                 "DataType": {
                     "anyOf": [
@@ -143,7 +163,7 @@
                 },
                 "MaximumValue": {
                     "description": "The maximum supported value for this parameter.",
-                    "longDescription": "This integer or number property shall contain the maximum value that this service supports.  This property shall not be present for non-integer or number parameters.",
+                    "longDescription": "This integer or number property shall contain the maximum value that this service supports.  For arrays, this property shall represent the maximum value for each array member.  This property shall not be present for non-integer or number parameters.",
                     "readonly": true,
                     "type": [
                         "number",
@@ -153,7 +173,7 @@
                 },
                 "MinimumValue": {
                     "description": "The minimum supported value for this parameter.",
-                    "longDescription": "This integer or number property shall contain the minimum value that this service supports.  This property shall not be present for parameters that are of types other than integer or number.",
+                    "longDescription": "This integer or number property shall contain the minimum value that this service supports.  For arrays, this property shall represent the minimum value for each array member.  This property shall not be present for non-integer or number parameters.",
                     "readonly": true,
                     "type": [
                         "number",
@@ -190,6 +210,6 @@
         }
     },
     "owningEntity": "DMTF",
-    "release": "2018.2",
-    "title": "#ActionInfo.v1_1_2.ActionInfo"
+    "release": "2021.2",
+    "title": "#ActionInfo.v1_2_0.ActionInfo"
 }

--- a/static/redfish/v1/JsonSchemas/Certificate/Certificate.json
+++ b/static/redfish/v1/JsonSchemas/Certificate/Certificate.json
@@ -1,5 +1,5 @@
 {
-    "$id": "http://redfish.dmtf.org/schemas/v1/Certificate.v1_3_0.json",
+    "$id": "http://redfish.dmtf.org/schemas/v1/Certificate.v1_4_0.json",
     "$ref": "#/definitions/Certificate",
     "$schema": "http://redfish.dmtf.org/schemas/v1/redfish-schema-v1.json",
     "copyright": "Copyright 2014-2021 DMTF. For the full DMTF copyright policy, see http://www.dmtf.org/about/policies/copyright",
@@ -95,6 +95,23 @@
                     "longDescription": "This property shall contain the format type for the certificate.",
                     "readonly": true
                 },
+                "CertificateUsageTypes": {
+                    "description": "The types or purposes for this certificate.",
+                    "items": {
+                        "anyOf": [
+                            {
+                                "$ref": "#/definitions/CertificateUsageType"
+                            },
+                            {
+                                "type": "null"
+                            }
+                        ]
+                    },
+                    "longDescription": "The value of this property shall contain an array describing the types or purposes for this certificate.",
+                    "readonly": true,
+                    "type": "array",
+                    "versionAdded": "v1_4_0"
+                },
                 "Description": {
                     "anyOf": [
                         {
@@ -145,6 +162,12 @@
                     "longDescription": "This property shall contain the key usage extension, which defines the purpose of the public keys in this certificate.",
                     "readonly": true,
                     "type": "array"
+                },
+                "Links": {
+                    "$ref": "#/definitions/Links",
+                    "description": "The links to other resources that are related to this resource.",
+                    "longDescription": "This property shall contain links to resources that are related to but are not contained by, or subordinate to, this resource.",
+                    "versionAdded": "v1_4_0"
                 },
                 "Name": {
                     "$ref": "http://redfish.dmtf.org/schemas/v1/Resource.json#/definitions/Name",
@@ -213,6 +236,25 @@
             ],
             "type": "object"
         },
+        "CertificateUsageType": {
+            "enum": [
+                "User",
+                "Web",
+                "SSH",
+                "Device",
+                "Platform",
+                "BIOS"
+            ],
+            "enumDescriptions": {
+                "BIOS": "This certificate is a BIOS certificate like those associated with UEFI.",
+                "Device": "This certificate is a device type certificate like those associated with SPDM and other standards.",
+                "Platform": "This certificate is a platform type certificate like those associated with SPDM and other standards.",
+                "SSH": "This certificate is used for SSH.",
+                "User": "This certificate is a user certificate like those associated with a manager account.",
+                "Web": "This certificate is a web or HTTPS certificate like those used for event destinations."
+            },
+            "type": "string"
+        },
         "Identifier": {
             "additionalProperties": false,
             "description": "The identifier information about a certificate.",
@@ -276,6 +318,60 @@
                     "longDescription": "This property shall contain the state, province, or region of the organization of the entity.",
                     "readonly": true,
                     "type": "string"
+                }
+            },
+            "type": "object"
+        },
+        "Links": {
+            "additionalProperties": false,
+            "description": "The links to other resources that are related to this resource.",
+            "longDescription": "This Redfish Specification-described type shall contain links to resources that are related to but are not contained by, or subordinate to, this resource.",
+            "patternProperties": {
+                "^([a-zA-Z_][a-zA-Z0-9_]*)?@(odata|Redfish|Message)\\.[a-zA-Z_][a-zA-Z0-9_]*$": {
+                    "description": "This property shall specify a valid odata or Redfish property.",
+                    "type": [
+                        "array",
+                        "boolean",
+                        "integer",
+                        "number",
+                        "null",
+                        "object",
+                        "string"
+                    ]
+                }
+            },
+            "properties": {
+                "Issuer": {
+                    "anyOf": [
+                        {
+                            "$ref": "http://redfish.dmtf.org/schemas/v1/Certificate.json#/definitions/Certificate"
+                        },
+                        {
+                            "type": "null"
+                        }
+                    ],
+                    "description": "A link to the certificate of the CA that issued this certificate.",
+                    "longDescription": "This property shall contain a link to a resources of type Certificate that represents the certificate of the CA that issued this certificate.",
+                    "readonly": false,
+                    "versionAdded": "v1_4_0"
+                },
+                "Oem": {
+                    "$ref": "http://redfish.dmtf.org/schemas/v1/Resource.json#/definitions/Oem",
+                    "description": "The OEM extension property.",
+                    "longDescription": "This property shall contain the OEM extensions.  All values for properties contained in this object shall conform to the Redfish Specification-described requirements."
+                },
+                "Subjects": {
+                    "description": "An array of links to certificates that were issued by the CA that is represented by this certificate.",
+                    "items": {
+                        "$ref": "http://redfish.dmtf.org/schemas/v1/Certificate.json#/definitions/Certificate"
+                    },
+                    "longDescription": "This property shall contain an array of links to resources of type Certificate that were issued by the CA that is represented by this certificate.",
+                    "readonly": false,
+                    "type": "array",
+                    "versionAdded": "v1_4_0"
+                },
+                "Subjects@odata.count": {
+                    "$ref": "http://redfish.dmtf.org/schemas/v1/odata-v4.json#/definitions/count"
                 }
             },
             "type": "object"
@@ -482,6 +578,6 @@
         }
     },
     "owningEntity": "DMTF",
-    "release": "2021.1",
-    "title": "#Certificate.v1_3_0.Certificate"
+    "release": "2021.2",
+    "title": "#Certificate.v1_4_0.Certificate"
 }

--- a/static/redfish/v1/JsonSchemas/Chassis/Chassis.json
+++ b/static/redfish/v1/JsonSchemas/Chassis/Chassis.json
@@ -1,5 +1,5 @@
 {
-    "$id": "http://redfish.dmtf.org/schemas/v1/Chassis.v1_16_0.json",
+    "$id": "http://redfish.dmtf.org/schemas/v1/Chassis.v1_17_0.json",
     "$ref": "#/definitions/Chassis",
     "$schema": "http://redfish.dmtf.org/schemas/v1/redfish-schema-v1.json",
     "copyright": "Copyright 2014-2021 DMTF. For the full DMTF copyright policy, see http://www.dmtf.org/about/policies/copyright",
@@ -98,6 +98,13 @@
                     "description": "The type of physical form factor of the chassis.",
                     "longDescription": "This property shall indicate the physical form factor for the type of chassis.",
                     "readonly": true
+                },
+                "Controls": {
+                    "$ref": "http://redfish.dmtf.org/schemas/v1/ControlCollection.json#/definitions/ControlCollection",
+                    "description": "The link to the collection of controls located in this chassis.",
+                    "longDescription": "This property shall contain a link to a resource collection of type ControlCollection.",
+                    "readonly": true,
+                    "versionAdded": "v1_17_0"
                 },
                 "DepthMm": {
                     "description": "The depth of the chassis.",
@@ -593,6 +600,19 @@
                 }
             },
             "properties": {
+                "Cables": {
+                    "description": "An array of links to the cables connected to this chassis.",
+                    "items": {
+                        "$ref": "http://redfish.dmtf.org/schemas/v1/Cable.json#/definitions/Cable"
+                    },
+                    "longDescription": "This property shall contain an array of links to resources of type Cable that represent the cables connected to this chassis.",
+                    "readonly": true,
+                    "type": "array",
+                    "versionAdded": "v1_17_0"
+                },
+                "Cables@odata.count": {
+                    "$ref": "http://redfish.dmtf.org/schemas/v1/odata-v4.json#/definitions/count"
+                },
                 "ComputerSystems": {
                     "description": "An array of links to the computer systems that this chassis directly and wholly contains.",
                     "items": {
@@ -903,6 +923,6 @@
         }
     },
     "owningEntity": "DMTF",
-    "release": "2021.1",
-    "title": "#Chassis.v1_16_0.Chassis"
+    "release": "2021.2",
+    "title": "#Chassis.v1_17_0.Chassis"
 }

--- a/static/redfish/v1/JsonSchemas/ComputerSystem/ComputerSystem.json
+++ b/static/redfish/v1/JsonSchemas/ComputerSystem/ComputerSystem.json
@@ -1,5 +1,5 @@
 {
-    "$id": "http://redfish.dmtf.org/schemas/v1/ComputerSystem.v1_15_0.json",
+    "$id": "http://redfish.dmtf.org/schemas/v1/ComputerSystem.v1_16_0.json",
     "$ref": "#/definitions/ComputerSystem",
     "$schema": "http://redfish.dmtf.org/schemas/v1/redfish-schema-v1.json",
     "copyright": "Copyright 2014-2021 DMTF. For the full DMTF copyright policy, see http://www.dmtf.org/about/policies/copyright",
@@ -627,6 +627,19 @@
                     "$ref": "http://redfish.dmtf.org/schemas/v1/Resource.json#/definitions/Id",
                     "readonly": true
                 },
+                "IdlePowerSaver": {
+                    "anyOf": [
+                        {
+                            "$ref": "#/definitions/IdlePowerSaver"
+                        },
+                        {
+                            "type": "null"
+                        }
+                    ],
+                    "description": "The idle power saver settings of the computer system.",
+                    "longDescription": "This property shall contain the idle power saver settings of the computer system.",
+                    "versionAdded": "v1_16_0"
+                },
                 "IndicatorLED": {
                     "anyOf": [
                         {
@@ -641,6 +654,19 @@
                     "longDescription": "This property shall contain the state of the indicator light, which identifies this system.",
                     "readonly": false,
                     "versionDeprecated": "v1_13_0"
+                },
+                "KeyManagement": {
+                    "anyOf": [
+                        {
+                            "$ref": "#/definitions/KeyManagement"
+                        },
+                        {
+                            "type": "null"
+                        }
+                    ],
+                    "description": "The key management settings of the computer system.",
+                    "longDescription": "This property shall contain the key management settings of the computer system.",
+                    "versionAdded": "v1_16_0"
                 },
                 "LastResetTime": {
                     "description": "The date and time when the system was last reset or rebooted.",
@@ -1153,6 +1179,83 @@
             },
             "type": "string"
         },
+        "IdlePowerSaver": {
+            "additionalProperties": false,
+            "description": "The idle power saver settings of a computer system.",
+            "longDescription": "This object shall contain the idle power saver settings of a computer system.",
+            "patternProperties": {
+                "^([a-zA-Z_][a-zA-Z0-9_]*)?@(odata|Redfish|Message)\\.[a-zA-Z_][a-zA-Z0-9_]*$": {
+                    "description": "This property shall specify a valid odata or Redfish property.",
+                    "type": [
+                        "array",
+                        "boolean",
+                        "integer",
+                        "number",
+                        "null",
+                        "object",
+                        "string"
+                    ]
+                }
+            },
+            "properties": {
+                "Enabled": {
+                    "description": "An indication of whether idle power saver is enabled.",
+                    "longDescription": "The value of this property shall indicate if idle power saver is enabled.",
+                    "readonly": false,
+                    "type": "boolean",
+                    "versionAdded": "v1_16_0"
+                },
+                "EnterDwellTimeSeconds": {
+                    "description": "The duration in seconds the computer system is below the EnterUtilizationPercent value before the idle power save is activated.",
+                    "longDescription": "This property shall contain the duration in seconds the computer system is below the EnterUtilizationPercent value before the idle power save is activated.",
+                    "minimum": 0,
+                    "readonly": false,
+                    "type": [
+                        "integer",
+                        "null"
+                    ],
+                    "units": "s",
+                    "versionAdded": "v1_16_0"
+                },
+                "EnterUtilizationPercent": {
+                    "description": "The percentage of utilization that the computer system shall be lower than to enter idle power save.",
+                    "longDescription": "This property shall contain the percentage of utilization that the computer system shall be lower than to enter idle power save.",
+                    "minimum": 0,
+                    "readonly": false,
+                    "type": [
+                        "number",
+                        "null"
+                    ],
+                    "units": "%",
+                    "versionAdded": "v1_16_0"
+                },
+                "ExitDwellTimeSeconds": {
+                    "description": "The duration in seconds the computer system is above the ExitUtilizationPercent value before the idle power save is stopped.",
+                    "longDescription": "This property shall contain the duration in seconds the computer system is above the ExitUtilizationPercent value before the idle power save is stopped.",
+                    "minimum": 0,
+                    "readonly": false,
+                    "type": [
+                        "integer",
+                        "null"
+                    ],
+                    "units": "s",
+                    "versionAdded": "v1_16_0"
+                },
+                "ExitUtilizationPercent": {
+                    "description": "The percentage of utilization that the computer system shall be higher than to exit idle power save.",
+                    "longDescription": "This property shall contain the percentage of utilization that the computer system shall be higher than to exit idle power save.",
+                    "minimum": 0,
+                    "readonly": false,
+                    "type": [
+                        "number",
+                        "null"
+                    ],
+                    "units": "%",
+                    "versionAdded": "v1_16_0"
+                }
+            },
+            "type": "object"
+        },
         "IndicatorLED": {
             "enum": [
                 "Unknown",
@@ -1208,6 +1311,113 @@
                 "OemMethod": "The TrustedModule supports switching InterfaceType through an OEM proprietary mechanism."
             },
             "type": "string"
+        },
+        "KMIPServer": {
+            "additionalProperties": false,
+            "description": "The KMIP server settings for a computer system.",
+            "longDescription": "This object shall contain the KMIP server settings for a computer system.",
+            "patternProperties": {
+                "^([a-zA-Z_][a-zA-Z0-9_]*)?@(odata|Redfish|Message)\\.[a-zA-Z_][a-zA-Z0-9_]*$": {
+                    "description": "This property shall specify a valid odata or Redfish property.",
+                    "type": [
+                        "array",
+                        "boolean",
+                        "integer",
+                        "number",
+                        "null",
+                        "object",
+                        "string"
+                    ]
+                }
+            },
+            "properties": {
+                "Address": {
+                    "description": "The KMIP server address.",
+                    "longDescription": "This property shall contain the KMIP server address.",
+                    "readonly": false,
+                    "type": [
+                        "string",
+                        "null"
+                    ],
+                    "versionAdded": "v1_16_0"
+                },
+                "Password": {
+                    "description": "The password to access the KMIP server.  The value is `null` in responses.",
+                    "longDescription": "This property shall contain the password to access the KMIP server.  The value shall be `null` in responses.",
+                    "readonly": false,
+                    "type": [
+                        "string",
+                        "null"
+                    ],
+                    "versionAdded": "v1_16_0"
+                },
+                "Port": {
+                    "description": "The KMIP server port.",
+                    "longDescription": "This property shall contain the KMIP server port.",
+                    "readonly": false,
+                    "type": [
+                        "integer",
+                        "null"
+                    ],
+                    "versionAdded": "v1_16_0"
+                },
+                "Username": {
+                    "description": "The username to access the KMIP server.",
+                    "longDescription": "This property shall contain the username to access the KMIP server.",
+                    "readonly": false,
+                    "type": [
+                        "string",
+                        "null"
+                    ],
+                    "versionAdded": "v1_16_0"
+                }
+            },
+            "type": "object"
+        },
+        "KeyManagement": {
+            "additionalProperties": false,
+            "description": "The key management settings of a computer system.",
+            "longDescription": "This object shall contain the key management settings of a computer system.",
+            "patternProperties": {
+                "^([a-zA-Z_][a-zA-Z0-9_]*)?@(odata|Redfish|Message)\\.[a-zA-Z_][a-zA-Z0-9_]*$": {
+                    "description": "This property shall specify a valid odata or Redfish property.",
+                    "type": [
+                        "array",
+                        "boolean",
+                        "integer",
+                        "number",
+                        "null",
+                        "object",
+                        "string"
+                    ]
+                }
+            },
+            "properties": {
+                "KMIPCertificates": {
+                    "$ref": "http://redfish.dmtf.org/schemas/v1/CertificateCollection.json#/definitions/CertificateCollection",
+                    "description": "The link to a collection of server certificates for the servers referenced by the KMIPServers property.",
+                    "longDescription": "This property shall contain a link to a resource collection of type CertificateCollection that represents the server certificates for the servers referenced by the KMIPServers property.",
+                    "readonly": true,
+                    "versionAdded": "v1_16_0"
+                },
+                "KMIPServers": {
+                    "description": "The KMIP servers to which this computer system is subscribed.",
+                    "items": {
+                        "anyOf": [
+                            {
+                                "$ref": "#/definitions/KMIPServer"
+                            },
+                            {
+                                "type": "null"
+                            }
+                        ]
+                    },
+                    "longDescription": "This property shall contain the KMIP servers to which this computer system is subscribed for key management.",
+                    "type": "array",
+                    "versionAdded": "v1_16_0"
+                }
+            },
+            "type": "object"
         },
         "Links": {
             "additionalProperties": false,
@@ -1393,8 +1603,10 @@
                 },
                 "Status": {
                     "$ref": "http://redfish.dmtf.org/schemas/v1/Resource.json#/definitions/Status",
+                    "deprecated": "This property has been deprecated in favor of the Conditions property within Status in the root of this resource.",
                     "description": "The status and health of the resource and its subordinate or dependent resources.",
-                    "longDescription": "This property shall contain any status or health properties of the resource."
+                    "longDescription": "This property shall contain any status or health properties of the resource.",
+                    "versionDeprecated": "v1_16_0"
                 },
                 "TotalSystemMemoryGiB": {
                     "description": "The total configured operating system-accessible memory (RAM), measured in GiB.",
@@ -1568,8 +1780,10 @@
                 },
                 "Status": {
                     "$ref": "http://redfish.dmtf.org/schemas/v1/Resource.json#/definitions/Status",
+                    "deprecated": "This property has been deprecated in favor of the Conditions property within Status in the root of this resource.",
                     "description": "The status and health of the resource and its subordinate or dependent resources.",
-                    "longDescription": "This property shall contain any status or health properties of the resource."
+                    "longDescription": "This property shall contain any status or health properties of the resource.",
+                    "versionDeprecated": "v1_16_0"
                 },
                 "ThreadingEnabled": {
                     "description": "An indication of whether threading is enabled on all processors in this system.",
@@ -1791,10 +2005,12 @@
                 "OS",
                 "PhysicallyPartitioned",
                 "VirtuallyPartitioned",
-                "Composed"
+                "Composed",
+                "DPU"
             ],
             "enumDescriptions": {
                 "Composed": "A computer system constructed by binding resource blocks together.",
+                "DPU": "A computer system that performs the functions of a data processing unit, such as a SmartNIC.",
                 "OS": "An operating system instance.",
                 "Physical": "A computer system.",
                 "PhysicallyPartitioned": "A hardware-based partition of a computer system.",
@@ -1803,6 +2019,7 @@
             },
             "enumLongDescriptions": {
                 "Composed": "A SystemType of Composed typically represents a single system constructed from disaggregated resources through the Redfish composition service.",
+                "DPU": "A SystemType of DPU typically represents a single system that performs offload computation as a data processing unit, such as a SmartNIC.",
                 "OS": "A SystemType of OS typically represents an OS or hypervisor view of the system.",
                 "Physical": "A SystemType of Physical typically represents the hardware aspects of a system, such as a management controller.",
                 "PhysicallyPartitioned": "A SystemType of PhysicallyPartitioned typically represents a single system constructed from one or more physical systems through a firmware or hardware-based service.",
@@ -1810,7 +2027,8 @@
                 "VirtuallyPartitioned": "A SystemType of VirtuallyPartitioned typically represents a single system constructed from one or more virtual systems through a software-based service."
             },
             "enumVersionAdded": {
-                "Composed": "v1_4_0"
+                "Composed": "v1_4_0",
+                "DPU": "v1_16_0"
             },
             "type": "string"
         },
@@ -2067,6 +2285,6 @@
         }
     },
     "owningEntity": "DMTF",
-    "release": "2021.1",
-    "title": "#ComputerSystem.v1_15_0.ComputerSystem"
+    "release": "2021.2",
+    "title": "#ComputerSystem.v1_16_0.ComputerSystem"
 }

--- a/static/redfish/v1/JsonSchemas/Drive/Drive.json
+++ b/static/redfish/v1/JsonSchemas/Drive/Drive.json
@@ -1,5 +1,5 @@
 {
-    "$id": "http://redfish.dmtf.org/schemas/v1/Drive.v1_12_1.json",
+    "$id": "http://redfish.dmtf.org/schemas/v1/Drive.v1_13_0.json",
     "$ref": "#/definitions/Drive",
     "$schema": "http://redfish.dmtf.org/schemas/v1/redfish-schema-v1.json",
     "copyright": "Copyright 2014-2021 DMTF. For the full DMTF copyright policy, see http://www.dmtf.org/about/policies/copyright",
@@ -202,9 +202,9 @@
                             "type": "null"
                         }
                     ],
-                    "description": "The type of hot spare that this drive currently serves as.",
+                    "description": "The type of hot spare that this drive serves as.",
                     "longDescription": "This property shall contain the hot spare type for the associated drive.  If the drive currently serves as a hot spare, its Status.State field shall be 'StandbySpare' and 'Enabled' when it is part of a volume.",
-                    "readonly": true
+                    "readonly": false
                 },
                 "Id": {
                     "$ref": "http://redfish.dmtf.org/schemas/v1/Resource.json#/definitions/Id",
@@ -516,10 +516,10 @@
                 "Dedicated"
             ],
             "enumDescriptions": {
-                "Chassis": "The drive is currently serving as a hot spare for all other drives in the chassis.",
-                "Dedicated": "The drive is currently serving as a hot spare for a user-defined set of drives.",
-                "Global": "The drive is currently serving as a hot spare for all other drives in the storage system.",
-                "None": "The drive is not currently a hot spare."
+                "Chassis": "The drive is serving as a hot spare for all other drives in this storage domain that are contained in the same chassis.",
+                "Dedicated": "The drive is serving as a hot spare for a user-defined set of drives or volumes.  Clients cannot specify this value when modifying the HotspareType property.  This value is reported as a result of configuring the spare drives within a volume.",
+                "Global": "The drive is serving as a hot spare for all other drives in this storage domain.",
+                "None": "The drive is not a hot spare."
             },
             "type": "string"
         },
@@ -578,6 +578,13 @@
                 },
                 "PCIeFunctions@odata.count": {
                     "$ref": "http://redfish.dmtf.org/schemas/v1/odata-v4.json#/definitions/count"
+                },
+                "Storage": {
+                    "$ref": "http://redfish.dmtf.org/schemas/v1/Storage.json#/definitions/Storage",
+                    "description": "A link to the storage subsystem to which this drive belongs.",
+                    "longDescription": "This property shall contain a link to a resource of type Storage that represents the storage subsystem to which this drive belongs.",
+                    "readonly": true,
+                    "versionAdded": "v1_13_0"
                 },
                 "StoragePools": {
                     "description": "An array of links to the storage pools to which this drive belongs.",
@@ -785,6 +792,6 @@
         }
     },
     "owningEntity": "DMTF",
-    "release": "2020.4",
-    "title": "#Drive.v1_12_1.Drive"
+    "release": "2021.2",
+    "title": "#Drive.v1_13_0.Drive"
 }

--- a/static/redfish/v1/JsonSchemas/EthernetInterface/EthernetInterface.json
+++ b/static/redfish/v1/JsonSchemas/EthernetInterface/EthernetInterface.json
@@ -1,5 +1,5 @@
 {
-    "$id": "http://redfish.dmtf.org/schemas/v1/EthernetInterface.v1_6_4.json",
+    "$id": "http://redfish.dmtf.org/schemas/v1/EthernetInterface.v1_7_0.json",
     "$ref": "#/definitions/EthernetInterface",
     "$schema": "http://redfish.dmtf.org/schemas/v1/redfish-schema-v1.json",
     "copyright": "Copyright 2014-2021 DMTF. For the full DMTF copyright policy, see http://www.dmtf.org/about/policies/copyright",
@@ -597,9 +597,11 @@
                 },
                 "VLANs": {
                     "$ref": "http://redfish.dmtf.org/schemas/v1/VLanNetworkInterfaceCollection.json#/definitions/VLanNetworkInterfaceCollection",
+                    "deprecated": "This property has been deprecated in favor of newer methods indicating multiple VLANs.",
                     "description": "The link to a collection of VLANs, which applies only if the interface supports more than one VLAN.  If this property applies, the VLANEnabled and VLANId properties do not apply.",
                     "longDescription": "This property shall contain a link to a resource collection of type VLanNetworkInterfaceCollection, which applies only if the interface supports more than one VLAN.  If this property is present, the VLANEnabled and VLANId properties shall not be present.",
-                    "readonly": true
+                    "readonly": true,
+                    "versionDeprecated": "v1_7_0"
                 }
             },
             "required": [
@@ -731,10 +733,25 @@
                             "type": "null"
                         }
                     ],
+                    "deprecated": "This property has been deprecated in favor of NetworkDeviceFunctions as each EthernetInterface could represent more than one NetworkDeviceFunction.",
                     "description": "The link to the parent network device function and is only used when representing one of the VLANs on that network device function, such as is done in Unix.",
                     "longDescription": "This property shall contain a link to a resource of type NetworkDeviceFunction and only be populated with the EthernetInterfaceType property is `Virtual`.",
                     "readonly": true,
-                    "versionAdded": "v1_6_0"
+                    "versionAdded": "v1_6_0",
+                    "versionDeprecated": "v1_7_0"
+                },
+                "NetworkDeviceFunctions": {
+                    "description": "The link to the network device functions that comprise this Ethernet interface.",
+                    "items": {
+                        "$ref": "http://redfish.dmtf.org/schemas/v1/NetworkDeviceFunction.json#/definitions/NetworkDeviceFunction"
+                    },
+                    "longDescription": "This property shall contain an array of links to resources of type NetworkDeviceFunction.",
+                    "readonly": true,
+                    "type": "array",
+                    "versionAdded": "v1_7_0"
+                },
+                "NetworkDeviceFunctions@odata.count": {
+                    "$ref": "http://redfish.dmtf.org/schemas/v1/odata-v4.json#/definitions/count"
                 },
                 "Oem": {
                     "$ref": "http://redfish.dmtf.org/schemas/v1/Resource.json#/definitions/Oem",
@@ -813,6 +830,6 @@
         }
     },
     "owningEntity": "DMTF",
-    "release": "2020.1",
-    "title": "#EthernetInterface.v1_6_4.EthernetInterface"
+    "release": "2021.2",
+    "title": "#EthernetInterface.v1_7_0.EthernetInterface"
 }

--- a/static/redfish/v1/JsonSchemas/Event/Event.json
+++ b/static/redfish/v1/JsonSchemas/Event/Event.json
@@ -1,8 +1,8 @@
 {
-    "$id": "http://redfish.dmtf.org/schemas/v1/Event.v1_6_1.json",
+    "$id": "http://redfish.dmtf.org/schemas/v1/Event.v1_7_0.json",
     "$ref": "#/definitions/Event",
     "$schema": "http://redfish.dmtf.org/schemas/v1/redfish-schema-v1.json",
-    "copyright": "Copyright 2014-2020 DMTF. For the full DMTF copyright policy, see http://www.dmtf.org/about/policies/copyright",
+    "copyright": "Copyright 2014-2021 DMTF. For the full DMTF copyright policy, see http://www.dmtf.org/about/policies/copyright",
     "definitions": {
         "Actions": {
             "additionalProperties": false,
@@ -174,9 +174,16 @@
                     "readonly": true,
                     "versionDeprecated": "v1_3_0"
                 },
+                "LogEntry": {
+                    "$ref": "http://redfish.dmtf.org/schemas/v1/LogEntry.json#/definitions/LogEntry",
+                    "description": "The link to a log entry if an entry was created for this event.",
+                    "longDescription": "This property shall contain a link to a resource of type LogEntry that represents the log entry created for this event.",
+                    "readonly": true,
+                    "versionAdded": "v1_7_0"
+                },
                 "MemberId": {
-                    "description": "The identifier for the member within the collection.",
-                    "longDescription": "This property shall uniquely identify the member within the collection.  For services supporting Redfish v1.6 or higher, this value shall contain the zero-based array index.",
+                    "description": "The unique identifier for the member within an array.",
+                    "longDescription": "This property shall contain the unique identifier for this member within an array.  For services supporting Redfish v1.6 or higher, this value shall contain the zero-based array index.",
                     "readonly": true,
                     "type": "string"
                 },
@@ -315,6 +322,6 @@
         }
     },
     "owningEntity": "DMTF",
-    "release": "2020.3",
-    "title": "#Event.v1_6_1.Event"
+    "release": "2021.2",
+    "title": "#Event.v1_7_0.Event"
 }

--- a/static/redfish/v1/JsonSchemas/EventDestination/EventDestination.json
+++ b/static/redfish/v1/JsonSchemas/EventDestination/EventDestination.json
@@ -1,5 +1,5 @@
 {
-    "$id": "http://redfish.dmtf.org/schemas/v1/EventDestination.v1_10_1.json",
+    "$id": "http://redfish.dmtf.org/schemas/v1/EventDestination.v1_11_0.json",
     "$ref": "#/definitions/EventDestination",
     "$schema": "http://redfish.dmtf.org/schemas/v1/redfish-schema-v1.json",
     "copyright": "Copyright 2014-2021 DMTF. For the full DMTF copyright policy, see http://www.dmtf.org/about/policies/copyright",
@@ -103,6 +103,13 @@
                     "readonly": true,
                     "versionAdded": "v1_9_0"
                 },
+                "ClientCertificates": {
+                    "$ref": "http://redfish.dmtf.org/schemas/v1/CertificateCollection.json#/definitions/CertificateCollection",
+                    "description": "The link to a collection of client identity certificates provided to the server referenced by the Destination property.",
+                    "longDescription": "This property shall contain a link to a resource collection of type CertificateCollection that represents the client identity certificates that are provided to the server referenced by the Destination property as part of TLS handshaking.",
+                    "readonly": true,
+                    "versionAdded": "v1_11_0"
+                },
                 "Context": {
                     "description": "A client-supplied string that is stored with the event destination subscription.",
                     "longDescription": "This property shall contain a client-supplied context that remains with the connection through the connection's lifetime.",
@@ -168,6 +175,18 @@
                     "readonly": true,
                     "type": "array",
                     "versionDeprecated": "v1_5_0"
+                },
+                "HeartbeatIntervalMinutes": {
+                    "description": "Interval for sending heartbeat events to the destination in minutes.",
+                    "longDescription": "This property shall indicate the interval for sending periodic heartbeat events to the subscriber.  The value shall be the interval, in minutes, between each periodic event.  This property shall not be present if the SendHeartbeat property is not present.",
+                    "maximum": 65535,
+                    "minimum": 1,
+                    "readonly": true,
+                    "type": [
+                        "integer",
+                        "null"
+                    ],
+                    "versionAdded": "v1_11_0"
                 },
                 "HttpHeaders": {
                     "description": "An array of settings for HTTP headers, such as authorization information.  This array is null or an empty array in responses.  An empty array is the preferred return value on read operations.",
@@ -291,6 +310,16 @@
                     "longDescription": "This property shall contain the settings for an SNMP event destination.",
                     "versionAdded": "v1_7_0"
                 },
+                "SendHeartbeat": {
+                    "description": "Send a heartbeat event periodically to the destination.",
+                    "longDescription": "This property shall indicate that the service shall periodically send the `RedfishServiceFunctional` message defined in the Heartbeat Event Message Registry to the subscriber.  If this property is not present, no periodic event shall be sent.  This property shall not apply to event destinations if the SubscriptionType property contains the value `SSE`.",
+                    "readonly": true,
+                    "type": [
+                        "boolean",
+                        "null"
+                    ],
+                    "versionAdded": "v1_11_0"
+                },
                 "Status": {
                     "$ref": "http://redfish.dmtf.org/schemas/v1/Resource.json#/definitions/Status",
                     "description": "This property shall contain the status of the subscription.",
@@ -322,7 +351,7 @@
                     "versionAdded": "v1_3_0"
                 },
                 "SyslogFilters": {
-                    "description": "A list of syslog message filters to send to a remote syslog server.",
+                    "description": "A list of filters applied to syslog messages before sending to a remote syslog server.  An empty list indicates all syslog messages are sent.",
                     "items": {
                         "anyOf": [
                             {
@@ -812,6 +841,6 @@
         }
     },
     "owningEntity": "DMTF",
-    "release": "2020.4",
-    "title": "#EventDestination.v1_10_1.EventDestination"
+    "release": "2021.2",
+    "title": "#EventDestination.v1_11_0.EventDestination"
 }

--- a/static/redfish/v1/JsonSchemas/EventService/EventService.json
+++ b/static/redfish/v1/JsonSchemas/EventService/EventService.json
@@ -1,8 +1,8 @@
 {
-    "$id": "http://redfish.dmtf.org/schemas/v1/EventService.v1_7_1.json",
+    "$id": "http://redfish.dmtf.org/schemas/v1/EventService.v1_7_2.json",
     "$ref": "#/definitions/EventService",
     "$schema": "http://redfish.dmtf.org/schemas/v1/redfish-schema-v1.json",
-    "copyright": "Copyright 2014-2020 DMTF. For the full DMTF copyright policy, see http://www.dmtf.org/about/policies/copyright",
+    "copyright": "Copyright 2014-2021 DMTF. For the full DMTF copyright policy, see http://www.dmtf.org/about/policies/copyright",
     "definitions": {
         "Actions": {
             "additionalProperties": false,
@@ -192,8 +192,8 @@
                     "versionAdded": "v1_1_0"
                 },
                 "ServiceEnabled": {
-                    "description": "An indication of whether this service is enabled.",
-                    "longDescription": "This property shall indicate whether this service is enabled.",
+                    "description": "An indication of whether this service is enabled.  If `false`, events are no longer published, new SSE connections cannot be established, and existing SSE connections are terminated.",
+                    "longDescription": "This property shall indicate whether this service is enabled.  If `false`, events are no longer published, new SSE connections cannot be established, and existing SSE connections are terminated.",
                     "readonly": false,
                     "type": [
                         "boolean",
@@ -584,5 +584,5 @@
     },
     "owningEntity": "DMTF",
     "release": "2020.2",
-    "title": "#EventService.v1_7_1.EventService"
+    "title": "#EventService.v1_7_2.EventService"
 }

--- a/static/redfish/v1/JsonSchemas/LogService/LogService.json
+++ b/static/redfish/v1/JsonSchemas/LogService/LogService.json
@@ -1,13 +1,13 @@
 {
-    "$id": "http://redfish.dmtf.org/schemas/v1/LogService.v1_2_0.json",
+    "$id": "http://redfish.dmtf.org/schemas/v1/LogService.v1_3_0.json",
     "$ref": "#/definitions/LogService",
     "$schema": "http://redfish.dmtf.org/schemas/v1/redfish-schema-v1.json",
-    "copyright": "Copyright 2014-2020 DMTF. For the full DMTF copyright policy, see http://www.dmtf.org/about/policies/copyright",
+    "copyright": "Copyright 2014-2021 DMTF. For the full DMTF copyright policy, see http://www.dmtf.org/about/policies/copyright",
     "definitions": {
         "Actions": {
             "additionalProperties": false,
-            "description": "The available actions for this Resource.",
-            "longDescription": "This type shall contain the available actions for this Resource.",
+            "description": "The available actions for this resource.",
+            "longDescription": "This type shall contain the available actions for this resource.",
             "patternProperties": {
                 "^([a-zA-Z_][a-zA-Z0-9_]*)?@(odata|Redfish|Message)\\.[a-zA-Z_][a-zA-Z0-9_]*$": {
                     "description": "This property shall specify a valid odata or Redfish property.",
@@ -31,17 +31,24 @@
                 },
                 "Oem": {
                     "$ref": "#/definitions/OemActions",
-                    "description": "The available OEM-specific actions for this Resource.",
-                    "longDescription": "This property shall contain the available OEM-specific actions for this Resource."
+                    "description": "The available OEM-specific actions for this resource.",
+                    "longDescription": "This property shall contain the available OEM-specific actions for this resource."
                 }
             },
             "type": "object"
         },
         "ClearLog": {
             "additionalProperties": false,
-            "description": "The action to clear the log for this Log Service.",
-            "longDescription": "This action shall delete all entries found in the Entries collection for this Log Service.",
-            "parameters": {},
+            "description": "The action to clear the log for this log service.",
+            "longDescription": "This action shall delete all entries found in the LogEntryCollection resource for this log service.",
+            "parameters": {
+                "LogEntriesETag": {
+                    "description": "The ETag of the log entry collection within this log service.  If the provided ETag does not match the current ETag of the log entry collection, the request is rejected.",
+                    "longDescription": "This parameter shall contain the ETag of the LogEntryCollection resource for this log service.  If the client-provided ETag does not match the current ETag of the LogEntryCollection resource for this log service, the service shall return the HTTP 428 (Precondition Required) status code to reject the request.",
+                    "type": "string",
+                    "versionAdded": "v1_3_0"
+                }
+            },
             "patternProperties": {
                 "^([a-zA-Z_][a-zA-Z0-9_]*)?@(odata|Redfish|Message)\\.[a-zA-Z_][a-zA-Z0-9_]*$": {
                     "description": "This property shall specify a valid odata or Redfish property.",
@@ -138,7 +145,7 @@
             ],
             "enumDescriptions": {
                 "Event": "The log contains Redfish-defined messages.",
-                "Multiple": "The log contains multiple log entry types and, therefore, the Log Service cannot guarantee a single entry type.",
+                "Multiple": "The log contains multiple log entry types and, therefore, the log service cannot guarantee a single entry type.",
                 "OEM": "The log contains entries in an OEM-defined format.",
                 "SEL": "The log contains legacy IPMI System Event Log (SEL) entries."
             },
@@ -146,8 +153,8 @@
         },
         "LogService": {
             "additionalProperties": false,
-            "description": "The LogService schema contains properties for monitoring and configuring a Log Service.",
-            "longDescription": "This Resource shall represent a Log Service for a Redfish implementation.",
+            "description": "The LogService schema contains properties for monitoring and configuring a log service.  When the Id property contains `DeviceLog`, the log contains device-resident log entries that follow the physical device when moved from system-to-system, and not a replication or subset of a system event log.",
+            "longDescription": "This resource shall represent a log service for a Redfish implementation.  When the Id property contains `DeviceLog`, the log shall contain log entries that migrate with the device.",
             "patternProperties": {
                 "^([a-zA-Z_][a-zA-Z0-9_]*)?@(odata|Redfish|Message)\\.[a-zA-Z_][a-zA-Z0-9_]*$": {
                     "description": "This property shall specify a valid odata or Redfish property.",
@@ -177,13 +184,20 @@
                 },
                 "Actions": {
                     "$ref": "#/definitions/Actions",
-                    "description": "The available actions for this Resource.",
-                    "longDescription": "This property shall contain the available actions for this Resource."
+                    "description": "The available actions for this resource.",
+                    "longDescription": "This property shall contain the available actions for this resource."
+                },
+                "AutoDSTEnabled": {
+                    "description": "An indication of whether the log service is configured for automatic Daylight Saving Time (DST) adjustment.",
+                    "longDescription": "This property shall indicate whether the log service is configured for automatic Daylight Saving Time (DST) adjustment.  DST adjustment shall not modify the timestamp of existing log entries.",
+                    "readonly": false,
+                    "type": "boolean",
+                    "versionAdded": "v1_3_0"
                 },
                 "DateTime": {
-                    "description": "The current date and time, with UTC offset, that the Log Service uses to set or read time.",
+                    "description": "The current date and time with UTC offset of the log service.",
                     "format": "date-time",
-                    "longDescription": "This property shall represent the current DateTime value, with UTC offset, in Redfish Timestamp format that the Log Service uses to set or read time.",
+                    "longDescription": "This property shall contain the current date and time with UTC offset of the log service.",
                     "readonly": false,
                     "type": [
                         "string",
@@ -191,8 +205,8 @@
                     ]
                 },
                 "DateTimeLocalOffset": {
-                    "description": "The UTC offset that the current DateTime property value contains in the `+HH:MM` format.",
-                    "longDescription": "This property shall represent the UTC offset that the current DateTime property value contains.",
+                    "description": "The time offset from UTC that the DateTime property is in `+HH:MM` format.",
+                    "longDescription": "This property shall contain the offset from UTC time that the DateTime property contains.  If both DateTime and DateTimeLocalOffset are provided in modification requests, services shall apply DateTimeLocalOffset after DateTime is applied.",
                     "pattern": "^([-+][0-1][0-9]:[0-5][0-9])$",
                     "readonly": false,
                     "type": [
@@ -214,7 +228,7 @@
                 "Entries": {
                     "$ref": "http://redfish.dmtf.org/schemas/v1/LogEntryCollection.json#/definitions/LogEntryCollection",
                     "description": "The link to the log entry collection.",
-                    "longDescription": "This property shall contain a link to a Resource Collection of type LogEntryCollection.",
+                    "longDescription": "This property shall contain a link to a resource collection of type LogEntryCollection.",
                     "readonly": true
                 },
                 "Id": {
@@ -231,13 +245,13 @@
                         }
                     ],
                     "description": "The format of the log entries.",
-                    "longDescription": "This property shall represent the EntryType of all LogEntry Resources contained in the Entries collection.  If the service cannot determine or guarantee a single EntryType for all LogEntry Resources, this property's value shall be `Multiple`.",
+                    "longDescription": "This property shall contain the value for the EntryType property of all LogEntry resources contained in the LogEntryCollection resource for this log service.  If the service cannot determine or guarantee a single EntryType value for all LogEntry resources, this property shall contain the value `Multiple`.",
                     "readonly": true,
                     "versionAdded": "v1_1_0"
                 },
                 "MaxNumberOfRecords": {
                     "description": "The maximum number of log entries that this service can have.",
-                    "longDescription": "This property shall contain the maximum number of LogEntry Resources in the Entries collection for this service.",
+                    "longDescription": "This property shall contain the maximum number of LogEntry resources in the LogEntryCollection resource for this service.",
                     "minimum": 0,
                     "readonly": true,
                     "type": "integer"
@@ -254,7 +268,7 @@
                 "OverWritePolicy": {
                     "$ref": "#/definitions/OverWritePolicy",
                     "description": "The overwrite policy for this service that takes place when the log is full.",
-                    "longDescription": "This property shall indicate the policy of the Log Service when the MaxNumberOfRecords has been reached.",
+                    "longDescription": "This property shall indicate the policy of the log service when the MaxNumberOfRecords has been reached.",
                     "readonly": true
                 },
                 "ServiceEnabled": {
@@ -268,8 +282,8 @@
                 },
                 "Status": {
                     "$ref": "http://redfish.dmtf.org/schemas/v1/Resource.json#/definitions/Status",
-                    "description": "The status and health of the Resource and its subordinate or dependent Resources.",
-                    "longDescription": "This property shall contain any status or health properties of the Resource."
+                    "description": "The status and health of the resource and its subordinate or dependent resources.",
+                    "longDescription": "This property shall contain any status or health properties of the resource."
                 },
                 "SyslogFilters": {
                     "description": "A list of syslog message filters to be logged locally.",
@@ -298,8 +312,8 @@
         },
         "OemActions": {
             "additionalProperties": true,
-            "description": "The available OEM-specific actions for this Resource.",
-            "longDescription": "This type shall contain the available OEM-specific actions for this Resource.",
+            "description": "The available OEM-specific actions for this resource.",
+            "longDescription": "This type shall contain the available OEM-specific actions for this resource.",
             "patternProperties": {
                 "^([a-zA-Z_][a-zA-Z0-9_]*)?@(odata|Redfish|Message)\\.[a-zA-Z_][a-zA-Z0-9_]*$": {
                     "description": "This property shall specify a valid odata or Redfish property.",
@@ -469,6 +483,6 @@
         }
     },
     "owningEntity": "DMTF",
-    "release": "2020.3",
-    "title": "#LogService.v1_2_0.LogService"
+    "release": "2021.2",
+    "title": "#LogService.v1_3_0.LogService"
 }

--- a/static/redfish/v1/JsonSchemas/Manager/Manager.json
+++ b/static/redfish/v1/JsonSchemas/Manager/Manager.json
@@ -1,5 +1,5 @@
 {
-    "$id": "http://redfish.dmtf.org/schemas/v1/Manager.v1_12_0.json",
+    "$id": "http://redfish.dmtf.org/schemas/v1/Manager.v1_13_0.json",
     "$ref": "#/definitions/Manager",
     "$schema": "http://redfish.dmtf.org/schemas/v1/redfish-schema-v1.json",
     "copyright": "Copyright 2014-2021 DMTF. For the full DMTF copyright policy, see http://www.dmtf.org/about/policies/copyright",
@@ -356,15 +356,22 @@
                     "type": "boolean",
                     "versionAdded": "v1_4_0"
                 },
+                "Certificates": {
+                    "$ref": "http://redfish.dmtf.org/schemas/v1/CertificateCollection.json#/definitions/CertificateCollection",
+                    "description": "The link to a collection of certificates for device identity and attestation.",
+                    "longDescription": "This property shall contain a link to a resource collection of type CertificateCollection that contains certificates for device identity and attestation.",
+                    "readonly": true,
+                    "versionAdded": "v1_13_0"
+                },
                 "CommandShell": {
                     "$ref": "#/definitions/CommandShell",
                     "description": "The command shell service that this manager provides.",
                     "longDescription": "This property shall contain information about the command shell service of this manager."
                 },
                 "DateTime": {
-                    "description": "The current date and time with UTC offset that the manager uses to set or read time.",
+                    "description": "The current date and time with UTC offset of the manager.",
                     "format": "date-time",
-                    "longDescription": "This property shall represent the current DateTime value for the manager, with UTC offset, in Redfish Timestamp format.",
+                    "longDescription": "This property shall contain the current date and time with UTC offset of the manager.",
                     "readonly": false,
                     "type": [
                         "string",
@@ -373,7 +380,7 @@
                 },
                 "DateTimeLocalOffset": {
                     "description": "The time offset from UTC that the DateTime property is in `+HH:MM` format.",
-                    "longDescription": "This property shall represent the offset from UTC time that the current DateTime property contains.",
+                    "longDescription": "This property shall contain the offset from UTC time that the DateTime property contains.  If both DateTime and DateTimeLocalOffset are provided in modification requests, services shall apply DateTimeLocalOffset after DateTime is applied.",
                     "pattern": "^([-+][0-1][0-9]:[0-5][0-9])$",
                     "readonly": false,
                     "type": [
@@ -473,6 +480,15 @@
                         "null"
                     ],
                     "versionAdded": "v1_7_0"
+                },
+                "Measurements": {
+                    "description": "An array of DSP0274-defined measurement blocks.",
+                    "items": {
+                        "$ref": "http://redfish.dmtf.org/schemas/v1/SoftwareInventory.json#/definitions/MeasurementBlock"
+                    },
+                    "longDescription": "This property shall contain an array of DSP0274-defined measurement blocks.",
+                    "type": "array",
+                    "versionAdded": "v1_13_0"
                 },
                 "Model": {
                     "description": "The model information of this manager, as defined by the manufacturer.",
@@ -924,6 +940,6 @@
         }
     },
     "owningEntity": "DMTF",
-    "release": "2021.1",
-    "title": "#Manager.v1_12_0.Manager"
+    "release": "2021.2",
+    "title": "#Manager.v1_13_0.Manager"
 }

--- a/static/redfish/v1/JsonSchemas/ManagerNetworkProtocol/ManagerNetworkProtocol.json
+++ b/static/redfish/v1/JsonSchemas/ManagerNetworkProtocol/ManagerNetworkProtocol.json
@@ -1,8 +1,8 @@
 {
-    "$id": "http://redfish.dmtf.org/schemas/v1/ManagerNetworkProtocol.v1_7_0.json",
+    "$id": "http://redfish.dmtf.org/schemas/v1/ManagerNetworkProtocol.v1_8_0.json",
     "$ref": "#/definitions/ManagerNetworkProtocol",
     "$schema": "http://redfish.dmtf.org/schemas/v1/redfish-schema-v1.json",
-    "copyright": "Copyright 2014-2020 DMTF. For the full DMTF copyright policy, see http://www.dmtf.org/about/policies/copyright",
+    "copyright": "Copyright 2014-2021 DMTF. For the full DMTF copyright policy, see http://www.dmtf.org/about/policies/copyright",
     "definitions": {
         "Actions": {
             "additionalProperties": false,
@@ -252,6 +252,19 @@
                     "description": "The OEM extension property.",
                     "longDescription": "This property shall contain the OEM extensions.  All values for properties that this object contains shall conform to the Redfish Specification-described requirements."
                 },
+                "Proxy": {
+                    "anyOf": [
+                        {
+                            "$ref": "#/definitions/ProxyConfiguration"
+                        },
+                        {
+                            "type": "null"
+                        }
+                    ],
+                    "description": "The HTTP/HTTPS proxy information for this manager.",
+                    "longDescription": "This property shall contain the HTTP/HTTPS proxy configuration for this manager.",
+                    "versionAdded": "v1_8_0"
+                },
                 "RDP": {
                     "$ref": "#/definitions/Protocol",
                     "description": "The settings for this manager's Remote Desktop Protocol support.",
@@ -428,6 +441,91 @@
                         "boolean",
                         "null"
                     ]
+                }
+            },
+            "type": "object"
+        },
+        "ProxyConfiguration": {
+            "additionalProperties": false,
+            "description": "The HTTP/HTTPS proxy information for a manager.",
+            "longDescription": "This property shall contain the HTTP/HTTPS proxy configuration for a manager.",
+            "patternProperties": {
+                "^([a-zA-Z_][a-zA-Z0-9_]*)?@(odata|Redfish|Message)\\.[a-zA-Z_][a-zA-Z0-9_]*$": {
+                    "description": "This property shall specify a valid odata or Redfish property.",
+                    "type": [
+                        "array",
+                        "boolean",
+                        "integer",
+                        "number",
+                        "null",
+                        "object",
+                        "string"
+                    ]
+                }
+            },
+            "properties": {
+                "Enabled": {
+                    "description": "Indicates if the manager uses the proxy server.",
+                    "longDescription": "This property shall indicate if the proxy server is used for communications.",
+                    "readonly": false,
+                    "type": "boolean",
+                    "versionAdded": "v1_8_0"
+                },
+                "ExcludeAddresses": {
+                    "description": "Addresses that do not require the proxy server to access.",
+                    "items": {
+                        "type": [
+                            "string",
+                            "null"
+                        ]
+                    },
+                    "longDescription": "This property shall contain a list of hostnames or IP addresses that do not require a connection through the proxy server to access.",
+                    "readonly": false,
+                    "type": "array",
+                    "versionAdded": "v1_8_0"
+                },
+                "Password": {
+                    "description": "The password for the proxy.  The value is `null` in responses.",
+                    "longDescription": "This property shall contain the password for this proxy.  The value shall be `null` in responses.",
+                    "readonly": false,
+                    "type": [
+                        "string",
+                        "null"
+                    ],
+                    "versionAdded": "v1_8_0"
+                },
+                "PasswordSet": {
+                    "description": "Indicates if the Password property is set.",
+                    "longDescription": "This property shall contain `true` if a valid value was provided for the Password property.  Otherwise, the property shall contain `false`.",
+                    "readonly": true,
+                    "type": "boolean",
+                    "versionAdded": "v1_8_0"
+                },
+                "ProxyAutoConfigURI": {
+                    "description": "The URI used to access a proxy auto-configuration (PAC) file.",
+                    "format": "uri-reference",
+                    "longDescription": "This property shall contain the URI at which to access a proxy auto-configuration (PAC) file containing one or more JavaScript functions for configuring proxy usage for this manager.",
+                    "readonly": false,
+                    "type": [
+                        "string",
+                        "null"
+                    ],
+                    "versionAdded": "v1_8_0"
+                },
+                "ProxyServerURI": {
+                    "description": "The URI of the proxy server, including the scheme and any non-default port value.",
+                    "format": "uri-reference",
+                    "longDescription": "This property shall contain the URI of the proxy server.  The value shall contain the scheme for accessing the server, and shall include the port if the value is not the default port for the specified scheme.",
+                    "readonly": false,
+                    "type": "string",
+                    "versionAdded": "v1_8_0"
+                },
+                "Username": {
+                    "description": "The username for the proxy.",
+                    "longDescription": "This property shall contain the username for this proxy.",
+                    "readonly": false,
+                    "type": "string",
+                    "versionAdded": "v1_8_0"
                 }
             },
             "type": "object"
@@ -792,6 +890,6 @@
         }
     },
     "owningEntity": "DMTF",
-    "release": "2020.4",
-    "title": "#ManagerNetworkProtocol.v1_7_0.ManagerNetworkProtocol"
+    "release": "2021.2",
+    "title": "#ManagerNetworkProtocol.v1_8_0.ManagerNetworkProtocol"
 }

--- a/static/redfish/v1/JsonSchemas/Memory/Memory.json
+++ b/static/redfish/v1/JsonSchemas/Memory/Memory.json
@@ -1,5 +1,5 @@
 {
-    "$id": "http://redfish.dmtf.org/schemas/v1/Memory.v1_12_0.json",
+    "$id": "http://redfish.dmtf.org/schemas/v1/Memory.v1_13_0.json",
     "$ref": "#/definitions/Memory",
     "$schema": "http://redfish.dmtf.org/schemas/v1/redfish-schema-v1.json",
     "copyright": "Copyright 2014-2021 DMTF. For the full DMTF copyright policy, see http://www.dmtf.org/about/policies/copyright",
@@ -465,6 +465,13 @@
                     ],
                     "versionAdded": "v1_10_0"
                 },
+                "Log": {
+                    "$ref": "http://redfish.dmtf.org/schemas/v1/LogService.json#/definitions/LogService",
+                    "description": "The link to the log service associated with this memory.",
+                    "longDescription": "This property shall contain a link to a resource of type LogService.",
+                    "readonly": true,
+                    "versionAdded": "v1_13_0"
+                },
                 "LogicalSizeMiB": {
                     "description": "Total size of the logical memory in MiB.",
                     "longDescription": "This property shall contain the total size of the logical memory in MiB.",
@@ -642,6 +649,21 @@
                         "null"
                     ],
                     "units": "MHz"
+                },
+                "OperatingSpeedRangeMHz": {
+                    "anyOf": [
+                        {
+                            "$ref": "http://redfish.dmtf.org/schemas/v1/Control.json#/definitions/ControlRangeExcerpt"
+                        },
+                        {
+                            "type": "null"
+                        }
+                    ],
+                    "description": "Range of allowed operating speeds (MHz).",
+                    "excerptCopy": "ControlRangeExcerpt",
+                    "longDescription": "This property shall contain the operating speed control excerpt for this resource.",
+                    "readonly": false,
+                    "versionAdded": "v1_13_0"
                 },
                 "PartNumber": {
                     "description": "The product part number of this device.",
@@ -1554,6 +1576,6 @@
         }
     },
     "owningEntity": "DMTF",
-    "release": "2021.1",
-    "title": "#Memory.v1_12_0.Memory"
+    "release": "2021.2",
+    "title": "#Memory.v1_13_0.Memory"
 }

--- a/static/redfish/v1/JsonSchemas/Processor/Processor.json
+++ b/static/redfish/v1/JsonSchemas/Processor/Processor.json
@@ -1,5 +1,5 @@
 {
-    "$id": "http://redfish.dmtf.org/schemas/v1/Processor.v1_12_0.json",
+    "$id": "http://redfish.dmtf.org/schemas/v1/Processor.v1_13_0.json",
     "$ref": "#/definitions/Processor",
     "$schema": "http://redfish.dmtf.org/schemas/v1/redfish-schema-v1.json",
     "copyright": "Copyright 2014-2021 DMTF. For the full DMTF copyright policy, see http://www.dmtf.org/about/policies/copyright",
@@ -384,6 +384,19 @@
                 "Memory@odata.count": {
                     "$ref": "http://redfish.dmtf.org/schemas/v1/odata-v4.json#/definitions/count"
                 },
+                "NetworkDeviceFunctions": {
+                    "description": "The network device functions to which this processor performs offload computation, such as with a SmartNIC.",
+                    "items": {
+                        "$ref": "http://redfish.dmtf.org/schemas/v1/NetworkDeviceFunction.json#/definitions/NetworkDeviceFunction"
+                    },
+                    "longDescription": "This property shall contain an array of links to resources of type NetworkDeviceFunction that represent the network device functions to which this processor performs offload computation, such as with a SmartNIC.",
+                    "readonly": true,
+                    "type": "array",
+                    "versionAdded": "v1_13_0"
+                },
+                "NetworkDeviceFunctions@odata.count": {
+                    "$ref": "http://redfish.dmtf.org/schemas/v1/odata-v4.json#/definitions/count"
+                },
                 "Oem": {
                     "$ref": "http://redfish.dmtf.org/schemas/v1/Resource.json#/definitions/Oem",
                     "description": "The OEM extension property.",
@@ -431,6 +444,16 @@
                 }
             },
             "properties": {
+                "ECCModeEnabled": {
+                    "description": "An indication of whether memory ECC mode is enabled for this processor.",
+                    "longDescription": "The value of this property shall indicate if memory ECC mode is enabled for this processor.  This value shall not affect system memory ECC mode.",
+                    "readonly": false,
+                    "type": [
+                        "boolean",
+                        "null"
+                    ],
+                    "versionAdded": "v1_13_0"
+                },
                 "Metrics": {
                     "$ref": "http://redfish.dmtf.org/schemas/v1/MemoryMetrics.json#/definitions/MemoryMetrics",
                     "description": "The link to the memory metrics associated with all memory of this processor.",
@@ -450,8 +473,8 @@
                     "versionAdded": "v1_11_0"
                 },
                 "TotalMemorySizeMiB": {
-                    "description": "Total size of volatile memory of this processor.",
-                    "longDescription": "This property shall contain the total size of non-cache, volatile memory of this processor.",
+                    "description": "Total size of volatile memory attached to this processor.",
+                    "longDescription": "This property shall contain the total size of non-cache, volatile memory attached to this processor.  This value indicates the size of memory directly attached or with strong affinity to this processor, not the total memory accessible by the processor.  This property shall not be present for implementations where all processors have equal memory performance or access characteristics, such as hop count, for all system memory.",
                     "readonly": true,
                     "type": [
                         "integer",
@@ -764,6 +787,21 @@
                     "units": "MHz",
                     "versionAdded": "v1_8_0"
                 },
+                "OperatingSpeedRangeMHz": {
+                    "anyOf": [
+                        {
+                            "$ref": "http://redfish.dmtf.org/schemas/v1/Control.json#/definitions/ControlRangeExcerpt"
+                        },
+                        {
+                            "type": "null"
+                        }
+                    ],
+                    "description": "Range of allowed operating speeds (MHz).",
+                    "excerptCopy": "ControlRangeExcerpt",
+                    "longDescription": "This property shall contain the operating speed control excerpt for this resource.",
+                    "readonly": false,
+                    "versionAdded": "v1_13_0"
+                },
                 "PartNumber": {
                     "description": "The part number of the processor.",
                     "longDescription": "This property shall contain a part number assigned by the organization that is responsible for producing or manufacturing the processor.",
@@ -773,6 +811,13 @@
                         "null"
                     ],
                     "versionAdded": "v1_7_0"
+                },
+                "Ports": {
+                    "$ref": "http://redfish.dmtf.org/schemas/v1/PortCollection.json#/definitions/PortCollection",
+                    "description": "The link to the collection of ports for this processor.",
+                    "longDescription": "This property shall contain a link to a resource collection of type PortCollection.  It shall contain the interconnect ports of this processor.  It shall not contain ports of for GraphicsController resources, USBController resources, or other adapter-related type of resources.",
+                    "readonly": true,
+                    "versionAdded": "v1_13_0"
                 },
                 "ProcessorArchitecture": {
                     "anyOf": [
@@ -1360,6 +1405,6 @@
         }
     },
     "owningEntity": "DMTF",
-    "release": "2021.1",
-    "title": "#Processor.v1_12_0.Processor"
+    "release": "2021.2",
+    "title": "#Processor.v1_13_0.Processor"
 }

--- a/static/redfish/v1/JsonSchemas/Resource/Resource.json
+++ b/static/redfish/v1/JsonSchemas/Resource/Resource.json
@@ -1,5 +1,5 @@
 {
-    "$id": "http://redfish.dmtf.org/schemas/v1/Resource.v1_12_0.json",
+    "$id": "http://redfish.dmtf.org/schemas/v1/Resource.v1_13_0.json",
     "$schema": "http://redfish.dmtf.org/schemas/v1/redfish-schema-v1.json",
     "copyright": "Copyright 2014-2021 DMTF. For the full DMTF copyright policy, see http://www.dmtf.org/about/policies/copyright",
     "definitions": {
@@ -271,12 +271,14 @@
                 "Bay",
                 "Connector",
                 "Socket",
-                "Backplane"
+                "Backplane",
+                "Embedded"
             ],
             "enumDescriptions": {
                 "Backplane": "A backplane.",
                 "Bay": "A bay.",
                 "Connector": "A connector or port.",
+                "Embedded": "Embedded within a part.",
                 "Slot": "A slot.",
                 "Socket": "A socket."
             },
@@ -284,11 +286,13 @@
                 "Backplane": "This value shall indicate the part is a backplane in an enclosure.",
                 "Bay": "This value shall indicate the part is located in a bay.",
                 "Connector": "This value shall indicate the part is located in a connector or port.",
+                "Embedded": "This value shall indicate the part is embedded or otherwise permanently incorporated into a larger part or device.  This value shall not be used for parts that can be removed by a user or are considered field-replaceable.",
                 "Slot": "This value shall indicate the part is located in a slot.",
                 "Socket": "This value shall indicate the part is located in a socket."
             },
             "enumVersionAdded": {
-                "Backplane": "v1_12_0"
+                "Backplane": "v1_12_0",
+                "Embedded": "v1_13_0"
             },
             "longDescription": "This enumeration shall list the types of locations for a part within an enclosure.",
             "type": "string"
@@ -360,8 +364,8 @@
                             "type": "null"
                         }
                     ],
-                    "description": "The type of location of the part, such as slot, bay, socket, or slot.",
-                    "longDescription": "This property shall contain the type of location of the part, such as slot, bay, socket, or slot.",
+                    "description": "The type of location of the part.",
+                    "longDescription": "This property shall contain the type of location of the part.",
                     "readonly": true,
                     "versionAdded": "v1_5_0"
                 },
@@ -910,8 +914,8 @@
                     "$ref": "http://redfish.dmtf.org/schemas/v1/odata-v4.json#/definitions/id"
                 },
                 "MemberId": {
-                    "description": "The identifier for the member within the collection.",
-                    "longDescription": "This property shall uniquely identify the member within the collection.  For services supporting Redfish v1.6 or higher, this value shall contain the zero-based array index.",
+                    "description": "The unique identifier for the member within an array.",
+                    "longDescription": "This property shall contain the unique identifier for this member within an array.  For services supporting Redfish v1.6 or higher, this value shall contain the zero-based array index.",
                     "readonly": true,
                     "type": "string"
                 },
@@ -1049,6 +1053,6 @@
         }
     },
     "owningEntity": "DMTF",
-    "release": "2021.1",
-    "title": "#Resource.v1_12_0"
+    "release": "2021.2",
+    "title": "#Resource.v1_13_0"
 }

--- a/static/redfish/v1/JsonSchemas/Sensor/Sensor.json
+++ b/static/redfish/v1/JsonSchemas/Sensor/Sensor.json
@@ -1,5 +1,5 @@
 {
-    "$id": "http://redfish.dmtf.org/schemas/v1/Sensor.v1_3_0.json",
+    "$id": "http://redfish.dmtf.org/schemas/v1/Sensor.v1_4_0.json",
     "$ref": "#/definitions/Sensor",
     "$schema": "http://redfish.dmtf.org/schemas/v1/redfish-schema-v1.json",
     "copyright": "Copyright 2014-2021 DMTF. For the full DMTF copyright policy, see http://www.dmtf.org/about/policies/copyright",
@@ -43,7 +43,7 @@
             "enumDescriptions": {
                 "PhysicalSensor": "The reading is acquired from a physical sensor.",
                 "Reported": "The reading is obtained from software or a device.",
-                "Synthesized": "The reading is obtained by applying a calculation on one or more properties.  The calculation is not provided."
+                "Synthesized": "The reading is obtained by applying a calculation on one or more properties or multiple sensors.  The calculation is not provided."
             },
             "type": "string"
         },
@@ -66,6 +66,19 @@
                 }
             },
             "properties": {
+                "AssociatedControls": {
+                    "description": "An array of links to the controls that can affect this sensor.",
+                    "items": {
+                        "$ref": "http://redfish.dmtf.org/schemas/v1/Control.json#/definitions/Control"
+                    },
+                    "longDescription": "This property shall contain an array of links to resources of type Control that represent the controls that can affect this sensor.",
+                    "readonly": true,
+                    "type": "array",
+                    "versionAdded": "v1_4_0"
+                },
+                "AssociatedControls@odata.count": {
+                    "$ref": "http://redfish.dmtf.org/schemas/v1/odata-v4.json#/definitions/count"
+                },
                 "Oem": {
                     "$ref": "http://redfish.dmtf.org/schemas/v1/Resource.json#/definitions/Oem",
                     "description": "The OEM extension property.",
@@ -102,6 +115,8 @@
                 "Power",
                 "EnergykWh",
                 "EnergyJoules",
+                "EnergyWh",
+                "ChargeAh",
                 "Voltage",
                 "Current",
                 "Frequency",
@@ -118,8 +133,10 @@
                 "AirFlow": "Airflow.",
                 "Altitude": "Altitude.",
                 "Barometric": "Barometric pressure.",
+                "ChargeAh": "Charge (Ah).",
                 "Current": "Current.",
                 "EnergyJoules": "Energy (Joules).",
+                "EnergyWh": "Energy (Wh).",
                 "EnergykWh": "Energy (kWh).",
                 "Frequency": "Frequency.",
                 "Humidity": "Relative Humidity.",
@@ -136,9 +153,11 @@
                 "AirFlow": "This value shall indicate a measurement of a volume of gas per unit of time that flows through a particular junction.  The ReadingUnits shall be `cft_i/min`.",
                 "Altitude": "This value shall indicate a measurement of altitude, in meter units, and the ReadingUnits value shall be `m`.",
                 "Barometric": "This value shall indicate a measurement of barometric pressure, in millimeters, of a mercury column, and the ReadingUnits value shall be `mm[Hg]`.",
+                "ChargeAh": "This value shall indicate the amount of charge of the monitored item.  If representing metered power consumption,  integral of real power over time, the value shall reflect the power consumption since the sensor metrics were last reset.  The value of the Reading property shall be in amp-hour units and the ReadingUnits value shall be `A.h`.",
                 "Current": "This value shall indicate a measurement of the root mean square (RMS) of instantaneous current calculated over an integer number of line cycles for a circuit.  Current is expressed in Amperes units and the ReadingUnits value shall be `A`.",
-                "EnergyJoules": "This value shall indicate the energy, integral of real power over time, of the monitored item since the sensor metrics were last reset.  The value of the Reading property shall be in Joule units and the ReadingUnits value shall be `J`.  This value is used for device-level energy consumption measurements, while EnergykWh is used for large-scale consumption measurements.",
-                "EnergykWh": "This value shall indicate the energy, integral of real power over time, of the monitored item since the sensor metrics were last reset.  The value of the Reading property shall be in kilowatt-hour units and the ReadingUnits value shall be `kW.h`.  This value is used for large-scale energy consumption measurements, while EnergyJoules is used for device-level consumption measurements.",
+                "EnergyJoules": "This value shall indicate the energy, integral of real power over time, of the monitored item.  If representing metered power consumption the value shall reflect the power consumption since the sensor metrics were last reset.  The value of the Reading property shall be in Joule units and the ReadingUnits value shall be `J`.  This value is used for device-level energy consumption measurements, while EnergykWh is used for large-scale consumption measurements.",
+                "EnergyWh": "This value shall indicate the energy, integral of real power over time, of the monitored item.  If representing metered power consumption the value shall reflect the power consumption since the sensor metrics were last reset.  The value of the Reading property shall be in watt-hour units and the ReadingUnits value shall be `W.h`.  This value is used for device-level energy consumption measurements, while EnergykWh is used for large-scale consumption measurements.",
+                "EnergykWh": "This value shall indicate the energy, integral of real power over time, of the monitored item.  If representing metered power consumption the value shall reflect the power consumption since the sensor metrics were last reset.  The value of the Reading property shall be in kilowatt-hour units and the ReadingUnits value shall be `kW.h`.  This value is used for large-scale energy consumption measurements, while EnergyJoules and EnergyWh are used for device-level consumption measurements.",
                 "Frequency": "This value shall indicate a frequency measurement, in Hertz units, and the ReadingUnits value shall be `Hz`.",
                 "Humidity": "This value shall indicate a relative humidity measurement, in percent units, and the ReadingUnits value shall be '%'.",
                 "LiquidFlow": "This value shall indicate a measurement of a volume of liquid per unit of time that flows through a particular junction.  The ReadingUnits shall be `L/s`.",
@@ -151,6 +170,8 @@
                 "Voltage": "This value shall indicate a measurement of the root mean square (RMS) of instantaneous voltage calculated over an integer number of line cycles for a circuit.  Voltage is expressed in Volts units and the ReadingUnits value shall be `V`."
             },
             "enumVersionAdded": {
+                "ChargeAh": "v1_4_0",
+                "EnergyWh": "v1_4_0",
                 "Percent": "v1_1_0"
             },
             "type": "string"
@@ -254,13 +275,65 @@
                 "ApparentVA": {
                     "description": "The product of voltage and current for an AC circuit, in Volt-Ampere units.",
                     "excerpt": "SensorPower,SensorPowerArray",
-                    "longDescription": "This property shall contain the product of VoltageRMS multiplied by CurrentRMS for a circuit.  This property can appear in sensors of the Power ReadingType, and shall not appear in sensors of other ReadingType values.",
+                    "longDescription": "This property shall contain the product of voltage (RMS) multiplied by current (RMS) for a circuit.  This property can appear in sensors of the Power ReadingType, and shall not appear in sensors of other ReadingType values.",
                     "readonly": true,
                     "type": [
                         "number",
                         "null"
                     ],
                     "units": "V.A"
+                },
+                "AverageReading": {
+                    "description": "The average sensor value.",
+                    "longDescription": "This property shall contain the average sensor value over the time specified by the value of the AveragingInterval property.  The value shall be reset by the ResetMetrics action.",
+                    "readonly": true,
+                    "type": [
+                        "number",
+                        "null"
+                    ],
+                    "versionAdded": "v1_4_0"
+                },
+                "AveragingInterval": {
+                    "description": "The interval over which the average sensor value is calculated.",
+                    "longDescription": "This property shall contain the interval over which the sensor value is averaged to produce the value of the AverageReading property.  This property shall only be present if the AverageReading property is present.",
+                    "pattern": "-?P(\\d+D)?(T(\\d+H)?(\\d+M)?(\\d+(.\\d+)?S)?)?",
+                    "readonly": false,
+                    "type": [
+                        "string",
+                        "null"
+                    ],
+                    "versionAdded": "v1_4_0"
+                },
+                "AveragingIntervalAchieved": {
+                    "description": "Indicates that enough readings were collected to calculate the average sensor reading over the averaging interval time.",
+                    "longDescription": "This property shall indicate that enough readings were collected to calculate the AverageReading value over the interval specified by the AveragingInterval property.  The value shall be reset by the ResetMetrics action.  This property shall only be present if the AveragingInterval property is present.",
+                    "readonly": true,
+                    "type": [
+                        "boolean",
+                        "null"
+                    ],
+                    "versionAdded": "v1_4_0"
+                },
+                "Calibration": {
+                    "description": "The calibration offset applied to the Reading.",
+                    "longDescription": "This property shall contain the offset applied to the raw sensor value to provide a calibrated value for the sensor as returned by the Reading property.  The value of this property shall follow the units of the Reading property for this sensor instance.  Updating the value of this property shall not affect the value of the CalibrationTime property.",
+                    "readonly": false,
+                    "type": [
+                        "number",
+                        "null"
+                    ],
+                    "versionAdded": "v1_4_0"
+                },
+                "CalibrationTime": {
+                    "description": "The date and time that the sensor was last calibrated.",
+                    "format": "date-time",
+                    "longDescription": "This property shall contain the date and time that the sensor was last calibrated.  This property is intended to reflect the actual time the calibration occurred.",
+                    "readonly": false,
+                    "type": [
+                        "string",
+                        "null"
+                    ],
+                    "versionAdded": "v1_4_0"
                 },
                 "CrestFactor": {
                     "description": "The crest factor for this sensor.",
@@ -349,6 +422,27 @@
                     "description": "The location information for this sensor.",
                     "longDescription": "This property shall indicate the location information for this sensor."
                 },
+                "LowestReading": {
+                    "description": "The lowest sensor value.",
+                    "longDescription": "This property shall contain the lowest sensor value since the last ResetMetrics action was performed or the service last reset the time-based property values.",
+                    "readonly": true,
+                    "type": [
+                        "number",
+                        "null"
+                    ],
+                    "versionAdded": "v1_4_0"
+                },
+                "LowestReadingTime": {
+                    "description": "The time when the lowest sensor value occurred.",
+                    "format": "date-time",
+                    "longDescription": "This property shall contain the date and time when the lowest sensor value was observed.",
+                    "readonly": true,
+                    "type": [
+                        "string",
+                        "null"
+                    ],
+                    "versionAdded": "v1_4_0"
+                },
                 "MaxAllowableOperatingValue": {
                     "description": "The maximum allowable operating value for this equipment.",
                     "longDescription": "This property shall contain the maximum allowable operating value for the equipment that this sensor monitors, as specified by a standards body, manufacturer, or both.",
@@ -426,7 +520,7 @@
                 "PowerFactor": {
                     "description": "The power factor for this sensor.",
                     "excerpt": "SensorPower,SensorPowerArray",
-                    "longDescription": "This property shall identify the quotient of PowerRealWatts and PowerApparentVA for a circuit.  PowerFactor is expressed in unit-less 1/100ths.  This property can appear in sensors of the Power ReadingType, and shall not appear in sensors of other ReadingType values.",
+                    "longDescription": "This property shall identify the quotient of real power (W) and apparent power (VA) for a circuit.  PowerFactor is expressed in unit-less 1/100ths.  This property can appear in sensors of the Power ReadingType, and shall not appear in sensors of other ReadingType values.",
                     "maximum": 1,
                     "minimum": 0,
                     "readonly": true,
@@ -445,7 +539,7 @@
                     ]
                 },
                 "ReactiveVAR": {
-                    "description": "The square root of the difference term of squared ApparentVA and squared Power (Reading) for a circuit, in var units.",
+                    "description": "The square root of the difference term of squared apparent VA and squared power (Reading) for a circuit, in VAR units.",
                     "excerpt": "SensorPower,SensorPowerArray",
                     "longDescription": "This property shall contain the arithmetic mean of product terms of instantaneous voltage and quadrature current measurements calculated over an integer number of line cycles for a circuit.  This property can appear in sensors of the Power ReadingType, and shall not appear in sensors of other ReadingType values.",
                     "readonly": true,
@@ -550,6 +644,12 @@
                         "null"
                     ],
                     "versionAdded": "v1_1_0"
+                },
+                "SensorGroup": {
+                    "$ref": "http://redfish.dmtf.org/schemas/v1/Redundancy.json#/definitions/RedundantGroup",
+                    "description": "The group of sensors that provide readings for this sensor.",
+                    "longDescription": "This property shall contain information for a group of sensors that provide input for the value of this sensor's reading.  If this property is present, the Implementation property shall contain the value `Synthesized`.  The group may be created for redundancy or to improve the accuracy of the reading through multiple sensor inputs.",
+                    "versionAdded": "v1_4_0"
                 },
                 "SensorResetTime": {
                     "description": "The date and time when the time-based properties were last reset.",
@@ -1052,7 +1152,7 @@
                 "ApparentVA": {
                     "description": "The product of voltage and current for an AC circuit, in Volt-Ampere units.",
                     "excerpt": "SensorPower,SensorPowerArray",
-                    "longDescription": "This property shall contain the product of VoltageRMS multiplied by CurrentRMS for a circuit.  This property can appear in sensors of the Power ReadingType, and shall not appear in sensors of other ReadingType values.",
+                    "longDescription": "This property shall contain the product of voltage (RMS) multiplied by current (RMS) for a circuit.  This property can appear in sensors of the Power ReadingType, and shall not appear in sensors of other ReadingType values.",
                     "readonly": true,
                     "type": [
                         "number",
@@ -1102,7 +1202,7 @@
                 "PowerFactor": {
                     "description": "The power factor for this sensor.",
                     "excerpt": "SensorPower,SensorPowerArray",
-                    "longDescription": "This property shall identify the quotient of PowerRealWatts and PowerApparentVA for a circuit.  PowerFactor is expressed in unit-less 1/100ths.  This property can appear in sensors of the Power ReadingType, and shall not appear in sensors of other ReadingType values.",
+                    "longDescription": "This property shall identify the quotient of real power (W) and apparent power (VA) for a circuit.  PowerFactor is expressed in unit-less 1/100ths.  This property can appear in sensors of the Power ReadingType, and shall not appear in sensors of other ReadingType values.",
                     "maximum": 1,
                     "minimum": 0,
                     "readonly": true,
@@ -1112,7 +1212,7 @@
                     ]
                 },
                 "ReactiveVAR": {
-                    "description": "The square root of the difference term of squared ApparentVA and squared Power (Reading) for a circuit, in var units.",
+                    "description": "The square root of the difference term of squared apparent VA and squared power (Reading) for a circuit, in VAR units.",
                     "excerpt": "SensorPower,SensorPowerArray",
                     "longDescription": "This property shall contain the arithmetic mean of product terms of instantaneous voltage and quadrature current measurements calculated over an integer number of line cycles for a circuit.  This property can appear in sensors of the Power ReadingType, and shall not appear in sensors of other ReadingType values.",
                     "readonly": true,
@@ -1158,7 +1258,7 @@
                 "ApparentVA": {
                     "description": "The product of voltage and current for an AC circuit, in Volt-Ampere units.",
                     "excerpt": "SensorPower,SensorPowerArray",
-                    "longDescription": "This property shall contain the product of VoltageRMS multiplied by CurrentRMS for a circuit.  This property can appear in sensors of the Power ReadingType, and shall not appear in sensors of other ReadingType values.",
+                    "longDescription": "This property shall contain the product of voltage (RMS) multiplied by current (RMS) for a circuit.  This property can appear in sensors of the Power ReadingType, and shall not appear in sensors of other ReadingType values.",
                     "readonly": true,
                     "type": [
                         "number",
@@ -1180,7 +1280,7 @@
                 "PowerFactor": {
                     "description": "The power factor for this sensor.",
                     "excerpt": "SensorPower,SensorPowerArray",
-                    "longDescription": "This property shall identify the quotient of PowerRealWatts and PowerApparentVA for a circuit.  PowerFactor is expressed in unit-less 1/100ths.  This property can appear in sensors of the Power ReadingType, and shall not appear in sensors of other ReadingType values.",
+                    "longDescription": "This property shall identify the quotient of real power (W) and apparent power (VA) for a circuit.  PowerFactor is expressed in unit-less 1/100ths.  This property can appear in sensors of the Power ReadingType, and shall not appear in sensors of other ReadingType values.",
                     "maximum": 1,
                     "minimum": 0,
                     "readonly": true,
@@ -1190,7 +1290,7 @@
                     ]
                 },
                 "ReactiveVAR": {
-                    "description": "The square root of the difference term of squared ApparentVA and squared Power (Reading) for a circuit, in var units.",
+                    "description": "The square root of the difference term of squared apparent VA and squared power (Reading) for a circuit, in VAR units.",
                     "excerpt": "SensorPower,SensorPowerArray",
                     "longDescription": "This property shall contain the arithmetic mean of product terms of instantaneous voltage and quadrature current measurements calculated over an integer number of line cycles for a circuit.  This property can appear in sensors of the Power ReadingType, and shall not appear in sensors of other ReadingType values.",
                     "readonly": true,
@@ -1429,6 +1529,6 @@
         }
     },
     "owningEntity": "DMTF",
-    "release": "2021.1",
-    "title": "#Sensor.v1_3_0.Sensor"
+    "release": "2021.2",
+    "title": "#Sensor.v1_4_0.Sensor"
 }

--- a/static/redfish/v1/JsonSchemas/ServiceRoot/ServiceRoot.json
+++ b/static/redfish/v1/JsonSchemas/ServiceRoot/ServiceRoot.json
@@ -1,5 +1,5 @@
 {
-    "$id": "http://redfish.dmtf.org/schemas/v1/ServiceRoot.v1_10_0.json",
+    "$id": "http://redfish.dmtf.org/schemas/v1/ServiceRoot.v1_11_0.json",
     "$ref": "#/definitions/ServiceRoot",
     "$schema": "http://redfish.dmtf.org/schemas/v1/redfish-schema-v1.json",
     "copyright": "Copyright 2014-2021 DMTF. For the full DMTF copyright policy, see http://www.dmtf.org/about/policies/copyright",
@@ -250,6 +250,13 @@
                     "readonly": true,
                     "versionAdded": "v1_8_0"
                 },
+                "Cables": {
+                    "$ref": "http://redfish.dmtf.org/schemas/v1/CableCollection.json#/definitions/CableCollection",
+                    "description": "The link to a collection of cables.",
+                    "longDescription": "This property shall contain a link to a resource collection of type CableCollection.",
+                    "readonly": true,
+                    "versionAdded": "v1_11_0"
+                },
                 "CertificateService": {
                     "$ref": "http://redfish.dmtf.org/schemas/v1/CertificateService.json#/definitions/CertificateService",
                     "description": "The link to the Certificate Service.",
@@ -317,6 +324,13 @@
                     "description": "The link to a collection of JSON Schema files.",
                     "longDescription": "This property shall contain a link to a Resource Collection of type JsonSchemaFileCollection.",
                     "readonly": true
+                },
+                "KeyService": {
+                    "$ref": "http://redfish.dmtf.org/schemas/v1/KeyService.json#/definitions/KeyService",
+                    "description": "The link to the key service.",
+                    "longDescription": "This property shall contain a link to a resource of type KeyService.",
+                    "readonly": true,
+                    "versionAdded": "v1_11_0"
                 },
                 "Links": {
                     "$ref": "#/definitions/Links",
@@ -476,6 +490,6 @@
         }
     },
     "owningEntity": "DMTF",
-    "release": "2021.1",
-    "title": "#ServiceRoot.v1_10_0.ServiceRoot"
+    "release": "2021.2",
+    "title": "#ServiceRoot.v1_11_0.ServiceRoot"
 }

--- a/static/redfish/v1/JsonSchemas/SoftwareInventory/SoftwareInventory.json
+++ b/static/redfish/v1/JsonSchemas/SoftwareInventory/SoftwareInventory.json
@@ -1,8 +1,8 @@
 {
-    "$id": "http://redfish.dmtf.org/schemas/v1/SoftwareInventory.v1_4_0.json",
+    "$id": "http://redfish.dmtf.org/schemas/v1/SoftwareInventory.v1_5_0.json",
     "$ref": "#/definitions/SoftwareInventory",
     "$schema": "http://redfish.dmtf.org/schemas/v1/redfish-schema-v1.json",
-    "copyright": "Copyright 2014-2020 DMTF. For the full DMTF copyright policy, see http://www.dmtf.org/about/policies/copyright",
+    "copyright": "Copyright 2014-2021 DMTF. For the full DMTF copyright policy, see http://www.dmtf.org/about/policies/copyright",
     "definitions": {
         "Actions": {
             "additionalProperties": false,
@@ -60,6 +60,16 @@
                         "null"
                     ],
                     "versionAdded": "v1_4_0"
+                },
+                "MeasurementIndex": {
+                    "description": "The DSP0274-defined Index field of the measurement block.",
+                    "longDescription": "This property shall contain the value of DSP0274-defined Index field of the measurement block.",
+                    "readonly": true,
+                    "type": [
+                        "integer",
+                        "null"
+                    ],
+                    "versionAdded": "v1_5_0"
                 },
                 "MeasurementSize": {
                     "description": "The DSP0274-defined MeasurementSize field of the measurement block.",
@@ -279,6 +289,6 @@
         }
     },
     "owningEntity": "DMTF",
-    "release": "2020.4",
-    "title": "#SoftwareInventory.v1_4_0.SoftwareInventory"
+    "release": "2021.2",
+    "title": "#SoftwareInventory.v1_5_0.SoftwareInventory"
 }

--- a/static/redfish/v1/JsonSchemas/Storage/Storage.json
+++ b/static/redfish/v1/JsonSchemas/Storage/Storage.json
@@ -1,5 +1,5 @@
 {
-    "$id": "http://redfish.dmtf.org/schemas/v1/Storage.v1_10_1.json",
+    "$id": "http://redfish.dmtf.org/schemas/v1/Storage.v1_11_0.json",
     "$ref": "#/definitions/Storage",
     "$schema": "http://redfish.dmtf.org/schemas/v1/redfish-schema-v1.json",
     "copyright": "Copyright 2014-2021 DMTF. For the full DMTF copyright policy, see http://www.dmtf.org/about/policies/copyright",
@@ -23,6 +23,9 @@
                 }
             },
             "properties": {
+                "#Storage.ResetToDefaults": {
+                    "$ref": "#/definitions/ResetToDefaults"
+                },
                 "#Storage.SetEncryptionKey": {
                     "$ref": "#/definitions/SetEncryptionKey"
                 },
@@ -118,6 +121,19 @@
                     "type": "array"
                 },
                 "Enclosures@odata.count": {
+                    "$ref": "http://redfish.dmtf.org/schemas/v1/odata-v4.json#/definitions/count"
+                },
+                "HostingStorageSystems": {
+                    "description": "The storage systems that host this storage subsystem.",
+                    "items": {
+                        "$ref": "http://redfish.dmtf.org/schemas/v1/ComputerSystem.json#/definitions/ComputerSystem"
+                    },
+                    "longDescription": "This property shall contain an array of links to resources of type ComputerSystem that represent the storage systems that host this storage subsystem.  The members of this array shall be in the StorageSystems resource collection off the service root.",
+                    "readonly": true,
+                    "type": "array",
+                    "versionAdded": "v1_11_0"
+                },
+                "HostingStorageSystems@odata.count": {
                     "$ref": "http://redfish.dmtf.org/schemas/v1/odata-v4.json#/definitions/count"
                 },
                 "Oem": {
@@ -226,6 +242,57 @@
                 }
             },
             "type": "object"
+        },
+        "ResetToDefaults": {
+            "additionalProperties": false,
+            "description": "The reset action resets the storage device to factory defaults.  This can cause the loss of data.",
+            "longDescription": "This action shall reset the storage device.  This action can impact other resources.",
+            "parameters": {
+                "ResetType": {
+                    "$ref": "#/definitions/ResetToDefaultsType",
+                    "description": "The type of reset to defaults.",
+                    "longDescription": "This parameter shall contain the type of reset to defaults.",
+                    "requiredParameter": true
+                }
+            },
+            "patternProperties": {
+                "^([a-zA-Z_][a-zA-Z0-9_]*)?@(odata|Redfish|Message)\\.[a-zA-Z_][a-zA-Z0-9_]*$": {
+                    "description": "This property shall specify a valid odata or Redfish property.",
+                    "type": [
+                        "array",
+                        "boolean",
+                        "integer",
+                        "number",
+                        "null",
+                        "object",
+                        "string"
+                    ]
+                }
+            },
+            "properties": {
+                "target": {
+                    "description": "Link to invoke action",
+                    "format": "uri-reference",
+                    "type": "string"
+                },
+                "title": {
+                    "description": "Friendly action name",
+                    "type": "string"
+                }
+            },
+            "type": "object",
+            "versionAdded": "v1_11_0"
+        },
+        "ResetToDefaultsType": {
+            "enum": [
+                "ResetAll",
+                "PreserveVolumes"
+            ],
+            "enumDescriptions": {
+                "PreserveVolumes": "Reset all settings to factory defaults but preserve the configured volumes on the controllers.",
+                "ResetAll": "Reset all settings to factory defaults and remove all volumes."
+            },
+            "type": "string"
         },
         "SetEncryptionKey": {
             "additionalProperties": false,
@@ -550,8 +617,8 @@
                     "versionAdded": "v1_10_0"
                 },
                 "MemberId": {
-                    "description": "The identifier for the member within the collection.",
-                    "longDescription": "This property shall uniquely identify the member within the collection.  For services supporting Redfish v1.6 or higher, this value shall contain the zero-based array index.",
+                    "description": "The unique identifier for the member within an array.",
+                    "longDescription": "This property shall contain the unique identifier for this member within an array.  For services supporting Redfish v1.6 or higher, this value shall contain the zero-based array index.",
                     "readonly": true,
                     "type": "string"
                 },
@@ -793,6 +860,6 @@
         }
     },
     "owningEntity": "DMTF",
-    "release": "2020.4",
-    "title": "#Storage.v1_10_1.Storage"
+    "release": "2021.2",
+    "title": "#Storage.v1_11_0.Storage"
 }

--- a/static/redfish/v1/JsonSchemas/StorageController/StorageController.json
+++ b/static/redfish/v1/JsonSchemas/StorageController/StorageController.json
@@ -1,5 +1,5 @@
 {
-    "$id": "http://redfish.dmtf.org/schemas/v1/StorageController.v1_2_0.json",
+    "$id": "http://redfish.dmtf.org/schemas/v1/StorageController.v1_3_0.json",
     "$ref": "#/definitions/StorageController",
     "$schema": "http://redfish.dmtf.org/schemas/v1/redfish-schema-v1.json",
     "copyright": "Copyright 2014-2021 DMTF. For the full DMTF copyright policy, see http://www.dmtf.org/about/policies/copyright",
@@ -180,6 +180,19 @@
                     "type": "array"
                 },
                 "Endpoints@odata.count": {
+                    "$ref": "http://redfish.dmtf.org/schemas/v1/odata-v4.json#/definitions/count"
+                },
+                "NetworkDeviceFunctions": {
+                    "description": "The network device functions that provide connectivity to this controller.",
+                    "items": {
+                        "$ref": "http://redfish.dmtf.org/schemas/v1/NetworkDeviceFunction.json#/definitions/NetworkDeviceFunction"
+                    },
+                    "longDescription": "This property shall contain an array of links to resources of type NetworkDeviceFunction that represent the devices that provide connectivity to this controller.",
+                    "readonly": true,
+                    "type": "array",
+                    "versionAdded": "v1_3_0"
+                },
+                "NetworkDeviceFunctions@odata.count": {
                     "$ref": "http://redfish.dmtf.org/schemas/v1/odata-v4.json#/definitions/count"
                 },
                 "Oem": {
@@ -829,6 +842,6 @@
         }
     },
     "owningEntity": "DMTF",
-    "release": "2021.1",
-    "title": "#StorageController.v1_2_0.StorageController"
+    "release": "2021.2",
+    "title": "#StorageController.v1_3_0.StorageController"
 }

--- a/static/redfish/v1/JsonSchemas/UpdateService/UpdateService.json
+++ b/static/redfish/v1/JsonSchemas/UpdateService/UpdateService.json
@@ -1,5 +1,5 @@
 {
-    "$id": "http://redfish.dmtf.org/schemas/v1/UpdateService.v1_9_0.json",
+    "$id": "http://redfish.dmtf.org/schemas/v1/UpdateService.v1_10_0.json",
     "$ref": "#/definitions/UpdateService",
     "$schema": "http://redfish.dmtf.org/schemas/v1/redfish-schema-v1.json",
     "copyright": "Copyright 2014-2021 DMTF. For the full DMTF copyright policy, see http://www.dmtf.org/about/policies/copyright",
@@ -367,6 +367,13 @@
                     "description": "The available actions for this resource.",
                     "longDescription": "This property shall contain the available actions for this resource."
                 },
+                "ClientCertificates": {
+                    "$ref": "http://redfish.dmtf.org/schemas/v1/CertificateCollection.json#/definitions/CertificateCollection",
+                    "description": "The link to a collection of client identity certificates provided to the server referenced by the ImageURI property in SimpleUpdate.",
+                    "longDescription": "This property shall contain a link to a resource collection of type CertificateCollection that represents the client identity certificates that are provided to the server referenced by the ImageURI property in SimpleUpdate as part of TLS handshaking.",
+                    "readonly": true,
+                    "versionAdded": "v1_10_0"
+                },
                 "Description": {
                     "anyOf": [
                         {
@@ -512,6 +519,6 @@
         }
     },
     "owningEntity": "DMTF",
-    "release": "2021.1",
-    "title": "#UpdateService.v1_9_0.UpdateService"
+    "release": "2021.2",
+    "title": "#UpdateService.v1_10_0.UpdateService"
 }

--- a/static/redfish/v1/JsonSchemas/VLanNetworkInterface/VLanNetworkInterface.json
+++ b/static/redfish/v1/JsonSchemas/VLanNetworkInterface/VLanNetworkInterface.json
@@ -1,8 +1,8 @@
 {
-    "$id": "http://redfish.dmtf.org/schemas/v1/VLanNetworkInterface.v1_2_0.json",
+    "$id": "http://redfish.dmtf.org/schemas/v1/VLanNetworkInterface.v1_3_0.json",
     "$ref": "#/definitions/VLanNetworkInterface",
     "$schema": "http://redfish.dmtf.org/schemas/v1/redfish-schema-v1.json",
-    "copyright": "Copyright 2014-2020 DMTF. For the full DMTF copyright policy, see http://www.dmtf.org/about/policies/copyright",
+    "copyright": "Copyright 2014-2021 DMTF. For the full DMTF copyright policy, see http://www.dmtf.org/about/policies/copyright",
     "definitions": {
         "Actions": {
             "additionalProperties": false,
@@ -72,6 +72,16 @@
                 }
             },
             "properties": {
+                "Tagged": {
+                    "description": "An indication of whether this VLAN is tagged or untagged for this interface.",
+                    "longDescription": "This property shall indicate whether this VLAN is tagged or untagged for this interface.",
+                    "readonly": false,
+                    "type": [
+                        "boolean",
+                        "null"
+                    ],
+                    "versionAdded": "v1_3_0"
+                },
                 "VLANEnable": {
                     "description": "An indication of whether this VLAN is enabled for this VLAN network interface.",
                     "longDescription": "This property shall indicate whether this VLAN is enabled for this VLAN network interface.",
@@ -127,6 +137,7 @@
         },
         "VLanNetworkInterface": {
             "additionalProperties": false,
+            "deprecated": "This schema has been deprecated in favor of using individual EthernetInterface resources to show VLAN information.",
             "description": "The VLanNetworkInterface schema describes a VLAN network instance that is available on a manager, system, or other device.",
             "longDescription": "This resource contains information for a VLAN network instance that is available on a manager, system, or other device for a Redfish implementation.",
             "patternProperties": {
@@ -233,10 +244,11 @@
                 "VLANEnable",
                 "VLANId"
             ],
-            "type": "object"
+            "type": "object",
+            "versionDeprecated": "v1_3_0"
         }
     },
     "owningEntity": "DMTF",
-    "release": "2020.4",
-    "title": "#VLanNetworkInterface.v1_2_0.VLanNetworkInterface"
+    "release": "2021.2",
+    "title": "#VLanNetworkInterface.v1_3_0.VLanNetworkInterface"
 }

--- a/static/redfish/v1/JsonSchemas/VirtualMedia/VirtualMedia.json
+++ b/static/redfish/v1/JsonSchemas/VirtualMedia/VirtualMedia.json
@@ -1,13 +1,13 @@
 {
-    "$id": "http://redfish.dmtf.org/schemas/v1/VirtualMedia.v1_4_0.json",
+    "$id": "http://redfish.dmtf.org/schemas/v1/VirtualMedia.v1_5_0.json",
     "$ref": "#/definitions/VirtualMedia",
     "$schema": "http://redfish.dmtf.org/schemas/v1/redfish-schema-v1.json",
     "copyright": "Copyright 2014-2021 DMTF. For the full DMTF copyright policy, see http://www.dmtf.org/about/policies/copyright",
     "definitions": {
         "Actions": {
             "additionalProperties": false,
-            "description": "The available actions for this Resource.",
-            "longDescription": "This type shall contain the available actions for this Resource.",
+            "description": "The available actions for this resource.",
+            "longDescription": "This type shall contain the available actions for this resource.",
             "patternProperties": {
                 "^([a-zA-Z_][a-zA-Z0-9_]*)?@(odata|Redfish|Message)\\.[a-zA-Z_][a-zA-Z0-9_]*$": {
                     "description": "This property shall specify a valid odata or Redfish property.",
@@ -31,8 +31,8 @@
                 },
                 "Oem": {
                     "$ref": "#/definitions/OemActions",
-                    "description": "The available OEM-specific actions for this Resource.",
-                    "longDescription": "This property shall contain the available OEM-specific actions for this Resource.",
+                    "description": "The available OEM-specific actions for this resource.",
+                    "longDescription": "This property shall contain the available OEM-specific actions for this resource.",
                     "versionAdded": "v1_1_0"
                 }
             },
@@ -92,43 +92,43 @@
             "longDescription": "This action shall attach remote media to virtual media.",
             "parameters": {
                 "Image": {
-                    "description": "The URI of the remote media to attach to the virtual media.",
-                    "longDescription": "This parameter shall specify the URI of the remote media to be attached to the virtual media.",
+                    "description": "The URI of the media to attach to the virtual media.",
+                    "longDescription": "This parameter shall contain the URI of the media to be attached to the virtual media.  This parameter may specify an absolute URI to remote media or a relative URI to media local to the implementation.  A service may allow a relative URI to reference a SoftwareInventory resource.",
                     "requiredParameter": true,
                     "type": "string"
                 },
                 "Inserted": {
                     "description": "An indication of whether the image is treated as inserted upon completion of the action.  The default is `true`.",
-                    "longDescription": "This parameter shall indicate whether the image is treated as inserted upon completion of the action.  If the client does not provide this parameter, the service shall default this value to `true`.",
+                    "longDescription": "This parameter shall contain whether the image is treated as inserted upon completion of the action.  If the client does not provide this parameter, the service shall default this value to `true`.",
                     "type": "boolean"
                 },
                 "Password": {
-                    "description": "The password to access the Image parameter-specified URI.",
-                    "longDescription": "This parameter shall represent the password to access the Image parameter-specified URI.",
+                    "description": "The password to access the URI specified by the Image parameter.",
+                    "longDescription": "This parameter shall contain the password to access the URI specified by the Image parameter.",
                     "type": "string",
                     "versionAdded": "v1_3_0"
                 },
                 "TransferMethod": {
                     "$ref": "#/definitions/TransferMethod",
-                    "description": "The transfer method to use with the Image.",
-                    "longDescription": "This parameter shall describe how the image transfer occurs.",
+                    "description": "The transfer method to use with the image.",
+                    "longDescription": "This parameter shall contain the transfer method to use with the specified image URI.",
                     "versionAdded": "v1_3_0"
                 },
                 "TransferProtocolType": {
                     "$ref": "#/definitions/TransferProtocolType",
                     "description": "The network protocol to use with the image.",
-                    "longDescription": "This parameter shall represent the network protocol to use with the specified image URI.",
+                    "longDescription": "This parameter shall contain the network protocol to use with the specified image URI.",
                     "versionAdded": "v1_3_0"
                 },
                 "UserName": {
-                    "description": "The user name to access the Image parameter-specified URI.",
-                    "longDescription": "This parameter shall contain the user name to access the Image parameter-specified URI.",
+                    "description": "The username to access the URI specified by the Image parameter.",
+                    "longDescription": "This parameter shall contain the username to access the URI specified by the Image parameter.",
                     "type": "string",
                     "versionAdded": "v1_3_0"
                 },
                 "WriteProtected": {
                     "description": "An indication of whether the remote media is treated as write-protected.  The default is `true`.",
-                    "longDescription": "This parameter shall indicate whether the remote media is treated as write-protected.  If the client does not provide this parameter, the service shall default this value to `true`.",
+                    "longDescription": "This parameter shall contain whether the remote media is treated as write-protected.  If the client does not provide this parameter, the service shall default this value to `true`.",
                     "type": "boolean"
                 }
             },
@@ -177,8 +177,8 @@
         },
         "OemActions": {
             "additionalProperties": true,
-            "description": "The available OEM-specific actions for this Resource.",
-            "longDescription": "This type shall contain the available OEM-specific actions for this Resource.",
+            "description": "The available OEM-specific actions for this resource.",
+            "longDescription": "This type shall contain the available OEM-specific actions for this resource.",
             "patternProperties": {
                 "^([a-zA-Z_][a-zA-Z0-9_]*)?@(odata|Redfish|Message)\\.[a-zA-Z_][a-zA-Z0-9_]*$": {
                     "description": "This property shall specify a valid odata or Redfish property.",
@@ -235,7 +235,7 @@
         "VirtualMedia": {
             "additionalProperties": false,
             "description": "The VirtualMedia schema contains properties related to the monitor and control of an instance of virtual media, such as a remote CD, DVD, or USB device.  A manager for a system or device provides virtual media functionality.",
-            "longDescription": "This Resource shall represent a virtual media service for a Redfish implementation.",
+            "longDescription": "This resource shall represent a virtual media service for a Redfish implementation.",
             "patternProperties": {
                 "^([a-zA-Z_][a-zA-Z0-9_]*)?@(odata|Redfish|Message)\\.[a-zA-Z_][a-zA-Z0-9_]*$": {
                     "description": "This property shall specify a valid odata or Redfish property.",
@@ -265,8 +265,8 @@
                 },
                 "Actions": {
                     "$ref": "#/definitions/Actions",
-                    "description": "The available actions for this Resource.",
-                    "longDescription": "This property shall contain the available actions for this Resource.",
+                    "description": "The available actions for this resource.",
+                    "longDescription": "This property shall contain the available actions for this resource.",
                     "versionAdded": "v1_1_0"
                 },
                 "Certificates": {
@@ -275,6 +275,13 @@
                     "longDescription": "This property shall contain a link to a resource collection of type CertificateCollection that represents the server certificates for the server referenced by the Image property.  If VerifyCertificate is `true`, services shall compare the certificates in this collection with the certificate obtained during handshaking with the image server in order to verify the identify of the image server prior to completing the remote media connection.  If the server cannot be verified, the service shall not complete the remote media connection.  If VerifyCertificate is `false`, the service shall not perform certificate verification.",
                     "readonly": true,
                     "versionAdded": "v1_4_0"
+                },
+                "ClientCertificates": {
+                    "$ref": "http://redfish.dmtf.org/schemas/v1/CertificateCollection.json#/definitions/CertificateCollection",
+                    "description": "The link to a collection of client identity certificates provided to the server referenced by the Image property.",
+                    "longDescription": "This property shall contain a link to a resource collection of type CertificateCollection that represents the client identity certificates that are provided to the server referenced by the Image property as part of TLS handshaking.",
+                    "readonly": true,
+                    "versionAdded": "v1_5_0"
                 },
                 "ConnectedVia": {
                     "anyOf": [
@@ -286,7 +293,7 @@
                         }
                     ],
                     "description": "The current virtual media connection method.",
-                    "longDescription": "This property shall contain the current connection method from a client to the virtual media that this Resource represents.",
+                    "longDescription": "This property shall contain the current connection method from a client to the virtual media that this resource represents.",
                     "readonly": true
                 },
                 "Description": {
@@ -307,7 +314,7 @@
                 "Image": {
                     "description": "The URI of the location of the selected image.",
                     "format": "uri-reference",
-                    "longDescription": "This property shall contain an URI.  A null value indicated no image connection.",
+                    "longDescription": "This property shall contain the URI of the media attached to the virtual media.  This value may specify an absolute URI to remote media or a relative URI to media local to the implementation.  A service may allow a relative URI to reference a SoftwareInventory resource.  The value `null` shall indicates no image connection.",
                     "readonly": false,
                     "type": [
                         "string",
@@ -337,7 +344,7 @@
                     "items": {
                         "$ref": "#/definitions/MediaType"
                     },
-                    "longDescription": "The values of this array shall be the supported media types for this connection.",
+                    "longDescription": "This property shall contain an array of the supported media types for this connection.",
                     "readonly": true,
                     "type": "array"
                 },
@@ -434,6 +441,6 @@
         }
     },
     "owningEntity": "DMTF",
-    "release": "2021.1",
-    "title": "#VirtualMedia.v1_4_0.VirtualMedia"
+    "release": "2021.2",
+    "title": "#VirtualMedia.v1_5_0.VirtualMedia"
 }

--- a/static/redfish/v1/schema/AccountService_v1.xml
+++ b/static/redfish/v1/schema/AccountService_v1.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!---->
 <!--################################################################################       -->
-<!--# Redfish Schema:  AccountService v1.9.0                                               -->
+<!--# Redfish Schema:  AccountService v1.10.0                                              -->
 <!--#                                                                                      -->
 <!--# For a detailed change log, see the README file contained in the DSP8010 bundle,      -->
 <!--# available at http://www.dmtf.org/standards/redfish                                   -->
@@ -56,8 +56,8 @@
       <Annotation Term="Redfish.OwningEntity" String="DMTF"/>
 
       <EntityType Name="AccountService" BaseType="Resource.v1_0_0.Resource" Abstract="true">
-        <Annotation Term="OData.Description" String="The AccountService schema defines an account service.  The properties are common to, and enable management of, all user accounts.  The properties include the password requirements and control features, such as account lockout.  The schema also contains links to the manager accounts and roles."/>
-        <Annotation Term="OData.LongDescription" String="This resource shall represent an account service for a Redfish implementation.  The properties are common to, and enable management of, all user accounts.  The properties include the password requirements and control features, such as account lockout."/>
+        <Annotation Term="OData.Description" String="The AccountService schema defines an account service.  The properties are common to, and enable management of, all user accounts.  The properties include the password requirements and control features, such as account lockout.  Properties and actions in this service specify general behavior that should be followed for typical accounts, however implementations may override these behaviors for special accounts or situations to avoid denial of service or other deadlock situations."/>
+        <Annotation Term="OData.LongDescription" String="This resource shall represent an account service for a Redfish implementation.  The properties are common to, and enable management of, all user accounts.  The properties include the password requirements and control features, such as account lockout.  Properties and actions in this service specify general behavior that should be followed for typical accounts, however implementations may override these behaviors for special accounts or situations to avoid denial of service or other deadlock situations."/>
         <Annotation Term="Capabilities.InsertRestrictions">
           <Record>
             <PropertyValue Property="Insertable" Bool="false"/>
@@ -216,6 +216,12 @@
       <EntityType Name="AccountService" BaseType="AccountService.v1_0_11.AccountService"/>
     </Schema>
 
+    <Schema xmlns="http://docs.oasis-open.org/odata/ns/edm" Namespace="AccountService.v1_0_13">
+      <Annotation Term="Redfish.OwningEntity" String="DMTF"/>
+      <Annotation Term="OData.Description" String="This version was created to clarify that services are allowed to protect accounts to avoid deadlock conditions."/>
+      <EntityType Name="AccountService" BaseType="AccountService.v1_0_12.AccountService"/>
+    </Schema>
+
     <Schema xmlns="http://docs.oasis-open.org/odata/ns/edm" Namespace="AccountService.v1_1_0">
       <Annotation Term="Redfish.OwningEntity" String="DMTF"/>
       <Annotation Term="Redfish.Release" String="2016.3"/>
@@ -282,6 +288,12 @@
       <Annotation Term="Redfish.OwningEntity" String="DMTF"/>
       <Annotation Term="OData.Description" String="This version was created to correct various description to use proper normative terminology."/>
       <EntityType Name="AccountService" BaseType="AccountService.v1_1_8.AccountService"/>
+    </Schema>
+
+    <Schema xmlns="http://docs.oasis-open.org/odata/ns/edm" Namespace="AccountService.v1_1_10">
+      <Annotation Term="Redfish.OwningEntity" String="DMTF"/>
+      <Annotation Term="OData.Description" String="This version was created to clarify that services are allowed to protect accounts to avoid deadlock conditions."/>
+      <EntityType Name="AccountService" BaseType="AccountService.v1_1_9.AccountService"/>
     </Schema>
 
     <Schema xmlns="http://docs.oasis-open.org/odata/ns/edm" Namespace="AccountService.v1_2_0">
@@ -364,6 +376,12 @@
       <Annotation Term="Redfish.OwningEntity" String="DMTF"/>
       <Annotation Term="OData.Description" String="This version was created to correct various description to use proper normative terminology."/>
       <EntityType Name="AccountService" BaseType="AccountService.v1_2_8.AccountService"/>
+    </Schema>
+
+    <Schema xmlns="http://docs.oasis-open.org/odata/ns/edm" Namespace="AccountService.v1_2_10">
+      <Annotation Term="Redfish.OwningEntity" String="DMTF"/>
+      <Annotation Term="OData.Description" String="This version was created to clarify that services are allowed to protect accounts to avoid deadlock conditions."/>
+      <EntityType Name="AccountService" BaseType="AccountService.v1_2_9.AccountService"/>
     </Schema>
 
     <Schema xmlns="http://docs.oasis-open.org/odata/ns/edm" Namespace="AccountService.v1_3_0">
@@ -483,6 +501,18 @@
               <Record>
                 <PropertyValue Property="Kind" EnumMember="Redfish.RevisionKind/Added"/>
                 <PropertyValue Property="Version" String="v1_8_0"/>
+              </Record>
+            </Collection>
+          </Annotation>
+        </Member>
+        <Member Name="OAuth2">
+          <Annotation Term="OData.Description" String="An external OAuth 2.0 service."/>
+          <Annotation Term="OData.LongDescription" String="The external account provider shall be an RFC6749-conformant service.  The ServiceAddresses format shall contain a set of URIs that correspond to the RFC8414-defined metadata for the OAuth 2.0 service."/>
+          <Annotation Term="Redfish.Revisions">
+            <Collection>
+              <Record>
+                <PropertyValue Property="Kind" EnumMember="Redfish.RevisionKind/Added"/>
+                <PropertyValue Property="Version" String="v1_10_0"/>
               </Record>
             </Collection>
           </Annotation>
@@ -649,6 +679,12 @@
       <EntityType Name="AccountService" BaseType="AccountService.v1_3_7.AccountService"/>
     </Schema>
 
+    <Schema xmlns="http://docs.oasis-open.org/odata/ns/edm" Namespace="AccountService.v1_3_9">
+      <Annotation Term="Redfish.OwningEntity" String="DMTF"/>
+      <Annotation Term="OData.Description" String="This version was created to clarify that services are allowed to protect accounts to avoid deadlock conditions."/>
+      <EntityType Name="AccountService" BaseType="AccountService.v1_3_8.AccountService"/>
+    </Schema>
+
     <Schema xmlns="http://docs.oasis-open.org/odata/ns/edm" Namespace="AccountService.v1_4_0">
       <Annotation Term="Redfish.OwningEntity" String="DMTF"/>
       <Annotation Term="Redfish.Release" String="2018.3"/>
@@ -701,6 +737,12 @@
       <EntityType Name="AccountService" BaseType="AccountService.v1_4_5.AccountService"/>
     </Schema>
 
+    <Schema xmlns="http://docs.oasis-open.org/odata/ns/edm" Namespace="AccountService.v1_4_7">
+      <Annotation Term="Redfish.OwningEntity" String="DMTF"/>
+      <Annotation Term="OData.Description" String="This version was created to clarify that services are allowed to protect accounts to avoid deadlock conditions."/>
+      <EntityType Name="AccountService" BaseType="AccountService.v1_4_6.AccountService"/>
+    </Schema>
+
     <Schema xmlns="http://docs.oasis-open.org/odata/ns/edm" Namespace="AccountService.v1_5_0">
       <Annotation Term="Redfish.OwningEntity" String="DMTF"/>
       <Annotation Term="Redfish.Release" String="2019.1"/>
@@ -745,6 +787,12 @@
       <EntityType Name="AccountService" BaseType="AccountService.v1_5_4.AccountService"/>
     </Schema>
 
+    <Schema xmlns="http://docs.oasis-open.org/odata/ns/edm" Namespace="AccountService.v1_5_6">
+      <Annotation Term="Redfish.OwningEntity" String="DMTF"/>
+      <Annotation Term="OData.Description" String="This version was created to clarify that services are allowed to protect accounts to avoid deadlock conditions."/>
+      <EntityType Name="AccountService" BaseType="AccountService.v1_5_5.AccountService"/>
+    </Schema>
+
     <Schema xmlns="http://docs.oasis-open.org/odata/ns/edm" Namespace="AccountService.v1_6_0">
       <Annotation Term="Redfish.OwningEntity" String="DMTF"/>
       <Annotation Term="Redfish.Release" String="2019.2"/>
@@ -775,6 +823,12 @@
       <Annotation Term="Redfish.OwningEntity" String="DMTF"/>
       <Annotation Term="OData.Description" String="This version was created to correct various description to use proper normative terminology."/>
       <EntityType Name="AccountService" BaseType="AccountService.v1_6_3.AccountService"/>
+    </Schema>
+
+    <Schema xmlns="http://docs.oasis-open.org/odata/ns/edm" Namespace="AccountService.v1_6_5">
+      <Annotation Term="Redfish.OwningEntity" String="DMTF"/>
+      <Annotation Term="OData.Description" String="This version was created to clarify that services are allowed to protect accounts to avoid deadlock conditions."/>
+      <EntityType Name="AccountService" BaseType="AccountService.v1_6_4.AccountService"/>
     </Schema>
 
     <Schema xmlns="http://docs.oasis-open.org/odata/ns/edm" Namespace="AccountService.v1_7_0">
@@ -814,6 +868,12 @@
       <Annotation Term="Redfish.OwningEntity" String="DMTF"/>
       <Annotation Term="OData.Description" String="This version was created to correct various description to use proper normative terminology."/>
       <EntityType Name="AccountService" BaseType="AccountService.v1_7_3.AccountService"/>
+    </Schema>
+
+    <Schema xmlns="http://docs.oasis-open.org/odata/ns/edm" Namespace="AccountService.v1_7_5">
+      <Annotation Term="Redfish.OwningEntity" String="DMTF"/>
+      <Annotation Term="OData.Description" String="This version was created to clarify that services are allowed to protect accounts to avoid deadlock conditions."/>
+      <EntityType Name="AccountService" BaseType="AccountService.v1_7_4.AccountService"/>
     </Schema>
 
     <Schema xmlns="http://docs.oasis-open.org/odata/ns/edm" Namespace="AccountService.v1_8_0">
@@ -921,6 +981,12 @@
       <EntityType Name="AccountService" BaseType="AccountService.v1_8_0.AccountService"/>
     </Schema>
 
+    <Schema xmlns="http://docs.oasis-open.org/odata/ns/edm" Namespace="AccountService.v1_8_2">
+      <Annotation Term="Redfish.OwningEntity" String="DMTF"/>
+      <Annotation Term="OData.Description" String="This version was created to clarify that services are allowed to protect accounts to avoid deadlock conditions."/>
+      <EntityType Name="AccountService" BaseType="AccountService.v1_8_1.AccountService"/>
+    </Schema>
+
     <Schema xmlns="http://docs.oasis-open.org/odata/ns/edm" Namespace="AccountService.v1_9_0">
       <Annotation Term="Redfish.Release" String="2021.1"/>
       <Annotation Term="Redfish.OwningEntity" String="DMTF"/>
@@ -933,6 +999,68 @@
           <Annotation Term="OData.LongDescription" String="This property shall contain the number of days before account passwords in this account service will expire.  The value shall be applied during account creation and password modification unless the PasswordExpiration property is provided.  The value `null` shall indicate that account passwords never expire.  This property does not apply to accounts from external account providers."/>
         </Property>
       </EntityType>
+    </Schema>
+
+    <Schema xmlns="http://docs.oasis-open.org/odata/ns/edm" Namespace="AccountService.v1_9_1">
+      <Annotation Term="Redfish.OwningEntity" String="DMTF"/>
+      <Annotation Term="OData.Description" String="This version was created to clarify that services are allowed to protect accounts to avoid deadlock conditions."/>
+      <EntityType Name="AccountService" BaseType="AccountService.v1_9_0.AccountService"/>
+    </Schema>
+
+    <Schema xmlns="http://docs.oasis-open.org/odata/ns/edm" Namespace="AccountService.v1_10_0">
+      <Annotation Term="Redfish.OwningEntity" String="DMTF"/>
+      <Annotation Term="Redfish.Release" String="2021.2"/>
+
+      <EntityType Name="AccountService" BaseType="AccountService.v1_9_1.AccountService">
+        <Property Name="OAuth2" Type="AccountService.v1_10_0.ExternalAccountProvider">
+          <Annotation Term="OData.Description" String="The first OAuth 2.0 external account provider that this account service supports."/>
+          <Annotation Term="OData.LongDescription" String="This property shall contain the first OAuth 2.0 external account provider that this account service supports.  If the account service supports one or more OAuth 2.0 services as an external account provider, this entity shall be populated by default.  This entity shall not be present in the additional external account providers resource collection."/>
+        </Property>
+      </EntityType>
+
+      <ComplexType Name="ExternalAccountProvider" BaseType="AccountService.v1_8_0.ExternalAccountProvider">
+        <Property Name="OAuth2Service" Type="AccountService.v1_10_0.OAuth2Service">
+          <Annotation Term="OData.Description" String="The additional information needed to parse an OAuth 2.0 service."/>
+          <Annotation Term="OData.LongDescription" String="This property shall contain additional information needed to parse an OAuth 2.0 service.  This property should only be present inside an OAuth2 property."/>
+        </Property>
+      </ComplexType>
+
+      <ComplexType Name="OAuth2Service">
+        <Annotation Term="OData.AdditionalProperties" Bool="false"/>
+        <Annotation Term="OData.Description" String="Various settings to parse an OAuth 2.0 service."/>
+        <Annotation Term="OData.LongDescription" String="This type shall contain settings for parsing an OAuth 2.0 service."/>
+        <Property Name="Mode" Type="AccountService.v1_10_0.OAuth2Mode" Nullable="false">
+          <Annotation Term="OData.Permissions" EnumMember="OData.Permission/ReadWrite"/>
+          <Annotation Term="OData.Description" String="The mode of operation for token validation."/>
+          <Annotation Term="OData.LongDescription" String="This property shall contain the mode of operation for token validation."/>
+        </Property>
+        <Property Name="Issuer" Type="Edm.String">
+          <Annotation Term="OData.Permissions" EnumMember="OData.Permission/ReadWrite"/>
+          <Annotation Term="OData.Description" String="The issuer string of the OAuth 2.0 service."/>
+          <Annotation Term="OData.LongDescription" String="This property shall contain the RFC8414-defined issuer string of the OAuth 2.0 service.  If the Mode property contains the value `Discovery`, this property shall contain the value of the `issuer` string from the OAuth 2.0 service's metadata and this property shall be read-only."/>
+        </Property>
+        <Property Name="Audience" Type="Collection(Edm.String)" Nullable="false">
+          <Annotation Term="OData.Permissions" EnumMember="OData.Permission/Read"/>
+          <Annotation Term="OData.Description" String="The allowable audience strings of the Redfish service."/>
+          <Annotation Term="OData.LongDescription" String="This property shall contain an array of allowable RFC7519-defined audience strings of the Redfish service.  The values shall uniquely identify the Redfish service.  For example, a MAC address or UUID for the manager can uniquely identify the service."/>
+        </Property>
+        <Property Name="OAuthServiceSigningKeys" Type="Edm.String">
+          <Annotation Term="OData.Permissions" EnumMember="OData.Permission/ReadWrite"/>
+          <Annotation Term="OData.Description" String="The Base64-encoded signing keys of the issuer of the OAuth 2.0 service."/>
+          <Annotation Term="OData.LongDescription" String="This property shall contain a Base64-encoded string of the RFC7517-defined signing keys of the issuer of the OAuth 2.0 service.  If the Mode property contains the value `Discovery`, this property shall contain the keys found at the URI specified by the `jwks_uri` string from the OAuth 2.0 service's metadata and this property shall be read-only."/>
+        </Property>
+      </ComplexType>
+
+      <EnumType Name="OAuth2Mode">
+        <Member Name="Discovery">
+          <Annotation Term="OData.Description" String="OAuth 2.0 service information for token validation is downloaded by the service."/>
+          <Annotation Term="OData.LongDescription" String="This value shall indicate the service performs token validation from information found at the URIs specified by the ServiceAddresses property.  Services shall implement a caching method of this information so it's not necessary to retrieve metadata and key information for every request containing a token."/>
+        </Member>
+        <Member Name="Offline">
+          <Annotation Term="OData.Description" String="OAuth 2.0 service information for token validation is configured by a client."/>
+          <Annotation Term="OData.LongDescription" String="This value shall indicate the service performs token validation from properties configured by a client."/>
+        </Member>
+      </EnumType>
     </Schema>
 
   </edmx:DataServices>

--- a/static/redfish/v1/schema/ActionInfo_v1.xml
+++ b/static/redfish/v1/schema/ActionInfo_v1.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!---->
 <!--################################################################################       -->
-<!--# Redfish Schema:  ActionInfo v1.1.2                                                   -->
+<!--# Redfish Schema:  ActionInfo v1.2.0                                                   -->
 <!--#                                                                                      -->
 <!--# For a detailed change log, see the README file contained in the DSP8010 bundle,      -->
 <!--# available at http://www.dmtf.org/standards/redfish                                   -->
@@ -30,8 +30,8 @@
       <Annotation Term="Redfish.OwningEntity" String="DMTF"/>
 
       <EntityType Name="ActionInfo" BaseType="Resource.v1_0_0.Resource" Abstract="true">
-        <Annotation Term="OData.Description" String="The ActionInfo schema defines the supported parameters and other information for a Redfish action.  Supported parameters can differ among vendors and even among Resource instances.  This data can ensure that action requests from applications contain supported parameters."/>
-        <Annotation Term="OData.LongDescription" String="This Resource shall represent the supported parameters and other information for a Redfish action on a target within a Redfish implementation.  Supported parameters can differ among vendors and even among Resource instances.  This data can ensure that action requests from applications contain supported parameters."/>
+        <Annotation Term="OData.Description" String="The ActionInfo schema defines the supported parameters and other information for a Redfish action.  Supported parameters can differ among vendors and even among resource instances.  This data can ensure that action requests from applications contain supported parameters."/>
+        <Annotation Term="OData.LongDescription" String="This resource shall represent the supported parameters and other information for a Redfish action on a target within a Redfish implementation.  Supported parameters can differ among vendors and even among resource instances.  This data can ensure that action requests from applications contain supported parameters."/>
         <Annotation Term="Capabilities.InsertRestrictions">
           <Record>
             <PropertyValue Property="Insertable" Bool="false"/>
@@ -48,7 +48,6 @@
           </Record>
         </Annotation>
       </EntityType>
-
     </Schema>
 
     <Schema xmlns="http://docs.oasis-open.org/odata/ns/edm" Namespace="ActionInfo.v1_0_0">
@@ -58,14 +57,14 @@
       <EntityType Name="ActionInfo" BaseType="ActionInfo.ActionInfo">
         <Property Name="Parameters" Type="Collection(ActionInfo.v1_0_0.Parameters)" Nullable="false">
           <Annotation Term="OData.Description" String="The list of parameters included in the specified Redfish action."/>
-          <Annotation Term="OData.LongDescription" String="This property shall list the parameters included in the specified Redfish action for this Resource."/>
+          <Annotation Term="OData.LongDescription" String="This property shall list the parameters included in the specified Redfish action for this resource."/>
         </Property>
       </EntityType>
 
       <ComplexType Name="Parameters">
         <Annotation Term="OData.AdditionalProperties" Bool="false"/>
-        <Annotation Term="OData.Description" String="The information about a parameter included in a Redfish action for this Resource."/>
-        <Annotation Term="OData.LongDescription" String="This property shall contain information about a parameter included in a Redfish Action for this Resource."/>
+        <Annotation Term="OData.Description" String="The information about a parameter included in a Redfish action for this resource."/>
+        <Annotation Term="OData.LongDescription" String="This property shall contain information about a parameter included in a Redfish action for this resource."/>
         <Property Name="Name" Type="Edm.String" Nullable="false">
           <Annotation Term="OData.Permissions" EnumMember="OData.Permission/Read"/>
           <Annotation Term="OData.Description"  String="The name of the parameter for this action."/>
@@ -90,7 +89,7 @@
         <Property Name="AllowableValues" Type="Collection(Edm.String)">
           <Annotation Term="OData.Permissions" EnumMember="OData.Permission/Read"/>
           <Annotation Term="OData.Description" String="The allowable values for this parameter as applied to this action target."/>
-          <Annotation Term="OData.LongDescription" String="This property shall indicate the allowable values for this parameter as applied to this action target."/>
+          <Annotation Term="OData.LongDescription" String="This property shall indicate the allowable values for this parameter as applied to this action target.  For arrays, this property shall represent the allowable values for each array member."/>
         </Property>
       </ComplexType>
 
@@ -117,12 +116,11 @@
           <Annotation Term="OData.Description" String="An array of JSON objects."/>
         </Member>
       </EnumType>
-
     </Schema>
 
     <Schema xmlns="http://docs.oasis-open.org/odata/ns/edm" Namespace="ActionInfo.v1_0_1">
       <Annotation Term="Redfish.OwningEntity" String="DMTF"/>
-      <Annotation Term="OData.Description" String="This version was created to add explicit Permissions annotations to all properties for clarity."/>
+      <Annotation Term="OData.Description" String="This version was created to add explicit permissions annotations to all properties for clarity."/>
       <EntityType Name="ActionInfo" BaseType="ActionInfo.v1_0_0.ActionInfo"/>
     </Schema>
 
@@ -156,22 +154,29 @@
       <EntityType Name="ActionInfo" BaseType="ActionInfo.v1_0_5.ActionInfo"/>
     </Schema>
 
+    <Schema xmlns="http://docs.oasis-open.org/odata/ns/edm" Namespace="ActionInfo.v1_0_7">
+      <Annotation Term="Redfish.OwningEntity" String="DMTF"/>
+      <Annotation Term="OData.Description" String="This version was created to clarify the behavior of AllowableValues for array parameters."/>
+      <EntityType Name="ActionInfo" BaseType="ActionInfo.v1_0_6.ActionInfo"/>
+    </Schema>
+
     <Schema xmlns="http://docs.oasis-open.org/odata/ns/edm" Namespace="ActionInfo.v1_1_0">
       <Annotation Term="Redfish.OwningEntity" String="DMTF"/>
       <Annotation Term="Redfish.Release" String="2018.2"/>
       <Annotation Term="OData.Description" String="This version was created to add properties to specify parameter minimum and maximum values."/>
+
       <EntityType Name="ActionInfo" BaseType="ActionInfo.v1_0_4.ActionInfo"/>
 
       <ComplexType Name="Parameters" BaseType="ActionInfo.v1_0_0.Parameters">
         <Property Name="MinimumValue" Type="Edm.Decimal">
           <Annotation Term="OData.Permissions" EnumMember="OData.Permission/Read"/>
           <Annotation Term="OData.Description" String="The minimum supported value for this parameter."/>
-          <Annotation Term="OData.LongDescription" String="This integer or number property shall contain the minimum value that this service supports.  This property shall not be present for parameters that are of types other than integer or number."/>
+          <Annotation Term="OData.LongDescription" String="This integer or number property shall contain the minimum value that this service supports.  For arrays, this property shall represent the minimum value for each array member.  This property shall not be present for non-integer or number parameters."/>
         </Property>
         <Property Name="MaximumValue" Type="Edm.Decimal">
           <Annotation Term="OData.Permissions" EnumMember="OData.Permission/Read"/>
           <Annotation Term="OData.Description" String="The maximum supported value for this parameter."/>
-          <Annotation Term="OData.LongDescription" String="This integer or number property shall contain the maximum value that this service supports.  This property shall not be present for non-integer or number parameters."/>
+          <Annotation Term="OData.LongDescription" String="This integer or number property shall contain the maximum value that this service supports.  For arrays, this property shall represent the maximum value for each array member.  This property shall not be present for non-integer or number parameters."/>
         </Property>
       </ComplexType>
     </Schema>
@@ -186,6 +191,32 @@
       <Annotation Term="Redfish.OwningEntity" String="DMTF"/>
       <Annotation Term="OData.Description" String="This version was created to update descriptions that this schema defines."/>
       <EntityType Name="ActionInfo" BaseType="ActionInfo.v1_1_1.ActionInfo"/>
+    </Schema>
+
+    <Schema xmlns="http://docs.oasis-open.org/odata/ns/edm" Namespace="ActionInfo.v1_1_3">
+      <Annotation Term="Redfish.OwningEntity" String="DMTF"/>
+      <Annotation Term="OData.Description" String="This version was created to clarify the behavior of AllowableValues, MinimumValue, and MaximumValue for array parameters."/>
+      <EntityType Name="ActionInfo" BaseType="ActionInfo.v1_1_2.ActionInfo"/>
+    </Schema>
+
+    <Schema xmlns="http://docs.oasis-open.org/odata/ns/edm" Namespace="ActionInfo.v1_2_0">
+      <Annotation Term="Redfish.OwningEntity" String="DMTF"/>
+      <Annotation Term="Redfish.Release" String="2021.2"/>
+
+      <EntityType Name="ActionInfo" BaseType="ActionInfo.v1_1_3.ActionInfo"/>
+
+      <ComplexType Name="Parameters" BaseType="ActionInfo.v1_1_0.Parameters">
+        <Property Name="ArraySizeMinimum" Type="Edm.Int64">
+          <Annotation Term="OData.Permissions" EnumMember="OData.Permission/Read"/>
+          <Annotation Term="OData.Description" String="The minimum number of array elements required for this parameter."/>
+          <Annotation Term="OData.LongDescription" String="This property shall contain the minimum number of array elements required by this service for this parameter.  This property shall not be present for non-array parameters."/>
+        </Property>
+        <Property Name="ArraySizeMaximum" Type="Edm.Int64">
+          <Annotation Term="OData.Permissions" EnumMember="OData.Permission/Read"/>
+          <Annotation Term="OData.Description" String="The maximum number of array elements allowed for this parameter."/>
+          <Annotation Term="OData.LongDescription" String="This property shall contain the maximum number of array elements that this service supports for this parameter.  This property shall not be present for non-array parameters."/>
+        </Property>
+      </ComplexType>
     </Schema>
 
   </edmx:DataServices>

--- a/static/redfish/v1/schema/Assembly_v1.xml
+++ b/static/redfish/v1/schema/Assembly_v1.xml
@@ -97,6 +97,8 @@
             <String>/redfish/v1/Chassis/{ChassisId}/Thermal/Fans/{FanId}/Assembly</String>
             <String>/redfish/v1/Chassis/{ChassisId}/ThermalSubsystem/Fans/{FanId}/Assembly</String>
             <String>/redfish/v1/Chassis/{ChassisId}/PowerSubsystem/PowerSupplies/{PowerSupplyId}/Assembly</String>
+            <String>/redfish/v1/PowerEquipment/PowerShelves/{PowerDistributionId}/PowerSupplies/{PowerSupplyId}/Assembly</String>
+            <String>/redfish/v1/Chassis/{ChassisId}/PowerSubsystem/Batteries/{BatteryId}/Assembly</String>
           </Collection>
         </Annotation>
       </EntityType>

--- a/static/redfish/v1/schema/CertificateCollection_v1.xml
+++ b/static/redfish/v1/schema/CertificateCollection_v1.xml
@@ -69,6 +69,7 @@
             <String>/redfish/v1/CompositionService/ResourceBlocks/{ResourceBlockId}/Systems/{ComputerSystemId}/SecureBoot/SecureBootDatabases/{DatabaseId}/Certificates</String>
             <String>/redfish/v1/ResourceBlocks/{ResourceBlockId}/Systems/{ComputerSystemId}/SecureBoot/SecureBootDatabases/{DatabaseId}/Certificates</String>
             <String>/redfish/v1/EventService/Subscriptions/{EventDestinationId}/Certificates</String>
+            <String>/redfish/v1/EventService/Subscriptions/{EventDestinationId}/ClientCertificates</String>
             <String>/redfish/v1/Systems/{ComputerSystemId}/Certificates</String>
             <String>/redfish/v1/CompositionService/ResourceBlocks/{ResourceBlockId}/Systems/{ComputerSystemId}/Certificates</String>
             <String>/redfish/v1/ResourceBlocks/{ResourceBlockId}/Systems/{ComputerSystemId}/Certificates</String>
@@ -107,9 +108,17 @@
             <String>/redfish/v1/ResourceBlocks/{ResourceBlockId}/Systems/{ComputerSystemId}/Storage/{StorageId}/Drives/{DriveId}/Certificates</String>
             <String>/redfish/v1/Chassis/{ChassisId}/NetworkAdapters/{NetworkAdapterId}/Certificates</String>
             <String>/redfish/v1/Systems/{ComputerSystemId}/VirtualMedia/{VirtualMediaId}/Certificates</String>
+            <String>/redfish/v1/Systems/{ComputerSystemId}/VirtualMedia/{VirtualMediaId}/ClientCertificates</String>
             <String>/redfish/v1/CompositionService/ResourceBlocks/{ResourceBlockId}/Systems/{ComputerSystemId}/VirtualMedia/{VirtualMediaId}/Certificates</String>
+            <String>/redfish/v1/CompositionService/ResourceBlocks/{ResourceBlockId}/Systems/{ComputerSystemId}/VirtualMedia/{VirtualMediaId}/ClientCertificates</String>
             <String>/redfish/v1/ResourceBlocks/{ResourceBlockId}/Systems/{ComputerSystemId}/VirtualMedia/{VirtualMediaId}/Certificates</String>
+            <String>/redfish/v1/ResourceBlocks/{ResourceBlockId}/Systems/{ComputerSystemId}/VirtualMedia/{VirtualMediaId}/ClientCertificates</String>
             <String>/redfish/v1/UpdateService/RemoteServerCertificates</String>
+            <String>/redfish/v1/UpdateService/ClientCertificates</String>
+            <String>/redfish/v1/Managers/{ManagerId}/Certificates</String>                   
+            <String>/redfish/v1/Systems/{ComputerSystemId}/KeyManagement/KMIPCertificates</String>
+            <String>/redfish/v1/CompositionService/ResourceBlocks/{ResourceBlockId}/Systems/{ComputerSystemId}/KeyManagement/KMIPCertificates</String>
+            <String>/redfish/v1/ResourceBlocks/{ResourceBlockId}/Systems/{ComputerSystemId}/KeyManagement/KMIPCertificates</String>
           </Collection>
         </Annotation>
         <NavigationProperty Name="Members" Type="Collection(Certificate.Certificate)">

--- a/static/redfish/v1/schema/Certificate_v1.xml
+++ b/static/redfish/v1/schema/Certificate_v1.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!---->
 <!--################################################################################       -->
-<!--# Redfish Schema:  Certificate v1.3.0                                                  -->
+<!--# Redfish Schema:  Certificate v1.4.0                                                  -->
 <!--#                                                                                      -->
 <!--# For a detailed change log, see the README file contained in the DSP8010 bundle,      -->
 <!--# available at http://www.dmtf.org/standards/redfish                                   -->
@@ -18,6 +18,7 @@
     <edmx:Include Namespace="Org.OData.Capabilities.V1" Alias="Capabilities"/>
   </edmx:Reference>
   <edmx:Reference Uri="http://redfish.dmtf.org/schemas/v1/Resource_v1.xml">
+    <edmx:Include Namespace="Resource"/>
     <edmx:Include Namespace="Resource.v1_0_0"/>
   </edmx:Reference>
   <edmx:Reference Uri="http://redfish.dmtf.org/schemas/v1/RedfishExtensions_v1.xml">
@@ -40,7 +41,7 @@
         </Annotation>
         <Annotation Term="Capabilities.UpdateRestrictions">
           <Record>
-            <PropertyValue Property="Updatable" Bool="false"/>
+            <PropertyValue Property="Updatable" Bool="true"/>
           </Record>
         </Annotation>
         <Annotation Term="Capabilities.DeleteRestrictions">
@@ -67,6 +68,7 @@
             <String>/redfish/v1/CompositionService/ResourceBlocks/{ResourceBlockId}/Systems/{ComputerSystemId}/SecureBoot/SecureBootDatabases/{DatabaseId}/Certificates/{CertificateId}</String>
             <String>/redfish/v1/ResourceBlocks/{ResourceBlockId}/Systems/{ComputerSystemId}/SecureBoot/SecureBootDatabases/{DatabaseId}/Certificates/{CertificateId}</String>
             <String>/redfish/v1/EventService/Subscriptions/{EventDestinationId}/Certificates/{CertificateId}</String>
+            <String>/redfish/v1/EventService/Subscriptions/{EventDestinationId}/ClientCertificates/{CertificateId}</String>
             <String>/redfish/v1/Systems/{ComputerSystemId}/Certificates/{CertificateId}</String>
             <String>/redfish/v1/CompositionService/ResourceBlocks/{ResourceBlockId}/Systems/{ComputerSystemId}/Certificates/{CertificateId}</String>
             <String>/redfish/v1/ResourceBlocks/{ResourceBlockId}/Systems/{ComputerSystemId}/Certificates/{CertificateId}</String>
@@ -105,21 +107,41 @@
             <String>/redfish/v1/ResourceBlocks/{ResourceBlockId}/Systems/{ComputerSystemId}/Storage/{StorageId}/Drives/{DriveId}/Certificates/{CertificateId}</String>
             <String>/redfish/v1/Chassis/{ChassisId}/NetworkAdapters/{NetworkAdapterId}/Certificates/{CertificateId}</String>
             <String>/redfish/v1/Systems/{ComputerSystemId}/VirtualMedia/{VirtualMediaId}/Certificates/{CertificateId}</String>
+            <String>/redfish/v1/Systems/{ComputerSystemId}/VirtualMedia/{VirtualMediaId}/ClientCertificates/{CertificateId}</String>
             <String>/redfish/v1/CompositionService/ResourceBlocks/{ResourceBlockId}/Systems/{ComputerSystemId}/VirtualMedia/{VirtualMediaId}/Certificates/{CertificateId}</String>
+            <String>/redfish/v1/CompositionService/ResourceBlocks/{ResourceBlockId}/Systems/{ComputerSystemId}/VirtualMedia/{VirtualMediaId}/ClientCertificates/{CertificateId}</String>
             <String>/redfish/v1/ResourceBlocks/{ResourceBlockId}/Systems/{ComputerSystemId}/VirtualMedia/{VirtualMediaId}/Certificates/{CertificateId}</String>
+            <String>/redfish/v1/ResourceBlocks/{ResourceBlockId}/Systems/{ComputerSystemId}/VirtualMedia/{VirtualMediaId}/ClientCertificates/{CertificateId}</String>
             <String>/redfish/v1/UpdateService/RemoteServerCertificates/{CertificateId}</String>
+            <String>/redfish/v1/UpdateService/ClientCertificates/{CertificateId}</String>
+            <String>/redfish/v1/Managers/{ManagerId}/Certificates/{CertificateId}</String>            
+            <String>/redfish/v1/Systems/{ComputerSystemId}/KeyManagement/KMIPCertificates</String>
+            <String>/redfish/v1/CompositionService/ResourceBlocks/{ResourceBlockId}/Systems/{ComputerSystemId}/KeyManagement/KMIPCertificates</String>
+            <String>/redfish/v1/ResourceBlocks/{ResourceBlockId}/Systems/{ComputerSystemId}/KeyManagement/KMIPCertificates</String>
           </Collection>
         </Annotation>
       </EntityType>
 
       <EnumType Name="CertificateType">
         <Member Name="PEM">
-          <Annotation Term="OData.Description" String="A Privacy Enhanced Mail (PEM)-encoded certificate."/>
-          <Annotation Term="OData.LongDescription" String="The format of the certificate shall contain a Privacy Enhanced Mail (PEM)-encoded string, containing RFC5280-defined structures."/>
+          <Annotation Term="OData.Description" String="A Privacy Enhanced Mail (PEM)-encoded single certificate."/>
+          <Annotation Term="OData.LongDescription" String="This value shall indicate the format of the certificate shall contain a Privacy Enhanced Mail (PEM)-encoded string, containing RFC5280-defined structures, representing a single certificate."/>
+        </Member>
+        <Member Name="PEMchain">
+          <Annotation Term="OData.Description" String="A Privacy Enhanced Mail (PEM)-encoded certificate chain."/>
+          <Annotation Term="OData.LongDescription" String="This value shall indicate the format of the certificate shall contain a Privacy Enhanced Mail (PEM)-encoded string, containing RFC5280-defined structures, representing a certificate chain."/>
+          <Annotation Term="Redfish.Revisions">
+            <Collection>
+              <Record>
+                <PropertyValue Property="Kind" EnumMember="Redfish.RevisionKind/Added"/>
+                <PropertyValue Property="Version" String="v1_4_0"/>
+              </Record>
+            </Collection>
+          </Annotation>
         </Member>
         <Member Name="PKCS7">
           <Annotation Term="OData.Description" String="A Privacy Enhanced Mail (PEM)-encoded PKCS7 certificate."/>
-          <Annotation Term="OData.LongDescription" String="The format of the certificate shall contain a Privacy Enhanced Mail (PEM)-encoded string, containing RFC5280- and RFC2315-defined structures.  The service can discard additional certificates or other data in the structure."/>
+          <Annotation Term="OData.LongDescription" String="The format of the certificate shall contain a Privacy Enhanced Mail (PEM)-encoded string, containing RFC5280-defined and RFC2315-defined structures.  The service can discard additional certificates or other data in the structure."/>
         </Member>
       </EnumType>
 
@@ -473,6 +495,61 @@
           <Annotation Term="OData.LongDescription" String="The value of this property shall be a string containing the algorithm used for generating the signature of the certificate, as defined by the RFC5280 'signatureAlgorithm' field.  The value shall be a string representing the ASN.1 OID of the signature algorithm as defined in, but not limited to, RFC3279, RFC4055, or RFC4491."/>
         </Property>
       </EntityType>
+    </Schema>
+
+    <Schema xmlns="http://docs.oasis-open.org/odata/ns/edm" Namespace="Certificate.v1_4_0">
+      <Annotation Term="Redfish.OwningEntity" String="DMTF"/>
+      <Annotation Term="Redfish.Release" String="2021.2"/>
+
+      <EntityType Name="Certificate" BaseType="Certificate.v1_3_0.Certificate">
+        <Property Name="Links" Type="Certificate.v1_4_0.Links" Nullable="false">
+          <Annotation Term="OData.Description" String="The links to other resources that are related to this resource."/>
+          <Annotation Term="OData.LongDescription" String="This property shall contain links to resources that are related to but are not contained by, or subordinate to, this resource."/>
+        </Property>
+        <Property Name="CertificateUsageTypes" Type="Collection(Certificate.v1_4_0.CertificateUsageType)">
+          <Annotation Term="OData.Permissions" EnumMember="OData.Permission/Read"/>
+          <Annotation Term="OData.Description" String="The types or purposes for this certificate."/>
+          <Annotation Term="OData.LongDescription" String="The value of this property shall contain an array describing the types or purposes for this certificate."/>
+        </Property>        
+      </EntityType>
+
+      <ComplexType Name="Links" BaseType="Resource.Links">
+        <Annotation Term="OData.Description" String="The links to other resources that are related to this resource."/>
+        <Annotation Term="OData.LongDescription" String="This Redfish Specification-described type shall contain links to resources that are related to but are not contained by, or subordinate to, this resource."/>
+        <NavigationProperty Name="Issuer" Type="Certificate.Certificate">
+          <Annotation Term="OData.Permissions" EnumMember="OData.Permission/ReadWrite"/>
+          <Annotation Term="OData.Description" String="A link to the certificate of the CA that issued this certificate."/>
+          <Annotation Term="OData.LongDescription" String="This property shall contain a link to a resources of type Certificate that represents the certificate of the CA that issued this certificate."/>
+          <Annotation Term="OData.AutoExpandReferences"/>
+        </NavigationProperty>
+        <NavigationProperty Name="Subjects" Type="Collection(Certificate.Certificate)">
+          <Annotation Term="OData.Permissions" EnumMember="OData.Permission/ReadWrite"/>
+          <Annotation Term="OData.Description" String="An array of links to certificates that were issued by the CA that is represented by this certificate."/>
+          <Annotation Term="OData.LongDescription" String="This property shall contain an array of links to resources of type Certificate that were issued by the CA that is represented by this certificate."/>
+          <Annotation Term="OData.AutoExpandReferences"/>
+        </NavigationProperty>
+      </ComplexType>
+      
+      <EnumType Name="CertificateUsageType">
+        <Member Name="User">
+          <Annotation Term="OData.Description" String="This certificate is a user certificate like those associated with a manager account."/>
+        </Member>
+        <Member Name="Web">
+          <Annotation Term="OData.Description" String="This certificate is a web or HTTPS certificate like those used for event destinations."/>
+        </Member>
+        <Member Name="SSH">
+          <Annotation Term="OData.Description" String="This certificate is used for SSH."/>
+        </Member>
+        <Member Name="Device">
+          <Annotation Term="OData.Description" String="This certificate is a device type certificate like those associated with SPDM and other standards."/>
+        </Member>
+        <Member Name="Platform">
+          <Annotation Term="OData.Description" String="This certificate is a platform type certificate like those associated with SPDM and other standards."/>
+        </Member>
+        <Member Name="BIOS">
+          <Annotation Term="OData.Description" String="This certificate is a BIOS certificate like those associated with UEFI."/>
+        </Member>
+      </EnumType>
     </Schema>
 
   </edmx:DataServices>

--- a/static/redfish/v1/schema/Chassis_v1.xml
+++ b/static/redfish/v1/schema/Chassis_v1.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!---->
 <!--################################################################################       -->
-<!--# Redfish Schema:  Chassis v1.16.0                                                     -->
+<!--# Redfish Schema:  Chassis v1.17.0                                                     -->
 <!--#                                                                                      -->
 <!--# For a detailed change log, see the README file contained in the DSP8010 bundle,      -->
 <!--# available at http://www.dmtf.org/standards/redfish                                   -->
@@ -97,6 +97,9 @@
   <edmx:Reference Uri="http://redfish.dmtf.org/schemas/v1/DriveCollection_v1.xml">
     <edmx:Include Namespace="DriveCollection"/>
   </edmx:Reference>
+  <edmx:Reference Uri="http://redfish.dmtf.org/schemas/v1/ControlCollection_v1.xml">
+    <edmx:Include Namespace="ControlCollection"/>
+  </edmx:Reference>
   <edmx:Reference Uri="http://redfish.dmtf.org/schemas/v1/EnvironmentMetrics_v1.xml">
     <edmx:Include Namespace="EnvironmentMetrics"/>
   </edmx:Reference>
@@ -105,6 +108,9 @@
   </edmx:Reference>
   <edmx:Reference Uri="http://redfish.dmtf.org/schemas/v1/SoftwareInventory_v1.xml">
     <edmx:Include Namespace="SoftwareInventory"/>
+  </edmx:Reference>
+  <edmx:Reference Uri="http://redfish.dmtf.org/schemas/v1/Cable_v1.xml">
+    <edmx:Include Namespace="Cable"/>
   </edmx:Reference>
 
   <edmx:DataServices>
@@ -1559,6 +1565,29 @@
           <Annotation Term="OData.LongDescription" String="This property shall contain the spare part number of the chassis."/>
         </Property>
       </EntityType>
+    </Schema>
+
+    <Schema xmlns="http://docs.oasis-open.org/odata/ns/edm" Namespace="Chassis.v1_17_0">
+      <Annotation Term="Redfish.OwningEntity" String="DMTF"/>
+      <Annotation Term="Redfish.Release" String="2021.2"/>
+
+      <EntityType Name="Chassis" BaseType="Chassis.v1_16_0.Chassis">
+        <NavigationProperty Name="Controls" Type="ControlCollection.ControlCollection" ContainsTarget="true" Nullable="false">
+          <Annotation Term="OData.Permissions" EnumMember="OData.Permission/Read"/>
+          <Annotation Term="OData.Description" String="The link to the collection of controls located in this chassis."/>
+          <Annotation Term="OData.LongDescription" String="This property shall contain a link to a resource collection of type ControlCollection."/>
+          <Annotation Term="OData.AutoExpandReferences"/>
+        </NavigationProperty>
+      </EntityType>
+
+      <ComplexType Name="Links" BaseType="Chassis.v1_11_0.Links">
+        <NavigationProperty Name="Cables" Type="Collection(Cable.Cable)">
+          <Annotation Term="OData.Permissions" EnumMember="OData.Permission/Read"/>
+          <Annotation Term="OData.Description" String="An array of links to the cables connected to this chassis."/>
+          <Annotation Term="OData.LongDescription" String="This property shall contain an array of links to resources of type Cable that represent the cables connected to this chassis."/>
+          <Annotation Term="OData.AutoExpandReferences"/>
+        </NavigationProperty>
+      </ComplexType>
     </Schema>
 
   </edmx:DataServices>

--- a/static/redfish/v1/schema/ComputerSystem_v1.xml
+++ b/static/redfish/v1/schema/ComputerSystem_v1.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!---->
 <!--################################################################################       -->
-<!--# Redfish Schema:  ComputerSystem v1.15.0                                              -->
+<!--# Redfish Schema:  ComputerSystem v1.16.0                                              -->
 <!--#                                                                                      -->
 <!--# For a detailed change log, see the README file contained in the DSP8010 bundle,      -->
 <!--# available at http://www.dmtf.org/standards/redfish                                   -->
@@ -503,6 +503,18 @@
             </Collection>
           </Annotation>
         </Member>
+        <Member Name="DPU">
+          <Annotation Term="OData.Description" String="A computer system that performs the functions of a data processing unit, such as a SmartNIC."/>
+          <Annotation Term="OData.LongDescription" String="A SystemType of DPU typically represents a single system that performs offload computation as a data processing unit, such as a SmartNIC."/>
+          <Annotation Term="Redfish.Revisions">
+            <Collection>
+              <Record>
+                <PropertyValue Property="Kind" EnumMember="Redfish.RevisionKind/Added"/>
+                <PropertyValue Property="Version" String="v1_16_0"/>
+              </Record>
+            </Collection>
+          </Annotation>
+        </Member>
       </EnumType>
 
       <EnumType Name="IndicatorLED">
@@ -599,6 +611,15 @@
         <Property Name="Status" Type="Resource.Status"  Nullable="false">
           <Annotation Term="OData.Description" String="The status and health of the resource and its subordinate or dependent resources."/>
           <Annotation Term="OData.LongDescription" String="This property shall contain any status or health properties of the resource."/>
+          <Annotation Term="Redfish.Revisions">
+            <Collection>
+              <Record>
+                <PropertyValue Property="Kind" EnumMember="Redfish.RevisionKind/Deprecated"/>
+                <PropertyValue Property="Version" String="v1_16_0"/>
+                <PropertyValue Property="Description" String="This property has been deprecated in favor of the Conditions property within Status in the root of this resource."/>
+              </Record>
+            </Collection>
+          </Annotation>
         </Property>
       </ComplexType>
 
@@ -616,6 +637,15 @@
         <Property Name="Status" Type="Resource.Status"  Nullable="false">
           <Annotation Term="OData.Description" String="The status and health of the resource and its subordinate or dependent resources."/>
           <Annotation Term="OData.LongDescription" String="This property shall contain any status or health properties of the resource."/>
+          <Annotation Term="Redfish.Revisions">
+            <Collection>
+              <Record>
+                <PropertyValue Property="Kind" EnumMember="Redfish.RevisionKind/Deprecated"/>
+                <PropertyValue Property="Version" String="v1_16_0"/>
+                <PropertyValue Property="Description" String="This property has been deprecated in favor of the Conditions property within Status in the root of this resource."/>
+              </Record>
+            </Collection>
+          </Annotation>
         </Property>
       </ComplexType>
     </Schema>
@@ -2335,6 +2365,104 @@
           <Annotation Term="OData.Permissions" EnumMember="OData.Permission/ReadWrite"/>
           <Annotation Term="OData.Description" String="An indication of whether threading is enabled on all processors in this system."/>
           <Annotation Term="OData.LongDescription" String="The value of this property shall indicate that all Processor resources in this system where the ProcessorType property contains `CPU` have multiple threading support enabled."/>
+        </Property>
+      </ComplexType>
+    </Schema>
+
+    <Schema xmlns="http://docs.oasis-open.org/odata/ns/edm" Namespace="ComputerSystem.v1_16_0">
+      <Annotation Term="Redfish.OwningEntity" String="DMTF"/>
+      <Annotation Term="Redfish.Release" String="2021.2"/>
+      <Annotation Term="OData.Description" String="This version was created to add IdlePowerSaver.  It was also created to add KeyManagement.  It was also created to deprecate Status within ProcessorSummary and MemorySummary in favor of Conditions within Status at the root of the resource."/>
+
+      <EntityType Name="ComputerSystem" BaseType="ComputerSystem.v1_15_0.ComputerSystem">
+        <Property Name="IdlePowerSaver" Type="ComputerSystem.v1_16_0.IdlePowerSaver">
+          <Annotation Term="OData.Description" String="The idle power saver settings of the computer system."/>
+          <Annotation Term="OData.LongDescription" String="This property shall contain the idle power saver settings of the computer system."/>
+        </Property>
+        <Property Name="KeyManagement" Type="ComputerSystem.v1_16_0.KeyManagement">
+          <Annotation Term="OData.Description" String="The key management settings of the computer system."/>
+          <Annotation Term="OData.LongDescription" String="This property shall contain the key management settings of the computer system."/>
+        </Property>
+      </EntityType>
+
+      <ComplexType Name="IdlePowerSaver">
+        <Annotation Term="OData.AdditionalProperties" Bool="false"/>
+        <Annotation Term="OData.Description" String="The idle power saver settings of a computer system."/>
+        <Annotation Term="OData.LongDescription" String="This object shall contain the idle power saver settings of a computer system."/>
+        <Property Name="Enabled" Type="Edm.Boolean" Nullable="false">
+          <Annotation Term="OData.Permissions" EnumMember="OData.Permission/ReadWrite"/>
+          <Annotation Term="OData.Description" String="An indication of whether idle power saver is enabled."/>
+          <Annotation Term="OData.LongDescription" String="The value of this property shall indicate if idle power saver is enabled."/>
+        </Property>
+        <Property Name="EnterUtilizationPercent" Type="Edm.Decimal">
+          <Annotation Term="OData.Permissions" EnumMember="OData.Permission/ReadWrite"/>
+          <Annotation Term="OData.Description" String="The percentage of utilization that the computer system shall be lower than to enter idle power save."/>
+          <Annotation Term="OData.LongDescription" String="This property shall contain the percentage of utilization that the computer system shall be lower than to enter idle power save."/>
+          <Annotation Term="Validation.Minimum" Int="0"/>
+          <Annotation Term="Measures.Unit" String="%"/>
+        </Property>
+        <Property Name="EnterDwellTimeSeconds" Type="Edm.Int64">
+          <Annotation Term="OData.Permissions" EnumMember="OData.Permission/ReadWrite"/>
+          <Annotation Term="OData.Description" String="The duration in seconds the computer system is below the EnterUtilizationPercent value before the idle power save is activated."/>
+          <Annotation Term="OData.LongDescription" String="This property shall contain the duration in seconds the computer system is below the EnterUtilizationPercent value before the idle power save is activated."/>
+          <Annotation Term="Validation.Minimum" Int="0"/>
+          <Annotation Term="Measures.Unit" String="s"/>
+        </Property>
+        <Property Name="ExitUtilizationPercent" Type="Edm.Decimal">
+          <Annotation Term="OData.Permissions" EnumMember="OData.Permission/ReadWrite"/>
+          <Annotation Term="OData.Description" String="The percentage of utilization that the computer system shall be higher than to exit idle power save."/>
+          <Annotation Term="OData.LongDescription" String="This property shall contain the percentage of utilization that the computer system shall be higher than to exit idle power save."/>
+          <Annotation Term="Validation.Minimum" Int="0"/>
+          <Annotation Term="Measures.Unit" String="%"/>
+        </Property>
+        <Property Name="ExitDwellTimeSeconds" Type="Edm.Int64">
+          <Annotation Term="OData.Permissions" EnumMember="OData.Permission/ReadWrite"/>
+          <Annotation Term="OData.Description" String="The duration in seconds the computer system is above the ExitUtilizationPercent value before the idle power save is stopped."/>
+          <Annotation Term="OData.LongDescription" String="This property shall contain the duration in seconds the computer system is above the ExitUtilizationPercent value before the idle power save is stopped."/>
+          <Annotation Term="Validation.Minimum" Int="0"/>
+          <Annotation Term="Measures.Unit" String="s"/>
+        </Property>
+      </ComplexType>
+
+      <ComplexType Name="KeyManagement">
+        <Annotation Term="OData.AdditionalProperties" Bool="false"/>
+        <Annotation Term="OData.Description" String="The key management settings of a computer system."/>
+        <Annotation Term="OData.LongDescription" String="This object shall contain the key management settings of a computer system."/>
+        <Property Name="KMIPServers" Type="Collection(ComputerSystem.v1_16_0.KMIPServer)">
+          <Annotation Term="OData.Description" String="The KMIP servers to which this computer system is subscribed."/>
+          <Annotation Term="OData.LongDescription" String="This property shall contain the KMIP servers to which this computer system is subscribed for key management."/>
+        </Property>
+        <NavigationProperty Name="KMIPCertificates" Type="CertificateCollection.CertificateCollection" ContainsTarget="true" Nullable="false">
+          <Annotation Term="OData.Permissions" EnumMember="OData.Permission/Read"/>
+          <Annotation Term="OData.Description" String="The link to a collection of server certificates for the servers referenced by the KMIPServers property."/>
+          <Annotation Term="OData.LongDescription" String="This property shall contain a link to a resource collection of type CertificateCollection that represents the server certificates for the servers referenced by the KMIPServers property."/>
+          <Annotation Term="OData.AutoExpandReferences"/>
+        </NavigationProperty>
+      </ComplexType>
+
+      <ComplexType Name="KMIPServer">
+        <Annotation Term="OData.AdditionalProperties" Bool="false"/>
+        <Annotation Term="OData.Description" String="The KMIP server settings for a computer system."/>
+        <Annotation Term="OData.LongDescription" String="This object shall contain the KMIP server settings for a computer system."/>
+        <Property Name="Address" Type="Edm.String">
+          <Annotation Term="OData.Permissions" EnumMember="OData.Permission/ReadWrite"/>
+          <Annotation Term="OData.Description" String="The KMIP server address."/>
+          <Annotation Term="OData.LongDescription" String="This property shall contain the KMIP server address."/>
+        </Property>
+        <Property Name="Port" Type="Edm.Int64">
+          <Annotation Term="OData.Permissions" EnumMember="OData.Permission/ReadWrite"/>
+          <Annotation Term="OData.Description" String="The KMIP server port."/>
+          <Annotation Term="OData.LongDescription" String="This property shall contain the KMIP server port."/>
+        </Property>
+        <Property Name="Username" Type="Edm.String">
+          <Annotation Term="OData.Permissions" EnumMember="OData.Permission/ReadWrite"/>
+          <Annotation Term="OData.Description" String="The username to access the KMIP server."/>
+          <Annotation Term="OData.LongDescription" String="This property shall contain the username to access the KMIP server."/>
+        </Property>
+        <Property Name="Password" Type="Edm.String">
+          <Annotation Term="OData.Permissions" EnumMember="OData.Permission/ReadWrite"/>
+          <Annotation Term="OData.Description" String="The password to access the KMIP server.  The value is `null` in responses."/>
+          <Annotation Term="OData.LongDescription" String="This property shall contain the password to access the KMIP server.  The value shall be `null` in responses."/>
         </Property>
       </ComplexType>
     </Schema>

--- a/static/redfish/v1/schema/Drive_v1.xml
+++ b/static/redfish/v1/schema/Drive_v1.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!---->
 <!--################################################################################                   -->
-<!--# Redfish Schema:  Drive v1.12.1                                                                   -->
+<!--# Redfish Schema:  Drive v1.13.0                                                                   -->
 <!--#                                                                                                  -->
 <!--# For a detailed change log, see the README file contained in the DSP8010 bundle,                  -->
 <!--# available at http://www.dmtf.org/standards/redfish                                               -->
@@ -59,6 +59,9 @@
   </edmx:Reference>
   <edmx:Reference Uri="http://redfish.dmtf.org/schemas/v1/SoftwareInventory_v1.xml">
     <edmx:Include Namespace="SoftwareInventory"/>
+  </edmx:Reference>
+  <edmx:Reference Uri="http://redfish.dmtf.org/schemas/v1/Storage_v1.xml">
+    <edmx:Include Namespace="Storage"/>
   </edmx:Reference>
 
   <edmx:DataServices>
@@ -226,8 +229,8 @@
           </Annotation>
         </Property>
         <Property Name="HotspareType" Type="Drive.v1_0_0.HotspareType">
-          <Annotation Term="OData.Permissions" EnumMember="OData.Permission/Read"/>
-          <Annotation Term="OData.Description" String="The type of hot spare that this drive currently serves as."/>
+          <Annotation Term="OData.Permissions" EnumMember="OData.Permission/ReadWrite"/>
+          <Annotation Term="OData.Description" String="The type of hot spare that this drive serves as."/>
           <Annotation Term="OData.LongDescription" String="This property shall contain the hot spare type for the associated drive.  If the drive currently serves as a hot spare, its Status.State field shall be 'StandbySpare' and 'Enabled' when it is part of a volume."/>
         </Property>
         <Property Name="EncryptionAbility" Type="Drive.v1_0_0.EncryptionAbility">
@@ -321,16 +324,16 @@
 
       <EnumType Name="HotspareType">
         <Member Name="None">
-          <Annotation Term="OData.Description" String="The drive is not currently a hot spare."/>
+          <Annotation Term="OData.Description" String="The drive is not a hot spare."/>
         </Member>
         <Member Name="Global">
-          <Annotation Term="OData.Description" String="The drive is currently serving as a hot spare for all other drives in the storage system."/>
+          <Annotation Term="OData.Description" String="The drive is serving as a hot spare for all other drives in this storage domain."/>
         </Member>
         <Member Name="Chassis">
-          <Annotation Term="OData.Description" String="The drive is currently serving as a hot spare for all other drives in the chassis."/>
+          <Annotation Term="OData.Description" String="The drive is serving as a hot spare for all other drives in this storage domain that are contained in the same chassis."/>
         </Member>
         <Member Name="Dedicated">
-          <Annotation Term="OData.Description" String="The drive is currently serving as a hot spare for a user-defined set of drives."/>
+          <Annotation Term="OData.Description" String="The drive is serving as a hot spare for a user-defined set of drives or volumes.  Clients cannot specify this value when modifying the HotspareType property.  This value is reported as a result of configuring the spare drives within a volume."/>
         </Member>
       </EnumType>
 
@@ -478,6 +481,12 @@
       <EntityType Name="Drive" BaseType="Drive.v1_0_11.Drive"/>
     </Schema>
 
+    <Schema xmlns="http://docs.oasis-open.org/odata/ns/edm" Namespace="Drive.v1_0_13">
+      <Annotation Term="Redfish.OwningEntity" String="DMTF"/>
+      <Annotation Term="OData.Description" String="This version was created to change the permissions for HotspareType to read-write."/>
+      <EntityType Name="Drive" BaseType="Drive.v1_0_12.Drive"/>
+    </Schema>
+
     <Schema xmlns="http://docs.oasis-open.org/odata/ns/edm" Namespace="Drive.v1_1_0">
       <Annotation Term="Redfish.OwningEntity" String="DMTF"/>
       <Annotation Term="Redfish.Release" String="2016.2"/>
@@ -587,6 +596,12 @@
       <EntityType Name="Drive" BaseType="Drive.v1_1_10.Drive"/>
     </Schema>
 
+    <Schema xmlns="http://docs.oasis-open.org/odata/ns/edm" Namespace="Drive.v1_1_12">
+      <Annotation Term="Redfish.OwningEntity" String="DMTF"/>
+      <Annotation Term="OData.Description" String="This version was created to change the permissions for HotspareType to read-write."/>
+      <EntityType Name="Drive" BaseType="Drive.v1_1_11.Drive"/>
+    </Schema>
+
     <Schema xmlns="http://docs.oasis-open.org/odata/ns/edm" Namespace="Drive.v1_2_0">
       <Annotation Term="Redfish.OwningEntity" String="DMTF"/>
       <Annotation Term="Redfish.Release" String="2017.1"/>
@@ -657,6 +672,12 @@
       <EntityType Name="Drive" BaseType="Drive.v1_2_8.Drive"/>
     </Schema>
 
+    <Schema xmlns="http://docs.oasis-open.org/odata/ns/edm" Namespace="Drive.v1_2_10">
+      <Annotation Term="Redfish.OwningEntity" String="DMTF"/>
+      <Annotation Term="OData.Description" String="This version was created to change the permissions for HotspareType to read-write."/>
+      <EntityType Name="Drive" BaseType="Drive.v1_2_9.Drive"/>
+    </Schema>
+
     <Schema xmlns="http://docs.oasis-open.org/odata/ns/edm" Namespace="Drive.v1_3_0">
       <Annotation Term="Redfish.OwningEntity" String="DMTF"/>
       <Annotation Term="Redfish.Release" String="2017.3"/>
@@ -719,6 +740,12 @@
       <EntityType Name="Drive" BaseType="Drive.v1_3_7.Drive"/>
     </Schema>
 
+    <Schema xmlns="http://docs.oasis-open.org/odata/ns/edm" Namespace="Drive.v1_3_9">
+      <Annotation Term="Redfish.OwningEntity" String="DMTF"/>
+      <Annotation Term="OData.Description" String="This version was created to change the permissions for HotspareType to read-write."/>
+      <EntityType Name="Drive" BaseType="Drive.v1_3_8.Drive"/>
+    </Schema>
+
     <Schema xmlns="http://docs.oasis-open.org/odata/ns/edm" Namespace="Drive.v1_4_0">
       <Annotation Term="Redfish.OwningEntity" String="DMTF"/>
       <Annotation Term="Redfish.Release" String="2018.1"/>
@@ -777,6 +804,12 @@
       <Annotation Term="Redfish.OwningEntity" String="DMTF"/>
       <Annotation Term="OData.Description" String="This version was created to correct various description to use proper normative terminology."/>
       <EntityType Name="Drive" BaseType="Drive.v1_4_7.Drive"/>
+    </Schema>
+
+    <Schema xmlns="http://docs.oasis-open.org/odata/ns/edm" Namespace="Drive.v1_4_9">
+      <Annotation Term="Redfish.OwningEntity" String="DMTF"/>
+      <Annotation Term="OData.Description" String="This version was created to change the permissions for HotspareType to read-write."/>
+      <EntityType Name="Drive" BaseType="Drive.v1_4_8.Drive"/>
     </Schema>
 
     <Schema xmlns="http://docs.oasis-open.org/odata/ns/edm" Namespace="Drive.v1_5_0">
@@ -843,6 +876,12 @@
       <EntityType Name="Drive" BaseType="Drive.v1_5_6.Drive"/>
     </Schema>
 
+    <Schema xmlns="http://docs.oasis-open.org/odata/ns/edm" Namespace="Drive.v1_5_8">
+      <Annotation Term="Redfish.OwningEntity" String="DMTF"/>
+      <Annotation Term="OData.Description" String="This version was created to change the permissions for HotspareType to read-write."/>
+      <EntityType Name="Drive" BaseType="Drive.v1_5_7.Drive"/>
+    </Schema>
+
     <Schema xmlns="http://docs.oasis-open.org/odata/ns/edm" Namespace="Drive.v1_6_0">
       <Annotation Term="Redfish.OwningEntity" String="DMTF"/>
       <Annotation Term="Redfish.Release" String="2019.1"/>
@@ -888,6 +927,12 @@
       <EntityType Name="Drive" BaseType="Drive.v1_6_4.Drive"/>
     </Schema>
 
+    <Schema xmlns="http://docs.oasis-open.org/odata/ns/edm" Namespace="Drive.v1_6_6">
+      <Annotation Term="Redfish.OwningEntity" String="DMTF"/>
+      <Annotation Term="OData.Description" String="This version was created to change the permissions for HotspareType to read-write."/>
+      <EntityType Name="Drive" BaseType="Drive.v1_6_5.Drive"/>
+    </Schema>
+
     <Schema xmlns="http://docs.oasis-open.org/odata/ns/edm" Namespace="Drive.v1_7_0">
       <Annotation Term="Redfish.OwningEntity" String="DMTF"/>
       <Annotation Term="Redfish.Release" String="2019.2"/>
@@ -924,6 +969,12 @@
       <Annotation Term="Redfish.OwningEntity" String="DMTF"/>
       <Annotation Term="OData.Description" String="This version was created to correct various description to use proper normative terminology."/>
       <EntityType Name="Drive" BaseType="Drive.v1_7_3.Drive"/>
+    </Schema>
+
+    <Schema xmlns="http://docs.oasis-open.org/odata/ns/edm" Namespace="Drive.v1_7_5">
+      <Annotation Term="Redfish.OwningEntity" String="DMTF"/>
+      <Annotation Term="OData.Description" String="This version was created to change the permissions for HotspareType to read-write."/>
+      <EntityType Name="Drive" BaseType="Drive.v1_7_4.Drive"/>
     </Schema>
 
     <Schema xmlns="http://docs.oasis-open.org/odata/ns/edm" Namespace="Drive.v1_8_0">
@@ -966,6 +1017,12 @@
       <EntityType Name="Drive" BaseType="Drive.v1_8_3.Drive"/>
     </Schema>
 
+    <Schema xmlns="http://docs.oasis-open.org/odata/ns/edm" Namespace="Drive.v1_8_5">
+      <Annotation Term="Redfish.OwningEntity" String="DMTF"/>
+      <Annotation Term="OData.Description" String="This version was created to change the permissions for HotspareType to read-write."/>
+      <EntityType Name="Drive" BaseType="Drive.v1_8_4.Drive"/>
+    </Schema>
+
     <Schema xmlns="http://docs.oasis-open.org/odata/ns/edm" Namespace="Drive.v1_9_0">
       <Annotation Term="Redfish.OwningEntity" String="DMTF"/>
       <Annotation Term="Redfish.Release" String="2019.4"/>
@@ -1004,6 +1061,12 @@
       <EntityType Name="Drive" BaseType="Drive.v1_9_3.Drive"/>
     </Schema>
 
+    <Schema xmlns="http://docs.oasis-open.org/odata/ns/edm" Namespace="Drive.v1_9_5">
+      <Annotation Term="Redfish.OwningEntity" String="DMTF"/>
+      <Annotation Term="OData.Description" String="This version was created to change the permissions for HotspareType to read-write."/>
+      <EntityType Name="Drive" BaseType="Drive.v1_9_4.Drive"/>
+    </Schema>
+
     <Schema xmlns="http://docs.oasis-open.org/odata/ns/edm" Namespace="Drive.v1_10_0">
       <Annotation Term="Redfish.OwningEntity" String="DMTF"/>
       <Annotation Term="Redfish.Release" String="2020.2"/>
@@ -1030,6 +1093,12 @@
       <EntityType Name="Drive" BaseType="Drive.v1_10_1.Drive"/>
     </Schema>
 
+    <Schema xmlns="http://docs.oasis-open.org/odata/ns/edm" Namespace="Drive.v1_10_3">
+      <Annotation Term="Redfish.OwningEntity" String="DMTF"/>
+      <Annotation Term="OData.Description" String="This version was created to change the permissions for HotspareType to read-write."/>
+      <EntityType Name="Drive" BaseType="Drive.v1_10_2.Drive"/>
+    </Schema>
+
     <Schema xmlns="http://docs.oasis-open.org/odata/ns/edm" Namespace="Drive.v1_11_0">
       <Annotation Term="Redfish.OwningEntity" String="DMTF"/>
       <Annotation Term="Redfish.Release" String="2020.3"/>
@@ -1054,6 +1123,12 @@
       <Annotation Term="Redfish.OwningEntity" String="DMTF"/>
       <Annotation Term="OData.Description" String="This version was created to correct various description to use proper normative terminology."/>
       <EntityType Name="Drive" BaseType="Drive.v1_11_1.Drive"/>
+    </Schema>
+
+    <Schema xmlns="http://docs.oasis-open.org/odata/ns/edm" Namespace="Drive.v1_11_3">
+      <Annotation Term="Redfish.OwningEntity" String="DMTF"/>
+      <Annotation Term="OData.Description" String="This version was created to change the permissions for HotspareType to read-write."/>
+      <EntityType Name="Drive" BaseType="Drive.v1_11_2.Drive"/>
     </Schema>
 
     <Schema xmlns="http://docs.oasis-open.org/odata/ns/edm" Namespace="Drive.v1_12_0">
@@ -1085,6 +1160,28 @@
       <Annotation Term="Redfish.OwningEntity" String="DMTF"/>
       <Annotation Term="OData.Description" String="This version was created to correct various description to use proper normative terminology."/>
       <EntityType Name="Drive" BaseType="Drive.v1_12_0.Drive"/>
+    </Schema>
+
+    <Schema xmlns="http://docs.oasis-open.org/odata/ns/edm" Namespace="Drive.v1_12_2">
+      <Annotation Term="Redfish.OwningEntity" String="DMTF"/>
+      <Annotation Term="OData.Description" String="This version was created to change the permissions for HotspareType to read-write."/>
+      <EntityType Name="Drive" BaseType="Drive.v1_12_1.Drive"/>
+    </Schema>
+
+    <Schema xmlns="http://docs.oasis-open.org/odata/ns/edm" Namespace="Drive.v1_13_0">
+      <Annotation Term="Redfish.OwningEntity" String="DMTF"/>
+      <Annotation Term="Redfish.Release" String="2021.2"/>
+
+      <EntityType Name="Drive" BaseType="Drive.v1_12_2.Drive"/>
+
+      <ComplexType Name="Links" BaseType="Drive.v1_8_0.Links">
+        <NavigationProperty Name="Storage" Type="Storage.Storage" Nullable="false">
+          <Annotation Term="OData.Permissions" EnumMember="OData.Permission/Read"/>
+          <Annotation Term="OData.Description" String="A link to the storage subsystem to which this drive belongs."/>
+          <Annotation Term="OData.LongDescription" String="This property shall contain a link to a resource of type Storage that represents the storage subsystem to which this drive belongs."/>
+          <Annotation Term="OData.AutoExpandReferences"/>
+        </NavigationProperty>
+      </ComplexType>
     </Schema>
 
   </edmx:DataServices>

--- a/static/redfish/v1/schema/EthernetInterfaceCollection_v1.xml
+++ b/static/redfish/v1/schema/EthernetInterfaceCollection_v1.xml
@@ -57,6 +57,7 @@
             <String>/redfish/v1/Systems/{ComputerSystemId}/EthernetInterfaces</String>
             <String>/redfish/v1/CompositionService/ResourceBlocks/{ResourceBlockId}/Systems/{ComputerSystemId}/EthernetInterfaces</String>
             <String>/redfish/v1/ResourceBlocks/{ResourceBlockId}/Systems/{ComputerSystemId}/EthernetInterfaces</String>
+            <String>/redfish/v1/Chassis/{ChassisId}/NetworkAdapters/{NetworkAdaptersId}/NetworkDeviceFunctions/{NetworkDeviceFunctionId}/EthernetInterfaces</String>
           </Collection>
         </Annotation>
         <NavigationProperty Name="Members" Type="Collection(EthernetInterface.EthernetInterface)">

--- a/static/redfish/v1/schema/EthernetInterface_v1.xml
+++ b/static/redfish/v1/schema/EthernetInterface_v1.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!---->
 <!--################################################################################       -->
-<!--# Redfish Schema:  EthernetInterface v1.6.4                                            -->
+<!--# Redfish Schema:  EthernetInterface v1.7.0                                            -->
 <!--#                                                                                      -->
 <!--# For a detailed change log, see the README file contained in the DSP8010 bundle,      -->
 <!--# available at http://www.dmtf.org/standards/redfish                                   -->
@@ -82,6 +82,7 @@
             <String>/redfish/v1/CompositionService/ResourceBlocks/{ResourceBlockId}/Systems/{ComputerSystemId}/EthernetInterfaces/{EthernetInterfaceId}</String>
             <String>/redfish/v1/ResourceBlocks/{ResourceBlockId}/EthernetInterfaces/{EthernetInterfaceId}</String>
             <String>/redfish/v1/ResourceBlocks/{ResourceBlockId}/Systems/{ComputerSystemId}/EthernetInterfaces/{EthernetInterfaceId}</String>
+            <String>/redfish/v1/Chassis/{ChassisId}/NetworkAdapters/{NetworkAdaptersId}/NetworkDeviceFunctions/{NetworkDeviceFunctionId}/EthernetInterfaces/{EthernetInterfaceId}</String>
           </Collection>
         </Annotation>
       </EntityType>
@@ -188,6 +189,15 @@
           <Annotation Term="OData.Description" String="The link to a collection of VLANs, which applies only if the interface supports more than one VLAN.  If this property applies, the VLANEnabled and VLANId properties do not apply."/>
           <Annotation Term="OData.LongDescription" String="This property shall contain a link to a resource collection of type VLanNetworkInterfaceCollection, which applies only if the interface supports more than one VLAN.  If this property is present, the VLANEnabled and VLANId properties shall not be present."/>
           <Annotation Term="OData.AutoExpandReferences"/>
+          <Annotation Term="Redfish.Revisions">
+            <Collection>
+              <Record>
+                <PropertyValue Property="Kind" EnumMember="Redfish.RevisionKind/Deprecated"/>
+                <PropertyValue Property="Version" String="v1_7_0"/>
+                <PropertyValue Property="Description" String="This property has been deprecated in favor of newer methods indicating multiple VLANs."/>
+              </Record>
+            </Collection>
+          </Annotation>
         </NavigationProperty>
       </EntityType>
 
@@ -830,6 +840,15 @@
           <Annotation Term="OData.Description" String="The link to the parent network device function and is only used when representing one of the VLANs on that network device function, such as is done in Unix."/>
           <Annotation Term="OData.LongDescription" String="This property shall contain a link to a resource of type NetworkDeviceFunction and only be populated with the EthernetInterfaceType property is `Virtual`."/>
           <Annotation Term="OData.AutoExpandReferences"/>
+          <Annotation Term="Redfish.Revisions">
+            <Collection>
+              <Record>
+                <PropertyValue Property="Kind" EnumMember="Redfish.RevisionKind/Deprecated"/>
+                <PropertyValue Property="Version" String="v1_7_0"/>
+                <PropertyValue Property="Description" String="This property has been deprecated in favor of NetworkDeviceFunctions as each EthernetInterface could represent more than one NetworkDeviceFunction."/>
+              </Record>
+            </Collection>
+          </Annotation>
         </NavigationProperty>
       </ComplexType>
 
@@ -867,6 +886,22 @@
       <Annotation Term="Redfish.OwningEntity" String="DMTF"/>
       <Annotation Term="OData.Description" String="This version was created to correct various description to use proper normative terminology."/>
       <EntityType Name="EthernetInterface" BaseType="EthernetInterface.v1_6_3.EthernetInterface"/>
+    </Schema>
+
+    <Schema xmlns="http://docs.oasis-open.org/odata/ns/edm" Namespace="EthernetInterface.v1_7_0">
+      <Annotation Term="Redfish.OwningEntity" String="DMTF"/>
+      <Annotation Term="Redfish.Release" String="2021.2"/>
+      <Annotation Term="OData.Description" String="This version was created to deprecate several properties and add NetworkDeviceFunctions link collection."/>
+      <EntityType Name="EthernetInterface" BaseType="EthernetInterface.v1_6_4.EthernetInterface"/>
+
+      <ComplexType Name="Links" BaseType="EthernetInterface.v1_6_0.Links">
+        <NavigationProperty Name="NetworkDeviceFunctions" Type="Collection(NetworkDeviceFunction.NetworkDeviceFunction)">
+          <Annotation Term="OData.Permissions" EnumMember="OData.Permission/Read"/>
+          <Annotation Term="OData.Description" String="The link to the network device functions that comprise this Ethernet interface."/>
+          <Annotation Term="OData.LongDescription" String="This property shall contain an array of links to resources of type NetworkDeviceFunction."/>
+          <Annotation Term="OData.AutoExpandReferences"/>
+        </NavigationProperty>
+      </ComplexType>
     </Schema>
 
   </edmx:DataServices>

--- a/static/redfish/v1/schema/EventDestination_v1.xml
+++ b/static/redfish/v1/schema/EventDestination_v1.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!---->
 <!--################################################################################       -->
-<!--# Redfish Schema:  EventDestination v1.10.1                                            -->
+<!--# Redfish Schema:  EventDestination v1.11.0                                            -->
 <!--#                                                                                      -->
 <!--# For a detailed change log, see the README file contained in the DSP8010 bundle,      -->
 <!--# available at http://www.dmtf.org/standards/redfish                                   -->
@@ -866,7 +866,7 @@
           <Annotation Term="OData.LongDescription" String="This property shall indicate whether whether the service will verify the certificate of the server referenced by the Destination property prior to sending the event."/>
         </Property>
         <Property Name="SyslogFilters" Type="Collection(EventDestination.v1_9_0.SyslogFilter)">
-          <Annotation Term="OData.Description" String="A list of syslog message filters to send to a remote syslog server."/>
+          <Annotation Term="OData.Description" String="A list of filters applied to syslog messages before sending to a remote syslog server.  An empty list indicates all syslog messages are sent."/>
           <Annotation Term="OData.LongDescription" String="This property shall describe all desired syslog messages to send to a remote syslog server.  If this property contains an empty array or is absent, all messages shall be sent."/>
         </Property>
         <Property Name="OEMProtocol" Type="Edm.String" Nullable="false">
@@ -1019,6 +1019,12 @@
       <EntityType Name="EventDestination" BaseType="EventDestination.v1_9_1.EventDestination"/>
     </Schema>
 
+    <Schema xmlns="http://docs.oasis-open.org/odata/ns/edm" Namespace="EventDestination.v1_9_3">
+      <Annotation Term="Redfish.OwningEntity" String="DMTF"/>
+      <Annotation Term="OData.Description" String="This version was created to improve the description of SyslogFilters."/>
+      <EntityType Name="EventDestination" BaseType="EventDestination.v1_9_2.EventDestination"/>
+    </Schema>
+
     <Schema xmlns="http://docs.oasis-open.org/odata/ns/edm" Namespace="EventDestination.v1_10_0">
       <Annotation Term="Redfish.OwningEntity" String="DMTF"/>
       <Annotation Term="OData.Description" String="This version was created to add additional SNMP authentication protocols and to provide better description for the authentication and encryption keys.  It also added `RetryForeverWithBackoff` to DeliveryRetryPolicy and long description details to the DeliveryRetryPolicy values."/>
@@ -1044,6 +1050,38 @@
       <Annotation Term="Redfish.OwningEntity" String="DMTF"/>
       <Annotation Term="OData.Description" String="This version was created to correct various description to use proper normative terminology."/>
       <EntityType Name="EventDestination" BaseType="EventDestination.v1_10_0.EventDestination"/>
+    </Schema>
+
+    <Schema xmlns="http://docs.oasis-open.org/odata/ns/edm" Namespace="EventDestination.v1_10_2">
+      <Annotation Term="Redfish.OwningEntity" String="DMTF"/>
+      <Annotation Term="OData.Description" String="This version was created to improve the description of SyslogFilters."/>
+      <EntityType Name="EventDestination" BaseType="EventDestination.v1_10_1.EventDestination"/>
+    </Schema>
+
+    <Schema xmlns="http://docs.oasis-open.org/odata/ns/edm" Namespace="EventDestination.v1_11_0">
+      <Annotation Term="Redfish.OwningEntity" String="DMTF"/>
+      <Annotation Term="Redfish.Release" String="2021.2"/>
+
+      <EntityType Name="EventDestination" BaseType="EventDestination.v1_10_2.EventDestination">
+        <Property Name="SendHeartbeat" Type="Edm.Boolean">
+          <Annotation Term="OData.Permissions" EnumMember="OData.Permission/Read"/>
+          <Annotation Term="OData.Description" String="Send a heartbeat event periodically to the destination."/>
+          <Annotation Term="OData.LongDescription" String="This property shall indicate that the service shall periodically send the `RedfishServiceFunctional` message defined in the Heartbeat Event Message Registry to the subscriber.  If this property is not present, no periodic event shall be sent.  This property shall not apply to event destinations if the SubscriptionType property contains the value `SSE`."/>
+        </Property>
+        <Property Name="HeartbeatIntervalMinutes" Type="Edm.Int64">
+          <Annotation Term="OData.Permissions" EnumMember="OData.Permission/Read"/>
+          <Annotation Term="OData.Description" String="Interval for sending heartbeat events to the destination in minutes."/>
+          <Annotation Term="OData.LongDescription" String="This property shall indicate the interval for sending periodic heartbeat events to the subscriber.  The value shall be the interval, in minutes, between each periodic event.  This property shall not be present if the SendHeartbeat property is not present."/>
+          <Annotation Term="Validation.Minimum" Int="1"/>
+          <Annotation Term="Validation.Maximum" Int="65535"/>
+        </Property>
+        <NavigationProperty Name="ClientCertificates" Type="CertificateCollection.CertificateCollection" ContainsTarget="true" Nullable="false">
+          <Annotation Term="OData.Permissions" EnumMember="OData.Permission/Read"/>
+          <Annotation Term="OData.Description" String="The link to a collection of client identity certificates provided to the server referenced by the Destination property."/>
+          <Annotation Term="OData.LongDescription" String="This property shall contain a link to a resource collection of type CertificateCollection that represents the client identity certificates that are provided to the server referenced by the Destination property as part of TLS handshaking."/>
+          <Annotation Term="OData.AutoExpandReferences"/>
+        </NavigationProperty>
+      </EntityType>
     </Schema>
 
   </edmx:DataServices>

--- a/static/redfish/v1/schema/EventService_v1.xml
+++ b/static/redfish/v1/schema/EventService_v1.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!---->
 <!--################################################################################       -->
-<!--# Redfish Schema:  EventService v1.7.1                                                 -->
+<!--# Redfish Schema:  EventService v1.7.2                                                 -->
 <!--#                                                                                      -->
 <!--# For a detailed change log, see the README file contained in the DSP8010 bundle,      -->
 <!--# available at http://www.dmtf.org/standards/redfish                                   -->
@@ -137,8 +137,8 @@
       <EntityType Name="EventService" BaseType="EventService.EventService">
         <Property Name="ServiceEnabled" Type="Edm.Boolean">
           <Annotation Term="OData.Permissions" EnumMember="OData.Permission/ReadWrite"/>
-          <Annotation Term="OData.Description" String="An indication of whether this service is enabled."/>
-          <Annotation Term="OData.LongDescription" String="This property shall indicate whether this service is enabled."/>
+          <Annotation Term="OData.Description" String="An indication of whether this service is enabled.  If `false`, events are no longer published, new SSE connections cannot be established, and existing SSE connections are terminated."/>
+          <Annotation Term="OData.LongDescription" String="This property shall indicate whether this service is enabled.  If `false`, events are no longer published, new SSE connections cannot be established, and existing SSE connections are terminated."/>
         </Property>
         <Property Name="DeliveryRetryAttempts" Type="Edm.Int64" Nullable="false">
           <Annotation Term="OData.Permissions" EnumMember="OData.Permission/ReadWrite"/>
@@ -270,6 +270,12 @@
       <EntityType Name="EventService" BaseType="EventService.v1_0_12.EventService"/>
     </Schema>
 
+    <Schema xmlns="http://docs.oasis-open.org/odata/ns/edm" Namespace="EventService.v1_0_14">
+      <Annotation Term="Redfish.OwningEntity" String="DMTF"/>
+      <Annotation Term="OData.Description" String="This version was created to clarify the behavior of the event service when it is disabled."/>
+      <EntityType Name="EventService" BaseType="EventService.v1_0_13.EventService"/>
+    </Schema>
+
     <Schema xmlns="http://docs.oasis-open.org/odata/ns/edm" Namespace="EventService.v1_1_0">
       <Annotation Term="Redfish.OwningEntity" String="DMTF"/>
       <Annotation Term="Redfish.Release" String="2018.1"/>
@@ -318,6 +324,12 @@
       <Annotation Term="Redfish.OwningEntity" String="DMTF"/>
       <Annotation Term="OData.Description" String="This version was created specify 64-bit integers in OpenAPI."/>
       <EntityType Name="EventService" BaseType="EventService.v1_1_5.EventService"/>
+    </Schema>
+
+    <Schema xmlns="http://docs.oasis-open.org/odata/ns/edm" Namespace="EventService.v1_1_7">
+      <Annotation Term="Redfish.OwningEntity" String="DMTF"/>
+      <Annotation Term="OData.Description" String="This version was created to clarify the behavior of the event service when it is disabled."/>
+      <EntityType Name="EventService" BaseType="EventService.v1_1_6.EventService"/>
     </Schema>
 
     <Schema xmlns="http://docs.oasis-open.org/odata/ns/edm" Namespace="EventService.v1_2_0">
@@ -433,6 +445,12 @@
       <EntityType Name="EventService" BaseType="EventService.v1_2_4.EventService"/>
     </Schema>
 
+    <Schema xmlns="http://docs.oasis-open.org/odata/ns/edm" Namespace="EventService.v1_2_6">
+      <Annotation Term="Redfish.OwningEntity" String="DMTF"/>
+      <Annotation Term="OData.Description" String="This version was created to clarify the behavior of the event service when it is disabled."/>
+      <EntityType Name="EventService" BaseType="EventService.v1_2_5.EventService"/>
+    </Schema>
+
     <Schema xmlns="http://docs.oasis-open.org/odata/ns/edm" Namespace="EventService.v1_3_0">
       <Annotation Term="Redfish.OwningEntity" String="DMTF"/>
       <Annotation Term="Redfish.Release" String="2019.1"/>
@@ -463,6 +481,12 @@
       <Annotation Term="Redfish.OwningEntity" String="DMTF"/>
       <Annotation Term="OData.Description" String="This version was created to correct various typographical errors."/>
       <EntityType Name="EventService" BaseType="EventService.v1_3_3.EventService"/>
+    </Schema>
+
+    <Schema xmlns="http://docs.oasis-open.org/odata/ns/edm" Namespace="EventService.v1_3_5">
+      <Annotation Term="Redfish.OwningEntity" String="DMTF"/>
+      <Annotation Term="OData.Description" String="This version was created to clarify the behavior of the event service when it is disabled."/>
+      <EntityType Name="EventService" BaseType="EventService.v1_3_4.EventService"/>
     </Schema>
 
     <Schema xmlns="http://docs.oasis-open.org/odata/ns/edm" Namespace="EventService.v1_4_0">
@@ -496,6 +520,12 @@
       <Annotation Term="Redfish.OwningEntity" String="DMTF"/>
       <Annotation Term="OData.Description" String="This version was created to correct various typographical errors."/>
       <EntityType Name="EventService" BaseType="EventService.v1_4_2.EventService"/>
+    </Schema>
+
+    <Schema xmlns="http://docs.oasis-open.org/odata/ns/edm" Namespace="EventService.v1_4_5">
+      <Annotation Term="Redfish.OwningEntity" String="DMTF"/>
+      <Annotation Term="OData.Description" String="This version was created to clarify the behavior of the event service when it is disabled."/>
+      <EntityType Name="EventService" BaseType="EventService.v1_4_3.EventService"/>
     </Schema>
 
     <Schema xmlns="http://docs.oasis-open.org/odata/ns/edm" Namespace="EventService.v1_5_0">
@@ -627,6 +657,12 @@
       <EntityType Name="EventService" BaseType="EventService.v1_5_2.EventService"/>
     </Schema>
 
+    <Schema xmlns="http://docs.oasis-open.org/odata/ns/edm" Namespace="EventService.v1_5_4">
+      <Annotation Term="Redfish.OwningEntity" String="DMTF"/>
+      <Annotation Term="OData.Description" String="This version was created to clarify the behavior of the event service when it is disabled."/>
+      <EntityType Name="EventService" BaseType="EventService.v1_5_3.EventService"/>
+    </Schema>
+
     <Schema xmlns="http://docs.oasis-open.org/odata/ns/edm" Namespace="EventService.v1_6_0">
       <Annotation Term="Redfish.OwningEntity" String="DMTF"/>
       <Annotation Term="Redfish.Release" String="2020.1"/>
@@ -652,6 +688,12 @@
       <EntityType Name="EventService" BaseType="EventService.v1_6_1.EventService"/>
     </Schema>
 
+    <Schema xmlns="http://docs.oasis-open.org/odata/ns/edm" Namespace="EventService.v1_6_3">
+      <Annotation Term="Redfish.OwningEntity" String="DMTF"/>
+      <Annotation Term="OData.Description" String="This version was created to clarify the behavior of the event service when it is disabled."/>
+      <EntityType Name="EventService" BaseType="EventService.v1_6_2.EventService"/>
+    </Schema>
+
     <Schema xmlns="http://docs.oasis-open.org/odata/ns/edm" Namespace="EventService.v1_7_0">
       <Annotation Term="Redfish.OwningEntity" String="DMTF"/>
       <Annotation Term="Redfish.Release" String="2020.2"/>
@@ -664,6 +706,12 @@
       <Annotation Term="Redfish.OwningEntity" String="DMTF"/>
       <Annotation Term="OData.Description" String="This version was created to correct various typographical errors."/>
       <EntityType Name="EventService" BaseType="EventService.v1_7_0.EventService"/>
+    </Schema>
+
+    <Schema xmlns="http://docs.oasis-open.org/odata/ns/edm" Namespace="EventService.v1_7_2">
+      <Annotation Term="Redfish.OwningEntity" String="DMTF"/>
+      <Annotation Term="OData.Description" String="This version was created to clarify the behavior of the event service when it is disabled."/>
+      <EntityType Name="EventService" BaseType="EventService.v1_7_1.EventService"/>
     </Schema>
 
   </edmx:DataServices>

--- a/static/redfish/v1/schema/Event_v1.xml
+++ b/static/redfish/v1/schema/Event_v1.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!---->
 <!--################################################################################       -->
-<!--# Redfish Schema:  Event v1.6.1                                                        -->
+<!--# Redfish Schema:  Event v1.7.0                                                        -->
 <!--#                                                                                      -->
 <!--# For a detailed change log, see the README file contained in the DSP8010 bundle,      -->
 <!--# available at http://www.dmtf.org/standards/redfish                                   -->
@@ -24,6 +24,9 @@
   <edmx:Reference Uri="http://redfish.dmtf.org/schemas/v1/Resource_v1.xml">
     <edmx:Include Namespace="Resource"/>
     <edmx:Include Namespace="Resource.v1_0_0"/>
+  </edmx:Reference>
+  <edmx:Reference Uri="http://redfish.dmtf.org/schemas/v1/LogEntry_v1.xml">
+    <edmx:Include Namespace="LogEntry"/>
   </edmx:Reference>
 
   <edmx:DataServices>
@@ -626,6 +629,22 @@
       <Annotation Term="OData.Description" String="This version was created to correct the description for MessageId, and to align descriptions between the Message and Event schemas.  It was also updated to remove language in the long description for EventId to align with the specification."/>
       <EntityType Name="Event" BaseType="Event.v1_6_0.Event"/>
       <EntityType Name="EventRecord" BaseType="Event.v1_6_0.EventRecord"/>
+    </Schema>
+
+    <Schema xmlns="http://docs.oasis-open.org/odata/ns/edm" Namespace="Event.v1_7_0">
+      <Annotation Term="Redfish.OwningEntity" String="DMTF"/>
+      <Annotation Term="Redfish.Release" String="2021.2"/>
+
+      <EntityType Name="Event" BaseType="Event.v1_6_1.Event"/>
+
+      <EntityType Name="EventRecord" BaseType="Event.v1_6_1.EventRecord">
+        <NavigationProperty Name="LogEntry" Type="LogEntry.LogEntry" Nullable="false">
+          <Annotation Term="OData.Permissions" EnumMember="OData.Permission/Read"/>
+          <Annotation Term="OData.Description" String="The link to a log entry if an entry was created for this event."/>
+          <Annotation Term="OData.LongDescription" String="This property shall contain a link to a resource of type LogEntry that represents the log entry created for this event."/>
+          <Annotation Term="OData.AutoExpandReferences"/>
+        </NavigationProperty>
+      </EntityType>
     </Schema>
 
   </edmx:DataServices>

--- a/static/redfish/v1/schema/LogEntryCollection_v1.xml
+++ b/static/redfish/v1/schema/LogEntryCollection_v1.xml
@@ -59,6 +59,7 @@
             <String>/redfish/v1/Chassis/{ChassisId}/LogServices/{LogServiceId}/Entries</String>
             <String>/redfish/v1/JobService/Log/Entries</String>
             <String>/redfish/v1/TelemetryService/LogService/Entries</String>
+            <String>/redfish/v1/Systems/{ComputerSystemId}/Memory/{MemoryId}/DeviceLog/Entries</String>
           </Collection>
         </Annotation>
         <NavigationProperty Name="Members" Type="Collection(LogEntry.LogEntry)">

--- a/static/redfish/v1/schema/LogEntry_v1.xml
+++ b/static/redfish/v1/schema/LogEntry_v1.xml
@@ -65,6 +65,7 @@
             <String>/redfish/v1/Chassis/{ChassisId}/LogServices/{LogServiceId}/Entries/{LogEntryId}</String>
             <String>/redfish/v1/JobService/Log/Entries/{LogEntryId}</String>
             <String>/redfish/v1/TelemetryService/LogService/Entries/{LogEntryId}</String>
+            <String>/redfish/v1/Systems/{ComputerSystemId}/Memory/{MemoryId}/DeviceLog/Entries/{LogEntryId}</String>
           </Collection>
         </Annotation>
       </EntityType>

--- a/static/redfish/v1/schema/LogService_v1.xml
+++ b/static/redfish/v1/schema/LogService_v1.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!---->
 <!--################################################################################       -->
-<!--# Redfish Schema:  LogService v1.2.0                                                   -->
+<!--# Redfish Schema:  LogService v1.3.0                                                   -->
 <!--#                                                                                      -->
 <!--# For a detailed change log, see the README file contained in the DSP8010 bundle,      -->
 <!--# available at http://www.dmtf.org/standards/redfish                                   -->
@@ -35,8 +35,8 @@
       <Annotation Term="Redfish.OwningEntity" String="DMTF"/>
 
       <EntityType Name="LogService" BaseType="Resource.v1_0_0.Resource" Abstract="true">
-        <Annotation Term="OData.Description" String="The LogService schema contains properties for monitoring and configuring a Log Service."/>
-        <Annotation Term="OData.LongDescription" String="This Resource shall represent a Log Service for a Redfish implementation."/>
+        <Annotation Term="OData.Description" String="The LogService schema contains properties for monitoring and configuring a log service.  When the Id property contains `DeviceLog`, the log contains device-resident log entries that follow the physical device when moved from system-to-system, and not a replication or subset of a system event log."/>
+        <Annotation Term="OData.LongDescription" String="This resource shall represent a log service for a Redfish implementation.  When the Id property contains `DeviceLog`, the log shall contain log entries that migrate with the device."/>
         <Annotation Term="Capabilities.InsertRestrictions">
           <Record>
             <PropertyValue Property="Insertable" Bool="false"/>
@@ -45,7 +45,7 @@
         <Annotation Term="Capabilities.UpdateRestrictions">
           <Record>
             <PropertyValue Property="Updatable" Bool="true"/>
-            <Annotation Term="OData.Description" String="The date and time properties can be updated for a Log Service."/>
+            <Annotation Term="OData.Description" String="The date and time properties can be updated for a log service."/>
           </Record>
         </Annotation>
         <Annotation Term="Capabilities.DeleteRestrictions">
@@ -62,14 +62,27 @@
             <String>/redfish/v1/Chassis/{ChassisId}/LogServices/{LogServiceId}</String>
             <String>/redfish/v1/JobService/Log</String>
             <String>/redfish/v1/TelemetryService/LogService</String>
+            <String>/redfish/v1/Systems/{ComputerSystemId}/Memory/{MemoryId}/DeviceLog</String>
           </Collection>
         </Annotation>
       </EntityType>
 
       <Action Name="ClearLog" IsBound="true">
+        <Annotation Term="OData.Description" String="The action to clear the log for this log service."/>
+        <Annotation Term="OData.LongDescription" String="This action shall delete all entries found in the LogEntryCollection resource for this log service."/>
         <Parameter Name="LogService" Type="LogService.v1_0_0.Actions"/>
-        <Annotation Term="OData.Description" String="The action to clear the log for this Log Service."/>
-        <Annotation Term="OData.LongDescription" String="This action shall delete all entries found in the Entries collection for this Log Service."/>
+        <Parameter Name="LogEntriesETag" Type="Edm.String">
+          <Annotation Term="OData.Description" String="The ETag of the log entry collection within this log service.  If the provided ETag does not match the current ETag of the log entry collection, the request is rejected."/>
+          <Annotation Term="OData.LongDescription" String="This parameter shall contain the ETag of the LogEntryCollection resource for this log service.  If the client-provided ETag does not match the current ETag of the LogEntryCollection resource for this log service, the service shall return the HTTP 428 (Precondition Required) status code to reject the request."/>
+          <Annotation Term="Redfish.Revisions">
+            <Collection>
+              <Record>
+                <PropertyValue Property="Kind" EnumMember="Redfish.RevisionKind/Added"/>
+                <PropertyValue Property="Version" String="v1_3_0"/>
+              </Record>
+            </Collection>
+          </Annotation>
+        </Parameter>
       </Action>
 
       <Action Name="CollectDiagnosticData" IsBound="true">
@@ -108,55 +121,55 @@
         <Property Name="MaxNumberOfRecords" Type="Edm.Int64" Nullable="false">
           <Annotation Term="OData.Permissions" EnumMember="OData.Permission/Read"/>
           <Annotation Term="OData.Description" String="The maximum number of log entries that this service can have."/>
-          <Annotation Term="OData.LongDescription" String="This property shall contain the maximum number of LogEntry Resources in the Entries collection for this service."/>
+          <Annotation Term="OData.LongDescription" String="This property shall contain the maximum number of LogEntry resources in the LogEntryCollection resource for this service."/>
           <Annotation Term="Validation.Minimum" Int="0"/>
         </Property>
         <Property Name="OverWritePolicy" Type="LogService.v1_0_0.OverWritePolicy" Nullable="false">
           <Annotation Term="OData.Permissions" EnumMember="OData.Permission/Read"/>
           <Annotation Term="OData.Description" String="The overwrite policy for this service that takes place when the log is full."/>
-          <Annotation Term="OData.LongDescription" String="This property shall indicate the policy of the Log Service when the MaxNumberOfRecords has been reached."/>
+          <Annotation Term="OData.LongDescription" String="This property shall indicate the policy of the log service when the MaxNumberOfRecords has been reached."/>
         </Property>
         <Property Name="DateTime" Type="Edm.DateTimeOffset">
           <Annotation Term="OData.Permissions" EnumMember="OData.Permission/ReadWrite"/>
-          <Annotation Term="OData.Description" String="The current date and time, with UTC offset, that the Log Service uses to set or read time."/>
-          <Annotation Term="OData.LongDescription" String="This property shall represent the current DateTime value, with UTC offset, in Redfish Timestamp format that the Log Service uses to set or read time."/>
+          <Annotation Term="OData.Description" String="The current date and time with UTC offset of the log service."/>
+          <Annotation Term="OData.LongDescription" String="This property shall contain the current date and time with UTC offset of the log service."/>
         </Property>
         <Property Name="DateTimeLocalOffset" Type="Edm.String">
           <Annotation Term="OData.Permissions" EnumMember="OData.Permission/ReadWrite"/>
-          <Annotation Term="OData.Description" String="The UTC offset that the current DateTime property value contains in the `+HH:MM` format."/>
-          <Annotation Term="OData.LongDescription" String="This property shall represent the UTC offset that the current DateTime property value contains."/>
+          <Annotation Term="OData.Description" String="The time offset from UTC that the DateTime property is in `+HH:MM` format."/>
+          <Annotation Term="OData.LongDescription" String="This property shall contain the offset from UTC time that the DateTime property contains.  If both DateTime and DateTimeLocalOffset are provided in modification requests, services shall apply DateTimeLocalOffset after DateTime is applied."/>
           <Annotation Term="Validation.Pattern" String="^([-+][0-1][0-9]:[0-5][0-9])$"/>
         </Property>
         <NavigationProperty Name="Entries" Type="LogEntryCollection.LogEntryCollection" ContainsTarget="true" Nullable="false">
           <Annotation Term="OData.Permissions" EnumMember="OData.Permission/Read"/>
           <Annotation Term="OData.Description" String="The link to the log entry collection."/>
-          <Annotation Term="OData.LongDescription" String="This property shall contain a link to a Resource Collection of type LogEntryCollection."/>
+          <Annotation Term="OData.LongDescription" String="This property shall contain a link to a resource collection of type LogEntryCollection."/>
           <Annotation Term="OData.AutoExpandReferences"/>
         </NavigationProperty>
         <Property Name="Actions" Type="LogService.v1_0_0.Actions" Nullable="false">
-          <Annotation Term="OData.Description" String="The available actions for this Resource."/>
-          <Annotation Term="OData.LongDescription" String="This property shall contain the available actions for this Resource."/>
+          <Annotation Term="OData.Description" String="The available actions for this resource."/>
+          <Annotation Term="OData.LongDescription" String="This property shall contain the available actions for this resource."/>
         </Property>
         <Property Name="Status" Type="Resource.Status" Nullable="false">
-          <Annotation Term="OData.Description" String="The status and health of the Resource and its subordinate or dependent Resources."/>
-          <Annotation Term="OData.LongDescription" String="This property shall contain any status or health properties of the Resource."/>
+          <Annotation Term="OData.Description" String="The status and health of the resource and its subordinate or dependent resources."/>
+          <Annotation Term="OData.LongDescription" String="This property shall contain any status or health properties of the resource."/>
         </Property>
       </EntityType>
 
       <ComplexType Name="Actions">
         <Annotation Term="OData.AdditionalProperties" Bool="false"/>
-        <Annotation Term="OData.Description" String="The available actions for this Resource."/>
-        <Annotation Term="OData.LongDescription" String="This type shall contain the available actions for this Resource."/>
+        <Annotation Term="OData.Description" String="The available actions for this resource."/>
+        <Annotation Term="OData.LongDescription" String="This type shall contain the available actions for this resource."/>
         <Property Name="Oem" Type="LogService.v1_0_0.OemActions" Nullable="false">
-          <Annotation Term="OData.Description" String="The available OEM-specific actions for this Resource."/>
-          <Annotation Term="OData.LongDescription" String="This property shall contain the available OEM-specific actions for this Resource."/>
+          <Annotation Term="OData.Description" String="The available OEM-specific actions for this resource."/>
+          <Annotation Term="OData.LongDescription" String="This property shall contain the available OEM-specific actions for this resource."/>
         </Property>
       </ComplexType>
 
       <ComplexType Name="OemActions">
         <Annotation Term="OData.AdditionalProperties" Bool="true"/>
-        <Annotation Term="OData.Description" String="The available OEM-specific actions for this Resource."/>
-        <Annotation Term="OData.LongDescription" String="This type shall contain the available OEM-specific actions for this Resource."/>
+        <Annotation Term="OData.Description" String="The available OEM-specific actions for this resource."/>
+        <Annotation Term="OData.LongDescription" String="This type shall contain the available OEM-specific actions for this resource."/>
       </ComplexType>
 
       <EnumType Name="OverWritePolicy">
@@ -192,7 +205,7 @@
 
     <Schema xmlns="http://docs.oasis-open.org/odata/ns/edm" Namespace="LogService.v1_0_5">
       <Annotation Term="Redfish.OwningEntity" String="DMTF"/>
-      <Annotation Term="OData.Description" String="This version was created to correct the short and long descriptions in the defined Actions."/>
+      <Annotation Term="OData.Description" String="This version was created to correct the short and long descriptions in the defined actions."/>
       <EntityType Name="LogService" BaseType="LogService.v1_0_4.LogService"/>
     </Schema>
 
@@ -214,6 +227,12 @@
       <EntityType Name="LogService" BaseType="LogService.v1_0_7.LogService"/>
     </Schema>
 
+    <Schema xmlns="http://docs.oasis-open.org/odata/ns/edm" Namespace="LogService.v1_0_9">
+      <Annotation Term="Redfish.OwningEntity" String="DMTF"/>
+      <Annotation Term="OData.Description" String="This version was created to correct various typographical errors."/>
+      <EntityType Name="LogService" BaseType="LogService.v1_0_8.LogService"/>
+    </Schema>
+
     <Schema xmlns="http://docs.oasis-open.org/odata/ns/edm" Namespace="LogService.v1_1_0">
       <Annotation Term="Redfish.OwningEntity" String="DMTF"/>
       <Annotation Term="Redfish.Release" String="2017.3"/>
@@ -223,7 +242,7 @@
         <Property Name="LogEntryType" Type="LogService.v1_1_0.LogEntryTypes">
           <Annotation Term="OData.Permissions" EnumMember="OData.Permission/Read"/>
           <Annotation Term="OData.Description" String="The format of the log entries."/>
-          <Annotation Term="OData.LongDescription" String="This property shall represent the EntryType of all LogEntry Resources contained in the Entries collection.  If the service cannot determine or guarantee a single EntryType for all LogEntry Resources, this property's value shall be `Multiple`."/>
+          <Annotation Term="OData.LongDescription" String="This property shall contain the value for the EntryType property of all LogEntry resources contained in the LogEntryCollection resource for this log service.  If the service cannot determine or guarantee a single EntryType value for all LogEntry resources, this property shall contain the value `Multiple`."/>
         </Property>
       </EntityType>
 
@@ -235,7 +254,7 @@
           <Annotation Term="OData.Description" String="The log contains legacy IPMI System Event Log (SEL) entries."/>
         </Member>
         <Member Name="Multiple">
-          <Annotation Term="OData.Description" String="The log contains multiple log entry types and, therefore, the Log Service cannot guarantee a single entry type."/>
+          <Annotation Term="OData.Description" String="The log contains multiple log entry types and, therefore, the log service cannot guarantee a single entry type."/>
         </Member>
         <Member Name="OEM">
           <Annotation Term="OData.Description" String="The log contains entries in an OEM-defined format."/>
@@ -259,6 +278,12 @@
       <Annotation Term="Redfish.OwningEntity" String="DMTF"/>
       <Annotation Term="OData.Description" String="This version was created to update descriptions that this schema defines."/>
       <EntityType Name="LogService" BaseType="LogService.v1_1_2.LogService"/>
+    </Schema>
+
+    <Schema xmlns="http://docs.oasis-open.org/odata/ns/edm" Namespace="LogService.v1_1_4">
+      <Annotation Term="Redfish.OwningEntity" String="DMTF"/>
+      <Annotation Term="OData.Description" String="This version was created to correct various typographical errors."/>
+      <EntityType Name="LogService" BaseType="LogService.v1_1_3.LogService"/>
     </Schema>
 
     <Schema xmlns="http://docs.oasis-open.org/odata/ns/edm" Namespace="LogService.v1_2_0">
@@ -412,6 +437,26 @@
           <Annotation Term="OData.Description" String="OEM diagnostic data."/>
         </Member>
       </EnumType>
+    </Schema>
+
+    <Schema xmlns="http://docs.oasis-open.org/odata/ns/edm" Namespace="LogService.v1_2_1">
+      <Annotation Term="Redfish.OwningEntity" String="DMTF"/>
+      <Annotation Term="OData.Description" String="This version was created to correct various typographical errors."/>
+      <EntityType Name="LogService" BaseType="LogService.v1_2_0.LogService"/>
+    </Schema>
+
+    <Schema xmlns="http://docs.oasis-open.org/odata/ns/edm" Namespace="LogService.v1_3_0">
+      <Annotation Term="Redfish.OwningEntity" String="DMTF"/>
+      <Annotation Term="Redfish.Release" String="2021.2"/>
+      <Annotation Term="OData.Description" String="This version was created to add the LogEntriesETag parameter to the ClearLog action."/>
+
+      <EntityType Name="LogService" BaseType="LogService.v1_2_1.LogService">
+        <Property Name="AutoDSTEnabled" Type="Edm.Boolean" Nullable="false">
+          <Annotation Term="OData.Permissions" EnumMember="OData.Permission/ReadWrite"/>
+          <Annotation Term="OData.Description" String="An indication of whether the log service is configured for automatic Daylight Saving Time (DST) adjustment."/>
+          <Annotation Term="OData.LongDescription" String="This property shall indicate whether the log service is configured for automatic Daylight Saving Time (DST) adjustment.  DST adjustment shall not modify the timestamp of existing log entries."/>
+        </Property>
+      </EntityType>
     </Schema>
 
   </edmx:DataServices>

--- a/static/redfish/v1/schema/ManagerNetworkProtocol_v1.xml
+++ b/static/redfish/v1/schema/ManagerNetworkProtocol_v1.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!---->
 <!--################################################################################       -->
-<!--# Redfish Schema:  ManagerNetworkProtocol v1.7.0                                       -->
+<!--# Redfish Schema:  ManagerNetworkProtocol v1.8.0                                       -->
 <!--#                                                                                      -->
 <!--# For a detailed change log, see the README file contained in the DSP8010 bundle,      -->
 <!--# available at http://www.dmtf.org/standards/redfish                                   -->
@@ -667,6 +667,62 @@
       <Annotation Term="OData.Description" String="This version was created to add additional SNMP authentication protocols."/>
 
       <EntityType Name="ManagerNetworkProtocol" BaseType="ManagerNetworkProtocol.v1_6_2.ManagerNetworkProtocol"/>
+    </Schema>
+
+    <Schema xmlns="http://docs.oasis-open.org/odata/ns/edm" Namespace="ManagerNetworkProtocol.v1_8_0">
+      <Annotation Term="Redfish.OwningEntity" String="DMTF"/>
+      <Annotation Term="Redfish.Release" String="2021.2"/>
+      <Annotation Term="OData.Description" String="This version was created to add proxy support."/>
+
+      <EntityType Name="ManagerNetworkProtocol" BaseType="ManagerNetworkProtocol.v1_7_0.ManagerNetworkProtocol">
+        <Property Name="Proxy" Type="ManagerNetworkProtocol.v1_8_0.ProxyConfiguration">
+          <Annotation Term="OData.Description" String="The HTTP/HTTPS proxy information for this manager."/>
+          <Annotation Term="OData.LongDescription" String="This property shall contain the HTTP/HTTPS proxy configuration for this manager."/>
+        </Property>
+      </EntityType>
+
+      <ComplexType Name="ProxyConfiguration">
+        <Annotation Term="OData.AdditionalProperties" Bool="false"/>
+        <Annotation Term="OData.Description" String="The HTTP/HTTPS proxy information for a manager."/>
+        <Annotation Term="OData.LongDescription" String="This property shall contain the HTTP/HTTPS proxy configuration for a manager."/>
+        <Property Name="Enabled" Type="Edm.Boolean" Nullable="false">
+          <Annotation Term="OData.Permissions" EnumMember="OData.Permission/ReadWrite"/>
+          <Annotation Term="OData.Description" String="Indicates if the manager uses the proxy server."/>
+          <Annotation Term="OData.LongDescription" String="This property shall indicate if the proxy server is used for communications."/>
+        </Property>
+        <Property Name="ProxyServerURI" Type="Edm.String" Nullable="false">
+          <Annotation Term="OData.Permissions" EnumMember="OData.Permission/ReadWrite"/>
+          <Annotation Term="OData.Description" String="The URI of the proxy server, including the scheme and any non-default port value."/>
+          <Annotation Term="OData.LongDescription" String="This property shall contain the URI of the proxy server.  The value shall contain the scheme for accessing the server, and shall include the port if the value is not the default port for the specified scheme."/>
+          <Annotation Term="OData.IsURL"/>
+        </Property>
+        <Property Name="Username" Type="Edm.String" Nullable="false">
+          <Annotation Term="OData.Permissions" EnumMember="OData.Permission/ReadWrite"/>
+          <Annotation Term="OData.Description" String="The username for the proxy."/>
+          <Annotation Term="OData.LongDescription" String="This property shall contain the username for this proxy."/>
+        </Property>
+        <Property Name="Password" Type="Edm.String">
+          <Annotation Term="OData.Permissions" EnumMember="OData.Permission/ReadWrite"/>
+          <Annotation Term="OData.Description" String="The password for the proxy.  The value is `null` in responses."/>
+          <Annotation Term="OData.LongDescription" String="This property shall contain the password for this proxy.  The value shall be `null` in responses."/>
+        </Property>
+        <Property Name="PasswordSet" Type="Edm.Boolean" Nullable="false">
+          <Annotation Term="OData.Permissions" EnumMember="OData.Permission/Read"/>
+          <Annotation Term="OData.Description" String="Indicates if the Password property is set."/>
+          <Annotation Term="OData.LongDescription" String="This property shall contain `true` if a valid value was provided for the Password property.  Otherwise, the property shall contain `false`."/>
+        </Property>
+        <Property Name="ExcludeAddresses" Type="Collection(Edm.String)">
+          <Annotation Term="OData.Permissions" EnumMember="OData.Permission/ReadWrite"/>
+          <Annotation Term="OData.Description" String="Addresses that do not require the proxy server to access."/>
+          <Annotation Term="OData.LongDescription" String="This property shall contain a list of hostnames or IP addresses that do not require a connection through the proxy server to access."/>
+        </Property>
+        <Property Name="ProxyAutoConfigURI" Type="Edm.String">
+          <Annotation Term="OData.Permissions" EnumMember="OData.Permission/ReadWrite"/>
+          <Annotation Term="OData.Description" String="The URI used to access a proxy auto-configuration (PAC) file."/>
+          <Annotation Term="OData.LongDescription" String="This property shall contain the URI at which to access a proxy auto-configuration (PAC) file containing one or more JavaScript functions for configuring proxy usage for this manager."/>
+          <Annotation Term="OData.IsURL"/>
+        </Property>
+      </ComplexType>
     </Schema>
 
   </edmx:DataServices>

--- a/static/redfish/v1/schema/Manager_v1.xml
+++ b/static/redfish/v1/schema/Manager_v1.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!---->
 <!--################################################################################       -->
-<!--# Redfish Schema:  Manager v1.11.1                                                     -->
+<!--# Redfish Schema:  Manager v1.13.0                                                     -->
 <!--#                                                                                      -->
 <!--# For a detailed change log, see the README file contained in the DSP8010 bundle,      -->
 <!--# available at http://www.dmtf.org/standards/redfish                                   -->
@@ -63,6 +63,9 @@
   </edmx:Reference>
   <edmx:Reference Uri="http://redfish.dmtf.org/schemas/v1/PortCollection_v1.xml">
     <edmx:Include Namespace="PortCollection"/>
+  </edmx:Reference>
+  <edmx:Reference Uri="http://redfish.dmtf.org/schemas/v1/CertificateCollection_v1.xml">
+    <edmx:Include Namespace="CertificateCollection"/>
   </edmx:Reference>
 
   <edmx:DataServices>
@@ -219,13 +222,13 @@
         </Property>
         <Property Name="DateTime" Type="Edm.DateTimeOffset">
           <Annotation Term="OData.Permissions" EnumMember="OData.Permission/ReadWrite"/>
-          <Annotation Term="OData.Description" String="The current date and time with UTC offset that the manager uses to set or read time."/>
-          <Annotation Term="OData.LongDescription" String="This property shall represent the current DateTime value for the manager, with UTC offset, in Redfish Timestamp format."/>
+          <Annotation Term="OData.Description" String="The current date and time with UTC offset of the manager."/>
+          <Annotation Term="OData.LongDescription" String="This property shall contain the current date and time with UTC offset of the manager."/>
         </Property>
         <Property Name="DateTimeLocalOffset" Type="Edm.String">
           <Annotation Term="OData.Permissions" EnumMember="OData.Permission/ReadWrite"/>
           <Annotation Term="OData.Description" String="The time offset from UTC that the DateTime property is in `+HH:MM` format."/>
-          <Annotation Term="OData.LongDescription" String="This property shall represent the offset from UTC time that the current DateTime property contains."/>
+          <Annotation Term="OData.LongDescription" String="This property shall contain the offset from UTC time that the DateTime property contains.  If both DateTime and DateTimeLocalOffset are provided in modification requests, services shall apply DateTimeLocalOffset after DateTime is applied."/>
           <Annotation Term="Validation.Pattern" String="^([-+][0-1][0-9]:[0-5][0-9])$"/>
         </Property>
         <Property Name="FirmwareVersion" Type="Edm.String">
@@ -510,6 +513,12 @@
       <EntityType Name="Manager" BaseType="Manager.v1_0_14.Manager"/>
     </Schema>
 
+    <Schema xmlns="http://docs.oasis-open.org/odata/ns/edm" Namespace="Manager.v1_0_16">
+      <Annotation Term="Redfish.OwningEntity" String="DMTF"/>
+      <Annotation Term="OData.Description" String="This version was created to clarify the behavior when both DateTime and DateTimeLocalOffset are provided in modification requests."/>
+      <EntityType Name="Manager" BaseType="Manager.v1_0_15.Manager"/>
+    </Schema>
+
     <Schema xmlns="http://docs.oasis-open.org/odata/ns/edm" Namespace="Manager.v1_1_0">
       <Annotation Term="Redfish.OwningEntity" String="DMTF"/>
       <Annotation Term="Redfish.Release" String="2016.1"/>
@@ -604,6 +613,12 @@
       <EntityType Name="Manager" BaseType="Manager.v1_1_12.Manager"/>
     </Schema>
 
+    <Schema xmlns="http://docs.oasis-open.org/odata/ns/edm" Namespace="Manager.v1_1_14">
+      <Annotation Term="Redfish.OwningEntity" String="DMTF"/>
+      <Annotation Term="OData.Description" String="This version was created to clarify the behavior when both DateTime and DateTimeLocalOffset are provided in modification requests."/>
+      <EntityType Name="Manager" BaseType="Manager.v1_1_13.Manager"/>
+    </Schema>
+
     <Schema xmlns="http://docs.oasis-open.org/odata/ns/edm" Namespace="Manager.v1_2_0">
       <Annotation Term="Redfish.OwningEntity" String="DMTF"/>
       <Annotation Term="Redfish.Release" String="2016.2"/>
@@ -695,6 +710,12 @@
       <EntityType Name="Manager" BaseType="Manager.v1_2_12.Manager"/>
     </Schema>
 
+    <Schema xmlns="http://docs.oasis-open.org/odata/ns/edm" Namespace="Manager.v1_2_14">
+      <Annotation Term="Redfish.OwningEntity" String="DMTF"/>
+      <Annotation Term="OData.Description" String="This version was created to clarify the behavior when both DateTime and DateTimeLocalOffset are provided in modification requests."/>
+      <EntityType Name="Manager" BaseType="Manager.v1_2_13.Manager"/>
+    </Schema>
+
     <Schema xmlns="http://docs.oasis-open.org/odata/ns/edm" Namespace="Manager.v1_3_0">
       <Annotation Term="Redfish.OwningEntity" String="DMTF"/>
       <Annotation Term="Redfish.Release" String="2016.3"/>
@@ -781,6 +802,12 @@
       <EntityType Name="Manager" BaseType="Manager.v1_3_11.Manager"/>
     </Schema>
 
+    <Schema xmlns="http://docs.oasis-open.org/odata/ns/edm" Namespace="Manager.v1_3_13">
+      <Annotation Term="Redfish.OwningEntity" String="DMTF"/>
+      <Annotation Term="OData.Description" String="This version was created to clarify the behavior when both DateTime and DateTimeLocalOffset are provided in modification requests."/>
+      <EntityType Name="Manager" BaseType="Manager.v1_3_12.Manager"/>
+    </Schema>
+
     <Schema xmlns="http://docs.oasis-open.org/odata/ns/edm" Namespace="Manager.v1_4_0">
       <Annotation Term="Redfish.OwningEntity" String="DMTF"/>
       <Annotation Term="Redfish.Release" String="2018.1"/>
@@ -857,6 +884,12 @@
       <EntityType Name="Manager" BaseType="Manager.v1_4_8.Manager"/>
     </Schema>
 
+    <Schema xmlns="http://docs.oasis-open.org/odata/ns/edm" Namespace="Manager.v1_4_10">
+      <Annotation Term="Redfish.OwningEntity" String="DMTF"/>
+      <Annotation Term="OData.Description" String="This version was created to clarify the behavior when both DateTime and DateTimeLocalOffset are provided in modification requests."/>
+      <EntityType Name="Manager" BaseType="Manager.v1_4_9.Manager"/>
+    </Schema>
+
     <Schema xmlns="http://docs.oasis-open.org/odata/ns/edm" Namespace="Manager.v1_5_0">
       <Annotation Term="Redfish.OwningEntity" String="DMTF"/>
       <Annotation Term="Redfish.Release" String="2018.2"/>
@@ -925,6 +958,12 @@
       <EntityType Name="Manager" BaseType="Manager.v1_5_7.Manager"/>
     </Schema>
 
+    <Schema xmlns="http://docs.oasis-open.org/odata/ns/edm" Namespace="Manager.v1_5_9">
+      <Annotation Term="Redfish.OwningEntity" String="DMTF"/>
+      <Annotation Term="OData.Description" String="This version was created to clarify the behavior when both DateTime and DateTimeLocalOffset are provided in modification requests."/>
+      <EntityType Name="Manager" BaseType="Manager.v1_5_8.Manager"/>
+    </Schema>
+
     <Schema xmlns="http://docs.oasis-open.org/odata/ns/edm" Namespace="Manager.v1_6_0">
       <Annotation Term="Redfish.OwningEntity" String="DMTF"/>
       <Annotation Term="Redfish.Release" String="2019.2"/>
@@ -975,6 +1014,12 @@
       <Annotation Term="Redfish.OwningEntity" String="DMTF"/>
       <Annotation Term="OData.Description" String="This version was created to clarify the usage of RemoteAccountService to be allowed for other types of aggregated managers.  It was also created to correct various description to use proper normative terminology."/>
       <EntityType Name="Manager" BaseType="Manager.v1_6_4.Manager"/>
+    </Schema>
+
+    <Schema xmlns="http://docs.oasis-open.org/odata/ns/edm" Namespace="Manager.v1_6_6">
+      <Annotation Term="Redfish.OwningEntity" String="DMTF"/>
+      <Annotation Term="OData.Description" String="This version was created to clarify the behavior when both DateTime and DateTimeLocalOffset are provided in modification requests."/>
+      <EntityType Name="Manager" BaseType="Manager.v1_6_5.Manager"/>
     </Schema>
 
     <Schema xmlns="http://docs.oasis-open.org/odata/ns/edm" Namespace="Manager.v1_7_0">
@@ -1030,6 +1075,12 @@
       <EntityType Name="Manager" BaseType="Manager.v1_7_4.Manager"/>
     </Schema>
 
+    <Schema xmlns="http://docs.oasis-open.org/odata/ns/edm" Namespace="Manager.v1_7_6">
+      <Annotation Term="Redfish.OwningEntity" String="DMTF"/>
+      <Annotation Term="OData.Description" String="This version was created to clarify the behavior when both DateTime and DateTimeLocalOffset are provided in modification requests."/>
+      <EntityType Name="Manager" BaseType="Manager.v1_7_5.Manager"/>
+    </Schema>
+
     <Schema xmlns="http://docs.oasis-open.org/odata/ns/edm" Namespace="Manager.v1_8_0">
       <Annotation Term="Redfish.OwningEntity" String="DMTF"/>
       <Annotation Term="Redfish.Release" String="2020.1"/>
@@ -1072,6 +1123,12 @@
       <Annotation Term="Redfish.OwningEntity" String="DMTF"/>
       <Annotation Term="OData.Description" String="This version was created to clarify the usage of RemoteAccountService to be allowed for other types of aggregated managers.  It was also created to correct various description to use proper normative terminology."/>
       <EntityType Name="Manager" BaseType="Manager.v1_8_3.Manager"/>
+    </Schema>
+
+    <Schema xmlns="http://docs.oasis-open.org/odata/ns/edm" Namespace="Manager.v1_8_5">
+      <Annotation Term="Redfish.OwningEntity" String="DMTF"/>
+      <Annotation Term="OData.Description" String="This version was created to clarify the behavior when both DateTime and DateTimeLocalOffset are provided in modification requests."/>
+      <EntityType Name="Manager" BaseType="Manager.v1_8_4.Manager"/>
     </Schema>
 
     <Schema xmlns="http://docs.oasis-open.org/odata/ns/edm" Namespace="Manager.v1_9_0">
@@ -1121,6 +1178,12 @@
       <EntityType Name="Manager" BaseType="Manager.v1_9_2.Manager"/>
     </Schema>
 
+    <Schema xmlns="http://docs.oasis-open.org/odata/ns/edm" Namespace="Manager.v1_9_4">
+      <Annotation Term="Redfish.OwningEntity" String="DMTF"/>
+      <Annotation Term="OData.Description" String="This version was created to clarify the behavior when both DateTime and DateTimeLocalOffset are provided in modification requests."/>
+      <EntityType Name="Manager" BaseType="Manager.v1_9_3.Manager"/>
+    </Schema>
+
     <Schema xmlns="http://docs.oasis-open.org/odata/ns/edm" Namespace="Manager.v1_10_0">
       <Annotation Term="Redfish.OwningEntity" String="DMTF"/>
       <Annotation Term="Redfish.Release" String="2020.3"/>
@@ -1145,6 +1208,12 @@
       <Annotation Term="Redfish.OwningEntity" String="DMTF"/>
       <Annotation Term="OData.Description" String="This version was created to clarify the usage of RemoteAccountService to be allowed for other types of aggregated managers.  It was also created to correct various description to use proper normative terminology."/>
       <EntityType Name="Manager" BaseType="Manager.v1_10_1.Manager"/>
+    </Schema>
+
+    <Schema xmlns="http://docs.oasis-open.org/odata/ns/edm" Namespace="Manager.v1_10_3">
+      <Annotation Term="Redfish.OwningEntity" String="DMTF"/>
+      <Annotation Term="OData.Description" String="This version was created to clarify the behavior when both DateTime and DateTimeLocalOffset are provided in modification requests."/>
+      <EntityType Name="Manager" BaseType="Manager.v1_10_2.Manager"/>
     </Schema>
 
     <Schema xmlns="http://docs.oasis-open.org/odata/ns/edm" Namespace="Manager.v1_11_0">
@@ -1176,6 +1245,12 @@
       <EntityType Name="Manager" BaseType="Manager.v1_11_0.Manager"/>
     </Schema>
 
+    <Schema xmlns="http://docs.oasis-open.org/odata/ns/edm" Namespace="Manager.v1_11_2">
+      <Annotation Term="Redfish.OwningEntity" String="DMTF"/>
+      <Annotation Term="OData.Description" String="This version was created to clarify the behavior when both DateTime and DateTimeLocalOffset are provided in modification requests."/>
+      <EntityType Name="Manager" BaseType="Manager.v1_11_1.Manager"/>
+    </Schema>
+
     <Schema xmlns="http://docs.oasis-open.org/odata/ns/edm" Namespace="Manager.v1_12_0">
       <Annotation Term="Redfish.OwningEntity" String="DMTF"/>
       <Annotation Term="Redfish.Release" String="2021.1"/>
@@ -1186,6 +1261,30 @@
           <Annotation Term="OData.Description" String="The USB ports of the manager."/>
           <Annotation Term="OData.LongDescription" String="This property shall contain a link to a resource collection of type PortCollection that represent the USB ports of the manager."/>
         </NavigationProperty>
+      </EntityType>
+    </Schema>
+
+    <Schema xmlns="http://docs.oasis-open.org/odata/ns/edm" Namespace="Manager.v1_12_1">
+      <Annotation Term="Redfish.OwningEntity" String="DMTF"/>
+      <Annotation Term="OData.Description" String="This version was created to clarify the behavior when both DateTime and DateTimeLocalOffset are provided in modification requests."/>
+      <EntityType Name="Manager" BaseType="Manager.v1_12_0.Manager"/>
+    </Schema>
+
+    <Schema xmlns="http://docs.oasis-open.org/odata/ns/edm" Namespace="Manager.v1_13_0">
+      <Annotation Term="Redfish.OwningEntity" String="DMTF"/>
+      <Annotation Term="Redfish.Release" String="2021.2"/>
+
+      <EntityType Name="Manager" BaseType="Manager.v1_12_1.Manager">
+        <NavigationProperty Name="Certificates" Type="CertificateCollection.CertificateCollection" ContainsTarget="true" Nullable="false">
+          <Annotation Term="OData.Permissions" EnumMember="OData.Permission/Read"/>
+          <Annotation Term="OData.Description" String="The link to a collection of certificates for device identity and attestation."/>
+          <Annotation Term="OData.LongDescription" String="This property shall contain a link to a resource collection of type CertificateCollection that contains certificates for device identity and attestation."/>
+          <Annotation Term="OData.AutoExpandReferences"/>
+        </NavigationProperty>
+        <Property Name="Measurements" Type="Collection(SoftwareInventory.MeasurementBlock)" Nullable="false">
+          <Annotation Term="OData.Description" String="An array of DSP0274-defined measurement blocks."/>
+          <Annotation Term="OData.LongDescription" String="This property shall contain an array of DSP0274-defined measurement blocks."/>
+        </Property>
       </EntityType>
     </Schema>
 

--- a/static/redfish/v1/schema/Memory_v1.xml
+++ b/static/redfish/v1/schema/Memory_v1.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!---->
 <!--################################################################################       -->
-<!--# Redfish Schema:  Memory v1.12.0                                                      -->
+<!--# Redfish Schema:  Memory v1.13.0                                                      -->
 <!--#                                                                                      -->
 <!--# For a detailed change log, see the README file contained in the DSP8010 bundle,      -->
 <!--# available at http://www.dmtf.org/standards/redfish                                   -->
@@ -48,6 +48,12 @@
   </edmx:Reference>
   <edmx:Reference Uri="http://redfish.dmtf.org/schemas/v1/SoftwareInventory_v1.xml">
     <edmx:Include Namespace="SoftwareInventory"/>
+  </edmx:Reference>
+  <edmx:Reference Uri="http://redfish.dmtf.org/schemas/v1/LogService_v1.xml">
+    <edmx:Include Namespace="LogService"/>
+  </edmx:Reference>
+  <edmx:Reference Uri="http://redfish.dmtf.org/schemas/v1/Control_v1.xml">
+    <edmx:Include Namespace="Control"/>
   </edmx:Reference>
 
   <edmx:DataServices>
@@ -1698,6 +1704,26 @@
           <Annotation Term="OData.Description" String="An indication of whether this memory is enabled."/>
           <Annotation Term="OData.LongDescription" String="The value of this property shall indicate if this memory is enabled."/>
         </Property>
+      </EntityType>
+    </Schema>
+
+    <Schema xmlns="http://docs.oasis-open.org/odata/ns/edm" Namespace="Memory.v1_13_0">
+      <Annotation Term="Redfish.OwningEntity" String="DMTF"/>
+      <Annotation Term="Redfish.Release" String="2021.2"/>
+
+      <EntityType Name="Memory" BaseType="Memory.v1_12_0.Memory">
+        <NavigationProperty Name="Log" Type="LogService.LogService" ContainsTarget="true" Nullable="false">
+          <Annotation Term="OData.Permissions" EnumMember="OData.Permission/Read"/>
+          <Annotation Term="OData.Description" String="The link to the log service associated with this memory."/>
+          <Annotation Term="OData.LongDescription" String="This property shall contain a link to a resource of type LogService."/>
+          <Annotation Term="OData.AutoExpandReferences"/>
+        </NavigationProperty>
+        <NavigationProperty Name="OperatingSpeedRangeMHz" Type="Control.Control">
+          <Annotation Term="OData.Permissions" EnumMember="OData.Permission/ReadWrite"/>
+          <Annotation Term="Redfish.ExcerptCopy" String="Range"/>
+          <Annotation Term="OData.Description" String="Range of allowed operating speeds (MHz)."/>
+          <Annotation Term="OData.LongDescription" String="This property shall contain the operating speed control excerpt for this resource."/>
+        </NavigationProperty>
       </EntityType>
     </Schema>
 

--- a/static/redfish/v1/schema/ProcessorCollection_v1.xml
+++ b/static/redfish/v1/schema/ProcessorCollection_v1.xml
@@ -60,6 +60,8 @@
             <String>/redfish/v1/ResourceBlocks/{ResourceBlockId}/Processors/{ProcessorId}/SubProcessors</String>
             <String>/redfish/v1/ResourceBlocks/{ResourceBlockId}/Systems/{ComputerSystemId}/Processors</String>
             <String>/redfish/v1/ResourceBlocks/{ResourceBlockId}/Systems/{ComputerSystemId}/Processors/{ProcessorId}/SubProcessors</String>
+            <String>/redfish/v1/Chassis/{ChassisId}/NetworkAdapters/{NetworkAdapterId}/Processors</String>
+            <String>/redfish/v1/Chassis/{ChassisId}/NetworkAdapters/{NetworkAdapterId}/Processors/{ProcessorId}/SubProcessors</String>
           </Collection>
         </Annotation>
         <NavigationProperty Name="Members" Type="Collection(Processor.Processor)">

--- a/static/redfish/v1/schema/Processor_v1.xml
+++ b/static/redfish/v1/schema/Processor_v1.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!---->
 <!--################################################################################       -->
-<!--# Redfish Schema:  Processor v1.12.0                                                   -->
+<!--# Redfish Schema:  Processor v1.13.0                                                   -->
 <!--#                                                                                      -->
 <!--# For a detailed change log, see the README file contained in the DSP8010 bundle,      -->
 <!--# available at http://www.dmtf.org/standards/redfish                                   -->
@@ -79,6 +79,15 @@
   <edmx:Reference Uri="http://redfish.dmtf.org/schemas/v1/GraphicsController_v1.xml">
     <edmx:Include Namespace="GraphicsController"/>
   </edmx:Reference>
+  <edmx:Reference Uri="http://redfish.dmtf.org/schemas/v1/NetworkDeviceFunction_v1.xml">
+    <edmx:Include Namespace="NetworkDeviceFunction"/>
+  </edmx:Reference>
+  <edmx:Reference Uri="http://redfish.dmtf.org/schemas/v1/Control_v1.xml">
+    <edmx:Include Namespace="Control"/>
+  </edmx:Reference>
+  <edmx:Reference Uri="http://redfish.dmtf.org/schemas/v1/PortCollection_v1.xml">
+    <edmx:Include Namespace="PortCollection"/>
+  </edmx:Reference>
 
   <edmx:DataServices>
 
@@ -116,6 +125,8 @@
             <String>/redfish/v1/ResourceBlocks/{ResourceBlockId}/Processors/{ProcessorId}/SubProcessors/{ProcessorId2}</String>
             <String>/redfish/v1/ResourceBlocks/{ResourceBlockId}/Systems/{ComputerSystemId}/Processors/{ProcessorId}</String>
             <String>/redfish/v1/ResourceBlocks/{ResourceBlockId}/Systems/{ComputerSystemId}/Processors/{ProcessorId}/SubProcessors/{ProcessorId2}</String>
+            <String>/redfish/v1/Chassis/{ChassisId}/NetworkAdapters/{NetworkAdapterId}/Processors/{ProcessorId}</String>
+            <String>/redfish/v1/Chassis/{ChassisId}/NetworkAdapters/{NetworkAdapterId}/Processors/{ProcessorId}/SubProcessors/{ProcessorId2}</String>
           </Collection>
         </Annotation>
       </EntityType>
@@ -1441,8 +1452,8 @@
         </Property>
         <Property Name="TotalMemorySizeMiB" Type="Edm.Int64">
           <Annotation Term="OData.Permissions" EnumMember="OData.Permission/Read"/>
-          <Annotation Term="OData.Description" String="Total size of volatile memory of this processor."/>
-          <Annotation Term="OData.LongDescription" String="This property shall contain the total size of non-cache, volatile memory of this processor."/>
+          <Annotation Term="OData.Description" String="Total size of volatile memory attached to this processor."/>
+          <Annotation Term="OData.LongDescription" String="This property shall contain the total size of non-cache, volatile memory attached to this processor.  This value indicates the size of memory directly attached or with strong affinity to this processor, not the total memory accessible by the processor.  This property shall not be present for implementations where all processors have equal memory performance or access characteristics, such as hop count, for all system memory."/>
           <Annotation Term="Measures.Unit" String="MiBy"/>
         </Property>
         <NavigationProperty Name="Metrics" Type="MemoryMetrics.MemoryMetrics" ContainsTarget="true" Nullable="false">
@@ -1462,11 +1473,16 @@
       </ComplexType>
     </Schema>
 
-
     <Schema xmlns="http://docs.oasis-open.org/odata/ns/edm" Namespace="Processor.v1_11_1">
       <Annotation Term="Redfish.OwningEntity" String="DMTF"/>
       <Annotation Term="OData.Description" String="This version was created to correct various description to use proper normative terminology."/>
       <EntityType Name="Processor" BaseType="Processor.v1_11_0.Processor"/>
+    </Schema>
+
+    <Schema xmlns="http://docs.oasis-open.org/odata/ns/edm" Namespace="Processor.v1_11_2">
+      <Annotation Term="Redfish.OwningEntity" String="DMTF"/>
+      <Annotation Term="OData.Description" String="This version was created to clarify the usage of TotalMemorySizeMiB."/>
+      <EntityType Name="Processor" BaseType="Processor.v1_11_1.Processor"/>
     </Schema>
 
     <Schema xmlns="http://docs.oasis-open.org/odata/ns/edm" Namespace="Processor.v1_12_0">
@@ -1487,6 +1503,49 @@
           <Annotation Term="OData.Permissions" EnumMember="OData.Permission/Read"/>
           <Annotation Term="OData.Description" String="A link to the graphics controller associated with this processor."/>
           <Annotation Term="OData.LongDescription" String="This property shall contain a link to resource of type GraphicsController that is associated with this processor."/>
+          <Annotation Term="OData.AutoExpandReferences"/>
+        </NavigationProperty>
+      </ComplexType>
+    </Schema>
+
+    <Schema xmlns="http://docs.oasis-open.org/odata/ns/edm" Namespace="Processor.v1_12_1">
+      <Annotation Term="Redfish.OwningEntity" String="DMTF"/>
+      <Annotation Term="OData.Description" String="This version was created to clarify the usage of TotalMemorySizeMiB."/>
+      <EntityType Name="Processor" BaseType="Processor.v1_12_0.Processor"/>
+    </Schema>
+
+    <Schema xmlns="http://docs.oasis-open.org/odata/ns/edm" Namespace="Processor.v1_13_0">
+      <Annotation Term="Redfish.OwningEntity" String="DMTF"/>
+      <Annotation Term="Redfish.Release" String="2021.2"/>
+
+      <EntityType Name="Processor" BaseType="Processor.v1_12_1.Processor">
+        <NavigationProperty Name="OperatingSpeedRangeMHz" Type="Control.Control">
+          <Annotation Term="OData.Permissions" EnumMember="OData.Permission/ReadWrite"/>
+          <Annotation Term="Redfish.ExcerptCopy" String="Range"/>
+          <Annotation Term="OData.Description" String="Range of allowed operating speeds (MHz)."/>
+          <Annotation Term="OData.LongDescription" String="This property shall contain the operating speed control excerpt for this resource."/>
+        </NavigationProperty>
+        <NavigationProperty Name="Ports" Type="PortCollection.PortCollection" ContainsTarget="true" Nullable="false">
+          <Annotation Term="OData.Permissions" EnumMember="OData.Permission/Read"/>
+          <Annotation Term="OData.Description" String="The link to the collection of ports for this processor."/>
+          <Annotation Term="OData.LongDescription" String="This property shall contain a link to a resource collection of type PortCollection.  It shall contain the interconnect ports of this processor.  It shall not contain ports of for GraphicsController resources, USBController resources, or other adapter-related type of resources."/>
+          <Annotation Term="OData.AutoExpandReferences"/>
+        </NavigationProperty>
+      </EntityType>
+
+      <ComplexType Name="MemorySummary" BaseType="Processor.v1_11_0.MemorySummary">
+        <Property Name="ECCModeEnabled" Type="Edm.Boolean">
+          <Annotation Term="OData.Permissions" EnumMember="OData.Permission/ReadWrite"/>
+          <Annotation Term="OData.Description" String="An indication of whether memory ECC mode is enabled for this processor."/>
+          <Annotation Term="OData.LongDescription" String="The value of this property shall indicate if memory ECC mode is enabled for this processor.  This value shall not affect system memory ECC mode."/>
+        </Property>
+      </ComplexType>
+
+      <ComplexType Name="Links" BaseType="Processor.v1_12_0.Links">
+        <NavigationProperty Name="NetworkDeviceFunctions" Type="Collection(NetworkDeviceFunction.NetworkDeviceFunction)">
+          <Annotation Term="OData.Permissions" EnumMember="OData.Permission/Read"/>
+          <Annotation Term="OData.Description" String="The network device functions to which this processor performs offload computation, such as with a SmartNIC."/>
+          <Annotation Term="OData.LongDescription" String="This property shall contain an array of links to resources of type NetworkDeviceFunction that represent the network device functions to which this processor performs offload computation, such as with a SmartNIC."/>
           <Annotation Term="OData.AutoExpandReferences"/>
         </NavigationProperty>
       </ComplexType>

--- a/static/redfish/v1/schema/Resource_v1.xml
+++ b/static/redfish/v1/schema/Resource_v1.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!---->
 <!--################################################################################       -->
-<!--# Redfish Schema:  Resource v1.12.0                                                    -->
+<!--# Redfish Schema:  Resource v1.13.0                                                    -->
 <!--#                                                                                      -->
 <!--# For a detailed change log, see the README file contained in the DSP8010 bundle,      -->
 <!--# available at http://www.dmtf.org/standards/redfish                                   -->
@@ -30,18 +30,18 @@
       <Annotation Term="Redfish.OwningEntity" String="DMTF"/>
 
       <TypeDefinition Name="Id" UnderlyingType="Edm.String">
-        <Annotation Term="OData.Description" String="The identifier that uniquely identifies the resource within the collection of similar resources."/>
-        <Annotation Term="OData.LongDescription" String="This property represents an identifier for the resource.  The resource values shall comply with the Redfish Specification-described requirements."/>
+        <Annotation Term="OData.Description" String="The unique identifier for this resource within the collection of similar resources."/>
+        <Annotation Term="OData.LongDescription" String="This property shall contain the identifier for this resource.  The value shall conform with the 'Id' clause of the Redfish Specification."/>
       </TypeDefinition>
 
       <TypeDefinition Name="Description" UnderlyingType="Edm.String">
         <Annotation Term="OData.Description" String="The description of this resource.  Used for commonality in the schema definitions."/>
-        <Annotation Term="OData.LongDescription" String="This object represents the description of this resource.  The resource values shall comply with the Redfish Specification-described requirements."/>
+        <Annotation Term="OData.LongDescription" String="This property shall contain the description of this resource.  The value shall conform with the 'Description' clause of the Redfish Specification."/>
       </TypeDefinition>
 
       <TypeDefinition Name="Name" UnderlyingType="Edm.String">
         <Annotation Term="OData.Description"  String="The name of the resource or array member."/>
-        <Annotation Term="OData.LongDescription" String="This object represents the name of this resource or array member.  The resource values shall comply with the Redfish Specification-described requirements.  This string value shall be of the 'Name' reserved word format."/>
+        <Annotation Term="OData.LongDescription" String="This property shall contain the name of this resource or array member.  The value shall conform with the 'Name' clause of the Redfish Specification."/>
       </TypeDefinition>
 
       <TypeDefinition Name="UUID" UnderlyingType="Edm.Guid"/>
@@ -310,6 +310,42 @@
             </Collection>
           </Annotation>
         </Member>
+        <Member Name="Suspend">
+          <Annotation Term="OData.Description" String="Write the state of the unit to disk before powering off.  This allows for the state to be restored when powered back on."/>
+          <Annotation Term="OData.LongDescription" String="This value shall indicate the resource will have any state information written to persistent memory and then transition to a power off state.  Upon successful completion, the PowerState property, if supported, shall contain the value `Off`."/>
+          <Annotation Term="Redfish.Revisions">
+            <Collection>
+              <Record>
+                <PropertyValue Property="Kind" EnumMember="Redfish.RevisionKind/Added"/>
+                <PropertyValue Property="Version" String="v1_13_0"/>
+              </Record>
+            </Collection>
+          </Annotation>
+        </Member>
+        <Member Name="Pause">
+          <Annotation Term="OData.Description" String="Pause execution on the unit but do not remove power.  This is typically a feature of virtual machine hypervisors."/>
+          <Annotation Term="OData.LongDescription" String="This value shall indicate the resource will transition to a paused state.  Upon successful completion, the PowerState property, if supported, shall contain the value `Paused`."/>
+          <Annotation Term="Redfish.Revisions">
+            <Collection>
+              <Record>
+                <PropertyValue Property="Kind" EnumMember="Redfish.RevisionKind/Added"/>
+                <PropertyValue Property="Version" String="v1_13_0"/>
+              </Record>
+            </Collection>
+          </Annotation>
+        </Member>
+        <Member Name="Resume">
+          <Annotation Term="OData.Description" String="Resume execution on the paused unit.  This is typically a feature of virtual machine hypervisors."/>
+          <Annotation Term="OData.LongDescription" String="This value shall indicate the resource will transition to a power on state.  Upon successful completion, the PowerState property, if supported, shall contain the value `On`."/>
+          <Annotation Term="Redfish.Revisions">
+            <Collection>
+              <Record>
+                <PropertyValue Property="Kind" EnumMember="Redfish.RevisionKind/Added"/>
+                <PropertyValue Property="Version" String="v1_13_0"/>
+              </Record>
+            </Collection>
+          </Annotation>
+        </Member>
       </EnumType>
 
       <ComplexType Name="Identifier" Abstract="true">
@@ -352,6 +388,17 @@
         <Member Name="PoweringOff">
           <Annotation Term="OData.Description" String="A temporary state between on and off."/>
         </Member>
+        <Member Name="Paused">
+          <Annotation Term="OData.Description" String="The state is paused."/>
+          <Annotation Term="Redfish.Revisions">
+            <Collection>
+              <Record>
+                <PropertyValue Property="Kind" EnumMember="Redfish.RevisionKind/Added"/>
+                <PropertyValue Property="Version" String="v1_13_0"/>
+              </Record>
+            </Collection>
+          </Annotation>
+        </Member>
       </EnumType>
     </Schema>
 
@@ -367,8 +414,8 @@
         </Key>
         <Property Name="MemberId" Nullable="false" Type="Edm.String">
           <Annotation Term="OData.Permissions" EnumMember="OData.Permission/Read"/>
-          <Annotation Term="OData.Description" String="The identifier for the member within the collection."/>
-          <Annotation Term="OData.LongDescription" String="This property shall uniquely identify the member within the collection.  For services supporting Redfish v1.6 or higher, this value shall contain the zero-based array index."/>
+          <Annotation Term="OData.Description" String="The unique identifier for the member within an array."/>
+          <Annotation Term="OData.LongDescription" String="This property shall contain the unique identifier for this member within an array.  For services supporting Redfish v1.6 or higher, this value shall contain the zero-based array index."/>
           <Annotation Term="Redfish.Required"/>
         </Property>
       </EntityType>
@@ -462,6 +509,11 @@
     <Schema xmlns="http://docs.oasis-open.org/odata/ns/edm" Namespace="Resource.v1_0_12">
       <Annotation Term="Redfish.OwningEntity" String="DMTF"/>
       <Annotation Term="OData.Description" String="This version was created to correct various description to use proper normative terminology."/>
+    </Schema>
+
+    <Schema xmlns="http://docs.oasis-open.org/odata/ns/edm" Namespace="Resource.v1_0_13">
+      <Annotation Term="Redfish.OwningEntity" String="DMTF"/>
+      <Annotation Term="OData.Description" String="This version was created to clarify the descriptions for Id, Name, Description, and MemberId to be consistent with usage in the specification."/>
     </Schema>
 
     <Schema xmlns="http://docs.oasis-open.org/odata/ns/edm" Namespace="Resource.v1_1_0">
@@ -646,6 +698,11 @@
       <Annotation Term="OData.Description" String="This version was created to add formats to the different durable name types.  It was also created to correct various description to use proper normative terminology."/>
     </Schema>
 
+    <Schema xmlns="http://docs.oasis-open.org/odata/ns/edm" Namespace="Resource.v1_1_14">
+      <Annotation Term="Redfish.OwningEntity" String="DMTF"/>
+      <Annotation Term="OData.Description" String="This version was created to clarify the descriptions for Id, Name, Description, and MemberId to be consistent with usage in the specification."/>
+    </Schema>
+
     <Schema xmlns="http://docs.oasis-open.org/odata/ns/edm" Namespace="Resource.v1_2_0">
       <Annotation Term="Redfish.OwningEntity" String="DMTF"/>
       <Annotation Term="Redfish.Release" String="2016.2"/>
@@ -710,6 +767,11 @@
     <Schema xmlns="http://docs.oasis-open.org/odata/ns/edm" Namespace="Resource.v1_2_12">
       <Annotation Term="Redfish.OwningEntity" String="DMTF"/>
       <Annotation Term="OData.Description" String="This version was created to add formats to the different durable name types.  It was also created to correct various description to use proper normative terminology."/>
+    </Schema>
+
+    <Schema xmlns="http://docs.oasis-open.org/odata/ns/edm" Namespace="Resource.v1_2_13">
+      <Annotation Term="Redfish.OwningEntity" String="DMTF"/>
+      <Annotation Term="OData.Description" String="This version was created to clarify the descriptions for Id, Name, Description, and MemberId to be consistent with usage in the specification."/>
     </Schema>
 
     <Schema xmlns="http://docs.oasis-open.org/odata/ns/edm" Namespace="Resource.v1_3_0">
@@ -1006,6 +1068,11 @@
       <Annotation Term="OData.Description" String="This version was created to add formats to the different durable name types.  It was also created to correct various description to use proper normative terminology."/>
     </Schema>
 
+    <Schema xmlns="http://docs.oasis-open.org/odata/ns/edm" Namespace="Resource.v1_3_12">
+      <Annotation Term="Redfish.OwningEntity" String="DMTF"/>
+      <Annotation Term="OData.Description" String="This version was created to clarify the descriptions for Id, Name, Description, and MemberId to be consistent with usage in the specification."/>
+    </Schema>
+
     <Schema xmlns="http://docs.oasis-open.org/odata/ns/edm" Namespace="Resource.v1_4_0">
       <Annotation Term="Redfish.OwningEntity" String="DMTF"/>
       <Annotation Term="Redfish.Release" String="2017.1"/>
@@ -1062,6 +1129,11 @@
       <Annotation Term="OData.Description" String="This version was created to add formats to the different durable name types.  It was also created to correct various description to use proper normative terminology."/>
     </Schema>
 
+    <Schema xmlns="http://docs.oasis-open.org/odata/ns/edm" Namespace="Resource.v1_4_11">
+      <Annotation Term="Redfish.OwningEntity" String="DMTF"/>
+      <Annotation Term="OData.Description" String="This version was created to clarify the descriptions for Id, Name, Description, and MemberId to be consistent with usage in the specification."/>
+    </Schema>
+
     <Schema xmlns="http://docs.oasis-open.org/odata/ns/edm" Namespace="Resource.v1_5_0">
       <Annotation Term="Redfish.OwningEntity" String="DMTF"/>
       <Annotation Term="Redfish.Release" String="2017.2"/>
@@ -1094,6 +1166,18 @@
               <Record>
                 <PropertyValue Property="Kind" EnumMember="Redfish.RevisionKind/Added"/>
                 <PropertyValue Property="Version" String="v1_12_0"/>
+              </Record>
+            </Collection>
+          </Annotation>
+        </Member>
+        <Member Name="Embedded">
+          <Annotation Term="OData.Description" String="Embedded within a part."/>
+          <Annotation Term="OData.LongDescription" String="This value shall indicate the part is embedded or otherwise permanently incorporated into a larger part or device.  This value shall not be used for parts that can be removed by a user or are considered field-replaceable."/>
+          <Annotation Term="Redfish.Revisions">
+            <Collection>
+              <Record>
+                <PropertyValue Property="Kind" EnumMember="Redfish.RevisionKind/Added"/>
+                <PropertyValue Property="Version" String="v1_13_0"/>
               </Record>
             </Collection>
           </Annotation>
@@ -1172,8 +1256,8 @@
         </Property>
         <Property Name="LocationType" Type="Resource.v1_5_0.LocationType">
           <Annotation Term="OData.Permissions" EnumMember="OData.Permission/Read"/>
-          <Annotation Term="OData.Description" String="The type of location of the part, such as slot, bay, socket, or slot."/>
-          <Annotation Term="OData.LongDescription" String="This property shall contain the type of location of the part, such as slot, bay, socket, or slot."/>
+          <Annotation Term="OData.Description" String="The type of location of the part."/>
+          <Annotation Term="OData.LongDescription" String="This property shall contain the type of location of the part."/>
         </Property>
         <Property Name="LocationOrdinalValue" Type="Edm.Int64" DefaultValue="0">
           <Annotation Term="OData.Permissions" EnumMember="OData.Permission/Read"/>
@@ -1245,6 +1329,11 @@
       <Annotation Term="OData.Description" String="This version was created to add formats to the different durable name types.  It was also created to correct various description to use proper normative terminology.  It was also created to clarify the usage of LocationType within PartLocation."/>
     </Schema>
 
+    <Schema xmlns="http://docs.oasis-open.org/odata/ns/edm" Namespace="Resource.v1_5_10">
+      <Annotation Term="Redfish.OwningEntity" String="DMTF"/>
+      <Annotation Term="OData.Description" String="This version was created to correct the description for LocationType within PartLocation.  It was also created to clarify the descriptions for Id, Name, Description, and MemberId to be consistent with usage in the specification."/>
+    </Schema>
+
     <Schema xmlns="http://docs.oasis-open.org/odata/ns/edm" Namespace="Resource.v1_6_0">
       <Annotation Term="Redfish.OwningEntity" String="DMTF"/>
       <Annotation Term="Redfish.Release" String="2017.3"/>
@@ -1310,6 +1399,11 @@
     <Schema xmlns="http://docs.oasis-open.org/odata/ns/edm" Namespace="Resource.v1_6_8">
       <Annotation Term="Redfish.OwningEntity" String="DMTF"/>
       <Annotation Term="OData.Description" String="This version was created to add formats to the different durable name types.  It was also created to correct various description to use proper normative terminology.  It was also created to clarify the usage of LocationType within PartLocation."/>
+    </Schema>
+
+    <Schema xmlns="http://docs.oasis-open.org/odata/ns/edm" Namespace="Resource.v1_6_9">
+      <Annotation Term="Redfish.OwningEntity" String="DMTF"/>
+      <Annotation Term="OData.Description" String="This version was created to correct the description for LocationType within PartLocation.  It was also created to clarify the descriptions for Id, Name, Description, and MemberId to be consistent with usage in the specification."/>
     </Schema>
 
     <Schema xmlns="http://docs.oasis-open.org/odata/ns/edm" Namespace="Resource.v1_7_0">
@@ -1396,6 +1490,11 @@
       <Annotation Term="OData.Description" String="This version was created to add formats to the different durable name types.  It was also created to correct various description to use proper normative terminology.  It was also created to clarify the usage of LocationType within PartLocation."/>
     </Schema>
 
+    <Schema xmlns="http://docs.oasis-open.org/odata/ns/edm" Namespace="Resource.v1_7_8">
+      <Annotation Term="Redfish.OwningEntity" String="DMTF"/>
+      <Annotation Term="OData.Description" String="This version was created to correct the description for LocationType within PartLocation.  It was also created to clarify the descriptions for Id, Name, Description, and MemberId to be consistent with usage in the specification."/>
+    </Schema>
+
     <Schema xmlns="http://docs.oasis-open.org/odata/ns/edm" Namespace="Resource.v1_8_0">
       <Annotation Term="Redfish.OwningEntity" String="DMTF"/>
       <Annotation Term="Redfish.Release" String="2018.3"/>
@@ -1437,6 +1536,11 @@
       <Annotation Term="OData.Description" String="This version was created to add formats to the different durable name types.  It was also created to correct various description to use proper normative terminology.  It was also created to clarify the usage of LocationType within PartLocation."/>
     </Schema>
 
+    <Schema xmlns="http://docs.oasis-open.org/odata/ns/edm" Namespace="Resource.v1_8_8">
+      <Annotation Term="Redfish.OwningEntity" String="DMTF"/>
+      <Annotation Term="OData.Description" String="This version was created to correct the description for LocationType within PartLocation.  It was also created to clarify the descriptions for Id, Name, Description, and MemberId to be consistent with usage in the specification."/>
+    </Schema>
+
     <Schema xmlns="http://docs.oasis-open.org/odata/ns/edm" Namespace="Resource.v1_9_0">
       <Annotation Term="Redfish.OwningEntity" String="DMTF"/>
       <Annotation Term="Redfish.Release" String="2019.4"/>
@@ -1468,6 +1572,11 @@
       <Annotation Term="OData.Description" String="This version was created to add formats to the different durable name types.  It was also created to correct various description to use proper normative terminology.  It was also created to clarify the usage of LocationType within PartLocation."/>
     </Schema>
 
+    <Schema xmlns="http://docs.oasis-open.org/odata/ns/edm" Namespace="Resource.v1_9_6">
+      <Annotation Term="Redfish.OwningEntity" String="DMTF"/>
+      <Annotation Term="OData.Description" String="This version was created to correct the description for LocationType within PartLocation.  It was also created to clarify the descriptions for Id, Name, Description, and MemberId to be consistent with usage in the specification."/>
+    </Schema>
+
     <Schema xmlns="http://docs.oasis-open.org/odata/ns/edm" Namespace="Resource.v1_10_0">
       <Annotation Term="Redfish.OwningEntity" String="DMTF"/>
       <Annotation Term="Redfish.Release" String="2020.3"/>
@@ -1484,6 +1593,11 @@
       <Annotation Term="OData.Description" String="This version was created to add formats to the different durable name types.  It was also created to correct various description to use proper normative terminology.  It was also created to clarify the usage of LocationType within PartLocation."/>
     </Schema>
 
+    <Schema xmlns="http://docs.oasis-open.org/odata/ns/edm" Namespace="Resource.v1_10_3">
+      <Annotation Term="Redfish.OwningEntity" String="DMTF"/>
+      <Annotation Term="OData.Description" String="This version was created to correct the description for LocationType within PartLocation.  It was also created to clarify the descriptions for Id, Name, Description, and MemberId to be consistent with usage in the specification."/>
+    </Schema>
+
     <Schema xmlns="http://docs.oasis-open.org/odata/ns/edm" Namespace="Resource.v1_11_0">
       <Annotation Term="Redfish.OwningEntity" String="DMTF"/>
       <Annotation Term="Redfish.Release" String="2020.4"/>
@@ -1495,10 +1609,26 @@
       <Annotation Term="OData.Description" String="This version was created to add formats to the different durable name types.  It was also created to correct various description to use proper normative terminology.  It was also created to clarify the usage of LocationType within PartLocation."/>
     </Schema>
 
+    <Schema xmlns="http://docs.oasis-open.org/odata/ns/edm" Namespace="Resource.v1_11_2">
+      <Annotation Term="Redfish.OwningEntity" String="DMTF"/>
+      <Annotation Term="OData.Description" String="This version was created to correct the description for LocationType within PartLocation.  It was also created to clarify the descriptions for Id, Name, Description, and MemberId to be consistent with usage in the specification."/>
+    </Schema>
+
     <Schema xmlns="http://docs.oasis-open.org/odata/ns/edm" Namespace="Resource.v1_12_0">
       <Annotation Term="Redfish.OwningEntity" String="DMTF"/>
       <Annotation Term="Redfish.Release" String="2021.1"/>
       <Annotation Term="OData.Description" String="This version was created to deprecate the `NSID` enumeration from Identifiers.  It was also created to add `Backplane` to LocationType within PartLocation."/>
+    </Schema>
+
+    <Schema xmlns="http://docs.oasis-open.org/odata/ns/edm" Namespace="Resource.v1_12_1">
+      <Annotation Term="Redfish.OwningEntity" String="DMTF"/>
+      <Annotation Term="OData.Description" String="This version was created to correct the description for LocationType within PartLocation.  It was also created to clarify the descriptions for Id, Name, Description, and MemberId to be consistent with usage in the specification."/>
+    </Schema>
+
+    <Schema xmlns="http://docs.oasis-open.org/odata/ns/edm" Namespace="Resource.v1_13_0">
+      <Annotation Term="Redfish.OwningEntity" String="DMTF"/>
+      <Annotation Term="Redfish.Release" String="2021.2"/>
+      <Annotation Term="OData.Description" String="This version was created to add `Embedded` to LocationType within PartLocation.  It was also to add the `Pause`, `Resume`, and `Suspend` enumerations to ResetType.  It was also created to add `Paused` to PowerState."/>
     </Schema>
 
   </edmx:DataServices>

--- a/static/redfish/v1/schema/SensorCollection_v1.xml
+++ b/static/redfish/v1/schema/SensorCollection_v1.xml
@@ -58,6 +58,7 @@
             <String>/redfish/v1/PowerEquipment/FloorPDUs/{PowerDistributionId}/Sensors</String>
             <String>/redfish/v1/PowerEquipment/Switchgear/{PowerDistributionId}/Sensors</String>
             <String>/redfish/v1/PowerEquipment/TransferSwitches/{PowerDistributionId}/Sensors</String>
+            <String>/redfish/v1/PowerEquipment/PowerShelves/{PowerDistributionId}/Sensors</String>
           </Collection>
         </Annotation>
         <NavigationProperty Name="Members" Type="Collection(Sensor.Sensor)">

--- a/static/redfish/v1/schema/Sensor_v1.xml
+++ b/static/redfish/v1/schema/Sensor_v1.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!---->
 <!--################################################################################       -->
-<!--# Redfish Schema:  Sensor v1.3.0                                                       -->
+<!--# Redfish Schema:  Sensor v1.4.0                                                       -->
 <!--#                                                                                      -->
 <!--# For a detailed change log, see the README file contained in the DSP8010 bundle,      -->
 <!--# available at http://www.dmtf.org/standards/redfish                                   -->
@@ -30,6 +30,12 @@
   </edmx:Reference>
   <edmx:Reference Uri="http://redfish.dmtf.org/schemas/v1/PhysicalContext_v1.xml">
     <edmx:Include Namespace="PhysicalContext"/>
+  </edmx:Reference>
+  <edmx:Reference Uri="http://redfish.dmtf.org/schemas/v1/Control_v1.xml">
+    <edmx:Include Namespace="Control"/>
+  </edmx:Reference>
+  <edmx:Reference Uri="http://redfish.dmtf.org/schemas/v1/Redundancy_v1.xml">
+    <edmx:Include Namespace="Redundancy"/>
   </edmx:Reference>
 
   <edmx:DataServices>
@@ -62,7 +68,9 @@
             <String>/redfish/v1/PowerEquipment/Sensors/{SensorId}</String>
             <String>/redfish/v1/PowerEquipment/RackPDUs/{PowerDistributionId}/Sensors/{SensorId}</String>
             <String>/redfish/v1/PowerEquipment/FloorPDUs/{PowerDistributionId}/Sensors/{SensorId}</String>
+            <String>/redfish/v1/PowerEquipment/Switchgear/{PowerDistributionId}/Sensors/{SensorId}</String>
             <String>/redfish/v1/PowerEquipment/TransferSwitches/{PowerDistributionId}/Sensors/{SensorId}</String>
+            <String>/redfish/v1/PowerEquipment/PowerShelves/{PowerDistributionId}/Sensors/{SensorId}</String>
           </Collection>
         </Annotation>
       </EntityType>
@@ -230,13 +238,13 @@
         <Property Name="ApparentVA" Type="Edm.Decimal">
           <Annotation Term="OData.Permissions" EnumMember="OData.Permission/Read"/>
           <Annotation Term="OData.Description" String="The product of voltage and current for an AC circuit, in Volt-Ampere units."/>
-          <Annotation Term="OData.LongDescription" String="This property shall contain the product of VoltageRMS multiplied by CurrentRMS for a circuit.  This property can appear in sensors of the Power ReadingType, and shall not appear in sensors of other ReadingType values."/>
+          <Annotation Term="OData.LongDescription" String="This property shall contain the product of voltage (RMS) multiplied by current (RMS) for a circuit.  This property can appear in sensors of the Power ReadingType, and shall not appear in sensors of other ReadingType values."/>
           <Annotation Term="Measures.Unit" String="V.A"/>
           <Annotation Term="Redfish.Excerpt" String="Power,PowerArray"/>
         </Property>
         <Property Name="ReactiveVAR" Type="Edm.Decimal">
           <Annotation Term="OData.Permissions" EnumMember="OData.Permission/Read"/>
-          <Annotation Term="OData.Description" String="The square root of the difference term of squared ApparentVA and squared Power (Reading) for a circuit, in var units."/>
+          <Annotation Term="OData.Description" String="The square root of the difference term of squared apparent VA and squared power (Reading) for a circuit, in VAR units."/>
           <Annotation Term="OData.LongDescription" String="This property shall contain the arithmetic mean of product terms of instantaneous voltage and quadrature current measurements calculated over an integer number of line cycles for a circuit.  This property can appear in sensors of the Power ReadingType, and shall not appear in sensors of other ReadingType values."/>
           <Annotation Term="Measures.Unit" String="V.A"/>
           <Annotation Term="Redfish.Excerpt" String="Power,PowerArray"/>
@@ -244,7 +252,7 @@
         <Property Name="PowerFactor" Type="Edm.Decimal">
           <Annotation Term="OData.Permissions" EnumMember="OData.Permission/Read"/>
           <Annotation Term="OData.Description" String="The power factor for this sensor."/>
-          <Annotation Term="OData.LongDescription" String="This property shall identify the quotient of PowerRealWatts and PowerApparentVA for a circuit.  PowerFactor is expressed in unit-less 1/100ths.  This property can appear in sensors of the Power ReadingType, and shall not appear in sensors of other ReadingType values."/>
+          <Annotation Term="OData.LongDescription" String="This property shall identify the quotient of real power (W) and apparent power (VA) for a circuit.  PowerFactor is expressed in unit-less 1/100ths.  This property can appear in sensors of the Power ReadingType, and shall not appear in sensors of other ReadingType values."/>
           <Annotation Term="Validation.Minimum" Int="0"/>
           <Annotation Term="Validation.Maximum" Int="1"/>
           <Annotation Term="Redfish.Excerpt" String="Power,PowerArray"/>
@@ -435,11 +443,35 @@
         </Member>
         <Member Name="EnergykWh">
           <Annotation Term="OData.Description" String="Energy (kWh)."/>
-          <Annotation Term="OData.LongDescription" String="This value shall indicate the energy, integral of real power over time, of the monitored item since the sensor metrics were last reset.  The value of the Reading property shall be in kilowatt-hour units and the ReadingUnits value shall be `kW.h`.  This value is used for large-scale energy consumption measurements, while EnergyJoules is used for device-level consumption measurements."/>
+          <Annotation Term="OData.LongDescription" String="This value shall indicate the energy, integral of real power over time, of the monitored item.  If representing metered power consumption the value shall reflect the power consumption since the sensor metrics were last reset.  The value of the Reading property shall be in kilowatt-hour units and the ReadingUnits value shall be `kW.h`.  This value is used for large-scale energy consumption measurements, while EnergyJoules and EnergyWh are used for device-level consumption measurements."/>
         </Member>
         <Member Name="EnergyJoules">
           <Annotation Term="OData.Description" String="Energy (Joules)."/>
-          <Annotation Term="OData.LongDescription" String="This value shall indicate the energy, integral of real power over time, of the monitored item since the sensor metrics were last reset.  The value of the Reading property shall be in Joule units and the ReadingUnits value shall be `J`.  This value is used for device-level energy consumption measurements, while EnergykWh is used for large-scale consumption measurements."/>
+          <Annotation Term="OData.LongDescription" String="This value shall indicate the energy, integral of real power over time, of the monitored item.  If representing metered power consumption the value shall reflect the power consumption since the sensor metrics were last reset.  The value of the Reading property shall be in Joule units and the ReadingUnits value shall be `J`.  This value is used for device-level energy consumption measurements, while EnergykWh is used for large-scale consumption measurements."/>
+        </Member>
+        <Member Name="EnergyWh">
+          <Annotation Term="OData.Description" String="Energy (Wh)."/>
+          <Annotation Term="OData.LongDescription" String="This value shall indicate the energy, integral of real power over time, of the monitored item.  If representing metered power consumption the value shall reflect the power consumption since the sensor metrics were last reset.  The value of the Reading property shall be in watt-hour units and the ReadingUnits value shall be `W.h`.  This value is used for device-level energy consumption measurements, while EnergykWh is used for large-scale consumption measurements."/>
+          <Annotation Term="Redfish.Revisions">
+            <Collection>
+              <Record>
+                <PropertyValue Property="Kind" EnumMember="Redfish.RevisionKind/Added"/>
+                <PropertyValue Property="Version" String="v1_4_0"/>
+              </Record>
+            </Collection>
+          </Annotation>
+        </Member>
+        <Member Name="ChargeAh">
+          <Annotation Term="OData.Description" String="Charge (Ah)."/>
+          <Annotation Term="OData.LongDescription" String="This value shall indicate the amount of charge of the monitored item.  If representing metered power consumption,  integral of real power over time, the value shall reflect the power consumption since the sensor metrics were last reset.  The value of the Reading property shall be in amp-hour units and the ReadingUnits value shall be `A.h`."/>
+          <Annotation Term="Redfish.Revisions">
+            <Collection>
+              <Record>
+                <PropertyValue Property="Kind" EnumMember="Redfish.RevisionKind/Added"/>
+                <PropertyValue Property="Version" String="v1_4_0"/>
+              </Record>
+            </Collection>
+          </Annotation>
         </Member>
         <Member Name="Voltage">
           <Annotation Term="OData.Description" String="Voltage (AC or DC)."/>
@@ -532,6 +564,12 @@
       <EntityType Name="Sensor" BaseType="Sensor.v1_0_5.Sensor"/>
     </Schema>
 
+    <Schema xmlns="http://docs.oasis-open.org/odata/ns/edm" Namespace="Sensor.v1_0_7">
+      <Annotation Term="Redfish.OwningEntity" String="DMTF"/>
+      <Annotation Term="OData.Description" String="This version was created to correct various typographical errors."/>
+      <EntityType Name="Sensor" BaseType="Sensor.v1_0_6.Sensor"/>
+    </Schema>
+
     <Schema xmlns="http://docs.oasis-open.org/odata/ns/edm" Namespace="Sensor.v1_1_0">
       <Annotation Term="Redfish.OwningEntity" String="DMTF"/>
       <Annotation Term="Redfish.Release" String="2019.4"/>
@@ -578,7 +616,7 @@
           <Annotation Term="OData.Description" String="The reading is acquired from a physical sensor."/>
         </Member>
         <Member Name="Synthesized">
-          <Annotation Term="OData.Description" String="The reading is obtained by applying a calculation on one or more properties.  The calculation is not provided."/>
+          <Annotation Term="OData.Description" String="The reading is obtained by applying a calculation on one or more properties or multiple sensors.  The calculation is not provided."/>
         </Member>
         <Member Name="Reported">
           <Annotation Term="OData.Description" String="The reading is obtained from software or a device."/>
@@ -596,6 +634,12 @@
       <Annotation Term="Redfish.OwningEntity" String="DMTF"/>
       <Annotation Term="OData.Description" String="This version was created to correct various typographical errors."/>
       <EntityType Name="Sensor" BaseType="Sensor.v1_1_1.Sensor"/>
+    </Schema>
+
+    <Schema xmlns="http://docs.oasis-open.org/odata/ns/edm" Namespace="Sensor.v1_1_3">
+      <Annotation Term="Redfish.OwningEntity" String="DMTF"/>
+      <Annotation Term="OData.Description" String="This version was created to correct various typographical errors."/>
+      <EntityType Name="Sensor" BaseType="Sensor.v1_1_2.Sensor"/>
     </Schema>
 
     <Schema xmlns="http://docs.oasis-open.org/odata/ns/edm" Namespace="Sensor.v1_2_0">
@@ -646,6 +690,12 @@
       </ComplexType>
     </Schema>
 
+    <Schema xmlns="http://docs.oasis-open.org/odata/ns/edm" Namespace="Sensor.v1_2_1">
+      <Annotation Term="Redfish.OwningEntity" String="DMTF"/>
+      <Annotation Term="OData.Description" String="This version was created to correct various typographical errors."/>
+      <EntityType Name="Sensor" BaseType="Sensor.v1_2_0.Sensor"/>
+    </Schema>
+
     <Schema xmlns="http://docs.oasis-open.org/odata/ns/edm" Namespace="Sensor.v1_3_0">
       <Annotation Term="Redfish.OwningEntity" String="DMTF"/>
       <Annotation Term="Redfish.Release" String="2021.1"/>
@@ -660,6 +710,68 @@
       <ComplexType Name="Links" BaseType="Resource.Links">
         <Annotation Term="OData.Description" String="The links to other resources that are related to this resource."/>
         <Annotation Term="OData.LongDescription" String="This Redfish Specification-described type shall contain links to resources that are related to but are not contained by, or subordinate to, this resource."/>
+      </ComplexType>
+    </Schema>
+
+    <Schema xmlns="http://docs.oasis-open.org/odata/ns/edm" Namespace="Sensor.v1_3_1">
+      <Annotation Term="Redfish.OwningEntity" String="DMTF"/>
+      <Annotation Term="OData.Description" String="This version was created to correct various typographical errors."/>
+      <EntityType Name="Sensor" BaseType="Sensor.v1_3_0.Sensor"/>
+    </Schema>
+
+    <Schema xmlns="http://docs.oasis-open.org/odata/ns/edm" Namespace="Sensor.v1_4_0">
+      <Annotation Term="Redfish.OwningEntity" String="DMTF"/>
+      <Annotation Term="Redfish.Release" String="2021.2"/>
+
+      <EntityType Name="Sensor" BaseType="Sensor.v1_3_1.Sensor">
+        <Property Name="SensorGroup" Type="Redundancy.RedundantGroup" Nullable="false">
+          <Annotation Term="OData.Description" String="The group of sensors that provide readings for this sensor."/>
+          <Annotation Term="OData.LongDescription" String="This property shall contain information for a group of sensors that provide input for the value of this sensor's reading.  If this property is present, the Implementation property shall contain the value `Synthesized`.  The group may be created for redundancy or to improve the accuracy of the reading through multiple sensor inputs."/>
+        </Property>
+        <Property Name="LowestReading" Type="Edm.Decimal">
+          <Annotation Term="OData.Permissions" EnumMember="OData.Permission/Read"/>
+          <Annotation Term="OData.Description" String="The lowest sensor value."/>
+          <Annotation Term="OData.LongDescription" String="This property shall contain the lowest sensor value since the last ResetMetrics action was performed or the service last reset the time-based property values."/>
+        </Property>
+        <Property Name="LowestReadingTime" Type="Edm.DateTimeOffset">
+          <Annotation Term="OData.Permissions" EnumMember="OData.Permission/Read"/>
+          <Annotation Term="OData.Description" String="The time when the lowest sensor value occurred."/>
+          <Annotation Term="OData.LongDescription" String="This property shall contain the date and time when the lowest sensor value was observed."/>
+        </Property>
+        <Property Name="AverageReading" Type="Edm.Decimal">
+          <Annotation Term="OData.Permissions" EnumMember="OData.Permission/Read"/>
+          <Annotation Term="OData.Description" String="The average sensor value."/>
+          <Annotation Term="OData.LongDescription" String="This property shall contain the average sensor value over the time specified by the value of the AveragingInterval property.  The value shall be reset by the ResetMetrics action."/>
+        </Property>
+        <Property Name="AveragingInterval" Type="Edm.Duration">
+          <Annotation Term="OData.Permissions" EnumMember="OData.Permission/ReadWrite"/>
+          <Annotation Term="OData.Description" String="The interval over which the average sensor value is calculated."/>
+          <Annotation Term="OData.LongDescription" String="This property shall contain the interval over which the sensor value is averaged to produce the value of the AverageReading property.  This property shall only be present if the AverageReading property is present."/>
+        </Property>
+        <Property Name="AveragingIntervalAchieved" Type="Edm.Boolean">
+          <Annotation Term="OData.Permissions" EnumMember="OData.Permission/Read"/>
+          <Annotation Term="OData.Description" String="Indicates that enough readings were collected to calculate the average sensor reading over the averaging interval time."/>
+          <Annotation Term="OData.LongDescription" String="This property shall indicate that enough readings were collected to calculate the AverageReading value over the interval specified by the AveragingInterval property.  The value shall be reset by the ResetMetrics action.  This property shall only be present if the AveragingInterval property is present."/>
+        </Property>
+        <Property Name="Calibration" Type="Edm.Decimal">
+          <Annotation Term="OData.Permissions" EnumMember="OData.Permission/ReadWrite"/>
+          <Annotation Term="OData.Description" String="The calibration offset applied to the Reading."/>
+          <Annotation Term="OData.LongDescription" String="This property shall contain the offset applied to the raw sensor value to provide a calibrated value for the sensor as returned by the Reading property.  The value of this property shall follow the units of the Reading property for this sensor instance.  Updating the value of this property shall not affect the value of the CalibrationTime property."/>
+        </Property>
+        <Property Name="CalibrationTime" Type="Edm.DateTimeOffset">
+          <Annotation Term="OData.Permissions" EnumMember="OData.Permission/ReadWrite"/>
+          <Annotation Term="OData.Description" String="The date and time that the sensor was last calibrated."/>
+          <Annotation Term="OData.LongDescription" String="This property shall contain the date and time that the sensor was last calibrated.  This property is intended to reflect the actual time the calibration occurred."/>
+        </Property>
+      </EntityType>
+
+      <ComplexType Name="Links" BaseType="Sensor.v1_3_0.Links">
+        <NavigationProperty Name="AssociatedControls" Type="Collection(Control.Control)">
+          <Annotation Term="OData.Permissions" EnumMember="OData.Permission/Read"/>
+          <Annotation Term="OData.Description" String="An array of links to the controls that can affect this sensor."/>
+          <Annotation Term="OData.LongDescription" String="This property shall contain an array of links to resources of type Control that represent the controls that can affect this sensor."/>
+          <Annotation Term="OData.AutoExpandReferences"/>
+        </NavigationProperty>
       </ComplexType>
     </Schema>
 

--- a/static/redfish/v1/schema/ServiceRoot_v1.xml
+++ b/static/redfish/v1/schema/ServiceRoot_v1.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!---->
 <!--################################################################################       -->
-<!--# Redfish Schema:  ServiceRoot v1.10.0                                                 -->
+<!--# Redfish Schema:  ServiceRoot v1.11.0                                                 -->
 <!--#                                                                                      -->
 <!--# For a detailed change log, see the README file contained in the DSP8010 bundle,      -->
 <!--# available at http://www.dmtf.org/standards/redfish                                   -->
@@ -96,6 +96,12 @@
   </edmx:Reference>
   <edmx:Reference Uri="http://redfish.dmtf.org/schemas/swordfish/v1/NVMeDomainCollection_v1.xml">
     <edmx:Include Namespace="NVMeDomainCollection"/>
+  </edmx:Reference>
+  <edmx:Reference Uri="http://redfish.dmtf.org/schemas/v1/KeyService_v1.xml">
+    <edmx:Include Namespace="KeyService"/>
+  </edmx:Reference>
+  <edmx:Reference Uri="http://redfish.dmtf.org/schemas/v1/CableCollection_v1.xml">
+    <edmx:Include Namespace="CableCollection"/>
   </edmx:Reference>
 
   <edmx:DataServices>
@@ -708,6 +714,30 @@
           <Annotation Term="OData.Description" String="The link to a collection of NVMe domains."/>
           <Annotation Term="OData.LongDescription" String="This property shall contain a link to a resource collection of type NVMeDomainCollection."/>
           <Annotation Term="OData.AutoExpandReferences"/>
+        </NavigationProperty>
+      </EntityType>
+    </Schema>
+
+    <Schema xmlns="http://docs.oasis-open.org/odata/ns/edm" Namespace="ServiceRoot.v1_11_0">
+      <Annotation Term="Redfish.OwningEntity" String="DMTF"/>
+      <Annotation Term="Redfish.Release" String="2021.2"/>
+
+      <EntityContainer Name="ServiceContainer" Extends="ServiceRoot.v1_10_0.ServiceContainer">
+        <Singleton Name="KeyService" Type="KeyService.KeyService"/>
+        <Singleton Name="Cables" Type="CableCollection.CableCollection"/>
+      </EntityContainer>
+
+      <EntityType Name="ServiceRoot" BaseType="ServiceRoot.v1_10_0.ServiceRoot">
+        <NavigationProperty Name="KeyService" Type="KeyService.KeyService" Nullable="false">
+          <Annotation Term="OData.Permissions" EnumMember="OData.Permission/Read"/>
+          <Annotation Term="OData.Description" String="The link to the key service."/>
+          <Annotation Term="OData.LongDescription" String="This property shall contain a link to a resource of type KeyService."/>
+          <Annotation Term="OData.AutoExpandReferences"/>
+        </NavigationProperty>
+        <NavigationProperty Name="Cables" Type="CableCollection.CableCollection" Nullable="false">
+          <Annotation Term="OData.Permissions" EnumMember="OData.Permission/Read"/>
+          <Annotation Term="OData.Description" String="The link to a collection of cables."/>
+          <Annotation Term="OData.LongDescription" String="This property shall contain a link to a resource collection of type CableCollection."/>
         </NavigationProperty>
       </EntityType>
     </Schema>

--- a/static/redfish/v1/schema/SoftwareInventory_v1.xml
+++ b/static/redfish/v1/schema/SoftwareInventory_v1.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!---->
 <!--################################################################################       -->
-<!--# Redfish Schema:  SoftwareInventory v1.4.0                                            -->
+<!--# Redfish Schema:  SoftwareInventory v1.5.0                                            -->
 <!--#                                                                                      -->
 <!--# For a detailed change log, see the README file contained in the DSP8010 bundle,      -->
 <!--# available at http://www.dmtf.org/standards/redfish                                   -->
@@ -267,6 +267,22 @@
           <Annotation Term="OData.Description" String="The hexadecimal string representation of the numeric value of the DSP0274-defined Measurement field  of the measurement block."/>
           <Annotation Term="OData.LongDescription" String="This property shall contain the value of the hexadecimal string representation of the numeric value of the DSP0274-defined Measurement field  of the measurement block."/>
           <Annotation Term="Validation.Pattern" String="^[0-9a-fA-F]+$"/>
+        </Property>
+      </ComplexType>
+    </Schema>
+
+    <Schema xmlns="http://docs.oasis-open.org/odata/ns/edm" Namespace="SoftwareInventory.v1_5_0">
+      <Annotation Term="Redfish.OwningEntity" String="DMTF"/>
+      <Annotation Term="Redfish.Release" String="2021.2"/>
+      <Annotation Term="OData.Description" String="This version was created to add MeasurementIndex property to MeasurementBlock complex type in support of DSP0274."/>
+
+      <EntityType Name="SoftwareInventory" BaseType="SoftwareInventory.v1_4_0.SoftwareInventory"/>
+
+      <ComplexType Name="MeasurementBlock" BaseType="SoftwareInventory.v1_4_0.MeasurementBlock">
+        <Property Name="MeasurementIndex" Type="Edm.Int64">
+          <Annotation Term="OData.Permissions" EnumMember="OData.Permission/Read"/>
+          <Annotation Term="OData.Description" String="The DSP0274-defined Index field of the measurement block."/>
+          <Annotation Term="OData.LongDescription" String="This property shall contain the value of DSP0274-defined Index field of the measurement block."/>
         </Property>
       </ComplexType>
     </Schema>

--- a/static/redfish/v1/schema/StorageController_v1.xml
+++ b/static/redfish/v1/schema/StorageController_v1.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!---->
 <!--################################################################################       -->
-<!--# Redfish Schema:  StorageController v1.2.0                                            -->
+<!--# Redfish Schema:  StorageController v1.3.0                                            -->
 <!--#                                                                                      -->
 <!--# For a detailed change log, see the README file contained in the DSP8010 bundle,      -->
 <!--# available at http://www.dmtf.org/standards/redfish                                   -->
@@ -57,6 +57,9 @@
   </edmx:Reference>
   <edmx:Reference Uri="http://redfish.dmtf.org/schemas/v1/EnvironmentMetrics_v1.xml">
     <edmx:Include Namespace="EnvironmentMetrics"/>
+  </edmx:Reference>
+  <edmx:Reference Uri="http://redfish.dmtf.org/schemas/v1/NetworkDeviceFunction_v1.xml">
+    <edmx:Include Namespace="NetworkDeviceFunction"/>
   </edmx:Reference>
 
   <edmx:DataServices>
@@ -518,6 +521,23 @@
           <Annotation Term="OData.Description" String="Indicates if the controller supports reservations."/>
           <Annotation Term="OData.LongDescription" String="This property shall indicate if the controller supports reservations."/>
         </Property>
+      </ComplexType>
+    </Schema>
+
+    <Schema xmlns="http://docs.oasis-open.org/odata/ns/edm" Namespace="StorageController.v1_3_0">
+      <Annotation Term="Redfish.OwningEntity" String="DMTF"/>
+      <Annotation Term="Redfish.Release" String="2021.2"/>
+      <Annotation Term="OData.Description" String="This version was created to add a link for NetworkDeviceFunctions."/>
+
+      <EntityType Name="StorageController" BaseType="StorageController.v1_2_0.StorageController"/>
+
+      <ComplexType Name="Links" BaseType="StorageController.v1_0_0.Links">
+        <NavigationProperty Name="NetworkDeviceFunctions" Type="Collection(NetworkDeviceFunction.NetworkDeviceFunction)">
+          <Annotation Term="OData.Permissions" EnumMember="OData.Permission/Read"/>
+          <Annotation Term="OData.Description" String="The network device functions that provide connectivity to this controller."/>
+          <Annotation Term="OData.LongDescription" String="This property shall contain an array of links to resources of type NetworkDeviceFunction that represent the devices that provide connectivity to this controller."/>
+          <Annotation Term="OData.AutoExpandReferences"/>
+        </NavigationProperty>
       </ComplexType>
     </Schema>
 

--- a/static/redfish/v1/schema/Storage_v1.xml
+++ b/static/redfish/v1/schema/Storage_v1.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!---->
 <!--################################################################################                   -->
-<!--# Redfish Schema:  Storage v1.10.1                                                                 -->
+<!--# Redfish Schema:  Storage v1.11.0                                                                 -->
 <!--#                                                                                                  -->
 <!--# For a detailed change log, see the README file contained in the DSP8010 bundle,                  -->
 <!--# available at http://www.dmtf.org/standards/redfish                                               -->
@@ -91,6 +91,9 @@
   <edmx:Reference Uri="http://redfish.dmtf.org/schemas/v1/SoftwareInventory_v1.xml">
     <edmx:Include Namespace="SoftwareInventory"/>
   </edmx:Reference>
+  <edmx:Reference Uri="http://redfish.dmtf.org/schemas/v1/ComputerSystem_v1.xml">
+    <edmx:Include Namespace="ComputerSystem"/>
+  </edmx:Reference>
 
   <edmx:DataServices>
 
@@ -141,6 +144,24 @@
           <Annotation Term="OData.Description" String="The encryption key to set on the storage subsystem."/>
           <Annotation Term="OData.LongDescription" String="This parameter shall contain the encryption key to set on the storage subsystem."/>
         </Parameter>
+      </Action>
+
+      <Action Name="ResetToDefaults" IsBound="true">
+        <Annotation Term="OData.Description" String="The reset action resets the storage device to factory defaults.  This can cause the loss of data."/>
+        <Annotation Term="OData.LongDescription" String="This action shall reset the storage device.  This action can impact other resources."/>
+        <Parameter Name="Storage" Type="Storage.v1_0_0.Actions"/>
+        <Parameter Name="ResetType" Type="Storage.v1_11_0.ResetToDefaultsType" Nullable="false">
+          <Annotation Term="OData.Description" String="The type of reset to defaults."/>
+          <Annotation Term="OData.LongDescription" String="This parameter shall contain the type of reset to defaults."/>
+        </Parameter>
+        <Annotation Term="Redfish.Revisions">
+          <Collection>
+            <Record>
+              <PropertyValue Property="Kind" EnumMember="Redfish.RevisionKind/Added"/>
+              <PropertyValue Property="Version" String="v1_11_0"/>
+            </Record>
+          </Collection>
+        </Annotation>
       </Action>
     </Schema>
 
@@ -1042,6 +1063,32 @@
       <Annotation Term="OData.Description" String="This version was created to correct various description to use proper normative terminology."/>
       <EntityType Name="Storage" BaseType="Storage.v1_10_0.Storage"/>
       <EntityType Name="StorageController" BaseType="Storage.v1_10_0.StorageController"/>
+    </Schema>
+
+    <Schema xmlns="http://docs.oasis-open.org/odata/ns/edm" Namespace="Storage.v1_11_0">
+      <Annotation Term="Redfish.OwningEntity" String="DMTF"/>
+      <Annotation Term="Redfish.Release" String="2021.2"/>
+      <Annotation Term="OData.Description" String="This version was created to add the ResetToDefaults action."/>
+
+      <EntityType Name="Storage" BaseType="Storage.v1_10_1.Storage"/>
+
+      <EnumType Name="ResetToDefaultsType">
+        <Member Name="ResetAll">
+          <Annotation Term="OData.Description" String="Reset all settings to factory defaults and remove all volumes."/>
+        </Member>
+        <Member Name="PreserveVolumes">
+          <Annotation Term="OData.Description" String="Reset all settings to factory defaults but preserve the configured volumes on the controllers."/>
+        </Member>
+      </EnumType>
+
+      <ComplexType Name="Links" BaseType="Storage.v1_9_0.Links">
+        <NavigationProperty Name="HostingStorageSystems" Type="Collection(ComputerSystem.ComputerSystem)">
+          <Annotation Term="OData.Permissions" EnumMember="OData.Permission/Read"/>
+          <Annotation Term="OData.Description" String="The storage systems that host this storage subsystem."/>
+          <Annotation Term="OData.LongDescription" String="This property shall contain an array of links to resources of type ComputerSystem that represent the storage systems that host this storage subsystem.  The members of this array shall be in the StorageSystems resource collection off the service root."/>
+          <Annotation Term="OData.AutoExpandReferences"/>
+        </NavigationProperty>
+      </ComplexType>
     </Schema>
 
   </edmx:DataServices>

--- a/static/redfish/v1/schema/UpdateService_v1.xml
+++ b/static/redfish/v1/schema/UpdateService_v1.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!---->
 <!--################################################################################       -->
-<!--# Redfish Schema:  UpdateService v1.9.0                                                -->
+<!--# Redfish Schema:  UpdateService v1.10.0                                               -->
 <!--#                                                                                      -->
 <!--# For a detailed change log, see the README file contained in the DSP8010 bundle,      -->
 <!--# available at http://www.dmtf.org/standards/redfish                                   -->
@@ -764,6 +764,20 @@
           <Annotation Term="OData.Description" String="An indication of whether the service will verify the certificate of the server referenced by the ImageURI property in SimpleUpdate prior to sending the transfer request."/>
           <Annotation Term="OData.LongDescription" String="This property shall indicate whether whether the service will verify the certificate of the server referenced by the ImageURI property in SimpleUpdate prior to sending the transfer request."/>
         </Property>
+      </EntityType>
+    </Schema>
+
+    <Schema xmlns="http://docs.oasis-open.org/odata/ns/edm" Namespace="UpdateService.v1_10_0">
+      <Annotation Term="Redfish.OwningEntity" String="DMTF"/>
+      <Annotation Term="Redfish.Release" String="2021.2"/>
+
+      <EntityType Name="UpdateService" BaseType="UpdateService.v1_8_3.UpdateService">
+        <NavigationProperty Name="ClientCertificates" Type="CertificateCollection.CertificateCollection" ContainsTarget="true" Nullable="false">
+          <Annotation Term="OData.Permissions" EnumMember="OData.Permission/Read"/>
+          <Annotation Term="OData.Description" String="The link to a collection of client identity certificates provided to the server referenced by the ImageURI property in SimpleUpdate."/>
+          <Annotation Term="OData.LongDescription" String="This property shall contain a link to a resource collection of type CertificateCollection that represents the client identity certificates that are provided to the server referenced by the ImageURI property in SimpleUpdate as part of TLS handshaking."/>
+          <Annotation Term="OData.AutoExpandReferences"/>
+        </NavigationProperty>
       </EntityType>
     </Schema>
 

--- a/static/redfish/v1/schema/VLanNetworkInterface_v1.xml
+++ b/static/redfish/v1/schema/VLanNetworkInterface_v1.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!---->
 <!--################################################################################       -->
-<!--# Redfish Schema:  VLanNetworkInterface v1.2.0                                         -->
+<!--# Redfish Schema:  VLanNetworkInterface v1.3.0                                         -->
 <!--#                                                                                      -->
 <!--# For a detailed change log, see the README file contained in the DSP8010 bundle,      -->
 <!--# available at http://www.dmtf.org/standards/redfish                                   -->
@@ -59,6 +59,15 @@
             <String>/redfish/v1/CompositionService/ResourceBlocks/{ResourceBlockId}/Systems/{ComputerSystemId}/EthernetInterfaces/{EthernetInterfaceId}/VLANs/{VLanNetworkInterfaceId}</String>
             <String>/redfish/v1/ResourceBlocks/{ResourceBlockId}/EthernetInterfaces/{EthernetInterfaceId}/VLANs/{VLanNetworkInterfaceId}</String>
             <String>/redfish/v1/ResourceBlocks/{ResourceBlockId}/Systems/{ComputerSystemId}/EthernetInterfaces/{EthernetInterfaceId}/VLANs/{VLanNetworkInterfaceId}</String>
+          </Collection>
+        </Annotation>
+        <Annotation Term="Redfish.Revisions">
+          <Collection>
+            <Record>
+              <PropertyValue Property="Kind" EnumMember="Redfish.RevisionKind/Deprecated"/>
+              <PropertyValue Property="Version" String="v1_3_0"/>
+              <PropertyValue Property="Description" String="This schema has been deprecated in favor of using individual EthernetInterface resources to show VLAN information."/>
+            </Record>
           </Collection>
         </Annotation>
       </EntityType>
@@ -247,6 +256,21 @@
         <Annotation Term="Validation.Minimum" Int="0"/>
         <Annotation Term="Validation.Maximum" Int="7"/>
       </TypeDefinition>
+    </Schema>
+
+    <Schema xmlns="http://docs.oasis-open.org/odata/ns/edm" Namespace="VLanNetworkInterface.v1_3_0">
+      <Annotation Term="Redfish.OwningEntity" String="DMTF"/>
+      <Annotation Term="Redfish.Release" String="2021.2"/>
+
+      <EntityType Name="VLanNetworkInterface" BaseType="VLanNetworkInterface.v1_2_0.VLanNetworkInterface"/>
+
+      <ComplexType Name="VLAN" BaseType="VLanNetworkInterface.v1_2_0.VLAN">
+        <Property Name="Tagged" Type="Edm.Boolean">
+          <Annotation Term="OData.Permissions" EnumMember="OData.Permission/ReadWrite"/>
+          <Annotation Term="OData.Description" String="An indication of whether this VLAN is tagged or untagged for this interface."/>
+          <Annotation Term="OData.LongDescription" String="This property shall indicate whether this VLAN is tagged or untagged for this interface."/>
+        </Property>
+      </ComplexType>
     </Schema>
 
   </edmx:DataServices>

--- a/static/redfish/v1/schema/VirtualMedia_v1.xml
+++ b/static/redfish/v1/schema/VirtualMedia_v1.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!---->
 <!--################################################################################       -->
-<!--# Redfish Schema:  VirtualMedia v1.4.0                                                 -->
+<!--# Redfish Schema:  VirtualMedia v1.5.0                                                 -->
 <!--#                                                                                      -->
 <!--# For a detailed change log, see the README file contained in the DSP8010 bundle,      -->
 <!--# available at http://www.dmtf.org/standards/redfish                                   -->
@@ -35,7 +35,7 @@
 
       <EntityType Name="VirtualMedia" BaseType="Resource.v1_0_0.Resource" Abstract="true">
         <Annotation Term="OData.Description" String="The VirtualMedia schema contains properties related to the monitor and control of an instance of virtual media, such as a remote CD, DVD, or USB device.  A manager for a system or device provides virtual media functionality."/>
-        <Annotation Term="OData.LongDescription" String="This Resource shall represent a virtual media service for a Redfish implementation."/>
+        <Annotation Term="OData.LongDescription" String="This resource shall represent a virtual media service for a Redfish implementation."/>
         <Annotation Term="Capabilities.InsertRestrictions">
           <Record>
             <PropertyValue Property="Insertable" Bool="false"/>
@@ -75,20 +75,20 @@
         </Annotation>
         <Parameter Name="VirtualMedia" Type="VirtualMedia.v1_1_0.Actions"/>
         <Parameter Name="Image" Type="Edm.String" Nullable="false">
-          <Annotation Term="OData.Description" String="The URI of the remote media to attach to the virtual media."/>
-          <Annotation Term="OData.LongDescription" String="This parameter shall specify the URI of the remote media to be attached to the virtual media."/>
+          <Annotation Term="OData.Description" String="The URI of the media to attach to the virtual media."/>
+          <Annotation Term="OData.LongDescription" String="This parameter shall contain the URI of the media to be attached to the virtual media.  This parameter may specify an absolute URI to remote media or a relative URI to media local to the implementation.  A service may allow a relative URI to reference a SoftwareInventory resource."/>
         </Parameter>
         <Parameter Name="Inserted" Type="Edm.Boolean">
           <Annotation Term="OData.Description" String="An indication of whether the image is treated as inserted upon completion of the action.  The default is `true`."/>
-          <Annotation Term="OData.LongDescription" String="This parameter shall indicate whether the image is treated as inserted upon completion of the action.  If the client does not provide this parameter, the service shall default this value to `true`."/>
+          <Annotation Term="OData.LongDescription" String="This parameter shall contain whether the image is treated as inserted upon completion of the action.  If the client does not provide this parameter, the service shall default this value to `true`."/>
         </Parameter>
         <Parameter Name="WriteProtected" Type="Edm.Boolean">
           <Annotation Term="OData.Description" String="An indication of whether the remote media is treated as write-protected.  The default is `true`."/>
-          <Annotation Term="OData.LongDescription" String="This parameter shall indicate whether the remote media is treated as write-protected.  If the client does not provide this parameter, the service shall default this value to `true`."/>
+          <Annotation Term="OData.LongDescription" String="This parameter shall contain whether the remote media is treated as write-protected.  If the client does not provide this parameter, the service shall default this value to `true`."/>
         </Parameter>
         <Parameter Name="UserName" Type="Edm.String">
-          <Annotation Term="OData.Description" String="The user name to access the Image parameter-specified URI."/>
-          <Annotation Term="OData.LongDescription" String="This parameter shall contain the user name to access the Image parameter-specified URI."/>
+          <Annotation Term="OData.Description" String="The username to access the URI specified by the Image parameter."/>
+          <Annotation Term="OData.LongDescription" String="This parameter shall contain the username to access the URI specified by the Image parameter."/>
           <Annotation Term="Redfish.Revisions">
             <Collection>
               <Record>
@@ -99,8 +99,8 @@
           </Annotation>
         </Parameter>
         <Parameter Name="Password" Type="Edm.String">
-          <Annotation Term="OData.Description" String="The password to access the Image parameter-specified URI."/>
-          <Annotation Term="OData.LongDescription" String="This parameter shall represent the password to access the Image parameter-specified URI."/>
+          <Annotation Term="OData.Description" String="The password to access the URI specified by the Image parameter."/>
+          <Annotation Term="OData.LongDescription" String="This parameter shall contain the password to access the URI specified by the Image parameter."/>
           <Annotation Term="Redfish.Revisions">
             <Collection>
               <Record>
@@ -112,7 +112,7 @@
         </Parameter>
         <Parameter Name="TransferProtocolType" Type="VirtualMedia.v1_3_0.TransferProtocolType">
           <Annotation Term="OData.Description" String="The network protocol to use with the image."/>
-          <Annotation Term="OData.LongDescription" String="This parameter shall represent the network protocol to use with the specified image URI."/>
+          <Annotation Term="OData.LongDescription" String="This parameter shall contain the network protocol to use with the specified image URI."/>
           <Annotation Term="Redfish.Revisions">
             <Collection>
               <Record>
@@ -123,8 +123,8 @@
           </Annotation>
         </Parameter>
         <Parameter Name="TransferMethod" Type="VirtualMedia.v1_3_0.TransferMethod">
-          <Annotation Term="OData.Description" String="The transfer method to use with the Image."/>
-          <Annotation Term="OData.LongDescription" String="This parameter shall describe how the image transfer occurs."/>
+          <Annotation Term="OData.Description" String="The transfer method to use with the image."/>
+          <Annotation Term="OData.LongDescription" String="This parameter shall contain the transfer method to use with the specified image URI."/>
           <Annotation Term="Redfish.Revisions">
             <Collection>
               <Record>
@@ -149,7 +149,6 @@
         </Annotation>
         <Parameter Name="VirtualMedia" Type="VirtualMedia.v1_1_0.Actions"/>
       </Action>
-
     </Schema>
 
     <Schema xmlns="http://docs.oasis-open.org/odata/ns/edm" Namespace="VirtualMedia.v1_0_0">
@@ -165,18 +164,18 @@
         <Property Name="Image" Type="Edm.String">
           <Annotation Term="OData.Permissions" EnumMember="OData.Permission/ReadWrite"/>
           <Annotation Term="OData.Description" String="The URI of the location of the selected image."/>
-          <Annotation Term="OData.LongDescription" String="This property shall contain an URI.  A null value indicated no image connection."/>
+          <Annotation Term="OData.LongDescription" String="This property shall contain the URI of the media attached to the virtual media.  This value may specify an absolute URI to remote media or a relative URI to media local to the implementation.  A service may allow a relative URI to reference a SoftwareInventory resource.  The value `null` shall indicates no image connection."/>
           <Annotation Term="OData.IsURL"/>
         </Property>
         <Property Name="MediaTypes" Type="Collection(VirtualMedia.v1_0_0.MediaType)" Nullable="false">
           <Annotation Term="OData.Permissions" EnumMember="OData.Permission/Read"/>
           <Annotation Term="OData.Description" String="The media types supported as virtual media."/>
-          <Annotation Term="OData.LongDescription" String="The values of this array shall be the supported media types for this connection."/>
+          <Annotation Term="OData.LongDescription" String="This property shall contain an array of the supported media types for this connection."/>
         </Property>
         <Property Name="ConnectedVia" Type="VirtualMedia.v1_0_0.ConnectedVia">
           <Annotation Term="OData.Permissions" EnumMember="OData.Permission/Read"/>
           <Annotation Term="OData.Description" String="The current virtual media connection method."/>
-          <Annotation Term="OData.LongDescription" String="This property shall contain the current connection method from a client to the virtual media that this Resource represents."/>
+          <Annotation Term="OData.LongDescription" String="This property shall contain the current connection method from a client to the virtual media that this resource represents."/>
         </Property>
         <Property Name="Inserted" Type="Edm.Boolean">
           <Annotation Term="OData.Permissions" EnumMember="OData.Permission/ReadWrite"/>
@@ -219,7 +218,6 @@
           <Annotation Term="OData.Description" String="Connected through an OEM-defined method."/>
         </Member>
       </EnumType>
-
     </Schema>
 
     <Schema xmlns="http://docs.oasis-open.org/odata/ns/edm" Namespace="VirtualMedia.v1_0_2">
@@ -242,7 +240,7 @@
 
     <Schema xmlns="http://docs.oasis-open.org/odata/ns/edm" Namespace="VirtualMedia.v1_0_5">
       <Annotation Term="Redfish.OwningEntity" String="DMTF"/>
-      <Annotation Term="OData.Description" String="This version was created to use the new Revisions annotation."/>
+      <Annotation Term="OData.Description" String="This version was created to use the new revisions annotation."/>
       <EntityType Name="VirtualMedia" BaseType="VirtualMedia.v1_0_4.VirtualMedia"/>
     </Schema>
 
@@ -258,30 +256,37 @@
       <EntityType Name="VirtualMedia" BaseType="VirtualMedia.v1_0_6.VirtualMedia"/>
     </Schema>
 
+    <Schema xmlns="http://docs.oasis-open.org/odata/ns/edm" Namespace="VirtualMedia.v1_0_8">
+      <Annotation Term="Redfish.OwningEntity" String="DMTF"/>
+      <Annotation Term="OData.Description" String="This version was created to clarify the usage of Image when mounting media from a local source."/>
+      <EntityType Name="VirtualMedia" BaseType="VirtualMedia.v1_0_7.VirtualMedia"/>
+    </Schema>
+
     <Schema xmlns="http://docs.oasis-open.org/odata/ns/edm" Namespace="VirtualMedia.v1_1_0">
       <Annotation Term="Redfish.OwningEntity" String="DMTF"/>
       <Annotation Term="Redfish.Release" String="2017.1"/>
+
       <EntityType Name="VirtualMedia" BaseType="VirtualMedia.v1_0_3.VirtualMedia">
         <Property Name="Actions" Type="VirtualMedia.v1_1_0.Actions" Nullable="false">
-          <Annotation Term="OData.Description" String="The available actions for this Resource."/>
-          <Annotation Term="OData.LongDescription" String="This property shall contain the available actions for this Resource."/>
+          <Annotation Term="OData.Description" String="The available actions for this resource."/>
+          <Annotation Term="OData.LongDescription" String="This property shall contain the available actions for this resource."/>
         </Property>
       </EntityType>
 
       <ComplexType Name="Actions">
         <Annotation Term="OData.AdditionalProperties" Bool="false"/>
-        <Annotation Term="OData.Description" String="The available actions for this Resource."/>
-        <Annotation Term="OData.LongDescription" String="This type shall contain the available actions for this Resource."/>
+        <Annotation Term="OData.Description" String="The available actions for this resource."/>
+        <Annotation Term="OData.LongDescription" String="This type shall contain the available actions for this resource."/>
         <Property Name="Oem" Type="VirtualMedia.v1_1_0.OemActions" Nullable="false">
-          <Annotation Term="OData.Description" String="The available OEM-specific actions for this Resource."/>
-          <Annotation Term="OData.LongDescription" String="This property shall contain the available OEM-specific actions for this Resource."/>
+          <Annotation Term="OData.Description" String="The available OEM-specific actions for this resource."/>
+          <Annotation Term="OData.LongDescription" String="This property shall contain the available OEM-specific actions for this resource."/>
         </Property>
       </ComplexType>
 
       <ComplexType Name="OemActions">
         <Annotation Term="OData.AdditionalProperties" Bool="true"/>
-        <Annotation Term="OData.Description" String="The available OEM-specific actions for this Resource."/>
-        <Annotation Term="OData.LongDescription" String="This type shall contain the available OEM-specific actions for this Resource."/>
+        <Annotation Term="OData.Description" String="The available OEM-specific actions for this resource."/>
+        <Annotation Term="OData.LongDescription" String="This type shall contain the available OEM-specific actions for this resource."/>
       </ComplexType>
     </Schema>
 
@@ -299,7 +304,7 @@
 
     <Schema xmlns="http://docs.oasis-open.org/odata/ns/edm" Namespace="VirtualMedia.v1_1_3">
       <Annotation Term="Redfish.OwningEntity" String="DMTF"/>
-      <Annotation Term="OData.Description" String="This version was created to use the new Revisions annotation."/>
+      <Annotation Term="OData.Description" String="This version was created to use the new revisions annotation."/>
       <EntityType Name="VirtualMedia" BaseType="VirtualMedia.v1_1_2.VirtualMedia"/>
     </Schema>
 
@@ -315,10 +320,17 @@
       <EntityType Name="VirtualMedia" BaseType="VirtualMedia.v1_1_4.VirtualMedia"/>
     </Schema>
 
+    <Schema xmlns="http://docs.oasis-open.org/odata/ns/edm" Namespace="VirtualMedia.v1_1_6">
+      <Annotation Term="Redfish.OwningEntity" String="DMTF"/>
+      <Annotation Term="OData.Description" String="This version was created to clarify the usage of Image when mounting media from a local source."/>
+      <EntityType Name="VirtualMedia" BaseType="VirtualMedia.v1_1_5.VirtualMedia"/>
+    </Schema>
+
     <Schema xmlns="http://docs.oasis-open.org/odata/ns/edm" Namespace="VirtualMedia.v1_2_0">
       <Annotation Term="Redfish.OwningEntity" String="DMTF"/>
       <Annotation Term="Redfish.Release" String="2017.3"/>
       <Annotation Term="OData.Description" String="This version was created to change the permissions of Image, Inserted, and WriteProtected and to add the InsertMedia and EjectMedia actions."/>
+
       <EntityType Name="VirtualMedia" BaseType="VirtualMedia.v1_1_1.VirtualMedia"/>
     </Schema>
 
@@ -330,7 +342,7 @@
 
     <Schema xmlns="http://docs.oasis-open.org/odata/ns/edm" Namespace="VirtualMedia.v1_2_2">
       <Annotation Term="Redfish.OwningEntity" String="DMTF"/>
-      <Annotation Term="OData.Description" String="This version was created to use the new Revisions annotation."/>
+      <Annotation Term="OData.Description" String="This version was created to use the new revisions annotation."/>
       <EntityType Name="VirtualMedia" BaseType="VirtualMedia.v1_2_1.VirtualMedia"/>
     </Schema>
 
@@ -344,6 +356,12 @@
       <Annotation Term="Redfish.OwningEntity" String="DMTF"/>
       <Annotation Term="OData.Description" String="This version was created to update the Password description.  It was also created to update descriptions that this schema defines."/>
       <EntityType Name="VirtualMedia" BaseType="VirtualMedia.v1_2_3.VirtualMedia"/>
+    </Schema>
+
+    <Schema xmlns="http://docs.oasis-open.org/odata/ns/edm" Namespace="VirtualMedia.v1_2_5">
+      <Annotation Term="Redfish.OwningEntity" String="DMTF"/>
+      <Annotation Term="OData.Description" String="This version was created to clarify the usage of Image when mounting media from a local source."/>
+      <EntityType Name="VirtualMedia" BaseType="VirtualMedia.v1_2_4.VirtualMedia"/>
     </Schema>
 
     <Schema xmlns="http://docs.oasis-open.org/odata/ns/edm" Namespace="VirtualMedia.v1_3_0">
@@ -426,6 +444,12 @@
       <EntityType Name="VirtualMedia" BaseType="VirtualMedia.v1_3_1.VirtualMedia"/>
     </Schema>
 
+    <Schema xmlns="http://docs.oasis-open.org/odata/ns/edm" Namespace="VirtualMedia.v1_3_3">
+      <Annotation Term="Redfish.OwningEntity" String="DMTF"/>
+      <Annotation Term="OData.Description" String="This version was created to clarify the usage of Image when mounting media from a local source."/>
+      <EntityType Name="VirtualMedia" BaseType="VirtualMedia.v1_3_2.VirtualMedia"/>
+    </Schema>
+
     <Schema xmlns="http://docs.oasis-open.org/odata/ns/edm" Namespace="VirtualMedia.v1_4_0">
       <Annotation Term="Redfish.OwningEntity" String="DMTF"/>
       <Annotation Term="Redfish.Release" String="2021.1"/>
@@ -447,6 +471,26 @@
           <Annotation Term="OData.Description" String="An indication of whether the service will verify the certificate of the server referenced by the Image property prior to completing the remote media connection."/>
           <Annotation Term="OData.LongDescription" String="This property shall indicate whether whether the service will verify the certificate of the server referenced by the Image property prior to completing the remote media connection."/>
         </Property>
+      </EntityType>
+    </Schema>
+
+    <Schema xmlns="http://docs.oasis-open.org/odata/ns/edm" Namespace="VirtualMedia.v1_4_1">
+      <Annotation Term="Redfish.OwningEntity" String="DMTF"/>
+      <Annotation Term="OData.Description" String="This version was created to clarify the usage of Image when mounting media from a local source."/>
+      <EntityType Name="VirtualMedia" BaseType="VirtualMedia.v1_4_0.VirtualMedia"/>
+    </Schema>
+
+    <Schema xmlns="http://docs.oasis-open.org/odata/ns/edm" Namespace="VirtualMedia.v1_5_0">
+      <Annotation Term="Redfish.OwningEntity" String="DMTF"/>
+      <Annotation Term="Redfish.Release" String="2021.2"/>
+
+      <EntityType Name="VirtualMedia" BaseType="VirtualMedia.v1_4_1.VirtualMedia">
+        <NavigationProperty Name="ClientCertificates" Type="CertificateCollection.CertificateCollection" ContainsTarget="true" Nullable="false">
+          <Annotation Term="OData.Permissions" EnumMember="OData.Permission/Read"/>
+          <Annotation Term="OData.Description" String="The link to a collection of client identity certificates provided to the server referenced by the Image property."/>
+          <Annotation Term="OData.LongDescription" String="This property shall contain a link to a resource collection of type CertificateCollection that represents the client identity certificates that are provided to the server referenced by the Image property as part of TLS handshaking."/>
+          <Annotation Term="OData.AutoExpandReferences"/>
+        </NavigationProperty>
       </EntityType>
     </Schema>
 


### PR DESCRIPTION
Upstream is https://gerrit.openbmc-project.xyz/c/openbmc/bmcweb/+/47162

I reran update_schemas.py  after cherry-picking downstream. To my surprise, no changes (means we have done a good job of keeping our schemas correct. Also means we need to pull in Environmental metrics downstream, I'll ask IPS to do this.) 

Orginal Commit msg: 

Update the script to point at 2021.2, change the path of the files since
they moved yet again, and run the script.

The directory structure moved back to the way they had it pre-2020.1:
https://github.com/openbmc/bmcweb/commit/a778c0261282b95e14ea3f4406959638b5edb040

Since we have an exclude list, this only brings in new versions of
schemas bmcweb already uses.

Overview of 2021.2:
https://www.dmtf.org/sites/default/files/Redfish_Release_2021.2_Overview.pdf

IBM plans to use Control (for PowerCapping) and IdlePowerSaver
immediately.

Tested: Validator passed after DMTF/Redfish-Service-Validator/pull/423
merged.
CI uses the latest Redfish-Service-Validator so not a problem for CI.
For manual users only a small window where an older validator would
fail. After the schemapack changes but before PR423.

See the new schemas.

Change-Id: I2fe539087167cf6d962c14bf31fa23861302646f
Signed-off-by: Gunnar Mills <gmills@us.ibm.com>