### PR TITLE
Audit log enhancements and fixs

### DIFF
--- a/http/http_connection.hpp
+++ b/http/http_connection.hpp
@@ -445,22 +445,33 @@ class Connection :
             (req->method() == boost::beast::http::verb::delete_))
         {
 
-            // Look for good return codes and if so we know the operation passed
-            if ((res.resultInt() >= 200) && (res.resultInt() < 300))
+            if (userSession != nullptr)
             {
-                audit::auditEvent(("op=" + std::string(req->methodString()) +
-                                   ":" + std::string(req->target()) + " ")
-                                      .c_str(),
-                                  userSession->username,
-                                  req->ipAddress.to_string(), true);
+                // Look for good return codes and if so we know the operation
+                // passed
+                if ((res.resultInt() >= 200) && (res.resultInt() < 300))
+                {
+                    audit::auditEvent(
+                        ("op=" + std::string(req->methodString()) + ":" +
+                         std::string(req->target()) + " ")
+                            .c_str(),
+                        userSession->username, req->ipAddress.to_string(),
+                        true);
+                }
+                else
+                {
+                    audit::auditEvent(
+                        ("op=" + std::string(req->methodString()) + ":" +
+                         std::string(req->target()) + " ")
+                            .c_str(),
+                        userSession->username, req->ipAddress.to_string(),
+                        false);
+                }
             }
             else
             {
-                audit::auditEvent(("op=" + std::string(req->methodString()) +
-                                   ":" + std::string(req->target()) + " ")
-                                      .c_str(),
-                                  userSession->username,
-                                  req->ipAddress.to_string(), false);
+                BMCWEB_LOG_ERROR
+                    << "UserSession is null, not able to log audit event!";
             }
         }
 #endif // BMCWEB_ENABLE_LINUX_AUDIT_EVENTS

