### PR TITLE
Add new Message registry with ASCII post code place holder

### DIFF
--- a/http/utility.hpp
+++ b/http/utility.hpp
@@ -541,6 +541,30 @@ inline bool base64Decode(const std::string_view input, std::string& output)
     return true;
 }
 
+/**
+ * Method returns 64bit post code into ASCII string
+ *
+ * @param[in] postcode value
+ *
+ * @return ascii converted post code string
+ */
+
+inline std::string convertToAscii(const uint64_t& element)
+{
+    uint64_t tmpelement = element;
+    uint8_t* p = static_cast<uint8_t*>(static_cast<void*>(&tmpelement));
+    std::span<unsigned char> bytearray{p, 8};
+
+    if (std::count_if(bytearray.begin(), bytearray.end(), [](unsigned char c) {
+            return (std::isprint(c) == 0);
+        }) != 0)
+    {
+        return {};
+    }
+
+    return {std::string(bytearray.begin(), bytearray.end())};
+}
+
 inline bool constantTimeStringCompare(const std::string_view a,
                                       const std::string_view b)
 {

--- a/redfish-core/include/registries/openbmc_message_registry.hpp
+++ b/redfish-core/include/registries/openbmc_message_registry.hpp
@@ -235,6 +235,16 @@ constexpr std::array registry = {
             {"number", "number", "number"},
             "None.",
         }},
