### PR TITLE
Reset connection handlers of resource/system dump on power off

### DIFF
--- a/include/dump_offload.hpp
+++ b/include/dump_offload.hpp
@@ -335,8 +335,13 @@ inline void resetHandlers()
             BMCWEB_LOG_DEBUG << "No handler to cleanup";
             return;
         }
-        handler->first->close();
-        BMCWEB_LOG_CRITICAL << "INFO: resetHandlers cleanup";
+        if ((handler->second->dumpType == "system") ||
+            (handler->second->dumpType == "resource"))
+        {
+            handler->first->close();
+            BMCWEB_LOG_CRITICAL << "INFO: " << handler->second->dumpType
+                                << " dump resetHandlers cleanup";
+        }
     }
     return;
 }


### PR DESCRIPTION
This commit adds check to clean up connection handlers of system/resource dumps if there is a unexpected Poweroff during system or resource dump offload.

This is only needed for system/resource dumps
Other dumps like Hostboot, hw dump, and sbe dumps are stored on bmc

Fixes https://w3.rchland.ibm.com/projects/bestquest/?defect=SW547805

Tested by:
Power off while system dump offloading.
Power off while other host dump offloading 