### PR TITLE
1050: Refresh of PCIe Topology (#377)(#382)(#404)(#406)

### DIFF
--- a/redfish-core/lib/oem/ibm/pcie_topology_refresh.hpp
+++ b/redfish-core/lib/oem/ibm/pcie_topology_refresh.hpp
@@ -1,0 +1,157 @@
+#pragma once
+
+#include "async_resp.hpp"
+#include "dbus_utility.hpp"
+#include "redfish_util.hpp"
+
+#include <variant>
+
+namespace redfish
+{
+// Timer for PCIe Topology Refresh
+static std::unique_ptr<boost::asio::steady_timer> pcieTopologyRefreshTimer;
+static uint count = 0;
+
+/**
+ * @brief PCIe Topology Refresh monitor. which block incoming request
+ *
+ * @param[in] timer       pointer to steady timer which block call
+ * @param[in] aResp   Shared pointer for generating response message.
+ * @param[in] count   how many time this method get called.
+ *
+ * @return None.
+ */
+void pcieTopologyRefreshWatchdog(
+    const boost::system::error_code& ec, boost::asio::steady_timer* timer,
+    const std::shared_ptr<bmcweb::AsyncResp>& aResp, uint* countPtr)
+{
+    if (ec)
+    {
+        BMCWEB_LOG_ERROR << "steady_timer error " << ec;
+        messages::internalError(aResp->res);
+        pcieTopologyRefreshTimer = nullptr;
+        (*countPtr) = 0;
+        return;
+    }
+    //  This method can block incoming requests max for 8 seconds. So, each
+    //  call to this method adds a 1-second block, and the maximum call allow is
+    //  8 times which makes it a total of ~8 seconds
+    if ((*countPtr) >= 8)
+    {
+        messages::internalError(aResp->res);
+        pcieTopologyRefreshTimer = nullptr;
+        (*countPtr) = 0;
+        return;
+    }
+    ++(*countPtr);
+    crow::connections::systemBus->async_method_call(
+        [aResp, timer, countPtr](const boost::system::error_code ec1,
+                                 std::variant<bool>& pcieRefreshValue) {
+        if (ec1)
+        {
+            BMCWEB_LOG_ERROR << "DBUS response error " << ec1;
+            messages::internalError(aResp->res);
+            pcieTopologyRefreshTimer = nullptr;
+            (*countPtr) = 0;
+            return;
+        }
+        const bool* pcieRefreshValuePtr = std::get_if<bool>(&pcieRefreshValue);
+        if (pcieRefreshValuePtr == nullptr)
+        {
+            BMCWEB_LOG_ERROR << "pcieRefreshValuePtr value nullptr";
+            messages::internalError(aResp->res);
+            pcieTopologyRefreshTimer = nullptr;
+            (*countPtr) = 0;
+            return;
+        }
+        // After PCIe Topology Refresh, it sets the pcieRefreshValuePtr
+        // value to false. if a value is not false, extend the time, and if
+        // it is false, delete the timer and reset the counter
+        if (*pcieRefreshValuePtr)
+        {
+            BMCWEB_LOG_ERROR << "pcieRefreshValuePtr time extended";
+            timer->expires_at(timer->expiry() +
+                              boost::asio::chrono::seconds(1));
+            timer->async_wait(
+                [timer, aResp, countPtr](const boost::system::error_code ec2) {
+                pcieTopologyRefreshWatchdog(ec2, timer, aResp, countPtr);
+            });
+        }
+        else
+        {
+            BMCWEB_LOG_ERROR << "pcieRefreshValuePtr value refreshed";
+            pcieTopologyRefreshTimer = nullptr;
+            (*countPtr) = 0;
+            return;
+        }
+        },
+        "xyz.openbmc_project.PLDM", "/xyz/openbmc_project/pldm",
+        "org.freedesktop.DBus.Properties", "Get", "com.ibm.PLDM.PCIeTopology",
+        "PCIeTopologyRefresh");
+};
+
+/**
+ * @brief Sets PCIe Topology Refresh state.
+ *
+ * @param[in] aResp   Shared pointer for generating response message.
+ * @param[in] state   PCIe Topology Refresh state from request.
+ *
+ * @return None.
+ */
+inline void
+    setPCIeTopologyRefresh(const crow::Request& req,
+                           const std::shared_ptr<bmcweb::AsyncResp>& aResp,
+                           const bool state)
+{
+    BMCWEB_LOG_DEBUG << "Set PCIe Topology Refresh status.";
+    crow::connections::systemBus->async_method_call(
+        [&req, aResp](const boost::system::error_code ec) {
+        if (ec)
+        {
+            BMCWEB_LOG_DEBUG << "PCIe Topology Refresh failed." << ec;
+            messages::internalError(aResp->res);
+            return;
+        }
+        count = 0;
+        pcieTopologyRefreshTimer =
+            std::make_unique<boost::asio::steady_timer>(*req.ioService);
+        pcieTopologyRefreshTimer->expires_after(std::chrono::seconds(1));
+        pcieTopologyRefreshTimer->async_wait(
+            [timer = pcieTopologyRefreshTimer.get(),
+             aResp](const boost::system::error_code ec1) {
+            pcieTopologyRefreshWatchdog(ec1, timer, aResp, &count);
+        });
+        },
+        "xyz.openbmc_project.PLDM", "/xyz/openbmc_project/pldm",
+        "org.freedesktop.DBus.Properties", "Set", "com.ibm.PLDM.PCIeTopology",
+        "PCIeTopologyRefresh", std::variant<bool>(state));
+}
+
+/**
+ * @brief Sets Save PCIe Topology Info state.
+ *
+ * @param[in] aResp   Shared pointer for generating response message.
+ * @param[in] state   Save PCIe Topology Info state from request.
+ *
+ * @return None.
+ */
+inline void
+    setSavePCIeTopologyInfo(const std::shared_ptr<bmcweb::AsyncResp>& aResp,
+                            const bool state)
+{
+    BMCWEB_LOG_DEBUG << "Set Save PCIe Topology Info status.";
+    crow::connections::systemBus->async_method_call(
+        [aResp](const boost::system::error_code ec) {
+        if (ec)
+        {
+            BMCWEB_LOG_ERROR << "Save PCIe Topology Info failed." << ec;
+            messages::internalError(aResp->res);
+            return;
+        }
+        },
+        "xyz.openbmc_project.PLDM", "/xyz/openbmc_project/pldm",
+        "org.freedesktop.DBus.Properties", "Set", "com.ibm.PLDM.PCIeTopology",
+        "SavePCIeTopologyInfo", std::variant<bool>(state));
+}
+
+} // namespace redfish

--- a/static/redfish/v1/JsonSchemas/OemComputerSystem/index.json
+++ b/static/redfish/v1/JsonSchemas/OemComputerSystem/index.json
@@ -169,6 +169,24 @@
                         "boolean",
                         "null"
                     ]
