### PR TITLE
BMC_SHELL web-base_shell

### DIFF
--- a/http/obmc_shell.hpp
+++ b/http/obmc_shell.hpp
@@ -1,0 +1,250 @@
+#pragma once
+
+#include <pty.h>
+#include <pwd.h>
+#include <termios.h>
+
+#include <app.hpp>
+#include <boost/asio/posix/stream_descriptor.hpp>
+#include <boost/process/io.hpp>
+#include <websocket.hpp>
+
+#include <map>
+
+namespace crow
+{
+
+namespace obmc_shell
+{
+
+class Handler : public std::enable_shared_from_this<Handler>
+{
+  public:
+    explicit Handler(crow::websocket::Connection* conn) :
+        session(conn), streamFileDescriptor(conn->getIoContext())
+    {
+        outputBuffer.fill(0);
+    }
+
+    ~Handler() = default;
+
+    Handler(const Handler&) = delete;
+    Handler(Handler&&) = delete;
+    Handler& operator=(const Handler&) = delete;
+    Handler& operator=(Handler&&) = delete;
+
+    void doClose()
+    {
+        streamFileDescriptor.close();
+
+        // boost::process::child::terminate uses SIGKILL, need to send SIGTERM
+        int rc = kill(pid, SIGKILL);
+        session = nullptr;
+        if (rc != 0)
+        {
+            return;
+        }
+        waitpid(pid, nullptr, 0);
+    }
+
+    void connect()
+    {
+        pid = forkpty(&ttyFileDescriptor, nullptr, nullptr, nullptr);
+
+        if (pid == -1)
+        {
+            // ERROR
+            if (session != nullptr)
+            {
+                session->close("Error creating ssh child process");
+            }
+            return;
+        }
+        if (pid == 0)
+        {
+            // CHILD
+
+            // sets the effective user ID
+            // as service user
+            bool isUidSet = false;
+            if (auto userName = session->getUserName(); !userName.empty())
+            {
+                if (struct passwd* pw = getpwnam(userName.c_str());
+                    pw != nullptr)
+                {
+                    int uidr = setuid(pw->pw_uid);
+                    if (uidr == 0)
+                    {
+                        isUidSet = true;
+                    }
+                    else
+                    {
+                        BMCWEB_LOG_ERROR << "sets service user failed Error: "
+                                         << uidr;
+                    }
+                }
+                else
+                {
+                    BMCWEB_LOG_ERROR << "getpwnam return null passwd";
+                }
+            }
+            else
+            {
+                BMCWEB_LOG_ERROR << "userName is empty";
+            }
+
+            // close connection unable to set
+            // setuid()
+            if (!isUidSet)
+            {
+                session->close("sets service user failed");
+                return;
+            }
+
+            // create /bin/sh chiled process
+            // NOLINTNEXTLINE(cppcoreguidelines-pro-type-vararg)
+            execl("/bin/sh", "/bin/sh", nullptr);
+            return;
+        }
+        if (pid > 0)
+        {
+            // PARENT
+
+            // for io operation assing file discriptor
+            // to boost stream_descriptor
+            streamFileDescriptor.assign(ttyFileDescriptor);
+            doWrite();
+            doRead();
+        }
+    }
+
+    void doWrite()
+    {
+        if (session == nullptr)
+        {
+            BMCWEB_LOG_DEBUG << "session is closed";
+            return;
+        }
+        if (doingWrite)
+        {
+            BMCWEB_LOG_DEBUG << "Already writing.  Bailing out";
+            return;
+        }
+
+        if (inputBuffer.empty())
+        {
+            BMCWEB_LOG_DEBUG << "inputBuffer empty.  Bailing out";
+            return;
+        }
+
+        doingWrite = true;
+        streamFileDescriptor.async_write_some(
+            boost::asio::buffer(inputBuffer.data(), inputBuffer.size()),
+            [this, self(shared_from_this())](boost::beast::error_code ec,
+                                             std::size_t bytesWritten) {
+            BMCWEB_LOG_DEBUG << "Wrote " << bytesWritten << "bytes";
+            doingWrite = false;
+            inputBuffer.erase(0, bytesWritten);
+            if (ec == boost::asio::error::eof)
+            {
+                session->close("ssh socket port closed");
+                return;
+            }
+            if (ec)
+            {
+                session->close("Error in writing to processSSH port");
+                BMCWEB_LOG_ERROR << "Error in ssh socket write " << ec;
+                return;
+            }
+            doWrite();
+            });
+    }
+
+    void doRead()
+    {
+        if (session == nullptr)
+        {
+            BMCWEB_LOG_DEBUG << "session is closed";
+            return;
+        }
+        streamFileDescriptor.async_read_some(
+            boost::asio::buffer(outputBuffer.data(), outputBuffer.size()),
+            [this, self(shared_from_this())](
+                const boost::system::error_code& ec, std::size_t bytesRead) {
+            BMCWEB_LOG_DEBUG << "Read done.  Read " << bytesRead << " bytes";
+            if (session == nullptr)
+            {
+                BMCWEB_LOG_DEBUG << "session is closed";
+                return;
+            }
+            if (ec)
+            {
+                BMCWEB_LOG_ERROR << "Couldn't read from ssh port: " << ec;
+                session->close("Error in connecting to ssh port");
+                return;
+            }
+            std::string_view payload(outputBuffer.data(), bytesRead);
+            session->sendBinary(payload);
+            doRead();
+            });
+    }
+
+    // this has to public
+    std::string inputBuffer;
+
+  private:
+    crow::websocket::Connection* session;
+    boost::asio::posix::stream_descriptor streamFileDescriptor;
+    bool doingWrite{false};
+    int ttyFileDescriptor{0};
+    pid_t pid{0};
+
+    std::array<char, 4096> outputBuffer{};
+};
+
+static std::map<crow::websocket::Connection*, std::shared_ptr<Handler>>
+    mapHandler;
+
+inline void requestRoutes(App& app)
+{
+    BMCWEB_ROUTE(app, "/bmc-console")
+        .privileges({{"ConfigureManager"}})
+        .websocket()
+        .onopen([](crow::websocket::Connection& conn) {
+            BMCWEB_LOG_DEBUG << "Connection " << &conn << " opened";
+            if (auto it = mapHandler.find(&conn); it == mapHandler.end())
+            {
+                auto insertData =
+                    mapHandler.emplace(&conn, std::make_shared<Handler>(&conn));
+                if (std::get<bool>(insertData))
+                {
+                    std::get<0>(insertData)->second->connect();
+                }
+            }
+        })
+        .onclose(
+            [](crow::websocket::Connection& conn, const std::string& reason) {
+        BMCWEB_LOG_DEBUG << "bmc-shell console.onclose(reason = '" << reason
+                         << "')";
+        if (auto it = mapHandler.find(&conn); it != mapHandler.end())
+        {
+            it->second->doClose();
+            mapHandler.erase(it);
+        }
+        })
+        .onmessage([]([[maybe_unused]] crow::websocket::Connection& conn,
+                      const std::string& data, [[maybe_unused]] bool isBinary) {
+            if (auto it = mapHandler.find(&conn); it != mapHandler.end())
+            {
+                it->second->inputBuffer += data;
+                it->second->doWrite();
+            }
+            else
+            {
+                BMCWEB_LOG_ERROR << "connection to webScoket not found";
+            }
+        });
+}
+
+} // namespace obmc_shell
+} // namespace crow

