### PR TITLE
Health and State are independent

### DIFF
--- a/redfish-core/lib/processor.hpp
+++ b/redfish-core/lib/processor.hpp
@@ -1080,7 +1080,8 @@ inline void
                 {
                     aResp->res.jsonValue["Status"]["State"] = "Absent";
                 }
-                else if (functional == false)
+
+                if (functional == false)
                 {
                     aResp->res.jsonValue["Status"]["Health"] = "Critical";
                 }


### PR DESCRIPTION
If State is UnavailableOffline or Absent, still allow Health to be set
to Critical.

This should fix part of SW545991.

This matches with what we do in like other places in processor.hpp, Assemblies, Fans, Memory etc: 
https://github.com/ibm-openbmc/bmcweb/blob/9d3146f5b2710c387f353846e23fc22b8fe42a99/redfish-core/lib/processor.hpp#L481

Signed-off-by: Gunnar Mills <gmills@us.ibm.com>