### PR TITLE
Publish properties under PCIeDevice schema

### DIFF
--- a/scripts/update_schemas.py
+++ b/scripts/update_schemas.py
@@ -9,7 +9,7 @@ import json
 
 import xml.etree.ElementTree as ET
 
-VERSION = "DSP8010_2021.3"
+VERSION = "DSP8010_2021.4"
 
 SCRIPT_DIR = os.path.dirname(os.path.realpath(__file__))
 

--- a/static/redfish/v1/$metadata/index.xml
+++ b/static/redfish/v1/$metadata/index.xml
@@ -253,6 +253,7 @@
         <edmx:Include Namespace="Cable"/>
         <edmx:Include Namespace="Cable.v1_0_0"/>
         <edmx:Include Namespace="Cable.v1_1_0"/>
+        <edmx:Include Namespace="Cable.v1_2_0"/>
     </edmx:Reference>
     <edmx:Reference Uri="/redfish/v1/schema/CableCollection_v1.xml">
         <edmx:Include Namespace="CableCollection"/>
@@ -430,6 +431,7 @@
         <edmx:Include Namespace="Chassis.v1_16_0"/>
         <edmx:Include Namespace="Chassis.v1_17_0"/>
         <edmx:Include Namespace="Chassis.v1_18_0"/>
+        <edmx:Include Namespace="Chassis.v1_19_0"/>
     </edmx:Reference>
     <edmx:Reference Uri="/redfish/v1/schema/ChassisCollection_v1.xml">
         <edmx:Include Namespace="ChassisCollection"/>
@@ -639,6 +641,7 @@
         <edmx:Include Namespace="ComputerSystem.v1_15_1"/>
         <edmx:Include Namespace="ComputerSystem.v1_16_0"/>
         <edmx:Include Namespace="ComputerSystem.v1_16_1"/>
+        <edmx:Include Namespace="ComputerSystem.v1_17_0"/>
     </edmx:Reference>
     <edmx:Reference Uri="/redfish/v1/schema/ComputerSystemCollection_v1.xml">
         <edmx:Include Namespace="ComputerSystemCollection"/>
@@ -681,6 +684,7 @@
         <edmx:Include Namespace="Drive.v1_0_11"/>
         <edmx:Include Namespace="Drive.v1_0_12"/>
         <edmx:Include Namespace="Drive.v1_0_13"/>
+        <edmx:Include Namespace="Drive.v1_0_14"/>
         <edmx:Include Namespace="Drive.v1_1_0"/>
         <edmx:Include Namespace="Drive.v1_1_1"/>
         <edmx:Include Namespace="Drive.v1_1_2"/>
@@ -694,6 +698,7 @@
         <edmx:Include Namespace="Drive.v1_1_10"/>
         <edmx:Include Namespace="Drive.v1_1_11"/>
         <edmx:Include Namespace="Drive.v1_1_12"/>
+        <edmx:Include Namespace="Drive.v1_1_13"/>
         <edmx:Include Namespace="Drive.v1_2_0"/>
         <edmx:Include Namespace="Drive.v1_2_1"/>
         <edmx:Include Namespace="Drive.v1_2_2"/>
@@ -705,6 +710,7 @@
         <edmx:Include Namespace="Drive.v1_2_8"/>
         <edmx:Include Namespace="Drive.v1_2_9"/>
         <edmx:Include Namespace="Drive.v1_2_10"/>
+        <edmx:Include Namespace="Drive.v1_2_11"/>
         <edmx:Include Namespace="Drive.v1_3_0"/>
         <edmx:Include Namespace="Drive.v1_3_1"/>
         <edmx:Include Namespace="Drive.v1_3_2"/>
@@ -715,6 +721,7 @@
         <edmx:Include Namespace="Drive.v1_3_7"/>
         <edmx:Include Namespace="Drive.v1_3_8"/>
         <edmx:Include Namespace="Drive.v1_3_9"/>
+        <edmx:Include Namespace="Drive.v1_3_10"/>
         <edmx:Include Namespace="Drive.v1_4_0"/>
         <edmx:Include Namespace="Drive.v1_4_1"/>
         <edmx:Include Namespace="Drive.v1_4_2"/>
@@ -725,6 +732,7 @@
         <edmx:Include Namespace="Drive.v1_4_7"/>
         <edmx:Include Namespace="Drive.v1_4_8"/>
         <edmx:Include Namespace="Drive.v1_4_9"/>
+        <edmx:Include Namespace="Drive.v1_4_10"/>
         <edmx:Include Namespace="Drive.v1_5_0"/>
         <edmx:Include Namespace="Drive.v1_5_1"/>
         <edmx:Include Namespace="Drive.v1_5_2"/>
@@ -734,6 +742,7 @@
         <edmx:Include Namespace="Drive.v1_5_6"/>
         <edmx:Include Namespace="Drive.v1_5_7"/>
         <edmx:Include Namespace="Drive.v1_5_8"/>
+        <edmx:Include Namespace="Drive.v1_5_9"/>
         <edmx:Include Namespace="Drive.v1_6_0"/>
         <edmx:Include Namespace="Drive.v1_6_1"/>
         <edmx:Include Namespace="Drive.v1_6_2"/>
@@ -741,36 +750,45 @@
         <edmx:Include Namespace="Drive.v1_6_4"/>
         <edmx:Include Namespace="Drive.v1_6_5"/>
         <edmx:Include Namespace="Drive.v1_6_6"/>
+        <edmx:Include Namespace="Drive.v1_6_7"/>
         <edmx:Include Namespace="Drive.v1_7_0"/>
         <edmx:Include Namespace="Drive.v1_7_1"/>
         <edmx:Include Namespace="Drive.v1_7_2"/>
         <edmx:Include Namespace="Drive.v1_7_3"/>
         <edmx:Include Namespace="Drive.v1_7_4"/>
         <edmx:Include Namespace="Drive.v1_7_5"/>
+        <edmx:Include Namespace="Drive.v1_7_6"/>
         <edmx:Include Namespace="Drive.v1_8_0"/>
         <edmx:Include Namespace="Drive.v1_8_1"/>
         <edmx:Include Namespace="Drive.v1_8_2"/>
         <edmx:Include Namespace="Drive.v1_8_3"/>
         <edmx:Include Namespace="Drive.v1_8_4"/>
         <edmx:Include Namespace="Drive.v1_8_5"/>
+        <edmx:Include Namespace="Drive.v1_8_6"/>
         <edmx:Include Namespace="Drive.v1_9_0"/>
         <edmx:Include Namespace="Drive.v1_9_1"/>
         <edmx:Include Namespace="Drive.v1_9_2"/>
         <edmx:Include Namespace="Drive.v1_9_3"/>
         <edmx:Include Namespace="Drive.v1_9_4"/>
         <edmx:Include Namespace="Drive.v1_9_5"/>
+        <edmx:Include Namespace="Drive.v1_9_6"/>
         <edmx:Include Namespace="Drive.v1_10_0"/>
         <edmx:Include Namespace="Drive.v1_10_1"/>
         <edmx:Include Namespace="Drive.v1_10_2"/>
         <edmx:Include Namespace="Drive.v1_10_3"/>
+        <edmx:Include Namespace="Drive.v1_10_4"/>
         <edmx:Include Namespace="Drive.v1_11_0"/>
         <edmx:Include Namespace="Drive.v1_11_1"/>
         <edmx:Include Namespace="Drive.v1_11_2"/>
         <edmx:Include Namespace="Drive.v1_11_3"/>
+        <edmx:Include Namespace="Drive.v1_11_4"/>
         <edmx:Include Namespace="Drive.v1_12_0"/>
         <edmx:Include Namespace="Drive.v1_12_1"/>
         <edmx:Include Namespace="Drive.v1_12_2"/>
+        <edmx:Include Namespace="Drive.v1_12_3"/>
         <edmx:Include Namespace="Drive.v1_13_0"/>
+        <edmx:Include Namespace="Drive.v1_13_1"/>
+        <edmx:Include Namespace="Drive.v1_14_0"/>
     </edmx:Reference>
     <edmx:Reference Uri="/redfish/v1/schema/DriveCollection_v1.xml">
         <edmx:Include Namespace="DriveCollection"/>
@@ -935,6 +953,7 @@
         <edmx:Include Namespace="EthernetInterface.v1_6_3"/>
         <edmx:Include Namespace="EthernetInterface.v1_6_4"/>
         <edmx:Include Namespace="EthernetInterface.v1_7_0"/>
+        <edmx:Include Namespace="EthernetInterface.v1_8_0"/>
     </edmx:Reference>
     <edmx:Reference Uri="/redfish/v1/schema/EthernetInterfaceCollection_v1.xml">
         <edmx:Include Namespace="EthernetInterfaceCollection"/>
@@ -1059,12 +1078,15 @@
         <edmx:Include Namespace="EventDestination.v1_9_2"/>
         <edmx:Include Namespace="EventDestination.v1_9_3"/>
         <edmx:Include Namespace="EventDestination.v1_9_4"/>
+        <edmx:Include Namespace="EventDestination.v1_9_5"/>
         <edmx:Include Namespace="EventDestination.v1_10_0"/>
         <edmx:Include Namespace="EventDestination.v1_10_1"/>
         <edmx:Include Namespace="EventDestination.v1_10_2"/>
         <edmx:Include Namespace="EventDestination.v1_10_3"/>
+        <edmx:Include Namespace="EventDestination.v1_10_4"/>
         <edmx:Include Namespace="EventDestination.v1_11_0"/>
         <edmx:Include Namespace="EventDestination.v1_11_1"/>
+        <edmx:Include Namespace="EventDestination.v1_11_2"/>
     </edmx:Reference>
     <edmx:Reference Uri="/redfish/v1/schema/EventDestinationCollection_v1.xml">
         <edmx:Include Namespace="EventDestinationCollection"/>
@@ -1383,7 +1405,10 @@
         <edmx:Include Namespace="LogEntry.v1_7_1"/>
         <edmx:Include Namespace="LogEntry.v1_8_0"/>
         <edmx:Include Namespace="LogEntry.v1_9_0"/>
+        <edmx:Include Namespace="LogEntry.v1_9_1"/>
         <edmx:Include Namespace="LogEntry.v1_10_0"/>
+        <edmx:Include Namespace="LogEntry.v1_10_1"/>
+        <edmx:Include Namespace="LogEntry.v1_11_0"/>
     </edmx:Reference>
     <edmx:Reference Uri="/redfish/v1/schema/LogEntryCollection_v1.xml">
         <edmx:Include Namespace="LogEntryCollection"/>
@@ -1530,6 +1555,7 @@
         <edmx:Include Namespace="Manager.v1_12_0"/>
         <edmx:Include Namespace="Manager.v1_12_1"/>
         <edmx:Include Namespace="Manager.v1_13_0"/>
+        <edmx:Include Namespace="Manager.v1_14_0"/>
     </edmx:Reference>
     <edmx:Reference Uri="/redfish/v1/schema/ManagerAccount_v1.xml">
         <edmx:Include Namespace="ManagerAccount"/>
@@ -1747,6 +1773,8 @@
         <edmx:Include Namespace="Memory.v1_11_0"/>
         <edmx:Include Namespace="Memory.v1_12_0"/>
         <edmx:Include Namespace="Memory.v1_13_0"/>
+        <edmx:Include Namespace="Memory.v1_13_1"/>
+        <edmx:Include Namespace="Memory.v1_14_0"/>
     </edmx:Reference>
     <edmx:Reference Uri="/redfish/v1/schema/MemoryChunks_v1.xml">
         <edmx:Include Namespace="MemoryChunks"/>
@@ -2210,6 +2238,7 @@
         <edmx:Include Namespace="PCIeDevice.v1_6_1"/>
         <edmx:Include Namespace="PCIeDevice.v1_7_0"/>
         <edmx:Include Namespace="PCIeDevice.v1_8_0"/>
+        <edmx:Include Namespace="PCIeDevice.v1_9_0"/>
     </edmx:Reference>
     <edmx:Reference Uri="/redfish/v1/schema/PCIeDeviceCollection_v1.xml">
         <edmx:Include Namespace="PCIeDeviceCollection"/>
@@ -2535,6 +2564,8 @@
         <edmx:Include Namespace="Processor.v1_12_0"/>
         <edmx:Include Namespace="Processor.v1_12_1"/>
         <edmx:Include Namespace="Processor.v1_13_0"/>
+        <edmx:Include Namespace="Processor.v1_13_1"/>
+        <edmx:Include Namespace="Processor.v1_14_0"/>
     </edmx:Reference>
     <edmx:Reference Uri="/redfish/v1/schema/ProcessorCollection_v1.xml">
         <edmx:Include Namespace="ProcessorCollection"/>
@@ -2697,6 +2728,7 @@
         <edmx:Include Namespace="Resource.v1_6_7"/>
         <edmx:Include Namespace="Resource.v1_6_8"/>
         <edmx:Include Namespace="Resource.v1_6_9"/>
+        <edmx:Include Namespace="Resource.v1_6_10"/>
         <edmx:Include Namespace="Resource.v1_7_0"/>
         <edmx:Include Namespace="Resource.v1_7_1"/>
         <edmx:Include Namespace="Resource.v1_7_2"/>
@@ -2706,6 +2738,7 @@
         <edmx:Include Namespace="Resource.v1_7_6"/>
         <edmx:Include Namespace="Resource.v1_7_7"/>
         <edmx:Include Namespace="Resource.v1_7_8"/>
+        <edmx:Include Namespace="Resource.v1_7_9"/>
         <edmx:Include Namespace="Resource.v1_8_0"/>
         <edmx:Include Namespace="Resource.v1_8_1"/>
         <edmx:Include Namespace="Resource.v1_8_2"/>
@@ -2715,6 +2748,7 @@
         <edmx:Include Namespace="Resource.v1_8_6"/>
         <edmx:Include Namespace="Resource.v1_8_7"/>
         <edmx:Include Namespace="Resource.v1_8_8"/>
+        <edmx:Include Namespace="Resource.v1_8_9"/>
         <edmx:Include Namespace="Resource.v1_9_0"/>
         <edmx:Include Namespace="Resource.v1_9_1"/>
         <edmx:Include Namespace="Resource.v1_9_2"/>
@@ -2722,16 +2756,22 @@
         <edmx:Include Namespace="Resource.v1_9_4"/>
         <edmx:Include Namespace="Resource.v1_9_5"/>
         <edmx:Include Namespace="Resource.v1_9_6"/>
+        <edmx:Include Namespace="Resource.v1_9_7"/>
         <edmx:Include Namespace="Resource.v1_10_0"/>
         <edmx:Include Namespace="Resource.v1_10_1"/>
         <edmx:Include Namespace="Resource.v1_10_2"/>
         <edmx:Include Namespace="Resource.v1_10_3"/>
+        <edmx:Include Namespace="Resource.v1_10_4"/>
         <edmx:Include Namespace="Resource.v1_11_0"/>
         <edmx:Include Namespace="Resource.v1_11_1"/>
         <edmx:Include Namespace="Resource.v1_11_2"/>
+        <edmx:Include Namespace="Resource.v1_11_3"/>
         <edmx:Include Namespace="Resource.v1_12_0"/>
         <edmx:Include Namespace="Resource.v1_12_1"/>
+        <edmx:Include Namespace="Resource.v1_12_2"/>
         <edmx:Include Namespace="Resource.v1_13_0"/>
+        <edmx:Include Namespace="Resource.v1_13_1"/>
+        <edmx:Include Namespace="Resource.v1_14_0"/>
     </edmx:Reference>
     <edmx:Reference Uri="/redfish/v1/schema/ResourceBlock_v1.xml">
         <edmx:Include Namespace="ResourceBlock"/>
@@ -2852,15 +2892,21 @@
         <edmx:Include Namespace="Sensor.v1_0_5"/>
         <edmx:Include Namespace="Sensor.v1_0_6"/>
         <edmx:Include Namespace="Sensor.v1_0_7"/>
+        <edmx:Include Namespace="Sensor.v1_0_8"/>
         <edmx:Include Namespace="Sensor.v1_1_0"/>
         <edmx:Include Namespace="Sensor.v1_1_1"/>
         <edmx:Include Namespace="Sensor.v1_1_2"/>
         <edmx:Include Namespace="Sensor.v1_1_3"/>
+        <edmx:Include Namespace="Sensor.v1_1_4"/>
         <edmx:Include Namespace="Sensor.v1_2_0"/>
         <edmx:Include Namespace="Sensor.v1_2_1"/>
+        <edmx:Include Namespace="Sensor.v1_2_2"/>
         <edmx:Include Namespace="Sensor.v1_3_0"/>
         <edmx:Include Namespace="Sensor.v1_3_1"/>
+        <edmx:Include Namespace="Sensor.v1_3_2"/>
         <edmx:Include Namespace="Sensor.v1_4_0"/>
+        <edmx:Include Namespace="Sensor.v1_4_1"/>
+        <edmx:Include Namespace="Sensor.v1_5_0"/>
     </edmx:Reference>
     <edmx:Reference Uri="/redfish/v1/schema/SensorCollection_v1.xml">
         <edmx:Include Namespace="SensorCollection"/>
@@ -2934,6 +2980,7 @@
         <edmx:Include Namespace="ServiceRoot.v1_10_0"/>
         <edmx:Include Namespace="ServiceRoot.v1_11_0"/>
         <edmx:Include Namespace="ServiceRoot.v1_12_0"/>
+        <edmx:Include Namespace="ServiceRoot.v1_13_0"/>
     </edmx:Reference>
     <edmx:Reference Uri="/redfish/v1/schema/Session_v1.xml">
         <edmx:Include Namespace="Session"/>
@@ -2990,16 +3037,19 @@
         <edmx:Include Namespace="Settings.v1_1_3"/>
         <edmx:Include Namespace="Settings.v1_1_4"/>
         <edmx:Include Namespace="Settings.v1_1_5"/>
+        <edmx:Include Namespace="Settings.v1_1_6"/>
         <edmx:Include Namespace="Settings.v1_2_0"/>
         <edmx:Include Namespace="Settings.v1_2_1"/>
         <edmx:Include Namespace="Settings.v1_2_2"/>
         <edmx:Include Namespace="Settings.v1_2_3"/>
         <edmx:Include Namespace="Settings.v1_2_4"/>
         <edmx:Include Namespace="Settings.v1_2_5"/>
+        <edmx:Include Namespace="Settings.v1_2_6"/>
         <edmx:Include Namespace="Settings.v1_3_0"/>
         <edmx:Include Namespace="Settings.v1_3_1"/>
         <edmx:Include Namespace="Settings.v1_3_2"/>
         <edmx:Include Namespace="Settings.v1_3_3"/>
+        <edmx:Include Namespace="Settings.v1_3_4"/>
     </edmx:Reference>
     <edmx:Reference Uri="/redfish/v1/schema/Signature_v1.xml">
         <edmx:Include Namespace="Signature"/>
@@ -3058,6 +3108,7 @@
         <edmx:Include Namespace="SoftwareInventory.v1_3_0"/>
         <edmx:Include Namespace="SoftwareInventory.v1_4_0"/>
         <edmx:Include Namespace="SoftwareInventory.v1_5_0"/>
+        <edmx:Include Namespace="SoftwareInventory.v1_6_0"/>
     </edmx:Reference>
     <edmx:Reference Uri="/redfish/v1/schema/SoftwareInventoryCollection_v1.xml">
         <edmx:Include Namespace="SoftwareInventoryCollection"/>
@@ -3141,6 +3192,7 @@
         <edmx:Include Namespace="Storage.v1_10_0"/>
         <edmx:Include Namespace="Storage.v1_10_1"/>
         <edmx:Include Namespace="Storage.v1_11_0"/>
+        <edmx:Include Namespace="Storage.v1_12_0"/>
     </edmx:Reference>
     <edmx:Reference Uri="/redfish/v1/schema/StorageCollection_v1.xml">
         <edmx:Include Namespace="StorageCollection"/>
@@ -3155,6 +3207,7 @@
         <edmx:Include Namespace="StorageController.v1_2_0"/>
         <edmx:Include Namespace="StorageController.v1_3_0"/>
         <edmx:Include Namespace="StorageController.v1_4_0"/>
+        <edmx:Include Namespace="StorageController.v1_5_0"/>
     </edmx:Reference>
     <edmx:Reference Uri="/redfish/v1/schema/StorageControllerCollection_v1.xml">
         <edmx:Include Namespace="StorageControllerCollection"/>
@@ -3445,7 +3498,10 @@
         <edmx:Include Namespace="UpdateService.v1_8_3"/>
         <edmx:Include Namespace="UpdateService.v1_8_4"/>
         <edmx:Include Namespace="UpdateService.v1_9_0"/>
+        <edmx:Include Namespace="UpdateService.v1_9_1"/>
         <edmx:Include Namespace="UpdateService.v1_10_0"/>
+        <edmx:Include Namespace="UpdateService.v1_10_1"/>
+        <edmx:Include Namespace="UpdateService.v1_11_0"/>
     </edmx:Reference>
     <edmx:Reference Uri="/redfish/v1/schema/USBController_v1.xml">
         <edmx:Include Namespace="USBController"/>
@@ -3491,7 +3547,9 @@
         <edmx:Include Namespace="VirtualMedia.v1_3_3"/>
         <edmx:Include Namespace="VirtualMedia.v1_4_0"/>
         <edmx:Include Namespace="VirtualMedia.v1_4_1"/>
+        <edmx:Include Namespace="VirtualMedia.v1_4_2"/>
         <edmx:Include Namespace="VirtualMedia.v1_5_0"/>
+        <edmx:Include Namespace="VirtualMedia.v1_5_1"/>
     </edmx:Reference>
     <edmx:Reference Uri="/redfish/v1/schema/VirtualMediaCollection_v1.xml">
         <edmx:Include Namespace="VirtualMediaCollection"/>

--- a/static/redfish/v1/JsonSchemas/Cable/Cable.json
+++ b/static/redfish/v1/JsonSchemas/Cable/Cable.json
@@ -1,5 +1,5 @@
 {
-    "$id": "http://redfish.dmtf.org/schemas/v1/Cable.v1_1_0.json",
+    "$id": "http://redfish.dmtf.org/schemas/v1/Cable.v1_2_0.json",
     "$ref": "#/definitions/Cable",
     "$schema": "http://redfish.dmtf.org/schemas/v1/redfish-schema-v1.json",
     "copyright": "Copyright 2014-2021 DMTF. For the full DMTF copyright policy, see http://www.dmtf.org/about/policies/copyright",
@@ -346,16 +346,20 @@
                 "SFPPlus",
                 "USBA",
                 "USBC",
-                "QSFP"
+                "QSFP",
+                "CDFP",
+                "OSFP"
             ],
             "enumDescriptions": {
                 "ACPower": "This cable connects to a AC power connector.",
+                "CDFP": "This cable connects to a CDFP connector.",
                 "DB9": "This cable connects to a DB9 connector.",
                 "DCPower": "This cable connects to a DC power connector.",
                 "DisplayPort": "This cable connects to a DisplayPort power connector.",
                 "HDMI": "This cable connects to an HDMI connector.",
                 "ICI": "This cable connects to an ICI connector.",
                 "IPASS": "This cable connects to an IPASS connector.",
+                "OSFP": "This cable connects to a OSFP connector.",
                 "PCIe": "This cable connects to a PCIe connector.",
                 "Proprietary": "This cable connects to a proprietary connector.",
                 "QSFP": "This cable connects to a QSFP connector.",
@@ -367,6 +371,10 @@
                 "SlimSAS": "This cable connects to a SlimSAS connector.",
                 "USBA": "This cable connects to a USB-A connector.",
                 "USBC": "This cable connects to a USB-C connector."
+            },
+            "enumVersionAdded": {
+                "CDFP": "v1_2_0",
+                "OSFP": "v1_2_0"
             },
             "type": "string"
         },
@@ -492,6 +500,6 @@
         }
     },
     "owningEntity": "DMTF",
-    "release": "2021.3",
-    "title": "#Cable.v1_1_0.Cable"
+    "release": "2021.4",
+    "title": "#Cable.v1_2_0.Cable"
 }

--- a/static/redfish/v1/JsonSchemas/Chassis/Chassis.json
+++ b/static/redfish/v1/JsonSchemas/Chassis/Chassis.json
@@ -1,5 +1,5 @@
 {
-    "$id": "http://redfish.dmtf.org/schemas/v1/Chassis.v1_18_0.json",
+    "$id": "http://redfish.dmtf.org/schemas/v1/Chassis.v1_19_0.json",
     "$ref": "#/definitions/Chassis",
     "$schema": "http://redfish.dmtf.org/schemas/v1/redfish-schema-v1.json",
     "copyright": "Copyright 2014-2021 DMTF. For the full DMTF copyright policy, see http://www.dmtf.org/about/policies/copyright",
@@ -262,13 +262,15 @@
                     "versionAdded": "v1_12_0"
                 },
                 "Measurements": {
+                    "deprecated": "This property has been deprecated in favor of the ComponentIntegrity resource.",
                     "description": "An array of DSP0274-defined measurement blocks.",
                     "items": {
                         "$ref": "http://redfish.dmtf.org/schemas/v1/SoftwareInventory.json#/definitions/MeasurementBlock"
                     },
                     "longDescription": "This property shall contain an array of DSP0274-defined measurement blocks.",
                     "type": "array",
-                    "versionAdded": "v1_15_0"
+                    "versionAdded": "v1_15_0",
+                    "versionDeprecated": "v1_19_0"
                 },
                 "MediaControllers": {
                     "$ref": "http://redfish.dmtf.org/schemas/v1/MediaControllerCollection.json#/definitions/MediaControllerCollection",
@@ -963,6 +965,6 @@
         }
     },
     "owningEntity": "DMTF",
-    "release": "2021.3",
-    "title": "#Chassis.v1_18_0.Chassis"
+    "release": "2021.4",
+    "title": "#Chassis.v1_19_0.Chassis"
 }

--- a/static/redfish/v1/JsonSchemas/ComputerSystem/ComputerSystem.json
+++ b/static/redfish/v1/JsonSchemas/ComputerSystem/ComputerSystem.json
@@ -1,5 +1,5 @@
 {
-    "$id": "http://redfish.dmtf.org/schemas/v1/ComputerSystem.v1_16_1.json",
+    "$id": "http://redfish.dmtf.org/schemas/v1/ComputerSystem.v1_17_0.json",
     "$ref": "#/definitions/ComputerSystem",
     "$schema": "http://redfish.dmtf.org/schemas/v1/redfish-schema-v1.json",
     "copyright": "Copyright 2014-2021 DMTF. For the full DMTF copyright policy, see http://www.dmtf.org/about/policies/copyright",
@@ -707,13 +707,15 @@
                     ]
                 },
                 "Measurements": {
+                    "deprecated": "This property has been deprecated in favor of the ComponentIntegrity resource.",
                     "description": "An array of DSP0274-defined measurement blocks.",
                     "items": {
                         "$ref": "http://redfish.dmtf.org/schemas/v1/SoftwareInventory.json#/definitions/MeasurementBlock"
                     },
                     "longDescription": "This property shall contain an array of DSP0274-defined measurement blocks.",
                     "type": "array",
-                    "versionAdded": "v1_14_0"
+                    "versionAdded": "v1_14_0",
+                    "versionDeprecated": "v1_17_0"
                 },
                 "Memory": {
                     "$ref": "http://redfish.dmtf.org/schemas/v1/MemoryCollection.json#/definitions/MemoryCollection",
@@ -1505,6 +1507,19 @@
                     "description": "The OEM extension property.",
                     "longDescription": "This property shall contain the OEM extensions.  All values for properties contained in this object shall conform to the Redfish Specification-described requirements."
                 },
