### PR TITLE
Hypervisor Static IP error handling

### DIFF
--- a/redfish-core/lib/hypervisor_system.hpp
+++ b/redfish-core/lib/hypervisor_system.hpp
@@ -369,7 +369,21 @@ inline void
         [asyncResp](const boost::system::error_code ec) {
             if (ec)
             {
-                messages::internalError(asyncResp->res);
+                BMCWEB_LOG_DEBUG
+                    << "createHypervisorIPv4 failed: ec: " << ec.message()
+                    << " ec.value= " << ec.value();
+                if ((ec == boost::system::errc::io_error) ||
+                    (ec == boost::system::errc::invalid_argument) ||
+                    (ec == boost::system::errc::argument_list_too_long))
+                {
+                    messages::invalidObject(asyncResp->res,
+                                            "IPv4StaticAddresses");
+                }
+                else
+                {
+                    messages::internalError(asyncResp->res);
+                }
+
                 return;
             }
         },


### PR DESCRIPTION
When some invalid IP is provided for the hypervisor IP, BMC was
sending 500, Internal server error

This commit changes the invalid input errot from 5xx to 4xx

Tested by:
 1. Set valid IP for hypervisor static network
 2. Set invalid IP; say 10.5.5.012 and see the 4xx error is raised

Signed-off-by: Sunitha Harish <sunharis@in.ibm.com>
Change-Id: I26a5fadf29db8378db228f77c47d78a95e03be4d