### PR TITLE
Fix Redfish Validators: ERROR - /redfish/v1/Systems/system/Storage/1/Drives/media0 and failRedfishUriStrict

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -380,6 +380,7 @@ srcfiles_unittest = files(
   'test/redfish-core/include/utils/stl_utils_test.cpp',
   'test/redfish-core/include/utils/time_utils_test.cpp',
   'test/redfish-core/lib/chassis_test.cpp',
+  'test/redfish-core/lib/sensors_test.cpp',
   'test/redfish-core/lib/log_services_dump_test.cpp',
   'test/redfish-core/lib/service_root_test.cpp',
   'test/redfish-core/lib/thermal_subsystem_test.cpp',

--- a/redfish-core/lib/sensors.hpp
+++ b/redfish-core/lib/sensors.hpp
@@ -21,6 +21,7 @@
 #include <boost/algorithm/string/classification.hpp>
 #include <boost/algorithm/string/find.hpp>
 #include <boost/algorithm/string/predicate.hpp>
+#include <boost/algorithm/string/replace.hpp>
 #include <boost/algorithm/string/split.hpp>
 #include <boost/range/algorithm/replace_copy_if.hpp>
 #include <dbus_singleton.hpp>
@@ -732,7 +733,7 @@ inline void objectPropertiesToJson(
 {
     if (chassisSubNode == sensors::node::sensors)
     {
-        std::string subNodeEscaped(chassisSubNode);
+        std::string subNodeEscaped(sensorType);
         subNodeEscaped.erase(
             std::remove(subNodeEscaped.begin(), subNodeEscaped.end(), '_'),
             subNodeEscaped.end());
@@ -2577,6 +2578,24 @@ inline bool
     return false;
 }
 
+inline std::pair<std::string, std::string>
+    splitSensorNameAndType(std::string_view sensorId)
+{
+    size_t index = sensorId.find('_');
+    if (index == std::string::npos)
+    {
+        return std::make_pair<std::string, std::string>("", "");
+    }
+    std::string sensorType{sensorId.substr(0, index)};
+    std::string sensorName{sensorId.substr(index + 1)};
+    // fan_pwm and fan_tach need special handling
+    if (sensorType == "fantach" || sensorType == "fanpwm")
+    {
+        sensorType.insert(3, 1, '_');
+    }
+    return std::make_pair(sensorType, sensorName);
+}
+
 /**
  * @brief Entry point for overriding sensor values of given sensor
  *
@@ -2633,8 +2652,10 @@ inline void setSensorsOverride(
         for (const auto& item : overrideMap)
         {
             const auto& sensor = item.first;
-            if (!findSensorNameUsingSensorPath(sensor, *sensorsList,
-                                               *sensorNames))
+            std::pair<std::string, std::string> sensorNameType =
+                splitSensorNameAndType(sensor);
+            if (!findSensorNameUsingSensorPath(sensorNameType.second,
+                                               *sensorsList, *sensorNames))
             {
                 BMCWEB_LOG_INFO << "Unable to find memberId " << item.first;
                 messages::resourceNotFound(sensorAsyncResp->asyncResp->res,
@@ -2875,33 +2896,28 @@ inline void handleSensorGet(App& app, const crow::Request& req,
     {
         return;
     }
-    size_t index = sensorId.find('_');
-    if (index == std::string::npos)
+    std::pair<std::string, std::string> nameType =
+        splitSensorNameAndType(sensorId);
+    if (nameType.first.empty() || nameType.second.empty())
     {
         messages::resourceNotFound(asyncResp->res, sensorId, "Sensor");
         return;
     }
+
     asyncResp->res.jsonValue["@odata.id"] = crow::utility::urlFromPieces(
         "redfish", "v1", "Chassis", chassisId, "Sensors", sensorId);
-    std::string sensorType = sensorId.substr(0, index);
-    std::string sensorName = sensorId.substr(index + 1);
-    // fan_pwm and fan_tach need special handling
-    if (sensorType == "fantach" || sensorType == "fanpwm")
-    {
-        sensorType.insert(3, 1, '_');
-    }
 
     BMCWEB_LOG_DEBUG << "Sensor doGet enter";
 
     const std::array<const char*, 1> interfaces = {
         "xyz.openbmc_project.Sensor.Value"};
-    std::string sensorPath = "/xyz/openbmc_project/sensors/" + sensorType +
-                             '/' + sensorName;
+    std::string sensorPath = "/xyz/openbmc_project/sensors/" + nameType.first +
+                             '/' + nameType.second;
     // Get a list of all of the sensors that implement Sensor.Value
     // and get the path and service name associated with the sensor
     crow::connections::systemBus->async_method_call(
-        [asyncResp, sensorPath,
-         sensorName](const boost::system::error_code ec,
+        [asyncResp,
+         sensorPath](const boost::system::error_code ec,
                      const ::dbus::utility::MapperGetObject& subtree) {
         BMCWEB_LOG_DEBUG << "respHandler1 enter";
         if (ec)

--- a/redfish-core/lib/storage.hpp
+++ b/redfish-core/lib/storage.hpp
@@ -15,10 +15,12 @@
 */
 #pragma once
 
+#include "app.hpp"
+#include "dbus_utility.hpp"
+#include "generated/enums/drive.hpp"
+#include "generated/enums/protocol.hpp"
 #include "openbmc_dbus_rest.hpp"
 
-#include <app.hpp>
-#include <dbus_utility.hpp>
 #include <query.hpp>
 #include <registries/privilege_registry.hpp>
 #include <sdbusplus/asio/property.hpp>
@@ -364,40 +366,50 @@ inline void getDriveState(const std::shared_ptr<bmcweb::AsyncResp>& asyncResp,
         });
 }
 
-inline std::optional<std::string> convertDriveType(const std::string& type)
+inline std::optional<drive::MediaType> convertDriveType(std::string_view type)
 {
     if (type == "xyz.openbmc_project.Inventory.Item.Drive.DriveType.HDD")
     {
-        return "HDD";
+        return drive::MediaType::HDD;
     }
     if (type == "xyz.openbmc_project.Inventory.Item.Drive.DriveType.SSD")
     {
-        return "SSD";
+        return drive::MediaType::SSD;
+    }
+    if (type == "xyz.openbmc_project.Inventory.Item.Drive.DriveType.Unknown")
+    {
+        return std::nullopt;
     }
 
-    return std::nullopt;
+    return drive::MediaType::Invalid;
 }
 
-inline std::optional<std::string> convertDriveProtocol(const std::string& proto)
+inline std::optional<protocol::Protocol>
+    convertDriveProtocol(std::string_view proto)
 {
     if (proto == "xyz.openbmc_project.Inventory.Item.Drive.DriveProtocol.SAS")
     {
-        return "SAS";
+        return protocol::Protocol::SAS;
     }
     if (proto == "xyz.openbmc_project.Inventory.Item.Drive.DriveProtocol.SATA")
     {
-        return "SATA";
+        return protocol::Protocol::SATA;
     }
     if (proto == "xyz.openbmc_project.Inventory.Item.Drive.DriveProtocol.NVMe")
     {
-        return "NVMe";
+        return protocol::Protocol::NVMe;
     }
     if (proto == "xyz.openbmc_project.Inventory.Item.Drive.DriveProtocol.FC")
     {
-        return "FC";
+        return protocol::Protocol::FC;
+    }
+    if (proto ==
+        "xyz.openbmc_project.Inventory.Item.Drive.DriveProtocol.Unknown")
+    {
+        return std::nullopt;
     }
 
-    return std::nullopt;
+    return protocol::Protocol::Invalid;
 }
 
 inline void
@@ -433,11 +445,16 @@ inline void
                     return;
                 }
 
