### PR TITLE
1050: Add privilege check in handleUpgrade and check "service" for HYP console

### DIFF
--- a/http/app.hpp
+++ b/http/app.hpp
@@ -58,9 +58,11 @@ class App
     App& operator=(const App&&) = delete;
 
     template <typename Adaptor>
-    void handleUpgrade(const Request& req, Response& res, Adaptor&& adaptor)
+    void handleUpgrade(Request& req,
+                       const std::shared_ptr<bmcweb::AsyncResp>& asyncResp,
+                       Adaptor&& adaptor)
     {
-        router.handleUpgrade(req, res, std::forward<Adaptor>(adaptor));
+        router.handleUpgrade(req, asyncResp, std::forward<Adaptor>(adaptor));
     }
 
     void handle(Request& req,

--- a/http/http_connection.hpp
+++ b/http/http_connection.hpp
@@ -384,7 +384,7 @@ class Connection :
                 thisReq.getHeaderValue(boost::beast::http::field::upgrade),
                 "websocket"))
         {
-            handler->handleUpgrade(thisReq, res, std::move(adaptor));
+            handler->handleUpgrade(thisReq, asyncResp, std::move(adaptor));
             // delete lambda with self shared_ptr
             // to enable connection destruction
             asyncResp->res.setCompleteRequestHandler(nullptr);

--- a/http/routing.hpp
+++ b/http/routing.hpp
@@ -9,12 +9,14 @@
 #include "privileges.hpp"
 #include "sessions.hpp"
 #include "utility.hpp"
+#include "utils/dbus_utils.hpp"
 #include "verb.hpp"
 #include "websocket.hpp"
 
 #include <async_resp.hpp>
 #include <boost/beast/ssl/ssl_stream.hpp>
 #include <boost/container/flat_map.hpp>
+#include <sdbusplus/unpack_properties.hpp>
 
 #include <cerrno>
 #include <cstdint>
@@ -55,19 +57,21 @@ class BaseRule
     virtual void handle(const Request& /*req*/,
                         const std::shared_ptr<bmcweb::AsyncResp>&,
                         const RoutingParams&) = 0;
-    virtual void handleUpgrade(const Request& /*req*/, Response& res,
-                               boost::asio::ip::tcp::socket&& /*adaptor*/)
+#ifndef BMCWEB_ENABLE_SSL
+    virtual void
+        handleUpgrade(const Request& /*req*/,
+                      const std::shared_ptr<bmcweb::AsyncResp>& asyncResp,
+                      boost::asio::ip::tcp::socket&& /*adaptor*/)
     {
-        res.result(boost::beast::http::status::not_found);
-        res.end();
+        asyncResp->res.result(boost::beast::http::status::not_found);
     }
-#ifdef BMCWEB_ENABLE_SSL
+#else
     virtual void handleUpgrade(
-        const Request& /*req*/, Response& res,
+        const Request& /*req*/,
+        const std::shared_ptr<bmcweb::AsyncResp>& asyncResp,
         boost::beast::ssl_stream<boost::asio::ip::tcp::socket>&& /*adaptor*/)
     {
-        res.result(boost::beast::http::status::not_found);
-        res.end();
+        asyncResp->res.result(boost::beast::http::status::not_found);
     }
 #endif
 
@@ -345,7 +349,9 @@ class WebSocketRule : public BaseRule
         asyncResp->res.result(boost::beast::http::status::not_found);
     }
 
-    void handleUpgrade(const Request& req, Response& /*res*/,
+#ifndef BMCWEB_ENABLE_SSL
+    void handleUpgrade(const Request& req,
+                       const std::shared_ptr<bmcweb::AsyncResp>& /*asyncResp*/,
                        boost::asio::ip::tcp::socket&& adaptor) override
     {
         BMCWEB_LOG_DEBUG << "Websocket handles upgrade";
@@ -357,8 +363,9 @@ class WebSocketRule : public BaseRule
                 closeHandler, errorHandler);
         myConnection->start();
     }
