### PR TITLE
Restrict use of subfolder in configfiles path

### DIFF
--- a/include/ibm/management_console_rest.hpp
+++ b/include/ibm/management_console_rest.hpp
@@ -391,8 +391,11 @@ inline void
         for (const auto& file : std::filesystem::directory_iterator(loc))
         {
             const std::filesystem::path& pathObj = file.path();
-            pathObjList.push_back("/ibm/v1/Host/ConfigFiles/" +
-                                  pathObj.filename().string());
+            if (std::filesystem::is_regular_file(pathObj))
+            {
+                pathObjList.push_back("/ibm/v1/Host/ConfigFiles/" +
+                                      pathObj.filename().string());
+            }
         }
     }
     asyncResp->res.jsonValue["@odata.type"] =
@@ -456,7 +459,7 @@ inline void handleFileGet(const std::shared_ptr<bmcweb::AsyncResp>& asyncResp,
     BMCWEB_LOG_DEBUG << "HandleGet on SaveArea files on path: " << fileID;
     std::filesystem::path loc(
         "/var/lib/bmcweb/ibm-management-console/configfiles/" + fileID);
-    if (!std::filesystem::exists(loc))
+    if (!std::filesystem::exists(loc) || !std::filesystem::is_regular_file(loc))
     {
         BMCWEB_LOG_ERROR << loc << " Not found";
         asyncResp->res.result(boost::beast::http::status::not_found);


### PR DESCRIPTION
Code changes to fix SW558001.
Limit the GET function on configfiles to display only regular files and return an error if the user try to GET on a subfolder in configfiles, created manually, avoiding the bmcweb crash.

Tested:
Create subfolder under configfiles path

curl -k -H "X-Auth-Token: $bmc_token" -X GET -D patch1.txt
https://${bmc}/ibm/v1/Host/ConfigFiles

Without fix:
Lists all contents of the ConfigFiles folder

With Fix:
lists only the regular files

Run the command with subfolder
curl -k -H "X-Auth-Token: $bmc_token" -X GET -D patch1.txt
https://${bmc}/ibm/v1/Host/ConfigFiles/testfolder

Without fix:
bmcweb crashes

With the fix:
“Description”: “Resource Not Found”

Corresponding upstream commit : https://gerrit.openbmc.org/c/openbmc/bmcweb/+/59077/6/include/ibm/management_console_rest.hpp#308 to restrict use of subfolder in configfiles path