### PR TITLE
OEM - Enclosure Firmware Version

### DIFF
--- a/redfish-core/lib/chassis.hpp
+++ b/redfish-core/lib/chassis.hpp
@@ -441,8 +441,12 @@ inline void requestRoutesChassis(App& app)
                                         messages::internalError(asyncResp->res);
                                         return;
                                     }
+                                    asyncResp->res.jsonValue["Oem"]["OpenBMC"]
+                                                            ["@odata.type"] =
+                                        "#OemChassis.v1_0_0.Chassis";
                                     asyncResp->res
-                                        .jsonValue["FirmwareVersion"] = *value;
+                                        .jsonValue["Oem"]["OpenBMC"]
+                                                  ["FirmwareVersion"] = *value;
                                 },
                                 connectionName, path,
                                 "org.freedesktop.DBus.Properties", "Get",

--- a/redfish-core/lib/chassis.hpp
+++ b/redfish-core/lib/chassis.hpp
@@ -413,6 +413,42 @@ inline void requestRoutesChassis(App& app)
                                 locationInterface, "LocationCode");
                         }
 
+                        const std::string versionInterface =
+                            "xyz.openbmc_project.Software.Version";
+                        if (std::find(interfaces2.begin(), interfaces2.end(),
+                                      versionInterface) != interfaces2.end())
+                        {
+                            crow::connections::systemBus->async_method_call(
+                                [asyncResp, chassisId(std::string(chassisId))](
+                                    const boost::system::error_code ec,
+                                    const std::variant<std::string>& property) {
+                                    if (ec)
+                                    {
+                                        BMCWEB_LOG_DEBUG
+                                            << "DBUS response error for "
+                                               "Version";
+                                        messages::internalError(asyncResp->res);
+                                        return;
+                                    }
+
+                                    const std::string* value =
+                                        std::get_if<std::string>(&property);
+                                    if (value == nullptr)
+                                    {
+                                        BMCWEB_LOG_DEBUG
+                                            << "Null value returned "
+                                               "for Version";
+                                        messages::internalError(asyncResp->res);
+                                        return;
+                                    }
+                                    asyncResp->res
+                                        .jsonValue["FirmwareVersion"] = *value;
+                                },
+                                connectionName, path,
+                                "org.freedesktop.DBus.Properties", "Get",
+                                versionInterface, "Version");
+                        }
+
                         crow::connections::systemBus->async_method_call(
                             [asyncResp, chassisId(std::string(chassisId)), path,
                              connectionNames](

--- a/scripts/update_schemas.py
+++ b/scripts/update_schemas.py
@@ -180,6 +180,15 @@ with open(metadata_index_path, 'w') as metadata_index:
         "        <edmx:Include Namespace=\"OemUpdateService.v1_0_0\"/>\n")
     metadata_index.write("    </edmx:Reference>\n")
 
+    metadata_index.write(
+        "    <edmx:Reference Uri=\""
+        "/redfish/v1/schema/OemChassis_v1.xml\">\n")
+    metadata_index.write(
+        "        <edmx:Include Namespace=\"OemChassis\"/>\n")
+    metadata_index.write(
+        "        <edmx:Include Namespace=\"OemChassis.v1_0_0\"/>\n")
+    metadata_index.write("    </edmx:Reference>\n")
+
     metadata_index.write("</edmx:Edmx>\n")
 
 schema_files = {}

--- a/static/redfish/v1/$metadata/index.xml
+++ b/static/redfish/v1/$metadata/index.xml
@@ -3629,4 +3629,8 @@
         <edmx:Include Namespace="OemUpdateService"/>
         <edmx:Include Namespace="OemUpdateService.v1_0_0"/>
     </edmx:Reference>
+    <edmx:Reference Uri="/redfish/v1/schema/OemChassis_v1.xml">
+        <edmx:Include Namespace="OemChassis"/>
+        <edmx:Include Namespace="OemChassis.v1_0_0"/>
+    </edmx:Reference>
 </edmx:Edmx>

--- a/static/redfish/v1/JsonSchemas/OemChassis/index.json
+++ b/static/redfish/v1/JsonSchemas/OemChassis/index.json
@@ -1,0 +1,43 @@
+{
+    "$id": "http://redfish.dmtf.org/schemas/v1/OemChassis.v1_0_0.json",
+    "$schema": "http://redfish.dmtf.org/schemas/v1/redfish-schema-v1.json",
+    "copyright": "Copyright 2014-2019 DMTF. For the full DMTF copyright policy, see http://www.dmtf.org/about/policies/copyright",
+    "definitions": {
+        "Assembly": {
+            "additionalProperties": false,
+            "description": "An indication of whether the system is prepared for the assembly to be changed.",
+            "parameters": {},
+            "patternProperties": {
+                "^([a-zA-Z_][a-zA-Z0-9_]*)?@(odata|Redfish|Message)\\.[a-zA-Z_][a-zA-Z0-9_]*$": {
+                    "description": "This property shall specify a valid odata or Redfish property.",
+                    "type": [
+                        "array",
+                        "boolean",
+                        "integer",
+                        "number",
+                        "null",
+                        "object",
+                        "string"
+                    ]
+                }
+            },
+            "properties": {
+                "FirmwareVersion": {
+                    "description": "The firmware version of this chassis.",
+                    "longDescription": "This property shall contain the firmware version as defined by the manufacturer for the associated manager.",
+                    "readonly": true,
+                    "type": [
+                        "string",
+                        "null"
+                    ]
+                }
+            },
+            "type": "object"
+        }
+    },
+    "OwningEntity": "OpenBMC",
+    "release": "1.0",
+    "title": "#OemChassis.v1_0_0"
+}
+
+

--- a/static/redfish/v1/JsonSchemas/OemChassis/index.json
+++ b/static/redfish/v1/JsonSchemas/OemChassis/index.json
@@ -3,9 +3,9 @@
     "$schema": "http://redfish.dmtf.org/schemas/v1/redfish-schema-v1.json",
     "copyright": "Copyright 2014-2019 DMTF. For the full DMTF copyright policy, see http://www.dmtf.org/about/policies/copyright",
     "definitions": {
-        "Assembly": {
+        "Chassis": {
             "additionalProperties": false,
-            "description": "An indication of whether the system is prepared for the assembly to be changed.",
+            "description": "An indication of whether the system is prepared for the chassis to be changed.",
             "parameters": {},
             "patternProperties": {
                 "^([a-zA-Z_][a-zA-Z0-9_]*)?@(odata|Redfish|Message)\\.[a-zA-Z_][a-zA-Z0-9_]*$": {
@@ -24,7 +24,7 @@
             "properties": {
                 "FirmwareVersion": {
                     "description": "The firmware version of this chassis.",
-                    "longDescription": "This property shall contain the firmware version as defined by the manufacturer for the associated manager.",
+                    "longDescription": "This property shall contain the firmware version as defined by the manufacturer for the associated chassis.",
                     "readonly": true,
                     "type": [
                         "string",

--- a/static/redfish/v1/schema/OemChassis_v1.xml
+++ b/static/redfish/v1/schema/OemChassis_v1.xml
@@ -1,0 +1,29 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<edmx:Edmx xmlns:edmx="http://docs.oasis-open.org/odata/ns/edmx" Version="4.0">
+    <edmx:Reference Uri="http://docs.oasis-open.org/odata/odata/v4.0/errata03/csd01/complete/vocabularies/Org.OData.Core.V1.xml">
+        <edmx:Include Namespace="Org.OData.Core.V1" Alias="OData"/>
+    </edmx:Reference>
+    <edmx:Reference Uri="http://redfish.dmtf.org/schemas/v1/Chassis_v1.xml">
+        <edmx:Include Namespace="Chassis"/>
+        <edmx:Include Namespace="Chassis.v1_0_0"/>
+    </edmx:Reference>
+    <edmx:Reference Uri="http://redfish.dmtf.org/schemas/v1/RedfishExtensions_v1.xml">
+        <edmx:Include Namespace="RedfishExtensions.v1_0_0" Alias="Redfish"/>
+    </edmx:Reference>
+
+    <edmx:DataServices>
+
+        <Schema xmlns="http://docs.oasis-open.org/odata/ns/edm" Namespace="OemChassis">
+            <Annotation Term="Redfish.OwningEntity" String="IBM"/>
+        </Schema>
+
+        <Schema xmlns="http://docs.oasis-open.org/odata/ns/edm" Namespace="OemChassis.v1_0_0">
+            <Action Name="ReadyToRemove" IsBound="true">
+                <Annotation Term="OData.Description" String="An indication of whether the system is prepared for the Chassis to be changed."/>
+                <Annotation Term="OData.LongDescription" String="This property shall indicate whether the system is ready for the assmebly to be changed.  Setting the value to `true` shall cause the service to perform appropriate actions to stop monitoring the battery voltage.  Setting the value to `false` shall cause the service to perform appropriate actions to resume monitoring the battery voltage."/>
+                <Parameter Name="OemChassis" Type="OemChassis.v1_0_0.OemActions"/>
+            </Action>
+        </Schema>
+
+    </edmx:DataServices>
+</edmx:Edmx>

--- a/static/redfish/v1/schema/OemChassis_v1.xml
+++ b/static/redfish/v1/schema/OemChassis_v1.xml
@@ -18,9 +18,9 @@
         </Schema>
 
         <Schema xmlns="http://docs.oasis-open.org/odata/ns/edm" Namespace="OemChassis.v1_0_0">
-            <Action Name="ReadyToRemove" IsBound="true">
-                <Annotation Term="OData.Description" String="An indication of whether the system is prepared for the Chassis to be changed."/>
-                <Annotation Term="OData.LongDescription" String="This property shall indicate whether the system is ready for the assmebly to be changed.  Setting the value to `true` shall cause the service to perform appropriate actions to stop monitoring the battery voltage.  Setting the value to `false` shall cause the service to perform appropriate actions to resume monitoring the battery voltage."/>
+            <Action Name="FirmwareVersion" IsBound="true">
+                <Annotation Term="OData.Description" String="The firmware version of this chassis."/>
+                <Annotation Term="OData.LongDescription" String="This property shall contain the firmware version as defined by the manufacturer for the associated chassis."/>
                 <Parameter Name="OemChassis" Type="OemChassis.v1_0_0.OemActions"/>
             </Action>
         </Schema>


### PR DESCRIPTION
Mex is updating via a lid in the host image, updated via PHYP.

PHYP sends an FRU record set PDR and sends the io enclosure version
data via the frurecord table and pldm parses that and hosts the
Version Interface on the mex chassis object.

This implementation retrieves that mex chassis FirmwareVersion data,
which defined via the manufacturer for the associated chassis, and
displayed on Redfish OEM schema for chassis.

Test: Tested Using Jankins validator. All Oem related checks are failing.