### PR TITLE
Add ACFWindowActive to /redfish/v1 (#331)

### DIFF
--- a/redfish-core/lib/service_root.hpp
+++ b/redfish-core/lib/service_root.hpp
@@ -37,9 +37,11 @@ namespace redfish
 inline void
     handleACFWindowActive(const std::shared_ptr<bmcweb::AsyncResp>& asyncResp)
 {
-    crow::connections::systemBus->async_method_call(
+    sdbusplus::asio::getProperty<bool>(
+        *crow::connections::systemBus, "com.ibm.PanelApp", "/com/ibm/panel_app",
+        "com.ibm.panel", "ACFWindowActive",
         [asyncResp](const boost::system::error_code ec,
-                    const std::variant<bool>& retVal) {
+                    const bool isACFWindowActive) {
         if (ec)
         {
             BMCWEB_LOG_ERROR << "Failed to read ACFWindowActive property";
@@ -47,19 +49,9 @@ inline void
             asyncResp->res.jsonValue["Oem"]["IBM"]["ACFWindowActive"] = false;
             return;
         }
-        const bool* isACFWindowActive = std::get_if<bool>(&retVal);
-        if (isACFWindowActive == nullptr)
-        {
-            BMCWEB_LOG_ERROR << "nullptr for ACFWindowActive";
-            messages::internalError(asyncResp->res);
-            return;
-        }
         asyncResp->res.jsonValue["Oem"]["IBM"]["ACFWindowActive"] =
-            *isACFWindowActive;
-        },
-        "com.ibm.PanelApp", "/com/ibm/panel_app",
-        "org.freedesktop.DBus.Properties", "Get", "com.ibm.panel",
-        "ACFWindowActive");
+            isACFWindowActive;
+        });
 }
 
 inline void

