### PR TITLE
Bug fix: cannot delete ACF

### DIFF
--- a/redfish-core/lib/account_service.hpp
+++ b/redfish-core/lib/account_service.hpp
@@ -2633,7 +2633,6 @@ inline void requestAccountServiceRoutes(App& app)
                                     "AllowUnauthACFUpload",
                                     allowUnauthACFUpload);
                             }
-                            
                             if (!rc)
                             {
                                 BMCWEB_LOG_ERROR << "Illegal Property ";

--- a/redfish-core/lib/account_service.hpp
+++ b/redfish-core/lib/account_service.hpp
@@ -2618,10 +2618,23 @@ inline void requestAccountServiceRoutes(App& app)
                         {
                             std::optional<bool> allowUnauthACFUpload;
                             std::optional<std::string> acfFile;
-                            if (!redfish::json_util::readJson(
+                            bool rc;
+                            // Property ACFFile may be null or string
+                            if (acf.value().contains("ACFFile") &&
+                                (acf.value()["ACFFile"] == nullptr))
+                            {
+                                acfFile = "";
+                                rc = true;
+                            }
+                            else
+                            {
+                                rc = redfish::json_util::readJson(
                                     *acf, asyncResp->res, "ACFFile", acfFile,
                                     "AllowUnauthACFUpload",
-                                    allowUnauthACFUpload))
+                                    allowUnauthACFUpload);
+                            }
+                            
+                            if (!rc)
                             {
                                 BMCWEB_LOG_ERROR << "Illegal Property ";
                                 messages::propertyMissing(asyncResp->res,


### PR DESCRIPTION
This fixes a bug with the ACF upload function which was introduced in 921ba85e0bc68779573db121790bde574332d395 (the AllowUnauthACFUpload function).  The bug prevents PATCHing the {"ACFFile":null} value from deleting the ACF.  Patching an empty string {"ACFFile":""} works and effectively deletes the ACF.

In this fix, you can PATCH the /redfish/v1/AccountService/Accounts/service property Oem.IBM.ACF.ACFFile to have either the null value, an empty string, or a correct base64-encoded ACF content

Tested: Combinations of ACFFile and AllowUnauthACFUpload property values.