### PR TITLE
HMC-BMC Lock management: Fix resourceId check

### DIFF
--- a/include/ibm/locks.hpp
+++ b/include/ibm/locks.hpp
@@ -538,6 +538,22 @@ inline bool Lock::isConflictRecord(const LockRequest& refLockRecord1,
         return false;
     }
 
+    // If there is a WriteLock and both resourceIds are exactly same
+    // then return conflict
+    BMCWEB_LOG_DEBUG << "resourceId from refLockRecord1: "
+                     << std::get<3>(refLockRecord1);
+    BMCWEB_LOG_DEBUG << "resourceId from refLockRecord2: "
+                     << std::get<3>(refLockRecord2);
+    if ((boost::equals(std::get<2>(refLockRecord1), "Write") ||
+         boost::equals(std::get<2>(refLockRecord2), "Write")) &&
+        ((std::get<3>(refLockRecord1)) == (std::get<3>(refLockRecord2))))
+    {
+        BMCWEB_LOG_ERROR << "One of the record is WriteLock and resourceId are "
+                            "idential"
+                         << std::get<3>(refLockRecord1) << " . Return conflict";
+        return true;
+    }
+
     uint32_t i = 0;
     uint32_t segStartIndex = 0;
     for (const auto& p : std::get<4>(refLockRecord1))
@@ -561,6 +577,9 @@ inline bool Lock::isConflictRecord(const LockRequest& refLockRecord1,
              boost::equals(std::get<4>(refLockRecord2)[i].first, "LockSame")) &&
             (p.second == std::get<4>(refLockRecord2)[i].second))
         {
+            BMCWEB_LOG_DEBUG
+                << "Either of the Comparing locks are trying to LockSame "
+                   "resources under the current resource level";
             return true;
         }
 
@@ -589,6 +608,8 @@ inline bool Lock::isConflictRecord(const LockRequest& refLockRecord1,
                                     std::get<3>(refLockRecord2)),
                                 segItr)))
                 {
+                    BMCWEB_LOG_DEBUG << "checkByte returned false for index: "
+                                     << segStartIndex;
                     return false;
                 }
             }

--- a/redfish-core/ut/lock_test.cpp
+++ b/redfish-core/ut/lock_test.cpp
@@ -203,8 +203,8 @@ TEST_F(LockTest, MultiRequestWithoutConflictduetoDifferentSegmentLength)
     // two different kind of resources
     std::get<4>(request[0])[0].second = 3;
     const LockRequests& t = request;
-    // Return No Conflict
-    ASSERT_EQ(0, lockManager.isConflictRequest(t));
+    // Return Conflict
+    ASSERT_EQ(1, lockManager.isConflictRequest(t));
 }
 
 TEST_F(LockTest, MultiRequestWithoutConflictduetoReadLocktype)


### PR DESCRIPTION
When codeupdate was being performed from HMC, adding an IO
adaptor was allowed by BMC. This is due to a problem in
the lock algorithm, where if the resourceId bytes are matched,
lock conflict is not sent out to HMC

This commit sends lock conflict error for such scenarios

Testedby:
 1. Manual curl commands to acquireLock using same resourceId
    with different combinations of lock type
 2. Tested the scenario of adding IO adaptor when code update
    was running

Signed-off-by: sunharis <sunharis@in.ibm.com>