### PR TITLE
Change errors to debug level traces

### DIFF
--- a/redfish-core/lib/ethernet.hpp
+++ b/redfish-core/lib/ethernet.hpp
@@ -480,7 +480,7 @@ inline void
                         }
                         else
                         {
-                            BMCWEB_LOG_ERROR
+                            BMCWEB_LOG_DEBUG
                                 << "Got extra property: " << property.first
                                 << " on the " << objpath.first.str << " object";
                         }
@@ -554,7 +554,7 @@ inline void
                         }
                         else
                         {
-                            BMCWEB_LOG_ERROR
+                            BMCWEB_LOG_DEBUG
                                 << "Got extra property: " << property.first
                                 << " on the " << objpath.first.str << " object";
                         }

--- a/redfish-core/lib/hypervisor_system.hpp
+++ b/redfish-core/lib/hypervisor_system.hpp
@@ -208,7 +208,7 @@ inline bool extractHypervisorInterfaceData(
                         }
                         else
                         {
-                            BMCWEB_LOG_ERROR
+                            BMCWEB_LOG_DEBUG
                                 << "Got extra property: " << property.first
                                 << " on the " << objpath.first.str << " object";
                         }


### PR DESCRIPTION
This commit removes few unnecessary error logs in hyp_ethernet and
ethernet header files and changes them to debug level traces.

Tested By:

Before the changes:

Nov 26 06:10:46 bmc bmcweb[264]: (2021-11-26 06:10:46) [ERROR "hyperv \
isor_system.hpp":211] Got extra property: Type on the /xyz/openbmc_pr \
oject/network/hypervisor/eth0/ipv4/addr0 object
Nov 26 06:10:46 bmc bmcweb[264]: (2021-11-26 06:10:46) [ERROR "hyperv \
isor_system.hpp":211] Got extra property: Origin on the /xyz/openbmc_ \
project/network/hypervisor/eth1/ipv4/addr0 object
Nov 26 06:10:46 bmc bmcweb[264]: (2021-11-26 06:10:46) [ERROR "hyperv \
isor_system.hpp":211] Got extra property: Type on the /xyz/openbmc_pr \
oject/network/hypervisor/eth1/ipv4/addr0 object

After changes:

These traces wont be logged unless the bmcweb logging flag is enabled.

Signed-off-by: Asmitha Karunanithi <asmitk01@in.ibm.com>
Change-Id: I7160d3f71121a9758124a7c29517176e396c333e