### PR TITLE
Initial Telemetry Service Framework

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -368,6 +368,8 @@ srcfiles_unittest = ['include/ut/dbus_utility_test.cpp',
                      'redfish-core/ut/time_utils_test.cpp',
                      'http/ut/utility_test.cpp']
 
+srcfiles_unittest_dependencies = ['redfish-core/src/error_messages.cpp']
+
 # Gather the Configuration data
 
 conf_data = configuration_data()
@@ -425,7 +427,7 @@ executable('bmcweb',srcfiles_bmcweb,
 if(get_option('tests').enabled())
   foreach src_test : srcfiles_unittest
     testname = src_test.split('/')[-1].split('.')[0]
-    test(testname,executable(testname,src_test,
+    test(testname,executable(testname,[src_test] + srcfiles_unittest_dependencies,
                 include_directories : incdir,
                 install_dir: bindir,
                 dependencies: [

--- a/redfish-core/include/event_service_manager.hpp
+++ b/redfish-core/include/event_service_manager.hpp
@@ -14,6 +14,7 @@
 // limitations under the License.
 */
 #pragma once
+#include "metric_report.hpp"
 #include "registries.hpp"
 #include "registries/base_message_registry.hpp"
 #include "registries/openbmc_message_registry.hpp"
@@ -511,46 +512,31 @@ class Subscription : public persistent_data::UserSubscription
     }
 #endif
 
-    void filterAndSendReports(const std::string& id2,
-                              const std::string& readingsTs,
-                              const ReadingsObjType& readings)
+    void filterAndSendReports(
+        const std::string& id,
+        const std::variant<telemetry::TimestampReadings>& var)
     {
-        std::string metricReportDef =
-            "/redfish/v1/TelemetryService/MetricReportDefinitions/" + id2;
+        std::string mrdUri = telemetry::metricReportDefinitionUri + id;
 
         // Empty list means no filter. Send everything.
         if (metricReportDefinitions.size())
         {
             if (std::find(metricReportDefinitions.begin(),
                           metricReportDefinitions.end(),
-                          metricReportDef) == metricReportDefinitions.end())
+                          mrdUri) == metricReportDefinitions.end())
             {
                 return;
             }
         }
 
-        nlohmann::json metricValuesArray = nlohmann::json::array();
-        for (const auto& it : readings)
+        nlohmann::json msg;
+        if (!telemetry::fillReport(msg, id, var))
         {
-            metricValuesArray.push_back({});
-            nlohmann::json& entry = metricValuesArray.back();
-
-            auto& [id, property, value, timestamp] = it;
-
-            entry = {{"MetricId", id},
-                     {"MetricProperty", property},
-                     {"MetricValue", std::to_string(value)},
-                     {"Timestamp", crow::utility::getDateTime(timestamp)}};
+            BMCWEB_LOG_ERROR << "Failed to fill the MetricReport for DBus "
+                                "Report with id "
+                             << id;
+            return;
         }
-
-        nlohmann::json msg = {
-            {"@odata.id", "/redfish/v1/TelemetryService/MetricReports/" + id},
-            {"@odata.type", "#MetricReport.v1_3_0.MetricReport"},
-            {"Id", id2},
-            {"Name", id2},
-            {"Timestamp", readingsTs},
-            {"MetricReportDefinition", {{"@odata.id", metricReportDef}}},
-            {"MetricValues", metricValuesArray}};
 
         this->sendEvent(
             msg.dump(2, ' ', true, nlohmann::json::error_handler_t::replace));
@@ -1322,75 +1308,6 @@ class EventServiceManager
     }
 
 #endif
-
-    void getMetricReading(const std::string& service,
-                          const std::string& objPath, const std::string& intf)
-    {
-        std::size_t found = objPath.find_last_of('/');
-        if (found == std::string::npos)
-        {
-            BMCWEB_LOG_DEBUG << "Invalid objPath received";
-            return;
-        }
-
-        std::string idStr = objPath.substr(found + 1);
-        if (idStr.empty())
-        {
-            BMCWEB_LOG_DEBUG << "Invalid ID in objPath";
-            return;
-        }
-
-        crow::connections::systemBus->async_method_call(
-            [idStr{std::move(idStr)}](
-                const boost::system::error_code ec,
-                boost::container::flat_map<
-                    std::string, std::variant<int32_t, ReadingsObjType>>&
-                    resp) {
-                if (ec)
-                {
-                    BMCWEB_LOG_DEBUG
-                        << "D-Bus call failed to GetAll metric readings.";
-                    return;
-                }
-
-                const int32_t* timestampPtr =
-                    std::get_if<int32_t>(&resp["Timestamp"]);
-                if (!timestampPtr)
-                {
-                    BMCWEB_LOG_DEBUG << "Failed to Get timestamp.";
-                    return;
-                }
-
-                ReadingsObjType* readingsPtr =
-                    std::get_if<ReadingsObjType>(&resp["Readings"]);
-                if (!readingsPtr)
-                {
-                    BMCWEB_LOG_DEBUG << "Failed to Get Readings property.";
-                    return;
-                }
-
-                if (!readingsPtr->size())
-                {
-                    BMCWEB_LOG_DEBUG << "No metrics report to be transferred";
-                    return;
-                }
-
-                for (const auto& it :
-                     EventServiceManager::getInstance().subscriptionsMap)
-                {
-                    std::shared_ptr<Subscription> entry = it.second;
-                    if (entry->eventFormatType == metricReportFormatType)
-                    {
-                        entry->filterAndSendReports(
-                            idStr, crow::utility::getDateTime(*timestampPtr),
-                            *readingsPtr);
-                    }
-                }
-            },
-            service, objPath, "org.freedesktop.DBus.Properties", "GetAll",
-            intf);
-    }
-
     void unregisterMetricReportSignal()
     {
         if (matchTelemetryMonitor)
@@ -1410,9 +1327,11 @@ class EventServiceManager
         }
 
         BMCWEB_LOG_DEBUG << "Metrics report signal - Register";
-        std::string matchStr(
-            "type='signal',member='ReportUpdate', "
-            "interface='xyz.openbmc_project.MonitoringService.Report'");
+        std::string matchStr = "type='signal',member='PropertiesChanged',"
+                               "interface='org.freedesktop.DBus.Properties',"
+                               "path_namespace=/xyz/openbmc_project/Telemetry/"
+                               "Reports/TelemetryService,"
+                               "arg0=xyz.openbmc_project.Telemetry.Report";
 
         matchTelemetryMonitor = std::make_shared<sdbusplus::bus::match::match>(
             *crow::connections::systemBus, matchStr,
@@ -1423,10 +1342,43 @@ class EventServiceManager
                     return;
                 }
 
-                std::string service = msg.get_sender();
-                std::string objPath = msg.get_path();
-                std::string intf = msg.get_interface();
-                getMetricReading(service, objPath, intf);
+                sdbusplus::message::object_path path(msg.get_path());
+                std::string id = path.filename();
+                if (id.empty())
+                {
+                    BMCWEB_LOG_ERROR << "Failed to get Id from path";
+                    return;
+                }
+
+                std::string intf;
+                std::vector<std::pair<
+                    std::string, std::variant<telemetry::TimestampReadings>>>
+                    props;
+                std::vector<std::string> invalidProps;
+                msg.read(intf, props, invalidProps);
+
+                auto found =
+                    std::find_if(props.begin(), props.end(), [](const auto& x) {
+                        return x.first == "Readings";
+                    });
+                if (found == props.end())
+                {
+                    BMCWEB_LOG_INFO
+                        << "Failed to get Readings from Report properties";
+                    return;
+                }
+
+                const std::variant<telemetry::TimestampReadings>& readings =
+                    found->second;
+                for (const auto& it :
+                     EventServiceManager::getInstance().subscriptionsMap)
+                {
+                    Subscription& entry = *it.second.get();
+                    if (entry.eventFormatType == metricReportFormatType)
+                    {
+                        entry.filterAndSendReports(id, readings);
+                    }
+                }
             });
     }
 