+                "OffloadedNetworkDeviceFunctions": {
+                    "description": "The network device functions to which this system performs offload computation, such as with a SmartNIC.",
+                    "items": {
+                        "$ref": "http://redfish.dmtf.org/schemas/v1/NetworkDeviceFunction.json#/definitions/NetworkDeviceFunction"
+                    },
+                    "longDescription": "This property shall contain an array of links to resources of type NetworkDeviceFunction that represent the network device functions to which this system performs offload computation, such as with a SmartNIC.  This property shall not be present if the SystemType property does not contain `DPU`.",
+                    "readonly": true,
+                    "type": "array",
+                    "versionAdded": "v1_17_0"
+                },
+                "OffloadedNetworkDeviceFunctions@odata.count": {
+                    "$ref": "http://redfish.dmtf.org/schemas/v1/odata-v4.json#/definitions/count"
+                },
                 "PoweredBy": {
                     "description": "An array of links to resources or objects that power this computer system.  Normally, the link is for either a chassis or a specific set of power supplies.",
                     "items": {
@@ -2285,6 +2300,6 @@
         }
     },
     "owningEntity": "DMTF",
-    "release": "2021.2",
-    "title": "#ComputerSystem.v1_16_1.ComputerSystem"
+    "release": "2021.4",
+    "title": "#ComputerSystem.v1_17_0.ComputerSystem"
 }

--- a/static/redfish/v1/JsonSchemas/Drive/Drive.json
+++ b/static/redfish/v1/JsonSchemas/Drive/Drive.json
@@ -1,5 +1,5 @@
 {
-    "$id": "http://redfish.dmtf.org/schemas/v1/Drive.v1_13_0.json",
+    "$id": "http://redfish.dmtf.org/schemas/v1/Drive.v1_14_0.json",
     "$ref": "#/definitions/Drive",
     "$schema": "http://redfish.dmtf.org/schemas/v1/redfish-schema-v1.json",
     "copyright": "Copyright 2014-2021 DMTF. For the full DMTF copyright policy, see http://www.dmtf.org/about/policies/copyright",
@@ -268,13 +268,15 @@
                     ]
                 },
                 "Measurements": {
+                    "deprecated": "This property has been deprecated in favor of the ComponentIntegrity resource.",
                     "description": "An array of DSP0274-defined measurement blocks.",
                     "items": {
                         "$ref": "http://redfish.dmtf.org/schemas/v1/SoftwareInventory.json#/definitions/MeasurementBlock"
                     },
                     "longDescription": "This property shall contain an array of DSP0274-defined measurement blocks.",
                     "type": "array",
-                    "versionAdded": "v1_12_0"
+                    "versionAdded": "v1_12_0",
+                    "versionDeprecated": "v1_14_0"
                 },
                 "MediaType": {
                     "anyOf": [
@@ -401,7 +403,7 @@
                         "number",
                         "null"
                     ],
-                    "units": "RPM"
+                    "units": "{rev}/min"
                 },
                 "SKU": {
                     "description": "The SKU for this drive.",
@@ -560,6 +562,19 @@
                     "versionAdded": "v1_1_0"
                 },
                 "Endpoints@odata.count": {
+                    "$ref": "http://redfish.dmtf.org/schemas/v1/odata-v4.json#/definitions/count"
+                },
+                "NetworkDeviceFunctions": {
+                    "description": "An array of links to the network device functions that provide network connectivity for this drive.",
+                    "items": {
+                        "$ref": "http://redfish.dmtf.org/schemas/v1/NetworkDeviceFunction.json#/definitions/NetworkDeviceFunction"
+                    },
+                    "longDescription": "This property shall contain the array of links to resources of type NetworkDeviceFunction.  This property should only be present for drives with network connectivity, such as Ethernet attached drives.",
+                    "readonly": true,
+                    "type": "array",
+                    "versionAdded": "v1_14_0"
+                },
+                "NetworkDeviceFunctions@odata.count": {
                     "$ref": "http://redfish.dmtf.org/schemas/v1/odata-v4.json#/definitions/count"
                 },
                 "Oem": {
@@ -792,6 +807,6 @@
         }
     },
     "owningEntity": "DMTF",
-    "release": "2021.2",
-    "title": "#Drive.v1_13_0.Drive"
+    "release": "2021.4",
+    "title": "#Drive.v1_14_0.Drive"
 }

--- a/static/redfish/v1/JsonSchemas/EthernetInterface/EthernetInterface.json
+++ b/static/redfish/v1/JsonSchemas/EthernetInterface/EthernetInterface.json
@@ -1,5 +1,5 @@
 {
-    "$id": "http://redfish.dmtf.org/schemas/v1/EthernetInterface.v1_7_0.json",
+    "$id": "http://redfish.dmtf.org/schemas/v1/EthernetInterface.v1_8_0.json",
     "$ref": "#/definitions/EthernetInterface",
     "$schema": "http://redfish.dmtf.org/schemas/v1/redfish-schema-v1.json",
     "copyright": "Copyright 2014-2021 DMTF. For the full DMTF copyright policy, see http://www.dmtf.org/about/policies/copyright",
@@ -175,7 +175,7 @@
                         }
                     ],
                     "description": "Determines the DHCPv6 operating mode for this interface.",
-                    "longDescription": "This property shall control the operating mode of DHCPv6 on this interface.  DHCPv6 stateful mode configures addresses, and when it is enabled, stateless mode is also implicitly enabled.",
+                    "longDescription": "This property shall control the operating mode of DHCPv6 on this interface.",
                     "readonly": false,
                     "versionAdded": "v1_4_0"
                 },
@@ -190,8 +190,8 @@
                     "versionAdded": "v1_4_0"
                 },
                 "UseDomainName": {
-                    "description": "An indication of whether the interface uses a domain name supplied through DHCP v6 stateless mode.",
-                    "longDescription": "This property shall indicate whether the interface uses a domain name supplied through DHCP v6 stateless mode.",
+                    "description": "An indication of whether this interface uses a DHCP v6-supplied domain name.",
+                    "longDescription": "This property shall indicate whether the interface uses a DHCP v6-supplied domain name.",
                     "readonly": false,
                     "type": [
                         "boolean",
@@ -226,17 +226,31 @@
             "enum": [
                 "Stateful",
                 "Stateless",
-                "Disabled"
+                "Disabled",
+                "Enabled"
             ],
+            "enumDeprecated": {
+                "Stateful": "This property has been deprecated in favor of `Enabled`.  The control between 'stateful' and 'stateless' is managed by the DHCP server and not the client.",
+                "Stateless": "This property has been deprecated in favor of `Enabled`.  The control between 'stateful' and 'stateless' is managed by the DHCP server and not the client."
+            },
             "enumDescriptions": {
                 "Disabled": "DHCPv6 is disabled.",
+                "Enabled": "DHCPv6 is enabled.",
                 "Stateful": "DHCPv6 stateful mode.",
                 "Stateless": "DHCPv6 stateless mode."
             },
             "enumLongDescriptions": {
                 "Disabled": "DHCPv6 shall be disabled for this interface.",
-                "Stateful": "DHCPv6 shall operate in stateful mode on this interface.  DHCPv6 stateful mode configures addresses, and when it is enabled, stateless mode is also implicitly enabled.",
-                "Stateless": "DHCPv6 shall operate in stateless mode on this interface.  DHCPv6 stateless mode allows configuring the interface using DHCP options but does not configure addresses.  It is always enabled by default whenever DHCPv6 Stateful mode is also enabled."
+                "Enabled": "DHCPv6 shall be enabled for this interface.",
+                "Stateful": "DHCPv6 shall operate in stateful mode on this interface.  DHCPv6 stateful mode configures addresses, and when it is enabled, stateless mode is also implicitly enabled.  Services may replace this value with `Enabled`.",
+                "Stateless": "DHCPv6 shall operate in stateless mode on this interface.  DHCPv6 stateless mode allows configuring the interface using DHCP options but does not configure addresses.  It is always enabled by default whenever DHCPv6 Stateful mode is also enabled.  Services may replace this value with `Enabled`."
+            },
+            "enumVersionAdded": {
+                "Enabled": "v1_8_0"
+            },
+            "enumVersionDeprecated": {
+                "Stateful": "v1_8_0",
+                "Stateless": "v1_8_0"
             },
             "type": "string"
         },
@@ -831,5 +845,5 @@
     },
     "owningEntity": "DMTF",
     "release": "2021.2",
-    "title": "#EthernetInterface.v1_7_0.EthernetInterface"
+    "title": "#EthernetInterface.v1_8_0.EthernetInterface"
 }

--- a/static/redfish/v1/JsonSchemas/EventDestination/EventDestination.json
+++ b/static/redfish/v1/JsonSchemas/EventDestination/EventDestination.json
@@ -1,5 +1,5 @@
 {
-    "$id": "http://redfish.dmtf.org/schemas/v1/EventDestination.v1_11_1.json",
+    "$id": "http://redfish.dmtf.org/schemas/v1/EventDestination.v1_11_2.json",
     "$ref": "#/definitions/EventDestination",
     "$schema": "http://redfish.dmtf.org/schemas/v1/redfish-schema-v1.json",
     "copyright": "Copyright 2014-2021 DMTF. For the full DMTF copyright policy, see http://www.dmtf.org/about/policies/copyright",
@@ -368,7 +368,7 @@
                 },
                 "VerifyCertificate": {
                     "description": "An indication of whether the service will verify the certificate of the server referenced by the Destination property prior to sending the event.",
-                    "longDescription": "This property shall indicate whether whether the service will verify the certificate of the server referenced by the Destination property prior to sending the event.",
+                    "longDescription": "This property shall indicate whether whether the service will verify the certificate of the server referenced by the Destination property prior to sending the event.  If this property is not supported by the service or specified by the client in the create request, it shall be assumed to be `false`.",
                     "readonly": false,
                     "type": [
                         "boolean",
@@ -842,5 +842,5 @@
     },
     "owningEntity": "DMTF",
     "release": "2021.2",
-    "title": "#EventDestination.v1_11_1.EventDestination"
+    "title": "#EventDestination.v1_11_2.EventDestination"
 }

--- a/static/redfish/v1/JsonSchemas/LogEntry/LogEntry.json
+++ b/static/redfish/v1/JsonSchemas/LogEntry/LogEntry.json
@@ -1,5 +1,5 @@
 {
-    "$id": "http://redfish.dmtf.org/schemas/v1/LogEntry.v1_10_0.json",
+    "$id": "http://redfish.dmtf.org/schemas/v1/LogEntry.v1_11_0.json",
     "$ref": "#/definitions/LogEntry",
     "$schema": "http://redfish.dmtf.org/schemas/v1/redfish-schema-v1.json",
     "copyright": "Copyright 2014-2021 DMTF. For the full DMTF copyright policy, see http://www.dmtf.org/about/policies/copyright",
@@ -349,9 +349,23 @@
                     ],
                     "versionAdded": "v1_3_0"
                 },
+                "Originator": {
+                    "description": "The source of the log entry.",
+                    "longDescription": "This property shall contain the source of the log entry.",
+                    "readonly": true,
+                    "type": "string",
+                    "versionAdded": "v1_11_0"
+                },
+                "OriginatorType": {
+                    "$ref": "#/definitions/OriginatorTypes",
+                    "description": "The type of originator data.",
+                    "longDescription": "This property shall contain the type of originator data.",
+                    "readonly": true,
+                    "versionAdded": "v1_11_0"
+                },
                 "Resolution": {
                     "description": "Used to provide suggestions on how to resolve the situation that caused the log entry.",
-                    "longDescription": "This property shall contain the resolution of the log entry.  Services can replace the resolution defined in the message registry with a more specific resolution in a log entry.",
+                    "longDescription": "This property shall contain the resolution of the log entry.  Services should replace the resolution defined in the message registry with a more specific resolution in a log entry.",
                     "readonly": true,
                     "type": "string",
                     "versionAdded": "v1_9_0"
@@ -588,6 +602,19 @@
             "properties": {},
             "type": "object"
         },
+        "OriginatorTypes": {
+            "enum": [
+                "Client",
+                "Internal",
+                "SupportingService"
+            ],
+            "enumDescriptions": {
+                "Client": "A client of the service created this log entry.",
+                "Internal": "A process running on the service created this log entry.",
+                "SupportingService": "A process not running on the service but running on a supporting service, such as RDE implementations, UEFI, or host processes, created this log entry."
+            },
+            "type": "string"
+        },
         "SensorType": {
             "enum": [
                 "Platform Security Violation Attempt",
@@ -688,6 +715,6 @@
         }
     },
     "owningEntity": "DMTF",
-    "release": "2021.3",
-    "title": "#LogEntry.v1_10_0.LogEntry"
+    "release": "2021.4",
+    "title": "#LogEntry.v1_11_0.LogEntry"
 }

--- a/static/redfish/v1/JsonSchemas/Manager/Manager.json
+++ b/static/redfish/v1/JsonSchemas/Manager/Manager.json
@@ -1,5 +1,5 @@
 {
-    "$id": "http://redfish.dmtf.org/schemas/v1/Manager.v1_13_0.json",
+    "$id": "http://redfish.dmtf.org/schemas/v1/Manager.v1_14_0.json",
     "$ref": "#/definitions/Manager",
     "$schema": "http://redfish.dmtf.org/schemas/v1/redfish-schema-v1.json",
     "copyright": "Copyright 2014-2021 DMTF. For the full DMTF copyright policy, see http://www.dmtf.org/about/policies/copyright",
@@ -465,6 +465,20 @@
                     "longDescription": "This property shall contain a link to a resource collection of type LogServiceCollection that this manager uses.",
                     "readonly": true
                 },
+                "ManagerDiagnosticData": {
+                    "anyOf": [
+                        {
+                            "$ref": "http://redfish.dmtf.org/schemas/v1/ManagerDiagnosticData.json#/definitions/ManagerDiagnosticData"
+                        },
+                        {
+                            "type": "null"
+                        }
+                    ],
+                    "description": "The diagnostic data for this manager.",
+                    "longDescription": "This property shall contain a link to a resource of type ManagerDiagnosticData that represents the diagnostic data for this manager.",
+                    "readonly": true,
+                    "versionAdded": "v1_14_0"
+                },
                 "ManagerType": {
                     "$ref": "#/definitions/ManagerType",
                     "description": "The type of manager that this resource represents.",
@@ -482,13 +496,15 @@
                     "versionAdded": "v1_7_0"
                 },
                 "Measurements": {
+                    "deprecated": "This property has been deprecated in favor of the ComponentIntegrity resource.",
                     "description": "An array of DSP0274-defined measurement blocks.",
                     "items": {
                         "$ref": "http://redfish.dmtf.org/schemas/v1/SoftwareInventory.json#/definitions/MeasurementBlock"
                     },
                     "longDescription": "This property shall contain an array of DSP0274-defined measurement blocks.",
                     "type": "array",
-                    "versionAdded": "v1_13_0"
+                    "versionAdded": "v1_13_0",
+                    "versionDeprecated": "v1_14_0"
                 },
                 "Model": {
                     "description": "The model information of this manager, as defined by the manufacturer.",
@@ -940,6 +956,6 @@
         }
     },
     "owningEntity": "DMTF",
-    "release": "2021.2",
-    "title": "#Manager.v1_13_0.Manager"
+    "release": "2021.4",
+    "title": "#Manager.v1_14_0.Manager"
 }

--- a/static/redfish/v1/JsonSchemas/Memory/Memory.json
+++ b/static/redfish/v1/JsonSchemas/Memory/Memory.json
@@ -1,5 +1,5 @@
 {
-    "$id": "http://redfish.dmtf.org/schemas/v1/Memory.v1_13_0.json",
+    "$id": "http://redfish.dmtf.org/schemas/v1/Memory.v1_14_0.json",
     "$ref": "#/definitions/Memory",
     "$schema": "http://redfish.dmtf.org/schemas/v1/redfish-schema-v1.json",
     "copyright": "Copyright 2014-2021 DMTF. For the full DMTF copyright policy, see http://www.dmtf.org/about/policies/copyright",
@@ -503,13 +503,15 @@
                     "units": "mW"
                 },
                 "Measurements": {
+                    "deprecated": "This property has been deprecated in favor of the ComponentIntegrity resource.",
                     "description": "An array of DSP0274-defined measurement blocks.",
                     "items": {
                         "$ref": "http://redfish.dmtf.org/schemas/v1/SoftwareInventory.json#/definitions/MeasurementBlock"
                     },
                     "longDescription": "This property shall contain an array of DSP0274-defined measurement blocks.",
                     "type": "array",
-                    "versionAdded": "v1_11_0"
+                    "versionAdded": "v1_11_0",
+                    "versionDeprecated": "v1_14_0"
                 },
                 "MemoryDeviceType": {
                     "anyOf": [
@@ -661,7 +663,7 @@
                     ],
                     "description": "Range of allowed operating speeds (MHz).",
                     "excerptCopy": "ControlRangeExcerpt",
-                    "longDescription": "This property shall contain the operating speed control excerpt for this resource.",
+                    "longDescription": "This property shall contain the operating speed control, in megahertz units, for this resource.  The value of the DataSourceUri property, if present, shall reference a resource of type Control with the ControlType property containing the value of `FrequencyMHz`.",
                     "readonly": false,
                     "versionAdded": "v1_13_0"
                 },
@@ -1576,6 +1578,6 @@
         }
     },
     "owningEntity": "DMTF",
-    "release": "2021.2",
-    "title": "#Memory.v1_13_0.Memory"
+    "release": "2021.4",
+    "title": "#Memory.v1_14_0.Memory"
 }

--- a/static/redfish/v1/JsonSchemas/PCIeDevice/PCIeDevice.json
+++ b/static/redfish/v1/JsonSchemas/PCIeDevice/PCIeDevice.json
@@ -1,5 +1,5 @@
 {
-    "$id": "http://redfish.dmtf.org/schemas/v1/PCIeDevice.v1_8_0.json",
+    "$id": "http://redfish.dmtf.org/schemas/v1/PCIeDevice.v1_9_0.json",
     "$ref": "#/definitions/PCIeDevice",
     "$schema": "http://redfish.dmtf.org/schemas/v1/redfish-schema-v1.json",
     "copyright": "Copyright 2014-2021 DMTF. For the full DMTF copyright policy, see http://www.dmtf.org/about/policies/copyright",
@@ -42,6 +42,19 @@
                 "MultiFunction": "A multi-function PCIe device.",
                 "Simulated": "A PCIe device that is not currently physically present, but is being simulated by the PCIe infrastructure.",
                 "SingleFunction": "A single-function PCIe device."
+            },
+            "type": "string"
+        },
+        "LaneSplittingType": {
+            "enum": [
+                "None",
+                "Bridged",
+                "Bifurcated"
+            ],
+            "enumDescriptions": {
+                "Bifurcated": "The slot is bifurcated to split the lanes with associated devices.",
+                "Bridged": "The slot has a bridge to share the lanes with associated devices.",
+                "None": "The slot has no lane splitting."
             },
             "type": "string"
         },
@@ -291,6 +304,19 @@
                         "null"
                     ]
                 },
+                "Slot": {
+                    "anyOf": [
+                        {
+                            "$ref": "#/definitions/Slot"
+                        },
+                        {
+                            "type": "null"
+                        }
+                    ],
+                    "description": "Information about the slot for this PCIe device.",
+                    "longDescription": "This property shall contain information about the PCIe slot for this PCIe device.",
+                    "versionAdded": "v1_9_0"
+                },
                 "SparePartNumber": {
                     "description": "The spare part number of the PCIe device.",
                     "longDescription": "This property shall contain the spare part number of the PCIe device.",
@@ -508,9 +534,115 @@
                 }
             },
             "type": "object"
+        },
+        "Slot": {
+            "additionalProperties": false,
+            "description": "The PCIe slot associated with a PCIe device.",
+            "longDescription": "This object shall contain properties that describe the PCIe slot associated with a PCIe device.",
+            "patternProperties": {
+                "^([a-zA-Z_][a-zA-Z0-9_]*)?@(odata|Redfish|Message)\\.[a-zA-Z_][a-zA-Z0-9_]*$": {
+                    "description": "This property shall specify a valid odata or Redfish property.",
+                    "type": [
+                        "array",
+                        "boolean",
+                        "integer",
+                        "number",
+                        "null",
+                        "object",
+                        "string"
+                    ]
+                }
+            },
+            "properties": {
+                "LaneSplitting": {
+                    "anyOf": [
+                        {
+                            "$ref": "#/definitions/LaneSplittingType"
+                        },
+                        {
+                            "type": "null"
+                        }
+                    ],
+                    "description": "The lane splitting strategy used in the PCIe slot.",
+                    "longDescription": "This property shall contain lane splitting information of the associated PCIe slot.",
+                    "readonly": true,
+                    "versionAdded": "v1_9_0"
+                },
+                "Lanes": {
+                    "description": "The number of PCIe lanes supported by this slot.",
+                    "longDescription": "This property shall contain the maximum number of PCIe lanes supported by the slot.",
+                    "maximum": 32,
+                    "readonly": true,
+                    "type": [
+                        "integer",
+                        "null"
+                    ],
+                    "versionAdded": "v1_9_0"
+                },
+                "Location": {
+                    "$ref": "http://redfish.dmtf.org/schemas/v1/Resource.json#/definitions/Location",
+                    "description": "The location of the PCIe slot.",
+                    "longDescription": "This property shall contain part location information, including a ServiceLabel property, of the associated PCIe slot.",
+                    "versionAdded": "v1_9_0"
+                },
+                "PCIeType": {
+                    "anyOf": [
+                        {
+                            "$ref": "http://redfish.dmtf.org/schemas/v1/PCIeDevice.json#/definitions/PCIeTypes"
+                        },
+                        {
+                            "type": "null"
+                        }
+                    ],
+                    "description": "The PCIe specification this slot supports.",
+                    "longDescription": "This property shall contain the maximum PCIe specification that this slot supports.",
+                    "readonly": true,
+                    "versionAdded": "v1_9_0"
+                },
+                "SlotType": {
+                    "anyOf": [
+                        {
+                            "$ref": "#/definitions/SlotType"
+                        },
+                        {
+                            "type": "null"
+                        }
+                    ],
+                    "description": "The PCIe slot type.",
+                    "longDescription": "This property shall contain the PCIe slot type.",
+                    "readonly": true,
+                    "versionAdded": "v1_9_0"
+                }
+            },
+            "type": "object"
+        },
+        "SlotType": {
+            "enum": [
+                "FullLength",
+                "HalfLength",
+                "LowProfile",
+                "Mini",
+                "M2",
+                "OEM",
+                "OCP3Small",
+                "OCP3Large",
+                "U2"
+            ],
+            "enumDescriptions": {
+                "FullLength": "Full-Length PCIe slot.",
+                "HalfLength": "Half-Length PCIe slot.",
+                "LowProfile": "Low-Profile or Slim PCIe slot.",
+                "M2": "PCIe M.2 slot.",
+                "Mini": "Mini PCIe slot.",
+                "OCP3Large": "Open Compute Project 3.0 large form factor slot.",
+                "OCP3Small": "Open Compute Project 3.0 small form factor slot.",
+                "OEM": "An OEM-specific slot.",
+                "U2": "U.2 / SFF-8639 slot or bay."
+            },
+            "type": "string"
         }
     },
     "owningEntity": "DMTF",
-    "release": "2021.3",
-    "title": "#PCIeDevice.v1_8_0.PCIeDevice"
+    "release": "2021.4",
+    "title": "#PCIeDevice.v1_9_0.PCIeDevice"
 }

--- a/static/redfish/v1/JsonSchemas/Processor/Processor.json
+++ b/static/redfish/v1/JsonSchemas/Processor/Processor.json
@@ -1,5 +1,5 @@
 {
-    "$id": "http://redfish.dmtf.org/schemas/v1/Processor.v1_13_0.json",
+    "$id": "http://redfish.dmtf.org/schemas/v1/Processor.v1_14_0.json",
     "$ref": "#/definitions/Processor",
     "$schema": "http://redfish.dmtf.org/schemas/v1/redfish-schema-v1.json",
     "copyright": "Copyright 2014-2021 DMTF. For the full DMTF copyright policy, see http://www.dmtf.org/about/policies/copyright",
@@ -719,13 +719,15 @@
                     "versionAdded": "v1_4_0"
                 },
                 "Measurements": {
+                    "deprecated": "This property has been deprecated in favor of the ComponentIntegrity resource.",
                     "description": "An array of DSP0274-defined measurement blocks.",
                     "items": {
                         "$ref": "http://redfish.dmtf.org/schemas/v1/SoftwareInventory.json#/definitions/MeasurementBlock"
                     },
                     "longDescription": "This property shall contain an array of DSP0274-defined measurement blocks.",
                     "type": "array",
-                    "versionAdded": "v1_11_0"
+                    "versionAdded": "v1_11_0",
+                    "versionDeprecated": "v1_14_0"
                 },
                 "MemorySummary": {
                     "$ref": "#/definitions/MemorySummary",
@@ -798,7 +800,7 @@
                     ],
                     "description": "Range of allowed operating speeds (MHz).",
                     "excerptCopy": "ControlRangeExcerpt",
-                    "longDescription": "This property shall contain the operating speed control excerpt for this resource.",
+                    "longDescription": "This property shall contain the operating speed control, measured in megahertz units, for this resource.  The value of the DataSourceUri property, if present, shall reference a resource of type Control with the ControlType property containing the value of `FrequencyMHz`.",
                     "readonly": false,
                     "versionAdded": "v1_13_0"
                 },
@@ -1405,6 +1407,6 @@
         }
     },
     "owningEntity": "DMTF",
-    "release": "2021.2",
-    "title": "#Processor.v1_13_0.Processor"
+    "release": "2021.4",
+    "title": "#Processor.v1_14_0.Processor"
 }

