### PR TITLE
http_connection: Bump connection timeout to 3min

### DIFF
--- a/http/http_connection.hpp
+++ b/http/http_connection.hpp
@@ -47,10 +47,10 @@ constexpr uint64_t loggedOutPostBodyLimit = 4096;
 
 constexpr uint32_t httpHeaderLimit = 8192;
 
-// drop all connections after 1 minute, this time limit was chosen
+// drop all connections after 3 minutes, this time limit was chosen
 // arbitrarily and can be adjusted later if needed
 static constexpr const size_t loggedInAttempts =
-    (60 / timerQueueTimeoutSeconds);
+    (180 / timerQueueTimeoutSeconds);
 
 static constexpr const size_t loggedOutAttempts =
     (15 / timerQueueTimeoutSeconds);


### PR DESCRIPTION
With the current 1min timeout, there are cases when the image upload
times out due to slow network connections.

Signed-off-by: Adriana Kobylak <anoo@us.ibm.com>