### PR TITLE
Add call to getPELJson interface

### DIFF
--- a/redfish-core/include/redfish.hpp
+++ b/redfish-core/include/redfish.hpp
@@ -199,6 +199,8 @@ class RedfishService
         requestRoutesDBusCELogEntry(app);
         requestRoutesDBusEventLogEntryDownload(app);
         requestRoutesDBusCELogEntryDownload(app);
+        requestRoutesDBusEventLogEntryDownloadPelJson(app);
+        requestRoutesDBusCELogEntryDownloadPelJson(app);
 #endif
 
         requestRoutesMessageRegistryFileCollection(app);

--- a/redfish-core/lib/log_services.hpp
+++ b/redfish-core/lib/log_services.hpp
@@ -2595,6 +2595,109 @@ inline void requestRoutesDBusCELogEntry(App& app)
             });
 }
 
+inline void
+    displayOemPelAttachment(const std::shared_ptr<bmcweb::AsyncResp>& asyncResp,
+                            const std::string& entryID)
+{
+
+    auto respHandler = [asyncResp, entryID](const boost::system::error_code ec,
+                                            const std::string& pelJson) {
+        if (ec.value() == EBADR)
+        {
+            messages::resourceNotFound(asyncResp->res, "OemPelAttachment",
+                                       entryID);
+            return;
+        }
+        if (ec)
+        {
+            BMCWEB_LOG_DEBUG << "DBUS response error " << ec;
+            messages::internalError(asyncResp->res);
+            return;
+        }
+
+        asyncResp->res.jsonValue["Oem"]["IBM"]["PelJson"] = pelJson;
+        asyncResp->res.jsonValue["Oem"]["@odata.type"] =
+            "#OemLogEntryAttachment.Oem";
+        asyncResp->res.jsonValue["Oem"]["IBM"]["@odata.type"] =
+            "#OemLogEntryAttachment.IBM";
+    };
+
+    uint32_t id;
+    auto [ptrIndex, ecIndex] =
+        std::from_chars(entryID.data(), entryID.data() + entryID.size(), id);
+
+    if (ecIndex != std::errc())
+    {
+        BMCWEB_LOG_DEBUG << "Unable to convert to entryID " << entryID
+                         << " to uint32_t";
+        messages::internalError(asyncResp->res);
+        return;
+    }
+
+    crow::connections::systemBus->async_method_call(
+        respHandler, "xyz.openbmc_project.Logging",
+        "/xyz/openbmc_project/logging", "org.open_power.Logging.PEL",
+        "GetPELJSON", id);
+}
+
+inline void requestRoutesDBusEventLogEntryDownloadPelJson(App& app)
+{
+    BMCWEB_ROUTE(app, "/redfish/v1/Systems/system/LogServices/EventLog/Entries/"
+                      "<str>/OemPelAttachment")
+        .privileges(redfish::privileges::getLogEntry)
+        .methods(boost::beast::http::verb::get)(
+            [](const crow::Request&,
+               const std::shared_ptr<bmcweb::AsyncResp>& asyncResp,
+               const std::string& param)
+
+            {
+                std::string entryID = param;
+                dbus::utility::escapePathForDbus(entryID);
+
+                auto eventLogAttachmentCallback =
+                    [asyncResp, entryID](bool hiddenPropVal) {
+                        if (hiddenPropVal)
+                        {
+                            messages::resourceNotFound(asyncResp->res,
+                                                       "LogEntry", entryID);
+                            return;
+                        }
+                        displayOemPelAttachment(asyncResp, entryID);
+                    };
+                getHiddenPropertyValue(asyncResp, entryID,
+                                       std::move(eventLogAttachmentCallback));
+            });
+}
+
+inline void requestRoutesDBusCELogEntryDownloadPelJson(App& app)
+{
+    BMCWEB_ROUTE(app, "/redfish/v1/Systems/system/LogServices/CELog/Entries/"
+                      "<str>/OemPelAttachment")
+        .privileges(redfish::privileges::getLogEntry)
+        .methods(boost::beast::http::verb::get)(
+            [](const crow::Request&,
+               const std::shared_ptr<bmcweb::AsyncResp>& asyncResp,
+               const std::string& param)
+
+            {
+                std::string entryID = param;
+                dbus::utility::escapePathForDbus(entryID);
+
+                auto eventLogAttachmentCallback =
+                    [asyncResp, entryID](bool hiddenPropVal) {
+                        if (!hiddenPropVal)
+                        {
+                            messages::resourceNotFound(asyncResp->res,
+                                                       "LogEntry", entryID);
+                            return;
+                        }
+                        displayOemPelAttachment(asyncResp, entryID);
+                    };
+                getHiddenPropertyValue(asyncResp, entryID,
+                                       std::move(eventLogAttachmentCallback));
+            });
+}
+
 inline void getEventLogEntryAttachment(
     const std::shared_ptr<bmcweb::AsyncResp>& asyncResp,
     const std::string& entryID)

