### PR TITLE
SW549923: Add asyncResp support during handleUpgrade

### DIFF
--- a/http/app.hpp
+++ b/http/app.hpp
@@ -45,9 +45,11 @@ class App
     }
 
     template <typename Adaptor>
-    void handleUpgrade(const Request& req, Response& res, Adaptor&& adaptor)
+    void handleUpgrade(const Request& req,
+                       std::shared_ptr<bmcweb::AsyncResp>& asyncResp,
+                       Adaptor&& adaptor)
     {
-        router.handleUpgrade(req, res, std::move(adaptor));
+        router.handleUpgrade(req, asyncResp, std::forward<Adaptor>(adaptor));
     }
 
     void handle(Request& req,

--- a/http/http_connection.hpp
+++ b/http/http_connection.hpp
@@ -375,15 +375,36 @@ class Connection :
                               [self] { self->completeRequest(); });
         });
 
+        auto asyncResp = std::make_shared<bmcweb::AsyncResp>(res);
         if (thisReq.isUpgrade() &&
             boost::iequals(
                 thisReq.getHeaderValue(boost::beast::http::field::upgrade),
                 "websocket"))
         {
-            handler->handleUpgrade(thisReq, res, std::move(adaptor));
-            // delete lambda with self shared_ptr
-            // to enable connection destruction
-            res.setCompleteRequestHandler(nullptr);
+            asyncResp->res.setCompleteRequestHandler(
+                [self(shared_from_this())]() {
+                    if (self->res.resultInt() != 101)
+                    {
+                        // When any error occurs during handle upgradation,
+                        // the result in response will be set to respective
+                        // error. during success Result will be Switching
+                        // Protocols (101), which implies successful handle
+                        // upgrade. Response needs to be sent over this
+                        // connection only on failure.
+                        boost::asio::post(self->adaptor.get_executor(),
+                                          [self] { self->completeRequest(); });
+                        return;
+                    }
+
+                    // Set Complete request handler to NULL to remove
+                    // the shared pointer of connection to enable
+                    // connection destruction. As the connection would
+                    // get upgraded, we wouldn't need this connection
+                    // any longer
+                    self->res.setCompleteRequestHandler(nullptr);
+                });
+            handler->handleUpgrade(thisReq, asyncResp,
+                                   std::forward<Adaptor>(adaptor));
             return;
         }
 
@@ -392,13 +413,13 @@ class Connection :
             boost::ends_with(url, "/attachment"))
         {
             BMCWEB_LOG_DEBUG << "upgrade stream connection";
-            handler->handleUpgrade(*req, res, std::move(adaptor));
+            handler->handleUpgrade(*req, asyncResp,
+                                   std::forward<Adaptor>(adaptor));
             // delete lambda with self shared_ptr
             // to enable connection destruction
             res.completeRequestHandler = nullptr;
             return;
         }
-        auto asyncResp = std::make_shared<bmcweb::AsyncResp>(res);
         handler->handle(thisReq, asyncResp);
     }
 

--- a/http/http_response.hpp
+++ b/http/http_response.hpp
@@ -42,6 +42,14 @@ struct Response
     Response() : stringResponse(response_type{})
     {}
 
+    Response(response_type& stringRes) : stringResponse(stringRes)
+    {}
+
+    ~Response() = default;
+
+    Response(const Response&) = delete;
+    Response(Response&&) = delete;
+
     Response& operator=(const Response& r) = delete;
 
     Response& operator=(Response&& r) noexcept

--- a/http/websocket.hpp
+++ b/http/websocket.hpp
@@ -90,7 +90,7 @@ class ConnectionImpl : public Connection
             ws.get_executor().context());
     }
 
-    void start()
+    void start(std::shared_ptr<bmcweb::AsyncResp>& asyncResp)
     {
         BMCWEB_LOG_DEBUG << "starting connection " << this;
 
@@ -99,8 +99,8 @@ class ConnectionImpl : public Connection
         std::string_view protocol = req[bf::sec_websocket_protocol];
 
         ws.set_option(boost::beast::websocket::stream_base::decorator(
-            [session{session}, protocol{std::string(protocol)}](
-                boost::beast::websocket::response_type& m) {
+            [session{session}, protocol{std::string(protocol)},
+             asyncResp](boost::beast::websocket::response_type& m) {
 
 #ifndef BMCWEB_INSECURE_DISABLE_CSRF_PREVENTION
                 if (session != nullptr)
@@ -130,6 +130,7 @@ class ConnectionImpl : public Connection
                 m.insert("X-XSS-Protection", "1; "
                                              "mode=block");
                 m.insert("X-Content-Type-Options", "nosniff");
+                asyncResp->res = std::move(Response(m));
             }));
 
         // Perform the websocket upgrade


### PR DESCRIPTION
This commit mainly implies support for asyncResp to handle upgrades for
 WebSocket connection.
The current implementation uses the earlier method of using the response
object and calling response. end() to initiate completion handler.
This commit modifies the implementation to use asyncResp, where the
completion handler gets called asynchronously as the response object
goes out of scope.

This change is mainly for handling privilege into WebSocket connections.

test:
tested using bmc_console on the Rainer system. Able to test success cases.
Hard to reproduce failed test case. 