### PR TITLE
UnpackErrorReason moved to enum

### DIFF
--- a/redfish-core/lib/metric_report_definition.hpp
+++ b/redfish-core/lib/metric_report_definition.hpp
@@ -123,12 +123,10 @@ inline void fillReportDefinition(
     }
     catch (const sdbusplus::exception::UnpackPropertyError& error)
     {
-        BMCWEB_LOG_ERROR << error.what() << ", property: "
-                         << error.propertyName + ", reason: " << error.reason;
+        BMCWEB_LOG_ERROR << error.what()
+                         << ", property: " << error.propertyName;
         messages::queryParameterValueFormatError(
-            asyncResp->res,
-            std::string(error.propertyName) + " " + std::string(error.reason),
-            error.what());
+            asyncResp->res, std::string(error.propertyName), error.what());
         messages::internalError(asyncResp->res);
     }
 }


### PR DESCRIPTION
UnpackErrorReason moved to enum at
https://gerrit.openbmc.org/c/openbmc/sdbusplus/+/50321/24/include/sdbusplus/exception.hpp

We pulled https://gerrit.openbmc.org/c/openbmc/bmcweb/+/44270/43/redfish-core/lib/metric_report_definition.hpp
in but it hasn't merged upstream.

I was concerned about moving to something like:
`static_cast<int>(error.reason)`
due to CI passing but builds failing so just removed using this property.
Could bump [sdbusplus](https://github.ibm.com/openbmc/openbmc/blob/1020-ghe/meta-phosphor/recipes-extended/sdbusplus/sdbusplus-rev.inc) but I think this is just safest, remove this property all together. 
There is only 2 enums (missingProperty, wrongType). I don't think these Redfish messages get that much attention. 
This has to be addressed anyway upstream.

Tested: bmcweb build and CI passed.

Signed-off-by: Gunnar Mills <gmills@us.ibm.com>