### PR TITLE
Return right BMC state to the redfish client

### DIFF
--- a/redfish-core/lib/managers.hpp
+++ b/redfish-core/lib/managers.hpp
@@ -1963,8 +1963,8 @@ inline void getBMCState(const std::shared_ptr<bmcweb::AsyncResp>& aResp)
             else if (*state == "xyz.openbmc_project.State.BMC.BMCState."
                                "NotReady")
             {
-                aResp->res.jsonValue["PowerState"] = "Starting";
-                aResp->res.jsonValue["Status"]["State"] = "Disabled";
+                aResp->res.jsonValue["PowerState"] = "PoweringOn";
+                aResp->res.jsonValue["Status"]["State"] = "Starting";
                 aResp->res.jsonValue["Status"]["Health"] = "OK";
             }
             else if (*state == "xyz.openbmc_project.State.BMC.BMCState."
@@ -1976,9 +1976,9 @@ inline void getBMCState(const std::shared_ptr<bmcweb::AsyncResp>& aResp)
             }
             else
             {
-                aResp->res.jsonValue["PowerState"] = "Off";
-                aResp->res.jsonValue["Status"]["State"] = "Disabled";
-                aResp->res.jsonValue["Status"]["Health"] = "OK";
+                BMCWEB_LOG_ERROR << "Unsupported D-Bus CurrentBMCState "
+                                 << *state;
+                messages::internalError(aResp->res);
             }
         },
         "xyz.openbmc_project.State.BMC", "/xyz/openbmc_project/state/bmc0",


### PR DESCRIPTION
Currently BMC PowerState hardcoded to "On" on redfish interface.

this commit adds check to display bmc state based on current bmc state on state manager D-bus 

This is to fix HMC-BMC defect SW541358

Tested by:
GET /redfish/v1/Managers/bmc for different bmc states
Redfish validator passed