### PR TITLE
1050 upstream aggregation patches

### DIFF
--- a/Redfish.md
+++ b/Redfish.md
@@ -82,6 +82,13 @@ Fields common to all schemas
 - Members
 - Members@odata.count
 
+### /redfish/v1/AggregationService/AggregationSources/{AggregationSourceId}
+
+#### AggregationSource
+
+- HostName
+- Password
+
 ### /redfish/v1/AccountService/Accounts/
 
 #### ManagerAccountCollection

--- a/http/http_client.hpp
+++ b/http/http_client.hpp
@@ -50,9 +50,10 @@
 namespace crow
 {
 
-// It is assumed that the BMC should be able to handle 4 parallel connections
-constexpr uint8_t maxPoolSize = 4;
-constexpr uint8_t maxRequestQueueSize = 50;
+// With Redfish Aggregation it is assumed we will connect to another instance
+// of BMCWeb which can handle 100 simultaneous connections.
+constexpr size_t maxPoolSize = 20;
+constexpr size_t maxRequestQueueSize = 500;
 constexpr unsigned int httpReadBodyLimit = 131072;
 constexpr unsigned int httpReadBufferSize = 4096;
 

--- a/http/http_client.hpp
+++ b/http/http_client.hpp
@@ -777,8 +777,13 @@ class ConnectionPool : public std::enable_shared_from_this<ConnectionPool>
         }
         else
         {
+            // If we can't buffer the request then we should let the callback
+            // handle a 429 Too Many Requests dummy response
             BMCWEB_LOG_ERROR << destIP << ":" << std::to_string(destPort)
                              << " request queue full.  Dropping request.";
+            Response dummyRes;
+            dummyRes.result(boost::beast::http::status::too_many_requests);
+            resHandler(dummyRes);
         }
     }
 

--- a/redfish-core/include/redfish.hpp
+++ b/redfish-core/include/redfish.hpp
@@ -78,8 +78,9 @@ class RedfishService
     {
         requestAccountServiceRoutes(app);
 #ifdef BMCWEB_ENABLE_REDFISH_AGGREGATION
-        requestAggregationServiceRoutes(app);
-        requestAggregationSourcesRoutes(app);
+        requestRoutesAggregationService(app);
+        requestRoutesAggregationSourceCollection(app);
+        requestRoutesAggregationSource(app);
 #endif
         requestRoutesRoles(app);
         requestRoutesRoleCollection(app);

--- a/redfish-core/include/redfish_aggregator.hpp
+++ b/redfish-core/include/redfish_aggregator.hpp
@@ -787,6 +787,11 @@ class RedfishAggregator
         using crow::utility::OrMorePaths;
         using crow::utility::readUrlSegments;
         const boost::urls::url_view url = thisReq.urlView;
+        // UpdateService is the only top level resource that is not a Collection
+        if (readUrlSegments(url, "redfish", "v1", "UpdateService"))
+        {
+            return Result::LocalHandle;
+        }
 
         // We don't need to aggregate JsonSchemas due to potential issues such
         // as version mismatches between aggregator and satellite BMCs.  For

--- a/redfish-core/include/redfish_aggregator.hpp
+++ b/redfish-core/include/redfish_aggregator.hpp
@@ -34,7 +34,7 @@ constexpr std::array nonUriProperties{
     // "HostName", // Isn't actually a Redfish URI
     "Image",
     "MetricProperty",
-    "OriginOfCondition",
+    // "OriginOfCondition", // Is URI when in request, but is object in response
     "TaskMonitor",
     "target", // normal string, but target URI for POST to invoke an action
 };
@@ -190,15 +190,10 @@ class RedfishAggregator
     static inline boost::system::error_code
         aggregationRetryHandler(unsigned int respCode)
     {
-        // As a default, assume 200X is alright.
-        // We don't need to retry on a 404
-        if ((respCode < 200) || ((respCode >= 300) && (respCode != 404)))
-        {
-            return boost::system::errc::make_error_code(
-                boost::system::errc::result_out_of_range);
-        }
-
-        // Return 0 if the response code is valid
+        // Allow all response codes because we want to surface any satellite
+        // issue to the client
+        BMCWEB_LOG_DEBUG << "Received " << respCode
+                         << " response from satellite";
         return boost::system::errc::make_error_code(
             boost::system::errc::success);
     }
@@ -586,6 +581,19 @@ class RedfishAggregator
         }
     }
 
+  public:
+    RedfishAggregator(const RedfishAggregator&) = delete;
+    RedfishAggregator& operator=(const RedfishAggregator&) = delete;
+    RedfishAggregator(RedfishAggregator&&) = delete;
+    RedfishAggregator& operator=(RedfishAggregator&&) = delete;
+    ~RedfishAggregator() = default;
+
+    static RedfishAggregator& getInstance()
+    {
+        static RedfishAggregator handler;
+        return handler;
+    }
+
     // Processes the response returned by a satellite BMC and loads its
     // contents into asyncResp
     static void
@@ -593,14 +601,7 @@ class RedfishAggregator
                         const std::shared_ptr<bmcweb::AsyncResp>& asyncResp,
                         crow::Response& resp)
     {
-        // No processing needed if the request wasn't successful
-        if (resp.resultInt() != 200)
-        {
-            BMCWEB_LOG_DEBUG << "No need to parse satellite response";
-            asyncResp->res.stringResponse = std::move(resp.stringResponse);
-            return;
-        }
-
+        // We want to attempt prefix fixing regardless of response code
         // The resp will not have a json component
         // We need to create a json from resp's stringResponse
         if (resp.getHeaderValue("Content-Type") == "application/json")
@@ -616,9 +617,6 @@ class RedfishAggregator
 
             BMCWEB_LOG_DEBUG << "Successfully parsed satellite response";
 
-            // TODO: For collections we  want to add the satellite responses to
-            // our response rather than just straight overwriting them if our
-            // local handling was successful (i.e. would return a 200).
             addPrefixes(jsonVal, prefix);
 
             BMCWEB_LOG_DEBUG << "Added prefix to parsed satellite response";
@@ -632,8 +630,8 @@ class RedfishAggregator
         {
             if (!resp.body().empty())
             {
-                // We received a 200 response without the correct Content-Type
-                // so return an Operation Failed error
+                // We received a valid response without the correct
+                // Content-Type so return an Operation Failed error
                 BMCWEB_LOG_ERROR
                     << "Satellite response must be of type \"application/json\"";
                 messages::operationFailed(asyncResp->res);
@@ -763,19 +761,6 @@ class RedfishAggregator
             }
         }
     } // End processCollectionResponse()
-
-  public:
-    RedfishAggregator(const RedfishAggregator&) = delete;
-    RedfishAggregator& operator=(const RedfishAggregator&) = delete;
-    RedfishAggregator(RedfishAggregator&&) = delete;
-    RedfishAggregator& operator=(RedfishAggregator&&) = delete;
-    ~RedfishAggregator() = default;
-
-    static RedfishAggregator& getInstance()
-    {
-        static RedfishAggregator handler;
-        return handler;
-    }
 
     // Entry point to Redfish Aggregation
     // Returns Result stating whether or not we still need to locally handle the

