### PR TITLE
Add CableStatus, Status.State, Status.Health

### DIFF
--- a/redfish-core/lib/cable.hpp
+++ b/redfish-core/lib/cable.hpp
@@ -88,6 +88,49 @@ inline void
             }
             resp.jsonValue["CableType"] = *cableTypeDescription;
         }
+        else if (propKey == "CableStatus")
+        {
+            const std::string* cableStatus =
+                std::get_if<std::string>(&propVariant);
+            if (cableStatus == nullptr)
+            {
+                messages::internalError(resp);
+                return;
+            }
+
+            std::string linkStatus = *cableStatus;
+            if (linkStatus.empty())
+            {
+                continue;
+            }
+
+            if (linkStatus ==
+                "xyz.openbmc_project.Inventory.Item.Cable.Status.Inactive")
+            {
+                resp.jsonValue["CableStatus"] = "Normal";
+                resp.jsonValue["Status"]["State"] = "StandbyOffline";
+                resp.jsonValue["Status"]["Health"] = "OK";
+                return;
+            }
+
+            if (linkStatus == "xyz.openbmc_project.Inventory.Item."
+                              "Cable.Status.Running")
+            {
+                resp.jsonValue["CableStatus"] = "Normal";
+                resp.jsonValue["Status"]["State"] = "Enabled";
+                resp.jsonValue["Status"]["Health"] = "OK";
+                return;
+            }
+
+            if (linkStatus == "xyz.openbmc_project.Inventory.Item."
+                              "Cable.Status.PoweredOff")
+            {
+                resp.jsonValue["CableStatus"] = "Disabled";
+                resp.jsonValue["Status"]["State"] = "StandbyOffline";
+                resp.jsonValue["Status"]["Health"] = "OK";
+                return;
+            }
+        }
         else if (propKey == "Length")
         {
             const double* cableLength = std::get_if<double>(&propVariant);


### PR DESCRIPTION
Add CableStatus, Status.State, Status.Health to cables collection

Testing
1) curl testing:
curl -k -H "X-Auth-Token: $t" https://$bmc/redfish/v1/Cables/dp0_cable1

{
  "@odata.id": "/redfish/v1/Cables/dp0_cable1",
  "@odata.type": "#Cable.v1_2_0.Cable",
  "CableStatus": "Normal",
  "Id": "dp0_cable1",
  ...
  "Name": "Cable",
  "Status": {
    "Health": "OK",
    "State": "StandbyOffline"
  }
}

2) validator testing passed for added properties

Signed-off-by: Ali Ahmed <ama213000@gmail.com>