--- a/redfish-core/include/utils/telemetry_utils.hpp
+++ b/redfish-core/include/utils/telemetry_utils.hpp
@@ -10,10 +10,52 @@ namespace telemetry
 
 constexpr const char* service = "xyz.openbmc_project.Telemetry";
 constexpr const char* reportInterface = "xyz.openbmc_project.Telemetry.Report";
+constexpr const char* metricDefinitionUri =
+    "/redfish/v1/TelemetryService/MetricDefinitions/";
 constexpr const char* metricReportDefinitionUri =
     "/redfish/v1/TelemetryService/MetricReportDefinitions/";
 constexpr const char* metricReportUri =
     "/redfish/v1/TelemetryService/MetricReports/";
+
+inline std::optional<nlohmann::json>
+    getMetadataJson(const std::string& metadataStr)
+{
+    std::optional<nlohmann::json> res =
+        nlohmann::json::parse(metadataStr, nullptr, false);
+    if (res->is_discarded())
+    {
+        BMCWEB_LOG_ERROR << "Malformed reading metatadata JSON provided by "
+                            "telemetry service.";
+        return std::nullopt;
+    }
+    return res;
+}
+
+inline std::optional<std::string>
+    readStringFromMetadata(const nlohmann::json& metadataJson, const char* key)
+{
+    std::optional<std::string> res;
+    if (auto it = metadataJson.find(key); it != metadataJson.end())
+    {
+        if (const std::string* value = it->get_ptr<const std::string*>())
+        {
+            res = *value;
+        }
+        else
+        {
+            BMCWEB_LOG_ERROR << "Incorrect reading metatadata JSON provided by "
+                                "telemetry service. Missing key '"
+                             << key << "'.";
+        }
+    }
+    else
+    {
+        BMCWEB_LOG_ERROR << "Incorrect reading metatadata JSON provided by "
+                            "telemetry service. Key '"
+                         << key << "' has a wrong type.";
+    }
+    return res;
+}
 
 inline void
     getReportCollection(const std::shared_ptr<bmcweb::AsyncResp>& asyncResp,

--- a/redfish-core/lib/metric_report.hpp
+++ b/redfish-core/lib/metric_report.hpp
@@ -1,5 +1,6 @@
 #pragma once
 
+#include "sensors.hpp"
 #include "utils/telemetry_utils.hpp"
 
 #include <app.hpp>
@@ -15,34 +16,56 @@ using Readings =
     std::vector<std::tuple<std::string, std::string, double, uint64_t>>;
 using TimestampReadings = std::tuple<uint64_t, Readings>;
 
-inline nlohmann::json toMetricValues(const Readings& readings)
+inline bool fillMetricValues(nlohmann::json& metricValues,
+                             const Readings& readings)
 {
-    nlohmann::json metricValues = nlohmann::json::array_t();
-
-    for (auto& [id, metadata, sensorValue, timestamp] : readings)
+    for (auto& [id, metadataStr, sensorValue, timestamp] : readings)
     {
+        std::optional<nlohmann::json> readingMetadataJson =
+            getMetadataJson(metadataStr);
+        if (!readingMetadataJson)
+        {
+            return false;
+        }
+
+        std::optional<std::string> sensorDbusPath =
+            readStringFromMetadata(*readingMetadataJson, "SensorDbusPath");
+        if (!sensorDbusPath)
+        {
+            return false;
+        }
+
+        std::optional<std::string> sensorRedfishUri =
+            readStringFromMetadata(*readingMetadataJson, "SensorRedfishUri");
+        if (!sensorRedfishUri)
+        {
+            return false;
+        }
+
+        std::string metricDefinition =
+            std::string(metricDefinitionUri) +
+            sensors::toReadingType(
+                sdbusplus::message::object_path(*sensorDbusPath)
+                    .parent_path()
+                    .filename());
+
         metricValues.push_back({
+            {"MetricDefinition",
+             nlohmann::json{{"@odata.id", metricDefinition}}},
             {"MetricId", id},
-            {"MetricProperty", metadata},
+            {"MetricProperty", *sensorRedfishUri},
             {"MetricValue", std::to_string(sensorValue)},
             {"Timestamp",
              crow::utility::getDateTime(static_cast<time_t>(timestamp))},
         });
     }
 
-    return metricValues;
+    return true;
 }
 
 inline bool fillReport(nlohmann::json& json, const std::string& id,
                        const std::variant<TimestampReadings>& var)
 {
-    json["@odata.type"] = "#MetricReport.v1_3_0.MetricReport";
-    json["@odata.id"] = telemetry::metricReportUri + id;
-    json["Id"] = id;
-    json["Name"] = id;
-    json["MetricReportDefinition"]["@odata.id"] =
-        telemetry::metricReportDefinitionUri + id;
-
     const TimestampReadings* timestampReadings =
         std::get_if<TimestampReadings>(&var);
     if (!timestampReadings)
@@ -52,9 +75,22 @@ inline bool fillReport(nlohmann::json& json, const std::string& id,
     }
 
     const auto& [timestamp, readings] = *timestampReadings;
+    nlohmann::json metricValues = nlohmann::json::array();
+    if (!fillMetricValues(metricValues, readings))
+    {
+        return false;
+    }
+
+    json["@odata.type"] = "#MetricReport.v1_3_0.MetricReport";
+    json["@odata.id"] = telemetry::metricReportUri + id;
+    json["Id"] = id;
+    json["Name"] = id;
+    json["MetricReportDefinition"]["@odata.id"] =
+        telemetry::metricReportDefinitionUri + id;
     json["Timestamp"] =
         crow::utility::getDateTime(static_cast<time_t>(timestamp));
-    json["MetricValues"] = toMetricValues(readings);
+    json["MetricValues"] = metricValues;
+
     return true;
 }
 } // namespace telemetry

