### PR TITLE
Add logging to internal error

### DIFF
--- a/include/openbmc_dbus_rest.hpp
+++ b/include/openbmc_dbus_rest.hpp
@@ -1395,8 +1395,7 @@ inline void findActionOnInterface(
                                     argumentNode->NextSiblingElement("arg");
                             }
 
-                            nlohmann::json::const_iterator argIt =
-                                transaction->arguments.begin();
+                            auto argIt = transaction->arguments.begin();
 
                             argumentNode = methodNode->FirstChildElement("arg");
 
@@ -1807,7 +1806,7 @@ inline void handlePut(const crow::Request& req,
         return;
     }
 
-    nlohmann::json::const_iterator propertyIt = requestDbusData.find("data");
+    auto propertyIt = requestDbusData.find("data");
     if (propertyIt == requestDbusData.end())
     {
         setErrorResponse(asyncResp->res,

--- a/include/source_location.hpp
+++ b/include/source_location.hpp
@@ -1,0 +1,27 @@
+#pragma once
+
+// As of clang-12, clang still doesn't support std::source_location, which
+// means that clang-tidy also doesn't support std::source_location.
+// Inside the libstdc++ implementation of <source_location> is this check of
+// __builtin_source_location to determine if the compiler supports the
+// necessary bits for std::source_location, and if not the header ends up doing
+// nothing.  Use this same builtin-check to detect when we're running under
+// an "older" clang and fallback to std::experimental::source_location instead.
+
+#if __has_builtin(__builtin_source_location)
+#include <source_location>
+
+namespace bmcweb
+{
+using source_location = std::source_location;
+}
+
+#else
+#include <experimental/source_location>
+
+namespace bmcweb
+{
+using source_location = std::experimental::source_location;
+}
+
+#endif

--- a/include/ssl_key_handler.hpp
+++ b/include/ssl_key_handler.hpp
@@ -144,15 +144,15 @@ inline bool verifyOpensslKeyCert(const std::string& filepath)
                 }
             }
 #else
-            EVP_PKEY_CTX* pkey_ctx =
+            EVP_PKEY_CTX* pkeyCtx =
                 EVP_PKEY_CTX_new_from_pkey(nullptr, pkey, nullptr);
 
-            if (!pkey_ctx)
+            if (!pkeyCtx)
             {
-                std::cerr << "Unable to allocate pkey_ctx " << ERR_get_error()
+                std::cerr << "Unable to allocate pkeyCtx " << ERR_get_error()
                           << "\n";
             }
-            else if (EVP_PKEY_check(pkey_ctx) == 1)
+            else if (EVP_PKEY_check(pkeyCtx) == 1)
             {
                 privateKeyValid = true;
             }
@@ -186,7 +186,7 @@ inline bool verifyOpensslKeyCert(const std::string& filepath)
             }
 
 #if (OPENSSL_VERSION_NUMBER > 0x30000000L)
-            EVP_PKEY_CTX_free(pkey_ctx);
+            EVP_PKEY_CTX_free(pkeyCtx);
 #endif
             EVP_PKEY_free(pkey);
         }

--- a/meson.build
+++ b/meson.build
@@ -1,10 +1,10 @@
 project('bmcweb', 'cpp',
         version : '1.0',
-        meson_version: '>=0.53.2',
+        meson_version: '>=0.57.0',
         default_options: [
             'werror=true',
             'warning_level=3',
-            'cpp_std=c++17',
+            'cpp_std=c++20',
             'buildtype=debugoptimized',
             'b_ndebug=if-release',
             'b_lto=true',
@@ -22,8 +22,8 @@ summary('Issues',project_issues_url, section: 'Report Issues')
 
 # Validate the c++ Standard
 
-if get_option('cpp_std') != 'c++17'
-    error('This project requires c++17 support')
+if get_option('cpp_std') != 'c++20'
+    error('This project requires c++20 support')
 endif
 
 # Get compiler and default build type

--- a/redfish-core/include/error_messages.hpp
+++ b/redfish-core/include/error_messages.hpp
@@ -17,6 +17,7 @@
 #include "http_response.hpp"
 
 #include <nlohmann/json.hpp>
+#include <source_location.hpp>
 
 namespace redfish
 {
@@ -88,7 +89,8 @@ void actionParameterValueFormatError(crow::Response& res,
  * @returns Message InternalError formatted to JSON */
 nlohmann::json internalError();
 
-void internalError(crow::Response& res);
+void internalError(crow::Response& res, const bmcweb::source_location location =
+                                            bmcweb::source_location::current());
 
 /**
  * @brief Formats UnrecognizedRequestBody message into JSON

--- a/redfish-core/lib/redfish_util.hpp
+++ b/redfish-core/lib/redfish_util.hpp
@@ -13,8 +13,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 */
-#ifndef BMCWEB_ENABLE_REDFISH_ONE_CHASSIS
 #pragma once
+#ifndef BMCWEB_ENABLE_REDFISH_ONE_CHASSIS
 
 namespace redfish
 {

--- a/redfish-core/src/error_messages.cpp
+++ b/redfish-core/src/error_messages.cpp
@@ -228,8 +228,11 @@ nlohmann::json internalError(void)
                        "consider resetting the service."}};
 }
 
-void internalError(crow::Response& res)
+void internalError(crow::Response& res, const bmcweb::source_location location)
 {
+    BMCWEB_LOG_CRITICAL << "Internal Error " << location.file_name() << "("
+                        << location.line() << ":" << location.column() << ") `"
+                        << location.function_name() << "`: ";
     res.result(boost::beast::http::status::internal_server_error);
     addMessageToErrorJson(res.jsonValue, internalError());
 }


### PR DESCRIPTION
The goal here is to just bring in the upstream commit to add logging when a InternalError is returned to the user. The features in that commit though required c++20. Bringing in c++20 brought in other upstream commit requirements. Nothing seems all that risky here but there are quite a few commits. The only one I didn't pull in from upstream is the last one. I'm pretty sure this was also fixed upstream but in a more complex manner. I went with the simpler solution in our downstream code (utilize auto).

Upstream Commits:
https://gerrit.openbmc-project.xyz/c/openbmc/bmcweb/+/49313
https://gerrit.openbmc-project.xyz/c/openbmc/bmcweb/+/48547
https://gerrit.openbmc-project.xyz/c/openbmc/bmcweb/+/47574
https://gerrit.openbmc-project.xyz/c/openbmc/bmcweb/+/49650
https://gerrit.openbmc-project.xyz/c/openbmc/bmcweb/+/49450
https://gerrit.openbmc-project.xyz/c/openbmc/bmcweb/+/50093