### PR TITLE
Add support for fault data dump

### DIFF
--- a/redfish-core/lib/log_services.hpp
+++ b/redfish-core/lib/log_services.hpp
@@ -1178,6 +1178,23 @@ inline void createDump(const std::shared_ptr<bmcweb::AsyncResp>& asyncResp,
             messages::internalError(asyncResp->res);
             return;
         }
+        if (oemDiagnosticDataType)
+        {
+            if (*oemDiagnosticDataType == "FaultData")
+            {
+                // Fault data dump
+                createDumpParams.emplace_back(
+                    "xyz.openbmc_project.Dump.Internal.Create.Type",
+                    "xyz.openbmc_project.Dump.Internal.Create.Type.FaultData");
+            }
+            else
+            {
+                BMCWEB_LOG_ERROR
+                    << "Wrong parameter value passed for 'OEMDiagnosticDataType'";
+                messages::internalError(asyncResp->res);
+                return;
+            }
+        }
         dumpPath = "/redfish/v1/Managers/bmc/LogServices/Dump/";
     }
     else


### PR DESCRIPTION
Fault data dump contains the server fault information and is collected by the BMC and is stored on the bmc.

This dump entry will be stored as one other bmc dump entry in the dbus. This code adds support for creation of this dump. Listing and deletion of this dump will be the same as how it is done for bmc dump.

Tested By:

* Create dump command: POST https://${bmc}/redfish/v1/Managers/bmc/LogServices/Dump\ /Actions/LogService.CollectDiagnosticData -d \
'{"DiagnosticDataType":"Manager", "OEMDiagnosticDataType":"FaultData"}'

* List dumps: GET https://${bmc}/redfish/v1/Managers/bmc/LogServices/Dump/Entries/

* Get dump: GET https://${bmc}/redfish/v1/Managers/bmc/LogServices/Dump/Entries/<id>

* Delete dump: DELETE https://${bmc}/redfish/v1/Managers/bmc/LogServices/Dump/Entries/<id>

Change-Id: I5f258a4ca201fe882778fba73037f44a3d4ab44b