### PR TITLE
Refresh of PCIe Topology

### DIFF
--- a/redfish-core/lib/oem/ibm/pcie_topology_refresh.hpp
+++ b/redfish-core/lib/oem/ibm/pcie_topology_refresh.hpp
@@ -1,0 +1,76 @@
+#pragma once
+
+#include "async_resp.hpp"
+#include "dbus_utility.hpp"
+#include "redfish_util.hpp"
+
+#include <variant>
+
+namespace redfish
+{
+
+/**
+ * @brief Retrieves PCIe Topology Refresh properties over DBUS
+ *
+ * @param[in] aResp     Shared pointer for completing asynchronous calls.
+ *
+ * @return None.
+ */
+inline void
+    getPCIeTopologyRefresh(const std::shared_ptr<bmcweb::AsyncResp>& aResp)
+{
+    crow::connections::systemBus->async_method_call(
+        [aResp](const boost::system::error_code ec,
+                std::variant<bool>& pcieRefreshValue) {
+            if (ec)
+            {
+                BMCWEB_LOG_DEBUG << "DBUS response error " << ec;
+                messages::internalError(aResp->res);
+                return;
+            }
+            const bool* pcieRefreshValuePtr =
+                std::get_if<bool>(&pcieRefreshValue);
+            if (!pcieRefreshValuePtr)
+            {
+                messages::internalError(aResp->res);
+                return;
+            }
+            aResp->res.jsonValue["Oem"]["@odata.type"] =
+                "#OemComputerSystem.Oem";
+            nlohmann::json& pcieRefresh = aResp->res.jsonValue["Oem"]["IBM"];
+            pcieRefresh["@odata.type"] = "#OemComputerSystem.IBM";
+            pcieRefresh["PCIeTopologyRefresh"] = *pcieRefreshValuePtr;
+        },
+        "xyz.openbmc_project.PLDM", "/xyz/openbmc_project/pldm",
+        "org.freedesktop.DBus.Properties", "Get", "com.ibm.PLDM.PCIeTopology",
+        "PCIeTopologyRefresh");
+}
+
+/**
+ * @brief Sets PCIe Topology Refresh state.
+ *
+ * @param[in] aResp   Shared pointer for generating response message.
+ * @param[in] state   PCIe Topology Refresh state from request.
+ *
+ * @return None.
+ */
+inline void
+    setPCIeTopologyRefresh(const std::shared_ptr<bmcweb::AsyncResp>& aResp,
+                           const bool state)
+{
+    BMCWEB_LOG_DEBUG << "Set PCIe Topology Refresh status.";
+    crow::connections::systemBus->async_method_call(
+        [aResp](const boost::system::error_code ec) {
+            if (ec)
+            {
+                BMCWEB_LOG_DEBUG << "PCIe Topology Refresh failed." << ec;
+                messages::internalError(aResp->res);
+                return;
+            }
+        },
+        "xyz.openbmc_project.PLDM", "/xyz/openbmc_project/pldm",
+        "org.freedesktop.DBus.Properties", "Set", "com.ibm.PLDM.PCIeTopology",
+        "PCIeTopologyRefresh", std::variant<bool>(state));
+}
+
+} // namespace redfish

--- a/redfish-core/lib/systems.hpp
+++ b/redfish-core/lib/systems.hpp
@@ -22,6 +22,8 @@
 #include "oem/ibm/lamp_test.hpp"
 #include "oem/ibm/system_attention_indicator.hpp"
 #endif
+#include "oem/ibm/pcie_topology_refresh.hpp"
+
 #include <app.hpp>
 #include <boost/container/flat_map.hpp>
 #include <registries/privilege_registry.hpp>
@@ -2770,6 +2772,7 @@ inline void requestRoutesSystems(App& app)
             getHostState(asyncResp);
             getBootProgress(asyncResp);
             getPCIeDeviceList(asyncResp, "PCIeDevices");
+            getPCIeTopologyRefresh(asyncResp);
             getHostWatchdogTimer(asyncResp);
             getPowerRestorePolicy(asyncResp);
             getStopBootOnFault(asyncResp);
@@ -2906,12 +2909,13 @@ inline void requestRoutesSystems(App& app)
                         std::optional<bool> lampTest;
                         std::optional<bool> partitionSAI;
                         std::optional<bool> platformSAI;
