### PR TITLE
Add missing usage of new verb class in router

### DIFF
--- a/http/routing.hpp
+++ b/http/routing.hpp
@@ -1267,11 +1267,11 @@ class Router
         }
 
         if ((rules[ruleIndex]->getMethods() &
-             (1U << static_cast<size_t>(req.method()))) == 0)
+             (1U << static_cast<size_t>(*verb))) == 0)
         {
             BMCWEB_LOG_DEBUG << "Rule found but method mismatch: " << req.url
                              << " with " << req.methodString() << "("
-                             << static_cast<uint32_t>(req.method()) << ") / "
+                             << static_cast<uint32_t>(*verb) << ") / "
                              << rules[ruleIndex]->getMethods();
             res.result(boost::beast::http::status::not_found);
             res.end();
@@ -1279,7 +1279,7 @@ class Router
         }
 
         BMCWEB_LOG_DEBUG << "Matched rule (upgrade) '" << rules[ruleIndex]->rule
-                         << "' " << static_cast<uint32_t>(req.method()) << " / "
+                         << "' " << static_cast<uint32_t>(*verb) << " / "
                          << rules[ruleIndex]->getMethods();
 
         // any uncaught exceptions become 500s
@@ -1362,7 +1362,7 @@ class Router
         RoutingParams params = std::move(foundRoute.route.params);
 
         BMCWEB_LOG_DEBUG << "Matched rule '" << rule.rule << "' "
-                         << static_cast<uint32_t>(req.method()) << " / "
+                         << static_cast<uint32_t>(*verb) << " / "
                          << rule.getMethods();
 
         if (req.session == nullptr)


### PR DESCRIPTION
Despite introduction of a new enum class containing method verbs, some functions were still using the one from Boost. This had caused erratic behaviour when trying to create a websocket (e.g. /nbd/<str>), because enum value of old type was compared to the one of new type. This change fixes that.

Tested:
    Verified that websockets are now created without errors and access
    hostconsole from the GUI.
    
    Upstream work:
     - Cherry-picked following commit from upstream and tested
     https://github.com/openbmc/bmcweb/commit/1c99da037b2242c6fbad3441038081c5703dc1e9

Change-Id: I52c874de9b02463618143d3b031f5c795dd42ad8