### PR TITLE
Bump schema to access Enabled property

### DIFF
--- a/redfish-core/lib/memory.hpp
+++ b/redfish-core/lib/memory.hpp
@@ -853,7 +853,7 @@ inline void getDimmData(const std::shared_ptr<bmcweb::AsyncResp>& aResp,
             return;
         }
         // Set @odata only if object is found
-        aResp->res.jsonValue["@odata.type"] = "#Memory.v1_11_0.Memory";
+        aResp->res.jsonValue["@odata.type"] = "#Memory.v1_12_0.Memory";
         aResp->res.jsonValue["@odata.id"] = crow::utility::urlFromPieces(
             "redfish", "v1", "Systems", "system", "Memory", dimmId);
         return;


### PR DESCRIPTION
The redfish validator failed with Enabled not defined.

Bumped the schema to v1_12_0 to access the enabled property.

![image](https://user-images.githubusercontent.com/112156780/221474913-758e75d2-9b3b-401e-93d6-d719cb48f067.png)

Signed-off-by: Deepa Karthikeyan <deepakala.karthikeyan@ibm.com>