### PR TITLE
Handle invalid dump attachment better as redfish NotFound

### DIFF
--- a/http/http_connection.hpp
+++ b/http/http_connection.hpp
@@ -5,6 +5,7 @@
 #ifdef BMCWEB_ENABLE_LINUX_AUDIT_EVENTS
 #include "audit_events.hpp"
 #endif
+#include "dump_utils.hpp"
 #include "http_response.hpp"
 #include "http_utility.hpp"
 #include "logging.hpp"
@@ -423,11 +424,21 @@ class Connection :
                     return;
                 }
             });
-            BMCWEB_LOG_DEBUG << "upgrade stream connection";
-            handler->handleUpgrade(*req, asyncResp, std::move(adaptor));
-            // delete lambda with self shared_ptr
-            // to enable connection destruction
-            res.completeRequestHandler = nullptr;
+
+            redfish::dump_utils::getValidDumpEntryForAttachment(
+                asyncResp, url,
+                [asyncResp, this, self(shared_from_this())](
+                    [[maybe_unused]] const std::string& objectPath,
+                    [[maybe_unused]] const std::string& entryID,
+                    [[maybe_unused]] const std::string& dumpType) {
+                BMCWEB_LOG_DEBUG << "upgrade stream connection";
+                handler->handleUpgrade(*req, asyncResp, std::move(adaptor));
+
+                // delete lambda with self shared_ptr
+                // to enable connection destruction
+                res.completeRequestHandler = nullptr;
+                });
+
             return;
         }
 

--- a/include/dump_utils.hpp
+++ b/include/dump_utils.hpp
@@ -1,0 +1,114 @@
+#pragma once
+
+#include "async_resp.hpp"
+#include "error_messages.hpp"
+#include "logging.hpp"
+#include "utility.hpp"
+
+#include <boost/algorithm/string/case_conv.hpp>
+#include <boost/system/error_code.hpp>
+#include <dbus_singleton.hpp>
+#include <dbus_utility.hpp>
+
+#include <cstddef>
+#include <string>
+
+namespace redfish
+{
+namespace dump_utils
+{
+
+inline void getValidDumpEntryForAttachment(
+    const std::shared_ptr<bmcweb::AsyncResp>& asyncResp, const std::string& url,
+    std::function<void(const std::string& objectPath,
+                       const std::string& entryID,
+                       const std::string& dumpType)>&& callback)
+{
+    std::string dumpType;
+    std::string entryID;
+    std::string entriesPath;
+
+    if (crow::utility::readUrlSegments(url, "redfish", "v1", "Managers", "bmc",
+                                       "LogServices", "Dump", "Entries",
+                                       std::ref(entryID), "attachment"))
+    {
+        // BMC type dump
+        dumpType = "BMC";
+        entriesPath = "/redfish/v1/Managers/bmc/LogServices/Dump/Entries/";
+    }
+    else if (crow::utility::readUrlSegments(
+                 url, "redfish", "v1", "Systems", "system", "LogServices",
+                 "Dump", "Entries", std::ref(entryID), "attachment"))
+    {
+        // System type
+        dumpType = "System";
+        entriesPath = "/redfish/v1/Systems/system/LogServices/Dump/Entries/";
+    }
+    if (dumpType.empty() || entryID.empty())
+    {
+        redfish::messages::resourceNotFound(asyncResp->res, "Dump", entryID);
+        return;
+    }
+
+    std::string dumpId(entryID);
+
+    if (dumpType != "BMC")
+    {
+        std::size_t pos = entryID.find_first_of('_');
+        if (pos == std::string::npos || (pos + 1) >= entryID.length())
+        {
+            // Requested ID is invalid
+            messages::invalidObject(
+                asyncResp->res, crow::utility::urlFromPieces(
+                                    "redfish", "v1", "Systems", "system",
+                                    "LogServices", "Dump", "Entries", entryID));
+            return;
+        }
+        dumpId = entryID.substr(pos + 1);
+    }
+
+    auto getValidDumpEntryCallback =
+        [asyncResp, entryID, dumpType, dumpId, entriesPath, callback](
+
+            const boost::system::error_code& ec,
+            const dbus::utility::ManagedObjectType& resp) {
+        if (ec.value() == EBADR)
+        {
+            messages::resourceNotFound(asyncResp->res, dumpType + " dump",
+                                       entryID);
+            return;
+        }
+        if (ec)
+        {
+            BMCWEB_LOG_ERROR << "DumpEntry resp_handler got error " << ec;
+            messages::internalError(asyncResp->res);
+            return;
+        }
+
+        std::string dumpEntryIdPath =
+            "/xyz/openbmc_project/dump/" +
+            std::string(boost::algorithm::to_lower_copy(dumpType)) + "/entry/" +
+            dumpId;
+
+        for (const auto& objectPath : resp)
+        {
+            if (objectPath.first.str != dumpEntryIdPath)
+            {
+                continue;
+            }
+            callback(std::move(dumpEntryIdPath), entryID, dumpType);
+            return;
+        }
+
+        BMCWEB_LOG_WARNING << "Can't find Dump Entry " << entryID;
+        messages::resourceNotFound(asyncResp->res, dumpType + " dump", entryID);
+    };
+
+    crow::connections::systemBus->async_method_call(
+        std::move(getValidDumpEntryCallback),
+        "xyz.openbmc_project.Dump.Manager", "/xyz/openbmc_project/dump",
+        "org.freedesktop.DBus.ObjectManager", "GetManagedObjects");
+}
+
+} // namespace dump_utils
+} // namespace redfish


### PR DESCRIPTION
An invalid `/redfish/v1/Managers/bmc/LogServices/Dump/Entries/INVALID/attachment` generates non-redfish style error messages

```
% curl -k -X GET https://${bmc}:18080/redfish/v1/Managers/bmc/LogServices/Dump/Entries/INVALID/attachment
% echo $?
```

OR
```
https://${bmc}:18080/redfish/v1/Managers/bmc/LogServices/Dump/Entries/INVALID/attachment

Output:
This <BMC> page can’t be found
No webpage was found for the web
address: https://<BMC>:18080/redfish/v1/Managers/bmc/LogServices/Dump/Entries/INVALID/attachment

HTTP ERROR 404
```

```
$https://${bmc}:18080/redfish/v1/Managers/bmc/LogServices/Dump/Entries/INVALID/attachment
<BMC> is currently unable to handle this request.
HTTP ERROR 503
```

The better output will be like
```
{
  "error": {
    "@Message.ExtendedInfo": [
      {
        "@odata.type": "#Message.v1_1_1.Message",
        "Message": "The requested resource of type BMC dump named 'INVALID' was not found.",
        "MessageArgs": [
          "BMC dump",
          "INVALID"
        ],
        "MessageId": "Base.1.13.0.ResourceNotFound",
        "MessageSeverity": "Critical",
        "Resolution": "Provide a valid resource identifier and resubmit the request."
      }
    ],
    "code": "Base.1.13.0.ResourceNotFound",
    "message": "The requested resource of type BMC dump named 'INVALID' was not found."
  }
}
```


Tested:
 - Run valid or invalid attachment queries like
```
    % curl -k -X GET https://${bmc}:18080/redfish/v1/Managers/bmc/LogServices/Dump/Entries/1/attachment
    % curl -k -X GET https://${bmc}:18080/redfish/v1/Managers/bmc/LogServices/Dump/Entries/INVALID/attachment

    % curl -k -X GET https://${bmc}:18080/redfish/v1/Systems/system/LogServices/Dump/Entries/INVALID/attachment
```
 - Run redfish validator
