### PR TITLE
Move TaskState to Running for dumps except rsc dump

### DIFF
--- a/redfish-core/lib/log_services.hpp
+++ b/redfish-core/lib/log_services.hpp
@@ -1020,6 +1020,15 @@ inline void createDumpTaskCallback(
         "member='PropertiesChanged',path='" +
             createdObjPath.str + "'");
 
+    // Take the task state to "Running" for all dumps except
+    // Resource dumps as there is no validation on the user input
+    // for dump creation, meaning only in resource dump creation,
+    // validation will be done on the user input.
+    if (dumpPath.find("/resource/") == std::string::npos)
+    {
+        task->state = "Running";
+    }
+
     task->startTimer(std::chrono::minutes(20));
     task->populateResp(asyncResp->res);
     task->payload.emplace(req);


### PR DESCRIPTION
When a user initiates a dump, the dump manager creates the
dump entry dbus object and bmcweb starts a task which monitors
property changed signal on this object. The task will be in its
initial state "Starting".

Now, in case of resource dump, the dbus call to create dump
expects additional parameters from the user, which will be
validated. Once the validation is successful, the task state
moves to "Running", if not it moves to "Cancelled".

But for the other dump types, there will be no validation
done on the user input. Hence, the task state should directly
move from "Starting" to "Running" and then to "Completed" once
the dump collection is successful.

This commit adds the change to move the task state to "Running"
once it is started, for all the dumps except resource dump.

Fix for the defect: SW550799

Tested-By:

POST https://${bmc}/redfish/v1/Managers/bmc/LogServices/Dump/Actions/\
LogService.CollectDiagnosticData -d '{"DiagnosticDataType":"Manager"}'
{
  "@odata.id": "/redfish/v1/TaskService/Tasks/0",
  "@odata.type": "#Task.v1_4_3.Task",
  "Id": "0",
  "TaskState": "Running",
  "TaskStatus": "OK"
}

POST https://${bmc}/redfish/v1/Systems/system/LogServices/Dump/Actions/\
LogService.CollectDiagnosticData -d '{"DiagnosticDataType":"OEM", \
"OEMDiagnosticDataType":"Resource_wrongSelector_wrongPWD"}'
{
  "@odata.id": "/redfish/v1/TaskService/Tasks/1",
  "@odata.type": "#Task.v1_4_3.Task",
  "Id": "1",
  "TaskState": "Starting",
  "TaskStatus": "OK"
}

Signed-off-by: Asmitha Karunanithi <asmitk01@in.ibm.com>
Change-Id: Idcfb457846943f21e652a8f5ebe08184fa113735