### PR TITLE
Show IPv6StaticDefaultGateways in redfish response

### DIFF
--- a/redfish-core/lib/hypervisor_system.hpp
+++ b/redfish-core/lib/hypervisor_system.hpp
@@ -680,13 +680,15 @@ inline void parseInterfaceData(
     }
 
     std::string ipv6GatewayStr = ethData.ipv6DefaultGateway;
+
     if (ipv6GatewayStr.empty())
     {
         ipv6GatewayStr = "::";
     }
 
-    jsonResponse["IPv6DefaultGateway"] = ipv6GatewayStr;
-
+    nlohmann::json& ipv6StaticDefaultGw =
+        jsonResponse["IPv6StaticDefaultGateways"];
+    ipv6StaticDefaultGw = nlohmann::json::array();
     nlohmann::json& ipv6Array = jsonResponse["IPv6Addresses"];
     nlohmann::json& ipv6StaticArray = jsonResponse["IPv6StaticAddresses"];
     ipv6Array = nlohmann::json::array();
@@ -707,7 +709,12 @@ inline void parseInterfaceData(
             ipv6StaticArray.push_back(
                 {{"Address", ipv6Config.address},
                  {"PrefixLength", ipv6Config.prefixLength}});
+            if (ipv6GatewayStr != "::")
+            {
+                ipv6StaticDefaultGw.push_back({{"Address", ipv6GatewayStr}});
+            }
         }
+        jsonResponse["IPv6DefaultGateway"] = ipv6GatewayStr;
     }
 
     if (ipv4IsActive)


### PR DESCRIPTION
Currently, when a user does a patch on "IPv6StaticDefaultGateways", the gateway is displayed only in "IPv6DefaultGateway" property. This commit will also display the former in the redfish response.

Tested By:

[1] PATCH -d '{"IPv6StaticDefaultGateways":["fe08::2"]}' https://${bmc}/redfish/v1/Systems/hypervisor/EthernetInterfaces/eth<0/1>

The redfish response will include the following:
"""
  "IPv6DefaultGateway": "fe08::2",
  "IPv6StaticDefaultGateways": [
    {
      "Address": "fe08::2"
    }
  ],
"""

Change-Id: I10c7b243cd25b26addca10f0aad49b6c3cda8f22