### PR TITLE
Configure DHCP4 and DHCP6 independently

### DIFF
--- a/redfish-core/lib/ethernet.hpp
+++ b/redfish-core/lib/ethernet.hpp
@@ -86,8 +86,11 @@ struct EthernetInterfaceData
     size_t mtuSize;
     bool autoNeg;
     bool dnsEnabled;
+    bool dnsv6Enabled;
     bool ntpEnabled;
+    bool ntpv6Enabled;
     bool hostNameEnabled;
+    bool hostNamev6Enabled;
     bool linkUp;
     bool nicEnabled;
     bool ipv6AcceptRa;
@@ -359,7 +362,8 @@ inline bool extractEthernetInterfaceData(
                 }
             }
 
-            if (objpath.first == "/xyz/openbmc_project/network/dhcp")
+            if (objpath.first ==
+                "/xyz/openbmc_project/network/" + ethifaceId + "/dhcp4")
             {
                 if (ifacePair.first ==
                     "xyz.openbmc_project.Network.DHCPConfiguration")
@@ -391,6 +395,44 @@ inline bool extractEthernetInterfaceData(
                             if (hostNameEnabled != nullptr)
                             {
                                 ethData.hostNameEnabled = *hostNameEnabled;
+                            }
+                        }
+                    }
+                }
+            }
+            if (objpath.first ==
+                "/xyz/openbmc_project/network/" + ethifaceId + "/dhcp6")
+            {
+                if (ifacePair.first ==
+                    "xyz.openbmc_project.Network.DHCPConfiguration")
+                {
+                    for (const auto& propertyPair : ifacePair.second)
+                    {
+                        if (propertyPair.first == "DNSEnabled")
+                        {
+                            const bool* dnsEnabled =
+                                std::get_if<bool>(&propertyPair.second);
+                            if (dnsEnabled != nullptr)
+                            {
+                                ethData.dnsv6Enabled = *dnsEnabled;
+                            }
+                        }
+                        else if (propertyPair.first == "NTPEnabled")
+                        {
+                            const bool* ntpEnabled =
+                                std::get_if<bool>(&propertyPair.second);
+                            if (ntpEnabled != nullptr)
+                            {
+                                ethData.ntpv6Enabled = *ntpEnabled;
+                            }
+                        }
+                        else if (propertyPair.first == "HostNameEnabled")
+                        {
+                            const bool* hostNameEnabled =
+                                std::get_if<bool>(&propertyPair.second);
+                            if (hostNameEnabled != nullptr)
+                            {
+                                ethData.hostNamev6Enabled = *hostNameEnabled;
                             }
                         }
                     }
@@ -1243,8 +1285,10 @@ inline void setEthernetInterfaceBoolProperty(
         dbus::utility::DbusVariantType{value});
 }
 
-inline void setDHCPv4Config(const std::string& propertyName, const bool& value,
-                            const std::shared_ptr<bmcweb::AsyncResp>& asyncResp)
+inline void setDHCPConfig(const std::string& propertyName, const bool& value,
+                          const std::shared_ptr<bmcweb::AsyncResp>& asyncResp,
+                          const std::string& ethifaceId,
+                          const std::string& nwType)
 {
     BMCWEB_LOG_DEBUG << propertyName << " = " << value;
     crow::connections::systemBus->async_method_call(
@@ -1256,7 +1300,8 @@ inline void setDHCPv4Config(const std::string& propertyName, const bool& value,
             return;
         }
         },
-        "xyz.openbmc_project.Network", "/xyz/openbmc_project/network/dhcp",
+        "xyz.openbmc_project.Network",
+        "/xyz/openbmc_project/network/dhcp/" + ethifaceId + "/" + nwType,
         "org.freedesktop.DBus.Properties", "Set",
         "xyz.openbmc_project.Network.DHCPConfiguration", propertyName,
         dbus::utility::DbusVariantType{value});
@@ -1313,84 +1358,56 @@ inline void handleDHCPPatch(const std::string& ifaceId,
         nextv6DHCPState = ipv6Active;
     }
 
-    bool nextDNS{};
-    if (v4dhcpParms.useDnsServers && v6dhcpParms.useDnsServers)
-    {
-        if (*v4dhcpParms.useDnsServers != *v6dhcpParms.useDnsServers)
-        {
-            messages::generalError(asyncResp->res);
-            return;
-        }
-        nextDNS = *v4dhcpParms.useDnsServers;
-    }
-    else if (v4dhcpParms.useDnsServers)
+    bool nextDNS = ethData.dnsEnabled;
+    bool nextDNSv6 = ethData.dnsv6Enabled;
+    if (v4dhcpParms.useDnsServers)
     {
         nextDNS = *v4dhcpParms.useDnsServers;
     }
-    else if (v6dhcpParms.useDnsServers)
+    if (v6dhcpParms.useDnsServers)
     {
-        nextDNS = *v6dhcpParms.useDnsServers;
-    }
-    else
-    {
-        nextDNS = ethData.dnsEnabled;
+        nextDNSv6 = *v6dhcpParms.useDnsServers;
     }
 
-    bool nextNTP{};
-    if (v4dhcpParms.useNtpServers && v6dhcpParms.useNtpServers)
-    {
-        if (*v4dhcpParms.useNtpServers != *v6dhcpParms.useNtpServers)
-        {
-            messages::generalError(asyncResp->res);
-            return;
-        }
-        nextNTP = *v4dhcpParms.useNtpServers;
-    }
-    else if (v4dhcpParms.useNtpServers)
+    bool nextNTP = ethData.ntpEnabled;
+    bool nextNTPv6 = ethData.ntpv6Enabled;
+    if (v4dhcpParms.useNtpServers)
     {
         nextNTP = *v4dhcpParms.useNtpServers;
     }
-    else if (v6dhcpParms.useNtpServers)
+    if (v6dhcpParms.useNtpServers)
     {
-        nextNTP = *v6dhcpParms.useNtpServers;
-    }
-    else
-    {
-        nextNTP = ethData.ntpEnabled;
+        nextNTPv6 = *v6dhcpParms.useNtpServers;
     }
 
-    bool nextUseDomain{};
-    if (v4dhcpParms.useDomainName && v6dhcpParms.useDomainName)
-    {
-        if (*v4dhcpParms.useDomainName != *v6dhcpParms.useDomainName)
-        {
-            messages::generalError(asyncResp->res);
-            return;
-        }
-        nextUseDomain = *v4dhcpParms.useDomainName;
-    }
-    else if (v4dhcpParms.useDomainName)
+    bool nextUseDomain = ethData.hostNameEnabled;
+    bool nextUsev6Domain = ethData.hostNamev6Enabled;
+    if (v4dhcpParms.useDomainName)
     {
         nextUseDomain = *v4dhcpParms.useDomainName;
     }
-    else if (v6dhcpParms.useDomainName)
+    if (v6dhcpParms.useDomainName)
     {
-        nextUseDomain = *v6dhcpParms.useDomainName;
-    }
-    else
-    {
-        nextUseDomain = ethData.hostNameEnabled;
+        nextUsev6Domain = *v6dhcpParms.useDomainName;
     }
 
     BMCWEB_LOG_DEBUG << "set DHCPEnabled...";
     setDHCPEnabled(ifaceId, "DHCPEnabled", nextv4DHCPState, nextv6DHCPState,
                    asyncResp);
     BMCWEB_LOG_DEBUG << "set DNSEnabled...";
-    setDHCPv4Config("DNSEnabled", nextDNS, asyncResp);
+    setDHCPConfig("DNSEnabled", nextDNS, asyncResp, ifaceId, "dhcp4");
     BMCWEB_LOG_DEBUG << "set NTPEnabled...";
-    setDHCPv4Config("NTPEnabled", nextNTP, asyncResp);
+    setDHCPConfig("NTPEnabled", nextNTP, asyncResp, ifaceId, "dhcp4");
     BMCWEB_LOG_DEBUG << "set HostNameEnabled...";
-    setDHCPv4Config("HostNameEnabled", nextUseDomain, asyncResp);
+    setDHCPConfig("HostNameEnabled", nextUseDomain, asyncResp, ifaceId,
+                  "dhcp4");
+    BMCWEB_LOG_DEBUG << "set DNSv6Enabled...";
+    setDHCPConfig("DNSv6Enabled", nextDNSv6, asyncResp, ifaceId, "dhcp6");
+    BMCWEB_LOG_DEBUG << "set NTPv6Enabled...";
+    setDHCPConfig("NTPv6Enabled", nextNTPv6, asyncResp, ifaceId, "dhcp6");
+    BMCWEB_LOG_DEBUG << "set Hostv6NameEnabled...";
+    setDHCPConfig("HostNamev6Enabled", nextUsev6Domain, asyncResp, ifaceId,
+                  "dhcp6");
 }
 
 inline boost::container::flat_set<IPv4AddressData>::const_iterator