--- a/scripts/update_schemas.py
+++ b/scripts/update_schemas.py
@@ -171,6 +171,13 @@ with open(metadata_index_path, 'w') as metadata_index:
 
     metadata_index.write(
         "    <edmx:Reference Uri=\""
+        "/redfish/v1/schema/OemLogEntryAttachment_v1.xml\">\n")
+    metadata_index.write(
+        "        <edmx:Include Namespace=\"OemLogEntryAttachment\"/>\n")
+    metadata_index.write("    </edmx:Reference>\n")
+
+    metadata_index.write(
+        "    <edmx:Reference Uri=\""
         "/redfish/v1/schema/OemManagerAccount.v1_0_0.xml\">\n")
     metadata_index.write(
         "        <edmx:Include Namespace=\"OemManagerAccount\"/>\n")

--- a/static/redfish/v1/$metadata/index.xml
+++ b/static/redfish/v1/$metadata/index.xml
@@ -3743,6 +3743,9 @@
         <edmx:Include Namespace="OemLogEntry"/>
         <edmx:Include Namespace="OemLogEntry.v1_0_0"/>
     </edmx:Reference>
+    <edmx:Reference Uri="/redfish/v1/schema/OemLogEntryAttachment_v1.xml">
+        <edmx:Include Namespace="OemLogEntryAttachment"/>
+    </edmx:Reference>
     <edmx:Reference Uri="/redfish/v1/schema/OemManagerAccount.v1_0_0.xml">
         <edmx:Include Namespace="OemManagerAccount"/>
         <edmx:Include Namespace="OemManagerAccount.v1_0_0"/>

--- a/static/redfish/v1/JsonSchemas/OemLogEntryAttachment/index.json
+++ b/static/redfish/v1/JsonSchemas/OemLogEntryAttachment/index.json
@@ -1,0 +1,66 @@
+{
+    "$id": "http://redfish.dmtf.org/schemas/v1/OemLogEntryAttachment.json",
+    "$schema": "http://redfish.dmtf.org/schemas/v1/redfish-schema-v1.json",
+    "copyright": "Copyright 2014-2019 DMTF. For the full DMTF copyright policy, see http://www.dmtf.org/about/policies/copyright",
+    "definitions": {
+        "Oem": {
+            "additionalProperties": true,
+            "description": "OemLogEntryAttachment Oem properties.",
+            "patternProperties": {
+                "^([a-zA-Z_][a-zA-Z0-9_]*)?@(odata|Redfish|Message)\\.[a-zA-Z_][a-zA-Z0-9_]*$": {
+                    "description": "This property shall specify a valid odata or Redfish property.",
+                    "type": [
+                        "null",
+                        "string"
+                    ]
+                }
+            },
+            "properties": {
+                "IBM": {
+                    "anyOf": [
+                        {
+                            "$ref": "#/definitions/IBM"
+                        },
+                        {
+                            "type": "null"
+                        }
+                    ]
+                }
+
+            },
+            "type": "object"
+        },
+        "IBM": {
+            "additionalProperties": true,
+            "description": "Oem properties for IBM.",
+            "patternProperties": {
+                "^([a-zA-Z_][a-zA-Z0-9_]*)?@(odata|Redfish|Message)\\.[a-zA-Z_][a-zA-Z0-9_]*$": {
+                    "description": "This property shall specify a valid odata or Redfish property.",
+                    "type": [
+                        "array",
+                        "boolean",
+                        "integer",
+                        "number",
+                        "null",
+                        "object",
+                        "string"
+                    ]
+                }
+            },
+            "properties": {
+                "PelJson": {
+                    "description": "PEL in Json format.",
+                    "readonly": true,
+                    "type": [
+                        "string",
+                        "null"
+                    ]
+                }
+            },
+            "type": "object"
+        }
+    },
+    "owningEntity": "IBM",
+    "release": "1.0",
+    "title": "#OemLogEntryAttachment"
+}

