### PR TITLE
Remove Power#/Thermal# Uris from MetricProperties

### DIFF
--- a/redfish-core/lib/metric_definition.hpp
+++ b/redfish-core/lib/metric_definition.hpp
@@ -217,12 +217,9 @@ inline void mapRedfishUriToDbusPath(Callback&& callback)
 
         for (const std::string& chassisName : chassisNames)
         {
-            for (const auto& [sensorNode, dbusPaths] : sensors::dbus::paths)
-            {
-                ++counter->second;
-                retrieveUriToDbusMap(chassisName, sensorNode.data(),
-                                     handleRetrieveUriToDbusMap);
-            }
+            ++counter->second;
+            retrieveUriToDbusMap(chassisName, sensors::node::sensors.data(),
+                                 handleRetrieveUriToDbusMap);
         }
     });
 }


### PR DESCRIPTION
[SW544335](https://w3.rchland.ibm.com/projects/bestquest/?defect=SW544335): For TelemetryService MetricDefinitions, remove references to
redfish uri paths under old Power#/Thermal# schemas. These paths
are outdate and not supported.
For each MetricDefinition, under MetricProperties paths with
'Power#' or 'Thermal#' will no longer appear. This will reduce
the internal errors thrown for clients using TelemetryService.

Signed-off-by: Ali Ahmed <ama213000@gmail.com>