@@ -1768,13 +1785,12 @@ inline void parseInterfaceData(
     jsonResponse["DHCPv4"]["UseNTPServers"] = ethData.ntpEnabled;
     jsonResponse["DHCPv4"]["UseDNSServers"] = ethData.dnsEnabled;
     jsonResponse["DHCPv4"]["UseDomainName"] = ethData.hostNameEnabled;
-
     jsonResponse["DHCPv6"]["OperatingMode"] =
         translateDhcpEnabledToBool(ethData.dhcpEnabled, false) ? "Enabled"
                                                                : "Disabled";
-    jsonResponse["DHCPv6"]["UseNTPServers"] = ethData.ntpEnabled;
-    jsonResponse["DHCPv6"]["UseDNSServers"] = ethData.dnsEnabled;
-    jsonResponse["DHCPv6"]["UseDomainName"] = ethData.hostNameEnabled;
+    jsonResponse["DHCPv6"]["UseNTPServers"] = ethData.ntpv6Enabled;
+    jsonResponse["DHCPv6"]["UseDNSServers"] = ethData.dnsv6Enabled;
+    jsonResponse["DHCPv6"]["UseDomainName"] = ethData.hostNamev6Enabled;
     jsonResponse["StatelessAddressAutoConfig"]["IPv6AutoConfigEnabled"] =
         ethData.ipv6AcceptRa;
 


### PR DESCRIPTION
At present, DHCP parameters like DNSEnabled, NTPEnabled etc. are
shared between DHCPv4 and DHCPv6 in the network configuration.

This change is to enable the possibility to have separate writable
parameters for DHCPv4 and DHCPv6 in the network configuration 
to be able to configure them independently.

The DHCP configuration was in the network manager level earlier,
it has been moved to interface level with
https://github.com/ibm-openbmc/phosphor-networkd/pull/87.
This bmcweb change is to move the redfish settings to the interface level.

Tested by:

Patch request:
  
 curl -k -H "X-Auth-Token: $bmc_token" -X  PATCH -d 
 '{"DHCPv6":{"UseNTPServers":false}}' 
 https://${bmc}/redfish/v1/Managers/bmc/EthernetInterfaces/eth1
 
Patch Response:
 {
  "@Message.ExtendedInfo": [
    {
      "@odata.type": "#Message.v1_1_1.Message",
      "Message": "The request completed successfully.",
      "MessageArgs": [],
      "MessageId": "Base.1.13.0.Success",
      "MessageSeverity": "OK",
      "Resolution": "None"
    }
  ],

Get Request:
curl -k -H "X-Auth-Token: $bmc_token" -X GET 
https://${bmc}/redfish/v1/Managers/bmc/EthernetInterfaces/eth1
  
Get Response:
{
  "@odata.id": "/redfish/v1/Managers/bmc/EthernetInterfaces/eth1",
  "@odata.type": "#EthernetInterface.v1_8_0.EthernetInterface",
  "DHCPv4": {
    "DHCPEnabled": true,
    "UseDNSServers": true,
    "UseDomainName": true,
    "UseNTPServers": true
  },
  "DHCPv6": {
    "OperatingMode": "Enabled",
    "UseDNSServers": true,
    "UseDomainName": true,
    "UseNTPServers": false
  },  
  

Change-Id: I5db29b6dfc8966ff5af51041da11e5b79da7d1dd