### PR TITLE
1050 single eth port fix

### DIFF
--- a/redfish-core/lib/network_protocol.hpp
+++ b/redfish-core/lib/network_protocol.hpp
@@ -169,6 +169,17 @@ inline void getNetworkData(const std::shared_ptr<bmcweb::AsyncResp>& asyncResp,
     asyncResp->res.jsonValue["HTTP"]["Port"] = nullptr;
     asyncResp->res.jsonValue["HTTP"]["ProtocolEnabled"] = false;
 
+    // The ProtocolEnabled of the following protocols is determined by
+    // inspecting the state of associated systemd sockets. If these protocols
+    // have been disabled, then the systemd socket unit files will not be found
+    // and the protocols will not be returned in this Redfish query. Set some
+    // defaults to ensure something is always returned.
+    for (const auto& nwkProtocol : networkProtocolToDbus)
+    {
+        asyncResp->res.jsonValue[nwkProtocol.first]["Port"] = nullptr;
+        asyncResp->res.jsonValue[nwkProtocol.first]["ProtocolEnabled"] = false;
+    }
+
     std::string hostName = getHostName();
 
     asyncResp->res.jsonValue["HostName"] = hostName;

--- a/redfish-core/lib/network_protocol.hpp
+++ b/redfish-core/lib/network_protocol.hpp
@@ -36,13 +36,16 @@ namespace redfish
 void getNTPProtocolEnabled(const std::shared_ptr<bmcweb::AsyncResp>& asyncResp);
 std::string getHostName();
 
-static constexpr const char* sshServiceName = "dropbear";
-static constexpr const char* httpsServiceName = "bmcweb";
-static constexpr const char* ipmiServiceName = "phosphor-ipmi-net";
-static constexpr std::array<std::pair<const char*, const char*>, 3>
-    protocolToService = {{{"SSH", sshServiceName},
-                          {"HTTPS", httpsServiceName},
-                          {"IPMI", ipmiServiceName}}};
+static constexpr std::string_view sshServiceName = "dropbear";
+static constexpr std::string_view httpsServiceName = "bmcweb";
+static constexpr std::string_view ipmiServiceName = "phosphor-ipmi-net";
+
+// Mapping from Redfish NetworkProtocol key name to backend service that hosts
+// that protocol.
+static constexpr std::array<std::pair<std::string_view, std::string_view>, 3>
+    networkProtocolToDbus = {{{"SSH", sshServiceName},
+                              {"HTTPS", httpsServiceName},
+                              {"IPMI", ipmiServiceName}}};
 
 inline void extractNTPServersAndDomainNamesData(
     const dbus::utility::ManagedObjectType& dbusData,
@@ -110,6 +113,38 @@ void getEthernetIfaceData(CallbackFunc&& callback)
         "org.freedesktop.DBus.ObjectManager", "GetManagedObjects");
 }
 
+inline void afterNetworkPortRequest(
+    const std::shared_ptr<bmcweb::AsyncResp>& asyncResp,
+    const boost::system::error_code& ec,
+    const std::vector<std::tuple<std::string, std::string, bool>>& socketData)
+{
+    if (ec)
+    {
+        messages::internalError(asyncResp->res);
+        return;
+    }
+    for (const auto& data : socketData)
+    {
+        const std::string& socketPath = get<0>(data);
+        const std::string& protocolName = get<1>(data);
+        bool isProtocolEnabled = get<2>(data);
+
+        asyncResp->res.jsonValue[protocolName]["ProtocolEnabled"] =
+            isProtocolEnabled;
+        asyncResp->res.jsonValue[protocolName]["Port"] = nullptr;
+        getPortNumber(socketPath, [asyncResp, protocolName](
+                                      const boost::system::error_code& ec2,
+                                      int portNumber) {
+            if (ec2)
+            {
+                messages::internalError(asyncResp->res);
+                return;
+            }
+            asyncResp->res.jsonValue[protocolName]["Port"] = portNumber;
+        });
+    }
+}
+
 inline void getNetworkData(const std::shared_ptr<bmcweb::AsyncResp>& asyncResp,
                            const crow::Request& req)
 {
@@ -131,7 +166,7 @@ inline void getNetworkData(const std::shared_ptr<bmcweb::AsyncResp>& asyncResp,
     // but from security perspective it is not recommended to use.
     // Hence using protocolEnabled as false to make it OCP and security-wise
     // compliant
-    asyncResp->res.jsonValue["HTTP"]["Port"] = 0;
+    asyncResp->res.jsonValue["HTTP"]["Port"] = nullptr;
     asyncResp->res.jsonValue["HTTP"]["ProtocolEnabled"] = false;
 
     std::string hostName = getHostName();
@@ -176,43 +211,8 @@ inline void getNetworkData(const std::shared_ptr<bmcweb::AsyncResp>& asyncResp,
             "/redfish/v1/Managers/bmc/NetworkProtocol/HTTPS/Certificates";
     }
 
-    for (const auto& protocol : protocolToService)
-    {
-        const std::string& protocolName = protocol.first;
-        const std::string& serviceName = protocol.second;
-        getPortStatusAndPath(
-            serviceName,
-            [asyncResp, protocolName](const boost::system::error_code ec,
-                                      const std::string& socketPath,
-                                      bool isProtocolEnabled) {
-            // If the service is not installed, that is not an error
-            if (ec == boost::system::errc::no_such_process)
-            {
-                asyncResp->res.jsonValue[protocolName]["Port"] =
-                    nlohmann::detail::value_t::null;
-                asyncResp->res.jsonValue[protocolName]["ProtocolEnabled"] =
-                    false;
-                return;
-            }
-            if (ec)
-            {
-                messages::internalError(asyncResp->res);
-                return;
-            }
-            asyncResp->res.jsonValue[protocolName]["ProtocolEnabled"] =
-                isProtocolEnabled;
-            getPortNumber(socketPath, [asyncResp, protocolName](
-                                          const boost::system::error_code ec2,
-                                          int portNumber) {
-                if (ec2)
-                {
-                    messages::internalError(asyncResp->res);
-                    return;
-                }
-                asyncResp->res.jsonValue[protocolName]["Port"] = portNumber;
-            });
-            });
-    }
+    getPortStatusAndPath(std::span(networkProtocolToDbus),
+                         std::bind_front(afterNetworkPortRequest, asyncResp));
 } // namespace redfish
 
 inline void handleNTPProtocolEnabled(
@@ -458,7 +458,7 @@ inline void
         });
 }
 
