### PR TITLE
1050: Add Get for PCIe properties LinkId and  LinkWidth (#348)(#398)

### DIFF
--- a/redfish-core/lib/pcie.hpp
+++ b/redfish-core/lib/pcie.hpp
@@ -440,6 +440,7 @@ inline void requestRoutesSystemPCIeDevice(App& app)
                         const std::string* prettyName = nullptr;
                         const std::string* locationCode = nullptr;
                         const bool* present = nullptr;
+                        const int64_t* lanesInUse = nullptr;
 
                         const bool success = sdbusplus::unpackPropertiesNoThrow(
                             dbus_utils::UnpackErrorPrinter(), pcieDevProperties,
@@ -448,7 +449,8 @@ inline void requestRoutesSystemPCIeDevice(App& app)
                             "PartNumber", partNumber, "SerialNumber",
                             serialNumber, "Model", model, "SparePartNumber",
                             sparePartNumber, "Name", prettyName, "LocationCode",
-                            locationCode, "Present", present);
+                            locationCode, "Present", present, "LanesInUse",
+                            lanesInUse);
 
                         if (!success)
                         {
@@ -521,6 +523,15 @@ inline void requestRoutesSystemPCIeDevice(App& app)
                             asyncResp->res
                                 .jsonValue["Slot"]["Location"]["PartLocation"]
                                           ["ServiceLabel"] = *locationCode;
+                        }
+
+                        // The default value of LanesInUse is 0, and the field
+                        // will be left as off if it is a default value.
+                        if (lanesInUse != nullptr && *lanesInUse != 0)
+                        {
+                            asyncResp->res
+                                .jsonValue["PCIeInterface"]["LanesInUse"] =
+                                *lanesInUse;
                         }
 
                         // Link status

--- a/redfish-core/lib/pcie_slots.hpp
+++ b/redfish-core/lib/pcie_slots.hpp
@@ -324,11 +324,12 @@ inline void
     const size_t* lanes = nullptr;
     const std::string* slotType = nullptr;
     const bool* hotPluggable = nullptr;
+    const size_t* busId = nullptr;
 
     const bool success = sdbusplus::unpackPropertiesNoThrow(
         dbus_utils::UnpackErrorPrinter(), propertiesList, "Generation",
         generation, "Lanes", lanes, "SlotType", slotType, "HotPluggable",
-        hotPluggable);
+        hotPluggable, "BusId", busId);
 
     if (!success)
     {
@@ -375,6 +376,13 @@ inline void
     if (hotPluggable != nullptr)
     {
         slot["HotPluggable"] = *hotPluggable;
+    }
+
+    if (busId != nullptr)
+    {
+        slot["Oem"]["@odata.type"] = "#OemPCIeSlots.Oem";
+        slot["Oem"]["IBM"]["@odata.type"] = "#OemPCIeSlots.IBM";
+        slot["Oem"]["IBM"]["LinkId"] = *busId;
     }
 
     size_t index = slots.size();

--- a/scripts/update_schemas.py
+++ b/scripts/update_schemas.py
@@ -446,6 +446,15 @@ with open(metadata_index_path, "w") as metadata_index:
     )
     metadata_index.write("    </edmx:Reference>\n")
 
+    metadata_index.write(
+        '    <edmx:Reference Uri="/redfish/v1/schema/OemPCIeSlots_v1.xml">\n'
+    )
+    metadata_index.write('        <edmx:Include Namespace="OemPCIeSlots"/>\n')
+    metadata_index.write(
+        '        <edmx:Include Namespace="OemPCIeSlots.v1_0_0"/>\n'
+    )
+    metadata_index.write("    </edmx:Reference>\n")
+
     metadata_index.write("</edmx:Edmx>\n")
 
 

