### PR TITLE
Hypervisor config: Send relevant error on patch

### DIFF
--- a/redfish-core/lib/hypervisor_system.hpp
+++ b/redfish-core/lib/hypervisor_system.hpp
@@ -569,8 +569,7 @@ inline void
                        const std::shared_ptr<bmcweb::AsyncResp>& asyncResp)
 {
     crow::connections::systemBus->async_method_call(
-        [asyncResp, gateway, ifaceId,
-         address](const boost::system::error_code ec) {
+        [asyncResp, ifaceId, address](const boost::system::error_code ec) {
         if (ec)
         {
             BMCWEB_LOG_DEBUG
@@ -584,6 +583,11 @@ inline void
                                             "redfish", "v1", "Systems",
                                             "hypervisor", "EthernetInterfaces",
                                             ifaceId));
+            }
+            else if (ec == boost::system::errc::io_error)
+            {
+                messages::propertyValueFormatError(asyncResp->res, address,
+                                                   "Address");
             }
             else
             {


### PR DESCRIPTION
This commit will send back relevant redfish error back if the client tries to configure the hypervisor network with invalid IPv6 address.

Tested By:

[1] PATCH -d '{"IPv6StaticAddresses": [{"Address": \ "9.3.2.3:1A:1B:1c:1D:1E:1F", "PrefixLength": 64}]}' \ https://${bmc}/redfish/v1/Systems/hypervisor/EthernetInterfaces/eth0

Change-Id: I262fe3bd222e8e35ac48e4433ba52a4b6d5fb649