### PR TITLE
Add GeneratorId prop to LogEntry schema for user trigerred dumps

### DIFF
--- a/static/redfish/v1/JsonSchemas/OemLogEntry/index.json
+++ b/static/redfish/v1/JsonSchemas/OemLogEntry/index.json
@@ -22,6 +22,14 @@
                 }
             },
             "properties": {
+                "GeneratorId": {
+                    "description": "Id of the user who created the LogEntry.",
+                    "longDescription": "Unique id of the user who has caused the creation of the LogEntry. Eg: ip address, session id, client id.",
+                    "type": [
+                        "string",
+                        "null"
+                    ]
+                },
                 "ManagementSystemAck" : {
                     "description": "Flag to keep track of external interface acknowledgment.",
                     "longDescription": "A true value says external interface acked error log, false says otherwise.",

--- a/static/redfish/v1/schema/OemLogEntry_v1.xml
+++ b/static/redfish/v1/schema/OemLogEntry_v1.xml
@@ -33,6 +33,10 @@
               <Annotation Term="OData.LongDescription" String="A true value says external interface acked error log, false says otherwise."/>
             </Property>
 
+            <Property Name="GeneratorId" Type="Edm.String">
+              <Annotation Term="OData.Description" String="Id of the user who created the LogEntry."/>
+              <Annotation Term="OData.LongDescription" String="Unique id of the user who has caused the creation of the LogEntry. Eg: ip address, session id, client id."/>
+            </Property>
       </EntityType>
     </Schema>
   </edmx:DataServices>


### PR DESCRIPTION
This commit adds a new oem property for user-trigerred
dumps, that will be used to indicate the session id of
the user that triggered the dump creation. When multiple
clients manages the bmc, there was a requirement that
which client has initiated the dump before offloading/
performing any operations on that dump. Hence, this prop
tags the session id of the redfish client that has initiated the
dump creation.

There is a discussion at DMTF to add this property to
the redfish end-point on LogEntry schema. This can
be also used for audit purposes. Please see
https://redfishforum.com/thread/547/usage-originofcondition-parameter-logentry-schema

So right now, this property has been added to
oemlogentry schema that was added here:
https://github.com/ibm-openbmc/bmcweb/pull/121/files

The dbus interface change for the same is here:
https://github.com/ibm-openbmc/phosphor-dbus-interfaces/pull/26/files

Tested By:

* Created a bmc dump using CollectDiagnosticData redfish api

* GET on the created dump entry:
    {
      "@odata.id": "/redfish/v1/Managers/bmc/LogServices/Dump/Entries/43",
      "@odata.type": "#LogEntry.v1_8_0.LogEntry",
      "AdditionalDataSizeBytes": 108644,
      "AdditionalDataURI": "/redfish/v1/Managers/bmc/LogServices/Dump/Entries/43/attachment",
      "Created": "2021-11-02T10:49:37+00:00",
      "DiagnosticDataType": "Manager",
      "EntryType": "Event",
      "Id": "43",
      "Name": "BMC Dump Entry",
      "Oem": {
        "OpenBMC": {
          "@odata.type": "#OemLogEntry.v1_0_0.LogEntry",
          "GeneratorId": "::ffff:9.43.40.132"
        }
      }

Redfish Validator passed.

Signed-off-by: Asmitha Karunanithi <asmitk01@in.ibm.com>
Change-Id: I050f2f2a9ff9a95ad6ac4fbc3a5a4283e26f64f7