### PR TITLE
1030: Fix python packaging problem

### DIFF
--- a/scripts/update_schemas.py
+++ b/scripts/update_schemas.py
@@ -2,7 +2,6 @@
 import requests
 import zipfile
 from io import BytesIO
-from packaging.version import Version, parse
 
 import os
 from collections import OrderedDict, defaultdict
@@ -56,36 +55,34 @@ zipBytesIO = BytesIO(r.content)
 zip_ref = zipfile.ZipFile(zipBytesIO)
 
 
-def version_sort_key(key):
-    """
-    Method that computes a sort key that zero pads all numbers, such that
-    version sorting like
-    0_2_0
-    0_10_0
-    sorts in the way humans expect.
-    it also does case insensitive comparisons.
-    """
-    key = str.casefold(key)
+class SchemaVersion:
+    '''
+    A Python class for sorting Redfish schema versions.  Allows sorting Redfish
+    versions in the way humans expect, by comparing version strings as lists
+    (ie 0_2_0 comes before 0_10_0) in the way humans expect.  It does case
+    insensitive schema name comparisons
+    '''
 
-    # Decription of this class calls it "Version numbering for anarchists and
-    # software realists.".  That seems like exactly what we need here.
+    def __init__(self, key):
+        key = str.casefold(key)
 
-    if not any(char.isdigit() for char in key):
-        split_tup = os.path.splitext(key)
-        key = split_tup[0] + ".v0_0_0" + split_tup[1]
+        split_tup = key.split(".")
+        self.version_pieces = [split_tup[0]]
+        if len(split_tup) < 2:
+            return
+        version = split_tup[1]
 
-    # special case some files that don't seem to follow the naming convention,
-    # and cause sort problems.  These need brought up with DMTF TODO(Ed)
-    if key == "odata.4.0.0.json":
-        key = "odata.v4_0_0.json"
-    if key == "redfish-schema.1.0.0.json":
-        key = "redfish-schema.v1_0_0.json"
+        if version.startswith("v"):
+            version = version[1:]
+        if any(char.isdigit() for char in version):
+            self.version_pieces.extend([int(x)
+                                       for x in version.split("_")])
 
-    return parse(key)
+    def __lt__(self, other):
+        return self.version_pieces < other.version_pieces
 
 
 # Remove the old files
-
 skip_prefixes = "Oem"
 if os.path.exists(schema_path):
     files = [
@@ -119,28 +116,30 @@ if not os.path.exists(json_schema_path):
 csdl_filenames = []
 json_schema_files = defaultdict(list)
 
-for zip_filepath in zip_ref.namelist():
-    if zip_filepath.startswith("csdl/") and (zip_filepath != "csdl/"):
-        csdl_filenames.append(os.path.basename(zip_filepath))
-    elif zip_filepath.startswith("json-schema/"):
-        filename = os.path.basename(zip_filepath)
+for zip_file in zip_ref.infolist():
+    if zip_file.is_dir():
+        continue
+    if zip_file.filename.startswith("csdl/"):
+        csdl_filenames.append(os.path.basename(zip_file.filename))
+    elif zip_file.filename.startswith("json-schema/"):
+        filename = os.path.basename(zip_file.filename)
         filenamesplit = filename.split(".")
         json_schema_files[filenamesplit[0]].append(filename)
-    elif zip_filepath.startswith("openapi/"):
+    elif zip_file.filename.startswith("openapi/"):
         pass
-    elif zip_filepath.startswith("dictionaries/"):
+    elif zip_file.filename.startswith("dictionaries/"):
         pass
 
 # sort the json files by version
 for key, value in json_schema_files.items():
-    value.sort(key=version_sort_key, reverse=True)
+    value.sort(key=SchemaVersion, reverse=True)
 
 # Create a dictionary ordered by schema name
 json_schema_files = OrderedDict(
-    sorted(json_schema_files.items(), key=lambda x: version_sort_key(x[0]))
+    sorted(json_schema_files.items(), key=lambda x: SchemaVersion(x[0]))
 )
 
-csdl_filenames.sort(key=version_sort_key)
+csdl_filenames.sort(key=SchemaVersion)
 with open(metadata_index_path, "w") as metadata_index:
 
     metadata_index.write('<?xml version="1.0" encoding="UTF-8"?>\n')


### PR DESCRIPTION
Merged upstream here: https://gerrit.openbmc.org/c/openbmc/bmcweb/+/59633

https://github.com/ibm-openbmc/bmcweb/blob/1050/run-ci isn't in 1030 or 1020 but without this change in 1020/1030 this script fails if using the docker container or if you pip install / pip update so probably worth fixing https://github.com/ibm-openbmc/bmcweb/pull/480 is the 1050 one and it already is in. 

Python packaging seems to have changed to be much more stringent about what version strings is accepts.  It's not clear why this was done, but we need a fix to unbreak CI.

This commit adds more parsing code into the script to parse out version numbers from  the form of LogEntry.v1_2_3 to split them up into a custom class, and sort manually.  Despite dropping the dependency, this ends up dropping a net 7 lines of code compared to using the library, so it seems worth it, especially given the breaking API change.

One seemingly unrelated change was that we were adding schema folders to the sort lists, which don't sort well because they have no version numbers or extensions.  This fixes to only add individual files to the list of things to sort.

Tested:
Code no longer crashes.
Running update_schemas.py generates the same result (with one minor same-prefix sort order change).

Signed-off-by: Ed Tanous <edtanous@google.com>
Change-Id: I1a792ffb4ad7bc71637ab1aa0648a245949aeeee