### PR TITLE
1050: Implement OEM lamp test and SAI

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -94,6 +94,7 @@ feature_map = {
   'xtoken-auth'                                 : '-DBMCWEB_ENABLE_XTOKEN_AUTHENTICATION',
   'redfish-license'                             : '-DBMCWEB_ENABLE_REDFISH_LICENSE',
   #'vm-nbdproxy'                                : '-DBMCWEB_ENABLE_VM_NBDPROXY',
+  'ibm-led-extensions'                          : '-DBMCWEB_ENABLE_IBM_LED_EXTENSIONS',
 }
 
 # Get the options status and build a project summary to show which flags are

--- a/meson_options.txt
+++ b/meson_options.txt
@@ -341,3 +341,9 @@ option(
       description: '''Enable hypervisor serial console WebSocket. Path is
                       \'/console1\'.'''
 )
+
+option('ibm-led-extensions',
+      type : 'feature',
+      value : 'disabled',
+      description : 'Enable the IBM LED extensions such as lamp test and system attention indicators'
+)

--- a/redfish-core/lib/oem/ibm/lamp_test.hpp
+++ b/redfish-core/lib/oem/ibm/lamp_test.hpp
@@ -1,0 +1,100 @@
+#pragma once
+
+#include "async_resp.hpp"
+#include "dbus_utility.hpp"
+#include "redfish_util.hpp"
+
+#include <variant>
+
+namespace redfish
+{
+
+/**
+ * @brief Retrieves lamp test state.
+ *
+ * @param[in] aResp     Shared pointer for generating response message.
+ *
+ * @return None.
+ */
+inline void getLampTestState(const std::shared_ptr<bmcweb::AsyncResp>& aResp)
+{
+    BMCWEB_LOG_DEBUG << "Get lamp test state";
+
+    std::array<const char*, 1> interfaces = {"xyz.openbmc_project.Led.Group"};
+    dbus::utility::getDbusObject(
+        "/xyz/openbmc_project/led/groups/lamp_test", interfaces,
+        [aResp](const boost::system::error_code& ec,
+                const dbus::utility::MapperGetObject& object) {
+        if (ec || object.empty())
+        {
+            BMCWEB_LOG_ERROR << "DBUS response error " << ec.message();
+            messages::internalError(aResp->res);
+            return;
+        }
+
+        sdbusplus::asio::getProperty<bool>(
+            *crow::connections::systemBus, object.begin()->first,
+            "/xyz/openbmc_project/led/groups/lamp_test",
+            "xyz.openbmc_project.Led.Group", "Asserted",
+            [aResp](const boost::system::error_code& ec1, bool assert) {
+            if (ec1)
+            {
+                if (ec1.value() != EBADR)
+                {
+                    messages::internalError(aResp->res);
+                }
+                return;
+            }
+
+            aResp->res.jsonValue["Oem"]["@odata.type"] =
+                "#OemComputerSystem.Oem";
+            aResp->res.jsonValue["Oem"]["IBM"]["@odata.type"] =
+                "#OemComputerSystem.IBM";
+            aResp->res.jsonValue["Oem"]["IBM"]["LampTest"] = assert;
+            });
+        });
+}
+
+/**
+ * @brief Sets lamp test state.
+ *
+ * @param[in] aResp   Shared pointer for generating response message.
+ * @param[in] state   Lamp test state from request.
+ *
+ * @return None.
+ */
+inline void setLampTestState(const std::shared_ptr<bmcweb::AsyncResp>& aResp,
+                             const bool state)
+{
+    BMCWEB_LOG_DEBUG << "Set lamp test status.";
+
+    std::array<const char*, 1> interfaces = {"xyz.openbmc_project.Led.Group"};
+    dbus::utility::getDbusObject(
+        "/xyz/openbmc_project/led/groups/lamp_test", interfaces,
+        [aResp, state](const boost::system::error_code& ec,
+                       const dbus::utility::MapperGetObject& object) {
+        if (ec || object.empty())
+        {
+            BMCWEB_LOG_ERROR << "DBUS response error " << ec.message();
+            messages::internalError(aResp->res);
+            return;
+        }
+
+        sdbusplus::asio::setProperty(
+            *crow::connections::systemBus, object.begin()->first,
+            "/xyz/openbmc_project/led/groups/lamp_test",
+            "xyz.openbmc_project.Led.Group", "Asserted", state,
+            [aResp](const boost::system::error_code& ec1) {
+            if (ec1)
+            {
+                if (ec1.value() != EBADR)
+                {
+                    messages::internalError(aResp->res);
+                }
+                return;
+            }
+            });
+        });
+}
+
+} // namespace redfish

