### PR TITLE
Displaying wrong date expiration date for UAK and AIX key licences

### DIFF
--- a/http/ut/utility_test.cpp
+++ b/http/ut/utility_test.cpp
@@ -72,3 +72,22 @@ TEST(Utility, convertToAsciiBadTestCase)
     stringCode = crow::utility::convertToAscii(0xD7D7D7D7D7D7D7D7);
     EXPECT_EQ("", stringCode);
 }
+
+TEST(Utility, GetDateTime)
+{
+    // some time before the epoch
+    EXPECT_EQ(crow::utility::getDateTimeStdtime(std::time_t{-1234567}),
+              "1969-12-17T17:03:53Z");
+    // epoch
+    EXPECT_EQ(crow::utility::getDateTimeStdtime(std::time_t{0}),
+              "1970-01-01T00:00:00Z");
+    // some time in the past after the epoch
+    EXPECT_EQ(crow::utility::getDateTimeUint(uint64_t{1638312095}),
+              "2021-11-30T22:41:35Z");
+    // some time in the future, beyond 2038
+    EXPECT_EQ(crow::utility::getDateTimeUint(uint64_t{41638312095}),
+              "3289-06-18T21:48:15Z");
+    // the maximum time we support
+    EXPECT_EQ(crow::utility::getDateTimeUint(uint64_t{253402300799}),
+              "9999-12-31T23:59:59Z");
+}

--- a/http/ut/utility_test.cpp
+++ b/http/ut/utility_test.cpp
@@ -73,21 +73,54 @@ TEST(Utility, convertToAsciiBadTestCase)
     EXPECT_EQ("", stringCode);
 }
 
-TEST(Utility, GetDateTime)
+TEST(Utility, GetDateTimeStdtime)
 {
+    using crow::utility::getDateTimeStdtime;
+
     // some time before the epoch
-    EXPECT_EQ(crow::utility::getDateTimeStdtime(std::time_t{-1234567}),
-              "1969-12-17T17:03:53Z");
+    EXPECT_EQ(getDateTimeStdtime(std::time_t{-1234567}),
+              "1969-12-17T17:03:53+00:00");
+
     // epoch
-    EXPECT_EQ(crow::utility::getDateTimeStdtime(std::time_t{0}),
-              "1970-01-01T00:00:00Z");
+    EXPECT_EQ(getDateTimeStdtime(std::time_t{0}), "1970-01-01T00:00:00+00:00");
     // some time in the past after the epoch
-    EXPECT_EQ(crow::utility::getDateTimeUint(uint64_t{1638312095}),
-              "2021-11-30T22:41:35Z");
+
+    // Limits
+    EXPECT_EQ(getDateTimeStdtime(std::numeric_limits<std::time_t>::max()),
+              "1969-12-31T23:59:59+00:00");
+    EXPECT_EQ(getDateTimeStdtime(std::numeric_limits<std::time_t>::min()),
+              "1970-01-01T00:00:00+00:00");
+}
+
+TEST(Utility, getDateTimeUint)
+{
+    using crow::utility::getDateTimeUint;
+
+    EXPECT_EQ(getDateTimeUint(uint64_t{1638312095}),
+              "2021-11-30T22:41:35+00:00");
     // some time in the future, beyond 2038
-    EXPECT_EQ(crow::utility::getDateTimeUint(uint64_t{41638312095}),
-              "3289-06-18T21:48:15Z");
+    EXPECT_EQ(getDateTimeUint(uint64_t{41638312095}),
+              "3289-06-18T21:48:15+00:00");
     // the maximum time we support
-    EXPECT_EQ(crow::utility::getDateTimeUint(uint64_t{253402300799}),
-              "9999-12-31T23:59:59Z");
+    EXPECT_EQ(getDateTimeUint(uint64_t{253402300799}),
+              "9999-12-31T23:59:59+00:00");
+
+    // This test currently throws an exception
+    // EXPECT_EQ(getDateTimeUint(std::numeric_limits<uint64_t>::max()), "");
+
+    EXPECT_EQ(getDateTimeUint(std::numeric_limits<uint64_t>::min()),
+              "1970-01-01T00:00:00+00:00");
+}
+
+TEST(Utility, getDateTimeUintMs)
+{
+    using crow::utility::getDateTimeUintMs;
+
+    // Note, this is the wrong result, but is here to make sure that we don't
+    // have worse behavior (ie seg faults, exceptions) when this happens
+    EXPECT_EQ(getDateTimeUintMs(std::numeric_limits<uint64_t>::max()),
+              "1969-12-31T23:59:59.999000+00:00");
+
+    EXPECT_EQ(getDateTimeUintMs(std::numeric_limits<uint64_t>::min()),
+              "1970-01-01T00:00:00+00:00");
 }

