### PR TITLE
IBM ACF Support

### DIFF
--- a/include/authentication.hpp
+++ b/include/authentication.hpp
@@ -239,6 +239,16 @@ static std::shared_ptr<persistent_data::UserSession>
         }
     }
 
+    // This patch is allowed for service user, without authorization to upload
+    // unauthenticated ACF.
+    if (boost::beast::http::verb::patch == method)
+    {
+        if (url == "/redfish/v1/AccountService/Accounts/service")
+        {
+            return true;
+        }
+    }
+
     // it's allowed to POST on session collection & login without
     // authentication
     if (boost::beast::http::verb::post == method)

--- a/redfish-core/include/error_messages.hpp
+++ b/redfish-core/include/error_messages.hpp
@@ -1057,6 +1057,17 @@ nlohmann::json operationNotAllowed();
 
 void operationNotAllowed(crow::Response& res);
 
+/**
+ * RestrictedRole is new in
+ * https://github.com/DMTF/Redfish/blob/master/registries/Base.1.9.0.json
+ * @brief Formats RestrictedRole message into JSON
+ * Message body: "The operation was not successful because the role '<arg1>' is
+ * restricted."
+ *
+ * @returns Message RestrictedRole formatted to JSON */
+nlohmann::json restrictedRole(const std::string& arg1);
+
+void restrictedRole(crow::Response& res, const std::string& arg1);
 } // namespace messages
 
 } // namespace redfish

