### PR TITLE
dbus_utility: Add MapperGetObject

### DIFF
--- a/include/dbus_utility.hpp
+++ b/include/dbus_utility.hpp
@@ -52,6 +52,9 @@ using MapperServiceMap =
 using MapperGetSubTreeResponse =
     std::vector<std::pair<std::string, MapperServiceMap>>;
 
+using MapperGetObject =
+    std::vector<std::pair<std::string, std::vector<std::string>>>;
+
 inline void escapePathForDbus(std::string& path)
 {
     const std::regex reg("[^A-Za-z0-9_/]");


### PR DESCRIPTION
https://github.com/ibm-openbmc/bmcweb/pull/426/files added MapperGetObject but that code isn't in 1020 so just add this line to match 1030/1040 and allow
https://github.com/ibm-openbmc/bmcweb/commit/7d10d4550b194818db62c87196739e8a7915cf8e to compile.

https://github.com/ibm-openbmc/bmcweb/blob/1030/include/dbus_utility.hpp#L55

See https://ibm-systems-power.slack.com/archives/C04KG79NAUA/p1679089972649529?thread_ts=1679071244.184949&cid=C04KG79NAUA

Tested: None. 1020 bmcweb compiles though.