--- a/redfish-core/lib/metric_report.hpp
+++ b/redfish-core/lib/metric_report.hpp
@@ -33,16 +33,14 @@ inline nlohmann::json toMetricValues(const Readings& readings)
     return metricValues;
 }
 
-inline void fillReport(const std::shared_ptr<bmcweb::AsyncResp>& asyncResp,
-                       const std::string& id,
+inline bool fillReport(nlohmann::json& json, const std::string& id,
                        const std::variant<TimestampReadings>& var)
 {
-    asyncResp->res.jsonValue["@odata.type"] =
-        "#MetricReport.v1_3_0.MetricReport";
-    asyncResp->res.jsonValue["@odata.id"] = telemetry::metricReportUri + id;
-    asyncResp->res.jsonValue["Id"] = id;
-    asyncResp->res.jsonValue["Name"] = id;
-    asyncResp->res.jsonValue["MetricReportDefinition"]["@odata.id"] =
+    json["@odata.type"] = "#MetricReport.v1_3_0.MetricReport";
+    json["@odata.id"] = telemetry::metricReportUri + id;
+    json["Id"] = id;
+    json["Name"] = id;
+    json["MetricReportDefinition"]["@odata.id"] =
         telemetry::metricReportDefinitionUri + id;
 
     const TimestampReadings* timestampReadings =
@@ -50,14 +48,14 @@ inline void fillReport(const std::shared_ptr<bmcweb::AsyncResp>& asyncResp,
     if (!timestampReadings)
     {
         BMCWEB_LOG_ERROR << "Property type mismatch or property is missing";
-        messages::internalError(asyncResp->res);
-        return;
+        return false;
     }
 
     const auto& [timestamp, readings] = *timestampReadings;
-    asyncResp->res.jsonValue["Timestamp"] =
+    json["Timestamp"] =
         crow::utility::getDateTime(static_cast<time_t>(timestamp));
-    asyncResp->res.jsonValue["MetricValues"] = toMetricValues(readings);
+    json["MetricValues"] = toMetricValues(readings);
+    return true;
 }
 } // namespace telemetry
 
@@ -118,7 +116,11 @@ inline void requestRoutesMetricReport(App& app)
                                     return;
                                 }
 
-                                telemetry::fillReport(asyncResp, id, ret);
+                                if (!telemetry::fillReport(
+                                        asyncResp->res.jsonValue, id, ret))
+                                {
+                                    messages::internalError(asyncResp->res);
+                                }
                             },
                             telemetry::service, reportPath,
                             "org.freedesktop.DBus.Properties", "Get",

--- a/redfish-core/lib/metric_report_definition.hpp
+++ b/redfish-core/lib/metric_report_definition.hpp
@@ -7,6 +7,8 @@
 #include <app.hpp>
 #include <boost/container/flat_map.hpp>
 #include <registries/privilege_registry.hpp>
+#include <sdbusplus/asio/property.hpp>
+#include <sdbusplus/unpack_properties.hpp>
 
 #include <tuple>
 #include <variant>
