### PR TITLE
1050: Fix NotFound Sensors to report as 404

### DIFF
--- a/redfish-core/lib/sensors.hpp
+++ b/redfish-core/lib/sensors.hpp
@@ -2909,17 +2909,24 @@ inline void handleSensorGet(App& app, const crow::Request& req,
 
     BMCWEB_LOG_DEBUG << "Sensor doGet enter";
 
-    const std::array<const char*, 1> interfaces = {
+    std::array<const char*, 1> interfaces = {
         "xyz.openbmc_project.Sensor.Value"};
     std::string sensorPath = "/xyz/openbmc_project/sensors/" + nameType.first +
                              '/' + nameType.second;
     // Get a list of all of the sensors that implement Sensor.Value
     // and get the path and service name associated with the sensor
-    crow::connections::systemBus->async_method_call(
-        [asyncResp,
-         sensorPath](const boost::system::error_code ec,
+    ::dbus::utility::getDbusObject(
+        sensorPath, interfaces,
+        [asyncResp, sensorId,
+         sensorPath](const boost::system::error_code& ec,
                      const ::dbus::utility::MapperGetObject& subtree) {
         BMCWEB_LOG_DEBUG << "respHandler1 enter";
+        if (ec == boost::system::errc::io_error)
+        {
+            BMCWEB_LOG_WARNING << "Sensor not found from getSensorPaths";
+            messages::resourceNotFound(asyncResp->res, sensorId, "Sensor");
+            return;
+        }
         if (ec)
         {
             messages::internalError(asyncResp->res);
@@ -2929,11 +2936,7 @@ inline void handleSensorGet(App& app, const crow::Request& req,
         }
         getSensorFromDbus(asyncResp, sensorPath, subtree);
         BMCWEB_LOG_DEBUG << "respHandler1 exit";
-        },
-        "xyz.openbmc_project.ObjectMapper",
-        "/xyz/openbmc_project/object_mapper",
-        "xyz.openbmc_project.ObjectMapper", "GetObject", sensorPath,
-        interfaces);
+        });
 }
 
 } // namespace sensors


### PR DESCRIPTION
Sensors that are not found are incorrectly reported as internal Server error and its logging is done as Error.
.
It will be changed to 404 - Not found and its logging will be WARNING.

```
redfishtool raw GET -r ${bmc} -u admin -p 0penBmc0 -S Always /redfish/v1/Chassis/chassis/Sensors/temperature_PCIE_1_Temp_invalid
   redfishtool: Transport: Response Error: status_code: 500 -- Internal Server Error
   redfishtool: raw: Error getting response

curl -k -X GET https://${bmc}/redfish/v1/Chassis/chassis/Sensors/temperature_PCIE_1_Temp_invalid
{
  "@odata.id": "/redfish/v1/Chassis/chassis/Sensors/temperature_PCIE_1_Temp_invalid",
  "error": {
    "@Message.ExtendedInfo": [
      {
        "@odata.type": "#Message.v1_1_1.Message",
        "Message": "The request failed due to an internal service error.  The service is still operational.",
        "MessageArgs": [],
        "MessageId": "Base.1.13.0.InternalError",
        "MessageSeverity": "Critical",
        "Resolution": "Resubmit the request.  If the problem persists, consider resetting the service."
      }
    ],
    "code": "Base.1.13.0.InternalError",
    "message": "The request failed due to an internal service error.  The service is still operational."
  }
}%
```

Its logging is

```
(2023-05-31 15:16:43) [CRITICAL "error_messages.cpp":282] Internal Error \
  ../../../../../../../../../bmcweb/redfish-core/lib/sensors.hpp(2928:36) \
 `redfish::sensors::handleSensorGet(App&, const crow::Request&, \
 const std::shared_ptr<bmcweb::AsyncResp>&, const std::string&, \
 const std::string&)::<lambda(const boost::system::error_code&, const dbus::utility::MapperGetObject&)>`:

(2023-05-31 15:16:43) [ERROR "sensors.hpp":2929] Sensor getSensorPaths resp_handler: Dbus error generic:5
```

The expected behavior will be

```
redfishtool raw GET -r ${bmc} -u admin -p 0penBmc0 -S Always /redfish/v1/Chassis/chassis/Sensors/temperature_PCIE_1_Temp_invalid
   redfishtool: Transport: Response Error: status_code: 404 -- Not Found

curl -k -X GET https://${bmc}/redfish/v1/Chassis/chassis/Sensors/temperature_PCIE_1_Temp_invalid
{
  "@odata.id": "/redfish/v1/Chassis/chassis/Sensors/temperature_PCIE_1_Temp_invalid",
  "error": {
    "@Message.ExtendedInfo": [
      {
        "@odata.type": "#Message.v1_1_1.Message",
        "Message": "The requested resource of type temperature_PCIE_1_Temp_invalid named 'Sensor' was not found.",
        "MessageArgs": [
          "temperature_PCIE_1_Temp_invalid",
          "Sensor"
        ],
        "MessageId": "Base.1.13.0.ResourceNotFound",
        "MessageSeverity": "Critical",
        "Resolution": "Provide a valid resource identifier and resubmit the request."
      }
    ],
    "code": "Base.1.13.0.ResourceNotFound",
    "message": "The requested resource of type temperature_PCIE_1_Temp_invalid named 'Sensor' was not found."
  }
}%

```

Its logging will be:

```
(2023-05-31 20:17:55) [WARNING "sensors.hpp":2928] Sensor not found from getSensorPaths
```

Change-Id: I5a51c1b5c0125b5396068311602964d4e249e297