### PR TITLE
PCIe Topology: Redfish: Reset Link

### DIFF
--- a/redfish-core/lib/pcie.hpp
+++ b/redfish-core/lib/pcie.hpp
@@ -96,6 +96,7 @@ static inline void
 
 /**
  * @brief Fill PCIeDevice Status and Health based on PCIeSlot Link Status
+ *
  * @param[in,out]   resp        HTTP response.
  * @param[in]       linkStatus  PCIeSlot Link Status.
  */
@@ -143,14 +144,15 @@ static inline void fillPcieDeviceStatus(crow::Response& resp,
 }
 
 /**
- * @brief Get PCIeSlot properties.
+ * @brief Get PCIe Slot properties.
+ *
  * @param[in,out]   asyncResp       Async HTTP response.
  * @param[in]       pcieSlotPath    Object path of the PCIeSlot.
  * @param[in]       serviceMap      A map to hold Service and corresponding
  * interface list for the given cable id.
  */
 static inline void
-    getPcieSlotLinkStatus(const std::shared_ptr<bmcweb::AsyncResp>& asyncResp,
+    getPcieSlotProperties(const std::shared_ptr<bmcweb::AsyncResp>& asyncResp,
                           const std::string& pcieSlotPath,
                           const dbus::utility::MapperServiceMap& serviceMap)
 {
@@ -158,38 +160,64 @@ static inline void
     {
         for (const auto& interface : interfaces)
         {
-            if (interface != "xyz.openbmc_project.Inventory.Item.PCIeSlot")
+            if ((interface == "xyz.openbmc_project.Inventory.Item.PCIeSlot") ||
+                interface == "com.ibm.Control.Host.PCIeLink")
             {
-                continue;
+                crow::connections::systemBus->async_method_call(
+                    [asyncResp](
+                        const boost::system::error_code ec,
+                        const dbus::utility::DBusPropertiesMap& properties) {
+                        if (ec)
+                        {
+                            BMCWEB_LOG_DEBUG << "DBUS response error " << ec;
+                            messages::internalError(asyncResp->res);
+                            return;
+                        }
+                        for (const auto& [propKey, propVariant] : properties)
+                        {
+                            if (propKey == "LinkStatus")
+                            {
+                                const std::string* value =
+                                    std::get_if<std::string>(&propVariant);
+                                if (value == nullptr)
+                                {
+                                    messages::internalError(asyncResp->res);
+                                    return;
+                                }
+
+                                std::string linkStatus = *value;
+                                if (!linkStatus.empty())
+                                {
+                                    fillPcieDeviceStatus(asyncResp->res,
+                                                         linkStatus);
+                                    return;
+                                }
+                            }
+
+                            if (propKey == "linkReset")
+                            {
+                                const bool* value =
+                                    std::get_if<bool>(&propVariant);
+                                if (value == nullptr)
+                                {
+                                    messages::internalError(asyncResp->res);
+                                    return;
+                                }
+
+                                asyncResp->res
+                                    .jsonValue["Oem"]["IBM"]["LinkReset"] =
+                                    *value;
+                                asyncResp->res.jsonValue["Oem"]["@odata.type"] =
+                                    "#OemPCIeDevice.Oem";
+                                asyncResp->res
+                                    .jsonValue["Oem"]["IBM"]["@odata.type"] =
+                                    "#OemPCIeDevice.IBM";
+                            }
+                        }
+                    },
+                    service, pcieSlotPath, "org.freedesktop.DBus.Properties",
+                    "GetAll", interface);
             }
-
-            crow::connections::systemBus->async_method_call(
-                [asyncResp](const boost::system::error_code ec,
-                            const dbus::utility::DbusVariantType& property) {
-                    if (ec)
-                    {
-                        BMCWEB_LOG_DEBUG << "DBUS response error " << ec;
-                        messages::internalError(asyncResp->res);
-                        return;
-                    }
-
-                    const std::string* value =
-                        std::get_if<std::string>(&property);
-                    if (value == nullptr)
-                    {
-                        messages::internalError(asyncResp->res);
-                        return;
-                    }
-
-                    std::string linkStatus = *value;
-                    if (!linkStatus.empty())
-                    {
-                        fillPcieDeviceStatus(asyncResp->res, linkStatus);
-                        return;
-                    }
-                },
-                service, pcieSlotPath, "org.freedesktop.DBus.Properties", "Get",
-                interface, "LinkStatus");
         }
     }
 }
@@ -199,15 +227,18 @@ static inline void
  * @param[in,out]   asyncResp       Async HTTP response.
  * @param[in]       pcieSlotPath    Object path of the PCIeSlot.
  * @param[in]       pcieDevice      PCIe device name/ID.
+ * @param[in]       callback        Callback method.
  */
+template <typename Callback>
 static inline void
-    getPcieSlotSubTree(const std::shared_ptr<bmcweb::AsyncResp>& asyncResp,
-                       const std::string& pcieSlotPath,
-                       const std::string& pcieDevice)
+    findPcieSlotServiceMap(const std::shared_ptr<bmcweb::AsyncResp>& asyncResp,
+                           const std::string& pcieSlotPath,
+                           const std::string& pcieDevice, Callback&& callback)
 {
-    auto respHandler = [asyncResp, pcieSlotPath,
-                        pcieDevice](const boost::system::error_code ec,
-                                    const MapperGetSubTreeResponse& subTree) {
+    auto respHandler = [asyncResp, pcieSlotPath, pcieDevice,
+                        callback{std::move(callback)}](
+                           const boost::system::error_code ec,
+                           const MapperGetSubTreeResponse& subTree) {
         if (ec)
         {
             BMCWEB_LOG_ERROR << "DBUS response error on GetSubTree"
@@ -236,7 +267,7 @@ static inline void
                 continue;
             }
 
-            getPcieSlotLinkStatus(asyncResp, pcieSlotPath, serviceMap);
+            callback(pcieSlotPath, serviceMap);
             return;
         }
         BMCWEB_LOG_ERROR << "PCIe Slot not found for " << pcieDevice;
@@ -251,15 +282,18 @@ static inline void
 }
 
 /**
- * @brief Main method for adding Link Status to the requested device
- * @param[in,out]   asyncResp       Async HTTP response.
- * @param[in]       pcieDevice      PCIe device name/ID.
+ * @brief Helper method to find the PCIe slot path
+ *
+ * @param[in,out]   asyncResp   Async HTTP response.
+ * @param[in]       pcieDevice  PCIe device name/ID.
+ * @param[in]       callback    Callback method.
  */
-static inline void addLinkStatusToPcieDevice(
-    const std::shared_ptr<bmcweb::AsyncResp>& asyncResp,
-    const std::string& pcieDevice)
+template <typename Callback>
+inline void
+    findPcieSlotPath(const std::shared_ptr<bmcweb::AsyncResp>& asyncResp,
+                     const std::string& pcieDevice, Callback&& callback)
 {
-    auto respHandler = [asyncResp, pcieDevice](
+    auto respHandler = [asyncResp, pcieDevice, callback{std::move(callback)}](
                            const boost::system::error_code ec,
                            const MapperGetSubTreePathsResponse& subTreePaths) {
         if (ec)
@@ -279,7 +313,8 @@ static inline void addLinkStatusToPcieDevice(
 
             std::string pcieSlotPath = path.parent_path();
 
-            getPcieSlotSubTree(asyncResp, pcieSlotPath, pcieDevice);
+            findPcieSlotServiceMap(asyncResp, pcieSlotPath, pcieDevice,
+                                   std::move(callback));
             break;
         }
     };
@@ -290,6 +325,87 @@ static inline void addLinkStatusToPcieDevice(
         "xyz.openbmc_project.ObjectMapper", "GetSubTreePaths",
         "/xyz/openbmc_project/inventory", 0,
         std::array<const char*, 1>{pcieDeviceInterface});
+}
+
+/**
+ * @brief Add link status and health property to PCIe device
+ *
+ * @param[in, out]  asyncResp   Async HTTP response.
+ * @param[in]       pcieDevice  PCIe device name/ID.
+ */
+inline void addLinkStatusToPcieDevice(
+    const std::shared_ptr<bmcweb::AsyncResp>& asyncResp,
+    const std::string& pcieDevice)
+{
+    auto linkStatus =
+        [asyncResp](const std::string& pcieSlotPath,
+                    const dbus::utility::MapperServiceMap& serviceMap) {
+            getPcieSlotProperties(asyncResp, pcieSlotPath, serviceMap);
+        };
+
+    findPcieSlotPath(asyncResp, pcieDevice, std::move(linkStatus));
+}
+
+/**
+ * @brief Set linkReset property
+ *
+ * @param[in, out]  asyncResp       Async HTTP response.
+ * @param[in]       pcieSlotPath    PCIe slot path.
+ * @param[in]       serviceMap      A map to hold Service and corresponding
+ * interface list for the given cable id.
+ * @param[in]       linkReset       Flag to reset.
+ */
+inline void handleLinkReset(const std::shared_ptr<bmcweb::AsyncResp>& asyncResp,
+                            const std::string& pcieSlotPath,
+                            const dbus::utility::MapperServiceMap& serviceMap,
+                            const bool& linkReset)
+{
+    for (const auto& [service, interfaces] : serviceMap)
+    {
+        for (const auto& interface : interfaces)
+        {
+            if (interface != "com.ibm.Control.Host.PCIeLink")
+            {
+                continue;
+            }
+
+            crow::connections::systemBus->async_method_call(
+                [asyncResp, pcieSlotPath, interface,
+                 linkReset](const boost::system::error_code ec) {
+                    if (ec)
+                    {
+                        BMCWEB_LOG_ERROR << "D-Bus responses error: " << ec;
+                        messages::internalError(asyncResp->res);
+                        return;
+                    }
+                    BMCWEB_LOG_DEBUG << "linkReset property set to: "
+                                     << (linkReset ? "true" : "false");
+                    return;
+                },
+                service, pcieSlotPath, "org.freedesktop.DBus.Properties", "Set",
+                interface, "linkReset", std::variant<bool>{linkReset});
+        }
+    }
+}
+
+/**
+ * @brief Api to reset link
+ *
+ * @param[in, out]  asyncResp   Async HTTP response.
+ * @param[in]       pcieDevice  PCIe device name/ID.
+ * @param[in]       linkReset   Flag to reset.
+ */
+inline void
+    pcieSlotLinkReset(const std::shared_ptr<bmcweb::AsyncResp>& asyncResp,
+                      const std::string& pcieDevice, const bool& linkReset)
+{
+    auto reset = [asyncResp, linkReset](
+                     const std::string& pcieSlotPath,
+                     const dbus::utility::MapperServiceMap& serviceMap) {
+        handleLinkReset(asyncResp, pcieSlotPath, serviceMap, linkReset);
+    };
+
+    findPcieSlotPath(asyncResp, pcieDevice, std::move(reset));
 }
 
 inline void requestRoutesSystemPCIeDeviceCollection(App& app)
@@ -480,6 +596,40 @@ inline void requestRoutesSystemPCIeDevice(App& app)
                     messages::resourceNotFound(asyncResp->res, "PCIeDevice",
                                                device);
                     return;
+                }
+            });
+
+    BMCWEB_ROUTE(app, "/redfish/v1/Systems/system/PCIeDevices/<str>/")
+        .privileges(redfish::privileges::patchPCIeDevice)
+        .methods(boost::beast::http::verb::patch)(
+            [](const crow::Request& req,
+               const std::shared_ptr<bmcweb::AsyncResp>& asyncResp,
+               const std::string& device) {
+                std::optional<nlohmann::json> oem;
+                if (!json_util::readJson(req, asyncResp->res, "Oem", oem))
+                {
+                    return;
+                }
+
+                if (oem)
+                {
+                    std::optional<nlohmann::json> ibmOem;
+                    if (!redfish::json_util::readJson(*oem, asyncResp->res,
+                                                      "IBM", ibmOem))
+                    {
+                        return;
+                    }
+
+                    if (ibmOem)
+                    {
+                        std::optional<bool> linkReset;
+                        if (!json_util::readJson(*ibmOem, asyncResp->res,
+                                                 "LinkReset", linkReset))
+                        {
+                            return;
+                        }
+                        pcieSlotLinkReset(asyncResp, device, *linkReset);
+                    }
                 }
             });
 }

