### PR TITLE
Prevent error when occ-control server not available

### DIFF
--- a/redfish-core/lib/systems.hpp
+++ b/redfish-core/lib/systems.hpp
@@ -1747,9 +1747,9 @@ inline void getPowerMode(const std::shared_ptr<bmcweb::AsyncResp>& aResp)
                         const std::variant<std::string>& pmode) {
                     if (ec)
                     {
+                        // Service not available, no error, return no data
                         BMCWEB_LOG_DEBUG
-                            << "DBUS response error on PowerMode Get: " << ec;
-                        messages::internalError(aResp->res);
+                            << "Service not available on PowerMode Get: " << ec;
                         return;
                     }
 
@@ -2242,10 +2242,10 @@ inline void getIdlePowerSaver(const std::shared_ptr<bmcweb::AsyncResp>& aResp)
                         ipsPropertiesType& properties) {
                     if (ec)
                     {
-                        BMCWEB_LOG_ERROR
-                            << "DBUS response error on IdlePowerSaver GetAll: "
+                        // Service not available, no error, return no data
+                        BMCWEB_LOG_DEBUG
+                            << "Service not available on PowerIPS GetAll: "
                             << ec;
-                        messages::internalError(aResp->res);
                         return;
                     }
 


### PR DESCRIPTION
The Power.Mode and Power.IdlePowerSaver data is only available when the
occ-control service is running. During a BMC reboot the service may
temporarly not be available so this data can not be provided.

Redfish clients would bet getting internalErrors when the power data is
not available. This change will allow the other system data to be returned.

Change-Id: I5ce64ebde9789b900daaca6e84554351b35dfbad
Signed-off-by: Chris Cain <cjcain@us.ibm.com>