### PR TITLE
HMC-BMC: SSLHandshakeException workaround

### DIFF
--- a/http/timer_queue.hpp
+++ b/http/timer_queue.hpp
@@ -15,7 +15,7 @@ constexpr const size_t timerQueueTimeoutSeconds = 5;
 namespace detail
 {
 
-constexpr const size_t maxSize = 300;
+constexpr const size_t maxSize = 1000;
 // fast timer queue for fixed tick value.
 class TimerQueue
 {


### PR DESCRIPTION
Bump the timer queue max size to 1000 as discussed in the design call on
3/1.

https://github.com/ibm-openbmc/bmcweb/pull/175 bumped this max size to
300 and the SSLHandshakeException largely went away but still
infrequently seeing them as SW544871, SW543056, and SW544631 shows. It
is largely unknown how the HMC can create enough requests to hit this
300 but bump to 1000 as a workaround.

Long term we will want to move to the new boost timer with 100
connection limit like upstream has  but when we did so here,
https://github.com/ibm-openbmc/bmcweb/pull/207, we were unable to code
update so that needs fixed first, tracked by
https://github.com/ibm-openbmc/dev/issues/3426.

1000 was choose arbitrarily, still wanted a max but big enough this
won't get in our way again.

Tested: Sanity testing like GUI and validator.

Signed-off-by: Gunnar Mills <gmills@us.ibm.com>