### PR TITLE
Enhance Name Utils Loggin

### DIFF
--- a/redfish-core/include/utils/name_utils.hpp
+++ b/redfish-core/include/utils/name_utils.hpp
@@ -36,6 +36,10 @@ inline void getPrettyName(
     if (services.size() != 1)
     {
         BMCWEB_LOG_ERROR << "Invalid Service Size " << services.size();
+        for (const auto& service : services)
+        {
+            BMCWEB_LOG_ERROR << "Invalid Service Name: " << service.first;
+        }
         if (asyncResp)
         {
             messages::internalError(asyncResp->res);


### PR DESCRIPTION
getPrettyName method gets called more than one time.
required Service information to debug the error messages.
Enhancing util logging message to retire service information.

Signed-off-by: Abhishek Patel <Abhishek.Patel@ibm.com>