### PR TITLE
Remove name_util::getPrettyName from FirmwareInventory

### DIFF
--- a/redfish-core/lib/update_service.hpp
+++ b/redfish-core/lib/update_service.hpp
@@ -21,7 +21,6 @@
 #include <boost/container/flat_map.hpp>
 #include <registries/privilege_registry.hpp>
 #include <utils/fw_utils.hpp>
-#include <utils/name_utils.hpp>
 
 #include <variant>
 
@@ -864,9 +863,6 @@ inline void requestRoutesSoftwareInventory(App& app)
                                              obj.second[0].first);
 
                         asyncResp->res.jsonValue["Name"] = "Software Inventory";
-                        name_util::getPrettyName(asyncResp, obj.first,
-                                                 obj.second,
-                                                 "/Name"_json_pointer);
 
                         crow::connections::systemBus->async_method_call(
                             [asyncResp, swId](


### PR DESCRIPTION
https://github.com/ibm-openbmc/bmcweb/commit/43691c15aaee5bf99eb142b063b9c5b1f4b423c6 added name_util::getPrettyName and one of the places it added it was Firmware Inventory (e.g. /redfish/v1/UpdateService/FirmwareInventory/7aaab73b). 

getPrettyName isn't as smart as it should probably be and it flags xyz.openbmc_project.Software.BMC.Updater and xyz.openbmc_project.Software.Version for having the same object (not just both having prettyName at the same object). 

We don't use PrettyName for Firmware Inventory so let's just remove this name_util::getPrettyName and save us a D-Bus call and the potential for this internalError.

The interalError seen on a rainier system was:

Mar 28 15:16:58 xxxx bmcweb[518]: (2022-03-28 15:16:58) [ERROR "name_utils.hpp":38] Invalid Service Size 2
Mar 28 15:16:58 xxxx bmcweb[518]: (2022-03-28 15:16:58) [ERROR "name_utils.hpp":41] Invalid Service Name:
xyz.openbmc_project.Software.BMC.Updater
Mar 28 15:16:58 xxxx bmcweb[518]: (2022-03-28 15:16:58) [ERROR "name_utils.hpp":41] Invalid Service Name:
xyz.openbmc_project.Software.Version
Mar 28 15:16:58 xxxx bmcweb[518]: (2022-03-28 15:16:58) [CRITICAL "error_messages.cpp":233] Internal Error
../git/redfish-core/include/utils/name_utils.hpp(45:36) void redfish::name_util::getPrettyName(const std::shared_ptr<bmcweb::AsyncResp>&, const string&, const std::vector<std::pair<std::__cxx11::basic_string<char>, std::vector<std::__cxx11::basic_string<char> > > >&, const nlohmann::json_pointer<nlohmann::basic_json<> >&):

A busctl introspect of xyz.openbmc_project.Software.BMC.Updater doesn't show any PrettyName property, also can see the Firmware Inventory using the default name:

```
{
"@odata.id": "/redfish/v1/UpdateService/FirmwareInventory/7aaab73b",
"@odata.type": "#SoftwareInventory.v1_1_0.SoftwareInventory",
"Description": "BMC image",
"Id": "7aaab73b",
"Name": "Software Inventory",
```

See: https://ibm-systems-power.slack.com/archives/C031HHVDKT5/p1648494917644449?thread_ts=1648485575.859449&cid=C031HHVDKT5 for more information 

Tested: None.

Signed-off-by: Gunnar Mills <gmills@us.ibm.com>