### PR TITLE
Sync HardwareIsolation 1030 commits to 1050

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -96,6 +96,7 @@ feature_map = {
   'redfish-license'                             : '-DBMCWEB_ENABLE_REDFISH_LICENSE',
   #'vm-nbdproxy'                                : '-DBMCWEB_ENABLE_VM_NBDPROXY',
   'ibm-led-extensions'                          : '-DBMCWEB_ENABLE_IBM_LED_EXTENSIONS',
+  'hw-isolation'                                : '-DBMCWEB_ENABLE_HW_ISOLATION',
 }
 
 # Get the options status and build a project summary to show which flags are

--- a/meson_options.txt
+++ b/meson_options.txt
@@ -354,3 +354,10 @@ option('ibm-led-extensions',
       value : 'disabled',
       description : 'Enable the IBM LED extensions such as lamp test and system attention indicators'
 )
+
+option(
+      'hw-isolation',
+      type : 'feature',
+      value : 'disabled',
+      description : 'Enable the Hardware Isolation feature'
+)

--- a/redfish-core/include/error_messages.hpp
+++ b/redfish-core/include/error_messages.hpp
@@ -483,6 +483,25 @@ void propertyValueIncorrect(crow::Response& res, std::string_view arg1,
                             std::string_view arg2);
 
 /**
+ * @brief Formats PropertyValueResourceConflict message into JSON
+ * Message body: "The property '%1' with the requested value of '%2' could
+ * not be written because the value conflicts with the state or configuration
+ * of the resource at '%3'."
+ *
+ * @param[in] arg1 Parameter of message that will replace %1 in its body.
+ * @param[in] arg2 Parameter of message that will replace %2 in its body.
+ * @param[in] arg3 Parameter of message that will replace %3 in its body.
+ *
+ * @returns Message PropertyValueResourceConflict to JSON */
+nlohmann::json propertyValueResourceConflict(const std::string& arg1,
+                                             const std::string& arg2,
+                                             const std::string& arg3);
+
+void propertyValueResourceConflict(crow::Response& res, const std::string& arg1,
+                                   const std::string& arg2,
+                                   const std::string& arg3);
+
+/**
  * @brief Formats ResourceCreationConflict message into JSON
  * Message body: "The resource could not be created.  The service has a resource
  * at URI '<arg1>' that conflicts with the creation request."

--- a/redfish-core/include/error_messages.hpp
+++ b/redfish-core/include/error_messages.hpp
@@ -502,6 +502,22 @@ void propertyValueResourceConflict(crow::Response& res, const std::string& arg1,
                                    const std::string& arg3);
 
 /**
+ * @brief Formats PropertyValueExternalConflict message into JSON
+ * Message body: "The property '%1' with the requested value of '%2' could not
+ * be written because the value is not available due to a configuration
+ * conflict."
+ *
+ * @param[in] arg1 Parameter of message that will replace %1 in its body.
+ * @param[in] arg2 Parameter of message that will replace %2 in its body.
+ *
+ * @returns Message PropertyValueExternalConflict to JSON */
+nlohmann::json propertyValueExternalConflict(const std::string& arg1,
+                                             const std::string& arg2);
+
+void propertyValueExternalConflict(crow::Response& res, const std::string& arg1,
+                                   const std::string& arg2);
+
+/**
  * @brief Formats ResourceCreationConflict message into JSON
  * Message body: "The resource could not be created.  The service has a resource
  * at URI '<arg1>' that conflicts with the creation request."

--- a/redfish-core/include/redfish.hpp
+++ b/redfish-core/include/redfish.hpp
@@ -185,6 +185,8 @@ class RedfishService
         requestRoutesOperatingConfig(app);
         requestRoutesMemoryCollection(app);
         requestRoutesMemory(app);
+        requestRoutesSubProcessors(app);
+        requestRoutesSubProcessorsCore(app);
 
         requestRoutesSystemsCollection(app);
         requestRoutesSystems(app);

--- a/redfish-core/include/redfish.hpp
+++ b/redfish-core/include/redfish.hpp
@@ -262,6 +262,10 @@ class RedfishService
 
         // Note, this must be the last route registered
         requestRoutesRedfish(app);
+
+#ifdef BMCWEB_ENABLE_HW_ISOLATION
+        requestRoutesSystemHardwareIsolationLogService(app);
+#endif
     }
 };
 

--- a/redfish-core/include/registries/openbmc_message_registry.hpp
+++ b/redfish-core/include/registries/openbmc_message_registry.hpp
@@ -567,6 +567,16 @@ constexpr std::array registry = {
             {"string"},
             "None.",
         }},
+    MessageEntry{
+        "HardwareIsolationReason",
+        {
+            "Indicates the condition that affects the health of this resource.",
+            "The reason for the resource isolation: %1",
+            "OK",
+            1,
+            {"string"},
+            "None.",
+        }},
     MessageEntry{"InvalidLoginAttempted",
                  {
                      "Indicates that a login was attempted on the specified "

--- a/redfish-core/include/utils/error_log_utils.hpp
+++ b/redfish-core/include/utils/error_log_utils.hpp
@@ -1,0 +1,83 @@
+#pragma once
+
+namespace redfish
+{
+namespace error_log_utils
+{
+
+/*
+ * @brief The helper API to set the Redfish error log URI in the given
+ *        Redfish property JSON path based on the Hidden property
+ *        which will be present in the given error log D-Bus object.
+ *
+ * @param[in] aResp - The redfish response to return.
+ * @param[in] errorLogObjPath - The error log D-Bus object path.
+ * @param[in] errorLogPropPath - The Redfish property json path to fill URI.
+ * @param[in] isLink - The boolean to add URI as a Redfish link.
+ *
+ * @return NULL
+ *
+ * @note The "isLink" parameter is used to add the URI as a link (i.e with
+ *       "@odata.id"). If passed as "false" then, the suffix will be added
+ *       as "/attachment" along with the URI.
+ */
+inline void setErrorLogUri(
+    const std::shared_ptr<bmcweb::AsyncResp>& aResp,
+    const sdbusplus::message::object_path& errorLogObjPath,
+    const nlohmann::json_pointer<nlohmann::json>& errorLogPropPath,
+    const bool isLink)
+{
+    // Get the Hidden Property
+    crow::connections::systemBus->async_method_call(
+        [aResp, errorLogObjPath, errorLogPropPath,
+         isLink](const boost::system::error_code ec,
+                 std::variant<bool>& hiddenProperty) {
+            if (ec)
+            {
+                BMCWEB_LOG_ERROR << "DBus response error [" << ec.value()
+                                 << " : " << ec.message()
+                                 << "] when tried to get the Hidden property "
+                                 << "from the given error log object "
+                                 << errorLogObjPath.str;
+                messages::internalError(aResp->res);
+                return;
+            }
+            bool* hiddenPropVal = std::get_if<bool>(&hiddenProperty);
+            if (hiddenPropVal == nullptr)
+            {
+                BMCWEB_LOG_ERROR << "Failed to get the Hidden property value "
+                                 << "from the given error log object "
+                                 << errorLogObjPath.str;
+                messages::internalError(aResp->res);
+                return;
+            }
+
+            std::string errLogUri{"/redfish/v1/Systems/system/LogServices/"};
+            if (*hiddenPropVal)
+            {
+                errLogUri.append("CELog/Entries/");
+            }
+            else
+            {
+                errLogUri.append("EventLog/Entries/");
+            }
+            errLogUri.append(errorLogObjPath.filename());
+
+            if (isLink)
+            {
+                aResp->res.jsonValue[errorLogPropPath] = {
+                    {"@odata.id", errLogUri}};
+            }
+            else
+            {
+                errLogUri.append("/attachment");
+                aResp->res.jsonValue[errorLogPropPath] = errLogUri;
+            }
+        },
+        "xyz.openbmc_project.Logging", errorLogObjPath.str,
+        "org.freedesktop.DBus.Properties", "Get",
+        "org.open_power.Logging.PEL.Entry", "Hidden");
+}
+
+} // namespace error_log_utils
+} // namespace redfish

--- a/redfish-core/include/utils/error_log_utils.hpp
+++ b/redfish-core/include/utils/error_log_utils.hpp
@@ -26,11 +26,11 @@ namespace error_log_utils
  *       might delete by the user via Redfish but, we should not throw
  *       internal error in that case, just log trace and return.
  */
-inline void setErrorLogUri(
-    const std::shared_ptr<bmcweb::AsyncResp>& aResp,
-    const sdbusplus::message::object_path& errorLogObjPath,
-    const nlohmann::json_pointer<nlohmann::json>& errorLogPropPath,
-    const bool isLink)
+inline void
+    setErrorLogUri(const std::shared_ptr<bmcweb::AsyncResp>& aResp,
+                   const sdbusplus::message::object_path& errorLogObjPath,
+                   const nlohmann::json::json_pointer& errorLogPropPath,
+                   const bool isLink)
 {
     // Get the Hidden Property
     crow::connections::systemBus->async_method_call(

--- a/redfish-core/include/utils/error_log_utils.hpp
+++ b/redfish-core/include/utils/error_log_utils.hpp
@@ -37,45 +37,43 @@ inline void setErrorLogUri(
         [aResp, errorLogObjPath, errorLogPropPath,
          isLink](const boost::system::error_code ec,
                  std::variant<bool>& hiddenProperty) {
-            if (ec)
-            {
-                BMCWEB_LOG_ERROR << "DBus response error [" << ec.value()
-                                 << " : " << ec.message()
-                                 << "] when tried to get the Hidden property "
-                                 << "from the given error log object "
-                                 << errorLogObjPath.str;
-                return;
-            }
-            bool* hiddenPropVal = std::get_if<bool>(&hiddenProperty);
-            if (hiddenPropVal == nullptr)
-            {
-                BMCWEB_LOG_ERROR << "Failed to get the Hidden property value "
-                                 << "from the given error log object "
-                                 << errorLogObjPath.str;
-                return;
-            }
+        if (ec)
+        {
+            BMCWEB_LOG_ERROR
+                << "DBus response error [" << ec.value() << " : "
+                << ec.message() << "] when tried to get the Hidden property "
+                << "from the given error log object " << errorLogObjPath.str;
+            return;
+        }
+        bool* hiddenPropVal = std::get_if<bool>(&hiddenProperty);
+        if (hiddenPropVal == nullptr)
+        {
+            BMCWEB_LOG_ERROR << "Failed to get the Hidden property value "
+                             << "from the given error log object "
+                             << errorLogObjPath.str;
+            return;
+        }
 
-            std::string errLogUri{"/redfish/v1/Systems/system/LogServices/"};
-            if (*hiddenPropVal)
-            {
-                errLogUri.append("CELog/Entries/");
-            }
-            else
-            {
-                errLogUri.append("EventLog/Entries/");
-            }
-            errLogUri.append(errorLogObjPath.filename());
+        std::string errLogUri{"/redfish/v1/Systems/system/LogServices/"};
+        if (*hiddenPropVal)
+        {
+            errLogUri.append("CELog/Entries/");
+        }
+        else
+        {
+            errLogUri.append("EventLog/Entries/");
+        }
+        errLogUri.append(errorLogObjPath.filename());
 
-            if (isLink)
-            {
-                aResp->res.jsonValue[errorLogPropPath] = {
-                    {"@odata.id", errLogUri}};
-            }
-            else
-            {
-                errLogUri.append("/attachment");
-                aResp->res.jsonValue[errorLogPropPath] = errLogUri;
-            }
+        if (isLink)
+        {
+            aResp->res.jsonValue[errorLogPropPath] = {{"@odata.id", errLogUri}};
+        }
+        else
+        {
+            errLogUri.append("/attachment");
+            aResp->res.jsonValue[errorLogPropPath] = errLogUri;
+        }
         },
         "xyz.openbmc_project.Logging", errorLogObjPath.str,
         "org.freedesktop.DBus.Properties", "Get",

--- a/redfish-core/include/utils/error_log_utils.hpp
+++ b/redfish-core/include/utils/error_log_utils.hpp
@@ -20,6 +20,11 @@ namespace error_log_utils
  * @note The "isLink" parameter is used to add the URI as a link (i.e with
  *       "@odata.id"). If passed as "false" then, the suffix will be added
  *       as "/attachment" along with the URI.
+ *
+ *       This API won't fill the given "errorLogPropPath" property if unable
+ *       to process the given error log D-Bus object since the error log
+ *       might delete by the user via Redfish but, we should not throw
+ *       internal error in that case, just log trace and return.
  */
 inline void setErrorLogUri(
     const std::shared_ptr<bmcweb::AsyncResp>& aResp,
@@ -39,7 +44,6 @@ inline void setErrorLogUri(
                                  << "] when tried to get the Hidden property "
                                  << "from the given error log object "
                                  << errorLogObjPath.str;
-                messages::internalError(aResp->res);
                 return;
             }
             bool* hiddenPropVal = std::get_if<bool>(&hiddenProperty);
@@ -48,7 +52,6 @@ inline void setErrorLogUri(
                 BMCWEB_LOG_ERROR << "Failed to get the Hidden property value "
                                  << "from the given error log object "
                                  << errorLogObjPath.str;
-                messages::internalError(aResp->res);
                 return;
             }
 

--- a/redfish-core/include/utils/hw_isolation.hpp
+++ b/redfish-core/include/utils/hw_isolation.hpp
@@ -285,6 +285,12 @@ inline void
                             std::to_string(enabledPropVal),
                             "HardwareIsolation");
                     }
+                    else if (strcmp(dbusError->name,
+                                    "xyz.openbmc_project.Common.Error."
+                                    "InsufficientPermission") == 0)
+                    {
+                        messages::resourceCannotBeDeleted(aResp->res);
+                    }
                     else
                     {
                         BMCWEB_LOG_ERROR << "DBus Error is unsupported so "

--- a/redfish-core/include/utils/hw_isolation.hpp
+++ b/redfish-core/include/utils/hw_isolation.hpp
@@ -1,0 +1,339 @@
+#pragma once
+
+#include <string>
+#include <vector>
+
+namespace redfish
+{
+namespace hw_isolation_utils
+{
+
+/**
+ * @brief API used to isolate the given resource
+ *
+ * @param[in] aResp - The redfish response to return to the caller.
+ * @param[in] resourceName - The redfish resource name which trying to isolate.
+ * @param[in] resourceId - The redfish resource id which trying to isolate.
+ * @param[in] resourceObjPath - The redfish resource dbus object path.
+ * @param[in] hwIsolationDbusName - The HardwareIsolation dbus name which is
+ *                                  hosting isolation dbus interfaces.
+ *
+ * @return The redfish response in given response buffer.
+ *
+ * @note This function will return the appropriate error based on the isolation
+ *       dbus "Create" interface error.
+ */
+inline void
+    isolateResource(const std::shared_ptr<bmcweb::AsyncResp>& aResp,
+                    const std::string& resourceName,
+                    const std::string& resourceId,
+                    const sdbusplus::message::object_path& resourceObjPath,
+                    const std::string& hwIsolationDbusName)
+{
+    crow::connections::systemBus->async_method_call(
+        [aResp, resourceName, resourceId,
+         resourceObjPath](const boost::system::error_code ec,
+                          const sdbusplus::message::message& msg) {
+            if (!ec)
+            {
+                messages::success(aResp->res);
+                return;
+            }
+
+            BMCWEB_LOG_ERROR << "DBUS response error [" << ec.value() << " : "
+                             << ec.message()
+                             << "] when tried to isolate the given resource: "
+                             << resourceObjPath.str;
+
+            const sd_bus_error* dbusError = msg.get_error();
+            if (dbusError == nullptr)
+            {
+                messages::internalError(aResp->res);
+                return;
+            }
+
+            BMCWEB_LOG_ERROR << "DBus ErrorName: " << dbusError->name
+                             << " ErrorMsg: " << dbusError->message;
+
+            if (strcmp(dbusError->name, "xyz.openbmc_project.Common.Error."
+                                        "InvalidArgument") == 0)
+            {
+                constexpr bool isolate = false;
+                messages::propertyValueIncorrect(aResp->res, "@odata.id",
+                                                 std::to_string(isolate));
+            }
+            else if (strcmp(dbusError->name, "xyz.openbmc_project.Common.Error."
+                                             "NotAllowed") == 0)
+            {
+                messages::propertyNotWritable(aResp->res, "Enabled");
+            }
+            else if (strcmp(dbusError->name, "xyz.openbmc_project.Common.Error."
+                                             "Unavailable") == 0)
+            {
+                messages::resourceInStandby(aResp->res);
+            }
+            else if (strcmp(dbusError->name, "xyz.openbmc_project."
+                                             "HardwareIsolation.Error."
+                                             "IsolatedAlready") == 0)
+            {
+                messages::resourceAlreadyExists(aResp->res, "@odata.id",
+                                                resourceName, resourceId);
+            }
+            else if (strcmp(dbusError->name, "xyz.openbmc_project.Common.Error."
+                                             "TooManyResources") == 0)
+            {
+                messages::createLimitReachedForResource(aResp->res);
+            }
+            else
+            {
+                BMCWEB_LOG_ERROR << "DBus Error is unsupported so "
+                                    "returning as Internal Error";
+                messages::internalError(aResp->res);
+            }
+            return;
+        },
+        hwIsolationDbusName, "/xyz/openbmc_project/hardware_isolation",
+        "xyz.openbmc_project.HardwareIsolation.Create", "Create",
+        resourceObjPath,
+        "xyz.openbmc_project.HardwareIsolation.Entry.Type.Manual");
+}
+
+/**
+ * @brief API used to deisolate the given resource
+ *
+ * @param[in] aResp - The redfish response to return to the caller.
+ * @param[in] resourceObjPath - The redfish resource dbus object path.
+ * @param[in] hwIsolationDbusName - The HardwareIsolation dbus name which is
+ *                                  hosting isolation dbus interfaces.
+ *
+ * @return The redfish response in given response buffer.
+ *
+ * @note - This function will try to identify the hardware isolated dbus entry
+ *         from associations endpoints by using the given resource dbus object
+ *         of "isolated_hw_entry".
+ *       - This function will use the last endpoint from the list since the
+ *         HardwareIsolation manager may be used the "Resolved" dbus entry
+ *         property to indicate the deisolation instead of delete
+ *         the entry object.
+ */
+inline void
+    deisolateResource(const std::shared_ptr<bmcweb::AsyncResp>& aResp,
+                      const sdbusplus::message::object_path& resourceObjPath,
+                      const std::string& hwIsolationDbusName)
+{
+    // Get the HardwareIsolation entry by using the given resource
+    // associations endpoints
+    crow::connections::systemBus->async_method_call(
+        [aResp, resourceObjPath, hwIsolationDbusName](
+            boost::system::error_code ec,
+            const std::variant<std::vector<std::string>>& vEndpoints) {
+            if (ec)
+            {
+                BMCWEB_LOG_ERROR << "DBus response error [" << ec.value()
+                                 << " : " << ec.message()
+                                 << "] when tried to get the hardware "
+                                    "isolation entry for the given "
+                                    "resource dbus object path: "
+                                 << resourceObjPath.str;
+                messages::internalError(aResp->res);
+                return;
+            }
+
+            std::string resourceIsolatedHwEntry;
+            const std::vector<std::string>* endpoints =
+                std::get_if<std::vector<std::string>>(&(vEndpoints));
+            if (endpoints == nullptr)
+            {
+                BMCWEB_LOG_ERROR << "Failed to get Associations endpoints "
+                                    "for the given object path: "
+                                 << resourceObjPath.str;
+                messages::internalError(aResp->res);
+                return;
+            }
+            resourceIsolatedHwEntry = endpoints->back();
+
+            // De-isolate the given resource
+            crow::connections::systemBus->async_method_call(
+                [aResp, resourceIsolatedHwEntry](
+                    const boost::system::error_code ec1,
+                    const sdbusplus::message::message& msg) {
+                    if (!ec1)
+                    {
+                        messages::success(aResp->res);
+                        return;
+                    }
+
+                    BMCWEB_LOG_ERROR << "DBUS response error [" << ec1.value()
+                                     << " : " << ec1.message()
+                                     << "] when tried to isolate the given "
+                                     << "resource: " << resourceIsolatedHwEntry;
+
+                    const sd_bus_error* dbusError = msg.get_error();
+
+                    if (dbusError == nullptr)
+                    {
+                        messages::internalError(aResp->res);
+                        return;
+                    }
+
+                    BMCWEB_LOG_ERROR << "DBus ErrorName: " << dbusError->name
+                                     << " ErrorMsg: " << dbusError->message;
+
+                    if (strcmp(dbusError->name,
+                               "xyz.openbmc_project.Common.Error."
+                               "NotAllowed") == 0)
+                    {
+                        messages::propertyNotWritable(aResp->res, "Entry");
+                    }
+                    else if (strcmp(dbusError->name,
+                                    "xyz.openbmc_project.Common.Error."
+                                    "Unavailable") == 0)
+                    {
+                        messages::resourceInStandby(aResp->res);
+                    }
+                    else
+                    {
+                        BMCWEB_LOG_ERROR << "DBus Error is unsupported so "
+                                            "returning as Internal Error";
+                        messages::internalError(aResp->res);
+                    }
+                    return;
+                },
+                hwIsolationDbusName, resourceIsolatedHwEntry,
+                "xyz.openbmc_project.Object.Delete", "Delete");
+        },
+        "xyz.openbmc_project.ObjectMapper",
+        resourceObjPath.str + "/isolated_hw_entry",
+        "org.freedesktop.DBus.Properties", "Get",
+        "xyz.openbmc_project.Association", "endpoints");
+}
+
+/**
+ * @brief API used to process hardware (aka resource) isolation request
+ *        This API can be used to any redfish resource if that redfish
+ *        supporting isolation feature (the resource can be isolate
+ *        from system boot)
+ *
+ * @param[in] aResp - The redfish response to return to the caller.
+ * @param[in] resourceName - The redfish resource name which trying to isolate.
+ * @param[in] resourceId - The redfish resource id which trying to isolate.
+ * @param[in] enabled - The redfish resource "Enabled" property value.
+ * @param[in] interfaces - The redfish resource dbus interfaces which will use
+ *                         to get the given resource dbus objects from
+ *                         the inventory.
+ *
+ * @return The redfish response in given response buffer.
+ *
+ * @note - This function will identify the given resource dbus object from
+ *         the inventory by using the given resource dbus interfaces along
+ *         with "Object:Enable" interface (which is used to map the "Enabled"
+ *         redfish property to dbus "Enabled" property - The "Enabled" is
+ *         used to do isolate the resource from system boot) and the given
+ *         redfish resource "Id".
+ *       - This function will do either isolate or deisolate based on the
+ *         given "Enabled" property value.
+ */
+inline void
+    processHardwareIsolationReq(const std::shared_ptr<bmcweb::AsyncResp>& aResp,
+                                const std::string& resourceName,
+                                const std::string& resourceId, bool enabled,
+                                const std::vector<const char*>& interfaces)
+{
+    std::vector<const char*> resourceIfaces(interfaces.begin(),
+                                            interfaces.end());
+    resourceIfaces.push_back("xyz.openbmc_project.Object.Enable");
+
+    // Make sure the given resourceId is present in inventory
+    crow::connections::systemBus->async_method_call(
+        [aResp, resourceName, resourceId,
+         enabled](boost::system::error_code ec,
+                  const std::vector<std::string>& objects) {
+            if (ec)
+            {
+                BMCWEB_LOG_ERROR << "DBus response error [" << ec.value()
+                                 << " : " << ec.message()
+                                 << "] when tried to check the given resource "
+                                    "is present in tne inventory";
+                messages::internalError(aResp->res);
+                return;
+            }
+
+            sdbusplus::message::object_path resourceObjPath;
+            for (const auto& object : objects)
+            {
+                sdbusplus::message::object_path path(object);
+                if (path.filename() == resourceId)
+                {
+                    resourceObjPath = path;
+                    break;
+                }
+            }
+
+            if (resourceObjPath.str.empty())
+            {
+                messages::resourceNotFound(aResp->res, resourceName,
+                                           resourceId);
+                return;
+            }
+
+            // Get the HardwareIsolation DBus name
+            crow::connections::systemBus->async_method_call(
+                [aResp, resourceObjPath, enabled, resourceName,
+                 resourceId](const boost::system::error_code ec1,
+                             const dbus::utility::MapperGetObject& objType) {
+                    if (ec1)
+                    {
+                        BMCWEB_LOG_ERROR
+                            << "DBUS response error [" << ec1.value() << " : "
+                            << ec1.message()
+                            << "] when tried to get the HardwareIsolation "
+                               "dbus name to isolate: "
+                            << resourceObjPath.str;
+                        messages::internalError(aResp->res);
+                        return;
+                    }
+
+                    if (objType.size() > 1)
+                    {
+                        BMCWEB_LOG_ERROR << "More than one dbus service "
+                                         << "implemented HardwareIsolation";
+                        messages::internalError(aResp->res);
+                        return;
+                    }
+
+                    if (objType[0].first.empty())
+                    {
+                        BMCWEB_LOG_ERROR << "The retrieved HardwareIsolation "
+                                         << "dbus name is empty";
+                        messages::internalError(aResp->res);
+                        return;
+                    }
+
+                    // Make sure whether need to isolate or de-isolate
+                    // the given resource
+                    if (!enabled)
+                    {
+                        isolateResource(aResp, resourceName, resourceId,
+                                        resourceObjPath, objType[0].first);
+                    }
+                    else
+                    {
+                        deisolateResource(aResp, resourceObjPath,
+                                          objType[0].first);
+                    }
+                },
+                "xyz.openbmc_project.ObjectMapper",
+                "/xyz/openbmc_project/object_mapper",
+                "xyz.openbmc_project.ObjectMapper", "GetObject",
+                "/xyz/openbmc_project/hardware_isolation",
+                std::array<const char*, 1>{
+                    "xyz.openbmc_project.HardwareIsolation.Create"});
+        },
+        "xyz.openbmc_project.ObjectMapper",
+        "/xyz/openbmc_project/object_mapper",
+        "xyz.openbmc_project.ObjectMapper", "GetSubTreePaths",
+        "/xyz/openbmc_project/inventory", 0, resourceIfaces);
+}
+
+} // namespace hw_isolation_utils
+} // namespace redfish

--- a/redfish-core/include/utils/hw_isolation.hpp
+++ b/redfish-core/include/utils/hw_isolation.hpp
@@ -1,5 +1,8 @@
 #pragma once
 
+#include <utils/error_log_utils.hpp>
+#include <utils/time_utils.hpp>
+
 #include <string>
 #include <vector>
 
@@ -333,6 +336,339 @@ inline void
         "/xyz/openbmc_project/object_mapper",
         "xyz.openbmc_project.ObjectMapper", "GetSubTreePaths",
         "/xyz/openbmc_project/inventory", 0, resourceIfaces);
+}
+
+/*
+ * @brief The helper API to set the Redfish severity level base on
+ *        the given severity.
+ *
+ * @param[in] aResp - The redfish response to return.
+ * @param[in] objPath - The D-Bus object path of the given severity.
+ * @param[in] severityPropPath - The Redfish severity property json path.
+ * @param[in] severityVal - The D-Bus object severity.
+ *
+ * @return True on success
+ *         False on failure and set the error in the redfish response.
+ */
+inline bool
+    setSeverity(const std::shared_ptr<bmcweb::AsyncResp>& aResp,
+                const sdbusplus::message::object_path& objPath,
+                const nlohmann::json_pointer<nlohmann::json>& severityPropPath,
+                const std::string& severityVal)
+{
+    if (severityVal == "xyz.openbmc_project.Logging.Event."
+                       "SeverityLevel.Critical")
+    {
+        aResp->res.jsonValue[severityPropPath] = "Critical";
+    }
+    else if ((severityVal == "xyz.openbmc_project.Logging."
+                             "Event.SeverityLevel.Warning") ||
+             (severityVal == "xyz.openbmc_project.Logging."
+                             "Event.SeverityLevel.Unknown"))
+    {
+        aResp->res.jsonValue[severityPropPath] = "Warning";
+    }
+    else if (severityVal == "xyz.openbmc_project.Logging."
+                            "Event.SeverityLevel.Ok")
+    {
+        aResp->res.jsonValue[severityPropPath] = "OK";
+    }
+    else
+    {
+        BMCWEB_LOG_ERROR << "Unsupported Severity[ " << severityVal
+                         << "] from object: " << objPath.str;
+        messages::internalError(aResp->res);
+        return false;
+    }
+    return true;
+}
+
+/*
+ * @brief The helper API to set the Redfish Status conditions based on
+ *        the given resource event log association.
+ *
+ * @param[in] aResp - The redfish response to return.
+ * @param[in] resourceObjPath - The resource D-Bus object object.
+ *
+ * @return NULL
+ */
+inline void
+    getHwIsolationStatus(const std::shared_ptr<bmcweb::AsyncResp>& aResp,
+                         const sdbusplus::message::object_path& resourceObjPath)
+{
+    crow::connections::systemBus->async_method_call(
+        [aResp, resourceObjPath](
+            boost::system::error_code ec,
+            const std::variant<std::vector<std::string>>& vEndpoints) {
+            if (ec)
+            {
+                if (ec.value() == EBADR)
+                {
+                    // No event so the respective hardware status doesn't need
+                    // any Redfish status condition
+                    return;
+                }
+                BMCWEB_LOG_ERROR << "DBus response error [" << ec.value()
+                                 << " : " << ec.message()
+                                 << "] when tried to get the hardware "
+                                    "status event for the given "
+                                    "resource dbus object path: "
+                                 << resourceObjPath.str << "EBADR: " << EBADR;
+                messages::internalError(aResp->res);
+                return;
+            }
+
+            const std::vector<std::string>* endpoints =
+                std::get_if<std::vector<std::string>>(&(vEndpoints));
+            if (endpoints == nullptr)
+            {
+                BMCWEB_LOG_ERROR << "Failed to get Associations endpoints "
+                                    "for the given object path: "
+                                 << resourceObjPath.str;
+                messages::internalError(aResp->res);
+                return;
+            }
+
+            bool found = false;
+            std::string hwStatusEventObj;
+            for (const auto& endpoint : *endpoints)
+            {
+                if (sdbusplus::message::object_path(endpoint)
+                        .parent_path()
+                        .filename() == "hw_isolation_status")
+                {
+                    hwStatusEventObj = endpoint;
+                    found = true;
+                    break;
+                }
+            }
+
+            if (!found)
+            {
+                // No event so the respective hardware status doesn't need
+                // any Redfish status condition
+                return;
+            }
+
+            // Get the dbus service name of the hardware status event object
+            crow::connections::systemBus->async_method_call(
+                [aResp, hwStatusEventObj](const boost::system::error_code ec1,
+                                          const dbus::utility::MapperGetObject& objType) {
+                    if (ec1)
+                    {
+                        BMCWEB_LOG_ERROR
+                            << "DBUS response error [" << ec1.value() << " : "
+                            << ec1.message()
+                            << "] when tried to get the dbus name "
+                            << "of the hardware status event object "
+                            << hwStatusEventObj;
+                        messages::internalError(aResp->res);
+                        return;
+                    }
+
+                    if (objType.size() > 1)
+                    {
+                        BMCWEB_LOG_ERROR << "More than one dbus service "
+                                         << "implemented the same hardware "
+                                         << "status event object "
+                                         << hwStatusEventObj;
+                        messages::internalError(aResp->res);
+                        return;
+                    }
+
+                    if (objType[0].first.empty())
+                    {
+                        BMCWEB_LOG_ERROR << "The retrieved hardware status "
+                                         << "event object dbus name is empty";
+                        messages::internalError(aResp->res);
+                        return;
+                    }
+
+                    using AssociationsValType = std::vector<
+                        std::tuple<std::string, std::string, std::string>>;
+                    using HwStausEventPropertiesType =
+                        boost::container::flat_map<
+                            std::string, std::variant<std::string, uint64_t,
+                                                      AssociationsValType>>;
+
+                    // Get event properties and fill into status conditions
+                    crow::connections::systemBus->async_method_call(
+                        [aResp, hwStatusEventObj](
+                            const boost::system::error_code ec2,
+                            const HwStausEventPropertiesType& properties) {
+                            if (ec2)
+                            {
+                                BMCWEB_LOG_ERROR
+                                    << "DBUS response error [" << ec2.value()
+                                    << " : " << ec2.message() << "] when tried "
+                                    << "to get the hardware status event "
+                                    << "object properties " << hwStatusEventObj;
+                                messages::internalError(aResp->res);
+                                return;
+                            }
+
+                            // Event is exist and that will get created when
+                            // the respective hardware is not functional so
+                            // set the state as "Disabled".
+                            aResp->res.jsonValue["Status"]["State"] =
+                                "Disabled";
+
+                            nlohmann::json& conditions =
+                                aResp->res.jsonValue["Status"]["Conditions"];
+                            conditions = nlohmann::json::array();
+                            conditions.push_back(nlohmann::json::object());
+                            nlohmann::json& condition = conditions.back();
+
+                            for (const auto& property : properties)
+                            {
+                                if (property.first == "Associations")
+                                {
+                                    const AssociationsValType* associations =
+                                        std::get_if<AssociationsValType>(
+                                            &property.second);
+                                    if (associations == nullptr)
+                                    {
+                                        BMCWEB_LOG_ERROR
+                                            << "Failed to get the Associations "
+                                            << "from object: "
+                                            << hwStatusEventObj;
+                                        messages::internalError(aResp->res);
+                                        return;
+                                    }
+
+                                    for (const auto& assoc : *associations)
+                                    {
+                                        if (std::get<0>(assoc) == "error_log")
+                                        {
+                                            sdbusplus::message::object_path
+                                                errPath = std::get<2>(assoc);
+                                            // we have only one condition
+                                            nlohmann::json_pointer logEntryPropPath =
+                                                "/Status/Conditions/0/LogEntry"_json_pointer;
+                                            error_log_utils::setErrorLogUri(
+                                                aResp, errPath,
+                                                logEntryPropPath, true);
+                                        }
+                                    }
+                                }
+                                else if (property.first == "Timestamp")
+                                {
+                                    const uint64_t* timestamp =
+                                        std::get_if<uint64_t>(&property.second);
+                                    if (timestamp == nullptr)
+                                    {
+                                        BMCWEB_LOG_ERROR
+                                            << "Failed to get the Timestamp "
+                                            << "from object: "
+                                            << hwStatusEventObj;
+                                        messages::internalError(aResp->res);
+                                        return;
+                                    }
+                                    condition["Timestamp"] =
+                                        redfish::time_utils::getDateTimeStdtime(
+                                            static_cast<std::time_t>(
+                                                *timestamp));
+                                }
+                                else if (property.first == "Message")
+                                {
+                                    const std::string* msgPropVal =
+                                        std::get_if<std::string>(
+                                            &property.second);
+                                    if (msgPropVal == nullptr)
+                                    {
+                                        BMCWEB_LOG_ERROR
+                                            << "Failed to get the Message "
+                                            << "from object: "
+                                            << hwStatusEventObj;
+                                        messages::internalError(aResp->res);
+                                        return;
+                                    }
+
+                                    const redfish::registries::Message* msgReg =
+                                        registries::getMessage(
+                                            "OpenBMC.0.2."
+                                            "HardwareIsolationReason");
+
+                                    if (msgReg == nullptr)
+                                    {
+                                        BMCWEB_LOG_ERROR
+                                            << "Failed to get "
+                                            << "the HardwareIsolationReason "
+                                            << "message registry to add "
+                                            << "in the condition";
+                                        messages::internalError(aResp->res);
+                                        return;
+                                    }
+
+                                    // Prepare MessageArgs as per defined in the
+                                    // MessageRegistries
+                                    std::vector<std::string> messageArgs{
+                                        *msgPropVal};
+
+                                    // Fill the "msgPropVal" as reason
+                                    std::string message = msgReg->message;
+                                    int i = 0;
+                                    for (const std::string& messageArg :
+                                         messageArgs)
+                                    {
+                                        std::string argIndex =
+                                            "%" + std::to_string(++i);
+                                        size_t argPos = message.find(argIndex);
+                                        if (argPos != std::string::npos)
+                                        {
+                                            message.replace(argPos,
+                                                            argIndex.length(),
+                                                            messageArg);
+                                        }
+                                    }
+                                    // Severity will be added based on the event
+                                    // object property
+                                    condition["Message"] = message;
+                                    condition["MessageArgs"] = messageArgs;
+                                    condition["MessageId"] =
+                                        "OpenBMC.0.2.HardwareIsolationReason";
+                                }
+                                else if (property.first == "Severity")
+                                {
+                                    const std::string* severity =
+                                        std::get_if<std::string>(
+                                            &property.second);
+                                    if (severity == nullptr)
+                                    {
+                                        BMCWEB_LOG_ERROR
+                                            << "Failed to get the Severity "
+                                            << "from object: "
+                                            << hwStatusEventObj;
+                                        messages::internalError(aResp->res);
+                                        return;
+                                    }
+
+                                    // we have only one condition
+                                    nlohmann::json_pointer severityPropPath =
+                                        "/Status/Conditions/0/Severity"_json_pointer;
+                                    if (!setSeverity(aResp, hwStatusEventObj,
+                                                     severityPropPath,
+                                                     *severity))
+                                    {
+                                        // Failed to set the severity
+                                        return;
+                                    }
+                                }
+                            }
+                        },
+                        objType[0].first, hwStatusEventObj,
+                        "org.freedesktop.DBus.Properties", "GetAll", "");
+                },
+                "xyz.openbmc_project.ObjectMapper",
+                "/xyz/openbmc_project/object_mapper",
+                "xyz.openbmc_project.ObjectMapper", "GetObject",
+                hwStatusEventObj,
+                std::array<const char*, 1>{
+                    "xyz.openbmc_project.Logging.Event"});
+        },
+        "xyz.openbmc_project.ObjectMapper", resourceObjPath.str + "/event_log",
+        "org.freedesktop.DBus.Properties", "Get",
+        "xyz.openbmc_project.Association", "endpoints");
 }
 
 } // namespace hw_isolation_utils

