### PR TITLE
ReadOnly users should not have ssh

### DIFF
--- a/redfish-core/lib/account_service.hpp
+++ b/redfish-core/lib/account_service.hpp
@@ -2057,8 +2057,8 @@ inline void requestAccountServiceRoutes(App& app)
 
                     for (const auto& group : *allGroupsList)
                     {
-                        if ((group != "ipmi") && ((group != "ssh") ||
-                                                  (*roleId == "Administrator")))
+                        if ((group != "ipmi") &&
+                            ((group != "ssh") || (*roleId == "Administrator")))
                         {
                             modGroupsList.push_back(group);
                         }

--- a/redfish-core/lib/account_service.hpp
+++ b/redfish-core/lib/account_service.hpp
@@ -2050,13 +2050,15 @@ inline void requestAccountServiceRoutes(App& app)
                         return;
                     }
 
-                    // Create (modified) modGroupsList from allGroupsList that
-                    // does not contain the ipmi group.
+                    // Create (modified) modGroupsList from allGroupsList.
+                    // Remove the ipmi group.  Also Remove "ssh" if the new
+                    // user is not an Administrator.
                     std::vector<std::string> modGroupsList;
 
                     for (const auto& group : *allGroupsList)
                     {
-                        if (group != "ipmi")
+                        if ((group != "ipmi") && ((group != "ssh") ||
+                                                  (*roleId == "Administrator")))
                         {
                             modGroupsList.push_back(group);
                         }


### PR DESCRIPTION
This changes the Redfish create new user API (POST /redfish/v1/AccountService/Accounts/) so only Administrator users will have the HostConsole AccountType value.  This is the same as the "ssh" phosphor privilege group.

Doing so prevents new ReadOnly users from using SSH port 2200.

Note that ReadOnly user created prior to this change will have the HostConsole AccountType privilege.  A BMC admin can PATCH a user's AccountTypes property to add or remove the HostConsole value.

Tested: Yes

Signed-off-by: Joseph Reynolds <joseph-reynolds@charter.net>