### PR TITLE
Environment metrics

### DIFF
--- a/redfish-core/include/redfish.hpp
+++ b/redfish-core/include/redfish.hpp
@@ -21,6 +21,7 @@
 #include "../lib/bios.hpp"
 #include "../lib/certificate_service.hpp"
 #include "../lib/chassis.hpp"
+#include "../lib/environment_metrics.hpp"
 #include "../lib/ethernet.hpp"
 #include "../lib/event_service.hpp"
 #include "../lib/fan.hpp"
@@ -95,6 +96,7 @@ class RedfishService
         requestRoutesPowerSupplyCollection(app);
         requestRoutesPowerSupply(app);
         requestRoutesPCIeSlots(app);
+        requestRoutesEnvironmentMetrics(app);
         requestRoutesChassisCollection(app);
         requestRoutesChassis(app);
         requestRoutesChassisResetAction(app);

--- a/redfish-core/lib/chassis.hpp
+++ b/redfish-core/lib/chassis.hpp
@@ -457,6 +457,11 @@ inline void requestRoutesChassis(App& app)
                                     {"@odata.id", "/redfish/v1/Chassis/" +
                                                       chassisId + "/Thermal"}};
 
+                                asyncResp->res.jsonValue["EnvironmentMetrics"] =
+                                    {{"@odata.id", "/redfish/v1/Chassis/" +
+                                                       chassisId +
+                                                       "/EnvironmentMetrics"}};
+
                                 // Power object
                                 asyncResp->res.jsonValue["Power"] = {
                                     {"@odata.id", "/redfish/v1/Chassis/" +

--- a/redfish-core/lib/environment_metrics.hpp
+++ b/redfish-core/lib/environment_metrics.hpp
@@ -172,6 +172,234 @@ inline void getPowerWatts(const std::shared_ptr<bmcweb::AsyncResp>& asyncResp,
 }
 
 inline void
+    getPowerLimitWatts(const std::shared_ptr<bmcweb::AsyncResp>& asyncResp)
+{
+    const std::array<std::string, 1> powerCapInterfaces = {
+        "xyz.openbmc_project.Control.Power.Cap"};
+    crow::connections::systemBus->async_method_call(
+        [asyncResp](
+            const boost::system::error_code ec,
+            const std::vector<std::pair<
+                std::string,
+                std::vector<std::pair<std::string, std::vector<std::string>>>>>&
+                powercapsubtree) {
+            if (ec)
+            {
+                BMCWEB_LOG_DEBUG << "D-Bus response error on GetSubTree " << ec;
+                messages::internalError(asyncResp->res);
+                return;
+            }
+
+            for (const auto& [objectPath, serviceName] : powercapsubtree)
+            {
+                if (objectPath.empty() || serviceName.size() != 1)
+                {
+                    BMCWEB_LOG_DEBUG << "Error getting D-Bus object!";
+                    messages::internalError(asyncResp->res);
+                    return;
+                }
+                const std::string& validPath = objectPath;
+                const std::string& connectionName = serviceName[0].first;
+
+                asyncResp->res.jsonValue["PowerLimitWatts"]["SetPoint"] = 0;
+                asyncResp->res.jsonValue["PowerLimitWatts"]["ControlMode"] =
+                    "automatic";
+                asyncResp->res
+                    .jsonValue["PowerLimitWatts"]
+                              ["ControlMode@Redfish.AllowableValues"] = {
+                    "automatic", "disabled"};
+
+                crow::connections::systemBus->async_method_call(
+                    [asyncResp](const boost::system::error_code ec2,
+                                const std::vector<std::pair<
+                                    std::string, std::variant<uint32_t, bool>>>&
+                                    properties) {
+                        if (ec2)
+                        {
+                            BMCWEB_LOG_DEBUG << "Power Limit Set: Dbus error: "
+                                             << ec2;
+                            messages::internalError(asyncResp->res);
+                            return;
+                        }
+
+                        for (const std::pair<std::string,
+                                             std::variant<uint32_t, bool>>&
+                                 property : properties)
+                        {
+                            if (property.first == "PowerCap")
+                            {
+                                const uint32_t* powerCap =
+                                    std::get_if<uint32_t>(&property.second);
+
+                                if (powerCap == nullptr)
+                                {
+
+                                    messages::internalError(asyncResp->res);
+                                    return;
+                                }
+                                asyncResp->res
+                                    .jsonValue["PowerLimitWatts"]["SetPoint"] =
+                                    *powerCap;
+                            }
+                            else if (property.first == "PowerCapEnable")
+                            {
+                                const bool* powerCapEnable =
+                                    std::get_if<bool>(&property.second);
+
+                                if (powerCapEnable == nullptr)
+                                {
+
+                                    messages::internalError(asyncResp->res);
+                                    return;
+                                }
+                                if (!*powerCapEnable)
+                                {
+                                    asyncResp->res.jsonValue["PowerLimitWatts"]
+                                                            ["ControlMode"] =
+                                        "disabled";
+                                }
+                            }
+                        }
+                    },
+                    connectionName, validPath,
+                    "org.freedesktop.DBus.Properties", "GetAll",
+                    "xyz.openbmc_project.Control.Power.Cap");
+            }
+        },
+        "xyz.openbmc_project.ObjectMapper",
+        "/xyz/openbmc_project/object_mapper",
+        "xyz.openbmc_project.ObjectMapper", "GetSubTree", "/", 0,
+        powerCapInterfaces);
+}
+
+inline void
+    setPowerSetPoint(const std::shared_ptr<bmcweb::AsyncResp>& asyncResp,
+                     uint32_t powerCap)
+{
+    BMCWEB_LOG_DEBUG << "Set Power Limit Watts Set Point";
+
+    const std::array<std::string, 1> powerCapInterfaces = {
+        "xyz.openbmc_project.Control.Power.Cap"};
+    crow::connections::systemBus->async_method_call(
+        [asyncResp, powerCap](
+            const boost::system::error_code ec,
+            const std::vector<std::pair<
+                std::string,
+                std::vector<std::pair<std::string, std::vector<std::string>>>>>&
+                powercapsubtree) {
+            if (ec)
+            {
+                BMCWEB_LOG_DEBUG << "D-Bus response error on GetSubTree " << ec;
+                messages::internalError(asyncResp->res);
+                return;
+            }
+
+            for (const auto& [objectPath, serviceName] : powercapsubtree)
+            {
+                if (objectPath.empty() || serviceName.size() != 1)
+                {
+                    BMCWEB_LOG_DEBUG << "Error getting D-Bus object!";
+                    messages::internalError(asyncResp->res);
+                    return;
+                }
+                const std::string& validPath = objectPath;
+                const std::string& connectionName = serviceName[0].first;
+
+                crow::connections::systemBus->async_method_call(
+                    [asyncResp](const boost::system::error_code ec) {
+                        if (ec)
+                        {
+                            BMCWEB_LOG_DEBUG << "Power Limit Set: Dbus error: "
+                                             << ec;
+                            messages::internalError(asyncResp->res);
+                            return;
+                        }
+                    },
+                    connectionName, validPath,
+                    "org.freedesktop.DBus.Properties", "Set",
+                    "xyz.openbmc_project.Control.Power.Cap", "PowerCap",
+                    std::variant<uint32_t>(powerCap));
+            }
+        },
+        "xyz.openbmc_project.ObjectMapper",
+        "/xyz/openbmc_project/object_mapper",
+        "xyz.openbmc_project.ObjectMapper", "GetSubTree", "/", 0,
+        powerCapInterfaces);
+}
+
+inline void
+    setPowerControlMode(const std::shared_ptr<bmcweb::AsyncResp>& asyncResp,
+                        const std::string& controlMode)
+{
+    BMCWEB_LOG_DEBUG << "Set Power Limit Watts Control Mode";
+    bool powerCapEnable;
+    if (controlMode == "disabled")
+    {
+        powerCapEnable = false;
+    }
+    else if (controlMode == "automatic")
+    {
+        powerCapEnable = true;
+    }
+    else
+    {
+        BMCWEB_LOG_DEBUG << "Power Control Mode  does not support this mode :"
+                         << controlMode;
+        messages::propertyValueNotInList(asyncResp->res, controlMode,
+                                         "ControlMode");
+    }
+
+    const std::array<std::string, 1> powerCapInterfaces = {
+        "xyz.openbmc_project.Control.Power.Cap"};
+    crow::connections::systemBus->async_method_call(
+        [asyncResp, powerCapEnable](
+            const boost::system::error_code ec,
+            const std::vector<std::pair<
+                std::string,
+                std::vector<std::pair<std::string, std::vector<std::string>>>>>&
+                powercapsubtree) {
+            if (ec)
+            {
+                BMCWEB_LOG_DEBUG << "D-Bus response error on GetSubTree " << ec;
+                messages::internalError(asyncResp->res);
+                return;
+            }
+
+            for (const auto& [objectPath, serviceName] : powercapsubtree)
+            {
+                if (objectPath.empty() || serviceName.size() != 1)
+                {
+                    BMCWEB_LOG_DEBUG << "Error getting D-Bus object!";
+                    messages::internalError(asyncResp->res);
+                    return;
+                }
+                const std::string& validPath = objectPath;
+                const std::string& connectionName = serviceName[0].first;
+
+                crow::connections::systemBus->async_method_call(
+                    [asyncResp](const boost::system::error_code ec) {
+                        if (ec)
+                        {
+                            messages::internalError(asyncResp->res);
+                            BMCWEB_LOG_ERROR
+                                << "powerCapEnable Get handler: Dbus error "
+                                << ec;
+                            return;
+                        }
+                    },
+                    connectionName, validPath,
+                    "org.freedesktop.DBus.Properties", "Set",
+                    "xyz.openbmc_project.Control.Power.Cap", "PowerCapEnable",
+                    std::variant<bool>(powerCapEnable));
+            }
+        },
+        "xyz.openbmc_project.ObjectMapper",
+        "/xyz/openbmc_project/object_mapper",
+        "xyz.openbmc_project.ObjectMapper", "GetSubTree", "/", 0,
+        powerCapInterfaces);
+}
+
+inline void
     getEnvironmentMetrics(const std::shared_ptr<bmcweb::AsyncResp>& asyncResp,
                           const std::string& chassisID)
 {
@@ -186,6 +414,7 @@ inline void
         "/redfish/v1/Chassis/" + chassisID + "/EnvironmentMetrics";
     getfanSpeedsPercent(asyncResp, chassisID);
     getPowerWatts(asyncResp, chassisID);
+    getPowerLimitWatts(asyncResp);
 }
 
 inline void requestRoutesEnvironmentMetrics(App& app)
@@ -214,6 +443,76 @@ inline void requestRoutesEnvironmentMetrics(App& app)
                     };
                 redfish::chassis_utils::getValidChassisID(
                     asyncResp, chassisID, std::move(getChassisID));
+            });
+
+    BMCWEB_ROUTE(app, "/redfish/v1/Chassis/<str>/EnvironmentMetrics/")
+        .privileges({{"ConfigureComponents"}})
+        // TODO: Use automated PrivilegeRegistry
+        // Need to wait for Redfish to release a new registry
+        .methods(boost::beast::http::verb::patch)(
+            [](const crow::Request& req,
+               const std::shared_ptr<bmcweb::AsyncResp>& asyncResp,
+               const std::string& chassisID) {
+                std::optional<nlohmann::json> powerLimitWatts;
+                if (!json_util::readJson(req, asyncResp->res, "PowerLimitWatts",
+                                         powerLimitWatts))
+                {
+                    return;
+                }
+
+                if (powerLimitWatts)
+                {
+                    std::optional<uint32_t> setPoint;
+                    std::optional<std::string> controlMode;
+                    if (!redfish::json_util::readJson(
+                            *powerLimitWatts, asyncResp->res, "SetPoint",
+                            setPoint, "ControlMode", controlMode))
+                    {
+                        return;
+                    }
+
+                    if (setPoint)
+                    {
+                        auto getChassisID =
+                            [asyncResp, chassisID,
+                             setPoint](const std::optional<std::string>&
+                                           validChassisID) {
+                                if (!validChassisID)
+                                {
+                                    BMCWEB_LOG_ERROR
+                                        << "Not a valid chassis ID:"
+                                        << chassisID;
+                                    messages::resourceNotFound(
+                                        asyncResp->res, "Chassis", chassisID);
+                                    return;
+                                }
+                                setPowerSetPoint(asyncResp, *setPoint);
+                            };
+                        redfish::chassis_utils::getValidChassisID(
+                            asyncResp, chassisID, std::move(getChassisID));
+                    }
+
+                    if (controlMode)
+                    {
+                        auto getChassisID =
+                            [asyncResp, chassisID,
+                             controlMode](const std::optional<std::string>&
+                                              validChassisID) {
+                                if (!validChassisID)
+                                {
+                                    BMCWEB_LOG_ERROR
+                                        << "Not a valid chassis ID:"
+                                        << chassisID;
+                                    messages::resourceNotFound(
+                                        asyncResp->res, "Chassis", chassisID);
+                                    return;
+                                }
+                                setPowerControlMode(asyncResp, *controlMode);
+                            };
+                        redfish::chassis_utils::getValidChassisID(
+                            asyncResp, chassisID, std::move(getChassisID));
+                    }
+                }
             });
 }
 

