### PR TITLE
Util api to fetch pretty name for assemblies

### DIFF
--- a/redfish-core/lib/assembly.hpp
+++ b/redfish-core/lib/assembly.hpp
@@ -3,6 +3,7 @@
 #include "led.hpp"
 
 #include <utils/json_utils.hpp>
+#include <utils/name_utils.hpp>
 
 #include <variant>
 
@@ -57,6 +58,11 @@ inline void
                     messages::internalError(aResp->res);
                     return;
                 }
+
+                nlohmann::json_pointer<nlohmann::json> ptr(
+                    "/Assemblies/" + std::to_string(assemblyIndex) + "/Name");
+
+                name_util::getPrettyName(aResp, assembly, object, ptr);
 
                 for (const auto& [serviceName, interfaceList] : object)
                 {


### PR DESCRIPTION
This commit implements change to use util api to fetch
prettyName property for any given assembly and publish
it as "Name" in assembly schema.

In case prettyName is blank for that FRU, then last part
of the object path will be used to populate assembly name.

Validator executed with no new errors.

Sample Output:
curl -k -H "X-Auth-Token: $bmc_token" -X GET https://${bmc}/redfish/v1/Chassis/chassis/Assembly/
{
  "@odata.id": "/redfish/v1/Chassis/chassis/Assembly",
  "@odata.type": "#Assembly.v1_3_0.Assembly",
  "Assemblies": [
    {
      "@odata.id": "/redfish/v1/Chassis/chassis/Assembly#/Assemblies/0",
      "@odata.type": "#Assembly.v1_3_0.AssemblyData",
      "Location": {
        "PartLocation": {
          "ServiceLabel": "U78DB.ND0.WZS000B-P0"
        }
      },
      "LocationIndicatorActive": false,
      "MemberId": "0",
      "Model": "2E2F",
      "Name": "SYSTEM BACKPLANE",
      "PartNumber": "02WG656",
      "SerialNumber": "Y132UF0AZ003",
      "SparePartNumber": "02WG655"
    },
    {
      "@odata.id": "/redfish/v1/Chassis/chassis/Assembly#/Assemblies/1",
      "@odata.type": "#Assembly.v1_3_0.AssemblyData",
      "Location": {
        "PartLocation": {
          "ServiceLabel": "U78DB.ND0.WZS000B-D0"
        }
      },
      "LocationIndicatorActive": false,
      "MemberId": "1",
      "Model": "6B85",
      "Name": "CEC OP PANEL    ",
      "PartNumber": "02WF427",
      "SerialNumber": "YA30UF09S00X",
      "SparePartNumber": "02PX028"
    },
    {
      "@odata.id": "/redfish/v1/Chassis/chassis/Assembly#/Assemblies/2",
      "@odata.type": "#Assembly.v1_3_0.AssemblyData",
      "Location": {
        "PartLocation": {
          "ServiceLabel": "U78DB.ND0.WZS000B-P1"
        }
      },
      "LocationIndicatorActive": false,
      "MemberId": "2",
      "Model": "6B89",
      "Name": "NVME   BACKPLANE",
      "PartNumber": "02WG682",
      "SerialNumber": "YA31UF09P00T",
      "SparePartNumber": "02WG681"
    },
    {
      "@odata.id": "/redfish/v1/Chassis/chassis/Assembly#/Assemblies/3",
      "@odata.type": "#Assembly.v1_3_0.AssemblyData",
      "Location": {
        "PartLocation": {
          "ServiceLabel": "U78DB.ND0.WZS000B-P2"
        }
      },
      "LocationIndicatorActive": false,
      "MemberId": "3",
      "Name": "disk_backplane1"
    },
    {
      "@odata.id": "/redfish/v1/Chassis/chassis/Assembly#/Assemblies/4",
      "@odata.type": "#Assembly.v1_3_0.AssemblyData",
      "Location": {
        "PartLocation": {
          "ServiceLabel": "U78DB.ND0.WZS000B-P3"
        }
      },
      "LocationIndicatorActive": false,
      "MemberId": "4",
      "Name": "disk_backplane2"
    },
    {
      "@odata.id": "/redfish/v1/Chassis/chassis/Assembly#/Assemblies/5",
      "@odata.type": "#Assembly.v1_3_0.AssemblyData",
      "Location": {
        "PartLocation": {
          "ServiceLabel": "U78DB.ND0.WZS000B-D1"
        }
      },
      "LocationIndicatorActive": false,
      "MemberId": "5",
      "Model": "6B86",
      "Name": "CEC OP PANEL LCD",
      "PartNumber": "02WF364",
      "SerialNumber": "YA30UF09S007",
      "SparePartNumber": "02WF367"
    },
    {
      "@odata.id": "/redfish/v1/Chassis/chassis/Assembly#/Assemblies/6",
      "@odata.type": "#Assembly.v1_3_0.AssemblyData",
      "Location": {
        "PartLocation": {
          "ServiceLabel": "U78DB.ND0.WZS000B-P0-E0"
        }
      },
      "LocationIndicatorActive": false,
      "MemberId": "6",
      "Model": "2E2F",
      "Name": "SYSTEM BACKPLANE",
      "PartNumber": "02WG656",
      "SerialNumber": "Y132UF0AZ003",
      "SparePartNumber": "02WG655"
    },
    {
      "@odata.id": "/redfish/v1/Chassis/chassis/Assembly#/Assemblies/7",
      "@odata.type": "#Assembly.v1_3_0.AssemblyData",
      "Location": {
        "PartLocation": {
          "ServiceLabel": "U78DB.ND0.WZS000B-P0-C22"
        }
      },
      "LocationIndicatorActive": false,
      "MemberId": "7",
      "Model": "6B59",
      "Name": "TPM CARD        ",
      "PartNumber": "02WF338",
      "SerialNumber": "Y131UF09S00H",
      "SparePartNumber": "02WF429"
    },
    {
      "@odata.id": "/redfish/v1/Chassis/chassis/Assembly#/Assemblies/8",
      "@odata.type": "#Assembly.v1_3_0.AssemblyData",
      "Location": {
        "PartLocation": {
          "ServiceLabel": "U78DB.ND0.WZS000B-P0-C14"
        }
      },
      "LocationIndicatorActive": false,
      "MemberId": "8",
      "Model": "2E32",
      "Name": "CPU POWER CARD  ",
      "PartNumber": "02CM286",
      "SerialNumber": "YH30A005M12F",
      "SparePartNumber": "02CM285"
    },
    {
      "@odata.id": "/redfish/v1/Chassis/chassis/Assembly#/Assemblies/9",
      "@odata.type": "#Assembly.v1_3_0.AssemblyData",
      "Location": {
        "PartLocation": {
          "ServiceLabel": "U78DB.ND0.WZS000B-P0-C23"
        }
      },
      "LocationIndicatorActive": false,
      "MemberId": "9",
      "Model": "2E32",
      "Name": "CPU POWER CARD  ",
      "PartNumber": "02CM286",
      "SerialNumber": "YH30A005M14K",
      "SparePartNumber": "02CM285"
    }
  ],
  "Assemblies@odata.count": 10,
  "Id": "Assembly",
  "Name": "Assembly Collection"
}

Signed-off-by: Sunny Srivastava <sunnsr25@in.ibm.com>