### PR TITLE
Redfish: Implement SNMP Trap

### DIFF
--- a/redfish-core/include/event_service_manager.hpp
+++ b/redfish-core/include/event_service_manager.hpp
@@ -587,6 +587,7 @@ class EventServiceManager
         initConfig();
     }
 
+    std::string snmpDbusId;
     std::string lastEventTStr;
     size_t noOfEventLogSubscribers{0};
     size_t noOfMetricReportSubscribers{0};
@@ -874,12 +875,20 @@ class EventServiceManager
         int retry = 3;
         while (retry)
         {
-            id = std::to_string(dist(gen));
-            if (gen.error())
+            if (!snmpDbusId.empty())
             {
-                retry = 0;
-                break;
+                id = snmpDbusId;
             }
+            else
+            {
+                id = std::to_string(dist(gen));
+                if (gen.error())
+                {
+                    retry = 0;
+                    break;
+                }
+            }
+
             auto inserted = subscriptionsMap.insert(std::pair(id, subValue));
             if (inserted.second)
             {
@@ -954,6 +963,11 @@ class EventServiceManager
             updateNoOfSubscribersCount();
             updateSubscriptionData();
         }
+    }
+
+    void setSnmpDbusId(const std::string& snmpId)
+    {
+        snmpDbusId = snmpId;
     }
 
     size_t getNumberOfSubscriptions()
