### PR TITLE
HW-Isolation: Fix, Don't throw internal error if failed to get error log

### DIFF
--- a/redfish-core/include/utils/error_log_utils.hpp
+++ b/redfish-core/include/utils/error_log_utils.hpp
@@ -20,6 +20,11 @@ namespace error_log_utils
  * @note The "isLink" parameter is used to add the URI as a link (i.e with
  *       "@odata.id"). If passed as "false" then, the suffix will be added
  *       as "/attachment" along with the URI.
+ *
+ *       This API won't fill the given "errorLogPropPath" property if unable
+ *       to process the given error log D-Bus object since the error log
+ *       might delete by the user via Redfish but, we should not throw
+ *       internal error in that case, just log trace and return.
  */
 inline void setErrorLogUri(
     const std::shared_ptr<bmcweb::AsyncResp>& aResp,
@@ -39,7 +44,6 @@ inline void setErrorLogUri(
                                  << "] when tried to get the Hidden property "
                                  << "from the given error log object "
                                  << errorLogObjPath.str;
-                messages::internalError(aResp->res);
                 return;
             }
             bool* hiddenPropVal = std::get_if<bool>(&hiddenProperty);
@@ -48,7 +52,6 @@ inline void setErrorLogUri(
                 BMCWEB_LOG_ERROR << "Failed to get the Hidden property value "
                                  << "from the given error log object "
                                  << errorLogObjPath.str;
-                messages::internalError(aResp->res);
                 return;
             }
 


### PR DESCRIPTION
This PR will address the [SW542539](https://w3.rchland.ibm.com/projects/bestquest/?defect=SW542539)

- The error log used to return in the Redfish response when the BMC
  returns the DIMM or Core (deconfigured one) details, and hardware
  isolation records.

- Currently, the bmcweb returns an internal error if failed to get
  the error log for the above use case but, the user might be deleted
  the error through Redfish or error log tool so, fixing to avoid
  internal error, just skipping the respective Redfish property that's
  used to return the error log URI and added the trace.

- Note, The deconfigured reason still be "Error" as per backend implementation
  just skipping the error log URI property if there is a failure to get
  the error log when the client tried to get DIMM or Core details.

Tested:

- Without Fix

```
curl -k -H "X-Auth-Token: $bmc_token" -X GET https://${bmc}/redfish/v1/ \
                                             Systems/system/Memory/dimm54
{
  "@odata.id": "/redfish/v1/Systems/system/Memory/dimm54",
  "@odata.type": "#Memory.v1_12_0.Memory",
  "AllowedSpeedsMHz": [],
  "BaseModuleType": "RDIMM",
  "BusWidthBits": 0,
  "CapacityMiB": 131072,
  "DataWidthBits": 0,
  "Enabled": false,
  "ErrorCorrection": "NoECC",
  "FirmwareRevision": "0",
  "Id": "dimm54",
  "Location": {
    "PartLocation": {
      "ServiceLabel": "U78D4.ND0.WZS000C-P0-C86"
    }
  },
  "LocationIndicatorActive": false,
  "Manufacturer": "",
  "Model": "32AD",
  "Name": "DIMM Slot",
  "OperatingSpeedMhz": 0,
  "PartNumber": "01GY874",
  "RankCount": 0,
  "SerialNumber": "YH311T14E00T",
  "SparePartNumber": "",
  "Status": {
    "Conditions": [
      {
        "Message": "The reason for the resource isolation: Error",
        "MessageArgs": [
          "Error"
        ],
        "MessageId": "OpenBMC.0.2.HardwareIsolationReason",
        "Severity": "Critical",
        "Timestamp": "2022-02-01T03:55:35+00:00"
      }
    ],
    "Health": "OK",
    "State": "Disabled"
  },
  "error": {
    "@Message.ExtendedInfo": [
      {
        "@odata.type": "#Message.v1_1_1.Message",
        "Message": "The request failed due to an internal service error. \
                     The service is still operational.",
        "MessageArgs": [],
        "MessageId": "Base.1.8.1.InternalError",
        "MessageSeverity": "Critical",
        "Resolution": "Resubmit the request.  If the problem persists, \
                       consider resetting the service."
      }
    ],
    "code": "Base.1.8.1.InternalError",
    "message": "The request failed due to an internal service error. \
                The service is still operational."
  }
}
```

- With Fix

```
curl -k -H "X-Auth-Token: $bmc_token" -X GET https://${bmc}/redfish/v1/ \
                                             Systems/system/Memory/dimm54
{
  "@odata.id": "/redfish/v1/Systems/system/Memory/dimm54",
  "@odata.type": "#Memory.v1_12_0.Memory",
  "AllowedSpeedsMHz": [],
  "BaseModuleType": "RDIMM",
  "BusWidthBits": 0,
  "CapacityMiB": 131072,
  "DataWidthBits": 0,
  "Enabled": false,
  "ErrorCorrection": "NoECC",
  "FirmwareRevision": "0",
  "Id": "dimm54",
  "Location": {
    "PartLocation": {
      "ServiceLabel": "U78D4.ND0.WZS000C-P0-C86"
    }
  },
  "LocationIndicatorActive": false,
  "Manufacturer": "",
  "Model": "32AD",
  "Name": "DIMM Slot",
  "OperatingSpeedMhz": 0,
  "PartNumber": "01GY874",
  "RankCount": 0,
  "SerialNumber": "YH311T14E00T",
  "SparePartNumber": "",
  "Status": {
    "Conditions": [
      {
        "Message": "The reason for the resource isolation: Error",
        "MessageArgs": [
          "Error"
        ],
        "MessageId": "OpenBMC.0.2.HardwareIsolationReason",
        "Severity": "Critical",
        "Timestamp": "2022-02-01T03:55:35+00:00"
      }
    ],
    "Health": "OK",
    "State": "Disabled"
  }
}
```