### PR TITLE
Support ipv6 on hypervisor ethernet interface

### DIFF
--- a/redfish-core/lib/ethernet.hpp
+++ b/redfish-core/lib/ethernet.hpp
@@ -69,6 +69,7 @@ struct IPv6AddressData
     std::string address;
     std::string origin;
     uint8_t prefixLength;
+    bool isActive;
 
     bool operator<(const IPv6AddressData& obj) const
     {

--- a/redfish-core/lib/ethernet.hpp
+++ b/redfish-core/lib/ethernet.hpp
@@ -131,7 +131,9 @@ inline bool translateDhcpEnabledToBool(const std::string& inputDHCP,
             (inputDHCP ==
              "xyz.openbmc_project.Network.EthernetInterface.DHCPConf.v4") ||
             (inputDHCP ==
-             "xyz.openbmc_project.Network.EthernetInterface.DHCPConf.both"));
+             "xyz.openbmc_project.Network.EthernetInterface.DHCPConf.both") ||
+            (inputDHCP ==
+             "xyz.openbmc_project.Network.EthernetInterface.DHCPConf.v4v6stateless"));
     }
     return ((inputDHCP ==
              "xyz.openbmc_project.Network.EthernetInterface.DHCPConf.v6") ||

--- a/redfish-core/lib/hypervisor_system.hpp
+++ b/redfish-core/lib/hypervisor_system.hpp
@@ -162,10 +162,12 @@ inline void
 }
 
 inline bool extractHypervisorInterfaceData(
+    const std::shared_ptr<bmcweb::AsyncResp>& asyncResp,
     const std::string& ethIfaceId,
     const dbus::utility::ManagedObjectType& dbusData,
     EthernetInterfaceData& ethData,
-    boost::container::flat_set<IPv4AddressData>& ipv4Config)
+    boost::container::flat_set<IPv4AddressData>& ipv4Config,
+    boost::container::flat_set<IPv6AddressData>& ipv6Config)
 {
     bool idFound = false;
     for (const auto& objpath : dbusData)
@@ -174,71 +176,131 @@ inline bool extractHypervisorInterfaceData(
         {
             std::pair<boost::container::flat_set<IPv4AddressData>::iterator,
                       bool>
-                it = ipv4Config.insert(IPv4AddressData{});
+                v4Itr = ipv4Config.insert(IPv4AddressData{});
 
-            IPv4AddressData& ipv4Address = *it.first;
-            if (objpath.first == "/xyz/openbmc_project/network/hypervisor/" +
-                                     ethIfaceId + "/ipv4/addr0")
+            std::pair<boost::container::flat_set<IPv6AddressData>::iterator,
+                      bool>
+                v6Itr = ipv6Config.insert(IPv6AddressData{});
+
+            IPv4AddressData& ipv4Address = *v4Itr.first;
+            IPv6AddressData& ipv6Address = *v6Itr.first;
+
+            for (std::string protocol : {"ipv4", "ipv6"})
             {
-                idFound = true;
-                if (interface.first == "xyz.openbmc_project.Network.IP")
+                std::string ipAddrObj =
+                    "/xyz/openbmc_project/network/hypervisor/";
+                ipAddrObj.append(ethIfaceId);
+                ipAddrObj.append("/");
+                ipAddrObj.append(protocol);
+                ipAddrObj.append("/addr0");
+                if (objpath.first == ipAddrObj)
                 {
-
-                    for (const auto& property : interface.second)
+                    idFound = true;
+                    if (interface.first == "xyz.openbmc_project.Network.IP")
                     {
-                        if (property.first == "Address")
+
+                        for (const auto& property : interface.second)
                         {
-                            const std::string* address =
-                                std::get_if<std::string>(&property.second);
-                            if (address != nullptr)
+                            if (property.first == "Address")
                             {
-                                ipv4Address.address = *address;
+                                const std::string* address =
+                                    std::get_if<std::string>(&property.second);
+                                if (address == nullptr)
+                                {
+                                    BMCWEB_LOG_ERROR
+                                        << "extractHypervisorInterfaceData: "
+                                           "Address property is not found";
+                                    messages::internalError(asyncResp->res);
+                                    return false;
+                                }
+                                if (protocol == "ipv4")
+                                {
+                                    ipv4Address.address = *address;
+                                }
+                                else if (protocol == "ipv6")
+                                {
+                                    ipv6Address.address = *address;
+                                }
                             }
-                        }
-                        else if (property.first == "PrefixLength")
-                        {
-                            const uint8_t* mask =
-                                std::get_if<uint8_t>(&property.second);
-                            if (mask != nullptr)
+                            else if (property.first == "PrefixLength")
                             {
-                                ipv4Address.netmask = getNetmask(*mask);
+                                const uint8_t* mask =
+                                    std::get_if<uint8_t>(&property.second);
+                                if (mask == nullptr)
+                                {
+                                    BMCWEB_LOG_ERROR
+                                        << "extractHypervisorInterfaceData: "
+                                           "PrefixLength property is not found";
+                                    messages::internalError(asyncResp->res);
+                                    return false;
+                                }
+                                if (protocol == "ipv4")
+                                {
+                                    ipv4Address.netmask = getNetmask(*mask);
+                                }
+                                else if (protocol == "ipv6")
+                                {
+                                    ipv6Address.prefixLength = *mask;
+                                }
                             }
-                        }
-                        else if (property.first == "Gateway")
-                        {
-                            const std::string* gateway =
-                                std::get_if<std::string>(&property.second);
-                            if (gateway != nullptr)
+                            else if (property.first == "Gateway")
                             {
-                                ipv4Address.gateway = *gateway;
+                                const std::string* gateway =
+                                    std::get_if<std::string>(&property.second);
+                                if (gateway == nullptr)
+                                {
+                                    BMCWEB_LOG_ERROR
+                                        << "extractHypervisorInterfaceData: "
+                                           "Gateway property is not found";
+                                    messages::internalError(asyncResp->res);
+                                    return false;
+                                }
+                                if (protocol == "ipv4")
+                                {
+                                    ipv4Address.gateway = *gateway;
+                                }
                             }
-                        }
-                        else
-                        {
-                            BMCWEB_LOG_DEBUG
-                                << "Got extra property: " << property.first
-                                << " on the " << objpath.first.str << " object";
+                            else
+                            {
+                                BMCWEB_LOG_DEBUG
+                                    << "Got extra property: " << property.first
+                                    << " on the " << objpath.first.str
+                                    << " object";
+                            }
                         }
                     }
-                }
-                else if (interface.first == "xyz.openbmc_project.Object.Enable")
-                {
-                    for (const auto& property : interface.second)
+                    else if (interface.first ==
+                             "xyz.openbmc_project.Object.Enable")
                     {
-                        if (property.first == "Enabled")
+                        for (const auto& property : interface.second)
                         {
-                            const bool* enabled =
-                                std::get_if<bool>(&property.second);
-                            if (enabled != nullptr)
+                            if (property.first == "Enabled")
                             {
-                                ipv4Address.isActive = *enabled;
+                                const bool* enabled =
+                                    std::get_if<bool>(&property.second);
+                                if (enabled == nullptr)
+                                {
+                                    BMCWEB_LOG_ERROR
+                                        << "extractHypervisorInterfaceData: "
+                                           "Enabled property is not found";
+                                    messages::internalError(asyncResp->res);
+                                    return false;
+                                }
+                                if (protocol == "ipv4")
+                                {
+                                    ipv4Address.isActive = *enabled;
+                                }
+                                else if (protocol == "ipv6")
+                                {
+                                    ipv6Address.isActive = *enabled;
+                                }
                             }
                         }
                     }
                 }
             }
-            else if (objpath.first ==
-                     "/xyz/openbmc_project/network/hypervisor/" + ethIfaceId)
+            if (objpath.first ==
+                "/xyz/openbmc_project/network/hypervisor/" + ethIfaceId)
             {
                 if (interface.first ==
                     "xyz.openbmc_project.Network.EthernetInterface")
@@ -250,18 +312,55 @@ inline bool extractHypervisorInterfaceData(
                         {
                             const std::string* dhcpEnabled =
                                 std::get_if<std::string>(&property.second);
-                            if (dhcpEnabled != nullptr)
+                            if (dhcpEnabled == nullptr)
                             {
-                                ethData.dhcpEnabled = *dhcpEnabled;
-                                if (!translateDhcpEnabledToBool(*dhcpEnabled,
-                                                                true))
-                                {
-                                    ipv4Address.origin = "Static";
-                                }
-                                else
-                                {
-                                    ipv4Address.origin = "DHCP";
-                                }
+                                BMCWEB_LOG_ERROR
+                                    << "extractHypervisorInterfaceData: "
+                                       "DHCPEnabled property is not found";
+                                messages::internalError(asyncResp->res);
+                                return false;
+                            }
+                            ethData.dhcpEnabled = *dhcpEnabled;
+                            if (!translateDhcpEnabledToBool(*dhcpEnabled, true))
+                            {
+                                ipv4Address.origin = "Static";
+                            }
+                            else
+                            {
+                                ipv4Address.origin = "DHCP";
+                            }
+
+                            if (!translateDhcpEnabledToBool(*dhcpEnabled,
+                                                            false))
+                            {
+                                ipv6Address.origin = "Static";
+                            }
+                            else
+                            {
+                                ipv6Address.origin = "DHCP";
+                            }
+                        }
+                        else if (property.first == "DefaultGateway6")
+                        {
+                            const std::string* defaultGateway6 =
+                                std::get_if<std::string>(&property.second);
+                            if (defaultGateway6 == nullptr)
+                            {
+                                BMCWEB_LOG_ERROR
+                                    << "extractHypervisorInterfaceData: "
+                                       "DefaultGateway6 property is not found";
+                                messages::internalError(asyncResp->res);
+                                return false;
+                            }
+                            std::string defaultGateway6Str = *defaultGateway6;
+                            if (defaultGateway6Str.empty())
+                            {
+                                ethData.ipv6DefaultGateway = "::";
+                            }
+                            else
+                            {
+                                ethData.ipv6DefaultGateway =
+                                    defaultGateway6Str;
                             }
                         }
                     }
@@ -280,10 +379,15 @@ inline bool extractHypervisorInterfaceData(
                         {
                             const std::string* hostname =
                                 std::get_if<std::string>(&property.second);
-                            if (hostname != nullptr)
+                            if (hostname == nullptr)
                             {
-                                ethData.hostName = *hostname;
+                                BMCWEB_LOG_ERROR
+                                    << "extractHypervisorInterfaceData: "
+                                       "HostName property is not found";
+                                messages::internalError(asyncResp->res);
+                                return false;
                             }
+                            ethData.hostName = *hostname;
                         }
                     }
                 }
@@ -301,30 +405,32 @@ inline bool extractHypervisorInterfaceData(
  * into JSON
  */
 template <typename CallbackFunc>
-void getHypervisorIfaceData(const std::string& ethIfaceId,
+void getHypervisorIfaceData(const std::shared_ptr<bmcweb::AsyncResp>& asyncResp,
+                            const std::string& ethIfaceId,
                             CallbackFunc&& callback)
 {
     crow::connections::systemBus->async_method_call(
-        [ethIfaceId{std::string{ethIfaceId}},
+        [asyncResp, ethIfaceId{std::string{ethIfaceId}},
          callback{std::forward<CallbackFunc>(callback)}](
             const boost::system::error_code error,
             const dbus::utility::ManagedObjectType& resp) {
         EthernetInterfaceData ethData{};
         boost::container::flat_set<IPv4AddressData> ipv4Data;
+        boost::container::flat_set<IPv6AddressData> ipv6Data;
         if (error)
         {
-            callback(false, ethData, ipv4Data);
+            callback(false, ethData, ipv4Data, ipv6Data);
             return;
         }
 
-        bool found =
-            extractHypervisorInterfaceData(ethIfaceId, resp, ethData, ipv4Data);
+        bool found = extractHypervisorInterfaceData(
+            asyncResp, ethIfaceId, resp, ethData, ipv4Data, ipv6Data);
 
         if (!found)
         {
             BMCWEB_LOG_DEBUG << "Hypervisor Interface not found";
         }
-        callback(found, ethData, ipv4Data);
+        callback(found, ethData, ipv4Data, ipv6Data);
         },
         "xyz.openbmc_project.Network.Hypervisor",
         "/xyz/openbmc_project/network/hypervisor",
@@ -358,27 +464,29 @@ inline void
 }
 
 /**
- * @brief Creates a static IPv4 entry
+ * @brief Creates a static IPv4/v6 entry
  *
- * @param[in] ifaceId      Id of interface upon which to create the IPv4 entry
- * @param[in] prefixLength IPv4 prefix syntax for the subnet mask
- * @param[in] gateway      IPv4 address of this interfaces gateway
- * @param[in] address      IPv4 address to assign to this interface
+ * @param[in] ifaceId      Id of interface upon which to create the IPv4/v6 entry
+ * @param[in] prefixLength IPv4/v6 prefix length
+ * @param[in] gateway      IPv4/v6 address of this interfaces gateway
+ * @param[in] address      IPv4/v6 address to assign to this interface
  * @param[io] asyncResp    Response object that will be returned to client
  *
  * @return None
  */
 inline void
-    createHypervisorIPv4(const std::string& ifaceId, const uint8_t prefixLength,
-                         const std::string& gateway, const std::string& address,
-                         const std::shared_ptr<bmcweb::AsyncResp>& asyncResp)
+    createHypervisorIP(const std::string& ifaceId, const uint8_t prefixLength,
+                       const std::string& gateway, const std::string& address,
+                       const std::string& protocol,
+                       const std::shared_ptr<bmcweb::AsyncResp>& asyncResp)
 {
     crow::connections::systemBus->async_method_call(
-        [asyncResp, ifaceId](const boost::system::error_code ec) {
+        [asyncResp, prefixLength, gateway, ifaceId,
+         address](const boost::system::error_code ec) {
         if (ec)
         {
             BMCWEB_LOG_DEBUG
-                << "createHypervisorIPv4 failed: ec: " << ec.message()
+                << "createHypervisorIP failed: ec: " << ec.message()
                 << " ec.value= " << ec.value();
             if ((ec == boost::system::errc::invalid_argument) ||
                 (ec == boost::system::errc::argument_list_too_long))
@@ -399,13 +507,12 @@ inline void
         },
         "xyz.openbmc_project.Network.Hypervisor",
         "/xyz/openbmc_project/network/hypervisor/" + ifaceId,
-        "xyz.openbmc_project.Network.IP.Create", "IP",
-        "xyz.openbmc_project.Network.IP.Protocol.IPv4", address, prefixLength,
-        gateway);
+        "xyz.openbmc_project.Network.IP.Create", "IP", protocol, address,
+        prefixLength, gateway);
 }
 
 /**
- * @brief Deletes given IPv4 interface
+ * @brief Deletes given IPv4/v6 interface
  *
  * @param[in] ifaceId     Id of interface whose IP should be deleted
  * @param[io] asyncResp   Response object that will be returned to client
@@ -413,8 +520,8 @@ inline void
  * @return None
  */
 inline void
-    deleteHypervisorIPv4(const std::string& ifaceId,
-                         const std::shared_ptr<bmcweb::AsyncResp>& asyncResp)
+    deleteHypervisorIP(const std::string& ifaceId, const std::string& protocol,
+                       const std::shared_ptr<bmcweb::AsyncResp>& asyncResp)
 {
     crow::connections::systemBus->async_method_call(
         [asyncResp, ifaceId](const boost::system::error_code ec) {
@@ -431,14 +538,16 @@ inline void
             "EthernetInterface");
         },
         "xyz.openbmc_project.Network.Hypervisor",
-        "/xyz/openbmc_project/network/hypervisor/" + ifaceId + "/ipv4/addr0",
+        "/xyz/openbmc_project/network/hypervisor/" + ifaceId + "/" + protocol +
+            "/addr0",
         "xyz.openbmc_project.Object.Delete", "Delete");
 }
 
 inline void parseInterfaceData(
     nlohmann::json& jsonResponse, const std::string& ifaceId,
     const EthernetInterfaceData& ethData,
-    const boost::container::flat_set<IPv4AddressData>& ipv4Data)
+    const boost::container::flat_set<IPv4AddressData>& ipv4Data,
+    const boost::container::flat_set<IPv6AddressData>& ipv6Data)
 {
     jsonResponse["Id"] = ifaceId;
     jsonResponse["@odata.id"] =
@@ -447,25 +556,116 @@ inline void parseInterfaceData(
     jsonResponse["DHCPv4"]["DHCPEnabled"] =
         translateDhcpEnabledToBool(ethData.dhcpEnabled, true);
 
+    if (translateDhcpEnabledToBool(ethData.dhcpEnabled, false))
+    {
+        jsonResponse["DHCPv6"]["OperatingMode"] = "Enabled";
+    }
+    else
+    {
+        jsonResponse["DHCPv6"]["OperatingMode"] = "Disabled";
+    }
+
     nlohmann::json& ipv4Array = jsonResponse["IPv4Addresses"];
     nlohmann::json& ipv4StaticArray = jsonResponse["IPv4StaticAddresses"];
     ipv4Array = nlohmann::json::array();
     ipv4StaticArray = nlohmann::json::array();
+    bool ipv4IsActive = false;
     for (const auto& ipv4Config : ipv4Data)
     {
-        jsonResponse["InterfaceEnabled"] = ipv4Config.isActive;
-        ipv4Array.push_back({{"AddressOrigin", ipv4Config.origin},
-                             {"SubnetMask", ipv4Config.netmask},
-                             {"Address", ipv4Config.address},
-                             {"Gateway", ipv4Config.gateway}});
+        ipv4IsActive = ipv4Config.isActive;
+        nlohmann::json::object_t ipv4;
+        ipv4["AddressOrigin"] = ipv4Config.origin;
+        ipv4["SubnetMask"] = ipv4Config.netmask;
+        ipv4["Address"] = ipv4Config.address;
+        ipv4["Gateway"] = ipv4Config.gateway;
         if (ipv4Config.origin == "Static")
         {
-            ipv4StaticArray.push_back({{"AddressOrigin", ipv4Config.origin},
-                                       {"SubnetMask", ipv4Config.netmask},
-                                       {"Address", ipv4Config.address},
-                                       {"Gateway", ipv4Config.gateway}});
+            ipv4StaticArray.push_back(ipv4);
+        }
+        ipv4Array.push_back(std::move(ipv4));
+    }
+
+    std::string ipv6GatewayStr = ethData.ipv6DefaultGateway;
+    if (ipv6GatewayStr.empty())
+    {
+        ipv6GatewayStr = "::";
+    }
+
+    jsonResponse["IPv6DefaultGateway"] = ipv6GatewayStr;
+
+    nlohmann::json& ipv6Array = jsonResponse["IPv6Addresses"];
+    nlohmann::json& ipv6StaticArray = jsonResponse["IPv6StaticAddresses"];
+    ipv6Array = nlohmann::json::array();
+    ipv6StaticArray = nlohmann::json::array();
+    nlohmann::json& ipv6AddrPolicyTable =
+        jsonResponse["IPv6AddressPolicyTable"];
+    ipv6AddrPolicyTable = nlohmann::json::array();
+    bool ipv6IsActive = false;
+
+    for (auto& ipv6Config : ipv6Data)
+    {
+        ipv6IsActive = ipv6Config.isActive;
+        ipv6Array.push_back({{"Address", ipv6Config.address},
+                             {"PrefixLength", ipv6Config.prefixLength},
+                             {"AddressOrigin", ipv6Config.origin}});
+        if (ipv6Config.origin == "Static")
+        {
+            ipv6StaticArray.push_back(
+                {{"Address", ipv6Config.address},
+                 {"PrefixLength", ipv6Config.prefixLength}});
         }
     }
+
+    if (ipv4IsActive)
+    {
+        jsonResponse["InterfaceEnabled"] = true;
+    }
+    else
+    {
+        if (ipv6IsActive)
+        {
+            jsonResponse["InterfaceEnabled"] = true;
+        }
+        else
+        {
+            jsonResponse["InterfaceEnabled"] = false;
+        }
+    }
+}
+
+inline void setIpv6DhcpOperatingMode(
+    const std::string& ifaceId, const std::string& operatingMode,
+    const std::shared_ptr<bmcweb::AsyncResp>& asyncResp)
+{
+    std::string ipv6DHCP;
+    if (operatingMode == "Enabled")
+    {
+        ipv6DHCP = "xyz.openbmc_project.Network.EthernetInterface.DHCPConf.v6";
+    }
+    else if (operatingMode == "Disabled")
+    {
+        ipv6DHCP =
+            "xyz.openbmc_project.Network.EthernetInterface.DHCPConf.none";
+    }
+    else
+    {
+        messages::propertyValueIncorrect(asyncResp->res, "OperatingMode",
+                                         operatingMode);
+        return;
+    }
+    crow::connections::systemBus->async_method_call(
+        [asyncResp](const boost::system::error_code ec) {
+            if (ec)
+            {
+                messages::internalError(asyncResp->res);
+                return;
+            }
+        },
+        "xyz.openbmc_project.Network.Hypervisor",
+        "/xyz/openbmc_project/network/hypervisor/" + ifaceId,
+        "org.freedesktop.DBus.Properties", "Set",
+        "xyz.openbmc_project.Network.EthernetInterface", "DHCPEnabled",
+        std::variant<std::string>(ipv6DHCP));
 }
 
 inline void setDHCPEnabled(const std::string& ifaceId,
@@ -612,8 +812,9 @@ inline void handleHypervisorIPv4StaticPatch(
             << " - ip: " << *address << "; gateway: " << *gateway
             << "; prefix length: " << static_cast<int64_t>(prefixLength);
 
-        createHypervisorIPv4(ifaceId, prefixLength, *gateway, *address,
-                             asyncResp);
+        createHypervisorIP(ifaceId, prefixLength, *gateway, *address,
+                           "xyz.openbmc_project.Network.IP.Protocol.IPv4",
+                           asyncResp);
         // Set the DHCPEnabled to false since the Static IPv4 is set
         setDHCPEnabled(ifaceId, false, asyncResp);
     }
@@ -621,7 +822,85 @@ inline void handleHypervisorIPv4StaticPatch(
     {
         if (thisJson.is_null())
         {
-            deleteHypervisorIPv4(ifaceId, asyncResp);
+            deleteHypervisorIP(ifaceId, "ipv4", asyncResp);
+        }
+    }
+}
+
+inline void handleHypervisorIPv6StaticPatch(
+    const crow::Request& req, const std::string& ifaceId,
+    const nlohmann::json& input,
+    const std::shared_ptr<bmcweb::AsyncResp>& asyncResp)
+{
+    if ((!input.is_array()) || input.empty())
+    {
+        messages::propertyValueTypeError(asyncResp->res, input.dump(),
+                                         "IPv6StaticAddresses");
+        return;
+    }
+
+    // Hypervisor considers the first IP address in the array list
+    // as the Hypervisor's virtual management interface supports single IPv4
+    // address
+    const nlohmann::json& thisJson = input[0];
+
+    // For the error string
+    std::string pathString = "IPv6StaticAddresses/1";
+
+    if (!thisJson.is_null() && !thisJson.empty())
+    {
+        std::optional<std::string> address;
+        std::optional<uint8_t> prefixLen;
+        std::optional<std::string> gateway;
+        nlohmann::json thisJsonCopy = thisJson;
+        if (!json_util::readJson(thisJsonCopy, asyncResp->res, "Address",
+                                 address, "PrefixLength", prefixLen, "Gateway",
+                                 gateway))
+        {
+            messages::propertyValueFormatError(
+                asyncResp->res,
+                thisJson.dump(2, ' ', true,
+                              nlohmann::json::error_handler_t::replace),
+                pathString);
+            return;
+        }
+
+        if (!address)
+        {
+            messages::propertyMissing(asyncResp->res, pathString + "/Address");
+            return;
+        }
+
+        if (!gateway)
+        {
+            // Since gateway is optional, replace it with default value
+            *gateway = "::";
+        }
+
+        if (!prefixLen)
+        {
+            messages::propertyMissing(asyncResp->res,
+                                      pathString + "/PrefixLength");
+            return;
+        }
+
+        BMCWEB_LOG_DEBUG
+            << "INFO: Static ip configuration request from client: "
+            << req.session->clientIp << " - ip: " << *address
+            << ";gateway: " << *gateway
+            << "; prefix length: " << static_cast<int64_t>(*prefixLen);
+
+        createHypervisorIP(ifaceId, *prefixLen, *gateway, *address,
+                           "xyz.openbmc_project.Network.IP.Protocol.IPv6",
+                           asyncResp);
+        // Set the DHCPEnabled to false since the Static IPv6 is set
+        setIpv6DhcpOperatingMode(ifaceId, "Disabled", asyncResp);
+    }
+    else
+    {
+        if (thisJson.is_null())
+        {
+            deleteHypervisorIP(ifaceId, "ipv6", asyncResp);
         }
     }
 }
@@ -766,10 +1045,12 @@ inline void requestRoutesHypervisorSystems(App& app)
             return;
         }
         getHypervisorIfaceData(
-            id,
+            asyncResp, id,
             [asyncResp, ifaceId{std::string(id)}](
                 const bool& success, const EthernetInterfaceData& ethData,
-                const boost::container::flat_set<IPv4AddressData>& ipv4Data) {
+                const boost::container::flat_set<IPv4AddressData>& ipv4Data,
+                const boost::container::flat_set<IPv6AddressData>&
+                    ipv6Data) {
             if (!success)
             {
                 messages::resourceNotFound(asyncResp->res, "EthernetInterface",
@@ -777,12 +1058,12 @@ inline void requestRoutesHypervisorSystems(App& app)
                 return;
             }
             asyncResp->res.jsonValue["@odata.type"] =
-                "#EthernetInterface.v1_6_0.EthernetInterface";
+                "#EthernetInterface.v1_8_0.EthernetInterface";
             asyncResp->res.jsonValue["Name"] = "Hypervisor Ethernet Interface";
             asyncResp->res.jsonValue["Description"] =
                 "Hypervisor's Virtual Management Ethernet Interface";
             parseInterfaceData(asyncResp->res.jsonValue, ifaceId, ethData,
-                               ipv4Data);
+                               ipv4Data, ipv6Data);
             });
         });
 
@@ -800,14 +1081,18 @@ inline void requestRoutesHypervisorSystems(App& app)
         }
         std::optional<std::string> hostName;
         std::optional<std::vector<nlohmann::json>> ipv4StaticAddresses;
+        std::optional<std::vector<nlohmann::json>> ipv6StaticAddresses;
         std::optional<nlohmann::json> ipv4Addresses;
         std::optional<nlohmann::json> dhcpv4;
+        std::optional<nlohmann::json> dhcpv6;
         std::optional<bool> ipv4DHCPEnabled;
+        std::optional<std::string> ipv6OperatingMode;
 
         if (!json_util::readJsonPatch(req, asyncResp->res, "HostName", hostName,
-                                      "IPv4StaticAddresses",
-                                      ipv4StaticAddresses, "IPv4Addresses",
-                                      ipv4Addresses, "DHCPv4", dhcpv4))
+                                      "IPv4StaticAddresses", ipv4StaticAddresses,
+                                      "IPv6StaticAddresses", ipv6StaticAddresses,
+                                      "IPv4Addresses", ipv4Addresses, "DHCPv4",
+                                      dhcpv4, "DHCPv6", dhcpv6))
         {
             return;
         }
@@ -827,14 +1112,27 @@ inline void requestRoutesHypervisorSystems(App& app)
             }
         }
 
