### PR TITLE
New property to always AllowUnauthACFUpload

### DIFF
--- a/redfish-core/lib/account_service.hpp
+++ b/redfish-core/lib/account_service.hpp
@@ -1090,7 +1090,7 @@ inline void
 const std::filesystem::path allowUnauthACFUploadFilename{
     "/var/lib/AllowUnauthACFUpload"};
 
-inline bool SetPropertyAllowUnauthACFUpload(
+inline bool setPropertyAllowUnauthACFUpload(
     const std::shared_ptr<bmcweb::AsyncResp>& asyncResp, bool allow)
 {
     if (allow)
@@ -1139,7 +1139,7 @@ inline bool SetPropertyAllowUnauthACFUpload(
     return true;
 }
 
-inline bool GetPropertyAllowUnauthACFUpload(
+inline bool getPropertyAllowUnauthACFUpload(
     const std::shared_ptr<bmcweb::AsyncResp>& asyncResp, bool& allow)
 {
     std::error_code ec;
@@ -1173,7 +1173,7 @@ inline void getAcfProperties(
     std::string expirationDate = std::get<2>(messageFDbus);
 
     bool alwaysAllowUnauthACFUploadProperty = false;
-    if (!GetPropertyAllowUnauthACFUpload(asyncResp,
+    if (!getPropertyAllowUnauthACFUpload(asyncResp,
                                          alwaysAllowUnauthACFUploadProperty))
     {
         return;
@@ -1817,7 +1817,7 @@ inline void triggerUnauthenticatedACFUpload(
             }
 
             bool allow;
-            GetPropertyAllowUnauthACFUpload(asyncResp, allow);
+            getPropertyAllowUnauthACFUpload(asyncResp, allow);
             if (allow)
             {
                 uploadACF(asyncResp, decodedAcf);
@@ -2669,7 +2669,7 @@ inline void requestAccountServiceRoutes(App& app)
 
                             if (allowUnauthACFUpload)
                             {
-                                if (!SetPropertyAllowUnauthACFUpload(
+                                if (!setPropertyAllowUnauthACFUpload(
                                         asyncResp, *allowUnauthACFUpload))
                                 {
                                     return;

--- a/redfish-core/lib/account_service.hpp
+++ b/redfish-core/lib/account_service.hpp
@@ -24,8 +24,6 @@
 #include <roles.hpp>
 #include <utils/json_utils.hpp>
 
-#include <filesystem>
-#include <iostream>
 #include <string>
 #include <variant>
 #include <vector>
@@ -2485,220 +2483,214 @@ inline void requestAccountServiceRoutes(App& app)
         // because of the special handling of ConfigureSelf, it's not able to
         // yet
         .privileges({{"ConfigureUsers"}, {"ConfigureSelf"}})
-        .methods(boost::beast::http::verb::patch)(
-            [](const crow::Request& req,
-               const std::shared_ptr<bmcweb::AsyncResp>& asyncResp,
-               const std::string& username) -> void {
-                std::optional<std::string> newUserName;
-                std::optional<std::string> password;
-                std::optional<bool> enabled;
-                std::optional<std::string> roleId;
-                std::optional<bool> locked;
-                std::optional<nlohmann::json> oem;
-                std::optional<std::vector<std::string>> accountType;
-                bool isUserItself = false;
+        .methods(
+            boost::beast::http::verb::
+                patch)([](const crow::Request& req,
+                          const std::shared_ptr<bmcweb::AsyncResp>& asyncResp,
+                          const std::string& username) -> void {
+            std::optional<std::string> newUserName;
+            std::optional<std::string> password;
+            std::optional<bool> enabled;
+            std::optional<std::string> roleId;
+            std::optional<bool> locked;
+            std::optional<nlohmann::json> oem;
+            std::optional<std::vector<std::string>> accountType;
+            bool isUserItself = false;
 
-                if (!json_util::readJson(req, asyncResp->res, "UserName",
-                                         newUserName, "Password", password,
-                                         "RoleId", roleId, "Enabled", enabled,
-                                         "Locked", locked, "Oem", oem,
-                                         "AccountTypes", accountType))
+            if (!json_util::readJson(
+                    req, asyncResp->res, "UserName", newUserName, "Password",
+                    password, "RoleId", roleId, "Enabled", enabled, "Locked",
+                    locked, "Oem", oem, "AccountTypes", accountType))
+            {
+                return;
+            }
+
+            // Unauthenticated user
+            if (req.session == nullptr)
+            {
+                // If user is service
+                if (username == "service")
                 {
-                    return;
-                }
-
-                // Unauthenticated user
-                if (req.session == nullptr)
-                {
-                    // If user is service
-                    if (username == "service")
-                    {
-                        if (oem)
-                        {
-                            // allow unauthenticated ACF upload based on panel
-                            // function 74 state.
-                            triggerUnauthenticatedACFUpload(asyncResp, oem);
-                            return;
-                        }
-                    }
-                    messages::insufficientPrivilege(asyncResp->res);
-                    return;
-                }
-
-                // check user isitself or not
-                isUserItself = (username == req.session->username);
-
-                Privileges effectiveUserPrivileges =
-                    redfish::getUserPrivileges(req.userRole);
-                Privileges configureUsers = {"ConfigureUsers"};
-                bool userHasConfigureUsers =
-                    effectiveUserPrivileges.isSupersetOf(configureUsers);
-                if (!userHasConfigureUsers)
-                {
-                    // Irrespective of role can patch ACF if function
-                    // 74 is active from panel.
-                    if (oem && (username == "service"))
+                    if (oem)
                     {
                         // allow unauthenticated ACF upload based on panel
                         // function 74 state.
                         triggerUnauthenticatedACFUpload(asyncResp, oem);
                         return;
                     }
-
-                    // ConfigureSelf accounts can only modify their own account
-                    if (username != req.session->username)
-                    {
-                        messages::insufficientPrivilege(asyncResp->res);
-                        return;
-                    }
-                    // ConfigureSelf accounts can only modify their password
-                    if (!json_util::readJson(req, asyncResp->res, "Password",
-                                             password))
-                    {
-                        return;
-                    }
                 }
+                messages::insufficientPrivilege(asyncResp->res);
+                return;
+            }
 
-                // For accounts which have a Restricted Role, restrict which
-                // properties can be patched.  Allow only Locked, Enabled, and
-                // Oem. Do not even allow the service user to change these
-                // properties. Implementation note: Ideally this would get the
-                // user's RoleId but that would take an additional D-Bus
-                // operation.
-                if ((username == "service") &&
-                    (newUserName || password || roleId))
+            // check user isitself or not
+            isUserItself = (username == req.session->username);
+
+            Privileges effectiveUserPrivileges =
+                redfish::getUserPrivileges(req.userRole);
+            Privileges configureUsers = {"ConfigureUsers"};
+            bool userHasConfigureUsers =
+                effectiveUserPrivileges.isSupersetOf(configureUsers);
+            if (!userHasConfigureUsers)
+            {
+                // Irrespective of role can patch ACF if function
+                // 74 is active from panel.
+                if (oem && (username == "service"))
                 {
-                    BMCWEB_LOG_ERROR
-                        << "Attempt to PATCH user who has a Restricted Role";
-                    messages::restrictedRole(asyncResp->res,
-                                             "OemIBMServiceAgent");
+                    // allow unauthenticated ACF upload based on panel
+                    // function 74 state.
+                    triggerUnauthenticatedACFUpload(asyncResp, oem);
                     return;
                 }
 
-                // Don't allow PATCHing an account to have a Restricted role.
-                if (roleId && redfish::isRestrictedRole(*roleId))
+                // ConfigureSelf accounts can only modify their own account
+                if (username != req.session->username)
                 {
-                    BMCWEB_LOG_ERROR
-                        << "Attempt to PATCH user to have a Restricted Role";
-                    messages::restrictedRole(asyncResp->res, *roleId);
+                    messages::insufficientPrivilege(asyncResp->res);
+                    return;
+                }
+                // ConfigureSelf accounts can only modify their password
+                if (!json_util::readJson(req, asyncResp->res, "Password",
+                                         password))
+                {
+                    return;
+                }
+            }
+
+            // For accounts which have a Restricted Role, restrict which
+            // properties can be patched.  Allow only Locked, Enabled, and Oem.
+            // Do not even allow the service user to change these properties.
+            // Implementation note: Ideally this would get the user's RoleId
+            // but that would take an additional D-Bus operation.
+            if ((username == "service") && (newUserName || password || roleId))
+            {
+                BMCWEB_LOG_ERROR
+                    << "Attempt to PATCH user who has a Restricted Role";
+                messages::restrictedRole(asyncResp->res, "OemIBMServiceAgent");
+                return;
+            }
+
+            // Don't allow PATCHing an account to have a Restricted role.
+            if (roleId && redfish::isRestrictedRole(*roleId))
+            {
+                BMCWEB_LOG_ERROR
+                    << "Attempt to PATCH user to have a Restricted Role";
+                messages::restrictedRole(asyncResp->res, *roleId);
+                return;
+            }
+
+            if (oem)
+            {
+                if (username != "service")
+                {
+                    // Only the service user has Oem properties
+                    messages::propertyUnknown(asyncResp->res, "Oem");
                     return;
                 }
 
-                if (oem)
+                std::optional<nlohmann::json> ibm;
+                if (!redfish::json_util::readJson(*oem, asyncResp->res, "IBM",
+                                                  ibm))
                 {
-                    if (username != "service")
-                    {
-                        // Only the service user has Oem properties
-                        messages::propertyUnknown(asyncResp->res, "Oem");
-                        return;
-                    }
-
-                    std::optional<nlohmann::json> ibm;
-                    if (!redfish::json_util::readJson(*oem, asyncResp->res,
-                                                      "IBM", ibm))
+                    BMCWEB_LOG_ERROR << "Illegal Property ";
+                    messages::propertyMissing(asyncResp->res, "IBM");
+                    return;
+                }
+                if (ibm)
+                {
+                    std::optional<nlohmann::json> acf;
+                    if (!redfish::json_util::readJson(*ibm, asyncResp->res,
+                                                      "ACF", acf))
                     {
                         BMCWEB_LOG_ERROR << "Illegal Property ";
-                        messages::propertyMissing(asyncResp->res, "IBM");
+                        messages::propertyMissing(asyncResp->res, "ACF");
                         return;
                     }
-                    if (ibm)
+                    if (acf)
                     {
-                        std::optional<nlohmann::json> acf;
-                        if (!redfish::json_util::readJson(*ibm, asyncResp->res,
-                                                          "ACF", acf))
+                        std::optional<bool> allowUnauthACFUpload;
+                        std::optional<std::string> acfFile;
+                        if (!redfish::json_util::readJson(
+                                *acf, asyncResp->res, "ACFFile", acfFile,
+                                "AllowUnauthACFUpload",
+                                allowUnauthACFUpload))
                         {
                             BMCWEB_LOG_ERROR << "Illegal Property ";
-                            messages::propertyMissing(asyncResp->res, "ACF");
+                            messages::propertyMissing(asyncResp->res,
+                                                      "ACFFile");
+                            messages::propertyMissing(
+                                asyncResp->res, "AllowUnauthACFUpload");
                             return;
                         }
-                        if (acf)
+
+                        if (acfFile)
                         {
-                            std::optional<bool> allowUnauthACFUpload;
-                            std::optional<std::string> acfFile;
-                            if (!redfish::json_util::readJson(
-                                    *acf, asyncResp->res, "ACFFile", acfFile,
-                                    "AllowUnauthACFUpload",
-                                    allowUnauthACFUpload))
+                            std::vector<uint8_t> decodedAcf;
+                            std::string sDecodedAcf;
+                            if (!crow::utility::base64Decode(*acfFile,
+                                                             sDecodedAcf))
                             {
-                                BMCWEB_LOG_ERROR << "Illegal Property ";
-                                messages::propertyMissing(asyncResp->res,
-                                                          "ACFFile");
-                                messages::propertyMissing(
-                                    asyncResp->res, "AllowUnauthACFUpload");
+                                BMCWEB_LOG_ERROR << "base64 decode failure ";
+                                messages::internalError(asyncResp->res);
                                 return;
                             }
-
-                            if (acfFile)
+                            try
                             {
-                                std::vector<uint8_t> decodedAcf;
-                                std::string sDecodedAcf;
-                                if (!crow::utility::base64Decode(*acfFile,
-                                                                 sDecodedAcf))
-                                {
-                                    BMCWEB_LOG_ERROR
-                                        << "base64 decode failure ";
-                                    messages::internalError(asyncResp->res);
-                                    return;
-                                }
-                                try
-                                {
-                                    std::copy(sDecodedAcf.begin(),
-                                              sDecodedAcf.end(),
-                                              std::back_inserter(decodedAcf));
-                                }
-                                catch (const std::exception& e)
-                                {
-                                    BMCWEB_LOG_ERROR << e.what();
-                                    messages::internalError(asyncResp->res);
-                                    return;
-                                }
-                                uploadACF(asyncResp, decodedAcf);
+                                std::copy(sDecodedAcf.begin(),
+                                          sDecodedAcf.end(),
+                                          std::back_inserter(decodedAcf));
                             }
-
-                            if (allowUnauthACFUpload)
+                            catch (const std::exception& e)
                             {
-                                setPropertyAllowUnauthACFUpload(
-                                    asyncResp, *allowUnauthACFUpload);
+                                BMCWEB_LOG_ERROR << e.what();
+                                messages::internalError(asyncResp->res);
+                                return;
                             }
+                            uploadACF(asyncResp, decodedAcf);
+                        }
+
+                        if (allowUnauthACFUpload)
+                        {
+                            setPropertyAllowUnauthACFUpload(
+                                asyncResp, *allowUnauthACFUpload);
                         }
                     }
                 }
+            }
 
-                // if user name is not provided in the patch method or if it
-                // matches the user name in the URI, then we are treating it as
-                // updating user properties other then username. If username
-                // provided doesn't match the URI, then we are treating this as
-                // user rename request.
-                if (!newUserName || (newUserName.value() == username))
-                {
-                    updateUserProperties(asyncResp, username, password, enabled,
+            // if user name is not provided in the patch method or if it
+            // matches the user name in the URI, then we are treating it as
+            // updating user properties other then username. If username
+            // provided doesn't match the URI, then we are treating this as
+            // user rename request.
+            if (!newUserName || (newUserName.value() == username))
+            {
+                updateUserProperties(asyncResp, username, password, enabled,
+                                     roleId, locked, accountType, isUserItself);
+                return;
+            }
+            crow::connections::systemBus->async_method_call(
+                [asyncResp, username, password(std::move(password)),
+                 roleId(std::move(roleId)), enabled,
+                 newUser{std::string(*newUserName)}, locked, isUserItself,
+                 accountType{std::move(accountType)}](
+                    const boost::system::error_code ec,
+                    sdbusplus::message::message& m) {
+                    if (ec)
+                    {
+                        userErrorMessageHandler(m.get_error(), asyncResp,
+                                                newUser, username);
+                        return;
+                    }
+
+                    updateUserProperties(asyncResp, newUser, password, enabled,
                                          roleId, locked, accountType,
                                          isUserItself);
-                    return;
-                }
-                crow::connections::systemBus->async_method_call(
-                    [asyncResp, username, password(std::move(password)),
-                     roleId(std::move(roleId)), enabled,
-                     newUser{std::string(*newUserName)}, locked, isUserItself,
-                     accountType{std::move(accountType)}](
-                        const boost::system::error_code ec,
-                        sdbusplus::message::message& m) {
-                        if (ec)
-                        {
-                            userErrorMessageHandler(m.get_error(), asyncResp,
-                                                    newUser, username);
-                            return;
-                        }
-
-                        updateUserProperties(asyncResp, newUser, password,
-                                             enabled, roleId, locked,
-                                             accountType, isUserItself);
-                    },
-                    "xyz.openbmc_project.User.Manager",
-                    "/xyz/openbmc_project/user",
-                    "xyz.openbmc_project.User.Manager", "RenameUser", username,
-                    *newUserName);
-            });
+                },
+                "xyz.openbmc_project.User.Manager", "/xyz/openbmc_project/user",
+                "xyz.openbmc_project.User.Manager", "RenameUser", username,
+                *newUserName);
+        });
 
     BMCWEB_ROUTE(app, "/redfish/v1/AccountService/Accounts/<str>/")
         .privileges(redfish::privileges::deleteManagerAccount)

--- a/redfish-core/lib/service_root.hpp
+++ b/redfish-core/lib/service_root.hpp
@@ -20,8 +20,6 @@
 #include <registries/privilege_registry.hpp>
 #include <utils/systemd_utils.hpp>
 
-#include <filesystem>
-
 namespace redfish
 {
 
@@ -88,10 +86,8 @@ inline void
         },
         "xyz.openbmc_project.Settings",
         "/xyz/openbmc_project/ibmacf/allow_unauth_upload",
-        "org.freedesktop.DBus.Properties",
-        "Get",
-        "xyz.openbmc_project.Object.Enable",
-        "Enabled");
+        "org.freedesktop.DBus.Properties", "Get",
+        "xyz.openbmc_project.Object.Enable", "Enabled");
 }
 
 inline void

--- a/redfish-core/lib/service_root.hpp
+++ b/redfish-core/lib/service_root.hpp
@@ -28,38 +28,70 @@ namespace redfish
 inline void
     handleACFWindowActive(const std::shared_ptr<bmcweb::AsyncResp>& asyncResp)
 {
-    bool allow;
-    getPropertyAllowUnauthACFUpload(asyncResp, allow); // ignore return code
-    if (allow)
-    {
-        asyncResp->res.jsonValue["Oem"]["IBM"]["ACFWindowActive"] = true;
-        return;
-    }
-
+    // Redfish property ACFWindowActive = true when D-Bus property
+    // allow_unauth_upload is true (Redfish property AllowUnauthACFUpload).
     crow::connections::systemBus->async_method_call(
-        [asyncResp](const boost::system::error_code ec,
-                    const std::variant<bool>& retVal) {
+        [asyncResp](const boost::system::error_code ec, 
+                    const std::variant<bool>& allowed) {
             if (ec)
             {
-                BMCWEB_LOG_ERROR << "Failed to read ACFWindowActive property";
-                // Default value when panel app is unreachable.
-                asyncResp->res.jsonValue["Oem"]["IBM"]["ACFWindowActive"] =
-                    false;
-                return;
-            }
-            const bool* isACFWindowActive = std::get_if<bool>(&retVal);
-            if (isACFWindowActive == nullptr)
-            {
-                BMCWEB_LOG_ERROR << "nullptr for ACFWindowActive";
+                BMCWEB_LOG_ERROR << "D-Bus response error reading allow_unauth_upload: " << ec;
                 messages::internalError(asyncResp->res);
                 return;
             }
-            asyncResp->res.jsonValue["Oem"]["IBM"]["ACFWindowActive"] =
-                *isACFWindowActive;
+            const bool *allowUnauthACFUpload = std::get_if<bool>(&allowed);
+            if (allowUnauthACFUpload == nullptr)
+            {
+                BMCWEB_LOG_ERROR << "nullptr for allow_unauth_upload";
+                messages::internalError(asyncResp->res);
+                return;
+            }
+            if (*allowUnauthACFUpload == true)
+            {
+                asyncResp->res.jsonValue["Oem"]["IBM"]["ACFWindowActive"] =
+                    *allowUnauthACFUpload;
+                return;
+            }
+
+            // ACFWindowActive = true also when D-Bus property ACFWindowActive
+            // is true (OpPanel function 74).  Otherwise, the Window is not
+            // active.
+            crow::connections::systemBus->async_method_call(
+                [asyncResp](const boost::system::error_code ec,
+                            const std::variant<bool>& retVal) {
+                    bool isActive;
+                    if (ec)
+                    {
+                        BMCWEB_LOG_ERROR
+                            << "Failed to read ACFWindowActive property";
+                        // The Panel app doesn't run on simulated systems.
+                        isActive = false;
+                    }
+                    else
+                    {
+                        const bool* isACFWindowActive = std::get_if<bool>(&retVal);
+                        if (isACFWindowActive == nullptr)
+                        {
+                            BMCWEB_LOG_ERROR << "nullptr for ACFWindowActive";
+                            messages::internalError(asyncResp->res);
+                            return;
+                        }
+                        isActive = *isACFWindowActive;
+                    }
+
+                    asyncResp->res.jsonValue["Oem"]["IBM"]["ACFWindowActive"] =
+                        isActive;
+                },
+                "com.ibm.PanelApp", "/com/ibm/panel_app",
+                "org.freedesktop.DBus.Properties", "Get", "com.ibm.panel",
+                "ACFWindowActive");
         },
-        "com.ibm.PanelApp", "/com/ibm/panel_app",
-        "org.freedesktop.DBus.Properties", "Get", "com.ibm.panel",
-        "ACFWindowActive");
+        "xyz.openbmc_project.Settings",
+        "/xyz/openbmc_project/ibmacf/allow_unauth_upload",
+        "org.freedesktop.DBus.Properties",
+        "Get",
+        "xyz.openbmc_project.Object.Enable",
+        "Enabled");
 }
 
 inline void

--- a/redfish-core/lib/service_root.hpp
+++ b/redfish-core/lib/service_root.hpp
@@ -20,12 +20,22 @@
 #include <registries/privilege_registry.hpp>
 #include <utils/systemd_utils.hpp>
 
+#include <filesystem>
+
 namespace redfish
 {
 
 inline void
     handleACFWindowActive(const std::shared_ptr<bmcweb::AsyncResp>& asyncResp)
 {
+    bool allow;
+    GetPropertyAllowUnauthACFUpload(asyncResp, allow); // ignore return code
+    if (allow)
+    {
+        asyncResp->res.jsonValue["Oem"]["IBM"]["ACFWindowActive"] = true;
+        return;
+    }
+
     crow::connections::systemBus->async_method_call(
         [asyncResp](const boost::system::error_code ec,
                     const std::variant<bool>& retVal) {

--- a/redfish-core/lib/service_root.hpp
+++ b/redfish-core/lib/service_root.hpp
@@ -29,7 +29,7 @@ inline void
     handleACFWindowActive(const std::shared_ptr<bmcweb::AsyncResp>& asyncResp)
 {
     bool allow;
-    GetPropertyAllowUnauthACFUpload(asyncResp, allow); // ignore return code
+    getPropertyAllowUnauthACFUpload(asyncResp, allow); // ignore return code
     if (allow)
     {
         asyncResp->res.jsonValue["Oem"]["IBM"]["ACFWindowActive"] = true;

--- a/static/redfish/v1/JsonSchemas/OemManagerAccount/index.json
+++ b/static/redfish/v1/JsonSchemas/OemManagerAccount/index.json
@@ -85,6 +85,15 @@
                         "boolean"
                     ],
                     "versionAdded": "v1_0_0"
+                },
+                "AllowUnauthACFUpload": {
+                    "description": "This property shall indicate if unauthorized users shall be allowed to upload ACFs.",
+                    "longDescription": "This property indicates if unauthorized users are allowed to upload ACFs or not.  When this property is true, users are allowed to upload ACFs regardless of their authentication status, regardless of their Role, and regardless of the time window created by Operator Panel function 74.",
+                    "readonly": false,
+                    "type": [
+                        "boolean"
+                    ],
+                    "versionAdded": "v1_0_1"
                 }
             },
             "type": "object"

--- a/static/redfish/v1/JsonSchemas/OemManagerAccount/index.json
+++ b/static/redfish/v1/JsonSchemas/OemManagerAccount/index.json
@@ -93,7 +93,7 @@
                     "type": [
                         "boolean"
                     ],
-                    "versionAdded": "v1_0_1"
+                    "versionAdded": "v1_0_0"
                 }
             },
             "type": "object"

--- a/static/redfish/v1/schema/OemManagerAccount.v1_0_0.xml
+++ b/static/redfish/v1/schema/OemManagerAccount.v1_0_0.xml
@@ -53,12 +53,17 @@
 				<Property Name="ExpirationDate" Type="Edm.String" Nullable="true">
 					<Annotation Term="OData.Permissions" EnumMember="OData.Permission/Read"/>
 					<Annotation Term="OData.Description" String="The expiration date of the ACF file."/>
-					<Annotation Term="OData.LongDescription" String="The expiration date of the ACF file, if the expiration date has been from the BMC then the ACF is not validD"/>
+					<Annotation Term="OData.LongDescription" String="The expiration date of the ACF file, if the expiration date has been from the BMC then the ACF is not valid."/>
 				</Property>
 				<Property Name="ACFInstalled" Type="Edm.Boolean">
 					<Annotation Term="OData.Permissions" EnumMember="OData.Permission/Read"/>
 					<Annotation Term="OData.Description" String="This property is set to true if the ACF is installed."/>
 					<Annotation Term="OData.LongDescription" String="This property indicates if the ACF is installed or not."/>
+				</Property>
+				<Property Name="AllowUnauthACFUpload" Type="Edm.Boolean">
+					<Annotation Term="OData.Permissions" EnumMember="OData.Permission/ReadWrite"/>
+					<Annotation Term="OData.Description" String="This property shall indicate if unauthorized users shall be allowed to upload ACFs."/>
+					<Annotation Term="OData.LongDescription" String="This property indicates if unauthorized users are allowed to upload ACFs or not.  When this property is true, users are allowed to upload ACFs regardless of their authentication status, regardless of their Role, and regardless of the time window created by Operator Panel function 74."/>
 				</Property>
 			</ComplexType>
 


### PR DESCRIPTION
This adds a new BMC security setting as a Redfish OEM property: URI /redfish/v1/AccountService/Accounts/service property Oem.IBM.ACF.AllowUnauthACFUpload can be set by the admin.  When true, any network agent is allowed to upload an ACF file to the BMC.  The default value is false.  This capability is included in the existing URI /redfish/v1 property Oem.IBM.ACFWindowActive.  For example, AllowUnauthACFUpload=true implies ACFWindowActive=true.

Tested: via Redfish scenarios
1. Ensure AllowUnauthACFUpload=false by default.
2. Ensure a non admin user is not allowed to GET or PATCH AllowUnauthACFUpload.
3. Ensure the admin can PATCH AllowUnauthACFUpload true and false, and GET the correct values, and these values survive BMC reboot.
4. With (OpPanel fn 74 is not active) and AllowUnauthACFUpload=false, ensure ACFWindowActive=false.  And unauth ACF upload is not allowed.
5. With (OpPanel fn 74 is not active) and AllowUnauthACFUpload=true, ensure ACFWindowActive=true.  And unauth ACF upload is allowed.