### PR TITLE
Filter PowerSupplyMetrics via associations

### DIFF
--- a/include/dbus_utility.hpp
+++ b/include/dbus_utility.hpp
@@ -52,6 +52,9 @@ using MapperServiceMap =
 using MapperGetSubTreeResponse =
     std::vector<std::pair<std::string, MapperServiceMap>>;
 
+using MapperGetObject =
+    std::vector<std::pair<std::string, std::vector<std::string>>>;
+
 inline void escapePathForDbus(std::string& path)
 {
     const std::regex reg("[^A-Za-z0-9_/]");

--- a/redfish-core/lib/account_service.hpp
+++ b/redfish-core/lib/account_service.hpp
@@ -79,8 +79,7 @@ using DbusInterfaceType = boost::container::flat_map<
 using ManagedObjectType =
     std::vector<std::pair<sdbusplus::message::object_path, DbusInterfaceType>>;
 
-using GetObjectType =
-    std::vector<std::pair<std::string, std::vector<std::string>>>;
+using GetObjectType = dbus::utility::MapperGetObject;
 
 inline std::string getRoleIdFromPrivilege(std::string_view role)
 {

--- a/redfish-core/lib/assembly.hpp
+++ b/redfish-core/lib/assembly.hpp
@@ -2,6 +2,7 @@
 
 #include "led.hpp"
 
+#include <dbus_utility.hpp>
 #include <utils/json_utils.hpp>
 #include <utils/name_utils.hpp>
 
@@ -107,10 +108,9 @@ inline void
         }
 
         crow::connections::systemBus->async_method_call(
-            [aResp, assemblyIndex, assembly](
-                const boost::system::error_code ec,
-                const std::vector<
-                    std::pair<std::string, std::vector<std::string>>>& object) {
+            [aResp, assemblyIndex,
+             assembly](const boost::system::error_code ec,
+                       const dbus::utility::MapperGetObject& object) {
                 if (ec)
                 {
                     BMCWEB_LOG_DEBUG << "DBUS response error";

--- a/redfish-core/lib/power_supply_metrics.hpp
+++ b/redfish-core/lib/power_supply_metrics.hpp
@@ -206,7 +206,7 @@ inline void
             const dbus::utility::MapperGetObject& intfObject) mutable {
             if (ec)
             {
-                BMCWEB_LOG_DEBUG << "D-Bus response error on GetSubTree " << ec;
+                BMCWEB_LOG_DEBUG << "D-Bus response error on GetObject " << ec;
                 messages::internalError(aResp->res);
                 return;
             }
@@ -314,7 +314,7 @@ inline void getValues(const std::shared_ptr<bmcweb::AsyncResp>& aResp,
  *
  * @param asyncResp     Pointer to object holding response data
  * @param powerSupplyPath Validated power supply path
- * @param callback      Callback for next step to get valid chassis ID
+ * @param callback      Callback for next step to populate Redfish JSON.
  */
 template <typename Callback>
 inline void
@@ -350,7 +350,6 @@ inline void
 
             if (inputHistoryItem != nullptr)
             {
-                // more
                 if ((*inputHistoryItem).size() == 0)
                 {
                     BMCWEB_LOG_ERROR
@@ -369,9 +368,7 @@ inline void
                     inputHistoryPath.push_back(objpath);
                 }
 
-                const std::string& serviceName = "not here";
-
-                callback(inputHistoryPath, serviceName);
+                callback(inputHistoryPath);
             }
         };
 
@@ -433,9 +430,7 @@ inline void requestRoutesPowerSupplyMetrics(App& app)
                             [asyncResp, chassisID, powerSupplyID,
                              validPowerSupplyPath](
                                 const std::optional<std::vector<std::string>>&
-                                    validInputHistoryItem,
-                                [[maybe_unused]] const std::string&
-                                    validInputHistoryService) {
+                                    validInputHistoryItem) {
                                 if (!validInputHistoryItem)
                                 {
                                     BMCWEB_LOG_ERROR

--- a/redfish-core/lib/power_supply_metrics.hpp
+++ b/redfish-core/lib/power_supply_metrics.hpp
@@ -294,6 +294,178 @@ inline void getValues(const std::shared_ptr<bmcweb::AsyncResp>& aResp,
 }
 
 /**
+ * @brief Retrieves valid input history item.
+ *
+ * Not all power supplies support the power input history. Do not provid Redfish
+ * fields for input power history if no associated endpoint matches this
+ * chassis.
+ *
+ * @param asyncResp   Pointer to object holding response data
+ * @param chassisID
+ * @param powerSupplyID
+ * @param callback  Callback for next step to get valid chassis ID
+ */
+template <typename Callback>
+inline void
+    getValidInputHistory(const std::shared_ptr<bmcweb::AsyncResp>& asyncResp,
+                         const std::string& chassisID,
+                         const std::string& powerSupplyID, Callback&& callback)
+{
+    BMCWEB_LOG_DEBUG << "getValidInputHistory enter";
+
+    const std::array<const char*, 2> interfaces = {
+        "org.open_power.Sensor.Aggregation.History.Average",
+        "org.open_power.Sensor.Aggregation.History.Maximum"};
+
+    auto respHandler = [callback{std::move(callback)}, asyncResp, chassisID,
+                        powerSupplyID](
+                           const boost::system::error_code ec,
+                           const std::vector<std::pair<
+                               std::string,
+                               std::vector<std::pair<
+                                   std::string, std::vector<std::string>>>>>&
+                               subtree) {
+        BMCWEB_LOG_DEBUG << "getValidInputHistory respHandler enter";
+
+        if (ec)
+        {
+            BMCWEB_LOG_ERROR << "getValidInputHistory respHandler DBUS error: "
+                             << ec;
+            messages::internalError(asyncResp->res);
+            return;
+        }
+
+        // Set the default value to resourceNotFound, and if we confirm finding
+        // association with chanssisID and powerSupplyID is correct, the error
+        // response will be cleared.
+        messages::resourceNotFound(asyncResp->res, "PowerSupplyMetrics",
+                                   "Metrics");
+
+        for (const auto& object : subtree)
+        {
+            // The association of this input history item is used to
+            // determine whether it belongs to this ChassisID, and therefore
+            // is valid to include for this power supply.
+            crow::connections::systemBus->async_method_call(
+                [callback{std::move(callback)}, asyncResp, chassisID,
+                 powerSupplyID, object](
+                    const boost::system::error_code ec,
+                    const std::variant<std::vector<std::string>>& endpoints) {
+                    if (ec)
+                    {
+                        if (ec.value() == EBADR)
+                        {
+                            // This input history item has no chassis
+                            // association.
+                            BMCWEB_LOG_DEBUG
+                                << "This input history item has no chassis {"
+                                << chassisID << "} association";
+                            return;
+                        }
+
+                        BMCWEB_LOG_ERROR << "DBUS response error";
+                        messages::internalError(asyncResp->res);
+                        return;
+                    }
+
+                    const std::vector<std::string>* itemChassis =
+                        std::get_if<std::vector<std::string>>(&(endpoints));
+
+                    if (itemChassis != nullptr)
+                    {
+                        // more stuff to do.
+                        if ((*itemChassis).size() != 1)
+                        {
+                            BMCWEB_LOG_ERROR
+                                << "Input history item association error! ";
+                            messages::internalError(asyncResp->res);
+                            return;
+                        }
+                        std::vector<std::string> chassisPath = *itemChassis;
+                        sdbusplus::message::object_path path(chassisPath[0]);
+                        std::string chassisName = path.filename();
+                        if (chassisName != chassisID)
+                        {
+                            // The input history item does not belong to the
+                            // chassisID
+                            BMCWEB_LOG_DEBUG
+                                << "This input history item (" << chassisName
+                                << ") does not belong to the chassisID ("
+                                << chassisID << ")";
+                            return;
+                        }
+
+                        sdbusplus::message::object_path itemPath(object.first);
+                        BMCWEB_LOG_DEBUG << "itemPath(object.first): "
+                                         << object.first;
+                        const std::string itemName = itemPath.filename();
+                        const std::string itemNameParent =
+                            itemPath.parent_path();
+                        BMCWEB_LOG_DEBUG << "itemNameParent: "
+                                         << itemNameParent;
+                        sdbusplus::message::object_path itemNameParentPath(
+                            itemNameParent);
+                        const std::string itemNameParentFilename =
+                            itemNameParentPath.filename();
+                        BMCWEB_LOG_DEBUG << "itemNameParentFilename: "
+                                         << itemNameParentFilename;
+                        if (itemName.empty())
+                        {
+                            BMCWEB_LOG_ERROR << "Failed to find itemName in "
+                                             << object.first;
+                            return;
+                        }
+
+                        std::string validPowerSupplyPath;
+
+                        BMCWEB_LOG_DEBUG << "Checking itemName.find("
+                                         << powerSupplyID << ")\n";
+                        if (itemNameParentFilename.find(powerSupplyID) !=
+                            std::string::npos)
+                        {
+                            // Clear resourceNotFound response
+                            asyncResp->res.clear();
+
+                            if (object.second.size() != 1)
+                            {
+                                BMCWEB_LOG_ERROR << "Error getting PowerSupply "
+                                                    "D-Bus object!";
+                                messages::internalError(asyncResp->res);
+                                return;
+                            }
+
+                            const std::string& path = object.first;
+                            const std::string& connectionName =
+                                object.second[0].first;
+
+                            callback(path, connectionName);
+                        }
+                        else
+                        {
+                            BMCWEB_LOG_INFO << "itemNameParentFilename ("
+                                            << itemNameParentFilename
+                                            << ") !find(powerSupplyID ("
+                                            << powerSupplyID << ")";
+                        }
+                    }
+                },
+                "xyz.openbmc_project.ObjectMapper", object.first + "/chassis",
+                "org.freedesktop.DBus.Properties", "Get",
+                "xyz.openbmc_project.Association", "endpoints");
+        }
+    };
+
+    // Get the input history items collection
+    crow::connections::systemBus->async_method_call(
+        respHandler, "xyz.openbmc_project.ObjectMapper",
+        "/xyz/openbmc_project/object_mapper",
+        "xyz.openbmc_project.ObjectMapper", "GetSubTree",
+        "/org/open_power/sensors/aggregation", 0, interfaces);
+
+    BMCWEB_LOG_DEBUG << "getValidInputHistory exit";
+}
+
+/**
  * Systems derived class for delivering OemPowerSupplyMetrics Schema.
  */
 inline void requestRoutesPowerSupplyMetrics(App& app)
@@ -301,76 +473,84 @@ inline void requestRoutesPowerSupplyMetrics(App& app)
     BMCWEB_ROUTE(app, "/redfish/v1/Chassis/<str>/PowerSubsystem/"
                       "PowerSupplies/<str>/Metrics")
         .privileges({{"Login"}})
-        .methods(boost::beast::http::verb::get)(
-            [](const crow::Request&,
-               const std::shared_ptr<bmcweb::AsyncResp>& asyncResp,
-               const std::string& chassisID, const std::string& powerSupplyID) {
-                auto getChassisID = [asyncResp, chassisID, powerSupplyID](
-                                        const std::optional<std::string>&
-                                            validChassisID) {
-                    if (!validChassisID)
-                    {
-                        BMCWEB_LOG_ERROR << "Not a valid chassis ID:"
-                                         << chassisID;
-                        messages::resourceNotFound(asyncResp->res, "Chassis",
-                                                   chassisID);
-                        return;
-                    }
+        .methods(
+            boost::beast::http::verb::
+                get)([](const crow::Request&,
+                        const std::shared_ptr<bmcweb::AsyncResp>& asyncResp,
+                        const std::string& chassisID,
+                        const std::string& powerSupplyID) {
+            auto getChassisID = [asyncResp, chassisID, powerSupplyID](
+                                    const std::optional<std::string>&
+                                        validChassisID) {
+                if (!validChassisID)
+                {
+                    BMCWEB_LOG_ERROR << "Not a valid chassis ID:" << chassisID;
+                    messages::resourceNotFound(asyncResp->res, "Chassis",
+                                               chassisID);
+                    return;
+                }
 
-                    if (chassisID != "chassis")
-                    {
-                        BMCWEB_LOG_ERROR << "No Metrics for chassis ID:"
-                                         << chassisID;
-                        messages::resourceNotFound(asyncResp->res, "Chassis",
-                                                   chassisID);
-                        return;
-                    }
+                BMCWEB_LOG_DEBUG << "ChassisID: " << chassisID;
 
-                    BMCWEB_LOG_DEBUG << "ChassisID: " << chassisID;
-
-                    auto getPowerSupplyHandler =
-                        [asyncResp, chassisID,
-                         powerSupplyID](const std::optional<std::string>&
-                                            validPowerSupplyPath,
-                                        [[maybe_unused]] const std::string&
-                                            validPowerSupplyService) {
-                            if (!validPowerSupplyPath)
-                            {
-                                BMCWEB_LOG_ERROR
-                                    << "Not a valid power supply ID:"
-                                    << powerSupplyID;
-                                messages::resourceNotFound(asyncResp->res,
-                                                           "PowerSupply",
-                                                           powerSupplyID);
-                                return;
-                            }
-
-                            BMCWEB_LOG_DEBUG << "PowerSupplyID: "
+                auto getPowerSupplyHandler =
+                    [asyncResp, chassisID, powerSupplyID](
+                        const std::optional<std::string>& validPowerSupplyPath,
+                        [[maybe_unused]] const std::string&
+                            validPowerSupplyService) {
+                        if (!validPowerSupplyPath)
+                        {
+                            BMCWEB_LOG_ERROR << "Not a valid power supply ID:"
                                              << powerSupplyID;
+                            messages::resourceNotFound(
+                                asyncResp->res, "PowerSupply", powerSupplyID);
+                            return;
+                        }
 
-                            asyncResp->res.jsonValue["@odata.type"] =
-                                "#PowerSupplyMetrics.v1_0_0.PowerSupplyMetrics";
-                            asyncResp->res.jsonValue["@odata.id"] =
-                                "/redfish/v1/Chassis/" + chassisID +
-                                "/PowerSubsystem/PowerSupplies/" +
-                                powerSupplyID + "/Metrics";
-                            asyncResp->res.jsonValue["Name"] =
-                                "Metrics for " + powerSupplyID;
-                            asyncResp->res.jsonValue["Id"] = "Metrics";
+                        BMCWEB_LOG_DEBUG << "PowerSupplyID: " << powerSupplyID;
 
-                            asyncResp->res.jsonValue["Oem"]["@odata.type"] =
-                                "#OemPowerSupplyMetrics.Oem";
-                            asyncResp->res
-                                .jsonValue["Oem"]["IBM"]["@odata.type"] =
-                                "#OemPowerSupplyMetrics.IBM";
-                            getValues(asyncResp, chassisID, powerSupplyID);
-                        };
-                    redfish::power_supply_utils::getValidPowerSupplyID(
-                        asyncResp, chassisID, powerSupplyID,
-                        std::move(getPowerSupplyHandler));
-                };
-                redfish::chassis_utils::getValidChassisID(
-                    asyncResp, chassisID, std::move(getChassisID));
-            });
+                        auto getInputHistoryItemHandler =
+                            [asyncResp, chassisID,
+                             powerSupplyID](const std::optional<std::string>&
+                                                validInputHistoryItem,
+                                            [[maybe_unused]] const std::string&
+                                                validInputHistoryService) {
+                                if (!validInputHistoryItem)
+                                {
+                                    BMCWEB_LOG_ERROR
+                                        << "not a valid input history item:";
+                                    messages::resourceNotFound(asyncResp->res,
+                                                               powerSupplyID,
+                                                               "Metrics");
+                                    return;
+                                }
+                                asyncResp->res.jsonValue["@odata.type"] =
+                                    "#PowerSupplyMetrics.v1_0_0."
+                                    "PowerSupplyMetrics";
+                                asyncResp->res.jsonValue["@odata.id"] =
+                                    "/redfish/v1/Chassis/" + chassisID +
+                                    "/PowerSubsystem/PowerSupplies/" +
+                                    powerSupplyID + "/Metrics";
+                                asyncResp->res.jsonValue["Name"] =
+                                    "Metrics for " + powerSupplyID;
+                                asyncResp->res.jsonValue["Id"] = "Metrics";
+
+                                asyncResp->res.jsonValue["Oem"]["@odata.type"] =
+                                    "#OemPowerSupplyMetrics.Oem";
+                                asyncResp->res
+                                    .jsonValue["Oem"]["IBM"]["@odata.type"] =
+                                    "#OemPowerSupplyMetrics.IBM";
+                                getValues(asyncResp, chassisID, powerSupplyID);
+                            };
+                        getValidInputHistory(
+                            asyncResp, chassisID, powerSupplyID,
+                            std::move(getInputHistoryItemHandler));
+                    };
+                redfish::power_supply_utils::getValidPowerSupplyID(
+                    asyncResp, chassisID, powerSupplyID,
+                    std::move(getPowerSupplyHandler));
+            };
+            redfish::chassis_utils::getValidChassisID(asyncResp, chassisID,
+                                                      std::move(getChassisID));
+        });
 }
 } // namespace redfish


### PR DESCRIPTION
Remove chassisID hardcoded hack. This was added to avoid showing Metrics
for MEX I/O drawer power supplies.

Add in a getValidInputHistory utility. Use associations to get the input
history aggregation items matched up with chassis and power supply.
Default the response to resourceNotFound. If a valid input history item
is found, clear the resourceNoteFound. Only return Redfish Metrics type
for aggregation items (average & maximum) that have an association. This
will avoid providing those Metrics for power supplies that do not
support it (MEX I/O drawer power supplies do not support input history).

Tested:
    Rainier 2S2U + MEX I/O drawer
    Verify Metrics for .../chassis/.../powersupply0 & 1
    Verify error for non-existent powersupply on chassis.
    Verify error for non-existent chassis1.
    Verify Metrics not shown for MEX chassis15363.
    Verify error for non-existent powersupply on MEX chassis15363
    Verify error for attempt to get Metrics from MEX powersupply:
Detailed test notes:
    https://gist.github.com/bjwyman/cae1a0cc6acdb02c4763e137888aae72

Change-Id: I2611dec59f55f116ac10d174308a506fcfc8b296
Signed-off-by: Brandon Wyman <bjwyman@gmail.com>