### PR TITLE
Added Hypervisor Serial Socket

### DIFF
--- a/include/obmc_hypervisor.hpp
+++ b/include/obmc_hypervisor.hpp
@@ -1,0 +1,167 @@
+#pragma once
+#include <sys/socket.h>
+
+#include <app.hpp>
+#include <async_resp.hpp>
+#include <boost/asio/local/stream_protocol.hpp>
+#include <boost/container/flat_map.hpp>
+#include <boost/container/flat_set.hpp>
+#include <websocket.hpp>
+
+#include <array>
+#include <memory>
+#include <string>
+
+namespace crow
+{
+namespace obmc_hypervisor
+{
+
+static std::unique_ptr<boost::asio::local::stream_protocol::socket> hostSocket;
+
+static std::array<char, 4096> outputBuffer;
+static std::string inputBuffer;
+
+static boost::container::flat_set<crow::websocket::Connection*> sessions;
+
+static bool doingWrite = false;
+
+inline void doWrite()
+{
+    if (doingWrite)
+    {
+        BMCWEB_LOG_DEBUG << "Already writing.  Bailing out";
+        return;
+    }
+
+    if (inputBuffer.empty())
+    {
+        BMCWEB_LOG_DEBUG << "Outbuffer empty.  Bailing out";
+        return;
+    }
+
+    if (!hostSocket)
+    {
+        BMCWEB_LOG_ERROR << "doWrite(): Socket closed.";
+        return;
+    }
+
+    doingWrite = true;
+    hostSocket->async_write_some(
+        boost::asio::buffer(inputBuffer.data(), inputBuffer.size()),
+        [](boost::beast::error_code ec, std::size_t bytesWritten) {
+        doingWrite = false;
+        inputBuffer.erase(0, bytesWritten);
+
+        if (ec == boost::asio::error::eof)
+        {
+            for (crow::websocket::Connection* session : sessions)
+            {
+                session->close("Error in reading to host port");
+            }
+            return;
+        }
+        if (ec)
+        {
+            BMCWEB_LOG_ERROR << "Error in host serial write " << ec;
+            return;
+        }
+        doWrite();
+        });
+}
+
+inline void doRead()
+{
+    if (!hostSocket)
+    {
+        BMCWEB_LOG_ERROR << "doRead(): Socket closed.";
+        return;
+    }
+
+    BMCWEB_LOG_DEBUG << "Reading from socket";
+    hostSocket->async_read_some(
+        boost::asio::buffer(outputBuffer.data(), outputBuffer.size()),
+        [](const boost::system::error_code& ec, std::size_t bytesRead) {
+        BMCWEB_LOG_DEBUG << "read done.  Read " << bytesRead << " bytes";
+        if (ec)
+        {
+            BMCWEB_LOG_ERROR << "Couldn't read from host serial port: " << ec;
+            for (crow::websocket::Connection* session : sessions)
+            {
+                session->close("Error in connecting to host port");
+            }
+            return;
+        }
+        std::string_view payload(outputBuffer.data(), bytesRead);
+        for (crow::websocket::Connection* session : sessions)
+        {
+            session->sendBinary(payload);
+        }
+        doRead();
+        });
+}
+
+inline void connectHandler(const boost::system::error_code& ec)
+{
+    if (ec)
+    {
+        BMCWEB_LOG_ERROR << "Couldn't connect to host serial port: " << ec;
+        for (crow::websocket::Connection* session : sessions)
+        {
+            session->close("Error in connecting to host port");
+        }
+        return;
+    }
+
+    doWrite();
+    doRead();
+}
+
+inline void requestRoutes(App& app)
+{
+    BMCWEB_ROUTE(app, "/console1")
+        .privileges({{"OemIBMPerformService"}})
+        .websocket()
+        .onopen(
+            [](crow::websocket::Connection& conn) {
+        BMCWEB_LOG_DEBUG << "Connection " << &conn << " opened";
+
+        // TODO: this user check must be removed when WebSocket privileges
+        // work.
+        if (conn.getUserName() != "service")
+        {
+            BMCWEB_LOG_DEBUG << "only service user have access to hypervisor";
+            conn.close("only service user have access to hypervisor");
+        }
+        sessions.insert(&conn);
+        if (hostSocket == nullptr)
+        {
+            const std::string consoleName("\0obmc-console.hypervisor", 24);
+            boost::asio::local::stream_protocol::endpoint ep(consoleName);
+
+            hostSocket =
+                std::make_unique<boost::asio::local::stream_protocol::socket>(
+                    conn.getIoContext());
+            hostSocket->async_connect(ep, connectHandler);
+        }
+        })
+        .onclose([](crow::websocket::Connection& conn,
+                    [[maybe_unused]] const std::string& reason) {
+            BMCWEB_LOG_INFO << "Closing websocket. Reason: " << reason;
+
+            sessions.erase(&conn);
+            if (sessions.empty())
+            {
+                hostSocket = nullptr;
+                inputBuffer.clear();
+                inputBuffer.shrink_to_fit();
+            }
+        })
+        .onmessage([]([[maybe_unused]] crow::websocket::Connection& conn,
+                      const std::string& data, [[maybe_unused]] bool isBinary) {
+            inputBuffer += data;
+            doWrite();
+        });
+}
+} // namespace obmc_hypervisor
+} // namespace crow

