### PR TITLE
Bump up the ConfigFile directory max limit

### DIFF
--- a/include/ibm/management_console_rest.hpp
+++ b/include/ibm/management_console_rest.hpp
@@ -43,11 +43,11 @@ constexpr char const* configFilePath =
     "/var/lib/bmcweb/ibm-management-console/configfiles";
 
 constexpr size_t maxSaveareaDirSize =
-    10000000; // Allow save area dir size to be max 10MB
+    25000000; // Allow save area dir size to be max 25MB
 constexpr size_t minSaveareaFileSize =
     100; // Allow save area file size of minimum 100B
 constexpr size_t maxSaveareaFileSize =
-    10000000; // Allow save area file size upto 10MB
+    25000000; // Allow save area file size upto 25MB
 constexpr size_t maxBroadcastMsgSize =
     1000; // Allow Broadcast message size upto 1KB
 
@@ -108,7 +108,7 @@ inline bool saveConfigFile(const std::string& data, const std::string& fileID,
     {
         asyncResp->res.result(boost::beast::http::status::bad_request);
         asyncResp->res.jsonValue["Description"] =
-            "File size exceeds maximum allowed size[10MB]";
+            "File size exceeds maximum allowed size[25MB]";
         return false;
     }
     std::ofstream file;
@@ -213,7 +213,7 @@ inline bool saveConfigFile(const std::string& data, const std::string& fileID,
         asyncResp->res.result(boost::beast::http::status::bad_request);
         asyncResp->res.jsonValue["Description"] =
             "File size does not fit in the savearea "
-            "directory maximum allowed size[10MB]";
+            "directory maximum allowed size[25MB]";
         return false;
     }
 


### PR DESCRIPTION
SW551763: When there is a 1000 partition configuration, HMC
is not able to install OS on all of them due to the
configFile directory size limit applied by BMC

The current limit is 10MB. HMC requires this to be
bumped up to 25MB.

This commit increases this upper limit

Tested by:
  Checked the save area upload works with this change

Signed-off-by: sunharis <sunharis@in.ibm.com>
Change-Id: Idcde692de9758e8eca3e9444beb2a4a9ff2bc36d