--- a/scripts/update_schemas.py
+++ b/scripts/update_schemas.py
@@ -212,6 +212,14 @@ with open(metadata_index_path, 'w') as metadata_index:
         "        <edmx:Include Namespace=\"OemChassis.v1_0_0\"/>\n")
     metadata_index.write("    </edmx:Reference>\n")
 
+    metadata_index.write(
+        "       <edmx:Reference Uri=\""
+        "/redfish/v1/schema/OemPCIeDevice_v1.xml\">\n")
+    metadata_index.write(
+        "        <edmx:Include Namespace=\"OemPCIeDevice\"/>\n")
+    metadata_index.write(
+        "        <edmx:Include Namespace=\"OemCPCIeDevice.v1_0_0\"/>\n")
+    metadata_index.write("    </edmx:Reference>\n")
     metadata_index.write("</edmx:Edmx>\n")
 
 schema_files = {}

--- a/static/redfish/v1/$metadata/index.xml
+++ b/static/redfish/v1/$metadata/index.xml
@@ -3762,4 +3762,8 @@
         <edmx:Include Namespace="OemChassis"/>
         <edmx:Include Namespace="OemChassis.v1_0_0"/>
     </edmx:Reference>
+    <edmx:Reference Uri="/redfish/v1/schema/OemPCIeDevice_v1.xml">
+        <edmx:Include Namespace="OemPCIeDevice"/>
+        <edmx:Include Namespace="OemPCIeDevice.v1_0_0"/>
+    </edmx:Reference>
 </edmx:Edmx>

