### PR TITLE
Do not query health of PLDM fans

### DIFF
--- a/redfish-core/lib/fan.hpp
+++ b/redfish-core/lib/fan.hpp
@@ -43,6 +43,14 @@ inline void getFanHealth(const std::shared_ptr<bmcweb::AsyncResp>& asyncResp,
                          const std::string& connectionName,
                          const std::string& path)
 {
+    if ("xyz.openbmc_project.PLDM" == connectionName)
+    {
+        asyncResp->res.jsonValue["Status"]["Health"] = "Unknown";
+
+        // cannot read health info for fans off this controller
+        return;
+    }
+
     // Set the default Health to OK
     asyncResp->res.jsonValue["Status"]["Health"] = "OK";
 


### PR DESCRIPTION
The PLDM driver does not have the capability to query health status of
fans in MEX drawers. This change returns early if the serviceName
indicates it came from PLDM.