### PR TITLE
redfish:systems: Handle power restore policy of "None"

### DIFF
--- a/redfish-core/lib/systems.hpp
+++ b/redfish-core/lib/systems.hpp
@@ -961,16 +961,20 @@ inline void
             }
 
             const boost::container::flat_map<std::string, std::string>
-                policyMaps = {
-                    {"xyz.openbmc_project.Control.Power.RestorePolicy.Policy."
-                     "AlwaysOn",
-                     "AlwaysOn"},
-                    {"xyz.openbmc_project.Control.Power.RestorePolicy.Policy."
-                     "AlwaysOff",
-                     "AlwaysOff"},
-                    {"xyz.openbmc_project.Control.Power.RestorePolicy.Policy."
-                     "Restore",
-                     "LastState"}};
+                policyMaps = {{"xyz.openbmc_project.Control.Power."
+                               "RestorePolicy.Policy.AlwaysOn",
+                               "AlwaysOn"},
+                              {"xyz.openbmc_project.Control.Power."
+                               "RestorePolicy.Policy.AlwaysOff",
+                               "AlwaysOff"},
+                              {"xyz.openbmc_project.Control.Power."
+                               "RestorePolicy.Policy.Restore",
+                               "LastState"},
+                              // Return `AlwaysOff` when power restore policy
+                              // set to "None"
+                              {"xyz.openbmc_project.Control.Power."
+                               "RestorePolicy.Policy.None",
+                               "AlwaysOff"}};
 
             const std::string* policyPtr = std::get_if<std::string>(&policy);
 


### PR DESCRIPTION
On the Control.Power.RestorePolicy interface, a value of "None" is
allowed on the PowerRestorePolicy property and Redfish should handle
this value instead of throwing an internal error. Until support of
"None" as a one time parameter is included into the Redfish schema,
return "AlwaysOff" to align with the dbus interface.

Tested:
  Set PowerRestorePolicy to "None" enum value
  Verified `PowerRestorePolicy` value is "AlwaysOff" thru Redfish
  Set PowerRestorePolicy to "AlwaysOff" enum value
  Verified `PowerRestorePolicy` value is "AlwaysOff" thru Redfish
  Ran Redfish validator:

	Elapsed time: 0:02:47
	invalidPropertyValue: 44
	metadataNamespaces: 2390
	pass: 4384
	passAction: 10
	passGet: 212
	passRedfishUri: 170
	repeat: 1
	skipNoSchema: 3
	skipOptional: 4530
	warnDeprecated: 319
	warningPresent: 64
	Validation has succeeded.

Signed-off-by: Matthew Barth <msbarth@us.ibm.com>
Change-Id: Idb5b16ae797527b9d35a58aa3c26f6527aa5436d