### PR TITLE
Add newRedfish role OemIBMServiceAgent

### DIFF
--- a/redfish-core/include/error_messages.hpp
+++ b/redfish-core/include/error_messages.hpp
@@ -975,6 +975,17 @@ void addMessageToErrorJson(nlohmann::json& target,
                            const nlohmann::json& message);
 void addMessageToJson(nlohmann::json& target, const nlohmann::json& message,
                       const std::string& fieldPath);
+
+/**
+ * RestrictedRole is new in https://github.com/DMTF/Redfish/blob/master/registries/Base.1.9.0.json
+ * @brief Formats RestrictedRole message into JSON
+ * Message body: "The operation was not successful because the role '<arg1>' is restricted."
+ *
+ * @returns Message RestrictedRole formatted to JSON */
+nlohmann::json restrictedRole(const std::string& arg1);
+void restrictedRole(crow::Response& res, const std::string& arg1);
+
+
 } // namespace messages
 
 } // namespace redfish

--- a/redfish-core/include/privileges.hpp
+++ b/redfish-core/include/privileges.hpp
@@ -46,7 +46,7 @@ constexpr const size_t maxPrivilegeCount = 32;
 /** @brief A vector of all privilege names and their indexes */
 static const std::array<std::string, maxPrivilegeCount> privilegeNames{
     "Login", "ConfigureManager", "ConfigureComponents", "ConfigureSelf",
-    "ConfigureUsers"};
+    "ConfigureUsers", "OemIBMPerformService"};
 
 /**
  * @brief Redfish privileges
@@ -223,6 +223,13 @@ inline const Privileges& getUserPrivileges(const std::string& userRole)
         // Redfish privilege : Readonly
         static Privileges readOnly{"Login", "ConfigureSelf"};
         return readOnly;
+    }
+    if (userRole == "priv-oemibmserviceagent")
+    {
+        static Privileges admin{"Login", "ConfigureManager", "ConfigureSelf",
+                                "ConfigureUsers", "ConfigureComponents",
+                                "OemIBMPerformService"};
+        return admin;
     }
     // Redfish privilege : NoAccess
     static Privileges noaccess;

--- a/redfish-core/lib/account_service.hpp
+++ b/redfish-core/lib/account_service.hpp
@@ -24,6 +24,8 @@
 #include <utils/json_utils.hpp>
 
 #include <string>
+#include <roles.hpp>
+
 #include <variant>
 #include <vector>
 
@@ -94,6 +96,10 @@ inline std::string getRoleIdFromPrivilege(std::string_view role)
     {
         return "Operator";
     }
+    if (role == "priv-oemibmserviceagent")
+    {
+        return "OemIBMServiceAgent";
+    }
     if ((role == "") || (role == "priv-noaccess"))
     {
         return "NoAccess";
@@ -113,6 +119,10 @@ inline std::string getPrivilegeFromRoleId(std::string_view role)
     if (role == "Operator")
     {
         return "priv-operator";
+    }
+    if (role == "OemIBMServiceAgent")
+    {
+        return "priv-oemibmserviceagent";
     }
     if ((role == "NoAccess") || (role == ""))
     {
@@ -267,6 +277,13 @@ inline void handleRoleMapPatch(
                                      localRole))
             {
                 continue;
+            }
+
+            // Do not allow mapping to a Restricted LocalRole
+            if (localRole && redfish::isRestrictedRole(*localRole))
+            {
+                messages::restrictedRole(asyncResp->res, *localRole);
+                return;
             }
 
             // Update existing RoleMapping Object
@@ -1676,6 +1693,13 @@ inline void requestAccountServiceRoutes(App& app)
                 return;
             }
 
+            // Don't allow new accounts to have a Restricted Role.
+            if (redfish::isRestrictedRole(*roleId))
+            {
+                messages::restrictedRole(asyncResp->res, *roleId);
+                return;
+            }
+
             std::string priv = getPrivilegeFromRoleId(*roleId);
             if (priv.empty())
             {
@@ -1687,6 +1711,7 @@ inline void requestAccountServiceRoutes(App& app)
             // phosphor-user-manager is added. In order to avoid dependency
             // issues, this is added in bmcweb, which will removed, once
             // phosphor-user-manager supports priv-noaccess.
+            // WARNING: roleId changes from Redfish Role to Phosphor privilege role.
             if (priv == "priv-noaccess")
             {
                 roleId = "";
@@ -2008,6 +2033,28 @@ inline void requestAccountServiceRoutes(App& app)
                 }
             }
 
+
+            // Don't PATCH any account which has a Restricted Role,
+            // except allow the Locked property.
+            // Do not even allow the service user to change these properties.
+            // Implementation note: Ideally this would get the user's RoleId
+            // but that would take an additional D-Bus operation.
+            if ((username == "service") &&
+                (newUserName || password || roleId || enabled))
+            {
+                BMCWEB_LOG_ERROR << "Attempt to PATCH user who has a Restricted Role";
+                messages::restrictedRole(asyncResp->res, "OemIBMServiceAgent");
+                return;
+            }
+
+            // Don't PATCH any account to have a Restricted Role.
+            if (roleId && redfish::isRestrictedRole(*roleId))
+            {
+                BMCWEB_LOG_ERROR << "Attempt to PATCH user to have a Restricted Role";
+                messages::restrictedRole(asyncResp->res, *roleId);
+                return;
+            }
+
             if (oem)
             {
                 std::optional<nlohmann::json> ibm;
@@ -2153,6 +2200,16 @@ inline void requestAccountServiceRoutes(App& app)
                const std::string& username) -> void {
                 const std::string userPath =
                     "/xyz/openbmc_project/user/" + username;
+
+                // Don't DELETE accounts which have a Restricted Role (the service account).
+                // Implementation note: Ideally this would get the user's RoleId
+                // but that would take an additional D-Bus operation.
+                if (username == "service")
+                {
+                    BMCWEB_LOG_ERROR << "Attempt to DELETE user who has a Restricted Role";
+                    messages::restrictedRole(asyncResp->res, "OemIBMServiceAgent");
+                    return;
+                }
 
                 crow::connections::systemBus->async_method_call(
                     [asyncResp, username](const boost::system::error_code ec) {

--- a/redfish-core/src/error_messages.cpp
+++ b/redfish-core/src/error_messages.cpp
@@ -2172,6 +2172,32 @@ void mutualExclusiveProperties(crow::Response& res, const std::string& arg1,
     addMessageToErrorJson(res.jsonValue, mutualExclusiveProperties(arg1, arg2));
 }
 
+/**
+ * @internal
+ * @brief Formats RestrictedRole into JSON
+ *
+ * See header file for more information
+ * @endinternal
+ */
+nlohmann::json restrictedRole(const std::string& arg1)
+{
+    return nlohmann::json{
+        {"@odata.type", "#Message.v1_1_1.Message"},
+        {"MessageId", "Base.1.9.0.RestrictedRole"},
+        {"Message", "The operation was not successful because the role '" + arg1 + "' is restricted."},
+        {"MessageArgs", {arg1}},
+        {"MessageSeverity", "Warning"},
+        {"Resolution",
+         "No resolution is required.  For standard roles, consider using the role "
+         "specified in the AlternateRoleId property in the Role resource."}};
+}
+
+void restrictedRole(crow::Response& res, const std::string& arg1)
+{
+    res.result(boost::beast::http::status::bad_request);
+    addMessageToErrorJson(res.jsonValue, restrictedRole(arg1));
+}
+
 } // namespace messages
 
 } // namespace redfish