--- a/http/ut/utility_test.cpp
+++ b/http/ut/utility_test.cpp
@@ -2,11 +2,16 @@
 
 #include "gmock/gmock.h"
 
+namespace crow::utility
+{
+namespace
+{
+
 TEST(Utility, Base64DecodeAuthString)
 {
     std::string authString("dXNlcm40bWU6cGFzc3cwcmQ=");
     std::string result;
-    EXPECT_TRUE(crow::utility::base64Decode(authString, result));
+    EXPECT_TRUE(base64Decode(authString, result));
     EXPECT_EQ(result, "usern4me:passw0rd");
 }
 
@@ -14,7 +19,7 @@ TEST(Utility, Base64DecodeNonAscii)
 {
     std::string junkString("\xff\xee\xdd\xcc\x01\x11\x22\x33");
     std::string result;
-    EXPECT_FALSE(crow::utility::base64Decode(junkString, result));
+    EXPECT_FALSE(base64Decode(junkString, result));
 }
 
 TEST(Utility, Base64EncodeString)
@@ -22,28 +27,28 @@ TEST(Utility, Base64EncodeString)
     using namespace std::string_literals;
     std::string encoded;
 
-    encoded = crow::utility::base64encode("");
+    encoded = base64encode("");
     EXPECT_EQ(encoded, "");
 
-    encoded = crow::utility::base64encode("f");
+    encoded = base64encode("f");
     EXPECT_EQ(encoded, "Zg==");
 
-    encoded = crow::utility::base64encode("f0");
+    encoded = base64encode("f0");
     EXPECT_EQ(encoded, "ZjA=");
 
-    encoded = crow::utility::base64encode("f0\0"s);
+    encoded = base64encode("f0\0"s);
     EXPECT_EQ(encoded, "ZjAA");
 
-    encoded = crow::utility::base64encode("f0\0 "s);
+    encoded = base64encode("f0\0 "s);
     EXPECT_EQ(encoded, "ZjAAIA==");
 
-    encoded = crow::utility::base64encode("f0\0 B"s);
+    encoded = base64encode("f0\0 B"s);
     EXPECT_EQ(encoded, "ZjAAIEI=");
 
-    encoded = crow::utility::base64encode("f0\0 Ba"s);
+    encoded = base64encode("f0\0 Ba"s);
     EXPECT_EQ(encoded, "ZjAAIEJh");
 
-    encoded = crow::utility::base64encode("f0\0 Bar"s);
+    encoded = base64encode("f0\0 Bar"s);
     EXPECT_EQ(encoded, "ZjAAIEJhcg==");
 }
 
@@ -51,9 +56,9 @@ TEST(Utility, Base64EncodeDecodeString)
 {
     using namespace std::string_literals;
     std::string data("Data fr\0m 90 reading a \nFile"s);
-    std::string encoded = crow::utility::base64encode(data);
+    std::string encoded = base64encode(data);
     std::string decoded;
-    EXPECT_TRUE(crow::utility::base64Decode(encoded, decoded));
+    EXPECT_TRUE(base64Decode(encoded, decoded));
     EXPECT_EQ(data, decoded);
 }
 
@@ -83,19 +88,16 @@ TEST(Utility, GetDateTimeStdtime)
 
     // epoch
     EXPECT_EQ(getDateTimeStdtime(std::time_t{0}), "1970-01-01T00:00:00+00:00");
-    // some time in the past after the epoch
 
     // Limits
     EXPECT_EQ(getDateTimeStdtime(std::numeric_limits<std::time_t>::max()),
-              "1969-12-31T23:59:59+00:00");
+              "9999-12-31T23:59:59+00:00");
     EXPECT_EQ(getDateTimeStdtime(std::numeric_limits<std::time_t>::min()),
               "1970-01-01T00:00:00+00:00");
 }
 
