### PR TITLE
Add call to getPELJson interface

### DIFF
--- a/redfish-core/include/redfish.hpp
+++ b/redfish-core/include/redfish.hpp
@@ -184,6 +184,8 @@ class RedfishService
         requestRoutesDBusCELogEntry(app);
         requestRoutesDBusEventLogEntryDownload(app);
         requestRoutesDBusCELogEntryDownload(app);
+        requestRoutesDBusEventLogEntryDownloadPelJson(app);
+        requestRoutesDBusCELogEntryDownloadPelJson(app);
 #endif
 
 #ifdef BMCWEB_ENABLE_REDFISH_HOST_LOGGER

--- a/scripts/update_schemas.py
+++ b/scripts/update_schemas.py
@@ -369,10 +369,24 @@ with open(metadata_index_path, "w") as metadata_index:
     metadata_index.write("    </edmx:Reference>\n")
 
     metadata_index.write(
-        "    <edmx:Reference Uri=\"/redfish/v1/schema/OemLogEntry_v1.xml\">\n")
-    metadata_index.write("        <edmx:Include Namespace=\"OemLogEntry\"/>\n")
+        '    <edmx:Reference Uri="/redfish/v1/schema/OemLogEntry_v1.xml">\n'
+    )
+    metadata_index.write('        <edmx:Include Namespace="OemLogEntry"/>\n')
     metadata_index.write(
-        "        <edmx:Include Namespace=\"OemLogEntry.v1_0_0\"/>\n")
+        '        <edmx:Include Namespace="OemLogEntry.v1_0_0"/>\n'
+    )
+    metadata_index.write("    </edmx:Reference>\n")
+
+    metadata_index.write(
+        '    <edmx:Reference Uri="'
+        '/redfish/v1/schema/OemLogEntryAttachment_v1.xml">\n'
+    )
+    metadata_index.write(
+        '        <edmx:Include Namespace="OemLogEntryAttachment"/>\n'
+    )
+    metadata_index.write(
+        '        <edmx:Include Namespace="OemLogEntryAttachment.v1_0_0"/>\n'
+    )
     metadata_index.write("    </edmx:Reference>\n")
 
     metadata_index.write("</edmx:Edmx>\n")

--- a/static/redfish/v1/$metadata/index.xml
+++ b/static/redfish/v1/$metadata/index.xml
@@ -2838,4 +2838,8 @@
         <edmx:Include Namespace="OemLogEntry"/>
         <edmx:Include Namespace="OemLogEntry.v1_0_0"/>
     </edmx:Reference>
+    <edmx:Reference Uri="/redfish/v1/schema/OemLogEntryAttachment_v1.xml">
+        <edmx:Include Namespace="OemLogEntryAttachment"/>
+        <edmx:Include Namespace="OemLogEntryAttachment.v1_0_0"/>
+    </edmx:Reference>
 </edmx:Edmx>

--- a/static/redfish/v1/JsonSchemas/OemLogEntryAttachment/index.json
+++ b/static/redfish/v1/JsonSchemas/OemLogEntryAttachment/index.json
@@ -1,0 +1,66 @@
+{
+    "$id": "http://redfish.dmtf.org/schemas/v1/OemLogEntryAttachment.json",
+    "$schema": "http://redfish.dmtf.org/schemas/v1/redfish-schema-v1.json",
+    "copyright": "Copyright 2014-2019 DMTF. For the full DMTF copyright policy, see http://www.dmtf.org/about/policies/copyright",
+    "definitions": {
+        "Oem": {
+            "additionalProperties": true,
+            "description": "OemLogEntryAttachment Oem properties.",
+            "patternProperties": {
+                "^([a-zA-Z_][a-zA-Z0-9_]*)?@(odata|Redfish|Message)\\.[a-zA-Z_][a-zA-Z0-9_]*$": {
+                    "description": "This property shall specify a valid odata or Redfish property.",
+                    "type": [
+                        "null",
+                        "string"
+                    ]
+                }
+            },
+            "properties": {
+                "IBM": {
+                    "anyOf": [
+                        {
+                            "$ref": "#/definitions/IBM"
+                        },
+                        {
+                            "type": "null"
+                        }
+                    ]
+                }
+
+            },
+            "type": "object"
+        },
+        "IBM": {
+            "additionalProperties": true,
+            "description": "Oem properties for IBM.",
+            "patternProperties": {
+                "^([a-zA-Z_][a-zA-Z0-9_]*)?@(odata|Redfish|Message)\\.[a-zA-Z_][a-zA-Z0-9_]*$": {
+                    "description": "This property shall specify a valid odata or Redfish property.",
+                    "type": [
+                        "array",
+                        "boolean",
+                        "integer",
+                        "number",
+                        "null",
+                        "object",
+                        "string"
+                    ]
+                }
+            },
+            "properties": {
+                "PelJson": {
+                    "description": "PEL in Json format.",
+                    "readonly": true,
+                    "type": [
+                        "string",
+                        "null"
+                    ]
+                }
+            },
+            "type": "object"
+        }
+    },
+    "owningEntity": "IBM",
+    "release": "1.0",
+    "title": "#OemLogEntryAttachment"
+}

