### PR TITLE
OemSessionSchema

### DIFF
--- a/static/redfish/v1/schema/OemSession_v1.xml
+++ b/static/redfish/v1/schema/OemSession_v1.xml
@@ -4,15 +4,14 @@
   <edmx:Reference Uri="http://docs.oasis-open.org/odata/odata/v4.0/errata03/csd01/complete/vocabularies/Org.OData.Core.V1.xml">
     <edmx:Include Namespace="Org.OData.Core.V1" Alias="OData"/>
   </edmx:Reference>
-  <edmx:Reference Uri="http://docs.oasis-open.org/odata/odata/v4.0/errata03/csd01/complete/vocabularies/Org.OData.Measures.V1.xml">
-    <edmx:Include Namespace="Org.OData.Measures.V1" Alias="Measures"/>
+  <edmx:Reference Uri="http://docs.oasis-open.org/odata/odata/v4.0/errata03/csd01/complete/vocabularies/Org.OData.Capabilities.V1.xml">
+    <edmx:Include Namespace="Org.OData.Capabilities.V1" Alias="Capabilities"/>
+  </edmx:Reference>
+  <edmx:Reference Uri="http://redfish.dmtf.org/schemas/v1/Resource_v1.xml">
+    <edmx:Include Namespace="Resource.v1_0_0"/>
   </edmx:Reference>
   <edmx:Reference Uri="http://redfish.dmtf.org/schemas/v1/RedfishExtensions_v1.xml">
     <edmx:Include Namespace="RedfishExtensions.v1_0_0" Alias="Redfish"/>
-  </edmx:Reference>
-  <edmx:Reference Uri="http://redfish.dmtf.org/schemas/v1/Resource_v1.xml">
-    <edmx:Include Namespace="Resource"/>
-    <edmx:Include Namespace="Resource.v1_0_0"/>
   </edmx:Reference>
   <edmx:DataServices>
 
@@ -24,16 +23,22 @@
       <Annotation Term="Redfish.OwningEntity" String="OpenBMC"/>
       <Annotation Term="Redfish.Release" String="1.0"/>
 
-      <EntityType Name="Session" BaseType="Resource.OemObject" Abstract="true">
-          <Annotation Term="OData.Description" String="OEM Extension for Session"/>
-          <Annotation Term="OData.LongDescription" String="OEM Extension for Session"/>
-
+        <ComplexType Name="Oem" BaseType="Resource.OemObject">
+          <Annotation Term="OData.AdditionalProperties" Bool="true" />
+          <Annotation Term="OData.Description" String="OemSession Oem properties." />
+          <Annotation Term="OData.AutoExpand" />
+          <Property Name="OpenBMC" Type="OemSession.v1_0_0.OpenBMC" />
+        </ComplexType>
+        
+        <ComplexType Name="OpenBMC">
+          <Annotation Term="OData.AdditionalProperties" Bool="true" />
+          <Annotation Term="OData.Description" String="Oem properties for OpenBMC." />
+          <Annotation Term="OData.AutoExpand" />
             <Property Name="ClientID" Type="Edm.String">
               <Annotation Term="OData.Description" String="The Id of the client creating this session."/>
               <Annotation Term="OData.LongDescription" String="This will be the unique identifier set by the client."/>
             </Property>
-
-      </EntityType>
+        </ComplexType>
     </Schema>
   </edmx:DataServices>
 </edmx:Edmx>


### PR DESCRIPTION
The current OemSession schema file doesn't have a proper schema
declaration for the OemSession XML file.
because of that, Jenkins validator failed to validate Oem
"redfish/v1/SessionService/Sessions/{sessionID}" redfish value.

This commit fixes OemSeesion Schema.
Tested using Jenkins Validator. 

Defect:
https://w3.rchland.ibm.com/projects/bestquest/?defect=SW550227