### PR TITLE
Handle patchCpuCoreMembers request

### DIFF
--- a/redfish-core/lib/processor.hpp
+++ b/redfish-core/lib/processor.hpp
@@ -1991,6 +1991,11 @@ inline void requestRoutesSubProcessorsCore(App& app)
 
         getSubProcessorData(asyncResp, processorId, coreId);
         });
+
+    BMCWEB_ROUTE(
+        app, "/redfish/v1/Systems/system/Processors/<str>/SubProcessors/<str>")
+        .privileges(redfish::privileges::patchProcessor)
+        .methods(boost::beast::http::verb::patch)(patchCpuCoreMembers);
 }
 
 } // namespace redfish


### PR DESCRIPTION
This was missed while rebasing 1030 changes. NA for Upstream as we do not have the method to patch Cpu Core Members on upstream
It is fixed now and handles 
curl -k -H "X-Auth-Token: $bmc_token" -X PATCH
https://${BMC_IP}/redfish/v1/Systems/system/Processors/dcm0-cpu0/SubProcessors/core8 -d '{"Enabled" : <true/false> }' successfully