### PR TITLE
Dump: Fix Epoch time convertion for Elapsed property

### DIFF
--- a/redfish-core/lib/log_services.hpp
+++ b/redfish-core/lib/log_services.hpp
@@ -575,7 +575,8 @@ inline void
                 thisEntry["@odata.id"] = dumpPath + entryID;
                 thisEntry["Id"] = entryID;
                 thisEntry["EntryType"] = "Event";
-                thisEntry["Created"] = crow::utility::getDateTime(timestamp);
+                thisEntry["Created"] =
+                    crow::utility::getDateTime(timestamp / 1000 / 1000);
 
                 thisEntry["AdditionalDataSizeBytes"] = size;
 


### PR DESCRIPTION
Dump D-bus entry "Elapsed" property value populated in microseconds
This commit converts microseconds to seconds to display correct timestamp

This PR Fixes SW550169

Tested By:
Get on Dump entry