### PR TITLE
NetworkProtocol: Set StaticNTPServers dbus on PATCH

### DIFF
--- a/redfish-core/lib/network_protocol.hpp
+++ b/redfish-core/lib/network_protocol.hpp
@@ -288,7 +288,7 @@ inline void
                             },
                             service, objectPath,
                             "org.freedesktop.DBus.Properties", "Set", interface,
-                            "NTPServers",
+                            "StaticNTPServers",
                             std::variant<std::vector<std::string>>{ntpServers});
                     }
                 }


### PR DESCRIPTION
There was no way to differentiate between the static and
DHCP assigned NTP servers. Networkd and Dbus has added
support for StaticNTPServers to save the static configuration
and NTPServers will be read-only and contain the current active
NTP servers at the system.

Tested by:
 1. PATCH /redfish/v1/Managers/bmc/NetworkProtocol
    -d '{"NTP" : { "NTPServers": ["9.3.1.2"]}}'
    Verify that this adds the NTPs server to the NetworkProtocol
 2. Enable DHCP to fetch NTP servers list from the DHCP server.
    Verify that they are listed when GET on NetworkProtocol

Signed-off-by: sunharis <sunharis@in.ibm.com>
Change-Id: Ifac77485485839292b770d36def35da17d723c4e