### PR TITLE
Remove AddressState from redfish response

### DIFF
--- a/redfish-core/lib/ethernet.hpp
+++ b/redfish-core/lib/ethernet.hpp
@@ -1784,7 +1784,9 @@ inline void parseInterfaceData(
         ipv6["Address"] = ipv6Config.address;
         ipv6["PrefixLength"] = ipv6Config.prefixLength;
         ipv6["AddressOrigin"] = ipv6Config.origin;
-        ipv6["AddressState"] = nullptr;
+        // TODO: Let this not display null until there is a network backend
+        // to fetch the valid enum value. The value null misleads the user.
+        // ipv6["AddressState"] = nullptr;
         ipv6Array.push_back(std::move(ipv6));
         if (ipv6Config.origin == "Static")
         {


### PR DESCRIPTION
Network backend does not return the AddressState and its currently displayed as null. This is misleading the user

This commit removes this property until backend suppports.

Tested by:
 Verify ethernet interface does not return AddressState for IPv6

Change-Id: I5489f57ce3d50d1480033f27adf1bc95153fdd18
Signed-off-by: Sunitha Harish <sunithaharish04@gmail.com>