### PR TITLE
Reset Event retryPolicy on BMC reboot

### DIFF
--- a/redfish-core/include/event_service_manager.hpp
+++ b/redfish-core/include/event_service_manager.hpp
@@ -406,6 +406,17 @@ class Subscription : public persistent_data::UserSubscription
             conn = std::make_shared<crow::HttpClient>(
                 crow::connections::systemBus->get_io_context(), subId, host,
                 port, path, uriProto, httpHeaders);
+            uint32_t retryAttempts;
+            uint32_t retryTimeoutInterval;
+            persistent_data::EventServiceConfig eventServiceConfig =
+                persistent_data::EventServiceStore::getInstance()
+                    .getEventServiceConfig();
+
+            retryAttempts = eventServiceConfig.retryAttempts;
+            retryTimeoutInterval = eventServiceConfig.retryTimeoutInterval;
+
+            conn->setRetryPolicy(retryPolicy);
+            conn->setRetryConfig(retryAttempts, retryTimeoutInterval);
         }
         if (conn->getConnState() != crow::ConnState::terminated)
         {


### PR DESCRIPTION
When BMC reboots, the existing subscriptions get reloaded to the
memory. A http client connection object is created freshly. But
the retry policy values were not applied on that object and the
http client object uses the default values for them

This commit sets the retryPolicy and retryConfig parameters
after the BMC reboot for the persisted subscribers

Tested by:
  Check the retry policy and time intervals of a subscriber
after the BMC reset -or- bmcweb restart

Signed-off-by: sunharis <sunharis@in.ibm.com>
Change-Id: I572c1d1c7c56c609b392e28fb1e896dae5fe5b5f