### PR TITLE
Add OemServiceRoot schema

### DIFF
--- a/scripts/update_schemas.py
+++ b/scripts/update_schemas.py
@@ -389,6 +389,17 @@ with open(metadata_index_path, "w") as metadata_index:
     )
     metadata_index.write("    </edmx:Reference>\n")
 
+    metadata_index.write(
+        '    <edmx:Reference Uri="/redfish/v1/schema/OemServiceRoot_v1.xml">\n'
+    )
+    metadata_index.write(
+        '        <edmx:Include Namespace="OemServiceRoot"/>\n'
+    )
+    metadata_index.write(
+        '        <edmx:Include Namespace="OemServiceRoot.v1_0_0"/>\n'
+    )
+    metadata_index.write("    </edmx:Reference>\n")
+
     metadata_index.write("</edmx:Edmx>\n")
 
 

--- a/static/redfish/v1/$metadata/index.xml
+++ b/static/redfish/v1/$metadata/index.xml
@@ -2842,4 +2842,8 @@
         <edmx:Include Namespace="OemLogEntryAttachment"/>
         <edmx:Include Namespace="OemLogEntryAttachment.v1_0_0"/>
     </edmx:Reference>
+    <edmx:Reference Uri="/redfish/v1/schema/OemServiceRoot_v1.xml">
+        <edmx:Include Namespace="OemServiceRoot"/>
+        <edmx:Include Namespace="OemServiceRoot.v1_0_0"/>
+    </edmx:Reference>
 </edmx:Edmx>

--- a/static/redfish/v1/JsonSchemas/OemServiceRoot/index.json
+++ b/static/redfish/v1/JsonSchemas/OemServiceRoot/index.json
@@ -1,0 +1,65 @@
+{
+    "$id": "http://redfish.dmtf.org/schemas/v1/OemLogEntryAttachment.json",
+    "$schema": "http://redfish.dmtf.org/schemas/v1/redfish-schema-v1.json",
+    "copyright": "Copyright 2014-2019 DMTF. For the full DMTF copyright policy, see http://www.dmtf.org/about/policies/copyright",
+    "definitions": {
+        "Oem": {
+            "additionalProperties": true,
+            "description": "OemLogEntryAttachment Oem properties.",
+            "patternProperties": {
+                "^([a-zA-Z_][a-zA-Z0-9_]*)?@(odata|Redfish|Message)\\.[a-zA-Z_][a-zA-Z0-9_]*$": {
+                    "description": "This property shall specify a valid odata or Redfish property.",
+                    "type": [
+                        "null",
+                        "string"
+                    ]
+                }
+            },
+            "properties": {
+                "IBM": {
+                    "anyOf": [
+                        {
+                            "$ref": "#/definitions/IBM"
+                        },
+                        {
+                            "type": "null"
+                        }
+                    ]
+                }
+            },
+            "type": "object"
+        },
+        "IBM": {
+            "additionalProperties": true,
+            "description": "Oem properties for IBM.",
+            "patternProperties": {
+                "^([a-zA-Z_][a-zA-Z0-9_]*)?@(odata|Redfish|Message)\\.[a-zA-Z_][a-zA-Z0-9_]*$": {
+                    "description": "This property shall specify a valid odata or Redfish property.",
+                    "type": [
+                        "array",
+                        "boolean",
+                        "integer",
+                        "number",
+                        "null",
+                        "object",
+                        "string"
+                    ]
+                }
+            },
+            "properties": {
+                "PelJson": {
+                    "description": "PEL in Json format.",
+                    "readonly": true,
+                    "type": [
+                        "string",
+                        "null"
+                    ]
+                }
+            },
+            "type": "object"
+        }
+    },
+    "owningEntity": "IBM",
+    "release": "1.0",
+    "title": "#OemLogEntryAttachment"
+}

