### PR TITLE
1050 add audit log support

### DIFF
--- a/http/http_connection.hpp
+++ b/http/http_connection.hpp
@@ -487,6 +487,7 @@ class Connection :
         if (((req->method() == boost::beast::http::verb::post) &&
              audit::checkPostAudit(*req)) ||
             (req->method() == boost::beast::http::verb::patch) ||
+            (req->method() == boost::beast::http::verb::put) ||
             (req->method() == boost::beast::http::verb::delete_))
         {
 
@@ -502,10 +503,13 @@ class Connection :
 
                 std::string additionalInfo = "";
                 // Exclude the body of account PATCH/POST
-                if ((req->method() == boost::beast::http::verb::patch ||
-                     req->method() == boost::beast::http::verb::post) &&
-                    !req->target().starts_with(
-                        "/redfish/v1/AccountService/Accounts"))
+                // Exclude the body of ConfigFiles PUT
+                if (((req->method() == boost::beast::http::verb::patch ||
+                      req->method() == boost::beast::http::verb::post) &&
+                     !req->target().starts_with(
+                         "/redfish/v1/AccountService/Accounts")) ||
+                    (req->method() == boost::beast::http::verb::put &&
+                     !req->target().starts_with("/ibm/v1/Host/ConfigFiles")))
                 {
                     additionalInfo = req->body + " ";
                 }

--- a/http/http_connection.hpp
+++ b/http/http_connection.hpp
@@ -489,7 +489,8 @@ class Connection :
             (req->method() == boost::beast::http::verb::patch) ||
             (req->method() == boost::beast::http::verb::delete_))
         {
-            if (res.result() == boost::beast::http::status::ok)
+            // Look for good return codes and if so we know the operation passed
+            if ((res.resultInt() >= 200) && (res.resultInt() < 300))
             {
                 audit::auditEvent(*req,
                                   ("op=" + std::string(req->methodString()) +
@@ -506,7 +507,7 @@ class Connection :
                                   false);
             }
         }
-#endif
+#endif // BMCWEB_ENABLE_LINUX_AUDIT_EVENTS
 
         BMCWEB_LOG_INFO << "Response: " << this << ' ' << req->url << ' '
                         << res.resultInt() << " keepalive=" << req->keepAlive();

--- a/http/http_connection.hpp
+++ b/http/http_connection.hpp
@@ -503,13 +503,14 @@ class Connection :
 
                 std::string additionalInfo = "";
                 // Exclude the body of account PATCH/POST
-                // Exclude the body of ConfigFiles PUT
+                // Exclude the body of /ibm/v1 PUT/POST
                 if (((req->method() == boost::beast::http::verb::patch ||
                       req->method() == boost::beast::http::verb::post) &&
-                     !req->target().starts_with(
-                         "/redfish/v1/AccountService/Accounts")) ||
+                     (!req->target().starts_with(
+                          "/redfish/v1/AccountService/Accounts") &&
+                      !req->target().starts_with("/ibm/v1"))) ||
                     (req->method() == boost::beast::http::verb::put &&
-                     !req->target().starts_with("/ibm/v1/Host/ConfigFiles")))
+                     !req->target().starts_with("/ibm/v1")))
                 {
                     additionalInfo = req->body + " ";
                 }

