### PR TITLE
SW552380: On logout set Session cookie with expired date

### DIFF
--- a/include/login_routes.hpp
+++ b/include/login_routes.hpp
@@ -246,6 +246,11 @@ inline void requestRoutes(App& app)
                 auto& session = req.session;
                 if (session != nullptr)
                 {
+                    asyncResp->res.addHeader(
+                        "Set-Cookie", "SESSION="
+                                      "; SameSite=Strict; Secure; HttpOnly; "
+                                      "expires=Thu, 01 Jan 1970 00:00:00 GMT");
+
                     asyncResp->res.jsonValue = {
                         {"data", "User '" + session->username + "' logged out"},
                         {"message", "200 OK"},


### PR DESCRIPTION
This fixes [SW552380](https://w3.rchland.ibm.com/projects/bestquest/?defect=SW552380)

The Session cookie is an HttpOnly cookie.
HttpOnly means the cookie cannot be accessed through client side script
because of this the GUI can not delete this cookie on log out.
Recommendation online was setting this cookie to an expired date.

From https://tools.ietf.org/search/rfc6265
"Finally, to remove a cookie, the server returns a Set-Cookie header
with an expiration date in the past. The server will be successful in
removing the cookie only if the Path and the Domain attribute in the
Set-Cookie header match the values used when the cookie was created."

For more information see
https://stackoverflow.com/questions/5285940/correct-way-to-delete-cookies-server-side

Modern browsers delete expired cookies although based on reading it
might not be right away but on the next request from that domain or
when the browser is cleaning up cookies.

When I tested the cookie is deleted right away.

Also set the SESSION to an empty string.

Webui-vue and phosphor-webui both use this /logout route:
https://github.com/openbmc/webui-vue/blob/a5fefd0ad25753e5f7da03d77dfe7fe10255ebb6/src/store/modules/Authentication/AuthenticanStore.js#L50
https://github.com/openbmc/phosphor-webui/blob/339db9a4c8610c5ecb92993c0bbc2219933bc858/app/common/services/userModel.js#L46
It seemed unnecessary to add this to the Session Delete.

Tested: No longer have the cookie after log out on webui-vue.
            Tested on Firefox and Chrome.

Signed-off-by: Gunnar Mills <gmills@us.ibm.com>