### PR TITLE
SW551687: Restrict OCC passthrough to service

### DIFF
--- a/include/ibm/management_console_rest.hpp
+++ b/include/ibm/management_console_rest.hpp
@@ -1344,7 +1344,7 @@ inline void requestRoutes(App& app)
             });
 
     BMCWEB_ROUTE(app, "/ibm/v1/OCC/Control/<str>/Actions/PassThrough.Send")
-        .privileges({{"ConfigureManager"}})
+        .privileges({{"OemIBMPerformService"}})
         .methods(boost::beast::http::verb::post)(
             [](const crow::Request& req,
                const std::shared_ptr<bmcweb::AsyncResp>& asyncResp,


### PR DESCRIPTION
https://w3.rchland.ibm.com/projects/bestquest/?defect=SW551687

As decided, OCC passthrough should be service only:
https://app.slack.com/client/T0JA1U9GV/C0Q6TQP5Z/thread/C0Q6TQP5Z-1614612567.256600/1615218172.434700

For security concerns lock this interface down. 

This is downstream only. This OCC passthrough and this Service Agent are downstream only. 

Tested: For admin got Forbidden back. Service user still works. 

Signed-off-by: Gunnar Mills <gmills@us.ibm.com>