### PR TITLE
Fix IBM OEM LED Bugs

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -88,12 +88,11 @@ feature_map = {
   'insecure-tftp-update'            : '-DBMCWEB_INSECURE_ENABLE_REDFISH_FW_TFTP_UPDATE',
   #'vm-nbdproxy'                     : '-DBMCWEB_ENABLE_VM_NBDPROXY',
   'vm-websocket'                    : '-DBMCWEB_ENABLE_VM_WEBSOCKET',
-  'ibm-lamp-test'                   : '-DBMCWEB_ENABLE_IBM_LAMP_TEST',
+  'ibm-led-extensions'              : '-DBMCWEB_ENABLE_IBM_LED_EXTENSIONS',
   'ibm-usb-code-update'             : '-DBMCWEB_ENABLE_IBM_USB_CODE_UPDATE',
   'hw-isolation'                    : '-DBMCWEB_ENABLE_HW_ISOLATION',
   'redfish-license'                 : '-DBMCWEB_ENABLE_REDFISH_LICENSE',
   'fan-oem-data'                    : '-DBMCWEB_ENABLE_FAN_OEM_DATA',
-  'ibm-sai'                         : '-DBMCWEB_ENABLE_SAI',
 }
 
 # Get the options status and build a project summary to show which flags are

--- a/meson_options.txt
+++ b/meson_options.txt
@@ -32,14 +32,13 @@ option('cookie-auth', type : 'feature', value : 'enabled', description : '''Enab
 option('mutual-tls-auth', type : 'feature', value : 'enabled', description : '''Enables authenticating users through TLS client certificates. The insecure-disable-ssl must be disabled for this option to take effect.''')
 option('ibm-management-console', type : 'feature', value : 'disabled', description : 'Enable the IBM management console specific functionality. Paths are under \'/ibm/v1/\'')
 option('google-api', type : 'feature', value : 'disabled', description : 'Enable the Google specific functionality. Paths are under \'/google/v1/\'')
-option('ibm-lamp-test', type : 'feature', value : 'disabled', description : 'Enable the IBM lamp test functionality')
+option('ibm-led-extensions', type : 'feature', value : 'disabled', description : 'Enable the IBM LED extensions such as lamp test and system attention indicators')
 option('ibm-usb-code-update', type : 'feature', value : 'disabled', description : 'Enable the USB code update functionality')
 option('http-body-limit', type: 'integer', min : 0, max : 512, value : 30, description : 'Specifies the http request body length limit')
 option('redfish-new-powersubsystem-thermalsubsystem', type : 'feature', value : 'disabled', description : 'Enable/disable the new PowerSubsystem, ThermalSubsystem, and all children schemas. This includes displaying all sensors in the SensorCollection. At a later date, this feature will be defaulted to enabled.')
 option('redfish-allow-deprecated-power-thermal', type : 'feature', value : 'enabled', description : 'Enable/disable the old Power / Thermal. The default condition is allowing the old Power / Thermal.')
 option ('https_port', type : 'integer', min : 1, max : 65535, value : 443, description : 'HTTPS Port number.')
 option('fan-oem-data', type : 'feature', value : 'disabled', description : 'Enable additional fan properties for Pid and Stepwise controllers. These OEM properties are under the Manager resource.')
-option('ibm-sai', type : 'feature', value : 'disabled', description : 'Enable the IBM system attention indicator functionality')
 
 # Insecure options. Every option that starts with a `insecure` flag should
 # not be enabled by default for any platform, unless the author fully comprehends

--- a/redfish-core/lib/oem/ibm/system_attention_indicator.hpp
+++ b/redfish-core/lib/oem/ibm/system_attention_indicator.hpp
@@ -108,11 +108,8 @@ inline void getSAI(const std::shared_ptr<bmcweb::AsyncResp>& aResp,
                     return;
                 }
 
-                nlohmann::json& oemSAI =
-                    aResp->res.jsonValue["Oem"]["OpenBmc"]["IBMOem"];
-                aResp->res.jsonValue["Oem"]["OpenBmc"]["@odata.type"] =
-                    "#OemComputerSystem.OpenBmc";
-                oemSAI["@odata.type"] = "#OemComputerSystem.IBMOem";
+                nlohmann::json& oemSAI = aResp->res.jsonValue["Oem"]["IBM"];
+                oemSAI["@odata.type"] = "#OemComputerSystem.IBM";
                 if (propertyValue == "PartitionSystemAttentionIndicator")
                 {
                     oemSAI["PartitionSystemAttentionIndicator"] = *ledOn;

--- a/redfish-core/lib/systems.hpp
+++ b/redfish-core/lib/systems.hpp
@@ -18,10 +18,8 @@
 #include "led.hpp"
 #include "pcie.hpp"
 #include "redfish_util.hpp"
-#ifdef BMCWEB_ENABLE_IBM_LAMP_TEST
+#ifdef BMCWEB_ENABLE_IBM_LED_EXTENSIONS
 #include "oem/ibm/lamp_test.hpp"
-#endif
-#ifdef BMCWEB_ENABLE_SAI
 #include "oem/ibm/system_attention_indicator.hpp"
 #endif
 #include <app.hpp>
@@ -2732,10 +2730,8 @@ inline void requestRoutesSystems(App& app)
             getStopBootOnFault(asyncResp);
             getAutomaticRetry(asyncResp);
             getLastResetTime(asyncResp);
-#ifdef BMCWEB_ENABLE_IBM_LAMP_TEST
+#ifdef BMCWEB_ENABLE_IBM_LED_EXTENSIONS
             getLampTestState(asyncResp);
-#endif
-#ifdef BMCWEB_ENABLE_SAI
             getSAI(asyncResp, "PartitionSystemAttentionIndicator");
             getSAI(asyncResp, "PlatformSystemAttentionIndicator");
 #endif
@@ -2861,25 +2857,12 @@ inline void requestRoutesSystems(App& app)
 
                     if (ibmOem)
                     {
-#ifdef BMCWEB_ENABLE_IBM_LAMP_TEST
+#ifdef BMCWEB_ENABLE_IBM_LED_EXTENSIONS
                         std::optional<bool> lampTest;
-                        if (!json_util::readJson(*ibmOem, asyncResp->res,
-                                                 "LampTest", lampTest))
-                        {
-                            return;
-                        }
-
-                        if (lampTest)
-                        {
-                            setLampTestState(asyncResp, *lampTest);
-                        }
-#endif
-
-#ifdef BMCWEB_ENABLE_SAI
                         std::optional<bool> partitionSAI;
                         std::optional<bool> platformSAI;
                         if (!json_util::readJson(
-                                *ibmOem, asyncResp->res,
+                                *ibmOem, asyncResp->res, "LampTest", lampTest,
                                 "PartitionSystemAttentionIndicator",
                                 partitionSAI,
                                 "PlatformSystemAttentionIndicator",
@@ -2887,7 +2870,10 @@ inline void requestRoutesSystems(App& app)
                         {
                             return;
                         }
-
+                        if (lampTest)
+                        {
+                            setLampTestState(asyncResp, *lampTest);
+                        }
                         if (partitionSAI)
                         {
                             setSAI(asyncResp,

--- a/static/redfish/v1/JsonSchemas/OemComputerSystem/index.json
+++ b/static/redfish/v1/JsonSchemas/OemComputerSystem/index.json
@@ -116,9 +116,9 @@
             "properties": {},
             "type": "object"
         },
-        "IBMOem": {
+        "IBM": {
             "additionalProperties": true,
-            "description": "Oem properties for IBMOem.",
+            "description": "Oem properties for IBM.",
             "patternProperties": {
                 "^([a-zA-Z_][a-zA-Z0-9_]*)?@(odata|Redfish|Message)\\.[a-zA-Z_][a-zA-Z0-9_]*$": {
                     "description": "This property shall specify a valid odata or Redfish property.",
@@ -134,6 +134,15 @@
                 }
             },
             "properties": {
+                "LampTest": {
+                    "description": "An indicator allowing an operator to run LED lamp test.",
+                    "longDescription": "This property shall contain the state of lamp state function for this resource.",
+                    "readonly": false,
+                    "type": [
+                        "boolean",
+                        "null"
+                    ]
+                },
                 "PartitionSystemAttentionIndicator": {
                     "description": "An indicator allowing an operator to operate partition system attention.",
                     "longDescription": "This property shall contain the state of the partition system attention of this resource.",

--- a/static/redfish/v1/schema/OemComputerSystem_v1.xml
+++ b/static/redfish/v1/schema/OemComputerSystem_v1.xml
@@ -24,29 +24,27 @@
                 <Annotation Term="OData.AutoExpand"/>
                 <Property Name="OpenBmc" Type="OemComputerSystem.OpenBmc"/>
                 <Property Name="IBM" Type="OemComputerSystem.IBM"/>
-                <Property Name="IBMOem" Type="OemComputerSystem.IBMOem"/>
-            </ComplexType>
-
-            <ComplexType Name="IBMOem" BaseType="Resource.OemObject">
-                <Annotation Term="OData.AdditionalProperties" Bool="true" />
-                <Annotation Term="OData.Description" String="Oem properties for IBM." />
-                <Annotation Term="OData.AutoExpand"/>
-                <Property Name="PartitionSystemAttentionIndicator" Type="OemComputerSystem.IBMOem">
-                    <Annotation Term="OData.Permissions" EnumMember="OData.Permission/Read"/>
-                    <Annotation Term="OData.Description" String="An indicator allowing an operator to operate partition system attention."/>
-                    <Annotation Term="OData.LongDescription" String="This property shall contain the state of the partition system attention of this resource."/>
-                </Property>
-                <Property Name="PlatformSystemAttentionIndicator" Type="OemComputerSystem.IBMOem">
-                    <Annotation Term="OData.Permissions" EnumMember="OData.Permission/Read"/>
-                    <Annotation Term="OData.Description" String="An indicator allowing an operator to operate platform system attention."/>
-                    <Annotation Term="OData.LongDescription" String="This property shall contain the state of the platform system attention of this resource."/>
-                </Property>
             </ComplexType>
 
             <ComplexType Name="IBM" BaseType="Resource.OemObject">
                 <Annotation Term="OData.AdditionalProperties" Bool="true" />
                 <Annotation Term="OData.Description" String="Oem properties for IBM." />
                 <Annotation Term="OData.AutoExpand"/>
+                <Property Name="LampTest" Type="OemComputerSystem.IBM">
+                    <Annotation Term="OData.Permissions" EnumMember="OData.Permission/ReadWrite"/>
+                    <Annotation Term="OData.Description" String="An indicator allowing an operator to run LED lamp test."/>
+                    <Annotation Term="OData.LongDescription" String="This property shall contain the state of lamp state function for this resource."/>
+                </Property>
+                <Property Name="PartitionSystemAttentionIndicator" Type="OemComputerSystem.IBM">
+                    <Annotation Term="OData.Permissions" EnumMember="OData.Permission/ReadWrite"/>
+                    <Annotation Term="OData.Description" String="An indicator allowing an operator to operate partition system attention."/>
+                    <Annotation Term="OData.LongDescription" String="This property shall contain the state of the partition system attention of this resource."/>
+                </Property>
+                <Property Name="PlatformSystemAttentionIndicator" Type="OemComputerSystem.IBM">
+                    <Annotation Term="OData.Permissions" EnumMember="OData.Permission/ReadWrite"/>
+                    <Annotation Term="OData.Description" String="An indicator allowing an operator to operate platform system attention."/>
+                    <Annotation Term="OData.LongDescription" String="This property shall contain the state of the platform system attention of this resource."/>
+                </Property>
             </ComplexType>
 
             <ComplexType Name="OpenBmc" BaseType="Resource.OemObject">


### PR DESCRIPTION
This commit simplifies the IBM OEM LED functions in the ComputerSystem
schema. Instead of using multiple feature flags for system attention
indicator and lamp test, this collapses them to just one: `ibm-led-extensions`

This simplifies the patch code significantly, while fixing erroneous
"unknown property" responses.

Signed-off-by: Santosh Puranik <santosh.puranik@in.ibm.com>