### PR TITLE
LogService: HW-Isolation: Return an appropriate error

### DIFF
--- a/redfish-core/include/error_messages.hpp
+++ b/redfish-core/include/error_messages.hpp
@@ -437,6 +437,22 @@ void propertyValueResourceConflict(crow::Response& res, const std::string& arg1,
                                    const std::string& arg3);
 
 /**
+ * @brief Formats PropertyValueExternalConflict message into JSON
+ * Message body: "The property '%1' with the requested value of '%2' could not
+ * be written because the value is not available due to a configuration
+ * conflict."
+ *
+ * @param[in] arg1 Parameter of message that will replace %1 in its body.
+ * @param[in] arg2 Parameter of message that will replace %2 in its body.
+ *
+ * @returns Message PropertyValueExternalConflict to JSON */
+nlohmann::json propertyValueExternalConflict(const std::string& arg1,
+                                             const std::string& arg2);
+
+void propertyValueExternalConflict(crow::Response& res, const std::string& arg1,
+                                   const std::string& arg2);
+
+/**
  * @brief Formats ResourceCreationConflict message into JSON
  * Message body: "The resource could not be created.  The service has a resource
  * at URI '<arg1>' that conflicts with the creation request."

--- a/redfish-core/include/utils/hw_isolation.hpp
+++ b/redfish-core/include/utils/hw_isolation.hpp
@@ -130,8 +130,8 @@ inline void
             if (strcmp(dbusError->name, "xyz.openbmc_project.Common.Error."
                                         "InvalidArgument") == 0)
             {
-                messages::propertyValueIncorrect(
-                    aResp->res, "@odata.id", std::to_string(enabledPropVal));
+                messages::propertyValueExternalConflict(
+                    aResp->res, "Enabled", std::to_string(enabledPropVal));
             }
             else if (strcmp(dbusError->name, "xyz.openbmc_project.Common.Error."
                                              "NotAllowed") == 0)

--- a/redfish-core/include/utils/hw_isolation.hpp
+++ b/redfish-core/include/utils/hw_isolation.hpp
@@ -138,13 +138,6 @@ inline void
             {
                 retChassisPowerStateOffRequiredError(aResp, resourceObjPath);
             }
-            else if (strcmp(dbusError->name, "xyz.openbmc_project.Common.Error."
-                                             "Unavailable") == 0)
-            {
-                messages::propertyValueResourceConflict(
-                    aResp->res, "Enabled", std::to_string(enabledPropVal),
-                    "HardwareIsolation");
-            }
             else if (strcmp(dbusError->name, "xyz.openbmc_project."
                                              "HardwareIsolation.Error."
                                              "IsolatedAlready") == 0)
@@ -271,18 +264,6 @@ inline void
                     {
                         retChassisPowerStateOffRequiredError(aResp,
                                                              resourceObjPath);
-                    }
-                    else if (strcmp(dbusError->name,
-                                    "xyz.openbmc_project.Common.Error."
-                                    "Unavailable") == 0)
-                    {
-                        // The Enabled property value will be "true" to
-                        // de-isolate.
-                        constexpr bool enabledPropVal = true;
-                        messages::propertyValueResourceConflict(
-                            aResp->res, "Enabled",
-                            std::to_string(enabledPropVal),
-                            "HardwareIsolation");
                     }
                     else if (strcmp(dbusError->name,
                                     "xyz.openbmc_project.Common.Error."

--- a/redfish-core/lib/log_services.hpp
+++ b/redfish-core/lib/log_services.hpp
@@ -5265,18 +5265,51 @@ inline void deleteSystemHardwareIsolationLogEntryById(
 
             // Delete the respective dbus entry object
             crow::connections::systemBus->async_method_call(
-                [asyncResp, entryObjPath](const boost::system::error_code ec) {
-                    if (ec)
+                [asyncResp,
+                 entryObjPath](const boost::system::error_code ec,
+                               const sdbusplus::message::message& msg) {
+                    if (!ec)
                     {
-                        BMCWEB_LOG_ERROR << "DBUS response error ["
-                                         << ec.value() << " : " << ec.message()
-                                         << "] when tried to delete the given "
-                                            "object path: "
-                                         << entryObjPath.str;
+                        messages::success(asyncResp->res);
+                        return;
+                    }
+
+                    BMCWEB_LOG_ERROR << "DBUS response error [" << ec.value()
+                                     << " : " << ec.message()
+                                     << "] when tried to delete the given "
+                                     << "entry: " << entryObjPath.str;
+
+                    const sd_bus_error* dbusError = msg.get_error();
+
+                    if (dbusError == nullptr)
+                    {
                         messages::internalError(asyncResp->res);
                         return;
                     }
-                    messages::success(asyncResp->res);
+
+                    BMCWEB_LOG_ERROR << "DBus ErrorName: " << dbusError->name
+                                     << " ErrorMsg: " << dbusError->message;
+
+                    if (strcmp(dbusError->name,
+                               "xyz.openbmc_project.Common.Error."
+                               "NotAllowed") == 0)
+                    {
+                        messages::chassisPowerStateOffRequired(asyncResp->res,
+                                                               "chassis");
+                    }
+                    else if (strcmp(dbusError->name,
+                                    "xyz.openbmc_project.Common.Error."
+                                    "InsufficientPermission") == 0)
+                    {
+                        messages::resourceCannotBeDeleted(asyncResp->res);
+                    }
+                    else
+                    {
+                        BMCWEB_LOG_ERROR << "DBus Error is unsupported so "
+                                            "returning as Internal Error";
+                        messages::internalError(asyncResp->res);
+                    }
+                    return;
                 },
                 objType[0].first, entryObjPath.str,
                 "xyz.openbmc_project.Object.Delete", "Delete");
@@ -5331,18 +5364,45 @@ inline void postSystemHardwareIsolationLogServiceClearLog(
 
             // Delete all HardwareIsolation entries
             crow::connections::systemBus->async_method_call(
-                [asyncResp](const boost::system::error_code ec) {
-                    if (ec)
+                [asyncResp](const boost::system::error_code ec,
+                            const sdbusplus::message::message& msg) {
+                    if (!ec)
                     {
-                        BMCWEB_LOG_ERROR
-                            << "DBUS response error [" << ec.value() << " : "
-                            << ec.message()
-                            << "] when tried to delete all HardwareIsolation "
-                               "entries";
+                        messages::success(asyncResp->res);
+                        return;
+                    }
+
+                    BMCWEB_LOG_ERROR
+                        << "DBUS response error [" << ec.value() << " : "
+                        << ec.message()
+                        << "] when tried to delete all HardwareIsolation "
+                           "entries";
+
+                    const sd_bus_error* dbusError = msg.get_error();
+
+                    if (dbusError == nullptr)
+                    {
                         messages::internalError(asyncResp->res);
                         return;
                     }
-                    messages::success(asyncResp->res);
+
+                    BMCWEB_LOG_ERROR << "DBus ErrorName: " << dbusError->name
+                                     << " ErrorMsg: " << dbusError->message;
+
+                    if (strcmp(dbusError->name,
+                               "xyz.openbmc_project.Common.Error."
+                               "NotAllowed") == 0)
+                    {
+                        messages::chassisPowerStateOffRequired(asyncResp->res,
+                                                               "chassis");
+                    }
+                    else
+                    {
+                        BMCWEB_LOG_ERROR << "DBus Error is unsupported so "
+                                            "returning as Internal Error";
+                        messages::internalError(asyncResp->res);
+                    }
+                    return;
                 },
                 objType[0].first, "/xyz/openbmc_project/hardware_isolation",
                 "xyz.openbmc_project.Collection.DeleteAll", "DeleteAll");

--- a/redfish-core/src/error_messages.cpp
+++ b/redfish-core/src/error_messages.cpp
@@ -957,9 +957,39 @@ void propertyValueResourceConflict(crow::Response& res, const std::string& arg1,
                                    const std::string& arg2,
                                    const std::string& arg3)
 {
-    res.result(boost::beast::http::status::bad_request);
+    res.result(boost::beast::http::status::conflict);
     addMessageToErrorJson(res.jsonValue,
                           propertyValueResourceConflict(arg1, arg2, arg3));
+}
+
+/**
+ * @internal
+ * @brief Formats PropertyValueExternalConflict message into JSON
+ *
+ * See header file for more information
+ * @endinternal
+ */
+nlohmann::json propertyValueExternalConflict(const std::string& arg1,
+                                             const std::string& arg2)
+{
+    return nlohmann::json{
+        {"@odata.type", "#Message.v1_1_1.Message"},
+        {"MessageId", "Base.1.10.0.PropertyValueExternalConflict"},
+        {"Message", "The property '" + arg1 +
+                        "' with the requested value of '" + arg2 +
+                        "' could not be written because the value "
+                        "is not available due to a configuration conflict."},
+        {"MessageArgs", {arg1, arg2}},
+        {"MessageSeverity", "Warning"},
+        {"Resolution", "No resolution is required."}};
+}
+
+void propertyValueExternalConflict(crow::Response& res, const std::string& arg1,
+                                   const std::string& arg2)
+{
+    res.result(boost::beast::http::status::conflict);
+    addMessageToErrorJson(res.jsonValue,
+                          propertyValueExternalConflict(arg1, arg2));
 }
 
 /**


### PR DESCRIPTION
It fixes [SW547295](https://w3.rchland.ibm.com/projects/bestquest/?defect=SW547295) - LogService: HW-Isolation: Return an appropriate error

- Hardware isolation D-Bus service errors:

  - Returns "NotAllowed" error when the manual hardware isolation request
    is not allowed during host power on or running.

    - Redfish server returns "ChassisPowerStateOffRequired" error.

  - Returns "InsufficientPermission" error when the user is not allowed
    to delete the hardware isolation entry that's created by the system due to
    some error.

    - Redfish server returns "ResourceCannotBeDeleted" error for the DELETE
      method request.

  - Returns "InvalidArgument" if the given resource is unable to locate in the
    backend system model (aka, device tree) to process the request.

    - Redfish server returns "PropertyValueExternalConflict" error.