### PR TITLE
OBMC_SHELL web-base_shell

### DIFF
--- a/http/obmc_shell.hpp
+++ b/http/obmc_shell.hpp
@@ -1,0 +1,245 @@
+#pragma once
+
+#include <pty.h>
+#include <pwd.h>
+#include <termios.h>
+
+#include <app.hpp>
+#include <boost/asio/posix/stream_descriptor.hpp>
+#include <boost/process/io.hpp>
+#include <websocket.hpp>
+
+#include <map>
+
+namespace crow
+{
+
+namespace obmc_shell
+{
+
+class Handler : public std::enable_shared_from_this<Handler>
+{
+  public:
+    Handler(crow::websocket::Connection* conn) :
+        session(conn), streamFileDescriptor(conn->getIoContext()),
+        doingWrite(false)
+    {}
+
+    ~Handler() = default;
+
+    void doClose()
+    {
+        streamFileDescriptor.close();
+
+        // boost::process::child::terminate uses SIGKILL, need to send SIGTERM
+        int rc = kill(pid, SIGKILL);
+        session = nullptr;
+        if (rc)
+        {
+            return;
+        }
+        waitpid(pid, nullptr, 0);
+    }
+
+    void connect()
+    {
+        pid = forkpty(&ttyFileDescriptor, nullptr, nullptr, nullptr);
+
+        if (pid == -1)
+        {
+            // ERROR
+            if (session)
+            {
+                session->close("Error creating ssh child process");
+            }
+            return;
+        }
+        if (pid == 0)
+        {
+            // CHILD
+
+            // sets the effective user ID
+            // as service user
+            bool isUidSet = false;
+            if (auto userName = session->getUserName(); !userName.empty())
+            {
+                if (struct passwd* pw = getpwnam(userName.c_str());
+                    pw != nullptr)
+                {
+                    int uidr = setuid(pw->pw_uid);
+                    if (!uidr)
+                    {
+                        isUidSet = true;
+                    }
+                    else
+                    {
+                        BMCWEB_LOG_ERROR << "sets service user failed Error: "
+                                         << uidr;
+                    }
+                }
+                else
+                {
+                    BMCWEB_LOG_ERROR << "getpwnam return null passwd";
+                }
+            }
+            else
+            {
+                BMCWEB_LOG_ERROR << "userName is empty";
+            }
+
+            // close connection unable to set
+            // setuid()
+            if (!isUidSet)
+            {
+                session->close("sets service user failed");
+                return;
+            }
+
+            // create /bin/sh chiled process
+            execl("/bin/sh", "/bin/sh", nullptr);
+            return;
+        }
+        if (pid > 0)
+        {
+            // PARENT
+
+            // for io operation assing file discriptor
+            // to boost stream_descriptor
+            streamFileDescriptor.assign(ttyFileDescriptor);
+            doWrite();
+            doRead();
+        }
+    }
+
+    void doWrite()
+    {
+        if (!session)
+        {
+            BMCWEB_LOG_DEBUG << "session is closed";
+            return;
+        }
+        if (doingWrite)
+        {
+            BMCWEB_LOG_DEBUG << "Already writing.  Bailing out";
+            return;
+        }
+
+        if (inputBuffer.empty())
+        {
+            BMCWEB_LOG_DEBUG << "inputBuffer empty.  Bailing out";
+            return;
+        }
+
+        doingWrite = true;
+        streamFileDescriptor.async_write_some(
+            boost::asio::buffer(inputBuffer.data(), inputBuffer.size()),
+            [this, self(shared_from_this())](boost::beast::error_code ec,
+                                             std::size_t bytesWritten) {
+                BMCWEB_LOG_DEBUG << "Wrote " << bytesWritten << "bytes";
+                doingWrite = false;
+                inputBuffer.erase(0, bytesWritten);
+                if (ec == boost::asio::error::eof)
+                {
+                    session->close("ssh socket port closed");
+                    return;
+                }
+                if (ec)
+                {
+                    session->close("Error in writing to processSSH port");
+                    BMCWEB_LOG_ERROR << "Error in ssh socket write " << ec;
+                    return;
+                }
+                doWrite();
+            });
+    }
+
+    void doRead()
+    {
+        if (!session)
+        {
+            BMCWEB_LOG_DEBUG << "session is closed";
+            return;
+        }
+        streamFileDescriptor.async_read_some(
+            boost::asio::buffer(outputBuffer.data(), outputBuffer.size()),
+            [this, self(shared_from_this())](
+                const boost::system::error_code& ec, std::size_t bytesRead) {
+                BMCWEB_LOG_DEBUG << "Read done.  Read " << bytesRead
+                                 << " bytes";
+                if (!session)
+                {
+                    BMCWEB_LOG_DEBUG << "session is closed";
+                    return;
+                }
+                if (ec)
+                {
+                    BMCWEB_LOG_ERROR << "Couldn't read from ssh port: " << ec;
+                    session->close("Error in connecting to ssh port");
+                    return;
+                }
+                std::string_view payload(outputBuffer.data(), bytesRead);
+                session->sendBinary(payload);
+                doRead();
+            });
+    }
+
+    // this has to public
+    std::string inputBuffer;
+
+  private:
+    crow::websocket::Connection* session;
+    boost::asio::posix::stream_descriptor streamFileDescriptor;
+    bool doingWrite;
+    int ttyFileDescriptor;
+    pid_t pid;
+
+    std::array<char, 4096> outputBuffer;
+};
+
+static std::map<crow::websocket::Connection*, std::shared_ptr<Handler>>
+    mapHandler;
+
+inline void requestRoutes(App& app)
+{
+    BMCWEB_ROUTE(app, "/bmc-console")
+        .privileges({{"ConfigureManager"}})
+        .websocket()
+        .onopen([](crow::websocket::Connection& conn,
+                   const std::shared_ptr<bmcweb::AsyncResp>&) {
+            BMCWEB_LOG_DEBUG << "Connection " << &conn << " opened";
+            if (auto it = mapHandler.find(&conn); it == mapHandler.end())
+            {
+                auto insertData =
+                    mapHandler.emplace(&conn, std::make_shared<Handler>(&conn));
+                if (std::get<bool>(insertData))
+                {
+                    std::get<0>(insertData)->second->connect();
+                }
+            }
+        })
+        .onclose(
+            [](crow::websocket::Connection& conn, const std::string& reason) {
+                BMCWEB_LOG_DEBUG << "bmc-shell console.onclose(reason = '"
+                                 << reason << "')";
+                if (auto it = mapHandler.find(&conn); it != mapHandler.end())
+                {
+                    it->second->doClose();
+                    mapHandler.erase(it);
+                }
+            })
+        .onmessage([]([[maybe_unused]] crow::websocket::Connection& conn,
+                      const std::string& data, [[maybe_unused]] bool isBinary) {
+            if (auto it = mapHandler.find(&conn); it != mapHandler.end())
+            {
+                it->second->inputBuffer += data;
+                it->second->doWrite();
+            }
+            else
+            {
+                BMCWEB_LOG_ERROR << "connection to webScoket not found";
+            }
+        });
+}
+
+} // namespace obmc_shell
+} // namespace crow

