### PR TITLE
1050: Redfish: Fix issue of set Assemply LocationIndicatorActive

### DIFF
--- a/redfish-core/lib/assembly.hpp
+++ b/redfish-core/lib/assembly.hpp
@@ -784,8 +784,11 @@ inline void checkAssociation(const std::shared_ptr<bmcweb::AsyncResp>& aResp,
         return;
     }
 
-    aResp->res.jsonValue["Assemblies"] = nlohmann::json::array();
-    aResp->res.jsonValue["Assemblies@odata.count"] = 0;
+    if (!setLocationIndicatorActiveFlag)
+    {
+        aResp->res.jsonValue["Assemblies"] = nlohmann::json::array();
+        aResp->res.jsonValue["Assemblies@odata.count"] = 0;
+    }
 
     // check if this chassis hosts any association
     crow::connections::systemBus->async_method_call(
@@ -864,11 +867,15 @@ inline void getChassis(const std::shared_ptr<bmcweb::AsyncResp>& aResp,
                 continue;
             }
 
-            aResp->res.jsonValue["@odata.type"] = "#Assembly.v1_3_0.Assembly";
-            aResp->res.jsonValue["@odata.id"] =
-                "/redfish/v1/Chassis/" + chassisID + "/Assembly";
-            aResp->res.jsonValue["Name"] = "Assembly Collection";
-            aResp->res.jsonValue["Id"] = "Assembly";
+            if (!setLocationIndicatorActiveFlag)
+            {
+                aResp->res.jsonValue["@odata.type"] =
+                    "#Assembly.v1_3_0.Assembly";
+                aResp->res.jsonValue["@odata.id"] =
+                    "/redfish/v1/Chassis/" + chassisID + "/Assembly";
+                aResp->res.jsonValue["Name"] = "Assembly Collection";
+                aResp->res.jsonValue["Id"] = "Assembly";
+            }
 
             checkAssociation(aResp, path, setLocationIndicatorActiveFlag, req);
             return;


### PR DESCRIPTION
Upstream: https://gerrit.openbmc.org/c/openbmc/bmcweb/+/42441

when we do a patch request on Assembly it gives following response: curl -k -H "X-Auth-Token: $token" -X PATCH -d
'{"Assemblies":[{"MemberId" : "2", "LocationIndicatorActive":true}]}' https://${BMC_IP}/redfish/v1/Chassis/chassis/Assembly {
  "@odata.id": "/redfish/v1/Chassis/chassis/Assembly",
  "@odata.type": "#Assembly.v1_3_0.Assembly",
  "Assemblies": [],
  "Assemblies@odata.count": 0,
  "Id": "Assembly",
  "Name": "Assembly Collection"
}
This response is not expected. This commit will fix this issue.

Tested:
when we do a patch request on Assembly it does not give any response: curl -k -H "X-Auth-Token: $token" -X PATCH -d
'{"Assemblies":[{"MemberId" : "2", "LocationIndicatorActive":true}]}' https://${BMC_IP}/redfish/v1/Chassis/chassis/Assembly