### PR TITLE
Redfish: Remove powersupply asset error log

### DIFF
--- a/redfish-core/lib/power_supply.hpp
+++ b/redfish-core/lib/power_supply.hpp
@@ -19,8 +19,6 @@ inline void
                         propertiesList) {
             if (ec)
             {
-                BMCWEB_LOG_ERROR << "Can't get PowerSupply asset!";
-                messages::internalError(asyncResp->res);
                 return;
             }
             for (const std::pair<std::string, std::variant<std::string>>&


### PR DESCRIPTION
According to the discussion with @lkammath , if the powersupply does not have asset information, no error need be
reported because the mex power supply does not have asset information
on dbus.