+        if (dhcpv6)
+        {
+            if (!json_util::readJson(*dhcpv6, asyncResp->res,
+                                     "OperatingMode", ipv6OperatingMode))
+            {
+                return;
+            }
+        }
+
+
         const std::string& clientIp = req.session->clientIp;
         getHypervisorIfaceData(
-            ifaceId,
-            [clientIp, asyncResp, ifaceId, hostName = std::move(hostName),
+            asyncResp, ifaceId,
+            [req, clientIp, asyncResp, ifaceId, hostName = std::move(hostName),
              ipv4StaticAddresses = std::move(ipv4StaticAddresses),
-             ipv4DHCPEnabled, dhcpv4 = std::move(dhcpv4)](
+             ipv6StaticAddresses = std::move(ipv6StaticAddresses),
+             ipv4DHCPEnabled, dhcpv4 = std::move(dhcpv4),
+             dhcpv6 = std::move(dhcpv6), ipv6OperatingMode](
                 const bool& success, const EthernetInterfaceData& ethData,
-                const boost::container::flat_set<IPv4AddressData>&) {
+                const boost::container::flat_set<IPv4AddressData>&,
+                const boost::container::flat_set<IPv6AddressData>&) {
             if (!success)
             {
                 messages::resourceNotFound(asyncResp->res, "EthernetInterface",
@@ -889,6 +1187,54 @@ inline void requestRoutesHypervisorSystems(App& app)
                                                 asyncResp);
             }
 
+            if (ipv6StaticAddresses)
+            {
+                const nlohmann::json& ipv6Static = *ipv6StaticAddresses;
+                if (ipv6Static.begin() == ipv6Static.end())
+                {
+                    messages::propertyValueTypeError(
+                        asyncResp->res,
+                        ipv6Static.dump(
+                            2, ' ', true,
+                            nlohmann::json::error_handler_t::replace),
+                        "IPv6StaticAddresses");
+                    return;
+                }
+
+                // One and only one hypervisor instance supported
+                if (ipv6Static.size() != 1)
+                {
+                    messages::propertyValueFormatError(
+                        asyncResp->res,
+                        ipv6Static.dump(
+                            2, ' ', true,
+                            nlohmann::json::error_handler_t::replace),
+                        "IPv6StaticAddresses");
+                    return;
+                }
+
+                const nlohmann::json& ipv6Json = ipv6Static[0];
+                // Check if the param is 'null'. If its null, it means
+                // that user wants to delete the IP address. Deleting
+                // the IP address is allowed only if its statically
+                // configured. Deleting the address originated from DHCP
+                // is not allowed.
+                if ((ipv6Json.is_null()) &&
+                    (translateDhcpEnabledToBool(ethData.dhcpEnabled,
+                                                false)))
+                {
+                    BMCWEB_LOG_ERROR
+                        << "Failed to delete on ipv6StaticAddresses "
+                           "as the interface is DHCP enabled";
+                    messages::propertyValueConflict(
+                        asyncResp->res, "IPv6StaticAddresses",
+                        "DHCPEnabled");
+                    return;
+                }
+                handleHypervisorIPv6StaticPatch(req, ifaceId,
+                                                ipv6Static, asyncResp);
+            }
+
             if (hostName)
             {
                 handleHostnamePatch(*hostName, asyncResp);
@@ -897,6 +1243,12 @@ inline void requestRoutesHypervisorSystems(App& app)
             if (dhcpv4)
             {
                 setDHCPEnabled(ifaceId, *ipv4DHCPEnabled, asyncResp);
+            }
+
+            if (dhcpv6)
+            {
+                setIpv6DhcpOperatingMode(ifaceId, *ipv6OperatingMode,
+                                         asyncResp);
             }
             });
         asyncResp->res.result(boost::beast::http::status::accepted);


### PR DESCRIPTION
This PR adds ipv6 support for hypervisor nw configuration & hypervisor IPv6 SLAAC support

https://gerrit.openbmc.org/c/openbmc/bmcweb/+/54109
https://gerrit.openbmc.org/c/openbmc/bmcweb/+/54126