### PR TITLE
Add system name in the Redfish Systems ResetActionInfo

### DIFF
--- a/redfish-core/lib/systems.hpp
+++ b/redfish-core/lib/systems.hpp
@@ -2785,23 +2785,15 @@ inline void requestRoutesSystemResetActionInfo(App& app)
     /**
      * Functions triggers appropriate requests on DBus
      */
-    BMCWEB_ROUTE(app, "/redfish/v1/Systems/<str>/ResetActionInfo/")
+    BMCWEB_ROUTE(app, "/redfish/v1/Systems/system/ResetActionInfo/")
         .privileges(redfish::privileges::getActionInfo)
         .methods(boost::beast::http::verb::get)(
             [&app](const crow::Request& req,
-                   const std::shared_ptr<bmcweb::AsyncResp>& asyncResp,
-                   const std::string& systemName) {
+                   const std::shared_ptr<bmcweb::AsyncResp>& asyncResp) {
         if (!redfish::setUpRedfishRoute(app, req, asyncResp))
         {
             return;
         }
-        if (systemName != "system")
-        {
-            messages::resourceNotFound(asyncResp->res, "ComputerSystem",
-                                       systemName);
-            return;
-        }
-
         asyncResp->res.addHeader(
             boost::beast::http::field::link,
             "</redfish/v1/JsonSchemas/ActionInfo/ActionInfo.json>; rel=describedby");


### PR DESCRIPTION
The reason for this change is that there are basically two routes defined: [1] /redfish/v1/Systems/<str>/ResetActionInfo/ in systems.hpp [2] /redfish/v1/Systems/hypervisor/ResetActionInfo/ in hypervisor_system.hpp

Whenever a user does a get on /redfish/v1/Systems/hypervisor/ResetActionInfo, the first route is hit and that checks if <str> is "system" and if not, bmcweb throws resource not found error.

Error:
ERROR - Members: GET of resource at URI /redfish/v1/Systems/hypervisor/ResetActionInfo
        returned HTTP error. Check URI.
ERROR - URI did not return resource /redfish/v1/Systems/hypervisor/ResetActionInfo
  	GET Failure HTTP Code (404)

The below upstream commit is causing this issue:
[1] openbmc/bmcweb@22d268c#diff-cddfc26fddb6ba29f3fd81ecf5840fc6d9a8554bbca92f578d81b97db8b14895

To resolve this issue, the route handler is changed back to /redfish/v1/Systems/system/ResetActionInfo in this commit.

Upstream: https://gerrit.openbmc.org/c/openbmc/bmcweb/+/61224