### PR TITLE
Redfish : Implement LocationIndicatorActive for PCIeSlots

### DIFF
--- a/Redfish.md
+++ b/Redfish.md
@@ -155,6 +155,7 @@ Fields common to all schemas
 - Links/ComputerSystems
 - Links/ManagedBy
 - PCIeDevices
+- PCIeSlots
 - Power
   - Shall be included if component contains voltage/current sensing components,
     otherwise will be omitted.
@@ -196,6 +197,16 @@ Fields common to all schemas
 - PowerSupplies
 - Redundancy
 - Voltages
+
+### /redfish/v1/Chassis/{ChassisId}/PCIeSlots/
+
+#### Slots
+
+- HotPluggable
+- Lanes
+- LocationIndicatorActive
+- PCIeType
+- SlotType
 
 ### /redfish/v1/Chassis/{ChassisId}/Sensors/
 

--- a/redfish-core/include/redfish.hpp
+++ b/redfish-core/include/redfish.hpp
@@ -36,6 +36,7 @@
 #include "metric_report_definition.hpp"
 #include "network_protocol.hpp"
 #include "pcie.hpp"
+#include "pcie_slots.hpp"
 #include "power.hpp"
 #include "power_subsystem.hpp"
 #include "power_supply.hpp"
@@ -224,6 +225,7 @@ class RedfishService
         requestRoutesLDAPCertificate(app);
         requestRoutesTrustStoreCertificate(app);
 
+        requestRoutesPCIeSlots(app);
         requestRoutesSystemPCIeFunctionCollection(app);
         requestRoutesSystemPCIeFunction(app);
         requestRoutesSystemPCIeDeviceCollection(app);

--- a/redfish-core/lib/chassis.hpp
+++ b/redfish-core/lib/chassis.hpp
@@ -278,6 +278,8 @@ inline void
                 "/redfish/v1/Chassis/" + chassisId + "/ResetActionInfo";
             asyncResp->res.jsonValue["PCIeDevices"]["@odata.id"] =
                 "/redfish/v1/Systems/system/PCIeDevices";
