### PR TITLE
DumpOffload: Clean up Unix Socket on abrupt http connection close

### DIFF
--- a/include/dump_offload.hpp
+++ b/include/dump_offload.hpp
@@ -177,6 +177,7 @@ class Handler : public std::enable_shared_from_this<Handler>
         }
         if (fileExists)
         {
+            unixSocket.close();
             std::remove(unixSocketPath.c_str());
         }
         return;
@@ -341,6 +342,7 @@ inline void requestRoutes(App& app)
                 BMCWEB_LOG_DEBUG << "No handler to cleanup";
                 return;
             }
+            handler->second->cleanupSocketFiles();
             handler->second->outputBuffer.clear();
             handlers.erase(handler);
         });
@@ -416,6 +418,7 @@ inline void requestRoutes(App& app)
                 BMCWEB_LOG_DEBUG << "No handler to cleanup";
                 return;
             }
+            handler->second->cleanupSocketFiles();
             handlers.erase(handler);
             handler->second->outputBuffer.clear();
         });


### PR DESCRIPTION
Generally system/LPA dumps may take few mins to offload dump.
In slow network scenarios it may take few hours and client can choose to stop 
dump offload abruptly from client side.

This commit does unix socket cleanup when client abruptly closes
http connection while offloading dump.

This is downstream only since the dump offload is downstream only, 
we plan to upstream dump offload one day <or insert the real plan>
There isn't a defect for this but issue was seen without this change 

Tested by:
Interrupt curl command while offloading system dump 
Interrupt curl command while offloading LPA dump 