-                std::optional<std::string> mediaType = convertDriveType(*value);
+                std::optional<drive::MediaType> mediaType =
+                    convertDriveType(*value);
                 if (!mediaType)
                 {
-                    BMCWEB_LOG_ERROR << "Unsupported DriveType Interface: "
-                                     << *value;
+                    BMCWEB_LOG_WARNING << "UnknownDriveType Interface: "
+                                       << *value;
+                    continue;
+                }
+                if (*mediaType == drive::MediaType::Invalid)
+                {
                     messages::internalError(asyncResp->res);
                     return;
                 }
@@ -473,11 +490,16 @@ inline void
                     return;
                 }
 
-                std::optional<std::string> proto = convertDriveProtocol(*value);
+                std::optional<protocol::Protocol> proto =
+                    convertDriveProtocol(*value);
                 if (!proto)
                 {
-                    BMCWEB_LOG_ERROR << "Unsupported DrivePrototype Interface: "
-                                     << *value;
+                    BMCWEB_LOG_WARNING << "Unknown DrivePrototype Interface: "
+                                       << *value;
+                    continue;
+                }
+                if (*proto == protocol::Protocol::Invalid)
+                {
                     messages::internalError(asyncResp->res);
                     return;
                 }

--- a/static/redfish/v1/schema/OemLogEntryAttachment_v1.xml
+++ b/static/redfish/v1/schema/OemLogEntryAttachment_v1.xml
@@ -19,6 +19,10 @@
 
     <Schema xmlns="http://docs.oasis-open.org/odata/ns/edm" Namespace="OemLogEntryAttachment">
       <Annotation Term="Redfish.OwningEntity" String="IBM"/>