@@ -17,87 +19,90 @@ namespace redfish
 namespace telemetry
 {
 
-using ReadingParameters =
-    std::vector<std::tuple<sdbusplus::message::object_path, std::string,
-                           std::string, std::string>>;
+using ReadingParameters = std::vector<
+    std::tuple<std::vector<sdbusplus::message::object_path>, std::string,
+               std::string, std::string, std::string, uint64_t>>;
 
 inline void fillReportDefinition(
     const std::shared_ptr<bmcweb::AsyncResp>& asyncResp, const std::string& id,
     const std::vector<
-        std::pair<std::string, std::variant<std::string, bool, uint64_t,
-                                            ReadingParameters>>>& ret)
+        std::pair<std::string, std::variant<std::monostate, std::string, bool,
+                                            uint64_t, ReadingParameters>>>&
+        properties)
 {
-    asyncResp->res.jsonValue["@odata.type"] =
-        "#MetricReportDefinition.v1_3_0.MetricReportDefinition";
-    asyncResp->res.jsonValue["@odata.id"] =
-        telemetry::metricReportDefinitionUri + id;
-    asyncResp->res.jsonValue["Id"] = id;
-    asyncResp->res.jsonValue["Name"] = id;
-    asyncResp->res.jsonValue["MetricReport"]["@odata.id"] =
-        telemetry::metricReportUri + id;
-    asyncResp->res.jsonValue["Status"]["State"] = "Enabled";
-    asyncResp->res.jsonValue["ReportUpdates"] = "Overwrite";
+    try
+    {
+        bool emitsReadingsUpdate = false;
+        bool logToMetricReportsCollection = false;
+        ReadingParameters readingParams;
+        std::string reportingType;
+        uint64_t interval = 0u;
 
-    const bool* emitsReadingsUpdate = nullptr;
-    const bool* logToMetricReportsCollection = nullptr;
-    const ReadingParameters* readingParams = nullptr;
-    const std::string* reportingType = nullptr;
-    const uint64_t* interval = nullptr;
-    for (const auto& [key, var] : ret)
-    {
-        if (key == "EmitsReadingsUpdate")
+        sdbusplus::unpackProperties(
+            properties, "EmitsReadingsUpdate", emitsReadingsUpdate,
+            "LogToMetricReportsCollection", logToMetricReportsCollection,
+            "ReadingParametersFutureVersion", readingParams, "ReportingType",
+            reportingType, "Interval", interval);
+
+        std::vector<std::string> redfishReportActions;
+        redfishReportActions.reserve(2);
+        if (emitsReadingsUpdate)
         {
-            emitsReadingsUpdate = std::get_if<bool>(&var);
+            redfishReportActions.emplace_back("RedfishEvent");
         }
-        else if (key == "LogToMetricReportsCollection")
+        if (logToMetricReportsCollection)
         {
-            logToMetricReportsCollection = std::get_if<bool>(&var);
+            redfishReportActions.emplace_back("LogToMetricReportsCollection");
         }
-        else if (key == "ReadingParameters")
+
+        nlohmann::json metrics = nlohmann::json::array();
+        for (auto& [sensorPath, operationType, id, metadata,
+                    collectionTimeScope, collectionDuration] : readingParams)
         {
-            readingParams = std::get_if<ReadingParameters>(&var);
+            std::vector<std::string> metricProperties;
+
+            nlohmann::json parsedMetadata = nlohmann::json::parse(metadata);
+            if (!json_util::readJson(parsedMetadata, asyncResp->res,
+                                     "MetricProperties", metricProperties))
+            {
+                BMCWEB_LOG_ERROR << "Failed to read metadata";
+                messages::internalError(asyncResp->res);
+                return;
+            }
+
+            metrics.push_back({
+                {"MetricId", id},
+                {"MetricProperties", std::move(metricProperties)},
+            });
         }
-        else if (key == "ReportingType")
-        {
-            reportingType = std::get_if<std::string>(&var);
-        }
-        else if (key == "Interval")
-        {
-            interval = std::get_if<uint64_t>(&var);
-        }
+
+        asyncResp->res.jsonValue["@odata.type"] =
+            "#MetricReportDefinition.v1_3_0.MetricReportDefinition";
+        asyncResp->res.jsonValue["@odata.id"] =
+            telemetry::metricReportDefinitionUri + id;
+        asyncResp->res.jsonValue["Id"] = id;
+        asyncResp->res.jsonValue["Name"] = id;
+        asyncResp->res.jsonValue["MetricReport"]["@odata.id"] =
+            telemetry::metricReportUri + id;
+        asyncResp->res.jsonValue["Status"]["State"] = "Enabled";
+        asyncResp->res.jsonValue["ReportUpdates"] = "Overwrite";
+        asyncResp->res.jsonValue["Metrics"] = metrics;
+        asyncResp->res.jsonValue["MetricReportDefinitionType"] = reportingType;
+        asyncResp->res.jsonValue["ReportActions"] = redfishReportActions;
+        asyncResp->res.jsonValue["Schedule"]["RecurrenceInterval"] =
+            time_utils::toDurationString(std::chrono::milliseconds(interval));
     }
-    if (!emitsReadingsUpdate || !logToMetricReportsCollection ||
-        !readingParams || !reportingType || !interval)
+    catch (const sdbusplus::exception::UnpackPropertyError& error)
     {
-        BMCWEB_LOG_ERROR << "Property type mismatch or property is missing";
+        BMCWEB_LOG_ERROR << error.what() << ", property: "
+                         << error.propertyName + ", reason: " << error.reason;
         messages::internalError(asyncResp->res);
-        return;
     }
-
-    std::vector<std::string> redfishReportActions;
-    redfishReportActions.reserve(2);
-    if (*emitsReadingsUpdate)
+    catch (const nlohmann::json::parse_error& e)
     {
-        redfishReportActions.emplace_back("RedfishEvent");
+        BMCWEB_LOG_ERROR << "Failed to parse metadata: " << e.what();
+        messages::internalError(asyncResp->res);
     }
-    if (*logToMetricReportsCollection)
-    {
-        redfishReportActions.emplace_back("LogToMetricReportsCollection");
-    }
-
-    nlohmann::json metrics = nlohmann::json::array();
-    for (auto& [sensorPath, operationType, id, metadata] : *readingParams)
-    {
-        metrics.push_back({
-            {"MetricId", id},
-            {"MetricProperties", {metadata}},
-        });
-    }
-    asyncResp->res.jsonValue["Metrics"] = metrics;
-    asyncResp->res.jsonValue["MetricReportDefinitionType"] = *reportingType;
-    asyncResp->res.jsonValue["ReportActions"] = redfishReportActions;
-    asyncResp->res.jsonValue["Schedule"]["RecurrenceInterval"] =
-        time_utils::toDurationString(std::chrono::milliseconds(*interval));
 }
 
 struct AddReportArgs
@@ -275,6 +280,11 @@ class AddReport
 
         for (const auto& [id, uris] : args.metrics)
         {
+            std::vector<sdbusplus::message::object_path> dbusPaths;
+            dbusPaths.reserve(uris.size());
+            nlohmann::json metadata;
+            metadata["MetricProperties"] = nlohmann::json::array();
+
             for (size_t i = 0; i < uris.size(); i++)
             {
                 const std::string& uri = uris[i];
@@ -291,8 +301,12 @@ class AddReport
                 }
 
                 const std::string& dbusPath = el->second;
-                readingParams.emplace_back(dbusPath, "SINGLE", id, uri);
+                dbusPaths.emplace_back(dbusPath);
+                metadata["MetricProperties"].emplace_back(uri);
             }
+
+            readingParams.emplace_back(dbusPaths, "SINGLE", id, metadata.dump(),
+                                       "Point", 0u);
         }
         const std::shared_ptr<bmcweb::AsyncResp> aResp = asyncResp;
         crow::connections::systemBus->async_method_call(
@@ -330,10 +344,10 @@ class AddReport
                 messages::created(aResp->res);
             },
             telemetry::service, "/xyz/openbmc_project/Telemetry/Reports",