-#ifdef BMCWEB_ENABLE_SSL
-    void handleUpgrade(const Request& req, Response& /*res*/,
+#else
+    void handleUpgrade(const Request& req,
+                       const std::shared_ptr<bmcweb::AsyncResp>& /*asyncResp*/,
                        boost::beast::ssl_stream<boost::asio::ip::tcp::socket>&&
                            adaptor) override
     {
@@ -422,7 +429,7 @@ struct RuleParameterTraits
         return *p;
     }
 
-    self_t& name(const std::string_view name) noexcept
+    self_t& name(std::string_view name) noexcept
     {
         self_t* self = static_cast<self_t*>(this);
         self->nameStr = name;
@@ -663,7 +670,7 @@ class TaggedRule :
     }
 
     template <typename Func>
-    void operator()(const std::string_view name, Func&& f)
+    void operator()(std::string_view name, Func&& f)
     {
         nameStr = name;
         (*this).template operator()<Func>(std::forward(f));
@@ -807,7 +814,7 @@ class Trie
     }
 
     std::pair<unsigned, RoutingParams>
-        find(const std::string_view reqUrl, const Node* node = nullptr,
+        find(std::string_view reqUrl, const Node* node = nullptr,
              size_t pos = 0, RoutingParams* params = nullptr) const
     {
         RoutingParams empty;
@@ -1237,14 +1244,152 @@ class Router
         return findRoute;
     }
 
+    static bool isUserPrivileged(
+        Request& req, const std::shared_ptr<bmcweb::AsyncResp>& asyncResp,
+        BaseRule& rule, const dbus::utility::DBusPropertiesMap& userInfoMap)
+    {
+        std::string userRole{};
+        const std::string* userRolePtr = nullptr;
+        const bool* remoteUser = nullptr;
+        const bool* passwordExpired = nullptr;
+
+        const bool success = sdbusplus::unpackPropertiesNoThrow(
+            redfish::dbus_utils::UnpackErrorPrinter(), userInfoMap,
+            "UserPrivilege", userRolePtr, "RemoteUser", remoteUser,
+            "UserPasswordExpired", passwordExpired);
+
+        if (!success)
+        {
+            asyncResp->res.result(
+                boost::beast::http::status::internal_server_error);
+            return false;
+        }
+
+        if (userRolePtr != nullptr)
+        {
+            userRole = *userRolePtr;
+            BMCWEB_LOG_DEBUG << "userName = " << req.session->username
+                             << " userRole = " << *userRolePtr;
+        }
+
+        if (remoteUser == nullptr)
+        {
+            BMCWEB_LOG_ERROR << "RemoteUser property missing or wrong type";
+            asyncResp->res.result(
+                boost::beast::http::status::internal_server_error);
+            return false;
+        }
+        bool expired = false;
+        if (passwordExpired == nullptr)
+        {
+            if (!*remoteUser)
+            {
+                BMCWEB_LOG_ERROR
+                    << "UserPasswordExpired property is expected for"
+                       " local user but is missing or wrong type";
+                asyncResp->res.result(
+                    boost::beast::http::status::internal_server_error);
+                return false;
+            }
+        }
+        else
+        {
+            expired = *passwordExpired;
+        }
+
+        // Get the user's privileges from the role
+        redfish::Privileges userPrivileges =
+            redfish::getUserPrivileges(userRole);
+
+        // Set isConfigureSelfOnly based on D-Bus results.  This
+        // ignores the results from both pamAuthenticateUser and the
+        // value from any previous use of this session.
+        req.session->isConfigureSelfOnly = expired;
+
+        // Modify privileges if isConfigureSelfOnly.
+        if (req.session->isConfigureSelfOnly)
+        {
+            // Remove all privileges except ConfigureSelf
+            userPrivileges = userPrivileges.intersection(
+                redfish::Privileges{"ConfigureSelf"});
+            BMCWEB_LOG_DEBUG << "Operation limited to ConfigureSelf";
+        }
+
+        if (!rule.checkPrivileges(userPrivileges))
+        {
+            asyncResp->res.result(boost::beast::http::status::forbidden);
+            if (req.session->isConfigureSelfOnly)
+            {
+                redfish::messages::passwordChangeRequired(
+                    asyncResp->res, crow::utility::urlFromPieces(
+                                        "redfish", "v1", "AccountService",
+                                        "Accounts", req.session->username));
+            }
+            return false;
+        }
+
+        req.userRole = userRole;
+
+        return true;
+    }
+
+    template <typename CallbackFn>
+    void afterGetUserInfo(Request&& req,
+                          const std::shared_ptr<bmcweb::AsyncResp>& asyncResp,
+                          BaseRule& rule, CallbackFn&& callback,
+                          const boost::system::error_code& ec,
+                          const dbus::utility::DBusPropertiesMap& userInfoMap)
+    {
+        if (ec)
+        {
+            BMCWEB_LOG_ERROR << "GetUserInfo failed...";
+            asyncResp->res.result(
+                boost::beast::http::status::internal_server_error);
+            return;
+        }
+
+        if (!Router::isUserPrivileged(req, asyncResp, rule, userInfoMap))
+        {
+            // User is not privileged
+            BMCWEB_LOG_ERROR << "Insufficient Privilege";
+            asyncResp->res.result(boost::beast::http::status::forbidden);
+            return;
+        }
+        callback(std::move(req));
+    }
+
+    template <typename CallbackFn>
+    void validatePrivilege(Request&& req,
+                           const std::shared_ptr<bmcweb::AsyncResp>& asyncResp,
+                           BaseRule& rule, CallbackFn&& callback)
+    {
+        if (req.session == nullptr)
+        {
+            return;
+        }
+        std::string username = req.session->username;
+        crow::connections::systemBus->async_method_call(
+            [this, req{std::move(req)}, asyncResp, &rule,
+             callback(std::forward<CallbackFn>(callback))](
+                const boost::system::error_code& ec,
+                const dbus::utility::DBusPropertiesMap& userInfoMap) mutable {
+            afterGetUserInfo(std::move(req), asyncResp, rule,
+                             std::forward<CallbackFn>(callback), ec,
+                             userInfoMap);
+            },
+            "xyz.openbmc_project.User.Manager", "/xyz/openbmc_project/user",
+            "xyz.openbmc_project.User.Manager", "GetUserInfo", username);
+    }
+
     template <typename Adaptor>
-    void handleUpgrade(const Request& req, Response& res, Adaptor&& adaptor)
+    void handleUpgrade(Request& req,
+                       const std::shared_ptr<bmcweb::AsyncResp>& asyncResp,
+                       Adaptor&& adaptor)
     {
         std::optional<HttpVerb> verb = httpVerbFromBoost(req.method());
         if (!verb || static_cast<size_t>(*verb) >= perMethods.size())
         {
-            res.result(boost::beast::http::status::not_found);
-            res.end();
+            asyncResp->res.result(boost::beast::http::status::not_found);
             return;
         }
         PerMethod& perMethod = perMethods[static_cast<size_t>(*verb)];
@@ -1256,8 +1401,7 @@ class Router
         if (ruleIndex == 0U)
         {
             BMCWEB_LOG_DEBUG << "Cannot match rules " << req.url;
-            res.result(boost::beast::http::status::not_found);
-            res.end();
+            asyncResp->res.result(boost::beast::http::status::not_found);
             return;
         }
 
@@ -1266,44 +1410,29 @@ class Router
             throw std::runtime_error("Trie internal structure corrupted!");
         }
 
-        if ((rules[ruleIndex]->getMethods() &
-             (1U << static_cast<size_t>(*verb))) == 0)
+        BaseRule& rule = *rules[ruleIndex];
+        size_t methods = rule.getMethods();
+        if ((methods & (1U << static_cast<size_t>(*verb))) == 0)
         {
             BMCWEB_LOG_DEBUG << "Rule found but method mismatch: " << req.url
                              << " with " << req.methodString() << "("
                              << static_cast<uint32_t>(*verb) << ") / "
-                             << rules[ruleIndex]->getMethods();
-            res.result(boost::beast::http::status::not_found);
-            res.end();
+                             << methods;
+            asyncResp->res.result(boost::beast::http::status::not_found);
             return;
         }
 
-        BMCWEB_LOG_DEBUG << "Matched rule (upgrade) '" << rules[ruleIndex]->rule
-                         << "' " << static_cast<uint32_t>(*verb) << " / "
-                         << rules[ruleIndex]->getMethods();
+        BMCWEB_LOG_DEBUG << "Matched rule (upgrade) '" << rule.rule << "' "
+                         << static_cast<uint32_t>(*verb) << " / " << methods;
 
-        // any uncaught exceptions become 500s
-        try
-        {
-            rules[ruleIndex]->handleUpgrade(req, res,
-                                            std::forward<Adaptor>(adaptor));
-        }
-        catch (const std::exception& e)
-        {
-            BMCWEB_LOG_ERROR << "An uncaught exception occurred: " << e.what();
-            res.result(boost::beast::http::status::internal_server_error);
-            res.end();
-            return;
-        }
-        catch (...)
-        {
-            BMCWEB_LOG_ERROR
-                << "An uncaught exception occurred. The type was unknown "
-                   "so no information was available.";
-            res.result(boost::beast::http::status::internal_server_error);
-            res.end();
-            return;
-        }
+        // TODO(ed) This should be able to use std::bind_front, but it doesn't
+        // appear to work with the std::move on adaptor.
+        validatePrivilege(
+            std::move(req), asyncResp, rule,
+            [&rule, asyncResp, adaptor(std::forward<Adaptor>(adaptor))](
+                Request&& thisReq) mutable {
+            rule.handleUpgrade(thisReq, asyncResp, std::move(adaptor));
+            });
     }
 
     void handle(Request& req,
@@ -1370,111 +1499,11 @@ class Router
             rule.handle(req, asyncResp, params);
             return;
         }
-        std::string username = req.session->username;
-
-        crow::connections::systemBus->async_method_call(
-            [req{std::move(req)}, asyncResp, &rule, params](
-                const boost::system::error_code ec,
-                const dbus::utility::DBusPropertiesMap& userInfoMap) mutable {
-            if (ec)
-            {
-                BMCWEB_LOG_ERROR << "GetUserInfo failed...";
-                asyncResp->res.result(
-                    boost::beast::http::status::internal_server_error);
-                return;
-            }
-            std::string userRole{};
-            const bool* remoteUser = nullptr;
-            std::optional<bool> passwordExpired;
-
-            for (const auto& userInfo : userInfoMap)
-            {
-                if (userInfo.first == "UserPrivilege")
-                {
-                    const std::string* userRolePtr =
-                        std::get_if<std::string>(&userInfo.second);
-                    if (userRolePtr == nullptr)
-                    {
-                        continue;
-                    }
-                    userRole = *userRolePtr;
-                    BMCWEB_LOG_DEBUG << "userName = " << req.session->username
-                                     << " userRole = " << *userRolePtr;
-                }
-                else if (userInfo.first == "RemoteUser")
-                {
-                    remoteUser = std::get_if<bool>(&userInfo.second);
-                }
-                else if (userInfo.first == "UserPasswordExpired")
-                {
-                    const bool* passwordExpiredPtr =
-                        std::get_if<bool>(&userInfo.second);
-                    if (passwordExpiredPtr == nullptr)
-                    {
-                        continue;
-                    }
-                    passwordExpired = *passwordExpiredPtr;
-                }
-            }
-
-            if (remoteUser == nullptr)
-            {
-                BMCWEB_LOG_ERROR << "RemoteUser property missing or wrong type";
-                asyncResp->res.result(
-                    boost::beast::http::status::internal_server_error);
-                return;
-            }
-
-            if (passwordExpired == std::nullopt)
-            {
-                if (!*remoteUser)
-                {
-                    BMCWEB_LOG_ERROR
-                        << "UserPasswordExpired property is expected for"
-                           " local user but is missing or wrong type";
-                    asyncResp->res.result(
-                        boost::beast::http::status::internal_server_error);
-                    return;
-                }
-                passwordExpired = false;
-            }
-
-            // Get the user's privileges from the role
-            redfish::Privileges userPrivileges =
-                redfish::getUserPrivileges(userRole);
-
-            // Set isConfigureSelfOnly based on D-Bus results.  This
-            // ignores the results from both pamAuthenticateUser and the
-            // value from any previous use of this session.
-            req.session->isConfigureSelfOnly = *passwordExpired;
-
-            // Modify privileges if isConfigureSelfOnly.
-            if (req.session->isConfigureSelfOnly)
-            {
-                // Remove all privileges except ConfigureSelf
-                userPrivileges = userPrivileges.intersection(
-                    redfish::Privileges{"ConfigureSelf"});
-                BMCWEB_LOG_DEBUG << "Operation limited to ConfigureSelf";
-            }
-
-            if (!rule.checkPrivileges(userPrivileges))
-            {
-                asyncResp->res.result(boost::beast::http::status::forbidden);
-                if (req.session->isConfigureSelfOnly)
-                {
-                    redfish::messages::passwordChangeRequired(
-                        asyncResp->res, crow::utility::urlFromPieces(
-                                            "redfish", "v1", "AccountService",
-                                            "Accounts", req.session->username));
-                }
-                return;
-            }
-
-            req.userRole = userRole;
-            rule.handle(req, asyncResp, params);
-            },
-            "xyz.openbmc_project.User.Manager", "/xyz/openbmc_project/user",
-            "xyz.openbmc_project.User.Manager", "GetUserInfo", username);
+        validatePrivilege(
+            std::move(req), asyncResp, rule,
+            [&rule, asyncResp, params](Request&& thisReq) mutable {
+            rule.handle(thisReq, asyncResp, params);
+            });
     }
 
     void debugPrint()


