### PR TITLE
1050: Use by-value in url and Request handling

### DIFF
--- a/.clang-tidy
+++ b/.clang-tidy
@@ -315,3 +315,4 @@ CheckOptions:
   - { key: readability-identifier-naming.NamespaceCase, value: lower_case }
   - { key: readability-identifier-naming.StructCase,    value: CamelCase  }
   - { key: cppcoreguidelines-macro-usage.AllowedRegexp, value: DEBUG*|NLOHMANN_JSON_SERIALIZE_ENUM }
+  - { key: performance-unnecessary-value-param.AllowedTypes, value: ((segments_view)|(url_view)) }

--- a/COMMON_ERRORS.md
+++ b/COMMON_ERRORS.md
@@ -23,7 +23,7 @@ This pointer is not guaranteed to be filled, and could be a null dereference.
 ## 2. String views aren't null terminated
 
 ```cpp
-int getIntFromString(const std::string_view s){
+int getIntFromString(std::string_view s){
     return std::atoi(s.data());
 }
 ```

--- a/http/http_request.hpp
+++ b/http/http_request.hpp
@@ -20,7 +20,6 @@ namespace crow
 struct Request
 {
     boost::beast::http::request<boost::beast::http::string_body> req;
-    boost::beast::http::fields& fields;
     std::string_view url{};
     boost::urls::url_view urlView{};
 
@@ -37,7 +36,7 @@ struct Request
     Request(boost::beast::http::request<boost::beast::http::string_body> reqIn,
             std::error_code& ec) :
         req(std::move(reqIn)),
-        fields(req.base()), body(req.body())
+        body(req.body())
     {
         if (!setUrlInfo())
         {
@@ -46,18 +45,16 @@ struct Request
     }
 
     Request(const Request& other) :
-        req(other.req), fields(req.base()), isSecure(other.isSecure),
-        body(req.body()), ioService(other.ioService),
-        ipAddress(other.ipAddress), session(other.session),
-        userRole(other.userRole)
+        req(other.req), isSecure(other.isSecure), body(req.body()),
+        ioService(other.ioService), ipAddress(other.ipAddress),
+        session(other.session), userRole(other.userRole)
     {
         setUrlInfo();
     }
 
     Request(Request&& other) noexcept :
-        req(std::move(other.req)), fields(req.base()), isSecure(other.isSecure),
-        body(req.body()), ioService(other.ioService),
-        ipAddress(std::move(other.ipAddress)),
+        req(std::move(other.req)), isSecure(other.isSecure), body(req.body()),
+        ioService(other.ioService), ipAddress(std::move(other.ipAddress)),
         session(std::move(other.session)), userRole(std::move(other.userRole))
     {
         setUrlInfo();
@@ -90,6 +87,11 @@ struct Request
     std::string_view target() const
     {
         return req.target();
+    }
+
+    const boost::beast::http::fields& fields() const
+    {
+        return req.base();
     }
 
     bool target(std::string_view target)

--- a/http/http_request.hpp
+++ b/http/http_request.hpp
@@ -92,7 +92,7 @@ struct Request
         return req.target();
     }
 
-    bool target(const std::string_view target)
+    bool target(std::string_view target)
     {
         req.target(target);
         return setUrlInfo();

--- a/http/http_response.hpp
+++ b/http/http_response.hpp
@@ -30,7 +30,7 @@ struct Response
 
     nlohmann::json jsonValue;
 
-    void addHeader(const std::string_view key, const std::string_view value)
+    void addHeader(std::string_view key, std::string_view value)
     {
         stringResponse->set(key, value);
     }

--- a/http/routing.hpp
+++ b/http/routing.hpp
@@ -1327,7 +1327,8 @@ class Router
             // Make sure it's safe to deference the array at that index
             static_assert(maxVerbIndex <
                           std::tuple_size_v<decltype(perMethods)>);
-            FindRoute route = findRouteByIndex(req.url, perMethodIndex);
+            FindRoute route =
+                findRouteByIndex(req.url().encoded_path(), perMethodIndex);
             if (route.rule == nullptr)
             {
                 continue;
@@ -1498,11 +1499,13 @@ class Router
         Trie& trie = perMethod.trie;
         std::vector<BaseRule*>& rules = perMethod.rules;
 
-        const std::pair<unsigned, RoutingParams>& found = trie.find(req.url);
+        const std::pair<unsigned, RoutingParams>& found =
+            trie.find(req.url().encoded_path());
         unsigned ruleIndex = found.first;
         if (ruleIndex == 0U)
         {
-            BMCWEB_LOG_DEBUG << "Cannot match rules " << req.url;
+            BMCWEB_LOG_DEBUG << "Cannot match rules "
+                             << req.url().encoded_path();
             asyncResp->res.result(boost::beast::http::status::not_found);
             return;
         }
@@ -1516,10 +1519,10 @@ class Router
         size_t methods = rule.getMethods();
         if ((methods & (1U << static_cast<size_t>(*verb))) == 0)
         {
-            BMCWEB_LOG_DEBUG << "Rule found but method mismatch: " << req.url
-                             << " with " << req.methodString() << "("
-                             << static_cast<uint32_t>(*verb) << ") / "
-                             << methods;
+            BMCWEB_LOG_DEBUG
+                << "Rule found but method mismatch: "
+                << req.url().encoded_path() << " with " << req.methodString()
+                << "(" << static_cast<uint32_t>(*verb) << ") / " << methods;
             asyncResp->res.result(boost::beast::http::status::not_found);
             return;
         }
@@ -1555,13 +1558,14 @@ class Router
             // route
             if (foundRoute.allowHeader.empty())
             {
-                foundRoute.route = findRouteByIndex(req.url, notFoundIndex);
+                foundRoute.route =
+                    findRouteByIndex(req.url().encoded_path(), notFoundIndex);
             }
             else
             {
                 // See if we have a method not allowed (405) handler
-                foundRoute.route =
-                    findRouteByIndex(req.url, methodNotAllowedIndex);
+                foundRoute.route = findRouteByIndex(req.url().encoded_path(),
+                                                    methodNotAllowedIndex);
             }
         }
 

--- a/http/routing.hpp
+++ b/http/routing.hpp
@@ -1,5 +1,6 @@
 #pragma once
 
+#include "async_resp.hpp"
 #include "common.hpp"
 #include "dbus_utility.hpp"
 #include "error_messages.hpp"
@@ -14,7 +15,6 @@
 #include "verb.hpp"
 #include "websocket.hpp"
 
-#include <async_resp.hpp>
 #include <boost/beast/ssl/ssl_stream.hpp>
 #include <boost/container/flat_map.hpp>
 #include <sdbusplus/unpack_properties.hpp>
@@ -531,7 +531,7 @@ struct RuleParameterTraits
         return *p;
     }
 
-    self_t& name(const std::string_view name) noexcept
+    self_t& name(std::string_view name) noexcept
     {
         self_t* self = static_cast<self_t*>(this);
         self->nameStr = name;
@@ -772,7 +772,7 @@ class TaggedRule :
     }
 
     template <typename Func>
-    void operator()(const std::string_view name, Func&& f)
+    void operator()(std::string_view name, Func&& f)
     {
         nameStr = name;
         (*this).template operator()<Func>(std::forward(f));
@@ -916,7 +916,7 @@ class Trie
     }
 
     std::pair<unsigned, RoutingParams>
-        find(const std::string_view reqUrl, const Node* node = nullptr,
+        find(std::string_view reqUrl, const Node* node = nullptr,
              size_t pos = 0, RoutingParams* params = nullptr) const
     {
         RoutingParams empty;

--- a/http/utility.hpp
+++ b/http/utility.hpp
@@ -668,10 +668,10 @@ class UrlSegmentMatcherVisitor
     std::string_view segment;
 };
 
-inline bool readUrlSegments(const boost::urls::url_view& urlView,
+inline bool readUrlSegments(const boost::urls::url_view& url,
                             std::initializer_list<UrlSegment>&& segments)
 {
-    const boost::urls::segments_view& urlSegments = urlView.segments();
+    const boost::urls::segments_view& urlSegments = url.segments();
 
     if (!urlSegments.is_absolute())
     {
@@ -712,10 +712,9 @@ inline bool readUrlSegments(const boost::urls::url_view& urlView,
 } // namespace details
 
 template <typename... Args>
-inline bool readUrlSegments(const boost::urls::url_view& urlView,
-                            Args&&... args)
+inline bool readUrlSegments(const boost::urls::url_view& url, Args&&... args)
 {
-    return details::readUrlSegments(urlView, {std::forward<Args>(args)...});
+    return details::readUrlSegments(url, {std::forward<Args>(args)...});
 }
 
 inline boost::urls::url replaceUrlSegment(const boost::urls::url_view& urlView,
@@ -748,13 +747,13 @@ inline boost::urls::url replaceUrlSegment(const boost::urls::url_view& urlView,
     return url;
 }
 
-inline std::string setProtocolDefaults(const boost::urls::url_view& url)
+inline std::string setProtocolDefaults(const boost::urls::url_view& urlView)
 {
-    if (url.scheme() == "https")
+    if (urlView.scheme() == "https")
     {
         return "https";
     }
-    if (url.scheme() == "http")
+    if (urlView.scheme() == "http")
     {
         if (bmcwebInsecureEnableHttpPushStyleEventing)
         {
@@ -762,7 +761,7 @@ inline std::string setProtocolDefaults(const boost::urls::url_view& url)
         }
         return "";
     }
-    if (url.scheme() == "snmp")
+    if (urlView.scheme() == "snmp")
     {
         return "snmp";
     }

--- a/http/utility.hpp
+++ b/http/utility.hpp
@@ -1,6 +1,7 @@
 #pragma once
 
-#include <bmcweb_config.h>
+#include "bmcweb_config.h"
+
 #include <openssl/crypto.h>
 
 #include <boost/callable_traits.hpp>
@@ -377,7 +378,7 @@ struct FunctionTraits
     using arg = std::tuple_element_t<i, boost::callable_traits::args_t<T>>;
 };
 
-inline std::string base64encode(const std::string_view data)
+inline std::string base64encode(std::string_view data)
 {
     const std::array<char, 64> key = {
         'A', 'B', 'C', 'D', 'E', 'F', 'G', 'H', 'I', 'J', 'K', 'L', 'M',
@@ -437,7 +438,7 @@ inline std::string base64encode(const std::string_view data)
 
 // TODO this is temporary and should be deleted once base64 is refactored out of
 // crow
-inline bool base64Decode(const std::string_view input, std::string& output)
+inline bool base64Decode(std::string_view input, std::string& output)
 {
     static const char nop = static_cast<char>(-1);
     // See note on encoding_data[] in above function
@@ -565,8 +566,7 @@ inline std::string convertToAscii(const uint64_t& element)
     return {std::string(bytearray.begin(), bytearray.end())};
 }
 
-inline bool constantTimeStringCompare(const std::string_view a,
-                                      const std::string_view b)
+inline bool constantTimeStringCompare(std::string_view a, std::string_view b)
 {
     // Important note, this function is ONLY constant time if the two input
     // sizes are the same
@@ -579,7 +579,7 @@ inline bool constantTimeStringCompare(const std::string_view a,
 
 struct ConstantTimeCompare
 {
-    bool operator()(const std::string_view a, const std::string_view b) const
+    bool operator()(std::string_view a, std::string_view b) const
     {
         return constantTimeStringCompare(a, b);
     }
@@ -591,7 +591,7 @@ inline boost::urls::url
     appendUrlPieces(boost::urls::url& url,
                     const std::initializer_list<std::string_view> args)
 {
-    for (const std::string_view& arg : args)
+    for (std::string_view arg : args)
     {
         url.segments().push_back(arg);
     }
@@ -720,7 +720,7 @@ inline bool readUrlSegments(const boost::urls::url_view& urlView,
 
 inline boost::urls::url replaceUrlSegment(const boost::urls::url_view& urlView,
                                           const uint replaceLoc,
-                                          const std::string_view newSegment)
+                                          std::string_view newSegment)
 {
     const boost::urls::segments_view& urlSegments = urlView.segments();
     boost::urls::url url("/");

--- a/http/utility.hpp
+++ b/http/utility.hpp
@@ -668,10 +668,10 @@ class UrlSegmentMatcherVisitor
     std::string_view segment;
 };
 
-inline bool readUrlSegments(const boost::urls::url_view& url,
+inline bool readUrlSegments(boost::urls::url_view url,
                             std::initializer_list<UrlSegment>&& segments)
 {
-    const boost::urls::segments_view& urlSegments = url.segments();
+    boost::urls::segments_view urlSegments = url.segments();
 
     if (!urlSegments.is_absolute())
     {
@@ -712,16 +712,16 @@ inline bool readUrlSegments(const boost::urls::url_view& url,
 } // namespace details
 
 template <typename... Args>
-inline bool readUrlSegments(const boost::urls::url_view& url, Args&&... args)
+inline bool readUrlSegments(boost::urls::url_view url, Args&&... args)
 {
     return details::readUrlSegments(url, {std::forward<Args>(args)...});
 }
 
-inline boost::urls::url replaceUrlSegment(const boost::urls::url_view& urlView,
+inline boost::urls::url replaceUrlSegment(boost::urls::url_view urlView,
                                           const uint replaceLoc,
                                           std::string_view newSegment)
 {
-    const boost::urls::segments_view& urlSegments = urlView.segments();
+    boost::urls::segments_view urlSegments = urlView.segments();
     boost::urls::url url("/");
 
     if (!urlSegments.is_absolute())
@@ -747,7 +747,7 @@ inline boost::urls::url replaceUrlSegment(const boost::urls::url_view& urlView,
     return url;
 }
 
-inline std::string setProtocolDefaults(const boost::urls::url_view& urlView)
+inline std::string setProtocolDefaults(boost::urls::url_view urlView)
 {
     if (urlView.scheme() == "https")
     {
@@ -768,7 +768,7 @@ inline std::string setProtocolDefaults(const boost::urls::url_view& urlView)
     return "";
 }
 
-inline uint16_t setPortDefaults(const boost::urls::url_view& url)
+inline uint16_t setPortDefaults(boost::urls::url_view url)
 {
     uint16_t port = url.port_number();
     if (port != 0)
@@ -854,7 +854,7 @@ template <>
 struct adl_serializer<boost::urls::url_view>
 {
     // NOLINTNEXTLINE(readability-identifier-naming)
-    static void to_json(json& j, const boost::urls::url_view& url)
+    static void to_json(json& j, boost::urls::url_view url)
     {
         j = url.buffer();
     }

--- a/http/websocket.hpp
+++ b/http/websocket.hpp
@@ -147,7 +147,7 @@ class ConnectionImpl : public Connection
         });
     }
 
-    void sendBinary(const std::string_view msg) override
+    void sendBinary(std::string_view msg) override
     {
         ws.binary(true);
         outBuffer.emplace_back(msg);
@@ -161,7 +161,7 @@ class ConnectionImpl : public Connection
         doWrite();
     }
 
-    void sendText(const std::string_view msg) override
+    void sendText(std::string_view msg) override
     {
         ws.text(true);
         outBuffer.emplace_back(msg);
@@ -175,7 +175,7 @@ class ConnectionImpl : public Connection
         doWrite();
     }
 
-    void close(const std::string_view msg) override
+    void close(std::string_view msg) override
     {
         ws.async_close(
             {boost::beast::websocket::close_code::normal, msg},

--- a/include/http_utility.hpp
+++ b/include/http_utility.hpp
@@ -109,7 +109,7 @@ inline bool isContentTypeAllowed(std::string_view header, ContentType type,
     return type == allowed;
 }
 
-inline std::string urlEncode(const std::string_view value)
+inline std::string urlEncode(std::string_view value)
 {
     std::ostringstream escaped;
     escaped.fill('0');

--- a/include/human_sort.hpp
+++ b/include/human_sort.hpp
@@ -22,8 +22,7 @@ enum class ModeType
 
 } // namespace details
 
-inline int alphanumComp(const std::string_view left,
-                        const std::string_view right)
+inline int alphanumComp(std::string_view left, std::string_view right)
 {
 
     std::string_view::const_iterator l = left.begin();

--- a/include/ibm/management_console_rest.hpp
+++ b/include/ibm/management_console_rest.hpp
@@ -367,7 +367,7 @@ inline void
     else
     {
         // Single file upload
-        const std::string& data = req.body;
+        const std::string& data = req.body();
         uploadStatus = saveConfigFile(data, fileID, asyncResp);
         if (!uploadStatus)
         {

--- a/include/ibm/utils.hpp
+++ b/include/ibm/utils.hpp
@@ -10,7 +10,7 @@ namespace crow
 namespace ibm_utils
 {
 
-inline bool createDirectory(const std::string_view path)
+inline bool createDirectory(std::string_view path)
 {
     // Create persistent directory
     std::error_code ec;

--- a/include/image_upload.hpp
+++ b/include/image_upload.hpp
@@ -96,7 +96,7 @@ inline void
     BMCWEB_LOG_DEBUG << "Writing file to " << filepath;
     std::ofstream out(filepath, std::ofstream::out | std::ofstream::binary |
                                     std::ofstream::trunc);
-    out << req.body;
+    out << req.body();
     out.close();
     timeout.async_wait(timeoutHandler);
 }

--- a/include/login_routes.hpp
+++ b/include/login_routes.hpp
@@ -37,7 +37,8 @@ inline void requestRoutes(App& app)
         // Check if auth was provided by a payload
         if (contentType.starts_with("application/json"))
         {
-            loginCredentials = nlohmann::json::parse(req.body, nullptr, false);
+            loginCredentials =
+                nlohmann::json::parse(req.body(), nullptr, false);
             if (loginCredentials.is_discarded())
             {
                 BMCWEB_LOG_DEBUG << "Bad json in request";

--- a/include/multipart_parser.hpp
+++ b/include/multipart_parser.hpp
@@ -73,8 +73,8 @@ class MultipartParser
         lookbehind.resize(boundary.size() + 8);
         state = State::START;
 
-        const char* buffer = req.body.data();
-        size_t len = req.body.size();
+        const char* buffer = req.body().data();
+        size_t len = req.body().size();
         char cl = 0;
 
         for (size_t i = 0; i < len; i++)

--- a/include/nbd_proxy.hpp
+++ b/include/nbd_proxy.hpp
@@ -108,7 +108,7 @@ struct NbdProxyServer : std::enable_shared_from_this<NbdProxyServer>
             "xyz.openbmc_project.VirtualMedia.Proxy", "Mount");
     }
 
-    void send(const std::string_view data)
+    void send(std::string_view data)
     {
         boost::asio::buffer_copy(ws2uxBuf.prepare(data.size()),
                                  boost::asio::buffer(data));

--- a/include/openbmc_dbus_rest.hpp
+++ b/include/openbmc_dbus_rest.hpp
@@ -1541,7 +1541,7 @@ inline void handleAction(const crow::Request& req,
     BMCWEB_LOG_DEBUG << "handleAction on path: " << objectPath << " and method "
                      << methodName;
     nlohmann::json requestDbusData =
-        nlohmann::json::parse(req.body, nullptr, false);
+        nlohmann::json::parse(req.body(), nullptr, false);
 
     if (requestDbusData.is_discarded())
     {
@@ -1857,7 +1857,7 @@ inline void handlePut(const crow::Request& req,
     }
 
     nlohmann::json requestDbusData =
-        nlohmann::json::parse(req.body, nullptr, false);
+        nlohmann::json::parse(req.body(), nullptr, false);
 
     if (requestDbusData.is_discarded())
     {
@@ -2396,7 +2396,7 @@ inline void
         }
 
         nlohmann::json requestDbusData =
-            nlohmann::json::parse(req.body, nullptr, false);
+            nlohmann::json::parse(req.body(), nullptr, false);
 
         if (requestDbusData.is_discarded())
         {

--- a/include/openbmc_dbus_rest.hpp
+++ b/include/openbmc_dbus_rest.hpp
@@ -103,8 +103,7 @@ inline bool validateFilename(const std::string& filename)
 
 inline void setErrorResponse(crow::Response& res,
                              boost::beast::http::status result,
-                             const std::string& desc,
-                             const std::string_view msg)
+                             const std::string& desc, std::string_view msg)
 {
     res.result(result);
     res.jsonValue["data"]["description"] = desc;

--- a/include/pam_authenticate.hpp
+++ b/include/pam_authenticate.hpp
@@ -83,8 +83,8 @@ inline int pamFunctionConversation(int numMsg, const struct pam_message** msg,
  * @param username The provided username aka account name.
  * @param password The provided password.
  * @returns PAM error code or PAM_SUCCESS for success. */
-inline int pamAuthenticateUser(const std::string_view username,
-                               const std::string_view password)
+inline int pamAuthenticateUser(std::string_view username,
+                               std::string_view password)
 {
     std::string userStr(username);
     std::string passStr(password);

--- a/include/security_headers.hpp
+++ b/include/security_headers.hpp
@@ -57,7 +57,7 @@ inline void addSecurityHeaders(const crow::Request& req [[maybe_unused]],
                                                  "object-src *; "
                                                  "base-uri *");
 
-        const std::string_view origin = req.getHeaderValue("Origin");
+        std::string_view origin = req.getHeaderValue("Origin");
         res.addHeader(bf::access_control_allow_origin, origin);
         res.addHeader(bf::access_control_allow_methods, "GET, "
                                                         "POST, "

--- a/include/sessions.hpp
+++ b/include/sessions.hpp
@@ -200,8 +200,7 @@ class SessionStore
 {
   public:
     std::shared_ptr<UserSession> generateUserSession(
-        const std::string_view username,
-        const boost::asio::ip::address& clientIp,
+        std::string_view username, const boost::asio::ip::address& clientIp,
         const std::optional<std::string>& clientId,
         PersistenceType persistence = PersistenceType::TIMEOUT,
         bool isConfigureSelfOnly = false)
@@ -263,8 +262,7 @@ class SessionStore
         return it.first->second;
     }
 
-    std::shared_ptr<UserSession>
-        loginSessionByToken(const std::string_view token)
+    std::shared_ptr<UserSession> loginSessionByToken(std::string_view token)
     {
         applySessionTimeouts();
         if (token.size() != sessionTokenSize)
@@ -281,7 +279,7 @@ class SessionStore
         return userSession;
     }
 
-    std::shared_ptr<UserSession> getSessionByUid(const std::string_view uid)
+    std::shared_ptr<UserSession> getSessionByUid(std::string_view uid)
     {
         applySessionTimeouts();
         // TODO(Ed) this is inefficient

--- a/redfish-core/include/error_messages.hpp
+++ b/redfish-core/include/error_messages.hpp
@@ -71,10 +71,9 @@ void malformedJSON(crow::Response& res);
  * @param[in] arg1 Parameter of message that will replace %1 in its body.
  *
  * @returns Message ResourceMissingAtURI formatted to JSON */
-nlohmann::json resourceMissingAtURI(const boost::urls::url_view& arg1);
+nlohmann::json resourceMissingAtURI(boost::urls::url_view arg1);
 
-void resourceMissingAtURI(crow::Response& res,
-                          const boost::urls::url_view& arg1);
+void resourceMissingAtURI(crow::Response& res, boost::urls::url_view arg1);
 
 /**
  * @brief Formats ActionParameterValueFormatError message into JSON
@@ -126,11 +125,10 @@ void unrecognizedRequestBody(crow::Response& res);
  * @param[in] arg2 Parameter of message that will replace %2 in its body.
  *
  * @returns Message ResourceAtUriUnauthorized formatted to JSON */
-nlohmann::json resourceAtUriUnauthorized(const boost::urls::url_view& arg1,
+nlohmann::json resourceAtUriUnauthorized(boost::urls::url_view arg1,
                                          std::string_view arg2);
 
-void resourceAtUriUnauthorized(crow::Response& res,
-                               const boost::urls::url_view& arg1,
+void resourceAtUriUnauthorized(crow::Response& res, boost::urls::url_view arg1,
                                std::string_view arg2);
 
 /**
@@ -276,10 +274,10 @@ void propertyValueOutOfRange(crow::Response& res, std::string_view arg1,
  * @param[in] arg1 Parameter of message that will replace %1 in its body.
  *
  * @returns Message ResourceAtUriInUnknownFormat formatted to JSON */
-nlohmann::json resourceAtUriInUnknownFormat(const boost::urls::url_view& arg1);
+nlohmann::json resourceAtUriInUnknownFormat(boost::urls::url_view arg1);
 
 void resourceAtUriInUnknownFormat(crow::Response& res,
-                                  const boost::urls::url_view& arg1);
+                                  boost::urls::url_view arg1);
 
 /**
  * @brief Formats ServiceDisabled message into JSON
@@ -386,10 +384,9 @@ void resourceTypeIncompatible(crow::Response& res, std::string_view arg1,
  * @param[in] arg2 Parameter of message that will replace %2 in its body.
  *
  * @returns Message ResetRequired formatted to JSON */
-nlohmann::json resetRequired(const boost::urls::url_view& arg1,
-                             std::string_view arg2);
+nlohmann::json resetRequired(boost::urls::url_view arg1, std::string_view arg2);
 
-void resetRequired(crow::Response& res, const boost::urls::url_view& arg1,
+void resetRequired(crow::Response& res, boost::urls::url_view arg1,
                    std::string_view arg2);
 
 /**
@@ -444,11 +441,11 @@ void propertyValueConflict(crow::Response& res, std::string_view arg1,
  * @returns Message PropertyValueResourceConflict to JSON */
 nlohmann::json propertyValueResourceConflict(std::string_view arg1,
                                              std::string_view arg2,
-                                             const boost::urls::url_view& arg3);
+                                             boost::urls::url_view arg3);
 
 void propertyValueResourceConflict(crow::Response& res, std::string_view arg1,
                                    std::string_view arg2,
-                                   const boost::urls::url_view& arg3);
+                                   boost::urls::url_view arg3);
 
 /**
  * @brief Formats PropertyValueExternalConflict message into JSON
@@ -525,10 +522,9 @@ void propertyValueExternalConflict(crow::Response& res, const std::string& arg1,
  * @param[in] arg1 Parameter of message that will replace %1 in its body.
  *
  * @returns Message ResourceCreationConflict formatted to JSON */
-nlohmann::json resourceCreationConflict(const boost::urls::url_view& arg1);
+nlohmann::json resourceCreationConflict(boost::urls::url_view arg1);
 
-void resourceCreationConflict(crow::Response& res,
-                              const boost::urls::url_view& arg1);
+void resourceCreationConflict(crow::Response& res, boost::urls::url_view arg1);
 
 /**
  * @brief Formats MaximumErrorsExceeded message into JSON
@@ -621,10 +617,10 @@ void resourceNotFound(crow::Response& res, std::string_view arg1,
  * @param[in] arg1 Parameter of message that will replace %1 in its body.
  *
  * @returns Message CouldNotEstablishConnection formatted to JSON */
-nlohmann::json couldNotEstablishConnection(const boost::urls::url_view& arg1);
+nlohmann::json couldNotEstablishConnection(boost::urls::url_view arg1);
 
 void couldNotEstablishConnection(crow::Response& res,
-                                 const boost::urls::url_view& arg1);
+                                 boost::urls::url_view arg1);
 
 /**
  * @brief Formats PropertyNotWritable message into JSON
@@ -703,11 +699,11 @@ void actionParameterNotSupported(crow::Response& res, std::string_view arg1,
  * @param[in] arg2 Parameter of message that will replace %2 in its body.
  *
  * @returns Message SourceDoesNotSupportProtocol formatted to JSON */
-nlohmann::json sourceDoesNotSupportProtocol(const boost::urls::url_view& arg1,
+nlohmann::json sourceDoesNotSupportProtocol(boost::urls::url_view arg1,
                                             std::string_view arg2);
 
 void sourceDoesNotSupportProtocol(crow::Response& res,
-                                  const boost::urls::url_view& arg1,
+                                  boost::urls::url_view arg1,
                                   std::string_view arg2);
 
 /**
@@ -739,9 +735,9 @@ void accountRemoved(crow::Response& res);
  * @param[in] arg1 Parameter of message that will replace %1 in its body.
  *
  * @returns Message AccessDenied formatted to JSON */
-nlohmann::json accessDenied(const boost::urls::url_view& arg1);
+nlohmann::json accessDenied(boost::urls::url_view arg1);
 
-void accessDenied(crow::Response& res, const boost::urls::url_view& arg1);
+void accessDenied(crow::Response& res, boost::urls::url_view arg1);
 
 /**
  * @brief Formats QueryNotSupported message into JSON
@@ -836,9 +832,9 @@ void noValidSession(crow::Response& res);
  * @param[in] arg1 Parameter of message that will replace %1 in its body.
  *
  * @returns Message InvalidObject formatted to JSON */
-nlohmann::json invalidObject(const boost::urls::url_view& arg1);
+nlohmann::json invalidObject(boost::urls::url_view arg1);
 
-void invalidObject(crow::Response& res, const boost::urls::url_view& arg1);
+void invalidObject(crow::Response& res, boost::urls::url_view arg1);
 
 /**
  * @brief Formats ResourceInStandby message into JSON
@@ -1058,10 +1054,9 @@ void queryParameterOutOfRange(crow::Response& res, std::string_view arg1,
  *
  * @returns Message PasswordChangeRequired formatted to JSON */
 
-nlohmann::json passwordChangeRequired(const boost::urls::url_view& arg1);
+nlohmann::json passwordChangeRequired(boost::urls::url_view arg1);
 
-void passwordChangeRequired(crow::Response& res,
-                            const boost::urls::url_view& arg1);
+void passwordChangeRequired(crow::Response& res, boost::urls::url_view arg1);
 
 /**
  * @brief Formats InvalidUpload message into JSON

--- a/redfish-core/include/event_service_manager.hpp
+++ b/redfish-core/include/event_service_manager.hpp
@@ -109,7 +109,7 @@ static const Message*
     return nullptr;
 }
 
-static const Message* formatMessage(const std::string_view& messageID)
+static const Message* formatMessage(std::string_view messageID)
 {
     // Redfish MessageIds are in the form
     // RegistryName.MajorVersion.MinorVersion.MessageKey, so parse it to find

--- a/redfish-core/include/privileges.hpp
+++ b/redfish-core/include/privileges.hpp
@@ -110,7 +110,7 @@ class Privileges
      * @return               None
      *
      */
-    bool setSinglePrivilege(const std::string_view privilege)
+    bool setSinglePrivilege(std::string_view privilege)
     {
         for (size_t searchIndex = 0; searchIndex < privilegeNames.size();
              searchIndex++)

--- a/redfish-core/include/query.hpp
+++ b/redfish-core/include/query.hpp
@@ -78,7 +78,8 @@ inline bool handleIfMatch(crow::App& app, const crow::Request& req,
     boost::system::error_code ec;
 
     // Try to GET the same resource
-    crow::Request newReq({boost::beast::http::verb::get, req.url, 11}, ec);
+    crow::Request newReq(
+        {boost::beast::http::verb::get, req.url().encoded_path(), 11}, ec);
 
     if (ec)
     {
@@ -127,7 +128,7 @@ inline bool handleIfMatch(crow::App& app, const crow::Request& req,
     asyncResp->res.addHeader("OData-Version", "4.0");
 
     std::optional<query_param::Query> queryOpt =
-        query_param::parseParameters(req.urlView.params(), asyncResp->res);
+        query_param::parseParameters(req.url().params(), asyncResp->res);
     if (queryOpt == std::nullopt)
     {
         return false;

--- a/redfish-core/include/redfish_aggregator.hpp
+++ b/redfish-core/include/redfish_aggregator.hpp
@@ -1,11 +1,12 @@
 #pragma once
 
-#include <aggregation_utils.hpp>
+#include "aggregation_utils.hpp"
+#include "dbus_utility.hpp"
+#include "error_messages.hpp"
+#include "http_client.hpp"
+#include "http_connection.hpp"
+
 #include <boost/algorithm/string/predicate.hpp>
-#include <dbus_utility.hpp>
-#include <error_messages.hpp>
-#include <http_client.hpp>
-#include <http_connection.hpp>
 
 #include <array>
 
@@ -486,7 +487,7 @@ class RedfishAggregator
         }
 
         // We didn't recognize the prefix and need to return a 404
-        std::string_view nameStr = req.urlView.segments().back();
+        std::string nameStr = req.url().segments().back();
         messages::resourceNotFound(asyncResp->res, "", nameStr);
     }
 
@@ -518,7 +519,7 @@ class RedfishAggregator
             // don't need to write an error code
             if (isCollection == AggregationType::Resource)
             {
-                std::string_view nameStr = sharedReq->urlView.segments().back();
+                std::string nameStr = sharedReq->url().segments().back();
                 messages::resourceNotFound(asyncResp->res, "", nameStr);
             }
             return;
@@ -540,8 +541,7 @@ class RedfishAggregator
             return;
         }
 
-        const boost::urls::segments_view urlSegments =
-            thisReq.urlView.segments();
+        const boost::urls::segments_view urlSegments = thisReq.url().segments();
         boost::urls::url currentUrl("/");
         boost::urls::segments_view::iterator it = urlSegments.begin();
         const boost::urls::segments_view::const_iterator end =
@@ -879,7 +879,7 @@ class RedfishAggregator
     {
         using crow::utility::OrMorePaths;
         using crow::utility::readUrlSegments;
-        const boost::urls::url_view url = thisReq.urlView;
+        const boost::urls::url_view url = thisReq.url();
         // UpdateService is the only top level resource that is not a Collection
         if (readUrlSegments(url, "redfish", "v1", "UpdateService"))
         {

--- a/redfish-core/include/redfish_aggregator.hpp
+++ b/redfish-core/include/redfish_aggregator.hpp
@@ -607,7 +607,7 @@ class RedfishAggregator
         crow::HttpClient::getInstance().sendDataWithCallback(
             data, id, std::string(sat->second.host()),
             sat->second.port_number(), targetURI, false /*useSSL*/,
-            thisReq.fields, thisReq.method(), retryPolicyName, cb);
+            thisReq.fields(), thisReq.method(), retryPolicyName, cb);
     }
 
     // Forward a request for a collection URI to each known satellite BMC
@@ -626,7 +626,7 @@ class RedfishAggregator
             crow::HttpClient::getInstance().sendDataWithCallback(
                 data, id, std::string(sat.second.host()),
                 sat.second.port_number(), targetURI, false /*useSSL*/,
-                thisReq.fields, thisReq.method(), retryPolicyName, cb);
+                thisReq.fields(), thisReq.method(), retryPolicyName, cb);
         }
     }
 

--- a/redfish-core/include/redfish_aggregator.hpp
+++ b/redfish-core/include/redfish_aggregator.hpp
@@ -43,7 +43,7 @@ constexpr std::array nonUriProperties{
 // Determines if the passed property contains a URI.  Those property names
 // either end with a case-insensitive version of "uri" or are specifically
 // defined in the above array.
-inline bool isPropertyUri(const std::string_view propertyName)
+inline bool isPropertyUri(std::string_view propertyName)
 {
     return boost::iends_with(propertyName, "uri") ||
            std::binary_search(nonUriProperties.begin(), nonUriProperties.end(),

--- a/redfish-core/include/registries.hpp
+++ b/redfish-core/include/registries.hpp
@@ -61,7 +61,7 @@ inline std::string
 {
     std::string ret;
     size_t reserve = msg.size();
-    for (const std::string_view& arg : messageArgs)
+    for (std::string_view arg : messageArgs)
     {
         reserve += arg.size();
     }
@@ -102,7 +102,7 @@ inline nlohmann::json::object_t
     std::string msg =
         redfish::registries::fillMessageArgs(args, entry.second.message);
     nlohmann::json jArgs = nlohmann::json::array();
-    for (const std::string_view arg : args)
+    for (std::string_view arg : args)
     {
         jArgs.push_back(arg);
     }

--- a/redfish-core/include/resource_messages.hpp
+++ b/redfish-core/include/resource_messages.hpp
@@ -10,7 +10,7 @@ namespace messages
 
 inline nlohmann::json
     getLogResourceEvent(redfish::registries::resource_event::Index name,
-                        std::span<const std::string_view> args)
+                        std::span<std::string_view> args)
 {
     size_t index = static_cast<size_t>(name);
     if (index >= redfish::registries::resource_event::registry.size())

--- a/redfish-core/lib/account_service.hpp
+++ b/redfish-core/lib/account_service.hpp
@@ -2581,7 +2581,7 @@ inline void
             else if (acf && (username != "service"))
             {
                 messages::resourceAtUriUnauthorized(
-                    asyncResp->res, req.urlView,
+                    asyncResp->res, req.url(),
                     "ACF properties access not allowed by non service "
                     "user");
             }

--- a/redfish-core/lib/certificate_service.hpp
+++ b/redfish-core/lib/certificate_service.hpp
@@ -145,7 +145,7 @@ class CertificateFile
  * @return None
  */
 static void updateCertIssuerOrSubject(nlohmann::json& out,
-                                      const std::string_view value)
+                                      std::string_view value)
 {
     // example: O=openbmc-project.xyz,CN=localhost
     std::string_view::iterator i = value.begin();
@@ -160,16 +160,14 @@ static void updateCertIssuerOrSubject(nlohmann::json& out,
         {
             break;
         }
-        const std::string_view key(tokenBegin,
-                                   static_cast<size_t>(i - tokenBegin));
+        std::string_view key(tokenBegin, static_cast<size_t>(i - tokenBegin));
         ++i;
         tokenBegin = i;
         while (i != value.end() && *i != ',')
         {
             ++i;
         }
-        const std::string_view val(tokenBegin,
-                                   static_cast<size_t>(i - tokenBegin));
+        std::string_view val(tokenBegin, static_cast<size_t>(i - tokenBegin));
         if (key == "L")
         {
             out["City"] = val;

--- a/redfish-core/lib/certificate_service.hpp
+++ b/redfish-core/lib/certificate_service.hpp
@@ -51,12 +51,12 @@ inline std::string getCertificateFromReqBody(
     const std::shared_ptr<bmcweb::AsyncResp>& asyncResp,
     const crow::Request& req)
 {
-    nlohmann::json reqJson = nlohmann::json::parse(req.body, nullptr, false);
+    nlohmann::json reqJson = nlohmann::json::parse(req.body(), nullptr, false);
 
     if (reqJson.is_discarded())
     {
         // We did not receive JSON request, proceed as it is RAW data
-        return req.body;
+        return req.body();
     }
 
     std::string certificate;

--- a/redfish-core/lib/log_services.hpp
+++ b/redfish-core/lib/log_services.hpp
@@ -120,7 +120,7 @@ static const Message*
     return nullptr;
 }
 
-static const Message* getMessage(const std::string_view& messageID)
+static const Message* getMessage(std::string_view messageID)
 {
     // Redfish MessageIds are in the form
     // RegistryName.MajorVersion.MinorVersion.MessageKey, so parse it to find
@@ -182,7 +182,7 @@ inline std::string translateSeverityDbusToRedfish(const std::string& s)
 }
 
 inline static int getJournalMetadata(sd_journal* journal,
-                                     const std::string_view& field,
+                                     std::string_view field,
                                      std::string_view& contents)
 {
     const char* data = nullptr;
@@ -218,8 +218,8 @@ inline std::optional<bool> getProviderNotifyAction(const std::string& notify)
 }
 
 inline static int getJournalMetadata(sd_journal* journal,
-                                     const std::string_view& field,
-                                     const int& base, long int& contents)
+                                     std::string_view field, const int& base,
+                                     long int& contents)
 {
     int ret = 0;
     std::string_view metadata;
@@ -4638,8 +4638,7 @@ enum class OEMDiagnosticType
     invalid,
 };
 
-inline OEMDiagnosticType
-    getOEMDiagnosticType(const std::string_view& oemDiagStr)
+inline OEMDiagnosticType getOEMDiagnosticType(std::string_view oemDiagStr)
 {
     if (oemDiagStr == "OnDemand")
     {

--- a/redfish-core/lib/log_services.hpp
+++ b/redfish-core/lib/log_services.hpp
@@ -4577,8 +4577,8 @@ inline void requestRoutesCrashdumpFile(App& app)
         }
 
         auto getStoredLogCallback =
-            [asyncResp, logID, fileName, url(boost::urls::url(req.urlView))](
-                const boost::system::error_code ec,
+            [asyncResp, logID, fileName, url(boost::urls::url(req.url()))](
+                const boost::system::error_code& ec,
                 const std::vector<
                     std::pair<std::string, dbus::utility::DbusVariantType>>&
                     resp) {

--- a/redfish-core/lib/redfish_sessions.hpp
+++ b/redfish-core/lib/redfish_sessions.hpp
@@ -220,7 +220,7 @@ inline void handleSessionCollectionPost(
     bool isConfigureSelfOnly = pamrc == PAM_NEW_AUTHTOK_REQD;
     if ((pamrc != PAM_SUCCESS) && !isConfigureSelfOnly)
     {
-        messages::resourceAtUriUnauthorized(asyncResp->res, req.urlView,
+        messages::resourceAtUriUnauthorized(asyncResp->res, req.url(),
                                             "Invalid username or password");
         return;
     }

--- a/redfish-core/lib/redfish_v1.hpp
+++ b/redfish-core/lib/redfish_v1.hpp
@@ -84,7 +84,7 @@ inline void
     json["Name"] = "JsonSchemaFile Collection";
     json["Description"] = "Collection of JsonSchemaFiles";
     nlohmann::json::array_t members;
-    for (const std::string_view schema : schemas)
+    for (std::string_view schema : schemas)
     {
         nlohmann::json::object_t member;
         member["@odata.id"] = crow::utility::urlFromPieces(

--- a/redfish-core/lib/redfish_v1.hpp
+++ b/redfish-core/lib/redfish_v1.hpp
@@ -38,7 +38,7 @@ inline void redfish404(App& app, const crow::Request& req,
 
     BMCWEB_LOG_ERROR << "404 on path " << path;
 
-    std::string name = req.urlView.segments().back();
+    std::string name = req.url().segments().back();
     // Note, if we hit the wildcard route, we don't know the "type" the user was
     // actually requesting, but giving them a return with an empty string is
     // still better than nothing.

--- a/redfish-core/lib/task.hpp
+++ b/redfish-core/lib/task.hpp
@@ -56,7 +56,7 @@ struct Payload
             jsonBody = nullptr;
         }
 
-        for (const auto& field : req.fields)
+        for (const auto& field : req.fields())
         {
             if (std::find(headerWhitelist.begin(), headerWhitelist.end(),
                           field.name()) == headerWhitelist.end())

--- a/redfish-core/lib/task.hpp
+++ b/redfish-core/lib/task.hpp
@@ -42,7 +42,7 @@ struct Payload
     explicit Payload(const crow::Request& req) :
         targetUri(req.url), httpOperation(req.methodString()),
         httpHeaders(nlohmann::json::array()),
-        jsonBody(nlohmann::json::parse(req.body, nullptr, false))
+        jsonBody(nlohmann::json::parse(req.body(), nullptr, false))
     {
         using field_ns = boost::beast::http::field;
         constexpr const std::array<boost::beast::http::field, 7>

--- a/redfish-core/lib/task.hpp
+++ b/redfish-core/lib/task.hpp
@@ -188,7 +188,7 @@ struct TaskData : std::enable_shared_from_this<TaskData>
         });
     }
 
-    static void sendTaskEvent(const std::string_view state, size_t index)
+    static void sendTaskEvent(std::string_view state, size_t index)
     {
         std::string origin =
             "/redfish/v1/TaskService/Tasks/" + std::to_string(index);

--- a/redfish-core/lib/task.hpp
+++ b/redfish-core/lib/task.hpp
@@ -40,9 +40,8 @@ constexpr bool completed = true;
 struct Payload
 {
     explicit Payload(const crow::Request& req) :
-        targetUri(req.url), httpOperation(req.methodString()),
-        httpHeaders(nlohmann::json::array()),
-        jsonBody(nlohmann::json::parse(req.body(), nullptr, false))
+        targetUri(req.url().encoded_path()), httpOperation(req.methodString()),
+        httpHeaders(nlohmann::json::array())
     {
         using field_ns = boost::beast::http::field;
         constexpr const std::array<boost::beast::http::field, 7>

--- a/redfish-core/lib/update_service.hpp
+++ b/redfish-core/lib/update_service.hpp
@@ -634,7 +634,7 @@ inline void
     BMCWEB_LOG_DEBUG << "Writing file to " << filepath;
     std::ofstream out(filepath, std::ofstream::out | std::ofstream::binary |
                                     std::ofstream::trunc);
-    out << req.body;
+    out << req.body();
     out.close();
     BMCWEB_LOG_DEBUG << "file upload complete!!";
 }

--- a/redfish-core/lib/virtual_media.hpp
+++ b/redfish-core/lib/virtual_media.hpp
@@ -292,7 +292,7 @@ enum class TransferProtocol
  *
  */
 inline std::optional<TransferProtocol>
-    getTransferProtocolFromUri(const boost::urls::url_view& imageUri)
+    getTransferProtocolFromUri(boost::urls::url_view imageUri)
 {
     std::string_view scheme = imageUri.scheme();
     if (scheme == "smb")

--- a/redfish-core/src/error_messages.cpp
+++ b/redfish-core/src/error_messages.cpp
@@ -203,14 +203,13 @@ void malformedJSON(crow::Response& res)
  * See header file for more information
  * @endinternal
  */
-nlohmann::json resourceMissingAtURI(const boost::urls::url_view& arg1)
+nlohmann::json resourceMissingAtURI(boost::urls::url_view arg1)
 {
     std::array<std::string_view, 1> args{arg1.buffer()};
     return getLog(redfish::registries::base::Index::resourceMissingAtURI, args);
 }
 
-void resourceMissingAtURI(crow::Response& res,
-                          const boost::urls::url_view& arg1)
+void resourceMissingAtURI(crow::Response& res, boost::urls::url_view arg1)
 {
     res.result(boost::beast::http::status::bad_request);
     addMessageToErrorJson(res.jsonValue, resourceMissingAtURI(arg1));
@@ -288,15 +287,14 @@ void unrecognizedRequestBody(crow::Response& res)
  * See header file for more information
  * @endinternal
  */
-nlohmann::json resourceAtUriUnauthorized(const boost::urls::url_view& arg1,
+nlohmann::json resourceAtUriUnauthorized(boost::urls::url_view arg1,
                                          std::string_view arg2)
 {
     return getLog(redfish::registries::base::Index::resourceAtUriUnauthorized,
                   std::to_array<std::string_view>({arg1.buffer(), arg2}));
 }
 
-void resourceAtUriUnauthorized(crow::Response& res,
-                               const boost::urls::url_view& arg1,
+void resourceAtUriUnauthorized(crow::Response& res, boost::urls::url_view arg1,
                                std::string_view arg2)
 {
     res.result(boost::beast::http::status::unauthorized);
@@ -519,7 +517,7 @@ void propertyValueOutOfRange(crow::Response& res, std::string_view arg1,
  * See header file for more information
  * @endinternal
  */
-nlohmann::json resourceAtUriInUnknownFormat(const boost::urls::url_view& arg1)
+nlohmann::json resourceAtUriInUnknownFormat(boost::urls::url_view arg1)
 {
     return getLog(
         redfish::registries::base::Index::resourceAtUriInUnknownFormat,
@@ -527,7 +525,7 @@ nlohmann::json resourceAtUriInUnknownFormat(const boost::urls::url_view& arg1)
 }
 
 void resourceAtUriInUnknownFormat(crow::Response& res,
-                                  const boost::urls::url_view& arg1)
+                                  boost::urls::url_view arg1)
 {
     res.result(boost::beast::http::status::bad_request);
     addMessageToErrorJson(res.jsonValue, resourceAtUriInUnknownFormat(arg1));
@@ -694,14 +692,13 @@ void resourceTypeIncompatible(crow::Response& res, std::string_view arg1,
  * See header file for more information
  * @endinternal
  */
-nlohmann::json resetRequired(const boost::urls::url_view& arg1,
-                             std::string_view arg2)
+nlohmann::json resetRequired(boost::urls::url_view arg1, std::string_view arg2)
 {
     return getLog(redfish::registries::base::Index::resetRequired,
                   std::to_array<std::string_view>({arg1.buffer(), arg2}));
 }
 
-void resetRequired(crow::Response& res, const boost::urls::url_view& arg1,
+void resetRequired(crow::Response& res, boost::urls::url_view arg1,
                    std::string_view arg2)
 {
     res.result(boost::beast::http::status::bad_request);
@@ -777,7 +774,7 @@ void propertyValueConflict(crow::Response& res, std::string_view arg1,
  */
 nlohmann::json propertyValueResourceConflict(std::string_view arg1,
                                              std::string_view arg2,
-                                             const boost::urls::url_view& arg3)
+                                             boost::urls::url_view arg3)
 {
     return getLog(
         redfish::registries::base::Index::propertyValueResourceConflict,
@@ -786,7 +783,7 @@ nlohmann::json propertyValueResourceConflict(std::string_view arg1,
 
 void propertyValueResourceConflict(crow::Response& res, std::string_view arg1,
                                    std::string_view arg2,
-                                   const boost::urls::url_view& arg3)
+                                   boost::urls::url_view arg3)
 {
     res.result(boost::beast::http::status::conflict);
     addMessageToErrorJson(res.jsonValue,
@@ -908,14 +905,13 @@ void propertyValueExternalConflict(crow::Response& res, const std::string& arg1,
  * See header file for more information
  * @endinternal
  */
-nlohmann::json resourceCreationConflict(const boost::urls::url_view& arg1)
+nlohmann::json resourceCreationConflict(boost::urls::url_view arg1)
 {
     return getLog(redfish::registries::base::Index::resourceCreationConflict,
                   std::to_array<std::string_view>({arg1.buffer()}));
 }
 
-void resourceCreationConflict(crow::Response& res,
-                              const boost::urls::url_view& arg1)
+void resourceCreationConflict(crow::Response& res, boost::urls::url_view arg1)
 {
     res.result(boost::beast::http::status::bad_request);
     addMessageToErrorJson(res.jsonValue, resourceCreationConflict(arg1));
@@ -1060,14 +1056,14 @@ void resourceNotFound(crow::Response& res, std::string_view arg1,
  * See header file for more information
  * @endinternal
  */
-nlohmann::json couldNotEstablishConnection(const boost::urls::url_view& arg1)
+nlohmann::json couldNotEstablishConnection(boost::urls::url_view arg1)
 {
     return getLog(redfish::registries::base::Index::couldNotEstablishConnection,
                   std::to_array<std::string_view>({arg1.buffer()}));
 }
 
 void couldNotEstablishConnection(crow::Response& res,
-                                 const boost::urls::url_view& arg1)
+                                 boost::urls::url_view arg1)
 {
     res.result(boost::beast::http::status::not_found);
     addMessageToErrorJson(res.jsonValue, couldNotEstablishConnection(arg1));
@@ -1184,7 +1180,7 @@ void actionParameterNotSupported(crow::Response& res, std::string_view arg1,
  * See header file for more information
  * @endinternal
  */
-nlohmann::json sourceDoesNotSupportProtocol(const boost::urls::url_view& arg1,
+nlohmann::json sourceDoesNotSupportProtocol(boost::urls::url_view arg1,
                                             std::string_view arg2)
 {
     return getLog(
@@ -1193,7 +1189,7 @@ nlohmann::json sourceDoesNotSupportProtocol(const boost::urls::url_view& arg1,
 }
 
 void sourceDoesNotSupportProtocol(crow::Response& res,
-                                  const boost::urls::url_view& arg1,
+                                  boost::urls::url_view arg1,
                                   std::string_view arg2)
 {
     res.result(boost::beast::http::status::bad_request);
@@ -1245,13 +1241,13 @@ void accountRemoved(crow::Response& res)
  * See header file for more information
  * @endinternal
  */
-nlohmann::json accessDenied(const boost::urls::url_view& arg1)
+nlohmann::json accessDenied(boost::urls::url_view arg1)
 {
     return getLog(redfish::registries::base::Index::accessDenied,
                   std::to_array<std::string_view>({arg1.buffer()}));
 }
 
-void accessDenied(crow::Response& res, const boost::urls::url_view& arg1)
+void accessDenied(crow::Response& res, boost::urls::url_view arg1)
 {
     res.result(boost::beast::http::status::forbidden);
     addMessageToErrorJson(res.jsonValue, accessDenied(arg1));
@@ -1412,13 +1408,13 @@ void noValidSession(crow::Response& res)
  * See header file for more information
  * @endinternal
  */
-nlohmann::json invalidObject(const boost::urls::url_view& arg1)
+nlohmann::json invalidObject(boost::urls::url_view arg1)
 {
     return getLog(redfish::registries::base::Index::invalidObject,
                   std::to_array<std::string_view>({arg1.buffer()}));
 }
 
-void invalidObject(crow::Response& res, const boost::urls::url_view& arg1)
+void invalidObject(crow::Response& res, boost::urls::url_view arg1)
 {
     res.result(boost::beast::http::status::bad_request);
     addMessageToErrorJson(res.jsonValue, invalidObject(arg1));
@@ -1758,7 +1754,7 @@ void queryParameterOutOfRange(crow::Response& res, std::string_view arg1,
                           queryParameterOutOfRange(arg1, arg2, arg3));
 }
 
-nlohmann::json passwordChangeRequired(const boost::urls::url_view& arg1)
+nlohmann::json passwordChangeRequired(boost::urls::url_view arg1)
 {
     return getLog(redfish::registries::base::Index::passwordChangeRequired,
                   std::to_array<std::string_view>({arg1.buffer()}));
@@ -1771,8 +1767,7 @@ nlohmann::json passwordChangeRequired(const boost::urls::url_view& arg1)
  * See header file for more information
  * @endinternal
  */
-void passwordChangeRequired(crow::Response& res,
-                            const boost::urls::url_view& arg1)
+void passwordChangeRequired(crow::Response& res, boost::urls::url_view arg1)
 {
     messages::addMessageToJsonRoot(res.jsonValue, passwordChangeRequired(arg1));
 }

--- a/redfish-core/src/utils/json_utils.cpp
+++ b/redfish-core/src/utils/json_utils.cpp
@@ -24,7 +24,7 @@ namespace json_util
 bool processJsonFromRequest(crow::Response& res, const crow::Request& req,
                             nlohmann::json& reqJson)
 {
-    reqJson = nlohmann::json::parse(req.body, nullptr, false);
+    reqJson = nlohmann::json::parse(req.body(), nullptr, false);
 
     if (reqJson.is_discarded())
     {

--- a/test/http/router_test.cpp
+++ b/test/http/router_test.cpp
@@ -36,7 +36,7 @@ TEST(Router, AllowHeader)
     Router router;
     std::error_code ec;
 
-    constexpr const std::string_view url = "/foo";
+    constexpr std::string_view url = "/foo";
 
     Request req{{boost::beast::http::verb::get, url, 11}, ec};
 
@@ -75,7 +75,7 @@ TEST(Router, 404)
     Router router;
     std::error_code ec;
 
-    constexpr const std::string_view url = "/foo/bar";
+    constexpr std::string_view url = "/foo/bar";
 
     Request req{{boost::beast::http::verb::get, url, 11}, ec};
 
@@ -105,7 +105,7 @@ TEST(Router, 405)
     Router router;
     std::error_code ec;
 
-    constexpr const std::string_view url = "/foo/bar";
+    constexpr std::string_view url = "/foo/bar";
 
     Request req{{boost::beast::http::verb::patch, url, 11}, ec};
 

--- a/test/redfish-core/include/utils/json_utils_test.cpp
+++ b/test/redfish-core/include/utils/json_utils_test.cpp
@@ -271,9 +271,10 @@ TEST(ReadJsonPatch, ValidElementsReturnsTrueResponseOkValuesUnpackedCorrectly)
 {
     crow::Response res;
     std::error_code ec;
-    crow::Request req({}, ec);
+    crow::Request req("{\"integer\": 1}", ec);
+
     // Ignore errors intentionally
-    req.body = "{\"integer\": 1}";
+    req.req.set(boost::beast::http::field::content_type, "application/json");
 
     int64_t integer = 0;
     ASSERT_TRUE(readJsonPatch(req, res, "integer", integer));
@@ -286,9 +287,8 @@ TEST(ReadJsonPatch, EmptyObjectReturnsFalseResponseBadRequest)
 {
     crow::Response res;
     std::error_code ec;
-    crow::Request req({}, ec);
+    crow::Request req("{}", ec);
     // Ignore errors intentionally
-    req.body = "{}";
 
     std::optional<int64_t> integer = 0;
     ASSERT_FALSE(readJsonPatch(req, res, "integer", integer));
@@ -300,9 +300,9 @@ TEST(ReadJsonPatch, OdataIgnored)
 {
     crow::Response res;
     std::error_code ec;
-    crow::Request req({}, ec);
+    crow::Request req(R"({"@odata.etag": "etag", "integer": 1})", ec);
+    req.req.set(boost::beast::http::field::content_type, "application/json");
     // Ignore errors intentionally
-    req.body = R"({"@odata.etag": "etag", "integer": 1})";
 
     std::optional<int64_t> integer = 0;
     ASSERT_TRUE(readJsonPatch(req, res, "integer", integer));
@@ -315,9 +315,8 @@ TEST(ReadJsonPatch, OnlyOdataGivesNoOperation)
 {
     crow::Response res;
     std::error_code ec;
-    crow::Request req({}, ec);
+    crow::Request req(R"({"@odata.etag": "etag"})", ec);
     // Ignore errors intentionally
-    req.body = R"({"@odata.etag": "etag"})";
 
     std::optional<int64_t> integer = 0;
     ASSERT_FALSE(readJsonPatch(req, res, "integer", integer));
@@ -329,9 +328,9 @@ TEST(ReadJsonAction, ValidElementsReturnsTrueResponseOkValuesUnpackedCorrectly)
 {
     crow::Response res;
     std::error_code ec;
-    crow::Request req({}, ec);
+    crow::Request req("{\"integer\": 1}", ec);
+    req.req.set(boost::beast::http::field::content_type, "application/json");
     // Ignore errors intentionally
-    req.body = "{\"integer\": 1}";
 
     int64_t integer = 0;
     ASSERT_TRUE(readJsonAction(req, res, "integer", integer));
@@ -344,9 +343,9 @@ TEST(ReadJsonAction, EmptyObjectReturnsTrueResponseOk)
 {
     crow::Response res;
     std::error_code ec;
-    crow::Request req({}, ec);
+    crow::Request req({"{}"}, ec);
+    req.req.set(boost::beast::http::field::content_type, "application/json");
     // Ignore errors intentionally
-    req.body = "{}";
 
     std::optional<int64_t> integer = 0;
     ASSERT_TRUE(readJsonAction(req, res, "integer", integer));


### PR DESCRIPTION
Various places could be enhanced for code & memory safety by using by-value parameter passing instead of by-reference, and also follows up the cpp standards.

This is also to sync up with upstream so that the further code changes and upstreaming could be more easier and smoother.

The following upstream commits are incorporated

- Pass string views by value
  https://gerrit.openbmc.org/c/openbmc/bmcweb/+/61012

- Remove fields member from Request
  https://gerrit.openbmc.org/c/openbmc/bmcweb/+/61010

- Remove body member from Request
  https://gerrit.openbmc.org/c/openbmc/bmcweb/+/61011

- Make url by value in Request
  https://gerrit.openbmc.org/c/openbmc/bmcweb/+/61410

- Take url views by value
  https://gerrit.openbmc.org/c/openbmc/bmcweb/+/61495

Tested:
   Redfish validator passed
   Several GUI interfaces are tried.