### PR TITLE
Fix sessions json object compilation errors

### DIFF
--- a/include/persistent_data.hpp
+++ b/include/persistent_data.hpp
@@ -225,12 +225,17 @@ class ConfigFile
             if (p.second->persistence !=
                 persistent_data::PersistenceType::SINGLE_REQUEST)
             {
-                sessions.push_back({
-                    {"unique_id", p.second->uniqueId},
-                    {"username", p.second->username},
-                    {"client_ip", p.second->clientIp},
-                    {"client_id", p.second->clientId},
-                });
+                nlohmann::json::object_t session;
+                session["unique_id"] = p.second->uniqueId;
+                session["session_token"] = p.second->sessionToken;
+                session["username"] = p.second->username;
+                session["csrf_token"] = p.second->csrfToken;
+                session["client_ip"] = p.second->clientIp;
+                if (p.second->clientId)
+                {
+                    session["client_id"] = *p.second->clientId;
+                }
+                sessions.push_back(std::move(session));
             }
         }
 


### PR DESCRIPTION
This commit fix compilation error which was hit due to new json infra changes from upstream

bmcweb/include/persistent_data.hpp:228:35: error: no matching function for call to 'nlohmann::json_abi_v3_11_2::basic_json<>::push_back(<brace-enclosed initializer list>)'
