### PR TITLE
Expand Success Case For Audit Logging

### DIFF
--- a/http/http_connection.hpp
+++ b/http/http_connection.hpp
@@ -443,7 +443,8 @@ class Connection :
             (req->method() == boost::beast::http::verb::patch) ||
             (req->method() == boost::beast::http::verb::delete_))
         {
-            if (res.result() == boost::beast::http::status::ok)
+            // Look for good return codes and if so we know the operation passed
+            if ((res.resultInt() >= 200) && (res.resultInt() < 300))
             {
                 audit::auditEvent(*req,
                                   ("op=" + std::string(req->methodString()) +
@@ -460,7 +461,7 @@ class Connection :
                                   false);
             }
         }
-#endif
+#endif // BMCWEB_ENABLE_LINUX_AUDIT_EVENTS
 
         BMCWEB_LOG_INFO << "Response: " << this << ' ' << req->url << ' '
                         << res.resultInt() << " keepalive=" << req->keepAlive();


### PR DESCRIPTION
This change ensures that all "success" responses are catched and audit logs the appropriate message accordingly. Prior to this change, there was a response that was missed because of the method used to determine an valid and invalid request, but this ensures it is logged as well.