--- a/redfish-core/lib/environment_metrics.hpp
+++ b/redfish-core/lib/environment_metrics.hpp
@@ -1,0 +1,220 @@
+#pragma once
+
+#include <app.hpp>
+#include <utils/chassis_utils.hpp>
+#include <utils/json_utils.hpp>
+
+namespace redfish
+{
+inline void
+    getfanSpeedsPercent(const std::shared_ptr<bmcweb::AsyncResp>& asyncResp,
+                        const std::string& chassisID)
+{
+    BMCWEB_LOG_DEBUG << "Get properties for getFan associated to chassis = "
+                     << chassisID;
+    const std::array<std::string, 1> sensorInterfaces = {
+        "xyz.openbmc_project.Sensor.Value"};
+    crow::connections::systemBus->async_method_call(
+        [asyncResp, chassisID](
+            const boost::system::error_code ec,
+            const std::vector<std::pair<
+                std::string,
+                std::vector<std::pair<std::string, std::vector<std::string>>>>>&
+                sensorsubtree) {
+            if (ec)
+            {
+                BMCWEB_LOG_DEBUG << "D-Bus response error on GetSubTree " << ec;
+                if (ec.value() == boost::system::errc::io_error)
+                {
+                    messages::resourceNotFound(asyncResp->res, "Chassis",
+                                               chassisID);
+                    return;
+                }
+                messages::internalError(asyncResp->res);
+                return;
+            }
+            nlohmann::json& fanList =
+                asyncResp->res.jsonValue["FanSpeedsPercent"];
+            fanList = nlohmann::json::array();
+
+            for (const auto& [objectPath, serviceName] : sensorsubtree)
+            {
+                if (objectPath.empty() || serviceName.size() != 1)
+                {
+                    BMCWEB_LOG_DEBUG << "Error getting D-Bus object!";
+                    messages::internalError(asyncResp->res);
+                    return;
+                }
+                const std::string& validPath = objectPath;
+                const std::string& connectionName = serviceName[0].first;
+                std::vector<std::string> split;
+                // Reserve space for
+                // /xyz/openbmc_project/sensors/<name>/<subname>
+                split.reserve(6);
+                boost::algorithm::split(split, validPath,
+                                        boost::is_any_of("/"));
+                if (split.size() < 6)
+                {
+                    BMCWEB_LOG_ERROR << "Got path that isn't long enough "
+                                     << validPath;
+                    continue;
+                }
+                // These indexes aren't intuitive, as boost::split puts an empty
+                // string at the beginning
+                const std::string& sensorType = split[4];
+                const std::string& sensorName = split[5];
+                BMCWEB_LOG_DEBUG << "sensorName " << sensorName
+                                 << " sensorType " << sensorType;
+                if (sensorType == "fan" || sensorType == "fan_tach" ||
+                    sensorType == "fan_pwm")
+                {
+                    crow::connections::systemBus->async_method_call(
+                        [asyncResp, chassisID, &fanList,
+                         sensorName](const boost::system::error_code ec,
+                                     const std::variant<double>& value) {
+                            if (ec)
+                            {
+                                BMCWEB_LOG_DEBUG << "Can't get Fan speed!";
+                                messages::internalError(asyncResp->res);
+                                return;
+                            }
+
+                            const double* attributeValue =
+                                std::get_if<double>(&value);
+                            if (attributeValue == nullptr)
+                            {
+                                // illegal property
+                                messages::internalError(asyncResp->res);
+                                return;
+                            }
+                            std::string tempPath = "/redfish/v1/Chassis/" +
+                                                   chassisID + "/Sensors/";
+                            fanList.push_back(
+                                {{"DeviceName", "Chassis Fan #" + sensorName},
+                                 {"SpeedRPM", *attributeValue},
+                                 {"DataSourceUri", tempPath + sensorName},
+                                 {"@odata.id", tempPath + sensorName}});
+                        },
+                        connectionName, validPath,
+                        "org.freedesktop.DBus.Properties", "Get",
+                        "xyz.openbmc_project.Sensor.Value", "Value");
+                }
+                else
+                {
+                    BMCWEB_LOG_DEBUG
+                        << "This is not a fan-related sensor,sensortype = "
+                        << sensorType;
+                    continue;
+                }
+            }
+        },
+        "xyz.openbmc_project.ObjectMapper",
+        "/xyz/openbmc_project/object_mapper",
+        "xyz.openbmc_project.ObjectMapper", "GetSubTree",
+        "/xyz/openbmc_project/sensors", 0, sensorInterfaces);
+}
+
+inline void getPowerWatts(const std::shared_ptr<bmcweb::AsyncResp>& asyncResp,
+                          const std::string& chassisID)
+{
+    const std::array<const char*, 1> totalPowerInterfaces = {
+        "xyz.openbmc_project.Sensor.Value"};
+    const std::string& totalPowerPath =
+        "/xyz/openbmc_project/sensors/power/total_power";
+    crow::connections::systemBus->async_method_call(
+        [asyncResp, chassisID, totalPowerPath](
+            const boost::system::error_code ec,
+            const std::vector<std::pair<std::string, std::vector<std::string>>>&
+                object) {
+            if (ec)
+            {
+                BMCWEB_LOG_DEBUG << "DBUS response error";
+                messages::internalError(asyncResp->res);
+                return;
+            }
+            for (const auto& tempObject : object)
+            {
+                const std::string& connectionName = tempObject.first;
+                crow::connections::systemBus->async_method_call(
+                    [asyncResp, chassisID](const boost::system::error_code ec,
+                                           const std::variant<double>& value) {
+                        if (ec)
+                        {
+                            BMCWEB_LOG_DEBUG << "Can't get Power Watts!";
+                            messages::internalError(asyncResp->res);
+                            return;
+                        }
+
+                        const double* attributeValue =
+                            std::get_if<double>(&value);
+                        if (attributeValue == nullptr)
+                        {
+                            // illegal property
+                            messages::internalError(asyncResp->res);
+                            return;
+                        }
+                        std::string tempPath =
+                            "/redfish/v1/Chassis/" + chassisID + "/Sensors/";
+                        asyncResp->res.jsonValue["PowerWatts"] = {
+                            {"Reading", *attributeValue},
+                            {"DataSourceUri", tempPath + "total_power"},
+                            {"@odata.id", tempPath + "total_power"}};
+                    },
+                    connectionName, totalPowerPath,
+                    "org.freedesktop.DBus.Properties", "Get",
+                    "xyz.openbmc_project.Sensor.Value", "Value");
+            }
+        },
+        "xyz.openbmc_project.ObjectMapper",
+        "/xyz/openbmc_project/object_mapper",
+        "xyz.openbmc_project.ObjectMapper", "GetObject", totalPowerPath,
+        totalPowerInterfaces);
+}
+
+inline void
+    getEnvironmentMetrics(const std::shared_ptr<bmcweb::AsyncResp>& asyncResp,
+                          const std::string& chassisID)
+{
+    BMCWEB_LOG_DEBUG
+        << "Get properties for EnvironmentMetrics associated to chassis = "
+        << chassisID;
+    asyncResp->res.jsonValue["@odata.type"] =
+        "#EnvironmentMetrics.v1_1_0.EnvironmentMetrics";
+    asyncResp->res.jsonValue["Name"] = "Chassis Environment Metrics";
+    asyncResp->res.jsonValue["Id"] = "EnvironmentMetrics";
+    asyncResp->res.jsonValue["@odata.id"] =
+        "/redfish/v1/Chassis/" + chassisID + "/EnvironmentMetrics";
+    getfanSpeedsPercent(asyncResp, chassisID);
+    getPowerWatts(asyncResp, chassisID);
+}
+
+inline void requestRoutesEnvironmentMetrics(App& app)
+{
+    BMCWEB_ROUTE(app, "/redfish/v1/Chassis/<str>/EnvironmentMetrics/")
+        .privileges({{"Login"}})
+        // TODO: Use automated PrivilegeRegistry
+        // Need to wait for Redfish to release a new registry
+        .methods(boost::beast::http::verb::get)(
+            [](const crow::Request&,
+               const std::shared_ptr<bmcweb::AsyncResp>& asyncResp,
+               const std::string& chassisID) {
+                auto getChassisID =
+                    [asyncResp, chassisID](
+                        const std::optional<std::string>& validChassisID) {
+                        if (!validChassisID)
+                        {
+                            BMCWEB_LOG_ERROR << "Not a valid chassis ID:"
+                                             << chassisID;
+                            messages::resourceNotFound(asyncResp->res,
+                                                       "Chassis", chassisID);
+                            return;
+                        }
+
+                        getEnvironmentMetrics(asyncResp, *validChassisID);
+                    };
+                redfish::chassis_utils::getValidChassisID(
+                    asyncResp, chassisID, std::move(getChassisID));
+            });
+}
+
+} // namespace redfish


### PR DESCRIPTION
PR to grab support for EnvironmentMetrics:

Note: The changes here were pulled from gerrit upstream, and just solved some conflicts.

Upstream changes:
Add Redfish EnvironmentMetrics schema in bmcweb: https://gerrit.openbmc-project.xyz/c/openbmc/bmcweb/+/43170
Add PowerLimitWatts in EnvironmentMetrics: https://gerrit.openbmc-project.xyz/c/openbmc/bmcweb/+/47300