### PR TITLE
Add GET method for TriggerCollection

### DIFF
--- a/redfish-core/include/redfish.hpp
+++ b/redfish-core/include/redfish.hpp
@@ -50,6 +50,7 @@
 #include "../lib/thermal.hpp"
 #include "../lib/thermal_metrics.hpp"
 #include "../lib/thermal_subsystem.hpp"
+#include "../lib/trigger.hpp"
 #include "../lib/update_service.hpp"
 #include "../lib/virtual_media.hpp"
 
@@ -229,6 +230,7 @@ class RedfishService
         requestRoutesMetricReportDefinition(app);
         requestRoutesMetricReportCollection(app);
         requestRoutesMetricReport(app);
+        requestRoutesTriggerCollection(app);
 
 #ifdef BMCWEB_ENABLE_HW_ISOLATION
         requestRoutesSystemHardwareIsolationLogService(app);

--- a/redfish-core/include/utils/telemetry_utils.hpp
+++ b/redfish-core/include/utils/telemetry_utils.hpp
@@ -9,6 +9,8 @@ namespace telemetry
 {
 
 constexpr const char* service = "xyz.openbmc_project.Telemetry";
+constexpr const char* reportSubtree =
+    "/xyz/openbmc_project/Telemetry/Reports/TelemetryService";
 constexpr const char* reportInterface = "xyz.openbmc_project.Telemetry.Report";
 constexpr const char* metricDefinitionUri =
     "/redfish/v1/TelemetryService/MetricDefinitions/";
@@ -16,6 +18,11 @@ constexpr const char* metricReportDefinitionUri =
     "/redfish/v1/TelemetryService/MetricReportDefinitions/";
 constexpr const char* metricReportUri =
     "/redfish/v1/TelemetryService/MetricReports/";
+constexpr const char* triggerSubtree =
+    "/xyz/openbmc_project/Telemetry/Triggers/TelemetryService";
+constexpr const char* triggerInterface =
+    "xyz.openbmc_project.Telemetry.Trigger";
+constexpr const char* triggerUri = "/redfish/v1/TelemetryService/Triggers/";
 
 inline std::optional<nlohmann::json>
     getMetadataJson(const std::string& metadataStr)
@@ -57,15 +64,27 @@ inline std::optional<std::string>
     return res;
 }
 
-inline void
-    getReportCollection(const std::shared_ptr<bmcweb::AsyncResp>& asyncResp,
-                        const std::string& uri)
+struct CollectionParams
 {
-    const std::array<const char*, 1> interfaces = {reportInterface};
+    const char* subtree;
+    int depth;
+    std::array<const char*, 1> interfaces;
 
+    CollectionParams() = delete;
+    CollectionParams(const char* st, int dp,
+                     const std::array<const char*, 1>& ifaces) :
+        subtree{st},
+        depth{dp}, interfaces{ifaces}
+    {}
+};
+
+inline void getCollection(const std::shared_ptr<bmcweb::AsyncResp>& asyncResp,
+                          const std::string& uri,
+                          const CollectionParams& params)
+{
     crow::connections::systemBus->async_method_call(
         [asyncResp, uri](const boost::system::error_code ec,
-                         const std::vector<std::string>& reports) {
+                         const std::vector<std::string>& items) {
             if (ec == boost::system::errc::io_error)
             {
                 asyncResp->res.jsonValue["Members"] = nlohmann::json::array();
@@ -82,13 +101,13 @@ inline void
             nlohmann::json& members = asyncResp->res.jsonValue["Members"];
             members = nlohmann::json::array();
 
-            for (const std::string& report : reports)
+            for (const std::string& item : items)
             {
-                sdbusplus::message::object_path path(report);
+                sdbusplus::message::object_path path(item);
                 std::string name = path.filename();
                 if (name.empty())
                 {
-                    BMCWEB_LOG_ERROR << "Received invalid path: " << report;
+                    BMCWEB_LOG_ERROR << "Received invalid path: " << item;
                     messages::internalError(asyncResp->res);
                     return;
                 }
@@ -99,9 +118,8 @@ inline void
         },
         "xyz.openbmc_project.ObjectMapper",
         "/xyz/openbmc_project/object_mapper",
-        "xyz.openbmc_project.ObjectMapper", "GetSubTreePaths",
-        "/xyz/openbmc_project/Telemetry/Reports/TelemetryService", 1,
-        interfaces);
+        "xyz.openbmc_project.ObjectMapper", "GetSubTreePaths", params.subtree,
+        params.depth, params.interfaces);
 }
 
 inline std::string getDbusReportPath(const std::string& id)

--- a/redfish-core/lib/metric_report.hpp
+++ b/redfish-core/lib/metric_report.hpp
@@ -108,8 +108,10 @@ inline void requestRoutesMetricReportCollection(App& app)
                     "/redfish/v1/TelemetryService/MetricReports";
                 asyncResp->res.jsonValue["Name"] = "Metric Report Collection";
 
-                telemetry::getReportCollection(asyncResp,
-                                               telemetry::metricReportUri);
+                telemetry::getCollection(
+                    asyncResp, telemetry::metricReportUri,
+                    telemetry::CollectionParams(telemetry::reportSubtree, 1,
+                                                {telemetry::reportInterface}));
             });
 }
 

--- a/redfish-core/lib/metric_report_definition.hpp
+++ b/redfish-core/lib/metric_report_definition.hpp
@@ -490,8 +490,10 @@ inline void requestRoutesMetricReportDefinitionCollection(App& app)
                 asyncResp->res.jsonValue["Name"] =
                     "Metric Definition Collection";
 
-                telemetry::getReportCollection(
-                    asyncResp, telemetry::metricReportDefinitionUri);
+                telemetry::getCollection(
+                    asyncResp, telemetry::metricReportDefinitionUri,
+                    telemetry::CollectionParams(telemetry::reportSubtree, 1,
+                                                {telemetry::reportInterface}));
             });
 
     BMCWEB_ROUTE(app, "/redfish/v1/TelemetryService/MetricReportDefinitions/")

--- a/redfish-core/lib/trigger.hpp
+++ b/redfish-core/lib/trigger.hpp
@@ -1,0 +1,31 @@
+#pragma once
+
+#include "utils/telemetry_utils.hpp"
+
+#include <app.hpp>
+#include <registries/privilege_registry.hpp>
+
+namespace redfish
+{
+
+inline void requestRoutesTriggerCollection(App& app)
+{
+    BMCWEB_ROUTE(app, "/redfish/v1/TelemetryService/Triggers/")
+        .privileges(redfish::privileges::getTriggersCollection)
+        .methods(boost::beast::http::verb::get)(
+            [](const crow::Request&,
+               const std::shared_ptr<bmcweb::AsyncResp>& asyncResp) {
+                asyncResp->res.jsonValue["@odata.type"] =
+                    "#TriggersCollection.TriggersCollection";
+                asyncResp->res.jsonValue["@odata.id"] =
+                    "/redfish/v1/TelemetryService/Triggers";
+                asyncResp->res.jsonValue["Name"] = "Triggers Collection";
+
+                telemetry::getCollection(
+                    asyncResp, telemetry::triggerUri,
+                    telemetry::CollectionParams(telemetry::triggerSubtree, 1,
+                                                {telemetry::triggerInterface}));
+            });
+}
+
+} // namespace redfish


### PR DESCRIPTION
PR to grab support for Triggers collection: 

Note: The changes here were pulled from gerrit upstream, and just solved some conflicts.

Upstream changes:
Add GET method for TriggerCollection: https://gerrit.openbmc-project.xyz/c/openbmc/bmcweb/+/45490