### PR TITLE
Fix StrictAccountTypes Validator Error

### DIFF
--- a/redfish-core/lib/account_service.hpp
+++ b/redfish-core/lib/account_service.hpp
@@ -230,7 +230,6 @@ inline bool getUserGroupFromAccountType(
     {
         userGroup.emplace_back("web");
     }
-
     if ((isHostConsole) && (isManagerConsole))
     {
         userGroup.emplace_back("ssh");

--- a/redfish-core/lib/account_service.hpp
+++ b/redfish-core/lib/account_service.hpp
@@ -230,6 +230,7 @@ inline bool getUserGroupFromAccountType(
     {
         userGroup.emplace_back("web");
     }
+
     if ((isHostConsole) && (isManagerConsole))
     {
         userGroup.emplace_back("ssh");
@@ -1713,7 +1714,6 @@ inline void requestAccountServiceRoutes(App& app)
                 {"Description", "Account Service"},
                 {"ServiceEnabled", true},
                 {"MaxPasswordLength", 20},
-                {"StrictAccountTypes", true},
                 {"Accounts",
                  {{"@odata.id", "/redfish/v1/AccountService/Accounts"}}},
                 {"Roles", {{"@odata.id", "/redfish/v1/AccountService/Roles"}}},
@@ -2168,10 +2168,11 @@ inline void requestAccountServiceRoutes(App& app)
 
                     asyncResp->res.jsonValue = {
                         {"@odata.type",
-                         "#ManagerAccount.v1_4_0.ManagerAccount"},
+                         "#ManagerAccount.v1_7_0.ManagerAccount"},
                         {"Name", "User Account"},
                         {"Description", "User Account"},
-                        {"Password", nullptr}};
+                        {"Password", nullptr},
+                        {"StrictAccountTypes", true}};
 
                     for (const auto& interface : userIt->second)
                     {


### PR DESCRIPTION
Fix StrictAccountTypes parameter set under ManagerAccount.

Fix:
StrictAccountTypes was attached under AccountService, which was wrong 
based on http://redfish.dmtf.org/schemas/v1/ManagerAccount.v1_8_1.json
this PR delete that StrictAccountTypes from AccountService and attach under
ManagerAccount and also update schemas version with the right version. 

This fixes the Validator Error George spotted.

Commit will be made upstream. 

Tested: 
using Redfish validator