### PR TITLE
LogEntry: HW-Isolation: Removed the Resolved property

### DIFF
--- a/redfish-core/include/utils/hw_isolation.hpp
+++ b/redfish-core/include/utils/hw_isolation.hpp
@@ -178,10 +178,6 @@ inline void
  * @note - This function will try to identify the hardware isolated dbus entry
  *         from associations endpoints by using the given resource dbus object
  *         of "isolated_hw_entry".
- *       - This function will use the last endpoint from the list since the
- *         HardwareIsolation manager may be used the "Resolved" dbus entry
- *         property to indicate the deisolation instead of delete
- *         the entry object.
  */
 inline void
     deisolateResource(const std::shared_ptr<bmcweb::AsyncResp>& aResp,

--- a/redfish-core/lib/log_services.hpp
+++ b/redfish-core/lib/log_services.hpp
@@ -5002,19 +5002,6 @@ inline void fillSystemHardwareIsolationLogEntry(
                         break;
                     }
                 }
-                else if (property.first == "Resolved")
-                {
-                    const bool* resolved = std::get_if<bool>(&property.second);
-                    if (resolved == nullptr)
-                    {
-                        BMCWEB_LOG_ERROR
-                            << "Failed to get the Resolved"
-                            << "from object: " << dbusObjIt->first.str;
-                        messages::internalError(asyncResp->res);
-                        break;
-                    }
-                    entryJson["Resolved"] = *resolved;
-                }
             }
         }
         else if (interface.first == "xyz.openbmc_project."


### PR DESCRIPTION
It Fixes [SW549170](https://w3.rchland.ibm.com/projects/bestquest/?defect=SW549170)

- The backend application is not going to maintain the Resolved
  D-Bus entry because the resolved hardware isolation record slot
  might be reused for the new record so it won't be accurate always.

- So, In the Redfish also, we can drop the Resolved property while
  listing the hardware isolation records.

Tested:

- Verified by listing the hardware isolation records in the Redfish.
```
curl -k -H "X-Auth-Token: $bmc_token" -X GET https://${bmc}/redfish/v1/ \
            Systems/system/LogServices/HardwareIsolation/Entries/1
{
  "@odata.id": "/redfish/v1/Systems/system/LogServices/HardwareIsolation/Entries/1",
  "@odata.type": "#LogEntry.v1_9_0.LogEntry",
  "Created": "2022-05-05T11:39:25+00:00",
  "EntryType": "Event",
  "Id": "1",
  "Links": {
    "OriginOfCondition": {
      "@odata.id": "/redfish/v1/Systems/system/Memory/dimm0"
    }
  },
  "Message": "Memory DIMM",
  "Name": "Hardware Isolation Entry",
  "Severity": "Warning"
}
```