### PR TITLE
1050.power supply

### DIFF
--- a/Redfish.md
+++ b/Redfish.md
@@ -338,6 +338,11 @@ Fields common to all schemas
 
 ##### PowerSupply
 
+- Manufacturer
+- Model
+- PartNumber
+- SerialNumber
+- SparePartNumber
 - Status
 
 ### /redfish/v1/EventService/

--- a/Redfish.md
+++ b/Redfish.md
@@ -339,6 +339,7 @@ Fields common to all schemas
 ##### PowerSupply
 
 - FirmwareVersion
+- Location
 - Manufacturer
 - Model
 - PartNumber

--- a/Redfish.md
+++ b/Redfish.md
@@ -338,6 +338,7 @@ Fields common to all schemas
 
 ##### PowerSupply
 
+- FirmwareVersion
 - Manufacturer
 - Model
 - PartNumber

--- a/Redfish.md
+++ b/Redfish.md
@@ -334,6 +334,10 @@ Fields common to all schemas
 - Members
 - Members@odata.count
 
+#### /redfish/v1/Chassis/{ChassisId}/PowerSubsystem/PowerSupplies/{PowerSupplyId}
+
+##### PowerSupply
+
 ### /redfish/v1/EventService/
 
 #### EventService

--- a/Redfish.md
+++ b/Redfish.md
@@ -326,6 +326,14 @@ Fields common to all schemas
 - MinNumNeeded
 - MaxNumSupported
 
+#### /redfish/v1/Chassis/{ChassisId}/PowerSubsystem/PowerSupplies
+
+##### PowerSupplies
+
+- Description
+- Members
+- Members@odata.count
+
 ### /redfish/v1/EventService/
 
 #### EventService

--- a/Redfish.md
+++ b/Redfish.md
@@ -338,6 +338,8 @@ Fields common to all schemas
 
 ##### PowerSupply
 
+- Status
+
 ### /redfish/v1/EventService/
 
 #### EventService

--- a/Redfish.md
+++ b/Redfish.md
@@ -338,6 +338,7 @@ Fields common to all schemas
 
 ##### PowerSupply
 
+- EfficiencyPercent
 - FirmwareVersion
 - Location
 - Manufacturer

--- a/Redfish.md
+++ b/Redfish.md
@@ -341,6 +341,7 @@ Fields common to all schemas
 - EfficiencyPercent
 - FirmwareVersion
 - Location
+- LocationIndicatorActive
 - Manufacturer
 - Model
 - PartNumber

--- a/include/dbus_utility.hpp
+++ b/include/dbus_utility.hpp
@@ -189,5 +189,20 @@ inline void getAssociationEndPoints(
         });
 }
 
+inline void
+    getDbusObject(const std::string& path, std::span<const char*> interfaces,
+                  std::function<void(const boost::system::error_code&,
+                                     const MapperGetObject&)>&& callback)
+{
+    crow::connections::systemBus->async_method_call(
+        [callback{std::move(callback)}](const boost::system::error_code& ec,
+                                        const MapperGetObject& object) {
+        callback(ec, object);
+        },
+        "xyz.openbmc_project.ObjectMapper",
+        "/xyz/openbmc_project/object_mapper",
+        "xyz.openbmc_project.ObjectMapper", "GetObject", path, interfaces);
+}
+
 } // namespace utility
 } // namespace dbus

--- a/include/dbus_utility.hpp
+++ b/include/dbus_utility.hpp
@@ -18,6 +18,7 @@
 #include "dbus_singleton.hpp"
 
 #include <boost/system/error_code.hpp> // IWYU pragma: keep
+#include <sdbusplus/asio/property.hpp>
 #include <sdbusplus/message/native_types.hpp>
 
 #include <array>
@@ -93,6 +94,7 @@ using MapperGetAncestorsResponse = std::vector<
               std::vector<std::pair<std::string, std::vector<std::string>>>>>;
 
 using MapperGetSubTreePathsResponse = std::vector<std::string>;
+using MapperEndPoints = std::vector<std::string>;
 
 inline void escapePathForDbus(std::string& path)
 {
@@ -171,6 +173,20 @@ inline void getSubTreePaths(
         "/xyz/openbmc_project/object_mapper",
         "xyz.openbmc_project.ObjectMapper", "GetSubTreePaths", path, 0,
         interfaces);
+}
+
+inline void getAssociationEndPoints(
+    const std::string& path,
+    std::function<void(const boost::system::error_code&,
+                       const MapperEndPoints&)>&& callback)
+{
+    sdbusplus::asio::getProperty<MapperEndPoints>(
+        *crow::connections::systemBus, "xyz.openbmc_project.ObjectMapper", path,
+        "xyz.openbmc_project.Association", "endpoints",
+        [callback{std::move(callback)}](const boost::system::error_code& ec,
+                                        const MapperEndPoints& endpoints) {
+        callback(ec, endpoints);
+        });
 }
 
 } // namespace utility

--- a/redfish-core/include/redfish.hpp
+++ b/redfish-core/include/redfish.hpp
@@ -35,6 +35,7 @@
 #include "pcie.hpp"
 #include "power.hpp"
 #include "power_subsystem.hpp"
+#include "power_supply.hpp"
 #include "processor.hpp"
 #include "redfish_sessions.hpp"
 #include "redfish_v1.hpp"
@@ -82,6 +83,7 @@ class RedfishService
 #ifdef BMCWEB_NEW_POWERSUBSYSTEM_THERMALSUBSYSTEM
         requestRoutesEnvironmentMetrics(app);
         requestRoutesPowerSubsystem(app);
+        requestRoutesPowerSupplyCollection(app);
         requestRoutesThermalSubsystem(app);
 #endif
         requestRoutesManagerCollection(app);

--- a/redfish-core/include/redfish.hpp
+++ b/redfish-core/include/redfish.hpp
@@ -83,6 +83,7 @@ class RedfishService
 #ifdef BMCWEB_NEW_POWERSUBSYSTEM_THERMALSUBSYSTEM
         requestRoutesEnvironmentMetrics(app);
         requestRoutesPowerSubsystem(app);
+        requestRoutesPowerSupply(app);
         requestRoutesPowerSupplyCollection(app);
         requestRoutesThermalSubsystem(app);
 #endif

