### PR TITLE
Remove link from Chassis to PCIeDevice

### DIFF
--- a/redfish-core/lib/chassis.hpp
+++ b/redfish-core/lib/chassis.hpp
@@ -313,9 +313,6 @@ inline void requestRoutesChassis(App& app)
                              {"@Redfish.ActionInfo", "/redfish/v1/Chassis/" +
                                                          chassisId +
                                                          "/ResetActionInfo"}};
-                        asyncResp->res.jsonValue["PCIeDevices"] = {
-                            {"@odata.id",
-                             "/redfish/v1/Systems/system/PCIeDevices"}};
 
                         const std::string& connectionName =
                             connectionNames[0].first;


### PR DESCRIPTION
The commit removes current support that assumes 1:1
system:Chassis for Chassis/PCIeDevices.

Current implementation populates the same collection of
PCIeDevices w.r.t chassis as w.r.t. system.
For systems with multiple chassis the current assumption
does not hold true.

Validator has been executed with no new errors.

Signed-off-by: Sunny Srivastava <sunnsr25@in.ibm.com>