### PR TITLE
1050: Fix GET PCIeDevice to io drawer module (e.g. MEX)

### DIFF
--- a/redfish-core/lib/pcie.hpp
+++ b/redfish-core/lib/pcie.hpp
@@ -108,8 +108,11 @@ inline void getPcieDevicePathAndService(
             return;
         }
 
+        // Find DBus object to get its serviceName
+        std::array<const char*, 1> interfaces = {pcieDeviceInterface};
+
         dbus::utility::getDbusObject(
-            pcieDevicePath, {},
+            pcieDevicePath, interfaces,
             [pcieDevice, pcieDevicePath, asyncResp,
              callback{callback}](const boost::system::error_code& ec1,
                                  const dbus::utility::MapperGetObject& object) {


### PR DESCRIPTION
PCIe hardware topology fails to load io module PCIeDevices info like:

```
curl -k  -v 'https://${BMC}/redfish/v1/Systems/system/PCIeDevices?$expand=.($levels=2)'
curl -k  -X GET  https://${bmc}/redfish/v1/Systems/system/PCIeDevices/system_chassis15363_logical_slot1_io_module1
```

It is due to the missing interface specification to obtain getDbusObject().
Upstream is communicated in  https://gerrit.openbmc.org/c/openbmc/bmcweb/+/61625

Tested:
  - Redfish validator passed
  - Run PCIe hardware topology on GUI and monitor Web "inspect" Network activities

The error output is like:

```
curl -k  -X GET  https://${bmc}/redfish/v1/Systems/system/PCIeDevices/system_chassis15363_logical_slot1_io_module1
{
  "error": {
    "@Message.ExtendedInfo": [
      {
        "@odata.type": "#Message.v1_1_1.Message",
        "Message": "The requested resource of type PCIeDevice named 'system_chassis15363_logical_slot1_io_module1' was not found.",
        "MessageArgs": [
          "PCIeDevice",
          "system_chassis15363_logical_slot1_io_module1"
        ],
        "MessageId": "Base.1.13.0.ResourceNotFound",
        "MessageSeverity": "Critical",
        "Resolution": "Provide a valid resource identifier and resubmit the request."
      }
    ],
    "code": "Base.1.13.0.ResourceNotFound",
    "message": "The requested resource of type PCIeDevice named 'system_chassis15363_logical_slot1_io_module1' was not found."
  }
}
```
