### PR TITLE
Redfish OEM Update Command for Concurrent Update (#141)

### DIFF
--- a/redfish-core/include/redfish.hpp
+++ b/redfish-core/include/redfish.hpp
@@ -114,6 +114,7 @@ class RedfishService
 #ifdef BMCWEB_INSECURE_ENABLE_REDFISH_FW_TFTP_UPDATE
         requestRoutesUpdateServiceActionsSimpleUpdate(app);
 #endif
+        requestRoutesUpdateServiceActionsOemConcurrentUpdate(app);
         requestRoutesSoftwareInventoryCollection(app);
         requestRoutesSoftwareInventory(app);
 

--- a/scripts/update_schemas.py
+++ b/scripts/update_schemas.py
@@ -416,6 +416,18 @@ with open(metadata_index_path, "w") as metadata_index:
     )
     metadata_index.write("    </edmx:Reference>\n")
 
+    metadata_index.write(
+        '    <edmx:Reference Uri="'
+        '/redfish/v1/schema/OemUpdateService_v1.xml">\n'
+    )
+    metadata_index.write(
+        '        <edmx:Include Namespace="OemUpdateService"/>\n'
+    )
+    metadata_index.write(
+        '        <edmx:Include Namespace="OemUpdateService.v1_0_0"/>\n'
+    )
+    metadata_index.write("    </edmx:Reference>\n")
+
     metadata_index.write("</edmx:Edmx>\n")
 
 

--- a/static/redfish/v1/$metadata/index.xml
+++ b/static/redfish/v1/$metadata/index.xml
@@ -2854,4 +2854,8 @@
         <edmx:Include Namespace="OemChassis"/>
         <edmx:Include Namespace="OemChassis.v1_0_0"/>
     </edmx:Reference>
+    <edmx:Reference Uri="/redfish/v1/schema/OemUpdateService_v1.xml">
+        <edmx:Include Namespace="OemUpdateService"/>
+        <edmx:Include Namespace="OemUpdateService.v1_0_0"/>
+    </edmx:Reference>
 </edmx:Edmx>

--- a/static/redfish/v1/JsonSchemas/OemUpdateService/index.json
+++ b/static/redfish/v1/JsonSchemas/OemUpdateService/index.json
@@ -1,0 +1,41 @@
+{
+    "$id": "http://redfish.dmtf.org/schemas/v1/OemUpdateService.v1_0_0.json",
+    "$schema": "http://redfish.dmtf.org/schemas/v1/redfish-schema-v1.json",
+    "copyright": "Copyright 2014-2019 DMTF. For the full DMTF copyright policy, see http://www.dmtf.org/about/policies/copyright",
+    "definitions": {
+        "ConcurrentUpdate": {
+            "additionalProperties": false,
+            "description": "This object concurrently updates software components",
+            "parameters": {},
+            "patternProperties": {
+                "^([a-zA-Z_][a-zA-Z0-9_]*)?@(odata|Redfish|Message)\\.[a-zA-Z_][a-zA-Z0-9_]*$": {
+                    "description": "This property shall specify a valid odata or Redfish property.",
+                    "type": [
+                        "array",
+                        "boolean",
+                        "integer",
+                        "number",
+                        "null",
+                        "object",
+                        "string"
+                    ]
+                }
+            },
+            "properties": {
+                "target": {
+                    "description": "Link to invoke action",
+                    "format": "uri-reference",
+                    "type": "string"
+                },
+                "title": {
+                    "description": "Friendly action name",
+                    "type": "string"
+                }
+            },
+            "type": "object"
+        }
+    },
+    "OwningEntity": "OpenBMC",
+    "release": "1.0",
+    "title": "#OemUpdateService.v1_0_0"
+}

--- a/static/redfish/v1/schema/OemUpdateService_v1.xml
+++ b/static/redfish/v1/schema/OemUpdateService_v1.xml
@@ -1,0 +1,29 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<edmx:Edmx xmlns:edmx="http://docs.oasis-open.org/odata/ns/edmx" Version="4.0">
+    <edmx:Reference Uri="http://docs.oasis-open.org/odata/odata/v4.0/errata03/csd01/complete/vocabularies/Org.OData.Core.V1.xml">
+        <edmx:Include Namespace="Org.OData.Core.V1" Alias="OData"/>
+    </edmx:Reference>
+    <edmx:Reference Uri="http://redfish.dmtf.org/schemas/v1/UpdateService_v1.xml">
+        <edmx:Include Namespace="UpdateService"/>
+        <edmx:Include Namespace="UpdateService.v1_0_0"/>
+    </edmx:Reference>
+    <edmx:Reference Uri="http://redfish.dmtf.org/schemas/v1/RedfishExtensions_v1.xml">
+        <edmx:Include Namespace="RedfishExtensions.v1_0_0" Alias="Redfish"/>
+    </edmx:Reference>
+
+    <edmx:DataServices>
+
+        <Schema xmlns="http://docs.oasis-open.org/odata/ns/edm" Namespace="OemUpdateService">
+            <Annotation Term="Redfish.OwningEntity" String="IBM"/>
+        </Schema>
+
+        <Schema xmlns="http://docs.oasis-open.org/odata/ns/edm" Namespace="OemUpdateService.v1_0_0">
+            <Action Name="ConcurrentUpdate" IsBound="true">
+                <Annotation Term="OData.Description" String="This action concurrently updates firmware."/>
+                <Annotation Term="OData.LongDescription" String="This action concurrently updates firmware, synchronizing the host and bmc."/>
+                <Parameter Name="UpdateService" Type="UpdateService.v1_0_0.OemActions"/>
+            </Action>
+        </Schema>
+
+    </edmx:DataServices>
+</edmx:Edmx>


### PR DESCRIPTION
This commit adds a new update command to be used by the management console to perform concurrent updates. It works like the current update command, but with added support for the OnReset apply time setting.

Tested: Ensured that redfish command updates as usual and updates still occurred while the ApplyTime was in the OnReset state.