### PR TITLE
After other services

### DIFF
--- a/config/bmcweb.service.in
+++ b/config/bmcweb.service.in
@@ -7,6 +7,7 @@ Wants=network.target
 After=network.target
 After=xyz.openbmc_project.User.Manager.service
 After=xyz.openbmc_project.State.BMC.service
+After=xyz.openbmc_project.Software.BMC.Updater.service
 
 [Service]
 ExecReload=kill -s HUP $MAINPID

--- a/config/bmcweb.service.in
+++ b/config/bmcweb.service.in
@@ -5,6 +5,7 @@ StartLimitBurst=4
 
 Wants=network.target
 After=network.target
+After=xyz.openbmc_project.User.Manager.service
 
 [Service]
 ExecReload=kill -s HUP $MAINPID

--- a/config/bmcweb.service.in
+++ b/config/bmcweb.service.in
@@ -8,6 +8,7 @@ After=network.target
 After=xyz.openbmc_project.User.Manager.service
 After=xyz.openbmc_project.State.BMC.service
 After=xyz.openbmc_project.Software.BMC.Updater.service
+After=xyz.openbmc_project.State.Host@0.service
 
 [Service]
 ExecReload=kill -s HUP $MAINPID

--- a/config/bmcweb.service.in
+++ b/config/bmcweb.service.in
@@ -6,6 +6,7 @@ StartLimitBurst=4
 Wants=network.target
 After=network.target
 After=xyz.openbmc_project.User.Manager.service
+After=xyz.openbmc_project.State.BMC.service
 
 [Service]
 ExecReload=kill -s HUP $MAINPID


### PR DESCRIPTION
This is 4 cherry-picks: 
1. https://github.com/ibm-openbmc/bmcweb/pull/222  Add pre-req to phosphor-user-manager service #222 
2. https://github.com/ibm-openbmc/bmcweb/commit/5c1f9c758d11c90326e94d80d034b41a3a126e28 Start bmcweb after bmc state manager (https://github.com/ibm-openbmc/bmcweb/pull/298)
3. https://github.com/ibm-openbmc/bmcweb/commit/802c381289fe3b2dd715e9c4fda88a30ccbc48b4 Start bmcweb after bmc code update manager (https://github.com/ibm-openbmc/bmcweb/pull/302)
4. https://github.com/ibm-openbmc/bmcweb/commit/222d582231f83b3cc51deb26837f951072417b51 SW547232: Start bmcweb after host state manager (https://github.com/ibm-openbmc/bmcweb/pull/306)

These were all needed so bmcweb doesn't come up until we have the required services. 

https://gerrit.openbmc.org/c/openbmc/bmcweb/+/50314 is attempting to get in 1. 

Tested: built 1050 and 
```
journalctl | grep Started | grep 'Phosphor Host\|bmcweb\|OpenBMC Software\|Phosphor User'

Jan 07 02:19:08 ever8bmc systemd[1]: Started Phosphor certificate manager for bmcweb.
Jan 07 02:19:19 ever8bmc systemd[1]: Started Phosphor User Manager.
Jan 07 02:19:23 ever8bmc systemd[1]: Started OpenBMC Software Update Manager.
Jan 07 02:19:27 ever8bmc systemd[1]: Started Phosphor Host State Manager.
Jan 07 02:19:53 ever8bmc systemd[1]: Started Start bmcweb server.


```