### PR TITLE
1050: Fix duplicated var definition in http_stream classes and fix handle upgrade

### DIFF
--- a/http/http_stream.hpp
+++ b/http/http_stream.hpp
@@ -55,7 +55,7 @@ class ConnectionImpl : public Connection
         openHandler(std::move(openHandlerIn)),
         messageHandler(std::move(messageHandlerIn)),
         closeHandler(std::move(closeHandlerIn)),
-        errorHandler(std::move(errorHandlerIn)), req(reqIn)
+        errorHandler(std::move(errorHandlerIn))
     {}
 
     boost::asio::io_context* getIoContext() override
@@ -162,7 +162,6 @@ class ConnectionImpl : public Connection
     std::function<void(Connection&, bool&)> closeHandler;
     std::function<void(Connection&)> errorHandler;
     std::function<void()> handlerFunc;
-    crow::Request req;
 };
 } // namespace streaming_response
 } // namespace crow

--- a/http/routing.hpp
+++ b/http/routing.hpp
@@ -357,7 +357,7 @@ class WebSocketRule : public BaseRule
             myConnection = std::make_shared<
                 crow::websocket::ConnectionImpl<boost::asio::ip::tcp::socket>>(
                 req, std::move(adaptor), openHandler, messageHandler,
-                closeHandler, errorHandler);
+                messageExHandler, closeHandler, errorHandler);
         myConnection->start();
     }
 #ifdef BMCWEB_ENABLE_SSL
@@ -372,7 +372,7 @@ class WebSocketRule : public BaseRule
             myConnection = std::make_shared<crow::websocket::ConnectionImpl<
                 boost::beast::ssl_stream<boost::asio::ip::tcp::socket>>>(
                 req, std::move(adaptor), openHandler, messageHandler,
-                closeHandler, errorHandler);
+                messageExHandler, closeHandler, errorHandler);
         myConnection->start();
     }
 #endif
@@ -388,6 +388,13 @@ class WebSocketRule : public BaseRule
     self_t& onmessage(Func f)
     {
         messageHandler = f;
+        return *this;
+    }
+
+    template <typename Func>
+    self_t& onmessageex(Func f)
+    {
+        messageExHandler = f;
         return *this;
     }
 
@@ -409,6 +416,10 @@ class WebSocketRule : public BaseRule
     std::function<void(crow::websocket::Connection&)> openHandler;
     std::function<void(crow::websocket::Connection&, const std::string&, bool)>
         messageHandler;
+    std::function<void(crow::websocket::Connection&, std::string_view,
+                       crow::websocket::MessageType type,
+                       std::function<void()>&& whenComplete)>
+        messageExHandler;
     std::function<void(crow::websocket::Connection&, const std::string&)>
         closeHandler;
     std::function<void(crow::websocket::Connection&)> errorHandler;

--- a/http/routing.hpp
+++ b/http/routing.hpp
@@ -1387,28 +1387,8 @@ class Router
                          << "' " << static_cast<uint32_t>(*verb) << " / "
                          << rules[ruleIndex]->getMethods();
 
