### PR TITLE
Revert "Add traces when deleting subsription (#279)"

### DIFF
--- a/redfish-core/lib/event_service.hpp
+++ b/redfish-core/lib/event_service.hpp
@@ -170,7 +170,6 @@ inline void
             }
 
             messages::resourceNotFound(asyncResp->res, "Subscriptions", id);
-            BMCWEB_LOG_CRITICAL << "Delete SNMP subscription on get";
             EventServiceManager::getInstance().deleteSubscription(id);
         },
         "xyz.openbmc_project.Network.SNMP",
@@ -1017,7 +1016,6 @@ inline void requestRoutesEventDestination(App& app)
                         "xyz.openbmc_project.Network.SNMP", snmpPath,
                         "xyz.openbmc_project.Object.Delete", "Delete");
 
-                    BMCWEB_LOG_CRITICAL << "Delete SNMP subscription";
                     EventServiceManager::getInstance().deleteSubscription(
                         param);
 
@@ -1031,8 +1029,6 @@ inline void requestRoutesEventDestination(App& app)
                         boost::beast::http::status::not_found);
                     return;
                 }
-
-                BMCWEB_LOG_CRITICAL << "Request delete subscription";
                 EventServiceManager::getInstance().deleteSubscription(param);
             });
 }


### PR DESCRIPTION
This reverts commit ed4b3c0437b4293e9af9c200502e39b956824263.

Extra logging was added to debug SW545127.
SW545127 was fixed here:
https://github.com/ibm-openbmc/bmcweb/pull/303

Revert this commit that added the logging:
https://github.com/ibm-openbmc/bmcweb/pull/279/files

Note: The Log Error on TerminateAfterRetries in http/http_client.hpp
stayed due to thinking it would be useful and was touched in #303.

Reason for change: Help keep the journal clean/No longer needed. 

Testing: None. Straight forward change. 