### PR TITLE
1050 audit reuse fd

### DIFF
--- a/include/audit_events.hpp
+++ b/include/audit_events.hpp
@@ -1,5 +1,8 @@
 #pragma once
 
+#include "http_request.hpp"
+#include "logging.hpp"
+
 #include <libaudit.h>
 
 #include <boost/asio/ip/host_name.hpp>

--- a/meson.build
+++ b/meson.build
@@ -386,6 +386,10 @@ srcfiles_unittest = files(
   'test/redfish-core/lib/thermal_subsystem_test.cpp',
 )
 
+if (get_option('audit-events').enabled())
+	srcfiles_unittest += files('test/include/audit_events_test.cpp',)
+endif
+
 if(get_option('tests').enabled())
     # generate the test executable
     foreach test_src : srcfiles_unittest

--- a/test/include/audit_events_test.cpp
+++ b/test/include/audit_events_test.cpp
@@ -1,0 +1,43 @@
+#include "audit_events.hpp"
+
+#include <gtest/gtest.h> // IWYU pragma: keep
+
+// IWYU pragma: no_include <gtest/gtest-message.h>
+// IWYU pragma: no_include <gtest/gtest-test-part.h>
+// IWYU pragma: no_include "gtest/gtest_pred_impl.h"
+
+namespace audit
+{
+namespace
+{
+
+TEST(auditOpen, PositiveTest)
+{
+    int origFd;
+
+    EXPECT_TRUE(auditOpen());
+    EXPECT_NE(auditfd, -1);
+
+    origFd = auditfd;
+    EXPECT_TRUE(auditOpen());
+    EXPECT_EQ(auditfd, origFd);
+}
+
+TEST(auditClose, PositiveTest)
+{
+    auditClose(true);
+    EXPECT_TRUE(tryOpen);
+    EXPECT_EQ(auditfd, -1);
+
+    EXPECT_TRUE(auditOpen());
+    auditClose(true);
+    EXPECT_TRUE(tryOpen);
+    EXPECT_EQ(auditfd, -1);
+
+    EXPECT_TRUE(auditOpen());
+    auditClose(false);
+    EXPECT_FALSE(auditOpen());
+}
+
+} // namespace
+} // namespace audit


### PR DESCRIPTION
Audit Log: Reuse fd to optimize performance of logging events

Performance impact of audit logging is one of the upstream concerns. By reusing the same file-descriptor for the audit logging we can shorten the path when a bmcweb event is logged.

I've also added testcases for the new utility functions added as part of this change. Note: The tests are looking at the internal values set by auditOpen() and auditClose(). I know from reading guidelines that this isn't a desired testing approach. I didn't see much else I could test that didn't check these values. If anyone has better ideas I would be glad to make changes.

I would like to merge these commits into 1050/1060 only. I thought it would be good to get testing on what I propose to push upstream as well as make this align closer with what will hopefully get merged upstream eventually.