### PR TITLE
Part of SW544661: Change BiosAttributeRegistry to Login

### DIFF
--- a/redfish-core/lib/bios.hpp
+++ b/redfish-core/lib/bios.hpp
@@ -551,7 +551,7 @@ inline void requestRoutesBiosAttributeRegistry(App& app)
     BMCWEB_ROUTE(
         app,
         "/redfish/v1/Registries/BiosAttributeRegistry/BiosAttributeRegistry")
-        .privileges({{"ConfigureManager"}})
+        .privileges({{"Login"}})
         .methods(
             boost::beast::http::verb::
                 get)([](const crow::Request&,


### PR DESCRIPTION
This is 1 of 3 fixes for SW544661

BiosAttributeRegistry was ConfigureManager, that doesn't make sense and
was causing the GUI problems.

The upstream commit has moved to "Login", let's do the same.
https://gerrit.openbmc.org/c/openbmc/bmcweb/+/29670/57/redfish-core/lib/bios.hpp#374

Redfish implies  (https://redfish.dmtf.org/registries/Redfish_1.2.0_PrivilegeRegistry.json) this should be login:

        {
            "Entity": "MessageRegistryFile",
            "OperationMap": {
                "GET": [
                    {
                        "Privilege": [
                            "Login"
                        ]
                    }
                ],


The other registries are.
Just a bit of a question mark because https://redfish.dmtf.org/schemas/v1/MessageRegistryFile_v1.xml is really at /redfish/v1/Registries/{MessageRegistryFileId}

https://github.com/ibm-openbmc/bmcweb/blob/8044381620b228f99b707ea2b444c7675e714f26/redfish-core/lib/message_registries.hpp#L244

Tested: bmcweb built. Straightforward. Did not do further testing. 

Signed-off-by: Gunnar Mills <gmills@us.ibm.com>