### PR TITLE
Add OemServiceRoot Schema for additional properties needed for non-auth ACF generation

### DIFF
--- a/scripts/update_schemas.py
+++ b/scripts/update_schemas.py
@@ -190,6 +190,7 @@ with open(metadata_index_path, 'w') as metadata_index:
     metadata_index.write("    </edmx:Reference>\n")
 
     metadata_index.write(
+        "    <edmx:Reference Uri=\""
         "/redfish/v1/schema/OemChassis_v1.xml\">\n")
     metadata_index.write(
         "        <edmx:Include Namespace=\"OemChassis\"/>\n")

--- a/scripts/update_schemas.py
+++ b/scripts/update_schemas.py
@@ -149,6 +149,13 @@ with open(metadata_index_path, 'w') as metadata_index:
     metadata_index.write("    </edmx:Reference>\n")
 
     metadata_index.write(
+        "    <edmx:Reference Uri=\""
+        "/redfish/v1/schema/OemServiceRoot_v1.xml\">\n")
+    metadata_index.write(
+        "        <edmx:Include Namespace=\"OemServiceRoot\"/>\n")
+    metadata_index.write("    </edmx:Reference>\n")
+
+    metadata_index.write(
         "    <edmx:Reference Uri=\"/redfish/v1/schema/OemSession_v1.xml\">\n")
     metadata_index.write("        <edmx:Include Namespace=\"OemSession\"/>\n")
     metadata_index.write(

--- a/static/redfish/v1/$metadata/index.xml
+++ b/static/redfish/v1/$metadata/index.xml
@@ -213,6 +213,7 @@
     <edmx:Reference Uri="/redfish/v1/schema/Battery_v1.xml">
         <edmx:Include Namespace="Battery"/>
         <edmx:Include Namespace="Battery.v1_0_0"/>
+        <edmx:Include Namespace="Battery.v1_0_1"/>
     </edmx:Reference>
     <edmx:Reference Uri="/redfish/v1/schema/BatteryCollection_v1.xml">
         <edmx:Include Namespace="BatteryCollection"/>
@@ -220,6 +221,7 @@
     <edmx:Reference Uri="/redfish/v1/schema/BatteryMetrics_v1.xml">
         <edmx:Include Namespace="BatteryMetrics"/>
         <edmx:Include Namespace="BatteryMetrics.v1_0_0"/>
+        <edmx:Include Namespace="BatteryMetrics.v1_0_1"/>
     </edmx:Reference>
     <edmx:Reference Uri="/redfish/v1/schema/Bios_v1.xml">
         <edmx:Include Namespace="Bios"/>
@@ -441,11 +443,17 @@
         <edmx:Include Namespace="Circuit.v1_0_0"/>
         <edmx:Include Namespace="Circuit.v1_0_1"/>
         <edmx:Include Namespace="Circuit.v1_0_2"/>
+        <edmx:Include Namespace="Circuit.v1_0_3"/>
         <edmx:Include Namespace="Circuit.v1_1_0"/>
         <edmx:Include Namespace="Circuit.v1_1_1"/>
+        <edmx:Include Namespace="Circuit.v1_1_2"/>
         <edmx:Include Namespace="Circuit.v1_2_0"/>
+        <edmx:Include Namespace="Circuit.v1_2_1"/>
         <edmx:Include Namespace="Circuit.v1_3_0"/>
+        <edmx:Include Namespace="Circuit.v1_3_1"/>
         <edmx:Include Namespace="Circuit.v1_4_0"/>
+        <edmx:Include Namespace="Circuit.v1_4_1"/>
+        <edmx:Include Namespace="Circuit.v1_5_0"/>
     </edmx:Reference>
     <edmx:Reference Uri="/redfish/v1/schema/CircuitCollection_v1.xml">
         <edmx:Include Namespace="CircuitCollection"/>
@@ -465,6 +473,13 @@
         <edmx:Include Namespace="CollectionCapabilities.v1_2_1"/>
         <edmx:Include Namespace="CollectionCapabilities.v1_2_2"/>
         <edmx:Include Namespace="CollectionCapabilities.v1_3_0"/>
+    </edmx:Reference>
+    <edmx:Reference Uri="/redfish/v1/schema/ComponentIntegrity_v1.xml">
+        <edmx:Include Namespace="ComponentIntegrity"/>
+        <edmx:Include Namespace="ComponentIntegrity.v1_0_0"/>
+    </edmx:Reference>
+    <edmx:Reference Uri="/redfish/v1/schema/ComponentIntegrityCollection_v1.xml">
+        <edmx:Include Namespace="ComponentIntegrityCollection"/>
     </edmx:Reference>
     <edmx:Reference Uri="/redfish/v1/schema/CompositionReservation_v1.xml">
         <edmx:Include Namespace="CompositionReservation"/>
@@ -664,6 +679,8 @@
     <edmx:Reference Uri="/redfish/v1/schema/Control_v1.xml">
         <edmx:Include Namespace="Control"/>
         <edmx:Include Namespace="Control.v1_0_0"/>
+        <edmx:Include Namespace="Control.v1_0_1"/>
+        <edmx:Include Namespace="Control.v1_1_0"/>
     </edmx:Reference>
     <edmx:Reference Uri="/redfish/v1/schema/ControlCollection_v1.xml">
         <edmx:Include Namespace="ControlCollection"/>
@@ -881,7 +898,10 @@
     <edmx:Reference Uri="/redfish/v1/schema/EnvironmentMetrics_v1.xml">
         <edmx:Include Namespace="EnvironmentMetrics"/>
         <edmx:Include Namespace="EnvironmentMetrics.v1_0_0"/>
+        <edmx:Include Namespace="EnvironmentMetrics.v1_0_1"/>
         <edmx:Include Namespace="EnvironmentMetrics.v1_1_0"/>
+        <edmx:Include Namespace="EnvironmentMetrics.v1_1_1"/>
+        <edmx:Include Namespace="EnvironmentMetrics.v1_2_0"/>
     </edmx:Reference>
     <edmx:Reference Uri="/redfish/v1/schema/EthernetInterface_v1.xml">
         <edmx:Include Namespace="EthernetInterface"/>
@@ -1184,6 +1204,7 @@
         <edmx:Include Namespace="Fabric.v1_2_0"/>
         <edmx:Include Namespace="Fabric.v1_2_1"/>
         <edmx:Include Namespace="Fabric.v1_2_2"/>
+        <edmx:Include Namespace="Fabric.v1_3_0"/>
     </edmx:Reference>
     <edmx:Reference Uri="/redfish/v1/schema/FabricAdapter_v1.xml">
         <edmx:Include Namespace="FabricAdapter"/>
@@ -1212,7 +1233,9 @@
         <edmx:Include Namespace="Fan"/>
         <edmx:Include Namespace="Fan.v1_0_0"/>
         <edmx:Include Namespace="Fan.v1_0_1"/>
+        <edmx:Include Namespace="Fan.v1_0_2"/>
         <edmx:Include Namespace="Fan.v1_1_0"/>
+        <edmx:Include Namespace="Fan.v1_1_1"/>
     </edmx:Reference>
     <edmx:Reference Uri="/redfish/v1/schema/FanCollection_v1.xml">
         <edmx:Include Namespace="FanCollection"/>
@@ -1620,6 +1643,10 @@
     </edmx:Reference>
     <edmx:Reference Uri="/redfish/v1/schema/ManagerCollection_v1.xml">
         <edmx:Include Namespace="ManagerCollection"/>
+    </edmx:Reference>
+    <edmx:Reference Uri="/redfish/v1/schema/ManagerDiagnosticData_v1.xml">
+        <edmx:Include Namespace="ManagerDiagnosticData"/>
+        <edmx:Include Namespace="ManagerDiagnosticData.v1_0_0"/>
     </edmx:Reference>
     <edmx:Reference Uri="/redfish/v1/schema/ManagerNetworkProtocol_v1.xml">
         <edmx:Include Namespace="ManagerNetworkProtocol"/>
@@ -2057,6 +2084,7 @@
         <edmx:Include Namespace="NetworkAdapter.v1_6_0"/>
         <edmx:Include Namespace="NetworkAdapter.v1_7_0"/>
         <edmx:Include Namespace="NetworkAdapter.v1_8_0"/>
+        <edmx:Include Namespace="NetworkAdapter.v1_9_0"/>
     </edmx:Reference>
     <edmx:Reference Uri="/redfish/v1/schema/NetworkAdapterCollection_v1.xml">
         <edmx:Include Namespace="NetworkAdapterCollection"/>
@@ -2111,6 +2139,7 @@
         <edmx:Include Namespace="NetworkDeviceFunction.v1_5_2"/>
         <edmx:Include Namespace="NetworkDeviceFunction.v1_6_0"/>
         <edmx:Include Namespace="NetworkDeviceFunction.v1_7_0"/>
+        <edmx:Include Namespace="NetworkDeviceFunction.v1_8_0"/>
     </edmx:Reference>
     <edmx:Reference Uri="/redfish/v1/schema/NetworkDeviceFunctionCollection_v1.xml">
         <edmx:Include Namespace="NetworkDeviceFunctionCollection"/>
@@ -2191,10 +2220,15 @@
         <edmx:Include Namespace="Outlet.v1_0_0"/>
         <edmx:Include Namespace="Outlet.v1_0_1"/>
         <edmx:Include Namespace="Outlet.v1_0_2"/>
+        <edmx:Include Namespace="Outlet.v1_0_3"/>
         <edmx:Include Namespace="Outlet.v1_1_0"/>
         <edmx:Include Namespace="Outlet.v1_1_1"/>
+        <edmx:Include Namespace="Outlet.v1_1_2"/>
         <edmx:Include Namespace="Outlet.v1_2_0"/>
+        <edmx:Include Namespace="Outlet.v1_2_1"/>
         <edmx:Include Namespace="Outlet.v1_3_0"/>
+        <edmx:Include Namespace="Outlet.v1_3_1"/>
+        <edmx:Include Namespace="Outlet.v1_4_0"/>
     </edmx:Reference>
     <edmx:Reference Uri="/redfish/v1/schema/OutletCollection_v1.xml">
         <edmx:Include Namespace="OutletCollection"/>
@@ -2203,6 +2237,8 @@
         <edmx:Include Namespace="OutletGroup"/>
         <edmx:Include Namespace="OutletGroup.v1_0_0"/>
         <edmx:Include Namespace="OutletGroup.v1_0_1"/>
+        <edmx:Include Namespace="OutletGroup.v1_0_2"/>
+        <edmx:Include Namespace="OutletGroup.v1_1_0"/>
     </edmx:Reference>
     <edmx:Reference Uri="/redfish/v1/schema/OutletGroupCollection_v1.xml">
         <edmx:Include Namespace="OutletGroupCollection"/>
@@ -2316,6 +2352,7 @@
         <edmx:Include Namespace="Port.v1_4_0"/>
         <edmx:Include Namespace="Port.v1_4_1"/>
         <edmx:Include Namespace="Port.v1_5_0"/>
+        <edmx:Include Namespace="Port.v1_6_0"/>
     </edmx:Reference>
     <edmx:Reference Uri="/redfish/v1/schema/PortCollection_v1.xml">
         <edmx:Include Namespace="PortCollection"/>
@@ -2409,8 +2446,11 @@
         <edmx:Include Namespace="PowerDistribution.v1_0_1"/>
         <edmx:Include Namespace="PowerDistribution.v1_0_2"/>
         <edmx:Include Namespace="PowerDistribution.v1_0_3"/>
+        <edmx:Include Namespace="PowerDistribution.v1_0_4"/>
         <edmx:Include Namespace="PowerDistribution.v1_1_0"/>
+        <edmx:Include Namespace="PowerDistribution.v1_1_1"/>
         <edmx:Include Namespace="PowerDistribution.v1_2_0"/>
+        <edmx:Include Namespace="PowerDistribution.v1_2_1"/>
     </edmx:Reference>
     <edmx:Reference Uri="/redfish/v1/schema/PowerDistributionCollection_v1.xml">
         <edmx:Include Namespace="PowerDistributionCollection"/>
@@ -2419,8 +2459,12 @@
         <edmx:Include Namespace="PowerDistributionMetrics"/>
         <edmx:Include Namespace="PowerDistributionMetrics.v1_0_0"/>
         <edmx:Include Namespace="PowerDistributionMetrics.v1_0_1"/>
+        <edmx:Include Namespace="PowerDistributionMetrics.v1_0_2"/>
         <edmx:Include Namespace="PowerDistributionMetrics.v1_1_0"/>
+        <edmx:Include Namespace="PowerDistributionMetrics.v1_1_1"/>
         <edmx:Include Namespace="PowerDistributionMetrics.v1_2_0"/>
+        <edmx:Include Namespace="PowerDistributionMetrics.v1_2_1"/>
+        <edmx:Include Namespace="PowerDistributionMetrics.v1_3_0"/>
     </edmx:Reference>
     <edmx:Reference Uri="/redfish/v1/schema/PowerDomain_v1.xml">
         <edmx:Include Namespace="PowerDomain"/>
@@ -2449,6 +2493,7 @@
         <edmx:Include Namespace="PowerSupply.v1_0_1"/>
         <edmx:Include Namespace="PowerSupply.v1_1_0"/>
         <edmx:Include Namespace="PowerSupply.v1_2_0"/>
+        <edmx:Include Namespace="PowerSupply.v1_3_0"/>
     </edmx:Reference>
     <edmx:Reference Uri="/redfish/v1/schema/PowerSupplyCollection_v1.xml">
         <edmx:Include Namespace="PowerSupplyCollection"/>
@@ -2456,6 +2501,7 @@
     <edmx:Reference Uri="/redfish/v1/schema/PowerSupplyMetrics_v1.xml">
         <edmx:Include Namespace="PowerSupplyMetrics"/>
         <edmx:Include Namespace="PowerSupplyMetrics.v1_0_0"/>
+        <edmx:Include Namespace="PowerSupplyMetrics.v1_0_1"/>
     </edmx:Reference>
     <edmx:Reference Uri="/redfish/v1/schema/PrivilegeRegistry_v1.xml">
         <edmx:Include Namespace="PrivilegeRegistry"/>
@@ -2587,7 +2633,9 @@
         <edmx:Include Namespace="ProcessorMetrics.v1_2_1"/>
         <edmx:Include Namespace="ProcessorMetrics.v1_2_2"/>
         <edmx:Include Namespace="ProcessorMetrics.v1_3_0"/>
+        <edmx:Include Namespace="ProcessorMetrics.v1_3_1"/>
         <edmx:Include Namespace="ProcessorMetrics.v1_4_0"/>
+        <edmx:Include Namespace="ProcessorMetrics.v1_4_1"/>
     </edmx:Reference>
     <edmx:Reference Uri="/redfish/v1/schema/Protocol_v1.xml">
         <edmx:Include Namespace="Protocol"/>
@@ -2637,6 +2685,13 @@
         <edmx:Include Namespace="Redundancy.v1_3_5"/>
         <edmx:Include Namespace="Redundancy.v1_3_6"/>
         <edmx:Include Namespace="Redundancy.v1_4_0"/>
+    </edmx:Reference>
+    <edmx:Reference Uri="/redfish/v1/schema/RegisteredClient_v1.xml">
+        <edmx:Include Namespace="RegisteredClient"/>
+        <edmx:Include Namespace="RegisteredClient.v1_0_0"/>
+    </edmx:Reference>
+    <edmx:Reference Uri="/redfish/v1/schema/RegisteredClientCollection_v1.xml">
+        <edmx:Include Namespace="RegisteredClientCollection"/>
     </edmx:Reference>
     <edmx:Reference Uri="/redfish/v1/schema/Resource_v1.xml">
         <edmx:Include Namespace="Resource"/>
@@ -2936,6 +2991,10 @@
     </edmx:Reference>
     <edmx:Reference Uri="/redfish/v1/schema/SerialInterfaceCollection_v1.xml">
         <edmx:Include Namespace="SerialInterfaceCollection"/>
+    </edmx:Reference>
+    <edmx:Reference Uri="/redfish/v1/schema/ServiceConditions_v1.xml">
+        <edmx:Include Namespace="ServiceConditions"/>
+        <edmx:Include Namespace="ServiceConditions.v1_0_0"/>
     </edmx:Reference>
     <edmx:Reference Uri="/redfish/v1/schema/ServiceRoot_v1.xml">
         <edmx:Include Namespace="ServiceRoot"/>
@@ -3246,6 +3305,7 @@
         <edmx:Include Namespace="Switch.v1_5_1"/>
         <edmx:Include Namespace="Switch.v1_6_0"/>
         <edmx:Include Namespace="Switch.v1_7_0"/>
+        <edmx:Include Namespace="Switch.v1_8_0"/>
     </edmx:Reference>
     <edmx:Reference Uri="/redfish/v1/schema/SwitchCollection_v1.xml">
         <edmx:Include Namespace="SwitchCollection"/>
@@ -3406,6 +3466,7 @@
     <edmx:Reference Uri="/redfish/v1/schema/ThermalMetrics_v1.xml">
         <edmx:Include Namespace="ThermalMetrics"/>
         <edmx:Include Namespace="ThermalMetrics.v1_0_0"/>
+        <edmx:Include Namespace="ThermalMetrics.v1_0_1"/>
     </edmx:Reference>
     <edmx:Reference Uri="/redfish/v1/schema/ThermalSubsystem_v1.xml">
         <edmx:Include Namespace="ThermalSubsystem"/>

--- a/static/redfish/v1/$metadata/index.xml
+++ b/static/redfish/v1/$metadata/index.xml
@@ -3732,6 +3732,9 @@
         <edmx:Include Namespace="OemAccountService"/>
         <edmx:Include Namespace="OemAccountService.v1_0_0"/>
     </edmx:Reference>
+    <edmx:Reference Uri="/redfish/v1/schema/OemServiceRoot_v1.xml">
+        <edmx:Include Namespace="OemServiceRoot"/>
+    </edmx:Reference>
     <edmx:Reference Uri="/redfish/v1/schema/OemSession_v1.xml">
         <edmx:Include Namespace="OemSession"/>
         <edmx:Include Namespace="OemSession.v1_0_0"/>

--- a/static/redfish/v1/JsonSchemas/Battery/Battery.json
+++ b/static/redfish/v1/JsonSchemas/Battery/Battery.json
@@ -1,5 +1,5 @@
 {
-    "$id": "http://redfish.dmtf.org/schemas/v1/Battery.v1_0_0.json",
+    "$id": "http://redfish.dmtf.org/schemas/v1/Battery.v1_0_1.json",
     "$ref": "#/definitions/Battery",
     "$schema": "http://redfish.dmtf.org/schemas/v1/redfish-schema-v1.json",
     "copyright": "Copyright 2014-2021 DMTF. For the full DMTF copyright policy, see http://www.dmtf.org/about/policies/copyright",
@@ -291,9 +291,9 @@
                 },
                 "StateOfHealthPercent": {
                     "$ref": "http://redfish.dmtf.org/schemas/v1/Sensor.json#/definitions/SensorExcerpt",
-                    "description": "The state of health of this battery.",
+                    "description": "The state of health (percent) of this battery.",
                     "excerptCopy": "SensorExcerpt",
-                    "longDescription": "This property shall contain the state of health of this battery as a percentage."
+                    "longDescription": "This property shall contain the state of health, in percent units, of this battery.  The value of the DataSourceUri property, if present, shall reference a resource of type Sensor with the ReadingType property containing the value `Percent`."
                 },
                 "Status": {
                     "$ref": "http://redfish.dmtf.org/schemas/v1/Resource.json#/definitions/Status",
@@ -462,5 +462,5 @@
     },
     "owningEntity": "DMTF",
     "release": "2021.2",
-    "title": "#Battery.v1_0_0.Battery"
+    "title": "#Battery.v1_0_1.Battery"
 }

--- a/static/redfish/v1/JsonSchemas/BatteryMetrics/BatteryMetrics.json
+++ b/static/redfish/v1/JsonSchemas/BatteryMetrics/BatteryMetrics.json
@@ -1,5 +1,5 @@
 {
-    "$id": "http://redfish.dmtf.org/schemas/v1/BatteryMetrics.v1_0_0.json",
+    "$id": "http://redfish.dmtf.org/schemas/v1/BatteryMetrics.v1_0_1.json",
     "$ref": "#/definitions/BatteryMetrics",
     "$schema": "http://redfish.dmtf.org/schemas/v1/redfish-schema-v1.json",
     "copyright": "Copyright 2014-2021 DMTF. For the full DMTF copyright policy, see http://www.dmtf.org/about/policies/copyright",
@@ -68,12 +68,12 @@
                     "longDescription": "This property shall contain the available actions for this resource."
                 },
                 "CellVoltages": {
-                    "description": "The cell voltage readings for this battery.",
+                    "description": "The cell voltages (V) for this battery.",
                     "excerptCopy": "SensorVoltageExcerpt",
                     "items": {
                         "$ref": "http://redfish.dmtf.org/schemas/v1/Sensor.json#/definitions/SensorVoltageExcerpt"
                     },
-                    "longDescription": "This property shall contain the cell voltage sensors for this battery.",
+                    "longDescription": "This property shall contain the cell voltages, in volt units, for this battery.  The value of the DataSourceUri property, if present, shall reference a resource of type Sensor with the ReadingType property containing the value `Voltage`.",
                     "type": "array"
                 },
                 "CellVoltages@odata.count": {
@@ -81,9 +81,9 @@
                 },
                 "ChargePercent": {
                     "$ref": "http://redfish.dmtf.org/schemas/v1/Sensor.json#/definitions/SensorExcerpt",
-                    "description": "The amount of charge available in this battery as a percentage.",
+                    "description": "The amount of charge available (percent) in this battery.",
                     "excerptCopy": "SensorExcerpt",
-                    "longDescription": "This property shall contain the amount of charge available in this battery as a percentage."
+                    "longDescription": "This property shall contain the amount of charge available, in percent units, in this battery.  The value of the DataSourceUri property, if present, shall reference a resource of type Sensor with the ReadingType property containing the value `Percent`."
                 },
                 "Description": {
                     "anyOf": [
@@ -112,15 +112,15 @@
                 },
                 "InputCurrentAmps": {
                     "$ref": "http://redfish.dmtf.org/schemas/v1/Sensor.json#/definitions/SensorCurrentExcerpt",
-                    "description": "The input current reading for this battery.",
+                    "description": "The input current (A) for this battery.",
                     "excerptCopy": "SensorCurrentExcerpt",
-                    "longDescription": "This property shall contain the input current sensor for this battery."
+                    "longDescription": "This property shall contain the input current, in ampere units, for this battery.  The value of the DataSourceUri property, if present, shall reference a resource of type Sensor with the ReadingType property containing the value `Current`."
                 },
                 "InputVoltage": {
                     "$ref": "http://redfish.dmtf.org/schemas/v1/Sensor.json#/definitions/SensorVoltageExcerpt",
-                    "description": "The input voltage reading for this battery.",
+                    "description": "The input voltage (V) for this battery.",
                     "excerptCopy": "SensorVoltageExcerpt",
-                    "longDescription": "This property shall contain the input voltage sensor for this battery."
+                    "longDescription": "This property shall contain the input voltage, in volt units, for this battery.  The value of the DataSourceUri property, if present, shall reference a resource of type Sensor with the ReadingType property containing the value `Voltage`."
                 },
                 "Name": {
                     "$ref": "http://redfish.dmtf.org/schemas/v1/Resource.json#/definitions/Name",
@@ -132,24 +132,24 @@
                     "longDescription": "This property shall contain the OEM extensions.  All values for properties that this object contains shall conform to the Redfish Specification-described requirements."
                 },
                 "OutputCurrentAmps": {
-                    "description": "The output current readings for this battery.",
+                    "description": "The output currents (A) for this battery.",
                     "excerptCopy": "SensorCurrentExcerpt",
                     "items": {
                         "$ref": "http://redfish.dmtf.org/schemas/v1/Sensor.json#/definitions/SensorCurrentExcerpt"
                     },
-                    "longDescription": "This property shall contain the output current sensors for this battery.  The sensors shall appear in the same array order as the OutputVoltages property.",
+                    "longDescription": "This property shall contain the output currents, in ampere units, for this battery.  The value of the DataSourceUri property, if present, shall reference a resource of type Sensor with the ReadingType property containing the value `Current`.  The sensors shall appear in the same array order as the OutputVoltages property.",
                     "type": "array"
                 },
                 "OutputCurrentAmps@odata.count": {
                     "$ref": "http://redfish.dmtf.org/schemas/v1/odata-v4.json#/definitions/count"
                 },
                 "OutputVoltages": {
-                    "description": "The output voltage readings for this battery.",
+                    "description": "The output voltages (V) for this battery.",
                     "excerptCopy": "SensorVoltageExcerpt",
                     "items": {
                         "$ref": "http://redfish.dmtf.org/schemas/v1/Sensor.json#/definitions/SensorVoltageExcerpt"
                     },
-                    "longDescription": "This property shall contain the output voltage sensors for this battery.  The sensors shall appear in the same array order as the OutputCurrentAmps property.",
+                    "longDescription": "This property shall contain the output voltages, in volt units, for this battery.  The value of the DataSourceUri property, if present, shall reference a resource of type Sensor with the ReadingType property containing the value `Voltage`.  The sensors shall appear in the same array order as the OutputCurrentAmps property.",
                     "type": "array"
                 },
                 "OutputVoltages@odata.count": {
@@ -162,21 +162,21 @@
                 },
                 "StoredChargeAmpHours": {
                     "$ref": "http://redfish.dmtf.org/schemas/v1/Sensor.json#/definitions/SensorExcerpt",
-                    "description": "The charge stored in this battery in amp-hours.",
+                    "description": "The charge (Ah) stored in this battery.",
                     "excerptCopy": "SensorExcerpt",
-                    "longDescription": "This property shall contain the charge sensor for this battery in amp-hours."
+                    "longDescription": "This property shall contain the stored charge, in ampere-hours units, for this battery.  The value of the DataSourceUri property, if present, shall reference a resource of type Sensor with the ReadingType property containing the value `ChargeAh`."
                 },
                 "StoredEnergyWattHours": {
                     "$ref": "http://redfish.dmtf.org/schemas/v1/Sensor.json#/definitions/SensorExcerpt",
-                    "description": "The energy stored in this battery in watt-hours.",
+                    "description": "The energy (Wh) stored in this battery.",
                     "excerptCopy": "SensorExcerpt",
-                    "longDescription": "This property shall contain the energy sensor for this battery in watt-hours."
+                    "longDescription": "This property shall contain the stored energy, in watt-hour units, for this battery.  The value of the DataSourceUri property, if present, shall reference a resource of type Sensor with the ReadingType property containing the value `EnergyWh`."
                 },
                 "TemperatureCelsius": {
                     "$ref": "http://redfish.dmtf.org/schemas/v1/Sensor.json#/definitions/SensorExcerpt",
-                    "description": "The temperature reading for this battery.",
+                    "description": "The temperature (C) for this battery.",
                     "excerptCopy": "SensorExcerpt",
-                    "longDescription": "This property shall contain the temperature sensor for this battery."
+                    "longDescription": "This property shall contain the temperature, in degrees Celsius units, for this battery.  The value of the DataSourceUri property, if present, shall reference a resource of type Sensor with the ReadingType property containing the value `Temperature`."
                 }
             },
             "required": [
@@ -211,5 +211,5 @@
     },
     "owningEntity": "DMTF",
     "release": "2021.2",
-    "title": "#BatteryMetrics.v1_0_0.BatteryMetrics"
+    "title": "#BatteryMetrics.v1_0_1.BatteryMetrics"
 }

--- a/static/redfish/v1/JsonSchemas/Circuit/Circuit.json
+++ b/static/redfish/v1/JsonSchemas/Circuit/Circuit.json
@@ -1,5 +1,5 @@
 {
-    "$id": "http://redfish.dmtf.org/schemas/v1/Circuit.v1_4_0.json",
+    "$id": "http://redfish.dmtf.org/schemas/v1/Circuit.v1_5_0.json",
     "$ref": "#/definitions/Circuit",
     "$schema": "http://redfish.dmtf.org/schemas/v1/redfish-schema-v1.json",
     "copyright": "Copyright 2014-2021 DMTF. For the full DMTF copyright policy, see http://www.dmtf.org/about/policies/copyright",
@@ -140,6 +140,13 @@
                     "longDescription": "This property shall contain the type of circuit.",
                     "readonly": true
                 },
+                "ConfigurationLocked": {
+                    "description": "Indicates whether the configuration is locked.",
+                    "longDescription": "This property shall indicate whether modification requests to this resource are not permitted.  If `true`, services shall reject modification requests to other properties in this resource.",
+                    "readonly": false,
+                    "type": "boolean",
+                    "versionAdded": "v1_5_0"
+                },
                 "CriticalCircuit": {
                     "description": "Designates if this is a critical circuit.",
                     "longDescription": "This property shall indicate whether the circuit is designated as a critical circuit, and therefore is excluded from autonomous logic that could affect the state of the circuit.  The value shall be `true` if the circuit is deemed critical, and `false` if the circuit is not critical.",
@@ -158,9 +165,9 @@
                             "type": "null"
                         }
                     ],
-                    "description": "The current reading for this single phase circuit.",
+                    "description": "The current (A) for this single phase circuit.",
                     "excerptCopy": "SensorCurrentExcerpt",
-                    "longDescription": "This property shall contain the current, measured in Amperes, for this single phase circuit.  This property shall not appear in resource instances representing poly-phase circuits."
+                    "longDescription": "This property shall contain the current, in ampere units, for this single phase circuit.  The value of the DataSourceUri property, if present, shall reference a resource of type Sensor with the ReadingType property containing the value `Current`.  This property shall not appear in resource instances representing poly-phase circuits."
                 },
                 "Description": {
                     "anyOf": [
@@ -223,9 +230,9 @@
                             "type": "null"
                         }
                     ],
-                    "description": "The energy reading for this circuit.",
+                    "description": "The energy (kWh) for this circuit.",
                     "excerptCopy": "SensorEnergykWhExcerpt",
-                    "longDescription": "This property shall contain the total energy, measured in kilowatt-hours (kW.h), for this circuit, that represents the `Total` ElectricalContext sensor when multiple energy sensors exist for this circuit."
+                    "longDescription": "This property shall contain the total energy, in kilowatt-hour units, for this circuit, that represents the `Total` ElectricalContext sensor when multiple energy sensors exist for this circuit.  The value of the DataSourceUri property, if present, shall reference a resource of type Sensor with the ReadingType property containing the value `EnergykWh`."
                 },
                 "FrequencyHz": {
                     "anyOf": [
@@ -236,9 +243,9 @@
                             "type": "null"
                         }
                     ],
-                    "description": "The frequency reading for this circuit.",
+                    "description": "The frequency (Hz) for this circuit.",
                     "excerptCopy": "SensorExcerpt",
-                    "longDescription": "This property shall contain the frequency sensor for this circuit."
+                    "longDescription": "This property shall contain the frequency, in hertz units, for this circuit.  The value of the DataSourceUri property, if present, shall reference a resource of type Sensor with the ReadingType property containing the value `Frequency`."
                 },
                 "Id": {
                     "$ref": "http://redfish.dmtf.org/schemas/v1/Resource.json#/definitions/Id",
@@ -332,7 +339,7 @@
                         }
                     ],
                     "description": "The current readings for this circuit.",
-                    "longDescription": "This property shall contain the current sensor(s) for this circuit.  For single phase circuits this property shall contain a duplicate copy of the current sensor referenced in the CurrentSensor property, if present.  For poly-phase circuits this property should contain multiple current sensor readings used to fully describe the circuit."
+                    "longDescription": "This property shall contain the current sensors for this circuit.  For single phase circuits this property shall contain a duplicate copy of the current sensor referenced in the CurrentAmps property, if present.  For poly-phase circuits this property should contain multiple current sensor readings used to fully describe the circuit."
                 },
                 "PolyPhaseEnergykWh": {
                     "anyOf": [
@@ -344,7 +351,7 @@
                         }
                     ],
                     "description": "The energy readings for this circuit.",
-                    "longDescription": "This property shall contain the energy sensor(s) for this circuit.  For single phase circuits this property shall contain a duplicate copy of the energy sensor referenced in the EnergySensor property, if present.  For poly-phase circuits this property should contain multiple energy sensor readings used to fully describe the circuit."
+                    "longDescription": "This property shall contain the energy sensors for this circuit.  For single phase circuits this property shall contain a duplicate copy of the energy sensor referenced in the EnergykWh property, if present.  For poly-phase circuits this property should contain multiple energy sensor readings used to fully describe the circuit."
                 },
                 "PolyPhasePowerWatts": {
                     "anyOf": [
@@ -356,7 +363,7 @@
                         }
                     ],
                     "description": "The power readings for this circuit.",
-                    "longDescription": "This property shall contain the power sensor(s) for this circuit.  For single phase circuits this property shall contain a duplicate copy of the power sensor referenced in the PowerSensor property, if present.  For poly-phase circuits this property should contain multiple power sensor readings used to fully describe the circuit."
+                    "longDescription": "This property shall contain the power sensors for this circuit.  For single phase circuits this property shall contain a duplicate copy of the power sensor referenced in the PowerWatts property, if present.  For poly-phase circuits this property should contain multiple power sensor readings used to fully describe the circuit."
                 },
                 "PolyPhaseVoltage": {
                     "anyOf": [
@@ -368,7 +375,14 @@
                         }
                     ],
                     "description": "The voltage readings for this circuit.",
-                    "longDescription": "This property shall contain the voltage sensor(s) for this circuit.  For single phase circuits this property shall contain a duplicate copy of the voltage sensor referenced in the VoltageSensor property, if present.  For poly-phase circuits this property should contain multiple voltage sensor readings used to fully describe the circuit."
+                    "longDescription": "This property shall contain the voltage sensors for this circuit.  For single phase circuits this property shall contain a duplicate copy of the voltage sensor referenced in the Voltage property, if present.  For poly-phase circuits this property should contain multiple voltage sensor readings used to fully describe the circuit."
+                },
+                "PowerControlLocked": {
+                    "description": "Indicates whether power control requests are locked.",
+                    "longDescription": "This property shall indicate whether requests to the PowerControl action are locked.  If `true`, services shall reject requests to the PowerControl action.",
+                    "readonly": false,
+                    "type": "boolean",
+                    "versionAdded": "v1_5_0"
                 },
                 "PowerCycleDelaySeconds": {
                     "description": "The number of seconds to delay power on after a PowerControl action to cycle power.  Zero seconds indicates no delay.",
@@ -397,9 +411,9 @@
                             "type": "null"
                         }
                     ],
-                    "description": "The power load (%) for this circuit.",
+                    "description": "The power load (percent) for this circuit.",
                     "excerptCopy": "SensorExcerpt",
-                    "longDescription": "This property shall contain the power load, measured in percent, for this circuit, that represents the `Total` ElectricalContext for this circuit.",
+                    "longDescription": "This property shall contain the power load, in percent units, for this circuit, that represents the `Total` ElectricalContext for this circuit.",
                     "versionAdded": "v1_3_0"
                 },
                 "PowerOffDelaySeconds": {
@@ -448,6 +462,13 @@
                     "longDescription": "This property shall contain the power state of the circuit.",
                     "readonly": true
                 },
+                "PowerStateInTransition": {
+                    "description": "Indicates whether the power state is undergoing a delayed transition.",
+                    "longDescription": "This property shall indicate whether the PowerState property will undergo a transition between on and off states due to a configured delay.  The transition may be due to the configuration of the power on, off, or restore delay properties.  If `true`, the PowerState property will transition at the conclusion of a configured delay.",
+                    "readonly": true,
+                    "type": "boolean",
+                    "versionAdded": "v1_5_0"
+                },
                 "PowerWatts": {
                     "anyOf": [
                         {
@@ -457,13 +478,13 @@
                             "type": "null"
                         }
                     ],
-                    "description": "The power reading for this circuit.",
+                    "description": "The power (W) for this circuit.",
                     "excerptCopy": "SensorPowerExcerpt",
-                    "longDescription": "This property shall contain the total power, measured in Watts, for this circuit, that represents the `Total` ElectricalContext sensor when multiple power sensors exist for this circuit."
+                    "longDescription": "This property shall contain the total power, in watt units, for this circuit, that represents the `Total` ElectricalContext sensor when multiple power sensors exist for this circuit.  The value of the DataSourceUri property, if present, shall reference a resource of type Sensor with the ReadingType property containing the value `Power`."
                 },
                 "RatedCurrentAmps": {
                     "description": "The rated maximum current allowed for this circuit.",
-                    "longDescription": "This property shall contain the rated maximum current for this circuit, in Amps, after any required de-rating, due to safety agency or other regulatory requirements, has been applied.",
+                    "longDescription": "This property shall contain the rated maximum current for this circuit, in ampere units, after any required de-rating, due to safety agency or other regulatory requirements, has been applied.",
                     "minimum": 0,
                     "readonly": true,
                     "type": [
@@ -476,6 +497,34 @@
                     "$ref": "http://redfish.dmtf.org/schemas/v1/Resource.json#/definitions/Status",
                     "description": "The status and health of the resource and its subordinate or dependent resources.",
                     "longDescription": "This property shall contain any status or health properties of the resource."
+                },
+                "UnbalancedCurrentPercent": {
+                    "anyOf": [
+                        {
+                            "$ref": "http://redfish.dmtf.org/schemas/v1/Sensor.json#/definitions/SensorExcerpt"
+                        },
+                        {
+                            "type": "null"
+                        }
+                    ],
+                    "description": "The current imbalance (percent) between phases.",
+                    "excerptCopy": "SensorExcerpt",
+                    "longDescription": "This property shall contain the current imbalance, in percent units, between phases in a poly-phase circuit.  The value of the DataSourceUri property, if present, shall reference a resource of type Sensor with the ReadingType property containing the value `Percent`.",
+                    "versionAdded": "v1_5_0"
+                },
+                "UnbalancedVoltagePercent": {
+                    "anyOf": [
+                        {
+                            "$ref": "http://redfish.dmtf.org/schemas/v1/Sensor.json#/definitions/SensorExcerpt"
+                        },
+                        {
+                            "type": "null"
+                        }
+                    ],
+                    "description": "The voltage imbalance (percent) between phases.",
+                    "excerptCopy": "SensorExcerpt",
+                    "longDescription": "This property shall contain the voltage imbalance, in percent units, between phases in a poly-phase circuit.  The value of the DataSourceUri property, if present, shall reference a resource of type Sensor with the ReadingType property containing the value `Percent`.",
+                    "versionAdded": "v1_5_0"
                 },
                 "UserLabel": {
                     "description": "A user-assigned label.",
@@ -493,9 +542,9 @@
                             "type": "null"
                         }
                     ],
-                    "description": "The voltage reading for this single phase circuit.",
+                    "description": "The voltage (V) for this single phase circuit.",
                     "excerptCopy": "SensorVoltageExcerpt",
-                    "longDescription": "This property shall contain the voltage, measured in Volts, for this single phase circuit.  This property shall not appear in resource instances representing poly-phase circuits."
+                    "longDescription": "This property shall contain the voltage, in volt units, for this single phase circuit.  The value of the DataSourceUri property, if present, shall reference a resource of type Sensor with the ReadingType property containing the value `Voltage`.  This property shall not appear in resource instances representing poly-phase circuits."
                 },
                 "VoltageType": {
                     "anyOf": [
@@ -567,9 +616,9 @@
                             "type": "null"
                         }
                     ],
-                    "description": "Line 1 current sensor.",
+                    "description": "Line 1 current (A).",
                     "excerptCopy": "SensorCurrentExcerpt",
-                    "longDescription": "This property shall contain a Sensor excerpt of type Current that measures current for L1.  This property shall not be present if the circuit does not include an L1 measurement."
+                    "longDescription": "This property shall contain the line current, in ampere units, for L1.  The value of the DataSourceUri property, if present, shall reference a resource of type Sensor with the ReadingType property containing the value `Current`.  This property shall not be present if the equipment does not include an L1 measurement."
                 },
                 "Line2": {
                     "anyOf": [
@@ -580,9 +629,9 @@
                             "type": "null"
                         }
                     ],
-                    "description": "Line 2 current sensor.",
+                    "description": "Line 2 current (A).",
                     "excerptCopy": "SensorCurrentExcerpt",
-                    "longDescription": "This property shall contain a Sensor excerpt of type Current that measures current for L2.  This property shall not be present if the circuit does not include an L2 measurement."
+                    "longDescription": "This property shall contain the line current, in ampere units, for L2.  The value of the DataSourceUri property, if present, shall reference a resource of type Sensor with the ReadingType property containing the value `Current`.  This property shall not be present if the equipment does not include an L2 measurement."
                 },
                 "Line3": {
                     "anyOf": [
@@ -593,9 +642,9 @@
                             "type": "null"
                         }
                     ],
-                    "description": "Line 3 current sensor.",
+                    "description": "Line 3 current (A).",
                     "excerptCopy": "SensorCurrentExcerpt",
-                    "longDescription": "This property shall contain a Sensor excerpt of type Current that measures current for L3.  This property shall not be present if the circuit does not include an L3 measurement."
+                    "longDescription": "This property shall contain the line current, in ampere units, for L3.  The value of the DataSourceUri property, if present, shall reference a resource of type Sensor with the ReadingType property containing the value `Current`.  This property shall not be present if the equipment does not include an L3 measurement."
                 },
                 "Neutral": {
                     "anyOf": [
@@ -606,9 +655,9 @@
                             "type": "null"
                         }
                     ],
-                    "description": "Neutral line current sensor.",
+                    "description": "Neutral line current (A).",
                     "excerptCopy": "SensorCurrentExcerpt",
-                    "longDescription": "This property shall contain a Sensor excerpt of type Current that measures current for the Neutral line.  This property shall not be present if the circuit does not include a Neutral measurement."
+                    "longDescription": "This property shall contain the line current, in ampere units, for the Neutral line.  The value of the DataSourceUri property, if present, shall reference a resource of type Sensor with the ReadingType property containing the value `Current`.  This property shall not be present if the equipment does not include a Neutral line measurement."
                 }
             },
             "type": "object"
@@ -641,9 +690,9 @@
                             "type": "null"
                         }
                     ],
-                    "description": "The Line 1 to Line 2 energy reading for this circuit.",
+                    "description": "The Line 1 to Line 2 energy (kWh) for this circuit.",
                     "excerptCopy": "SensorEnergykWhExcerpt",
-                    "longDescription": "This property shall contain a Sensor excerpt of type EnergykWh that measures energy between L1 and L2.  This property shall not be present if the circuit does not include an L1-L2 measurement."
+                    "longDescription": "This property shall contain the energy, in kilowatt-hour units, between L1 and L2.  The value of the DataSourceUri property, if present, shall reference a resource of type Sensor with the ReadingType property containing the value `EnergykWh`.  This property shall not be present if the equipment does not include an L1-L2 measurement."
                 },
                 "Line1ToNeutral": {
                     "anyOf": [
@@ -654,9 +703,9 @@
                             "type": "null"
                         }
                     ],
-                    "description": "The Line 1 to Neutral energy reading for this circuit.",
+                    "description": "The Line 1 to Neutral energy (kWh) for this circuit.",
                     "excerptCopy": "SensorEnergykWhExcerpt",
-                    "longDescription": "This property shall contain a Sensor excerpt of type EnergykWh that measures energy between L1 and Neutral.  This property shall not be present if the circuit does not include an L1-Neutral measurement."
+                    "longDescription": "This property shall contain the energy, in kilowatt-hour units, between L1 and Neutral.  The value of the DataSourceUri property, if present, shall reference a resource of type Sensor with the ReadingType property containing the value `EnergykWh`.  This property shall not be present if the equipment does not include an L1-Neutral measurement."
                 },
                 "Line2ToLine3": {
                     "anyOf": [
@@ -667,9 +716,9 @@
                             "type": "null"
                         }
                     ],
-                    "description": "The Line 2 to Line 3 energy reading for this circuit.",
+                    "description": "The Line 2 to Line 3 energy (kWh) for this circuit.",
                     "excerptCopy": "SensorEnergykWhExcerpt",
-                    "longDescription": "This property shall contain a Sensor excerpt of type EnergykWh that measures energy between L2 and L3.  This property shall not be present if the circuit does not include an L2-L3 measurement."
+                    "longDescription": "This property shall contain the energy, in kilowatt-hour units, between L2 and L3.  The value of the DataSourceUri property, if present, shall reference a resource of type Sensor with the ReadingType property containing the value `EnergykWh`.  This property shall not be present if the equipment does not include an L2-L3 measurement."
                 },
                 "Line2ToNeutral": {
                     "anyOf": [
@@ -680,9 +729,9 @@
                             "type": "null"
                         }
                     ],
-                    "description": "The Line 2 to Neutral energy reading for this circuit.",
+                    "description": "The Line 2 to Neutral energy (kWh) for this circuit.",
                     "excerptCopy": "SensorEnergykWhExcerpt",
-                    "longDescription": "This property shall contain a Sensor excerpt of type EnergykWh that measures energy between L2 and Neutral.  This property shall not be present if the circuit does not include an L2-Neutral measurement."
+                    "longDescription": "This property shall contain the energy, in kilowatt-hour units, between L2 and Neutral.  The value of the DataSourceUri property, if present, shall reference a resource of type Sensor with the ReadingType property containing the value `EnergykWh`.  This property shall not be present if the equipment does not include an L2-Neutral measurement."
                 },
                 "Line3ToLine1": {
                     "anyOf": [
@@ -693,9 +742,9 @@
                             "type": "null"
                         }
                     ],
-                    "description": "The Line 3 to Line 1 energy reading for this circuit.",
+                    "description": "The Line 3 to Line 1 energy (kWh) for this circuit.",
                     "excerptCopy": "SensorEnergykWhExcerpt",
-                    "longDescription": "This property shall contain a Sensor excerpt of type EnergykWh that measures energy between L3 and L1.  This property shall not be present if the circuit does not include an L3-L1 measurement."
+                    "longDescription": "This property shall contain the energy, in kilowatt-hour units, between L3 and L1.  The value of the DataSourceUri property, if present, shall reference a resource of type Sensor with the ReadingType property containing the value `EnergykWh`.  This property shall not be present if the equipment does not include an L3-L1 measurement."
                 },
                 "Line3ToNeutral": {
                     "anyOf": [
@@ -706,9 +755,9 @@
                             "type": "null"
                         }
                     ],
-                    "description": "The Line 3 to Neutral energy reading for this circuit.",
+                    "description": "The Line 3 to Neutral energy (kWh) for this circuit.",
                     "excerptCopy": "SensorEnergykWhExcerpt",
-                    "longDescription": "This property shall contain a Sensor excerpt of type EnergykWh that measures energy between L3 and Neutral.  This property shall not be present if the circuit does not include an L3-Neutral measurement."
+                    "longDescription": "This property shall contain the energy, in kilowatt-hour units, between L3 and Neutral.  The value of the DataSourceUri property, if present, shall reference a resource of type Sensor with the ReadingType property containing the value `EnergykWh`.  This property shall not be present if the equipment does not include an L3-Neutral measurement."
                 }
             },
             "type": "object"
@@ -833,7 +882,7 @@
             "longDescription": "This action shall control the power state of the circuit.",
             "parameters": {
                 "PowerState": {
-                    "$ref": "http://redfish.dmtf.org/schemas/v1/Resource.json#/definitions/PowerState",
+                    "$ref": "http://redfish.dmtf.org/schemas/v1/Circuit.json#/definitions/PowerState",
                     "description": "The desired power state of the circuit.",
                     "longDescription": "This parameter shall contain the desired power state of the circuit."
                 }
@@ -893,9 +942,9 @@
                             "type": "null"
                         }
                     ],
-                    "description": "The Line 1 to Line 2 power reading for this circuit.",
+                    "description": "The Line 1 to Line 2 power (W) for this circuit.",
                     "excerptCopy": "SensorPowerExcerpt",
-                    "longDescription": "This property shall contain a Sensor excerpt of type Power that measures power between L1 and L2.  This property shall not be present if the circuit does not include an L1-L2 measurement."
+                    "longDescription": "This property shall contain the power, in watt units, between L1 and L2.  The value of the DataSourceUri property, if present, shall reference a resource of type Sensor with the ReadingType property containing the value `Power`.  This property shall not be present if the equipment does not include an L1-L2 measurement."
                 },
                 "Line1ToNeutral": {
                     "anyOf": [
@@ -906,9 +955,9 @@
                             "type": "null"
                         }
                     ],
-                    "description": "The Line 1 to Neutral power reading for this circuit.",
+                    "description": "The Line 1 to Neutral power (W) for this circuit.",
                     "excerptCopy": "SensorPowerExcerpt",
-                    "longDescription": "This property shall contain a Sensor excerpt of type Power that measures power between L1 and Neutral.  This property shall not be present if the circuit does not include an L1-Neutral measurement."
+                    "longDescription": "This property shall contain the power, in watt units, between L1 and Neutral.  The value of the DataSourceUri property, if present, shall reference a resource of type Sensor with the ReadingType property containing the value `Power`.  This property shall not be present if the equipment does not include an L1-Neutral measurement."
                 },
                 "Line2ToLine3": {
                     "anyOf": [
@@ -919,9 +968,9 @@
                             "type": "null"
                         }
                     ],
-                    "description": "The Line 2 to Line 3 power reading for this circuit.",
+                    "description": "The Line 2 to Line 3 power (W) for this circuit.",
                     "excerptCopy": "SensorPowerExcerpt",
-                    "longDescription": "This property shall contain a sensor excerpt of type Power that measures power between L2 and L3.  This property shall not be present if the circuit does not include an L2-L3 measurement."
+                    "longDescription": "This property shall contain the power, in watt units, between L2 and L3.  The value of the DataSourceUri property, if present, shall reference a resource of type Sensor with the ReadingType property containing the value `Power`.  This property shall not be present if the equipment does not include an L2-L3 measurement."
                 },
                 "Line2ToNeutral": {
                     "anyOf": [
@@ -932,9 +981,9 @@
                             "type": "null"
                         }
                     ],
-                    "description": "The Line 2 to Neutral power reading for this circuit.",
+                    "description": "The Line 2 to Neutral power (W) for this circuit.",
                     "excerptCopy": "SensorPowerExcerpt",
-                    "longDescription": "This property shall contain a Sensor excerpt of type Power that measures power between L2 and Neutral.  This property shall not be present if the circuit does not include an L2-Neutral measurement."
+                    "longDescription": "This property shall contain the power, in watt units, between L2 and Neutral.  The value of the DataSourceUri property, if present, shall reference a resource of type Sensor with the ReadingType property containing the value `Power`.  This property shall not be present if the equipment does not include an L2-Neutral measurement."
                 },
                 "Line3ToLine1": {
                     "anyOf": [
@@ -945,9 +994,9 @@
                             "type": "null"
                         }
                     ],
-                    "description": "The Line 3 to Line 1 power reading for this circuit.",
+                    "description": "The Line 3 to Line 1 power (W) for this circuit.",
                     "excerptCopy": "SensorPowerExcerpt",
-                    "longDescription": "This property shall contain a Sensor excerpt of type Power that measures power between L3 and L1.  This property shall not be present if the circuit does not include an L3-L1 measurement."
+                    "longDescription": "This property shall contain the power, in watt units, between L3 and L1.  The value of the DataSourceUri property, if present, shall reference a resource of type Sensor with the ReadingType property containing the value `Power`.  This property shall not be present if the equipment does not include an L3-L1 measurement."
                 },
                 "Line3ToNeutral": {
                     "anyOf": [
@@ -958,9 +1007,9 @@
                             "type": "null"
                         }
                     ],
-                    "description": "The Line 3 to Neutral power reading for this circuit.",
+                    "description": "The Line 3 to Neutral power (W) for this circuit.",
                     "excerptCopy": "SensorPowerExcerpt",
-                    "longDescription": "This property shall contain a Sensor excerpt of type Power that measures power between L3 and Neutral.  This property shall not be present if the circuit does not include an L3-Neutral measurement."
+                    "longDescription": "This property shall contain the power, in watt units, between L3 and Neutral.  The value of the DataSourceUri property, if present, shall reference a resource of type Sensor with the ReadingType property containing the value `Power`.  This property shall not be present if the equipment does not include an L3-Neutral measurement."
                 }
             },
             "type": "object"
@@ -1025,9 +1074,9 @@
                             "type": "null"
                         }
                     ],
-                    "description": "The Line 1 to Line 2 voltage reading for this circuit.",
+                    "description": "The Line 1 to Line 2 voltage (V) for this circuit.",
                     "excerptCopy": "SensorVoltageExcerpt",
-                    "longDescription": "This property shall contain a Sensor excerpt of type Voltage that measures voltage between L1 and L2.  This property shall not be present if the circuit does not include an L1-L2 measurement."
+                    "longDescription": "This property shall contain the line-to-line voltage, in volt units, between L1 and L2.  The value of the DataSourceUri property, if present, shall reference a resource of type Sensor with the ReadingType property containing the value `Voltage`.  This property shall not be present if the equipment does not include an L1-L2 measurement."
                 },
                 "Line1ToNeutral": {
                     "anyOf": [
@@ -1038,9 +1087,9 @@
                             "type": "null"
                         }
                     ],
-                    "description": "The Line 1 to Neutral voltage reading for this circuit.",
+                    "description": "The Line 1 to Neutral voltage (V) for this circuit.",
                     "excerptCopy": "SensorVoltageExcerpt",
-                    "longDescription": "This property shall contain a Sensor excerpt of type Voltage that measures voltage between L1 and Neutral.  This property shall not be present if the circuit does not include an L1-Neutral measurement."
+                    "longDescription": "This property shall contain the line-to-line voltage, in volt units, between L1 and Neutral.  The value of the DataSourceUri property, if present, shall reference a resource of type Sensor with the ReadingType property containing the value `Voltage`.  This property shall not be present if the equipment does not include an L1-Neutral measurement."
                 },
                 "Line2ToLine3": {
                     "anyOf": [
@@ -1051,9 +1100,9 @@
                             "type": "null"
                         }
                     ],
-                    "description": "The Line 2 to Line 3 voltage reading for this circuit.",
+                    "description": "The Line 2 to Line 3 voltage (V) for this circuit.",
                     "excerptCopy": "SensorVoltageExcerpt",
-                    "longDescription": "This property shall contain a Sensor excerpt of type Voltage that measures voltage between L2 and L3.  This property shall not be present if the circuit does not include an L2-L3 measurement."
+                    "longDescription": "This property shall contain the line-to-line voltage, in volt units, between L2 and L3.  The value of the DataSourceUri property, if present, shall reference a resource of type Sensor with the ReadingType property containing the value `Voltage`.  This property shall not be present if the equipment does not include an L2-L3 measurement."
                 },
                 "Line2ToNeutral": {
                     "anyOf": [
@@ -1064,9 +1113,9 @@
                             "type": "null"
                         }
                     ],
-                    "description": "The Line 2 to Neutral voltage reading for this circuit.",
+                    "description": "The Line 2 to Neutral voltage (V) for this circuit.",
                     "excerptCopy": "SensorVoltageExcerpt",
-                    "longDescription": "This property shall contain a Sensor excerpt of type Voltage that measures voltage between L2 and Neutral.  This property shall not be present if the circuit does not include an L2-Neutral measurement."
+                    "longDescription": "This property shall contain the line-to-line voltage, in volt units, between L2 and Neutral.  The value of the DataSourceUri property, if present, shall reference a resource of type Sensor with the ReadingType property containing the value `Voltage`.  This property shall not be present if the equipment does not include an L2-Neutral measurement."
                 },
                 "Line3ToLine1": {
                     "anyOf": [
@@ -1077,9 +1126,9 @@
                             "type": "null"
                         }
                     ],
-                    "description": "The Line 3 to Line 1 voltage reading for this circuit.",
+                    "description": "The Line 3 to Line 1 voltage (V) for this circuit.",
                     "excerptCopy": "SensorVoltageExcerpt",
-                    "longDescription": "This property shall contain a Sensor excerpt of type Voltage that measures voltage between L3 and L1.  This property shall not be present if the circuit does not include an L3-L1 measurement."
+                    "longDescription": "This property shall contain the line-to-line voltage, in volt units, between L3 and L1.  The value of the DataSourceUri property, if present, shall reference a resource of type Sensor with the ReadingType property containing the value `Voltage`.  This property shall not be present if the equipment does not include an L3-L1 measurement."
                 },
                 "Line3ToNeutral": {
                     "anyOf": [
@@ -1090,9 +1139,9 @@
                             "type": "null"
                         }
                     ],
-                    "description": "The Line 3 to Neutral voltage reading for this circuit.",
+                    "description": "The Line 3 to Neutral voltage (V) for this circuit.",
                     "excerptCopy": "SensorVoltageExcerpt",
-                    "longDescription": "This property shall contain a Sensor excerpt of type Voltage that measures voltage between L3 and Neutral.  This property shall not be present if the circuit does not include an L3-Neutral measurement."
+                    "longDescription": "This property shall contain the line-to-line voltage, in volt units, between L3 and Neutral.  The value of the DataSourceUri property, if present, shall reference a resource of type Sensor with the ReadingType property containing the value `Voltage`.  This property shall not be present if the equipment does not include an L3-Neutral measurement."
                 }
             },
             "type": "object"
@@ -1110,6 +1159,6 @@
         }
     },
     "owningEntity": "DMTF",
-    "release": "2021.3",
-    "title": "#Circuit.v1_4_0.Circuit"
+    "release": "2021.4",
+    "title": "#Circuit.v1_5_0.Circuit"
 }

--- a/static/redfish/v1/JsonSchemas/ComponentIntegrity/ComponentIntegrity.json
+++ b/static/redfish/v1/JsonSchemas/ComponentIntegrity/ComponentIntegrity.json
@@ -1,0 +1,1179 @@
+{
+    "$id": "http://redfish.dmtf.org/schemas/v1/ComponentIntegrity.v1_0_0.json",
+    "$ref": "#/definitions/ComponentIntegrity",
+    "$schema": "http://redfish.dmtf.org/schemas/v1/redfish-schema-v1.json",
+    "copyright": "Copyright 2014-2021 DMTF. For the full DMTF copyright policy, see http://www.dmtf.org/about/policies/copyright",
+    "definitions": {
+        "Actions": {
+            "additionalProperties": false,
+            "description": "The available actions for this resource.",
+            "longDescription": "This type shall contain the available actions for this resource.",
+            "patternProperties": {
+                "^([a-zA-Z_][a-zA-Z0-9_]*)?@(odata|Redfish|Message)\\.[a-zA-Z_][a-zA-Z0-9_]*$": {
+                    "description": "This property shall specify a valid odata or Redfish property.",
+                    "type": [
+                        "array",
+                        "boolean",
+                        "integer",
+                        "number",
+                        "null",
+                        "object",
+                        "string"
+                    ]
+                }
+            },
+            "properties": {
+                "#ComponentIntegrity.SPDMGetSignedMeasurements": {
+                    "$ref": "#/definitions/SPDMGetSignedMeasurements"
+                },
+                "Oem": {
+                    "$ref": "#/definitions/OemActions",
+                    "description": "The available OEM-specific actions for this resource.",
+                    "longDescription": "This property shall contain the available OEM-specific actions for this resource."
+                }
+            },
+            "type": "object"
+        },
+        "CommonAuthInfo": {
+            "additionalProperties": false,
+            "description": "Common Authentication information.",
+            "longDescription": "This object shall contain common identity-related authentication information.",
+            "patternProperties": {
+                "^([a-zA-Z_][a-zA-Z0-9_]*)?@(odata|Redfish|Message)\\.[a-zA-Z_][a-zA-Z0-9_]*$": {
+                    "description": "This property shall specify a valid odata or Redfish property.",
+                    "type": [
+                        "array",
+                        "boolean",
+                        "integer",
+                        "number",
+                        "null",
+                        "object",
+                        "string"
+                    ]
+                }
+            },
+            "properties": {
+                "ComponentCertificate": {
+                    "$ref": "http://redfish.dmtf.org/schemas/v1/Certificate.json#/definitions/Certificate",
+                    "description": "A link to the certificate that represents the identify of the component.",
+                    "longDescription": "This property shall contain a link to a resource of type Certificate that represents the identify of the component referenced by the TargetComponentURI property.",
+                    "readonly": true
+                },
+                "VerificationStatus": {
+                    "anyOf": [
+                        {
+                            "$ref": "#/definitions/VerificationStatus"
+                        },
+                        {
+                            "type": "null"
+                        }
+                    ],
+                    "description": "The status of the verification of the identity of the component.",
+                    "longDescription": "This property shall contain the status of the verification of the identity of the component referenced by the TargetComponentURI property..",
+                    "readonly": true
+                }
+            },
+            "type": "object"
+        },
+        "CommunicationInfo": {
+            "additionalProperties": false,
+            "description": "Information about communication between two components.",
+            "longDescription": "This object shall contain information about communication between two components.",
+            "patternProperties": {
+                "^([a-zA-Z_][a-zA-Z0-9_]*)?@(odata|Redfish|Message)\\.[a-zA-Z_][a-zA-Z0-9_]*$": {
+                    "description": "This property shall specify a valid odata or Redfish property.",
+                    "type": [
+                        "array",
+                        "boolean",
+                        "integer",
+                        "number",
+                        "null",
+                        "object",
+                        "string"
+                    ]
+                }
+            },
+            "properties": {
+                "Sessions": {
+                    "description": "The active sessions or communication channels between two components.",
+                    "items": {
+                        "anyOf": [
+                            {
+                                "$ref": "#/definitions/SingleSessionInfo"
+                            },
+                            {
+                                "type": "null"
+                            }
+                        ]
+                    },
+                    "longDescription": "This property shall contain an array of the active sessions or communication channels between two components  The active sessions or communication channels do not reflect how future sessions or communication channels are established.",
+                    "type": "array"
+                }
+            },
+            "type": "object"
+        },
+        "ComponentIntegrity": {
+            "additionalProperties": false,
+            "description": "The ComponentIntegrity resource provides critical and pertinent security information about a specific device, system, software element, or other managed entity.",
+            "longDescription": "This resource shall represent critical and pertinent security information about a specific device, system, software element, or other managed entity.",
+            "patternProperties": {
+                "^([a-zA-Z_][a-zA-Z0-9_]*)?@(odata|Redfish|Message)\\.[a-zA-Z_][a-zA-Z0-9_]*$": {
+                    "description": "This property shall specify a valid odata or Redfish property.",
+                    "type": [
+                        "array",
+                        "boolean",
+                        "integer",
+                        "number",
+                        "null",
+                        "object",
+                        "string"
+                    ]
+                }
+            },
+            "properties": {
+                "@odata.context": {
+                    "$ref": "http://redfish.dmtf.org/schemas/v1/odata-v4.json#/definitions/context"
+                },
+                "@odata.etag": {
+                    "$ref": "http://redfish.dmtf.org/schemas/v1/odata-v4.json#/definitions/etag"
+                },
+                "@odata.id": {
+                    "$ref": "http://redfish.dmtf.org/schemas/v1/odata-v4.json#/definitions/id"
+                },
+                "@odata.type": {
+                    "$ref": "http://redfish.dmtf.org/schemas/v1/odata-v4.json#/definitions/type"
+                },
+                "Actions": {
+                    "$ref": "#/definitions/Actions",
+                    "description": "The available actions for this resource.",
+                    "longDescription": "This property shall contain the available actions for this resource."
+                },
+                "ComponentIntegrityEnabled": {
+                    "description": "An indication of whether security protocols are enabled for the component.",
+                    "longDescription": "This property shall indicate whether security protocols are enabled for the component.  If ComponentIntegrityType contains `SPDM`, a value of `false` shall prohibit the SPDM Requester from using SPDM to communicate with the component identified by the TargetComponentURI property.  If ComponentIntegrityType contains `TPM`, a value of `false` shall disable the TPM component identified by the TargetComponentURI property entirely.  If `false`, services shall not provide the TPM and SPDM properties in response payloads for this resource.  If `false`, services shall reject action requests to this resource.  If `true`, services shall allow security protocols with the component identified by the TargetComponentURI property.",
+                    "readonly": false,
+                    "type": "boolean"
+                },
+                "ComponentIntegrityType": {
+                    "$ref": "#/definitions/ComponentIntegrityType",
+                    "description": "The type of security technology for the component.",
+                    "longDescription": "This value of this property shall contain the underlying security technology providing integrity information for the component.",
+                    "readonly": true
+                },
+                "ComponentIntegrityTypeVersion": {
+                    "description": "The version of the security technology.",
+                    "longDescription": "This value of this property shall contain the version of the security technology indicated by the ComponentIntegrityType property.  If ComponentIntegrityType contains `SPDM`, this property shall contain the negotiated or selected SPDM protocol.  If ComponentIntegrityType contains `TPM`, this property shall contain the version of the TPM.",
+                    "readonly": true,
+                    "type": "string"
+                },
+                "Description": {
+                    "anyOf": [
+                        {
+                            "$ref": "http://redfish.dmtf.org/schemas/v1/Resource.json#/definitions/Description"
+                        },
+                        {
+                            "type": "null"
+                        }
+                    ],
+                    "readonly": true
+                },
+                "Id": {
+                    "$ref": "http://redfish.dmtf.org/schemas/v1/Resource.json#/definitions/Id",
+                    "readonly": true
+                },
+                "LastUpdated": {
+                    "description": "The date and time when information for the component was last updated.",
+                    "format": "date-time",
+                    "longDescription": "This property shall contain the date and time when information for the component was last updated.",
+                    "readonly": true,
+                    "type": [
+                        "string",
+                        "null"
+                    ]
+                },
+                "Links": {
+                    "$ref": "#/definitions/Links",
+                    "description": "The links to other resources that are related to this resource.",
+                    "longDescription": "This property shall contain links to resources that are related to but are not contained by, or subordinate to, this resource."
+                },
+                "Name": {
+                    "$ref": "http://redfish.dmtf.org/schemas/v1/Resource.json#/definitions/Name",
+                    "readonly": true
+                },
+                "Oem": {
+                    "$ref": "http://redfish.dmtf.org/schemas/v1/Resource.json#/definitions/Oem",
+                    "description": "The OEM extension property.",
+                    "longDescription": "This property shall contain the OEM extensions.  All values for properties that this object contains shall conform to the Redfish Specification-described requirements."
+                },
+                "SPDM": {
+                    "$ref": "#/definitions/SPDMinfo",
+                    "description": "Integrity information about the SPDM Responder as reported by an SPDM Requester.",
+                    "longDescription": "This property shall contain integrity information about the SPDM Responder identified by the TargetComponentURI property as reported by an SPDM Requester.  This property shall be present if ComponentIntegrityType contains `SPDM` and `ComponentIntegrityEnabled` contains `true`.  For other cases, this property shall be absent."
+                },
+                "Status": {
+                    "$ref": "http://redfish.dmtf.org/schemas/v1/Resource.json#/definitions/Status",
+                    "description": "The status and health of the resource and its subordinate or dependent resources.",
+                    "longDescription": "This property shall contain any status or health properties of the resource."
+                },
+                "TPM": {
+                    "$ref": "#/definitions/TPMinfo",
+                    "description": "Integrity information about the Trusted Platform Module (TPM).",
+                    "longDescription": "This property shall contain integrity information about the Trusted Platform Module (TPM) identified by the TargetComponentURI property,  This property shall be present if ComponentIntegrityType contains `TPM` and `ComponentIntegrityEnabled` contains `true`.  For other cases, this property shall be absent."
+                },
+                "TargetComponentURI": {
+                    "description": "The link to the the component whose integrity that this resource reports.",
+                    "longDescription": "This value of this property shall contain a link to the resource whose integrity information is reported in this resource.  If ComponentIntegrityType contains `SPDM`, this property shall contain a URI to the resource that represents the SPDM Responder.  If ComponentIntegrityType contains `TPM`, this property shall contain a URI with RFC6901-defined JSON fragment notation to a member of the TrustedModules array in a ComputerSystem resource that represents the TPM.",
+                    "readonly": true,
+                    "type": "string"
+                }
+            },
+            "required": [
+                "ComponentIntegrityType",
+                "ComponentIntegrityTypeVersion",
+                "TargetComponentURI",
+                "@odata.id",
+                "@odata.type",
+                "Id",
+                "Name"
+            ],
+            "type": "object"
+        },
+        "ComponentIntegrityType": {
+            "enum": [
+                "SPDM",
+                "TPM",
+                "OEM"
+            ],
+            "enumDescriptions": {
+                "OEM": "OEM-specific.",
+                "SPDM": "Security Protocol and Data Model (SPDM) protocol.",
+                "TPM": "Trusted Platform Module (TPM)."
+            },
+            "enumLongDescriptions": {
+                "OEM": "This value shall indicate the integrity information is OEM-specific and the OEM section may include additional information.",
+                "SPDM": "This value shall indicate the integrity information is obtained through the Security Protocol and Data Model (SPDM) protocol as defined in DMTF DSP0274.",
+                "TPM": "This value shall indicate the integrity information is related to a Trusted Platform Module (TPM) as defined by the Trusted Computing Group (TCG)."
+            },
+            "type": "string"
+        },
+        "DMTFmeasurementTypes": {
+            "enum": [
+                "ImmutableROM",
+                "MutableFirmware",
+                "HardwareConfiguration",
+                "FirmwareConfiguration",
+                "MutableFirmwareVersion",
+                "MutableFirmwareSecurityVersionNumber",
+                "MeasurementManifest"
+            ],
+            "enumDescriptions": {
+                "FirmwareConfiguration": "Firmware configuration, such as configurable firmware policy.",
+                "HardwareConfiguration": "Hardware configuration, such as straps.",
+                "ImmutableROM": "Immutable ROM.",
+                "MeasurementManifest": "Measurement Manifest.",
+                "MutableFirmware": "Mutable firmware or any mutable code.",
+                "MutableFirmwareSecurityVersionNumber": "Mutable firmware security version number.",
+                "MutableFirmwareVersion": "Mutable firmware version."
+            },
+            "type": "string"
+        },
+        "Links": {
+            "additionalProperties": false,
+            "description": "The links to other resources that are related to this resource.",
+            "longDescription": "This Redfish Specification-described type shall contain links to resources that are related to but are not contained by, or subordinate to, this resource.",
+            "patternProperties": {
+                "^([a-zA-Z_][a-zA-Z0-9_]*)?@(odata|Redfish|Message)\\.[a-zA-Z_][a-zA-Z0-9_]*$": {
+                    "description": "This property shall specify a valid odata or Redfish property.",
+                    "type": [
+                        "array",
+                        "boolean",
+                        "integer",
+                        "number",
+                        "null",
+                        "object",
+                        "string"
+                    ]
+                }
+            },
+            "properties": {
+                "ComponentsProtected": {
+                    "description": "An array of links to resources that the target component protects.",
+                    "items": {
+                        "$ref": "http://redfish.dmtf.org/schemas/v1/odata-v4.json#/definitions/idRef"
+                    },
+                    "longDescription": "This property shall contain an array of links to resources that the component identified by the TargetComponentURI property provides integrity protection.  This property shall not contain the value of the TargetComponentURI property.",
+                    "readonly": true,
+                    "type": "array"
+                },
+                "ComponentsProtected@odata.count": {
+                    "$ref": "http://redfish.dmtf.org/schemas/v1/odata-v4.json#/definitions/count"
+                },
+                "Oem": {
+                    "$ref": "http://redfish.dmtf.org/schemas/v1/Resource.json#/definitions/Oem",
+                    "description": "The OEM extension property.",
+                    "longDescription": "This property shall contain the OEM extensions.  All values for properties contained in this object shall conform to the Redfish Specification-described requirements."
+                }
+            },
+            "type": "object"
+        },
+        "MeasurementSpecification": {
+            "enum": [
+                "DMTF"
+            ],
+            "enumDescriptions": {
+                "DMTF": "DMTF."
+            },
+            "enumLongDescriptions": {
+                "DMTF": "This value shall indicate the measurement specification is defined by DMTF in DSP0274."
+            },
+            "type": "string"
+        },
+        "OemActions": {
+            "additionalProperties": true,
+            "description": "The available OEM-specific actions for this resource.",
+            "longDescription": "This type shall contain the available OEM-specific actions for this resource.",
+            "patternProperties": {
+                "^([a-zA-Z_][a-zA-Z0-9_]*)?@(odata|Redfish|Message)\\.[a-zA-Z_][a-zA-Z0-9_]*$": {
+                    "description": "This property shall specify a valid odata or Redfish property.",
+                    "type": [
+                        "array",
+                        "boolean",
+                        "integer",
+                        "number",
+                        "null",
+                        "object",
+                        "string"
+                    ]
+                }
+            },
+            "properties": {},
+            "type": "object"
+        },
+        "SPDMGetSignedMeasurements": {
+            "actionResponse": {
+                "$ref": "#/definitions/SPDMGetSignedMeasurementsResponse"
+            },
+            "additionalProperties": false,
+            "description": "This action generates an SPDM cryptographic signed statement over the given nonce and measurements of the SPDM Responder.",
+            "longDescription": "This action shall generate a cryptographic signed statement over the given nonce and measurements corresponding to the SPDM Responder.  This action shall not be present if the ComponentIntegrityType property does not contain the value `SPDM`.  The SPDM Requester shall issue one or more SPDM 'GET_MEASUREMENTS' requests for each of the requested measurement indices to the SPDM Responder.  When the SPDM 'GET_MEASUREMENTS' requests are made for version 1.2, the parameter 'RawBitStreamRequested' shall contain `0`.  The SPDM Requester shall provide the nonce for the action to the SPDM Responder in the last SPDM 'GET_MEASUREMENTS' request.  The SPDM Requester shall request a signature in the last SPDM 'GET_MEASUREMENTS' request.",
+            "parameters": {
+                "MeasurementIndices": {
+                    "description": "An array of indices that identify the measurement blocks to sign.",
+                    "items": {
+                        "type": "integer"
+                    },
+                    "longDescription": "This parameter shall contain an array of indices that identify the measurement blocks to sign.  This array shall contain one or more unique values between `0` to `254`, inclusive, or contain a single value of `255`.  If not provided by the client, the value shall be assumed to be an array containing a single value of `255`.",
+                    "type": "array"
+                },
+                "SlotId": {
+                    "description": "The slot identifier for the certificate containing the private key to generate the signature over the measurements.",
+                    "longDescription": "This parameter shall contain the SPDM slot identifier for the certificate containing the private key to generate the signature over the measurements.  If not provided by the client, the value shall be assumed to be `0`.  The SPDM Requester shall send this value to the SPDM Responder in the SPDM 'GET_MEASUREMENTS' request.",
+                    "type": "integer"
+                }
+            },
+            "patternProperties": {
+                "^([a-zA-Z_][a-zA-Z0-9_]*)?@(odata|Redfish|Message)\\.[a-zA-Z_][a-zA-Z0-9_]*$": {
+                    "description": "This property shall specify a valid odata or Redfish property.",
+                    "type": [
+                        "array",
+                        "boolean",
+                        "integer",
+                        "number",
+                        "null",
+                        "object",
+                        "string"
+                    ]
+                }
+            },
+            "properties": {
+                "target": {
+                    "description": "Link to invoke action",
+                    "format": "uri-reference",
+                    "type": "string"
+                },
+                "title": {
+                    "description": "Friendly action name",
+                    "type": "string"
+                }
+            },
+            "type": "object"
+        },
+        "SPDMGetSignedMeasurementsResponse": {
+            "additionalProperties": false,
+            "description": "The SPDM signed measurement from an SPDM Responder.",
+            "longDescription": "This object shall contain the SPDM signed measurements from an SPDM Responder.",
+            "patternProperties": {
+                "^([a-zA-Z_][a-zA-Z0-9_]*)?@(odata|Redfish|Message)\\.[a-zA-Z_][a-zA-Z0-9_]*$": {
+                    "description": "This property shall specify a valid odata or Redfish property.",
+                    "type": [
+                        "array",
+                        "boolean",
+                        "integer",
+                        "number",
+                        "null",
+                        "object",
+                        "string"
+                    ]
+                }
+            },
+            "properties": {
+                "Certificate": {
+                    "$ref": "http://redfish.dmtf.org/schemas/v1/Certificate.json#/definitions/Certificate",
+                    "description": "A link to the certificate corresponding to the SPDM slot identifier that can be used to validate the signature.",
+                    "longDescription": "This property shall contain a link to a resource of type Certificate that represents the certificate corresponding to the SPDM slot identifier that can be used to validate the signature.  This property shall not be present if the SlotId parameter contains the value `15`.",
+                    "readonly": true
+                },
+                "HashingAlgorithm": {
+                    "description": "The hashing algorithm used for generating the cryptographic signed statement.",
+                    "longDescription": "This property shall contain the hashing algorithm negotiated between the SPDM Requester and the SPDM Responder.  The allowable values for this property shall be the hash algorithm names found in the 'BaseHashAlgo' field of the 'NEGOTIATE_ALGORITHMS' request message in DSP0274.  If the algorithm is an extended algorithm, this property shall contain the value `OEM`.",
+                    "readonly": true,
+                    "type": "string"
+                },
+                "Oem": {
+                    "$ref": "http://redfish.dmtf.org/schemas/v1/Resource.json#/definitions/Oem",
+                    "description": "The OEM extension property.",
+                    "longDescription": "This property shall contain the OEM extensions.  All values for properties contained in this object shall conform to the Redfish Specification-described requirements."
+                },
+                "PublicKey": {
+                    "description": "A Privacy Enhanced Mail (PEM)-encoded public key that can be used to validate the signature.",
+                    "longDescription": "This property shall contain a Privacy Enhanced Mail (PEM)-encoded public key, as defined in section 13 of RFC7468, that can be used to validate the signature.  This property shall only be present when the SPDM Requester was pre-provisioned with the SPDM Responder's public key and the SlotId parameter contains the value `15`.",
+                    "readonly": true,
+                    "type": "string"
+                },
+                "SignedMeasurements": {
+                    "description": "Base64 encoded cryptographic signed statement generated by the signer.",
+                    "longDescription": "This property shall contain the cryptographic signed statement over the given nonce and measurement blocks corresponding to the requested measurement indices.  If the SPDM version is 1.2, this value shall be a concatenation of SPDM 'VCA' and 'GET_MEASUREMENTS' requests and responses exchanged between the SPDM Requester and the SPDM Responder.  If SPDM version is 1.0 or 1.1, this value shall be a concatenation of SPDM 'GET_MEASUREMENTS' requests and responses exchanged between the SPDM Requester and the SPDM Responder.  The last 'MEASUREMENTS' response shall contain a signature generated over the 'L2' string by the SPDM Responder.",
+                    "readonly": true,
+                    "type": "string"
+                },
+                "SigningAlgorithm": {
+                    "description": "The asymmetric signing algorithm used for generating the cryptographic signed statement.",
+                    "longDescription": "This property shall contain the asymmetric signing algorithm negotiated between the SPDM Requester and the SPDM Responder.  The allowable values for this property shall be the asymmetric key signature algorithm names found in the 'BaseAsymAlgo' field of the 'NEGOTIATE_ALGORITHMS' request message in DSP0274.  If the algorithm is an extended algorithm, this property shall contain the value `OEM`.",
+                    "readonly": true,
+                    "type": "string"
+                },
+                "Version": {
+                    "description": "The SPDM version used by the SPDM Responder to generate the cryptographic signed statement.",
+                    "longDescription": "This property shall contain the SPDM version negotiated between the SPDM Requester and the SPDM Responder to generate the cryptographic signed statement.  For example, `1.0`, `1.1`, or `1.2`.",
+                    "readonly": true,
+                    "type": "string"
+                }
+            },
+            "required": [
+                "SignedMeasurements",
+                "Version",
+                "HashingAlgorithm",
+                "SigningAlgorithm"
+            ],
+            "type": "object"
+        },
+        "SPDMcommunication": {
+            "additionalProperties": false,
+            "description": "Information about communication between two components.",
+            "longDescription": "This object shall contain information about communication between two components.",
+            "patternProperties": {
+                "^([a-zA-Z_][a-zA-Z0-9_]*)?@(odata|Redfish|Message)\\.[a-zA-Z_][a-zA-Z0-9_]*$": {
+                    "description": "This property shall specify a valid odata or Redfish property.",
+                    "type": [
+                        "array",
+                        "boolean",
+                        "integer",
+                        "number",
+                        "null",
+                        "object",
+                        "string"
+                    ]
+                }
+            },
+            "properties": {
+                "Sessions": {
+                    "description": "The active sessions or communication channels between two components.",
+                    "items": {
+                        "anyOf": [
+                            {
+                                "$ref": "#/definitions/SingleSessionInfo"
+                            },
+                            {
+                                "type": "null"
+                            }
+                        ]
+                    },
+                    "longDescription": "This property shall contain an array of the active sessions or communication channels between two components  The active sessions or communication channels do not reflect how future sessions or communication channels are established.",
+                    "type": "array"
+                }
+            },
+            "type": "object"
+        },
+        "SPDMidentity": {
+            "additionalProperties": false,
+            "description": "Identity authentication information about the SPDM Requester and SPDM Responder.",
+            "longDescription": "This object shall contain identity authentication information about the SPDM Requester and SPDM Responder.",
+            "patternProperties": {
+                "^([a-zA-Z_][a-zA-Z0-9_]*)?@(odata|Redfish|Message)\\.[a-zA-Z_][a-zA-Z0-9_]*$": {
+                    "description": "This property shall specify a valid odata or Redfish property.",
+                    "type": [
+                        "array",
+                        "boolean",
+                        "integer",
+                        "number",
+                        "null",
+                        "object",
+                        "string"
+                    ]
+                }
+            },
+            "properties": {
+                "RequesterAuthentication": {
+                    "anyOf": [
+                        {
+                            "$ref": "#/definitions/SPDMrequesterAuth"
+                        },
+                        {
+                            "type": "null"
+                        }
+                    ],
+                    "description": "Authentication information of the identity of the SPDM Requester.",
+                    "longDescription": "This property shall contain authentication information of the identity of the SPDM Requester."
+                },
+                "ResponderAuthentication": {
+                    "anyOf": [
+                        {
+                            "$ref": "#/definitions/SPDMresponderAuth"
+                        },
+                        {
+                            "type": "null"
+                        }
+                    ],
+                    "description": "Authentication information of the identity of the SPDM Responder.",
+                    "longDescription": "This property shall contain authentication information of the identity of the SPDM Responder."
+                }
+            },
+            "type": "object"
+        },
+        "SPDMinfo": {
+            "additionalProperties": false,
+            "description": "Integrity information about an SPDM Responder as reported by an SPDM Requester.",
+            "longDescription": "This object shall contain integrity information about an SPDM Responder as reported by an SPDM Requester.",
+            "patternProperties": {
+                "^([a-zA-Z_][a-zA-Z0-9_]*)?@(odata|Redfish|Message)\\.[a-zA-Z_][a-zA-Z0-9_]*$": {
+                    "description": "This property shall specify a valid odata or Redfish property.",
+                    "type": [
+                        "array",
+                        "boolean",
+                        "integer",
+                        "number",
+                        "null",
+                        "object",
+                        "string"
+                    ]
+                }
+            },
+            "properties": {
+                "ComponentCommunication": {
+                    "anyOf": [
+                        {
+                            "$ref": "#/definitions/SPDMcommunication"
+                        },
+                        {
+                            "type": "null"
+                        }
+                    ],
+                    "description": "Information about communication between the SPDM Requester and SPDM Responder.",
+                    "longDescription": "This property shall contain information about communication between the SPDM Requester and SPDM Responder."
+                },
+                "IdentityAuthentication": {
+                    "anyOf": [
+                        {
+                            "$ref": "#/definitions/SPDMidentity"
+                        },
+                        {
+                            "type": "null"
+                        }
+                    ],
+                    "description": "Identity authentication information about the SPDM Requester and SPDM Responder.",
+                    "longDescription": "This property shall contain identity authentication information about the SPDM Requester and SPDM Responder."
+                },
+                "MeasurementSet": {
+                    "anyOf": [
+                        {
+                            "$ref": "#/definitions/SPDMmeasurementSet"
+                        },
+                        {
+                            "type": "null"
+                        }
+                    ],
+                    "description": "Measurement information about the SPDM Responder.",
+                    "longDescription": "This property shall contain measurement information for the SPDM Responder."
+                },
+                "Requester": {
+                    "$ref": "http://redfish.dmtf.org/schemas/v1/odata-v4.json#/definitions/idRef",
+                    "description": "The link to the the component that is reporting the integrity information of the target component.",
+                    "longDescription": "This property shall contain a link to the resource representing the SPDM Responder that is reporting the integrity of the SPDM Responder identified by the TargetComponentURI property.",
+                    "readonly": true
+                }
+            },
+            "required": [
+                "Requester"
+            ],
+            "type": "object"
+        },
+        "SPDMmeasurementSet": {
+            "additionalProperties": false,
+            "description": "SPDM Responder measurement information.",
+            "longDescription": "This object shall contain SPDM Responder measurement information.",
+            "patternProperties": {
+                "^([a-zA-Z_][a-zA-Z0-9_]*)?@(odata|Redfish|Message)\\.[a-zA-Z_][a-zA-Z0-9_]*$": {
+                    "description": "This property shall specify a valid odata or Redfish property.",
+                    "type": [
+                        "array",
+                        "boolean",
+                        "integer",
+                        "number",
+                        "null",
+                        "object",
+                        "string"
+                    ]
+                }
+            },
+            "properties": {
+                "MeasurementSpecification": {
+                    "anyOf": [
+                        {
+                            "$ref": "#/definitions/MeasurementSpecification"
+                        },
+                        {
+                            "type": "null"
+                        }
+                    ],
+                    "description": "The measurement specification negotiated between the SPDM Requester and SPDM Responder.",
+                    "longDescription": "This property shall contain the measurement specification negotiated between the SPDM Requester and SPDM Responder.",
+                    "readonly": true
+                },
+                "MeasurementSummary": {
+                    "description": "The measurement summary data.",
+                    "longDescription": "This property shall contain the Base64-encoded measurement summary using the hash algorithm indicated by the MeasurementSummaryHashAlgorithm property.",
+                    "pattern": "^[A-Za-z0-9+/]+={0,2}$",
+                    "readonly": true,
+                    "type": [
+                        "string",
+                        "null"
+                    ]
+                },
+                "MeasurementSummaryHashAlgorithm": {
+                    "description": "The hash algorithm used to compute the measurement summary.",
+                    "longDescription": "This property shall contain the hash algorithm used to compute the measurement summary.  The allowable values for this property shall be the hash algorithm names found in the 'BaseHashAlgo' field of the 'NEGOTIATE_ALGORITHMS' request message in DSP0274.  If the algorithm is an extended algorithm, this property shall contain the value `OEM`.",
+                    "readonly": true,
+                    "type": [
+                        "string",
+                        "null"
+                    ]
+                },
+                "MeasurementSummaryType": {
+                    "anyOf": [
+                        {
+                            "$ref": "#/definitions/SPDMmeasurementSummaryType"
+                        },
+                        {
+                            "type": "null"
+                        }
+                    ],
+                    "description": "The type of measurement summary.",
+                    "longDescription": "This property shall contain the type of measurement summary.",
+                    "readonly": true
+                },
+                "Measurements": {
+                    "description": "Measurements from an SPDM Responder.",
+                    "items": {
+                        "anyOf": [
+                            {
+                                "$ref": "#/definitions/SPDMsingleMeasurement"
+                            },
+                            {
+                                "type": "null"
+                            }
+                        ]
+                    },
+                    "longDescription": "This property shall contain measurements from an SPDM Responder.",
+                    "type": "array"
+                },
+                "Oem": {
+                    "$ref": "http://redfish.dmtf.org/schemas/v1/Resource.json#/definitions/Oem",
+                    "description": "The OEM extension property.",
+                    "longDescription": "This property shall contain the OEM extensions.  All values for properties contained in this object shall conform to the Redfish Specification-described requirements."
+                }
+            },
+            "type": "object"
+        },
+        "SPDMmeasurementSummaryType": {
+            "enum": [
+                "TCB",
+                "All"
+            ],
+            "enumDescriptions": {
+                "All": "The measurement summary covers all measurements in SPDM.",
+                "TCB": "The measurement summary covers the TCB."
+            },
+            "type": "string"
+        },
+        "SPDMrequesterAuth": {
+            "additionalProperties": false,
+            "description": "Authentication information of the identity of the SPDM Requester.",
+            "longDescription": "This object shall contain authentication information of the identity of the SPDM Requester.",
+            "patternProperties": {
+                "^([a-zA-Z_][a-zA-Z0-9_]*)?@(odata|Redfish|Message)\\.[a-zA-Z_][a-zA-Z0-9_]*$": {
+                    "description": "This property shall specify a valid odata or Redfish property.",
+                    "type": [
+                        "array",
+                        "boolean",
+                        "integer",
+                        "number",
+                        "null",
+                        "object",
+                        "string"
+                    ]
+                }
+            },
+            "properties": {
+                "ProvidedCertificate": {
+                    "$ref": "http://redfish.dmtf.org/schemas/v1/Certificate.json#/definitions/Certificate",
+                    "description": "A link to the certificate that represents the identify of the SPDM Requester provided in mutual authentication.",
+                    "longDescription": "This property shall contain a link to a resource of type Certificate that represents the identify of the SPDM Requester provided in mutual authentication.",
+                    "readonly": true
+                }
+            },
+            "type": "object"
+        },
+        "SPDMresponderAuth": {
+            "additionalProperties": false,
+            "description": "Common Authentication information.",
+            "longDescription": "This object shall contain common identity-related authentication information.",
+            "patternProperties": {
+                "^([a-zA-Z_][a-zA-Z0-9_]*)?@(odata|Redfish|Message)\\.[a-zA-Z_][a-zA-Z0-9_]*$": {
+                    "description": "This property shall specify a valid odata or Redfish property.",
+                    "type": [
+                        "array",
+                        "boolean",
+                        "integer",
+                        "number",
+                        "null",
+                        "object",
+                        "string"
+                    ]
+                }
+            },
+            "properties": {
+                "ComponentCertificate": {
+                    "$ref": "http://redfish.dmtf.org/schemas/v1/Certificate.json#/definitions/Certificate",
+                    "description": "A link to the certificate that represents the identify of the component.",
+                    "longDescription": "This property shall contain a link to a resource of type Certificate that represents the identify of the component referenced by the TargetComponentURI property.",
+                    "readonly": true
+                },
+                "VerificationStatus": {
+                    "anyOf": [
+                        {
+                            "$ref": "#/definitions/VerificationStatus"
+                        },
+                        {
+                            "type": "null"
+                        }
+                    ],
+                    "description": "The status of the verification of the identity of the component.",
+                    "longDescription": "This property shall contain the status of the verification of the identity of the component referenced by the TargetComponentURI property..",
+                    "readonly": true
+                }
+            },
+            "type": "object"
+        },
+        "SPDMsingleMeasurement": {
+            "additionalProperties": false,
+            "description": "A single SPDM measurement for an SPDM Responder.",
+            "longDescription": "This object shall contain a single SPDM measurement for an SPDM Responder.",
+            "patternProperties": {
+                "^([a-zA-Z_][a-zA-Z0-9_]*)?@(odata|Redfish|Message)\\.[a-zA-Z_][a-zA-Z0-9_]*$": {
+                    "description": "This property shall specify a valid odata or Redfish property.",
+                    "type": [
+                        "array",
+                        "boolean",
+                        "integer",
+                        "number",
+                        "null",
+                        "object",
+                        "string"
+                    ]
+                }
+            },
+            "properties": {
+                "LastUpdated": {
+                    "description": "The date and time when information for the measurement was last updated.",
+                    "format": "date-time",
+                    "longDescription": "This property shall contain the date and time when information for the measurement was last updated.",
+                    "readonly": true,
+                    "type": [
+                        "string",
+                        "null"
+                    ]
+                },
+                "Measurement": {
+                    "description": "The measurement data.",
+                    "longDescription": "This property shall contain the Base64-encoded measurement using the hash algorithm indicated by the MeasurementHashAlgorithm property.  This property shall not contain a raw bit stream as a measurement.  If the SPDM Responder provides a raw bit stream, the SPDM Requester may apply a hash algorithm to the raw bit stream in order to report the measurement.",
+                    "pattern": "^[A-Za-z0-9+/]+={0,2}$",
+                    "readonly": true,
+                    "type": [
+                        "string",
+                        "null"
+                    ]
+                },
+                "MeasurementHashAlgorithm": {
+                    "description": "The hash algorithm used to compute the measurement.",
+                    "longDescription": "This property shall contain the hash algorithm used to compute the measurement.  The allowable values for this property shall be the hash algorithm names found in the 'BaseHashAlgo' field of the 'NEGOTIATE_ALGORITHMS' request message in DSP0274.  If the algorithm is an extended algorithm, this property shall contain the value `OEM`.  This property shall not be present if MeasurementSpecification does not contain `DMTF`.",
+                    "readonly": true,
+                    "type": [
+                        "string",
+                        "null"
+                    ]
+                },
+                "MeasurementIndex": {
+                    "description": "The index of the measurement.",
+                    "longDescription": "This property shall contain the index of the measurement.",
+                    "readonly": true,
+                    "type": [
+                        "integer",
+                        "null"
+                    ]
+                },
+                "MeasurementType": {
+                    "anyOf": [
+                        {
+                            "$ref": "#/definitions/DMTFmeasurementTypes"
+                        },
+                        {
+                            "type": "null"
+                        }
+                    ],
+                    "description": "The type or characteristics of the data that this measurement represents.",
+                    "longDescription": "This property shall contain the type or characteristics of the data that this measurement represents.  This property shall not be present if MeasurementSpecification does not contain `DMTF`.",
+                    "readonly": true
+                },
+                "Oem": {
+                    "$ref": "http://redfish.dmtf.org/schemas/v1/Resource.json#/definitions/Oem",
+                    "description": "The OEM extension property.",
+                    "longDescription": "This property shall contain the OEM extensions.  All values for properties contained in this object shall conform to the Redfish Specification-described requirements."
+                },
+                "PartofSummaryHash": {
+                    "description": "Indicates whether this measurement is part of the measurement summary.",
+                    "longDescription": "This property shall indicate if this measurement is part of the measurement summary in the MeasurementSummary property.  If this property is not present, it shall be assumed to be `false`.",
+                    "readonly": true,
+                    "type": [
+                        "boolean",
+                        "null"
+                    ]
+                }
+            },
+            "type": "object"
+        },
+        "SecureSessionType": {
+            "enum": [
+                "Plain",
+                "EncryptedAuthenticated",
+                "AuthenticatedOnly"
+            ],
+            "enumDescriptions": {
+                "AuthenticatedOnly": "An established session where only authentication is protecting the communication.",
+                "EncryptedAuthenticated": "An established session where both encryption and authentication are protecting the communication.",
+                "Plain": "A plain text session without any protection."
+            },
+            "type": "string"
+        },
+        "SingleSessionInfo": {
+            "additionalProperties": false,
+            "description": "Information about a single communication channel or session between two components.",
+            "longDescription": "This object shall contain information about a single communication channel or session between two components.",
+            "patternProperties": {
+                "^([a-zA-Z_][a-zA-Z0-9_]*)?@(odata|Redfish|Message)\\.[a-zA-Z_][a-zA-Z0-9_]*$": {
+                    "description": "This property shall specify a valid odata or Redfish property.",
+                    "type": [
+                        "array",
+                        "boolean",
+                        "integer",
+                        "number",
+                        "null",
+                        "object",
+                        "string"
+                    ]
+                }
+            },
+            "properties": {
+                "SessionId": {
+                    "description": "The identifier for an active session or communication channel between two components.",
+                    "longDescription": "This property shall contain the unique identifier for the active session or communication channel between two components.",
+                    "readonly": true,
+                    "type": [
+                        "integer",
+                        "null"
+                    ]
+                },
+                "SessionType": {
+                    "anyOf": [
+                        {
+                            "$ref": "#/definitions/SecureSessionType"
+                        },
+                        {
+                            "type": "null"
+                        }
+                    ],
+                    "description": "The type of session or communication channel between two components.",
+                    "longDescription": "This property shall contain the type of session or communication channel between two components.",
+                    "readonly": true
+                }
+            },
+            "type": "object"
+        },
+        "TPMauth": {
+            "additionalProperties": false,
+            "description": "Common Authentication information.",
+            "longDescription": "This object shall contain common identity-related authentication information.",
+            "patternProperties": {
+                "^([a-zA-Z_][a-zA-Z0-9_]*)?@(odata|Redfish|Message)\\.[a-zA-Z_][a-zA-Z0-9_]*$": {
+                    "description": "This property shall specify a valid odata or Redfish property.",
+                    "type": [
+                        "array",
+                        "boolean",
+                        "integer",
+                        "number",
+                        "null",
+                        "object",
+                        "string"
+                    ]
+                }
+            },
+            "properties": {
+                "ComponentCertificate": {
+                    "$ref": "http://redfish.dmtf.org/schemas/v1/Certificate.json#/definitions/Certificate",
+                    "description": "A link to the certificate that represents the identify of the component.",
+                    "longDescription": "This property shall contain a link to a resource of type Certificate that represents the identify of the component referenced by the TargetComponentURI property.",
+                    "readonly": true
+                },
+                "VerificationStatus": {
+                    "anyOf": [
+                        {
+                            "$ref": "#/definitions/VerificationStatus"
+                        },
+                        {
+                            "type": "null"
+                        }
+                    ],
+                    "description": "The status of the verification of the identity of the component.",
+                    "longDescription": "This property shall contain the status of the verification of the identity of the component referenced by the TargetComponentURI property..",
+                    "readonly": true
+                }
+            },
+            "type": "object"
+        },
+        "TPMcommunication": {
+            "additionalProperties": false,
+            "description": "Information about communication between two components.",
+            "longDescription": "This object shall contain information about communication between two components.",
+            "patternProperties": {
+                "^([a-zA-Z_][a-zA-Z0-9_]*)?@(odata|Redfish|Message)\\.[a-zA-Z_][a-zA-Z0-9_]*$": {
+                    "description": "This property shall specify a valid odata or Redfish property.",
+                    "type": [
+                        "array",
+                        "boolean",
+                        "integer",
+                        "number",
+                        "null",
+                        "object",
+                        "string"
+                    ]
+                }
+            },
+            "properties": {
+                "Sessions": {
+                    "description": "The active sessions or communication channels between two components.",
+                    "items": {
+                        "anyOf": [
+                            {
+                                "$ref": "#/definitions/SingleSessionInfo"
+                            },
+                            {
+                                "type": "null"
+                            }
+                        ]
+                    },
+                    "longDescription": "This property shall contain an array of the active sessions or communication channels between two components  The active sessions or communication channels do not reflect how future sessions or communication channels are established.",
+                    "type": "array"
+                }
+            },
+            "type": "object"
+        },
+        "TPMinfo": {
+            "additionalProperties": false,
+            "description": "Integrity information about a Trusted Platform Module (TPM).",
+            "longDescription": "This object shall contain integrity information about a Trusted Platform Module (TPM).",
+            "patternProperties": {
+                "^([a-zA-Z_][a-zA-Z0-9_]*)?@(odata|Redfish|Message)\\.[a-zA-Z_][a-zA-Z0-9_]*$": {
+                    "description": "This property shall specify a valid odata or Redfish property.",
+                    "type": [
+                        "array",
+                        "boolean",
+                        "integer",
+                        "number",
+                        "null",
+                        "object",
+                        "string"
+                    ]
+                }
+            },
+            "properties": {
+                "ComponentCommunication": {
+                    "anyOf": [
+                        {
+                            "$ref": "#/definitions/TPMcommunication"
+                        },
+                        {
+                            "type": "null"
+                        }
+                    ],
+                    "description": "Information about communication with the TPM.",
+                    "longDescription": "This property shall contain information about communication with the TPM."
+                },
+                "IdentityAuthentication": {
+                    "anyOf": [
+                        {
+                            "$ref": "#/definitions/TPMauth"
+                        },
+                        {
+                            "type": "null"
+                        }
+                    ],
+                    "description": "Identity authentication information about the TPM.",
+                    "longDescription": "This property shall contain identity authentication information about the TPM."
+                },
+                "MeasurementSet": {
+                    "anyOf": [
+                        {
+                            "$ref": "#/definitions/TPMmeasurementSet"
+                        },
+                        {
+                            "type": "null"
+                        }
+                    ],
+                    "description": "Measurement information from the TPM.",
+                    "longDescription": "This property shall contain measurement information from the TPM."
+                }
+            },
+            "type": "object"
+        },
+        "TPMmeasurementSet": {
+            "additionalProperties": false,
+            "description": "Trusted Computing Group TPM measurement information.",
+            "longDescription": "This object shall contain Trusted Computing Group TPM measurement information.",
+            "patternProperties": {
+                "^([a-zA-Z_][a-zA-Z0-9_]*)?@(odata|Redfish|Message)\\.[a-zA-Z_][a-zA-Z0-9_]*$": {
+                    "description": "This property shall specify a valid odata or Redfish property.",
+                    "type": [
+                        "array",
+                        "boolean",
+                        "integer",
+                        "number",
+                        "null",
+                        "object",
+                        "string"
+                    ]
+                }
+            },
+            "properties": {
+                "Measurements": {
+                    "description": "Measurements from a TPM.",
+                    "items": {
+                        "anyOf": [
+                            {
+                                "$ref": "#/definitions/TPMsingleMeasurement"
+                            },
+                            {
+                                "type": "null"
+                            }
+                        ]
+                    },
+                    "longDescription": "This property shall contain measurements from a TPM.",
+                    "type": "array"
+                }
+            },
+            "type": "object"
+        },
+        "TPMsingleMeasurement": {
+            "additionalProperties": false,
+            "description": "A single Trusted Computing Group TPM measurement.",
+            "longDescription": "This object shall contain a single Trusted Computing Group TPM measurement.",
+            "patternProperties": {
+                "^([a-zA-Z_][a-zA-Z0-9_]*)?@(odata|Redfish|Message)\\.[a-zA-Z_][a-zA-Z0-9_]*$": {
+                    "description": "This property shall specify a valid odata or Redfish property.",
+                    "type": [
+                        "array",
+                        "boolean",
+                        "integer",
+                        "number",
+                        "null",
+                        "object",
+                        "string"
+                    ]
+                }
+            },
+            "properties": {
+                "LastUpdated": {
+                    "description": "The date and time when information for the measurement was last updated.",
+                    "format": "date-time",
+                    "longDescription": "This property shall contain the date and time when information for the measurement was last updated.",
+                    "readonly": true,
+                    "type": [
+                        "string",
+                        "null"
+                    ]
+                },
+                "Measurement": {
+                    "description": "The measurement data.",
+                    "longDescription": "This property shall contain the Base64-encoded PCR digest using the hashing algorithm indicated by MeasurementHashAlgorithm property.",
+                    "pattern": "^[A-Za-z0-9+/]+={0,2}$",
+                    "readonly": true,
+                    "type": [
+                        "string",
+                        "null"
+                    ]
+                },
+                "MeasurementHashAlgorithm": {
+                    "description": "The hash algorithm used to compute the measurement.",
+                    "longDescription": "This property shall contain the hash algorithm used to compute the measurement.  The allowable values for this property shall be the strings in the 'Algorithm Name' field of the 'TPM_ALG_ID Constants' table within the 'Trusted Computing Group Algorithm Registry'.",
+                    "readonly": true,
+                    "type": [
+                        "string",
+                        "null"
+                    ]
+                },
+                "PCR": {
+                    "description": "The Platform Configuration Register (PCR) bank of the measurement.",
+                    "longDescription": "This property shall contain the Platform Configuration Register (PCR) bank of the measurement.",
+                    "readonly": true,
+                    "type": [
+                        "integer",
+                        "null"
+                    ]
+                }
+            },
+            "type": "object"
+        },
+        "VerificationStatus": {
+            "enum": [
+                "Success",
+                "Failed"
+            ],
+            "enumDescriptions": {
+                "Failed": "Unsuccessful verification.",
+                "Success": "Successful verification."
+            },
+            "type": "string"
+        }
+    },
+    "owningEntity": "DMTF",
+    "release": "2021.4",
+    "title": "#ComponentIntegrity.v1_0_0.ComponentIntegrity"
+}

--- a/static/redfish/v1/JsonSchemas/ComponentIntegrity/index.json
+++ b/static/redfish/v1/JsonSchemas/ComponentIntegrity/index.json
@@ -1,0 +1,21 @@
+{
+    "@odata.context": "/redfish/v1/$metadata#JsonSchemaFile.JsonSchemaFile",
+    "@odata.id": "/redfish/v1/JsonSchemas/ComponentIntegrity",
+    "@odata.type": "#JsonSchemaFile.v1_0_2.JsonSchemaFile",
+    "Name": "ComponentIntegrity Schema File",
+    "Schema": "#ComponentIntegrity.ComponentIntegrity",
+    "Description": "ComponentIntegrity Schema File Location",
+    "Id": "ComponentIntegrity",
+    "Languages": [
+        "en"
+    ],
+    "Languages@odata.count": 1,
+    "Location": [
+        {
+            "Language": "en",
+            "PublicationUri": "http://redfish.dmtf.org/schemas/v1/ComponentIntegrity.json",
+            "Uri": "/redfish/v1/JsonSchemas/ComponentIntegrity/ComponentIntegrity.json"
+        }
+    ],
+    "Location@odata.count": 1
+}

--- a/static/redfish/v1/JsonSchemas/Control/Control.json
+++ b/static/redfish/v1/JsonSchemas/Control/Control.json
@@ -1,5 +1,5 @@
 {
-    "$id": "http://redfish.dmtf.org/schemas/v1/Control.v1_0_0.json",
+    "$id": "http://redfish.dmtf.org/schemas/v1/Control.v1_1_0.json",
     "$ref": "#/definitions/Control",
     "$schema": "http://redfish.dmtf.org/schemas/v1/redfish-schema-v1.json",
     "copyright": "Copyright 2014-2021 DMTF. For the full DMTF copyright policy, see http://www.dmtf.org/about/policies/copyright",
@@ -279,8 +279,7 @@
                     ],
                     "description": "The sensor reading associated with this control.",
                     "excerptCopy": "SensorExcerpt",
-                    "longDescription": "This property shall contain the Sensor excerpt directly associated with this control.  This property shall not be present if multiple sensors are associated with a single control.",
-                    "readonly": true
+                    "longDescription": "This property shall contain the Sensor excerpt directly associated with this control.  The value of the DataSourceUri property shall reference a resource of type Sensor.  This property shall not be present if multiple sensors are associated with a single control."
                 },
                 "SetPoint": {
                     "description": "The desired set point of the control.",
@@ -743,17 +742,27 @@
             "enum": [
                 "Temperature",
                 "Power",
-                "Frequency"
+                "Frequency",
+                "FrequencyMHz",
+                "Pressure"
             ],
             "enumDescriptions": {
-                "Frequency": "Frequency control.",
-                "Power": "Power control or power limit.",
-                "Temperature": "Temperature control or thermostat."
+                "Frequency": "Frequency (Hz) control.",
+                "FrequencyMHz": "Frequency (MHz) control.",
+                "Power": "Power (W) control or power limit.",
+                "Pressure": "Pressure (kPa) control.",
+                "Temperature": "Temperature (C) control or thermostat."
             },
             "enumLongDescriptions": {
-                "Frequency": "This value shall indicate a control used to limit the operating frequency, measured in Hertz units, of a device, either to a single set point or within a range, and the SetPointUnits property shall contain `Hz`.",
-                "Power": "This value shall indicate a control used to regulate or limit maximum power consumption, in Watts units, either to a single set point or within a range, and the SetPointUnits property shall contain `W`.",
+                "Frequency": "This value shall indicate a control used to limit the operating frequency, in hertz units, of a device, either to a single set point or within a range, and the SetPointUnits property shall contain `Hz`.",
+                "FrequencyMHz": "This value shall indicate a control used to limit the operating frequency, in megahertz units, of a device, either to a single set point or within a range, and the SetPointUnits property shall contain `MHz`.",
+                "Power": "This value shall indicate a control used to regulate or limit maximum power consumption, in watt units, either to a single set point or within a range, and the SetPointUnits property shall contain `W`.",
+                "Pressure": "This value shall indicate a control used to adjust pressure in a system, in kilopascal units, and the SetPointUnits property shall contain `kPa`.",
                 "Temperature": "This value shall indicate a control used to regulate temperature, in units of degrees Celsius, either to a single set point or within a range, and the SetPointUnits property shall contain `Cel`."
+            },
+            "enumVersionAdded": {
+                "FrequencyMHz": "v1_1_0",
+                "Pressure": "v1_1_0"
             },
             "type": "string"
         },
@@ -808,6 +817,6 @@
         }
     },
     "owningEntity": "DMTF",
-    "release": "2021.2",
-    "title": "#Control.v1_0_0.Control"
+    "release": "2021.4",
+    "title": "#Control.v1_1_0.Control"
 }

--- a/static/redfish/v1/JsonSchemas/EnvironmentMetrics/EnvironmentMetrics.json
+++ b/static/redfish/v1/JsonSchemas/EnvironmentMetrics/EnvironmentMetrics.json
@@ -1,5 +1,5 @@
 {
-    "$id": "http://redfish.dmtf.org/schemas/v1/EnvironmentMetrics.v1_1_0.json",
+    "$id": "http://redfish.dmtf.org/schemas/v1/EnvironmentMetrics.v1_2_0.json",
     "$ref": "#/definitions/EnvironmentMetrics",
     "$schema": "http://redfish.dmtf.org/schemas/v1/redfish-schema-v1.json",
     "copyright": "Copyright 2014-2021 DMTF. For the full DMTF copyright policy, see http://www.dmtf.org/about/policies/copyright",
@@ -65,6 +65,20 @@
                 "@odata.type": {
                     "$ref": "http://redfish.dmtf.org/schemas/v1/odata-v4.json#/definitions/type"
                 },
+                "AbsoluteHumidity": {
+                    "anyOf": [
+                        {
+                            "$ref": "http://redfish.dmtf.org/schemas/v1/Sensor.json#/definitions/SensorExcerpt"
+                        },
+                        {
+                            "type": "null"
+                        }
+                    ],
+                    "description": "Absolute humidity (g/cu m).",
+                    "excerptCopy": "SensorExcerpt",
+                    "longDescription": "This property shall contain the absolute (volumetric) humidity sensor reading, in grams/cubic meter units, for this resource.  The value of the DataSourceUri property, if present, shall reference a resource of type Sensor with the ReadingType property containing the value `AbsoluteHumidity`.",
+                    "versionAdded": "v1_2_0"
+                },
                 "Actions": {
                     "$ref": "#/definitions/Actions",
                     "description": "The available actions for this resource.",
@@ -92,8 +106,22 @@
                     ],
                     "description": "The dew point temperature (C).",
                     "excerptCopy": "SensorExcerpt",
-                    "longDescription": "This property shall contain the dew point, measured in degrees Celsius, based on the temperature and humidity values for this resource.",
+                    "longDescription": "This property shall contain the dew point, in degrees Celsius, based on the temperature and humidity values for this resource.  The value of the DataSourceUri property, if present, shall reference a resource of type Sensor with the ReadingType property containing the value `Temperature`.",
                     "versionAdded": "v1_1_0"
+                },
+                "EnergyJoules": {
+                    "anyOf": [
+                        {
+                            "$ref": "http://redfish.dmtf.org/schemas/v1/Sensor.json#/definitions/SensorExcerpt"
+                        },
+                        {
+                            "type": "null"
+                        }
+                    ],
+                    "description": "Energy consumption (J).",
+                    "excerptCopy": "SensorExcerpt",
+                    "longDescription": "This property shall contain the total energy, in joules, for this resource.  The value of the DataSourceUri property, if present, shall reference a resource of type Sensor with the ReadingType property containing the value `EnergyJoules`.  This property is used for reporting device-level energy consumption measurements, while EnergykWh is used for large-scale consumption measurements.",
+                    "versionAdded": "v1_2_0"
                 },
                 "EnergykWh": {
                     "anyOf": [
@@ -106,7 +134,7 @@
                     ],
                     "description": "Energy consumption (kWh).",
                     "excerptCopy": "SensorEnergykWhExcerpt",
-                    "longDescription": "This property shall contain the total energy, measured in kilowatt-hours (kW.h), for this resource."
+                    "longDescription": "This property shall contain the total energy, in kilowatt-hours, for this resource.  The value of the DataSourceUri property, if present, shall reference a resource of type Sensor with the ReadingType property containing the value `EnergykWh`."
                 },
                 "FanSpeedsPercent": {
                     "description": "Fan speeds (percent).",
@@ -114,7 +142,7 @@
                     "items": {
                         "$ref": "http://redfish.dmtf.org/schemas/v1/Sensor.json#/definitions/SensorFanArrayExcerpt"
                     },
-                    "longDescription": "This property shall contain the fan speed readings for this resource.",
+                    "longDescription": "This property shall contain the fan speeds, in percent units, for this resource.  The value of the DataSourceUri property, if present, shall reference a resource of type Sensor with the ReadingType property containing the value `Percent`.",
                     "type": "array"
                 },
                 "FanSpeedsPercent@odata.count": {
@@ -131,7 +159,7 @@
                     ],
                     "description": "Humidity (percent).",
                     "excerptCopy": "SensorExcerpt",
-                    "longDescription": "This property shall contain the humidity sensor reading for this resource."
+                    "longDescription": "This property shall contain the humidity, in percent units, for this resource.  The value of the DataSourceUri property, if present, shall reference a resource of type Sensor with the ReadingType property containing the value `Humidity`."
                 },
                 "Id": {
                     "$ref": "http://redfish.dmtf.org/schemas/v1/Resource.json#/definitions/Id",
@@ -155,9 +183,9 @@
                             "type": "null"
                         }
                     ],
-                    "description": "Power limit (Watts).",
+                    "description": "Power limit (W).",
                     "excerptCopy": "ControlSingleExcerpt",
-                    "longDescription": "This property shall contain the power limit control for this resource.",
+                    "longDescription": "This property shall contain the power limit control, in watt units, for this resource.  The value of the DataSourceUri property, if present, shall reference a resource of type Control with the ControlType property containing the value of `Power`.",
                     "readonly": false,
                     "versionAdded": "v1_1_0"
                 },
@@ -170,9 +198,9 @@
                             "type": "null"
                         }
                     ],
-                    "description": "The power load (%) for this device.",
+                    "description": "The power load (percent) for this device.",
                     "excerptCopy": "SensorExcerpt",
-                    "longDescription": "This property shall contain the power load, measured in percent, for this device, that represents the `Total` ElectricalContext for this device.",
+                    "longDescription": "This property shall contain the power load, in percent units, for this device, that represents the `Total` ElectricalContext for this device.  The value of the DataSourceUri property, if present, shall reference a resource of type Sensor with the ReadingType property containing the value `Percent`.",
                     "versionAdded": "v1_1_0"
                 },
                 "PowerWatts": {
@@ -184,9 +212,9 @@
                             "type": "null"
                         }
                     ],
-                    "description": "Power consumption (Watts).",
+                    "description": "Power consumption (W).",
                     "excerptCopy": "SensorPowerExcerpt",
-                    "longDescription": "This property shall contain the total power, measured in Watts, for this resource."
+                    "longDescription": "This property shall contain the total power, in watt units, for this resource.  The value of the DataSourceUri property, if present, shall reference a resource of type Sensor with the ReadingType property containing the value `Power`."
                 },
                 "TemperatureCelsius": {
                     "anyOf": [
@@ -199,7 +227,7 @@
                     ],
                     "description": "Temperature (Celsius).",
                     "excerptCopy": "SensorExcerpt",
-                    "longDescription": "This property shall contain the temperature sensor reading for this resource."
+                    "longDescription": "This property shall contain the temperature, in degrees Celsius units, for this resource.  The value of the DataSourceUri property, if present, shall reference a resource of type Sensor with the ReadingType property containing the value `Temperature`."
                 }
             },
             "required": [
@@ -265,6 +293,6 @@
         }
     },
     "owningEntity": "DMTF",
-    "release": "2021.2",
-    "title": "#EnvironmentMetrics.v1_1_0.EnvironmentMetrics"
+    "release": "2021.4",
+    "title": "#EnvironmentMetrics.v1_2_0.EnvironmentMetrics"
 }

--- a/static/redfish/v1/JsonSchemas/Fabric/Fabric.json
+++ b/static/redfish/v1/JsonSchemas/Fabric/Fabric.json
@@ -1,5 +1,5 @@
 {
-    "$id": "http://redfish.dmtf.org/schemas/v1/Fabric.v1_2_2.json",
+    "$id": "http://redfish.dmtf.org/schemas/v1/Fabric.v1_3_0.json",
     "$ref": "#/definitions/Fabric",
     "$schema": "http://redfish.dmtf.org/schemas/v1/redfish-schema-v1.json",
     "copyright": "Copyright 2014-2021 DMTF. For the full DMTF copyright policy, see http://www.dmtf.org/about/policies/copyright",
@@ -156,6 +156,20 @@
                     "longDescription": "This property shall contain a link to a resource collection of type SwitchCollection.",
                     "readonly": true
                 },
+                "UUID": {
+                    "anyOf": [
+                        {
+                            "$ref": "http://redfish.dmtf.org/schemas/v1/Resource.json#/definitions/UUID"
+                        },
+                        {
+                            "type": "null"
+                        }
+                    ],
+                    "description": "The UUID for this fabric.",
+                    "longDescription": "This property shall contain a universal unique identifier number for the fabric.",
+                    "readonly": false,
+                    "versionAdded": "v1_3_0"
+                },
                 "Zones": {
                     "$ref": "http://redfish.dmtf.org/schemas/v1/ZoneCollection.json#/definitions/ZoneCollection",
                     "description": "The collection of links to the zones that this fabric contains.",
@@ -221,6 +235,6 @@
         }
     },
     "owningEntity": "DMTF",
-    "release": "2020.3",
-    "title": "#Fabric.v1_2_2.Fabric"
+    "release": "TBD",
+    "title": "#Fabric.v1_3_0.Fabric"
 }

--- a/static/redfish/v1/JsonSchemas/Fan/Fan.json
+++ b/static/redfish/v1/JsonSchemas/Fan/Fan.json
@@ -1,5 +1,5 @@
 {
-    "$id": "http://redfish.dmtf.org/schemas/v1/Fan.v1_1_0.json",
+    "$id": "http://redfish.dmtf.org/schemas/v1/Fan.v1_1_1.json",
     "$ref": "#/definitions/Fan",
     "$schema": "http://redfish.dmtf.org/schemas/v1/redfish-schema-v1.json",
     "copyright": "Copyright 2014-2021 DMTF. For the full DMTF copyright policy, see http://www.dmtf.org/about/policies/copyright",
@@ -162,10 +162,9 @@
                             "type": "null"
                         }
                     ],
-                    "description": "Power consumption (Watts).",
+                    "description": "Power consumption (W).",
                     "excerptCopy": "SensorPowerExcerpt",
-                    "longDescription": "This property shall contain the total power, measured in Watts, for this resource.",
-                    "readonly": true,
+                    "longDescription": "This property shall contain the total power, in watt units, for this resource.  The value of the DataSourceUri property, if present, shall reference a resource of type Sensor with the ReadingType property containing the value `Power`.",
                     "versionAdded": "v1_1_0"
                 },
                 "SerialNumber": {
@@ -195,10 +194,9 @@
                             "type": "null"
                         }
                     ],
-                    "description": "The fan speed reading.",
+                    "description": "The fan speed (percent).",
                     "excerptCopy": "SensorFanExcerpt",
-                    "longDescription": "This property shall contain the fan speed sensor.",
-                    "readonly": true
+                    "longDescription": "This property shall contain the fan speed, in percent units, for this resource.  The value of the DataSourceUri property, if present, shall reference a resource of type Sensor with the ReadingType property containing the value `Percent`."
                 },
                 "Status": {
                     "$ref": "http://redfish.dmtf.org/schemas/v1/Resource.json#/definitions/Status",
@@ -238,5 +236,5 @@
     },
     "owningEntity": "DMTF",
     "release": "2021.1",
-    "title": "#Fan.v1_1_0.Fan"
+    "title": "#Fan.v1_1_1.Fan"
 }

--- a/static/redfish/v1/JsonSchemas/ManagerDiagnosticData/ManagerDiagnosticData.json
+++ b/static/redfish/v1/JsonSchemas/ManagerDiagnosticData/ManagerDiagnosticData.json
@@ -1,0 +1,558 @@
+{
+    "$id": "http://redfish.dmtf.org/schemas/v1/ManagerDiagnosticData.v1_0_0.json",
+    "$ref": "#/definitions/ManagerDiagnosticData",
+    "$schema": "http://redfish.dmtf.org/schemas/v1/redfish-schema-v1.json",
+    "copyright": "Copyright 2014-2021 DMTF. For the full DMTF copyright policy, see http://www.dmtf.org/about/policies/copyright",
+    "definitions": {
+        "Actions": {
+            "additionalProperties": false,
+            "description": "The available actions for this resource.",
+            "longDescription": "This type shall contain the available actions for this resource.",
+            "patternProperties": {
+                "^([a-zA-Z_][a-zA-Z0-9_]*)?@(odata|Redfish|Message)\\.[a-zA-Z_][a-zA-Z0-9_]*$": {
+                    "description": "This property shall specify a valid odata or Redfish property.",
+                    "type": [
+                        "array",
+                        "boolean",
+                        "integer",
+                        "number",
+                        "null",
+                        "object",
+                        "string"
+                    ]
+                }
+            },
+            "properties": {
+                "#ManagerDiagnosticData.ResetMetrics": {
+                    "$ref": "#/definitions/ResetMetrics"
+                },
+                "Oem": {
+                    "$ref": "#/definitions/OemActions",
+                    "description": "The available OEM-specific actions for this resource.",
+                    "longDescription": "This property shall contain the available OEM-specific actions for this resource."
+                }
+            },
+            "type": "object"
+        },
+        "BootTimeStatistics": {
+            "additionalProperties": false,
+            "description": "The boot time statistics of a manager.",
+            "longDescription": "This object shall contain the boot time statistics of a manager.",
+            "patternProperties": {
+                "^([a-zA-Z_][a-zA-Z0-9_]*)?@(odata|Redfish|Message)\\.[a-zA-Z_][a-zA-Z0-9_]*$": {
+                    "description": "This property shall specify a valid odata or Redfish property.",
+                    "type": [
+                        "array",
+                        "boolean",
+                        "integer",
+                        "number",
+                        "null",
+                        "object",
+                        "string"
+                    ]
+                }
+            },
+            "properties": {
+                "FirmwareTimeSeconds": {
+                    "description": "The number of seconds the manager spent in the firmware stage.",
+                    "longDescription": "This property shall contain the number of seconds the manager spent in the firmware stage.",
+                    "readonly": true,
+                    "type": [
+                        "number",
+                        "null"
+                    ]
+                },
+                "InitrdTimeSeconds": {
+                    "description": "The number of seconds the manager spent in the initrd boot stage.",
+                    "longDescription": "This property shall contain the number of seconds the manager spent in the initrd boot stage.",
+                    "readonly": true,
+                    "type": [
+                        "number",
+                        "null"
+                    ]
+                },
+                "KernelTimeSeconds": {
+                    "description": "The number of seconds the manager spent in the kernel stage.",
+                    "longDescription": "This property shall contain the number of seconds the manager spent in the kernel stage.",
+                    "readonly": true,
+                    "type": [
+                        "number",
+                        "null"
+                    ]
+                },
+                "LoaderTimeSeconds": {
+                    "description": "The number of seconds the manager spent in the loader stage.",
+                    "longDescription": "This property shall contain the number of seconds the manager spent in the loader stage.",
+                    "readonly": true,
+                    "type": [
+                        "number",
+                        "null"
+                    ]
+                },
+                "UserSpaceTimeSeconds": {
+                    "description": "The number of seconds the manager spent in the user space boot stage.",
+                    "longDescription": "This property shall contain the number of seconds the manager spent in the user space boot stage.",
+                    "readonly": true,
+                    "type": [
+                        "number",
+                        "null"
+                    ]
+                }
+            },
+            "type": "object"
+        },
+        "I2CBusStatistics": {
+            "additionalProperties": false,
+            "description": "The statistics of an I2C bus.",
+            "longDescription": "This object shall contain statistics of an I2C bus.",
+            "patternProperties": {
+                "^([a-zA-Z_][a-zA-Z0-9_]*)?@(odata|Redfish|Message)\\.[a-zA-Z_][a-zA-Z0-9_]*$": {
+                    "description": "This property shall specify a valid odata or Redfish property.",
+                    "type": [
+                        "array",
+                        "boolean",
+                        "integer",
+                        "number",
+                        "null",
+                        "object",
+                        "string"
+                    ]
+                }
+            },
+            "properties": {
+                "BusErrorCount": {
+                    "description": "The number of bus errors on this I2C bus.",
+                    "longDescription": "This property shall contain the number of bus errors on this I2C bus.  Bus errors include, but are not limited to, an SDA rising or falling edge while SCL is high or a stuck bus signal.",
+                    "readonly": true,
+                    "type": [
+                        "integer",
+                        "null"
+                    ]
+                },
+                "I2CBusName": {
+                    "description": "The name of the I2C bus.",
+                    "longDescription": "This property shall contain the name of the I2C bus.",
+                    "readonly": true,
+                    "type": "string"
+                },
+                "NACKCount": {
+                    "description": "The number of NACKs on this I2C bus.",
+                    "longDescription": "This property shall contain the number of NACKs on this I2C bus.",
+                    "readonly": true,
+                    "type": [
+                        "integer",
+                        "null"
+                    ]
+                },
+                "TotalTransactionCount": {
+                    "description": "The total number of transactions on this I2C bus.",
+                    "longDescription": "This property shall contain the total number of transactions on this I2C bus.  The count shall include the number of I2C transactions initiated by the manager and the number of I2C transactions where the manager is the target device.",
+                    "readonly": true,
+                    "type": [
+                        "integer",
+                        "null"
+                    ]
+                }
+            },
+            "type": "object"
+        },
+        "ManagerDiagnosticData": {
+            "additionalProperties": false,
+            "description": "The ManagerDiagnosticData schema defines internal diagnostic data for a manager.  It contains information that might be used by vendors to collect debug information about the manager.  Clients should not make decisions for raising alerts, creating service events, or other actions based on information in this resource.",
+            "longDescription": "This resource shall represent internal diagnostic data for a manager for a Redfish implementation.  Clients should not make decisions for raising alerts, creating service events, or other actions based on information in this resource.",
+            "patternProperties": {
+                "^([a-zA-Z_][a-zA-Z0-9_]*)?@(odata|Redfish|Message)\\.[a-zA-Z_][a-zA-Z0-9_]*$": {
+                    "description": "This property shall specify a valid odata or Redfish property.",
+                    "type": [
+                        "array",
+                        "boolean",
+                        "integer",
+                        "number",
+                        "null",
+                        "object",
+                        "string"
+                    ]
+                }
+            },
+            "properties": {
+                "@odata.context": {
+                    "$ref": "http://redfish.dmtf.org/schemas/v1/odata-v4.json#/definitions/context"
+                },
+                "@odata.etag": {
+                    "$ref": "http://redfish.dmtf.org/schemas/v1/odata-v4.json#/definitions/etag"
+                },
+                "@odata.id": {
+                    "$ref": "http://redfish.dmtf.org/schemas/v1/odata-v4.json#/definitions/id"
+                },
+                "@odata.type": {
+                    "$ref": "http://redfish.dmtf.org/schemas/v1/odata-v4.json#/definitions/type"
+                },
+                "Actions": {
+                    "$ref": "#/definitions/Actions",
+                    "description": "The available actions for this resource.",
+                    "longDescription": "The actions property shall contain the available actions for this resource."
+                },
+                "BootTimeStatistics": {
+                    "$ref": "#/definitions/BootTimeStatistics",
+                    "description": "The boot time statistics of the manager.",
+                    "longDescription": "This property shall contain the boot time statistics of the manager."
+                },
+                "Description": {
+                    "anyOf": [
+                        {
+                            "$ref": "http://redfish.dmtf.org/schemas/v1/Resource.json#/definitions/Description"
+                        },
+                        {
+                            "type": "null"
+                        }
+                    ],
+                    "readonly": true
+                },
+                "FreeStorageSpaceKiB": {
+                    "description": "The available storage space on this manager in kibibytes (KiB).",
+                    "longDescription": "This property shall contain the available storage space on this manager in kibibytes (KiB).",
+                    "readonly": true,
+                    "type": [
+                        "integer",
+                        "null"
+                    ],
+                    "units": "KiBy"
+                },
+                "I2CBuses": {
+                    "description": "The statistics of the I2C buses.",
+                    "items": {
+                        "$ref": "#/definitions/I2CBusStatistics"
+                    },
+                    "longDescription": "This property shall contain the statistics of the I2C buses.  Services may subdivide a physical bus into multiple entries in this property based on how the manager tracks bus segments, virtual buses from a controller, and other segmentation capabilities.",
+                    "type": "array"
+                },
+                "Id": {
+                    "$ref": "http://redfish.dmtf.org/schemas/v1/Resource.json#/definitions/Id",
+                    "readonly": true
+                },
+                "MemoryECCStatistics": {
+                    "$ref": "#/definitions/MemoryECCStatistics",
+                    "description": "The memory ECC statistics of the manager.",
+                    "longDescription": "This property shall contain the memory ECC statistics of the manager."
+                },
+                "MemoryStatistics": {
+                    "$ref": "#/definitions/MemoryStatistics",
+                    "description": "The memory statistics of the manager.",
+                    "longDescription": "This property shall contain the memory statistics of the manager."
+                },
+                "Name": {
+                    "$ref": "http://redfish.dmtf.org/schemas/v1/Resource.json#/definitions/Name",
+                    "readonly": true
+                },
+                "Oem": {
+                    "$ref": "http://redfish.dmtf.org/schemas/v1/Resource.json#/definitions/Oem",
+                    "description": "The OEM extension property.",
+                    "longDescription": "This property shall contain the OEM extensions.  All values for properties that this object contains shall conform to the Redfish Specification-described requirements."
+                },
+                "ProcessorStatistics": {
+                    "$ref": "#/definitions/ProcessorStatistics",
+                    "description": "The processor statistics of the manager.",
+                    "longDescription": "This property shall contain the processor statistics of the manager."
+                },
+                "TopProcesses": {
+                    "description": "The statistics of the top processes of this manager.",
+                    "items": {
+                        "anyOf": [
+                            {
+                                "$ref": "#/definitions/ProcessStatistics"
+                            },
+                            {
+                                "type": "null"
+                            }
+                        ]
+                    },
+                    "longDescription": "This property shall contain the statistics of the top processes of this manager.",
+                    "type": "array"
+                }
+            },
+            "required": [
+                "@odata.id",
+                "@odata.type",
+                "Id",
+                "Name"
+            ],
+            "type": "object"
+        },
+        "MemoryECCStatistics": {
+            "additionalProperties": false,
+            "description": "The memory ECC statistics of a manager.",
+            "longDescription": "This object shall contain the memory ECC statistics of a manager.",
+            "patternProperties": {
+                "^([a-zA-Z_][a-zA-Z0-9_]*)?@(odata|Redfish|Message)\\.[a-zA-Z_][a-zA-Z0-9_]*$": {
+                    "description": "This property shall specify a valid odata or Redfish property.",
+                    "type": [
+                        "array",
+                        "boolean",
+                        "integer",
+                        "number",
+                        "null",
+                        "object",
+                        "string"
+                    ]
+                }
+            },
+            "properties": {
+                "CorrectableECCErrorCount": {
+                    "description": "The number of the correctable errors since reset.",
+                    "longDescription": "This property shall contain the number of correctable errors since reset.",
+                    "readonly": true,
+                    "type": [
+                        "integer",
+                        "null"
+                    ]
+                },
+                "UncorrectableECCErrorCount": {
+                    "description": "The number of the uncorrectable errors since reset.",
+                    "longDescription": "This property shall contain the number of uncorrectable errors since reset.",
+                    "readonly": true,
+                    "type": [
+                        "integer",
+                        "null"
+                    ]
+                }
+            },
+            "type": "object"
+        },
+        "MemoryStatistics": {
+            "additionalProperties": false,
+            "description": "The memory statistics of a manager.",
+            "longDescription": "This object shall contain the memory statistics of a manager.",
+            "patternProperties": {
+                "^([a-zA-Z_][a-zA-Z0-9_]*)?@(odata|Redfish|Message)\\.[a-zA-Z_][a-zA-Z0-9_]*$": {
+                    "description": "This property shall specify a valid odata or Redfish property.",
+                    "type": [
+                        "array",
+                        "boolean",
+                        "integer",
+                        "number",
+                        "null",
+                        "object",
+                        "string"
+                    ]
+                }
+            },
+            "properties": {
+                "AvailableBytes": {
+                    "description": "The amount of memory available in bytes for starting new processes without swapping.",
+                    "longDescription": "This property shall contain the amount of memory available in bytes for starting new processes without swapping.  This includes free memory and reclaimable cache and buffers.",
+                    "readonly": true,
+                    "type": [
+                        "integer",
+                        "null"
+                    ],
+                    "units": "By"
+                },
+                "BuffersAndCacheBytes": {
+                    "description": "The amount of memory used in bytes by kernel buffers, page caches, and slabs.",
+                    "longDescription": "This property shall contain the amount of memory used in bytes by kernel buffers, page caches, and slabs.",
+                    "readonly": true,
+                    "type": [
+                        "integer",
+                        "null"
+                    ],
+                    "units": "By"
+                },
+                "FreeBytes": {
+                    "description": "The amount of free memory in bytes.",
+                    "longDescription": "This property shall contain the amount of free memory in bytes.",
+                    "readonly": true,
+                    "type": [
+                        "integer",
+                        "null"
+                    ],
+                    "units": "By"
+                },
+                "SharedBytes": {
+                    "description": "The amount of shared memory in bytes.",
+                    "longDescription": "This property shall contain the amount of shared memory in bytes.  This includes things such as memory consumed by temporary filesystems.",
+                    "readonly": true,
+                    "type": [
+                        "integer",
+                        "null"
+                    ],
+                    "units": "By"
+                },
+                "TotalBytes": {
+                    "description": "The total amount of memory in bytes.",
+                    "longDescription": "This property shall contain the total amount of memory in bytes.",
+                    "readonly": true,
+                    "type": [
+                        "integer",
+                        "null"
+                    ],
+                    "units": "By"
+                },
+                "UsedBytes": {
+                    "description": "The amount of used memory in bytes.",
+                    "longDescription": "This property shall contain the amount of used memory in bytes.  This value is calculated as TotalBytes minus FreeBytes minus BuffersAndCacheBytes.",
+                    "readonly": true,
+                    "type": [
+                        "integer",
+                        "null"
+                    ],
+                    "units": "By"
+                }
+            },
+            "type": "object"
+        },
+        "OemActions": {
+            "additionalProperties": true,
+            "description": "The available OEM-specific actions for this resource.",
+            "longDescription": "This type shall contain the available OEM-specific actions for this resource.",
+            "patternProperties": {
+                "^([a-zA-Z_][a-zA-Z0-9_]*)?@(odata|Redfish|Message)\\.[a-zA-Z_][a-zA-Z0-9_]*$": {
+                    "description": "This property shall specify a valid odata or Redfish property.",
+                    "type": [
+                        "array",
+                        "boolean",
+                        "integer",
+                        "number",
+                        "null",
+                        "object",
+                        "string"
+                    ]
+                }
+            },
+            "properties": {},
+            "type": "object"
+        },
+        "ProcessStatistics": {
+            "additionalProperties": false,
+            "description": "The statistics of a process running on a manager.",
+            "longDescription": "This object shall contain the statistics of a process running on a manager.",
+            "patternProperties": {
+                "^([a-zA-Z_][a-zA-Z0-9_]*)?@(odata|Redfish|Message)\\.[a-zA-Z_][a-zA-Z0-9_]*$": {
+                    "description": "This property shall specify a valid odata or Redfish property.",
+                    "type": [
+                        "array",
+                        "boolean",
+                        "integer",
+                        "number",
+                        "null",
+                        "object",
+                        "string"
+                    ]
+                }
+            },
+            "properties": {
+                "CommandLine": {
+                    "description": "The command line of this process.",
+                    "longDescription": "This property shall contain the command line with parameters of this process.",
+                    "readonly": true,
+                    "type": "string"
+                },
+                "KernelTimeSeconds": {
+                    "description": "The number of seconds this process executed in kernel space.",
+                    "longDescription": "This property shall contain the number of seconds this process executed in kernel space.",
+                    "readonly": true,
+                    "type": [
+                        "number",
+                        "null"
+                    ]
+                },
+                "ResidentSetSizeBytes": {
+                    "description": "The resident set size of this process in bytes.",
+                    "longDescription": "This property shall contain the resident set size of this process in bytes, which is the amount of memory allocated to the process and is in RAM.",
+                    "readonly": true,
+                    "type": [
+                        "integer",
+                        "null"
+                    ],
+                    "units": "By"
+                },
+                "UserTimeSeconds": {
+                    "description": "The number of seconds this process executed in user space.",
+                    "longDescription": "This property shall contain the number of seconds this process executed in user space.",
+                    "readonly": true,
+                    "type": [
+                        "number",
+                        "null"
+                    ]
+                }
+            },
+            "type": "object"
+        },
+        "ProcessorStatistics": {
+            "additionalProperties": false,
+            "description": "The processor statistics of a manager.",
+            "longDescription": "This object shall contain the processor statistics of a manager.",
+            "patternProperties": {
+                "^([a-zA-Z_][a-zA-Z0-9_]*)?@(odata|Redfish|Message)\\.[a-zA-Z_][a-zA-Z0-9_]*$": {
+                    "description": "This property shall specify a valid odata or Redfish property.",
+                    "type": [
+                        "array",
+                        "boolean",
+                        "integer",
+                        "number",
+                        "null",
+                        "object",
+                        "string"
+                    ]
+                }
+            },
+            "properties": {
+                "KernelPercent": {
+                    "description": "The percentage of CPU time spent in kernel mode.",
+                    "longDescription": "This property shall contain the percentage of CPU time spent in kernel mode.",
+                    "readonly": true,
+                    "type": [
+                        "number",
+                        "null"
+                    ],
+                    "units": "%"
+                },
+                "UserPercent": {
+                    "description": "The percentage of CPU time spent in user mode.",
+                    "longDescription": "This property shall contain the percentage of CPU time spent in user mode.",
+                    "readonly": true,
+                    "type": [
+                        "number",
+                        "null"
+                    ],
+                    "units": "%"
+                }
+            },
+            "type": "object"
+        },
+        "ResetMetrics": {
+            "additionalProperties": false,
+            "description": "Resets time intervals or counted values of the diagnostic data for this manager.",
+            "longDescription": "This action shall reset any time intervals or counted values of the diagnostic data for this manager.",
+            "parameters": {},
+            "patternProperties": {
+                "^([a-zA-Z_][a-zA-Z0-9_]*)?@(odata|Redfish|Message)\\.[a-zA-Z_][a-zA-Z0-9_]*$": {
+                    "description": "This property shall specify a valid odata or Redfish property.",
+                    "type": [
+                        "array",
+                        "boolean",
+                        "integer",
+                        "number",
+                        "null",
+                        "object",
+                        "string"
+                    ]
+                }
+            },
+            "properties": {
+                "target": {
+                    "description": "Link to invoke action",
+                    "format": "uri-reference",
+                    "type": "string"
+                },
+                "title": {
+                    "description": "Friendly action name",
+                    "type": "string"
+                }
+            },
+            "type": "object"
+        }
+    },
+    "owningEntity": "DMTF",
+    "release": "2021.4",
+    "title": "#ManagerDiagnosticData.v1_0_0.ManagerDiagnosticData"
+}

--- a/static/redfish/v1/JsonSchemas/ManagerDiagnosticData/index.json
+++ b/static/redfish/v1/JsonSchemas/ManagerDiagnosticData/index.json
@@ -1,0 +1,21 @@
+{
+    "@odata.context": "/redfish/v1/$metadata#JsonSchemaFile.JsonSchemaFile",
+    "@odata.id": "/redfish/v1/JsonSchemas/ManagerDiagnosticData",
+    "@odata.type": "#JsonSchemaFile.v1_0_2.JsonSchemaFile",
+    "Name": "ManagerDiagnosticData Schema File",
+    "Schema": "#ManagerDiagnosticData.ManagerDiagnosticData",
+    "Description": "ManagerDiagnosticData Schema File Location",
+    "Id": "ManagerDiagnosticData",
+    "Languages": [
+        "en"
+    ],
+    "Languages@odata.count": 1,
+    "Location": [
+        {
+            "Language": "en",
+            "PublicationUri": "http://redfish.dmtf.org/schemas/v1/ManagerDiagnosticData.json",
+            "Uri": "/redfish/v1/JsonSchemas/ManagerDiagnosticData/ManagerDiagnosticData.json"
+        }
+    ],
+    "Location@odata.count": 1
+}

--- a/static/redfish/v1/JsonSchemas/NetworkAdapter/NetworkAdapter.json
+++ b/static/redfish/v1/JsonSchemas/NetworkAdapter/NetworkAdapter.json
@@ -1,5 +1,5 @@
 {
-    "$id": "http://redfish.dmtf.org/schemas/v1/NetworkAdapter.v1_8_0.json",
+    "$id": "http://redfish.dmtf.org/schemas/v1/NetworkAdapter.v1_9_0.json",
     "$ref": "#/definitions/NetworkAdapter",
     "$schema": "http://redfish.dmtf.org/schemas/v1/redfish-schema-v1.json",
     "copyright": "Copyright 2014-2021 DMTF. For the full DMTF copyright policy, see http://www.dmtf.org/about/policies/copyright",
@@ -418,13 +418,15 @@
                     ]
                 },
                 "Measurements": {
+                    "deprecated": "This property has been deprecated in favor of the ComponentIntegrity resource.",
                     "description": "An array of DSP0274-defined measurement blocks.",
                     "items": {
                         "$ref": "http://redfish.dmtf.org/schemas/v1/SoftwareInventory.json#/definitions/MeasurementBlock"
                     },
                     "longDescription": "This property shall contain an array of DSP0274-defined measurement blocks.",
                     "type": "array",
-                    "versionAdded": "v1_6_0"
+                    "versionAdded": "v1_6_0",
+                    "versionDeprecated": "v1_9_0"
                 },
                 "Metrics": {
                     "anyOf": [
@@ -736,6 +738,6 @@
         }
     },
     "owningEntity": "DMTF",
-    "release": "2021.2",
-    "title": "#NetworkAdapter.v1_8_0.NetworkAdapter"
+    "release": "2021.4",
+    "title": "#NetworkAdapter.v1_9_0.NetworkAdapter"
 }

--- a/static/redfish/v1/JsonSchemas/NetworkDeviceFunction/NetworkDeviceFunction.json
+++ b/static/redfish/v1/JsonSchemas/NetworkDeviceFunction/NetworkDeviceFunction.json
@@ -1,5 +1,5 @@
 {
-    "$id": "http://redfish.dmtf.org/schemas/v1/NetworkDeviceFunction.v1_7_0.json",
+    "$id": "http://redfish.dmtf.org/schemas/v1/NetworkDeviceFunction.v1_8_0.json",
     "$ref": "#/definitions/NetworkDeviceFunction",
     "$schema": "http://redfish.dmtf.org/schemas/v1/redfish-schema-v1.json",
     "copyright": "Copyright 2014-2021 DMTF. For the full DMTF copyright policy, see http://www.dmtf.org/about/policies/copyright",
@@ -850,10 +850,12 @@
                 },
                 "PhysicalNetworkPortAssignment": {
                     "$ref": "http://redfish.dmtf.org/schemas/v1/Port.json#/definitions/Port",
+                    "deprecated": "This property has been deprecated in favor of PhysicalNetworkPortAssignment within Links to avoid loops on expand.",
                     "description": "The physical port to which this network device function is currently assigned.",
                     "longDescription": "This property shall contain a link to a resource of type Port that is the physical port to which this network device function is currently assigned.  This value shall be one of the AssignablePhysicalNetworkPorts array members.",
                     "readonly": true,
-                    "versionAdded": "v1_5_0"
+                    "versionAdded": "v1_5_0",
+                    "versionDeprecated": "v1_8_0"
                 },
                 "PhysicalPortAssignment": {
                     "$ref": "http://redfish.dmtf.org/schemas/v1/NetworkPort.json#/definitions/NetworkPort",
@@ -1234,6 +1236,6 @@
         }
     },
     "owningEntity": "DMTF",
-    "release": "2021.2",
-    "title": "#NetworkDeviceFunction.v1_7_0.NetworkDeviceFunction"
+    "release": "2021.4",
+    "title": "#NetworkDeviceFunction.v1_8_0.NetworkDeviceFunction"
 }

--- a/static/redfish/v1/JsonSchemas/OemServiceRoot/index.json
+++ b/static/redfish/v1/JsonSchemas/OemServiceRoot/index.json
@@ -1,0 +1,96 @@
+{
+    "$id": "http://redfish.dmtf.org/schemas/v1/OemServiceRoot.json",
+    "$schema": "http://redfish.dmtf.org/schemas/v1/redfish-schema-v1.json",
+    "copyright": "Copyright 2014-2019 DMTF. For the full DMTF copyright policy, see http://www.dmtf.org/about/policies/copyright",
+    "definitions": {
+        "Oem": {
+            "additionalProperties": true,
+            "description": "OemServiceRoot Oem properties.",
+            "patternProperties": {
+                "^([a-zA-Z_][a-zA-Z0-9_]*)?@(odata|Redfish|Message)\\.[a-zA-Z_][a-zA-Z0-9_]*$": {
+                    "description": "This property shall specify a valid odata or Redfish property.",
+                    "type": [
+                        "null",
+                        "string"
+                    ]
+                }
+            },
+            "properties": {
+                "IBM": {
+                    "anyOf": [
+                        {
+                            "$ref": "#/definitions/IBM"
+                        },
+                        {
+                            "type": "null"
+                        }
+                    ]
+                }
+
+            },
+            "type": "object"
+        },
+        "IBM": {
+            "additionalProperties": true,
+            "description": "Oem properties for IBM.",
+            "patternProperties": {
+                "^([a-zA-Z_][a-zA-Z0-9_]*)?@(odata|Redfish|Message)\\.[a-zA-Z_][a-zA-Z0-9_]*$": {
+                    "description": "This property shall specify a valid odata or Redfish property.",
+                    "type": [
+                        "array",
+                        "boolean",
+                        "integer",
+                        "number",
+                        "null",
+                        "object",
+                        "string"
+                    ]
+                }
+            },
+            "properties": {
+                "Model": {
+                    "description": "The product name for this system, without the manufacturer name.",
+                    "longDescription": "This property shall describe how the manufacturer refers to this system.  Typically, this value is the product name for this system without the manufacturer name.",
+                    "readonly": true,
+                    "type": [
+                        "string",
+                        "null"
+                    ]
+                },
+                "SerialNumber": {
+                    "description": "The serial number for this system.",
+                    "longDescription": "This property shall contain the serial number for the system.",
+                    "readonly": true,
+                    "type": [
+                        "string",
+                        "null"
+                    ]
+                },
+                "DateTime": {
+                    "description": "The current date and time with UTC offset of the manager.",
+                    "format": "date-time",
+                    "longDescription": "This property shall contain the current date and time with UTC offset of the manager.",
+                    "readonly": false,
+                    "type": [
+                        "string",
+                        "null"
+                    ]
+                },
+                "DateTimeLocalOffset": {
+                    "description": "The time offset from UTC that the DateTime property is in `+HH:MM` format.",
+                    "longDescription": "This property shall contain the offset from UTC time that the DateTime property contains.  If both DateTime and DateTimeLocalOffset are provided in modification requests, services shall apply DateTimeLocalOffset after DateTime is applied.",
+                    "pattern": "^([-+][0-1][0-9]:[0-5][0-9])$",
+                    "readonly": false,
+                    "type": [
+                        "string",
+                        "null"
+                    ]
+                }
+            },
+            "type": "object"
+        }
+    },
+    "owningEntity": "IBM",
+    "release": "1.0",
+    "title": "#OemServiceRoot"
+}

--- a/static/redfish/v1/JsonSchemas/Outlet/Outlet.json
+++ b/static/redfish/v1/JsonSchemas/Outlet/Outlet.json
@@ -1,5 +1,5 @@
 {
-    "$id": "http://redfish.dmtf.org/schemas/v1/Outlet.v1_3_0.json",
+    "$id": "http://redfish.dmtf.org/schemas/v1/Outlet.v1_4_0.json",
     "$ref": "#/definitions/Outlet",
     "$schema": "http://redfish.dmtf.org/schemas/v1/redfish-schema-v1.json",
     "copyright": "Copyright 2014-2021 DMTF. For the full DMTF copyright policy, see http://www.dmtf.org/about/policies/copyright",
@@ -65,9 +65,9 @@
                             "type": "null"
                         }
                     ],
-                    "description": "Line 1 current sensor.",
+                    "description": "Line 1 current (A).",
                     "excerptCopy": "SensorCurrentExcerpt",
-                    "longDescription": "This property shall contain a Sensor excerpt of type Current that measures current for L1.  This property shall not be present if the outlet does not include an L1 measurement."
+                    "longDescription": "This property shall contain the line current, in ampere units, for L1.  The value of the DataSourceUri property, if present, shall reference a resource of type Sensor with the ReadingType property containing the value `Current`.  This property shall not be present if the equipment does not include an L1 measurement."
                 },
                 "Line2": {
                     "anyOf": [
@@ -78,9 +78,9 @@
                             "type": "null"
                         }
                     ],
-                    "description": "Line 2 current sensor.",
+                    "description": "Line 2 current (A).",
                     "excerptCopy": "SensorCurrentExcerpt",
-                    "longDescription": "This property shall contain a Sensor excerpt of type Current that measures current for L2.  This property shall not be present if the outlet does not include an L2 measurement."
+                    "longDescription": "This property shall contain the line current, in ampere units, for L2.  The value of the DataSourceUri property, if present, shall reference a resource of type Sensor with the ReadingType property containing the value `Current`.  This property shall not be present if the equipment does not include an L2 measurement."
                 },
                 "Line3": {
                     "anyOf": [
@@ -91,9 +91,9 @@
                             "type": "null"
                         }
                     ],
-                    "description": "Line 3 current sensor.",
+                    "description": "Line 3 current (A).",
                     "excerptCopy": "SensorCurrentExcerpt",
-                    "longDescription": "This property shall contain a Sensor excerpt of type Current that measures current for L3.  This property shall not be present if the outlet does not include an L3 measurement."
+                    "longDescription": "This property shall contain the line current, in ampere units, for L3.  The value of the DataSourceUri property, if present, shall reference a resource of type Sensor with the ReadingType property containing the value `Current`.  This property shall not be present if the equipment does not include an L3 measurement."
                 },
                 "Neutral": {
                     "anyOf": [
@@ -104,9 +104,9 @@
                             "type": "null"
                         }
                     ],
-                    "description": "Neutral line current sensor.",
+                    "description": "Neutral line current (A).",
                     "excerptCopy": "SensorCurrentExcerpt",
-                    "longDescription": "This property shall contain a Sensor excerpt of type Current that measures current for the Neutral line.  This property shall not be present if the outlet does not include a Neutral measurement."
+                    "longDescription": "This property shall contain the line current, in ampere units, for the Neutral line.  The value of the DataSourceUri property, if present, shall reference a resource of type Sensor with the ReadingType property containing the value `Current`.  This property shall not be present if the equipment does not include a Neutral line measurement."
                 }
             },
             "type": "object"
@@ -247,6 +247,13 @@
                     "description": "The available actions for this resource.",
                     "longDescription": "This property shall contain the available actions for this resource."
                 },
+                "ConfigurationLocked": {
+                    "description": "Indicates whether the configuration is locked.",
+                    "longDescription": "This property shall indicate whether modification requests to this resource are not permitted.  If `true`, services shall reject modification requests to other properties in this resource.",
+                    "readonly": false,
+                    "type": "boolean",
+                    "versionAdded": "v1_4_0"
+                },
                 "CurrentAmps": {
                     "anyOf": [
                         {
@@ -256,9 +263,9 @@
                             "type": "null"
                         }
                     ],
-                    "description": "The current reading for this single phase outlet.",
+                    "description": "The current (A) for this single phase outlet.",
                     "excerptCopy": "SensorCurrentExcerpt",
-                    "longDescription": "This property shall contain the current, measured in Amperes, for this single phase outlet.  This property shall not appear in resource instances representing poly-phase outlets."
+                    "longDescription": "This property shall contain the current, in ampere units, for this single phase outlet.  The value of the DataSourceUri property, if present, shall reference a resource of type Sensor with the ReadingType property containing the value `Current`.  This property shall not appear in resource instances representing poly-phase outlets."
                 },
                 "Description": {
                     "anyOf": [
@@ -306,9 +313,9 @@
                             "type": "null"
                         }
                     ],
-                    "description": "The energy reading for this outlet.",
+                    "description": "The energy (kWh) for this outlet.",
                     "excerptCopy": "SensorEnergykWhExcerpt",
-                    "longDescription": "This property shall contain the total energy, measured in kilowatt-hours (kW.h), for this outlet, that represents the `Total` ElectricalContext sensor when multiple energy sensors exist for this outlet."
+                    "longDescription": "This property shall contain the total energy, in kilowatt-hour units, for this outlet, that represents the `Total` ElectricalContext sensor when multiple energy sensors exist for this outlet.  The value of the DataSourceUri property, if present, shall reference a resource of type Sensor with the ReadingType property containing the value `EnergykWh`."
                 },
                 "FrequencyHz": {
                     "anyOf": [
@@ -319,9 +326,9 @@
                             "type": "null"
                         }
                     ],
-                    "description": "The frequency reading for this outlet.",
+                    "description": "The frequency (Hz) for this outlet.",
                     "excerptCopy": "SensorExcerpt",
-                    "longDescription": "This property shall contain the frequency sensor for this outlet."
+                    "longDescription": "This property shall contain the frequency, in hertz units, for this outlet.  The value of the DataSourceUri property, if present, shall reference a resource of type Sensor with the ReadingType property containing the value `Frequency`."
                 },
                 "Id": {
                     "$ref": "http://redfish.dmtf.org/schemas/v1/Resource.json#/definitions/Id",
@@ -415,7 +422,7 @@
                         }
                     ],
                     "description": "The current readings for this outlet.",
-                    "longDescription": "This property shall contain the current sensor(s) for this outlet.  For single phase outlets this property shall contain a duplicate copy of the current sensor referenced in the CurrentSensor property, if present.  For poly-phase outlets this property should contain multiple current sensor readings used to fully describe the outlet."
+                    "longDescription": "This property shall contain the current readings for this outlet.  For single phase outlets this property shall contain a duplicate copy of the current sensor referenced in the CurrentAmps property, if present.  For poly-phase outlets this property should contain multiple current sensor readings used to fully describe the outlet."
                 },
                 "PolyPhaseVoltage": {
                     "anyOf": [
@@ -427,7 +434,14 @@
                         }
                     ],
                     "description": "The voltage readings for this outlet.",
-                    "longDescription": "This property shall contain the voltage sensor(s) for this outlet.  For single phase outlets this property shall contain a duplicate copy of the voltage sensor referenced in the VoltageSensor property, if present.  For poly-phase outlets this property should contain multiple voltage sensor readings used to fully describe the outlet."
+                    "longDescription": "This property shall contain the voltage readings for this outlet.  For single phase outlets this property shall contain a duplicate copy of the voltage sensor referenced in the Voltage property, if present.  For poly-phase outlets this property should contain multiple voltage sensor readings used to fully describe the outlet."
+                },
+                "PowerControlLocked": {
+                    "description": "Indicates whether power control requests are locked.",
+                    "longDescription": "This property shall indicate whether requests to the PowerControl action are locked.  If `true`, services shall reject requests to the PowerControl action.",
+                    "readonly": false,
+                    "type": "boolean",
+                    "versionAdded": "v1_4_0"
                 },
                 "PowerCycleDelaySeconds": {
                     "description": "The number of seconds to delay power on after a PowerControl action to cycle power.  Zero seconds indicates no delay.",
@@ -456,9 +470,9 @@
                             "type": "null"
                         }
                     ],
-                    "description": "The power load (%) for this outlet.",
+                    "description": "The power load (percent) for this outlet.",
                     "excerptCopy": "SensorExcerpt",
-                    "longDescription": "This property shall contain the power load, measured in percent, for this outlet, that represents the `Total` ElectricalContext for this outlet.",
+                    "longDescription": "This property shall contain the power load, in percent units, for this outlet, that represents the `Total` ElectricalContext for this outlet.  The value of the DataSourceUri property, if present, shall reference a resource of type Sensor with the ReadingType property containing the value `Percent`.",
                     "versionAdded": "v1_2_0"
                 },
                 "PowerOffDelaySeconds": {
@@ -507,6 +521,13 @@
                     "longDescription": "This property shall contain the power state of the outlet.",
                     "readonly": true
                 },
+                "PowerStateInTransition": {
+                    "description": "Indicates whether the power state is undergoing a delayed transition.",
+                    "longDescription": "This property shall indicate whether the PowerState property will undergo a transition between on and off states due to a configured delay.  The transition may be due to the configuration of the power on, off, or restore delay properties.  If `true`, the PowerState property will transition at the conclusion of a configured delay.",
+                    "readonly": true,
+                    "type": "boolean",
+                    "versionAdded": "v1_4_0"
+                },
                 "PowerWatts": {
                     "anyOf": [
                         {
@@ -516,13 +537,13 @@
                             "type": "null"
                         }
                     ],
-                    "description": "The power reading for this outlet.",
+                    "description": "The power (W) for this outlet.",
                     "excerptCopy": "SensorPowerExcerpt",
-                    "longDescription": "This property shall contain the total power, measured in Watts, for this outlet, that represents the `Total` ElectricalContext sensor when multiple power sensors exist for this outlet."
+                    "longDescription": "This property shall contain the total power, in watt units, for this outlet, that represents the `Total` ElectricalContext sensor when multiple power sensors exist for this outlet.  The value of the DataSourceUri property, if present, shall reference a resource of type Sensor with the ReadingType property containing the value `Power`."
                 },
                 "RatedCurrentAmps": {
                     "description": "The rated maximum current allowed for this outlet.",
-                    "longDescription": "This property shall contain the rated maximum current for this outlet, in Amps, after any required de-rating, due to safety agency or other regulatory requirements, has been applied.",
+                    "longDescription": "This property shall contain the rated maximum current for this outlet, in ampere units, after any required de-rating, due to safety agency or other regulatory requirements, has been applied.",
                     "minimum": 0,
                     "readonly": true,
                     "type": [
@@ -552,9 +573,9 @@
                             "type": "null"
                         }
                     ],
-                    "description": "The voltage reading for this single phase outlet.",
+                    "description": "The voltage (V) for this single phase outlet.",
                     "excerptCopy": "SensorVoltageExcerpt",
-                    "longDescription": "This property shall contain the voltage, measured in Volts, for this single phase outlet.  This property shall not appear in resource instances representing poly-phase outlets."
+                    "longDescription": "This property shall contain the voltage, in volt units, for this single phase outlet.  The value of the DataSourceUri property, if present, shall reference a resource of type Sensor with the ReadingType property containing the value `Voltage`.  This property shall not appear in resource instances representing poly-phase outlets."
                 },
                 "VoltageType": {
                     "anyOf": [
@@ -676,9 +697,9 @@
                             "type": "null"
                         }
                     ],
-                    "description": "The Line 1 to Line 2 voltage reading for this outlet.",
+                    "description": "The Line 1 to Line 2 voltage (V) for this outlet.",
                     "excerptCopy": "SensorVoltageExcerpt",
-                    "longDescription": "This property shall contain a Sensor excerpt of type Voltage that measures voltage between L1 and L2.  This property shall not be present if the outlet does not include an L1-L2 measurement."
+                    "longDescription": "This property shall contain the line-to-line voltage, in volt units, between L1 and L2.  The value of the DataSourceUri property, if present, shall reference a resource of type Sensor with the ReadingType property containing the value `Voltage`.  This property shall not be present if the equipment does not include an L1-L2 measurement."
                 },
                 "Line1ToNeutral": {
                     "anyOf": [
@@ -689,9 +710,9 @@
                             "type": "null"
                         }
                     ],
-                    "description": "The Line 1 to Neutral voltage reading for this outlet.",
+                    "description": "The Line 1 to Neutral voltage (V) for this outlet.",
                     "excerptCopy": "SensorVoltageExcerpt",
-                    "longDescription": "This property shall contain a Sensor excerpt of type Voltage that measures voltage between L1 and Neutral.  This property shall not be present if the outlet does not include an L1-Neutral measurement."
+                    "longDescription": "This property shall contain the line-to-line voltage, in volt units, between L1 and Neutral.  The value of the DataSourceUri property, if present, shall reference a resource of type Sensor with the ReadingType property containing the value `Voltage`.  This property shall not be present if the equipment does not include an L1-Neutral measurement."
                 },
                 "Line2ToLine3": {
                     "anyOf": [
@@ -702,9 +723,9 @@
                             "type": "null"
                         }
                     ],
-                    "description": "The Line 2 to Line 3 voltage reading for this outlet.",
+                    "description": "The Line 2 to Line 3 voltage (V) for this outlet.",
                     "excerptCopy": "SensorVoltageExcerpt",
-                    "longDescription": "This property shall contain a Sensor excerpt of type Voltage that measures voltage between L2 and L3.  This property shall not be present if the outlet does not include an L2-L3 measurement."
+                    "longDescription": "This property shall contain the line-to-line voltage, in volt units, between L2 and L3.  The value of the DataSourceUri property, if present, shall reference a resource of type Sensor with the ReadingType property containing the value `Voltage`.  This property shall not be present if the equipment does not include an L2-L3 measurement."
                 },
                 "Line2ToNeutral": {
                     "anyOf": [
@@ -715,9 +736,9 @@
                             "type": "null"
                         }
                     ],
-                    "description": "The Line 2 to Neutral voltage reading for this outlet.",
+                    "description": "The Line 2 to Neutral voltage (V) for this outlet.",
                     "excerptCopy": "SensorVoltageExcerpt",
-                    "longDescription": "This property shall contain a Sensor excerpt of type Voltage that measures voltage between L2 and Neutral.  This property shall not be present if the outlet does not include an L2-Neutral measurement."
+                    "longDescription": "This property shall contain the line-to-line voltage, in volt units, between L2 and Neutral.  The value of the DataSourceUri property, if present, shall reference a resource of type Sensor with the ReadingType property containing the value `Voltage`.  This property shall not be present if the equipment does not include an L2-Neutral measurement."
                 },
                 "Line3ToLine1": {
                     "anyOf": [
@@ -728,9 +749,9 @@
                             "type": "null"
                         }
                     ],
-                    "description": "The Line 3 to Line 1 voltage reading for this outlet.",
+                    "description": "The Line 3 to Line 1 voltage (V) for this outlet.",
                     "excerptCopy": "SensorVoltageExcerpt",
-                    "longDescription": "This property shall contain a Sensor excerpt of type Voltage that measures voltage between L3 and L1.  This property shall not be present if the outlet does not include an L3-L1 measurement."
+                    "longDescription": "This property shall contain the line-to-line voltage, in volt units, between L3 and L1.  The value of the DataSourceUri property, if present, shall reference a resource of type Sensor with the ReadingType property containing the value `Voltage`.  This property shall not be present if the equipment does not include an L3-L1 measurement."
                 },
                 "Line3ToNeutral": {
                     "anyOf": [
@@ -741,9 +762,9 @@
                             "type": "null"
                         }
                     ],
-                    "description": "The Line 3 to Neutral voltage reading for this outlet.",
+                    "description": "The Line 3 to Neutral voltage (V) for this outlet.",
                     "excerptCopy": "SensorVoltageExcerpt",
-                    "longDescription": "This property shall contain a Sensor excerpt of type Voltage that measures voltage between L3 and Neutral.  This property shall not be present if the outlet does not include an L3-Neutral measurement."
+                    "longDescription": "This property shall contain the line-to-line voltage, in volt units, between L3 and Neutral.  The value of the DataSourceUri property, if present, shall reference a resource of type Sensor with the ReadingType property containing the value `Voltage`.  This property shall not be present if the equipment does not include an L3-Neutral measurement."
                 }
             },
             "type": "object"
@@ -761,6 +782,6 @@
         }
     },
     "owningEntity": "DMTF",
-    "release": "2021.3",
-    "title": "#Outlet.v1_3_0.Outlet"
+    "release": "2021.4",
+    "title": "#Outlet.v1_4_0.Outlet"
 }

--- a/static/redfish/v1/JsonSchemas/OutletGroup/OutletGroup.json
+++ b/static/redfish/v1/JsonSchemas/OutletGroup/OutletGroup.json
@@ -1,8 +1,8 @@
 {
-    "$id": "http://redfish.dmtf.org/schemas/v1/OutletGroup.v1_0_1.json",
+    "$id": "http://redfish.dmtf.org/schemas/v1/OutletGroup.v1_1_0.json",
     "$ref": "#/definitions/OutletGroup",
     "$schema": "http://redfish.dmtf.org/schemas/v1/redfish-schema-v1.json",
-    "copyright": "Copyright 2014-2020 DMTF. For the full DMTF copyright policy, see http://www.dmtf.org/about/policies/copyright",
+    "copyright": "Copyright 2014-2021 DMTF. For the full DMTF copyright policy, see http://www.dmtf.org/about/policies/copyright",
     "definitions": {
         "Actions": {
             "additionalProperties": false,
@@ -133,6 +133,13 @@
                     "description": "The available actions for this resource.",
                     "longDescription": "This property shall contain the available actions for this resource."
                 },
+                "ConfigurationLocked": {
+                    "description": "Indicates whether the configuration is locked.",
+                    "longDescription": "This property shall indicate whether modification requests to this resource are not permitted.  If `true`, services shall reject modification requests to other properties in this resource.",
+                    "readonly": false,
+                    "type": "boolean",
+                    "versionAdded": "v1_1_0"
+                },
                 "CreatedBy": {
                     "description": "The creator of this outlet group.",
                     "longDescription": "This property shall contain the name of the person or application that created this outlet group.",
@@ -162,10 +169,9 @@
                             "type": "null"
                         }
                     ],
-                    "description": "The energy reading for this outlet group.",
+                    "description": "The energy (kWh) for this outlet group.",
                     "excerptCopy": "SensorEnergykWhExcerpt",
-                    "longDescription": "This property shall contain the total energy, measured in kilowatt-hours (kW.h), for this outlet group, that represents the `Total` ElectricalContext sensor when multiple energy sensors exist for this outlet group.",
-                    "readonly": true
+                    "longDescription": "This property shall contain the total energy, in kilowatt-hour units, for this outlet group, that represents the `Total` ElectricalContext sensor when multiple energy sensors exist for this outlet group.  The value of the DataSourceUri property, if present, shall reference a resource of type Sensor with the ReadingType property containing the value `EnergykWh`."
                 },
                 "Id": {
                     "$ref": "http://redfish.dmtf.org/schemas/v1/Resource.json#/definitions/Id",
@@ -184,6 +190,13 @@
                     "$ref": "http://redfish.dmtf.org/schemas/v1/Resource.json#/definitions/Oem",
                     "description": "The OEM extension property.",
                     "longDescription": "This property shall contain the OEM extensions.  All values for properties that this object contains shall conform to the Redfish Specification-described requirements."
+                },
+                "PowerControlLocked": {
+                    "description": "Indicates whether power control requests are locked.",
+                    "longDescription": "This property shall indicate whether requests to the PowerControl action are locked.  If `true`, services shall reject requests to the PowerControl action.",
+                    "readonly": false,
+                    "type": "boolean",
+                    "versionAdded": "v1_1_0"
                 },
                 "PowerCycleDelaySeconds": {
                     "description": "The number of seconds to delay power on after a PowerControl action to cycle power.  Zero seconds indicates no delay.",
@@ -249,6 +262,13 @@
                     "longDescription": "This property shall contain the power state of the outlet group.",
                     "readonly": true
                 },
+                "PowerStateInTransition": {
+                    "description": "Indicates whether the power state is undergoing a delayed transition.",
+                    "longDescription": "This property shall indicate whether the PowerState property will undergo a transition between on and off states due to a configured delay.  The transition may be due to the configuration of the power on, off, or restore delay properties.  If `true`, the PowerState property will transition at the conclusion of a configured delay.",
+                    "readonly": true,
+                    "type": "boolean",
+                    "versionAdded": "v1_1_0"
+                },
                 "PowerWatts": {
                     "anyOf": [
                         {
@@ -258,10 +278,9 @@
                             "type": "null"
                         }
                     ],
-                    "description": "The power reading for this outlet group.",
+                    "description": "The power (W) for this outlet group.",
                     "excerptCopy": "SensorPowerExcerpt",
-                    "longDescription": "This property shall contain the total power, measured in Watts, for this outlet group, that represents the `Total` ElectricalContext sensor when multiple power sensors exist for this outlet group.",
-                    "readonly": true
+                    "longDescription": "This property shall contain the total power, in watt units, for this outlet group, that represents the `Total` ElectricalContext sensor when multiple power sensors exist for this outlet group.  The value of the DataSourceUri property, if present, shall reference a resource of type Sensor with the ReadingType property containing the value `Power`."
                 },
                 "Status": {
                     "$ref": "http://redfish.dmtf.org/schemas/v1/Resource.json#/definitions/Status",
@@ -349,6 +368,6 @@
         }
     },
     "owningEntity": "DMTF",
-    "release": "2019.4",
-    "title": "#OutletGroup.v1_0_1.OutletGroup"
+    "release": "2021.4",
+    "title": "#OutletGroup.v1_1_0.OutletGroup"
 }

--- a/static/redfish/v1/JsonSchemas/Port/Port.json
+++ b/static/redfish/v1/JsonSchemas/Port/Port.json
@@ -1,5 +1,5 @@
 {
-    "$id": "http://redfish.dmtf.org/schemas/v1/Port.v1_5_0.json",
+    "$id": "http://redfish.dmtf.org/schemas/v1/Port.v1_6_0.json",
     "$ref": "#/definitions/Port",
     "$schema": "http://redfish.dmtf.org/schemas/v1/redfish-schema-v1.json",
     "copyright": "Copyright 2014-2021 DMTF. For the full DMTF copyright policy, see http://www.dmtf.org/about/policies/copyright",
@@ -456,6 +456,70 @@
                 "PortComp": "Port component, based in the value of entPhysicalAlias in RFC4133."
             },
             "type": "string"
+        },
+        "InfiniBandProperties": {
+            "additionalProperties": false,
+            "description": "InfiniBand-specific properties for a port.",
+            "longDescription": "This type shall contain InfiniBand-specific properties for a port.",
+            "patternProperties": {
+                "^([a-zA-Z_][a-zA-Z0-9_]*)?@(odata|Redfish|Message)\\.[a-zA-Z_][a-zA-Z0-9_]*$": {
+                    "description": "This property shall specify a valid odata or Redfish property.",
+                    "type": [
+                        "array",
+                        "boolean",
+                        "integer",
+                        "number",
+                        "null",
+                        "object",
+                        "string"
+                    ]
+                }
+            },
+            "properties": {
+                "AssociatedNodeGUIDs": {
+                    "description": "An array of configured node GUIDs that are associated with this network port, including the programmed address of the lowest numbered network device function, the configured but not active address, if applicable, the address for hardware port teaming, or other network addresses.",
+                    "items": {
+                        "type": [
+                            "string",
+                            "null"
+                        ]
+                    },
+                    "longDescription": "This property shall contain an array of configured node GUIDs that are associated with this network port, including the programmed address of the lowest numbered network device function, the configured but not active address if applicable, the address for hardware port teaming, or other network addresses.",
+                    "pattern": "^([0-9A-Fa-f]{4}[:-]){3}([0-9A-Fa-f]{4})$",
+                    "readonly": true,
+                    "type": "array",
+                    "versionAdded": "v1_6_0"
+                },
+                "AssociatedPortGUIDs": {
+                    "description": "An array of configured port GUIDs that are associated with this network port, including the programmed address of the lowest numbered network device function, the configured but not active address, if applicable, the address for hardware port teaming, or other network addresses.",
+                    "items": {
+                        "type": [
+                            "string",
+                            "null"
+                        ]
+                    },
+                    "longDescription": "This property shall contain an array of configured port GUIDs that are associated with this network port, including the programmed address of the lowest numbered network device function, the configured but not active address if applicable, the address for hardware port teaming, or other network addresses.",
+                    "pattern": "^([0-9A-Fa-f]{4}[:-]){3}([0-9A-Fa-f]{4})$",
+                    "readonly": true,
+                    "type": "array",
+                    "versionAdded": "v1_6_0"
+                },
+                "AssociatedSystemGUIDs": {
+                    "description": "An array of configured system GUIDs that are associated with this network port, including the programmed address of the lowest numbered network device function, the configured but not active address, if applicable, the address for hardware port teaming, or other network addresses.",
+                    "items": {
+                        "type": [
+                            "string",
+                            "null"
+                        ]
+                    },
+                    "longDescription": "This property shall contain an array of configured system GUIDs that are associated with this network port, including the programmed address of the lowest numbered network device function, the configured but not active address if applicable, the address for hardware port teaming, or other network addresses.",
+                    "pattern": "^([0-9A-Fa-f]{4}[:-]){3}([0-9A-Fa-f]{4})$",
+                    "readonly": true,
+                    "type": "array",
+                    "versionAdded": "v1_6_0"
+                }
+            },
+            "type": "object"
         },
         "LLDPReceive": {
             "additionalProperties": false,
@@ -1078,6 +1142,19 @@
                     "$ref": "http://redfish.dmtf.org/schemas/v1/Resource.json#/definitions/Id",
                     "readonly": true
                 },
+                "InfiniBand": {
+                    "anyOf": [
+                        {
+                            "$ref": "#/definitions/InfiniBandProperties"
+                        },
+                        {
+                            "type": "null"
+                        }
+                    ],
+                    "description": "InfiniBand properties for this port.",
+                    "longDescription": "This property shall contain InfiniBand-specific properties of the port.",
+                    "versionAdded": "v1_6_0"
+                },
                 "InterfaceEnabled": {
                     "description": "An indication of whether the interface is enabled.",
                     "longDescription": "This property shall indicate whether the interface is enabled.",
@@ -1572,6 +1649,6 @@
         }
     },
     "owningEntity": "DMTF",
-    "release": "2021.2",
-    "title": "#Port.v1_5_0.Port"
+    "release": "2021.4",
+    "title": "#Port.v1_6_0.Port"
 }

--- a/static/redfish/v1/JsonSchemas/PowerDistribution/PowerDistribution.json
+++ b/static/redfish/v1/JsonSchemas/PowerDistribution/PowerDistribution.json
@@ -1,5 +1,5 @@
 {
-    "$id": "http://redfish.dmtf.org/schemas/v1/PowerDistribution.v1_2_0.json",
+    "$id": "http://redfish.dmtf.org/schemas/v1/PowerDistribution.v1_2_1.json",
     "$ref": "#/definitions/PowerDistribution",
     "$schema": "http://redfish.dmtf.org/schemas/v1/redfish-schema-v1.json",
     "copyright": "Copyright 2014-2021 DMTF. For the full DMTF copyright policy, see http://www.dmtf.org/about/policies/copyright",
@@ -560,8 +560,8 @@
             },
             "properties": {
                 "OverNominalFrequencyHz": {
-                    "description": "The frequency in Hertz over the nominal value that satisfies a criterion for transfer.",
-                    "longDescription": "This property shall contain the frequency in Hertz over the nominal value that satisfies a criterion for transfer.",
+                    "description": "The frequency in hertz over the nominal value that satisfies a criterion for transfer.",
+                    "longDescription": "This property shall contain the frequency in hertz over the nominal value that satisfies a criterion for transfer.",
                     "readonly": false,
                     "type": [
                         "number",
@@ -593,8 +593,8 @@
                     "readonly": false
                 },
                 "UnderNominalFrequencyHz": {
-                    "description": "The frequency in Hertz under the nominal value that satisfies a criterion for transfer.",
-                    "longDescription": "This property shall contain the frequency in Hertz under the nominal value that satisfies a criterion for transfer.",
+                    "description": "The frequency in hertz under the nominal value that satisfies a criterion for transfer.",
+                    "longDescription": "This property shall contain the frequency in hertz under the nominal value that satisfies a criterion for transfer.",
                     "readonly": false,
                     "type": [
                         "number",
@@ -631,5 +631,5 @@
     },
     "owningEntity": "DMTF",
     "release": "2021.3",
-    "title": "#PowerDistribution.v1_2_0.PowerDistribution"
+    "title": "#PowerDistribution.v1_2_1.PowerDistribution"
 }

--- a/static/redfish/v1/JsonSchemas/PowerDistributionMetrics/PowerDistributionMetrics.json
+++ b/static/redfish/v1/JsonSchemas/PowerDistributionMetrics/PowerDistributionMetrics.json
@@ -1,5 +1,5 @@
 {
-    "$id": "http://redfish.dmtf.org/schemas/v1/PowerDistributionMetrics.v1_2_0.json",
+    "$id": "http://redfish.dmtf.org/schemas/v1/PowerDistributionMetrics.v1_3_0.json",
     "$ref": "#/definitions/PowerDistributionMetrics",
     "$schema": "http://redfish.dmtf.org/schemas/v1/redfish-schema-v1.json",
     "copyright": "Copyright 2014-2021 DMTF. For the full DMTF copyright policy, see http://www.dmtf.org/about/policies/copyright",
@@ -86,6 +86,20 @@
                 "@odata.type": {
                     "$ref": "http://redfish.dmtf.org/schemas/v1/odata-v4.json#/definitions/type"
                 },
+                "AbsoluteHumidity": {
+                    "anyOf": [
+                        {
+                            "$ref": "http://redfish.dmtf.org/schemas/v1/Sensor.json#/definitions/SensorExcerpt"
+                        },
+                        {
+                            "type": "null"
+                        }
+                    ],
+                    "description": "Absolute humidity (g/cu m).",
+                    "excerptCopy": "SensorExcerpt",
+                    "longDescription": "This property shall contain the absolute (volumetric) humidity sensor reading, in grams/cubic meter units, for this resource.  The value of the DataSourceUri property, if present, shall reference a resource of type Sensor with the ReadingType property containing the value `AbsoluteHumidity`.",
+                    "versionAdded": "v1_3_0"
+                },
                 "Actions": {
                     "$ref": "#/definitions/Actions",
                     "description": "The available actions for this resource.",
@@ -113,7 +127,7 @@
                     ],
                     "description": "Energy consumption (kWh).",
                     "excerptCopy": "SensorEnergykWhExcerpt",
-                    "longDescription": "This property shall contain the total energy, measured in kilowatt-hours (kWh), for this unit, that represents the `Total` ElectricalContext sensor when multiple energy sensors exist."
+                    "longDescription": "This property shall contain the total energy, in kilowatt-hours, for this resource, that represents the `Total` ElectricalContext sensor when multiple energy sensors exist.  The value of the DataSourceUri property, if present, shall reference a resource of type Sensor with the ReadingType property containing the value `EnergykWh`."
                 },
                 "HumidityPercent": {
                     "anyOf": [
@@ -126,7 +140,7 @@
                     ],
                     "description": "Humidity (percent).",
                     "excerptCopy": "SensorExcerpt",
-                    "longDescription": "This property shall contain the humidity sensor reading for this resource.",
+                    "longDescription": "This property shall contain the humidity, in percent units, for this resource.  The value of the DataSourceUri property, if present, shall reference a resource of type Sensor with the ReadingType property containing the value `Humidity`.",
                     "versionAdded": "v1_1_0"
                 },
                 "Id": {
@@ -151,9 +165,9 @@
                             "type": "null"
                         }
                     ],
-                    "description": "The power load (%) for this equipment.",
+                    "description": "The power load (percent) for this equipment.",
                     "excerptCopy": "SensorExcerpt",
-                    "longDescription": "This property shall contain the power load, measured in percent, for this equipment, that represents the `Total` ElectricalContext for this equipment.",
+                    "longDescription": "This property shall contain the power load, in percent units, for this device, that represents the `Total` ElectricalContext for this device.  The value of the DataSourceUri property, if present, shall reference a resource of type Sensor with the ReadingType property containing the value `Percent`.",
                     "versionAdded": "v1_2_0"
                 },
                 "PowerWatts": {
@@ -165,9 +179,9 @@
                             "type": "null"
                         }
                     ],
-                    "description": "Power consumption (Watts).",
+                    "description": "Power consumption (W).",
                     "excerptCopy": "SensorPowerExcerpt",
-                    "longDescription": "This property shall contain the total power, measured in Watts, for this unit, that represents the `Total` ElectricalContext sensor when multiple power sensors exist."
+                    "longDescription": "This property shall contain the total power, in watt units, for this resource, that represents the `Total` ElectricalContext sensor when multiple power sensors exist.  The value of the DataSourceUri property, if present, shall reference a resource of type Sensor with the ReadingType property containing the value `Power`."
                 },
                 "TemperatureCelsius": {
                     "anyOf": [
@@ -180,7 +194,7 @@
                     ],
                     "description": "Temperature (Celsius).",
                     "excerptCopy": "SensorExcerpt",
-                    "longDescription": "This property shall contain the temperature sensor reading for this resource.",
+                    "longDescription": "This property shall contain the temperature, in degrees Celsius units, for this resource.  The value of the DataSourceUri property, if present, shall reference a resource of type Sensor with the ReadingType property containing the value `Temperature`.",
                     "versionAdded": "v1_1_0"
                 }
             },
@@ -226,6 +240,6 @@
         }
     },
     "owningEntity": "DMTF",
-    "release": "2021.2",
-    "title": "#PowerDistributionMetrics.v1_2_0.PowerDistributionMetrics"
+    "release": "2021.4",
+    "title": "#PowerDistributionMetrics.v1_3_0.PowerDistributionMetrics"
 }

--- a/static/redfish/v1/JsonSchemas/PowerSupply/PowerSupply.json
+++ b/static/redfish/v1/JsonSchemas/PowerSupply/PowerSupply.json
@@ -1,5 +1,5 @@
 {
-    "$id": "http://redfish.dmtf.org/schemas/v1/PowerSupply.v1_2_0.json",
+    "$id": "http://redfish.dmtf.org/schemas/v1/PowerSupply.v1_3_0.json",
     "$ref": "#/definitions/PowerSupply",
     "$schema": "http://redfish.dmtf.org/schemas/v1/redfish-schema-v1.json",
     "copyright": "Copyright 2014-2021 DMTF. For the full DMTF copyright policy, see http://www.dmtf.org/about/policies/copyright",
@@ -125,6 +125,19 @@
                 }
             },
             "type": "object"
+        },
+        "LineStatus": {
+            "enum": [
+                "Normal",
+                "LossOfInput",
+                "OutOfRange"
+            ],
+            "enumDescriptions": {
+                "LossOfInput": "No power detected at line input.",
+                "Normal": "Line input is within normal operating range.",
+                "OutOfRange": "Line input voltage or current is outside of normal operating range."
+            },
+            "type": "string"
         },
         "Links": {
             "additionalProperties": false,
@@ -368,6 +381,20 @@
                     "longDescription": "This property shall contain a collection of ranges usable by this power supply.",
                     "type": "array"
                 },
+                "LineInputStatus": {
+                    "anyOf": [
+                        {
+                            "$ref": "#/definitions/LineStatus"
+                        },
+                        {
+                            "type": "null"
+                        }
+                    ],
+                    "description": "The status of the line input.",
+                    "longDescription": "This property shall contain the status of the power line input for this power supply.",
+                    "readonly": true,
+                    "versionAdded": "v1_3_0"
+                },
                 "Links": {
                     "$ref": "#/definitions/Links",
                     "description": "The links to other resources that are related to this resource.",
@@ -593,6 +620,6 @@
         }
     },
     "owningEntity": "DMTF",
-    "release": "2021.3",
-    "title": "#PowerSupply.v1_2_0.PowerSupply"
+    "release": "2021.4",
+    "title": "#PowerSupply.v1_3_0.PowerSupply"
 }

--- a/static/redfish/v1/JsonSchemas/PowerSupplyMetrics/PowerSupplyMetrics.json
+++ b/static/redfish/v1/JsonSchemas/PowerSupplyMetrics/PowerSupplyMetrics.json
@@ -1,8 +1,8 @@
 {
-    "$id": "http://redfish.dmtf.org/schemas/v1/PowerSupplyMetrics.v1_0_0.json",
+    "$id": "http://redfish.dmtf.org/schemas/v1/PowerSupplyMetrics.v1_0_1.json",
     "$ref": "#/definitions/PowerSupplyMetrics",
     "$schema": "http://redfish.dmtf.org/schemas/v1/redfish-schema-v1.json",
-    "copyright": "Copyright 2014-2020 DMTF. For the full DMTF copyright policy, see http://www.dmtf.org/about/policies/copyright",
+    "copyright": "Copyright 2014-2021 DMTF. For the full DMTF copyright policy, see http://www.dmtf.org/about/policies/copyright",
     "definitions": {
         "Actions": {
             "additionalProperties": false,
@@ -34,126 +34,6 @@
             },
             "type": "object"
         },
-        "CurrentSensors": {
-            "additionalProperties": false,
-            "description": "The current sensors for this power supply.",
-            "longDescription": "This type shall contain properties that describe current sensor readings for a power supply.",
-            "patternProperties": {
-                "^([a-zA-Z_][a-zA-Z0-9_]*)?@(odata|Redfish|Message)\\.[a-zA-Z_][a-zA-Z0-9_]*$": {
-                    "description": "This property shall specify a valid odata or Redfish property.",
-                    "type": [
-                        "array",
-                        "boolean",
-                        "integer",
-                        "number",
-                        "null",
-                        "object",
-                        "string"
-                    ]
-                }
-            },
-            "properties": {
-                "Input": {
-                    "anyOf": [
-                        {
-                            "$ref": "http://redfish.dmtf.org/schemas/v1/Sensor.json#/definitions/SensorCurrentExcerpt"
-                        },
-                        {
-                            "type": "null"
-                        }
-                    ],
-                    "description": "The power supply input.",
-                    "excerptCopy": "SensorCurrentExcerpt",
-                    "longDescription": "This property shall contain the current sensor that measures current at the input of the power supply.",
-                    "readonly": true
-                },
-                "InputSecondary": {
-                    "anyOf": [
-                        {
-                            "$ref": "http://redfish.dmtf.org/schemas/v1/Sensor.json#/definitions/SensorCurrentExcerpt"
-                        },
-                        {
-                            "type": "null"
-                        }
-                    ],
-                    "description": "The power supply secondary input.",
-                    "excerptCopy": "SensorCurrentExcerpt",
-                    "longDescription": "This property shall contain the current sensor that measures current at the secondary input of the power supply.  This property shall not be present if the power supply does not include a secondary input.",
-                    "readonly": true
-                },
-                "Output12Volt": {
-                    "anyOf": [
-                        {
-                            "$ref": "http://redfish.dmtf.org/schemas/v1/Sensor.json#/definitions/SensorCurrentExcerpt"
-                        },
-                        {
-                            "type": "null"
-                        }
-                    ],
-                    "description": "The 12V nominal output.",
-                    "excerptCopy": "SensorCurrentExcerpt",
-                    "longDescription": "This property shall contain the current sensor that measures current on a 12 Volt nominal output power rail.  This property shall not be present if the power supply does not include a 12V output.",
-                    "readonly": true
-                },
-                "Output3Volt": {
-                    "anyOf": [
-                        {
-                            "$ref": "http://redfish.dmtf.org/schemas/v1/Sensor.json#/definitions/SensorCurrentExcerpt"
-                        },
-                        {
-                            "type": "null"
-                        }
-                    ],
-                    "description": "The 3V nominal output.",
-                    "excerptCopy": "SensorCurrentExcerpt",
-                    "longDescription": "This property shall contain the current sensor that measures current on a 3 Volt nominal output power rail.  This property shall not be present if the power supply does not include a 3V output.",
-                    "readonly": true
-                },
-                "Output48Volt": {
-                    "anyOf": [
-                        {
-                            "$ref": "http://redfish.dmtf.org/schemas/v1/Sensor.json#/definitions/SensorCurrentExcerpt"
-                        },
-                        {
-                            "type": "null"
-                        }
-                    ],
-                    "description": "The 48V nominal output.",
-                    "excerptCopy": "SensorCurrentExcerpt",
-                    "longDescription": "This property shall contain the current sensor that measures current on a 48 Volt nominal output power rail.  This property shall not be present if the power supply does not include a 48V output.",
-                    "readonly": true
-                },
-                "Output5Volt": {
-                    "anyOf": [
-                        {
-                            "$ref": "http://redfish.dmtf.org/schemas/v1/Sensor.json#/definitions/SensorCurrentExcerpt"
-                        },
-                        {
-                            "type": "null"
-                        }
-                    ],
-                    "description": "The 5V nominal output.",
-                    "excerptCopy": "SensorCurrentExcerpt",
-                    "longDescription": "This property shall contain the current sensor that measures current on a 5 Volt nominal output power rail.  This property shall not be present if the power supply does not include a 5V output.",
-                    "readonly": true
-                },
-                "OutputAux": {
-                    "anyOf": [
-                        {
-                            "$ref": "http://redfish.dmtf.org/schemas/v1/Sensor.json#/definitions/SensorCurrentExcerpt"
-                        },
-                        {
-                            "type": "null"
-                        }
-                    ],
-                    "description": "The auxiliary (AUX) output.",
-                    "excerptCopy": "SensorCurrentExcerpt",
-                    "longDescription": "This property shall contain the current sensor that measures current on an auxiliary (AUX) output power rail.  This property shall not be present if the power supply does not include an auxiliary output.",
-                    "readonly": true
-                }
-            },
-            "type": "object"
-        },
         "OemActions": {
             "additionalProperties": true,
             "description": "The available OEM-specific actions for this resource.",
@@ -173,70 +53,6 @@
                 }
             },
             "properties": {},
-            "type": "object"
-        },
-        "PowerSensors": {
-            "additionalProperties": false,
-            "description": "The power sensors for this power supply.",
-            "longDescription": "This type shall contain properties that describe power sensor readings for a power supply.",
-            "patternProperties": {
-                "^([a-zA-Z_][a-zA-Z0-9_]*)?@(odata|Redfish|Message)\\.[a-zA-Z_][a-zA-Z0-9_]*$": {
-                    "description": "This property shall specify a valid odata or Redfish property.",
-                    "type": [
-                        "array",
-                        "boolean",
-                        "integer",
-                        "number",
-                        "null",
-                        "object",
-                        "string"
-                    ]
-                }
-            },
-            "properties": {
-                "Input": {
-                    "anyOf": [
-                        {
-                            "$ref": "http://redfish.dmtf.org/schemas/v1/Sensor.json#/definitions/SensorPowerExcerpt"
-                        },
-                        {
-                            "type": "null"
-                        }
-                    ],
-                    "description": "The input power reading for the power supply.",
-                    "excerptCopy": "SensorPowerExcerpt",
-                    "longDescription": "This property shall contain the power, measured in Watts, for this power supply unit, as measured at the input of the power supply.",
-                    "readonly": true
-                },
-                "InputSecondary": {
-                    "anyOf": [
-                        {
-                            "$ref": "http://redfish.dmtf.org/schemas/v1/Sensor.json#/definitions/SensorPowerExcerpt"
-                        },
-                        {
-                            "type": "null"
-                        }
-                    ],
-                    "description": "The secondary input power reading for the power supply.",
-                    "excerptCopy": "SensorPowerExcerpt",
-                    "longDescription": "This property shall contain the power, measured in Watts, for this power supply unit, as measured at the secondary input of the power supply.  This property shall not appear if the power supply does not contain a secondary input.",
-                    "readonly": true
-                },
-                "Output": {
-                    "anyOf": [
-                        {
-                            "$ref": "http://redfish.dmtf.org/schemas/v1/Sensor.json#/definitions/SensorPowerExcerpt"
-                        },
-                        {
-                            "type": "null"
-                        }
-                    ],
-                    "description": "The output power reading for the power supply.",
-                    "excerptCopy": "SensorPowerExcerpt",
-                    "longDescription": "This property shall contain the power, measured in Watts, for this power supply unit, as measured at the output of the power supply.",
-                    "readonly": true
-                }
-            },
             "type": "object"
         },
         "PowerSupplyMetrics": {
@@ -295,10 +111,9 @@
                             "type": "null"
                         }
                     ],
-                    "description": "The energy consumption of this unit.",
+                    "description": "The energy consumption (kWh) of this unit.",
                     "excerptCopy": "SensorEnergykWhExcerpt",
-                    "longDescription": "This property shall contain the total energy, measured in kilowatt-hours (kWh), for this unit, that represents the `Total` ElectricalContext sensor when multiple energy sensors exist.",
-                    "readonly": true
+                    "longDescription": "This property shall contain the total energy, in kilowatt-hours units, for this unit, that represents the `Total` ElectricalContext sensor when multiple energy sensors exist.  The value of the DataSourceUri property, if present, shall reference a resource of type Sensor with the ReadingType property containing the value `EnergykWh`."
                 },
                 "FanSpeedPercent": {
                     "anyOf": [
@@ -309,10 +124,9 @@
                             "type": "null"
                         }
                     ],
-                    "description": "The fan speed reading for this power supply.",
+                    "description": "The fan speed (percent) for this power supply.",
                     "excerptCopy": "SensorFanExcerpt",
-                    "longDescription": "This property shall contain the fan speed sensor for this power supply.",
-                    "readonly": true
+                    "longDescription": "This property shall contain the fan speed, in percent units, for this resource.  The value of the DataSourceUri property, if present, shall reference a resource of type Sensor with the ReadingType property containing the value `Percent`."
                 },
                 "FrequencyHz": {
                     "anyOf": [
@@ -323,10 +137,9 @@
                             "type": "null"
                         }
                     ],
-                    "description": "The frequency reading for this power supply.",
+                    "description": "The frequency (Hz) for this power supply.",
                     "excerptCopy": "SensorExcerpt",
-                    "longDescription": "This property shall contain the frequency sensor for this power supply.",
-                    "readonly": true
+                    "longDescription": "This property shall contain the frequency, in hertz units, for this power supply."
                 },
                 "Id": {
                     "$ref": "http://redfish.dmtf.org/schemas/v1/Resource.json#/definitions/Id",
@@ -341,10 +154,9 @@
                             "type": "null"
                         }
                     ],
-                    "description": "The input current reading for this power supply.",
+                    "description": "The input current (A) for this power supply.",
                     "excerptCopy": "SensorCurrentExcerpt",
-                    "longDescription": "This property shall contain the sensor measuring the input current for this power supply.",
-                    "readonly": true
+                    "longDescription": "This property shall contain the input current, in ampere units, for this power supply.  The value of the DataSourceUri property, if present, shall reference a resource of type Sensor with the ReadingType property containing the value `Current`."
                 },
                 "InputPowerWatts": {
                     "anyOf": [
@@ -355,10 +167,9 @@
                             "type": "null"
                         }
                     ],
-                    "description": "The input power reading for this power supply.",
+                    "description": "The input power (W) for this power supply.",
                     "excerptCopy": "SensorPowerExcerpt",
-                    "longDescription": "This property shall contain the sensor measuring the input power for this power supply.",
-                    "readonly": true
+                    "longDescription": "This property shall contain the input power, in watt units, for this power supply.  The value of the DataSourceUri property, if present, shall reference a resource of type Sensor with the ReadingType property containing the value `Power`."
                 },
                 "InputVoltage": {
                     "anyOf": [
@@ -369,10 +180,9 @@
                             "type": "null"
                         }
                     ],
-                    "description": "The input voltage reading for this power supply.",
+                    "description": "The input voltage (V) for this power supply.",
                     "excerptCopy": "SensorVoltageExcerpt",
-                    "longDescription": "This property shall contain the sensor measuring the input voltage for this power supply.",
-                    "readonly": true
+                    "longDescription": "This property shall contain the input voltage, in volt units, for this power supply.  The value of the DataSourceUri property, if present, shall reference a resource of type Sensor with the ReadingType property containing the value `Voltage`."
                 },
                 "Name": {
                     "$ref": "http://redfish.dmtf.org/schemas/v1/Resource.json#/definitions/Name",
@@ -392,45 +202,41 @@
                             "type": "null"
                         }
                     ],
-                    "description": "The total power output reading for this power supply.",
+                    "description": "The total power output (W) for this power supply.",
                     "excerptCopy": "SensorPowerExcerpt",
-                    "longDescription": "This property shall contain the sensor measuring the total output power for this power supply.",
-                    "readonly": true
+                    "longDescription": "This property shall contain the total output power, in watt units, for this power supply.  The value of the DataSourceUri property, if present, shall reference a resource of type Sensor with the ReadingType property containing the value `Power`."
                 },
                 "RailCurrentAmps": {
-                    "description": "The current readings for this power supply.",
+                    "description": "The output currents (A) for this power supply.",
                     "excerptCopy": "SensorCurrentExcerpt",
                     "items": {
                         "$ref": "http://redfish.dmtf.org/schemas/v1/Sensor.json#/definitions/SensorCurrentExcerpt"
                     },
-                    "longDescription": "This property shall contain the output current sensors for this power supply.  The sensors shall appear in the same array order as the OutputRails property in the associated PowerSupply resource.",
-                    "readonly": true,
+                    "longDescription": "This property shall contain the output currents, in ampere units, for this power supply.  The value of the DataSourceUri property, if present, shall reference a resource of type Sensor with the ReadingType property containing the value `Current`.  The sensors shall appear in the same array order as the OutputRails property in the associated PowerSupply resource.",
                     "type": "array"
                 },
                 "RailCurrentAmps@odata.count": {
                     "$ref": "http://redfish.dmtf.org/schemas/v1/odata-v4.json#/definitions/count"
                 },
                 "RailPowerWatts": {
-                    "description": "The power readings for this power supply.",
+                    "description": "The output power readings (W) for this power supply.",
                     "excerptCopy": "SensorPowerExcerpt",
                     "items": {
                         "$ref": "http://redfish.dmtf.org/schemas/v1/Sensor.json#/definitions/SensorPowerExcerpt"
                     },
-                    "longDescription": "This property shall contain the output power sensors for this power supply.  The sensors shall appear in the same array order as the OutputRails property in the associated PowerSupply resource.",
-                    "readonly": true,
+                    "longDescription": "This property shall contain the output power readings, in watt units, for this power supply.  The value of the DataSourceUri property, if present, shall reference a resource of type Sensor with the ReadingType property containing the value `Power`.  The sensors shall appear in the same array order as the OutputRails property in the associated PowerSupply resource.",
                     "type": "array"
                 },
                 "RailPowerWatts@odata.count": {
                     "$ref": "http://redfish.dmtf.org/schemas/v1/odata-v4.json#/definitions/count"
                 },
                 "RailVoltage": {
-                    "description": "The voltage readings for this power supply.",
+                    "description": "The output voltages (V) for this power supply.",
                     "excerptCopy": "SensorVoltageExcerpt",
                     "items": {
                         "$ref": "http://redfish.dmtf.org/schemas/v1/Sensor.json#/definitions/SensorVoltageExcerpt"
                     },
-                    "longDescription": "This property shall contain the output voltage sensors for this power supply.  The sensors shall appear in the same array order as the OutputRails property in the associated PowerSupply resource.",
-                    "readonly": true,
+                    "longDescription": "This property shall contain the output voltages, in volt units, for this power supply.  The value of the DataSourceUri property, if present, shall reference a resource of type Sensor with the ReadingType property containing the value `Voltage`.  The sensors shall appear in the same array order as the OutputRails property in the associated PowerSupply resource.",
                     "type": "array"
                 },
                 "RailVoltage@odata.count": {
@@ -450,10 +256,9 @@
                             "type": "null"
                         }
                     ],
-                    "description": "The temperature reading for this power supply.",
+                    "description": "The temperature (C) for this power supply.",
                     "excerptCopy": "SensorExcerpt",
-                    "longDescription": "This property shall contain the temperature sensor for this power supply.",
-                    "readonly": true
+                    "longDescription": "This property shall contain the temperature, in degrees Celsius units, for this resource.  The value of the DataSourceUri property, if present, shall reference a resource of type Sensor with the ReadingType property containing the value `Temperature`."
                 }
             },
             "required": [
@@ -495,129 +300,9 @@
                 }
             },
             "type": "object"
-        },
-        "VoltageSensors": {
-            "additionalProperties": false,
-            "description": "The voltage readings for a power supply.",
-            "longDescription": "This type shall contain properties that describe voltage sensor readings for a power supply.",
-            "patternProperties": {
-                "^([a-zA-Z_][a-zA-Z0-9_]*)?@(odata|Redfish|Message)\\.[a-zA-Z_][a-zA-Z0-9_]*$": {
-                    "description": "This property shall specify a valid odata or Redfish property.",
-                    "type": [
-                        "array",
-                        "boolean",
-                        "integer",
-                        "number",
-                        "null",
-                        "object",
-                        "string"
-                    ]
-                }
-            },
-            "properties": {
-                "Input": {
-                    "anyOf": [
-                        {
-                            "$ref": "http://redfish.dmtf.org/schemas/v1/Sensor.json#/definitions/SensorVoltageExcerpt"
-                        },
-                        {
-                            "type": "null"
-                        }
-                    ],
-                    "description": "The power supply input.",
-                    "excerptCopy": "SensorVoltageExcerpt",
-                    "longDescription": "This property shall contain the voltage sensor that measures voltage at the input to the power supply.",
-                    "readonly": true
-                },
-                "InputSecondary": {
-                    "anyOf": [
-                        {
-                            "$ref": "http://redfish.dmtf.org/schemas/v1/Sensor.json#/definitions/SensorVoltageExcerpt"
-                        },
-                        {
-                            "type": "null"
-                        }
-                    ],
-                    "description": "The power supply secondary input.",
-                    "excerptCopy": "SensorVoltageExcerpt",
-                    "longDescription": "This property shall contain the voltage sensor that measures voltage at a secondary input to the power supply.  This property shall not be present if the power supply does not include a secondary input.",
-                    "readonly": true
-                },
-                "Output12Volt": {
-                    "anyOf": [
-                        {
-                            "$ref": "http://redfish.dmtf.org/schemas/v1/Sensor.json#/definitions/SensorVoltageExcerpt"
-                        },
-                        {
-                            "type": "null"
-                        }
-                    ],
-                    "description": "The 12V nominal output.",
-                    "excerptCopy": "SensorVoltageExcerpt",
-                    "longDescription": "This property shall contain the voltage sensor that measures voltage on a 12 Volt nominal output power rail.  This property shall not be present if the power supply does not include a 12V output.",
-                    "readonly": true
-                },
-                "Output3Volt": {
-                    "anyOf": [
-                        {
-                            "$ref": "http://redfish.dmtf.org/schemas/v1/Sensor.json#/definitions/SensorVoltageExcerpt"
-                        },
-                        {
-                            "type": "null"
-                        }
-                    ],
-                    "description": "The 3V nominal output.",
-                    "excerptCopy": "SensorVoltageExcerpt",
-                    "longDescription": "This property shall contain the voltage sensor that measures voltage on a 3 Volt nominal output power rail.  This property shall not be present if the power supply does not include a 3V output.",
-                    "readonly": true
-                },
-                "Output48Volt": {
-                    "anyOf": [
-                        {
-                            "$ref": "http://redfish.dmtf.org/schemas/v1/Sensor.json#/definitions/SensorVoltageExcerpt"
-                        },
-                        {
-                            "type": "null"
-                        }
-                    ],
-                    "description": "The 48V nominal output.",
-                    "excerptCopy": "SensorVoltageExcerpt",
-                    "longDescription": "This property shall contain the voltage sensor that measures voltage on a 48 Volt nominal output power rail.  This property shall not be present if the power supply does not include a 48V output.",
-                    "readonly": true
-                },
-                "Output5Volt": {
-                    "anyOf": [
-                        {
-                            "$ref": "http://redfish.dmtf.org/schemas/v1/Sensor.json#/definitions/SensorVoltageExcerpt"
-                        },
-                        {
-                            "type": "null"
-                        }
-                    ],
-                    "description": "The 5V nominal output.",
-                    "excerptCopy": "SensorVoltageExcerpt",
-                    "longDescription": "This property shall contain the voltage sensor that measures voltage on a 3 Volt nominal output power rail.  This property shall not be present if the power supply does not include a 3V output.",
-                    "readonly": true
-                },
-                "OutputAux": {
-                    "anyOf": [
-                        {
-                            "$ref": "http://redfish.dmtf.org/schemas/v1/Sensor.json#/definitions/SensorVoltageExcerpt"
-                        },
-                        {
-                            "type": "null"
-                        }
-                    ],
-                    "description": "The auxiliary (AUX) output.",
-                    "excerptCopy": "SensorVoltageExcerpt",
-                    "longDescription": "This property shall contain the voltage sensor that measures current on an auxiliary (AUX) output power rail.  This property shall not be present if the power supply does not include an auxiliary output.",
-                    "readonly": true
-                }
-            },
-            "type": "object"
         }
     },
     "owningEntity": "DMTF",
     "release": "2020.4",
-    "title": "#PowerSupplyMetrics.v1_0_0.PowerSupplyMetrics"
+    "title": "#PowerSupplyMetrics.v1_0_1.PowerSupplyMetrics"
 }

--- a/static/redfish/v1/JsonSchemas/ProcessorMetrics/ProcessorMetrics.json
+++ b/static/redfish/v1/JsonSchemas/ProcessorMetrics/ProcessorMetrics.json
@@ -1,5 +1,5 @@
 {
-    "$id": "http://redfish.dmtf.org/schemas/v1/ProcessorMetrics.v1_4_0.json",
+    "$id": "http://redfish.dmtf.org/schemas/v1/ProcessorMetrics.v1_4_1.json",
     "$ref": "#/definitions/ProcessorMetrics",
     "$schema": "http://redfish.dmtf.org/schemas/v1/redfish-schema-v1.json",
     "copyright": "Copyright 2014-2021 DMTF. For the full DMTF copyright policy, see http://www.dmtf.org/about/policies/copyright",
@@ -512,10 +512,9 @@
                             "type": "null"
                         }
                     ],
-                    "description": "The core voltage of this processor in Volts.",
+                    "description": "The core voltage (V) of this processor.",
                     "excerptCopy": "SensorVoltageExcerpt",
-                    "longDescription": "The value of this property shall contain the sensor measuring the core voltage of this processor in Volts.  The core voltage of the processor may change more frequently than the manager is able to monitor.",
-                    "readonly": true,
+                    "longDescription": "The value of this property shall contain the core voltage, in volt units, of this processor.  The core voltage of the processor may change more frequently than the manager is able to monitor.  The value of the DataSourceUri property, if present, shall reference a resource of type Sensor with the ReadingType property containing the value `Voltage`.",
                     "versionAdded": "v1_3_0"
                 },
                 "Description": {
@@ -644,5 +643,5 @@
     },
     "owningEntity": "DMTF",
     "release": "2021.3",
-    "title": "#ProcessorMetrics.v1_4_0.ProcessorMetrics"
+    "title": "#ProcessorMetrics.v1_4_1.ProcessorMetrics"
 }

--- a/static/redfish/v1/JsonSchemas/RegisteredClient/RegisteredClient.json
+++ b/static/redfish/v1/JsonSchemas/RegisteredClient/RegisteredClient.json
@@ -1,0 +1,234 @@
+{
+    "$id": "http://redfish.dmtf.org/schemas/v1/RegisteredClient.v1_0_0.json",
+    "$ref": "#/definitions/RegisteredClient",
+    "$schema": "http://redfish.dmtf.org/schemas/v1/redfish-schema-v1.json",
+    "copyright": "Copyright 2014-2021 DMTF. For the full DMTF copyright policy, see http://www.dmtf.org/about/policies/copyright",
+    "definitions": {
+        "Actions": {
+            "additionalProperties": false,
+            "description": "The available actions for this resource.",
+            "longDescription": "This type shall contain the available actions for this resource.",
+            "patternProperties": {
+                "^([a-zA-Z_][a-zA-Z0-9_]*)?@(odata|Redfish|Message)\\.[a-zA-Z_][a-zA-Z0-9_]*$": {
+                    "description": "This property shall specify a valid odata or Redfish property.",
+                    "type": [
+                        "array",
+                        "boolean",
+                        "integer",
+                        "number",
+                        "null",
+                        "object",
+                        "string"
+                    ]
+                }
+            },
+            "properties": {
+                "Oem": {
+                    "$ref": "#/definitions/OemActions",
+                    "description": "The available OEM-specific actions for this resource.",
+                    "longDescription": "This property shall contain the available OEM-specific actions for this resource."
+                }
+            },
+            "type": "object"
+        },
+        "ClientType": {
+            "enum": [
+                "Monitor",
+                "Configure"
+            ],
+            "enumDescriptions": {
+                "Configure": "The registered client performs update, create, and delete operations on the resources listed in the ManagedResources property as well as read operations on the service.",
+                "Monitor": "The registered client only performs read operations on this service."
+            },
+            "type": "string"
+        },
+        "ManagedResource": {
+            "additionalProperties": false,
+            "description": "A resource managed by a client.",
+            "longDescription": "This object shall contain information about a resource managed by a client.  The managed resource may specify subordinate resources.",
+            "patternProperties": {
+                "^([a-zA-Z_][a-zA-Z0-9_]*)?@(odata|Redfish|Message)\\.[a-zA-Z_][a-zA-Z0-9_]*$": {
+                    "description": "This property shall specify a valid odata or Redfish property.",
+                    "type": [
+                        "array",
+                        "boolean",
+                        "integer",
+                        "number",
+                        "null",
+                        "object",
+                        "string"
+                    ]
+                }
+            },
+            "properties": {
+                "IncludesSubordinates": {
+                    "description": "Indicates whether the subordinate resources of the managed resource are also managed by the registered client.",
+                    "longDescription": "This property shall indicate whether the subordinate resources of the managed resource referenced by the ManagedResourceURI property are also managed by the registered client.  If not specified, the value is assumed to be `false` unless ManagedResourceURI references a resource collection.",
+                    "readonly": false,
+                    "type": [
+                        "boolean",
+                        "null"
+                    ]
+                },
+                "ManagedResourceURI": {
+                    "description": "The URI of the resource or resource collection managed by the registered client.",
+                    "format": "uri-reference",
+                    "longDescription": "This property shall contain the URI of the Redfish resource or Redfish resource collection managed by the registered client.  When the URI references a resource collection, all members of the resource collection may be monitored or configured by the client, and the IncludesSubordinates property shall contain `true`.",
+                    "readonly": false,
+                    "type": [
+                        "string",
+                        "null"
+                    ]
+                },
+                "PreferExclusive": {
+                    "description": "Indicates whether the registered client expects to have exclusive access to the managed resource.",
+                    "longDescription": "This property shall indicate whether the registered client expects to have exclusive access to the managed resource referenced by the ManagedResourceURI property, and its subordinate resources if IncludesSubordinates contains `true`.  If not specified, the value is assumed to be `false`.",
+                    "readonly": false,
+                    "type": [
+                        "boolean",
+                        "null"
+                    ]
+                }
+            },
+            "type": "object"
+        },
+        "OemActions": {
+            "additionalProperties": true,
+            "description": "The available OEM-specific actions for this resource.",
+            "longDescription": "This type shall contain the available OEM-specific actions for this resource.",
+            "patternProperties": {
+                "^([a-zA-Z_][a-zA-Z0-9_]*)?@(odata|Redfish|Message)\\.[a-zA-Z_][a-zA-Z0-9_]*$": {
+                    "description": "This property shall specify a valid odata or Redfish property.",
+                    "type": [
+                        "array",
+                        "boolean",
+                        "integer",
+                        "number",
+                        "null",
+                        "object",
+                        "string"
+                    ]
+                }
+            },
+            "properties": {},
+            "type": "object"
+        },
+        "RegisteredClient": {
+            "additionalProperties": false,
+            "description": "The RegisteredClient schema defines the record format for a registered client.  It is designed to allow well behaved clients to register with a Redfish service such that other clients are aware the service might be configured or monitored by the client.",
+            "longDescription": "This resource shall represent a registered client  for a Redfish implementation.  It is not expected that transient tools, such as a short lived CLI tool, register.  Clients and management tools that live for long periods of time can create RegisteredClient resources so that other clients are aware the service might be configured or monitored by the client.",
+            "patternProperties": {
+                "^([a-zA-Z_][a-zA-Z0-9_]*)?@(odata|Redfish|Message)\\.[a-zA-Z_][a-zA-Z0-9_]*$": {
+                    "description": "This property shall specify a valid odata or Redfish property.",
+                    "type": [
+                        "array",
+                        "boolean",
+                        "integer",
+                        "number",
+                        "null",
+                        "object",
+                        "string"
+                    ]
+                }
+            },
+            "properties": {
+                "@odata.context": {
+                    "$ref": "http://redfish.dmtf.org/schemas/v1/odata-v4.json#/definitions/context"
+                },
+                "@odata.etag": {
+                    "$ref": "http://redfish.dmtf.org/schemas/v1/odata-v4.json#/definitions/etag"
+                },
+                "@odata.id": {
+                    "$ref": "http://redfish.dmtf.org/schemas/v1/odata-v4.json#/definitions/id"
+                },
+                "@odata.type": {
+                    "$ref": "http://redfish.dmtf.org/schemas/v1/odata-v4.json#/definitions/type"
+                },
+                "Actions": {
+                    "$ref": "#/definitions/Actions",
+                    "description": "The available actions for this resource.",
+                    "longDescription": "This property shall contain the available actions for this resource."
+                },
+                "ClientType": {
+                    "$ref": "#/definitions/ClientType",
+                    "description": "The type of registered client.",
+                    "longDescription": "This property shall contain the type of registered client.",
+                    "readonly": false
+                },
+                "ClientURI": {
+                    "description": "The URI of the registered client.",
+                    "longDescription": "This property shall contain the URI of the registered client.",
+                    "readonly": false,
+                    "type": "string"
+                },
+                "CreatedDate": {
+                    "description": "The date and time when the client entry was created.",
+                    "format": "date-time",
+                    "longDescription": "This property shall contain the date and time when the client entry was created.",
+                    "readonly": true,
+                    "type": "string"
+                },
+                "Description": {
+                    "anyOf": [
+                        {
+                            "$ref": "http://redfish.dmtf.org/schemas/v1/Resource.json#/definitions/Description"
+                        },
+                        {
+                            "type": "null"
+                        }
+                    ],
+                    "readonly": true
+                },
+                "ExpirationDate": {
+                    "description": "The date and time when the client entry will expire.",
+                    "format": "date-time",
+                    "longDescription": "This property shall contain the date and time when the client entry expires.  Registered clients that are actively managing or monitoring should periodically update this value.  The value should not be more than 7 days after the date when it was last set.  If the current date is beyond this date, the service may delete this client entry.",
+                    "readonly": false,
+                    "type": "string"
+                },
+                "Id": {
+                    "$ref": "http://redfish.dmtf.org/schemas/v1/Resource.json#/definitions/Id",
+                    "readonly": true
+                },
+                "ManagedResources": {
+                    "description": "An array of resources that the registered client monitors or configures.",
+                    "items": {
+                        "anyOf": [
+                            {
+                                "$ref": "#/definitions/ManagedResource"
+                            },
+                            {
+                                "type": "null"
+                            }
+                        ]
+                    },
+                    "longDescription": "This property shall contain an array of resources that the registered client monitors or configures.  Other clients can use this property to understand which resources are monitored or configured by the registered client.",
+                    "type": "array"
+                },
+                "Name": {
+                    "$ref": "http://redfish.dmtf.org/schemas/v1/Resource.json#/definitions/Name",
+                    "readonly": true
+                },
+                "Oem": {
+                    "$ref": "http://redfish.dmtf.org/schemas/v1/Resource.json#/definitions/Oem",
+                    "description": "The OEM extension property.",
+                    "longDescription": "This property shall contain the OEM extensions.  All values for properties that this object contains shall conform to the Redfish Specification-described requirements."
+                }
+            },
+            "required": [
+                "ClientType",
+                "@odata.id",
+                "@odata.type",
+                "Id",
+                "Name"
+            ],
+            "requiredOnCreate": [
+                "ClientType"
+            ],
+            "type": "object"
+        }
+    },
+    "owningEntity": "DMTF",
+    "release": "2021.4",
+    "title": "#RegisteredClient.v1_0_0.RegisteredClient"
+}

--- a/static/redfish/v1/JsonSchemas/RegisteredClient/index.json
+++ b/static/redfish/v1/JsonSchemas/RegisteredClient/index.json
@@ -1,0 +1,21 @@
+{
+    "@odata.context": "/redfish/v1/$metadata#JsonSchemaFile.JsonSchemaFile",
+    "@odata.id": "/redfish/v1/JsonSchemas/RegisteredClient",
+    "@odata.type": "#JsonSchemaFile.v1_0_2.JsonSchemaFile",
+    "Name": "RegisteredClient Schema File",
+    "Schema": "#RegisteredClient.RegisteredClient",
+    "Description": "RegisteredClient Schema File Location",
+    "Id": "RegisteredClient",
+    "Languages": [
+        "en"
+    ],
+    "Languages@odata.count": 1,
+    "Location": [
+        {
+            "Language": "en",
+            "PublicationUri": "http://redfish.dmtf.org/schemas/v1/RegisteredClient.json",
+            "Uri": "/redfish/v1/JsonSchemas/RegisteredClient/RegisteredClient.json"
+        }
+    ],
+    "Location@odata.count": 1
+}

--- a/static/redfish/v1/JsonSchemas/ServiceConditions/ServiceConditions.json
+++ b/static/redfish/v1/JsonSchemas/ServiceConditions/ServiceConditions.json
@@ -1,0 +1,149 @@
+{
+    "$id": "http://redfish.dmtf.org/schemas/v1/ServiceConditions.v1_0_0.json",
+    "$ref": "#/definitions/ServiceConditions",
+    "$schema": "http://redfish.dmtf.org/schemas/v1/redfish-schema-v1.json",
+    "copyright": "Copyright 2014-2021 DMTF. For the full DMTF copyright policy, see http://www.dmtf.org/about/policies/copyright",
+    "definitions": {
+        "Actions": {
+            "additionalProperties": false,
+            "description": "The available actions for this resource.",
+            "longDescription": "This type shall contain the available actions for this resource.",
+            "patternProperties": {
+                "^([a-zA-Z_][a-zA-Z0-9_]*)?@(odata|Redfish|Message)\\.[a-zA-Z_][a-zA-Z0-9_]*$": {
+                    "description": "This property shall specify a valid odata or Redfish property.",
+                    "type": [
+                        "array",
+                        "boolean",
+                        "integer",
+                        "number",
+                        "null",
+                        "object",
+                        "string"
+                    ]
+                }
+            },
+            "properties": {
+                "Oem": {
+                    "$ref": "#/definitions/OemActions",
+                    "description": "The available OEM-specific actions for this resource.",
+                    "longDescription": "This property shall contain the available OEM-specific actions for this resource."
+                }
+            },
+            "type": "object"
+        },
+        "OemActions": {
+            "additionalProperties": true,
+            "description": "The available OEM-specific actions for this resource.",
+            "longDescription": "This type shall contain the available OEM-specific actions for this resource.",
+            "patternProperties": {
+                "^([a-zA-Z_][a-zA-Z0-9_]*)?@(odata|Redfish|Message)\\.[a-zA-Z_][a-zA-Z0-9_]*$": {
+                    "description": "This property shall specify a valid odata or Redfish property.",
+                    "type": [
+                        "array",
+                        "boolean",
+                        "integer",
+                        "number",
+                        "null",
+                        "object",
+                        "string"
+                    ]
+                }
+            },
+            "properties": {},
+            "type": "object"
+        },
+        "ServiceConditions": {
+            "additionalProperties": false,
+            "description": "The ServiceConditions schema contains definitions for reporting the conditions present in the service that require attention.",
+            "longDescription": "This resource shall be used to represent the overall conditions present in a service for a Redfish implementation.",
+            "patternProperties": {
+                "^([a-zA-Z_][a-zA-Z0-9_]*)?@(odata|Redfish|Message)\\.[a-zA-Z_][a-zA-Z0-9_]*$": {
+                    "description": "This property shall specify a valid odata or Redfish property.",
+                    "type": [
+                        "array",
+                        "boolean",
+                        "integer",
+                        "number",
+                        "null",
+                        "object",
+                        "string"
+                    ]
+                }
+            },
+            "properties": {
+                "@odata.context": {
+                    "$ref": "http://redfish.dmtf.org/schemas/v1/odata-v4.json#/definitions/context"
+                },
+                "@odata.etag": {
+                    "$ref": "http://redfish.dmtf.org/schemas/v1/odata-v4.json#/definitions/etag"
+                },
+                "@odata.id": {
+                    "$ref": "http://redfish.dmtf.org/schemas/v1/odata-v4.json#/definitions/id"
+                },
+                "@odata.type": {
+                    "$ref": "http://redfish.dmtf.org/schemas/v1/odata-v4.json#/definitions/type"
+                },
+                "Actions": {
+                    "$ref": "#/definitions/Actions",
+                    "description": "The available actions for this resource.",
+                    "longDescription": "This property shall contain the available actions for this resource."
+                },
+                "Conditions": {
+                    "description": "Conditions reported by this service that require attention.",
+                    "items": {
+                        "anyOf": [
+                            {
+                                "$ref": "http://redfish.dmtf.org/schemas/v1/Resource.json#/definitions/Condition"
+                            },
+                            {
+                                "type": "null"
+                            }
+                        ]
+                    },
+                    "longDescription": "This property shall represent a roll-up of the active conditions requiring attention in resources of this Redfish service.  The service may roll up any number of conditions originating from resources in the service, using the `ConditionInRelatedResource` message from Base Message Registry.",
+                    "type": "array"
+                },
+                "Description": {
+                    "anyOf": [
+                        {
+                            "$ref": "http://redfish.dmtf.org/schemas/v1/Resource.json#/definitions/Description"
+                        },
+                        {
+                            "type": "null"
+                        }
+                    ],
+                    "readonly": true
+                },
+                "HealthRollup": {
+                    "$ref": "http://redfish.dmtf.org/schemas/v1/Resource.json#/definitions/Health",
+                    "description": "The health roll-up for all resources.",
+                    "longDescription": "This property shall contain the highest severity of any messages included in the Conditions property.",
+                    "readonly": true
+                },
+                "Id": {
+                    "$ref": "http://redfish.dmtf.org/schemas/v1/Resource.json#/definitions/Id",
+                    "readonly": true
+                },
+                "Name": {
+                    "$ref": "http://redfish.dmtf.org/schemas/v1/Resource.json#/definitions/Name",
+                    "readonly": true
+                },
+                "Oem": {
+                    "$ref": "http://redfish.dmtf.org/schemas/v1/Resource.json#/definitions/Oem",
+                    "description": "The OEM extension property.",
+                    "longDescription": "This property shall contain the OEM extensions.  All values for properties that this object contains shall conform to the Redfish Specification-described requirements."
+                }
+            },
+            "required": [
+                "@odata.id",
+                "@odata.type",
+                "Id",
+                "Name"
+            ],
+            "type": "object"
+        }
+    },
+    "owningEntity": "DMTF",
+    "release": "2021.4",
+    "title": "#ServiceConditions.v1_0_0.ServiceConditions"
+}

--- a/static/redfish/v1/JsonSchemas/ServiceConditions/index.json
+++ b/static/redfish/v1/JsonSchemas/ServiceConditions/index.json
@@ -1,0 +1,21 @@
+{
+    "@odata.context": "/redfish/v1/$metadata#JsonSchemaFile.JsonSchemaFile",
+    "@odata.id": "/redfish/v1/JsonSchemas/ServiceConditions",
+    "@odata.type": "#JsonSchemaFile.v1_0_2.JsonSchemaFile",
+    "Name": "ServiceConditions Schema File",
+    "Schema": "#ServiceConditions.ServiceConditions",
+    "Description": "ServiceConditions Schema File Location",
+    "Id": "ServiceConditions",
+    "Languages": [
+        "en"
+    ],
+    "Languages@odata.count": 1,
+    "Location": [
+        {
+            "Language": "en",
+            "PublicationUri": "http://redfish.dmtf.org/schemas/v1/ServiceConditions.json",
+            "Uri": "/redfish/v1/JsonSchemas/ServiceConditions/ServiceConditions.json"
+        }
+    ],
+    "Location@odata.count": 1
+}

--- a/static/redfish/v1/JsonSchemas/Switch/Switch.json
+++ b/static/redfish/v1/JsonSchemas/Switch/Switch.json
@@ -1,5 +1,5 @@
 {
-    "$id": "http://redfish.dmtf.org/schemas/v1/Switch.v1_7_0.json",
+    "$id": "http://redfish.dmtf.org/schemas/v1/Switch.v1_8_0.json",
     "$ref": "#/definitions/Switch",
     "$schema": "http://redfish.dmtf.org/schemas/v1/redfish-schema-v1.json",
     "copyright": "Copyright 2014-2021 DMTF. For the full DMTF copyright policy, see http://www.dmtf.org/about/policies/copyright",
@@ -348,13 +348,15 @@
                     "versionAdded": "v1_4_0"
                 },
                 "Measurements": {
+                    "deprecated": "This property has been deprecated in favor of the ComponentIntegrity resource.",
                     "description": "An array of DSP0274-defined measurement blocks.",
                     "items": {
                         "$ref": "http://redfish.dmtf.org/schemas/v1/SoftwareInventory.json#/definitions/MeasurementBlock"
                     },
                     "longDescription": "This property shall contain an array of DSP0274-defined measurement blocks.",
                     "type": "array",
-                    "versionAdded": "v1_5_0"
+                    "versionAdded": "v1_5_0",
+                    "versionDeprecated": "v1_8_0"
                 },
                 "Metrics": {
                     "$ref": "http://redfish.dmtf.org/schemas/v1/SwitchMetrics.json#/definitions/SwitchMetrics",
@@ -501,6 +503,6 @@
         }
     },
     "owningEntity": "DMTF",
-    "release": "2021.3",
-    "title": "#Switch.v1_7_0.Switch"
+    "release": "2021.4",
+    "title": "#Switch.v1_8_0.Switch"
 }

--- a/static/redfish/v1/JsonSchemas/ThermalMetrics/ThermalMetrics.json
+++ b/static/redfish/v1/JsonSchemas/ThermalMetrics/ThermalMetrics.json
@@ -1,8 +1,8 @@
 {
-    "$id": "http://redfish.dmtf.org/schemas/v1/ThermalMetrics.v1_0_0.json",
+    "$id": "http://redfish.dmtf.org/schemas/v1/ThermalMetrics.v1_0_1.json",
     "$ref": "#/definitions/ThermalMetrics",
     "$schema": "http://redfish.dmtf.org/schemas/v1/redfish-schema-v1.json",
-    "copyright": "Copyright 2014-2020 DMTF. For the full DMTF copyright policy, see http://www.dmtf.org/about/policies/copyright",
+    "copyright": "Copyright 2014-2021 DMTF. For the full DMTF copyright policy, see http://www.dmtf.org/about/policies/copyright",
     "definitions": {
         "Actions": {
             "additionalProperties": false,
@@ -89,7 +89,7 @@
         },
         "TemperatureSummary": {
             "additionalProperties": false,
-            "description": "The temperature sensors for a subsystem.",
+            "description": "The temperature readings for a subsystem.",
             "longDescription": "This type shall contain properties that describe temperature sensor for a subsystem.",
             "patternProperties": {
                 "^([a-zA-Z_][a-zA-Z0-9_]*)?@(odata|Redfish|Message)\\.[a-zA-Z_][a-zA-Z0-9_]*$": {
@@ -115,10 +115,9 @@
                             "type": "null"
                         }
                     ],
-                    "description": "The ambient temperature of this subsystem.",
+                    "description": "The ambient temperature (Celsius) of this subsystem.",
                     "excerptCopy": "SensorExcerpt",
-                    "longDescription": "This property shall contain the temperature reading for the ambient temperature of this subsystem.",
-                    "readonly": true
+                    "longDescription": "This property shall contain the temperature, in degrees Celsius units, for the ambient temperature of this subsystem.  The value of the DataSourceUri property, if present, shall reference a resource of type Sensor with the ReadingType property containing the value `Temperature`."
                 },
                 "Exhaust": {
                     "anyOf": [
@@ -129,10 +128,9 @@
                             "type": "null"
                         }
                     ],
-                    "description": "The exhaust temperature of this subsystem.",
+                    "description": "The exhaust temperature (Celsius) of this subsystem.",
                     "excerptCopy": "SensorExcerpt",
-                    "longDescription": "This property shall contain the temperature reading for the exhaust temperature of this subsystem.",
-                    "readonly": true
+                    "longDescription": "This property shall contain the temperature, in degrees Celsius units, for the exhaust temperature of this subsystem.  The value of the DataSourceUri property, if present, shall reference a resource of type Sensor with the ReadingType property containing the value `Temperature`."
                 },
                 "Intake": {
                     "anyOf": [
@@ -143,10 +141,9 @@
                             "type": "null"
                         }
                     ],
-                    "description": "The intake temperature of this subsystem.",
+                    "description": "The intake temperature (Celsius) of this subsystem.",
                     "excerptCopy": "SensorExcerpt",
-                    "longDescription": "This property shall contain the temperature reading for the intake temperature of this subsystem.",
-                    "readonly": true
+                    "longDescription": "This property shall contain the temperature, in degrees Celsius units, for the intake temperature of this subsystem.  The value of the DataSourceUri property, if present, shall reference a resource of type Sensor with the ReadingType property containing the value `Temperature`."
                 },
                 "Internal": {
                     "anyOf": [
@@ -157,10 +154,9 @@
                             "type": "null"
                         }
                     ],
-                    "description": "The internal temperature of this subsystem.",
+                    "description": "The internal temperature (Celsius) of this subsystem.",
                     "excerptCopy": "SensorExcerpt",
-                    "longDescription": "This property shall contain the temperature reading for the internal temperature of this subsystem.",
-                    "readonly": true
+                    "longDescription": "This property shall contain the temperature, in degrees Celsius units, for the internal temperature of this subsystem.  The value of the DataSourceUri property, if present, shall reference a resource of type Sensor with the ReadingType property containing the value `Temperature`."
                 }
             },
             "type": "object"
@@ -226,13 +222,12 @@
                     "longDescription": "This property shall contain the OEM extensions.  All values for properties that this object contains shall conform to the Redfish Specification-described requirements."
                 },
                 "TemperatureReadingsCelsius": {
-                    "description": "The temperature readings from all related sensors for this device.",
+                    "description": "The temperatures (Celsius) from all related sensors for this device.",
                     "excerptCopy": "SensorArrayExcerpt",
                     "items": {
                         "$ref": "http://redfish.dmtf.org/schemas/v1/Sensor.json#/definitions/SensorArrayExcerpt"
                     },
-                    "longDescription": "This property shall contain the temperature sensors for this subsystem.",
-                    "readonly": true,
+                    "longDescription": "This property shall contain the temperatures, in degrees Celsius units, for this subsystem.  The value of the DataSourceUri property, if present, shall reference a resource of type Sensor with the ReadingType property containing the value `Temperature`.",
                     "type": "array"
                 },
                 "TemperatureReadingsCelsius@odata.count": {
@@ -262,5 +257,5 @@
     },
     "owningEntity": "DMTF",
     "release": "2020.4",
-    "title": "#ThermalMetrics.v1_0_0.ThermalMetrics"
+    "title": "#ThermalMetrics.v1_0_1.ThermalMetrics"
 }

--- a/static/redfish/v1/JsonSchemas/index.json
+++ b/static/redfish/v1/JsonSchemas/index.json
@@ -4,7 +4,7 @@
   "@odata.type": "#JsonSchemaFileCollection.JsonSchemaFileCollection",
   "Name": "JsonSchemaFile Collection",
   "Description": "Collection of JsonSchemaFiles",
-  "Members@odata.count": 135,
+  "Members@odata.count": 139,
   "Members": [
     {
       "@odata.id": "/redfish/v1/JsonSchemas/AccelerationFunction"
@@ -68,6 +68,9 @@
     },
     {
       "@odata.id": "/redfish/v1/JsonSchemas/CollectionCapabilities"
+    },
+    {
+      "@odata.id": "/redfish/v1/JsonSchemas/ComponentIntegrity"
     },
     {
       "@odata.id": "/redfish/v1/JsonSchemas/CompositionReservation"
@@ -170,6 +173,9 @@
     },
     {
       "@odata.id": "/redfish/v1/JsonSchemas/ManagerAccount"
+    },
+    {
+      "@odata.id": "/redfish/v1/JsonSchemas/ManagerDiagnosticData"
     },
     {
       "@odata.id": "/redfish/v1/JsonSchemas/ManagerNetworkProtocol"
@@ -295,6 +301,9 @@
       "@odata.id": "/redfish/v1/JsonSchemas/Redundancy"
     },
     {
+      "@odata.id": "/redfish/v1/JsonSchemas/RegisteredClient"
+    },
+    {
       "@odata.id": "/redfish/v1/JsonSchemas/Resource"
     },
     {
@@ -323,6 +332,9 @@
     },
     {
       "@odata.id": "/redfish/v1/JsonSchemas/SerialInterface"
+    },
+    {
+      "@odata.id": "/redfish/v1/JsonSchemas/ServiceConditions"
     },
     {
       "@odata.id": "/redfish/v1/JsonSchemas/ServiceRoot"

--- a/static/redfish/v1/schema/BatteryMetrics_v1.xml
+++ b/static/redfish/v1/schema/BatteryMetrics_v1.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!---->
 <!--################################################################################       -->
-<!--# Redfish Schema:  BatteryMetrics v1.0.0                                               -->
+<!--# Redfish Schema:  BatteryMetrics v1.0.1                                               -->
 <!--#                                                                                      -->
 <!--# For a detailed change log, see the README file contained in the DSP8010 bundle,      -->
 <!--# available at http://www.dmtf.org/standards/redfish                                   -->
@@ -77,48 +77,48 @@
           <Annotation Term="Validation.Minimum" Int="0"/>
         </Property>
         <NavigationProperty Name="InputVoltage" Type="Sensor.Sensor" Nullable="false">
-          <Annotation Term="OData.Description" String="The input voltage reading for this battery."/>
-          <Annotation Term="OData.LongDescription" String="This property shall contain the input voltage sensor for this battery."/>
+          <Annotation Term="OData.Description" String="The input voltage (V) for this battery."/>
+          <Annotation Term="OData.LongDescription" String="This property shall contain the input voltage, in volt units, for this battery.  The value of the DataSourceUri property, if present, shall reference a resource of type Sensor with the ReadingType property containing the value `Voltage`."/>
           <Annotation Term="Redfish.ExcerptCopy" String="Voltage"/>
         </NavigationProperty>
         <NavigationProperty Name="InputCurrentAmps" Type="Sensor.Sensor" Nullable="false">
-          <Annotation Term="OData.Description" String="The input current reading for this battery."/>
-          <Annotation Term="OData.LongDescription" String="This property shall contain the input current sensor for this battery."/>
+          <Annotation Term="OData.Description" String="The input current (A) for this battery."/>
+          <Annotation Term="OData.LongDescription" String="This property shall contain the input current, in ampere units, for this battery.  The value of the DataSourceUri property, if present, shall reference a resource of type Sensor with the ReadingType property containing the value `Current`."/>
           <Annotation Term="Redfish.ExcerptCopy" String="Current"/>
         </NavigationProperty>
         <NavigationProperty Name="OutputVoltages" Type="Collection(Sensor.Sensor)">
-          <Annotation Term="OData.Description" String="The output voltage readings for this battery."/>
-          <Annotation Term="OData.LongDescription" String="This property shall contain the output voltage sensors for this battery.  The sensors shall appear in the same array order as the OutputCurrentAmps property."/>
+          <Annotation Term="OData.Description" String="The output voltages (V) for this battery."/>
+          <Annotation Term="OData.LongDescription" String="This property shall contain the output voltages, in volt units, for this battery.  The value of the DataSourceUri property, if present, shall reference a resource of type Sensor with the ReadingType property containing the value `Voltage`.  The sensors shall appear in the same array order as the OutputCurrentAmps property."/>
           <Annotation Term="Redfish.ExcerptCopy" String="Voltage"/>
         </NavigationProperty>
         <NavigationProperty Name="OutputCurrentAmps" Type="Collection(Sensor.Sensor)">
-          <Annotation Term="OData.Description" String="The output current readings for this battery."/>
-          <Annotation Term="OData.LongDescription" String="This property shall contain the output current sensors for this battery.  The sensors shall appear in the same array order as the OutputVoltages property."/>
+          <Annotation Term="OData.Description" String="The output currents (A) for this battery."/>
+          <Annotation Term="OData.LongDescription" String="This property shall contain the output currents, in ampere units, for this battery.  The value of the DataSourceUri property, if present, shall reference a resource of type Sensor with the ReadingType property containing the value `Current`.  The sensors shall appear in the same array order as the OutputVoltages property."/>
           <Annotation Term="Redfish.ExcerptCopy" String="Current"/>
         </NavigationProperty>
         <NavigationProperty Name="StoredEnergyWattHours" Type="Sensor.Sensor" Nullable="false">
-          <Annotation Term="OData.Description" String="The energy stored in this battery in watt-hours."/>
-          <Annotation Term="OData.LongDescription" String="This property shall contain the energy sensor for this battery in watt-hours."/>
+          <Annotation Term="OData.Description" String="The energy (Wh) stored in this battery."/>
+          <Annotation Term="OData.LongDescription" String="This property shall contain the stored energy, in watt-hour units, for this battery.  The value of the DataSourceUri property, if present, shall reference a resource of type Sensor with the ReadingType property containing the value `EnergyWh`."/>
           <Annotation Term="Redfish.ExcerptCopy"/>
         </NavigationProperty>
         <NavigationProperty Name="StoredChargeAmpHours" Type="Sensor.Sensor" Nullable="false">
-          <Annotation Term="OData.Description" String="The charge stored in this battery in amp-hours."/>
-          <Annotation Term="OData.LongDescription" String="This property shall contain the charge sensor for this battery in amp-hours."/>
+          <Annotation Term="OData.Description" String="The charge (Ah) stored in this battery."/>
+          <Annotation Term="OData.LongDescription" String="This property shall contain the stored charge, in ampere-hours units, for this battery.  The value of the DataSourceUri property, if present, shall reference a resource of type Sensor with the ReadingType property containing the value `ChargeAh`."/>
           <Annotation Term="Redfish.ExcerptCopy"/>
         </NavigationProperty>
         <NavigationProperty Name="TemperatureCelsius" Type="Sensor.Sensor" Nullable="false">
-          <Annotation Term="OData.Description" String="The temperature reading for this battery."/>
-          <Annotation Term="OData.LongDescription" String="This property shall contain the temperature sensor for this battery."/>
+          <Annotation Term="OData.Description" String="The temperature (C) for this battery."/>
+          <Annotation Term="OData.LongDescription" String="This property shall contain the temperature, in degrees Celsius units, for this battery.  The value of the DataSourceUri property, if present, shall reference a resource of type Sensor with the ReadingType property containing the value `Temperature`."/>
           <Annotation Term="Redfish.ExcerptCopy"/>
         </NavigationProperty>
         <NavigationProperty Name="ChargePercent" Type="Sensor.Sensor" Nullable="false">
-          <Annotation Term="OData.Description" String="The amount of charge available in this battery as a percentage."/>
-          <Annotation Term="OData.LongDescription" String="This property shall contain the amount of charge available in this battery as a percentage."/>
+          <Annotation Term="OData.Description" String="The amount of charge available (percent) in this battery."/>
+          <Annotation Term="OData.LongDescription" String="This property shall contain the amount of charge available, in percent units, in this battery.  The value of the DataSourceUri property, if present, shall reference a resource of type Sensor with the ReadingType property containing the value `Percent`."/>
           <Annotation Term="Redfish.ExcerptCopy"/>
         </NavigationProperty>
         <NavigationProperty Name="CellVoltages" Type="Collection(Sensor.Sensor)">
-          <Annotation Term="OData.Description" String="The cell voltage readings for this battery."/>
-          <Annotation Term="OData.LongDescription" String="This property shall contain the cell voltage sensors for this battery."/>
+          <Annotation Term="OData.Description" String="The cell voltages (V) for this battery."/>
+          <Annotation Term="OData.LongDescription" String="This property shall contain the cell voltages, in volt units, for this battery.  The value of the DataSourceUri property, if present, shall reference a resource of type Sensor with the ReadingType property containing the value `Voltage`."/>
           <Annotation Term="Redfish.ExcerptCopy" String="Voltage"/>
         </NavigationProperty>
         <Property Name="Actions" Type="BatteryMetrics.v1_0_0.Actions" Nullable="false">
@@ -142,6 +142,12 @@
         <Annotation Term="OData.Description" String="The available OEM-specific actions for this resource."/>
         <Annotation Term="OData.LongDescription" String="This type shall contain the available OEM-specific actions for this resource."/>
       </ComplexType>
+    </Schema>
+
+    <Schema xmlns="http://docs.oasis-open.org/odata/ns/edm" Namespace="BatteryMetrics.v1_0_1">
+      <Annotation Term="Redfish.OwningEntity" String="DMTF"/>
+      <Annotation Term="OData.Description" String="This version was created to update descriptions to tie excerpt property definitions to a specific type of Sensor or Control."/>
+      <EntityType Name="BatteryMetrics" BaseType="BatteryMetrics.v1_0_0.BatteryMetrics"/>
     </Schema>
 
   </edmx:DataServices>

--- a/static/redfish/v1/schema/Battery_v1.xml
+++ b/static/redfish/v1/schema/Battery_v1.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!---->
 <!--################################################################################       -->
-<!--# Redfish Schema:  Battery v1.0.0                                                      -->
+<!--# Redfish Schema:  Battery v1.0.1                                                      -->
 <!--#                                                                                      -->
 <!--# For a detailed change log, see the README file contained in the DSP8010 bundle,      -->
 <!--# available at http://www.dmtf.org/standards/redfish                                   -->
@@ -209,8 +209,8 @@
           <Annotation Term="OData.LongDescription" String="This property shall contain the charge state of this battery."/>
         </Property>
         <NavigationProperty Name="StateOfHealthPercent" Type="Sensor.Sensor" Nullable="false">
-          <Annotation Term="OData.Description" String="The state of health of this battery."/>
-          <Annotation Term="OData.LongDescription" String="This property shall contain the state of health of this battery as a percentage."/>
+          <Annotation Term="OData.Description" String="The state of health (percent) of this battery."/>
+          <Annotation Term="OData.LongDescription" String="This property shall contain the state of health, in percent units, of this battery.  The value of the DataSourceUri property, if present, shall reference a resource of type Sensor with the ReadingType property containing the value `Percent`."/>
           <Annotation Term="Redfish.ExcerptCopy"/>
         </NavigationProperty>
         <NavigationProperty Name="Assembly" Type="Assembly.Assembly" ContainsTarget="true" Nullable="false">
@@ -261,6 +261,12 @@
           <Annotation Term="OData.LongDescription" String="This value shall indicate the battery is discharging and energy is leaving the battery."/>
         </Member>
       </EnumType>
+    </Schema>
+
+    <Schema xmlns="http://docs.oasis-open.org/odata/ns/edm" Namespace="Battery.v1_0_1">
+      <Annotation Term="Redfish.OwningEntity" String="DMTF"/>
+      <Annotation Term="OData.Description" String="This version was created to update descriptions to tie excerpt property definitions to a specific type of Sensor or Control."/>
+      <EntityType Name="Battery" BaseType="Battery.v1_0_0.Battery"/>
     </Schema>
 
   </edmx:DataServices>

--- a/static/redfish/v1/schema/Circuit_v1.xml
+++ b/static/redfish/v1/schema/Circuit_v1.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!---->
 <!--################################################################################       -->
-<!--# Redfish Schema:  Circuit v1.4.0                                                      -->
+<!--# Redfish Schema:  Circuit v1.5.0                                                      -->
 <!--#                                                                                      -->
 <!--# For a detailed change log, see the README file contained in the DSP8010 bundle,      -->
 <!--# available at http://www.dmtf.org/standards/redfish                                   -->
@@ -85,7 +85,7 @@
         <Annotation Term="OData.Description" String="This action turns the circuit on or off."/>
         <Annotation Term="OData.LongDescription" String="This action shall control the power state of the circuit."/>
         <Parameter Name="Circuit" Type="Circuit.v1_0_0.Actions"/>
-        <Parameter Name="PowerState" Type="Resource.PowerState">
+        <Parameter Name="PowerState" Type="Circuit.PowerState">
           <Annotation Term="OData.Description" String="The desired power state of the circuit."/>
           <Annotation Term="OData.LongDescription" String="This parameter shall contain the desired power state of the circuit."/>
         </Parameter>
@@ -109,10 +109,22 @@
 
       <EnumType Name="PowerState">
         <Member Name="On">
-          <Annotation Term="OData.Description" String="The circuit is powered on."/>
+          <Annotation Term="OData.Description" String="Power on."/>
         </Member>
         <Member Name="Off">
-          <Annotation Term="OData.Description" String="The circuit is powered off."/>
+          <Annotation Term="OData.Description" String="Power off."/>
+        </Member>
+        <Member Name="PowerCycle">
+          <Annotation Term="OData.Description" String="Power cycle."/>
+          <Annotation Term="OData.LongDescription" String="This value shall indicate the resource will transition to a power off state, then transition to a power on state.  Upon successful completion, the PowerState property, if supported, shall contain the value `On`."/>
+          <Annotation Term="Redfish.Revisions">
+            <Collection>
+              <Record>
+                <PropertyValue Property="Kind" EnumMember="Redfish.RevisionKind/Added"/>
+                <PropertyValue Property="Version" String="v1_5_0"/>
+              </Record>
+            </Collection>
+          </Annotation>
         </Member>
       </EnumType>
 
@@ -408,7 +420,7 @@
         <Property Name="RatedCurrentAmps" Type="Edm.Decimal">
           <Annotation Term="OData.Permissions" EnumMember="OData.Permission/Read"/>
           <Annotation Term="OData.Description" String="The rated maximum current allowed for this circuit."/>
-          <Annotation Term="OData.LongDescription" String="This property shall contain the rated maximum current for this circuit, in Amps, after any required de-rating, due to safety agency or other regulatory requirements, has been applied."/>
+          <Annotation Term="OData.LongDescription" String="This property shall contain the rated maximum current for this circuit, in ampere units, after any required de-rating, due to safety agency or other regulatory requirements, has been applied."/>
           <Annotation Term="Measures.Unit" String="A"/>
           <Annotation Term="Validation.Minimum" Int="0"/>
         </Property>
@@ -468,44 +480,44 @@
         </Property>
         <NavigationProperty Name="Voltage" Type="Sensor.Sensor">
           <Annotation Term="Redfish.ExcerptCopy" String="Voltage"/>
-          <Annotation Term="OData.Description" String="The voltage reading for this single phase circuit."/>
-          <Annotation Term="OData.LongDescription" String="This property shall contain the voltage, measured in Volts, for this single phase circuit.  This property shall not appear in resource instances representing poly-phase circuits."/>
+          <Annotation Term="OData.Description" String="The voltage (V) for this single phase circuit."/>
+          <Annotation Term="OData.LongDescription" String="This property shall contain the voltage, in volt units, for this single phase circuit.  The value of the DataSourceUri property, if present, shall reference a resource of type Sensor with the ReadingType property containing the value `Voltage`.  This property shall not appear in resource instances representing poly-phase circuits."/>
         </NavigationProperty>
         <NavigationProperty Name="CurrentAmps" Type="Sensor.Sensor">
           <Annotation Term="Redfish.ExcerptCopy" String="Current"/>
-          <Annotation Term="OData.Description" String="The current reading for this single phase circuit."/>
-          <Annotation Term="OData.LongDescription" String="This property shall contain the current, measured in Amperes, for this single phase circuit.  This property shall not appear in resource instances representing poly-phase circuits."/>
+          <Annotation Term="OData.Description" String="The current (A) for this single phase circuit."/>
+          <Annotation Term="OData.LongDescription" String="This property shall contain the current, in ampere units, for this single phase circuit.  The value of the DataSourceUri property, if present, shall reference a resource of type Sensor with the ReadingType property containing the value `Current`.  This property shall not appear in resource instances representing poly-phase circuits."/>
         </NavigationProperty>
         <NavigationProperty Name="PowerWatts" Type="Sensor.Sensor">
           <Annotation Term="Redfish.ExcerptCopy" String="Power"/>
-          <Annotation Term="OData.Description" String="The power reading for this circuit."/>
-          <Annotation Term="OData.LongDescription" String="This property shall contain the total power, measured in Watts, for this circuit, that represents the `Total` ElectricalContext sensor when multiple power sensors exist for this circuit."/>
+          <Annotation Term="OData.Description" String="The power (W) for this circuit."/>
+          <Annotation Term="OData.LongDescription" String="This property shall contain the total power, in watt units, for this circuit, that represents the `Total` ElectricalContext sensor when multiple power sensors exist for this circuit.  The value of the DataSourceUri property, if present, shall reference a resource of type Sensor with the ReadingType property containing the value `Power`."/>
         </NavigationProperty>
         <NavigationProperty Name="EnergykWh" Type="Sensor.Sensor">
           <Annotation Term="Redfish.ExcerptCopy" String="EnergykWh"/>
-          <Annotation Term="OData.Description" String="The energy reading for this circuit."/>
-          <Annotation Term="OData.LongDescription" String="This property shall contain the total energy, measured in kilowatt-hours (kW.h), for this circuit, that represents the `Total` ElectricalContext sensor when multiple energy sensors exist for this circuit."/>
+          <Annotation Term="OData.Description" String="The energy (kWh) for this circuit."/>
+          <Annotation Term="OData.LongDescription" String="This property shall contain the total energy, in kilowatt-hour units, for this circuit, that represents the `Total` ElectricalContext sensor when multiple energy sensors exist for this circuit.  The value of the DataSourceUri property, if present, shall reference a resource of type Sensor with the ReadingType property containing the value `EnergykWh`."/>
         </NavigationProperty>
         <NavigationProperty Name="FrequencyHz" Type="Sensor.Sensor">
           <Annotation Term="Redfish.ExcerptCopy"/>
-          <Annotation Term="OData.Description" String="The frequency reading for this circuit."/>
-          <Annotation Term="OData.LongDescription" String="This property shall contain the frequency sensor for this circuit."/>
+          <Annotation Term="OData.Description" String="The frequency (Hz) for this circuit."/>
+          <Annotation Term="OData.LongDescription" String="This property shall contain the frequency, in hertz units, for this circuit.  The value of the DataSourceUri property, if present, shall reference a resource of type Sensor with the ReadingType property containing the value `Frequency`."/>
         </NavigationProperty>
         <Property Name="PolyPhaseVoltage" Type="Circuit.v1_0_0.VoltageSensors">
           <Annotation Term="OData.Description" String="The voltage readings for this circuit."/>
-          <Annotation Term="OData.LongDescription" String="This property shall contain the voltage sensor(s) for this circuit.  For single phase circuits this property shall contain a duplicate copy of the voltage sensor referenced in the VoltageSensor property, if present.  For poly-phase circuits this property should contain multiple voltage sensor readings used to fully describe the circuit."/>
+          <Annotation Term="OData.LongDescription" String="This property shall contain the voltage sensors for this circuit.  For single phase circuits this property shall contain a duplicate copy of the voltage sensor referenced in the Voltage property, if present.  For poly-phase circuits this property should contain multiple voltage sensor readings used to fully describe the circuit."/>
         </Property>
         <Property Name="PolyPhaseCurrentAmps" Type="Circuit.v1_0_0.CurrentSensors">
           <Annotation Term="OData.Description" String="The current readings for this circuit."/>
-          <Annotation Term="OData.LongDescription" String="This property shall contain the current sensor(s) for this circuit.  For single phase circuits this property shall contain a duplicate copy of the current sensor referenced in the CurrentSensor property, if present.  For poly-phase circuits this property should contain multiple current sensor readings used to fully describe the circuit."/>
+          <Annotation Term="OData.LongDescription" String="This property shall contain the current sensors for this circuit.  For single phase circuits this property shall contain a duplicate copy of the current sensor referenced in the CurrentAmps property, if present.  For poly-phase circuits this property should contain multiple current sensor readings used to fully describe the circuit."/>
         </Property>
         <Property Name="PolyPhasePowerWatts" Type="Circuit.v1_0_0.PowerSensors">
           <Annotation Term="OData.Description" String="The power readings for this circuit."/>
-          <Annotation Term="OData.LongDescription" String="This property shall contain the power sensor(s) for this circuit.  For single phase circuits this property shall contain a duplicate copy of the power sensor referenced in the PowerSensor property, if present.  For poly-phase circuits this property should contain multiple power sensor readings used to fully describe the circuit."/>
+          <Annotation Term="OData.LongDescription" String="This property shall contain the power sensors for this circuit.  For single phase circuits this property shall contain a duplicate copy of the power sensor referenced in the PowerWatts property, if present.  For poly-phase circuits this property should contain multiple power sensor readings used to fully describe the circuit."/>
         </Property>
         <Property Name="PolyPhaseEnergykWh" Type="Circuit.v1_0_0.EnergySensors">
           <Annotation Term="OData.Description" String="The energy readings for this circuit."/>
-          <Annotation Term="OData.LongDescription" String="This property shall contain the energy sensor(s) for this circuit.  For single phase circuits this property shall contain a duplicate copy of the energy sensor referenced in the EnergySensor property, if present.  For poly-phase circuits this property should contain multiple energy sensor readings used to fully describe the circuit."/>
+          <Annotation Term="OData.LongDescription" String="This property shall contain the energy sensors for this circuit.  For single phase circuits this property shall contain a duplicate copy of the energy sensor referenced in the EnergykWh property, if present.  For poly-phase circuits this property should contain multiple energy sensor readings used to fully describe the circuit."/>
         </Property>
         <Property Name="Links" Type="Circuit.v1_0_0.Links" Nullable="false">
           <Annotation Term="OData.Description" String="The links to other resources that are related to this resource."/>
@@ -556,33 +568,33 @@
         <Annotation Term="OData.LongDescription" String="This type shall contain properties that describe voltage sensor readings for a circuit."/>
         <NavigationProperty Name="Line1ToLine2" Type="Sensor.Sensor">
           <Annotation Term="Redfish.ExcerptCopy" String="Voltage"/>
-          <Annotation Term="OData.Description" String="The Line 1 to Line 2 voltage reading for this circuit."/>
-          <Annotation Term="OData.LongDescription" String="This property shall contain a Sensor excerpt of type Voltage that measures voltage between L1 and L2.  This property shall not be present if the circuit does not include an L1-L2 measurement."/>
+          <Annotation Term="OData.Description" String="The Line 1 to Line 2 voltage (V) for this circuit."/>
+          <Annotation Term="OData.LongDescription" String="This property shall contain the line-to-line voltage, in volt units, between L1 and L2.  The value of the DataSourceUri property, if present, shall reference a resource of type Sensor with the ReadingType property containing the value `Voltage`.  This property shall not be present if the equipment does not include an L1-L2 measurement."/>
         </NavigationProperty>
         <NavigationProperty Name="Line2ToLine3" Type="Sensor.Sensor">
           <Annotation Term="Redfish.ExcerptCopy" String="Voltage"/>
-          <Annotation Term="OData.Description" String="The Line 2 to Line 3 voltage reading for this circuit."/>
-          <Annotation Term="OData.LongDescription" String="This property shall contain a Sensor excerpt of type Voltage that measures voltage between L2 and L3.  This property shall not be present if the circuit does not include an L2-L3 measurement."/>
+          <Annotation Term="OData.Description" String="The Line 2 to Line 3 voltage (V) for this circuit."/>
+          <Annotation Term="OData.LongDescription" String="This property shall contain the line-to-line voltage, in volt units, between L2 and L3.  The value of the DataSourceUri property, if present, shall reference a resource of type Sensor with the ReadingType property containing the value `Voltage`.  This property shall not be present if the equipment does not include an L2-L3 measurement."/>
         </NavigationProperty>
         <NavigationProperty Name="Line3ToLine1" Type="Sensor.Sensor">
           <Annotation Term="Redfish.ExcerptCopy" String="Voltage"/>
-          <Annotation Term="OData.Description" String="The Line 3 to Line 1 voltage reading for this circuit."/>
-          <Annotation Term="OData.LongDescription" String="This property shall contain a Sensor excerpt of type Voltage that measures voltage between L3 and L1.  This property shall not be present if the circuit does not include an L3-L1 measurement."/>
+          <Annotation Term="OData.Description" String="The Line 3 to Line 1 voltage (V) for this circuit."/>
+          <Annotation Term="OData.LongDescription" String="This property shall contain the line-to-line voltage, in volt units, between L3 and L1.  The value of the DataSourceUri property, if present, shall reference a resource of type Sensor with the ReadingType property containing the value `Voltage`.  This property shall not be present if the equipment does not include an L3-L1 measurement."/>
         </NavigationProperty>
         <NavigationProperty Name="Line1ToNeutral" Type="Sensor.Sensor">
           <Annotation Term="Redfish.ExcerptCopy" String="Voltage"/>
-          <Annotation Term="OData.Description" String="The Line 1 to Neutral voltage reading for this circuit."/>
-          <Annotation Term="OData.LongDescription" String="This property shall contain a Sensor excerpt of type Voltage that measures voltage between L1 and Neutral.  This property shall not be present if the circuit does not include an L1-Neutral measurement."/>
+          <Annotation Term="OData.Description" String="The Line 1 to Neutral voltage (V) for this circuit."/>
+          <Annotation Term="OData.LongDescription" String="This property shall contain the line-to-line voltage, in volt units, between L1 and Neutral.  The value of the DataSourceUri property, if present, shall reference a resource of type Sensor with the ReadingType property containing the value `Voltage`.  This property shall not be present if the equipment does not include an L1-Neutral measurement."/>
         </NavigationProperty>
         <NavigationProperty Name="Line2ToNeutral" Type="Sensor.Sensor">
           <Annotation Term="Redfish.ExcerptCopy" String="Voltage"/>
-          <Annotation Term="OData.Description" String="The Line 2 to Neutral voltage reading for this circuit."/>
-          <Annotation Term="OData.LongDescription" String="This property shall contain a Sensor excerpt of type Voltage that measures voltage between L2 and Neutral.  This property shall not be present if the circuit does not include an L2-Neutral measurement."/>
+          <Annotation Term="OData.Description" String="The Line 2 to Neutral voltage (V) for this circuit."/>
+          <Annotation Term="OData.LongDescription" String="This property shall contain the line-to-line voltage, in volt units, between L2 and Neutral.  The value of the DataSourceUri property, if present, shall reference a resource of type Sensor with the ReadingType property containing the value `Voltage`.  This property shall not be present if the equipment does not include an L2-Neutral measurement."/>
         </NavigationProperty>
         <NavigationProperty Name="Line3ToNeutral" Type="Sensor.Sensor">
           <Annotation Term="Redfish.ExcerptCopy" String="Voltage"/>
-          <Annotation Term="OData.Description" String="The Line 3 to Neutral voltage reading for this circuit."/>
-          <Annotation Term="OData.LongDescription" String="This property shall contain a Sensor excerpt of type Voltage that measures voltage between L3 and Neutral.  This property shall not be present if the circuit does not include an L3-Neutral measurement."/>
+          <Annotation Term="OData.Description" String="The Line 3 to Neutral voltage (V) for this circuit."/>
+          <Annotation Term="OData.LongDescription" String="This property shall contain the line-to-line voltage, in volt units, between L3 and Neutral.  The value of the DataSourceUri property, if present, shall reference a resource of type Sensor with the ReadingType property containing the value `Voltage`.  This property shall not be present if the equipment does not include an L3-Neutral measurement."/>
         </NavigationProperty>
       </ComplexType>
 
@@ -592,23 +604,23 @@
         <Annotation Term="OData.LongDescription" String="This type shall contain properties that describe current sensor readings for a circuit."/>
         <NavigationProperty Name="Line1" Type="Sensor.Sensor">
           <Annotation Term="Redfish.ExcerptCopy" String="Current"/>
-          <Annotation Term="OData.Description" String="Line 1 current sensor."/>
-          <Annotation Term="OData.LongDescription" String="This property shall contain a Sensor excerpt of type Current that measures current for L1.  This property shall not be present if the circuit does not include an L1 measurement."/>
+          <Annotation Term="OData.Description" String="Line 1 current (A)."/>
+          <Annotation Term="OData.LongDescription" String="This property shall contain the line current, in ampere units, for L1.  The value of the DataSourceUri property, if present, shall reference a resource of type Sensor with the ReadingType property containing the value `Current`.  This property shall not be present if the equipment does not include an L1 measurement."/>
         </NavigationProperty>
         <NavigationProperty Name="Line2" Type="Sensor.Sensor">
           <Annotation Term="Redfish.ExcerptCopy" String="Current"/>
-          <Annotation Term="OData.Description" String="Line 2 current sensor."/>
-          <Annotation Term="OData.LongDescription" String="This property shall contain a Sensor excerpt of type Current that measures current for L2.  This property shall not be present if the circuit does not include an L2 measurement."/>
+          <Annotation Term="OData.Description" String="Line 2 current (A)."/>
+          <Annotation Term="OData.LongDescription" String="This property shall contain the line current, in ampere units, for L2.  The value of the DataSourceUri property, if present, shall reference a resource of type Sensor with the ReadingType property containing the value `Current`.  This property shall not be present if the equipment does not include an L2 measurement."/>
         </NavigationProperty>
         <NavigationProperty Name="Line3" Type="Sensor.Sensor">
           <Annotation Term="Redfish.ExcerptCopy" String="Current"/>
-          <Annotation Term="OData.Description" String="Line 3 current sensor."/>
-          <Annotation Term="OData.LongDescription" String="This property shall contain a Sensor excerpt of type Current that measures current for L3.  This property shall not be present if the circuit does not include an L3 measurement."/>
+          <Annotation Term="OData.Description" String="Line 3 current (A)."/>
+          <Annotation Term="OData.LongDescription" String="This property shall contain the line current, in ampere units, for L3.  The value of the DataSourceUri property, if present, shall reference a resource of type Sensor with the ReadingType property containing the value `Current`.  This property shall not be present if the equipment does not include an L3 measurement."/>
         </NavigationProperty>
         <NavigationProperty Name="Neutral" Type="Sensor.Sensor">
           <Annotation Term="Redfish.ExcerptCopy" String="Current"/>
-          <Annotation Term="OData.Description" String="Neutral line current sensor."/>
-          <Annotation Term="OData.LongDescription" String="This property shall contain a Sensor excerpt of type Current that measures current for the Neutral line.  This property shall not be present if the circuit does not include a Neutral measurement."/>
+          <Annotation Term="OData.Description" String="Neutral line current (A)."/>
+          <Annotation Term="OData.LongDescription" String="This property shall contain the line current, in ampere units, for the Neutral line.  The value of the DataSourceUri property, if present, shall reference a resource of type Sensor with the ReadingType property containing the value `Current`.  This property shall not be present if the equipment does not include a Neutral line measurement."/>
         </NavigationProperty>
       </ComplexType>
 
@@ -618,33 +630,33 @@
         <Annotation Term="OData.LongDescription" String="This type shall contain properties that describe energy sensor readings for a circuit."/>
         <NavigationProperty Name="Line1ToLine2" Type="Sensor.Sensor">
           <Annotation Term="Redfish.ExcerptCopy" String="EnergykWh"/>
-          <Annotation Term="OData.Description" String="The Line 1 to Line 2 energy reading for this circuit."/>
-          <Annotation Term="OData.LongDescription" String="This property shall contain a Sensor excerpt of type EnergykWh that measures energy between L1 and L2.  This property shall not be present if the circuit does not include an L1-L2 measurement."/>
+          <Annotation Term="OData.Description" String="The Line 1 to Line 2 energy (kWh) for this circuit."/>
+          <Annotation Term="OData.LongDescription" String="This property shall contain the energy, in kilowatt-hour units, between L1 and L2.  The value of the DataSourceUri property, if present, shall reference a resource of type Sensor with the ReadingType property containing the value `EnergykWh`.  This property shall not be present if the equipment does not include an L1-L2 measurement."/>
         </NavigationProperty>
         <NavigationProperty Name="Line2ToLine3" Type="Sensor.Sensor">
           <Annotation Term="Redfish.ExcerptCopy" String="EnergykWh"/>
-          <Annotation Term="OData.Description" String="The Line 2 to Line 3 energy reading for this circuit."/>
-          <Annotation Term="OData.LongDescription" String="This property shall contain a Sensor excerpt of type EnergykWh that measures energy between L2 and L3.  This property shall not be present if the circuit does not include an L2-L3 measurement."/>
+          <Annotation Term="OData.Description" String="The Line 2 to Line 3 energy (kWh) for this circuit."/>
+          <Annotation Term="OData.LongDescription" String="This property shall contain the energy, in kilowatt-hour units, between L2 and L3.  The value of the DataSourceUri property, if present, shall reference a resource of type Sensor with the ReadingType property containing the value `EnergykWh`.  This property shall not be present if the equipment does not include an L2-L3 measurement."/>
         </NavigationProperty>
         <NavigationProperty Name="Line3ToLine1" Type="Sensor.Sensor">
           <Annotation Term="Redfish.ExcerptCopy" String="EnergykWh"/>
-          <Annotation Term="OData.Description" String="The Line 3 to Line 1 energy reading for this circuit."/>
-          <Annotation Term="OData.LongDescription" String="This property shall contain a Sensor excerpt of type EnergykWh that measures energy between L3 and L1.  This property shall not be present if the circuit does not include an L3-L1 measurement."/>
+          <Annotation Term="OData.Description" String="The Line 3 to Line 1 energy (kWh) for this circuit."/>
+          <Annotation Term="OData.LongDescription" String="This property shall contain the energy, in kilowatt-hour units, between L3 and L1.  The value of the DataSourceUri property, if present, shall reference a resource of type Sensor with the ReadingType property containing the value `EnergykWh`.  This property shall not be present if the equipment does not include an L3-L1 measurement."/>
         </NavigationProperty>
         <NavigationProperty Name="Line1ToNeutral" Type="Sensor.Sensor">
           <Annotation Term="Redfish.ExcerptCopy" String="EnergykWh"/>
-          <Annotation Term="OData.Description" String="The Line 1 to Neutral energy reading for this circuit."/>
-          <Annotation Term="OData.LongDescription" String="This property shall contain a Sensor excerpt of type EnergykWh that measures energy between L1 and Neutral.  This property shall not be present if the circuit does not include an L1-Neutral measurement."/>
+          <Annotation Term="OData.Description" String="The Line 1 to Neutral energy (kWh) for this circuit."/>
+          <Annotation Term="OData.LongDescription" String="This property shall contain the energy, in kilowatt-hour units, between L1 and Neutral.  The value of the DataSourceUri property, if present, shall reference a resource of type Sensor with the ReadingType property containing the value `EnergykWh`.  This property shall not be present if the equipment does not include an L1-Neutral measurement."/>
         </NavigationProperty>
         <NavigationProperty Name="Line2ToNeutral" Type="Sensor.Sensor">
           <Annotation Term="Redfish.ExcerptCopy" String="EnergykWh"/>
-          <Annotation Term="OData.Description" String="The Line 2 to Neutral energy reading for this circuit."/>
-          <Annotation Term="OData.LongDescription" String="This property shall contain a Sensor excerpt of type EnergykWh that measures energy between L2 and Neutral.  This property shall not be present if the circuit does not include an L2-Neutral measurement."/>
+          <Annotation Term="OData.Description" String="The Line 2 to Neutral energy (kWh) for this circuit."/>
+          <Annotation Term="OData.LongDescription" String="This property shall contain the energy, in kilowatt-hour units, between L2 and Neutral.  The value of the DataSourceUri property, if present, shall reference a resource of type Sensor with the ReadingType property containing the value `EnergykWh`.  This property shall not be present if the equipment does not include an L2-Neutral measurement."/>
         </NavigationProperty>
         <NavigationProperty Name="Line3ToNeutral" Type="Sensor.Sensor">
           <Annotation Term="Redfish.ExcerptCopy" String="EnergykWh"/>
-          <Annotation Term="OData.Description" String="The Line 3 to Neutral energy reading for this circuit."/>
-          <Annotation Term="OData.LongDescription" String="This property shall contain a Sensor excerpt of type EnergykWh that measures energy between L3 and Neutral.  This property shall not be present if the circuit does not include an L3-Neutral measurement."/>
+          <Annotation Term="OData.Description" String="The Line 3 to Neutral energy (kWh) for this circuit."/>
+          <Annotation Term="OData.LongDescription" String="This property shall contain the energy, in kilowatt-hour units, between L3 and Neutral.  The value of the DataSourceUri property, if present, shall reference a resource of type Sensor with the ReadingType property containing the value `EnergykWh`.  This property shall not be present if the equipment does not include an L3-Neutral measurement."/>
         </NavigationProperty>
       </ComplexType>
 
@@ -654,33 +666,33 @@
         <Annotation Term="OData.LongDescription" String="This type shall contain properties that describe power sensor readings for a circuit."/>
         <NavigationProperty Name="Line1ToLine2" Type="Sensor.Sensor">
           <Annotation Term="Redfish.ExcerptCopy" String="Power"/>
-          <Annotation Term="OData.Description" String="The Line 1 to Line 2 power reading for this circuit."/>
-          <Annotation Term="OData.LongDescription" String="This property shall contain a Sensor excerpt of type Power that measures power between L1 and L2.  This property shall not be present if the circuit does not include an L1-L2 measurement."/>
+          <Annotation Term="OData.Description" String="The Line 1 to Line 2 power (W) for this circuit."/>
+          <Annotation Term="OData.LongDescription" String="This property shall contain the power, in watt units, between L1 and L2.  The value of the DataSourceUri property, if present, shall reference a resource of type Sensor with the ReadingType property containing the value `Power`.  This property shall not be present if the equipment does not include an L1-L2 measurement."/>
         </NavigationProperty>
         <NavigationProperty Name="Line2ToLine3" Type="Sensor.Sensor">
           <Annotation Term="Redfish.ExcerptCopy" String="Power"/>
-          <Annotation Term="OData.Description" String="The Line 2 to Line 3 power reading for this circuit."/>
-          <Annotation Term="OData.LongDescription" String="This property shall contain a sensor excerpt of type Power that measures power between L2 and L3.  This property shall not be present if the circuit does not include an L2-L3 measurement."/>
+          <Annotation Term="OData.Description" String="The Line 2 to Line 3 power (W) for this circuit."/>
+          <Annotation Term="OData.LongDescription" String="This property shall contain the power, in watt units, between L2 and L3.  The value of the DataSourceUri property, if present, shall reference a resource of type Sensor with the ReadingType property containing the value `Power`.  This property shall not be present if the equipment does not include an L2-L3 measurement."/>
         </NavigationProperty>
         <NavigationProperty Name="Line3ToLine1" Type="Sensor.Sensor">
           <Annotation Term="Redfish.ExcerptCopy" String="Power"/>
-          <Annotation Term="OData.Description" String="The Line 3 to Line 1 power reading for this circuit."/>
-          <Annotation Term="OData.LongDescription" String="This property shall contain a Sensor excerpt of type Power that measures power between L3 and L1.  This property shall not be present if the circuit does not include an L3-L1 measurement."/>
+          <Annotation Term="OData.Description" String="The Line 3 to Line 1 power (W) for this circuit."/>
+          <Annotation Term="OData.LongDescription" String="This property shall contain the power, in watt units, between L3 and L1.  The value of the DataSourceUri property, if present, shall reference a resource of type Sensor with the ReadingType property containing the value `Power`.  This property shall not be present if the equipment does not include an L3-L1 measurement."/>
         </NavigationProperty>
         <NavigationProperty Name="Line1ToNeutral" Type="Sensor.Sensor">
           <Annotation Term="Redfish.ExcerptCopy" String="Power"/>
-          <Annotation Term="OData.Description" String="The Line 1 to Neutral power reading for this circuit."/>
-          <Annotation Term="OData.LongDescription" String="This property shall contain a Sensor excerpt of type Power that measures power between L1 and Neutral.  This property shall not be present if the circuit does not include an L1-Neutral measurement."/>
+          <Annotation Term="OData.Description" String="The Line 1 to Neutral power (W) for this circuit."/>
+          <Annotation Term="OData.LongDescription" String="This property shall contain the power, in watt units, between L1 and Neutral.  The value of the DataSourceUri property, if present, shall reference a resource of type Sensor with the ReadingType property containing the value `Power`.  This property shall not be present if the equipment does not include an L1-Neutral measurement."/>
         </NavigationProperty>
         <NavigationProperty Name="Line2ToNeutral" Type="Sensor.Sensor">
           <Annotation Term="Redfish.ExcerptCopy" String="Power"/>
-          <Annotation Term="OData.Description" String="The Line 2 to Neutral power reading for this circuit."/>
-          <Annotation Term="OData.LongDescription" String="This property shall contain a Sensor excerpt of type Power that measures power between L2 and Neutral.  This property shall not be present if the circuit does not include an L2-Neutral measurement."/>
+          <Annotation Term="OData.Description" String="The Line 2 to Neutral power (W) for this circuit."/>
+          <Annotation Term="OData.LongDescription" String="This property shall contain the power, in watt units, between L2 and Neutral.  The value of the DataSourceUri property, if present, shall reference a resource of type Sensor with the ReadingType property containing the value `Power`.  This property shall not be present if the equipment does not include an L2-Neutral measurement."/>
         </NavigationProperty>
         <NavigationProperty Name="Line3ToNeutral" Type="Sensor.Sensor">
           <Annotation Term="Redfish.ExcerptCopy" String="Power"/>
-          <Annotation Term="OData.Description" String="The Line 3 to Neutral power reading for this circuit."/>
-          <Annotation Term="OData.LongDescription" String="This property shall contain a Sensor excerpt of type Power that measures power between L3 and Neutral.  This property shall not be present if the circuit does not include an L3-Neutral measurement."/>
+          <Annotation Term="OData.Description" String="The Line 3 to Neutral power (W) for this circuit."/>
+          <Annotation Term="OData.LongDescription" String="This property shall contain the power, in watt units, between L3 and Neutral.  The value of the DataSourceUri property, if present, shall reference a resource of type Sensor with the ReadingType property containing the value `Power`.  This property shall not be present if the equipment does not include an L3-Neutral measurement."/>
         </NavigationProperty>
       </ComplexType>
 
@@ -732,6 +744,12 @@
       <EntityType Name="Circuit" BaseType="Circuit.v1_0_1.Circuit"/>
     </Schema>
 
+    <Schema xmlns="http://docs.oasis-open.org/odata/ns/edm" Namespace="Circuit.v1_0_3">
+      <Annotation Term="Redfish.OwningEntity" String="DMTF"/>
+      <Annotation Term="OData.Description" String="This version was created to update descriptions to tie excerpt property definitions to a specific type of Sensor or Control.  It was also created to correct the type for the PowerState parameter of the PowerControl action."/>
+      <EntityType Name="Circuit" BaseType="Circuit.v1_0_2.Circuit"/>
+    </Schema>
+
     <Schema xmlns="http://docs.oasis-open.org/odata/ns/edm" Namespace="Circuit.v1_1_0">
       <Annotation Term="Redfish.OwningEntity" String="DMTF"/>
       <Annotation Term="Redfish.Release" String="2020.3"/>
@@ -752,12 +770,24 @@
       <EntityType Name="Circuit" BaseType="Circuit.v1_1_0.Circuit"/>
     </Schema>
 
+    <Schema xmlns="http://docs.oasis-open.org/odata/ns/edm" Namespace="Circuit.v1_1_2">
+      <Annotation Term="Redfish.OwningEntity" String="DMTF"/>
+      <Annotation Term="OData.Description" String="This version was created to update descriptions to tie excerpt property definitions to a specific type of Sensor or Control.  It was also created to correct the type for the PowerState parameter of the PowerControl action."/>
+      <EntityType Name="Circuit" BaseType="Circuit.v1_1_1.Circuit"/>
+    </Schema>
+
     <Schema xmlns="http://docs.oasis-open.org/odata/ns/edm" Namespace="Circuit.v1_2_0">
       <Annotation Term="Redfish.OwningEntity" String="DMTF"/>
       <Annotation Term="Redfish.Release" String="2020.4"/>
       <Annotation Term="OData.Description" String="This version was created to add DC50V to NominalVoltageType."/>
 
       <EntityType Name="Circuit" BaseType="Circuit.v1_1_1.Circuit"/>
+    </Schema>
+
+    <Schema xmlns="http://docs.oasis-open.org/odata/ns/edm" Namespace="Circuit.v1_2_1">
+      <Annotation Term="Redfish.OwningEntity" String="DMTF"/>
+      <Annotation Term="OData.Description" String="This version was created to update descriptions to tie excerpt property definitions to a specific type of Sensor or Control.  It was also created to correct the type for the PowerState parameter of the PowerControl action."/>
+      <EntityType Name="Circuit" BaseType="Circuit.v1_2_0.Circuit"/>
     </Schema>
 
     <Schema xmlns="http://docs.oasis-open.org/odata/ns/edm" Namespace="Circuit.v1_3_0">
@@ -767,10 +797,16 @@
       <EntityType Name="Circuit" BaseType="Circuit.v1_2_0.Circuit">
         <NavigationProperty Name="PowerLoadPercent" Type="Sensor.Sensor">
           <Annotation Term="Redfish.ExcerptCopy"/>
-          <Annotation Term="OData.Description" String="The power load (%) for this circuit."/>
-          <Annotation Term="OData.LongDescription" String="This property shall contain the power load, measured in percent, for this circuit, that represents the `Total` ElectricalContext for this circuit."/>
+          <Annotation Term="OData.Description" String="The power load (percent) for this circuit."/>
+          <Annotation Term="OData.LongDescription" String="This property shall contain the power load, in percent units, for this circuit, that represents the `Total` ElectricalContext for this circuit."/>
         </NavigationProperty>
       </EntityType>
+    </Schema>
+
+    <Schema xmlns="http://docs.oasis-open.org/odata/ns/edm" Namespace="Circuit.v1_3_1">
+      <Annotation Term="Redfish.OwningEntity" String="DMTF"/>
+      <Annotation Term="OData.Description" String="This version was created to update descriptions to tie excerpt property definitions to a specific type of Sensor or Control.  It was also created to correct the type for the PowerState parameter of the PowerControl action."/>
+      <EntityType Name="Circuit" BaseType="Circuit.v1_3_0.Circuit"/>
     </Schema>
 
     <Schema xmlns="http://docs.oasis-open.org/odata/ns/edm" Namespace="Circuit.v1_4_0">
@@ -821,6 +857,46 @@
           <Annotation Term="OData.AutoExpandReferences"/>
         </NavigationProperty>
       </ComplexType>
+    </Schema>
+
+    <Schema xmlns="http://docs.oasis-open.org/odata/ns/edm" Namespace="Circuit.v1_4_1">
+      <Annotation Term="Redfish.OwningEntity" String="DMTF"/>
+      <Annotation Term="OData.Description" String="This version was created to update descriptions to tie excerpt property definitions to a specific type of Sensor or Control.  It was also created to correct the type for the PowerState parameter of the PowerControl action."/>
+      <EntityType Name="Circuit" BaseType="Circuit.v1_4_0.Circuit"/>
+    </Schema>
+
+    <Schema xmlns="http://docs.oasis-open.org/odata/ns/edm" Namespace="Circuit.v1_5_0">
+      <Annotation Term="Redfish.OwningEntity" String="DMTF"/>
+      <Annotation Term="Redfish.Release" String="2021.4"/>
+      <Annotation Term="OData.Description" String="This version was created to add `PowerCycle` to the PowerState parameter of the PowerControl action."/>
+
+      <EntityType Name="Circuit" BaseType="Circuit.v1_4_1.Circuit">
+        <NavigationProperty Name="UnbalancedVoltagePercent" Type="Sensor.Sensor">
+          <Annotation Term="Redfish.ExcerptCopy"/>
+          <Annotation Term="OData.Description" String="The voltage imbalance (percent) between phases."/>
+          <Annotation Term="OData.LongDescription" String="This property shall contain the voltage imbalance, in percent units, between phases in a poly-phase circuit.  The value of the DataSourceUri property, if present, shall reference a resource of type Sensor with the ReadingType property containing the value `Percent`."/>
+        </NavigationProperty>
+        <NavigationProperty Name="UnbalancedCurrentPercent" Type="Sensor.Sensor">
+          <Annotation Term="Redfish.ExcerptCopy"/>
+          <Annotation Term="OData.Description" String="The current imbalance (percent) between phases."/>
+          <Annotation Term="OData.LongDescription" String="This property shall contain the current imbalance, in percent units, between phases in a poly-phase circuit.  The value of the DataSourceUri property, if present, shall reference a resource of type Sensor with the ReadingType property containing the value `Percent`."/>
+        </NavigationProperty>
+        <Property Name="PowerControlLocked" Type="Edm.Boolean" Nullable="false">
+          <Annotation Term="OData.Permissions" EnumMember="OData.Permission/ReadWrite"/>
+          <Annotation Term="OData.Description" String="Indicates whether power control requests are locked."/>
+          <Annotation Term="OData.LongDescription" String="This property shall indicate whether requests to the PowerControl action are locked.  If `true`, services shall reject requests to the PowerControl action."/>
+        </Property>
+        <Property Name="ConfigurationLocked" Type="Edm.Boolean" Nullable="false">
+          <Annotation Term="OData.Permissions" EnumMember="OData.Permission/ReadWrite"/>
+          <Annotation Term="OData.Description" String="Indicates whether the configuration is locked."/>
+          <Annotation Term="OData.LongDescription" String="This property shall indicate whether modification requests to this resource are not permitted.  If `true`, services shall reject modification requests to other properties in this resource."/>
+        </Property>
+        <Property Name="PowerStateInTransition" Type="Edm.Boolean" Nullable="false">
+          <Annotation Term="OData.Permissions" EnumMember="OData.Permission/Read"/>
+          <Annotation Term="OData.Description" String="Indicates whether the power state is undergoing a delayed transition."/>
+          <Annotation Term="OData.LongDescription" String="This property shall indicate whether the PowerState property will undergo a transition between on and off states due to a configured delay.  The transition may be due to the configuration of the power on, off, or restore delay properties.  If `true`, the PowerState property will transition at the conclusion of a configured delay."/>
+        </Property>
+      </EntityType>
     </Schema>
 
   </edmx:DataServices>

--- a/static/redfish/v1/schema/ComponentIntegrityCollection_v1.xml
+++ b/static/redfish/v1/schema/ComponentIntegrityCollection_v1.xml
@@ -1,0 +1,69 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!---->
+<!--################################################################################       -->
+<!--# Redfish Schema:  ComponentIntegrityCollection                                        -->
+<!--#                                                                                      -->
+<!--# For a detailed change log, see the README file contained in the DSP8010 bundle,      -->
+<!--# available at http://www.dmtf.org/standards/redfish                                   -->
+<!--# Copyright 2014-2021 DMTF.                                                            -->
+<!--# For the full DMTF copyright policy, see http://www.dmtf.org/about/policies/copyright -->
+<!--################################################################################       -->
+<!---->
+<edmx:Edmx xmlns:edmx="http://docs.oasis-open.org/odata/ns/edmx" Version="4.0">
+
+  <edmx:Reference Uri="http://docs.oasis-open.org/odata/odata/v4.0/errata03/csd01/complete/vocabularies/Org.OData.Core.V1.xml">
+    <edmx:Include Namespace="Org.OData.Core.V1" Alias="OData"/>
+  </edmx:Reference>
+  <edmx:Reference Uri="http://docs.oasis-open.org/odata/odata/v4.0/errata03/csd01/complete/vocabularies/Org.OData.Capabilities.V1.xml">
+    <edmx:Include Namespace="Org.OData.Capabilities.V1" Alias="Capabilities"/>
+  </edmx:Reference>
+  <edmx:Reference Uri="http://redfish.dmtf.org/schemas/v1/Resource_v1.xml">
+    <edmx:Include Namespace="Resource.v1_0_0"/>
+  </edmx:Reference>
+  <edmx:Reference Uri="http://redfish.dmtf.org/schemas/v1/RedfishExtensions_v1.xml">
+    <edmx:Include Namespace="RedfishExtensions.v1_0_0" Alias="Redfish"/>
+  </edmx:Reference>
+  <edmx:Reference Uri="http://redfish.dmtf.org/schemas/v1/ComponentIntegrity_v1.xml">
+    <edmx:Include Namespace="ComponentIntegrity"/>
+  </edmx:Reference>
+
+  <edmx:DataServices>
+
+    <Schema xmlns="http://docs.oasis-open.org/odata/ns/edm" Namespace="ComponentIntegrityCollection">
+      <Annotation Term="Redfish.OwningEntity" String="DMTF"/>
+
+      <EntityType Name="ComponentIntegrityCollection" BaseType="Resource.v1_0_0.ResourceCollection">
+        <Annotation Term="OData.Description" String="The collection of ComponentIntegrity resource instances."/>
+        <Annotation Term="OData.LongDescription" String="This resource shall represent a resource collection of ComponentIntegrity instances for a Redfish implementation."/>
+        <Annotation Term="Capabilities.InsertRestrictions">
+          <Record>
+            <PropertyValue Property="Insertable" Bool="false"/>
+          </Record>
+        </Annotation>
+        <Annotation Term="Capabilities.UpdateRestrictions">
+          <Record>
+            <PropertyValue Property="Updatable" Bool="false"/>
+          </Record>
+        </Annotation>
+        <Annotation Term="Capabilities.DeleteRestrictions">
+          <Record>
+            <PropertyValue Property="Deletable" Bool="false"/>
+          </Record>
+        </Annotation>
+        <Annotation Term="Redfish.Uris">
+          <Collection>
+            <String>/redfish/v1/ComponentIntegrity</String>
+          </Collection>
+        </Annotation>
+        <NavigationProperty Name="Members" Type="Collection(ComponentIntegrity.ComponentIntegrity)">
+          <Annotation Term="OData.Permissions" EnumMember="OData.Permission/Read"/>
+          <Annotation Term="OData.Description" String="The members of this collection."/>
+          <Annotation Term="OData.LongDescription" String="This property shall contain an array of links to the members of this collection."/>
+          <Annotation Term="OData.AutoExpandReferences"/>
+          <Annotation Term="Redfish.Required"/>
+        </NavigationProperty>
+      </EntityType>
+    </Schema>
+
+  </edmx:DataServices>
+</edmx:Edmx>

--- a/static/redfish/v1/schema/ComponentIntegrity_v1.xml
+++ b/static/redfish/v1/schema/ComponentIntegrity_v1.xml
@@ -1,0 +1,514 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!---->
+<!--################################################################################       -->
+<!--# Redfish Schema:  ComponentIntegrity v1.0.0                                           -->
+<!--#                                                                                      -->
+<!--# For a detailed change log, see the README file contained in the DSP8010 bundle,      -->
+<!--# available at http://www.dmtf.org/standards/redfish                                   -->
+<!--# Copyright 2014-2021 DMTF.                                                            -->
+<!--# For the full DMTF copyright policy, see http://www.dmtf.org/about/policies/copyright -->
+<!--################################################################################       -->
+<!---->
+<edmx:Edmx xmlns:edmx="http://docs.oasis-open.org/odata/ns/edmx" Version="4.0">
+
+  <edmx:Reference Uri="http://docs.oasis-open.org/odata/odata/v4.0/errata03/csd01/complete/vocabularies/Org.OData.Core.V1.xml">
+    <edmx:Include Namespace="Org.OData.Core.V1" Alias="OData"/>
+  </edmx:Reference>
+  <edmx:Reference Uri="http://docs.oasis-open.org/odata/odata/v4.0/errata03/csd01/complete/vocabularies/Org.OData.Capabilities.V1.xml">
+    <edmx:Include Namespace="Org.OData.Capabilities.V1" Alias="Capabilities"/>
+  </edmx:Reference>
+  <edmx:Reference Uri="http://redfish.dmtf.org/schemas/v1/RedfishExtensions_v1.xml">
+    <edmx:Include Namespace="Validation.v1_0_0" Alias="Validation"/>
+    <edmx:Include Namespace="RedfishExtensions.v1_0_0" Alias="Redfish"/>
+  </edmx:Reference>
+  <edmx:Reference Uri="http://redfish.dmtf.org/schemas/v1/Resource_v1.xml">
+    <edmx:Include Namespace="Resource"/>
+    <edmx:Include Namespace="Resource.v1_0_0"/>
+  </edmx:Reference>
+  <edmx:Reference Uri="http://redfish.dmtf.org/schemas/v1/Certificate_v1.xml">
+    <edmx:Include Namespace="Certificate"/>
+  </edmx:Reference>
+
+  <edmx:DataServices>
+
+    <Schema xmlns="http://docs.oasis-open.org/odata/ns/edm" Namespace="ComponentIntegrity">
+      <Annotation Term="Redfish.OwningEntity" String="DMTF"/>
+
+      <EntityType Name="ComponentIntegrity" BaseType="Resource.v1_0_0.Resource" Abstract="true">
+        <Annotation Term="OData.Description" String="The ComponentIntegrity resource provides critical and pertinent security information about a specific device, system, software element, or other managed entity."/>
+        <Annotation Term="OData.LongDescription" String="This resource shall represent critical and pertinent security information about a specific device, system, software element, or other managed entity."/>
+        <Annotation Term="Capabilities.InsertRestrictions">
+          <Record>
+            <PropertyValue Property="Insertable" Bool="false"/>
+          </Record>
+        </Annotation>
+        <Annotation Term="Capabilities.UpdateRestrictions">
+          <Record>
+            <PropertyValue Property="Updatable" Bool="true"/>
+          </Record>
+        </Annotation>
+        <Annotation Term="Capabilities.DeleteRestrictions">
+          <Record>
+            <PropertyValue Property="Deletable" Bool="false"/>
+          </Record>
+        </Annotation>
+        <Annotation Term="Redfish.Uris">
+          <Collection>
+            <String>/redfish/v1/ComponentIntegrity/{ComponentIntegrityId}</String>
+          </Collection>
+        </Annotation>
+      </EntityType>
+
+      <Action Name="SPDMGetSignedMeasurements" IsBound="true">
+        <Annotation Term="OData.Description" String="This action generates an SPDM cryptographic signed statement over the given nonce and measurements of the SPDM Responder."/>
+        <Annotation Term="OData.LongDescription" String="This action shall generate a cryptographic signed statement over the given nonce and measurements corresponding to the SPDM Responder.  This action shall not be present if the ComponentIntegrityType property does not contain the value `SPDM`.  The SPDM Requester shall issue one or more SPDM 'GET_MEASUREMENTS' requests for each of the requested measurement indices to the SPDM Responder.  When the SPDM 'GET_MEASUREMENTS' requests are made for version 1.2, the parameter 'RawBitStreamRequested' shall contain `0`.  The SPDM Requester shall provide the nonce for the action to the SPDM Responder in the last SPDM 'GET_MEASUREMENTS' request.  The SPDM Requester shall request a signature in the last SPDM 'GET_MEASUREMENTS' request."/>
+        <Parameter Name="Nonce" Type="Edm.String">
+          <Annotation Term="OData.Description" String="A 32-byte hex-encoded string that is signed with the measurements.  The value should be unique."/>
+          <Annotation Term="OData.LongDescription" String="This parameter shall contain a 32-byte hex-encoded string that is signed with the measurements.  If not provided by the client, the SPDM Requester shall generate the nonce.  The value should be unique and generated using a random or a pseudo-random generator."/>
+          <Annotation Term="Validation.Pattern" String="^[0-9a-fA-F]{64}$"/>
+        </Parameter>
+        <Parameter Name="SlotId" Type="Edm.Int64">
+          <Annotation Term="OData.Description" String="The slot identifier for the certificate containing the private key to generate the signature over the measurements."/>
+          <Annotation Term="OData.LongDescription" String="This parameter shall contain the SPDM slot identifier for the certificate containing the private key to generate the signature over the measurements.  If not provided by the client, the value shall be assumed to be `0`.  The SPDM Requester shall send this value to the SPDM Responder in the SPDM 'GET_MEASUREMENTS' request."/>
+        </Parameter>
+        <Parameter Name="MeasurementIndices" Type="Collection(Edm.Int64)">
+          <Annotation Term="OData.Description" String="An array of indices that identify the measurement blocks to sign."/>
+          <Annotation Term="OData.LongDescription" String="This parameter shall contain an array of indices that identify the measurement blocks to sign.  This array shall contain one or more unique values between `0` to `254`, inclusive, or contain a single value of `255`.  If not provided by the client, the value shall be assumed to be an array containing a single value of `255`."/>
+        </Parameter>
+        <ReturnType Type="ComponentIntegrity.v1_0_0.SPDMGetSignedMeasurementsResponse" Nullable="false"/>
+      </Action>
+    </Schema>
+
+    <Schema xmlns="http://docs.oasis-open.org/odata/ns/edm" Namespace="ComponentIntegrity.v1_0_0">
+      <Annotation Term="Redfish.OwningEntity" String="DMTF"/>
+      <Annotation Term="Redfish.Release" String="2021.4"/>
+
+      <EntityType Name="ComponentIntegrity" BaseType="ComponentIntegrity.ComponentIntegrity">
+        <Property Name="Actions" Type="ComponentIntegrity.v1_0_0.Actions" Nullable="false">
+          <Annotation Term="OData.Description" String="The available actions for this resource."/>
+          <Annotation Term="OData.LongDescription" String="This property shall contain the available actions for this resource."/>
+        </Property>
+        <Property Name="Status" Type="Resource.Status" Nullable="false">
+          <Annotation Term="OData.Description" String="The status and health of the resource and its subordinate or dependent resources."/>
+          <Annotation Term="OData.LongDescription" String="This property shall contain any status or health properties of the resource."/>
+        </Property>
+        <Property Name="ComponentIntegrityType" Type="ComponentIntegrity.v1_0_0.ComponentIntegrityType" Nullable="false">
+          <Annotation Term="OData.Permissions" EnumMember="OData.Permission/Read"/>
+          <Annotation Term="OData.Description" String="The type of security technology for the component."/>
+          <Annotation Term="OData.LongDescription" String="This value of this property shall contain the underlying security technology providing integrity information for the component."/>
+          <Annotation Term="Redfish.Required"/>
+        </Property>
+        <Property Name="ComponentIntegrityTypeVersion" Type="Edm.String" Nullable="false">
+          <Annotation Term="OData.Permissions" EnumMember="OData.Permission/Read"/>
+          <Annotation Term="OData.Description" String="The version of the security technology."/>
+          <Annotation Term="OData.LongDescription" String="This value of this property shall contain the version of the security technology indicated by the ComponentIntegrityType property.  If ComponentIntegrityType contains `SPDM`, this property shall contain the negotiated or selected SPDM protocol.  If ComponentIntegrityType contains `TPM`, this property shall contain the version of the TPM."/>
+          <Annotation Term="Redfish.Required"/>
+        </Property>
+        <Property Name="ComponentIntegrityEnabled" Type="Edm.Boolean" Nullable="false">
+          <Annotation Term="OData.Permissions" EnumMember="OData.Permission/ReadWrite"/>
+          <Annotation Term="OData.Description" String="An indication of whether security protocols are enabled for the component."/>
+          <Annotation Term="OData.LongDescription" String="This property shall indicate whether security protocols are enabled for the component.  If ComponentIntegrityType contains `SPDM`, a value of `false` shall prohibit the SPDM Requester from using SPDM to communicate with the component identified by the TargetComponentURI property.  If ComponentIntegrityType contains `TPM`, a value of `false` shall disable the TPM component identified by the TargetComponentURI property entirely.  If `false`, services shall not provide the TPM and SPDM properties in response payloads for this resource.  If `false`, services shall reject action requests to this resource.  If `true`, services shall allow security protocols with the component identified by the TargetComponentURI property."/>
+        </Property>
+        <Property Name="TargetComponentURI" Type="Edm.String" Nullable="false">
+          <Annotation Term="OData.Permissions" EnumMember="OData.Permission/Read"/>
+          <Annotation Term="OData.Description" String="The link to the the component whose integrity that this resource reports."/>
+          <Annotation Term="OData.LongDescription" String="This value of this property shall contain a link to the resource whose integrity information is reported in this resource.  If ComponentIntegrityType contains `SPDM`, this property shall contain a URI to the resource that represents the SPDM Responder.  If ComponentIntegrityType contains `TPM`, this property shall contain a URI with RFC6901-defined JSON fragment notation to a member of the TrustedModules array in a ComputerSystem resource that represents the TPM."/>
+          <Annotation Term="Redfish.Required"/>
+        </Property>
+        <Property Name="Links" Type="ComponentIntegrity.v1_0_0.Links" Nullable="false">
+          <Annotation Term="OData.Description" String="The links to other resources that are related to this resource."/>
+          <Annotation Term="OData.LongDescription" String="This property shall contain links to resources that are related to but are not contained by, or subordinate to, this resource."/>
+        </Property>
+        <Property Name="LastUpdated" Type="Edm.DateTimeOffset">
+          <Annotation Term="OData.Permissions" EnumMember="OData.Permission/Read"/>
+          <Annotation Term="OData.Description" String="The date and time when information for the component was last updated."/>
+          <Annotation Term="OData.LongDescription" String="This property shall contain the date and time when information for the component was last updated."/>
+        </Property>
+        <Property Name="SPDM" Type="ComponentIntegrity.v1_0_0.SPDMinfo" Nullable="false">
+          <Annotation Term="OData.Description" String="Integrity information about the SPDM Responder as reported by an SPDM Requester."/>
+          <Annotation Term="OData.LongDescription" String="This property shall contain integrity information about the SPDM Responder identified by the TargetComponentURI property as reported by an SPDM Requester.  This property shall be present if ComponentIntegrityType contains `SPDM` and `ComponentIntegrityEnabled` contains `true`.  For other cases, this property shall be absent."/>
+        </Property>
+        <Property Name="TPM" Type="ComponentIntegrity.v1_0_0.TPMinfo" Nullable="false">
+          <Annotation Term="OData.Description" String="Integrity information about the Trusted Platform Module (TPM)."/>
+          <Annotation Term="OData.LongDescription" String="This property shall contain integrity information about the Trusted Platform Module (TPM) identified by the TargetComponentURI property,  This property shall be present if ComponentIntegrityType contains `TPM` and `ComponentIntegrityEnabled` contains `true`.  For other cases, this property shall be absent."/>
+        </Property>
+      </EntityType>
+
+      <ComplexType Name="Actions">
+        <Annotation Term="OData.AdditionalProperties" Bool="false"/>
+        <Annotation Term="OData.Description" String="The available actions for this resource."/>
+        <Annotation Term="OData.LongDescription" String="This type shall contain the available actions for this resource."/>
+        <Property Name="Oem" Type="ComponentIntegrity.v1_0_0.OemActions" Nullable="false">
+          <Annotation Term="OData.Description" String="The available OEM-specific actions for this resource."/>
+          <Annotation Term="OData.LongDescription" String="This property shall contain the available OEM-specific actions for this resource."/>
+        </Property>
+      </ComplexType>
+
+      <ComplexType Name="OemActions">
+        <Annotation Term="OData.AdditionalProperties" Bool="true"/>
+        <Annotation Term="OData.Description" String="The available OEM-specific actions for this resource."/>
+        <Annotation Term="OData.LongDescription" String="This type shall contain the available OEM-specific actions for this resource."/>
+      </ComplexType>
+
+      <EnumType Name="ComponentIntegrityType">
+        <Member Name="SPDM">
+          <Annotation Term="OData.Description" String="Security Protocol and Data Model (SPDM) protocol."/>
+          <Annotation Term="OData.LongDescription" String="This value shall indicate the integrity information is obtained through the Security Protocol and Data Model (SPDM) protocol as defined in DMTF DSP0274."/>
+        </Member>
+        <Member Name="TPM">
+          <Annotation Term="OData.Description" String="Trusted Platform Module (TPM)."/>
+          <Annotation Term="OData.LongDescription" String="This value shall indicate the integrity information is related to a Trusted Platform Module (TPM) as defined by the Trusted Computing Group (TCG)."/>
+        </Member>
+        <Member Name="OEM">
+          <Annotation Term="OData.Description" String="OEM-specific."/>
+          <Annotation Term="OData.LongDescription" String="This value shall indicate the integrity information is OEM-specific and the OEM section may include additional information."/>
+        </Member>
+      </EnumType>
+
+      <ComplexType Name="Links" BaseType="Resource.Links">
+        <Annotation Term="OData.Description" String="The links to other resources that are related to this resource."/>
+        <Annotation Term="OData.LongDescription" String="This Redfish Specification-described type shall contain links to resources that are related to but are not contained by, or subordinate to, this resource."/>
+        <NavigationProperty Name="ComponentsProtected" Type="Collection(Resource.Item)">
+          <Annotation Term="OData.Permissions" EnumMember="OData.Permission/Read"/>
+          <Annotation Term="OData.Description" String="An array of links to resources that the target component protects."/>
+          <Annotation Term="OData.LongDescription" String="This property shall contain an array of links to resources that the component identified by the TargetComponentURI property provides integrity protection.  This property shall not contain the value of the TargetComponentURI property."/>
+        </NavigationProperty>
+      </ComplexType>
+
+      <ComplexType Name="SPDMinfo">
+        <Annotation Term="OData.AdditionalProperties" Bool="false"/>
+        <Annotation Term="OData.Description" String="Integrity information about an SPDM Responder as reported by an SPDM Requester."/>
+        <Annotation Term="OData.LongDescription" String="This object shall contain integrity information about an SPDM Responder as reported by an SPDM Requester."/>
+        <NavigationProperty Name="Requester" Type="Resource.Item" Nullable="false">
+          <Annotation Term="OData.Permissions" EnumMember="OData.Permission/Read"/>
+          <Annotation Term="OData.Description" String="The link to the the component that is reporting the integrity information of the target component."/>
+          <Annotation Term="OData.LongDescription" String="This property shall contain a link to the resource representing the SPDM Responder that is reporting the integrity of the SPDM Responder identified by the TargetComponentURI property."/>
+          <Annotation Term="Redfish.Required"/>
+        </NavigationProperty>
+        <Property Name="MeasurementSet" Type="ComponentIntegrity.v1_0_0.SPDMmeasurementSet">
+          <Annotation Term="OData.Description" String="Measurement information about the SPDM Responder."/>
+          <Annotation Term="OData.LongDescription" String="This property shall contain measurement information for the SPDM Responder."/>
+        </Property>
+        <Property Name="IdentityAuthentication" Type="ComponentIntegrity.v1_0_0.SPDMidentity">
+          <Annotation Term="OData.Description" String="Identity authentication information about the SPDM Requester and SPDM Responder."/>
+          <Annotation Term="OData.LongDescription" String="This property shall contain identity authentication information about the SPDM Requester and SPDM Responder."/>
+        </Property>
+        <Property Name="ComponentCommunication" Type="ComponentIntegrity.v1_0_0.SPDMcommunication">
+          <Annotation Term="OData.Description" String="Information about communication between the SPDM Requester and SPDM Responder."/>
+          <Annotation Term="OData.LongDescription" String="This property shall contain information about communication between the SPDM Requester and SPDM Responder."/>
+        </Property>
+      </ComplexType>
+
+      <ComplexType Name="TPMinfo">
+        <Annotation Term="OData.AdditionalProperties" Bool="false"/>
+        <Annotation Term="OData.Description" String="Integrity information about a Trusted Platform Module (TPM)."/>
+        <Annotation Term="OData.LongDescription" String="This object shall contain integrity information about a Trusted Platform Module (TPM)."/>
+        <Property Name="MeasurementSet" Type="ComponentIntegrity.v1_0_0.TPMmeasurementSet">
+          <Annotation Term="OData.Description" String="Measurement information from the TPM."/>
+          <Annotation Term="OData.LongDescription" String="This property shall contain measurement information from the TPM."/>
+        </Property>
+        <Property Name="IdentityAuthentication" Type="ComponentIntegrity.v1_0_0.TPMauth">
+          <Annotation Term="OData.Description" String="Identity authentication information about the TPM."/>
+          <Annotation Term="OData.LongDescription" String="This property shall contain identity authentication information about the TPM."/>
+        </Property>
+        <Property Name="ComponentCommunication" Type="ComponentIntegrity.v1_0_0.TPMcommunication">
+          <Annotation Term="OData.Description" String="Information about communication with the TPM."/>
+          <Annotation Term="OData.LongDescription" String="This property shall contain information about communication with the TPM."/>
+        </Property>
+      </ComplexType>
+
+      <ComplexType Name="SPDMmeasurementSet">
+        <Annotation Term="OData.AdditionalProperties" Bool="false"/>
+        <Annotation Term="OData.Description" String="SPDM Responder measurement information."/>
+        <Annotation Term="OData.LongDescription" String="This object shall contain SPDM Responder measurement information."/>
+        <Property Name="MeasurementSpecification" Type="ComponentIntegrity.v1_0_0.MeasurementSpecification">
+          <Annotation Term="OData.Permissions" EnumMember="OData.Permission/Read"/>
+          <Annotation Term="OData.Description" String="The measurement specification negotiated between the SPDM Requester and SPDM Responder."/>
+          <Annotation Term="OData.LongDescription" String="This property shall contain the measurement specification negotiated between the SPDM Requester and SPDM Responder."/>
+        </Property>
+        <Property Name="Measurements" Type="Collection(ComponentIntegrity.v1_0_0.SPDMsingleMeasurement)">
+          <Annotation Term="OData.Description" String="Measurements from an SPDM Responder."/>
+          <Annotation Term="OData.LongDescription" String="This property shall contain measurements from an SPDM Responder."/>
+        </Property>
+        <Property Name="MeasurementSummary" Type="Edm.String">
+          <Annotation Term="OData.Permissions" EnumMember="OData.Permission/Read"/>
+          <Annotation Term="OData.Description" String="The measurement summary data."/>
+          <Annotation Term="OData.LongDescription" String="This property shall contain the Base64-encoded measurement summary using the hash algorithm indicated by the MeasurementSummaryHashAlgorithm property."/>
+          <Annotation Term="Validation.Pattern" String="^[A-Za-z0-9+/]+={0,2}$"/>
+        </Property>
+        <Property Name="MeasurementSummaryHashAlgorithm" Type="Edm.String">
+          <Annotation Term="OData.Permissions" EnumMember="OData.Permission/Read"/>
+          <Annotation Term="OData.Description" String="The hash algorithm used to compute the measurement summary."/>
+          <Annotation Term="OData.LongDescription" String="This property shall contain the hash algorithm used to compute the measurement summary.  The allowable values for this property shall be the hash algorithm names found in the 'BaseHashAlgo' field of the 'NEGOTIATE_ALGORITHMS' request message in DSP0274.  If the algorithm is an extended algorithm, this property shall contain the value `OEM`."/>
+        </Property>
+        <Property Name="MeasurementSummaryType" Type="ComponentIntegrity.v1_0_0.SPDMmeasurementSummaryType">
+          <Annotation Term="OData.Permissions" EnumMember="OData.Permission/Read"/>
+          <Annotation Term="OData.Description" String="The type of measurement summary."/>
+          <Annotation Term="OData.LongDescription" String="This property shall contain the type of measurement summary."/>
+        </Property>
+        <Property Name="Oem" Type="Resource.Oem" Nullable="false">
+          <Annotation Term="OData.Description" String="The OEM extension property."/>
+          <Annotation Term="OData.LongDescription" String="This property shall contain the OEM extensions.  All values for properties contained in this object shall conform to the Redfish Specification-described requirements."/>
+        </Property>
+      </ComplexType>
+
+      <EnumType Name="MeasurementSpecification">
+        <Member Name="DMTF">
+          <Annotation Term="OData.Description" String="DMTF."/>
+          <Annotation Term="OData.LongDescription" String="This value shall indicate the measurement specification is defined by DMTF in DSP0274."/>
+        </Member>
+      </EnumType>
+
+      <EnumType Name="SPDMmeasurementSummaryType">
+        <Member Name="TCB">
+          <Annotation Term="OData.Description" String="The measurement summary covers the TCB."/>
+        </Member>
+        <Member Name="All">
+          <Annotation Term="OData.Description" String="The measurement summary covers all measurements in SPDM."/>
+        </Member>
+      </EnumType>
+
+      <ComplexType Name="SPDMsingleMeasurement">
+        <Annotation Term="OData.AdditionalProperties" Bool="false"/>
+        <Annotation Term="OData.Description" String="A single SPDM measurement for an SPDM Responder."/>
+        <Annotation Term="OData.LongDescription" String="This object shall contain a single SPDM measurement for an SPDM Responder."/>
+        <Property Name="MeasurementIndex" Type="Edm.Int64">
+          <Annotation Term="OData.Permissions" EnumMember="OData.Permission/Read"/>
+          <Annotation Term="OData.Description" String="The index of the measurement."/>
+          <Annotation Term="OData.LongDescription" String="This property shall contain the index of the measurement."/>
+        </Property>
+        <Property Name="PartofSummaryHash" Type="Edm.Boolean">
+          <Annotation Term="OData.Permissions" EnumMember="OData.Permission/Read"/>
+          <Annotation Term="OData.Description" String="Indicates whether this measurement is part of the measurement summary."/>
+          <Annotation Term="OData.LongDescription" String="This property shall indicate if this measurement is part of the measurement summary in the MeasurementSummary property.  If this property is not present, it shall be assumed to be `false`."/>
+        </Property>
+        <Property Name="LastUpdated" Type="Edm.DateTimeOffset">
+          <Annotation Term="OData.Permissions" EnumMember="OData.Permission/Read"/>
+          <Annotation Term="OData.Description" String="The date and time when information for the measurement was last updated."/>
+          <Annotation Term="OData.LongDescription" String="This property shall contain the date and time when information for the measurement was last updated."/>
+        </Property>
+        <Property Name="Measurement" Type="Edm.String">
+          <Annotation Term="OData.Permissions" EnumMember="OData.Permission/Read"/>
+          <Annotation Term="OData.Description" String="The measurement data."/>
+          <Annotation Term="OData.LongDescription" String="This property shall contain the Base64-encoded measurement using the hash algorithm indicated by the MeasurementHashAlgorithm property.  This property shall not contain a raw bit stream as a measurement.  If the SPDM Responder provides a raw bit stream, the SPDM Requester may apply a hash algorithm to the raw bit stream in order to report the measurement."/>
+          <Annotation Term="Validation.Pattern" String="^[A-Za-z0-9+/]+={0,2}$"/>
+        </Property>
+        <Property Name="MeasurementHashAlgorithm" Type="Edm.String">
+          <Annotation Term="OData.Permissions" EnumMember="OData.Permission/Read"/>
+          <Annotation Term="OData.Description" String="The hash algorithm used to compute the measurement."/>
+          <Annotation Term="OData.LongDescription" String="This property shall contain the hash algorithm used to compute the measurement.  The allowable values for this property shall be the hash algorithm names found in the 'BaseHashAlgo' field of the 'NEGOTIATE_ALGORITHMS' request message in DSP0274.  If the algorithm is an extended algorithm, this property shall contain the value `OEM`.  This property shall not be present if MeasurementSpecification does not contain `DMTF`."/>
+        </Property>
+        <Property Name="MeasurementType" Type="ComponentIntegrity.v1_0_0.DMTFmeasurementTypes">
+          <Annotation Term="OData.Permissions" EnumMember="OData.Permission/Read"/>
+          <Annotation Term="OData.Description" String="The type or characteristics of the data that this measurement represents."/>
+          <Annotation Term="OData.LongDescription" String="This property shall contain the type or characteristics of the data that this measurement represents.  This property shall not be present if MeasurementSpecification does not contain `DMTF`."/>
+        </Property>
+        <Property Name="Oem" Type="Resource.Oem" Nullable="false">
+          <Annotation Term="OData.Description" String="The OEM extension property."/>
+          <Annotation Term="OData.LongDescription" String="This property shall contain the OEM extensions.  All values for properties contained in this object shall conform to the Redfish Specification-described requirements."/>
+        </Property>
+      </ComplexType>
+
+      <EnumType Name="DMTFmeasurementTypes">
+        <Member Name="ImmutableROM">
+          <Annotation Term="OData.Description" String="Immutable ROM."/>
+        </Member>
+        <Member Name="MutableFirmware">
+          <Annotation Term="OData.Description" String="Mutable firmware or any mutable code."/>
+        </Member>
+        <Member Name="HardwareConfiguration">
+          <Annotation Term="OData.Description" String="Hardware configuration, such as straps."/>
+        </Member>
+        <Member Name="FirmwareConfiguration">
+          <Annotation Term="OData.Description" String="Firmware configuration, such as configurable firmware policy."/>
+        </Member>
+        <Member Name="MutableFirmwareVersion">
+          <Annotation Term="OData.Description" String="Mutable firmware version."/>
+        </Member>
+        <Member Name="MutableFirmwareSecurityVersionNumber">
+          <Annotation Term="OData.Description" String="Mutable firmware security version number."/>
+        </Member>
+        <Member Name="MeasurementManifest">
+          <Annotation Term="OData.Description" String="Measurement Manifest."/>
+        </Member>
+      </EnumType>
+
+      <ComplexType Name="TPMmeasurementSet">
+        <Annotation Term="OData.AdditionalProperties" Bool="false"/>
+        <Annotation Term="OData.Description" String="Trusted Computing Group TPM measurement information."/>
+        <Annotation Term="OData.LongDescription" String="This object shall contain Trusted Computing Group TPM measurement information."/>
+        <Property Name="Measurements" Type="Collection(ComponentIntegrity.v1_0_0.TPMsingleMeasurement)">
+          <Annotation Term="OData.Description" String="Measurements from a TPM."/>
+          <Annotation Term="OData.LongDescription" String="This property shall contain measurements from a TPM."/>
+        </Property>
+      </ComplexType>
+
+      <ComplexType Name="TPMsingleMeasurement">
+        <Annotation Term="OData.AdditionalProperties" Bool="false"/>
+        <Annotation Term="OData.Description" String="A single Trusted Computing Group TPM measurement."/>
+        <Annotation Term="OData.LongDescription" String="This object shall contain a single Trusted Computing Group TPM measurement."/>
+        <Property Name="PCR" Type="Edm.Int64">
+          <Annotation Term="OData.Permissions" EnumMember="OData.Permission/Read"/>
+          <Annotation Term="OData.Description" String="The Platform Configuration Register (PCR) bank of the measurement."/>
+          <Annotation Term="OData.LongDescription" String="This property shall contain the Platform Configuration Register (PCR) bank of the measurement."/>
+        </Property>
+        <Property Name="Measurement" Type="Edm.String">
+          <Annotation Term="OData.Permissions" EnumMember="OData.Permission/Read"/>
+          <Annotation Term="OData.Description" String="The measurement data."/>
+          <Annotation Term="OData.LongDescription" String="This property shall contain the Base64-encoded PCR digest using the hashing algorithm indicated by MeasurementHashAlgorithm property."/>
+          <Annotation Term="Validation.Pattern" String="^[A-Za-z0-9+/]+={0,2}$"/>
+        </Property>
+        <Property Name="MeasurementHashAlgorithm" Type="Edm.String">
+          <Annotation Term="OData.Permissions" EnumMember="OData.Permission/Read"/>
+          <Annotation Term="OData.Description" String="The hash algorithm used to compute the measurement."/>
+          <Annotation Term="OData.LongDescription" String="This property shall contain the hash algorithm used to compute the measurement.  The allowable values for this property shall be the strings in the 'Algorithm Name' field of the 'TPM_ALG_ID Constants' table within the 'Trusted Computing Group Algorithm Registry'."/>
+        </Property>
+        <Property Name="LastUpdated" Type="Edm.DateTimeOffset">
+          <Annotation Term="OData.Permissions" EnumMember="OData.Permission/Read"/>
+          <Annotation Term="OData.Description" String="The date and time when information for the measurement was last updated."/>
+          <Annotation Term="OData.LongDescription" String="This property shall contain the date and time when information for the measurement was last updated."/>
+        </Property>
+      </ComplexType>
+
+      <EnumType Name="VerificationStatus">
+        <Member Name="Success">
+          <Annotation Term="OData.Description" String="Successful verification."/>
+        </Member>
+        <Member Name="Failed">
+          <Annotation Term="OData.Description" String="Unsuccessful verification."/>
+        </Member>
+      </EnumType>
+
+      <ComplexType Name="CommonAuthInfo">
+        <Annotation Term="OData.AdditionalProperties" Bool="false"/>
+        <Annotation Term="OData.Description" String="Common Authentication information."/>
+        <Annotation Term="OData.LongDescription" String="This object shall contain common identity-related authentication information."/>
+        <NavigationProperty Name="ComponentCertificate" Type="Certificate.Certificate" Nullable="false">
+          <Annotation Term="OData.Permissions" EnumMember="OData.Permission/Read"/>
+          <Annotation Term="OData.Description" String="A link to the certificate that represents the identify of the component."/>
+          <Annotation Term="OData.LongDescription" String="This property shall contain a link to a resource of type Certificate that represents the identify of the component referenced by the TargetComponentURI property."/>
+        </NavigationProperty>
+        <Property Name="VerificationStatus" Type="ComponentIntegrity.v1_0_0.VerificationStatus">
+          <Annotation Term="OData.Permissions" EnumMember="OData.Permission/Read"/>
+          <Annotation Term="OData.Description" String="The status of the verification of the identity of the component."/>
+          <Annotation Term="OData.LongDescription" String="This property shall contain the status of the verification of the identity of the component referenced by the TargetComponentURI property.."/>
+        </Property>
+      </ComplexType>
+
+      <ComplexType Name="SPDMresponderAuth" BaseType="ComponentIntegrity.v1_0_0.CommonAuthInfo"/>
+      <ComplexType Name="TPMauth" BaseType="ComponentIntegrity.v1_0_0.CommonAuthInfo"/>
+
+      <ComplexType Name="SPDMrequesterAuth">
+        <Annotation Term="OData.AdditionalProperties" Bool="false"/>
+        <Annotation Term="OData.Description" String="Authentication information of the identity of the SPDM Requester."/>
+        <Annotation Term="OData.LongDescription" String="This object shall contain authentication information of the identity of the SPDM Requester."/>
+        <NavigationProperty Name="ProvidedCertificate" Type="Certificate.Certificate" Nullable="false">
+          <Annotation Term="OData.Permissions" EnumMember="OData.Permission/Read"/>
+          <Annotation Term="OData.Description" String="A link to the certificate that represents the identify of the SPDM Requester provided in mutual authentication."/>
+          <Annotation Term="OData.LongDescription" String="This property shall contain a link to a resource of type Certificate that represents the identify of the SPDM Requester provided in mutual authentication."/>
+        </NavigationProperty>
+      </ComplexType>
+
+      <ComplexType Name="SPDMidentity">
+        <Annotation Term="OData.AdditionalProperties" Bool="false"/>
+        <Annotation Term="OData.Description" String="Identity authentication information about the SPDM Requester and SPDM Responder."/>
+        <Annotation Term="OData.LongDescription" String="This object shall contain identity authentication information about the SPDM Requester and SPDM Responder."/>
+        <Property Name="ResponderAuthentication" Type="ComponentIntegrity.v1_0_0.SPDMresponderAuth">
+          <Annotation Term="OData.Description" String="Authentication information of the identity of the SPDM Responder."/>
+          <Annotation Term="OData.LongDescription" String="This property shall contain authentication information of the identity of the SPDM Responder."/>
+        </Property>
+        <Property Name="RequesterAuthentication" Type="ComponentIntegrity.v1_0_0.SPDMrequesterAuth">
+          <Annotation Term="OData.Description" String="Authentication information of the identity of the SPDM Requester."/>
+          <Annotation Term="OData.LongDescription" String="This property shall contain authentication information of the identity of the SPDM Requester."/>
+        </Property>
+      </ComplexType>
+
+      <EnumType Name="SecureSessionType">
+        <Member Name="Plain">
+          <Annotation Term="OData.Description" String="A plain text session without any protection."/>
+        </Member>
+        <Member Name="EncryptedAuthenticated">
+          <Annotation Term="OData.Description" String="An established session where both encryption and authentication are protecting the communication."/>
+        </Member>
+        <Member Name="AuthenticatedOnly">
+          <Annotation Term="OData.Description" String="An established session where only authentication is protecting the communication."/>
+        </Member>
+      </EnumType>
+
+      <ComplexType Name="SingleSessionInfo">
+        <Annotation Term="OData.AdditionalProperties" Bool="false"/>
+        <Annotation Term="OData.Description" String="Information about a single communication channel or session between two components."/>
+        <Annotation Term="OData.LongDescription" String="This object shall contain information about a single communication channel or session between two components."/>
+        <Property Name="SessionId" Type="Edm.Int64">
+          <Annotation Term="OData.Permissions" EnumMember="OData.Permission/Read"/>
+          <Annotation Term="OData.Description" String="The identifier for an active session or communication channel between two components."/>
+          <Annotation Term="OData.LongDescription" String="This property shall contain the unique identifier for the active session or communication channel between two components."/>
+        </Property>
+        <Property Name="SessionType" Type="ComponentIntegrity.v1_0_0.SecureSessionType">
+          <Annotation Term="OData.Permissions" EnumMember="OData.Permission/Read"/>
+          <Annotation Term="OData.Description" String="The type of session or communication channel between two components."/>
+          <Annotation Term="OData.LongDescription" String="This property shall contain the type of session or communication channel between two components."/>
+        </Property>
+      </ComplexType>
+
+      <ComplexType Name="CommunicationInfo">
+        <Annotation Term="OData.AdditionalProperties" Bool="false"/>
+        <Annotation Term="OData.Description" String="Information about communication between two components."/>
+        <Annotation Term="OData.LongDescription" String="This object shall contain information about communication between two components."/>
+        <Property Name="Sessions" Type="Collection(ComponentIntegrity.v1_0_0.SingleSessionInfo)">
+          <Annotation Term="OData.Description" String="The active sessions or communication channels between two components."/>
+          <Annotation Term="OData.LongDescription" String="This property shall contain an array of the active sessions or communication channels between two components  The active sessions or communication channels do not reflect how future sessions or communication channels are established."/>
+        </Property>
+      </ComplexType>
+
+      <ComplexType Name="SPDMcommunication" BaseType="ComponentIntegrity.v1_0_0.CommunicationInfo"/>
+      <ComplexType Name="TPMcommunication" BaseType="ComponentIntegrity.v1_0_0.CommunicationInfo"/>
+
+      <ComplexType Name="SPDMGetSignedMeasurementsResponse">
+        <Annotation Term="OData.AdditionalProperties" Bool="false"/>
+        <Annotation Term="OData.Description" String="The SPDM signed measurement from an SPDM Responder."/>
+        <Annotation Term="OData.LongDescription" String="This object shall contain the SPDM signed measurements from an SPDM Responder."/>
+        <Property Name="SignedMeasurements" Type="Edm.String"  Nullable="false">
+          <Annotation Term="OData.Permissions" EnumMember="OData.Permission/Read"/>
+          <Annotation Term="OData.Description" String="Base64 encoded cryptographic signed statement generated by the signer."/>
+          <Annotation Term="OData.LongDescription" String="This property shall contain the cryptographic signed statement over the given nonce and measurement blocks corresponding to the requested measurement indices.  If the SPDM version is 1.2, this value shall be a concatenation of SPDM 'VCA' and 'GET_MEASUREMENTS' requests and responses exchanged between the SPDM Requester and the SPDM Responder.  If SPDM version is 1.0 or 1.1, this value shall be a concatenation of SPDM 'GET_MEASUREMENTS' requests and responses exchanged between the SPDM Requester and the SPDM Responder.  The last 'MEASUREMENTS' response shall contain a signature generated over the 'L2' string by the SPDM Responder."/>
+          <Annotation Term="Redfish.Required"/>
+        </Property>
+        <NavigationProperty Name="Certificate" Type="Certificate.Certificate" Nullable="false">
+          <Annotation Term="OData.Permissions" EnumMember="OData.Permission/Read"/>
+          <Annotation Term="OData.Description" String="A link to the certificate corresponding to the SPDM slot identifier that can be used to validate the signature."/>
+          <Annotation Term="OData.LongDescription" String="This property shall contain a link to a resource of type Certificate that represents the certificate corresponding to the SPDM slot identifier that can be used to validate the signature.  This property shall not be present if the SlotId parameter contains the value `15`."/>
+        </NavigationProperty>
+        <Property Name="PublicKey" Type="Edm.String" Nullable="false">
+          <Annotation Term="OData.Permissions" EnumMember="OData.Permission/Read"/>
+          <Annotation Term="OData.Description" String="A Privacy Enhanced Mail (PEM)-encoded public key that can be used to validate the signature."/>
+          <Annotation Term="OData.LongDescription" String="This property shall contain a Privacy Enhanced Mail (PEM)-encoded public key, as defined in section 13 of RFC7468, that can be used to validate the signature.  This property shall only be present when the SPDM Requester was pre-provisioned with the SPDM Responder's public key and the SlotId parameter contains the value `15`."/>
+        </Property>
+        <Property Name="Version" Type="Edm.String"  Nullable="false">
+          <Annotation Term="OData.Permissions" EnumMember="OData.Permission/Read"/>
+          <Annotation Term="OData.Description" String="The SPDM version used by the SPDM Responder to generate the cryptographic signed statement."/>
+          <Annotation Term="OData.LongDescription" String="This property shall contain the SPDM version negotiated between the SPDM Requester and the SPDM Responder to generate the cryptographic signed statement.  For example, `1.0`, `1.1`, or `1.2`."/>
+          <Annotation Term="Redfish.Required"/>
+        </Property>
+        <Property Name="HashingAlgorithm" Type="Edm.String" Nullable="false">
+          <Annotation Term="OData.Permissions" EnumMember="OData.Permission/Read"/>
+          <Annotation Term="OData.Description" String="The hashing algorithm used for generating the cryptographic signed statement."/>
+          <Annotation Term="OData.LongDescription" String="This property shall contain the hashing algorithm negotiated between the SPDM Requester and the SPDM Responder.  The allowable values for this property shall be the hash algorithm names found in the 'BaseHashAlgo' field of the 'NEGOTIATE_ALGORITHMS' request message in DSP0274.  If the algorithm is an extended algorithm, this property shall contain the value `OEM`."/>
+          <Annotation Term="Redfish.Required"/>
+        </Property>
+        <Property Name="SigningAlgorithm" Type="Edm.String" Nullable="false">
+          <Annotation Term="OData.Permissions" EnumMember="OData.Permission/Read"/>
+          <Annotation Term="OData.Description" String="The asymmetric signing algorithm used for generating the cryptographic signed statement."/>
+          <Annotation Term="OData.LongDescription" String="This property shall contain the asymmetric signing algorithm negotiated between the SPDM Requester and the SPDM Responder.  The allowable values for this property shall be the asymmetric key signature algorithm names found in the 'BaseAsymAlgo' field of the 'NEGOTIATE_ALGORITHMS' request message in DSP0274.  If the algorithm is an extended algorithm, this property shall contain the value `OEM`."/>
+          <Annotation Term="Redfish.Required"/>
+        </Property>
+        <Property Name="Oem" Type="Resource.Oem" Nullable="false">
+          <Annotation Term="OData.Description" String="The OEM extension property."/>
+          <Annotation Term="OData.LongDescription" String="This property shall contain the OEM extensions.  All values for properties contained in this object shall conform to the Redfish Specification-described requirements."/>
+        </Property>
+      </ComplexType>
+    </Schema>
+
+  </edmx:DataServices>
+</edmx:Edmx>
+

--- a/static/redfish/v1/schema/Control_v1.xml
+++ b/static/redfish/v1/schema/Control_v1.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!---->
 <!--################################################################################       -->
-<!--# Redfish Schema:  Control v1.0.0                                                      -->
+<!--# Redfish Schema:  Control v1.1.0                                                      -->
 <!--#                                                                                      -->
 <!--# For a detailed change log, see the README file contained in the DSP8010 bundle,      -->
 <!--# available at http://www.dmtf.org/standards/redfish                                   -->
@@ -213,10 +213,9 @@
         </Property>
 
         <NavigationProperty Name="Sensor" Type="Sensor.Sensor">
-          <Annotation Term="OData.Permissions" EnumMember="OData.Permission/Read"/>
           <Annotation Term="Redfish.ExcerptCopy"/>
           <Annotation Term="OData.Description" String="The sensor reading associated with this control."/>
-          <Annotation Term="OData.LongDescription" String="This property shall contain the Sensor excerpt directly associated with this control.  This property shall not be present if multiple sensors are associated with a single control."/>
+          <Annotation Term="OData.LongDescription" String="This property shall contain the Sensor excerpt directly associated with this control.  The value of the DataSourceUri property shall reference a resource of type Sensor.  This property shall not be present if multiple sensors are associated with a single control."/>
         </NavigationProperty>
         <NavigationProperty Name="AssociatedSensors" Type="Collection(Sensor.Sensor)">
           <Annotation Term="OData.Permissions" EnumMember="OData.Permission/Read"/>
@@ -264,16 +263,40 @@
 
       <EnumType Name="ControlType">
         <Member Name="Temperature">
-          <Annotation Term="OData.Description" String="Temperature control or thermostat."/>
+          <Annotation Term="OData.Description" String="Temperature (C) control or thermostat."/>
           <Annotation Term="OData.LongDescription" String="This value shall indicate a control used to regulate temperature, in units of degrees Celsius, either to a single set point or within a range, and the SetPointUnits property shall contain `Cel`."/>
         </Member>
         <Member Name="Power">
-          <Annotation Term="OData.Description" String="Power control or power limit."/>
-          <Annotation Term="OData.LongDescription" String="This value shall indicate a control used to regulate or limit maximum power consumption, in Watts units, either to a single set point or within a range, and the SetPointUnits property shall contain `W`."/>
+          <Annotation Term="OData.Description" String="Power (W) control or power limit."/>
+          <Annotation Term="OData.LongDescription" String="This value shall indicate a control used to regulate or limit maximum power consumption, in watt units, either to a single set point or within a range, and the SetPointUnits property shall contain `W`."/>
         </Member>
         <Member Name="Frequency">
-          <Annotation Term="OData.Description" String="Frequency control."/>
-          <Annotation Term="OData.LongDescription" String="This value shall indicate a control used to limit the operating frequency, measured in Hertz units, of a device, either to a single set point or within a range, and the SetPointUnits property shall contain `Hz`."/>
+          <Annotation Term="OData.Description" String="Frequency (Hz) control."/>
+          <Annotation Term="OData.LongDescription" String="This value shall indicate a control used to limit the operating frequency, in hertz units, of a device, either to a single set point or within a range, and the SetPointUnits property shall contain `Hz`."/>
+        </Member>
+        <Member Name="FrequencyMHz">
+          <Annotation Term="OData.Description" String="Frequency (MHz) control."/>
+          <Annotation Term="OData.LongDescription" String="This value shall indicate a control used to limit the operating frequency, in megahertz units, of a device, either to a single set point or within a range, and the SetPointUnits property shall contain `MHz`."/>
+          <Annotation Term="Redfish.Revisions">
+            <Collection>
+              <Record>
+                <PropertyValue Property="Kind" EnumMember="Redfish.RevisionKind/Added"/>
+                <PropertyValue Property="Version" String="v1_1_0"/>
+              </Record>
+            </Collection>
+          </Annotation>
+        </Member>
+        <Member Name="Pressure">
+          <Annotation Term="OData.Description" String="Pressure (kPa) control."/>
+          <Annotation Term="OData.LongDescription" String="This value shall indicate a control used to adjust pressure in a system, in kilopascal units, and the SetPointUnits property shall contain `kPa`."/>
+          <Annotation Term="Redfish.Revisions">
+            <Collection>
+              <Record>
+                <PropertyValue Property="Kind" EnumMember="Redfish.RevisionKind/Added"/>
+                <PropertyValue Property="Version" String="v1_1_0"/>
+              </Record>
+            </Collection>
+          </Annotation>
         </Member>
       </EnumType>
 
@@ -330,6 +353,20 @@
         <Annotation Term="OData.Description" String="The available OEM-specific actions for this resource."/>
         <Annotation Term="OData.LongDescription" String="This type shall contain the available OEM-specific actions for this resource."/>
       </ComplexType>
+    </Schema>
+
+    <Schema xmlns="http://docs.oasis-open.org/odata/ns/edm" Namespace="Control.v1_0_1">
+      <Annotation Term="Redfish.OwningEntity" String="DMTF"/>
+      <Annotation Term="OData.Description" String="This version was created to correct various typographical errors."/>
+      <EntityType Name="Control" BaseType="Control.v1_0_0.Control"/>
+    </Schema>
+
+    <Schema xmlns="http://docs.oasis-open.org/odata/ns/edm" Namespace="Control.v1_1_0">
+      <Annotation Term="Redfish.OwningEntity" String="DMTF"/>
+      <Annotation Term="Redfish.Release" String="2021.4"/>
+      <Annotation Term="OData.Description" String="This version was created to add `FrequencyMhz` and `Pressure` to ControlType."/>
+
+      <EntityType Name="Control" BaseType="Control.v1_0_1.Control"/>
     </Schema>
 
   </edmx:DataServices>

--- a/static/redfish/v1/schema/EnvironmentMetrics_v1.xml
+++ b/static/redfish/v1/schema/EnvironmentMetrics_v1.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!---->
 <!--################################################################################       -->
-<!--# Redfish Schema:  EnvironmentMetrics v1.1.0                                           -->
+<!--# Redfish Schema:  EnvironmentMetrics v1.2.0                                           -->
 <!--#                                                                                      -->
 <!--# For a detailed change log, see the README file contained in the DSP8010 bundle,      -->
 <!--# available at http://www.dmtf.org/standards/redfish                                   -->
@@ -126,27 +126,27 @@
         <NavigationProperty Name="TemperatureCelsius" Type="Sensor.Sensor">
           <Annotation Term="Redfish.ExcerptCopy"/>
           <Annotation Term="OData.Description" String="Temperature (Celsius)."/>
-          <Annotation Term="OData.LongDescription" String="This property shall contain the temperature sensor reading for this resource."/>
+          <Annotation Term="OData.LongDescription" String="This property shall contain the temperature, in degrees Celsius units, for this resource.  The value of the DataSourceUri property, if present, shall reference a resource of type Sensor with the ReadingType property containing the value `Temperature`."/>
         </NavigationProperty>
         <NavigationProperty Name="HumidityPercent" Type="Sensor.Sensor">
           <Annotation Term="Redfish.ExcerptCopy"/>
           <Annotation Term="OData.Description" String="Humidity (percent)."/>
-          <Annotation Term="OData.LongDescription" String="This property shall contain the humidity sensor reading for this resource."/>
+          <Annotation Term="OData.LongDescription" String="This property shall contain the humidity, in percent units, for this resource.  The value of the DataSourceUri property, if present, shall reference a resource of type Sensor with the ReadingType property containing the value `Humidity`."/>
         </NavigationProperty>
         <NavigationProperty Name="FanSpeedsPercent" Type="Collection(Sensor.Sensor)">
           <Annotation Term="Redfish.ExcerptCopy" String="FanArray"/>
           <Annotation Term="OData.Description" String="Fan speeds (percent)."/>
-          <Annotation Term="OData.LongDescription" String="This property shall contain the fan speed readings for this resource."/>
+          <Annotation Term="OData.LongDescription" String="This property shall contain the fan speeds, in percent units, for this resource.  The value of the DataSourceUri property, if present, shall reference a resource of type Sensor with the ReadingType property containing the value `Percent`."/>
         </NavigationProperty>
         <NavigationProperty Name="PowerWatts" Type="Sensor.Sensor">
           <Annotation Term="Redfish.ExcerptCopy" String="Power"/>
-          <Annotation Term="OData.Description" String="Power consumption (Watts)."/>
-          <Annotation Term="OData.LongDescription" String="This property shall contain the total power, measured in Watts, for this resource."/>
+          <Annotation Term="OData.Description" String="Power consumption (W)."/>
+          <Annotation Term="OData.LongDescription" String="This property shall contain the total power, in watt units, for this resource.  The value of the DataSourceUri property, if present, shall reference a resource of type Sensor with the ReadingType property containing the value `Power`."/>
         </NavigationProperty>
         <NavigationProperty Name="EnergykWh" Type="Sensor.Sensor">
           <Annotation Term="Redfish.ExcerptCopy" String="EnergykWh"/>
           <Annotation Term="OData.Description" String="Energy consumption (kWh)."/>
-          <Annotation Term="OData.LongDescription" String="This property shall contain the total energy, measured in kilowatt-hours (kW.h), for this resource."/>
+          <Annotation Term="OData.LongDescription" String="This property shall contain the total energy, in kilowatt-hours, for this resource.  The value of the DataSourceUri property, if present, shall reference a resource of type Sensor with the ReadingType property containing the value `EnergykWh`."/>
         </NavigationProperty>
         <Property Name="Actions" Type="EnvironmentMetrics.v1_0_0.Actions" Nullable="false">
           <Annotation Term="OData.Description" String="The available actions for this resource."/>
@@ -171,6 +171,12 @@
       </ComplexType>
     </Schema>
 
+    <Schema xmlns="http://docs.oasis-open.org/odata/ns/edm" Namespace="EnvironmentMetrics.v1_0_1">
+      <Annotation Term="Redfish.OwningEntity" String="DMTF"/>
+      <Annotation Term="OData.Description" String="This version was created to update descriptions to tie excerpt property definitions to a specific type of Sensor or Control."/>
+      <EntityType Name="EnvironmentMetrics" BaseType="EnvironmentMetrics.v1_0_0.EnvironmentMetrics"/>
+    </Schema>
+
     <Schema xmlns="http://docs.oasis-open.org/odata/ns/edm" Namespace="EnvironmentMetrics.v1_1_0">
       <Annotation Term="Redfish.OwningEntity" String="DMTF"/>
       <Annotation Term="Redfish.Release" String="2021.2"/>
@@ -179,19 +185,43 @@
       <EntityType Name="EnvironmentMetrics" BaseType="EnvironmentMetrics.v1_0_0.EnvironmentMetrics">
         <NavigationProperty Name="PowerLoadPercent" Type="Sensor.Sensor">
           <Annotation Term="Redfish.ExcerptCopy"/>
-          <Annotation Term="OData.Description" String="The power load (%) for this device."/>
-          <Annotation Term="OData.LongDescription" String="This property shall contain the power load, measured in percent, for this device, that represents the `Total` ElectricalContext for this device."/>
+          <Annotation Term="OData.Description" String="The power load (percent) for this device."/>
+          <Annotation Term="OData.LongDescription" String="This property shall contain the power load, in percent units, for this device, that represents the `Total` ElectricalContext for this device.  The value of the DataSourceUri property, if present, shall reference a resource of type Sensor with the ReadingType property containing the value `Percent`."/>
         </NavigationProperty>
         <NavigationProperty Name="PowerLimitWatts" Type="Control.Control">
           <Annotation Term="OData.Permissions" EnumMember="OData.Permission/ReadWrite"/>
           <Annotation Term="Redfish.ExcerptCopy" String="Single"/>
-          <Annotation Term="OData.Description" String="Power limit (Watts)."/>
-          <Annotation Term="OData.LongDescription" String="This property shall contain the power limit control for this resource."/>
+          <Annotation Term="OData.Description" String="Power limit (W)."/>
+          <Annotation Term="OData.LongDescription" String="This property shall contain the power limit control, in watt units, for this resource.  The value of the DataSourceUri property, if present, shall reference a resource of type Control with the ControlType property containing the value of `Power`."/>
         </NavigationProperty>
         <NavigationProperty Name="DewPointCelsius" Type="Sensor.Sensor">
           <Annotation Term="Redfish.ExcerptCopy"/>
           <Annotation Term="OData.Description" String="The dew point temperature (C)."/>
-          <Annotation Term="OData.LongDescription" String="This property shall contain the dew point, measured in degrees Celsius, based on the temperature and humidity values for this resource."/>
+          <Annotation Term="OData.LongDescription" String="This property shall contain the dew point, in degrees Celsius, based on the temperature and humidity values for this resource.  The value of the DataSourceUri property, if present, shall reference a resource of type Sensor with the ReadingType property containing the value `Temperature`."/>
+        </NavigationProperty>
+      </EntityType>
+    </Schema>
+
+    <Schema xmlns="http://docs.oasis-open.org/odata/ns/edm" Namespace="EnvironmentMetrics.v1_1_1">
+      <Annotation Term="Redfish.OwningEntity" String="DMTF"/>
+      <Annotation Term="OData.Description" String="This version was created to update descriptions to tie excerpt property definitions to a specific type of Sensor or Control."/>
+      <EntityType Name="EnvironmentMetrics" BaseType="EnvironmentMetrics.v1_1_0.EnvironmentMetrics"/>
+    </Schema>
+
+    <Schema xmlns="http://docs.oasis-open.org/odata/ns/edm" Namespace="EnvironmentMetrics.v1_2_0">
+      <Annotation Term="Redfish.OwningEntity" String="DMTF"/>
+      <Annotation Term="Redfish.Release" String="2021.4"/>
+
+      <EntityType Name="EnvironmentMetrics" BaseType="EnvironmentMetrics.v1_1_1.EnvironmentMetrics">
+        <NavigationProperty Name="AbsoluteHumidity" Type="Sensor.Sensor">
+          <Annotation Term="Redfish.ExcerptCopy"/>
+          <Annotation Term="OData.Description" String="Absolute humidity (g/cu m)."/>
+          <Annotation Term="OData.LongDescription" String="This property shall contain the absolute (volumetric) humidity sensor reading, in grams/cubic meter units, for this resource.  The value of the DataSourceUri property, if present, shall reference a resource of type Sensor with the ReadingType property containing the value `AbsoluteHumidity`."/>
+        </NavigationProperty>
+        <NavigationProperty Name="EnergyJoules" Type="Sensor.Sensor">
+          <Annotation Term="Redfish.ExcerptCopy"/>
+          <Annotation Term="OData.Description" String="Energy consumption (J)."/>
+          <Annotation Term="OData.LongDescription" String="This property shall contain the total energy, in joules, for this resource.  The value of the DataSourceUri property, if present, shall reference a resource of type Sensor with the ReadingType property containing the value `EnergyJoules`.  This property is used for reporting device-level energy consumption measurements, while EnergykWh is used for large-scale consumption measurements."/>
         </NavigationProperty>
       </EntityType>
     </Schema>

--- a/static/redfish/v1/schema/Fabric_v1.xml
+++ b/static/redfish/v1/schema/Fabric_v1.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!---->
 <!--################################################################################       -->
-<!--# Redfish Schema:  Fabric v1.2.2                                                       -->
+<!--# Redfish Schema:  Fabric v1.3.0                                                       -->
 <!--#                                                                                      -->
 <!--# For a detailed change log, see the README file contained in the DSP8010 bundle,      -->
 <!--# available at http://www.dmtf.org/standards/redfish                                   -->
@@ -61,7 +61,7 @@
         </Annotation>
         <Annotation Term="Capabilities.UpdateRestrictions">
           <Record>
-            <PropertyValue Property="Updatable" Bool="false"/>
+            <PropertyValue Property="Updatable" Bool="true"/>
           </Record>
         </Annotation>
         <Annotation Term="Capabilities.DeleteRestrictions">
@@ -262,6 +262,19 @@
       <Annotation Term="Redfish.OwningEntity" String="DMTF"/>
       <Annotation Term="OData.Description" String="This version was created to correct various description to use proper normative terminology."/>
       <EntityType Name="Fabric" BaseType="Fabric.v1_2_1.Fabric"/>
+    </Schema>
+
+    <Schema xmlns="http://docs.oasis-open.org/odata/ns/edm" Namespace="Fabric.v1_3_0">
+      <Annotation Term="Redfish.OwningEntity" String="DMTF"/>
+      <Annotation Term="Redfish.Release" String="TBD"/>
+
+      <EntityType Name="Fabric" BaseType="Fabric.v1_2_2.Fabric">
+        <Property Name="UUID" Type="Resource.UUID">
+          <Annotation Term="OData.Permissions" EnumMember="OData.Permission/ReadWrite"/>
+          <Annotation Term="OData.Description" String="The UUID for this fabric."/>
+          <Annotation Term="OData.LongDescription" String="This property shall contain a universal unique identifier number for the fabric."/>
+        </Property>
+      </EntityType>
     </Schema>
 
   </edmx:DataServices>

--- a/static/redfish/v1/schema/Fan_v1.xml
+++ b/static/redfish/v1/schema/Fan_v1.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!---->
 <!--################################################################################       -->
-<!--# Redfish Schema:  Fan v1.1.0                                                          -->
+<!--# Redfish Schema:  Fan v1.1.1                                                          -->
 <!--#                                                                                      -->
 <!--# For a detailed change log, see the README file contained in the DSP8010 bundle,      -->
 <!--# available at http://www.dmtf.org/standards/redfish                                   -->
@@ -87,10 +87,9 @@
           <Annotation Term="OData.LongDescription" String="This property shall contain any status or health properties of the resource."/>
         </Property>
         <NavigationProperty Name="SpeedPercent" Type="Sensor.Sensor">
-          <Annotation Term="OData.Permissions" EnumMember="OData.Permission/Read"/>
           <Annotation Term="Redfish.ExcerptCopy" String="Fan"/>
-          <Annotation Term="OData.Description" String="The fan speed reading."/>
-          <Annotation Term="OData.LongDescription" String="This property shall contain the fan speed sensor."/>
+          <Annotation Term="OData.Description" String="The fan speed (percent)."/>
+          <Annotation Term="OData.LongDescription" String="This property shall contain the fan speed, in percent units, for this resource.  The value of the DataSourceUri property, if present, shall reference a resource of type Sensor with the ReadingType property containing the value `Percent`."/>
         </NavigationProperty>
         <Property Name="Manufacturer" Type="Edm.String">
           <Annotation Term="OData.Permissions" EnumMember="OData.Permission/Read"/>
@@ -166,18 +165,29 @@
       <EntityType Name="Fan" BaseType="Fan.v1_0_0.Fan"/>
     </Schema>
 
+    <Schema xmlns="http://docs.oasis-open.org/odata/ns/edm" Namespace="Fan.v1_0_2">
+      <Annotation Term="Redfish.OwningEntity" String="DMTF"/>
+      <Annotation Term="OData.Description" String="This version was created to update descriptions to tie excerpt property definitions to a specific type of Sensor or Control."/>
+      <EntityType Name="Fan" BaseType="Fan.v1_0_1.Fan"/>
+    </Schema>
+
     <Schema xmlns="http://docs.oasis-open.org/odata/ns/edm" Namespace="Fan.v1_1_0">
       <Annotation Term="Redfish.OwningEntity" String="DMTF"/>
       <Annotation Term="Redfish.Release" String="2021.1"/>
 
       <EntityType Name="Fan" BaseType="Fan.v1_0_1.Fan">
         <NavigationProperty Name="PowerWatts" Type="Sensor.Sensor">
-          <Annotation Term="OData.Permissions" EnumMember="OData.Permission/Read"/>
           <Annotation Term="Redfish.ExcerptCopy" String="Power"/>
-          <Annotation Term="OData.Description" String="Power consumption (Watts)."/>
-          <Annotation Term="OData.LongDescription" String="This property shall contain the total power, measured in Watts, for this resource."/>
+          <Annotation Term="OData.Description" String="Power consumption (W)."/>
+          <Annotation Term="OData.LongDescription" String="This property shall contain the total power, in watt units, for this resource.  The value of the DataSourceUri property, if present, shall reference a resource of type Sensor with the ReadingType property containing the value `Power`."/>
         </NavigationProperty>
       </EntityType>
+    </Schema>
+
+    <Schema xmlns="http://docs.oasis-open.org/odata/ns/edm" Namespace="Fan.v1_1_1">
+      <Annotation Term="Redfish.OwningEntity" String="DMTF"/>
+      <Annotation Term="OData.Description" String="This version was created to update descriptions to tie excerpt property definitions to a specific type of Sensor or Control."/>
+      <EntityType Name="Fan" BaseType="Fan.v1_1_0.Fan"/>
     </Schema>
 
   </edmx:DataServices>

--- a/static/redfish/v1/schema/ManagerDiagnosticData_v1.xml
+++ b/static/redfish/v1/schema/ManagerDiagnosticData_v1.xml
@@ -1,0 +1,286 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!---->
+<!--################################################################################       -->
+<!--# Redfish Schema:  ManagerDiagnosticData v1.0.0                                        -->
+<!--#                                                                                      -->
+<!--# For a detailed change log, see the README file contained in the DSP8010 bundle,      -->
+<!--# available at http://www.dmtf.org/standards/redfish                                   -->
+<!--# Copyright 2014-2021 DMTF.                                                            -->
+<!--# For the full DMTF copyright policy, see http://www.dmtf.org/about/policies/copyright -->
+<!--################################################################################       -->
+<!---->
+<edmx:Edmx xmlns:edmx="http://docs.oasis-open.org/odata/ns/edmx" Version="4.0">
+
+  <edmx:Reference Uri="http://docs.oasis-open.org/odata/odata/v4.0/errata03/csd01/complete/vocabularies/Org.OData.Core.V1.xml">
+    <edmx:Include Namespace="Org.OData.Core.V1" Alias="OData"/>
+  </edmx:Reference>
+  <edmx:Reference Uri="http://docs.oasis-open.org/odata/odata/v4.0/errata03/csd01/complete/vocabularies/Org.OData.Capabilities.V1.xml">
+    <edmx:Include Namespace="Org.OData.Capabilities.V1" Alias="Capabilities"/>
+  </edmx:Reference>
+  <edmx:Reference Uri="http://docs.oasis-open.org/odata/odata/v4.0/errata03/csd01/complete/vocabularies/Org.OData.Measures.V1.xml">
+    <edmx:Include Namespace="Org.OData.Measures.V1" Alias="Measures"/>
+  </edmx:Reference>
+  <edmx:Reference Uri="http://redfish.dmtf.org/schemas/v1/RedfishExtensions_v1.xml">
+    <edmx:Include Namespace="RedfishExtensions.v1_0_0" Alias="Redfish"/>
+  </edmx:Reference>
+  <edmx:Reference Uri="http://redfish.dmtf.org/schemas/v1/Resource_v1.xml">
+    <edmx:Include Namespace="Resource.v1_0_0"/>
+  </edmx:Reference>
+
+  <edmx:DataServices>
+
+    <Schema xmlns="http://docs.oasis-open.org/odata/ns/edm" Namespace="ManagerDiagnosticData">
+      <Annotation Term="Redfish.OwningEntity" String="DMTF"/>
+
+      <EntityType Name="ManagerDiagnosticData" BaseType="Resource.v1_0_0.Resource" Abstract="true">
+        <Annotation Term="OData.Description" String="The ManagerDiagnosticData schema defines internal diagnostic data for a manager.  It contains information that might be used by vendors to collect debug information about the manager.  Clients should not make decisions for raising alerts, creating service events, or other actions based on information in this resource."/>
+        <Annotation Term="OData.LongDescription" String="This resource shall represent internal diagnostic data for a manager for a Redfish implementation.  Clients should not make decisions for raising alerts, creating service events, or other actions based on information in this resource."/>
+        <Annotation Term="Capabilities.InsertRestrictions">
+          <Record>
+            <PropertyValue Property="Insertable" Bool="false"/>
+          </Record>
+        </Annotation>
+        <Annotation Term="Capabilities.UpdateRestrictions">
+          <Record>
+            <PropertyValue Property="Updatable" Bool="false"/>
+          </Record>
+        </Annotation>
+        <Annotation Term="Capabilities.DeleteRestrictions">
+          <Record>
+            <PropertyValue Property="Deletable" Bool="false"/>
+          </Record>
+        </Annotation>
+        <Annotation Term="Redfish.Uris">
+          <Collection>
+            <String>/redfish/v1/Managers/{ManagerId}/ManagerDiagnosticData</String>
+          </Collection>
+        </Annotation>
+      </EntityType>
+
+      <Action Name="ResetMetrics" IsBound="true">
+        <Annotation Term="OData.Description" String="Resets time intervals or counted values of the diagnostic data for this manager."/>
+        <Annotation Term="OData.LongDescription" String="This action shall reset any time intervals or counted values of the diagnostic data for this manager."/>
+        <Parameter Name="ManagerDiagnosticData" Type="ManagerDiagnosticData.v1_0_0.Actions"/>
+      </Action>
+    </Schema>
+
+    <Schema xmlns="http://docs.oasis-open.org/odata/ns/edm" Namespace="ManagerDiagnosticData.v1_0_0">
+      <Annotation Term="Redfish.OwningEntity" String="DMTF"/>
+      <Annotation Term="Redfish.Release" String="2021.4"/>
+
+      <EntityType Name="ManagerDiagnosticData" BaseType="ManagerDiagnosticData.ManagerDiagnosticData">
+        <Property Name="I2CBuses" Type="Collection(ManagerDiagnosticData.v1_0_0.I2CBusStatistics)" Nullable="false">
+          <Annotation Term="OData.Description" String="The statistics of the I2C buses."/>
+          <Annotation Term="OData.LongDescription" String="This property shall contain the statistics of the I2C buses.  Services may subdivide a physical bus into multiple entries in this property based on how the manager tracks bus segments, virtual buses from a controller, and other segmentation capabilities."/>
+        </Property>
+        <Property Name="MemoryStatistics" Type="ManagerDiagnosticData.v1_0_0.MemoryStatistics" Nullable="false">
+          <Annotation Term="OData.Description" String="The memory statistics of the manager."/>
+          <Annotation Term="OData.LongDescription" String="This property shall contain the memory statistics of the manager."/>
+        </Property>
+        <Property Name="ProcessorStatistics" Type="ManagerDiagnosticData.v1_0_0.ProcessorStatistics" Nullable="false">
+          <Annotation Term="OData.Description" String="The processor statistics of the manager."/>
+          <Annotation Term="OData.LongDescription" String="This property shall contain the processor statistics of the manager."/>
+        </Property>
+        <Property Name="BootTimeStatistics" Type="ManagerDiagnosticData.v1_0_0.BootTimeStatistics" Nullable="false">
+          <Annotation Term="OData.Description" String="The boot time statistics of the manager."/>
+          <Annotation Term="OData.LongDescription" String="This property shall contain the boot time statistics of the manager."/>
+        </Property>
+        <Property Name="FreeStorageSpaceKiB" Type="Edm.Int64">
+          <Annotation Term="OData.Permissions" EnumMember="OData.Permission/Read"/>
+          <Annotation Term="OData.Description" String="The available storage space on this manager in kibibytes (KiB)."/>
+          <Annotation Term="OData.LongDescription" String="This property shall contain the available storage space on this manager in kibibytes (KiB)."/>
+          <Annotation Term="Measures.Unit" String="KiBy"/>
+        </Property>
+        <Property Name="MemoryECCStatistics" Type="ManagerDiagnosticData.v1_0_0.MemoryECCStatistics" Nullable="false">
+          <Annotation Term="OData.Description" String="The memory ECC statistics of the manager."/>
+          <Annotation Term="OData.LongDescription" String="This property shall contain the memory ECC statistics of the manager."/>
+        </Property>
+        <Property Name="TopProcesses" Type="Collection(ManagerDiagnosticData.v1_0_0.ProcessStatistics)">
+          <Annotation Term="OData.Description" String="The statistics of the top processes of this manager."/>
+          <Annotation Term="OData.LongDescription" String="This property shall contain the statistics of the top processes of this manager."/>
+        </Property>
+        <Property Name="Actions" Type="ManagerDiagnosticData.v1_0_0.Actions" Nullable="false">
+          <Annotation Term="OData.Description" String="The available actions for this resource."/>
+          <Annotation Term="OData.LongDescription" String="The actions property shall contain the available actions for this resource."/>
+        </Property>
+      </EntityType>
+      
+      <ComplexType Name="I2CBusStatistics">
+        <Annotation Term="OData.AdditionalProperties" Bool="false"/>
+        <Annotation Term="OData.Description" String="The statistics of an I2C bus."/>
+        <Annotation Term="OData.LongDescription" String="This object shall contain statistics of an I2C bus."/>
+        <Property Name="I2CBusName" Type="Edm.String" Nullable="false">
+          <Annotation Term="OData.Permissions" EnumMember="OData.Permission/Read"/>
+          <Annotation Term="OData.Description" String="The name of the I2C bus."/>
+          <Annotation Term="OData.LongDescription" String="This property shall contain the name of the I2C bus."/>
+        </Property>
+        <Property Name="TotalTransactionCount" Type="Edm.Int64">
+          <Annotation Term="OData.Permissions" EnumMember="OData.Permission/Read"/>
+          <Annotation Term="OData.Description" String="The total number of transactions on this I2C bus."/>
+          <Annotation Term="OData.LongDescription" String="This property shall contain the total number of transactions on this I2C bus.  The count shall include the number of I2C transactions initiated by the manager and the number of I2C transactions where the manager is the target device."/>
+        </Property>
+        <Property Name="BusErrorCount" Type="Edm.Int64">
+          <Annotation Term="OData.Permissions" EnumMember="OData.Permission/Read"/>
+          <Annotation Term="OData.Description" String="The number of bus errors on this I2C bus."/>
+          <Annotation Term="OData.LongDescription" String="This property shall contain the number of bus errors on this I2C bus.  Bus errors include, but are not limited to, an SDA rising or falling edge while SCL is high or a stuck bus signal."/>
+        </Property>
+        <Property Name="NACKCount" Type="Edm.Int64">
+          <Annotation Term="OData.Permissions" EnumMember="OData.Permission/Read"/>
+          <Annotation Term="OData.Description" String="The number of NACKs on this I2C bus."/>
+          <Annotation Term="OData.LongDescription" String="This property shall contain the number of NACKs on this I2C bus."/>
+        </Property>
+      </ComplexType>
+      
+      <ComplexType Name="MemoryStatistics">
+        <Annotation Term="OData.AdditionalProperties" Bool="false"/>
+        <Annotation Term="OData.Description" String="The memory statistics of a manager."/>
+        <Annotation Term="OData.LongDescription" String="This object shall contain the memory statistics of a manager."/>
+        <Property Name="TotalBytes" Type="Edm.Int64">
+          <Annotation Term="OData.Permissions" EnumMember="OData.Permission/Read"/>
+          <Annotation Term="OData.Description" String="The total amount of memory in bytes."/>
+          <Annotation Term="OData.LongDescription" String="This property shall contain the total amount of memory in bytes."/>
+          <Annotation Term="Measures.Unit" String="By"/>
+        </Property>
+        <Property Name="UsedBytes" Type="Edm.Int64">
+          <Annotation Term="OData.Permissions" EnumMember="OData.Permission/Read"/>
+          <Annotation Term="OData.Description" String="The amount of used memory in bytes."/>
+          <Annotation Term="OData.LongDescription" String="This property shall contain the amount of used memory in bytes.  This value is calculated as TotalBytes minus FreeBytes minus BuffersAndCacheBytes."/>
+          <Annotation Term="Measures.Unit" String="By"/>
+        </Property>
+        <Property Name="FreeBytes" Type="Edm.Int64">
+          <Annotation Term="OData.Permissions" EnumMember="OData.Permission/Read"/>
+          <Annotation Term="OData.Description" String="The amount of free memory in bytes."/>
+          <Annotation Term="OData.LongDescription" String="This property shall contain the amount of free memory in bytes."/>
+          <Annotation Term="Measures.Unit" String="By"/>
+        </Property>
+        <Property Name="SharedBytes" Type="Edm.Int64">
+          <Annotation Term="OData.Permissions" EnumMember="OData.Permission/Read"/>
+          <Annotation Term="OData.Description" String="The amount of shared memory in bytes."/>
+          <Annotation Term="OData.LongDescription" String="This property shall contain the amount of shared memory in bytes.  This includes things such as memory consumed by temporary filesystems."/>
+          <Annotation Term="Measures.Unit" String="By"/>
+        </Property>
+        <Property Name="BuffersAndCacheBytes" Type="Edm.Int64">
+          <Annotation Term="OData.Permissions" EnumMember="OData.Permission/Read"/>
+          <Annotation Term="OData.Description" String="The amount of memory used in bytes by kernel buffers, page caches, and slabs."/>
+          <Annotation Term="OData.LongDescription" String="This property shall contain the amount of memory used in bytes by kernel buffers, page caches, and slabs."/>
+          <Annotation Term="Measures.Unit" String="By"/>
+        </Property>
+        <Property Name="AvailableBytes" Type="Edm.Int64">
+          <Annotation Term="OData.Permissions" EnumMember="OData.Permission/Read"/>
+          <Annotation Term="OData.Description" String="The amount of memory available in bytes for starting new processes without swapping."/>
+          <Annotation Term="OData.LongDescription" String="This property shall contain the amount of memory available in bytes for starting new processes without swapping.  This includes free memory and reclaimable cache and buffers."/>
+          <Annotation Term="Measures.Unit" String="By"/>
+        </Property>
+      </ComplexType>
+      
+      <ComplexType Name="ProcessStatistics">
+        <Annotation Term="OData.AdditionalProperties" Bool="false"/>
+        <Annotation Term="OData.Description" String="The statistics of a process running on a manager."/>
+        <Annotation Term="OData.LongDescription" String="This object shall contain the statistics of a process running on a manager."/>
+        <Property Name="CommandLine" Type="Edm.String" Nullable="false">
+          <Annotation Term="OData.Permissions" EnumMember="OData.Permission/Read"/>
+          <Annotation Term="OData.Description" String="The command line of this process."/>
+          <Annotation Term="OData.LongDescription" String="This property shall contain the command line with parameters of this process."/>
+        </Property>
+        <Property Name="UserTimeSeconds" Type="Edm.Decimal">
+          <Annotation Term="OData.Permissions" EnumMember="OData.Permission/Read"/>
+          <Annotation Term="OData.Description" String="The number of seconds this process executed in user space."/>
+          <Annotation Term="OData.LongDescription" String="This property shall contain the number of seconds this process executed in user space."/>
+        </Property>
+        <Property Name="KernelTimeSeconds" Type="Edm.Decimal">
+          <Annotation Term="OData.Permissions" EnumMember="OData.Permission/Read"/>
+          <Annotation Term="OData.Description" String="The number of seconds this process executed in kernel space."/>
+          <Annotation Term="OData.LongDescription" String="This property shall contain the number of seconds this process executed in kernel space."/>
+        </Property>
+        <Property Name="ResidentSetSizeBytes" Type="Edm.Int64">
+          <Annotation Term="OData.Permissions" EnumMember="OData.Permission/Read"/>
+          <Annotation Term="OData.Description" String="The resident set size of this process in bytes."/>
+          <Annotation Term="OData.LongDescription" String="This property shall contain the resident set size of this process in bytes, which is the amount of memory allocated to the process and is in RAM."/>
+          <Annotation Term="Measures.Unit" String="By"/>
+        </Property>
+      </ComplexType>
+
+      <ComplexType Name="ProcessorStatistics">
+        <Annotation Term="OData.AdditionalProperties" Bool="false"/>
+        <Annotation Term="OData.Description" String="The processor statistics of a manager."/>
+        <Annotation Term="OData.LongDescription" String="This object shall contain the processor statistics of a manager."/>
+        <Property Name="KernelPercent" Type="Edm.Decimal">
+          <Annotation Term="OData.Permissions" EnumMember="OData.Permission/Read"/>
+          <Annotation Term="OData.Description" String="The percentage of CPU time spent in kernel mode."/>
+          <Annotation Term="OData.LongDescription" String="This property shall contain the percentage of CPU time spent in kernel mode."/>
+          <Annotation Term="Measures.Unit" String="%"/>
+        </Property>
+        <Property Name="UserPercent" Type="Edm.Decimal">
+          <Annotation Term="OData.Permissions" EnumMember="OData.Permission/Read"/>
+          <Annotation Term="OData.Description" String="The percentage of CPU time spent in user mode."/>
+          <Annotation Term="OData.LongDescription" String="This property shall contain the percentage of CPU time spent in user mode."/>
+          <Annotation Term="Measures.Unit" String="%"/>
+        </Property>
+      </ComplexType>
+
+      <ComplexType Name="BootTimeStatistics">
+        <Annotation Term="OData.AdditionalProperties" Bool="false"/>
+        <Annotation Term="OData.Description" String="The boot time statistics of a manager."/>
+        <Annotation Term="OData.LongDescription" String="This object shall contain the boot time statistics of a manager."/>
+        <Property Name="FirmwareTimeSeconds" Type="Edm.Decimal">
+          <Annotation Term="OData.Permissions" EnumMember="OData.Permission/Read"/>
+          <Annotation Term="OData.Description" String="The number of seconds the manager spent in the firmware stage."/>
+          <Annotation Term="OData.LongDescription" String="This property shall contain the number of seconds the manager spent in the firmware stage."/>
+        </Property>
+        <Property Name="LoaderTimeSeconds" Type="Edm.Decimal">
+          <Annotation Term="OData.Permissions" EnumMember="OData.Permission/Read"/>
+          <Annotation Term="OData.Description" String="The number of seconds the manager spent in the loader stage."/>
+          <Annotation Term="OData.LongDescription" String="This property shall contain the number of seconds the manager spent in the loader stage."/>
+        </Property>
+        <Property Name="KernelTimeSeconds" Type="Edm.Decimal">
+          <Annotation Term="OData.Permissions" EnumMember="OData.Permission/Read"/>
+          <Annotation Term="OData.Description" String="The number of seconds the manager spent in the kernel stage."/>
+          <Annotation Term="OData.LongDescription" String="This property shall contain the number of seconds the manager spent in the kernel stage."/>
+        </Property>
+        <Property Name="InitrdTimeSeconds" Type="Edm.Decimal">
+          <Annotation Term="OData.Permissions" EnumMember="OData.Permission/Read"/>
+          <Annotation Term="OData.Description" String="The number of seconds the manager spent in the initrd boot stage."/>
+          <Annotation Term="OData.LongDescription" String="This property shall contain the number of seconds the manager spent in the initrd boot stage."/>
+        </Property>
+        <Property Name="UserSpaceTimeSeconds" Type="Edm.Decimal">
+          <Annotation Term="OData.Permissions" EnumMember="OData.Permission/Read"/>
+          <Annotation Term="OData.Description" String="The number of seconds the manager spent in the user space boot stage."/>
+          <Annotation Term="OData.LongDescription" String="This property shall contain the number of seconds the manager spent in the user space boot stage."/>
+        </Property>
+      </ComplexType>
+
+      <ComplexType Name="MemoryECCStatistics">
+        <Annotation Term="OData.AdditionalProperties" Bool="false"/>
+        <Annotation Term="OData.Description" String="The memory ECC statistics of a manager."/>
+        <Annotation Term="OData.LongDescription" String="This object shall contain the memory ECC statistics of a manager."/>
+        <Property Name="CorrectableECCErrorCount" Type="Edm.Int64">
+          <Annotation Term="OData.Permissions" EnumMember="OData.Permission/Read"/>
+          <Annotation Term="OData.Description" String="The number of the correctable errors since reset."/>
+          <Annotation Term="OData.LongDescription" String="This property shall contain the number of correctable errors since reset."/>
+        </Property>
+        <Property Name="UncorrectableECCErrorCount" Type="Edm.Int64">
+          <Annotation Term="OData.Permissions" EnumMember="OData.Permission/Read"/>
+          <Annotation Term="OData.Description" String="The number of the uncorrectable errors since reset."/>
+          <Annotation Term="OData.LongDescription" String="This property shall contain the number of uncorrectable errors since reset."/>
+        </Property>
+      </ComplexType>
+
+      <ComplexType Name="Actions">
+        <Annotation Term="OData.AdditionalProperties" Bool="false"/>
+        <Annotation Term="OData.Description" String="The available actions for this resource."/>
+        <Annotation Term="OData.LongDescription" String="This type shall contain the available actions for this resource."/>
+        <Property Name="Oem" Type="ManagerDiagnosticData.v1_0_0.OemActions" Nullable="false">
+          <Annotation Term="OData.Description" String="The available OEM-specific actions for this resource."/>
+          <Annotation Term="OData.LongDescription" String="This property shall contain the available OEM-specific actions for this resource."/>
+        </Property>
+      </ComplexType>
+
+      <ComplexType Name="OemActions">
+        <Annotation Term="OData.AdditionalProperties" Bool="true"/>
+        <Annotation Term="OData.Description" String="The available OEM-specific actions for this resource."/>
+        <Annotation Term="OData.LongDescription" String="This type shall contain the available OEM-specific actions for this resource."/>
+      </ComplexType>
+    </Schema>
+
+  </edmx:DataServices>
+</edmx:Edmx>

--- a/static/redfish/v1/schema/NetworkAdapter_v1.xml
+++ b/static/redfish/v1/schema/NetworkAdapter_v1.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!---->
 <!--################################################################################       -->
-<!--# Redfish Schema:  NetworkAdapter v1.8.0                                               -->
+<!--# Redfish Schema:  NetworkAdapter v1.9.0                                               -->
 <!--#                                                                                      -->
 <!--# For a detailed change log, see the README file contained in the DSP8010 bundle,      -->
 <!--# available at http://www.dmtf.org/standards/redfish                                   -->
@@ -595,6 +595,15 @@
         <Property Name="Measurements" Type="Collection(SoftwareInventory.MeasurementBlock)" Nullable="false">
           <Annotation Term="OData.Description" String="An array of DSP0274-defined measurement blocks."/>
           <Annotation Term="OData.LongDescription" String="This property shall contain an array of DSP0274-defined measurement blocks."/>
+          <Annotation Term="Redfish.Revisions">
+            <Collection>
+              <Record>
+                <PropertyValue Property="Kind" EnumMember="Redfish.RevisionKind/Deprecated"/>
+                <PropertyValue Property="Version" String="v1_9_0"/>
+                <PropertyValue Property="Description" String="This property has been deprecated in favor of the ComponentIntegrity resource."/>
+              </Record>
+            </Collection>
+          </Annotation>
         </Property>
       </EntityType>
     </Schema>
@@ -637,6 +646,14 @@
           <Annotation Term="OData.AutoExpandReferences"/>
         </NavigationProperty>
       </EntityType>
+    </Schema>
+
+    <Schema xmlns="http://docs.oasis-open.org/odata/ns/edm" Namespace="NetworkAdapter.v1_9_0">
+      <Annotation Term="Redfish.OwningEntity" String="DMTF"/>
+      <Annotation Term="Redfish.Release" String="2021.4"/>
+      <Annotation Term="OData.Description" String="This version was created to deprecate Measurements in favor of measurement reporting in the ComponentIntegrity resource."/>
+
+      <EntityType Name="NetworkAdapter" BaseType="NetworkAdapter.v1_8_0.NetworkAdapter"/>
     </Schema>
 
   </edmx:DataServices>

--- a/static/redfish/v1/schema/NetworkDeviceFunction_v1.xml
+++ b/static/redfish/v1/schema/NetworkDeviceFunction_v1.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!---->
 <!--################################################################################       -->
-<!--# Redfish Schema:  NetworkDeviceFunction v1.7.0                                        -->
+<!--# Redfish Schema:  NetworkDeviceFunction v1.8.0                                        -->
 <!--#                                                                                      -->
 <!--# For a detailed change log, see the README file contained in the DSP8010 bundle,      -->
 <!--# available at http://www.dmtf.org/standards/redfish                                   -->
@@ -860,6 +860,15 @@
           <Annotation Term="OData.Description" String="The physical port to which this network device function is currently assigned."/>
           <Annotation Term="OData.LongDescription" String="This property shall contain a link to a resource of type Port that is the physical port to which this network device function is currently assigned.  This value shall be one of the AssignablePhysicalNetworkPorts array members."/>
           <Annotation Term="OData.AutoExpandReferences"/>
+          <Annotation Term="Redfish.Revisions">
+            <Collection>
+              <Record>
+                <PropertyValue Property="Kind" EnumMember="Redfish.RevisionKind/Deprecated"/>
+                <PropertyValue Property="Version" String="v1_8_0"/>
+                <PropertyValue Property="Description" String="This property has been deprecated in favor of PhysicalNetworkPortAssignment within Links to avoid loops on expand."/>
+              </Record>
+            </Collection>
+          </Annotation>
         </NavigationProperty>
         <Property Name="InfiniBand" Type="NetworkDeviceFunction.v1_5_0.InfiniBand" Nullable="false">
           <Annotation Term="OData.Description" String="The InfiniBand capabilities, status, and configuration values for this network device function."/>
@@ -1056,6 +1065,14 @@
           <Annotation Term="OData.LongDescription" String="This property shall contain a link to a collection of type EthernetInterfaceCollection that represent the Ethernet interfaces present on this network device function.  This property shall not be present if this network device function is not referenced by a NetworkInterface resource."/>
         </NavigationProperty>
       </ComplexType>
+    </Schema>
+
+    <Schema xmlns="http://docs.oasis-open.org/odata/ns/edm" Namespace="NetworkDeviceFunction.v1_8_0">
+      <Annotation Term="Redfish.OwningEntity" String="DMTF"/>
+      <Annotation Term="Redfish.Release" String="2021.4"/>
+      <Annotation Term="OData.Description" String="This version was created to deprecate PhysicalNetworkPortAssignment at the root of the resource in favor of PhysicalNetworkPortAssignment within Links."/>
+
+      <EntityType Name="NetworkDeviceFunction" BaseType="NetworkDeviceFunction.v1_7_0.NetworkDeviceFunction"/>
     </Schema>
 
   </edmx:DataServices>

--- a/static/redfish/v1/schema/OemServiceRoot_v1.xml
+++ b/static/redfish/v1/schema/OemServiceRoot_v1.xml
@@ -1,0 +1,63 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<edmx:Edmx xmlns:edmx="http://docs.oasis-open.org/odata/ns/edmx" Version="4.0">
+
+  <edmx:Reference Uri="http://docs.oasis-open.org/odata/odata/v4.0/errata03/csd01/complete/vocabularies/Org.OData.Core.V1.xml">
+    <edmx:Include Namespace="Org.OData.Core.V1" Alias="OData"/>
+  </edmx:Reference>
+  <edmx:Reference Uri="http://docs.oasis-open.org/odata/odata/v4.0/errata03/csd01/complete/vocabularies/Org.OData.Measures.V1.xml">
+    <edmx:Include Namespace="Org.OData.Measures.V1" Alias="Measures"/>
+  </edmx:Reference>
+  <edmx:Reference Uri="http://redfish.dmtf.org/schemas/v1/RedfishExtensions_v1.xml">
+    <edmx:Include Namespace="RedfishExtensions.v1_0_0" Alias="Redfish"/>
+  </edmx:Reference>
+    <edmx:Reference Uri="http://redfish.dmtf.org/schemas/v1/ServiceRoot_v1.xml">
+        <edmx:Include Namespace="ServiceRoot"/>
+        <edmx:Include Namespace="ServiceRoot.v1_12_0"/>
+    </edmx:Reference>
+  <edmx:Reference Uri="http://redfish.dmtf.org/schemas/v1/Resource_v1.xml">
+    <edmx:Include Namespace="Resource"/>
+    <edmx:Include Namespace="Resource.v1_0_0"/>
+  </edmx:Reference>
+
+  <edmx:DataServices>
+
+    <Schema xmlns="http://docs.oasis-open.org/odata/ns/edm" Namespace="OemServiceRoot">
+      <Annotation Term="Redfish.OwningEntity" String="IBM"/>
+
+      <ComplexType Name="Oem" BaseType="Resource.OemObject">
+        <Annotation Term="OData.AdditionalProperties" Bool="true"/>
+        <Annotation Term="OData.Description" String="OemServiceRoot Oem properties."/>
+        <Annotation Term="OData.AutoExpand"/>
+        <Property Name="IBM" Type="OemServiceRoot.IBM"/>
+      </ComplexType>
+
+      <ComplexType Name="IBM" BaseType="Resource.OemObject">
+        <Annotation Term="OData.AdditionalProperties" Bool="true" />
+        <Annotation Term="OData.Description" String="Oem properties for IBM." />
+        <Annotation Term="OData.AutoExpand"/>
+        <Property Name="Model" Type="OemServiceRoot.IBM">
+          <Annotation Term="OData.Permissions" EnumMember="OData.Permission/Read"/>
+          <Annotation Term="OData.Description" String="The product name for this system, without the manufacturer name."/>
+          <Annotation Term="OData.LongDescription" String="This property shall describe how the manufacturer refers to this system.  Typically, this value is the product name for this system without the manufacturer name."/>
+        </Property>
+        <Property Name="SerialNumber" Type="OemServiceRoot.IBM">
+          <Annotation Term="OData.Permissions" EnumMember="OData.Permission/Read"/>
+          <Annotation Term="OData.Description" String="The serial number for this system."/>
+          <Annotation Term="OData.LongDescription" String="This property shall contain the serial number for the system."/>
+        </Property>
+        <Property Name="DateTime" Type="OemServiceRoot.IBM">
+          <Annotation Term="OData.Permissions" EnumMember="OData.Permission/ReadWrite"/>
+          <Annotation Term="OData.Description" String="The current date and time with UTC offset of the manager."/>
+          <Annotation Term="OData.LongDescription" String="This property shall contain the current date and time with UTC offset of the manager."/>
+        </Property>
+        <Property Name="DateTimeLocalOffset" Type="OemServiceRoot.IBM">
+          <Annotation Term="OData.Permissions" EnumMember="OData.Permission/ReadWrite"/>
+          <Annotation Term="OData.Description" String="The time offset from UTC that the DateTime property is in `+HH:MM` format."/>
+          <Annotation Term="OData.LongDescription" String="This property shall contain the offset from UTC time that the DateTime property contains.  If both DateTime and DateTimeLocalOffset are provided in modification requests, services shall apply DateTimeLocalOffset after DateTime is applied."/>
+        </Property>
+      </ComplexType>
+
+    </Schema>
+
+  </edmx:DataServices>
+</edmx:Edmx>

--- a/static/redfish/v1/schema/OutletGroup_v1.xml
+++ b/static/redfish/v1/schema/OutletGroup_v1.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!---->
 <!--################################################################################       -->
-<!--# Redfish Schema:  OutletGroup v1.0.1                                                  -->
+<!--# Redfish Schema:  OutletGroup v1.1.0                                                  -->
 <!--#                                                                                      -->
 <!--# For a detailed change log, see the README file contained in the DSP8010 bundle,      -->
 <!--# available at http://www.dmtf.org/standards/redfish                                   -->
@@ -87,10 +87,22 @@
 
       <EnumType Name="PowerState">
         <Member Name="On">
-          <Annotation Term="OData.Description" String="The outlet group is powered on."/>
+          <Annotation Term="OData.Description" String="Power on."/>
         </Member>
         <Member Name="Off">
-          <Annotation Term="OData.Description" String="The outlet group is powered off."/>
+          <Annotation Term="OData.Description" String="Power off."/>
+        </Member>
+        <Member Name="PowerCycle">
+          <Annotation Term="OData.Description" String="Power cycle."/>
+          <Annotation Term="OData.LongDescription" String="This value shall indicate the resource will transition to a power off state, then transition to a power on state.  Upon successful completion, the PowerState property, if supported, shall contain the value `On`."/>
+          <Annotation Term="Redfish.Revisions">
+            <Collection>
+              <Record>
+                <PropertyValue Property="Kind" EnumMember="Redfish.RevisionKind/Added"/>
+                <PropertyValue Property="Version" String="v1_1_0"/>
+              </Record>
+            </Collection>
+          </Annotation>
         </Member>
       </EnumType>
     </Schema>
@@ -146,16 +158,14 @@
         </Property>
 
         <NavigationProperty Name="PowerWatts" Type="Sensor.Sensor">
-          <Annotation Term="OData.Permissions" EnumMember="OData.Permission/Read"/>
           <Annotation Term="Redfish.ExcerptCopy" String="Power"/>
-          <Annotation Term="OData.Description" String="The power reading for this outlet group."/>
-          <Annotation Term="OData.LongDescription" String="This property shall contain the total power, measured in Watts, for this outlet group, that represents the `Total` ElectricalContext sensor when multiple power sensors exist for this outlet group."/>
+          <Annotation Term="OData.Description" String="The power (W) for this outlet group."/>
+          <Annotation Term="OData.LongDescription" String="This property shall contain the total power, in watt units, for this outlet group, that represents the `Total` ElectricalContext sensor when multiple power sensors exist for this outlet group.  The value of the DataSourceUri property, if present, shall reference a resource of type Sensor with the ReadingType property containing the value `Power`."/>
         </NavigationProperty>
         <NavigationProperty Name="EnergykWh" Type="Sensor.Sensor">
-          <Annotation Term="OData.Permissions" EnumMember="OData.Permission/Read"/>
           <Annotation Term="Redfish.ExcerptCopy" String="EnergykWh"/>
-          <Annotation Term="OData.Description" String="The energy reading for this outlet group."/>
-          <Annotation Term="OData.LongDescription" String="This property shall contain the total energy, measured in kilowatt-hours (kW.h), for this outlet group, that represents the `Total` ElectricalContext sensor when multiple energy sensors exist for this outlet group."/>
+          <Annotation Term="OData.Description" String="The energy (kWh) for this outlet group."/>
+          <Annotation Term="OData.LongDescription" String="This property shall contain the total energy, in kilowatt-hour units, for this outlet group, that represents the `Total` ElectricalContext sensor when multiple energy sensors exist for this outlet group.  The value of the DataSourceUri property, if present, shall reference a resource of type Sensor with the ReadingType property containing the value `EnergykWh`."/>
         </NavigationProperty>
 
         <Property Name="Links" Type="OutletGroup.v1_0_0.Links" Nullable="false">
@@ -200,6 +210,36 @@
       <Annotation Term="Redfish.OwningEntity" String="DMTF"/>
       <Annotation Term="OData.Description" String="This version was created to correct various typographical errors."/>
       <EntityType Name="OutletGroup" BaseType="OutletGroup.v1_0_0.OutletGroup"/>
+    </Schema>
+
+    <Schema xmlns="http://docs.oasis-open.org/odata/ns/edm" Namespace="OutletGroup.v1_0_2">
+      <Annotation Term="Redfish.OwningEntity" String="DMTF"/>
+      <Annotation Term="OData.Description" String="This version was created to update descriptions to tie excerpt property definitions to a specific type of Sensor or Control. It was also created to correct various typographical errors."/>
+      <EntityType Name="OutletGroup" BaseType="OutletGroup.v1_0_1.OutletGroup"/>
+    </Schema>
+
+    <Schema xmlns="http://docs.oasis-open.org/odata/ns/edm" Namespace="OutletGroup.v1_1_0">
+      <Annotation Term="Redfish.OwningEntity" String="DMTF"/>
+      <Annotation Term="Redfish.Release" String="2021.4"/>
+      <Annotation Term="OData.Description" String="This version was created to add `PowerCycle` to the PowerState parameter of the PowerControl action."/>
+
+      <EntityType Name="OutletGroup" BaseType="OutletGroup.v1_0_2.OutletGroup">
+        <Property Name="PowerControlLocked" Type="Edm.Boolean" Nullable="false">
+          <Annotation Term="OData.Permissions" EnumMember="OData.Permission/ReadWrite"/>
+          <Annotation Term="OData.Description" String="Indicates whether power control requests are locked."/>
+          <Annotation Term="OData.LongDescription" String="This property shall indicate whether requests to the PowerControl action are locked.  If `true`, services shall reject requests to the PowerControl action."/>
+        </Property>
+        <Property Name="ConfigurationLocked" Type="Edm.Boolean" Nullable="false">
+          <Annotation Term="OData.Permissions" EnumMember="OData.Permission/ReadWrite"/>
+          <Annotation Term="OData.Description" String="Indicates whether the configuration is locked."/>
+          <Annotation Term="OData.LongDescription" String="This property shall indicate whether modification requests to this resource are not permitted.  If `true`, services shall reject modification requests to other properties in this resource."/>
+        </Property>
+        <Property Name="PowerStateInTransition" Type="Edm.Boolean" Nullable="false">
+          <Annotation Term="OData.Permissions" EnumMember="OData.Permission/Read"/>
+          <Annotation Term="OData.Description" String="Indicates whether the power state is undergoing a delayed transition."/>
+          <Annotation Term="OData.LongDescription" String="This property shall indicate whether the PowerState property will undergo a transition between on and off states due to a configured delay.  The transition may be due to the configuration of the power on, off, or restore delay properties.  If `true`, the PowerState property will transition at the conclusion of a configured delay."/>
+        </Property>
+      </EntityType>
     </Schema>
 
   </edmx:DataServices>

--- a/static/redfish/v1/schema/Outlet_v1.xml
+++ b/static/redfish/v1/schema/Outlet_v1.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!---->
 <!--################################################################################       -->
-<!--# Redfish Schema:  Outlet v1.3.0                                                       -->
+<!--# Redfish Schema:  Outlet v1.4.0                                                       -->
 <!--#                                                                                      -->
 <!--# For a detailed change log, see the README file contained in the DSP8010 bundle,      -->
 <!--# available at http://www.dmtf.org/standards/redfish                                   -->
@@ -94,10 +94,22 @@
 
       <EnumType Name="PowerState">
         <Member Name="On">
-          <Annotation Term="OData.Description" String="The outlet is powered on."/>
+          <Annotation Term="OData.Description" String="Power on."/>
         </Member>
         <Member Name="Off">
-          <Annotation Term="OData.Description" String="The outlet is powered off."/>
+          <Annotation Term="OData.Description" String="Power off."/>
+        </Member>
+        <Member Name="PowerCycle">
+          <Annotation Term="OData.Description" String="Power cycle."/>
+          <Annotation Term="OData.LongDescription" String="This value shall indicate the resource will transition to a power off state, then transition to a power on state.  Upon successful completion, the PowerState property, if supported, shall contain the value `On`."/>
+          <Annotation Term="Redfish.Revisions">
+            <Collection>
+              <Record>
+                <PropertyValue Property="Kind" EnumMember="Redfish.RevisionKind/Added"/>
+                <PropertyValue Property="Version" String="v1_4_0"/>
+              </Record>
+            </Collection>
+          </Annotation>
         </Member>
       </EnumType>
 
@@ -206,7 +218,7 @@
         <Property Name="RatedCurrentAmps" Type="Edm.Decimal">
           <Annotation Term="OData.Permissions" EnumMember="OData.Permission/Read"/>
           <Annotation Term="OData.Description" String="The rated maximum current allowed for this outlet."/>
-          <Annotation Term="OData.LongDescription" String="This property shall contain the rated maximum current for this outlet, in Amps, after any required de-rating, due to safety agency or other regulatory requirements, has been applied."/>
+          <Annotation Term="OData.LongDescription" String="This property shall contain the rated maximum current for this outlet, in ampere units, after any required de-rating, due to safety agency or other regulatory requirements, has been applied."/>
           <Annotation Term="Measures.Unit" String="A"/>
           <Annotation Term="Validation.Minimum" Int="0"/>
         </Property>
@@ -261,37 +273,37 @@
         </Property>
         <NavigationProperty Name="Voltage" Type="Sensor.Sensor">
           <Annotation Term="Redfish.ExcerptCopy" String="Voltage"/>
-          <Annotation Term="OData.Description" String="The voltage reading for this single phase outlet."/>
-          <Annotation Term="OData.LongDescription" String="This property shall contain the voltage, measured in Volts, for this single phase outlet.  This property shall not appear in resource instances representing poly-phase outlets."/>
+          <Annotation Term="OData.Description" String="The voltage (V) for this single phase outlet."/>
+          <Annotation Term="OData.LongDescription" String="This property shall contain the voltage, in volt units, for this single phase outlet.  The value of the DataSourceUri property, if present, shall reference a resource of type Sensor with the ReadingType property containing the value `Voltage`.  This property shall not appear in resource instances representing poly-phase outlets."/>
         </NavigationProperty>
         <NavigationProperty Name="CurrentAmps" Type="Sensor.Sensor">
           <Annotation Term="Redfish.ExcerptCopy" String="Current"/>
-          <Annotation Term="OData.Description" String="The current reading for this single phase outlet."/>
-          <Annotation Term="OData.LongDescription" String="This property shall contain the current, measured in Amperes, for this single phase outlet.  This property shall not appear in resource instances representing poly-phase outlets."/>
+          <Annotation Term="OData.Description" String="The current (A) for this single phase outlet."/>
+          <Annotation Term="OData.LongDescription" String="This property shall contain the current, in ampere units, for this single phase outlet.  The value of the DataSourceUri property, if present, shall reference a resource of type Sensor with the ReadingType property containing the value `Current`.  This property shall not appear in resource instances representing poly-phase outlets."/>
         </NavigationProperty>
         <NavigationProperty Name="PowerWatts" Type="Sensor.Sensor">
           <Annotation Term="Redfish.ExcerptCopy" String="Power"/>
-          <Annotation Term="OData.Description" String="The power reading for this outlet."/>
-          <Annotation Term="OData.LongDescription" String="This property shall contain the total power, measured in Watts, for this outlet, that represents the `Total` ElectricalContext sensor when multiple power sensors exist for this outlet."/>
+          <Annotation Term="OData.Description" String="The power (W) for this outlet."/>
+          <Annotation Term="OData.LongDescription" String="This property shall contain the total power, in watt units, for this outlet, that represents the `Total` ElectricalContext sensor when multiple power sensors exist for this outlet.  The value of the DataSourceUri property, if present, shall reference a resource of type Sensor with the ReadingType property containing the value `Power`."/>
         </NavigationProperty>
         <NavigationProperty Name="EnergykWh" Type="Sensor.Sensor">
           <Annotation Term="Redfish.ExcerptCopy" String="EnergykWh"/>
-          <Annotation Term="OData.Description" String="The energy reading for this outlet."/>
-          <Annotation Term="OData.LongDescription" String="This property shall contain the total energy, measured in kilowatt-hours (kW.h), for this outlet, that represents the `Total` ElectricalContext sensor when multiple energy sensors exist for this outlet."/>
+          <Annotation Term="OData.Description" String="The energy (kWh) for this outlet."/>
+          <Annotation Term="OData.LongDescription" String="This property shall contain the total energy, in kilowatt-hour units, for this outlet, that represents the `Total` ElectricalContext sensor when multiple energy sensors exist for this outlet.  The value of the DataSourceUri property, if present, shall reference a resource of type Sensor with the ReadingType property containing the value `EnergykWh`."/>
         </NavigationProperty>
         <NavigationProperty Name="FrequencyHz" Type="Sensor.Sensor">
           <Annotation Term="Redfish.ExcerptCopy"/>
-          <Annotation Term="OData.Description" String="The frequency reading for this outlet."/>
-          <Annotation Term="OData.LongDescription" String="This property shall contain the frequency sensor for this outlet."/>
+          <Annotation Term="OData.Description" String="The frequency (Hz) for this outlet."/>
+          <Annotation Term="OData.LongDescription" String="This property shall contain the frequency, in hertz units, for this outlet.  The value of the DataSourceUri property, if present, shall reference a resource of type Sensor with the ReadingType property containing the value `Frequency`."/>
         </NavigationProperty>
 
         <Property Name="PolyPhaseVoltage" Type="Outlet.v1_0_0.VoltageSensors">
           <Annotation Term="OData.Description" String="The voltage readings for this outlet."/>
-          <Annotation Term="OData.LongDescription" String="This property shall contain the voltage sensor(s) for this outlet.  For single phase outlets this property shall contain a duplicate copy of the voltage sensor referenced in the VoltageSensor property, if present.  For poly-phase outlets this property should contain multiple voltage sensor readings used to fully describe the outlet."/>
+          <Annotation Term="OData.LongDescription" String="This property shall contain the voltage readings for this outlet.  For single phase outlets this property shall contain a duplicate copy of the voltage sensor referenced in the Voltage property, if present.  For poly-phase outlets this property should contain multiple voltage sensor readings used to fully describe the outlet."/>
         </Property>
         <Property Name="PolyPhaseCurrentAmps" Type="Outlet.v1_0_0.CurrentSensors">
           <Annotation Term="OData.Description" String="The current readings for this outlet."/>
-          <Annotation Term="OData.LongDescription" String="This property shall contain the current sensor(s) for this outlet.  For single phase outlets this property shall contain a duplicate copy of the current sensor referenced in the CurrentSensor property, if present.  For poly-phase outlets this property should contain multiple current sensor readings used to fully describe the outlet."/>
+          <Annotation Term="OData.LongDescription" String="This property shall contain the current readings for this outlet.  For single phase outlets this property shall contain a duplicate copy of the current sensor referenced in the CurrentAmps property, if present.  For poly-phase outlets this property should contain multiple current sensor readings used to fully describe the outlet."/>
         </Property>
 
         <Property Name="Links" Type="Outlet.v1_0_0.Links" Nullable="false">
@@ -337,33 +349,33 @@
         <Annotation Term="OData.LongDescription" String="This type shall contain properties that describe voltage sensor readings for an outlet."/>
         <NavigationProperty Name="Line1ToLine2" Type="Sensor.Sensor">
           <Annotation Term="Redfish.ExcerptCopy" String="Voltage"/>
-          <Annotation Term="OData.Description" String="The Line 1 to Line 2 voltage reading for this outlet."/>
-          <Annotation Term="OData.LongDescription" String="This property shall contain a Sensor excerpt of type Voltage that measures voltage between L1 and L2.  This property shall not be present if the outlet does not include an L1-L2 measurement."/>
+          <Annotation Term="OData.Description" String="The Line 1 to Line 2 voltage (V) for this outlet."/>
+          <Annotation Term="OData.LongDescription" String="This property shall contain the line-to-line voltage, in volt units, between L1 and L2.  The value of the DataSourceUri property, if present, shall reference a resource of type Sensor with the ReadingType property containing the value `Voltage`.  This property shall not be present if the equipment does not include an L1-L2 measurement."/>
         </NavigationProperty>
         <NavigationProperty Name="Line2ToLine3" Type="Sensor.Sensor">
           <Annotation Term="Redfish.ExcerptCopy" String="Voltage"/>
-          <Annotation Term="OData.Description" String="The Line 2 to Line 3 voltage reading for this outlet."/>
-          <Annotation Term="OData.LongDescription" String="This property shall contain a Sensor excerpt of type Voltage that measures voltage between L2 and L3.  This property shall not be present if the outlet does not include an L2-L3 measurement."/>
+          <Annotation Term="OData.Description" String="The Line 2 to Line 3 voltage (V) for this outlet."/>
+          <Annotation Term="OData.LongDescription" String="This property shall contain the line-to-line voltage, in volt units, between L2 and L3.  The value of the DataSourceUri property, if present, shall reference a resource of type Sensor with the ReadingType property containing the value `Voltage`.  This property shall not be present if the equipment does not include an L2-L3 measurement."/>
         </NavigationProperty>
         <NavigationProperty Name="Line3ToLine1" Type="Sensor.Sensor">
           <Annotation Term="Redfish.ExcerptCopy" String="Voltage"/>
-          <Annotation Term="OData.Description" String="The Line 3 to Line 1 voltage reading for this outlet."/>
-          <Annotation Term="OData.LongDescription" String="This property shall contain a Sensor excerpt of type Voltage that measures voltage between L3 and L1.  This property shall not be present if the outlet does not include an L3-L1 measurement."/>
+          <Annotation Term="OData.Description" String="The Line 3 to Line 1 voltage (V) for this outlet."/>
+          <Annotation Term="OData.LongDescription" String="This property shall contain the line-to-line voltage, in volt units, between L3 and L1.  The value of the DataSourceUri property, if present, shall reference a resource of type Sensor with the ReadingType property containing the value `Voltage`.  This property shall not be present if the equipment does not include an L3-L1 measurement."/>
         </NavigationProperty>
         <NavigationProperty Name="Line1ToNeutral" Type="Sensor.Sensor">
           <Annotation Term="Redfish.ExcerptCopy" String="Voltage"/>
-          <Annotation Term="OData.Description" String="The Line 1 to Neutral voltage reading for this outlet."/>
-          <Annotation Term="OData.LongDescription" String="This property shall contain a Sensor excerpt of type Voltage that measures voltage between L1 and Neutral.  This property shall not be present if the outlet does not include an L1-Neutral measurement."/>
+          <Annotation Term="OData.Description" String="The Line 1 to Neutral voltage (V) for this outlet."/>
+          <Annotation Term="OData.LongDescription" String="This property shall contain the line-to-line voltage, in volt units, between L1 and Neutral.  The value of the DataSourceUri property, if present, shall reference a resource of type Sensor with the ReadingType property containing the value `Voltage`.  This property shall not be present if the equipment does not include an L1-Neutral measurement."/>
         </NavigationProperty>
         <NavigationProperty Name="Line2ToNeutral" Type="Sensor.Sensor">
           <Annotation Term="Redfish.ExcerptCopy" String="Voltage"/>
-          <Annotation Term="OData.Description" String="The Line 2 to Neutral voltage reading for this outlet."/>
-          <Annotation Term="OData.LongDescription" String="This property shall contain a Sensor excerpt of type Voltage that measures voltage between L2 and Neutral.  This property shall not be present if the outlet does not include an L2-Neutral measurement."/>
+          <Annotation Term="OData.Description" String="The Line 2 to Neutral voltage (V) for this outlet."/>
+          <Annotation Term="OData.LongDescription" String="This property shall contain the line-to-line voltage, in volt units, between L2 and Neutral.  The value of the DataSourceUri property, if present, shall reference a resource of type Sensor with the ReadingType property containing the value `Voltage`.  This property shall not be present if the equipment does not include an L2-Neutral measurement."/>
         </NavigationProperty>
         <NavigationProperty Name="Line3ToNeutral" Type="Sensor.Sensor">
           <Annotation Term="Redfish.ExcerptCopy" String="Voltage"/>
-          <Annotation Term="OData.Description" String="The Line 3 to Neutral voltage reading for this outlet."/>
-          <Annotation Term="OData.LongDescription" String="This property shall contain a Sensor excerpt of type Voltage that measures voltage between L3 and Neutral.  This property shall not be present if the outlet does not include an L3-Neutral measurement."/>
+          <Annotation Term="OData.Description" String="The Line 3 to Neutral voltage (V) for this outlet."/>
+          <Annotation Term="OData.LongDescription" String="This property shall contain the line-to-line voltage, in volt units, between L3 and Neutral.  The value of the DataSourceUri property, if present, shall reference a resource of type Sensor with the ReadingType property containing the value `Voltage`.  This property shall not be present if the equipment does not include an L3-Neutral measurement."/>
         </NavigationProperty>
       </ComplexType>
 
@@ -373,23 +385,23 @@
         <Annotation Term="OData.LongDescription" String="This type shall contain properties that describe current sensor readings for an outlet."/>
         <NavigationProperty Name="Line1" Type="Sensor.Sensor">
           <Annotation Term="Redfish.ExcerptCopy" String="Current"/>
-          <Annotation Term="OData.Description" String="Line 1 current sensor."/>
-          <Annotation Term="OData.LongDescription" String="This property shall contain a Sensor excerpt of type Current that measures current for L1.  This property shall not be present if the outlet does not include an L1 measurement."/>
+          <Annotation Term="OData.Description" String="Line 1 current (A)."/>
+          <Annotation Term="OData.LongDescription" String="This property shall contain the line current, in ampere units, for L1.  The value of the DataSourceUri property, if present, shall reference a resource of type Sensor with the ReadingType property containing the value `Current`.  This property shall not be present if the equipment does not include an L1 measurement."/>
         </NavigationProperty>
         <NavigationProperty Name="Line2" Type="Sensor.Sensor">
           <Annotation Term="Redfish.ExcerptCopy" String="Current"/>
-          <Annotation Term="OData.Description" String="Line 2 current sensor."/>
-          <Annotation Term="OData.LongDescription" String="This property shall contain a Sensor excerpt of type Current that measures current for L2.  This property shall not be present if the outlet does not include an L2 measurement."/>
+          <Annotation Term="OData.Description" String="Line 2 current (A)."/>
+          <Annotation Term="OData.LongDescription" String="This property shall contain the line current, in ampere units, for L2.  The value of the DataSourceUri property, if present, shall reference a resource of type Sensor with the ReadingType property containing the value `Current`.  This property shall not be present if the equipment does not include an L2 measurement."/>
         </NavigationProperty>
         <NavigationProperty Name="Line3" Type="Sensor.Sensor">
           <Annotation Term="Redfish.ExcerptCopy" String="Current"/>
-          <Annotation Term="OData.Description" String="Line 3 current sensor."/>
-          <Annotation Term="OData.LongDescription" String="This property shall contain a Sensor excerpt of type Current that measures current for L3.  This property shall not be present if the outlet does not include an L3 measurement."/>
+          <Annotation Term="OData.Description" String="Line 3 current (A)."/>
+          <Annotation Term="OData.LongDescription" String="This property shall contain the line current, in ampere units, for L3.  The value of the DataSourceUri property, if present, shall reference a resource of type Sensor with the ReadingType property containing the value `Current`.  This property shall not be present if the equipment does not include an L3 measurement."/>
         </NavigationProperty>
         <NavigationProperty Name="Neutral" Type="Sensor.Sensor">
           <Annotation Term="Redfish.ExcerptCopy" String="Current"/>
-          <Annotation Term="OData.Description" String="Neutral line current sensor."/>
-          <Annotation Term="OData.LongDescription" String="This property shall contain a Sensor excerpt of type Current that measures current for the Neutral line.  This property shall not be present if the outlet does not include a Neutral measurement."/>
+          <Annotation Term="OData.Description" String="Neutral line current (A)."/>
+          <Annotation Term="OData.LongDescription" String="This property shall contain the line current, in ampere units, for the Neutral line.  The value of the DataSourceUri property, if present, shall reference a resource of type Sensor with the ReadingType property containing the value `Current`.  This property shall not be present if the equipment does not include a Neutral line measurement."/>
         </NavigationProperty>
       </ComplexType>
 
@@ -415,6 +427,12 @@
       <EntityType Name="Outlet" BaseType="Outlet.v1_0_1.Outlet"/>
     </Schema>
 
+    <Schema xmlns="http://docs.oasis-open.org/odata/ns/edm" Namespace="Outlet.v1_0_3">
+      <Annotation Term="Redfish.OwningEntity" String="DMTF"/>
+      <Annotation Term="OData.Description" String="This version was created to update descriptions to tie excerpt property definitions to a specific type of Sensor or Control."/>
+      <EntityType Name="Outlet" BaseType="Outlet.v1_0_2.Outlet"/>
+    </Schema>
+
     <Schema xmlns="http://docs.oasis-open.org/odata/ns/edm" Namespace="Outlet.v1_1_0">
       <Annotation Term="Redfish.OwningEntity" String="DMTF"/>
       <Annotation Term="Redfish.Release" String="2020.3"/>
@@ -427,13 +445,18 @@
           <Annotation Term="OData.LongDescription" String="This property shall contain the state of the indicator used to physically identify or locate this resource.  A write to this property shall update the value of IndicatorLED in this resource, if supported, to reflect the implementation of the locating function."/>
         </Property>
       </EntityType>
-
     </Schema>
 
     <Schema xmlns="http://docs.oasis-open.org/odata/ns/edm" Namespace="Outlet.v1_1_1">
       <Annotation Term="Redfish.OwningEntity" String="DMTF"/>
       <Annotation Term="OData.Description" String="This version was created to correct various typographical errors."/>
       <EntityType Name="Outlet" BaseType="Outlet.v1_1_0.Outlet"/>
+    </Schema>
+
+    <Schema xmlns="http://docs.oasis-open.org/odata/ns/edm" Namespace="Outlet.v1_1_2">
+      <Annotation Term="Redfish.OwningEntity" String="DMTF"/>
+      <Annotation Term="OData.Description" String="This version was created to update descriptions to tie excerpt property definitions to a specific type of Sensor or Control."/>
+      <EntityType Name="Outlet" BaseType="Outlet.v1_1_1.Outlet"/>
     </Schema>
 
     <Schema xmlns="http://docs.oasis-open.org/odata/ns/edm" Namespace="Outlet.v1_2_0">
@@ -443,10 +466,16 @@
       <EntityType Name="Outlet" BaseType="Outlet.v1_1_1.Outlet">
         <NavigationProperty Name="PowerLoadPercent" Type="Sensor.Sensor">
           <Annotation Term="Redfish.ExcerptCopy"/>
-          <Annotation Term="OData.Description" String="The power load (%) for this outlet."/>
-          <Annotation Term="OData.LongDescription" String="This property shall contain the power load, measured in percent, for this outlet, that represents the `Total` ElectricalContext for this outlet."/>
+          <Annotation Term="OData.Description" String="The power load (percent) for this outlet."/>
+          <Annotation Term="OData.LongDescription" String="This property shall contain the power load, in percent units, for this outlet, that represents the `Total` ElectricalContext for this outlet.  The value of the DataSourceUri property, if present, shall reference a resource of type Sensor with the ReadingType property containing the value `Percent`."/>
         </NavigationProperty>
       </EntityType>
+    </Schema>
+
+    <Schema xmlns="http://docs.oasis-open.org/odata/ns/edm" Namespace="Outlet.v1_2_1">
+      <Annotation Term="Redfish.OwningEntity" String="DMTF"/>
+      <Annotation Term="OData.Description" String="This version was created to update descriptions to tie excerpt property definitions to a specific type of Sensor or Control."/>
+      <EntityType Name="Outlet" BaseType="Outlet.v1_2_0.Outlet"/>
     </Schema>
 
     <Schema xmlns="http://docs.oasis-open.org/odata/ns/edm" Namespace="Outlet.v1_3_0">
@@ -486,6 +515,36 @@
           <Annotation Term="OData.AutoExpandReferences"/>
         </NavigationProperty>
       </ComplexType>
+    </Schema>
+
+    <Schema xmlns="http://docs.oasis-open.org/odata/ns/edm" Namespace="Outlet.v1_3_1">
+      <Annotation Term="Redfish.OwningEntity" String="DMTF"/>
+      <Annotation Term="OData.Description" String="This version was created to update descriptions to tie excerpt property definitions to a specific type of Sensor or Control."/>
+      <EntityType Name="Outlet" BaseType="Outlet.v1_3_0.Outlet"/>
+    </Schema>
+
+    <Schema xmlns="http://docs.oasis-open.org/odata/ns/edm" Namespace="Outlet.v1_4_0">
+      <Annotation Term="Redfish.OwningEntity" String="DMTF"/>
+      <Annotation Term="Redfish.Release" String="2021.4"/>
+      <Annotation Term="OData.Description" String="This version was created to add `PowerCycle` to the PowerState parameter of the PowerControl action."/>
+
+      <EntityType Name="Outlet" BaseType="Outlet.v1_3_1.Outlet">
+        <Property Name="PowerControlLocked" Type="Edm.Boolean" Nullable="false">
+          <Annotation Term="OData.Permissions" EnumMember="OData.Permission/ReadWrite"/>
+          <Annotation Term="OData.Description" String="Indicates whether power control requests are locked."/>
+          <Annotation Term="OData.LongDescription" String="This property shall indicate whether requests to the PowerControl action are locked.  If `true`, services shall reject requests to the PowerControl action."/>
+        </Property>
+        <Property Name="ConfigurationLocked" Type="Edm.Boolean" Nullable="false">
+          <Annotation Term="OData.Permissions" EnumMember="OData.Permission/ReadWrite"/>
+          <Annotation Term="OData.Description" String="Indicates whether the configuration is locked."/>
+          <Annotation Term="OData.LongDescription" String="This property shall indicate whether modification requests to this resource are not permitted.  If `true`, services shall reject modification requests to other properties in this resource."/>
+        </Property>
+        <Property Name="PowerStateInTransition" Type="Edm.Boolean" Nullable="false">
+          <Annotation Term="OData.Permissions" EnumMember="OData.Permission/Read"/>
+          <Annotation Term="OData.Description" String="Indicates whether the power state is undergoing a delayed transition."/>
+          <Annotation Term="OData.LongDescription" String="This property shall indicate whether the PowerState property will undergo a transition between on and off states due to a configured delay.  The transition may be due to the configuration of the power on, off, or restore delay properties.  If `true`, the PowerState property will transition at the conclusion of a configured delay."/>
+        </Property>
+      </EntityType>
     </Schema>
 
   </edmx:DataServices>

--- a/static/redfish/v1/schema/Port_v1.xml
+++ b/static/redfish/v1/schema/Port_v1.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!---->
 <!--################################################################################       -->
-<!--# Redfish Schema:  Port v1.5.0                                                         -->
+<!--# Redfish Schema:  Port v1.6.0                                                         -->
 <!--#                                                                                      -->
 <!--# For a detailed change log, see the README file contained in the DSP8010 bundle,      -->
 <!--# available at http://www.dmtf.org/standards/redfish                                   -->
@@ -1171,6 +1171,42 @@
           <Annotation Term="OData.LongDescription" String="This property shall contain an array of links to resources of type Cable that represent the cables connected to this port."/>
           <Annotation Term="OData.AutoExpandReferences"/>
         </NavigationProperty>
+      </ComplexType>
+    </Schema>
+
+    <Schema xmlns="http://docs.oasis-open.org/odata/ns/edm" Namespace="Port.v1_6_0">
+      <Annotation Term="Redfish.OwningEntity" String="DMTF"/>
+      <Annotation Term="Redfish.Release" String="2021.4"/>
+
+      <EntityType Name="Port" BaseType="Port.v1_5_0.Port">
+        <Property Name="InfiniBand" Type="Port.v1_6_0.InfiniBandProperties">
+          <Annotation Term="OData.Description" String="InfiniBand properties for this port."/>
+          <Annotation Term="OData.LongDescription" String="This property shall contain InfiniBand-specific properties of the port."/>
+        </Property>
+      </EntityType>
+
+      <ComplexType Name="InfiniBandProperties">
+        <Annotation Term="OData.AdditionalProperties" Bool="false"/>
+        <Annotation Term="OData.Description" String="InfiniBand-specific properties for a port."/>
+        <Annotation Term="OData.LongDescription" String="This type shall contain InfiniBand-specific properties for a port."/>
+        <Property Name="AssociatedPortGUIDs" Type="Collection(Edm.String)">
+          <Annotation Term="OData.Permissions" EnumMember="OData.Permission/Read"/>
+          <Annotation Term="OData.Description" String="An array of configured port GUIDs that are associated with this network port, including the programmed address of the lowest numbered network device function, the configured but not active address, if applicable, the address for hardware port teaming, or other network addresses."/>
+          <Annotation Term="OData.LongDescription" String="This property shall contain an array of configured port GUIDs that are associated with this network port, including the programmed address of the lowest numbered network device function, the configured but not active address if applicable, the address for hardware port teaming, or other network addresses."/>
+          <Annotation Term="Validation.Pattern" String="^([0-9A-Fa-f]{4}[:-]){3}([0-9A-Fa-f]{4})$"/>
+        </Property>
+        <Property Name="AssociatedNodeGUIDs" Type="Collection(Edm.String)">
+          <Annotation Term="OData.Permissions" EnumMember="OData.Permission/Read"/>
+          <Annotation Term="OData.Description" String="An array of configured node GUIDs that are associated with this network port, including the programmed address of the lowest numbered network device function, the configured but not active address, if applicable, the address for hardware port teaming, or other network addresses."/>
+          <Annotation Term="OData.LongDescription" String="This property shall contain an array of configured node GUIDs that are associated with this network port, including the programmed address of the lowest numbered network device function, the configured but not active address if applicable, the address for hardware port teaming, or other network addresses."/>
+          <Annotation Term="Validation.Pattern" String="^([0-9A-Fa-f]{4}[:-]){3}([0-9A-Fa-f]{4})$"/>
+        </Property>
+        <Property Name="AssociatedSystemGUIDs" Type="Collection(Edm.String)">
+          <Annotation Term="OData.Permissions" EnumMember="OData.Permission/Read"/>
+          <Annotation Term="OData.Description" String="An array of configured system GUIDs that are associated with this network port, including the programmed address of the lowest numbered network device function, the configured but not active address, if applicable, the address for hardware port teaming, or other network addresses."/>
+          <Annotation Term="OData.LongDescription" String="This property shall contain an array of configured system GUIDs that are associated with this network port, including the programmed address of the lowest numbered network device function, the configured but not active address if applicable, the address for hardware port teaming, or other network addresses."/>
+          <Annotation Term="Validation.Pattern" String="^([0-9A-Fa-f]{4}[:-]){3}([0-9A-Fa-f]{4})$"/>
+        </Property>
       </ComplexType>
     </Schema>
 

--- a/static/redfish/v1/schema/PowerDistributionMetrics_v1.xml
+++ b/static/redfish/v1/schema/PowerDistributionMetrics_v1.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!---->
 <!--################################################################################       -->
-<!--# Redfish Schema:  PowerDistributionMetrics v1.2.0                                     -->
+<!--# Redfish Schema:  PowerDistributionMetrics v1.3.0                                     -->
 <!--#                                                                                      -->
 <!--# For a detailed change log, see the README file contained in the DSP8010 bundle,      -->
 <!--# available at http://www.dmtf.org/standards/redfish                                   -->
@@ -77,14 +77,14 @@
       <EntityType Name="PowerDistributionMetrics" BaseType="PowerDistributionMetrics.PowerDistributionMetrics">
         <NavigationProperty Name="PowerWatts" Type="Sensor.Sensor">
           <Annotation Term="Redfish.ExcerptCopy" String="Power"/>
-          <Annotation Term="OData.Description" String="Power consumption (Watts)."/>
-          <Annotation Term="OData.LongDescription" String="This property shall contain the total power, measured in Watts, for this unit, that represents the `Total` ElectricalContext sensor when multiple power sensors exist."/>
+          <Annotation Term="OData.Description" String="Power consumption (W)."/>
+          <Annotation Term="OData.LongDescription" String="This property shall contain the total power, in watt units, for this resource, that represents the `Total` ElectricalContext sensor when multiple power sensors exist.  The value of the DataSourceUri property, if present, shall reference a resource of type Sensor with the ReadingType property containing the value `Power`."/>
         </NavigationProperty>
 
         <NavigationProperty Name="EnergykWh" Type="Sensor.Sensor">
           <Annotation Term="Redfish.ExcerptCopy" String="EnergykWh"/>
           <Annotation Term="OData.Description" String="Energy consumption (kWh)."/>
-          <Annotation Term="OData.LongDescription" String="This property shall contain the total energy, measured in kilowatt-hours (kWh), for this unit, that represents the `Total` ElectricalContext sensor when multiple energy sensors exist."/>
+          <Annotation Term="OData.LongDescription" String="This property shall contain the total energy, in kilowatt-hours, for this resource, that represents the `Total` ElectricalContext sensor when multiple energy sensors exist.  The value of the DataSourceUri property, if present, shall reference a resource of type Sensor with the ReadingType property containing the value `EnergykWh`."/>
         </NavigationProperty>
 
         <Property Name="Actions" Type="PowerDistributionMetrics.v1_0_0.Actions" Nullable="false">
@@ -116,6 +116,12 @@
       <EntityType Name="PowerDistributionMetrics" BaseType="PowerDistributionMetrics.v1_0_0.PowerDistributionMetrics"/>
     </Schema>
 
+    <Schema xmlns="http://docs.oasis-open.org/odata/ns/edm" Namespace="PowerDistributionMetrics.v1_0_2">
+      <Annotation Term="Redfish.OwningEntity" String="DMTF"/>
+      <Annotation Term="OData.Description" String="This version was created to update descriptions to tie excerpt property definitions to a specific type of Sensor or Control."/>
+      <EntityType Name="PowerDistributionMetrics" BaseType="PowerDistributionMetrics.v1_0_1.PowerDistributionMetrics"/>
+    </Schema>
+
     <Schema xmlns="http://docs.oasis-open.org/odata/ns/edm" Namespace="PowerDistributionMetrics.v1_1_0">
       <Annotation Term="Redfish.OwningEntity" String="DMTF"/>
       <Annotation Term="Redfish.Release" String="2021.1"/>
@@ -124,14 +130,20 @@
         <NavigationProperty Name="TemperatureCelsius" Type="Sensor.Sensor">
           <Annotation Term="Redfish.ExcerptCopy"/>
           <Annotation Term="OData.Description" String="Temperature (Celsius)."/>
-          <Annotation Term="OData.LongDescription" String="This property shall contain the temperature sensor reading for this resource."/>
+          <Annotation Term="OData.LongDescription" String="This property shall contain the temperature, in degrees Celsius units, for this resource.  The value of the DataSourceUri property, if present, shall reference a resource of type Sensor with the ReadingType property containing the value `Temperature`."/>
         </NavigationProperty>
         <NavigationProperty Name="HumidityPercent" Type="Sensor.Sensor">
           <Annotation Term="Redfish.ExcerptCopy"/>
           <Annotation Term="OData.Description" String="Humidity (percent)."/>
-          <Annotation Term="OData.LongDescription" String="This property shall contain the humidity sensor reading for this resource."/>
+          <Annotation Term="OData.LongDescription" String="This property shall contain the humidity, in percent units, for this resource.  The value of the DataSourceUri property, if present, shall reference a resource of type Sensor with the ReadingType property containing the value `Humidity`."/>
         </NavigationProperty>
       </EntityType>
+    </Schema>
+
+    <Schema xmlns="http://docs.oasis-open.org/odata/ns/edm" Namespace="PowerDistributionMetrics.v1_1_1">
+      <Annotation Term="Redfish.OwningEntity" String="DMTF"/>
+      <Annotation Term="OData.Description" String="This version was created to update descriptions to tie excerpt property definitions to a specific type of Sensor or Control."/>
+      <EntityType Name="PowerDistributionMetrics" BaseType="PowerDistributionMetrics.v1_1_0.PowerDistributionMetrics"/>
     </Schema>
 
     <Schema xmlns="http://docs.oasis-open.org/odata/ns/edm" Namespace="PowerDistributionMetrics.v1_2_0">
@@ -142,8 +154,27 @@
       <EntityType Name="PowerDistributionMetrics" BaseType="PowerDistributionMetrics.v1_1_0.PowerDistributionMetrics">
         <NavigationProperty Name="PowerLoadPercent" Type="Sensor.Sensor">
           <Annotation Term="Redfish.ExcerptCopy"/>
-          <Annotation Term="OData.Description" String="The power load (%) for this equipment."/>
-          <Annotation Term="OData.LongDescription" String="This property shall contain the power load, measured in percent, for this equipment, that represents the `Total` ElectricalContext for this equipment."/>
+          <Annotation Term="OData.Description" String="The power load (percent) for this equipment."/>
+          <Annotation Term="OData.LongDescription" String="This property shall contain the power load, in percent units, for this device, that represents the `Total` ElectricalContext for this device.  The value of the DataSourceUri property, if present, shall reference a resource of type Sensor with the ReadingType property containing the value `Percent`."/>
+        </NavigationProperty>
+      </EntityType>
+    </Schema>
+
+    <Schema xmlns="http://docs.oasis-open.org/odata/ns/edm" Namespace="PowerDistributionMetrics.v1_2_1">
+      <Annotation Term="Redfish.OwningEntity" String="DMTF"/>
+      <Annotation Term="OData.Description" String="This version was created to update descriptions to tie excerpt property definitions to a specific type of Sensor or Control."/>
+      <EntityType Name="PowerDistributionMetrics" BaseType="PowerDistributionMetrics.v1_2_0.PowerDistributionMetrics"/>
+    </Schema>
+
+    <Schema xmlns="http://docs.oasis-open.org/odata/ns/edm" Namespace="PowerDistributionMetrics.v1_3_0">
+      <Annotation Term="Redfish.OwningEntity" String="DMTF"/>
+      <Annotation Term="Redfish.Release" String="2021.4"/>
+
+      <EntityType Name="PowerDistributionMetrics" BaseType="PowerDistributionMetrics.v1_2_1.PowerDistributionMetrics">
+        <NavigationProperty Name="AbsoluteHumidity" Type="Sensor.Sensor">
+          <Annotation Term="Redfish.ExcerptCopy"/>
+          <Annotation Term="OData.Description" String="Absolute humidity (g/cu m)."/>
+          <Annotation Term="OData.LongDescription" String="This property shall contain the absolute (volumetric) humidity sensor reading, in grams/cubic meter units, for this resource.  The value of the DataSourceUri property, if present, shall reference a resource of type Sensor with the ReadingType property containing the value `AbsoluteHumidity`."/>
         </NavigationProperty>
       </EntityType>
     </Schema>

--- a/static/redfish/v1/schema/PowerDistribution_v1.xml
+++ b/static/redfish/v1/schema/PowerDistribution_v1.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!---->
 <!--################################################################################       -->
-<!--# Redfish Schema:  PowerDistribution v1.2.0                                            -->
+<!--# Redfish Schema:  PowerDistribution v1.2.1                                            -->
 <!--#                                                                                      -->
 <!--# For a detailed change log, see the README file contained in the DSP8010 bundle,      -->
 <!--# available at http://www.dmtf.org/standards/redfish                                   -->
@@ -381,14 +381,14 @@
         </Property>
         <Property Name="OverNominalFrequencyHz" Type="Edm.Decimal">
           <Annotation Term="OData.Permissions" EnumMember="OData.Permission/ReadWrite"/>
-          <Annotation Term="OData.Description" String="The frequency in Hertz over the nominal value that satisfies a criterion for transfer."/>
-          <Annotation Term="OData.LongDescription" String="This property shall contain the frequency in Hertz over the nominal value that satisfies a criterion for transfer."/>
+          <Annotation Term="OData.Description" String="The frequency in hertz over the nominal value that satisfies a criterion for transfer."/>
+          <Annotation Term="OData.LongDescription" String="This property shall contain the frequency in hertz over the nominal value that satisfies a criterion for transfer."/>
           <Annotation Term="Measures.Unit" String="Hz"/>
         </Property>
         <Property Name="UnderNominalFrequencyHz" Type="Edm.Decimal">
           <Annotation Term="OData.Permissions" EnumMember="OData.Permission/ReadWrite"/>
-          <Annotation Term="OData.Description" String="The frequency in Hertz under the nominal value that satisfies a criterion for transfer."/>
-          <Annotation Term="OData.LongDescription" String="This property shall contain the frequency in Hertz under the nominal value that satisfies a criterion for transfer."/>
+          <Annotation Term="OData.Description" String="The frequency in hertz under the nominal value that satisfies a criterion for transfer."/>
+          <Annotation Term="OData.LongDescription" String="This property shall contain the frequency in hertz under the nominal value that satisfies a criterion for transfer."/>
           <Annotation Term="Measures.Unit" String="Hz"/>
         </Property>
       </ComplexType>
@@ -440,6 +440,12 @@
       <EntityType Name="PowerDistribution" BaseType="PowerDistribution.v1_0_2.PowerDistribution"/>
     </Schema>
 
+    <Schema xmlns="http://docs.oasis-open.org/odata/ns/edm" Namespace="PowerDistribution.v1_0_4">
+      <Annotation Term="Redfish.OwningEntity" String="DMTF"/>
+      <Annotation Term="OData.Description" String="This version was created to correct various typographic errors."/>
+      <EntityType Name="PowerDistribution" BaseType="PowerDistribution.v1_0_3.PowerDistribution"/>
+    </Schema>
+
     <Schema xmlns="http://docs.oasis-open.org/odata/ns/edm" Namespace="PowerDistribution.v1_1_0">
       <Annotation Term="Redfish.OwningEntity" String="DMTF"/>
       <Annotation Term="Redfish.Release" String="2021.2"/>
@@ -463,12 +469,24 @@
       </EntityType>
     </Schema>
 
+    <Schema xmlns="http://docs.oasis-open.org/odata/ns/edm" Namespace="PowerDistribution.v1_1_1">
+      <Annotation Term="Redfish.OwningEntity" String="DMTF"/>
+      <Annotation Term="OData.Description" String="This version was created to correct various typographic errors."/>
+      <EntityType Name="PowerDistribution" BaseType="PowerDistribution.v1_1_0.PowerDistribution"/>
+    </Schema>
+
     <Schema xmlns="http://docs.oasis-open.org/odata/ns/edm" Namespace="PowerDistribution.v1_2_0">
       <Annotation Term="Redfish.OwningEntity" String="DMTF"/>
       <Annotation Term="Redfish.Release" String="2021.3"/>
       <Annotation Term="OData.Description" String="This version was created to add `Bus` to PowerEquipmentType."/>
 
       <EntityType Name="PowerDistribution" BaseType="PowerDistribution.v1_1_0.PowerDistribution"/>
+    </Schema>
+
+    <Schema xmlns="http://docs.oasis-open.org/odata/ns/edm" Namespace="PowerDistribution.v1_2_1">
+      <Annotation Term="Redfish.OwningEntity" String="DMTF"/>
+      <Annotation Term="OData.Description" String="This version was created to correct various typographic errors."/>
+      <EntityType Name="PowerDistribution" BaseType="PowerDistribution.v1_2_0.PowerDistribution"/>
     </Schema>
 
   </edmx:DataServices>

--- a/static/redfish/v1/schema/PowerSupplyMetrics_v1.xml
+++ b/static/redfish/v1/schema/PowerSupplyMetrics_v1.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!---->
 <!--################################################################################       -->
-<!--# Redfish Schema:  PowerSupplyMetrics v1.0.0                                           -->
+<!--# Redfish Schema:  PowerSupplyMetrics v1.0.1                                           -->
 <!--#                                                                                      -->
 <!--# For a detailed change log, see the README file contained in the DSP8010 bundle,      -->
 <!--# available at http://www.dmtf.org/standards/redfish                                   -->
@@ -77,70 +77,59 @@
           <Annotation Term="OData.LongDescription" String="This property shall contain any status or health properties of the resource."/>
         </Property>
         <NavigationProperty Name="InputVoltage" Type="Sensor.Sensor">
-          <Annotation Term="OData.Permissions" EnumMember="OData.Permission/Read"/>
-          <Annotation Term="OData.Description" String="The input voltage reading for this power supply."/>
-          <Annotation Term="OData.LongDescription" String="This property shall contain the sensor measuring the input voltage for this power supply."/>
+          <Annotation Term="OData.Description" String="The input voltage (V) for this power supply."/>
+          <Annotation Term="OData.LongDescription" String="This property shall contain the input voltage, in volt units, for this power supply.  The value of the DataSourceUri property, if present, shall reference a resource of type Sensor with the ReadingType property containing the value `Voltage`."/>
           <Annotation Term="Redfish.ExcerptCopy" String="Voltage"/>
         </NavigationProperty>
         <NavigationProperty Name="InputCurrentAmps" Type="Sensor.Sensor">
-          <Annotation Term="OData.Permissions" EnumMember="OData.Permission/Read"/>
-          <Annotation Term="OData.Description" String="The input current reading for this power supply."/>
-          <Annotation Term="OData.LongDescription" String="This property shall contain the sensor measuring the input current for this power supply."/>
+          <Annotation Term="OData.Description" String="The input current (A) for this power supply."/>
+          <Annotation Term="OData.LongDescription" String="This property shall contain the input current, in ampere units, for this power supply.  The value of the DataSourceUri property, if present, shall reference a resource of type Sensor with the ReadingType property containing the value `Current`."/>
           <Annotation Term="Redfish.ExcerptCopy" String="Current"/>
         </NavigationProperty>
         <NavigationProperty Name="InputPowerWatts" Type="Sensor.Sensor">
-          <Annotation Term="OData.Permissions" EnumMember="OData.Permission/Read"/>
-          <Annotation Term="OData.Description" String="The input power reading for this power supply."/>
-          <Annotation Term="OData.LongDescription" String="This property shall contain the sensor measuring the input power for this power supply."/>
+          <Annotation Term="OData.Description" String="The input power (W) for this power supply."/>
+          <Annotation Term="OData.LongDescription" String="This property shall contain the input power, in watt units, for this power supply.  The value of the DataSourceUri property, if present, shall reference a resource of type Sensor with the ReadingType property containing the value `Power`."/>
           <Annotation Term="Redfish.ExcerptCopy" String="Power"/>
         </NavigationProperty>
         <NavigationProperty Name="EnergykWh" Type="Sensor.Sensor">
-          <Annotation Term="OData.Permissions" EnumMember="OData.Permission/Read"/>
           <Annotation Term="Redfish.ExcerptCopy" String="EnergykWh"/>
-          <Annotation Term="OData.Description" String="The energy consumption of this unit."/>
-          <Annotation Term="OData.LongDescription" String="This property shall contain the total energy, measured in kilowatt-hours (kWh), for this unit, that represents the `Total` ElectricalContext sensor when multiple energy sensors exist."/>
+          <Annotation Term="OData.Description" String="The energy consumption (kWh) of this unit."/>
+          <Annotation Term="OData.LongDescription" String="This property shall contain the total energy, in kilowatt-hours units, for this unit, that represents the `Total` ElectricalContext sensor when multiple energy sensors exist.  The value of the DataSourceUri property, if present, shall reference a resource of type Sensor with the ReadingType property containing the value `EnergykWh`."/>
         </NavigationProperty>
         <NavigationProperty Name="FrequencyHz" Type="Sensor.Sensor">
-          <Annotation Term="OData.Permissions" EnumMember="OData.Permission/Read"/>
           <Annotation Term="Redfish.ExcerptCopy"/>
-          <Annotation Term="OData.Description" String="The frequency reading for this power supply."/>
-          <Annotation Term="OData.LongDescription" String="This property shall contain the frequency sensor for this power supply."/>
+          <Annotation Term="OData.Description" String="The frequency (Hz) for this power supply."/>
+          <Annotation Term="OData.LongDescription" String="This property shall contain the frequency, in hertz units, for this power supply."/>
         </NavigationProperty>
         <NavigationProperty Name="OutputPowerWatts" Type="Sensor.Sensor">
-          <Annotation Term="OData.Permissions" EnumMember="OData.Permission/Read"/>
-          <Annotation Term="OData.Description" String="The total power output reading for this power supply."/>
-          <Annotation Term="OData.LongDescription" String="This property shall contain the sensor measuring the total output power for this power supply."/>
+          <Annotation Term="OData.Description" String="The total power output (W) for this power supply."/>
+          <Annotation Term="OData.LongDescription" String="This property shall contain the total output power, in watt units, for this power supply.  The value of the DataSourceUri property, if present, shall reference a resource of type Sensor with the ReadingType property containing the value `Power`."/>
           <Annotation Term="Redfish.ExcerptCopy" String="Power"/>
         </NavigationProperty>
         <NavigationProperty Name="RailVoltage" Type="Collection(Sensor.Sensor)">
-          <Annotation Term="OData.Permissions" EnumMember="OData.Permission/Read"/>
-          <Annotation Term="OData.Description" String="The voltage readings for this power supply."/>
-          <Annotation Term="OData.LongDescription" String="This property shall contain the output voltage sensors for this power supply.  The sensors shall appear in the same array order as the OutputRails property in the associated PowerSupply resource."/>
+          <Annotation Term="OData.Description" String="The output voltages (V) for this power supply."/>
+          <Annotation Term="OData.LongDescription" String="This property shall contain the output voltages, in volt units, for this power supply.  The value of the DataSourceUri property, if present, shall reference a resource of type Sensor with the ReadingType property containing the value `Voltage`.  The sensors shall appear in the same array order as the OutputRails property in the associated PowerSupply resource."/>
           <Annotation Term="Redfish.ExcerptCopy" String="Voltage"/>
         </NavigationProperty>
         <NavigationProperty Name="RailCurrentAmps" Type="Collection(Sensor.Sensor)">
-          <Annotation Term="OData.Permissions" EnumMember="OData.Permission/Read"/>
-          <Annotation Term="OData.Description" String="The current readings for this power supply."/>
-          <Annotation Term="OData.LongDescription" String="This property shall contain the output current sensors for this power supply.  The sensors shall appear in the same array order as the OutputRails property in the associated PowerSupply resource."/>
+          <Annotation Term="OData.Description" String="The output currents (A) for this power supply."/>
+          <Annotation Term="OData.LongDescription" String="This property shall contain the output currents, in ampere units, for this power supply.  The value of the DataSourceUri property, if present, shall reference a resource of type Sensor with the ReadingType property containing the value `Current`.  The sensors shall appear in the same array order as the OutputRails property in the associated PowerSupply resource."/>
           <Annotation Term="Redfish.ExcerptCopy" String="Current"/>
         </NavigationProperty>
         <NavigationProperty Name="RailPowerWatts" Type="Collection(Sensor.Sensor)">
-          <Annotation Term="OData.Permissions" EnumMember="OData.Permission/Read"/>
-          <Annotation Term="OData.Description" String="The power readings for this power supply."/>
-          <Annotation Term="OData.LongDescription" String="This property shall contain the output power sensors for this power supply.  The sensors shall appear in the same array order as the OutputRails property in the associated PowerSupply resource."/>
+          <Annotation Term="OData.Description" String="The output power readings (W) for this power supply."/>
+          <Annotation Term="OData.LongDescription" String="This property shall contain the output power readings, in watt units, for this power supply.  The value of the DataSourceUri property, if present, shall reference a resource of type Sensor with the ReadingType property containing the value `Power`.  The sensors shall appear in the same array order as the OutputRails property in the associated PowerSupply resource."/>
           <Annotation Term="Redfish.ExcerptCopy" String="Power"/>
         </NavigationProperty>
         <NavigationProperty Name="TemperatureCelsius" Type="Sensor.Sensor">
-          <Annotation Term="OData.Permissions" EnumMember="OData.Permission/Read"/>
           <Annotation Term="Redfish.ExcerptCopy"/>
-          <Annotation Term="OData.Description" String="The temperature reading for this power supply."/>
-          <Annotation Term="OData.LongDescription" String="This property shall contain the temperature sensor for this power supply."/>
+          <Annotation Term="OData.Description" String="The temperature (C) for this power supply."/>
+          <Annotation Term="OData.LongDescription" String="This property shall contain the temperature, in degrees Celsius units, for this resource.  The value of the DataSourceUri property, if present, shall reference a resource of type Sensor with the ReadingType property containing the value `Temperature`."/>
         </NavigationProperty>
         <NavigationProperty Name="FanSpeedPercent" Type="Sensor.Sensor">
-          <Annotation Term="OData.Permissions" EnumMember="OData.Permission/Read"/>
           <Annotation Term="Redfish.ExcerptCopy" String="Fan"/>
-          <Annotation Term="OData.Description" String="The fan speed reading for this power supply."/>
-          <Annotation Term="OData.LongDescription" String="This property shall contain the fan speed sensor for this power supply."/>
+          <Annotation Term="OData.Description" String="The fan speed (percent) for this power supply."/>
+          <Annotation Term="OData.LongDescription" String="This property shall contain the fan speed, in percent units, for this resource.  The value of the DataSourceUri property, if present, shall reference a resource of type Sensor with the ReadingType property containing the value `Percent`."/>
         </NavigationProperty>
 
         <Property Name="Actions" Type="PowerSupplyMetrics.v1_0_0.Actions" Nullable="false">
@@ -148,126 +137,6 @@
           <Annotation Term="OData.LongDescription" String="This property shall contain the available actions for this resource."/>
         </Property>
       </EntityType>
-
-      <ComplexType Name="VoltageSensors">
-        <Annotation Term="OData.AdditionalProperties" Bool="false"/>
-        <Annotation Term="OData.Description" String="The voltage readings for a power supply."/>
-        <Annotation Term="OData.LongDescription" String="This type shall contain properties that describe voltage sensor readings for a power supply."/>
-        <NavigationProperty Name="Input" Type="Sensor.Sensor">
-          <Annotation Term="OData.Permissions" EnumMember="OData.Permission/Read"/>
-          <Annotation Term="Redfish.ExcerptCopy" String="Voltage"/>
-          <Annotation Term="OData.Description" String="The power supply input."/>
-          <Annotation Term="OData.LongDescription" String="This property shall contain the voltage sensor that measures voltage at the input to the power supply."/>
-        </NavigationProperty>
-        <NavigationProperty Name="InputSecondary" Type="Sensor.Sensor">
-          <Annotation Term="OData.Permissions" EnumMember="OData.Permission/Read"/>
-          <Annotation Term="Redfish.ExcerptCopy" String="Voltage"/>
-          <Annotation Term="OData.Description" String="The power supply secondary input."/>
-          <Annotation Term="OData.LongDescription" String="This property shall contain the voltage sensor that measures voltage at a secondary input to the power supply.  This property shall not be present if the power supply does not include a secondary input."/>
-        </NavigationProperty>
-        <NavigationProperty Name="Output3Volt" Type="Sensor.Sensor">
-          <Annotation Term="OData.Permissions" EnumMember="OData.Permission/Read"/>
-          <Annotation Term="Redfish.ExcerptCopy" String="Voltage"/>
-          <Annotation Term="OData.Description" String="The 3V nominal output."/>
-          <Annotation Term="OData.LongDescription" String="This property shall contain the voltage sensor that measures voltage on a 3 Volt nominal output power rail.  This property shall not be present if the power supply does not include a 3V output."/>
-        </NavigationProperty>
-        <NavigationProperty Name="Output5Volt" Type="Sensor.Sensor">
-          <Annotation Term="OData.Permissions" EnumMember="OData.Permission/Read"/>
-          <Annotation Term="Redfish.ExcerptCopy" String="Voltage"/>
-          <Annotation Term="OData.Description" String="The 5V nominal output."/>
-          <Annotation Term="OData.LongDescription" String="This property shall contain the voltage sensor that measures voltage on a 3 Volt nominal output power rail.  This property shall not be present if the power supply does not include a 3V output."/>
-        </NavigationProperty>
-        <NavigationProperty Name="Output12Volt" Type="Sensor.Sensor">
-          <Annotation Term="OData.Permissions" EnumMember="OData.Permission/Read"/>
-          <Annotation Term="Redfish.ExcerptCopy" String="Voltage"/>
-          <Annotation Term="OData.Description" String="The 12V nominal output."/>
-          <Annotation Term="OData.LongDescription" String="This property shall contain the voltage sensor that measures voltage on a 12 Volt nominal output power rail.  This property shall not be present if the power supply does not include a 12V output."/>
-        </NavigationProperty>
-        <NavigationProperty Name="Output48Volt" Type="Sensor.Sensor">
-          <Annotation Term="OData.Permissions" EnumMember="OData.Permission/Read"/>
-          <Annotation Term="Redfish.ExcerptCopy" String="Voltage"/>
-          <Annotation Term="OData.Description" String="The 48V nominal output."/>
-          <Annotation Term="OData.LongDescription" String="This property shall contain the voltage sensor that measures voltage on a 48 Volt nominal output power rail.  This property shall not be present if the power supply does not include a 48V output."/>
-        </NavigationProperty>
-        <NavigationProperty Name="OutputAux" Type="Sensor.Sensor">
-          <Annotation Term="OData.Permissions" EnumMember="OData.Permission/Read"/>
-          <Annotation Term="Redfish.ExcerptCopy" String="Voltage"/>
-          <Annotation Term="OData.Description" String="The auxiliary (AUX) output."/>
-          <Annotation Term="OData.LongDescription" String="This property shall contain the voltage sensor that measures current on an auxiliary (AUX) output power rail.  This property shall not be present if the power supply does not include an auxiliary output."/>
-        </NavigationProperty>
-      </ComplexType>
-
-      <ComplexType Name="CurrentSensors">
-        <Annotation Term="OData.AdditionalProperties" Bool="false"/>
-        <Annotation Term="OData.Description" String="The current sensors for this power supply."/>
-        <Annotation Term="OData.LongDescription" String="This type shall contain properties that describe current sensor readings for a power supply."/>
-        <NavigationProperty Name="Input" Type="Sensor.Sensor">
-          <Annotation Term="OData.Permissions" EnumMember="OData.Permission/Read"/>
-          <Annotation Term="Redfish.ExcerptCopy" String="Current"/>
-          <Annotation Term="OData.Description" String="The power supply input."/>
-          <Annotation Term="OData.LongDescription" String="This property shall contain the current sensor that measures current at the input of the power supply."/>
-        </NavigationProperty>
-        <NavigationProperty Name="InputSecondary" Type="Sensor.Sensor">
-          <Annotation Term="OData.Permissions" EnumMember="OData.Permission/Read"/>
-          <Annotation Term="Redfish.ExcerptCopy" String="Current"/>
-          <Annotation Term="OData.Description" String="The power supply secondary input."/>
-          <Annotation Term="OData.LongDescription" String="This property shall contain the current sensor that measures current at the secondary input of the power supply.  This property shall not be present if the power supply does not include a secondary input."/>
-        </NavigationProperty>
-        <NavigationProperty Name="Output3Volt" Type="Sensor.Sensor">
-          <Annotation Term="OData.Permissions" EnumMember="OData.Permission/Read"/>
-          <Annotation Term="Redfish.ExcerptCopy" String="Current"/>
-          <Annotation Term="OData.Description" String="The 3V nominal output."/>
-          <Annotation Term="OData.LongDescription" String="This property shall contain the current sensor that measures current on a 3 Volt nominal output power rail.  This property shall not be present if the power supply does not include a 3V output."/>
-        </NavigationProperty>
-        <NavigationProperty Name="Output5Volt" Type="Sensor.Sensor">
-          <Annotation Term="OData.Permissions" EnumMember="OData.Permission/Read"/>
-          <Annotation Term="Redfish.ExcerptCopy" String="Current"/>
-          <Annotation Term="OData.Description" String="The 5V nominal output."/>
-          <Annotation Term="OData.LongDescription" String="This property shall contain the current sensor that measures current on a 5 Volt nominal output power rail.  This property shall not be present if the power supply does not include a 5V output."/>
-        </NavigationProperty>
-        <NavigationProperty Name="Output12Volt" Type="Sensor.Sensor">
-          <Annotation Term="OData.Permissions" EnumMember="OData.Permission/Read"/>
-          <Annotation Term="Redfish.ExcerptCopy" String="Current"/>
-          <Annotation Term="OData.Description" String="The 12V nominal output."/>
-          <Annotation Term="OData.LongDescription" String="This property shall contain the current sensor that measures current on a 12 Volt nominal output power rail.  This property shall not be present if the power supply does not include a 12V output."/>
-        </NavigationProperty>
-        <NavigationProperty Name="Output48Volt" Type="Sensor.Sensor">
-          <Annotation Term="OData.Permissions" EnumMember="OData.Permission/Read"/>
-          <Annotation Term="Redfish.ExcerptCopy" String="Current"/>
-          <Annotation Term="OData.Description" String="The 48V nominal output."/>
-          <Annotation Term="OData.LongDescription" String="This property shall contain the current sensor that measures current on a 48 Volt nominal output power rail.  This property shall not be present if the power supply does not include a 48V output."/>
-        </NavigationProperty>
-        <NavigationProperty Name="OutputAux" Type="Sensor.Sensor">
-          <Annotation Term="OData.Permissions" EnumMember="OData.Permission/Read"/>
-          <Annotation Term="Redfish.ExcerptCopy" String="Current"/>
-          <Annotation Term="OData.Description" String="The auxiliary (AUX) output."/>
-          <Annotation Term="OData.LongDescription" String="This property shall contain the current sensor that measures current on an auxiliary (AUX) output power rail.  This property shall not be present if the power supply does not include an auxiliary output."/>
-        </NavigationProperty>
-      </ComplexType>
-
-      <ComplexType Name="PowerSensors">
-        <Annotation Term="OData.AdditionalProperties" Bool="false"/>
-        <Annotation Term="OData.Description" String="The power sensors for this power supply."/>
-        <Annotation Term="OData.LongDescription" String="This type shall contain properties that describe power sensor readings for a power supply."/>
-        <NavigationProperty Name="Input" Type="Sensor.Sensor">
-          <Annotation Term="OData.Permissions" EnumMember="OData.Permission/Read"/>
-          <Annotation Term="Redfish.ExcerptCopy" String="Power"/>
-          <Annotation Term="OData.Description" String="The input power reading for the power supply."/>
-          <Annotation Term="OData.LongDescription" String="This property shall contain the power, measured in Watts, for this power supply unit, as measured at the input of the power supply."/>
-        </NavigationProperty>
-        <NavigationProperty Name="InputSecondary" Type="Sensor.Sensor">
-          <Annotation Term="OData.Permissions" EnumMember="OData.Permission/Read"/>
-          <Annotation Term="Redfish.ExcerptCopy" String="Power"/>
-          <Annotation Term="OData.Description" String="The secondary input power reading for the power supply."/>
-          <Annotation Term="OData.LongDescription" String="This property shall contain the power, measured in Watts, for this power supply unit, as measured at the secondary input of the power supply.  This property shall not appear if the power supply does not contain a secondary input."/>
-        </NavigationProperty>
-        <NavigationProperty Name="Output" Type="Sensor.Sensor">
-          <Annotation Term="OData.Permissions" EnumMember="OData.Permission/Read"/>
-          <Annotation Term="Redfish.ExcerptCopy" String="Power"/>
-          <Annotation Term="OData.Description" String="The output power reading for the power supply."/>
-          <Annotation Term="OData.LongDescription" String="This property shall contain the power, measured in Watts, for this power supply unit, as measured at the output of the power supply."/>
-        </NavigationProperty>
-      </ComplexType>
 
       <ComplexType Name="Actions">
         <Annotation Term="OData.AdditionalProperties" Bool="false"/>
@@ -284,6 +153,12 @@
         <Annotation Term="OData.Description" String="The available OEM-specific actions for this resource."/>
         <Annotation Term="OData.LongDescription" String="This type shall contain the available OEM-specific actions for this resource."/>
       </ComplexType>
+    </Schema>
+
+    <Schema xmlns="http://docs.oasis-open.org/odata/ns/edm" Namespace="PowerSupplyMetrics.v1_0_1">
+      <Annotation Term="Redfish.OwningEntity" String="DMTF"/>
+      <Annotation Term="OData.Description" String="This version was created to update descriptions to tie excerpt property definitions to a specific type of Sensor or Control.  It was also created to remove unused object definitions."/>
+      <EntityType Name="PowerSupplyMetrics" BaseType="PowerSupplyMetrics.v1_0_0.PowerSupplyMetrics"/>
     </Schema>
 
   </edmx:DataServices>

--- a/static/redfish/v1/schema/PowerSupply_v1.xml
+++ b/static/redfish/v1/schema/PowerSupply_v1.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!---->
 <!--################################################################################       -->
-<!--# Redfish Schema:  PowerSupply v1.2.0                                                  -->
+<!--# Redfish Schema:  PowerSupply v1.3.0                                                  -->
 <!--#                                                                                      -->
 <!--# For a detailed change log, see the README file contained in the DSP8010 bundle,      -->
 <!--# available at http://www.dmtf.org/standards/redfish                                   -->
@@ -352,6 +352,31 @@
           <Annotation Term="OData.AutoExpandReferences"/>
         </NavigationProperty>
       </ComplexType>
+    </Schema>
+
+    <Schema xmlns="http://docs.oasis-open.org/odata/ns/edm" Namespace="PowerSupply.v1_3_0">
+      <Annotation Term="Redfish.OwningEntity" String="DMTF"/>
+      <Annotation Term="Redfish.Release" String="2021.4"/>
+
+      <EntityType Name="PowerSupply" BaseType="PowerSupply.v1_2_0.PowerSupply">
+        <Property Name="LineInputStatus" Type="PowerSupply.v1_3_0.LineStatus">
+          <Annotation Term="OData.Permissions" EnumMember="OData.Permission/Read"/>
+          <Annotation Term="OData.Description" String="The status of the line input."/>
+          <Annotation Term="OData.LongDescription" String="This property shall contain the status of the power line input for this power supply."/>
+        </Property>
+      </EntityType>
+
+      <EnumType Name="LineStatus">
+        <Member Name="Normal">
+          <Annotation Term="OData.Description" String="Line input is within normal operating range."/>
+        </Member>
+        <Member Name="LossOfInput">
+          <Annotation Term="OData.Description" String="No power detected at line input."/>
+        </Member>
+        <Member Name="OutOfRange">
+          <Annotation Term="OData.Description" String="Line input voltage or current is outside of normal operating range."/>
+        </Member>
+      </EnumType>
     </Schema>
 
   </edmx:DataServices>

--- a/static/redfish/v1/schema/ProcessorMetrics_v1.xml
+++ b/static/redfish/v1/schema/ProcessorMetrics_v1.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!---->
 <!--################################################################################       -->
-<!--# Redfish Schema:  ProcessorMetrics v1.4.0                                             -->
+<!--# Redfish Schema:  ProcessorMetrics v1.4.1                                             -->
 <!--#                                                                                      -->
 <!--# For a detailed change log, see the README file contained in the DSP8010 bundle,      -->
 <!--# available at http://www.dmtf.org/standards/redfish                                   -->
@@ -456,12 +456,17 @@
 
       <EntityType Name="ProcessorMetrics" BaseType="ProcessorMetrics.v1_2_2.ProcessorMetrics">
         <NavigationProperty Name="CoreVoltage" Type="Sensor.Sensor">
-          <Annotation Term="OData.Permissions" EnumMember="OData.Permission/Read"/>
-          <Annotation Term="OData.Description" String="The core voltage of this processor in Volts."/>
-          <Annotation Term="OData.LongDescription" String="The value of this property shall contain the sensor measuring the core voltage of this processor in Volts.  The core voltage of the processor may change more frequently than the manager is able to monitor."/>
+          <Annotation Term="OData.Description" String="The core voltage (V) of this processor."/>
+          <Annotation Term="OData.LongDescription" String="The value of this property shall contain the core voltage, in volt units, of this processor.  The core voltage of the processor may change more frequently than the manager is able to monitor.  The value of the DataSourceUri property, if present, shall reference a resource of type Sensor with the ReadingType property containing the value `Voltage`."/>
           <Annotation Term="Redfish.ExcerptCopy" String="Voltage"/>
         </NavigationProperty>
       </EntityType>
+    </Schema>
+
+    <Schema xmlns="http://docs.oasis-open.org/odata/ns/edm" Namespace="ProcessorMetrics.v1_3_1">
+      <Annotation Term="Redfish.OwningEntity" String="DMTF"/>
+      <Annotation Term="OData.Description" String="This version was created to update descriptions to tie excerpt property definitions to a specific type of Sensor or Control."/>
+      <EntityType Name="ProcessorMetrics" BaseType="ProcessorMetrics.v1_3_0.ProcessorMetrics"/>
     </Schema>
 
     <Schema xmlns="http://docs.oasis-open.org/odata/ns/edm" Namespace="ProcessorMetrics.v1_4_0">
@@ -474,6 +479,12 @@
           <Annotation Term="OData.LongDescription" String="This property shall contain the PCIe errors associated with this processor."/>
         </Property>
       </EntityType>
+    </Schema>
+
+    <Schema xmlns="http://docs.oasis-open.org/odata/ns/edm" Namespace="ProcessorMetrics.v1_4_1">
+      <Annotation Term="Redfish.OwningEntity" String="DMTF"/>
+      <Annotation Term="OData.Description" String="This version was created to update descriptions to tie excerpt property definitions to a specific type of Sensor or Control."/>
+      <EntityType Name="ProcessorMetrics" BaseType="ProcessorMetrics.v1_4_0.ProcessorMetrics"/>
     </Schema>
 
   </edmx:DataServices>

--- a/static/redfish/v1/schema/RegisteredClientCollection_v1.xml
+++ b/static/redfish/v1/schema/RegisteredClientCollection_v1.xml
@@ -1,0 +1,69 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!---->
+<!--################################################################################       -->
+<!--# Redfish Schema:  RegisteredClientCollection                                          -->
+<!--#                                                                                      -->
+<!--# For a detailed change log, see the README file contained in the DSP8010 bundle,      -->
+<!--# available at http://www.dmtf.org/standards/redfish                                   -->
+<!--# Copyright 2014-2021 DMTF.                                                            -->
+<!--# For the full DMTF copyright policy, see http://www.dmtf.org/about/policies/copyright -->
+<!--################################################################################       -->
+<!---->
+<edmx:Edmx xmlns:edmx="http://docs.oasis-open.org/odata/ns/edmx" Version="4.0">
+
+  <edmx:Reference Uri="http://docs.oasis-open.org/odata/odata/v4.0/errata03/csd01/complete/vocabularies/Org.OData.Core.V1.xml">
+    <edmx:Include Namespace="Org.OData.Core.V1" Alias="OData"/>
+  </edmx:Reference>
+  <edmx:Reference Uri="http://docs.oasis-open.org/odata/odata/v4.0/errata03/csd01/complete/vocabularies/Org.OData.Capabilities.V1.xml">
+    <edmx:Include Namespace="Org.OData.Capabilities.V1" Alias="Capabilities"/>
+  </edmx:Reference>
+  <edmx:Reference Uri="http://redfish.dmtf.org/schemas/v1/Resource_v1.xml">
+    <edmx:Include Namespace="Resource.v1_0_0"/>
+  </edmx:Reference>
+  <edmx:Reference Uri="http://redfish.dmtf.org/schemas/v1/RedfishExtensions_v1.xml">
+    <edmx:Include Namespace="RedfishExtensions.v1_0_0" Alias="Redfish"/>
+  </edmx:Reference>
+  <edmx:Reference Uri="http://redfish.dmtf.org/schemas/v1/RegisteredClient_v1.xml">
+    <edmx:Include Namespace="RegisteredClient"/>
+  </edmx:Reference>
+
+  <edmx:DataServices>
+
+    <Schema xmlns="http://docs.oasis-open.org/odata/ns/edm" Namespace="RegisteredClientCollection">
+      <Annotation Term="Redfish.OwningEntity" String="DMTF"/>
+
+      <EntityType Name="RegisteredClientCollection" BaseType="Resource.v1_0_0.ResourceCollection">
+        <Annotation Term="OData.Description" String="The collection of RegisteredClient resource instances."/>
+        <Annotation Term="OData.LongDescription" String="This resource shall represent a resource collection of RegisteredClient instances for a Redfish implementation."/>
+        <Annotation Term="Capabilities.InsertRestrictions">
+          <Record>
+            <PropertyValue Property="Insertable" Bool="true"/>
+          </Record>
+        </Annotation>
+        <Annotation Term="Capabilities.UpdateRestrictions">
+          <Record>
+            <PropertyValue Property="Updatable" Bool="false"/>
+          </Record>
+        </Annotation>
+        <Annotation Term="Capabilities.DeleteRestrictions">
+          <Record>
+            <PropertyValue Property="Deletable" Bool="false"/>
+          </Record>
+        </Annotation>
+        <Annotation Term="Redfish.Uris">
+          <Collection>
+            <String>/redfish/v1/RegisteredClients</String>
+          </Collection>
+        </Annotation>
+        <NavigationProperty Name="Members" Type="Collection(RegisteredClient.RegisteredClient)">
+          <Annotation Term="OData.Permissions" EnumMember="OData.Permission/Read"/>
+          <Annotation Term="OData.Description" String="The members of this collection."/>
+          <Annotation Term="OData.LongDescription" String="This property shall contain an array of links to the members of this collection."/>
+          <Annotation Term="OData.AutoExpandReferences"/>
+          <Annotation Term="Redfish.Required"/>
+        </NavigationProperty>
+      </EntityType>
+    </Schema>
+
+  </edmx:DataServices>
+</edmx:Edmx>

--- a/static/redfish/v1/schema/RegisteredClient_v1.xml
+++ b/static/redfish/v1/schema/RegisteredClient_v1.xml
@@ -1,0 +1,146 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!---->
+<!--################################################################################       -->
+<!--# Redfish Schema:  RegisteredClient v1.0.0                                             -->
+<!--#                                                                                      -->
+<!--# For a detailed change log, see the README file contained in the DSP8010 bundle,      -->
+<!--# available at http://www.dmtf.org/standards/redfish                                   -->
+<!--# Copyright 2014-2021 DMTF.                                                            -->
+<!--# For the full DMTF copyright policy, see http://www.dmtf.org/about/policies/copyright -->
+<!--################################################################################       -->
+<!---->
+<edmx:Edmx xmlns:edmx="http://docs.oasis-open.org/odata/ns/edmx" Version="4.0">
+
+  <edmx:Reference Uri="http://docs.oasis-open.org/odata/odata/v4.0/errata03/csd01/complete/vocabularies/Org.OData.Core.V1.xml">
+    <edmx:Include Namespace="Org.OData.Core.V1" Alias="OData"/>
+  </edmx:Reference>
+  <edmx:Reference Uri="http://docs.oasis-open.org/odata/odata/v4.0/errata03/csd01/complete/vocabularies/Org.OData.Capabilities.V1.xml">
+    <edmx:Include Namespace="Org.OData.Capabilities.V1" Alias="Capabilities"/>
+  </edmx:Reference>
+  <edmx:Reference Uri="http://redfish.dmtf.org/schemas/v1/Resource_v1.xml">
+    <edmx:Include Namespace="Resource"/>
+    <edmx:Include Namespace="Resource.v1_0_0"/>
+  </edmx:Reference>
+  <edmx:Reference Uri="http://redfish.dmtf.org/schemas/v1/RedfishExtensions_v1.xml">
+    <edmx:Include Namespace="RedfishExtensions.v1_0_0" Alias="Redfish"/>
+    <edmx:Include Namespace="Validation.v1_0_0" Alias="Validation"/>
+  </edmx:Reference>
+
+  <edmx:DataServices>
+
+    <Schema xmlns="http://docs.oasis-open.org/odata/ns/edm" Namespace="RegisteredClient">
+      <Annotation Term="Redfish.OwningEntity" String="DMTF"/>
+
+      <EntityType Name="RegisteredClient" BaseType="Resource.v1_0_0.Resource" Abstract="true">
+        <Annotation Term="OData.Description" String="The RegisteredClient schema defines the record format for a registered client.  It is designed to allow well behaved clients to register with a Redfish service such that other clients are aware the service might be configured or monitored by the client."/>
+        <Annotation Term="OData.LongDescription" String="This resource shall represent a registered client  for a Redfish implementation.  It is not expected that transient tools, such as a short lived CLI tool, register.  Clients and management tools that live for long periods of time can create RegisteredClient resources so that other clients are aware the service might be configured or monitored by the client."/>
+        <Annotation Term="Capabilities.InsertRestrictions">
+          <Record>
+            <PropertyValue Property="Insertable" Bool="false"/>
+          </Record>
+        </Annotation>
+        <Annotation Term="Capabilities.UpdateRestrictions">
+          <Record>
+            <PropertyValue Property="Updatable" Bool="true"/>
+          </Record>
+        </Annotation>
+        <Annotation Term="Capabilities.DeleteRestrictions">
+          <Record>
+            <PropertyValue Property="Deletable" Bool="true"/>
+          </Record>
+        </Annotation>
+        <Annotation Term="Redfish.Uris">
+          <Collection>
+            <String>/redfish/v1/RegisteredClients/{RegisteredClientId}</String>
+          </Collection>
+        </Annotation>
+      </EntityType>
+    </Schema>
+
+    <Schema xmlns="http://docs.oasis-open.org/odata/ns/edm" Namespace="RegisteredClient.v1_0_0">
+      <Annotation Term="Redfish.OwningEntity" String="DMTF"/>
+      <Annotation Term="Redfish.Release" String="2021.4"/>
+
+      <EntityType Name="RegisteredClient" BaseType="RegisteredClient.RegisteredClient">
+        <Property Name="CreatedDate" Type="Edm.DateTimeOffset" Nullable="false">
+          <Annotation Term="OData.Permissions" EnumMember="OData.Permission/Read"/>
+          <Annotation Term="OData.Description" String="The date and time when the client entry was created."/>
+          <Annotation Term="OData.LongDescription" String="This property shall contain the date and time when the client entry was created."/>
+        </Property>
+        <Property Name="ExpirationDate" Type="Edm.DateTimeOffset" Nullable="false">
+          <Annotation Term="OData.Permissions" EnumMember="OData.Permission/ReadWrite"/>
+          <Annotation Term="OData.Description" String="The date and time when the client entry will expire."/>
+          <Annotation Term="OData.LongDescription" String="This property shall contain the date and time when the client entry expires.  Registered clients that are actively managing or monitoring should periodically update this value.  The value should not be more than 7 days after the date when it was last set.  If the current date is beyond this date, the service may delete this client entry."/>
+        </Property>
+        <Property Name="ClientURI" Type="Edm.String" Nullable="false">
+          <Annotation Term="OData.Permissions" EnumMember="OData.Permission/ReadWrite"/>
+          <Annotation Term="OData.Description" String="The URI of the registered client."/>
+          <Annotation Term="OData.LongDescription" String="This property shall contain the URI of the registered client."/>
+        </Property>
+        <Property Name="ClientType" Type="RegisteredClient.v1_0_0.ClientType" Nullable="false">
+          <Annotation Term="OData.Permissions" EnumMember="OData.Permission/ReadWrite"/>
+          <Annotation Term="OData.Description" String="The type of registered client."/>
+          <Annotation Term="OData.LongDescription" String="This property shall contain the type of registered client."/>
+          <Annotation Term="Redfish.Required"/>
+          <Annotation Term="Redfish.RequiredOnCreate"/>
+        </Property>
+        <Property Name="ManagedResources" Type="Collection(RegisteredClient.v1_0_0.ManagedResource)">
+          <Annotation Term="OData.Description" String="An array of resources that the registered client monitors or configures."/>
+          <Annotation Term="OData.LongDescription" String="This property shall contain an array of resources that the registered client monitors or configures.  Other clients can use this property to understand which resources are monitored or configured by the registered client."/>
+        </Property>
+        <Property Name="Actions" Type="RegisteredClient.v1_0_0.Actions" Nullable="false">
+          <Annotation Term="OData.Description" String="The available actions for this resource."/>
+          <Annotation Term="OData.LongDescription" String="This property shall contain the available actions for this resource."/>
+        </Property>
+      </EntityType>
+
+      <EnumType Name="ClientType">
+        <Member Name="Monitor">
+          <Annotation Term="OData.Description" String="The registered client only performs read operations on this service."/>
+        </Member>
+        <Member Name="Configure">
+          <Annotation Term="OData.Description" String="The registered client performs update, create, and delete operations on the resources listed in the ManagedResources property as well as read operations on the service."/>
+        </Member>
+      </EnumType>
+
+      <ComplexType Name="ManagedResource">
+        <Annotation Term="OData.AdditionalProperties" Bool="false"/>
+        <Annotation Term="OData.Description" String="A resource managed by a client."/>
+        <Annotation Term="OData.LongDescription" String="This object shall contain information about a resource managed by a client.  The managed resource may specify subordinate resources."/>
+        <Property Name="ManagedResourceURI" Type="Edm.String">
+          <Annotation Term="OData.Permissions" EnumMember="OData.Permission/ReadWrite"/>
+          <Annotation Term="OData.Description" String="The URI of the resource or resource collection managed by the registered client."/>
+          <Annotation Term="OData.LongDescription" String="This property shall contain the URI of the Redfish resource or Redfish resource collection managed by the registered client.  When the URI references a resource collection, all members of the resource collection may be monitored or configured by the client, and the IncludesSubordinates property shall contain `true`."/>
+          <Annotation Term="OData.IsURL"/>
+        </Property>
+        <Property Name="PreferExclusive" Type="Edm.Boolean">
+          <Annotation Term="OData.Permissions" EnumMember="OData.Permission/ReadWrite"/>
+          <Annotation Term="OData.Description" String="Indicates whether the registered client expects to have exclusive access to the managed resource."/>
+          <Annotation Term="OData.LongDescription" String="This property shall indicate whether the registered client expects to have exclusive access to the managed resource referenced by the ManagedResourceURI property, and its subordinate resources if IncludesSubordinates contains `true`.  If not specified, the value is assumed to be `false`."/>
+        </Property>
+        <Property Name="IncludesSubordinates" Type="Edm.Boolean">
+          <Annotation Term="OData.Permissions" EnumMember="OData.Permission/ReadWrite"/>
+          <Annotation Term="OData.Description" String="Indicates whether the subordinate resources of the managed resource are also managed by the registered client."/>
+          <Annotation Term="OData.LongDescription" String="This property shall indicate whether the subordinate resources of the managed resource referenced by the ManagedResourceURI property are also managed by the registered client.  If not specified, the value is assumed to be `false` unless ManagedResourceURI references a resource collection."/>
+        </Property>
+      </ComplexType>
+
+      <ComplexType Name="Actions">
+        <Annotation Term="OData.AdditionalProperties" Bool="false"/>
+        <Annotation Term="OData.Description" String="The available actions for this resource."/>
+        <Annotation Term="OData.LongDescription" String="This type shall contain the available actions for this resource."/>
+        <Property Name="Oem" Type="RegisteredClient.v1_0_0.OemActions" Nullable="false">
+          <Annotation Term="OData.Description" String="The available OEM-specific actions for this resource."/>
+          <Annotation Term="OData.LongDescription" String="This property shall contain the available OEM-specific actions for this resource."/>
+        </Property>
+      </ComplexType>
+
+      <ComplexType Name="OemActions">
+        <Annotation Term="OData.AdditionalProperties" Bool="true"/>
+        <Annotation Term="OData.Description" String="The available OEM-specific actions for this resource."/>
+        <Annotation Term="OData.LongDescription" String="This type shall contain the available OEM-specific actions for this resource."/>
+      </ComplexType>
+    </Schema>
+
+  </edmx:DataServices>
+</edmx:Edmx>

--- a/static/redfish/v1/schema/ServiceConditions_v1.xml
+++ b/static/redfish/v1/schema/ServiceConditions_v1.xml
@@ -1,0 +1,97 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!---->
+<!--################################################################################       -->
+<!--# Redfish Schema:  ServiceConditions v1.0.0                                            -->
+<!--#                                                                                      -->
+<!--# For a detailed change log, see the README file contained in the DSP8010 bundle,      -->
+<!--# available at http://www.dmtf.org/standards/redfish                                   -->
+<!--# Copyright 2014-2021 DMTF.                                                            -->
+<!--# For the full DMTF copyright policy, see http://www.dmtf.org/about/policies/copyright -->
+<!--################################################################################       -->
+<!---->
+<edmx:Edmx xmlns:edmx="http://docs.oasis-open.org/odata/ns/edmx" Version="4.0">
+
+  <edmx:Reference Uri="http://docs.oasis-open.org/odata/odata/v4.0/errata03/csd01/complete/vocabularies/Org.OData.Core.V1.xml">
+    <edmx:Include Namespace="Org.OData.Core.V1" Alias="OData"/>
+  </edmx:Reference>
+  <edmx:Reference Uri="http://docs.oasis-open.org/odata/odata/v4.0/errata03/csd01/complete/vocabularies/Org.OData.Capabilities.V1.xml">
+    <edmx:Include Namespace="Org.OData.Capabilities.V1" Alias="Capabilities"/>
+  </edmx:Reference>
+  <edmx:Reference Uri="http://redfish.dmtf.org/schemas/v1/RedfishExtensions_v1.xml">
+    <edmx:Include Namespace="RedfishExtensions.v1_0_0" Alias="Redfish"/>
+  </edmx:Reference>
+  <edmx:Reference Uri="http://redfish.dmtf.org/schemas/v1/Resource_v1.xml">
+    <edmx:Include Namespace="Resource"/>
+    <edmx:Include Namespace="Resource.v1_0_0"/>
+  </edmx:Reference>
+
+  <edmx:DataServices>
+
+    <Schema xmlns="http://docs.oasis-open.org/odata/ns/edm" Namespace="ServiceConditions">
+      <Annotation Term="Redfish.OwningEntity" String="DMTF"/>
+
+      <EntityType Name="ServiceConditions" BaseType="Resource.v1_0_0.Resource" Abstract="true">
+        <Annotation Term="OData.Description" String="The ServiceConditions schema contains definitions for reporting the conditions present in the service that require attention."/>
+        <Annotation Term="OData.LongDescription" String="This resource shall be used to represent the overall conditions present in a service for a Redfish implementation."/>
+        <Annotation Term="Capabilities.InsertRestrictions">
+          <Record>
+            <PropertyValue Property="Insertable" Bool="false"/>
+          </Record>
+        </Annotation>
+        <Annotation Term="Capabilities.UpdateRestrictions">
+          <Record>
+            <PropertyValue Property="Updatable" Bool="false"/>
+          </Record>
+        </Annotation>
+        <Annotation Term="Capabilities.DeleteRestrictions">
+          <Record>
+            <PropertyValue Property="Deletable" Bool="false"/>
+          </Record>
+        </Annotation>
+        <Annotation Term="Redfish.Uris">
+          <Collection>
+            <String>/redfish/v1/ServiceConditions</String>
+          </Collection>
+        </Annotation>
+      </EntityType>
+    </Schema>
+
+    <Schema xmlns="http://docs.oasis-open.org/odata/ns/edm" Namespace="ServiceConditions.v1_0_0">
+      <Annotation Term="Redfish.OwningEntity" String="DMTF"/>
+      <Annotation Term="Redfish.Release" String="2021.4"/>
+
+      <EntityType Name="ServiceConditions" BaseType="ServiceConditions.ServiceConditions">
+        <Property Name="HealthRollup" Type="Resource.Health" Nullable="false">
+          <Annotation Term="OData.Permissions" EnumMember="OData.Permission/Read"/>
+          <Annotation Term="OData.Description" String="The health roll-up for all resources."/>
+          <Annotation Term="OData.LongDescription" String="This property shall contain the highest severity of any messages included in the Conditions property."/>
+        </Property>
+        <Property Name="Conditions" Type="Collection(Resource.Condition)">
+          <Annotation Term="OData.Description" String="Conditions reported by this service that require attention."/>
+          <Annotation Term="OData.LongDescription" String="This property shall represent a roll-up of the active conditions requiring attention in resources of this Redfish service.  The service may roll up any number of conditions originating from resources in the service, using the `ConditionInRelatedResource` message from Base Message Registry."/>
+        </Property>
+        <Property Name="Actions" Type="ServiceConditions.v1_0_0.Actions" Nullable="false">
+          <Annotation Term="OData.Description" String="The available actions for this resource."/>
+          <Annotation Term="OData.LongDescription" String="This property shall contain the available actions for this resource."/>
+        </Property>
+      </EntityType>
+
+      <ComplexType Name="Actions">
+        <Annotation Term="OData.AdditionalProperties" Bool="false"/>
+        <Annotation Term="OData.Description" String="The available actions for this resource."/>
+        <Annotation Term="OData.LongDescription" String="This type shall contain the available actions for this resource."/>
+        <Property Name="Oem" Type="ServiceConditions.v1_0_0.OemActions" Nullable="false">
+          <Annotation Term="OData.Description" String="The available OEM-specific actions for this resource."/>
+          <Annotation Term="OData.LongDescription" String="This property shall contain the available OEM-specific actions for this resource."/>
+        </Property>
+      </ComplexType>
+
+      <ComplexType Name="OemActions">
+        <Annotation Term="OData.AdditionalProperties" Bool="true"/>
+        <Annotation Term="OData.Description" String="The available OEM-specific actions for this resource."/>
+        <Annotation Term="OData.LongDescription" String="This type shall contain the available OEM-specific actions for this resource."/>
+      </ComplexType>
+    </Schema>
+
+  </edmx:DataServices>
+</edmx:Edmx>

--- a/static/redfish/v1/schema/Switch_v1.xml
+++ b/static/redfish/v1/schema/Switch_v1.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!---->
 <!--################################################################################       -->
-<!--# Redfish Schema:  Switch v1.7.0                                                       -->
+<!--# Redfish Schema:  Switch v1.8.0                                                       -->
 <!--#                                                                                      -->
 <!--# For a detailed change log, see the README file contained in the DSP8010 bundle,      -->
 <!--# available at http://www.dmtf.org/standards/redfish                                   -->
@@ -485,6 +485,15 @@
         <Property Name="Measurements" Type="Collection(SoftwareInventory.MeasurementBlock)" Nullable="false">
           <Annotation Term="OData.Description" String="An array of DSP0274-defined measurement blocks."/>
           <Annotation Term="OData.LongDescription" String="This property shall contain an array of DSP0274-defined measurement blocks."/>
+          <Annotation Term="Redfish.Revisions">
+            <Collection>
+              <Record>
+                <PropertyValue Property="Kind" EnumMember="Redfish.RevisionKind/Deprecated"/>
+                <PropertyValue Property="Version" String="v1_8_0"/>
+                <PropertyValue Property="Description" String="This property has been deprecated in favor of the ComponentIntegrity resource."/>
+              </Record>
+            </Collection>
+          </Annotation>
         </Property>
       </EntityType>
     </Schema>
@@ -527,6 +536,14 @@
           <Annotation Term="OData.AutoExpandReferences"/>
         </NavigationProperty>
       </EntityType>
+    </Schema>
+
+    <Schema xmlns="http://docs.oasis-open.org/odata/ns/edm" Namespace="Switch.v1_8_0">
+      <Annotation Term="Redfish.OwningEntity" String="DMTF"/>
+      <Annotation Term="Redfish.Release" String="2021.4"/>
+      <Annotation Term="OData.Description" String="This version was created to deprecate Measurements in favor of measurement reporting in the ComponentIntegrity resource."/>
+
+      <EntityType Name="Switch" BaseType="Switch.v1_7_0.Switch"/>
     </Schema>
 
   </edmx:DataServices>

--- a/static/redfish/v1/schema/ThermalMetrics_v1.xml
+++ b/static/redfish/v1/schema/ThermalMetrics_v1.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!---->
 <!--################################################################################       -->
-<!--# Redfish Schema:  ThermalMetrics v1.0.0                                               -->
+<!--# Redfish Schema:  ThermalMetrics v1.0.1                                               -->
 <!--#                                                                                      -->
 <!--# For a detailed change log, see the README file contained in the DSP8010 bundle,      -->
 <!--# available at http://www.dmtf.org/standards/redfish                                   -->
@@ -75,10 +75,9 @@
           <Annotation Term="OData.LongDescription" String="This property shall contain the temperature sensor readings for this subsystem."/>
         </Property>
         <NavigationProperty Name="TemperatureReadingsCelsius" Type="Collection(Sensor.Sensor)">
-          <Annotation Term="OData.Permissions" EnumMember="OData.Permission/Read"/>
           <Annotation Term="Redfish.ExcerptCopy" String="Array"/>
-          <Annotation Term="OData.Description" String="The temperature readings from all related sensors for this device."/>
-          <Annotation Term="OData.LongDescription" String="This property shall contain the temperature sensors for this subsystem."/>
+          <Annotation Term="OData.Description" String="The temperatures (Celsius) from all related sensors for this device."/>
+          <Annotation Term="OData.LongDescription" String="This property shall contain the temperatures, in degrees Celsius units, for this subsystem.  The value of the DataSourceUri property, if present, shall reference a resource of type Sensor with the ReadingType property containing the value `Temperature`."/>
         </NavigationProperty>
         <Property Name="Actions" Type="ThermalMetrics.v1_0_0.Actions" Nullable="false">
           <Annotation Term="OData.Description" String="The available actions for this resource."/>
@@ -88,31 +87,27 @@
 
       <ComplexType Name="TemperatureSummary">
         <Annotation Term="OData.AdditionalProperties" Bool="false"/>
-        <Annotation Term="OData.Description" String="The temperature sensors for a subsystem."/>
+        <Annotation Term="OData.Description" String="The temperature readings for a subsystem."/>
         <Annotation Term="OData.LongDescription" String="This type shall contain properties that describe temperature sensor for a subsystem."/>
         <NavigationProperty Name="Internal" Type="Sensor.Sensor">
-          <Annotation Term="OData.Permissions" EnumMember="OData.Permission/Read"/>
           <Annotation Term="Redfish.ExcerptCopy"/>
-          <Annotation Term="OData.Description" String="The internal temperature of this subsystem."/>
-          <Annotation Term="OData.LongDescription" String="This property shall contain the temperature reading for the internal temperature of this subsystem."/>
+          <Annotation Term="OData.Description" String="The internal temperature (Celsius) of this subsystem."/>
+          <Annotation Term="OData.LongDescription" String="This property shall contain the temperature, in degrees Celsius units, for the internal temperature of this subsystem.  The value of the DataSourceUri property, if present, shall reference a resource of type Sensor with the ReadingType property containing the value `Temperature`."/>
         </NavigationProperty>
         <NavigationProperty Name="Intake" Type="Sensor.Sensor">
-          <Annotation Term="OData.Permissions" EnumMember="OData.Permission/Read"/>
           <Annotation Term="Redfish.ExcerptCopy"/>
-          <Annotation Term="OData.Description" String="The intake temperature of this subsystem."/>
-          <Annotation Term="OData.LongDescription" String="This property shall contain the temperature reading for the intake temperature of this subsystem."/>
+          <Annotation Term="OData.Description" String="The intake temperature (Celsius) of this subsystem."/>
+          <Annotation Term="OData.LongDescription" String="This property shall contain the temperature, in degrees Celsius units, for the intake temperature of this subsystem.  The value of the DataSourceUri property, if present, shall reference a resource of type Sensor with the ReadingType property containing the value `Temperature`."/>
         </NavigationProperty>
         <NavigationProperty Name="Exhaust" Type="Sensor.Sensor">
-          <Annotation Term="OData.Permissions" EnumMember="OData.Permission/Read"/>
           <Annotation Term="Redfish.ExcerptCopy"/>
-          <Annotation Term="OData.Description" String="The exhaust temperature of this subsystem."/>
-          <Annotation Term="OData.LongDescription" String="This property shall contain the temperature reading for the exhaust temperature of this subsystem."/>
+          <Annotation Term="OData.Description" String="The exhaust temperature (Celsius) of this subsystem."/>
+          <Annotation Term="OData.LongDescription" String="This property shall contain the temperature, in degrees Celsius units, for the exhaust temperature of this subsystem.  The value of the DataSourceUri property, if present, shall reference a resource of type Sensor with the ReadingType property containing the value `Temperature`."/>
         </NavigationProperty>
         <NavigationProperty Name="Ambient" Type="Sensor.Sensor">
-          <Annotation Term="OData.Permissions" EnumMember="OData.Permission/Read"/>
           <Annotation Term="Redfish.ExcerptCopy"/>
-          <Annotation Term="OData.Description" String="The ambient temperature of this subsystem."/>
-          <Annotation Term="OData.LongDescription" String="This property shall contain the temperature reading for the ambient temperature of this subsystem."/>
+          <Annotation Term="OData.Description" String="The ambient temperature (Celsius) of this subsystem."/>
+          <Annotation Term="OData.LongDescription" String="This property shall contain the temperature, in degrees Celsius units, for the ambient temperature of this subsystem.  The value of the DataSourceUri property, if present, shall reference a resource of type Sensor with the ReadingType property containing the value `Temperature`."/>
         </NavigationProperty>
       </ComplexType>
 
@@ -131,6 +126,12 @@
         <Annotation Term="OData.Description" String="The available OEM-specific actions for this resource."/>
         <Annotation Term="OData.LongDescription" String="This type shall contain the available OEM-specific actions for this resource."/>
       </ComplexType>
+    </Schema>
+
+    <Schema xmlns="http://docs.oasis-open.org/odata/ns/edm" Namespace="ThermalMetrics.v1_0_1">
+      <Annotation Term="Redfish.OwningEntity" String="DMTF"/>
+      <Annotation Term="OData.Description" String="This version was created to update descriptions to tie excerpt property definitions to a specific type of Sensor or Control. It was also created to correct various typographical errors."/>
+      <EntityType Name="ThermalMetrics" BaseType="ThermalMetrics.v1_0_0.ThermalMetrics"/>
     </Schema>
 
   </edmx:DataServices>


### PR DESCRIPTION
To generate ACF certificate for log in requires 1) the MTM,
2) Serial number, and 3) DateTime. This commit adds this information
to the Service Root (i.e. <ip>/redfish/v1) under the "ACF" property.
The Service Root is unauthenticated, granting ability to generate
ACF to log in if all other user passwords are forgotten.

Tested:

1) redfish curl testing

Signed-off-by: Ali Ahmed <ama213000@gmail.com>
Change-Id: I68e73bf8fe9aad2723aabca23f95cc9e149f001f