+            asyncResp->res.jsonValue["PCIeSlots"]["@odata.id"] =
+                "/redfish/v1/Chassis/" + chassisId + "/PCIeSlots";
 
             sdbusplus::asio::getProperty<std::vector<std::string>>(
                 *crow::connections::systemBus,

--- a/redfish-core/lib/pcie_slots.hpp
+++ b/redfish-core/lib/pcie_slots.hpp
@@ -1,7 +1,8 @@
 #pragma once
 
 #include "error_messages.hpp"
-#include "generated/enums/pcie_slot.hpp"
+#include "generated/enums/pcie_slots.hpp"
+#include "led.hpp"
 #include "utility.hpp"
 
 #include <app.hpp>
@@ -15,59 +16,172 @@
 namespace redfish
 {
 
-inline pcie_slot::SlotTypes dbusSlotTypeToRf(const std::string& slotType)
+inline std::optional<pcie_slots::SlotTypes>
+    dbusSlotTypeToRf(const std::string& slotType)
 {
     if (slotType ==
         "xyz.openbmc_project.Inventory.Item.PCIeSlot.SlotTypes.FullLength")
     {
-        return pcie_slot::SlotTypes::FullLength;
+        return pcie_slots::SlotTypes::FullLength;
     }
     if (slotType ==
         "xyz.openbmc_project.Inventory.Item.PCIeSlot.SlotTypes.HalfLength")
     {
-        return pcie_slot::SlotTypes::HalfLength;
+        return pcie_slots::SlotTypes::HalfLength;
     }
     if (slotType ==
         "xyz.openbmc_project.Inventory.Item.PCIeSlot.SlotTypes.LowProfile")
     {
-        return pcie_slot::SlotTypes::LowProfile;
+        return pcie_slots::SlotTypes::LowProfile;
     }
     if (slotType ==
         "xyz.openbmc_project.Inventory.Item.PCIeSlot.SlotTypes.Mini")
     {
-        return pcie_slot::SlotTypes::Mini;
+        return pcie_slots::SlotTypes::Mini;
     }
     if (slotType == "xyz.openbmc_project.Inventory.Item.PCIeSlot.SlotTypes.M_2")
     {
-        return pcie_slot::SlotTypes::M2;
+        return pcie_slots::SlotTypes::M2;
     }
     if (slotType == "xyz.openbmc_project.Inventory.Item.PCIeSlot.SlotTypes.OEM")
     {
-        return pcie_slot::SlotTypes::OEM;
+        return pcie_slots::SlotTypes::OEM;
     }
     if (slotType ==
         "xyz.openbmc_project.Inventory.Item.PCIeSlot.SlotTypes.OCP3Small")
     {
-        return pcie_slot::SlotTypes::OCP3Small;
+        return pcie_slots::SlotTypes::OCP3Small;
     }
     if (slotType ==
         "xyz.openbmc_project.Inventory.Item.PCIeSlot.SlotTypes.OCP3Large")
     {
-        return pcie_slot::SlotTypes::OCP3Large;
+        return pcie_slots::SlotTypes::OCP3Large;
     }
     if (slotType == "xyz.openbmc_project.Inventory.Item.PCIeSlot.SlotTypes.U_2")
     {
-        return pcie_slot::SlotTypes::U2;
+        return pcie_slots::SlotTypes::U2;
+    }
+    if (slotType.empty() ||
+        slotType ==
+            "xyz.openbmc_project.Inventory.Item.PCIeSlot.SlotTypes.Unknown")
+    {
+        return pcie_slots::SlotTypes::Invalid;
     }
 
-    // Unknown or others
-    return pcie_slot::SlotTypes::Invalid;
+    // Unspecified slotType needs return an internal error.
+    return std::nullopt;
+}
+
+// We need a global variable to keep track of the actual number of slots,
+// and then use this variable to check if the number of slots in the request
+// is correct
+std::map<unsigned int, std::string> updatePcieSlotsMaps{};
+
+// Check whether the total number of slots in the request is consistent with the
+// actual total number of slots
+void checkPCIeSlotsCount(
+    const std::shared_ptr<bmcweb::AsyncResp>& asyncResp,
+    const unsigned int total, const std::string& validChassisPath,
+    std::function<void(const std::map<unsigned int, std::string>&)>&& callback)
+{
+    BMCWEB_LOG_DEBUG << "Check PCIeSlots count for PCIeSlots request "
+                        "associated to chassis";
+    crow::connections::systemBus->async_method_call(
+        [asyncResp, total, validChassisPath, callback{std::move(callback)}](
+            const boost::system::error_code ec,
+            const dbus::utility::MapperGetSubTreePathsResponse&
+                pcieSlotsPaths) {
+        if (ec)
+        {
+            BMCWEB_LOG_ERROR << "D-Bus response error on GetSubTree " << ec;
+            messages::internalError(asyncResp->res);
+            return;
+        }
+
+        unsigned int index = 0;
+        unsigned int count = 0;
+        auto slotNum = pcieSlotsPaths.size();
+        for (const auto& path : pcieSlotsPaths)
+        {
+            index++;
+            dbus::utility::getAssociationEndPoints(
+                path + "/chassis",
+                [asyncResp, total, validChassisPath, count{++count}, slotNum,
+                 index, path,
+                 callback](const boost::system::error_code& ec1,
+                           const dbus::utility::MapperEndPoints& endpoints) {
+                if (ec1)
+                {
+                    if (ec1.value() == EBADR)
+                    {
+                        if (count == slotNum)
+                        {
+                            // the total number of slots in the request
+                            // is correct
+                            if (updatePcieSlotsMaps.size() == total)
+                            {
+                                callback(updatePcieSlotsMaps);
+                            }
+                            else
+                            {
+                                messages::resourceNotFound(
+                                    asyncResp->res, "Chassis", "slots count");
+                                return;
+                            }
+                        }
+
+                        // This PCIeSlot have no chassis association.
+                        return;
+                    }
+                    BMCWEB_LOG_ERROR << "DBUS response error";
+                    messages::internalError(asyncResp->res);
+
+                    return;
+                }
+
+                for (const auto& endpoint : endpoints)
+                {
+                    if (endpoint == validChassisPath)
+                    {
+                        updatePcieSlotsMaps[index] = path;
+                    }
+                }
+
+                if (updatePcieSlotsMaps.size() > total)
+                {
+                    BMCWEB_LOG_ERROR
+                        << "The actual number of cpieslots is greater than total";
+                    messages::internalError(asyncResp->res);
+                }
+
+                if (count == slotNum)
+                {
+                    // Last time DBus has returned
+                    if (updatePcieSlotsMaps.size() == total)
+                    {
+                        callback(updatePcieSlotsMaps);
+                    }
+                    else
+                    {
+                        messages::internalError(asyncResp->res);
+                    }
+                }
+                });
+        }
+        },
+        "xyz.openbmc_project.ObjectMapper",
+        "/xyz/openbmc_project/object_mapper",
+        "xyz.openbmc_project.ObjectMapper", "GetSubTreePaths",
+        "/xyz/openbmc_project/inventory", int32_t(0),
+        std::array<const char*, 1>{
+            "xyz.openbmc_project.Inventory.Item.PCIeSlot"});
 }
 
 inline void
     onPcieSlotGetAllDone(const std::shared_ptr<bmcweb::AsyncResp>& asyncResp,
                          const boost::system::error_code ec,
-                         const dbus::utility::DBusPropertiesMap& propertiesList)
+                         const dbus::utility::DBusPropertiesMap& propertiesList,
+                         const std::string& pcieSlotPath)
 {
     if (ec)
     {
@@ -114,7 +228,10 @@ inline void
             messages::internalError(asyncResp->res);
             return;
         }
-        slot["PCIeType"] = !pcieType;
+        if (*pcieType != pcie_device::PCIeTypes::Invalid)
+        {
+            slot["PCIeType"] = *pcieType;
+        }
     }
 
     if (lanes != nullptr)
@@ -125,13 +242,17 @@ inline void
 
     if (slotType != nullptr)
     {
-        std::string redfishSlotType = dbusSlotTypeToRf(*slotType);
-        if (!slotType.empty())
+        std::optional<pcie_slots::SlotTypes> redfishSlotType =
+            dbusSlotTypeToRf(*slotType);
+        if (!redfishSlotType)
         {
             messages::internalError(asyncResp->res);
             return;
         }
-        slot["SlotType"] = redfishSlotType;
+        if (*redfishSlotType != pcie_slots::SlotTypes::Invalid)
+        {
+            slot["SlotType"] = *redfishSlotType;
+        }
     }
 
     if (hotPluggable != nullptr)
@@ -140,12 +261,16 @@ inline void
     }
 
     slots.emplace_back(std::move(slot));
