### PR TITLE
Sensors: Add humidity ReadingUnits and ReadingType

### DIFF
--- a/redfish-core/lib/sensors.hpp
+++ b/redfish-core/lib/sensors.hpp
@@ -106,6 +106,10 @@ inline const char* toReadingType(const std::string& sensorType)
     {
         return "Percent";
     }
+    if (sensorType == "humidity")
+    {
+        return "Humidity";
+    }
     if (sensorType == "altitude")
     {
         return "Altitude";
@@ -143,7 +147,8 @@ inline const char* toReadingUnits(const std::string& sensorType)
     {
         return "Cel";
     }
-    if (sensorType == "fan_pwm" || sensorType == "utilization")
+    if (sensorType == "fan_pwm" || sensorType == "utilization" ||
+        sensorType == "humidity")
     {
         return "%";
     }


### PR DESCRIPTION
Add humidity ReadingUnits and ReadingType

This should have been included in https://github.com/ibm-openbmc/bmcweb/pull/320

Tested: Built this code and loaded on a Rainier with a humidity sensor.
Validator passed.
Before with 320:
```
{
"@odata.id": ["/redfish/v1/Chassis/chassis/Sensors/Relative_Humidity"](https://rain104bmc.aus.stglabs.ibm.com/redfish/v1/Chassis/chassis/Sensors/Relative_Humidity),
"@odata.type": "#Sensor.v1_0_0.Sensor",
"Id": "Relative_Humidity",
"Name": "Relative Humidity",
"Reading": 58.532714841832004,
"ReadingRangeMax": 100.0,
"ReadingRangeMin": 0.0,
"Status": {
"Health": "OK",
"State": "Enabled"
}
}
```
After: 
```
{
"@odata.id": ["/redfish/v1/Chassis/chassis/Sensors/Relative_Humidity"](https://rain104bmc.aus.stglabs.ibm.com:18080/redfish/v1/Chassis/chassis/Sensors/Relative_Humidity),
"@odata.type": "#Sensor.v1_0_0.Sensor",
"Id": "Relative_Humidity",
"Name": "Relative Humidity",
"Reading": 61.935424802658005,
"ReadingRangeMax": 100.0,
"ReadingRangeMin": 0.0,
"ReadingType": "Humidity", <- new field 
"ReadingUnits": "%", <- new field
"Status": {
"Health": "OK",
"State": "Enabled"
}
}

```


Signed-off-by: Gunnar Mills <gmills@us.ibm.com>
Change-Id: Ib1f52b0b0e3d8c4bfec8c4389c811fdb8b9d887a