### PR TITLE
Added Hypervisor Serial Socket

### DIFF
--- a/include/obmc_console.hpp
+++ b/include/obmc_console.hpp
@@ -151,5 +151,45 @@ inline void requestRoutes(App& app)
             doWrite();
         });
 }
+
+inline void requestRoutesHypervisor(App& app)
+{
+    BMCWEB_ROUTE(app, "/console1")
+        .privileges({{"ConfigureComponents", "ConfigureManager"}})
+        .websocket()
+        .onopen(
+            [](crow::websocket::Connection& conn) {
+        BMCWEB_LOG_DEBUG << "Connection " << &conn << " opened";
+
+        sessions.insert(&conn);
+        if (hostSocket == nullptr)
+        {
+            const std::string consoleName("\0obmc-console.hypervisor", 24);
+            boost::asio::local::stream_protocol::endpoint ep(consoleName);
+
+            hostSocket =
+                std::make_unique<boost::asio::local::stream_protocol::socket>(
+                    conn.getIoContext());
+            hostSocket->async_connect(ep, connectHandler);
+        }
+        })
+        .onclose([](crow::websocket::Connection& conn,
+                    [[maybe_unused]] const std::string& reason) {
+            BMCWEB_LOG_INFO << "Closing websocket. Reason: " << reason;
+
+            sessions.erase(&conn);
+            if (sessions.empty())
+            {
+                hostSocket = nullptr;
+                inputBuffer.clear();
+                inputBuffer.shrink_to_fit();
+            }
+        })
+        .onmessage([]([[maybe_unused]] crow::websocket::Connection& conn,
+                      const std::string& data, [[maybe_unused]] bool isBinary) {
+            inputBuffer += data;
+            doWrite();
+        });
+}
 } // namespace obmc_console
 } // namespace crow

--- a/meson.build
+++ b/meson.build
@@ -66,6 +66,7 @@ feature_map = {
   'event-subscription'                          : '-DBMCWEB_ENABLE_EVENT_SUBSCRIPTION_WEBSOCKET',
   'google-api'                                  : '-DBMCWEB_ENABLE_GOOGLE_API',
   'host-serial-socket'                          : '-DBMCWEB_ENABLE_HOST_SERIAL_WEBSOCKET',
+  'hypervisor-serial-socket'                    : '-DBMCWEB_ENABLE_HYPERVISOR_SERIAL_WEBSOCKET',
   'ibm-management-console'                      : '-DBMCWEB_ENABLE_IBM_MANAGEMENT_CONSOLE',
   'insecure-disable-auth'                       : '-DBMCWEB_INSECURE_DISABLE_AUTHX',
   'insecure-disable-csrf'                       : '-DBMCWEB_INSECURE_DISABLE_CSRF_PREVENTION',

--- a/meson_options.txt
+++ b/meson_options.txt
@@ -318,10 +318,18 @@ option(
 )
 
 option(
-      'bmc-shell-socket',
-      type : 'feature',
-      value : 'disabled',
-      description : '''Enable BMC command shell WebSocket, which makes it
-                       possible to access secure shell. Path is
-                       \'/bmc-console\'.'''
+    'bmc-shell-socket',
+    type: 'feature',
+    value: 'disabled',
+    description: '''Enable BMC command shell WebSocket, which makes it
+                    possible to access secure shell. Path is
+                    \'/bmc-console\'.'''
+)
+
+option(
+    'hypervisor-serial-socket',
+    type: 'feature',
+    value: 'disabled',
+    description: '''Enable hypervisor serial console WebSocket. Path is
+                    \'/console1\'.'''
 )

--- a/src/webserver_main.cpp
+++ b/src/webserver_main.cpp
@@ -114,6 +114,10 @@ static int run()
     crow::obmc_shell::requestRoutes(app);
 #endif
 
+#ifdef BMCWEB_ENABLE_HYPERVISOR_SERIAL_WEBSOCKET
+    crow::obmc_console::requestRoutesHypervisor(app);
+#endif
+
 #ifdef BMCWEB_ENABLE_VM_WEBSOCKET
     crow::obmc_vm::requestRoutes(app);
 #endif


### PR DESCRIPTION
This commit adds `wss://${window.location.host}/console1` WebSocket into bmcweb. it retrieves 'PHYP debug shell' info and displays WebSocket data into WebUI using SOL (Serial over LAN) console.

'console1' read data from UNIX domain socket '@obmc-console.hypervisor' and display it in WebUI.

Privilege set to {"ConfigureComponents", "ConfigureManager"}. That mean only Administrator and Operator can retrieve console data.

Tested:
  configure UNIX domain socket '@obmc-console.hypervisor' with
  'wss://${window.location.host}/console0' (which currently use for
  retrieve 'host serial console data on SOL'). The test is successful,
  able to receive 'PHYP debug shell' data in SOL on WebUI.

Signed-off-by: Abhishek Patel <Abhishek.Patel@ibm.com>
Change-Id: Icece6ceddd0eeab8db7ebf1e5e863c22a59ae45f