### PR TITLE
1050: Fix OemMessage Schema (#431)

### DIFF
--- a/static/redfish/v1/JsonSchemas/OemMessage/index.json
+++ b/static/redfish/v1/JsonSchemas/OemMessage/index.json
@@ -3,10 +3,40 @@
     "$schema": "http://redfish.dmtf.org/schemas/v1/redfish-schema-v1.json",
     "copyright": "Copyright 2014-2019 DMTF. For the full DMTF copyright policy, see http://www.dmtf.org/about/policies/copyright",
     "definitions": {
-        "Message": {
-            "additionalProperties": false,
-            "description": "OEM Extension for Message",
-            "longDescription": "OEM Extension for Message, provides extra property for reason for exception.",
+        "Oem": {
+            "additionalProperties": true,
+            "description": "OemMessage Oem properties.",
+            "patternProperties": {
+                "^([a-zA-Z_][a-zA-Z0-9_]*)?@(odata|Redfish|Message)\\.[a-zA-Z_][a-zA-Z0-9_]*$": {
+                    "description": "This property shall specify a valid odata or Redfish property.",
+                    "type": [
+                        "array",
+                        "boolean",
+                        "integer",
+                        "number",
+                        "null",
+                        "object",
+                        "string"
+                    ]
+                }
+            },
+            "properties": {
+                "OpenBmc": {
+                    "anyOf": [
+                        {
+                            "$ref": "#/definitions/OpenBmc"
+                        },
+                        {
+                            "type": "null"
+                        }
+                    ]
+                }
+            },
+            "type": "object"
+        },
+        "OpenBmc": {
+            "additionalProperties": true,
+            "description": "Oem properties for OpenBmc.",
             "patternProperties": {
                 "^([a-zA-Z_][a-zA-Z0-9_]*)?@(odata|Redfish|Message)\\.[a-zA-Z_][a-zA-Z0-9_]*$": {
                     "description": "This property shall specify a valid odata or Redfish property.",

--- a/static/redfish/v1/schema/OemMessage_v1.xml
+++ b/static/redfish/v1/schema/OemMessage_v1.xml
@@ -7,6 +7,10 @@
   <edmx:Reference Uri="http://redfish.dmtf.org/schemas/v1/RedfishExtensions_v1.xml">
     <edmx:Include Namespace="RedfishExtensions.v1_0_0" Alias="Redfish"/>
   </edmx:Reference>
+  <edmx:Reference Uri="http://redfish.dmtf.org/schemas/v1/Message.xml">
+    <edmx:Include Namespace="Message"/>
+    <edmx:Include Namespace="Message.v1_1_2"/>
+  </edmx:Reference>
   <edmx:Reference Uri="http://redfish.dmtf.org/schemas/v1/Resource_v1.xml">
     <edmx:Include Namespace="Resource"/>
     <edmx:Include Namespace="Resource.v1_0_0"/>
@@ -19,24 +23,31 @@
 
     <Schema xmlns="http://docs.oasis-open.org/odata/ns/edm" Namespace="OemMessage.v1_0_0">
       <Annotation Term="Redfish.OwningEntity" String="OpenBMC"/>
-      <Annotation Term="Redfish.Release" String="1.0"/>
 
-      <EntityType Name="Message" BaseType="Resource.OemObject" Abstract="true">
-          <Annotation Term="OData.Description" String="OEM Extension for Message"/>
-          <Annotation Term="OData.LongDescription" String="OEM Extension for Message to provide the OEM specific details"/>
-            <Property Name="AbortReason" Type="Edm.String">
-              <Annotation Term="OData.Description" String="String indicating the reason for exception."/>
-              <Annotation Term="OData.LongDescription" String="Unique string that provides reason for exception."/>
-            </Property>
-            <Property Name="AdditionalData" Type="Edm.String">
-              <Annotation Term="OData.Description" String="String indicating the reason for exception."/>
-              <Annotation Term="OData.LongDescription" String="Unique string that provides reason for exception."/>
-            </Property>
-            <Property Name="EventId" Type="Edm.String">
-              <Annotation Term="OData.Description" String="String indicating the reason for exception."/>
-              <Annotation Term="OData.LongDescription" String="Unique string that provides reason for exception."/>
-            </Property>
-      </EntityType>
+      <ComplexType Name="Oem" BaseType="Resource.OemObject">
+        <Annotation Term="OData.AdditionalProperties" Bool="true"/>
+        <Annotation Term="OData.Description" String="OemMessage Oem properties."/>
+        <Annotation Term="OData.AutoExpand"/>
+        <Property Name="OpenBMC" Type="OemMessage.OpenBMC"/>
+      </ComplexType>
+
+      <ComplexType Name="OpenBMC">
+        <Annotation Term="OData.AdditionalProperties" Bool="true" />
+        <Annotation Term="OData.Description" String="Oem properties for OpenBMC." />
+        <Annotation Term="OData.AutoExpand" />
+        <Property Name="AbortReason" Type="Edm.String">
+          <Annotation Term="OData.Description" String="String indicating the reason for exception."/>
+          <Annotation Term="OData.LongDescription" String="Unique string that provides reason for exception."/>
+        </Property>
+        <Property Name="AdditionalData" Type="Edm.String">
+          <Annotation Term="OData.Description" String="String indicating the reason for exception."/>
+          <Annotation Term="OData.LongDescription" String="Unique string that provides reason for exception."/>
+        </Property>
+        <Property Name="EventId" Type="Edm.String">
+          <Annotation Term="OData.Description" String="String indicating the reason for exception."/>
+          <Annotation Term="OData.LongDescription" String="Unique string that provides reason for exception."/>
+        </Property>
+      </ComplexType>
     </Schema>
   </edmx:DataServices>
 


### PR DESCRIPTION
Redfish validator throws an error due to OemMessage EntityType resource not containing the required @odata.id property.

Testing:
Ran validator and verified the error is not thrown, and the overall validator test passed.

Known Issue: Validator test gives WARNING/FAIL for OEM properties. This is across all downstream OEM schemas. This needs to be handled separately for all OEM schemas.