### PR TITLE
Disallow renaming user accounts

### DIFF
--- a/redfish-core/lib/account_service.hpp
+++ b/redfish-core/lib/account_service.hpp
@@ -2340,6 +2340,13 @@ inline void requestAccountServiceRoutes(App& app)
                 return;
             }
 
+            if (newUserName)
+            {
+                // Disallow renaming users: it breaks the "admin" account
+                messages::propertyNotWritable(asyncResp->res, "UserName");
+                return;
+            }
+            
             // Unauthenticated user
             if (req.session == nullptr)
             {


### PR DESCRIPTION
This change disallows renaming user accounts.  Renaming the admin account breaks the account access, so we disallow account renaming.

Tested via curl:
Created new user account.
Attempt to rename it failed.
PATCH https://${BMC}/redfish/v1/AccountService/Accounts/testuser -d '{"UserName": "someuser"}'
{
  "UserName@Message.ExtendedInfo": [
    {
      "@odata.type": "#Message.v1_1_1.Message",
      "Message": "The property UserName is a read only property and cannot be assigned a value.",
      "MessageArgs": [
        "UserName"
      ],
      "MessageId": "Base.1.8.1.PropertyNotWritable",
      "MessageSeverity": "Warning",
      "Resolution": "Remove the property from the request body and resubmit the request if the operation failed."
    }
  ]
}

Attempt to change password succeeded.

Signed-off-by: Joseph Reynolds <joseph-reynolds@charter.net>