@@ -1386,20 +1400,20 @@ class EventServiceManager
                              std::string& host, std::string& port,
                              std::string& path)
     {
-        // Validate URL using regex expression
-        // Format: <protocol>://<host>:<port>/<path>
-        // protocol: http/https
-        const std::regex urlRegex(
-            "(http|https)://([^/\\x20\\x3f\\x23\\x3a]+):?([0-9]*)(/"
-            "([^\\x20\\x23\\x3f]*\\x3f?([^\\x20\\x23\\x3f])*)?)");
-        std::cmatch match;
-        if (!std::regex_match(destUrl.c_str(), match, urlRegex))
+        boost::urls::error_code ec;
+        boost::urls::url_view urlview =
+            boost::urls::parse_uri(boost::string_view(destUrl.c_str()), ec);
+        if (ec)
         {
             BMCWEB_LOG_INFO << "Dest. url did not match ";
             return false;
         }
 
-        urlProto = std::string(match[1].first, match[1].second);
+        urlProto = std::string(urlview.scheme());
+        host = std::string(urlview.host());
+        port = std::string(urlview.port());
+        path = std::string(urlview.encoded_path());
+
         if (urlProto == "http")
         {
 #ifndef BMCWEB_INSECURE_ENABLE_HTTP_PUSH_STYLE_EVENTING
@@ -1407,9 +1421,6 @@ class EventServiceManager
 #endif
         }
 
-        host = std::string(match[2].first, match[2].second);
-        port = std::string(match[3].first, match[3].second);
-        path = std::string(match[4].first, match[4].second);
         if (port.empty())
         {
             if (urlProto == "http")

--- a/redfish-core/lib/event_service.hpp
+++ b/redfish-core/lib/event_service.hpp
@@ -43,6 +43,206 @@ static constexpr const std::array<const char*, 1> supportedResourceTypes = {
 
 static constexpr const uint8_t maxNoOfSubscriptions = 20;
 
+inline void
+    getSnmpTrapClientdata(const std::shared_ptr<bmcweb::AsyncResp>& asyncResp,
+                          const std::string& id, const std::string& objectPath)
+{
+    asyncResp->res.jsonValue = {
+        {"@odata.type", "#EventDestination.v1_7_0.EventDestination"},
+        {"Protocol", "SNMPv2c"}};
+    asyncResp->res.jsonValue["@odata.id"] =
+        "/redfish/v1/EventService/Subscriptions/" + id;
+    asyncResp->res.jsonValue["Id"] = id;
+    asyncResp->res.jsonValue["Name"] = "Event Destination " + id;
+
+    asyncResp->res.jsonValue["SubscriptionType"] = "SNMPTrap";
+    asyncResp->res.jsonValue["EventFormatType"] = "Event";
+
+    std::shared_ptr<Subscription> subValue =
+        EventServiceManager::getInstance().getSubscription(id);
+    if (subValue != nullptr)
+    {
+        asyncResp->res.jsonValue["Context"] = subValue->customText;
+    }
+    else
+    {
+        asyncResp->res.jsonValue["Context"] = "";
+    }
+
+    crow::connections::systemBus->async_method_call(
+        [asyncResp](
+            const boost::system::error_code ec,
+            const std::vector<
+                std::pair<std::string, std::variant<std::string, uint16_t>>>&
+                propertiesList) {
+            if (ec)
+            {
+                BMCWEB_LOG_ERROR << "D-Bus response error on GetSubTree " << ec;
+                messages::internalError(asyncResp->res);
+                return;
+            }
+
+            std::string address = "";
+            std::string port;
+
+            for (const std::pair<std::string,
+                                 std::variant<std::string, uint16_t>>&
+                     property : propertiesList)
+            {
+                const std::string& propertyName = property.first;
+
+                if (propertyName == "Address")
+                {
+                    const std::string* value =
+                        std::get_if<std::string>(&property.second);
+                    if (value == nullptr)
+                    {
+                        messages::internalError(asyncResp->res);
+                        return;
+                    }
+                    address = *value;
+                }
+                else if (propertyName == "Port")
+                {
+                    const uint16_t* value =
+                        std::get_if<uint16_t>(&property.second);
+                    if (value == nullptr)
+                    {
+                        messages::internalError(asyncResp->res);
+                        return;
+                    }
+                    port = std::to_string(*value);
+                }
+            }
+
+            if (address == "" || port == "")
+            {
+                messages::internalError(asyncResp->res);
+                return;
+            }
+
+            std::string destination = "snmp://";
+            destination.append(address);
+            destination.append(":");
+            destination.append(port);
+
+            asyncResp->res.jsonValue["Destination"] = std::move(destination);
+        },
+        "xyz.openbmc_project.Network.SNMP", objectPath,
+        "org.freedesktop.DBus.Properties", "GetAll",
+        "xyz.openbmc_project.Network.Client");
+}
+
+inline void
+    getSnmpTrapClient(const std::shared_ptr<bmcweb::AsyncResp>& asyncResp,
+                      const std::string& id)
+{
+    crow::connections::systemBus->async_method_call(
+        [asyncResp, id](const boost::system::error_code ec,
+                        dbus::utility::ManagedObjectType& resp) {
+            if (ec)
+            {
+                BMCWEB_LOG_ERROR << "D-Bus response error on GetManagedObjects "
+                                 << ec;
+                messages::internalError(asyncResp->res);
+                return;
+            }
+
+            bool foundSnmpClient = false;
+
+            for (const auto& objpath : resp)
+            {
+                sdbusplus::message::object_path path(objpath.first);
+                const std::string snmpId = path.filename();
+                if (snmpId.empty())
+                {
+                    BMCWEB_LOG_ERROR << "The SNMP client ID is wrong";
+                    messages::internalError(asyncResp->res);
+                    return;
+                }
+                const std::string subscriptionId = "snmp" + snmpId;
+                if (id != subscriptionId)
+                {
+                    continue;
+                }
+
+                foundSnmpClient = true;
+                getSnmpTrapClientdata(asyncResp, id, objpath.first);
+            }
+            if (foundSnmpClient == false)
+            {
+                messages::resourceNotFound(asyncResp->res, "Subscriptions", id);
+
+                EventServiceManager::getInstance().deleteSubscription(id);
+
+                return;
+            }
+        },
+        "xyz.openbmc_project.Network.SNMP",
+        "/xyz/openbmc_project/network/snmp/manager",
+        "org.freedesktop.DBus.ObjectManager", "GetManagedObjects");
+}
+
+inline void
+    createSnmpTrapClient(const std::shared_ptr<bmcweb::AsyncResp>& asyncResp,
+                         const std::string& host, const std::string& port,
+                         const std::string& destUrl,
+                         const std::shared_ptr<Subscription>& subValue)
+{
+    uint16_t snmpTrapPort = 0;
+    // Check the port
+    auto ret =
+        std::from_chars(port.c_str(), port.c_str() + port.size(), snmpTrapPort);
+    if (ret.ec != std::errc())
+    {
+        messages::propertyValueTypeError(asyncResp->res, destUrl,
+                                         "Destination");
+        return;
+    }
+
+    crow::connections::systemBus->async_method_call(
+        [asyncResp, subValue](const boost::system::error_code ec,
+                              const std::string& dbusSNMPid) {
+            if (ec)
+            {
+                messages::internalError(asyncResp->res);
+                return;
+            }
+
+            sdbusplus::message::object_path path(dbusSNMPid);
+            const std::string snmpId = path.filename();
+            if (snmpId.empty())
+            {
+                messages::internalError(asyncResp->res);
+                return;
+            }
+
+            const std::string subscriptionId =
+                "snmp" + http_helpers::urlEncode(snmpId);
+
+            EventServiceManager::getInstance().setSnmpDbusId(subscriptionId);
+            std::string id =
+                EventServiceManager::getInstance().addSubscription(subValue);
+
+            EventServiceManager::getInstance().setSnmpDbusId("");
+
+            if (id.empty())
+            {
+                messages::internalError(asyncResp->res);
+                return;
+            }
+
+            asyncResp->res.addHeader("Location",
+                                     "/redfish/v1/EventService/Subscriptions/" +
+                                         subscriptionId);
+            messages::created(asyncResp->res);
+        },
+        "xyz.openbmc_project.Network.SNMP",
+        "/xyz/openbmc_project/network/snmp/manager",
+        "xyz.openbmc_project.Network.Client.Create", "Client", host,
+        snmpTrapPort);
+}
+
 inline void requestRoutesEventService(App& app)
 {
     BMCWEB_ROUTE(app, "/redfish/v1/EventService/")
@@ -187,15 +387,53 @@ inline void requestRoutesEventDestinationCollection(App& app)
                 std::vector<std::string> subscripIds =
                     EventServiceManager::getInstance().getAllIDs();
                 memberArray = nlohmann::json::array();
-                asyncResp->res.jsonValue["Members@odata.count"] =
-                    subscripIds.size();
 
                 for (const std::string& id : subscripIds)
                 {
-                    memberArray.push_back(
-                        {{"@odata.id",
-                          "/redfish/v1/EventService/Subscriptions/" + id}});
+                    if (!boost::starts_with(id, "snmp"))
+                    {
+                        memberArray.push_back(
+                            {{"@odata.id",
+                              "/redfish/v1/EventService/Subscriptions/" + id}});
+                    }
                 }
+
+                crow::connections::systemBus->async_method_call(
+                    [asyncResp,
+                     &memberArray](const boost::system::error_code ec,
+                                   dbus::utility::ManagedObjectType& resp) {
+                        if (ec)
+                        {
+                            BMCWEB_LOG_ERROR
+                                << "D-Bus response error on GetManagedObjects "
+                                << ec;
+                            messages::internalError(asyncResp->res);
+                            return;
+                        }
+
+                        for (const auto& objpath : resp)
+                        {
+                            sdbusplus::message::object_path path(objpath.first);
+                            const std::string snmpId = path.filename();
+                            if (snmpId.empty())
+                            {
+                                BMCWEB_LOG_ERROR
+                                    << "The SNMP client ID is wrong";
+                                messages::internalError(asyncResp->res);
+                                return;
+                            }
+                            const std::string subscriptionId = "snmp" + snmpId;
+                            memberArray.push_back(
+                                {{"@odata.id",
+                                  "/redfish/v1/EventService/Subscriptions/" +
+                                      subscriptionId}});
+                            asyncResp->res.jsonValue["Members@odata.count"] =
+                                memberArray.size();
+                        }
+                    },
+                    "xyz.openbmc_project.Network.SNMP",
+                    "/xyz/openbmc_project/network/snmp/manager",
+                    "org.freedesktop.DBus.ObjectManager", "GetManagedObjects");
             });
     BMCWEB_ROUTE(app, "/redfish/v1/EventService/Subscriptions/")
         .privileges(redfish::privileges::postEventDestinationCollection)
@@ -211,6 +449,10 @@ inline void requestRoutesEventDestinationCollection(App& app)
 
                 std::string destUrl;
                 std::string protocol;
+                std::string uriProto;
+                std::string host;
+                std::string port;
+                std::string path;
                 std::optional<std::string> context;
                 std::optional<std::string> subscriptionType;
                 std::optional<std::string> eventFormatType2;
@@ -243,27 +485,22 @@ inline void requestRoutesEventDestinationCollection(App& app)
                     }
                 }
 
