### PR TITLE
1050: Fix Pretty redfish html logo display (#658) (#669)

### DIFF
--- a/http/app.hpp
+++ b/http/app.hpp
@@ -58,9 +58,11 @@ class App
     App& operator=(const App&&) = delete;
 
     template <typename Adaptor>
-    void handleUpgrade(const Request& req, Response& res, Adaptor&& adaptor)
+    void handleUpgrade(const Request& req,
+                       const std::shared_ptr<bmcweb::AsyncResp>& asyncResp,
+                       Adaptor&& adaptor)
     {
-        router.handleUpgrade(req, res, std::forward<Adaptor>(adaptor));
+        router.handleUpgrade(req, asyncResp, std::forward<Adaptor>(adaptor));
     }
 
     void handle(Request& req,

--- a/http/routing.hpp
+++ b/http/routing.hpp
@@ -1477,7 +1477,7 @@ class Router
         std::string username = req.session->username;
 
         crow::connections::systemBus->async_method_call(
-            [req{std::move(req)}, asyncResp, &rule, params](
+            [req, asyncResp, &rule, params](
                 const boost::system::error_code ec,
                 const dbus::utility::DBusPropertiesMap& userInfoMap) mutable {
             if (ec)


### PR DESCRIPTION
Fix redfish browser to show html redfish logo.
It is also reported by tester - https://jazz07.rchland.ibm.com:13443/jazz/web/projects/CSSD#action=com.ibm.team.workitem.viewWorkItem&id=483135

On bmc redish web view, DMTF Redfish logo fails to display.
It is because the headers in the Request is no longer valid after the use of move().

The following upstream commits are needed.

- Add asyncResp support to handleUpgrade 
https://gerrit.openbmc.org/c/openbmc/bmcweb/+/46989
Change-Id: I1c6c91f126b734e1b5573d5ef204fe2bf6ed6c26

- Fix Request use-after-move
Change-Id: Iae68a68817146c28377bbcade04716725e4a6096 
https://gerrit.openbmc.org/c/openbmc/bmcweb/+/61768

Tested:

- Redfish validator passed
- `https://${bmc}/redfish/v1` is showing the pretty redfish logo
- Tried some GUI pages and worked without issues.
- Tried consoles on GUI and worked without issues.
