### PR TITLE
EventService: Fix the httpHeader initialization

### DIFF
--- a/http/http_client.hpp
+++ b/http/http_client.hpp
@@ -241,7 +241,8 @@ class HttpClient : public std::enable_shared_from_this<HttpClient>
             {
                 // The listener failed to receive the Sent-Event
                 BMCWEB_LOG_ERROR << "recvMessage() Listener Failed to "
-                                    "receive Sent-Event";
+                                    "receive Sent-Event. Header Response Code: "
+                                 << respCode;
                 self->state = ConnState::recvFailed;
                 self->handleConnState();
                 return;

--- a/redfish-core/lib/event_service.hpp
+++ b/redfish-core/lib/event_service.hpp
@@ -463,7 +463,6 @@ inline void requestRoutesEventDestinationCollection(App& app)
                 std::optional<std::vector<std::string>> resTypes;
                 std::optional<std::vector<nlohmann::json>> headers;
                 std::optional<std::vector<nlohmann::json>> mrdJsonArray;
-                boost::beast::http::fields httpHeaders;
 
                 if (!json_util::readJson(
                         req, asyncResp->res, "Destination", destUrl, "Context",
@@ -532,29 +531,8 @@ inline void requestRoutesEventDestinationCollection(App& app)
                     path = "/";
                 }
 
-                if (headers)
-                {
-                    for (const nlohmann::json& headerChunk : *headers)
-                    {
-                        for (const auto& item : headerChunk.items())
-                        {
-                            const std::string* value =
-                                item.value().get_ptr<const std::string*>();
-                            if (value == nullptr)
-                            {
-                                messages::propertyValueFormatError(
-                                    asyncResp->res, item.value().dump(2, true),
-                                    "HttpHeaders/" + item.key());
-                                return;
-                            }
-                            httpHeaders.set(item.key(), *value);
-                        }
-                    }
-                }
-
                 std::shared_ptr<Subscription> subValue =
-                    std::make_shared<Subscription>(host, port, path, uriProto,
-                                                   httpHeaders);
+                    std::make_shared<Subscription>(host, port, path, uriProto);
 
                 subValue->destinationUrl = destUrl;
 
@@ -617,7 +595,22 @@ inline void requestRoutesEventDestinationCollection(App& app)
 
                 if (headers)
                 {
-                    subValue->httpHeaders = httpHeaders;
+                    for (const nlohmann::json& headerChunk : *headers)
+                    {
+                        for (const auto& item : headerChunk.items())
+                        {
+                            const std::string* value =
+                                item.value().get_ptr<const std::string*>();
+                            if (value == nullptr)
+                            {
+                                messages::propertyValueFormatError(
+                                    asyncResp->res, item.value().dump(2, true),
+                                    "HttpHeaders/" + item.key());
+                                return;
+                            }
+                            subValue->httpHeaders.set(item.key(), *value);
+                        }
+                    }
                 }
 
                 if (regPrefixes)


### PR DESCRIPTION
When the BMC is rebooted, the persisted httpHeader was not
sent to the http client object. Thus the custom headers set
by the subscriber were not sent along with the events

This commit inititalizes the http client connection after the
custom headers are loaded to the subscriber after a BMC reset

Tested by:
 1. Create new subscription with http custom header and see events
    are received by the subscriber
 2. Reboot the BMC and check the further events are reported good

Signed-off-by: sunharis <sunharis@gfwa129.aus.stglabs.ibm.com>
Change-Id: I87295e7ed4d3d94786dead370351a69ec9ef1982