### PR TITLE
1050: Redfish SNMP: Allow use of empty port

### DIFF
--- a/http/utility.hpp
+++ b/http/utility.hpp
@@ -812,7 +812,7 @@ inline bool validateAndSplitUrl(std::string_view destUrl, std::string& urlProto,
         return false;
     }
 
-    if (urlProto == "snmp")
+    if (urlProto == "snmp" && !url.value().port().empty())
     {
         uint16_t portTmp = 0;
         // Check the port


### PR DESCRIPTION
Allow the use of an empty port to configure the SNMP manager, and set it to 162 when the port number is empty.

Test:
curl -k -H "X-Auth-Token: $token" -X POST
https://${bmc}/redfish/v1/EventService/Subscriptions -d '{"Destination":"snmp://9.41.166.76:",
"SubscriptionType":"SNMPTrap", "Protocol":"SNMPv2c"}' {
  "@Message.ExtendedInfo": [
    {
      "@odata.type": "#Message.v1_1_1.Message",
      "Message": "The resource has been created successfully.",
      "MessageArgs": [],
      "MessageId": "Base.1.13.0.Created",
      "MessageSeverity": "OK",
      "Resolution": "None."
    }
  ]
}
curl -k -H "X-Auth-Token: $token" -X GET
https://${bmc}/redfish/v1/EventService/Subscriptions/snmp1 {
  "@odata.id": "/redfish/v1/EventService/Subscriptions/snmp1",
  "@odata.type": "#EventDestination.v1_8_0.EventDestination",
  "Context": "",
  "Destination": "snmp://9.41.166.76:162",
  "EventFormatType": "Event",
  "Id": "snmp1",
  "Name": "Event Destination snmp1",
  "Protocol": "SNMPv2c",
  "SubscriptionType": "SNMPTrap"
}