--- a/static/redfish/v1/JsonSchemas/Resource/Resource.json
+++ b/static/redfish/v1/JsonSchemas/Resource/Resource.json
@@ -1,5 +1,5 @@
 {
-    "$id": "http://redfish.dmtf.org/schemas/v1/Resource.v1_13_0.json",
+    "$id": "http://redfish.dmtf.org/schemas/v1/Resource.v1_14_0.json",
     "$schema": "http://redfish.dmtf.org/schemas/v1/redfish-schema-v1.json",
     "copyright": "Copyright 2014-2021 DMTF. For the full DMTF copyright policy, see http://www.dmtf.org/about/policies/copyright",
     "definitions": {
@@ -64,7 +64,8 @@
                 "EUI",
                 "NQN",
                 "NSID",
-                "NGUID"
+                "NGUID",
+                "MACAddress"
             ],
             "enumDeprecated": {
                 "NSID": "This value has been deprecated due to its non-uniqueness and `NGUID` should be used."
@@ -72,6 +73,7 @@
             "enumDescriptions": {
                 "EUI": "The IEEE-defined 64-bit Extended Unique Identifier (EUI).",
                 "FC_WWN": "The Fibre Channel (FC) World Wide Name (WWN).",
+                "MACAddress": "The media access control address (MAC address).",
                 "NAA": "The Name Address Authority (NAA) format.",
                 "NGUID": "The Namespace Globally Unique Identifier (NGUID).",
                 "NQN": "The NVMe Qualified Name (NQN).",
@@ -82,6 +84,7 @@
             "enumLongDescriptions": {
                 "EUI": "This durable name shall contain the hexadecimal representation of the IEEE-defined 64-bit Extended Unique Identifier (EUI), as defined in the IEEE's Guidelines for 64-bit Global Identifier (EUI-64) Specification.  The DurableName property shall follow the pattern '^([0-9A-Fa-f]{2}[:-]){7}([0-9A-Fa-f]{2})$', where the most significant octet is first.",
                 "FC_WWN": "This durable name shall contain a hexadecimal representation of the World-Wide Name (WWN) format, as defined in the T11 Fibre Channel Physical and Signaling Interface Specification.  The DurableName property shall follow the pattern '^([0-9A-Fa-f]{2}[:-]){7}([0-9A-Fa-f]{2})$', where the most significant octet is first.",
+                "MACAddress": "This durable name shall be a media access control address (MAC address), which is a unique identifier assigned to a network interface controller (NIC) for use as a network address.  This value should not be used if a more specific type of identifier is available.  The DurableName property shall follow the pattern '^([0-9A-Fa-f]{2}[:-]){5}([0-9A-Fa-f]{2})$', where the most significant octet is first.",
                 "NAA": "This durable name shall contain a hexadecimal representation of the Name Address Authority structure, as defined in the T11 Fibre Channel - Framing and Signaling - 3 (FC-FS-3) specification.  The DurableName property shall follow the pattern '^(([0-9A-Fa-f]{2}){8}){1,2}$', where the most significant octet is first.",
                 "NGUID": "This durable name shall be in the Namespace Globally Unique Identifier (NGUID), as defined in the NVN Express Specification.  The DurableName property shall follow the pattern '^([0-9A-Fa-f]{2}){16}$', where the most significant octet is first.",
                 "NQN": "This durable name shall be in the NVMe Qualified Name (NQN) format, as defined in the NVN Express over Fabric Specification.",
@@ -90,6 +93,7 @@
                 "iQN": "This durable name shall be in the iSCSI Qualified Name (iQN) format, as defined in RFC3720 and RFC3721."
             },
             "enumVersionAdded": {
+                "MACAddress": "v1_14_0",
                 "NGUID": "v1_10_0",
                 "NQN": "v1_6_0",
                 "NSID": "v1_6_0"
@@ -166,7 +170,7 @@
             "properties": {
                 "AltitudeMeters": {
                     "description": "The altitude of the resource in meters.",
-                    "longDescription": "This property shall contain the altitude of the resource in meters.",
+                    "longDescription": "This property shall contain the altitude of the resource, in meters units, defined as the elevation above sea level.",
                     "readonly": false,
                     "type": [
                         "number",
@@ -1053,6 +1057,6 @@
         }
     },
     "owningEntity": "DMTF",
-    "release": "2021.2",
-    "title": "#Resource.v1_13_0"
+    "release": "2021.4",
+    "title": "#Resource.v1_14_0"
 }

--- a/static/redfish/v1/JsonSchemas/Sensor/Sensor.json
+++ b/static/redfish/v1/JsonSchemas/Sensor/Sensor.json
@@ -1,5 +1,5 @@
 {
-    "$id": "http://redfish.dmtf.org/schemas/v1/Sensor.v1_4_0.json",
+    "$id": "http://redfish.dmtf.org/schemas/v1/Sensor.v1_5_0.json",
     "$ref": "#/definitions/Sensor",
     "$schema": "http://redfish.dmtf.org/schemas/v1/redfish-schema-v1.json",
     "copyright": "Copyright 2014-2021 DMTF. For the full DMTF copyright policy, see http://www.dmtf.org/about/policies/copyright",
@@ -121,58 +121,66 @@
                 "Current",
                 "Frequency",
                 "Pressure",
+                "PressurekPa",
                 "LiquidLevel",
                 "Rotational",
                 "AirFlow",
                 "LiquidFlow",
                 "Barometric",
                 "Altitude",
-                "Percent"
+                "Percent",
+                "AbsoluteHumidity"
             ],
             "enumDescriptions": {
-                "AirFlow": "Airflow.",
-                "Altitude": "Altitude.",
-                "Barometric": "Barometric pressure.",
+                "AbsoluteHumidity": "Absolute humidity (g/cu m).",
+                "AirFlow": "Airflow (cu ft/min).",
+                "Altitude": "Altitude (m).",
+                "Barometric": "Barometric pressure (mm).",
                 "ChargeAh": "Charge (Ah).",
-                "Current": "Current.",
-                "EnergyJoules": "Energy (Joules).",
+                "Current": "Current (A).",
+                "EnergyJoules": "Energy (J).",
                 "EnergyWh": "Energy (Wh).",
                 "EnergykWh": "Energy (kWh).",
-                "Frequency": "Frequency.",
-                "Humidity": "Relative Humidity.",
-                "LiquidFlow": "Liquid flow.",
-                "LiquidLevel": "Liquid level.",
-                "Percent": "Percent.",
-                "Power": "Power.",
-                "Pressure": "Pressure.",
-                "Rotational": "Rotational.",
-                "Temperature": "Temperature.",
-                "Voltage": "Voltage (AC or DC)."
+                "Frequency": "Frequency (Hz).",
+                "Humidity": "Relative humidity (percent).",
+                "LiquidFlow": "Liquid flow (L/s).",
+                "LiquidLevel": "Liquid level (cm).",
+                "Percent": "Percent (%).",
+                "Power": "Power (W).",
+                "Pressure": "Pressure (Pa).",
+                "PressurekPa": "Pressure (kPa).",
+                "Rotational": "Rotational (RPM).",
+                "Temperature": "Temperature (C).",
+                "Voltage": "Voltage (VAC or VDC)."
             },
             "enumLongDescriptions": {
-                "AirFlow": "This value shall indicate a measurement of a volume of gas per unit of time that flows through a particular junction.  The ReadingUnits shall be `cft_i/min`.",
-                "Altitude": "This value shall indicate a measurement of altitude, in meter units, and the ReadingUnits value shall be `m`.",
-                "Barometric": "This value shall indicate a measurement of barometric pressure, in millimeters, of a mercury column, and the ReadingUnits value shall be `mm[Hg]`.",
-                "ChargeAh": "This value shall indicate the amount of charge of the monitored item.  If representing metered power consumption,  integral of real power over time, the value shall reflect the power consumption since the sensor metrics were last reset.  The value of the Reading property shall be in amp-hour units and the ReadingUnits value shall be `A.h`.",
-                "Current": "This value shall indicate a measurement of the root mean square (RMS) of instantaneous current calculated over an integer number of line cycles for a circuit.  Current is expressed in Amperes units and the ReadingUnits value shall be `A`.",
-                "EnergyJoules": "This value shall indicate the energy, integral of real power over time, of the monitored item.  If representing metered power consumption the value shall reflect the power consumption since the sensor metrics were last reset.  The value of the Reading property shall be in Joule units and the ReadingUnits value shall be `J`.  This value is used for device-level energy consumption measurements, while EnergykWh is used for large-scale consumption measurements.",
+                "AbsoluteHumidity": "This value shall indicate an absolute (volumetric) humidity measurement, in grams per cubic meter units, and the ReadingUnits value shall be `g/m3`.",
+                "AirFlow": "This value shall indicate a measurement of a volume of gas per unit of time, in cubic feet per minute units, that flows through a particular junction.  The ReadingUnits shall be `[ft_i]3/min`.",
+                "Altitude": "This value shall indicate a measurement of altitude, in meter units, defined as the elevation above sea level.  The ReadingUnits value shall be `m`.",
+                "Barometric": "This value shall indicate a measurement of barometric pressure, in millimeters of a mercury column, and the ReadingUnits value shall be `mm[Hg]`.",
+                "ChargeAh": "This value shall indicate the amount of charge of the monitored item.  If representing metered power consumption,  integral of real power over time, the value shall reflect the power consumption since the sensor metrics were last reset.  The value of the Reading property shall be in ampere-hour units and the ReadingUnits value shall be `A.h`.",
+                "Current": "This value shall indicate a measurement of the root mean square (RMS) of instantaneous current calculated over an integer number of line cycles for a circuit.  Current is expressed in ampere units and the ReadingUnits value shall be `A`.",
+                "EnergyJoules": "This value shall indicate the energy, integral of real power over time, of the monitored item.  If representing metered power consumption the value shall reflect the power consumption since the sensor metrics were last reset.  The value of the Reading property shall be in joule units and the ReadingUnits value shall be `J`.  This value is used for device-level energy consumption measurements, while EnergykWh is used for large-scale consumption measurements.",
                 "EnergyWh": "This value shall indicate the energy, integral of real power over time, of the monitored item.  If representing metered power consumption the value shall reflect the power consumption since the sensor metrics were last reset.  The value of the Reading property shall be in watt-hour units and the ReadingUnits value shall be `W.h`.  This value is used for device-level energy consumption measurements, while EnergykWh is used for large-scale consumption measurements.",
                 "EnergykWh": "This value shall indicate the energy, integral of real power over time, of the monitored item.  If representing metered power consumption the value shall reflect the power consumption since the sensor metrics were last reset.  The value of the Reading property shall be in kilowatt-hour units and the ReadingUnits value shall be `kW.h`.  This value is used for large-scale energy consumption measurements, while EnergyJoules and EnergyWh are used for device-level consumption measurements.",
-                "Frequency": "This value shall indicate a frequency measurement, in Hertz units, and the ReadingUnits value shall be `Hz`.",
+                "Frequency": "This value shall indicate a frequency measurement, in hertz units, and the ReadingUnits value shall be `Hz`.",
                 "Humidity": "This value shall indicate a relative humidity measurement, in percent units, and the ReadingUnits value shall be '%'.",
-                "LiquidFlow": "This value shall indicate a measurement of a volume of liquid per unit of time that flows through a particular junction.  The ReadingUnits shall be `L/s`.",
-                "LiquidLevel": "This value shall indicate a measurement of fluid height relative to a specified vertical datum and the ReadingUnits value shall be `cm`.",
+                "LiquidFlow": "This value shall indicate a measurement of a volume of liquid per unit of time, in liters per second units, that flows through a particular junction.  The ReadingUnits shall be `L/s`.",
+                "LiquidLevel": "This value shall indicate a measurement of fluid height, in centimeter units, relative to a specified vertical datum and the ReadingUnits value shall be `cm`.",
                 "Percent": "This value shall indicate a percentage measurement, in percent units, and the ReadingUnits value shall be `%`.",
-                "Power": "This value shall indicate the arithmetic mean of product terms of instantaneous voltage and current values measured over integer number of line cycles for a circuit, in Watt units, and the ReadingUnits value shall be 'W'.",
-                "Pressure": "This value shall indicate a measurement of force applied perpendicular to the surface of an object per unit area over which that force is distributed.  The ReadingUnits shall be `Pa`.",
-                "Rotational": "This value shall indicate a measurement of rotational frequency, in revolutions per minute unit, and the ReadingUnits value shall be `RPM`.",
+                "Power": "This value shall indicate the arithmetic mean of product terms of instantaneous voltage and current values measured over integer number of line cycles for a circuit, in watt units, and the ReadingUnits value shall be 'W'.",
+                "Pressure": "This value shall indicate a measurement of force, in pascal units, applied perpendicular to the surface of an object per unit area over which that force is distributed.  The ReadingUnits shall be `Pa`.",
+                "PressurekPa": "This value shall indicate a measurement of pressure, in kilopascal units, relative to atmospheric pressure.  The ReadingUnits value shall be `kPa`.",
+                "Rotational": "This value shall indicate a measurement of rotational frequency, in revolutions per minute unit, and the ReadingUnits value shall be either `{rev}/min`, which is preferred, or `RPM`, which is a deprecated value.",
                 "Temperature": "This value shall indicate a temperature measurement, in degrees Celsius units, and the ReadingUnits value shall be 'Cel'.",
-                "Voltage": "This value shall indicate a measurement of the root mean square (RMS) of instantaneous voltage calculated over an integer number of line cycles for a circuit.  Voltage is expressed in Volts units and the ReadingUnits value shall be `V`."
+                "Voltage": "This value shall indicate a measurement of the root mean square (RMS) of instantaneous voltage calculated over an integer number of line cycles for a circuit.  Voltage is expressed in volt units and the ReadingUnits value shall be `V`."
             },
             "enumVersionAdded": {
+                "AbsoluteHumidity": "v1_5_0",
                 "ChargeAh": "v1_4_0",
                 "EnergyWh": "v1_4_0",
-                "Percent": "v1_1_0"
+                "Percent": "v1_1_0",
+                "PressurekPa": "v1_5_0"
             },
             "type": "string"
         },
@@ -273,7 +281,7 @@
                     ]
                 },
                 "ApparentVA": {
-                    "description": "The product of voltage and current for an AC circuit, in Volt-Ampere units.",
+                    "description": "The product of voltage and current for an AC circuit, in volt-ampere units.",
                     "excerpt": "SensorPower,SensorPowerArray",
                     "longDescription": "This property shall contain the product of voltage (RMS) multiplied by current (RMS) for a circuit.  This property can appear in sensors of the Power ReadingType, and shall not appear in sensors of other ReadingType values.",
                     "readonly": true,
@@ -282,6 +290,18 @@
                         "null"
                     ],
                     "units": "V.A"
+                },
+                "ApparentkVAh": {
+                    "description": "Apparent energy (kVAh).",
+                    "excerpt": "SensorEnergykWh",
+                    "longDescription": "This property shall contain the apparent energy, in kilovolt-ampere-hour units, for an electrical energy measurement.  This property can appear in sensors with a ReadingType containing `EnergykWh`, and shall not appear in sensors with other ReadingType values.",
+                    "readonly": true,
+                    "type": [
+                        "number",
+                        "null"
+                    ],
+                    "units": "kV.A.h",
+                    "versionAdded": "v1_5_0"
                 },
                 "AverageReading": {
                     "description": "The average sensor value.",
@@ -489,6 +509,19 @@
                         "null"
                     ]
                 },
+                "PhaseAngleDegrees": {
+                    "description": "The phase angle (degrees) between the current and voltage waveforms.",
+                    "excerpt": "SensorPower,SensorPowerArray",
+                    "longDescription": "This property shall contain the phase angle, in degree units, between the current and voltage waveforms for an electrical measurement.  This property can appear in sensors with a ReadingType containing `Power`, and shall not appear in sensors with other ReadingType values.",
+                    "maximum": 90,
+                    "minimum": -90,
+                    "readonly": true,
+                    "type": [
+                        "number",
+                        "null"
+                    ],
+                    "versionAdded": "v1_5_0"
+                },
                 "PhysicalContext": {
                     "anyOf": [
                         {
@@ -520,9 +553,9 @@
                 "PowerFactor": {
                     "description": "The power factor for this sensor.",
                     "excerpt": "SensorPower,SensorPowerArray",
-                    "longDescription": "This property shall identify the quotient of real power (W) and apparent power (VA) for a circuit.  PowerFactor is expressed in unit-less 1/100ths.  This property can appear in sensors of the Power ReadingType, and shall not appear in sensors of other ReadingType values.",
+                    "longDescription": "This property shall identify the quotient of real power (W) and apparent power (VA) for a circuit.  PowerFactor is expressed in unit-less 1/100ths.  This property can appear in sensors containing a ReadingType value of `Power`, and shall not appear in sensors of other ReadingType values.",
                     "maximum": 1,
-                    "minimum": 0,
+                    "minimum": -1,
                     "readonly": true,
                     "type": [
                         "number",
@@ -548,6 +581,18 @@
                         "null"
                     ],
                     "units": "V.A"
+                },
+                "ReactivekVARh": {
+                    "description": "Reactive energy (kVARh).",
+                    "excerpt": "SensorEnergykWh",
+                    "longDescription": "This property shall contain the reactive energy, in kilovolt-ampere-hours (reactive) units, for an electrical energy measurement.  This property can appear in sensors with a ReadingType containing `EnergykWh`, and shall not appear in sensors with other ReadingType values.",
+                    "readonly": true,
+                    "type": [
+                        "number",
+                        "null"
+                    ],
+                    "units": "kV.A.h",
+                    "versionAdded": "v1_5_0"
                 },
                 "Reading": {
                     "description": "The sensor value.",
@@ -671,7 +716,7 @@
                         "number",
                         "null"
                     ],
-                    "units": "RPM",
+                    "units": "{rev}/min",
                     "versionAdded": "v1_2_0"
                 },
                 "Status": {
@@ -887,6 +932,18 @@
                 }
             },
             "properties": {
+                "ApparentkVAh": {
+                    "description": "Apparent energy (kVAh).",
+                    "excerpt": "SensorEnergykWh",
+                    "longDescription": "This property shall contain the apparent energy, in kilovolt-ampere-hour units, for an electrical energy measurement.  This property can appear in sensors with a ReadingType containing `EnergykWh`, and shall not appear in sensors with other ReadingType values.",
+                    "readonly": true,
+                    "type": [
+                        "number",
+                        "null"
+                    ],
+                    "units": "kV.A.h",
+                    "versionAdded": "v1_5_0"
+                },
                 "DataSourceUri": {
                     "description": "The link to the resource that provides the data for this sensor.",
                     "excerptCopyOnly": true,
@@ -908,6 +965,18 @@
                         "null"
                     ],
                     "versionAdded": "v1_1_0"
+                },
+                "ReactivekVARh": {
+                    "description": "Reactive energy (kVARh).",
+                    "excerpt": "SensorEnergykWh",
+                    "longDescription": "This property shall contain the reactive energy, in kilovolt-ampere-hours (reactive) units, for an electrical energy measurement.  This property can appear in sensors with a ReadingType containing `EnergykWh`, and shall not appear in sensors with other ReadingType values.",
+                    "readonly": true,
+                    "type": [
+                        "number",
+                        "null"
+                    ],
+                    "units": "kV.A.h",
+                    "versionAdded": "v1_5_0"
                 },
                 "Reading": {
                     "description": "The sensor value.",
@@ -1067,7 +1136,7 @@
                         "number",
                         "null"
                     ],
-                    "units": "RPM",
+                    "units": "{rev}/min",
                     "versionAdded": "v1_2_0"
                 }
             },
@@ -1123,7 +1192,7 @@
                         "number",
                         "null"
                     ],
-                    "units": "RPM",
+                    "units": "{rev}/min",
                     "versionAdded": "v1_2_0"
                 }
             },
@@ -1150,7 +1219,7 @@
             },
             "properties": {
                 "ApparentVA": {
-                    "description": "The product of voltage and current for an AC circuit, in Volt-Ampere units.",
+                    "description": "The product of voltage and current for an AC circuit, in volt-ampere units.",
                     "excerpt": "SensorPower,SensorPowerArray",
                     "longDescription": "This property shall contain the product of voltage (RMS) multiplied by current (RMS) for a circuit.  This property can appear in sensors of the Power ReadingType, and shall not appear in sensors of other ReadingType values.",
                     "readonly": true,
@@ -1170,6 +1239,19 @@
                         "string",
                         "null"
                     ]
+                },
+                "PhaseAngleDegrees": {
+                    "description": "The phase angle (degrees) between the current and voltage waveforms.",
+                    "excerpt": "SensorPower,SensorPowerArray",
+                    "longDescription": "This property shall contain the phase angle, in degree units, between the current and voltage waveforms for an electrical measurement.  This property can appear in sensors with a ReadingType containing `Power`, and shall not appear in sensors with other ReadingType values.",
+                    "maximum": 90,
+                    "minimum": -90,
+                    "readonly": true,
+                    "type": [
+                        "number",
+                        "null"
+                    ],
+                    "versionAdded": "v1_5_0"
                 },
                 "PhysicalContext": {
                     "anyOf": [
@@ -1202,9 +1284,9 @@
                 "PowerFactor": {
                     "description": "The power factor for this sensor.",
                     "excerpt": "SensorPower,SensorPowerArray",
-                    "longDescription": "This property shall identify the quotient of real power (W) and apparent power (VA) for a circuit.  PowerFactor is expressed in unit-less 1/100ths.  This property can appear in sensors of the Power ReadingType, and shall not appear in sensors of other ReadingType values.",
+                    "longDescription": "This property shall identify the quotient of real power (W) and apparent power (VA) for a circuit.  PowerFactor is expressed in unit-less 1/100ths.  This property can appear in sensors containing a ReadingType value of `Power`, and shall not appear in sensors of other ReadingType values.",
                     "maximum": 1,
-                    "minimum": 0,
+                    "minimum": -1,
                     "readonly": true,
                     "type": [
                         "number",
@@ -1256,7 +1338,7 @@
             },
             "properties": {
                 "ApparentVA": {
-                    "description": "The product of voltage and current for an AC circuit, in Volt-Ampere units.",
+                    "description": "The product of voltage and current for an AC circuit, in volt-ampere units.",
                     "excerpt": "SensorPower,SensorPowerArray",
                     "longDescription": "This property shall contain the product of voltage (RMS) multiplied by current (RMS) for a circuit.  This property can appear in sensors of the Power ReadingType, and shall not appear in sensors of other ReadingType values.",
                     "readonly": true,
@@ -1277,12 +1359,25 @@
                         "null"
                     ]
                 },
+                "PhaseAngleDegrees": {
+                    "description": "The phase angle (degrees) between the current and voltage waveforms.",
+                    "excerpt": "SensorPower,SensorPowerArray",
+                    "longDescription": "This property shall contain the phase angle, in degree units, between the current and voltage waveforms for an electrical measurement.  This property can appear in sensors with a ReadingType containing `Power`, and shall not appear in sensors with other ReadingType values.",
+                    "maximum": 90,
+                    "minimum": -90,
+                    "readonly": true,
+                    "type": [
+                        "number",
+                        "null"
+                    ],
+                    "versionAdded": "v1_5_0"
+                },
                 "PowerFactor": {
                     "description": "The power factor for this sensor.",
                     "excerpt": "SensorPower,SensorPowerArray",
-                    "longDescription": "This property shall identify the quotient of real power (W) and apparent power (VA) for a circuit.  PowerFactor is expressed in unit-less 1/100ths.  This property can appear in sensors of the Power ReadingType, and shall not appear in sensors of other ReadingType values.",
+                    "longDescription": "This property shall identify the quotient of real power (W) and apparent power (VA) for a circuit.  PowerFactor is expressed in unit-less 1/100ths.  This property can appear in sensors containing a ReadingType value of `Power`, and shall not appear in sensors of other ReadingType values.",
                     "maximum": 1,
-                    "minimum": 0,
+                    "minimum": -1,
                     "readonly": true,
                     "type": [
                         "number",
@@ -1529,6 +1624,6 @@
         }
     },
     "owningEntity": "DMTF",
-    "release": "2021.2",
-    "title": "#Sensor.v1_4_0.Sensor"
+    "release": "2021.4",
+    "title": "#Sensor.v1_5_0.Sensor"
 }

--- a/static/redfish/v1/JsonSchemas/ServiceRoot/ServiceRoot.json
+++ b/static/redfish/v1/JsonSchemas/ServiceRoot/ServiceRoot.json
@@ -1,5 +1,5 @@
 {
-    "$id": "http://redfish.dmtf.org/schemas/v1/ServiceRoot.v1_12_0.json",
+    "$id": "http://redfish.dmtf.org/schemas/v1/ServiceRoot.v1_13_0.json",
     "$ref": "#/definitions/ServiceRoot",
     "$schema": "http://redfish.dmtf.org/schemas/v1/redfish-schema-v1.json",
     "copyright": "Copyright 2014-2021 DMTF. For the full DMTF copyright policy, see http://www.dmtf.org/about/policies/copyright",
@@ -270,6 +270,13 @@
                     "longDescription": "This property shall contain a link to a Resource Collection of type ChassisCollection.",
                     "readonly": true
                 },
+                "ComponentIntegrity": {
+                    "$ref": "http://redfish.dmtf.org/schemas/v1/ComponentIntegrityCollection.json#/definitions/ComponentIntegrityCollection",
+                    "description": "The link to a collection of component integrity information.",
+                    "longDescription": "This property shall contain a link to a resource collection of type ComponentIntegrityCollection.",
+                    "readonly": true,
+                    "versionAdded": "v1_13_0"
+                },
                 "CompositionService": {
                     "$ref": "http://redfish.dmtf.org/schemas/v1/CompositionService.json#/definitions/CompositionService",
                     "description": "The link to the Composition Service.",
@@ -396,6 +403,13 @@
                     "readonly": true,
                     "type": "string"
                 },
+                "RegisteredClients": {
+                    "$ref": "http://redfish.dmtf.org/schemas/v1/RegisteredClientCollection.json#/definitions/RegisteredClientCollection",
+                    "description": "The link to a collection of registered clients.",
+                    "longDescription": "This property shall contain a link to a resource collection of type RegisteredClientCollection.",
+                    "readonly": true,
+                    "versionAdded": "v1_13_0"
+                },
                 "Registries": {
                     "$ref": "http://redfish.dmtf.org/schemas/v1/MessageRegistryFileCollection.json#/definitions/MessageRegistryFileCollection",
                     "description": "The link to a collection of Registries.",
@@ -408,6 +422,13 @@
                     "longDescription": "This property shall contain a link to a Resource Collection of type ResourceBlockCollection.",
                     "readonly": true,
                     "versionAdded": "v1_5_0"
+                },
+                "ServiceConditions": {
+                    "$ref": "http://redfish.dmtf.org/schemas/v1/ServiceConditions.json#/definitions/ServiceConditions",
+                    "description": "The link to the service conditions.",
+                    "longDescription": "This property shall contain a link to a resource of type ServiceConditions.",
+                    "readonly": true,
+                    "versionAdded": "v1_13_0"
                 },
                 "SessionService": {
                     "$ref": "http://redfish.dmtf.org/schemas/v1/SessionService.json#/definitions/SessionService",
@@ -497,6 +518,6 @@
         }
     },
     "owningEntity": "DMTF",
-    "release": "2021.3",
-    "title": "#ServiceRoot.v1_12_0.ServiceRoot"
+    "release": "2021.4",
+    "title": "#ServiceRoot.v1_13_0.ServiceRoot"
 }

