### PR TITLE
Fix issues while creating dumps

### DIFF
--- a/redfish-core/include/resource_messages.hpp
+++ b/redfish-core/include/resource_messages.hpp
@@ -37,7 +37,7 @@ inline nlohmann::json resourceCreated()
 inline nlohmann::json resourceRemoved()
 {
     return getLogResourceEvent(
-        redfish::registries::resource_event::Index::resourceCreated, {});
+        redfish::registries::resource_event::Index::resourceRemoved, {});
 }
 
 } // namespace messages

--- a/redfish-core/lib/log_services.hpp
+++ b/redfish-core/lib/log_services.hpp
@@ -895,7 +895,8 @@ inline std::string getDumpEntryPath(const std::string& dumpPath)
     {
         return "/redfish/v1/Managers/bmc/LogServices/Dump/Entries/";
     }
-    if (dumpPath == "/xyz/openbmc_project/dump/system/entry")
+    if ((dumpPath == "/xyz/openbmc_project/dump/system/entry") ||
+        (dumpPath == "/xyz/openbmc_project/dump/resource/entry"))
     {
         return "/redfish/v1/Systems/system/LogServices/Dump/Entries/";
     }
@@ -1004,12 +1005,12 @@ inline void createDumpTaskCallback(
             taskData->messages.emplace_back(retMessage);
 
             std::string headerLoc;
-            if ((createdObjPath.str).find("/resource/") == std::string::npos)
+            if ((createdObjPath.str).find("/resource/") != std::string::npos)
             {
                 headerLoc = "Location: " + dumpEntryPath +
                             http_helpers::urlEncode("Resource_" + dumpId);
             }
-            else if ((createdObjPath.str).find("/system/") == std::string::npos)
+            else if ((createdObjPath.str).find("/system/") != std::string::npos)
             {
                 headerLoc = "Location: " + dumpEntryPath +
                             http_helpers::urlEncode("System_" + dumpId);
@@ -1084,7 +1085,7 @@ inline void createDump(const std::shared_ptr<bmcweb::AsyncResp>& asyncResp,
                 "DiagnosticDataType & OEMDiagnosticDataType");
             return;
         }
-        if ((*oemDiagnosticDataType != "System") ||
+        if ((*oemDiagnosticDataType != "System") &&
             (*diagnosticDataType != "OEM"))
         {
             BMCWEB_LOG_ERROR << "Wrong parameter values passed";


### PR DESCRIPTION
There were a few changes missed during the rebase activity

This change will fix the following issues:
* BMC dumps on successful creation is reported as Resource_<bmc dump id> in the task header
* Resource creation fails to initiate with "Wrong parameter values passed" error

Tested-By:

* Created a BMC dump and checked the task URI associated with this dump creation for correct bmc dump id in the "Location" field
* Successful reation of a resource dump