-inline std::string encodeServiceObjectPath(const std::string& serviceName)
+inline std::string encodeServiceObjectPath(std::string_view serviceName)
 {
     sdbusplus::message::object_path objPath(
         "/xyz/openbmc_project/control/service");

--- a/redfish-core/lib/redfish_util.hpp
+++ b/redfish-core/lib/redfish_util.hpp
@@ -159,6 +159,33 @@ void getPortStatusAndPath(
                 bool isProtocolEnabled =
                     ((unitState == "running") || (unitState == "listening"));
 
+                // Some protocols may have multiple services associated with
+                // them (for example IPMI). Look to see if we've already added
+                // an entry for the current protocol.
+                auto find = std::find_if(socketData.begin(), socketData.end(),
+                                         [kv](const auto& i) {
+                    return std::get<1>(i) == std::string(kv.first);
+                });
+                if (find != socketData.end())
+                {
+                    // It only takes one enabled systemd service to consider a
+                    // protocol enabled so if the current entry already has it
+                    // enabled (or the new one is disabled) then just continue,
+                    // otherwise remove the current one and add this new one.
+                    if (std::get<2>(*find) || !isProtocolEnabled)
+                    {
+                        // Already registered as enabled or current one is not
+                        // enabled, nothing to do
+                        BMCWEB_LOG_DEBUG
+                            << "protocolName: " << kv.first
+                            << ", already true or current one is false: "
+                            << isProtocolEnabled;
+                        break;
+                    }
+                    // Remove existing entry and replace with new one (below)
+                    socketData.erase(find);
+                }
+
                 socketData.emplace_back(socketPath, std::string(kv.first),
                                         isProtocolEnabled);
                 // We found service, return from inner loop.

--- a/redfish-core/lib/redfish_util.hpp
+++ b/redfish-core/lib/redfish_util.hpp
@@ -93,21 +93,25 @@ void getMainChassisId(std::shared_ptr<bmcweb::AsyncResp> asyncResp,
 }
 
 template <typename CallbackFunc>
-void getPortStatusAndPath(const std::string& serviceName,
-                          CallbackFunc&& callback)
+void getPortStatusAndPath(
+    std::span<const std::pair<std::string_view, std::string_view>>
+        protocolToDBus,
+    CallbackFunc&& callback)
 {
     crow::connections::systemBus->async_method_call(
-        [serviceName, callback{std::forward<CallbackFunc>(callback)}](
-            const boost::system::error_code ec,
+        [protocolToDBus, callback{std::forward<CallbackFunc>(callback)}](
+            const boost::system::error_code& ec,
             const std::vector<UnitStruct>& r) {
+        std::vector<std::tuple<std::string, std::string, bool>> socketData;
         if (ec)
         {
             BMCWEB_LOG_ERROR << ec;
             // return error code
-            callback(ec, "", false);
+            callback(ec, socketData);
             return;
         }
 
+        // save all service output into vector
         for (const UnitStruct& unit : r)
         {
             // Only traverse through <xyz>.socket units
@@ -138,31 +142,31 @@ void getPortStatusAndPath(const std::string& serviceName,
             // unitsName without ".socket", only <xyz>
             std::string unitNameStr = unitName.substr(0, lastCharPos);
 
-            // We are interested in services, which starts with
-            // mapped service name
-            if (unitNameStr != serviceName)
+            for (const auto& kv : protocolToDBus)
             {
-                continue;
+                // We are interested in services, which starts with
+                // mapped service name
+                if (unitNameStr != kv.second)
+                {
+                    continue;
+                }
+
+                const std::string& socketPath =
+                    std::get<NET_PROTO_UNIT_OBJ_PATH>(unit);
+                const std::string& unitState =
+                    std::get<NET_PROTO_UNIT_SUB_STATE>(unit);
+
+                bool isProtocolEnabled =
+                    ((unitState == "running") || (unitState == "listening"));
+
+                socketData.emplace_back(socketPath, std::string(kv.first),
+                                        isProtocolEnabled);
+                // We found service, return from inner loop.
+                break;
             }
-
-            const std::string& socketPath =
-                std::get<NET_PROTO_UNIT_OBJ_PATH>(unit);
-            const std::string& unitState =
-                std::get<NET_PROTO_UNIT_SUB_STATE>(unit);
-
-            bool isProtocolEnabled =
-                ((unitState == "running") || (unitState == "listening"));
-            // We found service, return from inner loop.
-            callback(ec, socketPath, isProtocolEnabled);
-            return;
         }
 
-        //  no service foudn, throw error
-        boost::system::error_code ec1 = boost::system::errc::make_error_code(
-            boost::system::errc::no_such_process);
-        // return error code
-        callback(ec1, "", false);
-        BMCWEB_LOG_ERROR << ec1;
+        callback(ec, socketData);
         },
         "org.freedesktop.systemd1", "/org/freedesktop/systemd1",
         "org.freedesktop.systemd1.Manager", "ListUnits");

--- a/redfish-core/lib/systems.hpp
+++ b/redfish-core/lib/systems.hpp
@@ -43,6 +43,10 @@
 namespace redfish
 {
 
+const static std::array<std::pair<std::string_view, std::string_view>, 2>
+    protocolToDBusForSystems{
+        {{"SSH", "obmc-console-ssh"}, {"IPMI", "phosphor-ipmi-net"}}};
+
 /**
  * @brief Updates the Functional State of DIMMs
  *
@@ -2421,6 +2425,42 @@ inline void handleComputerSystemCollectionHead(
         "</redfish/v1/JsonSchemas/ComputerSystem/ComputerSystem.json>; rel=describedby");
 }
 
+inline void afterPortRequest(
+    const std::shared_ptr<bmcweb::AsyncResp>& asyncResp,
+    const boost::system::error_code& ec,
+    const std::vector<std::tuple<std::string, std::string, bool>>& socketData)
+{
+    if (ec)
+    {
+        messages::internalError(asyncResp->res);
+        return;
+    }
+    for (const auto& data : socketData)
+    {
+        const std::string& socketPath = get<0>(data);
+        const std::string& protocolName = get<1>(data);
+        bool isProtocolEnabled = get<2>(data);
+        nlohmann::json& dataJson = asyncResp->res.jsonValue["SerialConsole"];
+        dataJson[protocolName]["ServiceEnabled"] = isProtocolEnabled;
+        // need to retrieve port number for
+        // obmc-console-ssh service
+        if (protocolName == "SSH")
+        {
+            getPortNumber(socketPath, [asyncResp, protocolName](
+                                          const boost::system::error_code ec1,
+                                          int portNumber) {
+                if (ec1)
+                {
+                    messages::internalError(asyncResp->res);
+                    return;
+                }
+                nlohmann::json& dataJson1 =
+                    asyncResp->res.jsonValue["SerialConsole"];
+                dataJson1[protocolName]["Port"] = portNumber;
+            });
+        }
+    }
+}
 /**
  * Systems derived class for delivering Computer Systems Schema.
  */
@@ -2502,6 +2542,8 @@ inline void requestRoutesSystems(App& app)
         asyncResp->res
             .jsonValue["SerialConsole"]["SSH"]["HotKeySequenceDisplay"] =
             "Press ~. to exit console";
+        getPortStatusAndPath(std::span{protocolToDBusForSystems},
+                             std::bind_front(afterPortRequest, asyncResp));
 
 #ifdef BMCWEB_ENABLE_KVM
         // Fill in GraphicalConsole info


### PR DESCRIPTION
Bonnell only has one ethernet port. A bug in bmcweb code was found when dealing with this in the redfish/v1/Managers/bmc/NetworkProtocol interface. See commit messages for more details and testing information.

This brings in one merged upstream change which is a pre-req to pulling in the 2 fixes (which are still under review):
- https://gerrit.openbmc.org/c/openbmc/bmcweb/+/44438
- https://gerrit.openbmc.org/c/openbmc/bmcweb/+/62229
- https://gerrit.openbmc.org/c/openbmc/bmcweb/+/62278

This was found as a part of Defect 484897 work