--- a/static/redfish/v1/JsonSchemas/Settings/Settings.json
+++ b/static/redfish/v1/JsonSchemas/Settings/Settings.json
@@ -1,7 +1,7 @@
 {
-    "$id": "http://redfish.dmtf.org/schemas/v1/Settings.v1_3_3.json",
+    "$id": "http://redfish.dmtf.org/schemas/v1/Settings.v1_3_4.json",
     "$schema": "http://redfish.dmtf.org/schemas/v1/redfish-schema-v1.json",
-    "copyright": "Copyright 2014-2020 DMTF. For the full DMTF copyright policy, see http://www.dmtf.org/about/policies/copyright",
+    "copyright": "Copyright 2014-2021 DMTF. For the full DMTF copyright policy, see http://www.dmtf.org/about/policies/copyright",
     "definitions": {
         "ApplyTime": {
             "enum": [
@@ -55,7 +55,7 @@
                 "MaintenanceWindowStartTime": {
                     "description": "The start time of a maintenance window.",
                     "format": "date-time",
-                    "longDescription": "This property shall indicate the date and time when the service can start to apply the requested settings or operation as part of a maintenance window.",
+                    "longDescription": "This property shall indicate the date and time when the service can start to apply the requested settings or operation as part of a maintenance window.  Services shall provide a default value if not configured by a user.",
                     "readonly": false,
                     "type": "string",
                     "versionAdded": "v1_2_0"
@@ -105,7 +105,7 @@
                 "MaintenanceWindowStartTime": {
                     "description": "The start time of a maintenance window.",
                     "format": "date-time",
-                    "longDescription": "This property shall contain the same as the MaintenanceWindowStartTime property found in the MaintenanceWindow structure on the MaintenanceWindowResource.  This property shall be required if the SupportedValues property contains `AtMaintenanceWindowStart` or `InMaintenanceWindowOnReset`.",
+                    "longDescription": "This property shall contain the same as the MaintenanceWindowStartTime property found in the MaintenanceWindow structure on the MaintenanceWindowResource.  Services shall provide a default value if not configured by a user.  This property shall be required if the SupportedValues property contains `AtMaintenanceWindowStart` or `InMaintenanceWindowOnReset`.",
                     "readonly": true,
                     "type": "string",
                     "versionAdded": "v1_2_0"
@@ -164,7 +164,7 @@
                 "MaintenanceWindowStartTime": {
                     "description": "The start time of a maintenance window.",
                     "format": "date-time",
-                    "longDescription": "This property shall indicate the date and time when the service can start to apply the future configuration as part of a maintenance window.  This property shall be required if the ApplyTime property is `AtMaintenanceWindowStart` or `InMaintenanceWindowOnReset`.",
+                    "longDescription": "This property shall indicate the date and time when the service can start to apply the future configuration as part of a maintenance window.  Services shall provide a default value if not configured by a user.  This property shall be required if the ApplyTime property is `AtMaintenanceWindowStart` or `InMaintenanceWindowOnReset`.",
                     "readonly": false,
                     "type": "string",
                     "versionAdded": "v1_1_0"
@@ -247,5 +247,5 @@
     },
     "owningEntity": "DMTF",
     "release": "2019.3",
-    "title": "#Settings.v1_3_3"
+    "title": "#Settings.v1_3_4"
 }

--- a/static/redfish/v1/JsonSchemas/SoftwareInventory/SoftwareInventory.json
+++ b/static/redfish/v1/JsonSchemas/SoftwareInventory/SoftwareInventory.json
@@ -1,5 +1,5 @@
 {
-    "$id": "http://redfish.dmtf.org/schemas/v1/SoftwareInventory.v1_5_0.json",
+    "$id": "http://redfish.dmtf.org/schemas/v1/SoftwareInventory.v1_6_0.json",
     "$ref": "#/definitions/SoftwareInventory",
     "$schema": "http://redfish.dmtf.org/schemas/v1/redfish-schema-v1.json",
     "copyright": "Copyright 2014-2021 DMTF. For the full DMTF copyright policy, see http://www.dmtf.org/about/policies/copyright",
@@ -188,9 +188,11 @@
                 },
                 "Measurement": {
                     "$ref": "http://redfish.dmtf.org/schemas/v1/SoftwareInventory.json#/definitions/MeasurementBlock",
+                    "deprecated": "This property has been deprecated in favor of the ComponentIntegrity resource.",
                     "description": "A DSP0274-defined measurement block.",
                     "longDescription": "This property shall contain a DSP0274-defined measurement block.",
-                    "versionAdded": "v1_4_0"
+                    "versionAdded": "v1_4_0",
+                    "versionDeprecated": "v1_6_0"
                 },
                 "Name": {
                     "$ref": "http://redfish.dmtf.org/schemas/v1/Resource.json#/definitions/Name",
@@ -289,6 +291,6 @@
         }
     },
     "owningEntity": "DMTF",
-    "release": "2021.2",
-    "title": "#SoftwareInventory.v1_5_0.SoftwareInventory"
+    "release": "2021.4",
+    "title": "#SoftwareInventory.v1_6_0.SoftwareInventory"
 }

--- a/static/redfish/v1/JsonSchemas/Storage/Storage.json
+++ b/static/redfish/v1/JsonSchemas/Storage/Storage.json
@@ -1,5 +1,5 @@
 {
-    "$id": "http://redfish.dmtf.org/schemas/v1/Storage.v1_11_0.json",
+    "$id": "http://redfish.dmtf.org/schemas/v1/Storage.v1_12_0.json",
     "$ref": "#/definitions/Storage",
     "$schema": "http://redfish.dmtf.org/schemas/v1/redfish-schema-v1.json",
     "copyright": "Copyright 2014-2021 DMTF. For the full DMTF copyright policy, see http://www.dmtf.org/about/policies/copyright",
@@ -608,13 +608,15 @@
                     ]
                 },
                 "Measurements": {
+                    "deprecated": "This property has been deprecated in favor of the ComponentIntegrity resource.",
                     "description": "An array of DSP0274-defined measurement blocks.",
                     "items": {
                         "$ref": "http://redfish.dmtf.org/schemas/v1/SoftwareInventory.json#/definitions/MeasurementBlock"
                     },
                     "longDescription": "This property shall contain an array of DSP0274-defined measurement blocks.",
                     "type": "array",
-                    "versionAdded": "v1_10_0"
+                    "versionAdded": "v1_10_0",
+                    "versionDeprecated": "v1_12_0"
                 },
                 "MemberId": {
                     "description": "The unique identifier for the member within an array.",
@@ -860,6 +862,6 @@
         }
     },
     "owningEntity": "DMTF",
-    "release": "2021.2",
-    "title": "#Storage.v1_11_0.Storage"
+    "release": "2021.4",
+    "title": "#Storage.v1_12_0.Storage"
 }

--- a/static/redfish/v1/JsonSchemas/StorageController/StorageController.json
+++ b/static/redfish/v1/JsonSchemas/StorageController/StorageController.json
@@ -1,5 +1,5 @@
 {
-    "$id": "http://redfish.dmtf.org/schemas/v1/StorageController.v1_4_0.json",
+    "$id": "http://redfish.dmtf.org/schemas/v1/StorageController.v1_5_0.json",
     "$ref": "#/definitions/StorageController",
     "$schema": "http://redfish.dmtf.org/schemas/v1/redfish-schema-v1.json",
     "copyright": "Copyright 2014-2021 DMTF. For the full DMTF copyright policy, see http://www.dmtf.org/about/policies/copyright",
@@ -732,13 +732,15 @@
                     ]
                 },
                 "Measurements": {
+                    "deprecated": "This property has been deprecated in favor of the ComponentIntegrity resource.",
                     "description": "An array of DSP0274-defined measurement blocks.",
                     "items": {
                         "$ref": "http://redfish.dmtf.org/schemas/v1/SoftwareInventory.json#/definitions/MeasurementBlock"
                     },
                     "longDescription": "This property shall contain an array of DSP0274-defined measurement blocks.",
                     "type": "array",
-                    "versionAdded": "v1_1_0"
+                    "versionAdded": "v1_1_0",
+                    "versionDeprecated": "v1_5_0"
                 },
                 "Model": {
                     "description": "The model number for the storage controller.",
@@ -862,6 +864,6 @@
         }
     },
     "owningEntity": "DMTF",
-    "release": "2021.3",
-    "title": "#StorageController.v1_4_0.StorageController"
+    "release": "2021.4",
+    "title": "#StorageController.v1_5_0.StorageController"
 }

--- a/static/redfish/v1/JsonSchemas/UpdateService/UpdateService.json
+++ b/static/redfish/v1/JsonSchemas/UpdateService/UpdateService.json
@@ -1,5 +1,5 @@
 {
-    "$id": "http://redfish.dmtf.org/schemas/v1/UpdateService.v1_10_0.json",
+    "$id": "http://redfish.dmtf.org/schemas/v1/UpdateService.v1_11_0.json",
     "$ref": "#/definitions/UpdateService",
     "$schema": "http://redfish.dmtf.org/schemas/v1/redfish-schema-v1.json",
     "copyright": "Copyright 2014-2021 DMTF. For the full DMTF copyright policy, see http://www.dmtf.org/about/policies/copyright",
@@ -42,19 +42,25 @@
                 "Immediate",
                 "OnReset",
                 "AtMaintenanceWindowStart",
-                "InMaintenanceWindowOnReset"
+                "InMaintenanceWindowOnReset",
+                "OnStartUpdateRequest"
             ],
             "enumDescriptions": {
                 "AtMaintenanceWindowStart": "Apply during an administrator-specified maintenance window.",
                 "Immediate": "Apply immediately.",
                 "InMaintenanceWindowOnReset": "Apply after a reset but within an administrator-specified maintenance window.",
-                "OnReset": "Apply on a reset."
+                "OnReset": "Apply on a reset.",
+                "OnStartUpdateRequest": "Apply when the StartUpdate action of the update service is invoked."
             },
             "enumLongDescriptions": {
                 "AtMaintenanceWindowStart": "This value shall indicate the HttpPushUri-provided software is applied during the maintenance window specified by the MaintenanceWindowStartTime and MaintenanceWindowDurationInSeconds properties.  A service may perform resets during this maintenance window.",
                 "Immediate": "This value shall indicate the HttpPushUri-provided software is applied immediately.",
                 "InMaintenanceWindowOnReset": "This value shall indicate the HttpPushUri-provided software is applied during the maintenance window specified by the MaintenanceWindowStartTime and MaintenanceWindowDurationInSeconds properties, and if a reset occurs within the maintenance window.",
-                "OnReset": "This value shall indicate the HttpPushUri-provided software is applied when the system or service is reset."
+                "OnReset": "This value shall indicate the HttpPushUri-provided software is applied when the system or service is reset.",
+                "OnStartUpdateRequest": "This value shall indicate the HttpPushUri-provided software is applied when the StartUpdate action of the update service is invoked."
+            },
+            "enumVersionAdded": {
+                "OnStartUpdateRequest": "v1_11_0"
             },
             "type": "string"
         },
@@ -123,6 +129,13 @@
                 }
             },
             "properties": {
+                "ForceUpdate": {
+                    "description": "An indication of whether the service should bypass update policies when applying the HttpPushUri-provided image.",
+                    "longDescription": "This property shall indicate whether the service should bypass update policies when applying the HttpPushUri-provided image, such as allowing a component to be downgraded.  Services may contain update policies that are never bypassed, such as minimum version enforcement.  If this property is not present, it shall be assumed to be `false`.",
+                    "readonly": false,
+                    "type": "boolean",
+                    "versionAdded": "v1_11_0"
+                },
                 "HttpPushUriApplyTime": {
                     "$ref": "#/definitions/HttpPushUriApplyTime",
                     "description": "The settings for when to apply HttpPushUri-provided firmware.",
@@ -158,6 +171,12 @@
             "description": "This action updates software components.",
             "longDescription": "This action shall update installed software components in a software image file located at an ImageURI parameter-specified URI.",
             "parameters": {
+                "ForceUpdate": {
+                    "description": "An indication of whether the service should bypass update policies when applying the provided image.  The default is `false`.",
+                    "longDescription": "This parameter shall indicate whether the service should bypass update policies when applying the provided image, such as allowing a component to be downgraded.  Services may contain update policies that are never bypassed, such as minimum version enforcement.  If the client does not provide this parameter, the service shall default this value to `false`.",
+                    "type": "boolean",
+                    "versionAdded": "v1_11_0"
+                },
                 "ImageURI": {
                     "description": "The URI of the software image to install.",
                     "longDescription": "This parameter shall contain an RFC3986-defined URI that links to a software image that the update service retrieves to install software in that image.  This URI should contain a scheme that describes the transfer protocol.  If the TransferProtocol parameter is absent or not supported, and a transfer protocol is not specified by a scheme contained within this URI, the service shall use HTTP to get the image.",
@@ -308,6 +327,13 @@
                 }
             },
             "properties": {
+                "ForceUpdate": {
+                    "description": "An indication of whether the service should bypass update policies when applying the provided image.  The default is `false`.",
+                    "longDescription": "This property shall indicate whether the service should bypass update policies when applying the provided image, such as allowing a component to be downgraded.  Services may contain update policies that are never bypassed, such as minimum version enforcement.  If the client does not provide this parameter, the service shall default this value to `false`.",
+                    "readonly": false,
+                    "type": "boolean",
+                    "versionAdded": "v1_11_0"
+                },
                 "Oem": {
                     "$ref": "http://redfish.dmtf.org/schemas/v1/Resource.json#/definitions/Oem",
                     "description": "The OEM extension property.",
@@ -324,7 +350,7 @@
                         ]
                     },
                     "longDescription": "This property shall contain zero or more URIs that indicate where to apply the update image when using the URI specified by the MultipartHttpPushUri property to push a software image.  These targets should correspond to software inventory instances or their related items.  If this property is not present or contains no targets, the service shall apply the software image to all applicable targets, as determined by the service.",
-                    "readonly": true,
+                    "readonly": false,
                     "type": "array",
                     "versionAdded": "v1_6_0"
                 }
@@ -500,7 +526,7 @@
                 },
                 "VerifyRemoteServerCertificate": {
                     "description": "An indication of whether the service will verify the certificate of the server referenced by the ImageURI property in SimpleUpdate prior to sending the transfer request.",
-                    "longDescription": "This property shall indicate whether whether the service will verify the certificate of the server referenced by the ImageURI property in SimpleUpdate prior to sending the transfer request.",
+                    "longDescription": "This property shall indicate whether whether the service will verify the certificate of the server referenced by the ImageURI property in SimpleUpdate prior to sending the transfer request.  If this property is not supported by the service, it shall be assumed to be `false`.  This property should default to `false` in order to maintain compatibility with older clients.",
                     "readonly": false,
                     "type": [
                         "boolean",
@@ -519,6 +545,6 @@
         }
     },
     "owningEntity": "DMTF",
-    "release": "2021.2",
-    "title": "#UpdateService.v1_10_0.UpdateService"
+    "release": "2021.4",
+    "title": "#UpdateService.v1_11_0.UpdateService"
 }

--- a/static/redfish/v1/JsonSchemas/VirtualMedia/VirtualMedia.json
+++ b/static/redfish/v1/JsonSchemas/VirtualMedia/VirtualMedia.json
@@ -1,5 +1,5 @@
 {
-    "$id": "http://redfish.dmtf.org/schemas/v1/VirtualMedia.v1_5_0.json",
+    "$id": "http://redfish.dmtf.org/schemas/v1/VirtualMedia.v1_5_1.json",
     "$ref": "#/definitions/VirtualMedia",
     "$schema": "http://redfish.dmtf.org/schemas/v1/redfish-schema-v1.json",
     "copyright": "Copyright 2014-2021 DMTF. For the full DMTF copyright policy, see http://www.dmtf.org/about/policies/copyright",
@@ -413,7 +413,7 @@
                 },
                 "VerifyCertificate": {
                     "description": "An indication of whether the service will verify the certificate of the server referenced by the Image property prior to completing the remote media connection.",
-                    "longDescription": "This property shall indicate whether whether the service will verify the certificate of the server referenced by the Image property prior to completing the remote media connection.",
+                    "longDescription": "This property shall indicate whether whether the service will verify the certificate of the server referenced by the Image property prior to completing the remote media connection.  If this property is not supported by the service, it shall be assumed to be `false`.  This property should default to `false` in order to maintain compatibility with older clients.",
                     "readonly": false,
                     "type": [
                         "boolean",
@@ -442,5 +442,5 @@
     },
     "owningEntity": "DMTF",
     "release": "2021.2",
-    "title": "#VirtualMedia.v1_5_0.VirtualMedia"
+    "title": "#VirtualMedia.v1_5_1.VirtualMedia"
 }

--- a/static/redfish/v1/schema/Cable_v1.xml
+++ b/static/redfish/v1/schema/Cable_v1.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!---->
 <!--################################################################################       -->
-<!--# Redfish Schema:  Cable v1.1.0                                                        -->
+<!--# Redfish Schema:  Cable v1.2.0                                                        -->
 <!--#                                                                                      -->
 <!--# For a detailed change log, see the README file contained in the DSP8010 bundle,      -->
 <!--# available at http://www.dmtf.org/standards/redfish                                   -->
@@ -263,6 +263,28 @@
         <Member Name="QSFP">
           <Annotation Term="OData.Description" String="This cable connects to a QSFP connector."/>
         </Member>
+        <Member Name="CDFP">
+          <Annotation Term="OData.Description" String="This cable connects to a CDFP connector."/>
+          <Annotation Term="Redfish.Revisions">
+            <Collection>
+              <Record>
+                <PropertyValue Property="Kind" EnumMember="Redfish.RevisionKind/Added"/>
+                <PropertyValue Property="Version" String="v1_2_0"/>
+              </Record>
+            </Collection>
+          </Annotation>
+        </Member>
+        <Member Name="OSFP">
+          <Annotation Term="OData.Description" String="This cable connects to a OSFP connector."/>
+          <Annotation Term="Redfish.Revisions">
+            <Collection>
+              <Record>
+                <PropertyValue Property="Kind" EnumMember="Redfish.RevisionKind/Added"/>
+                <PropertyValue Property="Version" String="v1_2_0"/>
+              </Record>
+            </Collection>
+          </Annotation>
+        </Member>
       </EnumType>
 
       <EnumType Name="CableStatus">
@@ -361,6 +383,14 @@
           <Annotation Term="OData.LongDescription" String="This property shall contain a user-assigned label used to identify this resource.  If a value has not been assigned by a user, the value of this property shall be an empty string."/>
         </Property>
       </EntityType>
+    </Schema>
+
+    <Schema xmlns="http://docs.oasis-open.org/odata/ns/edm" Namespace="Cable.v1_2_0">
+      <Annotation Term="Redfish.OwningEntity" String="DMTF"/>
+      <Annotation Term="Redfish.Release" String="2021.4"/>
+      <Annotation Term="OData.Description" String="This version was created to add `CDFP` and `OSFP` to ConnectorType."/>
+
+      <EntityType Name="Cable" BaseType="Cable.v1_1_0.Cable"/>
     </Schema>
 
   </edmx:DataServices>

--- a/static/redfish/v1/schema/Chassis_v1.xml
+++ b/static/redfish/v1/schema/Chassis_v1.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!---->
 <!--################################################################################       -->
-<!--# Redfish Schema:  Chassis v1.18.0                                                     -->
+<!--# Redfish Schema:  Chassis v1.19.0                                                     -->
 <!--#                                                                                      -->
 <!--# For a detailed change log, see the README file contained in the DSP8010 bundle,      -->
 <!--# available at http://www.dmtf.org/standards/redfish                                   -->
@@ -1546,6 +1546,15 @@
         <Property Name="Measurements" Type="Collection(SoftwareInventory.MeasurementBlock)" Nullable="false">
           <Annotation Term="OData.Description" String="An array of DSP0274-defined measurement blocks."/>
           <Annotation Term="OData.LongDescription" String="This property shall contain an array of DSP0274-defined measurement blocks."/>
+          <Annotation Term="Redfish.Revisions">
+            <Collection>
+              <Record>
+                <PropertyValue Property="Kind" EnumMember="Redfish.RevisionKind/Deprecated"/>
+                <PropertyValue Property="Version" String="v1_19_0"/>
+                <PropertyValue Property="Description" String="This property has been deprecated in favor of the ComponentIntegrity resource."/>
+              </Record>
+            </Collection>
+          </Annotation>
         </Property>
       </EntityType>
     </Schema>
@@ -1619,6 +1628,14 @@
           <Annotation Term="OData.AutoExpandReferences"/>
         </NavigationProperty>
       </ComplexType>
+    </Schema>
+
+    <Schema xmlns="http://docs.oasis-open.org/odata/ns/edm" Namespace="Chassis.v1_19_0">
+      <Annotation Term="Redfish.OwningEntity" String="DMTF"/>
+      <Annotation Term="Redfish.Release" String="2021.4"/>
+      <Annotation Term="OData.Description" String="This version was created to deprecate Measurements in favor of measurement reporting in the ComponentIntegrity resource."/>
+
+      <EntityType Name="Chassis" BaseType="Chassis.v1_18_0.Chassis"/>
     </Schema>
 
   </edmx:DataServices>

--- a/static/redfish/v1/schema/ComputerSystem_v1.xml
+++ b/static/redfish/v1/schema/ComputerSystem_v1.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!---->
 <!--################################################################################       -->
-<!--# Redfish Schema:  ComputerSystem v1.16.0                                              -->
+<!--# Redfish Schema:  ComputerSystem v1.17.0                                              -->
 <!--#                                                                                      -->
 <!--# For a detailed change log, see the README file contained in the DSP8010 bundle,      -->
 <!--# available at http://www.dmtf.org/standards/redfish                                   -->
@@ -108,6 +108,9 @@
   </edmx:Reference>
   <edmx:Reference Uri="http://redfish.dmtf.org/schemas/v1/USBControllerCollection_v1.xml">
     <edmx:Include Namespace="USBControllerCollection"/>
+  </edmx:Reference>
+  <edmx:Reference Uri="http://redfish.dmtf.org/schemas/v1/NetworkDeviceFunction_v1.xml">
+    <edmx:Include Namespace="NetworkDeviceFunction"/>
   </edmx:Reference>
 
   <edmx:DataServices>
@@ -2305,6 +2308,15 @@
         <Property Name="Measurements" Type="Collection(SoftwareInventory.MeasurementBlock)" Nullable="false">
           <Annotation Term="OData.Description" String="An array of DSP0274-defined measurement blocks."/>
           <Annotation Term="OData.LongDescription" String="This property shall contain an array of DSP0274-defined measurement blocks."/>
+          <Annotation Term="Redfish.Revisions">
+            <Collection>
+              <Record>
+                <PropertyValue Property="Kind" EnumMember="Redfish.RevisionKind/Deprecated"/>
+                <PropertyValue Property="Version" String="v1_17_0"/>
+                <PropertyValue Property="Description" String="This property has been deprecated in favor of the ComponentIntegrity resource."/>
+              </Record>
+            </Collection>
+          </Annotation>
         </Property>
       </EntityType>
 
@@ -2537,6 +2549,23 @@
       <Annotation Term="Redfish.OwningEntity" String="DMTF"/>
       <Annotation Term="OData.Description" String="This version was created to clarify the BootOrder property might be controlled with a settings resource."/>
       <EntityType Name="ComputerSystem" BaseType="ComputerSystem.v1_16_0.ComputerSystem"/>
+    </Schema>
+
+    <Schema xmlns="http://docs.oasis-open.org/odata/ns/edm" Namespace="ComputerSystem.v1_17_0">
+      <Annotation Term="Redfish.OwningEntity" String="DMTF"/>
+      <Annotation Term="Redfish.Release" String="2021.4"/>
+      <Annotation Term="OData.Description" String="This version was created to deprecate Measurements in favor of measurement reporting in the ComponentIntegrity resource."/>
+
+      <EntityType Name="ComputerSystem" BaseType="ComputerSystem.v1_16_1.ComputerSystem"/>
+
+      <ComplexType Name="Links" BaseType="ComputerSystem.v1_5_0.Links">
+        <NavigationProperty Name="OffloadedNetworkDeviceFunctions" Type="Collection(NetworkDeviceFunction.NetworkDeviceFunction)">
+          <Annotation Term="OData.Permissions" EnumMember="OData.Permission/Read"/>
+          <Annotation Term="OData.Description" String="The network device functions to which this system performs offload computation, such as with a SmartNIC."/>
+          <Annotation Term="OData.LongDescription" String="This property shall contain an array of links to resources of type NetworkDeviceFunction that represent the network device functions to which this system performs offload computation, such as with a SmartNIC.  This property shall not be present if the SystemType property does not contain `DPU`."/>
+          <Annotation Term="OData.AutoExpandReferences"/>
+        </NavigationProperty>
+      </ComplexType>
     </Schema>
 
   </edmx:DataServices>

--- a/static/redfish/v1/schema/Drive_v1.xml
+++ b/static/redfish/v1/schema/Drive_v1.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!---->
 <!--################################################################################                   -->
-<!--# Redfish Schema:  Drive v1.13.0                                                                   -->
+<!--# Redfish Schema:  Drive v1.14.0                                                                   -->
 <!--#                                                                                                  -->
 <!--# For a detailed change log, see the README file contained in the DSP8010 bundle,                  -->
 <!--# available at http://www.dmtf.org/standards/redfish                                               -->
@@ -62,6 +62,9 @@
   </edmx:Reference>
   <edmx:Reference Uri="http://redfish.dmtf.org/schemas/v1/Storage_v1.xml">
     <edmx:Include Namespace="Storage"/>
+  </edmx:Reference>
+  <edmx:Reference Uri="http://redfish.dmtf.org/schemas/v1/NetworkDeviceFunction_v1.xml">
+    <edmx:Include Namespace="NetworkDeviceFunction"/>
   </edmx:Reference>
 
   <edmx:DataServices>
@@ -247,7 +250,7 @@
           <Annotation Term="OData.Permissions" EnumMember="OData.Permission/Read"/>
           <Annotation Term="OData.Description" String="The rotation speed of this drive, in revolutions per minute (RPM)."/>
           <Annotation Term="OData.LongDescription" String="This property shall contain the rotation speed, in revolutions per minute (RPM), of the associated drive."/>
-          <Annotation Term="Measures.Unit" String="RPM"/>
+          <Annotation Term="Measures.Unit" String="{rev}/min"/>
         </Property>
         <Property Name="BlockSizeBytes" Type="Edm.Int64">
           <Annotation Term="OData.Permissions" EnumMember="OData.Permission/Read"/>
@@ -487,6 +490,12 @@
       <EntityType Name="Drive" BaseType="Drive.v1_0_12.Drive"/>
     </Schema>
 
+    <Schema xmlns="http://docs.oasis-open.org/odata/ns/edm" Namespace="Drive.v1_0_14">
+      <Annotation Term="Redfish.OwningEntity" String="DMTF"/>
+      <Annotation Term="OData.Description" String="This version was created to correct the units annotation value for RotationSpeedRPM to match the available UCUM format."/>
+      <EntityType Name="Drive" BaseType="Drive.v1_0_13.Drive"/>
+    </Schema>
+
     <Schema xmlns="http://docs.oasis-open.org/odata/ns/edm" Namespace="Drive.v1_1_0">
       <Annotation Term="Redfish.OwningEntity" String="DMTF"/>
       <Annotation Term="Redfish.Release" String="2016.2"/>