--- a/redfish-core/include/utils/sw_utils.hpp
+++ b/redfish-core/include/utils/sw_utils.hpp
@@ -42,13 +42,11 @@ inline void
                                 const bool populateLinkToImages)
 {
     // Used later to determine running (known on Redfish as active) Sw images
-    sdbusplus::asio::getProperty<std::vector<std::string>>(
-        *crow::connections::systemBus, "xyz.openbmc_project.ObjectMapper",
+    dbus::utility::getAssociationEndPoints(
         "/xyz/openbmc_project/software/functional",
-        "xyz.openbmc_project.Association", "endpoints",
-        [aResp, swVersionPurpose, activeVersionPropName,
-         populateLinkToImages](const boost::system::error_code ec,
-                               const std::vector<std::string>& functionalSw) {
+        [aResp, swVersionPurpose, activeVersionPropName, populateLinkToImages](
+            const boost::system::error_code& ec,
+            const dbus::utility::MapperEndPoints& functionalSw) {
         BMCWEB_LOG_DEBUG << "populateSoftwareInformation enter";
         if (ec)
         {

--- a/redfish-core/include/utils/systems_utils.hpp
+++ b/redfish-core/include/utils/systems_utils.hpp
@@ -1,0 +1,73 @@
+#pragma once
+
+#include "async_resp.hpp"
+
+#include <boost/system/error_code.hpp>
+
+#include <array>
+#include <functional>
+#include <optional>
+#include <string>
+#include <utility>
+
+namespace redfish
+{
+
+namespace systems_utils
+{
+/**
+ * @brief Retrieves valid systems path
+ * @param asyncResp     Pointer to object holding response data
+ * @param systemId      System Id to be verified
+ * @param callback      Callback for next step to get valid systems path
+ */
+void getValidSystemsPath(
+    const std::shared_ptr<bmcweb::AsyncResp>& asyncResp,
+    const std::string& systemId,
+    std::function<void(const std::optional<std::string>&)>&& callback)
+{
+    BMCWEB_LOG_DEBUG << "checkSystemsId enter";
+
+    auto respHandler =
+        [callback{std::move(callback)}, asyncResp, systemId](
+            const boost::system::error_code& ec,
+            const dbus::utility::MapperGetSubTreePathsResponse& systemsPaths) {
+        BMCWEB_LOG_DEBUG << "getValidSystemsPath respHandler enter";
+        if (ec)
+        {
+            BMCWEB_LOG_ERROR << "getValidSystemsPath respHandler DBUS error: "
+                             << ec;
+            messages::internalError(asyncResp->res);
+            return;
+        }
+
+        std::optional<std::string> systemsPath;
+        std::string systemName;
+        for (const std::string& system : systemsPaths)
+        {
+            sdbusplus::message::object_path path(system);
+            systemName = path.filename();
+            if (systemName.empty())
+            {
+                BMCWEB_LOG_ERROR << "Failed to find '/' in " << system;
+                continue;
+            }
+            if (systemName == systemId)
+            {
+                systemsPath = system;
+                break;
+            }
+        }
+        callback(systemsPath);
+    };
+
+    // Get the Systems Collection
+    std::vector<std::string> interfaces = {
+        "xyz.openbmc_project.Inventory.Item.System"};
+    dbus::utility::getSubTreePaths("/xyz/openbmc_project/inventory", interfaces,
+                                   std::move(respHandler));
+    BMCWEB_LOG_DEBUG << "checkSystemsId exit";
+}
+
+} // namespace systems_utils
+} // namespace redfish

--- a/redfish-core/lib/chassis.hpp
+++ b/redfish-core/lib/chassis.hpp
@@ -333,7 +333,7 @@ inline void
                               interface) != interfaces2.end())
                 {
                     getIndicatorLedState(asyncResp);
-                    getLocationIndicatorActive(asyncResp);
+                    getLocationIndicatorActive(asyncResp, path);
                     break;
                 }
             }
@@ -553,7 +553,7 @@ inline void
             {
                 if (indicatorChassis)
                 {
-                    setLocationIndicatorActive(asyncResp,
+                    setLocationIndicatorActive(asyncResp, path,
                                                *locationIndicatorActive);
                 }
                 else

--- a/redfish-core/lib/led.hpp
+++ b/redfish-core/lib/led.hpp
@@ -22,6 +22,8 @@
 #include <app.hpp>
 #include <sdbusplus/asio/property.hpp>
 
+#include <array>
+
 namespace redfish
 {
 /**
@@ -155,60 +157,93 @@ inline void
         dbus::utility::DbusVariantType(ledBlinkng));
 }
 
-/**
- * @brief Retrieves identify led group properties over dbus
- *
- * @param[in] aResp     Shared pointer for generating response message.
- *
- * @return None.
- */
-inline void
-    getLocationIndicatorActive(const std::shared_ptr<bmcweb::AsyncResp>& aResp)
+inline void getLedAsset(const std::shared_ptr<bmcweb::AsyncResp>& aResp,
+                        const std::string& ledGroup)
 {
-    BMCWEB_LOG_DEBUG << "Get LocationIndicatorActive";
-    sdbusplus::asio::getProperty<bool>(
-        *crow::connections::systemBus, "xyz.openbmc_project.LED.GroupManager",
-        "/xyz/openbmc_project/led/groups/enclosure_identify_blink",
-        "xyz.openbmc_project.Led.Group", "Asserted",
-        [aResp](const boost::system::error_code ec, const bool blinking) {
-        // Some systems may not have enclosure_identify_blink object so
-        // proceed to get enclosure_identify state.
-        if (ec == boost::system::errc::invalid_argument)
+    std::array<const char*, 1> interfaces = {"xyz.openbmc_project.Led.Group"};
+    dbus::utility::getDbusObject(
+        ledGroup, interfaces,
+        [aResp, ledGroup](const boost::system::error_code& ec,
+                          const dbus::utility::MapperGetObject& object) {
+        if (ec || object.size() != 1)
         {
-            BMCWEB_LOG_DEBUG
-                << "Get identity blinking LED failed, missmatch in property type";
+            BMCWEB_LOG_ERROR << "DBUS response error " << ec.message();
             messages::internalError(aResp->res);
             return;
         }
 
-        // Blinking ON, no need to check enclosure_identify assert.
-        if (!ec && blinking)
-        {
-            aResp->res.jsonValue["LocationIndicatorActive"] = true;
-            return;
-        }
-
         sdbusplus::asio::getProperty<bool>(
-            *crow::connections::systemBus,
-            "xyz.openbmc_project.LED.GroupManager",
-            "/xyz/openbmc_project/led/groups/enclosure_identify",
+            *crow::connections::systemBus, object.begin()->first, ledGroup,
             "xyz.openbmc_project.Led.Group", "Asserted",
-            [aResp](const boost::system::error_code ec2, const bool ledOn) {
-            if (ec2 == boost::system::errc::invalid_argument)
+            [aResp](const boost::system::error_code& ec1, bool assert) {
+            if (ec1)
             {
-                BMCWEB_LOG_DEBUG
-                    << "Get enclosure identity led failed, missmatch in property type";
                 messages::internalError(aResp->res);
                 return;
             }
 
-            if (ec2)
+            aResp->res.jsonValue["LocationIndicatorActive"] = assert;
+            });
+        });
+}
+
+inline void setLedAsset(const std::shared_ptr<bmcweb::AsyncResp>& aResp,
+                        const std::string& ledGroup, bool ledState)
+{
+    std::array<const char*, 1> interfaces = {"xyz.openbmc_project.Led.Group"};
+    dbus::utility::getDbusObject(
+        ledGroup, interfaces,
+        [aResp, ledGroup,
+         ledState](const boost::system::error_code& ec,
+                   const dbus::utility::MapperGetObject& object) {
+        if (ec || object.size() != 1)
+        {
+            BMCWEB_LOG_ERROR << "DBUS response error " << ec.message();
+            messages::internalError(aResp->res);
+            return;
+        }
+
+        sdbusplus::asio::setProperty(
+            *crow::connections::systemBus, object.begin()->first, ledGroup,
+            "xyz.openbmc_project.Led.Group", "Asserted", ledState,
+            [aResp](const boost::system::error_code& ec1) {
+            if (ec1)
             {
+                messages::internalError(aResp->res);
                 return;
             }
-
-            aResp->res.jsonValue["LocationIndicatorActive"] = ledOn;
             });
+        });
+}
+
+/**
+ * @brief Retrieves identify led group properties over dbus
+ *
+ * @param[in] aResp     Shared pointer for generating response message.
+ * @param[in] objPath   Object path on PIM
+ *
+ * @return None.
+ */
+inline void
+    getLocationIndicatorActive(const std::shared_ptr<bmcweb::AsyncResp>& aResp,
+                               const std::string& objPath)
+{
+    BMCWEB_LOG_DEBUG << "Get LocationIndicatorActive";
+
+    dbus::utility::getAssociationEndPoints(
+        objPath + "/identifying",
+        [aResp](const boost::system::error_code& ec,
+                const dbus::utility::MapperEndPoints& endpoints) {
+        if (ec.value() != EBADR)
+        {
+            messages::internalError(aResp->res);
+            return;
+        }
+
+        for (const auto& endpoint : endpoints)
+        {
+            getLedAsset(aResp, endpoint);
+        }
         });
 }
 
@@ -216,43 +251,31 @@ inline void
  * @brief Sets identify led group properties
  *
  * @param[in] aResp     Shared pointer for generating response message.
+ * @param[in] objPath   Object path on PIM
  * @param[in] ledState  LED state passed from request
  *
  * @return None.
  */
 inline void
     setLocationIndicatorActive(const std::shared_ptr<bmcweb::AsyncResp>& aResp,
-                               const bool ledState)
+                               const std::string& objPath, bool ledState)
 {
     BMCWEB_LOG_DEBUG << "Set LocationIndicatorActive";
 
-    crow::connections::systemBus->async_method_call(
-        [aResp, ledState](const boost::system::error_code ec) mutable {
-        if (ec)
+    dbus::utility::getAssociationEndPoints(
+        objPath + "/identifying",
+        [aResp, ledState](const boost::system::error_code& ec,
+                          const dbus::utility::MapperEndPoints& endpoints) {
+        if (ec.value() != EBADR)
         {
-            // Some systems may not have enclosure_identify_blink object so
-            // lets set enclosure_identify state also if
-            // enclosure_identify_blink failed
-            crow::connections::systemBus->async_method_call(
-                [aResp](const boost::system::error_code ec2) {
-                if (ec2)
-                {
-                    BMCWEB_LOG_DEBUG << "DBUS response error " << ec2;
-                    messages::internalError(aResp->res);
-                    return;
-                }
-                },
-                "xyz.openbmc_project.LED.GroupManager",
-                "/xyz/openbmc_project/led/groups/enclosure_identify",
-                "org.freedesktop.DBus.Properties", "Set",
-                "xyz.openbmc_project.Led.Group", "Asserted",
-                dbus::utility::DbusVariantType(ledState));
+            messages::internalError(aResp->res);
+            return;
         }
-        },
-        "xyz.openbmc_project.LED.GroupManager",
-        "/xyz/openbmc_project/led/groups/enclosure_identify_blink",
-        "org.freedesktop.DBus.Properties", "Set",
-        "xyz.openbmc_project.Led.Group", "Asserted",
-        dbus::utility::DbusVariantType(ledState));
+
+        for (const auto& endpoint : endpoints)
+        {
+            setLedAsset(aResp, endpoint, ledState);
+        }
+        });
 }
 } // namespace redfish

--- a/redfish-core/lib/power_subsystem.hpp
+++ b/redfish-core/lib/power_subsystem.hpp
@@ -35,6 +35,9 @@ inline void doPowerSubsystemCollection(
         "redfish", "v1", "Chassis", chassisId, "PowerSubsystem");
     asyncResp->res.jsonValue["Status"]["State"] = "Enabled";
     asyncResp->res.jsonValue["Status"]["Health"] = "OK";
+    asyncResp->res.jsonValue["PowerSupplies"]["@odata.id"] =
+        crow::utility::urlFromPieces("redfish", "v1", "Chassis", chassisId,
+                                     "PowerSubsystem", "PowerSupplies");
 }
 
 inline void handlePowerSubsystemCollectionHead(

--- a/redfish-core/lib/power_supply.hpp
+++ b/redfish-core/lib/power_supply.hpp
@@ -229,6 +229,69 @@ inline void
 }
 
 inline void
+    getPowerSupplyAsset(const std::shared_ptr<bmcweb::AsyncResp>& asyncResp,
+                        const std::string& service, const std::string& path)
+{
+    sdbusplus::asio::getAllProperties(
+        *crow::connections::systemBus, service, path,
+        "xyz.openbmc_project.Inventory.Decorator.Asset",
+        [asyncResp](const boost::system::error_code ec,
+                    const dbus::utility::DBusPropertiesMap& propertiesList) {
+        if (ec)
+        {
+            if (ec.value() != EBADR)
+            {
+                messages::internalError(asyncResp->res);
+            }
+            return;
+        }
+
+        const std::string* partNumber = nullptr;
+        const std::string* serialNumber = nullptr;
+        const std::string* manufacturer = nullptr;
+        const std::string* model = nullptr;
+        const std::string* sparePartNumber = nullptr;
+
+        const bool success = sdbusplus::unpackPropertiesNoThrow(
+            dbus_utils::UnpackErrorPrinter(), propertiesList, "PartNumber",
+            partNumber, "SerialNumber", serialNumber, "Manufacturer",
+            manufacturer, "Model", model, "SparePartNumber", sparePartNumber);
+
+        if (!success)
+        {
+            messages::internalError(asyncResp->res);
+            return;
+        }
+
+        if (partNumber != nullptr)
+        {
+            asyncResp->res.jsonValue["PartNumber"] = *partNumber;
+        }
+
+        if (serialNumber != nullptr)
+        {
+            asyncResp->res.jsonValue["SerialNumber"] = *serialNumber;
+        }
+
+        if (manufacturer != nullptr)
+        {
+            asyncResp->res.jsonValue["Manufacturer"] = *manufacturer;
+        }
+
+        if (model != nullptr)
+        {
+            asyncResp->res.jsonValue["Model"] = *model;
+        }
+
+        // SparePartNumber is optional on D-Bus so skip if it is empty
+        if (sparePartNumber != nullptr && !sparePartNumber->empty())
+        {
+            asyncResp->res.jsonValue["SparePartNumber"] = *sparePartNumber;
+        }
+        });
+}
+
+inline void
     doPowerSupplyGet(const std::shared_ptr<bmcweb::AsyncResp>& asyncResp,
                      const std::string& chassisId,
                      const std::string& powerSupplyId,
@@ -273,6 +336,8 @@ inline void
                                 powerSupplyPath);
             getPowerSupplyHealth(asyncResp, object.begin()->first,
                                  powerSupplyPath);
+            getPowerSupplyAsset(asyncResp, object.begin()->first,
+                                powerSupplyPath);
             });
     });
 }

--- a/redfish-core/lib/power_supply.hpp
+++ b/redfish-core/lib/power_supply.hpp
@@ -291,6 +291,27 @@ inline void
         });
 }
 
