### PR TITLE
Fix AccountService patch privileges

### DIFF
--- a/redfish-core/lib/account_service.hpp
+++ b/redfish-core/lib/account_service.hpp
@@ -1484,7 +1484,7 @@ inline void requestAccountServiceRoutes(App& app)
         });
 
     BMCWEB_ROUTE(app, "/redfish/v1/AccountService/")
-        .privileges(redfish::privileges::getAccountService)
+        .privileges(redfish::privileges::patchAccountService)
         .methods(boost::beast::http::verb::patch)(
             [](const crow::Request& req,
                const std::shared_ptr<bmcweb::AsyncResp>& asyncResp) -> void {


### PR DESCRIPTION
This got broke when moving to the Automate PrivilegeRegistry and was
correct before.
https://github.com/openbmc/bmcweb/commit/f5ffd8062e556cb3bdf5f441dd393e784b771e85

https://github.com/openbmc/bmcweb/blame/2c37b4b0f465344aeea311efd61fd9a217ad8e3e/redfish-core/lib/account_service.hpp#L569

This is moving AccountService patch privilege from Login to
ConfigureUsers, moving to what it was before.
Without this change a ReadOnly user could set the AccountUnlockTimeout
and patch LDAP.

Upstream is https://gerrit.openbmc-project.xyz/c/openbmc/bmcweb/+/50094 and has been merged 

Defect is https://w3.rchland.ibm.com/projects/bestquest/?defect=SW541092

Change-Id: I7fe3727e0909fe5c94b655bbb3bbc7ce7b3c842a
Signed-off-by: Gunnar Mills <gmills@us.ibm.com>