### PR TITLE
Add ACFWindowActive to /redfish/v1

### DIFF
--- a/redfish-core/lib/service_root.hpp
+++ b/redfish-core/lib/service_root.hpp
@@ -123,6 +123,34 @@ inline void
     asyncResp->res.jsonValue["Oem"]["IBM"]["DateTimeLocalOffset"] =
         redfishDateTimeOffset.second;
 
+    // Report if ACFWindowActive
+    crow::connections::systemBus->async_method_call(
+        [asyncResp](const boost::system::error_code ec,
+                    const std::variant<bool>& retVal) {
+            if (ec)
+            {
+                BMCWEB_LOG_ERROR
+                    << "Failed to read ACFWindowActive property";
+            }
+            else
+            {
+                const bool* isACFWindowActive = std::get_if<bool>(&retVal);
+                if (isACFWindowActive == nullptr)
+                {
+                    BMCWEB_LOG_ERROR << "nullptr for ACFWindowActive";
+                    messages::internalError(asyncResp->res);
+                }
+                else
+                {
+                    asyncResp->res.jsonValue["Oem"]["IBM"]["ACFWindowActive"] =
+                        *isACFWindowActive;
+                }
+            }
+        },
+        "com.ibm.PanelApp", "/com/ibm/panel_app",
+        "org.freedesktop.DBus.Properties", "Get", "com.ibm.panel",
+        "ACFWindowActive");
+
     asyncResp->res.jsonValue["Oem"]["@odata.type"] = "#OemServiceRoot.Oem";
     asyncResp->res.jsonValue["Oem"]["IBM"]["@odata.type"] =
         "#OemServiceRoot.IBM";

--- a/redfish-core/lib/service_root.hpp
+++ b/redfish-core/lib/service_root.hpp
@@ -23,6 +23,40 @@
 namespace redfish
 {
 
+
+inline void
+    handleACFWindowActive(const std::shared_ptr<bmcweb::AsyncResp>& asyncResp)
+{
+    crow::connections::systemBus->async_method_call(
+        [asyncResp](const boost::system::error_code ec,
+                    const std::variant<bool>& retVal) {
+            if (ec)
+            {
+                BMCWEB_LOG_ERROR
+                    << "Failed to read ACFWindowActive property";
+                // Default value when panel app is unreachable.
+                asyncResp->res.jsonValue["Oem"]["IBM"]["ACFWindowActive"] =
+                    false;
+            }
+            const bool* isACFWindowActive = std::get_if<bool>(&retVal);
+            if (isACFWindowActive == nullptr)
+            {
+                BMCWEB_LOG_ERROR << "nullptr for ACFWindowActive";
+                messages::internalError(asyncResp->res);
+            }
+            else
+            {
+                asyncResp->res.jsonValue["Oem"]["IBM"]["ACFWindowActive"] =
+                    *isACFWindowActive;
+            }
+        },
+        "com.ibm.PanelApp", "/com/ibm/panel_app",
+        "org.freedesktop.DBus.Properties", "Get", "com.ibm.panel",
+        "ACFWindowActive");
+}
+
+
+
 inline void
     handleServiceRootOem(const std::shared_ptr<bmcweb::AsyncResp>& asyncResp)
 {
@@ -122,35 +156,7 @@ inline void
         redfishDateTimeOffset.first;
     asyncResp->res.jsonValue["Oem"]["IBM"]["DateTimeLocalOffset"] =
         redfishDateTimeOffset.second;
-
-    // Report if ACFWindowActive
-    crow::connections::systemBus->async_method_call(
-        [asyncResp](const boost::system::error_code ec,
-                    const std::variant<bool>& retVal) {
-            if (ec)
-            {
-                BMCWEB_LOG_ERROR
-                    << "Failed to read ACFWindowActive property";
-            }
-            else
-            {
-                const bool* isACFWindowActive = std::get_if<bool>(&retVal);
-                if (isACFWindowActive == nullptr)
-                {
-                    BMCWEB_LOG_ERROR << "nullptr for ACFWindowActive";
-                    messages::internalError(asyncResp->res);
-                }
-                else
-                {
-                    asyncResp->res.jsonValue["Oem"]["IBM"]["ACFWindowActive"] =
-                        *isACFWindowActive;
-                }
-            }
-        },
-        "com.ibm.PanelApp", "/com/ibm/panel_app",
-        "org.freedesktop.DBus.Properties", "Get", "com.ibm.panel",
-        "ACFWindowActive");
-
+    handleACFWindowActive(asyncResp);
     asyncResp->res.jsonValue["Oem"]["@odata.type"] = "#OemServiceRoot.Oem";
     asyncResp->res.jsonValue["Oem"]["IBM"]["@odata.type"] =
         "#OemServiceRoot.IBM";

--- a/redfish-core/lib/service_root.hpp
+++ b/redfish-core/lib/service_root.hpp
@@ -23,7 +23,6 @@
 namespace redfish
 {
 
-
 inline void
     handleACFWindowActive(const std::shared_ptr<bmcweb::AsyncResp>& asyncResp)
 {
@@ -32,30 +31,26 @@ inline void
                     const std::variant<bool>& retVal) {
             if (ec)
             {
-                BMCWEB_LOG_ERROR
-                    << "Failed to read ACFWindowActive property";
+                BMCWEB_LOG_ERROR << "Failed to read ACFWindowActive property";
                 // Default value when panel app is unreachable.
                 asyncResp->res.jsonValue["Oem"]["IBM"]["ACFWindowActive"] =
                     false;
+                return;
             }
             const bool* isACFWindowActive = std::get_if<bool>(&retVal);
             if (isACFWindowActive == nullptr)
             {
                 BMCWEB_LOG_ERROR << "nullptr for ACFWindowActive";
                 messages::internalError(asyncResp->res);
+                return;
             }
-            else
-            {
-                asyncResp->res.jsonValue["Oem"]["IBM"]["ACFWindowActive"] =
-                    *isACFWindowActive;
-            }
+            asyncResp->res.jsonValue["Oem"]["IBM"]["ACFWindowActive"] =
+                *isACFWindowActive;
         },
         "com.ibm.PanelApp", "/com/ibm/panel_app",
         "org.freedesktop.DBus.Properties", "Get", "com.ibm.panel",
         "ACFWindowActive");
 }
-
-
 
 inline void
     handleServiceRootOem(const std::shared_ptr<bmcweb::AsyncResp>& asyncResp)

--- a/static/redfish/v1/JsonSchemas/OemServiceRoot/index.json
+++ b/static/redfish/v1/JsonSchemas/OemServiceRoot/index.json
@@ -85,6 +85,15 @@
                         "string",
                         "null"
                     ]
