### PR TITLE
Fix lock record comparison to identify lock conflicts

### DIFF
--- a/include/ibm/locks.hpp
+++ b/include/ibm/locks.hpp
@@ -599,7 +599,7 @@ inline bool Lock::isConflictRecord(const LockRequest& refLockRecord1,
         ++i;
     }
 
-    return false;
+    return true;
 }
 
 inline uint32_t Lock::generateTransactionId()

--- a/include/ibm/locks.hpp
+++ b/include/ibm/locks.hpp
@@ -538,22 +538,6 @@ inline bool Lock::isConflictRecord(const LockRequest& refLockRecord1,
         return false;
     }
 
-    // If there is a WriteLock and both resourceIds are exactly same
-    // then return conflict
-    BMCWEB_LOG_DEBUG << "resourceId from refLockRecord1: "
-                     << std::get<3>(refLockRecord1);
-    BMCWEB_LOG_DEBUG << "resourceId from refLockRecord2: "
-                     << std::get<3>(refLockRecord2);
-    if ((boost::equals(std::get<2>(refLockRecord1), "Write") ||
-         boost::equals(std::get<2>(refLockRecord2), "Write")) &&
-        ((std::get<3>(refLockRecord1)) == (std::get<3>(refLockRecord2))))
-    {
-        BMCWEB_LOG_ERROR << "One of the record is WriteLock and resourceId are "
-                            "idential"
-                         << std::get<3>(refLockRecord1) << " . Return conflict";
-        return true;
-    }
-
     uint32_t i = 0;
     uint32_t segStartIndex = 0;
     for (const auto& p : std::get<4>(refLockRecord1))
@@ -577,9 +561,6 @@ inline bool Lock::isConflictRecord(const LockRequest& refLockRecord1,
              boost::equals(std::get<4>(refLockRecord2)[i].first, "LockSame")) &&
             (p.second == std::get<4>(refLockRecord2)[i].second))
         {
-            BMCWEB_LOG_DEBUG
-                << "Either of the Comparing locks are trying to LockSame "
-                   "resources under the current resource level";
             return true;
         }
 
@@ -608,8 +589,6 @@ inline bool Lock::isConflictRecord(const LockRequest& refLockRecord1,
                                     std::get<3>(refLockRecord2)),
                                 segItr)))
                 {
-                    BMCWEB_LOG_DEBUG << "checkByte returned false for index: "
-                                     << segStartIndex;
                     return false;
                 }
             }

--- a/redfish-core/ut/lock_test.cpp
+++ b/redfish-core/ut/lock_test.cpp
@@ -203,8 +203,8 @@ TEST_F(LockTest, MultiRequestWithoutConflictduetoDifferentSegmentLength)
     // two different kind of resources
     std::get<4>(request[0])[0].second = 3;
     const LockRequests& t = request;
-    // Return Conflict
-    ASSERT_EQ(1, lockManager.isConflictRequest(t));
+    // Return No Conflict
+    ASSERT_EQ(0, lockManager.isConflictRequest(t));
 }
 
 TEST_F(LockTest, MultiRequestWithoutConflictduetoReadLocktype)


### PR DESCRIPTION
This PR fixes https://w3.rchland.ibm.com/projects/bestquest/?defect=SW551506

This PR  has following changes

1. Reverts https://github.com/ibm-openbmc/bmcweb/pull/295
2. Fixes isConflictRecord() method return value


Tested by:
Tested with all possible lock record combinations 