### PR TITLE
PowerSubsystem: Add PowerSupplyMetrics

### DIFF
--- a/include/dbus_utility.hpp
+++ b/include/dbus_utility.hpp
@@ -68,6 +68,7 @@ using DbusVariantType = std::variant<
     std::vector<std::tuple<std::string, std::string>>,
     std::vector<std::tuple<uint32_t, std::vector<uint32_t>>>,
     std::vector<std::tuple<uint32_t, size_t>>,
+    std::vector<std::tuple<uint64_t, int64_t>>,
     std::vector<std::tuple<
       std::vector<std::tuple<sdbusplus::message::object_path, std::string>>,
       std::string, std::string, uint64_t>>

--- a/redfish-core/include/redfish.hpp
+++ b/redfish-core/include/redfish.hpp
@@ -44,6 +44,7 @@
 #include "power.hpp"
 #include "power_subsystem.hpp"
 #include "power_supply.hpp"
+#include "power_supply_metrics.hpp"
 #include "processor.hpp"
 #include "redfish_sessions.hpp"
 #include "redfish_v1.hpp"
@@ -101,6 +102,7 @@ class RedfishService
         requestRoutesPowerSubsystem(app);
         requestRoutesPowerSupply(app);
         requestRoutesPowerSupplyCollection(app);
+        requestRoutesPowerSupplyMetrics(app);
         requestRoutesThermalSubsystem(app);
         requestRoutesThermalMetrics(app);
 #endif

--- a/redfish-core/include/utils/power_supply_utils.hpp
+++ b/redfish-core/include/utils/power_supply_utils.hpp
@@ -3,6 +3,7 @@
 #include "async_resp.hpp"
 #include "dbus_utility.hpp"
 #include "error_messages.hpp"
+#include "logging.hpp"
 
 #include <boost/system/error_code.hpp>
 #include <sdbusplus/message.hpp>