--- a/redfish-core/lib/oem/ibm/system_attention_indicator.hpp
+++ b/redfish-core/lib/oem/ibm/system_attention_indicator.hpp
@@ -1,0 +1,138 @@
+#pragma once
+
+#include "async_resp.hpp"
+#include "dbus_utility.hpp"
+
+#include <variant>
+
+namespace redfish
+{
+/**
+ * @brief Get System Attention Indicator
+ *
+ * @param[in] aResp             Shared pointer for generating response message.
+ * @param[in] propertyValue     The property value
+ *                              (PartitionSystemAttentionIndicator/PlatformSystemAttentionIndicator).
+ *
+ * @return None.
+ */
+inline void getSAI(const std::shared_ptr<bmcweb::AsyncResp>& aResp,
+                   const std::string& propertyValue)
+{
+    BMCWEB_LOG_DEBUG << "Get platform/partition system attention indicator";
+
+    std::string name{};
+    if (propertyValue == "PartitionSystemAttentionIndicator")
+    {
+        name = "partition_system_attention_indicator";
+    }
+    else if (propertyValue == "PlatformSystemAttentionIndicator")
+    {
+        name = "platform_system_attention_indicator";
+    }
+    else
+    {
+        messages::propertyUnknown(aResp->res, propertyValue);
+        return;
+    }
+
+    std::array<const char*, 1> interfaces = {"xyz.openbmc_project.Led.Group"};
+    dbus::utility::getDbusObject(
+        "/xyz/openbmc_project/led/groups/" + name, interfaces,
+        [aResp, name,
+         propertyValue](const boost::system::error_code& ec,
+                        const dbus::utility::MapperGetObject& object) {
+        if (ec || object.empty())
+        {
+            BMCWEB_LOG_ERROR << "DBUS response error " << ec.message();
+            messages::internalError(aResp->res);
+            return;
+        }
+
+        sdbusplus::asio::getProperty<bool>(
+            *crow::connections::systemBus, object.begin()->first,
+            "/xyz/openbmc_project/led/groups/" + name,
+            "xyz.openbmc_project.Led.Group", "Asserted",
+            [aResp, propertyValue](const boost::system::error_code& ec1,
+                                   bool assert) {
+            if (ec1)
+            {
+                if (ec1.value() != EBADR)
+                {
+                    messages::internalError(aResp->res);
+                }
+                return;
+            }
+
+            nlohmann::json& oemSAI = aResp->res.jsonValue["Oem"]["IBM"];
+            oemSAI["@odata.type"] = "#OemComputerSystem.IBM";
+            if (propertyValue == "PartitionSystemAttentionIndicator")
+            {
+                oemSAI["PartitionSystemAttentionIndicator"] = assert;
+            }
+            else if (propertyValue == "PlatformSystemAttentionIndicator")
+            {
+                oemSAI["PlatformSystemAttentionIndicator"] = assert;
+            }
+            });
+        });
+}
+
+/**
+ * @brief Set System Attention Indicator
+ *
+ * @param[in] aResp             Shared pointer for generating response message.
+ * @param[in] propertyValue     The property value
+ *                              (PartitionSystemAttentionIndicator/PlatformSystemAttentionIndicator).
+ * @param[in] value             true or fasle
+ *
+ * @return None.
+ */
+inline void setSAI(const std::shared_ptr<bmcweb::AsyncResp>& aResp,
+                   const std::string& propertyValue, bool value)
+{
+    BMCWEB_LOG_DEBUG << "Set platform/partition system attention indicator";
+
+    std::string name{};
+    if (propertyValue == "PartitionSystemAttentionIndicator")
+    {
+        name = "partition_system_attention_indicator";
+    }
+    else if (propertyValue == "PlatformSystemAttentionIndicator")
+    {
+        name = "platform_system_attention_indicator";
+    }
+    else
+    {
+        return;
+    }
+
+    std::array<const char*, 1> interfaces = {"xyz.openbmc_project.Led.Group"};
+    dbus::utility::getDbusObject(
+        "/xyz/openbmc_project/led/groups/" + name, interfaces,
+        [aResp, name, value](const boost::system::error_code& ec,
+                             const dbus::utility::MapperGetObject& object) {
+        if (ec || object.empty())
+        {
+            BMCWEB_LOG_ERROR << "DBUS response error " << ec.message();
+            messages::internalError(aResp->res);
+            return;
+        }
+
+        sdbusplus::asio::setProperty(
+            *crow::connections::systemBus, object.begin()->first,
+            "/xyz/openbmc_project/led/groups/" + name,
+            "xyz.openbmc_project.Led.Group", "Asserted", value,
+            [aResp](const boost::system::error_code& ec1) {
+            if (ec1)
+            {
+                if (ec1.value() != EBADR)
+                {
+                    messages::internalError(aResp->res);
+                }
+                return;
+            }
+            });
+        });
+}
+} // namespace redfish

