### PR TITLE
Fix bug: bmcweb SNMP errors in the Journal

### DIFF
--- a/redfish-core/include/event_service_manager.hpp
+++ b/redfish-core/include/event_service_manager.hpp
@@ -397,6 +397,11 @@ class Subscription : public persistent_data::UserSubscription
 
     void sendEvent(const std::string& msg)
     {
+        if (subscriptionType == "SNMPTrap")
+        {
+            return; // Don't need send SNMPTrap event.
+        }
+
         if (conn == nullptr)
         {
             // create the HttpClient connection
@@ -1068,6 +1073,12 @@ class EventServiceManager
             {
                 isSubscribed = true;
             }
+
+            if (entry->subscriptionType == "SNMPTrap")
+            {
+                isSubscribed = false; // Don't need send SNMPTrap event.
+            }
+
             if (isSubscribed)
             {
                 nlohmann::json msgJson = {


### PR DESCRIPTION
Fix this bug: https://github.com/ibm-openbmc/dev/issues/3599

Internal defect number is https://w3.rchland.ibm.com/projects/bestquest/?defect=SW553815

Don't send event to snmptrap subscription.

Signed-off-by: Chicago Duan <duanzhijia01@inspur.com>