### PR TITLE
redfish: disable ForceRestart support

### DIFF
--- a/redfish-core/lib/systems.hpp
+++ b/redfish-core/lib/systems.hpp
@@ -3164,12 +3164,6 @@ inline void requestRoutesSystemActionsReset(App& app)
                 command = "xyz.openbmc_project.State.Chassis.Transition.Off";
                 hostCommand = false;
             }
-            else if (resetType == "ForceRestart")
-            {
-                command =
-                    "xyz.openbmc_project.State.Host.Transition.ForceWarmReboot";
-                hostCommand = true;
-            }
             else if (resetType == "GracefulShutdown")
             {
                 command = "xyz.openbmc_project.State.Host.Transition.Off";

--- a/redfish-core/lib/systems.hpp
+++ b/redfish-core/lib/systems.hpp
@@ -3140,114 +3140,120 @@ inline void requestRoutesSystemActionsReset(App& app)
     BMCWEB_ROUTE(app,
                  "/redfish/v1/Systems/system/Actions/ComputerSystem.Reset/")
         .privileges(redfish::privileges::postComputerSystem)
-        .methods(
-            boost::beast::http::verb::
-                post)([](const crow::Request& req,
-                         const std::shared_ptr<bmcweb::AsyncResp>& asyncResp) {
-            std::string resetType;
-            if (!json_util::readJson(req, asyncResp->res, "ResetType",
-                                     resetType))
-            {
-                return;
-            }
+        .methods(boost::beast::http::verb::post)(
+            [](const crow::Request& req,
+               const std::shared_ptr<bmcweb::AsyncResp>& asyncResp) {
+                std::string resetType;
+                if (!json_util::readJson(req, asyncResp->res, "ResetType",
+                                         resetType))
+                {
+                    return;
+                }
 
-            // Get the command and host vs. chassis
-            std::string command;
-            bool hostCommand;
-            if ((resetType == "On") || (resetType == "ForceOn"))
-            {
-                command = "xyz.openbmc_project.State.Host.Transition.On";
-                hostCommand = true;
-            }
-            else if (resetType == "ForceOff")
-            {
-                command = "xyz.openbmc_project.State.Chassis.Transition.Off";
-                hostCommand = false;
-            }
-            else if (resetType == "GracefulShutdown")
-            {
-                command = "xyz.openbmc_project.State.Host.Transition.Off";
-                hostCommand = true;
-            }
-            else if (resetType == "GracefulRestart")
-            {
-                command = "xyz.openbmc_project.State.Host.Transition."
-                          "GracefulWarmReboot";
-                hostCommand = true;
-            }
-            else if (resetType == "PowerCycle")
-            {
-                command = "xyz.openbmc_project.State.Host.Transition.Reboot";
-                hostCommand = true;
-            }
-            else if (resetType == "Nmi")
-            {
-                doNMI(asyncResp);
-                return;
-            }
-            else
-            {
-                messages::actionParameterUnknown(asyncResp->res, "Reset",
-                                                 resetType);
-                return;
-            }
+                // Get the command and host vs. chassis
+                std::string command;
+                bool hostCommand;
+                if ((resetType == "On") || (resetType == "ForceOn"))
+                {
+                    command = "xyz.openbmc_project.State.Host.Transition.On";
+                    hostCommand = true;
+                }
+                else if (resetType == "ForceOff")
+                {
+                    command =
+                        "xyz.openbmc_project.State.Chassis.Transition.Off";
+                    hostCommand = false;
+                }
+                else if (resetType == "GracefulShutdown")
+                {
+                    command = "xyz.openbmc_project.State.Host.Transition.Off";
+                    hostCommand = true;
+                }
+                else if (resetType == "GracefulRestart")
+                {
+                    command = "xyz.openbmc_project.State.Host.Transition."
+                              "GracefulWarmReboot";
+                    hostCommand = true;
+                }
+                else if (resetType == "PowerCycle")
+                {
+                    command =
+                        "xyz.openbmc_project.State.Host.Transition.Reboot";
+                    hostCommand = true;
+                }
+                else if (resetType == "Nmi")
+                {
+                    doNMI(asyncResp);
+                    return;
+                }
+                else
+                {
+                    messages::actionParameterUnknown(asyncResp->res, "Reset",
+                                                     resetType);
+                    return;
+                }
 
-            if (hostCommand)
-            {
-                crow::connections::systemBus->async_method_call(
-                    [asyncResp, resetType](const boost::system::error_code ec) {
-                        if (ec)
-                        {
-                            BMCWEB_LOG_ERROR << "D-Bus responses error: " << ec;
-                            if (ec.value() ==
-                                boost::asio::error::invalid_argument)
+                if (hostCommand)
+                {
+                    crow::connections::systemBus->async_method_call(
+                        [asyncResp,
+                         resetType](const boost::system::error_code ec) {
+                            if (ec)
                             {
-                                messages::actionParameterNotSupported(
-                                    asyncResp->res, resetType, "Reset");
+                                BMCWEB_LOG_ERROR << "D-Bus responses error: "
+                                                 << ec;
+                                if (ec.value() ==
+                                    boost::asio::error::invalid_argument)
+                                {
+                                    messages::actionParameterNotSupported(
+                                        asyncResp->res, resetType, "Reset");
+                                }
+                                else
+                                {
+                                    messages::internalError(asyncResp->res);
+                                }
+                                return;
                             }
-                            else
+                            messages::success(asyncResp->res);
+                        },
+                        "xyz.openbmc_project.State.Host",
+                        "/xyz/openbmc_project/state/host0",
+                        "org.freedesktop.DBus.Properties", "Set",
+                        "xyz.openbmc_project.State.Host",
+                        "RequestedHostTransition",
+                        std::variant<std::string>{command});
+                }
+                else
+                {
+                    crow::connections::systemBus->async_method_call(
+                        [asyncResp,
+                         resetType](const boost::system::error_code ec) {
+                            if (ec)
                             {
-                                messages::internalError(asyncResp->res);
+                                BMCWEB_LOG_ERROR << "D-Bus responses error: "
+                                                 << ec;
+                                if (ec.value() ==
+                                    boost::asio::error::invalid_argument)
+                                {
+                                    messages::actionParameterNotSupported(
+                                        asyncResp->res, resetType, "Reset");
+                                }
+                                else
+                                {
+                                    messages::internalError(asyncResp->res);
+                                }
+                                return;
                             }
-                            return;
-                        }
-                        messages::success(asyncResp->res);
-                    },
-                    "xyz.openbmc_project.State.Host",
-                    "/xyz/openbmc_project/state/host0",
-                    "org.freedesktop.DBus.Properties", "Set",
-                    "xyz.openbmc_project.State.Host", "RequestedHostTransition",
-                    std::variant<std::string>{command});
-            }
-            else
-            {
-                crow::connections::systemBus->async_method_call(
-                    [asyncResp, resetType](const boost::system::error_code ec) {
-                        if (ec)
-                        {
-                            BMCWEB_LOG_ERROR << "D-Bus responses error: " << ec;
-                            if (ec.value() ==
-                                boost::asio::error::invalid_argument)
-                            {
-                                messages::actionParameterNotSupported(
-                                    asyncResp->res, resetType, "Reset");
-                            }
-                            else
-                            {
-                                messages::internalError(asyncResp->res);
-                            }
-                            return;
-                        }
-                        messages::success(asyncResp->res);
-                    },
-                    "xyz.openbmc_project.State.Chassis",
-                    "/xyz/openbmc_project/state/chassis0",
-                    "org.freedesktop.DBus.Properties", "Set",
-                    "xyz.openbmc_project.State.Chassis",
-                    "RequestedPowerTransition",
-                    std::variant<std::string>{command});
-            }
-        });
+                            messages::success(asyncResp->res);
+                        },
+                        "xyz.openbmc_project.State.Chassis",
+                        "/xyz/openbmc_project/state/chassis0",
+                        "org.freedesktop.DBus.Properties", "Set",
+                        "xyz.openbmc_project.State.Chassis",
+                        "RequestedPowerTransition",
+                        std::variant<std::string>{command});
+                }
+            });
 }
 
 /**

--- a/redfish-core/lib/systems.hpp
+++ b/redfish-core/lib/systems.hpp
@@ -3584,9 +3584,8 @@ inline void requestRoutesSystemResetActionInfo(App& app)
                        {"Required", true},
                        {"DataType", "String"},
                        {"AllowableValues",
-                        {"On", "ForceOff", "ForceOn", "ForceRestart",
-                         "GracefulRestart", "GracefulShutdown", "PowerCycle",
-                         "Nmi"}}}}}};
+                        {"On", "ForceOff", "ForceOn", "GracefulRestart",
+                         "GracefulShutdown", "PowerCycle", "Nmi"}}}}}};
             });
 }
 } // namespace redfish


### PR DESCRIPTION
Per recent internal team discussions, IBM will be disabling the
ForceRestart ResetType option. This is because the hypervisor firmware
on IBM based systems requires host reboots to always be graceful to
ensure certain BIOS settings are correctly set.

Tested:
curl -k -H "X-Auth-Token: $token" -X POST https://${bmc}/redfish/v1/Systems/system/Actions/ComputerSystem.Reset -d '{"ResetType": "ForceRestart"}'
{
  "error": {
    "@Message.ExtendedInfo": [
      {
        "@odata.type": "#Message.v1_1_1.Message",
        "Message": "The action Reset was submitted with the invalid parameter ForceRestart.",
        "MessageArgs": [
          "Reset",
          "ForceRestart"
        ],
        "MessageId": "Base.1.8.1.ActionParameterUnknown",
        "MessageSeverity": "Warning",
        "Resolution": "Correct the invalid parameter and resubmit the request if the operation failed."
      }
    ],
    "code": "Base.1.8.1.ActionParameterUnknown",
    "message": "The action Reset was submitted with the invalid parameter ForceRestart."
  }
}

Signed-off-by: Andrew Geissler <geissonator@yahoo.com>