### PR TITLE
EnvMetrics: Add AllowableMin/Max to PowerLimitWatts

### DIFF
--- a/redfish-core/lib/environment_metrics.hpp
+++ b/redfish-core/lib/environment_metrics.hpp
@@ -295,6 +295,36 @@ inline void
                                         "Disabled";
                                 }
                             }
+                            else if (property.first == "MinPowerCapValue")
+                            {
+                                const uint32_t* minCap =
+                                    std::get_if<uint32_t>(&property.second);
+
+                                if (minCap == nullptr)
+                                {
+
+                                    messages::internalError(asyncResp->res);
+                                    return;
+                                }
+                                asyncResp->res.jsonValue["PowerLimitWatts"]
+                                                        ["AllowableMin"] =
+                                    *minCap;
+                            }
+                            else if (property.first == "MaxPowerCapValue")
+                            {
+                                const uint32_t* maxCap =
+                                    std::get_if<uint32_t>(&property.second);
+
+                                if (maxCap == nullptr)
+                                {
+
+                                    messages::internalError(asyncResp->res);
+                                    return;
+                                }
+                                asyncResp->res.jsonValue["PowerLimitWatts"]
+                                                        ["AllowableMax"] =
+                                    *maxCap;
+                            }
                         }
                     },
                     connectionName, validPath,


### PR DESCRIPTION
Add the allowable range for the power cap/limit.
The AllowableMax and AllowableMin properties come from DBus.

Ran validator on hardware all EnvironmentMetrics passed.
Verified on hardware:
curl -s -k -X GET https://$bmc/redfish/v1/Chassis/chassis/EnvironmentMetrics

  "Id": "EnvironmentMetrics",
  "Name": "Chassis Environment Metrics",
  "PowerLimitWatts": {
    "AllowableMax": 3584,
    "AllowableMin": 2700,
    "ControlMode": "Disabled",
    "SetPoint": 990
  },

Change-Id: I7866b7243c56316fe7b883f58f4c2a88c62e2bdf
Signed-off-by: Chris Cain <cjcain@us.ibm.com>