### PR TITLE
1050 fan

### DIFF
--- a/Redfish.md
+++ b/Redfish.md
@@ -271,6 +271,14 @@ Fields common to all schemas
 
 - Status
 
+#### /redfish/v1/Chassis/{ChassisId}/ThermalSubsystem/Fans
+
+##### Fans
+
+- Description
+- Members
+- Members@odata.count
+
 ### /redfish/v1/Chassis/{ChassisId}/Power#/PowerControl/{ControlName}/
 
 #### PowerControl

--- a/Redfish.md
+++ b/Redfish.md
@@ -288,6 +288,7 @@ Fields common to all schemas
 - Model
 - PartNumber
 - SerialNumber
+- SpeedPercent
 - Status
 
 ### /redfish/v1/Chassis/{ChassisId}/Power#/PowerControl/{ControlName}/

--- a/Redfish.md
+++ b/Redfish.md
@@ -283,6 +283,10 @@ Fields common to all schemas
 
 ##### Fan
 
+- Manufacturer
+- Model
+- PartNumber
+- SerialNumber
 - Status
 
 ### /redfish/v1/Chassis/{ChassisId}/Power#/PowerControl/{ControlName}/

--- a/Redfish.md
+++ b/Redfish.md
@@ -284,6 +284,7 @@ Fields common to all schemas
 ##### Fan
 
 - Location
+- LocationIndicatorActive
 - Manufacturer
 - Model
 - PartNumber

--- a/Redfish.md
+++ b/Redfish.md
@@ -279,6 +279,12 @@ Fields common to all schemas
 - Members
 - Members@odata.count
 
+#### /redfish/v1/Chassis/{ChassisId}/ThermalSubsystem/Fans/{FanId}
+
+##### Fan
+
+- Status
+
 ### /redfish/v1/Chassis/{ChassisId}/Power#/PowerControl/{ControlName}/
 
 #### PowerControl

--- a/Redfish.md
+++ b/Redfish.md
@@ -283,6 +283,7 @@ Fields common to all schemas
 
 ##### Fan
 
+- Location
 - Manufacturer
 - Model
 - PartNumber

--- a/redfish-core/include/redfish.hpp
+++ b/redfish-core/include/redfish.hpp
@@ -84,6 +84,7 @@ class RedfishService
 #endif
 #ifdef BMCWEB_NEW_POWERSUBSYSTEM_THERMALSUBSYSTEM
         requestRoutesEnvironmentMetrics(app);
+        requestRoutesFan(app);
         requestRoutesFanCollection(app);
         requestRoutesPowerSubsystem(app);
         requestRoutesPowerSupply(app);

--- a/redfish-core/include/redfish.hpp
+++ b/redfish-core/include/redfish.hpp
@@ -24,6 +24,7 @@
 #include "environment_metrics.hpp"
 #include "ethernet.hpp"
 #include "event_service.hpp"
+#include "fan.hpp"
 #include "hypervisor_system.hpp"
 #include "log_services.hpp"
 #include "manager_diagnostic_data.hpp"
@@ -83,6 +84,7 @@ class RedfishService
 #endif
 #ifdef BMCWEB_NEW_POWERSUBSYSTEM_THERMALSUBSYSTEM
         requestRoutesEnvironmentMetrics(app);
+        requestRoutesFanCollection(app);
         requestRoutesPowerSubsystem(app);
         requestRoutesPowerSupply(app);
         requestRoutesPowerSupplyCollection(app);

