### PR TITLE
SW549923: Add Support for WebSocket privilege check

### DIFF
--- a/http/app.hpp
+++ b/http/app.hpp
@@ -45,7 +45,7 @@ class App
     }
 
     template <typename Adaptor>
-    void handleUpgrade(const Request& req,
+    void handleUpgrade(Request& req,
                        std::shared_ptr<bmcweb::AsyncResp>& asyncResp,
                        Adaptor&& adaptor)
     {

--- a/http/obmc_shell.hpp
+++ b/http/obmc_shell.hpp
@@ -174,8 +174,8 @@ static std::map<crow::websocket::Connection*, std::shared_ptr<Handler>>
 inline void requestRoutes(App& app)
 {
     BMCWEB_ROUTE(app, "/bmc-console")
-        .privileges({{"OemIBMPerformService"}})
         .websocket()
+        .privileges({{"OemIBMPerformService"}})
         .onopen([](crow::websocket::Connection& conn,
                    const std::shared_ptr<bmcweb::AsyncResp>&) {
             BMCWEB_LOG_DEBUG << "Connection " << &conn << " opened";

--- a/http/routing.hpp
+++ b/http/routing.hpp
@@ -101,6 +101,8 @@ class BaseRule
     friend class Router;
     template <typename T>
     friend struct RuleParameterTraits;
+    template <typename T>
+    friend struct PrivilegeParameterTraits;
 };
 
 namespace detail
@@ -315,6 +317,33 @@ struct Wrapped
 } // namespace routing_handler_call_helper
 } // namespace detail
 
+template <typename T>
+struct PrivilegeParameterTraits
+{
+    using self_t = T;
+    self_t& privileges(
+        const std::initializer_list<std::initializer_list<const char*>>& p)
+    {
+        self_t* self = static_cast<self_t*>(this);
+        for (const std::initializer_list<const char*>& privilege : p)
+        {
+            self->privilegesSet.emplace_back(privilege);
+        }
+        return *self;
+    }
+
+    template <size_t N, typename... MethodArgs>
+    self_t& privileges(const std::array<redfish::Privileges, N>& p)
+    {
+        self_t* self = static_cast<self_t*>(this);
+        for (const redfish::Privileges& privilege : p)
+        {
+            self->privilegesSet.emplace_back(privilege);
+        }
+        return *self;
+    }
+};
+
 class WebSocketRule : public BaseRule
 {
     using self_t = WebSocketRule;
@@ -490,7 +519,7 @@ class StreamingResponseRule : public BaseRule
 };
 
 template <typename T>
-struct RuleParameterTraits
+struct RuleParameterTraits : public PrivilegeParameterTraits<T>
 {
     using self_t = T;
     WebSocketRule& websocket()
@@ -530,28 +559,6 @@ struct RuleParameterTraits
         self_t* self = static_cast<self_t*>(this);
         methods(argsMethod...);
         self->methodsBitfield |= 1U << static_cast<size_t>(method);
-        return *self;
-    }
-
-    self_t& privileges(
-        const std::initializer_list<std::initializer_list<const char*>>& p)
-    {
-        self_t* self = static_cast<self_t*>(this);
-        for (const std::initializer_list<const char*>& privilege : p)
-        {
-            self->privilegesSet.emplace_back(privilege);
-        }
-        return *self;
-    }
-
-    template <size_t N, typename... MethodArgs>
-    self_t& privileges(const std::array<redfish::Privileges, N>& p)
-    {
-        self_t* self = static_cast<self_t*>(this);
-        for (const redfish::Privileges& privilege : p)
-        {
-            self->privilegesSet.emplace_back(privilege);
-        }
         return *self;
     }
 };

--- a/include/dbus_monitor.hpp
+++ b/include/dbus_monitor.hpp
@@ -105,8 +105,8 @@ inline int onPropertyUpdate(sd_bus_message* m, void* userdata,
 inline void requestRoutes(App& app)
 {
     BMCWEB_ROUTE(app, "/subscribe")
-        .privileges({{"Login"}})
         .websocket()
+        .privileges({{"Login"}})
         .onopen([&](crow::websocket::Connection& conn,
                     const std::shared_ptr<bmcweb::AsyncResp>&) {
             BMCWEB_LOG_DEBUG << "Connection " << &conn << " opened";

--- a/include/kvm_websocket.hpp
+++ b/include/kvm_websocket.hpp
@@ -159,8 +159,8 @@ inline void requestRoutes(App& app)
     sessions.reserve(maxSessions);
 
     BMCWEB_ROUTE(app, "/kvm/0")
-        .privileges({{"ConfigureComponents", "ConfigureManager"}})
         .websocket()
+        .privileges({{"ConfigureComponents", "ConfigureManager"}})
         .onopen([](crow::websocket::Connection& conn,
                    const std::shared_ptr<bmcweb::AsyncResp>&) {
             BMCWEB_LOG_DEBUG << "Connection " << &conn << " opened";

--- a/include/obmc_console.hpp
+++ b/include/obmc_console.hpp
@@ -117,8 +117,8 @@ inline void connectHandler(const boost::system::error_code& ec)
 inline void requestRoutes(App& app)
 {
     BMCWEB_ROUTE(app, "/console0")
-        .privileges({{"ConfigureComponents", "ConfigureManager"}})
         .websocket()
+        .privileges({{"ConfigureComponents", "ConfigureManager"}})
         .onopen([](crow::websocket::Connection& conn,
                    const std::shared_ptr<bmcweb::AsyncResp>&) {
             BMCWEB_LOG_DEBUG << "Connection " << &conn << " opened";

--- a/include/obmc_hypervisor.hpp
+++ b/include/obmc_hypervisor.hpp
@@ -118,7 +118,7 @@ inline void requestRoutes(App& app)
 {
     BMCWEB_ROUTE(app, "/console1")
         .websocket()
-        .privileges({{"ConfigureComponents", "ConfigureManager"}})
+        .privileges({{"OemIBMPerformService"}})
         .onopen([](crow::websocket::Connection& conn,
                    const std::shared_ptr<bmcweb::AsyncResp>&) {
             BMCWEB_LOG_DEBUG << "Connection " << &conn << " opened";

--- a/include/obmc_hypervisor.hpp
+++ b/include/obmc_hypervisor.hpp
@@ -117,8 +117,8 @@ inline void connectHandler(const boost::system::error_code& ec)
 inline void requestRoutes(App& app)
 {
     BMCWEB_ROUTE(app, "/console1")
-        .privileges({{"ConfigureComponents", "ConfigureManager"}})
         .websocket()
+        .privileges({{"ConfigureComponents", "ConfigureManager"}})
         .onopen([](crow::websocket::Connection& conn,
                    const std::shared_ptr<bmcweb::AsyncResp>&) {
             BMCWEB_LOG_DEBUG << "Connection " << &conn << " opened";

--- a/include/vm_websocket.hpp
+++ b/include/vm_websocket.hpp
@@ -156,8 +156,8 @@ static std::shared_ptr<Handler> handler;
 inline void requestRoutes(App& app)
 {
     BMCWEB_ROUTE(app, "/vm/0/0")
-        .privileges({{"ConfigureComponents", "ConfigureManager"}})
         .websocket()
+        .privileges({{"ConfigureComponents", "ConfigureManager"}})
         .onopen([](crow::websocket::Connection& conn,
                    const std::shared_ptr<bmcweb::AsyncResp>&) {
             BMCWEB_LOG_DEBUG << "Connection " << &conn << " opened";


### PR DESCRIPTION
This commit enables a privilege check for the user(s) in case of upgraded
connections.
Previously there was no chack for WebSocket Privileges. Users with no
privileges will also be able to access WebSockets connections. For
bmc_console and other WebSocket privileges are defined, but they are
useless without check.

Here there are mainly two commits retrieved from upstream.

https://gerrit.openbmc-project.xyz/c/openbmc/bmcweb/+/46990/1
https://gerrit.openbmc-project.xyz/c/openbmc/bmcweb/+/46991/1

downstream PR is also there for WebSocket connection
establishment, mainly 101 checks (when WebSocket establishes connection).
https://github.com/ibm-openbmc/bmcweb/pull/322

Tested:
Tested using the rainier system, where bmc_console only creates
a WebSocket connection for the service user. Admin, and any other
user gets discarded.