--- a/static/redfish/v1/schema/OemLogEntryAttachment_v1.xml
+++ b/static/redfish/v1/schema/OemLogEntryAttachment_v1.xml
@@ -1,0 +1,43 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<edmx:Edmx xmlns:edmx="http://docs.oasis-open.org/odata/ns/edmx" Version="4.0">
+
+  <edmx:Reference Uri="http://docs.oasis-open.org/odata/odata/v4.0/errata03/csd01/complete/vocabularies/Org.OData.Core.V1.xml">
+    <edmx:Include Namespace="Org.OData.Core.V1" Alias="OData"/>
+  </edmx:Reference>
+  <edmx:Reference Uri="http://docs.oasis-open.org/odata/odata/v4.0/errata03/csd01/complete/vocabularies/Org.OData.Measures.V1.xml">
+    <edmx:Include Namespace="Org.OData.Measures.V1" Alias="Measures"/>
+  </edmx:Reference>
+  <edmx:Reference Uri="http://redfish.dmtf.org/schemas/v1/RedfishExtensions_v1.xml">
+    <edmx:Include Namespace="RedfishExtensions.v1_0_0" Alias="Redfish"/>
+  </edmx:Reference>
+  <edmx:Reference Uri="http://redfish.dmtf.org/schemas/v1/Resource_v1.xml">
+    <edmx:Include Namespace="Resource"/>
+    <edmx:Include Namespace="Resource.v1_0_0"/>
+  </edmx:Reference>
+
+  <edmx:DataServices>
+
+    <Schema xmlns="http://docs.oasis-open.org/odata/ns/edm" Namespace="OemLogEntryAttachment">
+      <Annotation Term="Redfish.OwningEntity" String="IBM"/>
+
+      <ComplexType Name="Oem" BaseType="Resource.OemObject">
+        <Annotation Term="OData.AdditionalProperties" Bool="true"/>
+        <Annotation Term="OData.Description" String="OemLogEntryAttachment Oem properties."/>
+        <Annotation Term="OData.AutoExpand"/>
+        <Property Name="IBM" Type="OemLogEntryAttachment.IBM"/>
+      </ComplexType>
+
+      <ComplexType Name="IBM" BaseType="Resource.OemObject">
+        <Annotation Term="OData.AdditionalProperties" Bool="false" />
+        <Annotation Term="OData.Description" String="Oem properties for IBM." />
+        <Annotation Term="OData.AutoExpand"/>
+        <Property Name="PelJson" Type="OemLogEntryAttachment.IBM">
+          <Annotation Term="OData.Permissions" EnumMember="OData.Permission/Read"/>
+          <Annotation Term="OData.Description" String="PEL in Json format."/>
+        </Property>
+      </ComplexType>
+
+    </Schema>
+
+  </edmx:DataServices>
+</edmx:Edmx>


### PR DESCRIPTION
Add call to getPELJson for both EventLog and CELog log services.
Returns PEL in json format.

Dev story is https://github.com/ibm-openbmc/dev/issues/3538. 
This is downstream only. 


Commit message:
[Add call to getPELJson interface](https://github.com/ibm-openbmc/bmcweb/pull/324/commits/b3ff538190a1e2a7fa58daede4034ce6867cf173) 

Add call to getPELJson for both EventLog and CELog log services.
Returns PEL in json format.
EventLog path is redfish/v1/Systems/system/LogServices/EventLog
CELog    path is redfish/v1/Systems/system/LogServices/CELog

Tested:
1) Passed redfish validator
2) Curl testing passed

a) curl -k -H "X-Auth-Token: $token" -X GET \
https://$bmc/redfish/v1/Systems/system/LogServices/CELog/Entries/4/OemPelAttachment

{
    "Oem": {
        "@odata.type": "#OemLogEntryAttachment.Oem",
        "IBM": {
            "@odata.type": "#OemLogEntryAttachment.IBM",
            "PelJson": "{\n"Private Header": {\n "Section Version": "1",\n ..."
        }
    }
}

b) curl -k -H "X-Auth-Token: $token" -X GET \
https://$bmc/redfish/v1/Systems/system/LogServices/EventLog/Entries/9/OemPelAttachment

{
  "Oem": {
    "@odata.type": "#OemLogEntryAttachment.Oem",
    "IBM": {
      "@odata.type": "#OemLogEntryAttachment.IBM",
      "PelJson": "{\n\"Private Header\": {\n    \"Section Version\": ..."
    }
  }
}

Signed-off-by: Ali Ahmed <ama213000@gmail.com>
Change-Id: I4d37f1107a50274a2c8bc21db30134ccb21d08f9

Change-Id: I72539d0928d40d8140cb34640ef2414c77c1e3b7