+inline void getPowerSupplyFirmwareVersion(
+    const std::shared_ptr<bmcweb::AsyncResp>& asyncResp,
+    const std::string& service, const std::string& path)
+{
+    sdbusplus::asio::getProperty<std::string>(
+        *crow::connections::systemBus, service, path,
+        "xyz.openbmc_project.Software.Version", "Version",
+        [asyncResp](const boost::system::error_code ec,
+                    const std::string& value) {
+        if (ec)
+        {
+            if (ec.value() != EBADR)
+            {
+                messages::internalError(asyncResp->res);
+            }
+            return;
+        }
+        asyncResp->res.jsonValue["FirmwareVersion"] = value;
+        });
+}
+
 inline void
     doPowerSupplyGet(const std::shared_ptr<bmcweb::AsyncResp>& asyncResp,
                      const std::string& chassisId,
@@ -338,6 +359,8 @@ inline void
                                  powerSupplyPath);
             getPowerSupplyAsset(asyncResp, object.begin()->first,
                                 powerSupplyPath);
+            getPowerSupplyFirmwareVersion(asyncResp, object.begin()->first,
+                                          powerSupplyPath);
             });
     });
 }

--- a/redfish-core/lib/power_supply.hpp
+++ b/redfish-core/lib/power_supply.hpp
@@ -313,6 +313,28 @@ inline void getPowerSupplyFirmwareVersion(
 }
 
 inline void
