### PR TITLE
Fix clang-tidy error for ibm/locks

### DIFF
--- a/include/ibm/locks.hpp
+++ b/include/ibm/locks.hpp
@@ -38,6 +38,7 @@ using RcAcquireLock = std::pair<bool, std::variant<Rc, std::pair<bool, int>>>;
 using RcReleaseLockApi = std::pair<bool, std::variant<bool, RcRelaseLock>>;
 using SessionFlags = std::pair<SType, SType>;
 using ListOfSessionIds = std::vector<std::string>;
+static constexpr uint8_t lockResourceIdSizeInBytes = 8;
 
 class Lock
 {
@@ -187,7 +188,7 @@ class Lock
 
 inline RcGetLockList Lock::getLockList(const ListOfSessionIds& listSessionId)
 {
-    std::vector<std::pair<uint32_t, LockRequests>> lockList;
+    std::vector<std::pair<uint32_t, LockRequests>> lockList{};
 
     if (!lockTable.empty())
     {
@@ -520,18 +521,29 @@ inline bool Lock::isConflictRequest(const LockRequests& refLockRequestStructure)
 inline bool Lock::checkByte(uint64_t resourceId1, uint64_t resourceId2,
                             uint32_t position)
 {
-    // NOLINTNEXTLINE(cppcoreguidelines-pro-type-reinterpret-cast)
-    uint8_t* p = reinterpret_cast<uint8_t*>(&resourceId1);
-    // NOLINTNEXTLINE(cppcoreguidelines-pro-type-reinterpret-cast)
-    uint8_t* q = reinterpret_cast<uint8_t*>(&resourceId2);
+    std::vector<uint8_t> res1;
+    std::vector<uint8_t> res2;
+    uint8_t resId1size = sizeof(resourceId1);
+    uint8_t resId2size = sizeof(resourceId2);
+    for (uint8_t i = 0; i < resId1size; i++)
+    {
+        uint8_t byte = static_cast<uint8_t>(resourceId1 >> (i * 8));
+        res1.insert(res1.begin(), byte);
+    }
 
-    // NOLINTNEXTLINE(cppcoreguidelines-pro-bounds-pointer-arithmetic)
-    uint8_t pPosition = p[position];
-    // NOLINTNEXTLINE(cppcoreguidelines-pro-bounds-pointer-arithmetic)
-    uint8_t qPosition = q[position];
+    for (uint8_t i = 0; i < resId2size; i++)
+    {
+        uint8_t byte = static_cast<uint8_t>(resourceId2 >> (i * 8));
+        res2.insert(res2.begin(), byte);
+    }
 
-    BMCWEB_LOG_DEBUG << "Comparing bytes " << std::to_string(pPosition) << ","
-                     << std::to_string(qPosition);
+    uint8_t pPosition = 0;
+    uint8_t qPosition = 0;
+    if (position < lockResourceIdSizeInBytes)
+    {
+        pPosition = res1[position];
+        qPosition = res2[position];
+    }
     return pPosition == qPosition;
 }
 


### PR DESCRIPTION
ibm/locks that has had clang-tidy warnings disabled for a while due to multiple safety and endianness issues.
https://github.com/openbmc/bmcweb/commit/26b3630b181d1093483e4d5ebe6aeeb91a6a2976

this commit uncomments locks code which causes warnings and fixes these warnings

Tested by: create & list locks with redfish curl and management console

Change-Id: I569e0dc5c11f259b7cca4b22722c9b4d87c68c80