--- a/http/http_connection.hpp
+++ b/http/http_connection.hpp
@@ -444,22 +444,23 @@ class Connection :
             (req->method() == boost::beast::http::verb::patch) ||
             (req->method() == boost::beast::http::verb::delete_))
         {
+
             // Look for good return codes and if so we know the operation passed
             if ((res.resultInt() >= 200) && (res.resultInt() < 300))
             {
-                audit::auditEvent(*req,
-                                  ("op=" + std::string(req->methodString()) +
+                audit::auditEvent(("op=" + std::string(req->methodString()) +
                                    ":" + std::string(req->target()) + " ")
                                       .c_str(),
-                                  true);
+                                  userSession->username,
+                                  req->ipAddress.to_string(), true);
             }
             else
             {
-                audit::auditEvent(*req,
-                                  ("op=" + std::string(req->methodString()) +
+                audit::auditEvent(("op=" + std::string(req->methodString()) +
                                    ":" + std::string(req->target()) + " ")
                                       .c_str(),
-                                  false);
+                                  userSession->username,
+                                  req->ipAddress.to_string(), false);
             }
         }
 #endif // BMCWEB_ENABLE_LINUX_AUDIT_EVENTS

--- a/include/audit_events.hpp
+++ b/include/audit_events.hpp
@@ -70,7 +70,7 @@ inline void auditEvent(const char* opPath, const std::string& userName,
         if (userLen > bufLeft)
         {
             // Username won't fit into fixed sized buffer. Leave it off.
-            BMCWEB_LOG_WARNING << "Audit buffer too small, truncating:"
+            BMCWEB_LOG_WARNING << "Audit buffer too small for username:"
                                << " bufLeft=" << bufLeft
                                << " userLen=" << userLen;
             code = __LINE__;

--- a/include/audit_events.hpp
+++ b/include/audit_events.hpp
@@ -1,10 +1,11 @@
 #pragma once
 
-#ifdef BMCWEB_ENABLE_LINUX_AUDIT_EVENTS
 #include <libaudit.h>
 
 #include <boost/asio/ip/host_name.hpp>
-#endif
+
+#include <cstring>
+#include <string>
 
 namespace audit
 {
@@ -20,11 +21,9 @@ inline bool checkPostAudit(const crow::Request& req)
     return true;
 }
 
-inline void auditEvent([[maybe_unused]] const crow::Request& req,
-                       [[maybe_unused]] const char* opPath,
-                       [[maybe_unused]] bool success)
+inline void auditEvent(const char* opPath, const std::string& userName,
+                       const std::string& ipAddress, bool success)
 {
-#ifdef BMCWEB_ENABLE_LINUX_AUDIT_EVENTS
     int auditfd;
 
     char cnfgBuff[256];
@@ -41,7 +40,7 @@ inline void auditEvent([[maybe_unused]] const crow::Request& req,
     strncpy(cnfgBuff, opPath, std::strlen(opPath) + 1);
 
     // encode user account name to ensure it is in an appropriate format
-    user = audit_encode_nv_string("acct", req.session->username.c_str(), 0);
+    user = audit_encode_nv_string("acct", userName.c_str(), 0);
     if (user == NULL)
     {
         BMCWEB_LOG_ERROR << "Error appending user to audit msg : "
@@ -56,14 +55,12 @@ inline void auditEvent([[maybe_unused]] const crow::Request& req,
 
     if (audit_log_user_message(auditfd, AUDIT_USYS_CONFIG, cnfgBuff,
                                boost::asio::ip::host_name().c_str(),
-                               req.ipAddress.to_string().c_str(), NULL,
-                               int(success)) <= 0)
+                               ipAddress.c_str(), NULL, int(success)) <= 0)
     {
         BMCWEB_LOG_ERROR << "Error writing audit message: " << strerror(errno);
     }
 
     close(auditfd);
-#endif
     return;
 }
 

--- a/include/audit_events.hpp
+++ b/include/audit_events.hpp
@@ -28,7 +28,7 @@ inline void auditEvent(const char* opPath, const std::string& userName,
     int code = __LINE__;
 
     char cnfgBuff[256];
-    size_t bufLeft = 256;
+    size_t bufLeft = 256; // Amount left available in cnfgBuff
     char* user = NULL;
     size_t opPathLen;
     size_t userLen = 0;
@@ -44,6 +44,7 @@ inline void auditEvent(const char* opPath, const std::string& userName,
     opPathLen = std::strlen(opPath) + 1;
     if (opPathLen > bufLeft)
     {
+        // Truncate event message to fit into fixed sized buffer.
         BMCWEB_LOG_WARNING << "Audit buffer too small, truncating:"
                            << " bufLeft=" << bufLeft
                            << " opPathLen=" << opPathLen;
@@ -68,6 +69,7 @@ inline void auditEvent(const char* opPath, const std::string& userName,
 
         if (userLen > bufLeft)
         {
+            // Username won't fit into fixed sized buffer. Leave it off.
             BMCWEB_LOG_WARNING << "Audit buffer too small, truncating:"
                                << " bufLeft=" << bufLeft
                                << " userLen=" << userLen;

--- a/include/audit_events.hpp
+++ b/include/audit_events.hpp
@@ -44,11 +44,11 @@ inline void auditEvent(const char* opPath, const std::string& userName,
     opPathLen = std::strlen(opPath) + 1;
     if (opPathLen > bufLeft)
     {
-	    BMCWEB_LOG_WARNING << "Audit buffer too small, truncating:"
-	    	<< " bufLeft=" << bufLeft
-	    	<< " opPathLen=" << opPathLen;
-	    opPathLen = bufLeft;
-	    code = __LINE__;
+        BMCWEB_LOG_WARNING << "Audit buffer too small, truncating:"
+                           << " bufLeft=" << bufLeft
+                           << " opPathLen=" << opPathLen;
+        opPathLen = bufLeft;
+        code = __LINE__;
     }
     strncpy(cnfgBuff, opPath, opPathLen);
     cnfgBuff[opPathLen - 1] = '\0';
@@ -60,29 +60,27 @@ inline void auditEvent(const char* opPath, const std::string& userName,
     {
         BMCWEB_LOG_ERROR << "Error appending user to audit msg : "
                          << strerror(errno);
-	code = __LINE__;
+        code = __LINE__;
     }
     else
     {
-	userLen = std::strlen(user) + 1;
+        userLen = std::strlen(user) + 1;
 
-	if (userLen > bufLeft)
-	{
-		BMCWEB_LOG_WARNING << "Audit buffer too small, truncating:"
-			<< " bufLeft=" << bufLeft
-			<< " userLen=" << userLen;
-	    	code = __LINE__;
-	}
-	else
-	{
-        	strncat(cnfgBuff, user, userLen);
-	}
+        if (userLen > bufLeft)
+        {
+            BMCWEB_LOG_WARNING << "Audit buffer too small, truncating:"
+                               << " bufLeft=" << bufLeft
+                               << " userLen=" << userLen;
+            code = __LINE__;
+        }
+        else
+        {
+            strncat(cnfgBuff, user, userLen);
+        }
     }
 
-    BMCWEB_LOG_DEBUG << "auditEvent: code=" << code
-    	<< " bufLeft=" << bufLeft
-	<< " opPathLen=" << opPathLen
-	<< " userLen=" << userLen;
+    BMCWEB_LOG_DEBUG << "auditEvent: code=" << code << " bufLeft=" << bufLeft
+                     << " opPathLen=" << opPathLen << " userLen=" << userLen;
 
     free(user);
 

--- a/include/audit_events.hpp
+++ b/include/audit_events.hpp
@@ -38,7 +38,7 @@ inline void auditEvent([[maybe_unused]] const crow::Request& req,
         return;
     }
 
-    strcpy(cnfgBuff, opPath);
+    strncpy(cnfgBuff, opPath, std::strlen(opPath) + 1);
 
     // encode user account name to ensure it is in an appropriate format
     user = audit_encode_nv_string("acct", req.session->username.c_str(), 0);

--- a/include/login_routes.hpp
+++ b/include/login_routes.hpp
@@ -1,5 +1,8 @@
 #pragma once
 
+#ifdef BMCWEB_ENABLE_LINUX_AUDIT_EVENTS
+#include "audit_events.hpp"
+#endif
 #include "multipart_parser.hpp"
 
 #include <app.hpp>
@@ -182,6 +185,13 @@ inline void requestRoutes(App& app)
                 {
                     asyncResp->res.result(
                         boost::beast::http::status::unauthorized);
+#ifdef BMCWEB_ENABLE_LINUX_AUDIT_EVENTS
+                    audit::auditEvent(("op=" + std::string(req.methodString()) +
+                                       ":" + std::string(req.target()) + " ")
+                                          .c_str(),
+                                      std::string(username),
+                                      req.ipAddress.to_string(), false);
+#endif
                 }
                 else
                 {
@@ -236,6 +246,13 @@ inline void requestRoutes(App& app)
                 BMCWEB_LOG_DEBUG << "Couldn't interpret password";
                 asyncResp->res.result(boost::beast::http::status::bad_request);
             }
+#ifdef BMCWEB_ENABLE_LINUX_AUDIT_EVENTS
+            audit::auditEvent(("op=" + std::string(req.methodString()) + ":" +
+                               std::string(req.target()) + " ")
+                                  .c_str(),
+                              std::string(username), req.ipAddress.to_string(),
+                              true);
+#endif
         });
 
     BMCWEB_ROUTE(app, "/logout")


### PR DESCRIPTION
This supersedes: https://github.com/ibm-openbmc/bmcweb/pull/456

This is a 1030.
Please cherry pick into 1040 as well. 

This fixes defects:  https://w3.rchland.ibm.com/projects/bestquest/?defect=SW558520  and https://w3.rchland.ibm.com/projects/bestquest/?defect=PE00DWMX

1. [swap strcpy for strncpy](https://github.com/ibm-openbmc/bmcweb/commit/3d8ae93444cee8875deb0b5d067f195041f3cb85)
   a.     strncpy has range checks, which reduce the possibility of overrunning the buffer in the case of a bug. see https://github.com/ibm-openbmc/bmcweb/commit/eb7d3d5400555715d755ed03722dbbfe2b6607c9
2. [Refactor audit logs](https://github.com/ibm-openbmc/bmcweb/commit/def76ffbacc34a67369f4c91ea0b30b7e532d86f)
   a.  Pass in UserName and IpAddress.
   b.  Move to userSession->username over req.session->username 
   c.  Rely on including in the ifdef in http/http_connection and don't have addition ifdefs in include/audit_events.hpp.
3. [Make sure UserSession is not null](https://github.com/ibm-openbmc/bmcweb/commit/73544eb5e0ce182f215647f2d2b3d1852f63d292)
   a. Have seen core dumps due to req.session->username
4.   [Add audit login / session post](https://github.com/ibm-openbmc/bmcweb/commit/44e2fc36b3191678c96cfc6ceef35c9115760fba)
   a. Took this code from Zami. This adds audit logs for a POST to /login or POST to the session collection, creating a session.
5. [Add additional audit information](https://github.com/ibm-openbmc/bmcweb/commit/e088f6375035a41405bed128186d11d17fc924b9)
   a. Add properties modified to PATCH or POST exclude account PATCH or POST
   
Tested: 

Validator passed.

When Audit is enabled, builds and disabled, builds.
 Using the GUI.

```
Jan 10 20:30:41 p10bmc kernel: audit: type=1111
audit(1673382641.679:12): pid=702 uid=0 auid=4294967295 ses=4294967295
msg='op=PATCH:/redfish/v1/Systems/system
{"Boot":{"TrustedModuleRequiredToBoot":false}} acct="service"
exe="/usr/bin/bmcweb" hostname=p10bmc addr=::ffff:9.211.155.15
terminal=? res=success'

Jan 10 20:32:08 p10bmc audit[702]: AUDIT1111 pid=702 uid=0
auid=4294967295 ses=4294967295
msg='op=POST:/redfish/v1/Systems/system/Actions/ComputerSystem.Reset
{"ResetType":"GracefulShutdown"} acct="service" exe="/usr/bin/bmcweb"
hostname=p10bmc addr=::ffff:9.211.155.15 terminal=? res=success'

Jan 10 21:00:00 p10bmc kernel: audit: type=1111 audit(1673384400.039:21):
pid=1117 uid=0 auid=4294967295 ses=4294967295
msg='op=PATCH:/redfish/v1/AccountService/Accounts/gui acct="service"
exe="/tmp/bmcweb" hostname=p10bmc addr=9.211.155.15 terminal=pts/0
res=success'

Jan 10 21:47:06 p10bmc audit[1481]: AUDIT1111 pid=1481 uid=0 auid=4294967295 ses=4294967295 msg='op=DELETE:/redfish/v1/SessionService/Sessions/smPLuHOajG acct="service" exe="/tmp/bmcweb" hostname=p10bmc addr=9.211.155.15 terminal=pts/0 res=success'
```