-                // Validate the URL using regex expression
-                // Format: <protocol>://<host>:<port>/<uri>
-                // protocol: http/https
-                // host: Exclude ' ', ':', '#', '?'
-                // port: Empty or numeric value with ':' separator.
-                // uri: Start with '/' and Exclude '#', ' '
-                //      Can include query params(ex: '/event?test=1')
-                // TODO: Need to validate hostname extensively(as per rfc)
-                const std::regex urlRegex(
-                    "(http|https)://([^/\\x20\\x3f\\x23\\x3a]+):?([0-9]*)(/"
-                    "([^\\x20\\x23\\x3f]*\\x3f?([^\\x20\\x23\\x3f])*)?)");
-                std::cmatch match;
-                if (!std::regex_match(destUrl.c_str(), match, urlRegex))
+                boost::urls::error_code ec;
+                boost::urls::url_view urlview = boost::urls::parse_uri(
+                    boost::string_view(destUrl.c_str()), ec);
+                if (ec)
                 {
+                    std::cerr << "Wrong url! Error:" << ec << "\n";
                     messages::propertyValueFormatError(asyncResp->res, destUrl,
                                                        "Destination");
                     return;
                 }
 
-                std::string uriProto =
-                    std::string(match[1].first, match[1].second);
+                uriProto = std::string(urlview.scheme());
+                host = std::string(urlview.host());
+                port = std::string(urlview.port());
+                path = std::string(urlview.encoded_path());
+
                 if (uriProto == "http")
                 {
 #ifndef BMCWEB_INSECURE_ENABLE_HTTP_PUSH_STYLE_EVENTING
@@ -273,14 +510,15 @@ inline void requestRoutesEventDestinationCollection(App& app)
 #endif
                 }
 
