### PR TITLE
1050: Fix redfish browser - html redfish logo display

### DIFF
--- a/http/app.hpp
+++ b/http/app.hpp
@@ -58,9 +58,11 @@ class App
     App& operator=(const App&&) = delete;
 
     template <typename Adaptor>
-    void handleUpgrade(const Request& req, Response& res, Adaptor&& adaptor)
+    void handleUpgrade(const Request& req,
+                       const std::shared_ptr<bmcweb::AsyncResp>& asyncResp,
+                       Adaptor&& adaptor)
     {
-        router.handleUpgrade(req, res, std::forward<Adaptor>(adaptor));
+        router.handleUpgrade(req, asyncResp, std::forward<Adaptor>(adaptor));
     }
 
     void handle(Request& req,

--- a/http/app.hpp
+++ b/http/app.hpp
@@ -58,7 +58,7 @@ class App
     App& operator=(const App&&) = delete;
 
     template <typename Adaptor>
-    void handleUpgrade(const Request& req,
+    void handleUpgrade(Request& req,
                        const std::shared_ptr<bmcweb::AsyncResp>& asyncResp,
                        Adaptor&& adaptor)
     {

--- a/http/http_connection.hpp
+++ b/http/http_connection.hpp
@@ -384,10 +384,21 @@ class Connection :
                 thisReq.getHeaderValue(boost::beast::http::field::upgrade),
                 "websocket"))
         {
-            handler->handleUpgrade(thisReq, res, std::move(adaptor));
-            // delete lambda with self shared_ptr
-            // to enable connection destruction
-            asyncResp->res.setCompleteRequestHandler(nullptr);
+            asyncResp->res.setCompleteRequestHandler(
+                [self(shared_from_this())](crow::Response& thisRes) {
+                if (thisRes.result() != boost::beast::http::status::ok)
+                {
+                    // When any error occurs before handle upgradation,
+                    // the result in response will be set to respective
+                    // error. By default the Result will be OK (200),
+                    // which implies successful handle upgrade. Response
+                    // needs to be sent over this connection only on
+                    // failure.
+                    self->completeRequest(thisRes);
+                    return;
+                }
+            });
+            handler->handleUpgrade(thisReq, asyncResp, std::move(adaptor));
             return;
         }
 
@@ -396,7 +407,7 @@ class Connection :
             boost::ends_with(url, "/attachment"))
         {
             BMCWEB_LOG_DEBUG << "upgrade stream connection";
-            handler->handleUpgrade(*req, res, std::move(adaptor));
+            handler->handleUpgrade(*req, asyncResp, std::move(adaptor));
             // delete lambda with self shared_ptr
             // to enable connection destruction
             res.completeRequestHandler = nullptr;

--- a/http/routing.hpp
+++ b/http/routing.hpp
@@ -10,12 +10,14 @@
 #include "privileges.hpp"
 #include "sessions.hpp"
 #include "utility.hpp"
+#include "utils/dbus_utils.hpp"
 #include "verb.hpp"
 #include "websocket.hpp"
 
 #include <async_resp.hpp>
 #include <boost/beast/ssl/ssl_stream.hpp>
 #include <boost/container/flat_map.hpp>
+#include <sdbusplus/unpack_properties.hpp>
 
 #include <cerrno>
 #include <cstdint>
@@ -56,6 +58,7 @@ class BaseRule
     virtual void handle(const Request& /*req*/,
                         const std::shared_ptr<bmcweb::AsyncResp>&,
                         const RoutingParams&) = 0;
+#ifndef BMCWEB_ENABLE_SSL
     virtual void
         handleUpgrade(const Request& /*req*/,
                       const std::shared_ptr<bmcweb::AsyncResp>& asyncResp,
@@ -63,7 +66,7 @@ class BaseRule
     {
         asyncResp->res.result(boost::beast::http::status::not_found);
     }
-#ifdef BMCWEB_ENABLE_SSL
+#else
     virtual void handleUpgrade(
         const Request& /*req*/,
         const std::shared_ptr<bmcweb::AsyncResp>& asyncResp,
@@ -347,6 +350,7 @@ class WebSocketRule : public BaseRule
         asyncResp->res.result(boost::beast::http::status::not_found);
     }
 
+#ifndef BMCWEB_ENABLE_SSL
     void handleUpgrade(const Request& req,
                        const std::shared_ptr<bmcweb::AsyncResp>& /*asyncResp*/,
                        boost::asio::ip::tcp::socket&& adaptor) override
@@ -360,7 +364,7 @@ class WebSocketRule : public BaseRule
                 closeHandler, errorHandler);
         myConnection->start();
     }
