### PR TITLE
Fix redfish validator errors

### DIFF
--- a/redfish-core/lib/chassis.hpp
+++ b/redfish-core/lib/chassis.hpp
@@ -149,8 +149,7 @@ inline void handleChassisCollectionGet(
 
     collection_util::getCollectionMembers(
         asyncResp, boost::urls::url("/redfish/v1/Chassis"),
-        {"xyz.openbmc_project.Inventory.Item.Board",
-         "xyz.openbmc_project.Inventory.Item.Chassis"});
+        {"xyz.openbmc_project.Inventory.Item.Chassis"});
 }
 
 /**
@@ -215,8 +214,7 @@ inline void
     {
         return;
     }
-    const std::array<const char*, 2> interfaces = {
-        "xyz.openbmc_project.Inventory.Item.Board",
+    const std::array<const char*, 1> interfaces = {
         "xyz.openbmc_project.Inventory.Item.Chassis"};
 
     crow::connections::systemBus->async_method_call(
@@ -523,8 +521,7 @@ inline void
             "299 - \"IndicatorLED is deprecated. Use LocationIndicatorActive instead.\"");
     }
 
-    const std::array<const char*, 2> interfaces = {
-        "xyz.openbmc_project.Inventory.Item.Board",
+    const std::array<const char*, 1> interfaces = {
         "xyz.openbmc_project.Inventory.Item.Chassis"};
 
     const std::string& chassisId = param;

--- a/redfish-core/lib/roles.hpp
+++ b/redfish-core/lib/roles.hpp
@@ -123,7 +123,7 @@ inline void requestRoutesRoles(App& app)
             return;
         }
 
-        asyncResp->res.jsonValue["@odata.type"] = "#Role.v1_2_2.Role";
+        asyncResp->res.jsonValue["@odata.type"] = "#Role.v1_3_0.Role";
         asyncResp->res.jsonValue["Name"] = "User Role";
         asyncResp->res.jsonValue["Description"] = roleId + " User Role";
         asyncResp->res.jsonValue["OemPrivileges"] = std::move(oemPrivArray);


### PR DESCRIPTION
Change 1) pull in https://github.com/ibm-openbmc/bmcweb/commit/26c886543e0d33bccf26c4b11156d09b5a3eedd9. This fixes 4 validator errors `ERROR - Restricted not defined in schema Role.v1_2_2 (check version, spelling and casing)`
Change 2) Redfish chassis: Only return Inventory.Item.Chassis

Part of https://github.com/ibm-openbmc/bmcweb/commit/f300f37d4dcde1f476459d18962f7ff2552ed8b3

Want it now so the validator doesn't fail. The assemblies can come later. Fixes 3 validator errors, that 2nd board Tola_Board goes away 

Tested: no longer see these validator errors 