--- a/redfish-core/include/redfish_aggregator.hpp
+++ b/redfish-core/include/redfish_aggregator.hpp
@@ -496,25 +496,28 @@ class RedfishAggregator
             return;
         }
 
-        std::string updateServiceName;
-        std::string memberName;
-        if (crow::utility::readUrlSegments(
-                thisReq.urlView, "redfish", "v1", "UpdateService",
-                std::ref(updateServiceName), std::ref(memberName),
-                crow::utility::OrMorePaths()))
-        {
-            // Must be FirmwareInventory or SoftwareInventory
-            findSatellite(thisReq, asyncResp, satelliteInfo, memberName);
-            return;
-        }
+        const boost::urls::segments_view urlSegments =
+            thisReq.urlView.segments();
+        boost::urls::url currentUrl("/");
+        boost::urls::segments_view::iterator it = urlSegments.begin();
+        const boost::urls::segments_view::const_iterator end =
+            urlSegments.end();
 
-        std::string collectionName;
-        if (crow::utility::readUrlSegments(
-                thisReq.urlView, "redfish", "v1", std::ref(collectionName),
-                std::ref(memberName), crow::utility::OrMorePaths()))
+        // Skip past the leading "/redfish/v1"
+        it++;
+        it++;
+        for (; it != end; it++)
         {
-            findSatellite(thisReq, asyncResp, satelliteInfo, memberName);
-            return;
+            if (std::binary_search(topCollections.begin(), topCollections.end(),
+                                   currentUrl.buffer()))
+            {
+                // We've matched a resource collection so this current segment
+                // must contain an aggregation prefix
+                findSatellite(thisReq, asyncResp, satelliteInfo, *it);
+                return;
+            }
+
+            currentUrl.segments().push_back(*it);
         }
 
         // We shouldn't reach this point since we should've hit one of the
@@ -784,11 +787,6 @@ class RedfishAggregator
         using crow::utility::OrMorePaths;
         using crow::utility::readUrlSegments;
         const boost::urls::url_view url = thisReq.urlView;
-        // UpdateService is the only top level resource that is not a Collection
-        if (readUrlSegments(url, "redfish", "v1", "UpdateService"))
-        {
-            return Result::LocalHandle;
-        }
 
         // We don't need to aggregate JsonSchemas due to potential issues such
         // as version mismatches between aggregator and satellite BMCs.  For
@@ -800,52 +798,72 @@ class RedfishAggregator
             return Result::LocalHandle;
         }
 
-        if (readUrlSegments(url, "redfish", "v1", "UpdateService",
-                            "SoftwareInventory") ||
-            readUrlSegments(url, "redfish", "v1", "UpdateService",
-                            "FirmwareInventory"))
+        // The first two segments should be "/redfish/v1".  We need to check
+        // that before we can search topCollections
+        if (!crow::utility::readUrlSegments(url, "redfish", "v1",
+                                            crow::utility::OrMorePaths()))
         {
-            startAggregation(AggregationType::Collection, thisReq, asyncResp);
             return Result::LocalHandle;
         }
 
-        // Is the request for a resource collection?:
-        // /redfish/v1/<resource>
-        // e.g. /redfish/v1/Chassis
-        std::string collectionName;
-        if (readUrlSegments(url, "redfish", "v1", std::ref(collectionName)))
-        {
-            startAggregation(AggregationType::Collection, thisReq, asyncResp);
-            return Result::LocalHandle;
-        }
+        // Parse the URI to see if it begins with a known top level collection
+        // such as:
+        // /redfish/v1/Chassis
+        // /redfish/v1/UpdateService/FirmwareInventory
+        const boost::urls::segments_view urlSegments = url.segments();
+        std::string collectionItem;
+        boost::urls::url currentUrl("/");
+        boost::urls::segments_view::iterator it = urlSegments.begin();
+        const boost::urls::segments_view::const_iterator end =
+            urlSegments.end();
 
-        // We know that the ID of an aggregated resource will begin with
-        // "5B247A".  For the most part the URI will begin like this:
-        // /redfish/v1/<resource>/<resource ID>
-        // Note, FirmwareInventory and SoftwareInventory are "special" because
-        // they are two levels deep, but still need aggregated
-        // /redfish/v1/UpdateService/FirmwareInventory/<FirmwareInventory ID>
-        // /redfish/v1/UpdateService/SoftwareInventory/<SoftwareInventory ID>
-        std::string memberName;
-        if (readUrlSegments(url, "redfish", "v1", "UpdateService",
-                            "SoftwareInventory", std::ref(memberName),
-                            OrMorePaths()) ||
-            readUrlSegments(url, "redfish", "v1", "UpdateService",
-                            "FirmwareInventory", std::ref(memberName),
-                            OrMorePaths()) ||
-            readUrlSegments(url, "redfish", "v1", std::ref(collectionName),
-                            std::ref(memberName), OrMorePaths()))
+        // Skip past the leading "/redfish/v1"
+        it++;
+        it++;
+        for (; it != end; it++)
         {
-            if (memberName.starts_with("5B247A"))
+            collectionItem = *it;
+            if (std::binary_search(topCollections.begin(), topCollections.end(),
+                                   currentUrl.buffer()))
             {
-                BMCWEB_LOG_DEBUG << "Need to forward a request";
+                // We've matched a resource collection so this current segment
+                // might contain an aggregation prefix
+                if (collectionItem.starts_with("5B247A"))
+                {
+                    BMCWEB_LOG_DEBUG << "Need to forward a request";
 
-                // Extract the prefix from the request's URI, retrieve the
-                // associated satellite config information, and then forward the
-                // request to that satellite.
-                startAggregation(AggregationType::Resource, thisReq, asyncResp);
-                return Result::NoLocalHandle;
+                    // Extract the prefix from the request's URI, retrieve the
+                    // associated satellite config information, and then forward
+                    // the request to that satellite.
+                    startAggregation(AggregationType::Resource, thisReq,
+                                     asyncResp);
+                    return Result::NoLocalHandle;
+                }
+
+                // Handle collection URI with a trailing backslash
+                // e.g. /redfish/v1/Chassis/
+                it++;
+                if ((it == end) && collectionItem.empty())
+                {
+                    startAggregation(AggregationType::Collection, thisReq,
+                                     asyncResp);
+                }
+
+                // We didn't recognize the prefix or it's a collection with a
+                // trailing "/".  In both cases we still want to locally handle
+                // the request
+                return Result::LocalHandle;
             }
+
+            currentUrl.segments().push_back(collectionItem);
+        }
+
+        // If we made it here then currentUrl could contain a top level
+        // collection URI without a trailing "/", e.g. /redfish/v1/Chassis
+        if (std::binary_search(topCollections.begin(), topCollections.end(),
+                               currentUrl.buffer()))
+        {
+            startAggregation(AggregationType::Collection, thisReq, asyncResp);
             return Result::LocalHandle;
         }
 

