### PR TITLE
Version upgrade for adapter schema

### DIFF
--- a/redfish-core/lib/FabricAdapters.hpp
+++ b/redfish-core/lib/FabricAdapters.hpp
@@ -152,7 +152,7 @@ inline void
 inline void getAdapter(const std::shared_ptr<bmcweb::AsyncResp>& aResp,
                        const std::string& adapter)
 {
-    aResp->res.jsonValue["@odata.type"] = "#FabricAdapter.v1_0_0.FabricAdapter";
+    aResp->res.jsonValue["@odata.type"] = "#FabricAdapter.v1_1_0.FabricAdapter";
     aResp->res.jsonValue["@odata.id"] =
         "/redfish/v1/Systems/system/FabricAdapters/" + adapter;
 
@@ -168,7 +168,7 @@ inline void getAdapter(const std::shared_ptr<bmcweb::AsyncResp>& aResp,
                 if (ec.value() == boost::system::errc::io_error)
                 {
                     messages::resourceNotFound(
-                        aResp->res, "#FabricAdapter.v1_0_0.FabricAdapter",
+                        aResp->res, "#FabricAdapter.v1_1_0.FabricAdapter",
                         adapter);
                     return;
                 }


### PR DESCRIPTION
The commit upgrades the version of adapter schema from v_1_0_0
to v_1_1_0 in order to publish "LocationCode" property.

Signed-off-by: Sunny Srivastava <sunnsr25@in.ibm.com>