### PR TITLE
HW-Isolation: Fix, Update State if the Core and DIMM are recovered

### DIFF
--- a/redfish-core/include/utils/hw_isolation.hpp
+++ b/redfish-core/include/utils/hw_isolation.hpp
@@ -585,6 +585,15 @@ inline void
                                         return;
                                     }
 
+                                    // Host recovered even if there is hardware
+                                    // isolation entry so change the state.
+                                    if (*msgPropVal == "Recovered")
+                                    {
+                                        aResp->res
+                                            .jsonValue["Status"]["State"] =
+                                            "Enabled";
+                                    }
+
                                     const message_registries::Message* msgReg =
                                         message_registries::getMessage(
                                             "OpenBMC.0.2."


### PR DESCRIPTION
- Currently, The state of the isolated Core and DIMM will be set as
  "Disabled" if the host tried to recover and mark it as functional
  even if there is a hardware isolation record for the Core and DIMM.

- Fixed that by changing the state as Enabled if hardware isolation
  status event is "Recovered".

Tested:

- Without Fix:

```
curl -k -H "X-Auth-Token: $bmc_token" -X GET https://${bmc}/redfish/v1/ \
            Systems/system/Processors/dcm0-cpu0/SubProcessors/core0
{
  "@odata.id": "/redfish/v1/Systems/system/Processors/dcm0-cpu0/SubProcessors/core0",
  "@odata.type": "#Processor.v1_12_0.Processor",
  "Enabled": false,
  "Id": "core0",
  "Name": "core0",
  "Status": {
    "Conditions": [
      {
        "Message": "The reason for the resource isolation: Recovered",
        "MessageArgs": [
          "Recovered"
        ],
        "MessageId": "OpenBMC.0.2.HardwareIsolationReason",
        "Severity": "Warning",
        "Timestamp": "2022-03-16T06:02:39+00:00"
      }
    ],
    "Health": "OK",
    "State": "Disabled"
  }
}
```

- With Fix:

```
curl -k -H "X-Auth-Token: $bmc_token" -X GET https://${bmc}/redfish/v1/ \
            Systems/system/Processors/dcm0-cpu0/SubProcessors/core0
{
  "@odata.id": "/redfish/v1/Systems/system/Processors/dcm0-cpu0/SubProcessors/core0",
  "@odata.type": "#Processor.v1_12_0.Processor",
  "Enabled": false,
  "Id": "core0",
  "Name": "core0",
  "Status": {
    "Conditions": [
      {
        "Message": "The reason for the resource isolation: Recovered",
        "MessageArgs": [
          "Recovered"
        ],
        "MessageId": "OpenBMC.0.2.HardwareIsolationReason",
        "Severity": "Warning",
        "Timestamp": "2022-03-16T06:02:39+00:00"
      }
    ],
    "Health": "OK",
    "State": "Enabled"
  }
}
```