### PR TITLE
Problem with RemoteRoleMapping JSON

### DIFF
--- a/redfish-core/lib/account_service.hpp
+++ b/redfish-core/lib/account_service.hpp
@@ -248,17 +248,10 @@ inline void parseLDAPConfigData(nlohmann::json& jsonResponse,
         BMCWEB_LOG_DEBUG << "Pushing the data groupName="
                          << obj.second.groupName << "\n";
 
-        nlohmann::json::array_t remoteGroupArray;
         nlohmann::json::object_t remoteGroup;
         remoteGroup["RemoteGroup"] = obj.second.groupName;
-        remoteGroupArray.emplace_back(std::move(remoteGroup));
-        roleMapArray.emplace_back(std::move(remoteGroupArray));
-
-        nlohmann::json::array_t localRoleArray;
-        nlohmann::json::object_t localRole;
-        localRole["LocalRole"] = getRoleIdFromPrivilege(obj.second.privilege);
-        localRoleArray.emplace_back(std::move(localRole));
-        roleMapArray.emplace_back(std::move(localRoleArray));
+        remoteGroup["LocalRole"] = getRoleIdFromPrivilege(obj.second.privilege);
+        roleMapArray.emplace_back(std::move(remoteGroup));
     }
 }
 


### PR DESCRIPTION
The current LDAP group map on /redfish/v1/AccountService is incorrect and is creating a bad JSON response. instead of an array of objects, is creating a nested array of objects. The problem is visible on the website adding a new LDAP group map, it will show 2 empty rows instead of one with the correct data.

The current JSON data is:
"RemoteRoleMapping": [
           [
               {
                   "RemoteGroup": "groupname"
               }
           ],
           [
               {
                   "LocalRole": "Operator"
               }
           ]
       ],
The correct JSON is:
"RemoteRoleMapping": [
            {
                "LocalRole": "Operator",
                "RemoteGroup": "groupname"
            }
        ],

The tests redfish/account_service/test_ldap_configuration crashed BMCWEB generates around 9 core dump files.

Tested:
redfish/account_service/test_ldap_configuration passed the tests Adding a new LDAP group map on the website, showing the correct data,

Change-Id: I5de7db372ceff1cc596da2b04f5fd730415f7216