### PR TITLE
Revert use boost timer with 100 connection limit

### DIFF
--- a/http/http_client.hpp
+++ b/http/http_client.hpp
@@ -22,7 +22,6 @@
 #include <boost/beast/http/message.hpp>
 #include <boost/beast/ssl/ssl_stream.hpp>
 #include <boost/beast/version.hpp>
-#include <boost/circular_buffer.hpp>
 #include <include/async_resolve.hpp>
 
 #include <cstdlib>

--- a/http/http_connection.hpp
+++ b/http/http_connection.hpp
@@ -300,6 +300,10 @@ class Connection :
                                         const boost::system::error_code& ec) {
                                         if (ec)
                                         {
+                                            BMCWEB_LOG_ERROR
+                                                << this
+                                                << "async_handshake failed: "
+                                                << ec.message();
                                             return;
                                         }
                                         doReadHeaders();

--- a/http/http_connection.hpp
+++ b/http/http_connection.hpp
@@ -5,6 +5,7 @@
 #include "http_response.hpp"
 #include "http_utility.hpp"
 #include "logging.hpp"
+#include "timer_queue.hpp"
 #include "utility.hpp"
 
 #include <boost/algorithm/string.hpp>
@@ -12,7 +13,6 @@
 #include <boost/asio/io_context.hpp>
 #include <boost/asio/ip/tcp.hpp>
 #include <boost/asio/ssl/stream.hpp>
-#include <boost/asio/steady_timer.hpp>
 #include <boost/beast/core/flat_static_buffer.hpp>
 #include <boost/beast/ssl/ssl_stream.hpp>
 #include <boost/beast/websocket.hpp>
@@ -47,17 +47,25 @@ constexpr uint64_t loggedOutPostBodyLimit = 4096;
 
 constexpr uint32_t httpHeaderLimit = 8192;
 
+// drop all connections after 1 minute, this time limit was chosen
+// arbitrarily and can be adjusted later if needed
+static constexpr const size_t loggedInAttempts =
+    (60 / timerQueueTimeoutSeconds);
+
+static constexpr const size_t loggedOutAttempts =
+    (15 / timerQueueTimeoutSeconds);
+
 template <typename Adaptor, typename Handler>
 class Connection :
     public std::enable_shared_from_this<Connection<Adaptor, Handler>>
 {
   public:
-    Connection(Handler* handlerIn, boost::asio::steady_timer&& timerIn,
+    Connection(Handler* handlerIn,
                std::function<std::string()>& getCachedDateStrF,
-               Adaptor adaptorIn) :
+               detail::TimerQueue& timerQueueIn, Adaptor adaptorIn) :
         adaptor(std::move(adaptorIn)),
-        handler(handlerIn), timer(std::move(timerIn)),
-        getCachedDateStr(getCachedDateStrF)
+        handler(handlerIn), getCachedDateStr(getCachedDateStrF),
+        timerQueue(timerQueueIn)
     {
         parser.emplace(std::piecewise_construct, std::make_tuple());
         parser->body_limit(httpReqBodyLimit);
@@ -278,7 +286,8 @@ class Connection :
 
     void start()
     {
-        startDeadline();
+
+        startDeadline(0);
 
         // TODO(ed) Abstract this to a more clever class with the idea of an
         // asynchronous "start"
@@ -304,6 +313,7 @@ class Connection :
 
     void handle()
     {
+        cancelDeadlineTimer();
         std::error_code reqEc;
         crow::Request& thisReq = req.emplace(parser->release(), reqEc);
         if (reqEc)
@@ -571,9 +581,13 @@ class Connection :
                 sessionIsFromTransport = false;
                 userSession = crow::authorization::authenticate(
                     ip, res, method, parser->get().base(), userSession);
-
                 bool loggedIn = userSession != nullptr;
-                if (!loggedIn)
+                if (loggedIn)
+                {
+                    startDeadline(loggedInAttempts);
+                    BMCWEB_LOG_DEBUG << "Starting slow deadline";
+                }
+                else
                 {
                     const boost::optional<uint64_t> contentLength =
                         parser->content_length();
@@ -586,9 +600,9 @@ class Connection :
                         return;
                     }
 
+                    startDeadline(loggedOutAttempts);
                     BMCWEB_LOG_DEBUG << "Starting quick deadline";
                 }
-
                 doRead();
             });
     }
@@ -596,7 +610,7 @@ class Connection :
     void doRead()
     {
         BMCWEB_LOG_DEBUG << this << " doRead";
-        startDeadline();
+
         boost::beast::http::async_read(
             adaptor, buffer, *parser,
             [this,
@@ -604,11 +618,36 @@ class Connection :
                                        std::size_t bytesTransferred) {
                 BMCWEB_LOG_DEBUG << this << " async_read " << bytesTransferred
                                  << " Bytes";
-                cancelDeadlineTimer();
+
+                bool errorWhileReading = false;
                 if (ec)
                 {
                     BMCWEB_LOG_ERROR
                         << this << " Error while reading: " << ec.message();
+                    errorWhileReading = true;
+                }
+                else
+                {
+                    if (isAlive())
+                    {
+                        cancelDeadlineTimer();
+                        if (userSession != nullptr)
+                        {
+                            startDeadline(loggedInAttempts);
+                        }
+                        else
+                        {
+                            startDeadline(loggedOutAttempts);
+                        }
+                    }
+                    else
+                    {
+                        errorWhileReading = true;
+                    }
+                }
+                if (errorWhileReading)
+                {
+                    cancelDeadlineTimer();
                     close();
                     BMCWEB_LOG_DEBUG << this << " from read(1)";
                     return;
@@ -619,10 +658,18 @@ class Connection :
 
     void doWrite()
     {
+        bool loggedIn = req && req->session;
+        if (loggedIn)
+        {
+            startDeadline(loggedInAttempts);
+        }
+        else
+        {
+            startDeadline(loggedOutAttempts);
+        }
         BMCWEB_LOG_DEBUG << this << " doWrite";
         res.preparePayload();
         serializer.emplace(*res.stringResponse);
-        startDeadline();
         boost::beast::http::async_write(
             adaptor, *serializer,
             [this,
@@ -668,51 +715,64 @@ class Connection :
 
     void cancelDeadlineTimer()
     {
-        timer.cancel();
+        if (timerCancelKey)
+        {
+            BMCWEB_LOG_DEBUG << this << " timer cancelled: " << &timerQueue
+                             << ' ' << *timerCancelKey;
+            timerQueue.cancel(*timerCancelKey);
+            timerCancelKey.reset();
+        }
     }
 
-    void startDeadline()
+    void startDeadline(size_t timerIterations)
     {
         cancelDeadlineTimer();
 
-        std::chrono::seconds timeout(15);
-        // allow slow uploads for logged in users
-        bool loggedIn = req && req->session;
-        if (loggedIn)
+        if (timerIterations)
         {
-            timeout = std::chrono::seconds(60);
-            return;
+            timerIterations--;
         }
 
-        std::weak_ptr<Connection<Adaptor, Handler>> weakSelf = weak_from_this();
-        timer.expires_after(timeout);
-        timer.async_wait([weakSelf](const boost::system::error_code ec) {
-            // Note, we are ignoring other types of errors here;  If the timer
-            // failed for any reason, we should still close the connection
+        timerCancelKey =
+            timerQueue.add([self(shared_from_this()), timerIterations,
+                            readCount{parser->get().body().size()}] {
+                // Mark timer as not active to avoid canceling it during
+                // Connection destructor which leads to double free issue
+                self->timerCancelKey.reset();
+                if (!self->isAlive())
+                {
+                    return;
+                }
 
-            std::shared_ptr<Connection<Adaptor, Handler>> self =
-                weakSelf.lock();
-            if (!self)
-            {
-                BMCWEB_LOG_CRITICAL << self << " Failed to capture connection";
-                return;
-            }
-            if (ec == boost::asio::error::operation_aborted)
-            {
-                // Canceled wait means the path succeeeded.
-                return;
-            }
-            if (ec)
-            {
-                BMCWEB_LOG_CRITICAL << self << " timer failed " << ec;
-            }
+                bool loggedIn = self->req && self->req->session;
+                // allow slow uploads for logged in users
+                if (loggedIn && self->parser->get().body().size() > readCount)
+                {
+                    BMCWEB_LOG_DEBUG << self.get()
+                                     << " restart timer - read in progress";
+                    self->startDeadline(timerIterations);
+                    return;
+                }
 
-            BMCWEB_LOG_WARNING << self << "Connection timed out, closing";
+                // Threshold can be used to drop slow connections
+                // to protect against slow-rate DoS attack
+                if (timerIterations)
+                {
+                    BMCWEB_LOG_DEBUG << self.get() << " restart timer";
+                    self->startDeadline(timerIterations);
+                    return;
+                }
 
-            self->close();
-        });
+                self->close();
+            });
 
-        BMCWEB_LOG_DEBUG << this << " timer started";
+        if (!timerCancelKey)
+        {
+            close();
+            return;
+        }
+        BMCWEB_LOG_DEBUG << this << " timer added: " << &timerQueue << ' '
+                         << *timerCancelKey;
     }
 
   private:
@@ -736,14 +796,12 @@ class Connection :
     bool sessionIsFromTransport = false;
     std::shared_ptr<persistent_data::UserSession> userSession;
 
-    boost::asio::steady_timer timer;
+    std::optional<size_t> timerCancelKey;
 
     std::function<std::string()>& getCachedDateStr;
+    detail::TimerQueue& timerQueue;
 
     using std::enable_shared_from_this<
         Connection<Adaptor, Handler>>::shared_from_this;
-
-    using std::enable_shared_from_this<
-        Connection<Adaptor, Handler>>::weak_from_this;
 };
 } // namespace crow

--- a/http/http_connection.hpp
+++ b/http/http_connection.hpp
@@ -291,10 +291,6 @@ class Connection :
                                         const boost::system::error_code& ec) {
                                         if (ec)
                                         {
-                                            BMCWEB_LOG_ERROR
-                                                << this
-                                                << "async_handshake failed: "
-                                                << ec.message();
                                             return;
                                         }
                                         doReadHeaders();

--- a/http/http_server.hpp
+++ b/http/http_server.hpp
@@ -164,32 +164,45 @@ class Server
 
     void doAccept()
     {
+        std::optional<Adaptor> adaptorTemp;
         boost::asio::steady_timer timer(*ioService);
-        std::shared_ptr<Connection<Adaptor, Handler>> connection;
         if constexpr (std::is_same<Adaptor,
                                    boost::beast::ssl_stream<
                                        boost::asio::ip::tcp::socket>>::value)
         {
-            connection = std::make_shared<Connection<Adaptor, Handler>>(
+            adaptorTemp = Adaptor(*ioService, *adaptorCtx);
+            auto p = std::make_shared<Connection<Adaptor, Handler>>(
                 handler, std::move(timer), getCachedDateStr,
-                Adaptor(*ioService, *adaptorCtx));
+                std::move(adaptorTemp.value()));
+
+            acceptor->async_accept(p->socket().next_layer(),
+                                   [this, p](boost::system::error_code ec) {
+                                       if (!ec)
+                                       {
+                                           boost::asio::post(
+                                               *this->ioService,
+                                               [p] { p->start(); });
+                                       }
+                                       doAccept();
+                                   });
         }
         else
         {
-            connection = std::make_shared<Connection<Adaptor, Handler>>(
+            adaptorTemp = Adaptor(*ioService);
+            auto p = std::make_shared<Connection<Adaptor, Handler>>(
                 handler, std::move(timer), getCachedDateStr,
-                Adaptor(*ioService));
+                std::move(adaptorTemp.value()));
+
+            acceptor->async_accept(
+                p->socket(), [this, p](boost::system::error_code ec) {
+                    if (!ec)
+                    {
+                        boost::asio::post(*this->ioService,
+                                          [p] { p->start(); });
+                    }
+                    doAccept();
+                });
         }
-        acceptor->async_accept(
-            boost::beast::get_lowest_layer(connection->socket()),
-            [this, connection](boost::system::error_code ec) {
-                if (!ec)
-                {
-                    boost::asio::post(*this->ioService,
-                                      [connection] { connection->start(); });
-                }
-                doAccept();
-            });
     }
 
   private:

--- a/http/http_server.hpp
+++ b/http/http_server.hpp
@@ -2,6 +2,7 @@
 
 #include "http_connection.hpp"
 #include "logging.hpp"
+#include "timer_queue.hpp"
 
 #include <boost/asio/ip/address.hpp>
 #include <boost/asio/ip/tcp.hpp>
@@ -35,8 +36,8 @@ class Server
                std::make_shared<boost::asio::io_context>()) :
         ioService(std::move(io)),
         acceptor(std::move(acceptorIn)),
-        signals(*ioService, SIGINT, SIGTERM, SIGHUP), handler(handlerIn),
-        adaptorCtx(std::move(adaptorCtx))
+        signals(*ioService, SIGINT, SIGTERM, SIGHUP), timer(*ioService),
+        handler(handlerIn), adaptorCtx(std::move(adaptorCtx))
     {}
 
     Server(Handler* handlerIn, const std::string& bindaddr, uint16_t port,
@@ -89,6 +90,19 @@ class Server
             }
             return this->dateStr;
         };
+
+        timer.expires_after(std::chrono::seconds(1));
+
+        timerHandler = [this](const boost::system::error_code& ec) {
+            if (ec)
+            {
+                return;
+            }
+            timerQueue.process();
+            timer.expires_after(std::chrono::seconds(1));
+            timer.async_wait(timerHandler);
+        };
+        timer.async_wait(timerHandler);
 
         BMCWEB_LOG_INFO << "bmcweb server is running, local endpoint "
                         << acceptor->local_endpoint();
@@ -165,14 +179,13 @@ class Server
     void doAccept()
     {
         std::optional<Adaptor> adaptorTemp;
-        boost::asio::steady_timer timer(*ioService);
         if constexpr (std::is_same<Adaptor,
                                    boost::beast::ssl_stream<
                                        boost::asio::ip::tcp::socket>>::value)
         {
             adaptorTemp = Adaptor(*ioService, *adaptorCtx);
             auto p = std::make_shared<Connection<Adaptor, Handler>>(
-                handler, std::move(timer), getCachedDateStr,
+                handler, getCachedDateStr, timerQueue,
                 std::move(adaptorTemp.value()));
 
             acceptor->async_accept(p->socket().next_layer(),
@@ -190,7 +203,7 @@ class Server
         {
             adaptorTemp = Adaptor(*ioService);
             auto p = std::make_shared<Connection<Adaptor, Handler>>(
-                handler, std::move(timer), getCachedDateStr,
+                handler, getCachedDateStr, timerQueue,
                 std::move(adaptorTemp.value()));
 
             acceptor->async_accept(
@@ -207,17 +220,21 @@ class Server
 
   private:
     std::shared_ptr<boost::asio::io_context> ioService;
+    detail::TimerQueue timerQueue;
     std::function<std::string()> getCachedDateStr;
     std::unique_ptr<boost::asio::ip::tcp::acceptor> acceptor;
     boost::asio::signal_set signals;
+    boost::asio::steady_timer timer;
 
     std::string dateStr;
 
     Handler* handler;
 
+    std::function<void(const boost::system::error_code& ec)> timerHandler;
+
 #ifdef BMCWEB_ENABLE_SSL
     bool useSsl{false};
 #endif
     std::shared_ptr<boost::asio::ssl::context> adaptorCtx;
-};
+}; // namespace crow
 } // namespace crow

--- a/http/timer_queue.hpp
+++ b/http/timer_queue.hpp
@@ -1,0 +1,97 @@
+#pragma once
+
+#include "logging.hpp"
+
+#include <boost/circular_buffer.hpp>
+#include <boost/circular_buffer/space_optimized.hpp>
+
+#include <chrono>
+#include <functional>
+
+namespace crow
+{
+
+constexpr const size_t timerQueueTimeoutSeconds = 5;
+namespace detail
+{
+
+constexpr const size_t maxSize = 100;
+// fast timer queue for fixed tick value.
+class TimerQueue
+{
+  public:
+    TimerQueue()
+    {
+        dq.set_capacity(maxSize);
+    }
+
+    void cancel(size_t k)
+    {
+        size_t index = k - step;
+        if (index < dq.size())
+        {
+            dq[index].second = nullptr;
+        }
+        while (dq.begin() != dq.end() && dq.front().second == nullptr)
+        {
+            dq.pop_front();
+            step++;
+        }
+    }
+
+    std::optional<size_t> add(std::function<void()> f)
+    {
+        if (dq.size() == maxSize)
+        {
+            return std::nullopt;
+        }
+
+        dq.push_back(
+            std::make_pair(std::chrono::steady_clock::now(), std::move(f)));
+        size_t ret = step + dq.size() - 1;
+
+        BMCWEB_LOG_DEBUG << "timer add inside: " << this << ' ' << ret;
+        return ret;
+    }
+
+    void process()
+    {
+        auto now = std::chrono::steady_clock::now();
+        while (!dq.empty())
+        {
+            auto& x = dq.front();
+            // Check expiration time only for active handlers,
+            // remove canceled ones immediately
+            if (x.second)
+            {
+                if (now - x.first <
+                    std::chrono::seconds(timerQueueTimeoutSeconds))
+                {
+                    break;
+                }
+
+                BMCWEB_LOG_DEBUG << "timer call: " << this << ' ' << step;
+                // we know that timer handlers are very simple currently; call
+                // here
+                x.second();
+            }
+            dq.pop_front();
+            step++;
+        }
+    }
+
+  private:
+    using storage_type =
+        std::pair<std::chrono::time_point<std::chrono::steady_clock>,
+                  std::function<void()>>;
+
+    boost::circular_buffer_space_optimized<storage_type,
+                                           std::allocator<storage_type>>
+        dq{};
+
+    // boost::circular_buffer<storage_type> dq{20};
+    // std::deque<storage_type> dq{};
+    size_t step{};
+};
+} // namespace detail
+} // namespace crow

--- a/http/timer_queue.hpp
+++ b/http/timer_queue.hpp
@@ -15,7 +15,7 @@ constexpr const size_t timerQueueTimeoutSeconds = 5;
 namespace detail
 {
 
-constexpr const size_t maxSize = 100;
+constexpr const size_t maxSize = 300;
 // fast timer queue for fixed tick value.
 class TimerQueue
 {
@@ -43,6 +43,7 @@ class TimerQueue
     {
         if (dq.size() == maxSize)
         {
+            BMCWEB_LOG_ERROR << "timer add: dq.size has hit maxSize";
             return std::nullopt;
         }
 


### PR DESCRIPTION
This reverts the following PR: 
https://github.com/ibm-openbmc/bmcweb/pull/207/files

reverts the following 5 commits: 
Add back error message from 
Implement connection limit
Deduplicate doAccept code
Make timer system use boost 
Revert "HMC-BMC: SSLHandshakeException fix

Test reported seeing CI code update fails, @geissonator was not able to reproduce that but was able to reproduce code update taking 5 times as long. 
We will live with what we have, "Sunitha's workaround which bumps up the timer queue from 100 to 300."

This was verified to fix on a CI machine.  