### PR TITLE
RedfishEvents: Fix upstream redfish events code for HMC

### DIFF
--- a/http/http_client.hpp
+++ b/http/http_client.hpp
@@ -591,7 +591,7 @@ class ConnectionInfo : public std::enable_shared_from_this<ConnectionInfo>
     {
         if (useSSL)
         {
-            std::optional<boost::asio::ssl::context> sslCtx =
+            /* std::optional<boost::asio::ssl::context> sslCtx =
                 ensuressl::getSSLClientContext();
 
             if (!sslCtx)
@@ -606,8 +606,10 @@ class ConnectionInfo : public std::enable_shared_from_this<ConnectionInfo>
                 state = ConnState::sslInitFailed;
                 waitAndRetry();
                 return;
-            }
-            sslConn.emplace(conn, *sslCtx);
+            } */
+            boost::asio::ssl::context sslCtx{
+                boost::asio::ssl::context::tlsv13_client};
+            sslConn.emplace(conn, sslCtx);
             setCipherSuiteTLSext();
         }
     }

--- a/src/webserver_main.cpp
+++ b/src/webserver_main.cpp
@@ -132,6 +132,14 @@ static int run()
 #ifdef BMCWEB_ENABLE_IBM_MANAGEMENT_CONSOLE
     crow::ibm_mc::requestRoutes(app);
     crow::ibm_mc_lock::Lock::getInstance();
+    // Start BMC and Host state change dbus monitor
+    crow::dbus_monitor::registerStateChangeSignal();
+    // Start Dump created signal monitor for BMC and System Dump
+    crow::dbus_monitor::registerDumpUpdateSignal();
+    // Start BIOS Attr change dbus monitor
+    crow::dbus_monitor::registerBIOSAttrUpdateSignal();
+    // Start event log entry created monitor
+    crow::dbus_monitor::registerEventLogCreatedSignal();
 #endif
 
 #ifdef BMCWEB_ENABLE_GOOGLE_API


### PR DESCRIPTION
Currently there are no events send to HMC with OpenBMC upstream redfish event code.
This commit modifies SSL context to use "boost::asio::ssl::context::tlsv13_client" in the 
eventing code to send events to HMC

Tested By:
Connected BMC to HMC and seen event subscription added 
Noticed Task, Dump and save area redfish events received on HMC.