### PR DESCRIPTION
This commit enables privilege check for user(s) in case of upgraded
connections.
Currently users with no privileges will also be able to access
Websockets connections (Ex: KVM).

The privilege check was already in place for normal connections (i.e.
router->handle()). This commit lifts off the privilege check code and
moves it into a common function (validatePrivilege()), which can be used
both by handle() and handleUpgrade() and register required callback to
be called.

Also, the const qualifier for Request in the handleUpgrade() function's
signature is removed to enable setting "isConfigureSelf" field of
request. The signature of handleUpgrade() is made identical to handle().

Unfortunately, this does not work for consoles - host/hyp consoles
because the original privilege checking is not done properly in handleUpgrade().

So, at this time, it will keep the same way as it was done 1030
to check "service" for hyp console.

Tested:
 - Redfish validator passed.
 - websocket_test.py
 - Admin and Operator users are able to access console on WebUI
 - Readonly User was unable to access console on WebUI

Example test method of 'console' on webui:
 - Use web-browser, and open 'inspect' sub-page tab
 - Under 'admin',  access & switch between
   https://${bmc-ip}:18080/#/operations/service-login
   https://${bmc-ip}:18080/#/operations/host-console



`https://${bmc-ip}:18080/#/operations/service-login` will show
'handles upgrade' on bmcweb debug log:

```
(2023-03-18 19:44:45) [DEBUG "http_connection.hpp":530] Fetch the client IP address
(2023-03-18 19:44:45) [INFO "http_connection.hpp":347] Request:  0x29291f0 HTTP/1.1 GET /console1 9.163.54.115
(2023-03-18 19:44:45) [DEBUG "http_connection.hpp":376] Setting completion handler
(2023-03-18 19:44:45) [DEBUG "http_response.hpp":208] 0x28a9b48 setting completion handler
(2023-03-18 19:44:45) [DEBUG "routing.hpp":1425] Matched rule (upgrade) '/console1' 1 / 2
(2023-03-18 19:44:45) [DEBUG "http_response.hpp":208] 0x28a9b48 setting completion handler
(2023-03-18 19:44:45) [DEBUG "http_response.hpp":208] 0x292b4b8 setting completion handler
(2023-03-18 19:44:45) [DEBUG "http_connection.hpp":85] 0x29291f0 Connection closed, total 5
(2023-03-18 19:44:45) [ERROR "websocket.hpp":217] doRead error system:125
(2023-03-18 19:44:45) [DEBUG "obmc_shell.hpp":208] bmc-shell console.onclose(reason = 'only service user have access to bmc console')
(2023-03-18 19:44:45) [ERROR "websocket.hpp":265] Error in ws.async_write system:125
(2023-03-18 19:44:45) [DEBUG "obmc_shell.hpp":146] Read done.  Read 0 bytes
(2023-03-18 19:44:45) [DEBUG "obmc_shell.hpp":149] session is closed
(2023-03-18 19:44:45) [DEBUG "routing.hpp":1271] userName = admin userRole = priv-admin
(2023-03-18 19:44:45) [DEBUG "routing.hpp":372] Websocket handles upgrade
(2023-03-18 19:44:45) [DEBUG "websocket.hpp":88] Creating new connection 0x2a1f6c8
(2023-03-18 19:44:45) [DEBUG "websocket.hpp":99] starting connection 0x2a1f6c8
(2023-03-18 19:44:45) [DEBUG "http_response.hpp":193] 0x28a9b48 calling completion handler
(2023-03-18 19:44:45) [DEBUG "websocket.hpp":198] Websocket accepted connection
(2023-03-18 19:44:45) [DEBUG "obmc_hypervisor.hpp":127] Connection 0x2a1f6c8 opened
(2023-03-18 19:44:45) [DEBUG "obmc_hypervisor.hpp":133] only service user have access to hypervisor
(2023-03-18 19:44:45) [DEBUG "obmc_hypervisor.hpp":39] Outbuffer empty.  Bailing out
(2023-03-18 19:44:45) [DEBUG "obmc_hypervisor.hpp":81] Reading from socket
(2023-03-18 19:44:46) [ERROR "websocket.hpp":217] doRead error system:125
(2023-03-18 19:44:46) [INFO "obmc_hypervisor.hpp":150] Closing websocket. Reason: only service user have access to hypervisor
(2023-03-18 19:44:46) [DEBUG "obmc_hypervisor.hpp":85] read done.  Read 0 bytes
(2023-03-18 19:44:46) [ERROR "obmc_hypervisor.hpp":88] Couldn't read from host serial port: system:125
```

