### PR TITLE
Add traces when deleting subsription

### DIFF
--- a/http/http_client.hpp
+++ b/http/http_client.hpp
@@ -424,7 +424,7 @@ class HttpClient : public std::enable_shared_from_this<HttpClient>
 
                 state = ConnState::terminated;
                 // Remove the subscription
-                BMCWEB_LOG_DEBUG << "TerminateAfterRetries is set. retryCount: "
+                BMCWEB_LOG_ERROR << "TerminateAfterRetries is set. retryCount: "
                                  << retryCount << " .Subscriber: " << subId
                                  << " deleted";
                 persistent_data::EventServiceStore::getInstance()

--- a/redfish-core/lib/event_service.hpp
+++ b/redfish-core/lib/event_service.hpp
@@ -170,6 +170,7 @@ inline void
             }
 
             messages::resourceNotFound(asyncResp->res, "Subscriptions", id);
+            BMCWEB_LOG_CRITICAL << "Delete SNMP subscription on get";
             EventServiceManager::getInstance().deleteSubscription(id);
         },
         "xyz.openbmc_project.Network.SNMP",
@@ -1016,6 +1017,7 @@ inline void requestRoutesEventDestination(App& app)
                         "xyz.openbmc_project.Network.SNMP", snmpPath,
                         "xyz.openbmc_project.Object.Delete", "Delete");
 
+                    BMCWEB_LOG_CRITICAL << "Delete SNMP subscription";
                     EventServiceManager::getInstance().deleteSubscription(
                         param);
 
@@ -1029,6 +1031,8 @@ inline void requestRoutesEventDestination(App& app)
                         boost::beast::http::status::not_found);
                     return;
                 }
+
+                BMCWEB_LOG_CRITICAL << "Request delete subscription";
                 EventServiceManager::getInstance().deleteSubscription(param);
             });
 }


### PR DESCRIPTION
As discussed in the 3/10 call, seeing cores when deleting a subsription,
SW545127 and
https://ibm-systems-power.slack.com/archives/C0Q6TQP5Z/p1644609233481139?thread_ts=1644608150.995019&cid=C0Q6TQP5Z
are 2 backtraces. The theory is the lack of locking between subsequent
calls is causing this. This tracing will help prove this.

Did not test, added traces only.

Signed-off-by: Gunnar Mills <gmills@us.ibm.com>