### PR TITLE
Add pretty name for fabric adapters

### DIFF
--- a/redfish-core/lib/fabric_adapters.hpp
+++ b/redfish-core/lib/fabric_adapters.hpp
@@ -269,6 +269,8 @@ inline void getValidFabricAdapterPath(
                 fabric_util::buildFabricUniquePath(adapterPath);
             if (fabric_util::checkFabricAdapterId(adapterId, adapterUniq))
             {
+                nlohmann::json::json_pointer ptr("/Name");
+                name_util::getPrettyName(aResp, adapterPath, serviceMap, ptr);
                 callback(adapterPath, serviceMap.begin()->first,
                          serviceMap.begin()->second);
                 return;


### PR DESCRIPTION
The commit implement changes to make use of util function to populate name for fabric adapters.

Validator was executed and no new error was found.

Test output:
{
  "@odata.id": "/redfish/v1/Systems/system/FabricAdapters/motherboard-pcieslot0-pcie_card0",
  "@odata.type": "#FabricAdapter.v1_4_0.FabricAdapter",
  "Id": "motherboard-pcieslot0-pcie_card0",
  "Links": {
    "PCIeDevices": [
      {
        "@odata.id": "/redfish/v1/Systems/system/PCIeDevices/chassis_motherboard_pcieslot0_pcie_card0"
      }
    ],
    "PCIeDevices@odata.count": 1
  },
  "Location": {
    "PartLocation": {
      "ServiceLabel": "U78DA.ND0.       -P0-C0"
    }
  },
  "LocationIndicatorActive": null,
  "Name": "PCIe Card",
  "Ports": {
    "@odata.id": "/redfish/v1/Systems/system/FabricAdapters/motherboard-pcieslot0-pcie_card0/Ports"
  },
  "Status": {
    "Health": "OK",
    "State": "Absent"
  }
}
Signed-off-by: Sunny Srivastava <sunnsr25@in.ibm.com>