### PR TITLE
Pull ntp related upstream commits

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -369,6 +369,7 @@ srcfiles_unittest = [
   'redfish-core/ut/lock_test.cpp',
   'redfish-core/ut/configfile_test.cpp',
   'redfish-core/ut/time_utils_test.cpp',
+  'redfish-core/ut/stl_utils_test.cpp',
   'http/ut/utility_test.cpp'
 ]
 

--- a/redfish-core/include/utils/stl_utils.hpp
+++ b/redfish-core/include/utils/stl_utils.hpp
@@ -1,0 +1,39 @@
+#pragma once
+
+#include <algorithm>
+#include <string>
+
+namespace redfish
+{
+
+namespace stl_utils
+{
+
+template <typename ForwardIterator>
+ForwardIterator firstDuplicate(ForwardIterator first, ForwardIterator last)
+{
+    auto newLast = first;
+
+    for (auto current = first; current != last; ++current)
+    {
+        if (std::find(first, newLast, *current) == newLast)
+        {
+            if (newLast != current)
+            {
+                *newLast = *current;
+            }
+            ++newLast;
+        }
+    }
+
+    return newLast;
+}
+
+template <typename T>
+void removeDuplicate(T& t)
+{
+    t.erase(firstDuplicate(t.begin(), t.end()), t.end());
+}
+
+} // namespace stl_utils
+} // namespace redfish

--- a/redfish-core/lib/network_protocol.hpp
+++ b/redfish-core/lib/network_protocol.hpp
@@ -22,6 +22,7 @@
 #include <app.hpp>
 #include <registries/privilege_registry.hpp>
 #include <utils/json_utils.hpp>
+#include <utils/stl_utils.hpp>
 
 #include <optional>
 #include <variant>
@@ -237,9 +238,19 @@ inline void handleNTPProtocolEnabled(
 }
 
 inline void
