### PR TITLE
1050: Redfish check snmpTrap port

### DIFF
--- a/http/utility.hpp
+++ b/http/utility.hpp
@@ -10,6 +10,7 @@
 #include <nlohmann/json.hpp>
 
 #include <array>
+#include <charconv>
 #include <chrono>
 #include <cstddef>
 #include <cstdint>
@@ -811,6 +812,18 @@ inline bool validateAndSplitUrl(std::string_view destUrl, std::string& urlProto,
         return false;
     }
 
+    if (urlProto == "snmp")
+    {
+        uint16_t portTmp = 0;
+        // Check the port
+        auto ret = std::from_chars(
+            url.value().port().data(),
+            url.value().port().data() + url.value().port().size(), portTmp);
+        if (ret.ec != std::errc())
+        {
+            return false;
+        }
+    }
     port = setPortDefaults(url.value());
 
     host = url->encoded_host();


### PR DESCRIPTION
The upstream rule is to set the default value if the port is not compliant.

IBM requires an error to be returned if the port is not compliant. 
ref: https://github.com/ibm-openbmc/dev/issues/3626

Test:
```
curl -k -H "X-Auth-Token: $token" -X POST https://${bmc}/redfish/v1/EventService/Subscriptions -d '{"Destination":"snmp://9.41.166.76:65536", "SubscriptionType":"SNMPTrap", "Protocol":"SNMPv2c"}'
{
  "Destination@Message.ExtendedInfo": [
    {
      "@odata.type": "#Message.v1_1_1.Message",
      "Message": "The value 'snmp://9.41.166.76:65536' for the property Destination is of a different format than the property can accept.",
      "MessageArgs": [
        "snmp://9.41.166.76:65536",
        "Destination"
      ],
      "MessageId": "Base.1.13.0.PropertyValueFormatError",
      "MessageSeverity": "Warning",
      "Resolution": "Correct the value for the property in the request body and resubmit the request if the operation failed."
    }
  ]
}
```