### PR TITLE
1050: Refactor and Simplify PCIeSlot handling

### DIFF
--- a/include/dbus_utility.hpp
+++ b/include/dbus_utility.hpp
@@ -31,6 +31,7 @@
 #include <span>
 #include <sstream>
 #include <string>
+#include <string_view>
 #include <tuple>
 #include <utility>
 #include <variant>
@@ -208,6 +209,23 @@ inline void getAssociationEndPoints(
                                         const MapperEndPoints& endpoints) {
         callback(ec, endpoints);
         });
+}
+
+inline void getAssociatedSubTree(
+    const sdbusplus::message::object_path& associatedPath,
+    const sdbusplus::message::object_path& path, int32_t depth,
+    std::span<const std::string_view> interfaces,
+    std::function<void(const boost::system::error_code&,
+                       const MapperGetSubTreeResponse&)>&& callback)
+{
+    crow::connections::systemBus->async_method_call(
+        [callback{std::move(callback)}](
+            const boost::system::error_code& ec,
+            const MapperGetSubTreeResponse& subtree) { callback(ec, subtree); },
+        "xyz.openbmc_project.ObjectMapper",
+        "/xyz/openbmc_project/object_mapper",
+        "xyz.openbmc_project.ObjectMapper", "GetAssociatedSubTree",
+        associatedPath, path, depth, interfaces);
 }
 
 inline void getAssociatedSubTreePaths(


### PR DESCRIPTION
1050: Refactor and Simplify PCIeSlot handling

PCIeSlots are currently obtained in 2 stages;
  - getSubTree for PCIeSlots
  - getAssociationEndPoint for each slot

This can be done in a simpler way by using `getAssociatedSubTree()`
in one step;
  - getAssociatedSubTree for the given chassis
  
Tested:
  - Compare the outputs of /redfish/v1/Chassis/chassis<X>/PCIeSlots
    before and after the change
  - Run Redfish Validator passed