-TEST(Utility, getDateTimeUint)
+TEST(Utility, GetDateTimeUint)
 {
-    using crow::utility::getDateTimeUint;
-
     EXPECT_EQ(getDateTimeUint(uint64_t{1638312095}),
               "2021-11-30T22:41:35+00:00");
     // some time in the future, beyond 2038
@@ -105,22 +107,21 @@ TEST(Utility, getDateTimeUint)
     EXPECT_EQ(getDateTimeUint(uint64_t{253402300799}),
               "9999-12-31T23:59:59+00:00");
 
-    // This test currently throws an exception
-    // EXPECT_EQ(getDateTimeUint(std::numeric_limits<uint64_t>::max()), "");
+    // returns the maximum Redfish date
+    EXPECT_EQ(getDateTimeUint(std::numeric_limits<uint64_t>::max()),
+              "9999-12-31T23:59:59+00:00");
 
     EXPECT_EQ(getDateTimeUint(std::numeric_limits<uint64_t>::min()),
               "1970-01-01T00:00:00+00:00");
 }
 
-TEST(Utility, getDateTimeUintMs)
+TEST(Utility, GetDateTimeUintMs)
 {
-    using crow::utility::getDateTimeUintMs;
-
-    // Note, this is the wrong result, but is here to make sure that we don't
-    // have worse behavior (ie seg faults, exceptions) when this happens
+    // returns the maximum Redfish date
     EXPECT_EQ(getDateTimeUintMs(std::numeric_limits<uint64_t>::max()),
-              "1969-12-31T23:59:59.999000+00:00");
-
+              "9999-12-31T23:59:59.999000+00:00");
     EXPECT_EQ(getDateTimeUintMs(std::numeric_limits<uint64_t>::min()),
               "1970-01-01T00:00:00+00:00");
 }
+} // namespace
+} // namespace crow::utility

--- a/http/utility.hpp
+++ b/http/utility.hpp
@@ -611,8 +611,8 @@ inline std::string getDateTime(boost::posix_time::milliseconds timeSinceEpoch)
 // date. This behavior is to avoid exceptions throwed by Boost.
 inline std::string getDateTimeUint(uint64_t secondsSinceEpoch)
 {
-    boost::posix_time::seconds boostSeconds(
-        std::min(secondsSinceEpoch, maxSeconds));
+    secondsSinceEpoch = std::min(secondsSinceEpoch, maxSeconds);
+    boost::posix_time::seconds boostSeconds(secondsSinceEpoch);
     return getDateTime(
         boost::posix_time::milliseconds(boostSeconds.total_milliseconds()));
 }
@@ -623,13 +623,17 @@ inline std::string getDateTimeUint(uint64_t secondsSinceEpoch)
 // supported date.
 inline std::string getDateTimeUintMs(uint64_t milliSecondsSinceEpoch)
 {
-    return getDateTime(boost::posix_time::milliseconds(
-        std::min(maxMilliSeconds, milliSecondsSinceEpoch)));
+    milliSecondsSinceEpoch = std::min(maxMilliSeconds, milliSecondsSinceEpoch);
+    return getDateTime(boost::posix_time::milliseconds(milliSecondsSinceEpoch));
 }
 inline std::string getDateTimeStdtime(std::time_t secondsSinceEpoch)
 {
-    boost::posix_time::ptime time = boost::posix_time::from_time_t(
-        std::min(secondsSinceEpoch, std::time_t{maxSeconds}));
+    if (secondsSinceEpoch > static_cast<int64_t>(maxSeconds))
+    {
+        secondsSinceEpoch = static_cast<std::time_t>(maxSeconds);
+    }
+    boost::posix_time::ptime time =
+        boost::posix_time::from_time_t(secondsSinceEpoch);
     return boost::posix_time::to_iso_extended_string(time) + "+00:00";
 }
 /**

--- a/http/utility.hpp
+++ b/http/utility.hpp
@@ -1,5 +1,4 @@
 #pragma once
-
 #include "nlohmann/json.hpp"
 
 #include <openssl/crypto.h>
@@ -590,26 +589,28 @@ inline std::string convertToAscii(const uint64_t& element)
 }
 
 /**
- * Method returns Date Time information according to requested format
+ * Method returns Date Time information in the ISO extended format
  *
- * @param[in] time time in second since the Epoch
+ * @param[in] timestamp in second since the Epoch; it can be negative
  *
- * @return Date Time according to requested format
+ * @return Date Time in the ISO extended format
  */
