### PR TITLE
http_connection: Bump connection timeout to 12 min

### DIFF
--- a/http/http_connection.hpp
+++ b/http/http_connection.hpp
@@ -47,10 +47,10 @@ constexpr uint64_t loggedOutPostBodyLimit = 4096;
 
 constexpr uint32_t httpHeaderLimit = 8192;
 
-// drop all connections after 3 minutes, this time limit was chosen
+// drop all connections after 12 minutes, this time limit was chosen
 // arbitrarily and can be adjusted later if needed
 static constexpr const size_t loggedInAttempts =
-    (180 / timerQueueTimeoutSeconds);
+    (720 / timerQueueTimeoutSeconds);
 
 static constexpr const size_t loggedOutAttempts =
     (15 / timerQueueTimeoutSeconds);


### PR DESCRIPTION
Bump the connection timeout to 12min to allow firmware image uploads at
low network speeds.

Change-Id: Ia62860050c76eb61e8f65e7c5057b1ff94ebbb8e
Signed-off-by: Adriana Kobylak <anoo@us.ibm.com>