### PR TITLE
Correct Id parameter for two log services

### DIFF
--- a/redfish-core/lib/log_services.hpp
+++ b/redfish-core/lib/log_services.hpp
@@ -3530,7 +3530,7 @@ inline void requestRoutesBMCJournalLogService(App& app)
             "/redfish/v1/Managers/bmc/LogServices/Journal";
         asyncResp->res.jsonValue["Name"] = "Open BMC Journal Log Service";
         asyncResp->res.jsonValue["Description"] = "BMC Journal Log Service";
-        asyncResp->res.jsonValue["Id"] = "BMC Journal";
+        asyncResp->res.jsonValue["Id"] = "Journal";
         asyncResp->res.jsonValue["OverWritePolicy"] = "WrapsWhenFull";
 
         std::pair<std::string, std::string> redfishDateTimeOffset =
@@ -4839,7 +4839,7 @@ inline void requestRoutesPostCodesLogService(App& app)
             "#LogService.v1_1_0.LogService";
         asyncResp->res.jsonValue["Name"] = "POST Code Log Service";
         asyncResp->res.jsonValue["Description"] = "POST Code Log Service";
-        asyncResp->res.jsonValue["Id"] = "BIOS POST Code Log";
+        asyncResp->res.jsonValue["Id"] = "PostCodes";
         asyncResp->res.jsonValue["OverWritePolicy"] = "WrapsWhenFull";
         asyncResp->res.jsonValue["Entries"]["@odata.id"] =
             "/redfish/v1/Systems/system/LogServices/PostCodes/Entries";


### PR DESCRIPTION
Merged upstream at https://gerrit.openbmc.org/c/openbmc/bmcweb/+/60766 
A similar change was done for 1020, 1030, 1040 

The Journal and EventLog now fail redfish-service-validators new test. Per the specification, the "Id" parameter should match the elements odata id segment in the collection.  The validator now tests for this, and these two fail.

Tested: Redfish service validator now passes.


Change-Id: I463eea7ae7a7dfd6a9d6d562ae4f03dc887a9478