### PR TITLE
Fix Oem AssociatedAssembly Link

### DIFF
--- a/static/redfish/v1/JsonSchemas/OemPCIeSlots/index.json
+++ b/static/redfish/v1/JsonSchemas/OemPCIeSlots/index.json
@@ -25,6 +25,14 @@
                     "description": "An identifier to detect the PCIe bus linked to the slot.",
                     "readonly": true,
                     "type": "integer"
+                },
+                "AssociatedAssembly": {
+                    "description": "Represent association slot with assembly.",
+                    "readonly": true,
+                    "type": [
+                        "null",
+                        "object"
+                    ]
                 }
             },
             "type": "object"

--- a/static/redfish/v1/schema/OemPCIeSlots_v1.xml
+++ b/static/redfish/v1/schema/OemPCIeSlots_v1.xml
@@ -44,6 +44,10 @@
           <Annotation Term="OData.Permissions" EnumMember="OData.Permission/Read"/>
           <Annotation Term="OData.Description" String="Number of PCIe lanes in use."/>
         </Property>
+        <Property Name="AssociatedAssembly" Type="OemPCIeSlots.IBM">
+          <Annotation Term="OData.Permissions" EnumMember="OData.Permission/Read"/>
+          <Annotation Term="OData.Description" String="Represent association slot with assembly."/>
+        </Property>
       </ComplexType>
 
     </Schema>


### PR DESCRIPTION
This commit Fix Oem Links for Associated Assembly.

Tested not throw error in validator:
curl -k -H 'X-Auth-Token: $bmc_token' -X GET https://${BMC_IP}/redfish/v1/Chassis/chassis/PCIeSlots
...
....
"Slots": [
{
"HotPluggable": false,
"Lanes": 0,
"Links": {
"Oem": {
"IBM": {
"AssociatedAssembly": [
{
"@odata.id": ["/redfish/v1/Chassis/chassis/Assembly#/Assemblies/19"]}
]
}
},
...
....