### PR TITLE
Remove PCIe Topology Properties GET

### DIFF
--- a/redfish-core/lib/oem/ibm/pcie_topology_refresh.hpp
+++ b/redfish-core/lib/oem/ibm/pcie_topology_refresh.hpp
@@ -11,42 +11,6 @@ namespace redfish
 // Timer for PCIe Topology Refresh
 static std::unique_ptr<boost::asio::steady_timer> pcieTopologyRefreshTimer;
 static uint count = 0;
-/**
- * @brief Retrieves PCIe Topology Refresh properties over DBUS
- *
- * @param[in] aResp     Shared pointer for completing asynchronous calls.
- *
- * @return None.
- */
-inline void
-    getPCIeTopologyRefresh(const std::shared_ptr<bmcweb::AsyncResp>& aResp)
-{
-    crow::connections::systemBus->async_method_call(
-        [aResp](const boost::system::error_code ec,
-                std::variant<bool>& pcieRefreshValue) {
-            if (ec)
-            {
-                BMCWEB_LOG_ERROR << "DBUS response error " << ec;
-                messages::internalError(aResp->res);
-                return;
-            }
-            const bool* pcieRefreshValuePtr =
-                std::get_if<bool>(&pcieRefreshValue);
-            if (!pcieRefreshValuePtr)
-            {
-                messages::internalError(aResp->res);
-                return;
-            }
-            aResp->res.jsonValue["Oem"]["@odata.type"] =
-                "#OemComputerSystem.Oem";
-            nlohmann::json& pcieRefresh = aResp->res.jsonValue["Oem"]["IBM"];
-            pcieRefresh["@odata.type"] = "#OemComputerSystem.IBM";
-            pcieRefresh["PCIeTopologyRefresh"] = *pcieRefreshValuePtr;
-        },
-        "xyz.openbmc_project.PLDM", "/xyz/openbmc_project/pldm",
-        "org.freedesktop.DBus.Properties", "Get", "com.ibm.PLDM.PCIeTopology",
-        "PCIeTopologyRefresh");
-}
 
 /**
  * @brief PCIe Topology Refresh monitor. which block incoming request
@@ -162,43 +126,6 @@ inline void
         "xyz.openbmc_project.PLDM", "/xyz/openbmc_project/pldm",
         "org.freedesktop.DBus.Properties", "Set", "com.ibm.PLDM.PCIeTopology",
         "PCIeTopologyRefresh", std::variant<bool>(state));
-}
-
-/**
- * @brief Retrieves Save PCIe Topology Info properties over DBUS
- *
- * @param[in] aResp     Shared pointer for completing asynchronous calls.
- *
- * @return None.
- */
-inline void
-    getSavePCIeTopologyInfo(const std::shared_ptr<bmcweb::AsyncResp>& aResp)
-{
-    crow::connections::systemBus->async_method_call(
-        [aResp](const boost::system::error_code ec,
-                std::variant<bool>& savePCIeTopologyInfo) {
-            if (ec)
-            {
-                BMCWEB_LOG_ERROR << "DBUS response error " << ec;
-                messages::internalError(aResp->res);
-                return;
-            }
-            const bool* savePCIeTopologyInfoPtr =
-                std::get_if<bool>(&savePCIeTopologyInfo);
-            if (!savePCIeTopologyInfoPtr)
-            {
-                messages::internalError(aResp->res);
-                return;
-            }
-            aResp->res.jsonValue["Oem"]["@odata.type"] =
-                "#OemComputerSystem.Oem";
-            nlohmann::json& pcieRefresh = aResp->res.jsonValue["Oem"]["IBM"];
-            pcieRefresh["@odata.type"] = "#OemComputerSystem.IBM";
-            pcieRefresh["SavePCIeTopologyInfo"] = *savePCIeTopologyInfoPtr;
-        },
-        "xyz.openbmc_project.PLDM", "/xyz/openbmc_project/pldm",
-        "org.freedesktop.DBus.Properties", "Get", "com.ibm.PLDM.PCIeTopology",
-        "SavePCIeTopologyInfo");
 }
 
 /**

--- a/redfish-core/lib/systems.hpp
+++ b/redfish-core/lib/systems.hpp
@@ -2772,8 +2772,6 @@ inline void requestRoutesSystems(App& app)
             getHostState(asyncResp);
             getBootProgress(asyncResp);
             getPCIeDeviceList(asyncResp, "PCIeDevices");
-            getPCIeTopologyRefresh(asyncResp);
-            getSavePCIeTopologyInfo(asyncResp);
             getHostWatchdogTimer(asyncResp);
             getPowerRestorePolicy(asyncResp);
             getStopBootOnFault(asyncResp);


### PR DESCRIPTION
This would be the fix for [SW553662](https://w3.rchland.ibm.com/projects/bestquest/?defect=SW553662) if approved. 


I do want to note this is an error case, i.e. PLDM being stopped is an error case.

Redfish API is fully discoverable, which means things like the entire tree can be walked (hypermedia API) and properties that can be PATCHed are present in the GET.

There was 2 IBM OEM PCIETopology properties (SavePCIeTopologyInfo and PCIeTopologyRefresh) added to the PATCH of /redfish/v1/Systems/system. These properties are used on the GUI PCIe Topology page. Because they were added to the PATCH they have also been added to the /redfish/v1/Systems/system GET because of said Redfish rule above.

These properties call PLDM, when PLDM is down or hung (https://ibm-systems-power.slack.com/archives/C031HHVDKT5/p1655995065713389 discussion around PLDM hang SW553469) now GET /redfish/v1/Systems/system will respond with an error or hang itself. PLDM being down/hung has happened many times. /redfish/v1/Systems/system is used by HMC and could lead to HMC going to a no connection state.

The easiest change here is to just remove these from the /redfish/v1/Systems/system GET, which 100% violates the Redfish standard but PCIeTopology already violated the Redfish standard.

Long term we probably want to move to an Action here  

Tested: 

```
"Oem": {
"@odata.type": "#OemComputerSystem.Oem",
"IBM": {
"@odata.type": "#OemComputerSystem.IBM",
"LampTest": false,
"PartitionSystemAttentionIndicator": false,
"PlatformSystemAttentionIndicator": true,
"SafeMode": false
}
},
```

PATCH still works:

curl -k -X PATCH https://${BMC_IP}/redfish/v1/Systems/system/ -d '{"Oem":{"IBM":{"SavePCIeTopologyInfo":true}}}'
curl -k -X PATCH https://${BMC_IP}/redfish/v1/Systems/system/ -d '{"Oem":{"IBM":{"PCIeTopologyRefresh":true}}}'

Signed-off-by: Gunnar Mills <gmills@us.ibm.com>