### PR TITLE
Core: Fix, Patch a core into the respective parent processor

### DIFF
--- a/redfish-core/include/utils/hw_isolation.hpp
+++ b/redfish-core/include/utils/hw_isolation.hpp
@@ -223,6 +223,8 @@ inline void
  * @param[in] interfaces - The redfish resource dbus interfaces which will use
  *                         to get the given resource dbus objects from
  *                         the inventory.
+ * @param[in] parentSubtreePath - The resource parent subtree path to get
+ *                                the resource object path.
  *
  * @return The redfish response in given response buffer.
  *
@@ -235,11 +237,11 @@ inline void
  *       - This function will do either isolate or deisolate based on the
  *         given "Enabled" property value.
  */
-inline void
-    processHardwareIsolationReq(const std::shared_ptr<bmcweb::AsyncResp>& aResp,
-                                const std::string& resourceName,
-                                const std::string& resourceId, bool enabled,
-                                const std::vector<const char*>& interfaces)
+inline void processHardwareIsolationReq(
+    const std::shared_ptr<bmcweb::AsyncResp>& aResp,
+    const std::string& resourceName, const std::string& resourceId,
+    bool enabled, const std::vector<const char*>& interfaces,
+    const std::string& parentSubtreePath = "/xyz/openbmc_project/inventory")
 {
     std::vector<const char*> resourceIfaces(interfaces.begin(),
                                             interfaces.end());
@@ -334,7 +336,7 @@ inline void
         "xyz.openbmc_project.ObjectMapper",
         "/xyz/openbmc_project/object_mapper",
         "xyz.openbmc_project.ObjectMapper", "GetSubTreePaths",
-        "/xyz/openbmc_project/inventory", 0, resourceIfaces);
+        parentSubtreePath, 0, resourceIfaces);
 }
 
 /*

--- a/redfish-core/lib/processor.hpp
+++ b/redfish-core/lib/processor.hpp
@@ -1876,6 +1876,7 @@ inline void requestRoutesSubProcessors(App& app)
  *        patched to do appropriate action.
  *
  * @param[in] asyncResp - The redfish response to return.
+ * @param[in] procObjPath - The parent processor object path.
  * @param[in] coreId - The patched Processor Core resource id.
  * @param[in] enabled - The patched "Enabled" member value.
  *
@@ -1890,12 +1891,14 @@ inline void requestRoutesSubProcessors(App& app)
  */
 inline void
     patchCpuCoreMemberEnabled(const std::shared_ptr<bmcweb::AsyncResp>& resp,
+                              const std::string& procObjPath,
                               const std::string& coreId, const bool enabled)
 {
     redfish::hw_isolation_utils::processHardwareIsolationReq(
         resp, "Core", coreId, enabled,
         std::vector<const char*>(procCoreInterfaces.begin(),
-                                 procCoreInterfaces.end()));
+                                 procCoreInterfaces.end()),
+        procObjPath);
 }
 
 /**
@@ -1915,7 +1918,7 @@ inline void
 inline void
     patchCpuCoreMembers(const crow::Request& req,
                         const std::shared_ptr<bmcweb::AsyncResp>& asyncResp,
-                        const std::string& /* processorId */,
+                        const std::string& processorId,
                         const std::string& coreId)
 {
     std::optional<bool> enabled;
@@ -1925,10 +1928,15 @@ inline void
         return;
     }
 
-    if (enabled.has_value())
-    {
-        patchCpuCoreMemberEnabled(asyncResp, coreId, *enabled);
-    }
+    auto callback = [asyncResp, coreId, enabled](const std::string& cpuPath) {
+        // Handle patched Enabled Redfish property
+        if (enabled.has_value())
+        {
+            patchCpuCoreMemberEnabled(asyncResp, cpuPath, coreId, *enabled);
+        }
+    };
+
+    getProcessorPaths(asyncResp, processorId, std::move(callback));
 }
 
 inline void requestRoutesSubProcessorsCore(App& app)


### PR DESCRIPTION
Currently, the patch request handler of the Core resource is getting
the core inventory object by using the given Core id alone instead of
using the given processor and core id so, it might get the wrong core
object because the same core object might exist in the different
processor so fixed that in this patch.

Tested:

- Without Fix

```
> curl -k -H "X-Auth-Token: $bmc_token" -X PATCH https://${bmc}/redfish/v1 \
             /Systems/system/Processors/dcm0-cpu1/SubProcessors/core2 \
             -d '{"Enabled" : 'fale'}'

> guard -l (BMC console)
ID       | ERROR    |  Type  | Path
00000001 | 00000000 | manual | physical:sys-0/node-0/proc-0/eq-1/fc-0 <-- Should be proc-1 (dcm0-cpu1)
```

- With Fix

```
> curl -k -H "X-Auth-Token: $bmc_token" -X PATCH https://${bmc}/redfish/v1 \
             /Systems/system/Processors/dcm0-cpu1/SubProcessors/core2 \
             -d '{"Enabled" : 'fale'}'

> guard -l (BMC console)
ID       | ERROR    |  Type  | Path
00000001 | 00000000 | manual | physical:sys-0/node-0/proc-0/eq-1/fc-0
00000002 | 00000000 | manual | physical:sys-0/node-0/proc-1/eq-1/fc-0
```