### PR TITLE
Multipart parser

### DIFF
--- a/include/ibm/management_console_rest.hpp
+++ b/include/ibm/management_console_rest.hpp
@@ -34,6 +34,8 @@ constexpr const char* methodNotAllowedMsg = "Method Not Allowed";
 constexpr const char* resourceNotFoundMsg = "Resource Not Found";
 constexpr const char* contentNotAcceptableMsg = "Content Not Acceptable";
 constexpr const char* internalServerError = "Internal Server Error";
+constexpr const char* internalFileSystemError = "Internal FileSystem Error";
+constexpr const char* badRequestMsg = "Bad Request";
 constexpr const char* propertyMissing = "Required Property Missing";
 constexpr uint32_t maxCSRLength = 4096;
 std::filesystem::path rootCertPath = "/var/lib/ibm/bmcweb/RootCert";
@@ -89,7 +91,7 @@ inline void saveConfigFile(const std::string& data, const std::string& fileID,
     {
         asyncResp->res.result(
             boost::beast::http::status::internal_server_error);
-        asyncResp->res.jsonValue["Description"] = internalServerError;
+        asyncResp->res.jsonValue["Description"] = internalFileSystemError;
         BMCWEB_LOG_DEBUG << "handleIbmPut: Failed to find if file exists. ec : "
                          << ec;
         return;
@@ -103,7 +105,7 @@ inline void saveConfigFile(const std::string& data, const std::string& fileID,
         {
             asyncResp->res.result(
                 boost::beast::http::status::internal_server_error);
-            asyncResp->res.jsonValue["Description"] = internalServerError;
+            asyncResp->res.jsonValue["Description"] = internalFileSystemError;
             BMCWEB_LOG_DEBUG << "handleIbmPut: Failed to find file size. ec : "
                              << ec;
             return;
@@ -216,7 +218,7 @@ inline void
     {
         asyncResp->res.result(
             boost::beast::http::status::internal_server_error);
-        asyncResp->res.jsonValue["Description"] = internalServerError;
+        asyncResp->res.jsonValue["Description"] = internalFileSystemError;
         BMCWEB_LOG_DEBUG << "handleIbmPut: Failed to prepare save-area "
                             "directory iterator. ec : "
                          << ec;
@@ -231,7 +233,8 @@ inline void
             {
                 asyncResp->res.result(
                     boost::beast::http::status::internal_server_error);
-                asyncResp->res.jsonValue["Description"] = internalServerError;
+                asyncResp->res.jsonValue["Description"] =
+                    internalFileSystemError;
                 BMCWEB_LOG_DEBUG << "handleIbmPut: Failed to find save-area "
                                     "directory . ec : "
                                  << ec;
@@ -242,7 +245,8 @@ inline void
             {
                 asyncResp->res.result(
                     boost::beast::http::status::internal_server_error);
-                asyncResp->res.jsonValue["Description"] = internalServerError;
+                asyncResp->res.jsonValue["Description"] =
+                    internalFileSystemError;
                 BMCWEB_LOG_DEBUG << "handleIbmPut: Failed to find save-area "
                                     "file size inside the directory . ec : "
                                  << ec;
@@ -263,9 +267,8 @@ inline void
             // handle error
             BMCWEB_LOG_ERROR << "MIME parse failed, ec : " << ec.value()
                              << " , ec message : " << ec.message();
-            asyncResp->res.result(
-                boost::beast::http::status::internal_server_error);
-            asyncResp->res.jsonValue["Description"] = internalServerError;
+            asyncResp->res.result(boost::beast::http::status::bad_request);
+            asyncResp->res.jsonValue["Description"] = badRequestMsg;
             return;
         }
         const std::string* uploadData = nullptr;
@@ -277,9 +280,8 @@ inline void
             if (it == formpart.fields.end())
             {
                 BMCWEB_LOG_ERROR << "Couldn't find Content-Disposition";
-                asyncResp->res.result(
-                    boost::beast::http::status::internal_server_error);
-                asyncResp->res.jsonValue["Description"] = internalServerError;
+                asyncResp->res.result(boost::beast::http::status::bad_request);
+                asyncResp->res.jsonValue["Description"] = badRequestMsg;
                 return;
             }
             BMCWEB_LOG_DEBUG << "Parsing value " << it->value();

--- a/include/login_routes.hpp
+++ b/include/login_routes.hpp
@@ -1,5 +1,7 @@
 #pragma once
 
+#include "multipart_parser.hpp"
+
 #include <app.hpp>
 #include <boost/container/flat_set.hpp>
 #include <common.hpp>
@@ -118,6 +120,50 @@ inline void requestRoutes(App& app)
                                 }
                             }
                         }
+                    }
+                }
+            }
+            else if (boost::starts_with(contentType, "multipart/form-data"))
+            {
+                looksLikePhosphorRest = true;
+                std::error_code ec;
+                MultipartParser parser(req, ec);
+                if (ec)
+                {
+                    // handle error
+                    BMCWEB_LOG_ERROR << "MIME parse failed, ec : " << ec.value()
+                                     << " , ec message : " << ec.message();
+                    asyncResp->res.result(
+                        boost::beast::http::status::bad_request);
+                    return;
+                }
+
+                for (const FormPart& formpart : parser.mime_fields)
+                {
+                    boost::beast::http::fields::const_iterator it =
+                        formpart.fields.find("Content-Disposition");
+                    if (it == formpart.fields.end())
+                    {
+                        BMCWEB_LOG_ERROR << "Couldn't find Content-Disposition";
+                        asyncResp->res.result(
+                            boost::beast::http::status::bad_request);
+                        continue;
+                    }
+
+                    BMCWEB_LOG_INFO << "Parsing value " << it->value();
+
+                    if (it->value() == "form-data; name=\"username\"")
+                    {
+                        username = formpart.content;
+                    }
+                    else if (it->value() == "form-data; name=\"password\"")
+                    {
+                        password = formpart.content;
+                    }
+                    else
+                    {
+                        BMCWEB_LOG_INFO << "Extra format, ignore it."
+                                        << it->value();
                     }
                 }
             }

