### PR TITLE
Bring PEL related commits into 1050

### DIFF
--- a/redfish-core/lib/log_services.hpp
+++ b/redfish-core/lib/log_services.hpp
@@ -1687,9 +1687,10 @@ inline void requestRoutesDBusEventLogEntryCollection(App& app)
                 const uint64_t* timestamp = nullptr;
                 const uint64_t* updateTimestamp = nullptr;
                 const std::string* severity = nullptr;
-                const std::string* message = nullptr;
+                const std::string* subsystem = nullptr;
                 const std::string* filePath = nullptr;
                 const std::string* resolution = nullptr;
+                const std::string* eventId = nullptr;
                 bool resolved = false;
                 const bool* hidden = nullptr;
                 bool serviceProviderNotified = false;
@@ -1725,10 +1726,15 @@ inline void requestRoutesDBusEventLogEntryCollection(App& app)
                                 resolution = std::get_if<std::string>(
                                     &propertyMap.second);
                             }
-                            else if (propertyMap.first == "Message")
+                            else if (propertyMap.first == "EventId")
                             {
-                                message = std::get_if<std::string>(
+                                eventId = std::get_if<std::string>(
                                     &propertyMap.second);
+                                if (eventId == nullptr)
+                                {
+                                    messages::internalError(asyncResp->res);
+                                    return;
+                                }
                             }
                             else if (propertyMap.first == "Resolved")
                             {
@@ -1755,8 +1761,7 @@ inline void requestRoutesDBusEventLogEntryCollection(App& app)
                                     *serviceProviderNotifiedptr;
                             }
                         }
-                        if (id == nullptr || message == nullptr ||
-                            severity == nullptr)
+                        if (id == nullptr || severity == nullptr)
                         {
                             messages::internalError(asyncResp->res);
                             return;
@@ -1787,7 +1792,16 @@ inline void requestRoutesDBusEventLogEntryCollection(App& app)
                                     messages::internalError(asyncResp->res);
                                     return;
                                 }
-                                break;
+                            }
+                            else if (propertyMap.first == "Subsystem")
+                            {
+                                subsystem = std::get_if<std::string>(
+                                    &propertyMap.second);
+                                if (subsystem == nullptr)
+                                {
+                                    messages::internalError(asyncResp->res);
+                                    return;
+                                }
                             }
                         }
                     }
@@ -1795,9 +1809,10 @@ inline void requestRoutesDBusEventLogEntryCollection(App& app)
                 // Object path without the
                 // xyz.openbmc_project.Logging.Entry interface, ignore
                 // and continue.
-                if (id == nullptr || message == nullptr ||
+                if (id == nullptr || eventId == nullptr ||
                     severity == nullptr || timestamp == nullptr ||
-                    updateTimestamp == nullptr || hidden == nullptr)
+                    updateTimestamp == nullptr || hidden == nullptr ||
+                    subsystem == nullptr)
                 {
                     continue;
                 }
@@ -1816,7 +1831,9 @@ inline void requestRoutesDBusEventLogEntryCollection(App& app)
                     std::to_string(*id);
                 thisEntry["Name"] = "System Event Log Entry";
                 thisEntry["Id"] = std::to_string(*id);
-                thisEntry["Message"] = *message;
+                thisEntry["EventId"] = *eventId;
+                thisEntry["Message"] = (*eventId).substr(0, 8) +
+                                       " event in subsystem: " + *subsystem;
                 thisEntry["Resolved"] = resolved;
                 if ((resolution != nullptr) && (!(*resolution).empty()))
                 {
@@ -1901,8 +1918,9 @@ inline void requestRoutesDBusCELogEntryCollection(App& app)
                 const uint64_t* timestamp = nullptr;
                 const uint64_t* updateTimestamp = nullptr;
                 const std::string* severity = nullptr;
-                const std::string* message = nullptr;
+                const std::string* subsystem = nullptr;
                 const std::string* filePath = nullptr;
+                const std::string* eventId = nullptr;
                 const std::string* resolution = nullptr;
                 bool resolved = false;
                 const bool* hidden = nullptr;
@@ -1939,10 +1957,15 @@ inline void requestRoutesDBusCELogEntryCollection(App& app)
                                 resolution = std::get_if<std::string>(
                                     &propertyMap.second);
                             }
