### PR TITLE
Add IPv6 StatelessAddressAutoConfiguration

### DIFF
--- a/redfish-core/lib/ethernet.hpp
+++ b/redfish-core/lib/ethernet.hpp
@@ -1173,6 +1173,80 @@ inline void setDHCPv4Config(const std::string& propertyName, const bool& value,
         std::variant<bool>{value});
 }
 
+inline bool translateDHCPEnabledToIPv6AutoConfig(const std::string& inputDHCP)
+{
+    return (inputDHCP == "xyz.openbmc_project.Network.EthernetInterface."
+                         "DHCPConf.v4v6stateless") ||
+           (inputDHCP == "xyz.openbmc_project.Network.EthernetInterface."
+                         "DHCPConf.v6stateless");
+}
+
+inline std::string
+    translateIPv6AutoConfigToDHCPEnabled(const std::string& inputDHCP,
+                                         const bool& ipv6AutoConfig)
+{
+    if (ipv6AutoConfig)
+    {
+        if ((inputDHCP ==
+             "xyz.openbmc_project.Network.EthernetInterface.DHCPConf.v4") ||
+            (inputDHCP ==
+             "xyz.openbmc_project.Network.EthernetInterface.DHCPConf.both"))
+        {
+            return "xyz.openbmc_project.Network.EthernetInterface.DHCPConf."
+                   "v4v6stateless";
+        }
+        if ((inputDHCP ==
+             "xyz.openbmc_project.Network.EthernetInterface.DHCPConf.v6") ||
+            (inputDHCP ==
+             "xyz.openbmc_project.Network.EthernetInterface.DHCPConf.none"))
+        {
+            return "xyz.openbmc_project.Network.EthernetInterface.DHCPConf."
+                   "v6stateless";
+        }
+    }
+    if (!ipv6AutoConfig)
+    {
+        if ((inputDHCP == "xyz.openbmc_project.Network.EthernetInterface."
+                          "DHCPConf.v4v6stateless") ||
+            (inputDHCP ==
+             "xyz.openbmc_project.Network.EthernetInterface.DHCPConf.both"))
+        {
+            return "xyz.openbmc_project.Network.EthernetInterface.DHCPConf.v4";
+        }
+        if (inputDHCP == "xyz.openbmc_project.Network.EthernetInterface."
+                         "DHCPConf.v6stateless")
+        {
+            return "xyz.openbmc_project.Network.EthernetInterface.DHCPConf."
+                   "none";
+        }
+    }
+    return inputDHCP;
+}
+
+inline void handleSLAACAutoConfigPatch(
+    const std::string& ifaceId, const EthernetInterfaceData& ethData,
+    const bool& ipv6AutoConfigEnabled,
+    const std::shared_ptr<bmcweb::AsyncResp>& asyncResp)
+{
+    const std::string dhcp = translateIPv6AutoConfigToDHCPEnabled(
+        ethData.DHCPEnabled, ipv6AutoConfigEnabled);
+    crow::connections::systemBus->async_method_call(
+        [asyncResp](const boost::system::error_code ec) {
+            if (ec)
+            {
+                BMCWEB_LOG_ERROR << "D-Bus responses error: " << ec;
+                messages::internalError(asyncResp->res);
+                return;
+            }
+            messages::success(asyncResp->res);
+        },
+        "xyz.openbmc_project.Network",
+        "/xyz/openbmc_project/network/" + ifaceId,
+        "org.freedesktop.DBus.Properties", "Set",
+        "xyz.openbmc_project.Network.EthernetInterface", "DHCPEnabled",
+        std::variant<std::string>{dhcp});
+}
+
 inline void handleDHCPPatch(const std::string& ifaceId,
                             const EthernetInterfaceData& ethData,
                             const DHCPParameters& v4dhcpParms,
@@ -1188,8 +1262,7 @@ inline void handleDHCPPatch(const std::string& ifaceId,
     bool nextv6DHCPState{};
     if (v6dhcpParms.dhcpv6OperatingMode)
     {
-        if ((*v6dhcpParms.dhcpv6OperatingMode != "Stateful") &&
-            (*v6dhcpParms.dhcpv6OperatingMode != "Stateless") &&
+        if ((*v6dhcpParms.dhcpv6OperatingMode != "Enabled") &&
             (*v6dhcpParms.dhcpv6OperatingMode != "Disabled"))
         {
             messages::propertyValueFormatError(asyncResp->res,
@@ -1197,7 +1270,7 @@ inline void handleDHCPPatch(const std::string& ifaceId,
                                                "OperatingMode");
             return;
         }
-        nextv6DHCPState = (*v6dhcpParms.dhcpv6OperatingMode == "Stateful");
+        nextv6DHCPState = (*v6dhcpParms.dhcpv6OperatingMode == "Enabled");
     }
     else
     {
@@ -1660,11 +1733,13 @@ inline void parseInterfaceData(
     jsonResponse["DHCPv4"]["UseDomainName"] = ethData.HostNameEnabled;
 
     jsonResponse["DHCPv6"]["OperatingMode"] =
-        translateDHCPEnabledToBool(ethData.DHCPEnabled, false) ? "Stateful"
+        translateDHCPEnabledToBool(ethData.DHCPEnabled, false) ? "Enabled"
                                                                : "Disabled";
     jsonResponse["DHCPv6"]["UseNTPServers"] = ethData.NTPEnabled;
     jsonResponse["DHCPv6"]["UseDNSServers"] = ethData.DNSEnabled;
     jsonResponse["DHCPv6"]["UseDomainName"] = ethData.HostNameEnabled;
+    jsonResponse["StatelessAddressAutoConfig"]["IPv6AutoConfigEnabled"] =
+        translateDHCPEnabledToIPv6AutoConfig(ethData.DHCPEnabled);
 
     if (!ethData.hostname.empty())
     {
@@ -1825,7 +1900,7 @@ inline void requestEthernetInterfacesRoutes(App& app)
                         }
 
                         asyncResp->res.jsonValue["@odata.type"] =
-                            "#EthernetInterface.v1_4_1.EthernetInterface";
+                            "#EthernetInterface.v1_8_0.EthernetInterface";
                         asyncResp->res.jsonValue["Name"] =
                             "Manager Ethernet Interface";
                         asyncResp->res.jsonValue["Description"] =
@@ -1857,6 +1932,8 @@ inline void requestEthernetInterfacesRoutes(App& app)
                 std::optional<bool> interfaceEnabled;
                 DHCPParameters v4dhcpParms;
                 DHCPParameters v6dhcpParms;
+                std::optional<nlohmann::json> statelessAddressAutoConfig;
+                std::optional<bool> ipv6AutoConfigEnabled;
 
                 if (!json_util::readJson(
                         req, asyncResp->res, "HostName", hostname, "FQDN", fqdn,
@@ -1865,7 +1942,9 @@ inline void requestEthernetInterfacesRoutes(App& app)
                         staticNameServers, "IPv6DefaultGateway",
                         ipv6DefaultGateway, "IPv6StaticAddresses",
                         ipv6StaticAddresses, "DHCPv4", dhcpv4, "DHCPv6", dhcpv6,
-                        "InterfaceEnabled", interfaceEnabled))
+                        "StatelessAddressAutoConfig",
+                        statelessAddressAutoConfig, "InterfaceEnabled",
+                        interfaceEnabled))
                 {
                     return;
                 }
@@ -1894,6 +1973,15 @@ inline void requestEthernetInterfacesRoutes(App& app)
                         return;
                     }
                 }
+                if (statelessAddressAutoConfig)
+                {
+                    if (!json_util::readJson(
+                            *statelessAddressAutoConfig, asyncResp->res,
+                            "IPv6AutoConfigEnabled", ipv6AutoConfigEnabled))
+                    {
+                        return;
+                    }
+                }
 
                 // Get single eth interface data, and call the below callback
                 // for JSON preparation
@@ -1906,6 +1994,9 @@ inline void requestEthernetInterfacesRoutes(App& app)
                      ipv6StaticAddresses = std::move(ipv6StaticAddresses),
                      staticNameServers = std::move(staticNameServers),
                      dhcpv4 = std::move(dhcpv4), dhcpv6 = std::move(dhcpv6),
+                     statelessAddressAutoConfig =
+                         std::move(statelessAddressAutoConfig),
+                     ipv6AutoConfigEnabled,
                      v4dhcpParms = std::move(v4dhcpParms),
                      v6dhcpParms = std::move(v6dhcpParms), interfaceEnabled](
                         const bool& success,
@@ -1930,6 +2021,12 @@ inline void requestEthernetInterfacesRoutes(App& app)
                                             v6dhcpParms, asyncResp);
                         }
 
+                        if (statelessAddressAutoConfig)
+                        {
+                            handleSLAACAutoConfigPatch(ifaceId, ethData,
+                                                       *ipv6AutoConfigEnabled,
+                                                       asyncResp);
+                        }
                         if (hostname)
                         {
                             handleHostnamePatch(*hostname, asyncResp);


### PR DESCRIPTION
This commit has following changes
1.Adds "StatelessAddressAutoConfig" support
as per latest EthernetInterface.v1_8_0 schema.
2.Update schema version to EthernetInterface.v1_8_0
3.Remove support for deprecated Stateful and Stateless enums of
DHCPv6 "OperatingMode"

Tested by:
GET
PATCH -d '{"StatelessAddressAutoConfig": { "IPv6AutoConfigEnabled": true}}'
PATCH -d '{"StatelessAddressAutoConfig": { "IPv6AutoConfigEnabled": false}}'
PATCH -d '{"DHCPv6" : {"OperatingMode":"Enabled"}}'
PATCH -d '{"DHCPv6" : {"OperatingMode":"Disabled"}}'

Redfish Validator passed

Signed-off-by: Ravi Teja <raviteja28031990@gmail.com>
Change-Id: I29d471750ef513074bc5e49c31a16fa15d3d760c