--- a/http/http_connection.hpp
+++ b/http/http_connection.hpp
@@ -489,22 +489,38 @@ class Connection :
             (req->method() == boost::beast::http::verb::patch) ||
             (req->method() == boost::beast::http::verb::delete_))
         {
-            // Look for good return codes and if so we know the operation passed
-            if ((res.resultInt() >= 200) && (res.resultInt() < 300))
+
+            if (userSession != nullptr)
             {
-                audit::auditEvent(*req,
-                                  ("op=" + std::string(req->methodString()) +
-                                   ":" + std::string(req->target()) + " ")
+                bool requestSuccess = false;
+                // Look for good return codes and if so we know the operation
+                // passed
+                if ((res.resultInt() >= 200) && (res.resultInt() < 300))
+                {
+                    requestSuccess = true;
+                }
+
+                std::string additionalInfo = "";
+                // Exclude the body of account PATCH/POST
+                if ((req->method() == boost::beast::http::verb::patch ||
+                     req->method() == boost::beast::http::verb::post) &&
+                    !req->target().starts_with(
+                        "/redfish/v1/AccountService/Accounts"))
+                {
+                    additionalInfo = req->body + " ";
+                }
+
+                audit::auditEvent(("op=" + std::string(req->methodString()) +
+                                   ":" + std::string(req->target()) + " " +
+                                   additionalInfo)
                                       .c_str(),
-                                  true);
+                                  userSession->username,
+                                  req->ipAddress.to_string(), requestSuccess);
             }
             else
             {
-                audit::auditEvent(*req,
-                                  ("op=" + std::string(req->methodString()) +
-                                   ":" + std::string(req->target()) + " ")
-                                      .c_str(),
-                                  false);
+                BMCWEB_LOG_ERROR
+                    << "UserSession is null, not able to log audit event!";
             }
         }
 #endif // BMCWEB_ENABLE_LINUX_AUDIT_EVENTS

--- a/include/audit_events.hpp
+++ b/include/audit_events.hpp
@@ -1,0 +1,100 @@
+#pragma once
+
+#ifdef BMCWEB_ENABLE_LINUX_AUDIT_EVENTS
+#include <libaudit.h>
+
+#include <boost/asio/ip/host_name.hpp>
+#endif
+
+namespace audit
+{
+
+void auditAcctEvent([[maybe_unused]] int type,
+                    [[maybe_unused]] const char* username,
+                    [[maybe_unused]] uid_t uid,
+                    [[maybe_unused]] const char* remoteHostName,
+                    [[maybe_unused]] const char* remoteIpAddress,
+                    [[maybe_unused]] const char* tty,
+                    [[maybe_unused]] bool success)
+{
+#ifdef BMCWEB_ENABLE_LINUX_AUDIT_EVENTS
+    int auditfd;
+
+    const char* op = NULL;
+
+    auditfd = audit_open();
+
+    if (auditfd < 0)
+    {
+        BMCWEB_LOG_ERROR << "Error opening audit socket : " << strerror(errno);
+        return;
+    }
+    if (type == AUDIT_USER_LOGIN)
+    {
+        op = "login";
+    }
+    else if (type == AUDIT_USER_LOGOUT)
+    {
+        op = "logout";
+    }
+
+    if (audit_log_acct_message(auditfd, type, NULL, op, username, uid,
+                               remoteHostName, remoteIpAddress, tty,
+                               int(success)) <= 0)
+    {
+        BMCWEB_LOG_ERROR << "Error writing audit message: " << strerror(errno);
+    }
+
+    close(auditfd);
+#endif
+    return;
+}
+
+inline void auditEvent([[maybe_unused]] const crow::Request& req,
+                       [[maybe_unused]] const char* opPath,
+                       [[maybe_unused]] bool success)
+{
+#ifdef BMCWEB_ENABLE_LINUX_AUDIT_EVENTS
+    int auditfd;
+
+    char cnfgBuff[256];
+    char* user = NULL;
+
+    auditfd = audit_open();
+
+    if (auditfd < 0)
+    {
+        BMCWEB_LOG_ERROR << "Error opening audit socket : " << strerror(errno);
+        return;
+    }
+
+    strcpy(cnfgBuff, opPath);
+
+    // encode user account name to ensure it is in an appropriate format
+    user = audit_encode_nv_string("acct", req.session->username.c_str(), 0);
+    if (user == NULL)
+    {
+        BMCWEB_LOG_ERROR << "Error appending user to audit msg : "
+                         << strerror(errno);
+    }
+    else
+    {
+        strncat(cnfgBuff, user, 50);
+    }
+
+    free(user);
+
+    if (audit_log_user_message(auditfd, AUDIT_USYS_CONFIG, cnfgBuff,
+                               boost::asio::ip::host_name().c_str(),
+                               req.ipAddress.to_string().c_str(), NULL,
+                               int(success)) <= 0)
+    {
+        BMCWEB_LOG_ERROR << "Error writing audit message: " << strerror(errno);
+    }
+
+    close(auditfd);
+#endif
+    return;
+}
+
+} // namespace audit

