### PR TITLE
Added Hypervisor Serial Socket

### DIFF
--- a/include/obmc_console.hpp
+++ b/include/obmc_console.hpp
@@ -153,5 +153,45 @@ inline void requestRoutes(App& app)
             doWrite();
         });
 }
+
+inline void requestRoutesHypervisor(App& app)
+{
+    BMCWEB_ROUTE(app, "/console1")
+        .privileges({{"ConfigureComponents", "ConfigureManager"}})
+        .websocket()
+        .onopen([](crow::websocket::Connection& conn,
+                   const std::shared_ptr<bmcweb::AsyncResp>&) {
+            BMCWEB_LOG_DEBUG << "Connection " << &conn << " opened";
+
+            sessions.insert(&conn);
+            if (hostSocket == nullptr)
+            {
+                const std::string consoleName("\0obmc-console.hypervisor", 24);
+                boost::asio::local::stream_protocol::endpoint ep(consoleName);
+
+                hostSocket = std::make_unique<
+                    boost::asio::local::stream_protocol::socket>(
+                    conn.getIoContext());
+                hostSocket->async_connect(ep, connectHandler);
+            }
+        })
+        .onclose([](crow::websocket::Connection& conn,
+                    [[maybe_unused]] const std::string& reason) {
+            BMCWEB_LOG_INFO << "Closing websocket. Reason: " << reason;
+
+            sessions.erase(&conn);
+            if (sessions.empty())
+            {
+                hostSocket = nullptr;
+                inputBuffer.clear();
+                inputBuffer.shrink_to_fit();
+            }
+        })
+        .onmessage([]([[maybe_unused]] crow::websocket::Connection& conn,
+                      const std::string& data, [[maybe_unused]] bool isBinary) {
+            inputBuffer += data;
+            doWrite();
+        });
+}
 } // namespace obmc_console
 } // namespace crow

--- a/meson.build
+++ b/meson.build
@@ -60,6 +60,7 @@ feature_map = {
 'insecure-disable-csrf'           : '-DBMCWEB_INSECURE_DISABLE_CSRF_PREVENTION',
 'insecure-disable-ssl'            : '-DBMCWEB_INSECURE_DISABLE_SSL',
 'host-serial-socket'              : '-DBMCWEB_ENABLE_HOST_SERIAL_WEBSOCKET',
+'hypervisor-serial-socket'        : '-DBMCWEB_ENABLE_HYPERVISOR_SERIAL_WEBSOCKET',
 'ibm-management-console'          : '-DBMCWEB_ENABLE_IBM_MANAGEMENT_CONSOLE',
 'google-api'                      : '-DBMCWEB_ENABLE_GOOGLE_API',
 'kvm'                             : '-DBMCWEB_ENABLE_KVM' ,

--- a/meson_options.txt
+++ b/meson_options.txt
@@ -15,6 +15,7 @@ option('rest', type : 'feature', value : 'enabled', description : '''Enable Phos
 option('event-subscription', type : 'feature', value : 'enabled', description: 'Enable Event Subscription through websocket')
 option('redfish', type : 'feature',value : 'enabled', description: 'Enable Redfish APIs.  Paths are under \'/redfish/v1/\'. See https://github.com/openbmc/bmcweb/blob/master/DEVELOPING.md#redfish.')
 option('host-serial-socket', type : 'feature', value : 'enabled', description : 'Enable host serial console WebSocket. Path is \'/console0\'.  See https://github.com/openbmc/docs/blob/master/console.md.')
+option('hypervisor-serial-socket', type : 'feature', value : 'disabled', description : 'Enable hypervisor serial console WebSocket. Path is \'/console1\'.')
 option('static-hosting', type : 'feature', value : 'enabled', description : 'Enable serving files from the \'/usr/share/www\' directory as paths under \'/\'.')
 option('redfish-bmc-journal', type : 'feature', value : 'disabled', description : 'Enable BMC journal access through Redfish. Paths are under \'/redfish/v1/Managers/bmc/LogServices/Journal\'.')
 option('redfish-cpu-log', type : 'feature', value : 'disabled', description : '''Enable CPU log service transactions through Redfish. Paths are under \'/redfish/v1/Systems/system/LogServices/Crashdump'.''')

--- a/src/webserver_main.cpp
+++ b/src/webserver_main.cpp
@@ -106,6 +106,10 @@ int main(int /*argc*/, char** /*argv*/)
     crow::obmc_console::requestRoutes(app);
 #endif
 
+#ifdef BMCWEB_ENABLE_HYPERVISOR_SERIAL_WEBSOCKET
+    crow::obmc_console::requestRoutesHypervisor(app);
+#endif
+
 #ifdef BMCWEB_ENABLE_VM_WEBSOCKET
     crow::obmc_vm::requestRoutes(app);
 #endif


### PR DESCRIPTION
This commit adds `wss://${window.location.host}/console1` WebSocket
into bmcweb. it retrieves 'PHYP debug shell' info and displays
WebSocket data into WebUI using SOL (Serial over LAN) console.

'console1' read data from UNIX domain socket '@obmc-console.hypervisor'
and display it in WebUI.

Privilege set to {"ConfigureComponents", "ConfigureManager"}.
That mean only Administrator and Operator can retrieve console data.

Tested:
  configure UNIX domain socket '@obmc-console.hypervisor' with
  'wss://${window.location.host}/console0' (which currently use for
  retrieve 'host serial console data on SOL'). The test is successful,
  able to receive 'PHYP debug shell' data in SOL on WebUI.

Signed-off-by: Abhishek Patel <Abhishek.Patel@ibm.com>
Change-Id: Icece6ceddd0eeab8db7ebf1e5e863c22a59ae45f