### PR TITLE
Add LicenseRegistry support

### DIFF
--- a/redfish-core/include/error_messages.hpp
+++ b/redfish-core/include/error_messages.hpp
@@ -971,6 +971,10 @@ nlohmann::json mutualExclusiveProperties(const std::string& arg1,
 void mutualExclusiveProperties(crow::Response& res, const std::string& arg1,
                                const std::string& arg2);
 
+void addMessageToErrorJson(nlohmann::json& target,
+                           const nlohmann::json& message);
+void addMessageToJson(nlohmann::json& target, const nlohmann::json& message,
+                      const std::string& fieldPath);
 } // namespace messages
 
 } // namespace redfish

--- a/redfish-core/include/license_messages.hpp
+++ b/redfish-core/include/license_messages.hpp
@@ -1,5 +1,6 @@
 
 #include "http_response.hpp"
+
 #include <nlohmann/json.hpp>
 
 namespace redfish
@@ -67,21 +68,20 @@ inline nlohmann::json licenseInstalled(const std::string& arg1)
 
 void licenseInstalled(crow::Response& res)
 {
-    res.result(boost::beast::http::status::internal_server_error);
-    addMessageToErrorJson(res.jsonValue,
-                          licenseInstalled("Host license installed"));
+    res.result(boost::beast::http::status::ok);
+    addMessageToErrorJson(res.jsonValue, licenseInstalled("LicenseInstalled"));
 }
 
 inline nlohmann::json invalidLicense()
 {
-    return nlohmann::json{
-        {"@odata.type", "#Message.v1_0_0.Message"},
-        {"MessageId", "License.1.0.0.InvalidLicense"},
-        {"Message", "The content of the license was not recognized, is "
-                    "corrupted, or is invalid."},
-        {"MessageArgs", {}},
-        {"Severity", "Critical"},
-        {"Resolution", "None."}};
+    return nlohmann::json{{"@odata.type", "#Message.v1_0_0.Message"},
+                          {"MessageId", "License.1.0.0.InvalidLicense"},
+                          {"Message",
+                           "The content of the license was not recognized, is "
+                           "corrupted, or is invalid."},
+                          {"MessageArgs", {}},
+                          {"Severity", "Critical"},
+                          {"Resolution", "None."}};
 }
 
 void invalidLicense(crow::Response& res)
@@ -101,11 +101,10 @@ inline nlohmann::json installFailed(const std::string& arg1)
         {"Resolution", "None."}};
 }
 
-void installFailed(crow::Response& res)
+void installFailed(crow::Response& res, const std::string& reason)
 {
     res.result(boost::beast::http::status::internal_server_error);
-    addMessageToErrorJson(res.jsonValue,
-                          installFailed("Server failed to install"));
+    addMessageToErrorJson(res.jsonValue, installFailed(reason));
 }
 
 inline nlohmann::json notApplicableToTarget()

