### PR TITLE
1050: Fix bug: bmcweb SNMP errors in the Journal

### DIFF
--- a/redfish-core/include/event_service_manager.hpp
+++ b/redfish-core/include/event_service_manager.hpp
@@ -388,6 +388,11 @@ class Subscription : public persistent_data::UserSubscription
 
     bool sendEvent(std::string& msg)
     {
+        if (subscriptionType == "SNMPTrap")
+        {
+            return true; // Don't need send SNMPTrap event.
+        }
+
         persistent_data::EventServiceConfig eventServiceConfig =
             persistent_data::EventServiceStore::getInstance()
                 .getEventServiceConfig();
@@ -1054,6 +1059,12 @@ class EventServiceManager
             {
                 isSubscribed = true;
             }
+
+            if (entry->subscriptionType == "SNMPTrap")
+            {
+                isSubscribed = false; // Don't need send SNMPTrap event.
+            }
+
             if (isSubscribed)
             {
                 nlohmann::json msgJson;


### PR DESCRIPTION
Fix this bug: ibm-openbmc/dev#3599
Don't send event to snmptrap subscription.

Upstream: https://gerrit.openbmc.org/c/openbmc/bmcweb/+/38599

https://github.com/ibm-openbmc/bmcweb/pull/413

Signed-off-by: Chicago Duan <duanzhijia01@inspur.com>