### PR TITLE
Fix EnvironmentMetrics not showing

### DIFF
--- a/redfish-core/include/redfish.hpp
+++ b/redfish-core/include/redfish.hpp
@@ -85,6 +85,7 @@ class RedfishService
         requestRoutesPower(app);
 #endif
 #ifdef BMCWEB_NEW_POWERSUBSYSTEM_THERMALSUBSYSTEM
+        requestRoutesEnvironmentMetrics(app);
         requestRoutesThermalSubsystem(app);
         requestRoutesThermalMetrics(app);
         requestRoutesPowerSubsystem(app);
@@ -99,7 +100,6 @@ class RedfishService
         requestRoutesManagerResetActionInfo(app);
         requestRoutesManagerResetToDefaultsAction(app);
         requestRoutesPCIeSlots(app);
-        requestRoutesEnvironmentMetrics(app);
         requestRoutesChassisCollection(app);
         requestRoutesChassis(app);
         requestRoutesChassisResetAction(app);

--- a/redfish-core/lib/chassis.hpp
+++ b/redfish-core/lib/chassis.hpp
@@ -457,27 +457,27 @@ inline void requestRoutesChassis(App& app)
                                     {"@odata.id", "/redfish/v1/Chassis/" +
                                                       chassisId + "/Thermal"}};
 
-                                asyncResp->res.jsonValue["EnvironmentMetrics"] =
-                                    {{"@odata.id", "/redfish/v1/Chassis/" +
-                                                       chassisId +
-                                                       "/EnvironmentMetrics"}};
-
                                 // Power object
                                 asyncResp->res.jsonValue["Power"] = {
                                     {"@odata.id", "/redfish/v1/Chassis/" +
                                                       chassisId + "/Power"}};
 #endif
 
-                                asyncResp->res.jsonValue["ThermalSubsystem"] = {
-                                    {"@odata.id", "/redfish/v1/Chassis/" +
-                                                      chassisId +
-                                                      "/ThermalSubsystem"}};
-
 #ifdef BMCWEB_NEW_POWERSUBSYSTEM_THERMALSUBSYSTEM
+                                asyncResp->res.jsonValue["EnvironmentMetrics"] =
+                                    {{"@odata.id", "/redfish/v1/Chassis/" +
+                                                       chassisId +
+                                                       "/EnvironmentMetrics"}};
+
                                 asyncResp->res.jsonValue["PowerSubsystem"] = {
                                     {"@odata.id", "/redfish/v1/Chassis/" +
                                                       chassisId +
                                                       "/PowerSubsystem"}};
+
+                                asyncResp->res.jsonValue["ThermalSubsystem"] = {
+                                    {"@odata.id", "/redfish/v1/Chassis/" +
+                                                      chassisId +
+                                                      "/ThermalSubsystem"}};
 #endif
 
                                 // SensorCollection


### PR DESCRIPTION
Noticed EnvironmentMetrics was not in the chassis resource after talking with the GUI team.

EnvironmentMetrics is part of the new PowerSubsystem, ThermalSubsystem
so move it under the correct option.

Also moved PowerSubsystem to make it correct and fixed redfish.hpp.

https://gerrit.openbmc-project.xyz/c/openbmc/bmcweb/+/40326/26/redfish-core/lib/chassis.hpp
was correct upstream and left a comment on
https://gerrit.openbmc-project.xyz/c/openbmc/bmcweb/+/43170.

BMCWEB_ALLOW_DEPRECATED_POWER_THERMAL is disabled downstream while
BMCWEB_NEW_POWERSUBSYSTEM_THERMALSUBSYSTEM is enabled downstream.
https://github.com/ibm-openbmc/openbmc/blob/1020/meta-ibm/recipes-phosphor/interfaces/bmcweb_%25.bbappend#L4

This is going to introduce a validator error when the system is off. This error isn't new, it is just now being exposed since this URI was hidden the validator did not know to look.  https://github.com/ibm-openbmc/dev/issues/3401 tracks fixing this and making this sensor value optional 

FYI @ChicagoDuan @zhanghaodi @lxwinspur 

```
 curl -k https://$bmc/redfish/v1/Chassis/chassis/EnvironmentMetrics
{
  "@odata.id": "/redfish/v1/Chassis/chassis/EnvironmentMetrics",
  "@odata.type": "#EnvironmentMetrics.v1_1_0.EnvironmentMetrics",
  "FanSpeedsPercent": [
    {
    ....
      "PowerLimitWatts": {
    "ControlMode": "disabled",
    "ControlMode@Redfish.AllowableValues": [
      "automatic",
      "disabled"
    ],
    "SetPoint": 0
  },
  "error": {
    "@Message.ExtendedInfo": [
      {
        "@odata.type": "#Message.v1_1_1.Message",
        "Message": "The request failed due to an internal service error.  The service is still operational.",
        "MessageArgs": [],
        "MessageId": "Base.1.8.1.InternalError",
        "MessageSeverity": "Critical",
        "Resolution": "Resubmit the request.  If the problem persists, consider resetting the service."
      }
    ],
    "code": "Base.1.8.1.InternalError",
    "message": "The request failed due to an internal service error.  The service is still operational."
  }

    
```
Do see EnvironmentMetrics, PowerSubsystem, ThermalSubsystem 
```
 curl -k https://$bmc/redfish/v1/Chassis/chassis
{
  "@odata.id": "/redfish/v1/Chassis/chassis",
  "@odata.type": "#Chassis.v1_15_0.Chassis",
  "Actions": {
    "#Chassis.Reset": {
      "@Redfish.ActionInfo": "/redfish/v1/Chassis/chassis/ResetActionInfo",
      "target": "/redfish/v1/Chassis/chassis/Actions/Chassis.Reset"
    }
  },
  "Assembly": {
    "@odata.id": "/redfish/v1/Chassis/chassis/Assembly"
  },
  "ChassisType": "RackMount",
  "EnvironmentMetrics": {
    "@odata.id": "/redfish/v1/Chassis/chassis/EnvironmentMetrics"
  },
```
Signed-off-by: Gunnar Mills <gmills@us.ibm.com>