-#ifdef BMCWEB_ENABLE_SSL
+#else
     void handleUpgrade(const Request& req,
                        const std::shared_ptr<bmcweb::AsyncResp>& /*asyncResp*/,
                        boost::beast::ssl_stream<boost::asio::ip::tcp::socket>&&
@@ -432,6 +436,7 @@ class StreamingResponseRule : public BaseRule
         asyncResp->res.result(boost::beast::http::status::not_found);
     }
 
+#ifndef BMCWEB_ENABLE_SSL
     void handleUpgrade(const Request& req,
                        const std::shared_ptr<bmcweb::AsyncResp>& /*asyncResp*/,
                        boost::asio::ip::tcp::socket&& adaptor) override
@@ -448,8 +453,7 @@ class StreamingResponseRule : public BaseRule
         myConnection.reset();
         myConnection = nullptr;
     }
-
-#ifdef BMCWEB_ENABLE_SSL
+#else
     void handleUpgrade(const Request& req,
                        const std::shared_ptr<bmcweb::AsyncResp>& /*asyncResp*/,
                        boost::beast::ssl_stream<boost::asio::ip::tcp::socket>&&
@@ -1342,8 +1346,141 @@ class Router
         return findRoute;
     }
 
+    static bool isUserPrivileged(
+        Request& req, const std::shared_ptr<bmcweb::AsyncResp>& asyncResp,
+        BaseRule& rule, const dbus::utility::DBusPropertiesMap& userInfoMap)
+    {
+        std::string userRole{};
+        const std::string* userRolePtr = nullptr;
+        const bool* remoteUser = nullptr;
+        const bool* passwordExpired = nullptr;
+
+        const bool success = sdbusplus::unpackPropertiesNoThrow(
+            redfish::dbus_utils::UnpackErrorPrinter(), userInfoMap,
+            "UserPrivilege", userRolePtr, "RemoteUser", remoteUser,
+            "UserPasswordExpired", passwordExpired);
+
+        if (!success)
+        {
+            asyncResp->res.result(
+                boost::beast::http::status::internal_server_error);
+            return false;
+        }
+
+        if (userRolePtr != nullptr)
+        {
+            userRole = *userRolePtr;
+            BMCWEB_LOG_DEBUG << "userName = " << req.session->username
+                             << " userRole = " << *userRolePtr;
+        }
+
+        if (remoteUser == nullptr)
+        {
+            BMCWEB_LOG_ERROR << "RemoteUser property missing or wrong type";
+            asyncResp->res.result(
+                boost::beast::http::status::internal_server_error);
+            return false;
+        }
+        bool expired = false;
+        if (passwordExpired == nullptr)
+        {
+            if (!*remoteUser)
+            {
+                BMCWEB_LOG_ERROR
+                    << "UserPasswordExpired property is expected for"
+                       " local user but is missing or wrong type";
+                asyncResp->res.result(
+                    boost::beast::http::status::internal_server_error);
+                return false;
+            }
+        }
+        else
+        {
+            expired = *passwordExpired;
+        }
+
+        // Get the user's privileges from the role
+        redfish::Privileges userPrivileges =
+            redfish::getUserPrivileges(userRole);
+
+        // Set isConfigureSelfOnly based on D-Bus results.  This
+        // ignores the results from both pamAuthenticateUser and the
+        // value from any previous use of this session.
+        req.session->isConfigureSelfOnly = expired;
+
+        // Modify privileges if isConfigureSelfOnly.
+        if (req.session->isConfigureSelfOnly)
+        {
+            // Remove all privileges except ConfigureSelf
+            userPrivileges = userPrivileges.intersection(
+                redfish::Privileges{"ConfigureSelf"});
+            BMCWEB_LOG_DEBUG << "Operation limited to ConfigureSelf";
+        }
+
+        if (!rule.checkPrivileges(userPrivileges))
+        {
+            asyncResp->res.result(boost::beast::http::status::forbidden);
+            if (req.session->isConfigureSelfOnly)
+            {
+                redfish::messages::passwordChangeRequired(
+                    asyncResp->res, crow::utility::urlFromPieces(
+                                        "redfish", "v1", "AccountService",
+                                        "Accounts", req.session->username));
+            }
+            return false;
+        }
+
+        req.userRole = userRole;
+
+        return true;
+    }
+
+    template <typename CallbackFn>
+    void afterGetUserInfo(Request& req,
+                          const std::shared_ptr<bmcweb::AsyncResp>& asyncResp,
+                          BaseRule& rule, CallbackFn&& callback,
+                          const boost::system::error_code& ec,
+                          const dbus::utility::DBusPropertiesMap& userInfoMap)
+    {
+        if (ec)
+        {
+            BMCWEB_LOG_ERROR << "GetUserInfo failed...";
+            asyncResp->res.result(
+                boost::beast::http::status::internal_server_error);
+            return;
+        }
+
+        if (!Router::isUserPrivileged(req, asyncResp, rule, userInfoMap))
+        {
+            // User is not privileged
+            BMCWEB_LOG_ERROR << "Insufficient Privilege";
+            asyncResp->res.result(boost::beast::http::status::forbidden);
+            return;
+        }
+        callback();
+    }
+
+    template <typename CallbackFn>
+    void validatePrivilege(Request& req,
+                           const std::shared_ptr<bmcweb::AsyncResp>& asyncResp,
+                           BaseRule& rule, CallbackFn&& callback)
+    {
+        crow::connections::systemBus->async_method_call(
+            [this, &req, asyncResp, &rule,
+             callback(std::forward<CallbackFn>(callback))](
+                const boost::system::error_code& ec,
+                const dbus::utility::DBusPropertiesMap& userInfoMap) mutable {
+            afterGetUserInfo(req, asyncResp, rule,
+                             std::forward<CallbackFn>(callback), ec,
+                             userInfoMap);
+            },
+            "xyz.openbmc_project.User.Manager", "/xyz/openbmc_project/user",
+            "xyz.openbmc_project.User.Manager", "GetUserInfo",
+            req.session->username);
+    }
+
     template <typename Adaptor>
