### PR TITLE
Telemetry MetricReportsDefinition Collections update

### DIFF
--- a/redfish-core/include/event_service_manager.hpp
+++ b/redfish-core/include/event_service_manager.hpp
@@ -14,6 +14,7 @@
 // limitations under the License.
 */
 #pragma once
+#include "metric_report.hpp"
 #include "registries.hpp"
 #include "registries/base_message_registry.hpp"
 #include "registries/openbmc_message_registry.hpp"
@@ -506,46 +507,31 @@ class Subscription : public persistent_data::UserSubscription
     }
 #endif
 
-    void filterAndSendReports(const std::string& id2,
-                              const std::string& readingsTs,
-                              const ReadingsObjType& readings)
+    void filterAndSendReports(
+        const std::string& id,
+        const std::variant<telemetry::TimestampReadings>& var)
     {
-        std::string metricReportDef =
-            "/redfish/v1/TelemetryService/MetricReportDefinitions/" + id2;
+        std::string mrdUri = telemetry::metricReportDefinitionUri + id;
 
         // Empty list means no filter. Send everything.
         if (metricReportDefinitions.size())
         {
             if (std::find(metricReportDefinitions.begin(),
                           metricReportDefinitions.end(),
-                          metricReportDef) == metricReportDefinitions.end())
+                          mrdUri) == metricReportDefinitions.end())
             {
                 return;
             }
         }
 
-        nlohmann::json metricValuesArray = nlohmann::json::array();
-        for (const auto& it : readings)
+        nlohmann::json msg;
+        if (!telemetry::fillReport(msg, id, var))
         {
-            metricValuesArray.push_back({});
-            nlohmann::json& entry = metricValuesArray.back();
-
-            auto& [id, property, value, timestamp] = it;
-
-            entry = {{"MetricId", id},
-                     {"MetricProperty", property},
-                     {"MetricValue", std::to_string(value)},
-                     {"Timestamp", crow::utility::getDateTime(timestamp)}};
+            BMCWEB_LOG_ERROR << "Failed to fill the MetricReport for DBus "
+                                "Report with id "
+                             << id;
+            return;
         }
-
-        nlohmann::json msg = {
-            {"@odata.id", "/redfish/v1/TelemetryService/MetricReports/" + id},
-            {"@odata.type", "#MetricReport.v1_3_0.MetricReport"},
-            {"Id", id2},
-            {"Name", id2},
-            {"Timestamp", readingsTs},
-            {"MetricReportDefinition", {{"@odata.id", metricReportDef}}},
-            {"MetricValues", metricValuesArray}};
 
         this->sendEvent(
             msg.dump(2, ' ', true, nlohmann::json::error_handler_t::replace));
@@ -1331,73 +1317,43 @@ class EventServiceManager
     }
 
 #endif