--- a/redfish-core/lib/fan.hpp
+++ b/redfish-core/lib/fan.hpp
@@ -12,13 +12,31 @@
 namespace redfish
 {
 
-inline void
-    updateFanList(const std::shared_ptr<bmcweb::AsyncResp>& /* asyncResp */,
-                  const std::string& /* chassisId */,
-                  const std::string& /* fanPath */)
+inline void updateFanList(const std::shared_ptr<bmcweb::AsyncResp>& asyncResp,
+                          const std::string& chassisId,
+                          const std::string& fanPath)
 {
-    // TODO In order for the validator to pass, the Members property will be
-    // implemented on the next commit
+    std::string fanName = sdbusplus::message::object_path(fanPath).filename();
+    if (fanName.empty())
+    {
+        return;
+    }
+
+    nlohmann::json item;
+    item["@odata.id"] =
+        crow::utility::urlFromPieces("redfish", "v1", "Chassis", chassisId,
+                                     "ThermalSubsystem", "Fans", fanName);
+
+    nlohmann::json& fanList = asyncResp->res.jsonValue["Members"];
+    fanList.emplace_back(std::move(item));
+    asyncResp->res.jsonValue["Members@odata.count"] = fanList.size();
+}
+
+inline bool checkFanId(const std::string& fanPath, const std::string& fanId)
+{
+    std::string fanName = sdbusplus::message::object_path(fanPath).filename();
+
+    return !(fanName.empty() || fanName != fanId);
 }
 
 inline void fanCollection(const std::shared_ptr<bmcweb::AsyncResp>& asyncResp,
@@ -146,6 +164,143 @@ inline void requestRoutesFanCollection(App& app)
         .privileges(redfish::privileges::getFanCollection)
         .methods(boost::beast::http::verb::get)(
             std::bind_front(handleFanCollectionGet, std::ref(app)));
+}
+
+inline void getValidFanPath(const std::shared_ptr<bmcweb::AsyncResp>& asyncResp,
+                            const std::string& validChassisPath,
+                            const std::string& fanId,
+                            std::function<void()>&& callback)
+{
+    dbus::utility::getAssociationEndPoints(
+        validChassisPath + "/cooled_by",
+        [asyncResp, fanId, callback{std::move(callback)}](
+            const boost::system::error_code& ec,
+            const dbus::utility::MapperEndPoints& ivEndpoints) {
+        if (ec)
+        {
+            if (ec.value() != EBADR)
+            {
+                messages::internalError(asyncResp->res);
+            }
+            messages::resourceNotFound(asyncResp->res, "Fan", fanId);
+            return;
+        }
+
+        messages::resourceNotFound(asyncResp->res, "Fan", fanId);
+        for (const auto& ivEndpoint : ivEndpoints)
+        {
+            dbus::utility::getAssociationEndPoints(
+                ivEndpoint + "/sensors",
+                [asyncResp, fanId, ivEndpoint, callback](
+                    const boost::system::error_code& ec1,
+                    const dbus::utility::MapperEndPoints& sensorEndpoints) {
+                if (ec1 && ec1.value() != EBADR)
+                {
+                    messages::internalError(asyncResp->res);
+                    return;
+                }
+
+                if (sensorEndpoints.empty())
+                {
+                    if (checkFanId(ivEndpoint, fanId))
+                    {
+                        asyncResp->res.clear();
+                        callback();
+                    }
+                    return;
+                }
+
+                for (const auto& sensorEndpoint : sensorEndpoints)
+                {
+                    if (checkFanId(sensorEndpoint, fanId))
+                    {
+                        asyncResp->res.clear();
+                        callback();
+                        return;
+                    }
+                }
+                });
+        }
+        });
+}
+
+inline void doFanGet(const std::shared_ptr<bmcweb::AsyncResp>& asyncResp,
+                     const std::string& chassisId, const std::string& fanId,
+                     const std::optional<std::string>& validChassisPath)
+{
+    if (!validChassisPath)
+    {
+        messages::resourceNotFound(asyncResp->res, "Chassis", chassisId);
+        return;
+    }
+
+    getValidFanPath(asyncResp, *validChassisPath, fanId,
+                    [asyncResp, chassisId, fanId]() {
+        asyncResp->res.addHeader(
+            boost::beast::http::field::link,
+            "</redfish/v1/JsonSchemas/Fan/Fan.json>; rel=describedby");
+        asyncResp->res.jsonValue["@odata.type"] = "#Fan.v1_3_0.Fan";
+        asyncResp->res.jsonValue["Name"] = fanId;
+        asyncResp->res.jsonValue["Id"] = fanId;
+        asyncResp->res.jsonValue["@odata.id"] =
+            crow::utility::urlFromPieces("redfish", "v1", "Chassis", chassisId,
+                                         "ThermalSubsystem", "Fans", fanId);
+    });
+}
+
+inline void handleFanHead(App& app, const crow::Request& req,
+                          const std::shared_ptr<bmcweb::AsyncResp>& asyncResp,
+                          const std::string& chassisId,
+                          const std::string& fanId)
+{
+    if (!redfish::setUpRedfishRoute(app, req, asyncResp))
+    {
+        return;
+    }
+
+    redfish::chassis_utils::getValidChassisPath(
+        asyncResp, chassisId,
+        [asyncResp, fanId](const std::optional<std::string>& validChassisPath) {
+        if (!validChassisPath)
+        {
+            messages::resourceNotFound(asyncResp->res, "Fan", fanId);
+            return;
+        }
+
+        // Get the correct Path and Service that match the input parameters
+        getValidFanPath(asyncResp, *validChassisPath, fanId, [asyncResp]() {
+            asyncResp->res.addHeader(
+                boost::beast::http::field::link,
+                "</redfish/v1/JsonSchemas/Fan/Fan.json>; rel=describedby");
+        });
+        });
+}
+
+inline void handleFanGet(App& app, const crow::Request& req,
+                         const std::shared_ptr<bmcweb::AsyncResp>& asyncResp,
+                         const std::string& chassisId, const std::string& fanId)
+{
+    if (!redfish::setUpRedfishRoute(app, req, asyncResp))
+    {
+        return;
+    }
+
+    redfish::chassis_utils::getValidChassisPath(
+        asyncResp, chassisId,
+        std::bind_front(doFanGet, asyncResp, chassisId, fanId));
+}
+
+inline void requestRoutesFan(App& app)
+{
+    BMCWEB_ROUTE(app, "/redfish/v1/Chassis/<str>/ThermalSubsystem/Fans/<str>/")
+        .privileges(redfish::privileges::headFan)
+        .methods(boost::beast::http::verb::head)(
+            std::bind_front(handleFanHead, std::ref(app)));
+
+    BMCWEB_ROUTE(app, "/redfish/v1/Chassis/<str>/ThermalSubsystem/Fans/<str>/")
+        .privileges(redfish::privileges::getFan)
+        .methods(boost::beast::http::verb::get)(
+            std::bind_front(handleFanGet, std::ref(app)));
 }
 
 } // namespace redfish

