### PR TITLE
1050: OEM Battery Concurrent Maintenance for Everest System

### DIFF
--- a/redfish-core/lib/assembly.hpp
+++ b/redfish-core/lib/assembly.hpp
@@ -49,6 +49,49 @@ inline void
         // Set the default Status
         tempyArray.at(assemblyIndex)["Status"]["Health"] = "OK";
 
+        // Handle special case for tod_battery assembly OEM ReadyToRemove
+        // property NOTE: The following method for the special case of the
+        // tod_battery ReadyToRemove property only works when there is only ONE
+        // adcsensor handled by the adcsensor application.
+        if (sdbusplus::message::object_path(assembly).filename() ==
+            "tod_battery")
+        {
+            tempyArray.at(assemblyIndex)["Oem"]["OpenBMC"]["@odata.type"] =
+                "#OemAssembly.v1_0_0.Assembly";
+
+            crow::connections::systemBus->async_method_call(
+                [aResp, assemblyIndex](const boost::system::error_code ec) {
+                if (ec)
+                {
+                    if (ec.value() == 5)
+                    {
+                        // Battery voltage is not on DBUS so ADCSensor is not
+                        // running.
+                        nlohmann::json& assemblyArray =
+                            aResp->res.jsonValue["Assemblies"];
+                        assemblyArray.at(
+                            assemblyIndex)["Oem"]["OpenBMC"]["ReadyToRemove"] =
+                            true;
+                        return;
+                    }
+                    BMCWEB_LOG_DEBUG << "DBUS response error" << ec.value();
+                    messages::internalError(aResp->res);
+                    return;
+                }
+
+                nlohmann::json& assemblyArray =
+                    aResp->res.jsonValue["Assemblies"];
+
+                assemblyArray.at(
+                    assemblyIndex)["Oem"]["OpenBMC"]["ReadyToRemove"] = false;
+                },
+                "xyz.openbmc_project.ObjectMapper",
+                "/xyz/openbmc_project/object_mapper",
+                "xyz.openbmc_project.ObjectMapper", "GetObject",
+                "/xyz/openbmc_project/sensors/voltage/Battery_Voltage",
+                std::array<const char*, 0>{});
+        }
+
         crow::connections::systemBus->async_method_call(
             [aResp, assemblyIndex, assembly](
                 const boost::system::error_code ec,
@@ -302,21 +345,52 @@ inline void setAssemblylocationIndicators(
 
     std::vector<nlohmann::json> items = std::move(*assemblyData);
     std::map<std::string, bool> locationIndicatorActiveMap;
+    std::map<std::string, nlohmann::json> oemIndicatorMap;
 
     for (auto& item : items)
     {
-        bool locationIndicatorActive = false;
-        std::string memberId;
+        std::optional<std::string> memberId;
+        std::optional<bool> locationIndicatorActive;
+        std::optional<nlohmann::json> oem;
 
-        if (!json_util::readJson(item, asyncResp->res,
-                                 "LocationIndicatorActive",
-                                 locationIndicatorActive, "MemberId", memberId))
+        if (!json_util::readJson(
+                item, asyncResp->res, "LocationIndicatorActive",
+                locationIndicatorActive, "MemberId", memberId, "Oem", oem))
         {
             return;
         }
-        if (!memberId.empty())
+
+        if (locationIndicatorActive)
         {
-            locationIndicatorActiveMap[memberId] = locationIndicatorActive;
+            if (memberId)
+            {
+                locationIndicatorActiveMap[*memberId] =
+                    *locationIndicatorActive;
+            }
+            else
+            {
+                BMCWEB_LOG_ERROR << "Property Missing ";
+                BMCWEB_LOG_ERROR
+                    << "MemberId must be included with LocationIndicatorActive ";
+                messages::propertyMissing(asyncResp->res, "MemberId");
+                return;
+            }
+        }
+
+        if (oem)
+        {
+            if (memberId)
+            {
+                oemIndicatorMap[*memberId] = *oem;
+            }
+            else
+            {
+                BMCWEB_LOG_ERROR << "Property Missing ";
+                BMCWEB_LOG_ERROR
+                    << "MemberId must be included with the Oem property ";
+                messages::propertyMissing(asyncResp->res, "MemberId");
+                return;
+            }
         }
     }
 
@@ -329,6 +403,104 @@ inline void setAssemblylocationIndicators(
         if (iter != locationIndicatorActiveMap.end())
         {
             setLocationIndicatorActive(asyncResp, assembly, iter->second);
+        }
+
+        auto iter2 = oemIndicatorMap.find(std::to_string(assemblyIndex));
+
+        if (iter2 != oemIndicatorMap.end())
+        {
+            std::optional<nlohmann::json> openbmc;
+            if (!json_util::readJson(iter2->second, asyncResp->res, "OpenBMC",
+                                     openbmc))
+            {
+                BMCWEB_LOG_ERROR << "Property Value Format Error ";
+                messages::propertyValueFormatError(
+                    asyncResp->res,
+                    (*openbmc).dump(2, ' ', true,
+                                    nlohmann::json::error_handler_t::replace),
+                    "OpenBMC");
+                return;
+            }
+
+            if (!openbmc)
+            {
+                BMCWEB_LOG_ERROR << "Property Missing ";
+                messages::propertyMissing(asyncResp->res, "OpenBMC");
+                return;
+            }
+
+            std::optional<bool> readytoremove;
+            if (!json_util::readJson(*openbmc, asyncResp->res, "ReadyToRemove",
+                                     readytoremove))
+            {
+                BMCWEB_LOG_ERROR << "Property Value Format Error ";
+                messages::propertyValueFormatError(
+                    asyncResp->res,
+                    (*openbmc).dump(2, ' ', true,
+                                    nlohmann::json::error_handler_t::replace),
+                    "ReadyToRemove");
+                return;
+            }
+
+            if (!readytoremove)
+            {
+                BMCWEB_LOG_ERROR << "Property Missing ";
+                messages::propertyMissing(asyncResp->res, "ReadyToRemove");
+                return;
+            }
+
+            // Handle special case for tod_battery assembly OEM ReadyToRemove
+            // property. NOTE: The following method for the special case of the
+            // tod_battery ReadyToRemove property only works when there is only
+            // ONE adcsensor handled by the adcsensor application.
+            if (sdbusplus::message::object_path(assembly).filename() ==
+                "tod_battery")
+            {
+                if (readytoremove.value())
+                {
+                    // Call systemd to stop ADCSensor
+                    crow::connections::systemBus->async_method_call(
+                        [asyncResp](const boost::system::error_code ec) {
+                        if (ec)
+                        {
+                            BMCWEB_LOG_ERROR << "Failed to Stop ADCSensor:"
+                                             << ec;
+                            messages::internalError(asyncResp->res);
+                            return;
+                        }
+                        messages::success(asyncResp->res);
+                        },
+                        "org.freedesktop.systemd1", "/org/freedesktop/systemd1",
+                        "org.freedesktop.systemd1.Manager", "StopUnit",
+                        "xyz.openbmc_project.adcsensor.service", "replace");
+                }
+                else if (!readytoremove.value())
+                {
+                    // Call systemd to start ADCSensor
+                    crow::connections::systemBus->async_method_call(
+                        [asyncResp](const boost::system::error_code ec) {
+                        if (ec)
+                        {
+                            BMCWEB_LOG_ERROR << "Failed to Start ADCSensor:"
+                                             << ec;
+                            messages::internalError(asyncResp->res);
+                            return;
+                        }
+                        messages::success(asyncResp->res);
+                        },
+                        "org.freedesktop.systemd1", "/org/freedesktop/systemd1",
+                        "org.freedesktop.systemd1.Manager", "StartUnit",
+                        "xyz.openbmc_project.adcsensor.service", "replace");
+                }
+            }
+            else
+            {
+                BMCWEB_LOG_ERROR
+                    << "Property Unknown: ReadyToRemove on Assembly with MemberID: "
+                    << assemblyIndex;
+                messages::propertyUnknown(asyncResp->res, "ReadyToRemove");
+                return;
+            }
         }
         assemblyIndex++;
     }

--- a/scripts/update_schemas.py
+++ b/scripts/update_schemas.py
@@ -408,6 +408,15 @@ with open(metadata_index_path, "w") as metadata_index:
     metadata_index.write("    </edmx:Reference>\n")
 
     metadata_index.write(
+        '    <edmx:Reference Uri="/redfish/v1/schema/OemAssembly_v1.xml">\n'
+    )
+    metadata_index.write('        <edmx:Include Namespace="OemAssembly"/>\n')
+    metadata_index.write(
+        '        <edmx:Include Namespace="OemAssembly.v1_0_0"/>\n'
+    )
+    metadata_index.write("    </edmx:Reference>\n")
+
+    metadata_index.write(
         '    <edmx:Reference Uri="/redfish/v1/schema/OemChassis_v1.xml">\n'
     )
     metadata_index.write('        <edmx:Include Namespace="OemChassis"/>\n')

--- a/static/redfish/v1/$metadata/index.xml
+++ b/static/redfish/v1/$metadata/index.xml
@@ -2850,6 +2850,10 @@
         <edmx:Include Namespace="OemManagerAccount"/>
         <edmx:Include Namespace="OemManagerAccount.v1_0_0"/>
     </edmx:Reference>
+    <edmx:Reference Uri="/redfish/v1/schema/OemAssembly_v1.xml">
+        <edmx:Include Namespace="OemAssembly"/>
+        <edmx:Include Namespace="OemAssembly.v1_0_0"/>
+    </edmx:Reference>
     <edmx:Reference Uri="/redfish/v1/schema/OemChassis_v1.xml">
         <edmx:Include Namespace="OemChassis"/>
         <edmx:Include Namespace="OemChassis.v1_0_0"/>

--- a/static/redfish/v1/JsonSchemas/OemAssembly/index.json
+++ b/static/redfish/v1/JsonSchemas/OemAssembly/index.json
@@ -1,0 +1,42 @@
+{
+    "$id": "http://redfish.dmtf.org/schemas/v1/OemAssembly.v1_0_0.json",
+    "$schema": "http://redfish.dmtf.org/schemas/v1/redfish-schema-v1.json",
+    "copyright": "Copyright 2014-2019 DMTF. For the full DMTF copyright policy, see http://www.dmtf.org/about/policies/copyright",
+    "definitions": {
+        "Assembly": {
+            "additionalProperties": false,
+            "description": "An indication of whether the system is prepared for the assembly to be removed.",
+            "parameters": {},
+            "patternProperties": {
+                "^([a-zA-Z_][a-zA-Z0-9_]*)?@(odata|Redfish|Message)\\.[a-zA-Z_][a-zA-Z0-9_]*$": {
+                    "description": "This property shall specify a valid odata or Redfish property.",
+                    "type": [
+                        "array",
+                        "boolean",
+                        "integer",
+                        "number",
+                        "null",
+                        "object",
+                        "string"
+                    ]
+                }
+            },
+            "properties": {
+                "ReadyToRemove": {
+                    "description": "An indication of whether the system is prepared for an assembly to be removed.",
+                    "longDescription": "This property shall indicate whether the system is ready for the assembly to be changed.  Setting the value to `true` shall cause the service to perform appropriate actions to allow the assembly to be removed.  Setting the value to `false` shall cause the service to perform appropriate actions to allow the assembly to be installed.",
+                    "readonly": false,
+                    "type": [
+                        "boolean",
+                        "null"
+                    ],
+                    "versionAdded": "v1_0_0"
+                }
+            },
+            "type": "object"
+        }
+    },
+    "OwningEntity": "OpenBMC",
+    "release": "1.0",
+    "title": "#OemAssembly.v1_0_0"
+}

--- a/static/redfish/v1/schema/OemAssembly_v1.xml
+++ b/static/redfish/v1/schema/OemAssembly_v1.xml
@@ -1,0 +1,43 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<edmx:Edmx xmlns:edmx="http://docs.oasis-open.org/odata/ns/edmx" Version="4.0">
+    <edmx:Reference Uri="http://docs.oasis-open.org/odata/odata/v4.0/errata03/csd01/complete/vocabularies/Org.OData.Core.V1.xml">
+        <edmx:Include Namespace="Org.OData.Core.V1" Alias="OData"/>
+    </edmx:Reference>
+    <edmx:Reference Uri="http://redfish.dmtf.org/schemas/v1/Assembly_v1.xml">
+        <edmx:Include Namespace="Assembly"/>
+        <edmx:Include Namespace="Assembly.v1_0_0"/>
+    </edmx:Reference>
+    <edmx:Reference Uri="http://redfish.dmtf.org/schemas/v1/RedfishExtensions_v1.xml">
+        <edmx:Include Namespace="RedfishExtensions.v1_0_0" Alias="Redfish"/>
+    </edmx:Reference>
+    <edmx:Reference Uri="http://redfish.dmtf.org/schemas/v1/Resource_v1.xml">
+        <edmx:Include Namespace="Resource"/>
+        <edmx:Include Namespace="Resource.v1_0_0"/>
+    </edmx:Reference>
+    
+    <edmx:DataServices>
+
+        <Schema xmlns="http://docs.oasis-open.org/odata/ns/edm" Namespace="OemAssembly">
+            <Annotation Term="Redfish.OwningEntity" String="OpenBMC"/>
+        </Schema>
+
+        <Schema xmlns="http://docs.oasis-open.org/odata/ns/edm" Namespace="OemAssembly.v1_0_0">
+            <ComplexType Name="Oem" BaseType="Resource.OemObject">
+                <Annotation Term="OData.AdditionalProperties" Bool="true" />
+                <Annotation Term="OData.Description" String="OemAssembly Oem properties." />
+                <Annotation Term="OData.AutoExpand" />
+                <Property Name="OpenBMC" Type="OemAssembly.v1_0_0.OpenBMC" />
+            </ComplexType>
+        
+            <ComplexType Name="OpenBMC">
+                <Annotation Term="OData.AdditionalProperties" Bool="true" />
+                <Annotation Term="OData.Description" String="Oem properties for OpenBMC." />
+                <Annotation Term="OData.AutoExpand" />
+                <Property Name="ReadyToRemove" Type="Edm.Boolean" />
+                    <Annotation Term="OData.Description" String="Indicates if the assembly is ready to be removed." />
+                    <Annotation Term="OData.LongDescription" String="Indicates if the system is prepared for the assembly to be removed." />
+            </ComplexType>
+        </Schema>
+
+    </edmx:DataServices>
+</edmx:Edmx>


### PR DESCRIPTION
OEM Battery Concurrent Maintenance For Everest System 

The current impementation of this feature supports
the redfish OEM ReadyToRemove property for the TOD
battery on assembly.  The TOD battery is put in the
ReadyToRemove state by stopping the adcsensor application.
The reverse occurs when the adcsensor application
is restarted.  The adcsensor is stopped and started
by calling systemd.  Note that this implementation
only works if the adcsensor application handles one
ADC sensor.

* Update for PR: https://github.com/ibm-openbmc/bmcweb/pull/224