-    handleNTPServersPatch(const std::vector<std::string>& ntpServers,
-                          const std::shared_ptr<bmcweb::AsyncResp>& asyncResp)
+    handleNTPServersPatch(const std::shared_ptr<bmcweb::AsyncResp>& asyncResp,
+                          std::vector<std::string>& ntpServers)
 {
+    auto iter = stl_utils::firstDuplicate(ntpServers.begin(), ntpServers.end());
+    if (iter != ntpServers.end())
+    {
+        std::string pointer =
+            "NTPServers/" +
+            std::to_string(std::distance(ntpServers.begin(), iter));
+        messages::propertyValueIncorrect(asyncResp->res, pointer, *iter);
+        return;
+    }
+
     crow::connections::systemBus->async_method_call(
         [asyncResp](const boost::system::error_code ec) {
             if (ec)
@@ -393,12 +404,8 @@ inline void requestRoutesNetworkProtocol(App& app)
 
                     if (ntpServers)
                     {
-                        std::sort((*ntpServers).begin(), (*ntpServers).end());
-                        (*ntpServers)
-                            .erase(std::unique((*ntpServers).begin(),
-                                               (*ntpServers).end()),
-                                   (*ntpServers).end());
-                        handleNTPServersPatch(*ntpServers, asyncResp);
+                        stl_utils::removeDuplicate(*ntpServers);
+                        handleNTPServersPatch(asyncResp, *ntpServers);
                     }
                 }
 

--- a/redfish-core/lib/network_protocol.hpp
+++ b/redfish-core/lib/network_protocol.hpp
@@ -44,33 +44,32 @@ inline void
     {
         for (const auto& ifacePair : obj.second)
         {
-            if (obj.first == "/xyz/openbmc_project/network/eth0")
+            if (ifacePair.first !=
+                "xyz.openbmc_project.Network.EthernetInterface")
             {
-                if (ifacePair.first ==
-                    "xyz.openbmc_project.Network.EthernetInterface")
+                continue;
+            }
+
+            for (const auto& propertyPair : ifacePair.second)
+            {
+                if (propertyPair.first == "NTPServers")
                 {
-                    for (const auto& propertyPair : ifacePair.second)
+                    const std::vector<std::string>* ntpServers =
+                        std::get_if<std::vector<std::string>>(
+                            &propertyPair.second);
+                    if (ntpServers != nullptr)
                     {
-                        if (propertyPair.first == "NTPServers")
-                        {
-                            const std::vector<std::string>* ntpServers =
-                                std::get_if<std::vector<std::string>>(
-                                    &propertyPair.second);
-                            if (ntpServers != nullptr)
-                            {
-                                ntpData = *ntpServers;
-                            }
-                        }
-                        else if (propertyPair.first == "DomainName")
-                        {
-                            const std::vector<std::string>* domainNames =
-                                std::get_if<std::vector<std::string>>(
-                                    &propertyPair.second);
-                            if (domainNames != nullptr)
-                            {
-                                dnData = *domainNames;
-                            }
-                        }
+                        ntpData = *ntpServers;
+                    }
+                }
+                else if (propertyPair.first == "DomainName")
+                {
+                    const std::vector<std::string>* domainNames =
+                        std::get_if<std::vector<std::string>>(
+                            &propertyPair.second);
+                    if (domainNames != nullptr)
+                    {
+                        dnData = *domainNames;
                     }
                 }
             }
@@ -130,30 +129,28 @@ inline void getNetworkData(const std::shared_ptr<bmcweb::AsyncResp>& asyncResp,
 
     getNTPProtocolEnabled(asyncResp);
 
-    // TODO Get eth0 interface data, and call the below callback for JSON
-    // preparation
-    getEthernetIfaceData(
-        [hostName, asyncResp](const bool& success,
-                              const std::vector<std::string>& ntpServers,
-                              const std::vector<std::string>& domainNames) {
-            if (!success)
+    getEthernetIfaceData([hostName, asyncResp](
+                             const bool& success,
+                             const std::vector<std::string>& ntpServers,
+                             const std::vector<std::string>& domainNames) {
+        if (!success)
+        {
+            messages::resourceNotFound(asyncResp->res, "ManagerNetworkProtocol",
+                                       "NetworkProtocol");
+            return;
+        }
+        asyncResp->res.jsonValue["NTP"]["NTPServers"] = ntpServers;
+        if (hostName.empty() == false)
+        {
+            std::string fqdn = hostName;
+            if (domainNames.empty() == false)
             {
-                messages::resourceNotFound(asyncResp->res, "EthernetInterface",
-                                           "eth0");
-                return;
+                fqdn += ".";
+                fqdn += domainNames[0];
             }
-            asyncResp->res.jsonValue["NTP"]["NTPServers"] = ntpServers;
-            if (hostName.empty() == false)
-            {
-                std::string fqdn = hostName;
-                if (domainNames.empty() == false)
-                {
-                    fqdn += ".";
-                    fqdn += domainNames[0];
-                }
-                asyncResp->res.jsonValue["FQDN"] = std::move(fqdn);
-            }
-        });
+            asyncResp->res.jsonValue["FQDN"] = std::move(fqdn);
+        }
+    });
 
     Privileges effectiveUserPrivileges =
         redfish::getUserPrivileges(req.userRole);
@@ -252,17 +249,51 @@ inline void
     }
 
     crow::connections::systemBus->async_method_call(
-        [asyncResp](const boost::system::error_code ec) {
+        [asyncResp,
+         ntpServers](boost::system::error_code ec,
+                     const crow::openbmc_mapper::GetSubTreeType& subtree) {
             if (ec)
             {
+                BMCWEB_LOG_WARNING << "D-Bus error: " << ec << ", "
+                                   << ec.message();
                 messages::internalError(asyncResp->res);
                 return;
             }
+
+            for (const auto& [objectPath, serviceMap] : subtree)
+            {
+                for (const auto& [service, interfaces] : serviceMap)
+                {
+                    for (const auto& interface : interfaces)
+                    {
+                        if (interface !=
+                            "xyz.openbmc_project.Network.EthernetInterface")
+                        {
+                            continue;
+                        }
+
+                        crow::connections::systemBus->async_method_call(
+                            [asyncResp](const boost::system::error_code ec) {
+                                if (ec)
+                                {
+                                    messages::internalError(asyncResp->res);
+                                    return;
+                                }
+                            },
+                            service, objectPath,
+                            "org.freedesktop.DBus.Properties", "Set", interface,
+                            "NTPServers",
+                            std::variant<std::vector<std::string>>{ntpServers});
+                    }
+                }
+            }
         },
-        "xyz.openbmc_project.Network", "/xyz/openbmc_project/network/eth0",
-        "org.freedesktop.DBus.Properties", "Set",
-        "xyz.openbmc_project.Network.EthernetInterface", "NTPServers",
-        std::variant<std::vector<std::string>>{ntpServers});
+        "xyz.openbmc_project.ObjectMapper",
+        "/xyz/openbmc_project/object_mapper",
+        "xyz.openbmc_project.ObjectMapper", "GetSubTree",
+        "/xyz/openbmc_project", 0,
+        std::array<const char*, 1>{
+            "xyz.openbmc_project.Network.EthernetInterface"});
 }
 
 inline void

--- a/redfish-core/lib/network_protocol.hpp
+++ b/redfish-core/lib/network_protocol.hpp
@@ -248,6 +248,12 @@ inline void
         return;
     }
 
+    // Removing empty element
+    ntpServers.erase(
+        std::remove_if(ntpServers.begin(), ntpServers.end(),
+                       [](const std::string& s) { return s.empty(); }),
+        ntpServers.end());
+
     crow::connections::systemBus->async_method_call(
         [asyncResp,
          ntpServers](boost::system::error_code ec,

--- a/redfish-core/ut/stl_utils_test.cpp
+++ b/redfish-core/ut/stl_utils_test.cpp
@@ -1,0 +1,21 @@
+#include "utils/stl_utils.hpp"
+
+#include <gmock/gmock.h>
+
+TEST(STLUtilesTest, RemoveDuplicates)
+{
+    std::vector<std::string> strVec = {"s1", "s4", "s1", "s2", "", "s3", "s3"};
+
+    auto iter =
+        redfish::stl_utils::firstDuplicate(strVec.begin(), strVec.end());
+    EXPECT_EQ(*iter, "s3");
+
+    redfish::stl_utils::removeDuplicate(strVec);
+
+    EXPECT_EQ(strVec.size(), 5);
+    EXPECT_EQ(strVec[0], "s1");
+    EXPECT_EQ(strVec[1], "s4");
+    EXPECT_EQ(strVec[2], "s2");
+    EXPECT_EQ(strVec[3], "");
+    EXPECT_EQ(strVec[4], "s3");
+}


### PR DESCRIPTION
This PR pulls two upstream commits related to ntp servers (that were merged long back).

1. Remove NTPServers duplicate values and null values
When saving the set NTPServers values from webUI, NTPServer may contain
duplicate values and null values and update them to D-Bus.
Now, need to parse and verify the value of the ntpServers attribute,and
remove duplicate values and null values.

2. Fix NTPServers are hard-coded for eth0
Since bmcweb is getting and patching NTPServers only from
'/xyz/openbmc_project/network/eth0' object, and this is hard-coded, if
we use eth1, it will broken the NTP configuration and fail to route to
the correct NTPServer.
All NTPServers of xyz.openbmc_project.Network.EthernetInterface
interface should be updated.

https://gerrit.openbmc-project.xyz/c/openbmc/bmcweb/+/47344
https://gerrit.openbmc-project.xyz/c/openbmc/bmcweb/+/47342