### PR TITLE
Using sdbusplus::asio wrapper functions

### DIFF
--- a/include/dbus_utility.hpp
+++ b/include/dbus_utility.hpp
@@ -97,7 +97,11 @@ using MapperGetAncestorsResponse = std::vector<
               std::vector<std::pair<std::string, std::vector<std::string>>>>>;
 
 using MapperGetSubTreePathsResponse = std::vector<std::string>;
+
 using MapperEndPoints = std::vector<std::string>;
+
+using AssociationList =
+    std::vector<std::tuple<std::string, std::string, std::string>>;
 
 inline void escapePathForDbus(std::string& path)
 {
@@ -208,6 +212,20 @@ inline void
         "xyz.openbmc_project.ObjectMapper",
         "/xyz/openbmc_project/object_mapper",
         "xyz.openbmc_project.ObjectMapper", "GetObject", path, interfaces);
+}
+
+inline void
+    getAssociationList(const std::string& service, const std::string& path,
+                       std::function<void(const boost::system::error_code&,
+                                          const AssociationList&)>&& callback)
+{
+    sdbusplus::asio::getProperty<AssociationList>(
+        *crow::connections::systemBus, service, path,
+        "xyz.openbmc_project.Association.Definitions", "Associations",
+        [callback{std::move(callback)}](const boost::system::error_code& ec,
+                                        const AssociationList& associations) {
+        callback(ec, associations);
+        });
 }
 
 } // namespace utility

--- a/redfish-core/include/utils/chassis_utils.hpp
+++ b/redfish-core/include/utils/chassis_utils.hpp
@@ -134,10 +134,11 @@ inline void
 
     // if there is assembly association, look
     // for endpoints
-    crow::connections::systemBus->async_method_call(
+    dbus::utility::getAssociationEndPoints(
+        assemblyPath,
         [aResp, chassisPath, callback{std::forward<Callback>(callback)}](
             const boost::system::error_code ec,
-            const dbus::utility::DbusVariantType& endpoints) {
+            const dbus::utility::MapperEndPoints& assemblyList) {
         if (ec)
         {
             BMCWEB_LOG_DEBUG << "DBUS response "
@@ -146,24 +147,12 @@ inline void
             return;
         }
 
-        const std::vector<std::string>* assemblyList =
-            std::get_if<std::vector<std::string>>(&(endpoints));
-
-        if (assemblyList == nullptr)
-        {
-            BMCWEB_LOG_DEBUG << "No assembly found";
-            return;
-        }
-
-        std::vector<std::string> sortedAssemblyList = *assemblyList;
+        dbus::utility::MapperEndPoints sortedAssemblyList = assemblyList;
         std::sort(sortedAssemblyList.begin(), sortedAssemblyList.end());
         checkAssemblyInterface(aResp, chassisPath, sortedAssemblyList,
                                std::move(callback));
         return;
-        },
-        "xyz.openbmc_project.ObjectMapper", assemblyPath,
-        "org.freedesktop.DBus.Properties", "Get",
-        "xyz.openbmc_project.Association", "endpoints");
+        });
 }
 
 template <typename Callback>