-            "xyz.openbmc_project.Telemetry.ReportManager", "AddReport",
-            "TelemetryService/" + args.name, args.reportingType,
-            args.emitsReadingsUpdate, args.logToMetricReportsCollection,
-            args.interval, readingParams);
+            "xyz.openbmc_project.Telemetry.ReportManager",
+            "AddReportFutureVersion", "TelemetryService/" + args.name,
+            args.reportingType, args.emitsReadingsUpdate,
+            args.logToMetricReportsCollection, args.interval, readingParams);
     }
 
     void insert(const boost::container::flat_map<std::string, std::string>& el)
@@ -415,37 +429,39 @@ inline void requestRoutesMetricReportDefinition(App& app)
     BMCWEB_ROUTE(app,
                  "/redfish/v1/TelemetryService/MetricReportDefinitions/<str>/")
         .privileges(redfish::privileges::getMetricReportDefinition)
-        .methods(boost::beast::http::verb::get)(
-            [](const crow::Request&,
-               const std::shared_ptr<bmcweb::AsyncResp>& asyncResp,
-               const std::string& id) {
-                crow::connections::systemBus->async_method_call(
-                    [asyncResp, id](
-                        const boost::system::error_code ec,
-                        const std::vector<std::pair<
-                            std::string,
-                            std::variant<std::string, bool, uint64_t,
-                                         telemetry::ReadingParameters>>>& ret) {
-                        if (ec.value() == EBADR ||
-                            ec == boost::system::errc::host_unreachable)
-                        {
-                            messages::resourceNotFound(
-                                asyncResp->res, "MetricReportDefinition", id);
-                            return;
-                        }
-                        if (ec)
-                        {
-                            BMCWEB_LOG_ERROR << "respHandler DBus error " << ec;
-                            messages::internalError(asyncResp->res);
-                            return;
-                        }
+        .methods(
+            boost::beast::http::verb::get)([](const crow::Request&,
+                                              const std::shared_ptr<
+                                                  bmcweb::AsyncResp>& asyncResp,
+                                              const std::string& id) {
+            sdbusplus::asio::getAllProperties(
+                *crow::connections::systemBus, telemetry::service,
+                telemetry::getDbusReportPath(id), telemetry::reportInterface,
+                [asyncResp,
+                 id](boost::system::error_code ec,
+                     const std::vector<std::pair<
+                         std::string,
+                         std::variant<std::monostate, std::string, bool,
+                                      uint64_t, telemetry::ReadingParameters>>>&
+                         properties) {
+                    if (ec.value() == EBADR ||
+                        ec == boost::system::errc::host_unreachable)
+                    {
+                        messages::resourceNotFound(
+                            asyncResp->res, "MetricReportDefinition", id);
+                        return;
+                    }
+                    if (ec)
+                    {
+                        BMCWEB_LOG_ERROR << "respHandler DBus error " << ec;
+                        messages::internalError(asyncResp->res);
+                        return;
+                    }
 
-                        telemetry::fillReportDefinition(asyncResp, id, ret);
-                    },
-                    telemetry::service, telemetry::getDbusReportPath(id),
-                    "org.freedesktop.DBus.Properties", "GetAll",
-                    telemetry::reportInterface);
-            });
+                    telemetry::fillReportDefinition(asyncResp, id, properties);
+                });
+        });
+
     BMCWEB_ROUTE(app,
                  "/redfish/v1/TelemetryService/MetricReportDefinitions/<str>/")
         .privileges(redfish::privileges::deleteMetricReportDefinitionCollection)

