### PR TITLE
Revert "FFDC: Collect current in-memory sessions for BMC dump (#510)"

### DIFF
--- a/http/http_server.hpp
+++ b/http/http_server.hpp
@@ -19,9 +19,7 @@
 #include <memory>
 #include <utility>
 #include <vector>
-#ifdef BMCWEB_ENABLE_IBM_MANAGEMENT_CONSOLE
-#include <persistent_data.hpp>
-#endif
+
 namespace crow
 {
 
@@ -38,11 +36,7 @@ class Server
         acceptor(std::move(acceptorIn)),
         signals(*ioService, SIGINT, SIGTERM, SIGHUP), handler(handlerIn),
         adaptorCtx(std::move(adaptorCtxIn))
-    {
-#ifdef BMCWEB_ENABLE_IBM_MANAGEMENT_CONSOLE
-        signals.add(SIGUSR1);
-#endif
-    }
+    {}
 
     Server(Handler* handlerIn, const std::string& bindaddr, uint16_t port,
            const std::shared_ptr<boost::asio::ssl::context>& adaptorCtxIn,
@@ -154,16 +148,6 @@ class Server
                     }
                     this->startAsyncWaitForSignal();
                 }
-#ifdef BMCWEB_ENABLE_IBM_MANAGEMENT_CONSOLE
-                if (signalNo == SIGUSR1)
-                {
-                    BMCWEB_LOG_CRITICAL
-                        << "INFO: Receivied USR1 signal to dump latest session "
-                           "data for bmc dump";
-                    persistent_data::getConfig().writeCurrentSessionData();
-                    this->startAsyncWaitForSignal();
-                }
-#endif
                 else
                 {
                     stop();

--- a/include/persistent_data.hpp
+++ b/include/persistent_data.hpp
@@ -25,8 +25,6 @@ class ConfigFile
   public:
     // todo(ed) should read this from a fixed location somewhere, not CWD
     static constexpr const char* filename = "bmcweb_persistent_data.json";
-    static constexpr const char* dumpFilename =
-        "bmcweb_current_session_snapshot.json";
 
     ConfigFile()
     {
@@ -194,84 +192,6 @@ class ConfigFile
             writeData();
         }
     }
-
-#ifdef BMCWEB_ENABLE_IBM_MANAGEMENT_CONSOLE
-    void writeCurrentSessionData()
-    {
-        std::ofstream persistentFile(dumpFilename);
-        std::filesystem::perms permission =
-            std::filesystem::perms::owner_read |
-            std::filesystem::perms::owner_write |
-            std::filesystem::perms::group_read;
-        std::filesystem::permissions(filename, permission);
-        const auto& eventServiceConfig =
-            EventServiceStore::getInstance().getEventServiceConfig();
-        nlohmann::json data{
-            {"eventservice_config",
-             {{"ServiceEnabled", eventServiceConfig.enabled},
-              {"DeliveryRetryAttempts", eventServiceConfig.retryAttempts},
-              {"DeliveryRetryIntervalSeconds",
-               eventServiceConfig.retryTimeoutInterval}}
-
-            },
-            {"system_uuid", systemUuid},
-            {"revision", jsonRevision},
-            {"timeout", SessionStore::getInstance().getTimeoutInSeconds()}};
-
-        nlohmann::json& sessions = data["sessions"];
-        sessions = nlohmann::json::array();
-        for (const auto& p : SessionStore::getInstance().authTokens)
-        {
-            if (p.second->persistence !=
-                persistent_data::PersistenceType::SINGLE_REQUEST)
-            {
-                sessions.push_back({
-                    {"unique_id", p.second->uniqueId},
-                    {"username", p.second->username},
-                    {"client_ip", p.second->clientIp},
-                    {"client_id", p.second->clientId},
-                });
-            }
-        }
-
-        nlohmann::json& subscriptions = data["subscriptions"];
-        subscriptions = nlohmann::json::array();
-        for (const auto& it :
-             EventServiceStore::getInstance().subscriptionsConfigMap)
-        {
-            std::shared_ptr<UserSubscription> subValue = it.second;
-            if (subValue->subscriptionType == "SSE")
-            {
-                BMCWEB_LOG_DEBUG
-                    << "The subscription type is SSE, so skipping.";
-                continue;
-            }
-            nlohmann::json::object_t headers;
-            for (const boost::beast::http::fields::value_type& header :
-                 subValue->httpHeaders)
-            {
-                std::string name(header.name_string());
-                headers[std::move(name)] = header.value();
-            }
-
-            subscriptions.push_back({
-                {"Id", subValue->id},
-                {"Context", subValue->customText},
-                {"DeliveryRetryPolicy", subValue->retryPolicy},
-                {"Destination", subValue->destinationUrl},
-                {"EventFormatType", subValue->eventFormatType},
-                {"HttpHeaders", std::move(headers)},
-                {"MessageIds", subValue->registryMsgIds},
-                {"Protocol", subValue->protocol},
-                {"RegistryPrefixes", subValue->registryPrefixes},
-                {"ResourceTypes", subValue->resourceTypes},
-                {"SubscriptionType", subValue->subscriptionType},
-                {"MetricReportDefinitions", subValue->metricReportDefinitions},
-            });
-        }
-        persistentFile << data;
-    }
-#endif
 
     void writeData()
     {


### PR DESCRIPTION
See https://ibm-systems-power.slack.com/archives/C04KG79NAUA/p1674682450639329?thread_ts=1674607010.347749&cid=C04KG79NAUA

bmcweb bump is failing. The failure is:
 In file included from ../git/http/http_server.hpp:23,
|                  from ../git/http/app.hpp:5,
|                  from ../git/src/webserver_main.cpp:4:
| ../git/include/persistent_data.hpp: In member function 'void
persistent_data::ConfigFile::writeCurrentSessionData()':
| ../git/include/persistent_data.hpp:228:35: error: no matching function
for call to
'nlohmann::json_abi_v3_11_2::basic_json<>::push_back(<brace-enclosed
initializer list>)'
|   228 |                 sessions.push_back({
|       |                 ~~~~~~~~~~~~~~~~~~^~
|   229 |                     {"unique_id", p.second->uniqueId},
|       |                     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
|   230 |                     {"username", p.second->username},
|       |                     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
|   231 |                     {"client_ip", p.second->clientIp},
|       |                     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
|   232 |                     {"client_id", p.second->clientId},
|       |                     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
|   233 |                 });
|       |                 ~~
| In file included from ../git/http/http_response.hpp:3,

510 can be resubmitted.

This reverts commit 9c8f72077191ec5632f43d0f172eaa81b9df925f.