### PR TITLE
MEX not Support PowerSupply FirmwareVersion

### DIFF
--- a/redfish-core/lib/power_supply.hpp
+++ b/redfish-core/lib/power_supply.hpp
@@ -62,6 +62,12 @@ inline void getPowerSupplyFirmwareVersion(
                     const std::variant<std::string> state) {
             if (ec)
             {
+                if (ec.value() == EBADR)
+                {
+                    BMCWEB_LOG_DEBUG
+                        << "PowerSupply Firmware not found, skipping";
+                    return;
+                }
                 BMCWEB_LOG_ERROR << "Can't get PowerSupply firmware version!";
                 messages::internalError(asyncResp->res);
                 return;


### PR DESCRIPTION
Mex-supported chassis does not support the power supply firmware version.
where current bmcweb code tries to retrieve that data even that interface is not supported via dbus.
adding an error check code will determine why it is failing.
if it failed because of `EBADR` then no return error in redfish API 

Tested: using the mex rainier system 

Defect: https://w3.rchland.ibm.com/projects/bestquest/?defect=SW549511