### PR TITLE
Processor: Add processor throttle status

### DIFF
--- a/Redfish.md
+++ b/Redfish.md
@@ -905,6 +905,8 @@ other.
 - Socket
 - SparePartNumber
 - Status
+- ThrottleCauses
+- Throttled
 - TotalCores
 - TotalThreads
 - Version

--- a/redfish-core/include/utils/name_utils.hpp
+++ b/redfish-core/include/utils/name_utils.hpp
@@ -13,37 +13,19 @@ namespace name_util
  *
  * @param[i,o] asyncResp  Async response object
  * @param[i]   path       D-bus object path to find the find pretty name
- * @param[i]   services   List of services to exporting the D-bus object path
+ * @param[i]   service    Service for Inventory interface
  * @param[i]   namePath   Json pointer to the name field to update.
  *
  * @return void
  */
-inline void getPrettyName(
-    const std::shared_ptr<bmcweb::AsyncResp>& asyncResp,
-    const std::string& path,
-    const std::vector<std::pair<std::string, std::vector<std::string>>>&
-        services,
-    const nlohmann::json::json_pointer& namePath)
+inline void getPrettyName(const std::shared_ptr<bmcweb::AsyncResp>& asyncResp,
+                          const std::string& path, const std::string& service,
+                          const nlohmann::json::json_pointer& namePath)
 {
     BMCWEB_LOG_DEBUG << "Get PrettyName for: " << path;
 
-    // Ensure we only got one service back
-    if (services.size() != 1)
-    {
-        BMCWEB_LOG_ERROR << "Invalid Service Size " << services.size();
-        for (const auto& service : services)
-        {
-            BMCWEB_LOG_ERROR << "Invalid Service Name: " << service.first;
-        }
-        if (asyncResp)
-        {
-            messages::internalError(asyncResp->res);
-        }
-        return;
-    }
-
     sdbusplus::asio::getProperty<std::string>(
-        *crow::connections::systemBus, services[0].first, path,
+        *crow::connections::systemBus, service, path,
         "xyz.openbmc_project.Inventory.Item", "PrettyName",
 
         [asyncResp, path, namePath](const boost::system::error_code ec,

--- a/redfish-core/lib/assembly.hpp
+++ b/redfish-core/lib/assembly.hpp
@@ -160,7 +160,7 @@ inline void
             nlohmann::json::json_pointer ptr(
                 "/Assemblies/" + std::to_string(assemblyIndex) + "/Name");
 
-            name_util::getPrettyName(aResp, assembly, object, ptr);
+            name_util::getPrettyName(aResp, assembly, object[0].first, ptr);
 
             for (const auto& [serviceName, interfaceList] : object)
             {

--- a/redfish-core/lib/chassis.hpp
+++ b/redfish-core/lib/chassis.hpp
@@ -315,7 +315,7 @@ inline void
                 "#Chassis.v1_16_0.Chassis";
             asyncResp->res.jsonValue["@odata.id"] = "/redfish/v1/Chassis/" +
                                                     chassisId;
-            name_util::getPrettyName(asyncResp, path, connectionNames,
+            name_util::getPrettyName(asyncResp, path, connectionNames[0].first,
                                      "/Name"_json_pointer);
 
             asyncResp->res.jsonValue["ChassisType"] = "RackMount";

--- a/redfish-core/lib/fabric_adapters.hpp
+++ b/redfish-core/lib/fabric_adapters.hpp
@@ -269,7 +269,8 @@ inline void getValidFabricAdapterPath(
             if (fabric_util::checkFabricAdapterId(adapterId, adapterUniq))
             {
                 nlohmann::json::json_pointer ptr("/Name");
-                name_util::getPrettyName(aResp, adapterPath, serviceMap, ptr);
+                name_util::getPrettyName(aResp, adapterPath,
+                                         serviceMap[0].first, ptr);
                 callback(adapterPath, serviceMap.begin()->first,
                          serviceMap.begin()->second);
                 return;

--- a/redfish-core/lib/log_services.hpp
+++ b/redfish-core/lib/log_services.hpp
@@ -5880,14 +5880,14 @@ inline void getPrettyNameByDbusObjPath(
             auto msgPropPath = "/Members"_json_pointer;
             msgPropPath /= entryJsonIdx - 1;
             msgPropPath /= "Message";
-            name_util::getPrettyName(asyncResp, dbusObjPath.str, objType,
-                                     msgPropPath);
+            name_util::getPrettyName(asyncResp, dbusObjPath.str,
+                                     objType[0].first, msgPropPath);
         }
         else
         {
             asyncResp->res.jsonValue["Message"] = dbusObjPath.filename();
-            name_util::getPrettyName(asyncResp, dbusObjPath.str, objType,
-                                     "/Message"_json_pointer);
+            name_util::getPrettyName(asyncResp, dbusObjPath.str,
+                                     objType[0].first, "/Message"_json_pointer);
         }
         },
         "xyz.openbmc_project.ObjectMapper",

--- a/redfish-core/lib/storage.hpp
+++ b/redfish-core/lib/storage.hpp
@@ -152,7 +152,7 @@ inline void
             auto namePointer = "/StorageControllers"_json_pointer;
             namePointer /= index;
             namePointer /= "Name";
-            name_util::getPrettyName(asyncResp, path, interfaceDict,
+            name_util::getPrettyName(asyncResp, path, interfaceDict[0].first,
                                      namePointer);
 
             storageController["MemberId"] = id;
@@ -605,7 +605,7 @@ inline void requestRoutesDrive(App& app)
             asyncResp->res.jsonValue["@odata.type"] = "#Drive.v1_7_0.Drive";
             asyncResp->res.jsonValue["@odata.id"] =
                 "/redfish/v1/Systems/system/Storage/1/Drives/" + driveId;
-            name_util::getPrettyName(asyncResp, path, drive->second,
+            name_util::getPrettyName(asyncResp, path, drive->second[0].first,
                                      "/Name"_json_pointer);
             asyncResp->res.jsonValue["Id"] = driveId;
 


### PR DESCRIPTION
- Update Processor Schema to 18.0
- Add processor throttle status and cause https://gerrit.openbmc.org/c/openbmc/phosphor-dbus-interfaces/+/63063 Throttled: An indication of whether the processor is throttled. ThrottledCauses: An array of reasons that the processor is throttled.
- Remove processor version from messages
- Change getPrettyName to take specific service name instead of map

Ran validator and no new errors were found.

Change-Id: Ia4a58ae0f26ffc6177f418420ba45063471323da