### PR TITLE
Increase bmcweb automatic restart

### DIFF
--- a/bmcweb.service.in
+++ b/bmcweb.service.in
@@ -1,5 +1,7 @@
 [Unit]
 Description=Start bmcweb server
+StartLimitIntervalSec=20
+StartLimitBurst=5
 
 Wants=network.target
 After=network.target
@@ -13,8 +15,6 @@ ExecReload=kill -s HUP $MAINPID
 ExecStart=@MESON_INSTALL_PREFIX@/bin/bmcweb
 Type=simple
 WorkingDirectory=/home/root
-StartLimitInterval=15
-StartLimitBurst=5
 
 [Install]
 WantedBy=network.target

--- a/bmcweb.service.in
+++ b/bmcweb.service.in
@@ -13,6 +13,8 @@ ExecReload=kill -s HUP $MAINPID
 ExecStart=@MESON_INSTALL_PREFIX@/bin/bmcweb
 Type=simple
 WorkingDirectory=/home/root
+StartLimitInterval=15
+StartLimitBurst=5
 
 [Install]
 WantedBy=network.target

--- a/bmcweb.service.in
+++ b/bmcweb.service.in
@@ -1,7 +1,7 @@
 [Unit]
 Description=Start bmcweb server
-StartLimitIntervalSec=20
-StartLimitBurst=5
+StartLimitIntervalSec=30
+StartLimitBurst=4
 
 Wants=network.target
 After=network.target


### PR DESCRIPTION
Defect: https://w3.rchland.ibm.com/projects/bestquest/?defect=SW550081
Currently our systemd service are automatically restarted on failure a
max of 2 times over 30 seconds. I.e. our current settings are:
StartLimitIntervalSec=30
StartLimitBurst=2

Done via https://gerrit.openbmc-project.xyz/c/openbmc/openbmc/+/8400

Certificate manager restarts bmcweb when a new certificate is uploaded,
we have seen this happen 3 times in a 30 second period.
Allow bmcweb to be restarted 4 times over a 30 second period before
stopping. I.e. 
StartLimitIntervalSec=30
StartLimitBurst=4

This is a short term fix, the long term fix is Certificate manager will
throttle how often it restarts bmcweb or bmcweb doesn't require a restart.
Since bmcweb is critical to our operations, we are also okay with more retries.

Tested: 
Added an abort() to the Systems collection resource (could have picked any interface but choose /redfish/v1/Systems). I wanted to see that bmcweb could "make it up, start responding, then crash" *5 times, all in the 15-second window. My concern was like a stale event coming up and causing bmcweb to core, I still wanted to make sure this could happen 5 times in 15 seconds so bmcweb wouldn't just continue to core.
 
bmcweb crashed 5 times due to calling /redfish/v1/Systems and systemd put it in a failed state