@@ -34,6 +35,7 @@ inline void getInputHistoryPaths(
             {
                 if (ec.value() != EBADR)
                 {
+                    BMCWEB_LOG_ERROR << "D-Bus response error: " << ec;
                     messages::internalError(asyncResp->res);
                     return;
                 }
@@ -72,6 +74,7 @@ inline void getValidPowerSupplyPath(
             {
                 if (ec.value() != EBADR)
                 {
+                    BMCWEB_LOG_ERROR << "D-Bus response error: " << ec;
                     messages::internalError(asyncResp->res);
                 }
                 return;

--- a/redfish-core/include/utils/power_supply_utils.hpp
+++ b/redfish-core/include/utils/power_supply_utils.hpp
@@ -1,0 +1,99 @@
+#pragma once
+
+#include "async_resp.hpp"
+#include "dbus_utility.hpp"
+#include "error_messages.hpp"
+
+#include <boost/system/error_code.hpp>
+#include <sdbusplus/message.hpp>
+
+#include <functional>
+#include <memory>
+#include <string>
+#include <utility>
+#include <vector>
+
+namespace redfish
+{
+
+namespace power_supply_utils
+{
+
+inline void getInputHistoryPaths(
+    const std::shared_ptr<bmcweb::AsyncResp>& asyncResp,
+    const std::string& validPowerSupplyPath,
+    std::function<void(const std::vector<std::string>& historyPaths)>&&
+        callback)
+{
+    std::string associationPath = validPowerSupplyPath + "/input_history";
+    dbus::utility::getAssociationEndPoints(
+        associationPath, [asyncResp, callback{std::move(callback)}](
+                             const boost::system::error_code& ec,
+                             const dbus::utility::MapperEndPoints& endpoints) {
+            if (ec)
+            {
+                if (ec.value() != EBADR)
+                {
+                    messages::internalError(asyncResp->res);
+                    return;
+                }
+
+                // Association does not exist.  This is a valid situation; some
+                // power supplies do not have input power history.  Pass an
+                // empty vector to the callback.
+                callback(std::vector<std::string>{});
+                return;
+            }
+
+            callback(endpoints);
+        });
+}
+
+inline bool checkPowerSupplyId(const std::string& powerSupplyPath,
+                               const std::string& powerSupplyId)
+{
+    std::string powerSupplyName =
+        sdbusplus::message::object_path(powerSupplyPath).filename();
+
+    return !(powerSupplyName.empty() || powerSupplyName != powerSupplyId);
+}
+
+inline void getValidPowerSupplyPath(
+    const std::shared_ptr<bmcweb::AsyncResp>& asyncResp,
+    const std::string& validChassisPath, const std::string& powerSupplyId,
+    std::function<void(const std::string& powerSupplyPath)>&& callback)
+{
+    std::string powerPath = validChassisPath + "/powered_by";
+    dbus::utility::getAssociationEndPoints(
+        powerPath, [asyncResp, powerSupplyId, callback{std::move(callback)}](
+                       const boost::system::error_code& ec,
+                       const dbus::utility::MapperEndPoints& endpoints) {
+            if (ec)
+            {
+                if (ec.value() != EBADR)
+                {
+                    messages::internalError(asyncResp->res);
+                }
+                return;
+            }
+
+            for (const auto& endpoint : endpoints)
+            {
+                if (checkPowerSupplyId(endpoint, powerSupplyId))
+                {
+                    callback(endpoint);
+                    return;
+                }
+            }
+
+            if (!endpoints.empty())
+            {
+                messages::resourceNotFound(asyncResp->res, "PowerSupplies",
+                                           powerSupplyId);
+                return;
+            }
+        });
+}
+
+} // namespace power_supply_utils
+} // namespace redfish

--- a/redfish-core/lib/power_supply.hpp
+++ b/redfish-core/lib/power_supply.hpp
@@ -6,10 +6,12 @@
 #include "query.hpp"
 #include "registries/privilege_registry.hpp"
 #include "utils/chassis_utils.hpp"
+#include "utils/power_supply_utils.hpp"
 
 #include <memory>
 #include <optional>
 #include <string>
+#include <vector>
 
 namespace redfish
 {
@@ -133,52 +135,6 @@ inline void requestRoutesPowerSupplyCollection(App& app)
         .privileges(redfish::privileges::getPowerSupplyCollection)
         .methods(boost::beast::http::verb::get)(
             std::bind_front(handlePowerSupplyCollectionGet, std::ref(app)));
-}
-
-inline bool checkPowerSupplyId(const std::string& powerSupplyPath,
-                               const std::string& powerSupplyId)
-{
-    std::string powerSupplyName =
-        sdbusplus::message::object_path(powerSupplyPath).filename();
-
-    return !(powerSupplyName.empty() || powerSupplyName != powerSupplyId);
-}
-
-inline void getValidPowerSupplyPath(
-    const std::shared_ptr<bmcweb::AsyncResp>& asyncResp,
-    const std::string& validChassisPath, const std::string& powerSupplyId,
-    std::function<void(const std::string& powerSupplyPath)>&& callback)
-{
-    std::string powerPath = validChassisPath + "/powered_by";
-    dbus::utility::getAssociationEndPoints(
-        powerPath, [asyncResp, powerSupplyId, callback{std::move(callback)}](
-                       const boost::system::error_code& ec,
-                       const dbus::utility::MapperEndPoints& endpoints) {
-            if (ec)
-            {
-                if (ec.value() != EBADR)
-                {
-                    messages::internalError(asyncResp->res);
-                }
-                return;
-            }
-
-            for (const auto& endpoint : endpoints)
-            {
-                if (checkPowerSupplyId(endpoint, powerSupplyId))
-                {
-                    callback(endpoint);
-                    return;
-                }
-            }
-
-            if (!endpoints.empty())
-            {
-                messages::resourceNotFound(asyncResp->res, "PowerSupplies",
-                                           powerSupplyId);
-                return;
-            }
-        });
 }
 
 inline void
@@ -420,6 +376,26 @@ inline void
 }
 
 inline void
+    getPowerSupplyMetrics(const std::shared_ptr<bmcweb::AsyncResp>& asyncResp,
+                          const std::string& chassisId,
+                          const std::string& powerSupplyId,
+                          const std::string& validPowerSupplyPath)
+{
+    redfish::power_supply_utils::getInputHistoryPaths(
+        asyncResp, validPowerSupplyPath,
+        [asyncResp, chassisId,
+         powerSupplyId](const std::vector<std::string>& historyPaths) {
+        if (historyPaths.size() > 0)
+        {
+            asyncResp->res.jsonValue["Metrics"]["@odata.id"] =
+                crow::utility::urlFromPieces(
+                    "redfish", "v1", "Chassis", chassisId, "PowerSubsystem",
+                    "PowerSupplies", powerSupplyId, "Metrics");
+        }
+        });
+}
+
+inline void
     doPowerSupplyGet(const std::shared_ptr<bmcweb::AsyncResp>& asyncResp,
                      const std::string& chassisId,
                      const std::string& powerSupplyId,
@@ -432,9 +408,10 @@ inline void
     }
 
     // Get the correct Path and Service that match the input parameters
-    getValidPowerSupplyPath(asyncResp, *validChassisPath, powerSupplyId,
-                            [asyncResp, chassisId, powerSupplyId](
-                                const std::string& powerSupplyPath) {
+    redfish::power_supply_utils::getValidPowerSupplyPath(
+        asyncResp, *validChassisPath, powerSupplyId,
+        [asyncResp, chassisId,
+         powerSupplyId](const std::string& powerSupplyPath) {
         asyncResp->res.addHeader(
             boost::beast::http::field::link,
             "</redfish/v1/JsonSchemas/PowerSupply/PowerSupply.json>; rel=describedby");
@@ -472,7 +449,9 @@ inline void
 
         getEfficiencyPercent(asyncResp);
         getLocationIndicatorActive(asyncResp, powerSupplyPath);
-    });
+        getPowerSupplyMetrics(asyncResp, chassisId, powerSupplyId,
+                              powerSupplyPath);
+        });
 }
 
 inline void
@@ -497,12 +476,13 @@ inline void
         }
 
         // Get the correct Path and Service that match the input parameters
-        getValidPowerSupplyPath(asyncResp, *validChassisPath, powerSupplyId,
-                                [asyncResp](const std::string&) {
+        redfish::power_supply_utils::getValidPowerSupplyPath(
+            asyncResp, *validChassisPath, powerSupplyId,
+            [asyncResp](const std::string&) {
             asyncResp->res.addHeader(
                 boost::beast::http::field::link,
                 "</redfish/v1/JsonSchemas/PowerSupply/PowerSupply.json>; rel=describedby");
-        });
+            });
         });
 }
 
