### PR TITLE
Add originator id & type for user trigerred dumps

### DIFF
--- a/redfish-core/lib/log_services.hpp
+++ b/redfish-core/lib/log_services.hpp
@@ -338,9 +338,31 @@ static bool
     return !redfishLogFiles.empty();
 }
 
+inline std::string
+    mapDbusOriginatorTypeToRedfish(const std::string& originatorType)
+{
+    if (originatorType ==
+        "xyz.openbmc_project.Common.OriginatedBy.OriginatorTypes.Client")
+    {
+        return "Client";
+    }
+    if (originatorType ==
+        "xyz.openbmc_project.Common.OriginatedBy.OriginatorTypes.Internal")
+    {
+        return "Internal";
+    }
+    if (originatorType ==
+        "xyz.openbmc_project.Common.OriginatedBy.OriginatorTypes.SupportingService")
+    {
+        return "SupportingService";
+    }
+    return "";
+}
+
 inline void parseDumpEntryFromDbusObject(
     const dbus::utility::ManagedObjectType::value_type& object,
     std::string& dumpStatus, uint64_t& size, uint64_t& timestampUs,
+    std::string& originatorId, std::string& originatorType,
     const std::shared_ptr<bmcweb::AsyncResp>& asyncResp)
 {
     for (const auto& interfaceMap : object.second)
@@ -395,6 +417,42 @@ inline void parseDumpEntryFromDbusObject(
                     }
                     timestampUs = *usecsTimeStamp;
                     break;
+                }
+            }
+        }
+        else if (interfaceMap.first ==
+                 "xyz.openbmc_project.Common.OriginatedBy")
+        {
+            for (const auto& propertyMap : interfaceMap.second)
+            {
+                if (propertyMap.first == "OriginatorId")
+                {
+                    const std::string* id =
+                        std::get_if<std::string>(&propertyMap.second);
+                    if (id == nullptr)
+                    {
+                        messages::internalError(asyncResp->res);
+                        break;
+                    }
+                    originatorId = *id;
+                }
+
+                if (propertyMap.first == "OriginatorType")
+                {
+                    const std::string* type =
+                        std::get_if<std::string>(&propertyMap.second);
+                    if (type == nullptr)
+                    {
+                        messages::internalError(asyncResp->res);
+                        break;
+                    }
+
+                    originatorType = mapDbusOriginatorTypeToRedfish(*type);
+                    if (originatorType.empty())
+                    {
+                        messages::internalError(asyncResp->res);
+                        break;
+                    }
                 }
             }
         }
@@ -483,6 +541,8 @@ inline void
             uint64_t timestampUs = 0;
             uint64_t size = 0;
             std::string dumpStatus;
+            std::string originatorId;
+            std::string originatorType;
             nlohmann::json::object_t thisEntry;
 
             std::string entryID = object.first.filename();
@@ -492,6 +552,7 @@ inline void
             }
 
             parseDumpEntryFromDbusObject(object, dumpStatus, size, timestampUs,
+                                         originatorId, originatorType,
                                          asyncResp);
 
             if (dumpStatus !=
@@ -502,13 +563,19 @@ inline void
                 continue;
             }
 
-            thisEntry["@odata.type"] = "#LogEntry.v1_9_0.LogEntry";
+            thisEntry["@odata.type"] = "#LogEntry.v1_11_0.LogEntry";
             thisEntry["@odata.id"] = entriesPath + entryID;
             thisEntry["Id"] = entryID;
             thisEntry["EntryType"] = "Event";
             thisEntry["Name"] = dumpType + " Dump Entry";
             thisEntry["Created"] =
                 redfish::time_utils::getDateTimeUintUs(timestampUs);
+
+            if (!originatorId.empty())
+            {
+                thisEntry["Originator"] = originatorId;
+                thisEntry["OriginatorType"] = originatorType;
+            }
 
             if (dumpType == "BMC")
             {
@@ -571,9 +638,12 @@ inline void
             uint64_t timestampUs = 0;
             uint64_t size = 0;
             std::string dumpStatus;
+            std::string originatorId;
+            std::string originatorType;
 
             parseDumpEntryFromDbusObject(objectPath, dumpStatus, size,
-                                         timestampUs, asyncResp);
+                                         timestampUs, originatorId,
+                                         originatorType, asyncResp);
 
             if (dumpStatus !=
                     "xyz.openbmc_project.Common.Progress.OperationStatus.Completed" &&
@@ -587,13 +657,19 @@ inline void
             }
 
             asyncResp->res.jsonValue["@odata.type"] =
-                "#LogEntry.v1_9_0.LogEntry";
+                "#LogEntry.v1_11_0.LogEntry";
             asyncResp->res.jsonValue["@odata.id"] = entriesPath + entryID;
             asyncResp->res.jsonValue["Id"] = entryID;
             asyncResp->res.jsonValue["EntryType"] = "Event";
             asyncResp->res.jsonValue["Name"] = dumpType + " Dump Entry";
             asyncResp->res.jsonValue["Created"] =
                 redfish::time_utils::getDateTimeUintUs(timestampUs);
+
+            if (!originatorId.empty())
+            {
+                asyncResp->res.jsonValue["Originator"] = originatorId;
+                asyncResp->res.jsonValue["OriginatorType"] = originatorType;
+            }
 
             if (dumpType == "BMC")
             {
@@ -896,6 +972,13 @@ inline void createDump(const std::shared_ptr<bmcweb::AsyncResp>& asyncResp,
 
     std::vector<std::pair<std::string, std::variant<std::string, uint64_t>>>
         createDumpParamVec;
+
+    createDumpParamVec.emplace_back(
+        "xyz.openbmc_project.Dump.Create.CreateParameters.OriginatorId",
+        req.session->clientIp);
+    createDumpParamVec.emplace_back(
+        "xyz.openbmc_project.Dump.Create.CreateParameters.OriginatorType",
+        "xyz.openbmc_project.Common.OriginatedBy.OriginatorTypes.Client");
 
     crow::connections::systemBus->async_method_call(
         [asyncResp, payload(task::Payload(req)), dumpPath](


### PR DESCRIPTION
The LogEntry schema has the below properties to store the originator (or the source) of the dump log entry and type of originator data:
  * Originator
  * OriginatorType

Reference:
[1] https://redfish.dmtf.org/schemas/v1/LogEntry_v1.xml

phosphor-debug-collector orchestrates the collection and offload of dumps. It now implements the OriginatedBy interface for all the dumps. [1] https://gerrit.openbmc.org/c/openbmc/phosphor-debug-collector/+/48337

Redfish Validator passed.

Tested By:
* Created bmc dump
* Get on the created bmc dump lists the newly added properties in the redfish response

Signed-off-by: Asmitha Karunanithi <asmitk01@in.ibm.com>
Change-Id: I473eabb81db7511f064904120992ed5449d323e5