### PR TITLE
Change the completionhandler to accept Res

### DIFF
--- a/http/http_connection.hpp
+++ b/http/http_connection.hpp
@@ -336,7 +336,7 @@ class Connection :
             if (thisReq.getHeaderValue(boost::beast::http::field::host).empty())
             {
                 res.result(boost::beast::http::status::bad_request);
-                completeRequest();
+                completeRequest(res);
                 return;
             }
         }
@@ -355,7 +355,7 @@ class Connection :
 
         if (res.completed)
         {
-            completeRequest();
+            completeRequest(res);
             return;
         }
 
@@ -366,14 +366,16 @@ class Connection :
             forward_unauthorized::sendUnauthorized(
                 req->url, req->getHeaderValue("User-Agent"),
                 req->getHeaderValue("Accept"), res);
-            completeRequest();
+            completeRequest(res);
             return;
         }
 
-        res.setCompleteRequestHandler([self(shared_from_this())] {
-            boost::asio::post(self->adaptor.get_executor(),
-                              [self] { self->completeRequest(); });
-        });
+        auto asyncResp = std::make_shared<bmcweb::AsyncResp>();
+        BMCWEB_LOG_DEBUG << "Setting completion handler";
+        asyncResp->res.setCompleteRequestHandler(
+            [self(shared_from_this())](crow::Response& thisRes) {
+                self->completeRequest(thisRes);
+            });
 
         if (thisReq.isUpgrade() &&
             boost::iequals(
@@ -383,7 +385,7 @@ class Connection :
             handler->handleUpgrade(thisReq, res, std::move(adaptor));
             // delete lambda with self shared_ptr
             // to enable connection destruction
-            res.setCompleteRequestHandler(nullptr);
+            asyncResp->res.setCompleteRequestHandler(nullptr);
             return;
         }
 
@@ -395,10 +397,9 @@ class Connection :
             handler->handleUpgrade(*req, res, std::move(adaptor));
             // delete lambda with self shared_ptr
             // to enable connection destruction
-            res.completeRequestHandler = nullptr;
+            asyncResp->res.setCompleteRequestHandler(nullptr);
             return;
         }
-        auto asyncResp = std::make_shared<bmcweb::AsyncResp>(res);
         handler->handle(thisReq, asyncResp);
     }
 
@@ -422,8 +423,7 @@ class Connection :
                                          boost::asio::ip::tcp::socket>>)
         {
             adaptor.next_layer().close();
-#ifdef BMCWEB_ENABLE_MUTUAL_TLS_AUTHENTICATION
-            if (userSession != nullptr)
+            if (sessionIsFromTransport && userSession != nullptr)
             {
                 BMCWEB_LOG_DEBUG
                     << this
@@ -431,7 +431,6 @@ class Connection :
                 persistent_data::SessionStore::getInstance().removeSession(
                     userSession);
             }
-#endif // BMCWEB_ENABLE_MUTUAL_TLS_AUTHENTICATION
         }
         else
         {
@@ -439,12 +438,13 @@ class Connection :
         }
     }
 
-    void completeRequest()
+    void completeRequest(crow::Response& thisRes)
     {
         if (!req)
         {
             return;
         }
+        res = std::move(thisRes);
         BMCWEB_LOG_INFO << "Response: " << this << ' ' << req->url << ' '
                         << res.resultInt() << " keepalive=" << req->keepAlive();
 
@@ -497,7 +497,7 @@ class Connection :
 
         res.keepAlive(req->keepAlive());
 
-        doWrite();
+        doWrite(res);
 
         // delete lambda with self shared_ptr
         // to enable connection destruction
@@ -660,7 +660,7 @@ class Connection :
             });
     }
 
-    void doWrite()
+    void doWrite(crow::Response& thisRes)
     {
         bool loggedIn = req && req->session;
         if (loggedIn)
@@ -672,8 +672,8 @@ class Connection :
             startDeadline(loggedOutAttempts);
         }
         BMCWEB_LOG_DEBUG << this << " doWrite";