+
+    // Get pcie slot location indicator state
+    nlohmann::json& slotLIA = slots.back();
+    getLocationIndicatorActive(asyncResp, pcieSlotPath, slotLIA);
 }
 
 inline void onMapperAssociationDone(
     const std::shared_ptr<bmcweb::AsyncResp>& asyncResp,
     const std::string& chassisID, const std::string& pcieSlotPath,
-    const std::string& connectionName, const boost::system::error_code ec,
+    const std::string& connectionName, const boost::system::error_code& ec,
     const std::variant<std::vector<std::string>>& endpoints)
 {
     if (ec)
@@ -188,16 +313,17 @@ inline void onMapperAssociationDone(
     sdbusplus::asio::getAllProperties(
         *crow::connections::systemBus, connectionName, pcieSlotPath,
         "xyz.openbmc_project.Inventory.Item.PCIeSlot",
-        [asyncResp](const boost::system::error_code ec,
-                    const dbus::utility::DBusPropertiesMap& propertiesList) {
-        onPcieSlotGetAllDone(asyncResp, ec, propertiesList);
+        [asyncResp,
+         pcieSlotPath](const boost::system::error_code& ec1,
+                       const dbus::utility::DBusPropertiesMap& propertiesList) {
+        onPcieSlotGetAllDone(asyncResp, ec1, propertiesList, pcieSlotPath);
         });
 }
 
 inline void
     onMapperSubtreeDone(const std::shared_ptr<bmcweb::AsyncResp>& asyncResp,
                         const std::string& chassisID,
-                        const boost::system::error_code ec,
+                        const boost::system::error_code& ec,
                         const dbus::utility::MapperGetSubTreeResponse& subtree)
 {
     if (ec)
@@ -236,10 +362,10 @@ inline void
             // it belongs to this ChassisID
             crow::connections::systemBus->async_method_call(
                 [asyncResp, chassisID, pcieSlotPath, connectionName](
-                    const boost::system::error_code ec,
+                    const boost::system::error_code& ec1,
                     const std::variant<std::vector<std::string>>& endpoints) {
                 onMapperAssociationDone(asyncResp, chassisID, pcieSlotPath,
-                                        connectionName, ec, endpoints);
+                                        connectionName, ec1, endpoints);
                 },
                 "xyz.openbmc_project.ObjectMapper",
                 std::string{pcieSlotAssociationPath},
@@ -273,12 +399,91 @@ inline void handlePCIeSlotCollectionGet(
             "xyz.openbmc_project.Inventory.Item.PCIeSlot"});
 }
 
+inline void
+    handlePCIeSlotsPatch(App& app, const crow::Request& req,
+                         const std::shared_ptr<bmcweb::AsyncResp>& asyncResp,
+                         const std::string& chassisId)
+{
+    if (!redfish::setUpRedfishRoute(app, req, asyncResp))
+    {
+        return;
+    }
+
+    std::optional<std::vector<nlohmann::json>> slotsData;
+    if (!json_util::readJsonPatch(req, asyncResp->res, "Slots", slotsData))
+    {
+        return;
+    }
+    if (!slotsData || slotsData->empty())
+    {
+        return;
+    }
+    std::vector<nlohmann::json> slots = std::move(*slotsData);
+    std::map<unsigned int, bool> locationIndicatorActiveMap;
+    unsigned int slotIndex = 0;
+    for (auto& slot : slots)
+    {
+        slotIndex++;
+
+        if (slot.empty())
+        {
+            continue;
+        }
+
+        bool locationIndicatorActive = false;
+        if (json_util::readJson(slot, asyncResp->res, "LocationIndicatorActive",
+                                locationIndicatorActive))
+        {
+            locationIndicatorActiveMap[slotIndex] = locationIndicatorActive;
+        }
+    }
+
+    // Clear updatePcieSlotsMaps
+    updatePcieSlotsMaps.clear();
+
+    unsigned int total = static_cast<unsigned int>(slots.size());
+    auto respHandler =
+        [asyncResp, chassisId, total,
+         locationIndicatorActiveMap{std::move(locationIndicatorActiveMap)}](
+            const std::optional<std::string>& validChassisPath) {
+        if (!validChassisPath)
+        {
+            BMCWEB_LOG_ERROR << "Not a valid chassis ID:" << chassisId;
+            messages::resourceNotFound(asyncResp->res, "Chassis", chassisId);
+            return;
+        }
+
+        // Get the correct Path and Service that match the input
+        // parameters
+        checkPCIeSlotsCount(
+            asyncResp, total, *validChassisPath,
+            [asyncResp, locationIndicatorActiveMap](
+                const std::map<unsigned int, std::string>& maps) {
+            for (const auto& [i, v] : locationIndicatorActiveMap)
+            {
+                if (maps.contains(i))
+                {
+                    setLocationIndicatorActive(asyncResp, maps.at(i), v);
+                }
+            }
+            });
+    };
+
+    redfish::chassis_utils::getValidChassisPath(asyncResp, chassisId,
+                                                std::bind_front(respHandler));
+}
+
 inline void requestRoutesPCIeSlots(App& app)
 {
     BMCWEB_ROUTE(app, "/redfish/v1/Chassis/<str>/PCIeSlots/")
         .privileges(redfish::privileges::getPCIeSlots)
         .methods(boost::beast::http::verb::get)(
             std::bind_front(handlePCIeSlotCollectionGet, std::ref(app)));
+
+    BMCWEB_ROUTE(app, "/redfish/v1/Chassis/<str>/PCIeSlots/")
+        .privileges(redfish::privileges::patchPCIeSlots)
+        .methods(boost::beast::http::verb::patch)(
+            std::bind_front(handlePCIeSlotsPatch, std::ref(app)));
 }
 
 } // namespace redfish


