### PR TITLE
Add vmi ipv6 support

### DIFF
--- a/include/login_routes.hpp
+++ b/include/login_routes.hpp
@@ -246,6 +246,11 @@ inline void requestRoutes(App& app)
                 auto& session = req.session;
                 if (session != nullptr)
                 {
+                    asyncResp->res.addHeader(
+                        "Set-Cookie", "SESSION="
+                                      "; SameSite=Strict; Secure; HttpOnly; "
+                                      "expires=Thu, 01 Jan 1970 00:00:00 GMT");
+
                     asyncResp->res.jsonValue = {
                         {"data", "User '" + session->username + "' logged out"},
                         {"message", "200 OK"},

--- a/redfish-core/lib/oem/ibm/pcie_topology_refresh.hpp
+++ b/redfish-core/lib/oem/ibm/pcie_topology_refresh.hpp
@@ -8,7 +8,9 @@
 
 namespace redfish
 {
-
+// Timer for PCIe Topology Refresh
+static std::unique_ptr<boost::asio::steady_timer> pcieTopologyRefreshTimer;
+static uint count = 0;
 /**
  * @brief Retrieves PCIe Topology Refresh properties over DBUS
  *
@@ -47,6 +49,85 @@ inline void
 }
 
 /**
+ * @brief PCIe Topology Refresh monitor. which block incoming request
+ *
+ * @param[in] timer       pointer to steady timer which block call
+ * @param[in] aResp   Shared pointer for generating response message.
+ * @param[in] count   how many time this method get called.
+ *
+ * @return None.
+ */
+void pcieTopologyRefreshWatchdog(
+    const boost::system::error_code& ec, boost::asio::steady_timer* timer,
+    const std::shared_ptr<bmcweb::AsyncResp>& aResp, uint* countPtr)
+{
+    if (ec)
+    {
+        BMCWEB_LOG_DEBUG << "steady_timer error " << ec;
+        messages::internalError(aResp->res);
+        pcieTopologyRefreshTimer = nullptr;
+        (*countPtr) = 0;
+        return;
+    }
+    //  This method can block incoming requests max for 8 seconds. So, each
+    //  call to this method adds a 1-second block, and the maximum call allow is
+    //  8 times which makes it a total of ~8 seconds
+    if ((*countPtr) >= 8)
+    {
+        messages::internalError(aResp->res);
+        pcieTopologyRefreshTimer = nullptr;
+        (*countPtr) = 0;
+        return;
+    }
+    ++(*countPtr);
+    crow::connections::systemBus->async_method_call(
+        [aResp, timer, countPtr](const boost::system::error_code ec,
+                                 std::variant<bool>& pcieRefreshValue) {
+            if (ec)
+            {
+                BMCWEB_LOG_DEBUG << "DBUS response error " << ec;
+                messages::internalError(aResp->res);
+                pcieTopologyRefreshTimer = nullptr;
+                (*countPtr) = 0;
+                return;
+            }
+            const bool* pcieRefreshValuePtr =
+                std::get_if<bool>(&pcieRefreshValue);
+            if (!pcieRefreshValuePtr)
+            {
+                BMCWEB_LOG_DEBUG << "pcieRefreshValuePtr value nullptr";
+                messages::internalError(aResp->res);
+                pcieTopologyRefreshTimer = nullptr;
+                (*countPtr) = 0;
+                return;
+            }
+            // After PCIe Topology Refresh, it sets the pcieRefreshValuePtr
+            // value to false. if a value is not false, extend the time, and if
+            // it is false, delete the timer and reset the counter
+            if (*pcieRefreshValuePtr)
+            {
+                BMCWEB_LOG_DEBUG << "pcieRefreshValuePtr time extended";
+                timer->expires_at(timer->expiry() +
+                                  boost::asio::chrono::seconds(1));
+                timer->async_wait([timer, aResp, countPtr](
+                                      const boost::system::error_code ec) {
+                    pcieTopologyRefreshWatchdog(ec, timer, aResp, countPtr);
+                });
+            }
+            else
+            {
+                BMCWEB_LOG_DEBUG << "pcieRefreshValuePtr value refreshed";
+                pcieTopologyRefreshTimer = nullptr;
+                (*countPtr) = 0;
+                return;
+            }
+        },
+        "xyz.openbmc_project.PLDM", "/xyz/openbmc_project/pldm",
+        "org.freedesktop.DBus.Properties", "Get", "com.ibm.PLDM.PCIeTopology",
+        "PCIeTopologyRefresh");
+};
+
+/**
  * @brief Sets PCIe Topology Refresh state.
  *
  * @param[in] aResp   Shared pointer for generating response message.
@@ -55,18 +136,28 @@ inline void
  * @return None.
  */
 inline void
-    setPCIeTopologyRefresh(const std::shared_ptr<bmcweb::AsyncResp>& aResp,
+    setPCIeTopologyRefresh(const crow::Request& req,
+                           const std::shared_ptr<bmcweb::AsyncResp>& aResp,
                            const bool state)
 {
     BMCWEB_LOG_DEBUG << "Set PCIe Topology Refresh status.";
     crow::connections::systemBus->async_method_call(
-        [aResp](const boost::system::error_code ec) {
+        [&req, aResp](const boost::system::error_code ec) {
             if (ec)
             {
                 BMCWEB_LOG_DEBUG << "PCIe Topology Refresh failed." << ec;
                 messages::internalError(aResp->res);
                 return;
             }
+            count = 0;
+            pcieTopologyRefreshTimer =
+                std::make_unique<boost::asio::steady_timer>(*req.ioService);
+            pcieTopologyRefreshTimer->expires_after(std::chrono::seconds(1));
+            pcieTopologyRefreshTimer->async_wait(
+                [timer = pcieTopologyRefreshTimer.get(),
+                 aResp](const boost::system::error_code ec) {
+                    pcieTopologyRefreshWatchdog(ec, timer, aResp, &count);
+                });
         },
         "xyz.openbmc_project.PLDM", "/xyz/openbmc_project/pldm",
         "org.freedesktop.DBus.Properties", "Set", "com.ibm.PLDM.PCIeTopology",

--- a/redfish-core/lib/systems.hpp
+++ b/redfish-core/lib/systems.hpp
@@ -2946,7 +2946,7 @@ inline void requestRoutesSystems(App& app)
 #endif
                         if (pcieTopologyRefresh)
                         {
-                            setPCIeTopologyRefresh(asyncResp,
+                            setPCIeTopologyRefresh(req, asyncResp,
                                                    *pcieTopologyRefresh);
                         }
                     }

--- a/static/redfish/v1/JsonSchemas/OemPCIeSlots/index.json
+++ b/static/redfish/v1/JsonSchemas/OemPCIeSlots/index.json
@@ -25,6 +25,14 @@
                     "description": "An identifier to detect the PCIe bus linked to the slot.",
                     "readonly": true,
                     "type": "integer"
+                },
+                "AssociatedAssembly": {
+                    "description": "Represent association slot with assembly.",
+                    "readonly": true,
+                    "type": [
+                        "null",
+                        "object"
+                    ]
                 }
             },
             "type": "object"

--- a/static/redfish/v1/schema/OemPCIeSlots_v1.xml
+++ b/static/redfish/v1/schema/OemPCIeSlots_v1.xml
@@ -44,6 +44,10 @@
           <Annotation Term="OData.Permissions" EnumMember="OData.Permission/Read"/>
           <Annotation Term="OData.Description" String="Number of PCIe lanes in use."/>
         </Property>
+        <Property Name="AssociatedAssembly" Type="OemPCIeSlots.IBM">
+          <Annotation Term="OData.Permissions" EnumMember="OData.Permission/Read"/>
+          <Annotation Term="OData.Description" String="Represent association slot with assembly."/>
+        </Property>
       </ComplexType>
 
     </Schema>


### PR DESCRIPTION
This PR pulls the following gerrit commits that adds vmi ipv6 support:

https://gerrit.openbmc.org/c/openbmc/bmcweb/+/45063
https://gerrit.openbmc.org/c/openbmc/bmcweb/+/54109
https://gerrit.openbmc.org/c/openbmc/bmcweb/+/54126