### PR TITLE
host-state: do not return anything if unavailable

### DIFF
--- a/redfish-core/lib/systems.hpp
+++ b/redfish-core/lib/systems.hpp
@@ -612,7 +612,14 @@ inline void getHostState(const std::shared_ptr<bmcweb::AsyncResp>& aResp)
                 const std::variant<std::string>& hostState) {
             if (ec)
             {
-                BMCWEB_LOG_DEBUG << "DBUS response error " << ec;
+                if (ec == boost::system::errc::host_unreachable)
+                {
+                    // Service not available, no error, just don't return
+                    // host state info
+                    BMCWEB_LOG_DEBUG << "Service not available " << ec;
+                    return;
+                }
+                BMCWEB_LOG_ERROR << "DBUS response error " << ec;
                 messages::internalError(aResp->res);
                 return;
             }


### PR DESCRIPTION
The host state information is provided by the
xyz.openbmc_project.State.Host service. There is no guarantee that this
service will be up and running by the time bmcweb needs it. Returning an
InternalError simply because a service is not yet running is
not very user friendly to our clients. In most situations, a client will
ignore all data returned when a 500 is returned.

Instead of putting systemd Wants/Before type relationships on everything
possibly needed by bmcweb, the design point is to simply return what
bmcweb can get at that instant in time. With this change, the majority
of the redfish system object data can be returned and used by the
client.

This scenario has been seen a few times on our p10bmc machine.

Tested:
- Verified that when xyz.openbmc_project.State.Host was unavailable, a
  call to redfish/v1/Systems/system returned what was available without
  error.
- Verified that redfish validator passed
- Verified that redfish validator passed when
  xyz.openbmc_project.State.Host.service was unavailable

Change-Id: I22c6942d2c81083bf90fa4180e95b1fa19221374
Signed-off-by: Andrew Geissler <geissonator@yahoo.com>