### PR TITLE
Fix for some lock related defects

### DIFF
--- a/include/ibm/locks.hpp
+++ b/include/ibm/locks.hpp
@@ -112,9 +112,6 @@ class Lock
 
     Lock()
     {
-        // Remove the persistent file
-        std::filesystem::remove(fileName);
-        lockTable.clear();
         transactionId = lockTable.empty() ? 0 : prev(lockTable.end())->first;
     }
 
@@ -264,7 +261,7 @@ inline RcAcquireLock Lock::acquireLock(const LockRequests& lockRequestStructure)
 
     if (status)
     {
-        BMCWEB_LOG_DEBUG << "There is a conflict within itself";
+        BMCWEB_LOG_ERROR << "There is a conflict within itself";
         return std::make_pair(true, std::make_pair(status, 1));
     }
     BMCWEB_LOG_DEBUG << "The request is not conflicting within itself";

--- a/include/ibm/locks.hpp
+++ b/include/ibm/locks.hpp
@@ -553,6 +553,7 @@ inline bool Lock::isConflictRecord(const LockRequest& refLockRecord1,
     }
 
     uint32_t i = 0;
+    uint32_t segStartIndex = 0;
     for (const auto& p : std::get<4>(refLockRecord1))
     {
 
@@ -590,23 +591,21 @@ inline bool Lock::isConflictRecord(const LockRequest& refLockRecord1,
 
         // compare segment data
 
-        for (uint32_t j = 0; j < p.second; j++)
+        for (uint32_t segLenItr = 0; segLenItr < p.second; segLenItr++)
         {
-            // if the segment data is different, then the locks is on a
-            // different resource so no conflict between the lock
-            // records.
-            // BMC is little endian, but the resourceID is formed by
-            // the Management Console in such a way that, the first byte
-            // from the MSB Position corresponds to the First Segment
-            // data. Therefore we need to convert the incoming
-            // resourceID into Big Endian before processing further.
-            if (!(checkByte(
-                    boost::endian::endian_reverse(std::get<3>(refLockRecord1)),
-                    boost::endian::endian_reverse(std::get<3>(refLockRecord2)),
-                    j)))
+            for (uint32_t segItr = segStartIndex;
+                 segItr < segStartIndex + p.second; segItr++)
             {
-                return false;
+                if (!(checkByte(boost::endian::endian_reverse(
+                                    std::get<3>(refLockRecord1)),
+                                boost::endian::endian_reverse(
+                                    std::get<3>(refLockRecord2)),
+                                segItr)))
+                {
+                    return false;
+                }
             }
+            segStartIndex = segStartIndex + p.second;
         }
 
         ++i;

--- a/include/ibm/locks.hpp
+++ b/include/ibm/locks.hpp
@@ -112,6 +112,9 @@ class Lock
 
     Lock()
     {
+        // Remove the persistent file
+        std::filesystem::remove(fileName);
+        lockTable.clear();
         transactionId = lockTable.empty() ? 0 : prev(lockTable.end())->first;
     }
 

--- a/include/ibm/management_console_rest.hpp
+++ b/include/ibm/management_console_rest.hpp
@@ -492,7 +492,8 @@ inline void
         }
         if (validityStatus.first && (validityStatus.second == 1))
         {
-            BMCWEB_LOG_ERROR << "There is a conflict within itself";
+            BMCWEB_LOG_ERROR
+                << "handleAcquireLockAPI: There is a conflict within itself";
             asyncResp->res.result(boost::beast::http::status::conflict);
             return;
         }
@@ -546,7 +547,8 @@ inline void
             }
         }
 
-        BMCWEB_LOG_ERROR << "There is a conflict with the lock table";
+        BMCWEB_LOG_ERROR
+            << "handleAcquireLockAPI: There is a conflict with the lock table";
 
         asyncResp->res.result(boost::beast::http::status::conflict);
         nlohmann::json returnJson;