--- a/meson.build
+++ b/meson.build
@@ -61,6 +61,7 @@ incdir = include_directories(
 
 feature_map = {
   'basic-auth'                                  : '-DBMCWEB_ENABLE_BASIC_AUTHENTICATION',
+  'bmc-shell-socket'                            : '-DBMCWEB_ENABLE_BMC_SHELL_WEBSOCKET',
   'cookie-auth'                                 : '-DBMCWEB_ENABLE_COOKIE_AUTHENTICATION',
   'event-subscription'                          : '-DBMCWEB_ENABLE_EVENT_SUBSCRIPTION_WEBSOCKET',
   'google-api'                                  : '-DBMCWEB_ENABLE_GOOGLE_API',

--- a/meson_options.txt
+++ b/meson_options.txt
@@ -316,3 +316,12 @@ option(
                     enable on production systems at this time.  Other query
                     parameters such as only are not controlled by this option.'''
 )
+
+option(
+      'bmc-shell-socket',
+      type : 'feature',
+      value : 'disabled',
+      description : '''Enable BMC command shell WebSocket, which makes it
+                       possible to access secure shell. Path is
+                       \'/bmc-console\'.'''
+)

--- a/src/webserver_main.cpp
+++ b/src/webserver_main.cpp
@@ -15,6 +15,7 @@
 #include <login_routes.hpp>
 #include <nbd_proxy.hpp>
 #include <obmc_console.hpp>
+#include <obmc_shell.hpp>
 #include <openbmc_dbus_rest.hpp>
 #include <redfish.hpp>
 #include <redfish_aggregator.hpp>
@@ -107,6 +108,10 @@ static int run()
 
 #ifdef BMCWEB_ENABLE_HOST_SERIAL_WEBSOCKET
     crow::obmc_console::requestRoutes(app);
+#endif
+
+#ifdef BMCWEB_ENABLE_BMC_SHELL_WEBSOCKET
+    crow::obmc_shell::requestRoutes(app);
 #endif
 
 #ifdef BMCWEB_ENABLE_VM_WEBSOCKET


### PR DESCRIPTION
This commit includes a web-based shell, making it possible to access secure shell servers through standard web browsers using WebSocket.

Path of WebSocket:
    wss://{hostname}/bmc-console

Implementation:

    So when bmcweb WebSocket gets a request for a new connection, it
    creates a child process of bmcweb using the forking bmcweb process
    (which begins a new process operating in a pseudoterminal).

    Then on that pseudoterminal call exec("/bin/sh") which replaces the
    current process image with a "/bin/sh" process image.

    bmcweb is communicating with that child process using
    stream_descriptor, similar to read write from a file descriptor,
    with asynchronous ability. So the shell can execute all commands
    like ls, cd, etc.

    WebSocket here only acts as a mediator between child process, which
    acts as a shell, and xterm.js, which write in NodeJS

Authorize user for Shell :

    Only service users can access this interface, which means only
    managers can access this interface.

Test:
    Needs testing using webUI. Currently, webUI does not work with p11
    bring-up openbmc and 1050 bmcweb. The testing should be done
    using the image built with 1050-ghe. 

This change is downstream change only.