--- a/redfish-core/include/privileges.hpp
+++ b/redfish-core/include/privileges.hpp
@@ -55,8 +55,8 @@ constexpr const size_t maxPrivilegeCount = 32;
 
 /** @brief A vector of all privilege names and their indexes */
 static const std::array<std::string, maxPrivilegeCount> privilegeNames{
-    "Login", "ConfigureManager", "ConfigureComponents", "ConfigureSelf",
-    "ConfigureUsers"};
+    "Login",         "ConfigureManager", "ConfigureComponents",
+    "ConfigureSelf", "ConfigureUsers",   "OemIBMPerformService"};
 
 /**
  * @brief Redfish privileges
@@ -234,6 +234,13 @@ inline const Privileges& getUserPrivileges(const std::string& userRole)
         // Redfish privilege : Readonly
         static Privileges readOnly{"Login", "ConfigureSelf"};
         return readOnly;
+    }
+    if (userRole == "priv-oemibmserviceagent")
+    {
+        static Privileges admin{
+            "Login",          "ConfigureManager",    "ConfigureSelf",
+            "ConfigureUsers", "ConfigureComponents", "OemIBMPerformService"};
+        return admin;
     }
     // Redfish privilege : NoAccess
     static Privileges noaccess;

--- a/redfish-core/lib/account_service.hpp
+++ b/redfish-core/lib/account_service.hpp
@@ -1414,6 +1414,138 @@ inline void updateUserProperties(std::shared_ptr<bmcweb::AsyncResp> asyncResp,
         });
 }
 
+inline void uploadACF(const std::shared_ptr<bmcweb::AsyncResp>& asyncResp,
+                      const std::vector<uint8_t>& decodedAcf)
+{
+    crow::connections::systemBus->async_method_call(
+        [asyncResp](const boost::system::error_code ec,
+                    sdbusplus::message::message& m,
+                    const std::tuple<std::vector<uint8_t>, bool, std::string>&
+                        messageFDbus) {
+        if (ec)
+        {
+            BMCWEB_LOG_ERROR << "DBUS response error: " << ec;
+            if (strcmp(m.get_error()->name, "xyz.openbmc_project.Certs.Error."
+                                            "InvalidCertificate") == 0)
+            {
+                redfish::messages::invalidUpload(
+                    asyncResp->res,
+                    "/redfish/v1/AccountService/Accounts/service",
+                    "Invalid Certificate");
+            }
+            else
+            {
+                messages::internalError(asyncResp->res);
+            }
+            return;
+        }
+        getAcfProperties(asyncResp, messageFDbus);
+        },
+        "xyz.openbmc_project.Certs.ACF."
+        "Manager",
+        "/xyz/openbmc_project/certs/ACF", "xyz.openbmc_project.Certs.ACF",
+        "InstallACF", decodedAcf);
+}
+
+inline void triggerUnauthenticatedACFUpload(
+    const std::shared_ptr<bmcweb::AsyncResp>& asyncResp,
+    std::optional<nlohmann::json> oem)
+{
+    std::optional<nlohmann::json> ibm;
+    if (!redfish::json_util::readJson(*oem, asyncResp->res, "IBM", ibm))
+    {
+        BMCWEB_LOG_ERROR << "Illegal Property ";
+        messages::propertyMissing(asyncResp->res, "IBM");
+        return;
+    }
+
+    if (ibm)
+    {
+        std::optional<nlohmann::json> acf;
+        if (!redfish::json_util::readJson(*ibm, asyncResp->res, "ACF", acf))
+        {
+            BMCWEB_LOG_ERROR << "Illegal Property ";
+            messages::propertyMissing(asyncResp->res, "ACF");
+            return;
+        }
+
+        if (acf)
+        {
+            std::vector<uint8_t> decodedAcf;
+            std::optional<std::string> acfFile;
+            if (acf.value().contains("ACFFile") &&
+                acf.value()["ACFFile"] == nullptr)
+            {
+                acfFile = "";
+            }
+            else
+            {
+                if (!redfish::json_util::readJson(*acf, asyncResp->res,
+                                                  "ACFFile", acfFile))
+                {
+                    BMCWEB_LOG_ERROR << "Illegal Property ";
+                    messages::propertyMissing(asyncResp->res, "ACFFile");
+                    return;
+                }
+
+                std::string sDecodedAcf;
+                if (!crow::utility::base64Decode(*acfFile, sDecodedAcf))
+                {
+                    BMCWEB_LOG_ERROR << "base64 decode failure ";
+                    messages::internalError(asyncResp->res);
+                    return;
+                }
+                try
+                {
+                    std::copy(sDecodedAcf.begin(), sDecodedAcf.end(),
+                              std::back_inserter(decodedAcf));
+                }
+                catch (const std::exception& e)
+                {
+                    BMCWEB_LOG_ERROR << e.what();
+                    messages::internalError(asyncResp->res);
+                    return;
+                }
+            }
+
+            crow::connections::systemBus->async_method_call(
+                [asyncResp, decodedAcf](const boost::system::error_code ec,
+                                        const std::variant<bool>& retVal) {
+                if (ec)
+                {
+                    BMCWEB_LOG_ERROR
+                        << "Failed to read ACFWindowActive property";
+                    messages::internalError(asyncResp->res);
+                    return;
+                }
+
+                const bool* isACFWindowActive = std::get_if<bool>(&retVal);
+
+                if (isACFWindowActive == nullptr)
+                {
+                    BMCWEB_LOG_ERROR << "nullptr for ACFWindowActive";
+                    messages::internalError(asyncResp->res);
+                    return;
+                }
+
+                if (*isACFWindowActive)
+                {
+                    uploadACF(asyncResp, decodedAcf);
+                    return;
+                }
+
+                BMCWEB_LOG_ERROR << "ACF window not set to "
+                                    "active from panel";
+                messages::insufficientPrivilege(asyncResp->res);
+                return;
+                },
+                "com.ibm.PanelApp", "/com/ibm/panel_app",
+                "org.freedesktop.DBus.Properties", "Get", "com.ibm.panel",
+                "ACFWindowActive");
+        }
+    }
+}
+
 inline void handleAccountServiceHead(
     App& app, const crow::Request& req,
     const std::shared_ptr<bmcweb::AsyncResp>& asyncResp)
@@ -2117,24 +2249,48 @@ inline void
         return;
     }
 
+    if (!json_util::readJsonPatch(
+            req, asyncResp->res, "UserName", newUserName, "Password", password,
+            "RoleId", roleId, "Enabled", enabled, "Locked", locked, "Oem", oem))
+    {
+        return;
+    }
+
+    // Unauthenticated user
+    if (req.session == nullptr)
+    {
+        // If user is service
+        if (username == "service")
+        {
+            if (oem)
+            {
+                // allow unauthenticated ACF upload based on panel
+                // function 74 state.
+                triggerUnauthenticatedACFUpload(asyncResp, oem);
+                return;
+            }
+        }
+        messages::insufficientPrivilege(asyncResp->res);
+        return;
+    }
+
     Privileges effectiveUserPrivileges =
         redfish::getUserPrivileges(req.userRole);
     Privileges configureUsers = {"ConfigureUsers"};
     bool userHasConfigureUsers =
         effectiveUserPrivileges.isSupersetOf(configureUsers);
-    if (userHasConfigureUsers)
+    if (!userHasConfigureUsers)
     {
-        // Users with ConfigureUsers can modify for all users
-        if (!json_util::readJsonPatch(req, asyncResp->res, "UserName",
-                                      newUserName, "Password", password,
-                                      "RoleId", roleId, "Enabled", enabled,
-                                      "Locked", locked, "Oem", oem))
+        // Irrespective of role can patch ACF if function
+        // 74 is active from panel.
+        if (oem && (username == "service"))
         {
+            // allow unauthenticated ACF upload based on panel
+            // function 74 state.
+            triggerUnauthenticatedACFUpload(asyncResp, oem);
             return;
         }
-    }
-    else
-    {
+
         // ConfigureSelf accounts can only modify their own account
         if (username != req.session->username)
         {
@@ -2227,35 +2383,7 @@ inline void
                     }
                 }
 
-                crow::connections::systemBus->async_method_call(
-                    [asyncResp](const boost::system::error_code ec,
-                                sdbusplus::message::message& m,
-                                const std::tuple<std::vector<uint8_t>, bool,
-                                                 std::string>& messageFDbus) {
-                    if (ec)
-                    {
-                        BMCWEB_LOG_ERROR << "DBUS response error: " << ec;
-                        if (strcmp(m.get_error()->name,
-                                   "xyz.openbmc_project.Certs."
-                                   "Error.InvalidCertificate") == 0)
-                        {
-                            redfish::messages::invalidUpload(
-                                asyncResp->res,
-                                "/redfish/v1/AccountService/"
-                                "Accounts/service",
-                                "Invalid Certificate");
-                        }
-                        else
-                        {
-                            messages::internalError(asyncResp->res);
-                        }
-                        return;
-                    }
-                    getAcfProperties(asyncResp, messageFDbus);
-                    },
-                    "xyz.openbmc_project.Certs.ACF.Manager",
-                    "/xyz/openbmc_project/certs/ACF",
-                    "xyz.openbmc_project.Certs.ACF", "InstallACF", decodedAcf);
+                uploadACF(asyncResp, decodedAcf);
             }
             else if (acf && (username != "service"))
             {

--- a/redfish-core/lib/account_service.hpp
+++ b/redfish-core/lib/account_service.hpp
@@ -1923,6 +1923,20 @@ inline void handleAccountCollectionPost(
             return;
         }
 
+        // Create (modified) modGroupsList from allGroupsList that
+        // does not contain the ipmi group.
+        std::vector<std::string> modGroupsList;
+
+        for (const auto& group : allGroupsList)
+        {
+            if (group != "ipmi")
+            {
+                modGroupsList.push_back(group);
+            }
+        }
+
+        const std::vector<std::string>* pModGroupsList = &modGroupsList;
+
         crow::connections::systemBus->async_method_call(
             [asyncResp, username, password](const boost::system::error_code ec2,
                                             sdbusplus::message_t& m) {
@@ -1967,7 +1981,7 @@ inline void handleAccountCollectionPost(
             },
             "xyz.openbmc_project.User.Manager", "/xyz/openbmc_project/user",
             "xyz.openbmc_project.User.Manager", "CreateUser", username,
-            allGroupsList, *roleId, *enabled);
+            *pModGroupsList, *roleId, *enabled);
         });
 }
 

--- a/redfish-core/lib/account_service.hpp
+++ b/redfish-core/lib/account_service.hpp
@@ -844,6 +844,107 @@ inline void
         ldapConfigInterface, "UserNameAttribute",
         dbus::utility::DbusVariantType(userNameAttribute));
 }
+
+inline void getAcfProperties(
+    const std::shared_ptr<bmcweb::AsyncResp>& asyncResp,
+    const std::tuple<std::vector<uint8_t>, bool, std::string>& messageFDbus)
+{
+    asyncResp->res.jsonValue["Oem"]["IBM"]["@odata.type"] =
+        "#OemManagerAccount.v1_0_0.IBM";
+    asyncResp->res.jsonValue["Oem"]["IBM"]["ACF"]["@odata.type"] =
+        "#OemManagerAccount.v1_0_0.ACF";
+    // Get messages from call to InstallACF and add values to json
+    std::vector<uint8_t> acfFile = std::get<0>(messageFDbus);
+    std::string decodeACFFile(acfFile.begin(), acfFile.end());
+    std::string encodedACFFile = crow::utility::base64encode(decodeACFFile);
+
+    bool acfInstalled = std::get<1>(messageFDbus);
+    std::string expirationDate = std::get<2>(messageFDbus);
+
+    asyncResp->res
+        .jsonValue["Oem"]["IBM"]["ACF"]["WarningLongDatedExpiration"] = nullptr;
+    asyncResp->res.jsonValue["Oem"]["IBM"]["ACF"]["ACFFile"] = nullptr;
+    asyncResp->res.jsonValue["Oem"]["IBM"]["ACF"]["ExpirationDate"] = nullptr;
+
+    if (acfInstalled)
+    {
+        asyncResp->res.jsonValue["Oem"]["IBM"]["ACF"]["ExpirationDate"] =
+            expirationDate;
+
+        asyncResp->res.jsonValue["Oem"]["IBM"]["ACF"]["ACFFile"] =
+            encodedACFFile;
+
+        std::time_t result = std::time(nullptr);
+
+        // YYYY-MM-DD format
+        // Parse expirationDate to get difference between now and expiration
+        std::string expirationDateCpy = expirationDate;
+        std::string delimiter = "-";
+        std::vector<int> parseTime;
+
+        char* endPtr = nullptr;
+        size_t pos = 0;
+        std::string token;
+        // expirationDate should be exactly 10 characters
+        if (expirationDateCpy.length() != 10)
+        {
+            BMCWEB_LOG_ERROR << "expirationDate format invalid";
+            asyncResp->res = {};
+            messages::internalError(asyncResp->res);
+            return;
+        }
+        while ((pos = expirationDateCpy.find(delimiter)) != std::string::npos)
+        {
+            token = expirationDateCpy.substr(0, pos);
+            parseTime.push_back(
+                static_cast<int>(std::strtol(token.c_str(), &endPtr, 10)));
+
+            if (*endPtr != '\0')
+            {
+                BMCWEB_LOG_ERROR << "expirationDate format enum";
+                asyncResp->res = {};
+                messages::internalError(asyncResp->res);
+                return;
+            }
+            expirationDateCpy.erase(0, pos + delimiter.length());
+        }
+        parseTime.push_back(static_cast<int>(
+            std::strtol(expirationDateCpy.c_str(), &endPtr, 10)));
+
+        // Expect 3 sections. YYYY MM DD
+        if (*endPtr != '\0' && parseTime.size() != 3)
+        {
+            BMCWEB_LOG_ERROR << "expirationDate format invalid";
+            messages::internalError(asyncResp->res);
+            return;
+        }
+
+        std::tm tm{}; // zero initialise
+        tm.tm_year = parseTime.at(0) - 1900;
+        tm.tm_mon = parseTime.at(1) - 1;
+        tm.tm_mday = parseTime.at(2);
+
+        std::time_t t = std::mktime(&tm);
+        u_int diffTime = static_cast<u_int>(std::difftime(t, result));
+        // BMC date is displayed if exp date > 30 days
+        // 30 days = 30 * 24 * 60 * 60 seconds
+        if (diffTime > 2592000)
+        {
+            asyncResp->res
+                .jsonValue["Oem"]["IBM"]["ACF"]["WarningLongDatedExpiration"] =
+                true;
+        }
+        else
+        {
+            asyncResp->res
+                .jsonValue["Oem"]["IBM"]["ACF"]["WarningLongDatedExpiration"] =
+                false;
+        }
+    }
+    asyncResp->res.jsonValue["Oem"]["IBM"]["ACF"]["ACFInstalled"] =
+        acfInstalled;
+}
+
 /**
  * @brief updates the LDAP group attribute and updates the
           json response with the new value.
@@ -1896,6 +1997,25 @@ inline void
             "/redfish/v1/AccountService/Accounts/" + accountName;
         asyncResp->res.jsonValue["Id"] = accountName;
         asyncResp->res.jsonValue["UserName"] = accountName;
+
+        if (accountName == "service")
+        {
+            crow::connections::systemBus->async_method_call(
+                [asyncResp](const boost::system::error_code ec2,
+                            const std::tuple<std::vector<uint8_t>, bool,
+                                             std::string>& messageFDbus) {
+                if (ec2)
+                {
+                    BMCWEB_LOG_ERROR << "DBUS response error: " << ec2;
+                    messages::internalError(asyncResp->res);
+                    return;
+                }
+                getAcfProperties(asyncResp, messageFDbus);
+                },
+                "xyz.openbmc_project.Certs.ACF.Manager",
+                "/xyz/openbmc_project/certs/ACF",
+                "xyz.openbmc_project.Certs.ACF", "GetACFInfo");
+        }
         },
         "xyz.openbmc_project.User.Manager", "/xyz/openbmc_project/user",
         "org.freedesktop.DBus.ObjectManager", "GetManagedObjects");
@@ -1956,6 +2076,7 @@ inline void
     std::optional<bool> enabled;
     std::optional<std::string> roleId;
     std::optional<bool> locked;
+    std::optional<nlohmann::json> oem;
 
     if (req.session == nullptr)
     {
@@ -1974,7 +2095,7 @@ inline void
         if (!json_util::readJsonPatch(req, asyncResp->res, "UserName",
                                       newUserName, "Password", password,
                                       "RoleId", roleId, "Enabled", enabled,
-                                      "Locked", locked))
+                                      "Locked", locked, "Oem", oem))
         {
             return;
         }
@@ -1993,6 +2114,103 @@ inline void
                                       password))
         {
             return;
+        }
+    }
+
+    if (oem)
+    {
+        std::optional<nlohmann::json> ibm;
+        if (!redfish::json_util::readJson(*oem, asyncResp->res, "IBM", ibm))
+        {
+            BMCWEB_LOG_ERROR << "Illegal Property ";
+            messages::propertyMissing(asyncResp->res, "IBM");
+            return;
+        }
+        if (ibm)
+        {
+            std::optional<nlohmann::json> acf;
+            if (!redfish::json_util::readJson(*ibm, asyncResp->res, "ACF", acf))
+            {
+                BMCWEB_LOG_ERROR << "Illegal Property ";
+                messages::propertyMissing(asyncResp->res, "ACF");
+                return;
+            }
+            if (acf && (username == "service"))
+            {
+                std::vector<uint8_t> decodedAcf;
+                std::optional<std::string> acfFile;
+                if (acf.value().contains("ACFFile") &&
+                    acf.value()["ACFFile"] == nullptr)
+                {
+                    acfFile = "";
+                }
+                else
+                {
+                    if (!redfish::json_util::readJson(*acf, asyncResp->res,
+                                                      "ACFFile", acfFile))
+                    {
+                        BMCWEB_LOG_ERROR << "Illegal Property ";
+                        messages::propertyMissing(asyncResp->res, "ACFFile");
+                        return;
+                    }
+
+                    std::string sDecodedAcf;
+                    if (!crow::utility::base64Decode(*acfFile, sDecodedAcf))
+                    {
+                        BMCWEB_LOG_ERROR << "base64 decode failure ";
+                        messages::internalError(asyncResp->res);
+                        return;
+                    }
+                    try
+                    {
+                        std::copy(sDecodedAcf.begin(), sDecodedAcf.end(),
+                                  std::back_inserter(decodedAcf));
+                    }
+                    catch (const std::exception& e)
+                    {
+                        BMCWEB_LOG_ERROR << e.what();
+                        messages::internalError(asyncResp->res);
+                        return;
+                    }
+                }
+
+                crow::connections::systemBus->async_method_call(
+                    [asyncResp](const boost::system::error_code ec,
+                                sdbusplus::message::message& m,
+                                const std::tuple<std::vector<uint8_t>, bool,
+                                                 std::string>& messageFDbus) {
+                    if (ec)
+                    {
+                        BMCWEB_LOG_ERROR << "DBUS response error: " << ec;
+                        if (strcmp(m.get_error()->name,
+                                   "xyz.openbmc_project.Certs."
+                                   "Error.InvalidCertificate") == 0)
+                        {
+                            redfish::messages::invalidUpload(
+                                asyncResp->res,
+                                "/redfish/v1/AccountService/"
+                                "Accounts/service",
+                                "Invalid Certificate");
+                        }
+                        else
+                        {
+                            messages::internalError(asyncResp->res);
+                        }
+                        return;
+                    }
+                    getAcfProperties(asyncResp, messageFDbus);
+                    },
+                    "xyz.openbmc_project.Certs.ACF.Manager",
+                    "/xyz/openbmc_project/certs/ACF",
+                    "xyz.openbmc_project.Certs.ACF", "InstallACF", decodedAcf);
+            }
+            else if (acf && (username != "service"))
+            {
+                messages::resourceAtUriUnauthorized(
+                    asyncResp->res, req.urlView,
+                    "ACF properties access not allowed by non service "
+                    "user");
+            }
         }
     }
 

--- a/redfish-core/lib/roles.hpp
+++ b/redfish-core/lib/roles.hpp
@@ -43,13 +43,17 @@ inline std::string getRoleFromPrivileges(std::string_view priv)
     {
         return "NoAccess";
     }
+    if (priv == "priv-oemibmserviceagent")
+    {
+        return "OemIBMServiceAgent";
+    }
     return "";
 }
 
 inline bool getAssignedPrivFromRole(std::string_view role,
                                     nlohmann::json& privArray)
 {
-    if (role == "Administrator")
+    if ((role == "Administrator") || (role == "OemIBMServiceAgent"))
     {
         privArray = {"Login", "ConfigureManager", "ConfigureUsers",
                      "ConfigureSelf", "ConfigureComponents"};
@@ -73,6 +77,29 @@ inline bool getAssignedPrivFromRole(std::string_view role,
     return true;
 }
 
+inline bool getOemPrivFromRole(std::string_view role, nlohmann::json& privArray)
+{
+    if ((role == "Administrator") || (role == "Operator") ||
+        (role == "ReadOnly") || (role == "NoAccess"))
+    {
+        privArray = nlohmann::json::array();
+    }
+    else if (role == "OemIBMServiceAgent")
+    {
+        privArray = {"OemIBMPerformService"};
+    }
+    else
+    {
+        return false;
+    }
+    return true;
+}
+
+inline bool isRestrictedRole(const std::string& role)
+{
+    return role == "OemIBMServiceAgent";
+}
+
 inline void requestRoutesRoles(App& app)
 {
     BMCWEB_ROUTE(app, "/redfish/v1/AccountService/Roles/<str>/")
@@ -93,16 +120,24 @@ inline void requestRoutesRoles(App& app)
             return;
         }
 
+        nlohmann::json oemPrivArray = nlohmann::json::array();
+        if (!getOemPrivFromRole(roleId, oemPrivArray))
+        {
+            messages::resourceNotFound(asyncResp->res, "Role", roleId);
+            return;
+        }
+
         asyncResp->res.jsonValue["@odata.type"] = "#Role.v1_2_2.Role";
         asyncResp->res.jsonValue["Name"] = "User Role";
         asyncResp->res.jsonValue["Description"] = roleId + " User Role";
-        asyncResp->res.jsonValue["OemPrivileges"] = nlohmann::json::array();
+        asyncResp->res.jsonValue["OemPrivileges"] = std::move(oemPrivArray);
         asyncResp->res.jsonValue["IsPredefined"] = true;
         asyncResp->res.jsonValue["Id"] = roleId;
         asyncResp->res.jsonValue["RoleId"] = roleId;
         asyncResp->res.jsonValue["@odata.id"] =
             "/redfish/v1/AccountService/Roles/" + roleId;
         asyncResp->res.jsonValue["AssignedPrivileges"] = std::move(privArray);
+        asyncResp->res.jsonValue["Restricted"] = isRestrictedRole(roleId);
         });
 }
 

--- a/redfish-core/src/error_messages.cpp
+++ b/redfish-core/src/error_messages.cpp
@@ -1796,6 +1796,33 @@ nlohmann::json invalidUpload(std::string_view arg1, std::string_view arg2)
     return ret;
 }
 
+/**
+ * @internal
+ * @brief Formats RestrictedRole into JSON
+ *
+ * See header file for more information
+ * @endinternal
+ */
+nlohmann::json restrictedRole(const std::string& arg1)
+{
+    return nlohmann::json{
+        {"@odata.type", "#Message.v1_1_1.Message"},
+        {"MessageId", "Base.1.9.0.RestrictedRole"},
+        {"Message", "The operation was not successful because the role '" +
+                        arg1 + "' is restricted."},
+        {"MessageArgs", {arg1}},
+        {"MessageSeverity", "Warning"},
+        {"Resolution",
+         "No resolution is required.  For standard roles, consider using the role "
+         "specified in the AlternateRoleId property in the Role resource."}};
+}
+
+void restrictedRole(crow::Response& res, const std::string& arg1)
+{
+    res.result(boost::beast::http::status::bad_request);
+    addMessageToErrorJson(res.jsonValue, restrictedRole(arg1));
+}
+
 } // namespace messages
 
 } // namespace redfish