--- a/redfish-core/include/redfish_aggregator.hpp
+++ b/redfish-core/include/redfish_aggregator.hpp
@@ -278,53 +278,18 @@ class RedfishAggregator
     // Dummy callback used by the Constructor so that it can report the number
     // of satellite configs when the class is first created
     static void constructorCallback(
+        const boost::system::error_code& ec,
         const std::unordered_map<std::string, boost::urls::url>& satelliteInfo)
     {
+        if (ec)
+        {
+            BMCWEB_LOG_ERROR << "Something went wrong while querying dbus!";
+            return;
+        }
+
         BMCWEB_LOG_DEBUG << "There were "
                          << std::to_string(satelliteInfo.size())
                          << " satellite configs found at startup";
-    }
-
-    // Polls D-Bus to get all available satellite config information
-    // Expects a handler which interacts with the returned configs
-    static void getSatelliteConfigs(
-        const std::function<void(
-            const std::unordered_map<std::string, boost::urls::url>&)>& handler)
-    {
-        BMCWEB_LOG_DEBUG << "Gathering satellite configs";
-        crow::connections::systemBus->async_method_call(
-            [handler](const boost::system::error_code ec,
-                      const dbus::utility::ManagedObjectType& objects) {
-            if (ec)
-            {
-                BMCWEB_LOG_ERROR << "DBUS response error " << ec.value() << ", "
-                                 << ec.message();
-                return;
-            }
-
-            // Maps a chosen alias representing a satellite BMC to a url
-            // containing the information required to create a http
-            // connection to the satellite
-            std::unordered_map<std::string, boost::urls::url> satelliteInfo;
-
-            findSatelliteConfigs(objects, satelliteInfo);
-
-            if (!satelliteInfo.empty())
-            {
-                BMCWEB_LOG_DEBUG << "Redfish Aggregation enabled with "
-                                 << std::to_string(satelliteInfo.size())
-                                 << " satellite BMCs";
-            }
-            else
-            {
-                BMCWEB_LOG_DEBUG
-                    << "No satellite BMCs detected.  Redfish Aggregation not enabled";
-            }
-            handler(satelliteInfo);
-            },
-            "xyz.openbmc_project.EntityManager",
-            "/xyz/openbmc_project/inventory",
-            "org.freedesktop.DBus.ObjectManager", "GetManagedObjects");
     }
 
     // Search D-Bus objects for satellite config objects and add their
@@ -531,10 +496,17 @@ class RedfishAggregator
         AggregationType isCollection,
         const std::shared_ptr<crow::Request>& sharedReq,
         const std::shared_ptr<bmcweb::AsyncResp>& asyncResp,
+        const boost::system::error_code& ec,
         const std::unordered_map<std::string, boost::urls::url>& satelliteInfo)
     {
         if (sharedReq == nullptr)
         {
+            return;
+        }
+        // Something went wrong while querying dbus
+        if (ec)
+        {
+            messages::internalError(asyncResp->res);
             return;
         }
 
@@ -669,6 +641,51 @@ class RedfishAggregator
     {
         static RedfishAggregator handler;
         return handler;
+    }
+
+    // Polls D-Bus to get all available satellite config information
+    // Expects a handler which interacts with the returned configs
+    static void getSatelliteConfigs(
+        std::function<
+            void(const boost::system::error_code&,
+                 const std::unordered_map<std::string, boost::urls::url>&)>
+            handler)
+    {
+        BMCWEB_LOG_DEBUG << "Gathering satellite configs";
+        crow::connections::systemBus->async_method_call(
+            [handler{std::move(handler)}](
+                const boost::system::error_code& ec,
+                const dbus::utility::ManagedObjectType& objects) {
+            std::unordered_map<std::string, boost::urls::url> satelliteInfo;
+            if (ec)
+            {
+                BMCWEB_LOG_ERROR << "DBUS response error " << ec.value() << ", "
+                                 << ec.message();
+                handler(ec, satelliteInfo);
+                return;
+            }
+
+            // Maps a chosen alias representing a satellite BMC to a url
+            // containing the information required to create a http
+            // connection to the satellite
+            findSatelliteConfigs(objects, satelliteInfo);
+
+            if (!satelliteInfo.empty())
+            {
+                BMCWEB_LOG_DEBUG << "Redfish Aggregation enabled with "
+                                 << std::to_string(satelliteInfo.size())
+                                 << " satellite BMCs";
+            }
+            else
+            {
+                BMCWEB_LOG_DEBUG
+                    << "No satellite BMCs detected.  Redfish Aggregation not enabled";
+            }
+            handler(ec, satelliteInfo);
+            },
+            "xyz.openbmc_project.EntityManager",
+            "/xyz/openbmc_project/inventory",
+            "org.freedesktop.DBus.ObjectManager", "GetManagedObjects");
     }
 
     // Processes the response returned by a satellite BMC and loads its
@@ -909,7 +926,11 @@ class RedfishAggregator
             {
                 // We've matched a resource collection so this current segment
                 // might contain an aggregation prefix
-                if (collectionItem.starts_with("5B247A"))
+                // TODO: This needs to be rethought when we can support multiple
+                // satellites due to
+                // /redfish/v1/AggregationService/AggregationSources/5B247A
+                // being a local resource describing the satellite
+                if (collectionItem.starts_with("5B247A_"))
                 {
                     BMCWEB_LOG_DEBUG << "Need to forward a request";
 

--- a/redfish-core/include/redfish_aggregator.hpp
+++ b/redfish-core/include/redfish_aggregator.hpp
@@ -50,19 +50,14 @@ inline bool isPropertyUri(const std::string_view propertyName)
                               propertyName);
 }
 
-static void addPrefixToItem(nlohmann::json& item, std::string_view prefix)
+static inline void addPrefixToStringItem(std::string& strValue,
+                                         std::string_view prefix)
 {
-    std::string* strValue = item.get_ptr<std::string*>();
-    if (strValue == nullptr)
-    {
-        BMCWEB_LOG_CRITICAL << "Field wasn't a string????";
-        return;
-    }
     // Make sure the value is a properly formatted URI
-    auto parsed = boost::urls::parse_relative_ref(*strValue);
+    auto parsed = boost::urls::parse_relative_ref(strValue);
     if (!parsed)
     {
-        BMCWEB_LOG_CRITICAL << "Couldn't parse URI from resource " << *strValue;
+        BMCWEB_LOG_CRITICAL << "Couldn't parse URI from resource " << strValue;
         return;
     }
 
@@ -131,13 +126,55 @@ static void addPrefixToItem(nlohmann::json& item, std::string_view prefix)
     if (addedPrefix)
     {
         url.segments().insert(url.segments().begin(), {"redfish", "v1"});
-        item = url;
+        strValue = url.buffer();
     }
+}
+
+static inline void addPrefixToItem(nlohmann::json& item,
+                                   std::string_view prefix)
+{
+    std::string* strValue = item.get_ptr<std::string*>();
+    if (strValue == nullptr)
+    {
+        BMCWEB_LOG_CRITICAL << "Field wasn't a string????";
+        return;
+    }
+    addPrefixToStringItem(*strValue, prefix);
+    item = *strValue;
+}
+
+static inline void addAggregatedHeaders(crow::Response& asyncResp,
+                                        crow::Response& resp,
+                                        std::string_view prefix)
+{
+    if (!resp.getHeaderValue("Content-Type").empty())
+    {
+        asyncResp.addHeader(boost::beast::http::field::content_type,
+                            resp.getHeaderValue("Content-Type"));
+    }
+    if (!resp.getHeaderValue("Allow").empty())
+    {
+        asyncResp.addHeader(boost::beast::http::field::allow,
+                            resp.getHeaderValue("Allow"));
+    }
+    std::string_view header = resp.getHeaderValue("Location");
+    if (!header.empty())
+    {
+        std::string location(header);
+        addPrefixToStringItem(location, prefix);
+        asyncResp.addHeader(boost::beast::http::field::location, location);
+    }
+    if (!resp.getHeaderValue("Retry-After").empty())
+    {
+        asyncResp.addHeader(boost::beast::http::field::retry_after,
+                            resp.getHeaderValue("Retry-After"));
+    }
+    // TODO: we need special handling for Link Header Value
 }
 
 // Search the json for all URIs and add the supplied prefix if the URI is for
 // an aggregated resource.
-static void addPrefixes(nlohmann::json& json, std::string_view prefix)
+static inline void addPrefixes(nlohmann::json& json, std::string_view prefix)
 {
     nlohmann::json::object_t* object =
         json.get_ptr<nlohmann::json::object_t*>();
@@ -636,15 +673,11 @@ class RedfishAggregator
         }
         else
         {
-            if (!resp.body().empty())
-            {
-                // We received a valid response without the correct
-                // Content-Type so return an Operation Failed error
-                BMCWEB_LOG_ERROR
-                    << "Satellite response must be of type \"application/json\"";
-                messages::operationFailed(asyncResp->res);
-            }
+            // We allow any Content-Type that is not "application/json" now
+            asyncResp->res.result(resp.result());
+            asyncResp->res.write(resp.body());
         }
+        addAggregatedHeaders(asyncResp->res, resp, prefix);
     }
 
     // Processes the collection response returned by a satellite BMC and merges

