### PR TITLE
Remove health.hpp calls where unneeded (#237)

### DIFF
--- a/redfish-core/lib/ethernet.hpp
+++ b/redfish-core/lib/ethernet.hpp
@@ -1589,33 +1589,11 @@ inline void parseInterfaceData(
     const boost::container::flat_set<IPv4AddressData>& ipv4Data,
     const boost::container::flat_set<IPv6AddressData>& ipv6Data)
 {
-    constexpr const std::array<const char*, 1> inventoryForEthernet = {
-        "xyz.openbmc_project.Inventory.Item.Ethernet"};
-
     nlohmann::json& jsonResponse = asyncResp->res.jsonValue;
     jsonResponse["Id"] = ifaceId;
     jsonResponse["@odata.id"] =
         "/redfish/v1/Managers/bmc/EthernetInterfaces/" + ifaceId;
     jsonResponse["InterfaceEnabled"] = ethData.nicEnabled;
-
-    auto health = std::make_shared<HealthPopulate>(asyncResp);
-
-    crow::connections::systemBus->async_method_call(
-        [health](const boost::system::error_code ec,
-                 const dbus::utility::MapperGetSubTreePathsResponse& resp) {
-        if (ec)
-        {
-            return;
-        }
-
-        health->inventory = resp;
-        },
-        "xyz.openbmc_project.ObjectMapper",
-        "/xyz/openbmc_project/object_mapper",
-        "xyz.openbmc_project.ObjectMapper", "GetSubTreePaths", "/", int32_t(0),
-        inventoryForEthernet);
-
-    health->populate();
 
     if (ethData.nicEnabled)
     {

--- a/redfish-core/lib/managers.hpp
+++ b/redfish-core/lib/managers.hpp
@@ -17,7 +17,6 @@
 
 #include "app.hpp"
 #include "dbus_utility.hpp"
-#include "health.hpp"
 #include "query.hpp"
 #include "redfish_util.hpp"
 #include "registries/privilege_registry.hpp"
@@ -2037,10 +2036,6 @@ inline void requestRoutesManager(App& app)
 
         asyncResp->res.jsonValue["Links"]["ManagerForServers"] =
             std::move(managerForServers);
-
-        auto health = std::make_shared<HealthPopulate>(asyncResp);
-        health->isManagersHealth = true;
-        health->populate();
 
         sw_util::populateSoftwareInformation(asyncResp, sw_util::bmcPurpose,
                                              "FirmwareVersion", true);

--- a/redfish-core/lib/task.hpp
+++ b/redfish-core/lib/task.hpp
@@ -478,8 +478,6 @@ inline void requestRoutesTaskService(App& app)
 
         asyncResp->res.jsonValue["LifeCycleEventOnTaskStateChange"] = true;
 
-        auto health = std::make_shared<HealthPopulate>(asyncResp);
-        health->populate();
         asyncResp->res.jsonValue["Status"]["State"] = "Enabled";
         asyncResp->res.jsonValue["ServiceEnabled"] = true;
         asyncResp->res.jsonValue["Tasks"]["@odata.id"] =


### PR DESCRIPTION
Fixes https://github.com/ibm-openbmc/dev/issues/3459

health.hpp is based on https://github.com/openbmc/docs/blob/master/designs/redfish-health-rolllup.md

It uses a xyz.openbmc_project.Inventory.Item.Global to identify resources that have a HealthRollup and then uses "critical" or "warning" associations to set that HealthRollup. It is largely unused by us downstream. The only place we are using healthRollup is chassis. This change removes health.hpp expect from chassis.hpp. Instead we tend to us Functional to set the Health and haven't been setting HealthRollup.

We have recently hit some performance problems and Andrew noted "Over a 13 second window at runtime on an Everest, there was 1.8 MB/s traffic over D-Bus. The biggest packet size (mapper←bmcweb) was 500KB."

Atleast some of these 500KB packets were theorized to be health.hpp's "busctl call xyz.openbmc_project.ObjectMapper / org.freedesktop.DBus.ObjectManager GetManagedObjects". This inefficient query should be addressed upstream, for the time being though let's just remove health.hpp except where it is needed.

Commit has been cherry-picked to 1040.

Tested: loaded on a system. 

For example, no longer see system healthrollup
```
"Status": {
"Health": "OK",
"State": "Disabled"
},
```

Other resources impacted (storage, manager, etc) look good too.

Signed-off-by: Gunnar Mills <gmills@us.ibm.com>