### PR TITLE
Redfish: PCIeSlots support empty JSON object in do PATCH command

### DIFF
--- a/redfish-core/lib/pcie_slots.hpp
+++ b/redfish-core/lib/pcie_slots.hpp
@@ -697,17 +697,21 @@ inline void requestRoutesPCIeSlots(App& app)
                 unsigned int total = 0;
                 for (auto& slot : slots)
                 {
-                    bool locationIndicatorActive;
-
                     slotIndex++;
-                    if (!json_util::readJson(slot, asyncResp->res,
-                                             "LocationIndicatorActive",
-                                             locationIndicatorActive))
+
+                    if (slot.empty())
                     {
-                        return;
+                        continue;
                     }
-                    locationIndicatorActiveMap[slotIndex] =
-                        locationIndicatorActive;
+
+                    bool locationIndicatorActive;
+                    if (json_util::readJson(slot, asyncResp->res,
+                                            "LocationIndicatorActive",
+                                            locationIndicatorActive))
+                    {
+                        locationIndicatorActiveMap[slotIndex] =
+                            locationIndicatorActive;
+                    }
                 }
 
                 total = slotIndex;


### PR DESCRIPTION
PCIeSlots support empty JSON object in do PATCH command

Tested:
If we have 10 pcieslots,and we want to set 2nd slot's
LocationIndicatorActive to true, we can use the following command:
curl -k -H "X-Auth-Token: $token" -X PATCH -d
'{"Slots":[{},{"LocationIndicatorActive":true},{},{},{},{},{},{},{},{}]}'

Signed-off-by: Chicago Duan <duanzhijia01@inspur.com>