--- a/redfish-core/include/license_messages.hpp
+++ b/redfish-core/include/license_messages.hpp
@@ -1,0 +1,130 @@
+
+#include "http_response.hpp"
+#include <nlohmann/json.hpp>
+
+namespace redfish
+{
+
+namespace messages
+{
+
+static void addMessageToErrorJson(nlohmann::json& target,
+                                  const nlohmann::json& message)
+{
+    auto& error = target["error"];
+
+    // If this is the first error message, fill in the information from the
+    // first error message to the top level struct
+    if (!error.is_object())
+    {
+        auto messageIdIterator = message.find("MessageId");
+        if (messageIdIterator == message.end())
+        {
+            BMCWEB_LOG_CRITICAL
+                << "Attempt to add error message without MessageId";
+            return;
+        }
+
+        auto messageFieldIterator = message.find("Message");
+        if (messageFieldIterator == message.end())
+        {
+            BMCWEB_LOG_CRITICAL
+                << "Attempt to add error message without Message";
+            return;
+        }
+        error = {{"code", *messageIdIterator},
+                 {"message", *messageFieldIterator}};
+    }
+    else
+    {
+        // More than 1 error occurred, so the message has to be generic
+        error["code"] = std::string(messageVersionPrefix) + "GeneralError";
+        error["message"] = "A general error has occurred. See Resolution for "
+                           "information on how to resolve the error.";
+    }
+
+    // This check could technically be done in in the default construction
+    // branch above, but because we need the pointer to the extended info field
+    // anyway, it's more efficient to do it here.
+    auto& extendedInfo = error[messages::messageAnnotation];
+    if (!extendedInfo.is_array())
+    {
+        extendedInfo = nlohmann::json::array();
+    }
+
+    extendedInfo.push_back(message);
+}
+
+inline nlohmann::json licenseInstalled(const std::string& arg1)
+{
+    return nlohmann::json{{"@odata.type", "#Message.v1_0_0.Message"},
+                          {"MessageId", "License.1.0.0.LicenseInstalled"},
+                          {"Message", "The license has been installed."},
+                          {"MessageArgs", {arg1}},
+                          {"Severity", "OK"},
+                          {"Resolution", "None."}};
+}
+
+void licenseInstalled(crow::Response& res)
+{
+    res.result(boost::beast::http::status::internal_server_error);
+    addMessageToErrorJson(res.jsonValue,
+                          licenseInstalled("Host license installed"));
+}
+
+inline nlohmann::json invalidLicense()
+{
+    return nlohmann::json{
+        {"@odata.type", "#Message.v1_0_0.Message"},
+        {"MessageId", "License.1.0.0.InvalidLicense"},
+        {"Message", "The content of the license was not recognized, is "
+                    "corrupted, or is invalid."},
+        {"MessageArgs", {}},
+        {"Severity", "Critical"},
+        {"Resolution", "None."}};
+}
+
+void invalidLicense(crow::Response& res)
+{
+    res.result(boost::beast::http::status::bad_request);
+    addMessageToErrorJson(res.jsonValue, invalidLicense());
+}
+
+inline nlohmann::json installFailed(const std::string& arg1)
+{
+    return nlohmann::json{
+        {"@odata.type", "#Message.v1_0_0.Message"},
+        {"MessageId", "License.1.0.0.InstallFailed"},
+        {"Message", "Failed to install the license.  Reason: %1."},
+        {"MessageArgs", {arg1}},
+        {"Severity", "Critical"},
+        {"Resolution", "None."}};
+}
+
+void installFailed(crow::Response& res)
+{
+    res.result(boost::beast::http::status::internal_server_error);
+    addMessageToErrorJson(res.jsonValue,
+                          installFailed("Server failed to install"));
+}
+
+inline nlohmann::json notApplicableToTarget()
+{
+    return nlohmann::json{
+        {"@odata.type", "#Message.v1_0_0.Message"},
+        {"MessageId", "License.1.0.0.notApplicableToTarget"},
+        {"Message",
+         "Indicates that the license is not applicable to the target."},
+        {"MessageArgs", {}},
+        {"Severity", "Critical"},
+        {"Resolution", "None."}};
+}
+
+void notApplicableToTarget(crow::Response& res)
+{
+    res.result(boost::beast::http::status::internal_server_error);
+    addMessageToErrorJson(res.jsonValue, notApplicableToTarget());
+}
+
+} // namespace messages
+} // namespace redfish

