### PR TITLE
SW549923: Only service user can access bmc-console/hypervisor

### DIFF
--- a/http/obmc_shell.hpp
+++ b/http/obmc_shell.hpp
@@ -179,6 +179,15 @@ inline void requestRoutes(App& app)
         .onopen([](crow::websocket::Connection& conn,
                    const std::shared_ptr<bmcweb::AsyncResp>&) {
             BMCWEB_LOG_DEBUG << "Connection " << &conn << " opened";
+
+            // TODO: this user check must be removed when WebSocket privileges
+            // work.
+            if (conn.getUserName() != "service")
+            {
+                BMCWEB_LOG_DEBUG
+                    << "only service user have access to obmc_shell";
+                conn.close("only service user have access to bmc console");
+            }
             if (auto it = mapHandler.find(&conn); it == mapHandler.end())
             {
                 auto insertData =

--- a/include/obmc_hypervisor.hpp
+++ b/include/obmc_hypervisor.hpp
@@ -122,7 +122,14 @@ inline void requestRoutes(App& app)
         .onopen([](crow::websocket::Connection& conn,
                    const std::shared_ptr<bmcweb::AsyncResp>&) {
             BMCWEB_LOG_DEBUG << "Connection " << &conn << " opened";
-
+            // TODO: this user check must be removed when WebSocket privileges
+            // work.
+            if (conn.getUserName() != "service")
+            {
+                BMCWEB_LOG_DEBUG
+                    << "only service user have access to hypervisor";
+                conn.close("only service user have access to hypervisor");
+            }
             sessions.insert(&conn);
             if (hostSocket == nullptr)
             {


### PR DESCRIPTION
https://w3.rchland.ibm.com/projects/bestquest/?defect=SW549923

bmcweb has limitations for WebSocket privilege, where none of the
current WebSocket checks for privilege before allowing users to access
WebSocket.

bmc-console need to check for a ser (privilege) before allowing a user
to access the console.

hypervisor console needs to check for a ser (privilege) before allowing
a user to access the hypervisor  console

based on the current bmcweb implementation, it is easy to check the
username for an upcoming request. So this commits checking for a
username before allowing a user to access the console. if a user's name
is "service," they can only access bmc-console.

this change is tested using the Rainier system.