### PR TITLE
Update to fix SW546643

### DIFF
--- a/redfish-core/lib/roles.hpp
+++ b/redfish-core/lib/roles.hpp
@@ -39,7 +39,7 @@ inline std::string getRoleFromPrivileges(std::string_view priv)
     }
     if (priv == "priv-oemibmserviceagent")
     {
-        return "ServiceAgent";
+        return "OemIBMServiceAgent";
     }
     return "";
 }
@@ -47,7 +47,7 @@ inline std::string getRoleFromPrivileges(std::string_view priv)
 inline bool getAssignedPrivFromRole(std::string_view role,
                                     nlohmann::json& privArray)
 {
-    if ((role == "Administrator") || (role == "ServiceAgent"))
+    if ((role == "Administrator") || (role == "OemIBMServiceAgent"))
     {
         privArray = {"Login", "ConfigureManager", "ConfigureUsers",
                      "ConfigureSelf", "ConfigureComponents"};
@@ -74,7 +74,7 @@ inline bool getOemPrivFromRole(std::string_view role, nlohmann::json& privArray)
     {
         privArray = nlohmann::json::array();
     }
-    else if (role == "ServiceAgent")
+    else if (role == "OemIBMServiceAgent")
     {
         privArray = {"OemIBMPerformService"};
     }
@@ -87,7 +87,7 @@ inline bool getOemPrivFromRole(std::string_view role, nlohmann::json& privArray)
 
 inline bool isRestrictedRole(const std::string& role)
 {
-    if ((role == "Operator") || (role == "ServiceAgent"))
+    if ((role == "Operator") || (role == "OemIBMServiceAgent"))
     {
         return true;
     }
@@ -119,7 +119,7 @@ inline void requestRoutesRoles(App& app)
                 asyncResp->res.jsonValue = {
                     {"@odata.type", "#Role.v1_3_0.Role"},
                     {"Name", "User Role"},
-                    {"Description", roleId + " User Role"},
+                    {"Description", ""},
                     {"OemPrivileges", std::move(oemPrivArray)},
                     {"IsPredefined", true},
                     {"Id", roleId},
@@ -127,6 +127,15 @@ inline void requestRoutesRoles(App& app)
                     {"@odata.id", "/redfish/v1/AccountService/Roles/" + roleId},
                     {"AssignedPrivileges", std::move(privArray)},
                     {"Restricted", isRestrictedRole(roleId)}};
+
+                if (roleId == "OemIBMServiceAgent")
+                {
+                    asyncResp->res.jsonValue["Description"] = "ServiceAgent";
+                }
+                else
+                {
+                    asyncResp->res.jsonValue["Description"] = roleId;
+                }
             });
 }
 

--- a/redfish-core/lib/roles.hpp
+++ b/redfish-core/lib/roles.hpp
@@ -39,7 +39,7 @@ inline std::string getRoleFromPrivileges(std::string_view priv)
     }
     if (priv == "priv-oemibmserviceagent")
     {
-        return "OemIBMServiceAgent";
+        return "ServiceAgent";
     }
     return "";
 }
@@ -47,7 +47,7 @@ inline std::string getRoleFromPrivileges(std::string_view priv)
 inline bool getAssignedPrivFromRole(std::string_view role,
                                     nlohmann::json& privArray)
 {
-    if ((role == "Administrator") || (role == "OemIBMServiceAgent"))
+    if ((role == "Administrator") || (role == "ServiceAgent"))
     {
         privArray = {"Login", "ConfigureManager", "ConfigureUsers",
                      "ConfigureSelf", "ConfigureComponents"};
@@ -74,7 +74,7 @@ inline bool getOemPrivFromRole(std::string_view role, nlohmann::json& privArray)
     {
         privArray = nlohmann::json::array();
     }
-    else if (role == "OemIBMServiceAgent")
+    else if (role == "ServiceAgent")
     {
         privArray = {"OemIBMPerformService"};
     }
@@ -87,7 +87,7 @@ inline bool getOemPrivFromRole(std::string_view role, nlohmann::json& privArray)
 
 inline bool isRestrictedRole(const std::string& role)
 {
-    if ((role == "Operator") || (role == "OemIBMServiceAgent"))
+    if ((role == "Operator") || (role == "ServiceAgent"))
     {
         return true;
     }


### PR DESCRIPTION
The Redfish GET API for AccountService roles should return
"ServiceAgent" for the case of the OemIBMServiceAgent role
and not "OemIBMServiceAgent".

The following Redfish APIs were tested to verify that
the system correctly returns "ServiceAgent" and correctly
parses "ServiceAgent" to return the role privileges.

1)Redfish API to GET AccountService Roles.
tippolit@gfwa166:~/Code/openbmc/build/p10bmc$ curl -k -X GET
https://service:0penBmc0@ever8bmc:18080/redfish/v1/AccountService/Roles
{
  "@odata.id": "/redfish/v1/AccountService/Roles",
  "@odata.type": "#RoleCollection.RoleCollection",
  "Description": "BMC User Roles",
  "Members": [
    {
      "@odata.id": "/redfish/v1/AccountService/Roles/Administrator"
    },
    {
      "@odata.id": "/redfish/v1/AccountService/Roles/Operator"
    },
    {
      "@odata.id": "/redfish/v1/AccountService/Roles/ReadOnly"
    },
    {
      "@odata.id": "/redfish/v1/AccountService/Roles/ServiceAgent"
    }
  ],
  "Members@odata.count": 4,
  "Name": "Roles Collection"
}tippolit@gfwa166

2)Redfish API to GET ServiceAgent privileges.
tippolit@gfwa166:~/Code/openbmc/build/p10bmc$ curl -k -X GET
https://service:0penBmc0@ever8bmc:18080/redfish/v1/AccountService/Roles/ServiceAgent
{
  "@odata.id": "/redfish/v1/AccountService/Roles/ServiceAgent",
  "@odata.type": "#Role.v1_3_0.Role",
  "AssignedPrivileges": [
    "Login",
    "ConfigureManager",
    "ConfigureUsers",
    "ConfigureSelf",
    "ConfigureComponents"
  ],
  "Description": "ServiceAgent User Role",
  "Id": "ServiceAgent",
  "IsPredefined": true,
  "Name": "User Role",
  "OemPrivileges": [
    "OemIBMPerformService"
  ],
  "Restricted": true,
  "RoleId": "ServiceAgent"
}tippolit@gfwa166

Signed-off-by: Tom Ippolito <thomas.ippolito@ibm.com>