### PR TITLE
1020: Add Spare Part Number for Chassis

### DIFF
--- a/redfish-core/lib/chassis.hpp
+++ b/redfish-core/lib/chassis.hpp
@@ -434,17 +434,32 @@ inline void requestRoutesChassis(App& app)
                                     if ((propertyName == "PartNumber") ||
                                         (propertyName == "SerialNumber") ||
                                         (propertyName == "Manufacturer") ||
-                                        (propertyName == "Model"))
+                                        (propertyName == "Model") ||
+                                        (propertyName == "SparePartNumber"))
                                     {
                                         const std::string* value =
                                             std::get_if<std::string>(
                                                 &property.second);
-                                        if (value != nullptr)
+                                        if (value == nullptr)
                                         {
-                                            asyncResp->res
-                                                .jsonValue[propertyName] =
-                                                *value;
+                                            BMCWEB_LOG_ERROR
+                                                << "Null value returned for "
+                                                << propertyName;
+                                            messages::internalError(
+                                                asyncResp->res);
+                                            return;
                                         }
+                                        // SparePartNumber is optional on D-Bus
+                                        // so skip if it is empty
+                                        if (propertyName == "SparePartNumber")
+                                        {
+                                            if (*value == "")
+                                            {
+                                                continue;
+                                            }
+                                        }
+                                        asyncResp->res.jsonValue[propertyName] =
+                                            *value;
                                     }
                                 }
                                 asyncResp->res.jsonValue["Name"] = chassisId;


### PR DESCRIPTION
From original commit msg:
Spare part number field is missing from Chassis URI via Redfish
This commit added that.

Test:
curl -k -H "X-Auth-Token: $bmc_token" -X GET https://${bmc}:${port}/redfish/v1/Chassis/chassis
{
"@odata.id": "/redfish/v1/Chassis/chassis",
"@odata.type": "#Chassis.v1_14_0.Chassis",
"Actions": {
"#Chassis.Reset": {
"@Redfish.ActionInfo": "/redfish/v1/Chassis/chassis/ResetActionInfo",
"target": "/redfish/v1/Chassis/chassis/Actions/Chassis.Reset"
}
},
"ChassisType": "RackMount",
"Id": "chassis",
...
"Location": {
"PartLocation": {
"ServiceLabel": "U78DA.ND0.WZS0066"
}
},
"Manufacturer": "",
"Model": "2E2D",
"Name": "chassis",
...
"PartNumber": "03KP024",
...
"PowerState": "Off",
...
"SerialNumber": "YF32UF18C00A",
"SparePartNumber": "02WG677", <-------------------SparePartNumber
"Status": {
"Health": "OK",
"HealthRollup": "OK",
"State": "StandbyOffline"
},

Signed-off-by: Alpana Kumari alpankum@in.ibm.com
Change-Id: I3a67ddb947ae94180fc206ce5c5870057b36ee47