-                std::string host = std::string(match[2].first, match[2].second);
-                std::string port = std::string(match[3].first, match[3].second);
-                std::string path = std::string(match[4].first, match[4].second);
                 if (port.empty())
                 {
                     if (uriProto == "http")
                     {
                         port = "80";
+                    }
+                    else if (uriProto == "snmp")
+                    {
+                        port = "162";
                     }
                     else
                     {
@@ -299,7 +537,8 @@ inline void requestRoutesEventDestinationCollection(App& app)
 
                 if (subscriptionType)
                 {
-                    if (*subscriptionType != "RedfishEvent")
+                    if ((*subscriptionType != "RedfishEvent") &&
+                        (*subscriptionType != "SNMPTrap"))
                     {
                         messages::propertyValueNotInList(asyncResp->res,
                                                          *subscriptionType,
@@ -310,10 +549,17 @@ inline void requestRoutesEventDestinationCollection(App& app)
                 }
                 else
                 {
-                    subValue->subscriptionType = "RedfishEvent"; // Default
+                    if (protocol == "SNMPv2c")
+                    {
+                        subValue->subscriptionType = "SNMPTrap";
+                    }
+                    else
+                    {
+                        subValue->subscriptionType = "RedfishEvent"; // Default
+                    }
                 }
 
-                if (protocol != "Redfish")
+                if ((protocol != "Redfish") && (protocol != "SNMPv2c"))
                 {
                     messages::propertyValueNotInList(asyncResp->res, protocol,
                                                      "Protocol");
@@ -477,18 +723,28 @@ inline void requestRoutesEventDestinationCollection(App& app)
                     }
                 }
 
-                std::string id =
-                    EventServiceManager::getInstance().addSubscription(
-                        subValue);
-                if (id.empty())
+                if (protocol == "SNMPv2c")
                 {
-                    messages::internalError(asyncResp->res);
-                    return;
+                    // Create the snmp client
+                    createSnmpTrapClient(asyncResp, host, port, destUrl,
+                                         subValue);
                 }
+                else
+                {
+                    std::string id =
+                        EventServiceManager::getInstance().addSubscription(
+                            subValue);
+                    if (id.empty())
+                    {
+                        messages::internalError(asyncResp->res);
+                        return;
+                    }
 
-                messages::created(asyncResp->res);
-                asyncResp->res.addHeader(
-                    "Location", "/redfish/v1/EventService/Subscriptions/" + id);
+                    messages::created(asyncResp->res);
+                    asyncResp->res.addHeader(
+                        "Location",
+                        "/redfish/v1/EventService/Subscriptions/" + id);
+                }
             });
 }
 
