### PR TITLE
Static IPv6 config: Send relevant error on patch.

### DIFF
--- a/redfish-core/lib/ethernet.hpp
+++ b/redfish-core/lib/ethernet.hpp
@@ -947,10 +947,19 @@ inline void createIPv6(const std::string& ifaceId, uint8_t prefixLength,
                        const std::string& address,
                        const std::shared_ptr<bmcweb::AsyncResp>& asyncResp)
 {
-    auto createIpHandler = [asyncResp](const boost::system::error_code ec) {
+    auto createIpHandler =
+        [asyncResp, address](const boost::system::error_code& ec) {
         if (ec)
         {
-            messages::internalError(asyncResp->res);
+            if (ec == boost::system::errc::io_error)
+            {
+                messages::propertyValueFormatError(asyncResp->res, address,
+                                                   "Address");
+            }
+            else
+            {
+                messages::internalError(asyncResp->res);
+            }
         }
     };
     // Passing null for gateway, as per redfish spec IPv6StaticAddresses object


### PR DESCRIPTION
Upstream Commit: https://gerrit.openbmc.org/c/openbmc/bmcweb/+/64542
Defect Link: https://jazz07.rchland.ibm.com:13443/jazz/web/projects/CSSD#action=com.ibm.team.workitem.viewWorkItem&id=549291

This commit will send back relevant redfish error back if the client tries to configure the IPv6 static ip with invalid IPv6 address.

Tested By:

PATCH -D patch.txt -d '{"IPv6StaticAddresses":
[{"Address": "1A:1B:1C:1D:10.5.5.6","PrefixLength": 64}]}' https://${bmc}/redfish/v1/Systems/hypervisor/EthernetInterfaces/eth1

Current behaviour:

response: 500 Internal Server Error
          The request failed due to an internal service error

Modified behaviour:

response: 400 Bad Request
          The value '1A:1B:1C:1D:10.5.5.6' for the property Address
          is of a different format than the property can accept.

Change-Id: Ibbd6b82acea51fb16785ffbfaca9ae43956c7cb6