--- a/meson.build
+++ b/meson.build
@@ -66,6 +66,7 @@ feature_map = {
   'event-subscription'                          : '-DBMCWEB_ENABLE_EVENT_SUBSCRIPTION_WEBSOCKET',
   'google-api'                                  : '-DBMCWEB_ENABLE_GOOGLE_API',
   'host-serial-socket'                          : '-DBMCWEB_ENABLE_HOST_SERIAL_WEBSOCKET',
+  'hypervisor-serial-socket'                    : '-DBMCWEB_ENABLE_HYPERVISOR_SERIAL_WEBSOCKET',
   'ibm-management-console'                      : '-DBMCWEB_ENABLE_IBM_MANAGEMENT_CONSOLE',
   'insecure-disable-auth'                       : '-DBMCWEB_INSECURE_DISABLE_AUTHX',
   'insecure-disable-csrf'                       : '-DBMCWEB_INSECURE_DISABLE_CSRF_PREVENTION',

--- a/meson_options.txt
+++ b/meson_options.txt
@@ -325,3 +325,11 @@ option(
                        possible to access secure shell. Path is
                        \'/bmc-console\'.'''
 )
+
+option(
+      'hypervisor-serial-socket',
+      type: 'feature',
+      value: 'disabled',
+      description: '''Enable hypervisor serial console WebSocket. Path is
+                      \'/console1\'.'''
+)

--- a/src/webserver_main.cpp
+++ b/src/webserver_main.cpp
@@ -15,6 +15,7 @@
 #include <login_routes.hpp>
 #include <nbd_proxy.hpp>
 #include <obmc_console.hpp>
+#include <obmc_hypervisor.hpp>
 #include <obmc_shell.hpp>
 #include <openbmc_dbus_rest.hpp>
 #include <redfish.hpp>
@@ -112,6 +113,10 @@ static int run()
 
 #ifdef BMCWEB_ENABLE_BMC_SHELL_WEBSOCKET
     crow::obmc_shell::requestRoutes(app);
+#endif
+
+#ifdef BMCWEB_ENABLE_HYPERVISOR_SERIAL_WEBSOCKET
+    crow::obmc_hypervisor::requestRoutes(app);
 #endif
 
 #ifdef BMCWEB_ENABLE_VM_WEBSOCKET


### PR DESCRIPTION
This commit adds `wss://${window.location.host}/console1` WebSocket into bmcweb. it retrieves 'PHYP debug shell' info and displays WebSocket data into WebUI using SOL (Serial over LAN) console.

console1 reads data from UNIX domain socket '@obmc-console.hypervisor' and display it in WebUI.

Privilege is set to {"ConfigureComponents", "ConfigureManager"}.

Tested:
  Used webUI to open Hypervisor console. Console window was displayed.
  However, we are not getting the shell because the BMC goes to
  Quiecsed state and the Host does not move to 'Running' state.
  There is still some level of missing support on 1050-ghe, and this
  needs testing once we have all the missing support is enabled.

Signed-off-by: Shantappa Teekappanavar <shantappa.teekappanavar@ibm.com>