### PR TITLE
Return HTTP 409 Error for a lock conflict

### DIFF
--- a/include/ibm/management_console_rest.hpp
+++ b/include/ibm/management_console_rest.hpp
@@ -656,7 +656,7 @@ inline void
         {
             BMCWEB_LOG_ERROR
                 << "handleAcquireLockAPI: There is a conflict within itself";
-            asyncResp->res.result(boost::beast::http::status::bad_request);
+            asyncResp->res.result(boost::beast::http::status::conflict);
             return;
         }
     }


### PR DESCRIPTION
Currently, bmcweb returns 400 Bad request when there is a lock
conflict. HMC has a separate retry mechanism for lock conflict
and it expects 409 conflict error from bmcweb. So HMC cannot
detect 400 BAD Request error as lock conflict. Hence this change.

Fix for the defet at: https://w3.rchland.ibm.com/projects/bestquest/?defect=SW551506

Tested.

Signed-off-by: Asmitha Karunanithi <asmitk01@in.ibm.com>
Change-Id: I5eebf61d51e2788462ccb94794ad58455654437f