--- a/redfish-core/lib/fan.hpp
+++ b/redfish-core/lib/fan.hpp
@@ -1,0 +1,151 @@
+#pragma once
+
+#include "app.hpp"
+#include "dbus_utility.hpp"
+#include "error_messages.hpp"
+#include "utils/chassis_utils.hpp"
+
+#include <memory>
+#include <optional>
+#include <string>
+
+namespace redfish
+{
+
+inline void
+    updateFanList(const std::shared_ptr<bmcweb::AsyncResp>& /* asyncResp */,
+                  const std::string& /* chassisId */,
+                  const std::string& /* fanPath */)
+{
+    // TODO In order for the validator to pass, the Members property will be
+    // implemented on the next commit
+}
+
+inline void fanCollection(const std::shared_ptr<bmcweb::AsyncResp>& asyncResp,
+                          const std::string& fanPath,
+                          const std::string& chassisId)
+{
+    dbus::utility::getAssociationEndPoints(
+        fanPath + "/sensors",
+        [asyncResp, fanPath,
+         chassisId](const boost::system::error_code& ec,
+                    const dbus::utility::MapperEndPoints& endpoints) {
+        if (ec)
+        {
+            if (ec.value() != EBADR)
+            {
+                messages::internalError(asyncResp->res);
+                return;
+            }
+        }
+
+        if (endpoints.empty())
+        {
+            updateFanList(asyncResp, chassisId, fanPath);
+            return;
+        }
+
+        for (const auto& endpoint : endpoints)
+        {
+            updateFanList(asyncResp, chassisId, endpoint);
+        }
+        });
+}
+
+inline void doFanCollection(const std::shared_ptr<bmcweb::AsyncResp>& asyncResp,
+                            const std::string& chassisId,
+                            const std::optional<std::string>& validChassisPath)
+{
+    if (!validChassisPath)
+    {
+        messages::resourceNotFound(asyncResp->res, "Chassis", chassisId);
+        return;
+    }
+
+    asyncResp->res.addHeader(
+        boost::beast::http::field::link,
+        "</redfish/v1/JsonSchemas/FanCollection/FanCollection.json>; rel=describedby");
+    asyncResp->res.jsonValue["@odata.type"] = "#FanCollection.FanCollection";
+    asyncResp->res.jsonValue["@odata.id"] = crow::utility::urlFromPieces(
+        "redfish", "v1", "Chassis", chassisId, "ThermalSubsystem", "Fans");
+    asyncResp->res.jsonValue["Name"] = "Fan Collection";
+    asyncResp->res.jsonValue["Description"] =
+        "The collection of Fan resource instances " + chassisId;
+    asyncResp->res.jsonValue["Members"] = nlohmann::json::array();
+    asyncResp->res.jsonValue["Members@odata.count"] = 0;
+
+    dbus::utility::getAssociationEndPoints(
+        *validChassisPath + "/cooled_by",
+        [asyncResp,
+         chassisId](const boost::system::error_code& ec,
+                    const dbus::utility::MapperEndPoints& endpoints) {
+        if (ec)
+        {
+            if (ec.value() != EBADR)
+            {
+                messages::internalError(asyncResp->res);
+            }
+            return;
+        }
+
+        for (const auto& endpoint : endpoints)
+        {
+            fanCollection(asyncResp, endpoint, chassisId);
+        }
+        });
+}
+
+inline void
+    handleFanCollectionHead(App& app, const crow::Request& req,
+                            const std::shared_ptr<bmcweb::AsyncResp>& asyncResp,
+                            const std::string& chassisId)
+{
+    if (!redfish::setUpRedfishRoute(app, req, asyncResp))
+    {
+        return;
+    }
+
+    redfish::chassis_utils::getValidChassisPath(
+        asyncResp, chassisId,
+        [asyncResp,
+         chassisId](const std::optional<std::string>& validChassisPath) {
+        if (!validChassisPath)
+        {
+            messages::resourceNotFound(asyncResp->res, "Chassis", chassisId);
+            return;
+        }
+        asyncResp->res.addHeader(
+            boost::beast::http::field::link,
+            "</redfish/v1/JsonSchemas/FanCollection/FanCollection.json>; rel=describedby");
+        });
+}
+
+inline void
+    handleFanCollectionGet(App& app, const crow::Request& req,
+                           const std::shared_ptr<bmcweb::AsyncResp>& asyncResp,
+                           const std::string& chassisId)
+{
+    if (!redfish::setUpRedfishRoute(app, req, asyncResp))
+    {
+        return;
+    }
+
+    redfish::chassis_utils::getValidChassisPath(
+        asyncResp, chassisId,
+        std::bind_front(doFanCollection, asyncResp, chassisId));
+}
+
+inline void requestRoutesFanCollection(App& app)
+{
+    BMCWEB_ROUTE(app, "/redfish/v1/Chassis/<str>/ThermalSubsystem/Fans/")
+        .privileges(redfish::privileges::headFanCollection)
+        .methods(boost::beast::http::verb::head)(
+            std::bind_front(handleFanCollectionHead, std::ref(app)));
+
+    BMCWEB_ROUTE(app, "/redfish/v1/Chassis/<str>/ThermalSubsystem/Fans/")
+        .privileges(redfish::privileges::getFanCollection)
+        .methods(boost::beast::http::verb::get)(
+            std::bind_front(handleFanCollectionGet, std::ref(app)));
+}
+
+} // namespace redfish