--- a/static/redfish/v1/JsonSchemas/OemPCIeDevice/index.json
+++ b/static/redfish/v1/JsonSchemas/OemPCIeDevice/index.json
@@ -1,0 +1,69 @@
+{
+    "$id": "http://redfish.dmtf.org/schemas/v1/OemPCIeDevice.json",
+    "$schema": "http://redfish.dmtf.org/schemas/v1/redfish-schema-v1.json",
+    "copyright": "Copyright 2014-2019 DMTF. For the full DMTF copyright policy, see http://www.dmtf.org/about/policies/copyright",
+    "definitions": {
+        "Oem": {
+            "additionalProperties": true,
+            "description": "OemPCIeDevice Oem properties.",
+            "patternProperties": {
+                "^([a-zA-Z_][a-zA-Z0-9_]*)?@(odata|Redfish|Message)\\.[a-zA-Z_][a-zA-Z0-9_]*$": {
+                    "description": "This property shall specify a valid odata or Redfish property.",
+                    "type": [
+                        "array",
+                        "boolean",
+                        "integer",
+                        "number",
+                        "null",
+                        "object",
+                        "string"
+                    ]
+                }
+            },
+            "properties": {
+                "IBM": {
+                    "anyOf": [
+                        {
+                            "$ref": "#/definitions/IBM"
+                        },
+                        {
+                            "type": "null"
+                        }
+                    ]
+                }
+
+            },
+            "type": "object"
+        },
+        "IBM": {
+            "additionalProperties": true,
+            "description": "Oem properties for IBM.",
+            "patternProperties": {
+                "^([a-zA-Z_][a-zA-Z0-9_]*)?@(odata|Redfish|Message)\\.[a-zA-Z_][a-zA-Z0-9_]*$": {
+                    "description": "This property shall specify a valid odata or Redfish property.",
+                    "type": [
+                        "array",
+                        "boolean",
+                        "integer",
+                        "number",
+                        "null",
+                        "object",
+                        "string"
+                    ]
+                }
+            },
+            "properties": {
+                "LinkReset": {
+                    "description": "Reset the PCIe Link",
+                    "longDescription": "A true value resets the PCIe Link.",
+                    "readonly": false,
+                    "type": "boolean"
+                }
+            },
+            "type": "object"
+        }
+    },
+    "owningEntity": "IBM",
+    "release": "1.0",
+    "title": "#OemPCIeDevice"
+}

