### PR TITLE
Fix broadcast eventing issue

### DIFF
--- a/include/ibm/management_console_rest.hpp
+++ b/include/ibm/management_console_rest.hpp
@@ -532,7 +532,12 @@ inline void
         asyncResp->res.result(boost::beast::http::status::bad_request);
         return;
     }
-    redfish::EventServiceManager::getInstance().sendBroadcastMsg(broadcastMsg);
+
+    std::string origin = "/ibm/v1/HMC/BroadcastService";
+    nlohmann::json msgJson = {{"Message", broadcastMsg}};
+
+    redfish::EventServiceManager::getInstance().sendEvent(msgJson, origin,
+                                                          "BroadcastService");
 }
 
 inline void handleFileUrl(const crow::Request& req,

--- a/redfish-core/include/event_service_manager.hpp
+++ b/redfish-core/include/event_service_manager.hpp
@@ -1085,23 +1085,6 @@ class EventServiceManager
             }
         }
     }
-    void sendBroadcastMsg(const std::string& broadcastMsg)
-    {
-        for (const auto& it : this->subscriptionsMap)
-        {
-            std::shared_ptr<Subscription> entry = it.second;
-            nlohmann::json msgJson;
-            msgJson["Timestamp"] =
-                redfish::time_utils::getDateTimeOffsetNow().first;
-            msgJson["OriginOfCondition"] = "/ibm/v1/HMC/BroadcastService";
-            msgJson["Name"] = "Broadcast Message";
-            msgJson["Message"] = broadcastMsg;
-
-            std::string strMsg = msgJson.dump(
-                2, ' ', true, nlohmann::json::error_handler_t::replace);
-            entry->sendEvent(strMsg);
-        }
-    }
 
 #ifndef BMCWEB_ENABLE_REDFISH_DBUS_LOG_ENTRIES
 


### PR DESCRIPTION
Broadcast events were not sent in the right format to the connected client due to which the client was unable to process the event.

Currently the events are sent in the following format: events:{
  "Message": "<>",
  "Name": "Broadcast Message",
  "OriginOfCondition": "/ibm/v1/HMC/BroadcastService",
  "Timestamp": "2023-05-05T03:15:50+00:00"
}

With this PR, the event json is changed to the following format which is the common format for all kinds of events: {
  "@odata.type":"#Event.v1_4_0.Event",
  "Events":{
     "EventId":"Broadcast Event",
     "EventTimestamp":"2020-07-15T12:03:30+00:00",
     "MemberId":"Broadcast Event",
     "Message":"Hi This is a message to forward to a single HMC",
     "OriginOfCondition":"/ibm/v1/HMC/BroadcastService"
  },
  "Id":1,
  "Name":"Event Log"
}

Fixes: https://jazz07.rchland.ibm.com:13443/jazz/web/projects/CSSD#action=com.ibm.team.workitem.viewWorkItem&id=516553

Tested By:
POST https://${bmc}/ibm/v1/HMC/BroadcastService -d '{"Message":"A Test message"}'