### PR TITLE
bmcweb: Add property value out of range error msg

### DIFF
--- a/redfish-core/include/error_messages.hpp
+++ b/redfish-core/include/error_messages.hpp
@@ -240,6 +240,21 @@ void propertyValueNotInList(crow::Response& res, const std::string& arg1,
                             const std::string& arg2);
 
 /**
+ * @brief Formats PropertyValueOutOfRange message into JSON
+ * Message body: "The value <arg1> for the property <arg2> is not in the
+ * supported range of acceptable values."
+ *
+ * @param[in] arg1 Parameter of message that will replace %1 in its body.
+ * @param[in] arg2 Parameter of message that will replace %2 in its body.
+ *
+ * @returns Message PropertyValueOutOfRange formatted to JSON */
+nlohmann::json propertyValueOutOfRange(const std::string& arg1,
+                                       const std::string& arg2);
+
+void propertyValueOutOfRange(crow::Response& res, const std::string& arg1,
+                             const std::string& arg2);
+
+/**
  * @brief Formats ResourceAtUriInUnknownFormat message into JSON
  * Message body: "The resource at <arg1> is in a format not recognized by the
  * service."

--- a/redfish-core/lib/bios.hpp
+++ b/redfish-core/lib/bios.hpp
@@ -388,8 +388,12 @@ inline void requestRoutesBiosSettings(App& app)
                         return;
                     }
 
-                    boost::container::flat_map<std::string,
-                                               std::pair<bool, std::string>>
+                    boost::container::flat_map<
+                        std::string,
+                        std::tuple<bool, std::string,
+                                   boost::container::flat_map<
+                                       std::string,
+                                       std::variant<int64_t, std::string>>>>
                         biosAttrsType;
                     const BiosBaseTableType* baseBiosTable =
                         std::get_if<BiosBaseTableType>(&retBiosTable);
@@ -403,17 +407,63 @@ inline void requestRoutesBiosSettings(App& app)
 
                     for (const BiosBaseTableItemType& item : *baseBiosTable)
                     {
+                        const std::vector<OptionsItemType>& optionsVector =
+                            std::get<biosBaseOptions>(item.second);
+
+                        boost::container::flat_map<
+                            std::string, std::variant<int64_t, std::string>>
+                            attrBaseOptions;
+
+                        for (const OptionsItemType& optItem : optionsVector)
+                        {
+                            const std::string& strOptItemType =
+                                std::get<optItemType>(optItem);
+
+                            const std::string& optItemTypeRedfish =
+                                mapBoundTypeToRedfish(strOptItemType);
+
+                            if (optItemTypeRedfish == "UNKNOWN")
+                            {
+                                BMCWEB_LOG_ERROR
+                                    << "optItemTypeRedfish == UNKNOWN";
+                                messages::internalError(asyncResp->res);
+                                return;
+                            }
+                            if (optItemTypeRedfish == "OneOf")
+                            {
+                                const std::string* currValue =
+                                    std::get_if<std::string>(
+                                        &std::get<optItemValue>(optItem));
+                                if (currValue != nullptr)
+                                {
+                                    attrBaseOptions.try_emplace(
+                                        optItemTypeRedfish, *currValue);
+                                }
+                            }
+                            else
+                            {
+                                const int64_t* currValue = std::get_if<int64_t>(
+                                    &std::get<optItemValue>(optItem));
+                                if (currValue != nullptr)
+                                {
+                                    attrBaseOptions.try_emplace(
+                                        optItemTypeRedfish, *currValue);
+                                }
+                            }
+                        }
+
                         biosAttrsType.try_emplace(
                             item.first,
-                            std::make_pair(
+                            std::make_tuple(
                                 std::get<biosBaseReadonlyStatus>(item.second),
-                                std::get<biosBaseAttrType>(item.second)));
+                                std::get<biosBaseAttrType>(item.second),
+                                attrBaseOptions));
                     }
 
                     PendingAttributesType pendingAttributes;
                     for (auto& attrItr : attrsJson.items())
                     {
-                        std::string attrName = attrItr.key();
+                        const std::string& attrName = attrItr.key();
 
                         if (attrName == "")
                         {
@@ -429,7 +479,8 @@ inline void requestRoutesBiosSettings(App& app)
                             return;
                         }
 
-                        bool biosAttrReadOnlyStatus = ((*it).second).first;
+                        const bool& biosAttrReadOnlyStatus =
+                            std::get<0>((*it).second);
                         if (biosAttrReadOnlyStatus == true)
                         {
                             BMCWEB_LOG_ERROR
@@ -439,7 +490,8 @@ inline void requestRoutesBiosSettings(App& app)
                             return;
                         }
 
-                        std::string biosAttrType = ((*it).second).second;
+                        const std::string& biosAttrType =
+                            std::get<1>((*it).second);
                         if (biosAttrType == "")
                         {
                             BMCWEB_LOG_ERROR
@@ -448,7 +500,7 @@ inline void requestRoutesBiosSettings(App& app)
                             return;
                         }
 
-                        std::string biosRedfishAttrType =
+                        const std::string& biosRedfishAttrType =
                             mapAttrTypeToRedfish(biosAttrType);
                         if (biosRedfishAttrType == "Integer")
                         {
@@ -464,13 +516,103 @@ inline void requestRoutesBiosSettings(App& app)
                                                                  val, attrName);
                                 return;
                             }
-                            int64_t attrValue = attrItr.value();
+                            const int64_t& attrValue = attrItr.value();
+
+                            boost::container::flat_map<
+                                std::string, std::variant<int64_t, std::string>>
+                                attrBaseOptionsMap = std::get<2>((*it).second);
+
+                            int64_t lowerBoundVal = 0;
+                            int64_t upperBoundVal = 0;
+
+                            // Get Lower Bound value
+                            auto iter = attrBaseOptionsMap.find("LowerBound");
+                            if (iter != attrBaseOptionsMap.end())
+                            {
+                                lowerBoundVal =
+                                    std::get<int64_t>((*iter).second);
+                            }
+
+                            // Get Upper Bound value
+                            iter = attrBaseOptionsMap.find("UpperBound");
+                            if (iter != attrBaseOptionsMap.end())
+                            {
+                                upperBoundVal =
+                                    std::get<int64_t>((*iter).second);
+                            }
+
+                            if (attrValue < lowerBoundVal ||
+                                attrValue > upperBoundVal)
+                            {
+                                BMCWEB_LOG_ERROR
+                                    << "Attribute value is out of range for "
+                                    << attrName;
+                                std::string val =
+                                    boost::lexical_cast<std::string>(attrValue);
+                                messages::propertyValueOutOfRange(
+                                    asyncResp->res, val, attrName);
+                                return;
+                            }
+
                             pendingAttributes.emplace_back(std::make_pair(
                                 attrName,
                                 std::make_tuple(biosAttrType, attrValue)));
                         }
-                        else if (biosRedfishAttrType == "String" ||
-                                 biosRedfishAttrType == "Enumeration" ||
+                        else if (biosRedfishAttrType == "String")
+                        {
+                            if (attrItr.value().type() !=
+                                nlohmann::json::value_t::string)
+                            {
+                                BMCWEB_LOG_ERROR
+                                    << "The value must be of type String";
+                                std::string val =
+                                    boost::lexical_cast<std::string>(
+                                        attrItr.value());
+                                messages::propertyValueTypeError(asyncResp->res,
+                                                                 val, attrName);
+                                return;
+                            }
+                            boost::container::flat_map<
+                                std::string, std::variant<int64_t, std::string>>
+                                attrBaseOptionsMap = std::get<2>((*it).second);
+
+                            int64_t minStringLength = 0;
+                            int64_t maxStringLength = 0;
+
+                            // Get Minimum String Length
+                            auto iter = attrBaseOptionsMap.find("MinLength");
+                            if (iter != attrBaseOptionsMap.end())
+                            {
+                                minStringLength =
+                                    std::get<int64_t>((*iter).second);
+                            }
+
+                            // Get Maximum String Length
+                            iter = attrBaseOptionsMap.find("MaxLength");
+                            if (iter != attrBaseOptionsMap.end())
+                            {
+                                maxStringLength =
+                                    std::get<int64_t>((*iter).second);
+                            }
+                            const std::string& attrValue = attrItr.value();
+                            const int64_t attrValueLength =
+                                static_cast<int64_t>(attrValue.length());
+                            if (attrValueLength < minStringLength ||
+                                attrValueLength > maxStringLength)
+                            {
+                                BMCWEB_LOG_ERROR << "Attribute value length is "
+                                                    "incorrect for "
+                                                 << attrName;
+                                messages::propertyValueIncorrect(
+                                    asyncResp->res, attrName, attrValue);
+                                return;
+                            }
+
+                            pendingAttributes.emplace_back(std::make_pair(
+                                attrName,
+                                std::make_tuple(biosAttrType, attrValue)));
+                        }
+                        else if (biosRedfishAttrType == "Enumeration" ||
                                  biosRedfishAttrType == "Password")
                         {
                             if (attrItr.value().type() !=

--- a/redfish-core/src/error_messages.cpp
+++ b/redfish-core/src/error_messages.cpp
@@ -549,6 +549,35 @@ void propertyValueNotInList(crow::Response& res, const std::string& arg1,
 
 /**
  * @internal
+ * @brief Formats PropertyValueOutOfRange message into JSON for the specified
+ * property
+ *
+ * See header file for more information
+ * @endinternal
+ */
+nlohmann::json propertyValueOutOfRange(const std::string& arg1,
+                                       const std::string& arg2)
+{
+    return nlohmann::json{
+        {"@odata.type", "#Message.v1_1_1.Message"},
+        {"MessageId", "Base.1.13.0.PropertyValueOutOfRange"},
+        {"Message", "The value " + arg1 + " for the property " + arg2 +
+                        " is not in the supported range of acceptable values."},
+        {"MessageArgs", {arg1, arg2}},
+        {"MessageSeverity", "Warning"},
+        {"Resolution", "Correct the value for the property in the request body "
+                       "and resubmit the request if the operation failed."}};
+}
+
+void propertyValueOutOfRange(crow::Response& res, const std::string& arg1,
+                             const std::string& arg2)
+{
+    res.result(boost::beast::http::status::bad_request);
+    addMessageToJson(res.jsonValue, propertyValueOutOfRange(arg1, arg2), arg2);
+}
+
+/**
+ * @internal
  * @brief Formats ResourceAtUriInUnknownFormat message into JSON
  *
  * See header file for more information


### PR DESCRIPTION
Current implementation displays internal error message when BIOS
attribute value is not within the lower and upper bound values.
Also, the same internal error message is displayed when the length
of the String type value for the attribute to be updated is not
within the specified limit.

This commit displays property value out of range error message for
Integer type-based attributes in case of an error, and property value
incorrect for String type-based attributes.

Testing:
$ curl -k -X PATCH -d '{"Attributes":{"hb_mfg_flags_current":
"000000000000000000000000000000000"}}'
 https://user:password@host/redfish/v1/Systems/system/Bios/Settings
{
  "error": {
    "@Message.ExtendedInfo": [
      {
        "@odata.type": "#Message.v1_1_1.Message",
        "Message": "The property 'hb_mfg_flags_current' with the
requested value of '000000000000000000000000000000000' could not be
written because the value does not meet the constraints of the
implementation.",
        "MessageArgs": [
          "hb_mfg_flags_current",
          "000000000000000000000000000000000"
        ],
        "MessageId": "Base.1.8.1.PropertyValueIncorrect",
        "MessageSeverity": "Warning",
        "Resolution": "No resolution is required."
      }
    ],
    "code": "Base.1.8.1.PropertyValueIncorrect",
    "message": "The property 'hb_mfg_flags_current' with the requested
value of '000000000000000000000000000000000' could not be written
because the value does not meet the constraints of the implementation."
  }
}

$ curl -k -X PATCH -d '{"Attributes":{"hb_ioadapter_enlarged_capacity":
200}}'
 https://user:password@host/redfish/v1/Systems/system/Bios/Settings
{
  "hb_ioadapter_enlarged_capacity@Message.ExtendedInfo": [
    {
      "@odata.type": "#Message.v1_1_1.Message",
      "Message": "The value 200 for the property
hb_ioadapter_enlarged_capacity is not in the supported range of
acceptable values.",
      "MessageArgs": [
        "200",
        "hb_ioadapter_enlarged_capacity"
      ],
      "MessageId": "Base.1.13.0.PropertyValueOutOfRange",
      "MessageSeverity": "Warning",
      "Resolution": "Correct the value for the property in the request
body and resubmit the request if the operation failed."
    }
  ]
}

Signed-off-by: Shantappa Teekappanavar <sbteeks@yahoo.com>