### PR TITLE
Add new Redfish role OemIBMServiceAgent

### DIFF
--- a/redfish-core/include/error_messages.hpp
+++ b/redfish-core/include/error_messages.hpp
@@ -975,6 +975,17 @@ void addMessageToErrorJson(nlohmann::json& target,
                            const nlohmann::json& message);
 void addMessageToJson(nlohmann::json& target, const nlohmann::json& message,
                       const std::string& fieldPath);
+
+/**
+ * RestrictedRole is new in https://github.com/DMTF/Redfish/blob/master/registries/Base.1.9.0.json
+ * @brief Formats RestrictedRole message into JSON
+ * Message body: "The operation was not successful because the role '<arg1>' is restricted."
+ *
+ * @returns Message RestrictedRole formatted to JSON */
+nlohmann::json restrictedRole(const std::string& arg1);
+void restrictedRole(crow::Response& res, const std::string& arg1);
+
+
 } // namespace messages
 
 } // namespace redfish

--- a/redfish-core/include/privileges.hpp
+++ b/redfish-core/include/privileges.hpp
@@ -46,7 +46,7 @@ constexpr const size_t maxPrivilegeCount = 32;
 /** @brief A vector of all privilege names and their indexes */
 static const std::array<std::string, maxPrivilegeCount> privilegeNames{
     "Login", "ConfigureManager", "ConfigureComponents", "ConfigureSelf",
-    "ConfigureUsers"};
+    "ConfigureUsers", "OemIBMPerformService"};
 
 /**
  * @brief Redfish privileges
@@ -223,6 +223,13 @@ inline const Privileges& getUserPrivileges(const std::string& userRole)
         // Redfish privilege : Readonly
         static Privileges readOnly{"Login", "ConfigureSelf"};
         return readOnly;
+    }
+    if (userRole == "priv-oemibmserviceagent")
+    {
+        static Privileges admin{"Login", "ConfigureManager", "ConfigureSelf",
+                                "ConfigureUsers", "ConfigureComponents",
+                                "OemIBMPerformService"};
+        return admin;
     }
     // Redfish privilege : NoAccess
     static Privileges noaccess;

--- a/redfish-core/src/error_messages.cpp
+++ b/redfish-core/src/error_messages.cpp
@@ -2172,6 +2172,32 @@ void mutualExclusiveProperties(crow::Response& res, const std::string& arg1,
     addMessageToErrorJson(res.jsonValue, mutualExclusiveProperties(arg1, arg2));
 }
 
+/**
+ * @internal
+ * @brief Formats RestrictedRole into JSON
+ *
+ * See header file for more information
+ * @endinternal
+ */
+nlohmann::json restrictedRole(const std::string& arg1)
+{
+    return nlohmann::json{
+        {"@odata.type", "#Message.v1_1_1.Message"},
+        {"MessageId", "Base.1.9.0.RestrictedRole"},
+        {"Message", "The operation was not successful because the role '" + arg1 + "' is restricted."},
+        {"MessageArgs", {arg1}},
+        {"MessageSeverity", "Warning"},
+        {"Resolution",
+         "No resolution is required.  For standard roles, consider using the role "
+         "specified in the AlternateRoleId property in the Role resource."}};
+}
+
+void restrictedRole(crow::Response& res, const std::string& arg1)
+{
+    res.result(boost::beast::http::status::bad_request);
+    addMessageToErrorJson(res.jsonValue, restrictedRole(arg1));
+}
+
 } // namespace messages
 
 } // namespace redfish


### PR DESCRIPTION
This adds a new OEM Redfish privilege OemIBMPerformService.  This is needed
to mark REST API operations which should be restricted to the service user.

This adds a new custom Redfish role OemIBMServiceAgent which corresponds to
the priv-oemibmserviceagent role in phosphor-user-manager.  This role has
all privileges including the new OemIBMPerformService privilege.

The new OemIBMServiceAgent is implemented as a Restricted Role.

PATCHing "service" account (which uses new OemIBMServiceAgent Role)
is allowed for only the following properties: Enabled, Locked, Oem.

Tested:
Tested only local users, not LDAP RemoteRoleMapping.
Tested on a system which had the new OemIBMServiceAgent role.

Setup: Ensure there is a "service" use who has role=OemIBMPerformService.
How?  Log into the BMC command shell as the root user:
  useradd service -G priv-oemibmserviceagent,web,redfish \
    -m -N -s /bin/sh -e ""
  passwd service   ---enter the password twice---
  systemctl restart xyz.openbmc_project.User.Manager.service

Tested aspects of DSP0266 version 1.12.0 "Restricted roles and restricted
privileges".  Numbers here correspond to bullets in that section:

1a. POST /redfish/v1/AccountService/Accounts/new with Role:OemIBMServiceAgent
Ensure it failed with message Base.1.9.0.RestrictedRole.

1b. PATCH /redfish/v1/AccountService/Accounts/ordinary with
Role:OemIBMServiceAgent.  Ensure it failed.

2. PATCH the "service" user (all property) and ensure it fails for all
properties except "Locked".

3. DELETE the "service" user && ensure it failed

4. PATCH the OemIBMServiceAgent role as the LocalRole within the
RemoteRoleMapping property && ensure it failed.

IMPI: Use ipmitool to try to create or modify the service user:
ipmitool user set name ...
ipmitool user set password ...

Signed-off-by: Joseph Reynolds <joseph-reynolds@charter.net>