```
May 16 17:15:02 perfrain86bmctest phosphor-dump-manager[439]: Error occurred during the read, errno(9)
May 16 17:15:02 perfrain86bmctest phosphor-dump-manager[439]: The operation failed internally.
May 16 17:15:02 perfrain86bmctest systemd[1]: systemd-journald.service: Sent signal SIGRTMIN+1 to main process 230 (systemd-journal) on client request.
May 16 17:15:02 perfrain86bmctest phosphor-dump-manager[1888]: performing dump compression /tmp/BMCDUMP.139F0B0.00000007.20220516171453
May 16 17:15:02 perfrain86bmctest phosphor-dump-manager[1888]: Adding Dump Header :/usr/share/dreport.d/include.d/gendumpheader
May 16 17:15:02 perfrain86bmctest systemd-coredump[1720]: Process 1682 (bmcweb) of user 0 dumped core.
May 16 17:15:02 perfrain86bmctest systemd[1]: bmcweb.service: Main process exited, code=dumped, status=6/ABRT
May 16 17:15:02 perfrain86bmctest systemd[1]: bmcweb.service: Failed with result 'core-dump'. <- **core dump 1** 
May 16 17:15:02 perfrain86bmctest systemd[1]: systemd-coredump@4-1716-0.service: Deactivated successfully.
May 16 17:15:03 perfrain86bmctest phosphor-dump-manager[1735]: Mon May 16 17:15:03 UTC 2022 Report is available in /var/lib/phosphor-debug-collector/dumps/6
May 16 17:15:03 perfrain86bmctest phosphor-dump-manager[1339]: Mon May 16 17:15:03 UTC 2022 Successfully completed
May 16 17:15:03 perfrain86bmctest systemd[1]: Started Start bmcweb server.
May 16 17:15:04 perfrain86bmctest bmcweb[1970]: pam_succeed_if(webserver:auth): requirement "user ingroup redfish" was met by user "service"
May 16 17:15:04 perfrain86bmctest systemd[1]: Started Process Core Dump (PID 1974/UID 0).
May 16 17:15:04 perfrain86bmctest systemd-coredump[1975]: Process 1970 (bmcweb) of user 0 dumped core.
May 16 17:15:04 perfrain86bmctest systemd[1]: bmcweb.service: Main process exited, code=dumped, status=6/ABRT
May 16 17:15:04 perfrain86bmctest systemd[1]: bmcweb.service: Failed with result 'core-dump'.  <- **core dump 2** 
May 16 17:15:04 perfrain86bmctest systemd[1]: systemd-coredump@5-1974-0.service: Deactivated successfully.
May 16 17:15:05 perfrain86bmctest systemd[1]: Started Start bmcweb server.
May 16 17:15:06 perfrain86bmctest bmcweb[1980]: pam_succeed_if(webserver:auth): requirement "user ingroup redfish" was met by user "service"
May 16 17:15:06 perfrain86bmctest systemd[1]: Started Process Core Dump (PID 1984/UID 0).
May 16 17:15:06 perfrain86bmctest systemd-coredump[1985]: Process 1980 (bmcweb) of user 0 dumped core.
May 16 17:15:06 perfrain86bmctest systemd[1]: bmcweb.service: Main process exited, code=dumped, status=6/ABRT
May 16 17:15:06 perfrain86bmctest systemd[1]: bmcweb.service: Failed with result 'core-dump'. <- **core dump 3** 
May 16 17:15:06 perfrain86bmctest systemd[1]: systemd-coredump@6-1984-0.service: Deactivated successfully.
May 16 17:15:07 perfrain86bmctest systemd[1]: Started Start bmcweb server.
May 16 17:15:07 perfrain86bmctest phosphor-dump-manager[1888]: Mon May 16 17:15:07 UTC 2022 Report is available in /var/lib/phosphor-debug-collector/dumps/7
May 16 17:15:07 perfrain86bmctest phosphor-dump-manager[1634]: Mon May 16 17:15:07 UTC 2022 Successfully completed
May 16 17:15:07 perfrain86bmctest bmcweb[1990]: pam_succeed_if(webserver:auth): requirement "user ingroup redfish" was met by user "service"
May 16 17:15:07 perfrain86bmctest systemd[1]: Started Process Core Dump (PID 2000/UID 0).
May 16 17:15:08 perfrain86bmctest systemd-coredump[2001]: Process 1990 (bmcweb) of user 0 dumped core.
May 16 17:15:08 perfrain86bmctest systemd[1]: bmcweb.service: Main process exited, code=dumped, status=6/ABRT
May 16 17:15:08 perfrain86bmctest systemd[1]: bmcweb.service: Failed with result 'core-dump'.  <- **core dump 4** 
May 16 17:15:08 perfrain86bmctest systemd[1]: systemd-coredump@7-2000-0.service: Deactivated successfully.
May 16 17:15:09 perfrain86bmctest systemd[1]: Started Start bmcweb server.
May 16 17:15:09 perfrain86bmctest bmcweb[2006]: pam_succeed_if(webserver:auth): requirement "user ingroup redfish" was met by user "service"
May 16 17:15:09 perfrain86bmctest systemd[1]: Started Process Core Dump (PID 2010/UID 0).
May 16 17:15:10 perfrain86bmctest systemd-coredump[2011]: Process 2006 (bmcweb) of user 0 dumped core.
May 16 17:15:10 perfrain86bmctest systemd[1]: bmcweb.service: Main process exited, code=dumped, status=6/ABRT
May 16 17:15:10 perfrain86bmctest systemd[1]: bmcweb.service: Failed with result 'core-dump'. <- **core dump 5** 
May 16 17:15:10 perfrain86bmctest systemd[1]: systemd-coredump@8-2010-0.service: Deactivated successfully.
May 16 17:15:11 perfrain86bmctest systemd[1]: Started Start bmcweb server.
May 16 17:15:11 perfrain86bmctest bmcweb[2016]: pam_succeed_if(webserver:auth): requirement "user ingroup redfish" was met by user "service"
May 16 17:15:11 perfrain86bmctest systemd[1]: Started Process Core Dump (PID 2020/UID 0).
May 16 17:15:12 perfrain86bmctest phosphor-log-manager[322]: Checking dump status failed: sd_bus_call: org.freedesktop.DBus.Error.Timeout: Connection timed out
May 16 17:15:12 perfrain86bmctest phosphor-log-manager[322]: Created PEL 0x50011e5a (BMC ID 465) with SRC BD8D1002
May 16 17:15:12 perfrain86bmctest ibm-panel[611]: sd_bus_call: org.freedesktop.DBus.Error.ServiceUnknown: The name is not activatableResolution is empty for PEL = /xyz/openbmc_project/logging/entry/465
May 16 17:15:14 perfrain86bmctest systemd-coredump[2021]: Process 2016 (bmcweb) of user 0 dumped core.
May 16 17:15:14 perfrain86bmctest systemd[1]: bmcweb.service: Main process exited, code=dumped, status=6/ABRT
May 16 17:15:14 perfrain86bmctest systemd[1]: bmcweb.service: Failed with result 'core-dump'. 
May 16 17:15:14 perfrain86bmctest systemd[1]: systemd-coredump@9-2020-0.service: Deactivated successfully.
May 16 17:15:14 perfrain86bmctest systemd[1]: bmcweb.service: Start request repeated too quickly. <- Limit reached
May 16 17:15:14 perfrain86bmctest systemd[1]: bmcweb.service: Failed with result 'core-dump'. 
May 16 17:15:14 perfrain86bmctest systemd[1]: Failed to start Start bmcweb server.
May 16 17:15:14 perfrain86bmctest phosphor-systemd-target-monitor[482]: Monitored systemd service has hit an error, unit:bmcweb.service, result:failed
May 16 17:15:14 perfrain86bmctest systemd[1]: bmcweb.socket: Failed with result 'service-start-limit-hit'.
May 16 17:15:14 perfrain86bmctest phosphor-dump-manager[439]: User initiated dump started, setting flag
May 16 17:15:14 perfrain86bmctest phosphor-dump-manager[439]: GeneratorId is not provided. Replacing the string with null
May 16 17:15:15 perfrain86bmctest systemd[1]: Reached target BMC Quiesce Target.
May 16 17:15:15 perfrain86bmctest phosphor-bmc-state-manager[497]: BMC has entered BMC_QUIESCED state
May 16 17:15:15 perfrain86bmctest phosphor-bmc-state-manager[497]: Setting the BMCState field to xyz.openbmc_project.State.BMC.BMCState.Quiesced
May 16 17:15:15 perfrain86bmctest phosphor-log-manager[322]: Created PEL 0x50011e5b (BMC ID 466) with SRC BD8D3404
May 16 17:15:15 perfrain86bmctest phosphor-ledmanager[492]: SAI: FRU path: /xyz/openbmc_project/inventory/system
May 16 17:15:24 perfrain86bmctest phosphor-dump-manager[2456]: performing dump compression /tmp/BMCDUMP.139F0B0.00000009.20220516171512
May 16 17:15:24 perfrain86bmctest phosphor-dump-manager[2464]: performing dump compression /tmp/BMCDUMP.139F0B0.00000010.20220516171512
May 16 17:15:24 perfrain86bmctest phosphor-dump-manager[2472]: performing dump compression /tmp/BMCDUMP.139F0B0.00000011.20220516171512
May 16 17:15:25 perfrain86bmctest phosphor-dump-manager[2456]: Adding Dump Header :/usr/share/dreport.d/include.d/gendumpheader
May 16 17:15:25 perfrain86bmctest phosphor-dump-manager[2472]: Adding Dump Header :/usr/share/dreport.d/include.d/gendumpheader
May 16 17:15:25 perfrain86bmctest phosphor-dump-manager[2464]: Adding Dump Header :/usr/share/dreport.d/include.d/gendumpheader
May 16 17:15:27 perfrain86bmctest phosphor-dump-manager[2824]: performing dump compression /tmp/BMCDUMP.139F0B0.00000012.20220516171514
May 16 17:15:28 perfrain86bmctest phosphor-dump-manager[2824]: Adding Dump Header :/usr/share/dreport.d/include.d/gendumpheader
May 16 17:15:28 perfrain86bmctest phosphor-dump-manager[2853]: performing dump compression /tmp/BMCDUMP.139F0B0.00000008.20220516171512
May 16 17:15:29 perfrain86bmctest systemd[1]: phosphor-fan-control@0.service: Sent signal SIGUSR1 to main process 309 (phosphor-fan-co) on client request.
May 16 17:15:30 perfrain86bmctest phosphor-dump-manager[2853]: Adding Dump Header :/usr/share/dreport.d/include.d/gendumpheader
May 16 17:15:34 perfrain86bmctest pldmd[665]: Received SIGUR1(10) Signal interrupt
May 16 17:15:38 perfrain86bmctest phosphor-dump-manager[2472]: Mon May 16 17:15:38 UTC 2022 Report is available in /var/lib/phosphor-debug-collector/dumps/11
May 16 17:15:38 perfrain86bmctest phosphor-dump-manager[2026]: Mon May 16 17:15:38 UTC 2022 Successfully completed
May 16 17:15:38 perfrain86bmctest phosphor-dump-manager[2456]: Mon May 16 17:15:38 UTC 2022 Report is available in /var/lib/phosphor-debug-collector/dumps/9
May 16 17:15:38 perfrain86bmctest phosphor-dump-manager[2023]: Mon May 16 17:15:38 UTC 2022 Successfully completed
May 16 17:15:38 perfrain86bmctest phosphor-dump-manager[2464]: Mon May 16 17:15:38 UTC 2022 Report is available in /var/lib/phosphor-debug-collector/dumps/10
May 16 17:15:38 perfrain86bmctest phosphor-dump-manager[2024]: Mon May 16 17:15:38 UTC 2022 Successfully completed
May 16 17:15:39 perfrain86bmctest phosphor-dump-manager[2824]: Mon May 16 17:15:39 UTC 2022 Report is available in /var/lib/phosphor-debug-collector/dumps/12
May 16 17:15:39 perfrain86bmctest phosphor-dump-manager[2138]: Mon May 16 17:15:39 UTC 2022 Successfully completed
May 16 17:15:39 perfrain86bmctest phosphor-dump-manager[2853]: Mon May 16 17:15:39 UTC 2022 Report is available in /var/lib/phosphor-debug-collector/dumps/8
May 16 17:15:39 perfrain86bmctest phosphor-dump-manager[2022]: Mon May 16 17:15:39 UTC 2022 Successfully completed
May 16 17:15:44 perfrain86bmctest phosphor-dump-manager[3153]: performing dump compression /tmp/BMCDUMP.139F0B0.00000013.20220516171515
May 16 17:15:45 perfrain86bmctest phosphor-dump-manager[3153]: Adding Dump Header :/usr/share/dreport.d/include.d/gendumpheader
May 16 17:15:49 perfrain86bmctest phosphor-dump-manager[3153]: Mon May 16 17:15:49 UTC 2022 Report is available in /var/lib/phosphor-debug-collector/dumps/13
May 16 17:15:49 perfrain86bmctest phosphor-dump-manager[2168]: Mon May 16 17:15:49 UTC 2022 Successfully completed
May 16 17:15:49 perfrain86bmctest phosphor-dump-manager[439]: User initiated dump completed, resetting flag

```

