### PR TITLE
Fix OemLogEntry Schema

### DIFF
--- a/static/redfish/v1/JsonSchemas/OemLogEntry/index.json
+++ b/static/redfish/v1/JsonSchemas/OemLogEntry/index.json
@@ -30,7 +30,57 @@
                         "null"
                     ]
                 },
-                "ManagementSystemAck" : {
+            "type": "object"
+            }
+        },
+        "Oem": {
+            "additionalProperties": true,
+            "description": "OemManager Oem properties.",
+            "patternProperties": {
+                "^([a-zA-Z_][a-zA-Z0-9_]*)?@(odata|Redfish|Message)\\.[a-zA-Z_][a-zA-Z0-9_.]+$": {
+                    "description": "This property shall specify a valid odata or Redfish property.",
+                    "type": [
+                        "array",
+                        "boolean",
+                        "number",
+                        "null",
+                        "object",
+                        "string"
+                    ]
+                }
+            },
+            "properties": {
+                "OpenBmc": {
+                    "anyOf": [
+                        {
+                            "$ref": "#/definitions/OpenBmc"
+                        },
+                        {
+                            "type": "null"
+                        }
+                    ]
+                }
+            },
+            "type": "object"
+        },
+        "OpenBmc": {
+            "additionalProperties": true,
+            "description": "Oem properties for OpenBmc.",
+            "patternProperties": {
+                "^([a-zA-Z_][a-zA-Z0-9_]*)?@(odata|Redfish|Message)\\.[a-zA-Z_][a-zA-Z0-9_.]+$": {
+                    "description": "This property shall specify a valid odata or Redfish property.",
+                    "type": [
+                        "array",
+                        "boolean",
+                        "number",
+                        "null",
+                        "object",
+                        "string"
+                    ]
+                }
+            },
+            "properties": {
+               "ManagementSystemAck" : {
                     "description": "Flag to keep track of external interface acknowledgment.",
                     "longDescription": "A true value says external interface acked error log, false says otherwise.",
                     "readonly": false,
@@ -38,9 +88,9 @@
                         "boolean",
                         "null"
                     ]
-                },
+                }
+            },
             "type": "object"
-            }
         }
     },
     "owningEntity": "OpenBMC",

--- a/static/redfish/v1/schema/OemLogEntry_v1.xml
+++ b/static/redfish/v1/schema/OemLogEntry_v1.xml
@@ -24,20 +24,28 @@
       <Annotation Term="Redfish.OwningEntity" String="OpenBMC"/>
       <Annotation Term="Redfish.Release" String="1.0"/>
 
-      <EntityType Name="LogEntry" BaseType="Resource.OemObject" Abstract="true">
-          <Annotation Term="OData.Description" String="OEM Extension for LogEntry"/>
-          <Annotation Term="OData.LongDescription" String="OEM Extension for LogEntry to provide the OEM specific details"/>
 
-            <Property Name="ManagementSystemAck" Type="Edm.Boolean">
-              <Annotation Term="OData.Description" String="Flag to keep track of external interface acknowledgment."/>
-              <Annotation Term="OData.LongDescription" String="A true value says external interface acked error log, false says otherwise."/>
-            </Property>
+<ComplexType Name="Oem" BaseType="Resource.OemObject">
+        <Annotation Term="OData.AdditionalProperties" Bool="true" />
+        <Annotation Term="OData.Description" String="OemLogEntry Oem properties." />
+        <Annotation Term="OData.AutoExpand" />
+        <Property Name="OpenBMC" Type="OemLogEntry.v1_0_0.OpenBMC" />
+      </ComplexType>
+        
+      <ComplexType Name="OpenBMC">
+        <Annotation Term="OData.AdditionalProperties" Bool="true" />
+        <Annotation Term="OData.Description" String="Oem properties for OpenBMC." />
+        <Annotation Term="OData.AutoExpand" />
+          <Property Name="ManagementSystemAck" Type="Edm.Boolean">
+            <Annotation Term="OData.Description" String="Flag to keep track of external interface acknowledgment."/>
+            <Annotation Term="OData.LongDescription" String="A true value says external interface acked error log, false says otherwise."/>
+          </Property>
 
-            <Property Name="GeneratorId" Type="Edm.String">
-              <Annotation Term="OData.Description" String="Id of the user who created the LogEntry."/>
-              <Annotation Term="OData.LongDescription" String="Unique id of the user who has caused the creation of the LogEntry. Eg: ip address, session id, client id."/>
-            </Property>
-      </EntityType>
+          <Property Name="GeneratorId" Type="Edm.String">
+            <Annotation Term="OData.Description" String="Id of the user who created the LogEntry."/>
+            <Annotation Term="OData.LongDescription" String="Unique id of the user who has caused the creation of the LogEntry. Eg: ip address, session id, client id."/>
+          </Property>
+      </ComplexType>
     </Schema>
   </edmx:DataServices>
 </edmx:Edmx>


### PR DESCRIPTION
[SW551554](https://w3.rchland.ibm.com/projects/bestquest/?defect=SW551554): OemLogEntry.v1_0_0.OpenBMC schema is not declared perfectly, which failed the Jenkin validator.
fix OemLogEntry schema fix Oem Log Entry Schema.

tested: this schema does not throw an error in Jenkin valiator.