### PR TITLE
DumpOffload: Allow only one dump offload at a time

### DIFF
--- a/include/dump_offload.hpp
+++ b/include/dump_offload.hpp
@@ -286,7 +286,10 @@ class Handler : public std::enable_shared_from_this<Handler>
 
 static boost::container::flat_map<crow::streaming_response::Connection*,
                                   std::shared_ptr<Handler>>
-    handlers;
+    bmcHandlers;
+static boost::container::flat_map<crow::streaming_response::Connection*,
+                                  std::shared_ptr<Handler>>
+    systemHandlers;
 
 inline void requestRoutes(App& app)
 {
@@ -296,13 +299,26 @@ inline void requestRoutes(App& app)
         .privileges({{"ConfigureComponents", "ConfigureManager"}})
         .streamingResponse()
         .onopen([](crow::streaming_response::Connection& conn) {
+            if (!bmcHandlers.empty())
+            {
+                BMCWEB_LOG_ERROR << "Can't allow dump offload opertaion, one "
+                                    "of the BMC dump is already offloading";
+                conn.sendStreamErrorStatus(
+                    boost::beast::http::status::service_unavailable);
+                conn.close();
+                return;
+            }
+
             std::string url(conn.req.target());
             std::string startDelimiter = "Entries/";
             std::size_t pos1 = url.rfind(startDelimiter);
             std::size_t pos2 = url.rfind("/attachment");
             if (pos1 == std::string::npos || pos2 == std::string::npos)
             {
-                BMCWEB_LOG_DEBUG << "Unable to extract the dump id";
+                BMCWEB_LOG_ERROR << "Unable to extract the dump id";
+                conn.sendStreamErrorStatus(
+                    boost::beast::http::status::not_found);
+                conn.close();
                 return;
             }
 
@@ -321,30 +337,32 @@ inline void requestRoutes(App& app)
             std::string unixSocketPath = unixSocketPathDir + dumpType +
                                          "_dump_" + std::to_string(dist(gen));
 
-            handlers[&conn] = std::make_shared<Handler>(
+            bmcHandlers[&conn] = std::make_shared<Handler>(
                 *ioCon, dumpId, dumpType, unixSocketPath);
-            handlers[&conn]->connection = &conn;
+            bmcHandlers[&conn]->connection = &conn;
 
             if (!crow::ibm_utils::createDirectory(unixSocketPathDir))
             {
-                handlers[&conn]->connection->sendStreamErrorStatus(
+                bmcHandlers[&conn]->connection->sendStreamErrorStatus(
                     boost::beast::http::status::not_found);
+                bmcHandlers[&conn]->connection->close();
                 return;
             }
-            BMCWEB_LOG_CRITICAL << "Dump offload initiated by: "
-                                << conn.req.session->clientIp;
-            handlers[&conn]->getDumpSize(dumpId, dumpType);
+            BMCWEB_LOG_CRITICAL
+                << "INFO: " << dumpType << " Dump id " << dumpId
+                << " offload initiated by: " << conn.req.session->clientIp;
+            bmcHandlers[&conn]->getDumpSize(dumpId, dumpType);
         })
         .onclose([](crow::streaming_response::Connection& conn) {
-            auto handler = handlers.find(&conn);
-            if (handler == handlers.end())
+            auto handler = bmcHandlers.find(&conn);
+            if (handler == bmcHandlers.end())
             {
                 BMCWEB_LOG_DEBUG << "No handler to cleanup";
                 return;
             }
             handler->second->cleanupSocketFiles();
             handler->second->outputBuffer.clear();
-            handlers.erase(handler);
+            bmcHandlers.erase(handler);
         });
 
     BMCWEB_ROUTE(
@@ -353,6 +371,16 @@ inline void requestRoutes(App& app)
         .privileges({{"ConfigureComponents", "ConfigureManager"}})
         .streamingResponse()
         .onopen([](crow::streaming_response::Connection& conn) {
+            if (!systemHandlers.empty())
+            {
+                BMCWEB_LOG_ERROR << "Can't allow dump offload opertaion, one "
+                                    "of the host dump is already offloading";
+                conn.sendStreamErrorStatus(
+                    boost::beast::http::status::service_unavailable);
+                conn.close();
+                return;
+            }
+
             std::string url(conn.req.target());
 
             std::string startDelimiter = "Entries/";
@@ -360,9 +388,10 @@ inline void requestRoutes(App& app)
             std::size_t pos2 = url.rfind("/attachment");
             if (pos1 == std::string::npos || pos2 == std::string::npos)
             {
-                BMCWEB_LOG_DEBUG << "Unable to extract the dump id";
+                BMCWEB_LOG_ERROR << "Unable to extract the dump id";
                 conn.sendStreamErrorStatus(
                     boost::beast::http::status::not_found);
+                conn.close();
                 return;
             }
 
@@ -397,29 +426,31 @@ inline void requestRoutes(App& app)
             std::string unixSocketPath = unixSocketPathDir + dumpType +
                                          "_dump_" + std::to_string(dist(gen));
 
-            handlers[&conn] = std::make_shared<Handler>(
+            systemHandlers[&conn] = std::make_shared<Handler>(
                 *ioCon, dumpId, dumpType, unixSocketPath);
-            handlers[&conn]->connection = &conn;
+            systemHandlers[&conn]->connection = &conn;
 
             if (!crow::ibm_utils::createDirectory(unixSocketPathDir))
             {
-                handlers[&conn]->connection->sendStreamErrorStatus(
+                systemHandlers[&conn]->connection->sendStreamErrorStatus(
                     boost::beast::http::status::not_found);
+                systemHandlers[&conn]->connection->close();
                 return;
             }
-            BMCWEB_LOG_CRITICAL << "Dump offload initiated by: "
-                                << conn.req.session->clientIp;
-            handlers[&conn]->getDumpSize(dumpId, dumpType);
+            BMCWEB_LOG_CRITICAL
+                << "INFO: " << dumpType << " dump id " << dumpId
+                << " offload initiated by: " << conn.req.session->clientIp;
+            systemHandlers[&conn]->getDumpSize(dumpId, dumpType);
         })
         .onclose([](crow::streaming_response::Connection& conn) {
-            auto handler = handlers.find(&conn);
-            if (handler == handlers.end())
+            auto handler = systemHandlers.find(&conn);
+            if (handler == systemHandlers.end())
             {
                 BMCWEB_LOG_DEBUG << "No handler to cleanup";
                 return;
             }
             handler->second->cleanupSocketFiles();
-            handlers.erase(handler);
+            systemHandlers.erase(handler);
             handler->second->outputBuffer.clear();
         });
 }


### PR DESCRIPTION
Currently bmcweb allows multiple dump offload request for both bmc and host dumps.

Allowing multiple requests causing issues.
1. pldmd crash due to no EID resources
2. dump manager dump file open issues

Here is one of the defect
https://w3.rchland.ibm.com/projects/bestquest/?defect=SW545731

This commit  handles these cases by returning ServiceUnavailable to client
if one the connection is already offloading dump

With this commit
1. Only one bmc dump offload allowed at a time.
2. Only one host dump offload allowed at a time.
3. One BMC dump and one HOST dump allowed to offload parallely.

Tested by:
 1. Test Offloading one host dump while another one is offloading.
 2. Test Offloading one bmc dump while another one is offloading.
 3. Test  One BMC dump and one HOST dump offload works parallely.