### PR TITLE
1050 audit log reuse fd

### DIFF
--- a/include/audit_events.hpp
+++ b/include/audit_events.hpp
@@ -1,5 +1,8 @@
 #pragma once
 
+#include "http_request.hpp"
+#include "logging.hpp"
+
 #include <libaudit.h>
 
 #include <boost/asio/ip/host_name.hpp>

--- a/meson.build
+++ b/meson.build
@@ -362,6 +362,7 @@ srcfiles_unittest = files(
   'test/http/router_test.cpp',
   'test/http/utility_test.cpp',
   'test/http/verb_test.cpp',
+  'test/include/audit_events_test.cpp',
   'test/include/dbus_utility_test.cpp',
   'test/include/google/google_service_root_test.cpp',
   'test/include/http_utility_test.cpp',

--- a/test/include/audit_events_test.cpp
+++ b/test/include/audit_events_test.cpp
@@ -1,0 +1,44 @@
+#include "audit_events.hpp"
+
+#include <gtest/gtest.h> // IWYU pragma: keep
+
+// IWYU pragma: no_include <gtest/gtest-message.h>
+// IWYU pragma: no_include <gtest/gtest-test-part.h>
+// IWYU pragma: no_include "gtest/gtest_pred_impl.h"
+
+namespace audit
+{
+namespace
+{
+
+TEST(auditOpen, PositiveTest)
+{
+    int origFd;
+
+    EXPECT_TRUE(auditOpen());
+    EXPECT_NE(auditfd, -1);
+
+    origFd = auditfd;
+    EXPECT_TRUE(auditOpen());
+    EXPECT_EQ(auditfd, origFd);
+}
+
+TEST(auditClose, PositiveTest)
+{
+    auditClose(true);
+    EXPECT_TRUE(tryOpen);
+    EXPECT_EQ(auditfd, -1);
+
+    EXPECT_TRUE(auditOpen());
+    auditClose(true);
+    EXPECT_TRUE(tryOpen);
+    EXPECT_EQ(auditfd, -1);
+
+    EXPECT_TRUE(auditOpen());
+    auditClose(false);
+    EXPECT_FALSE(tryOpen);
+    EXPECT_EQ(auditfd, -1);
+}
+
+} // namespace
+} // namespace audit

--- a/test/include/audit_events_test.cpp
+++ b/test/include/audit_events_test.cpp
@@ -1,3 +1,4 @@
+#ifdef BMCWEB_ENABLE_LINUX_AUDIT_EVENTS
 #include "audit_events.hpp"
 
 #include <gtest/gtest.h> // IWYU pragma: keep
@@ -42,3 +43,4 @@ TEST(auditClose, PositiveTest)
 
 } // namespace
 } // namespace audit
+#endif // BMCWEB_ENABLE_LINUX_AUDIT_EVENTS


### PR DESCRIPTION
Audit Log: Reuse fd in preparation for upstream push

Performance impact of audit logging is one of the upstream concerns. By reusing the same file-descriptor for the audit logging we can shorten the path when a bmcweb event is logged.

I've also added testcases for the new utility functions added as part of this change. Note: The tests are looking at the internal values set by auditOpen() and auditClose(). I know from reading guidelines that this isn't a desired testing approach. I didn't see much else I could test that didn't check these values. If anyone has better ideas I would be glad to make changes.

I would like to merge these commits into 1050/1060 only. I thought it would be good to get testing on what I propose to push upstream as well as make this align closer with what will hopefully get merged upstream eventually.