### PR TITLE
Redfish Assembly: Add More Inventory Types

### DIFF
--- a/redfish-core/lib/assembly.hpp
+++ b/redfish-core/lib/assembly.hpp
@@ -206,13 +206,15 @@ inline void
             "xyz.openbmc_project.ObjectMapper",
             "/xyz/openbmc_project/object_mapper",
             "xyz.openbmc_project.ObjectMapper", "GetObject", assembly,
-            std::array<const char*, 7>{
+            std::array<const char*, 9>{
                 "xyz.openbmc_project.Inventory.Item.Vrm",
                 "xyz.openbmc_project.Inventory.Item.Tpm",
                 "xyz.openbmc_project.Inventory.Item.Panel",
                 "xyz.openbmc_project.Inventory.Item.Battery",
                 "xyz.openbmc_project.Inventory.Item.DiskBackplane",
                 "xyz.openbmc_project.Inventory.Item.Board",
+                "xyz.openbmc_project.Inventory.Item.Connector",
+                "xyz.openbmc_project.Inventory.Item.Drive",
                 "xyz.openbmc_project.Inventory.Item.Board.Motherboard"});
 
         assemblyIndex++;
@@ -356,13 +358,15 @@ inline void checkAssemblyInterface(
         "/xyz/openbmc_project/object_mapper",
         "xyz.openbmc_project.ObjectMapper", "GetSubTree",
         "/xyz/openbmc_project/inventory", int32_t(0),
-        std::array<const char*, 7>{
+        std::array<const char*, 9>{
             "xyz.openbmc_project.Inventory.Item.Vrm",
             "xyz.openbmc_project.Inventory.Item.Tpm",
             "xyz.openbmc_project.Inventory.Item.Panel",
             "xyz.openbmc_project.Inventory.Item.Battery",
             "xyz.openbmc_project.Inventory.Item.DiskBackplane",
             "xyz.openbmc_project.Inventory.Item.Board",
+            "xyz.openbmc_project.Inventory.Item.Connector",
+            "xyz.openbmc_project.Inventory.Item.Drive",
             "xyz.openbmc_project.Inventory.Item.Board.Motherboard"});
 }
 


### PR DESCRIPTION
Add the Item.Connector and Item.Drive interfaces to
the list of interfaces we expose as Redfish inventories.

Signed-off-by: Santosh Puranik <santosh.puranik@in.ibm.com>