--- a/static/redfish/v1/JsonSchemas/OemComputerSystem/index.json
+++ b/static/redfish/v1/JsonSchemas/OemComputerSystem/index.json
@@ -82,6 +82,16 @@
                             "type": "null"
                         }
                     ]
+                },
+                "IBM": {
+                    "anyOf": [
+                        {
+                            "$ref": "#/definitions/IBM"
+                        },
+                        {
+                            "type": "null"
+                        }
+                    ]
                 }
             },
             "type": "object"
@@ -104,6 +114,54 @@
                 }
             },
             "properties": {},
+            "type": "object"
+        },
+        "IBM": {
+            "additionalProperties": true,
+            "description": "Oem properties for IBM.",
+            "patternProperties": {
+                "^([a-zA-Z_][a-zA-Z0-9_]*)?@(odata|Redfish|Message)\\.[a-zA-Z_][a-zA-Z0-9_]*$": {
+                    "description": "This property shall specify a valid odata or Redfish property.",
+                    "type": [
+                        "array",
+                        "boolean",
+                        "integer",
+                        "number",
+                        "null",
+                        "object",
+                        "string"
+                    ]
+                }
+            },
+            "properties": {
+                "LampTest": {
+                    "description": "An indicator allowing an operator to run LED lamp test.",
+                    "longDescription": "This property shall contain the state of lamp state function for this resource.",
+                    "readonly": false,
+                    "type": [
+                        "boolean",
+                        "null"
+                    ]
+                },
+                "PartitionSystemAttentionIndicator": {
+                    "description": "An indicator allowing an operator to operate partition system attention.",
+                    "longDescription": "This property shall contain the state of the partition system attention of this resource.",
+                    "readonly": false,
+                    "type": [
+                        "boolean",
+                        "null"
+                    ]
+                },
+                "PlatformSystemAttentionIndicator": {
+                    "description": "An indicator allowing an operator to operate platform system attention.",
+                    "longDescription": "This property shall contain the state of the platform system attention of this resource.",
+                    "readonly": false,
+                    "type": [
+                        "boolean",
+                        "null"
+                    ]
+                }
+            },
             "type": "object"
         }
     },

--- a/static/redfish/v1/schema/OemComputerSystem_v1.xml
+++ b/static/redfish/v1/schema/OemComputerSystem_v1.xml
@@ -23,6 +23,28 @@
                 <Annotation Term="OData.Description" String="OemComputerSystem Oem properties." />
                 <Annotation Term="OData.AutoExpand"/>
                 <Property Name="OpenBmc" Type="OemComputerSystem.OpenBmc"/>
