### PR TITLE
Fix & Reenable the handling of PCIeSlots schema

### DIFF
--- a/redfish-core/include/redfish.hpp
+++ b/redfish-core/include/redfish.hpp
@@ -35,6 +35,7 @@
 #include "metric_report_definition.hpp"
 #include "network_protocol.hpp"
 #include "pcie.hpp"
+#include "pcie_slots.hpp"
 #include "power.hpp"
 #include "power_subsystem.hpp"
 #include "power_supply.hpp"
@@ -97,6 +98,7 @@ class RedfishService
         requestRoutesManagerResetActionInfo(app);
         requestRoutesManagerResetToDefaultsAction(app);
         requestRoutesManagerDiagnosticData(app);
+        requestRoutesPCIeSlots(app);
         requestRoutesChassisCollection(app);
         requestRoutesChassis(app);
         requestRoutesChassisResetAction(app);

--- a/redfish-core/lib/chassis.hpp
+++ b/redfish-core/lib/chassis.hpp
@@ -442,6 +442,10 @@ inline void
                     "/redfish/v1/Chassis/" + chassisId + "/Sensors";
                 asyncResp->res.jsonValue["Status"]["State"] = "Enabled";
 
+                asyncResp->res.jsonValue["PCIeSlots"]["@odata.id"] =
+                    crow::utility::urlFromPieces("redfish", "v1", "Chassis",
+                                                 chassisId, "PCIeSlots");
+
                 nlohmann::json::array_t computerSystems;
                 nlohmann::json::object_t system;
                 system["@odata.id"] = "/redfish/v1/Systems/system";

--- a/redfish-core/lib/pcie_slots.hpp
+++ b/redfish-core/lib/pcie_slots.hpp
@@ -1,7 +1,7 @@
 #pragma once
 
 #include "error_messages.hpp"
-#include "generated/enums/pcie_slot.hpp"
+#include "generated/enums/pcie_slots.hpp"
 #include "utility.hpp"
 
 #include <app.hpp>
@@ -15,53 +15,60 @@
 namespace redfish
 {
 
-inline pcie_slot::SlotTypes dbusSlotTypeToRf(const std::string& slotType)
+inline std::optional<pcie_slots::SlotTypes>
+    dbusSlotTypeToRf(const std::string& slotType)
 {
     if (slotType ==
         "xyz.openbmc_project.Inventory.Item.PCIeSlot.SlotTypes.FullLength")
     {
-        return pcie_slot::SlotTypes::FullLength;
+        return pcie_slots::SlotTypes::FullLength;
     }
     if (slotType ==
         "xyz.openbmc_project.Inventory.Item.PCIeSlot.SlotTypes.HalfLength")
     {
-        return pcie_slot::SlotTypes::HalfLength;
+        return pcie_slots::SlotTypes::HalfLength;
     }
     if (slotType ==
         "xyz.openbmc_project.Inventory.Item.PCIeSlot.SlotTypes.LowProfile")
     {
-        return pcie_slot::SlotTypes::LowProfile;
+        return pcie_slots::SlotTypes::LowProfile;
     }
     if (slotType ==
         "xyz.openbmc_project.Inventory.Item.PCIeSlot.SlotTypes.Mini")
     {
-        return pcie_slot::SlotTypes::Mini;
+        return pcie_slots::SlotTypes::Mini;
     }
     if (slotType == "xyz.openbmc_project.Inventory.Item.PCIeSlot.SlotTypes.M_2")
     {
-        return pcie_slot::SlotTypes::M2;
+        return pcie_slots::SlotTypes::M2;
     }
     if (slotType == "xyz.openbmc_project.Inventory.Item.PCIeSlot.SlotTypes.OEM")
     {
-        return pcie_slot::SlotTypes::OEM;
+        return pcie_slots::SlotTypes::OEM;
     }
     if (slotType ==
         "xyz.openbmc_project.Inventory.Item.PCIeSlot.SlotTypes.OCP3Small")
     {
-        return pcie_slot::SlotTypes::OCP3Small;
+        return pcie_slots::SlotTypes::OCP3Small;
     }
     if (slotType ==
         "xyz.openbmc_project.Inventory.Item.PCIeSlot.SlotTypes.OCP3Large")
     {
-        return pcie_slot::SlotTypes::OCP3Large;
+        return pcie_slots::SlotTypes::OCP3Large;
     }
     if (slotType == "xyz.openbmc_project.Inventory.Item.PCIeSlot.SlotTypes.U_2")
     {
-        return pcie_slot::SlotTypes::U2;
+        return pcie_slots::SlotTypes::U2;
+    }
+    if (slotType.empty() ||
+        slotType ==
+            "xyz.openbmc_project.Inventory.Item.PCIeSlot.SlotTypes.Unknown")
+    {
+        return pcie_slots::SlotTypes::Invalid;
     }
 
-    // Unknown or others
-    return pcie_slot::SlotTypes::Invalid;
+    // Unspecified slotType needs return an internal error.
+    return std::nullopt;
 }
 
 inline void
@@ -114,7 +121,10 @@ inline void
             messages::internalError(asyncResp->res);
             return;
         }
