### PR TITLE
Fix for set DHCPConfig

### DIFF
--- a/redfish-core/lib/ethernet.hpp
+++ b/redfish-core/lib/ethernet.hpp
@@ -1519,7 +1519,7 @@ inline void setDHCPConfig(const std::string& propertyName, const bool& value,
         }
         },
         "xyz.openbmc_project.Network",
-        "/xyz/openbmc_project/network/dhcp/" + ethifaceId + "/" + nwType,
+        "/xyz/openbmc_project/network/" + ethifaceId + "/" + nwType,
         "org.freedesktop.DBus.Properties", "Set",
         "xyz.openbmc_project.Network.DHCPConfiguration", propertyName,
         dbus::utility::DbusVariantType{value});


### PR DESCRIPTION
This PR is to fix the issue caused by
    https://github.com/ibm-openbmc/bmcweb/commit/
    cde6f8fc1322aed9186e0b87b155d0d10ed43a63
    
    Upstream commit:
    https://gerrit.openbmc.org/c/openbmc/bmcweb/+/63390
    
    Tested by:
    
    Request:
    PATCH -d '{"DHCPv6":{"UseDomainName":false}}'
    https://${bmc}/redfish/v1/Managers/bmc/EthernetInterfaces/eth1
    
    Response:
    {
      "@Message.ExtendedInfo": [
        {
          "@odata.type": "#Message.v1_1_1.Message",
          "Message": "The request completed successfully.",
          "MessageArgs": [],
          "MessageId": "Base.1.13.0.Success",
          "MessageSeverity": "OK",
          "Resolution": "None"
        }
      ]
    
    Request:
    GET https://${bmc}/redfish/v1/Managers/bmc/EthernetInterfaces/eth1
    
    {
      "@odata.id": "/redfish/v1/Managers/bmc/EthernetInterfaces/eth1",
      "@odata.type": "#EthernetInterface.v1_8_0.EthernetInterface",
      "DHCPv4": {
        "DHCPEnabled": true,
        "UseDNSServers": false,
        "UseDomainName": false,
        "UseNTPServers": false
      },
      "DHCPv6": {
        "OperatingMode": "Enabled",
        "UseDNSServers": false,
        "UseDomainName": true,
        "UseNTPServers": true
      },