### PR TITLE
Enhance DUMP debug traces

### DIFF
--- a/include/dump_offload.hpp
+++ b/include/dump_offload.hpp
@@ -331,8 +331,8 @@ inline void requestRoutes(App& app)
                     boost::beast::http::status::not_found);
                 return;
             }
-            BMCWEB_LOG_INFO << "Dump offload initiated by: "
-                            << conn.req.session->clientIp;
+            BMCWEB_LOG_CRITICAL << "Dump offload initiated by: "
+                                << conn.req.session->clientIp;
             handlers[&conn]->getDumpSize(dumpId, dumpType);
         })
         .onclose([](crow::streaming_response::Connection& conn) {
@@ -407,8 +407,8 @@ inline void requestRoutes(App& app)
                     boost::beast::http::status::not_found);
                 return;
             }
-            BMCWEB_LOG_INFO << "Dump offload initiated by: "
-                            << conn.req.session->clientIp;
+            BMCWEB_LOG_CRITICAL << "Dump offload initiated by: "
+                                << conn.req.session->clientIp;
             handlers[&conn]->getDumpSize(dumpId, dumpType);
         })
         .onclose([](crow::streaming_response::Connection& conn) {

--- a/redfish-core/lib/log_services.hpp
+++ b/redfish-core/lib/log_services.hpp
@@ -803,7 +803,7 @@ inline void
             }
             if (foundDumpEntry == false)
             {
-                BMCWEB_LOG_ERROR << "Can't find Dump Entry";
+                BMCWEB_LOG_ERROR << "Can't find Dump Entry " << entryID;
                 messages::resourceNotFound(asyncResp->res, dumpType + " dump",
                                            entryID);
                 return;


### PR DESCRIPTION
These traces helps while debugging DUMP issues

1. In dump offload case, we have multiple defects where two HMCs connected
so we wanted to have trace which include client origin ip. so that we can confirm which HMC offloaded dump.
2. Printing Dump id to identify Dump in error case
