### PR TITLE
Push-sytle eventing: Revert "TerminateAfterRetries

### DIFF
--- a/http/http_client.hpp
+++ b/http/http_client.hpp
@@ -421,12 +421,9 @@ class HttpClient : public std::enable_shared_from_this<HttpClient>
                 }
 
                 state = ConnState::terminated;
-                // Remove the subscription
+                // TODO :Remove the subscription
                 BMCWEB_LOG_ERROR << "TerminateAfterRetries is set. retryCount: "
-                                 << retryCount << " .Subscriber: " << subId
-                                 << " deleted";
-                persistent_data::EventServiceStore::getInstance()
-                    .removeSubscription(subId);
+                                 << retryCount << " .Subscriber: " << subId;
                 return;
             }
             if (retryPolicyAction == "SuspendRetries")

--- a/include/event_service_store.hpp
+++ b/include/event_service_store.hpp
@@ -247,7 +247,7 @@ class EventServiceStore
     boost::container::flat_map<std::string, std::shared_ptr<UserSubscription>>
         subscriptionsConfigMap;
     EventServiceConfig eventServiceConfig;
-    bool needWrite{false};
+
     static EventServiceStore& getInstance()
     {
         static EventServiceStore eventServiceStore;
@@ -257,31 +257,6 @@ class EventServiceStore
     EventServiceConfig& getEventServiceConfig()
     {
         return eventServiceConfig;
-    }
-
-    bool needsWrite()
-    {
-        return needWrite;
-    }
-
-    void persistSubscription()
-    {
-        needWrite = true;
-        return;
-    }
-    void removeSubscription(const std::string& id)
-    {
-        auto obj = subscriptionsConfigMap.find(id);
-        if (obj != subscriptionsConfigMap.end())
-        {
-            BMCWEB_LOG_ERROR << "Deleting " << id
-                             << " from subscriptionsConfigMap";
-            subscriptionsConfigMap.erase(obj);
-            needWrite = true;
-            return;
-        }
-        BMCWEB_LOG_ERROR << "Subscriber " << id
-                         << " not found subscriptionsConfigMap";
     }
 };
 

--- a/include/persistent_data.hpp
+++ b/include/persistent_data.hpp
@@ -37,8 +37,7 @@ class ConfigFile
     {
         // Make sure we aren't writing stale sessions
         persistent_data::SessionStore::getInstance().applySessionTimeouts();
-        if ((persistent_data::SessionStore::getInstance().needsWrite()) ||
-            (persistent_data::EventServiceStore::getInstance().needsWrite()))
+        if (persistent_data::SessionStore::getInstance().needsWrite())
         {
             writeData();
         }


### PR DESCRIPTION
We had a bmcweb crash when the subscriber is deleted using
redfish command after its marked for delete via the event
retry policy "TerminateAfterRetries"

This commit reverts the "TerminateAfterRetries" support

Tested by:
  Send DELETE subscriber on a subscription which was set to
  TerminateAfterRetries. Verified there is no bmcweb crash

Signed-off-by: sunharis <sunharis@in.ibm.com>