--- a/include/multipart_parser.hpp
+++ b/include/multipart_parser.hpp
@@ -1,0 +1,501 @@
+#pragma once
+
+#include <boost/algorithm/string/predicate.hpp>
+#include <boost/beast/http/fields.hpp>
+#include <http_request.hpp>
+
+#include <string>
+#include <string_view>
+
+enum class ParserError
+{
+    ERROR_OVERFLOW = 500,
+    ERROR_UNDERFLOW,
+    ERROR_BOUNDARY_FORMAT,
+    ERROR_BOUNDARY_CR,
+    ERROR_BOUNDARY_LF,
+    ERROR_BOUNDARY_DATA,
+    ERROR_EMPTY_HEADER,
+    ERROR_HEADER_NAME,
+    ERROR_HEADER_VALUE,
+    ERROR_HEADER_ENDING
+};
+
+struct FormPart
+{
+    boost::beast::http::fields fields;
+    std::string content;
+};
+
+struct ParserErrCategory : std::error_category
+{
+    const char* name() const noexcept override
+    {
+        return "multipart parser";
+    }
+    std::string message(int ev) const override;
+};
+
+std::string ParserErrCategory::message(int ev) const
+{
+    switch (static_cast<ParserError>(ev))
+    {
+        case ParserError::ERROR_OVERFLOW:
+        {
+            return "Parser bug: index overflows lookbehind buffer. Please send "
+                   "bug report with input file attached.";
+        }
+        case ParserError::ERROR_UNDERFLOW:
+        {
+            return "Parser bug: index underflows lookbehind buffer. Please "
+                   "send bug report with input file attached.";
+        }
+        case ParserError::ERROR_BOUNDARY_FORMAT:
+        {
+            return "Malformed. Parser boundary format error.";
+        }
+        case ParserError::ERROR_BOUNDARY_CR:
+        {
+            return "Malformed. Expected cr after boundary.";
+        }
+        case ParserError::ERROR_BOUNDARY_LF:
+        {
+            return "Malformed. Expected lf after boundary cr.";
+        }
+        case ParserError::ERROR_BOUNDARY_DATA:
+        {
+            return "Malformed. Found different boundary data than the given "
+                   "one.";
+        }
+        case ParserError::ERROR_EMPTY_HEADER:
+        {
+            return "Malformed first header name character.";
+        }
+        case ParserError::ERROR_HEADER_NAME:
+        {
+            return "Malformed header name.";
+        }
+        case ParserError::ERROR_HEADER_VALUE:
+        {
+            return "Malformed header value: lf expected after cr";
+        }
+        case ParserError::ERROR_HEADER_ENDING:
+        {
+            return "Malformed header ending: lf expected after cr";
+        }
+        default:
+        {
+            return "unrecognized error";
+        }
+    }
+}
+
+const ParserErrCategory parserErrCategory{};
+
+class MultipartParser
+{
+  public:
+    std::vector<FormPart> mime_fields;
+    std::string boundary;
+
+  private:
+    std::string currentHeaderName;
+    std::string currentHeaderValue;
+
+    const crow::Request& req;
+
+    static constexpr char cr = '\r';
+    static constexpr char lf = '\n';
+    static constexpr char space = ' ';
+    static constexpr char hyphen = '-';
+    static constexpr char colon = ':';
+    static constexpr size_t unmarked = -1U;
+
+    static constexpr int partBoundary = 1;
+    static constexpr int lastBoundary = 2;
+
+    enum class State
+    {
+        ERROR,
+        START,
+        START_BOUNDARY,
+        HEADER_FIELD_START,
+        HEADER_FIELD,
+        HEADER_VALUE_START,
+        HEADER_VALUE,
+        HEADER_VALUE_ALMOST_DONE,
+        HEADERS_ALMOST_DONE,
+        PART_DATA_START,
+        PART_DATA,
+        PART_END,
+        END
+    };
+
+    std::array<bool, 256> boundaryIndex;
+    std::string lookbehind;
+    State state;
+    int flags = 0;
+    size_t index = 0;
+    size_t headerFieldMark = unmarked;
+    size_t headerValueMark = unmarked;
+    size_t partDataMark = unmarked;
+
+    void indexBoundary()
+    {
+        std::fill(boundaryIndex.begin(), boundaryIndex.end(), 0);
+        for (const char current : boundary)
+        {
+            boundaryIndex[static_cast<size_t>(
+                static_cast<unsigned char>(current))] = true;
+        }
+    }
+
+    char lower(char c) const
+    {
+        return static_cast<char>(c | 0x20);
+    }
+
+    inline bool isBoundaryChar(char c) const
+    {
+        return boundaryIndex[static_cast<size_t>(
+            static_cast<unsigned char>(c))];
+    }
+
+    void processPartData(size_t& prevIndex, size_t& index, const char* buffer,
+                         size_t len, size_t boundaryEnd, size_t& i, char c,
+                         State& state, int& flags, std::error_code& ec)
+    {
+        prevIndex = index;
+
+        if (index == 0)
+        {
+            // boyer-moore derived algorithm to safely skip non-boundary data
+            while (i + boundary.size() <= len)
+            {
+                if (isBoundaryChar(buffer[i + boundaryEnd]))
+                {
+                    break;
+                }
+
+                i += boundary.size();
+            }
+            if (i == len)
+            {
+                return;
+            }
+            c = buffer[i];
+        }
+
+        if (index < boundary.size())
+        {
+            if (boundary[index] == c)
+            {
+                if (index == 0)
+                {
+                    if (partDataMark != unmarked)
+                    {
+                        mime_fields.rbegin()->content += std::string_view(
+                            buffer + partDataMark, i - partDataMark);
+                    }
+                }
+                index++;
+            }
+            else
+            {
+                index = 0;
+            }
+        }
+        else if (index == boundary.size())
+        {
+            index++;
+            if (c == cr)
+            {
+                // cr = part boundary
+                flags |= partBoundary;
+            }
+            else if (c == hyphen)
+            {
+                // hyphen = end boundary
+                flags |= lastBoundary;
+            }
+            else
+            {
+                index = 0;
+            }
+        }
+        else if (index - 1 == boundary.size())
+        {
+            if (flags & partBoundary)
+            {
+                index = 0;
+                if (c == lf)
+                {
+                    // unset the PART_BOUNDARY flag
+                    flags &= ~partBoundary;
+                    mime_fields.push_back({});
+                    state = State::HEADER_FIELD_START;
+                    return;
+                }
+            }
+            else if (flags & lastBoundary)
+            {
+                if (c == hyphen)
+                {
+                    state = State::END;
+                }
+                else
+                {
+                    index = 0;
+                }
+            }
+            else
+            {
+                index = 0;
+            }
+        }
+        else if (index - 2 == boundary.size())
+        {
+            if (c == cr)
+            {
+                index++;
+            }
+            else
+            {
+                index = 0;
+            }
+        }
+        else if (index - boundary.size() == 3)
+        {
+            index = 0;
+            if (c == lf)
+            {
+                state = State::END;
+                return;
+            }
+        }
+
+        if (index > 0)
+        {
+            // when matching a possible boundary, keep a lookbehind reference
+            // in case it turns out to be a false lead
+            if (index - 1U >= lookbehind.size())
+            {
+                ec.assign(static_cast<int>(ParserError::ERROR_OVERFLOW),
+                          parserErrCategory);
+                return;
+            }
+            lookbehind[index - 1] = c;
+        }
+        else if (prevIndex > 0)
+        {
+            // if our boundary turned out to be rubbish, the captured lookbehind
+            // belongs to partData
+
+            mime_fields.rbegin()->content += lookbehind.substr(0, prevIndex);
+            prevIndex = 0;
+            partDataMark = i;
+
+            // reconsider the current character even so it interrupted the
+            // sequence it could be the beginning of a new sequence
+            i--;
+        }
+    }
+
+  public:
+    MultipartParser(const crow::Request& reqIn, std::error_code& ec) :
+        req(reqIn)
+    {
+        std::string_view contentType = req.getHeaderValue("content-type");
+
+        const std::string boundaryFormat = "multipart/form-data; boundary=";
+        if (!boost::starts_with(contentType, boundaryFormat))
+        {
+            ec.assign(static_cast<int>(ParserError::ERROR_BOUNDARY_FORMAT),
+                      parserErrCategory);
+            return;
+        }
+
+        std::string_view ctBoundary = contentType.substr(boundaryFormat.size());
+
+        BMCWEB_LOG_DEBUG << "Boundary is \"" << ctBoundary << "\"";
+
+        boundary = "\r\n--";
+        boundary += ctBoundary;
+        indexBoundary();
+        lookbehind.resize(boundary.size() + 8);
+        state = State::START;
+
+        parse(ec);
+    }
+
+  private:
+    void parse(std::error_code& ec)
+    {
+        const char* buffer = req.body.data();
+        size_t len = req.body.size();
+
+        if (state == State::ERROR || len == 0)
+        {
+            return;
+        }
+
+        size_t prevIndex = index;
+        char cl = 0;
+
+        for (size_t i = 0; i < len; i++)
+        {
+            char c = buffer[i];
+            switch (state)
+            {
+                case State::ERROR:
+                    return;
+                case State::START:
+                    index = 0;
+                    state = State::START_BOUNDARY;
+                    [[fallthrough]];
+                case State::START_BOUNDARY:
+                    if (index == boundary.size() - 2)
+                    {
+                        if (c != cr)
+                        {
+                            ec.assign(static_cast<int>(
+                                          ParserError::ERROR_BOUNDARY_CR),
+                                      parserErrCategory);
+                            return;
+                        }
+                        index++;
+                        break;
+                    }
+                    else if (index - 1 == boundary.size() - 2)
+                    {
+                        if (c != lf)
+                        {
+                            ec.assign(static_cast<int>(
+                                          ParserError::ERROR_BOUNDARY_LF),
+                                      parserErrCategory);
+                            return;
+                        }
+                        index = 0;
+
+                        mime_fields.push_back({});
+                        state = State::HEADER_FIELD_START;
+                        break;
+                    }
+                    if (c != boundary[index + 2])
+                    {
+                        ec.assign(
+                            static_cast<int>(ParserError::ERROR_BOUNDARY_DATA),
+                            parserErrCategory);
+                        BMCWEB_LOG_DEBUG << "Got " << c << "expecting "
+                                         << boundary[index + 2];
+                        return;
+                    }
+                    index++;
+                    break;
+                case State::HEADER_FIELD_START:
+                    currentHeaderName.resize(0);
+                    state = State::HEADER_FIELD;
+                    headerFieldMark = i;
+                    index = 0;
+                    [[fallthrough]];
+                case State::HEADER_FIELD:
+                    if (c == cr)
+                    {
+                        headerFieldMark = unmarked;
+                        state = State::HEADERS_ALMOST_DONE;
+                        break;
+                    }
+
+                    index++;
+                    if (c == hyphen)
+                    {
+                        break;
+                    }
+
+                    if (c == colon)
+                    {
+                        if (index == 1)
+                        {
+                            // empty header field
+                            ec.assign(static_cast<int>(
+                                          ParserError::ERROR_EMPTY_HEADER),
+                                      parserErrCategory);
+                            return;
+                        }
+                        currentHeaderName.append(buffer + headerFieldMark,
+                                                 i - headerFieldMark);
+                        state = State::HEADER_VALUE_START;
+                        break;
+                    }
+                    cl = lower(c);
+                    if (cl < 'a' || cl > 'z')
+                    {
+                        ec.assign(
+                            static_cast<int>(ParserError::ERROR_EMPTY_HEADER),
+                            parserErrCategory);
+                        return;
+                    }
+                    break;
+                case State::HEADER_VALUE_START:
+                    if (c == space)
+                    {
+                        break;
+                    }
+                    headerValueMark = i;
+                    state = State::HEADER_VALUE;
+                    [[fallthrough]];
+                case State::HEADER_VALUE:
+                    if (c == cr)
+                    {
+                        std::string_view value(buffer + headerValueMark,
+                                               i - headerValueMark);
+                        BMCWEB_LOG_DEBUG << "Found header " << currentHeaderName
+                                         << "=" << value;
+                        mime_fields.rbegin()->fields.set(currentHeaderName,
+                                                         value);
+                        state = State::HEADER_VALUE_ALMOST_DONE;
+                    }
+                    break;
+                case State::HEADER_VALUE_ALMOST_DONE:
+                    if (c != lf)
+                    {
+                        ec.assign(
+                            static_cast<int>(ParserError::ERROR_HEADER_VALUE),
+                            parserErrCategory);
+                        return;
+                    }
+                    state = State::HEADER_FIELD_START;
+                    break;
+                case State::HEADERS_ALMOST_DONE:
+                    if (c != lf)
+                    {
+                        ec.assign(
+                            static_cast<int>(ParserError::ERROR_HEADER_ENDING),
+                            parserErrCategory);
+                        return;
+                    }
+                    state = State::PART_DATA_START;
+                    break;
+                case State::PART_DATA_START:
+                    state = State::PART_DATA;
+                    partDataMark = i;
+                    [[fallthrough]];
+                case State::PART_DATA:
+                    processPartData(prevIndex, index, buffer, len,
+                                    boundary.size() - 1, i, c, state, flags,
+                                    ec);
+                    break;
+                default:
+                    return;
+            }
+        }
+
+        if (len != 0)
+        {
+            mime_fields.rbegin()->content +=
+                std::string_view(buffer + partDataMark, len);
+        }
+
+        return;
+    }
+};

