### PR TITLE
Bmcweb: Add PcieSlots Location Code

### DIFF
--- a/redfish-core/lib/pcie_slots.hpp
+++ b/redfish-core/lib/pcie_slots.hpp
@@ -346,10 +346,37 @@ void checkPCIeSlotsCount(
         });
 }
 
+inline void getLocationCode(const std::shared_ptr<bmcweb::AsyncResp>& asyncResp,
+                            const size_t index,
+                            const std::string& connectionName,
+                            const std::string& pcieSlotPath)
+{
+    sdbusplus::asio::getProperty<std::string>(
+        *crow::connections::systemBus, connectionName, pcieSlotPath,
+        "xyz.openbmc_project.Inventory.Decorator.LocationCode", "LocationCode",
+        [asyncResp, index](const boost::system::error_code& ec1,
+                           const std::string& property) {
+        if (ec1)
+        {
+            BMCWEB_LOG_ERROR << "Can't get location code property for PCIeSlot";
+            messages::internalError(asyncResp->res);
+            return;
+        }
+        if (property.empty())
+        {
+            BMCWEB_LOG_WARNING << "PcieSlot location code value is empty ";
+            return;
+        }
+        asyncResp->res.jsonValue["Slots"][index]["Location"]["PartLocation"]
+                                ["ServiceLabel"] = property;
+        });
+}
+
 inline void
     onPcieSlotGetAllDone(const std::shared_ptr<bmcweb::AsyncResp>& asyncResp,
                          const boost::system::error_code ec,
                          const dbus::utility::DBusPropertiesMap& propertiesList,
+                         const std::string& connectionName,
                          const std::string& pcieSlotPath)
 {
     if (ec)
@@ -440,6 +467,9 @@ inline void
     size_t index = slots.size();
     slots.emplace_back(std::move(slot));
 
+    // Get and set the location code
+    getLocationCode(asyncResp, index, connectionName, pcieSlotPath);
+
     // Get pcie device link
     addLinkedPcieDevices(asyncResp, pcieSlotPath, index);
 
@@ -499,10 +529,11 @@ inline void onMapperAssociationDone(
     sdbusplus::asio::getAllProperties(
         *crow::connections::systemBus, connectionName, pcieSlotPath,
         "xyz.openbmc_project.Inventory.Item.PCIeSlot",
-        [asyncResp,
+        [asyncResp, connectionName,
          pcieSlotPath](const boost::system::error_code& ec1,
                        const dbus::utility::DBusPropertiesMap& propertiesList) {
-        onPcieSlotGetAllDone(asyncResp, ec1, propertiesList, pcieSlotPath);
+        onPcieSlotGetAllDone(asyncResp, ec1, propertiesList, connectionName,
+                             pcieSlotPath);
         });
 }
 


### PR DESCRIPTION
Bmcweb: Add PcieSlots Location Code
    
    This commit fixes this STG Defect 478749.
    This commit adds location code for pcieSlots.
    Upstream commit- https://gerrit.openbmc.org/c/openbmc/bmcweb/+/62219
    
    Tested:
    -Ran Redfish service validator,
     No new error and can see the Location code for pcieSlots
    
    -Verified on Rainier100 system, Location code shows up for PCIeSlots.
    
    curl -k -H "X-Auth-Token: $bmc_token" -X GET https://${bmc}/redfish/v1/Chassis/chassis/PCIeSlots
    {
      "@odata.id": "/redfish/v1/Chassis/chassis/PCIeSlots",
      "@odata.type": "#PCIeSlots.v1_5_0.PCIeSlots",
      "Id": "1",
      "Name": "PCIe Slot Information",
      "Slots": [
        {
          "HotPluggable": false,
          "Lanes": 0,
          "Links": {
            "Oem": {
              "IBM": {
                "AssociatedAssembly": [
                  {
                    "@odata.id": "/redfish/v1/Chassis/chassis/Assembly#/Assemblies/19"
                  }
                ]
              }
            },
            "PCIeDevice": [
              {
                "@odata.id": "/redfish/v1/Systems/system/PCIeDevices/motherboard_disk_backplane0_nvme2_dp0_drive2"
              }
            ]
          },
          "Location": {
            "PartLocation": {
              "ServiceLabel": "U78DA.ND0.       -P1-C2"
            }
          },
          "LocationIndicatorActive": false,
          "Oem": {
            "@odata.type": "#OemPCIeSlots.Oem",
            "IBM": {
              "@odata.type": "#OemPCIeSlots.IBM",
              "LinkId": 0
            }
          },
          "SlotType": "U2"
        },
    
    Change-Id: I2bef85d9dbd95d5f0b923f5453c8cc72381ce546
    Signed-off-by: Alpana Kumari <alpankum@in.ibm.com>
