### PR TITLE
1050: bmcweb hostconsole websocket access issue

### DIFF
--- a/http/routing.hpp
+++ b/http/routing.hpp
@@ -1267,7 +1267,7 @@ class Router
         }
 
         if ((rules[ruleIndex]->getMethods() &
-             (1U << static_cast<size_t>(req.method()))) == 0)
+             (static_cast<size_t>(req.method()))) == 0)
         {
             BMCWEB_LOG_DEBUG << "Rule found but method mismatch: " << req.url
                              << " with " << req.methodString() << "("


### PR DESCRIPTION
The recent changes related to using new verb class in router missed to remove the method value shifting as per the new values.

Testing:
    Tested on machine and hostconsole is accessible
    through the GUI.

Fix was reported in https://github.com/openbmc/bmcweb/issues/243 and upstream work is in progress.