### PR TITLE
Allow a lower DeliveryRetryIntervalSeconds

### DIFF
--- a/redfish-core/lib/event_service.hpp
+++ b/redfish-core/lib/event_service.hpp
@@ -142,12 +142,12 @@ inline void requestRoutesEventService(App& app)
 
         if (retryInterval)
         {
-            // Supported range [30 - 180]
-            if ((*retryInterval < 30) || (*retryInterval > 180))
+            // Supported range [5 - 180]
+            if ((*retryInterval < 5) || (*retryInterval > 180))
             {
                 messages::queryParameterOutOfRange(
                     asyncResp->res, std::to_string(*retryInterval),
-                    "DeliveryRetryIntervalSeconds", "[30-180]");
+                    "DeliveryRetryIntervalSeconds", "[5-180]");
             }
             else
             {


### PR DESCRIPTION
The current DeliveryRetryIntervalSeconds range is 30 - 180 seconds. As far as I can tell, this is arbitrary. Lower the minimum to 5 seconds so the HMC can set it to this low. The current default will still be 30 seconds. The HMC wants this lower because the data might not be correct by the time the event is retried. The reason for not lowering further is concern about performance, a bunch of events retrying very fast, and the more time, the more likely the 2nd and 3rd try will be successful.

Before:

curl -k -X PATCH https://$bmc/redfish/v1/EventService/ -d '{DeliveryRetryIntervalSeconds": 5}' {
  "error": {
    "@Message.ExtendedInfo": [
      {
        "@odata.type": "#Message.v1_1_1.Message",
        "Message": "The value 5 for the query parameter DeliveryRetryIntervalSeconds is out of range [30-180].",
        "MessageArgs": [
          "5",
          "DeliveryRetryIntervalSeconds",
          "[30-180]"
        ],
        "MessageId": "Base.1.8.1.QueryParameterOutOfRange",
...

Tested: None at this time.

Signed-off-by: Gunnar Mills <gmills@us.ibm.com>