### PR DESCRIPTION
Implement LocationIndicatorActive for PCIeSlot schema, We can use locationindicatoractive to set or get the status of the location led of each pcie slot.

https://redfish.dmtf.org/schemas/v1/PCIeSlots.v1_4_1.json

We need to set the LocationIndicatorActive of all the slots in the dopatch command, even if we only want to modify one of them.(ex: see the third test result)

Tested: Validator passes.
1、Get LocationIndicatorActive
curl -k -H "X-Auth-Token: $token" -X GET https://${bmc}/redfish/v1/Chassis/chassis/PCIeSlots {
  "@odata.id": "/redfish/v1/Chassis/chassis/PCIeSlots",
  "@odata.type": "#PCIeSlots.v1_4_1.PCIeSlots",
  "Id": "PCIeSlots",
  "Name": "PCIe Slot Information",
  "Slots": [
    {
      "HotPluggable": false,
      "Lanes": 16,
      "LocationIndicatorActive": false,
      "PCIeType": "Gen1",
      "SlotType": "FullLength"
    },
    {
      "HotPluggable": false,
      "Lanes": 16,
      "LocationIndicatorActive": false,
      "PCIeType": "Gen1",
      "SlotType": "FullLength"
    }
  ]
}

We will see the slots identify leds is false too.
busctl get-property xyz.openbmc_project.LED.GroupManager /xyz/openbmc_project/led/groups/test1slot_identify xyz.openbmc_project.Led.Group Asserted b false