--- a/scripts/update_schemas.py
+++ b/scripts/update_schemas.py
@@ -399,6 +399,15 @@ with open(metadata_index_path, "w") as metadata_index:
     )
     metadata_index.write("    </edmx:Reference>\n")
 
+    metadata_index.write(
+        "    <edmx:Reference Uri=\""
+        "/redfish/v1/schema/OemManagerAccount.v1_0_0.xml\">\n")
+    metadata_index.write(
+        "        <edmx:Include Namespace=\"OemManagerAccount\"/>\n")
+    metadata_index.write(
+        "        <edmx:Include Namespace=\"OemManagerAccount.v1_0_0\"/>\n")
+    metadata_index.write("    </edmx:Reference>\n")
+
     metadata_index.write("</edmx:Edmx>\n")
 
 

--- a/static/redfish/v1/$metadata/index.xml
+++ b/static/redfish/v1/$metadata/index.xml
@@ -2846,4 +2846,8 @@
         <edmx:Include Namespace="OemServiceRoot"/>
         <edmx:Include Namespace="OemServiceRoot.v1_0_0"/>
     </edmx:Reference>
+    <edmx:Reference Uri="/redfish/v1/schema/OemManagerAccount.v1_0_0.xml">
+        <edmx:Include Namespace="OemManagerAccount"/>
+        <edmx:Include Namespace="OemManagerAccount.v1_0_0"/>
+    </edmx:Reference>
 </edmx:Edmx>

