### PR TITLE
Handle resource not found error while dump offload

### DIFF
--- a/include/dump_offload.hpp
+++ b/include/dump_offload.hpp
@@ -97,8 +97,16 @@ class Handler : public std::enable_shared_from_this<Handler>
                 if (ec)
                 {
                     BMCWEB_LOG_ERROR << "DBUS response error: " << ec;
-                    this->connection->sendStreamErrorStatus(
-                        boost::beast::http::status::internal_server_error);
+                    if (ec.value() == EBADR)
+                    {
+                        this->connection->sendStreamErrorStatus(
+                            boost::beast::http::status::not_found);
+                    }
+                    else
+                    {
+                        this->connection->sendStreamErrorStatus(
+                            boost::beast::http::status::internal_server_error);
+                    }
                     this->connection->close();
                     return;
                 }
@@ -159,8 +167,17 @@ class Handler : public std::enable_shared_from_this<Handler>
                     BMCWEB_LOG_ERROR
                         << "DBUS response error: Unable to get the dump size "
                         << ec;
-                    this->connection->sendStreamErrorStatus(
-                        boost::beast::http::status::internal_server_error);
+
+                    if (ec.value() == EBADR)
+                    {
+                        this->connection->sendStreamErrorStatus(
+                            boost::beast::http::status::not_found);
+                    }
+                    else
+                    {
+                        this->connection->sendStreamErrorStatus(
+                            boost::beast::http::status::internal_server_error);
+                    }
                     this->connection->close();
                     return;
                 }

--- a/redfish-core/lib/log_services.hpp
+++ b/redfish-core/lib/log_services.hpp
@@ -804,7 +804,8 @@ inline void
             if (foundDumpEntry == false)
             {
                 BMCWEB_LOG_ERROR << "Can't find Dump Entry";
-                messages::internalError(asyncResp->res);
+                messages::resourceNotFound(asyncResp->res, dumpType + " dump",
+                                           entryID);
                 return;
             }
         },


### PR DESCRIPTION
This commit is to return appropriate error for  invalid dump offload requests.

Fixes https://w3.rchland.ibm.com/projects/bestquest/?defect=SW542649

Tested by:

curl -k -H "X-Auth-Token: $bmc_token" -X GET -D header.txt https://${bmc}/redfish/v1/Systems/system/LogServices/Dump/Entries/System_1/attachment
bash-4.2$ cat header.txt 
HTTP/1.1 404 Not Found

bash-4.2$ 
bash-4.2$ curl -k -H "X-Auth-Token: $bmc_token" -X GET -D header.txt https://${bmc}/redfish/v1/Systems/system/LogServices/Dump/Entries/System_1
{
  "error": {
    "@Message.ExtendedInfo": [
      {
        "@odata.type": "#Message.v1_1_1.Message",
        "Message": "The requested resource of type System dump named System_1 was not found.",
        "MessageArgs": [
          "System dump",
          "System_1"
        ],
        "MessageId": "Base.1.8.1.ResourceNotFound",
        "MessageSeverity": "Critical",
        "Resolution": "Provide a valid resource identifier and resubmit the request."
      }
    ],
    "code": "Base.1.8.1.ResourceNotFound",
    "message": "The requested resource of type System dump named System_1 was not found."
  }
}

