### PR TITLE
Fix download log entry details and says bad request

### DIFF
--- a/include/http_utility.hpp
+++ b/include/http_utility.hpp
@@ -34,8 +34,14 @@ inline bool requestPrefersHtml(std::string_view header)
 
 inline bool isOctetAccepted(std::string_view header)
 {
-    for (const std::string& encoding : parseAccept(header))
+    for (std::string& encoding : parseAccept(header))
     {
+        // ignore any q-factor weighting (;q=)
+        std::size_t separator = encoding.find(";q=");
+        if (separator != std::string::npos)
+        {
+            encoding = encoding.substr(0, separator);
+        }
         if (encoding == "*/*" || encoding == "application/octet-stream")
         {
             return true;

--- a/include/ut/http_utility_test.cpp
+++ b/include/ut/http_utility_test.cpp
@@ -8,6 +8,10 @@ TEST(HttpUtility, requestPrefersHtml)
         http_helpers::requestPrefersHtml("*/*, application/octet-stream"));
     EXPECT_TRUE(http_helpers::isOctetAccepted("*/*, application/octet-stream"));
 
+    EXPECT_TRUE(http_helpers::isOctetAccepted("text/html, */*;q=0.8"));
+    EXPECT_TRUE(http_helpers::isOctetAccepted(
+        "application/xhtml+xml,application/octet-stream,text/html"));
+
     EXPECT_TRUE(
         http_helpers::requestPrefersHtml("text/html, application/json"));
     EXPECT_FALSE(http_helpers::isOctetAccepted("text/html, application/json"));


### PR DESCRIPTION
Upstream is https://gerrit.openbmc-project.xyz/c/openbmc/bmcweb/+/50879

Defect is https://w3.rchland.ibm.com/projects/bestquest/?defect=SW542274 

Remove q-factor weighting on Accept Header

bmcweb does not do anything with the q-factor weighting (;q=) so just
remove it from the encoding.

This is needed because routes like
"/redfish/v1/Systems/system/LogServices/EventLog/Entries/<str>/attachment"
have a check for isOctetAccepted. Even though `*/* `is in the Accept
Header isOctetAccepted still fails due to the q-factor weighting.

On the system I tested, on firefox, Accept looks like:
`Accept: text/html,application/xhtml+xml,application/xml;q=0.9,image/avif,image/webp,*/*;q=0.8`

On chrome it looks like: 
`Accept: text/html,application/xhtml+xml,application/xml;q=0.9,image/avif,image/webp,image/apng,*/*;q=0.8,application/signed-exchange;v=b3;q=0.9`

The GUI reported being unable to download a AdditionalDataURI (e.g.
...attachment/)

See: https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Accept
Tested:
/redfish/v1/Systems/system/LogServices/PostCodes/Entries/<str>/attachment/
and .../EventLog/Entries/<str>/attachment now return correctly.

Change-Id: I969f5f2c32c4acccd4d80615f17c44d0c8fabd0d
Signed-off-by: Gunnar Mills <gmills@us.ibm.com>