--- a/static/redfish/v1/JsonSchemas/OemManagerAccount/index.json
+++ b/static/redfish/v1/JsonSchemas/OemManagerAccount/index.json
@@ -1,0 +1,97 @@
+{
+    "$id": "http://redfish.dmtf.org/schemas/v1/OemManagerAccount.v1_0_0.json",
+    "$schema": "http://redfish.dmtf.org/schemas/v1/redfish-schema-v1.json",
+    "copyright": "Copyright 2014-2019 DMTF. For the full DMTF copyright policy, see http://www.dmtf.org/about/policies/copyright",
+    "definitions": {
+        "IBM": {
+            "additionalProperties": true,
+            "description": "Oem IBM ManagerAccount extension.",
+            "longDescription": "Oem IBM ManagementAccount extension.",
+            "patternProperties": {
+                "^([a-zA-Z_][a-zA-Z0-9_]*)?@(odata|Redfish|Message)\\.[a-zA-Z_][a-zA-Z0-9_]*$": {
+                    "description": "This property shall specify a valid odata or Redfish property.",
+                    "type": [
+                        "array",
+                        "boolean",
+                        "integer",
+                        "number",
+                        "null",
+                        "object",
+                        "string"
+                    ]
+                }
+            },
+            "properties": {
+                "ACF": {
+                    "$ref": "#/definitions/ACF",
+                    "description": "A collection of ACF properties.",
+                    "longDescription": "A collection of access control file properties.",
+                    "readonly": false,
+                    "versionAdded": "v1_0_0"
+                }
+            }
+        },
+        "ACF": {
+            "additionalProperties": false,
+            "description": "OEM Extension for ManagerAccount",
+            "longDescription": "OEM Extension for ManagerAccount to provide the Service account extension.",
+            "patternProperties": {
+                "^([a-zA-Z_][a-zA-Z0-9_]*)?@(odata|Redfish|Message)\\.[a-zA-Z_][a-zA-Z0-9_]*$": {
+                    "description": "This property shall specify a valid odata or Redfish property.",
+                    "type": [
+                        "array",
+                        "boolean",
+                        "integer",
+                        "number",
+                        "null",
+                        "object",
+                        "string"
+                    ]
+                }
+            },
+            "properties": {
+                "ACFFile": {
+                    "description": "Base 64 encoded ACF contents.",
+                    "longDescription": "Base 64 encoded ACF contents. Contents must have a valid signature, expiration date, and serial number must match BMC serial number",
+                    "readonly": false,
+                    "type": "string",
+                    "versionAdded": "v1_0_0"
+                },
+                "ExpirationDate": {
+                    "description": "The expiration date of the ACF file.",
+                    "longDescription": "The expiration date of the ACF file, if the expiration date has been from the BMC then the ACF is not valid.",
+                    "readonly": true,
+                    "type": [
+                        "string",
+                        "null"
+                    ],
+                    "versionAdded": "v1_0_0"
+                },
+                "WarningLongDatedExpiration": {
+                    "description": "This property is set to true if there is a long dated expiration.",
+                    "longDescription": "This property is set to true if the expiration date on the ACF exceeds 30 days from the BMC date.",
+                    "readonly": true,
+                    "type": [
+                        "boolean",
+                        "null"
+                    ],
+                    "versionAdded": "v1_0_0"
+                },
+                "ACFInstalled": {
+                    "description": "This property is set to true if the ACF is installed.",
+                    "longDescription": "This property indicates if the ACF is installed or not.",
+                    "readonly": true,
+                    "type": [
+                        "boolean"
+                    ],
+                    "versionAdded": "v1_0_0"
+                }
+            },
+            "type": "object"
+            }
+    },
+    "owningEntity": "OpenBMC",
+    "release": "1.0",
+    "title": "#OemManagerAccount"
+}
+

