### PR TITLE
Audit Log: Add PUT events to audit log for HMC config file management

### DIFF
--- a/http/http_connection.hpp
+++ b/http/http_connection.hpp
@@ -442,6 +442,7 @@ class Connection :
         if (((req->method() == boost::beast::http::verb::post) &&
              audit::checkPostAudit(*req)) ||
             (req->method() == boost::beast::http::verb::patch) ||
+            (req->method() == boost::beast::http::verb::put) ||
             (req->method() == boost::beast::http::verb::delete_))
         {
 
@@ -457,10 +458,13 @@ class Connection :
 
                 std::string additionalInfo = "";
                 // Exclude the body of account PATCH/POST
-                if ((req->method() == boost::beast::http::verb::patch ||
-                     req->method() == boost::beast::http::verb::post) &&
-                    !req->target().starts_with(
-                        "/redfish/v1/AccountService/Accounts"))
+                // Exclude the body of ConfigFiles PUT
+                if (((req->method() == boost::beast::http::verb::patch ||
+                      req->method() == boost::beast::http::verb::post) &&
+                     !req->target().starts_with(
+                         "/redfish/v1/AccountService/Accounts")) ||
+                    (req->method() == boost::beast::http::verb::put &&
+                     !req->target().starts_with("/ibm/v1/Host/ConfigFiles")))
                 {
                     additionalInfo = req->body + " ";
                 }

--- a/http/http_connection.hpp
+++ b/http/http_connection.hpp
@@ -458,13 +458,14 @@ class Connection :
 
                 std::string additionalInfo = "";
                 // Exclude the body of account PATCH/POST
-                // Exclude the body of ConfigFiles PUT
+                // Exclude the body of /ibm/v1 PUT/POST
                 if (((req->method() == boost::beast::http::verb::patch ||
                       req->method() == boost::beast::http::verb::post) &&
-                     !req->target().starts_with(
-                         "/redfish/v1/AccountService/Accounts")) ||
+                     (!req->target().starts_with(
+                          "/redfish/v1/AccountService/Accounts") &&
+                      !req->target().starts_with("/ibm/v1"))) ||
                     (req->method() == boost::beast::http::verb::put &&
-                     !req->target().starts_with("/ibm/v1/Host/ConfigFiles")))
+                     !req->target().starts_with("/ibm/v1")))
                 {
                     additionalInfo = req->body + " ";
                 }


### PR DESCRIPTION
Added PUT event for HMC config file management to events tracked in the audit log. Body is not included since it contains the config file data itself. Excluding body data for all IBM management console events as the data can be binary and larger than the audit log buffer size.

Tested these URI:
{PUT|DELETE} /ibm/v1/Host/ConfigFiles
POST /ibm/v1/Host/ConfigFiles/Actions/IBMConfigFiles.DeleteAll
Tested these additional URI:
POST /ibm/v1/HMC/BroadcastService
POST /ibm/v1/HMC/LockService/Actions/LockService.AcquireLock
Confirmed non IBM management console events still getting body data in audit log entry.