### PR TITLE
Fix bmcweb crash when patching bios attributes

### DIFF
--- a/redfish-core/lib/bios.hpp
+++ b/redfish-core/lib/bios.hpp
@@ -451,59 +451,62 @@ inline void requestRoutesBiosSettings(App& app)
                             mapAttrTypeToRedfish(biosAttrType);
                         if (biosRedfishAttrType == "Integer")
                         {
-                            try
-                            {
-                                int64_t attrValue = attrItr.value();
-                                pendingAttributes.emplace_back(std::make_pair(
-                                    attrName,
-                                    std::make_tuple(biosAttrType, attrValue)));
-                            }
-                            catch (nlohmann::detail::type_error& e)
+                            if (attrItr.value().type() !=
+                                nlohmann::json::value_t::number_unsigned)
                             {
                                 BMCWEB_LOG_ERROR
                                     << "The value must be of type int";
-                                messages::propertyValueTypeError(
-                                    asyncResp->res, attrItr.value(), attrName);
+                                std::string val =
+                                    boost::lexical_cast<std::string>(
+                                        attrItr.value());
+                                messages::propertyValueTypeError(asyncResp->res,
+                                                                 val, attrName);
                                 return;
                             }
+                            int64_t attrValue = attrItr.value();
+                            pendingAttributes.emplace_back(std::make_pair(
+                                attrName,
+                                std::make_tuple(biosAttrType, attrValue)));
                         }
                         else if (biosRedfishAttrType == "String" ||
                                  biosRedfishAttrType == "Enumeration" ||
                                  biosRedfishAttrType == "Password")
                         {
-                            try
-                            {
-                                std::string attrValue = attrItr.value();
-                                pendingAttributes.emplace_back(std::make_pair(
-                                    attrName,
-                                    std::make_tuple(biosAttrType, attrValue)));
-                            }
-                            catch (nlohmann::detail::type_error& e)
+                            if (attrItr.value().type() !=
+                                nlohmann::json::value_t::string)
                             {
                                 BMCWEB_LOG_ERROR
                                     << "The value must be of type string";
+                                std::string val =
+                                    boost::lexical_cast<std::string>(
+                                        attrItr.value());
                                 messages::propertyValueTypeError(asyncResp->res,
-                                                                 "", attrName);
+                                                                 val, attrName);
                                 return;
                             }
+                            std::string attrValue = attrItr.value();
+                            pendingAttributes.emplace_back(std::make_pair(
+                                attrName,
+                                std::make_tuple(biosAttrType, attrValue)));
                         }
                         else if (biosRedfishAttrType == "Boolean")
                         {
-                            try
-                            {
-                                bool attrValue = attrItr.value();
-                                pendingAttributes.emplace_back(std::make_pair(
-                                    attrName,
-                                    std::make_tuple(biosAttrType, attrValue)));
-                            }
-                            catch (nlohmann::detail::type_error& e)
+                            if (attrItr.value().type() !=
+                                nlohmann::json::value_t::boolean)
                             {
                                 BMCWEB_LOG_ERROR
                                     << "The value must be of type bool";
+                                std::string val =
+                                    boost::lexical_cast<std::string>(
+                                        attrItr.value());
                                 messages::propertyValueTypeError(asyncResp->res,
-                                                                 "", attrName);
+                                                                 val, attrName);
                                 return;
                             }
+                            bool attrValue = attrItr.value();
+                            pendingAttributes.emplace_back(std::make_pair(
+                                attrName,
+                                std::make_tuple(biosAttrType, attrValue)));
                         }
                         else
                         {


### PR DESCRIPTION
Bmcweb crashes when a bios attribute is patched with a value of
type that is not accepted. Say, when patching an attribute of
type string with other types - bool, float, int, bmcweb crashes
(current implementation). This pr fixes this issue by validating
the type of user given value in the redfish request.

This fixes the following defect:
https://w3.rchland.ibm.com/projects/bestquest/?defect=SW541381

Upstream commit:
https://gerrit.openbmc-project.xyz/c/openbmc/bmcweb/+/38702

Tested By:

* Int datatype:

PATCH -d '{"Attributes": {"vmi_if0_ipv4_prefix_length": 22}}' https://${bmc}/redfish/v1/Systems/system/Bios/Settings
>> Success

PATCH -d '{"Attributes": {"vmi_if0_ipv4_prefix_length":"24"}}' https://${bmc}/redfish/v1/Systems/system/Bios/Settings
{
  "vmi_if0_ipv4_prefix_length@Message.ExtendedInfo": [
    {
      "@odata.type": "#Message.v1_1_1.Message",
      "Message": "The value \"24\" for the property vmi_if0_ipv4_prefix_length is of a different type than the property can accept.",
      "MessageArgs": [
        "\"24\"",
        "vmi_if0_ipv4_prefix_length"
      ],
      "MessageId": "Base.1.8.1.PropertyValueTypeError",
      "MessageSeverity": "Warning",
      "Resolution": "Correct the value for the property in the request body and resubmit the request if the operation failed."
    }
  ]
}

PATCH -d '{"Attributes": {"vmi_if0_ipv4_prefix_length": true}}' https://${bmc}/redfish/v1/Systems/system/Bios/Settings
{
  "vmi_if0_ipv4_prefix_length@Message.ExtendedInfo": [
    {
      "@odata.type": "#Message.v1_1_1.Message",
      "Message": "The value true for the property vmi_if0_ipv4_prefix_length is of a different type than the property can accept.",
      "MessageArgs": [
        "true",
        "vmi_if0_ipv4_prefix_length"
      ],
      "MessageId": "Base.1.8.1.PropertyValueTypeError",
      "MessageSeverity": "Warning",
      "Resolution": "Correct the value for the property in the request body and resubmit the request if the operation failed."
    }
  ]
}

PATCH -d '{"Attributes": {"vmi_if0_ipv4_prefix_length": 22.7}}' https://${bmc}/redfish/v1/Systems/system/Bios/Settings
{
  "vmi_if0_ipv4_prefix_length@Message.ExtendedInfo": [
    {
      "@odata.type": "#Message.v1_1_1.Message",
      "Message": "The value 22.7 for the property vmi_if0_ipv4_prefix_length is of a different type than the property can accept.",
      "MessageArgs": [
        "22.7",
        "vmi_if0_ipv4_prefix_length"
      ],
      "MessageId": "Base.1.8.1.PropertyValueTypeError",
      "MessageSeverity": "Warning",
      "Resolution": "Correct the value for the property in the request body and resubmit the request if the operation failed."
    }
  ]
}

* String datatype:

PATCH -d '{"Attributes": {"vmi_if0_ipv4_gateway": "10.9.1.1"}}' https://${bmc}/redfish/v1/Systems/system/Bios/Settings
>> Success

PATCH -d '{"Attributes": {"vmi_if0_ipv4_gateway": 2.7}}' https://${bmc}/redfish/v1/Systems/system/Bios/Settings
{
  "vmi_if0_ipv4_gateway@Message.ExtendedInfo": [
    {
      "@odata.type": "#Message.v1_1_1.Message",
      "Message": "The value 2.7 for the property vmi_if0_ipv4_gateway is of a different type than the property can accept.",
      "MessageArgs": [
        "2.7",
        "vmi_if0_ipv4_gateway"
      ],
      "MessageId": "Base.1.8.1.PropertyValueTypeError",
      "MessageSeverity": "Warning",
      "Resolution": "Correct the value for the property in the request body and resubmit the request if the operation failed."
    }
  ]
}

PATCH -d '{"Attributes": {"vmi_if0_ipv4_gateway": true}}' https://${bmc}/redfish/v1/Systems/system/Bios/Settings
{
  "vmi_if0_ipv4_gateway@Message.ExtendedInfo": [
    {
      "@odata.type": "#Message.v1_1_1.Message",
      "Message": "The value true for the property vmi_if0_ipv4_gateway is of a different type than the property can accept.",
      "MessageArgs": [
        "true",
        "vmi_if0_ipv4_gateway"
      ],
      "MessageId": "Base.1.8.1.PropertyValueTypeError",
      "MessageSeverity": "Warning",
      "Resolution": "Correct the value for the property in the request body and resubmit the request if the operation failed."
    }
  ]
}

Signed-off-by: Asmitha Karunanithi <asmitk01@in.ibm.com>