### PR TITLE
Move to boost 1.82

### DIFF
--- a/subprojects/boost.wrap
+++ b/subprojects/boost.wrap
@@ -1,9 +1,9 @@
 [wrap-file]
-directory = boost_1_81_0
+directory = boost_1_82_0
 
-source_url = https://boostorg.jfrog.io/artifactory/main/release/1.81.0/source/boost_1_81_0.tar.bz2
-source_hash = 71feeed900fbccca04a3b4f2f84a7c217186f28a940ed8b7ed4725986baf99fa
-source_filename = 1_81_0.tar.bz2
+source_url = https://boostorg.jfrog.io/artifactory/main/release/1.82.0/source/boost_1_82_0.tar.bz2
+source_hash = a6e1ab9b0860e6a2881dd7b21fe9f737a095e5f33a3a874afc6a345228597ee6
+source_filename = 1_82_0.tar.bz2
 
 patch_directory = boost
 


### PR DESCRIPTION
Took this file from upstream at
https://gerrit.openbmc.org/c/openbmc/bmcweb/+/62818/11/subprojects/boost.wrap

We don't actually need this to accomplish building upstream bmcweb with 1050. 
https://github.ibm.com/openbmc/openbmc/pull/3649

But will want if we start using Boost::urls::format or other boost 1.82 features. Because of that I propose we just move to it. 

Tested: Built with 1050 and looked good when running out to /tmp/ on a rainier