### PR TITLE
1050: bmcweb: Add link Status and Health to PCIe device (#340) with PCIeSlots Link

### DIFF
--- a/redfish-core/lib/pcie_slots.hpp
+++ b/redfish-core/lib/pcie_slots.hpp
@@ -72,6 +72,55 @@ inline std::optional<pcie_slots::SlotTypes>
     return std::nullopt;
 }
 
+inline void
+    addLinkedPcieDevices(const std::shared_ptr<bmcweb::AsyncResp>& asyncResp,
+                         const std::string& slotPath, size_t index)
+{
+    // Collect device associated with this slot and
+    // populate it here
+    crow::connections::systemBus->async_method_call(
+        [asyncResp, index](
+            const boost::system::error_code ec,
+            const std::vector<std::pair<
+                std::string,
+                std::vector<std::pair<std::string, std::vector<std::string>>>>>&
+                subtree) {
+        if (ec)
+        {
+            BMCWEB_LOG_ERROR << "D-Bus response error on GetSubTree " << ec;
+            messages::internalError(asyncResp->res);
+            return;
+        }
+        if (subtree.empty())
+        {
+            BMCWEB_LOG_DEBUG
+                << "Can't find PCIeDevice D-Bus object for given slot";
+            return;
+        }
+
+        // Assuming only one device path per slot.
+        const std::string& pcieDevciePath = std::get<0>(subtree[0]);
+        const std::string pcieDevice =
+            sdbusplus::message::object_path(pcieDevciePath).filename();
+
+        if (pcieDevice.empty())
+        {
+            BMCWEB_LOG_ERROR << "Failed to find / in pcie device path";
+            messages::internalError(asyncResp->res);
+            return;
+        }
+
+        asyncResp->res.jsonValue["Slots"][index]["Links"]["PCIeDevice"] = {
+            {{"@odata.id",
+              "/redfish/v1/Systems/system/PCIeDevices/" + pcieDevice}}};
+        },
+        "xyz.openbmc_project.ObjectMapper",
+        "/xyz/openbmc_project/object_mapper",
+        "xyz.openbmc_project.ObjectMapper", "GetSubTree", slotPath, 0,
+        std::array<const char*, 1>{
+            "xyz.openbmc_project.Inventory.Item.PCIeDevice"});
+}
+
 // We need a global variable to keep track of the actual number of slots,
 // and then use this variable to check if the number of slots in the request
 // is correct
@@ -260,7 +309,11 @@ inline void
         slot["HotPluggable"] = *hotPluggable;
     }
 
+    size_t index = slots.size();
     slots.emplace_back(std::move(slot));
+
+    // Get pcie device link
+    addLinkedPcieDevices(asyncResp, pcieSlotPath, index);
 
     // Get pcie slot location indicator state
     nlohmann::json& slotLIA = slots.back();


### PR DESCRIPTION
This PR contains 2 commits as the second one requires the first.

1. Add Pcie slot to Pcie device link - https://github.com/ibm-openbmc/bmcweb/commit/cc625a7e94736ad5af3750fc21a7c75a91c3ea2d

    This commit implements to detect and populate link between PCIe
    slot and PCIe device attached to that slot.

3.  bmcweb: Add link Status and Health to PCIe device (#340) - https://github.com/ibm-openbmc/bmcweb/commit/a3c00833c2dd424a11f3e8169c2210fd04339f4e

    This commit adds Status and Health elements to the json object of
    PCIe Device when requested to get the device properties. These two
    elements are derived from LinkStatus of the PCIe Slot.