### PR TITLE
Bump connection timeout to 26 mins

### DIFF
--- a/http/http_connection.hpp
+++ b/http/http_connection.hpp
@@ -702,12 +702,15 @@ class Connection :
     {
         cancelDeadlineTimer();
 
-        std::chrono::seconds timeout(15);
+        std::chrono::seconds timeout(120);
         // allow slow uploads for logged in users
         bool loggedIn = userSession != nullptr;
         if (loggedIn)
         {
-            timeout = std::chrono::seconds(60);
+            // drop all connections after 26 minutes, this time limit
+            // is so high to support our large code update images on
+            // slow networks Need a better way to do this
+            timeout = std::chrono::seconds(1560);
             return;
         }
 


### PR DESCRIPTION
The connection timeout is set to 26 minutes to logged in users to support our large code update images, otherwise timeout is set to 120 seconds.

This matches what we had on 1020 and 1030.
Same as what we will have on 1050.

Took from https://github.com/ibm-openbmc/bmcweb/pull/455 Replaces https://github.com/ibm-openbmc/bmcweb/commit/63314c086a28f6d60839277fc381cf6717f47eb1

Signed-off-by: Gunnar Mills <gmills@us.ibm.com>