### PR TITLE
Move some event traces to DEBUG

### DIFF
--- a/http/http_client.hpp
+++ b/http/http_client.hpp
@@ -368,7 +368,7 @@ class HttpClient : public std::enable_shared_from_this<HttpClient>
                 }
                 else
                 {
-                    BMCWEB_LOG_ERROR << "INFO: Connection closed gracefully..."
+                    BMCWEB_LOG_DEBUG << "INFO: Connection closed gracefully..."
                                      << " Destination: " << self->host << ":"
                                      << self->port;
                 }
@@ -442,7 +442,7 @@ class HttpClient : public std::enable_shared_from_this<HttpClient>
                 return;
             }
 
-            BMCWEB_LOG_ERROR << retryPolicyAction
+            BMCWEB_LOG_DEBUG << retryPolicyAction
                              << " is set. Cleanup the current event and "
                                 "reset retrycount for subId: "
                              << subId;


### PR DESCRIPTION
**This should also go into 1020.** 

Not a separate defect for this, but a minor part of PE00F2N4/PE00F476 (this fix shouldn't be considered fixing those defects though.)

Just in the last month, been pinged 3 or 4 times about excess tracing in the journal around events. That is happening because the HMC is leaving around an event subscription. The HMC should clean this up, but they aren't. The HMC uses RetryForever and 5 seconds retry, so they continue to spam the journal pretty frequently. TerminateAfterRetries or SuspendRetries would also help clean this up but the HMC moving to that has some risk involved. On our side, much of this tracing is excessive.

Move 2 traces that are clearly not errors to debug so they don't appear in the journal:

`Dec 04 02:36:27 xxx bmcweb[794]: (2022-12-04 02:36:27) [ERROR "http_client.hpp":371] INFO: Connection closed gracefully... Destination: 9.3.84.77:17443`

and

`Dec 04 02:36:27 xxx bmcweb[794]: (2022-12-04 02:36:27) [ERROR "http_client.hpp":445] RetryForever is set. Cleanup the current event and reset retrycount for subId: 3144334111`

```
Wed Jan  4 04:30:07 2023 p10bmc bmcweb: (2023-01-04 04:30:07) [ERROR "http_client.hpp":203] sendMessage() failed: asio.ssl error Destination: 192.168.128.1:17443 to subId: 3897282527 Event: 1510071 Wed Jan  4 04:30:12 2023 p10bmc bmcweb: (2023-01-04 04:30:12) [ERROR "http_client.hpp":363] doClose() failed: asio.ssl error Destination: 192.168.128.1:17443
Wed Jan  4 04:30:12 2023 p10bmc bmcweb: (2023-01-04 04:30:12) [ERROR "http_client.hpp":127] Connect 0.0.0.0:0 failed: Network is unreachable Destination: 192.168.128.1:17443
Wed Jan  4 04:30:17 2023 p10bmc bmcweb: (2023-01-04 04:30:17) [ERROR "http_client.hpp":363] doClose() failed: asio.ssl error Destination: 192.168.128.1:17443
Wed Jan  4 04:30:17 2023 p10bmc bmcweb: (2023-01-04 04:30:17) [ERROR "http_client.hpp":127] Connect 0.0.0.0:0 failed: Network is unreachable Destination: 192.168.128.1:17443
Wed Jan  4 04:30:19 2023 p10bmc bmcweb: (2023-01-04 04:30:19) [ERROR "http_client.hpp":444] RetryForever is set. Cleanup the current event and reset retrycount for subId: 3897282527
Wed Jan  4 04:30:19 2023 p10bmc bmcweb: (2023-01-04 04:30:18) [ERROR "http_client.hpp":412] Maximum number of retries reached for Subscriber:3897282527
Wed Jan  4 04:30:19 2023 p10bmc bmcweb: (2023-01-04 04:30:19) [ERROR "http_client.hpp":203] sendMessage() failed: asio.ssl error Destination: 192.168.128.1:17443 to subId: 3897282527 Event: 1510074 Wed Jan  4 04:30:22 2023 p10bmc bmcweb: (2023-01-04 04:30:22) [ERROR "http_client.hpp":363] doClose() failed: asio.ssl error Destination: 192.168.128.1:17443
Wed Jan  4 04:30:22 2023 p10bmc bmcweb: (2023-01-04 04:30:22) [ERROR "http_client.hpp":127] Connect 0.0.0.0:0 failed: Network is unreachable Destination: 192.168.128.1:17443
Wed Jan  4 04:30:27 2023 p10bmc bmcweb: (2023-01-04 04:30:27) [ERROR "http_client.hpp":363] doClose() failed: asio.ssl error Destination: 192.168.128.1:17443
Wed Jan  4 04:30:27 2023 p10bmc bmcweb: (2023-01-04 04:30:27) [ERROR "http_client.hpp":127] Connect 0.0.0.0:0 failed: Network is unreachable Destination: 192.168.128.1:17443
Wed Jan  4 04:30:33 2023 p10bmc bmcweb: (2023-01-04 04:30:32) [ERROR "http_client.hpp":363] doClose() failed: asio.ssl error Destination: 192.168.128.1:17443
Wed Jan  4 04:30:33 2023 p10bmc bmcweb: (2023-01-04 04:30:33) [ERROR "http_client.hpp":127] Connect 0.0.0.0:0 failed: Network is unreachable Destination: 192.168.128.1:17443
Wed Jan  4 04:30:38 2023 p10bmc bmcweb: (2023-01-04 04:30:38) [ERROR "http_client.hpp":363] doClose() failed: asio.ssl error Destination: 192.168.128.1:17443
Wed Jan  4 04:30:38 2023 p10bmc bmcweb: (2023-01-04 04:30:38) [ERROR "http_client.hpp":444] RetryForever is set. Cleanup the current event and reset retrycount for subId: 3897282527
Wed Jan  4 04:30:38 2023 p10bmc bmcweb: (2023-01-04 04:30:38) [ERROR "http_client.hpp":412] Maximum number of retries reached for Subscriber:3897282527
```
is an example trace from Joe.


This doesn't fix the problem, this only cleans up a few traces.

Signed-off-by: Gunnar Mills <gmills@us.ibm.com>