+    getPowerSupplyLocation(const std::shared_ptr<bmcweb::AsyncResp>& asyncResp,
+                           const std::string& service, const std::string& path)
+{
+    sdbusplus::asio::getProperty<std::string>(
+        *crow::connections::systemBus, service, path,
+        "xyz.openbmc_project.Inventory.Decorator.LocationCode", "LocationCode",
+        [asyncResp](const boost::system::error_code ec,
+                    const std::string& value) {
+        if (ec)
+        {
+            if (ec.value() != EBADR)
+            {
+                messages::internalError(asyncResp->res);
+            }
+            return;
+        }
+        asyncResp->res.jsonValue["Location"]["PartLocation"]["ServiceLabel"] =
+            value;
+        });
+}
+
+inline void
     doPowerSupplyGet(const std::shared_ptr<bmcweb::AsyncResp>& asyncResp,
                      const std::string& chassisId,
                      const std::string& powerSupplyId,
@@ -361,6 +383,8 @@ inline void
                                 powerSupplyPath);
             getPowerSupplyFirmwareVersion(asyncResp, object.begin()->first,
                                           powerSupplyPath);
+            getPowerSupplyLocation(asyncResp, object.begin()->first,
+                                   powerSupplyPath);
             });
     });
 }

--- a/redfish-core/lib/power_supply.hpp
+++ b/redfish-core/lib/power_supply.hpp
@@ -1,0 +1,121 @@
+#pragma once
+
+#include "app.hpp"
+#include "dbus_utility.hpp"
+#include "query.hpp"
+#include "registries/privilege_registry.hpp"
+#include "utils/chassis_utils.hpp"
+
+#include <memory>
+#include <optional>
+#include <string>
+
+namespace redfish
+{
+
+inline void updatePowerSupplyList(
+    const std::shared_ptr<bmcweb::AsyncResp>& /* asyncResp */,
+    const std::string& /* chassisId */,
+    const std::string& /* powerSupplyPath */)
+{
+    // TODO In order for the validator to pass, the Members property will be
+    // implemented on the next commit
+}
+
+inline void
+    doPowerSupplyCollection(const std::shared_ptr<bmcweb::AsyncResp>& asyncResp,
+                            const std::string& chassisId,
+                            const std::optional<std::string>& validChassisPath)
+{
+    if (!validChassisPath)
+    {
+        messages::resourceNotFound(asyncResp->res, "Chassis", chassisId);
+        return;
+    }
+
+    asyncResp->res.addHeader(
+        boost::beast::http::field::link,
+        "</redfish/v1/JsonSchemas/PowerSupplyCollection/PowerSupplyCollection.json>; rel=describedby");
+    asyncResp->res.jsonValue["@odata.type"] =
+        "#PowerSupplyCollection.PowerSupplyCollection";
+    asyncResp->res.jsonValue["Name"] = "Power Supply Collection";
+    asyncResp->res.jsonValue["@odata.id"] =
+        crow::utility::urlFromPieces("redfish", "v1", "Chassis", chassisId,
+                                     "PowerSubsystem", "PowerSupplies");
+    asyncResp->res.jsonValue["Description"] =
+        "The collection of PowerSupply resource instances.";
+    asyncResp->res.jsonValue["Members"] = nlohmann::json::array();
+    asyncResp->res.jsonValue["Members@odata.count"] = 0;
+
+    std::string powerPath = *validChassisPath + "/powered_by";
+    dbus::utility::getAssociationEndPoints(
+        powerPath, [asyncResp, chassisId](
+                       const boost::system::error_code& ec,
+                       const dbus::utility::MapperEndPoints& endpoints) {
+            if (ec.value() != EBADR)
+            {
+                messages::internalError(asyncResp->res);
+                return;
+            }
+
+            for (const auto& endpoint : endpoints)
+            {
+                updatePowerSupplyList(asyncResp, chassisId, endpoint);
+            }
+        });
+}
+
+inline void handlePowerSupplyCollectionHead(
+    App& app, const crow::Request& req,
+    const std::shared_ptr<bmcweb::AsyncResp>& asyncResp,
+    const std::string& chassisId)
+{
+    if (!redfish::setUpRedfishRoute(app, req, asyncResp))
+    {
+        return;
+    }
+
+    redfish::chassis_utils::getValidChassisPath(
+        asyncResp, chassisId,
+        [asyncResp,
+         chassisId](const std::optional<std::string>& validChassisPath) {
+        if (!validChassisPath)
+        {
+            messages::resourceNotFound(asyncResp->res, "Chassis", chassisId);
+            return;
+        }
+        asyncResp->res.addHeader(
+            boost::beast::http::field::link,
+            "</redfish/v1/JsonSchemas/PowerSupplyCollection/PowerSupplyCollection.json>; rel=describedby");
+        });
+}
+
+inline void handlePowerSupplyCollectionGet(
+    App& app, const crow::Request& req,
+    const std::shared_ptr<bmcweb::AsyncResp>& asyncResp,
+    const std::string& chassisId)
+{
+    if (!redfish::setUpRedfishRoute(app, req, asyncResp))
+    {
+        return;
+    }
+
+    redfish::chassis_utils::getValidChassisPath(
+        asyncResp, chassisId,
+        std::bind_front(doPowerSupplyCollection, asyncResp, chassisId));
+}
+
+inline void requestRoutesPowerSupplyCollection(App& app)
+{
+    BMCWEB_ROUTE(app, "/redfish/v1/Chassis/<str>/PowerSubsystem/PowerSupplies/")
+        .privileges(redfish::privileges::headPowerSupplyCollection)
+        .methods(boost::beast::http::verb::head)(
+            std::bind_front(handlePowerSupplyCollectionHead, std::ref(app)));
+
+    BMCWEB_ROUTE(app, "/redfish/v1/Chassis/<str>/PowerSubsystem/PowerSupplies/")
+        .privileges(redfish::privileges::getPowerSupplyCollection)
+        .methods(boost::beast::http::verb::get)(
+            std::bind_front(handlePowerSupplyCollectionGet, std::ref(app)));
+}
+
+} // namespace redfish

