### PR TITLE
Fix ProcessorSummary CoreCount

### DIFF
--- a/redfish-core/lib/systems.hpp
+++ b/redfish-core/lib/systems.hpp
@@ -247,11 +247,11 @@ inline void getProcessorProperties(
 
             nlohmann::json& coreCount =
                 aResp->res.jsonValue["ProcessorSummary"]["CoreCount"];
-            uint64_t* coreCountPtr = coreCount.get_ptr<uint64_t*>();
+            int64_t* coreCountPtr = coreCount.get_ptr<int64_t*>();
 
             if (coreCountPtr == nullptr)
             {
-                coreCount = 0;
+                coreCount = *coreCountVal;
             }
             else
             {


### PR DESCRIPTION
There are 2 fixes here. 1) To account for integer representation in
json and 2) To fix the initial coreCount value.

1) The ProcessorSummary CoreCount is interpreted as a json integer.
nlohmann::json::get_ptr() wants a nlohmann::json::number_integer_t,
which by default is std:int64_t.
Switched from uint64_t to int64_t to pick up the previous value set
for CoreCount.

2) Previously, the Redfish CoreCount was set to 0 if json::get_ptr
returned a nullptr. Really, Redfish CoreCount should be set to whatever
value was recieved from dbus.

Signed-off-by: Ali Ahmed <ama213000@gmail.com>
Change-Id: Ie054d378154d152dda98df3d53b2966cb5928b22