### PR TITLE
Fix FabricAdapter Path on PCIeDevie to be unique

### DIFF
--- a/redfish-core/lib/fabric_adapters.hpp
+++ b/redfish-core/lib/fabric_adapters.hpp
@@ -7,6 +7,7 @@
 #include "utils/collection.hpp"
 #include "utils/dbus_utils.hpp"
 #include "utils/json_utils.hpp"
+#include "utils/pcie_util.hpp"
 
 #include <boost/system/error_code.hpp>
 #include <sdbusplus/asio/property.hpp>
@@ -177,7 +178,7 @@ inline void linkAsPCIeDevice(const std::shared_ptr<bmcweb::AsyncResp>& aResp,
                              const std::string& fabricAdapterPath)
 {
     const std::string pcieDeviceName =
-        sdbusplus::message::object_path(fabricAdapterPath).filename();
+        pcie_util::buildPCIeUniquePath(fabricAdapterPath);
 
     if (pcieDeviceName.empty())
     {


### PR DESCRIPTION
PCIeDevice device object is unique, but a fabric adapter on PCIeDevice is missing from it.  This fixes to make this Fabric Adapter on PCIeDevice as unique as like the other PCIeDevices.

PCIeDevices link should point to a correct/valid PCIeDevices.

```
% curl -k -X GET https://${bmc}:18080/redfish/v1/Systems/system/FabricAdapters/pcie_card10
{
  "@odata.id": "/redfish/v1/Systems/system/FabricAdapters/pcie_card10",
  "@odata.type": "#FabricAdapter.v1_4_0.FabricAdapter",
  "Id": "pcie_card10",
  "Links": {
    "PCIeDevices": [
      {
        "@odata.id": "/redfish/v1/Systems/system/PCIeDevices/chassis_motherboard_pcieslot10_pcie_card10"
      }
    ],
    "PCIeDevices@odata.count": 1
  },
...
}%

```