### PR TITLE
Replace CSP plugin-types directive with object-src

### DIFF
--- a/include/security_headers.hpp
+++ b/include/security_headers.hpp
@@ -35,7 +35,7 @@ inline void addSecurityHeaders(const crow::Request& req [[maybe_unused]],
                                                  "connect-src 'self' wss:; "
                                                  "form-action 'none'; "
                                                  "frame-ancestors 'none'; "
-                                                 "plugin-types 'none'; "
+                                                 "object-src 'none'; "
                                                  "base-uri 'none' ");
         // The KVM currently needs to load images from base64 encoded
         // strings. img-src 'self' data: is used to allow that.
@@ -54,7 +54,7 @@ inline void addSecurityHeaders(const crow::Request& req [[maybe_unused]],
                                                  "connect-src *; "
                                                  "form-action *; "
                                                  "frame-ancestors *; "
-                                                 "plugin-types *; "
+                                                 "object-src *; "
                                                  "base-uri *");
 
         const std::string_view origin = req.getHeaderValue("Origin");


### PR DESCRIPTION
Fixes https://w3.rchland.ibm.com/projects/bestquest/?defect=SW554049
fw1020.10

Been merged upstream for 4 months. https://gerrit.openbmc.org/c/openbmc/bmcweb/+/52039

The HTTP Content-Security-Policy (CSP) plugin-types directive has been
removed from the specification and is not supported by most browsers.
Chrome browser suggests to specify "object-src 'none'" instead to block
plugins, so replace it with that directive.

Refer https://github.com/w3c/webappsec-csp/issues/394 for details about
this change.

Tested:
* In Chrome 99.0.4844.74, it no longer gives errors about CSP
  plugin-types directive.
* Checked neiter <embed>, <object> or <applet> tags are used in eiter
  phosphor-webui or webui-vue.
* Using webui-vue, KVM and SOL Console works.

Change-Id: I79d7ed1de2c4d204bf040e7b32a7b6afe354862c
Signed-off-by: Jiaqing Zhao <jiaqing.zhao@intel.com>