### PR TITLE
Fix dump offload issue

### DIFF
--- a/http/http_connection.hpp
+++ b/http/http_connection.hpp
@@ -390,6 +390,19 @@ class Connection :
             asyncResp->res.setCompleteRequestHandler(nullptr);
             return;
         }
+
+        std::string url(req->target());
+        if (boost::contains(url, "/Dump/Entries/") &&
+            boost::ends_with(url, "/attachment"))
+        {
+            BMCWEB_LOG_DEBUG << "upgrade stream connection";
+            handler->handleUpgrade(*req, res, std::move(adaptor));
+            // delete lambda with self shared_ptr
+            // to enable connection destruction
+            res.completeRequestHandler = nullptr;
+            return;
+        }
+
         std::string_view expected =
             req->getHeaderValue(boost::beast::http::field::if_none_match);
         if (!expected.empty())

--- a/http/http_response.hpp
+++ b/http/http_response.hpp
@@ -2,6 +2,9 @@
 #include "logging.hpp"
 #include "nlohmann/json.hpp"
 
+#include <boost/asio/buffer.hpp>
+#include <boost/beast/core/flat_static_buffer.hpp>
+#include <boost/beast/http/basic_dynamic_body.hpp>
 #include <boost/beast/http/message.hpp>
 #include <boost/beast/http/string_body.hpp>
 #include <utils/hex_utils.hpp>
@@ -263,4 +266,117 @@ struct Response
     std::function<void(Response&)> completeRequestHandler;
     std::function<bool()> isAliveHelper;
 };
+
+struct DynamicResponse
+{
+    using response_type = boost::beast::http::response<
+        boost::beast::http::basic_dynamic_body<boost::beast::flat_static_buffer<
+            static_cast<std::size_t>(1024 * 1024)>>>;
+
+    std::optional<response_type> bufferResponse;
+
+    void addHeader(const std::string_view key, const std::string_view value)
+    {
+        bufferResponse->set(key, value);
+    }
+
+    void addHeader(boost::beast::http::field key, std::string_view value)
+    {
+        bufferResponse->set(key, value);
+    }
+
+    DynamicResponse() : bufferResponse(response_type{})
+    {}
+
+    ~DynamicResponse() = default;
+
+    DynamicResponse(const DynamicResponse&) = delete;
+
+    DynamicResponse(DynamicResponse&&) = delete;
+
+    DynamicResponse& operator=(const DynamicResponse& r) = delete;
+
+    DynamicResponse& operator=(DynamicResponse&& r) noexcept
+    {
+        BMCWEB_LOG_DEBUG << "Moving response containers";
+        bufferResponse = std::move(r.bufferResponse);
+        r.bufferResponse.emplace(response_type{});
+        completed = r.completed;
+        return *this;
+    }
+
+    void result(boost::beast::http::status v)
+    {
+        bufferResponse->result(v);
+    }
+
+    boost::beast::http::status result()
+    {
+        return bufferResponse->result();
+    }
+
+    unsigned resultInt()
+    {
+        return bufferResponse->result_int();
+    }
+
+    std::string_view reason()
+    {
+        return bufferResponse->reason();
+    }
+
+    bool isCompleted() const noexcept
+    {
+        return completed;
+    }
+
+    void keepAlive(bool k)
+    {
+        bufferResponse->keep_alive(k);
+    }
+
+    bool keepAlive()
+    {
+        return bufferResponse->keep_alive();
+    }
+
+    void preparePayload()
+    {
+        bufferResponse->prepare_payload();
+    }
+
+    void clear()
+    {
+        BMCWEB_LOG_DEBUG << this << " Clearing response containers";
+        bufferResponse.emplace(response_type{});
+        completed = false;
+    }
+
+    void end()
+    {
+        if (completed)
+        {
+            BMCWEB_LOG_DEBUG << "Dynamic response was ended twice";
+            return;
+        }
+        completed = true;
+        BMCWEB_LOG_DEBUG << "calling completion handler";
+        if (completeRequestHandler)
+        {
+            BMCWEB_LOG_DEBUG << "completion handler was valid";
+            completeRequestHandler();
+        }
+    }
+
+    bool isAlive()
+    {
+        return isAliveHelper && isAliveHelper();
+    }
+    std::function<void()> completeRequestHandler;
+
+  private:
+    bool completed{};
+    std::function<bool()> isAliveHelper;
+};
+
 } // namespace crow

--- a/http/routing.hpp
+++ b/http/routing.hpp
@@ -5,6 +5,7 @@
 #include "error_messages.hpp"
 #include "http_request.hpp"
 #include "http_response.hpp"
+#include "http_stream.hpp"
 #include "logging.hpp"
 #include "privileges.hpp"
 #include "sessions.hpp"
@@ -410,6 +411,96 @@ class WebSocketRule : public BaseRule
     std::function<void(crow::websocket::Connection&)> errorHandler;
 };
 
