### PR TITLE
Fix redfish validator error for IPv6StaticAddresses

### DIFF
--- a/redfish-core/lib/ethernet.hpp
+++ b/redfish-core/lib/ethernet.hpp
@@ -1735,9 +1735,7 @@ inline void parseInterfaceData(
         {
             ipv6StaticArray.push_back(
                 {{"Address", ipv6Config.address},
-                 {"PrefixLength", ipv6Config.prefixLength},
-                 {"AddressOrigin", ipv6Config.origin},
-                 {"AddressState", nullptr}});
+                 {"PrefixLength", ipv6Config.prefixLength}});
         }
     }
 }


### PR DESCRIPTION
This PR remove AddressOrgin and AddressStatus from IPv6StaticAddresses
to fix redfish validator errors

Redfish Validator Passed