--- a/static/redfish/v1/schema/OemPCIeDevice_v1.xml
+++ b/static/redfish/v1/schema/OemPCIeDevice_v1.xml
@@ -1,0 +1,52 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<edmx:Edmx xmlns:edmx="http://docs.oasis-open.org/odata/ns/edmx" Version="4.0">
+
+  <edmx:Reference Uri="http://docs.oasis-open.org/odata/odata/v4.0/errata03/csd01/complete/vocabularies/Org.OData.Core.V1.xml">
+    <edmx:Include Namespace="Org.OData.Core.V1" Alias="OData"/>
+  </edmx:Reference>
+  <edmx:Reference Uri="http://docs.oasis-open.org/odata/odata/v4.0/errata03/csd01/complete/vocabularies/Org.OData.Measures.V1.xml">
+    <edmx:Include Namespace="Org.OData.Measures.V1" Alias="Measures"/>
+  </edmx:Reference>
+  <edmx:Reference Uri="http://redfish.dmtf.org/schemas/v1/RedfishExtensions_v1.xml">
+    <edmx:Include Namespace="RedfishExtensions.v1_0_0" Alias="Redfish"/>
+  </edmx:Reference>
+    <edmx:Reference Uri="http://redfish.dmtf.org/schemas/v1/PCIeDevice_v1.xml">
+        <edmx:Include Namespace="PCIeDevice"/>
+        <edmx:Include Namespace="PCIeDevice.v1_9_0"/>
+    </edmx:Reference>
+  <edmx:Reference Uri="http://redfish.dmtf.org/schemas/v1/Resource_v1.xml">
+    <edmx:Include Namespace="Resource"/>
+    <edmx:Include Namespace="Resource.v1_0_0"/>
+  </edmx:Reference>
+
+  <edmx:DataServices>
+    <Schema xmlns="http://docs.oasis-open.org/odata/ns/edm" Namespace="OemPCIeDevice">
+      <Annotation Term="Redfish.OwningEntity" String="IBM"/>
+    </Schema>
+
+    <Schema xmlns="http://docs.oasis-open.org/odata/ns/edm" Namespace="OemPCIeDevice.v1_0_0">
+      <Annotation Term="Redfish.OwningEntity" String="IBM"/>
+
+      <ComplexType Name="Oem" BaseType="Resource.OemObject">
+        <Annotation Term="OData.AdditionalProperties" Bool="true"/>
+        <Annotation Term="OData.Description" String="OemPCIeDevice Oem properties."/>
+        <Annotation Term="OData.AutoExpand"/>
+        <Property Name="IBM" Type="OemPCIeDevice.IBM"/>
+      </ComplexType>
+
+      <ComplexType Name="IBM" BaseType="Resource.OemObject">
+        <Annotation Term="OData.AdditionalProperties" Bool="true" />
+        <Annotation Term="OData.Description" String="Oem properties for IBM." />
+        <Annotation Term="OData.AutoExpand"/>
+
+        <Property Name="LinkReset" Type="OemPCIeDevice.IBM">
+          <Annotation Term="OData.Permissions" EnumMember="OData.Permission/ReadWrite"/>
+          <Annotation Term="OData.Description" String="Reset the PCIe Link"/>
+          <Annotation Term="OData.LongDescription" String="A true value resets the PCIe Link."/>
+        </Property>
+      </ComplexType>
+
+    </Schema>
+
+  </edmx:DataServices>
+</edmx:Edmx>


