### PR TITLE
Update ServiceAgent role Description

### DIFF
--- a/redfish-core/lib/roles.hpp
+++ b/redfish-core/lib/roles.hpp
@@ -119,7 +119,6 @@ inline void requestRoutesRoles(App& app)
                 asyncResp->res.jsonValue = {
                     {"@odata.type", "#Role.v1_3_0.Role"},
                     {"Name", "User Role"},
-                    {"Description", roleId + " User Role"},
                     {"OemPrivileges", std::move(oemPrivArray)},
                     {"IsPredefined", true},
                     {"Id", roleId},
@@ -127,6 +126,15 @@ inline void requestRoutesRoles(App& app)
                     {"@odata.id", "/redfish/v1/AccountService/Roles/" + roleId},
                     {"AssignedPrivileges", std::move(privArray)},
                     {"Restricted", isRestrictedRole(roleId)}};
+
+                if (roleId == "OemIBMServiceAgent")
+                {
+                    asyncResp->res.jsonValue["Description"] = "ServiceAgent";
+                }
+                else
+                {
+                    asyncResp->res.jsonValue["Description"] = roleId;
+                }
             });
 }
 


### PR DESCRIPTION
SW546643: The Redfish GET API for AccountService role descriptions should return "ServiceAgent" for the case of the OemIBMServiceAgent role and not "OemIBMServiceAgent".

Tested:
/redfish/v1/AccountService/Roles/ROLE shows the intended descriptions.

Signed-off-by: Tom Ippolito <thomas.ippolito@ibm.com>
Signed-off-by: Joseph Reynolds <joseph-reynolds@charter.net>