### PR TITLE
Security: Stop Privilege Escalation 

### DIFF
--- a/redfish-core/lib/account_service.hpp
+++ b/redfish-core/lib/account_service.hpp
@@ -1986,15 +1986,22 @@ inline void requestAccountServiceRoutes(App& app)
             // their ConfigureSelf privilege does not apply.  In either
             // case, perform the authority check again without the user's
             // ConfigureSelf privilege.
-            if ((username != req.session->username))
+            Privileges effectiveUserPrivileges =
+                redfish::getUserPrivileges(req.userRole);
+            Privileges configureUsers = {"ConfigureUsers"};
+            bool userHasConfigureUsers =
+                effectiveUserPrivileges.isSupersetOf(configureUsers);
+            if (!userHasConfigureUsers)
             {
-                Privileges requiredPermissionsToChangeNonSelf = {
-                    {"ConfigureUsers"}};
-                Privileges effectiveUserPrivileges =
-                    redfish::getUserPrivileges(req.userRole);
 
-                if (!effectiveUserPrivileges.isSupersetOf(
-                        requiredPermissionsToChangeNonSelf))
+                // Can't modify other users
+                if (username != req.session->username)
+                {
+                    messages::insufficientPrivilege(asyncResp->res);
+                    return;
+                }
+                // Can't modify properties other than password
+                if (newUserName || enabled || roleId || locked)
                 {
                     messages::insufficientPrivilege(asyncResp->res);
                     return;

--- a/redfish-core/lib/account_service.hpp
+++ b/redfish-core/lib/account_service.hpp
@@ -2001,7 +2001,7 @@ inline void requestAccountServiceRoutes(App& app)
                     return;
                 }
                 // Can't modify properties other than password
-                if (newUserName || enabled || roleId || locked)
+                if (newUserName || enabled || roleId || locked || oem)
                 {
                     messages::insufficientPrivilege(asyncResp->res);
                     return;


### PR DESCRIPTION
Upstream is https://gerrit.openbmc-project.xyz/c/openbmc/bmcweb/+/48564

In Redfish spec, the Operator and Readonly group should only change
their own password using patch in ManagerAccount.
(because of their ConfigureSelf privilege).

Currently, they were able to change other properties like their RoleId.
This was introduced in
https://github.com/openbmc/bmcweb/commit/6c51eab135bb573c292d111170bc138b3a4b4eb0

https://www.dmtf.org/sites/default/files/standards/documents/DSP2046_2021.2.pdf

Test:
the 'xiao' is a Operator
~ curl -k -H "X-Auth-Token: $token" -X PATCH -d '{"RoleId":"ReadOnly"}'
https://${bmc}/redfish/v1/AccountService/Accounts/xiao
{
  "error": {
    "@Message.ExtendedInfo": [
      {
        "@odata.type": "#Message.v1_1_1.Message",
        "Message": "There are insufficient privileges for the account
or credentials associated with the current session to perform the
requested operation.",
        "MessageArgs": [],
        "MessageId": "Base.1.8.1.InsufficientPrivilege",
        "MessageSeverity": "Critical",
        "Resolution": "Either abandon the operation or change the
associated access rights and resubmit the request if the operation
failed."
      }
    ],
    "code": "Base.1.8.1.InsufficientPrivilege",
    "message": "There are insufficient privileges for the account or
credentials associated with the current session to perform the
requested operation."
  }
}%

Signed-off-by: Xiaochao Ma <maxiaochao@inspur.com>
Change-Id: Ifda85b944994354ac114858601511dceed29f907

Conflicts:
	redfish-core/lib/account_service.hpp