### PR TITLE
Fix async_method_call object paths while updating/deleting IP address

### DIFF
--- a/redfish-core/lib/ethernet.hpp
+++ b/redfish-core/lib/ethernet.hpp
@@ -629,7 +629,7 @@ inline void deleteIPv4(const std::string& ifaceId, const std::string& ipHash,
         }
         },
         "xyz.openbmc_project.Network",
-        "/xyz/openbmc_project/network/" + ifaceId + "/ipv4/" + ipHash,
+        "/xyz/openbmc_project/network/" + ifaceId + ipHash,
         "xyz.openbmc_project.Object.Delete", "Delete");
 }
 
@@ -729,7 +729,7 @@ inline void
             prefixLength, gateway);
         },
         "xyz.openbmc_project.Network",
-        +"/xyz/openbmc_project/network/" + ifaceId + "/ipv4/" + id,
+        "/xyz/openbmc_project/network/" + ifaceId + id,
         "xyz.openbmc_project.Object.Delete", "Delete");
 }
 
@@ -753,7 +753,7 @@ inline void deleteIPv6(const std::string& ifaceId, const std::string& ipHash,
         }
         },
         "xyz.openbmc_project.Network",
-        "/xyz/openbmc_project/network/" + ifaceId + "/ipv6/" + ipHash,
+        "/xyz/openbmc_project/network/" + ifaceId + ipHash,
         "xyz.openbmc_project.Object.Delete", "Delete");
 }
 
@@ -795,7 +795,7 @@ inline void
             prefixLength, "");
         },
         "xyz.openbmc_project.Network",
-        +"/xyz/openbmc_project/network/" + ifaceId + "/ipv6/" + id,
+        "/xyz/openbmc_project/network/" + ifaceId + id,
         "xyz.openbmc_project.Object.Delete", "Delete");
 }
 


### PR DESCRIPTION
This commit fixes IP address object paths in IP address Patch/Delete functions as per new networkd d-bus object paths

Tested By:
Delete IPv4/IPv6 IP addresses
PATCH IPv4/IPv6 IP addresses

Change-Id: Ia5a9db763a9ce7a2964f4e07cf8ecb85f04d374f