--- a/include/login_routes.hpp
+++ b/include/login_routes.hpp
@@ -1,5 +1,8 @@
 #pragma once
 
+#ifdef BMCWEB_ENABLE_LINUX_AUDIT_EVENTS
+#include "audit_events.hpp"
+#endif
 #include "multipart_parser.hpp"
 
 #include <app.hpp>
@@ -173,6 +176,13 @@ inline void requestRoutes(App& app)
             if ((pamrc != PAM_SUCCESS) && !isConfigureSelfOnly)
             {
                 asyncResp->res.result(boost::beast::http::status::unauthorized);
+#ifdef BMCWEB_ENABLE_LINUX_AUDIT_EVENTS
+                audit::auditEvent(("op=" + std::string(req.methodString()) +
+                                   ":" + std::string(req.target()) + " ")
+                                      .c_str(),
+                                  std::string(username),
+                                  req.ipAddress.to_string(), false);
+#endif
             }
             else
             {
@@ -225,6 +235,13 @@ inline void requestRoutes(App& app)
             BMCWEB_LOG_DEBUG << "Couldn't interpret password";
             asyncResp->res.result(boost::beast::http::status::bad_request);
         }
+#ifdef BMCWEB_ENABLE_LINUX_AUDIT_EVENTS
+        audit::auditEvent(("op=" + std::string(req.methodString()) + ":" +
+                           std::string(req.target()) + " ")
+                              .c_str(),
+                          std::string(username), req.ipAddress.to_string(),
+                          true);
+#endif
         });
 
     BMCWEB_ROUTE(app, "/logout")

--- a/meson.build
+++ b/meson.build
@@ -97,6 +97,7 @@ feature_map = {
   #'vm-nbdproxy'                                : '-DBMCWEB_ENABLE_VM_NBDPROXY',
   'ibm-led-extensions'                          : '-DBMCWEB_ENABLE_IBM_LED_EXTENSIONS',
   'hw-isolation'                                : '-DBMCWEB_ENABLE_HW_ISOLATION',
+  'audit-events'                                : '-DBMCWEB_ENABLE_LINUX_AUDIT_EVENTS',
 }
 
 # Get the options status and build a project summary to show which flags are
@@ -263,6 +264,11 @@ pam = cxx.find_library('pam', required: true)
 atomic =  cxx.find_library('atomic', required: true)
 openssl = dependency('openssl', required : true)
 bmcweb_dependencies += [pam, atomic, openssl]
+
+if get_option('audit-events').enabled()
+  audit = cxx.find_library('libaudit', required: true)
+  bmcweb_dependencies += audit
+endif
 
 sdbusplus = dependency('sdbusplus', required : false, include_type: 'system')
 if not sdbusplus.found()

--- a/meson_options.txt
+++ b/meson_options.txt
@@ -269,6 +269,12 @@ option(
     value : 'enabled',
     description: 'Enable Event Subscription through websocket'
 )
+option(
+    'audit-events',
+    type: 'feature',
+    value: 'disabled',
+    description: 'Enable audit events support for bmcweb'
+)
 
 # Insecure options. Every option that starts with a `insecure` flag should
 # not be enabled by default for any platform, unless the author fully comprehends

--- a/redfish-core/lib/managers.hpp
+++ b/redfish-core/lib/managers.hpp
@@ -20,6 +20,9 @@
 #endif
 #include "app.hpp"
 #include "dbus_utility.hpp"
+#ifdef BMCWEB_ENABLE_LINUX_AUDIT_EVENTS
+#include "audit_events.hpp"
+#endif
 #include "led.hpp"
 #include "query.hpp"
 #include "redfish_util.hpp"
