### PR TITLE
Build Fabric Adapters Unique Path

### DIFF
--- a/redfish-core/include/utils/fabric_util.hpp
+++ b/redfish-core/include/utils/fabric_util.hpp
@@ -1,0 +1,40 @@
+#pragma once
+
+#include <string>
+
+namespace redfish
+{
+namespace fabric_util
+{
+/**
+ * @brief Workaround to handle duplicate Fabric device list
+ *
+ * retrieve Fabric device endpoint information and if path is
+ * ~/chassisN/logical_slotN/io_moduleN then, replace redfish
+ * Fabric device as "chassisN-logical_slotN-io_moduleN"
+ *
+ * @param[i]   fullPath  object path of Fabric device
+ *
+ * @return string: unique Fabric device name
+ */
+inline std::string buildFabricUniquePath(const std::string& fullPath)
+{
+    sdbusplus::message::object_path path(fullPath);
+    sdbusplus::message::object_path parentPath = path.parent_path();
+
+    std::string devName;
+
+    if (!parentPath.parent_path().filename().empty())
+    {
+        devName = parentPath.parent_path().filename() + "-";
+    }
+    if (!parentPath.filename().empty())
+    {
+        devName += parentPath.filename() + "-";
+    }
+    devName += path.filename();
+    return devName;
+}
+
+} // namespace fabric_util
+} // namespace redfish

--- a/redfish-core/lib/cable.hpp
+++ b/redfish-core/lib/cable.hpp
@@ -2,6 +2,7 @@
 
 #include <boost/container/flat_map.hpp>
 #include <utils/chassis_utils.hpp>
+#include <utils/fabric_util.hpp>
 #include <utils/json_utils.hpp>
 #include <utils/pcie_util.hpp>
 
@@ -251,7 +252,9 @@ inline void
                 {
                     continue;
                 }
-                std::string endpointLeaf = path.parent_path().filename();
+                std::string parentPath = path.parent_path();
+                std::string endpointLeaf =
+                    fabric_util::buildFabricUniquePath(parentPath);
                 if (endpointLeaf.empty())
                 {
                     continue;
@@ -284,7 +287,9 @@ inline void
                 {
                     continue;
                 }
-                std::string endpointLeaf = path.parent_path().filename();
+                std::string parentPath = path.parent_path();
+                std::string endpointLeaf =
+                    fabric_util::buildFabricUniquePath(parentPath);
                 if (endpointLeaf.empty())
                 {
                     continue;

--- a/redfish-core/lib/port.hpp
+++ b/redfish-core/lib/port.hpp
@@ -2,6 +2,7 @@
 
 #include "led.hpp"
 
+#include <utils/fabric_util.hpp>
 #include <utils/json_utils.hpp>
 
 namespace redfish
@@ -105,15 +106,14 @@ inline void getPort(const std::shared_ptr<bmcweb::AsyncResp>& aResp,
             // vector.
             for (const auto& [objectPath, serviceMap] : subtree)
             {
+                sdbusplus::message::object_path path(objectPath);
+                std::string parentPath = path.parent_path();
                 std::string parentAdapter =
-                    sdbusplus::message::object_path(objectPath).parent_path();
-                parentAdapter =
-                    sdbusplus::message::object_path(parentAdapter).filename();
+                    fabric_util::buildFabricUniquePath(parentPath);
 
                 if (parentAdapter == adapterId)
                 {
-                    std::string portName =
-                        sdbusplus::message::object_path(objectPath).filename();
+                    std::string portName = path.filename();
 
                     if (portName != portId)
                     {
@@ -183,7 +183,7 @@ inline void getPortCollection(const std::shared_ptr<bmcweb::AsyncResp>& aResp,
                 {
                     std::string adapterPath = object.substr(0, pos);
                     if (adapterId ==
-                        sdbusplus::message::object_path(adapterPath).filename())
+                        fabric_util::buildFabricUniquePath(adapterPath))
                     {
                         sdbusplus::message::object_path path(object);
                         std::string leaf = path.filename();
@@ -249,8 +249,7 @@ inline void requestRoutesPortCollection(App& app)
                         for (const auto& [objectPath, serviceMap] : subtree)
                         {
                             std::string adapter =
-                                sdbusplus::message::object_path(objectPath)
-                                    .filename();
+                                fabric_util::buildFabricUniquePath(objectPath);
 
                             if (adapter.empty())
                             {
@@ -372,18 +371,14 @@ inline void requestRoutesPort(App& app)
                         // with empty vector.
                         for (const auto& [objectPath, serviceMap] : subtree)
                         {
+                            sdbusplus::message::object_path path(objectPath);
+                            std::string parentPath = path.parent_path();
                             std::string parentAdapter =
-                                sdbusplus::message::object_path(objectPath)
-                                    .parent_path();
-                            parentAdapter =
-                                sdbusplus::message::object_path(parentAdapter)
-                                    .filename();
+                                fabric_util::buildFabricUniquePath(parentPath);
 
                             if (parentAdapter == adapterId)
                             {
-                                std::string portName =
-                                    sdbusplus::message::object_path(objectPath)
-                                        .filename();
+                                std::string portName = path.filename();
 
                                 if (portName != portId)
                                 {


### PR DESCRIPTION
Defect is https://w3.rchland.ibm.com/projects/bestquest/?defect=SW552762
This commit makesFabric Adapters objects unique, before this commit
bmcweb shows Fabric Adaptersobjects with the same path even though all
the dbus objects have unique paths
 {"@odata.id": "/redfish/v1/Systems/system/FabricAdapters/io_module1"},
 {"@odata.id": "/redfish/v1/Systems/system/FabricAdapters/io_module1"}

after this change bmcweb retrieve FabricAdapterdevice endpoint information and
then, replace redfish FabricAdapter device as
"chassisN-logical_slotN-io_moduleN".

Tested: Validator passed
Motherboard FabricAdapter also gets affected.
```
curl -k -H "X-Auth-Token: $token" -X GET  https://${bmc}/redfish/v1/Systems/system/FabricAdapters/
{
...
...
{"@odata.id": "/redfish/v1/Systems/system/FabricAdapters/chassis-motherboard-disk_backplane0"},
{"@odata.id": "/redfish/v1/Systems/system/FabricAdapters/chassis-motherboard-disk_backplane1"},
{"@odata.id": "/redfish/v1/Systems/system/FabricAdapters/motherboard-pcieslot0-pcie_card0"},
{"@odata.id": "/redfish/v1/Systems/system/FabricAdapters/chassis15363-logical_slot1-io_module1"},
{"@odata.id": "/redfish/v1/Systems/system/FabricAdapters/chassis15363-logical_slot2-io_module2"}
...
...
}
```