### PR TITLE
HW-Isolation: : map "Manual" error message to Logging severity "OK"

### DIFF
--- a/redfish-core/lib/log_services.hpp
+++ b/redfish-core/lib/log_services.hpp
@@ -4993,14 +4993,17 @@ inline void fillSystemHardwareIsolationLogEntry(
                     {
                         entryJson["Severity"] = "Critical";
                     }
-                    else if ((*severity == "xyz.openbmc_project."
-                                           "HardwareIsolation."
-                                           "Entry.Type.Warning") ||
-                             (*severity == "xyz.openbmc_project."
-                                           "HardwareIsolation."
-                                           "Entry.Type.Manual"))
+                    else if (*severity == "xyz.openbmc_project."
+                                          "HardwareIsolation."
+                                          "Entry.Type.Warning")
                     {
                         entryJson["Severity"] = "Warning";
+                    }
+                    else if (*severity == "xyz.openbmc_project."
+                                          "HardwareIsolation."
+                                          "Entry.Type.Manual")
+                    {
+                        entryJson["Severity"] = "OK";
                     }
                     else
                     {


### PR DESCRIPTION
[SW553394](https://w3.rchland.ibm.com/projects/bestquest/?defect=SW553394): When PEL's with guard entry are deleted the severity type of guard record changed from Predictive to Manual in Deconfiguration records page.

Redfish severity "Warning" is translated to either "Predictive/Manual" in GUI. GUI marks the guard record as "Manual" if associated errorlog entry object is not found.

When a PEL is deleted associated error log object is deleted and GUI should not treat the associated guard records as "Manual"

Now using severity "OK" from the redfish schema to specify manually created guard records.

Signed-off-by: Marri Devender Rao <devenrao@in.ibm.com>

Change-Id: Idaa622b002b5409858ff2bbd01f82b162d53fe8c