--- a/redfish-core/lib/service_root.hpp
+++ b/redfish-core/lib/service_root.hpp
@@ -40,23 +40,22 @@ inline void
     crow::connections::systemBus->async_method_call(
         [asyncResp](const boost::system::error_code ec,
                     const std::variant<bool>& retVal) {
-            if (ec)
-            {
-                BMCWEB_LOG_ERROR << "Failed to read ACFWindowActive property";
-                // Default value when panel app is unreachable.
-                asyncResp->res.jsonValue["Oem"]["IBM"]["ACFWindowActive"] =
-                    false;
-                return;
-            }
-            const bool* isACFWindowActive = std::get_if<bool>(&retVal);
-            if (isACFWindowActive == nullptr)
-            {
-                BMCWEB_LOG_ERROR << "nullptr for ACFWindowActive";
-                messages::internalError(asyncResp->res);
-                return;
-            }
-            asyncResp->res.jsonValue["Oem"]["IBM"]["ACFWindowActive"] =
-                *isACFWindowActive;
+        if (ec)
+        {
+            BMCWEB_LOG_ERROR << "Failed to read ACFWindowActive property";
+            // Default value when panel app is unreachable.
+            asyncResp->res.jsonValue["Oem"]["IBM"]["ACFWindowActive"] = false;
+            return;
+        }
+        const bool* isACFWindowActive = std::get_if<bool>(&retVal);
+        if (isACFWindowActive == nullptr)
+        {
+            BMCWEB_LOG_ERROR << "nullptr for ACFWindowActive";
+            messages::internalError(asyncResp->res);
+            return;
+        }
+        asyncResp->res.jsonValue["Oem"]["IBM"]["ACFWindowActive"] =
+            *isACFWindowActive;
         },
         "com.ibm.PanelApp", "/com/ibm/panel_app",
         "org.freedesktop.DBus.Properties", "Get", "com.ibm.panel",

--- a/redfish-core/lib/service_root.hpp
+++ b/redfish-core/lib/service_root.hpp
@@ -35,6 +35,35 @@ namespace redfish
 {
 
 inline void
+    handleACFWindowActive(const std::shared_ptr<bmcweb::AsyncResp>& asyncResp)
+{
+    crow::connections::systemBus->async_method_call(
+        [asyncResp](const boost::system::error_code ec,
+                    const std::variant<bool>& retVal) {
+            if (ec)
+            {
+                BMCWEB_LOG_ERROR << "Failed to read ACFWindowActive property";
+                // Default value when panel app is unreachable.
+                asyncResp->res.jsonValue["Oem"]["IBM"]["ACFWindowActive"] =
+                    false;
+                return;
+            }
+            const bool* isACFWindowActive = std::get_if<bool>(&retVal);
+            if (isACFWindowActive == nullptr)
+            {
+                BMCWEB_LOG_ERROR << "nullptr for ACFWindowActive";
+                messages::internalError(asyncResp->res);
+                return;
+            }
+            asyncResp->res.jsonValue["Oem"]["IBM"]["ACFWindowActive"] =
+                *isACFWindowActive;
+        },
+        "com.ibm.PanelApp", "/com/ibm/panel_app",
+        "org.freedesktop.DBus.Properties", "Get", "com.ibm.panel",
+        "ACFWindowActive");
+}
+
+inline void
     handleServiceRootOem(const std::shared_ptr<bmcweb::AsyncResp>& asyncResp)
 {
     crow::connections::systemBus->async_method_call(
@@ -129,7 +158,7 @@ inline void
         redfishDateTimeOffset.first;
     asyncResp->res.jsonValue["Oem"]["IBM"]["DateTimeLocalOffset"] =
         redfishDateTimeOffset.second;
-
+    handleACFWindowActive(asyncResp);
     asyncResp->res.jsonValue["Oem"]["@odata.type"] = "#OemServiceRoot.Oem";
     asyncResp->res.jsonValue["Oem"]["IBM"]["@odata.type"] =
         "#OemServiceRoot.IBM";

--- a/static/redfish/v1/JsonSchemas/OemServiceRoot/index.json
+++ b/static/redfish/v1/JsonSchemas/OemServiceRoot/index.json
@@ -54,6 +54,44 @@
                         "string",
                         "null"
                     ]
+                },
+                "SerialNumber": {
+                    "description": "The serial number for this system.",
+                    "longDescription": "This property shall contain the serial number for the system.",
+                    "readonly": true,
+                    "type": [
+                        "string",
+                        "null"
+                    ]
+                },
+                "DateTime": {
+                    "description": "The current date and time with UTC offset of the manager.",
+                    "format": "date-time",
+                    "longDescription": "This property shall contain the current date and time with UTC offset of the manager.",
+                    "readonly": false,
+                    "type": [
+                        "string",
+                        "null"
+                    ]
+                },
+                "DateTimeLocalOffset": {
+                    "description": "The time offset from UTC that the DateTime property is in `+HH:MM` format.",
+                    "longDescription": "This property shall contain the offset from UTC time that the DateTime property contains.  If both DateTime and DateTimeLocalOffset are provided in modification requests, services shall apply DateTimeLocalOffset after DateTime is applied.",
+                    "pattern": "^([-+][0-1][0-9]:[0-5][0-9])$",
+                    "readonly": false,
+                    "type": [
+                        "string",
+                        "null"
+                    ]
+                },
+                "ACFWindowActive": {
+                    "description": "An indication of whether the time window for an unauthorized agent to upload an ACF is active.",
+                    "longDescription": "This property shall indicate if the time window for an unauthorized agent to upload an ACF is active.",
+                    "readonly": true,
+                    "type": [
+                        "boolean",
+                        "null"
+                    ]
                 }
             },
             "type": "object"

--- a/static/redfish/v1/schema/OemServiceRoot_v1.xml
+++ b/static/redfish/v1/schema/OemServiceRoot_v1.xml
@@ -55,6 +55,11 @@
           <Annotation Term="OData.Description" String="The time offset from UTC that the DateTime property is in `+HH:MM` format."/>
           <Annotation Term="OData.LongDescription" String="This property shall contain the offset from UTC time that the DateTime property contains.  If both DateTime and DateTimeLocalOffset are provided in modification requests, services shall apply DateTimeLocalOffset after DateTime is applied."/>
         </Property>
+        <Property Name="ACFWindowActive" Type="OemServiceRoot.IBM">
+          <Annotation Term="OData.Permissions" EnumMember="OData.Permission/Read"/>
+          <Annotation Term="OData.Description" String="An indication of whether the time window for an unauthorized agent to upload an ACF is active."/>
+          <Annotation Term="OData.LongDescription" String="This property shall indicate if the time window for an unauthorized agent to upload an ACF is active."/>
+        </Property>
       </ComplexType>
 
     </Schema>


### PR DESCRIPTION
* Add ACFWindowActive to /redfish/v1

This adds the Oem.IBM.ACFWindowActive boolean property to the Redfish service root at URI /redfish/v1.

Tested:
Via curl https://${BMC}/redfish/v1
Tested values true, false, and panel app not running. Simulated pressing function 74 via busctl set-property "com.ibm.PanelApp"
  "/com/ibm/panel_app" "com.ibm.panel" "ACFWindowActive" b true

Signed-off-by: Joseph Reynolds <joseph-reynolds@charter.net>

* Add ACFWindowActive to /redfish/v1

This restructures the ACFWindowActive code to BMCWeb coding style. This defaults to ACFWindowActive=false when the value is not available. This add the XML schema.

Tested:
Tested both true and false values via:
curl -k https://127.0.0.1:2643/redfish/v1
and simulating button press via
busctl set-property "com.ibm.PanelApp" "/com/ibm/panel_app" \
  "com.ibm.panel" "ACFWindowActive" b true

Signed-off-by: Joseph Reynolds <joseph-reynolds@charter.net>

* Add ACFWindowActive to /redfish/v1

Fixed up per review comments: add returns, removed else clause, removed blank lines

Signed-off-by: Joseph Reynolds <joseph-reynolds@charter.net>