### PR TITLE
Bump our connection timeout to 26 mins

### DIFF
--- a/http/http_connection.hpp
+++ b/http/http_connection.hpp
@@ -47,10 +47,11 @@ constexpr uint64_t loggedOutPostBodyLimit = 4096;
 
 constexpr uint32_t httpHeaderLimit = 8192;
 
-// drop all connections after 12 minutes, this time limit was chosen
-// arbitrarily and can be adjusted later if needed
+// drop all connections after 26 minutes, this time limit is so high
+// to support our large code update images on slow networks
+// Need a better way to do this
 static constexpr const size_t loggedInAttempts =
-    (720 / timerQueueTimeoutSeconds);
+    (1560 / timerQueueTimeoutSeconds);
 
 static constexpr const size_t loggedOutAttempts =
     (15 / timerQueueTimeoutSeconds);


### PR DESCRIPTION
https://w3.rchland.ibm.com/projects/bestquest/?defect=SW553617

Before this was 12 mins but have seen real examples of slow networks
hitting this 12 min timeout. Bump this timeout to 26 mins which should
support an upload speed of as low as 0.641 Mbit/s.

This will be all connections, not just code update.

This is definitely a bandage, long term:
1. code update connection timeout should not be the same as other
connection timeouts
2. We should install a lower code update timeout (e.g. 30 seconds) that
gets reset every time we get a packet
3. We should look at our image size, and make sure we can't make that
smaller

Tested: GUI works

Will continue to test 

Signed-off-by: Gunnar Mills <gmills@us.ibm.com>