### PR TITLE
redfish: remove ForceRestart from AllowableValues

### DIFF
--- a/redfish-core/lib/systems.hpp
+++ b/redfish-core/lib/systems.hpp
@@ -2190,12 +2190,6 @@ inline void requestRoutesSystemActionsReset(App& app)
             command = "xyz.openbmc_project.State.Chassis.Transition.Off";
             hostCommand = false;
         }
-        else if (resetType == "ForceRestart")
-        {
-            command =
-                "xyz.openbmc_project.State.Host.Transition.ForceWarmReboot";
-            hostCommand = true;
-        }
         else if (resetType == "GracefulShutdown")
         {
             command = "xyz.openbmc_project.State.Host.Transition.Off";
@@ -2620,7 +2614,6 @@ inline void requestRoutesSystemResetActionInfo(App& app)
         allowableValues.emplace_back("On");
         allowableValues.emplace_back("ForceOff");
         allowableValues.emplace_back("ForceOn");
-        allowableValues.emplace_back("ForceRestart");
         allowableValues.emplace_back("GracefulRestart");
         allowableValues.emplace_back("GracefulShutdown");
         allowableValues.emplace_back("PowerCycle");


### PR DESCRIPTION
Per recent internal team discussions, IBM will be disabling the
ForceRestart ResetType option. This is because the hypervisor firmware
on IBM based systems requires host reboots to always be graceful to
ensure certain BIOS settings are correctly set.

Tested:
curl -k -H "X-Auth-Token: $token" -X GET https://${bmc}/redfish/v1/Systems/system/ResetActionInfo {
  "@odata.id": "/redfish/v1/Systems/system/ResetActionInfo",
  "@odata.type": "#ActionInfo.v1_1_2.ActionInfo",
  "Id": "ResetActionInfo",
  "Name": "Reset Action Info",
  "Parameters": [
    {
      "AllowableValues": [
        "On",
        "ForceOff",
        "ForceOn",
        "GracefulRestart",
        "GracefulShutdown",
        "PowerCycle",
        "Nmi"
      ],
      "DataType": "String",
      "Name": "ResetType",
      "Required": true
    }
  ]
}

Signed-off-by: Andrew Geissler <geissonator@yahoo.com>