--- a/redfish-core/lib/power_supply.hpp
+++ b/redfish-core/lib/power_supply.hpp
@@ -13,13 +13,26 @@
 namespace redfish
 {
 
-inline void updatePowerSupplyList(
-    const std::shared_ptr<bmcweb::AsyncResp>& /* asyncResp */,
-    const std::string& /* chassisId */,
-    const std::string& /* powerSupplyPath */)
+inline void
+    updatePowerSupplyList(const std::shared_ptr<bmcweb::AsyncResp>& asyncResp,
+                          const std::string& chassisId,
+                          const std::string& powerSupplyPath)
 {
-    // TODO In order for the validator to pass, the Members property will be
-    // implemented on the next commit
+    std::string powerSupplyName =
+        sdbusplus::message::object_path(powerSupplyPath).filename();
+    if (powerSupplyName.empty())
+    {
+        return;
+    }
+
+    nlohmann::json item = nlohmann::json::object();
+    item["@odata.id"] = crow::utility::urlFromPieces(
+        "redfish", "v1", "Chassis", chassisId, "PowerSubsystem",
+        "PowerSupplies", powerSupplyName);
+
+    nlohmann::json& powerSupplyList = asyncResp->res.jsonValue["Members"];
+    powerSupplyList.emplace_back(std::move(item));
+    asyncResp->res.jsonValue["Members@odata.count"] = powerSupplyList.size();
 }
 
 inline void
@@ -52,9 +65,12 @@ inline void
         powerPath, [asyncResp, chassisId](
                        const boost::system::error_code& ec,
                        const dbus::utility::MapperEndPoints& endpoints) {
-            if (ec.value() != EBADR)
+            if (ec)
             {
-                messages::internalError(asyncResp->res);
+                if (ec.value() != EBADR)
+                {
+                    messages::internalError(asyncResp->res);
+                }
                 return;
             }
 
@@ -116,6 +132,144 @@ inline void requestRoutesPowerSupplyCollection(App& app)
         .privileges(redfish::privileges::getPowerSupplyCollection)
         .methods(boost::beast::http::verb::get)(
             std::bind_front(handlePowerSupplyCollectionGet, std::ref(app)));
+}
+
+inline bool checkPowerSupplyId(const std::string& powerSupplyPath,
+                               const std::string& powerSupplyId)
+{
+    std::string powerSupplyName =
+        sdbusplus::message::object_path(powerSupplyPath).filename();
+
+    return !(powerSupplyName.empty() || powerSupplyName != powerSupplyId);
+}
+
+inline void
+    getValidPowerSupplyPath(const std::shared_ptr<bmcweb::AsyncResp>& asyncResp,
+                            const std::string& validChassisPath,
+                            const std::string& powerSupplyId,
+                            std::function<void()>&& callback)
+{
+
+    std::string powerPath = validChassisPath + "/powered_by";
+    dbus::utility::getAssociationEndPoints(
+        powerPath, [asyncResp, powerSupplyId, callback{std::move(callback)}](
+                       const boost::system::error_code& ec,
+                       const dbus::utility::MapperEndPoints& endpoints) {
+            if (ec)
+            {
+                if (ec.value() != EBADR)
+                {
+                    messages::internalError(asyncResp->res);
+                }
+                return;
+            }
+
+            for (const auto& endpoint : endpoints)
+            {
+                if (checkPowerSupplyId(endpoint, powerSupplyId))
+                {
+                    callback();
+                    return;
+                }
+            }
+
+            if (!endpoints.empty())
+            {
+                messages::resourceNotFound(asyncResp->res, "PowerSupplies",
+                                           powerSupplyId);
+                return;
+            }
+        });
+}
+
+inline void
+    doPowerSupplyGet(const std::shared_ptr<bmcweb::AsyncResp>& asyncResp,
+                     const std::string& chassisId,
+                     const std::string& powerSupplyId,
+                     const std::optional<std::string>& validChassisPath)
+{
+    if (!validChassisPath)
+    {
+        messages::resourceNotFound(asyncResp->res, "Chassis", chassisId);
+        return;
+    }
+
+    // Get the correct Path and Service that match the input parameters
+    getValidPowerSupplyPath(asyncResp, *validChassisPath, powerSupplyId,
+                            [asyncResp, chassisId, powerSupplyId]() {
+        asyncResp->res.addHeader(
+            boost::beast::http::field::link,
+            "</redfish/v1/JsonSchemas/PowerSupply/PowerSupply.json>; rel=describedby");
+        asyncResp->res.jsonValue["@odata.type"] =
+            "#PowerSupply.v1_5_0.PowerSupply";
+        asyncResp->res.jsonValue["Name"] = powerSupplyId;
+        asyncResp->res.jsonValue["Id"] = powerSupplyId;
+        asyncResp->res.jsonValue["@odata.id"] = crow::utility::urlFromPieces(
+            "redfish", "v1", "Chassis", chassisId, "PowerSubsystem",
+            "PowerSupplies", powerSupplyId);
+    });
+}
+
+inline void
+    handlePowerSupplyHead(App& app, const crow::Request& req,
+                          const std::shared_ptr<bmcweb::AsyncResp>& asyncResp,
+                          const std::string& chassisId,
+                          const std::string& powerSupplyId)
+{
+    if (!redfish::setUpRedfishRoute(app, req, asyncResp))
+    {
+        return;
+    }
+
+    redfish::chassis_utils::getValidChassisPath(
+        asyncResp, chassisId,
+        [asyncResp, chassisId,
+         powerSupplyId](const std::optional<std::string>& validChassisPath) {
+        if (!validChassisPath)
+        {
+            messages::resourceNotFound(asyncResp->res, "Chassis", chassisId);
+            return;
+        }
+
+        // Get the correct Path and Service that match the input parameters
+        getValidPowerSupplyPath(asyncResp, *validChassisPath, powerSupplyId,
+                                [asyncResp]() {
+            asyncResp->res.addHeader(
+                boost::beast::http::field::link,
+                "</redfish/v1/JsonSchemas/PowerSupply/PowerSupply.json>; rel=describedby");
+        });
+        });
+}
+
+inline void
+    handlePowerSupplyGet(App& app, const crow::Request& req,
+                         const std::shared_ptr<bmcweb::AsyncResp>& asyncResp,
+                         const std::string& chassisId,
+                         const std::string& powerSupplyId)
+{
+    if (!redfish::setUpRedfishRoute(app, req, asyncResp))
+    {
+        return;
+    }
+
+    redfish::chassis_utils::getValidChassisPath(
+        asyncResp, chassisId,
+        std::bind_front(doPowerSupplyGet, asyncResp, chassisId, powerSupplyId));
+}
+
+inline void requestRoutesPowerSupply(App& app)
+{
+    BMCWEB_ROUTE(
+        app, "/redfish/v1/Chassis/<str>/PowerSubsystem/PowerSupplies/<str>/")
+        .privileges(redfish::privileges::headPowerSupply)
+        .methods(boost::beast::http::verb::head)(
+            std::bind_front(handlePowerSupplyHead, std::ref(app)));
+
+    BMCWEB_ROUTE(
+        app, "/redfish/v1/Chassis/<str>/PowerSubsystem/PowerSupplies/<str>/")
+        .privileges(redfish::privileges::getPowerSupply)
+        .methods(boost::beast::http::verb::get)(
+            std::bind_front(handlePowerSupplyGet, std::ref(app)));
 }
 
 } // namespace redfish

