### PR TITLE
Update ServiceAgent role Description (#366)

### DIFF
--- a/redfish-core/lib/roles.hpp
+++ b/redfish-core/lib/roles.hpp
@@ -125,7 +125,6 @@ inline void requestRoutesRoles(App& app)
 
         asyncResp->res.jsonValue["@odata.type"] = "#Role.v1_3_0.Role";
         asyncResp->res.jsonValue["Name"] = "User Role";
-        asyncResp->res.jsonValue["Description"] = roleId + " User Role";
         asyncResp->res.jsonValue["OemPrivileges"] = std::move(oemPrivArray);
         asyncResp->res.jsonValue["IsPredefined"] = true;
         asyncResp->res.jsonValue["Id"] = roleId;
@@ -134,6 +133,14 @@ inline void requestRoutesRoles(App& app)
             "/redfish/v1/AccountService/Roles/" + roleId;
         asyncResp->res.jsonValue["AssignedPrivileges"] = std::move(privArray);
         asyncResp->res.jsonValue["Restricted"] = isRestrictedRole(roleId);
+            
+        if (roleId == "OemIBMServiceAgent")
+        {
+            asyncResp->res.jsonValue["Description"] = "ServiceAgent";
+        }
+        else
+        {
+            asyncResp->res.jsonValue["Description"] = roleId;
         });
 }
 

--- a/redfish-core/lib/roles.hpp
+++ b/redfish-core/lib/roles.hpp
@@ -133,7 +133,7 @@ inline void requestRoutesRoles(App& app)
             "/redfish/v1/AccountService/Roles/" + roleId;
         asyncResp->res.jsonValue["AssignedPrivileges"] = std::move(privArray);
         asyncResp->res.jsonValue["Restricted"] = isRestrictedRole(roleId);
