### PR TITLE
Introducing DHCPv6 parameters to network config

### DIFF
--- a/redfish-core/lib/ethernet.hpp
+++ b/redfish-core/lib/ethernet.hpp
@@ -396,6 +396,33 @@ inline bool extractEthernetInterfaceData(
                                 ethData.hostNameEnabled = *hostNameEnabled;
                             }
                         }
+                        if (propertyPair.first == "DNSv6Enabled")
+                        {
+                            const bool* dnsv6Enabled =
+                                std::get_if<bool>(&propertyPair.second);
+                            if (dnsv6Enabled != nullptr)
+                            {
+                                ethData.dnsv6Enabled = *dnsv6Enabled;
+                            }
+                        }
+                        else if (propertyPair.first == "NTPv6Enabled")
+                        {
+                            const bool* ntpv6Enabled =
+                                std::get_if<bool>(&propertyPair.second);
+                            if (ntpv6Enabled != nullptr)
+                            {
+                                ethData.ntpv6Enabled = *ntpv6Enabled;
+                            }
+                        }
+                        else if (propertyPair.first == "HostNamev6Enabled")
+                        {
+                            const bool* hostNamev6Enabled =
+                                std::get_if<bool>(&propertyPair.second);
+                            if (hostNamev6Enabled != nullptr)
+                            {
+                                ethData.hostNamev6Enabled = *hostNamev6Enabled;
+                            }
+                        }
                     }
                 }
             }


### PR DESCRIPTION
At present, DHCP parameters like DNSEnabled, NTPEnabled etc. are
shared between DHCPv4 and DHCPv6 in the network configuration.

This change is to enable the possibility to have separate writable
parameters for DHCPv4 and DHCPv6 in the network configuration to be
able to configure them independently.

Tested by:

Used the redfish commands to set and get the parameter values
individually for both DHCPv4 and DHCPv6.
Verified that modifying the new DHCPv6 parameters are not disturbing
the existing DHCPv4 parameters and vice versa.
The values are shared between the ethernet interfaces. When we modify
a DHCPv6 value both interfaces are updated

Upstream PR : https://gerrit.openbmc.org/c/openbmc/bmcweb/+/63390