### PR TITLE
WIP: Remove InternalErrors on usbCodeUpdate GET

### DIFF
--- a/redfish-core/lib/oem/ibm/usb_code_update.hpp
+++ b/redfish-core/lib/oem/ibm/usb_code_update.hpp
@@ -92,7 +92,6 @@ inline void
                 if (ec)
                 {
                     BMCWEB_LOG_ERROR << "DBUS response error " << ec;
-                    messages::internalError(aResp->res);
                     return;
                 }
 
@@ -102,7 +101,6 @@ inline void
                 if (!usbCodeUpdateStatePtr)
                 {
                     BMCWEB_LOG_ERROR << "Can't get USB code update status!";
-                    messages::internalError(aResp->res);
                     return;
                 }
                 aResp->res.jsonValue["Oem"]["IBM"]["@odata.type"] =


### PR DESCRIPTION
Needs to go into 1020 and 1040. This code hasn't been brought into 1050 yet, so will intercept it then. 

usbCodeUpdate isn't a critical service, if it fails, just leave its properties off the response. Have a defect where on the 45th code update where we think usbCodeUpdate didn't respond (we don't have the journal so don't know more) and that caused bmcweb to return an internalError here. This internalError led to the HMC putting the BMC in No Connection. Yeah, this seems kind of fragile.. But this service isn't important so don't let it impact operations.

See https://jazz07.rchland.ibm.com:13443/jazz/web/projects/CSSD#action=com.ibm.team.workitem.viewWorkItem&id=401222 for more info 

This goes beyond https://github.com/ibm-openbmc/bmcweb/pull/258 which did this for 1 case of the usbCodeUpdate app. 

Tested: None.

Signed-off-by: Gunnar Mills <gmills@us.ibm.com>