### PR TITLE
enable error traces in bmcweb

### DIFF
--- a/http/logging.hpp
+++ b/http/logging.hpp
@@ -45,20 +45,16 @@ class Logger
            [[maybe_unused]] const size_t line, LogLevel levelIn) :
         level(levelIn)
     {
-#ifdef BMCWEB_ENABLE_LOGGING
         stringstream << "(" << timestamp() << ") [" << prefix << " "
                      << std::filesystem::path(filename).filename() << ":"
                      << line << "] ";
-#endif
     }
     ~Logger()
     {
         if (level >= getCurrentLogLevel())
         {
-#ifdef BMCWEB_ENABLE_LOGGING
             stringstream << std::endl;
             std::cerr << stringstream.str();
-#endif
         }
     }
 
@@ -73,13 +69,11 @@ class Logger
     {
         if (level >= getCurrentLogLevel())
         {
-#ifdef BMCWEB_ENABLE_LOGGING
             // Somewhere in the code we're implicitly casting an array to a
             // pointer in logging code.  It's non-trivial to find, so disable
             // the check here for now
             // NOLINTNEXTLINE(cppcoreguidelines-pro-bounds-array-to-pointer-decay)
             stringstream << value;
-#endif
         }
         return *this;
     }

--- a/src/webserver_main.cpp
+++ b/src/webserver_main.cpp
@@ -64,7 +64,13 @@ inline void setupSocket(crow::App& app)
 
 static int run()
 {
+    // If user has enabled logging, set level at debug so we get everything
+#ifdef BMCWEB_ENABLE_LOGGING
     crow::Logger::setLogLevel(crow::LogLevel::Debug);
+#else
+    // otherwise just enable the error logging
+    crow::Logger::setLogLevel(crow::LogLevel::Error);
+#endif
 
     auto io = std::make_shared<boost::asio::io_context>();
     App app(io);


### PR DESCRIPTION
In order to be able to more easily debug bmcweb related issue, lets enable error traces by default. So by default all Error and Critical level traces are now written to the journal. If the dev enables the bmcweb-logging feature then they will get all levels of trace.

There are some error traces periodically being written to the journal which do not appear to be errors (since all is working fine). The next commit will change the level of these logs.

Testing:
- Verified only the error and critical logs were displayed

Signed-off-by: Andrew Geissler <geissonator@yahoo.com>