### PR TITLE
Add Sensor Name to Debug trace

### DIFF
--- a/redfish-core/lib/sensors.hpp
+++ b/redfish-core/lib/sensors.hpp
@@ -3006,7 +3006,8 @@ inline void metricsObjectInterfacesToJson(
     auto valueIt = interfacesDict.find("xyz.openbmc_project.Sensor.Value");
     if (valueIt == interfacesDict.end())
     {
-        BMCWEB_LOG_ERROR << "Sensor doesn't have a value interface";
+        BMCWEB_LOG_ERROR << "Sensor doesn't have a value interface: "
+                         << sensorName;
         return;
     }
 


### PR DESCRIPTION
Seeing "Sensor doesn't have a value interface" because a core dump
issue. To potentially debug this issue, incldue the Sensor Name.

Signed-off-by: Gunnar Mills <gmills@us.ibm.com>