### PR TITLE
Remove Inventory.Item.Board interface from Chassis - FW1020.10

### DIFF
--- a/redfish-core/include/utils/chassis_utils.hpp
+++ b/redfish-core/include/utils/chassis_utils.hpp
@@ -16,8 +16,7 @@ void getValidChassisID(const std::shared_ptr<bmcweb::AsyncResp>& asyncResp,
                        const std::string& chassisID, Callback&& callback)
 {
     BMCWEB_LOG_DEBUG << "checkChassisId enter";
-    const std::array<const char*, 2> interfaces = {
-        "xyz.openbmc_project.Inventory.Item.Board",
+    const std::array<const char*, 1> interfaces = {
         "xyz.openbmc_project.Inventory.Item.Chassis"};
 
     auto respHandler = [callback{std::move(callback)}, asyncResp, chassisID](


### PR DESCRIPTION
[SW554254](https://w3.rchland.ibm.com/projects/bestquest/?defect=SW554254): IBM does not use the xyz.openbmc_project.Inventory.Item.Board interface for
chassis objects. Remove that interfaces so only objects implementing
xyz.openbmc_project.Inventory.Item.Chassis are returned for getValidChassisID

Testing not complete.

List of currently files using getValidChassisID():
1) redfish-core/lib/thermal_subsystem.hpp
2) redfish-core/lib/power_supply.hpp
3) redfish-core/lib/fan.hpp
4) redfish-core/lib/environment_metrics.hpp
5) redfish-core/lib/power_subsystem.hpp
6) redfish-core/lib/pcie_slots.hpp
7) redfish-core/lib/power_supply_metrics.hpp)

Signed-off-by: Ali Ahmed <ama213000@gmail.com>