+class StreamingResponseRule : public BaseRule
+{
+    using self_t = StreamingResponseRule;
+
+  public:
+    explicit StreamingResponseRule(const std::string& ruleIn) : BaseRule(ruleIn)
+    {}
+
+    void validate() override
+    {}
+
+    void handle(const Request& /*req*/,
+                const std::shared_ptr<bmcweb::AsyncResp>& asyncResp,
+                const RoutingParams& /*routinParams*/) override
+    {
+        asyncResp->res.result(boost::beast::http::status::not_found);
+    }
+
+    void handleUpgrade(const Request& req, Response& /*res*/,
+                       boost::asio::ip::tcp::socket&& adaptor) override
+    {
+        std::shared_ptr<crow::streaming_response::ConnectionImpl<
+            boost::asio::ip::tcp::socket>>
+            myConnection =
+                std::make_shared<crow::streaming_response::ConnectionImpl<
+                    boost::asio::ip::tcp::socket>>(req, std::move(adaptor),
+                                                   openHandler, messageHandler,
+                                                   closeHandler, errorHandler);
+
+        myConnection->start();
+        myConnection.reset();
+        myConnection = nullptr;
+    }
+
+#ifdef BMCWEB_ENABLE_SSL
+    void handleUpgrade(const Request& req, Response& /*res*/,
+                       boost::beast::ssl_stream<boost::asio::ip::tcp::socket>&&
+                           adaptor) override
+    {
+        std::shared_ptr<crow::streaming_response::ConnectionImpl<
+            boost::beast::ssl_stream<boost::asio::ip::tcp::socket>>>
+            myConnection =
+                std::make_shared<crow::streaming_response::ConnectionImpl<
+                    boost::beast::ssl_stream<boost::asio::ip::tcp::socket>>>(
+                    req, std::move(adaptor), openHandler, messageHandler,
+                    closeHandler, errorHandler);
+        myConnection->start();
+        myConnection.reset();
+        myConnection = nullptr;
+    }
+#endif
+
+    template <typename Func>
+    self_t& onopen(Func f)
+    {
+        openHandler = f;
+        return *this;
+    }
+
+    template <typename Func>
+    self_t& onmessage(Func f)
+    {
+        messageHandler = f;
+        return *this;
+    }
+
+    template <typename Func>
+    self_t& onclose(Func f)
+    {
+        closeHandler = f;
+        return *this;
+    }
+
+    template <typename Func>
+    self_t& onerror(Func f)
+    {
+        errorHandler = f;
+        return *this;
+    }
+
+  protected:
+    std::function<void(crow::streaming_response::Connection&)> openHandler;
+    std::function<void(crow::streaming_response::Connection&,
+                       const std::string&, bool)>
+        messageHandler;
+    std::function<void(crow::streaming_response::Connection&, bool&)>
+        closeHandler;
+    std::function<void(crow::streaming_response::Connection&)> errorHandler;
+};
+
 template <typename T>
 struct RuleParameterTraits
 {
@@ -418,6 +509,15 @@ struct RuleParameterTraits
     {
         self_t* self = static_cast<self_t*>(this);
         WebSocketRule* p = new WebSocketRule(self->rule);
+        self->ruleToUpgrade.reset(p);
+        return *p;
+    }
+
+    StreamingResponseRule& streamingResponse()
+    {
+        BMCWEB_LOG_DEBUG << "Invoking stream response rule";
+        self_t* self = static_cast<self_t*>(this);
+        StreamingResponseRule* p = new StreamingResponseRule(self->rule);
         self->ruleToUpgrade.reset(p);
         return *p;
     }

--- a/redfish-core/include/redfish.hpp
+++ b/redfish-core/include/redfish.hpp
@@ -21,6 +21,7 @@
 #include "cable.hpp"
 #include "certificate_service.hpp"
 #include "chassis.hpp"
+#include "dump_offload.hpp"
 #include "environment_metrics.hpp"
 #include "ethernet.hpp"
 #include "event_service.hpp"
@@ -259,6 +260,7 @@ class RedfishService
         requestRoutesSubmitTestEvent(app);
 
         hypervisor::requestRoutesHypervisorSystems(app);
+        crow::obmc_dump::requestRoutes(app);
 
         requestRoutesTelemetryService(app);
         requestRoutesMetricReportDefinitionCollection(app);


### PR DESCRIPTION
The dumps were not getting offloaded and this is because the route handlers for the same were not invoked on a GET request.

This issue is resolved by modifying the dump offload code as per the upstream http connection framework and allows clients to offload dumps using redfish URI.

This PR:
1. Enables dynamic response support
2. Defines new bmcweb rule to support dump streaming.
3. Adds routes for bmc and system dump offload.

The existing http connection is implemented based on http string buffer and now the http stream connection is implemented using http dynamic buffer body that enables dump data streaming over https. This dynamic buffer sends the data size that is to be received by the client in the http header, so that the client waits till data with the given size is received before the http connection is closed. Added DynamicResponse struct to deal with dynamic buffer body response type.

Tested By:
[1] GET https://${bmc}/redfish/v1/Managers/bmc/LogServices/Dump/Entries/< dumpId >/attachment  >  < filename >

Change-Id: I08fe2840f4f6e4d9b8f53a2f72f7eb7714c6aeb0