### PR TITLE
Added Hypervisor Serial Socket

### DIFF
--- a/include/obmc_hypervisor.hpp
+++ b/include/obmc_hypervisor.hpp
@@ -10,7 +10,7 @@
 
 namespace crow
 {
-namespace obmc_console
+namespace obmc_hypervisor
 {
 
 static std::unique_ptr<boost::asio::local::stream_protocol::socket> hostSocket;
@@ -116,7 +116,7 @@ inline void connectHandler(const boost::system::error_code& ec)
 
 inline void requestRoutes(App& app)
 {
-    BMCWEB_ROUTE(app, "/console0")
+    BMCWEB_ROUTE(app, "/console1")
         .privileges({{"ConfigureComponents", "ConfigureManager"}})
         .websocket()
         .onopen([](crow::websocket::Connection& conn,
@@ -126,7 +126,7 @@ inline void requestRoutes(App& app)
             sessions.insert(&conn);
             if (hostSocket == nullptr)
             {
-                const std::string consoleName("\0obmc-console", 13);
+                const std::string consoleName("\0obmc-console.hypervisor", 24);
                 boost::asio::local::stream_protocol::endpoint ep(consoleName);
 
                 hostSocket = std::make_unique<
@@ -153,5 +153,5 @@ inline void requestRoutes(App& app)
             doWrite();
         });
 }
-} // namespace obmc_console
+} // namespace obmc_hypervisor
 } // namespace crow

--- a/src/webserver_main.cpp
+++ b/src/webserver_main.cpp
@@ -14,6 +14,7 @@
 #include <kvm_websocket.hpp>
 #include <login_routes.hpp>
 #include <obmc_console.hpp>
+#include <obmc_hypervisor.hpp>
 #include <openbmc_dbus_rest.hpp>
 
 #ifdef BMCWEB_ENABLE_IBM_MANAGEMENT_CONSOLE
@@ -107,7 +108,7 @@ int main(int /*argc*/, char** /*argv*/)
 #endif
 
 #ifdef BMCWEB_ENABLE_HYPERVISOR_SERIAL_WEBSOCKET
-    crow::obmc_console::requestRoutesHypervisor(app);
+    crow::obmc_hypervisor::requestRoutes(app);
 #endif
 
 #ifdef BMCWEB_ENABLE_VM_WEBSOCKET


### PR DESCRIPTION
This commit adds `wss://${window.location.host}/console1` WebSocket
into bmcweb. it retrieves 'PHYP debug shell' info and displays
WebSocket data into WebUI using SOL (Serial over LAN) console.

'console1' read data from UNIX domain socket '@obmc-console.hypervisor'
and display it in WebUI.

Privilege set to {"ConfigureComponents", "ConfigureManager"}.
That mean only Administrator and Operator can retrieve console data.

Tested:
  configure UNIX domain socket '@obmc-console.hypervisor' with
  'wss://${window.location.host}/console0' (which currently use for
  retrieve 'host serial console data on SOL'). The test is successful,
  able to receive 'PHYP debug shell' data in SOL on WebUI.

This commit is create sparate session of obmc_hypervisor

Signed-off-by: Abhishek Patel <Abhishek.Patel@ibm.com>
Change-Id: Icece6ceddd0eeab8db7ebf1e5e863c22a59ae45f