--- a/redfish-core/lib/fan.hpp
+++ b/redfish-core/lib/fan.hpp
@@ -326,6 +326,28 @@ inline void getFanAsset(const std::shared_ptr<bmcweb::AsyncResp>& asyncResp,
         });
 }
 
+inline void getFanLocation(const std::shared_ptr<bmcweb::AsyncResp>& asyncResp,
+                           const std::string& service, const std::string& path)
+{
+    sdbusplus::asio::getProperty<std::string>(
+        *crow::connections::systemBus, service, path,
+        "xyz.openbmc_project.Inventory.Decorator.LocationCode", "LocationCode",
+        [asyncResp](const boost::system::error_code& ec,
+                    const std::string& value) {
+        if (ec)
+        {
+            if (ec.value() != EBADR)
+            {
+                messages::internalError(asyncResp->res);
+            }
+            return;
+        }
+
+        asyncResp->res.jsonValue["Location"]["PartLocation"]["ServiceLabel"] =
+            value;
+        });
+}
+
 inline void doFanGet(const std::shared_ptr<bmcweb::AsyncResp>& asyncResp,
                      const std::string& chassisId, const std::string& fanId,
                      const std::optional<std::string>& validChassisPath)
@@ -374,6 +396,7 @@ inline void doFanGet(const std::shared_ptr<bmcweb::AsyncResp>& asyncResp,
 
             getFanState(asyncResp, object.begin()->first, fanPath);
             getFanAsset(asyncResp, object.begin()->first, fanPath);
+            getFanLocation(asyncResp, object.begin()->first, fanPath);
             });
         });
 }

