### PR TITLE
1050: Redfish: Implement HealthRollup in chassis schema

### DIFF
--- a/redfish-core/lib/chassis.hpp
+++ b/redfish-core/lib/chassis.hpp
@@ -255,6 +255,50 @@ inline void
                     return; // no sensors = no failures
                 }
                 health->inventory = resp;
+
+                constexpr const std::array<const char*, 13>
+                    inventoryForChassis = {"xyz.openbmc_project.Inventory.Item."
+                                           "Dimm",
+                                           "xyz.openbmc_project.Inventory.Item."
+                                           "Cpu",
+                                           "xyz.openbmc_project.Inventory.Item."
+                                           "PowerSupply",
+                                           "xyz.openbmc_project.Inventory.Item."
+                                           "Fan",
+                                           "xyz.openbmc_project.Inventory.Item."
+                                           "PCIeSlot",
+                                           "xyz.openbmc_project.Inventory.Item."
+                                           "Vrm",
+                                           "xyz.openbmc_project.Inventory.Item."
+                                           "Tpm",
+                                           "xyz.openbmc_project.Inventory.Item."
+                                           "Panel",
+                                           "xyz.openbmc_project.Inventory.Item."
+                                           "Battery",
+                                           "xyz.openbmc_project.Inventory.Item."
+                                           "DiskBackplane",
+                                           "xyz.openbmc_project.Inventory.Item."
+                                           "Board",
+                                           "xyz.openbmc_project.Inventory.Item."
+                                           "Board.Motherboard",
+                                           "xyz.openbmc_project.Inventory.Item."
+                                           "Connector"};
+
+                crow::connections::systemBus->async_method_call(
+                    [health](const boost::system::error_code ec3,
+                             std::vector<std::string>& resp2) {
+                    if (ec3)
+                    {
+                        // no inventory
+                        return;
+                    }
+                    health->inventory.insert(health->inventory.end(),
+                                             resp2.begin(), resp2.end());
+                    },
+                    "xyz.openbmc_project.ObjectMapper",
+                    "/xyz/openbmc_project/object_mapper",
+                    "xyz.openbmc_project.ObjectMapper", "GetSubTreePaths", "/",
+                    int32_t(0), inventoryForChassis);
                 });
 
             health->populate();

--- a/redfish-core/lib/health.hpp
+++ b/redfish-core/lib/health.hpp
@@ -140,7 +140,6 @@ struct HealthPopulate : std::enable_shared_from_this<HealthPopulate>
             if (path.str.starts_with(globalInventoryPath) &&
                 path.str.ends_with("critical"))
             {
-                health = "Critical";
                 rollup = "Critical";
                 return;
             }


### PR DESCRIPTION
The health status of the current CPUs and powersupplies will not rollup to chassis. This submission implements rollup of the health status of CPUs and powersupplies to chassis.

No upstream commit. 1020 PR: https://github.com/ibm-openbmc/bmcweb/pull/107

Tested:
We need add the xyz.openbmc_project.Inventory.Item.Global interface to the chassis.
I create a critical association of powersupply1 using the same method as phosphor-logging:
[1] https://github.com/openbmc/phosphor-logging/blob/76198a2ea2e3deb14078e0d3dd3932b657ddd9b8/extensions/openpower-pels/service_indicators.cpp#L83

Then the chassis HealthRollup will become critical: curl -k -H "X-Auth-Token: $token" -X GET
https://${bmc}/redfish/v1/Chassis/chassis
"Status": {
    "Health": "OK",
    "HealthRollup": "Critical",
    "State": "Enabled"
  },

Signed-off-by: Chicago Duan <duanzhijia01@inspur.com>

ore/lib/chassis.hpp