### PR TITLE
1050: Fix OemServiceRoot index.json content

### DIFF
--- a/static/redfish/v1/JsonSchemas/OemServiceRoot/index.json
+++ b/static/redfish/v1/JsonSchemas/OemServiceRoot/index.json
@@ -1,11 +1,11 @@
 {
-    "$id": "http://redfish.dmtf.org/schemas/v1/OemLogEntryAttachment.json",
+    "$id": "http://redfish.dmtf.org/schemas/v1/OemServiceRoot.json",
     "$schema": "http://redfish.dmtf.org/schemas/v1/redfish-schema-v1.json",
     "copyright": "Copyright 2014-2019 DMTF. For the full DMTF copyright policy, see http://www.dmtf.org/about/policies/copyright",
     "definitions": {
         "Oem": {
             "additionalProperties": true,
-            "description": "OemLogEntryAttachment Oem properties.",
+            "description": "OemServiceRoot Oem properties.",
             "patternProperties": {
                 "^([a-zA-Z_][a-zA-Z0-9_]*)?@(odata|Redfish|Message)\\.[a-zA-Z_][a-zA-Z0-9_]*$": {
                     "description": "This property shall specify a valid odata or Redfish property.",
@@ -26,6 +26,7 @@
                         }
                     ]
                 }
+
             },
             "type": "object"
         },
@@ -47,8 +48,9 @@
                 }
             },
             "properties": {
-                "PelJson": {
-                    "description": "PEL in Json format.",
+                "Model": {
+                    "description": "The product name for this system, without the manufacturer name.",
+                    "longDescription": "This property shall describe how the manufacturer refers to this system.  Typically, this value is the product name for this system without the manufacturer name.",
                     "readonly": true,
                     "type": [
                         "string",
@@ -99,5 +101,5 @@
     },
     "owningEntity": "IBM",
     "release": "1.0",
-    "title": "#OemLogEntryAttachment"
+    "title": "#OemServiceRoot"
 }


### PR DESCRIPTION
The file `static/redfish/v1/JsonSchemas/OemServiceRoot/index.json` was incorrectly constructed
via commit
`https://github.com/ibm-openbmc/bmcweb/commit/5f790b1346da96e3ffbfa4b6e5eac15ede0eeae7`

This corrects the content of OemServiceRoot/index.json.