--- a/redfish-core/lib/power_supply.hpp
+++ b/redfish-core/lib/power_supply.hpp
@@ -143,13 +143,11 @@ inline bool checkPowerSupplyId(const std::string& powerSupplyPath,
     return !(powerSupplyName.empty() || powerSupplyName != powerSupplyId);
 }
 
-inline void
-    getValidPowerSupplyPath(const std::shared_ptr<bmcweb::AsyncResp>& asyncResp,
-                            const std::string& validChassisPath,
-                            const std::string& powerSupplyId,
-                            std::function<void()>&& callback)
+inline void getValidPowerSupplyPath(
+    const std::shared_ptr<bmcweb::AsyncResp>& asyncResp,
+    const std::string& validChassisPath, const std::string& powerSupplyId,
+    std::function<void(const std::string& powerSupplyPath)>&& callback)
 {
-
     std::string powerPath = validChassisPath + "/powered_by";
     dbus::utility::getAssociationEndPoints(
         powerPath, [asyncResp, powerSupplyId, callback{std::move(callback)}](
@@ -168,7 +166,7 @@ inline void
             {
                 if (checkPowerSupplyId(endpoint, powerSupplyId))
                 {
-                    callback();
+                    callback(endpoint);
                     return;
                 }
             }
@@ -179,6 +177,54 @@ inline void
                                            powerSupplyId);
                 return;
             }
+        });
+}
+
+inline void
+    getPowerSupplyState(const std::shared_ptr<bmcweb::AsyncResp>& asyncResp,
+                        const std::string& service, const std::string& path)
+{
+    sdbusplus::asio::getProperty<bool>(
+        *crow::connections::systemBus, service, path,
+        "xyz.openbmc_project.Inventory.Item", "Present",
+        [asyncResp](const boost::system::error_code ec, const bool value) {
+        if (ec)
+        {
+            if (ec.value() != EBADR)
+            {
+                messages::internalError(asyncResp->res);
+            }
+            return;
+        }
+
+        if (!value)
+        {
+            asyncResp->res.jsonValue["Status"]["State"] = "Absent";
+        }
+        });
+}
+
+inline void
+    getPowerSupplyHealth(const std::shared_ptr<bmcweb::AsyncResp>& asyncResp,
+                         const std::string& service, const std::string& path)
+{
+    sdbusplus::asio::getProperty<bool>(
+        *crow::connections::systemBus, service, path,
+        "xyz.openbmc_project.State.Decorator.OperationalStatus", "Functional",
+        [asyncResp](const boost::system::error_code ec, const bool value) {
+        if (ec)
+        {
+            if (ec.value() != EBADR)
+            {
+                messages::internalError(asyncResp->res);
+            }
+            return;
+        }
+
+        if (!value)
+        {
+            asyncResp->res.jsonValue["Status"]["Health"] = "Critical";
+        }
         });
 }
 