--- a/redfish-core/include/redfish_aggregator.hpp
+++ b/redfish-core/include/redfish_aggregator.hpp
@@ -601,6 +601,14 @@ class RedfishAggregator
                         const std::shared_ptr<bmcweb::AsyncResp>& asyncResp,
                         crow::Response& resp)
     {
+        // 429 and 502 mean we didn't actually send the request so don't
+        // overwrite the response headers in that case
+        if ((resp.resultInt() == 429) || (resp.resultInt() == 502))
+        {
+            asyncResp->res.result(resp.result());
+            return;
+        }
+
         // We want to attempt prefix fixing regardless of response code
         // The resp will not have a json component
         // We need to create a json from resp's stringResponse
@@ -646,6 +654,13 @@ class RedfishAggregator
         const std::shared_ptr<bmcweb::AsyncResp>& asyncResp,
         crow::Response& resp)
     {
+        // 429 and 502 mean we didn't actually send the request so don't
+        // overwrite the response headers in that case
+        if ((resp.resultInt() == 429) || (resp.resultInt() == 502))
+        {
+            return;
+        }
+
         if (resp.resultInt() != 200)
         {
             BMCWEB_LOG_DEBUG
@@ -671,6 +686,7 @@ class RedfishAggregator
 
                 // Notify the user if doing so won't overwrite a valid response
                 if ((asyncResp->res.resultInt() != 200) &&
+                    (asyncResp->res.resultInt() != 429) &&
                     (asyncResp->res.resultInt() != 502))
                 {
                     messages::operationFailed(asyncResp->res);
@@ -706,6 +722,7 @@ class RedfishAggregator
                     << "Collection does not exist, overwriting asyncResp";
                 asyncResp->res.result(resp.result());
                 asyncResp->res.jsonValue = std::move(jsonVal);
+                asyncResp->res.addHeader("Content-Type", "application/json");
 
                 BMCWEB_LOG_DEBUG << "Finished overwriting asyncResp";
             }
@@ -749,12 +766,13 @@ class RedfishAggregator
         {
             BMCWEB_LOG_ERROR << "Received unparsable response from \"" << prefix
                              << "\"";
-            // We received as response that was not a json
+            // We received a response that was not a json.
             // Notify the user only if we did not receive any valid responses,
             // if the resource collection does not already exist on the
             // aggregating BMC, and if we did not already set this warning due
             // to a failure from a different satellite
             if ((asyncResp->res.resultInt() != 200) &&
+                (asyncResp->res.resultInt() != 429) &&
                 (asyncResp->res.resultInt() != 502))
             {
                 messages::operationFailed(asyncResp->res);

--- a/redfish-core/include/redfish_aggregator.hpp
+++ b/redfish-core/include/redfish_aggregator.hpp
@@ -172,6 +172,38 @@ static inline void addAggregatedHeaders(crow::Response& asyncResp,
     // TODO: we need special handling for Link Header Value
 }
 
+// Fix HTTP headers which appear in responses from Task resources among others
+static inline void addPrefixToHeadersInResp(nlohmann::json& json,
+                                            std::string_view prefix)
+{
+    // The passed in "HttpHeaders" should be an array of headers
+    nlohmann::json::array_t* array = json.get_ptr<nlohmann::json::array_t*>();
+    if (array == nullptr)
+    {
+        BMCWEB_LOG_ERROR << "Field wasn't an array_t????";
+        return;
+    }
+
+    for (nlohmann::json& item : *array)
+    {
+        // Each header is a single string with the form "<Field>: <Value>"
+        std::string* strHeader = item.get_ptr<std::string*>();
+        if (strHeader == nullptr)
+        {
+            BMCWEB_LOG_CRITICAL << "Field wasn't a string????";
+            continue;
+        }
+
+        constexpr std::string_view location = "Location: ";
+        if (strHeader->starts_with(location))
+        {
+            std::string header = strHeader->substr(location.size());
+            addPrefixToStringItem(header, prefix);
+            *strHeader = std::string(location) + header;
+        }
+    }
+}
+
 // Search the json for all URIs and add the supplied prefix if the URI is for
 // an aggregated resource.
 static inline void addPrefixes(nlohmann::json& json, std::string_view prefix)
@@ -185,6 +217,14 @@ static inline void addPrefixes(nlohmann::json& json, std::string_view prefix)
             if (isPropertyUri(item.first))
             {
                 addPrefixToItem(item.second, prefix);
+                continue;
+            }
+
+            // "HttpHeaders" contains HTTP headers.  Among those we need to
+            // attempt to fix the "Location" header
+            if (item.first == "HttpHeaders")
+            {
+                addPrefixToHeadersInResp(item.second, prefix);
                 continue;
             }
 

--- a/redfish-core/include/utils/query_param.hpp
+++ b/redfish-core/include/utils/query_param.hpp
@@ -536,7 +536,7 @@ struct ExpandNode
 // with the keys from the jsonResponse object
 inline void findNavigationReferencesRecursive(
     ExpandType eType, nlohmann::json& jsonResponse,
-    const nlohmann::json::json_pointer& p, bool inLinks,
+    const nlohmann::json::json_pointer& p, int depth, bool inLinks,
     std::vector<ExpandNode>& out)
 {
     // If no expand is needed, return early
@@ -544,6 +544,7 @@ inline void findNavigationReferencesRecursive(
     {
         return;
     }
+
     nlohmann::json::array_t* array =
         jsonResponse.get_ptr<nlohmann::json::array_t*>();
     if (array != nullptr)
@@ -554,8 +555,8 @@ inline void findNavigationReferencesRecursive(
         {
             nlohmann::json::json_pointer newPtr = p / index;
             BMCWEB_LOG_DEBUG << "Traversing response at " << newPtr.to_string();
-            findNavigationReferencesRecursive(eType, element, newPtr, inLinks,
-                                              out);
+            findNavigationReferencesRecursive(eType, element, newPtr, depth,
+                                              inLinks, out);
             index++;
         }
     }
@@ -574,11 +575,29 @@ inline void findNavigationReferencesRecursive(
                 obj->begin()->second.get_ptr<const std::string*>();
             if (uri != nullptr)
             {
-                BMCWEB_LOG_DEBUG << "Found element at " << p.to_string();
+                BMCWEB_LOG_DEBUG << "Found " << *uri << " at " << p.to_string();
                 out.push_back({p, *uri});
+                return;
             }
         }
     }
+
+    int newDepth = depth;
+    auto odataId = obj->find("@odata.id");
+    if (odataId != obj->end())
+    {
+        // The Redfish spec requires all resources to include the resource
+        // identifier.  If the object has multiple elements and one of them is
+        // "@odata.id" then that means we have entered a new level / expanded
+        // resource.  We need to stop traversing if we're already at the desired
+        // depth
+        if ((obj->size() > 1) && (depth == 0))
+        {
+            return;
+        }
+        newDepth--;
+    }
+
     // Loop the object and look for links
     for (auto& element : *obj)
     {
@@ -602,16 +621,24 @@ inline void findNavigationReferencesRecursive(
         BMCWEB_LOG_DEBUG << "Traversing response at " << newPtr;
 
         findNavigationReferencesRecursive(eType, element.second, newPtr,
-                                          localInLinks, out);
+                                          newDepth, localInLinks, out);
     }
 }
 
+// TODO: When aggregation is enabled and we receive a partially expanded
+// response we may need need additional handling when the original URI was
+// up tree from a top level collection.
+// Isn't a concern until https://gerrit.openbmc.org/c/openbmc/bmcweb/+/60556
+// lands.  May want to avoid forwarding query params when request is uptree from
+// a top level collection.
 inline std::vector<ExpandNode>
-    findNavigationReferences(ExpandType eType, nlohmann::json& jsonResponse)
+    findNavigationReferences(ExpandType eType, int depth,
+                             nlohmann::json& jsonResponse)
 {
     std::vector<ExpandNode> ret;
     const nlohmann::json::json_pointer root = nlohmann::json::json_pointer("");
-    findNavigationReferencesRecursive(eType, jsonResponse, root, false, ret);
+    findNavigationReferencesRecursive(eType, jsonResponse, root, depth, false,
+                                      ret);
     return ret;
 }
 
@@ -772,8 +799,8 @@ class MultiAsyncResp : public std::enable_shared_from_this<MultiAsyncResp>
     // for deeper levels.
     void startQuery(const Query& query)
     {
-        std::vector<ExpandNode> nodes =
-            findNavigationReferences(query.expandType, finalRes->res.jsonValue);
+        std::vector<ExpandNode> nodes = findNavigationReferences(
+            query.expandType, query.expandLevel, finalRes->res.jsonValue);
         BMCWEB_LOG_DEBUG << nodes.size() << " nodes to traverse";
         const std::optional<std::string> queryStr = formatQueryForExpand(query);
         if (!queryStr)

--- a/redfish-core/lib/aggregation_service.hpp
+++ b/redfish-core/lib/aggregation_service.hpp
@@ -5,6 +5,7 @@
 #include "http_request.hpp"
 #include "http_response.hpp"
 #include "query.hpp"
+#include "redfish_aggregator.hpp"
 #include "registries/privilege_registry.hpp"
 
 #include <nlohmann/json.hpp>
@@ -50,7 +51,7 @@ inline void handleAggregationServiceGet(
         "/redfish/v1/AggregationService/AggregationSources";
 }
 
-inline void requestAggregationServiceRoutes(App& app)
+inline void requestRoutesAggregationService(App& app)
 {
     BMCWEB_ROUTE(app, "/redfish/v1/AggregationService/")
         .privileges(redfish::privileges::headAggregationService)
@@ -62,7 +63,31 @@ inline void requestAggregationServiceRoutes(App& app)
             std::bind_front(handleAggregationServiceGet, std::ref(app)));
 }
 
-inline void handleAggregationSourcesGet(
+inline void populateAggregationSourceCollection(
+    const std::shared_ptr<bmcweb::AsyncResp>& asyncResp,
+    const boost::system::error_code ec,
+    const std::unordered_map<std::string, boost::urls::url>& satelliteInfo)
+{
+    // Something went wrong while querying dbus
+    if (ec)
+    {
+        messages::internalError(asyncResp->res);
+        return;
+    }
+    nlohmann::json::array_t members = nlohmann::json::array();
+    for (const auto& sat : satelliteInfo)
+    {
+        nlohmann::json::object_t member;
+        member["@odata.id"] =
+            crow::utility::urlFromPieces("redfish", "v1", "AggregationService",
+                                         "AggregationSources", sat.first);
+        members.push_back(std::move(member));
+    }
+    asyncResp->res.jsonValue["Members@odata.count"] = members.size();
+    asyncResp->res.jsonValue["Members"] = std::move(members);
+}
+
+inline void handleAggregationSourceCollectionGet(
     App& app, const crow::Request& req,
     const std::shared_ptr<bmcweb::AsyncResp>& asyncResp)
 {
@@ -78,18 +103,124 @@ inline void handleAggregationSourcesGet(
     json["@odata.type"] =
         "#AggregationSourceCollection.AggregationSourceCollection";
     json["Name"] = "Aggregation Source Collection";
-    json["Members"] = nlohmann::json::array();
-    json["Members@odata.count"] = 0;
 
-    // TODO: Query D-Bus for satellite configs and add them to the Members array
+    // Query D-Bus for satellite configs and add them to the Members array
+    RedfishAggregator::getSatelliteConfigs(
+        std::bind_front(populateAggregationSourceCollection, asyncResp));
 }
 
-inline void requestAggregationSourcesRoutes(App& app)
+inline void handleAggregationSourceCollectionHead(
+    App& app, const crow::Request& req,
+    const std::shared_ptr<bmcweb::AsyncResp>& asyncResp)
+{
+    if (!redfish::setUpRedfishRoute(app, req, asyncResp))
+    {
+        return;
+    }
+    asyncResp->res.addHeader(
+        boost::beast::http::field::link,
+        "</redfish/v1/JsonSchemas/AggregationService/AggregationSourceCollection.json>; rel=describedby");
+}
+
+inline void requestRoutesAggregationSourceCollection(App& app)
 {
     BMCWEB_ROUTE(app, "/redfish/v1/AggregationService/AggregationSources/")
-        .privileges(redfish::privileges::getAggregationService)
+        .privileges(redfish::privileges::getAggregationSourceCollection)
+        .methods(boost::beast::http::verb::get)(std::bind_front(
+            handleAggregationSourceCollectionGet, std::ref(app)));
+
+    BMCWEB_ROUTE(app, "/redfish/v1/AggregationService/AggregationSources/")
+        .privileges(redfish::privileges::getAggregationSourceCollection)
+        .methods(boost::beast::http::verb::head)(std::bind_front(
+            handleAggregationSourceCollectionHead, std::ref(app)));
+}
+
+inline void populateAggregationSource(
+    const std::string& aggregationSourceId,
+    const std::shared_ptr<bmcweb::AsyncResp>& asyncResp,
+    const boost::system::error_code ec,
+    const std::unordered_map<std::string, boost::urls::url>& satelliteInfo)
+{
+    asyncResp->res.addHeader(
+        boost::beast::http::field::link,
+        "</redfish/v1/JsonSchemas/AggregationSource/AggregationSource.json>; rel=describedby");
+
+    // Something went wrong while querying dbus
+    if (ec)
+    {
+        messages::internalError(asyncResp->res);
+        return;
+    }
+
+    const auto& sat = satelliteInfo.find(aggregationSourceId);
+    if (sat == satelliteInfo.end())
+    {
+        messages::resourceNotFound(asyncResp->res, "AggregationSource",
+                                   aggregationSourceId);
+        return;
+    }
+
+    asyncResp->res.jsonValue["@odata.id"] =
+        crow::utility::urlFromPieces("redfish", "v1", "AggregationService",
+                                     "AggregationSources", aggregationSourceId);
+    asyncResp->res.jsonValue["@odata.type"] =
+        "#AggregationSource.v1_3_1.AggregationSource";
+    asyncResp->res.jsonValue["Id"] = aggregationSourceId;
+
+    // TODO: We may want to change this whenever we support aggregating multiple
+    // satellite BMCs.  Otherwise all AggregationSource resources will have the
+    // same "Name".
+    // TODO: We should use the "Name" from the satellite config whenever we add
+    // support for including it in the data returned in satelliteInfo.
+    asyncResp->res.jsonValue["Name"] = "Aggregation source";
+    std::string hostName(sat->second.encoded_origin());
+    asyncResp->res.jsonValue["HostName"] = std::move(hostName);
+
+    // The Redfish spec requires Password to be null in responses
+    asyncResp->res.jsonValue["Password"] = nullptr;
+}
+
+inline void handleAggregationSourceGet(
+    App& app, const crow::Request& req,
+    const std::shared_ptr<bmcweb::AsyncResp>& asyncResp,
+    const std::string& aggregationSourceId)
+{
+    if (!redfish::setUpRedfishRoute(app, req, asyncResp))
+    {
+        return;
+    }
+
+    // Query D-Bus for satellite config corresponding to the specified
+    // AggregationSource
+    RedfishAggregator::getSatelliteConfigs(std::bind_front(
+        populateAggregationSource, aggregationSourceId, asyncResp));
+}
+
+inline void handleAggregationSourceHead(
+    App& app, const crow::Request& req,
+    const std::shared_ptr<bmcweb::AsyncResp>& asyncResp,
+    const std::string& aggregationSourceId)
+{
+    if (!redfish::setUpRedfishRoute(app, req, asyncResp))
+    {
+        return;
+    }
+    asyncResp->res.addHeader(
+        boost::beast::http::field::link,
+        "</redfish/v1/JsonSchemas/AggregationService/AggregationSource.json>; rel=describedby");
+
+    // Needed to prevent unused variable error
+    BMCWEB_LOG_DEBUG << "Added link header to response from "
+                     << aggregationSourceId;
+}
+
+inline void requestRoutesAggregationSource(App& app)
+{
+    BMCWEB_ROUTE(app,
+                 "/redfish/v1/AggregationService/AggregationSources/<str>/")
+        .privileges(redfish::privileges::getAggregationSource)
         .methods(boost::beast::http::verb::get)(
-            std::bind_front(handleAggregationSourcesGet, std::ref(app)));
+            std::bind_front(handleAggregationSourceGet, std::ref(app)));
 }
 
 } // namespace redfish

--- a/redfish-core/lib/log_services.hpp
+++ b/redfish-core/lib/log_services.hpp
@@ -1184,12 +1184,15 @@ inline void createDump(const std::shared_ptr<bmcweb::AsyncResp>& asyncResp,
     std::vector<std::pair<std::string, std::variant<std::string, uint64_t>>>
         createDumpParamVec(createDumpParams);
 
-    createDumpParamVec.emplace_back(
-        "xyz.openbmc_project.Dump.Create.CreateParameters.OriginatorId",
-        req.session->clientIp);
-    createDumpParamVec.emplace_back(
-        "xyz.openbmc_project.Dump.Create.CreateParameters.OriginatorType",
-        "xyz.openbmc_project.Common.OriginatedBy.OriginatorTypes.Client");
+    if (req.session != nullptr)
+    {
+        createDumpParamVec.emplace_back(
+            "xyz.openbmc_project.Dump.Create.CreateParameters.OriginatorId",
+            req.session->clientIp);
+        createDumpParamVec.emplace_back(
+            "xyz.openbmc_project.Dump.Create.CreateParameters.OriginatorType",
+            "xyz.openbmc_project.Common.OriginatedBy.OriginatorTypes.Client");
+    }
 
     crow::connections::systemBus->async_method_call(
         [asyncResp, payload(task::Payload(req)), dumpPath](

--- a/subprojects/boost.wrap
+++ b/subprojects/boost.wrap
@@ -2,7 +2,7 @@
 directory = boost_1_81_0
 
 source_url = https://boostorg.jfrog.io/artifactory/main/release/1.81.0/source/boost_1_81_0.tar.bz2
-source_hash = 941c568e7ac79aa448ac28c98a5ec391fd1317170953c487bcf977c6ee6061ce
+source_hash = 71feeed900fbccca04a3b4f2f84a7c217186f28a940ed8b7ed4725986baf99fa
 source_filename = 1_81_0.tar.bz2
 
 patch_directory = boost

--- a/test/redfish-core/include/redfish_aggregator_test.cpp
+++ b/test/redfish-core/include/redfish_aggregator_test.cpp
@@ -205,6 +205,39 @@ TEST(addPrefixes, ParseJsonObjectNestedArray)
               "/redfish/v1/Chassis/5B42_TestChassis");
 }
 
+TEST(addPrefixes, FixHttpHeadersInResponseBody)
+{
+    nlohmann::json taskResp = nlohmann::json::parse(R"(
+    {
+      "@odata.id": "/redfish/v1/TaskService/Tasks/0",
+      "Name": "Task 0",
+      "Payload": {
+        "HttpHeaders": [
+          "User-Agent: curl/7.87.0",
+          "Accept: */*",
+          "Host: 127.127.12.7",
+          "Content-Length: 33",
+          "Location: /redfish/v1/Managers/bmc/LogServices/Dump/Entries/0"
+        ]
+      },
+      "PercentComplete": 100,
+      "TaskMonitor": "/redfish/v1/TaskService/Tasks/0/Monitor",
+      "TaskState": "Completed",
+      "TaskStatus": "OK"
+    }
+    )",
+                                                    nullptr, false);
+
+    addPrefixes(taskResp, "5B247A");
+    EXPECT_EQ(taskResp["@odata.id"], "/redfish/v1/TaskService/Tasks/5B247A_0");
+    EXPECT_EQ(taskResp["TaskMonitor"],
+              "/redfish/v1/TaskService/Tasks/5B247A_0/Monitor");
+    nlohmann::json& httpHeaders = taskResp["Payload"]["HttpHeaders"];
+    EXPECT_EQ(
+        httpHeaders[4],
+        "Location: /redfish/v1/Managers/5B247A_bmc/LogServices/Dump/Entries/0");
+}
+
 // Attempts to perform prefix fixing on a response with response code "result".
 // Fixing should always occur
 void assertProcessResponse(unsigned result)

--- a/test/redfish-core/include/utils/query_param_test.cpp
+++ b/test/redfish-core/include/utils/query_param_test.cpp
@@ -652,57 +652,203 @@ TEST(QueryParams, FindNavigationReferencesNonLink)
 {
     using nlohmann::json;
 
-    json singleTreeNode = R"({"Foo" : {"@odata.id": "/foobar"}})"_json;
+    // Responses must include their "@odata.id" property for $expand to work
+    // correctly
+    json singleTreeNode =
+        R"({"@odata.id": "/redfish/v1",
+        "Foo" : {"@odata.id": "/foobar"}})"_json;
 
     // Parsing as the root should net one entry
-    EXPECT_THAT(findNavigationReferences(ExpandType::Both, singleTreeNode),
+    EXPECT_THAT(findNavigationReferences(ExpandType::Both, 1, singleTreeNode),
                 UnorderedElementsAre(
                     ExpandNode{json::json_pointer("/Foo"), "/foobar"}));
 
     // Parsing in Non-hyperlinks mode should net one entry
-    EXPECT_THAT(findNavigationReferences(ExpandType::NotLinks, singleTreeNode),
-                UnorderedElementsAre(
-                    ExpandNode{json::json_pointer("/Foo"), "/foobar"}));
+    EXPECT_THAT(
+        findNavigationReferences(ExpandType::NotLinks, 1, singleTreeNode),
+        UnorderedElementsAre(
+            ExpandNode{json::json_pointer("/Foo"), "/foobar"}));
 
     // Searching for not types should return empty set
     EXPECT_TRUE(
-        findNavigationReferences(ExpandType::None, singleTreeNode).empty());
+        findNavigationReferences(ExpandType::None, 1, singleTreeNode).empty());
 
     // Searching for hyperlinks only should return empty set
     EXPECT_TRUE(
-        findNavigationReferences(ExpandType::Links, singleTreeNode).empty());
+        findNavigationReferences(ExpandType::Links, 1, singleTreeNode).empty());
 
+    // Responses must include their "@odata.id" property for $expand to work
+    // correctly
     json multiTreeNodes =
-        R"({"Links": {"@odata.id": "/links"}, "Foo" : {"@odata.id": "/foobar"}})"_json;
+        R"({"@odata.id": "/redfish/v1",
+        "Links": {"@odata.id": "/links"},
+        "Foo" : {"@odata.id": "/foobar"}})"_json;
+
     // Should still find Foo