-    void handleUpgrade(const Request& req,
+    void handleUpgrade(Request& req,
                        const std::shared_ptr<bmcweb::AsyncResp>& asyncResp,
                        Adaptor&& adaptor)
     {
@@ -1371,43 +1508,28 @@ class Router
             throw std::runtime_error("Trie internal structure corrupted!");
         }
 
-        if ((rules[ruleIndex]->getMethods() &
-             (1U << static_cast<size_t>(*verb))) == 0)
+        BaseRule& rule = *rules[ruleIndex];
+        size_t methods = rule.getMethods();
+        if ((methods & (1U << static_cast<size_t>(*verb))) == 0)
         {
             BMCWEB_LOG_DEBUG << "Rule found but method mismatch: " << req.url
                              << " with " << req.methodString() << "("
                              << static_cast<uint32_t>(*verb) << ") / "
-                             << rules[ruleIndex]->getMethods();
+                             << methods;
             asyncResp->res.result(boost::beast::http::status::not_found);
             return;
         }
 
-        BMCWEB_LOG_DEBUG << "Matched rule (upgrade) '" << rules[ruleIndex]->rule
-                         << "' " << static_cast<uint32_t>(*verb) << " / "
-                         << rules[ruleIndex]->getMethods();
+        BMCWEB_LOG_DEBUG << "Matched rule (upgrade) '" << rule.rule << "' "
+                         << static_cast<uint32_t>(*verb) << " / " << methods;
 
-        // any uncaught exceptions become 500s
-        try
-        {
-            rules[ruleIndex]->handleUpgrade(req, asyncResp,
-                                            std::forward<Adaptor>(adaptor));
-        }
-        catch (const std::exception& e)
-        {
-            BMCWEB_LOG_ERROR << "An uncaught exception occurred: " << e.what();
-            asyncResp->res.result(
-                boost::beast::http::status::internal_server_error);
-            return;
-        }
-        catch (...)
-        {
-            BMCWEB_LOG_ERROR
-                << "An uncaught exception occurred. The type was unknown "
-                   "so no information was available.";
-            asyncResp->res.result(
-                boost::beast::http::status::internal_server_error);
-            return;
-        }
+        // TODO(ed) This should be able to use std::bind_front, but it doesn't
+        // appear to work with the std::move on adaptor.
+        validatePrivilege(req, asyncResp, rule,
+                          [&rule, &req, asyncResp,
+                           adaptor(std::forward<Adaptor>(adaptor))]() mutable {
+            rule.handleUpgrade(req, asyncResp, std::move(adaptor));
+        });
     }
 
     void handle(Request& req,
@@ -1474,111 +1596,11 @@ class Router
             rule.handle(req, asyncResp, params);
             return;
         }
