### PR TITLE
HW-Isolation: Return ResourceCannotBeDeleted error

### DIFF
--- a/redfish-core/include/utils/hw_isolation.hpp
+++ b/redfish-core/include/utils/hw_isolation.hpp
@@ -284,6 +284,12 @@ inline void
                             std::to_string(enabledPropVal),
                             "HardwareIsolation");
                     }
+                    else if (strcmp(dbusError->name,
+                                    "xyz.openbmc_project.Common.Error."
+                                    "InsufficientPermission") == 0)
+                    {
+                        messages::resourceCannotBeDeleted(aResp->res);
+                    }
                     else
                     {
                         BMCWEB_LOG_ERROR << "DBus Error is unsupported so "


### PR DESCRIPTION
- The backend application will return the "InsufficientPermission" error
  if the user is not allowed to clear the system isolated hardware entry.

- The Redfish service provider need to return an appropriate error
  for the above case so added the support for the same.

Tested:

- Verified by clearing the system isolated hardware entry through the Redfish.

```
curl -k -H "X-Auth-Token: $bmc_token" -X PATCH https://${bmc}/redfish/v1/ \
                          Systems/system/Memory/dimm0 -d '{"Enabled" : true }'
{
  "error": {
    "@Message.ExtendedInfo": [
      {
        "@odata.type": "#Message.v1_1_1.Message",
        "Message": "The delete request failed because the resource requested cannot be deleted.",
        "MessageArgs": [],
        "MessageId": "Base.1.8.1.ResourceCannotBeDeleted",
        "MessageSeverity": "Critical",
        "Resolution": "Do not attempt to delete a non-deletable resource."
      }
    ],
    "code": "Base.1.8.1.ResourceCannotBeDeleted",
    "message": "The delete request failed because the resource requested cannot be deleted."
  }
}
```