### PR TITLE
1050: Fix redfish can't show USBCodeUpdateEnabled

### DIFF
--- a/redfish-core/lib/managers.hpp
+++ b/redfish-core/lib/managers.hpp
@@ -2389,6 +2389,7 @@ inline void requestRoutesManager(App& app)
                 }
             }
 #endif
+#else
             messages::propertyUnknown(asyncResp->res, "Oem");
             return;
 #endif

--- a/redfish-core/lib/oem/ibm/usb_code_update.hpp
+++ b/redfish-core/lib/oem/ibm/usb_code_update.hpp
@@ -10,7 +10,7 @@ namespace redfish
 {
 
 static constexpr const char* usbCodeUpdateObjectPath =
-    "/xyz/openbmc_project/control/service/phosphor_2dusb_2dcode_2dupdate";
+    "/xyz/openbmc_project/control/service/_70hosphor_2dusb_2dcode_2dupdate";
 
 /**
  * @brief Get the service name of the path


### PR DESCRIPTION
Redfish cannot show USBCodeUpdateEnabled because the dbus path has changed:
[1] https://github.com/ibm-openbmc/service-config-manager/commit/4b8637db4280dde044ec37535c3f379362ed3b7c

Fix another issue. When we use PATCH, we receive a propertyUnknown error.


Test:
```
 curl -k -H "X-Auth-Token: $token" -X GET https://${bmc}/redfish/v1/Managers/bmc
  "Oem": {
    "@odata.id": "/redfish/v1/Managers/bmc#/Oem",
    "@odata.type": "#OemManager.Oem",
    "IBM": {
      "@odata.id": "/redfish/v1/Managers/bmc#/Oem/IBM",
      "@odata.type": "#OemManager.IBM",
      "USBCodeUpdateEnabled": false
    },
    "OpenBmc": {
      "@odata.id": "/redfish/v1/Managers/bmc#/Oem/OpenBmc",
      "@odata.type": "#OemManager.OpenBmc",
      "Certificates": {
        "@odata.id": "/redfish/v1/Managers/bmc/Truststore/Certificates"
      }
    }
  },
```