@@ -602,6 +611,12 @@
       <EntityType Name="Drive" BaseType="Drive.v1_1_11.Drive"/>
     </Schema>
 
+    <Schema xmlns="http://docs.oasis-open.org/odata/ns/edm" Namespace="Drive.v1_1_13">
+      <Annotation Term="Redfish.OwningEntity" String="DMTF"/>
+      <Annotation Term="OData.Description" String="This version was created to correct the units annotation value for RotationSpeedRPM to match the available UCUM format."/>
+      <EntityType Name="Drive" BaseType="Drive.v1_1_12.Drive"/>
+    </Schema>
+
     <Schema xmlns="http://docs.oasis-open.org/odata/ns/edm" Namespace="Drive.v1_2_0">
       <Annotation Term="Redfish.OwningEntity" String="DMTF"/>
       <Annotation Term="Redfish.Release" String="2017.1"/>
@@ -678,6 +693,12 @@
       <EntityType Name="Drive" BaseType="Drive.v1_2_9.Drive"/>
     </Schema>
 
+    <Schema xmlns="http://docs.oasis-open.org/odata/ns/edm" Namespace="Drive.v1_2_11">
+      <Annotation Term="Redfish.OwningEntity" String="DMTF"/>
+      <Annotation Term="OData.Description" String="This version was created to correct the units annotation value for RotationSpeedRPM to match the available UCUM format."/>
+      <EntityType Name="Drive" BaseType="Drive.v1_2_10.Drive"/>
+    </Schema>
+
     <Schema xmlns="http://docs.oasis-open.org/odata/ns/edm" Namespace="Drive.v1_3_0">
       <Annotation Term="Redfish.OwningEntity" String="DMTF"/>
       <Annotation Term="Redfish.Release" String="2017.3"/>
@@ -746,6 +767,12 @@
       <EntityType Name="Drive" BaseType="Drive.v1_3_8.Drive"/>
     </Schema>
 
+    <Schema xmlns="http://docs.oasis-open.org/odata/ns/edm" Namespace="Drive.v1_3_10">
+      <Annotation Term="Redfish.OwningEntity" String="DMTF"/>
+      <Annotation Term="OData.Description" String="This version was created to correct the units annotation value for RotationSpeedRPM to match the available UCUM format."/>
+      <EntityType Name="Drive" BaseType="Drive.v1_3_9.Drive"/>
+    </Schema>
+
     <Schema xmlns="http://docs.oasis-open.org/odata/ns/edm" Namespace="Drive.v1_4_0">
       <Annotation Term="Redfish.OwningEntity" String="DMTF"/>
       <Annotation Term="Redfish.Release" String="2018.1"/>
@@ -810,6 +837,12 @@
       <Annotation Term="Redfish.OwningEntity" String="DMTF"/>
       <Annotation Term="OData.Description" String="This version was created to change the permissions for HotspareType to read-write."/>
       <EntityType Name="Drive" BaseType="Drive.v1_4_8.Drive"/>
+    </Schema>
+
+    <Schema xmlns="http://docs.oasis-open.org/odata/ns/edm" Namespace="Drive.v1_4_10">
+      <Annotation Term="Redfish.OwningEntity" String="DMTF"/>
+      <Annotation Term="OData.Description" String="This version was created to correct the units annotation value for RotationSpeedRPM to match the available UCUM format."/>
+      <EntityType Name="Drive" BaseType="Drive.v1_4_9.Drive"/>
     </Schema>
 
     <Schema xmlns="http://docs.oasis-open.org/odata/ns/edm" Namespace="Drive.v1_5_0">
@@ -882,6 +915,12 @@
       <EntityType Name="Drive" BaseType="Drive.v1_5_7.Drive"/>
     </Schema>
 
+    <Schema xmlns="http://docs.oasis-open.org/odata/ns/edm" Namespace="Drive.v1_5_9">
+      <Annotation Term="Redfish.OwningEntity" String="DMTF"/>
+      <Annotation Term="OData.Description" String="This version was created to correct the units annotation value for RotationSpeedRPM to match the available UCUM format."/>
+      <EntityType Name="Drive" BaseType="Drive.v1_5_8.Drive"/>
+    </Schema>
+
     <Schema xmlns="http://docs.oasis-open.org/odata/ns/edm" Namespace="Drive.v1_6_0">
       <Annotation Term="Redfish.OwningEntity" String="DMTF"/>
       <Annotation Term="Redfish.Release" String="2019.1"/>
@@ -933,6 +972,12 @@
       <EntityType Name="Drive" BaseType="Drive.v1_6_5.Drive"/>
     </Schema>
 
+    <Schema xmlns="http://docs.oasis-open.org/odata/ns/edm" Namespace="Drive.v1_6_7">
+      <Annotation Term="Redfish.OwningEntity" String="DMTF"/>
+      <Annotation Term="OData.Description" String="This version was created to correct the units annotation value for RotationSpeedRPM to match the available UCUM format."/>
+      <EntityType Name="Drive" BaseType="Drive.v1_6_6.Drive"/>
+    </Schema>
+
     <Schema xmlns="http://docs.oasis-open.org/odata/ns/edm" Namespace="Drive.v1_7_0">
       <Annotation Term="Redfish.OwningEntity" String="DMTF"/>
       <Annotation Term="Redfish.Release" String="2019.2"/>
@@ -975,6 +1020,12 @@
       <Annotation Term="Redfish.OwningEntity" String="DMTF"/>
       <Annotation Term="OData.Description" String="This version was created to change the permissions for HotspareType to read-write."/>
       <EntityType Name="Drive" BaseType="Drive.v1_7_4.Drive"/>
+    </Schema>
+
+    <Schema xmlns="http://docs.oasis-open.org/odata/ns/edm" Namespace="Drive.v1_7_6">
+      <Annotation Term="Redfish.OwningEntity" String="DMTF"/>
+      <Annotation Term="OData.Description" String="This version was created to correct the units annotation value for RotationSpeedRPM to match the available UCUM format."/>
+      <EntityType Name="Drive" BaseType="Drive.v1_7_5.Drive"/>
     </Schema>
 
     <Schema xmlns="http://docs.oasis-open.org/odata/ns/edm" Namespace="Drive.v1_8_0">
@@ -1023,6 +1074,12 @@
       <EntityType Name="Drive" BaseType="Drive.v1_8_4.Drive"/>
     </Schema>
 
+    <Schema xmlns="http://docs.oasis-open.org/odata/ns/edm" Namespace="Drive.v1_8_6">
+      <Annotation Term="Redfish.OwningEntity" String="DMTF"/>
+      <Annotation Term="OData.Description" String="This version was created to correct the units annotation value for RotationSpeedRPM to match the available UCUM format."/>
+      <EntityType Name="Drive" BaseType="Drive.v1_8_5.Drive"/>
+    </Schema>
+
     <Schema xmlns="http://docs.oasis-open.org/odata/ns/edm" Namespace="Drive.v1_9_0">
       <Annotation Term="Redfish.OwningEntity" String="DMTF"/>
       <Annotation Term="Redfish.Release" String="2019.4"/>
@@ -1067,6 +1124,12 @@
       <EntityType Name="Drive" BaseType="Drive.v1_9_4.Drive"/>
     </Schema>
 
+    <Schema xmlns="http://docs.oasis-open.org/odata/ns/edm" Namespace="Drive.v1_9_6">
+      <Annotation Term="Redfish.OwningEntity" String="DMTF"/>
+      <Annotation Term="OData.Description" String="This version was created to correct the units annotation value for RotationSpeedRPM to match the available UCUM format."/>
+      <EntityType Name="Drive" BaseType="Drive.v1_9_5.Drive"/>
+    </Schema>
+
     <Schema xmlns="http://docs.oasis-open.org/odata/ns/edm" Namespace="Drive.v1_10_0">
       <Annotation Term="Redfish.OwningEntity" String="DMTF"/>
       <Annotation Term="Redfish.Release" String="2020.2"/>
@@ -1097,6 +1160,12 @@
       <Annotation Term="Redfish.OwningEntity" String="DMTF"/>
       <Annotation Term="OData.Description" String="This version was created to change the permissions for HotspareType to read-write."/>
       <EntityType Name="Drive" BaseType="Drive.v1_10_2.Drive"/>
+    </Schema>
+
+    <Schema xmlns="http://docs.oasis-open.org/odata/ns/edm" Namespace="Drive.v1_10_4">
+      <Annotation Term="Redfish.OwningEntity" String="DMTF"/>
+      <Annotation Term="OData.Description" String="This version was created to correct the units annotation value for RotationSpeedRPM to match the available UCUM format."/>
+      <EntityType Name="Drive" BaseType="Drive.v1_10_3.Drive"/>
     </Schema>
 
     <Schema xmlns="http://docs.oasis-open.org/odata/ns/edm" Namespace="Drive.v1_11_0">
@@ -1131,6 +1200,12 @@
       <EntityType Name="Drive" BaseType="Drive.v1_11_2.Drive"/>
     </Schema>
 
+    <Schema xmlns="http://docs.oasis-open.org/odata/ns/edm" Namespace="Drive.v1_11_4">
+      <Annotation Term="Redfish.OwningEntity" String="DMTF"/>
+      <Annotation Term="OData.Description" String="This version was created to correct the units annotation value for RotationSpeedRPM to match the available UCUM format."/>
+      <EntityType Name="Drive" BaseType="Drive.v1_11_3.Drive"/>
+    </Schema>
+
     <Schema xmlns="http://docs.oasis-open.org/odata/ns/edm" Namespace="Drive.v1_12_0">
       <Annotation Term="Redfish.OwningEntity" String="DMTF"/>
       <Annotation Term="Redfish.Release" String="2020.4"/>
@@ -1152,6 +1227,15 @@
         <Property Name="Measurements" Type="Collection(SoftwareInventory.MeasurementBlock)" Nullable="false">
           <Annotation Term="OData.Description" String="An array of DSP0274-defined measurement blocks."/>
           <Annotation Term="OData.LongDescription" String="This property shall contain an array of DSP0274-defined measurement blocks."/>
+          <Annotation Term="Redfish.Revisions">
+            <Collection>
+              <Record>
+                <PropertyValue Property="Kind" EnumMember="Redfish.RevisionKind/Deprecated"/>
+                <PropertyValue Property="Version" String="v1_14_0"/>
+                <PropertyValue Property="Description" String="This property has been deprecated in favor of the ComponentIntegrity resource."/>
+              </Record>
+            </Collection>
+          </Annotation>
         </Property>
       </EntityType>
     </Schema>
@@ -1168,6 +1252,12 @@
       <EntityType Name="Drive" BaseType="Drive.v1_12_1.Drive"/>
     </Schema>
 
+    <Schema xmlns="http://docs.oasis-open.org/odata/ns/edm" Namespace="Drive.v1_12_3">
+      <Annotation Term="Redfish.OwningEntity" String="DMTF"/>
+      <Annotation Term="OData.Description" String="This version was created to correct the units annotation value for RotationSpeedRPM to match the available UCUM format."/>
+      <EntityType Name="Drive" BaseType="Drive.v1_12_2.Drive"/>
+    </Schema>
+
     <Schema xmlns="http://docs.oasis-open.org/odata/ns/edm" Namespace="Drive.v1_13_0">
       <Annotation Term="Redfish.OwningEntity" String="DMTF"/>
       <Annotation Term="Redfish.Release" String="2021.2"/>
@@ -1179,6 +1269,29 @@
           <Annotation Term="OData.Permissions" EnumMember="OData.Permission/Read"/>
           <Annotation Term="OData.Description" String="A link to the storage subsystem to which this drive belongs."/>
           <Annotation Term="OData.LongDescription" String="This property shall contain a link to a resource of type Storage that represents the storage subsystem to which this drive belongs."/>
+          <Annotation Term="OData.AutoExpandReferences"/>
+        </NavigationProperty>
+      </ComplexType>
+    </Schema>
+
+    <Schema xmlns="http://docs.oasis-open.org/odata/ns/edm" Namespace="Drive.v1_13_1">
+      <Annotation Term="Redfish.OwningEntity" String="DMTF"/>
+      <Annotation Term="OData.Description" String="This version was created to correct the units annotation value for RotationSpeedRPM to match the available UCUM format."/>
+      <EntityType Name="Drive" BaseType="Drive.v1_13_0.Drive"/>
+    </Schema>
+
+    <Schema xmlns="http://docs.oasis-open.org/odata/ns/edm" Namespace="Drive.v1_14_0">
+      <Annotation Term="Redfish.OwningEntity" String="DMTF"/>
+      <Annotation Term="Redfish.Release" String="2021.4"/>
+      <Annotation Term="OData.Description" String="This version was created to deprecate Measurements in favor of measurement reporting in the ComponentIntegrity resource."/>
+
+      <EntityType Name="Drive" BaseType="Drive.v1_13_1.Drive"/>
+
+      <ComplexType Name="Links" BaseType="Drive.v1_13_0.Links">
+        <NavigationProperty Name="NetworkDeviceFunctions" Type="Collection(NetworkDeviceFunction.NetworkDeviceFunction)">
+          <Annotation Term="OData.Permissions" EnumMember="OData.Permission/Read"/>
+          <Annotation Term="OData.Description" String="An array of links to the network device functions that provide network connectivity for this drive."/>
+          <Annotation Term="OData.LongDescription" String="This property shall contain the array of links to resources of type NetworkDeviceFunction.  This property should only be present for drives with network connectivity, such as Ethernet attached drives."/>
           <Annotation Term="OData.AutoExpandReferences"/>
         </NavigationProperty>
       </ComplexType>

--- a/static/redfish/v1/schema/EthernetInterface_v1.xml
+++ b/static/redfish/v1/schema/EthernetInterface_v1.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!---->
 <!--################################################################################       -->
-<!--# Redfish Schema:  EthernetInterface v1.7.0                                            -->
+<!--# Redfish Schema:  EthernetInterface v1.8.0                                            -->
 <!--#                                                                                      -->
 <!--# For a detailed change log, see the README file contained in the DSP8010 bundle,      -->
 <!--# available at http://www.dmtf.org/standards/redfish                                   -->
@@ -652,7 +652,7 @@
         <Property Name="OperatingMode" Type="EthernetInterface.v1_4_0.DHCPv6OperatingMode">
           <Annotation Term="OData.Permissions" EnumMember="OData.Permission/ReadWrite"/>
           <Annotation Term="OData.Description" String="Determines the DHCPv6 operating mode for this interface."/>
-          <Annotation Term="OData.LongDescription" String="This property shall control the operating mode of DHCPv6 on this interface.  DHCPv6 stateful mode configures addresses, and when it is enabled, stateless mode is also implicitly enabled."/>
+          <Annotation Term="OData.LongDescription" String="This property shall control the operating mode of DHCPv6 on this interface."/>
         </Property>
         <Property Name="UseDNSServers" Type="Edm.Boolean">
           <Annotation Term="OData.Permissions" EnumMember="OData.Permission/ReadWrite"/>
@@ -661,8 +661,8 @@
         </Property>
         <Property Name="UseDomainName" Type="Edm.Boolean">
           <Annotation Term="OData.Permissions" EnumMember="OData.Permission/ReadWrite"/>
-          <Annotation Term="OData.Description" String="An indication of whether the interface uses a domain name supplied through DHCP v6 stateless mode."/>
-          <Annotation Term="OData.LongDescription" String="This property shall indicate whether the interface uses a domain name supplied through DHCP v6 stateless mode."/>
+          <Annotation Term="OData.Description" String="An indication of whether this interface uses a DHCP v6-supplied domain name."/>
+          <Annotation Term="OData.LongDescription" String="This property shall indicate whether the interface uses a DHCP v6-supplied domain name."/>
         </Property>
         <Property Name="UseNTPServers" Type="Edm.Boolean">
           <Annotation Term="OData.Permissions" EnumMember="OData.Permission/ReadWrite"/>
@@ -679,15 +679,45 @@
       <EnumType Name="DHCPv6OperatingMode">
         <Member Name="Stateful">
           <Annotation Term="OData.Description" String="DHCPv6 stateful mode."/>
-          <Annotation Term="OData.LongDescription" String="DHCPv6 shall operate in stateful mode on this interface.  DHCPv6 stateful mode configures addresses, and when it is enabled, stateless mode is also implicitly enabled."/>
+          <Annotation Term="OData.LongDescription" String="DHCPv6 shall operate in stateful mode on this interface.  DHCPv6 stateful mode configures addresses, and when it is enabled, stateless mode is also implicitly enabled.  Services may replace this value with `Enabled`."/>
+          <Annotation Term="Redfish.Revisions">
+            <Collection>
+              <Record>
+                <PropertyValue Property="Kind" EnumMember="Redfish.RevisionKind/Deprecated"/>
+                <PropertyValue Property="Version" String="v1_8_0"/>
+                <PropertyValue Property="Description" String="This property has been deprecated in favor of `Enabled`.  The control between 'stateful' and 'stateless' is managed by the DHCP server and not the client."/>
+              </Record>
+            </Collection>
+          </Annotation>
         </Member>
         <Member Name="Stateless">
           <Annotation Term="OData.Description" String="DHCPv6 stateless mode."/>
-          <Annotation Term="OData.LongDescription" String="DHCPv6 shall operate in stateless mode on this interface.  DHCPv6 stateless mode allows configuring the interface using DHCP options but does not configure addresses.  It is always enabled by default whenever DHCPv6 Stateful mode is also enabled."/>
+          <Annotation Term="OData.LongDescription" String="DHCPv6 shall operate in stateless mode on this interface.  DHCPv6 stateless mode allows configuring the interface using DHCP options but does not configure addresses.  It is always enabled by default whenever DHCPv6 Stateful mode is also enabled.  Services may replace this value with `Enabled`."/>
+          <Annotation Term="Redfish.Revisions">
+            <Collection>
+              <Record>
+                <PropertyValue Property="Kind" EnumMember="Redfish.RevisionKind/Deprecated"/>
+                <PropertyValue Property="Version" String="v1_8_0"/>
+                <PropertyValue Property="Description" String="This property has been deprecated in favor of `Enabled`.  The control between 'stateful' and 'stateless' is managed by the DHCP server and not the client."/>
+              </Record>
+            </Collection>
+          </Annotation>
         </Member>
         <Member Name="Disabled">
           <Annotation Term="OData.Description" String="DHCPv6 is disabled."/>
           <Annotation Term="OData.LongDescription" String="DHCPv6 shall be disabled for this interface."/>
+        </Member>
+        <Member Name="Enabled">
+          <Annotation Term="OData.Description" String="DHCPv6 is enabled."/>
+          <Annotation Term="OData.LongDescription" String="DHCPv6 shall be enabled for this interface."/>
+          <Annotation Term="Redfish.Revisions">
+            <Collection>
+              <Record>
+                <PropertyValue Property="Kind" EnumMember="Redfish.RevisionKind/Added"/>
+                <PropertyValue Property="Version" String="v1_8_0"/>
+              </Record>
+            </Collection>
+          </Annotation>
         </Member>
       </EnumType>
 
@@ -892,6 +922,7 @@
       <Annotation Term="Redfish.OwningEntity" String="DMTF"/>
       <Annotation Term="Redfish.Release" String="2021.2"/>
       <Annotation Term="OData.Description" String="This version was created to deprecate several properties and add NetworkDeviceFunctions link collection."/>
+
       <EntityType Name="EthernetInterface" BaseType="EthernetInterface.v1_6_4.EthernetInterface"/>
 
       <ComplexType Name="Links" BaseType="EthernetInterface.v1_6_0.Links">
@@ -902,6 +933,14 @@
           <Annotation Term="OData.AutoExpandReferences"/>
         </NavigationProperty>
       </ComplexType>
+    </Schema>
+
+    <Schema xmlns="http://docs.oasis-open.org/odata/ns/edm" Namespace="EthernetInterface.v1_8_0">
+      <Annotation Term="Redfish.OwningEntity" String="DMTF"/>
+      <Annotation Term="Redfish.Release" String="2021.2"/>
+      <Annotation Term="OData.Description" String="This version was created to deprecate the `Stateless` and `Stateful` values for DHCPv6 OperatingMode and add `Enabled` to DHCPv6 OperatingMode."/>
+
+      <EntityType Name="EthernetInterface" BaseType="EthernetInterface.v1_7_0.EthernetInterface"/>
     </Schema>
 
   </edmx:DataServices>

--- a/static/redfish/v1/schema/EventDestination_v1.xml
+++ b/static/redfish/v1/schema/EventDestination_v1.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!---->
 <!--################################################################################       -->
-<!--# Redfish Schema:  EventDestination v1.11.1                                            -->
+<!--# Redfish Schema:  EventDestination v1.11.2                                            -->
 <!--#                                                                                      -->
 <!--# For a detailed change log, see the README file contained in the DSP8010 bundle,      -->
 <!--# available at http://www.dmtf.org/standards/redfish                                   -->
@@ -921,7 +921,7 @@
         <Property Name="VerifyCertificate" Type="Edm.Boolean">
           <Annotation Term="OData.Permissions" EnumMember="OData.Permission/ReadWrite"/>
           <Annotation Term="OData.Description" String="An indication of whether the service will verify the certificate of the server referenced by the Destination property prior to sending the event."/>
-          <Annotation Term="OData.LongDescription" String="This property shall indicate whether whether the service will verify the certificate of the server referenced by the Destination property prior to sending the event."/>
+          <Annotation Term="OData.LongDescription" String="This property shall indicate whether whether the service will verify the certificate of the server referenced by the Destination property prior to sending the event.  If this property is not supported by the service or specified by the client in the create request, it shall be assumed to be `false`."/>
         </Property>
         <Property Name="SyslogFilters" Type="Collection(EventDestination.v1_9_0.SyslogFilter)">
           <Annotation Term="OData.Description" String="A list of filters applied to syslog messages before sending to a remote syslog server.  An empty list indicates all syslog messages are sent."/>
@@ -1089,6 +1089,12 @@
       <EntityType Name="EventDestination" BaseType="EventDestination.v1_9_3.EventDestination"/>
     </Schema>
 
+    <Schema xmlns="http://docs.oasis-open.org/odata/ns/edm" Namespace="EventDestination.v1_9_5">
+      <Annotation Term="Redfish.OwningEntity" String="DMTF"/>
+      <Annotation Term="OData.Description" String="This version was created to clarify the behavior of VerifyCertificate when not supported or specified."/>
+      <EntityType Name="EventDestination" BaseType="EventDestination.v1_9_4.EventDestination"/>
+    </Schema>
+
     <Schema xmlns="http://docs.oasis-open.org/odata/ns/edm" Namespace="EventDestination.v1_10_0">
       <Annotation Term="Redfish.OwningEntity" String="DMTF"/>
       <Annotation Term="OData.Description" String="This version was created to add additional SNMP authentication protocols and to provide better description for the authentication and encryption keys.  It also added `RetryForeverWithBackoff` to DeliveryRetryPolicy and long description details to the DeliveryRetryPolicy values."/>
@@ -1128,6 +1134,12 @@
       <EntityType Name="EventDestination" BaseType="EventDestination.v1_10_2.EventDestination"/>
     </Schema>
 
+    <Schema xmlns="http://docs.oasis-open.org/odata/ns/edm" Namespace="EventDestination.v1_10_4">
+      <Annotation Term="Redfish.OwningEntity" String="DMTF"/>
+      <Annotation Term="OData.Description" String="This version was created to clarify the behavior of VerifyCertificate when not supported or specified."/>
+      <EntityType Name="EventDestination" BaseType="EventDestination.v1_10_3.EventDestination"/>
+    </Schema>
+
     <Schema xmlns="http://docs.oasis-open.org/odata/ns/edm" Namespace="EventDestination.v1_11_0">
       <Annotation Term="Redfish.OwningEntity" String="DMTF"/>
       <Annotation Term="Redfish.Release" String="2021.2"/>
@@ -1158,6 +1170,12 @@
       <Annotation Term="Redfish.OwningEntity" String="DMTF"/>
       <Annotation Term="OData.Description" String="This version was created to clarify the usage of the Destination property with server-sent events."/>
       <EntityType Name="EventDestination" BaseType="EventDestination.v1_11_0.EventDestination"/>
+    </Schema>
+
+    <Schema xmlns="http://docs.oasis-open.org/odata/ns/edm" Namespace="EventDestination.v1_11_2">
+      <Annotation Term="Redfish.OwningEntity" String="DMTF"/>
+      <Annotation Term="OData.Description" String="This version was created to clarify the behavior of VerifyCertificate when not supported or specified."/>
+      <EntityType Name="EventDestination" BaseType="EventDestination.v1_11_1.EventDestination"/>
     </Schema>
 
   </edmx:DataServices>

--- a/static/redfish/v1/schema/LogEntry_v1.xml
+++ b/static/redfish/v1/schema/LogEntry_v1.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!---->
 <!--################################################################################       -->
-<!--# Redfish Schema:  LogEntry v1.10.0                                                    -->
+<!--# Redfish Schema:  LogEntry v1.11.0                                                    -->
 <!--#                                                                                      -->
 <!--# For a detailed change log, see the README file contained in the DSP8010 bundle,      -->
 <!--# available at http://www.dmtf.org/standards/redfish                                   -->
@@ -1196,9 +1196,15 @@
         <Property Name="Resolution" Type="Edm.String" Nullable="false">
           <Annotation Term="OData.Permissions" EnumMember="OData.Permission/Read"/>
           <Annotation Term="OData.Description" String="Used to provide suggestions on how to resolve the situation that caused the log entry."/>
-          <Annotation Term="OData.LongDescription" String="This property shall contain the resolution of the log entry.  Services can replace the resolution defined in the message registry with a more specific resolution in a log entry."/>
+          <Annotation Term="OData.LongDescription" String="This property shall contain the resolution of the log entry.  Services should replace the resolution defined in the message registry with a more specific resolution in a log entry."/>
         </Property>
       </EntityType>
+    </Schema>
+
+    <Schema xmlns="http://docs.oasis-open.org/odata/ns/edm" Namespace="LogEntry.v1_9_1">
+      <Annotation Term="Redfish.OwningEntity" String="DMTF"/>
+      <Annotation Term="OData.Description" String="This version was created to update description for Resolution to recommend that an appropriate resolution is used."/>
+      <EntityType Name="LogEntry" BaseType="LogEntry.v1_9_0.LogEntry"/>
     </Schema>
 
     <Schema xmlns="http://docs.oasis-open.org/odata/ns/edm" Namespace="LogEntry.v1_10_0">
@@ -1207,6 +1213,42 @@
       <Annotation Term="OData.Description" String="This version was created add `CPER` and `CPERSection` to LogDiagnosticDataTypes."/>
 
       <EntityType Name="LogEntry" BaseType="LogEntry.v1_9_0.LogEntry"/>