-    EXPECT_THAT(findNavigationReferences(ExpandType::NotLinks, multiTreeNodes),
-                UnorderedElementsAre(
-                    ExpandNode{json::json_pointer("/Foo"), "/foobar"}));
+    EXPECT_THAT(
+        findNavigationReferences(ExpandType::NotLinks, 1, multiTreeNodes),
+        UnorderedElementsAre(
+            ExpandNode{json::json_pointer("/Foo"), "/foobar"}));
 }
 
 TEST(QueryParams, FindNavigationReferencesLink)
 {
     using nlohmann::json;
 
+    // Responses must include their "@odata.id" property for $expand to work
+    // correctly
     json singleLinkNode =
-        R"({"Links" : {"Sessions": {"@odata.id": "/foobar"}}})"_json;
+        R"({"@odata.id": "/redfish/v1",
+        "Links" : {"Sessions": {"@odata.id": "/foobar"}}})"_json;
 
     // Parsing as the root should net one entry
-    EXPECT_THAT(findNavigationReferences(ExpandType::Both, singleLinkNode),
+    EXPECT_THAT(findNavigationReferences(ExpandType::Both, 1, singleLinkNode),
                 UnorderedElementsAre(ExpandNode{
                     json::json_pointer("/Links/Sessions"), "/foobar"}));
     // Parsing in hyperlinks mode should net one entry
-    EXPECT_THAT(findNavigationReferences(ExpandType::Links, singleLinkNode),
+    EXPECT_THAT(findNavigationReferences(ExpandType::Links, 1, singleLinkNode),
                 UnorderedElementsAre(ExpandNode{
                     json::json_pointer("/Links/Sessions"), "/foobar"}));
 
     // Searching for not types should return empty set
     EXPECT_TRUE(
-        findNavigationReferences(ExpandType::None, singleLinkNode).empty());
+        findNavigationReferences(ExpandType::None, 1, singleLinkNode).empty());
 
     // Searching for non-hyperlinks only should return empty set
     EXPECT_TRUE(
-        findNavigationReferences(ExpandType::NotLinks, singleLinkNode).empty());
+        findNavigationReferences(ExpandType::NotLinks, 1, singleLinkNode)
+            .empty());
+}
+
+TEST(QueryParams, PreviouslyExpanded)
+{
+    using nlohmann::json;
+
+    // Responses must include their "@odata.id" property for $expand to work
+    // correctly
+    json expNode = json::parse(R"(
+{
+  "@odata.id": "/redfish/v1/Chassis",
+  "@odata.type": "#ChassisCollection.ChassisCollection",
+  "Members": [
+    {
+      "@odata.id": "/redfish/v1/Chassis/5B247A_Sat1",
+      "@odata.type": "#Chassis.v1_17_0.Chassis",
+      "Sensors": {
+        "@odata.id": "/redfish/v1/Chassis/5B247A_Sat1/Sensors"
+      }
+    },
+    {
+      "@odata.id": "/redfish/v1/Chassis/5B247A_Sat2",
+      "@odata.type": "#Chassis.v1_17_0.Chassis",
+      "Sensors": {
+        "@odata.id": "/redfish/v1/Chassis/5B247A_Sat2/Sensors"
+      }
+    }
+  ],
+  "Members@odata.count": 2,
+  "Name": "Chassis Collection"
+}
+)",
+                               nullptr, false);
+
+    // Expand has already occurred so we should not do anything
+    EXPECT_TRUE(
+        findNavigationReferences(ExpandType::NotLinks, 1, expNode).empty());
+
+    // Previous expand was only a single level so we should further expand
+    EXPECT_THAT(findNavigationReferences(ExpandType::NotLinks, 2, expNode),
+                UnorderedElementsAre(
+                    ExpandNode{json::json_pointer("/Members/0/Sensors"),
+                               "/redfish/v1/Chassis/5B247A_Sat1/Sensors"},
+                    ExpandNode{json::json_pointer("/Members/1/Sensors"),
+                               "/redfish/v1/Chassis/5B247A_Sat2/Sensors"}));
+
+    // Make sure we can handle when an array was expanded further down the tree
+    json expNode2 = R"({"@odata.id" : "/redfish/v1"})"_json;
+    expNode2["Chassis"] = std::move(expNode);
+    EXPECT_TRUE(
+        findNavigationReferences(ExpandType::NotLinks, 1, expNode2).empty());
+    EXPECT_TRUE(
+        findNavigationReferences(ExpandType::NotLinks, 2, expNode2).empty());
+
+    // Previous expand was two levels so we should further expand
+    EXPECT_THAT(findNavigationReferences(ExpandType::NotLinks, 3, expNode2),
+                UnorderedElementsAre(
+                    ExpandNode{json::json_pointer("/Chassis/Members/0/Sensors"),
+                               "/redfish/v1/Chassis/5B247A_Sat1/Sensors"},
+                    ExpandNode{json::json_pointer("/Chassis/Members/1/Sensors"),
+                               "/redfish/v1/Chassis/5B247A_Sat2/Sensors"}));
+}
+
+TEST(QueryParams, PartiallyPreviouslyExpanded)
+{
+    using nlohmann::json;
+
+    // Responses must include their "@odata.id" property for $expand to work
+    // correctly
+    json expNode = json::parse(R"(
+{
+  "@odata.id": "/redfish/v1/Chassis",
+  "@odata.type": "#ChassisCollection.ChassisCollection",
+  "Members": [
+    {
+      "@odata.id": "/redfish/v1/Chassis/Local"
+    },
+    {
+      "@odata.id": "/redfish/v1/Chassis/5B247A_Sat1",
+      "@odata.type": "#Chassis.v1_17_0.Chassis",
+      "Sensors": {
+        "@odata.id": "/redfish/v1/Chassis/5B247A_Sat1/Sensors"
+      }
+    }
+  ],
+  "Members@odata.count": 2,
+  "Name": "Chassis Collection"
+}
+)",
+                               nullptr, false);
+
+    // The 5B247A_Sat1 Chassis was already expanded a single level so we should
+    // only want to expand the Local Chassis
+    EXPECT_THAT(
+        findNavigationReferences(ExpandType::NotLinks, 1, expNode),
+        UnorderedElementsAre(ExpandNode{json::json_pointer("/Members/0"),
+                                        "/redfish/v1/Chassis/Local"}));
+
+    // The 5B247A_Sat1 Chassis was already expanded a single level so we should
+    // further expand it as well as the Local Chassis
+    EXPECT_THAT(findNavigationReferences(ExpandType::NotLinks, 2, expNode),
+                UnorderedElementsAre(
+                    ExpandNode{json::json_pointer("/Members/0"),
+                               "/redfish/v1/Chassis/Local"},
+                    ExpandNode{json::json_pointer("/Members/1/Sensors"),
+                               "/redfish/v1/Chassis/5B247A_Sat1/Sensors"}));
+
+    // Now the response has paths that have been expanded 0, 1, and 2 times
+    json expNode2 = R"({"@odata.id" : "/redfish/v1",
+                        "Systems": {"@odata.id": "/redfish/v1/Systems"}})"_json;
+    expNode2["Chassis"] = std::move(expNode);
+
+    EXPECT_THAT(findNavigationReferences(ExpandType::NotLinks, 1, expNode2),
+                UnorderedElementsAre(ExpandNode{json::json_pointer("/Systems"),
+                                                "/redfish/v1/Systems"}));
+
+    EXPECT_THAT(
+        findNavigationReferences(ExpandType::NotLinks, 2, expNode2),
+        UnorderedElementsAre(
+            ExpandNode{json::json_pointer("/Systems"), "/redfish/v1/Systems"},
+            ExpandNode{json::json_pointer("/Chassis/Members/0"),
+                       "/redfish/v1/Chassis/Local"}));
+
+    EXPECT_THAT(
+        findNavigationReferences(ExpandType::NotLinks, 3, expNode2),
+        UnorderedElementsAre(
+            ExpandNode{json::json_pointer("/Systems"), "/redfish/v1/Systems"},
+            ExpandNode{json::json_pointer("/Chassis/Members/0"),
+                       "/redfish/v1/Chassis/Local"},
+            ExpandNode{json::json_pointer("/Chassis/Members/1/Sensors"),
+                       "/redfish/v1/Chassis/5B247A_Sat1/Sensors"}));
 }
 
 } // namespace


