### PR TITLE
Add system name in the Redfish Systems route

### DIFF
--- a/redfish-core/lib/systems.hpp
+++ b/redfish-core/lib/systems.hpp
@@ -2429,22 +2429,17 @@ inline void requestRoutesSystems(App& app)
     /**
      * Functions triggers appropriate requests on DBus
      */
-    BMCWEB_ROUTE(app, "/redfish/v1/Systems/<str>/")
+    BMCWEB_ROUTE(app, "/redfish/v1/Systems/system/")
         .privileges(redfish::privileges::getComputerSystem)
         .methods(boost::beast::http::verb::get)(
             [&app](const crow::Request& req,
-                   const std::shared_ptr<bmcweb::AsyncResp>& asyncResp,
-                   const std::string& systemName) {
+                   const std::shared_ptr<bmcweb::AsyncResp>& asyncResp) {
         if (!redfish::setUpRedfishRoute(app, req, asyncResp))
         {
             return;
         }
-        if (systemName != "system")
-        {
-            messages::resourceNotFound(asyncResp->res, "ComputerSystem",
-                                       systemName);
-            return;
-        }
+
+        std::string systemName = "system";
         asyncResp->res.addHeader(
             boost::beast::http::field::link,
             "</redfish/v1/JsonSchemas/ComputerSystem/ComputerSystem.json>; rel=describedby");


### PR DESCRIPTION
This commit adds "system" as the system name in the redfish route handler (/redfish/v1/Systems/system) instead of /redfish/v1/Systems/<str>

The reason for this change is that there are basically two routes defined:
[1] /redfish/v1/Systems/<str>
[2] /redfish/v1/Systems/hypervisor

Whenever a user does a get on /redfish/v1/Systems/hypervisor, the first route is hit and that checks if <str> is system and if not, bmcweb throws resource not found error.

The below upstream commit is causing this issue:
[1] https://github.com/openbmc/bmcweb/commit/22d268cb2c0bc00676d08c79f6ab8958bee74a25#diff-cddfc26fddb6ba29f3fd81ecf5840fc6d9a8554bbca92f578d81b97db8b14895

To resolve this issue, the route handler is changed back to /redfish/v1/Systems/system in this commit.