### PR TITLE
SW541807 : FTC1020:Rainier: bmcweb error logs for lamp test to

### DIFF
--- a/redfish-core/lib/oem/ibm/lamp_test.hpp
+++ b/redfish-core/lib/oem/ibm/lamp_test.hpp
@@ -28,6 +28,11 @@ inline void getLampTestState(const std::shared_ptr<bmcweb::AsyncResp>& aResp)
                 getObjectType) {
             if (ec)
             {
+                if (ec.value() == 5) // generic:5 error
+                {
+                    BMCWEB_LOG_DEBUG << "lamp test not available yet!!";
+                    return;
+                }
                 BMCWEB_LOG_ERROR << "ObjectMapper::GetObject call failed: "
                                  << ec;
                 messages::internalError(aResp->res);


### PR DESCRIPTION
debug as the function is not available yet.