### PR TITLE
Redfish OEM Message for Code Update Errors

### DIFF
--- a/redfish-core/include/task_messages.hpp
+++ b/redfish-core/include/task_messages.hpp
@@ -20,15 +20,24 @@ namespace redfish
 namespace messages
 {
 
-inline nlohmann::json taskAborted(const std::string& arg1)
+inline nlohmann::json taskAborted(const std::string& arg1,
+                                  const std::string& arg2,
+                                  const std::string& arg3,
+                                  const std::string& arg4)
 {
     return nlohmann::json{
         {"@odata.type", "#Message.v1_0_0.Message"},
         {"MessageId", "TaskEvent.1.0.1.TaskAborted"},
         {"Message", "The task with id " + arg1 + " has been aborted."},
-        {"MessageArgs", {arg1}},
+        {"MessageArgs", {arg1, arg2, arg3, arg4}},
         {"Severity", "Critical"},
-        {"Resolution", "None."}};
+        {"Resolution", "None."},
+        {"Oem",
+         {{"OpenBMC",
+           {{"@odata.type", "#OemMessage.v1_0_0.Message"},
+             {"AbortReason", arg2},
+             {"AdditionalData", arg3},
+             {"EventId", arg4}}}}}};
 }
 
 inline nlohmann::json taskCancelled(const std::string& arg1)

--- a/redfish-core/lib/task.hpp
+++ b/redfish-core/lib/task.hpp
@@ -181,8 +181,7 @@ struct TaskData : std::enable_shared_from_this<TaskData>
                 self->state = "Cancelled";
                 self->status = "Warning";
                 self->messages.emplace_back(
-                    messages::taskAborted(std::to_string(self->index)));
-                // Send event :TaskAborted
+                    messages::taskAborted(std::to_string(self->index), "None", "None", "None"));
                 self->sendTaskEvent(self->state, self->index);
                 self->callback(ec, msg, self);
             });
@@ -226,8 +225,8 @@ struct TaskData : std::enable_shared_from_this<TaskData>
         else if (state == "Stopping")
         {
             redfish::EventServiceManager::getInstance().sendEvent(
-                redfish::messages::taskAborted(std::to_string(index)), origin,
-                resType);
+                redfish::messages::taskAborted(std::to_string(index), "None", "None", "None"),
+                origin, resType);
         }
         else if (state == "Completed")
         {

--- a/scripts/update_schemas.py
+++ b/scripts/update_schemas.py
@@ -230,6 +230,15 @@ with open(metadata_index_path, 'w') as metadata_index:
         "        <edmx:Include Namespace=\"OemPCIeSlots.v1_0_0\"/>\n")
     metadata_index.write("    </edmx:Reference>\n")
 
+    metadata_index.write(
+        "    <edmx:Reference Uri=\""
+        "/redfish/v1/schema/OemMessage_v1.xml\">\n")
+    metadata_index.write(
+        "        <edmx:Include Namespace=\"OemMessage\"/>\n")
+    metadata_index.write(
+        "        <edmx:Include Namespace=\"OemMessage.v1_0_0\"/>\n")    
+    metadata_index.write("    </edmx:Reference>\n")
+
     metadata_index.write("</edmx:Edmx>\n")
 
 schema_files = {}

--- a/static/redfish/v1/$metadata/index.xml
+++ b/static/redfish/v1/$metadata/index.xml
@@ -3770,4 +3770,8 @@
         <edmx:Include Namespace="OemPCIeSlots"/>
         <edmx:Include Namespace="OemPCIeSlots.v1_0_0"/>
     </edmx:Reference>
+    <edmx:Reference Uri="/redfish/v1/schema/OemMessage_v1.xml">
+        <edmx:Include Namespace="OemMessage"/>
+        <edmx:Include Namespace="OemMessage.v1_0_0"/>
+    </edmx:Reference>
 </edmx:Edmx>

