### PR TITLE
Audit Log: Factor out function to determine which events to audit

### DIFF
--- a/http/http_connection.hpp
+++ b/http/http_connection.hpp
@@ -495,11 +495,7 @@ class Connection :
         res = std::move(thisRes);
 
 #ifdef BMCWEB_ENABLE_LINUX_AUDIT_EVENTS
-        if (((req->method() == boost::beast::http::verb::post) &&
-             audit::checkPostAudit(*req)) ||
-            (req->method() == boost::beast::http::verb::patch) ||
-            (req->method() == boost::beast::http::verb::put) ||
-            (req->method() == boost::beast::http::verb::delete_))
+        if (audit::wantAudit(*req))
         {
             if (userSession != nullptr)
             {

--- a/include/audit_events.hpp
+++ b/include/audit_events.hpp
@@ -94,6 +94,14 @@ inline void auditSetState(bool enable)
     return;
 }
 
+/**
+ * @brief Checks if POST request should be audited on completion
+ *
+ * Login and Session requests are audited when the authentication is attempted.
+ * This allows failed requests to be audited with the user detail.
+ *
+ * @return True if request should be audited
+ */
 inline bool checkPostAudit(const crow::Request& req)
 {
     if ((req.target() == "/redfish/v1/SessionService/Sessions") ||
@@ -103,6 +111,24 @@ inline bool checkPostAudit(const crow::Request& req)
         return false;
     }
     return true;
+}
+
+/**
+ * @brief Checks if request should be audited after completion
+ * @return  True if request should be audited
+ */
+inline bool wantAudit(const crow::Request& req)
+{
+    if ((req.method() == boost::beast::http::verb::patch) ||
+        (req.method() == boost::beast::http::verb::put) ||
+        (req.method() == boost::beast::http::verb::delete_) ||
+        ((req.method() == boost::beast::http::verb::post) &&
+         checkPostAudit(req)))
+    {
+        return true;
+    }
+
+    return false;
 }
 
 inline void auditEvent(const char* opPath, const std::string& userName,

--- a/test/include/audit_events_test.cpp
+++ b/test/include/audit_events_test.cpp
@@ -57,5 +57,44 @@ TEST(auditReopen, PositiveTest)
     EXPECT_NE(auditfd, -1);
 }
 
+TEST(wantAudit, PositiveTest)
+{
+    constexpr const std::string_view url = "/foo";
+    std::error_code ec;
+
+    crow::Request patchRequest{{boost::beast::http::verb::patch, url, 11}, ec};
+    EXPECT_TRUE(wantAudit(patchRequest));
+
+    crow::Request putRequest{{boost::beast::http::verb::put, url, 11}, ec};
+    EXPECT_TRUE(wantAudit(putRequest));
+
+    crow::Request deleteRequest{{boost::beast::http::verb::delete_, url, 11},
+                                ec};
+    EXPECT_TRUE(wantAudit(deleteRequest));
+
+    crow::Request postRequest{{boost::beast::http::verb::post, url, 11}, ec};
+    EXPECT_TRUE(wantAudit(postRequest));
+}
+
+TEST(wantAudit, NegativeTest)
+{
+    constexpr const std::string_view url = "/foo";
+    std::error_code ec;
+
+    crow::Request postRequest{{boost::beast::http::verb::post, url, 11}, ec};
+
+    postRequest.target("/redfish/v1/SessionService/Sessions");
+    EXPECT_FALSE(wantAudit(postRequest));
+
+    postRequest.target("/redfish/v1/SessionService/Sessions/");
+    EXPECT_FALSE(wantAudit(postRequest));
+
+    postRequest.target("/login");
+    EXPECT_FALSE(wantAudit(postRequest));
+
+    crow::Request getRequest{{boost::beast::http::verb::get, url, 11}, ec};
+    EXPECT_FALSE(wantAudit(getRequest));
+}
+
 } // namespace
 } // namespace audit


### PR DESCRIPTION
Factored out function which determines which Redfish events to audit.
Change is in preparation for pushing upstream. I anticipate this is an area which will receive upstream comments.

I will push this into 1050 only.

Tested:
- Added unit test for new function, wantAudit().
- Confirmed expected events still being audited.