### PR TITLE
1050: Remove the default assembly Health

### DIFF
--- a/redfish-core/lib/assembly.hpp
+++ b/redfish-core/lib/assembly.hpp
@@ -101,9 +101,6 @@ inline void
         tempyArray.at(assemblyIndex)["Name"] =
             sdbusplus::message::object_path(assembly).filename();
 
-        // Set the default Status
-        tempyArray.at(assemblyIndex)["Status"]["Health"] = "OK";
-
         // Handle special case for tod_battery assembly OEM ReadyToRemove
         // property NOTE: The following method for the special case of the
         // tod_battery ReadyToRemove property only works when there is only ONE
@@ -241,6 +238,10 @@ inline void
                             if (!functional)
                             {
                                 assemblyData["Status"]["Health"] = "Critical";
+                            }
+                            else
+                            {
+                                assemblyData["Status"]["Health"] = "OK";
                             }
                             });
                     }


### PR DESCRIPTION
Defect is https://jazz07.rchland.ibm.com:13443/jazz/web/projects/CSSD#action=com.ibm.team.workitem.viewWorkItem&id=454681

Have a defect where assemblies for the I/O expansion chassis's assemblies don't have an operationalStatus because we don't know the health of the FRU but we still have a Redfish Health for these FRUs. Upstream we have been default Health and State, the thinking is "Hey I reported this inventory item, mark it as good by default.". Upstream maybe we should do something different.

Didn't test directly but tested 1030.

https://github.com/ibm-openbmc/bmcweb/pull/627/ is the 1030/1040 PR.