### PR TITLE
HMC Lock management improvements

### DIFF
--- a/include/ibm/locks.hpp
+++ b/include/ibm/locks.hpp
@@ -209,7 +209,15 @@ inline RcGetLockList Lock::getLockList(const ListOfSessionIds& listSessionId)
 inline RcReleaseLockApi Lock::releaseLock(const ListOfTransactionIds& p,
                                           const SessionFlags& ids)
 {
-    // Check if the locks are owned by the
+    bool status = validateRids(p);
+
+    if (!status)
+    {
+        // Validation of rids failed
+        BMCWEB_LOG_ERROR << "releaseLock: Contains invalid request id";
+        return std::make_pair(false, status);
+    }
+    // Validation passed, check if all the locks are owned by the
     // requesting HMC
     auto status2 = isItMyLock(p, ids);
     if (!status2.first)
@@ -333,7 +341,8 @@ inline bool Lock::validateRids(const ListOfTransactionIds& refRids)
         }
         else
         {
-            BMCWEB_LOG_DEBUG << "At least 1 inValid Request id";
+            BMCWEB_LOG_ERROR << "validateRids: At least 1 inValid Request id: "
+                             << id;
             return false;
         }
     }

--- a/include/ibm/locks.hpp
+++ b/include/ibm/locks.hpp
@@ -209,23 +209,12 @@ inline RcGetLockList Lock::getLockList(const ListOfSessionIds& listSessionId)
 inline RcReleaseLockApi Lock::releaseLock(const ListOfTransactionIds& p,
                                           const SessionFlags& ids)
 {
-
-    bool status = validateRids(p);
-
-    if (!status)
-    {
-        // Validation of rids failed
-        BMCWEB_LOG_DEBUG << "Not a Valid request id";
-        return std::make_pair(false, status);
-    }
-    // Validation passed, check if all the locks are owned by the
+    // Check if the locks are owned by the
     // requesting HMC
     auto status2 = isItMyLock(p, ids);
-    if (status2.first)
+    if (!status2.first)
     {
-        // The current hmc owns all the locks, so we can release
-        // them
-        releaseLock(p);
+        return std::make_pair(false, status2);
     }
     return std::make_pair(true, status2);
 }
@@ -263,25 +252,6 @@ inline RcAcquireLock Lock::acquireLock(const LockRequests& lockRequestStructure)
 
     BMCWEB_LOG_DEBUG << "Done with checking conflict with the locktable";
     return std::make_pair(false, conflict);
-}
-
-inline void Lock::releaseLock(const ListOfTransactionIds& refRids)
-{
-    for (const auto& id : refRids)
-    {
-        if (lockTable.erase(id))
-        {
-            BMCWEB_LOG_DEBUG << "Removing the locks with transaction ID : "
-                             << id;
-        }
-
-        else
-        {
-            BMCWEB_LOG_ERROR << "Removing the locks from the lock table "
-                                "failed, transaction ID: "
-                             << id;
-        }
-    }
 }
 
 inline void Lock::releaseLock(const std::string& sessionId)
@@ -328,6 +298,18 @@ inline RcRelaseLock Lock::isItMyLock(const ListOfTransactionIds& refRids,
         {
             // It is owned by the currently request hmc
             BMCWEB_LOG_DEBUG << "Lock is owned  by the current hmc";
+            // remove the lock
+            if (lockTable.erase(id))
+            {
+                BMCWEB_LOG_DEBUG << "Removing the locks with transaction ID : "
+                                 << id;
+            }
+            else
+            {
+                BMCWEB_LOG_ERROR << "Removing the locks from the lock table "
+                                    "failed, transaction ID: "
+                                 << id;
+            }
         }
         else
         {

--- a/include/ibm/management_console_rest.hpp
+++ b/include/ibm/management_console_rest.hpp
@@ -600,7 +600,8 @@ inline void
         }
         if (validityStatus.first && (validityStatus.second == 1))
         {
-            BMCWEB_LOG_DEBUG << "There is a conflict within itself";
+            BMCWEB_LOG_ERROR
+                << "handleAcquireLockAPI: There is a conflict within itself";
             asyncResp->res.result(boost::beast::http::status::bad_request);
             return;
         }
@@ -654,7 +655,8 @@ inline void
             }
         }
 
-        BMCWEB_LOG_ERROR << "There is a conflict with the lock table";
+        BMCWEB_LOG_ERROR
+            << "handleAcquireLockAPI: There is a conflict with the lock table";
 
         asyncResp->res.result(boost::beast::http::status::conflict);
         nlohmann::json returnJson, segments;
@@ -674,6 +676,7 @@ inline void
 
         returnJson["SegmentFlags"] = myarray;
 
+        BMCWEB_LOG_ERROR << "Conflicting lock record: " << returnJson;
         asyncResp->res.jsonValue["Record"] = returnJson;
         return;
     }
@@ -708,6 +711,7 @@ inline void
     if (!varReleaselock.first)
     {
         // validation Failed
+        BMCWEB_LOG_ERROR << "handleReleaseLockAPI: validation failed";
         asyncResp->res.result(boost::beast::http::status::bad_request);
         return;
     }
@@ -721,7 +725,8 @@ inline void
     }
 
     // valid rid, but the current hmc does not own all the locks
-    BMCWEB_LOG_DEBUG << "Current HMC does not own all the locks";
+    BMCWEB_LOG_DEBUG
+        << "handleReleaseLockAPI: Current HMC does not own all the locks";
     asyncResp->res.result(boost::beast::http::status::unauthorized);
 
     auto var = statusRelease.second;
@@ -741,6 +746,7 @@ inline void
     }
 
     returnJson["SegmentFlags"] = myArray;
+    BMCWEB_LOG_DEBUG << "handleReleaseLockAPI: lockrecord: " << returnJson;
     asyncResp->res.jsonValue["Record"] = returnJson;
     return;
 }


### PR DESCRIPTION
This commit optimizes the release lock code and adds
some traces to give more data for lock conflict scenarios

Tested by:
 1. With dual HMC, tested create & activate LPARs
 2. Triggered lock conflict by starting create LPAR on both HMCs
    at the same time

Signed-off-by: Sunitha Harish <sunharis@in.ibm.com>
Change-Id: I13f642be2f98059ee3401d35a767863b6d78d225