### PR TITLE
Remove setting of enabled property of hyp eth obj

### DIFF
--- a/redfish-core/lib/hypervisor_system.hpp
+++ b/redfish-core/lib/hypervisor_system.hpp
@@ -590,11 +590,6 @@ inline void handleHypervisorIPv4StaticPatch(
                              asyncResp);
         // Set the DHCPEnabled to false since the Static IPv4 is set
         setDHCPEnabled(ifaceId, false, asyncResp);
-
-        // Set this interface to disabled/inactive. This will be set
-        // to enabled/active by the pldm once the hypervisor
-        // consumes the updated settings from the user.
-        setIPv4InterfaceEnabled(ifaceId, false, asyncResp);
     }
     else
     {


### PR DESCRIPTION
This change removes the explicit setting of enabled property
to false whenever user configures a new ip. The flow will be
like: user configures an ip (patch) -> bmcweb calls the create ip
method of the dbus object -> ip address object will be updated with
user given values -> pldm sets the enabled property to true when the
host consumes it. bmcweb need not explicitly set the ip address.

Tested By:

* Poweroff host
GET https://${bmc}/redfish/v1/Systems/hypervisor/EthernetInterfaces/eth1{
  "@odata.id": "/redfish/v1/Systems/hypervisor/EthernetInterfaces/eth1",
  "@odata.type": "#EthernetInterface.v1_5_1.EthernetInterface",
  "DHCPv4": {
    "DHCPEnabled": false
  },
  "Description": "Hypervisor's Virtual Management Ethernet Interface",
  "HostName": "hn",
  "IPv4Addresses": [],
  "IPv4StaticAddresses": [],
  "Id": "eth1",
  "InterfaceEnabled": true,
  "Name": "Hypervisor Ethernet Interface"
}

* Then patch vmi ip:
PATCH -d '{"IPv4StaticAddresses":[{"Address": "9.3.197.5","SubnetMask": \
"255.255.255.0","Gateway":"9.3.197.1"}]}' https://${bmc}/redfish/v1/Systems/hypervisor/EthernetInterfaces/eth1

busctl introspect xyz.openbmc_project.Network.Hypervisor /xyz/openbmc_project/network/hypervisor/eth1/ipv4/addr0
NAME                                TYPE      SIGNATURE RESULT/VALUE                             FLAGS
org.freedesktop.DBus.Introspectable interface -         -                                        -
.Introspect                         method    -         s                                        -
org.freedesktop.DBus.Peer           interface -         -                                        -
.GetMachineId                       method    -         s                                        -
.Ping                               method    -         -                                        -
org.freedesktop.DBus.Properties     interface -         -                                        -
.Get                                method    ss        v                                        -
.GetAll                             method    s         a{sv}                                    -
.Set                                method    ssv       -                                        -
.PropertiesChanged                  signal    sa{sv}as  -                                        -
xyz.openbmc_project.Network.IP      interface -         -                                        -
.Address                            property  s         "9.3.197.4"                              emits-change writable
.Gateway                            property  s         "9.3.197.1"                              emits-change writable
.Origin                             property  s         "xyz.openbmc_project.Network.IP.Address… emits-change writable
.PrefixLength                       property  y         24                                       emits-change writable
.Type                               property  s         "xyz.openbmc_project.Network.IP.Protoco… emits-change writable
xyz.openbmc_project.Object.Delete   interface -         -                                        -
.Delete                             method    -         -                                        -
xyz.openbmc_project.Object.Enable   interface -         -                                        -
.Enabled                            property  b         false                                    emits-change writable

* Poweron the host:
GET https://${bmc}/redfish/v1/Systems/hypervisor/EthernetInterfaces/eth1{
  "@odata.id": "/redfish/v1/Systems/hypervisor/EthernetInterfaces/eth1",
  "@odata.type": "#EthernetInterface.v1_5_1.EthernetInterface",
  "DHCPv4": {
    "DHCPEnabled": false
  },
  "Description": "Hypervisor's Virtual Management Ethernet Interface",
  "HostName": "hn",
  "IPv4Addresses": [
    {
      "Address": "9.3.197.4",
      "AddressOrigin": "Static",
      "Gateway": "9.3.197.1",
      "SubnetMask": "255.255.255.0"
    }
  ],
  "IPv4StaticAddresses": [
    {
      "Address": "9.3.197.4",
      "AddressOrigin": "Static",
      "Gateway": "9.3.197.1",
      "SubnetMask": "255.255.255.0"
    }
  ],
  "Id": "eth1",
  "InterfaceEnabled": true,
  "Name": "Hypervisor Ethernet Interface"
}

busctl introspect xyz.openbmc_project.Network.Hypervisor /xyz/openbmc_project/network/hypervisor/eth1/ipv4/addr0
NAME                                TYPE      SIGNATURE RESULT/VALUE                             FLAGS
org.freedesktop.DBus.Introspectable interface -         -                                        -
.Introspect                         method    -         s                                        -
org.freedesktop.DBus.Peer           interface -         -                                        -
.GetMachineId                       method    -         s                                        -
.Ping                               method    -         -                                        -
org.freedesktop.DBus.Properties     interface -         -                                        -
.Get                                method    ss        v                                        -
.GetAll                             method    s         a{sv}                                    -
.Set                                method    ssv       -                                        -
.PropertiesChanged                  signal    sa{sv}as  -                                        -
xyz.openbmc_project.Network.IP      interface -         -                                        -
.Address                            property  s         "9.3.197.4"                              emits-change writable
.Gateway                            property  s         "9.3.197.1"                              emits-change writable
.Origin                             property  s         "xyz.openbmc_project.Network.IP.Address… emits-change writable
.PrefixLength                       property  y         24                                       emits-change writable
.Type                               property  s         "xyz.openbmc_project.Network.IP.Protoco… emits-change writable
xyz.openbmc_project.Object.Delete   interface -         -                                        -
.Delete                             method    -         -                                        -
xyz.openbmc_project.Object.Enable   interface -         -                                        -
.Enabled                            property  b         true                                     emits-change writable

Signed-off-by: Asmitha Karunanithi <asmitk01@in.ibm.com>