### PR TITLE
Fix LampTest and get/setSAI

### DIFF
--- a/redfish-core/lib/oem/ibm/system_attention_indicator.hpp
+++ b/redfish-core/lib/oem/ibm/system_attention_indicator.hpp
@@ -108,18 +108,21 @@ inline void getSAI(const std::shared_ptr<bmcweb::AsyncResp>& aResp,
                     return;
                 }
 
-                nlohmann::json& oemSAI =
-                    aResp->res.jsonValue["Oem"]["OpenBmc"]["IBMOem"];
-                aResp->res.jsonValue["Oem"]["OpenBmc"]["@odata.type"] =
-                    "#OemComputerSystem.OpenBmc";
-                oemSAI["@odata.type"] = "#OemComputerSystem.IBMOem";
+                aResp->res.jsonValue["Oem"]["@odata.type"] =
+                    "#OemComputerSystem.Oem";
+                aResp->res.jsonValue["Oem"]["IBM"]["@odata.type"] =
+                    "#OemComputerSystem.IBM";
                 if (propertyValue == "PartitionSystemAttentionIndicator")
                 {
-                    oemSAI["PartitionSystemAttentionIndicator"] = *ledOn;
+                    aResp->res.jsonValue["Oem"]["IBM"]
+                                        ["PartitionSystemAttentionIndicator"] =
+                        *ledOn;
                 }
                 else if (propertyValue == "PlatformSystemAttentionIndicator")
                 {
-                    oemSAI["PlatformSystemAttentionIndicator"] = *ledOn;
+                    aResp->res.jsonValue["Oem"]["IBM"]
+                                        ["PlatformSystemAttentionIndicator"] =
+                        *ledOn;
                 }
             },
             serviceName, objectPath, "org.freedesktop.DBus.Properties", "Get",

--- a/redfish-core/lib/systems.hpp
+++ b/redfish-core/lib/systems.hpp
@@ -2861,25 +2861,11 @@ inline void requestRoutesSystems(App& app)
 
                     if (ibmOem)
                     {
-#ifdef BMCWEB_ENABLE_IBM_LAMP_TEST
                         std::optional<bool> lampTest;
-                        if (!json_util::readJson(*ibmOem, asyncResp->res,
-                                                 "LampTest", lampTest))
-                        {
-                            return;
-                        }
-
-                        if (lampTest)
-                        {
-                            setLampTestState(asyncResp, *lampTest);
-                        }
-#endif
-
-#ifdef BMCWEB_ENABLE_SAI
                         std::optional<bool> partitionSAI;
                         std::optional<bool> platformSAI;
                         if (!json_util::readJson(
-                                *ibmOem, asyncResp->res,
+                                *ibmOem, asyncResp->res, "LampTest", lampTest,
                                 "PartitionSystemAttentionIndicator",
                                 partitionSAI,
                                 "PlatformSystemAttentionIndicator",
@@ -2888,6 +2874,14 @@ inline void requestRoutesSystems(App& app)
                             return;
                         }
 
+#ifdef BMCWEB_ENABLE_IBM_LAMP_TEST
+                        if (lampTest)
+                        {
+                            setLampTestState(asyncResp, *lampTest);
+                        }
+#endif
+
+#ifdef BMCWEB_ENABLE_SAI
                         if (partitionSAI)
                         {
                             setSAI(asyncResp,

--- a/static/redfish/v1/JsonSchemas/OemComputerSystem/index.json
+++ b/static/redfish/v1/JsonSchemas/OemComputerSystem/index.json
@@ -116,9 +116,9 @@
             "properties": {},
             "type": "object"
         },
-        "IBMOem": {
+        "IBM": {
             "additionalProperties": true,
-            "description": "Oem properties for IBMOem.",
+            "description": "Oem properties for IBM.",
             "patternProperties": {
                 "^([a-zA-Z_][a-zA-Z0-9_]*)?@(odata|Redfish|Message)\\.[a-zA-Z_][a-zA-Z0-9_]*$": {
                     "description": "This property shall specify a valid odata or Redfish property.",

--- a/static/redfish/v1/schema/OemComputerSystem_v1.xml
+++ b/static/redfish/v1/schema/OemComputerSystem_v1.xml
@@ -24,10 +24,9 @@
                 <Annotation Term="OData.AutoExpand"/>
                 <Property Name="OpenBmc" Type="OemComputerSystem.OpenBmc"/>
                 <Property Name="IBM" Type="OemComputerSystem.IBM"/>
-                <Property Name="IBMOem" Type="OemComputerSystem.IBMOem"/>
             </ComplexType>
 
-            <ComplexType Name="IBMOem" BaseType="Resource.OemObject">
+            <ComplexType Name="IBM" BaseType="Resource.OemObject">
                 <Annotation Term="OData.AdditionalProperties" Bool="true" />
                 <Annotation Term="OData.Description" String="Oem properties for IBM." />
                 <Annotation Term="OData.AutoExpand"/>
@@ -41,12 +40,6 @@
                     <Annotation Term="OData.Description" String="An indicator allowing an operator to operate platform system attention."/>
                     <Annotation Term="OData.LongDescription" String="This property shall contain the state of the platform system attention of this resource."/>
                 </Property>
-            </ComplexType>
-
-            <ComplexType Name="IBM" BaseType="Resource.OemObject">
-                <Annotation Term="OData.AdditionalProperties" Bool="true" />
-                <Annotation Term="OData.Description" String="Oem properties for IBM." />
-                <Annotation Term="OData.AutoExpand"/>
             </ComplexType>
 
             <ComplexType Name="OpenBmc" BaseType="Resource.OemObject">


### PR DESCRIPTION
Fix PartitionSystemAttentionIndicator / PlatformSystemAttentionIndicator OEM
refer: https://github.com/ibm-openbmc/dev/issues/3519

After enabled both -Dibm-sai and -Dibm-lamp-test Lamp Test no longer works
refer: https://github.com/ibm-openbmc/dev/issues/3520

Signed-off-by: George Liu <liuxiwei@inspur.com>