### PR TITLE
Return proper error resp for redfish dump creation

### DIFF
--- a/redfish-core/lib/log_services.hpp
+++ b/redfish-core/lib/log_services.hpp
@@ -1008,11 +1008,54 @@ inline void createDump(const std::shared_ptr<bmcweb::AsyncResp>& asyncResp,
         createDumpParamVec(createDumpParams);
 
     crow::connections::systemBus->async_method_call(
-        [asyncResp, req](const boost::system::error_code ec,
-                         const sdbusplus::message::object_path& objPath) {
+        [asyncResp, req,
+         dumpType](const boost::system::error_code ec,
+                   const sdbusplus::message::message& msg,
+                   const sdbusplus::message::object_path& objPath) {
             if (ec)
             {
                 BMCWEB_LOG_ERROR << "CreateDump resp_handler got error " << ec;
+                const sd_bus_error* dbusError = msg.get_error();
+                if (dbusError == nullptr)
+                {
+                    messages::internalError(asyncResp->res);
+                    return;
+                }
+
+                BMCWEB_LOG_ERROR << "CreateDump DBus error: " << dbusError->name
+                                 << " and error msg: " << dbusError->message;
+
+                if (strcmp(dbusError->name, "xyz.openbmc_project.Common.Error."
+                                            "NotAllowed") == 0)
+                {
+                    // This will be returned as a result of createDump call
+                    // made when the host is not powered on.
+                    messages::resourceInStandby(asyncResp->res);
+                    return;
+                }
+                if (strcmp(dbusError->name, "xyz.openbmc_project.Dump."
+                                            "Create.Error.Disabled") == 0)
+                {
+                    std::string dumpPath;
+                    if (dumpType == "BMC")
+                    {
+                        dumpPath = "/redfish/v1/Managers/bmc/LogServices/Dump/";
+                    }
+                    else if (dumpType == "System")
+                    {
+                        dumpPath =
+                            "/redfish/v1/Systems/system/LogServices/Dump/";
+                    }
+                    messages::serviceDisabled(asyncResp->res, dumpPath);
+                    return;
+                }
+                // Other Dbus errors such as:
+                // xyz.openbmc_project.Common.Error.InvalidArgument &
+                // org.freedesktop.DBus.Error.InvalidArgs are all related to
+                // the dbus call that is made here in the bmcweb
+                // implementation and has nothing to do with the client's
+                // input in the request. Hence, returning internal error
+                // back to the client.
                 messages::internalError(asyncResp->res);
                 return;
             }


### PR DESCRIPTION
Currently, only internal server error will be returned
to a client when there is a create dump dbus call failure
in the backend, irrespective of the error that's
returned by the phosphor-dump-manager.

This change will send a proper error response to the
user based on the host state. "resourceInStandBy" error will
now be returned when user initiates a host dump when the
host is powered off.

This fixes the defect at:
https://w3.rchland.ibm.com/projects/bestquest/?defect=SW536643

Tested By:

curl -k -H "X-Auth-Token: $bmc_token" -X POST https://${bmc}
/redfish/v1/Systems/system/LogServices/Dump/Actions/
LogService.CollectDiagnosticData -d
'{"DiagnosticDataType":"OEM", "OEMDiagnosticDataType":"Resource_vps_str"}'
{
  "error": {
    "@Message.ExtendedInfo": [
      {
        "@odata.type": "#Message.v1_1_1.Message",
        "Message": "The request could not be performed because the resource is in standby.",
        "MessageArgs": [],
        "MessageId": "Base.1.8.1.ResourceInStandby",
        "MessageSeverity": "Critical",
        "Resolution": "Ensure that the resource is in the correct power state and resubmit the request."
      }
    ],
    "code": "Base.1.8.1.ResourceInStandby",
    "message": "The request could not be performed because the resource is in standby."
  }
}

Signed-off-by: Asmitha Karunanithi <asmitk01@in.ibm.com>
Change-Id: I7522ee8737e0b1b25df25cb6c5b175517af403ce