### PR TITLE
Correct the AddressOrigin in redfish response

### DIFF
--- a/redfish-core/lib/hypervisor_system.hpp
+++ b/redfish-core/lib/hypervisor_system.hpp
@@ -161,6 +161,15 @@ inline void
         std::array<const char*, 1>{"xyz.openbmc_project.State.Host"});
 }
 
+inline bool translateSlaacEnabledToBool(const std::string& inputDHCP)
+{
+    return (
+        (inputDHCP ==
+         "xyz.openbmc_project.Network.EthernetInterface.DHCPConf.v6stateless") ||
+        (inputDHCP ==
+         "xyz.openbmc_project.Network.EthernetInterface.DHCPConf.v4v6stateless"));
+}
+
 inline bool extractHypervisorInterfaceData(
     const std::shared_ptr<bmcweb::AsyncResp>& asyncResp,
     const std::string& ethIfaceId,
@@ -333,7 +342,14 @@ inline bool extractHypervisorInterfaceData(
                             if (!translateDhcpEnabledToBool(*dhcpEnabled,
                                                             false))
                             {
-                                ipv6Address.origin = "Static";
+                                if (!translateSlaacEnabledToBool(*dhcpEnabled))
+                                {
+                                    ipv6Address.origin = "Static";
+                                }
+                                else
+                                {
+                                    ipv6Address.origin = "SLAAC";
+                                }
                             }
                             else
                             {


### PR DESCRIPTION
When a user enables "IPv6AutoConfigEnabled", the "AddressOrigin" property shows "Static" in the response. This commit will change it to "SLAAC".

Tested By:

PATCH -d '{"StatelessAddressAutoConfig": {"IPv6AutoConfigEnabled":true}}' \ https://${bmc}/redfish/v1/Systems/hypervisor/EthernetInterfaces/eth0

Fixes: https://jazz07.rchland.ibm.com:13443/jazz/web/projects/CSSD#action=com.ibm.team.workitem.viewWorkItem&id=449841

Change-Id: Icf602401b9fa51aac6d30dd429e3623e6efbc402