### PR TITLE
Push-style event: Delete subscriber after retry failures

### DIFF
--- a/include/event_service_store.hpp
+++ b/include/event_service_store.hpp
@@ -247,7 +247,7 @@ class EventServiceStore
     boost::container::flat_map<std::string, std::shared_ptr<UserSubscription>>
         subscriptionsConfigMap;
     EventServiceConfig eventServiceConfig;
-
+    bool needWrite{false};
     static EventServiceStore& getInstance()
     {
         static EventServiceStore eventServiceStore;
@@ -257,6 +257,31 @@ class EventServiceStore
     EventServiceConfig& getEventServiceConfig()
     {
         return eventServiceConfig;
+    }
+
+    bool needsWrite()
+    {
+        return needWrite;
+    }
+
+    void persistSubscription()
+    {
+        needWrite = true;
+        return;
+    }
+    void removeSubscription(const std::string& id)
+    {
+        auto obj = subscriptionsConfigMap.find(id);
+        if (obj != subscriptionsConfigMap.end())
+        {
+            BMCWEB_LOG_ERROR << "Deleting " << id
+                             << " from subscriptionsConfigMap";
+            subscriptionsConfigMap.erase(obj);
+            needWrite = true;
+            return;
+        }
+        BMCWEB_LOG_ERROR << "Subscriber " << id
+                         << " not found subscriptionsConfigMap";
     }
 };
 

--- a/include/persistent_data.hpp
+++ b/include/persistent_data.hpp
@@ -37,7 +37,8 @@ class ConfigFile
     {
         // Make sure we aren't writing stale sessions
         persistent_data::SessionStore::getInstance().applySessionTimeouts();
-        if (persistent_data::SessionStore::getInstance().needsWrite())
+        if ((persistent_data::SessionStore::getInstance().needsWrite()) ||
+            (persistent_data::EventServiceStore::getInstance().needsWrite()))
         {
             writeData();
         }

--- a/redfish-core/lib/event_service.hpp
+++ b/redfish-core/lib/event_service.hpp
@@ -832,7 +832,7 @@ inline void requestRoutesEventDestinationCollection(App& app)
                     messages::internalError(asyncResp->res);
                     return;
                 }
-
+                subValue->setSubId(id);
                 messages::created(asyncResp->res);
                 asyncResp->res.addHeader(
                     "Location", "/redfish/v1/EventService/Subscriptions/" + id);


### PR DESCRIPTION
Push style eventing implements sendEvent retries based on the
maximum retry limits set at the event service. When the max retry
is hit, it means that the subscriber is gone and bmc need not
attempt sending the event to that suscriber when next event occurs.
BMC should delete the subcription in this case.

Current implementation does not delete the subscription on hitting
maximum number of sendEvent retries. This overloads the http_client
at bmc to attempt a sendEvent to a non-existing or stale subscription.

This commit implements
1. Delete subscription after max retires
2. Store subscription id as a member of subscriber
3. Some trace enhancements at http client

Tested by:
 1. Subscribe to events and close the subscriber abruptly to see
    bmc retries and after all retry attempt failures, stops sending
    the events to that subscriber
 2. A bmc restart should cleanup these stale subscribers
 3. Tested sanity of the existing push-style eventing feature

Signed-off-by: Sunitha Harish <sunharis@in.ibm.com>
Change-Id: Idae9b4b4a8a4cc25239ea4637b7bde9f2e380b4f