### PR TITLE
bmcweb: Add property value out of range error msg

### DIFF
--- a/redfish-core/lib/bios.hpp
+++ b/redfish-core/lib/bios.hpp
@@ -401,8 +401,12 @@ inline void requestRoutesBiosSettings(App& app)
                 return;
             }
 
-            boost::container::flat_map<std::string,
-                                       std::pair<bool, std::string>>
+            boost::container::flat_map<
+                std::string,
+                std::tuple<
+                    bool, std::string,
+                    boost::container::flat_map<
+                        std::string, std::variant<int64_t, std::string>>>>
                 biosAttrsType;
             const BiosBaseTableType* baseBiosTable =
                 std::get_if<BiosBaseTableType>(&retBiosTable);
@@ -416,17 +420,61 @@ inline void requestRoutesBiosSettings(App& app)
 
             for (const BiosBaseTableItemType& item : *baseBiosTable)
             {
+                const std::vector<OptionsItemType>& optionsVector =
+                    std::get<biosBaseOptions>(item.second);
+
+                boost::container::flat_map<std::string,
+                                           std::variant<int64_t, std::string>>
+                    attrBaseOptions;
+
+                for (const OptionsItemType& optItem : optionsVector)
+                {
+                    const std::string& strOptItemType =
+                        std::get<optItemType>(optItem);
+
+                    const std::string& optItemTypeRedfish =
+                        mapBoundTypeToRedfish(strOptItemType);
+
+                    if (optItemTypeRedfish == "UNKNOWN")
+                    {
+                        BMCWEB_LOG_ERROR << "optItemTypeRedfish == UNKNOWN";
+                        messages::internalError(asyncResp->res);
+                        return;
+                    }
+                    if (optItemTypeRedfish == "OneOf")
+                    {
+                        const std::string* currValue = std::get_if<std::string>(
+                            &std::get<optItemValue>(optItem));
+                        if (currValue != nullptr)
+                        {
+                            attrBaseOptions.try_emplace(optItemTypeRedfish,
+                                                        *currValue);
+                        }
+                    }
+                    else
+                    {
+                        const int64_t* currValue = std::get_if<int64_t>(
+                            &std::get<optItemValue>(optItem));
+                        if (currValue != nullptr)
+                        {
+                            attrBaseOptions.try_emplace(optItemTypeRedfish,
+                                                        *currValue);
+                        }
+                    }
+                }
+
                 biosAttrsType.try_emplace(
                     item.first,
-                    std::make_pair(
+                    std::make_tuple(
                         std::get<biosBaseReadonlyStatus>(item.second),
-                        std::get<biosBaseAttrType>(item.second)));
+                        std::get<biosBaseAttrType>(item.second),
+                        attrBaseOptions));
             }
 
             PendingAttributesType pendingAttributes;
             for (const auto& attrItr : attrsJson.items())
             {
-                std::string attrName = attrItr.key();
+                const std::string& attrName = attrItr.key();
 
                 if (attrName.empty())
                 {
@@ -444,7 +492,8 @@ inline void requestRoutesBiosSettings(App& app)
                     return;
                 }
 
-                bool biosAttrReadOnlyStatus = ((*it).second).first;
+                const bool& biosAttrReadOnlyStatus = std::get<0>((*it).second);
+
                 if (biosAttrReadOnlyStatus)
                 {
                     BMCWEB_LOG_ERROR
@@ -453,7 +502,7 @@ inline void requestRoutesBiosSettings(App& app)
                     return;
                 }
 
-                std::string biosAttrType = ((*it).second).second;
+                const std::string& biosAttrType = std::get<1>((*it).second);
                 if (biosAttrType.empty())
                 {
                     BMCWEB_LOG_ERROR
@@ -462,7 +511,7 @@ inline void requestRoutesBiosSettings(App& app)
                     return;
                 }
 
-                std::string biosRedfishAttrType =
+                const std::string& biosRedfishAttrType =
                     mapAttrTypeToRedfish(biosAttrType);
                 if (biosRedfishAttrType == "Integer")
                 {
@@ -476,12 +525,92 @@ inline void requestRoutesBiosSettings(App& app)
                                                          attrName);
                         return;
                     }
-                    int64_t attrValue = attrItr.value();
+                    const int64_t& attrValue = attrItr.value();
+
+                    boost::container::flat_map<
+                        std::string, std::variant<int64_t, std::string>>
+                        attrBaseOptionsMap = std::get<2>((*it).second);
+
+                    int64_t lowerBoundVal = 0;
+                    int64_t upperBoundVal = 0;
+
+                    // Get Lower Bound value
+                    auto iter = attrBaseOptionsMap.find("LowerBound");
+                    if (iter != attrBaseOptionsMap.end())
+                    {
+                        lowerBoundVal = std::get<int64_t>((*iter).second);
+                    }
+
+                    // Get Upper Bound value
+                    iter = attrBaseOptionsMap.find("UpperBound");
+                    if (iter != attrBaseOptionsMap.end())
+                    {
+                        upperBoundVal = std::get<int64_t>((*iter).second);
+                    }
+
+                    if (attrValue < lowerBoundVal || attrValue > upperBoundVal)
+                    {
+                        BMCWEB_LOG_ERROR << "Attribute value is out of range";
+                        std::string val =
+                            boost::lexical_cast<std::string>(attrItr.value());
+                        messages::propertyValueOutOfRange(asyncResp->res, val,
+                                                          attrName);
+                        return;
+                    }
+
                     pendingAttributes.emplace_back(std::make_pair(
                         attrName, std::make_tuple(biosAttrType, attrValue)));
                 }
