### PR TITLE
Fix bmcweb hang

### DIFF
--- a/include/dump_offload.hpp
+++ b/include/dump_offload.hpp
@@ -407,7 +407,6 @@ inline void requestRoutes(App& app)
             << "INFO: " << dumpType << " Dump id " << dumpId
             << " offload initiated by: " << conn.req.session->clientIp;
         bmcHandlers[&conn]->getDumpSize(dumpId, dumpType);
-        ioCon->run();
         })
         .onclose([](crow::streaming_response::Connection& conn, bool& status) {
             auto handler = bmcHandlers.find(&conn);


### PR DESCRIPTION
looks like io.run() used while offloading dump causing bmcweb hang.
This commit Removes io.run() call to fix bmcweb hang/slowness.|
This change was introduced as part of https://github.com/ibm-openbmc/bmcweb/pull/652.
I suspect this change may cause intermittent bmcweb hang after dumpoffload