### PR DESCRIPTION
This adds a new OEM Redfish privilege OemIBMPerformService.  This is needed
to mark REST API operations which should be restricted to the service user.

This adds a new custom Redfish role OemIBMServiceAgent which corresponds to
the priv-oemibmserviceagent role in phosphor-user-manager.  This role has
all privileges including the new OemIBMPerformService privilege.

Tested:
Tested only local users, not LDAP RemoteRoleMapping.
Tested on a system which had the new OemIBMServiceAgent role.

Setup: Ensure there is a "service" use who has role=OemIBMPerformService.
How?  Log into the BMC command shell as the root user:
  useradd service -G priv-oemibmserviceagent,web,redfish \
    -m -N -s /bin/sh -e ""
  passwd service   ---enter the password twice---
  systemctl restart xyz.openbmc_project.User.Manager.service

Tested aspects of DSP0266 version 1.12.0 "Restricted roles and restricted
privileges".  Numbers here correspond to bullets in that section:

1a. POST /redfish/v1/AccountService/Accounts/new with Role:OemIBMServiceAgent
Ensure it failed with message Base.1.9.0.RestrictedRole.

1b. PATCH /redfish/v1/AccountService/Accounts/ordinary with
Role:OemIBMServiceAgent.  Ensure it failed.

2. PATCH the "service" user (all property) and ensure it fails for all
properties except "Locked".

3. DELETE the "service" user && ensure it failed

4. PATCH the OemIBMServiceAgent role as the LocalRole within the
RemoteRoleMapping property && ensure it failed.

IMPI: Use ipmitool to try to create or modify the service user:
ipmitool user set name ...
ipmitool user set password ...

Signed-off-by: Joseph Reynolds <joseph-reynolds@charter.net>