### PR TITLE
SW546837: Start bmcweb after bmc state manager

### DIFF
--- a/bmcweb.service.in
+++ b/bmcweb.service.in
@@ -4,6 +4,7 @@ Description=Start bmcweb server
 Wants=network.target
 After=network.target
 After=xyz.openbmc_project.User.Manager.service
+After=xyz.openbmc_project.State.BMC.service
 
 [Service]
 ExecReload=kill -s HUP $MAINPID


### PR DESCRIPTION
This fixes SW546837, which is caused by a 500 because of the bmc state manager not being up.

We have seen several defects where bmcweb returns 500 on an interface
because the service providing the interface isn't up. A 500 leads to the
HMC going to no connection. It has been a whack a mole, where we don't
return 500 when the service isn't up. E.g.
https://gerrit.openbmc-project.xyz/c/openbmc/bmcweb/+/50799.

For critical services like bmc state manager, let's just have bmcweb
start after. This will not be unstreamed at this time but do plan on discussing
this more upstream at a later date. 

Discussed here:
https://ibm-systems-power.slack.com/archives/C0Q6TQP5Z/p1648047781163589

Tested: Loaded on a system and did several reboots.
bmcweb looks good.

I see BMCState Manager start before
```
Mar 23 18:36:15 xxx systemd[1]: Started Phosphor Version Software Manager.
Mar 23 18:36:15 xxx systemd[1]: Started Phosphor Chassis State Manager.
Mar 23 18:36:15 xxx systemd[1]: Started Phosphor BMC State Manager.
Mar 23 18:36:15 xxx systemd[1]: Reached target Chassis0 power on after reset.
Mar 23 18:36:15 xx systemd-journald[227]: Forwarding to syslog missed 1 messages.
Mar 23 18:36:15 xx systemd[1]: Started Start bmcweb server.
--
Mar 23 18:41:59 xx systemd[1]: Started Hostname Service.
Mar 23 18:41:59 xx ipmid[616]: Set restrictedMode = false
Mar 23 18:41:59 xx systemd[1]: Started Phosphor Inband IPMI.
Mar 23 18:41:59 xx systemd[1]: Started Phosphor BMC State Manager.
Mar 23 18:41:59 xx systemd[1]: Reached target Chassis0 power on after reset.
Mar 23 18:41:59 xx systemd[1]: Started Start bmcweb server.

```

bmcweb is still up a full 90 - 120 seconds before we move to 
xyz.openbmc_project.State.BMC.BMCState.Ready 
```
Mar 23 18:35:58 xxx systemd[1]: Started Phosphor certificate manager for bmcweb.
Mar 23 18:36:15 xxx systemd[1]: Started Start bmcweb server.
```
After bmcweb is up about ~90 seconds of  
xyz.openbmc_project.State.BMC.BMCState.NotReady

Before we move to 
```
root@xxx:~# date 
Wed Mar 23 18:37:54 UTC 2022
root@xxx:~# obmcutil state
CurrentBMCState     : xyz.openbmc_project.State.BMC.BMCState.Ready <- First Ready I saw
```

Signed-off-by: Gunnar Mills <gmills@us.ibm.com>