### PR TITLE
Fix bmcweb::redfish bug Fan Health does not reflect "Functional"

### DIFF
--- a/redfish-core/lib/fan.hpp
+++ b/redfish-core/lib/fan.hpp
@@ -64,7 +64,7 @@ inline void getFanHealth(const std::shared_ptr<bmcweb::AsyncResp>& asyncResp,
             }
             if (*value == false)
             {
-                asyncResp->res.jsonValue["Status"]["State"] = "Absent";
+                asyncResp->res.jsonValue["Status"]["Health"] = "Critical";
             }
         },
         connectionName, path, "org.freedesktop.DBus.Properties", "Get",
@@ -562,8 +562,6 @@ inline void getValidFan(const std::shared_ptr<bmcweb::AsyncResp>& asyncResp,
                     }
                     if (chassisName != chassisId)
                     {
-                        BMCWEB_LOG_ERROR << "The fan obtained at this time "
-                                            "does not belong to chassis ";
                         continue;
                     }
                     fanList.push_back({{"@odata.id", newPath + fanName + "/"}});
@@ -584,8 +582,6 @@ inline void getValidFan(const std::shared_ptr<bmcweb::AsyncResp>& asyncResp,
                     }
                     if (chassisName != chassisId)
                     {
-                        BMCWEB_LOG_ERROR << "The fan obtained at this time "
-                                            "does not belong to chassis ";
                         continue;
                     }
                     const std::string& fanSensorPath = validPath + "/sensors";


### PR DESCRIPTION
1. Missing fan "Health" state not updated to reflect "Functional"
   dbus property for fan
   https://github.com/ibm-openbmc/dev/issues/3449

2. Repeatedly adding [ERROR "fan.hpp":587] The fan obtained at this
   time does not belong to chassis to journal
   https://github.com/ibm-openbmc/dev/issues/3448

Signed-off-by: George Liu <liuxiwei@inspur.com>