### PR TITLE
Audit Log: Hide details of building audit message into auditEvent()

### DIFF
--- a/http/http_connection.hpp
+++ b/http/http_connection.hpp
@@ -507,30 +507,11 @@ class Connection :
                     requestSuccess = true;
                 }
 
-                std::string additionalInfo = "";
-                // Exclude the body of account PATCH/POST
-                // Exclude the body of /ibm/v1 PUT/POST
-                if (((req->method() == boost::beast::http::verb::patch ||
-                      req->method() == boost::beast::http::verb::post) &&
-                     (!req->target().starts_with(
-                          "/redfish/v1/AccountService/Accounts") &&
-                      !req->target().starts_with("/ibm/v1"))) ||
-                    (req->method() == boost::beast::http::verb::put &&
-                     !req->target().starts_with("/ibm/v1")))
-                {
-                    additionalInfo = req->body + " ";
-                }
-
-                audit::auditEvent(("op=" + std::string(req->methodString()) +
-                                   ":" + std::string(req->target()) + " " +
-                                   additionalInfo)
-                                      .c_str(),
-                                  userSession->username,
-                                  req->ipAddress.to_string(), requestSuccess);
+                audit::auditEvent(*req, userSession->username, requestSuccess);
             }
             else
             {
-                BMCWEB_LOG_ERROR
+                BMCWEB_LOG_DEBUG
                     << "UserSession is null, not able to log audit event!";
             }
         }

--- a/include/login_routes.hpp
+++ b/include/login_routes.hpp
@@ -177,11 +177,7 @@ inline void requestRoutes(App& app)
             {
                 asyncResp->res.result(boost::beast::http::status::unauthorized);
 #ifdef BMCWEB_ENABLE_LINUX_AUDIT_EVENTS
-                audit::auditEvent(("op=" + std::string(req.methodString()) +
-                                   ":" + std::string(req.target()) + " ")
-                                      .c_str(),
-                                  std::string(username),
-                                  req.ipAddress.to_string(), false);
+                audit::auditEvent(req, std::string(username), false);
 #endif
             }
             else
@@ -229,11 +225,7 @@ inline void requestRoutes(App& app)
                     asyncResp->res.jsonValue["token"] = session->sessionToken;
                 }
 #ifdef BMCWEB_ENABLE_LINUX_AUDIT_EVENTS
-                audit::auditEvent(("op=" + std::string(req.methodString()) +
-                                   ":" + std::string(req.target()) + " ")
-                                      .c_str(),
-                                  std::string(username),
-                                  req.ipAddress.to_string(), true);
+                audit::auditEvent(req, std::string(username), true);
 #endif
             }
         }

--- a/redfish-core/lib/redfish_sessions.hpp
+++ b/redfish-core/lib/redfish_sessions.hpp
@@ -223,11 +223,7 @@ inline void handleSessionCollectionPost(
         messages::resourceAtUriUnauthorized(asyncResp->res, req.urlView,
                                             "Invalid username or password");
 #ifdef BMCWEB_ENABLE_LINUX_AUDIT_EVENTS
-        audit::auditEvent(("op=" + std::string(req.methodString()) + ":" +
-                           std::string(req.target()) + " ")
-                              .c_str(),
-                          std::string(username), req.ipAddress.to_string(),
-                          false);
+        audit::auditEvent(req, std::string(username), false);
 #endif
         return;
     }
@@ -277,10 +273,7 @@ inline void handleSessionCollectionPost(
     asyncResp->res.result(boost::beast::http::status::created);
 
 #ifdef BMCWEB_ENABLE_LINUX_AUDIT_EVENTS
-    audit::auditEvent(("op=" + std::string(req.methodString()) + ":" +
-                       std::string(req.target()) + " ")
-                          .c_str(),
-                      std::string(username), req.ipAddress.to_string(), true);
+    audit::auditEvent(req, std::string(username), true);
 #endif
 
     if (session->isConfigureSelfOnly)

--- a/test/include/audit_events_test.cpp
+++ b/test/include/audit_events_test.cpp
@@ -148,5 +148,54 @@ TEST(wantDetail, NegativeTest)
     EXPECT_FALSE(wantDetail(getRequest));
 }
 
