### PR TITLE
Fix for not showing PowerSupplies schema under chassis

### DIFF
--- a/redfish-core/include/redfish.hpp
+++ b/redfish-core/include/redfish.hpp
@@ -86,9 +86,6 @@ class RedfishService
 #ifdef BMCWEB_NEW_POWERSUBSYSTEM_THERMALSUBSYSTEM
         requestRoutesThermalSubsystem(app);
         requestRoutesThermalMetrics(app);
-        requestRoutesPowerSubsystem(app);
-        requestRoutesPowerSupplyCollection(app);
-        requestRoutesPowerSupply(app);
 #endif
         requestRoutesManagerCollection(app);
         requestRoutesFan(app);
@@ -97,6 +94,9 @@ class RedfishService
         requestRoutesManagerResetAction(app);
         requestRoutesManagerResetActionInfo(app);
         requestRoutesManagerResetToDefaultsAction(app);
+        requestRoutesPowerSubsystem(app);
+        requestRoutesPowerSupplyCollection(app);
+        requestRoutesPowerSupply(app);
         requestRoutesPCIeSlots(app);
         requestRoutesEnvironmentMetrics(app);
         requestRoutesChassisCollection(app);


### PR DESCRIPTION
Signed-off-by: Lakshminarayana R. Kammath <lkammath@in.ibm.com>
#166 introduced regression which caused to not show PS schema under chassis because all was moved under macro BMCWEB_NEW_POWERSUBSYSTEM_THERMALSUBSYSTEM. 

needed to build bmcweb with BMCWEB_NEW_POWERSUBSYSTEM_THERMALSUBSYSTEM and rainier is not doing same so, moving back to original place