### PR TITLE
Update to fix SW544220.

### DIFF
--- a/redfish-core/lib/account_service.hpp
+++ b/redfish-core/lib/account_service.hpp
@@ -2056,14 +2056,14 @@ inline void requestAccountServiceRoutes(App& app)
                     for (unsigned int index = 0; index < allGroupsList->size();
                          index++)
                     {
-				    	if (allGroupsList->at(index) != "ipmi")
+                        if (allGroupsList->at(index) != "ipmi")
                         {
                             modGroupsList.push_back(allGroupsList->at(index));
                         }
                     }
 
                     const std::vector<std::string>* pModGroupsList =
-                                                   &modGroupsList;
+                        &modGroupsList;
 
                     crow::connections::systemBus->async_method_call(
                         [asyncResp, username,

--- a/redfish-core/lib/account_service.hpp
+++ b/redfish-core/lib/account_service.hpp
@@ -2056,14 +2056,14 @@ inline void requestAccountServiceRoutes(App& app)
                     for (unsigned int index = 0; index < allGroupsList->size();
                          index++)
                     {
-                        if (allGroupsList->at(index) != "ipmi") 
+				    	if (allGroupsList->at(index) != "ipmi")
                         {
                             modGroupsList.push_back(allGroupsList->at(index));
                         }
                     }
 
                     const std::vector<std::string>* pModGroupsList =
-                        &modGroupsList;
+                                                   &modGroupsList;
 
                     crow::connections::systemBus->async_method_call(
                         [asyncResp, username,

--- a/redfish-core/lib/account_service.hpp
+++ b/redfish-core/lib/account_service.hpp
@@ -2048,6 +2048,22 @@ inline void requestAccountServiceRoutes(App& app)
                         messages::internalError(asyncResp->res);
                         return;
                     }
+                    
+                    // Create (modified) modGroupsList from allGroupsList that
+                    // does not contain the ipmi group.
+                    std::vector<std::string> modGroupsList;
+
+                    for (unsigned int index = 0; index < allGroupsList->size();
+                                                                 index++)
+                    {
+				    	if (allGroupsList->at(index) != "ipmi") 
+                        {
+                            modGroupsList.push_back(allGroupsList->at(index));
+                        }
+                    }
+
+                    const std::vector<std::string>* pModGroupsList =
+                                                   &modGroupsList;
 
                     crow::connections::systemBus->async_method_call(
                         [asyncResp, username,
@@ -2100,7 +2116,7 @@ inline void requestAccountServiceRoutes(App& app)
                         "xyz.openbmc_project.User.Manager",
                         "/xyz/openbmc_project/user",
                         "xyz.openbmc_project.User.Manager", "CreateUser",
-                        username, *allGroupsList, *roleId, *enabled);
+                        username, *pModGroupsList, *roleId, *enabled);
                 },
                 "xyz.openbmc_project.User.Manager", "/xyz/openbmc_project/user",
                 "org.freedesktop.DBus.Properties", "Get",

--- a/redfish-core/lib/account_service.hpp
+++ b/redfish-core/lib/account_service.hpp
@@ -2054,7 +2054,7 @@ inline void requestAccountServiceRoutes(App& app)
                     // does not contain the ipmi group.
                     std::vector<std::string> modGroupsList;
 
-                    for (const auto &group : *allGroupsList)
+                    for (const auto& group : *allGroupsList)
                     {
                         if (group != "ipmi")
                         {

--- a/redfish-core/lib/account_service.hpp
+++ b/redfish-core/lib/account_service.hpp
@@ -2048,22 +2048,22 @@ inline void requestAccountServiceRoutes(App& app)
                         messages::internalError(asyncResp->res);
                         return;
                     }
-                    
+
                     // Create (modified) modGroupsList from allGroupsList that
                     // does not contain the ipmi group.
                     std::vector<std::string> modGroupsList;
 
                     for (unsigned int index = 0; index < allGroupsList->size();
-                                                                 index++)
+                         index++)
                     {
-				    	if (allGroupsList->at(index) != "ipmi") 
+                        if (allGroupsList->at(index) != "ipmi") 
                         {
                             modGroupsList.push_back(allGroupsList->at(index));
                         }
                     }
 
                     const std::vector<std::string>* pModGroupsList =
-                                                   &modGroupsList;
+                        &modGroupsList;
 
                     crow::connections::systemBus->async_method_call(
                         [asyncResp, username,

--- a/redfish-core/lib/account_service.hpp
+++ b/redfish-core/lib/account_service.hpp
@@ -2054,12 +2054,11 @@ inline void requestAccountServiceRoutes(App& app)
                     // does not contain the ipmi group.
                     std::vector<std::string> modGroupsList;
 
-                    for (unsigned int index = 0; index < allGroupsList->size();
-                         index++)
+                    for (const auto &group : *allGroupsList)
                     {
-                        if (allGroupsList->at(index) != "ipmi")
+                        if (group != "ipmi")
                         {
-                            modGroupsList.push_back(allGroupsList->at(index));
+                            modGroupsList.push_back(group);
                         }
                     }
 


### PR DESCRIPTION
The number of users was limited to 17 and redfish
logins were included in the IPMI group.

This PR prevents redfish users from being included
in the IPMI group which is limited to 15 users.

A seperate PR for phosphor-user-manager fixes the
problem that limited the total number of system
users to 15 and not the maximum of 30.
(Note the root user is not counted in the 30.)

Tested: Three IPMI users existed on the system.
A service user existed on the system. A script
was run to create 30 more redfish users.  The system
allowed the creation of 26 redfish users for a total
of 30 users.

tippolit@gfwa166:~/Code/openbmc/build/p10bmc$ curl -k -X
GET https://service:0penBmc0@ever8bmc:18080/redfish/v1
/AccountService/Accounts
{
  "@odata.id": "/redfish/v1/AccountService/Accounts",
  "@odata.type": "#ManagerAccountCollection.ManagerAccountCollection",
  "Description": "BMC User Accounts",
  "Members": [
    {
      "@odata.id": "/redfish/v1/AccountService/Accounts/UserTest5"
    },
    {
      "@odata.id": "/redfish/v1/AccountService/Accounts/UserTest19"
    },
    {
      "@odata.id": "/redfish/v1/AccountService/Accounts/UserTest18"
    },
    {
      "@odata.id": "/redfish/v1/AccountService/Accounts/UserTest22"
    },
    {
      "@odata.id": "/redfish/v1/AccountService/Accounts/UserTest20"
    },
    {
      "@odata.id": "/redfish/v1/AccountService/Accounts/UserTest12"
    },
    {
      "@odata.id": "/redfish/v1/AccountService/Accounts/UserTest21"
    },
    {
      "@odata.id": "/redfish/v1/AccountService/Accounts/UserTest1"
    },
    {
      "@odata.id": "/redfish/v1/AccountService/Accounts/UserTest25"
    },
    {
      "@odata.id": "/redfish/v1/AccountService/Accounts/admin"
    },
    {
      "@odata.id": "/redfish/v1/AccountService/Accounts/UserTest2"
    },
    {
      "@odata.id": "/redfish/v1/AccountService/Accounts/UserTest23"
    },
    {
      "@odata.id": "/redfish/v1/AccountService/Accounts/UserTest3"
    },
    {
      "@odata.id": "/redfish/v1/AccountService/Accounts/UserTest26"
    },
    {
      "@odata.id": "/redfish/v1/AccountService/Accounts/UserTest13"
    },
    {
      "@odata.id": "/redfish/v1/AccountService/Accounts/UserTest11"
    },
    {
      "@odata.id": "/redfish/v1/AccountService/Accounts/UserTest4"
    },
    {
      "@odata.id": "/redfish/v1/AccountService/Accounts/ipmi2"
    },
    {
      "@odata.id": "/redfish/v1/AccountService/Accounts/UserTest24"
    },
    {
      "@odata.id": "/redfish/v1/AccountService/Accounts/UserTest14"
    },
    {
      "@odata.id": "/redfish/v1/AccountService/Accounts/UserTest6"
    },
    {
      "@odata.id": "/redfish/v1/AccountService/Accounts/UserTest15"
    },
    {
      "@odata.id": "/redfish/v1/AccountService/Accounts/UserTest10"
    },
    {
      "@odata.id": "/redfish/v1/AccountService/Accounts/ipmi1"
    },
    {
      "@odata.id": "/redfish/v1/AccountService/Accounts/service"
    },
    {
      "@odata.id": "/redfish/v1/AccountService/Accounts/UserTest17"
    },
    {
      "@odata.id": "/redfish/v1/AccountService/Accounts/UserTest8"
    },
    {
      "@odata.id": "/redfish/v1/AccountService/Accounts/UserTest9"
    },
    {
      "@odata.id": "/redfish/v1/AccountService/Accounts/UserTest7"
    },
    {
      "@odata.id": "/redfish/v1/AccountService/Accounts/UserTest16"
    }
  ],
  "Members@odata.count": 30,
  "Name": "Accounts Collection"
}tippolit@gfwa166:~/Code/openbmc/build/p10bmc$

Signed-off-by: Tom Ippolito <thomas.ippolito@ibm.com>