--- a/static/redfish/v1/schema/OemManagerAccount.v1_0_0.xml
+++ b/static/redfish/v1/schema/OemManagerAccount.v1_0_0.xml
@@ -1,0 +1,68 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<edmx:Edmx xmlns:edmx="http://docs.oasis-open.org/odata/ns/edmx" Version="4.0">
+    <edmx:Reference Uri="http://docs.oasis-open.org/odata/odata/v4.0/errata03/csd01/complete/vocabularies/Org.OData.Core.V1.xml">
+        <edmx:Include Namespace="Org.OData.Core.V1" Alias="OData" />
+    </edmx:Reference>
+    <edmx:Reference Uri="http://redfish.dmtf.org/schemas/v1/RedfishExtensions_v1.xml">
+        <edmx:Include Namespace="Validation.v1_0_0" Alias="Validation"/>
+        <edmx:Include Namespace="RedfishExtensions.v1_0_0" Alias="Redfish"/>
+    </edmx:Reference>
+    <edmx:Reference Uri="http://redfish.dmtf.org/schemas/v1/ManagerAccount_v1.xml">
+        <edmx:Include Namespace="ManagerAccount"/>
+        <edmx:Include Namespace="ManagerAccount.v1_4_0"/>
+    </edmx:Reference>
+    <edmx:Reference Uri="http://redfish.dmtf.org/schemas/v1/Resource_v1.xml">
+        <edmx:Include Namespace="Resource"/>
+        <edmx:Include Namespace="Resource.v1_0_0"/>
+    </edmx:Reference>
+
+	<edmx:DataServices>
+       <Schema xmlns="http://docs.oasis-open.org/odata/ns/edm" Namespace="OemManagerAccount">
+          <Annotation Term="Redfish.OwningEntity" String="IBM"/>
+      </Schema>
+
+        <Schema xmlns="http://docs.oasis-open.org/odata/ns/edm" Namespace="OemManagerAccount.v1_0_0">
+			<ComplexType Name="Oem" BaseType="Resource.OemObject">
+				<Annotation Term="OData.AdditionalProperties" Bool="true" />
+                <Annotation Term="OData.Description" String="OemManagerAccount Oem properties." />
+                <Annotation Term="OData.AutoExpand"/>
+				<Property Name="IBM" Type="OemManagerAccount.v1_0_0.IBM"/>
+			</ComplexType>
+
+            <ComplexType Name="IBM">
+                <Annotation Term="OData.AdditionalProperties" Bool="true" />
+                <Annotation Term="OData.Description" String="Oem properties for IBM." />
+                <Annotation Term="OData.AutoExpand"/>
+                <Property Name="ACF" Type="OemManagerAccount.v1_0_0.ACF"/>
+            </ComplexType>
+
+			<ComplexType Name="ACF">
+				<Annotation Term="OData.Description" String="A collection of ACF properties."/>
+				<Annotation Term="OData.LongDescription" String="A collection of access control file properties."/>
+				<Annotation Term="OData.AdditionalProperties" Bool="false"/>
+				<Property Name="ACFFile" Type="Edm.String" Nullable="true">
+					<Annotation Term="OData.Permissions" EnumMember="OData.Permission/ReadWrite"/>
+					<Annotation Term="OData.Description" String="Base 64 encoded ACF contents."/>
+					<Annotation Term="OData.LongDescription" String="Base 64 encoded ACF contents. Contents must have a valid signature, expiration date, and serial number must match BMC serial number"/>
+				</Property>
+				<Property Name="WarningLongDatedExpiration" Type="Edm.Boolean" Nullable="true">
+					<Annotation Term="OData.Permissions" EnumMember="OData.Permission/Read"/>
+					<Annotation Term="OData.Description" String="This property is set to true if there is a long dated expiration."/>
+					<Annotation Term="OData.LongDescription" String="This property is set to true if the expiration date on the ACF exceeds 30 days from the BMC date."/>
+				</Property>
+				<Property Name="ExpirationDate" Type="Edm.String" Nullable="true">
+					<Annotation Term="OData.Permissions" EnumMember="OData.Permission/Read"/>
+					<Annotation Term="OData.Description" String="The expiration date of the ACF file."/>
+					<Annotation Term="OData.LongDescription" String="The expiration date of the ACF file, if the expiration date has been from the BMC then the ACF is not validD"/>
+				</Property>
+				<Property Name="ACFInstalled" Type="Edm.Boolean">
+					<Annotation Term="OData.Permissions" EnumMember="OData.Permission/Read"/>
+					<Annotation Term="OData.Description" String="This property is set to true if the ACF is installed."/>
+					<Annotation Term="OData.LongDescription" String="This property indicates if the ACF is installed or not."/>
+				</Property>
+			</ComplexType>
+
+		</Schema>
+	</edmx:DataServices>
+</edmx:Edmx>
+


### PR DESCRIPTION
This PR adds support for upload of ACF certificate files, in addition to a new OEM user role.

Tested: Certificate is able to be uploaded via:
```
curl -k -H "X-Auth-Token: $TOKEN" -X PATCH -d '{"Oem":{"IBM":{"ACF":{"ACFFile":"'${service_acf_base64}'"}}}}' https://${BMC}:${BMC_HTTPS_port}/redfish/v1/AccountService/Accounts/service
```
and the BMC is accessible by logging as service.