### PR TITLE
Register events for SAI logical LEDs

### DIFF
--- a/include/event_dbus_monitor.hpp
+++ b/include/event_dbus_monitor.hpp
@@ -20,6 +20,8 @@ static std::shared_ptr<sdbusplus::bus::match::match> matchBIOSAttrUpdate;
 static std::shared_ptr<sdbusplus::bus::match::match> matchBootProgressChange;
 static std::shared_ptr<sdbusplus::bus::match::match> matchEventLogCreated;
 static std::shared_ptr<sdbusplus::bus::match::match> matchPostCodeChange;
+static std::shared_ptr<sdbusplus::bus::match::match> matchPlatformSAIChange;
+static std::shared_ptr<sdbusplus::bus::match::match> matchPartitionSAIChange;
 
 static uint64_t postCodeCounter = 0;
 
@@ -34,6 +36,7 @@ void registerBIOSAttrUpdateSignal();
 void registerBootProgressChangeSignal();
 void registerEventLogCreatedSignal();
 void registerPostCodeChangeSignal();
+void registerSAIStateChangeSignal();
 
 inline void sendEventOnEthIntf(const std::string& origin)
 {
@@ -195,6 +198,32 @@ inline void postCodePropertyChange(sdbusplus::message::message& msg)
                               postcodeEntryID;
     redfish::EventServiceManager::getInstance().sendEvent(
         redfish::messages::resourceCreated(), eventOrigin, "ComputerSystem");
+}
+
+inline void saiStateChangeSignal(sdbusplus::message::message& msg)
+{
+    BMCWEB_LOG_DEBUG << "System Attention Indicator State change match fired";
+
+    if (msg.is_method_error())
+    {
+        BMCWEB_LOG_ERROR << "SAI State change signal error";
+        return;
+    }
+
+    boost::container::flat_map<std::string, std::variant<bool>> values;
+    std::string objName;
+    msg.read(objName, values);
+
+    auto find = values.find("Asserted");
+    if (find == values.end())
+    {
+        return;
+    }
+
+    // Push an event
+    std::string origin = "/redfish/v1/Systems/system";
+    redfish::EventServiceManager::getInstance().sendEvent(
+        redfish::messages::resourceChanged(), origin, "ComputerSystem");
 }
 
 void registerHostStateChangeSignal()
@@ -586,5 +615,27 @@ void registerBIOSAttrUpdateSignal()
         biosAttrUpdate);
 }
 
+void registerSAIStateChangeSignal()
+{
+    BMCWEB_LOG_DEBUG
+        << "Platform System attention Indicator state change signal - Register";
+
+    matchPlatformSAIChange = std::make_unique<sdbusplus::bus::match::match>(
+        *crow::connections::systemBus,
+        "type='signal',member='PropertiesChanged',interface='org.freedesktop."
+        "DBus.Properties',path='/xyz/openbmc_project/led/groups/platform_system_attention_indicator',"
+        "arg0='xyz.openbmc_project.Led.Group'",
+        saiStateChangeSignal);
+
+    BMCWEB_LOG_DEBUG
+        << "Partition System attention Indicator state change signal - Register";
+
+    matchPartitionSAIChange = std::make_unique<sdbusplus::bus::match::match>(
+        *crow::connections::systemBus,
+        "type='signal',member='PropertiesChanged',interface='org.freedesktop."
+        "DBus.Properties',path='/xyz/openbmc_project/led/groups/partition_system_attention_indicator',"
+        "arg0='xyz.openbmc_project.Led.Group'",
+        saiStateChangeSignal);
+}
 } // namespace dbus_monitor
 } // namespace crow

--- a/src/webserver_main.cpp
+++ b/src/webserver_main.cpp
@@ -143,6 +143,9 @@ static int run()
     // Start hypervisor app dbus monitor for hypervisor
     // network configurations
     crow::dbus_monitor::registerVMIConfigChangeSignal();
+    // Start Platform and Partition SAI state change monitor
+    crow::dbus_monitor::registerSAIStateChangeSignal();
+
 #endif
 
 #ifdef BMCWEB_ENABLE_GOOGLE_API


### PR DESCRIPTION
HMC is not receiving events for the SAI logical LEDs like platform_system_attention_indicator and
partition_system_attention_indicator due to which the System Attention LED on HMC GUI displayed wrong status.

This commit fixes it by registering the redfish events for the above mentioned logical LEDs, so that whenever there is a PropertiesChanged signal generated on Asserted property, a redfish signal gets generated with the origin /Systems/system.

HMC can now capture the signal with the origin /Systems/system and queries the Properties (under the origin) which are changed.

Test:
busctl set-property xyz.openbmc_project.LED.GroupManager
 /xyz/openbmc_project/led/groups/platform_system_attention_indicator
 xyz.openbmc_project.Led.Group Asserted b true

busctl set-property xyz.openbmc_project.LED.GroupManager
/xyz/openbmc_project/led/groups/partition_system_attention_indicator
xyz.openbmc_project.Led.Group Asserted b true

2023-05-09 10:51:02.824 [Thread-9410]  :: EbmcRedfishEventHandler eventRecord for 9.3.29.122 - EventRecord [eventGroupId=0, eventId=15, eventTimestamp=2023-05-09T10:52:37+00:00, memberId=0, message=One or more resource properties have changed., messageArgs=[], messageId=ResourceEvent.1.0.3.ResourceChanged,
originOfCondition=/redfish/v1/Systems/system, severity=null]

On HMC GUI - System Attention LED is toggled on