-
-    void getMetricReading(const std::string& service,
-                          const std::string& objPath, const std::string& intf)
+    void getReadingsForReport(sdbusplus::message::message& msg)
     {
-        std::size_t found = objPath.find_last_of('/');
-        if (found == std::string::npos)
+        sdbusplus::message::object_path path(msg.get_path());
+        std::string id = path.filename();
+        if (id.empty())
         {
-            BMCWEB_LOG_DEBUG << "Invalid objPath received";
+            BMCWEB_LOG_ERROR << "Failed to get Id from path";
             return;
         }
 
-        std::string idStr = objPath.substr(found + 1);
-        if (idStr.empty())
+        std::string interface;
+        std::vector<
+            std::pair<std::string, std::variant<telemetry::TimestampReadings>>>
+            props;
+        std::vector<std::string> invalidProps;
+        msg.read(interface, props, invalidProps);
+
+        auto found =
+            std::find_if(props.begin(), props.end(),
+                         [](const auto& x) { return x.first == "Readings"; });
+        if (found == props.end())
         {
-            BMCWEB_LOG_DEBUG << "Invalid ID in objPath";
+            BMCWEB_LOG_INFO << "Failed to get Readings from Report properties";
             return;
         }
 
-        crow::connections::systemBus->async_method_call(
-            [idStr{std::move(idStr)}](
-                const boost::system::error_code ec,
-                boost::container::flat_map<
-                    std::string, std::variant<int32_t, ReadingsObjType>>&
-                    resp) {
-                if (ec)
-                {
-                    BMCWEB_LOG_DEBUG
-                        << "D-Bus call failed to GetAll metric readings.";
-                    return;
-                }
-
-                const int32_t* timestampPtr =
-                    std::get_if<int32_t>(&resp["Timestamp"]);
-                if (!timestampPtr)
-                {
-                    BMCWEB_LOG_DEBUG << "Failed to Get timestamp.";
-                    return;
-                }
-
-                ReadingsObjType* readingsPtr =
-                    std::get_if<ReadingsObjType>(&resp["Readings"]);
-                if (!readingsPtr)
-                {
-                    BMCWEB_LOG_DEBUG << "Failed to Get Readings property.";
-                    return;
-                }
-
-                if (!readingsPtr->size())
-                {
-                    BMCWEB_LOG_DEBUG << "No metrics report to be transferred";
-                    return;
-                }
-
-                for (const auto& it :
-                     EventServiceManager::getInstance().subscriptionsMap)
-                {
-                    std::shared_ptr<Subscription> entry = it.second;
-                    if (entry->eventFormatType == metricReportFormatType)
-                    {
-                        entry->filterAndSendReports(
-                            idStr, crow::utility::getDateTime(*timestampPtr),
-                            *readingsPtr);
-                    }
-                }
-            },
-            service, objPath, "org.freedesktop.DBus.Properties", "GetAll",
-            intf);
+        const std::variant<telemetry::TimestampReadings>& readings =
+            found->second;
+        for (const auto& it :
+             EventServiceManager::getInstance().subscriptionsMap)
+        {
+            Subscription& entry = *it.second.get();
+            if (entry.eventFormatType == metricReportFormatType)
+            {
+                entry.filterAndSendReports(id, readings);
+            }
+        }
     }
 
     void unregisterMetricReportSignal()
@@ -1419,9 +1375,9 @@ class EventServiceManager
         }
 
         BMCWEB_LOG_DEBUG << "Metrics report signal - Register";
-        std::string matchStr(
-            "type='signal',member='ReportUpdate', "
-            "interface='xyz.openbmc_project.MonitoringService.Report'");
+        std::string matchStr = "type='signal',member='PropertiesChanged',"
+                               "interface='org.freedesktop.DBus.Properties',"
+                               "arg0=xyz.openbmc_project.Telemetry.Report";
 
         matchTelemetryMonitor = std::make_shared<sdbusplus::bus::match::match>(
             *crow::connections::systemBus, matchStr,
@@ -1432,10 +1388,7 @@ class EventServiceManager
                     return;
                 }
 
-                std::string service = msg.get_sender();
-                std::string objPath = msg.get_path();
-                std::string intf = msg.get_interface();
-                getMetricReading(service, objPath, intf);
+                getReadingsForReport(msg);
             });
     }
 

--- a/redfish-core/lib/metric_report.hpp
+++ b/redfish-core/lib/metric_report.hpp
@@ -33,31 +33,29 @@ inline nlohmann::json toMetricValues(const Readings& readings)
     return metricValues;
 }
 
