### PR TITLE
VMI Cert: Reduce timeout to 10 seconds

### DIFF
--- a/include/ibm/management_console_rest.hpp
+++ b/include/ibm/management_console_rest.hpp
@@ -985,7 +985,7 @@ void handleCsrRequest(const std::shared_ptr<bmcweb::AsyncResp>& asyncResp,
         std::make_shared<boost::asio::steady_timer>(
             crow::connections::systemBus->get_io_context());
 
-    timeout->expires_after(std::chrono::seconds(60));
+    timeout->expires_after(std::chrono::seconds(10));
     crow::connections::systemBus->async_method_call(
         [asyncResp, timeout](const boost::system::error_code ec,
                              sdbusplus::message::message& m) {


### PR DESCRIPTION
Currently VMI cert timeout increased to 60 sec as a workaround due to VMI issue earlier.

VMI cert request is generally completed with in a second.
This commit sets max timeout back to 10 seconds.

Tested By:
Using SignCSR curl command