### PR TITLE
boot-progress: add support for SetupEntered

### DIFF
--- a/redfish-core/lib/systems.hpp
+++ b/redfish-core/lib/systems.hpp
@@ -889,17 +889,15 @@ inline void getBootProgress(const std::shared_ptr<bmcweb::AsyncResp>& aResp)
             {
                 rfBpLastState = "PCIResourceConfigStarted";
             }
-            else if (
-                bootProgressStr ==
-                "xyz.openbmc_project.State.Boot.Progress.ProgressStages."
-                "SystemSetup")
+            else if (*bootProgressStr ==
+                     "xyz.openbmc_project.State.Boot.Progress.ProgressStages."
+                     "SystemSetup")
             {
                 rfBpLastState = "SetupEntered";
             }
-            else if (
-                bootProgressStr ==
-                "xyz.openbmc_project.State.Boot.Progress.ProgressStages."
-                "SystemInitComplete")
+            else if (*bootProgressStr ==
+                     "xyz.openbmc_project.State.Boot.Progress.ProgressStages."
+                     "SystemInitComplete")
             {
                 rfBpLastState = "SystemHardwareInitializationComplete";
             }

--- a/redfish-core/lib/systems.hpp
+++ b/redfish-core/lib/systems.hpp
@@ -889,9 +889,17 @@ inline void getBootProgress(const std::shared_ptr<bmcweb::AsyncResp>& aResp)
             {
                 rfBpLastState = "PCIResourceConfigStarted";
             }
-            else if (*bootProgressStr ==
-                     "xyz.openbmc_project.State.Boot.Progress.ProgressStages."
-                     "SystemInitComplete")
+            else if (
+                bootProgressStr ==
+                "xyz.openbmc_project.State.Boot.Progress.ProgressStages."
+                "SystemSetup")
+            {
+                rfBpLastState = "SetupEntered";
+            }
+            else if (
+                bootProgressStr ==
+                "xyz.openbmc_project.State.Boot.Progress.ProgressStages."
+                "SystemInitComplete")
             {
                 rfBpLastState = "SystemHardwareInitializationComplete";
             }


### PR DESCRIPTION
The following phosphor-dbus-interfaces commit introduced a new
BootProgress value:
https://github.com/openbmc/phosphor-dbus-interfaces/commit/d01d1f84191894ad605a9ba5b546280bcfc64f7d

Add support for this to the Redfish API provided by bmcweb.

Tested:
- Manually set BootProgress D-Bus property to SystemSetup and verify
  busctl set-property xyz.openbmc_project.State.Host
    /xyz/openbmc_project/state/host0 xyz.openbmc_project.State.Boot.Progress
    BootProgress s
    xyz.openbmc_project.State.Boot.Progress.ProgressStages.SystemSetup

  curl -k -H "X-Auth-Token: $token" -X GET https://${bmc}/redfish/v1/Systems/system
    "BootProgress": {
    "LastState": "SetupEntered"
  },

- Verified validator passed when LastState was "SetupEntered"

Change-Id: Ie966766b88d2923bc0d10d89370713c7b17df14b
Signed-off-by: Andrew Geissler <geissonator@yahoo.com>