### PR TITLE
clang: default inits for variables

### DIFF
--- a/http/obmc_shell.hpp
+++ b/http/obmc_shell.hpp
@@ -21,8 +21,8 @@ class Handler : public std::enable_shared_from_this<Handler>
 {
   public:
     Handler(crow::websocket::Connection* conn) :
-        session(conn), streamFileDescriptor(conn->getIoContext()),
-        doingWrite(false)
+        session(conn), streamFileDescriptor(conn->getIoContext())
+
     {}
 
     ~Handler() = default;
@@ -161,7 +161,7 @@ class Handler : public std::enable_shared_from_this<Handler>
   private:
     crow::websocket::Connection* session;
     boost::asio::posix::stream_descriptor streamFileDescriptor;
-    bool doingWrite;
+    bool doingWrite{false};
     int ttyFileDescriptor;
     pid_t pid;
 

--- a/include/dump_offload.hpp
+++ b/include/dump_offload.hpp
@@ -42,8 +42,7 @@ class Handler : public std::enable_shared_from_this<Handler>
         entryID(entryIDIn),
         dumpType(dumpTypeIn),
         outputBuffer(boost::beast::flat_static_buffer<socketBufferSize>()),
-        unixSocketPath(unixSocketPathIn), unixSocket(ios), dumpSize(0),
-        waitTimer(ios), connectRetryCount(0)
+        unixSocketPath(unixSocketPathIn), unixSocket(ios), waitTimer(ios)
     {}
 
     /**
@@ -313,10 +312,10 @@ class Handler : public std::enable_shared_from_this<Handler>
     boost::beast::flat_static_buffer<socketBufferSize> outputBuffer;
     std::filesystem::path unixSocketPath;
     boost::asio::local::stream_protocol::socket unixSocket;
-    uint64_t dumpSize;
+    uint64_t dumpSize{0};
     boost::asio::steady_timer waitTimer;
     crow::streaming_response::Connection* connection = nullptr;
-    uint16_t connectRetryCount;
+    uint16_t connectRetryCount{0};
 };
 
 static boost::container::flat_map<crow::streaming_response::Connection*,

--- a/include/kvm_websocket.hpp
+++ b/include/kvm_websocket.hpp
@@ -17,7 +17,7 @@ class KvmSession
 {
   public:
     explicit KvmSession(crow::websocket::Connection& connIn) :
-        conn(connIn), hostSocket(conn.getIoContext()), doingWrite(false)
+        conn(connIn), hostSocket(conn.getIoContext())
     {
         boost::asio::ip::tcp::endpoint endpoint(
             boost::asio::ip::make_address("127.0.0.1"), 5900);
@@ -147,7 +147,7 @@ class KvmSession
     boost::asio::ip::tcp::socket hostSocket;
     boost::beast::flat_static_buffer<1024U * 50U> outputBuffer;
     boost::beast::flat_static_buffer<1024U> inputBuffer;
-    bool doingWrite;
+    bool doingWrite{false};
 };
 
 static boost::container::flat_map<crow::websocket::Connection*,

--- a/include/vm_websocket.hpp
+++ b/include/vm_websocket.hpp
@@ -23,7 +23,7 @@ class Handler : public std::enable_shared_from_this<Handler>
 {
   public:
     Handler(const std::string& mediaIn, boost::asio::io_context& ios) :
-        pipeOut(ios), pipeIn(ios), media(mediaIn), doingWrite(false),
+        pipeOut(ios), pipeIn(ios), media(mediaIn),
         outputBuffer(new boost::beast::flat_static_buffer<nbdBufferSize>),
         inputBuffer(new boost::beast::flat_static_buffer<nbdBufferSize>)
     {}
@@ -143,7 +143,7 @@ class Handler : public std::enable_shared_from_this<Handler>
     boost::process::async_pipe pipeIn;
     boost::process::child proxy;
     std::string media;
-    bool doingWrite;
+    bool doingWrite{false};
 
     std::unique_ptr<boost::beast::flat_static_buffer<nbdBufferSize>>
         outputBuffer;

--- a/redfish-core/include/server_sent_events.hpp
+++ b/redfish-core/include/server_sent_events.hpp
@@ -53,9 +53,9 @@ class ServerSentEvents : public std::enable_shared_from_this<ServerSentEvents>
     std::shared_ptr<boost::beast::tcp_stream> sseConn;
     std::queue<std::pair<uint64_t, std::string>> requestDataQueue;
     std::string outBuffer;
-    SseConnState state;
-    int retryCount;
-    int maxRetryAttempts;
+    SseConnState state{SseConnState::startInit};
+    int retryCount{0};
+    int maxRetryAttempts{5};
 
     void sendEvent(const std::string& id, const std::string& msg)
     {
@@ -260,8 +260,8 @@ class ServerSentEvents : public std::enable_shared_from_this<ServerSentEvents>
     ServerSentEvents& operator=(ServerSentEvents&&) = delete;
 
     ServerSentEvents(const std::shared_ptr<boost::beast::tcp_stream>& adaptor) :
-        sseConn(adaptor), state(SseConnState::startInit), retryCount(0),
-        maxRetryAttempts(5)
+        sseConn(adaptor)
+
     {
         startSSE();
     }

--- a/redfish-core/lib/sensors.hpp
+++ b/redfish-core/lib/sensors.hpp
@@ -290,10 +290,9 @@ class InventoryItem
 {
   public:
     InventoryItem(const std::string& objPath) :
-        objectPath(objPath), name(), isPresent(true), isFunctional(true),
-        isPowerSupply(false), powerSupplyEfficiencyPercent(-1), manufacturer(),
-        model(), partNumber(), serialNumber(), sensors(), ledObjectPath(""),
-        ledState(LedState::UNKNOWN)
+        objectPath(objPath), name(), manufacturer(), model(), partNumber(),
+        serialNumber(), sensors(), ledObjectPath("")
+
     {
         // Set inventory item name to last node of object path
         sdbusplus::message::object_path path(objectPath);
@@ -306,17 +305,17 @@ class InventoryItem
 
     std::string objectPath;
     std::string name;
-    bool isPresent;
-    bool isFunctional;
-    bool isPowerSupply;
-    int powerSupplyEfficiencyPercent;
+    bool isPresent{true};
+    bool isFunctional{true};
+    bool isPowerSupply{false};
+    int powerSupplyEfficiencyPercent{-1};
     std::string manufacturer;
     std::string model;
     std::string partNumber;
     std::string serialNumber;
     std::set<std::string> sensors;
     std::string ledObjectPath;
-    LedState ledState;
+    LedState ledState{LedState::UNKNOWN};
 };
 
 /**


### PR DESCRIPTION
Needed to move our downstream CI to more recent clang so changes we pull
in from upstream will pass. This found a few minor issues in our
downstream bmcweb code. I'm sure this is fixed upstream somewhere
already (since CI is passing against upstream code) but cherry picking
in changes from upstream is getting complex due to our divergent
streams. We'll just knock this one out when we fully rebase with
upstream in 1040

Signed-off-by: Andrew Geissler <geissonator@yahoo.com>