### PR TITLE
Fabric adapter version upgrade

### DIFF
--- a/redfish-core/lib/FabricAdapters.hpp
+++ b/redfish-core/lib/FabricAdapters.hpp
@@ -178,7 +178,7 @@ inline void
 inline void getAdapter(const std::shared_ptr<bmcweb::AsyncResp>& aResp,
                        const std::string& adapter)
 {
-    aResp->res.jsonValue["@odata.type"] = "#FabricAdapter.v1_1_0.FabricAdapter";
+    aResp->res.jsonValue["@odata.type"] = "#FabricAdapter.v1_2_0.FabricAdapter";
     aResp->res.jsonValue["@odata.id"] =
         "/redfish/v1/Systems/system/FabricAdapters/" + adapter;
 
@@ -194,7 +194,7 @@ inline void getAdapter(const std::shared_ptr<bmcweb::AsyncResp>& aResp,
                 if (ec.value() == boost::system::errc::io_error)
                 {
                     messages::resourceNotFound(
-                        aResp->res, "#FabricAdapter.v1_1_0.FabricAdapter",
+                        aResp->res, "#FabricAdapter.v1_2_0.FabricAdapter",
                         adapter);
                     return;
                 }


### PR DESCRIPTION
The commit does a version upgrate for adapter schema.
The upgrade is required to include link to PCIeDevices
from adapter.

Validator has been executed and no new error has been found.
Signed-off-by: Sunny Srivastava <sunnsr25@in.ibm.com>