### PR TITLE
Redfish: Implements Redfish Assembly Health

### DIFF
--- a/redfish-core/lib/assembly.hpp
+++ b/redfish-core/lib/assembly.hpp
@@ -47,6 +47,10 @@ inline void
         tempyArray.at(assemblyIndex)["Name"] =
             sdbusplus::message::object_path(assembly).filename();
 
+        // Set the default Status
+        tempyArray.at(assemblyIndex)["Status"]["Health"] = "OK";
+        tempyArray.at(assemblyIndex)["Status"]["State"] = "Enabled";
+
         crow::connections::systemBus->async_method_call(
             [aResp, assemblyIndex, assembly](
                 const boost::system::error_code ec,
@@ -194,6 +198,47 @@ inline void
                                 "xyz.openbmc_project.Inventory.Decorator."
                                 "LocationCode",
                                 "LocationCode");
+                        }
+                        else if (interface == "xyz.openbmc_project.State."
+                                              "Decorator.OperationalStatus")
+                        {
+                            crow::connections::systemBus->async_method_call(
+                                [aResp, assemblyIndex](
+                                    const boost::system::error_code ec,
+                                    const std::variant<bool>& property) {
+                                    if (ec)
+                                    {
+                                        BMCWEB_LOG_DEBUG
+                                            << "DBUS response error";
+                                        messages::internalError(aResp->res);
+                                        return;
+                                    }
+
+                                    nlohmann::json& assemblyArray =
+                                        aResp->res.jsonValue["Assemblies"];
+                                    nlohmann::json& assemblyData =
+                                        assemblyArray.at(assemblyIndex);
+
+                                    const bool* value =
+                                        std::get_if<bool>(&property);
+
+                                    if (value == nullptr)
+                                    {
+                                        // illegal value
+                                        messages::internalError(aResp->res);
+                                        return;
+                                    }
+                                    if (*value == false)
+                                    {
+                                        assemblyData["Status"]["Health"] =
+                                            "Critical";
+                                    }
+                                },
+                                serviceName, assembly,
+                                "org.freedesktop.DBus.Properties", "Get",
+                                "xyz.openbmc_project.State.Decorator."
+                                "OperationalStatus",
+                                "Functional");
                         }
                     }
                 }


### PR DESCRIPTION
Look for the OperationalStatus to set the Assembly Health.
If the OperationalStatus is false, then set the Health to "Critical"
If the OperationalStatus is true, then the Health is "OK"

Signed-off-by: Chicago Duan <duanzhijia01@inspur.com>