--- a/static/redfish/v1/$metadata/index.xml
+++ b/static/redfish/v1/$metadata/index.xml
@@ -2866,4 +2866,8 @@
         <edmx:Include Namespace="OemMessage"/>
         <edmx:Include Namespace="OemMessage.v1_0_0"/>
     </edmx:Reference>
+    <edmx:Reference Uri="/redfish/v1/schema/OemPCIeSlots_v1.xml">
+        <edmx:Include Namespace="OemPCIeSlots"/>
+        <edmx:Include Namespace="OemPCIeSlots.v1_0_0"/>
+    </edmx:Reference>
 </edmx:Edmx>

--- a/static/redfish/v1/JsonSchemas/OemPCIeSlots/index.json
+++ b/static/redfish/v1/JsonSchemas/OemPCIeSlots/index.json
@@ -1,0 +1,65 @@
+{
+    "$id": "http://redfish.dmtf.org/schemas/v1/OemPCIeSlots.json",
+    "$schema": "http://redfish.dmtf.org/schemas/v1/redfish-schema-v1.json",
+    "copyright": "Copyright 2014-2019 DMTF. For the full DMTF copyright policy, see http://www.dmtf.org/about/policies/copyright",
+    "definitions": {
+        "IBM": {
+            "additionalProperties": true,
+            "description": "Oem properties for IBM.",
+            "patternProperties": {
+                "^([a-zA-Z_][a-zA-Z0-9_]*)?@(odata|Redfish|Message)\\.[a-zA-Z_][a-zA-Z0-9_]*$": {
+                    "description": "This property shall specify a valid odata or Redfish property.",
+                    "type": [
+                        "array",
+                        "boolean",
+                        "integer",
+                        "number",
+                        "null",
+                        "object",
+                        "string"
+                    ]
+                }
+            },
+            "properties": {
+                "LinkId": {
+                    "description": "An identifier to detect the PCIe bus linked to the slot.",
+                    "readonly": true,
+                    "type": "integer"
+                }
+            },
+            "type": "object"
+        },
+        "Oem": {
+            "additionalProperties": true,
+            "description": "OemPCIeSlots Oem properties.",
+            "patternProperties": {
+                "^([a-zA-Z_][a-zA-Z0-9_]*)?@(odata|Redfish|Message)\\.[a-zA-Z_][a-zA-Z0-9_]*$": {
+                    "description": "This property shall specify a valid odata or Redfish property.",
+                    "type": [
+                        "array",
+                        "boolean",
+                        "integer",
+                        "number",
+                        "null",
+                        "object",
+                        "string"
+                    ]
+                }
+            },
+            "properties": {
+                "IBM": {
+                    "anyOf": [
+                        {
+                            "$ref": "#/definitions/IBM"
+                        },
+                        {
+                            "type": "null"
+                        }
+                    ]
+                }
+            },
+            "type": "object"
+        }
+    },
+    "title": "#OemPCIeSlots"
+}