+                },
+                "PCIeTopologyRefresh": {
+                    "description": "An indication of topology information is ready.",
+                    "longDescription": "This property when set to 'true' refreshes the topology information. The application which uses this should set it to 'false' when a refresh occurs.",
+                    "readonly": true,
+                    "type": [
+                        "boolean",
+                        "null"
+                    ]
+                },
+                "SavePCIeTopologyInfo": {
+                    "description": "An indication of PEL topology information is saves.",
+                    "longDescription": "This property when set to 'true' saves the topology information. The information is saved in the form of a PEL(Error Log).",
+                    "readonly": true,
+                    "type": [
+                        "boolean",
+                        "null"
+                    ]
                 }
             },
             "type": "object"

--- a/static/redfish/v1/schema/OemComputerSystem_v1.xml
+++ b/static/redfish/v1/schema/OemComputerSystem_v1.xml
@@ -45,6 +45,21 @@
                     <Annotation Term="OData.Description" String="An indicator allowing an operator to operate platform system attention."/>
                     <Annotation Term="OData.LongDescription" String="This property shall contain the state of the platform system attention of this resource."/>
                 </Property>
+                <Property Name="SafeMode" Type="OemComputerSystem.IBM">
+                  <Annotation Term="OData.Permissions" EnumMember="OData.Permission/Read"/>
+                  <Annotation Term="OData.Description" String="An indication of whether safe mode is enabled."/>
+                  <Annotation Term="OData.LongDescription" String="The value of this property shall indicate if safe mode is enabled."/>
+                </Property>
+                <Property Name="PCIeTopologyRefresh" Type="OemComputerSystem.IBM">
+                  <Annotation Term="OData.Permissions" EnumMember="OData.Permission/ReadWrite"/>
+                  <Annotation Term="OData.Description" String="An indication of topology information is ready."/>
+                  <Annotation Term="OData.LongDescription" String="This property when set to 'true' refreshes the topology information. The application which uses this should set it to 'false' when a refresh occurs."/>
+                </Property>
+                <Property Name="SavePCIeTopologyInfo" Type="OemComputerSystem.IBM">
+                  <Annotation Term="OData.Permissions" EnumMember="OData.Permission/ReadWrite"/>
+                  <Annotation Term="OData.Description" String="An indication of PEL topology information is saves."/>
+                  <Annotation Term="OData.LongDescription" String="This property when set to 'true' saves the topology information. The information is saved in the form of a PEL(Error Log)."/>
+                </Property>
             </ComplexType>
 
             <ComplexType Name="OpenBmc" BaseType="Resource.OemObject">


### PR DESCRIPTION
This implements PATCH of PCIeTopologyRefresh & SavePCIeTopologyInfo.

```
curl -k -X PATCH https://${bmc}:18080/redfish/v1/Systems/system/ -d '{"Oem":{"IBM":{"PCIeTopologyRefresh":true}}}'
curl -k -X PATCH https://${bmc}:18080/redfish/v1/Systems/system/ -d '{"Oem":{"IBM":{"SavePCIeTopologyInfo":true}}}'
```

This pulls in the following 1030 PRs:

- https://github.com/ibm-openbmc/bmcweb/pull/377
- https://github.com/ibm-openbmc/bmcweb/pull/382
- https://github.com/ibm-openbmc/bmcweb/pull/404
- https://github.com/ibm-openbmc/bmcweb/pull/406

This commit also adds functionality, where bmcweb creates a watchdog (using timer) where timer waits for one second and then checks if PCIe Topology gets refreshed or not. If not, then wait for one more second and repeat this process eight times, and then the watchdog expires in between if it gets refreshed then unblock the request.

Tested:

```
curl -k -X GET https://${bmc}:18080/redfish/v1/Systems/system/
{
...
  "Oem": {
    "@odata.type": "#OemComputerSystem.Oem",
    "IBM": {
      "@odata.type": "#OemComputerSystem.IBM",
      "LampTest": false,
      "PartitionSystemAttentionIndicator": false,
      "PlatformSystemAttentionIndicator": false
    }
  },
...
  "SafeMode": {
    "SafeMode": false
  },
...
}
```

PATCH works:

```
curl -k -X PATCH https://${bmc}:18080/redfish/v1/Systems/system/ -d '{"Oem":{"IBM":{"PCIeTopologyRefresh":true}}}'
curl -k -X PATCH https://${bmc}:18080/redfish/v1/Systems/system/ -d '{"Oem":{"IBM":{"SavePCIeTopologyInfo":true}}}'
```