### PR TITLE
1050: Return forbidden return code for RestrictedRole operations

### DIFF
--- a/redfish-core/src/error_messages.cpp
+++ b/redfish-core/src/error_messages.cpp
@@ -1857,21 +1857,13 @@ nlohmann::json invalidUpload(std::string_view arg1, std::string_view arg2)
  */
 nlohmann::json restrictedRole(const std::string& arg1)
 {
-    return nlohmann::json{
-        {"@odata.type", "#Message.v1_1_1.Message"},
-        {"MessageId", "Base.1.9.0.RestrictedRole"},
-        {"Message", "The operation was not successful because the role '" +
-                        arg1 + "' is restricted."},
-        {"MessageArgs", {arg1}},
-        {"MessageSeverity", "Warning"},
-        {"Resolution",
-         "No resolution is required.  For standard roles, consider using the role "
-         "specified in the AlternateRoleId property in the Role resource."}};
+    return getLog(redfish::registries::base::Index::restrictedRole,
+                  std::to_array<std::string_view>({arg1}));
 }
 
 void restrictedRole(crow::Response& res, const std::string& arg1)
 {
-    res.result(boost::beast::http::status::bad_request);
+    res.result(boost::beast::http::status::forbidden);
     addMessageToErrorJson(res.jsonValue, restrictedRole(arg1));
 }
 


### PR DESCRIPTION
This fixes the http error code of the operations of the restricted role which currently result in bad_request (400) instead of forbidden (403).

Defect:
https://jazz07.rchland.ibm.com:13443/jazz/web/projects/CSSD#action=com.ibm.team.workitem.viewWorkItem&id=356235

Upstream: 
https://gerrit.openbmc.org/c/openbmc/bmcweb/+/61657
Change-Id: I1b212ccb5a630750eb5d4197970b4fb75fceffd7

Tested:

```
user=service
pass=<admin's passwd>

$ redfishtool -r ${bmc}:18080 -u ${user} -p ${pass} -S Always raw POST /redfish/v1/AccountService/Accounts -d '{"UserName":"service","Password":"newPwd1","RoleId":"Operator"}'
   redfishtool: Transport: Response Error: status_code: 403 -- Forbidden--user not authorized to perform action
   redfishtool: raw: Error sending POST to resource, aborting

$ redfishtool -r ${bmc}:18080 -u ${user} -p ${pass} -S Always raw PATCH /redfish/v1/AccountService/Accounts/${user} -d '{"Password":"NewTestPwd123"}'
   redfishtool: Transport: Response Error: status_code: 403 -- Forbidden--user not authorized to perform action

$ redfishtool -r ${bmc}:18080 -u ${user} -p ${pass} -S Always raw PATCH /redfish/v1/AccountService/Accounts/${user} -d '{"UserName":"new-service"}'
   redfishtool: Transport: Response Error: status_code: 403 -- Forbidden--user not authorized to perform action

$ redfishtool -r ${bmc}:18080 -u ${user} -p ${pass} -S Always raw PATCH /redfish/v1/AccountService/Accounts/${user} -d '{"RoleId":"Operator"}'
   redfishtool: Transport: Response Error: status_code: 403 -- Forbidden--user not authorized to perform action

$ redfishtool -r ${bmc}:18080 -u ${user} -p ${pass} -S Always raw DELETE /redfish/v1/AccountService/Accounts/${user}
   redfishtool: Transport: Response Error: status_code: 403 -- Forbidden--user not authorized to perform action
   redfishtool: raw: Error sending DELETE to resource, aborting

```
