### PR TITLE
log_services: Fix isContentTypeAllowed checks

### DIFF
--- a/redfish-core/lib/log_services.hpp
+++ b/redfish-core/lib/log_services.hpp
@@ -3181,7 +3181,7 @@ inline void requestRoutesDBusEventLogEntryDownload(App& app)
         {
             return;
         }
-        if (http_helpers::isContentTypeAllowed(
+        if (!http_helpers::isContentTypeAllowed(
                 req.getHeaderValue("Accept"),
                 http_helpers::ContentType::OctetStream, true))
         {
@@ -3226,7 +3226,7 @@ inline void requestRoutesDBusCELogEntryDownload(App& app)
         {
             return;
         }
-        if (http_helpers::isContentTypeAllowed(
+        if (!http_helpers::isContentTypeAllowed(
                 req.getHeaderValue("Accept"),
                 http_helpers::ContentType::OctetStream, true))
         {
@@ -5353,7 +5353,7 @@ inline void requestRoutesPostCodesEntryAdditionalData(App& app)
         {
             return;
         }
-        if (http_helpers::isContentTypeAllowed(
+        if (!http_helpers::isContentTypeAllowed(
                 req.getHeaderValue("Accept"),
                 http_helpers::ContentType::OctetStream, true))
         {


### PR DESCRIPTION
The commit https://gerrit.openbmc.org/c/openbmc/bmcweb/+/56694 inadvertently changed the polarity on the if checks using the newly introduced isContentTypeAllowed function which caused 'Bad Request' to be returned when the content type was allowed.

Tested:
Getting the EventLog and PostCodes attachment would return the data instead of 'Bad Request'.


Change-Id: Iafcdeaba1a0723326347bb2a832b53bbf0aab230