### PR TITLE
New property to always AllowUnauthACFUpload

### DIFF
--- a/redfish-core/lib/account_service.hpp
+++ b/redfish-core/lib/account_service.hpp
@@ -1077,6 +1077,29 @@ inline void
         std::variant<std::string>(userNameAttribute));
 }
 
+inline void setPropertyAllowUnauthACFUpload(
+    const std::shared_ptr<bmcweb::AsyncResp>& asyncResp, bool allow)
+{
+    crow::connections::systemBus->async_method_call(
+        [asyncResp, allow](const boost::system::error_code ec) {
+            if (ec)
+            {
+                BMCWEB_LOG_ERROR << "D-Bus responses error: " << ec;
+                messages::internalError(asyncResp->res);
+                return;
+            }
+            messages::success(asyncResp->res);
+            return;
+        },
+        "xyz.openbmc_project.Settings",
+        "/xyz/openbmc_project/ibmacf/allow_unauth_upload",
+        "org.freedesktop.DBus.Properties",
+        "Set",
+        "xyz.openbmc_project.Object.Enable",
+        "Enabled",
+        std::variant<bool>(allow));
+}
+
 inline void getAcfProperties(
     const std::shared_ptr<bmcweb::AsyncResp>& asyncResp,
     const std::tuple<std::vector<uint8_t>, bool, std::string>& messageFDbus)
@@ -1175,6 +1198,26 @@ inline void getAcfProperties(
     }
     asyncResp->res.jsonValue["Oem"]["IBM"]["ACF"]["ACFInstalled"] =
         acfInstalled;