`https://${bmc-ip}:18080/#/operations/service-login` will show
'handles upgrade' on bmcweb debug log:

```
3-03-18 19:45:31) [DEBUG "authentication.hpp":42] [AuthMiddleware] Basic authentication
(2023-03-18 19:45:31) [DEBUG "authentication.hpp":70] [AuthMiddleware] Authenticating user: admin
(2023-03-18 19:45:31) [DEBUG "authentication.hpp":71] [AuthMiddleware] User IPAddress: 9.163.54.115
(2023-03-18 19:45:31) [DEBUG "http_connection.hpp":630] 0x28d1880 doRead
(2023-03-18 19:45:31) [DEBUG "http_connection.hpp":636] 0x28d1880 async_read 0 Bytes
(2023-03-18 19:45:31) [DEBUG "http_connection.hpp":530] Fetch the client IP address
(2023-03-18 19:45:31) [INFO "http_connection.hpp":347] Request:  0x28d1880 HTTP/1.1 GET /console0 9.163.54.115
(2023-03-18 19:45:31) [DEBUG "http_connection.hpp":376] Setting completion handler
(2023-03-18 19:45:31) [DEBUG "http_response.hpp":208] 0x2888718 setting completion handler
(2023-03-18 19:45:31) [DEBUG "routing.hpp":1425] Matched rule (upgrade) '/console0' 1 / 2
(2023-03-18 19:45:31) [DEBUG "http_response.hpp":208] 0x2888718 setting completion handler
(2023-03-18 19:45:31) [DEBUG "http_response.hpp":208] 0x28d3b48 setting completion handler
(2023-03-18 19:45:31) [DEBUG "http_connection.hpp":85] 0x28d1880 Connection closed, total 5
(2023-03-18 19:45:31) [DEBUG "routing.hpp":1271] userName = admin userRole = priv-admin
(2023-03-18 19:45:31) [DEBUG "routing.hpp":372] Websocket handles upgrade
(2023-03-18 19:45:31) [DEBUG "websocket.hpp":88] Creating new connection 0x2a1f6c8
(2023-03-18 19:45:31) [DEBUG "websocket.hpp":99] starting connection 0x2a1f6c8
(2023-03-18 19:45:31) [DEBUG "http_response.hpp":193] 0x2888718 calling completion handler
(2023-03-18 19:45:31) [DEBUG "websocket.hpp":198] Websocket accepted connection
(2023-03-18 19:45:31) [DEBUG "obmc_console.hpp":123] Connection 0x2a1f6c8 opened
(2023-03-18 19:45:31) [DEBUG "obmc_console.hpp":35] Outbuffer empty.  Bailing out
(2023-03-18 19:45:31) [DEBUG "obmc_console.hpp":77] Reading from socket
(2023-03-18 19:45:31) [DEBUG "http_response.hpp":193] 0x28864b0 calling completion handler
(2023-03-18 19:45:31) [DEBUG "http_response.hpp":196] 0x28864b0 completion handler was valid
(2023-03-18 19:45:31) [DEBUG "query_param.hpp":948] Processing query params
(2023-03-18 19:45:31) [DEBUG "http_response.hpp":65] Moving response containers; this: 0x282a1c8; other: 0x28864b0
(2023-03-18 19:45:31) [INFO "http_connection.hpp":444] Response: 0x2827f00  $$/Chassis/cha  200 keepalive=1
(2023-03-18 19:45:31) [DEBUG "http_connection.hpp":653] 0x2827f00 doWrite
(2023-03-18 19:45:32) [DEBUG "http_response.hpp":208] 0x282a1c8 setting completion handler
(2023-03-18 19:45:32) [DEBUG "http_connection.hpp":661] 0x2827f00 async_write 582 bytes
(2023-03-18 19:45:32) [DEBUG "http_connection.hpp":679] 0x2827f00 Clearing response
(2023-03-18 19:45:32) [DEBUG "http_response.hpp":152] 0x282a1c8 Clearing response containers
(2023-03-18 19:45:32) [DEBUG "http_connection.hpp":549] 0x2827f00 doReadHeaders
(2023-03-18 19:45:32) [DEBUG "obmc_console.hpp":162] userName = admin userRole = priv-admin

```

Upstream:
https://gerrit.openbmc.org/c/openbmc/bmcweb/+/46991
https://gerrit.openbmc.org/c/openbmc/bmcweb/+/61677

