### PR TITLE
Add PartNumber to Cables (#394)

### DIFF
--- a/redfish-core/lib/cable.hpp
+++ b/redfish-core/lib/cable.hpp
@@ -117,6 +117,26 @@ inline void
                     const dbus::utility::DBusPropertiesMap& properties) {
                 fillCableProperties(asyncResp->res, ec, properties);
                 });
+
+            sdbusplus::asio::getProperty<std::string>(
+                *crow::connections::systemBus, service, cableObjectPath,
+                "xyz.openbmc_project.Inventory.Decorator.Asset", "PartNumber",
+                [asyncResp](const boost::system::error_code ec,
+                            const std::string& property) {
+                if (ec.value() == EBADR)
+                {
+                    // PartNumber is optional, ignore the failure if it doesn't
+                    // exist.
+                    return;
+                }
+                if (ec)
+                {
+                    BMCWEB_LOG_DEBUG << "DBus response error for PartNumber";
+                    messages::internalError(asyncResp->res);
+                    return;
+                }
+                asyncResp->res.jsonValue["PartNumber"] = property;
+                });
         }
     }
 }


### PR DESCRIPTION
Add PartNumber property to cables.
Also fix code so CableType and LengthMeters properties display correctly.

Testing:
1) Redfish validator passed

2) curl testing:
time curl -k -H "X-Auth-Token: $token" -X GET \
https://$bmc/redfish/v1/Cables/external_cable_0

{
  "@odata.id": "/redfish/v1/Cables/external_cable_0",
  "@odata.type": "#Cable.v1_2_0.Cable",
  "CableStatus": "Normal",
  "CableType": "optical",
  "Id": "external_cable_0",
  "LengthMeters": 2.0,
  ...
  "Name": "Cable",
  "PartNumber": "78P6567 ",
  "Status": {
    "Health": "OK",
    "State": "Enabled"
  }
}
Signed-off-by: Ali Ahmed <ama213000@gmail.com>