### PR TITLE
Ethernet: Fix getting empty IP address

### DIFF
--- a/redfish-core/lib/ethernet.hpp
+++ b/redfish-core/lib/ethernet.hpp
@@ -410,20 +410,40 @@ inline void
                     const dbus::utility::ManagedObjectType& dbusData,
                     boost::container::flat_set<IPv6AddressData>& ipv6Config)
 {
-    const std::string ipv6PathStart =
-        "/xyz/openbmc_project/network/" + ethifaceId + "/ipv6/";
+    const std::string ipPathStart =
+        "/xyz/openbmc_project/network/" + ethifaceId;
 
     // Since there might be several IPv6 configurations aligned with
     // single ethernet interface, loop over all of them
     for (const auto& objpath : dbusData)
     {
         // Check if proper pattern for object path appears
-        if (objpath.first.str.starts_with(ipv6PathStart))
+        if (objpath.first.str.starts_with(ipPathStart + "/"))
         {
             for (const auto& interface : objpath.second)
             {
                 if (interface.first == "xyz.openbmc_project.Network.IP")
                 {
+                    auto type = std::find_if(interface.second.begin(),
+                                             interface.second.end(),
+                                             [](const auto& property) {
+                        return property.first == "Type";
+                    });
+                    if (type == interface.second.end())
+                    {
+                        continue;
+                    }
+
+                    const std::string* typeStr =
+                        std::get_if<std::string>(&type->second);
+
+                    if (typeStr == nullptr ||
+                        (*typeStr !=
+                         "xyz.openbmc_project.Network.IP.Protocol.IPv6"))
+                    {
+                        continue;
+                    }
+
                     // Instance IPv6AddressData structure, and set as
                     // appropriate
                     std::pair<
@@ -432,7 +452,7 @@ inline void
                         it = ipv6Config.insert(IPv6AddressData{});
                     IPv6AddressData& ipv6Address = *it.first;
                     ipv6Address.id =
-                        objpath.first.str.substr(ipv6PathStart.size());
+                        objpath.first.str.substr(ipPathStart.size());
                     for (const auto& property : interface.second)
                     {
                         if (property.first == "Address")
@@ -488,20 +508,40 @@ inline void
                   const dbus::utility::ManagedObjectType& dbusData,
                   boost::container::flat_set<IPv4AddressData>& ipv4Config)
 {
-    const std::string ipv4PathStart =
-        "/xyz/openbmc_project/network/" + ethifaceId + "/ipv4/";
+    const std::string ipPathStart =
+        "/xyz/openbmc_project/network/" + ethifaceId;
 
     // Since there might be several IPv4 configurations aligned with
     // single ethernet interface, loop over all of them
     for (const auto& objpath : dbusData)
     {
         // Check if proper pattern for object path appears
-        if (objpath.first.str.starts_with(ipv4PathStart))
+        if (objpath.first.str.starts_with(ipPathStart + "/"))
         {
             for (const auto& interface : objpath.second)
             {
                 if (interface.first == "xyz.openbmc_project.Network.IP")
                 {
+                    auto type = std::find_if(interface.second.begin(),
+                                             interface.second.end(),
+                                             [](const auto& property) {
+                        return property.first == "Type";
+                    });
+                    if (type == interface.second.end())
+                    {
+                        continue;
+                    }
+
+                    const std::string* typeStr =
+                        std::get_if<std::string>(&type->second);
+
+                    if (typeStr == nullptr ||
+                        (*typeStr !=
+                         "xyz.openbmc_project.Network.IP.Protocol.IPv4"))
+                    {
+                        continue;
+                    }
+
                     // Instance IPv4AddressData structure, and set as
                     // appropriate
                     std::pair<
@@ -510,7 +550,7 @@ inline void
                         it = ipv4Config.insert(IPv4AddressData{});
                     IPv4AddressData& ipv4Address = *it.first;
                     ipv4Address.id =
-                        objpath.first.str.substr(ipv4PathStart.size());
+                        objpath.first.str.substr(ipPathStart.size());
                     for (const auto& property : interface.second)
                     {
                         if (property.first == "Address")


### PR DESCRIPTION
Dbus for "xyz.openbmc_project.Network" changed to no protocol in object path[0]. And this is in line with expectations[1]. Since that, it will get empty IP address when calling
"/redfish/v1/Managers/bmc/EthernetInterfaces/eth1".

Dbus before:
/xyz/openbmc_project/network/eth0/ipv4/52348b91
Now:
/xyz/openbmc_project/network/eth0/_66e80_3a_3aa00_3a27ff_3afee1_3a5408

Test:
Before:
GET /redfish/v1/Managers/bmc/EthernetInterfaces/eth1
```
{

  "IPv4Addresses": [],
  "IPv4StaticAddresses": [],
  "IPv6AddressPolicyTable": [],
  "IPv6Addresses": [],
}
```

After:
GET /redfish/v1/Managers/bmc/EthernetInterfaces/eth1
```
{
    "IPv4Addresses": [
        {
          "Address": "192.168.1.108",
          "AddressOrigin": "DHCP",
          "Gateway": "192.168.1.2",
          "SubnetMask": "255.255.255.0"
        }
      ],
    "IPv6Addresses": [
        {
          "Address": "fe80::e24f:43ff:fefe:ca5d",
          "AddressOrigin": "LinkLocal",
          "AddressState": null,
          "PrefixLength": 64
        }
      ],
}
```

[0]: https://github.com/openbmc/phosphor-networkd/commit/59e5b91d9784274d1d99b4c10e939c38606efacc [1]: https://discord.com/channels/775381525260664832/775381525260664836/1044873098010316840

Change-Id: I40a5357e6ad31afa7156ac3bce908ae48d26a0cf
Signed-off-by: Tony Lee <tony.lee@quantatw.com>
Signed-off-by: Jian Zhang <zhangjian.3032@bytedance.com>