### PR TITLE
SW558078 (partial fix): Return bad request if can't construct

### DIFF
--- a/http/http_connection.hpp
+++ b/http/http_connection.hpp
@@ -311,6 +311,8 @@ class Connection :
         if (reqEc)
         {
             BMCWEB_LOG_DEBUG << "Request failed to construct" << reqEc;
+            res.result(boost::beast::http::status::bad_request);
+            completeRequest();
             return;
         }
         thisReq.session = userSession;


### PR DESCRIPTION
Defect is [SW558078 ](https://w3.rchland.ibm.com/projects/bestquest/?defect=SW558078) and needs to go into 1030 as well.
This is only a partial fix  

Upstream is  https://gerrit.openbmc.org/c/openbmc/bmcweb/+/59803/4 and has merged. Will be picked up on the next rebase of 1050 bmcweb. 

If given a bad URI, e.g. "https://$bmc/?a=id;" return http bad request (400) like we do other places, e.g. a few lines below.

Certain scanners expect to see bad request when crawling and probing for vulnerabilities and using not valid URIs. Just dropping the connection causes errors with these scanners. They think connection problem or worse the server was taken down.

Tested: Tested downstream https://$bmc/?a=id; returns bad request

Prashanth Katti
https://ibm-systems-power.slack.com/archives/C04A0JPSKUN/p1668588741353509)
I see significant improvement in results on fix given by
[@gmills](https://ibm-systems-power.slack.com/team/W7L8DV267), earlier I was getting error on 119 links. Now getting only for 6 URI links. Pls find attached detailed reports.


Signed-off-by: Gunnar Mills <gmills@us.ibm.com>