### PR TITLE
Disallow disabling the service user

### DIFF
--- a/redfish-core/lib/account_service.hpp
+++ b/redfish-core/lib/account_service.hpp
@@ -2395,7 +2395,8 @@ inline void requestAccountServiceRoutes(App& app)
             // Do not even allow the service user to change these properties.
             // Implementation note: Ideally this would get the user's RoleId
             // but that would take an additional D-Bus operation.
-            if ((username == "service") && (newUserName || password || roleId))
+            if ((username == "service") &&
+                (newUserName || password || roleId || enabled))
             {
                 BMCWEB_LOG_ERROR
                     << "Attempt to PATCH user who has a Restricted Role";


### PR DESCRIPTION
This changes the PATCH /redfish/v1/AccountService/Accounts/service operation so the service user cannot be disabled.  Effectively, the way to disable service user login is to delete the ACF file.

Tested: Yes

Signed-off-by: Joseph Reynolds <joseph-reynolds@charter.net>