### PR TITLE
Change BMCWEB_LOG level for 404/405

### DIFF
--- a/redfish-core/lib/redfish_v1.hpp
+++ b/redfish-core/lib/redfish_v1.hpp
@@ -36,7 +36,7 @@ inline void redfish404(App& app, const crow::Request& req,
         return;
     }
 
-    BMCWEB_LOG_ERROR << "404 on path " << path;
+    BMCWEB_LOG_WARNING << "404 on path " << path;
 
     std::string name = req.urlView.segments().back();
     // Note, if we hit the wildcard route, we don't know the "type" the user was
@@ -56,7 +56,7 @@ inline void redfish405(App& app, const crow::Request& req,
         return;
     }
 
-    BMCWEB_LOG_ERROR << "405 on path " << path;
+    BMCWEB_LOG_WARNING << "405 on path " << path;
     asyncResp->res.result(boost::beast::http::status::method_not_allowed);
     if (req.method() == boost::beast::http::verb::delete_)
     {


### PR DESCRIPTION
Defect is https://jazz07.rchland.ibm.com:13443/jazz/web/projects/CSSD#action=com.ibm.team.workitem.viewWorkItem&id=486536

Upstream is merged at https://gerrit.openbmc.org/c/openbmc/bmcweb/+/61133

404/405 which are part of 4xx errors are client-side errors. These might be server errors, e.g. a client is walking the redfish tree and had a id that no longer exists but they could also be the client tried an id or URL that isn't there, e.g. a fuzz tester. Due to this, use WARNING log level.

A future commit attempts to better clarify our log levels.

Saw "404 on path v1/badinput/badinput"

Tested: None.

Change-Id: I4f056754638ef2d640615e9fcc74a7a68a767593