### PR TITLE
Add Model & CoreCount to ProcessorSummary

### DIFF
--- a/redfish-core/lib/systems.hpp
+++ b/redfish-core/lib/systems.hpp
@@ -142,6 +142,158 @@ inline void
 }
 
 /*
+ * @brief Get "ProcessorSummary" Properties
+ *
+ * @param[in] aResp Shared pointer for completing asynchronous calls
+ * @param[in] service dbus service for Cpu Information
+ * @param[in] path dbus path for Cpu
+ * @param[in] properties from dbus Inventory.Item.Cpu interface
+ *
+ * @return None.
+ */
+inline void getProcessorProperties(
+    const std::shared_ptr<bmcweb::AsyncResp>& aResp, const std::string& service,
+    const std::string& path,
+    const std::vector<std::pair<
+        std::string, std::variant<std::string, uint64_t, uint32_t, uint16_t>>>&
+        properties)
+{
+
+    BMCWEB_LOG_DEBUG << "Got " << properties.size() << " Cpu properties.";
+
+    auto getCpuPresenceState =
+        [aResp](const boost::system::error_code ec3,
+                const std::variant<bool>& cpuPresenceCheck) {
+            if (ec3)
+            {
+                BMCWEB_LOG_ERROR << "DBUS response error " << ec3;
+                return;
+            }
+            modifyCpuPresenceState(aResp, cpuPresenceCheck);
+        };
+
+    auto getCpuFunctionalState =
+        [aResp](const boost::system::error_code ec3,
+                const std::variant<bool>& cpuFunctionalCheck) {
+            if (ec3)
+            {
+                BMCWEB_LOG_ERROR << "DBUS response error " << ec3;
+                return;
+            }
+            modifyCpuFunctionalState(aResp, cpuFunctionalCheck);
+        };
+
+    // Get the Presence of CPU
+    crow::connections::systemBus->async_method_call(
+        std::move(getCpuPresenceState), service, path,
+        "org.freedesktop.DBus.Properties", "Get",
+        "xyz.openbmc_project.Inventory.Item", "Present");
+
+    // Get the Functional State
+    crow::connections::systemBus->async_method_call(
+        std::move(getCpuFunctionalState), service, path,
+        "org.freedesktop.DBus.Properties", "Get",
+        "xyz.openbmc_project.State.Decorator.OperationalStatus", "Functional");
+
+    for (const auto& property : properties)
+    {
+
+        if (property.first == "Family")
+        {
+            // Get the CPU Model
+            const std::string* modelStr =
+                std::get_if<std::string>(&property.second);
+            if (!modelStr)
+            {
+                messages::internalError(aResp->res);
+                return;
+            }
+            nlohmann::json& prevModel =
+                aResp->res.jsonValue["ProcessorSummary"]["Model"];
+            std::string* prevModelPtr = prevModel.get_ptr<std::string*>();
+
+            // If CPU Models are different, use the first entry in
+            // alphabetical order
+
+            // If Model has never been set
+            // before, set it to *modelStr
+            if (prevModelPtr == nullptr)
+            {
+                prevModel = *modelStr;
+            }
+            // If Model has been set before, only change if new Model is
+            // higher in alphabetical order
+            else
+            {
+                if (*modelStr < *prevModelPtr)
+                {
+                    prevModel = *modelStr;
+                }
+            }
+        }
+
+        if (property.first == "CoreCount")
+        {
+
+            // Get CPU CoreCount and add it to the total
+            const uint16_t* coreCountVal =
+                std::get_if<uint16_t>(&property.second);
+
+            if (!coreCountVal)
+            {
+                messages::internalError(aResp->res);
+                return;
+            }
+
+            nlohmann::json& coreCount =
+                aResp->res.jsonValue["ProcessorSummary"]["CoreCount"];
+            uint64_t* coreCountPtr = coreCount.get_ptr<uint64_t*>();
+
+            if (coreCountPtr == nullptr)
+            {
+                coreCount = 0;
+            }
+            else
+            {
+                *coreCountPtr += *coreCountVal;
+            }
+        }
+    }
+}
+
+/*
+ * @brief Get ProcessorSummary fields
+ *
+ * @param[in] aResp Shared pointer for completing asynchronous calls
+ * @param[in] service dbus service for Cpu Information
+ * @param[in] path dbus path for Cpu
+ *
+ * @return None.
+ */
+inline void getProcessorSummary(const std::shared_ptr<bmcweb::AsyncResp>& aResp,
+                                const std::string& service,
+                                const std::string& path)
+{
+
+    crow::connections::systemBus->async_method_call(
+        [aResp, service,
+         path](const boost::system::error_code ec2,
+               const std::vector<std::pair<
+                   std::string, std::variant<std::string, uint64_t, uint32_t,
+                                             uint16_t>>>& properties) {
+            if (ec2)
+            {
+                BMCWEB_LOG_ERROR << "DBUS response error " << ec2;
+                messages::internalError(aResp->res);
+                return;
+            }
+            getProcessorProperties(aResp, service, path, properties);
+        },
+        service, path, "org.freedesktop.DBus.Properties", "GetAll",
+        "xyz.openbmc_project.Inventory.Item.Cpu");
+}
+
+/*
  * @brief Retrieves computer system properties over dbus
  *
  * @param[in] aResp Shared pointer for completing asynchronous calls
@@ -311,158 +463,7 @@ inline void
                             BMCWEB_LOG_DEBUG
                                 << "Found Cpu, now get its properties.";
 
-                            auto getCpuPresenceState =
-                                [aResp](const boost::system::error_code ec2,
-                                        const std::variant<bool>&
-                                            cpuPresenceCheck) {
-                                    if (ec2)
-                                    {
-                                        BMCWEB_LOG_ERROR
-                                            << "DBUS response error " << ec2;
-                                        return;
-                                    }
-                                    modifyCpuPresenceState(aResp,
-                                                           cpuPresenceCheck);
-                                };
-
-                            auto getCpuFunctionalState =
-                                [aResp](const boost::system::error_code ec2,
-                                        const std::variant<bool>&
-                                            cpuFunctionalCheck) {
-                                    if (ec2)
-                                    {
-                                        BMCWEB_LOG_ERROR
-                                            << "DBUS response error " << ec2;
-                                        return;
-                                    }
-                                    modifyCpuFunctionalState(
-                                        aResp, cpuFunctionalCheck);
-                                };
-
-                            // Get the Presence of CPU
-                            crow::connections::systemBus->async_method_call(
-                                std::move(getCpuPresenceState),
-                                connection.first, path,
-                                "org.freedesktop.DBus."
-                                "Properties",
-                                "Get",
-                                "xyz.openbmc_project.Inventory."
-                                "Item",
-                                "Present");
-
-                            // Get the Functional State
-                            crow::connections::systemBus->async_method_call(
-                                std::move(getCpuFunctionalState),
-                                connection.first, path,
-                                "org.freedesktop.DBus."
-                                "Properties",
-                                "Get",
-                                "xyz.openbmc_project.State."
-                                "Decorator."
-                                "OperationalStatus",
-                                "Functional");
-
-                            crow::connections::systemBus->async_method_call(
-                                [aResp, service{connection.first},
-                                 path](const boost::system::error_code ec2,
-                                       const std::vector<std::pair<
-                                           std::string,
-                                           std::variant<std::string, uint64_t,
-                                                        uint32_t, uint16_t>>>&
-                                           properties) {
-                                    if (ec2)
-                                    {
-                                        BMCWEB_LOG_ERROR
-                                            << "DBUS response error " << ec2;
-                                        messages::internalError(aResp->res);
-                                        return;
-                                    }
-                                    BMCWEB_LOG_DEBUG << "Got "
-                                                     << properties.size()
-                                                     << " Cpu properties.";
-
-                                    for (const auto& property : properties)
-                                    {
-
-                                        if (property.first == "Family")
-                                        {
-                                            // Get the CPU Model
-                                            const std::string* modelStr =
-                                                std::get_if<std::string>(
-                                                    &property.second);
-                                            if (!modelStr)
-                                            {
-                                                messages::internalError(
-                                                    aResp->res);
-                                                return;
-                                            }
-                                            nlohmann::json& prevModel =
-                                                aResp->res.jsonValue
-                                                    ["ProcessorSummary"]
-                                                    ["Model"];
-                                            std::string* prevModelPtr =
-                                                prevModel
-                                                    .get_ptr<std::string*>();
-
-                                            // If CPU Models are different, use
-                                            // the first entry in alphabetical
-                                            // order
-
-                                            // If Model has never been set
-                                            // before, set it to *modelStr
-                                            if (prevModelPtr == nullptr)
-                                            {
-                                                prevModel = *modelStr;
-                                            }
-                                            // If Model has been set before,
-                                            // only change if new Model is
-                                            // higher in alphabetical order
-                                            else
-                                            {
-                                                if (*modelStr < *prevModelPtr)
-                                                {
-                                                    prevModel = *modelStr;
-                                                }
-                                            }
-                                        }
-
-                                        if (property.first == "CoreCount")
-                                        {
-
-                                            // Get CPU CoreCount and add it
-                                            // total
-                                            const uint16_t* coreCountVal =
-                                                std::get_if<uint16_t>(
-                                                    &property.second);
-
-                                            if (!coreCountVal)
-                                            {
-                                                messages::internalError(
-                                                    aResp->res);
-                                                return;
-                                            }
-
-                                            nlohmann::json& coreCount =
-                                                aResp->res.jsonValue
-                                                    ["ProcessorSummary"]
-                                                    ["CoreCount"];
-                                            uint64_t* coreCountPtr =
-                                                coreCount.get_ptr<uint64_t*>();
-
-                                            if (coreCountPtr == nullptr)
-                                            {
-                                                coreCount = *coreCountVal;
-                                            }
-                                            else
-                                            {
-                                                *coreCountPtr += *coreCountVal;
-                                            }
-                                        }
-                                    }
-                                },
-                                connection.first, path,
-                                "org.freedesktop.DBus.Properties", "GetAll",
-                                "xyz.openbmc_project.Inventory.Item.Cpu");
+                            getProcessorSummary(aResp, connection.first, path);
 
                             cpuHealth->inventory.emplace_back(path);
                         }


### PR DESCRIPTION
Upstream is https://gerrit.openbmc-project.xyz/c/openbmc/bmcweb/+/44564 but this also includes getting the model. 

This should no impact, just moves the code closer to what is upstream.

In Redfish ComputerSystem schema, the ProcessorSummary parameter
lists summary information of the Processors on the system. This commit
adds the 'Model' and 'CoreCount' properties to ProcessorSummary.

If the CPU Models are different, then the 'Model' field takes the first
entry in alphabetical order.

Testing:

1. Redfish Validator Testing successfully passed.
2. Curl testing:

curl -k -H "X-Auth-Token: $tok" https://$bmc/redfish/v1/Systems/system

...
  "ProcessorSummary": {
    "CoreCount": 24,
    "Count": 2,
    "Model": "test_name",
    "Status": {
      "Health": "OK",
      "HealthRollup": "OK",
      "State": "Disabled"
    }
  },
...

Signed-off-by: Ali Ahmed <ama213000@gmail.com>
Change-Id: Idda4f20bd1bb3f5002791ad20787979c632ed5f0