+    </Schema>
+
+    <Schema xmlns="http://docs.oasis-open.org/odata/ns/edm" Namespace="OemLogEntryAttachment.v1_0_0">
+      <Annotation Term="Redfish.OwningEntity" String="IBM"/>
 
       <ComplexType Name="Oem" BaseType="Resource.OemObject">
         <Annotation Term="OData.AdditionalProperties" Bool="true"/>

--- a/static/redfish/v1/schema/OemServiceRoot_v1.xml
+++ b/static/redfish/v1/schema/OemServiceRoot_v1.xml
@@ -23,7 +23,11 @@
 
     <Schema xmlns="http://docs.oasis-open.org/odata/ns/edm" Namespace="OemServiceRoot">
       <Annotation Term="Redfish.OwningEntity" String="IBM"/>
+    </Schema>
 
+
+    <Schema xmlns="http://docs.oasis-open.org/odata/ns/edm" Namespace="OemServiceRoot.v1_0_0">
+      <Annotation Term="Redfish.OwningEntity" String="IBM"/>
       <ComplexType Name="Oem" BaseType="Resource.OemObject">
         <Annotation Term="OData.AdditionalProperties" Bool="true"/>
         <Annotation Term="OData.Description" String="OemServiceRoot Oem properties."/>

--- a/test/redfish-core/lib/sensors_test.cpp
+++ b/test/redfish-core/lib/sensors_test.cpp
@@ -1,0 +1,36 @@
+#include "sensors.hpp"
+
+#include <gmock/gmock.h> // IWYU pragma: keep
+#include <gtest/gtest.h> // IWYU pragma: keep
+
+// IWYU pragma: no_include <gtest/gtest-message.h>
+// IWYU pragma: no_include <gtest/gtest-test-part.h>
+// IWYU pragma: no_include "gtest/gtest_pred_impl.h"
+// IWYU pragma: no_include <gmock/gmock-matchers.h>
+// IWYU pragma: no_include <gtest/gtest-matchers.h>
+
+namespace redfish
+{
+namespace
+{
+
+TEST(SplitSensorNameAndType, Type)
+{
+    EXPECT_EQ(splitSensorNameAndType("fantach_foo_1").first, "fan_tach");
+    EXPECT_EQ(splitSensorNameAndType("temperature_foo2").first, "temperature");
+}
+
+TEST(SplitSensorNameAndType, Name)
+{
+    EXPECT_EQ(splitSensorNameAndType("fantach_foo_1").second, "foo_1");
+    EXPECT_EQ(splitSensorNameAndType("temperature_foo2").second, "foo2");
+}
+
+TEST(SplitSensorNameAndType, Error)
+{
+    EXPECT_TRUE(splitSensorNameAndType("fantach").first.empty());
+    EXPECT_TRUE(splitSensorNameAndType("temperature").second.empty());
+}
+
+} // namespace
+} // namespace redfish