@@ -196,7 +242,8 @@ inline void
 
     // Get the correct Path and Service that match the input parameters
     getValidPowerSupplyPath(asyncResp, *validChassisPath, powerSupplyId,
-                            [asyncResp, chassisId, powerSupplyId]() {
+                            [asyncResp, chassisId, powerSupplyId](
+                                const std::string& powerSupplyPath) {
         asyncResp->res.addHeader(
             boost::beast::http::field::link,
             "</redfish/v1/JsonSchemas/PowerSupply/PowerSupply.json>; rel=describedby");
@@ -207,6 +254,26 @@ inline void
         asyncResp->res.jsonValue["@odata.id"] = crow::utility::urlFromPieces(
             "redfish", "v1", "Chassis", chassisId, "PowerSubsystem",
             "PowerSupplies", powerSupplyId);
+
+        asyncResp->res.jsonValue["Status"]["State"] = "Enabled";
+        asyncResp->res.jsonValue["Status"]["Health"] = "OK";
+
+        dbus::utility::getDbusObject(
+            powerSupplyPath, {},
+            [asyncResp,
+             powerSupplyPath](const boost::system::error_code& ec,
+                              const dbus::utility::MapperGetObject& object) {
+            if (ec || object.size() == 0)
+            {
+                messages::internalError(asyncResp->res);
+                return;
+            }
+
+            getPowerSupplyState(asyncResp, object.begin()->first,
+                                powerSupplyPath);
+            getPowerSupplyHealth(asyncResp, object.begin()->first,
+                                 powerSupplyPath);
+            });
     });
 }
 
@@ -233,7 +300,7 @@ inline void
 
         // Get the correct Path and Service that match the input parameters
         getValidPowerSupplyPath(asyncResp, *validChassisPath, powerSupplyId,
-                                [asyncResp]() {
+                                [asyncResp](const std::string&) {
             asyncResp->res.addHeader(
                 boost::beast::http::field::link,
                 "</redfish/v1/JsonSchemas/PowerSupply/PowerSupply.json>; rel=describedby");

--- a/redfish-core/lib/power_supply.hpp
+++ b/redfish-core/lib/power_supply.hpp
@@ -335,6 +335,58 @@ inline void
 }
 
 inline void
+    getEfficiencyPercent(const std::shared_ptr<bmcweb::AsyncResp>& asyncResp)
+{
+    static const std::string efficiencyIntf =
+        "xyz.openbmc_project.Control.PowerSupplyAttributes";
+    // Gets the Power Supply Attributes such as EfficiencyPercent.
+    // Currently we only support one power supply EfficiencyPercent, use this
+    // for all the power supplies.
+    crow::connections::systemBus->async_method_call(
+        [asyncResp](const boost::system::error_code ec,
+                    const dbus::utility::MapperGetSubTreeResponse& subtree) {
+        if (ec)
+        {
+            if (ec.value() == EBADR)
+            {
+                return;
+            }
+            BMCWEB_LOG_ERROR << "respHandler DBus error " << ec.message();
+            messages::internalError(asyncResp->res);
+            return;
+        }
+
+        for (const auto& [path, serviceMap] : subtree)
+        {
+            for (const auto& [service, interfaces] : serviceMap)
+            {
+                sdbusplus::asio::getProperty<uint32_t>(
+                    *crow::connections::systemBus, service, path,
+                    efficiencyIntf, "DeratingFactor",
+                    [asyncResp](const boost::system::error_code ec1,
+                                const uint32_t value) {
+                    if (ec1 || value == 0)
+                    {
+                        return;
+                    }
+
+                    nlohmann::json item;
+                    item["EfficiencyPercent"] = value;
+                    nlohmann::json& efficiencyList =
+                        asyncResp->res.jsonValue["EfficiencyRatings"];
+                    efficiencyList.emplace_back(std::move(item));
+                    });
+            }
+        }
+        },
+        "xyz.openbmc_project.ObjectMapper",
+        "/xyz/openbmc_project/object_mapper",
+        "xyz.openbmc_project.ObjectMapper", "GetSubTree",
+        "/xyz/openbmc_project", 0,
+        std::array<const char*, 1>{efficiencyIntf.c_str()});
+}
+
+inline void
     doPowerSupplyGet(const std::shared_ptr<bmcweb::AsyncResp>& asyncResp,
                      const std::string& chassisId,
                      const std::string& powerSupplyId,
@@ -386,6 +438,8 @@ inline void
             getPowerSupplyLocation(asyncResp, object.begin()->first,
                                    powerSupplyPath);
             });
+
+        getEfficiencyPercent(asyncResp);
     });
 }
 

--- a/redfish-core/lib/power_supply.hpp
+++ b/redfish-core/lib/power_supply.hpp
@@ -2,6 +2,7 @@
 
 #include "app.hpp"
 #include "dbus_utility.hpp"