-inline std::string getDateTime(const std::time_t& time)
+inline std::string getDateTime(boost::posix_time::seconds secondsSinceEpoch)
 {
-    std::array<char, 128> dateTime;
-    std::string redfishDateTime("0000-00-00T00:00:00Z00:00");
+    boost::posix_time::ptime epoch(boost::gregorian::date(1970, 1, 1));
+    boost::posix_time::ptime time = epoch + secondsSinceEpoch;
+    // append zero offset to the end according to the Redfish spec for Date-Time
+    return boost::posix_time::to_iso_extended_string(time) + 'Z';
+}
 
-    if (std::strftime(dateTime.begin(), dateTime.size(), "%FT%T%z",
-                      std::localtime(&time)))
-    {
-        // insert the colon required by the ISO 8601 standard
-        redfishDateTime = std::string(dateTime.data());
-        redfishDateTime.insert(redfishDateTime.end() - 2, ':');
-    }
+inline std::string getDateTimeUint(uint64_t secondsSinceEpoch)
+{
+    return getDateTime(boost::posix_time::seconds(secondsSinceEpoch));
+}
 
-    return redfishDateTime;
+inline std::string getDateTimeStdtime(std::time_t secondsSinceEpoch)
+{
+    return getDateTime(boost::posix_time::seconds(secondsSinceEpoch));
 }
 
 inline std::string getDateTimeUintMs(uint64_t millisSecondsSinceEpoch)