--- a/meson.build
+++ b/meson.build
@@ -65,6 +65,7 @@ feature_map = {
   'insecure-disable-ssl'            : '-DBMCWEB_INSECURE_DISABLE_SSL',
   'host-serial-socket'              : '-DBMCWEB_ENABLE_HOST_SERIAL_WEBSOCKET',
   'hypervisor-serial-socket'        : '-DBMCWEB_ENABLE_HYPERVISOR_SERIAL_WEBSOCKET',
+  'bmc-shell-socket'                : '-DBMCWEB_ENABLE_BMC_SHELL_WEBSOCKET',
   'ibm-management-console'          : '-DBMCWEB_ENABLE_IBM_MANAGEMENT_CONSOLE',
   'google-api'                      : '-DBMCWEB_ENABLE_GOOGLE_API',
   'kvm'                             : '-DBMCWEB_ENABLE_KVM' ,

--- a/meson_options.txt
+++ b/meson_options.txt
@@ -16,6 +16,7 @@ option('event-subscription', type : 'feature', value : 'enabled', description: '
 option('redfish', type : 'feature',value : 'enabled', description: 'Enable Redfish APIs.  Paths are under \'/redfish/v1/\'. See https://github.com/openbmc/bmcweb/blob/master/DEVELOPING.md#redfish.')
 option('host-serial-socket', type : 'feature', value : 'enabled', description : 'Enable host serial console WebSocket. Path is \'/console0\'.  See https://github.com/openbmc/docs/blob/master/console.md.')
 option('hypervisor-serial-socket', type : 'feature', value : 'disabled', description : 'Enable hypervisor serial console WebSocket. Path is \'/console1\'.')
+option('bmc-shell-socket', type : 'feature', value : 'disabled', description : 'Enable BMC command shell WebSocket, which makes it possible to access secure shell. Path is \'/bmc-console\'.')
 option('static-hosting', type : 'feature', value : 'enabled', description : 'Enable serving files from the \'/usr/share/www\' directory as paths under \'/\'.')
 option('redfish-bmc-journal', type : 'feature', value : 'disabled', description : 'Enable BMC journal access through Redfish. Paths are under \'/redfish/v1/Managers/bmc/LogServices/Journal\'.')
 option('redfish-cpu-log', type : 'feature', value : 'disabled', description : '''Enable CPU log service transactions through Redfish. Paths are under \'/redfish/v1/Systems/system/LogServices/Crashdump'.''')

--- a/src/webserver_main.cpp
+++ b/src/webserver_main.cpp
@@ -15,6 +15,7 @@
 #include <login_routes.hpp>
 #include <obmc_console.hpp>
 #include <obmc_hypervisor.hpp>
+#include <obmc_shell.hpp>
 #include <openbmc_dbus_rest.hpp>
 
 #ifdef BMCWEB_ENABLE_IBM_MANAGEMENT_CONSOLE
@@ -109,6 +110,10 @@ int main(int /*argc*/, char** /*argv*/)
 
 #ifdef BMCWEB_ENABLE_HYPERVISOR_SERIAL_WEBSOCKET
     crow::obmc_hypervisor::requestRoutes(app);
+#endif
+
+#ifdef BMCWEB_ENABLE_BMC_SHELL_WEBSOCKET
+    crow::obmc_shell::requestRoutes(app);
 #endif
 
 #ifdef BMCWEB_ENABLE_VM_WEBSOCKET


### PR DESCRIPTION
This commit includes a web-based shell, making it possible to access secure shell servers through standard web browsers using WebSocket. 

Path of WebSocket:
    wss://{hostname}/bmc-console

Implementation:

So when bmcweb WebSocket gets a request for a new connection, it creates a child process of bmcweb using "/bin/sh" via calling bp::Child, which is similar to call exec("/bin/sh").

bmcweb is communicating with that child process using async_pipe. So the shell can execute all commands like ls, cd, etc.

Here shell WebSocket only retrieves individual charactor at a time.

WebSocket gets 'l', 's', and '\n' three char separately for the ls command. So bmcweb buffer them and pass to the child's process when it gets '\n'. In return child process return the output of that command. Which bmcweb return to the WebSocket.

Authorize user for Shell :

Only service users can access this interface, which means only managers can access this interface.

Test:
This commit gets tested using the xterm.js console.

The essential operation can perform on this xterm console, Ex: ls, cd, grep, etc.

We can also execute the interactive command, like "top", but it doesn't perform well. Refresh time is slow, and the kill signal does not work using a terminal.

This change is downstream change only.