--- a/static/redfish/v1/schema/OemPCIeSlots_v1.xml
+++ b/static/redfish/v1/schema/OemPCIeSlots_v1.xml
@@ -1,0 +1,52 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<edmx:Edmx xmlns:edmx="http://docs.oasis-open.org/odata/ns/edmx" Version="4.0">
+
+  <edmx:Reference Uri="http://docs.oasis-open.org/odata/odata/v4.0/errata03/csd01/complete/vocabularies/Org.OData.Core.V1.xml">
+    <edmx:Include Namespace="Org.OData.Core.V1" Alias="OData"/>
+  </edmx:Reference>
+  <edmx:Reference Uri="http://docs.oasis-open.org/odata/odata/v4.0/errata03/csd01/complete/vocabularies/Org.OData.Measures.V1.xml">
+    <edmx:Include Namespace="Org.OData.Measures.V1" Alias="Measures"/>
+  </edmx:Reference>
+  <edmx:Reference Uri="http://redfish.dmtf.org/schemas/v1/RedfishExtensions_v1.xml">
+    <edmx:Include Namespace="RedfishExtensions.v1_0_0" Alias="Redfish"/>
+  </edmx:Reference>
+    <edmx:Reference Uri="http://redfish.dmtf.org/schemas/v1/PCIeSlots_v1.xml">
+        <edmx:Include Namespace="PCIeSlots"/>
+        <edmx:Include Namespace="PCIeSlots.v1_5_0"/>
+    </edmx:Reference>
+  <edmx:Reference Uri="http://redfish.dmtf.org/schemas/v1/Resource_v1.xml">
+    <edmx:Include Namespace="Resource"/>
+    <edmx:Include Namespace="Resource.v1_0_0"/>
+  </edmx:Reference>
+
+  <edmx:DataServices>
+
+    <Schema xmlns="http://docs.oasis-open.org/odata/ns/edm" Namespace="OemPCIeSlots">
+      <Annotation Term="Redfish.OwningEntity" String="IBM"/>
+    </Schema>
+
+    <Schema xmlns="http://docs.oasis-open.org/odata/ns/edm" Namespace="OemPCIeSlots.v1_0_0">
+      <Annotation Term="Redfish.OwningEntity" String="IBM"/>
+
+      <ComplexType Name="Oem" BaseType="Resource.OemObject">
+        <Annotation Term="OData.AdditionalProperties" Bool="true"/>
+        <Annotation Term="OData.Description" String="OemPCIeSlots Oem properties."/>
+        <Annotation Term="OData.AutoExpand"/>
+        <Property Name="IBM" Type="OemPCIeSlots.IBM"/>
+      </ComplexType>
+
+      <ComplexType Name="IBM" BaseType="Resource.OemObject">
+        <Annotation Term="OData.AdditionalProperties" Bool="true" />
+        <Annotation Term="OData.Description" String="Oem properties for IBM." />
+        <Annotation Term="OData.AutoExpand"/>
+
+        <Property Name="LinkId" Type="OemPCIeSlots.IBM">
+          <Annotation Term="OData.Permissions" EnumMember="OData.Permission/Read"/>
+          <Annotation Term="OData.Description" String="Number of PCIe lanes in use."/>
+        </Property>
+      </ComplexType>
+
+    </Schema>
+
+  </edmx:DataServices>
+</edmx:Edmx>


### PR DESCRIPTION
Added Redfish OEM.IBM property 'LinkId' to PCIeSlots under redfish/v1/Chassis. LinkId maps to dbus BusId property for the Inventory.Item.PCIeSlots interface.

Added Redfish property 'LanesInUse' to PCIeDevices under redfish/v1/Systems. LanesInUse maps to dbus LanesInUse property for the Inventory.Item.PCIeDevice interface. Note: GUI might map this property to 'LinkWidth'

`LinkWidth`: https://gerrit.openbmc.org/c/openbmc/bmcweb/+/58753
`BusId`:     IBM OEM

Tested:
1) Redfish validator passed

2) Curl testing
A)
curl -k <token> https://$bmc/redfish/v1/Chassis/chassis/PCIeSlots ...
    {
      "Links": {
        "PCIeDevice": [
          {
            "@odata.id": "/redfish/v1/Systems/system/PCIeDevices/pcie_card8"
          }
        ],
      ...
      "Oem": {
        "@odata.type": "#OemPCIeSlots.Oem",
        "IBM": {
          "@odata.type": "#OemPCIeSlots.IBM",
          "LinkId": 0
        }
      },
      "SlotType": "FullLength"
    },
...

B)
curl -k <token> https://$bmc/redfish/v1/Systems/system/PCIeDevices/pcie_card7 {
  "@odata.id": "/redfish/v1/Systems/system/PCIeDevices/pcie_card7",
  "@odata.type": "#PCIeDevice.v1_9_0.PCIeDevice",
...
  "PCIeInterface": {
    "LanesInUse": 0
  },
...
}