### PR DESCRIPTION
Confirmed that with these patches we can get /redfish/v1/AggregationService function working:

```
curl -k -H "X-Auth-Token: $token" -X GET https://${bmc}/redfish/v1/AggregationService
{
  "@odata.id": "/redfish/v1/AggregationService",
  "@odata.type": "#AggregationService.v1_0_1.AggregationService",
  "AggregationSources": {
    "@odata.id": "/redfish/v1/AggregationService/AggregationSources"
  },
  "Description": "Aggregation Service",
  "Id": "AggregationService",
  "Name": "Aggregation Service",
  "ServiceEnabled": true
}

curl -k -H "X-Auth-Token: $token" -X GET https://${bmc}/redfish/v1/AggregationService/AggregationSources
{
  "@odata.id": "/redfish/v1/AggregationService/AggregationSources",
  "@odata.type": "#AggregationSourceCollection.AggregationSourceCollection",
  "Members": [
    {
      "@odata.id": "/redfish/v1/AggregationService/AggregationSources/5B247A"
    }
  ],
  "Members@odata.count": 1,
  "Name": "Aggregation Source Collection"
}

curl -k -H "X-Auth-Token: $token" -X GET https://${bmc}/redfish/v1/AggregationService/AggregationSources/5B247A
{
  "@odata.id": "/redfish/v1/AggregationService/AggregationSources/5B247A",
  "@odata.type": "#AggregationSource.v1_3_1.AggregationSource",
  "HostName": "http://X.X.XX.XX:2280",
  "Id": "5B247A",
  "Name": "Aggregation source",
  "Password": null
}

```

These are all pulled directly from merged upstream patches.