### PR TITLE
Audit Log: Correct logging of success login case.

### DIFF
--- a/include/login_routes.hpp
+++ b/include/login_routes.hpp
@@ -228,6 +228,13 @@ inline void requestRoutes(App& app)
                     // if content type is json, assume json token
                     asyncResp->res.jsonValue["token"] = session->sessionToken;
                 }
+#ifdef BMCWEB_ENABLE_LINUX_AUDIT_EVENTS
+                audit::auditEvent(("op=" + std::string(req.methodString()) +
+                                   ":" + std::string(req.target()) + " ")
+                                      .c_str(),
+                                  std::string(username),
+                                  req.ipAddress.to_string(), true);
+#endif
             }
         }
         else
@@ -235,13 +242,6 @@ inline void requestRoutes(App& app)
             BMCWEB_LOG_DEBUG << "Couldn't interpret password";
             asyncResp->res.result(boost::beast::http::status::bad_request);
         }
-#ifdef BMCWEB_ENABLE_LINUX_AUDIT_EVENTS
-        audit::auditEvent(("op=" + std::string(req.methodString()) + ":" +
-                           std::string(req.target()) + " ")
-                              .c_str(),
-                          std::string(username), req.ipAddress.to_string(),
-                          true);
-#endif
         });
 
     BMCWEB_ROUTE(app, "/logout")


### PR DESCRIPTION
The audit logging of a success login case was happening even if the login failed. This was because of the placement of the callout to do the logging. Moved the callout so that the logging only happens after a pamAuthenticateUser() call. Success or fail reported will depend on result of the authentication.

This fixes STG Defect 532686.

Tested:
Initiated failed login and saw only failure audit entry added.
Initiated success login and saw only success audit entry added.