```
systemctl status bmcweb
× bmcweb.service - Start bmcweb server
     Loaded: loaded (/lib/systemd/system/bmcweb.service; enabled; vendor preset: enabled)
     Active: failed (Result: core-dump) since Mon 2022-05-16 17:15:14 UTC; 6min ago
TriggeredBy: × bmcweb.socket
    Process: 2016 ExecStart=/usr/bin/bmcweb (code=dumped, signal=ABRT)
   Main PID: 2016 (code=dumped, signal=ABRT)

May 16 17:15:11 perfrain86bmctest systemd[1]: Started Start bmcweb server.
May 16 17:15:11 perfrain86bmctest bmcweb[2016]: pam_succeed_if(webserver:auth): requirement "user ingroup redfish" was…service"
May 16 17:15:14 perfrain86bmctest systemd[1]: bmcweb.service: Main process exited, code=dumped, status=6/ABRT
May 16 17:15:14 perfrain86bmctest systemd[1]: bmcweb.service: Failed with result 'core-dump'.
May 16 17:15:14 perfrain86bmctest systemd[1]: bmcweb.service: Start request repeated too quickly.
May 16 17:15:14 perfrain86bmctest systemd[1]: bmcweb.service: Failed with result 'core-dump'.
May 16 17:15:14 perfrain86bmctest systemd[1]: Failed to start Start bmcweb server.
Hint: Some lines were ellipsized, use -l to show in full.
```

My simple script I used to test: 
```
# /bin/bash
bmc=service:yyy@zzzzz

for i in {1..100}
do
   echo "$i time:"
   curl -k https://$bmc/redfish/v1/Systems
   sleep .25
done
```

My bmcweb code to cause the core: 
```
git diff
diff --git a/redfish-core/lib/systems.hpp b/redfish-core/lib/systems.hpp
index 35ed2418..3de608ac 100644
--- a/redfish-core/lib/systems.hpp
+++ b/redfish-core/lib/systems.hpp
@@ -2451,6 +2451,8 @@ inline void requestRoutesSystemsCollection(App& app)
                 asyncResp->res.jsonValue["@odata.id"] = "/redfish/v1/Systems";
                 asyncResp->res.jsonValue["Name"] = "Computer System Collection";
 
+                abort();
+
                 crow::connections::systemBus->async_method_call(
                     [asyncResp](const boost::system::error_code ec,
                                 const std::variant<std::string>& /*hostName*/) {

```

Signed-off-by: Gunnar Mills <gmills@us.ibm.com>