--- a/redfish-core/include/registries/license_message_registry.hpp
+++ b/redfish-core/include/registries/license_message_registry.hpp
@@ -1,0 +1,130 @@
+
+/****************************************************************
+ * This is an auto-generated header which contains definitions
+ * for Redfish DMTF defined messages.
+ ***************************************************************/
+#pragma once
+#include <registries.hpp>
+
+namespace redfish::message_registries::license
+{
+const Header header = {
+    "Copyright 2014-2021 DMTF. All rights reserved.",
+    "#MessageRegistry.v1_4_2.MessageRegistry",
+    "License.1.0.0",
+    "License Message Registry",
+    "en",
+    "This registry defines the license status and error messages.",
+    "License",
+    "1.0.0",
+    "DMTF",
+};
+constexpr const char* url = "https://redfish.dmtf.org/registries/License.1.0.0";
+
+constexpr std::array<MessageEntry, 8> registry = {
+    MessageEntry{"DaysBeforeExpiration",
+                 {
+                     "Indicates the number of days remaining on a license "
+                     "before expiration.",
+                     "The license '%1' will expire in %2 days.",
+                     "OK",
+                     "OK",
+                     2,
+                     {
+                         "string",
+                         "number",
+                     },
+                     "None.",
+                 }},
+    MessageEntry{"Expired",
+                 {
+                     "Indicates that a license has expired and its "
+                     "functionality has been disabled.",
+                     "The license '%1' has expired.",
+                     "Warning",
+                     "Warning",
+                     1,
+                     {
+                         "string",
+                     },
+                     "None.",
+                 }},
+    MessageEntry{"GracePeriod",
+                 {
+                     "Indicates that a license has expired and entered its "
+                     "grace period.",
+                     "The license '%1' has expired, %2 day grace period before "
+                     "licensed functionality is disabled.",
+                     "Warning",
+                     "Warning",
+                     2,
+                     {
+                         "string",
+                         "number",
+                     },
+                     "None.",
+                 }},
+    MessageEntry{
+        "InstallFailed",
+        {
+            "Indicates that the service failed to install the license.",
+            "Failed to install the license.  Reason: %1.",
+            "Critical",
+            "Critical",
+            1,
+            {
+                "String",
+            },
+            "None.",
+        }},
+    MessageEntry{
+        "InvalidLicense",
+        {
+            "Indicates that the license was not recognized, is corrupted, or "
+            "is invalid.",
+            "The content of the license was not recognized, is corrupted, or "
+            "is invalid.",
+            "Critical",
+            "Critical",
+            0,
+            {},
+            "Verify the license content is correct and resubmit the request.",
+        }},
+    MessageEntry{"LicenseInstalled",
+                 {
+                     "Indicates that a license has been installed.",
+                     "The license '%1' has been installed.",
+                     "OK",
+                     "OK",
+                     1,
+                     {
+                         "String",
+                     },
+                     "None.",
+                 }},
+    MessageEntry{
+        "NotApplicableToTarget",
+        {
+            "Indicates that the license is not applicable to the target.",
+            "The license is not applicable to the target.",
+            "Critical",
+            "Critical",
+            0,
+            {},
+            "Check the license compatibility or applicability to the specified "
+            "target.",
+        }},
+    MessageEntry{
+        "TargetsRequired",
+        {
+            "Indicates that one or more targets need to be specified with the "
+            "license.",
+            "The license requires targets to be specified.",
+            "Critical",
+            "Critical",
+            0,
+            {},
+            "Add `AuthorizedDevices` to `Links` and resubmit the request.",
+        }},
+};
+} // namespace redfish::message_registries::license

--- a/redfish-core/include/registries/license_message_registry.hpp
+++ b/redfish-core/include/registries/license_message_registry.hpp
@@ -73,7 +73,7 @@ constexpr std::array<MessageEntry, 8> registry = {
             "Critical",
             1,
             {
-                "String",
+                "string",
             },
             "None.",
         }},
@@ -98,7 +98,7 @@ constexpr std::array<MessageEntry, 8> registry = {
                      "OK",
                      1,
                      {
-                         "String",
+                         "string",
                      },
                      "None.",
                  }},