+
+    crow::connections::systemBus->async_method_call(
+        [asyncResp](const boost::system::error_code ec, 
+                    const std::variant<bool>& retval) {
+            if (ec)
+            {
+                BMCWEB_LOG_ERROR << "D-Bus responses error: " << ec;
+                messages::internalError(asyncResp->res);
+                return;
+            }
+            const bool *allowed = std::get_if<bool>(&retval);
+            asyncResp->res.jsonValue["Oem"]["IBM"]["ACF"]
+                ["AllowUnauthACFUpload"] = *allowed;
+        },
+        "xyz.openbmc_project.Settings",
+        "/xyz/openbmc_project/ibmacf/allow_unauth_upload",
+        "org.freedesktop.DBus.Properties",
+        "Get",
+        "xyz.openbmc_project.Object.Enable",
+        "Enabled");
 }
 
 /**
@@ -1667,10 +1710,15 @@ inline void uploadACF(const std::shared_ptr<bmcweb::AsyncResp>& asyncResp,
         "InstallACF", decodedAcf);
 }
 
+// This is called when someone either is not authenticated or is not
+// authorized to upload an ACF, and they are trying to upload an ACF;
+// in this condition, uploading an ACF is allowed when
+// AllowUnauthACFUpload is true.
 inline void triggerUnauthenticatedACFUpload(
     const std::shared_ptr<bmcweb::AsyncResp>& asyncResp,
     std::optional<nlohmann::json> oem)
 {
+    std::vector<uint8_t> decodedAcf;
     std::optional<nlohmann::json> ibm;
     if (!redfish::json_util::readJson(*oem, asyncResp->res, "IBM", ibm))
     {
@@ -1691,7 +1739,6 @@ inline void triggerUnauthenticatedACFUpload(
 
         if (acf)
         {
-            std::vector<uint8_t> decodedAcf;
             std::optional<std::string> acfFile;
             if (acf.value().contains("ACFFile") &&
                 acf.value()["ACFFile"] == nullptr)
@@ -1727,43 +1774,78 @@ inline void triggerUnauthenticatedACFUpload(
                     return;
                 }
             }
+        }
+    }
 
+    // Allow ACF upload when D-Bus property allow_unauth_upload is true (aka
+    // Redfish property AllowUnauthACFUpload).
+    crow::connections::systemBus->async_method_call(
+        [asyncResp, decodedAcf](const boost::system::error_code ec, 
+                    const std::variant<bool>& allowed) {
+            if (ec)
+            {
+                BMCWEB_LOG_ERROR << "D-Bus response error reading allow_unauth_upload: " << ec;
+                messages::internalError(asyncResp->res);
+                return;
+            }
+            const bool *allowUnauthACFUpload = std::get_if<bool>(&allowed);
+            if (allowUnauthACFUpload == nullptr)
+            {
+                BMCWEB_LOG_ERROR << "nullptr for allow_unauth_upload";
+                messages::internalError(asyncResp->res);
+                return;
+            }
+            if (*allowUnauthACFUpload == true)
+            {
+                uploadACF(asyncResp, decodedAcf);
+                return;
+            }
+
+            // Allow ACF upload when D-Bus property ACFWindowActive is true
+            // (aka OpPanel function 74).
             crow::connections::systemBus->async_method_call(
                 [asyncResp, decodedAcf](const boost::system::error_code ec,
                                         const std::variant<bool>& retVal) {
+                    bool isActive;
                     if (ec)
                     {
                         BMCWEB_LOG_ERROR
                             << "Failed to read ACFWindowActive property";
-                        messages::internalError(asyncResp->res);
-                        return;
+                        // The Panel app doesn't run on simulated systems.
+                        isActive = false;
                     }
-
-                    const bool* isACFWindowActive = std::get_if<bool>(&retVal);
-
-                    if (isACFWindowActive == nullptr)
+                    else
                     {
-                        BMCWEB_LOG_ERROR << "nullptr for ACFWindowActive";
-                        messages::internalError(asyncResp->res);
-                        return;
+                        const bool* isACFWindowActive = std::get_if<bool>(&retVal);
+                        if (isACFWindowActive == nullptr)
+                        {
+                            BMCWEB_LOG_ERROR << "nullptr for ACFWindowActive";
+                            messages::internalError(asyncResp->res);
+                            return;
+                        }
+                        isActive = *isACFWindowActive;
                     }
-
-                    if (*isACFWindowActive == true)
+                    
+                    if (isActive == true)
                     {
                         uploadACF(asyncResp, decodedAcf);
                         return;
                     }
 
-                    BMCWEB_LOG_ERROR << "ACF window not set to "
-                                        "active from panel";
+                    BMCWEB_LOG_ERROR << "ACF upload not allowed";
                     messages::insufficientPrivilege(asyncResp->res);
                     return;
                 },
                 "com.ibm.PanelApp", "/com/ibm/panel_app",
                 "org.freedesktop.DBus.Properties", "Get", "com.ibm.panel",
                 "ACFWindowActive");
-        }
-    }
+        },
+        "xyz.openbmc_project.Settings",
+        "/xyz/openbmc_project/ibmacf/allow_unauth_upload",
+        "org.freedesktop.DBus.Properties",
+        "Get",
+        "xyz.openbmc_project.Object.Enable",
+        "Enabled");
 }
 
 inline void requestAccountServiceRoutes(App& app)
@@ -2499,6 +2581,13 @@ inline void requestAccountServiceRoutes(App& app)
 
             if (oem)
             {
+                if (username != "service")
+                {
+                    // Only the service user has Oem properties
+                    messages::propertyUnknown(asyncResp->res, "Oem");
+                    return;
+                }
+
                 std::optional<nlohmann::json> ibm;
                 if (!redfish::json_util::readJson(*oem, asyncResp->res, "IBM",
                                                   ibm))
@@ -2517,26 +2606,26 @@ inline void requestAccountServiceRoutes(App& app)
                         messages::propertyMissing(asyncResp->res, "ACF");
                         return;
                     }
-                    if (acf && (username == "service"))
+                    if (acf)
                     {
-                        std::vector<uint8_t> decodedAcf;
+                        std::optional<bool> allowUnauthACFUpload;
                         std::optional<std::string> acfFile;
-                        if (acf.value().contains("ACFFile") &&
-                            acf.value()["ACFFile"] == nullptr)
+                        if (!redfish::json_util::readJson(
+                                *acf, asyncResp->res, "ACFFile", acfFile,
+                                "AllowUnauthACFUpload",
+                                allowUnauthACFUpload))
                         {
-                            acfFile = "";
+                            BMCWEB_LOG_ERROR << "Illegal Property ";
+                            messages::propertyMissing(asyncResp->res,
+                                                      "ACFFile");
+                            messages::propertyMissing(
+                                asyncResp->res, "AllowUnauthACFUpload");
+                            return;
                         }
-                        else
-                        {
-                            if (!redfish::json_util::readJson(
-                                    *acf, asyncResp->res, "ACFFile", acfFile))
-                            {
-                                BMCWEB_LOG_ERROR << "Illegal Property ";
-                                messages::propertyMissing(asyncResp->res,
-                                                          "ACFFile");
-                                return;
-                            }
 
+                        if (acfFile)
+                        {
+                            std::vector<uint8_t> decodedAcf;
                             std::string sDecodedAcf;
                             if (!crow::utility::base64Decode(*acfFile,
                                                              sDecodedAcf))
@@ -2557,16 +2646,14 @@ inline void requestAccountServiceRoutes(App& app)
                                 messages::internalError(asyncResp->res);
                                 return;
                             }
+                            uploadACF(asyncResp, decodedAcf);
                         }
 
-                        uploadACF(asyncResp, decodedAcf);
-                    }
-                    else if (acf && (username != "service"))
-                    {
-                        messages::resourceAtUriUnauthorized(
-                            asyncResp->res, std::string(req.url),
-                            "ACF properties access not allowed by non service "
-                            "user");
+                        if (allowUnauthACFUpload)
+                        {
+                            setPropertyAllowUnauthACFUpload(
+                                asyncResp, *allowUnauthACFUpload);
+                        }
                     }
                 }
             }

--- a/redfish-core/lib/account_service.hpp
+++ b/redfish-core/lib/account_service.hpp
@@ -1207,6 +1207,12 @@ inline void getAcfProperties(
                 return;
             }
             const bool* allowed = std::get_if<bool>(&retval);
+            if (allowed == nullptr)
+            {
+                BMCWEB_LOG_ERROR << "Property 'allowed' is not bool";
+                messages::internalError(asyncResp->res);
+                return;
+            }
             asyncResp->res
                 .jsonValue["Oem"]["IBM"]["ACF"]["AllowUnauthACFUpload"] =
                 *allowed;

--- a/redfish-core/lib/account_service.hpp
+++ b/redfish-core/lib/account_service.hpp
@@ -1825,7 +1825,7 @@ inline void triggerUnauthenticatedACFUpload(
                         }
                         isActive = *isACFWindowActive;
                     }
-                    
+
                     if (isActive == true)
                     {
                         uploadACF(asyncResp, decodedAcf);

--- a/redfish-core/lib/service_root.hpp
+++ b/redfish-core/lib/service_root.hpp
@@ -29,15 +29,17 @@ inline void
     // Redfish property ACFWindowActive = true when D-Bus property
     // allow_unauth_upload is true (Redfish property AllowUnauthACFUpload).
     crow::connections::systemBus->async_method_call(
-        [asyncResp](const boost::system::error_code ec, 
+        [asyncResp](const boost::system::error_code ec,
                     const std::variant<bool>& allowed) {
             if (ec)
             {
-                BMCWEB_LOG_ERROR << "D-Bus response error reading allow_unauth_upload: " << ec;
+                BMCWEB_LOG_ERROR
+                    << "D-Bus response error reading allow_unauth_upload: "
+                    << ec;
                 messages::internalError(asyncResp->res);
                 return;
             }
-            const bool *allowUnauthACFUpload = std::get_if<bool>(&allowed);
+            const bool* allowUnauthACFUpload = std::get_if<bool>(&allowed);
             if (allowUnauthACFUpload == nullptr)
             {
                 BMCWEB_LOG_ERROR << "nullptr for allow_unauth_upload";
@@ -67,7 +69,8 @@ inline void
                     }
                     else
                     {
-                        const bool* isACFWindowActive = std::get_if<bool>(&retVal);
+                        const bool* isACFWindowActive =
+                            std::get_if<bool>(&retVal);
                         if (isACFWindowActive == nullptr)
                         {
                             BMCWEB_LOG_ERROR << "nullptr for ACFWindowActive";

--- a/redfish-core/lib/service_root.hpp
+++ b/redfish-core/lib/service_root.hpp
@@ -68,8 +68,8 @@ inline void
                         BMCWEB_LOG_ERROR
                             << "Failed to read ACFWindowActive property";
                         // The Panel app doesn't run on simulated systems.
-                        asyncResp->res.jsonValue["Oem"]["IBM"]["ACFWindowActive"] =
-                            false;
+                        asyncResp->res
+                            .jsonValue["Oem"]["IBM"]["ACFWindowActive"] = false;
                         return;
                     }
                     const bool* isACFWindowActive = std::get_if<bool>(&retVal);

--- a/static/redfish/v1/JsonSchemas/OemManagerAccount/index.json
+++ b/static/redfish/v1/JsonSchemas/OemManagerAccount/index.json
@@ -85,6 +85,15 @@
                         "boolean"
                     ],
                     "versionAdded": "v1_0_0"
+                },
+                "AllowUnauthACFUpload": {
+                    "description": "This property shall indicate if unauthorized users shall be allowed to upload ACFs.",
+                    "longDescription": "This property indicates if unauthorized users are allowed to upload ACFs or not.  When this property is true, users are allowed to upload ACFs regardless of their authentication status, regardless of their Role, and regardless of the time window created by Operator Panel function 74.",
+                    "readonly": false,
+                    "type": [
+                        "boolean"
+                    ],
+                    "versionAdded": "v1_0_0"
                 }
             },
             "type": "object"

--- a/static/redfish/v1/schema/OemManagerAccount.v1_0_0.xml
+++ b/static/redfish/v1/schema/OemManagerAccount.v1_0_0.xml
@@ -53,12 +53,17 @@
 				<Property Name="ExpirationDate" Type="Edm.String" Nullable="true">
 					<Annotation Term="OData.Permissions" EnumMember="OData.Permission/Read"/>
 					<Annotation Term="OData.Description" String="The expiration date of the ACF file."/>
-					<Annotation Term="OData.LongDescription" String="The expiration date of the ACF file, if the expiration date has been from the BMC then the ACF is not validD"/>
+					<Annotation Term="OData.LongDescription" String="The expiration date of the ACF file, if the expiration date has been from the BMC then the ACF is not valid."/>
 				</Property>
 				<Property Name="ACFInstalled" Type="Edm.Boolean">
 					<Annotation Term="OData.Permissions" EnumMember="OData.Permission/Read"/>
 					<Annotation Term="OData.Description" String="This property is set to true if the ACF is installed."/>
 					<Annotation Term="OData.LongDescription" String="This property indicates if the ACF is installed or not."/>
+				</Property>
+				<Property Name="AllowUnauthACFUpload" Type="Edm.Boolean">
+					<Annotation Term="OData.Permissions" EnumMember="OData.Permission/ReadWrite"/>
+					<Annotation Term="OData.Description" String="This property shall indicate if unauthorized users shall be allowed to upload ACFs."/>
+					<Annotation Term="OData.LongDescription" String="This property indicates if unauthorized users are allowed to upload ACFs or not.  When this property is true, users are allowed to upload ACFs regardless of their authentication status, regardless of their Role, and regardless of the time window created by Operator Panel function 74."/>
 				</Property>
 			</ComplexType>
 


### PR DESCRIPTION
Background: The Access Control File (ACF) service access is a 2-factor authentication scheme intended for BMC administrators to determine when authorized service and support representatives (SSRs) are allowed to access their BMC but not allow the administrator to have access. In this scheme, only the SSR can create valid ACFs,m which they then give it to the BMC admin for upload to the BMC.  Doing so authorizes the SSR to login to the BMC's service account via an unique password.

A problem with this scheme is some BMC admins lose their password.  To solve this, Operator Panel function 74 opens a 30 minute time window where anyone is allowed to upload a valid ACF to the BMC.

A problem with that solution is that in some installations there is difficulty gaining physical access to the operator panel.  To solve that, there is a new security setting to open up the ACF upload function...

This adds a new BMC security setting as a Redfish OEM property: URI /redfish/v1/AccountService/Accounts/service property Oem.IBM.ACF.AllowUnauthACFUpload can be set by the admin.  When true, any network agent is allowed to upload an ACF file to the BMC. The default value is false.  This capability is included in the existing URI /redfish/v1 property Oem.IBM.ACFWindowActive.  For example, when AllowUnauthACFUpload=true, ACFWindowActive is true.

Tested: via Redfish scenarios
1. Ensure AllowUnauthACFUpload=false by default.
2. Ensure a non admin user is not allowed to GET or PATCH AllowUnauthACFUpload.
3. Ensure the admin can PATCH AllowUnauthACFUpload true and false, and GET the correct values, and these values survive BMC reboot.
4. With (OpPanel fn 74 is not active) and AllowUnauthACFUpload=false, ensure ACFWindowActive=false.  And unauth ACF upload is not allowed.
5. With (OpPanel fn 74 is not active) and AllowUnauthACFUpload=true,

Cheatsheet:
```
busctl set-property com.ibm.PanelApp /com/ibm/panel_app com.ibm.panel ACFWindowActive b true
curl -k -H "X-Auth-Token: $TOKEN" -X PATCH -d '{"Oem":{"IBM":{"ACF":{"AllowUnauthACFUpload": true}}}}' https://${bmc}/redfish/v1/AccountService/Accounts/service
curl -k -H "X-Auth-Token: $TOKEN" -X GET https://${bmc}/redfish/v1
curl -k -X PATCH -d '{"Oem":{"IBM":{"ACF":{"ACFFile":"'${acf}'"}}}}' https://${bmc}/redfish/v1/AccountService/Accounts/service

```