### PR TITLE
Util api to fetch pretty name for assemblies

### DIFF
--- a/redfish-core/lib/assembly.hpp
+++ b/redfish-core/lib/assembly.hpp
@@ -5,6 +5,7 @@
 #include <sdbusplus/unpack_properties.hpp>
 #include <utils/dbus_utils.hpp>
 #include <utils/json_utils.hpp>
+#include <utils/name_utils.hpp>
 
 #include <cstddef>
 #include <string>
@@ -155,6 +156,11 @@ inline void
                 messages::internalError(aResp->res);
                 return;
             }
+
+            nlohmann::json::json_pointer ptr(
+                "/Assemblies/" + std::to_string(assemblyIndex) + "/Name");
+
+            name_util::getPrettyName(aResp, assembly, object, ptr);
 
             for (const auto& [serviceName, interfaceList] : object)
             {


### PR DESCRIPTION
This commit implements change to use util api to fetch prettyName property for any given assembly and publish it as "Name" in assembly schema.

In case prettyName is blank for that FRU, then last part of the object path will be used to populate assembly name.

Validator executed with no new errors.