-                else if (biosRedfishAttrType == "String" ||
-                         biosRedfishAttrType == "Enumeration" ||
+                else if (biosRedfishAttrType == "String")
+                {
+                    if (attrItr.value().type() !=
+                        nlohmann::json::value_t::string)
+                    {
+                        BMCWEB_LOG_ERROR << "The value must be of type String";
+                        std::string val =
+                            boost::lexical_cast<std::string>(attrItr.value());
+                        messages::propertyValueTypeError(asyncResp->res, val,
+                                                         attrName);
+                        return;
+                    }
+                    boost::container::flat_map<
+                        std::string, std::variant<int64_t, std::string>>
+                        attrBaseOptionsMap = std::get<2>((*it).second);
+
+                    int64_t minStringLength = 0;
+                    int64_t maxStringLength = 0;
+
+                    // Get Minimum String Length
+                    auto iter = attrBaseOptionsMap.find("MinLength");
+                    if (iter != attrBaseOptionsMap.end())
+                    {
+                        minStringLength = std::get<int64_t>((*iter).second);
+                    }
+
+                    // Get Maximum String Length
+                    iter = attrBaseOptionsMap.find("MaxLength");
+                    if (iter != attrBaseOptionsMap.end())
+                    {
+                        maxStringLength = std::get<int64_t>((*iter).second);
+                    }
+                    const std::string& attrValue = attrItr.value();
+                    const int64_t attrValueLength =
+                        static_cast<int64_t>(attrValue.length());
+                    if (attrValueLength < minStringLength ||
+                        attrValueLength > maxStringLength)
+                    {
+                        BMCWEB_LOG_ERROR << "Attribute value length is "
+                                            "incorrect for "
+                                         << attrName;
+                        messages::propertyValueIncorrect(asyncResp->res,
+                                                         attrName, attrValue);
+                        return;
+                    }
+
+                    pendingAttributes.emplace_back(std::make_pair(
+                        attrName, std::make_tuple(biosAttrType, attrValue)));
+                }
+                else if (biosRedfishAttrType == "Enumeration" ||
                          biosRedfishAttrType == "Password")
                 {
                     if (attrItr.value().type() !=


### PR DESCRIPTION
Current implementation displays internal error message when BIOS attribute value is not within the lower and upper bound values. Also, the same internal error message is displayed when the length of the String type value for the attribute to be updated is not within the specified limit.

This commit displays property value out of range error message for Integer type-based attributes in case of an error, and property value incorrect for String type-based attributes.

Testing:
$ curl -k -X PATCH -d '{"Attributes":{"hb_mfg_flags_current": "000000000000000000000000000000000"}}'
 https://user:password@host/redfish/v1/Systems/system/Bios/Settings
{
  "error": {
    "@Message.ExtendedInfo": [
      {
        "@odata.type": "#Message.v1_1_1.Message",
        "Message": "The property 'hb_mfg_flags_current' with the
requested value of '000000000000000000000000000000000' could not be written because the value does not meet the constraints of the implementation.",
        "MessageArgs": [
          "hb_mfg_flags_current",
          "000000000000000000000000000000000"
        ],
        "MessageId": "Base.1.8.1.PropertyValueIncorrect",
        "MessageSeverity": "Warning",
        "Resolution": "No resolution is required."
      }
    ],
    "code": "Base.1.8.1.PropertyValueIncorrect",
    "message": "The property 'hb_mfg_flags_current' with the requested
value of '000000000000000000000000000000000' could not be written because the value does not meet the constraints of the implementation."
  }
}

$ curl -k -X PATCH -d '{"Attributes":{"hb_ioadapter_enlarged_capacity": 200}}'
 https://user:password@host/redfish/v1/Systems/system/Bios/Settings
{
  "hb_ioadapter_enlarged_capacity@Message.ExtendedInfo": [
    {
      "@odata.type": "#Message.v1_1_1.Message",
      "Message": "The value 200 for the property
hb_ioadapter_enlarged_capacity is not in the supported range of acceptable values.",
      "MessageArgs": [
        "200",
        "hb_ioadapter_enlarged_capacity"
      ],
      "MessageId": "Base.1.13.0.PropertyValueOutOfRange",
      "MessageSeverity": "Warning",
      "Resolution": "Correct the value for the property in the request
body and resubmit the request if the operation failed."
    }
  ]
}

Signed-off-by: Shantappa Teekappanavar <sbteeks@yahoo.com>