### PR TITLE
Revert commits to fix bmcweb crash hang

### DIFF
--- a/http/app.hpp
+++ b/http/app.hpp
@@ -58,7 +58,7 @@ class App
     App& operator=(const App&&) = delete;
 
     template <typename Adaptor>
-    void handleUpgrade(Request& req,
+    void handleUpgrade(const Request& req,
                        const std::shared_ptr<bmcweb::AsyncResp>& asyncResp,
                        Adaptor&& adaptor)
     {

--- a/http/app.hpp
+++ b/http/app.hpp
@@ -58,11 +58,9 @@ class App
     App& operator=(const App&&) = delete;
 
     template <typename Adaptor>
-    void handleUpgrade(const Request& req,
-                       const std::shared_ptr<bmcweb::AsyncResp>& asyncResp,
-                       Adaptor&& adaptor)
+    void handleUpgrade(const Request& req, Response& res, Adaptor&& adaptor)
     {
-        router.handleUpgrade(req, asyncResp, std::forward<Adaptor>(adaptor));
+        router.handleUpgrade(req, res, std::forward<Adaptor>(adaptor));
     }
 
     void handle(Request& req,

--- a/http/http_connection.hpp
+++ b/http/http_connection.hpp
@@ -384,21 +384,10 @@ class Connection :
                 thisReq.getHeaderValue(boost::beast::http::field::upgrade),
                 "websocket"))
         {
-            asyncResp->res.setCompleteRequestHandler(
-                [self(shared_from_this())](crow::Response& thisRes) {
-                if (thisRes.result() != boost::beast::http::status::ok)
-                {
-                    // When any error occurs before handle upgradation,
-                    // the result in response will be set to respective
-                    // error. By default the Result will be OK (200),
-                    // which implies successful handle upgrade. Response
-                    // needs to be sent over this connection only on
-                    // failure.
-                    self->completeRequest(thisRes);
-                    return;
-                }
-            });
-            handler->handleUpgrade(thisReq, asyncResp, std::move(adaptor));
+            handler->handleUpgrade(thisReq, res, std::move(adaptor));
+            // delete lambda with self shared_ptr
+            // to enable connection destruction
+            asyncResp->res.setCompleteRequestHandler(nullptr);
             return;
         }
 
@@ -407,7 +396,7 @@ class Connection :
             boost::ends_with(url, "/attachment"))
         {
             BMCWEB_LOG_DEBUG << "upgrade stream connection";
-            handler->handleUpgrade(*req, asyncResp, std::move(adaptor));
+            handler->handleUpgrade(*req, res, std::move(adaptor));
             // delete lambda with self shared_ptr
             // to enable connection destruction
             res.completeRequestHandler = nullptr;


### PR DESCRIPTION
This reverts this PR: 
https://github.com/ibm-openbmc/bmcweb/pull/658

This PR was the only bmcweb PR to go into 2.22 
https://github.ibm.com/openbmc/release-notes/wiki/fw1050.00-2.22

2.22 is were we first saw bmcweb hanging and core dumping when shut down. Defects are: 
487666
487798
487741

The root cause can be investigated more but for now, let's get the train back on the tracks. 

Tested: bmcweb with 2.21 works on one of the systems we saw this happening on. Built bmcweb with this commit and loaded onto 2 of the bmcs we saw this on and no longer are hanging.