-inline void fillReport(const std::shared_ptr<bmcweb::AsyncResp>& asyncResp,
-                       const std::string& id,
+inline bool fillReport(nlohmann::json& json, const std::string& id,
                        const std::variant<TimestampReadings>& var)
 {
-    asyncResp->res.jsonValue["@odata.type"] =
-        "#MetricReport.v1_3_0.MetricReport";
-    asyncResp->res.jsonValue["@odata.id"] = telemetry::metricReportUri + id;
-    asyncResp->res.jsonValue["Id"] = id;
-    asyncResp->res.jsonValue["Name"] = id;
-    asyncResp->res.jsonValue["MetricReportDefinition"]["@odata.id"] =
-        telemetry::metricReportDefinitionUri + id;
+    json["@odata.type"] = "#MetricReport.v1_3_0.MetricReport";
+    json["@odata.id"] = telemetry::metricReportUri + std::string("/") + id;
+    json["Id"] = id;
+    json["Name"] = id;
+    json["MetricReportDefinition"]["@odata.id"] =
+        telemetry::metricReportDefinitionUri + std::string("/") + id;
 
     const TimestampReadings* timestampReadings =
         std::get_if<TimestampReadings>(&var);
     if (!timestampReadings)
     {
         BMCWEB_LOG_ERROR << "Property type mismatch or property is missing";
-        messages::internalError(asyncResp->res);
-        return;
+        return false;
     }
 
     const auto& [timestamp, readings] = *timestampReadings;
-    asyncResp->res.jsonValue["Timestamp"] =
+    json["Timestamp"] =
         crow::utility::getDateTime(static_cast<time_t>(timestamp));
-    asyncResp->res.jsonValue["MetricValues"] = toMetricValues(readings);
+    json["MetricValues"] = toMetricValues(readings);
+    return true;
 }
 } // namespace telemetry
 
@@ -118,7 +116,11 @@ inline void requestRoutesMetricReport(App& app)
                                     return;
                                 }
 
-                                telemetry::fillReport(asyncResp, id, ret);
+                                if (!telemetry::fillReport(
+                                        asyncResp->res.jsonValue, id, ret))
+                                {
+                                    messages::internalError(asyncResp->res);
+                                }
                             },
                             telemetry::service, reportPath,
                             "org.freedesktop.DBus.Properties", "Get",

--- a/redfish-core/lib/metric_report_definition.hpp
+++ b/redfish-core/lib/metric_report_definition.hpp
@@ -7,6 +7,8 @@
 #include <app.hpp>
 #include <boost/container/flat_map.hpp>
 #include <registries/privilege_registry.hpp>
+#include <sdbusplus/asio/property.hpp>
+#include <sdbusplus/unpack_properties.hpp>
 
 #include <tuple>
 #include <variant>