-        std::string username = req.session->username;
 
-        crow::connections::systemBus->async_method_call(
-            [req{std::move(req)}, asyncResp, &rule, params](
-                const boost::system::error_code ec,
-                const dbus::utility::DBusPropertiesMap& userInfoMap) mutable {
-            if (ec)
-            {
-                BMCWEB_LOG_ERROR << "GetUserInfo failed...";
-                asyncResp->res.result(
-                    boost::beast::http::status::internal_server_error);
-                return;
-            }
-            std::string userRole{};
-            const bool* remoteUser = nullptr;
-            std::optional<bool> passwordExpired;
-
-            for (const auto& userInfo : userInfoMap)
-            {
-                if (userInfo.first == "UserPrivilege")
-                {
-                    const std::string* userRolePtr =
-                        std::get_if<std::string>(&userInfo.second);
-                    if (userRolePtr == nullptr)
-                    {
-                        continue;
-                    }
-                    userRole = *userRolePtr;
-                    BMCWEB_LOG_DEBUG << "userName = " << req.session->username
-                                     << " userRole = " << *userRolePtr;
-                }
-                else if (userInfo.first == "RemoteUser")
-                {
-                    remoteUser = std::get_if<bool>(&userInfo.second);
-                }
-                else if (userInfo.first == "UserPasswordExpired")
-                {
-                    const bool* passwordExpiredPtr =
-                        std::get_if<bool>(&userInfo.second);
-                    if (passwordExpiredPtr == nullptr)
-                    {
-                        continue;
-                    }
-                    passwordExpired = *passwordExpiredPtr;
-                }
-            }
-
-            if (remoteUser == nullptr)
-            {
-                BMCWEB_LOG_ERROR << "RemoteUser property missing or wrong type";
-                asyncResp->res.result(
-                    boost::beast::http::status::internal_server_error);
-                return;
-            }
-
-            if (passwordExpired == std::nullopt)
-            {
-                if (!*remoteUser)
-                {
-                    BMCWEB_LOG_ERROR
-                        << "UserPasswordExpired property is expected for"
-                           " local user but is missing or wrong type";
-                    asyncResp->res.result(
-                        boost::beast::http::status::internal_server_error);
-                    return;
-                }
-                passwordExpired = false;
-            }
-
-            // Get the user's privileges from the role
-            redfish::Privileges userPrivileges =
-                redfish::getUserPrivileges(userRole);
-
-            // Set isConfigureSelfOnly based on D-Bus results.  This
-            // ignores the results from both pamAuthenticateUser and the
-            // value from any previous use of this session.
-            req.session->isConfigureSelfOnly = *passwordExpired;
-
-            // Modify privileges if isConfigureSelfOnly.
-            if (req.session->isConfigureSelfOnly)
-            {
-                // Remove all privileges except ConfigureSelf
-                userPrivileges = userPrivileges.intersection(
-                    redfish::Privileges{"ConfigureSelf"});
-                BMCWEB_LOG_DEBUG << "Operation limited to ConfigureSelf";
-            }
-
-            if (!rule.checkPrivileges(userPrivileges))
-            {
-                asyncResp->res.result(boost::beast::http::status::forbidden);
-                if (req.session->isConfigureSelfOnly)
-                {
-                    redfish::messages::passwordChangeRequired(
-                        asyncResp->res, crow::utility::urlFromPieces(
-                                            "redfish", "v1", "AccountService",
-                                            "Accounts", req.session->username));
-                }
-                return;
-            }
-
-            req.userRole = userRole;
-            rule.handle(req, asyncResp, params);
-            },
-            "xyz.openbmc_project.User.Manager", "/xyz/openbmc_project/user",
-            "xyz.openbmc_project.User.Manager", "GetUserInfo", username);
+        validatePrivilege(req, asyncResp, rule,
+                          std::bind_front(&BaseRule::handle, std::ref(rule),
+                                          std::ref(req), asyncResp,
+                                          std::ref(params)));
     }
 
     void debugPrint()

