### PR TITLE
DumpOffload: Avoid reset OffloadUri on dump offload success

### DIFF
--- a/http/http_stream.hpp
+++ b/http/http_stream.hpp
@@ -32,6 +32,7 @@ struct Connection : std::enable_shared_from_this<Connection>
 
     crow::Request req;
     crow::DynamicResponse streamres;
+    bool completionStatus = false;
 };
 
 template <typename Adaptor>
@@ -42,7 +43,7 @@ class ConnectionImpl : public Connection
                    std::function<void(Connection&)> openHandler,
                    std::function<void(Connection&, const std::string&, bool)>
                        messageHandler,
-                   std::function<void(Connection&)> closeHandler,
+                   std::function<void(Connection&, bool&)> closeHandler,
                    std::function<void(Connection&)> errorHandler) :
 
         Connection(reqIn),
@@ -128,7 +129,7 @@ class ConnectionImpl : public Connection
     {
         streamres.end();
         boost::beast::get_lowest_layer(adaptor).close();
-        closeHandler(*this);
+        closeHandler(*this, completionStatus);
     }
 
     void doWrite()
@@ -155,7 +156,7 @@ class ConnectionImpl : public Connection
     bool doingWrite = false;
     std::function<void(Connection&)> openHandler;
     std::function<void(Connection&, const std::string&, bool)> messageHandler;
-    std::function<void(Connection&)> closeHandler;
+    std::function<void(Connection&, bool&)> closeHandler;
     std::function<void(Connection&)> errorHandler;
     std::function<void()> handlerFunc;
     crow::Request req;

--- a/http/routing.hpp
+++ b/http/routing.hpp
@@ -484,7 +484,8 @@ class StreamingResponseRule : public BaseRule
     std::function<void(crow::streaming_response::Connection&,
                        const std::string&, bool)>
         messageHandler;
-    std::function<void(crow::streaming_response::Connection&)> closeHandler;
+    std::function<void(crow::streaming_response::Connection&, bool&)>
+        closeHandler;
     std::function<void(crow::streaming_response::Connection&)> errorHandler;
 };
 


### PR DESCRIPTION
As per design, pldm needs to reset OffloadURI while handling FileAck
after dump offload completed for resource and system dumps
for other dumps dump manager handles.

bmcweb still needs to reset OffloadUri on dump offload failure cases.
This is applies to all dump including BMC stored host dump and BMC dump 

This PR fixes SW548188 which is already MUST FIX approved


Tested by:
1.Few iterations of Offload system dump
2.Abruptly close connection while dump offloading
Note: