### PR TITLE
Fix memory PATCH permission

### DIFF
--- a/redfish-core/lib/memory.hpp
+++ b/redfish-core/lib/memory.hpp
@@ -1193,7 +1193,7 @@ inline void requestRoutesMemory(App& app)
             });
 
     BMCWEB_ROUTE(app, "/redfish/v1/Systems/system/Memory/<str>/")
-        .privileges({{"Login"}})
+        .privileges(redfish::privileges::patchMemory)
         .methods(boost::beast::http::verb::patch)(
             [](const crow::Request& req,
                const std::shared_ptr<bmcweb::AsyncResp>& asyncResp,


### PR DESCRIPTION
https://github.com/ibm-openbmc/bmcweb/commit/c8f82b319f98020317f3a36fcf080398a90c3ad4
added PATCHing of memory but incorrectly used Login see
https://redfish.dmtf.org/registries/Redfish_1.2.0_PrivilegeRegistry.json

Move to "patchMemory" which is "ConfigureComponents".
https://github.com/ibm-openbmc/bmcweb/blob/8044381620b228f99b707ea2b444c7675e714f26/redfish-core/include/registries/privilege_registry.hpp#L1291

Noticed this in a deconfigure defect.
Cores already has this correct.
https://github.com/ibm-openbmc/bmcweb/blob/1020/redfish-core/lib/processor.hpp#L1956

Tested: None.

Signed-off-by: Gunnar Mills <gmills@us.ibm.com>