-        res.preparePayload();
-        serializer.emplace(*res.stringResponse);
+        thisRes.preparePayload();
+        serializer.emplace(*thisRes.stringResponse);
         boost::beast::http::async_write(
             adaptor, *serializer,
             [this,

--- a/http/http_response.hpp
+++ b/http/http_response.hpp
@@ -42,15 +42,29 @@ struct Response
     Response() : stringResponse(response_type{})
     {}
 
+    ~Response() = default;
+
+    Response(const Response&) = delete;
+    Response(Response&&) = delete;
+
     Response& operator=(const Response& r) = delete;
 
     Response& operator=(Response&& r) noexcept
     {
-        BMCWEB_LOG_DEBUG << "Moving response containers";
+        BMCWEB_LOG_DEBUG << "Moving response containers; this: " << this
+                         << "; other: " << &r;
+        if (this == &r)
+        {
+            return *this;
+        }
         stringResponse = std::move(r.stringResponse);
         r.stringResponse.emplace(response_type{});
         jsonValue = std::move(r.jsonValue);
         completed = r.completed;
+        completeRequestHandler = std::move(r.completeRequestHandler);
+        isAliveHelper = std::move(r.isAliveHelper);
+        r.completeRequestHandler = nullptr;
+        r.isAliveHelper = nullptr;
         return *this;
     }
 
@@ -116,22 +130,16 @@ struct Response
     {
         if (completed)
         {
-            BMCWEB_LOG_ERROR << "Response was ended twice";
+            BMCWEB_LOG_ERROR << this << " Response was ended twice";
             return;
         }
         completed = true;
-        BMCWEB_LOG_DEBUG << "calling completion handler";
+        BMCWEB_LOG_DEBUG << this << " calling completion handler";
         if (completeRequestHandler)
         {
-            BMCWEB_LOG_DEBUG << "completion handler was valid";
-            completeRequestHandler();
+            BMCWEB_LOG_DEBUG << this << " completion handler was valid";
+            completeRequestHandler(*this);
         }
-    }
-
-    void end(std::string_view bodyPart)
-    {
-        write(bodyPart);
-        end();
     }
 
     bool isAlive()
@@ -139,14 +147,36 @@ struct Response
         return isAliveHelper && isAliveHelper();
     }
 
-    void setCompleteRequestHandler(std::function<void()> newHandler)
+    void setCompleteRequestHandler(std::function<void(Response&)>&& handler)
     {
-        completeRequestHandler = std::move(newHandler);
+        BMCWEB_LOG_DEBUG << this << " setting completion handler";
+        completeRequestHandler = std::move(handler);
+    }
+
+    std::function<void(Response&)> releaseCompleteRequestHandler()
+    {
+        BMCWEB_LOG_DEBUG << this << " releasing completion handler"
+                         << static_cast<bool>(completeRequestHandler);
+        std::function<void(Response&)> ret = completeRequestHandler;
+        completeRequestHandler = nullptr;
+        return ret;
+    }
+
+    void setIsAliveHelper(std::function<bool()>&& handler)
+    {
+        isAliveHelper = std::move(handler);
+    }
+
+    std::function<bool()> releaseIsAliveHelper()
+    {
+        std::function<bool()> ret = std::move(isAliveHelper);
+        isAliveHelper = nullptr;
+        return ret;
     }
 
   private:
-    bool completed{};
-    std::function<void()> completeRequestHandler;
+    bool completed = false;
+    std::function<void(Response&)> completeRequestHandler;
     std::function<bool()> isAliveHelper;
 
     // In case of a JSON object, set the Content-Type header

--- a/http/websocket.hpp
+++ b/http/websocket.hpp
@@ -193,10 +193,10 @@ class ConnectionImpl : public Connection
     {
         BMCWEB_LOG_DEBUG << "Websocket accepted connection";
 
-        auto asyncResp = std::make_shared<bmcweb::AsyncResp>(
-            res, [this, self(shared_from_this())]() { doRead(); });
+        auto asyncResp = std::make_shared<bmcweb::AsyncResp>();
 
         asyncResp->res.result(boost::beast::http::status::ok);
+        doRead();
 
         if (openHandler)
         {

--- a/include/async_resp.hpp
+++ b/include/async_resp.hpp
@@ -15,28 +15,17 @@ namespace bmcweb
 class AsyncResp
 {
   public:
-    AsyncResp(crow::Response& response) : res(response)
-    {}
-
-    AsyncResp(crow::Response& response, std::function<void()>&& function) :
-        res(response), func(std::move(function))
-    {}
+    AsyncResp() = default;
 
     AsyncResp(const AsyncResp&) = delete;
     AsyncResp(AsyncResp&&) = delete;
 
     ~AsyncResp()
     {
-        if (func && res.result() == boost::beast::http::status::ok)
-        {
-            func();
-        }
-
         res.end();
     }
 
-    crow::Response& res;
-    std::function<void()> func;
+    crow::Response res;
 };
 
 } // namespace bmcweb

--- a/include/openbmc_dbus_rest.hpp
+++ b/include/openbmc_dbus_rest.hpp
@@ -2232,9 +2232,7 @@ inline void requestRoutes(App& app)
             [](const crow::Request&,
                const std::shared_ptr<bmcweb::AsyncResp>& asyncResp,
                const std::string& connection) {
-                introspectObjects(
-                    connection, "/",
-                    std::make_shared<bmcweb::AsyncResp>(asyncResp->res));
+                introspectObjects(connection, "/", asyncResp);
             });
 
     BMCWEB_ROUTE(app, "/bus/system/<str>/<path>")

--- a/redfish-core/include/query.hpp
+++ b/redfish-core/include/query.hpp
@@ -1,0 +1,24 @@
+#pragma once
+
+#include "utils/query_param.hpp"
+
+namespace redfish
+{
+inline bool setUpRedfishRoute(crow::App& app, const crow::Request& req,
+                              crow::Response& res)
+{
+    BMCWEB_LOG_DEBUG << "setup redfish route";
+    std::optional<query_param::Query> query =
+        query_param::parseParameters(req.urlParams, res);
+    std::function<void(crow::Response&)> handler =
+        res.releaseCompleteRequestHandler();
+    BMCWEB_LOG_DEBUG << "Function was valid: " << static_cast<bool>(handler);
+    BMCWEB_LOG_DEBUG << "Setting completion handler for query";
+    res.setCompleteRequestHandler([&app, handler(std::move(handler)),
+                                   query](crow::Response& res) mutable {
+        BMCWEB_LOG_DEBUG << "Starting query params handling";
+        processAllParams(app, query, res, handler);
+    });
+    return true;
+}
+} // namespace redfish

--- a/redfish-core/include/query.hpp
+++ b/redfish-core/include/query.hpp
@@ -8,8 +8,12 @@ inline bool setUpRedfishRoute(crow::App& app, const crow::Request& req,
                               crow::Response& res)
 {
     BMCWEB_LOG_DEBUG << "setup redfish route";
-    std::optional<query_param::Query> query =
-        query_param::parseParameters(req.urlParams, res);
+    auto query = query_param::parseParameters(req.urlParams, res);
+    if (query == nullptr)
+    {
+        BMCWEB_LOG_DEBUG << "No query params to process";
+        return true;
+    }
     std::function<void(crow::Response&)> handler =
         res.releaseCompleteRequestHandler();
     BMCWEB_LOG_DEBUG << "Function was valid: " << static_cast<bool>(handler);

--- a/redfish-core/include/utils/query_param.hpp
+++ b/redfish-core/include/utils/query_param.hpp
@@ -1,0 +1,131 @@
+#pragma once
+
+#include "app.hpp"
+#include "async_resp.hpp"
+#include "error_messages.hpp"
+#include "http_request.hpp"
+#include "routing.hpp"
+
+#include <string_view>
+#include <vector>
+
+namespace redfish
+{
+namespace query_param
+{
+struct Query
+{
+    bool isOnly = false;
+};
+inline std::optional<Query>
+    parseParameters(const boost::urls::query_params_view& urlParams,
+                    crow::Response& res)
+{
+    Query ret{};
+    for (const boost::urls::query_params_view::value_type& it : urlParams)
+    {
+        if (it.key() == "only")
+        {
+            // Only cannot be combined with any other query
+            if (urlParams.size() != 1)
+            {
+                messages::queryCombinationInvalid(res);
+                return std::nullopt;
+            }
+            if (!it.value().empty())
+            {
+                messages::queryParameterValueFormatError(res, it.value(),
+                                                         it.key());
+                return std::nullopt;
+            }
+            ret.isOnly = true;
+        }
+    }
+    return ret;
+}
+inline bool processOnly(crow::App& app, crow::Response& res,
+                        std::function<void(crow::Response&)>& completionHandler)
+{
+    BMCWEB_LOG_DEBUG << "Processing only query param";
+    auto itMembers = res.jsonValue.find("Members");
+    if (itMembers == res.jsonValue.end())
+    {
+        messages::queryNotSupportedOnResource(res);
+        completionHandler(res);
+        return false;
+    }
+    auto itMemBegin = itMembers->begin();
+    if (itMemBegin == itMembers->end() || itMembers->size() != 1)
+    {
+        BMCWEB_LOG_DEBUG << "Members contains " << itMembers->size()
+                         << " element, returning full collection.";
+        completionHandler(res);
+        return false;
+    }
+    auto itUrl = itMemBegin->find("@odata.id");
+    if (itUrl == itMemBegin->end())
+    {
+        BMCWEB_LOG_DEBUG << "No found odata.id";
+        messages::internalError(res);
+        completionHandler(res);
+        return false;
+    }
+    const std::string* url = itUrl->get_ptr<const std::string*>();
+    if (!url)
+    {
+        BMCWEB_LOG_DEBUG << "@odata.id wasn't a string????";
+        messages::internalError(res);
+        completionHandler(res);
+        return false;
+    }
+    // TODO(Ed) copy request headers?
+    // newReq.session = req.session;
+    std::error_code ec;
+    crow::Request newReq({boost::beast::http::verb::get, *url, 11}, ec);
+    if (ec)
+    {
+        messages::internalError(res);
+        completionHandler(res);
+        return false;
+    }
+    auto asyncResp = std::make_shared<bmcweb::AsyncResp>();
+    BMCWEB_LOG_DEBUG << "setting completion handler on " << &asyncResp->res;
+    asyncResp->res.setCompleteRequestHandler(std::move(completionHandler));
+    asyncResp->res.setIsAliveHelper(res.releaseIsAliveHelper());
+    app.handle(newReq, asyncResp);
+    return true;
+}
+void processAllParams(crow::App& app, const std::optional<Query>& query,
+                      crow::Response& intermediateResponse,
+                      std::function<void(crow::Response&)>& completionHandler)
+{
+    if (!completionHandler)
+    {
+        BMCWEB_LOG_DEBUG << "Function was invalid?";
+        return;
+    }
+    BMCWEB_LOG_DEBUG << "Processing query params";
+    if (!query)
+    {
+        BMCWEB_LOG_DEBUG << "No query params to process";
+        // Query params weren't valid, no need to continue;
+        completionHandler(intermediateResponse);
+        return;
+    }
+    // If the request failed, there's no reason to even try to run query
+    // params.
+    if (intermediateResponse.resultInt() < 200 ||
+        intermediateResponse.resultInt() >= 400)
+    {
+        completionHandler(intermediateResponse);
+        return;
+    }
+    if (query->isOnly)
+    {
+        processOnly(app, intermediateResponse, completionHandler);
+        return;
+    }
+    completionHandler(intermediateResponse);
+}
+} // namespace query_param
+} // namespace redfish

--- a/redfish-core/include/utils/query_param.hpp
+++ b/redfish-core/include/utils/query_param.hpp
@@ -13,15 +13,28 @@ namespace redfish
 {
 namespace query_param
 {
+const uint64_t expandMaxLevel = 2;  // todo
+const uint64_t expandMinLenth = 12; //*($levels=1)
 struct Query
 {
     bool isOnly = false;
+    bool isExpand = false;
+    uint64_t expandLevel;
+    std::string expandType;
+    std::vector<std::string> pendingUrlVec;
+    std::vector<std::string> processedUrlVec;
+    nlohmann::json jsonValue;
 };
-inline std::optional<Query>
+
+void processAllParams(crow::App& app, std::shared_ptr<Query>& query,
+                      crow::Response& intermediateResponse,
+                      std::function<void(crow::Response&)>& completionHandler);
+
+std::shared_ptr<Query>
     parseParameters(const boost::urls::query_params_view& urlParams,
                     crow::Response& res)
 {
-    Query ret{};
+    auto ret = std::make_shared<Query>();
     for (const boost::urls::query_params_view::value_type& it : urlParams)
     {
         if (it.key() == "only")
@@ -30,19 +43,224 @@ inline std::optional<Query>
             if (urlParams.size() != 1)
             {
                 messages::queryCombinationInvalid(res);
-                return std::nullopt;
+                return nullptr;
             }
             if (!it.value().empty())
             {
                 messages::queryParameterValueFormatError(res, it.value(),
                                                          it.key());
-                return std::nullopt;
+                return nullptr;
             }
-            ret.isOnly = true;
+            ret->isOnly = true;
+        }
+        else if (it.key() == "$expand")
+        {
+            std::string value = std::string(it.value());
+            if (value == "*" || value == "." || value == "~")
+            {
+                ret->isExpand = true;
+                ret->expandType = std::move(value);
+                ret->expandLevel = 1;
+            }
+            else if (value.size() >= expandMinLenth &&
+                     value.substr(1, 9) == "($levels=" &&
+                     (value[0] == '*' || value[0] == '.' || value[0] == '~') &&
+                     value[value.size() - 1] == ')')
+            {
+                ret->isExpand = true;
+                ret->expandType = value[0];
+                ret->expandLevel = strtoul(
+                    value.substr(10, value.size() - 2).c_str(), nullptr, 10);
+                ret->expandLevel = ret->expandLevel < expandMaxLevel
+                                       ? ret->expandLevel
+                                       : expandMaxLevel;
+            }
+            else
+            {
+                messages::queryParameterValueFormatError(res, it.value(),
+                                                         it.key());
+                return nullptr;
+            }
         }
     }
     return ret;
 }
+
+inline void recursiveToGetUrls(nlohmann::json& j, std::shared_ptr<Query>& query)
+{
+    auto itExpand = j.find("isExpand");
+    if (itExpand == j.end())
+    {
+        auto it = j.find("@odata.id");
+        if (it != j.end())
+        {
+            std::string url = it->get<std::string>();
+
+            if (url.find('#') == std::string::npos)
+            {
+                query->pendingUrlVec.push_back(url);
+            }
+        }
+        else if (query->expandType == "*" || query->expandType == ".")
+        {
+            it = j.find("@Redfish.Settings");
+            if (it != j.end())
+            {
+                std::string url = it->get<std::string>();
+                if (url.find('#') == std::string::npos)
+                {
+                    query->pendingUrlVec.push_back(url);
+                }
+            }
+            else
+            {
+                it = j.find("@Redfish.ActionInfo");
+                if (it != j.end())
+                {
+                    std::string url = it->get<std::string>();
+                    if (url.find('#') == std::string::npos)
+                    {
+                        query->pendingUrlVec.push_back(url);
+                    }
+                }
+                else
+                {
+                    it = j.find("@Redfish.CollectionCapabilities");
+                    if (it != j.end())
+                    {
+                        std::string url = it->get<std::string>();
+                        if (url.find('#') == std::string::npos)
+                        {
+                            query->pendingUrlVec.push_back(url);
+                        }
+                    }
+                }
+            }
+        }
+    }
+    for (auto it = j.begin(); it != j.end(); ++it)
+    {
+        if (it->is_object())
+        {
+            if (query->expandType == "." && it.key() == "Links")
+            {
+                continue;
+            }
+            recursiveToGetUrls(*it, query);
+        }
+        else if (it->is_array())
+        {
+            for (auto& itArray : *it)
+            {
+                recursiveToGetUrls(itArray, query);
+            }
+        }
+    }
+}
+
+inline bool insertJson(nlohmann::json& base, const std::string& pos,
+                       const nlohmann::json& data,
+                       const std::shared_ptr<Query>& query)
+{
+    auto itExpand = base.find("isExpand");
+    if (itExpand != base.end())
+    {
+        if (itExpand->get<unsigned int>() <= query->expandLevel)
+        {
+            return false;
+        }
+    }
+    else
+    {
+        auto it = base.find("@odata.id");
+        if (it != base.end())
+        {
+            if (it->get<std::string>() == pos)
+            {
+                base = data;
+                return true;
+            }
+        }
+        else if (query->expandType == "*" || query->expandType == ".")
+        {
+            it = base.find("@Redfish.Settings");
+            if (it != base.end())
+            {
+                if (it->get<std::string>() == pos)
+                {
+                    base = data;
+                    return true;
+                }
+            }
+            else
+            {
+                it = base.find("@Redfish.ActionInfo");
+                if (it != base.end())
+                {
+                    if (it->get<std::string>() == pos)
+                    {
+                        base = data;
+                        return true;
+                    }
+                }
+                else
+                {
+                    it = base.find("@Redfish.CollectionCapabilities");
+                    if (it != base.end())
+                    {
+                        if (it->get<std::string>() == pos)
+                        {
+                            base = data;
+                            return true;
+                        }
+                    }
+                }
+            }
+        }
+    }
+    for (auto it = base.begin(); it != base.end(); ++it)
+    {
+        if (it->is_object())
+        {
+            if (query->expandType == "." && it.key() == "Links")
+            {
+                continue;
+            }
+            if (insertJson(*it, pos, data, query))
+            {
+                return true;
+            }
+        }
+        else if (it->is_array())
+        {
+            for (auto& itArray : *it)
+            {
+                if (insertJson(itArray, pos, data, query))
+                {
+                    return true;
+                }
+            }
+        }
+    }
+    return false;
+}
+
+inline void deleteExpand(nlohmann::json& j)
+{
+    auto it = j.find("isExpand");
+    if (it != j.end())
+    {
+        j.erase(it);
+    }
+    for (auto& it : j)
+    {
+        if (it.is_structured())
+        {
+            deleteExpand(it);
+        }
+    }
+}
+
 inline bool processOnly(crow::App& app, crow::Response& res,
                         std::function<void(crow::Response&)>& completionHandler)
 {
@@ -71,7 +289,7 @@ inline bool processOnly(crow::App& app, crow::Response& res,
         return false;
     }
     const std::string* url = itUrl->get_ptr<const std::string*>();
-    if (!url)
+    if (url == nullptr)
     {
         BMCWEB_LOG_DEBUG << "@odata.id wasn't a string????";
         messages::internalError(res);
@@ -95,7 +313,77 @@ inline bool processOnly(crow::App& app, crow::Response& res,
     app.handle(newReq, asyncResp);
     return true;
 }
-void processAllParams(crow::App& app, const std::optional<Query>& query,
+
+inline bool
+    processExpand(crow::App& app, crow::Response& res,
+                  std::function<void(crow::Response&)>& completionHandler,
+                  std::shared_ptr<Query>& query)
+{
+    if (query->pendingUrlVec.size() == 0)
+    {
+        if (res.jsonValue.find("isExpand") == res.jsonValue.end())
+        {
+            res.jsonValue["isExpand"] = query->expandLevel + 1;
+        }
+        recursiveToGetUrls(res.jsonValue, query);
+        if (query->pendingUrlVec.size() == 0)
+        {
+            deleteExpand(res.jsonValue);
+            return false;
+        }
+        query->jsonValue = res.jsonValue;
+
+        for (auto url : query->pendingUrlVec)
+        {
+            std::error_code ec;
+            crow::Request newReq({boost::beast::http::verb::get, url, 11}, ec);
+            if (ec)
+            {
+                messages::internalError(res);
+                completionHandler(res);
+                return true;
+            }
+
+            auto asyncResp = std::make_shared<bmcweb::AsyncResp>();
+            BMCWEB_LOG_DEBUG << "setting completion handler on "
+                             << &asyncResp->res;
+            asyncResp->res.setCompleteRequestHandler(
+                [&app, handler(completionHandler),
+                 query](crow::Response& res) mutable {
+                    BMCWEB_LOG_DEBUG << "Starting query params handling";
+                    processAllParams(app, query, res, handler);
+                });
+            asyncResp->res.setIsAliveHelper(res.releaseIsAliveHelper());
+            app.handle(newReq, asyncResp);
+        }
+        return true;
+    }
+    if (res.jsonValue.find("isExpand") == res.jsonValue.end())
+    {
+        res.jsonValue["isExpand"] = query->expandLevel;
+    }
+    insertJson(query->jsonValue, res.jsonValue["@odata.id"], res.jsonValue,
+               query);
+    query->processedUrlVec.push_back(res.jsonValue["@odata.id"]);
+
+    if (query->pendingUrlVec.size() == query->processedUrlVec.size())
+    {
+        query->expandLevel -= 1;
+        res.jsonValue = query->jsonValue;
+        if (query->expandLevel == 0)
+        {
+            deleteExpand(res.jsonValue);
+            return false;
+        }
+        query->pendingUrlVec.clear();
+        query->processedUrlVec.clear();
+        return processExpand(app, res, completionHandler, query);
+    }
+
+    return true;
+}
+
+void processAllParams(crow::App& app, std::shared_ptr<Query>& query,
                       crow::Response& intermediateResponse,
                       std::function<void(crow::Response&)>& completionHandler)
 {
@@ -105,13 +393,6 @@ void processAllParams(crow::App& app, const std::optional<Query>& query,
         return;
     }
     BMCWEB_LOG_DEBUG << "Processing query params";
-    if (!query)
-    {
-        BMCWEB_LOG_DEBUG << "No query params to process";
-        // Query params weren't valid, no need to continue;
-        completionHandler(intermediateResponse);
-        return;
-    }
     // If the request failed, there's no reason to even try to run query
     // params.
     if (intermediateResponse.resultInt() < 200 ||
@@ -124,6 +405,13 @@ void processAllParams(crow::App& app, const std::optional<Query>& query,
     {
         processOnly(app, intermediateResponse, completionHandler);
         return;
+    }
+    if (query->isExpand)
+    {
+        if (processExpand(app, intermediateResponse, completionHandler, query))
+        {
+            return;
+        }
     }
     completionHandler(intermediateResponse);
 }

--- a/redfish-core/lib/sensors.hpp
+++ b/redfish-core/lib/sensors.hpp
@@ -2971,10 +2971,9 @@ inline void retrieveUriToDbusMap(const std::string& chassis,
         return;
     }
 
-    auto res = std::make_shared<crow::Response>();
-    auto asyncResp = std::make_shared<bmcweb::AsyncResp>(*res);
+    auto asyncResp = std::make_shared<bmcweb::AsyncResp>();
     auto callback =
-        [res, asyncResp, mapCompleteCb{std::move(mapComplete)}](
+        [asyncResp, mapCompleteCb{std::move(mapComplete)}](
             const boost::beast::http::status status,
             const boost::container::flat_map<std::string, std::string>&
                 uriToDbus) { mapCompleteCb(status, uriToDbus); };

--- a/redfish-core/lib/sensors.hpp
+++ b/redfish-core/lib/sensors.hpp
@@ -15,6 +15,8 @@
 */
 #pragma once
 
+#include "query.hpp"
+
 #include <app.hpp>
 #include <boost/algorithm/string/predicate.hpp>
 #include <boost/algorithm/string/split.hpp>
@@ -3388,56 +3390,57 @@ inline void requestRoutesSensorCollection(App& app)
 {
     BMCWEB_ROUTE(app, "/redfish/v1/Chassis/<str>/Sensors/")
         .privileges(redfish::privileges::getSensorCollection)
-        .methods(
-            boost::beast::http::verb::get)([](const crow::Request&,
-                                              const std::shared_ptr<
-                                                  bmcweb::AsyncResp>& aResp,
-                                              const std::string& chassisId) {
-            BMCWEB_LOG_DEBUG << "SensorCollection doGet enter";
+        .methods(boost::beast::http::verb::get)(
+            [&app](const crow::Request& req,
+                   const std::shared_ptr<bmcweb::AsyncResp>& aResp,
+                   const std::string& chassisId) {
+                BMCWEB_LOG_DEBUG << "SensorCollection doGet enter";
+                redfish::setUpRedfishRoute(app, req, aResp->res);
+                std::shared_ptr<SensorsAsyncResp> asyncResp =
+                    std::make_shared<SensorsAsyncResp>(
+                        aResp, chassisId,
+                        sensors::dbus::paths.at(sensors::node::sensors),
+                        sensors::node::sensors);
 
-            std::shared_ptr<SensorsAsyncResp> asyncResp =
-                std::make_shared<SensorsAsyncResp>(
-                    aResp, chassisId,
-                    sensors::dbus::paths.at(sensors::node::sensors),
-                    sensors::node::sensors);
+                auto getChassisCb =
+                    [asyncResp](const std::shared_ptr<
+                                boost::container::flat_set<std::string>>&
+                                    sensorNames) {
+                        BMCWEB_LOG_DEBUG << "getChassisCb enter";
 
-            auto getChassisCb =
-                [asyncResp](
-                    const std::shared_ptr<
-                        boost::container::flat_set<std::string>>& sensorNames) {
-                    BMCWEB_LOG_DEBUG << "getChassisCb enter";
-
-                    nlohmann::json& entriesArray =
-                        asyncResp->asyncResp->res.jsonValue["Members"];
-                    for (auto& sensor : *sensorNames)
-                    {
-                        BMCWEB_LOG_DEBUG << "Adding sensor: " << sensor;
-
-                        sdbusplus::message::object_path path(sensor);
-                        std::string sensorName = path.filename();
-                        if (sensorName.empty())
+                        nlohmann::json& entriesArray =
+                            asyncResp->asyncResp->res.jsonValue["Members"];
+                        for (auto& sensor : *sensorNames)
                         {
-                            BMCWEB_LOG_ERROR << "Invalid sensor path: "
-                                             << sensor;
-                            messages::internalError(asyncResp->asyncResp->res);
-                            return;
+                            BMCWEB_LOG_DEBUG << "Adding sensor: " << sensor;
+
+                            sdbusplus::message::object_path path(sensor);
+                            std::string sensorName = path.filename();
+                            if (sensorName.empty())
+                            {
+                                BMCWEB_LOG_ERROR << "Invalid sensor path: "
+                                                 << sensor;
+                                messages::internalError(
+                                    asyncResp->asyncResp->res);
+                                return;
+                            }
+                            entriesArray.push_back(
+                                {{"@odata.id", "/redfish/v1/Chassis/" +
+                                                   asyncResp->chassisId + "/" +
+                                                   asyncResp->chassisSubNode +
+                                                   "/" + sensorName}});
                         }
-                        entriesArray.push_back(
-                            {{"@odata.id", "/redfish/v1/Chassis/" +
-                                               asyncResp->chassisId + "/" +
-                                               asyncResp->chassisSubNode + "/" +
-                                               sensorName}});
-                    }
 
-                    asyncResp->asyncResp->res.jsonValue["Members@odata.count"] =
-                        entriesArray.size();
-                    BMCWEB_LOG_DEBUG << "getChassisCb exit";
-                };
+                        asyncResp->asyncResp->res
+                            .jsonValue["Members@odata.count"] =
+                            entriesArray.size();
+                        BMCWEB_LOG_DEBUG << "getChassisCb exit";
+                    };
 
-            // Get set of sensors in chassis
-            getChassis(asyncResp, std::move(getChassisCb));
-            BMCWEB_LOG_DEBUG << "SensorCollection doGet exit";
-        });
+                // Get set of sensors in chassis
+                getChassis(asyncResp, std::move(getChassisCb));
+                BMCWEB_LOG_DEBUG << "SensorCollection doGet exit";
+            });
 }
 
 inline void requestRoutesSensor(App& app)

--- a/redfish-core/lib/service_root.hpp
+++ b/redfish-core/lib/service_root.hpp
@@ -68,6 +68,15 @@ inline void
         {"@odata.id", "/redfish/v1/LicenseService"}};
 #endif
     asyncResp->res.jsonValue["Cables"] = {{"@odata.id", "/redfish/v1/Cables"}};
+    asyncResp->res.jsonValue["ProtocolFeaturesSupported"] = {
+        {"OnlyMemberQuery", true},
+        {"ExpandQuery",
+         {{"ExpandAll", false},
+          {"Levels", false},
+          {"MaxLevels", 0},
+          {"Links", false},
+          {"NoLinks", false}}},
+        {"SelectQuery", false}};
 }
 
 inline void requestRoutesServiceRoot(App& app)

--- a/redfish-core/lib/systems.hpp
+++ b/redfish-core/lib/systems.hpp
@@ -17,6 +17,7 @@
 
 #include "led.hpp"
 #include "pcie.hpp"
+#include "query.hpp"
 #include "redfish_util.hpp"
 #ifdef BMCWEB_ENABLE_IBM_LAMP_TEST
 #include "oem/ibm/lamp_test.hpp"
@@ -2439,8 +2440,9 @@ inline void requestRoutesSystemsCollection(App& app)
     BMCWEB_ROUTE(app, "/redfish/v1/Systems/")
         .privileges(redfish::privileges::getComputerSystemCollection)
         .methods(boost::beast::http::verb::get)(
-            [](const crow::Request& /*req*/,
-               const std::shared_ptr<bmcweb::AsyncResp>& asyncResp) {
+            [&app](const crow::Request& req,
+                   const std::shared_ptr<bmcweb::AsyncResp>& asyncResp) {
+                redfish::setUpRedfishRoute(app, req, asyncResp->res);
                 asyncResp->res.jsonValue["@odata.type"] =
                     "#ComputerSystemCollection.ComputerSystemCollection";
                 asyncResp->res.jsonValue["@odata.id"] = "/redfish/v1/Systems";


### PR DESCRIPTION
These modifications are from WIP:Redfish:Query parameters:Only
(https://gerrit.openbmc-project.xyz/c/openbmc/bmcweb/+/47474). It will
be used in future CLs for Query Parameters.

The code changed the completion handle to accept Res to be able to
recall handle with a new Response object.
AsyncResp owns a new res, so there is no need to pass in a res.

Also fixed a self-move assignment bug.

Context:
Originally submitted:
https://gerrit.openbmc-project.xyz/c/openbmc/bmcweb/+/480020

Reveted here:
https://gerrit.openbmc-project.xyz/c/openbmc/bmcweb/+/48880

Because of failures here:
https://gerrit.openbmc-project.xyz/c/openbmc/openbmc/+/48864

Tested:
1. Romulus QEMU + Robot tests; all passed
2. Use scripts/websocket_test.py to test websockets. It is still work
correctly.
python3 websocket_test.py --host 127.0.0.1:2443

Signed-off-by: Nan Zhou <nanzhoumails@gmail.com>
Signed-off-by: John Edward Broadbent <jebr@google.com>
Signed-off-by: zhanghaicheng <zhanghch05@inspur.com>