### PR TITLE
Push-style event: Remove 30 sec expire timer for sendMessage

### DIFF
--- a/http/http_client.hpp
+++ b/http/http_client.hpp
@@ -215,8 +215,6 @@ class HttpClient : public std::enable_shared_from_this<HttpClient>
             self->recvMessage();
         };
 
-        // Set a timeout on the operation
-        conn.expires_after(std::chrono::seconds(30));
         if (sslConn)
         {
             boost::beast::http::async_write(*sslConn, req,
@@ -346,8 +344,6 @@ class HttpClient : public std::enable_shared_from_this<HttpClient>
     {
         state = ConnState::closeInProgress;
 
-        // Set the timeout on the tcp stream socket for the async operation
-        conn.expires_after(std::chrono::seconds(30));
         if (sslConn)
         {
             sslConn->async_shutdown([self = shared_from_this()](
@@ -371,7 +367,9 @@ class HttpClient : public std::enable_shared_from_this<HttpClient>
                 }
                 else
                 {
-                    BMCWEB_LOG_DEBUG << "Connection closed gracefully...";
+                    BMCWEB_LOG_ERROR << "INFO: Connection closed gracefully..."
+                                     << " Destination: " << self->host << ":"
+                                     << self->port;
                 }
                 self->conn.close();
 


### PR DESCRIPTION
When BMC hits a idle onnection timeout, and the subscriber
socket is closed, the next sendEvent fails with broken pipe
error. There is a 30 sec expire timeout for this socket and
this delays the next retry to 30 sec

This commit removed that 30 sec timer for sendMesage. Thus
after a send failure, the socket will be recreated immediately

Tested by:
 1. CEC IPL and tested good path of events
 2. Left the setup for more than 30 mins idle timeout which is
    set at HMC. Then triggered an event to see the retry is done
    immediately

Signed-off-by: sunharis <sunharis@in.ibm.com>
Change-Id: I714722381bd204c9922bb297930c10e4b3a525c8