busctl get-property xyz.openbmc_project.LED.GroupManager /xyz/openbmc_project/led/groups/test2slot_identify xyz.openbmc_project.Led.Group Asserted b false

2、Set LocationIndicatorActive to true
curl -k -H "X-Auth-Token: $token" -X PATCH -d '{"Slots":[{"LocationIndicatorActive":true},{"LocationIndicatorActive":true}]}' https://${bmc}/redfish/v1/Chassis/chassis/PCIeSlots

Then we will see the slot location LED lit up, and the LocationIndicatorActive value becomes true: curl -k -H "X-Auth-Token: $token" -X GET https://${bmc}/redfish/v1/Chassis/chassis/PCIeSlots {
  "@odata.id": "/redfish/v1/Chassis/chassis/PCIeSlots",
  "@odata.type": "#PCIeSlots.v1_4_1.PCIeSlots",
  "Id": "PCIeSlots",
  "Name": "PCIe Slot Information",
  "Slots": [
    {
      "HotPluggable": false,
      "Lanes": 16,
      "LocationIndicatorActive": true,
      "PCIeType": "Gen1",
      "SlotType": "FullLength"
    },
    {
      "HotPluggable": false,
      "Lanes": 16,
      "LocationIndicatorActive": true,
      "PCIeType": "Gen1",
      "SlotType": "FullLength"
    }
  ]
}

We will see the slots identify leds is true too.
busctl get-property xyz.openbmc_project.LED.GroupManager /xyz/openbmc_project/led/groups/test1slot_identify xyz.openbmc_project.Led.Group Asserted b true

busctl get-property xyz.openbmc_project.LED.GroupManager /xyz/openbmc_project/led/groups/test2slot_identify xyz.openbmc_project.Led.Group Asserted b true

