### PR TITLE
bmcweb: Ignore Cable Length property value if NaN

### DIFF
--- a/redfish-core/lib/cable.hpp
+++ b/redfish-core/lib/cable.hpp
@@ -49,15 +49,17 @@ inline void
     {
         if (!std::isfinite(*length))
         {
-            if (std::isnan(*length))
+            // Cable length is NaN by default, do not throw an error
+            if (!std::isnan(*length))
             {
+                messages::internalError(resp);
                 return;
             }
-            messages::internalError(resp);
-            return;
         }
-
-        resp.jsonValue["LengthMeters"] = *length;
+        else
+        {
+            resp.jsonValue["LengthMeters"] = *length;
+        }
     }
 
     if (cableStatus != nullptr && !cableStatus->empty())


### PR DESCRIPTION
Cable Length property value is NaN by default. The current implementation ignores processing other remaining Cable properties if the length is NaN. Per Ed's comment here we need to ignore if length is NaN and continue to process remaining properties: https://gerrit.openbmc.org/c/openbmc/bmcweb/+/50265/4..7/redfish-core/lib/cable.hpp#b51

Testing:
1. Validator test not done, assumed it is OK since it is a minor change in the code logic.

2. curl testing: $ curl -k https://user:password@host:18080/redfish/v1/Cables/dp0_cable1 {
  "@odata.id": "/redfish/v1/Cables/dp0_cable1",
  "@odata.type": "#Cable.v1_2_0.Cable",
  "CableStatus": "Normal",
  "CableType": "",
  "Id": "dp0_cable1",
  "Name": "Cable",
  "Status": {
    "Health": "OK",
    "State": "StandbyOffline"
  }
}

Upstream is https://gerrit.openbmc.org/c/openbmc/bmcweb/+/58465

Signed-off-by: Shantappa Teekappanavar <shantappa.teekappanavar@ibm.com>
Change-Id: If73828484d91bbf2eee45a31973c825bab008ba4