--- a/redfish-core/include/utils/hw_isolation.hpp
+++ b/redfish-core/include/utils/hw_isolation.hpp
@@ -139,13 +139,6 @@ inline void
             {
                 retChassisPowerStateOffRequiredError(aResp, resourceObjPath);
             }
-            else if (strcmp(dbusError->name, "xyz.openbmc_project.Common.Error."
-                                             "Unavailable") == 0)
-            {
-                messages::propertyValueResourceConflict(
-                    aResp->res, "Enabled", std::to_string(enabledPropVal),
-                    "HardwareIsolation");
-            }
             else if (strcmp(dbusError->name, "xyz.openbmc_project."
                                              "HardwareIsolation.Error."
                                              "IsolatedAlready") == 0)
@@ -272,18 +265,6 @@ inline void
                     {
                         retChassisPowerStateOffRequiredError(aResp,
                                                              resourceObjPath);
-                    }
-                    else if (strcmp(dbusError->name,
-                                    "xyz.openbmc_project.Common.Error."
-                                    "Unavailable") == 0)
-                    {
-                        // The Enabled property value will be "true" to
-                        // de-isolate.
-                        constexpr bool enabledPropVal = true;
-                        messages::propertyValueResourceConflict(
-                            aResp->res, "Enabled",
-                            std::to_string(enabledPropVal),
-                            "HardwareIsolation");
                     }
                     else if (strcmp(dbusError->name,
                                     "xyz.openbmc_project.Common.Error."

--- a/redfish-core/include/utils/hw_isolation.hpp
+++ b/redfish-core/include/utils/hw_isolation.hpp
@@ -224,6 +224,8 @@ inline void
  * @param[in] interfaces - The redfish resource dbus interfaces which will use
  *                         to get the given resource dbus objects from
  *                         the inventory.
+ * @param[in] parentSubtreePath - The resource parent subtree path to get
+ *                                the resource object path.
  *
  * @return The redfish response in given response buffer.
  *
@@ -236,11 +238,11 @@ inline void
  *       - This function will do either isolate or deisolate based on the
  *         given "Enabled" property value.
  */
-inline void
-    processHardwareIsolationReq(const std::shared_ptr<bmcweb::AsyncResp>& aResp,
-                                const std::string& resourceName,
-                                const std::string& resourceId, bool enabled,
-                                const std::vector<const char*>& interfaces)
+inline void processHardwareIsolationReq(
+    const std::shared_ptr<bmcweb::AsyncResp>& aResp,
+    const std::string& resourceName, const std::string& resourceId,
+    bool enabled, const std::vector<const char*>& interfaces,
+    const std::string& parentSubtreePath = "/xyz/openbmc_project/inventory")
 {
     std::vector<const char*> resourceIfaces(interfaces.begin(),
                                             interfaces.end());
@@ -335,7 +337,7 @@ inline void
         "xyz.openbmc_project.ObjectMapper",
         "/xyz/openbmc_project/object_mapper",
         "xyz.openbmc_project.ObjectMapper", "GetSubTreePaths",
-        "/xyz/openbmc_project/inventory", 0, resourceIfaces);
+        parentSubtreePath, 0, resourceIfaces);
 }
 
 /*

--- a/redfish-core/include/utils/hw_isolation.hpp
+++ b/redfish-core/include/utils/hw_isolation.hpp
@@ -586,6 +586,15 @@ inline void
                                         return;
                                     }
 
+                                    // Host recovered even if there is hardware
+                                    // isolation entry so change the state.
+                                    if (*msgPropVal == "Recovered")
+                                    {
+                                        aResp->res
+                                            .jsonValue["Status"]["State"] =
+                                            "Enabled";
+                                    }
+
                                     const redfish::registries::Message* msgReg =
                                         registries::getMessage(
                                             "OpenBMC.0.2."

--- a/redfish-core/include/utils/hw_isolation.hpp
+++ b/redfish-core/include/utils/hw_isolation.hpp
@@ -132,7 +132,7 @@ inline void
                                     "InvalidArgument") == 0)
         {
             messages::propertyValueExternalConflict(
-                aResp->res, "Enabled", std::to_string(enabledPropVal));
+                aResp->res, "Enabled", std::to_string(enabledPropVal ? 1 : 0));
         }
         else if (strcmp(dbusError->name, "xyz.openbmc_project.Common.Error."
                                          "NotAllowed") == 0)
@@ -143,8 +143,9 @@ inline void
                                          "HardwareIsolation.Error."
                                          "IsolatedAlready") == 0)
         {
-            messages::resourceAlreadyExists(aResp->res, resourceName, "Enabled",
-                                            std::to_string(enabledPropVal));
+            messages::resourceAlreadyExists(
+                aResp->res, resourceName, "Enabled",
+                std::to_string(enabledPropVal ? 1 : 0));
         }
         else if (strcmp(dbusError->name, "xyz.openbmc_project.Common.Error."
                                          "TooManyResources") == 0)
@@ -419,11 +420,10 @@ inline void processHardwareIsolationReq(
  * @return True on success
  *         False on failure and set the error in the redfish response.
  */
-inline bool
-    setSeverity(const std::shared_ptr<bmcweb::AsyncResp>& aResp,
-                const sdbusplus::message::object_path& objPath,
-                const nlohmann::json_pointer<nlohmann::json>& severityPropPath,
-                const std::string& severityVal)
+inline bool setSeverity(const std::shared_ptr<bmcweb::AsyncResp>& aResp,
+                        const sdbusplus::message::object_path& objPath,
+                        const nlohmann::json::json_pointer& severityPropPath,
+                        const std::string& severityVal)
 {
     if (severityVal == "xyz.openbmc_project.Logging.Event."
                        "SeverityLevel.Critical")
@@ -607,7 +607,7 @@ inline void
                                 sdbusplus::message::object_path errPath =
                                     std::get<2>(assoc);
                                 // we have only one condition
-                                nlohmann::json_pointer logEntryPropPath =
+                                nlohmann::json::json_pointer logEntryPropPath =
                                     "/Status/Conditions/0/LogEntry"_json_pointer;
                                 error_log_utils::setErrorLogUri(
                                     aResp, errPath, logEntryPropPath, true);
@@ -702,7 +702,7 @@ inline void
                         }
 
                         // we have only one condition
-                        nlohmann::json_pointer severityPropPath =
+                        nlohmann::json::json_pointer severityPropPath =
                             "/Status/Conditions/0/Severity"_json_pointer;
                         if (!setSeverity(aResp, hwStatusEventObj,
                                          severityPropPath, *severity))

--- a/redfish-core/include/utils/hw_isolation.hpp
+++ b/redfish-core/include/utils/hw_isolation.hpp
@@ -179,10 +179,6 @@ inline void
  * @note - This function will try to identify the hardware isolated dbus entry
  *         from associations endpoints by using the given resource dbus object
  *         of "isolated_hw_entry".
