### PR TITLE
Fix internal error due to system_attention_indicator while booting

### DIFF
--- a/redfish-core/lib/oem/ibm/system_attention_indicator.hpp
+++ b/redfish-core/lib/oem/ibm/system_attention_indicator.hpp
@@ -44,8 +44,7 @@ inline void getSAI(const std::shared_ptr<bmcweb::AsyncResp>& aResp,
                         const dbus::utility::MapperGetObject& object) {
         if (ec || object.empty())
         {
-            BMCWEB_LOG_ERROR << "DBUS response error " << ec.message();
-            messages::internalError(aResp->res);
+            BMCWEB_LOG_DEBUG << "Failed to get LED DBus name: " << ec.message();
             return;
         }
 


### PR DESCRIPTION
We should not return an internal error if the service is not up.

Fixes https://github.com/ibm-openbmc/dev/issues/3618