+                <Property Name="IBM" Type="OemComputerSystem.IBM"/>
+            </ComplexType>
+
+            <ComplexType Name="IBM" BaseType="Resource.OemObject">
+                <Annotation Term="OData.AdditionalProperties" Bool="true" />
+                <Annotation Term="OData.Description" String="Oem properties for IBM." />
+                <Annotation Term="OData.AutoExpand"/>
+                <Property Name="LampTest" Type="OemComputerSystem.IBM">
+                    <Annotation Term="OData.Permissions" EnumMember="OData.Permission/ReadWrite"/>
+                    <Annotation Term="OData.Description" String="An indicator allowing an operator to run LED lamp test."/>
+                    <Annotation Term="OData.LongDescription" String="This property shall contain the state of lamp state function for this resource."/>
+                </Property>
+                <Property Name="PartitionSystemAttentionIndicator" Type="OemComputerSystem.IBM">
+                    <Annotation Term="OData.Permissions" EnumMember="OData.Permission/ReadWrite"/>
+                    <Annotation Term="OData.Description" String="An indicator allowing an operator to operate partition system attention."/>
+                    <Annotation Term="OData.LongDescription" String="This property shall contain the state of the partition system attention of this resource."/>
+                </Property>
+                <Property Name="PlatformSystemAttentionIndicator" Type="OemComputerSystem.IBM">
+                    <Annotation Term="OData.Permissions" EnumMember="OData.Permission/ReadWrite"/>
+                    <Annotation Term="OData.Description" String="An indicator allowing an operator to operate platform system attention."/>
+                    <Annotation Term="OData.LongDescription" String="This property shall contain the state of the platform system attention of this resource."/>
+                </Property>
             </ComplexType>
 
             <ComplexType Name="OpenBmc" BaseType="Resource.OemObject">


### PR DESCRIPTION
Implement OEM lamp test in redfish/v1/Systems/system

Implement SystemAttentionIndicator in redfish/v1/Systems/system
refer: https://github.com/ibm-openbmc/dev/issues/2120

We use macros to control the URL, which need to be enabled in
bmcweb_%.bbappend to see it, for example:
EXTRA_OEMESON_append = " \
    -Dibm-led-extensions=enabled \
    "

Tested:
1. Get the lamp test and SAI:
curl -k -H "X-Auth-Token: $token" \
https://${bmc}/redfish/v1/Systems/system
{
  "@odata.id": "/redfish/v1/Systems/system",
  "@odata.type": "#ComputerSystem.v1_16_0.ComputerSystem",
  ...
  "Oem": {
    "@odata.type": "#OemComputerSystem.Oem",
    "IBM": {
      "@odata.type": "#OemComputerSystem.IBM",
      "LampTest": false,
      "PartitionSystemAttentionIndicator": false,
      "PlatformSystemAttentionIndicator": false
    }
  },
  ...
}

2. Set the lamp test and SAI:
curl -k -H "X-Auth-Token: $token" -X PATCH \
https://${bmc}/redfish/v1/Systems/system -d \
'{"Oem":{"IBM":{"LampTest": true, \
"PartitionSystemAttentionIndicator": true}}}'

3. Get the lamp test and SAI:
curl -k -H "X-Auth-Token: $token" \
https://${bmc}/redfish/v1/Systems/system
{
  "@odata.id": "/redfish/v1/Systems/system",
  "@odata.type": "#ComputerSystem.v1_16_0.ComputerSystem",
  ...
  "Oem": {
    "@odata.type": "#OemComputerSystem.Oem",
    "IBM": {
      "@odata.type": "#OemComputerSystem.IBM",
      "LampTest": true,
      "PartitionSystemAttentionIndicator": true,
      "PlatformSystemAttentionIndicator": false
    }
  },
  ...
}