### PR TITLE
Add pre-req to phosphor-user-manager service

### DIFF
--- a/bmcweb.service.in
+++ b/bmcweb.service.in
@@ -3,6 +3,7 @@ Description=Start bmcweb server
 
 Wants=network.target
 After=network.target
+After=xyz.openbmc_project.User.Manager.service
 
 [Service]
 ExecReload=kill -s HUP $MAINPID

--- a/http/routing.hpp
+++ b/http/routing.hpp
@@ -1414,7 +1414,9 @@ class Router
                     userInfo) {
                 if (ec)
                 {
-                    BMCWEB_LOG_ERROR << "GetUserInfo failed...";
+                    BMCWEB_LOG_ERROR << "GetUserInfo failed for user: "
+                                     << req.session->username
+                                     << " sessionId: " << req.session->uniqueId;
                     asyncResp->res.result(
                         boost::beast::http::status::internal_server_error);
                     return;


### PR DESCRIPTION
bmcweb now can start without any defined dependencies on the
user manager application. But bmcweb requires the user manager
to be up and running to serve the incoming requests while checking
the user authorization

This commit adds this runtime dependancy to the bmcweb and an
improvement at the GetUserInfo failure trace

Tested by:
  1. BMC reboot with test image
  2. Connect redfish client and reboot the BMC and see all
     incoming commands are processed good after reboot
  3. No GetUserInfo failures observed while rebooting the bmc

Signed-off-by: Sunitha Harish <sunharis@in.ibm.com>
Change-Id: Ic444f9c7b8e04ee31b6414224c3ec66dc4009070