### PR TITLE
1050: Rollback to add LocationIndicator slot (#630)

### DIFF
--- a/redfish-core/lib/led.hpp
+++ b/redfish-core/lib/led.hpp
@@ -239,10 +239,11 @@ inline void
 {
     BMCWEB_LOG_DEBUG << "Get LocationIndicatorActive";
 
+    nlohmann::json& jsonIn = jsonInput["LocationIndicatorActive"];
     dbus::utility::getAssociationEndPoints(
         objPath + "/identifying",
-        [aResp, &jsonInput](const boost::system::error_code& ec,
-                            const dbus::utility::MapperEndPoints& endpoints) {
+        [aResp, &jsonIn](const boost::system::error_code& ec,
+                         const dbus::utility::MapperEndPoints& endpoints) {
         if (ec)
         {
             if (ec.value() != EBADR)
@@ -252,7 +253,6 @@ inline void
             return;
         }
 
-        nlohmann::json& jsonIn = jsonInput["LocationIndicatorActive"];
         for (const auto& endpoint : endpoints)
         {
             getLedAsset(aResp, endpoint, jsonIn);


### PR DESCRIPTION
As a part of https://github.com/ibm-openbmc/bmcweb/pull/630, LocationIndicatorActive slot is added only if there is an association to Led Group.
This change have caused a side-effect of bmcweb coredump during PCIeSlots LocationIndicator handling.

So at this time, led.hpp will be rolled-back
so that the slot is always added even if there is no association.

The error happened with PR630.

```
$ curl -k -X GET https://${bmc}:18080/redfish/v1/Chassis/chassis/PCIeSlots
curl: (52) Empty reply from server
```

Its debug traces are:
```
(2023-03-23 20:56:56) [DEBUG "routing.hpp":1364] Matched rule '/redfish/v1/Chassis/<str>/PCIeSlots/' 1 / 2
(2023-03-23 20:56:56) [DEBUG "routing.hpp":1401] userName = service userRole = priv-oemibmserviceagent
(2023-03-23 20:56:56) [DEBUG "query.hpp":114] setup redfish route
(2023-03-23 20:56:56) [DEBUG "http_response.hpp":218] 0x264fed8 releasing completion handler1
(2023-03-23 20:56:56) [DEBUG "http_response.hpp":208] 0x264fed8 setting completion handler
(2023-03-23 20:56:56) [DEBUG "pcie_slots.hpp":527] Get properties for PCIeSlots associated to chassis = chassis
(2023-03-23 20:56:56) [DEBUG "led.hpp":240] Get LocationIndicatorActive
(2023-03-23 20:56:56) [DEBUG "led.hpp":240] Get LocationIndicatorActive
...
(2023-03-23 20:56:56) [DEBUG "led.hpp":240] Get LocationIndicatorActive
(2023-03-23 20:56:56) [DEBUG "led.hpp":240] Get LocationIndicatorActive
(2023-03-23 20:56:56) [DEBUG "pcie_slots.hpp":141] No processor association found
(2023-03-23 20:56:56) [DEBUG "pcie_slots.hpp":198] Disk backplane association not found
Aborted (core dumped)
```

Tested:
 - Run PCIeSlots to verify whether it still coredumps
 - Run Redfish validator
 