### PR TITLE
Check PowerSupply availability prop for State/Hlth

### DIFF
--- a/redfish-core/lib/power_supply.hpp
+++ b/redfish-core/lib/power_supply.hpp
@@ -127,15 +127,15 @@ inline void
 inline void
     getPowerSupplyState(const std::shared_ptr<bmcweb::AsyncResp>& asyncResp,
                         const std::string& connectionName,
-                        const std::string& path)
+                        const std::string& path, bool available)
 {
 
     // Set the default state to Absent
     asyncResp->res.jsonValue["Status"]["State"] = "Enabled";
 
     crow::connections::systemBus->async_method_call(
-        [asyncResp](const boost::system::error_code ec,
-                    const std::variant<bool> state) {
+        [asyncResp, available](const boost::system::error_code ec,
+                               const std::variant<bool> state) {
             if (ec)
             {
                 if (ec.value() == EBADR)
@@ -157,6 +157,11 @@ inline void
             {
                 asyncResp->res.jsonValue["Status"]["State"] = "Absent";
             }
+            else if (!available)
+            {
+                asyncResp->res.jsonValue["Status"]["State"] =
+                    "UnavailableOffline";
+            }
         },
         connectionName, path, "org.freedesktop.DBus.Properties", "Get",
         "xyz.openbmc_project.Inventory.Item", "Present");
@@ -165,14 +170,14 @@ inline void
 inline void
     getPowerSupplyHealth(const std::shared_ptr<bmcweb::AsyncResp>& asyncResp,
                          const std::string& connectionName,
-                         const std::string& path)
+                         const std::string& path, bool available)
 {
     // Set the default Health to OK
     asyncResp->res.jsonValue["Status"]["Health"] = "OK";
 
     crow::connections::systemBus->async_method_call(
-        [asyncResp](const boost::system::error_code ec,
-                    const std::variant<bool> health) {
+        [asyncResp, available](const boost::system::error_code ec,
+                               const std::variant<bool> health) {
             if (ec)
             {
                 if (ec.value() == EBADR)
@@ -190,13 +195,50 @@ inline void
                 messages::internalError(asyncResp->res);
                 return;
             }
-            if (*value == false)
+            if ((*value == false) || !available)
             {
                 asyncResp->res.jsonValue["Status"]["Health"] = "Critical";
             }
         },
         connectionName, path, "org.freedesktop.DBus.Properties", "Get",
         "xyz.openbmc_project.State.Decorator.OperationalStatus", "Functional");
+}
+
+inline void getPowerSupplyStateAndHealth(
+    const std::shared_ptr<bmcweb::AsyncResp>& asyncResp,
+    const std::string& connectionName, const std::string& path)
+{
+    crow::connections::systemBus->async_method_call(
+        [asyncResp, connectionName,
+         path](const boost::system::error_code ec,
+               const std::variant<bool> availability) {
+            bool available = true;
+            if (ec)
+            {
+                if (ec.value() != EBADR)
+                {
+                    BMCWEB_LOG_ERROR << "Can't get PowerSupply availability!";
+                    messages::internalError(asyncResp->res);
+                    return;
+                }
+            }
+            else
+            {
+                const bool* value = std::get_if<bool>(&availability);
+                if (value == nullptr)
+                {
+                    messages::internalError(asyncResp->res);
+                    return;
+                }
+                available = *value;
+            }
+
+            getPowerSupplyState(asyncResp, connectionName, path, available);
+
+            getPowerSupplyHealth(asyncResp, connectionName, path, available);
+        },
+        connectionName, path, "org.freedesktop.DBus.Properties", "Get",
+        "xyz.openbmc_project.State.Decorator.Availability", "Available");
 }
 
 inline void
@@ -591,15 +633,10 @@ inline void requestRoutesPowerSupply(App& app)
                                                        validPowerSupplyService,
                                                        validPowerSupplyPath);
 
-                                // Get power supply state
-                                getPowerSupplyState(asyncResp,
-                                                    validPowerSupplyService,
-                                                    validPowerSupplyPath);
-
-                                // Get power supply health
-                                getPowerSupplyHealth(asyncResp,
-                                                     validPowerSupplyService,
-                                                     validPowerSupplyPath);
+                                // Get power supply state and health
+                                getPowerSupplyStateAndHealth(
+                                    asyncResp, validPowerSupplyService,
+                                    validPowerSupplyPath);
 
                                 // Get power supply firmware version
                                 getPowerSupplyFirmwareVersion(


### PR DESCRIPTION
This commit makes use of the Available property on the power supply
D-Bus object when determining the power supply state and health in the
PowerSupply response.  The power supply monitor code from phosphor-power
will set the property to false if it can determine that the power supply
isn't able to provide power due to certain faults.

If the PS isn't available, then the Health property will be set to
Critical, and the State will be set to UnavailableOffline (assuming it
shouldn't be Absent instead).

This is necessary because on IBM systems the Functional property
determines the fault LED state as well as the health value, and in
certain cases the fault LED needs to stay off even though the PS health
is not OK.  A specific example of this is when the PS cord is unplugged:
no fault LED is desired but it is desired for the Redfish output to show
that there is an issue with the PS.

If the Available property isn't present on D-Bus, it acts as if it had a
value of true and behaves the same as it does today.

Tested:
Available = false:
    "Health": "Critical",
    "State": "UnavailableOffline"

Available = true, Functional = false:
    "Health": "Critical",
    "State": "Enabled"

PS missing:
    "Health": "Critical",
    "State": "Absent"

Everything OK:
    "Health": "OK",
    "State": "Enabled"

No Available property on D-Bus:
    "Health": "OK",
    "State": "Enabled"

Upstream: https://gerrit.openbmc-project.xyz/c/openbmc/bmcweb/+/51336
Defect: SW542338

Signed-off-by: Matt Spinler <spinler@us.ibm.com>
Change-Id: I1a3194bf3a6ca3936954b31439070dcc2f343411