### PR TITLE
1050: Fix Redfish validator failure for missing power supplies

### DIFF
--- a/include/dbus_utility.hpp
+++ b/include/dbus_utility.hpp
@@ -210,6 +210,25 @@ inline void getAssociationEndPoints(
         });
 }
 
+inline void getAssociatedSubTreePaths(
+    const sdbusplus::message::object_path& associatedPath,
+    const sdbusplus::message::object_path& path, int32_t depth,
+    std::span<const std::string_view> interfaces,
+    std::function<void(const boost::system::error_code&,
+                       const MapperGetSubTreePathsResponse&)>&& callback)
+{
+    crow::connections::systemBus->async_method_call(
+        [callback{std::move(callback)}](
+            const boost::system::error_code& ec,
+            const MapperGetSubTreePathsResponse& subtreePaths) {
+        callback(ec, subtreePaths);
+        },
+        "xyz.openbmc_project.ObjectMapper",
+        "/xyz/openbmc_project/object_mapper",
+        "xyz.openbmc_project.ObjectMapper", "GetAssociatedSubTreePaths",
+        associatedPath, path, depth, interfaces);
+}
+
 inline void
     getDbusObject(const std::string& path, std::span<const char*> interfaces,
                   std::function<void(const boost::system::error_code&,


### PR DESCRIPTION
Fix Redfish validator error for missing power supplies
In the current implementation, bmcweb retrieves the power supply list
by querying the powered_by associations. However, the redfish validator
is failing due to missing power supplies that do not have the required
xyz.openbmc_project.Inventory.Item.PowerSupply D-Bus interface. This
failure occurs when querying a power supply without the specified
interface.

To address this issue, the fix ensures that missing power supplies are
not listed if they have a powered_by association but does not have the
xyz.openbmc_project.Inventory.Item.PowerSupply interface.

Defect: https://jazz07.rchland.ibm.com:13443/jazz/web/projects/CSSD#action=com.ibm.team.workitem.viewWorkItem&id=548747

upstream:
https://gerrit.openbmc.org/c/openbmc/bmcweb/+/62522

Tested: Validator Passed