### PR TITLE
1050: Fix bmcweb debug build failure

### DIFF
--- a/src/boost_url.cpp
+++ b/src/boost_url.cpp
@@ -1,2 +1,5 @@
 
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wnull-dereference"
 #include <boost/url/src.hpp>
+#pragma GCC diagnostic pop


### PR DESCRIPTION
Fix and workaround bmcweb debug build failure

When bmcweb is built with buildtype=debug, the failure happens related
to boost code and compiler.

```
| arm-openbmc-linux-gnueabi-g++ .... -Wnull-dereference
     -o bmcweb.p/src_boost_url.cpp.o
     -c ../../../../../../../../../ibm-bmcweb/src/boost_url.cpp
| In file included from <...>/usr/include/boost/url/grammar.hpp:29,
|                  from <...>/usr/include/boost/url.hpp:13,
|                  from <...>/usr/include/boost/url/src.hpp:28,
|                  from <...>/../../../ibm-bmcweb/src/boost_url.cpp:2:
| In member function 'std::size_t boost::urls::grammar::range<T>::size()
  const [with T = std::tuple<boost::core::basic_string_view<char>,
         boost::urls::pct_string_view>]',
  <...>
  <..>::origin_form_rule_t::parse(const char*&, const char*) const' at
  <...>/usr/include/boost/url/rfc/impl/origin_form_rule.ipp:43:21:
| <...>/usr/include/boost/url/grammar/range_rule.hpp:261:16:
  error: potential null pointer dereference [-Werror=null-dereference]
|   261 |         return n_;
|       |                ^~
| cc1plus: all warnings being treated as errors
```

This happens with src/boost_url.cpp which is to include boost/src.hpp.
To workaround, -Wnull-deference is ignored only for this file.

Change-Id: Ifbf283681271bd04feb5030c92b81c6189a1ec9b
Signed-off-by: Myung Bae <myungbae@us.ibm.com>