### PR TITLE
Fix CI code formatting

### DIFF
--- a/redfish-core/include/task_messages.hpp
+++ b/redfish-core/include/task_messages.hpp
@@ -35,9 +35,9 @@ inline nlohmann::json taskAborted(const std::string& arg1,
         {"Oem",
          {{"OpenBMC",
            {{"@odata.type", "#OemMessage.v1_0_0.Message"},
-             {"AbortReason", arg2},
-             {"AdditionalData", arg3},
-             {"EventId", arg4}}}}}};
+            {"AbortReason", arg2},
+            {"AdditionalData", arg3},
+            {"EventId", arg4}}}}}};
 }
 
 inline nlohmann::json taskCancelled(const std::string& arg1)

--- a/redfish-core/lib/task.hpp
+++ b/redfish-core/lib/task.hpp
@@ -180,8 +180,8 @@ struct TaskData : std::enable_shared_from_this<TaskData>
                 self->finishTask();
                 self->state = "Cancelled";
                 self->status = "Warning";
-                self->messages.emplace_back(
-                    messages::taskAborted(std::to_string(self->index), "None", "None", "None"));
+                self->messages.emplace_back(messages::taskAborted(
+                    std::to_string(self->index), "None", "None", "None"));
                 self->sendTaskEvent(self->state, self->index);
                 self->callback(ec, msg, self);
             });
@@ -225,7 +225,8 @@ struct TaskData : std::enable_shared_from_this<TaskData>
         else if (state == "Stopping")
         {
             redfish::EventServiceManager::getInstance().sendEvent(
-                redfish::messages::taskAborted(std::to_string(index), "None", "None", "None"),
+                redfish::messages::taskAborted(std::to_string(index), "None",
+                                               "None", "None"),
                 origin, resType);
         }
         else if (state == "Completed")

--- a/redfish-core/lib/update_service.hpp
+++ b/redfish-core/lib/update_service.hpp
@@ -62,19 +62,17 @@ inline static void activateImage(const std::string& objPath,
             "Active"));
 }
 
-inline void updateErrorLogMessage(
-    const std::shared_ptr<task::TaskData>& taskData,
-    const std::string& index)
+inline void
+    updateErrorLogMessage(const std::shared_ptr<task::TaskData>& taskData,
+                          const std::string& index)
 {
     crow::connections::systemBus->async_method_call(
-        [taskData, index](
-            const boost::system::error_code errorCode,
-            const dbus::utility::ManagedObjectType& resp) {
+        [taskData, index](const boost::system::error_code errorCode,
+                          const dbus::utility::ManagedObjectType& resp) {
             if (errorCode)
             {
-                BMCWEB_LOG_ERROR
-                    << "updateErrorLogMessage returned an error "
-                    << errorCode;
+                BMCWEB_LOG_ERROR << "updateErrorLogMessage returned an error "
+                                 << errorCode;
                 return;
             }
 
@@ -112,7 +110,6 @@ inline void updateErrorLogMessage(
                                     break;
                                 }
                                 message.append(*messagePtr);
-
                             }
                             else if (propertyMap.first == "AdditionalData")
                             {
@@ -127,7 +124,7 @@ inline void updateErrorLogMessage(
                                         messages::internalError());
                                     return;
                                 }
-                                for (auto& data: *addData)
+                                for (auto& data : *addData)
                                 {
                                     addDataStr.append(data);
                                     addDataStr.append(" ");

--- a/scripts/update_schemas.py
+++ b/scripts/update_schemas.py
@@ -236,7 +236,7 @@ with open(metadata_index_path, 'w') as metadata_index:
     metadata_index.write(
         "        <edmx:Include Namespace=\"OemMessage\"/>\n")
     metadata_index.write(
-        "        <edmx:Include Namespace=\"OemMessage.v1_0_0\"/>\n")    
+        "        <edmx:Include Namespace=\"OemMessage.v1_0_0\"/>\n")
     metadata_index.write("    </edmx:Reference>\n")
 
     metadata_index.write("</edmx:Edmx>\n")


### PR DESCRIPTION
https://github.com/ibm-openbmc/bmcweb/pull/294 never had CI ran.
Seeing CI fail on commits like https://github.com/ibm-openbmc/bmcweb/pull/375

Remove the trailing spaces in python causing this.
Run clang-format for the C++ code. 

Signed-off-by: Gunnar Mills <gmills@us.ibm.com>