--- a/http/routing.hpp
+++ b/http/routing.hpp
@@ -1436,7 +1436,7 @@ class Router
     }
 
     template <typename CallbackFn>
-    void afterGetUserInfo(Request&& req,
+    void afterGetUserInfo(Request& req,
                           const std::shared_ptr<bmcweb::AsyncResp>& asyncResp,
                           BaseRule& rule, CallbackFn&& callback,
                           const boost::system::error_code& ec,
@@ -1457,11 +1457,11 @@ class Router
             asyncResp->res.result(boost::beast::http::status::forbidden);
             return;
         }
-        callback(std::move(req));
+        callback(req);
     }
 
     template <typename CallbackFn>
-    void validatePrivilege(Request&& req,
+    void validatePrivilege(Request& req,
                            const std::shared_ptr<bmcweb::AsyncResp>& asyncResp,
                            BaseRule& rule, CallbackFn&& callback)
     {
@@ -1471,11 +1471,11 @@ class Router
         }
         std::string username = req.session->username;
         crow::connections::systemBus->async_method_call(
-            [this, req{std::move(req)}, asyncResp, &rule,
+            [this, &req, asyncResp, &rule,
              callback(std::forward<CallbackFn>(callback))](
                 const boost::system::error_code& ec,
                 const dbus::utility::DBusPropertiesMap& userInfoMap) mutable {
-            afterGetUserInfo(std::move(req), asyncResp, rule,
+            afterGetUserInfo(req, asyncResp, rule,
                              std::forward<CallbackFn>(callback), ec,
                              userInfoMap);
             },
@@ -1530,9 +1530,9 @@ class Router
         // TODO(ed) This should be able to use std::bind_front, but it doesn't
         // appear to work with the std::move on adaptor.
         validatePrivilege(
-            std::move(req), asyncResp, rule,
+            req, asyncResp, rule,
             [&rule, asyncResp, adaptor(std::forward<Adaptor>(adaptor))](
-                Request&& thisReq) mutable {
+                Request& thisReq) mutable {
             rule.handleUpgrade(thisReq, asyncResp, std::move(adaptor));
             });
     }
@@ -1601,11 +1601,10 @@ class Router
             rule.handle(req, asyncResp, params);
             return;
         }
-        validatePrivilege(
-            std::move(req), asyncResp, rule,
-            [&rule, asyncResp, params](Request&& thisReq) mutable {
+        validatePrivilege(req, asyncResp, rule,
+                          [&rule, asyncResp, params](Request& thisReq) mutable {
             rule.handle(thisReq, asyncResp, params);
-            });
+        });
     }
 
     void debugPrint()

--- a/http/routing.hpp
+++ b/http/routing.hpp
@@ -1436,7 +1436,7 @@ class Router
     }
 
     template <typename CallbackFn>
-    void afterGetUserInfo(Request& req,
+    void afterGetUserInfo(Request&& req,
                           const std::shared_ptr<bmcweb::AsyncResp>& asyncResp,
                           BaseRule& rule, CallbackFn&& callback,
                           const boost::system::error_code& ec,
@@ -1457,26 +1457,30 @@ class Router
             asyncResp->res.result(boost::beast::http::status::forbidden);
             return;
         }
-        callback();
+        callback(std::move(req));
     }
 
     template <typename CallbackFn>