@@ -635,7 +636,7 @@ inline std::string getDateTimeUintMs(uint64_t millisSecondsSinceEpoch)
 inline std::pair<std::string, std::string> getDateTimeOffsetNow()
 {
     std::time_t time = std::time(nullptr);
-    std::string dateTime = getDateTime(time);
+    std::string dateTime = getDateTimeStdtime(time);
 
     /* extract the local Time Offset value from the
      * recevied dateTime string.

--- a/redfish-core/include/utils/hw_isolation.hpp
+++ b/redfish-core/include/utils/hw_isolation.hpp
@@ -640,9 +640,8 @@ inline void
                                         return;
                                     }
                                     condition["Timestamp"] =
-                                        crow::utility::getDateTime(
-                                            static_cast<std::time_t>(
-                                                *timestamp));
+                                        crow::utility::getDateTimeUint(
+                                            *timestamp / 1000 / 1000);
                                 }
                                 else if (property.first == "Message")
                                 {

--- a/redfish-core/lib/certificate_service.hpp
+++ b/redfish-core/lib/certificate_service.hpp
@@ -643,9 +643,8 @@ static void getCertificateProperties(
                         std::get_if<uint64_t>(&property.second);
                     if (value)
                     {
-                        std::time_t time = static_cast<std::time_t>(*value);
                         asyncResp->res.jsonValue["ValidNotAfter"] =
-                            crow::utility::getDateTime(time);
+                            crow::utility::getDateTimeUint(*value);
                     }
                 }
                 else if (property.first == "ValidNotBefore")
@@ -654,9 +653,8 @@ static void getCertificateProperties(
                         std::get_if<uint64_t>(&property.second);
                     if (value)
                     {
-                        std::time_t time = static_cast<std::time_t>(*value);
                         asyncResp->res.jsonValue["ValidNotBefore"] =
-                            crow::utility::getDateTime(time);
+                            crow::utility::getDateTimeUint(*value);
                     }
                 }
             }

--- a/redfish-core/lib/license_service.hpp
+++ b/redfish-core/lib/license_service.hpp
@@ -396,7 +396,7 @@ inline void
                     continue;
                 }
 
-                std::time_t expirationTime;
+                uint64_t expirationTime;
                 const uint32_t* deviceNumPtr = nullptr;
                 const std::string* serialNumPtr = nullptr;
                 const std::string* licenseNamePtr = nullptr;
@@ -461,8 +461,7 @@ inline void
                                     messages::internalError(asyncResp->res);
                                     break;
                                 }
-                                expirationTime =
-                                    static_cast<std::time_t>(*timePtr);
+                                expirationTime = *timePtr;
                             }
                             else if (propertyMap.first == "SerialNumber")
                             {
@@ -522,7 +521,7 @@ inline void
                 asyncResp->res.jsonValue["SerialNumber"] = *serialNumPtr;
                 asyncResp->res.jsonValue["Name"] = *licenseNamePtr;
                 asyncResp->res.jsonValue["ExpirationDate"] =
-                    crow::utility::getDateTime(expirationTime);
+                    crow::utility::getDateTimeUint(expirationTime);
                 translateLicenseTypeDbusToRedfish(asyncResp, *licenseTypePtr);
                 translateAuthorizationTypeDbusToRedfish(asyncResp,
                                                         *authorizationTypePtr);

--- a/redfish-core/lib/log_services.hpp
+++ b/redfish-core/lib/log_services.hpp
@@ -224,8 +224,7 @@ inline static bool getEntryTimestamp(sd_journal* journal,
                          << strerror(-ret);
         return false;
     }
-    entryTimestamp = crow::utility::getDateTime(
-        static_cast<std::time_t>(timestamp / 1000 / 1000));
+    entryTimestamp = crow::utility::getDateTimeUint(timestamp / 1000 / 1000);
     return true;
 }
 
@@ -468,7 +467,7 @@ inline void
                 {
                     continue;
                 }
-                std::time_t timestamp;
+                uint64_t timestamp = 0;
                 uint64_t size = 0;
                 std::string dumpStatus;
                 std::string clientId;
@@ -535,8 +534,7 @@ inline void
                                     messages::internalError(asyncResp->res);
                                     break;
                                 }
-                                timestamp = static_cast<std::time_t>(
-                                    *usecsTimeStamp / 1000 / 1000);
+                                timestamp = (*usecsTimeStamp / 1000 / 1000);
                                 break;
                             }
                         }
@@ -575,7 +573,11 @@ inline void
                 thisEntry["@odata.id"] = dumpPath + entryID;
                 thisEntry["Id"] = entryID;
                 thisEntry["EntryType"] = "Event";
-                thisEntry["Created"] = crow::utility::getDateTime(timestamp);
+                thisEntry["Created"] =
+                    crow::utility::getDateTimeUint(timestamp);
+                thisEntry["Created"] =
+                    crow::utility::getDateTimeUint(timestamp);
+                thisEntry["Name"] = dumpType + " Dump Entry";
 
                 thisEntry["AdditionalDataSizeBytes"] = size;
 
@@ -677,7 +679,7 @@ inline void
                 }
 
                 foundDumpEntry = true;
-                std::time_t timestamp;
+                uint64_t timestamp = 0;
                 uint64_t size = 0;
                 std::string dumpStatus;
 
@@ -734,8 +736,7 @@ inline void
                                     messages::internalError(asyncResp->res);
                                     break;
                                 }
-                                timestamp = static_cast<std::time_t>(
-                                    *usecsTimeStamp / 1000 / 1000);
+                                timestamp = *usecsTimeStamp / 1000 / 1000;
                                 break;
                             }
                         }
@@ -779,7 +780,9 @@ inline void
                 asyncResp->res.jsonValue["Id"] = entryID;
                 asyncResp->res.jsonValue["EntryType"] = "Event";
                 asyncResp->res.jsonValue["Created"] =
-                    crow::utility::getDateTime(timestamp);
+                    crow::utility::getDateTimeUint(timestamp);
+                asyncResp->res.jsonValue["Name"] = dumpType + " Dump Entry";
+
                 asyncResp->res.jsonValue["AdditionalDataSizeBytes"] = size;
 
                 if (!clientId.empty())
@@ -2002,8 +2005,9 @@ inline void getDBusLogEntryCollection(
         }
         thisEntry["ServiceProviderNotified"] = serviceProviderNotified;
         thisEntry["Severity"] = translateSeverityDbusToRedfish(*severity);
-        thisEntry["Created"] = crow::utility::getDateTime(timestamp);
-        thisEntry["Modified"] = crow::utility::getDateTime(updateTimestamp);
+        thisEntry["Created"] = crow::utility::getDateTimeStdtime(timestamp);
+        thisEntry["Modified"] =
+            crow::utility::getDateTimeStdtime(updateTimestamp);
 #ifdef BMCWEB_ENABLE_IBM_MANAGEMENT_CONSOLE
         thisEntry["Oem"]["OpenBMC"]["@odata.type"] =
             "#OemLogEntry.v1_0_0.LogEntry";
@@ -2404,9 +2408,10 @@ inline void getDBusLogEntry(const std::shared_ptr<bmcweb::AsyncResp>& asyncResp,
         serviceProviderNotified;
     asyncResp->res.jsonValue["Severity"] =
         translateSeverityDbusToRedfish(*severity);
-    asyncResp->res.jsonValue["Created"] = crow::utility::getDateTime(timestamp);
+    asyncResp->res.jsonValue["Created"] =
+        crow::utility::getDateTimeStdtime(timestamp);
     asyncResp->res.jsonValue["Modified"] =
-        crow::utility::getDateTime(updateTimestamp);
+        crow::utility::getDateTimeStdtime(updateTimestamp);
 #ifdef BMCWEB_ENABLE_IBM_MANAGEMENT_CONSOLE
     asyncResp->res.jsonValue["Oem"]["OpenBMC"]["@odata.type"] =
         "#OemLogEntry.v1_0_0.LogEntry";
@@ -4103,9 +4108,8 @@ static void fillPostCodeEntry(
 
         // Get the Created time from the timestamp
         std::string entryTimeStr;
-        entryTimeStr = crow::utility::getDateTime(
-            static_cast<std::time_t>(usecSinceEpoch / 1000 / 1000));
-
+        entryTimeStr =
+            crow::utility::getDateTimeUint(usecSinceEpoch / 1000 / 1000);
         // assemble messageArgs: BootIndex, TimeOffset(100us), PostCode(hex)
         std::ostringstream hexCode;
         hexCode << "0x" << std::setfill('0') << std::setw(2) << std::hex

--- a/redfish-core/lib/managers.hpp
+++ b/redfish-core/lib/managers.hpp
@@ -1808,12 +1808,11 @@ inline void
             }
             // LastRebootTime is epoch time, in milliseconds
             // https://github.com/openbmc/phosphor-dbus-interfaces/blob/7f9a128eb9296e926422ddc312c148b625890bb6/xyz/openbmc_project/State/BMC.interface.yaml#L19
-            time_t lastResetTimeStamp =
-                static_cast<time_t>(*lastResetTimePtr / 1000);
+            uint64_t lastResetTimeStamp = *lastResetTimePtr / 1000;
 
             // Convert to ISO 8601 standard
             aResp->res.jsonValue["LastResetTime"] =
-                crow::utility::getDateTime(lastResetTimeStamp);
+                crow::utility::getDateTimeUint(lastResetTimeStamp);
         },
         "xyz.openbmc_project.State.BMC", "/xyz/openbmc_project/state/bmc0",
         "org.freedesktop.DBus.Properties", "Get",

--- a/redfish-core/lib/metric_report.hpp
+++ b/redfish-core/lib/metric_report.hpp
@@ -25,7 +25,7 @@ inline nlohmann::json toMetricValues(const Readings& readings)
             {"MetricId", id},
             {"MetricProperty", metadata},
             {"MetricValue", std::to_string(sensorValue)},
-            {"Timestamp", crow::utility::getDateTimeUintMs(timestamp)},
+            {"Timestamp", crow::utility::getDateTimeUint(timestamp)},
         });
     }
 
@@ -51,8 +51,7 @@ inline bool fillReport(nlohmann::json& json, const std::string& id,
     }
 
     const auto& [timestamp, readings] = *timestampReadings;
-
-    json["Timestamp"] = crow::utility::getDateTimeUintMs(timestamp);
+    json["Timestamp"] = crow::utility::getDateTimeUint(timestamp);
     json["MetricValues"] = toMetricValues(readings);
     return true;
 }

--- a/redfish-core/lib/power_supply_metrics.hpp
+++ b/redfish-core/lib/power_supply_metrics.hpp
@@ -48,8 +48,8 @@ inline void parseAverageMaximum(const std::shared_ptr<bmcweb::AsyncResp>& aResp,
         // Second value from average and maximum is just an integer type value
         // representing watts.
         inputPowerHistoryItemArray.push_back(
-            {{"Date", crow::utility::getDateTime(static_cast<std::time_t>(
-                          (std::get<0>(*average) / 1000)))},
+            {{"Date", crow::utility::getDateTimeUint(
+                          (std::get<0>(*average) / 1000 / 1000 / 1000))},
              {"Average", std::get<1>(*average)},
              {"Maximum", std::get<1>(*maximum)}});
     }
@@ -106,10 +106,9 @@ inline void getMaximumValues(const std::shared_ptr<bmcweb::AsyncResp>& aResp,
                 // power supply has used in a 30 second interval.
                 auto value = std::get<1>(values);
 
-                BMCWEB_LOG_DEBUG
-                    << "Date/Time: "
-                    << crow::utility::getDateTime(
-                           static_cast<std::time_t>(dateTime / 1000));
+                BMCWEB_LOG_DEBUG << "Date/Time: "
+                                 << crow::utility::getDateTimeUint(
+                                        dateTime / 1000 / 1000 / 1000);
                 BMCWEB_LOG_DEBUG << "Maximum Value: " << value;
 
                 maximumValues.emplace_back(dateTime, value);
@@ -174,10 +173,9 @@ inline void
                 // watts this power supply has used in a 30 second interval.
                 auto value = std::get<1>(values);
 
-                BMCWEB_LOG_DEBUG
-                    << "DateTime: "
-                    << crow::utility::getDateTime(
-                           static_cast<std::time_t>(dateTime / 1000));
+                BMCWEB_LOG_DEBUG << "DateTime: "
+                                 << crow::utility::getDateTimeUint(
+                                        dateTime / 1000 / 1000 / 1000);
                 BMCWEB_LOG_DEBUG << "Values: " << value;
 
                 averageValues.emplace_back(dateTime, value);

--- a/redfish-core/lib/systems.hpp
+++ b/redfish-core/lib/systems.hpp
@@ -837,12 +837,10 @@ inline void getLastResetTime(const std::shared_ptr<bmcweb::AsyncResp>& aResp)
             }
             // LastStateChangeTime is epoch time, in milliseconds
             // https://github.com/openbmc/phosphor-dbus-interfaces/blob/33e8e1dd64da53a66e888d33dc82001305cd0bf9/xyz/openbmc_project/State/Chassis.interface.yaml#L19
-            time_t lastResetTimeStamp =
-                static_cast<time_t>(*lastResetTimePtr / 1000);
-
+            uint64_t lastResetTimeStamp = *lastResetTimePtr / 1000;
             // Convert to ISO 8601 standard
             aResp->res.jsonValue["LastResetTime"] =
-                crow::utility::getDateTime(lastResetTimeStamp);
+                crow::utility::getDateTimeUint(lastResetTimeStamp);
         },
         "xyz.openbmc_project.State.Chassis",
         "/xyz/openbmc_project/state/chassis0",

--- a/redfish-core/lib/task.hpp
+++ b/redfish-core/lib/task.hpp
@@ -388,11 +388,11 @@ inline void requestRoutesTask(App& app)
                 asyncResp->res.jsonValue["Name"] = "Task " + strParam;
                 asyncResp->res.jsonValue["TaskState"] = ptr->state;
                 asyncResp->res.jsonValue["StartTime"] =
-                    crow::utility::getDateTime(ptr->startTime);
+                    crow::utility::getDateTimeStdtime(ptr->startTime);
                 if (ptr->endTime)
                 {
                     asyncResp->res.jsonValue["EndTime"] =
-                        crow::utility::getDateTime(*(ptr->endTime));
+                        crow::utility::getDateTimeStdtime(*(ptr->endTime));
                 }
                 asyncResp->res.jsonValue["TaskStatus"] = ptr->status;
                 asyncResp->res.jsonValue["Messages"] = ptr->messages;


### PR DESCRIPTION
This commit fixes time_t over flow error.
Also fixes the issue of displaying wrong date expiration date for UAK and AIX key licences in the BMC when expiration date is date past 01/01/2038 .

Tested by :
curl -k -H "X-Auth-Token: $bmc_token" -X GET https://$/{bmc_ip}/redfish/v1/LicenseService/Licenses/UAK
curl -k -H "X-Auth-Token: $bmc_token" -X GET https://$/{bmc_ip}/redfish/v1/LicenseService/Licenses/AIX