### PR TITLE
Fix std::time_t compilation errors

### DIFF
--- a/redfish-core/include/utils/hw_isolation.hpp
+++ b/redfish-core/include/utils/hw_isolation.hpp
@@ -641,7 +641,7 @@ inline void
                                     }
                                     condition["Timestamp"] =
                                         crow::utility::getDateTimeUint(
-                                            *timestamp / 1000 / 1000);
+                                            *timestamp);
                                 }
                                 else if (property.first == "Message")
                                 {

--- a/redfish-core/lib/log_services.hpp
+++ b/redfish-core/lib/log_services.hpp
@@ -5046,8 +5046,8 @@ inline void fillSystemHardwareIsolationLogEntry(
                         messages::internalError(asyncResp->res);
                         break;
                     }
-                    entryJson["Created"] = crow::utility::getDateTime(
-                        static_cast<std::time_t>(*elapsdTime));
+                    entryJson["Created"] =
+                        crow::utility::getDateTimeUint(*elapsdTime);
                 }
             }
         }

--- a/redfish-core/lib/power_supply_metrics.hpp
+++ b/redfish-core/lib/power_supply_metrics.hpp
@@ -48,8 +48,8 @@ inline void parseAverageMaximum(const std::shared_ptr<bmcweb::AsyncResp>& aResp,
         // Second value from average and maximum is just an integer type value
         // representing watts.
         inputPowerHistoryItemArray.push_back(
-            {{"Date", crow::utility::getDateTimeUint(
-                          (std::get<0>(*average) / 1000 / 1000 / 1000))},
+            {{"Date",
+              crow::utility::getDateTimeUint((std::get<0>(*average) / 1000))},
              {"Average", std::get<1>(*average)},
              {"Maximum", std::get<1>(*maximum)}});
     }
@@ -106,9 +106,9 @@ inline void getMaximumValues(const std::shared_ptr<bmcweb::AsyncResp>& aResp,
                 // power supply has used in a 30 second interval.
                 auto value = std::get<1>(values);
 
-                BMCWEB_LOG_DEBUG << "Date/Time: "
-                                 << crow::utility::getDateTimeUint(
-                                        dateTime / 1000 / 1000 / 1000);
+                BMCWEB_LOG_DEBUG
+                    << "Date/Time: "
+                    << crow::utility::getDateTimeUint(dateTime / 1000);
                 BMCWEB_LOG_DEBUG << "Maximum Value: " << value;
 
                 maximumValues.emplace_back(dateTime, value);
@@ -173,9 +173,9 @@ inline void
                 // watts this power supply has used in a 30 second interval.
                 auto value = std::get<1>(values);
 
-                BMCWEB_LOG_DEBUG << "DateTime: "
-                                 << crow::utility::getDateTimeUint(
-                                        dateTime / 1000 / 1000 / 1000);
+                BMCWEB_LOG_DEBUG
+                    << "DateTime: "
+                    << crow::utility::getDateTimeUint(dateTime / 1000);
                 BMCWEB_LOG_DEBUG << "Values: " << value;
 
                 averageValues.emplace_back(dateTime, value);


### PR DESCRIPTION
This PR resolves the compilation issues related
to std::time_t due to upstream rebasing.

Tested By:
[1] GET https://${bmc}/redfish/v1/Systems/system/LogServices/HardwareIsolation/Entries/1
    The redfish response showed the correct
    "Created" date time value