### PR TITLE
Link PCIeSlots to Processor schema

### DIFF
--- a/redfish-core/lib/pcie_slots.hpp
+++ b/redfish-core/lib/pcie_slots.hpp
@@ -124,6 +124,56 @@ inline void
         });
 }
 
+inline void
+    linkAssociatedProcessor(const std::shared_ptr<bmcweb::AsyncResp>& asyncResp,
+                            const std::string& pcieSlotPath, size_t index)
+{
+    dbus::utility::getAssociationEndPoints(
+        pcieSlotPath + "/upstream_processor",
+        [asyncResp, pcieSlotPath,
+         index](const boost::system::error_code& ec,
+                const dbus::utility::MapperEndPoints& endpoints) {
+        if (ec)
+        {
+            if (ec.value() == EBADR)
+            {
+                // This PCIeSlot have no processor association.
+                BMCWEB_LOG_DEBUG << "No processor association found";
+                return;
+            }
+            BMCWEB_LOG_ERROR << "DBUS response error" << ec.message();
+            messages::internalError(asyncResp->res);
+            return;
+        }
+
+        if (endpoints.empty())
+        {
+            BMCWEB_LOG_DEBUG << "No association found for processor";
+            messages::internalError(asyncResp->res);
+            return;
+        }
+
+        std::string cpuName =
+            sdbusplus::message::object_path(endpoints[0]).filename();
+        std::string dcmName =
+            (sdbusplus::message::object_path(endpoints[0]).parent_path())
+                .filename();
+
+        std::string processorName = dcmName + '-' + cpuName;
+
+        nlohmann::json& processorArray =
+            asyncResp->res.jsonValue["Slots"][index]["Links"]["Processors"];
+        processorArray = nlohmann::json::array();
+
+        processorArray.push_back(
+            {{"@odata.id",
+              "/redfish/v1/Systems/system/Processors/" + processorName}});
+        asyncResp->res
+            .jsonValue["Slots"][index]["Links"]["Processors@odata.count"] =
+            processorArray.size();
+        });
+}
+
 /**
  * @brief Add PCIeSlot to NMVe backplane assembly link
  *
@@ -392,6 +442,9 @@ inline void
     // Get pcie device link
     addLinkedPcieDevices(asyncResp, pcieSlotPath, index);
 
+    // Get processor link
+    linkAssociatedProcessor(asyncResp, pcieSlotPath, index);
+
     linkAssociatedDiskBackplane(asyncResp, pcieSlotPath, index);
 
     // Get pcie slot location indicator state
@@ -473,7 +526,7 @@ inline void
     BMCWEB_LOG_DEBUG << "Get properties for PCIeSlots associated to chassis = "
                      << chassisID;
 
-    asyncResp->res.jsonValue["@odata.type"] = "#PCIeSlots.v1_4_1.PCIeSlots";
+    asyncResp->res.jsonValue["@odata.type"] = "#PCIeSlots.v1_5_0.PCIeSlots";
     asyncResp->res.jsonValue["Name"] = "PCIe Slot Information";
     asyncResp->res.jsonValue["@odata.id"] = crow::utility::urlFromPieces(
         "redfish", "v1", "Chassis", chassisID, "PCIeSlots");


### PR DESCRIPTION
The commit implement channges to populate link(s) to processor associated witha given PCIeSlot.

The association is established by fetching mapper endpoints "upstream_processor" w.r.t given PCIeSlot.

Validator has been executed and no new error was found.

Sample output:
{
      "HotPluggable": false,
      "Lanes": 0,
      "Links": {
        "PCIeDevice": [
          {
            "@odata.id": "/redfish/v1/Systems/system/PCIeDevices/chassis_motherboard_pcieslot0_pcie_card0"
          }
        ],
        "Processors": [
          {
            "@odata.id": "/redfish/v1/Systems/system/Processors/dcm1-cpu1"
          }
        ],
        "Processors@odata.count": 1
      },
      "LocationIndicatorActive": false,
      "Oem": {
        "@odata.type": "#OemPCIeSlots.Oem",
        "IBM": {
          "@odata.type": "#OemPCIeSlots.IBM",
          "LinkId": 0
        }
      },
      "SlotType": "FullLength"
    },
}
Signed-off-by: Sunny Srivastava <sunnsr25@in.ibm.com>