+    </Schema>
+
+    <Schema xmlns="http://docs.oasis-open.org/odata/ns/edm" Namespace="LogEntry.v1_10_1">
+      <Annotation Term="Redfish.OwningEntity" String="DMTF"/>
+      <Annotation Term="OData.Description" String="This version was created to update description for Resolution to recommend that an appropriate resolution is used."/>
+      <EntityType Name="LogEntry" BaseType="LogEntry.v1_10_0.LogEntry"/>
+    </Schema>
+
+    <Schema xmlns="http://docs.oasis-open.org/odata/ns/edm" Namespace="LogEntry.v1_11_0">
+      <Annotation Term="Redfish.OwningEntity" String="DMTF"/>
+      <Annotation Term="Redfish.Release" String="2021.4"/>
+
+      <EntityType Name="LogEntry" BaseType="LogEntry.v1_10_1.LogEntry">
+        <Property Name="Originator" Type="Edm.String" Nullable="false">
+          <Annotation Term="OData.Permissions" EnumMember="OData.Permission/Read"/>
+          <Annotation Term="OData.Description" String="The source of the log entry."/>
+          <Annotation Term="OData.LongDescription" String="This property shall contain the source of the log entry."/>
+        </Property>
+        <Property Name="OriginatorType" Type="LogEntry.v1_11_0.OriginatorTypes" Nullable="false">
+          <Annotation Term="OData.Permissions" EnumMember="OData.Permission/Read"/>
+          <Annotation Term="OData.Description" String="The type of originator data."/>
+          <Annotation Term="OData.LongDescription" String="This property shall contain the type of originator data."/>
+        </Property>
+      </EntityType>
+
+      <EnumType Name="OriginatorTypes">
+        <Member Name="Client">
+          <Annotation Term="OData.Description" String="A client of the service created this log entry."/>
+        </Member>
+        <Member Name="Internal">
+          <Annotation Term="OData.Description" String="A process running on the service created this log entry."/>
+        </Member>
+        <Member Name="SupportingService">
+          <Annotation Term="OData.Description" String="A process not running on the service but running on a supporting service, such as RDE implementations, UEFI, or host processes, created this log entry."/>
+        </Member>
+      </EnumType>
     </Schema>
 
   </edmx:DataServices>

--- a/static/redfish/v1/schema/Manager_v1.xml
+++ b/static/redfish/v1/schema/Manager_v1.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!---->
 <!--################################################################################       -->
-<!--# Redfish Schema:  Manager v1.13.0                                                     -->
+<!--# Redfish Schema:  Manager v1.14.0                                                     -->
 <!--#                                                                                      -->
 <!--# For a detailed change log, see the README file contained in the DSP8010 bundle,      -->
 <!--# available at http://www.dmtf.org/standards/redfish                                   -->
@@ -66,6 +66,9 @@
   </edmx:Reference>
   <edmx:Reference Uri="http://redfish.dmtf.org/schemas/v1/CertificateCollection_v1.xml">
     <edmx:Include Namespace="CertificateCollection"/>
+  </edmx:Reference>
+  <edmx:Reference Uri="http://redfish.dmtf.org/schemas/v1/ManagerDiagnosticData_v1.xml">
+    <edmx:Include Namespace="ManagerDiagnosticData"/>
   </edmx:Reference>
 
   <edmx:DataServices>
@@ -1284,7 +1287,30 @@
         <Property Name="Measurements" Type="Collection(SoftwareInventory.MeasurementBlock)" Nullable="false">
           <Annotation Term="OData.Description" String="An array of DSP0274-defined measurement blocks."/>
           <Annotation Term="OData.LongDescription" String="This property shall contain an array of DSP0274-defined measurement blocks."/>
+          <Annotation Term="Redfish.Revisions">
+            <Collection>
+              <Record>
+                <PropertyValue Property="Kind" EnumMember="Redfish.RevisionKind/Deprecated"/>
+                <PropertyValue Property="Version" String="v1_14_0"/>
+                <PropertyValue Property="Description" String="This property has been deprecated in favor of the ComponentIntegrity resource."/>
+              </Record>
+            </Collection>
+          </Annotation>
         </Property>
+      </EntityType>
+    </Schema>
+
+    <Schema xmlns="http://docs.oasis-open.org/odata/ns/edm" Namespace="Manager.v1_14_0">
+      <Annotation Term="Redfish.OwningEntity" String="DMTF"/>
+      <Annotation Term="Redfish.Release" String="2021.4"/>
+      <Annotation Term="OData.Description" String="This version was created to deprecate Measurements in favor of measurement reporting in the ComponentIntegrity resource."/>
+
+      <EntityType Name="Manager" BaseType="Manager.v1_13_0.Manager">
+        <NavigationProperty Name="ManagerDiagnosticData" Type="ManagerDiagnosticData.ManagerDiagnosticData">
+          <Annotation Term="OData.Permissions" EnumMember="OData.Permission/Read"/>
+          <Annotation Term="OData.Description" String="The diagnostic data for this manager."/>
+          <Annotation Term="OData.LongDescription" String="This property shall contain a link to a resource of type ManagerDiagnosticData that represents the diagnostic data for this manager."/>
+        </NavigationProperty>
       </EntityType>
     </Schema>
 

--- a/static/redfish/v1/schema/Memory_v1.xml
+++ b/static/redfish/v1/schema/Memory_v1.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!---->
 <!--################################################################################       -->
-<!--# Redfish Schema:  Memory v1.13.0                                                      -->
+<!--# Redfish Schema:  Memory v1.14.0                                                      -->
 <!--#                                                                                      -->
 <!--# For a detailed change log, see the README file contained in the DSP8010 bundle,      -->
 <!--# available at http://www.dmtf.org/standards/redfish                                   -->
@@ -1680,6 +1680,15 @@
         <Property Name="Measurements" Type="Collection(SoftwareInventory.MeasurementBlock)" Nullable="false">
           <Annotation Term="OData.Description" String="An array of DSP0274-defined measurement blocks."/>
           <Annotation Term="OData.LongDescription" String="This property shall contain an array of DSP0274-defined measurement blocks."/>
+          <Annotation Term="Redfish.Revisions">
+            <Collection>
+              <Record>
+                <PropertyValue Property="Kind" EnumMember="Redfish.RevisionKind/Deprecated"/>
+                <PropertyValue Property="Version" String="v1_14_0"/>
+                <PropertyValue Property="Description" String="This property has been deprecated in favor of the ComponentIntegrity resource."/>
+              </Record>
+            </Collection>
+          </Annotation>
         </Property>
       </EntityType>
 
@@ -1722,9 +1731,23 @@
           <Annotation Term="OData.Permissions" EnumMember="OData.Permission/ReadWrite"/>
           <Annotation Term="Redfish.ExcerptCopy" String="Range"/>
           <Annotation Term="OData.Description" String="Range of allowed operating speeds (MHz)."/>
-          <Annotation Term="OData.LongDescription" String="This property shall contain the operating speed control excerpt for this resource."/>
+          <Annotation Term="OData.LongDescription" String="This property shall contain the operating speed control, in megahertz units, for this resource.  The value of the DataSourceUri property, if present, shall reference a resource of type Control with the ControlType property containing the value of `FrequencyMHz`."/>
         </NavigationProperty>
       </EntityType>
+    </Schema>
+
+    <Schema xmlns="http://docs.oasis-open.org/odata/ns/edm" Namespace="Memory.v1_13_1">
+      <Annotation Term="Redfish.OwningEntity" String="DMTF"/>
+      <Annotation Term="OData.Description" String="This version was created to update descriptions to tie excerpt property definitions to a specific type of Sensor or Control."/>
+      <EntityType Name="Memory" BaseType="Memory.v1_13_0.Memory"/>
+    </Schema>
+
+    <Schema xmlns="http://docs.oasis-open.org/odata/ns/edm" Namespace="Memory.v1_14_0">
+      <Annotation Term="Redfish.OwningEntity" String="DMTF"/>
+      <Annotation Term="Redfish.Release" String="2021.4"/>
+      <Annotation Term="OData.Description" String="This version was created to deprecate Measurements in favor of measurement reporting in the ComponentIntegrity resource."/>
+
+      <EntityType Name="Memory" BaseType="Memory.v1_13_1.Memory"/>
     </Schema>
 
   </edmx:DataServices>

--- a/static/redfish/v1/schema/PCIeDevice_v1.xml
+++ b/static/redfish/v1/schema/PCIeDevice_v1.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!---->
 <!--################################################################################       -->
-<!--# Redfish Schema:  PCIeDevice v1.8.0                                                   -->
+<!--# Redfish Schema:  PCIeDevice v1.9.0                                                   -->
 <!--#                                                                                      -->
 <!--# For a detailed change log, see the README file contained in the DSP8010 bundle,      -->
 <!--# available at http://www.dmtf.org/standards/redfish                                   -->
@@ -525,6 +525,91 @@
           <Annotation Term="OData.LongDescription" String="This property shall contain the total number of NAKs issued on the PCIe link by the receiver.  A NAK is issued by the receiver when it detects that a TLP from this device was missed.  This could be because this device did not transmit it, or because the receiver could not properly decode the packet."/>
         </Property>
       </ComplexType>
+    </Schema>
+
+    <Schema xmlns="http://docs.oasis-open.org/odata/ns/edm" Namespace="PCIeDevice.v1_9_0">
+      <Annotation Term="Redfish.OwningEntity" String="DMTF"/>
+      <Annotation Term="Redfish.Release" String="2021.4"/>
+
+      <EntityType Name="PCIeDevice" BaseType="PCIeDevice.v1_8_0.PCIeDevice">
+        <Property Name="Slot" Type="PCIeDevice.v1_9_0.Slot">
+          <Annotation Term="OData.Description" String="Information about the slot for this PCIe device."/>
+          <Annotation Term="OData.LongDescription" String="This property shall contain information about the PCIe slot for this PCIe device."/>
+        </Property>
+      </EntityType>
+
+      <ComplexType Name="Slot">
+        <Annotation Term="OData.AdditionalProperties" Bool="false"/>
+        <Annotation Term="OData.Description" String="The PCIe slot associated with a PCIe device."/>
+        <Annotation Term="OData.LongDescription" String="This object shall contain properties that describe the PCIe slot associated with a PCIe device."/>
+        <Property Name="PCIeType" Type="PCIeDevice.PCIeTypes">
+          <Annotation Term="OData.Permissions" EnumMember="OData.Permission/Read"/>
+          <Annotation Term="OData.Description" String="The PCIe specification this slot supports."/>
+          <Annotation Term="OData.LongDescription" String="This property shall contain the maximum PCIe specification that this slot supports."/>
+        </Property>
+        <Property Name="SlotType" Type="PCIeDevice.v1_9_0.SlotType">
+          <Annotation Term="OData.Permissions" EnumMember="OData.Permission/Read"/>
+          <Annotation Term="OData.Description" String="The PCIe slot type."/>
+          <Annotation Term="OData.LongDescription" String="This property shall contain the PCIe slot type."/>
+        </Property>
+        <Property Name="Lanes" Type="Edm.Int64">
+          <Annotation Term="OData.Permissions" EnumMember="OData.Permission/Read"/>
+          <Annotation Term="OData.Description" String="The number of PCIe lanes supported by this slot."/>
+          <Annotation Term="OData.LongDescription" String="This property shall contain the maximum number of PCIe lanes supported by the slot."/>
+          <Annotation Term="Validation.Maximum" Int="32"/>
+        </Property>
+        <Property Name="Location" Type="Resource.Location" Nullable="false">
+          <Annotation Term="OData.Description" String="The location of the PCIe slot."/>
+          <Annotation Term="OData.LongDescription" String="This property shall contain part location information, including a ServiceLabel property, of the associated PCIe slot."/>
+        </Property>
+        <Property Name="LaneSplitting" Type="PCIeDevice.v1_9_0.LaneSplittingType">
+          <Annotation Term="OData.Permissions" EnumMember="OData.Permission/Read"/>
+          <Annotation Term="OData.Description" String="The lane splitting strategy used in the PCIe slot."/>
+          <Annotation Term="OData.LongDescription" String="This property shall contain lane splitting information of the associated PCIe slot."/>
+        </Property>
+      </ComplexType>
+
+      <EnumType Name="SlotType">
+        <Member Name="FullLength">
+          <Annotation Term="OData.Description" String="Full-Length PCIe slot."/>
+        </Member>
+        <Member Name="HalfLength">
+          <Annotation Term="OData.Description" String="Half-Length PCIe slot."/>
+        </Member>
+        <Member Name="LowProfile">
+          <Annotation Term="OData.Description" String="Low-Profile or Slim PCIe slot."/>
+        </Member>
+        <Member Name="Mini">
+          <Annotation Term="OData.Description" String="Mini PCIe slot."/>
+        </Member>
+        <Member Name="M2">
+          <Annotation Term="OData.Description" String="PCIe M.2 slot."/>
+        </Member>
+        <Member Name="OEM">
+          <Annotation Term="OData.Description" String="An OEM-specific slot."/>
+        </Member>
+        <Member Name="OCP3Small">
+          <Annotation Term="OData.Description" String="Open Compute Project 3.0 small form factor slot."/>
+        </Member>
+        <Member Name="OCP3Large">
+          <Annotation Term="OData.Description" String="Open Compute Project 3.0 large form factor slot."/>
+        </Member>
+        <Member Name="U2">
+          <Annotation Term="OData.Description" String="U.2 / SFF-8639 slot or bay."/>
+        </Member>
+      </EnumType>
+
+      <EnumType Name="LaneSplittingType">
+        <Member Name="None">
+          <Annotation Term="OData.Description" String="The slot has no lane splitting."/>
+        </Member>
+        <Member Name="Bridged">
+          <Annotation Term="OData.Description" String="The slot has a bridge to share the lanes with associated devices."/>
+        </Member>
+        <Member Name="Bifurcated">
+          <Annotation Term="OData.Description" String="The slot is bifurcated to split the lanes with associated devices."/>
+        </Member>
+      </EnumType>
     </Schema>
 
   </edmx:DataServices>

--- a/static/redfish/v1/schema/Processor_v1.xml
+++ b/static/redfish/v1/schema/Processor_v1.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!---->
 <!--################################################################################       -->
-<!--# Redfish Schema:  Processor v1.13.0                                                   -->
+<!--# Redfish Schema:  Processor v1.14.0                                                   -->
 <!--#                                                                                      -->
 <!--# For a detailed change log, see the README file contained in the DSP8010 bundle,      -->
 <!--# available at http://www.dmtf.org/standards/redfish                                   -->
@@ -1437,6 +1437,15 @@
         <Property Name="Measurements" Type="Collection(SoftwareInventory.MeasurementBlock)" Nullable="false">
           <Annotation Term="OData.Description" String="An array of DSP0274-defined measurement blocks."/>
           <Annotation Term="OData.LongDescription" String="This property shall contain an array of DSP0274-defined measurement blocks."/>
+          <Annotation Term="Redfish.Revisions">
+            <Collection>
+              <Record>
+                <PropertyValue Property="Kind" EnumMember="Redfish.RevisionKind/Deprecated"/>
+                <PropertyValue Property="Version" String="v1_14_0"/>
+                <PropertyValue Property="Description" String="This property has been deprecated in favor of the ComponentIntegrity resource."/>
+              </Record>
+            </Collection>
+          </Annotation>
         </Property>
       </EntityType>
 
@@ -1523,7 +1532,7 @@
           <Annotation Term="OData.Permissions" EnumMember="OData.Permission/ReadWrite"/>
           <Annotation Term="Redfish.ExcerptCopy" String="Range"/>
           <Annotation Term="OData.Description" String="Range of allowed operating speeds (MHz)."/>
-          <Annotation Term="OData.LongDescription" String="This property shall contain the operating speed control excerpt for this resource."/>
+          <Annotation Term="OData.LongDescription" String="This property shall contain the operating speed control, measured in megahertz units, for this resource.  The value of the DataSourceUri property, if present, shall reference a resource of type Control with the ControlType property containing the value of `FrequencyMHz`."/>
         </NavigationProperty>
         <NavigationProperty Name="Ports" Type="PortCollection.PortCollection" ContainsTarget="true" Nullable="false">
           <Annotation Term="OData.Permissions" EnumMember="OData.Permission/Read"/>
@@ -1549,6 +1558,20 @@
           <Annotation Term="OData.AutoExpandReferences"/>
         </NavigationProperty>
       </ComplexType>
+    </Schema>
+
+    <Schema xmlns="http://docs.oasis-open.org/odata/ns/edm" Namespace="Processor.v1_13_1">
+      <Annotation Term="Redfish.OwningEntity" String="DMTF"/>
+      <Annotation Term="OData.Description" String="This version was created to update descriptions to tie excerpt property definitions to a specific type of Sensor or Control."/>
+      <EntityType Name="Processor" BaseType="Processor.v1_13_0.Processor"/>
+    </Schema>
+
+    <Schema xmlns="http://docs.oasis-open.org/odata/ns/edm" Namespace="Processor.v1_14_0">
+      <Annotation Term="Redfish.OwningEntity" String="DMTF"/>
+      <Annotation Term="Redfish.Release" String="2021.4"/>
+      <Annotation Term="OData.Description" String="This version was created to deprecate Measurements in favor of measurement reporting in the ComponentIntegrity resource."/>
+
+      <EntityType Name="Processor" BaseType="Processor.v1_13_1.Processor"/>
     </Schema>
 
   </edmx:DataServices>

--- a/static/redfish/v1/schema/Resource_v1.xml
+++ b/static/redfish/v1/schema/Resource_v1.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!---->
 <!--################################################################################       -->
-<!--# Redfish Schema:  Resource v1.13.0                                                    -->
+<!--# Redfish Schema:  Resource v1.14.0                                                    -->
 <!--#                                                                                      -->
 <!--# For a detailed change log, see the README file contained in the DSP8010 bundle,      -->
 <!--# available at http://www.dmtf.org/standards/redfish                                   -->
@@ -113,7 +113,7 @@
         </Property>
         <Property Name="Conditions" Type="Collection(Resource.Condition)">
           <Annotation Term="OData.Description" String="Conditions in this resource that require attention."/>
-          <Annotation Term="OData.LongDescription" String="This property shall represent the active conditions requiring attention in this or a related resource that affects the Health or HealthRollup of this resource."/>
+          <Annotation Term="OData.LongDescription" String="This property shall represent the active conditions requiring attention in this or a related resource that affects the Health or HealthRollup of this resource.  The service may roll up multiple conditions originating from a resource, using the `ConditionInRelatedResource` message from Base Message Registry."/>
           <Annotation Term="Redfish.Revisions">
             <Collection>
               <Record>
@@ -172,6 +172,19 @@
           <Annotation Term="OData.LongDescription" String="This property shall contain a link to a resource of type LogEntry that represents the log entry created for this condition."/>
           <Annotation Term="OData.AutoExpandReferences"/>
         </NavigationProperty>
+        <Property Name="Resolution" Type="Edm.String" Nullable="false">
+          <Annotation Term="OData.Permissions" EnumMember="OData.Permission/Read"/>
+          <Annotation Term="OData.Description" String="Suggestions on how to resolve the condition."/>
+          <Annotation Term="OData.LongDescription" String="This property shall contain the resolution of the condition.  Services should replace the resolution defined in the message registry with a more specific resolution."/>
+          <Annotation Term="Redfish.Revisions">
+            <Collection>
+              <Record>
+                <PropertyValue Property="Kind" EnumMember="Redfish.RevisionKind/Added"/>
+                <PropertyValue Property="Version" String="v1_14_0"/>
+              </Record>
+            </Collection>
+          </Annotation>
+        </Property>
       </ComplexType>
 
       <EnumType Name="State">
@@ -626,6 +639,18 @@
               <Record>
                 <PropertyValue Property="Kind" EnumMember="Redfish.RevisionKind/Added"/>
                 <PropertyValue Property="Version" String="v1_10_0"/>
+              </Record>
+            </Collection>
+          </Annotation>
+        </Member>
+        <Member Name="MACAddress">
+          <Annotation Term="OData.Description" String="The media access control address (MAC address)."/>
+          <Annotation Term="OData.LongDescription" String="This durable name shall be a media access control address (MAC address), which is a unique identifier assigned to a network interface controller (NIC) for use as a network address.  This value should not be used if a more specific type of identifier is available.  The DurableName property shall follow the pattern '^([0-9A-Fa-f]{2}[:-]){5}([0-9A-Fa-f]{2})$', where the most significant octet is first."/>
+          <Annotation Term="Redfish.Revisions">
+            <Collection>
+              <Record>
+                <PropertyValue Property="Kind" EnumMember="Redfish.RevisionKind/Added"/>
+                <PropertyValue Property="Version" String="v1_14_0"/>
               </Record>
             </Collection>
           </Annotation>
@@ -1337,7 +1362,7 @@
     <Schema xmlns="http://docs.oasis-open.org/odata/ns/edm" Namespace="Resource.v1_6_0">
       <Annotation Term="Redfish.OwningEntity" String="DMTF"/>
       <Annotation Term="Redfish.Release" String="2017.3"/>
-      <Annotation Term="OData.Description" String="This version was created to add GPS Coordinated to Location and enumerations for DurableNameFormat for NVMe fabric extension."/>
+      <Annotation Term="OData.Description" String="This version was created to add GPS coordinates to Location and enumerations for DurableNameFormat for NVMe fabric extension."/>
 
       <ComplexType Name="Location" BaseType="Resource.v1_5_0.Location">
         <Property Name="Longitude" Type="Edm.Decimal" DefaultValue="0">
@@ -1355,7 +1380,7 @@
         <Property Name="AltitudeMeters" Type="Edm.Decimal" DefaultValue="0">
           <Annotation Term="OData.Permissions" EnumMember="OData.Permission/ReadWrite"/>
           <Annotation Term="OData.Description" String="The altitude of the resource in meters."/>
-          <Annotation Term="OData.LongDescription" String="This property shall contain the altitude of the resource in meters."/>
+          <Annotation Term="OData.LongDescription" String="This property shall contain the altitude of the resource, in meters units, defined as the elevation above sea level."/>
           <Annotation Term="Measures.Unit" String="m"/>
         </Property>
       </ComplexType>
@@ -1404,6 +1429,11 @@
     <Schema xmlns="http://docs.oasis-open.org/odata/ns/edm" Namespace="Resource.v1_6_9">
       <Annotation Term="Redfish.OwningEntity" String="DMTF"/>
       <Annotation Term="OData.Description" String="This version was created to correct the description for LocationType within PartLocation.  It was also created to clarify the descriptions for Id, Name, Description, and MemberId to be consistent with usage in the specification."/>
+    </Schema>
+
+    <Schema xmlns="http://docs.oasis-open.org/odata/ns/edm" Namespace="Resource.v1_6_10">
+      <Annotation Term="Redfish.OwningEntity" String="DMTF"/>
+      <Annotation Term="OData.Description" String="This version was created to enhance the description of AltitudeMeters."/>
     </Schema>
 
     <Schema xmlns="http://docs.oasis-open.org/odata/ns/edm" Namespace="Resource.v1_7_0">
@@ -1495,6 +1525,11 @@
       <Annotation Term="OData.Description" String="This version was created to correct the description for LocationType within PartLocation.  It was also created to clarify the descriptions for Id, Name, Description, and MemberId to be consistent with usage in the specification."/>
     </Schema>
 
+    <Schema xmlns="http://docs.oasis-open.org/odata/ns/edm" Namespace="Resource.v1_7_9">
+      <Annotation Term="Redfish.OwningEntity" String="DMTF"/>
+      <Annotation Term="OData.Description" String="This version was created to enhance the description of AltitudeMeters."/>
+    </Schema>
+
     <Schema xmlns="http://docs.oasis-open.org/odata/ns/edm" Namespace="Resource.v1_8_0">
       <Annotation Term="Redfish.OwningEntity" String="DMTF"/>
       <Annotation Term="Redfish.Release" String="2018.3"/>
@@ -1541,6 +1576,11 @@
       <Annotation Term="OData.Description" String="This version was created to correct the description for LocationType within PartLocation.  It was also created to clarify the descriptions for Id, Name, Description, and MemberId to be consistent with usage in the specification."/>
     </Schema>
 
+    <Schema xmlns="http://docs.oasis-open.org/odata/ns/edm" Namespace="Resource.v1_8_9">
+      <Annotation Term="Redfish.OwningEntity" String="DMTF"/>
+      <Annotation Term="OData.Description" String="This version was created to enhance the description of AltitudeMeters."/>
+    </Schema>
+
     <Schema xmlns="http://docs.oasis-open.org/odata/ns/edm" Namespace="Resource.v1_9_0">
       <Annotation Term="Redfish.OwningEntity" String="DMTF"/>
       <Annotation Term="Redfish.Release" String="2019.4"/>
@@ -1577,6 +1617,11 @@
       <Annotation Term="OData.Description" String="This version was created to correct the description for LocationType within PartLocation.  It was also created to clarify the descriptions for Id, Name, Description, and MemberId to be consistent with usage in the specification."/>
     </Schema>
 
+    <Schema xmlns="http://docs.oasis-open.org/odata/ns/edm" Namespace="Resource.v1_9_7">
+      <Annotation Term="Redfish.OwningEntity" String="DMTF"/>
+      <Annotation Term="OData.Description" String="This version was created to enhance the description of AltitudeMeters."/>
+    </Schema>
+
     <Schema xmlns="http://docs.oasis-open.org/odata/ns/edm" Namespace="Resource.v1_10_0">
       <Annotation Term="Redfish.OwningEntity" String="DMTF"/>
       <Annotation Term="Redfish.Release" String="2020.3"/>
@@ -1598,6 +1643,11 @@
       <Annotation Term="OData.Description" String="This version was created to correct the description for LocationType within PartLocation.  It was also created to clarify the descriptions for Id, Name, Description, and MemberId to be consistent with usage in the specification."/>
     </Schema>
 
+    <Schema xmlns="http://docs.oasis-open.org/odata/ns/edm" Namespace="Resource.v1_10_4">
+      <Annotation Term="Redfish.OwningEntity" String="DMTF"/>
+      <Annotation Term="OData.Description" String="This version was created to enhance the description of AltitudeMeters."/>
+    </Schema>
+
     <Schema xmlns="http://docs.oasis-open.org/odata/ns/edm" Namespace="Resource.v1_11_0">
       <Annotation Term="Redfish.OwningEntity" String="DMTF"/>
       <Annotation Term="Redfish.Release" String="2020.4"/>
@@ -1614,6 +1664,11 @@
       <Annotation Term="OData.Description" String="This version was created to correct the description for LocationType within PartLocation.  It was also created to clarify the descriptions for Id, Name, Description, and MemberId to be consistent with usage in the specification."/>
     </Schema>
 
+    <Schema xmlns="http://docs.oasis-open.org/odata/ns/edm" Namespace="Resource.v1_11_3">
+      <Annotation Term="Redfish.OwningEntity" String="DMTF"/>
+      <Annotation Term="OData.Description" String="This version was created to enhance the description of AltitudeMeters.  It was also added to improve the description of Conditions."/>
+    </Schema>
+
     <Schema xmlns="http://docs.oasis-open.org/odata/ns/edm" Namespace="Resource.v1_12_0">
       <Annotation Term="Redfish.OwningEntity" String="DMTF"/>
       <Annotation Term="Redfish.Release" String="2021.1"/>
