### PR TITLE
Fix Validator: Bump session schema

### DIFF
--- a/redfish-core/lib/redfish_sessions.hpp
+++ b/redfish-core/lib/redfish_sessions.hpp
@@ -33,7 +33,7 @@ inline void fillSessionObject(crow::Response& res,
     res.jsonValue["UserName"] = session.username;
     res.jsonValue["@odata.id"] =
         "/redfish/v1/SessionService/Sessions/" + session.uniqueId;
-    res.jsonValue["@odata.type"] = "#Session.v1_3_0.Session";
+    res.jsonValue["@odata.type"] = "#Session.v1_5_0.Session";
     res.jsonValue["Name"] = "User Session";
     res.jsonValue["Description"] = "Manager User Session";
     res.jsonValue["ClientOriginIPAddress"] = session.clientIp;


### PR DESCRIPTION
https://github.com/ibm-openbmc/bmcweb/pull/449/files should have bumped the session schema like https://gerrit.openbmc.org/c/openbmc/bmcweb/+/56088 did.

George reported the error here: https://ibm-systems-power.slack.com/archives/C1HT3FHNK/p1666326196830579

![image](https://user-images.githubusercontent.com/5455127/197282413-24cf5e74-2889-4e7c-ab7c-62bad832f381.png)


From https://redfish.dmtf.org/schemas/v1/Session.v1_5_0.json:

"Context": {
    "description": "A client-supplied string that is stored with the session.",
    "longDescription": "This property shall contain a client-supplied context ...
....
    "versionAdded": "v1_5_0"
},

Tested: None.

Signed-off-by: Gunnar Mills <gmills@us.ibm.com>