### PR TITLE
remove Item.Board from Power, Redfihs_util and sensors

### DIFF
--- a/redfish-core/lib/power.hpp
+++ b/redfish-core/lib/power.hpp
@@ -301,8 +301,7 @@ inline void requestRoutesPower(App& app)
             "/xyz/openbmc_project/object_mapper",
             "xyz.openbmc_project.ObjectMapper", "GetSubTreePaths",
             "/xyz/openbmc_project/inventory", 0,
-            std::array<const char*, 2>{
-                "xyz.openbmc_project.Inventory.Item.Board",
+            std::array<const char*, 1>{
                 "xyz.openbmc_project.Inventory.Item.Chassis"});
         });
 

--- a/redfish-core/lib/redfish_util.hpp
+++ b/redfish-core/lib/redfish_util.hpp
@@ -88,8 +88,7 @@ void getMainChassisId(std::shared_ptr<bmcweb::AsyncResp> asyncResp,
         "/xyz/openbmc_project/object_mapper",
         "xyz.openbmc_project.ObjectMapper", "GetSubTree",
         "/xyz/openbmc_project/inventory", 0,
-        std::array<const char*, 2>{
-            "xyz.openbmc_project.Inventory.Item.Board",
+        std::array<const char*, 1>{
             "xyz.openbmc_project.Inventory.Item.Chassis"});
 }
 

--- a/redfish-core/lib/sensors.hpp
+++ b/redfish-core/lib/sensors.hpp
@@ -514,8 +514,7 @@ void getChassis(const std::shared_ptr<bmcweb::AsyncResp>& asyncResp,
                 std::span<std::string_view> sensorTypes, Callback&& callback)
 {
     BMCWEB_LOG_DEBUG << "getChassis enter";
-    const std::array<const char*, 2> interfaces = {
-        "xyz.openbmc_project.Inventory.Item.Board",
+    const std::array<const char*, 1> interfaces = {
         "xyz.openbmc_project.Inventory.Item.Chassis"};
     auto respHandler =
         [callback{std::forward<Callback>(callback)}, asyncResp,


### PR DESCRIPTION
bmcweb failed Project Redfish-Service-Validator

removing Item.Boars from below file will fix error we seen in vaildator
- redfish-core/lib/power.hpp
- redfish-core/lib/redfish_util.hpp
- redfish-core/lib/sensors.hpp