### PR TITLE
fw1020.10: Deconfig: Fix OriginOfCondition Link

### DIFF
--- a/redfish-core/lib/log_services.hpp
+++ b/redfish-core/lib/log_services.hpp
@@ -4789,6 +4789,7 @@ inline void getRedfishUriByDbusObjPath(
                             uriPropPath /= entryJsonIdx - 1;
                             uriPropPath /= "Links";
                             uriPropPath /= "OriginOfCondition";
+                            uriPropPath /= "@odata.id";
 
                             assembly::fillWithAssemblyId(
                                 asyncResp, std::get<0>(assemblyParent),


### PR DESCRIPTION
Fix [SW554007](https://w3.rchland.ibm.com/projects/bestquest/?defect=SW554093).

The OriginOfCondition Link should have an odata.id which was missing for
assemblies. All other Deconfig records already correctly had this property.

Before:
{
      "@odata.id": "/redfish/v1/Systems/system/LogServices/HardwareIsolation/Entries/51",
      "@odata.type": "#LogEntry.v1_9_0.LogEntry",
      "AdditionalDataURI": "/redfish/v1/Systems/system/LogServices/EventLog/Entries/343/attachment",
      "Created": "2022-07-07T07:38:28+00:00",
      "EntryType": "Event",
      "Id": "51",
      "Links": {
        "OriginOfCondition": "/redfish/v1/Chassis/chassis/Assembly#/Assemblies/19"    <============ Missing @odata.id":
      },
      "Message": "TPM Card",
      "Name": "Hardware Isolation Entry",
      "Severity": "Warning"
    },

After:
{
"@odata.id": "/redfish/v1/Systems/system/LogServices/HardwareIsolation/Entries/1",
"@odata.type": "#LogEntry.v1_9_0.LogEntry",
"AdditionalDataURI": "/redfish/v1/Systems/system/LogServices/EventLog/Entries/1/attachment",
"Created": "2022-07-08T17:25:06+00:00",
"EntryType": "Event",
"Id": "1",
"Links": {
"OriginOfCondition": {
"@odata.id": "/redfish/v1/Chassis/chassis/Assembly#/Assemblies/19"
}
},
"Message": "TPM Card",
"Name": "Hardware Isolation Entry",
"Severity": "Warning"
},

Signed-off-by: Gunnar Mills <gmills@us.ibm.com>