### PR TITLE
Refactor GetSubTreePaths and getCollectionMembers

### DIFF
--- a/include/dbus_utility.hpp
+++ b/include/dbus_utility.hpp
@@ -145,7 +145,8 @@ inline void checkDbusPathExists(const std::string& path, Callback&& callback)
 }
 
 inline void
-    getSubTree(const std::string& path, std::span<std::string> interfaces,
+    getSubTree(const std::string& path, int32_t depth,
+               std::span<const std::string_view> interfaces,
                std::function<void(const boost::system::error_code&,
                                   const MapperGetSubTreeResponse&)>&& callback)
 {
@@ -155,11 +156,13 @@ inline void
             const MapperGetSubTreeResponse& subtree) { callback(ec, subtree); },
         "xyz.openbmc_project.ObjectMapper",
         "/xyz/openbmc_project/object_mapper",
-        "xyz.openbmc_project.ObjectMapper", "GetSubTree", path, 0, interfaces);
+        "xyz.openbmc_project.ObjectMapper", "GetSubTree", path, depth,
+        interfaces);
 }
 
 inline void getSubTreePaths(
-    const std::string& path, std::span<std::string> interfaces,
+    const std::string& path, int32_t depth,
+    std::span<const std::string_view> interfaces,
     std::function<void(const boost::system::error_code&,
                        const MapperGetSubTreePathsResponse&)>&& callback)
 {
@@ -171,7 +174,7 @@ inline void getSubTreePaths(
         },
         "xyz.openbmc_project.ObjectMapper",
         "/xyz/openbmc_project/object_mapper",
-        "xyz.openbmc_project.ObjectMapper", "GetSubTreePaths", path, 0,
+        "xyz.openbmc_project.ObjectMapper", "GetSubTreePaths", path, depth,
         interfaces);
 }
 

--- a/include/google/google_service_root.hpp
+++ b/include/google/google_service_root.hpp
@@ -37,9 +37,11 @@ inline void handleRootOfTrustCollectionGet(
     asyncResp->res.jsonValue["@odata.id"] = "/google/v1/RootOfTrustCollection";
     asyncResp->res.jsonValue["@odata.type"] =
         "#RootOfTrustCollection.RootOfTrustCollection";
+    constexpr std::array<std::string_view, 1> interfaces{
+        "xyz.openbmc_project.Control.Hoth"};
     redfish::collection_util::getCollectionMembers(
         asyncResp, boost::urls::url("/google/v1/RootOfTrustCollection"),
-        {"xyz.openbmc_project.Control.Hoth"}, "/xyz/openbmc_project");
+        interfaces);
 }
 
 // Helper struct to identify a resolved D-Bus object interface

--- a/redfish-core/include/utils/systems_utils.hpp
+++ b/redfish-core/include/utils/systems_utils.hpp
@@ -62,10 +62,10 @@ void getValidSystemsPath(
     };
 
     // Get the Systems Collection
-    std::vector<std::string> interfaces = {
+    constexpr std::array<std::string_view, 1> interfaces = {
         "xyz.openbmc_project.Inventory.Item.System"};
-    dbus::utility::getSubTreePaths("/xyz/openbmc_project/inventory", interfaces,
-                                   std::move(respHandler));
+    dbus::utility::getSubTreePaths("/xyz/openbmc_project/inventory", 0,
+                                   interfaces, std::move(respHandler));
     BMCWEB_LOG_DEBUG << "checkSystemsId exit";
 }
 

--- a/redfish-core/lib/cable.hpp
+++ b/redfish-core/lib/cable.hpp
@@ -226,9 +226,10 @@ inline void requestRoutesCableCollection(App& app)
         asyncResp->res.jsonValue["Name"] = "Cable Collection";
         asyncResp->res.jsonValue["Description"] = "Collection of Cable Entries";
 
+        constexpr std::array<std::string_view, 1> interfaces{
+            "xyz.openbmc_project.Inventory.Item.Cable"};
         collection_util::getCollectionMembers(
-            asyncResp, boost::urls::url("/redfish/v1/Cables"),
-            {"xyz.openbmc_project.Inventory.Item.Cable"});
+            asyncResp, boost::urls::url("/redfish/v1/Cables"), interfaces);
         });
 }
 