--- a/redfish-core/lib/led.hpp
+++ b/redfish-core/lib/led.hpp
@@ -165,7 +165,7 @@ inline void getLedAsset(const std::shared_ptr<bmcweb::AsyncResp>& aResp,
         ledGroup, interfaces,
         [aResp, ledGroup](const boost::system::error_code& ec,
                           const dbus::utility::MapperGetObject& object) {
-        if (ec || object.size() != 1)
+        if (ec || object.empty())
         {
             BMCWEB_LOG_ERROR << "DBUS response error " << ec.message();
             messages::internalError(aResp->res);
@@ -178,7 +178,10 @@ inline void getLedAsset(const std::shared_ptr<bmcweb::AsyncResp>& aResp,
             [aResp](const boost::system::error_code& ec1, bool assert) {
             if (ec1)
             {
-                messages::internalError(aResp->res);
+                if (ec1.value() != EBADR)
+                {
+                    messages::internalError(aResp->res);
+                }
                 return;
             }
 
@@ -196,7 +199,7 @@ inline void setLedAsset(const std::shared_ptr<bmcweb::AsyncResp>& aResp,
         [aResp, ledGroup,
          ledState](const boost::system::error_code& ec,
                    const dbus::utility::MapperGetObject& object) {
-        if (ec || object.size() != 1)
+        if (ec || object.empty())
         {
             BMCWEB_LOG_ERROR << "DBUS response error " << ec.message();
             messages::internalError(aResp->res);
@@ -209,7 +212,10 @@ inline void setLedAsset(const std::shared_ptr<bmcweb::AsyncResp>& aResp,
             [aResp](const boost::system::error_code& ec1) {
             if (ec1)
             {
-                messages::internalError(aResp->res);
+                if (ec1.value() != EBADR)
+                {
+                    messages::internalError(aResp->res);
+                }
                 return;
             }
             });
@@ -234,9 +240,12 @@ inline void
         objPath + "/identifying",
         [aResp](const boost::system::error_code& ec,
                 const dbus::utility::MapperEndPoints& endpoints) {
-        if (ec.value() != EBADR)
+        if (ec)
         {
-            messages::internalError(aResp->res);
+            if (ec.value() != EBADR)
+            {
+                messages::internalError(aResp->res);
+            }
             return;
         }
 
@@ -266,9 +275,12 @@ inline void
         objPath + "/identifying",
         [aResp, ledState](const boost::system::error_code& ec,
                           const dbus::utility::MapperEndPoints& endpoints) {
-        if (ec.value() != EBADR)
+        if (ec)
         {
-            messages::internalError(aResp->res);
+            if (ec.value() != EBADR)
+            {
+                messages::internalError(aResp->res);
+            }
             return;
         }
 

--- a/redfish-core/lib/power_supply.hpp
+++ b/redfish-core/lib/power_supply.hpp
@@ -422,7 +422,7 @@ inline void
             [asyncResp,
              powerSupplyPath](const boost::system::error_code& ec,
                               const dbus::utility::MapperGetObject& object) {
-            if (ec || object.size() == 0)
+            if (ec || object.empty())
             {
                 messages::internalError(asyncResp->res);
                 return;

--- a/redfish-core/lib/thermal_subsystem.hpp
+++ b/redfish-core/lib/thermal_subsystem.hpp
@@ -36,6 +36,10 @@ inline void doThermalSubsystemCollection(
     asyncResp->res.jsonValue["@odata.id"] = crow::utility::urlFromPieces(
         "redfish", "v1", "Chassis", chassisId, "ThermalSubsystem");
 
+    asyncResp->res.jsonValue["Fans"]["@odata.id"] =
+        crow::utility::urlFromPieces("redfish", "v1", "Chassis", chassisId,
+                                     "ThermalSubsystem", "Fans");
+
     asyncResp->res.jsonValue["Status"]["State"] = "Enabled";
     asyncResp->res.jsonValue["Status"]["Health"] = "OK";
 }


### PR DESCRIPTION
These commits implement the Redfish Fan schema and populate the FanCollection members.
Include:
- Location
- LocationIndicatorActive
- Manufacturer
- Model
- PartNumber
- SerialNumber
- SpeedPercent
- Status

Upstream commits:
https://gerrit.openbmc.org/c/openbmc/bmcweb/+/57533
https://gerrit.openbmc.org/c/openbmc/bmcweb/+/57559
https://gerrit.openbmc.org/c/openbmc/bmcweb/+/41086
https://gerrit.openbmc.org/c/openbmc/bmcweb/+/57628
https://gerrit.openbmc.org/c/openbmc/bmcweb/+/57630
https://gerrit.openbmc.org/c/openbmc/bmcweb/+/57657
https://gerrit.openbmc.org/c/openbmc/bmcweb/+/42210