### PR TITLE
PCIe Topology: SavePCIeTopologyInfo

### DIFF
--- a/redfish-core/lib/systems.hpp
+++ b/redfish-core/lib/systems.hpp
@@ -2773,6 +2773,7 @@ inline void requestRoutesSystems(App& app)
             getBootProgress(asyncResp);
             getPCIeDeviceList(asyncResp, "PCIeDevices");
             getPCIeTopologyRefresh(asyncResp);
+            getSavePCIeTopologyInfo(asyncResp);
             getHostWatchdogTimer(asyncResp);
             getPowerRestorePolicy(asyncResp);
             getStopBootOnFault(asyncResp);
@@ -2910,12 +2911,14 @@ inline void requestRoutesSystems(App& app)
                         std::optional<bool> partitionSAI;
                         std::optional<bool> platformSAI;
                         std::optional<bool> pcieTopologyRefresh;
+                        std::optional<bool> savePCIeTopologyInfo;
                         if (!json_util::readJson(
                                 *ibmOem, asyncResp->res, "LampTest", lampTest,
                                 "PartitionSystemAttentionIndicator",
                                 partitionSAI,
                                 "PlatformSystemAttentionIndicator", platformSAI,
-                                "PCIeTopologyRefresh", pcieTopologyRefresh))
+                                "PCIeTopologyRefresh", pcieTopologyRefresh,
+                                "SavePCIeTopologyInfo", savePCIeTopologyInfo))
                         {
                             return;
                         }
@@ -2937,9 +2940,11 @@ inline void requestRoutesSystems(App& app)
                         }
 #else
                         std::optional<bool> pcieTopologyRefresh;
-                        if (!json_util::readJson(*ibmOem, asyncResp->res,
-                                                 "PCIeTopologyRefresh",
-                                                 pcieTopologyRefresh))
+                        std::optional<bool> savePCIeTopologyInfo;
+                        if (!json_util::readJson(
+                                *ibmOem, asyncResp->res, "PCIeTopologyRefresh",
+                                pcieTopologyRefresh, "SavePCIeTopologyInfo",
+                                savePCIeTopologyInfo))
                         {
                             return;
                         }
@@ -2948,6 +2953,11 @@ inline void requestRoutesSystems(App& app)
                         {
                             setPCIeTopologyRefresh(req, asyncResp,
                                                    *pcieTopologyRefresh);
+                        }
+                        if (savePCIeTopologyInfo)
+                        {
+                            setSavePCIeTopologyInfo(asyncResp,
+                                                    *savePCIeTopologyInfo);
                         }
                     }
                 }

--- a/static/redfish/v1/JsonSchemas/OemComputerSystem/index.json
+++ b/static/redfish/v1/JsonSchemas/OemComputerSystem/index.json
@@ -178,6 +178,15 @@
                         "boolean",
                         "null"
                     ]
+                },
+                "SavePCIeTopologyInfo": {
+                    "description": "An indication of PEL topology information is saves.",
+                    "longDescription": "This property when set to 'true' saves the topology information. The information is saved in the form of a PEL(Error Log).",
+                    "readonly": true,
+                    "type": [
+                        "boolean",
+                        "null"
+                    ]
                 }
             },
             "type": "object"

--- a/static/redfish/v1/schema/OemComputerSystem_v1.xml
+++ b/static/redfish/v1/schema/OemComputerSystem_v1.xml
@@ -55,6 +55,11 @@
                   <Annotation Term="OData.Description" String="An indication of topology information is ready."/>
                   <Annotation Term="OData.LongDescription" String="This property when set to 'true' refreshes the topology information. The application which uses this should set it to 'false' when a refresh occurs."/>
                 </Property>
+                <Property Name="SavePCIeTopologyInfo" Type="OemComputerSystem.IBM">
+                  <Annotation Term="OData.Permissions" EnumMember="OData.Permission/ReadWrite"/>
+                  <Annotation Term="OData.Description" String="An indication of PEL topology information is saves."/>
+                  <Annotation Term="OData.LongDescription" String="This property when set to 'true' saves the topology information. The information is saved in the form of a PEL(Error Log)."/>
+                </Property>
             </ComplexType>
 
             <ComplexType Name="OpenBmc" BaseType="Resource.OemObject">


### PR DESCRIPTION
This is the first part of https://w3.rchland.ibm.com/projects/bestquest/?defect=SW553479

This commit implements GET and PATCH for OEM IBM property Save PCIe Topology info.

SavePCIeTopologyInfo is boolean variable . This property when set to 'true' saves the topology information. The information is saved in the form of a PEL(Error Log).

Tested:  using Jenksin validator
```
curl -k -H "X-Auth-Token: $bmc_token" -X GET https://${BMC_IP}/redfish/v1/Systems/system/
```
output:
```
 {
 ...
  "Oem": {
    "@odata.type": "#OemComputerSystem.Oem",
    "IBM": {
      "@odata.type": "#OemComputerSystem.IBM",
      "LampTest": false,
      "PCIeTopologyRefresh": false,
      "PartitionSystemAttentionIndicator": false,
      "PlatformSystemAttentionIndicator": true,
      "SafeMode": false,
      "SavePCIeTopologyInfo": false
    }
  },
...
}
```
Patch:
```
curl -k -H "X-Auth-Token: $bmc_token" -X PATCH https://${BMC_IP}/redfish/v1/Systems/system/ -d '{"Oem":{"IBM":{"SavePCIeTopologyInfo":true}}}'
```