-            
+
         if (roleId == "OemIBMServiceAgent")
         {
             asyncResp->res.jsonValue["Description"] = "ServiceAgent";
@@ -146,51 +146,52 @@ inline void requestRoutesRoles(App& app)
 
 inline void requestRoutesRoleCollection(App& app)
 {
-    BMCWEB_ROUTE(app, "/redfish/v1/AccountService/Roles/")
-        .privileges(redfish::privileges::getRoleCollection)
-        .methods(boost::beast::http::verb::get)(
-            [&app](const crow::Request& req,
-                   const std::shared_ptr<bmcweb::AsyncResp>& asyncResp) {
-        if (!redfish::setUpRedfishRoute(app, req, asyncResp))
-        {
-            return;
-        }
-
-        asyncResp->res.jsonValue["@odata.id"] =
-            "/redfish/v1/AccountService/Roles";
-        asyncResp->res.jsonValue["@odata.type"] =
-            "#RoleCollection.RoleCollection";
-        asyncResp->res.jsonValue["Name"] = "Roles Collection";
-        asyncResp->res.jsonValue["Description"] = "BMC User Roles";
-
-        sdbusplus::asio::getProperty<std::vector<std::string>>(
-            *crow::connections::systemBus, "xyz.openbmc_project.User.Manager",
-            "/xyz/openbmc_project/user", "xyz.openbmc_project.User.Manager",
-            "AllPrivileges",
-            [asyncResp](const boost::system::error_code ec,
-                        const std::vector<std::string>& privList) {
-            if (ec)
+        BMCWEB_ROUTE(app, "/redfish/v1/AccountService/Roles/")
+            .privileges(redfish::privileges::getRoleCollection)
+            .methods(boost::beast::http::verb::get)(
+                [&app](const crow::Request& req,
+                       const std::shared_ptr<bmcweb::AsyncResp>& asyncResp) {
+            if (!redfish::setUpRedfishRoute(app, req, asyncResp))
             {
-                messages::internalError(asyncResp->res);
                 return;
             }
-            nlohmann::json& memberArray = asyncResp->res.jsonValue["Members"];
-            memberArray = nlohmann::json::array();
-            for (const std::string& priv : privList)
-            {
-                std::string role = getRoleFromPrivileges(priv);
-                if (!role.empty())
+
+            asyncResp->res.jsonValue["@odata.id"] =
+                "/redfish/v1/AccountService/Roles";
+            asyncResp->res.jsonValue["@odata.type"] =
+                "#RoleCollection.RoleCollection";
+            asyncResp->res.jsonValue["Name"] = "Roles Collection";
+            asyncResp->res.jsonValue["Description"] = "BMC User Roles";
+
+            sdbusplus::asio::getProperty<std::vector<std::string>>(
+                *crow::connections::systemBus,
+                "xyz.openbmc_project.User.Manager", "/xyz/openbmc_project/user",
+                "xyz.openbmc_project.User.Manager", "AllPrivileges",
+                [asyncResp](const boost::system::error_code ec,
+                            const std::vector<std::string>& privList) {
+                if (ec)
                 {
-                    nlohmann::json::object_t member;
-                    member["@odata.id"] =
-                        "/redfish/v1/AccountService/Roles/" + role;
-                    memberArray.push_back(std::move(member));
+                    messages::internalError(asyncResp->res);
+                    return;
                 }
-            }
-            asyncResp->res.jsonValue["Members@odata.count"] =
-                memberArray.size();
+                nlohmann::json& memberArray =
+                    asyncResp->res.jsonValue["Members"];
+                memberArray = nlohmann::json::array();
+                for (const std::string& priv : privList)
+                {
+                    std::string role = getRoleFromPrivileges(priv);
+                    if (!role.empty())
+                    {
+                        nlohmann::json::object_t member;
+                        member["@odata.id"] =
+                            "/redfish/v1/AccountService/Roles/" + role;
+                        memberArray.push_back(std::move(member));
+                    }
+                }
+                asyncResp->res.jsonValue["Members@odata.count"] =
+                    memberArray.size();
+                });
             });
-        });
 }
 
 } // namespace redfish

--- a/redfish-core/lib/roles.hpp
+++ b/redfish-core/lib/roles.hpp
@@ -133,7 +133,7 @@ inline void requestRoutesRoles(App& app)
             "/redfish/v1/AccountService/Roles/" + roleId;
         asyncResp->res.jsonValue["AssignedPrivileges"] = std::move(privArray);
         asyncResp->res.jsonValue["Restricted"] = isRestrictedRole(roleId);
-
+            
         if (roleId == "OemIBMServiceAgent")
         {
             asyncResp->res.jsonValue["Description"] = "ServiceAgent";
@@ -146,52 +146,51 @@ inline void requestRoutesRoles(App& app)
 
 inline void requestRoutesRoleCollection(App& app)
 {
-        BMCWEB_ROUTE(app, "/redfish/v1/AccountService/Roles/")
-            .privileges(redfish::privileges::getRoleCollection)
-            .methods(boost::beast::http::verb::get)(
-                [&app](const crow::Request& req,
-                       const std::shared_ptr<bmcweb::AsyncResp>& asyncResp) {
-            if (!redfish::setUpRedfishRoute(app, req, asyncResp))
+    BMCWEB_ROUTE(app, "/redfish/v1/AccountService/Roles/")
+        .privileges(redfish::privileges::getRoleCollection)
+        .methods(boost::beast::http::verb::get)(
+            [&app](const crow::Request& req,
+                   const std::shared_ptr<bmcweb::AsyncResp>& asyncResp) {
+        if (!redfish::setUpRedfishRoute(app, req, asyncResp))
+        {
+            return;
+        }
+
+        asyncResp->res.jsonValue["@odata.id"] =
+            "/redfish/v1/AccountService/Roles";
+        asyncResp->res.jsonValue["@odata.type"] =
+            "#RoleCollection.RoleCollection";
+        asyncResp->res.jsonValue["Name"] = "Roles Collection";
+        asyncResp->res.jsonValue["Description"] = "BMC User Roles";
+
+        sdbusplus::asio::getProperty<std::vector<std::string>>(
+            *crow::connections::systemBus, "xyz.openbmc_project.User.Manager",
+            "/xyz/openbmc_project/user", "xyz.openbmc_project.User.Manager",
+            "AllPrivileges",
+            [asyncResp](const boost::system::error_code ec,
+                        const std::vector<std::string>& privList) {
+            if (ec)
             {
+                messages::internalError(asyncResp->res);
                 return;
             }
-
-            asyncResp->res.jsonValue["@odata.id"] =
-                "/redfish/v1/AccountService/Roles";
-            asyncResp->res.jsonValue["@odata.type"] =
-                "#RoleCollection.RoleCollection";
-            asyncResp->res.jsonValue["Name"] = "Roles Collection";
-            asyncResp->res.jsonValue["Description"] = "BMC User Roles";
-
-            sdbusplus::asio::getProperty<std::vector<std::string>>(
-                *crow::connections::systemBus,
-                "xyz.openbmc_project.User.Manager", "/xyz/openbmc_project/user",
-                "xyz.openbmc_project.User.Manager", "AllPrivileges",
-                [asyncResp](const boost::system::error_code ec,
-                            const std::vector<std::string>& privList) {
-                if (ec)
+            nlohmann::json& memberArray = asyncResp->res.jsonValue["Members"];
+            memberArray = nlohmann::json::array();
+            for (const std::string& priv : privList)
+            {
+                std::string role = getRoleFromPrivileges(priv);
+                if (!role.empty())
                 {
-                    messages::internalError(asyncResp->res);
-                    return;
+                    nlohmann::json::object_t member;
+                    member["@odata.id"] =
+                        "/redfish/v1/AccountService/Roles/" + role;
+                    memberArray.push_back(std::move(member));
                 }
-                nlohmann::json& memberArray =
-                    asyncResp->res.jsonValue["Members"];
-                memberArray = nlohmann::json::array();
-                for (const std::string& priv : privList)
-                {
-                    std::string role = getRoleFromPrivileges(priv);
-                    if (!role.empty())
-                    {
-                        nlohmann::json::object_t member;
-                        member["@odata.id"] =
-                            "/redfish/v1/AccountService/Roles/" + role;
-                        memberArray.push_back(std::move(member));
-                    }
-                }
-                asyncResp->res.jsonValue["Members@odata.count"] =
-                    memberArray.size();
-                });
+            }
+            asyncResp->res.jsonValue["Members@odata.count"] =
+                memberArray.size();
             });
+        });
 }
 
 } // namespace redfish

--- a/redfish-core/lib/roles.hpp
+++ b/redfish-core/lib/roles.hpp
@@ -133,7 +133,7 @@ inline void requestRoutesRoles(App& app)
             "/redfish/v1/AccountService/Roles/" + roleId;
         asyncResp->res.jsonValue["AssignedPrivileges"] = std::move(privArray);
         asyncResp->res.jsonValue["Restricted"] = isRestrictedRole(roleId);
-            
+
         if (roleId == "OemIBMServiceAgent")
         {
             asyncResp->res.jsonValue["Description"] = "ServiceAgent";
@@ -141,56 +141,58 @@ inline void requestRoutesRoles(App& app)
         else
         {
             asyncResp->res.jsonValue["Description"] = roleId;
-        });
+        }
+    });
 }
 
 inline void requestRoutesRoleCollection(App& app)
 {
-    BMCWEB_ROUTE(app, "/redfish/v1/AccountService/Roles/")
-        .privileges(redfish::privileges::getRoleCollection)
-        .methods(boost::beast::http::verb::get)(
-            [&app](const crow::Request& req,
-                   const std::shared_ptr<bmcweb::AsyncResp>& asyncResp) {
-        if (!redfish::setUpRedfishRoute(app, req, asyncResp))
-        {
-            return;
-        }
-
-        asyncResp->res.jsonValue["@odata.id"] =
-            "/redfish/v1/AccountService/Roles";
-        asyncResp->res.jsonValue["@odata.type"] =
-            "#RoleCollection.RoleCollection";
-        asyncResp->res.jsonValue["Name"] = "Roles Collection";
-        asyncResp->res.jsonValue["Description"] = "BMC User Roles";
-
-        sdbusplus::asio::getProperty<std::vector<std::string>>(
-            *crow::connections::systemBus, "xyz.openbmc_project.User.Manager",
-            "/xyz/openbmc_project/user", "xyz.openbmc_project.User.Manager",
-            "AllPrivileges",
-            [asyncResp](const boost::system::error_code ec,
-                        const std::vector<std::string>& privList) {
-            if (ec)
+        BMCWEB_ROUTE(app, "/redfish/v1/AccountService/Roles/")
+            .privileges(redfish::privileges::getRoleCollection)
+            .methods(boost::beast::http::verb::get)(
+                [&app](const crow::Request& req,
+                       const std::shared_ptr<bmcweb::AsyncResp>& asyncResp) {
+            if (!redfish::setUpRedfishRoute(app, req, asyncResp))
             {
-                messages::internalError(asyncResp->res);
                 return;
             }
-            nlohmann::json& memberArray = asyncResp->res.jsonValue["Members"];
-            memberArray = nlohmann::json::array();
-            for (const std::string& priv : privList)
-            {
-                std::string role = getRoleFromPrivileges(priv);
-                if (!role.empty())
+
+            asyncResp->res.jsonValue["@odata.id"] =
+                "/redfish/v1/AccountService/Roles";
+            asyncResp->res.jsonValue["@odata.type"] =
+                "#RoleCollection.RoleCollection";
+            asyncResp->res.jsonValue["Name"] = "Roles Collection";
+            asyncResp->res.jsonValue["Description"] = "BMC User Roles";
+
+            sdbusplus::asio::getProperty<std::vector<std::string>>(
+                *crow::connections::systemBus,
+                "xyz.openbmc_project.User.Manager", "/xyz/openbmc_project/user",
+                "xyz.openbmc_project.User.Manager", "AllPrivileges",
+                [asyncResp](const boost::system::error_code ec,
+                            const std::vector<std::string>& privList) {
+                if (ec)
                 {
-                    nlohmann::json::object_t member;
-                    member["@odata.id"] =
-                        "/redfish/v1/AccountService/Roles/" + role;
-                    memberArray.push_back(std::move(member));
+                    messages::internalError(asyncResp->res);
+                    return;
                 }
-            }
-            asyncResp->res.jsonValue["Members@odata.count"] =
-                memberArray.size();
+                nlohmann::json& memberArray =
+                    asyncResp->res.jsonValue["Members"];
+                memberArray = nlohmann::json::array();
+                for (const std::string& priv : privList)
+                {
+                    std::string role = getRoleFromPrivileges(priv);
+                    if (!role.empty())
+                    {
+                        nlohmann::json::object_t member;
+                        member["@odata.id"] =
+                            "/redfish/v1/AccountService/Roles/" + role;
+                        memberArray.push_back(std::move(member));
+                    }
+                }
+                asyncResp->res.jsonValue["Members@odata.count"] =
+                    memberArray.size();
+                });
             });
-        });
 }
 
 } // namespace redfish


### PR DESCRIPTION
The Redfish GET API for AccountService roles should return "ServiceAgent" for the case of the OemIBMServiceAgent role and not "OemIBMServiceAgent".

Tested:
/redfish/v1/AccountService/Roles/ROLE shows the intended descriptions.

Signed-off-by: Tom Ippolito <thomas.ippolito@ibm.com>
Signed-off-by: Joseph Reynolds <joseph-reynolds@charter.net>

Co-authored-by: Tom Ippolito <thomas.ippolito@ibm.com>