### PR TITLE
Increase the dump create task timer

### DIFF
--- a/redfish-core/lib/log_services.hpp
+++ b/redfish-core/lib/log_services.hpp
@@ -877,7 +877,7 @@ inline void createDumpTaskCallback(
             createdObjPath.str +
             "',arg0='xyz.openbmc_project.Common.Progress'");
 
-    task->startTimer(std::chrono::minutes(3));
+    task->startTimer(std::chrono::minutes(6));
     task->populateResp(asyncResp->res);
     task->payload.emplace(req);
 }


### PR DESCRIPTION
Currently, the task timer is set to 3 minutes to listen
for the dump completion status. But the bmc dumps are
taking a bit longer timer than 3 minutes (around 4 minutes)
during ipl and the task timer expires with the task state set
to cancelled. Hence, with this change, the task timer is doubled
to 6 minutes to avoid the task timer expiration.

Tested By:

Poweron the host
Initiate bmc dump
Get on the task for task status and the created dump URI
Task status - Completed

Fixes the defect:
https://w3.rchland.ibm.com/projects/bestquest/?defect=SW538120

Gerrit change:
https://gerrit.openbmc-project.xyz/c/openbmc/bmcweb/+/38954/58..59/redfish-core/lib/log_services.hpp#828

Signed-off-by: Asmitha Karunanithi <asmitk01@in.ibm.com>