### PR TITLE
Enabled deconfiguration reason support to the DIMM and Core and Few fixes

### DIFF
--- a/redfish-core/include/registries/openbmc_message_registry.hpp
+++ b/redfish-core/include/registries/openbmc_message_registry.hpp
@@ -29,7 +29,7 @@ const Header header = {
     "0.2.0",
     "OpenBMC",
 };
-constexpr std::array<MessageEntry, 189> registry = {
+constexpr std::array<MessageEntry, 190> registry = {
     MessageEntry{
         "ADDDCCorrectable",
         {
@@ -2430,6 +2430,17 @@ constexpr std::array<MessageEntry, 189> registry = {
             "%1 Voltage Regulator Overheated.",
             "Critical",
             "Critical",
+            1,
+            {"string"},
+            "None.",
+        }},
+    MessageEntry{
+        "HardwareIsolationReason",
+        {
+            "Indicates the condition that affects the health of this resource.",
+            "The reason for the resource isolation: %1",
+            "OK",
+            "OK",
             1,
             {"string"},
             "None.",

--- a/redfish-core/include/registries/openbmc_message_registry.hpp
+++ b/redfish-core/include/registries/openbmc_message_registry.hpp
@@ -563,6 +563,17 @@ constexpr std::array<MessageEntry, 190> registry = {
             {"string"},
             "None.",
         }},
+    MessageEntry{
+        "HardwareIsolationReason",
+        {
+            "Indicates the condition that affects the health of this resource.",
+            "The reason for the resource isolation: %1",
+            "OK",
+            "OK",
+            1,
+            {"string"},
+            "None.",
+        }},
     MessageEntry{"InvalidLoginAttempted",
                  {
                      "Indicates that a login was attempted on the specified "
@@ -2430,17 +2441,6 @@ constexpr std::array<MessageEntry, 190> registry = {
             "%1 Voltage Regulator Overheated.",
             "Critical",
             "Critical",
-            1,
-            {"string"},
-            "None.",
-        }},
-    MessageEntry{
-        "HardwareIsolationReason",
-        {
-            "Indicates the condition that affects the health of this resource.",
-            "The reason for the resource isolation: %1",
-            "OK",
-            "OK",
             1,
             {"string"},
             "None.",

--- a/redfish-core/include/utils/error_log_utils.hpp
+++ b/redfish-core/include/utils/error_log_utils.hpp
@@ -1,0 +1,83 @@
+#pragma once
+
+namespace redfish
+{
+namespace error_log_utils
+{
+
+/*
+ * @brief The helper API to set the Redfish error log URI in the given
+ *        Redfish property JSON path based on the Hidden property
+ *        which will be present in the given error log D-Bus object.
+ *
+ * @param[in] aResp - The redfish response to return.
+ * @param[in] errorLogObjPath - The error log D-Bus object path.
+ * @param[in] errorLogPropPath - The Redfish property json path to fill URI.
+ * @param[in] isLink - The boolean to add URI as a Redfish link.
+ *
+ * @return NULL
+ *
+ * @note The "isLink" parameter is used to add the URI as a link (i.e with
+ *       "@odata.id"). If passed as "false" then, the suffix will be added
+ *       as "/attachment" along with the URI.
+ */
+inline void setErrorLogUri(
+    const std::shared_ptr<bmcweb::AsyncResp>& aResp,
+    const sdbusplus::message::object_path& errorLogObjPath,
+    const nlohmann::json_pointer<nlohmann::json>& errorLogPropPath,
+    const bool isLink)
+{
+    // Get the Hidden Property
+    crow::connections::systemBus->async_method_call(
+        [aResp, errorLogObjPath, errorLogPropPath,
+         isLink](const boost::system::error_code ec,
+                 std::variant<bool>& hiddenProperty) {
+            if (ec)
+            {
+                BMCWEB_LOG_ERROR << "DBus response error [" << ec.value()
+                                 << " : " << ec.message()
+                                 << "] when tried to get the Hidden property "
+                                 << "from the given error log object "
+                                 << errorLogObjPath.str;
+                messages::internalError(aResp->res);
+                return;
+            }
+            bool* hiddenPropVal = std::get_if<bool>(&hiddenProperty);
+            if (hiddenPropVal == nullptr)
+            {
+                BMCWEB_LOG_ERROR << "Failed to get the Hidden property value "
+                                 << "from the given error log object "
+                                 << errorLogObjPath.str;
+                messages::internalError(aResp->res);
+                return;
+            }
+
+            std::string errLogUri{"/redfish/v1/Systems/system/LogServices/"};
+            if (*hiddenPropVal)
+            {
+                errLogUri.append("CELog/Entries/");
+            }
+            else
+            {
+                errLogUri.append("EventLog/Entries/");
+            }
+            errLogUri.append(errorLogObjPath.filename());
+
+            if (isLink)
+            {
+                aResp->res.jsonValue[errorLogPropPath] = {
+                    {"@odata.id", errLogUri}};
+            }
+            else
+            {
+                errLogUri.append("/attachment");
+                aResp->res.jsonValue[errorLogPropPath] = errLogUri;
+            }
+        },
+        "xyz.openbmc_project.Logging", errorLogObjPath.str,
+        "org.freedesktop.DBus.Properties", "Get",
+        "org.open_power.Logging.PEL.Entry", "Hidden");
+}
+
+} // namespace error_log_utils
+} // namespace redfish

--- a/redfish-core/include/utils/hw_isolation.hpp
+++ b/redfish-core/include/utils/hw_isolation.hpp
@@ -532,7 +532,7 @@ inline void
                                             << "from object: "
                                             << hwStatusEventObj;
                                         messages::internalError(aResp->res);
-                                        break;
+                                        return;
                                     }
 
                                     for (const auto& assoc : *associations)
@@ -561,7 +561,7 @@ inline void
                                             << "from object: "
                                             << hwStatusEventObj;
                                         messages::internalError(aResp->res);
-                                        break;
+                                        return;
                                     }
                                     condition["Timestamp"] =
                                         crow::utility::getDateTime(
@@ -580,7 +580,7 @@ inline void
                                             << "from object: "
                                             << hwStatusEventObj;
                                         messages::internalError(aResp->res);
-                                        break;
+                                        return;
                                     }
 
                                     const message_registries::Message* msgReg =
@@ -596,7 +596,7 @@ inline void
                                             << "message registry to add "
                                             << "in the condition";
                                         messages::internalError(aResp->res);
-                                        break;
+                                        return;
                                     }
 
                                     // Prepare MessageArgs as per defined in the
@@ -639,7 +639,7 @@ inline void
                                             << "from object: "
                                             << hwStatusEventObj;
                                         messages::internalError(aResp->res);
-                                        break;
+                                        return;
                                     }
 
                                     // we have only one condition
@@ -650,7 +650,7 @@ inline void
                                                      *severity))
                                     {
                                         // Failed to set the severity
-                                        break;
+                                        return;
                                     }
                                 }
                             }

