### PR TITLE
Fix buildtype=debug

### DIFF
--- a/include/dump_offload.hpp
+++ b/include/dump_offload.hpp
@@ -165,6 +165,16 @@ class Handler : public std::enable_shared_from_this<Handler>
                     return;
                 }
                 const uint64_t* dumpsize = std::get_if<uint64_t>(&size);
+                if (dumpsize == nullptr)
+                {
+                    BMCWEB_LOG_ERROR << "DBUS response error: Unable to get "
+                                        "the dump size value"
+                                     << ec;
+                    this->connection->sendStreamErrorStatus(
+                        boost::beast::http::status::internal_server_error);
+                    this->connection->close();
+                    return;
+                }
                 this->dumpSize = *dumpsize;
                 this->initiateOffload();
                 this->doConnect();

--- a/redfish-core/lib/environment_metrics.hpp
+++ b/redfish-core/lib/environment_metrics.hpp
@@ -347,6 +347,7 @@ inline void
                          << controlMode;
         messages::propertyValueNotInList(asyncResp->res, controlMode,
                                          "ControlMode");
+        return;
     }
 
     const std::array<std::string, 1> powerCapInterfaces = {


### PR DESCRIPTION
2 fixes here, both are legit potential bugs, especially the 2nd.

1)  Fix potential null pointer dereference
When building with buildtype=debug:
| ../git/include/dump_offload.hpp:168:34: error: potential nullreference]
|   168 |                 this->dumpSize = *dumpsize;
|       |
This has been a issue for a while.
Slack discussion here on this:
https://ibm-systems-power.slack.com/archives/C0Q6TQP5Z/p1635947639390400
I took this fix from https://github.ibm.com/openbmc/bmcweb/pull/89/files

2)  Bail if controlMode is invalid  
This error was introduced in #135
When buildtype=debug:
../lib/environment_metrics.hpp:354:52: error: 'powerCapEnable' may be used
uninitialized in this function [-Werror=maybe-uninitialized]
Add the return.

Tested: bmcweb builds with buildtype=debug. Did not do any further testing.
