### PR TITLE
Fix core dump at metricProperties when argument_list_too_long

### DIFF
--- a/redfish-core/lib/metric_report_definition.hpp
+++ b/redfish-core/lib/metric_report_definition.hpp
@@ -370,13 +370,8 @@ class AddReport
                 }
                 if (ec == boost::system::errc::argument_list_too_long)
                 {
-                    nlohmann::json metricProperties = nlohmann::json::array();
-                    for (const auto& [uri, _] : uriToDbus)
-                    {
-                        metricProperties.emplace_back(uri);
-                    }
                     messages::propertyValueIncorrect(
-                        aResp->res, metricProperties, "MetricProperties");
+                        aResp->res, "MetricProperties", "MetricProperties");
                     return;
                 }
                 if (ec)


### PR DESCRIPTION
This commit fixes the core dump seen when the telemetry service returns when the argument list is too long.
for more info:
https://w3.rchland.ibm.com/projects/bestquest/?defect=SW550900
Also saw at [SW549950](https://w3.rchland.ibm.com/projects/bestquest/?defect=SW549950) and [SW551207](https://w3.rchland.ibm.com/projects/bestquest/?defect=SW551207)

In the old code when bmcweb get `boost::system::errc::argument_list_too_long` error  it try to build JSON array object and pass that to the `messages::propertyValueIncorrect` method, which only accept string argument `nlohmann::json propertyValueIncorrect(const std::string& arg1,const std::string& arg2);`
, but that JSON array object gets upcasted to std::string object and get pass to that method (still need investigation why).

Then bmcweb builds a response using the `propertyValueIncorrect` method. That time JSON string builder finds arg1 an object they get it is an array object, and it throws an error that results in bmcweb core dump.

There are two solutions to fix this problem.
The first is to retrieve the string form `metricProperties' using the dump() method.
The second one passes the raw string value into the error message.

We selected the second solution because this is safer.
We will continue to work upstream. 
We don't understand yet what MetricReportDefinition HMC is sending to cause us to hit this if argument_list_too_long and why they are sending that. So we will now reject this request. If this is indeed a metric report definition request we will need, we might need another change in the telemetry service later.

Test:
Tested on Everest system. 
FYI: it hard to reproduce `boost::system::errc::argument_list_too_long` error in bmcweb. so to test this, comment out if condition and allow code to flow that line. This results in a core dump before fixing. After fixing, get the below result. 

{
  "error": {
    "@Message.ExtendedInfo": [
      {
        "@odata.type": "#Message.v1_1_1.Message",
        "Message": "The property 'MetricProperties' with the requested value of 'MetricProperties' could not be written because the value does not meet the constraints of the implementation.",
        "MessageArgs": [
          "MetricProperties",
          "MetricProperties"
        ],
        "MessageId": "Base.1.8.1.PropertyValueIncorrect",
        "MessageSeverity": "Warning",
        "Resolution": "No resolution is required."
      }
    ],
    "code": "Base.1.8.1.PropertyValueIncorrect",
    "message": "The property 'MetricProperties' with the requested value of 'MetricProperties' could not be written because the value does not meet the constraints of the implementation."
  }
