### PR TITLE
Move ClientID parameter out of OEM

### DIFF
--- a/http/http_connection.hpp
+++ b/http/http_connection.hpp
@@ -253,13 +253,12 @@ class Connection :
                 return true;
             }
             sslUser.resize(lastChar);
-            std::string unsupportedClientId = "";
             sessionIsFromTransport = true;
-            userSession = persistent_data::SessionStore::getInstance()
-                              .generateUserSession(
-                                  sslUser, req->ipAddress.to_string(),
-                                  unsupportedClientId,
-                                  persistent_data::PersistenceType::TIMEOUT);
+            userSession =
+                persistent_data::SessionStore::getInstance()
+                    .generateUserSession(
+                        sslUser, req->ipAddress.to_string(), std::nullopt,
+                        persistent_data::PersistenceType::TIMEOUT);
             if (userSession != nullptr)
             {
                 BMCWEB_LOG_DEBUG

--- a/include/authorization.hpp
+++ b/include/authorization.hpp
@@ -85,9 +85,8 @@ static std::shared_ptr<persistent_data::UserSession>
     // needed.
     // This whole flow needs to be revisited anyway, as we can't be
     // calling directly into pam for every request
-    std::string unsupportedClientId = "";
     return persistent_data::SessionStore::getInstance().generateUserSession(
-        user, clientIp.to_string(), unsupportedClientId,
+        user, clientIp.to_string(), std::nullopt,
         persistent_data::PersistenceType::SINGLE_REQUEST, isConfigureSelfOnly);
 }
 #endif

--- a/include/ibm/management_console_rest.hpp
+++ b/include/ibm/management_console_rest.hpp
@@ -615,9 +615,9 @@ inline void
 
             segInfo.push_back(std::make_pair(lockFlags, segmentLength));
         }
-        lockRequestStructure.push_back(
-            make_tuple(req.session->uniqueId, req.session->clientId, lockType,
-                       resourceId, segInfo));
+        lockRequestStructure.push_back(make_tuple(
+            req.session->uniqueId, req.session->clientId.value_or(""), lockType,
+            resourceId, segInfo));
     }
 
     // print lock request into journal
@@ -760,8 +760,8 @@ inline void
     // validate the request ids
 
     auto varReleaselock = crow::ibm_mc_lock::Lock::getInstance().releaseLock(
-        listTransactionIds,
-        std::make_pair(req.session->clientId, req.session->uniqueId));
+        listTransactionIds, std::make_pair(req.session->clientId.value_or(""),
+                                           req.session->uniqueId));
 
     if (!varReleaselock.first)
     {

--- a/include/login_routes.hpp
+++ b/include/login_routes.hpp
@@ -185,12 +185,11 @@ inline void requestRoutes(App& app)
                 }
                 else
                 {
-                    std::string unsupportedClientId = "";
                     auto session =
                         persistent_data::SessionStore::getInstance()
                             .generateUserSession(
                                 username, req.ipAddress.to_string(),
-                                unsupportedClientId,
+                                std::nullopt,
                                 persistent_data::PersistenceType::TIMEOUT,
                                 isConfigureSelfOnly);
 

--- a/include/persistent_data.hpp
+++ b/include/persistent_data.hpp
@@ -223,12 +223,15 @@ class ConfigFile
             if (p.second->persistence !=
                 persistent_data::PersistenceType::SINGLE_REQUEST)
             {
-                sessions.push_back({
-                    {"unique_id", p.second->uniqueId},
-                    {"username", p.second->username},
-                    {"client_ip", p.second->clientIp},
-                    {"client_id", p.second->clientId},
-                });
+                nlohmann::json::object_t session;
+                session["unique_id"] = p.second->uniqueId;
+                session["username"] = p.second->username;
+                session["client_ip"] = p.second->clientIp;
+                if (p.second->clientId)
+                {
+                    session["client_id"] = *p.second->clientId;
+                }
+                sessions.push_back(std::move(session));
             }
         }
 
@@ -311,16 +314,17 @@ class ConfigFile
             if (p.second->persistence !=
                 persistent_data::PersistenceType::SINGLE_REQUEST)
             {
-                sessions.push_back({
-                    {"unique_id", p.second->uniqueId},
-                    {"session_token", p.second->sessionToken},
-                    {"username", p.second->username},
-                    {"csrf_token", p.second->csrfToken},
-                    {"client_ip", p.second->clientIp},
-#ifdef BMCWEB_ENABLE_IBM_MANAGEMENT_CONSOLE
-                    {"client_id", p.second->clientId},
-#endif
-                });
+                nlohmann::json::object_t session;
+                session["unique_id"] = p.second->uniqueId;
+                session["session_token"] = p.second->sessionToken;
+                session["username"] = p.second->username;
+                session["csrf_token"] = p.second->csrfToken;
+                session["client_ip"] = p.second->clientIp;
+                if (p.second->clientId)
+                {
+                    session["client_id"] = *p.second->clientId;
+                }
+                sessions.push_back(std::move(session));
             }
         }
         nlohmann::json& subscriptions = data["subscriptions"];

--- a/redfish-core/lib/redfish_sessions.hpp
+++ b/redfish-core/lib/redfish_sessions.hpp
@@ -37,10 +37,15 @@ inline void fillSessionObject(crow::Response& res,
     res.jsonValue["Name"] = "User Session";
     res.jsonValue["Description"] = "Manager User Session";
     res.jsonValue["ClientOriginIPAddress"] = session.clientIp;
+    if (session.clientId)
+    {
+        res.jsonValue["Context"] = *session.clientId;
+    }
 #ifdef BMCWEB_ENABLE_IBM_MANAGEMENT_CONSOLE
     res.jsonValue["Oem"]["OpenBMC"]["@odata.type"] =
         "#OemSession.v1_0_0.Session";
-    res.jsonValue["Oem"]["OpenBMC"]["ClientID"] = session.clientId;
+    res.jsonValue["Oem"]["OpenBMC"]["ClientID"] = session.clientId.value_or("");
+    ;
 #endif
 }
 
@@ -146,10 +151,10 @@ inline void requestRoutesSession(App& app)
                 std::string username;
                 std::string password;
                 std::optional<nlohmann::json> oemObject;
-                std::string clientId;
+                std::optional<std::string> clientId;
                 if (!json_util::readJson(req, asyncResp->res, "UserName",
-                                         username, "Password", password, "Oem",
-                                         oemObject))
+                                         username, "Password", password,
+                                         "Context", clientId, "Oem", oemObject))
                 {
                     return;
                 }
@@ -188,11 +193,22 @@ inline void requestRoutesSession(App& app)
                     {
                         return;
                     }
+                    std::optional<std::string> oemClientId;
                     if (!json_util::readJson(*bmcOem, asyncResp->res,
-                                             "ClientID", clientId))
+                                             "ClientID", oemClientId))
                     {
                         BMCWEB_LOG_ERROR << "Could not read ClientId";
                         return;
+                    }
+                    if (oemClientId)
+                    {
+                        if (clientId)
+                        {
+                            messages::propertyValueConflict(*oemClientId,
+                                                            *clientId);
+                            return;
+                        }
+                        clientId = *oemClientId;
                     }
                 }
 #endif


### PR DESCRIPTION
Pulling the changes from https://gerrit.openbmc.org/c/openbmc/bmcweb/+/56088 to Move ClientID parameter out of OEM