+                },
+                "ACFWindowActive": {
+                    "description": "An indication of whether the time window for an unauthorized agent to upload an ACF is active.",
+                    "longDescription": "This property shall indicate if the time window for an unauthorized agent to upload an ACF is active.",
+                    "readonly": true,
+                    "type": [
+                        "boolean",
+                        "null"
+                    ]
                 }
             },
             "type": "object"

--- a/static/redfish/v1/schema/OemServiceRoot_v1.xml
+++ b/static/redfish/v1/schema/OemServiceRoot_v1.xml
@@ -55,6 +55,11 @@
           <Annotation Term="OData.Description" String="The time offset from UTC that the DateTime property is in `+HH:MM` format."/>
           <Annotation Term="OData.LongDescription" String="This property shall contain the offset from UTC time that the DateTime property contains.  If both DateTime and DateTimeLocalOffset are provided in modification requests, services shall apply DateTimeLocalOffset after DateTime is applied."/>
         </Property>
+        <Property Name="ACFWindowActive" Type="OemServiceRoot.IBM">
+          <Annotation Term="OData.Permissions" EnumMember="OData.Permission/Read"/>
+          <Annotation Term="OData.Description" String="An indication of whether the time window for an unauthorized agent to upload an ACF is active."/>
+          <Annotation Term="OData.LongDescription" String="This property shall indicate if the time window for an unauthorized agent to upload an ACF is active."/>
+        </Property>
       </ComplexType>
 
     </Schema>


### PR DESCRIPTION
Partial fix for SW546530

This adds the Oem.IBM.ACFWindowActive boolean property to the Redfish service root at URI /redfish/v1.

Tested:
Via curl https://${BMC}/redfish/v1
Tested values true, false, and panel app not running.
Simulated pressing function 74 via busctl set-property "com.ibm.PanelApp"
  "/com/ibm/panel_app" "com.ibm.panel" "ACFWindowActive" b true

Signed-off-by: Joseph Reynolds <joseph-reynolds@charter.net>