### PR TITLE
Update schema to enable panel CM

### DIFF
--- a/redfish-core/lib/assembly.hpp
+++ b/redfish-core/lib/assembly.hpp
@@ -299,9 +299,9 @@ inline void
                                  "xyz.openbmc_project.Inventory.Item")
                         {
                             crow::connections::systemBus->async_method_call(
-                                [aResp, assemblyIndex](
-                                    const boost::system::error_code ec,
-                                    const std::variant<bool>& property) {
+                                [aResp, assemblyIndex,
+                                 assembly](const boost::system::error_code ec,
+                                           const std::variant<bool>& property) {
                                     if (ec)
                                     {
                                         BMCWEB_LOG_DEBUG
@@ -309,6 +309,11 @@ inline void
                                         messages::internalError(aResp->res);
                                         return;
                                     }
+
+                                    std::string fru =
+                                        sdbusplus::message::object_path(
+                                            assembly)
+                                            .filename();
 
                                     nlohmann::json& assemblyArray =
                                         aResp->res.jsonValue["Assemblies"];
@@ -324,16 +329,26 @@ inline void
                                         messages::internalError(aResp->res);
                                         return;
                                     }
-                                    if (*value == false)
+
+                                    // Special handling for LCD and base
+                                    // panel CM.
+                                    if (fru == "panel0" || fru == "panel1")
                                     {
-                                        assemblyData["Status"]["State"] =
-                                            "Absent";
+                                        assemblyData["Oem"]["OpenBMC"]
+                                                    ["@odata.type"] =
+                                                        "#OemAssembly.v1_0_"
+                                                        "0.Assembly";
+
+                                        // if panel is not present,
+                                        // implies it is already
+                                        // removed or can be placed.
+                                        assemblyData["Oem"]["OpenBMC"]
+                                                    ["ReadyToRemove"] =
+                                                        !(*value);
                                     }
-                                    else
-                                    {
-                                        assemblyData["Status"]["State"] =
-                                            "Enabled";
-                                    }
+
+                                    assemblyData["Status"]["State"] =
+                                        (*value == true) ? "Enabled" : "Absent";
                                 },
                                 serviceName, assembly,
                                 "org.freedesktop.DBus.Properties", "Get",
@@ -539,6 +554,43 @@ inline void setAssemblylocationIndicators(
                         "org.freedesktop.systemd1.Manager", "StartUnit",
                         "xyz.openbmc_project.adcsensor.service", "replace");
                 }
+            }
+
+            // Special handling for LCD and base panel. This is required to
+            // support concurrent maintenance for base and LCD panel.
+            else if (sdbusplus::message::object_path(assembly).filename() ==
+                         "panel0" ||
+                     sdbusplus::message::object_path(assembly).filename() ==
+                         "panel1")
+            {
+                // Based on the status of readytoremove flag, inventory data
+                // like CCIN and present property needs to be updated for this
+                // FRU.
+                // readytoremove as true implies FRU has been prepared for
+                // removal. Set action as "deleteFRUVPD". This is the api
+                // exposed by vpd-manager to clear CCIN and set present
+                // property as false for the FRU.
+                // readytoremove as false implies FRU has been replaced. Set
+                // action as "CollectFRUVPD". This is the api exposed by
+                // vpd-manager to recollect vpd for a given FRU.
+                std::string action = (readytoremove.value() == true)
+                                         ? "deleteFRUVPD"
+                                         : "CollectFRUVPD";
+
+                crow::connections::systemBus->async_method_call(
+                    [asyncResp, action](const boost::system::error_code ec) {
+                        if (ec)
+                        {
+                            BMCWEB_LOG_ERROR
+                                << "Call to Manager failed for action: "
+                                << action << " with error " << ec;
+                            messages::internalError(asyncResp->res);
+                            return;
+                        }
+                    },
+                    "com.ibm.VPD.Manager", "/com/ibm/VPD/Manager",
+                    "com.ibm.VPD.Manager", action,
+                    sdbusplus::message::object_path(assembly));
             }
             else
             {


### PR DESCRIPTION
The commit make required changes to enable  panel CM
by initiating the deletion of base and LCD panel FRU
and re-collection of base and LCD panel FRU as and
when initiated via GUI.

Validator was executed for this commit. No error was reported.

Signed-off-by: Sunny Srivastava <sunnsr25@in.ibm.com>