### PR TITLE
Remove the default assembly Health

### DIFF
--- a/redfish-core/lib/assembly.hpp
+++ b/redfish-core/lib/assembly.hpp
@@ -60,9 +60,6 @@ inline void
         tempyArray.at(assemblyIndex)["Name"] =
             sdbusplus::message::object_path(assembly).filename();
 
-        // Set the default Status
-        tempyArray.at(assemblyIndex)["Status"]["Health"] = "OK";
-
         // Handle special case for tod_battery assembly OEM ReadyToRemove
         // property NOTE: The following method for the special case of the
         // tod_battery ReadyToRemove property only works when there is only ONE
@@ -287,6 +284,10 @@ inline void
                                     {
                                         assemblyData["Status"]["Health"] =
                                             "Critical";
+                                    }
+                                    else
+                                    {
+                                        assemblyData["Status"]["Health"] = "OK";
                                     }
                                 },
                                 serviceName, assembly,


### PR DESCRIPTION
Needs to go into 1040 
Defect is https://jazz07.rchland.ibm.com:13443/jazz/web/projects/CSSD#action=com.ibm.team.workitem.viewWorkItem&id=454681

Since it is different lines, I'll push the 1050 myself. 
https://github.com/ibm-openbmc/bmcweb/blob/1050/redfish-core/lib/assembly.hpp#L105

Have a defect where assemblies for the I/O expansion chassis's assemblies don't have an operationalStatus because we don't know the health of the FRU but we still have a Redfish Health for these FRUs. Upstream we have been default Health and State, the thinking is "Hey I reported this inventory item, mark it as good by default.". Upstream maybe we should do something different.