### PR TITLE
Clean up http end_of_stream traces

### DIFF
--- a/http/http_connection.hpp
+++ b/http/http_connection.hpp
@@ -13,6 +13,7 @@
 #include <boost/asio/ssl/stream.hpp>
 #include <boost/asio/steady_timer.hpp>
 #include <boost/beast/core/flat_static_buffer.hpp>
+#include <boost/beast/http/error.hpp>
 #include <boost/beast/http/parser.hpp>
 #include <boost/beast/http/read.hpp>
 #include <boost/beast/http/serializer.hpp>
@@ -557,7 +558,7 @@ class Connection :
             if (ec)
             {
                 errorWhileReading = true;
-                if (ec == boost::asio::error::eof)
+                if (ec == boost::beast::http::error::end_of_stream)
                 {
                     BMCWEB_LOG_WARNING
                         << this << " Error while reading: " << ec.message();


### PR DESCRIPTION
This is a cherry-pick from upstream  https://github.com/openbmc/bmcweb/commit/a4326fe2710d12e30cf39dee2aaaba2e4fd0abfd.

http::end_of_stream log is not properly detected and thus it is being traced as error. It will be fixed to be traced as warning so they do not show up when just error traces are enabled (new default)

Here's the log we was getting:
Jan 10 13:34:32 ever6bmc bmcweb[2496]: (2023-01-10 13:34:32) \ [ERROR "http_connection.hpp":784] 0x14bd360 Error while \ reading: end of stream

Change-Id: I6ecee813c4f7806a676ba0ad3e4ab1a8f78747fd
Signed-off-by: Myung Bae <myungbae@us.ibm.com>