### PR TITLE
Revert "account_service: Added NoAccess role to Redfish"

### DIFF
--- a/redfish-core/lib/account_service.hpp
+++ b/redfish-core/lib/account_service.hpp
@@ -100,10 +100,6 @@ inline std::string getRoleIdFromPrivilege(std::string_view role)
     {
         return "OemIBMServiceAgent";
     }
-    if ((role == "") || (role == "priv-noaccess"))
-    {
-        return "NoAccess";
-    }
     return "";
 }
 
@@ -124,10 +120,6 @@ inline std::string getPrivilegeFromRoleId(std::string_view role)
     if (role == "OemIBMServiceAgent")
     {
         return "priv-oemibmserviceagent";
-    }
-    if ((role == "NoAccess") || (role == ""))
-    {
-        return "priv-noaccess";
     }
     return "";
 }

--- a/redfish-core/lib/roles.hpp
+++ b/redfish-core/lib/roles.hpp
@@ -37,10 +37,6 @@ inline std::string getRoleFromPrivileges(std::string_view priv)
     {
         return "Operator";
     }
-    if (priv == "priv-noaccess")
-    {
-        return "NoAccess";
-    }
     if (priv == "priv-oemibmserviceagent")
     {
         return "OemIBMServiceAgent";
@@ -63,10 +59,6 @@ inline bool getAssignedPrivFromRole(std::string_view role,
     else if (role == "ReadOnly")
     {
         privArray = {"Login", "ConfigureSelf"};
-    }
-    else if (role == "NoAccess")
-    {
-        privArray = nlohmann::json::array();
     }
     else
     {


### PR DESCRIPTION
This PR reverts a commit that added support for ldap priv-noaccess role
https://github.com/openbmc/bmcweb/commit/e9e6d240ab85e515f8d264e39b47a75043b73374

Signed-off-by: Asmitha Karunanithi <asmitk01@in.ibm.com>