### PR TITLE
Fix ResourceNotFound on manual guard of Dimm

### DIFF
--- a/redfish-core/lib/memory.hpp
+++ b/redfish-core/lib/memory.hpp
@@ -1008,7 +1008,10 @@ inline void
         return;
     }
 
-    setDimmData(asyncResp, dimmId, locationIndicatorActive);
+    if (locationIndicatorActive)
+    {
+        setDimmData(asyncResp, dimmId, locationIndicatorActive);
+    }
 
     if (enabled.has_value())
     {


### PR DESCRIPTION
Issue:
Even after successfully guarding the Dimm, we see
ResourceNotFound Extended Error info

Fix:
When we try to enable or disble a Dimm using redfish, it tries to set the DimmData for the locationIndicatorActive everytime. This is to be called only when locationIndicatorActive is provided similar to how it is done for 1030. So updated the code to match 1030.

Tested and works as expected.