### PR TITLE
Add missing odata.id field under OriginOfCondition for assemblies

### DIFF
--- a/redfish-core/lib/log_services.hpp
+++ b/redfish-core/lib/log_services.hpp
@@ -4814,6 +4814,7 @@ inline void getRedfishUriByDbusObjPath(
                         {
                             auto uriPropPath = "/Links"_json_pointer;
                             uriPropPath /= "OriginOfCondition";
+                            uriPropPath /= "@odata.id";
 
                             assembly::fillWithAssemblyId(
                                 asyncResp, std::get<0>(assemblyParent),


### PR DESCRIPTION
The OriginOfCondition Link should have an odata.id which was missing for assemblies. All other Deconfig records already correctly had this property.

curl -k -H "X-Auth-Token: $bmc_token" -XGET
https://${BMC_IP}/redfish/v1/Systems/system/LogServices/HardwareIsolation/Entries/50 {
  "@odata.id":
"/redfish/v1/Systems/system/LogServices/HardwareIsolation/Entries/50",
  "@odata.type": "#LogEntry.v1_9_0.LogEntry",
  "Created": "2023-01-03T10:38:43+00:00",
  "EntryType": "Event",
  "Id": "50",
  "Links": {
    "OriginOfCondition": "/redfish/v1/Chassis/chassis/Assembly#/Assemblies/49"
<-- missing @odata.id
  },
  "Message": "TPM Card",
  "Name": "Hardware Isolation Entry",
  "Severity": "OK"
}

curl -k -H "X-Auth-Token: $bmc_token" -XGET
https://${BMC_IP}/redfish/v1/Systems/system/LogServices/HardwareIsolation/Entries/50 {
  "@odata.id":
"/redfish/v1/Systems/system/LogServices/HardwareIsolation/Entries/50",
  "@odata.type": "#LogEntry.v1_9_0.LogEntry",
  "Created": "2023-01-03T10:38:43+00:00",
  "EntryType": "Event",
  "Id": "50",
  "Links": {
    "OriginOfCondition": {
      "@odata.id": "/redfish/v1/Chassis/chassis/Assembly#/Assemblies/49" <--
odata.id present
    }
  },
  "Message": "TPM Card",
  "Name": "Hardware Isolation Entry",
  "Severity": "OK"
}

Signed-off-by: deepakala <deepakala.karthikeyan@ibm.com>