### PR TITLE
Don't edit generated registries

### DIFF
--- a/redfish-core/include/registries/privilege_registry.hpp
+++ b/redfish-core/include/registries/privilege_registry.hpp
@@ -387,10 +387,6 @@ const static auto& postEthernetInterface = privilegeSetConfigureComponents;
 const static auto& putEthernetInterface = privilegeSetConfigureComponents;
 const static auto& deleteEthernetInterface = privilegeSetConfigureComponents;
 
-// Restrict the hypervisor ethernet interface PATCH to ConfigureManager
-const static auto& patchOEMHypervisorEthInterface =
-    privilegeSetConfigureManager;
-
 // Subordinate override for Manager -> EthernetInterface
 const static auto& patchEthernetInterfaceSubOverManager =
     privilegeSetConfigureManager;

--- a/redfish-core/lib/hypervisor_system.hpp
+++ b/redfish-core/lib/hypervisor_system.hpp
@@ -1050,9 +1050,10 @@ inline void requestRoutesHypervisorSystems(App& app)
                 });
         });
 
+    // Restrict the hypervisor ethernet interface PATCH to ConfigureManager
     BMCWEB_ROUTE(app,
                  "/redfish/v1/Systems/hypervisor/EthernetInterfaces/<str>/")
-        .privileges(redfish::privileges::patchOEMHypervisorEthInterface)
+        .privileges({{"ConfigureManager"}})
         .methods(
             boost::beast::http::verb::
                 patch)([](const crow::Request& req,


### PR DESCRIPTION
As Teeks and I learned, if you run the parse registries script
downstream the outputted files don't match. This is becuase in
downstream we have a patch that edits the priviledge registry.

At the top of the file:
"// privilege_registry.hpp is generated.  Do not edit directly"

Respect that.

Downstream only since the following commit is downstream only:
https://github.com/ibm-openbmc/bmcweb/commit/cb2fecf012c7f20fa93b16bc799eb1a70f3c003b#diff-36d772115a7d28a9c1bbe1c848e05d4570875f056b876cec47513927088437f5

Tested: It builds. No Other testing.
Signed-off-by: Gunnar Mills <gmills@us.ibm.com>