### PR TITLE
Return bad request if can't construct

### DIFF
--- a/http/http_connection.hpp
+++ b/http/http_connection.hpp
@@ -323,6 +323,8 @@ class Connection :
         if (reqEc)
         {
             BMCWEB_LOG_DEBUG << "Request failed to construct" << reqEc;
+            res.result(boost::beast::http::status::bad_request);
+            completeRequest(res);
             return;
         }
         thisReq.session = userSession;


### PR DESCRIPTION
This merged upstream here:
https://github.com/openbmc/bmcweb/commit/262f115299479c8f1142954622a358d53318e9fd

Just easier if we cherry-pick into 1050, since not sure when we will rebase next. I just worry, if it doesn't get cherry-picked, I get a defect. ;) 

If given a bad URI, e.g. "https://$bmc/?a=id;" return http bad request (400) like we do other places, e.g. a few lines below.

Certain scanners expect to see bad request when crawling and probing for vulnerabilities and using not valid URIs. Just dropping the connection causes errors with these scanners. They think connection problem or worse the server was taken down.

Signed-off-by: Gunnar Mills <gmills@us.ibm.com>