-        slot["PCIeType"] = !pcieType;
+        if (*pcieType != pcie_device::PCIeTypes::Invalid)
+        {
+            slot["PCIeType"] = !pcieType;
+        }
     }
 
     if (lanes != nullptr)
@@ -125,13 +135,17 @@ inline void
 
     if (slotType != nullptr)
     {
-        std::string redfishSlotType = dbusSlotTypeToRf(*slotType);
-        if (!slotType.empty())
+        std::optional<pcie_slots::SlotTypes> redfishSlotType =
+            dbusSlotTypeToRf(*slotType);
+        if (!redfishSlotType)
         {
             messages::internalError(asyncResp->res);
             return;
         }
-        slot["SlotType"] = redfishSlotType;
+        if (*redfishSlotType != pcie_slots::SlotTypes::Invalid)
+        {
+            slot["SlotType"] = *redfishSlotType;
+        }
     }
 
     if (hotPluggable != nullptr)
@@ -188,9 +202,9 @@ inline void onMapperAssociationDone(
     sdbusplus::asio::getAllProperties(
         *crow::connections::systemBus, connectionName, pcieSlotPath,
         "xyz.openbmc_project.Inventory.Item.PCIeSlot",
-        [asyncResp](const boost::system::error_code ec,
+        [asyncResp](const boost::system::error_code ec2,
                     const dbus::utility::DBusPropertiesMap& propertiesList) {
-        onPcieSlotGetAllDone(asyncResp, ec, propertiesList);
+        onPcieSlotGetAllDone(asyncResp, ec2, propertiesList);
         });
 }
 
@@ -236,10 +250,10 @@ inline void
             // it belongs to this ChassisID
             crow::connections::systemBus->async_method_call(
                 [asyncResp, chassisID, pcieSlotPath, connectionName](
-                    const boost::system::error_code ec,
+                    const boost::system::error_code ec2,
                     const std::variant<std::vector<std::string>>& endpoints) {
                 onMapperAssociationDone(asyncResp, chassisID, pcieSlotPath,
-                                        connectionName, ec, endpoints);
+                                        connectionName, ec2, endpoints);
                 },
                 "xyz.openbmc_project.ObjectMapper",
                 std::string{pcieSlotAssociationPath},


### PR DESCRIPTION
1050/upstream reverted the previous PCIeSlots schema implementation via  e825cbc8f967e54dfd6d911ebbbc6b2bfc7bc543 due to the validator failures.

    ---
    e825cbc8f967e54dfd6d911ebbbc6b2bfc7bc543
    This reverts commit 7691cc2f7ef1f0ceedf3de0554045a614f25776d.

    This causes validator failures
    ERROR - JsonSchemas: GET of resource at URI /redfish/v1/JsonSchemas returned HTTP 404. Check URI.
    ERROR - PCIeSlots: GET of resource at URI /redfish/v1/Chassis/motherboard/PCIeSlots returned HTTP 404. Check URI.
    ERROR - PCIeSlots: GET of resource at URI /redfish/v1/Chassis/chassis/PCIeSlots returned HTTP 404. Check URI.
    ---

With this fix, PCIeSlots schema will work again

$ curl -k -X GET https://${bmc}:18080/redfish/v1/Chassis/chassis/PCIeSlots {
  "@odata.id": "/redfish/v1/Chassis/chassis/PCIeSlots",
  "@odata.type": "#PCIeSlots.v1_4_1.PCIeSlots",
  "Id": "1",
  "Name": "PCIe Slot Information",
  "Slots": [
    {
      "HotPluggable": false,
      "Lanes": 0,
      "SlotType": "U2"
    },
…
}

Signed-off-by: Myung Bae <myungbae@us.ibm.com>