### PR TITLE
Leave off SerialConsole if EBADR|ETIMEDOUT

### DIFF
--- a/redfish-core/lib/systems.hpp
+++ b/redfish-core/lib/systems.hpp
@@ -2430,6 +2430,12 @@ inline void afterPortRequest(
 {
     if (ec)
     {
+        // These properties aren't critical if we see a timeout or if resource
+        // not found don't throw an error
+        if (ec.value() == EBADR || ec.value() == ETIMEDOUT)
+        {
+            return;
+        }
         messages::internalError(asyncResp->res);
         return;
     }


### PR DESCRIPTION
Defect is 531454 
Upstream is https://gerrit.openbmc.org/c/openbmc/bmcweb/+/63539

We have seen the following error:
```
May 10 21:52:35 xxxxxxbmc bmcweb[693]: (2023-05-10 21:52:35) [ERROR "redfish_util.hpp":108] generic:110
May 10 21:52:35 xxxxxxbmc bmcweb[693]: (2023-05-10 21:52:35) [CRITICAL "error_messages.cpp":258] Internal Error
../git/redfish-core/lib/systems.hpp(2435:32) `void redfish::afterPortRequest(const std::shared_ptr<bmcweb::AsyncResp>&, const boost::system::error_code&, const
std::vector<std::tuple<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> >,
std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> >, bool> >&)`:
```
https://gerrit.openbmc.org/c/openbmc/bmcweb/+/44438 added code to get the SerialConsole/IPMI/ServiceEnabled, SerialConsole/SSH/ServiceEnabled, and SerialConsole/SSH/Port based on phosphor-ipmi-net and obmc-console-ssh. We have seen this Systemd ListUnits call timeout (trace above). These properties aren't needed in
redfish/v1/Systems/system so if a time out or resource not found occurs don't return an error.

The one we actually care about is not returning an error on ETIMEDOUT but put EBADR in there as well. The BMC was higher utilization when we saw these timeouts.

Tested: Tested the good path. The properties look the same. No testing on this if (ec) path.
```
  "SerialConsole": {
    "IPMI": {
      "ServiceEnabled": true
    },
    "MaxConcurrentSessions": 15,
    "SSH": {
      "HotKeySequenceDisplay": "Press ~. to exit console",
      "Port": 2200,
      "ServiceEnabled": true
    }
  },
```
Change-Id: I129c6bcb9b8212fc14449bbd1595cf99c5a3c86c