### PR TITLE
Support tls1.3 for redfish event

### DIFF
--- a/http/http_client.hpp
+++ b/http/http_client.hpp
@@ -64,7 +64,7 @@ class HttpClient : public std::enable_shared_from_this<HttpClient>
 {
   private:
     crow::async_resolve::Resolver resolver;
-    boost::asio::ssl::context ctx{boost::asio::ssl::context::tlsv12_client};
+    boost::asio::ssl::context ctx{boost::asio::ssl::context::tlsv13_client};
     boost::beast::tcp_stream conn;
     std::optional<boost::beast::ssl_stream<boost::beast::tcp_stream&>> sslConn;
     boost::asio::steady_timer timer;
@@ -589,6 +589,7 @@ class HttpClient : public std::enable_shared_from_this<HttpClient>
         requestDataQueue.set_capacity(maxRequestQueueSize);
         if (uriProto == "https")
         {
+            ctx.set_options(boost::asio::ssl::context::no_tlsv1_1);
             sslConn.emplace(conn, ctx);
         }
     }


### PR DESCRIPTION
Current BMC implementation supports only tls1.2 client
The redfish listener who works on tls1.3 will not get
any redfish events.

This commit updates the ssl context of the http_client
to tls1.3 and removes the support for tls1.1 and lower
versions

Tested by:
  Send redfish events to tls1.2 listener and tls1.3
  listener. Both ends are receiving events as expected

Signed-off-by: sunharis <sunharis@in.ibm.com>
Change-Id: I635e6451178b58581fb32209c0d627f5d6d9632a