- *       - This function will use the last endpoint from the list since the
- *         HardwareIsolation manager may be used the "Resolved" dbus entry
- *         property to indicate the deisolation instead of delete
- *         the entry object.
  */
 inline void
     deisolateResource(const std::shared_ptr<bmcweb::AsyncResp>& aResp,

--- a/redfish-core/include/utils/hw_isolation.hpp
+++ b/redfish-core/include/utils/hw_isolation.hpp
@@ -131,8 +131,8 @@ inline void
             if (strcmp(dbusError->name, "xyz.openbmc_project.Common.Error."
                                         "InvalidArgument") == 0)
             {
-                messages::propertyValueIncorrect(
-                    aResp->res, "@odata.id", std::to_string(enabledPropVal));
+                messages::propertyValueExternalConflict(
+                    aResp->res, "Enabled", std::to_string(enabledPropVal));
             }
             else if (strcmp(dbusError->name, "xyz.openbmc_project.Common.Error."
                                              "NotAllowed") == 0)

--- a/redfish-core/include/utils/hw_isolation.hpp
+++ b/redfish-core/include/utils/hw_isolation.hpp
@@ -32,45 +32,45 @@ inline void retChassisPowerStateOffRequiredError(
                 std::string, boost::container::flat_map<
                                  std::string, std::vector<std::string>>>&
                 ancestors) {
-            if (ec)
-            {
-                BMCWEB_LOG_ERROR << "DBUS response error [" << ec.value()
-                                 << " : " << ec.message()
-                                 << "] when tried to get parent Chassis id for "
-                                    "the given resource object ["
-                                 << resourceObjPath.str << "]";
-                messages::internalError(aResp->res);
-                return;
-            }
+        if (ec)
+        {
+            BMCWEB_LOG_ERROR << "DBUS response error [" << ec.value() << " : "
+                             << ec.message()
+                             << "] when tried to get parent Chassis id for "
+                                "the given resource object ["
+                             << resourceObjPath.str << "]";
+            messages::internalError(aResp->res);
+            return;
+        }
 
-            if (ancestors.empty())
-            {
-                BMCWEB_LOG_ERROR
-                    << "The given resource object [" << resourceObjPath.str
-                    << "] is not the child of the Chassis so failed return "
-                    << "ChassisPowerStateOffRequiredError in the response";
-                messages::internalError(aResp->res);
-                return;
-            }
+        if (ancestors.empty())
+        {
+            BMCWEB_LOG_ERROR
+                << "The given resource object [" << resourceObjPath.str
+                << "] is not the child of the Chassis so failed return "
+                << "ChassisPowerStateOffRequiredError in the response";
+            messages::internalError(aResp->res);
+            return;
+        }
 
-            if (ancestors.size() > 1)
-            {
-                // Should not happen since GetAncestors returs parent object
-                // from the given child object path and we are just looking
-                // for parent chassis object id alone, so we should get one
-                // element.
-                BMCWEB_LOG_ERROR
-                    << "The given resource object [" << resourceObjPath.str
-                    << "] is contains more than one Chassis as parent so "
-                    << "failed return ChassisPowerStateOffRequiredError "
-                    << "in the response";
-                messages::internalError(aResp->res);
-                return;
-            }
-            messages::chassisPowerStateOffRequired(
-                aResp->res,
-                sdbusplus::message::object_path(ancestors.begin()->first)
-                    .filename());
+        if (ancestors.size() > 1)
+        {
+            // Should not happen since GetAncestors returs parent object
+            // from the given child object path and we are just looking
+            // for parent chassis object id alone, so we should get one
+            // element.
+            BMCWEB_LOG_ERROR
+                << "The given resource object [" << resourceObjPath.str
+                << "] is contains more than one Chassis as parent so "
+                << "failed return ChassisPowerStateOffRequiredError "
+                << "in the response";
+            messages::internalError(aResp->res);
+            return;
+        }
+        messages::chassisPowerStateOffRequired(
+            aResp->res,
+            sdbusplus::message::object_path(ancestors.begin()->first)
+                .filename());
         },
         "xyz.openbmc_project.ObjectMapper",
         "/xyz/openbmc_project/object_mapper",
@@ -105,60 +105,59 @@ inline void
         [aResp, resourceName, resourceId,
          resourceObjPath](const boost::system::error_code ec,
                           const sdbusplus::message::message& msg) {
-            if (!ec)
-            {
-                messages::success(aResp->res);
-                return;
-            }
-
-            BMCWEB_LOG_ERROR << "DBUS response error [" << ec.value() << " : "
-                             << ec.message()
-                             << "] when tried to isolate the given resource: "
-                             << resourceObjPath.str;
-
-            const sd_bus_error* dbusError = msg.get_error();
-            if (dbusError == nullptr)
-            {
-                messages::internalError(aResp->res);
-                return;
-            }
-
-            BMCWEB_LOG_ERROR << "DBus ErrorName: " << dbusError->name
-                             << " ErrorMsg: " << dbusError->message;
-
-            // The Enabled property value will be "false" to isolate.
-            constexpr bool enabledPropVal = false;
-            if (strcmp(dbusError->name, "xyz.openbmc_project.Common.Error."
-                                        "InvalidArgument") == 0)
-            {
-                messages::propertyValueExternalConflict(
-                    aResp->res, "Enabled", std::to_string(enabledPropVal));
-            }
-            else if (strcmp(dbusError->name, "xyz.openbmc_project.Common.Error."
-                                             "NotAllowed") == 0)
-            {
-                retChassisPowerStateOffRequiredError(aResp, resourceObjPath);
-            }
-            else if (strcmp(dbusError->name, "xyz.openbmc_project."
-                                             "HardwareIsolation.Error."
-                                             "IsolatedAlready") == 0)
-            {
-                messages::resourceAlreadyExists(aResp->res, resourceName,
-                                                "Enabled",
-                                                std::to_string(enabledPropVal));
-            }
-            else if (strcmp(dbusError->name, "xyz.openbmc_project.Common.Error."
-                                             "TooManyResources") == 0)
-            {
-                messages::createLimitReachedForResource(aResp->res);
-            }
-            else
-            {
-                BMCWEB_LOG_ERROR << "DBus Error is unsupported so "
-                                    "returning as Internal Error";
-                messages::internalError(aResp->res);
-            }
+        if (!ec)
+        {
+            messages::success(aResp->res);
             return;
+        }
+
+        BMCWEB_LOG_ERROR << "DBUS response error [" << ec.value() << " : "
+                         << ec.message()
+                         << "] when tried to isolate the given resource: "
+                         << resourceObjPath.str;
+
+        const sd_bus_error* dbusError = msg.get_error();
+        if (dbusError == nullptr)
+        {
+            messages::internalError(aResp->res);
+            return;
+        }
+
+        BMCWEB_LOG_ERROR << "DBus ErrorName: " << dbusError->name
+                         << " ErrorMsg: " << dbusError->message;
+
+        // The Enabled property value will be "false" to isolate.
+        constexpr bool enabledPropVal = false;
+        if (strcmp(dbusError->name, "xyz.openbmc_project.Common.Error."
+                                    "InvalidArgument") == 0)
+        {
+            messages::propertyValueExternalConflict(
+                aResp->res, "Enabled", std::to_string(enabledPropVal));
+        }
+        else if (strcmp(dbusError->name, "xyz.openbmc_project.Common.Error."
+                                         "NotAllowed") == 0)
+        {
+            retChassisPowerStateOffRequiredError(aResp, resourceObjPath);
+        }
+        else if (strcmp(dbusError->name, "xyz.openbmc_project."
+                                         "HardwareIsolation.Error."
+                                         "IsolatedAlready") == 0)
+        {
+            messages::resourceAlreadyExists(aResp->res, resourceName, "Enabled",
+                                            std::to_string(enabledPropVal));
+        }
+        else if (strcmp(dbusError->name, "xyz.openbmc_project.Common.Error."
+                                         "TooManyResources") == 0)
+        {
+            messages::createLimitReachedForResource(aResp->res);
+        }
+        else
+        {
+            BMCWEB_LOG_ERROR << "DBus Error is unsupported so "
+                                "returning as Internal Error";
+            messages::internalError(aResp->res);
+        }
+        return;
         },
         hwIsolationDbusName, "/xyz/openbmc_project/hardware_isolation",
         "xyz.openbmc_project.HardwareIsolation.Create", "Create",
@@ -191,93 +190,90 @@ inline void
         [aResp, resourceObjPath, hwIsolationDbusName](
             boost::system::error_code ec,
             const std::variant<std::vector<std::string>>& vEndpoints) {
-            if (ec)
+        if (ec)
+        {
+            BMCWEB_LOG_ERROR << "DBus response error [" << ec.value() << " : "
+                             << ec.message()
+                             << "] when tried to get the hardware "
+                                "isolation entry for the given "
+                                "resource dbus object path: "
+                             << resourceObjPath.str;
+            // The error code (53 == Invalid request descriptor) will be
+            // returned if dbus doesn't contains "isolated_hw_entry" for
+            // the given resource i.e it is not isolated to deisolate.
+            // This case might occur when resource are in the certain state
+            if (ec.value() == 53)
             {
-                BMCWEB_LOG_ERROR << "DBus response error [" << ec.value()
-                                 << " : " << ec.message()
-                                 << "] when tried to get the hardware "
-                                    "isolation entry for the given "
-                                    "resource dbus object path: "
-                                 << resourceObjPath.str;
-                // The error code (53 == Invalid request descriptor) will be
-                // returned if dbus doesn't contains "isolated_hw_entry" for
-                // the given resource i.e it is not isolated to deisolate.
-                // This case might occur when resource are in the certain state
-                if (ec.value() == 53)
-                {
-                    messages::propertyValueConflict(aResp->res, "Enabled",
-                                                    "Status.State");
-                }
-                else
-                {
-                    messages::internalError(aResp->res);
-                }
+                messages::propertyValueConflict(aResp->res, "Enabled",
+                                                "Status.State");
+            }
+            else
+            {
+                messages::internalError(aResp->res);
+            }
+            return;
+        }
+
+        std::string resourceIsolatedHwEntry;
+        const std::vector<std::string>* endpoints =
+            std::get_if<std::vector<std::string>>(&(vEndpoints));
+        if (endpoints == nullptr)
+        {
+            BMCWEB_LOG_ERROR << "Failed to get Associations endpoints "
+                                "for the given object path: "
+                             << resourceObjPath.str;
+            messages::internalError(aResp->res);
+            return;
+        }
+        resourceIsolatedHwEntry = endpoints->back();
+
+        // De-isolate the given resource
+        crow::connections::systemBus->async_method_call(
+            [aResp, resourceIsolatedHwEntry,
+             resourceObjPath](const boost::system::error_code ec1,
+                              const sdbusplus::message::message& msg) {
+            if (!ec1)
+            {
+                messages::success(aResp->res);
                 return;
             }
 
-            std::string resourceIsolatedHwEntry;
-            const std::vector<std::string>* endpoints =
-                std::get_if<std::vector<std::string>>(&(vEndpoints));
-            if (endpoints == nullptr)
+            BMCWEB_LOG_ERROR << "DBUS response error [" << ec1.value() << " : "
+                             << ec1.message()
+                             << "] when tried to isolate the given "
+                             << "resource: " << resourceIsolatedHwEntry;
+
+            const sd_bus_error* dbusError = msg.get_error();
+
+            if (dbusError == nullptr)
             {
-                BMCWEB_LOG_ERROR << "Failed to get Associations endpoints "
-                                    "for the given object path: "
-                                 << resourceObjPath.str;
                 messages::internalError(aResp->res);
                 return;
             }
-            resourceIsolatedHwEntry = endpoints->back();
 
-            // De-isolate the given resource
-            crow::connections::systemBus->async_method_call(
-                [aResp, resourceIsolatedHwEntry,
-                resourceObjPath](const boost::system::error_code ec1,
-                    const sdbusplus::message::message& msg) {
-                    if (!ec1)
-                    {
-                        messages::success(aResp->res);
-                        return;
-                    }
+            BMCWEB_LOG_ERROR << "DBus ErrorName: " << dbusError->name
+                             << " ErrorMsg: " << dbusError->message;
 
-                    BMCWEB_LOG_ERROR << "DBUS response error [" << ec1.value()
-                                     << " : " << ec1.message()
-                                     << "] when tried to isolate the given "
-                                     << "resource: " << resourceIsolatedHwEntry;
-
-                    const sd_bus_error* dbusError = msg.get_error();
-
-                    if (dbusError == nullptr)
-                    {
-                        messages::internalError(aResp->res);
-                        return;
-                    }
-
-                    BMCWEB_LOG_ERROR << "DBus ErrorName: " << dbusError->name
-                                     << " ErrorMsg: " << dbusError->message;
-
-                    if (strcmp(dbusError->name,
-                               "xyz.openbmc_project.Common.Error."
-                               "NotAllowed") == 0)
-                    {
-                        retChassisPowerStateOffRequiredError(aResp,
-                                                             resourceObjPath);
-                    }
-                    else if (strcmp(dbusError->name,
-                                    "xyz.openbmc_project.Common.Error."
-                                    "InsufficientPermission") == 0)
-                    {
-                        messages::resourceCannotBeDeleted(aResp->res);
-                    }
-                    else
-                    {
-                        BMCWEB_LOG_ERROR << "DBus Error is unsupported so "
-                                            "returning as Internal Error";
-                        messages::internalError(aResp->res);
-                    }
-                    return;
-                },
-                hwIsolationDbusName, resourceIsolatedHwEntry,
-                "xyz.openbmc_project.Object.Delete", "Delete");
+            if (strcmp(dbusError->name, "xyz.openbmc_project.Common.Error."
+                                        "NotAllowed") == 0)
+            {
+                retChassisPowerStateOffRequiredError(aResp, resourceObjPath);
+            }
+            else if (strcmp(dbusError->name, "xyz.openbmc_project.Common.Error."
+                                             "InsufficientPermission") == 0)
+            {
+                messages::resourceCannotBeDeleted(aResp->res);
+            }
+            else
+            {
+                BMCWEB_LOG_ERROR << "DBus Error is unsupported so "
+                                    "returning as Internal Error";
+                messages::internalError(aResp->res);
+            }
+            return;
+            },
+            hwIsolationDbusName, resourceIsolatedHwEntry,
+            "xyz.openbmc_project.Object.Delete", "Delete");
         },
         "xyz.openbmc_project.ObjectMapper",
         resourceObjPath.str + "/isolated_hw_entry",
@@ -327,86 +323,83 @@ inline void processHardwareIsolationReq(
         [aResp, resourceName, resourceId,
          enabled](boost::system::error_code ec,
                   const std::vector<std::string>& objects) {
-            if (ec)
+        if (ec)
+        {
+            BMCWEB_LOG_ERROR << "DBus response error [" << ec.value() << " : "
+                             << ec.message()
+                             << "] when tried to check the given resource "
+                                "is present in tne inventory";
+            messages::internalError(aResp->res);
+            return;
+        }
+
+        sdbusplus::message::object_path resourceObjPath;
+        for (const auto& object : objects)
+        {
+            sdbusplus::message::object_path path(object);
+            if (path.filename() == resourceId)
             {
-                BMCWEB_LOG_ERROR << "DBus response error [" << ec.value()
-                                 << " : " << ec.message()
-                                 << "] when tried to check the given resource "
-                                    "is present in tne inventory";
+                resourceObjPath = path;
+                break;
+            }
+        }
+
+        if (resourceObjPath.str.empty())
+        {
+            messages::resourceNotFound(aResp->res, resourceName, resourceId);
+            return;
+        }
+
+        // Get the HardwareIsolation DBus name
+        crow::connections::systemBus->async_method_call(
+            [aResp, resourceObjPath, enabled, resourceName,
+             resourceId](const boost::system::error_code ec1,
+                         const dbus::utility::MapperGetObject& objType) {
+            if (ec1)
+            {
+                BMCWEB_LOG_ERROR << "DBUS response error [" << ec1.value()
+                                 << " : " << ec1.message()
+                                 << "] when tried to get the HardwareIsolation "
+                                    "dbus name to isolate: "
+                                 << resourceObjPath.str;
                 messages::internalError(aResp->res);
                 return;
             }
 
-            sdbusplus::message::object_path resourceObjPath;
-            for (const auto& object : objects)
+            if (objType.size() > 1)
             {
-                sdbusplus::message::object_path path(object);
-                if (path.filename() == resourceId)
-                {
-                    resourceObjPath = path;
-                    break;
-                }
-            }
-
-            if (resourceObjPath.str.empty())
-            {
-                messages::resourceNotFound(aResp->res, resourceName,
-                                           resourceId);
+                BMCWEB_LOG_ERROR << "More than one dbus service "
+                                 << "implemented HardwareIsolation";
+                messages::internalError(aResp->res);
                 return;
             }
 
-            // Get the HardwareIsolation DBus name
-            crow::connections::systemBus->async_method_call(
-                [aResp, resourceObjPath, enabled, resourceName,
-                 resourceId](const boost::system::error_code ec1,
-                             const dbus::utility::MapperGetObject& objType) {
-                    if (ec1)
-                    {
-                        BMCWEB_LOG_ERROR
-                            << "DBUS response error [" << ec1.value() << " : "
-                            << ec1.message()
-                            << "] when tried to get the HardwareIsolation "
-                               "dbus name to isolate: "
-                            << resourceObjPath.str;
-                        messages::internalError(aResp->res);
-                        return;
-                    }
+            if (objType[0].first.empty())
+            {
+                BMCWEB_LOG_ERROR << "The retrieved HardwareIsolation "
+                                 << "dbus name is empty";
+                messages::internalError(aResp->res);
+                return;
+            }
 
-                    if (objType.size() > 1)
-                    {
-                        BMCWEB_LOG_ERROR << "More than one dbus service "
-                                         << "implemented HardwareIsolation";
-                        messages::internalError(aResp->res);
-                        return;
-                    }
-
-                    if (objType[0].first.empty())
-                    {
-                        BMCWEB_LOG_ERROR << "The retrieved HardwareIsolation "
-                                         << "dbus name is empty";
-                        messages::internalError(aResp->res);
-                        return;
-                    }
-
-                    // Make sure whether need to isolate or de-isolate
-                    // the given resource
-                    if (!enabled)
-                    {
-                        isolateResource(aResp, resourceName, resourceId,
-                                        resourceObjPath, objType[0].first);
-                    }
-                    else
-                    {
-                        deisolateResource(aResp, resourceObjPath,
-                                          objType[0].first);
-                    }
-                },
-                "xyz.openbmc_project.ObjectMapper",
-                "/xyz/openbmc_project/object_mapper",
-                "xyz.openbmc_project.ObjectMapper", "GetObject",
-                "/xyz/openbmc_project/hardware_isolation",
-                std::array<const char*, 1>{
-                    "xyz.openbmc_project.HardwareIsolation.Create"});
+            // Make sure whether need to isolate or de-isolate
+            // the given resource
+            if (!enabled)
+            {
+                isolateResource(aResp, resourceName, resourceId,
+                                resourceObjPath, objType[0].first);
+            }
+            else
+            {
+                deisolateResource(aResp, resourceObjPath, objType[0].first);
+            }
+            },
+            "xyz.openbmc_project.ObjectMapper",
+            "/xyz/openbmc_project/object_mapper",
+            "xyz.openbmc_project.ObjectMapper", "GetObject",
+            "/xyz/openbmc_project/hardware_isolation",
+            std::array<const char*, 1>{
+                "xyz.openbmc_project.HardwareIsolation.Create"});
         },
         "xyz.openbmc_project.ObjectMapper",
         "/xyz/openbmc_project/object_mapper",
@@ -476,280 +469,257 @@ inline void
         [aResp, resourceObjPath](
             boost::system::error_code ec,
             const std::variant<std::vector<std::string>>& vEndpoints) {
-            if (ec)
-            {
-                if (ec.value() == EBADR)
-                {
-                    // No event so the respective hardware status doesn't need
-                    // any Redfish status condition
-                    return;
-                }
-                BMCWEB_LOG_ERROR << "DBus response error [" << ec.value()
-                                 << " : " << ec.message()
-                                 << "] when tried to get the hardware "
-                                    "status event for the given "
-                                    "resource dbus object path: "
-                                 << resourceObjPath.str << "EBADR: " << EBADR;
-                messages::internalError(aResp->res);
-                return;
-            }
-
-            const std::vector<std::string>* endpoints =
-                std::get_if<std::vector<std::string>>(&(vEndpoints));
-            if (endpoints == nullptr)
-            {
-                BMCWEB_LOG_ERROR << "Failed to get Associations endpoints "
-                                    "for the given object path: "
-                                 << resourceObjPath.str;
-                messages::internalError(aResp->res);
-                return;
-            }
-
-            bool found = false;
-            std::string hwStatusEventObj;
-            for (const auto& endpoint : *endpoints)
-            {
-                if (sdbusplus::message::object_path(endpoint)
-                        .parent_path()
-                        .filename() == "hw_isolation_status")
-                {
-                    hwStatusEventObj = endpoint;
-                    found = true;
-                    break;
-                }
-            }
-
-            if (!found)
+        if (ec)
+        {
+            if (ec.value() == EBADR)
             {
                 // No event so the respective hardware status doesn't need
                 // any Redfish status condition
                 return;
             }
+            BMCWEB_LOG_ERROR << "DBus response error [" << ec.value() << " : "
+                             << ec.message()
+                             << "] when tried to get the hardware "
+                                "status event for the given "
+                                "resource dbus object path: "
+                             << resourceObjPath.str << "EBADR: " << EBADR;
+            messages::internalError(aResp->res);
+            return;
+        }
 
-            // Get the dbus service name of the hardware status event object
+        const std::vector<std::string>* endpoints =
+            std::get_if<std::vector<std::string>>(&(vEndpoints));
+        if (endpoints == nullptr)
+        {
+            BMCWEB_LOG_ERROR << "Failed to get Associations endpoints "
+                                "for the given object path: "
+                             << resourceObjPath.str;
+            messages::internalError(aResp->res);
+            return;
+        }
+
+        bool found = false;
+        std::string hwStatusEventObj;
+        for (const auto& endpoint : *endpoints)
+        {
+            if (sdbusplus::message::object_path(endpoint)
+                    .parent_path()
+                    .filename() == "hw_isolation_status")
+            {
+                hwStatusEventObj = endpoint;
+                found = true;
+                break;
+            }
+        }
+
+        if (!found)
+        {
+            // No event so the respective hardware status doesn't need
+            // any Redfish status condition
+            return;
+        }
+
+        // Get the dbus service name of the hardware status event object
+        crow::connections::systemBus->async_method_call(
+            [aResp,
+             hwStatusEventObj](const boost::system::error_code ec1,
+                               const dbus::utility::MapperGetObject& objType) {
+            if (ec1)
+            {
+                BMCWEB_LOG_ERROR << "DBUS response error [" << ec1.value()
+                                 << " : " << ec1.message()
+                                 << "] when tried to get the dbus name "
+                                 << "of the hardware status event object "
+                                 << hwStatusEventObj;
+                messages::internalError(aResp->res);
+                return;
+            }
+
+            if (objType.size() > 1)
+            {
+                BMCWEB_LOG_ERROR << "More than one dbus service "
+                                 << "implemented the same hardware "
+                                 << "status event object " << hwStatusEventObj;
+                messages::internalError(aResp->res);
+                return;
+            }
+
+            if (objType[0].first.empty())
+            {
+                BMCWEB_LOG_ERROR << "The retrieved hardware status "
+                                 << "event object dbus name is empty";
+                messages::internalError(aResp->res);
+                return;
+            }
+
+            using AssociationsValType =
+                std::vector<std::tuple<std::string, std::string, std::string>>;
+            using HwStausEventPropertiesType = boost::container::flat_map<
+                std::string,
+                std::variant<std::string, uint64_t, AssociationsValType>>;
+
+            // Get event properties and fill into status conditions
             crow::connections::systemBus->async_method_call(
-                [aResp, hwStatusEventObj](const boost::system::error_code ec1,
-                                          const dbus::utility::MapperGetObject& objType) {
-                    if (ec1)
+                [aResp, hwStatusEventObj](
+                    const boost::system::error_code ec2,
+                    const HwStausEventPropertiesType& properties) {
+                if (ec2)
+                {
+                    BMCWEB_LOG_ERROR
+                        << "DBUS response error [" << ec2.value() << " : "
+                        << ec2.message() << "] when tried "
+                        << "to get the hardware status event "
+                        << "object properties " << hwStatusEventObj;
+                    messages::internalError(aResp->res);
+                    return;
+                }
+
+                // Event is exist and that will get created when
+                // the respective hardware is not functional so
+                // set the state as "Disabled".
+                aResp->res.jsonValue["Status"]["State"] = "Disabled";
+
+                nlohmann::json& conditions =
+                    aResp->res.jsonValue["Status"]["Conditions"];
+                conditions = nlohmann::json::array();
+                conditions.push_back(nlohmann::json::object());
+                nlohmann::json& condition = conditions.back();
+
+                for (const auto& property : properties)
+                {
+                    if (property.first == "Associations")
                     {
-                        BMCWEB_LOG_ERROR
-                            << "DBUS response error [" << ec1.value() << " : "
-                            << ec1.message()
-                            << "] when tried to get the dbus name "
-                            << "of the hardware status event object "
-                            << hwStatusEventObj;
-                        messages::internalError(aResp->res);
-                        return;
-                    }
+                        const AssociationsValType* associations =
+                            std::get_if<AssociationsValType>(&property.second);
+                        if (associations == nullptr)
+                        {
+                            BMCWEB_LOG_ERROR
+                                << "Failed to get the Associations "
+                                << "from object: " << hwStatusEventObj;
+                            messages::internalError(aResp->res);
+                            return;
+                        }
 
-                    if (objType.size() > 1)
-                    {
-                        BMCWEB_LOG_ERROR << "More than one dbus service "
-                                         << "implemented the same hardware "
-                                         << "status event object "
-                                         << hwStatusEventObj;
-                        messages::internalError(aResp->res);
-                        return;
-                    }
-
-                    if (objType[0].first.empty())
-                    {
-                        BMCWEB_LOG_ERROR << "The retrieved hardware status "
-                                         << "event object dbus name is empty";
-                        messages::internalError(aResp->res);
-                        return;
-                    }
-
-                    using AssociationsValType = std::vector<
-                        std::tuple<std::string, std::string, std::string>>;
-                    using HwStausEventPropertiesType =
-                        boost::container::flat_map<
-                            std::string, std::variant<std::string, uint64_t,
-                                                      AssociationsValType>>;
-
-                    // Get event properties and fill into status conditions
-                    crow::connections::systemBus->async_method_call(
-                        [aResp, hwStatusEventObj](
-                            const boost::system::error_code ec2,
-                            const HwStausEventPropertiesType& properties) {
-                            if (ec2)
+                        for (const auto& assoc : *associations)
+                        {
+                            if (std::get<0>(assoc) == "error_log")
                             {
-                                BMCWEB_LOG_ERROR
-                                    << "DBUS response error [" << ec2.value()
-                                    << " : " << ec2.message() << "] when tried "
-                                    << "to get the hardware status event "
-                                    << "object properties " << hwStatusEventObj;
-                                messages::internalError(aResp->res);
-                                return;
+                                sdbusplus::message::object_path errPath =
+                                    std::get<2>(assoc);
+                                // we have only one condition
+                                nlohmann::json_pointer logEntryPropPath =
+                                    "/Status/Conditions/0/LogEntry"_json_pointer;
+                                error_log_utils::setErrorLogUri(
+                                    aResp, errPath, logEntryPropPath, true);
                             }
+                        }
+                    }
+                    else if (property.first == "Timestamp")
+                    {
+                        const uint64_t* timestamp =
+                            std::get_if<uint64_t>(&property.second);
+                        if (timestamp == nullptr)
+                        {
+                            BMCWEB_LOG_ERROR
+                                << "Failed to get the Timestamp "
+                                << "from object: " << hwStatusEventObj;
+                            messages::internalError(aResp->res);
+                            return;
+                        }
+                        condition["Timestamp"] =
+                            redfish::time_utils::getDateTimeStdtime(
+                                static_cast<std::time_t>(*timestamp));
+                    }
+                    else if (property.first == "Message")
+                    {
+                        const std::string* msgPropVal =
+                            std::get_if<std::string>(&property.second);
+                        if (msgPropVal == nullptr)
+                        {
+                            BMCWEB_LOG_ERROR
+                                << "Failed to get the Message "
+                                << "from object: " << hwStatusEventObj;
+                            messages::internalError(aResp->res);
+                            return;
+                        }
 
-                            // Event is exist and that will get created when
-                            // the respective hardware is not functional so
-                            // set the state as "Disabled".
-                            aResp->res.jsonValue["Status"]["State"] =
-                                "Disabled";
+                        // Host recovered even if there is hardware
+                        // isolation entry so change the state.
+                        if (*msgPropVal == "Recovered")
+                        {
+                            aResp->res.jsonValue["Status"]["State"] = "Enabled";
+                        }
 
-                            nlohmann::json& conditions =
-                                aResp->res.jsonValue["Status"]["Conditions"];
-                            conditions = nlohmann::json::array();
-                            conditions.push_back(nlohmann::json::object());
-                            nlohmann::json& condition = conditions.back();
+                        const redfish::registries::Message* msgReg =
+                            registries::getMessage("OpenBMC.0.2."
+                                                   "HardwareIsolationReason");
 
-                            for (const auto& property : properties)
+                        if (msgReg == nullptr)
+                        {
+                            BMCWEB_LOG_ERROR << "Failed to get "
+                                             << "the HardwareIsolationReason "
+                                             << "message registry to add "
+                                             << "in the condition";
+                            messages::internalError(aResp->res);
+                            return;
+                        }
+
+                        // Prepare MessageArgs as per defined in the
+                        // MessageRegistries
+                        std::vector<std::string> messageArgs{*msgPropVal};
+
+                        // Fill the "msgPropVal" as reason
+                        std::string message = msgReg->message;
+                        int i = 0;
+                        for (const std::string& messageArg : messageArgs)
+                        {
+                            std::string argIndex = "%" + std::to_string(++i);
+                            size_t argPos = message.find(argIndex);
+                            if (argPos != std::string::npos)
                             {
-                                if (property.first == "Associations")
-                                {
-                                    const AssociationsValType* associations =
-                                        std::get_if<AssociationsValType>(
-                                            &property.second);
-                                    if (associations == nullptr)
-                                    {
-                                        BMCWEB_LOG_ERROR
-                                            << "Failed to get the Associations "
-                                            << "from object: "
-                                            << hwStatusEventObj;
-                                        messages::internalError(aResp->res);
-                                        return;
-                                    }
-
-                                    for (const auto& assoc : *associations)
-                                    {
-                                        if (std::get<0>(assoc) == "error_log")
-                                        {
-                                            sdbusplus::message::object_path
-                                                errPath = std::get<2>(assoc);
-                                            // we have only one condition
-                                            nlohmann::json_pointer logEntryPropPath =
-                                                "/Status/Conditions/0/LogEntry"_json_pointer;
-                                            error_log_utils::setErrorLogUri(
-                                                aResp, errPath,
-                                                logEntryPropPath, true);
-                                        }
-                                    }
-                                }
-                                else if (property.first == "Timestamp")
-                                {
-                                    const uint64_t* timestamp =
-                                        std::get_if<uint64_t>(&property.second);
-                                    if (timestamp == nullptr)
-                                    {
-                                        BMCWEB_LOG_ERROR
-                                            << "Failed to get the Timestamp "
-                                            << "from object: "
-                                            << hwStatusEventObj;
-                                        messages::internalError(aResp->res);
-                                        return;
-                                    }
-                                    condition["Timestamp"] =
-                                        redfish::time_utils::getDateTimeStdtime(
-                                            static_cast<std::time_t>(
-                                                *timestamp));
-                                }
-                                else if (property.first == "Message")
-                                {
-                                    const std::string* msgPropVal =
-                                        std::get_if<std::string>(
-                                            &property.second);
-                                    if (msgPropVal == nullptr)
-                                    {
-                                        BMCWEB_LOG_ERROR
-                                            << "Failed to get the Message "
-                                            << "from object: "
-                                            << hwStatusEventObj;
-                                        messages::internalError(aResp->res);
-                                        return;
-                                    }
-
-                                    // Host recovered even if there is hardware
-                                    // isolation entry so change the state.
-                                    if (*msgPropVal == "Recovered")
-                                    {
-                                        aResp->res
-                                            .jsonValue["Status"]["State"] =
-                                            "Enabled";
-                                    }
-
-                                    const redfish::registries::Message* msgReg =
-                                        registries::getMessage(
-                                            "OpenBMC.0.2."
-                                            "HardwareIsolationReason");
-
-                                    if (msgReg == nullptr)
-                                    {
-                                        BMCWEB_LOG_ERROR
-                                            << "Failed to get "
-                                            << "the HardwareIsolationReason "
-                                            << "message registry to add "
-                                            << "in the condition";
-                                        messages::internalError(aResp->res);
-                                        return;
-                                    }
-
-                                    // Prepare MessageArgs as per defined in the
-                                    // MessageRegistries
-                                    std::vector<std::string> messageArgs{
-                                        *msgPropVal};
-
-                                    // Fill the "msgPropVal" as reason
-                                    std::string message = msgReg->message;
-                                    int i = 0;
-                                    for (const std::string& messageArg :
-                                         messageArgs)
-                                    {
-                                        std::string argIndex =
-                                            "%" + std::to_string(++i);
-                                        size_t argPos = message.find(argIndex);
-                                        if (argPos != std::string::npos)
-                                        {
-                                            message.replace(argPos,
-                                                            argIndex.length(),
-                                                            messageArg);
-                                        }
-                                    }
-                                    // Severity will be added based on the event
-                                    // object property
-                                    condition["Message"] = message;
-                                    condition["MessageArgs"] = messageArgs;
-                                    condition["MessageId"] =
-                                        "OpenBMC.0.2.HardwareIsolationReason";
-                                }
-                                else if (property.first == "Severity")
-                                {
-                                    const std::string* severity =
-                                        std::get_if<std::string>(
-                                            &property.second);
-                                    if (severity == nullptr)
-                                    {
-                                        BMCWEB_LOG_ERROR
-                                            << "Failed to get the Severity "
-                                            << "from object: "
-                                            << hwStatusEventObj;
-                                        messages::internalError(aResp->res);
-                                        return;
-                                    }
-
-                                    // we have only one condition
-                                    nlohmann::json_pointer severityPropPath =
-                                        "/Status/Conditions/0/Severity"_json_pointer;
-                                    if (!setSeverity(aResp, hwStatusEventObj,
-                                                     severityPropPath,
-                                                     *severity))
-                                    {
-                                        // Failed to set the severity
-                                        return;
-                                    }
-                                }
+                                message.replace(argPos, argIndex.length(),
+                                                messageArg);
                             }
-                        },
-                        objType[0].first, hwStatusEventObj,
-                        "org.freedesktop.DBus.Properties", "GetAll", "");
+                        }
+                        // Severity will be added based on the event
+                        // object property
+                        condition["Message"] = message;
+                        condition["MessageArgs"] = messageArgs;
+                        condition["MessageId"] =
+                            "OpenBMC.0.2.HardwareIsolationReason";
+                    }
+                    else if (property.first == "Severity")
+                    {
+                        const std::string* severity =
+                            std::get_if<std::string>(&property.second);
+                        if (severity == nullptr)
+                        {
+                            BMCWEB_LOG_ERROR
+                                << "Failed to get the Severity "
+                                << "from object: " << hwStatusEventObj;
+                            messages::internalError(aResp->res);
+                            return;
+                        }
+
+                        // we have only one condition
+                        nlohmann::json_pointer severityPropPath =
+                            "/Status/Conditions/0/Severity"_json_pointer;
+                        if (!setSeverity(aResp, hwStatusEventObj,
+                                         severityPropPath, *severity))
+                        {
+                            // Failed to set the severity
+                            return;
+                        }
+                    }
+                }
                 },
-                "xyz.openbmc_project.ObjectMapper",
-                "/xyz/openbmc_project/object_mapper",
-                "xyz.openbmc_project.ObjectMapper", "GetObject",
-                hwStatusEventObj,
-                std::array<const char*, 1>{
-                    "xyz.openbmc_project.Logging.Event"});
+                objType[0].first, hwStatusEventObj,
+                "org.freedesktop.DBus.Properties", "GetAll", "");
+            },
+            "xyz.openbmc_project.ObjectMapper",
+            "/xyz/openbmc_project/object_mapper",
+            "xyz.openbmc_project.ObjectMapper", "GetObject", hwStatusEventObj,
+            std::array<const char*, 1>{"xyz.openbmc_project.Logging.Event"});
         },
         "xyz.openbmc_project.ObjectMapper", resourceObjPath.str + "/event_log",
         "org.freedesktop.DBus.Properties", "Get",

--- a/redfish-core/include/utils/name_utils.hpp
+++ b/redfish-core/include/utils/name_utils.hpp
@@ -1,0 +1,80 @@
+
+#pragma once
+#include <async_resp.hpp>
+
+#include <algorithm>
+#include <string>
+#include <variant>
+#include <vector>
+
+namespace redfish
+{
+namespace name_util
+{
+
+/**
+ * @brief Populate the collection "Members" from a GetSubTreePaths search of
+ *        inventory
+ *
+ * @param[i,o] asyncResp  Async response object
+ * @param[i]   path       D-bus object path to find the find pretty name
+ * @param[i]   services   List of services to exporting the D-bus object path
+ * @param[i]   namePath   Json pointer to the name field to update.
+ *
+ * @return void
+ */
+inline void getPrettyName(
+    const std::shared_ptr<bmcweb::AsyncResp>& asyncResp,
+    const std::string& path,
+    const std::vector<std::pair<std::string, std::vector<std::string>>>&
+        services,
+    const nlohmann::json::json_pointer& namePath)
+{
+    BMCWEB_LOG_DEBUG << "Get PrettyName for: " << path;
+
+    // Ensure we only got one service back
+    if (services.size() != 1)
+    {
+        BMCWEB_LOG_ERROR << "Invalid Service Size " << services.size();
+        if (asyncResp)
+        {
+            messages::internalError(asyncResp->res);
+        }
+        return;
+    }
+
+    crow::connections::systemBus->async_method_call(
+        [asyncResp, path,
+         namePath](const boost::system::error_code ec,
+                   const std::variant<std::string>& prettyName) {
+        if (ec)
+        {
+            BMCWEB_LOG_DEBUG << "DBUS response error " << ec;
+            return;
+        }
+
+        const std::string* value = std::get_if<std::string>(&prettyName);
+
+        if (!value)
+        {
+
+            BMCWEB_LOG_ERROR << "Failed to get Pretty Name for " << path;
+            messages::internalError(asyncResp->res);
+            return;
+        }
+
+        if (value->empty())
+        {
+            return;
+        }
+
+        BMCWEB_LOG_DEBUG << "Pretty Name: " << *value;
+
+        asyncResp->res.jsonValue[namePath] = *value;
+        },
+        services[0].first, path, "org.freedesktop.DBus.Properties", "Get",
+        "xyz.openbmc_project.Inventory.Item", "PrettyName");
+}
+
+} // namespace name_util
+} // namespace redfish

--- a/redfish-core/include/utils/name_utils.hpp
+++ b/redfish-core/include/utils/name_utils.hpp
@@ -55,7 +55,7 @@ inline void getPrettyName(
 
         const std::string* value = std::get_if<std::string>(&prettyName);
 
-        if (!value)
+        if (value == nullptr)
         {
 
             BMCWEB_LOG_ERROR << "Failed to get Pretty Name for " << path;

--- a/redfish-core/lib/assembly.hpp
+++ b/redfish-core/lib/assembly.hpp
@@ -921,7 +921,7 @@ inline void fillWithAssemblyId(
     const std::string& assemblyParentServ,
     const sdbusplus::message::object_path& assemblyParentObjPath,
     const std::string& assemblyParentIface,
-    const nlohmann::json_pointer<nlohmann::json>& assemblyUriPropPath,
+    const nlohmann::json::json_pointer& assemblyUriPropPath,
     const sdbusplus::message::object_path& assembledObjPath,
     const std::string& assembledUriVal)
 {

--- a/redfish-core/lib/assembly.hpp
+++ b/redfish-core/lib/assembly.hpp
@@ -4,11 +4,23 @@
 
 #include <utils/json_utils.hpp>
 
+#include <iterator>
 #include <variant>
 
 namespace redfish
 {
 using VariantType = std::variant<bool, std::string, uint64_t, uint32_t>;
+
+constexpr std::array<const char*, 9> chassisAssemblyIfaces = {
+    "xyz.openbmc_project.Inventory.Item.Vrm",
+    "xyz.openbmc_project.Inventory.Item.Tpm",
+    "xyz.openbmc_project.Inventory.Item.Panel",
+    "xyz.openbmc_project.Inventory.Item.Battery",
+    "xyz.openbmc_project.Inventory.Item.DiskBackplane",
+    "xyz.openbmc_project.Inventory.Item.Board",
+    "xyz.openbmc_project.Inventory.Item.Connector",
+    "xyz.openbmc_project.Inventory.Item.Drive",
+    "xyz.openbmc_project.Inventory.Item.Board.Motherboard"};
 
 /**
  * @brief Get properties for the assemblies associated to given chassis
@@ -303,12 +315,7 @@ inline void
             "xyz.openbmc_project.ObjectMapper",
             "/xyz/openbmc_project/object_mapper",
             "xyz.openbmc_project.ObjectMapper", "GetObject", assembly,
-            std::array<const char*, 5>{
-                "xyz.openbmc_project.Inventory.Item.Vrm",
-                "xyz.openbmc_project.Inventory.Item.Tpm",
-                "xyz.openbmc_project.Inventory.Item.Panel",
-                "xyz.openbmc_project.Inventory.Item.Battery",
-                "xyz.openbmc_project.Inventory.Item.DiskBackplane"});
+            chassisAssemblyIfaces);
 
         assemblyIndex++;
     }
@@ -631,13 +638,7 @@ inline void checkAssemblyInterface(
         "xyz.openbmc_project.ObjectMapper",
         "/xyz/openbmc_project/object_mapper",
         "xyz.openbmc_project.ObjectMapper", "GetSubTree",
-        "/xyz/openbmc_project/inventory", int32_t(0),
-        std::array<const char*, 5>{
-            "xyz.openbmc_project.Inventory.Item.Vrm",
-            "xyz.openbmc_project.Inventory.Item.Tpm",
-            "xyz.openbmc_project.Inventory.Item.Panel",
-            "xyz.openbmc_project.Inventory.Item.Battery",
-            "xyz.openbmc_project.Inventory.Item.DiskBackplane"});
+        "/xyz/openbmc_project/inventory", int32_t(0), chassisAssemblyIfaces);
 }
 
 /**
@@ -891,6 +892,224 @@ inline void getChassis(const std::shared_ptr<bmcweb::AsyncResp>& aResp,
         std::array<const char*, 1>{
             "xyz.openbmc_project.Inventory.Item.Chassis"});
 }
+
+/**
+ * @brief API used to fill the Assembly id of the assembled object that
+ *        assembled in the given assembly parent object path.
+ *
+ *        bmcweb using the sequential numeric value by sorting the
+ *        assembled objects instead of the assembled object dbus id
+ *        for the Redfish Assembly implementation.
+ *
+ * @param[in] aResp - The redfish response to return.
+ * @param[in] assemblyParentServ - The assembly parent dbus service name.
+ * @param[in] assemblyParentObjPath - The assembly parent dbus object path.
+ * @param[in] assemblyParentIface - The assembly parent dbus interface name
+ *                                  to valid the supports in the bmcweb.
+ * @param[in] assemblyUriPropPath - The redfish property path to fill with id.
+ * @param[in] assembledObjPath - The assembled object that need to fill with
+ *                               its id. Used to check in the parent assembly
+ *                               associations.
+ * @param[in] assembledUriVal - The assembled object redfish uri value that
+ *                              need to replace with its id.
+ *
+ * @return The redfish response with assembled object id in the given
+ *         redfish property path if success else returns the error.
+ */
+inline void fillWithAssemblyId(
+    const std::shared_ptr<bmcweb::AsyncResp>& aResp,
+    const std::string& assemblyParentServ,
+    const sdbusplus::message::object_path& assemblyParentObjPath,
+    const std::string& assemblyParentIface,
+    const nlohmann::json_pointer<nlohmann::json>& assemblyUriPropPath,
+    const sdbusplus::message::object_path& assembledObjPath,
+    const std::string& assembledUriVal)
+{
+    if (assemblyParentIface != "xyz.openbmc_project.Inventory.Item.Chassis")
+    {
+        // Currently, bmcweb supporting only chassis assembly uri so return
+        // error if unsupported assembly uri interface was given
+        BMCWEB_LOG_ERROR << "Unsupported interface [" << assemblyParentIface
+                         << "] was given to fill assembly id. "
+                         << "Please add support in the bmcweb";
+        messages::internalError(aResp->res);
+        return;
+    }
+
+    using associationList =
+        std::vector<std::tuple<std::string, std::string, std::string>>;
+
+    crow::connections::systemBus->async_method_call(
+        [aResp, assemblyUriPropPath, assemblyParentObjPath, assembledObjPath,
+         assembledUriVal](const boost::system::error_code ec,
+                          const std::variant<associationList>& associations) {
+            if (ec)
+            {
+                BMCWEB_LOG_ERROR
+                    << "DBUS response error [" << ec.value() << " : "
+                    << ec.message()
+                    << "] when tried to get the Associations from ["
+                    << assemblyParentObjPath.str
+                    << "] to fill Assembly id of the assembled object ["
+                    << assembledObjPath.str << "]";
+                messages::internalError(aResp->res);
+                return;
+            }
+
+            const associationList* value =
+                std::get_if<associationList>(&associations);
+            if (value == nullptr)
+            {
+                BMCWEB_LOG_ERROR
+                    << "Failed to get the Associations from ["
+                    << assemblyParentObjPath.str
+                    << "] to fill Assembly id of the assembled object ["
+                    << assembledObjPath.str << "]";
+                messages::internalError(aResp->res);
+                return;
+            }
+
+            std::vector<std::string> assemblyAssoc;
+            for (const auto& association : *value)
+            {
+                if (std::get<0>(association) != "assembly")
+                {
+                    continue;
+                }
+                assemblyAssoc.emplace_back(std::get<2>(association));
+            }
+
+            if (assemblyAssoc.empty())
+            {
+                BMCWEB_LOG_ERROR
+                    << "No assembly associations in the ["
+                    << assemblyParentObjPath.str
+                    << "] to fill Assembly id of the assembled object ["
+                    << assembledObjPath.str << "]";
+                messages::internalError(aResp->res);
+                return;
+            }
+
+            // Mak sure whether the retrieved assembly associations are
+            // implemented before finding the assembly id as per bmcweb
+            // Assembly design.
+            crow::connections::systemBus->async_method_call(
+                [aResp, assemblyUriPropPath, assemblyParentObjPath,
+                 assembledObjPath, assemblyAssoc, assembledUriVal](
+                    const boost::system::error_code ec1,
+                    const std::vector<
+                        std::pair<std::string,
+                                  std::vector<std::pair<
+                                      std::string, std::vector<std::string>>>>>&
+                        objects) {
+                    if (ec1)
+                    {
+                        BMCWEB_LOG_ERROR
+                            << "DBUS response error [" << ec1.value() << " : "
+                            << ec1.message()
+                            << "] when tried to get the subtree to check "
+                            << "assembled objects implementation of the ["
+                            << assemblyParentObjPath.str
+                            << "] to find assembled object id of the ["
+                            << assembledObjPath.str
+                            << "] to fill in the URI property";
+                        messages::internalError(aResp->res);
+                        return;
+                    }
+
+                    if (objects.empty())
+                    {
+                        BMCWEB_LOG_ERROR
+                            << "No objects in the ["
+                            << assemblyParentObjPath.str
+                            << "] to check assembled objects implementation "
+                            << "to fill the assembled object [ "
+                            << assembledObjPath.str
+                            << "] id in the URI property";
+                        messages::internalError(aResp->res);
+                        return;
+                    }
+
+                    std::vector<std::string> implAssemblyAssocs;
+                    for (const auto& object : objects)
+                    {
+                        auto it = std::find(assemblyAssoc.begin(),
+                                            assemblyAssoc.end(), object.first);
+                        if (it != assemblyAssoc.end())
+                        {
+                            implAssemblyAssocs.emplace_back(*it);
+                        }
+                    }
+
+                    if (implAssemblyAssocs.empty())
+                    {
+                        BMCWEB_LOG_ERROR
+                            << "The assembled objects of the ["
+                            << assemblyParentObjPath.str
+                            << "] are not implemented so "
+                            << "unable to fill the assembled object [ "
+                            << assembledObjPath.str
+                            << "] id in the URI property";
+                        messages::internalError(aResp->res);
+                        return;
+                    }
+
+                    // sort the implemented assemply object as per bmcweb design
+                    // to match with Assembly GET and PATCH handler.
+                    std::sort(implAssemblyAssocs.begin(),
+                              implAssemblyAssocs.end());
+
+                    auto assembledObjectIt = std::find(
+                        implAssemblyAssocs.begin(), implAssemblyAssocs.end(),
+                        assembledObjPath.str);
+
+                    if (assembledObjectIt == implAssemblyAssocs.end())
+                    {
+                        BMCWEB_LOG_ERROR
+                            << "The assembled object [" << assembledObjPath.str
+                            << "] in the object [" << assemblyParentObjPath.str
+                            << "] is not implemented so unable to fill "
+                            << "assembled object id in the URI property";
+                        messages::internalError(aResp->res);
+                        return;
+                    }
+
+                    auto assembledObjectId = std::distance(
+                        implAssemblyAssocs.begin(), assembledObjectIt);
+
+                    std::string::size_type assembledObjectNamePos =
+                        assembledUriVal.rfind(assembledObjPath.filename());
+
+                    if (assembledObjectNamePos == std::string::npos)
+                    {
+                        BMCWEB_LOG_ERROR
+                            << "The assembled object name ["
+                            << assembledObjPath.filename() << "] is not "
+                            << "found in the redfish property value ["
+                            << assembledUriVal
+                            << "] to replace with assembled object id ["
+                            << assembledObjectId << "]";
+                        messages::internalError(aResp->res);
+                        return;
+                    }
+                    std::string uriValwithId(assembledUriVal);
+                    uriValwithId.replace(assembledObjectNamePos,
+                                         assembledObjPath.filename().length(),
+                                         std::to_string(assembledObjectId));
+
+                    aResp->res.jsonValue[assemblyUriPropPath] = uriValwithId;
+                },
+                "xyz.openbmc_project.ObjectMapper",
+                "/xyz/openbmc_project/object_mapper",
+                "xyz.openbmc_project.ObjectMapper", "GetSubTree",
+                "/xyz/openbmc_project/inventory", int32_t(0),
+                chassisAssemblyIfaces);
+        },
+        assemblyParentServ, assemblyParentObjPath.str,
+        "org.freedesktop.DBus.Properties", "Get",
+        "xyz.openbmc_project.Association.Definitions", "Associations");
+}
+
 } // namespace assembly
 
 /**

--- a/redfish-core/lib/chassis.hpp
+++ b/redfish-core/lib/chassis.hpp
@@ -27,6 +27,7 @@
 #include <sdbusplus/unpack_properties.hpp>
 #include <utils/collection.hpp>
 #include <utils/dbus_utils.hpp>
+#include <utils/name_utils.hpp>
 
 namespace redfish
 {
@@ -314,7 +315,9 @@ inline void
                 "#Chassis.v1_16_0.Chassis";
             asyncResp->res.jsonValue["@odata.id"] =
                 "/redfish/v1/Chassis/" + chassisId;
-            asyncResp->res.jsonValue["Name"] = "Chassis Collection";
+            name_util::getPrettyName(asyncResp, path, connectionNames,
+                                     "/Name"_json_pointer);
+
             asyncResp->res.jsonValue["ChassisType"] = "RackMount";
             asyncResp->res.jsonValue["Actions"]["#Chassis.Reset"]["target"] =
                 "/redfish/v1/Chassis/" + chassisId + "/Actions/Chassis.Reset";

--- a/redfish-core/lib/log_services.hpp
+++ b/redfish-core/lib/log_services.hpp
@@ -1396,6 +1396,16 @@ inline void requestRoutesSystemLogServiceCollection(App& app)
             "/xyz/openbmc_project/object_mapper",
             "xyz.openbmc_project.ObjectMapper", "GetSubTreePaths", "/", 0,
             std::array<const char*, 1>{postCodeIface});
+            
+#ifdef BMCWEB_ENABLE_HW_ISOLATION
+            nlohmann::json& logServiceArrayLocal =
+                asyncResp->res.jsonValue["Members"];
+            logServiceArrayLocal.push_back(
+                {{"@odata.id", "/redfish/v1/Systems/system/"
+                               "LogServices/HardwareIsolation"}});
+            asyncResp->res.jsonValue["Members@odata.count"] =
+                logServiceArrayLocal.size();
+#endif // BMCWEB_ENABLE_HW_ISOLATION            
         });
 }
 
@@ -5359,5 +5369,57 @@ inline void requestRoutesPostCodesEntry(App& app)
         getPostCodeForEntry(asyncResp, targetID);
         });
 }
+
+#ifdef BMCWEB_ENABLE_HW_ISOLATION
+/**
+ * @brief API Used to add the supported HardwareIsolation LogServices Members
+ *
+ * @param[in] req - The HardwareIsolation redfish request (unused now).
+ * @param[in] asyncResp - The redfish response to return.
+ *
+ * @return The redfish response in the given buffer.
+ */
+inline void getSystemHardwareIsolationLogService(
+    const crow::Request& /* req */,
+    const std::shared_ptr<bmcweb::AsyncResp>& asyncResp)
+{
+    asyncResp->res.jsonValue["@odata.id"] =
+        "/redfish/v1/Systems/system/LogServices/"
+        "HardwareIsolation";
+    asyncResp->res.jsonValue["@odata.type"] = "#LogService.v1_2_0.LogService";
+    asyncResp->res.jsonValue["Name"] = "Hardware Isolation LogService";
+    asyncResp->res.jsonValue["Description"] =
+        "Hardware Isolation LogService for system owned "
+        "devices";
+    asyncResp->res.jsonValue["Id"] = "HardwareIsolation";
+
+    asyncResp->res.jsonValue["Entries"] = {
+        {"@odata.id", "/redfish/v1/Systems/system/LogServices/"
+                      "HardwareIsolation/Entries"}};
+
+    asyncResp->res.jsonValue["Actions"] = {
+        {"#LogService.ClearLog",
+         {{"target", "/redfish/v1/Systems/system/LogServices/"
+                     "HardwareIsolation/Actions/"
+                     "LogService.ClearLog"}}}};
+}
+
+/**
+ * @brief API used to route the handler for HardwareIsolation Redfish
+ *        LogServices URI
+ *
+ * @param[in] app - Crow app on which Redfish will initialize
+ *
+ * @return The appropriate redfish response for the given redfish request.
+ */
+inline void requestRoutesSystemHardwareIsolationLogService(App& app)
+{
+    BMCWEB_ROUTE(app,
+                 "/redfish/v1/Systems/system/LogServices/HardwareIsolation/")
+        .privileges(redfish::privileges::getLogService)
+        .methods(boost::beast::http::verb::get)(
+            getSystemHardwareIsolationLogService);
+}
+#endif // BMCWEB_ENABLE_HW_ISOLATION
 
 } // namespace redfish

--- a/redfish-core/lib/log_services.hpp
+++ b/redfish-core/lib/log_services.hpp
@@ -66,6 +66,11 @@ constexpr char const* crashdumpTelemetryInterface =
     "com.intel.crashdump.Telemetry";
 
 #ifdef BMCWEB_ENABLE_HW_ISOLATION
+constexpr std::array<const char*, 3> hwIsolationEntryIfaces = {
+    "xyz.openbmc_project.HardwareIsolation.Entry",
+    "xyz.openbmc_project.Association.Definitions",
+    "xyz.openbmc_project.Time.EpochTime"};
+
 using RedfishResourceDBusInterfaces = std::string;
 using RedfishResourceCollectionUri = std::string;
 using RedfishUriListType = std::unordered_map<RedfishResourceDBusInterfaces,
@@ -6045,6 +6050,116 @@ inline void getSystemHardwareIsolationLogEntryCollection(
 }
 
 /**
+ * @brief API Used to fill LogEntry schema by using the HardwareIsolation dbus
+ *        entry object which will get by using the given entry id in redfish
+ *        uri.
+ *
+ * @param[in] req - The HardwareIsolation redfish request (unused now).
+ * @param[in] asyncResp - The redfish response to return.
+ * @param[in] entryId - The entry id of HardwareIsolation entries to retrieve
+ *                      the corresponding isolated hardware details.
+ *
+ * @return The redfish response in the given buffer with LogEntry schema
+ *         members if success else will error.
+ */
+inline void getSystemHardwareIsolationLogEntryById(
+    const crow::Request& /* req */,
+    const std::shared_ptr<bmcweb::AsyncResp>& asyncResp,
+    const std::string& entryId)
+{
+    sdbusplus::message::object_path entryObjPath(
+        std::string("/xyz/openbmc_project/hardware_isolation/entry") + "/" +
+        entryId);
+
+    auto getManagedObjectsRespHandler = [asyncResp, entryObjPath](
+                                            const boost::system::error_code ec,
+                                            const GetManagedObjectsType&
+                                                mgtObjs) {
+        if (ec)
+        {
+            BMCWEB_LOG_ERROR
+                << "DBUS response error [" << ec.value() << " : "
+                << ec.message()
+                << "] when tried to get the HardwareIsolation managed objects";
+            messages::internalError(asyncResp->res);
+            return;
+        }
+
+        bool entryIsPresent = false;
+        for (auto dbusObjIt = mgtObjs.begin(); dbusObjIt != mgtObjs.end();
+             dbusObjIt++)
+        {
+            if (dbusObjIt->first == entryObjPath)
+            {
+                entryIsPresent = true;
+                fillSystemHardwareIsolationLogEntry(asyncResp, 0, dbusObjIt);
+                break;
+            }
+        }
+
+        if (!entryIsPresent)
+        {
+            messages::resourceNotFound(asyncResp->res, "Entry",
+                                       entryObjPath.filename());
+            return;
+        }
+    };
+
+    auto getObjectRespHandler = [asyncResp, entryId, entryObjPath,
+                                 getManagedObjectsRespHandler](
+                                    const boost::system::error_code ec,
+                                    const dbus::utility::MapperGetObject& objType) {
+        if (ec || objType.empty())
+        {
+            BMCWEB_LOG_ERROR << "DBUS response error [" << ec.value() << " : "
+                             << ec.message()
+                             << "] when tried to get the HardwareIsolation "
+                                "dbus name the given object path: "
+                             << entryObjPath.str;
+            if (ec.value() == EBADR)
+            {
+                messages::resourceNotFound(asyncResp->res, "Entry", entryId);
+            }
+            else
+            {
+                messages::internalError(asyncResp->res);
+            }
+            return;
+        }
+
+        if (objType.size() > 1)
+        {
+            BMCWEB_LOG_ERROR << "More than one dbus service implemented "
+                                "the HardwareIsolation service";
+            messages::internalError(asyncResp->res);
+            return;
+        }
+
+        if (objType[0].first.empty())
+        {
+            BMCWEB_LOG_ERROR << "The retrieved HardwareIsolation dbus "
+                                "name is empty";
+            messages::internalError(asyncResp->res);
+            return;
+        }
+
+        // Fill the Redfish LogEntry schema for the identified entry dbus object
+        crow::connections::systemBus->async_method_call(
+            getManagedObjectsRespHandler, objType[0].first,
+            "/xyz/openbmc_project/hardware_isolation",
+            "org.freedesktop.DBus.ObjectManager", "GetManagedObjects");
+    };
+
+    // Make sure the given entry id is present in hardware isolation
+    // dbus entries and get the DBus name of that entry to fill LogEntry
+    crow::connections::systemBus->async_method_call(
+        getObjectRespHandler, "xyz.openbmc_project.ObjectMapper",
+        "/xyz/openbmc_project/object_mapper",
+        "xyz.openbmc_project.ObjectMapper", "GetObject", entryObjPath.str,
+        hwIsolationEntryIfaces);
+}
+
+/**
  * @brief API used to route the handler for HardwareIsolation Redfish
  *        LogServices URI
  *
@@ -6065,6 +6180,12 @@ inline void requestRoutesSystemHardwareIsolationLogService(App& app)
         .privileges(redfish::privileges::getLogEntryCollection)
         .methods(boost::beast::http::verb::get)(
             getSystemHardwareIsolationLogEntryCollection);
+
+    BMCWEB_ROUTE(app, "/redfish/v1/Systems/system/LogServices/"
+                      "HardwareIsolation/Entries/<str>/")
+        .privileges(redfish::privileges::getLogEntry)
+        .methods(boost::beast::http::verb::get)(
+            getSystemHardwareIsolationLogEntryById);
 }
 #endif // BMCWEB_ENABLE_HW_ISOLATION
 

--- a/redfish-core/lib/log_services.hpp
+++ b/redfish-core/lib/log_services.hpp
@@ -6242,6 +6242,73 @@ inline void deleteSystemHardwareIsolationLogEntryById(
 }
 
 /**
+ * @brief API Used to deisolate the all HardwareIsolation entries.
+ *
+ * @param[in] req - The HardwareIsolation redfish request (unused now).
+ * @param[in] asyncResp - The redfish response to return.
+ *
+ * @return The redfish response in the given buffer.
+ */
+inline void postSystemHardwareIsolationLogServiceClearLog(
+    const crow::Request& /* req */,
+    const std::shared_ptr<bmcweb::AsyncResp>& asyncResp)
+{
+    // Get the DBus name of HardwareIsolation service
+    crow::connections::systemBus->async_method_call(
+        [asyncResp](const boost::system::error_code ec,
+                    const dbus::utility::MapperGetObject& objType) {
+            if (ec || objType.empty())
+            {
+                BMCWEB_LOG_ERROR << "DBUS response error [" << ec.value()
+                                 << " : " << ec.message()
+                                 << "] when tried to get the HardwareIsolation "
+                                    "dbus name";
+                messages::internalError(asyncResp->res);
+                return;
+            }
+
+            if (objType.size() > 1)
+            {
+                BMCWEB_LOG_ERROR << "More than one dbus service implemented "
+                                    "the HardwareIsolation service";
+                messages::internalError(asyncResp->res);
+                return;
+            }
+
+            if (objType[0].first.empty())
+            {
+                BMCWEB_LOG_ERROR << "The retrieved HardwareIsolation dbus "
+                                    "name is empty";
+                messages::internalError(asyncResp->res);
+                return;
+            }
+
+            // Delete all HardwareIsolation entries
+            crow::connections::systemBus->async_method_call(
+                [asyncResp](const boost::system::error_code ec1) {
+                    if (ec1)
+                    {
+                        BMCWEB_LOG_ERROR
+                            << "DBUS response error [" << ec1.value() << " : "
+                            << ec1.message()
+                            << "] when tried to delete all HardwareIsolation "
+                               "entries";
+                        messages::internalError(asyncResp->res);
+                        return;
+                    }
+                    messages::success(asyncResp->res);
+                },
+                objType[0].first, "/xyz/openbmc_project/hardware_isolation",
+                "xyz.openbmc_project.Collection.DeleteAll", "DeleteAll");
+        },
+        "xyz.openbmc_project.ObjectMapper",
+        "/xyz/openbmc_project/object_mapper",
+        "xyz.openbmc_project.ObjectMapper", "GetObject",
+        "/xyz/openbmc_project/hardware_isolation",
+        std::array<const char*, 1>{"xyz.openbmc_project.Collection.DeleteAll"});
+}
+
+/**
  * @brief API used to route the handler for HardwareIsolation Redfish
  *        LogServices URI
  *
@@ -6274,6 +6341,13 @@ inline void requestRoutesSystemHardwareIsolationLogService(App& app)
         .privileges(redfish::privileges::deleteLogEntry)
         .methods(boost::beast::http::verb::delete_)(
             deleteSystemHardwareIsolationLogEntryById);
+
+    BMCWEB_ROUTE(app,
+                 "/redfish/v1/Systems/system/LogServices/HardwareIsolation/"
+                 "Actions/LogService.ClearLog/")
+        .privileges(redfish::privileges::postLogService)
+        .methods(boost::beast::http::verb::post)(
+            postSystemHardwareIsolationLogServiceClearLog);
 }
 #endif // BMCWEB_ENABLE_HW_ISOLATION
 

--- a/redfish-core/lib/log_services.hpp
+++ b/redfish-core/lib/log_services.hpp
@@ -6160,6 +6160,88 @@ inline void getSystemHardwareIsolationLogEntryById(
 }
 
 /**
+ * @brief API Used to deisolate the given HardwareIsolation entry.
+ *
+ * @param[in] req - The HardwareIsolation redfish request (unused now).
+ * @param[in] asyncResp - The redfish response to return.
+ * @param[in] entryId - The entry id of HardwareIsolation entries to deisolate.
+ *
+ * @return The redfish response in the given buffer.
+ */
+inline void deleteSystemHardwareIsolationLogEntryById(
+    const crow::Request& /* req */,
+    const std::shared_ptr<bmcweb::AsyncResp>& asyncResp,
+    const std::string& entryId)
+{
+    sdbusplus::message::object_path entryObjPath(
+        std::string("/xyz/openbmc_project/hardware_isolation/entry") + "/" +
+        entryId);
+
+    // Make sure the given entry id is present in hardware isolation
+    // entries and get the DBus name of that entry
+    crow::connections::systemBus->async_method_call(
+        [asyncResp, entryId, entryObjPath](const boost::system::error_code ec,
+                                           const dbus::utility::MapperGetObject& objType) {
+            if (ec || objType.empty())
+            {
+                BMCWEB_LOG_ERROR << "DBUS response error [" << ec.value()
+                                 << " : " << ec.message()
+                                 << "] when tried to get the HardwareIsolation "
+                                    "dbus name the given object path: "
+                                 << entryObjPath.str;
+                if (ec.value() == EBADR)
+                {
+                    messages::resourceNotFound(asyncResp->res, "Entry",
+                                               entryId);
+                }
+                else
+                {
+                    messages::internalError(asyncResp->res);
+                }
+                return;
+            }
+
+            if (objType.size() > 1)
+            {
+                BMCWEB_LOG_ERROR << "More than one dbus service implemented "
+                                    "the HardwareIsolation service";
+                messages::internalError(asyncResp->res);
+                return;
+            }
+
+            if (objType[0].first.empty())
+            {
+                BMCWEB_LOG_ERROR << "The retrieved HardwareIsolation dbus "
+                                    "name is empty";
+                messages::internalError(asyncResp->res);
+                return;
+            }
+
+            // Delete the respective dbus entry object
+            crow::connections::systemBus->async_method_call(
+                [asyncResp, entryObjPath](const boost::system::error_code ec1) {
+                    if (ec1)
+                    {
+                        BMCWEB_LOG_ERROR << "DBUS response error ["
+                                         << ec1.value() << " : " << ec1.message()
+                                         << "] when tried to delete the given "
+                                            "object path: "
+                                         << entryObjPath.str;
+                        messages::internalError(asyncResp->res);
+                        return;
+                    }
+                    messages::success(asyncResp->res);
+                },
+                objType[0].first, entryObjPath.str,
+                "xyz.openbmc_project.Object.Delete", "Delete");
+        },
+        "xyz.openbmc_project.ObjectMapper",
+        "/xyz/openbmc_project/object_mapper",
+        "xyz.openbmc_project.ObjectMapper", "GetObject", entryObjPath.str,
+        hwIsolationEntryIfaces);
+}
+
+/**
  * @brief API used to route the handler for HardwareIsolation Redfish
  *        LogServices URI
  *
@@ -6186,6 +6268,12 @@ inline void requestRoutesSystemHardwareIsolationLogService(App& app)
         .privileges(redfish::privileges::getLogEntry)
         .methods(boost::beast::http::verb::get)(
             getSystemHardwareIsolationLogEntryById);
+
+    BMCWEB_ROUTE(app, "/redfish/v1/Systems/system/LogServices/"
+                      "HardwareIsolation/Entries/<str>/")
+        .privileges(redfish::privileges::deleteLogEntry)
+        .methods(boost::beast::http::verb::delete_)(
+            deleteSystemHardwareIsolationLogEntryById);
 }
 #endif // BMCWEB_ENABLE_HW_ISOLATION
 

--- a/redfish-core/lib/log_services.hpp
+++ b/redfish-core/lib/log_services.hpp
@@ -5740,6 +5740,7 @@ inline void getRedfishUriByDbusObjPath(
                         {
                             auto uriPropPath = "/Links"_json_pointer;
                             uriPropPath /= "OriginOfCondition";
+                            uriPropPath /= "@odata.id";
 
                             assembly::fillWithAssemblyId(
                                 asyncResp, std::get<0>(assemblyParent),

--- a/redfish-core/lib/log_services.hpp
+++ b/redfish-core/lib/log_services.hpp
@@ -46,11 +46,14 @@
 #include <utils/name_utils.hpp>
 #include <utils/error_log_utils.hpp>
 
+#include "assembly.hpp"
+
 #include <charconv>
 #include <filesystem>
 #include <optional>
 #include <span>
 #include <string_view>
+#include <tuple>
 #include <variant>
 
 namespace redfish
@@ -83,7 +86,12 @@ RedfishUriListType redfishUriList = {
     {"xyz.openbmc_project.Inventory.Item.Dimm",
      "/redfish/v1/Systems/system/Memory"},
     {"xyz.openbmc_project.Inventory.Item.CpuCore",
-     "/redfish/v1/Systems/system/Processors/<str>/SubProcessors"}};
+     "/redfish/v1/Systems/system/Processors/<str>/SubProcessors"},
+    {"xyz.openbmc_project.Inventory.Item.Chassis", "/redfish/v1/Chassis"},
+    {"xyz.openbmc_project.Inventory.Item.Tpm",
+     "/redfish/v1/Chassis/<str>/Assembly#/Assemblies"},
+    {"xyz.openbmc_project.Inventory.Item.Board.Motherboard",
+     "/redfish/v1/Chassis/<str>/Assembly#/Assemblies"}};
      
 #endif // BMCWEB_ENABLE_HW_ISOLATION
 
@@ -5551,6 +5559,31 @@ inline void getRedfishUriByDbusObjPath(
                 return;
             }
 
+            bool isChassisAssemblyUri = false;
+            std::string::size_type assemblyStartPos =
+                redfishUri.rfind("/Assembly#/Assemblies");
+            if (assemblyStartPos != std::string::npos)
+            {
+                // Redfish URI using path segment like DBus object path
+                // so using object_path type
+                if (sdbusplus::message::object_path(
+                        redfishUri.substr(0, assemblyStartPos))
+                        .parent_path()
+                        .filename() != "Chassis")
+                {
+                    // Currently, bmcweb supporting only chassis
+                    // assembly uri so return error if unsupported
+                    // assembly uri added in the redfishUriList.
+                    BMCWEB_LOG_ERROR << "Unsupported Assembly URI ["
+                                     << redfishUri
+                                     << "] to fill in the OriginOfCondition. "
+                                     << "Please add support in the bmcweb";
+                    messages::internalError(asyncResp->res);
+                    return;
+                }
+                isChassisAssemblyUri = true;
+            }
+
             // Fill the all parents Redfish URI id.
             // For example, the processors id for the core.
             // "/redfish/v1/Systems/system/Processors/<str>/SubProcessors/core0"
@@ -5596,7 +5629,7 @@ inline void getRedfishUriByDbusObjPath(
 
             crow::connections::systemBus->async_method_call(
                 [asyncResp, dbusObjPath, entryJsonIdx, redfishUri, uriIdPos,
-                 uriIdPattern, ancestorsIfaces](
+                 uriIdPattern, ancestorsIfaces, isChassisAssemblyUri](
                     const boost::system::error_code ec1,
                     const boost::container::flat_map<
                         std::string,
@@ -5615,6 +5648,11 @@ inline void getRedfishUriByDbusObjPath(
                         return;
                     }
 
+                    // tuple: assembly parent service name, object path, and
+                    // interface
+                    std::tuple<std::string, sdbusplus::message::object_path,
+                               std::string>
+                        assemblyParent;
                     for (const auto& ancestorIface : ancestorsIfaces)
                     {
                         bool foundAncestor = false;
@@ -5633,6 +5671,17 @@ inline void getRedfishUriByDbusObjPath(
                                             getIsolatedHwItemId(
                                                 sdbusplus::message::object_path(
                                                     obj.first)));
+                                        if (isChassisAssemblyUri &&
+                                            interface ==
+                                                "xyz.openbmc_project.Inventory."
+                                                "Item.Chassis")
+                                        {
+                                            assemblyParent = std::make_tuple(
+                                                service.first,
+                                                sdbusplus::message::object_path(
+                                                    obj.first),
+                                                interface);
+                                        }
                                         break;
                                     }
                                 }
@@ -5666,11 +5715,38 @@ inline void getRedfishUriByDbusObjPath(
                         asyncResp->res.jsonValue["Members"][entryJsonIdx - 1]
                                                 ["Links"]["OriginOfCondition"] =
                             {{"@odata.id", redfishUri}};
+
+                        if (isChassisAssemblyUri)
+                        {
+                            auto uriPropPath = "/Members"_json_pointer;
+                            uriPropPath /= entryJsonIdx - 1;
+                            uriPropPath /= "Links";
+                            uriPropPath /= "OriginOfCondition";
+                            uriPropPath /= "@odata.id";
+
+                            assembly::fillWithAssemblyId(
+                                asyncResp, std::get<0>(assemblyParent),
+                                std::get<1>(assemblyParent),
+                                std::get<2>(assemblyParent), uriPropPath,
+                                dbusObjPath, redfishUri);
+                        }
                     }
                     else
                     {
                         asyncResp->res.jsonValue["Links"]["OriginOfCondition"] =
                             {{"@odata.id", redfishUri}};
+
+                        if (isChassisAssemblyUri)
+                        {
+                            auto uriPropPath = "/Links"_json_pointer;
+                            uriPropPath /= "OriginOfCondition";
+
+                            assembly::fillWithAssemblyId(
+                                asyncResp, std::get<0>(assemblyParent),
+                                std::get<1>(assemblyParent),
+                                std::get<2>(assemblyParent), uriPropPath,
+                                dbusObjPath, redfishUri);
+                        }
                     }
                 },
                 "xyz.openbmc_project.ObjectMapper",

--- a/redfish-core/lib/log_services.hpp
+++ b/redfish-core/lib/log_services.hpp
@@ -5554,15 +5554,55 @@ inline void getRedfishUriByDbusObjPath(
             // Fill the all parents Redfish URI id.
             // For example, the processors id for the core.
             // "/redfish/v1/Systems/system/Processors/<str>/SubProcessors/core0"
+            std::vector<std::pair<RedfishResourceDBusInterfaces, size_t>>
+                ancestorsIfaces;
+            while (uriIdPos != std::string::npos)
+            {
+                std::string parentRedfishUri =
+                    redfishUri.substr(0, uriIdPos - 1);
+                RedfishUriListType::const_iterator parentRedfishUriIt =
+                    std::find_if(redfishUriList.begin(), redfishUriList.end(),
+                                 [parentRedfishUri](const auto& ele) {
+                                     return parentRedfishUri == ele.second;
+                                 });
+
+                if (parentRedfishUriIt == redfishUriList.end())
+                {
+                    BMCWEB_LOG_ERROR
+                        << "Failed to fill Links:OriginOfCondition "
+                        << "because unable to get parent Redfish URI "
+                        << "[" << parentRedfishUri << "]"
+                        << "DBus interface for the identified "
+                        << "Redfish URI: " << redfishUri
+                        << " of the given DBus object path: "
+                        << dbusObjPath.str;
+                    messages::internalError(asyncResp->res);
+                    return;
+                }
+                ancestorsIfaces.emplace_back(
+                    std::make_pair(parentRedfishUriIt->first, uriIdPos));
+                uriIdPos = redfishUri.rfind(uriIdPattern,
+                                            uriIdPos - uriIdPattern.length());
+            }
+
+            // GetAncestors only accepts "as" for the interface list
+            std::vector<RedfishResourceDBusInterfaces> ancestorsIfacesOnly;
+            std::transform(
+                ancestorsIfaces.begin(), ancestorsIfaces.end(),
+                std::back_inserter(ancestorsIfacesOnly),
+                [](const std::pair<RedfishResourceDBusInterfaces, size_t>& p) {
+                    return p.first;
+                });
+
             crow::connections::systemBus->async_method_call(
                 [asyncResp, dbusObjPath, entryJsonIdx, redfishUri, uriIdPos,
-                 uriIdPattern](
+                 uriIdPattern, ancestorsIfaces](
                     const boost::system::error_code ec1,
                     const boost::container::flat_map<
                         std::string,
                         boost::container::flat_map<std::string,
                                                    std::vector<std::string>>>&
-                        subtree) mutable {
+                        ancestors) mutable {
                     if (ec1)
                     {
                         BMCWEB_LOG_ERROR
@@ -5575,83 +5615,50 @@ inline void getRedfishUriByDbusObjPath(
                         return;
                     }
 
-                    while (uriIdPos != std::string::npos)
+                    for (const auto& ancestorIface : ancestorsIfaces)
                     {
-                        std::string parentRedfishUri =
-                            redfishUri.substr(0, uriIdPos - 1);
-                        RedfishUriListType::const_iterator parentRedfishUriIt =
-                            std::find_if(
-                                redfishUriList.begin(), redfishUriList.end(),
-                                [parentRedfishUri](const auto& ele) {
-                                    return parentRedfishUri == ele.second;
-                                });
-
-                        if (parentRedfishUriIt == redfishUriList.end())
+                        bool foundAncestor = false;
+                        for (const auto& obj : ancestors)
                         {
-                            BMCWEB_LOG_ERROR
-                                << "Failed to fill Links:OriginOfCondition "
-                                << "because unable to get parent Redfish URI "
-                                << "[" << parentRedfishUri << "]"
-                                << "DBus interface for the identified "
-                                << "Redfish URI: " << redfishUri
-                                << " of the given DBus object path: "
-                                << dbusObjPath.str;
-                            messages::internalError(asyncResp->res);
-                            return;
-                        }
-
-                        std::string parentObj;
-                        for (const auto& obj : subtree)
-                        {
-                            if (dbusObjPath.str.find(
-                                    sdbusplus::message::object_path(obj.first)
-                                        .filename()) == std::string::npos)
-                            {
-                                // The object is not found in the isolated
-                                // hardware object path
-                                continue;
-                            }
-
                             for (const auto& service : obj.second)
                             {
                                 for (const auto& interface : service.second)
                                 {
-                                    if (interface == parentRedfishUriIt->first)
+                                    if (interface == ancestorIface.first)
                                     {
-                                        parentObj = obj.first;
+                                        foundAncestor = true;
+                                        redfishUri.replace(
+                                            ancestorIface.second,
+                                            uriIdPattern.length(),
+                                            getIsolatedHwItemId(
+                                                sdbusplus::message::object_path(
+                                                    obj.first)));
                                         break;
                                     }
                                 }
-                                if (!parentObj.empty())
+                                if (foundAncestor)
                                 {
                                     break;
                                 }
                             }
-                            if (!parentObj.empty())
+                            if (foundAncestor)
                             {
                                 break;
                             }
                         }
 
-                        if (parentObj.empty())
+                        if (!foundAncestor)
                         {
                             BMCWEB_LOG_ERROR
                                 << "Failed to fill Links:OriginOfCondition "
                                 << "because unable to get parent DBus path "
-                                << "for the identified parent Redfish URI: "
-                                << parentRedfishUri
+                                << "for the identified parent interface : "
+                                << ancestorIface.first
                                 << " of the given DBus object path: "
                                 << dbusObjPath.str;
                             messages::internalError(asyncResp->res);
                             return;
                         }
-
-                        redfishUri.replace(
-                            uriIdPos, uriIdPattern.length(),
-                            getIsolatedHwItemId(
-                                sdbusplus::message::object_path(parentObj)));
-
-                        uriIdPos = redfishUri.rfind(uriIdPattern);
                     }
 
                     if (entryJsonIdx > 0)
@@ -5668,9 +5675,8 @@ inline void getRedfishUriByDbusObjPath(
                 },
                 "xyz.openbmc_project.ObjectMapper",
                 "/xyz/openbmc_project/object_mapper",
-                "xyz.openbmc_project.ObjectMapper", "GetSubTree",
-                "/xyz/openbmc_project/inventory", 0,
-                std::array<const char*, 0>{});
+                "xyz.openbmc_project.ObjectMapper", "GetAncestors",
+                dbusObjPath.str, ancestorsIfacesOnly);
         },
         "xyz.openbmc_project.ObjectMapper",
         "/xyz/openbmc_project/object_mapper",

--- a/redfish-core/lib/log_services.hpp
+++ b/redfish-core/lib/log_services.hpp
@@ -43,6 +43,7 @@
 #include <sdbusplus/unpack_properties.hpp>
 #include <utils/dbus_utils.hpp>
 #include <utils/time_utils.hpp>
+#include <utils/name_utils.hpp>
 
 #include <charconv>
 #include <filesystem>
@@ -63,6 +64,22 @@ constexpr char const* crashdumpOnDemandInterface =
     "com.intel.crashdump.OnDemand";
 constexpr char const* crashdumpTelemetryInterface =
     "com.intel.crashdump.Telemetry";
+
+#ifdef BMCWEB_ENABLE_HW_ISOLATION
+using RedfishResourceDBusInterfaces = std::string;
+using RedfishResourceCollectionUri = std::string;
+using RedfishUriListType = std::unordered_map<RedfishResourceDBusInterfaces,
+                                              RedfishResourceCollectionUri>;
+
+RedfishUriListType redfishUriList = {
+    {"xyz.openbmc_project.Inventory.Item.Cpu",
+     "/redfish/v1/Systems/system/Processors"},
+    {"xyz.openbmc_project.Inventory.Item.Dimm",
+     "/redfish/v1/Systems/system/Memory"},
+    {"xyz.openbmc_project.Inventory.Item.CpuCore",
+     "/redfish/v1/Systems/system/Processors/<str>/SubProcessors"}};
+     
+#endif // BMCWEB_ENABLE_HW_ISOLATION
 
 enum class DumpCreationProgress
 {
@@ -117,6 +134,17 @@ static const Message* getMessage(const std::string_view& messageID)
 } // namespace registries
 
 namespace fs = std::filesystem;
+
+using AssociationsValType =
+    std::vector<std::tuple<std::string, std::string, std::string>>;
+using GetManagedPropertyType = boost::container::flat_map<
+    std::string,
+    std::variant<std::string, bool, uint8_t, int16_t, uint16_t, int32_t,
+                 uint32_t, int64_t, uint64_t, double, AssociationsValType>>;
+
+using GetManagedObjectsType = boost::container::flat_map<
+    sdbusplus::message::object_path,
+    boost::container::flat_map<std::string, GetManagedPropertyType>>;
 
 inline std::string translateSeverityDbusToRedfish(const std::string& s)
 {
@@ -5405,6 +5433,618 @@ inline void getSystemHardwareIsolationLogService(
 }
 
 /**
+ * @brief Workaround to handle DCM (Dual-Chip Module) package for Redfish
+ *
+ * This API will make sure processor modeled as dual chip module, If yes then,
+ * replace the redfish processor id as "dcmN-cpuN" because redfish currently
+ * does not support chip module concept.
+ *
+ * @param[in] dbusObjPath - The D-Bus object path to return the object instance
+ *
+ * @return the object instance with it parent instance id if the given object
+ *         is a processor else the object instance alone.
+ */
+inline std::string
+    getIsolatedHwItemId(const sdbusplus::message::object_path& dbusObjPath)
+{
+    std::string isolatedHwItemId;
+
+    if ((dbusObjPath.filename().find("cpu") != std::string::npos) &&
+        (dbusObjPath.parent_path().filename().find("dcm") != std::string::npos))
+    {
+        isolatedHwItemId = std::string(dbusObjPath.parent_path().filename() +
+                                       "-" + dbusObjPath.filename());
+    }
+    else
+    {
+        isolatedHwItemId = dbusObjPath.filename();
+    }
+    return isolatedHwItemId;
+}
+
+/**
+ * @brief API used to get redfish uri of the given dbus object and fill into
+ *        "OriginOfCondition" property of LogEntry schema.
+ *
+ * @param[in] asyncResp - The redfish response to return.
+ * @param[in] dbusObjPath - The DBus object path which represents redfishUri.
+ * @param[in] entryJsonIdx - The json entry index to add isolated hardware
+ *                            details in the appropriate entry json object.
+ *
+ * @return The redfish response with "OriginOfCondition" property of
+ *         LogEntry schema if success else return the error
+ */
+inline void getRedfishUriByDbusObjPath(
+    const std::shared_ptr<bmcweb::AsyncResp>& asyncResp,
+    const sdbusplus::message::object_path& dbusObjPath,
+    const size_t entryJsonIdx)
+{
+    crow::connections::systemBus->async_method_call(
+        [asyncResp, dbusObjPath, entryJsonIdx](
+            const boost::system::error_code ec, const dbus::utility::MapperGetObject& objType) {
+            if (ec || objType.empty())
+            {
+                BMCWEB_LOG_ERROR << "DBUS response error [" << ec.value()
+                                 << " : " << ec.message()
+                                 << "] when tried to get the RedfishURI of "
+                                 << "isolated hareware: " << dbusObjPath.str;
+                messages::internalError(asyncResp->res);
+                return;
+            }
+
+            RedfishUriListType::const_iterator redfishUriIt;
+            for (const auto& service : objType)
+            {
+                for (const auto& interface : service.second)
+                {
+                    redfishUriIt = redfishUriList.find(interface);
+                    if (redfishUriIt != redfishUriList.end())
+                    {
+                        // Found the Redfish URI of the isolated hardware unit.
+                        break;
+                    }
+                }
+                if (redfishUriIt != redfishUriList.end())
+                {
+                    // No need to check in the next service interface list
+                    break;
+                }
+            }
+
+            if (redfishUriIt == redfishUriList.end())
+            {
+                BMCWEB_LOG_ERROR
+                    << "The object[" << dbusObjPath.str
+                    << "] interface is not found in the Redfish URI list. "
+                    << "Please add the respective D-Bus interface name";
+                messages::internalError(asyncResp->res);
+                return;
+            }
+
+            // Fill the isolated hardware object id along with the Redfish URI
+            std::string redfishUri =
+                redfishUriIt->second + "/" + getIsolatedHwItemId(dbusObjPath);
+
+            // Make sure whether no need to fill the parent object id in the
+            // isolated hardware Redfish URI.
+            const std::string uriIdPattern{"<str>"};
+            size_t uriIdPos = redfishUri.rfind(uriIdPattern);
+            if (uriIdPos == std::string::npos)
+            {
+                if (entryJsonIdx > 0)
+                {
+                    asyncResp->res.jsonValue["Members"][entryJsonIdx - 1]
+                                            ["Links"]["OriginOfCondition"] = {
+                        {"@odata.id", redfishUri}};
+                }
+                else
+                {
+                    asyncResp->res.jsonValue["Links"]["OriginOfCondition"] = {
+                        {"@odata.id", redfishUri}};
+                }
+                return;
+            }
+
+            // Fill the all parents Redfish URI id.
+            // For example, the processors id for the core.
+            // "/redfish/v1/Systems/system/Processors/<str>/SubProcessors/core0"
+            crow::connections::systemBus->async_method_call(
+                [asyncResp, dbusObjPath, entryJsonIdx, redfishUri, uriIdPos,
+                 uriIdPattern](
+                    const boost::system::error_code ec1,
+                    const boost::container::flat_map<
+                        std::string,
+                        boost::container::flat_map<std::string,
+                                                   std::vector<std::string>>>&
+                        subtree) mutable {
+                    if (ec1)
+                    {
+                        BMCWEB_LOG_ERROR
+                            << "DBUS response error [" << ec1.value() << " : "
+                            << ec1.message()
+                            << "] when tried to fill the parent "
+                            << "objects id in the RedfishURI: " << redfishUri
+                            << " of the isolated hareware: " << dbusObjPath.str;
+                        messages::internalError(asyncResp->res);
+                        return;
+                    }
+
+                    while (uriIdPos != std::string::npos)
+                    {
+                        std::string parentRedfishUri =
+                            redfishUri.substr(0, uriIdPos - 1);
+                        RedfishUriListType::const_iterator parentRedfishUriIt =
+                            std::find_if(
+                                redfishUriList.begin(), redfishUriList.end(),
+                                [parentRedfishUri](const auto& ele) {
+                                    return parentRedfishUri == ele.second;
+                                });
+
+                        if (parentRedfishUriIt == redfishUriList.end())
+                        {
+                            BMCWEB_LOG_ERROR
+                                << "Failed to fill Links:OriginOfCondition "
+                                << "because unable to get parent Redfish URI "
+                                << "[" << parentRedfishUri << "]"
+                                << "DBus interface for the identified "
+                                << "Redfish URI: " << redfishUri
+                                << " of the given DBus object path: "
+                                << dbusObjPath.str;
+                            messages::internalError(asyncResp->res);
+                            return;
+                        }
+
+                        std::string parentObj;
+                        for (const auto& obj : subtree)
+                        {
+                            if (dbusObjPath.str.find(
+                                    sdbusplus::message::object_path(obj.first)
+                                        .filename()) == std::string::npos)
+                            {
+                                // The object is not found in the isolated
+                                // hardware object path
+                                continue;
+                            }
+
+                            for (const auto& service : obj.second)
+                            {
+                                for (const auto& interface : service.second)
+                                {
+                                    if (interface == parentRedfishUriIt->first)
+                                    {
+                                        parentObj = obj.first;
+                                        break;
+                                    }
+                                }
+                                if (!parentObj.empty())
+                                {
+                                    break;
+                                }
+                            }
+                            if (!parentObj.empty())
+                            {
+                                break;
+                            }
+                        }
+
+                        if (parentObj.empty())
+                        {
+                            BMCWEB_LOG_ERROR
+                                << "Failed to fill Links:OriginOfCondition "
+                                << "because unable to get parent DBus path "
+                                << "for the identified parent Redfish URI: "
+                                << parentRedfishUri
+                                << " of the given DBus object path: "
+                                << dbusObjPath.str;
+                            messages::internalError(asyncResp->res);
+                            return;
+                        }
+
+                        redfishUri.replace(
+                            uriIdPos, uriIdPattern.length(),
+                            getIsolatedHwItemId(
+                                sdbusplus::message::object_path(parentObj)));
+
+                        uriIdPos = redfishUri.rfind(uriIdPattern);
+                    }
+
+                    if (entryJsonIdx > 0)
+                    {
+                        asyncResp->res.jsonValue["Members"][entryJsonIdx - 1]
+                                                ["Links"]["OriginOfCondition"] =
+                            {{"@odata.id", redfishUri}};
+                    }
+                    else
+                    {
+                        asyncResp->res.jsonValue["Links"]["OriginOfCondition"] =
+                            {{"@odata.id", redfishUri}};
+                    }
+                },
+                "xyz.openbmc_project.ObjectMapper",
+                "/xyz/openbmc_project/object_mapper",
+                "xyz.openbmc_project.ObjectMapper", "GetSubTree",
+                "/xyz/openbmc_project/inventory", 0,
+                std::array<const char*, 0>{});
+        },
+        "xyz.openbmc_project.ObjectMapper",
+        "/xyz/openbmc_project/object_mapper",
+        "xyz.openbmc_project.ObjectMapper", "GetObject", dbusObjPath.str,
+        std::array<const char*, 0>{});
+}
+
+/**
+ * @brief API used to get "PrettyName" by using the given dbus object path
+ *        and fill into "Message" property of LogEntry schema.
+ *
+ * @param[in] asyncResp - The redfish response to return.
+ * @param[in] dbusObjPath - The DBus object path which represents redfishUri.
+ * @param[in] entryJsonIdx - The json entry index to add isolated hardware
+ *                            details in the appropriate entry json object.
+ *
+ * @return The redfish response with "Message" property of LogEntry schema
+ *         if success else nothing in redfish response.
+ */
+
+inline void getPrettyNameByDbusObjPath(
+    const std::shared_ptr<bmcweb::AsyncResp>& asyncResp,
+    const sdbusplus::message::object_path& dbusObjPath,
+    const size_t entryJsonIdx)
+{
+    crow::connections::systemBus->async_method_call(
+        [asyncResp, dbusObjPath,
+         entryJsonIdx](const boost::system::error_code ec,
+                       const dbus::utility::MapperGetObject& objType) mutable {
+            if (ec || objType.empty())
+            {
+                BMCWEB_LOG_ERROR << "DBUS response error [" << ec.value()
+                                 << " : " << ec.message()
+                                 << "] when tried to get the dbus name"
+                                    "of isolated hareware: "
+                                 << dbusObjPath.str;
+                messages::internalError(asyncResp->res);
+                return;
+            }
+
+            if (objType.size() > 1)
+            {
+                BMCWEB_LOG_ERROR << "More than one dbus service implemented "
+                                    "the xyz.openbmc_project.Inventory.Item "
+                                    "interface to get the PrettyName";
+                messages::internalError(asyncResp->res);
+                return;
+            }
+
+            if (objType[0].first.empty())
+            {
+                BMCWEB_LOG_ERROR << "The retrieved dbus name is empty for the "
+                                    "given dbus object: "
+                                 << dbusObjPath.str;
+                messages::internalError(asyncResp->res);
+                return;
+            }
+
+            if (entryJsonIdx > 0)
+            {
+                asyncResp->res
+                    .jsonValue["Members"][entryJsonIdx - 1]["Message"] =
+                    dbusObjPath.filename();
+                auto msgPropPath = "/Members"_json_pointer;
+                msgPropPath /= entryJsonIdx - 1;
+                msgPropPath /= "Message";
+                name_util::getPrettyName(asyncResp, dbusObjPath.str, objType,
+                                         msgPropPath);
+            }
+            else
+            {
+                asyncResp->res.jsonValue["Message"] = dbusObjPath.filename();
+                name_util::getPrettyName(asyncResp, dbusObjPath.str, objType,
+                                         "/Message"_json_pointer);
+            }
+        },
+        "xyz.openbmc_project.ObjectMapper",
+        "/xyz/openbmc_project/object_mapper",
+        "xyz.openbmc_project.ObjectMapper", "GetObject", dbusObjPath.str,
+        std::array<const char*, 1>{"xyz.openbmc_project.Inventory.Item"});
+}
+
+/**
+ * @brief API used to fill the isolated hardware details into LogEntry schema
+ *        by using the given isolated dbus object which is present in
+ *        xyz.openbmc_project.Association.Definitions::Associations of the
+ *        HardwareIsolation dbus entry object.
+ *
+ * @param[in] asyncResp - The redfish response to return.
+ * @param[in] dbusObjPath - The DBus object path which represents redfishUri.
+ * @param[in] entryJsonIdx - The json entry index to add isolated hardware
+ *                            details in the appropriate entry json object.
+ *
+ * @return The redfish response with appropriate redfish properties of the
+ *         isolated hardware details into LogEntry schema if success else
+ *         nothing in redfish response.
+ */
+inline void fillIsolatedHwDetailsByObjPath(
+    const std::shared_ptr<bmcweb::AsyncResp>& asyncResp,
+    const sdbusplus::message::object_path& dbusObjPath,
+    const size_t entryJsonIdx)
+{
+    // Fill Redfish uri of isolated hardware into "OriginOfCondition"
+    if (dbusObjPath.filename().find("unit") != std::string::npos)
+    {
+        // If Isolated Hardware object name contain "unit" then that unit
+        // is not modelled in inventory and redfish so the "OriginOfCondition"
+        // should filled with it's parent (aka FRU of unit) path.
+        getRedfishUriByDbusObjPath(asyncResp, dbusObjPath.parent_path(),
+                                   entryJsonIdx);
+    }
+    else
+    {
+        getRedfishUriByDbusObjPath(asyncResp, dbusObjPath, entryJsonIdx);
+    }
+
+    // Fill PrettyName of isolated hardware into "Message"
+    getPrettyNameByDbusObjPath(asyncResp, dbusObjPath, entryJsonIdx);
+}
+
+/**
+ * @brief API used to fill isolated hardware details into LogEntry schema
+ *        by using the given isolated dbus object.
+ *
+ * @param[in] asyncResp - The redfish response to return.
+ * @param[in] entryJsonIdx - The json entry index to add isolated hardware
+ *                            details. If passing less than or equal 0 then,
+ *                            it will assume the given asyncResp jsonValue as
+ *                            a single entry json object. If passing greater
+ *                            than 0 then, it will assume the given asyncResp
+ *                            jsonValue contains "Members" to fill in the
+ *                            appropriate entry json object.
+ * @param[in] dbusObjIt - The DBus object which contains isolated hardware
+                         details.
+ *
+ * @return The redfish response with appropriate redfish properties of the
+ *         isolated hardware details into LogEntry schema if success else
+ *         failure response.
+ */
+inline void fillSystemHardwareIsolationLogEntry(
+    const std::shared_ptr<bmcweb::AsyncResp>& asyncResp,
+    const size_t entryJsonIdx, GetManagedObjectsType::const_iterator& dbusObjIt)
+{
+    nlohmann::json& entryJson =
+        (entryJsonIdx > 0
+             ? asyncResp->res.jsonValue["Members"][entryJsonIdx - 1]
+             : asyncResp->res.jsonValue);
+
+    for (auto& interface : dbusObjIt->second)
+    {
+        if (interface.first == "xyz.openbmc_project."
+                               "HardwareIsolation.Entry")
+        {
+            for (auto& property : interface.second)
+            {
+                if (property.first == "Severity")
+                {
+                    const std::string* severity =
+                        std::get_if<std::string>(&property.second);
+                    if (severity == nullptr)
+                    {
+                        BMCWEB_LOG_ERROR
+                            << "Failed to get the Severity "
+                            << "from object: " << dbusObjIt->first.str;
+                        messages::internalError(asyncResp->res);
+                        break;
+                    }
+
+                    if (*severity == "xyz.openbmc_project."
+                                     "HardwareIsolation.Entry.Type."
+                                     "Critical")
+                    {
+                        entryJson["Severity"] = "Critical";
+                    }
+                    else if ((*severity == "xyz.openbmc_project."
+                                           "HardwareIsolation."
+                                           "Entry.Type.Warning") ||
+                             (*severity == "xyz.openbmc_project."
+                                           "HardwareIsolation."
+                                           "Entry.Type.Manual"))
+                    {
+                        entryJson["Severity"] = "Warning";
+                    }
+                    else
+                    {
+                        BMCWEB_LOG_ERROR
+                            << "Unsupported Severity[ " << *severity
+                            << "] from object: " << dbusObjIt->first.str;
+                        messages::internalError(asyncResp->res);
+                        break;
+                    }
+                }
+                else if (property.first == "Resolved")
+                {
+                    const bool* resolved = std::get_if<bool>(&property.second);
+                    if (resolved == nullptr)
+                    {
+                        BMCWEB_LOG_ERROR
+                            << "Failed to get the Resolved"
+                            << "from object: " << dbusObjIt->first.str;
+                        messages::internalError(asyncResp->res);
+                        break;
+                    }
+                    entryJson["Resolved"] = *resolved;
+                }
+            }
+        }
+        else if (interface.first == "xyz.openbmc_project."
+                                    "Time.EpochTime")
+        {
+            for (auto& property : interface.second)
+            {
+                if (property.first == "Elapsed")
+                {
+                    const uint64_t* elapsdTime =
+                        std::get_if<uint64_t>(&property.second);
+                    if (elapsdTime == nullptr)
+                    {
+                        BMCWEB_LOG_ERROR
+                            << "Failed to get the Elapsed time "
+                            << "from object: " << dbusObjIt->first.str;
+                        messages::internalError(asyncResp->res);
+                        break;
+                    }
+                    entryJson["Created"] = redfish::time_utils::getDateTimeUint(
+                        (*elapsdTime));
+                }
+            }
+        }
+        else if (interface.first == "xyz.openbmc_project.Association."
+                                    "Definitions")
+        {
+            for (auto& property : interface.second)
+            {
+                if (property.first == "Associations")
+                {
+                    const AssociationsValType* associations =
+                        std::get_if<AssociationsValType>(&property.second);
+                    if (associations == nullptr)
+                    {
+                        BMCWEB_LOG_ERROR
+                            << "Failed to get the Associations"
+                            << "from object: " << dbusObjIt->first.str;
+                        messages::internalError(asyncResp->res);
+                        break;
+                    }
+                    for (auto& assoc : *associations)
+                    {
+                        if (std::get<0>(assoc) == "isolated_hw")
+                        {
+                            fillIsolatedHwDetailsByObjPath(
+                                asyncResp,
+                                sdbusplus::message::object_path(
+                                    std::get<2>(assoc)),
+                                entryJsonIdx);
+                        }
+                        else if (std::get<0>(assoc) == "isolated_hw_errorlog")
+                        {
+                            sdbusplus::message::object_path errPath =
+                                std::get<2>(assoc);
+                            entryJson["AdditionalDataURI"] =
+                                "/redfish/v1/Systems/system/"
+                                "LogServices/EventLog/Entries/" +
+                                errPath.filename() + "/attachment";
+                        }
+                    }
+                }
+            }
+        }
+    }
+
+    entryJson["@odata.type"] = "#LogEntry.v1_9_0.LogEntry";
+    entryJson["@odata.id"] =
+        "/redfish/v1/Systems/system/LogServices/HardwareIsolation/"
+        "Entries/" +
+        dbusObjIt->first.filename();
+    entryJson["Id"] = dbusObjIt->first.filename();
+    entryJson["Name"] = "Hardware Isolation Entry";
+    entryJson["EntryType"] = "Event";
+}
+
+/**
+ * @brief API Used to add the supported HardwareIsolation LogEntry Entries id
+ *
+ * @param[in] req - The HardwareIsolation redfish request (unused now).
+ * @param[in] asyncResp - The redfish response to return.
+ *
+ * @return The redfish response in the given buffer.
+ *
+ * @note This function will return the available entries dbus object which are
+ *       created by HardwareIsolation manager.
+ */
+inline void getSystemHardwareIsolationLogEntryCollection(
+    const crow::Request& /* req */,
+    const std::shared_ptr<bmcweb::AsyncResp>& asyncResp)
+{
+
+    auto getManagedObjectsHandler = [asyncResp](
+                                        const boost::system::error_code ec,
+                                        const GetManagedObjectsType& mgtObjs) {
+        if (ec)
+        {
+            BMCWEB_LOG_ERROR
+                << "DBUS response error [" << ec.value() << " : "
+                << ec.message()
+                << "] when tried to get the HardwareIsolation managed objects";
+            messages::internalError(asyncResp->res);
+            return;
+        }
+
+        nlohmann::json& entriesArray = asyncResp->res.jsonValue["Members"];
+        entriesArray = nlohmann::json::array();
+
+        for (auto dbusObjIt = mgtObjs.begin(); dbusObjIt != mgtObjs.end();
+             dbusObjIt++)
+        {
+            entriesArray.push_back(nlohmann::json::object());
+
+            fillSystemHardwareIsolationLogEntry(asyncResp, entriesArray.size(),
+                                                dbusObjIt);
+        }
+
+        asyncResp->res.jsonValue["Members@odata.count"] = entriesArray.size();
+
+        asyncResp->res.jsonValue["@odata.type"] =
+            "#LogEntryCollection.LogEntryCollection";
+        asyncResp->res.jsonValue["@odata.id"] =
+            "/redfish/v1/Systems/system/LogServices/HardwareIsolation/"
+            "Entries";
+        asyncResp->res.jsonValue["Name"] = "Hardware Isolation Entries";
+        asyncResp->res.jsonValue["Description"] =
+            "Collection of System Hardware Isolation Entries";
+    };
+
+    // Get the DBus name of HardwareIsolation service
+    crow::connections::systemBus->async_method_call(
+        [asyncResp, getManagedObjectsHandler](
+            const boost::system::error_code ec, const dbus::utility::MapperGetObject& objType) {
+            if (ec || objType.empty())
+            {
+                BMCWEB_LOG_ERROR << "DBUS response error [" << ec.value()
+                                 << " : " << ec.message()
+                                 << "] when tried to get the HardwareIsolation "
+                                    "dbus name";
+                messages::internalError(asyncResp->res);
+                return;
+            }
+
+            if (objType.size() > 1)
+            {
+                BMCWEB_LOG_ERROR << "More than one dbus service implemented "
+                                    "the HardwareIsolation service";
+                messages::internalError(asyncResp->res);
+                return;
+            }
+
+            if (objType[0].first.empty())
+            {
+                BMCWEB_LOG_ERROR << "The retrieved HardwareIsolation dbus "
+                                    "name is empty";
+                messages::internalError(asyncResp->res);
+                return;
+            }
+
+            // Fill the Redfish LogEntry schema for the retrieved
+            // HardwareIsolation entries
+            crow::connections::systemBus->async_method_call(
+                getManagedObjectsHandler, objType[0].first,
+                "/xyz/openbmc_project/hardware_isolation",
+                "org.freedesktop.DBus.ObjectManager", "GetManagedObjects");
+        },
+        "xyz.openbmc_project.ObjectMapper",
+        "/xyz/openbmc_project/object_mapper",
+        "xyz.openbmc_project.ObjectMapper", "GetObject",
+        "/xyz/openbmc_project/hardware_isolation",
+        std::array<const char*, 1>{
+            "xyz.openbmc_project.HardwareIsolation.Create"});
+}
+
+/**
  * @brief API used to route the handler for HardwareIsolation Redfish
  *        LogServices URI
  *
@@ -5419,6 +6059,12 @@ inline void requestRoutesSystemHardwareIsolationLogService(App& app)
         .privileges(redfish::privileges::getLogService)
         .methods(boost::beast::http::verb::get)(
             getSystemHardwareIsolationLogService);
+
+    BMCWEB_ROUTE(
+        app, "/redfish/v1/Systems/system/LogServices/HardwareIsolation/Entries")
+        .privileges(redfish::privileges::getLogEntryCollection)
+        .methods(boost::beast::http::verb::get)(
+            getSystemHardwareIsolationLogEntryCollection);
 }
 #endif // BMCWEB_ENABLE_HW_ISOLATION
 

--- a/redfish-core/lib/log_services.hpp
+++ b/redfish-core/lib/log_services.hpp
@@ -44,6 +44,7 @@
 #include <utils/dbus_utils.hpp>
 #include <utils/time_utils.hpp>
 #include <utils/name_utils.hpp>
+#include <utils/error_log_utils.hpp>
 
 #include <charconv>
 #include <filesystem>
@@ -5930,10 +5931,25 @@ inline void fillSystemHardwareIsolationLogEntry(
                         {
                             sdbusplus::message::object_path errPath =
                                 std::get<2>(assoc);
-                            entryJson["AdditionalDataURI"] =
-                                "/redfish/v1/Systems/system/"
-                                "LogServices/EventLog/Entries/" +
-                                errPath.filename() + "/attachment";
+
+                            // Set error log uri based on the error log hidden
+                            // property
+                            if (entryJsonIdx > 0)
+                            {
+                                nlohmann::json_pointer errorLogPropPath =
+                                    "/Members"_json_pointer;
+                                errorLogPropPath /= entryJsonIdx - 1;
+                                errorLogPropPath /= "AdditionalDataURI";
+                                error_log_utils::setErrorLogUri(
+                                    asyncResp, errPath, errorLogPropPath,
+                                    false);
+                            }
+                            else
+                            {
+                                error_log_utils::setErrorLogUri(
+                                    asyncResp, errPath,
+                                    "/AdditionalDataURI"_json_pointer, false);
+                            }
                         }
                     }
                 }
@@ -5986,6 +6002,13 @@ inline void getSystemHardwareIsolationLogEntryCollection(
         for (auto dbusObjIt = mgtObjs.begin(); dbusObjIt != mgtObjs.end();
              dbusObjIt++)
         {
+            if (dbusObjIt->second.find(
+                    "xyz.openbmc_project.HardwareIsolation.Entry") ==
+                dbusObjIt->second.end())
+            {
+                // The retrieved object is not hardware isolation entry
+                continue;
+            }
             entriesArray.push_back(nlohmann::json::object());
 
             fillSystemHardwareIsolationLogEntry(asyncResp, entriesArray.size(),

--- a/redfish-core/lib/log_services.hpp
+++ b/redfish-core/lib/log_services.hpp
@@ -5945,19 +5945,6 @@ inline void fillSystemHardwareIsolationLogEntry(
                         break;
                     }
                 }
-                else if (property.first == "Resolved")
-                {
-                    const bool* resolved = std::get_if<bool>(&property.second);
-                    if (resolved == nullptr)
-                    {
-                        BMCWEB_LOG_ERROR
-                            << "Failed to get the Resolved"
-                            << "from object: " << dbusObjIt->first.str;
-                        messages::internalError(asyncResp->res);
-                        break;
-                    }
-                    entryJson["Resolved"] = *resolved;
-                }
             }
         }
         else if (interface.first == "xyz.openbmc_project."

--- a/redfish-core/lib/log_services.hpp
+++ b/redfish-core/lib/log_services.hpp
@@ -6324,18 +6324,51 @@ inline void deleteSystemHardwareIsolationLogEntryById(
 
             // Delete the respective dbus entry object
             crow::connections::systemBus->async_method_call(
-                [asyncResp, entryObjPath](const boost::system::error_code ec1) {
-                    if (ec1)
+                [asyncResp,
+                 entryObjPath](const boost::system::error_code ec1,
+                               const sdbusplus::message::message& msg) {
+                    if (!ec1)
                     {
-                        BMCWEB_LOG_ERROR << "DBUS response error ["
-                                         << ec1.value() << " : " << ec1.message()
-                                         << "] when tried to delete the given "
-                                            "object path: "
-                                         << entryObjPath.str;
+                        messages::success(asyncResp->res);
+                        return;
+                    }
+
+                    BMCWEB_LOG_ERROR << "DBUS response error [" << ec1.value()
+                                     << " : " << ec1.message()
+                                     << "] when tried to delete the given "
+                                     << "entry: " << entryObjPath.str;
+
+                    const sd_bus_error* dbusError = msg.get_error();
+
+                    if (dbusError == nullptr)
+                    {
                         messages::internalError(asyncResp->res);
                         return;
                     }
-                    messages::success(asyncResp->res);
+
+                    BMCWEB_LOG_ERROR << "DBus ErrorName: " << dbusError->name
+                                     << " ErrorMsg: " << dbusError->message;
+
+                    if (strcmp(dbusError->name,
+                               "xyz.openbmc_project.Common.Error."
+                               "NotAllowed") == 0)
+                    {
+                        messages::chassisPowerStateOffRequired(asyncResp->res,
+                                                               "chassis");
+                    }
+                    else if (strcmp(dbusError->name,
+                                    "xyz.openbmc_project.Common.Error."
+                                    "InsufficientPermission") == 0)
+                    {
+                        messages::resourceCannotBeDeleted(asyncResp->res);
+                    }
+                    else
+                    {
+                        BMCWEB_LOG_ERROR << "DBus Error is unsupported so "
+                                            "returning as Internal Error";
+                        messages::internalError(asyncResp->res);
+                    }
+                    return;
                 },
                 objType[0].first, entryObjPath.str,
                 "xyz.openbmc_project.Object.Delete", "Delete");
@@ -6390,18 +6423,45 @@ inline void postSystemHardwareIsolationLogServiceClearLog(
 
             // Delete all HardwareIsolation entries
             crow::connections::systemBus->async_method_call(
-                [asyncResp](const boost::system::error_code ec1) {
-                    if (ec1)
+                [asyncResp](const boost::system::error_code ec1,
+                            const sdbusplus::message::message& msg) {
+                    if (!ec1)
                     {
-                        BMCWEB_LOG_ERROR
-                            << "DBUS response error [" << ec1.value() << " : "
-                            << ec1.message()
-                            << "] when tried to delete all HardwareIsolation "
-                               "entries";
+                        messages::success(asyncResp->res);
+                        return;
+                    }
+
+                    BMCWEB_LOG_ERROR
+                        << "DBUS response error [" << ec1.value() << " : "
+                        << ec1.message()
+                        << "] when tried to delete all HardwareIsolation "
+                           "entries";
+
+                    const sd_bus_error* dbusError = msg.get_error();
+
+                    if (dbusError == nullptr)
+                    {
                         messages::internalError(asyncResp->res);
                         return;
                     }
-                    messages::success(asyncResp->res);
+
+                    BMCWEB_LOG_ERROR << "DBus ErrorName: " << dbusError->name
+                                     << " ErrorMsg: " << dbusError->message;
+
+                    if (strcmp(dbusError->name,
+                               "xyz.openbmc_project.Common.Error."
+                               "NotAllowed") == 0)
+                    {
+                        messages::chassisPowerStateOffRequired(asyncResp->res,
+                                                               "chassis");
+                    }
+                    else
+                    {
+                        BMCWEB_LOG_ERROR << "DBus Error is unsupported so "
+                                            "returning as Internal Error";
+                        messages::internalError(asyncResp->res);
+                    }
+                    return;
                 },
                 objType[0].first, "/xyz/openbmc_project/hardware_isolation",
                 "xyz.openbmc_project.Collection.DeleteAll", "DeleteAll");

--- a/redfish-core/lib/memory.hpp
+++ b/redfish-core/lib/memory.hpp
@@ -630,7 +630,7 @@ inline void getDimmDataByService(std::shared_ptr<bmcweb::AsyncResp> aResp,
     BMCWEB_LOG_DEBUG << "Get available system components.";
     sdbusplus::asio::getAllProperties(
         *crow::connections::systemBus, service, objPath, "",
-        [dimmId, aResp{std::move(aResp)}](
+        [dimmId, aResp{std::move(aResp)},objPath](
             const boost::system::error_code ec,
             const dbus::utility::DBusPropertiesMap& properties) {
         if (ec)
@@ -640,6 +640,11 @@ inline void getDimmDataByService(std::shared_ptr<bmcweb::AsyncResp> aResp,
             return;
         }
         assembleDimmProperties(dimmId, aResp, properties, ""_json_pointer);
+        
+#ifdef BMCWEB_ENABLE_HW_ISOLATION
+        // Check for the hardware status event
+        hw_isolation_utils::getHwIsolationStatus(aResp, objPath);
+#endif // end of BMCWEB_ENABLE_HW_ISOLATION
         });
 }
 

--- a/redfish-core/lib/memory.hpp
+++ b/redfish-core/lib/memory.hpp
@@ -24,6 +24,7 @@
 #include <sdbusplus/unpack_properties.hpp>
 #include <utils/collection.hpp>
 #include <utils/hex_utils.hpp>
+#include <utils/hw_isolation.hpp>
 #include <utils/json_utils.hpp>
 
 namespace redfish
@@ -720,6 +721,53 @@ inline void getDimmPartitionData(std::shared_ptr<bmcweb::AsyncResp> aResp,
 }
 
 /**
+ * @brief API used to get the Object.Enable interface properties value
+ *        for Memory
+ *
+ * @param[in] aResp - The redfish response to return.
+ * @param[in] service - The dbus service name which is hosting the given path.
+ * @param[in] path - The given Memory resource inventory dbus object path.
+ *
+ * @return The redfish response in the given buffer.
+ *
+ * @note - The "Enabled" member of the Memory (aka DIMM) is mapped with
+ *         "xyz.openbmc_project.Object.Enable::Enabled" dbus property.
+ */
+inline void getObjectEnable(std::shared_ptr<bmcweb::AsyncResp> aResp,
+                            const std::string& service, const std::string& path)
+{
+    crow::connections::systemBus->async_method_call(
+        [aResp{std::move(aResp)}](
+            const boost::system::error_code ec,
+            const boost::container::flat_map<std::string, std::variant<bool>>&
+                properties) {
+            if (ec)
+            {
+                BMCWEB_LOG_ERROR << "DBUS response error [" << ec.value()
+                                 << " : " << ec.message() << "]";
+                messages::internalError(aResp->res);
+                return;
+            }
+
+            for (const auto& [propName, propValue] : properties)
+            {
+                if (propName == "Enabled")
+                {
+                    const bool* enabled = std::get_if<bool>(&propValue);
+                    if (enabled == nullptr)
+                    {
+                        messages::internalError(aResp->res);
+                        break;
+                    }
+                    aResp->res.jsonValue["Enabled"] = *enabled;
+                }
+            }
+        },
+        service, path, "org.freedesktop.DBus.Properties", "GetAll",
+        "xyz.openbmc_project.Object.Enable");
+}
+
+/**
  * Find the D-Bus object representing the requested DIMM, and call the
  * handler with the results. If matching object is not found, add 404 error to
  * response and don't call the handler.
@@ -805,6 +853,7 @@ inline void getDimmData(const std::shared_ptr<bmcweb::AsyncResp>& aResp,
         bool dimmInterface = false;
         bool partitionInterface = false;
         bool associationInterface = false;
+        bool objectEnable = false;
         for (const auto& interface : interfaceList)
         {
             if (interface == "xyz.openbmc_project.Inventory.Item.Dimm")
@@ -821,6 +870,10 @@ inline void getDimmData(const std::shared_ptr<bmcweb::AsyncResp>& aResp,
             {
                 associationInterface = true;
             }
+            else if (interface == "xyz.openbmc_project.Object.Enable")
+            {
+                objectEnable = true;
+            }
         }
 
         if (dimmInterface && partitionInterface)
@@ -833,6 +886,11 @@ inline void getDimmData(const std::shared_ptr<bmcweb::AsyncResp>& aResp,
         else if (dimmInterface && associationInterface)
         {
             getLocationIndicatorActive(aResp, objectPath);
+        }
+
+        if (dimmInterface && objectEnable)
+        {
+            getObjectEnable(aResp, serviceName, objectPath);
         }
     }
 }
@@ -941,6 +999,32 @@ inline void setDimmObject(const std::shared_ptr<bmcweb::AsyncResp>& resp,
             "xyz.openbmc_project.Association.Definitions"});
 }
 
+/**
+ * @brief API used to process the Memory "Enabled" member which is
+ *        patched to do appropriate action.
+ *
+ * @param[in] resp - The redfish response to return.
+ * @param[in] dimmId - The patched Memory (aka DIMM) resource id.
+ * @param[in] enabled - The patched "Enabled" member value.
+ *
+ * @return The redfish response in the given buffer.
+ *
+ * @note - The "Enabled" member of the Memory (aka DIMM) is used to enable
+ *         (aka isolate) or disable (aka deisolate) the resource from the
+ *         system boot so this function will call "processHardwareIsolationReq"
+ *         function which is used to handle the resource isolation request.
+ *       - The "Enabled" member of the Memory is mapped with
+ *         "xyz.openbmc_project.Object.Enable::Enabled" dbus property.
+ */
+
+inline void patchMemberEnabled(const std::shared_ptr<bmcweb::AsyncResp>& resp,
+                               const std::string& dimmId, const bool enabled)
+{
+    redfish::hw_isolation_utils::processHardwareIsolationReq(
+        resp, "Memory", dimmId, enabled,
+        std::vector<const char*>(dimmInterfaces.begin(), dimmInterfaces.end()));
+}
+
 inline void requestRoutesMemoryCollection(App& app)
 {
     /**
@@ -1013,17 +1097,21 @@ inline void requestRoutesMemory(App& app)
                const std::shared_ptr<bmcweb::AsyncResp>& asyncResp,
                const std::string& dimmId) {
         std::optional<bool> locationIndicatorActive;
+        std::optional<bool> enabled;
         if (!json_util::readJsonPatch(req, asyncResp->res,
                                  "LocationIndicatorActive",
-                                 locationIndicatorActive))
+                                 locationIndicatorActive,"Enabled", enabled))
         {
             return;
-
         }
 
         if (locationIndicatorActive)
         {
             setDimmObject(asyncResp, dimmId, locationIndicatorActive);
+        }
+        if (enabled.has_value())
+        {
+            patchMemberEnabled(asyncResp, dimmId, *enabled);
         }
     });
 }

--- a/redfish-core/lib/memory.hpp
+++ b/redfish-core/lib/memory.hpp
@@ -29,6 +29,24 @@
 namespace redfish
 {
 
+using DimmProperty =
+    std::variant<std::string, std::vector<uint32_t>, std::vector<uint16_t>,
+                 uint64_t, uint32_t, uint16_t, uint8_t, bool>;
+
+using DimmProperties = boost::container::flat_map<std::string, DimmProperty>;
+
+// Map of service name to list of interfaces
+using MapperServiceMap =
+    std::vector<std::pair<std::string, std::vector<std::string>>>;
+
+// Map of object paths to MapperServiceMaps
+using MapperGetSubTreeResponse =
+    std::vector<std::pair<std::string, MapperServiceMap>>;
+
+// Interfaces which imply a D-Bus object represents a Memory
+constexpr std::array<const char*, 1> dimmInterfaces = {
+    "xyz.openbmc_project.Inventory.Item.Dimm"};
+
 inline std::string translateMemoryTypeToRedfish(const std::string& memoryType)
 {
     if (memoryType == "xyz.openbmc_project.Inventory.Item.Dimm.DeviceType.DDR")
@@ -701,62 +719,218 @@ inline void getDimmPartitionData(std::shared_ptr<bmcweb::AsyncResp> aResp,
     );
 }
 
-inline void getDimmData(std::shared_ptr<bmcweb::AsyncResp> aResp,
-                        const std::string& dimmId)
+/**
+ * Find the D-Bus object representing the requested DIMM, and call the
+ * handler with the results. If matching object is not found, add 404 error to
+ * response and don't call the handler.
+ *
+ * @param[in,out]   resp            Async HTTP response.
+ * @param[in]       dimmId          Redfish Dimm Id.
+ * @param[in]       handler         Callback to continue processing request upon
+ *                                  successfully finding object.
+ */
+template <typename Handler>
+inline void getDimmObject(const std::shared_ptr<bmcweb::AsyncResp>& resp,
+                          const std::string& dimmId, Handler&& handler)
 {
-    BMCWEB_LOG_DEBUG << "Get available system dimm resources.";
+    BMCWEB_LOG_DEBUG << "Get available system memory resources.";
+
+    // GetSubTree on all interfaces which provide info about a Memory
     crow::connections::systemBus->async_method_call(
-        [dimmId, aResp{std::move(aResp)}](
-            const boost::system::error_code ec,
-            const dbus::utility::MapperGetSubTreeResponse& subtree) {
-        if (ec)
-        {
-            BMCWEB_LOG_DEBUG << "DBUS response error";
-            messages::internalError(aResp->res);
-
-            return;
-        }
-        bool found = false;
-        for (const auto& [rawPath, object] : subtree)
-        {
-            sdbusplus::message::object_path path(rawPath);
-            for (const auto& [service, interfaces] : object)
+        [resp, dimmId, handler = std::forward<Handler>(handler)](
+            boost::system::error_code ec,
+            const MapperGetSubTreeResponse& subtree) mutable {
+            if (ec)
             {
-                for (const auto& interface : interfaces)
+                BMCWEB_LOG_DEBUG << "DBUS response error: " << ec;
+                messages::internalError(resp->res);
+                return;
+            }
+            for (const auto& [objectPath, serviceMap] : subtree)
+            {
+                // Ignore any objects which don't end with our desired dimm name
+                if (!boost::ends_with(objectPath, dimmId))
                 {
-                    if (interface ==
-                            "xyz.openbmc_project.Inventory.Item.Dimm" &&
-                        path.filename() == dimmId)
-                    {
-                        getDimmDataByService(aResp, dimmId, service, rawPath);
-                        found = true;
-                    }
+                    continue;
+                }
 
-                    // partitions are separate as there can be multiple
-                    // per
-                    // device, i.e.
-                    // /xyz/openbmc_project/Inventory/Item/Dimm1/Partition1
-                    // /xyz/openbmc_project/Inventory/Item/Dimm1/Partition2
-                    if (interface ==
-                            "xyz.openbmc_project.Inventory.Item.PersistentMemory.Partition" &&
-                        path.parent_path().filename() == dimmId)
+                bool found = false;
+                // Filter out objects that don't have the DIMM-specific
+                // interfaces to make sure we can return 404 on non-CPUs
+                // (e.g. /redfish/../Memory/cpu0)
+                for (const auto& [serviceName, interfaceList] : serviceMap)
+                {
+                    if (std::find_first_of(
+                            interfaceList.begin(), interfaceList.end(),
+                            dimmInterfaces.begin(),
+                            dimmInterfaces.end()) != interfaceList.end())
                     {
-                        getDimmPartitionData(aResp, service, rawPath);
+                        found = true;
+                        break;
                     }
                 }
+
+                if (!found)
+                {
+                    continue;
+                }
+
+                // Memory the first object which does match our dimm name and
+                // required interfaces, and potentially ignore any other
+                // matching objects. Assume all interfaces we want to process
+                // must be on the same object path.
+
+                handler(resp, dimmId, objectPath, serviceMap);
+                return;
+            }
+            messages::resourceNotFound(resp->res, "Memory", dimmId);
+        },
+        "xyz.openbmc_project.ObjectMapper",
+        "/xyz/openbmc_project/object_mapper",
+        "xyz.openbmc_project.ObjectMapper", "GetSubTree",
+        "/xyz/openbmc_project/inventory", 0,
+        std::array<const char*, 3>{
+            "xyz.openbmc_project.Inventory.Item.Dimm",
+            "xyz.openbmc_project.Inventory.Item.PersistentMemory.Partition",
+            "xyz.openbmc_project.Association.Definitions"});
+}
+
+inline void getDimmData(const std::shared_ptr<bmcweb::AsyncResp>& aResp,
+                        const std::string& dimmId,
+                        const std::string& objectPath,
+                        const MapperServiceMap& serviceMap)
+{
+    for (const auto& [serviceName, interfaceList] : serviceMap)
+    {
+        bool dimmInterface = false;
+        bool partitionInterface = false;
+        bool associationInterface = false;
+        for (const auto& interface : interfaceList)
+        {
+            if (interface == "xyz.openbmc_project.Inventory.Item.Dimm")
+            {
+                dimmInterface = true;
+                getDimmDataByService(aResp, dimmId, serviceName, objectPath);
+            }
+            else if (interface == "xyz.openbmc_project.Inventory.Item."
+                                  "PersistentMemory.Partition")
+            {
+                partitionInterface = true;
+            }
+            else if (interface == "xyz.openbmc_project.Association.Definitions")
+            {
+                associationInterface = true;
             }
         }
-        // Object not found
-        if (!found)
+
+        if (dimmInterface && partitionInterface)
         {
-            messages::resourceNotFound(aResp->res, "Memory", dimmId);
-            return;
+            // partitions are separate as there can be multiple per device,
+            // i.e. /xyz/openbmc_project/Inventory/Item/Dimm1/Partition1
+            // /xyz/openbmc_project/Inventory/Item/Dimm1/Partition2
+            getDimmPartitionData(aResp, serviceName, objectPath);
         }
-        // Set @odata only if object is found
-        aResp->res.jsonValue["@odata.type"] = "#Memory.v1_11_0.Memory";
-        aResp->res.jsonValue["@odata.id"] =
-            "/redfish/v1/Systems/system/Memory/" + dimmId;
-        return;
+        else if (dimmInterface && associationInterface)
+        {
+            getLocationIndicatorActive(aResp, objectPath);
+        }
+    }
+}
+
+inline void setDimmData(const std::shared_ptr<bmcweb::AsyncResp>& aResp,
+                        const MapperServiceMap& serviceMap,
+                        const std::string& objectPath,
+                        std::optional<bool> locationIndicatorActive)
+{
+    for (const auto& [serviceName, interfaceList] : serviceMap)
+    {
+        bool dimmInterface = false;
+        bool associationInterface = false;
+        for (const auto& interface : interfaceList)
+        {
+            if (interface == "xyz.openbmc_project.Inventory.Item.Dimm")
+            {
+                dimmInterface = true;
+            }
+            else if (interface == "xyz.openbmc_project.Association.Definitions")
+            {
+                associationInterface = true;
+            }
+        }
+
+        if (dimmInterface && associationInterface)
+        {
+            if (locationIndicatorActive)
+            {
+                setLocationIndicatorActive(aResp, objectPath,
+                                           *locationIndicatorActive);
+            }
+        }
+    }
+}
+
+/**
+ * Find the D-Bus object representing the requested DIMM, and call the
+ * handler with the results. If matching object is not found, add 404 error to
+ * response and don't call the handler.
+ *
+ * @param[in,out]   resp                              Async HTTP response.
+ * @param[in]       dimmId                            Redfish Dimm Id.
+ * @param[in]       locationIndicatorActive           Value of the property
+ */
+inline void setDimmObject(const std::shared_ptr<bmcweb::AsyncResp>& resp,
+                          const std::string& dimmId,
+                          std::optional<bool> locationIndicatorActive)
+{
+    // GetSubTree on all interfaces which provide info about a Memory
+    crow::connections::systemBus->async_method_call(
+        [resp, dimmId, locationIndicatorActive](
+            boost::system::error_code ec,
+            const MapperGetSubTreeResponse& subtree) mutable {
+            if (ec)
+            {
+                BMCWEB_LOG_DEBUG << "DBUS response error: " << ec;
+                messages::internalError(resp->res);
+                return;
+            }
+            for (const auto& [objectPath, serviceMap] : subtree)
+            {
+                // Ignore any objects which don't end with our desired dimm name
+                if (!boost::ends_with(objectPath, dimmId))
+                {
+                    continue;
+                }
+
+                bool found = false;
+                // Filter out objects that don't have the DIMM-specific
+                // interfaces to make sure we can return 404 on non-CPUs
+                // (e.g. /redfish/../Memory/cpu0)
+                for (const auto& [serviceName, interfaceList] : serviceMap)
+                {
+                    if (std::find_first_of(
+                            interfaceList.begin(), interfaceList.end(),
+                            dimmInterfaces.begin(),
+                            dimmInterfaces.end()) != interfaceList.end())
+                    {
+                        found = true;
+                        break;
+                    }
+                }
+
+                if (!found)
+                {
+                    continue;
+                }
+
+                // Memory the first object which does match our dimm name and
+                // required interfaces, and potentially ignore any other
+                // matching objects. Assume all interfaces we want to process
+                // must be on the same object path.
+                setDimmData(resp, serviceMap, objectPath,
+                            locationIndicatorActive);
+                return;
+            }
+            messages::resourceNotFound(resp->res, "Memory", dimmId);
         },
         "xyz.openbmc_project.ObjectMapper",
         "/xyz/openbmc_project/object_mapper",
@@ -764,7 +938,7 @@ inline void getDimmData(std::shared_ptr<bmcweb::AsyncResp> aResp,
         "/xyz/openbmc_project/inventory", 0,
         std::array<const char*, 2>{
             "xyz.openbmc_project.Inventory.Item.Dimm",
-            "xyz.openbmc_project.Inventory.Item.PersistentMemory.Partition"});
+            "xyz.openbmc_project.Association.Definitions"});
 }
 
 inline void requestRoutesMemoryCollection(App& app)
@@ -824,8 +998,34 @@ inline void requestRoutesMemory(App& app)
             return;
         }
 
-        getDimmData(asyncResp, dimmId);
-        });
+        asyncResp->res.jsonValue["@odata.type"] =
+                    "#Memory.v1_12_0.Memory";
+                asyncResp->res.jsonValue["@odata.id"] =
+                    "/redfish/v1/Systems/system/Memory/" + dimmId;
+                    
+        getDimmObject(asyncResp, dimmId, getDimmData);
+    });
+
+    BMCWEB_ROUTE(app, "/redfish/v1/Systems/system/Memory/<str>/")
+        .privileges({{"Login"}})
+        .methods(boost::beast::http::verb::patch)(
+            [](const crow::Request& req,
+               const std::shared_ptr<bmcweb::AsyncResp>& asyncResp,
+               const std::string& dimmId) {
+        std::optional<bool> locationIndicatorActive;
+        if (!json_util::readJsonPatch(req, asyncResp->res,
+                                 "LocationIndicatorActive",
+                                 locationIndicatorActive))
+        {
+            return;
+
+        }
+
+        if (locationIndicatorActive)
+        {
+            setDimmObject(asyncResp, dimmId, locationIndicatorActive);
+        }
+    });
 }
 
 } // namespace redfish

