### PR TITLE
Remove health.hpp calls where unneeded

### DIFF
--- a/redfish-core/lib/ethernet.hpp
+++ b/redfish-core/lib/ethernet.hpp
@@ -1633,33 +1633,11 @@ inline void parseInterfaceData(
     const boost::container::flat_set<IPv4AddressData>& ipv4Data,
     const boost::container::flat_set<IPv6AddressData>& ipv6Data)
 {
-    constexpr const std::array<const char*, 1> inventoryForEthernet = {
-        "xyz.openbmc_project.Inventory.Item.Ethernet"};
-
     nlohmann::json& jsonResponse = asyncResp->res.jsonValue;
     jsonResponse["Id"] = ifaceId;
     jsonResponse["@odata.id"] =
         "/redfish/v1/Managers/bmc/EthernetInterfaces/" + ifaceId;
     jsonResponse["InterfaceEnabled"] = ethData.nicEnabled;
-
-    auto health = std::make_shared<HealthPopulate>(asyncResp);
-
-    crow::connections::systemBus->async_method_call(
-        [health](const boost::system::error_code ec,
-                 std::vector<std::string>& resp) {
-            if (ec)
-            {
-                return;
-            }
-
-            health->inventory = std::move(resp);
-        },
-        "xyz.openbmc_project.ObjectMapper",
-        "/xyz/openbmc_project/object_mapper",
-        "xyz.openbmc_project.ObjectMapper", "GetSubTreePaths", "/", int32_t(0),
-        inventoryForEthernet);
-
-    health->populate();
 
     if (ethData.nicEnabled)
     {

--- a/redfish-core/lib/managers.hpp
+++ b/redfish-core/lib/managers.hpp
@@ -15,7 +15,6 @@
 */
 #pragma once
 
-#include "health.hpp"
 #ifdef BMCWEB_ENABLE_IBM_USB_CODE_UPDATE
 #include "oem/ibm/usb_code_update.hpp"
 #endif
@@ -2139,10 +2138,6 @@ inline void requestRoutesManager(App& app)
                 1;
             asyncResp->res.jsonValue["Links"]["ManagerForServers"] = {
                 {{"@odata.id", "/redfish/v1/Systems/system"}}};
-
-            auto health = std::make_shared<HealthPopulate>(asyncResp);
-            health->isManagersHealth = true;
-            health->populate();
 
             fw_util::populateFirmwareInformation(asyncResp, fw_util::bmcPurpose,
                                                  "FirmwareVersion", true);

--- a/redfish-core/lib/task.hpp
+++ b/redfish-core/lib/task.hpp
@@ -472,8 +472,6 @@ inline void requestRoutesTaskService(App& app)
                 asyncResp->res.jsonValue["LifeCycleEventOnTaskStateChange"] =
                     true;
 
-                auto health = std::make_shared<HealthPopulate>(asyncResp);
-                health->populate();
                 asyncResp->res.jsonValue["Status"]["State"] = "Enabled";
                 asyncResp->res.jsonValue["ServiceEnabled"] = true;
                 asyncResp->res.jsonValue["Tasks"] = {


### PR DESCRIPTION
Fixes https://github.com/ibm-openbmc/dev/issues/3459

health.hpp is based on https://github.com/openbmc/docs/blob/master/designs/redfish-health-rolllup.md

It uses an xyz.openbmc_project.Inventory.Item.Global to identify
resources that have a HealthRollup and then uses "critical" or
"warning" associations to set that HealthRollup. It is largely unused
by us downstream. The only place we are using healthRollup is chassis.
This change removes health.hpp expect from chassis.hpp.
Instead, we tend to use Functional to set the Health and haven't been
setting HealthRollup.

We actually have a few resources where we have a race condition with the Health.
E.g. With the introduction of https://github.com/ibm-openbmc/bmcweb/pull/221/files
which sets the BMC health, as does this health.hpp, it is a race for last place for
who sets the Health for the client. We have this upstream as well and we need
to re-architect this Health and HealthRollup. We have discussed this upstream
before. 

We have recently hit some performance problems and Andrew noted "Over
a 13 second window at runtime on an Everest, there was 1.8 MB/s
traffic over D-Bus. The biggest packet size (mapper←bmcweb) was 500KB."

At least some of these 500KB packets were theorized to be
health.hpp's "busctl call xyz.openbmc_project.ObjectMapper /
org.freedesktop.DBus.ObjectManager GetManagedObjects". This inefficient
query should be addressed upstream, for the time being though let's just
remove health.hpp except where it is needed.

This removes some properties, HealthRollup and Health (in certain cases). 

Computersystem and Manager lose the HealthRollup field.
Computersystem's ProcessorSummary and MemorySummary lose the Health and HealthRollup fields.
Task, Ethernet, and Storage Interface lose the Health and HealthRollup fields. 

 
Tested: 
Validator passes. 

Before: 
```
curl -k https://$bmc/redfish/v1/Systems/system
...
  "MemorySummary": {
    "Status": {
      "Health": "OK", <- You aren't going to see this anymore 
      "HealthRollup": "OK", <- You aren't going to see this anymore 
      "State": "Enabled"
    },
    "TotalSystemMemoryGiB": 256
  },

...
  "ProcessorSummary": {
    "CoreCount": 20,
    "Count": 4,
    "Model": "",
    "Status": {
      "Health": "OK", <- You aren't going to see this anymore 
      "HealthRollup": "OK", <- You aren't going to see this anymore 
      "State": "Enabled"
    }
  },
...
  "Status": {
    "Health": "OK",
    "HealthRollup": "OK", <---- you aren't going to see this now. Does this cause problems?
    "State": "Enabled"
  },

```

With this change: 
```
curl -k https://$bmc/redfish/v1/Systems/system
...
  "MemorySummary": {
    "Status": {
      "State": "Enabled"
    },
    "TotalSystemMemoryGiB": 256
  },

...
  "ProcessorSummary": {
    "CoreCount": 20,
    "Count": 4,
    "Model": "",
    "Status": {
      "State": "Enabled"
    }
  },

...
  "Status": {
    "Health": "OK",
    "State": "Enabled"
  },

```
Before: 
```
curl -k https://$bmc/redfish/v1/Systems/system/Storage/1{
  "@odata.id": "/redfish/v1/Systems/system/Storage/1",
...
  "Status": {
    "Health": "OK",
    "HealthRollup": "OK",
    "State": "Enabled"
  }
}
```

With this change: 
```

curl -k https://mybmc/redfish/v1/Systems/system/Storage/1
{
  "@odata.id": "/redfish/v1/Systems/system/Storage/1",
...
  "Status": {
    "State": "Enabled"
  }
}


```


Signed-off-by: Gunnar Mills <gmills@us.ibm.com>