### PR TITLE
Deduplicate url parsing code

### DIFF
--- a/http/http_connection.hpp
+++ b/http/http_connection.hpp
@@ -318,8 +318,13 @@ class Connection :
     void handle()
     {
         cancelDeadlineTimer();
-
-        crow::Request& thisReq = req.emplace(parser->release());
+        std::error_code reqEc;
+        crow::Request& thisReq = req.emplace(parser->release(), reqEc);
+        if (reqEc)
+        {
+            BMCWEB_LOG_DEBUG << "Request failed to construct" << reqEc;
+            return;
+        }
         thisReq.session = userSession;
 
         // Fetch the client IP address
@@ -341,18 +346,6 @@ class Connection :
                         << "." << thisReq.version() % 10 << ' '
                         << thisReq.methodString() << " " << thisReq.target()
                         << " " << thisReq.ipAddress;
-
-        boost::urls::error_code ec;
-        req->urlView = boost::urls::parse_relative_ref(
-            boost::urls::string_view(req->target().data(),
-                                     req->target().size()),
-            ec);
-        if (ec)
-        {
-            return;
-        }
-        req->url = std::string_view(req->urlView.encoded_path().data(),
-                                    req->urlView.encoded_path().size());
 
         res.setCompleteRequestHandler(nullptr);
         res.isAliveHelper = [this]() -> bool { return isAlive(); };
@@ -448,6 +441,10 @@ class Connection :
 
     void completeRequest()
     {
+        if (!req)
+        {
+            return;
+        }
         BMCWEB_LOG_INFO << "Response: " << this << ' ' << req->url << ' '
                         << res.resultInt() << " keepalive=" << req->keepAlive();
 
@@ -579,21 +576,6 @@ class Connection :
 
                 boost::beast::http::verb method = parser->get().method();
                 readClientIp();
-                boost::urls::error_code uriEc;
-                boost::urls::string_view uriStringView(
-                    parser->get().target().data(),
-                    parser->get().target().size());
-                BMCWEB_LOG_DEBUG << "Parsing URI: " << uriStringView;
-                req->urlView =
-                    boost::urls::parse_relative_ref(uriStringView, uriEc);
-                if (uriEc)
-                {
-                    BMCWEB_LOG_ERROR << "Failed to parse URI "
-                                     << uriEc.message();
-                    return;
-                }
-                req->url = std::string_view(req->urlView.encoded_path().data(),
-                                            req->urlView.encoded_path().size());
 
                 boost::asio::ip::address ip;
                 if (getClientIp(ip))

--- a/http/http_connection.hpp
+++ b/http/http_connection.hpp
@@ -590,17 +590,6 @@ class Connection :
                 {
                     startDeadline(loggedInAttempts);
                     BMCWEB_LOG_DEBUG << "Starting slow deadline";
-
-                    req->urlParams = req->urlView.query_params();
-
-#ifdef BMCWEB_ENABLE_DEBUG
-                    std::string paramList = "";
-                    for (const auto param : req->urlParams)
-                    {
-                        paramList += param->key() + " " + param->value() + " ";
-                    }
-                    BMCWEB_LOG_DEBUG << "QueryParams: " << paramList;
-#endif
                 }
                 else
                 {

--- a/include/ut/multipart_test.cpp
+++ b/include/ut/multipart_test.cpp
@@ -22,7 +22,7 @@ TEST(MultipartTest, TestGoodMultipartParser)
                  "-----------------------------d74496d66958873e--\r\n";
 
     std::error_code ec;
-    crow::Request reqIn(req);
+    crow::Request reqIn(req, ec);
     MultipartParser parser(reqIn, ec);
     ASSERT_FALSE(ec);
 
@@ -56,7 +56,7 @@ TEST(MultipartTest, TestBadMultipartParser)
                  "-----------------------------d74496d66958873e--\r\n";
 
     std::error_code ec;
-    crow::Request reqIn(req);
+    crow::Request reqIn(req, ec);
     MultipartParser parser(reqIn, ec);
     ASSERT_EQ(ec.value(), static_cast<int>(ParserError::ERROR_EMPTY_HEADER));
 }


### PR DESCRIPTION
Upstream is https://gerrit.openbmc-project.xyz/c/openbmc/bmcweb/+/47123/5 
This has been merged upstream, no problems have been observed upstream. 
This was suggested by @sunharis to pick up for the general performance improvement. 
I am not sure if we will see any real benefit here but it can't hurt and this commit is more correct.

The 2nd commit is making changes to include/ut/multipart_test.cpp to support this, something we recently pulled in. 
The 3rd commit is removing  several lines around query_params

Tested: GUI works including requests like powering on 


Orginal commit msg: 

In the current model, URLs get parsed twice, once to satisfy the
authenticate method, and once again later to satisfy the handle() call.
This commit deduplicates the parsing.  This is wasteful, and as of the
previous commit, unnecessary.

Specifically, it moves the actual parsing into the request object, and
adds a target() method to explicitly set a url.  This deduplicates the
code that was in http_connection, and centralizes it in request, where
it should really belong.

Tested:
curl --insecure "https://192.168.7.2/redfish/v1"
Returns the redfish v1 resource

curl --insecure "https://192.168.7.2/redfish/v1/Systems"
Returns 401 unauthorized

curl --insecure --user root:0penBmc "https://192.168.7.2/redfish/v1/Systems"
returns the SystemsCollection

Signed-off-by: Ed Tanous <edtanous@google.com>
Change-Id: Ie7ee2d9a9a51bf21c03793b35730e7a0ca82623a