### PR TITLE
CreateDump: change the Task states for resource dump

### DIFF
--- a/redfish-core/lib/log_services.hpp
+++ b/redfish-core/lib/log_services.hpp
@@ -921,6 +921,11 @@ inline DumpCreationProgress getDumpCompletionStatus(
                                                      "Resource selector"));
                 return DUMP_CREATE_FAILED;
             }
+            if (value.ends_with("Success"))
+            {
+                taskData->state = "Running";
+                return DUMP_CREATE_INPROGRESS;
+            }
             return DUMP_CREATE_INPROGRESS;
         }
     }

--- a/redfish-core/lib/task.hpp
+++ b/redfish-core/lib/task.hpp
@@ -91,7 +91,7 @@ struct TaskData : std::enable_shared_from_this<TaskData>
         matchStr(matchIn), index(idx),
         startTime(std::chrono::system_clock::to_time_t(
             std::chrono::system_clock::now())),
-        status("OK"), state("Running"), messages(nlohmann::json::array()),
+        status("OK"), state("Starting"), messages(nlohmann::json::array()),
         timer(crow::connections::systemBus->get_io_context())
 
     {}


### PR DESCRIPTION
Currently, HMC doesn’t have a way to return an error on resource
dump create request.

When HMC requests for a resource dump collection, there wont be any
validation on the BMC, bmcweb starts a task and returns the same
as the redfish response. HMC will then poll on the Redfish task
before returning success/failure on the createDump request thread.

Now with this change, the flow will be like:

    > CreateDump will return 202 with task url - (current behavior)

    > Task will be created with initial state as 'Starting'

    > Dump manager will set the DumpRequestStatus to Success when the
      resource selector validation is success - (current behavior)

    > With this change, bmcweb will change the taskstate to 'Running'
      once the validation is Success

    > HMC will poll the task URL to look for taskstate==Starting (initial
      state until the validation is done) and then the taskstate moves to
      'Running'. This will indicate that the resource selector validation
      is successful, and the dump creation is in progress

    > The task will be completed/cancelled based on Status property of the
      Progress interface implemented by the created dump object, indicating
      success/failure of dump collection.

Defect: SW547081

Tested By:

* Create Resource dump:

POST https://${bmc}/redfish/v1/Systems/system/LogServices/Dump/Actions\
/LogService.CollectDiagnosticData -d '{"DiagnosticDataType":"OEM", \
"OEMDiagnosticDataType":"Resource_<vspstr>_<pwd>"}'

* bmcweb returns a task:

{
  "@odata.id": "/redfish/v1/TaskService/Tasks/1",
  "@odata.type": "#Task.v1_4_3.Task",
  "Id": "1",
  "TaskState": "Starting",
  "TaskStatus": "OK"
}

* TaskStatus will be changed to Running once validation is successfull
(that is, DumpRequestStatus is success)

* TaskStatus will change to Completed if dump collection is successfull
or Cancelled if it fails. (that is, if Status is changed to Success/Failed)

Signed-off-by: Asmitha Karunanithi <asmitk01@in.ibm.com>
Change-Id: I2234bfc2f95ce27445d6d6a888a4895000436061