### PR TITLE
Resource Dump: Fix dump input argument checks

### DIFF
--- a/redfish-core/lib/log_services.hpp
+++ b/redfish-core/lib/log_services.hpp
@@ -1098,12 +1098,19 @@ inline void createDump(const std::shared_ptr<bmcweb::AsyncResp>& asyncResp,
 
             dumpPath = "/xyz/openbmc_project/dump/resource";
 
-            createDumpParams.emplace_back(
-                std::make_pair("com.ibm.Dump.Create.CreateParameters.VSPString",
-                               resourceDumpParams[1]));
-            createDumpParams.emplace_back(
-                std::make_pair("com.ibm.Dump.Create.CreateParameters.Password",
-                               resourceDumpParams[2]));
+            if (resourceDumpParams.size() >= 2)
+            {
+                createDumpParams.emplace_back(std::make_pair(
+                    "com.ibm.Dump.Create.CreateParameters.VSPString",
+                    resourceDumpParams[1]));
+            }
+
+            if (resourceDumpParams.size() == 3)
+            {
+                createDumpParams.emplace_back(std::make_pair(
+                    "com.ibm.Dump.Create.CreateParameters.Password",
+                    resourceDumpParams[2]));
+            }
         }
         else
         {


### PR DESCRIPTION
Currently resource dump argument  parsing does not have
argument size checks so it tries to access out of bound index and crashes
when user does not pass last argument.

This commit fixes this issue by adding input argument size checks

Tested By:
Tested resource dumps with differnt resource strings
"OEMDiagnosticDataType":"Resource_vsp -globalfr"
"OEMDiagnosticDataType":"Resource_lp 2_pwd"