### PR TITLE
CreateDump: Return error while Dump-manager busy with other dump

### DIFF
--- a/redfish-core/lib/log_services.hpp
+++ b/redfish-core/lib/log_services.hpp
@@ -1152,6 +1152,14 @@ inline void createDump(const std::shared_ptr<bmcweb::AsyncResp>& asyncResp,
                     messages::resourceInStandby(asyncResp->res);
                     return;
                 }
+
+                if (strcmp(dbusError->name, "xyz.openbmc_project.Common.Error."
+                                            "Unavailable") == 0)
+                {
+                    messages::resourceInUse(asyncResp->res);
+                    return;
+                }
+
                 if (strcmp(dbusError->name,
                            "org.freedesktop.DBus.Error.NoReply") == 0)
                 {


### PR DESCRIPTION
Dump manager returns Unavailable D-bus error when Dump-manager is not ready
to create dump.
This commit maps this D-bus error to ResourceInUse

Tested By:
Run create dump request while another dump creation going on