### PR TITLE
redfish-core: Processor: Fixed the processor object search

### DIFF
--- a/redfish-core/lib/processor.hpp
+++ b/redfish-core/lib/processor.hpp
@@ -1514,7 +1514,7 @@ inline void setProcessorObject(const std::shared_ptr<bmcweb::AsyncResp>& resp,
                 // Ignore any objects which don't end with our desired cpu name
                 sdbusplus::message::object_path path(objectPath);
                 std::string name = path.filename();
-                if (name.empty() || name != processorId)
+                if (name.empty() || !isProcObjectMatched(processorId, path))
                 {
                     continue;
                 }


### PR DESCRIPTION
- In this patch, added the DCM workaround to the processor
  PATCH request handler function which is missed early.

- Refer to "4b9628f" commit for the workaround details i.e the BMC
  inventory modeled the processor as DCM (Dual-Chip Module) package
  but, the Redfish doesn't support the DCM so added the workaround
  for that.

Tested:

- Without fix:
```
curl -k -H "X-Auth-Token: $bmc_token" -X PATCH \
https://${bmc}/redfish/v1/Systems/system/Processors/dcm0-cpu0 \
-d '{ "LocationIndicatorActive" : false }'

{
  "error": {
    "@Message.ExtendedInfo": [
      {
        "@odata.type": "#Message.v1_1_1.Message",
        "Message": "The requested resource of type \
                    #Processor.v1_12_0.Processor named dcm0-cpu0 \
                    was not found.",
        "MessageArgs": [
          "#Processor.v1_12_0.Processor",
          "dcm0-cpu0"
        ],
        "MessageId": "Base.1.8.1.ResourceNotFound",
        "MessageSeverity": "Critical",
        "Resolution": "Provide a valid resource identifier and \
                       resubmit the request."
      }
    ],
    "code": "Base.1.8.1.ResourceNotFound",
    "message": "The requested resource of type \
                #Processor.v1_12_0.Processor named dcm0-cpu0 \
                was not found."
  }
}
```

- With fix:
```
curl -k -H "X-Auth-Token: $bmc_token" -X PATCH \
https://${bmc}/redfish/v1/Systems/system/Processors/dcm0-cpu0 \
-d '{ "LocationIndicatorActive" : false }'
=> No errors
```