@@ -103,7 +106,8 @@ inline void setLocationIndicatorActiveState(
  * @param[in] asyncResp - Shared pointer for completing asynchronous calls
  */
 inline void
-    doBMCGracefulRestart(const std::shared_ptr<bmcweb::AsyncResp>& asyncResp)
+    doBMCGracefulRestart(const std::shared_ptr<bmcweb::AsyncResp>& asyncResp,
+                         const crow::Request& req)
 {
     const char* processName = "xyz.openbmc_project.State.BMC";
     const char* objectPath = "/xyz/openbmc_project/state/bmc0";
@@ -116,14 +120,29 @@ inline void
     dbus::utility::DbusVariantType dbusPropertyValue(propertyValue);
 
     crow::connections::systemBus->async_method_call(
-        [asyncResp](const boost::system::error_code ec) {
+        [asyncResp, req](const boost::system::error_code ec) {
         // Use "Set" method to set the property value.
+        std::string postPath =
+            "op=POST:/redfish/v1/Managers/bmc/Actions/Manager.Reset/";
         if (ec)
         {
             BMCWEB_LOG_DEBUG << "[Set] Bad D-Bus request error: " << ec;
             messages::internalError(asyncResp->res);
+#ifdef BMCWEB_ENABLE_LINUX_AUDIT_EVENTS
+            audit::audit_post_event(
+                AUDIT_USYS_CONFIG, postPath, req.session->username.c_str(),
+                boost::asio::ip::host_name().c_str(),
+                req.ipAddress.to_string().c_str(), NULL, false);
+#endif
             return;
         }
+
+#ifdef BMCWEB_ENABLE_LINUX_AUDIT_EVENTS
+        audit::audit_post_event(
+            AUDIT_USYS_CONFIG, postPath, req.session->username.c_str(),
+            boost::asio::ip::host_name().c_str(),
+            req.ipAddress.to_string().c_str(), NULL, true);
+#endif
 
         messages::success(asyncResp->res);
         },
@@ -194,7 +213,7 @@ inline void requestRoutesManagerResetAction(App& app)
         if (resetType == "GracefulRestart")
         {
             BMCWEB_LOG_DEBUG << "Proceeding with " << resetType;
-            doBMCGracefulRestart(asyncResp);
+            doBMCGracefulRestart(asyncResp, req);
             return;
         }
         if (resetType == "ForceRestart")
@@ -275,7 +294,7 @@ inline void requestRoutesManagerResetToDefaultsAction(App& app)
             }
             // Factory Reset doesn't actually happen until a reboot
             // Can't erase what the BMC is running on
-            doBMCGracefulRestart(asyncResp);
+            doBMCGracefulRestart(asyncResp, req);
             },
             "xyz.openbmc_project.Software.BMC.Updater",
             "/xyz/openbmc_project/software",
@@ -1852,7 +1871,8 @@ inline void
  */
 inline void
     setActiveFirmwareImage(const std::shared_ptr<bmcweb::AsyncResp>& aResp,
-                           const std::string& runningFirmwareTarget)
+                           const std::string& runningFirmwareTarget,
+                           const crow::Request& req)
 {
     // Get the Id from /redfish/v1/UpdateService/FirmwareInventory/<Id>
     std::string::size_type idPos = runningFirmwareTarget.rfind('/');
@@ -1876,7 +1896,7 @@ inline void
     // Make sure the image is valid before setting priority
     crow::connections::systemBus->async_method_call(
         [aResp, firmwareId,
-         runningFirmwareTarget](const boost::system::error_code ec,
+         runningFirmwareTarget, req](const boost::system::error_code ec,
                                 dbus::utility::ManagedObjectType& subtree) {
         if (ec)
         {
@@ -1932,14 +1952,14 @@ inline void
         // An addition could be a Redfish Setting like
         // ActiveSoftwareImageApplyTime and support OnReset
         crow::connections::systemBus->async_method_call(
-            [aResp](const boost::system::error_code ec2) {
+            [aResp, req](const boost::system::error_code ec2) {
             if (ec2)
             {
                 BMCWEB_LOG_DEBUG << "D-Bus response error setting.";
                 messages::internalError(aResp->res);
                 return;
             }
-            doBMCGracefulRestart(aResp);
+            doBMCGracefulRestart(aResp, req);
             },
 
             "xyz.openbmc_project.Software.BMC.Updater",

--- a/redfish-core/lib/redfish_sessions.hpp
+++ b/redfish-core/lib/redfish_sessions.hpp
@@ -14,7 +14,9 @@
 // limitations under the License.
 */
 #pragma once
-
+#ifdef BMCWEB_ENABLE_LINUX_AUDIT_EVENTS
+#include "audit_events.hpp"
+#endif
 #include "error_messages.hpp"
 #include "persistent_data.hpp"
 
@@ -223,10 +225,11 @@ inline void handleSessionCollectionPost(
         messages::resourceAtUriUnauthorized(asyncResp->res, req.urlView,
                                             "Invalid username or password");
 #ifdef BMCWEB_ENABLE_LINUX_AUDIT_EVENTS
-        audit::audit_acct_event(
-            AUDIT_USER_LOGIN, username.c_str(), getuid(),
-            boost::asio::ip::host_name().c_str(),
-            req.ipAddress.to_string().c_str(), NULL, false);
+        audit::auditEvent(("op=" + std::string(req.methodString()) + ":" +
+                           std::string(req.target()) + " ")
+                              .c_str(),
+                          std::string(username), req.ipAddress.to_string(),
+                          false);
 #endif
         return;
     }
@@ -276,10 +279,10 @@ inline void handleSessionCollectionPost(
     asyncResp->res.result(boost::beast::http::status::created);
 
 #ifdef BMCWEB_ENABLE_LINUX_AUDIT_EVENTS
-    audit::audit_acct_event(
-        AUDIT_USER_LOGIN, username.c_str(), getuid(),
-        boost::asio::ip::host_name().c_str(),
-        req.ipAddress.to_string().c_str(), NULL, true);
+    audit::auditEvent(("op=" + std::string(req.methodString()) + ":" +
+                       std::string(req.target()) + " ")
+                          .c_str(),
+                      std::string(username), req.ipAddress.to_string(), true);
 #endif
 
     if (session->isConfigureSelfOnly)

--- a/redfish-core/lib/redfish_sessions.hpp
+++ b/redfish-core/lib/redfish_sessions.hpp
@@ -15,9 +15,6 @@
 */
 #pragma once
 
-#ifdef BMCWEB_ENABLE_LINUX_AUDIT_EVENTS
-#include "audit_events.hpp"
-#endif
 #include "error_messages.hpp"
 #include "persistent_data.hpp"
 


### PR DESCRIPTION
Pull in all of the commits needed to support audit logging in bmcweb. These are all previously merged in 1030/1040.

This introduces a new bmcweb meson option, audit-events, which is defaulted to disabled. A later commit to openbmc/openbmc will enable audit logging on 1050. 

When audit-events is enabled all bmcweb PATCH, POST, PUT, and DELETE events are logged using the Linux kernel auditd subsystem. Additionally, login events coming through bmcweb are also recorded.

The body of the events is recorded as well except in the following cases:
- /redfish/v1/AccountService/Accounts PATCH/POST events - body is not recorded as it may contain clear text password
- /ibm/v1 PATCH/POST/PUT events - body is not recorded as it contains HMC config file binary data

Events are recorded in /var/log/audit/. User type dreport will gather these log files. See: [PR #100 phosphor-debug-collector](https://github.com/ibm-openbmc/phosphor-debug-collector/pull/100)

Upstream: [Discussion has begun for upstream work.](https://gerrit.openbmc.org/c/openbmc/bmcweb/+/55532) I will be addressing the community concerns brought up there as well as updating with the current state of this implementation.

Tested: Enabled auditing then initiated a variety of Redfish events using curl. Confirmed the events were recorded and confirmed the data recorded was accurate. Confirmed password was not included in audit data recorded.

