### PR TITLE
bmcweb: Add/Move common typedefs to dbus utility

### DIFF
--- a/include/dbus_utility.hpp
+++ b/include/dbus_utility.hpp
@@ -44,6 +44,14 @@ using ManagedItem = std::pair<
     boost::container::flat_map<
         std::string, boost::container::flat_map<std::string, DbusVariantType>>>;
 
+// Map of service name to list of interfaces
+using MapperServiceMap =
+    std::vector<std::pair<std::string, std::vector<std::string>>>;
+
+// Map of object paths to MapperServiceMaps
+using MapperGetSubTreeResponse =
+    std::vector<std::pair<std::string, MapperServiceMap>>;
+
 inline void escapePathForDbus(std::string& path)
 {
     const std::regex reg("[^A-Za-z0-9_/]");

--- a/redfish-core/lib/processor.hpp
+++ b/redfish-core/lib/processor.hpp
@@ -35,14 +35,6 @@ using InterfacesProperties = boost::container::flat_map<
     std::string,
     boost::container::flat_map<std::string, dbus::utility::DbusVariantType>>;
 
-// Map of service name to list of interfaces
-using MapperServiceMap =
-    std::vector<std::pair<std::string, std::vector<std::string>>>;
-
-// Map of object paths to MapperServiceMaps
-using MapperGetSubTreeResponse =
-    std::vector<std::pair<std::string, MapperServiceMap>>;
-
 // Interfaces which imply a D-Bus object represents a Processor
 constexpr std::array<const char*, 2> processorInterfaces = {
     "xyz.openbmc_project.Inventory.Item.Cpu",
@@ -760,7 +752,7 @@ inline void getProcessorObject(const std::shared_ptr<bmcweb::AsyncResp>& resp,
     crow::connections::systemBus->async_method_call(
         [resp, processorId, handler = std::forward<Handler>(handler)](
             boost::system::error_code ec,
-            const MapperGetSubTreeResponse& subtree) mutable {
+            const dbus::utility::MapperGetSubTreeResponse& subtree) mutable {
             if (ec)
             {
                 BMCWEB_LOG_DEBUG << "DBUS response error: " << ec;
@@ -830,7 +822,7 @@ inline void getProcessorObject(const std::shared_ptr<bmcweb::AsyncResp>& resp,
 inline void getProcessorData(const std::shared_ptr<bmcweb::AsyncResp>& aResp,
                              const std::string& processorId,
                              const std::string& objectPath,
-                             const MapperServiceMap& serviceMap)
+                             const dbus::utility::MapperServiceMap& serviceMap)
 {
     aResp->res.jsonValue["@odata.type"] = "#Processor.v1_12_0.Processor";
     aResp->res.jsonValue["@odata.id"] =
@@ -1403,7 +1395,8 @@ inline void
 inline void patchAppliedOperatingConfig(
     const std::shared_ptr<bmcweb::AsyncResp>& resp,
     const std::string& processorId, const std::string& appliedConfigUri,
-    const std::string& cpuObjectPath, const MapperServiceMap& serviceMap)
+    const std::string& cpuObjectPath,
+    const dbus::utility::MapperServiceMap& serviceMap)
 {
     // Check that the property even exists by checking for the interface
     const std::string* controlService = nullptr;
@@ -1646,9 +1639,9 @@ inline void requestRoutesOperatingConfig(App& app)
             // Ask for all objects implementing OperatingConfig so we can search
             // for one with a matching name
             crow::connections::systemBus->async_method_call(
-                [asyncResp, cpuName, configName,
-                 reqUrl{req.url}](boost::system::error_code ec,
-                                  const MapperGetSubTreeResponse& subtree) {
+                [asyncResp, cpuName, configName, reqUrl{req.url}](
+                    boost::system::error_code ec,
+                    const dbus::utility::MapperGetSubTreeResponse& subtree) {
                     if (ec)
                     {
                         BMCWEB_LOG_WARNING << "D-Bus error: " << ec << ", "
@@ -1829,7 +1822,7 @@ inline void requestRoutesProcessor(App& app)
                             const std::shared_ptr<bmcweb::AsyncResp>& asyncResp,
                             const std::string& processorId,
                             const std::string& objectPath,
-                            const MapperServiceMap& serviceMap) {
+                            const dbus::utility::MapperServiceMap& serviceMap) {
                             patchAppliedOperatingConfig(asyncResp, processorId,
                                                         appliedConfigUri,
                                                         objectPath, serviceMap);


### PR DESCRIPTION
The following typedefs that are commonly used by redfish services
to get dbus subtree objects:
MapperServiceMap =
    std::vector<std::pair<std::string, std::vector<std::string>>>
MapperGetSubTreeResponse =
    std::vector<std::pair<std::string, MapperServiceMap>>

This commit adds the above mentioned typedefs to dbus utility namespace
and removes locally defined typedefs in processor.hpp.

Testing:
Validator: No errors

Few sample outputs from curl command:

$ curl -k -X GET https://{$bmc}/redfish/v1/Systems/system/Processors
{
  "@odata.id": "/redfish/v1/Systems/system/Processors",
  "@odata.type": "#ProcessorCollection.ProcessorCollection",
  "Members": [
    {
      "@odata.id": "/redfish/v1/Systems/system/Processors/dcm0-cpu0"
    },
    {
      "@odata.id": "/redfish/v1/Systems/system/Processors/dcm0-cpu1"
    },
    {
      "@odata.id": "/redfish/v1/Systems/system/Processors/dcm1-cpu0"
    },
    {
      "@odata.id": "/redfish/v1/Systems/system/Processors/dcm1-cpu1"
    }
  ],
  "Members@odata.count": 4,
  "Name": "Processor Collection"
}

$ curl -k -X GET
https://{$bmc}/redfish/v1/Systems/system/Processors/dcm0-cpu0
{
  "@odata.id": "/redfish/v1/Systems/system/Processors/dcm0-cpu0",
  "@odata.type": "#Processor.v1_12_0.Processor",
  "Id": "dcm0-cpu0",
  "Location": {
    "PartLocation": {
      "ServiceLabel": "U78DA.ND0.WZS004K-P0-C15"
    }
  },
  "LocationIndicatorActive": false,
  "Manufacturer": "",
  "MaxSpeedMHz": 0,
  "Model": "5C67",
  "Name": "PROCESSOR MODULE",
  "PartNumber": "03JM290",
  "ProcessorId": {
    "EffectiveFamily": ""
  },
  "ProcessorType": "CPU",
  "SerialNumber": "YA3936061828",
  "Socket": "",
  "SparePartNumber": "F210110",
  "Status": {
    "Health": "OK",
    "State": "Enabled"
  },
  "SubProcessors": {
    "@odata.id":
"/redfish/v1/Systems/system/Processors/dcm0-cpu0/SubProcessors"
  },
  "TotalCores": 8,
  "TotalThreads": 0
}

$ curl -k -X GET
https://{$bmc}/redfish/v1/Systems/system/Processors/dcm0-cpu0/SubProcessors
{
  "@odata.id":
"/redfish/v1/Systems/system/Processors/dcm0-cpu0/SubProcessors",
  "@odata.type": "#ProcessorCollection.ProcessorCollection",
  "Members": [],
  "Members@odata.count": 0,
  "Name": "SubProcessor Collection"
}

Signed-off-by: Shantappa Teekappanavar <sbteeks@yahoo.com>
Change-Id: I297c763af38fa5b13ef297e911b338f406b7c6e6