### PR TITLE
1050: Update indicator LED verification

### DIFF
--- a/redfish-core/lib/chassis.hpp
+++ b/redfish-core/lib/chassis.hpp
@@ -344,9 +344,10 @@ inline void
 
             const std::vector<std::string>& interfaces2 =
                 connectionNames[0].second;
-            const std::array<const char*, 2> hasIndicatorLed = {
+            const std::array<const char*, 3> hasIndicatorLed = {
                 "xyz.openbmc_project.Inventory.Item.Panel",
-                "xyz.openbmc_project.Inventory.Item.Board.Motherboard"};
+                "xyz.openbmc_project.Inventory.Item.Board.Motherboard",
+                "xyz.openbmc_project.Inventory.Item.Chassis"};
 
             const std::string assetTagInterface =
                 "xyz.openbmc_project.Inventory.Decorator.AssetTag";
@@ -605,9 +606,10 @@ inline void
             const std::vector<std::string>& interfaces3 =
                 connectionNames[0].second;
 
-            const std::array<const char*, 2> hasIndicatorLed = {
+            const std::array<const char*, 3> hasIndicatorLed = {
                 "xyz.openbmc_project.Inventory.Item.Panel",
-                "xyz.openbmc_project.Inventory.Item.Board.Motherboard"};
+                "xyz.openbmc_project.Inventory.Item.Board.Motherboard",
+                "xyz.openbmc_project.Inventory.Item.Chassis"};
             bool indicatorChassis = false;
             for (const char* interface : hasIndicatorLed)
             {


### PR DESCRIPTION
Extend the hasIndicatorLed array and add
xyz.openbmc_project.Inventory.Item.Chassis interface.

Tested:
curl -k https://$bmc/redfish/v1/Chassis/chassis
{
  "@odata.id": "/redfish/v1/Chassis/chassis",
  "@odata.type": "#Chassis.v1_16_0.Chassis",
  "Actions": {
    "#Chassis.Reset": {
      "@Redfish.ActionInfo": "/redfish/v1/Chassis/chassis/ResetActionInfo",
      "target": "/redfish/v1/Chassis/chassis/Actions/Chassis.Reset"
    }
  },
  "IndicatorLED": "Off",
  "LocationIndicatorActive": false,
  "Manufacturer": "",
  "Model": "23",
  "Name": "chassis",
  ...
}