### PR TITLE
PowerSubsystem: Add Allocation properties

### DIFF
--- a/redfish-core/lib/power_subsystem.hpp
+++ b/redfish-core/lib/power_subsystem.hpp
@@ -75,7 +75,7 @@ inline void getPowerSubsystemAllocationProperties(
             }
 
             // If MaxPowerCapValue valid, store Allocation properties in JSON
-            if (maxPowerCapValue > 0)
+            if ((maxPowerCapValue > 0) && (maxPowerCapValue < UINT32_MAX))
             {
                 asyncResp->res.jsonValue["Allocation"]["AllocatedWatts"] =
                     powerCapEnable ? powerCap : maxPowerCapValue;

--- a/redfish-core/lib/power_subsystem.hpp
+++ b/redfish-core/lib/power_subsystem.hpp
@@ -4,8 +4,121 @@
 #include <utils/chassis_utils.hpp>
 #include <utils/json_utils.hpp>
 
+#include <cstdint>
+
 namespace redfish
 {
+
+// Map of service name to list of interfaces
+using MapperServiceMap =
+    std::vector<std::pair<std::string, std::vector<std::string>>>;
+
+// Map of object paths to MapperServiceMaps
+using MapperGetSubTreeResponse =
+    std::vector<std::pair<std::string, MapperServiceMap>>;
+
+// PowerCap interface
+constexpr auto powerCapInterface = "xyz.openbmc_project.Control.Power.Cap";
+
+// Variant for property values in PowerCap interface
+using PowerCapPropertiesValue = std::variant<uint32_t, bool>;
+
+// Vector of properties in the PowerCap interface
+using PowerCapProperties =
+    std::vector<std::pair<std::string, PowerCapPropertiesValue>>;
+
+inline void getPowerSubsystemAllocationProperties(
+    const std::shared_ptr<bmcweb::AsyncResp>& asyncResp,
+    const std::string& service, const std::string& objectPath)
+{
+    // Get all properties of PowerCap D-Bus interface
+    crow::connections::systemBus->async_method_call(
+        [asyncResp](const boost::system::error_code ec,
+                    const PowerCapProperties& properties) {
+            if (ec)
+            {
+                BMCWEB_LOG_DEBUG << "D-Bus response error on GetAll " << ec;
+                messages::internalError(asyncResp->res);
+                return;
+            }
+
+            // Get value of PowerCap properties from D-Bus response
+            uint32_t powerCap{0};
+            bool powerCapEnable{false};
+            uint32_t maxPowerCapValue{0};
+            for (const auto& [property, value] : properties)
+            {
+                if (property == "PowerCap")
+                {
+                    const uint32_t* valPtr = std::get_if<uint32_t>(&value);
+                    if (valPtr != nullptr)
+                    {
+                        powerCap = *valPtr;
+                    }
+                }
+                else if (property == "PowerCapEnable")
+                {
+                    const bool* valPtr = std::get_if<bool>(&value);
+                    if (valPtr != nullptr)
+                    {
+                        powerCapEnable = *valPtr;
+                    }
+                }
+                else if (property == "MaxPowerCapValue")
+                {
+                    const uint32_t* valPtr = std::get_if<uint32_t>(&value);
+                    if (valPtr != nullptr)
+                    {
+                        maxPowerCapValue = *valPtr;
+                    }
+                }
+            }
+
+            // If MaxPowerCapValue valid, store Allocation properties in JSON
+            if (maxPowerCapValue > 0)
+            {
+                asyncResp->res.jsonValue["Allocation"]["AllocatedWatts"] =
+                    powerCapEnable ? powerCap : maxPowerCapValue;
+                asyncResp->res.jsonValue["Allocation"]["RequestedWatts"] =
+                    maxPowerCapValue;
+            }
+        },
+        service, objectPath, "org.freedesktop.DBus.Properties", "GetAll",
+        powerCapInterface);
+}
+
+inline void getPowerSubsystemAllocation(
+    const std::shared_ptr<bmcweb::AsyncResp>& asyncResp)
+{
+    // Find service and object path that implement PowerCap interface (if any)
+    crow::connections::systemBus->async_method_call(
+        [asyncResp](const boost::system::error_code ec,
+                    const MapperGetSubTreeResponse& subTree) {
+            if (ec)
+            {
+                BMCWEB_LOG_DEBUG << "D-Bus response error on GetSubTree " << ec;
+                messages::internalError(asyncResp->res);
+                return;
+            }
+
+            if (!subTree.empty())
+            {
+                const auto& [objectPath, serviceMap] = subTree[0];
+                if (!serviceMap.empty())
+                {
+                    const auto& service = serviceMap[0].first;
+
+                    // Get properties from PowerCap interface and store in JSON
+                    getPowerSubsystemAllocationProperties(asyncResp, service,
+                                                          objectPath);
+                }
+            }
+        },
+        "xyz.openbmc_project.ObjectMapper",
+        "/xyz/openbmc_project/object_mapper",
+        "xyz.openbmc_project.ObjectMapper", "GetSubTree", "/", 0,
+        std::array<const char*, 1>{powerCapInterface});
+}
 
 inline void
     getPowerSubsystem(const std::shared_ptr<bmcweb::AsyncResp>& asyncResp,
@@ -23,6 +136,9 @@ inline void
         "/redfish/v1/Chassis/" + chassisID + "/PowerSubsystem";
     asyncResp->res.jsonValue["PowerSupplies"]["@odata.id"] =
         "/redfish/v1/Chassis/" + chassisID + "/PowerSubsystem/PowerSupplies";
+
+    // Get Allocation information from D-Bus and store in JSON
+    getPowerSubsystemAllocation(asyncResp);
 }
 
 inline void requestRoutesPowerSubsystem(App& app)


### PR DESCRIPTION
Add the Allocation properties to the PowerSubsystem output.

Set the Redfish properties based on properties from the D-Bus
xyz.openbmc_project.Control.Power.Cap interface:
* Redfish AllocatedWatts property:
  * Set to PowerCap property if PowerCapEnable is true
  * Set to MaxPowerCapValue property if PowerCapEnable is false
* Redfish RequestedWatts property:
  * Set to MaxPowerCapValue property

Tested:
* Passed the Redfish Validator
* For detailed test plan, see
  https://gist.github.com/smccarney/cadb51e27e97d669b46426b91bd5f659

Example Output:
$ curl -k https://${bmc}/redfish/v1/Chassis/chassis/PowerSubsystem
{
  "@odata.id": "/redfish/v1/Chassis/chassis/PowerSubsystem",
  "@odata.type": "#PowerSubsystem.v1_0_0.PowerSubsystem",
  "Allocation": {
    "AllocatedWatts": 5020,
    "RequestedWatts": 6111
  },
  "Id": "PowerSubsystem",
  "Name": "Power Subsystem for Chassis",
  "PowerSupplies": {
    "@odata.id": "/redfish/v1/Chassis/chassis/PowerSubsystem/PowerSupplies"
  }
}

Signed-off-by: Shawn McCarney <shawnmm@us.ibm.com>
Change-Id: I764582e1b72b12eaef48ad9973417f6757192541