+                        std::optional<bool> pcieTopologyRefresh;
                         if (!json_util::readJson(
                                 *ibmOem, asyncResp->res, "LampTest", lampTest,
                                 "PartitionSystemAttentionIndicator",
                                 partitionSAI,
-                                "PlatformSystemAttentionIndicator",
-                                platformSAI))
+                                "PlatformSystemAttentionIndicator", platformSAI,
+                                "PCIeTopologyRefresh", pcieTopologyRefresh))
                         {
                             return;
                         }
@@ -2931,7 +2935,20 @@ inline void requestRoutesSystems(App& app)
                                    "PlatformSystemAttentionIndicator",
                                    *platformSAI);
                         }
+#else
+                        std::optional<bool> pcieTopologyRefresh;
+                        if (!json_util::readJson(*ibmOem, asyncResp->res,
+                                                 "PCIeTopologyRefresh",
+                                                 pcieTopologyRefresh))
+                        {
+                            return;
+                        }
 #endif
+                        if (pcieTopologyRefresh)
+                        {
+                            setPCIeTopologyRefresh(asyncResp,
+                                                   *pcieTopologyRefresh);
+                        }
                     }
                 }
 

--- a/static/redfish/v1/JsonSchemas/OemComputerSystem/index.json
+++ b/static/redfish/v1/JsonSchemas/OemComputerSystem/index.json
@@ -169,6 +169,15 @@
                         "boolean",
                         "null"
                     ]
+                },
+                "PCIeTopologyRefresh": {
+                    "description": "An indication of topology information is ready.",
+                    "longDescription": "This property when set to 'true' refreshes the topology information. The application which uses this should set it to 'false' when a refresh occurs.",
+                    "readonly": true,
+                    "type": [
+                        "boolean",
+                        "null"
+                    ]
                 }
             },
             "type": "object"

--- a/static/redfish/v1/schema/OemComputerSystem_v1.xml
+++ b/static/redfish/v1/schema/OemComputerSystem_v1.xml
@@ -45,11 +45,15 @@
                     <Annotation Term="OData.Description" String="An indicator allowing an operator to operate platform system attention."/>
                     <Annotation Term="OData.LongDescription" String="This property shall contain the state of the platform system attention of this resource."/>
                 </Property>
-                </Property>
                 <Property Name="SafeMode" Type="OemComputerSystem.IBM">
                   <Annotation Term="OData.Permissions" EnumMember="OData.Permission/Read"/>
                   <Annotation Term="OData.Description" String="An indication of whether safe mode is enabled."/>
                   <Annotation Term="OData.LongDescription" String="The value of this property shall indicate if safe mode is enabled."/>
+                </Property>
+                <Property Name="PCIeTopologyRefresh" Type="OemComputerSystem.IBM">
+                  <Annotation Term="OData.Permissions" EnumMember="OData.Permission/ReadWrite"/>
+                  <Annotation Term="OData.Description" String="An indication of topology information is ready."/>
+                  <Annotation Term="OData.LongDescription" String="This property when set to 'true' refreshes the topology information. The application which uses this should set it to 'false' when a refresh occurs."/>
                 </Property>
             </ComplexType>
 


### PR DESCRIPTION
This commit allows us to Patch and gets the PCIeTopologyRefresh property.
when this property is set to true allow PLDM to refresh PCIe topology data.

Tested :
```
curl -v -k -H "X-Auth-Token: $bmc_token" -X GET https://${BMC_IP}/redfish/v1/Systems/system/
{
...
....
"Oem": {
  "@odata.type": "#OemComputerSystem.Oem",
    "IBM": {
       "@odata.type": "#OemComputerSystem.IBM",
       "LampTest": false,
       "PartitionSystemAttentionIndicator": false,
       "PlatformSystemAttentionIndicator": true,
       "SafeMode": false
}
},
....
...
}
```
```
curl -v -k -H "X-Auth-Token: $bmc_token" -X PATCH https://${BMC_IP}/redfish/v1/Systems/system/ -d '{"Oem":{"IBM":{"PCIeTopologyRefresh":true}}}'
// which set property true.
```
Run Jenkins validator.