--- a/static/redfish/v1/schema/OemServiceRoot_v1.xml
+++ b/static/redfish/v1/schema/OemServiceRoot_v1.xml
@@ -1,0 +1,63 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<edmx:Edmx xmlns:edmx="http://docs.oasis-open.org/odata/ns/edmx" Version="4.0">
+
+  <edmx:Reference Uri="http://docs.oasis-open.org/odata/odata/v4.0/errata03/csd01/complete/vocabularies/Org.OData.Core.V1.xml">
+    <edmx:Include Namespace="Org.OData.Core.V1" Alias="OData"/>
+  </edmx:Reference>
+  <edmx:Reference Uri="http://docs.oasis-open.org/odata/odata/v4.0/errata03/csd01/complete/vocabularies/Org.OData.Measures.V1.xml">
+    <edmx:Include Namespace="Org.OData.Measures.V1" Alias="Measures"/>
+  </edmx:Reference>
+  <edmx:Reference Uri="http://redfish.dmtf.org/schemas/v1/RedfishExtensions_v1.xml">
+    <edmx:Include Namespace="RedfishExtensions.v1_0_0" Alias="Redfish"/>
+  </edmx:Reference>
+    <edmx:Reference Uri="http://redfish.dmtf.org/schemas/v1/ServiceRoot_v1.xml">
+        <edmx:Include Namespace="ServiceRoot"/>
+        <edmx:Include Namespace="ServiceRoot.v1_12_0"/>
+    </edmx:Reference>
+  <edmx:Reference Uri="http://redfish.dmtf.org/schemas/v1/Resource_v1.xml">
+    <edmx:Include Namespace="Resource"/>
+    <edmx:Include Namespace="Resource.v1_0_0"/>
+  </edmx:Reference>
+
+  <edmx:DataServices>
+
+    <Schema xmlns="http://docs.oasis-open.org/odata/ns/edm" Namespace="OemServiceRoot">
+      <Annotation Term="Redfish.OwningEntity" String="IBM"/>
+
+      <ComplexType Name="Oem" BaseType="Resource.OemObject">
+        <Annotation Term="OData.AdditionalProperties" Bool="true"/>
+        <Annotation Term="OData.Description" String="OemServiceRoot Oem properties."/>
+        <Annotation Term="OData.AutoExpand"/>
+        <Property Name="IBM" Type="OemServiceRoot.IBM"/>
+      </ComplexType>
+
+      <ComplexType Name="IBM" BaseType="Resource.OemObject">
+        <Annotation Term="OData.AdditionalProperties" Bool="true" />
+        <Annotation Term="OData.Description" String="Oem properties for IBM." />
+        <Annotation Term="OData.AutoExpand"/>
+        <Property Name="Model" Type="OemServiceRoot.IBM">
+          <Annotation Term="OData.Permissions" EnumMember="OData.Permission/Read"/>
+          <Annotation Term="OData.Description" String="The product name for this system, without the manufacturer name."/>
+          <Annotation Term="OData.LongDescription" String="This property shall describe how the manufacturer refers to this system.  Typically, this value is the product name for this system without the manufacturer name."/>
+        </Property>
+        <Property Name="SerialNumber" Type="OemServiceRoot.IBM">
+          <Annotation Term="OData.Permissions" EnumMember="OData.Permission/Read"/>
+          <Annotation Term="OData.Description" String="The serial number for this system."/>
+          <Annotation Term="OData.LongDescription" String="This property shall contain the serial number for the system."/>
+        </Property>
+        <Property Name="DateTime" Type="OemServiceRoot.IBM">
+          <Annotation Term="OData.Permissions" EnumMember="OData.Permission/ReadWrite"/>
+          <Annotation Term="OData.Description" String="The current date and time with UTC offset of the manager."/>
+          <Annotation Term="OData.LongDescription" String="This property shall contain the current date and time with UTC offset of the manager."/>
+        </Property>
+        <Property Name="DateTimeLocalOffset" Type="OemServiceRoot.IBM">
+          <Annotation Term="OData.Permissions" EnumMember="OData.Permission/ReadWrite"/>
+          <Annotation Term="OData.Description" String="The time offset from UTC that the DateTime property is in `+HH:MM` format."/>
+          <Annotation Term="OData.LongDescription" String="This property shall contain the offset from UTC time that the DateTime property contains.  If both DateTime and DateTimeLocalOffset are provided in modification requests, services shall apply DateTimeLocalOffset after DateTime is applied."/>
+        </Property>
+      </ComplexType>
+
+    </Schema>
+
+  </edmx:DataServices>
+</edmx:Edmx>


### PR DESCRIPTION
This commit adds additional properties.

Testing:
1) redfish validator: not tested
2) curl command
curl -k <bmc_ip>/redfish/v1
  "Oem": {
    "@odata.type": "#OemServiceRoot.Oem",
    "IBM": {
      "@odata.type": "#OemServiceRoot.IBM",
      "DateTime": "2022-11-15T01:24:44+00:00",
      "DateTimeLocalOffset": "+00:00",
      "Model": "9105-22A",
      "SerialNumber": "139EF60"
    }
  },

Signed-off-by: Shantappa Teekappanavar <shantappa.teekappanavar@ibm.com>
Change-Id: Id4e3562ef4b8a56eca3cd98cc7adcedfb36d293d