--- a/static/redfish/v1/schema/OemLogEntryAttachment_v1.xml
+++ b/static/redfish/v1/schema/OemLogEntryAttachment_v1.xml
@@ -1,0 +1,43 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<edmx:Edmx xmlns:edmx="http://docs.oasis-open.org/odata/ns/edmx" Version="4.0">
+
+  <edmx:Reference Uri="http://docs.oasis-open.org/odata/odata/v4.0/errata03/csd01/complete/vocabularies/Org.OData.Core.V1.xml">
+    <edmx:Include Namespace="Org.OData.Core.V1" Alias="OData"/>
+  </edmx:Reference>
+  <edmx:Reference Uri="http://docs.oasis-open.org/odata/odata/v4.0/errata03/csd01/complete/vocabularies/Org.OData.Measures.V1.xml">
+    <edmx:Include Namespace="Org.OData.Measures.V1" Alias="Measures"/>
+  </edmx:Reference>
+  <edmx:Reference Uri="http://redfish.dmtf.org/schemas/v1/RedfishExtensions_v1.xml">
+    <edmx:Include Namespace="RedfishExtensions.v1_0_0" Alias="Redfish"/>
+  </edmx:Reference>
+  <edmx:Reference Uri="http://redfish.dmtf.org/schemas/v1/Resource_v1.xml">
+    <edmx:Include Namespace="Resource"/>
+    <edmx:Include Namespace="Resource.v1_0_0"/>
+  </edmx:Reference>
+
+  <edmx:DataServices>
+
+    <Schema xmlns="http://docs.oasis-open.org/odata/ns/edm" Namespace="OemLogEntryAttachment">
+      <Annotation Term="Redfish.OwningEntity" String="IBM"/>
+
+      <ComplexType Name="Oem" BaseType="Resource.OemObject">
+        <Annotation Term="OData.AdditionalProperties" Bool="true"/>
+        <Annotation Term="OData.Description" String="OemLogEntryAttachment Oem properties."/>
+        <Annotation Term="OData.AutoExpand"/>
+        <Property Name="IBM" Type="OemLogEntryAttachment.IBM"/>
+      </ComplexType>
+
+      <ComplexType Name="IBM" BaseType="Resource.OemObject">
+        <Annotation Term="OData.AdditionalProperties" Bool="false" />
+        <Annotation Term="OData.Description" String="Oem properties for IBM." />
+        <Annotation Term="OData.AutoExpand"/>
+        <Property Name="PelJson" Type="OemLogEntryAttachment.IBM">
+          <Annotation Term="OData.Permissions" EnumMember="OData.Permission/Read"/>
+          <Annotation Term="OData.Description" String="PEL in Json format."/>
+        </Property>
+      </ComplexType>
+
+    </Schema>
+
+  </edmx:DataServices>
+</edmx:Edmx>


### PR DESCRIPTION
Add call to getPELJson for both EventLog and CELog log services. Returns PEL in json format.
EventLog path is redfish/v1/Systems/system/LogServices/EventLog
CELog    path is redfish/v1/Systems/system/LogServices/CELog

Tested:
1) redfish validator: not tested
2) Curl testing passed
$ curl -k
http://rain104bmc:443/redfish/v1/Systems/system/LogServices/CELog/Entries/1/OemPelAttachment {
  "Oem": {
    "@odata.type": "#OemLogEntryAttachment.Oem",
    "IBM": {
      "@odata.type": "#OemLogEntryAttachment.IBM",
      "PelJson": "{\n\"Private Header\": {\n    \"Section Version\":
...
}

$ curl -k
http://rain104bmc:443/redfish/v1/Systems/system/LogServices/EventLog/Entries/9/OemPelAttachment {
  "Oem": {
    "@odata.type": "#OemLogEntryAttachment.Oem",
    "IBM": {
      "@odata.type": "#OemLogEntryAttachment.IBM",
      "PelJson": "{\n\"Private Header\": {\n
...
}

Signed-off-by: Shantappa Teekappanavar <shantappa.teekappanavar@ibm.com>
Change-Id: Icd75d9158acdebcdd64af9d1edf0a9794e6383bb