### PR TITLE
1050: Fix FabricAdapters Port Collection Handling

### DIFF
--- a/redfish-core/lib/port.hpp
+++ b/redfish-core/lib/port.hpp
@@ -96,8 +96,11 @@ inline void getPortCollection(const std::shared_ptr<bmcweb::AsyncResp>& aResp,
 
         for (const auto& path : paths)
         {
+            // get adapterPath from the dbus connector path
+            std::string adapterPath =
+                sdbusplus::message::object_path(path).parent_path();
             const std::string& adapterUniq =
-                fabric_util::buildFabricUniquePath(path);
+                fabric_util::buildFabricUniquePath(adapterPath);
             if (!fabric_util::checkFabricAdapterId(adapterId, adapterUniq))
             {
                 continue;


### PR DESCRIPTION
Port collection incorrectly returns an empty set
although the associated connectors are discovered.

For example,

FabricAdapter shows Ports.

```
% curl -k -X GET https://${bmc}/redfish/v1/Systems/system/FabricAdapters/chassis-motherboard-disk_backplane0
{
  "@odata.id": "/redfish/v1/Systems/system/FabricAdapters/chassis-motherboard-disk_backplane0",
  "@odata.type": "#FabricAdapter.v1_4_0.FabricAdapter",
  "Id": "chassis-motherboard-disk_backplane0",
....
  "Ports": {
    "@odata.id": "/redfish/v1/Systems/system/FabricAdapters/chassis-motherboard-disk_backplane0/Ports"
  },
.....
  }
}%

```

However, its port collection gives an empty list.

```
% curl -k -X GET https://${bmc}/redfish/v1/Systems/system/FabricAdapters/chassis-motherboard-disk_backplane0/Ports
{
  "@odata.id": "/redfish/v1/Systems/system/FabricAdapters/chassis-motherboard-disk_backplane0/Ports",
  "@odata.type": "#PortCollection.PortCollection",
  "Members": [],
  "Members@odata.count": 0,
  "Name": "Port Collection"
}%
```

This is caused by an error of considering the dbus connector name as fabric adapter name.

```
getPortCollection()
{
         for (const auto& path : paths)
         {
            const std::string& adapterUniq = path;
==>
            // get adapterPath from the dbus connector path
            std::string adapterPath =
                sdbusplus::message::object_path(path).parent_path();
             const std::string& adapterUniq =
                fabric_util::buildFabricUniquePath(adapterPath);
            ...
}

```

Tested:
   - Check FabricAdapters & their Ports content
   - Redfish Validator run

For example, after the fix, we'll see Ports like this

```
% curl -k -X GET https://${bmc}:18080/redfish/v1/Systems/system/FabricAdapters/chassis-motherboard-disk_backplane0/Ports
{
  "@odata.id": "/redfish/v1/Systems/system/FabricAdapters/chassis-motherboard-disk_backplane0/Ports",
  "@odata.type": "#PortCollection.PortCollection",
  "Members": [
    {
      "@odata.id": "/redfish/v1/Systems/system/FabricAdapters/chassis-motherboard-disk_backplane0/Ports/dp0_connector0"
    },
    {
      "@odata.id": "/redfish/v1/Systems/system/FabricAdapters/chassis-motherboard-disk_backplane0/Ports/dp0_connector1"
    },
    ...........
    {
      "@odata.id": "/redfish/v1/Systems/system/FabricAdapters/chassis-motherboard-disk_backplane0/Ports/dp0_connector5"
    }
  ],
  "Members@odata.count": 6,
  "Name": "Port Collection"
}%
```

Upstream: https://gerrit.openbmc.org/c/openbmc/bmcweb/+/61097
