### PR TITLE
Use std::string_view interface type in getDbusObject

### DIFF
--- a/include/dbus_utility.hpp
+++ b/include/dbus_utility.hpp
@@ -248,7 +248,8 @@ inline void getAssociatedSubTreePaths(
 }
 
 inline void
-    getDbusObject(const std::string& path, std::span<const char*> interfaces,
+    getDbusObject(const std::string& path,
+                  std::span<const std::string_view> interfaces,
                   std::function<void(const boost::system::error_code&,
                                      const MapperGetObject&)>&& callback)
 {

--- a/redfish-core/lib/environment_metrics.hpp
+++ b/redfish-core/lib/environment_metrics.hpp
@@ -14,6 +14,8 @@
 
 namespace redfish
 {
+static constexpr std::array<std::string_view, 1> sensorInterface = {
+    "xyz.openbmc_project.Sensor.Value"};
 inline void
     updateFanSensorList(const std::shared_ptr<bmcweb::AsyncResp>& asyncResp,
                         const std::string& chassisId,
@@ -66,9 +68,8 @@ inline void
                       const std::string& fanSensorPath,
                       const std::string& chassisId)
 {
-    std::array<const char*, 1> intefaces{"xyz.openbmc_project.Sensor.Value"};
     dbus::utility::getDbusObject(
-        fanSensorPath, intefaces,
+        fanSensorPath, sensorInterface,
         [asyncResp, chassisId,
          fanSensorPath](const boost::system::error_code& ec,
                         const dbus::utility::MapperGetObject& object) {
@@ -157,11 +158,9 @@ inline void handleEnvironmentMetricsHead(
 inline void getPowerWatts(const std::shared_ptr<bmcweb::AsyncResp>& asyncResp,
                           const std::string& chassisId)
 {
-    constexpr const char* interface = "xyz.openbmc_project.Sensor.Value";
     const std::string sensorPath = "/xyz/openbmc_project/sensors";
-    constexpr std::array<std::string_view, 1> sensorInterfaces = {interface};
     dbus::utility::getSubTreePaths(
-        sensorPath, 0, sensorInterfaces,
+        sensorPath, 0, sensorInterface,
         [asyncResp,
          chassisId](const boost::system::error_code& ec,
                     const dbus::utility::MapperGetSubTreePathsResponse& paths) {
@@ -190,9 +189,8 @@ inline void getPowerWatts(const std::shared_ptr<bmcweb::AsyncResp>& asyncResp,
 
         const std::string& totalPowerPath =
             "/xyz/openbmc_project/sensors/power/total_power";
-        std::array<const char*, 1> totalPowerInterfaces = {interface};
         dbus::utility::getDbusObject(
-            totalPowerPath, totalPowerInterfaces,
+            totalPowerPath, sensorInterface,
             [asyncResp, chassisId,
              totalPowerPath](const boost::system::error_code& ec1,
                              const dbus::utility::MapperGetObject& object) {

--- a/redfish-core/lib/fan.hpp
+++ b/redfish-core/lib/fan.hpp
@@ -325,8 +325,9 @@ inline void doFanGet(const std::shared_ptr<bmcweb::AsyncResp>& asyncResp,
         asyncResp->res.jsonValue["Status"]["Health"] = "OK";
         asyncResp->res.jsonValue["Status"]["State"] = "Enabled";
 
-        std::array<const char*, 1> interfaces = {
+        std::array<std::string_view, 1> interfaces = {
             "xyz.openbmc_project.Inventory.Item.Fan"};
+
         dbus::utility::getDbusObject(
             fanPath, interfaces,
             [asyncResp, fanPath, chassisId,

--- a/redfish-core/lib/led.hpp
+++ b/redfish-core/lib/led.hpp
@@ -26,6 +26,9 @@
 
 namespace redfish
 {
+
+static constexpr std::array<std::string_view, 1> ledGroupInterface = {
+    "xyz.openbmc_project.Led.Group"};
 /**
  * @brief Retrieves identify led group properties over dbus
  *
@@ -160,9 +163,8 @@ inline void
 inline void getLedAsset(const std::shared_ptr<bmcweb::AsyncResp>& aResp,
                         const std::string& ledGroup, nlohmann::json& jsonInput)
 {
-    std::array<const char*, 1> interfaces = {"xyz.openbmc_project.Led.Group"};
     dbus::utility::getDbusObject(
-        ledGroup, interfaces,
+        ledGroup, ledGroupInterface,
         [aResp, ledGroup,
          &jsonInput](const boost::system::error_code& ec,
                      const dbus::utility::MapperGetObject& object) {
@@ -195,9 +197,8 @@ inline void getLedAsset(const std::shared_ptr<bmcweb::AsyncResp>& aResp,
 inline void setLedAsset(const std::shared_ptr<bmcweb::AsyncResp>& aResp,
                         const std::string& ledGroup, bool ledState)
 {
-    std::array<const char*, 1> interfaces = {"xyz.openbmc_project.Led.Group"};
     dbus::utility::getDbusObject(
-        ledGroup, interfaces,
+        ledGroup, ledGroupInterface,
         [aResp, ledGroup,
          ledState](const boost::system::error_code& ec,
                    const dbus::utility::MapperGetObject& object) {

--- a/redfish-core/lib/oem/ibm/lamp_test.hpp
+++ b/redfish-core/lib/oem/ibm/lamp_test.hpp
@@ -20,7 +20,8 @@ inline void getLampTestState(const std::shared_ptr<bmcweb::AsyncResp>& aResp)
 {
     BMCWEB_LOG_DEBUG << "Get lamp test state";
 
-    std::array<const char*, 1> interfaces = {"xyz.openbmc_project.Led.Group"};
+    std::array<std::string_view, 1> interfaces = {
+        "xyz.openbmc_project.Led.Group"};
     dbus::utility::getDbusObject(
         "/xyz/openbmc_project/led/groups/lamp_test", interfaces,
         [aResp](const boost::system::error_code& ec,
@@ -73,7 +74,8 @@ inline void setLampTestState(const std::shared_ptr<bmcweb::AsyncResp>& aResp,
 {
     BMCWEB_LOG_DEBUG << "Set lamp test status.";
 
-    std::array<const char*, 1> interfaces = {"xyz.openbmc_project.Led.Group"};
+    std::array<std::string_view, 1> interfaces = {
+        "xyz.openbmc_project.Led.Group"};
     dbus::utility::getDbusObject(
         "/xyz/openbmc_project/led/groups/lamp_test", interfaces,
         [aResp, state](const boost::system::error_code& ec,

--- a/redfish-core/lib/oem/ibm/system_attention_indicator.hpp
+++ b/redfish-core/lib/oem/ibm/system_attention_indicator.hpp
@@ -36,7 +36,8 @@ inline void getSAI(const std::shared_ptr<bmcweb::AsyncResp>& aResp,
         return;
     }
 
-    std::array<const char*, 1> interfaces = {"xyz.openbmc_project.Led.Group"};
+    std::array<std::string_view, 1> interfaces = {
+        "xyz.openbmc_project.Led.Group"};
     dbus::utility::getDbusObject(
         "/xyz/openbmc_project/led/groups/" + name, interfaces,
         [aResp, name,
@@ -106,7 +107,8 @@ inline void setSAI(const std::shared_ptr<bmcweb::AsyncResp>& aResp,
         return;
     }
 
-    std::array<const char*, 1> interfaces = {"xyz.openbmc_project.Led.Group"};
+    std::array<std::string_view, 1> interfaces = {
+        "xyz.openbmc_project.Led.Group"};
     dbus::utility::getDbusObject(
         "/xyz/openbmc_project/led/groups/" + name, interfaces,
         [aResp, name, value](const boost::system::error_code& ec,

--- a/redfish-core/lib/pcie.hpp
+++ b/redfish-core/lib/pcie.hpp
@@ -35,10 +35,10 @@
 namespace redfish
 {
 
-static constexpr const char* pcieDeviceInterface =
-    "xyz.openbmc_project.Inventory.Item.PCIeDevice";
-static constexpr const char* pcieSlotInterface =
-    "xyz.openbmc_project.Inventory.Item.PCIeSlot";
+static constexpr std::array<std::string_view, 1> pcieDeviceInterface = {
+    "xyz.openbmc_project.Inventory.Item.PCIeDevice"};
+static constexpr std::array<std::string_view, 1> pcieSlotInterface = {
+    "xyz.openbmc_project.Inventory.Item.PCIeSlot"};
 
 using FindPcieSlotCbFunc = std::function<void(
     const std::string&, const dbus::utility::MapperServiceMap&)>;
@@ -107,11 +107,8 @@ inline void getPcieDevicePathAndService(
             return;
         }
 
-        // Find DBus object to get its serviceName
-        std::array<const char*, 1> interfaces = {pcieDeviceInterface};
-
         dbus::utility::getDbusObject(
-            pcieDevicePath, interfaces,
+            pcieDevicePath, pcieDeviceInterface,
             [pcieDevice, pcieDevicePath, asyncResp,
              callback{callback}](const boost::system::error_code& ec1,
                                  const dbus::utility::MapperGetObject& object) {
@@ -312,9 +309,8 @@ static inline void
                            const std::string& pcieSlotPath,
                            const std::string& pcieDevice, Callback&& callback)
 {
-    constexpr std::array<std::string_view, 1> interfaces = {pcieSlotInterface};
     dbus::utility::getSubTree(
-        "/xyz/openbmc_project/inventory", 0, interfaces,
+        "/xyz/openbmc_project/inventory", 0, pcieSlotInterface,
         [asyncResp, pcieSlotPath, pcieDevice,
          callback{std::forward<Callback>(callback)}](
             const boost::system::error_code& ec,
@@ -853,7 +849,8 @@ inline void requestRoutesSystemPCIeFunctionCollection(App& app)
 
             sdbusplus::asio::getAllProperties(
                 *crow::connections::systemBus, serviceName, pcieDevicePath,
-                pcieDeviceInterface, std::move(getPCIeDeviceCallback));
+                "xyz.openbmc_project.Inventory.Item.PCIeDevice",
+                std::move(getPCIeDeviceCallback));
         });
         });
 } // namespace redfish
@@ -990,7 +987,8 @@ inline void requestRoutesSystemPCIeFunction(App& app)
 
             sdbusplus::asio::getAllProperties(
                 *crow::connections::systemBus, serviceName, pcieDevicePath,
-                pcieDeviceInterface, getPCIeDeviceCallback);
+                "xyz.openbmc_project.Inventory.Item.PCIeDevice",
+                getPCIeDeviceCallback);
         });
         });
 }

--- a/redfish-core/lib/power_supply.hpp
+++ b/redfish-core/lib/power_supply.hpp
@@ -431,10 +431,8 @@ inline void
         asyncResp->res.jsonValue["Status"]["State"] = "Enabled";
         asyncResp->res.jsonValue["Status"]["Health"] = "OK";
 
-        std::array<const char*, 1> interfaces = {
-            "xyz.openbmc_project.Inventory.Item.PowerSupply"};
         dbus::utility::getDbusObject(
-            powerSupplyPath, interfaces,
+            powerSupplyPath, powerSupplyInterface,
             [asyncResp,
              powerSupplyPath](const boost::system::error_code& ec,
                               const dbus::utility::MapperGetObject& object) {

--- a/redfish-core/lib/power_supply_metrics.hpp
+++ b/redfish-core/lib/power_supply_metrics.hpp
@@ -43,8 +43,8 @@ static const char* historyMaximumInterface =
 static const char* historyAverageInterface =
     "org.open_power.Sensor.Aggregation.History.Average";
 
-static std::array<const char*, 2> historyInterfaces{historyMaximumInterface,
-                                                    historyAverageInterface};
+static std::array<std::string_view, 2> historyInterfaces{
+    historyMaximumInterface, historyAverageInterface};
 
 inline void addInputHistoryProperties(
     const std::shared_ptr<bmcweb::AsyncResp>& asyncResp,

--- a/redfish-core/lib/sensors.hpp
+++ b/redfish-core/lib/sensors.hpp
@@ -2909,7 +2909,7 @@ inline void handleSensorGet(App& app, const crow::Request& req,
 
     BMCWEB_LOG_DEBUG << "Sensor doGet enter";
 
-    std::array<const char*, 1> interfaces = {
+    std::array<std::string_view, 1> interfaces = {
         "xyz.openbmc_project.Sensor.Value"};
     std::string sensorPath = "/xyz/openbmc_project/sensors/" + nameType.first +
                              '/' + nameType.second;


### PR DESCRIPTION
Change the interface type to std::string_view in the getDbusObject function to ensure consistency with other functions such as getSubTree and getSubTreePaths.

Upstream commit:
https://gerrit.openbmc.org/c/openbmc/bmcweb/+/60230

Tested: Redfish Validator passed