### PR TITLE
1020 100821 Enable error traces in bmcweb

### DIFF
--- a/http/http_connection.hpp
+++ b/http/http_connection.hpp
@@ -528,13 +528,13 @@ class Connection :
             [this,
              self(shared_from_this())](const boost::system::error_code& ec,
                                        std::size_t bytesTransferred) {
-                BMCWEB_LOG_ERROR << this << " async_read_header "
-                                 << bytesTransferred << " Bytes";
+                BMCWEB_LOG_WARNING << this << " async_read_header "
+                                   << bytesTransferred << " Bytes";
                 bool errorWhileReading = false;
                 if (ec)
                 {
                     errorWhileReading = true;
-                    BMCWEB_LOG_ERROR
+                    BMCWEB_LOG_WARNING
                         << this << " Error while reading: " << ec.message();
                 }
                 else

--- a/http/logging.hpp
+++ b/http/logging.hpp
@@ -45,20 +45,16 @@ class Logger
            [[maybe_unused]] const size_t line, LogLevel levelIn) :
         level(levelIn)
     {
-#ifdef BMCWEB_ENABLE_LOGGING
         stringstream << "(" << timestamp() << ") [" << prefix << " "
                      << std::filesystem::path(filename).filename() << ":"
                      << line << "] ";
-#endif
     }
     ~Logger()
     {
         if (level >= getCurrentLogLevel())
         {
-#ifdef BMCWEB_ENABLE_LOGGING
             stringstream << std::endl;
             std::cerr << stringstream.str();
-#endif
         }
     }
 
@@ -68,9 +64,7 @@ class Logger
     {
         if (level >= getCurrentLogLevel())
         {
-#ifdef BMCWEB_ENABLE_LOGGING
             stringstream << value;
-#endif
         }
         return *this;
     }

--- a/include/authorization.hpp
+++ b/include/authorization.hpp
@@ -289,7 +289,7 @@ static std::shared_ptr<persistent_data::UserSession> authenticate(
     }
 #endif
     std::string_view authHeader = reqHeader["Authorization"];
-    BMCWEB_LOG_ERROR << "authHeader=" << authHeader;
+    BMCWEB_LOG_WARNING << "authHeader=" << authHeader;
 
     if (sessionOut == nullptr && authMethodsConfig.sessionToken)
     {

--- a/include/event_dbus_monitor.hpp
+++ b/include/event_dbus_monitor.hpp
@@ -350,7 +350,7 @@ void registerStateChangeSignal()
 
 void registerPostCodeChangeSignal()
 {
-    BMCWEB_LOG_ERROR << "PostCode change signal - Register";
+    BMCWEB_LOG_DEBUG << "PostCode change signal - Register";
 
     matchPostCodeChange = std::make_unique<sdbusplus::bus::match::match>(
         *crow::connections::systemBus,

--- a/src/webserver_main.cpp
+++ b/src/webserver_main.cpp
@@ -69,7 +69,13 @@ inline void setupSocket(crow::App& app)
 
 int main(int /*argc*/, char** /*argv*/)
 {
+    // If user has enabled logging, set level at debug so we get everything
+#ifdef BMCWEB_ENABLE_LOGGING
     crow::Logger::setLogLevel(crow::LogLevel::Debug);
+#else
+    // otherwise just enable the error logging
+    crow::Logger::setLogLevel(crow::LogLevel::Error);
+#endif
 
     auto io = std::make_shared<boost::asio::io_context>();
     App app(io);


### PR DESCRIPTION
Per a SoS meeting, enabling the error traces in bmcweb to better be able to debug issues. This is not uptreamable as the discussion there has continued to be that by default, no logging is enabled.