### PR TITLE
1050: Make PCIe Adapter Paths Unique (#372)(#391)

### DIFF
--- a/redfish-core/include/utils/pcie_util.hpp
+++ b/redfish-core/include/utils/pcie_util.hpp
@@ -1,0 +1,45 @@
+#pragma once
+
+#include <string>
+
+namespace redfish
+{
+namespace pcie_util
+{
+/**
+ * @brief Workaround to handle duplicate PCI device list
+ *
+ * retrieve PCI device endpoint information and if path is
+ * ~/chassisN/io_moduleN/slotN/adapterN then, replace redfish
+ * PCI device as "chassisN_io_moduleN_slotN_adapterN"
+ *
+ * @param[i]   fullPath  object path of PCIe device
+ *
+ * @return string: unique PCIe device name
+ */
+inline std::string buildPCIeUniquePath(const std::string& fullPath)
+{
+    sdbusplus::message::object_path path(fullPath);
+    sdbusplus::message::object_path parentPath = path.parent_path();
+    sdbusplus::message::object_path parentofParentPath =
+        parentPath.parent_path();
+    std::string devName;
+
+    if (!parentofParentPath.parent_path().filename().empty())
+    {
+        devName = parentofParentPath.parent_path().filename() + "_";
+    }
+    if (!parentofParentPath.filename().empty())
+    {
+        devName += parentofParentPath.filename() + "_";
+    }
+    if (!parentPath.filename().empty())
+    {
+        devName += parentPath.filename() + "_";
+    }
+    devName += path.filename();
+    return devName;
+}
+
+} // namespace pcie_util
+} // namespace redfish

--- a/redfish-core/lib/cable.hpp
+++ b/redfish-core/lib/cable.hpp
@@ -7,6 +7,7 @@
 #include <utils/chassis_utils.hpp>
 #include <utils/dbus_utils.hpp>
 #include <utils/json_utils.hpp>
+#include <utils/pcie_util.hpp>
 
 #include <memory>
 #include <string>
@@ -159,15 +160,15 @@ inline void
 
         for (const auto& fullPath : value)
         {
-            sdbusplus::message::object_path path(fullPath);
-            std::string leaf = path.filename();
-            if (leaf.empty())
+            std::string devName = pcie_util::buildPCIeUniquePath(fullPath);
+            if (devName.empty())
             {
                 continue;
             }
+
             linkArray.push_back(
                 {{"@odata.id",
-                  "/redfish/v1/Systems/system/PCIeDevices/" + leaf}});
+                  "/redfish/v1/Systems/system/PCIeDevices/" + devName}});
         }
     });
 

--- a/redfish-core/lib/pcie_slots.hpp
+++ b/redfish-core/lib/pcie_slots.hpp
@@ -14,6 +14,7 @@
 #include <sdbusplus/unpack_properties.hpp>
 #include <utils/dbus_utils.hpp>
 #include <utils/json_utils.hpp>
+#include <utils/pcie_util.hpp>
 
 #include <memory>
 #include <string>
@@ -107,10 +108,10 @@ inline void
 
         // Assuming only one device path per slot.
         const std::string& pcieDevciePath = std::get<0>(subtree[0]);
-        const std::string pcieDevice =
-            sdbusplus::message::object_path(pcieDevciePath).filename();
 
-        if (pcieDevice.empty())
+        std::string devName = pcie_util::buildPCIeUniquePath(pcieDevciePath);
+
+        if (devName.empty())
         {
             BMCWEB_LOG_ERROR << "Failed to find / in pcie device path";
             messages::internalError(asyncResp->res);
@@ -119,7 +120,7 @@ inline void
 
         asyncResp->res.jsonValue["Slots"][index]["Links"]["PCIeDevice"] = {
             {{"@odata.id",
-              "/redfish/v1/Systems/system/PCIeDevices/" + pcieDevice}}};
+              "/redfish/v1/Systems/system/PCIeDevices/" + devName}}};
         });
 }
 


### PR DESCRIPTION
This commit makes redfish adapter objects unique, before this commit bmcweb shows redfish adapter objects with the same path even though all the dbus objects have unique paths
{"@odata.id": "/redfish/v1/Systems/system/PCIeDevices/adapter1"}, {"@odata.id": "/redfish/v1/Systems/system/PCIeDevices/adapter1"}.

after this change bmcweb retrieve PCI device endpoint information and then, replace redfish PCI device as
"chassisN_io_moduleN_slotN_adapterN".

this change also affect below path because they also has slot and chassis value in their path.
"/xyz/openbmc_project/inventory/system/chassis/motherboard/pcieslot0/pcie_card0"

Tested result:

```
curl -k -H "X-Auth-Token: $token" -X GET  https://${bmc}/redfish/v1/Systems/system

{
...
...
"PCIeDevices": [
...
...
{"@odata.id": "/redfish/v1/Systems/system/PCIeDevices/chassis_pcieslot0_pcie_card0"},
{"@odata.id": "/redfish/v1/Systems/system/PCIeDevices/chassis_pcieslot1_pcie_card1"},
...
...
{"@odata.id": "/redfish/v1/Systems/system/PCIeDevices/chassis15363_io_module1_slot1_adapter1"},
{"@odata.id": "/redfish/v1/Systems/system/PCIeDevices/chassis15363_io_module1_slot2_adapter1"},
...
],
...
```