### PR TITLE
Increase bmcweb automatic restart (#356)

### DIFF
--- a/config/bmcweb.service.in
+++ b/config/bmcweb.service.in
@@ -1,5 +1,7 @@
 [Unit]
 Description=Start bmcweb server
+StartLimitIntervalSec=30
+StartLimitBurst=4
 
 Wants=network.target
 After=network.target


### PR DESCRIPTION
* Increase bmcweb automatic restart

Currently our systemd service are automatically restarted on failure a max of 3 times over 30 seconds. I.e. our current settings are: StartLimitInterval=30
StartLimitBurst=3

Certificate manager restarts bmcweb when a new certificate is uploaded, we have seen this happen more than 3 times in a 30 second period. Allow bmcweb to be restarted 5 times over a 15 second period before stopping.
This is a short term fix, the long term fix is Certificate manager will throttle how often it restarts bmcweb.


Signed-off-by: Gunnar Mills <gmills@us.ibm.com>