@@ -500,6 +756,13 @@ inline void requestRoutesEventDestination(App& app)
             [](const crow::Request&,
                const std::shared_ptr<bmcweb::AsyncResp>& asyncResp,
                const std::string& param) {
+                if (boost::starts_with(param, "snmp"))
+                {
+                    const std::string& id = param;
+                    getSnmpTrapClient(asyncResp, id);
+                    return;
+                }
+
                 std::shared_ptr<Subscription> subValue =
                     EventServiceManager::getInstance().getSubscription(param);
                 if (subValue == nullptr)
@@ -513,7 +776,7 @@ inline void requestRoutesEventDestination(App& app)
                 asyncResp->res.jsonValue = {
                     {"@odata.type",
                      "#EventDestination.v1_7_0.EventDestination"},
-                    {"Protocol", "Redfish"}};
+                    {"Protocol", subValue->protocol}};
                 asyncResp->res.jsonValue["@odata.id"] =
                     "/redfish/v1/EventService/Subscriptions/" + id;
                 asyncResp->res.jsonValue["Id"] = id;
@@ -612,6 +875,44 @@ inline void requestRoutesEventDestination(App& app)
             [](const crow::Request&,
                const std::shared_ptr<bmcweb::AsyncResp>& asyncResp,
                const std::string& param) {
+                if (boost::starts_with(param, "snmp"))
+                {
+                    std::string_view snmpTrapId = param;
+
+                    // Erase "snmp" in the request to find the corresponding
+                    // dbus snmp client id. For example, the snmpid in the
+                    // request is "snmp1", which will be "1" after being erased.
+                    snmpTrapId = snmpTrapId.substr(4, snmpTrapId.length() - 4);
+
+                    const std::string snmpPath =
+                        "/xyz/openbmc_project/network/snmp/manager/" +
+                        std::string(snmpTrapId);
+
+                    crow::connections::systemBus->async_method_call(
+                        [asyncResp, param](const boost::system::error_code ec) {
+                            if (ec)
+                            {
+                                // The snmp trap id is incorrect
+                                if (ec.value() == EBADR)
+                                {
+                                    messages::resourceNotFound(
+                                        asyncResp->res, "Subscription", param);
+                                    return;
+                                }
+                                messages::internalError(asyncResp->res);
+                                return;
+                            }
+                            messages::success(asyncResp->res);
+                        },
+                        "xyz.openbmc_project.Network.SNMP", snmpPath,
+                        "xyz.openbmc_project.Object.Delete", "Delete");
+
+                    EventServiceManager::getInstance().deleteSubscription(
+                        param);
+
+                    return;
+                }
+
                 if (!EventServiceManager::getInstance().isSubscriptionExist(
                         param))
                 {


### PR DESCRIPTION
Implement SNMPTrap in EventDestination of Redfish. We can use
this Redfish interface to add/get/delete the SNMPTrap port and
destination address. When the error log is generated, phosphor-snmp
will send SNMPTrap messages to our configured SNMPTrap destination.

The MIB is here:
https://github.com/openbmc/phosphor-snmp/blob/master/mibs/NotificationMIB.txt

Refer:
https://www.dmtf.org/sites/default/files/standards/documents/DSP0268_2019.3.pdf

SNMPTrap test: Tested ok on the Witherspoon machine.
Steps are as follows:
1. Use this Redfish interface to configure the port and
   destination address:
   curl -k -H "X-Auth-Token: $token" -X POST   https://${bmc}/redfish/v1/EventService/Subscriptions   -d '{"Destination": "snmp://192.168.31.89:162", "SubscriptionType": "SNMPTrap", "Protocol": "SNMPv2c"}'
2. Run the SNMPTrap receiver tool in the destination
   computer(192.168.31.89),I used iReasoning MIB Browser as the
   SNMPTrap receiving tool.
3. Trigger error logs such as power supply AC Lost. We will see
   the error log under /xyz/openbmc_project/logging.
4. The SNMPTrap receiver tool in the destination computer received
   the SNMPTrap sent by OpenBMC.

Tested: Validator passes
1. Add snmp client:
        curl -k -H "X-Auth-Token: $token" -X POST   https://${bmc}/redfish/v1/EventService/Subscriptions   -d '{"Destination": "snmp://192.168.31.89:162", "SubscriptionType": "SNMPTrap", "Protocol": "SNMPv2c", "Context": "testContext"}'
        {
          "@Message.ExtendedInfo": [
            {
              "@odata.type": "#Message.v1_0_0.Message",
              "Message": "The resource has been created successfully",
              "MessageArgs": [],
              "MessageId": "Base.1.8.1.Created",
              "MessageSeverity": "OK",
              "Resolution": "None"
            }
          ]
        }
2. Get snmp trap client configurations:
curl -k -H "X-Auth-Token: $token" -X GET https://${bmc}/redfish/v1/EventService/Subscriptions/snmp1
{
  "@odata.id": "/redfish/v1/EventService/Subscriptions/snmp1",
  "@odata.type": "#EventDestination.v1_7_0.EventDestination",
  "Context": "testContext",
  "Destination": "snmp://192.168.31.89:162",
  "EventFormatType": "Event",
  "Id": "snmp1",
  "Name": "Event Destination snmp1",
  "Protocol": "SNMPv2c",
  "SubscriptionType": "SNMPTrap"
}

Reboot the BMC, and get the snmp trap client again:
curl -k -H "X-Auth-Token: $token" -X GET https://${bmc}/redfish/v1/EventService/Subscriptions/snmp1
{
  "@odata.id": "/redfish/v1/EventService/Subscriptions/snmp1",
  "@odata.type": "#EventDestination.v1_7_0.EventDestination",
  "Context": "testContext",
  "Destination": "snmp://192.168.31.89:162",
  "EventFormatType": "Event",
  "Id": "snmp1",
  "Name": "Event Destination snmp1",
  "Protocol": "SNMPv2c",
  "SubscriptionType": "SNMPTrap"
}

3. Delete snmp client:
curl -k -H "X-Auth-Token: $token" -X DELETE https://${bmc}/redfish/v1/EventService/Subscriptions/snmp1
{
  "@Message.ExtendedInfo": [
    {
      "@odata.type": "#Message.v1_1_1.Message",
      "Message": "Successfully Completed Request",
      "MessageArgs": [],
      "MessageId": "Base.1.8.1.Success",
      "MessageSeverity": "OK",
      "Resolution": "None"
    }
  ]
}
4. After we have added some SNMP clients using Redfish, we can see them in Dbus
busctl tree xyz.openbmc_project.Network.SNMP
`-/xyz
  `-/xyz/openbmc_project
    `-/xyz/openbmc_project/network
      `-/xyz/openbmc_project/network/snmp
        `-/xyz/openbmc_project/network/snmp/manager
          |-/xyz/openbmc_project/network/snmp/manager/1

busctl introspect xyz.openbmc_project.Network.SNMP
/xyz/openbmc_project/network/snmp/manager/1 xyz.openbmc_project.Network.Client
NAME                 TYPE      SIGNATURE RESULT/VALUE    FLAGS
.Address             property  s         "192.168.31.89" emits-change writable
.Port                property  q         162             emits-change writable

5. Use "busctl call" add client
busctl call xyz.openbmc_project.Network.SNMP /xyz/openbmc_project/network/snmp/manager xyz.openbmc_project.Network.Client.Create Client sq 192.168.31.90 162
s "/xyz/openbmc_project/network/snmp/manager/2"

We will see it use the redfish url:
curl -k -H "X-Auth-Token: $token" -X GET https://${bmc}/redfish/v1/EventService/Subscriptions/snmp2
{
  "@odata.id": "/redfish/v1/EventService/Subscriptions/snmp2",
  "@odata.type": "#EventDestination.v1_7_0.EventDestination",
  "Context": "",
  "Destination": "snmp://192.168.31.90:162",
  "EventFormatType": "Event",
  "Id": "snmp2",
  "Name": "Event Destination snmp2",
  "Protocol": "SNMPv2c",
  "SubscriptionType": "SNMPTrap"
}

6. Deleting snmp client using "busctl"
First, we use redfish to add some SNMP clients:
 curl -k -H "X-Auth-Token: $token" -X POST   https://${bmc}/redfish/v1/EventService/Subscriptions   -d '{"Destination": "snmp://192.168.31.90:162", "SubscriptionType": "SNMPTrap", "Protocol": "SNMPv2c",   "Context": "testContext0"}'
 curl -k -H "X-Auth-Token: $token" -X POST   https://${bmc}/redfish/v1/EventService/Subscriptions   -d '{"Destination": "snmp://192.168.31.91:162", "SubscriptionType": "SNMPTrap", "Protocol": "SNMPv2c", "Context": "testContext1"}'

Then we can use redfish to get the subscriptions:
 curl -k -H "X-Auth-Token: $token" -XGET https://${bmc}/redfish/v1/EventService/Subscriptions
 {
  "@odata.id": "/redfish/v1/EventService/Subscriptions",
  "@odata.type": "#EventDestinationCollection.EventDestinationCollection",
  "Members": [
    {
      "@odata.id": "/redfish/v1/EventService/Subscriptions/snmp1"
    },
    {
      "@odata.id": "/redfish/v1/EventService/Subscriptions/snmp2"
    }
  ],
  "Members@odata.count": 2,
  "Name": "Event Destination Collections"
 }

Now we use busctl to delete SNMP client 2:
 busctl call xyz.openbmc_project.Network.SNMP /xyz/openbmc_project/network/snmp/manager/2 xyz.openbmc_project.Object.Delete Delete

Then we won't see snmp2 in the subscriptions of redfish:
 curl -k -H "X-Auth-Token: $token" -XGET https://${bmc}/redfish/v1/EventService/Subscriptions
 {
  "@odata.id": "/redfish/v1/EventService/Subscriptions",
  "@odata.type": "#EventDestinationCollection.EventDestinationCollection",
  "Members": [
    {
      "@odata.id": "/redfish/v1/EventService/Subscriptions/snmp1"
    }
  ],
  "Members@odata.count": 1,
  "Name": "Event Destination Collections"
 }

Signed-off-by: Chicago Duan <duanzhijia01@inspur.com>
Change-Id: Ie589b3934ee749c7e0add35e3ed1b0b7e817c557