### PR TITLE
Fix incorrect DBus service in power supply schema

### DIFF
--- a/redfish-core/lib/fan.hpp
+++ b/redfish-core/lib/fan.hpp
@@ -325,8 +325,10 @@ inline void doFanGet(const std::shared_ptr<bmcweb::AsyncResp>& asyncResp,
         asyncResp->res.jsonValue["Status"]["Health"] = "OK";
         asyncResp->res.jsonValue["Status"]["State"] = "Enabled";
 
+        std::array<const char*, 1> interfaces = {
+            "xyz.openbmc_project.Inventory.Item.Fan"};
         dbus::utility::getDbusObject(
-            fanPath, {},
+            fanPath, interfaces,
             [asyncResp, fanPath, chassisId,
              fanId](const boost::system::error_code& ec,
                     const dbus::utility::MapperGetObject& object) {

--- a/redfish-core/lib/power_supply.hpp
+++ b/redfish-core/lib/power_supply.hpp
@@ -426,8 +426,10 @@ inline void
         asyncResp->res.jsonValue["Status"]["State"] = "Enabled";
         asyncResp->res.jsonValue["Status"]["Health"] = "OK";
 
+        std::array<const char*, 1> interfaces = {
+            "xyz.openbmc_project.Inventory.Item.PowerSupply"};
         dbus::utility::getDbusObject(
-            powerSupplyPath, {},
+            powerSupplyPath, interfaces,
             [asyncResp,
              powerSupplyPath](const boost::system::error_code& ec,
                               const dbus::utility::MapperGetObject& object) {


### PR DESCRIPTION
The DBus call to retrieve the power supply object was using the wrong DBus service, resulting in incorrect data being fetched. This commit fixes the issue by updating the DBus interfaces array and using the correct service name. Now, the power supply Location can be retrieved accurately.

Tested:
'''
curl -k https://${bmc}/redfish/v1/Chassis/chassis15363/PowerSubsystem/PowerSupplies/powersupply1 {
  "@odata.id": "/redfish/v1/Chassis/chassis15363/PowerSubsystem/PowerSupplies/powersupply1",
  "@odata.type": "#PowerSupply.v1_5_0.PowerSupply",
  "EfficiencyRatings": [
    {
      "EfficiencyPercent": 90
    }
  ],
  "Id": "powersupply1",
  "Location": {
    "PartLocation": {
      "ServiceLabel": "U78CD.001.FZHCD44-E1"
    }
  },
  "LocationIndicatorActive": false,
  "Name": "powersupply1",
  "Status": {
    "Health": "OK",
    "State": "Enabled"
  }
}
'''

Change-Id: I38bedefae52f3f50a9bb2b80eb255843559077aa