--- a/static/redfish/v1/JsonSchemas/OemMessage/index.json
+++ b/static/redfish/v1/JsonSchemas/OemMessage/index.json
@@ -1,0 +1,56 @@
+{
+    "$id": "http://redfish.dmtf.org/schemas/v1/OemMessage.v1_0_0.json",
+    "$schema": "http://redfish.dmtf.org/schemas/v1/redfish-schema-v1.json",
+    "copyright": "Copyright 2014-2019 DMTF. For the full DMTF copyright policy, see http://www.dmtf.org/about/policies/copyright",
+    "definitions": {
+        "Message": {
+            "additionalProperties": false,
+            "description": "OEM Extension for Message",
+            "longDescription": "OEM Extension for Message, provides extra property for reason for exception.",
+            "patternProperties": {
+                "^([a-zA-Z_][a-zA-Z0-9_]*)?@(odata|Redfish|Message)\\.[a-zA-Z_][a-zA-Z0-9_]*$": {
+                    "description": "This property shall specify a valid odata or Redfish property.",
+                    "type": [
+                        "array",
+                        "boolean",
+                        "integer",
+                        "number",
+                        "null",
+                        "object",
+                        "string"
+                    ]
+                }
+            },
+            "properties": {
+                "AbortReason": {
+                    "description": "Reason oem for message",
+                    "longDescription": "An extra property for Message to provide more information to the user",
+                    "type": [
+                        "string",
+                        "null"
+                    ]
+                },
+                "AdditionalData": {
+                    "description": "Reason oem for message",
+                    "longDescription": "An extra property for Message to provide more information to the user",
+                    "type": [
+                        "string",
+                        "null"
+                    ]
+                },
+                "EventId": {
+                    "description": "Reason oem for message",
+                    "longDescription": "An extra property for Message to provide more information to the user",
+                    "type": [
+                        "string",
+                        "null"
+                    ]
+                }
+            },
+            "type": "object"
+        }
+    },
+    "owningEntity": "OpenBMC",
+    "release": "1.0",
+    "title": "#OemMessage.v1_0_0"
+}

--- a/static/redfish/v1/schema/OemMessage_v1.xml
+++ b/static/redfish/v1/schema/OemMessage_v1.xml
@@ -1,0 +1,43 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<edmx:Edmx xmlns:edmx="http://docs.oasis-open.org/odata/ns/edmx" Version="4.0">
+
+  <edmx:Reference Uri="http://docs.oasis-open.org/odata/odata/v4.0/errata03/csd01/complete/vocabularies/Org.OData.Core.V1.xml">
+    <edmx:Include Namespace="Org.OData.Core.V1" Alias="OData"/>
+  </edmx:Reference>
+  <edmx:Reference Uri="http://redfish.dmtf.org/schemas/v1/RedfishExtensions_v1.xml">
+    <edmx:Include Namespace="RedfishExtensions.v1_0_0" Alias="Redfish"/>
+  </edmx:Reference>
+  <edmx:Reference Uri="http://redfish.dmtf.org/schemas/v1/Resource_v1.xml">
+    <edmx:Include Namespace="Resource"/>
+    <edmx:Include Namespace="Resource.v1_0_0"/>
+  </edmx:Reference>
+
+  <edmx:DataServices>
+    <Schema xmlns="http://docs.oasis-open.org/odata/ns/edm" Namespace="OemMessage">
+      <Annotation Term="Redfish.OwningEntity" String="OpenBMC"/>
+    </Schema>
+
+    <Schema xmlns="http://docs.oasis-open.org/odata/ns/edm" Namespace="OemMessage.v1_0_0">
+      <Annotation Term="Redfish.OwningEntity" String="OpenBMC"/>
+      <Annotation Term="Redfish.Release" String="1.0"/>
+
+      <EntityType Name="Message" BaseType="Resource.OemObject" Abstract="true">
+          <Annotation Term="OData.Description" String="OEM Extension for Message"/>
+          <Annotation Term="OData.LongDescription" String="OEM Extension for Message to provide the OEM specific details"/>
+            <Property Name="AbortReason" Type="Edm.String">
+              <Annotation Term="OData.Description" String="String indicating the reason for exception."/>
+              <Annotation Term="OData.LongDescription" String="Unique string that provides reason for exception."/>
+            </Property>
+            <Property Name="AdditionalData" Type="Edm.String">
+              <Annotation Term="OData.Description" String="String indicating the reason for exception."/>
+              <Annotation Term="OData.LongDescription" String="Unique string that provides reason for exception."/>
+            </Property>
+            <Property Name="EventId" Type="Edm.String">
+              <Annotation Term="OData.Description" String="String indicating the reason for exception."/>
+              <Annotation Term="OData.LongDescription" String="Unique string that provides reason for exception."/>
+            </Property>
+      </EntityType>
+    </Schema>
+  </edmx:DataServices>
+
+</edmx:Edmx>


### PR DESCRIPTION
This commit provides a new Redfish OEM schema for Message that
will display error log information given a code update error.
This addition will provide users with a more detailed explanation
of the reason an update has failed.

Defect SW542946 (https://w3.rchland.ibm.com/projects/bestquest/?verb=view&id=SW542946)

Tested:
Ensured that upon code update failure, the task message included
the new OEM field where the corresponding error interface can be
displayed.

excerpt from validation pass:
Schema file OemMessage_v1.xml not found in ./SchemaFiles/metadata
Attempt 1 of /redfish/v1/schema/OemMessage_v1.xml
Response Time for GET to /redfish/v1/schema/OemMessage_v1.xml:
0.2782340639969334 seconds.
Writing online XML to file: OemMessage_v1.xml