### PR TITLE
1050: PCIe Topology: Redfish: Reset Link (#352)

### DIFF
--- a/scripts/update_schemas.py
+++ b/scripts/update_schemas.py
@@ -426,6 +426,16 @@ with open(metadata_index_path, "w") as metadata_index:
     metadata_index.write("    </edmx:Reference>\n")
 
     metadata_index.write(
+        "       <edmx:Reference"
+        ' Uri="/redfish/v1/schema/OemPCIeDevice_v1.xml">\n'
+    )
+    metadata_index.write('        <edmx:Include Namespace="OemPCIeDevice"/>\n')
+    metadata_index.write(
+        '        <edmx:Include Namespace="OemPCIeDevice.v1_0_0"/>\n'
+    )
+    metadata_index.write("    </edmx:Reference>\n")
+
+    metadata_index.write(
         '    <edmx:Reference Uri="'
         '/redfish/v1/schema/OemUpdateService_v1.xml">\n'
     )

--- a/static/redfish/v1/$metadata/index.xml
+++ b/static/redfish/v1/$metadata/index.xml
@@ -2858,6 +2858,10 @@
         <edmx:Include Namespace="OemChassis"/>
         <edmx:Include Namespace="OemChassis.v1_0_0"/>
     </edmx:Reference>
+       <edmx:Reference Uri="/redfish/v1/schema/OemPCIeDevice_v1.xml">
+        <edmx:Include Namespace="OemPCIeDevice"/>
+        <edmx:Include Namespace="OemPCIeDevice.v1_0_0"/>
+    </edmx:Reference>
     <edmx:Reference Uri="/redfish/v1/schema/OemUpdateService_v1.xml">
         <edmx:Include Namespace="OemUpdateService"/>
         <edmx:Include Namespace="OemUpdateService.v1_0_0"/>

--- a/static/redfish/v1/JsonSchemas/OemPCIeDevice/index.json
+++ b/static/redfish/v1/JsonSchemas/OemPCIeDevice/index.json
@@ -1,0 +1,69 @@
+{
+    "$id": "http://redfish.dmtf.org/schemas/v1/OemPCIeDevice.json",
+    "$schema": "http://redfish.dmtf.org/schemas/v1/redfish-schema-v1.json",
+    "copyright": "Copyright 2014-2019 DMTF. For the full DMTF copyright policy, see http://www.dmtf.org/about/policies/copyright",
+    "definitions": {
+        "Oem": {
+            "additionalProperties": true,
+            "description": "OemPCIeDevice Oem properties.",
+            "patternProperties": {
+                "^([a-zA-Z_][a-zA-Z0-9_]*)?@(odata|Redfish|Message)\\.[a-zA-Z_][a-zA-Z0-9_]*$": {
+                    "description": "This property shall specify a valid odata or Redfish property.",
+                    "type": [
+                        "array",
+                        "boolean",
+                        "integer",
+                        "number",
+                        "null",
+                        "object",
+                        "string"
+                    ]
+                }
+            },
+            "properties": {
+                "IBM": {
+                    "anyOf": [
+                        {
+                            "$ref": "#/definitions/IBM"
+                        },
+                        {
+                            "type": "null"
+                        }
+                    ]
+                }
+
+            },
+            "type": "object"
+        },
+        "IBM": {
+            "additionalProperties": true,
+            "description": "Oem properties for IBM.",
+            "patternProperties": {
+                "^([a-zA-Z_][a-zA-Z0-9_]*)?@(odata|Redfish|Message)\\.[a-zA-Z_][a-zA-Z0-9_]*$": {
+                    "description": "This property shall specify a valid odata or Redfish property.",
+                    "type": [
+                        "array",
+                        "boolean",
+                        "integer",
+                        "number",
+                        "null",
+                        "object",
+                        "string"
+                    ]
+                }
+            },
+            "properties": {
+                "LinkReset": {
+                    "description": "Reset the PCIe Link",
+                    "longDescription": "A true value resets the PCIe Link.",
+                    "readonly": false,
+                    "type": "boolean"
+                }
+            },
+            "type": "object"
+        }
+    },
+    "owningEntity": "IBM",
+    "release": "1.0",
+    "title": "#OemPCIeDevice"
+}

--- a/static/redfish/v1/schema/OemPCIeDevice_v1.xml
+++ b/static/redfish/v1/schema/OemPCIeDevice_v1.xml
@@ -1,0 +1,52 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<edmx:Edmx xmlns:edmx="http://docs.oasis-open.org/odata/ns/edmx" Version="4.0">
+
+  <edmx:Reference Uri="http://docs.oasis-open.org/odata/odata/v4.0/errata03/csd01/complete/vocabularies/Org.OData.Core.V1.xml">
+    <edmx:Include Namespace="Org.OData.Core.V1" Alias="OData"/>
+  </edmx:Reference>
+  <edmx:Reference Uri="http://docs.oasis-open.org/odata/odata/v4.0/errata03/csd01/complete/vocabularies/Org.OData.Measures.V1.xml">
+    <edmx:Include Namespace="Org.OData.Measures.V1" Alias="Measures"/>
+  </edmx:Reference>
+  <edmx:Reference Uri="http://redfish.dmtf.org/schemas/v1/RedfishExtensions_v1.xml">
+    <edmx:Include Namespace="RedfishExtensions.v1_0_0" Alias="Redfish"/>
+  </edmx:Reference>
+    <edmx:Reference Uri="http://redfish.dmtf.org/schemas/v1/PCIeDevice_v1.xml">
+        <edmx:Include Namespace="PCIeDevice"/>
+        <edmx:Include Namespace="PCIeDevice.v1_9_0"/>
+    </edmx:Reference>
+  <edmx:Reference Uri="http://redfish.dmtf.org/schemas/v1/Resource_v1.xml">
+    <edmx:Include Namespace="Resource"/>
+    <edmx:Include Namespace="Resource.v1_0_0"/>
+  </edmx:Reference>
+
+  <edmx:DataServices>
+    <Schema xmlns="http://docs.oasis-open.org/odata/ns/edm" Namespace="OemPCIeDevice">
+      <Annotation Term="Redfish.OwningEntity" String="IBM"/>
+    </Schema>
+
+    <Schema xmlns="http://docs.oasis-open.org/odata/ns/edm" Namespace="OemPCIeDevice.v1_0_0">
+      <Annotation Term="Redfish.OwningEntity" String="IBM"/>
+
+      <ComplexType Name="Oem" BaseType="Resource.OemObject">
+        <Annotation Term="OData.AdditionalProperties" Bool="true"/>
+        <Annotation Term="OData.Description" String="OemPCIeDevice Oem properties."/>
+        <Annotation Term="OData.AutoExpand"/>
+        <Property Name="IBM" Type="OemPCIeDevice.IBM"/>
+      </ComplexType>
+
+      <ComplexType Name="IBM" BaseType="Resource.OemObject">
+        <Annotation Term="OData.AdditionalProperties" Bool="true" />
+        <Annotation Term="OData.Description" String="Oem properties for IBM." />
+        <Annotation Term="OData.AutoExpand"/>
+
+        <Property Name="LinkReset" Type="OemPCIeDevice.IBM">
+          <Annotation Term="OData.Permissions" EnumMember="OData.Permission/ReadWrite"/>
+          <Annotation Term="OData.Description" String="Reset the PCIe Link"/>
+          <Annotation Term="OData.LongDescription" String="A true value resets the PCIe Link."/>
+        </Property>
+      </ComplexType>
+
+    </Schema>
+
+  </edmx:DataServices>
+</edmx:Edmx>


### PR DESCRIPTION
NOTE:A fix of  phosphor-dbus-interface related to  com.ibm.Control.Host.PCIeLink  is needed.

This commit sets linkReset property to the requested value

This is downstream change only

Issue:
https://github.com/ibm-openbmc/dev/issues/3551

Redfish Validator: test passed

Testing:
Set LinkReset to 'true' using PATCH API, and verified the property using GET API
$ curl -k -X PATCH
https://service:passwd@host:18080/redfish/v1/Systems/system/PCIeDevices/pcie_card0 -d '{"Oem": {"IBM": {"LinkReset": true}}}'

$ curl -k -X GET
https://service:passwd@host:18080/redfish/v1/Systems/system/PCIeDevices/pcie_card0 {
  "@odata.id": "/redfish/v1/Systems/system/PCIeDevices/pcie_card0",
  "@odata.type": "#PCIeDevice.v1_9_0.PCIeDevice",
  "Id": "pcie_card0",
  "Manufacturer": "",
  "Name": "PCIe Cable Card",
  "Oem": {
    "@odata.type": "#OemPCIeDevice.Oem",
    "IBM": {
      "@odata.type": "#OemPCIeDevice.IBM",
      "LinkReset": true
    }
  },
...
  "Status": {
    "Health": "OK",
    "State": "Enabled"
  }
}