@@ -177,10 +166,12 @@ inline void checkForAssemblyAssociations(
     using associationList =
         std::vector<std::tuple<std::string, std::string, std::string>>;
 
-    crow::connections::systemBus->async_method_call(
+    sdbusplus::asio::getProperty<associationList>(
+        *crow::connections::systemBus, service, chassisPath,
+        "xyz.openbmc_project.Association.Definitions", "Associations",
         [aResp, chassisPath, callback{std::forward<Callback>(callback)}](
             const boost::system::error_code ec,
-            const std::variant<associationList>& associations) {
+            const associationList& associations) {
         if (ec)
         {
             BMCWEB_LOG_DEBUG << "DBUS response error";
@@ -188,16 +179,7 @@ inline void checkForAssemblyAssociations(
             return;
         }
 
-        const associationList* value =
-            std::get_if<associationList>(&associations);
-        if (value == nullptr)
-        {
-            BMCWEB_LOG_DEBUG << "DBUS response error";
-            messages::internalError(aResp->res);
-            return;
-        }
-
-        for (const auto& listOfAssociations : *value)
+        for (const auto& listOfAssociations : associations)
         {
             if (std::get<0>(listOfAssociations) != "assembly")
             {
@@ -209,9 +191,7 @@ inline void checkForAssemblyAssociations(
             getAssemblyEndpoints(aResp, chassisPath, std::move(callback));
             break;
         }
-        },
-        service, chassisPath, "org.freedesktop.DBus.Properties", "Get",
-        "xyz.openbmc_project.Association.Definitions", "Associations");
+        });
 }
 
 template <typename Callback>

--- a/redfish-core/include/utils/chassis_utils.hpp
+++ b/redfish-core/include/utils/chassis_utils.hpp
@@ -163,15 +163,11 @@ inline void checkForAssemblyAssociations(
 {
     BMCWEB_LOG_DEBUG << "Check for assembly association";
 
-    using associationList =
-        std::vector<std::tuple<std::string, std::string, std::string>>;
-
-    sdbusplus::asio::getProperty<associationList>(
-        *crow::connections::systemBus, service, chassisPath,
-        "xyz.openbmc_project.Association.Definitions", "Associations",
+    dbus::utility::getAssociationList(
+        service, chassisPath,
         [aResp, chassisPath, callback{std::forward<Callback>(callback)}](
             const boost::system::error_code ec,
-            const associationList& associations) {
+            const dbus::utility::AssociationList& associations) {
         if (ec)
         {
             BMCWEB_LOG_DEBUG << "DBUS response error";

--- a/redfish-core/include/utils/dbus_utils.hpp
+++ b/redfish-core/include/utils/dbus_utils.hpp
@@ -14,7 +14,7 @@ struct UnpackErrorPrinter
     void operator()(const sdbusplus::UnpackErrorReason reason,
                     const std::string& property) const noexcept
     {
-        BMCWEB_LOG_DEBUG
+        BMCWEB_LOG_ERROR
             << "DBUS property error in property: " << property << ", reason: "
             << static_cast<
                    std::underlying_type_t<sdbusplus::UnpackErrorReason>>(

--- a/redfish-core/include/utils/error_log_utils.hpp
+++ b/redfish-core/include/utils/error_log_utils.hpp
@@ -1,5 +1,8 @@
 #pragma once
 
+#include <sdbusplus/asio/property.hpp>
+
+#include <memory>
 namespace redfish
 {
 namespace error_log_utils

--- a/redfish-core/include/utils/hw_isolation.hpp
+++ b/redfish-core/include/utils/hw_isolation.hpp
@@ -452,6 +452,111 @@ inline bool setSeverity(const std::shared_ptr<bmcweb::AsyncResp>& aResp,
     return true;
 }
 
+void assembleEventProperties(const std::shared_ptr<bmcweb::AsyncResp>& aResp,
+                             const dbus::utility::DBusPropertiesMap& properties,
+                             nlohmann::json& condition, const std::string& path)
+{
+    using AssociationsValType =
+        std::vector<std::tuple<std::string, std::string, std::string>>;
+    const AssociationsValType* associations = nullptr;
+    const uint64_t* timestamp = nullptr;
+    const std::string* msgPropVal = nullptr;
+    const std::string* severity = nullptr;
+
+    const bool success = sdbusplus::unpackPropertiesNoThrow(
+        dbus_utils::UnpackErrorPrinter(), properties, "Associations",
+        associations, "Timestamp", timestamp, "Message", msgPropVal, "Severity",
+        severity);
+
+    if (!success)
+    {
+        messages::internalError(aResp->res);
+        BMCWEB_LOG_ERROR << "Could not read one or more properties from "
+                         << path;
+        return;
+    }
+
+    if (associations != nullptr)
+    {
+        for (const auto& assoc : *associations)
+        {
+            if (std::get<0>(assoc) == "error_log")
+            {
+                sdbusplus::message::object_path errPath = std::get<2>(assoc);
+                // we have only one condition
+                nlohmann::json::json_pointer logEntryPropPath =
+                    "/Status/Conditions/0/LogEntry"_json_pointer;
+                error_log_utils::setErrorLogUri(aResp, errPath,
+                                                logEntryPropPath, true);
+            }
+        }
+    }
+
+    if (timestamp != nullptr)
+    {
+        condition["Timestamp"] = redfish::time_utils::getDateTimeStdtime(
+            static_cast<std::time_t>(*timestamp));
+    }
+
+    if (msgPropVal != nullptr)
+    {
+        // Host recovered even if there is hardware
+        // isolation entry so change the state.
+        if (*msgPropVal == "Recovered")
+        {
+            aResp->res.jsonValue["Status"]["State"] = "Enabled";
+        }
+
+        const redfish::registries::Message* msgReg =
+            registries::getMessage("OpenBMC.0.2."
+                                   "HardwareIsolationReason");
+
+        if (msgReg == nullptr)
+        {
+            BMCWEB_LOG_ERROR << "Failed to get "
+                             << "the HardwareIsolationReason "
+                             << "message registry to add "
+                             << "in the condition";
+            messages::internalError(aResp->res);
+            return;
+        }
+
+        // Prepare MessageArgs as per defined in the
+        // MessageRegistries
+        std::vector<std::string> messageArgs{*msgPropVal};
+
+        // Fill the "msgPropVal" as reason
+        std::string message = msgReg->message;
+        int i = 0;
+        for (const std::string& messageArg : messageArgs)
+        {
+            std::string argIndex = "%" + std::to_string(++i);
+            size_t argPos = message.find(argIndex);
+            if (argPos != std::string::npos)
+            {
+                message.replace(argPos, argIndex.length(), messageArg);
+            }
+        }
+        // Severity will be added based on the event
+        // object property
+        condition["Message"] = message;
+        condition["MessageArgs"] = messageArgs;
+        condition["MessageId"] = "OpenBMC.0.2.HardwareIsolationReason";
+    }
+
+    if (severity != nullptr)
+    {
+        // we have only one condition
+        nlohmann::json::json_pointer severityPropPath =
+            "/Status/Conditions/0/Severity"_json_pointer;
+        if (!setSeverity(aResp, path, severityPropPath, *severity))
+        {
+            // Failed to set the severity
+            return;
+        }
+    }
+}
+
 /*
  * @brief The helper API to set the Redfish Status conditions based on
  *        the given resource event log association.
@@ -552,17 +657,13 @@ inline void
                 return;
             }
 
-            using AssociationsValType =
-                std::vector<std::tuple<std::string, std::string, std::string>>;
-            using HwStausEventPropertiesType = boost::container::flat_map<
-                std::string,
-                std::variant<std::string, uint64_t, AssociationsValType>>;
-
             // Get event properties and fill into status conditions
-            crow::connections::systemBus->async_method_call(
+            sdbusplus::asio::getAllProperties(
+                *crow::connections::systemBus, objType[0].first,
+                hwStatusEventObj, "",
                 [aResp, hwStatusEventObj](
                     const boost::system::error_code ec2,
-                    const HwStausEventPropertiesType& properties) {
+                    const dbus::utility::DBusPropertiesMap& properties) {
                 if (ec2)
                 {
                     BMCWEB_LOG_ERROR
@@ -585,136 +686,9 @@ inline void
                 conditions.push_back(nlohmann::json::object());
                 nlohmann::json& condition = conditions.back();
 
-                for (const auto& property : properties)
-                {
-                    if (property.first == "Associations")
-                    {
-                        const AssociationsValType* associations =
-                            std::get_if<AssociationsValType>(&property.second);
-                        if (associations == nullptr)
-                        {
-                            BMCWEB_LOG_ERROR
-                                << "Failed to get the Associations "
-                                << "from object: " << hwStatusEventObj;
-                            messages::internalError(aResp->res);
-                            return;
-                        }
-
-                        for (const auto& assoc : *associations)
-                        {
-                            if (std::get<0>(assoc) == "error_log")
-                            {
-                                sdbusplus::message::object_path errPath =
-                                    std::get<2>(assoc);
-                                // we have only one condition
-                                nlohmann::json::json_pointer logEntryPropPath =
-                                    "/Status/Conditions/0/LogEntry"_json_pointer;
-                                error_log_utils::setErrorLogUri(
-                                    aResp, errPath, logEntryPropPath, true);
-                            }
-                        }
-                    }
-                    else if (property.first == "Timestamp")
-                    {
-                        const uint64_t* timestamp =
-                            std::get_if<uint64_t>(&property.second);
-                        if (timestamp == nullptr)
-                        {
-                            BMCWEB_LOG_ERROR
-                                << "Failed to get the Timestamp "
-                                << "from object: " << hwStatusEventObj;
-                            messages::internalError(aResp->res);
-                            return;
-                        }
-                        condition["Timestamp"] =
-                            redfish::time_utils::getDateTimeStdtime(
-                                static_cast<std::time_t>(*timestamp));
-                    }
-                    else if (property.first == "Message")
-                    {
-                        const std::string* msgPropVal =
-                            std::get_if<std::string>(&property.second);
-                        if (msgPropVal == nullptr)
-                        {
-                            BMCWEB_LOG_ERROR
-                                << "Failed to get the Message "
-                                << "from object: " << hwStatusEventObj;
-                            messages::internalError(aResp->res);
-                            return;
-                        }
-
-                        // Host recovered even if there is hardware
-                        // isolation entry so change the state.
-                        if (*msgPropVal == "Recovered")
-                        {
-                            aResp->res.jsonValue["Status"]["State"] = "Enabled";
-                        }
-
-                        const redfish::registries::Message* msgReg =
-                            registries::getMessage("OpenBMC.0.2."
-                                                   "HardwareIsolationReason");
-
-                        if (msgReg == nullptr)
-                        {
-                            BMCWEB_LOG_ERROR << "Failed to get "
-                                             << "the HardwareIsolationReason "
-                                             << "message registry to add "
-                                             << "in the condition";
-                            messages::internalError(aResp->res);
-                            return;
-                        }
-
-                        // Prepare MessageArgs as per defined in the
-                        // MessageRegistries
-                        std::vector<std::string> messageArgs{*msgPropVal};
-
-                        // Fill the "msgPropVal" as reason
-                        std::string message = msgReg->message;
-                        int i = 0;
-                        for (const std::string& messageArg : messageArgs)
-                        {
-                            std::string argIndex = "%" + std::to_string(++i);
-                            size_t argPos = message.find(argIndex);
-                            if (argPos != std::string::npos)
-                            {
-                                message.replace(argPos, argIndex.length(),
-                                                messageArg);
-                            }
-                        }
-                        // Severity will be added based on the event
-                        // object property
-                        condition["Message"] = message;
-                        condition["MessageArgs"] = messageArgs;
-                        condition["MessageId"] =
-                            "OpenBMC.0.2.HardwareIsolationReason";
-                    }
-                    else if (property.first == "Severity")
-                    {
-                        const std::string* severity =
-                            std::get_if<std::string>(&property.second);
-                        if (severity == nullptr)
-                        {
-                            BMCWEB_LOG_ERROR
-                                << "Failed to get the Severity "
-                                << "from object: " << hwStatusEventObj;
-                            messages::internalError(aResp->res);
-                            return;
-                        }
-
-                        // we have only one condition
-                        nlohmann::json::json_pointer severityPropPath =
-                            "/Status/Conditions/0/Severity"_json_pointer;
-                        if (!setSeverity(aResp, hwStatusEventObj,
-                                         severityPropPath, *severity))
-                        {
-                            // Failed to set the severity
-                            return;
-                        }
-                    }
-                }
-                },
-                objType[0].first, hwStatusEventObj,
-                "org.freedesktop.DBus.Properties", "GetAll", "");
+                assembleEventProperties(aResp, properties, condition,
+                                        hwStatusEventObj);
+                });
             },
             "xyz.openbmc_project.ObjectMapper",
             "/xyz/openbmc_project/object_mapper",

--- a/redfish-core/include/utils/hw_isolation.hpp
+++ b/redfish-core/include/utils/hw_isolation.hpp
@@ -4,7 +4,6 @@
 #include <utils/time_utils.hpp>
 
 #include <string>
-#include <vector>
 
 namespace redfish
 {

--- a/redfish-core/include/utils/name_utils.hpp
+++ b/redfish-core/include/utils/name_utils.hpp
@@ -2,11 +2,6 @@
 #pragma once
 #include <async_resp.hpp>
 
-#include <algorithm>
-#include <string>
-#include <variant>
-#include <vector>
-
 namespace redfish
 {
 namespace name_util

--- a/redfish-core/include/utils/name_utils.hpp
+++ b/redfish-core/include/utils/name_utils.hpp
@@ -43,37 +43,27 @@ inline void getPrettyName(
         return;
     }
 
-    crow::connections::systemBus->async_method_call(
-        [asyncResp, path,
-         namePath](const boost::system::error_code ec,
-                   const std::variant<std::string>& prettyName) {
+    sdbusplus::asio::getProperty<std::string>(
+        *crow::connections::systemBus, services[0].first, path,
+        "xyz.openbmc_project.Inventory.Item", "PrettyName",
+
+        [asyncResp, path, namePath](const boost::system::error_code ec,
+                                    const std::string& prettyName) {
         if (ec)
         {
             BMCWEB_LOG_DEBUG << "DBUS response error " << ec;
             return;
         }
 
-        const std::string* value = std::get_if<std::string>(&prettyName);
-
-        if (value == nullptr)
-        {
-
-            BMCWEB_LOG_ERROR << "Failed to get Pretty Name for " << path;
-            messages::internalError(asyncResp->res);
-            return;
-        }
-
-        if (value->empty())
+        if (prettyName.empty())
         {
             return;
         }
 
-        BMCWEB_LOG_DEBUG << "Pretty Name: " << *value;
+        BMCWEB_LOG_DEBUG << "Pretty Name: " << prettyName;
 
-        asyncResp->res.jsonValue[namePath] = *value;
-        },
-        services[0].first, path, "org.freedesktop.DBus.Properties", "Get",
-        "xyz.openbmc_project.Inventory.Item", "PrettyName");
+        asyncResp->res.jsonValue[namePath] = prettyName;
+        });
 }
 
 } // namespace name_util

--- a/redfish-core/lib/assembly.hpp
+++ b/redfish-core/lib/assembly.hpp
@@ -6,8 +6,8 @@
 #include <utils/dbus_utils.hpp>
 #include <utils/json_utils.hpp>
 
-#include <iterator>
-#include <variant>
+#include <cstddef>
+#include <string>
 
 namespace redfish
 {

--- a/redfish-core/lib/assembly.hpp
+++ b/redfish-core/lib/assembly.hpp
@@ -735,15 +735,11 @@ inline void checkForAssemblyAssociations(
 {
     BMCWEB_LOG_DEBUG << "Check for assembly association";
 
-    using associationList =
-        std::vector<std::tuple<std::string, std::string, std::string>>;
-
-    sdbusplus::asio::getProperty<associationList>(
-        *crow::connections::systemBus, service, chassisPath,
-        "xyz.openbmc_project.Association.Definitions", "Associations",
+    dbus::utility::getAssociationList(
+        service, chassisPath,
         [aResp, chassisPath, setLocationIndicatorActiveFlag,
          req](const boost::system::error_code ec,
-              const associationList& associations) {
+              const dbus::utility::AssociationList& associations) {
         if (ec)
         {
             BMCWEB_LOG_DEBUG << "DBUS response error";


### PR DESCRIPTION
Use sdbusplus::asio wrapper functions getProperty and getAllProperties in place of direct "Get" and "GetAll".
This is created to address the comment https://github.com/ibm-openbmc/bmcweb/pull/542#discussion_r1107935850

Tested output:
-bash-4.2$ curl -k -H "X-Auth-Token: 
{BMC_IP}/redfish/v1/Systems/system/LogServices/HardwareIsolation/Entries
{
"@odata.id": "/redfish/v1/Systems/system/LogServices/HardwareIsolation/Entries",
"@odata.type": "#LogEntryCollection.LogEntryCollection",
"Description": "Collection of System Hardware Isolation Entries",
"Members": [
{
"@odata.id": "/redfish/v1/Systems/system/LogServices/HardwareIsolation/Entries/1",
"@odata.type": "#LogEntry.v1_9_0.LogEntry",
"Created": "2023-03-06T00:43:47+00:00",
"EntryType": "Event",
"Id": "1",
"Links": {
"OriginOfCondition": {
"@odata.id": "/redfish/v1/Systems/system/Memory/dimm2"
}
},
"Message": "OpenCAPI Memory Buffer",
"Name": "Hardware Isolation Entry",
"Severity": "Warning"
},
{
"@odata.id": "/redfish/v1/Systems/system/LogServices/HardwareIsolation/Entries/3",
"@odata.type": "#LogEntry.v1_9_0.LogEntry",
"Created": "2023-03-06T00:43:47+00:00",
"EntryType": "Event",
"Id": "3",
"Links": {
"OriginOfCondition": {
"@odata.id": "/redfish/v1/Systems/system/Memory/dimm18"
}
},
"Message": "OpenCAPI Memory Buffer",
"Name": "Hardware Isolation Entry",
"Severity": "Warning"
},
{
"@odata.id": "/redfish/v1/Systems/system/LogServices/HardwareIsolation/Entries/5",
"@odata.type": "#LogEntry.v1_9_0.LogEntry",
"Created": "2023-03-06T00:43:47+00:00",
"EntryType": "Event",
"Id": "5",
"Links": {
"OriginOfCondition": {
"@odata.id": "/redfish/v1/Systems/system/Memory/dimm3"
}
},
"Message": "OpenCAPI Memory Buffer",
"Name": "Hardware Isolation Entry",
"Severity": "Warning"
},
{
"@odata.id": "/redfish/v1/Systems/system/LogServices/HardwareIsolation/Entries/7",
"@odata.type": "#LogEntry.v1_9_0.LogEntry",
"Created": "2023-03-06T00:43:47+00:00",
"EntryType": "Event",
"Id": "7",
"Links": {
"OriginOfCondition": {
"@odata.id": "/redfish/v1/Systems/system/Memory/dimm19"
}
},
"Message": "OpenCAPI Memory Buffer",
"Name": "Hardware Isolation Entry",
"Severity": "Warning"
}
],
"[Members@odata.count](mailto:Members@odata.count)": 4,
"Name": "Hardware Isolation Entries"