### PR TITLE
1050: Build Fabric Adapters Unique Path (#397)

### DIFF
--- a/redfish-core/include/utils/collection.hpp
+++ b/redfish-core/include/utils/collection.hpp
@@ -9,6 +9,7 @@
 #include <boost/url/url.hpp>
 #include <nlohmann/json.hpp>
 
+#include <functional>
 #include <span>
 #include <string>
 #include <string_view>
@@ -18,6 +19,71 @@ namespace redfish
 {
 namespace collection_util
 {
+
+/**
+ * @brief Populate the collection "Members" from a GetSubTreePaths search of
+ *        inventory
+ *
+ * @param[i,o] aResp  Async response object
+ * @param[i]   collectionPath  Redfish collection path which is used for the
+ *             Members Redfish Path
+ * @param[i]   interfaces  List of interfaces to constrain the GetSubTree search
+ * @param[i]   func getMembersFromPaths    Convert pathnames to member
+ * objects
+ * @param[in]  subtree     D-Bus base path to constrain search to.
+ *
+ * @return void
+ */
+inline void getCollectionMembersWithPathConversion(
+    std::shared_ptr<bmcweb::AsyncResp> aResp,
+    const boost::urls::url& collectionPath,
+    std::span<const std::string_view> interfaces,
+    std::function<void(std::vector<std::string>&,
+                       const dbus::utility::MapperGetSubTreePathsResponse&)>&&
+        getMembersFromPaths,
+    const char* subtree = "/xyz/openbmc_project/inventory")
+{
+    BMCWEB_LOG_DEBUG << "Get collection members for: "
+                     << collectionPath.buffer();
+    dbus::utility::getSubTreePaths(
+        subtree, 0, interfaces,
+        [collectionPath, aResp{std::move(aResp)},
+         getMembersFromPaths{std::move(getMembersFromPaths)}](
+            const boost::system::error_code& ec,
+            const dbus::utility::MapperGetSubTreePathsResponse& objects) {
+        if (ec == boost::system::errc::io_error)
+        {
+            aResp->res.jsonValue["Members"] = nlohmann::json::array();
+            aResp->res.jsonValue["Members@odata.count"] = 0;
+            return;
+        }
+
+        if (ec)
+        {
+            BMCWEB_LOG_DEBUG << "DBUS response error " << ec.value();
+            messages::internalError(aResp->res);
+            return;
+        }
+
+        std::vector<std::string> pathNames;
+        getMembersFromPaths(pathNames, objects);
+
+        std::sort(pathNames.begin(), pathNames.end(),
+                  AlphanumLess<std::string>());
+
+        nlohmann::json& members = aResp->res.jsonValue["Members"];
+        members = nlohmann::json::array();
+        for (const std::string& leaf : pathNames)
+        {
+            boost::urls::url url = collectionPath;
+            crow::utility::appendUrlPieces(url, leaf);
+            nlohmann::json::object_t member;
+            member["@odata.id"] = std::move(url);
+            members.push_back(std::move(member));
+        }
+        aResp->res.jsonValue["Members@odata.count"] = members.size();
+        });
+}
 
 /**
  * @brief Populate the collection "Members" from a GetSubTreePaths search of
@@ -37,28 +103,9 @@ inline void
                          std::span<const std::string_view> interfaces,
                          const char* subtree = "/xyz/openbmc_project/inventory")
 {
-    BMCWEB_LOG_DEBUG << "Get collection members for: "
-                     << collectionPath.buffer();
-    dbus::utility::getSubTreePaths(
-        subtree, 0, interfaces,
-        [collectionPath, aResp{std::move(aResp)}](
-            const boost::system::error_code& ec,
-            const dbus::utility::MapperGetSubTreePathsResponse& objects) {
-        if (ec == boost::system::errc::io_error)
-        {
-            aResp->res.jsonValue["Members"] = nlohmann::json::array();
-            aResp->res.jsonValue["Members@odata.count"] = 0;
-            return;
-        }
-
-        if (ec)
-        {
-            BMCWEB_LOG_DEBUG << "DBUS response error " << ec.value();
-            messages::internalError(aResp->res);
-            return;
-        }
-
-        std::vector<std::string> pathNames;
+    auto getMembersFromPaths =
+        [](std::vector<std::string>& pathNames,
+           const dbus::utility::MapperGetSubTreePathsResponse& objects) {
         for (const auto& object : objects)
         {
             sdbusplus::message::object_path path(object);
@@ -69,21 +116,11 @@ inline void
             }
             pathNames.push_back(leaf);
         }
-        std::sort(pathNames.begin(), pathNames.end(),
-                  AlphanumLess<std::string>());
+    };
 
-        nlohmann::json& members = aResp->res.jsonValue["Members"];
-        members = nlohmann::json::array();
-        for (const std::string& leaf : pathNames)
-        {
-            boost::urls::url url = collectionPath;
-            crow::utility::appendUrlPieces(url, leaf);
-            nlohmann::json::object_t member;
-            member["@odata.id"] = std::move(url);
-            members.push_back(std::move(member));
-        }
-        aResp->res.jsonValue["Members@odata.count"] = members.size();
-        });
+    getCollectionMembersWithPathConversion(
+        std::move(aResp), collectionPath, interfaces,
+        std::move(getMembersFromPaths), subtree);
 }
 
 } // namespace collection_util

--- a/redfish-core/include/utils/fabric_util.hpp
+++ b/redfish-core/include/utils/fabric_util.hpp
@@ -1,0 +1,67 @@
+#pragma once
+
+#include "async_resp.hpp"
+#include "dbus_utility.hpp"
+#include "error_messages.hpp"
+#include "http/utility.hpp"
+#include "human_sort.hpp"
+
+#include <boost/url/url.hpp>
+#include <nlohmann/json.hpp>
+
+#include <span>
+#include <string>
+#include <string_view>
+#include <vector>
+
+namespace redfish
+{
+namespace fabric_util
+{
+
+/*
+ * @brief Verify whether a given adapter is the same to a given adapterId.
+ *
+ * @param[i]   adapterId that represents a fabric object
+ * @param[i]   adapter that is to check whetehr it is the same adaptor
+ *
+ * @return void
+ */
+inline bool checkFabricAdapterId(const std::string& adapterId,
+                                 const std::string& adapter)
+{
+    return !(adapter.empty() || adapterId != adapter);
+}
+
+/**
+ * @brief Workaround to handle duplicate Fabric device list
+ *
+ * retrieve Fabric device endpoint information and if path is
+ * ~/chassisN/logical_slotN/io_moduleN then, replace redfish
+ * Fabric device as "chassisN-logical_slotN-io_moduleN"
+ *
+ * @param[i]   fullPath  object path of Fabric device
+ *
+ * @return string: unique Fabric device name
+ */
+inline std::string buildFabricUniquePath(const std::string& fullPath)
+{
+    sdbusplus::message::object_path path(fullPath);
+    sdbusplus::message::object_path parentPath = path.parent_path();
+
+    std::string devName;
+
+    if (!parentPath.parent_path().filename().empty())
+    {
+        devName = parentPath.parent_path().filename() + "-";
+    }
+    if (!parentPath.filename().empty())
+    {
+        devName += parentPath.filename() + "-";
+    }
+    devName += path.filename();
+    return devName;
+}
+
+} // namespace fabric_util
+} // namespace redfish

--- a/redfish-core/lib/cable.hpp
+++ b/redfish-core/lib/cable.hpp
@@ -6,6 +6,7 @@
 #include <sdbusplus/unpack_properties.hpp>
 #include <utils/chassis_utils.hpp>
 #include <utils/dbus_utils.hpp>
+#include <utils/fabric_util.hpp>
 #include <utils/json_utils.hpp>
 #include <utils/pcie_util.hpp>
 
@@ -229,7 +230,9 @@ inline void
             {
                 continue;
             }
-            std::string endpointLeaf = path.parent_path().filename();
+            std::string parentPath = path.parent_path();
+            std::string endpointLeaf =
+                fabric_util::buildFabricUniquePath(parentPath);
             if (endpointLeaf.empty())
             {
                 continue;
@@ -260,7 +263,9 @@ inline void
             {
                 continue;
             }
-            std::string endpointLeaf = path.parent_path().filename();
+            std::string parentPath = path.parent_path();
+            std::string endpointLeaf =
+                fabric_util::buildFabricUniquePath(parentPath);
             if (endpointLeaf.empty())
             {
                 continue;

--- a/redfish-core/lib/fabric_adapters.hpp
+++ b/redfish-core/lib/fabric_adapters.hpp
@@ -6,6 +6,7 @@
 #include "registries/privilege_registry.hpp"
 #include "utils/collection.hpp"
 #include "utils/dbus_utils.hpp"
+#include "utils/fabric_util.hpp"
 #include "utils/json_utils.hpp"
 #include "utils/pcie_util.hpp"
 
@@ -235,15 +236,6 @@ inline void doAdapterGet(const std::shared_ptr<bmcweb::AsyncResp>& aResp,
     }
 }
 
-inline bool checkFabricAdapterId(const std::string& adapterPath,
-                                 const std::string& adapterId)
-{
-    std::string fabricAdapterName =
-        sdbusplus::message::object_path(adapterPath).filename();
-
-    return !(fabricAdapterName.empty() || fabricAdapterName != adapterId);
-}
-
 inline void getValidFabricAdapterPath(
     const std::string& adapterId, const std::string& systemName,
     const std::shared_ptr<bmcweb::AsyncResp>& aResp,
@@ -271,7 +263,9 @@ inline void getValidFabricAdapterPath(
         }
         for (const auto& [adapterPath, serviceMap] : subtree)
         {
-            if (checkFabricAdapterId(adapterPath, adapterId))
+            std::string adapterUniq =
+                fabric_util::buildFabricUniquePath(adapterPath);
+            if (fabric_util::checkFabricAdapterId(adapterId, adapterUniq))
             {
                 callback(adapterPath, serviceMap.begin()->first,
                          serviceMap.begin()->second);
@@ -329,11 +323,25 @@ inline void handleFabricAdapterCollectionGet(
     aResp->res.jsonValue["@odata.id"] = crow::utility::urlFromPieces(
         "redfish", "v1", "Systems", systemName, "FabricAdapters");
 
+    auto getMembersFromPaths =
+        [](std::vector<std::string>& pathNames,
+           const dbus::utility::MapperGetSubTreePathsResponse& objects) {
+        for (const auto& object : objects)
+        {
+            std::string leaf = fabric_util::buildFabricUniquePath(object);
+            if (leaf.empty())
+            {
+                continue;
+            }
+            pathNames.push_back(leaf);
+        }
+    };
+
     constexpr std::array<std::string_view, 1> interfaces{
         "xyz.openbmc_project.Inventory.Item.FabricAdapter"};
-    collection_util::getCollectionMembers(
+    collection_util::getCollectionMembersWithPathConversion(
         aResp, boost::urls::url("/redfish/v1/Systems/system/FabricAdapters"),
-        interfaces);
+        interfaces, std::move(getMembersFromPaths));
 }
 
 inline void handleFabricAdapterCollectionHead(

--- a/redfish-core/lib/port.hpp
+++ b/redfish-core/lib/port.hpp
@@ -6,6 +6,7 @@
 #include "query.hpp"
 #include "registries/privilege_registry.hpp"
 
+#include <utils/fabric_util.hpp>
 #include <utils/json_utils.hpp>
 
 #include <array>
@@ -95,9 +96,9 @@ inline void getPortCollection(const std::shared_ptr<bmcweb::AsyncResp>& aResp,
 
         for (const auto& path : paths)
         {
-            if (sdbusplus::message::object_path(path)
-                    .parent_path()
-                    .filename() != adapterId)
+            const std::string& adapterUniq =
+                fabric_util::buildFabricUniquePath(path);
+            if (!fabric_util::checkFabricAdapterId(adapterId, adapterUniq))
             {
                 continue;
             }


### PR DESCRIPTION
Defect is https://w3.rchland.ibm.com/projects/bestquest/?defect=SW552762 This commit makesFabric Adapters objects unique, before this commit bmcweb shows Fabric Adaptersobjects with the same path even though all the dbus objects have unique paths

```
{"@odata.id": "/redfish/v1/Systems/system/FabricAdapters/io_module1"},
{"@odata.id": "/redfish/v1/Systems/system/FabricAdapters/io_module1"}
```

after this change bmcweb retrieve FabricAdapterdevice endpoint information and then, replace redfish FabricAdapter device as
"chassisN-logical_slotN-io_moduleN".

Tested: Validator passed
Motherboard FabricAdapter also gets affected.

```
curl -k -H "X-Auth-Token: $token" -X GET  https://${bmc}/redfish/v1/Systems/system/FabricAdapters/
{
  ...
  ...
  "Members": [
   {
      "@odata.id": "/redfish/v1/Systems/system/FabricAdapters/chassis-motherboard-disk_backplane0"
    },
    {
      "@odata.id": "/redfish/v1/Systems/system/FabricAdapters/chassis-motherboard-disk_backplane1"
    },
    {
      "@odata.id": "/redfish/v1/Systems/system/FabricAdapters/motherboard-pcieslot0-pcie_card0"
    },
    {
      "@odata.id": "/redfish/v1/Systems/system/FabricAdapters/motherboard-pcieslot3-pcie_card3"
    },
    ...
   ],
   ...
}
```