### PR TITLE
Fix websocket csrf checking

### DIFF
--- a/http/websocket.hpp
+++ b/http/websocket.hpp
@@ -110,8 +110,7 @@ class ConnectionImpl : public Connection
             if (session != nullptr)
             {
                 // use protocol for csrf checking
-                if (session->cookieAuth &&
-                    !crow::utility::constantTimeStringCompare(
+                if (!crow::utility::constantTimeStringCompare(
                         protocol, session->csrfToken))
                 {
                     BMCWEB_LOG_ERROR << "Websocket CSRF error";

--- a/include/sessions.hpp
+++ b/include/sessions.hpp
@@ -38,7 +38,6 @@ struct UserSession
     std::string clientIp;
     std::chrono::time_point<std::chrono::steady_clock> lastUpdated;
     PersistenceType persistence{PersistenceType::TIMEOUT};
-    bool cookieAuth = false;
     bool isConfigureSelfOnly = false;
 
     // There are two sources of truth for isConfigureSelfOnly:
@@ -256,7 +255,7 @@ class SessionStore
         auto session = std::make_shared<UserSession>(UserSession{
             uniqueId, sessionToken, std::string(username), csrfToken, clientId,
             redfish::ip_util::toString(clientIp),
-            std::chrono::steady_clock::now(), persistence, false,
+            std::chrono::steady_clock::now(), persistence,
             isConfigureSelfOnly});
         auto it = authTokens.emplace(sessionToken, session);
         // Only need to write to disk if session isn't about to be destroyed.


### PR DESCRIPTION
Defect is https://jazz07.rchland.ibm.com:13443/jazz/web/projects/CSSD#action=com.ibm.team.workitem.viewWorkItem&id=386332
Should go into 1020/1030/1040 but that is going to be a separate PR, Joseph and I can talk about who does that. 

https://github.com/openbmc/bmcweb/commit/f8aa3d2704d3897eb724dab9ac596af8b1f0e33e (4/15/20) added CSRF check into websockets but later setting cookieAuth to true was removed so this session->cookieAuth is always false. https://github.com/openbmc/bmcweb/commit/3909dc82a003893812f598434d6c4558107afa28 (7/15/20).

2 choices here add back this cookieAuth=true when cookie auth is used or remove this "if cookieAuth" and do this check anytime BMCWEB_INSECURE_DISABLE_CSRF_PREVENTION isn't enabled.

Really we shouldn't support any other auth on websockets so maybe if (!session->cookieAuth){
  unauthorized;
}
if go with the first choice. Went with the 2nd choice because cleaner.

This checking is a bit weird because it uses protocol for csrf checking. https://github.com/openbmc/webui-vue/blob/b63e9d9a70dabc4c9a7038f7727fca6bd17d940a/src/views/Operations/SerialOverLan/SerialOverLanConsole.vue#L98

Tested: Before could log in to webui-vue, delete the XSRF-TOKEN but still connect to the host console. After if deleted the XSRF-TOKEN (browser dev tools), the websocket does not connect. Don't have a system with KVM, VM enabled so wasn't able to check those but the webui-vue code for them looks to pass the token. The webui-vue host console works the same as before if you aren't messing with the XSRF-TOKEN.

Downstream testing: bmcweb console and GET wss://xxx.aus.stglabs.ibm.com/subscribe (used for the GUI header) work when the csrf token is there.

Change-Id: Ibd5910587648f68809c7fd518bcf5a0bcf8cf329

Upstream is https://gerrit.openbmc.org/c/openbmc/bmcweb/+/62135