3、We need to set the LocationIndicatorActive of all the slots in the dopatch command, even if you only want to modify one of them for example:
Now LocationIndicatorActive of both slots is false: curl -k -H "X-Auth-Token: $token" -X GET https://${bmc}/redfish/v1/Chassis/chassis/PCIeSlots {
  "@odata.id": "/redfish/v1/Chassis/chassis/PCIeSlots",
  "@odata.type": "#PCIeSlots.v1_4_1.PCIeSlots",
  "Id": "PCIeSlots",
  "Name": "PCIe Slot Information",
  "Slots": [
    {
      "HotPluggable": false,
      "Lanes": 16,
      "LocationIndicatorActive": false,
      "PCIeType": "Gen1",
      "SlotType": "FullLength"
    },
    {
      "HotPluggable": false,
      "Lanes": 16,
      "LocationIndicatorActive": false,
      "PCIeType": "Gen1",
      "SlotType": "FullLength"
    }
  ]
}

We want to set LocationIndicatorActive of the second slot to true. We need to send this command: curl -k -H "X-Auth-Token: $token" -X PATCH -d '{"Slots":[{"LocationIndicatorActive":false},{"LocationIndicatorActive":true}]}' https://${bmc}/redfish/v1/Chassis/chassis/PCIeSlots This command contains the value of the first slot.

curl -k -H "X-Auth-Token: $token" -X GET https://${bmc}/redfish/v1/Chassis/chassis/PCIeSlots {
  "@odata.id": "/redfish/v1/Chassis/chassis/PCIeSlots",
  "@odata.type": "#PCIeSlots.v1_4_1.PCIeSlots",
  "Id": "PCIeSlots",
  "Name": "PCIe Slot Information",
  "Slots": [
    {
      "HotPluggable": false,
      "Lanes": 16,
      "LocationIndicatorActive": false,
      "PCIeType": "Gen1",
      "SlotType": "FullLength"
    },
    {
      "HotPluggable": false,
      "Lanes": 16,
      "LocationIndicatorActive": true,
      "PCIeType": "Gen1",
      "SlotType": "FullLength"
    }
  ]
}

busctl get-property xyz.openbmc_project.LED.GroupManager /xyz/openbmc_project/led/groups/test1slot_identify xyz.openbmc_project.Led.Group Asserted b false

busctl get-property xyz.openbmc_project.LED.GroupManager /xyz/openbmc_project/led/groups/test2slot_identify xyz.openbmc_project.Led.Group Asserted b true

4、 Use set-property to change the value
busctl set-property xyz.openbmc_project.LED.GroupManager /xyz/openbmc_project/led/groups/test1slot_identify xyz.openbmc_project.Led.Group Asserted b true

busctl get-property xyz.openbmc_project.LED.GroupManager /xyz/openbmc_project/led/groups/test1slot_identify xyz.openbmc_project.Led.Group Asserted b true

busctl get-property xyz.openbmc_project.LED.GroupManager /xyz/openbmc_project/led/groups/test2slot_identify xyz.openbmc_project.Led.Group Asserted b false

curl -k -H "X-Auth-Token: $token" -X GET https://${bmc}/redfish/v1/Chassis/chassis/PCIeSlots {
  "@odata.id": "/redfish/v1/Chassis/chassis/PCIeSlots",
  "@odata.type": "#PCIeSlots.v1_4_1.PCIeSlots",
  "Id": "PCIeSlots",
  "Name": "PCIe Slot Information",
  "Slots": [
    {
      "HotPluggable": false,
      "Lanes": 16,
      "LocationIndicatorActive": true,
      "PCIeType": "Gen1",
      "SlotType": "FullLength"
    },
    {
      "HotPluggable": false,
      "Lanes": 16,
      "LocationIndicatorActive": false,
      "PCIeType": "Gen1",
      "SlotType": "FullLength"
    }
  ]
}

Signed-off-by: Chicago Duan <duanzhijia01@inspur.com>
Change-Id: I64c0ed90b37a17d3b7d834a0844228406e82575f