--- a/redfish-core/include/utils/hw_isolation.hpp
+++ b/redfish-core/include/utils/hw_isolation.hpp
@@ -10,11 +10,6 @@ namespace redfish
 namespace hw_isolation_utils
 {
 
-using AssociationsValType =
-    std::vector<std::tuple<std::string, std::string, std::string>>;
-using HwStausEventPropertiesType = boost::container::flat_map<
-    std::string, std::variant<std::string, uint64_t, AssociationsValType>>;
-
 /**
  * @brief API used to isolate the given resource
  *
@@ -433,6 +428,13 @@ inline void
                         messages::internalError(aResp->res);
                         return;
                     }
+
+                    using AssociationsValType = std::vector<
+                        std::tuple<std::string, std::string, std::string>>;
+                    using HwStausEventPropertiesType =
+                        boost::container::flat_map<
+                            std::string, std::variant<std::string, uint64_t,
+                                                      AssociationsValType>>;
 
                     // Get event properties and fill into status conditions
                     crow::connections::systemBus->async_method_call(

--- a/redfish-core/lib/log_services.hpp
+++ b/redfish-core/lib/log_services.hpp
@@ -4792,9 +4792,12 @@ inline void fillSystemHardwareIsolationLogEntry(
                             sdbusplus::message::object_path errPath =
                                 std::get<2>(assoc);
 
+                            // Set error log uri based on the error log hidden
+                            // property
                             if (entryJsonIdx > 0)
                             {
-                                auto errorLogPropPath = "/Members"_json_pointer;
+                                nlohmann::json_pointer errorLogPropPath =
+                                    "/Members"_json_pointer;
                                 errorLogPropPath /= entryJsonIdx - 1;
                                 errorLogPropPath /= "AdditionalDataURI";
                                 error_log_utils::setErrorLogUri(

--- a/redfish-core/lib/log_services.hpp
+++ b/redfish-core/lib/log_services.hpp
@@ -4862,6 +4862,13 @@ inline void getSystemHardwareIsolationLogEntryCollection(
         for (auto dbusObjIt = mgtObjs.begin(); dbusObjIt != mgtObjs.end();
              dbusObjIt++)
         {
+            if (dbusObjIt->second.find(
+                    "xyz.openbmc_project.HardwareIsolation.Entry") ==
+                dbusObjIt->second.end())
+            {
+                // The retrieved object is not hardware isolation entry
+                continue;
+            }
             entriesArray.push_back(nlohmann::json::object());
 
             fillSystemHardwareIsolationLogEntry(asyncResp, entriesArray.size(),

--- a/redfish-core/lib/log_services.hpp
+++ b/redfish-core/lib/log_services.hpp
@@ -33,6 +33,7 @@
 #include <boost/system/linux_error.hpp>
 #include <error_messages.hpp>
 #include <registries/privilege_registry.hpp>
+#include <utils/error_log_utils.hpp>
 
 #include <charconv>
 #include <filesystem>
@@ -4790,10 +4791,22 @@ inline void fillSystemHardwareIsolationLogEntry(
                         {
                             sdbusplus::message::object_path errPath =
                                 std::get<2>(assoc);
-                            entryJson["AdditionalDataURI"] =
-                                "/redfish/v1/Systems/system/"
-                                "LogServices/EventLog/Entries/" +
-                                errPath.filename() + "/attachment";
+
+                            if (entryJsonIdx > 0)
+                            {
+                                auto errorLogPropPath = "/Members"_json_pointer;
+                                errorLogPropPath /= entryJsonIdx - 1;
+                                errorLogPropPath /= "AdditionalDataURI";
+                                error_log_utils::setErrorLogUri(
+                                    asyncResp, errPath, errorLogPropPath,
+                                    false);
+                            }
+                            else
+                            {
+                                error_log_utils::setErrorLogUri(
+                                    asyncResp, errPath,
+                                    "/AdditionalDataURI"_json_pointer, false);
+                            }
                         }
                     }
                 }

--- a/redfish-core/lib/memory.hpp
+++ b/redfish-core/lib/memory.hpp
@@ -460,8 +460,9 @@ inline void getDimmDataByService(std::shared_ptr<bmcweb::AsyncResp> aResp,
 {
     BMCWEB_LOG_DEBUG << "Get available system components.";
     crow::connections::systemBus->async_method_call(
-        [dimmId, aResp{std::move(aResp)}](const boost::system::error_code ec,
-                                          const DimmProperties& properties) {
+        [dimmId, aResp{std::move(aResp)},
+         objPath](const boost::system::error_code ec,
+                  const DimmProperties& properties) {
             if (ec)
             {
                 BMCWEB_LOG_DEBUG << "DBUS response error";
@@ -752,6 +753,11 @@ inline void getDimmDataByService(std::shared_ptr<bmcweb::AsyncResp> aResp,
                     getPersistentMemoryProperties(aResp, properties);
                 }
             }
+
+#ifdef BMCWEB_ENABLE_HW_ISOLATION
+            // Check for the hardware status event
+            hw_isolation_utils::getHwIsolationStatus(aResp, objPath);
+#endif // end of BMCWEB_ENABLE_HW_ISOLATION
         },
         service, objPath, "org.freedesktop.DBus.Properties", "GetAll", "");
 }

--- a/redfish-core/lib/processor.hpp
+++ b/redfish-core/lib/processor.hpp
@@ -1071,6 +1071,11 @@ inline void
                         aResp->res.jsonValue["Status"]["Health"] = "Critical";
                     }
                 }
+
+#ifdef BMCWEB_ENABLE_HW_ISOLATION
+                // Check for the hardware status event
+                hw_isolation_utils::getHwIsolationStatus(aResp, objPath);
+#endif // end of BMCWEB_ENABLE_HW_ISOLATION
             }
         },
         service, "/xyz/openbmc_project/inventory",


### PR DESCRIPTION
This is downstream changes (no Gerrit links for the added patches)

Below are Changes included in this PR:
- **LogServices: HardwareIsolation: Fixed the "AdditionalDataURI"**
  - In the IBM platform system, recently the error entries are listed in the two different Redfish URI as mentioned below.
    - /redfish/v1/Systems/system/LogServices/EventLog/Entries/N
    - /redfish/v1/Systems/system/LogServices/CELog/Entries/N
  - But, the HardwareIsolation LogEntry "AdditionalDataURI" property (which is used to point the associated error log entry) using the old link i.e "EventLog" so if the user tried to access the hidden error log through that property then, that won't work so fixed that issue in this PR.
- **LogServices: HardwareIsolation: Fixed the LogEntryCollection**
  - Recently, the hardware isolation D-Bus service is modified to host another type of D-Bus object i.e Logging::Event so the HardwareIsolation LogEntryCollection returns all types of the object (aka resource or entry) instead of returning only the HardwareIsolation entries.

- **redfish-core: Memory & Core: Enabled the deconfiguration reason**
  - **Requirement**: In the IBM system platforms, we need to tell the reason and additional information to the external system user if any of DIMM or Core is not functional or whether is isolated from the system boot or is pending to isolate in the system.
