### PR TITLE
Redfish : Add USB code update Enable/Disable

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -88,6 +88,7 @@ feature_map = {
   #'vm-nbdproxy'                     : '-DBMCWEB_ENABLE_VM_NBDPROXY',
   'vm-websocket'                    : '-DBMCWEB_ENABLE_VM_WEBSOCKET',
   'ibm-lamp-test'                   : '-DBMCWEB_ENABLE_IBM_LAMP_TEST',
+  'ibm-usb-code-update'             : '-DBMCWEB_ENABLE_IBM_USB_CODE_UPDATE',
   'hw-isolation'                    : '-DBMCWEB_ENABLE_HW_ISOLATION',
 }
 

--- a/meson_options.txt
+++ b/meson_options.txt
@@ -31,6 +31,7 @@ option('mutual-tls-auth', type : 'feature', value : 'enabled', description : '''
 option('ibm-management-console', type : 'feature', value : 'disabled', description : 'Enable the IBM management console specific functionality. Paths are under \'/ibm/v1/\'')
 option('google-api', type : 'feature', value : 'disabled', description : 'Enable the Google specific functionality. Paths are under \'/google/v1/\'')
 option('ibm-lamp-test', type : 'feature', value : 'disabled', description : 'Enable the IBM lamp test functionality')
+option('ibm-usb-code-update', type : 'feature', value : 'disabled', description : 'Enable the USB code update functionality')
 option('http-body-limit', type: 'integer', min : 0, max : 512, value : 30, description : 'Specifies the http request body length limit')
 option('redfish-new-powersubsystem-thermalsubsystem', type : 'feature', value : 'disabled', description : 'Enable/disable the new PowerSubsystem, ThermalSubsystem, and all children schemas. This includes displaying all sensors in the SensorCollection. At a later date, this feature will be defaulted to enabled.')
 option('redfish-allow-deprecated-power-thermal', type : 'feature', value : 'enabled', description : 'Enable/disable the old Power / Thermal. The default condition is allowing the old Power / Thermal.')

--- a/redfish-core/lib/oem/ibm/usb_code_update.hpp
+++ b/redfish-core/lib/oem/ibm/usb_code_update.hpp
@@ -1,0 +1,153 @@
+#pragma once
+
+#include "async_resp.hpp"
+#include "dbus_utility.hpp"
+#include "redfish_util.hpp"
+
+#include <variant>
+
+namespace redfish
+{
+
+static constexpr const char* usbCodeUpdateObjectPath =
+    "/xyz/openbmc_project/control/service/phosphor_2dusb_2dcode_2dupdate";
+
+/**
+ * @brief Get the service name of the path
+ *
+ * @param[in] aResp     Shared pointer for generating response message.
+ * @param[in] path      The D-Bus Object path
+ * @param[in] handler   Call back
+ *
+ * @return None.
+ */
+template <typename Handler>
+inline void getServiceName(const std::shared_ptr<bmcweb::AsyncResp>& aResp,
+                           const std::string& path, Handler&& handler)
+{
+    // Map of service name to list of interfaces
+    using MapperServiceMap =
+        std::vector<std::pair<std::string, std::vector<std::string>>>;
+
+    // Map of object paths to MapperServiceMaps
+    using MapperGetSubTreeResponse =
+        std::vector<std::pair<std::string, MapperServiceMap>>;
+
+    crow::connections::systemBus->async_method_call(
+        [aResp, path,
+         handler{std::move(handler)}](const boost::system::error_code ec,
+                                      const MapperGetSubTreeResponse& subtree) {
+            std::string service{};
+            if (ec)
+            {
+                BMCWEB_LOG_ERROR << "DBUS response error, ec: " << ec.value();
+                messages::internalError(aResp->res);
+                return;
+            }
+
+            for (const auto& [objectPath, serviceMap] : subtree)
+            {
+                if (objectPath != path)
+                {
+                    continue;
+                }
+
+                if (serviceMap[0].first.empty() || serviceMap.size() != 1)
+                {
+                    BMCWEB_LOG_ERROR << "usb code update mapper error!";
+                    messages::internalError(aResp->res);
+                    return;
+                }
+
+                handler(serviceMap[0].first);
+                return;
+            }
+
+            BMCWEB_LOG_ERROR << "Can't find usb code update service!";
+            messages::internalError(aResp->res);
+            return;
+        },
+        "xyz.openbmc_project.ObjectMapper",
+        "/xyz/openbmc_project/object_mapper",
+        "xyz.openbmc_project.ObjectMapper", "GetSubTree",
+        "/xyz/openbmc_project", 0,
+        std::array<const char*, 1>{
+            "xyz.openbmc_project.Control.Service.Attributes"});
+}
+
+/**
+ * @brief Retrieves BMC USB code update state.
+ *
+ * @param[in] aResp     Shared pointer for generating response message.
+ *
+ * @return None.
+ */
+inline void
+    getUSBCodeUpdateState(const std::shared_ptr<bmcweb::AsyncResp>& aResp)
+{
+    BMCWEB_LOG_DEBUG << "Get USB code update state";
+    auto callback = [aResp](const std::string& service) {
+        crow::connections::systemBus->async_method_call(
+            [aResp](const boost::system::error_code ec,
+                    std::variant<bool>& usbCodeUpdateState) {
+                if (ec)
+                {
+                    BMCWEB_LOG_ERROR << "DBUS response error " << ec;
+                    messages::internalError(aResp->res);
+                    return;
+                }
+
+                const bool* usbCodeUpdateStatePtr =
+                    std::get_if<bool>(&usbCodeUpdateState);
+
+                if (!usbCodeUpdateStatePtr)
+                {
+                    BMCWEB_LOG_ERROR << "Can't get USB code update status!";
+                    messages::internalError(aResp->res);
+                    return;
+                }
+                aResp->res.jsonValue["Oem"]["IBM"]["@odata.type"] =
+                    "#OemManager.IBM";
+                aResp->res.jsonValue["Oem"]["IBM"]["@odata.id"] =
+                    "/redfish/v1/Managers/bmc#/Oem/IBM";
+                aResp->res.jsonValue["Oem"]["IBM"]["USBCodeUpdateEnabled"] =
+                    *usbCodeUpdateStatePtr;
+            },
+            service, usbCodeUpdateObjectPath, "org.freedesktop.DBus.Properties",
+            "Get", "xyz.openbmc_project.Control.Service.Attributes", "Enabled");
+    };
+    getServiceName(aResp, usbCodeUpdateObjectPath, std::move(callback));
+}
+
+/**
+ * @brief Sets BMC USB code update state.
+ *
+ * @param[in] aResp   Shared pointer for generating response message.
+ * @param[in] state   USB code update state from request.
+ *
+ * @return None.
+ */
+inline void
+    setUSBCodeUpdateState(const std::shared_ptr<bmcweb::AsyncResp>& aResp,
+                          const bool& state)
+{
+    BMCWEB_LOG_DEBUG << "Set USB code update status.";
+
+    auto callback = [aResp, state](const std::string& service) {
+        crow::connections::systemBus->async_method_call(
+            [aResp](const boost::system::error_code ec) {
+                if (ec)
+                {
+                    BMCWEB_LOG_ERROR
+                        << "Can't set USB code update status. Error: " << ec;
+                    messages::internalError(aResp->res);
+                    return;
+                }
+            },
+            service, usbCodeUpdateObjectPath, "org.freedesktop.DBus.Properties",
+            "Set", "xyz.openbmc_project.Control.Service.Attributes", "Enabled",
+            std::variant<bool>(state));
+    };
+    getServiceName(aResp, usbCodeUpdateObjectPath, std::move(callback));
+}
+} // namespace redfish

--- a/static/redfish/v1/JsonSchemas/OemManager/index.json
+++ b/static/redfish/v1/JsonSchemas/OemManager/index.json
@@ -291,6 +291,16 @@
                             "type": "null"
                         }
                     ]
+                },
+                "IBM": {
+                    "anyOf": [
+                        {
+                            "$ref": "#/definitions/IBM"
+                        },
+                        {
+                            "type": "null"
+                        }
+                    ]
                 }
             },
             "type": "object"
@@ -577,6 +587,32 @@
                     "description": "Input sensor reading for step.",
                     "longDescription": "Input sensor reading for step.",
                     "type": "number"
+                }
+            },
+            "type": "object"
+        },
+        "IBM": {
+            "additionalProperties": true,
+            "description": "Oem properties for IBM.",
+            "patternProperties": {
+                "^([a-zA-Z_][a-zA-Z0-9_]*)?@(odata|Redfish|Message)\\.[a-zA-Z_][a-zA-Z0-9_]*$": {
+                    "description": "This property shall specify a valid odata or Redfish property.",
+                    "type": [
+                        "array",
+                        "boolean",
+                        "integer",
+                        "number",
+                        "null",
+                        "object",
+                        "string"
+                    ]
+                }
+            },
+            "properties": {
+                "USBCodeUpdateEnabled": {
+                    "description": "An indication of whether the USB code update is enabled.",
+                    "longDescription": "An indication of whether the USB code update is enabled.",
+                    "type": "boolean"
                 }
             },
             "type": "object"

--- a/static/redfish/v1/schema/OemManager_v1.xml
+++ b/static/redfish/v1/schema/OemManager_v1.xml
@@ -26,8 +26,20 @@
                 <Annotation Term="OData.Description" String="OemManager Oem properties." />
                 <Annotation Term="OData.AutoExpand"/>
                 <Property Name="OpenBmc" Type="OemManager.OpenBmc"/>
+                <Property Name="IBM" Type="OemManager.IBM"/>
             </ComplexType>
 
+            <ComplexType Name="IBM" BaseType="Resource.OemObject">
+                <Annotation Term="OData.AdditionalProperties" Bool="true" />
+                <Annotation Term="OData.Description" String="Oem properties for IBM." />
+                <Annotation Term="OData.AutoExpand"/>
+                <Property Name="USBCodeUpdateEnabled" Type="Edm.Boolean" Nullable="false">
+                    <Annotation Term="OData.Permissions" EnumMember="OData.Permission/ReadWrite"/>
+                    <Annotation Term="OData.Description" String="An indication of whether the USB code update is enabled."/>
+                    <Annotation Term="OData.LongDescription" String="An indication of whether the USB code update is enabled."/>
+                </Property>
+            </ComplexType>
+            
             <ComplexType Name="OpenBmc" BaseType="Resource.OemObject">
                 <Annotation Term="OData.AdditionalProperties" Bool="true" />
                 <Annotation Term="OData.Description" String="Oem properties for OpenBmc." />


### PR DESCRIPTION
Implement USB code update Enable/Disable.
This is an OEM schema.

Tested: Validator no error
First, we need to pick this commit:
https://gerrit.openbmc-project.xyz/c/openbmc/service-config-manager/+/48780/5

1. Get USB code update state
curl -k -H "X-Auth-Token: $token" -X GET https://${bmc}/redfish/v1/Managers/bmc
{
  "@odata.id": "/redfish/v1/Managers/bmc",
  "@odata.type": "#Manager.v1_11_0.Manager",

  ...

  "Oem": {
    "@odata.id": "/redfish/v1/Managers/bmc#/Oem",
    "@odata.type": "#OemManager.Oem",
    "IBM": {
      "USBCodeUpdateEnabled": true
    },
    "OpenBmc": {
      "@odata.id": "/redfish/v1/Managers/bmc#/Oem/OpenBmc",
      "@odata.type": "#OemManager.OpenBmc",
      "Certificates": {
        "@odata.id": "/redfish/v1/Managers/bmc/Truststore/Certificates"
      }
    }
  },

  ...

2. Set disable USB code update
curl -k -H "X-Auth-Token: $token" -X PATCH
https://${bmc}/redfish/v1/Managers/bmc
-d '{"Oem":{"IBM":{"USBCodeUpdateEnabled": false}}}'

busctl get-property xyz.openbmc_project.Control.Service.Manager
/xyz/openbmc_project/control/service/phosphor_2dusb_2dcode_2dupdate
xyz.openbmc_project.Control.Service.Attributes Enabled
b false

3. Set enable USB code update
curl -k -H "X-Auth-Token: $token" -X PATCH
https://${bmc}/redfish/v1/Managers/bmc
-d '{"Oem":{"IBM":{"USBCodeUpdateEnabled": true}}}'

busctl get-property xyz.openbmc_project.Control.Service.Manager
/xyz/openbmc_project/control/service/phosphor_2dusb_2dcode_2dupdate
xyz.openbmc_project.Control.Service.Attributes Enabled
b true

Signed-off-by: Chicago Duan <duanzhijia01@inspur.com>