### PR TITLE
Remove async_handshake failed trace

### DIFF
--- a/http/http_connection.hpp
+++ b/http/http_connection.hpp
@@ -301,10 +301,6 @@ class Connection :
                                         const boost::system::error_code& ec) {
                                         if (ec)
                                         {
-                                            BMCWEB_LOG_ERROR
-                                                << this
-                                                << "async_handshake failed: "
-                                                << ec.message();
                                             return;
                                         }
                                         doReadHeaders();


### PR DESCRIPTION
Fix https://w3.rchland.ibm.com/projects/bestquest/?defect=SW554552

https://github.com/ibm-openbmc/bmcweb/commit/6dc5b8923fcecb3d3062e2b9a127262e4bfd26ed
added a trace for async_handshake failed.

These traces can clutter the journal and it isn't like the request is
actually failing.

Jul 15 15:19:49 z2331ebmc bmcweb[1835]: (2022-07-15 15:19:49) [ERROR "http_connection.hpp":303] 0x1945480async_handshake failed: asio.ssl error
Jul 15 15:19:49 z2331ebmc bmcweb[1835]: (2022-07-15 15:19:49) [ERROR "http_connection.hpp":303] 0x1c8f1c0async_handshake failed: asio.ssl error
Jul 15 15:19:49 z2331ebmc bmcweb[1835]: (2022-07-15 15:19:49) [ERROR "http_connection.hpp":303] 0x18810f8async_handshake failed: asio.ssl error
Jul 15 15:19:49 z2331ebmc bmcweb[1835]: (2022-07-15 15:19:49) [ERROR "http_connection.hpp":303] 0x18faba0async_handshake failed: asio.ssl error
Jul 15 15:19:49 z2331ebmc bmcweb[1835]: (2022-07-15 15:19:49) [ERROR "http_connection.hpp":303] 0x1a00ec0async_handshake failed: asio.ssl error
Jul 15 15:19:49 z2331ebmc bmcweb[1835]: (2022-07-15 15:19:49) [ERROR "http_connection.hpp":303] 0x19317e0async_handshake failed: asio.ssl error
Jul 15 15:19:50 z2331ebmc bmcweb[1835]: (2022-07-15 15:19:50) [ERROR "http_connection.hpp":303] 0x1c5cf78async_handshake failed: asio.ssl error
Jul 15 15:27:01 z2331ebmc bmcweb[1835]: (2022-07-15 15:27:01) [ERROR "http_connection.hpp":303] 0x1a54230async_handshake failed: asio.ssl error
Jul 15 15:27:01 z2331ebmc bmcweb[1835]: (2022-07-15 15:27:01) [ERROR "http_connection.hpp":303] 0x1c8ee38async_handshake failed: asio.ssl error
Jul 15 15:27:01 z2331ebmc bmcweb[1835]: (2022-07-15 15:27:01) [ERROR "http_connection.hpp":303] 0x18faba0async_handshake failed: asio.ssl error
Jul 15 15:27:01 z2331ebmc bmcweb[1835]: (2022-07-15 15:27:01) [ERROR "http_connection.hpp":303] 0x193d9b0async_handshake failed: asio.ssl error
Jul 15 15:27:01 z2331ebmc bmcweb[1835]: (2022-07-15 15:27:01) [ERROR "http_connection.hpp":303] 0x1a440f0async_handshake failed: asio.ssl error
Jul 15 15:27:28 z2331ebmc bmcweb[1835]: (2022-07-15 15:27:28) [ERROR "http_connection.hpp":303] 0x19ea888async_handshake failed: asio.ssl error
Jul 15 15:27:28 z2331ebmc bmcweb[1835]: (2022-07-15 15:27:28) [ERROR "http_connection.hpp":303] 0x1a54230async_handshake failed: asio.ssl error

I.e. these aren't a fatal error

Removing this, matches upstream:
https://github.com/openbmc/bmcweb/blob/07c8c20d371aae85611738ca61015fc6a8caa16a/http/http_connection.hpp#L310

We are caring more about journal traces since a few recent defects had
a wrapped journal.

Tested: None.

Signed-off-by: Gunnar Mills <gmills@us.ibm.com>