@@ -17,120 +19,158 @@ namespace redfish
 namespace telemetry
 {
 
-using ReadingParameters =
-    std::vector<std::tuple<sdbusplus::message::object_path, std::string,
-                           std::string, std::string>>;
+using ReadingParameters = std::vector<std::tuple<
+    std::vector<std::tuple<sdbusplus::message::object_path, std::string>>,
+    std::string, std::string, std::string, uint64_t>>;
+
+std::string toReadfishReportAction(std::string_view action)
+{
+    if (action == "EmitsReadingsUpdate")
+    {
+        return "RedfishEvent";
+    }
+    if (action == "LogToMetricReportsCollection")
+    {
+        return "LogToMetricReportsCollection";
+    }
+    return "";
+}
+
+std::string toDbusReportAction(std::string_view action)
+{
+    if (action == "RedfishEvent")
+    {
+        return "EmitsReadingsUpdate";
+    }
+    if (action == "LogToMetricReportsCollection")
+    {
+        return "LogToMetricReportsCollection";
+    }
+    return "";
+}
 
 inline void fillReportDefinition(
     const std::shared_ptr<bmcweb::AsyncResp>& asyncResp, const std::string& id,
     const std::vector<
-        std::pair<std::string, std::variant<std::string, bool, uint64_t,
-                                            ReadingParameters>>>& ret)
+        std::pair<std::string, std::variant<std::monostate, std::string, bool,
+                                            uint64_t, std::vector<std::string>,
+                                            ReadingParameters>>>& properties)
 {
-    asyncResp->res.jsonValue["@odata.type"] =
-        "#MetricReportDefinition.v1_3_0.MetricReportDefinition";
-    asyncResp->res.jsonValue["@odata.id"] =
-        telemetry::metricReportDefinitionUri + id;
-    asyncResp->res.jsonValue["Id"] = id;
-    asyncResp->res.jsonValue["Name"] = id;
-    asyncResp->res.jsonValue["MetricReport"]["@odata.id"] =
-        telemetry::metricReportUri + id;
-    asyncResp->res.jsonValue["Status"]["State"] = "Enabled";
-    asyncResp->res.jsonValue["ReportUpdates"] = "Overwrite";
+    try
+    {
+        std::vector<std::string> reportActions;
+        ReadingParameters readingParams;
+        std::string reportingType;
+        std::string reportUpdates;
+        std::string name;
+        uint64_t appendLimit = 0u;
+        uint64_t interval = 0u;
 
-    const bool* emitsReadingsUpdate = nullptr;
-    const bool* logToMetricReportsCollection = nullptr;
-    const ReadingParameters* readingParams = nullptr;
-    const std::string* reportingType = nullptr;
-    const uint64_t* interval = nullptr;
-    for (const auto& [key, var] : ret)
-    {
-        if (key == "EmitsReadingsUpdate")
+        sdbusplus::unpackProperties(
+            properties, "ReportActions", reportActions, "ReportUpdates",
+            reportUpdates, "AppendLimit", appendLimit,
+            "ReadingParametersFutureVersion", readingParams, "ReportingType",
+            reportingType, "Interval", interval, "Name", name);
+
+        for (std::string& action : reportActions)
         {
-            emitsReadingsUpdate = std::get_if<bool>(&var);
+            action = toReadfishReportAction(action);
+
+            if (action.empty())
+            {
+                messages::internalError(asyncResp->res);
+                return;
+            }
         }
-        else if (key == "LogToMetricReportsCollection")
+
+        nlohmann::json metrics = nlohmann::json::array();
+        for (auto& [sensorData, collectionFunction, id, collectionTimeScope,
+                    collectionDuration] : readingParams)
         {
-            logToMetricReportsCollection = std::get_if<bool>(&var);
+            std::vector<std::string> metricProperties;
+
+            for (auto& [sensorPath, sensorMetadata] : sensorData)
+            {
+                metricProperties.emplace_back(std::move(sensorMetadata));
+            }
+
+            metrics.push_back(
+                {{"MetricId", std::move(id)},
+                 {"MetricProperties", std::move(metricProperties)},
+                 {"CollectionFunction", std::move(collectionFunction)},
+                 {"CollectionDuration",
+                  time_utils::toDurationString(
+                      std::chrono::milliseconds(collectionDuration))},
+                 {"CollectionTimeScope", std::move(collectionTimeScope)}});
         }
-        else if (key == "ReadingParameters")
-        {
-            readingParams = std::get_if<ReadingParameters>(&var);
-        }
-        else if (key == "ReportingType")
-        {
-            reportingType = std::get_if<std::string>(&var);
-        }
-        else if (key == "Interval")
-        {
-            interval = std::get_if<uint64_t>(&var);
-        }
+
+        asyncResp->res.jsonValue["@odata.type"] =
+            "#MetricReportDefinition.v1_3_0.MetricReportDefinition";
+        asyncResp->res.jsonValue["@odata.id"] =
+            telemetry::metricReportDefinitionUri + std::string("/") + id;
+        asyncResp->res.jsonValue["Id"] = id;
+        asyncResp->res.jsonValue["Name"] = name;
+        asyncResp->res.jsonValue["MetricReport"]["@odata.id"] =
+            telemetry::metricReportUri + std::string("/") + id;
+        asyncResp->res.jsonValue["Status"]["State"] = "Enabled";
+        asyncResp->res.jsonValue["ReportUpdates"] = reportUpdates;
+        asyncResp->res.jsonValue["AppendLimit"] = appendLimit;
+        asyncResp->res.jsonValue["Metrics"] = metrics;
+        asyncResp->res.jsonValue["MetricReportDefinitionType"] = reportingType;
+        asyncResp->res.jsonValue["ReportActions"] = reportActions;
+        asyncResp->res.jsonValue["Schedule"]["RecurrenceInterval"] =
+            time_utils::toDurationString(std::chrono::milliseconds(interval));
     }
-    if (!emitsReadingsUpdate || !logToMetricReportsCollection ||
-        !readingParams || !reportingType || !interval)
+    catch (const sdbusplus::exception::UnpackPropertyError& error)
     {
-        BMCWEB_LOG_ERROR << "Property type mismatch or property is missing";
+        BMCWEB_LOG_ERROR << error.what() << ", property: "
+                         << error.propertyName + ", reason: " << error.reason;
+        messages::queryParameterValueFormatError(
+            asyncResp->res,
+            std::string(error.propertyName) + " " + std::string(error.reason),
+            error.what());
         messages::internalError(asyncResp->res);
-        return;
     }
-
-    std::vector<std::string> redfishReportActions;
-    redfishReportActions.reserve(2);
-    if (*emitsReadingsUpdate)
-    {
-        redfishReportActions.emplace_back("RedfishEvent");
-    }
-    if (*logToMetricReportsCollection)
-    {
-        redfishReportActions.emplace_back("LogToMetricReportsCollection");
-    }
-
-    nlohmann::json metrics = nlohmann::json::array();
-    for (auto& [sensorPath, operationType, id, metadata] : *readingParams)
-    {
-        metrics.push_back({
-            {"MetricId", id},
-            {"MetricProperties", {metadata}},
-        });
-    }
-    asyncResp->res.jsonValue["Metrics"] = metrics;
-    asyncResp->res.jsonValue["MetricReportDefinitionType"] = *reportingType;
-    asyncResp->res.jsonValue["ReportActions"] = redfishReportActions;
-    asyncResp->res.jsonValue["Schedule"]["RecurrenceInterval"] =
-        time_utils::toDurationString(std::chrono::milliseconds(*interval));
 }
 
 struct AddReportArgs
 {
-    std::string name;
+    struct MetricArgs
+    {
+        std::string id;
+        std::vector<std::string> uris;
+        std::optional<std::string> collectionFunction;
+        std::optional<std::string> collectionTimeScope;
+        std::optional<uint64_t> collectionDuration;
+    };
+
+    std::optional<std::string> id;
+    std::optional<std::string> name;
     std::string reportingType;
-    bool emitsReadingsUpdate = false;
-    bool logToMetricReportsCollection = false;
+    std::optional<std::string> reportUpdates;
+    std::optional<uint64_t> appendLimit;
+    std::vector<std::string> reportActions;
     uint64_t interval = 0;
-    std::vector<std::pair<std::string, std::vector<std::string>>> metrics;
+    std::vector<MetricArgs> metrics;
 };
 
 inline bool toDbusReportActions(crow::Response& res,
-                                std::vector<std::string>& actions,
+                                const std::vector<std::string>& actions,
                                 AddReportArgs& args)
 {
     size_t index = 0;
-    for (auto& action : actions)
+    for (const auto& action : actions)
     {
-        if (action == "RedfishEvent")
-        {
-            args.emitsReadingsUpdate = true;
-        }
-        else if (action == "LogToMetricReportsCollection")
-        {
-            args.logToMetricReportsCollection = true;
-        }
-        else
+        std::string dbusReportAction = toDbusReportAction(action);
+
+        if (dbusReportAction.empty())
         {
             messages::propertyValueNotInList(
                 res, action, "ReportActions/" + std::to_string(index));
             return false;
         }
+
+        args.reportActions.emplace_back(std::move(dbusReportAction));
         index++;
     }
     return true;
@@ -142,23 +182,12 @@ inline bool getUserParameters(crow::Response& res, const crow::Request& req,
     std::vector<nlohmann::json> metrics;
     std::vector<std::string> reportActions;
     std::optional<nlohmann::json> schedule;
-    if (!json_util::readJson(req, res, "Id", args.name, "Metrics", metrics,
-                             "MetricReportDefinitionType", args.reportingType,
-                             "ReportActions", reportActions, "Schedule",
-                             schedule))
+    if (!json_util::readJson(
+            req, res, "Id", args.id, "Name", args.name, "Metrics", metrics,
+            "MetricReportDefinitionType", args.reportingType, "ReportUpdates",
+            args.reportUpdates, "AppendLimit", args.appendLimit,
+            "ReportActions", reportActions, "Schedule", schedule))
     {
-        return false;
-    }
-
-    constexpr const char* allowedCharactersInName =
-        "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789_";
-    if (args.name.empty() || args.name.find_first_not_of(
-                                 allowedCharactersInName) != std::string::npos)
-    {
-        BMCWEB_LOG_ERROR << "Failed to match " << args.name
-                         << " with allowed character "
-                         << allowedCharactersInName;
-        messages::propertyValueIncorrect(res, "Id", args.name);
         return false;
     }
 
@@ -203,15 +232,35 @@ inline bool getUserParameters(crow::Response& res, const crow::Request& req,
     args.metrics.reserve(metrics.size());
     for (auto& m : metrics)
     {
-        std::string id;
-        std::vector<std::string> uris;
-        if (!json_util::readJson(m, res, "MetricId", id, "MetricProperties",
-                                 uris))
+        std::optional<std::string> collectionDurationStr;
+        AddReportArgs::MetricArgs metricArgs;
+        if (!json_util::readJson(
+                m, res, "MetricId", metricArgs.id, "MetricProperties",
+                metricArgs.uris, "CollectionFunction",
+                metricArgs.collectionFunction, "CollectionTimeScope",
+                metricArgs.collectionTimeScope, "CollectionDuration",
+                collectionDurationStr))
         {
             return false;
         }
 
-        args.metrics.emplace_back(std::move(id), std::move(uris));
+        if (collectionDurationStr)
+        {
+            std::optional<std::chrono::milliseconds> duration =
+                time_utils::fromDurationString(*collectionDurationStr);
+
+            if (!duration || duration->count() < 0)
+            {
+                messages::propertyValueIncorrect(res, "CollectionDuration",
+                                                 *collectionDurationStr);
+                return false;
+            }
+
+            metricArgs.collectionDuration =
+                static_cast<uint64_t>(duration->count());
+        }
+
+        args.metrics.emplace_back(std::move(metricArgs));
     }
 
     return true;
@@ -219,15 +268,14 @@ inline bool getUserParameters(crow::Response& res, const crow::Request& req,
 
 inline bool getChassisSensorNode(
     const std::shared_ptr<bmcweb::AsyncResp>& asyncResp,
-    const std::vector<std::pair<std::string, std::vector<std::string>>>&
-        metrics,
+    const std::vector<AddReportArgs::MetricArgs>& metrics,
     boost::container::flat_set<std::pair<std::string, std::string>>& matched)
 {
-    for (const auto& [id, uris] : metrics)
+    for (const auto& metric : metrics)
     {
-        for (size_t i = 0; i < uris.size(); i++)
+        for (size_t i = 0; i < metric.uris.size(); i++)
         {
-            const std::string& uri = uris[i];
+            const std::string& uri = metric.uris[i];
             std::string chassis;
             std::string node;
 
@@ -273,11 +321,16 @@ class AddReport
         telemetry::ReadingParameters readingParams;
         readingParams.reserve(args.metrics.size());
 
-        for (const auto& [id, uris] : args.metrics)
+        for (auto& metric : args.metrics)
         {
-            for (size_t i = 0; i < uris.size(); i++)
+            std::vector<
+                std::tuple<sdbusplus::message::object_path, std::string>>
+                sensorParams;
+            sensorParams.reserve(metric.uris.size());
+
+            for (size_t i = 0; i < metric.uris.size(); i++)
             {
-                const std::string& uri = uris[i];
+                const std::string& uri = metric.uris[i];
                 auto el = uriToDbus.find(uri);
                 if (el == uriToDbus.end())
                 {
@@ -291,17 +344,23 @@ class AddReport
                 }
 
                 const std::string& dbusPath = el->second;
-                readingParams.emplace_back(dbusPath, "SINGLE", id, uri);
+                sensorParams.emplace_back(dbusPath, uri);
             }
+
+            readingParams.emplace_back(
+                std::move(sensorParams), metric.collectionFunction.value_or(""),
+                std::move(metric.id), metric.collectionTimeScope.value_or(""),
+                metric.collectionDuration.value_or(0u));
         }
         const std::shared_ptr<bmcweb::AsyncResp> aResp = asyncResp;
         crow::connections::systemBus->async_method_call(
-            [aResp, name = args.name, uriToDbus = std::move(uriToDbus)](
+            [aResp, id = args.id.value_or(""),
+             uriToDbus = std::move(uriToDbus)](
                 const boost::system::error_code ec, const std::string&) {
                 if (ec == boost::system::errc::file_exists)
                 {
                     messages::resourceAlreadyExists(
-                        aResp->res, "MetricReportDefinition", "Id", name);
+                        aResp->res, "MetricReportDefinition", "Id", id);
                     return;
                 }
                 if (ec == boost::system::errc::too_many_files_open)
@@ -330,10 +389,12 @@ class AddReport
                 messages::created(aResp->res);
             },
             telemetry::service, "/xyz/openbmc_project/Telemetry/Reports",
-            "xyz.openbmc_project.Telemetry.ReportManager", "AddReport",
-            "TelemetryService/" + args.name, args.reportingType,
-            args.emitsReadingsUpdate, args.logToMetricReportsCollection,
-            args.interval, readingParams);
+            "xyz.openbmc_project.Telemetry.ReportManager",
+            "AddReportFutureVersion",
+            "TelemetryService/" + args.id.value_or(""), args.name.value_or(""),
+            args.reportingType, args.reportUpdates.value_or("Overwrite"),
+            args.appendLimit.value_or(0), args.reportActions, args.interval,
+            readingParams);
     }
 
     void insert(const boost::container::flat_map<std::string, std::string>& el)
@@ -419,13 +480,18 @@ inline void requestRoutesMetricReportDefinition(App& app)
             [](const crow::Request&,
                const std::shared_ptr<bmcweb::AsyncResp>& asyncResp,
                const std::string& id) {
-                crow::connections::systemBus->async_method_call(
-                    [asyncResp, id](
-                        const boost::system::error_code ec,
-                        const std::vector<std::pair<
-                            std::string,
-                            std::variant<std::string, bool, uint64_t,
-                                         telemetry::ReadingParameters>>>& ret) {
+                sdbusplus::asio::getAllProperties(
+                    *crow::connections::systemBus, telemetry::service,
+                    telemetry::getDbusReportPath(id),
+                    telemetry::reportInterface,
+                    [asyncResp,
+                     id](boost::system::error_code ec,
+                         const std::vector<std::pair<
+                             std::string,
+                             std::variant<std::monostate, std::string, bool,
+                                          uint64_t, std::vector<std::string>,
+                                          telemetry::ReadingParameters>>>&
+                             properties) {
                         if (ec.value() == EBADR ||
                             ec == boost::system::errc::host_unreachable)
                         {
@@ -440,12 +506,11 @@ inline void requestRoutesMetricReportDefinition(App& app)
                             return;
                         }
 
-                        telemetry::fillReportDefinition(asyncResp, id, ret);
-                    },
-                    telemetry::service, telemetry::getDbusReportPath(id),
-                    "org.freedesktop.DBus.Properties", "GetAll",
-                    telemetry::reportInterface);
+                        telemetry::fillReportDefinition(asyncResp, id,
+                                                        properties);
+                    });
             });
+
     BMCWEB_ROUTE(app,
                  "/redfish/v1/TelemetryService/MetricReportDefinitions/<str>/")
         .privileges(redfish::privileges::deleteMetricReportDefinitionCollection)


### PR DESCRIPTION
1) Refactor MetricReport in EventService.
2) Add CollectionTimeScope, CollectionFunction, CollectionDuration to MetricReportDefinition schema.


This PR requires a rebase of [Telemetry repo on upstream master for synchronization between bmcweb and telemetry binaries.](https://github.com/openbmc/telemetry/commits/master)
GHE-1020 srcrev bump: https://github.ibm.com/openbmc/openbmc/pull/1653 

NB:

1. Using ReportUpdate signal is no longer supported. Instead, Event Service monitors for PropertiesChanged signal from /xyz/openbmc_project/Telemetry/Reports path.  

Commits:
"Sync Telmetry service with EventService":
Change-Id: I2fc1841a6c9259a8bff30b34bddc0d4aabd41912

"Switched bmcweb to use new telemetry service API":
Change-Id: I2cd17069e3ea015c8f5571c29278f1d50536272a
https://gerrit.openbmc-project.xyz/c/openbmc/bmcweb/+/44270/25