### PR TITLE
SW547232: Start bmcweb after host state manager

### DIFF
--- a/bmcweb.service.in
+++ b/bmcweb.service.in
@@ -6,6 +6,7 @@ After=network.target
 After=xyz.openbmc_project.User.Manager.service
 After=xyz.openbmc_project.State.BMC.service
 After=xyz.openbmc_project.Software.BMC.Updater.service
+After=xyz.openbmc_project.State.Host.service
 
 [Service]
 ExecReload=kill -s HUP $MAINPID


### PR DESCRIPTION
This fixes SW547232, which is caused by HMC not getting the system
state information.

The system state information is optional in the System schema and
today bmcweb just leaves off when the Host State Manager isn't up.

The HMC goes to a No Connection state though when it can't get this
information. The HMC team will change their code by looking for BMC
Ready state but to move forward let's just wait for Host State Manager.

Tested:
See bmcweb start after Host State Manager.
```
Mar 29 14:30:57 ever20bmc phosphor-hypervisor-state-manager[544]: Change to Hypervisor State: xyz.openbmc_project.State.Host.HostState.Off
Mar 29 14:30:57 ever20bmc systemd[1]: Started Phosphor Host State Manager.
Mar 29 14:30:57 ever20bmc systemd[1]: Started Start bmcweb server.
```
This pushed bmcweb back another 21 seconds on Everest.
```
Mar 29 14:30:36 ever20bmc systemd[1]: Started Phosphor BMC State Manager. <- bmcweb used to start here
... 21 seconds here ...
Mar 29 14:30:57 ever20bmc systemd[1]: Started Phosphor Host State Manager.
Mar 29 14:30:57 ever20bmc systemd[1]: Started Start bmcweb server. <- now 21 seconds later after Host Manager
```
Signed-off-by: Gunnar Mills <gmills@us.ibm.com>