--- a/redfish-core/lib/metric_report_definition.hpp
+++ b/redfish-core/lib/metric_report_definition.hpp
@@ -23,6 +23,92 @@ using ReadingParameters = std::vector<
     std::tuple<std::vector<sdbusplus::message::object_path>, std::string,
                std::string, std::string, std::string, uint64_t>>;
 
+enum class MethodType
+{
+    get,
+    post
+};
+
+inline std::string getOperationType(std::string_view item, MethodType method)
+{
+    static const std::vector<std::pair<std::string, std::string>> operation = {
+        {"MAX", "Maximum"},
+        {"MIN", "Minimum"},
+        {"AVG", "Average"},
+        {"SUM", "Summation"}};
+
+    for (const auto& [getName, postName] : operation)
+    {
+        if (MethodType::get == method && getName == item)
+        {
+            return postName;
+        }
+        if (MethodType::post == method && postName == item)
+        {
+            return getName;
+        }
+    }
+    return "";
+}
+
+inline bool isTimeScopeValid(std::string_view item)
+{
+    static const std::vector<std::string> scope = {"Point", "Interval",
+                                                   "StartupInterval"};
+    return std::find(scope.begin(), scope.end(), item) != scope.end();
+}
+
+inline std::vector<std::string> getReportActions(bool emitsUpdate,
+                                                 bool logToMetricReports)
+{
+    std::vector<std::string> redfishReportActions;
+    redfishReportActions.reserve(2);
+    if (emitsUpdate)
+    {
+        redfishReportActions.emplace_back("RedfishEvent");
+    }
+    if (logToMetricReports)
+    {
+        redfishReportActions.emplace_back("LogToMetricReportsCollection");
+    }
+
+    return redfishReportActions;
+}
+
+inline std::optional<nlohmann::json>
+    getMetrics(const std::shared_ptr<bmcweb::AsyncResp>& asyncResp,
+               const ReadingParameters& params)
+{
+    nlohmann::json metrics = nlohmann::json::array();
+    for (auto& [sensorPath, operationType, id, metadata, collectionTimeScope,
+                collectionDuration] : params)
+    {
+        std::vector<std::string> metricProperties;
+
+        nlohmann::json parsedMetadata = nlohmann::json::parse(metadata);
+        if (!json_util::readJson(parsedMetadata, asyncResp->res,
+                                 "MetricProperties", metricProperties))
+        {
+            BMCWEB_LOG_ERROR << "Failed to read metadata";
+            messages::internalError(asyncResp->res);
+            return std::nullopt;
+        }
+
+        metrics.push_back({
+            {"MetricId", id},
+            {"MetricProperties", std::move(metricProperties)},
+            {"CollectionFunction",
+             getOperationType(operationType, MethodType::get)},
+            {"CollectionTimeScope", collectionTimeScope},
+            {"CollectionDuration",
+             time_utils::toDurationString(
+                 std::chrono::milliseconds(collectionDuration))},
+        });
+    }
+
+    return metrics;
+}
+
 inline void fillReportDefinition(
     const std::shared_ptr<bmcweb::AsyncResp>& asyncResp, const std::string& id,
     const std::vector<
@@ -44,53 +130,28 @@ inline void fillReportDefinition(
             "ReadingParametersFutureVersion", readingParams, "ReportingType",
             reportingType, "Interval", interval);
 
-        std::vector<std::string> redfishReportActions;
-        redfishReportActions.reserve(2);
-        if (emitsReadingsUpdate)
+        if (std::optional<nlohmann::json> metrics =
+                getMetrics(asyncResp, readingParams))
         {
-            redfishReportActions.emplace_back("RedfishEvent");
+            asyncResp->res.jsonValue["@odata.type"] =
+                "#MetricReportDefinition.v1_4_1.MetricReportDefinition";
+            asyncResp->res.jsonValue["@odata.id"] =
+                metricReportDefinitionUri + id;
+            asyncResp->res.jsonValue["Id"] = id;
+            asyncResp->res.jsonValue["Name"] = id;
+            asyncResp->res.jsonValue["MetricReport"]["@odata.id"] =
+                metricReportUri + id;
+            asyncResp->res.jsonValue["Status"]["State"] = "Enabled";
+            asyncResp->res.jsonValue["ReportUpdates"] = "Overwrite";
+            asyncResp->res.jsonValue["Metrics"] = *metrics;
+            asyncResp->res.jsonValue["MetricReportDefinitionType"] =
+                reportingType;
+            asyncResp->res.jsonValue["ReportActions"] = getReportActions(
+                emitsReadingsUpdate, logToMetricReportsCollection);
+            asyncResp->res.jsonValue["Schedule"]["RecurrenceInterval"] =
+                time_utils::toDurationString(
+                    std::chrono::milliseconds(interval));
         }
-        if (logToMetricReportsCollection)
-        {
-            redfishReportActions.emplace_back("LogToMetricReportsCollection");
-        }
-
-        nlohmann::json metrics = nlohmann::json::array();
-        for (auto& [sensorPath, operationType, id, metadata,
-                    collectionTimeScope, collectionDuration] : readingParams)
-        {
-            std::vector<std::string> metricProperties;
-
-            nlohmann::json parsedMetadata = nlohmann::json::parse(metadata);
-            if (!json_util::readJson(parsedMetadata, asyncResp->res,
-                                     "MetricProperties", metricProperties))
-            {
-                BMCWEB_LOG_ERROR << "Failed to read metadata";
-                messages::internalError(asyncResp->res);
-                return;
-            }
-
-            metrics.push_back({
-                {"MetricId", id},
-                {"MetricProperties", std::move(metricProperties)},
-            });
-        }
-
-        asyncResp->res.jsonValue["@odata.type"] =
-            "#MetricReportDefinition.v1_3_0.MetricReportDefinition";
-        asyncResp->res.jsonValue["@odata.id"] =
-            telemetry::metricReportDefinitionUri + id;
-        asyncResp->res.jsonValue["Id"] = id;
-        asyncResp->res.jsonValue["Name"] = id;
-        asyncResp->res.jsonValue["MetricReport"]["@odata.id"] =
-            telemetry::metricReportUri + id;
-        asyncResp->res.jsonValue["Status"]["State"] = "Enabled";
-        asyncResp->res.jsonValue["ReportUpdates"] = "Overwrite";
-        asyncResp->res.jsonValue["Metrics"] = metrics;
-        asyncResp->res.jsonValue["MetricReportDefinitionType"] = reportingType;
-        asyncResp->res.jsonValue["ReportActions"] = redfishReportActions;
-        asyncResp->res.jsonValue["Schedule"]["RecurrenceInterval"] =
-            time_utils::toDurationString(std::chrono::milliseconds(interval));
     }
     catch (const sdbusplus::exception::UnpackPropertyError& error)
     {
@@ -112,15 +173,34 @@ struct AddReportArgs
     bool emitsReadingsUpdate = false;
     bool logToMetricReportsCollection = false;
     uint64_t interval = 0;
-    std::vector<std::pair<std::string, std::vector<std::string>>> metrics;
+    std::vector<std::tuple<std::string, std::vector<std::string>, std::string,
+                           std::string, uint64_t>>
+        metrics;
 };
 
