### PR TITLE
Display vmiIp irrespective of interfaceEnabled prop

### DIFF
--- a/redfish-core/lib/hypervisor_system.hpp
+++ b/redfish-core/lib/hypervisor_system.hpp
@@ -432,7 +432,6 @@ inline void parseInterfaceData(
     jsonResponse["Id"] = ifaceId;
     jsonResponse["@odata.id"] =
         "/redfish/v1/Systems/hypervisor/EthernetInterfaces/" + ifaceId;
-    jsonResponse["InterfaceEnabled"] = true;
     jsonResponse["HostName"] = ethData.hostname;
     jsonResponse["DHCPv4"]["DHCPEnabled"] =
         translateDHCPEnabledToBool(ethData.DHCPEnabled, true);
@@ -443,20 +442,17 @@ inline void parseInterfaceData(
     ipv4StaticArray = nlohmann::json::array();
     for (auto& ipv4Config : ipv4Data)
     {
-        if (ipv4Config.isActive)
+        jsonResponse["InterfaceEnabled"] = ipv4Config.isActive;
+        ipv4Array.push_back({{"AddressOrigin", ipv4Config.origin},
+                             {"SubnetMask", ipv4Config.netmask},
+                             {"Address", ipv4Config.address},
+                             {"Gateway", ipv4Config.gateway}});
+        if (ipv4Config.origin == "Static")
         {
-
-            ipv4Array.push_back({{"AddressOrigin", ipv4Config.origin},
-                                 {"SubnetMask", ipv4Config.netmask},
-                                 {"Address", ipv4Config.address},
-                                 {"Gateway", ipv4Config.gateway}});
-            if (ipv4Config.origin == "Static")
-            {
-                ipv4StaticArray.push_back({{"AddressOrigin", ipv4Config.origin},
-                                           {"SubnetMask", ipv4Config.netmask},
-                                           {"Address", ipv4Config.address},
-                                           {"Gateway", ipv4Config.gateway}});
-            }
+            ipv4StaticArray.push_back({{"AddressOrigin", ipv4Config.origin},
+                                       {"SubnetMask", ipv4Config.netmask},
+                                       {"Address", ipv4Config.address},
+                                       {"Gateway", ipv4Config.gateway}});
         }
     }
 }


### PR DESCRIPTION
Earlier, GET on the hypervisor ethernet interface hardcodes
InterfaceEnabled property of the redfish response as true and
vmi ip config data will be displayed based on the dbus object's
"Enabled" property - display ip when the property is true, else
return null.

With this change, the vmi ip config data will be displayed irrespective
of the "Enabled" property's value and InterfaceEnabled property of
the redfish response is mapped to the "Enabled" property of the dbus object.
This allows the client to know the configuration data, whether it is consumed
by host/not.

Tested By:

dbus introspect command for vmi eth interface:

busctl introspect xyz.openbmc_project.Network.Hypervisor /xyz/openbmc_project/network/hypervisor/eth1/ipv4/addr0

GET https://${bmc}/redfish/v1/Systems/hypervisor/EthernetInterfaces/eth1
{
  "@odata.id": "/redfish/v1/Systems/hypervisor/EthernetInterfaces/eth1",
  "@odata.type": "#EthernetInterface.v1_5_1.EthernetInterface",
  "DHCPv4": {
    "DHCPEnabled": false
  },
  "Description": "Hypervisor's Virtual Management Ethernet Interface",
  "HostName": "",
  "IPv4Addresses": [
    {
      "Address": "9.3.29.190",
      "AddressOrigin": "Static",
      "Gateway": "9.3.29.1",
      "SubnetMask": "255.255.252.0"
    }
  ],
  "IPv4StaticAddresses": [
    {
      "Address": "9.3.29.190",
      "AddressOrigin": "Static",
      "Gateway": "9.3.29.1",
      "SubnetMask": "255.255.252.0"
    }
  ],
  "Id": "eth1",
  "InterfaceEnabled": false,
  "Name": "Hypervisor Ethernet Interface"
}

Signed-off-by: Asmitha Karunanithi <asmitk01@in.ibm.com>
Change-Id: I2dd84bd870822531a891404fc7e59de6a349471c