### PR TITLE
Add new fan-oem-data meson option

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -92,6 +92,7 @@ feature_map = {
   'ibm-usb-code-update'             : '-DBMCWEB_ENABLE_IBM_USB_CODE_UPDATE',
   'hw-isolation'                    : '-DBMCWEB_ENABLE_HW_ISOLATION',
   'redfish-license'                 : '-DBMCWEB_ENABLE_REDFISH_LICENSE',
+  'fan-oem-data'                    : '-DBMCWEB_ENABLE_FAN_OEM_DATA',
 }
 
 # Get the options status and build a project summary to show which flags are

--- a/meson_options.txt
+++ b/meson_options.txt
@@ -38,6 +38,7 @@ option('http-body-limit', type: 'integer', min : 0, max : 512, value : 30, descr
 option('redfish-new-powersubsystem-thermalsubsystem', type : 'feature', value : 'disabled', description : 'Enable/disable the new PowerSubsystem, ThermalSubsystem, and all children schemas. This includes displaying all sensors in the SensorCollection. At a later date, this feature will be defaulted to enabled.')
 option('redfish-allow-deprecated-power-thermal', type : 'feature', value : 'enabled', description : 'Enable/disable the old Power / Thermal. The default condition is allowing the old Power / Thermal.')
 option ('https_port', type : 'integer', min : 1, max : 65535, value : 443, description : 'HTTPS Port number.')
+option('fan-oem-data', type : 'feature', value : 'disabled', description : 'Enable additional fan properties for Pid and Stepwise controllers. These OEM properties are under the Manager resource.')
 
 # Insecure options. Every option that starts with a `insecure` flag should
 # not be enabled by default for any platform, unless the author fully comprehends

--- a/redfish-core/lib/managers.hpp
+++ b/redfish-core/lib/managers.hpp
@@ -2153,8 +2153,10 @@ inline void requestRoutesManager(App& app)
             getUSBCodeUpdateState(asyncResp);
 #endif
 
+#ifdef BMCWEB_ENABLE_FAN_OEM_DATA
             auto pids = std::make_shared<GetPIDValues>(asyncResp);
             pids->run();
+#endif
 
             getMainChassisId(
                 asyncResp, [](const std::string& chassisId,
@@ -2336,12 +2338,17 @@ inline void requestRoutesManager(App& app)
                 return;
             }
 
+#if defined(BMCWEB_ENABLE_FAN_OEM_DATA) ||                                     \
+    defined(BMCWEB_ENABLE_IBM_USB_CODE_UPDATE)
             if (oem)
             {
                 std::optional<nlohmann::json> openbmc;
                 std::optional<nlohmann::json> ibmOem;
-                if (!redfish::json_util::readJson(*oem, asyncResp->res,
+                if (!redfish::json_util::readJson(*oem, asyncResp->res
+#ifdef BMCWEB_ENABLE_FAN_OEM_DATA
+                                                  ,
                                                   "OpenBmc", openbmc
+#endif
 #ifdef BMCWEB_ENABLE_IBM_USB_CODE_UPDATE
                                                   ,
                                                   "IBM", ibmOem
@@ -2354,6 +2361,7 @@ inline void requestRoutesManager(App& app)
                                      nlohmann::json::error_handler_t::replace);
                     return;
                 }
+#ifdef BMCWEB_ENABLE_FAN_OEM_DATA
                 if (openbmc)
                 {
                     std::optional<nlohmann::json> fan;
@@ -2374,6 +2382,7 @@ inline void requestRoutesManager(App& app)
                         pid->run();
                     }
                 }
+#endif
 #ifdef BMCWEB_ENABLE_IBM_USB_CODE_UPDATE
                 if (ibmOem)
                 {
@@ -2392,6 +2401,7 @@ inline void requestRoutesManager(App& app)
                 }
 #endif
             }
+#endif
             if (links)
             {
                 std::optional<nlohmann::json> activeSoftwareImage;


### PR DESCRIPTION
This new option for the PID and Stepwise controllers Fan data here:
https://github.com/ibm-openbmc/bmcweb/blob/1020/static/redfish/v1/JsonSchemas/OemManager/index.json

fan-oem-data is defaulted to disable so these properties will no longer
appear on systems built from our downstream.

Tested: Redfish Validator passes. Manager resource looks good. USB code
update PATCH / GET still work.

With USB Code update enabled: 
```
  "Oem": {
    "@odata.id": "/redfish/v1/Managers/bmc#/Oem",
    "@odata.type": "#OemManager.Oem",
    "IBM": {
      "@odata.id": "/redfish/v1/Managers/bmc#/Oem/IBM",
      "@odata.type": "#OemManager.IBM",
      "USBCodeUpdateEnabled": true
    },
    "OpenBmc": {
      "@odata.id": "/redfish/v1/Managers/bmc#/Oem/OpenBmc",
      "@odata.type": "#OemManager.OpenBmc",
      "Certificates": {
        "@odata.id": "/redfish/v1/Managers/bmc/Truststore/Certificates"
      }
    }
  },
```
With USB code update disabled
```
  "Oem": {
    "@odata.id": "/redfish/v1/Managers/bmc#/Oem",
    "@odata.type": "#OemManager.Oem",
    "OpenBmc": {
      "@odata.id": "/redfish/v1/Managers/bmc#/Oem/OpenBmc",
      "@odata.type": "#OemManager.OpenBmc",
      "Certificates": {
        "@odata.id": "/redfish/v1/Managers/bmc/Truststore/Certificates"
      }
    }
  },
```


Signed-off-by: Gunnar Mills <gmills@us.ibm.com>

Upstream, this will probably have to have enabled to not break anyone for some time. Gunnar will handle upstream at a later time. This was mostly empty on our systems anyway so the actual impact on the API is minimal.

The reason for this change is 
"Jan 24 16:34:57 rain534 bmcweb[435]: (2022-01-24 16:34:57) [ERROR "managers.hpp":1196] GetPIDValues: Can't get thermalModeIface /xyz/openbmc_project/control/thermal/0"

See defects
https://w3.rchland.ibm.com/projects/bestquest/?defect=SW542592
https://w3.rchland.ibm.com/projects/bestquest/?defect=SW542477
https://w3.rchland.ibm.com/projects/bestquest/?defect=SW542584
https://w3.rchland.ibm.com/projects/bestquest/?defect=SW542622

 A theory is "bmcweb has no dependency on EM or its configs so my guess is we’ve got a race condition between when bmcweb starts and fan-control has the object on the bus". The HMC treats all 500s as a fail. Just put this code behind a #ifdef that is defaulted to disabled since we don't need it. 