### PR TITLE
GET PATCH userGroups Information ("AccountTypes")

### DIFF
--- a/redfish-core/include/error_messages.hpp
+++ b/redfish-core/include/error_messages.hpp
@@ -609,6 +609,17 @@ void sourceDoesNotSupportProtocol(crow::Response& res, const std::string& arg1,
                                   const std::string& arg2);
 
 /**
+ * @brief Formats StrictAccountTypes message into JSON
+ * Message body: Indicates the request failed because a set of `AccountTypes` or
+ * `OEMAccountTypes` was not accepted while `StrictAccountTypes` is set to `true
+ * @param[in] arg1 Parameter of message that will replace %1 in its body.
+ *
+ * @returns Message StrictAccountTypes formatted to JSON */
+nlohmann::json strictAccountTypes(const std::string& arg1);
+
+void strictAccountTypes(crow::Response& res, const std::string& arg1);
+
+/**
  * @brief Formats AccountRemoved message into JSON
  * Message body: "The account was successfully removed."
  *

--- a/redfish-core/lib/account_service.hpp
+++ b/redfish-core/lib/account_service.hpp
@@ -130,6 +130,59 @@ inline std::string getPrivilegeFromRoleId(std::string_view role)
     return "";
 }
 
+inline bool getAccountTypeFromUserGroup(std::string_view userGroup,
+                                        nlohmann::json& accountTypes)
+{
+    bool isFoundUserGroup = true;
+    if (userGroup == "redfish")
+    {
+        accountTypes.push_back("Redfish");
+    }
+    else if (userGroup == "ipmi")
+    {
+        accountTypes.push_back("IPMI");
+    }
+    else if (userGroup == "ssh")
+    {
+        accountTypes.push_back("HostConsole");
+        accountTypes.push_back("ManagerConsole");
+    }
+    else if (userGroup == "web")
+    {
+        accountTypes.push_back("WebUI");
+    }
+    else
+    {
+        // set false if userGroup not found
+        isFoundUserGroup = false;
+    }
+
+    return isFoundUserGroup;
+}
+
+inline void translateUserGroup(const std::vector<std::string>* userGroups,
+                               crow::Response& res)
+{
+    if (userGroups == nullptr)
+    {
+        BMCWEB_LOG_ERROR << "userGroups wasn't a string vector";
+        messages::internalError(res);
+        return;
+    }
+    nlohmann::json& accountTypes = res.jsonValue["AccountTypes"];
+    accountTypes = nlohmann::json::array();
+    for (const auto& userGroup : *userGroups)
+    {
+        if (!getAccountTypeFromUserGroup(userGroup, accountTypes))
+        {
+            BMCWEB_LOG_ERROR << "mapped value not for this userGroup value : "
+                             << userGroup;
+            messages::internalError(res);
+            return;
+        }
+    }
+}
+
 inline void userErrorMessageHandler(
     const sd_bus_error* e, const std::shared_ptr<bmcweb::AsyncResp>& asyncResp,
     const std::string& newUser, const std::string& username)
@@ -1990,8 +2043,7 @@ inline void requestAccountServiceRoutes(App& app)
                          "#ManagerAccount.v1_4_0.ManagerAccount"},
                         {"Name", "User Account"},
                         {"Description", "User Account"},
-                        {"Password", nullptr},
-                        {"AccountTypes", {"Redfish"}}};
+                        {"Password", nullptr}};
 
                     for (const auto& interface : userIt->second)
                     {
@@ -2078,6 +2130,15 @@ inline void requestAccountServiceRoutes(App& app)
                                     asyncResp->res
                                         .jsonValue["PasswordChangeRequired"] =
                                         *userPasswordExpired;
+                                }
+                                else if (property.first == "UserGroups")
+                                {
+                                    const std::vector<std::string>* userGroups =
+                                        std::get_if<std::vector<std::string>>(
+                                            &property.second);
+
+                                    translateUserGroup(userGroups,
+                                                       asyncResp->res);
                                 }
                             }
                         }

--- a/redfish-core/lib/account_service.hpp
+++ b/redfish-core/lib/account_service.hpp
@@ -215,14 +215,7 @@ inline bool getUserGroupFromAccountType(
         BMCWEB_LOG_ERROR << "HostConsole or ManagerConsole, one of value is "
                             "missing to set SSH property";
         isFoundAccountTypes = false;
-        if (!isHostConsole)
-        {
-            messages::strictAccountTypes(asyncResp->res, "AccountTypes");
-        }
-        if (!isManagerConsole)
-        {
-            messages::strictAccountTypes(asyncResp->res, "AccountTypes");
-        }
+        messages::strictAccountTypes(asyncResp->res, "AccountTypes");
         return isFoundAccountTypes;
     }
     if (isRedfish)

--- a/redfish-core/lib/account_service.hpp
+++ b/redfish-core/lib/account_service.hpp
@@ -70,7 +70,7 @@ struct LDAPConfigData
     std::vector<std::pair<std::string, LDAPRoleMapData>> groupRoleList;
 };
 
-using DbusVariantType = std::variant<bool, int32_t, std::string>;
+using DbusVariantType = std::variant<bool, int32_t, std::string, std::vector<std::string>>;
 
 using DbusInterfaceType = boost::container::flat_map<
     std::string, boost::container::flat_map<std::string, DbusVariantType>>;

--- a/redfish-core/lib/account_service.hpp
+++ b/redfish-core/lib/account_service.hpp
@@ -2327,8 +2327,7 @@ inline void requestAccountServiceRoutes(App& app)
             std::optional<bool> locked;
             std::optional<nlohmann::json> oem;
             std::optional<std::vector<std::string>> accountType;
-
-            bool isUserItself = (username == req.session->username);
+            bool isUserItself = false;
 
             if (!json_util::readJson(
                     req, asyncResp->res, "UserName", newUserName, "Password",
@@ -2355,6 +2354,9 @@ inline void requestAccountServiceRoutes(App& app)
                 messages::insufficientPrivilege(asyncResp->res);
                 return;
             }
+
+            // check user isitself or not
+            isUserItself = (username == req.session->username);
 
             Privileges effectiveUserPrivileges =
                 redfish::getUserPrivileges(req.userRole);

--- a/redfish-core/lib/account_service.hpp
+++ b/redfish-core/lib/account_service.hpp
@@ -217,11 +217,11 @@ inline bool getUserGroupFromAccountType(
         isFoundAccountTypes = false;
         if (!isHostConsole)
         {
-            messages::strictAccountTypes(asyncResp->res, "HostConsole");
+            messages::strictAccountTypes(asyncResp->res, "AccountTypes");
         }
         if (!isManagerConsole)
         {
-            messages::strictAccountTypes(asyncResp->res, "ManagerConsole");
+            messages::strictAccountTypes(asyncResp->res, "AccountTypes");
         }
         return isFoundAccountTypes;
     }
@@ -283,7 +283,7 @@ inline void translateAccountType(
         {
             BMCWEB_LOG_ERROR
                 << "user can not disable their own Redfish Property";
-            messages::strictAccountTypes(asyncResp->res, "Redfish");
+            messages::strictAccountTypes(asyncResp->res, "AccountTypes");
             return;
         }
     }

--- a/redfish-core/lib/account_service.hpp
+++ b/redfish-core/lib/account_service.hpp
@@ -70,7 +70,8 @@ struct LDAPConfigData
     std::vector<std::pair<std::string, LDAPRoleMapData>> groupRoleList;
 };
 
-using DbusVariantType = std::variant<bool, int32_t, std::string, std::vector<std::string>>;
+using DbusVariantType =
+    std::variant<bool, int32_t, std::string, std::vector<std::string>>;
 
 using DbusInterfaceType = boost::container::flat_map<
     std::string, boost::container::flat_map<std::string, DbusVariantType>>;
@@ -105,6 +106,7 @@ inline std::string getRoleIdFromPrivilege(std::string_view role)
     }
     return "";
 }
+
 inline std::string getPrivilegeFromRoleId(std::string_view role)
 {
     if (role == "Administrator")
@@ -133,7 +135,9 @@ inline std::string getPrivilegeFromRoleId(std::string_view role)
 inline bool getAccountTypeFromUserGroup(std::string_view userGroup,
                                         nlohmann::json& accountTypes)
 {
+    // set false if userGroup values are not found in list, return error
     bool isFoundUserGroup = true;
+
     if (userGroup == "redfish")
     {
         accountTypes.push_back("Redfish");
@@ -160,6 +164,76 @@ inline bool getAccountTypeFromUserGroup(std::string_view userGroup,
     return isFoundUserGroup;
 }
 
+inline bool getUserGroupFromAccountType(
+    const std::optional<std::vector<std::string>>& accountTypes,
+    std::vector<std::string>& userGroup)
+{
+    // set false if AccountTypes values are not found in list, return error
+    bool isFoundAccountTypes = true;
+
+    bool isRedfish = false;
+    bool isIPMI = false;
+    bool isHostConsole = false;
+    bool isManagerConsole = false;
+    bool isWebUI = false;
+
+    for (const auto& accountType : *accountTypes)
+    {
+        if (accountType == "Redfish")
+        {
+            isRedfish = true;
+        }
+        else if (accountType == "IPMI")
+        {
+            isIPMI = true;
+        }
+        else if (accountType == "WebUI")
+        {
+            isWebUI = true;
+        }
+        else if ((accountType == "HostConsole"))
+        {
+            isHostConsole = true;
+        }
+        else if (accountType == "ManagerConsole")
+        {
+            isManagerConsole = true;
+        }
+        else
+        {
+            // set false if accountTypes not found and return
+            isFoundAccountTypes = false;
+            return isFoundAccountTypes;
+        }
+    }
+
+    if (isRedfish)
+    {
+        userGroup.emplace_back("redfish");
+    }
+    if (isIPMI)
+    {
+        userGroup.emplace_back("ipmi");
+    }
+    if (isWebUI)
+    {
+        userGroup.emplace_back("web");
+    }
+    if ((isHostConsole) ^ (isManagerConsole))
+    {
+        BMCWEB_LOG_ERROR << "HostConsole or ManagerConsole, one of value is "
+                            "missing to set SSH property";
+        isFoundAccountTypes = false;
+        return isFoundAccountTypes;
+    }
+    if ((isHostConsole) && (isManagerConsole))
+    {
+        userGroup.emplace_back("ssh");
+    }
+
+    return isFoundAccountTypes;
+}
+
 inline void translateUserGroup(const std::vector<std::string>* userGroups,
                                crow::Response& res)
 {
@@ -181,6 +255,65 @@ inline void translateUserGroup(const std::vector<std::string>* userGroups,
             return;
         }
     }
+}
+
+inline void translateAccountType(
+    const std::optional<std::vector<std::string>>& accountType,
+    const std::shared_ptr<bmcweb::AsyncResp>& asyncResp,
+    const std::string& dbusObjectPath, bool isUserItself, bool isAdminUser)
+{
+    // user can not disable their own Redfish Property.
+    if (isUserItself)
+    {
+        if (auto it = std::find(accountType->cbegin(), accountType->cend(),
+                                "Redfish");
+            it == accountType->cend())
+        {
+            BMCWEB_LOG_ERROR
+                << "user can not disable their own Redfish Property";
+            messages::accountNotModified(asyncResp->res);
+            return;
+        }
+    }
+
+    // MAP userGroup with accountTypes value
+    std::vector<std::string> updatedUserGroup;
+    if (!getUserGroupFromAccountType(accountType, updatedUserGroup))
+    {
+        BMCWEB_LOG_ERROR << "accountType value unable to mapped";
+        messages::internalError(asyncResp->res);
+        return;
+    }
+
+    // ssh configuration can't disable for Admin User
+    if (isAdminUser)
+    {
+        if (auto it = std::find(updatedUserGroup.cbegin(),
+                                updatedUserGroup.cend(), "ssh");
+            it == updatedUserGroup.cend())
+        {
+            BMCWEB_LOG_ERROR
+                << "ssh configuration can't disable for Admin User";
+            messages::accountNotModified(asyncResp->res);
+            return;
+        }
+    }
+
+    crow::connections::systemBus->async_method_call(
+        [asyncResp](const boost::system::error_code ec) {
+            if (ec)
+            {
+                BMCWEB_LOG_ERROR << "D-Bus responses error: " << ec;
+                messages::internalError(asyncResp->res);
+                return;
+            }
+            messages::success(asyncResp->res);
+            return;
+        },
+        "xyz.openbmc_project.User.Manager", dbusObjectPath.c_str(),
+        "org.freedesktop.DBus.Properties", "Set",
+        "xyz.openbmc_project.User.Attributes", "UserGroups",
+        dbus::utility::DbusVariantType{updatedUserGroup});
 }
 
 inline void userErrorMessageHandler(
@@ -1303,12 +1436,11 @@ inline void handleLDAPPatch(nlohmann::json& input,
     });
 }
 
-inline void updateUserProperties(std::shared_ptr<bmcweb::AsyncResp> asyncResp,
-                                 const std::string& username,
-                                 std::optional<std::string> password,
-                                 std::optional<bool> enabled,
-                                 std::optional<std::string> roleId,
-                                 std::optional<bool> locked)
+inline void updateUserProperties(
+    std::shared_ptr<bmcweb::AsyncResp> asyncResp, const std::string& username,
+    std::optional<std::string> password, std::optional<bool> enabled,
+    std::optional<std::string> roleId, std::optional<bool> locked,
+    std::optional<std::vector<std::string>> accountType, bool isUserItself)
 {
     std::string dbusObjectPath = "/xyz/openbmc_project/user/" + username;
     dbus::utility::escapePathForDbus(dbusObjectPath);
@@ -1317,6 +1449,7 @@ inline void updateUserProperties(std::shared_ptr<bmcweb::AsyncResp> asyncResp,
         dbusObjectPath,
         [dbusObjectPath, username, password(std::move(password)),
          roleId(std::move(roleId)), enabled, locked,
+         accountType(std::move(accountType)), isUserItself,
          asyncResp{std::move(asyncResp)}](int rc) {
             if (!rc)
             {
@@ -1426,6 +1559,40 @@ inline void updateUserProperties(std::shared_ptr<bmcweb::AsyncResp> asyncResp,
                     "org.freedesktop.DBus.Properties", "Set",
                     "xyz.openbmc_project.User.Attributes",
                     "UserLockedForFailedAttempt", std::variant<bool>{*locked});
+            }
+            if (accountType)
+            {
+                crow::connections::systemBus->async_method_call(
+                    [accountType, asyncResp, dbusObjectPath,
+                     isUserItself](const boost::system::error_code ec,
+                                   std::variant<std::string>& userPrivilege) {
+                        if (ec)
+                        {
+                            BMCWEB_LOG_ERROR << "D-Bus responses error: " << ec;
+                            messages::internalError(asyncResp->res);
+                            return;
+                        }
+                        const std::string* userPrivPtr =
+                            std::get_if<std::string>(&userPrivilege);
+                        if (userPrivPtr == nullptr)
+                        {
+                            BMCWEB_LOG_ERROR << "UserPrivilege wasn't a "
+                                                "string";
+                            messages::internalError(asyncResp->res);
+                            return;
+                        }
+
+                        // check is user is admin user or not
+                        bool isAdminUser =
+                            (*userPrivPtr == "priv-admin") ? true : false;
+
+                        translateAccountType(accountType, asyncResp,
+                                             dbusObjectPath, isUserItself,
+                                             isAdminUser);
+                    },
+                    "xyz.openbmc_project.User.Manager", dbusObjectPath.c_str(),
+                    "org.freedesktop.DBus.Properties", "Get",
+                    "xyz.openbmc_project.User.Attributes", "UserPrivilege");
             }
         });
 }
@@ -2190,11 +2357,15 @@ inline void requestAccountServiceRoutes(App& app)
             std::optional<std::string> roleId;
             std::optional<bool> locked;
             std::optional<nlohmann::json> oem;
+            std::optional<std::vector<std::string>> accountType;
 
-            if (!json_util::readJson(req, asyncResp->res, "UserName",
-                                     newUserName, "Password", password,
-                                     "RoleId", roleId, "Enabled", enabled,
-                                     "Locked", locked, "Oem", oem))
+            bool isUserItself =
+                (username == req.session->username ? true : false);
+
+            if (!json_util::readJson(
+                    req, asyncResp->res, "UserName", newUserName, "Password",
+                    password, "RoleId", roleId, "Enabled", enabled, "Locked",
+                    locked, "Oem", oem, "AccountTypes", accountType))
             {
                 return;
             }
@@ -2352,15 +2523,16 @@ inline void requestAccountServiceRoutes(App& app)
             if (!newUserName || (newUserName.value() == username))
             {
                 updateUserProperties(asyncResp, username, password, enabled,
-                                     roleId, locked);
+                                     roleId, locked, accountType, isUserItself);
                 return;
             }
             crow::connections::systemBus->async_method_call(
                 [asyncResp, username, password(std::move(password)),
                  roleId(std::move(roleId)), enabled,
-                 newUser{std::string(*newUserName)},
-                 locked](const boost::system::error_code ec,
-                         sdbusplus::message::message& m) {
+                 newUser{std::string(*newUserName)}, locked, isUserItself,
+                 accountType{std::move(accountType)}](
+                    const boost::system::error_code ec,
+                    sdbusplus::message::message& m) {
                     if (ec)
                     {
                         userErrorMessageHandler(m.get_error(), asyncResp,
@@ -2369,7 +2541,8 @@ inline void requestAccountServiceRoutes(App& app)
                     }
 
                     updateUserProperties(asyncResp, newUser, password, enabled,
-                                         roleId, locked);
+                                         roleId, locked, accountType,
+                                         isUserItself);
                 },
                 "xyz.openbmc_project.User.Manager", "/xyz/openbmc_project/user",
                 "xyz.openbmc_project.User.Manager", "RenameUser", username,

--- a/redfish-core/src/error_messages.cpp
+++ b/redfish-core/src/error_messages.cpp
@@ -1346,6 +1346,34 @@ void sourceDoesNotSupportProtocol(crow::Response& res, const std::string& arg1,
 
 /**
  * @internal
+ * @brief strict Account Types message into JSON
+ *
+ * See header file for more information
+ * @endinternal
+ */
+nlohmann::json strictAccountTypes(const std::string& arg1)
+{
+    return nlohmann::json{
+        {"@odata.type", "#MessageRegistry.v1_5_0.MessageRegistry"},
+        {"MessageId", "Base.1.12.1.StrictAccountTypes"},
+        {"Message", "The request was not possible to fulfill with the account "
+                    "types included in property " +
+                        arg1 + " and property StrictAccountTypes set to true."},
+        {"MessageArgs", {arg1}},
+        {"MessageSeverity", "Warning"},
+        {"Resolution",
+         "Resubmit the request either with an acceptable set of AccountTypes "
+         "and OEMAccountTypes or with StrictAccountTypes set to false."}};
+}
+
+void strictAccountTypes(crow::Response& res, const std::string& arg1)
+{
+    res.result(boost::beast::http::status::bad_request);
+    addMessageToErrorJson(res.jsonValue, strictAccountTypes(arg1));
+}
+
+/**
+ * @internal
  * @brief Formats AccountRemoved message into JSON
  *
  * See header file for more information


### PR DESCRIPTION
This commit enhances the redfish API to retrieve and set userGroups
information for each user account.

"Redfish" is always enabled in each user role. That's why it was
hardcoded into JSON response data in the old redfish API, where now it
gets retrieved using dbus interface xyz.openbmc_project.User.Attributes.
UserGroups.

UserGroups retrieve data are "redfish", "ssh", "web", and "ipmi", where
redfish DMTF Schema has predefined enum type as described below.

  "AccountTypes": {
    "enum":["Redfish", "SNMP", "OEM", "HostConsole", "ManagerConsole",
            "IPMI", "KVMIP", "VirtualMedia", "WebUI"]
   }

Here UserGroups ssh is mapped with two AccountTypes "HostConsole",
"ManagerConsole".

  - Redfish ManagerConsole == SSH to port 22 == Phosphor User manager
    Phosphor “ssh” privilege
  - Redfish HostConsole == SSH to port 2200 (host console), Which
    OpenBMC implements using the Phosphor User manager Phosphor “ssh”
    privilege.

This commit also enhances the redfish API to set and unset userGroups
information for each user account.

Users with ConfigureUsers level privilege can patch (Set and Unset)
AccountTypes of each user role. In addition, a user with
"ConfigureSelf" level privilege can only set or Update their password.

"Redfish" is always enabled in each user role. However,
"ConfigureUsers" can disable other user redfish services. But if
"ConfigureUsers" try to disable its redfish service, that generates an
error.

In this commit, users can enable and disable "redfish", "ssh", and
"ipmi" services from each user.

Tested: tested using the curl command. test using both privileges
"ConfigureUsers", "ConfigureSelf"

curl -k -H "X-Auth-Token: $token" -X PATCH [https://${bmc}/redfish/v1/](https://%24%7Bbmc%7D/redfish/v1/)
  AccountService/Accounts/operator_user -d '{"AccountTypes":["IPMI",
  "HostConsole","ManagerConsole","ManagerConsole"]}'
  
curl -k -H "X-Auth-Token: $token" -X GET [https://${bmc}/redfish/v1/](https://%24%7Bbmc%7D/redfish/v1/)
AccountService/Accounts/admin
{
  "@[odata.id](http://odata.id/)": "/redfish/v1/AccountService/Accounts/admin",
  "@odata.type": "#ManagerAccount.v1_4_0.ManagerAccount",
  "AccountTypes": [
    "IPMI",
    "Redfish",
    "HostConsole",
    "ManagerConsole"
  ],
  "Description": "User Account",
  "Enabled": true,
  "Id": "admin",
  "Links": {
    "Role": {
      "@[odata.id](http://odata.id/)": "/redfish/v1/AccountService/Roles/Administrator"
    }
  },

    ...
    ...
}


upstream:
https://gerrit.openbmc-project.xyz/c/openbmc/bmcweb/+/50835
https://gerrit.openbmc-project.xyz/c/openbmc/bmcweb/+/50965