### PR TITLE
Not return InternalError when there is no usbcodeupdate service

### DIFF
--- a/redfish-core/lib/oem/ibm/usb_code_update.hpp
+++ b/redfish-core/lib/oem/ibm/usb_code_update.hpp
@@ -63,8 +63,7 @@ inline void getServiceName(const std::shared_ptr<bmcweb::AsyncResp>& aResp,
                 return;
             }
 
-            BMCWEB_LOG_ERROR << "Can't find usb code update service!";
-            messages::internalError(aResp->res);
+            BMCWEB_LOG_DEBUG << "Can't find usb code update service!";
             return;
         },
         "xyz.openbmc_project.ObjectMapper",


### PR DESCRIPTION
If usb code update service is not available, to not return the data
associated with it, instead of returning an InternalError response for
it.

Signed-off-by: Chicago Duan <duanzhijia01@inspur.com>