### PR TITLE
SW551248: On code update EBADR ec don't throw error

### DIFF
--- a/redfish-core/include/utils/fw_utils.hpp
+++ b/redfish-core/include/utils/fw_utils.hpp
@@ -139,6 +139,16 @@ inline void
                                     BMCWEB_LOG_ERROR << "error_code = " << ec3;
                                     BMCWEB_LOG_ERROR << "error msg = "
                                                      << ec3.message();
+                                    // If we happen to get a resource not found,
+                                    // it could be due to the code update app
+                                    // deleting it between the call to the
+                                    // mapper and here. Just leave these
+                                    // properties off if resource not found
+                                    // D-Bus error.
+                                    if (ec3.value() == EBADR)
+                                    {
+                                        return;
+                                    }
                                     messages::internalError(aResp->res);
                                     return;
                                 }


### PR DESCRIPTION
Fix defect [SW551248](https://w3.rchland.ibm.com/projects/bestquest/?defect=SW551248)

Discussed in discord here: https://discord.com/channels/775381525260664832/981260009256140852/981263933442785290

EBADR is the resource not found error code.
If we get one of those, just return when populating the firmware info for /redfish/v1/Managers/bmc.

We have saw where between the mapper call and the inner call here to
phosphor-bmc-code-mgmt, phosphor-bmc-code-mgmt deleted the iamge.

systemd[1]: Finished Delete image a from BMC storage.
bmcweb[698]: (2022-05-19 19:00:29) [ERROR "fw_utils.hpp":139] error_code = generic:53
bmcweb[698]: (2022-05-19 19:00:29) [ERROR "fw_utils.hpp":140] error msg = Invalid request descriptor
bmcweb[698]: (2022-05-19 19:00:29) [CRITICAL "error_messages.cpp":233] Internal Error ../git/redfish-core/include/utils/fw_utils.hpp

In the above case, bmcweb returned an internal error and the HMC went
to an incomplete state.

Tested: 
Everything looked the same, not an easy one to hit so had to be creative here.
So I made this look at a bad path: 
E.g. 
```
--- a/redfish-core/include/utils/fw_utils.hpp
+++ b/redfish-core/include/utils/fw_utils.hpp
@@ -247,7 +247,7 @@ inline void
                                         *version;
                                 }
                             },
-                            obj.second[0].first, obj.first,
+                            obj.second[0].first, obj.first + "badid",
                             "org.freedesktop.DBus.Properties", "GetAll",
                             "xyz.openbmc_project.Software.Version");

```

I see 
```
(2022-06-01 20:29:41) [ERROR "fw_utils.hpp":139] error_code = generic:53
(2022-06-01 20:29:41) [ERROR "fw_utils.hpp":140] error msg = Invalid request descriptor
```
in the traces and firmware version and  software links left off. The GUI handled this missing information well. 


Signed-off-by: Gunnar Mills <gmills@us.ibm.com>