### PR TITLE
Check PowerSupply availability prop for State/Hlth

### DIFF
--- a/redfish-core/lib/power_supply.hpp
+++ b/redfish-core/lib/power_supply.hpp
@@ -183,12 +183,14 @@ inline void getValidPowerSupplyPath(
 
 inline void
     getPowerSupplyState(const std::shared_ptr<bmcweb::AsyncResp>& asyncResp,
-                        const std::string& service, const std::string& path)
+                        const std::string& service, const std::string& path,
+                        bool available)
 {
     sdbusplus::asio::getProperty<bool>(
         *crow::connections::systemBus, service, path,
         "xyz.openbmc_project.Inventory.Item", "Present",
-        [asyncResp](const boost::system::error_code ec, const bool value) {
+        [asyncResp, available](const boost::system::error_code ec,
+                               const bool value) {
         if (ec)
         {
             if (ec.value() != EBADR)
@@ -202,17 +204,23 @@ inline void
         {
             asyncResp->res.jsonValue["Status"]["State"] = "Absent";
         }
+        else if (!available)
+        {
+            asyncResp->res.jsonValue["Status"]["State"] = "UnavailableOffline";
+        }
         });
 }
 
 inline void
     getPowerSupplyHealth(const std::shared_ptr<bmcweb::AsyncResp>& asyncResp,
-                         const std::string& service, const std::string& path)
+                         const std::string& service, const std::string& path,
+                         bool available)
 {
     sdbusplus::asio::getProperty<bool>(
         *crow::connections::systemBus, service, path,
         "xyz.openbmc_project.State.Decorator.OperationalStatus", "Functional",
-        [asyncResp](const boost::system::error_code ec, const bool value) {
+        [asyncResp, available](const boost::system::error_code ec,
+                               const bool value) {
         if (ec)
         {
             if (ec.value() != EBADR)
@@ -222,10 +230,34 @@ inline void
             return;
         }
 
-        if (!value)
+        if (!value || !available)
         {
             asyncResp->res.jsonValue["Status"]["Health"] = "Critical";
         }
+        });
+}
+
+inline void getPowerSupplyStateAndHealth(
+    const std::shared_ptr<bmcweb::AsyncResp>& asyncResp,
+    const std::string& service, const std::string& path)
+{
+    sdbusplus::asio::getProperty<bool>(
+        *crow::connections::systemBus, service, path,
+        "xyz.openbmc_project.State.Decorator.Availability", "Available",
+        [asyncResp, service, path](const boost::system::error_code ec,
+                                   const bool available) {
+        if (ec)
+        {
+            if (ec.value() != EBADR)
+            {
+                messages::internalError(asyncResp->res);
+            }
+            return;
+        }
+
+        getPowerSupplyState(asyncResp, service, path, available);
+
+        getPowerSupplyHealth(asyncResp, service, path, available);
         });
 }
 
@@ -428,10 +460,8 @@ inline void
                 return;
             }
 
-            getPowerSupplyState(asyncResp, object.begin()->first,
-                                powerSupplyPath);
-            getPowerSupplyHealth(asyncResp, object.begin()->first,
-                                 powerSupplyPath);
+            getPowerSupplyStateAndHealth(asyncResp, object.begin()->first,
+                                         powerSupplyPath);
             getPowerSupplyAsset(asyncResp, object.begin()->first,
                                 powerSupplyPath);
             getPowerSupplyFirmwareVersion(asyncResp, object.begin()->first,


### PR DESCRIPTION
This is the 1050 pull request for the commit already in 1030.  A little bit of refactoring was required.
Stalled upstream at https://gerrit.openbmc.org/c/openbmc/bmcweb/+/51336.

Original commit message:
This commit makes use of the Available property on the power supply D-Bus object when determining the power supply state and health in the PowerSupply response.  The power supply monitor code from phosphor-power will set the property to false if it can determine that the power supply isn't able to provide power due to certain faults.

If the PS isn't available, then the Health property will be set to Critical, and the State will be set to UnavailableOffline (assuming it shouldn't be Absent instead).

This is necessary because on IBM systems the Functional property determines the fault LED state as well as the health value, and in certain cases the fault LED needs to stay off even though the PS health is not OK.  A specific example of this is when the PS cord is unplugged: no fault LED is desired but it is desired for the Redfish output to show that there is an issue with the PS.

If the Available property isn't present on D-Bus, it acts as if it had a value of true and behaves the same as it does today.

Tested:
Available = false:
    "Health": "Critical",
    "State": "UnavailableOffline"

Available = true, Functional = false:
    "Health": "Critical",
    "State": "Enabled"

PS missing:
    "Health": "Critical",
    "State": "Absent"

Everything OK:
    "Health": "OK",
    "State": "Enabled"

No Available property on D-Bus:
    "Health": "OK",
    "State": "Enabled"

Signed-off-by: Matt Spinler <spinler@us.ibm.com>
Change-Id: I1a3194bf3a6ca3936954b31439070dcc2f343411