-                            else if (propertyMap.first == "Message")
+                            else if (propertyMap.first == "EventId")
                             {
-                                message = std::get_if<std::string>(
+                                eventId = std::get_if<std::string>(
                                     &propertyMap.second);
+                                if (eventId == nullptr)
+                                {
+                                    messages::internalError(asyncResp->res);
+                                    return;
+                                }
                             }
                             else if (propertyMap.first == "Resolved")
                             {
@@ -1969,8 +1992,7 @@ inline void requestRoutesDBusCELogEntryCollection(App& app)
                                     *serviceProviderNotifiedptr;
                             }
                         }
-                        if (id == nullptr || message == nullptr ||
-                            severity == nullptr)
+                        if (id == nullptr || severity == nullptr)
                         {
                             messages::internalError(asyncResp->res);
                             return;
@@ -2001,7 +2023,16 @@ inline void requestRoutesDBusCELogEntryCollection(App& app)
                                     messages::internalError(asyncResp->res);
                                     return;
                                 }
-                                break;
+                            }
+                            else if (propertyMap.first == "Subsystem")
+                            {
+                                subsystem = std::get_if<std::string>(
+                                    &propertyMap.second);
+                                if (subsystem == nullptr)
+                                {
+                                    messages::internalError(asyncResp->res);
+                                    return;
+                                }
                             }
                         }
                     }
@@ -2009,9 +2040,10 @@ inline void requestRoutesDBusCELogEntryCollection(App& app)
                 // Object path without the
                 // xyz.openbmc_project.Logging.Entry interface, ignore
                 // and continue.
-                if (id == nullptr || message == nullptr ||
+                if (id == nullptr || eventId == nullptr ||
                     severity == nullptr || timestamp == nullptr ||
-                    updateTimestamp == nullptr || hidden == nullptr)
+                    updateTimestamp == nullptr || hidden == nullptr ||
+                    subsystem == nullptr)
                 {
                     continue;
                 }
@@ -2030,7 +2062,9 @@ inline void requestRoutesDBusCELogEntryCollection(App& app)
                     std::to_string(*id);
                 thisEntry["Name"] = "System Event Log Entry";
                 thisEntry["Id"] = std::to_string(*id);
-                thisEntry["Message"] = *message;
+                thisEntry["EventId"] = *eventId;
+                thisEntry["Message"] = (*eventId).substr(0, 8) +
+                                       " event in subsystem: " + *subsystem;
                 thisEntry["Resolved"] = resolved;
                 if ((resolution != nullptr) && (!(*resolution).empty()))
                 {
@@ -2112,7 +2146,8 @@ inline void requestRoutesDBusEventLogEntry(App& app)
             const uint64_t* timestamp = nullptr;
             const uint64_t* updateTimestamp = nullptr;
             const std::string* severity = nullptr;
-            const std::string* message = nullptr;
+            const std::string* eventId = nullptr;
+            const std::string* subsystem = nullptr;
             const std::string* filePath = nullptr;
             const std::string* resolution = nullptr;
             bool resolved = false;
@@ -2122,9 +2157,10 @@ inline void requestRoutesDBusEventLogEntry(App& app)
             const bool success = sdbusplus::unpackPropertiesNoThrow(
                 dbus_utils::UnpackErrorPrinter(), resp, "Id", id, "Timestamp",
                 timestamp, "UpdateTimestamp", updateTimestamp, "Severity",
-                severity, "Message", message, "Resolved", resolved,
+                severity, "EventId", eventId, "Resolved", resolved,
                 "Resolution", resolution, "Path", filePath, "Hidden", hidden,
-                "ServiceProviderNotify", serviceProviderNotified);
+                "ServiceProviderNotify", serviceProviderNotified, "Subsystem",
+                subsystem);
 
             if (!success)
             {
@@ -2132,9 +2168,9 @@ inline void requestRoutesDBusEventLogEntry(App& app)
                 return;
             }
 