### PR DESCRIPTION
Defect is 430415

Two commits: 

1) Upstream is https://gerrit.openbmc.org/c/openbmc/bmcweb/+/59027 and merged

Hidden in this commit is the missing piece to fix the following validator error (took a bit to figure out why downstream saw this error and upstream didn't)
```
1 failRedfishUriStrict errors in /redfish/v1/Chassis/chassis/Sensors/current_vdd_p0_dcm0_rail_iout
ERROR - The Id property does not match the last segment of the URI /redfish/v1/Chassis/chassis/Sensors/current_vdd_p0_dcm0_rail_iout
```

Original commit msg:

c1d019a6056a2a0ef50e577b3139ab5a8dc49355 Sensor Optimization

Recently changed the way Ids were calculated in the sensor subsystem. Unfortunately, it wasn't clear to the author that this would effect the sensor override system, which relies on matching up a member ID with a dbus path, and was broken by this change.

This commit breaks out the code to calculate the type and name from a given URI segment into a helper method.

Tested: Inspection only.  Very few systems support this feature.  Code appears more correct than previously, which is known broken, so the lack of testing here seems reasonable.

Change-Id: I9aa8099a947a36b5ce914bc07ae60f1ebf0d209b

2) Upstream is https://gerrit.openbmc.org/c/openbmc/bmcweb/+/61110 and should merge soon

Original commit msg:

Fix the Redfish validator fail for Storage

This commit fixes the problem that Redfish Validator has not passed
because of the analytical URL failure
(Redfish/V1/Systems/System/System/Storage/1/Drives/Media0).

Redfish validator error message:
```
*** /redfish/v1/Systems/system/Storage/1
INFO - Type (Storage.v1_7_1.Storage), GET SUCCESS \
       (time: 0:00:00.184274)
INFO - Attempt 1 of /redfish/v1/Systems/system/Storage/1/ \
       Drives/media0
INFO - Response Time for GET to /redfish/v1/Systems/system/Storage/ \
       1/Drives/media0: 0.15951547500117158 seconds.
ERROR - Drives: GET of resource at URI /redfish/v1/Systems/system/ \
        Storage/1/Drives/media0 returned HTTP error. Check URI.
INFO - 	  FAIL...
INFO -
*** /redfish/v1/Systems/system/Storage/1/Drives/media0
ERROR - URI did not return resource /redfish/v1/Systems/system/ \
        Storage/1/Drives/media0
```
Change-Id: I1c7ff0e8103ce2e65cd3d73f6ef20abfe70a01b5

3. This fixes downstream only IBM OEM schemas. 
The error was 
```
badNamespaceInclude: 2
$metadata validation results
ERROR - The following namespaces included in $metadata could not be found in the referenced schema URI:
• Namespace OemLogEntryAttachment.v1_0_0 not found in schema /redfish/v1/schema/OemLogEntryAttachment_v1.xml
• Namespace OemServiceRoot.v1_0_0 not found in schema /redfish/v1/schema/OemServiceRoot_v1.xml
```


Tested on 1050: no longer see these errors 
https://sys-openbmc-dev-jenkins.swg-devops.com/job/OpenBMC-Dev/job/test/job/continuous-integration/job/ebmc/job/Redfish-Service-Validator/1277/ passes