### PR TITLE
Populate BMC state based on state manager property

### DIFF
--- a/redfish-core/lib/managers.hpp
+++ b/redfish-core/lib/managers.hpp
@@ -1941,6 +1941,57 @@ inline void setDateTime(std::shared_ptr<bmcweb::AsyncResp> aResp,
     }
 }
 
+inline void getBMCState(const std::shared_ptr<bmcweb::AsyncResp>& aResp)
+{
+    aResp->res.jsonValue["PowerState"] = "On";
+    sdbusplus::asio::getProperty<std::string>(
+        *crow::connections::systemBus, "xyz.openbmc_project.State.BMC",
+        "/xyz/openbmc_project/state/bmc0", "xyz.openbmc_project.State.BMC",
+        "CurrentBMCState",
+        [aResp](const boost::system::error_code ec,
+                const std::string& bmcState) {
+        if (ec)
+        {
+            BMCWEB_LOG_DEBUG << "DBUS response error for "
+                                "Location";
+            aResp->res.jsonValue["Status"]["State"] = "Enabled";
+            aResp->res.jsonValue["Status"]["Health"] = "OK";
+            return;
+        }
+
+        if (bmcState == "xyz.openbmc_project.State.BMC.BMCState.Ready")
+        {
+            aResp->res.jsonValue["Status"]["State"] = "Enabled";
+            aResp->res.jsonValue["Status"]["Health"] = "OK";
+        }
+        else if (bmcState == "xyz.openbmc_project.State.BMC.BMCState."
+                             "Quiesced")
+        {
+            aResp->res.jsonValue["Status"]["State"] = "Quiesced";
+            aResp->res.jsonValue["Status"]["Health"] = "Critical";
+        }
+        else if (bmcState == "xyz.openbmc_project.State.BMC.BMCState."
+                             "NotReady")
+        {
+            aResp->res.jsonValue["Status"]["State"] = "Starting";
+            aResp->res.jsonValue["Status"]["Health"] = "OK";
+        }
+        else if (bmcState == "xyz.openbmc_project.State.BMC.BMCState."
+                             "UpdateInProgress")
+        {
+            aResp->res.jsonValue["Status"]["State"] = "Updating";
+            aResp->res.jsonValue["Status"]["Health"] = "OK";
+        }
+        else
+        {
+            BMCWEB_LOG_DEBUG << "Unsupported D-Bus CurrentBMCState "
+                             << bmcState;
+            aResp->res.jsonValue["Status"]["State"] = "Enabled";
+            aResp->res.jsonValue["Status"]["Health"] = "OK";
+        }
+        });
+}
+
 inline void requestRoutesManager(App& app)
 {
     std::string uuid = persistent_data::getConfig().systemUuid;
@@ -1960,10 +2011,7 @@ inline void requestRoutesManager(App& app)
         asyncResp->res.jsonValue["Name"] = "OpenBmc Manager";
         asyncResp->res.jsonValue["Description"] =
             "Baseboard Management Controller";
-        asyncResp->res.jsonValue["PowerState"] = "On";
-        asyncResp->res.jsonValue["Status"]["State"] = "Enabled";
-        asyncResp->res.jsonValue["Status"]["Health"] = "OK";
-
+        getBMCState(asyncResp);
         asyncResp->res.jsonValue["ManagerType"] = "BMC";
         asyncResp->res.jsonValue["UUID"] = systemd_utils::getUuid();
         asyncResp->res.jsonValue["ServiceEntryPointUUID"] = uuid;
@@ -2076,30 +2124,6 @@ inline void requestRoutesManager(App& app)
             aRsp->res.jsonValue["Links"]["ManagerInChassis"]["@odata.id"] =
                 "/redfish/v1/Chassis/" + chassisId;
         });
-
-        static bool started = false;
-
-        if (!started)
-        {
-            sdbusplus::asio::getProperty<double>(
-                *crow::connections::systemBus, "org.freedesktop.systemd1",
-                "/org/freedesktop/systemd1", "org.freedesktop.systemd1.Manager",
-                "Progress",
-                [asyncResp](const boost::system::error_code ec,
-                            const double& val) {
-                if (ec)
-                {
-                    BMCWEB_LOG_ERROR << "Error while getting progress";
-                    messages::internalError(asyncResp->res);
-                    return;
-                }
-                if (val < 1.0)
-                {
-                    asyncResp->res.jsonValue["Status"]["State"] = "Starting";
-                    started = true;
-                }
-                });
-        }
 
         crow::connections::systemBus->async_method_call(
             [asyncResp](


### PR DESCRIPTION
The "Status" of the BMC has been historically fairly simple. If the BMC is at the point where it can respond to the Redfish call then it's "OK" and it's "On". Its "Status" could be derived based on the startup systemd target, multi-user.target, as either "Starting" or "Enabled".

However, with the introduction of new BMC states it is no longer this simple. The following design introduced a new "Quiesced" state for the BMC:
https://github.com/openbmc/docs/blob/master/designs/bmc-service-failure-debug-and-recovery.md

There has was also a new BMC state introduced, "UpdateInProgress", which indicates the BMC is in the middle of a firmware update.

These new BMC states require additional logic when responding to Redfish queries for the BMC "Status".

When a BMC is in a "Quiesced" state it is an indication that a critical BMC service has entered the failed state. It is important for BMC clients to be aware of this state to take the needed steps to service the system. For example, on IBM systems, this will trigger a call home event to IBM service. The undefined aspect of this state is what makes it so critical to get serviced.

bmcweb has a precedent of abstracting systemd states behind services like x86-power-control/phosphor-state-manager. It can see it in functions like getHostState() and getChassisState(). bmcweb could contain all of the logic to determine if the BMC is being updated or has a failed critical service but that:
  a) Adds a lot more code to bmcweb and
  b) Goes away from our design of allowing other repositories to
     abstract away the complexity of these states.

Tested:
- GET /redfish/v1/Managers/bmc for different BMC states
- Redfish Validator passed

Signed-off-by: Ravi Teja <raviteja28031990@gmail.com>
Change-Id: I8ceafb7036f41678516ebda3dce5200221bba947