### PR TITLE
Restrict the Operator role (#319)

### DIFF
--- a/redfish-core/lib/roles.hpp
+++ b/redfish-core/lib/roles.hpp
@@ -93,11 +93,7 @@ inline bool getOemPrivFromRole(std::string_view role, nlohmann::json& privArray)
 
 inline bool isRestrictedRole(const std::string& role)
 {
-    if ((role == "Operator") || (role == "OemIBMServiceAgent"))
-    {
-        return true;
-    }
-    return false;
+    return ((role == "Operator") || (role == "OemIBMServiceAgent"));
 }
 
 inline void requestRoutesRoles(App& app)

--- a/redfish-core/lib/roles.hpp
+++ b/redfish-core/lib/roles.hpp
@@ -93,7 +93,11 @@ inline bool getOemPrivFromRole(std::string_view role, nlohmann::json& privArray)
 
 inline bool isRestrictedRole(const std::string& role)
 {
-    return role == "OemIBMServiceAgent";
+    if ((role == "Operator") || (role == "OemIBMServiceAgent"))
+    {
+        return true;
+    }
+    return false;
 }
 
 inline void requestRoutesRoles(App& app)


### PR DESCRIPTION
This changes the Operator role to Restricted=true which means no users can have the Operator role.

Tested:
1. GET /redfish/v1/AccountService/Roles/Operator and ensure it has Restricted:true.
2. POST /redfish/v1/AccountService/Accounts/new with Role:Operator Ensure it failed with message Base.1.9.0.RestrictedRole. Posting a new Administrator user is successful.
3. PATCH /redfish/v1/AccountService/Accounts/ordinary with Role:Operator.  Ensure it failed.
Changing a user to the ReadOnly role is successful.
4. PATCH the OemIBMServiceAgent role as the LocalRole within the RemoteRoleMapping property && ensure it failed.

Signed-off-by: Joseph Reynolds <joseph-reynolds@charter.net>