### PR TITLE
Add sparePartNumber for Fan

### DIFF
--- a/redfish-core/lib/fan.hpp
+++ b/redfish-core/lib/fan.hpp
@@ -295,11 +295,12 @@ inline void getFanAsset(const std::shared_ptr<bmcweb::AsyncResp>& asyncResp,
         const std::string* serialNumber = nullptr;
         const std::string* manufacturer = nullptr;
         const std::string* model = nullptr;
+        const std::string* sparePartNumber = nullptr;
 
         const bool success = sdbusplus::unpackPropertiesNoThrow(
             dbus_utils::UnpackErrorPrinter(), propertiesList, "PartNumber",
             partNumber, "SerialNumber", serialNumber, "Manufacturer",
-            manufacturer, "Model", model);
+            manufacturer, "Model", model, "SparePartNumber", sparePartNumber);
 
         if (!success)
         {
@@ -325,6 +326,11 @@ inline void getFanAsset(const std::shared_ptr<bmcweb::AsyncResp>& asyncResp,
         if (model != nullptr)
         {
             asyncResp->res.jsonValue["Model"] = *model;
+        }
+
+        if (sparePartNumber != nullptr)
+        {
+            asyncResp->res.jsonValue["SparePartNumber"] = *sparePartNumber;
         }
         });
 }


### PR DESCRIPTION
Add sparePartNumber for Fan

This commit fixes defect 459342, by adding sparePartNumber for Fan.
    
    Tested-
    -Ran Redfish service validator and no new errors were seen.
     and can see the sparePartNumber for fans.
     https://sys-openbmc-dev-jenkins.swg-devops.com/job/OpenBMC-Dev/job/test/job/continuous-integration/job/ebmc/job/Redfish-Service-Validator/1212/artifact/logs/ConformanceHtmlLog_04_01_2023_122547.html
    
    -Verified on Rainier100 system, sparePartNumber shows up for fans.
    curl -k -H "X-Auth-Token: $bmc_token" -X GET https://${bmc}/redfish/v1/Chassis/chassis/ThermalSubsystem/Fans/fan0_1
    {
      "@odata.id": "/redfish/v1/Chassis/chassis/ThermalSubsystem/Fans/fan0_1",
      "@odata.type": "#Fan.v1_3_0.Fan",
      "Id": "fan0_1",
      "Location": {
        "PartLocation": {
          "ServiceLabel": "U78DA.ND0.WZS004A-A0"
        }
      },
      "LocationIndicatorActive": false,
      "Manufacturer": "Delta",
      "Model": "7B5G",
      "Name": "fan0_1",
      "PartNumber": "02YK200",
      "SerialNumber": "YS10JP12V0TY",
      "SparePartNumber": "02YK237",
      "Status": {
        "Health": "OK",
        "State": "Enabled"
      }
    }

Change-Id: I1acbf91d808736f189f77bcf1362a7f8562e92db
Signed-off-by: Alpana Kumari <alpankum@in.ibm.com>