### PR TITLE
1050: Remove Inventory.Item.Board interface from Chassis (#415)

### DIFF
--- a/redfish-core/include/utils/chassis_utils.hpp
+++ b/redfish-core/include/utils/chassis_utils.hpp
@@ -16,8 +16,7 @@ void getValidChassisPath(const std::shared_ptr<bmcweb::AsyncResp>& asyncResp,
                          const std::string& chassisId, Callback&& callback)
 {
     BMCWEB_LOG_DEBUG << "checkChassisId enter";
-    const std::array<const char*, 2> interfaces = {
-        "xyz.openbmc_project.Inventory.Item.Board",
+    const std::array<const char*, 1> interfaces = {
         "xyz.openbmc_project.Inventory.Item.Chassis"};
 
     auto respHandler =


### PR DESCRIPTION
IBM does not use the xyz.openbmc_project.Inventory.Item.Board interface for chassis objects. 
Remove that interfaces so only objects implementing xyz.openbmc_project.Inventory.Item.Chassis are returned for getValidChassisPath