### PR TITLE
1050: bmcweb update `identify` association for LED & Item assciation

### DIFF
--- a/redfish-core/lib/led.hpp
+++ b/redfish-core/lib/led.hpp
@@ -241,7 +241,7 @@ inline void
 
     nlohmann::json& jsonIn = jsonInput["LocationIndicatorActive"];
     dbus::utility::getAssociationEndPoints(
-        objPath + "/identify_led_group",
+        objPath + "/identifying",
         [aResp, &jsonIn](const boost::system::error_code& ec,
                          const dbus::utility::MapperEndPoints& endpoints) {
         if (ec)
@@ -283,7 +283,7 @@ inline void
     BMCWEB_LOG_DEBUG << "Set LocationIndicatorActive";
 
     dbus::utility::getAssociationEndPoints(
-        objPath + "/identify_led_group",
+        objPath + "/identifying",
         [aResp, ledState](const boost::system::error_code& ec,
                           const dbus::utility::MapperEndPoints& endpoints) {
         if (ec)


### PR DESCRIPTION
DBus inventory association uses "/identifying"
instead of "/identify_led_group" according to the latest association interface [1].

[1] https://github.com/openbmc/phosphor-dbus-interfaces/commit/9eb460c6cfc2d7c2feb29c86f4beb31d4c3d9250

upstream: https://gerrit.openbmc.org/c/openbmc/openbmc/+/61068