### PR TITLE
1050: Fix PCIeSlot UpstreamFabricAdapter Oem Link (#721)

### DIFF
--- a/redfish-core/lib/fabric_adapters.hpp
+++ b/redfish-core/lib/fabric_adapters.hpp
@@ -203,9 +203,8 @@ inline void doGetFabricAdapterPCIeSlots(
     const std::shared_ptr<bmcweb::AsyncResp>& aResp,
     const std::string& fabricAdapterPath,
     const dbus::utility::MapperEndPoints& pcieSlotPaths,
-    std::function<void(const std::string&,
-                       const dbus::utility::MapperEndPoints&)>
-        callback)
+    const std::function<void(const std::string&,
+                             const dbus::utility::MapperEndPoints&)>&& callback)
 {
     constexpr std::array<std::string_view, 1> chassisInterface{
         "xyz.openbmc_project.Inventory.Item.Chassis"};

--- a/redfish-core/lib/pcie_slots.hpp
+++ b/redfish-core/lib/pcie_slots.hpp
@@ -326,7 +326,7 @@ inline void
 
         slot["Oem"]["@odata.type"] = "#OemPCIeSlots.Oem";
         slot["Oem"]["IBM"]["@odata.type"] = "#OemPCIeSlots.IBM";
-        slot["Oem"]["IBM"]["UpstreamFabricAdapter"] =
+        slot["Oem"]["IBM"]["UpstreamFabricAdapter"]["@odata.id"] =
             crow::utility::urlFromPieces(
                 "redfish", "v1", "Systems", "system", "FabricAdapters",
                 fabric_util::buildFabricUniquePath(fabricAdapterPath));


### PR DESCRIPTION
A previous commit 3fb45da4 incorrectly generates an Oem Link, and it will be fixed.

BEFORE:
```
$ curl -k -X GET https://${bmc}:18080/redfish/v1/Chassis/chassis15363/PCIeSlots
{
  "@odata.id": "/redfish/v1/Chassis/chassis15363/PCIeSlots",
  "@odata.type": "#PCIeSlots.v1_5_0.PCIeSlots",
  "Id": "1",
  "Name": "PCIe Slot Information",
  "Slots": [
   ...
   {
      ...
      "LocationIndicatorActive": false,
      "Oem": {
        "@odata.type": "#OemPCIeSlots.Oem",
        "IBM": {
          "@odata.type": "#OemPCIeSlots.v1_0_1.OemPCIeSlots.IBM",
          "LinkId": 385,
          "UpstreamFabricAdapter": "/redfish/v1/Systems/system/FabricAdapters/chassis15363-logical_slot2-io_module2"
        }
      }
    },
```

FIX:

```
$ curl -k -X GET [https://${bmc}:18080/redfish/v1/Chassis/chassis15363/PCIeSlots](https://%24%7Bbmc%7D:18080/redfish/v1/Chassis/chassis15363/PCIeSlots)
{
  "@odata.id": "/redfish/v1/Chassis/chassis15363/PCIeSlots",
  "@odata.type": "#PCIeSlots.v1_5_0.PCIeSlots",
  "Id": "1",
  "Name": "PCIe Slot Information",
  "Slots": [
   ...
   {
      ...
      "LocationIndicatorActive": false,
      "Oem": {
        "@odata.type": "#OemPCIeSlots.Oem",
        "IBM": {
          "@odata.type": "#OemPCIeSlots.v1_0_1.OemPCIeSlots.IBM",
          "LinkId": 385,
          "UpstreamFabricAdapter": {
               "@odata.id": "/redfish/v1/Systems/system/FabricAdapters/chassis15363-logical_slot2-io_module2"
           }
        }
      }
    },
```