### PR TITLE
Link Fabric adapter to PCIeDevice schema

### DIFF
--- a/redfish-core/lib/FabricAdapters.hpp
+++ b/redfish-core/lib/FabricAdapters.hpp
@@ -138,6 +138,32 @@ inline void
                     "LocationCode",
                     "LocationCode");
             }
+            else if (interface ==
+                     "xyz.openbmc_project.Inventory.Item.PCIeDevice")
+            {
+                // if the adapter also implements this interface, link the
+                // adapter schema to PCIeDevice schema for this adapter.
+                const std::string pcieDevice =
+                    sdbusplus::message::object_path(objPath).filename();
+
+                if (pcieDevice.empty())
+                {
+                    BMCWEB_LOG_ERROR << "Failed to find / in pcie device path";
+                    messages::internalError(aResp->res);
+                    return;
+                }
+
+                nlohmann::json& deviceArray =
+                    aResp->res.jsonValue["Links"]["PCIeDevices"];
+                deviceArray = nlohmann::json::array();
+
+                deviceArray.push_back(
+                    {{"@odata.id",
+                      "/redfish/v1/Systems/system/PCIeDevices/" + pcieDevice}});
+
+                aResp->res.jsonValue["Links"]["PCIeDevices@odata.count"] =
+                    deviceArray.size();
+            }
         }
     }
 }


### PR DESCRIPTION
This commit implement changes to populate link to PCIeDevice
schema in case the given Fabric adapter also implements
"xyz.openbmc_project.Inventory.Item.PCIeDevice" interface.

Sample output:
curl -k -H "X-Auth-Token: $bmc_token" -X GET https://${bmc}/redfish/v1/Systems/system/FabricAdapers/pcie_card10
{
  "@odata.id": "/redfish/v1/Systems/system/FabricAdapters/pcie_card10",
  "@odata.type": "#FabricAdapter.v1_0_0.FabricAdapter",
  "Id": "pcie_card10",
  "Links": {
    "PCIeDevices": [
      {
        "@odata.id": "/redfish/v1/Systems/system/PCIeDevices/pcie_card10"
      }
    ],
    "PCIeDevices@odata.count": 1
  },
  "Location": {
    "PartLocation": {
      "ServiceLabel": "U78DA.ND0.WZS0066-P0-C10"
    }
  },
  "Model": "6B87",
  "Name": "NVME JBOF  RISER",
  "PartNumber": "03FL288",
  "Ports": {
    "@odata.id": "/redfish/v1/Systems/system/FabricAdapters/pcie_card10/Ports"
  },
  "SerialNumber": "Y131UF18P00W",
  "SparePartNumber": "03FL205"
}

Signed-off-by: Sunny Srivastava <sunnsr25@in.ibm.com>