### PR TITLE
Correct id parameter to pass validator

### DIFF
--- a/redfish-core/lib/bios.hpp
+++ b/redfish-core/lib/bios.hpp
@@ -256,7 +256,7 @@ inline void requestRoutesBiosSettings(App& app)
                     "/redfish/v1/Systems/system/Bios/Settings";
                 asyncResp->res.jsonValue["@odata.type"] = "#Bios.v1_1_0.Bios";
                 asyncResp->res.jsonValue["Name"] = "Bios Settings";
-                asyncResp->res.jsonValue["Id"] = "BiosSettings";
+                asyncResp->res.jsonValue["Id"] = "Settings";
                 asyncResp->res.jsonValue["AttributeRegistry"] =
                     "BiosAttributeRegistry";
                 nlohmann::json attributes(nlohmann::json::value_t::object);

--- a/redfish-core/lib/log_services.hpp
+++ b/redfish-core/lib/log_services.hpp
@@ -2944,7 +2944,7 @@ inline void requestRoutesBMCJournalLogService(App& app)
                     "Open BMC Journal Log Service";
                 asyncResp->res.jsonValue["Description"] =
                     "BMC Journal Log Service";
-                asyncResp->res.jsonValue["Id"] = "BMC Journal";
+                asyncResp->res.jsonValue["Id"] = "Journal";
                 asyncResp->res.jsonValue["OverWritePolicy"] = "WrapsWhenFull";
 
                 std::pair<std::string, std::string> redfishDateTimeOffset =
@@ -3992,7 +3992,7 @@ inline void requestRoutesPostCodesLogService(App& app)
                     {"@odata.type", "#LogService.v1_1_0.LogService"},
                     {"Name", "POST Code Log Service"},
                     {"Description", "POST Code Log Service"},
-                    {"Id", "BIOS POST Code Log"},
+                    {"Id", "PostCodes"},
                     {"OverWritePolicy", "WrapsWhenFull"},
                     {"Entries",
                      {{"@odata.id", "/redfish/v1/Systems/system/LogServices/"


### PR DESCRIPTION
Defect: https://w3.rchland.ibm.com/projects/bestquest/?defect=PE00FKYD
Needs to go into 1020, 1030, and 1040. 1050 will be separate. 

Errors we are seeing are 


1 failRedfishUriStrict errors in /redfish/v1/Systems/system/Bios/Settings
1 failRedfishUriStrict errors in /redfish/v1/Systems/system/LogServices/PostCodes

Example:
ERROR - URI /redfish/v1/Systems/system/LogServices/PostCodes does not match object IDs of resource chain
ERROR - URI /redfish/v1/Systems/system/Bios/Settings does not match object IDs of resource chain

The first commit is a cherry-pick of https://gerrit.openbmc.org/c/openbmc/bmcweb/+/60766
The 2nd commit is based on that and fixes 
1 failRedfishUriStrict errors in /redfish/v1/Systems/system/Bios/Settings. The 2nd commit isn't upstream because 
https://github.com/ibm-openbmc/bmcweb/commit/a8ec6d3be6ea4c8918bcbb554714607a19ec69c4 isn't upstream. Never the less, made the comment on the long-abandoned https://gerrit.openbmc.org/c/openbmc/bmcweb/+/29670/57/redfish-core/lib/bios.hpp#277