@@ -1625,10 +1680,26 @@
       <Annotation Term="OData.Description" String="This version was created to correct the description for LocationType within PartLocation.  It was also created to clarify the descriptions for Id, Name, Description, and MemberId to be consistent with usage in the specification."/>
     </Schema>
 
+    <Schema xmlns="http://docs.oasis-open.org/odata/ns/edm" Namespace="Resource.v1_12_2">
+      <Annotation Term="Redfish.OwningEntity" String="DMTF"/>
+      <Annotation Term="OData.Description" String="This version was created to enhance the description of AltitudeMeters.  It was also added to improve the description of Conditions."/>
+    </Schema>
+
     <Schema xmlns="http://docs.oasis-open.org/odata/ns/edm" Namespace="Resource.v1_13_0">
       <Annotation Term="Redfish.OwningEntity" String="DMTF"/>
       <Annotation Term="Redfish.Release" String="2021.2"/>
       <Annotation Term="OData.Description" String="This version was created to add `Embedded` to LocationType within PartLocation.  It was also to add the `Pause`, `Resume`, and `Suspend` enumerations to ResetType.  It was also created to add `Paused` to PowerState."/>
+    </Schema>
+
+    <Schema xmlns="http://docs.oasis-open.org/odata/ns/edm" Namespace="Resource.v1_13_1">
+      <Annotation Term="Redfish.OwningEntity" String="DMTF"/>
+      <Annotation Term="OData.Description" String="This version was created to enhance the description of AltitudeMeters.  It was also added to improve the description of Conditions."/>
+    </Schema>
+
+    <Schema xmlns="http://docs.oasis-open.org/odata/ns/edm" Namespace="Resource.v1_14_0">
+      <Annotation Term="Redfish.OwningEntity" String="DMTF"/>
+      <Annotation Term="Redfish.Release" String="2021.4"/>
+      <Annotation Term="OData.Description" String="This version was created to add Resolution to the Conditions property in Status.  It was also was created to add `MACAddress` to DurableNameFormat."/>
     </Schema>
 
   </edmx:DataServices>

--- a/static/redfish/v1/schema/Sensor_v1.xml
+++ b/static/redfish/v1/schema/Sensor_v1.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!---->
 <!--################################################################################       -->
-<!--# Redfish Schema:  Sensor v1.4.0                                                       -->
+<!--# Redfish Schema:  Sensor v1.5.0                                                       -->
 <!--#                                                                                      -->
 <!--# For a detailed change log, see the README file contained in the DSP8010 bundle,      -->
 <!--# available at http://www.dmtf.org/standards/redfish                                   -->
@@ -237,7 +237,7 @@
 
         <Property Name="ApparentVA" Type="Edm.Decimal">
           <Annotation Term="OData.Permissions" EnumMember="OData.Permission/Read"/>
-          <Annotation Term="OData.Description" String="The product of voltage and current for an AC circuit, in Volt-Ampere units."/>
+          <Annotation Term="OData.Description" String="The product of voltage and current for an AC circuit, in volt-ampere units."/>
           <Annotation Term="OData.LongDescription" String="This property shall contain the product of voltage (RMS) multiplied by current (RMS) for a circuit.  This property can appear in sensors of the Power ReadingType, and shall not appear in sensors of other ReadingType values."/>
           <Annotation Term="Measures.Unit" String="V.A"/>
           <Annotation Term="Redfish.Excerpt" String="Power,PowerArray"/>
@@ -252,8 +252,8 @@
         <Property Name="PowerFactor" Type="Edm.Decimal">
           <Annotation Term="OData.Permissions" EnumMember="OData.Permission/Read"/>
           <Annotation Term="OData.Description" String="The power factor for this sensor."/>
-          <Annotation Term="OData.LongDescription" String="This property shall identify the quotient of real power (W) and apparent power (VA) for a circuit.  PowerFactor is expressed in unit-less 1/100ths.  This property can appear in sensors of the Power ReadingType, and shall not appear in sensors of other ReadingType values."/>
-          <Annotation Term="Validation.Minimum" Int="0"/>
+          <Annotation Term="OData.LongDescription" String="This property shall identify the quotient of real power (W) and apparent power (VA) for a circuit.  PowerFactor is expressed in unit-less 1/100ths.  This property can appear in sensors containing a ReadingType value of `Power`, and shall not appear in sensors of other ReadingType values."/>
+          <Annotation Term="Validation.Minimum" Int="-1"/>
           <Annotation Term="Validation.Maximum" Int="1"/>
           <Annotation Term="Redfish.Excerpt" String="Power,PowerArray"/>
         </Property>
@@ -430,24 +430,24 @@
 
       <EnumType Name="ReadingType">
         <Member Name="Temperature">
-          <Annotation Term="OData.Description" String="Temperature."/>
+          <Annotation Term="OData.Description" String="Temperature (C)."/>
           <Annotation Term="OData.LongDescription" String="This value shall indicate a temperature measurement, in degrees Celsius units, and the ReadingUnits value shall be 'Cel'."/>
         </Member>
         <Member Name="Humidity">
-          <Annotation Term="OData.Description" String="Relative Humidity."/>
+          <Annotation Term="OData.Description" String="Relative humidity (percent)."/>
           <Annotation Term="OData.LongDescription" String="This value shall indicate a relative humidity measurement, in percent units, and the ReadingUnits value shall be '%'."/>
         </Member>
         <Member Name="Power">
-          <Annotation Term="OData.Description" String="Power."/>
-          <Annotation Term="OData.LongDescription" String="This value shall indicate the arithmetic mean of product terms of instantaneous voltage and current values measured over integer number of line cycles for a circuit, in Watt units, and the ReadingUnits value shall be 'W'."/>
+          <Annotation Term="OData.Description" String="Power (W)."/>
+          <Annotation Term="OData.LongDescription" String="This value shall indicate the arithmetic mean of product terms of instantaneous voltage and current values measured over integer number of line cycles for a circuit, in watt units, and the ReadingUnits value shall be 'W'."/>
         </Member>
         <Member Name="EnergykWh">
           <Annotation Term="OData.Description" String="Energy (kWh)."/>
           <Annotation Term="OData.LongDescription" String="This value shall indicate the energy, integral of real power over time, of the monitored item.  If representing metered power consumption the value shall reflect the power consumption since the sensor metrics were last reset.  The value of the Reading property shall be in kilowatt-hour units and the ReadingUnits value shall be `kW.h`.  This value is used for large-scale energy consumption measurements, while EnergyJoules and EnergyWh are used for device-level consumption measurements."/>
         </Member>
         <Member Name="EnergyJoules">
-          <Annotation Term="OData.Description" String="Energy (Joules)."/>
-          <Annotation Term="OData.LongDescription" String="This value shall indicate the energy, integral of real power over time, of the monitored item.  If representing metered power consumption the value shall reflect the power consumption since the sensor metrics were last reset.  The value of the Reading property shall be in Joule units and the ReadingUnits value shall be `J`.  This value is used for device-level energy consumption measurements, while EnergykWh is used for large-scale consumption measurements."/>
+          <Annotation Term="OData.Description" String="Energy (J)."/>
+          <Annotation Term="OData.LongDescription" String="This value shall indicate the energy, integral of real power over time, of the monitored item.  If representing metered power consumption the value shall reflect the power consumption since the sensor metrics were last reset.  The value of the Reading property shall be in joule units and the ReadingUnits value shall be `J`.  This value is used for device-level energy consumption measurements, while EnergykWh is used for large-scale consumption measurements."/>
         </Member>
         <Member Name="EnergyWh">
           <Annotation Term="OData.Description" String="Energy (Wh)."/>
@@ -463,7 +463,7 @@
         </Member>
         <Member Name="ChargeAh">
           <Annotation Term="OData.Description" String="Charge (Ah)."/>
-          <Annotation Term="OData.LongDescription" String="This value shall indicate the amount of charge of the monitored item.  If representing metered power consumption,  integral of real power over time, the value shall reflect the power consumption since the sensor metrics were last reset.  The value of the Reading property shall be in amp-hour units and the ReadingUnits value shall be `A.h`."/>
+          <Annotation Term="OData.LongDescription" String="This value shall indicate the amount of charge of the monitored item.  If representing metered power consumption,  integral of real power over time, the value shall reflect the power consumption since the sensor metrics were last reset.  The value of the Reading property shall be in ampere-hour units and the ReadingUnits value shall be `A.h`."/>
           <Annotation Term="Redfish.Revisions">
             <Collection>
               <Record>
@@ -474,53 +474,77 @@
           </Annotation>
         </Member>
         <Member Name="Voltage">
-          <Annotation Term="OData.Description" String="Voltage (AC or DC)."/>
-          <Annotation Term="OData.LongDescription" String="This value shall indicate a measurement of the root mean square (RMS) of instantaneous voltage calculated over an integer number of line cycles for a circuit.  Voltage is expressed in Volts units and the ReadingUnits value shall be `V`."/>
+          <Annotation Term="OData.Description" String="Voltage (VAC or VDC)."/>
+          <Annotation Term="OData.LongDescription" String="This value shall indicate a measurement of the root mean square (RMS) of instantaneous voltage calculated over an integer number of line cycles for a circuit.  Voltage is expressed in volt units and the ReadingUnits value shall be `V`."/>
         </Member>
         <Member Name="Current">
-          <Annotation Term="OData.Description" String="Current."/>
-          <Annotation Term="OData.LongDescription" String="This value shall indicate a measurement of the root mean square (RMS) of instantaneous current calculated over an integer number of line cycles for a circuit.  Current is expressed in Amperes units and the ReadingUnits value shall be `A`."/>
+          <Annotation Term="OData.Description" String="Current (A)."/>
+          <Annotation Term="OData.LongDescription" String="This value shall indicate a measurement of the root mean square (RMS) of instantaneous current calculated over an integer number of line cycles for a circuit.  Current is expressed in ampere units and the ReadingUnits value shall be `A`."/>
         </Member>
         <Member Name="Frequency">
-          <Annotation Term="OData.Description" String="Frequency."/>
-          <Annotation Term="OData.LongDescription" String="This value shall indicate a frequency measurement, in Hertz units, and the ReadingUnits value shall be `Hz`."/>
+          <Annotation Term="OData.Description" String="Frequency (Hz)."/>
+          <Annotation Term="OData.LongDescription" String="This value shall indicate a frequency measurement, in hertz units, and the ReadingUnits value shall be `Hz`."/>
         </Member>
         <Member Name="Pressure">
-          <Annotation Term="OData.Description" String="Pressure."/>
-          <Annotation Term="OData.LongDescription" String="This value shall indicate a measurement of force applied perpendicular to the surface of an object per unit area over which that force is distributed.  The ReadingUnits shall be `Pa`."/>
+          <Annotation Term="OData.Description" String="Pressure (Pa)."/>
+          <Annotation Term="OData.LongDescription" String="This value shall indicate a measurement of force, in pascal units, applied perpendicular to the surface of an object per unit area over which that force is distributed.  The ReadingUnits shall be `Pa`."/>
+        </Member>
+        <Member Name="PressurekPa">
+          <Annotation Term="OData.Description" String="Pressure (kPa)."/>
+          <Annotation Term="OData.LongDescription" String="This value shall indicate a measurement of pressure, in kilopascal units, relative to atmospheric pressure.  The ReadingUnits value shall be `kPa`."/>
+          <Annotation Term="Redfish.Revisions">
+            <Collection>
+              <Record>
+                <PropertyValue Property="Kind" EnumMember="Redfish.RevisionKind/Added"/>
+                <PropertyValue Property="Version" String="v1_5_0"/>
+              </Record>
+            </Collection>
+          </Annotation>
         </Member>
         <Member Name="LiquidLevel">
-          <Annotation Term="OData.Description" String="Liquid level."/>
-          <Annotation Term="OData.LongDescription" String="This value shall indicate a measurement of fluid height relative to a specified vertical datum and the ReadingUnits value shall be `cm`."/>
+          <Annotation Term="OData.Description" String="Liquid level (cm)."/>
+          <Annotation Term="OData.LongDescription" String="This value shall indicate a measurement of fluid height, in centimeter units, relative to a specified vertical datum and the ReadingUnits value shall be `cm`."/>
         </Member>
         <Member Name="Rotational">
-          <Annotation Term="OData.Description" String="Rotational."/>
-          <Annotation Term="OData.LongDescription" String="This value shall indicate a measurement of rotational frequency, in revolutions per minute unit, and the ReadingUnits value shall be `RPM`."/>
+          <Annotation Term="OData.Description" String="Rotational (RPM)."/>
+          <Annotation Term="OData.LongDescription" String="This value shall indicate a measurement of rotational frequency, in revolutions per minute unit, and the ReadingUnits value shall be either `{rev}/min`, which is preferred, or `RPM`, which is a deprecated value."/>
         </Member>
         <Member Name="AirFlow">
-          <Annotation Term="OData.Description" String="Airflow."/>
-          <Annotation Term="OData.LongDescription" String="This value shall indicate a measurement of a volume of gas per unit of time that flows through a particular junction.  The ReadingUnits shall be `cft_i/min`."/>
+          <Annotation Term="OData.Description" String="Airflow (cu ft/min)."/>
+          <Annotation Term="OData.LongDescription" String="This value shall indicate a measurement of a volume of gas per unit of time, in cubic feet per minute units, that flows through a particular junction.  The ReadingUnits shall be `[ft_i]3/min`."/>
         </Member>
         <Member Name="LiquidFlow">
-          <Annotation Term="OData.Description" String="Liquid flow."/>
-          <Annotation Term="OData.LongDescription" String="This value shall indicate a measurement of a volume of liquid per unit of time that flows through a particular junction.  The ReadingUnits shall be `L/s`."/>
+          <Annotation Term="OData.Description" String="Liquid flow (L/s)."/>
+          <Annotation Term="OData.LongDescription" String="This value shall indicate a measurement of a volume of liquid per unit of time, in liters per second units, that flows through a particular junction.  The ReadingUnits shall be `L/s`."/>
         </Member>
         <Member Name="Barometric">
-          <Annotation Term="OData.Description" String="Barometric pressure."/>
-          <Annotation Term="OData.LongDescription" String="This value shall indicate a measurement of barometric pressure, in millimeters, of a mercury column, and the ReadingUnits value shall be `mm[Hg]`."/>
+          <Annotation Term="OData.Description" String="Barometric pressure (mm)."/>
+          <Annotation Term="OData.LongDescription" String="This value shall indicate a measurement of barometric pressure, in millimeters of a mercury column, and the ReadingUnits value shall be `mm[Hg]`."/>
         </Member>
         <Member Name="Altitude">
-          <Annotation Term="OData.Description" String="Altitude."/>
-          <Annotation Term="OData.LongDescription" String="This value shall indicate a measurement of altitude, in meter units, and the ReadingUnits value shall be `m`."/>
+          <Annotation Term="OData.Description" String="Altitude (m)."/>
+          <Annotation Term="OData.LongDescription" String="This value shall indicate a measurement of altitude, in meter units, defined as the elevation above sea level.  The ReadingUnits value shall be `m`."/>
         </Member>
         <Member Name="Percent">
-          <Annotation Term="OData.Description" String="Percent."/>
+          <Annotation Term="OData.Description" String="Percent (%)."/>
           <Annotation Term="OData.LongDescription" String="This value shall indicate a percentage measurement, in percent units, and the ReadingUnits value shall be `%`."/>
           <Annotation Term="Redfish.Revisions">
             <Collection>
               <Record>
                 <PropertyValue Property="Kind" EnumMember="Redfish.RevisionKind/Added"/>
                 <PropertyValue Property="Version" String="v1_1_0"/>
+              </Record>
+            </Collection>
+          </Annotation>
+        </Member>
+        <Member Name="AbsoluteHumidity">
+          <Annotation Term="OData.Description" String="Absolute humidity (g/cu m)."/>
+          <Annotation Term="OData.LongDescription" String="This value shall indicate an absolute (volumetric) humidity measurement, in grams per cubic meter units, and the ReadingUnits value shall be `g/m3`."/>
+          <Annotation Term="Redfish.Revisions">
+            <Collection>
+              <Record>
+                <PropertyValue Property="Kind" EnumMember="Redfish.RevisionKind/Added"/>
+                <PropertyValue Property="Version" String="v1_5_0"/>
               </Record>
             </Collection>
           </Annotation>
@@ -568,6 +592,12 @@
       <Annotation Term="Redfish.OwningEntity" String="DMTF"/>
       <Annotation Term="OData.Description" String="This version was created to correct various typographical errors."/>
       <EntityType Name="Sensor" BaseType="Sensor.v1_0_6.Sensor"/>
+    </Schema>
+
+    <Schema xmlns="http://docs.oasis-open.org/odata/ns/edm" Namespace="Sensor.v1_0_8">
+      <Annotation Term="Redfish.OwningEntity" String="DMTF"/>
+      <Annotation Term="OData.Description" String="This version was created to add units to ReadingType descriptions.  It was also created to update the units of AirFlow to remove the deprecated format and the units of SpeedRPM to use the available UCUM format.  It was also created to correct various typographical errors.  It was also created to correct the minimum value for PowerFactor."/>
+      <EntityType Name="Sensor" BaseType="Sensor.v1_0_7.Sensor"/>
     </Schema>
 
     <Schema xmlns="http://docs.oasis-open.org/odata/ns/edm" Namespace="Sensor.v1_1_0">
@@ -642,6 +672,12 @@
       <EntityType Name="Sensor" BaseType="Sensor.v1_1_2.Sensor"/>
     </Schema>
 
+    <Schema xmlns="http://docs.oasis-open.org/odata/ns/edm" Namespace="Sensor.v1_1_4">
+      <Annotation Term="Redfish.OwningEntity" String="DMTF"/>
+      <Annotation Term="OData.Description" String="This version was created to add units to ReadingType descriptions.  It was also created to update the units of AirFlow to remove the deprecated format and the units of SpeedRPM to use the available UCUM format.  It was also created to correct various typographical errors.  It was also created to correct the minimum value for PowerFactor."/>
+      <EntityType Name="Sensor" BaseType="Sensor.v1_1_3.Sensor"/>
+    </Schema>
+
     <Schema xmlns="http://docs.oasis-open.org/odata/ns/edm" Namespace="Sensor.v1_2_0">
       <Annotation Term="Redfish.OwningEntity" String="DMTF"/>
       <Annotation Term="Redfish.Release" String="2020.4"/>
@@ -658,7 +694,7 @@
           <Annotation Term="OData.Permissions" EnumMember="OData.Permission/Read"/>
           <Annotation Term="OData.Description" String="The rotational speed."/>
           <Annotation Term="OData.LongDescription" String="This property shall contain a reading of the rotational speed of the device in revolutions per minute (RPM) units."/>
-          <Annotation Term="Measures.Unit" String="RPM"/>
+          <Annotation Term="Measures.Unit" String="{rev}/min"/>
           <Annotation Term="Redfish.Excerpt" String="Fan,FanArray"/>
         </Property>
         <Property Name="DeviceName" Type="Edm.String">
@@ -696,6 +732,12 @@
       <EntityType Name="Sensor" BaseType="Sensor.v1_2_0.Sensor"/>
     </Schema>
 
+    <Schema xmlns="http://docs.oasis-open.org/odata/ns/edm" Namespace="Sensor.v1_2_2">
+      <Annotation Term="Redfish.OwningEntity" String="DMTF"/>
+      <Annotation Term="OData.Description" String="This version was created to add units to ReadingType descriptions.  It was also created to update the units of AirFlow to remove the deprecated format and the units of SpeedRPM to use the available UCUM format.  It was also created to correct various typographical errors.  It was also created to correct the minimum value for PowerFactor."/>
+      <EntityType Name="Sensor" BaseType="Sensor.v1_2_1.Sensor"/>
+    </Schema>
+
     <Schema xmlns="http://docs.oasis-open.org/odata/ns/edm" Namespace="Sensor.v1_3_0">
       <Annotation Term="Redfish.OwningEntity" String="DMTF"/>
       <Annotation Term="Redfish.Release" String="2021.1"/>
@@ -717,6 +759,12 @@
       <Annotation Term="Redfish.OwningEntity" String="DMTF"/>
       <Annotation Term="OData.Description" String="This version was created to correct various typographical errors."/>
       <EntityType Name="Sensor" BaseType="Sensor.v1_3_0.Sensor"/>
+    </Schema>
+
+    <Schema xmlns="http://docs.oasis-open.org/odata/ns/edm" Namespace="Sensor.v1_3_2">
+      <Annotation Term="Redfish.OwningEntity" String="DMTF"/>
+      <Annotation Term="OData.Description" String="This version was created to add units to ReadingType descriptions.  It was also created to update the units of AirFlow to remove the deprecated format and the units of SpeedRPM to use the available UCUM format.  It was also created to correct various typographical errors.  It was also created to correct the minimum value for PowerFactor."/>
+      <EntityType Name="Sensor" BaseType="Sensor.v1_3_1.Sensor"/>
     </Schema>
 
     <Schema xmlns="http://docs.oasis-open.org/odata/ns/edm" Namespace="Sensor.v1_4_0">
@@ -773,6 +821,43 @@
           <Annotation Term="OData.AutoExpandReferences"/>
         </NavigationProperty>
       </ComplexType>
+    </Schema>
+
+    <Schema xmlns="http://docs.oasis-open.org/odata/ns/edm" Namespace="Sensor.v1_4_1">
+      <Annotation Term="Redfish.OwningEntity" String="DMTF"/>
+      <Annotation Term="OData.Description" String="This version was created to add units to ReadingType descriptions.  It was also created to update the units of AirFlow to remove the deprecated format and the units of SpeedRPM to use the available UCUM format.  It was also created to correct various typographical errors.  It was also created to correct the minimum value for PowerFactor."/>
+      <EntityType Name="Sensor" BaseType="Sensor.v1_4_0.Sensor"/>
+    </Schema>
+
+    <Schema xmlns="http://docs.oasis-open.org/odata/ns/edm" Namespace="Sensor.v1_5_0">
+      <Annotation Term="Redfish.OwningEntity" String="DMTF"/>
+      <Annotation Term="Redfish.Release" String="2021.4"/>
+      <Annotation Term="OData.Description" String="This version was created to add `AbsoluteHumidity` and `PressurekPa` to ReadingType."/>
+
+      <EntityType Name="Sensor" BaseType="Sensor.v1_4_1.Sensor">
+        <Property Name="ApparentkVAh" Type="Edm.Decimal">
+          <Annotation Term="OData.Permissions" EnumMember="OData.Permission/Read"/>
+          <Annotation Term="OData.Description" String="Apparent energy (kVAh)."/>
+          <Annotation Term="OData.LongDescription" String="This property shall contain the apparent energy, in kilovolt-ampere-hour units, for an electrical energy measurement.  This property can appear in sensors with a ReadingType containing `EnergykWh`, and shall not appear in sensors with other ReadingType values."/>
+          <Annotation Term="Measures.Unit" String="kV.A.h"/>
+          <Annotation Term="Redfish.Excerpt" String="EnergykWh"/>
+        </Property>
+        <Property Name="ReactivekVARh" Type="Edm.Decimal">
+          <Annotation Term="OData.Permissions" EnumMember="OData.Permission/Read"/>
+          <Annotation Term="OData.Description" String="Reactive energy (kVARh)."/>
+          <Annotation Term="OData.LongDescription" String="This property shall contain the reactive energy, in kilovolt-ampere-hours (reactive) units, for an electrical energy measurement.  This property can appear in sensors with a ReadingType containing `EnergykWh`, and shall not appear in sensors with other ReadingType values."/>
+          <Annotation Term="Measures.Unit" String="kV.A.h"/>
+          <Annotation Term="Redfish.Excerpt" String="EnergykWh"/>
+        </Property>
+        <Property Name="PhaseAngleDegrees" Type="Edm.Decimal">
+          <Annotation Term="OData.Permissions" EnumMember="OData.Permission/Read"/>
+          <Annotation Term="OData.Description" String="The phase angle (degrees) between the current and voltage waveforms."/>
+          <Annotation Term="OData.LongDescription" String="This property shall contain the phase angle, in degree units, between the current and voltage waveforms for an electrical measurement.  This property can appear in sensors with a ReadingType containing `Power`, and shall not appear in sensors with other ReadingType values."/>
+          <Annotation Term="Validation.Minimum" Int="-90"/>
+          <Annotation Term="Validation.Maximum" Int="90"/>
+          <Annotation Term="Redfish.Excerpt" String="Power,PowerArray"/>
+        </Property>
+      </EntityType>
     </Schema>
 
   </edmx:DataServices>

--- a/static/redfish/v1/schema/ServiceRoot_v1.xml
+++ b/static/redfish/v1/schema/ServiceRoot_v1.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!---->
 <!--################################################################################       -->
-<!--# Redfish Schema:  ServiceRoot v1.12.0                                                 -->
+<!--# Redfish Schema:  ServiceRoot v1.13.0                                                 -->
 <!--#                                                                                      -->
 <!--# For a detailed change log, see the README file contained in the DSP8010 bundle,      -->
 <!--# available at http://www.dmtf.org/standards/redfish                                   -->
@@ -105,6 +105,15 @@
   </edmx:Reference>
   <edmx:Reference Uri="http://redfish.dmtf.org/schemas/v1/CableCollection_v1.xml">
     <edmx:Include Namespace="CableCollection"/>
+  </edmx:Reference>
+  <edmx:Reference Uri="http://redfish.dmtf.org/schemas/v1/ServiceConditions_v1.xml">
+    <edmx:Include Namespace="ServiceConditions"/>
+  </edmx:Reference>
+  <edmx:Reference Uri="http://redfish.dmtf.org/schemas/v1/ComponentIntegrityCollection_v1.xml">
+    <edmx:Include Namespace="ComponentIntegrityCollection"/>
+  </edmx:Reference>
+  <edmx:Reference Uri="http://redfish.dmtf.org/schemas/v1/RegisteredClientCollection_v1.xml">
+    <edmx:Include Namespace="RegisteredClientCollection"/>
   </edmx:Reference>
 
   <edmx:DataServices>
@@ -759,6 +768,35 @@
           <Annotation Term="OData.Description" String="The link to the license service."/>
           <Annotation Term="OData.LongDescription" String="This property shall contain a link to a resource of type LicenseService."/>
           <Annotation Term="OData.AutoExpandReferences"/>