--- a/redfish-core/lib/license_service.hpp
+++ b/redfish-core/lib/license_service.hpp
@@ -95,7 +95,8 @@ inline void requestRoutesLicenseService(App& app)
 
 inline void
     getLicenseActivationAck(const std::shared_ptr<bmcweb::AsyncResp>& asyncResp,
-                            const std::string& status)
+                            const std::string& status,
+                            const std::string& licenseString)
 {
 
     if (status == "com.ibm.License.LicenseManager.Status.ActivationFailed")
@@ -127,7 +128,7 @@ inline void
     else if (status == "com.ibm.License.LicenseManager.Status.Activated")
     {
         BMCWEB_LOG_INFO << "License Activated";
-        messages::licenseInstalled(asyncResp->res);
+        messages::licenseInstalled(asyncResp->res, licenseString);
     }
     else
     {
@@ -182,7 +183,8 @@ inline void requestRoutesLicenseEntryCollection(App& app)
                     crow::connections::systemBus->get_io_context());
             timeout->expires_after(std::chrono::seconds(10));
             crow::connections::systemBus->async_method_call(
-                [timeout, asyncResp](const boost::system::error_code ec) {
+                [timeout, asyncResp,
+                 licenseString](const boost::system::error_code ec) {
                     if (ec)
                     {
                         BMCWEB_LOG_ERROR
@@ -218,8 +220,8 @@ inline void requestRoutesLicenseEntryCollection(App& app)
 
                     timeout->async_wait(timeoutHandler);
 
-                    auto callback = [asyncResp,
-                                     timeout](sdbusplus::message::message& m) {
+                    auto callback = [asyncResp, timeout, licenseString](
+                                        sdbusplus::message::message& m) {
                         BMCWEB_LOG_DEBUG << "Response Matched " << m.get();
                         boost::container::flat_map<std::string,
                                                    std::variant<std::string>>
@@ -241,7 +243,8 @@ inline void requestRoutesLicenseEntryCollection(App& app)
                                     messages::internalError(asyncResp->res);
                                     return;
                                 }
-                                getLicenseActivationAck(asyncResp, *status);
+                                getLicenseActivationAck(asyncResp, *status,
+                                                        licenseString);
                                 timeout->cancel();
                             }
                         }

--- a/redfish-core/lib/license_service.hpp
+++ b/redfish-core/lib/license_service.hpp
@@ -5,7 +5,7 @@
 #include <app.hpp>
 #include <error_messages.hpp>
 #include <registries/privilege_registry.hpp>
-
+#include <license_messages.hpp>
 #include <filesystem>
 #include <string_view>
 #include <variant>
@@ -99,38 +99,34 @@ inline void
 
     if (status == "com.ibm.License.LicenseManager.Status.ActivationFailed")
     {
-        // TODO: Need to return appropriate redfish error
         BMCWEB_LOG_ERROR << "LicenseActivationStatus: ActivationFailed";
-        messages::internalError(asyncResp->res);
+        messages::installFailed(asyncResp->res);
     }
     else if (status == "com.ibm.License.LicenseManager.Status.InvalidLicense")
     {
-        // TODO: Need to return appropriate redfish error
         BMCWEB_LOG_ERROR << "LicenseActivationStatus: InvalidLicense";
-        messages::internalError(asyncResp->res);
+        messages::invalidLicense(asyncResp->res);
     }
     else if (status == "com.ibm.License.LicenseManager.Status.IncorrectSystem")
     {
-        // TODO: Need to return appropriate redfish error
         BMCWEB_LOG_ERROR << "LicenseActivationStatus: IncorrectSystem";
-        messages::internalError(asyncResp->res);
+        messages::notApplicableToTarget(asyncResp->res);
     }
     else if (status ==
              "com.ibm.License.LicenseManager.Status.IncorrectSequence")
     {
-        // TODO: Need to return appropriate redfish error
         BMCWEB_LOG_ERROR << "LicenseActivationStatus: IncorrectSequence";
-        messages::internalError(asyncResp->res);
+        messages::notApplicableToTarget(asyncResp->res);
     }
     else if (status == "com.ibm.License.LicenseManager.Status.InvalidHostState")
     {
-        // TODO: Need to return appropriate redfish error
         BMCWEB_LOG_ERROR << "LicenseActivationStatus: InvalidHostState";
         messages::internalError(asyncResp->res);
     }
     else if (status == "com.ibm.License.LicenseManager.Status.Activated")
     {
         BMCWEB_LOG_INFO << "License Activated";
+        messages::licenseInstalled(asyncResp->res);
     }
     else
     {

--- a/redfish-core/lib/license_service.hpp
+++ b/redfish-core/lib/license_service.hpp
@@ -4,8 +4,9 @@
 
 #include <app.hpp>
 #include <error_messages.hpp>
-#include <registries/privilege_registry.hpp>
 #include <license_messages.hpp>
+#include <registries/privilege_registry.hpp>
+
 #include <filesystem>
 #include <string_view>
 #include <variant>
@@ -100,7 +101,7 @@ inline void
     if (status == "com.ibm.License.LicenseManager.Status.ActivationFailed")
     {
         BMCWEB_LOG_ERROR << "LicenseActivationStatus: ActivationFailed";
-        messages::installFailed(asyncResp->res);
+        messages::installFailed(asyncResp->res, "ActivationFailed");
     }
     else if (status == "com.ibm.License.LicenseManager.Status.InvalidLicense")
     {
@@ -121,7 +122,7 @@ inline void
     else if (status == "com.ibm.License.LicenseManager.Status.InvalidHostState")
     {
         BMCWEB_LOG_ERROR << "LicenseActivationStatus: InvalidHostState";
-        messages::internalError(asyncResp->res);
+        messages::installFailed(asyncResp->res, "InvalidHostState");
     }
     else if (status == "com.ibm.License.LicenseManager.Status.Activated")
     {

--- a/redfish-core/lib/message_registries.hpp
+++ b/redfish-core/lib/message_registries.hpp
@@ -18,6 +18,7 @@
 #include "registries.hpp"
 #include "registries/base_message_registry.hpp"
 #include "registries/bios_registry.hpp"
+#include "registries/license_message_registry.hpp"
 #include "registries/openbmc_message_registry.hpp"
 #include "registries/resource_event_message_registry.hpp"
 #include "registries/task_event_message_registry.hpp"
@@ -40,12 +41,13 @@ inline void handleMessageRegistryFileCollectionGet(
         {"@odata.id", "/redfish/v1/Registries"},
         {"Name", "MessageRegistryFile Collection"},
         {"Description", "Collection of MessageRegistryFiles"},
-        {"Members@odata.count", 5},
+        {"Members@odata.count", 6},
         {"Members",
          {{{"@odata.id", "/redfish/v1/Registries/Base"}},
           {{"@odata.id", "/redfish/v1/Registries/BiosAttributeRegistry"}},
           {{"@odata.id", "/redfish/v1/Registries/TaskEvent"}},
           {{"@odata.id", "/redfish/v1/Registries/ResourceEvent"}},
+          {{"@odata.id", "/redfish/v1/Registries/License"}},
           {{"@odata.id", "/redfish/v1/Registries/OpenBMC"}}}}};
 }
 
@@ -92,6 +94,11 @@ inline void handleMessageRoutesMessageRegistryFileGet(
     {
         header = &message_registries::resource_event::header;
         url = message_registries::resource_event::url;
+    }
+    else if (registry == "License")
+    {
+        header = &message_registries::license::header;
+        url = message_registries::license::url;
     }
     else
     {
@@ -167,6 +174,15 @@ inline void handleMessageRegistryGet(
         header = &message_registries::resource_event::header;
         for (const message_registries::MessageEntry& entry :
              message_registries::resource_event::registry)
+        {
+            registryEntries.emplace_back(&entry);
+        }
+    }
+    else if (registry == "License")
+    {
+        header = &message_registries::license::header;
+        for (const message_registries::MessageEntry& entry :
+             message_registries::license::registry)
         {
             registryEntries.emplace_back(&entry);
         }

--- a/redfish-core/src/error_messages.cpp
+++ b/redfish-core/src/error_messages.cpp
@@ -22,8 +22,8 @@ namespace redfish
 namespace messages
 {
 
-static void addMessageToErrorJson(nlohmann::json& target,
-                                  const nlohmann::json& message)
+void addMessageToErrorJson(nlohmann::json& target,
+                           const nlohmann::json& message)
 {
     auto& error = target["error"];
 
@@ -81,9 +81,8 @@ static void addMessageToJsonRoot(nlohmann::json& target,
     target[messages::messageAnnotation].push_back(message);
 }
 
-static void addMessageToJson(nlohmann::json& target,
-                             const nlohmann::json& message,
-                             const std::string& fieldPath)
+void addMessageToJson(nlohmann::json& target, const nlohmann::json& message,
+                      const std::string& fieldPath)
 {
     std::string extendedInfo(fieldPath + messages::messageAnnotation);
 

--- a/scripts/parse_registries.py
+++ b/scripts/parse_registries.py
@@ -64,7 +64,7 @@ files.append(make_getter('ResourceEvent.1.0.3.json',
                          'resource_event_message_registry.hpp',
                          'resource_event'))
 files.append(make_getter('License.1.0.0',
-                          'license_message_registry.hpp', 'license'))
+                         'license_message_registry.hpp', 'license'))
 
 # Remove the old files
 for file, json_dict, namespace, url in files:

--- a/scripts/parse_registries.py
+++ b/scripts/parse_registries.py
@@ -63,6 +63,8 @@ files.append(make_getter('TaskEvent.1.0.3.json',
 files.append(make_getter('ResourceEvent.1.0.3.json',
                          'resource_event_message_registry.hpp',
                          'resource_event'))
+files.append(make_getter('License.1.0.0',
+                          'license_message_registry.hpp', 'license'))
 
 # Remove the old files
 for file, json_dict, namespace, url in files:


### PR DESCRIPTION
This commit implements redfish License registry schema to handle  license errors 

Tested By: 
curl -k -H "X-Auth-Token: $bmc_token" -H "Content-Type: application/octet-stream" -X  POST https://${bmc}/redfish/v1/LicenseService/Licenses -d '{"LicenseString": "CA1F000000412C200000gyLzCwvb3rRUTg"}'
{
  "error": {
    "@Message.ExtendedInfo": [
      {
        "@odata.type": "#Message.v1_0_0.Message",
        "Message": "Indicates that the license is not applicable to the target.",
        "MessageArgs": null,
        "MessageId": "License.1.0.0.notApplicableToTarget",
        "Resolution": "None.",
        "Severity": "Critical"
      }
    ],
    "code": "License.1.0.0.notApplicableToTarget",
    "message": "Indicates that the license is not applicable to the target."
  }
}bash-4.2$ curl -k -H "X-Auth-Token: $bmc_token" -H "Content-Type: application/octet-stream" -X  POST https://${bmc}/redfish/v1/LicenseService/License -d '{"LicenseString": "CA1F000000412C200000gyLzCwvb3rRUT1"}'
{
  "error": {
    "@Message.ExtendedInfo": [
      {
        "@odata.type": "#Message.v1_0_0.Message",
        "Message": "The content of the license was not recognized, is corrupted, or is invalid.",
        "MessageArgs": null,
        "MessageId": "License.1.0.0.InvalidLicense",
        "Resolution": "None.",
        "Severity": "Critical"
      }
    ],
    "code": "License.1.0.0.InvalidLicense",
    "message": "The content of the license was not recognized, is corrupted, or is invalid."
  }
}bash-4.2$ 
bash-4.2$ curl -k -H "X-Auth-Token: $bmc_token" -H "Content-Type: application/octet-stream" -X  POST https://${bmc}/redfish/v1/LicenseService/Licenses -d '{"LicenseString": "CA1F000000412C200000gyLzCwvb3rRUT2"}'
{
  "error": {
    "@Message.ExtendedInfo": [
      {
        "@odata.type": "#Message.v1_0_0.Message",
        "Message": "Failed to install the license.  Reason: ActivationFailed",
        "MessageArgs": [
          "ActivationFailed"
        ],
        "MessageId": "License.1.0.0.InstallFailed",
        "Resolution": "None.",
        "Severity": "Critical"
      }
    ],
    "code": "License.1.0.0.InstallFailed",
    "message": "Failed to install the license.  Reason: ActivationFailed"
  }
}

curl -k -H "X-Auth-Token: $bmc_token" -H "Content-Type: application/octet-stream" -X  POST https://${bmc}/redfish/v1/LicenseService/Licenses -d '{"LicenseString": "CA1F000000412C200000gyLzCwvb3rRUT2"}'
{
  "LicenseInstalled@Message.ExtendedInfo": [
    {
      "@odata.type": "#Message.v1_0_0.Message",
      "Message": "The license has been installed CA1F000000412C200000gyLzCwvb3rRUT2",
      "MessageArgs": [
        "CA1F000000412C200000gyLzCwvb3rRUT2"
      ],
      "MessageId": "License.1.0.0.LicenseInstalled",
      "Resolution": "None.",
      "Severity": "OK"
    }
  ]
}
Redfish validator Passed