--- a/redfish-core/lib/chassis.hpp
+++ b/redfish-core/lib/chassis.hpp
@@ -147,9 +147,10 @@ inline void handleChassisCollectionGet(
     asyncResp->res.jsonValue["@odata.id"] = "/redfish/v1/Chassis";
     asyncResp->res.jsonValue["Name"] = "Chassis Collection";
 
+    constexpr std::array<std::string_view, 1> interfaces{
+        "xyz.openbmc_project.Inventory.Item.Chassis"};
     collection_util::getCollectionMembers(
-        asyncResp, boost::urls::url("/redfish/v1/Chassis"),
-        {"xyz.openbmc_project.Inventory.Item.Chassis"});
+        asyncResp, boost::urls::url("/redfish/v1/Chassis"), interfaces);
 }
 
 /**

--- a/redfish-core/lib/memory.hpp
+++ b/redfish-core/lib/memory.hpp
@@ -791,10 +791,11 @@ inline void requestRoutesMemoryCollection(App& app)
         asyncResp->res.jsonValue["Name"] = "Memory Module Collection";
         asyncResp->res.jsonValue["@odata.id"] =
             "/redfish/v1/Systems/system/Memory";
-
+        constexpr std::array<std::string_view, 1> interfaces{
+            "xyz.openbmc_project.Inventory.Item.Dimm"};
         collection_util::getCollectionMembers(
             asyncResp, boost::urls::url("/redfish/v1/Systems/system/Memory"),
-            {"xyz.openbmc_project.Inventory.Item.Dimm"});
+            interfaces);
         });
 }
 

--- a/redfish-core/lib/metric_report.hpp
+++ b/redfish-core/lib/metric_report.hpp
@@ -73,7 +73,9 @@ inline void requestRoutesMetricReportCollection(App& app)
         asyncResp->res.jsonValue["@odata.id"] =
             "/redfish/v1/TelemetryService/MetricReports";
         asyncResp->res.jsonValue["Name"] = "Metric Report Collection";
-        const std::vector<const char*> interfaces{telemetry::reportInterface};
+
+        constexpr std::array<std::string_view, 1> interfaces{
+            telemetry::reportInterface};
         collection_util::getCollectionMembers(
             asyncResp,
             boost::urls::url("/redfish/v1/TelemetryService/MetricReports"),

--- a/redfish-core/lib/metric_report_definition.hpp
+++ b/redfish-core/lib/metric_report_definition.hpp
@@ -359,7 +359,8 @@ inline void requestRoutesMetricReportDefinitionCollection(App& app)
         asyncResp->res.jsonValue["@odata.id"] =
             "/redfish/v1/TelemetryService/MetricReportDefinitions";
         asyncResp->res.jsonValue["Name"] = "Metric Definition Collection";
-        const std::vector<const char*> interfaces{telemetry::reportInterface};
+        constexpr std::array<std::string_view, 1> interfaces{
+            telemetry::reportInterface};
         collection_util::getCollectionMembers(
             asyncResp,
             boost::urls::url(

--- a/redfish-core/lib/network_protocol.hpp
+++ b/redfish-core/lib/network_protocol.hpp
@@ -359,9 +359,9 @@ inline void
         }
     };
 
-    std::vector<std::string> interfaces = {
+    constexpr std::array<std::string_view, 1> interfaces = {
         "xyz.openbmc_project.Network.EthernetInterface"};
-    dbus::utility::getSubTree("/xyz/openbmc_project", interfaces,
+    dbus::utility::getSubTree("/xyz/openbmc_project", 0, interfaces,
                               std::move(respHandler));
 }
 
@@ -413,9 +413,9 @@ inline void
         }
     };
 
-    std::vector<std::string> interfaces = {
+    constexpr std::array<std::string_view, 1> interfaces = {
         "xyz.openbmc_project.Control.Service.Attributes"};
-    dbus::utility::getSubTree("/xyz/openbmc_project/control/service",
+    dbus::utility::getSubTree("/xyz/openbmc_project/control/service", 0,
                               interfaces, std::move(respHandler));
 }
 

--- a/redfish-core/lib/processor.hpp
+++ b/redfish-core/lib/processor.hpp
@@ -36,7 +36,7 @@ namespace redfish
 {
 
 // Interfaces which imply a D-Bus object represents a Processor
-constexpr std::array<const char*, 2> processorInterfaces = {
+constexpr std::array<std::string_view, 2> processorInterfaces = {
     "xyz.openbmc_project.Inventory.Item.Cpu",
     "xyz.openbmc_project.Inventory.Item.Accelerator"};
 
@@ -1100,13 +1100,15 @@ inline void requestRoutesOperatingConfigCollection(App& app)
 
                 // Use the common search routine to construct the
                 // Collection of all Config objects under this CPU.
+                constexpr std::array<std::string_view, 1> interface {
+                    "xyz.openbmc_project.Inventory.Item.Cpu.OperatingConfig"
+                };
                 collection_util::getCollectionMembers(
                     asyncResp,
                     crow::utility::urlFromPieces("redfish", "v1", "Systems",
                                                  "system", "Processors",
                                                  cpuName, "OperatingConfigs"),
-                    {"xyz.openbmc_project.Inventory.Item.Cpu.OperatingConfig"},
-                    object.c_str());
+                    interface, object.c_str());
                 return;
             }
             },
@@ -1221,8 +1223,7 @@ inline void requestRoutesProcessorCollection(App& app)
         collection_util::getCollectionMembers(
             asyncResp,
             boost::urls::url("/redfish/v1/Systems/system/Processors"),
-            std::vector<const char*>(processorInterfaces.begin(),
-                                     processorInterfaces.end()));
+            processorInterfaces);
         });
 }
 

--- a/redfish-core/lib/thermal_metrics.hpp
+++ b/redfish-core/lib/thermal_metrics.hpp
@@ -117,7 +117,7 @@ void getThermalMetrics(
     const std::shared_ptr<SensorsAsyncResp>& sensorsAsyncResp,
     Callback&& callback)
 {
-    std::vector<std::string> interfaces = {
+    constexpr std::array<std::string_view, 2> interfaces = {
         "xyz.openbmc_project.Inventory.Item.Board",
         "xyz.openbmc_project.Inventory.Item.Chassis"};
 
@@ -203,8 +203,8 @@ void getThermalMetrics(
             callback(culledSensorList);
             });
     };
-    dbus::utility::getSubTreePaths("/xyz/openbmc_project/inventory", interfaces,
-                                   std::move(respHandler));
+    dbus::utility::getSubTreePaths("/xyz/openbmc_project/inventory", 0,
+                                   interfaces, std::move(respHandler));
 }
 
 /**

--- a/redfish-core/lib/trigger.hpp
+++ b/redfish-core/lib/trigger.hpp
@@ -304,7 +304,8 @@ inline void requestRoutesTriggerCollection(App& app)
         asyncResp->res.jsonValue["@odata.id"] =
             "/redfish/v1/TelemetryService/Triggers";
         asyncResp->res.jsonValue["Name"] = "Triggers Collection";
-        const std::vector<const char*> interfaces{telemetry::triggerInterface};
+        constexpr std::array<std::string_view, 1> interfaces{
+            telemetry::triggerInterface};
         collection_util::getCollectionMembers(
             asyncResp,
             boost::urls::url("/redfish/v1/TelemetryService/Triggers"),


### PR DESCRIPTION
Refactor GetSubTree, GetSubTreePaths and getCollectionMembers

Merging the following commits from upstream
https://gerrit.openbmc.org/c/openbmc/bmcweb/+/59537 https://gerrit.openbmc.org/c/openbmc/bmcweb/+/59428 https://gerrit.openbmc.org/c/openbmc/bmcweb/+/38751

Tested: Redfish Validator Passed

Change-Id: Ia549158d2e49770bb92af8bbc8e6fa93c0499677