+TEST(appendItemToBuf, PositiveTest)
+{
+    std::string testBuf;
+    std::string data;
+    std::string cmpStr;
+
+    data = "Initial data ";
+    cmpStr = data;
+
+    EXPECT_TRUE(appendItemToBuf(testBuf, data.length() + 20, data));
+    EXPECT_EQ(testBuf, cmpStr);
+
+    data = "Append data ";
+    cmpStr += data;
+    EXPECT_TRUE(
+        appendItemToBuf(testBuf, testBuf.length() + data.length(), data));
+    EXPECT_EQ(testBuf, cmpStr);
+
+    data = "Append more data ";
+    cmpStr += data;
+
+    EXPECT_TRUE(
+        appendItemToBuf(testBuf, testBuf.length() + data.length(), data));
+    EXPECT_EQ(testBuf, cmpStr);
+}
+
+TEST(appendItemToBuf, NegativeTest)
+{
+    std::string testBuf;
+    std::string data;
+    std::string cmpStr;
+
+    cmpStr = testBuf;
+    data = "Data not appended";
+
+    EXPECT_FALSE(appendItemToBuf(testBuf, data.length() - 5, data));
+    EXPECT_EQ(testBuf, cmpStr);
+
+    testBuf = "Initial data ";
+    cmpStr = testBuf;
+
+    EXPECT_FALSE(appendItemToBuf(testBuf, testBuf.length(), data));
+    EXPECT_EQ(testBuf, cmpStr);
+
+    EXPECT_FALSE(
+        appendItemToBuf(testBuf, testBuf.length() + data.length() - 1, data));
+    EXPECT_EQ(testBuf, cmpStr);
+}
+
 } // namespace
 } // namespace audit

--- a/test/include/audit_events_test.cpp
+++ b/test/include/audit_events_test.cpp
@@ -96,5 +96,57 @@ TEST(wantAudit, NegativeTest)
     EXPECT_FALSE(wantAudit(getRequest));
 }
 
+TEST(wantDetail, PositiveTest)
+{
+    constexpr const std::string_view url = "/foo";
+    std::error_code ec;
+
+    crow::Request patchRequest{{boost::beast::http::verb::patch, url, 11}, ec};
+    EXPECT_TRUE(wantDetail(patchRequest));
+
+    crow::Request putRequest{{boost::beast::http::verb::put, url, 11}, ec};
+    EXPECT_TRUE(wantDetail(putRequest));
+
+    crow::Request deleteRequest{{boost::beast::http::verb::delete_, url, 11},
+                                ec};
+    EXPECT_TRUE(wantDetail(deleteRequest));
+
+    crow::Request postRequest{{boost::beast::http::verb::post, url, 11}, ec};
+    EXPECT_TRUE(wantDetail(postRequest));
+}
+
+TEST(wantDetail, NegativeTest)
+{
+    constexpr const std::string_view url = "/foo";
+    std::error_code ec;
+
+    crow::Request patchRequest{{boost::beast::http::verb::patch, url, 11}, ec};
+    patchRequest.target("/redfish/v1/AccountService/Accounts/foo");
+    EXPECT_FALSE(wantDetail(patchRequest));
+
+    patchRequest.target("/ibm/v1/foo");
+    EXPECT_FALSE(wantDetail(patchRequest));
+
+    crow::Request postRequest{{boost::beast::http::verb::post, url, 11}, ec};
+
+    postRequest.target("/redfish/v1/AccountService/Accounts/bar");
+    EXPECT_FALSE(wantDetail(postRequest));
+
+    postRequest.target("/ibm/v1/bar");
+    EXPECT_FALSE(wantDetail(postRequest));
+
+    postRequest.target("/redfish/v1/SessionService/Sessions");
+    EXPECT_FALSE(wantDetail(postRequest));
+
+    postRequest.target("/redfish/v1/SessionService/Sessions/");
+    EXPECT_FALSE(wantDetail(postRequest));
+
+    postRequest.target("/login");
+    EXPECT_FALSE(wantDetail(postRequest));
+
+    crow::Request getRequest{{boost::beast::http::verb::get, url, 11}, ec};
+    EXPECT_FALSE(wantDetail(getRequest));
+}
+
 } // namespace
 } // namespace audit


### PR DESCRIPTION
Added utility functions to centralize checking whether detail data for the request being logged should be included in the log message. Moved the building of the audit message into the audit namespace so main bmcweb code doesn't have to understand the details. Changed building of message buffer to use std::string to simplify existing logic.

Tested:
 - CI passes with new unit tests and audit-events enabled.
 - Confirmed sampling of events have the correct detail data included.
 - Confirmed user session events do not have detail data.