### PR TITLE
Don't internal error if no slot location code

### DIFF
--- a/redfish-core/lib/pcie_slots.hpp
+++ b/redfish-core/lib/pcie_slots.hpp
@@ -358,6 +358,13 @@ inline void getLocationCode(const std::shared_ptr<bmcweb::AsyncResp>& asyncResp,
                            const std::string& property) {
         if (ec1)
         {
+            if (ec1.value() == EBADR)
+            {
+                // Don't always have PCIeSlot location codes
+                BMCWEB_LOG_DEBUG << "No slot location code found";
+                return;
+            }
+
             BMCWEB_LOG_ERROR << "Can't get location code property for PCIeSlot";
             messages::internalError(asyncResp->res);
             return;


### PR DESCRIPTION
https://github.com/ibm-openbmc/bmcweb/pull/650 added PcieSlots Location Code but it throws an internal error when there is no location code interface. Location code isn't required and logical slots don't have a location code so just leave off location code if the interface isn't there. This is what we had for 1030.

Archana was seeing "Base.1.13.0.InternalError", at https://${bmc}/redfish/v1/Chassis/chassis15364/PCIeSlots

Tested: Loaded onto the system and didn't see the error anymore.