-    void validatePrivilege(Request& req,
+    void validatePrivilege(Request&& req,
                            const std::shared_ptr<bmcweb::AsyncResp>& asyncResp,
                            BaseRule& rule, CallbackFn&& callback)
     {
+        if (req.session == nullptr)
+        {
+            return;
+        }
+        std::string username = req.session->username;
         crow::connections::systemBus->async_method_call(
-            [this, &req, asyncResp, &rule,
+            [this, req{std::move(req)}, asyncResp, &rule,
              callback(std::forward<CallbackFn>(callback))](
                 const boost::system::error_code& ec,
                 const dbus::utility::DBusPropertiesMap& userInfoMap) mutable {
-            afterGetUserInfo(req, asyncResp, rule,
+            afterGetUserInfo(std::move(req), asyncResp, rule,
                              std::forward<CallbackFn>(callback), ec,
                              userInfoMap);
             },
             "xyz.openbmc_project.User.Manager", "/xyz/openbmc_project/user",
-            "xyz.openbmc_project.User.Manager", "GetUserInfo",
-            req.session->username);
+            "xyz.openbmc_project.User.Manager", "GetUserInfo", username);
     }
 
     template <typename Adaptor>
@@ -1525,11 +1529,12 @@ class Router
 
         // TODO(ed) This should be able to use std::bind_front, but it doesn't
         // appear to work with the std::move on adaptor.
-        validatePrivilege(req, asyncResp, rule,
-                          [&rule, &req, asyncResp,
-                           adaptor(std::forward<Adaptor>(adaptor))]() mutable {
-            rule.handleUpgrade(req, asyncResp, std::move(adaptor));
-        });
+        validatePrivilege(
+            std::move(req), asyncResp, rule,
+            [&rule, asyncResp, adaptor(std::forward<Adaptor>(adaptor))](
+                Request&& thisReq) mutable {
+            rule.handleUpgrade(thisReq, asyncResp, std::move(adaptor));
+            });
     }
 
     void handle(Request& req,
@@ -1596,11 +1601,11 @@ class Router
             rule.handle(req, asyncResp, params);
             return;
         }
-
-        validatePrivilege(req, asyncResp, rule,
-                          std::bind_front(&BaseRule::handle, std::ref(rule),
-                                          std::ref(req), asyncResp,
-                                          std::ref(params)));
+        validatePrivilege(
+            std::move(req), asyncResp, rule,
+            [&rule, asyncResp, params](Request&& thisReq) mutable {
+            rule.handle(thisReq, asyncResp, params);
+            });
     }
 
     void debugPrint()


### PR DESCRIPTION
Fix redfish browser to show html redfish logo.
It is also reported by tester - https://jazz07.rchland.ibm.com:13443/jazz/web/projects/CSSD#action=com.ibm.team.workitem.viewWorkItem&id=483135

On bmc redish web view, DMTF Redfish logo fails to display.
It is because the headers in the Request is no longer valid
after the use of move().

The following upstream commits are needed.

- Add asyncResp support to handleUpgrade https://gerrit.openbmc.org/c/openbmc/bmcweb/+/46989
  Change-Id: I1c6c91f126b734e1b5573d5ef204fe2bf6ed6c26

- Add Support for privilege check in handleUpgrade https://gerrit.openbmc.org/c/openbmc/bmcweb/+/46991?usp=search
  Change-Id: I6f743c27e7e6077f1c6c56e6958922027e4404e8

- Fix some moves
  Change-Id: Ib6d99726a64326b7c8bad15bc9d4ca774ab6256d https://gerrit.openbmc.org/c/openbmc/bmcweb/+/61677

- Fix Request use-after-move
  Change-Id: Iae68a68817146c28377bbcade04716725e4a6096 https://gerrit.openbmc.org/c/openbmc/bmcweb/+/61768

Tested:

- Redfish validator passed
- [https://${bmc}/redfish/v1](https://%24%7Bbmc%7D/redfish/v1) is showing the pretty redfish logo
- Tried some GUI pages and worked without issues.
- Tried consoles on GUI and worked without issues.