### PR TITLE
Handle empty enum values in PCIeDevice and PCIeFunctions

### DIFF
--- a/redfish-core/lib/pcie.hpp
+++ b/redfish-core/lib/pcie.hpp
@@ -167,7 +167,10 @@ inline void requestRoutesSystemPCIeDevice(App& app)
                             &pcieDevProperties["DeviceType"]);
                         property)
                     {
-                        asyncResp->res.jsonValue["DeviceType"] = *property;
+                        if (!property->empty())
+                        {
+                            asyncResp->res.jsonValue["DeviceType"] = *property;
+                        }
                     }
 
                     if (std::string* property = std::get_if<std::string>(
@@ -381,7 +384,10 @@ inline void requestRoutesSystemPCIeFunction(App& app)
                                            "FunctionType"]);
                     property)
                 {
-                    asyncResp->res.jsonValue["FunctionType"] = *property;
+                    if (!property->empty())
+                    {
+                        asyncResp->res.jsonValue["FunctionType"] = *property;
+                    }
                 }
 
                 if (std::string* property = std::get_if<std::string>(
@@ -389,7 +395,10 @@ inline void requestRoutesSystemPCIeFunction(App& app)
                                            "DeviceClass"]);
                     property)
                 {
-                    asyncResp->res.jsonValue["DeviceClass"] = *property;
+                    if (!property->empty())
+                    {
+                        asyncResp->res.jsonValue["DeviceClass"] = *property;
+                    }
                 }
 
                 if (std::string* property = std::get_if<std::string>(


### PR DESCRIPTION
The commit implement changes to handle empty "DeviceType"
in PCIeDevice schema.
The property expects an enum value  and since  Dbus object
path for PCIeDevices are primed the value fetched from D-Bus
can be empty for the field.

Validator has been executed an no new error has been found.
Signed-off-by: Sunny Srivastava <sunnsr25@in.ibm.com>