### PR TITLE
Restrict host console to ConfigureManager

### DIFF
--- a/include/obmc_console.hpp
+++ b/include/obmc_console.hpp
@@ -6,6 +6,7 @@
 #include <boost/asio/local/stream_protocol.hpp>
 #include <boost/container/flat_map.hpp>
 #include <boost/container/flat_set.hpp>
+#include <privileges.hpp>
 #include <websocket.hpp>
 
 namespace crow
@@ -117,23 +118,75 @@ inline void connectHandler(const boost::system::error_code& ec)
 inline void requestRoutes(App& app)
 {
     BMCWEB_ROUTE(app, "/console0")
-        .privileges({{"ConfigureComponents", "ConfigureManager"}})
+        .privileges({{"ConfigureManager"}})
         .websocket()
         .onopen([](crow::websocket::Connection& conn,
-                   const std::shared_ptr<bmcweb::AsyncResp>&) {
+                   const std::shared_ptr<bmcweb::AsyncResp>& asyncResp) {
             BMCWEB_LOG_DEBUG << "Connection " << &conn << " opened";
+            // Ensure user has ConfigureManager, setting above does nothing
+            auto getUserInfo =
+                [&conn, asyncResp](
+                    const boost::system::error_code ec,
+                    boost::container::flat_map<
+                        std::string, std::variant<bool, std::string,
+                                                  std::vector<std::string>>>
+                        userInfo) {
+                    if (ec)
+                    {
+                        BMCWEB_LOG_ERROR << "GetUserInfo failed...";
+                        conn.close("Failed to get user information");
+                        return;
+                    }
 
-            sessions.insert(&conn);
-            if (hostSocket == nullptr)
-            {
-                const std::string consoleName("\0obmc-console", 13);
-                boost::asio::local::stream_protocol::endpoint ep(consoleName);
+                    const std::string* userRolePtr = nullptr;
+                    auto userInfoIter = userInfo.find("UserPrivilege");
+                    if (userInfoIter != userInfo.end())
+                    {
+                        userRolePtr =
+                            std::get_if<std::string>(&userInfoIter->second);
+                    }
 
-                hostSocket = std::make_unique<
-                    boost::asio::local::stream_protocol::socket>(
-                    conn.getIoContext());
-                hostSocket->async_connect(ep, connectHandler);
-            }
+                    std::string userRole{};
+                    if (userRolePtr != nullptr)
+                    {
+                        userRole = *userRolePtr;
+                        BMCWEB_LOG_DEBUG << "userName = " << conn.getUserName()
+                                         << " userRole = " << *userRolePtr;
+                    }
+
+                    // Get the user privileges from the role
+                    ::redfish::Privileges userPrivileges =
+                        ::redfish::getUserPrivileges(userRole);
+
+                    const ::redfish::Privileges requiredPrivileges{
+                        "ConfigureManager"};
+
+                    if (!userPrivileges.isSupersetOf(requiredPrivileges))
+                    {
+                        BMCWEB_LOG_DEBUG
+                            << "User " << conn.getUserName()
+                            << " not authorized for host console connection";
+                        conn.close("Unathourized access");
+                        return;
+                    }
+
+                    sessions.insert(&conn);
+                    if (hostSocket == nullptr)
+                    {
+                        const std::string consoleName("\0obmc-console", 13);
+                        boost::asio::local::stream_protocol::endpoint ep(
+                            consoleName);
+
+                        hostSocket = std::make_unique<
+                            boost::asio::local::stream_protocol::socket>(
+                            conn.getIoContext());
+                        hostSocket->async_connect(ep, connectHandler);
+                    }
+                };
+            crow::connections::systemBus->async_method_call(
+                std::move(getUserInfo), "xyz.openbmc_project.User.Manager",
+                "/xyz/openbmc_project/user", "xyz.openbmc_project.User.Manager",
+                "GetUserInfo", conn.getUserName());
         })
         .onclose([](crow::websocket::Connection& conn,
                     [[maybe_unused]] const std::string& reason) {


### PR DESCRIPTION
Part of [SW553027](https://w3.rchland.ibm.com/projects/bestquest/?defect=SW553027)

Currently, ReadOnly has access to the host console.
Restrict it to Admin or above.

This appears to add a half-second delay in starting the websocket (I assume this is for the dbus call). It is just noticeable but hard to measure (e.g. under a second).. Or I am going crazy. 

I followed code in https://github.com/ibm-openbmc/bmcweb/blob/8044381620b228f99b707ea2b444c7675e714f26/include/nbd_proxy.hpp#L417 

Tested: For a ReadOnly user I see 
```
websocket console0/ closed.
            code: 1000
            reason: Unathourized access
```
in the browser development tools console.

For Admin and Service the console works as normal as does the "Open in new tab". 
In the browser development tools console I see websocket console0/ opened and what I would expect flowing when booting the system. 


Signed-off-by: Gunnar Mills <gmills@us.ibm.com>