+        </NavigationProperty>
+      </EntityType>
+    </Schema>
+
+    <Schema xmlns="http://docs.oasis-open.org/odata/ns/edm" Namespace="ServiceRoot.v1_13_0">
+      <Annotation Term="Redfish.OwningEntity" String="DMTF"/>
+      <Annotation Term="Redfish.Release" String="2021.4"/>
+
+      <EntityContainer Name="ServiceContainer" Extends="ServiceRoot.v1_12_0.ServiceContainer">
+        <Singleton Name="ComponentIntegrity" Type="ComponentIntegrityCollection.ComponentIntegrityCollection"/>
+        <Singleton Name="ServiceConditions" Type="ServiceConditions.ServiceConditions"/>
+        <Singleton Name="RegisteredClients" Type="RegisteredClientCollection.RegisteredClientCollection"/>
+      </EntityContainer>
+
+      <EntityType Name="ServiceRoot" BaseType="ServiceRoot.v1_12_0.ServiceRoot">
+        <NavigationProperty Name="ServiceConditions" Type="ServiceConditions.ServiceConditions" Nullable="false">
+          <Annotation Term="OData.Permissions" EnumMember="OData.Permission/Read"/>
+          <Annotation Term="OData.Description" String="The link to the service conditions."/>
+          <Annotation Term="OData.LongDescription" String="This property shall contain a link to a resource of type ServiceConditions."/>
+        </NavigationProperty>
+        <NavigationProperty Name="ComponentIntegrity" Type="ComponentIntegrityCollection.ComponentIntegrityCollection" Nullable="false">
+          <Annotation Term="OData.Permissions" EnumMember="OData.Permission/Read"/>
+          <Annotation Term="OData.Description" String="The link to a collection of component integrity information."/>
+          <Annotation Term="OData.LongDescription" String="This property shall contain a link to a resource collection of type ComponentIntegrityCollection."/>
+        </NavigationProperty>
+        <NavigationProperty Name="RegisteredClients" Type="RegisteredClientCollection.RegisteredClientCollection" Nullable="false">
+          <Annotation Term="OData.Permissions" EnumMember="OData.Permission/Read"/>
+          <Annotation Term="OData.Description" String="The link to a collection of registered clients."/>
+          <Annotation Term="OData.LongDescription" String="This property shall contain a link to a resource collection of type RegisteredClientCollection."/>
         </NavigationProperty>
       </EntityType>
     </Schema>

--- a/static/redfish/v1/schema/Settings_v1.xml
+++ b/static/redfish/v1/schema/Settings_v1.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!---->
 <!--################################################################################       -->
-<!--# Redfish Schema:  Settings v1.3.3                                                     -->
+<!--# Redfish Schema:  Settings v1.3.4                                                     -->
 <!--#                                                                                      -->
 <!--# For a detailed change log, see the README file contained in the DSP8010 bundle,      -->
 <!--# available at http://www.dmtf.org/standards/redfish                                   -->
@@ -168,7 +168,7 @@
         <Property Name="MaintenanceWindowStartTime" Type="Edm.DateTimeOffset" Nullable="false">
           <Annotation Term="OData.Permissions" EnumMember="OData.Permission/ReadWrite"/>
           <Annotation Term="OData.Description" String="The start time of a maintenance window."/>
-          <Annotation Term="OData.LongDescription" String="This property shall indicate the date and time when the service can start to apply the future configuration as part of a maintenance window.  This property shall be required if the ApplyTime property is `AtMaintenanceWindowStart` or `InMaintenanceWindowOnReset`."/>
+          <Annotation Term="OData.LongDescription" String="This property shall indicate the date and time when the service can start to apply the future configuration as part of a maintenance window.  Services shall provide a default value if not configured by a user.  This property shall be required if the ApplyTime property is `AtMaintenanceWindowStart` or `InMaintenanceWindowOnReset`."/>
         </Property>
         <Property Name="MaintenanceWindowDurationInSeconds" Type="Edm.Int64" Nullable="false">
           <Annotation Term="OData.Permissions" EnumMember="OData.Permission/ReadWrite"/>
@@ -234,6 +234,13 @@
       <ComplexType Name="PreferredApplyTime" BaseType="Settings.v1_1_4.PreferredApplyTime"/>
     </Schema>
 
+    <Schema xmlns="http://docs.oasis-open.org/odata/ns/edm" Namespace="Settings.v1_1_6">
+      <Annotation Term="Redfish.OwningEntity" String="DMTF"/>
+      <Annotation Term="OData.Description" String="This version was created to clarify the default behavior of MaintenanceWindowStartTime."/>
+      <ComplexType Name="Settings" BaseType="Settings.v1_1_5.Settings"/>
+      <ComplexType Name="PreferredApplyTime" BaseType="Settings.v1_1_5.PreferredApplyTime"/>
+    </Schema>
+
     <Schema xmlns="http://docs.oasis-open.org/odata/ns/edm" Namespace="Settings.v1_2_0">
       <Annotation Term="Redfish.OwningEntity" String="DMTF"/>
       <Annotation Term="Redfish.Release" String="2018.1"/>
@@ -260,7 +267,7 @@
         <Property Name="MaintenanceWindowStartTime" Type="Edm.DateTimeOffset" Nullable="false">
           <Annotation Term="OData.Permissions" EnumMember="OData.Permission/Read"/>
           <Annotation Term="OData.Description" String="The start time of a maintenance window."/>
-          <Annotation Term="OData.LongDescription" String="This property shall contain the same as the MaintenanceWindowStartTime property found in the MaintenanceWindow structure on the MaintenanceWindowResource.  This property shall be required if the SupportedValues property contains `AtMaintenanceWindowStart` or `InMaintenanceWindowOnReset`."/>
+          <Annotation Term="OData.LongDescription" String="This property shall contain the same as the MaintenanceWindowStartTime property found in the MaintenanceWindow structure on the MaintenanceWindowResource.  Services shall provide a default value if not configured by a user.  This property shall be required if the SupportedValues property contains `AtMaintenanceWindowStart` or `InMaintenanceWindowOnReset`."/>
         </Property>
         <Property Name="MaintenanceWindowDurationInSeconds" Type="Edm.Int64" Nullable="false">
           <Annotation Term="OData.Permissions" EnumMember="OData.Permission/Read"/>
@@ -282,7 +289,7 @@
         <Property Name="MaintenanceWindowStartTime" Type="Edm.DateTimeOffset" Nullable="false">
           <Annotation Term="OData.Permissions" EnumMember="OData.Permission/ReadWrite"/>
           <Annotation Term="OData.Description" String="The start time of a maintenance window."/>
-          <Annotation Term="OData.LongDescription" String="This property shall indicate the date and time when the service can start to apply the requested settings or operation as part of a maintenance window."/>
+          <Annotation Term="OData.LongDescription" String="This property shall indicate the date and time when the service can start to apply the requested settings or operation as part of a maintenance window.  Services shall provide a default value if not configured by a user."/>
           <Annotation Term="Redfish.Required"/>
         </Property>
         <Property Name="MaintenanceWindowDurationInSeconds" Type="Edm.Int64" Nullable="false">
@@ -341,6 +348,15 @@
       <ComplexType Name="MaintenanceWindow" BaseType="Settings.v1_2_4.MaintenanceWindow"/>
     </Schema>
 
+    <Schema xmlns="http://docs.oasis-open.org/odata/ns/edm" Namespace="Settings.v1_2_6">
+      <Annotation Term="Redfish.OwningEntity" String="DMTF"/>
+      <Annotation Term="OData.Description" String="This version was created to clarify the default behavior of MaintenanceWindowStartTime."/>
+      <ComplexType Name="Settings" BaseType="Settings.v1_2_5.Settings"/>
+      <ComplexType Name="PreferredApplyTime" BaseType="Settings.v1_2_5.PreferredApplyTime"/>
+      <ComplexType Name="OperationApplyTimeSupport" BaseType="Settings.v1_2_5.OperationApplyTimeSupport"/>
+      <ComplexType Name="MaintenanceWindow" BaseType="Settings.v1_2_5.MaintenanceWindow"/>
+    </Schema>
+
     <Schema xmlns="http://docs.oasis-open.org/odata/ns/edm" Namespace="Settings.v1_3_0">
       <Annotation Term="Redfish.OwningEntity" String="DMTF"/>
       <Annotation Term="Redfish.Release" String="2019.3"/>
@@ -377,6 +393,15 @@
       <ComplexType Name="PreferredApplyTime" BaseType="Settings.v1_3_2.PreferredApplyTime"/>
       <ComplexType Name="OperationApplyTimeSupport" BaseType="Settings.v1_3_2.OperationApplyTimeSupport"/>
       <ComplexType Name="MaintenanceWindow" BaseType="Settings.v1_3_2.MaintenanceWindow"/>
+    </Schema>
+
+    <Schema xmlns="http://docs.oasis-open.org/odata/ns/edm" Namespace="Settings.v1_3_4">
+      <Annotation Term="Redfish.OwningEntity" String="DMTF"/>
+      <Annotation Term="OData.Description" String="This version was created to clarify the default behavior of MaintenanceWindowStartTime."/>
+      <ComplexType Name="Settings" BaseType="Settings.v1_3_3.Settings"/>
+      <ComplexType Name="PreferredApplyTime" BaseType="Settings.v1_3_3.PreferredApplyTime"/>
+      <ComplexType Name="OperationApplyTimeSupport" BaseType="Settings.v1_3_3.OperationApplyTimeSupport"/>
+      <ComplexType Name="MaintenanceWindow" BaseType="Settings.v1_3_3.MaintenanceWindow"/>
     </Schema>
 
   </edmx:DataServices>

--- a/static/redfish/v1/schema/SoftwareInventory_v1.xml
+++ b/static/redfish/v1/schema/SoftwareInventory_v1.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!---->
 <!--################################################################################       -->
-<!--# Redfish Schema:  SoftwareInventory v1.5.0                                            -->
+<!--# Redfish Schema:  SoftwareInventory v1.6.0                                            -->
 <!--#                                                                                      -->
 <!--# For a detailed change log, see the README file contained in the DSP8010 bundle,      -->
 <!--# available at http://www.dmtf.org/standards/redfish                                   -->
@@ -248,6 +248,15 @@
         <Property Name="Measurement" Type="SoftwareInventory.MeasurementBlock" Nullable="false">
           <Annotation Term="OData.Description" String="A DSP0274-defined measurement block."/>
           <Annotation Term="OData.LongDescription" String="This property shall contain a DSP0274-defined measurement block."/>
+          <Annotation Term="Redfish.Revisions">
+            <Collection>
+              <Record>
+                <PropertyValue Property="Kind" EnumMember="Redfish.RevisionKind/Deprecated"/>
+                <PropertyValue Property="Version" String="v1_6_0"/>
+                <PropertyValue Property="Description" String="This property has been deprecated in favor of the ComponentIntegrity resource."/>
+              </Record>
+            </Collection>
+          </Annotation>
         </Property>
       </EntityType>
 
@@ -285,6 +294,14 @@
           <Annotation Term="OData.LongDescription" String="This property shall contain the value of DSP0274-defined Index field of the measurement block."/>
         </Property>
       </ComplexType>
+    </Schema>
+
+    <Schema xmlns="http://docs.oasis-open.org/odata/ns/edm" Namespace="SoftwareInventory.v1_6_0">
+      <Annotation Term="Redfish.OwningEntity" String="DMTF"/>
+      <Annotation Term="Redfish.Release" String="2021.4"/>
+      <Annotation Term="OData.Description" String="This version was created to deprecate Measurement in favor of measurement reporting in the ComponentIntegrity resource."/>
+
+      <EntityType Name="SoftwareInventory" BaseType="SoftwareInventory.v1_5_0.SoftwareInventory"/>
     </Schema>
 
   </edmx:DataServices>

--- a/static/redfish/v1/schema/StorageController_v1.xml
+++ b/static/redfish/v1/schema/StorageController_v1.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!---->
 <!--################################################################################       -->
-<!--# Redfish Schema:  StorageController v1.3.0                                            -->
+<!--# Redfish Schema:  StorageController v1.5.0                                            -->
 <!--#                                                                                      -->
 <!--# For a detailed change log, see the README file contained in the DSP8010 bundle,      -->
 <!--# available at http://www.dmtf.org/standards/redfish                                   -->
@@ -491,6 +491,15 @@
         <Property Name="Measurements" Type="Collection(SoftwareInventory.MeasurementBlock)" Nullable="false">
           <Annotation Term="OData.Description" String="An array of DSP0274-defined measurement blocks."/>
           <Annotation Term="OData.LongDescription" String="This property shall contain an array of DSP0274-defined measurement blocks."/>
+          <Annotation Term="Redfish.Revisions">
+            <Collection>
+              <Record>
+                <PropertyValue Property="Kind" EnumMember="Redfish.RevisionKind/Deprecated"/>
+                <PropertyValue Property="Version" String="v1_5_0"/>
+                <PropertyValue Property="Description" String="This property has been deprecated in favor of the ComponentIntegrity resource."/>
+              </Record>
+            </Collection>
+          </Annotation>
         </Property>
       </EntityType>
     </Schema>
@@ -559,6 +568,14 @@
           <Annotation Term="OData.LongDescription" String="This property shall contain the number of I/O completion queues allocated to this NVMe I/O controller."/>
         </Property>
       </ComplexType>
+    </Schema>
+
+    <Schema xmlns="http://docs.oasis-open.org/odata/ns/edm" Namespace="StorageController.v1_5_0">
+      <Annotation Term="Redfish.OwningEntity" String="DMTF"/>
+      <Annotation Term="Redfish.Release" String="2021.4"/>
+      <Annotation Term="OData.Description" String="This version was created to deprecate Measurements in favor of measurement reporting in the ComponentIntegrity resource."/>
+
+      <EntityType Name="StorageController" BaseType="StorageController.v1_4_0.StorageController"/>
     </Schema>
 
   </edmx:DataServices>

--- a/static/redfish/v1/schema/Storage_v1.xml
+++ b/static/redfish/v1/schema/Storage_v1.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!---->
 <!--################################################################################                   -->
-<!--# Redfish Schema:  Storage v1.11.0                                                                 -->
+<!--# Redfish Schema:  Storage v1.12.0                                                                 -->
 <!--#                                                                                                  -->
 <!--# For a detailed change log, see the README file contained in the DSP8010 bundle,                  -->
 <!--# available at http://www.dmtf.org/standards/redfish                                               -->
@@ -1054,6 +1054,15 @@
         <Property Name="Measurements" Type="Collection(SoftwareInventory.MeasurementBlock)" Nullable="false">
           <Annotation Term="OData.Description" String="An array of DSP0274-defined measurement blocks."/>
           <Annotation Term="OData.LongDescription" String="This property shall contain an array of DSP0274-defined measurement blocks."/>
+          <Annotation Term="Redfish.Revisions">
+            <Collection>
+              <Record>
+                <PropertyValue Property="Kind" EnumMember="Redfish.RevisionKind/Deprecated"/>
+                <PropertyValue Property="Version" String="v1_12_0"/>
+                <PropertyValue Property="Description" String="This property has been deprecated in favor of the ComponentIntegrity resource."/>
+              </Record>
+            </Collection>
+          </Annotation>
         </Property>
       </EntityType>
     </Schema>
@@ -1089,6 +1098,14 @@
           <Annotation Term="OData.AutoExpandReferences"/>
         </NavigationProperty>
       </ComplexType>
+    </Schema>
+
+    <Schema xmlns="http://docs.oasis-open.org/odata/ns/edm" Namespace="Storage.v1_12_0">
+      <Annotation Term="Redfish.OwningEntity" String="DMTF"/>
+      <Annotation Term="Redfish.Release" String="2021.4"/>
+      <Annotation Term="OData.Description" String="This version was created to deprecate Measurements in favor of measurement reporting in the ComponentIntegrity resource."/>
+
+      <EntityType Name="Storage" BaseType="Storage.v1_11_0.Storage"/>
     </Schema>
 
   </edmx:DataServices>

--- a/static/redfish/v1/schema/UpdateService_v1.xml
+++ b/static/redfish/v1/schema/UpdateService_v1.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!---->
 <!--################################################################################       -->
-<!--# Redfish Schema:  UpdateService v1.10.0                                               -->
+<!--# Redfish Schema:  UpdateService v1.11.0                                               -->
 <!--#                                                                                      -->
 <!--# For a detailed change log, see the README file contained in the DSP8010 bundle,      -->
 <!--# available at http://www.dmtf.org/standards/redfish                                   -->
@@ -113,6 +113,18 @@
               <Record>
                 <PropertyValue Property="Kind" EnumMember="Redfish.RevisionKind/Added"/>
                 <PropertyValue Property="Version" String="v1_4_0"/>
+              </Record>
+            </Collection>
+          </Annotation>
+        </Parameter>
+        <Parameter Name="ForceUpdate" Type="Edm.Boolean">
+          <Annotation Term="OData.Description" String="An indication of whether the service should bypass update policies when applying the provided image.  The default is `false`."/>
+          <Annotation Term="OData.LongDescription" String="This parameter shall indicate whether the service should bypass update policies when applying the provided image, such as allowing a component to be downgraded.  Services may contain update policies that are never bypassed, such as minimum version enforcement.  If the client does not provide this parameter, the service shall default this value to `false`."/>
+          <Annotation Term="Redfish.Revisions">
+            <Collection>
+              <Record>
+                <PropertyValue Property="Kind" EnumMember="Redfish.RevisionKind/Added"/>
+                <PropertyValue Property="Version" String="v1_11_0"/>
               </Record>
             </Collection>
           </Annotation>
@@ -545,6 +557,18 @@
           <Annotation Term="OData.Description" String="Apply after a reset but within an administrator-specified maintenance window."/>
           <Annotation Term="OData.LongDescription" String="This value shall indicate the HttpPushUri-provided software is applied during the maintenance window specified by the MaintenanceWindowStartTime and MaintenanceWindowDurationInSeconds properties, and if a reset occurs within the maintenance window."/>
         </Member>
+        <Member Name="OnStartUpdateRequest">
+          <Annotation Term="OData.Description" String="Apply when the StartUpdate action of the update service is invoked."/>
+          <Annotation Term="OData.LongDescription" String="This value shall indicate the HttpPushUri-provided software is applied when the StartUpdate action of the update service is invoked."/>
+          <Annotation Term="Redfish.Revisions">
+            <Collection>
+              <Record>
+                <PropertyValue Property="Kind" EnumMember="Redfish.RevisionKind/Added"/>
+                <PropertyValue Property="Version" String="v1_11_0"/>
+              </Record>
+            </Collection>
+          </Annotation>
+        </Member>
       </EnumType>
     </Schema>
 
@@ -646,7 +670,7 @@
         <Annotation Term="OData.Description" String="The update parameters used with MultipartHttpPushUri software update."/>
         <Annotation Term="OData.LongDescription" String="This type shall contain the update parameters when passing the update image when using the URI specified by the MultipartHttpPushUri property to push a software image."/>
         <Property Name="Targets" Type="Collection(Edm.String)">
-          <Annotation Term="OData.Permissions" EnumMember="OData.Permission/Read"/>
+          <Annotation Term="OData.Permissions" EnumMember="OData.Permission/ReadWrite"/>
           <Annotation Term="OData.Description" String="An array of URIs that indicate where to apply the update image."/>
           <Annotation Term="OData.LongDescription" String="This property shall contain zero or more URIs that indicate where to apply the update image when using the URI specified by the MultipartHttpPushUri property to push a software image.  These targets should correspond to software inventory instances or their related items.  If this property is not present or contains no targets, the service shall apply the software image to all applicable targets, as determined by the service."/>
           <Annotation Term="OData.IsURL"/>
@@ -762,16 +786,22 @@
         <Property Name="VerifyRemoteServerCertificate" Type="Edm.Boolean">
           <Annotation Term="OData.Permissions" EnumMember="OData.Permission/ReadWrite"/>
           <Annotation Term="OData.Description" String="An indication of whether the service will verify the certificate of the server referenced by the ImageURI property in SimpleUpdate prior to sending the transfer request."/>
-          <Annotation Term="OData.LongDescription" String="This property shall indicate whether whether the service will verify the certificate of the server referenced by the ImageURI property in SimpleUpdate prior to sending the transfer request."/>
+          <Annotation Term="OData.LongDescription" String="This property shall indicate whether whether the service will verify the certificate of the server referenced by the ImageURI property in SimpleUpdate prior to sending the transfer request.  If this property is not supported by the service, it shall be assumed to be `false`.  This property should default to `false` in order to maintain compatibility with older clients."/>
         </Property>
       </EntityType>
+    </Schema>
+
+    <Schema xmlns="http://docs.oasis-open.org/odata/ns/edm" Namespace="UpdateService.v1_9_1">
+      <Annotation Term="Redfish.OwningEntity" String="DMTF"/>
+      <Annotation Term="OData.Description" String="This version was created to clarify the behavior of VerifyRemoteServerCertificate when not supported or configured."/>
+      <EntityType Name="UpdateService" BaseType="UpdateService.v1_9_0.UpdateService"/>
     </Schema>
 
     <Schema xmlns="http://docs.oasis-open.org/odata/ns/edm" Namespace="UpdateService.v1_10_0">
       <Annotation Term="Redfish.OwningEntity" String="DMTF"/>
       <Annotation Term="Redfish.Release" String="2021.2"/>
 
-      <EntityType Name="UpdateService" BaseType="UpdateService.v1_8_3.UpdateService">
+      <EntityType Name="UpdateService" BaseType="UpdateService.v1_9_1.UpdateService">
         <NavigationProperty Name="ClientCertificates" Type="CertificateCollection.CertificateCollection" ContainsTarget="true" Nullable="false">
           <Annotation Term="OData.Permissions" EnumMember="OData.Permission/Read"/>
           <Annotation Term="OData.Description" String="The link to a collection of client identity certificates provided to the server referenced by the ImageURI property in SimpleUpdate."/>
@@ -779,6 +809,36 @@
           <Annotation Term="OData.AutoExpandReferences"/>
         </NavigationProperty>
       </EntityType>
+    </Schema>
+
+    <Schema xmlns="http://docs.oasis-open.org/odata/ns/edm" Namespace="UpdateService.v1_10_1">
+      <Annotation Term="Redfish.OwningEntity" String="DMTF"/>
+      <Annotation Term="OData.Description" String="This version was created to clarify the behavior of VerifyRemoteServerCertificate when not supported or configured."/>
+      <EntityType Name="UpdateService" BaseType="UpdateService.v1_10_0.UpdateService"/>
+    </Schema>
+
+    <Schema xmlns="http://docs.oasis-open.org/odata/ns/edm" Namespace="UpdateService.v1_11_0">
+      <Annotation Term="Redfish.OwningEntity" String="DMTF"/>
+      <Annotation Term="Redfish.Release" String="2021.4"/>
+      <Annotation Term="OData.Description" String="This version was created to add `OnStartUpdateRequest` to ApplyTime."/>
+
+      <EntityType Name="UpdateService" BaseType="UpdateService.v1_10_1.UpdateService"/>
+
+      <ComplexType Name="HttpPushUriOptions" BaseType="UpdateService.v1_4_0.HttpPushUriOptions">
+        <Property Name="ForceUpdate" Type="Edm.Boolean" Nullable="false">
+          <Annotation Term="OData.Permissions" EnumMember="OData.Permission/ReadWrite"/>
+          <Annotation Term="OData.Description" String="An indication of whether the service should bypass update policies when applying the HttpPushUri-provided image."/>
+          <Annotation Term="OData.LongDescription" String="This property shall indicate whether the service should bypass update policies when applying the HttpPushUri-provided image, such as allowing a component to be downgraded.  Services may contain update policies that are never bypassed, such as minimum version enforcement.  If this property is not present, it shall be assumed to be `false`."/>
+        </Property>
+      </ComplexType>
+
+      <ComplexType Name="UpdateParameters" BaseType="UpdateService.v1_8_0.UpdateParameters">
+        <Property Name="ForceUpdate" Type="Edm.Boolean" Nullable="false">
+          <Annotation Term="OData.Permissions" EnumMember="OData.Permission/ReadWrite"/>
+          <Annotation Term="OData.Description" String="An indication of whether the service should bypass update policies when applying the provided image.  The default is `false`."/>
+          <Annotation Term="OData.LongDescription" String="This property shall indicate whether the service should bypass update policies when applying the provided image, such as allowing a component to be downgraded.  Services may contain update policies that are never bypassed, such as minimum version enforcement.  If the client does not provide this parameter, the service shall default this value to `false`."/>
+        </Property>
+      </ComplexType>
     </Schema>
 
   </edmx:DataServices>

--- a/static/redfish/v1/schema/VirtualMedia_v1.xml
+++ b/static/redfish/v1/schema/VirtualMedia_v1.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!---->
 <!--################################################################################       -->
-<!--# Redfish Schema:  VirtualMedia v1.5.0                                                 -->
+<!--# Redfish Schema:  VirtualMedia v1.5.1                                                 -->
 <!--#                                                                                      -->
 <!--# For a detailed change log, see the README file contained in the DSP8010 bundle,      -->
 <!--# available at http://www.dmtf.org/standards/redfish                                   -->
@@ -469,7 +469,7 @@
         <Property Name="VerifyCertificate" Type="Edm.Boolean">
           <Annotation Term="OData.Permissions" EnumMember="OData.Permission/ReadWrite"/>
           <Annotation Term="OData.Description" String="An indication of whether the service will verify the certificate of the server referenced by the Image property prior to completing the remote media connection."/>
-          <Annotation Term="OData.LongDescription" String="This property shall indicate whether whether the service will verify the certificate of the server referenced by the Image property prior to completing the remote media connection."/>
+          <Annotation Term="OData.LongDescription" String="This property shall indicate whether whether the service will verify the certificate of the server referenced by the Image property prior to completing the remote media connection.  If this property is not supported by the service, it shall be assumed to be `false`.  This property should default to `false` in order to maintain compatibility with older clients."/>
         </Property>
       </EntityType>
     </Schema>
@@ -478,6 +478,12 @@
       <Annotation Term="Redfish.OwningEntity" String="DMTF"/>
       <Annotation Term="OData.Description" String="This version was created to clarify the usage of Image when mounting media from a local source."/>
       <EntityType Name="VirtualMedia" BaseType="VirtualMedia.v1_4_0.VirtualMedia"/>
+    </Schema>
+
+    <Schema xmlns="http://docs.oasis-open.org/odata/ns/edm" Namespace="VirtualMedia.v1_4_2">
+      <Annotation Term="Redfish.OwningEntity" String="DMTF"/>
+      <Annotation Term="OData.Description" String="This version was created to clarify the behavior of VerifyCertificate when not supported or configured."/>
+      <EntityType Name="VirtualMedia" BaseType="VirtualMedia.v1_4_1.VirtualMedia"/>
     </Schema>
 
     <Schema xmlns="http://docs.oasis-open.org/odata/ns/edm" Namespace="VirtualMedia.v1_5_0">
@@ -492,6 +498,12 @@
           <Annotation Term="OData.AutoExpandReferences"/>
         </NavigationProperty>
       </EntityType>
+    </Schema>
+
+    <Schema xmlns="http://docs.oasis-open.org/odata/ns/edm" Namespace="VirtualMedia.v1_5_1">
+      <Annotation Term="Redfish.OwningEntity" String="DMTF"/>
+      <Annotation Term="OData.Description" String="This version was created to clarify the behavior of VerifyCertificate when not supported or configured."/>
+      <EntityType Name="VirtualMedia" BaseType="VirtualMedia.v1_5_0.VirtualMedia"/>
     </Schema>
 
   </edmx:DataServices>


### PR DESCRIPTION
The commit publishes following properties under
PCIeDevice schema.
- Part nummber
- Spare part number
- Location code
- Operational status
- Model
- Serial number

Version of the schema upgraded to 1.9.0 to accomodate
"Slot", in order to publish Location code.

Validator has been executed and no new error has been
found.

Signed-off-by: Sunny Srivastava <sunnsr25@in.ibm.com>