+    MessageEntry{
+        "BIOSPOSTCodeASCII",
+        {
+            "BIOS Power-On Self-Test Code received",
+            "Boot Count: %1; Time Stamp Offset: %2 seconds; POSTCode: %3; POST Code in ASCII: %4",
+            "OK",
+            4,
+            {"number", "number", "number", "string"},
+            "None.",
+        }},
     MessageEntry{"BIOSPOSTError",
                  {
                      "Indicates BIOS POST has encountered an error.",

--- a/redfish-core/lib/log_services.hpp
+++ b/redfish-core/lib/log_services.hpp
@@ -5023,7 +5023,7 @@ static bool fillPostCodeEntry(
 {
     // Get the Message from the MessageRegistry
     const registries::Message* message =
-        registries::getMessage("OpenBMC.0.2.BIOSPOSTCode");
+        registries::getMessage("OpenBMC.0.4.BIOSPOSTCodeASCII");
 
     uint64_t currentCodeIndex = 0;
     uint64_t firstCodeTimeUs = 0;
@@ -5077,6 +5077,8 @@ static bool fillPostCodeEntry(
         std::ostringstream hexCode;
         hexCode << "0x" << std::setfill('0') << std::setw(2) << std::hex
                 << std::get<0>(code.second);
+        std::string stringCode =
+            crow::utility::convertToAscii(std::get<uint64_t>(code.second));
         std::ostringstream timeOffsetStr;
         // Set Fixed -Point Notation
         timeOffsetStr << std::fixed;
@@ -5084,8 +5086,9 @@ static bool fillPostCodeEntry(
         timeOffsetStr << std::setprecision(4);
         // Add double to stream
         timeOffsetStr << static_cast<double>(usTimeOffset) / 1000 / 1000;
-        std::vector<std::string> messageArgs = {
-            std::to_string(bootIndex), timeOffsetStr.str(), hexCode.str()};
+        std::vector<std::string> messageArgs = {std::to_string(bootIndex),
+                                                timeOffsetStr.str(),
+                                                hexCode.str(), stringCode};
 
         // Get MessageArgs template from message registry
         std::string msg;
@@ -5122,7 +5125,7 @@ static bool fillPostCodeEntry(
         bmcLogEntry["Name"] = "POST Code Log Entry";
         bmcLogEntry["Id"] = postcodeEntryID;
         bmcLogEntry["Message"] = std::move(msg);
-        bmcLogEntry["MessageId"] = "OpenBMC.0.2.BIOSPOSTCode";
+        bmcLogEntry["MessageId"] = "OpenBMC.0.4.BIOSPOSTCodeASCII";
         bmcLogEntry["MessageArgs"] = std::move(messageArgs);
         bmcLogEntry["EntryType"] = "Event";
         bmcLogEntry["Severity"] = std::move(severity);

--- a/test/http/utility_test.cpp
+++ b/test/http/utility_test.cpp
@@ -235,5 +235,21 @@ TEST(AppendUrlFromPieces, PiecesAreAppendedViaDelimiters)
               "/redfish/v1/foo/bar/%2F/bad&tring");
 }
 
+TEST(Utility, convertToAsciiGoodTestCase)
+{
+    std::string stringCode = crow::utility::convertToAscii(0x205942444e415453);
+    EXPECT_EQ("STANDBY ", stringCode);
+    stringCode = crow::utility::convertToAscii(0x3030463130303143);
+    EXPECT_EQ("C1001F00", stringCode);
+}
+
+TEST(Utility, convertToAsciiBadTestCase)
+{
+    std::string stringCode = crow::utility::convertToAscii(0xFFFFFFFFFFFFFFFF);
+    EXPECT_EQ("", stringCode);
+    stringCode = crow::utility::convertToAscii(0xD7D7D7D7D7D7D7D7);
+    EXPECT_EQ("", stringCode);
+}
+
 } // namespace
 } // namespace crow::utility


### PR DESCRIPTION
- In the current state, the BIOS Post code message registry has a place holder to only display a hex based post code.

- Since Power 5 series of servers, IBM progress codes are ASCII based character codes as mentioned in the below link: (https://www.ibm.com/support/knowledgecenter/POWER5/ipha6_p5/progcodesmain.htm)

- These progress codes are displayed in multiple places like BMC GUI, Operator Panel , Hardware Management Console e.t.c, and most of the customers of power are well accustomed to seeing these character based codes. And in the current infrastructure we display the hex form of uint64 value, which can lead to misses where some customer does not know how to look up the code & translate it to ASCII and last thing we would want is for a service rep to do the translation.

- For most of the systems where we don't have the ASCII convertible progress codes, it should not be an issue as we still display the hex codes, but in addition we just display empty string in the ASCII place holder.

- Clients like management console, GUI(probably needs an OEM code), Operator Panel can probably do this conversion of hex to ASCII, but its the customers that we are really concerned about & also by adding this additional field in a new message registry we can probably share a common GUI code (that displays both the hex codes as well as ASCII codes).

- Redfish experts suggestion is, instead of changing the existing message registry which can break clients, we have to add a new message registry with almost the similar name like BIOSPOSTCodeASCII with the new argument set and bump up the minor version of the Message registry.

(https://redfishforum.com/thread/447/bumping-message-registry-backward-compatability)

Tested By :
- Redfish Validator - PASSED
```*** /redfish/v1/Systems/system/LogServices/PostCodes
	 Type (LogService.v1_1_0.LogService), GET SUCCESS (time: 0:00:02.247386)
Attempt 1 of /redfish/v1/Systems/system/LogServices/PostCodes/Entries
Response Time for GET to /redfish/v1/Systems/system/LogServices/PostCodes/Entries: 3.4031527920014923 seconds.
	 PASS

*** /redfish/v1/Systems/system/LogServices/PostCodes/Entries
	 Type (LogEntryCollection.LogEntryCollection), GET SUCCESS (time: 0:00:03.407296)
	 PASS

*** /redfish/v1/Systems/system/LogServices/PostCodes/Entries/B1-1
	 Type (LogEntry.v1_9_0.LogEntry), GET SUCCESS (time: 0)
	 PASS
```
- The base function that does the hex to ASCII conversion is unit tested.
- IBM systems does not a snooping port, so i could not test this on a real machine that generates the post codes, but I did the functional test by patching the snoopd daemon & the post-code-manager daemon.
- PATCH the Raw Post Code property

 $ busctl call xyz.openbmc_project.State.Boot.Raw /xyz/openbmc_project/state/boot/raw0
 org.freedesktop.DBus.Properties Get ss xyz.openbmc_project.State.Boot.Raw Value
 v t 2330967143279055955

- GET on the Post Code Entry should give the Post code in ASCII Format
```
    {
      "@odata.id": "/redfish/v1/Systems/system/LogServices/PostCodes/Entries/B5-12",
      "@odata.type": "#LogEntry.v1_9_0.LogEntry",
      "AdditionalDataURI": "/redfish/v1/Systems/system/LogServices/PostCodes/Entries/B5-12/attachment",
      "Created": "2023-03-27T14:17:59+00:00",
      "EntryType": "Event",
      "Id": "B5-12",
      "Message": "Boot Count: 5; Time Stamp Offset: 31.6142 seconds; POSTCode: 0x3543313930304343; POST Code in ASCII: CC0091C5",
      "MessageArgs": [
        "5",
        "31.6142",
        "0x3543313930304343",
        "CC0091C5"
      ],
      "MessageId": "OpenBMC.0.4.BIOSPOSTCodeASCII",
      "Name": "POST Code Log Entry",
      "Severity": "OK"
    }
  ],
  "Members@odata.count": 176,
  "Name": "BIOS POST Code Log Entries"
}
```
- Made sure that both the GUI Progress logs page & the real-time progress code indicator page displays the ASCII Progress codes.

Change-Id: I6405833ec1bfc2336bc7c7ef1544eb8a729c005d