### PR TITLE
Core: Update the Status.State if the core is not functional

### DIFF
--- a/redfish-core/lib/processor.hpp
+++ b/redfish-core/lib/processor.hpp
@@ -1080,6 +1080,11 @@ inline void
                 {
                     aResp->res.jsonValue["Status"]["State"] = "Absent";
                 }
+                else if (functional == false)
+                {
+                    // State also need to change if the core is non-functional
+                    aResp->res.jsonValue["Status"]["State"] = "Disabled";
+                }
 
                 if (functional == false)
                 {


### PR DESCRIPTION
It fixes [SW545991](https://w3.rchland.ibm.com/projects/bestquest/?defect=SW545991)

- The Core might be present and available in the system during runtime
  but, it might not be functional. This case may occur if the
  host system deallocated the core due to some failure at the runtime.

- So, the host will send a PLDM sensor event about the core deallocation
  to the BMC PLDM entity that will update the core inventory functional
  property that can be used to exchange the state to the user whenever
  the user requested to get the core details.

- Currently, the bmcweb returning Status.Health as "Critical" based on
  the Functional property and Status.State as "Enabled" based on the
  Present and Available properties that are implemented in the core inventory.

- But, we cannot say Status.State as "Enabled" when the respective resource
  is present and available but it is not functional because it might confuse
  the user who looking at the Redfish response so fixed the same.