### PR TITLE
Add getDateTimeUnitMs function

### DIFF
--- a/http/utility.hpp
+++ b/http/utility.hpp
@@ -4,6 +4,8 @@
 
 #include <openssl/crypto.h>
 
+#include <boost/date_time/posix_time/posix_time.hpp>
+
 #include <chrono>
 #include <cstdint>
 #include <cstring>
@@ -608,6 +610,17 @@ inline std::string getDateTime(const std::time_t& time)
     }
 
     return redfishDateTime;
+}
+
+inline std::string getDateTimeUintMs(uint64_t millisSecondsSinceEpoch)
+{
+
+    boost::posix_time::milliseconds timeSinceEpoch =
+        boost::posix_time::milliseconds(millisSecondsSinceEpoch);
+    boost::posix_time::ptime epoch(boost::gregorian::date(1970, 1, 1));
+    boost::posix_time::ptime time = epoch + timeSinceEpoch;
+
+    return boost::posix_time::to_iso_extended_string(time) + "+00:00";
 }
 
 /**

--- a/redfish-core/lib/metric_report.hpp
+++ b/redfish-core/lib/metric_report.hpp
@@ -25,8 +25,7 @@ inline nlohmann::json toMetricValues(const Readings& readings)
             {"MetricId", id},
             {"MetricProperty", metadata},
             {"MetricValue", std::to_string(sensorValue)},
-            {"Timestamp",
-             crow::utility::getDateTime(static_cast<time_t>(timestamp))},
+            {"Timestamp", crow::utility::getDateTimeUintMs(timestamp)},
         });
     }
 
@@ -52,8 +51,8 @@ inline bool fillReport(nlohmann::json& json, const std::string& id,
     }
 
     const auto& [timestamp, readings] = *timestampReadings;
-    json["Timestamp"] =
-        crow::utility::getDateTime(static_cast<time_t>(timestamp));
+
+    json["Timestamp"] = crow::utility::getDateTimeUintMs(timestamp);
     json["MetricValues"] = toMetricValues(readings);
     return true;
 }


### PR DESCRIPTION
This defect is https://w3.rchland.ibm.com/projects/bestquest/?defect=SW553937 and is marked for fw1020.10 

Telemetry service is using timestamp with milliseconds accuracy. Bmcweb
code assumed that timestamp is in seconds which produced a bad result.
This patchset updates the APIs, and adds a getDateTimeUintMs method,
which can be used to convert a millisecond timestamp into a string.

The work here is copied from upstream gerrit commit
https://gerrit.openbmc.org/c/openbmc/bmcweb/+/50027.

The reason for selected copy from the upstream commit is preserve
getDateTime() function as is. Other Redfish services will continue
to use getDateTime() without any disruption.

Testing:
1) Redfish validator passed.

2) Curl output passed.

curl -k -H "X-Auth-Token: $token" -X GET \
https://$bmc/redfish/v1/TelemetryService/MetricReports/ps2_input_power

Before:
...
    {
      "MetricId": "ps2_input_power_reading",
      "MetricProperty": "/redfish/v1/Chassis/chassis/Sensors/ps2_input_power/Reading",
      "MetricValue": "20.687500",
      "Timestamp": "1945-05-29T10:36:19+00:00"
    },
...

After:
...
    {
      "MetricId": "ps2_input_power_reading",
      "MetricProperty": "/redfish/v1/Chassis/chassis/Sensors/ps2_input_power/Reading",
      "MetricValue": "21.343750",
      "Timestamp": "2022-07-06T07:54:43.278000+00:00"
    },
...

Signed-off-by: Ali Ahmed <ama213000@gmail.com>