--- a/redfish-core/lib/processor.hpp
+++ b/redfish-core/lib/processor.hpp
@@ -1050,6 +1050,11 @@ inline void
                         aResp->res.jsonValue["Status"]["Health"] = "Critical";
                     }
                 }
+
+#ifdef BMCWEB_ENABLE_HW_ISOLATION
+                // Check for the hardware status event
+                hw_isolation_utils::getHwIsolationStatus(aResp, objPath);
+#endif // end of BMCWEB_ENABLE_HW_ISOLATION
             }
         },
         service, "/xyz/openbmc_project/inventory",

--- a/redfish-core/lib/processor.hpp
+++ b/redfish-core/lib/processor.hpp
@@ -1507,7 +1507,7 @@ inline void setProcessorObject(const std::shared_ptr<bmcweb::AsyncResp>& resp,
                 // Ignore any objects which don't end with our desired cpu name
                 sdbusplus::message::object_path path(objectPath);
                 std::string name = path.filename();
-                if (name.empty() || name != processorId)
+                if (name.empty() || !isProcObjectMatched(processorId, path))
                 {
                     continue;
                 }

--- a/redfish-core/lib/processor.hpp
+++ b/redfish-core/lib/processor.hpp
@@ -31,6 +31,7 @@
 #include <utils/collection.hpp>
 #include <utils/dbus_utils.hpp>
 #include <utils/json_utils.hpp>
+#include <utils/name_utils.hpp>
 
 namespace redfish
 {
@@ -723,6 +724,10 @@ inline void getProcessorObject(const std::shared_ptr<bmcweb::AsyncResp>& resp,
             // must be on the same object path.
 
             handler(objectPath, serviceMap);
+
+            name_util::getPrettyName(resp, objectPath, serviceMap,
+                                     "/Name"_json_pointer);
+
             return;
         }
         messages::resourceNotFound(resp->res, "Processor", processorId);

--- a/redfish-core/lib/processor.hpp
+++ b/redfish-core/lib/processor.hpp
@@ -900,7 +900,7 @@ inline void getProcessorPaths(const std::shared_ptr<bmcweb::AsyncResp>& aResp,
                               const std::string& processorId, Handler&& handler)
 {
     crow::connections::systemBus->async_method_call(
-        [processorId, aResp, handler{std::move(handler)}](
+        [processorId, aResp, handler{std::forward<Handler>(handler)}](
             const boost::system::error_code ec,
             const std::vector<std::string>& subTreePaths) {
         if (ec)
@@ -1035,7 +1035,7 @@ inline void
                 }
             }
 
-            if (present == false)
+            if (!present)
             {
                 aResp->res.jsonValue["Status"]["State"] = "Absent";
             }
@@ -1113,7 +1113,7 @@ inline void getSubProcessorData(const std::shared_ptr<bmcweb::AsyncResp>& aResp,
                 return;
             }
 
-            if (subtree.size() != 0)
+            if (!subtree.empty())
             {
                 // Object not found
                 messages::resourceNotFound(

--- a/redfish-core/lib/processor.hpp
+++ b/redfish-core/lib/processor.hpp
@@ -18,6 +18,7 @@
 #include "dbus_singleton.hpp"
 #include "error_messages.hpp"
 #include "health.hpp"
+#include "led.hpp"
 
 #include <app.hpp>
 #include <boost/container/flat_map.hpp>
@@ -692,7 +693,9 @@ inline void getProcessorObject(const std::shared_ptr<bmcweb::AsyncResp>& resp,
         for (const auto& [objectPath, serviceMap] : subtree)
         {
             // Ignore any objects which don't end with our desired cpu name
-            if (!objectPath.ends_with(processorId))
+            sdbusplus::message::object_path path(objectPath);
+            std::string name = path.filename();
+            if (name.empty() || name != processorId)
             {
                 continue;
             }
@@ -736,7 +739,7 @@ inline void getProcessorObject(const std::shared_ptr<bmcweb::AsyncResp>& resp,
         "/xyz/openbmc_project/object_mapper",
         "xyz.openbmc_project.ObjectMapper", "GetSubTree",
         "/xyz/openbmc_project/inventory", 0,
-        std::array<const char*, 8>{
+        std::array<const char*, 9>{
             "xyz.openbmc_project.Common.UUID",
             "xyz.openbmc_project.Inventory.Decorator.Asset",
             "xyz.openbmc_project.Inventory.Decorator.Revision",
@@ -744,7 +747,8 @@ inline void getProcessorObject(const std::shared_ptr<bmcweb::AsyncResp>& resp,
             "xyz.openbmc_project.Inventory.Decorator.LocationCode",
             "xyz.openbmc_project.Inventory.Item.Accelerator",
             "xyz.openbmc_project.Control.Processor.CurrentOperatingConfig",
-            "xyz.openbmc_project.Inventory.Decorator.UniqueIdentifier"});
+            "xyz.openbmc_project.Inventory.Decorator.UniqueIdentifier",
+            "xyz.openbmc_project.Association.Definitions"});
 }
 
 inline void getProcessorData(const std::shared_ptr<bmcweb::AsyncResp>& aResp,
@@ -754,19 +758,25 @@ inline void getProcessorData(const std::shared_ptr<bmcweb::AsyncResp>& aResp,
 {
     for (const auto& [serviceName, interfaceList] : serviceMap)
     {
+        bool assertInterface = false;
+        bool cpuInterface = false;
+        bool associationInterface = false;
+        bool revisionInterface = false;
+        bool locationCodeInterface = false;
         for (const auto& interface : interfaceList)
         {
             if (interface == "xyz.openbmc_project.Inventory.Decorator.Asset")
             {
-                getCpuAssetData(aResp, serviceName, objectPath);
+                assertInterface = true;
             }
             else if (interface ==
                      "xyz.openbmc_project.Inventory.Decorator.Revision")
             {
-                getCpuRevisionData(aResp, serviceName, objectPath);
+                revisionInterface = true;
             }
             else if (interface == "xyz.openbmc_project.Inventory.Item.Cpu")
             {
+                cpuInterface = true;
                 getCpuDataByService(aResp, processorId, serviceName,
                                     objectPath);
             }
@@ -785,7 +795,7 @@ inline void getProcessorData(const std::shared_ptr<bmcweb::AsyncResp>& aResp,
             else if (interface ==
                      "xyz.openbmc_project.Inventory.Decorator.LocationCode")
             {
-                getCpuLocationCode(aResp, serviceName, objectPath);
+                locationCodeInterface = true;
             }
             else if (interface == "xyz.openbmc_project.Common.UUID")
             {
@@ -796,6 +806,30 @@ inline void getProcessorData(const std::shared_ptr<bmcweb::AsyncResp>& aResp,
             {
                 getCpuUniqueId(aResp, serviceName, objectPath);
             }
+            else if (interface == "xyz.openbmc_project.Association.Definitions")
+            {
+                associationInterface = true;
+            }
+        }
+
+        if (cpuInterface && assertInterface)
+        {
+            getCpuAssetData(aResp, serviceName, objectPath);
+        }
+
+        if (cpuInterface && revisionInterface)
+        {
+            getCpuRevisionData(aResp, serviceName, objectPath);
+        }
+
+        if (cpuInterface && locationCodeInterface)
+        {
+            getCpuLocationCode(aResp, serviceName, objectPath);
+        }
+
+        if (cpuInterface && associationInterface)
+        {
+            getLocationIndicatorActive(aResp, objectPath);
         }
     }
 }
@@ -1059,6 +1093,114 @@ inline void handleProcessorCollectionHead(
         "</redfish/v1/JsonSchemas/ProcessorCollection/ProcessorCollection.json>; rel=describedby");
 }
 
+inline void setProcessorData(const std::shared_ptr<bmcweb::AsyncResp>& aResp,
+                             const dbus::utility::MapperServiceMap& serviceMap,
+                             const std::string& objectPath,
+                             std::optional<bool> locationIndicatorActive)
+{
+    for (const auto& [serviceName, interfaceList] : serviceMap)
+    {
+        bool cpuInterface = false;
+        bool associationInterface = false;
+        for (const auto& interface : interfaceList)
+        {
+            if (interface == "xyz.openbmc_project.Inventory.Item.Cpu")
+            {
+                cpuInterface = true;
+            }
+            else if (interface == "xyz.openbmc_project.Association.Definitions")
+            {
+                associationInterface = true;
+            }
+        }
+
+        if (cpuInterface && associationInterface)
+        {
+            if (locationIndicatorActive)
+            {
+                setLocationIndicatorActive(aResp, objectPath,
+                                           *locationIndicatorActive);
+            }
+        }
+    }
+}
+
+/**
+ * Find the D-Bus object representing the requested Processor, and call the
+ * setProcessorData with the results. If matching object is not found, add 404
+ * error to response and don't call the setProcessorData.
+ *
+ * @param[in,out]   resp                            Async HTTP response.
+ * @param[in]       processorId                     Redfish Processor Id.
+ * @param[in]       locationIndicatorActive         Value of the property
+ */
+inline void setProcessorObject(const std::shared_ptr<bmcweb::AsyncResp>& resp,
+                               const std::string& processorId,
+                               std::optional<bool> locationIndicatorActive)
+{
+    // GetSubTree on all interfaces which provide info about a Processor
+    crow::connections::systemBus->async_method_call(
+        [resp, processorId, locationIndicatorActive](
+            boost::system::error_code ec,
+            const dbus::utility::MapperGetSubTreeResponse& subtree) mutable {
+            if (ec)
+            {
+                BMCWEB_LOG_DEBUG << "DBUS response error: " << ec;
+                messages::internalError(resp->res);
+                return;
+            }
+            for (const auto& [objectPath, serviceMap] : subtree)
+            {
+                // Ignore any objects which don't end with our desired cpu name
+                sdbusplus::message::object_path path(objectPath);
+                std::string name = path.filename();
+                if (name.empty() || name != processorId)
+                {
+                    continue;
+                }
+
+                bool found = false;
+                // Filter out objects that don't have the CPU-specific
+                // interfaces to make sure we can return 404 on non-CPUs (e.g.
+                // /redfish/../Processors/dimm0)
+                for (const auto& [serviceName, interfaceList] : serviceMap)
+                {
+                    if (std::find_first_of(
+                            interfaceList.begin(), interfaceList.end(),
+                            processorInterfaces.begin(),
+                            processorInterfaces.end()) != interfaceList.end())
+                    {
+                        found = true;
+                        break;
+                    }
+                }
+
+                if (!found)
+                {
+                    continue;
+                }
+
+                // Process the first object which does match our cpu name and
+                // required interfaces, and potentially ignore any other
+                // matching objects. Assume all interfaces we want to process
+                // must be on the same object path.
+                setProcessorData(resp, serviceMap, objectPath,
+                                 locationIndicatorActive);
+                return;
+            }
+            messages::resourceNotFound(
+                resp->res, "#Processor.v1_11_0.Processor", processorId);
+        },
+        "xyz.openbmc_project.ObjectMapper",
+        "/xyz/openbmc_project/object_mapper",
+        "xyz.openbmc_project.ObjectMapper", "GetSubTree",
+        "/xyz/openbmc_project/inventory", 0,
+        std::array<const char*, 3>{
+            "xyz.openbmc_project.Inventory.Item.Cpu",
+            "xyz.openbmc_project.Inventory.Item.Accelerator",
+            "xyz.openbmc_project.Association.Definitions"});
+}
+
 inline void requestRoutesOperatingConfigCollection(App& app)
 {
 
@@ -1293,9 +1435,12 @@ inline void requestRoutesProcessor(App& app)
         }
 
         std::optional<nlohmann::json> appliedConfigJson;
-        if (!json_util::readJsonPatch(req, asyncResp->res,
-                                      "AppliedOperatingConfig",
-                                      appliedConfigJson))
+        std::optional<bool> locationIndicatorActive;
+        if (!json_util::readJsonPatch(
+                req, asyncResp->res, "AppliedOperatingConfig",
+                appliedConfigJson, "LocationIndicatorActive",
+                locationIndicatorActive))
+
         {
             return;
         }
@@ -1314,6 +1459,11 @@ inline void requestRoutesProcessor(App& app)
                                std::bind_front(patchAppliedOperatingConfig,
                                                asyncResp, processorId,
                                                appliedConfigUri));
+        }
+        if (locationIndicatorActive)
+        {
+            setProcessorObject(asyncResp, processorId,
+                               locationIndicatorActive);
         }
         });
 }

--- a/redfish-core/lib/processor.hpp
+++ b/redfish-core/lib/processor.hpp
@@ -31,6 +31,7 @@
 #include <sdbusplus/utility/dedup_variant.hpp>
 #include <utils/collection.hpp>
 #include <utils/dbus_utils.hpp>
+#include <utils/hw_isolation.hpp>
 #include <utils/json_utils.hpp>
 #include <utils/name_utils.hpp>
 
@@ -41,6 +42,10 @@ namespace redfish
 constexpr std::array<std::string_view, 2> processorInterfaces = {
     "xyz.openbmc_project.Inventory.Item.Cpu",
     "xyz.openbmc_project.Inventory.Item.Accelerator"};
+
+// Interfaces which imply a D-Bus object represents a Processor Core
+constexpr std::array<const char*, 1> procCoreInterfaces = {
+    "xyz.openbmc_project.Inventory.Item.CpuCore"};
 
 /**
  * @brief Workaround to handle DCM (Dual-Chip Module) package for Redfish
@@ -805,7 +810,7 @@ inline void getProcessorData(const std::shared_ptr<bmcweb::AsyncResp>& aResp,
                              const std::string& objectPath,
                              const dbus::utility::MapperServiceMap& serviceMap)
 {
-    aResp->res.jsonValue["@odata.type"] = "#Processor.v1_11_0.Processor";
+    aResp->res.jsonValue["@odata.type"] = "#Processor.v1_12_0.Processor";
     aResp->res.jsonValue["@odata.id"] =
         "/redfish/v1/Systems/system/Processors/" + processorId;
     aResp->res.jsonValue["SubProcessors"] = {
@@ -905,7 +910,7 @@ inline void getProcessorPaths(const std::shared_ptr<bmcweb::AsyncResp>& aResp,
                 if (ec.value() == boost::system::errc::io_error)
                 {
                     messages::resourceNotFound(aResp->res,
-                                               "#Processor.v1_11_0.Processor",
+                                               "#Processor.v1_12_0.Processor",
                                                processorId);
                     return;
                 }
@@ -928,7 +933,7 @@ inline void getProcessorPaths(const std::shared_ptr<bmcweb::AsyncResp>& aResp,
 
             // Object not found
             messages::resourceNotFound(
-                aResp->res, "#Processor.v1_11_0.Processor", processorId);
+                aResp->res, "#Processor.v1_12_0.Processor", processorId);
         },
         "xyz.openbmc_project.ObjectMapper",
         "/xyz/openbmc_project/object_mapper",
@@ -1015,6 +1020,23 @@ inline void
                             }
                         }
                     }
+                    else if (interface == "xyz.openbmc_project.Object.Enable")
+                    {
+                        for (const auto& [proName, proValue] : properties)
+                        {
+                            if (proName == "Enabled")
+                            {
+                                const bool* enabled =
+                                    std::get_if<bool>(&proValue);
+                                if (enabled == nullptr)
+                                {
+                                    messages::internalError(aResp->res);
+                                    return;
+                                }
+                                aResp->res.jsonValue["Enabled"] = *enabled;
+                            }
+                        }
+                    }
                 }
 
                 if (present == false)
@@ -1056,7 +1078,7 @@ inline void getSubProcessorData(const std::shared_ptr<bmcweb::AsyncResp>& aResp,
                     if (ec.value() == boost::system::errc::io_error)
                     {
                         messages::resourceNotFound(
-                            aResp->res, "#Processor.v1_11_0.Processor",
+                            aResp->res, "#Processor.v1_12_0.Processor",
                             processorId);
                         return;
                     }
@@ -1074,7 +1096,7 @@ inline void getSubProcessorData(const std::shared_ptr<bmcweb::AsyncResp>& aResp,
                     }
 
                     aResp->res.jsonValue["@odata.type"] =
-                        "#Processor.v1_11_0.Processor";
+                        "#Processor.v1_12_0.Processor";
                     aResp->res.jsonValue["@odata.id"] =
                         std::string("/redfish/v1/Systems/system/Processors/")
                             .append(processorId)
@@ -1096,7 +1118,7 @@ inline void getSubProcessorData(const std::shared_ptr<bmcweb::AsyncResp>& aResp,
                 {
                     // Object not found
                     messages::resourceNotFound(
-                        aResp->res, "#Processor.v1_11_0.Processor", coreId);
+                        aResp->res, "#Processor.v1_12_0.Processor", coreId);
                     return;
                 }
             },
@@ -1125,7 +1147,7 @@ inline void
                     if (ec.value() == boost::system::errc::io_error)
                     {
                         messages::resourceNotFound(
-                            aResp->res, "#Processor.v1_11_0.Processor",
+                            aResp->res, "#Processor.v1_12_0.Processor",
                             processorId);
                         return;
                     }
@@ -1520,7 +1542,7 @@ inline void setProcessorObject(const std::shared_ptr<bmcweb::AsyncResp>& resp,
                 return;
             }
             messages::resourceNotFound(
-                resp->res, "#Processor.v1_11_0.Processor", processorId);
+                resp->res, "#Processor.v1_12_0.Processor", processorId);
         },
         "xyz.openbmc_project.ObjectMapper",
         "/xyz/openbmc_project/object_mapper",
@@ -1874,6 +1896,66 @@ inline void requestRoutesSubProcessors(App& app)
             });
 }
 
+/**
+ * @brief API used to process the Processor Core "Enabled" member which is
+ *        patched to do appropriate action.
+ *
+ * @param[in] asyncResp - The redfish response to return.
+ * @param[in] coreId - The patched Processor Core resource id.
+ * @param[in] enabled - The patched "Enabled" member value.
+ *
+ * @return The redfish response in the given buffer.
+ *
+ * @note - The "Enabled" member of the Processor Core is used to enable
+ *         (aka isolate) or disable (aka deisolate) the resource from the
+ *         system boot so this function will call "processHardwareIsolationReq"
+ *         function which is used to handle the resource isolation request.
+ *       - The "Enabled" member of the Processor Core is mapped with
+ *         "xyz.openbmc_project.Object.Enable::Enabled" dbus property.
+ */
+inline void
+    patchCpuCoreMemberEnabled(const std::shared_ptr<bmcweb::AsyncResp>& resp,
+                              const std::string& coreId, const bool enabled)
+{
+    redfish::hw_isolation_utils::processHardwareIsolationReq(
+        resp, "Core", coreId, enabled,
+        std::vector<const char*>(procCoreInterfaces.begin(),
+                                 procCoreInterfaces.end()));
+}
+
+/**
+ * @brief API used to process the Processor Core members which are tried to
+ *        patch.
+ *
+ * @param[in] req - The redfish patched request to identify the patched members
+ * @param[in] asyncResp - The redfish response to return.
+ * @param[in] processorId - The patched Core Processor resource id (unused now)
+ * @param[in] coreId - The patched Processor Core resource id.
+ *
+ * @return The redfish response in the given buffer.
+ *
+ * @note This function will call the appropriate function to handle the patched
+ *       members of the Processor Core.
+ */
+inline void
+    patchCpuCoreMembers(const crow::Request& req,
+                        const std::shared_ptr<bmcweb::AsyncResp>& asyncResp,
+                        const std::string& /* processorId */,
+                        const std::string& coreId)
+{
+    std::optional<bool> enabled;
+
+    if (!json_util::readJsonPatch(req, asyncResp->res, "Enabled", enabled))
+    {
+        return;
+    }
+
+    if (enabled.has_value())
+    {
+        patchCpuCoreMemberEnabled(asyncResp, coreId, *enabled);
+    }
+}
+
 inline void requestRoutesSubProcessorsCore(App& app)
 {
     BMCWEB_ROUTE(
@@ -1885,6 +1967,11 @@ inline void requestRoutesSubProcessorsCore(App& app)
                const std::string& processorId, const std::string& coreId) {
                 getSubProcessorData(asyncResp, processorId, coreId);
             });
+
+    BMCWEB_ROUTE(
+        app, "/redfish/v1/Systems/system/Processors/<str>/SubProcessors/<str>")
+        .privileges(redfish::privileges::patchProcessor)
+        .methods(boost::beast::http::verb::patch)(patchCpuCoreMembers);
 }
 
 } // namespace redfish

--- a/redfish-core/lib/processor.hpp
+++ b/redfish-core/lib/processor.hpp
@@ -756,6 +756,13 @@ inline void getProcessorData(const std::shared_ptr<bmcweb::AsyncResp>& aResp,
                              const std::string& objectPath,
                              const dbus::utility::MapperServiceMap& serviceMap)
 {
+    aResp->res.jsonValue["@odata.type"] = "#Processor.v1_11_0.Processor";
+    aResp->res.jsonValue["@odata.id"] =
+        "/redfish/v1/Systems/system/Processors/" + processorId;
+    aResp->res.jsonValue["SubProcessors"] = {
+        {"@odata.id", "/redfish/v1/Systems/system/Processors/" + processorId +
+                          "/SubProcessors"}};
+
     for (const auto& [serviceName, interfaceList] : serviceMap)
     {
         bool assertInterface = false;
@@ -832,6 +839,281 @@ inline void getProcessorData(const std::shared_ptr<bmcweb::AsyncResp>& aResp,
             getLocationIndicatorActive(aResp, objectPath);
         }
     }
+}
+
+template <typename Handler>
+inline void getProcessorPaths(const std::shared_ptr<bmcweb::AsyncResp>& aResp,
+                              const std::string& processorId, Handler&& handler)
+{
+    crow::connections::systemBus->async_method_call(
+        [processorId, aResp, handler{std::move(handler)}](
+            const boost::system::error_code ec,
+            const std::vector<std::string>& subTreePaths) {
+            if (ec)
+            {
+                BMCWEB_LOG_ERROR << "DBUS response error";
+                // No processor objects found by mapper
+                if (ec.value() == boost::system::errc::io_error)
+                {
+                    messages::resourceNotFound(aResp->res,
+                                               "#Processor.v1_11_0.Processor",
+                                               processorId);
+                    return;
+                }
+
+                messages::internalError(aResp->res);
+                return;
+            }
+
+            for (const std::string& cpuPath : subTreePaths)
+            {
+                if (sdbusplus::message::object_path(cpuPath).filename() !=
+                    processorId)
+                {
+                    continue;
+                }
+
+                handler(cpuPath);
+                return;
+            }
+
+            // Object not found
+            messages::resourceNotFound(
+                aResp->res, "#Processor.v1_11_0.Processor", processorId);
+        },
+        "xyz.openbmc_project.ObjectMapper",
+        "/xyz/openbmc_project/object_mapper",
+        "xyz.openbmc_project.ObjectMapper", "GetSubTreePaths",
+        "/xyz/openbmc_project/inventory", 0,
+        std::array<const char*, 1>{"xyz.openbmc_project.Inventory.Item.Cpu"});
+}
+
+inline void
+    getCpuCoreDataByService(const std::shared_ptr<bmcweb::AsyncResp>& aResp,
+                            const std::string& service,
+                            const std::string& objPath)
+{
+    BMCWEB_LOG_DEBUG << "Get available system cpu core resources by service.";
+
+    aResp->res.jsonValue["Status"]["State"] = "Enabled";
+    aResp->res.jsonValue["Status"]["Health"] = "OK";
+
+    crow::connections::systemBus->async_method_call(
+        [objPath, aResp](const boost::system::error_code ec,
+                         const dbus::utility::ManagedObjectType& dbusData) {
+            if (ec)
+            {
+                BMCWEB_LOG_DEBUG << "DBUS response error, ec: " << ec.value();
+                messages::internalError(aResp->res);
+                return;
+            }
+
+            for (const auto& [path, interfaces] : dbusData)
+            {
+                if (path != objPath)
+                {
+                    continue;
+                }
+
+                bool present = true;
+                bool functional = true;
+
+                for (const auto& [interface, properties] : interfaces)
+                {
+                    if (interface == "xyz.openbmc_project.State."
+                                     "Decorator.OperationalStatus")
+                    {
+                        for (const auto& [proName, proValue] : properties)
+                        {
+                            if (proName == "Functional")
+                            {
+                                const bool* value =
+                                    std::get_if<bool>(&proValue);
+                                if (value == nullptr)
+                                {
+                                    messages::internalError(aResp->res);
+                                    return;
+                                }
+                                functional = *value;
+                            }
+                        }
+                    }
+                    else if (interface == "xyz.openbmc_project.Inventory.Item")
+                    {
+                        for (const auto& [proName, proValue] : properties)
+                        {
+                            if (proName == "Present")
+                            {
+                                const bool* value =
+                                    std::get_if<bool>(&proValue);
+                                if (value == nullptr)
+                                {
+                                    messages::internalError(aResp->res);
+                                    return;
+                                }
+                                present = *value;
+                            }
+                            else if (proName == "PrettyName")
+                            {
+                                const std::string* prettyName =
+                                    std::get_if<std::string>(&proValue);
+                                if (prettyName == nullptr)
+                                {
+                                    messages::internalError(aResp->res);
+                                    return;
+                                }
+                                aResp->res.jsonValue["Name"] = *prettyName;
+                            }
+                        }
+                    }
+                }
+
+                if (present == false)
+                {
+                    aResp->res.jsonValue["Status"]["State"] = "Absent";
+                }
+                else
+                {
+                    if (!functional)
+                    {
+                        aResp->res.jsonValue["Status"]["Health"] = "Critical";
+                    }
+                }
+            }
+        },
+        service, "/xyz/openbmc_project/inventory",
+        "org.freedesktop.DBus.ObjectManager", "GetManagedObjects");
+}
+
+inline void getSubProcessorData(const std::shared_ptr<bmcweb::AsyncResp>& aResp,
+                                const std::string& processorId,
+                                const std::string& coreId)
+{
+    BMCWEB_LOG_DEBUG << "Get available system sub processor resources.";
+
+    auto callback = [aResp, processorId, coreId](const std::string& cpuPath) {
+        crow::connections::systemBus->async_method_call(
+            [aResp, processorId, coreId](
+                const boost::system::error_code ec,
+                const boost::container::flat_map<
+                    std::string, boost::container::flat_map<
+                                     std::string, std::vector<std::string>>>&
+                    subtree) {
+                if (ec)
+                {
+                    BMCWEB_LOG_DEBUG << "DBUS response error, ec: "
+                                     << ec.value();
+                    // No processor objects found by mapper
+                    if (ec.value() == boost::system::errc::io_error)
+                    {
+                        messages::resourceNotFound(
+                            aResp->res, "#Processor.v1_11_0.Processor",
+                            processorId);
+                        return;
+                    }
+
+                    messages::internalError(aResp->res);
+                    return;
+                }
+
+                for (const auto& object : subtree)
+                {
+                    if (sdbusplus::message::object_path(object.first)
+                            .filename() != coreId)
+                    {
+                        continue;
+                    }
+
+                    aResp->res.jsonValue["@odata.type"] =
+                        "#Processor.v1_11_0.Processor";
+                    aResp->res.jsonValue["@odata.id"] =
+                        std::string("/redfish/v1/Systems/system/Processors/")
+                            .append(processorId)
+                            .append("/SubProcessors/")
+                            .append(coreId);
+                    aResp->res.jsonValue["Name"] = "SubProcessor";
+                    aResp->res.jsonValue["Id"] = coreId;
+
+                    for (const auto& service : object.second)
+                    {
+                        getCpuCoreDataByService(aResp, service.first,
+                                                object.first);
+                        break;
+                    }
+                    return;
+                }
+
+                if (subtree.size() != 0)
+                {
+                    // Object not found
+                    messages::resourceNotFound(
+                        aResp->res, "#Processor.v1_11_0.Processor", coreId);
+                    return;
+                }
+            },
+            "xyz.openbmc_project.ObjectMapper",
+            "/xyz/openbmc_project/object_mapper",
+            "xyz.openbmc_project.ObjectMapper", "GetSubTree", cpuPath, 0,
+            std::array<const char*, 1>{
+                "xyz.openbmc_project.Inventory.Item.CpuCore"});
+    };
+
+    getProcessorPaths(aResp, processorId, std::move(callback));
+}
+
+inline void
+    getSubProcessorMembers(const std::shared_ptr<bmcweb::AsyncResp>& aResp,
+                           const std::string& processorId)
+{
+    auto callback = [aResp, processorId](const std::string& cpuPath) {
+        crow::connections::systemBus->async_method_call(
+            [processorId, aResp](const boost::system::error_code ec,
+                                 const std::vector<std::string>& subTreePaths) {
+                if (ec)
+                {
+                    BMCWEB_LOG_ERROR << "DBUS response error";
+                    // No processor objects found by mapper
+                    if (ec.value() == boost::system::errc::io_error)
+                    {
+                        messages::resourceNotFound(
+                            aResp->res, "#Processor.v1_11_0.Processor",
+                            processorId);
+                        return;
+                    }
+
+                    messages::internalError(aResp->res);
+                    return;
+                }
+
+                aResp->res.jsonValue["@odata.type"] =
+                    "#ProcessorCollection.ProcessorCollection";
+                aResp->res.jsonValue["@odata.id"] =
+                    "/redfish/v1/Systems/system/Processors/" + processorId +
+                    "/SubProcessors";
+                aResp->res.jsonValue["Name"] = "SubProcessor Collection";
+                nlohmann::json& members = aResp->res.jsonValue["Members"];
+                members = nlohmann::json::array();
+                std::string subProcessorsPath =
+                    "/redfish/v1/Systems/system/Processors/" + processorId +
+                    "/SubProcessors/";
+                for (const std::string& corePath : subTreePaths)
+                {
+                    members.push_back(
+                        {{"@odata.id",
+                          subProcessorsPath +
+                              sdbusplus::message::object_path(corePath)
+                                  .filename()}});
+                }
+                aResp->res.jsonValue["Members@odata.count"] = members.size();
+            },
+            "xyz.openbmc_project.ObjectMapper",
+            "/xyz/openbmc_project/object_mapper",
+            "xyz.openbmc_project.ObjectMapper", "GetSubTreePaths", cpuPath, 0,
+            std::array<const char*, 1>{
+                "xyz.openbmc_project.Inventory.Item.CpuCore"});
+    };
+
+    getProcessorPaths(aResp, processorId, std::move(callback));
 }
 
 /**
@@ -1406,10 +1688,7 @@ inline void requestRoutesProcessor(App& app)
         asyncResp->res.addHeader(
             boost::beast::http::field::link,
             "</redfish/v1/JsonSchemas/Processor/Processor.json>; rel=describedby");
-        asyncResp->res.jsonValue["@odata.type"] =
-            "#Processor.v1_11_0.Processor";
-        asyncResp->res.jsonValue["@odata.id"] =
-            "/redfish/v1/Systems/system/Processors/" + processorId;
+
 
         getProcessorObject(
             asyncResp, processorId,
@@ -1466,6 +1745,32 @@ inline void requestRoutesProcessor(App& app)
                                locationIndicatorActive);
         }
         });
+}
+
+inline void requestRoutesSubProcessors(App& app)
+{
+    BMCWEB_ROUTE(app,
+                 "/redfish/v1/Systems/system/Processors/<str>/SubProcessors")
+        .privileges(redfish::privileges::getProcessorCollection)
+        .methods(boost::beast::http::verb::get)(
+            [](const crow::Request&,
+               const std::shared_ptr<bmcweb::AsyncResp>& asyncResp,
+               const std::string& processorId) {
+                getSubProcessorMembers(asyncResp, processorId);
+            });
+}
+
+inline void requestRoutesSubProcessorsCore(App& app)
+{
+    BMCWEB_ROUTE(
+        app, "/redfish/v1/Systems/system/Processors/<str>/SubProcessors/<str>")
+        .privileges(redfish::privileges::getProcessor)
+        .methods(boost::beast::http::verb::get)(
+            [](const crow::Request&,
+               const std::shared_ptr<bmcweb::AsyncResp>& asyncResp,
+               const std::string& processorId, const std::string& coreId) {
+                getSubProcessorData(asyncResp, processorId, coreId);
+            });
 }
 
 } // namespace redfish

--- a/redfish-core/lib/storage.hpp
+++ b/redfish-core/lib/storage.hpp
@@ -24,6 +24,7 @@
 #include <sdbusplus/asio/property.hpp>
 #include <sdbusplus/unpack_properties.hpp>
 #include <utils/dbus_utils.hpp>
+#include <utils/name_utils.hpp>
 
 namespace redfish
 {
@@ -146,7 +147,12 @@ inline void
             storageController["@odata.id"] =
                 "/redfish/v1/Systems/system/Storage/1#/StorageControllers/" +
                 std::to_string(index);
-            storageController["Name"] = id;
+            auto namePointer = "/StorageControllers"_json_pointer;
+            namePointer /= index;
+            namePointer /= "Name";
+            name_util::getPrettyName(asyncResp, path, interfaceDict,
+                                     namePointer);
+
             storageController["MemberId"] = id;
             storageController["Status"]["State"] = "Enabled";
 
@@ -577,7 +583,8 @@ inline void requestRoutesDrive(App& app)
             asyncResp->res.jsonValue["@odata.type"] = "#Drive.v1_7_0.Drive";
             asyncResp->res.jsonValue["@odata.id"] =
                 "/redfish/v1/Systems/system/Storage/1/Drives/" + driveId;
-            asyncResp->res.jsonValue["Name"] = driveId;
+            name_util::getPrettyName(asyncResp, path, drive->second,
+                                     "/Name"_json_pointer);
             asyncResp->res.jsonValue["Id"] = driveId;
 
             if (connectionNames.size() != 1)

--- a/redfish-core/lib/update_service.hpp
+++ b/redfish-core/lib/update_service.hpp
@@ -1065,6 +1065,7 @@ inline void requestRoutesSoftwareInventory(App& app)
                 sw_util::getSwStatus(asyncResp, swId, obj.second[0].first);
                 getSoftwareVersion(asyncResp, obj.second[0].first, obj.first,
                                    *swId);
+                asyncResp->res.jsonValue["Name"] = "Software Inventory";
             }
             if (!found)
             {
@@ -1077,7 +1078,6 @@ inline void requestRoutesSoftwareInventory(App& app)
             }
             asyncResp->res.jsonValue["@odata.type"] =
                 "#SoftwareInventory.v1_1_0.SoftwareInventory";
-            asyncResp->res.jsonValue["Name"] = "Software Inventory";
             asyncResp->res.jsonValue["Status"]["HealthRollup"] = "OK";
 
             asyncResp->res.jsonValue["Updateable"] = false;

--- a/redfish-core/src/error_messages.cpp
+++ b/redfish-core/src/error_messages.cpp
@@ -839,6 +839,40 @@ void propertyValueIncorrect(crow::Response& res, std::string_view arg1,
 
 /**
  * @internal
+ * @brief Formats PropertyValueResourceConflict message into JSON
+ *
+ * See header file for more information
+ * @endinternal
+ */
+nlohmann::json propertyValueResourceConflict(const std::string& arg1,
+                                             const std::string& arg2,
+                                             const std::string& arg3)
+{
+    return nlohmann::json{
+        {"@odata.type", "#Message.v1_1_1.Message"},
+        {"MessageId", "Base.1.10.0.PropertyValueResourceConflict"},
+        {"Message", "The property '" + arg1 +
+                        "' with the requested value of '" + arg2 +
+                        "' could not be written because the value "
+                        "conflicts with the state or configuration of "
+                        "the resource at '" +
+                        arg3 + "'."},
+        {"MessageArgs", {arg1, arg2, arg3}},
+        {"MessageSeverity", "Warning"},
+        {"Resolution", "No resolution is required."}};
+}
+
+void propertyValueResourceConflict(crow::Response& res, const std::string& arg1,
+                                   const std::string& arg2,
+                                   const std::string& arg3)
+{
+    res.result(boost::beast::http::status::bad_request);
+    addMessageToErrorJson(res.jsonValue,
+                          propertyValueResourceConflict(arg1, arg2, arg3));
+}
+
+/**
+ * @internal
  * @brief Formats ResourceCreationConflict message into JSON
  *
  * See header file for more information

--- a/redfish-core/src/error_messages.cpp
+++ b/redfish-core/src/error_messages.cpp
@@ -866,9 +866,39 @@ void propertyValueResourceConflict(crow::Response& res, const std::string& arg1,
                                    const std::string& arg2,
                                    const std::string& arg3)
 {
-    res.result(boost::beast::http::status::bad_request);
+    res.result(boost::beast::http::status::conflict);
     addMessageToErrorJson(res.jsonValue,
                           propertyValueResourceConflict(arg1, arg2, arg3));
+}
+
+/**
+ * @internal
+ * @brief Formats PropertyValueExternalConflict message into JSON
+ *
+ * See header file for more information
+ * @endinternal
+ */
+nlohmann::json propertyValueExternalConflict(const std::string& arg1,
+                                             const std::string& arg2)
+{
+    return nlohmann::json{
+        {"@odata.type", "#Message.v1_1_1.Message"},
+        {"MessageId", "Base.1.10.0.PropertyValueExternalConflict"},
+        {"Message", "The property '" + arg1 +
+                        "' with the requested value of '" + arg2 +
+                        "' could not be written because the value "
+                        "is not available due to a configuration conflict."},
+        {"MessageArgs", {arg1, arg2}},
+        {"MessageSeverity", "Warning"},
+        {"Resolution", "No resolution is required."}};
+}
+
+void propertyValueExternalConflict(crow::Response& res, const std::string& arg1,
+                                   const std::string& arg2)
+{
+    res.result(boost::beast::http::status::conflict);
+    addMessageToErrorJson(res.jsonValue,
+                          propertyValueExternalConflict(arg1, arg2));
 }
 
 /**


### PR DESCRIPTION
Sync HardwareIsolation commits from 1030 to 1050. 
Here is the upstream commits for the relevant ones. 
Implement LocationIndicatorActive for CPU resource | https://gerrit.openbmc.org/c/openbmc/bmcweb/+/37045
Implement SubProcessors for processor core | https://gerrit.openbmc.org/c/openbmc/bmcweb/+/38570
Implement LocationIndicatorActive for CPU resource | https://gerrit.openbmc.org/c/openbmc/bmcweb/+/37045

For the HWIsolation, the commits do not have respective upstream commits, as we do not have a standard guard implementation in the upstream

Test output:
After adding the patches, the Hardware Isolation records are 
-bash-4.2$ curl -k -H "X-Auth-Token: $bmc_token" -XGET https://${BMC_IP}/redfish/v1/Systems/system/LogServices/HardwareIsolation/Entries
{
  "@odata.id": "/redfish/v1/Systems/system/LogServices/HardwareIsolation/Entries",
  "@odata.type": "#LogEntryCollection.LogEntryCollection",
  "Description": "Collection of System Hardware Isolation Entries",
  "Members": [
    {
      "@odata.id": "/redfish/v1/Systems/system/LogServices/HardwareIsolation/Entries/1",
      "@odata.type": "#LogEntry.v1_9_0.LogEntry",
      "Created": "2023-02-12T15:11:24+00:00",
      "EntryType": "Event",
      "Id": "1",
      "Links": {
        "OriginOfCondition": {
          "@odata.id": "/redfish/v1/Systems/system/Memory/dimm2"
        }
      },
      "Message": "DDR Memory Port",
      "Name": "Hardware Isolation Entry",
      "Severity": "Warning"
    },
