### PR TITLE
HMC-BMC: SSLHandshakeException fix

### DIFF
--- a/http/http_connection.hpp
+++ b/http/http_connection.hpp
@@ -300,6 +300,10 @@ class Connection :
                                         const boost::system::error_code& ec) {
                                         if (ec)
                                         {
+                                            BMCWEB_LOG_ERROR
+                                                << this
+                                                << "async_handshake failed: "
+                                                << ec.message();
                                             return;
                                         }
                                         doReadHeaders();

--- a/http/timer_queue.hpp
+++ b/http/timer_queue.hpp
@@ -15,7 +15,7 @@ constexpr const size_t timerQueueTimeoutSeconds = 5;
 namespace detail
 {
 
-constexpr const size_t maxSize = 100;
+constexpr const size_t maxSize = 300;
 // fast timer queue for fixed tick value.
 class TimerQueue
 {
@@ -43,6 +43,7 @@ class TimerQueue
     {
         if (dq.size() == maxSize)
         {
+            BMCWEB_LOG_ERROR << "timer add: dq.size has hit maxSize";
             return std::nullopt;
         }
 


### PR DESCRIPTION
During the system boot, huge request-reponse exchange between the
managemenet console and BMC intermittently causes the queue overflow
resulting in closing the tcp socket used for the communication.
The re-attempt requests and the other requests in flight gets SSL PeerShutdown
error and following requests in the queue will hit the SSL handshake
exception
This situation automatically recovers after the timer gets cancelled after
processing/failing the current requests in line. But by that time various
errors are hit at HMC and system will be moved to Incomplte/NoConnection/Error
state depending on the commands which randomly fail

This commit is to bump up the time queue size from 100 to 300, to make room
for the huge incoming traffix at bmcweb

Testedby:
  On a dual HMC setup:
  1. Several IPLs are performed and verified that no SSLHandshakeException seen
     at HMC
  2. Twenty-two partitions were created and some LPAR operations were done
  3. BMC reboot is tested when the system was at operating state

Signed-off-by: Sunitha Harish <sunharis@in.ibm.com>
Change-Id: Iad6c10705a02c612377347939c7c2bdbf54bb97f