-        // any uncaught exceptions become 500s
-        try
-        {
-            rules[ruleIndex]->handleUpgrade(req, asyncResp,
-                                            std::forward<Adaptor>(adaptor));
-        }
-        catch (const std::exception& e)
-        {
-            BMCWEB_LOG_ERROR << "An uncaught exception occurred: " << e.what();
-            asyncResp->res.result(
-                boost::beast::http::status::internal_server_error);
-            return;
-        }
-        catch (...)
-        {
-            BMCWEB_LOG_ERROR
-                << "An uncaught exception occurred. The type was unknown "
-                   "so no information was available.";
-            asyncResp->res.result(
-                boost::beast::http::status::internal_server_error);
-            return;
-        }
+        rules[ruleIndex]->handleUpgrade(req, asyncResp,
+                                        std::forward<Adaptor>(adaptor));
     }
 
     void handle(Request& req,

--- a/http/routing.hpp
+++ b/http/routing.hpp
@@ -514,6 +514,7 @@ struct RuleParameterTraits
     {
         self_t* self = static_cast<self_t*>(this);
         WebSocketRule* p = new WebSocketRule(self->rule);
+        p->privilegesSet = self->privilegesSet;
         self->ruleToUpgrade.reset(p);
         return *p;
     }

--- a/http/websocket.hpp
+++ b/http/websocket.hpp
@@ -3,6 +3,7 @@
 
 #include <async_resp.hpp>
 #include <boost/asio/buffer.hpp>
+#include <boost/beast/core/multi_buffer.hpp>
 #include <boost/beast/websocket.hpp>
 
 #include <array>
@@ -16,6 +17,12 @@ namespace crow
 {
 namespace websocket
 {
+
+enum class MessageType
+{
+    Binary,
+    Text,
+};
 
 struct Connection : std::enable_shared_from_this<Connection>
 {
@@ -35,9 +42,13 @@ struct Connection : std::enable_shared_from_this<Connection>
 
     virtual void sendBinary(std::string_view msg) = 0;
     virtual void sendBinary(std::string&& msg) = 0;
+    virtual void sendEx(MessageType type, std::string_view msg,
+                        std::function<void()>&& onDone) = 0;
     virtual void sendText(std::string_view msg) = 0;
     virtual void sendText(std::string&& msg) = 0;
     virtual void close(std::string_view msg = "quit") = 0;
+    virtual void deferRead() = 0;
+    virtual void resumeRead() = 0;
     virtual boost::asio::io_context& getIoContext() = 0;
     virtual ~Connection() = default;
 
@@ -72,6 +83,10 @@ class ConnectionImpl : public Connection
         std::function<void(Connection&)> openHandlerIn,
         std::function<void(Connection&, const std::string&, bool)>
             messageHandlerIn,
+        std::function<void(crow::websocket::Connection&, std::string_view,
+                           crow::websocket::MessageType type,
+                           std::function<void()>&& whenComplete)>
+            messageExHandlerIn,
         std::function<void(Connection&, const std::string&)> closeHandlerIn,
         std::function<void(Connection&)> errorHandlerIn) :
         Connection(reqIn, reqIn.session == nullptr ? std::string{}
@@ -79,6 +94,7 @@ class ConnectionImpl : public Connection
         ws(std::move(adaptorIn)), inBuffer(inString, 131088),
         openHandler(std::move(openHandlerIn)),
         messageHandler(std::move(messageHandlerIn)),
+        messageExHandler(std::move(messageExHandlerIn)),
         closeHandler(std::move(closeHandlerIn)),
         errorHandler(std::move(errorHandlerIn)), session(reqIn.session)
     {
@@ -150,28 +166,61 @@ class ConnectionImpl : public Connection
     void sendBinary(const std::string_view msg) override
     {
         ws.binary(true);
-        outBuffer.emplace_back(msg);
+        outBuffer.commit(boost::asio::buffer_copy(outBuffer.prepare(msg.size()),
+                                                  boost::asio::buffer(msg)));
         doWrite();
+    }
+
+    void sendEx(MessageType type, std::string_view msg,
+                std::function<void()>&& onDone) override
+    {
+        if (doingWrite)
+        {
+            BMCWEB_LOG_CRITICAL
+                << "Cannot mix sendEx usage with sendBinary or sendText";
+            onDone();
+            return;
+        }
+        ws.binary(type == MessageType::Binary);
+
+        ws.async_write(boost::asio::buffer(msg),
+                       [weak(weak_from_this()), onDone{std::move(onDone)}](
+                           const boost::beast::error_code& ec, size_t) {
+            std::shared_ptr<Connection> self = weak.lock();
+
+            // Call the done handler regardless of whether we
+            // errored, but before we close things out
+            onDone();
+
+            if (ec)
+            {
+                BMCWEB_LOG_ERROR << "Error in ws.async_write " << ec;
+                self->close("write error");
+            }
+        });
     }
 
     void sendBinary(std::string&& msg) override
     {
         ws.binary(true);
-        outBuffer.emplace_back(std::move(msg));
+        outBuffer.commit(boost::asio::buffer_copy(outBuffer.prepare(msg.size()),
+                                                  boost::asio::buffer(msg)));
         doWrite();
     }
 
     void sendText(const std::string_view msg) override
     {
         ws.text(true);
-        outBuffer.emplace_back(msg);
+        outBuffer.commit(boost::asio::buffer_copy(outBuffer.prepare(msg.size()),
+                                                  boost::asio::buffer(msg)));
         doWrite();
     }
 
     void sendText(std::string&& msg) override
     {
         ws.text(true);
-        outBuffer.emplace_back(std::move(msg));
+        outBuffer.commit(boost::asio::buffer_copy(outBuffer.prepare(msg.size()),
+                                                  boost::asio::buffer(msg)));
         doWrite();
     }
 
@@ -196,19 +245,41 @@ class ConnectionImpl : public Connection
     {
         BMCWEB_LOG_DEBUG << "Websocket accepted connection";
 
-        doRead();
-
         if (openHandler)
         {
             openHandler(*this);
         }
+        doRead();
+    }
+
+    void deferRead() override
+    {
+        readingDefered = true;
+
+        // If we're not actively reading, we need to take ownership of
+        // ourselves for a small portion of time, do that, and clear when we
+        // resume.
+        selfOwned = shared_from_this();
+    }
+
+    void resumeRead() override
+    {
+        readingDefered = false;
+        doRead();
+
+        // No longer need to keep ourselves alive now that read is active.
+        selfOwned.reset();
     }
 
     void doRead()
     {
-        ws.async_read(inBuffer,
-                      [this, self(shared_from_this())](
-                          boost::beast::error_code ec, std::size_t bytesRead) {
+        if (readingDefered)
+        {
+            return;
+        }
+        ws.async_read(inBuffer, [this, self(shared_from_this())](
+                                    const boost::beast::error_code& ec,
+                                    size_t bytesRead) {
             if (ec)
             {
                 if (ec != boost::beast::websocket::error::closed)
@@ -222,16 +293,10 @@ class ConnectionImpl : public Connection
                 }
                 return;
             }
-            if (messageHandler)
-            {
-                messageHandler(*this, inString, ws.got_text());
-            }
-            inBuffer.consume(bytesRead);
-            inString.clear();
-            doRead();
+
+            handleMessage(bytesRead);
         });
     }
-
     void doWrite()
     {
         // If we're already doing a write, ignore the request, it will be picked
@@ -241,17 +306,17 @@ class ConnectionImpl : public Connection
             return;
         }
 
-        if (outBuffer.empty())
+        if (outBuffer.size() == 0)
         {
             // Done for now
             return;
         }
         doingWrite = true;
-        ws.async_write(boost::asio::buffer(outBuffer.front()),
-                       [this, self(shared_from_this())](
-                           boost::beast::error_code ec, std::size_t) {
+        ws.async_write(outBuffer.data(), [this, self(shared_from_this())](
+                                             const boost::beast::error_code& ec,
+                                             size_t bytesSent) {
             doingWrite = false;
-            outBuffer.erase(outBuffer.begin());
+            outBuffer.consume(bytesSent);
             if (ec == boost::beast::websocket::error::closed)
             {
                 // Do nothing here.  doRead handler will call the
@@ -269,21 +334,59 @@ class ConnectionImpl : public Connection
     }
 
   private:
+    void handleMessage(size_t bytesRead)
+    {
+        if (messageExHandler)
+        {
+            // Note, because of the interactions with the read buffers,
+            // this message handler overrides the normal message handler
+            messageExHandler(*this, inString, MessageType::Binary,
+                             [this, self(shared_from_this()), bytesRead]() {
+                if (self == nullptr)
+                {
+                    return;
+                }
+
+                inBuffer.consume(bytesRead);
+                inString.clear();
+
+                doRead();
+            });
+            return;
+        }
+
+        if (messageHandler)
+        {
+            messageHandler(*this, inString, ws.got_text());
+        }
+        inBuffer.consume(bytesRead);
+        inString.clear();
+        doRead();
+    }
+
     boost::beast::websocket::stream<Adaptor, false> ws;
 
+    bool readingDefered = false;
     std::string inString;
     boost::asio::dynamic_string_buffer<std::string::value_type,
                                        std::string::traits_type,
                                        std::string::allocator_type>
         inBuffer;
-    std::vector<std::string> outBuffer;
+
+    boost::beast::multi_buffer outBuffer;
     bool doingWrite = false;
 
     std::function<void(Connection&)> openHandler;
     std::function<void(Connection&, const std::string&, bool)> messageHandler;
+    std::function<void(crow::websocket::Connection&, std::string_view,
+                       crow::websocket::MessageType type,
+                       std::function<void()>&& whenComplete)>
+        messageExHandler;
     std::function<void(Connection&, const std::string&)> closeHandler;
     std::function<void(Connection&)> errorHandler;
     std::shared_ptr<persistent_data::UserSession> session;
+
+    std::shared_ptr<Connection> selfOwned;
 };
 } // namespace websocket
 } // namespace crow

--- a/include/dbus_utility.hpp
+++ b/include/dbus_utility.hpp
@@ -16,6 +16,7 @@
 #pragma once
 
 #include "dbus_singleton.hpp"
+#include "logging.hpp"
 
 #include <boost/system/error_code.hpp> // IWYU pragma: keep
 #include <sdbusplus/asio/property.hpp>
@@ -109,6 +110,14 @@ inline void escapePathForDbus(std::string& path)
 {
     const std::regex reg("[^A-Za-z0-9_/]");
     std::regex_replace(path.begin(), path.begin(), path.end(), reg, "_");
+}
+
+inline void logError(const boost::system::error_code& ec)
+{
+    if (ec)
+    {
+        BMCWEB_LOG_ERROR << "DBus error: " << ec << ", cannot call method";
+    }
 }
 
 // gets the string N strings deep into a path


### PR DESCRIPTION
There are a few issues in handling handleUpgrade - esp on websocket areas.

- Remove duplicated req var in a child http_stream
  http_stream has a shadowed 'req' variable between parent and child classes and it may cause the confusion in execution.

- Copy privilegeset into websocket rule
   privilegesSet became empty when a connection is upgraded.
  https://gerrit.openbmc.org/c/openbmc/bmcweb/+/62275

- Remove try-catch blocks on handleUpgrade
   https://gerrit.openbmc.org/c/openbmc/bmcweb/+/61617

- nbd proxy and websocket cleanups
   https://gerrit.openbmc.org/c/openbmc/bmcweb/+/51428
   The nbd (and all websocket daemons) suffer from a problem
    where there is no way to apply socket backpressure, so in certain
    conditions, it's trivial to run the BMC out of memory on a given
    message.  This is a problem.

Tested:
   - Redfish validator passed
   - Some GUI pages - e.g. consoles
