### PR TITLE
Add redfish support for SBE dumps

### DIFF
--- a/include/event_dbus_monitor.hpp
+++ b/include/event_dbus_monitor.hpp
@@ -427,6 +427,12 @@ inline void dumpCreatedSignal(sdbusplus::message::message& msg)
                           "Hardware_" +
                           dumpId;
         }
+        else if (dumpType == "sbe")
+        {
+            eventOrigin = "/redfish/v1/Systems/system/LogServices/Dump/Entries/"
+                          "SBE_" +
+                          dumpId;
+        }
         else
         {
             BMCWEB_LOG_ERROR << "Invalid dump type received when listening for "
@@ -489,6 +495,11 @@ inline void dumpDeletedSignal(sdbusplus::message::message& msg)
         eventOrigin =
             "/redfish/v1/Systems/system/LogServices/Dump/Entries/Hardware_" +
             dumpId;
+    }
+    else if (dumpType == "sbe")
+    {
+        eventOrigin =
+            "/redfish/v1/Systems/system/LogServices/Dump/Entries/SBE_" + dumpId;
     }
     else
     {

--- a/redfish-core/lib/log_services.hpp
+++ b/redfish-core/lib/log_services.hpp
@@ -441,7 +441,8 @@ inline void
         dumpPath = "/redfish/v1/Managers/bmc/LogServices/Dump/Entries/";
     }
     else if (dumpType == "System" || dumpType == "Resource" ||
-             dumpType == "Hostboot" || dumpType == "Hardware")
+             dumpType == "Hostboot" || dumpType == "Hardware" ||
+             dumpType == "SBE")
     {
         dumpPath = "/redfish/v1/Systems/system/LogServices/Dump/Entries/";
     }