### PR DESCRIPTION
This commit sets linkReset property to the requested value

This is downstream change only

Issue:
https://github.com/ibm-openbmc/dev/issues/3551

Redfish Validator: Passed

Testing:
Set LinkReset to 'true' using PATCH API, and verified the property using GET API
$ curl -k -X PATCH https://service:passwd@host:18080\
/redfish/v1/Systems/system/PCIeDevices/pcie_card0 -d '{"Oem": {"IBM": {"LinkReset": true}}}'

$ curl -k -X GET https://service:passwd@host:18080/redfish/v1/Systems/system/PCIeDevices/pcie_card0
{
  "@odata.id": "/redfish/v1/Systems/system/PCIeDevices/pcie_card0",
  "@odata.type": "#PCIeDevice.v1_9_0.PCIeDevice",
  "Id": "pcie_card0",
  "Manufacturer": "",
  "Name": "PCIe Cable Card",
  "Oem": {
    "@odata.type": "#OemPCIeDevice.Oem",
    "IBM": {
      "@odata.type": "#OemPCIeDevice.IBM",
      "LinkReset": true
    }
  },
...
  "Status": {
    "Health": "OK",
    "State": "Enabled"
  }
}

Signed-off-by: Shantappa Teekappanavar <sbteeks@yahoo.com>