### PR TITLE
Remove excess traces in the ThermalMetrics Query

### DIFF
--- a/redfish-core/lib/sensors.hpp
+++ b/redfish-core/lib/sensors.hpp
@@ -3287,8 +3287,6 @@ inline void getThermalSensorData(
 
                 if (sensorType != "temperature")
                 {
-                    BMCWEB_LOG_ERROR << "Unsure how to handle sensorType "
-                                     << sensorType;
                     continue;
                 }
 


### PR DESCRIPTION
Refer: https://github.com/ibm-openbmc/dev/issues/3463

ThermalMetrics works but see excess traces in the Journal
```
curl -k https://$mybmc/redfish/v1/Chassis/chassis/ThermalSubsystem/ThermalMetrics/
{
  "@odata.id": "/redfish/v1/Chassis/chassis/ThermalSubsystem/ThermalMetrics",
  "@odata.type": "#ThermalMetrics.v1_0_0.ThermalMetrics",
  "Id": "ThermalMetrics",
  "Name": "Chassis Thermal Metrics",
  "TemperatureReadingsCelsius": [
    {
      "@odata.id": "/redfish/v1/Chassis/chassis/Sensors/PCIE_1_Temp",
      "DataSourceUri": "/redfish/v1/Chassis/chassis/Sensors/PCIE_1_Temp",
      "DeviceName": "PCIE_1_Temp",
      "Reading": 29.0
    },
    {
      "@odata.id": "/redfish/v1/Chassis/chassis/Sensors/NVMe_JBOF_Card_1_Temp",
      "DataSourceUri": "/redfish/v1/Chassis/chassis/Sensors/NVMe_JBOF_Card_1_Temp",
      "DeviceName": "NVMe_JBOF_Card_1_Temp",
      "Reading": 46.563
    },
    {
      "@odata.id": "/redfish/v1/Chassis/chassis/Sensors/NVMe_JBOF_Card_1_Local_Temp",
```

```
(2022-01-27 02:44:35) [ERROR "sensors.hpp":3290] Unsure how to handle sensorType fan_tach
(2022-01-27 02:44:35) [ERROR "sensors.hpp":3290] Unsure how to handle sensorType fan_tach
(2022-01-27 02:44:35) [ERROR "sensors.hpp":3290] Unsure how to handle sensorType fan_tach
(2022-01-27 02:44:35) [ERROR "sensors.hpp":3290] Unsure how to handle sensorType fan_tach
(2022-01-27 02:44:35) [ERROR "sensors.hpp":3290] Unsure how to handle sensorType fan_tach
(2022-01-27 02:44:35) [ERROR "sensors.hpp":3290] Unsure how to handle sensorType fan_tach
```
This removes the excess traces 

Signed-off-by: George Liu <liuxiwei@inspur.com>