@@ -582,7 +583,8 @@ inline void
                         entryID + "/attachment";
                 }
                 else if (dumpType == "System" || dumpType == "Resource" ||
-                         dumpType == "Hostboot" || dumpType == "Hardware")
+                         dumpType == "Hostboot" || dumpType == "Hardware" ||
+                         dumpType == "SBE")
                 {
                     std::string dumpEntryId(dumpType + "_");
                     dumpEntryId.append(entryID);
@@ -615,7 +617,8 @@ inline void
         dumpId = entryID;
     }
     else if (dumpType == "System" || dumpType == "Resource" ||
-             dumpType == "Hostboot" || dumpType == "Hardware")
+             dumpType == "Hostboot" || dumpType == "Hardware" ||
+             dumpType == "SBE")
     {
         dumpPath = "/redfish/v1/Systems/system/LogServices/Dump/Entries/";
         std::size_t pos = entryID.find_first_of('_');
@@ -751,7 +754,8 @@ inline void
                         entryID + "/attachment";
                 }
                 else if (dumpType == "System" || dumpType == "Resource" ||
-                         dumpType == "Hostboot" || dumpType == "Hardware")
+                         dumpType == "Hostboot" || dumpType == "Hardware" ||
+                         dumpType == "SBE")
                 {
                     std::string dumpAttachment(
                         "/redfish/v1/Systems/system/LogServices/Dump/Entries/");
@@ -1028,7 +1032,7 @@ inline void clearDump(const std::shared_ptr<bmcweb::AsyncResp>& asyncResp,
 {
     std::string dumpInterface;
     if (dumpType == "Resource" || dumpType == "Hostboot" ||
-        dumpType == "Hardware")
+        dumpType == "Hardware" || dumpType == "SBE")
     {
         dumpInterface = "com.ibm.Dump.Entry." + dumpType;
     }
@@ -2911,23 +2915,25 @@ inline void requestRoutesSystemDumpEntryCollection(App& app)
      */
     BMCWEB_ROUTE(app, "/redfish/v1/Systems/system/LogServices/Dump/Entries/")
         .privileges(redfish::privileges::getLogEntryCollection)
-        .methods(boost::beast::http::verb::get)(
-            [](const crow::Request&,
-               const std::shared_ptr<bmcweb::AsyncResp>& asyncResp) {
-                asyncResp->res.jsonValue["@odata.type"] =
-                    "#LogEntryCollection.LogEntryCollection";
-                asyncResp->res.jsonValue["@odata.id"] =
-                    "/redfish/v1/Systems/system/LogServices/Dump/Entries";
-                asyncResp->res.jsonValue["Name"] = "System Dump Entries";
-                asyncResp->res.jsonValue["Description"] =
-                    "Collection of System, Resource, Hostboot & Hardware Dump "
-                    "Entries";
+        .methods(
+            boost::beast::http::verb::
+                get)([](const crow::Request&,
+                        const std::shared_ptr<bmcweb::AsyncResp>& asyncResp) {
+            asyncResp->res.jsonValue["@odata.type"] =
+                "#LogEntryCollection.LogEntryCollection";
+            asyncResp->res.jsonValue["@odata.id"] =
+                "/redfish/v1/Systems/system/LogServices/Dump/Entries";
+            asyncResp->res.jsonValue["Name"] = "System Dump Entries";
+            asyncResp->res.jsonValue["Description"] =
+                "Collection of System, Resource, Hostboot, Hardware & SBE Dump "
+                "Entries";
 
-                getDumpEntryCollection(asyncResp, "System");
-                getDumpEntryCollection(asyncResp, "Resource");
-                getDumpEntryCollection(asyncResp, "Hostboot");
-                getDumpEntryCollection(asyncResp, "Hardware");
-            });
+            getDumpEntryCollection(asyncResp, "System");
+            getDumpEntryCollection(asyncResp, "Resource");
+            getDumpEntryCollection(asyncResp, "Hostboot");
+            getDumpEntryCollection(asyncResp, "Hardware");
+            getDumpEntryCollection(asyncResp, "SBE");
+        });
 }
 
 inline void requestRoutesSystemDumpEntry(App& app)
@@ -2955,6 +2961,10 @@ inline void requestRoutesSystemDumpEntry(App& app)
                 else if (boost::starts_with(param, "Hardware"))
                 {
                     getDumpEntryById(asyncResp, param, "Hardware");
+                }
+                else if (boost::starts_with(param, "SBE"))
+                {
+                    getDumpEntryById(asyncResp, param, "SBE");
                 }
                 else
                 {
@@ -2995,6 +3005,10 @@ inline void requestRoutesSystemDumpEntry(App& app)
                 {
                     deleteDumpEntry(asyncResp, dumpId, "hardware");
                 }
+                else if (boost::starts_with(param, "SBE"))
+                {
+                    deleteDumpEntry(asyncResp, dumpId, "SBE");
+                }
                 else
                 {
                     messages::invalidObject(asyncResp->res, "Dump Id");
@@ -3031,6 +3045,7 @@ inline void requestRoutesSystemDumpClear(App& app)
                 clearDump(asyncResp, "Resource");
                 clearDump(asyncResp, "Hostboot");
                 clearDump(asyncResp, "Hardware");
+                clearDump(asyncResp, "SBE");
             });
 }
 


### PR DESCRIPTION
Tested By:

Listing of an SBE dump:
** curl -k -H "X-Auth-Token: $bmc_token" -X GET https://${bmc}/redfish/v1/Systems/system/LogServices/Dump/Entries/SBE_7
{
"@odata.id": "/redfish/v1/Systems/system/LogServices/Dump/Entries/SBE_7",
"@odata.type": "#LogEntry.v1_7_0.LogEntry",
"AdditionalDataSizeBytes": 283079,
"AdditionalDataURI": "/redfish/v1/Systems/system/LogServices/Dump/Entries/SBE_7/attachment",
"Created": "2021-10-05T03:43:59+00:00",
"DiagnosticDataType": "OEM",
"EntryType": "Event",
"Id": "SBE_7",
"Name": "System Dump Entry",
"OEMDiagnosticDataType": "SBE"
}

Deletion of an SBE dump:
** curl -k -H "X-Auth-Token: $bmc_token" -X DELETE https://${bmc}/redfish/v1/Systems/system/LogServices/Dump/Entries/SBE_5

Clear all host dumps:
** curl -k -H "X-Auth-Token: $bmc_token" -X POST https://${bmc}/redfish/v1/Managers/bmc/LogServices/Dump/Actions/LogService.ClearLog

The upstream for this is at:
https://gerrit.openbmc-project.xyz/c/openbmc/bmcweb/+/46823/