### PR TITLE
Add safe mode to user interface

### DIFF
--- a/static/redfish/v1/JsonSchemas/OemComputerSystem/index.json
+++ b/static/redfish/v1/JsonSchemas/OemComputerSystem/index.json
@@ -160,6 +160,15 @@
                         "boolean",
                         "null"
                     ]
+                },
+                "SafeMode": {
+                    "description": "An indication of whether safe mode is enabled.",
+                    "longDescription": "The value of this property shall indicate if safe mode is enabled.",
+                    "readonly": true,
+                    "type": [
+                        "boolean",
+                        "null"
+                    ]
                 }
             },
             "type": "object"

--- a/static/redfish/v1/schema/OemComputerSystem_v1.xml
+++ b/static/redfish/v1/schema/OemComputerSystem_v1.xml
@@ -45,6 +45,12 @@
                     <Annotation Term="OData.Description" String="An indicator allowing an operator to operate platform system attention."/>
                     <Annotation Term="OData.LongDescription" String="This property shall contain the state of the platform system attention of this resource."/>
                 </Property>
+                </Property>
+                <Property Name="SafeMode" Type="OemComputerSystem.IBM">
+                  <Annotation Term="OData.Permissions" EnumMember="OData.Permission/Read"/>
+                  <Annotation Term="OData.Description" String="An indication of whether safe mode is enabled."/>
+                  <Annotation Term="OData.LongDescription" String="The value of this property shall indicate if safe mode is enabled."/>
+                </Property>
             </ComplexType>
 
             <ComplexType Name="OpenBmc" BaseType="Resource.OemObject">


### PR DESCRIPTION

SW551103: Add the ability to see when system is in safe mode.
Tested: caused safe mode in system. checked redfish OEM
Signed-off-by: Sheldon Bailey <baileysh@us.ibm.com>