### PR TITLE
DELETE Dump: Handle Unavailable D-bus error

### DIFF
--- a/redfish-core/lib/log_services.hpp
+++ b/redfish-core/lib/log_services.hpp
@@ -832,7 +832,8 @@ inline void deleteDumpEntry(const std::shared_ptr<bmcweb::AsyncResp>& asyncResp,
                             const std::string& dumpType)
 {
     auto respHandler = [asyncResp,
-                        entryID](const boost::system::error_code ec) {
+                        entryID](const boost::system::error_code ec,
+                                 const sdbusplus::message::message& msg) {
         BMCWEB_LOG_DEBUG << "Dump Entry doDelete callback: Done";
         if (ec)
         {
@@ -841,6 +842,21 @@ inline void deleteDumpEntry(const std::shared_ptr<bmcweb::AsyncResp>& asyncResp,
                 messages::resourceNotFound(asyncResp->res, "LogEntry", entryID);
                 return;
             }
+
+            const sd_bus_error* dbusError = msg.get_error();
+            if (dbusError == nullptr)
+            {
+                messages::internalError(asyncResp->res);
+                return;
+            }
+
+            if (strcmp(dbusError->name, "xyz.openbmc_project.Common.Error."
+                                        "Unavailable") == 0)
+            {
+                messages::serviceTemporarilyUnavailable(asyncResp->res, "1");
+                return;
+            }
+
             BMCWEB_LOG_ERROR << "Dump (DBus) doDelete respHandler got error "
                              << ec;
             messages::internalError(asyncResp->res);


### PR DESCRIPTION
Dump manager return Unavailable error for delete operation
when then same dump offload is getting offloaded.

This PR maps Unavailable D-bus error to redfish
ServiceTemporaryUnavailable error.