### PR TITLE
Fix redfish GET issue on Dump collection

### DIFF
--- a/redfish-core/lib/log_services.hpp
+++ b/redfish-core/lib/log_services.hpp
@@ -565,7 +565,10 @@ inline void
         }
 
         nlohmann::json& entriesArray = asyncResp->res.jsonValue["Members"];
-        entriesArray = nlohmann::json::array();
+        if (entriesArray.empty())
+        {
+            entriesArray = nlohmann::json::array();
+        }
         std::string dumpEntryPath =
             "/xyz/openbmc_project/dump/" +
             std::string(boost::algorithm::to_lower_copy(dumpType)) + "/entry/";


### PR DESCRIPTION
Redfish GET on system dump entries returned null eventhough the dump entries were found in the backend. This PR fixes this issue by appending to the "Members" field of the redfish response instead of overriding it.

Tested By:

GET https://${bmc}/redfish/v1/Systems/system/LogServices/Dump/Entries