@@ -564,9 +544,10 @@ inline void
         }
 
         // Get the correct power supply Path that match the input parameters
-        getValidPowerSupplyPath(asyncResp, *validChassisPath, powerSupplyId,
-                                std::bind_front(doPatchPowerSupply, asyncResp,
-                                                locationIndicatorActive));
+        redfish::power_supply_utils::getValidPowerSupplyPath(
+            asyncResp, *validChassisPath, powerSupplyId,
+            std::bind_front(doPatchPowerSupply, asyncResp,
+                            locationIndicatorActive));
         });
 }
 

--- a/redfish-core/lib/power_supply.hpp
+++ b/redfish-core/lib/power_supply.hpp
@@ -385,7 +385,7 @@ inline void
         asyncResp, validPowerSupplyPath,
         [asyncResp, chassisId,
          powerSupplyId](const std::vector<std::string>& historyPaths) {
-        if (historyPaths.size() > 0)
+        if (!historyPaths.empty())
         {
             asyncResp->res.jsonValue["Metrics"]["@odata.id"] =
                 crow::utility::urlFromPieces(

--- a/redfish-core/lib/power_supply_metrics.hpp
+++ b/redfish-core/lib/power_supply_metrics.hpp
@@ -1,0 +1,288 @@
+#pragma once
+
+#include "app.hpp"
+#include "async_resp.hpp"
+#include "dbus_singleton.hpp"
+#include "dbus_utility.hpp"
+#include "error_messages.hpp"
+#include "query.hpp"
+#include "registries/privilege_registry.hpp"
+#include "utility.hpp"
+#include "utils/chassis_utils.hpp"
+#include "utils/dbus_utils.hpp"
+#include "utils/power_supply_utils.hpp"
+#include "utils/time_utils.hpp"
+
+#include <boost/beast/http/field.hpp>
+#include <boost/beast/http/verb.hpp>
+#include <boost/system/error_code.hpp>
+#include <sdbusplus/asio/property.hpp>
+#include <sdbusplus/unpack_properties.hpp>
+
+#include <algorithm>
+#include <array>
+#include <cmath>
+#include <cstdint>
+#include <functional>
+#include <memory>
+#include <optional>
+#include <string>
+#include <tuple>
+#include <utility>
+#include <vector>
+
+namespace redfish
+{
+
+namespace power_supply_metrics
+{
+
+static const char* historyMaximumInterface =
+    "org.open_power.Sensor.Aggregation.History.Maximum";
+static const char* historyAverageInterface =
+    "org.open_power.Sensor.Aggregation.History.Average";
+
+static std::array<const char*, 2> historyInterfaces{historyMaximumInterface,
+                                                    historyAverageInterface};
+
+inline void addInputHistoryProperties(
+    const std::shared_ptr<bmcweb::AsyncResp>& asyncResp,
+    const std::string& interface,
+    const dbus::utility::DBusPropertiesMap& propertiesList)
+{
+    // Get Scale and Values properties
+    int64_t scale{0};
+    std::vector<std::tuple<uint64_t, int64_t>> values{};
+    const bool success = sdbusplus::unpackPropertiesNoThrow(
+        dbus_utils::UnpackErrorPrinter(), propertiesList, "Scale", scale,
+        "Values", values);
+
+    if (!success)
+    {
+        messages::internalError(asyncResp->res);
+        return;
+    }
+
+    if (values.empty())
+    {
+        return;
+    }
+
+    // Make sure JSON array has correct number of items
+    auto& jsonItems =
+        asyncResp->res.jsonValue["Oem"]["IBM"]["InputPowerHistoryItems"];
+    if (jsonItems.empty())
+    {
+        // First set of values being added; create array with correct size
+        jsonItems = nlohmann::json(values.size(), nlohmann::json::object());
+    }
+    else if (jsonItems.size() != values.size())
+    {
+        // Second set of values being added; different size than first set
+        messages::internalError(asyncResp->res);
+        return;
+    }
+
+    // Loop through the values, adding them to the JSON array
+    for (unsigned int i = 0; i < values.size(); ++i)
+    {
+        auto& jsonItem = jsonItems[i];
+        const auto [timestamp, value] = values[i];
+        jsonItem["Date"] = redfish::time_utils::getDateTimeUintMs(timestamp);
+        double scaledValue = static_cast<double>(value) * std::pow(10.0, scale);
+        if (interface == historyMaximumInterface)
+        {
+            jsonItem["Maximum"] = scaledValue;
+        }
+        else
+        {
+            jsonItem["Average"] = scaledValue;
+        }
+    }
+}
+
+inline void getInputHistoryServiceAndInterface(
+    const std::shared_ptr<bmcweb::AsyncResp>& asyncResp,
+    const std::string& historyPath,
+    std::function<void(const std::string& service,
+                       const std::string& interface)>&& callback)
+{
+    dbus::utility::getDbusObject(
+        historyPath, historyInterfaces,
+        [asyncResp, callback{std::move(callback)}](
+            const boost::system::error_code& ec,
+            const dbus::utility::MapperGetObject& object) {
+        if (ec || object.empty())
+        {
+            messages::internalError(asyncResp->res);
+            return;
+        }
+
+        // Get service that provides the history path
+        const std::string& service = object.front().first;
+
+        // Get history interface for history path (Maximum or Average)
+        const auto& interfaces = object.front().second;
+        auto it = std::find_first_of(interfaces.cbegin(), interfaces.cend(),
+                                     historyInterfaces.cbegin(),
+                                     historyInterfaces.cend());
+        if (it == interfaces.cend())
+        {
+            messages::internalError(asyncResp->res);
+            return;
+        }
+        const std::string& interface = *it;
+
+        callback(service, interface);
+        });
+}
+
+inline void getInputHistory(const std::shared_ptr<bmcweb::AsyncResp>& asyncResp,
+                            std::vector<std::string> historyPaths)
+{
+    // Get the service and interface for the first history path
+    getInputHistoryServiceAndInterface(
+        asyncResp, historyPaths.front(),
+        [asyncResp, historyPaths](const std::string& service,
+                                  const std::string& interface) mutable {
+        // Get all properties from the first history path
+        sdbusplus::asio::getAllProperties(
+            *crow::connections::systemBus, service, historyPaths.front(),
+            interface,
+            [asyncResp, historyPaths,
+             interface](const boost::system::error_code ec,
+                        const dbus::utility::DBusPropertiesMap&
+                            propertiesList) mutable {
+            if (ec)
+            {
+                messages::internalError(asyncResp->res);
+                return;
+            }
+
+            // Add input history properties to the JSON response
+            addInputHistoryProperties(asyncResp, interface, propertiesList);
+
+            // Recurse if there are more input history paths
+            if (historyPaths.size() > 1)
+            {
+                historyPaths.erase(historyPaths.cbegin());
+                getInputHistory(asyncResp, historyPaths);
+            }
+            });
+        });
+}
+
+inline void getValidInputHistoryPaths(
+    const std::shared_ptr<bmcweb::AsyncResp>& asyncResp,
+    const std::string& chassisId, const std::string& powerSupplyId,
+    std::function<void(const std::vector<std::string>& historyPaths)>&&
+        callback)
+{
+    // Get chassis D-Bus path
+    redfish::chassis_utils::getValidChassisPath(
+        asyncResp, chassisId,
+        [asyncResp, chassisId, powerSupplyId, callback{std::move(callback)}](
+            const std::optional<std::string>& validChassisPath) {
+        if (!validChassisPath)
+        {
+            messages::resourceNotFound(asyncResp->res, "Chassis", chassisId);
+            return;
+        }
+
+        // Get power supply D-Bus path
+        redfish::power_supply_utils::getValidPowerSupplyPath(
+            asyncResp, *validChassisPath, powerSupplyId,
+            [asyncResp, callback{std::move(callback)}](
+                const std::string& validPowerSupplyPath) {
+            // Get input history D-Bus paths
+            redfish::power_supply_utils::getInputHistoryPaths(
+                asyncResp, validPowerSupplyPath,
+                [asyncResp, callback{std::move(callback)}](
+                    const std::vector<std::string>& historyPaths) {
+                if (historyPaths.empty())
+                {
+                    messages::resourceNotFound(asyncResp->res,
+                                               "PowerSupplyMetrics", "Metrics");
+                    return;
+                }
+
+                callback(historyPaths);
+                });
+            });
+        });
+}
+
+inline void handleHead(App& app, const crow::Request& req,
+                       const std::shared_ptr<bmcweb::AsyncResp>& asyncResp,
+                       const std::string& chassisId,
+                       const std::string& powerSupplyId)
+{
+    if (!redfish::setUpRedfishRoute(app, req, asyncResp))
+    {
+        return;
+    }
+
+    getValidInputHistoryPaths(asyncResp, chassisId, powerSupplyId,
+                              [asyncResp](const std::vector<std::string>&) {
+        asyncResp->res.addHeader(
+            boost::beast::http::field::link,
+            "</redfish/v1/JsonSchemas/PowerSupplyMetrics/PowerSupplyMetrics.json>; rel=describedby");
+    });
+}
+
+inline void handleGet(App& app, const crow::Request& req,
+                      const std::shared_ptr<bmcweb::AsyncResp>& asyncResp,
+                      const std::string& chassisId,
+                      const std::string& powerSupplyId)
+{
+    if (!redfish::setUpRedfishRoute(app, req, asyncResp))
+    {
+        return;
+    }
+
+    getValidInputHistoryPaths(
+        asyncResp, chassisId, powerSupplyId,
+        [asyncResp, chassisId,
+         powerSupplyId](const std::vector<std::string>& historyPaths) {
+        asyncResp->res.addHeader(
+            boost::beast::http::field::link,
+            "</redfish/v1/JsonSchemas/PowerSupplyMetrics/PowerSupplyMetrics.json>; rel=describedby");
+        asyncResp->res.jsonValue["@odata.type"] =
+            "#PowerSupplyMetrics.v1_0_1.PowerSupplyMetrics";
+        asyncResp->res.jsonValue["Name"] = "Metrics for " + powerSupplyId;
+        asyncResp->res.jsonValue["Id"] = "Metrics";
+        asyncResp->res.jsonValue["@odata.id"] = crow::utility::urlFromPieces(
+            "redfish", "v1", "Chassis", chassisId, "PowerSubsystem",
+            "PowerSupplies", powerSupplyId, "Metrics");
+        asyncResp->res.jsonValue["Oem"]["@odata.type"] =
+            "#OemPowerSupplyMetrics.v1_0_0.Oem";
+        asyncResp->res.jsonValue["Oem"]["IBM"]["@odata.type"] =
+            "#OemPowerSupplyMetrics.v1_0_0.IBM";
+        asyncResp->res.jsonValue["Oem"]["IBM"]["InputPowerHistoryItems"] =
+            nlohmann::json::array();
+
+        // Get input history values and add them to the response
+        getInputHistory(asyncResp, historyPaths);
+        });
+}
+
+} // namespace power_supply_metrics
+
+inline void requestRoutesPowerSupplyMetrics(App& app)
+{
+    BMCWEB_ROUTE(
+        app,
+        "/redfish/v1/Chassis/<str>/PowerSubsystem/PowerSupplies/<str>/Metrics")
+        .privileges(redfish::privileges::headPowerSupplyMetrics)
+        .methods(boost::beast::http::verb::head)(
+            std::bind_front(power_supply_metrics::handleHead, std::ref(app)));
+
+    BMCWEB_ROUTE(
+        app,
+        "/redfish/v1/Chassis/<str>/PowerSubsystem/PowerSupplies/<str>/Metrics")
+        .privileges(redfish::privileges::getPowerSupplyMetrics)
+        .methods(boost::beast::http::verb::get)(
+            std::bind_front(power_supply_metrics::handleGet, std::ref(app)));
+}
+
+} // namespace redfish

--- a/scripts/update_schemas.py
+++ b/scripts/update_schemas.py
@@ -300,6 +300,18 @@ with open(metadata_index_path, "w") as metadata_index:
     metadata_index.write("    </edmx:Reference>\n")
 
     metadata_index.write(
+        '    <edmx:Reference Uri="'
+        '/redfish/v1/schema/OemPowerSupplyMetrics_v1.xml">\n'
+    )
+    metadata_index.write(
+        '        <edmx:Include Namespace="OemPowerSupplyMetrics"/>\n'
+    )
+    metadata_index.write(
+        '        <edmx:Include Namespace="OemPowerSupplyMetrics.v1_0_0"/>\n'
+    )
+    metadata_index.write("    </edmx:Reference>\n")
+
+    metadata_index.write(
         '    <edmx:Reference Uri="/redfish/v1/schema/OemChassis_v1.xml">\n'
     )
     metadata_index.write('        <edmx:Include Namespace="OemChassis"/>\n')

--- a/static/redfish/v1/$metadata/index.xml
+++ b/static/redfish/v1/$metadata/index.xml
@@ -4236,6 +4236,10 @@
         <edmx:Include Namespace="OemAssembly"/>
         <edmx:Include Namespace="OemAssembly.v1_0_0"/>
     </edmx:Reference>
+    <edmx:Reference Uri="/redfish/v1/schema/OemPowerSupplyMetrics_v1.xml">
+        <edmx:Include Namespace="OemPowerSupplyMetrics"/>
+        <edmx:Include Namespace="OemPowerSupplyMetrics.v1_0_0"/>
+    </edmx:Reference>
     <edmx:Reference Uri="/redfish/v1/schema/OemChassis_v1.xml">
         <edmx:Include Namespace="OemChassis"/>
         <edmx:Include Namespace="OemChassis.v1_0_0"/>

--- a/static/redfish/v1/JsonSchemas/OemPowerSupplyMetrics/index.json
+++ b/static/redfish/v1/JsonSchemas/OemPowerSupplyMetrics/index.json
@@ -1,0 +1,107 @@
+{
+    "$id": "http://redfish.dmtf.org/schemas/v1/OemPowerSupplyMetrics.v1_0_0.json",
+    "$schema": "http://redfish.dmtf.org/schemas/v1/redfish-schema-v1.json",
+    "copyright": "Copyright 2014-2019 DMTF. For the full DMTF copyright policy, see http://www.dmtf.org/about/policies/copyright",
+    "definitions": {
+        "Oem": {
+            "additionalProperties": true,
+            "description": "OemPowerSupplyMetrics Oem properties.",
+            "patternProperties": {
+                "^([a-zA-Z_][a-zA-Z0-9_]*)?@(odata|Redfish|Message)\\.[a-zA-Z_][a-zA-Z0-9_]*$": {
+                    "description": "This property shall specify a valid odata or Redfish property.",
+                    "type": [
+                        "array",
+                        "boolean",
+                        "integer",
+                        "number",
+                        "null",
+                        "object",
+                        "string"
+                    ]
+                }
+            },
+            "properties": {
+                "IBM": {
+                    "anyOf": [
+                        {
+                            "$ref": "#/definitions/IBM"
+                        },
+                        {
+                            "type": "null"
+                        }
+                    ]
+                }
+            },
+            "type": "object"
+        },
+        "IBM": {
+            "additionalProperties": true,
+            "description": "Oem properties for IBM.",
+            "patternProperties": {
+                "^([a-zA-Z_][a-zA-Z0-9_]*)?@(odata|Redfish|Message)\\.[a-zA-Z_][a-zA-Z0-9_]*$": {
+                    "description": "This property shall specify a valid odata or Redfish property.",
+                    "type": [
+                        "array",
+                        "boolean",
+                        "integer",
+                        "number",
+                        "null",
+                        "object",
+                        "string"
+                    ]
+                }
+            },
+            "properties": {
+                "InputPowerHistoryItems": {
+                    "description": "Power supply input power history.  Average and maximum input power over 30 second intervals.",
+                    "items": {
+                        "$ref": "#/definitions/InputPowerHistoryItem"
+                    },
+                    "readonly": true,
+                    "type": "array"
+                }
+            },
+            "type": "object"
+        },
+        "InputPowerHistoryItem": {
+            "additionalProperties": false,
+            "description": "Power supply input power history over a 30 second interval.",
+            "patternProperties": {
+                "^([a-zA-Z_][a-zA-Z0-9_]*)?@(odata|Redfish|Message)\\.[a-zA-Z_][a-zA-Z0-9_]*$": {
+                    "description": "This property shall specify a valid odata or Redfish property.",
+                    "type": [
+                        "array",
+                        "boolean",
+                        "integer",
+                        "number",
+                        "null",
+                        "object",
+                        "string"
+                    ]
+                }
+            },
+            "properties": {
+                "Date": {
+                    "description": "The date and time for a 30 second interval of power supply input power history.",
+                    "format": "date-time",
+                    "readonly": true,
+                    "type": "string"
+                },
+                "Average": {
+                    "description": "Average input power to the power supply over a 30 second interval.",
+                    "readonly": true,
+                    "type": "number"
+                },
+                "Maximum": {
+                    "description": "Maximum input power to the power supply over a 30 second interval.",
+                    "readonly": true,
+                    "type": "number"
+                }
+            },
+            "type": "object"
+        }
+    },
+    "owningEntity": "IBM",
+    "release": "1.0",
+    "title": "#OemPowerSupplyMetrics.v1_0_0"
+}

--- a/static/redfish/v1/schema/OemPowerSupplyMetrics_v1.xml
+++ b/static/redfish/v1/schema/OemPowerSupplyMetrics_v1.xml
@@ -1,0 +1,58 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<edmx:Edmx xmlns:edmx="http://docs.oasis-open.org/odata/ns/edmx" Version="4.0">
+
+  <edmx:Reference Uri="http://docs.oasis-open.org/odata/odata/v4.0/errata03/csd01/complete/vocabularies/Org.OData.Core.V1.xml">
+    <edmx:Include Namespace="Org.OData.Core.V1" Alias="OData"/>
+  </edmx:Reference>
+  <edmx:Reference Uri="http://redfish.dmtf.org/schemas/v1/RedfishExtensions_v1.xml">
+    <edmx:Include Namespace="RedfishExtensions.v1_0_0" Alias="Redfish"/>
+  </edmx:Reference>
+  <edmx:Reference Uri="http://redfish.dmtf.org/schemas/v1/Resource_v1.xml">
+    <edmx:Include Namespace="Resource"/>
+    <edmx:Include Namespace="Resource.v1_0_0"/>
+  </edmx:Reference>
+
+  <edmx:DataServices>
+
+    <Schema xmlns="http://docs.oasis-open.org/odata/ns/edm" Namespace="OemPowerSupplyMetrics">
+      <Annotation Term="Redfish.OwningEntity" String="IBM"/>
+    </Schema>
+
+    <Schema xmlns="http://docs.oasis-open.org/odata/ns/edm" Namespace="OemPowerSupplyMetrics.v1_0_0">
+      <ComplexType Name="Oem" BaseType="Resource.OemObject">
+        <Annotation Term="OData.AdditionalProperties" Bool="true"/>
+        <Annotation Term="OData.Description" String="OemPowerSupplyMetrics Oem properties."/>
+        <Annotation Term="OData.AutoExpand"/>
+        <Property Name="IBM" Type="OemPowerSupplyMetrics.v1_0_0.IBM"/>
+      </ComplexType>
+
+      <ComplexType Name="IBM" BaseType="Resource.OemObject">
+        <Annotation Term="OData.AdditionalProperties" Bool="true"/>
+        <Annotation Term="OData.Description" String="Oem properties for IBM."/>
+        <Annotation Term="OData.AutoExpand"/>
+        <Property Name="InputPowerHistoryItems" Type="Collection(OemPowerSupplyMetrics.v1_0_0.InputPowerHistoryItem)">
+          <Annotation Term="OData.Permissions" EnumMember="OData.Permission/Read"/>
+          <Annotation Term="OData.Description" String="Power supply input power history.  Average and maximum input power over 30 second intervals."/>
+        </Property>
+      </ComplexType>
+
+      <ComplexType Name="InputPowerHistoryItem" BaseType="Resource.OemObject">
+        <Annotation Term="OData.AdditionalProperties" Bool="false"/>
+        <Annotation Term="OData.Description" String="Power supply input power history over a 30 second interval."/>
+        <Annotation Term="OData.AutoExpand"/>
+        <Property Name="Date" Type="Edm.DateTimeOffset">
+          <Annotation Term="OData.Permissions" EnumMember="OData.Permission/Read"/>
+          <Annotation Term="OData.Description" String="The date and time for a 30 second interval of power supply input power history."/>
+        </Property>
+        <Property Name="Average" Type="Edm.Decimal">
+          <Annotation Term="OData.Permissions" EnumMember="OData.Permission/Read"/>
+          <Annotation Term="OData.Description" String="Average input power to the power supply over a 30 second interval."/>
+        </Property>
+        <Property Name="Maximum" Type="Edm.Decimal">
+          <Annotation Term="OData.Permissions" EnumMember="OData.Permission/Read"/>
+          <Annotation Term="OData.Description" String="Maximum input power to the power supply over a 30 second interval."/>
+        </Property>
+      </ComplexType>
+    </Schema>
+  </edmx:DataServices>
+</edmx:Edmx>


### PR DESCRIPTION
Add support for the PowerSupplyMetrics Redfish schema.

Add the Metrics property to the Redfish PowerSupply output.  This property contains the URI for the power supply metrics.

Implement basic support for the PowerSupplyMetrics schema.  Initially support only power supply input power history.  Input history is not currently defined in the Redfish specification, and it is defined in OpenPower D-Bus interfaces, so it is stored in an IBM OEM property.

Modify the XML and JSON PowerSupplyMetrics schemas to define the IBM OEM property.

Tested:
* Passed the Redfish Validator
* Verified power supply input history displayed for chassis PSUs
* Verified power supply input history not displayed for I/O drawer PSUs
* For detailed test plan, see https://gist.github.com/smccarney/b3df3fc5142dbff0b0c502654ec1a5ac

Example Output:
```
$ curl -k https://${bmc}/redfish/v1/Chassis/chassis/PowerSubsystem/PowerSupplies/powersupply0 {
  "@odata.id": "/redfish/v1/Chassis/chassis/PowerSubsystem/PowerSupplies/powersupply0",
  "@odata.type": "#PowerSupply.v1_5_0.PowerSupply",
  "EfficiencyRatings": [
    {
      "EfficiencyPercent": 90
    }
  ],
  "FirmwareVersion": "423243324132",
  "Id": "powersupply0",
  "Location": {
    "PartLocation": {
      "ServiceLabel": "U78DA.ND0.WZS004K-E0"
    }
  },
  "LocationIndicatorActive": false,
  "Manufacturer": "",
  "Metrics": {
    "@odata.id": "/redfish/v1/Chassis/chassis/PowerSubsystem/PowerSupplies/powersupply0/Metrics"
  },
  "Model": "51E9",
  "Name": "powersupply0",
  "PartNumber": "03FP379",
  "SerialNumber": "YL30KY1450M3",
  "SparePartNumber": "03FP378",
  "Status": {
    "Health": "OK",
    "State": "Enabled"
  }
}

$ curl -k https://${bmc}/redfish/v1/Chassis/chassis/PowerSubsystem/PowerSupplies/powersupply0/Metrics {
  "@odata.id": "/redfish/v1/Chassis/chassis/PowerSubsystem/PowerSupplies/powersupply0/Metrics",
  "@odata.type": "#PowerSupplyMetrics.v1_0_1.PowerSupplyMetrics",
  "Id": "Metrics",
  "Name": "Metrics for powersupply0",
  "Oem": {
    "@odata.type": "#OemPowerSupplyMetrics.v1_0_0.Oem",
    "IBM": {
      "@odata.type": "#OemPowerSupplyMetrics.v1_0_0.IBM",
      "InputPowerHistoryItems": [
        {
          "Average": 265.0,
          "Date": "2023-04-25T04:40:56.530+00:00",
          "Maximum": 266.0
        },
        {
          "Average": 265.0,
          "Date": "2023-04-25T04:40:26.499+00:00",
          "Maximum": 266.0
        },
        {
          "Average": 266.0,
          "Date": "2023-04-25T04:39:56.468+00:00",
          "Maximum": 276.0
        }
      ]
    }
  }
}
```

Change-Id: I1e9523a87d016dde499a98c1262cea2b3a4d6557