### PR TITLE
sensors: Add Accuracy property to PS input power

### DIFF
--- a/redfish-core/lib/sensors.hpp
+++ b/redfish-core/lib/sensors.hpp
@@ -25,6 +25,7 @@
 #include <utils/json_utils.hpp>
 
 #include <cmath>
+#include <regex>
 #include <utility>
 #include <variant>
 
@@ -51,6 +52,9 @@ static constexpr std::string_view power = "Power";
 static constexpr std::string_view sensors = "Sensors";
 static constexpr std::string_view thermal = "Thermal";
 } // namespace node
+
+// Regular expression that matches power supply input power sensor names
+static const std::regex powerSupplyInputPowerPattern{"ps[0-9]+_input_power"};
 
 namespace dbus
 {
@@ -975,6 +979,13 @@ inline void objectInterfacesToJson(
         else
         {
             sensorJson["ReadingUnits"] = readingUnits;
+        }
+
+        // If this is a power supply input power sensor, set the Accuracy to 1%.
+        // All power supplies currently used on IBM systems have this accuracy.
+        if (std::regex_match(sensorName, sensors::powerSupplyInputPowerPattern))
+        {
+            sensorJson["Accuracy"] = 1;
         }
     }
     else if (sensorType == "temperature")


### PR DESCRIPTION
[SW551358](https://w3.rchland.ibm.com/projects/bestquest/?defect=SW551358): Add the Accuracy property to power supply input power sensors.

The current implementation is a temporary measure to meet the near-term
deadlines.  A long term implementation that obtains the accuracy
information from D-Bus will be delivered at a later date.

Tested:
* Ran validator
* Tested with PowerSubsystem URI
  * Verified no changes in output
* Tested with PowerSubsystem/PowerSupplies URI
  * Verified no changes in output
* Tested with PowerSupply URI
  * Verified no changes in output
* Tested with ThermalSubsystem URI
  * Verified no changes in output
* Tested with ThermalSubsystem/ThermalMetrics URI
  * Verified no changes in output
* Tested with Sensors URI
  * Verified no changes in output
* Tested with Sensors/sensor_name URI
  * Tested where sensor is a power supply input power sensor
    * Verified Accuracy property added with value of 1
    * Verified other properties are the same
  * Tested where sensor is a power supply input voltage sensor
    * Verified Accuracy property not added
    * Verified other properties are the same
  * Tested where sensor is not related to power supplies
    * Verified Accuracy property not added
    * Verified other properties are the same

Signed-off-by: Shawn McCarney <shawnmm@us.ibm.com>
Change-Id: I42b99582735a9273a6b80a66ce344c6332006747