--- a/include/ut/multipart_test.cpp
+++ b/include/ut/multipart_test.cpp
@@ -1,0 +1,62 @@
+#include <http_utility.hpp>
+#include <multipart_parser.hpp>
+
+#include <map>
+
+#include "gmock/gmock.h"
+
+TEST(MultipartTest, TestGoodMultipartParser)
+{
+    boost::beast::http::request<boost::beast::http::string_body> req{};
+
+    req.set("Content-Type",
+            "multipart/form-data; "
+            "boundary=---------------------------d74496d66958873e");
+
+    req.body() = "-----------------------------d74496d66958873e\r\n"
+                 "Content-Disposition: form-data; name=\"Test1\"\r\n\r\n"
+                 "{\"Key1\": 112233}\r\n"
+                 "-----------------------------d74496d66958873e\r\n"
+                 "Content-Disposition: form-data; name=\"Test2\"\r\n\r\n"
+                 "123456\r\n"
+                 "-----------------------------d74496d66958873e--\r\n";
+
+    std::error_code ec;
+    crow::Request reqIn(req);
+    MultipartParser parser(reqIn, ec);
+    ASSERT_FALSE(ec);
+
+    ASSERT_EQ(parser.boundary,
+              "\r\n-----------------------------d74496d66958873e");
+    ASSERT_EQ(parser.mime_fields.size(), 2);
+
+    ASSERT_EQ(parser.mime_fields[0].fields.at("Content-Disposition"),
+              "form-data; name=\"Test1\"");
+    ASSERT_EQ(parser.mime_fields[0].content, "{\"Key1\": 112233}");
+
+    ASSERT_EQ(parser.mime_fields[1].fields.at("Content-Disposition"),
+              "form-data; name=\"Test2\"");
+    ASSERT_EQ(parser.mime_fields[1].content, "123456");
+}
+
+TEST(MultipartTest, TestBadMultipartParser)
+{
+    boost::beast::http::request<boost::beast::http::string_body> req{};
+
+    req.set("Content-Type",
+            "multipart/form-data; "
+            "boundary=---------------------------d74496d66958873e");
+
+    req.body() = "-----------------------------d74496d66958873e\r\n"
+                 "Content-Disposition: form-data; name=\"Test1\"\r\n"
+                 "{\"Key1\": 112233}\r\n"
+                 "-----------------------------d74496d66958873e\r\n"
+                 "Content-Disposition: form-data; name=\"Test2\"\r\n"
+                 "123456\r\n"
+                 "-----------------------------d74496d66958873e--\r\n";
+
+    std::error_code ec;
+    crow::Request reqIn(req);
+    MultipartParser parser(reqIn, ec);
+    ASSERT_EQ(ec.value(), static_cast<int>(ParserError::ERROR_EMPTY_HEADER));
+}

--- a/meson.build
+++ b/meson.build
@@ -361,6 +361,7 @@ srcfiles_unittest = [
   'include/ut/dbus_utility_test.cpp',
   'include/ut/http_utility_test.cpp',
   'include/ut/human_sort_test.cpp',
+  'include/ut/multipart_test.cpp',
   'redfish-core/ut/privileges_test.cpp',
   'redfish-core/ut/lock_test.cpp',
   'redfish-core/ut/configfile_test.cpp',


### PR DESCRIPTION
As part of HMC performance improvement, this commit implements
multiple configfile upload with a single http request

This commit uses the upstream MIME parsing algorithm.

Upstream commit: https://gerrit.openbmc-project.xyz/c/openbmc/bmcweb/+/34974
The 2nd commit is a downstream only based on https://gerrit.openbmc-project.xyz/c/openbmc/bmcweb/+/32174/

Tested by:
    1. Multiple file upload
    curl -k -H "X-Auth-Token: $bmc_token" -H "Content-Type: multipart/form-data"
    -X POST https://${bmc}/ibm/v1/Host/ConfigFiles -F "testfile1=@<path>;type=application/octet-stream"
    -F "testfile2=@<path>;type=application/octet-stream"
    2. Tested the single file upload for sanity
