### PR TITLE
Bump Chassis schema to fix error

### DIFF
--- a/redfish-core/lib/chassis.hpp
+++ b/redfish-core/lib/chassis.hpp
@@ -303,7 +303,7 @@ inline void requestRoutesChassis(App& app)
                         }
 
                         asyncResp->res.jsonValue["@odata.type"] =
-                            "#Chassis.v1_15_0.Chassis";
+                            "#Chassis.v1_16_0.Chassis";
                         asyncResp->res.jsonValue["@odata.id"] =
                             "/redfish/v1/Chassis/" + chassisId;
                         asyncResp->res.jsonValue["Name"] = "Chassis Collection";
@@ -563,7 +563,7 @@ inline void requestRoutesChassis(App& app)
 
                     // Couldn't find an object with that name.  return an error
                     messages::resourceNotFound(
-                        asyncResp->res, "#Chassis.v1_15_0.Chassis", chassisId);
+                        asyncResp->res, "#Chassis.v1_16_0.Chassis", chassisId);
                 },
                 "xyz.openbmc_project.ObjectMapper",
                 "/xyz/openbmc_project/object_mapper",


### PR DESCRIPTION
https://gerrit.openbmc-project.xyz/c/openbmc/bmcweb/+/48719 added
support for the Chassis SparePartNumber. SparePartNumber was added to
the Chassis schema in v1_16_0 so need to bump the Chassis schema.

Bumped to v1_16_0 instead of the latest (v1_18_0) due to old guidance
from Redfish "only bump the schema if you need to". I.e. only bump if
using some property, etc in the schema. bmcweb has followed this.

The validator flags this as:
ERROR - SparePartNumber not defined in schema Chassis.v1_14_0 (check
version, spelling and casing)

From https://redfish.dmtf.org/schemas/v1/Chassis.v1_18_0.json:
"SparePartNumber": {
    "description": "The spare part number of the chassis.",
...
    "versionAdded": "v1_16_0"
},

Upstream is https://gerrit.openbmc-project.xyz/c/openbmc/bmcweb/+/50092 and has been merged 

Change-Id: I31d0bd388c4d9c787276de7b1be3fc95586e8bd2
Signed-off-by: Gunnar Mills <gmills@us.ibm.com>
