### PR TITLE
WIP: Audit log fixups

### DIFF
--- a/http/http_connection.hpp
+++ b/http/http_connection.hpp
@@ -437,8 +437,7 @@ class Connection :
         }
 
 #ifdef BMCWEB_ENABLE_LINUX_AUDIT_EVENTS
-        if (((req->method() == boost::beast::http::verb::post) &&
-             audit::checkPostAudit(*req)) ||
+        if ((req->method() == boost::beast::http::verb::post) ||
             (req->method() == boost::beast::http::verb::patch) ||
             (req->method() == boost::beast::http::verb::delete_))
         {

--- a/http/http_connection.hpp
+++ b/http/http_connection.hpp
@@ -441,22 +441,23 @@ class Connection :
             (req->method() == boost::beast::http::verb::patch) ||
             (req->method() == boost::beast::http::verb::delete_))
         {
+
             // Look for good return codes and if so we know the operation passed
             if ((res.resultInt() >= 200) && (res.resultInt() < 300))
             {
-                audit::auditEvent(*req,
-                                  ("op=" + std::string(req->methodString()) +
+                audit::auditEvent(("op=" + std::string(req->methodString()) +
                                    ":" + std::string(req->target()) + " ")
                                       .c_str(),
-                                  true);
+                                  userSession->username,
+                                  req->ipAddress.to_string(), true);
             }
             else
             {
-                audit::auditEvent(*req,
-                                  ("op=" + std::string(req->methodString()) +
+                audit::auditEvent(("op=" + std::string(req->methodString()) +
                                    ":" + std::string(req->target()) + " ")
                                       .c_str(),
-                                  false);
+                                  userSession->username,
+                                  req->ipAddress.to_string(), false);
             }
         }
 #endif // BMCWEB_ENABLE_LINUX_AUDIT_EVENTS

--- a/http/http_connection.hpp
+++ b/http/http_connection.hpp
@@ -442,22 +442,33 @@ class Connection :
             (req->method() == boost::beast::http::verb::delete_))
         {
 
-            // Look for good return codes and if so we know the operation passed
-            if ((res.resultInt() >= 200) && (res.resultInt() < 300))
+            if (userSession != nullptr)
             {
-                audit::auditEvent(("op=" + std::string(req->methodString()) +
-                                   ":" + std::string(req->target()) + " ")
-                                      .c_str(),
-                                  userSession->username,
-                                  req->ipAddress.to_string(), true);
+                // Look for good return codes and if so we know the operation
+                // passed
+                if ((res.resultInt() >= 200) && (res.resultInt() < 300))
+                {
+                    audit::auditEvent(
+                        ("op=" + std::string(req->methodString()) + ":" +
+                         std::string(req->target()) + " ")
+                            .c_str(),
+                        userSession->username, req->ipAddress.to_string(),
+                        true);
+                }
+                else
+                {
+                    audit::auditEvent(
+                        ("op=" + std::string(req->methodString()) + ":" +
+                         std::string(req->target()) + " ")
+                            .c_str(),
+                        userSession->username, req->ipAddress.to_string(),
+                        false);
+                }
             }
             else
             {
-                audit::auditEvent(("op=" + std::string(req->methodString()) +
-                                   ":" + std::string(req->target()) + " ")
-                                      .c_str(),
-                                  userSession->username,
-                                  req->ipAddress.to_string(), false);
+                BMCWEB_LOG_ERROR
+                    << "UserSession is null, not able to log audit event!";
             }
         }
 #endif // BMCWEB_ENABLE_LINUX_AUDIT_EVENTS

--- a/include/audit_events.hpp
+++ b/include/audit_events.hpp
@@ -1,19 +1,18 @@
 #pragma once
 
-#ifdef BMCWEB_ENABLE_LINUX_AUDIT_EVENTS
 #include <libaudit.h>
 
 #include <boost/asio/ip/host_name.hpp>
-#endif
+
+#include <cstring>
+#include <string>
 
 namespace audit
 {
 
-inline void auditEvent([[maybe_unused]] const crow::Request& req,
-                       [[maybe_unused]] const char* opPath,
-                       [[maybe_unused]] bool success)
+inline void auditEvent(const char* opPath, const std::string& userName,
+                       const std::string& ipAddress, bool success)
 {
-#ifdef BMCWEB_ENABLE_LINUX_AUDIT_EVENTS
     int auditfd;
 
     char cnfgBuff[256];
@@ -30,7 +29,7 @@ inline void auditEvent([[maybe_unused]] const crow::Request& req,
     strncpy(cnfgBuff, opPath, std::strlen(opPath) + 1);
 
     // encode user account name to ensure it is in an appropriate format
-    user = audit_encode_nv_string("acct", req.session->username.c_str(), 0);
+    user = audit_encode_nv_string("acct", userName.c_str(), 0);
     if (user == NULL)
     {
         BMCWEB_LOG_ERROR << "Error appending user to audit msg : "
@@ -45,14 +44,12 @@ inline void auditEvent([[maybe_unused]] const crow::Request& req,
 
     if (audit_log_user_message(auditfd, AUDIT_USYS_CONFIG, cnfgBuff,
                                boost::asio::ip::host_name().c_str(),
-                               req.ipAddress.to_string().c_str(), NULL,
-                               int(success)) <= 0)
+                               ipAddress.c_str(), NULL, int(success)) <= 0)
     {
         BMCWEB_LOG_ERROR << "Error writing audit message: " << strerror(errno);
     }
 
     close(auditfd);
-#endif
     return;
 }
 

--- a/include/audit_events.hpp
+++ b/include/audit_events.hpp
@@ -9,17 +9,6 @@
 namespace audit
 {
 
-inline bool checkPostAudit(const crow::Request& req)
-{
-    if ((req.target() == "/redfish/v1/SessionService/Sessions") ||
-        (req.target() == "/redfish/v1/SessionService/Sessions/") ||
-        (req.target() == "/login"))
-    {
-        return false;
-    }
-    return true;
-}
-
 inline void auditEvent([[maybe_unused]] const crow::Request& req,
                        [[maybe_unused]] const char* opPath,
                        [[maybe_unused]] bool success)

--- a/include/audit_events.hpp
+++ b/include/audit_events.hpp
@@ -38,7 +38,7 @@ inline void auditEvent([[maybe_unused]] const crow::Request& req,
         return;
     }
 
-    strcpy(cnfgBuff, opPath);
+    strncpy(cnfgBuff, opPath, std::strlen(opPath) + 1);
 
     // encode user account name to ensure it is in an appropriate format
     user = audit_encode_nv_string("acct", req.session->username.c_str(), 0);


### PR DESCRIPTION
Go with this one instead: https://github.com/ibm-openbmc/bmcweb/pull/500
This one is still here while we work though this but plan to close this. 

1. [swap strcpy for strncpy](https://github.com/ibm-openbmc/bmcweb/commit/e7b4385e76cebc1a7c981cec8cdbd42cbdff18fd)
   a.     strncpy has range checks, which reduce the possibility of overrunning the buffer in the case of a bug. see https://github.com/ibm-openbmc/bmcweb/commit/eb7d3d5400555715d755ed03722dbbfe2b6607c9
2. [Audit all POSTs, including logins](https://github.com/ibm-openbmc/bmcweb/commit/3daddfc3824f6031a56ad5861f0e6fd79792ac74)
   a.    Audit all POSTs
3. [Refactor audit logs](https://github.com/ibm-openbmc/bmcweb/commit/b6488905ab62afb464d3bbdda6b912683284ff60)
   a.  Pass in UserName and IpAddress.
   b.  Move to userSession->username over req.session->username 
   c.  Rely on including in the ifdef in http/http_connection and don't have addition ifdefs in include/audit_events.hpp.
4. [Make sure UserSession is not null](https://github.com/ibm-openbmc/bmcweb/commit/9effd539aaa8fd6a5149738ae8f47825a98cc689)
   a. Have seen core dumps due to req.session->username
   
   
Tested: 

Validator passed.

When Audit is enabled:
Token and basic auth from CURL. 
Using the GUI.
Deleting Error log 
```
Oct 26 21:19:25 rain71bmc audit[1750]: AUDIT1111 pid=1750 uid=0 auid=4294967295 ses=4294967295 msg='op=DELETE:/redfish/v1/Systems/system/LogServices/EventLog/Entries/4 acct="service" exe="/usr/bin/bmcweb" hostname=rain71bmc addr=::ffff:9.163.45.183 terminal=? res=success'
Oct 26 21:19:25 rain71bmc kernel: audit: type=1111 audit(1666819165.407:19): pid=1750 uid=0 auid=4294967295 ses=4294967295 msg='op=DELETE:/redfish/v1/Systems/system/LogServices/EventLog/Entries/4 acct="service" exe="/usr/bin/bmcweb" hostname=rain71bmc addr=::ffff:9.163.45.183 terminal=? res=success'
```

BMC reboot (POST)
```
Oct 27 16:38:25 rain71bmc phosphor-bmc-state-manager[507]: Setting the RequestedBMCTransition field to xyz.openbmc_project.State.BMC.Transition.Reboot
Oct 27 16:38:25 rain71bmc phosphor-bmc-state-manager[507]: Setting the BMCState field to xyz.openbmc_project.State.BMC.BMCState.NotReady
Oct 27 16:38:25 rain71bmc audit[1750]: AUDIT1111 pid=1750 uid=0 auid=4294967295 ses=4294967295 msg='op=POST:/redfish/v1/Managers/bmc/Actions/Manager.Reset acct="service" exe="/usr/bin/bmcweb" hostname=rain71bmc addr=::ffff:9.3.62.80 terminal=? res=success'
Oct 27 16:38:25 rain71bmc kernel: audit: type=1111 audit(1666888705.708:2980): pid=1750 uid=0 auid=4294967295 ses=4294967295 msg='op=POST:/redfish/v1/Managers/bmc/Actions/Manager.Reset acct="service" exe="/usr/bin/bmcweb" hostname=rain71bmc addr=::ffff:9.3.62.80 terminal=? res=success'
```
PATCHing properties like Power restore policy
```
Oct 27 16:40:56 rain71bmc audit[1739]: AUDIT1111 pid=1739 uid=0 auid=4294967295 ses=4294967295 msg='op=PATCH:/redfish/v1/Systems/system acct="service" exe="/usr/bin/bmcweb" hostname=rain71bmc addr=::ffff:9.163.45.183 terminal=? res=success'
Oct 27 16:40:56 rain71bmc bmcweb[1739]: (2022-10-27 16:40:56) [CRITICAL "http_connection.hpp":520] 0x2822490 Response content provided but code was no-content
Oct 27 16:40:56 rain71bmc kernel: audit: type=1111 audit(1666888856.437:14): pid=1739 uid=0 auid=4294967295 ses=4294967295 msg='op=PATCH:/redfish/v1/Systems/system acct="service" exe="/usr/bin/bmcweb" hostname=rain71bmc addr=::ffff:9.163.45.183 terminal=? res=success'
```

I was able to recreate the core dump seen before by deleting ~15 sessions at the same time via the GUI. 
When I tried this with this PR, it did not core dump, although I did see
```
Oct 27 18:58:30 ever6bmc bmcweb[2676]: (2022-10-27 18:58:30) [ERROR "http_connection.hpp":470] UserSession is null, not able to log audit event!
```