### PR TITLE
Fix CI; Run black

### DIFF
--- a/scripts/websocket_test.py
+++ b/scripts/websocket_test.py
@@ -45,10 +45,10 @@ async def hello():
     authbytes = "{}:{}".format(args.username, args.password).encode("ascii")
     auth = "Basic {}".format(base64.b64encode(authbytes).decode("ascii"))
     headers = {"Authorization": auth}
-    async with websockets.connect(
-        uri, ssl=ssl_context, extra_headers=headers
-    ) if args.ssl else websockets.connect(
-        uri, extra_headers=headers
+    async with (
+        websockets.connect(uri, ssl=ssl_context, extra_headers=headers)
+        if args.ssl
+        else websockets.connect(uri, extra_headers=headers)
     ) as websocket:
         request = json.dumps(
             {


### PR DESCRIPTION
Merged upstream at https://gerrit.openbmc.org/c/openbmc/bmcweb/+/60653

Seeing CI fails:
```
    Running beautysh
    Running black
reformatted scripts/websocket_test.py
```

```
diff --git a/scripts/websocket_test.py b/scripts/websocket_test.py
index 21c7f160..fce9cd7e 100755
--- a/scripts/websocket_test.py
+++ b/scripts/websocket_test.py
@@ -45,10 +45,10 @@ async def hello():
     authbytes = "{}:{}".format(args.username,
args.password).encode("ascii")
     auth = "Basic
{}".format(base64.b64encode(authbytes).decode("ascii"))
     headers = {"Authorization": auth}
-    async with websockets.connect(
-        uri, ssl=ssl_context, extra_headers=headers
-    ) if args.ssl else websockets.connect(
-        uri, extra_headers=headers
+    async with (
+        websockets.connect(uri, ssl=ssl_context, extra_headers=headers)
+        if args.ssl
+        else websockets.connect(uri, extra_headers=headers)
     ) as websocket:
         request = json.dumps(
             {
Format: FAILED
```

Change-Id: I8020716f2f9b9f1745d817728d3fe1eccd0bf778
Signed-off-by: Gunnar Mills <gmills@us.ibm.com>