### PR TITLE
ReadOnly users should not have ssh (#408)

### DIFF
--- a/redfish-core/lib/account_service.hpp
+++ b/redfish-core/lib/account_service.hpp
@@ -1911,13 +1911,15 @@ inline void handleAccountCollectionPost(
             return;
         }
 
-        // Create (modified) modGroupsList from allGroupsList that
-        // does not contain the ipmi group.
+        // Create (modified) modGroupsList from allGroupsList.
+        // Remove the ipmi group.  Also Remove "ssh" if the new
+        // user is not an Administrator.
         std::vector<std::string> modGroupsList;
 
         for (const auto& group : allGroupsList)
         {
-            if (group != "ipmi")
+            if ((group != "ipmi") &&
+                ((group != "ssh") || (*roleId == "Administrator")))
             {
                 modGroupsList.push_back(group);
             }


### PR DESCRIPTION
* ReadOnly users should not have ssh

This changes the Redfish create new user API (POST /redfish/v1/AccountService/Accounts/) so only Administrator users will have the HostConsole AccountType value.  This is the same as the "ssh" phosphor privilege group.

Doing so prevents new ReadOnly users from using SSH port 2200.

Note that ReadOnly user created prior to this change will have the HostConsole AccountType privilege.  A BMC admin can PATCH a user's AccountTypes property to add or remove the Hostconsole value.

Tested: Yes

Signed-off-by: Joseph Reynolds <joseph-reynolds@charter.net>

* fixup code formatting

Tested: Compiles

Signed-off-by: Joseph Reynolds <joseph-reynolds@charter.net>