+#include "led.hpp"
 #include "query.hpp"
 #include "registries/privilege_registry.hpp"
 #include "utils/chassis_utils.hpp"
@@ -440,6 +441,7 @@ inline void
             });
 
         getEfficiencyPercent(asyncResp);
+        getLocationIndicatorActive(asyncResp, powerSupplyPath);
     });
 }
 
@@ -490,6 +492,54 @@ inline void
         std::bind_front(doPowerSupplyGet, asyncResp, chassisId, powerSupplyId));
 }
 
+inline void
+    doPatchPowerSupply(const std::shared_ptr<bmcweb::AsyncResp>& asyncResp,
+                       const std::optional<bool> locationIndicatorActive,
+                       const std::string& powerSupplyPath)
+{
+    if (locationIndicatorActive)
+    {
+        setLocationIndicatorActive(asyncResp, powerSupplyPath,
+                                   *locationIndicatorActive);
+    }
+}
+
+inline void
+    handlePowerSupplyPatch(App& app, const crow::Request& req,
+                           const std::shared_ptr<bmcweb::AsyncResp>& asyncResp,
+                           const std::string& chassisId,
+                           const std::string& powerSupplyId)
+{
+    if (!redfish::setUpRedfishRoute(app, req, asyncResp))
+    {
+        return;
+    }
+
+    std::optional<bool> locationIndicatorActive;
+    if (!json_util::readJsonPatch(req, asyncResp->res,
+                                  "LocationIndicatorActive",
+                                  locationIndicatorActive))
+    {
+        return;
+    }
+
+    redfish::chassis_utils::getValidChassisPath(
+        asyncResp, chassisId,
+        [asyncResp, chassisId, powerSupplyId, locationIndicatorActive](
+            const std::optional<std::string>& validChassisPath) {
+        if (!validChassisPath)
+        {
+            messages::resourceNotFound(asyncResp->res, "Chassis", chassisId);
+            return;
+        }
+
+        // Get the correct power supply Path that match the input parameters
+        getValidPowerSupplyPath(asyncResp, *validChassisPath, powerSupplyId,
+                                std::bind_front(doPatchPowerSupply, asyncResp,
+                                                locationIndicatorActive));
+        });
+}
+
 inline void requestRoutesPowerSupply(App& app)
 {
     BMCWEB_ROUTE(
@@ -503,6 +553,12 @@ inline void requestRoutesPowerSupply(App& app)
         .privileges(redfish::privileges::getPowerSupply)
         .methods(boost::beast::http::verb::get)(
             std::bind_front(handlePowerSupplyGet, std::ref(app)));
+
+    BMCWEB_ROUTE(
+        app, "/redfish/v1/Chassis/<str>/PowerSubsystem/PowerSupplies/<str>/")
+        .privileges(redfish::privileges::patchPowerSupply)
+        .methods(boost::beast::http::verb::patch)(
+            std::bind_front(handlePowerSupplyPatch, std::ref(app)));
 }
 
 } // namespace redfish

--- a/redfish-core/lib/systems.hpp
+++ b/redfish-core/lib/systems.hpp
@@ -20,6 +20,7 @@
 #include "pcie.hpp"
 #include "query.hpp"
 #include "redfish_util.hpp"
+#include "utils/systems_utils.hpp"
 #include "utils/time_utils.hpp"
 
 #include <app.hpp>
@@ -2394,7 +2395,19 @@ inline void requestRoutesSystems(App& app)
             aRsp->res.jsonValue["Links"]["Chassis"] = std::move(chassisArray);
         });
 
-        getLocationIndicatorActive(asyncResp);
+        redfish::systems_utils::getValidSystemsPath(
+            asyncResp, systemName,
+            [asyncResp,
+             systemName](const std::optional<std::string>& validSystemsPath) {
+            if (!validSystemsPath)
+            {
+                messages::resourceNotFound(asyncResp->res, "Systems",
+                                           systemName);
+                return;
+            }
+            getLocationIndicatorActive(asyncResp, *validSystemsPath);
+            });
+
         // TODO (Gunnar): Remove IndicatorLED after enough time has passed
         getIndicatorLedState(asyncResp);
         getComputerSystem(asyncResp);
@@ -2497,7 +2510,20 @@ inline void requestRoutesSystems(App& app)
 
         if (locationIndicatorActive)
         {
-            setLocationIndicatorActive(asyncResp, *locationIndicatorActive);
+            redfish::systems_utils::getValidSystemsPath(
+                asyncResp, systemName,
+                [asyncResp, systemName,
+                 locationIndicatorActive{*locationIndicatorActive}](
+                    const std::optional<std::string>& validSystemsPath) {
+                if (!validSystemsPath)
+                {
+                    messages::resourceNotFound(asyncResp->res, "Systems",
+                                               systemName);
+                    return;
+                }
+                setLocationIndicatorActive(asyncResp, *validSystemsPath,
+                                           locationIndicatorActive);
+                });
         }
 
         // TODO (Gunnar): Remove IndicatorLED after enough time has


### PR DESCRIPTION
These commits implement the Redfish PowerSupply schema and populate the PowerSupplyCollection members.
Include:
- Efficiency Percent
- FirmwareVersion
- Location
- LocationIndicatorActive
- Manufacturer
- Model
- PartNumber
- SerialNumber
- SparePartNumber
- Status

Upstream commits:
<https://gerrit.openbmc.org/c/openbmc/bmcweb/+/58924/17>
<https://gerrit.openbmc.org/c/openbmc/bmcweb/+/57668/25>
<https://gerrit.openbmc.org/c/openbmc/bmcweb/+/57669/17>
<https://gerrit.openbmc.org/c/openbmc/bmcweb/+/57670/14>
<https://gerrit.openbmc.org/c/openbmc/bmcweb/+/57765/23>
<https://gerrit.openbmc.org/c/openbmc/bmcweb/+/57671/9>
<https://gerrit.openbmc.org/c/openbmc/bmcweb/+/57672/9>
<https://gerrit.openbmc.org/c/openbmc/bmcweb/+/57673/9>
<https://gerrit.openbmc.org/c/openbmc/bmcweb/+/57709/7>
<https://gerrit.openbmc.org/c/openbmc/bmcweb/+/42221/11>