### PR TITLE
1050: Fix Oem AssociatedAssembly Link

### DIFF
--- a/redfish-core/lib/pcie_slots.hpp
+++ b/redfish-core/lib/pcie_slots.hpp
@@ -173,7 +173,8 @@ inline void linkAssociatedDiskBackplane(
                 std::find(assemblyList.begin(), assemblyList.end(), drivePath);
             if (it != assemblyList.end())
             {
-                asyncResp->res.jsonValue["Slots"][index]["Links"]["Oem"] = {
+                asyncResp->res.jsonValue["Slots"][index]["Links"]["Oem"]["IBM"]
+                                        ["AssociatedAssembly"] = {
                     {{"@odata.id",
                       "/redfish/v1/Chassis/" + chassisId +
                           "/Assembly#/Assemblies/" +

--- a/static/redfish/v1/JsonSchemas/OemPCIeSlots/index.json
+++ b/static/redfish/v1/JsonSchemas/OemPCIeSlots/index.json
@@ -25,6 +25,14 @@
                     "description": "An identifier to detect the PCIe bus linked to the slot.",
                     "readonly": true,
                     "type": "integer"
+                },
+                "AssociatedAssembly": {
+                    "description": "Represent association slot with assembly.",
+                    "readonly": true,
+                    "type": [
+                        "null",
+                        "object"
+                    ]
                 }
             },
             "type": "object"

--- a/static/redfish/v1/schema/OemPCIeSlots_v1.xml
+++ b/static/redfish/v1/schema/OemPCIeSlots_v1.xml
@@ -44,6 +44,10 @@
           <Annotation Term="OData.Permissions" EnumMember="OData.Permission/Read"/>
           <Annotation Term="OData.Description" String="Number of PCIe lanes in use."/>
         </Property>
+        <Property Name="AssociatedAssembly" Type="OemPCIeSlots.IBM">
+          <Annotation Term="OData.Permissions" EnumMember="OData.Permission/Read"/>
+          <Annotation Term="OData.Description" String="Represent association slot with assembly."/>
+        </Property>
       </ComplexType>
 
     </Schema>


### PR DESCRIPTION
This fixes the incorrect/missing Oem association.
Prior to this, "AssociatedAssembly" is missing.

```
curl -k -X GET  https://${bmc}:18080/redfish/v1/Chassis/chassis/PCIeSlots

 "Slots": [
    {
      "HotPluggable": false,
      "Lanes": 0,
      "Links": {
        "Oem": {
          "IBM": {
            "AssociatedAssembly": [
              {
                "@odata.id": "/redfish/v1/Chassis/chassis/Assembly#/Assemblies/24"
              }
            ]
          }
        },
        "PCIeDevice": [
          {
            "@odata.id": "/redfish/v1/Systems/system/PCIeDevices/motherboard_disk_backplane0_nvme0_dp0_drive0"
          }
        ]
      },

```