+inline bool isIdValid(crow::Response& res, const std::string& id)
+{
+    constexpr const char* allowedCharactersInName =
+        "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789_";
+    if (id.empty() ||
+        id.find_first_not_of(allowedCharactersInName) != std::string::npos)
+    {
+        BMCWEB_LOG_ERROR << "Failed to match " << id
+                         << " with allowed character "
+                         << allowedCharactersInName;
+        messages::propertyValueIncorrect(res, "Id", id);
+        return false;
+    }
+
+    return true;
+}
+
 inline bool toDbusReportActions(crow::Response& res,
-                                std::vector<std::string>& actions,
+                                const std::vector<std::string>& actions,
                                 AddReportArgs& args)
 {
     size_t index = 0;
-    for (auto& action : actions)
+    for (const auto& action : actions)
     {
         if (action == "RedfishEvent")
         {
@@ -141,41 +221,14 @@ inline bool toDbusReportActions(crow::Response& res,
     return true;
 }
 
-inline bool getUserParameters(crow::Response& res, const crow::Request& req,
-                              AddReportArgs& args)
+inline bool toDbusReportingType(crow::Response& res,
+                                std::optional<nlohmann::json>& schedule,
+                                AddReportArgs& args)
 {
-    std::vector<nlohmann::json> metrics;
-    std::vector<std::string> reportActions;
-    std::optional<nlohmann::json> schedule;
-    if (!json_util::readJson(req, res, "Id", args.name, "Metrics", metrics,
-                             "MetricReportDefinitionType", args.reportingType,
-                             "ReportActions", reportActions, "Schedule",
-                             schedule))
-    {
-        return false;
-    }
-
-    constexpr const char* allowedCharactersInName =
-        "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789_";
-    if (args.name.empty() || args.name.find_first_not_of(
-                                 allowedCharactersInName) != std::string::npos)
-    {
-        BMCWEB_LOG_ERROR << "Failed to match " << args.name
-                         << " with allowed character "
-                         << allowedCharactersInName;
-        messages::propertyValueIncorrect(res, "Id", args.name);
-        return false;
-    }
-
     if (args.reportingType != "Periodic" && args.reportingType != "OnRequest")
     {
         messages::propertyValueNotInList(res, args.reportingType,
                                          "MetricReportDefinitionType");
-        return false;
-    }
-
-    if (!toDbusReportActions(res, reportActions, args))
-    {
         return false;
     }
 
@@ -193,7 +246,6 @@ inline bool getUserParameters(crow::Response& res, const crow::Request& req,
         {
             return false;
         }
-
         std::optional<std::chrono::milliseconds> durationNum =
             time_utils::fromDurationString(durationStr);
         if (!durationNum)
@@ -205,18 +257,79 @@ inline bool getUserParameters(crow::Response& res, const crow::Request& req,
         args.interval = static_cast<uint64_t>(durationNum->count());
     }
 
+    return true;
+}
+inline bool toDbusMetrics(crow::Response& res,
+                          std::vector<nlohmann::json>& metrics,
+                          AddReportArgs& args)
+{
+    uint16_t itemNb = 0;
     args.metrics.reserve(metrics.size());
     for (auto& m : metrics)
     {
         std::string id;
         std::vector<std::string> uris;
+        std::optional<std::string> function;
+        std::optional<std::string> scope;
+        std::optional<std::string> durationStr;
         if (!json_util::readJson(m, res, "MetricId", id, "MetricProperties",
-                                 uris))
+                                 uris, "CollectionFunction", function,
+                                 "CollectionTimeScope", scope,
+                                 "CollectionDuration", durationStr))
         {
             return false;
         }
 
-        args.metrics.emplace_back(std::move(id), std::move(uris));
+        function = function.has_value() ? function : "Average";
+        scope = scope.has_value() ? scope : "Point";
+        durationStr = durationStr.has_value() ? durationStr : "PT0S";
+
+        std::string operation = getOperationType(*function, MethodType::post);
+        if (operation.empty())
+        {
+            messages::propertyValueNotInList(
+                res, *function, "CollectionFunction/" + std::to_string(itemNb));
+            return false;
+        }
+        if (!isTimeScopeValid(*scope))
+        {
+            messages::propertyValueNotInList(
+                res, *scope, "CollectionTimeScope/" + std::to_string(itemNb));
+            return false;
+        }
+        std::optional<std::chrono::milliseconds> durationNum =
+            time_utils::fromDurationString(*durationStr);
+        if (!durationNum)
+        {
+            messages::propertyValueIncorrect(res, "CollectionDuration",
+                                             *durationStr);
+            return false;
+        }
+        args.metrics.emplace_back(std::move(id), std::move(uris),
+                                  std::move(operation), std::move(*scope),
+                                  static_cast<uint64_t>(durationNum->count()));
+        itemNb++;
+    }
+
+    return true;
+}
+
+inline bool getUserParameters(crow::Response& res, const crow::Request& req,
+                              AddReportArgs& args)
+{
+    std::vector<nlohmann::json> metrics;
+    std::vector<std::string> reportActions;
+    std::optional<nlohmann::json> schedule;
+    if (!json_util::readJson(req, res, "Id", args.name, "Metrics", metrics,
+                             "MetricReportDefinitionType", args.reportingType,
+                             "ReportActions", reportActions, "Schedule",
+                             schedule) ||
+        !isIdValid(res, args.name) ||
+        !toDbusReportActions(res, reportActions, args) ||
+        !toDbusReportingType(res, schedule, args) ||
+        !toDbusMetrics(res, metrics, args))
+    {
+        return false;
     }
 
     return true;
@@ -224,11 +337,11 @@ inline bool getUserParameters(crow::Response& res, const crow::Request& req,
 
 inline bool getChassisSensorNode(
     const std::shared_ptr<bmcweb::AsyncResp>& asyncResp,
-    const std::vector<std::pair<std::string, std::vector<std::string>>>&
-        metrics,
+    const std::vector<std::tuple<std::string, std::vector<std::string>,
+                                 std::string, std::string, uint64_t>>& metrics,
     boost::container::flat_set<std::pair<std::string, std::string>>& matched)
 {
-    for (const auto& [id, uris] : metrics)
+    for (const auto& [id, uris, operation, scope, duration] : metrics)
     {
         for (size_t i = 0; i < uris.size(); i++)
         {
@@ -275,10 +388,10 @@ class AddReport
             return;
         }
 
-        telemetry::ReadingParameters readingParams;
+        ReadingParameters readingParams;
         readingParams.reserve(args.metrics.size());
 
-        for (const auto& [id, uris] : args.metrics)
+        for (const auto& [id, uris, operation, scope, duration] : args.metrics)
         {
             std::vector<sdbusplus::message::object_path> dbusPaths;
             dbusPaths.reserve(uris.size());
@@ -305,8 +418,8 @@ class AddReport
                 metadata["MetricProperties"].emplace_back(uri);
             }
 
-            readingParams.emplace_back(dbusPaths, "SINGLE", id, metadata.dump(),
-                                       "Point", 0u);
+            readingParams.emplace_back(dbusPaths, operation, id,
+                                       metadata.dump(), scope, duration);
         }
         const std::shared_ptr<bmcweb::AsyncResp> aResp = asyncResp;
         crow::connections::systemBus->async_method_call(
@@ -343,7 +456,7 @@ class AddReport
 
                 messages::created(aResp->res);
             },
-            telemetry::service, "/xyz/openbmc_project/Telemetry/Reports",
+            service, "/xyz/openbmc_project/Telemetry/Reports",
             "xyz.openbmc_project.Telemetry.ReportManager",
             "AddReportFutureVersion", "TelemetryService/" + args.name,
             args.reportingType, args.emitsReadingsUpdate,

--- a/redfish-core/lib/sensors.hpp
+++ b/redfish-core/lib/sensors.hpp
@@ -21,6 +21,8 @@
 #include <boost/container/flat_map.hpp>
 #include <boost/range/algorithm/replace_copy_if.hpp>
 #include <dbus_singleton.hpp>
+#include <dbus_utility.hpp>
+#include <error_messages.hpp>
 #include <registries/privilege_registry.hpp>
 #include <utils/json_utils.hpp>
 


### PR DESCRIPTION
PR to grab support for Telemetry service's: 1) MetricReport, 2) MetricDefinition, and 3) MetricReportDefinition resource collections. 
These changes add some Get, Push, Delete REST operations for the above collections. 

Note: The changes here were pulled from gerrit upstream. Some commits are still WIP and merit revisiting for improved support and functionality, especially once they are successfully reviewed and merged upstream. 

Upstream changes:

1. Sync Telmetry service with EventService: https://gerrit.openbmc-project.xyz/c/openbmc/bmcweb/+/38798
2. Switched bmcweb to use new telemetry service API: https://gerrit.openbmc-project.xyz/c/openbmc/bmcweb/+/44270
3. Add support for MetricDefinition property in MetricReport:  https://gerrit.openbmc-project.xyz/c/openbmc/bmcweb/+/44512
4. Sync Telmetry service with EventService: https://gerrit.openbmc-project.xyz/c/openbmc/bmcweb/+/46349