-            if (id == nullptr || message == nullptr || severity == nullptr ||
+            if (id == nullptr || eventId == nullptr || severity == nullptr ||
                 timestamp == nullptr || updateTimestamp == nullptr ||
-                hidden == nullptr)
+                hidden == nullptr || subsystem == nullptr)
             {
                 messages::internalError(asyncResp->res);
                 return;
@@ -2155,8 +2191,10 @@ inline void requestRoutesDBusEventLogEntry(App& app)
                 std::to_string(*id);
             asyncResp->res.jsonValue["Name"] = "System Event Log Entry";
             asyncResp->res.jsonValue["Id"] = std::to_string(*id);
-            asyncResp->res.jsonValue["Message"] = *message;
+            asyncResp->res.jsonValue["Message"] =
+                (*eventId).substr(0, 8) + " event in subsystem: " + *subsystem;
             asyncResp->res.jsonValue["Resolved"] = resolved;
+            asyncResp->res.jsonValue["EventId"] = *eventId;
             if ((resolution != nullptr) && (!(*resolution).empty()))
             {
                 asyncResp->res.jsonValue["Resolution"] = *resolution;
@@ -2293,7 +2331,8 @@ inline void requestRoutesDBusCELogEntry(App& app)
             const uint64_t* timestamp = nullptr;
             const uint64_t* updateTimestamp = nullptr;
             const std::string* severity = nullptr;
-            const std::string* message = nullptr;
+            const std::string* eventId = nullptr;
+            const std::string* subsystem = nullptr;
             const std::string* filePath = nullptr;
             const std::string* resolution = nullptr;
             bool resolved = false;
@@ -2303,9 +2342,10 @@ inline void requestRoutesDBusCELogEntry(App& app)
             const bool success = sdbusplus::unpackPropertiesNoThrow(
                 dbus_utils::UnpackErrorPrinter(), resp, "Id", id, "Timestamp",
                 timestamp, "UpdateTimestamp", updateTimestamp, "Severity",
-                severity, "Message", message, "Resolved", resolved,
+                severity, "EventId", eventId, "Resolved", resolved,
                 "Resolution", resolution, "Path", filePath, "Hidden", hidden,
-                "ServiceProviderNotify", serviceProviderNotified);
+                "ServiceProviderNotify", serviceProviderNotified, "Subsystem",
+                subsystem);
 
             if (!success)
             {
@@ -2313,9 +2353,9 @@ inline void requestRoutesDBusCELogEntry(App& app)
                 return;
             }
 
-            if (id == nullptr || message == nullptr || severity == nullptr ||
+            if (id == nullptr || eventId == nullptr || severity == nullptr ||
                 timestamp == nullptr || updateTimestamp == nullptr ||
-                hidden == nullptr)
+                hidden == nullptr || subsystem == nullptr)
             {
                 messages::internalError(asyncResp->res);
                 return;
@@ -2336,8 +2376,10 @@ inline void requestRoutesDBusCELogEntry(App& app)
                 std::to_string(*id);
             asyncResp->res.jsonValue["Name"] = "System Event Log Entry";
             asyncResp->res.jsonValue["Id"] = std::to_string(*id);
-            asyncResp->res.jsonValue["Message"] = *message;
+            asyncResp->res.jsonValue["Message"] =
+                (*eventId).substr(0, 8) + " event in subsystem: " + *subsystem;
             asyncResp->res.jsonValue["Resolved"] = resolved;
+            asyncResp->res.jsonValue["EventId"] = *eventId;
             if ((resolution != nullptr) && (!(*resolution).empty()))
             {
                 asyncResp->res.jsonValue["Resolution"] = *resolution;

--- a/redfish-core/lib/log_services.hpp
+++ b/redfish-core/lib/log_services.hpp
@@ -2230,9 +2230,9 @@ inline void requestRoutesDBusEventLogEntry(App& app)
             const std::string* subsystem = nullptr;
             const std::string* filePath = nullptr;
             const std::string* resolution = nullptr;
-            bool resolved = false;
+            const bool* resolved = nullptr;
             const bool* hidden = nullptr;
-            bool serviceProviderNotified = false;
+            const bool* serviceProviderNotified = nullptr;
 #ifdef BMCWEB_ENABLE_IBM_MANAGEMENT_CONSOLE
             const bool* managementSystemAck = nullptr;
 #endif
@@ -2258,6 +2258,7 @@ inline void requestRoutesDBusEventLogEntry(App& app)
 
             if (id == nullptr || eventId == nullptr || severity == nullptr ||
                 timestamp == nullptr || updateTimestamp == nullptr ||
+                resolved == nullptr || serviceProviderNotified == nullptr ||
                 hidden == nullptr || subsystem == nullptr
 #ifdef BMCWEB_ENABLE_IBM_MANAGEMENT_CONSOLE
                 || managementSystemAck == nullptr
@@ -2285,7 +2286,7 @@ inline void requestRoutesDBusEventLogEntry(App& app)
             asyncResp->res.jsonValue["Id"] = std::to_string(*id);
             asyncResp->res.jsonValue["Message"] =
                 (*eventId).substr(0, 8) + " event in subsystem: " + *subsystem;
-            asyncResp->res.jsonValue["Resolved"] = resolved;
+            asyncResp->res.jsonValue["Resolved"] = *resolved;
             asyncResp->res.jsonValue["EventId"] = *eventId;
             if ((resolution != nullptr) && (!(*resolution).empty()))
             {
@@ -2299,7 +2300,7 @@ inline void requestRoutesDBusEventLogEntry(App& app)
             asyncResp->res.jsonValue["Modified"] =
                 redfish::time_utils::getDateTimeUintMs(*updateTimestamp);
             asyncResp->res.jsonValue["ServiceProviderNotified"] =
-                serviceProviderNotified;
+                *serviceProviderNotified;
             if (filePath != nullptr)
             {
                 asyncResp->res.jsonValue["AdditionalDataURI"] =
@@ -2433,9 +2434,9 @@ inline void requestRoutesDBusCELogEntry(App& app)
             const std::string* subsystem = nullptr;
             const std::string* filePath = nullptr;
             const std::string* resolution = nullptr;
-            bool resolved = false;
+            const bool* resolved = nullptr;
             const bool* hidden = nullptr;
-            bool serviceProviderNotified = false;
+            const bool* serviceProviderNotified = nullptr;
 #ifdef BMCWEB_ENABLE_IBM_MANAGEMENT_CONSOLE
             const bool* managementSystemAck = nullptr;
 #endif
@@ -2461,7 +2462,8 @@ inline void requestRoutesDBusCELogEntry(App& app)
 
             if (id == nullptr || eventId == nullptr || severity == nullptr ||
                 timestamp == nullptr || updateTimestamp == nullptr ||
-                hidden == nullptr || subsystem == nullptr
+                hidden == nullptr || subsystem == nullptr ||
+                resolved == nullptr || serviceProviderNotified == nullptr
 #ifdef BMCWEB_ENABLE_IBM_MANAGEMENT_CONSOLE
                 || managementSystemAck == nullptr
 #endif
@@ -2488,7 +2490,7 @@ inline void requestRoutesDBusCELogEntry(App& app)
             asyncResp->res.jsonValue["Id"] = std::to_string(*id);
             asyncResp->res.jsonValue["Message"] =
                 (*eventId).substr(0, 8) + " event in subsystem: " + *subsystem;
-            asyncResp->res.jsonValue["Resolved"] = resolved;
+            asyncResp->res.jsonValue["Resolved"] = *resolved;
             asyncResp->res.jsonValue["EventId"] = *eventId;
             if ((resolution != nullptr) && (!(*resolution).empty()))
             {
@@ -2502,7 +2504,7 @@ inline void requestRoutesDBusCELogEntry(App& app)
             asyncResp->res.jsonValue["Modified"] =
                 redfish::time_utils::getDateTimeUintMs(*updateTimestamp);
             asyncResp->res.jsonValue["ServiceProviderNotified"] =
-                serviceProviderNotified;
+                *serviceProviderNotified;
             if (filePath != nullptr)
             {
                 asyncResp->res.jsonValue["AdditionalDataURI"] =

--- a/scripts/update_schemas.py
+++ b/scripts/update_schemas.py
@@ -368,6 +368,13 @@ with open(metadata_index_path, "w") as metadata_index:
     )
     metadata_index.write("    </edmx:Reference>\n")
 
+    metadata_index.write(
+        "    <edmx:Reference Uri=\"/redfish/v1/schema/OemLogEntry_v1.xml\">\n")
+    metadata_index.write("        <edmx:Include Namespace=\"OemLogEntry\"/>\n")
+    metadata_index.write(
+        "        <edmx:Include Namespace=\"OemLogEntry.v1_0_0\"/>\n")
+    metadata_index.write("    </edmx:Reference>\n")
+
     metadata_index.write("</edmx:Edmx>\n")
 
 

--- a/static/redfish/v1/$metadata/index.xml
+++ b/static/redfish/v1/$metadata/index.xml
@@ -2834,4 +2834,8 @@
         <edmx:Include Namespace="OemSession"/>
         <edmx:Include Namespace="OemSession.v1_0_0"/>
     </edmx:Reference>
+    <edmx:Reference Uri="/redfish/v1/schema/OemLogEntry_v1.xml">
+        <edmx:Include Namespace="OemLogEntry"/>
+        <edmx:Include Namespace="OemLogEntry.v1_0_0"/>
+    </edmx:Reference>
 </edmx:Edmx>

--- a/static/redfish/v1/JsonSchemas/OemLogEntry/index.json
+++ b/static/redfish/v1/JsonSchemas/OemLogEntry/index.json
@@ -1,0 +1,42 @@
+{
+    "$id": "http://redfish.dmtf.org/schemas/v1/OemLogEntry.v1_0_0.json",
+    "$schema": "http://redfish.dmtf.org/schemas/v1/redfish-schema-v1.json",
+    "copyright": "Copyright 2014-2019 DMTF. For the full DMTF copyright policy, see http://www.dmtf.org/about/policies/copyright",
+    "definitions": {
+        "LogEntry": {
+            "additionalProperties": true,
+            "description": "OEM Extension for LogEntry",
+            "longDescription": "OEM Extension for LogEntry to provide the OEM specific details.",
+            "patternProperties": {
+                "^([a-zA-Z_][a-zA-Z0-9_]*)?@(odata|Redfish|Message)\\.[a-zA-Z_][a-zA-Z0-9_]*$": {
+                    "description": "This property shall specify a valid odata or Redfish property.",
+                    "type": [
+                        "array",
+                        "boolean",
+                        "integer",
+                        "number",
+                        "null",
+                        "object",
+                        "string"
+                    ]
+                }
+            },
+            "properties": {
+                "ManagementSystemAck" : {
+                    "description": "Flag to keep track of external interface acknowledgment.",
+                    "longDescription": "A true value says external interface acked error log, false says otherwise.",
+                    "readonly": false,
+                    "type": [
+                        "boolean",
+                        "null"
+                    ]
+                },
+            "type": "object"
+            }
+        }
+    },
+    "owningEntity": "OpenBMC",
+    "release": "1.0",
+    "title": "#OemLogEntry.v1_0_0"
+}
+

--- a/static/redfish/v1/schema/OemLogEntry_v1.xml
+++ b/static/redfish/v1/schema/OemLogEntry_v1.xml
@@ -1,0 +1,40 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<edmx:Edmx xmlns:edmx="http://docs.oasis-open.org/odata/ns/edmx" Version="4.0">
+
+  <edmx:Reference Uri="http://docs.oasis-open.org/odata/odata/v4.0/errata03/csd01/complete/vocabularies/Org.OData.Core.V1.xml">
+    <edmx:Include Namespace="Org.OData.Core.V1" Alias="OData"/>
+  </edmx:Reference>
+  <edmx:Reference Uri="http://docs.oasis-open.org/odata/odata/v4.0/errata03/csd01/complete/vocabularies/Org.OData.Measures.V1.xml">
+    <edmx:Include Namespace="Org.OData.Measures.V1" Alias="Measures"/>
+  </edmx:Reference>
+  <edmx:Reference Uri="http://redfish.dmtf.org/schemas/v1/RedfishExtensions_v1.xml">
+    <edmx:Include Namespace="RedfishExtensions.v1_0_0" Alias="Redfish"/>
+  </edmx:Reference>
+  <edmx:Reference Uri="http://redfish.dmtf.org/schemas/v1/Resource_v1.xml">
+    <edmx:Include Namespace="Resource"/>
+    <edmx:Include Namespace="Resource.v1_0_0"/>
+  </edmx:Reference>
+  <edmx:DataServices>
+
+    <Schema xmlns="http://docs.oasis-open.org/odata/ns/edm" Namespace="OemLogEntry">
+      <Annotation Term="Redfish.OwningEntity" String="OpenBMC"/>
+    </Schema>
+
+    <Schema xmlns="http://docs.oasis-open.org/odata/ns/edm" Namespace="OemLogEntry.v1_0_0">
+      <Annotation Term="Redfish.OwningEntity" String="OpenBMC"/>
+      <Annotation Term="Redfish.Release" String="1.0"/>
+
+      <EntityType Name="LogEntry" BaseType="Resource.OemObject" Abstract="true">
+          <Annotation Term="OData.Description" String="OEM Extension for LogEntry"/>
+          <Annotation Term="OData.LongDescription" String="OEM Extension for LogEntry to provide the OEM specific details"/>
+
+            <Property Name="ManagementSystemAck" Type="Edm.Boolean">
+              <Annotation Term="OData.Description" String="Flag to keep track of external interface acknowledgment."/>
+              <Annotation Term="OData.LongDescription" String="A true value says external interface acked error log, false says otherwise."/>
+            </Property>
+
+      </EntityType>
+    </Schema>
+  </edmx:DataServices>
+</edmx:Edmx>
+


### PR DESCRIPTION
This brings in 2 event log related commits from the earlier release, and adds a commit to fix some bool definitions that showed up at some point.

One commit brought forward adds support for the IBM OEM ManagementSystemAck property, which the HMC sets after it has processed an event log.
```
  "Oem": {
        "OpenBMC": {
          "@odata.type": "#OemLogEntry.v1_0_0.LogEntry",
          "ManagementSystemAck": false
        }
```

The other one fills in the Event ID property with the SRC words, and changes the Message property to something else.
```
"EventId": "BD802003 00080055 2E330010 00000000 00000000 00000000 00000000 00000000 00000000",
"Message": "BD802003 event in subsystem: Platform Firmware",
```

The last commit changes some of the bool arguments passed into sdbusplus::unpackPropertiesNoThrow() to pointers to be consistent with all of the other arguments passed into it.  It's possible what was there already worked, but was very confusing to look at.