@@ -614,7 +616,8 @@ inline void
     }
 
     // valid rid, but the current hmc does not own all the locks
-    BMCWEB_LOG_DEBUG << "Current HMC does not own all the locks";
+    BMCWEB_LOG_DEBUG
+        << "handleReleaseLockAPI: Current HMC does not own all the locks";
     asyncResp->res.result(boost::beast::http::status::unauthorized);
 
     auto var = statusRelease.second;

--- a/include/ibm/management_console_rest.hpp
+++ b/include/ibm/management_console_rest.hpp
@@ -478,7 +478,7 @@ inline void
 
     if (varAcquireLock.first)
     {
-        // Either validity failure of there is a conflict with itself
+        // Either validity failure or there is a conflict with itself
 
         auto validityStatus =
             std::get<std::pair<bool, int>>(varAcquireLock.second);
@@ -512,15 +512,48 @@ inline void
             asyncResp->res.jsonValue["TransactionID"] = var;
             return;
         }
-        BMCWEB_LOG_DEBUG << "There is a conflict with the lock table";
-        asyncResp->res.result(boost::beast::http::status::conflict);
+
+        // Check if the session is active. If active, send back the lock
+        // conflict, else clear the stale entry in the lock table.
         auto var =
             std::get<std::pair<uint32_t, LockRequest>>(conflictStatus.second);
+        std::string sessionId = std::get<0>(var.second);
+        auto session =
+            persistent_data::SessionStore::getInstance().getSessionByUid(
+                sessionId);
+
+        if (session == nullptr)
+        {
+            BMCWEB_LOG_ERROR << "Releasing lock of the session id(stale): "
+                             << sessionId;
+            // clear the stale entry
+            crow::ibm_mc_lock::Lock::getInstance().releaseLock(sessionId);
+
+            // create the new lock record for the session
+            varAcquireLock =
+                crow::ibm_mc_lock::Lock::getInstance().acquireLock(t);
+            conflictStatus =
+                std::get<crow::ibm_mc_lock::Rc>(varAcquireLock.second);
+            if (!conflictStatus.first)
+            {
+                asyncResp->res.result(boost::beast::http::status::ok);
+
+                auto var = std::get<uint32_t>(conflictStatus.second);
+                nlohmann::json returnJson;
+                returnJson["id"] = var;
+                asyncResp->res.jsonValue["TransactionID"] = var;
+                return;
+            }
+        }
+
+        BMCWEB_LOG_ERROR << "There is a conflict with the lock table";
+
+        asyncResp->res.result(boost::beast::http::status::conflict);
         nlohmann::json returnJson;
         nlohmann::json segments;
         nlohmann::json myarray = nlohmann::json::array();
         returnJson["TransactionID"] = var.first;
-        returnJson["SessionID"] = std::get<0>(var.second);
+        returnJson["SessionID"] = sessionId;
         returnJson["HMCID"] = std::get<1>(var.second);
         returnJson["LockType"] = std::get<2>(var.second);
         returnJson["ResourceID"] = std::get<3>(var.second);

--- a/include/ibm/management_console_rest.hpp
+++ b/include/ibm/management_console_rest.hpp
@@ -539,10 +539,10 @@ inline void
             {
                 asyncResp->res.result(boost::beast::http::status::ok);
 
-                auto var = std::get<uint32_t>(conflictStatus.second);
+                auto id = std::get<uint32_t>(conflictStatus.second);
                 nlohmann::json returnJson;
-                returnJson["id"] = var;
-                asyncResp->res.jsonValue["TransactionID"] = var;
+                returnJson["id"] = id;
+                asyncResp->res.jsonValue["TransactionID"] = id;
                 return;
             }
         }


### PR DESCRIPTION
This commit has changes to:
1. Avoid having stale entries in the lock table in BMC
2. Fix unnecessary lock conflicts due to seg length validation
3. Remove stale lock table entries of invalid sessionid