### PR TITLE
Configure DHCP4 and DHCP6 parameters independently

### DIFF
--- a/redfish-core/lib/ethernet.hpp
+++ b/redfish-core/lib/ethernet.hpp
@@ -1628,12 +1628,12 @@ inline void handleDHCPPatch(const std::string& ifaceId,
     BMCWEB_LOG_DEBUG << "set HostNameEnabled...";
     setDHCPConfig("HostNameEnabled", nextUseDomain, asyncResp, ifaceId,
                   "dhcp4");
-    BMCWEB_LOG_DEBUG << "set DNSv6Enabled...";
-    setDHCPConfig("DNSv6Enabled", nextDNSv6, asyncResp, ifaceId, "dhcp6");
-    BMCWEB_LOG_DEBUG << "set NTPv6Enabled...";
-    setDHCPConfig("NTPv6Enabled", nextNTPv6, asyncResp, ifaceId, "dhcp6");
-    BMCWEB_LOG_DEBUG << "set Hostv6NameEnabled...";
-    setDHCPConfig("HostNamev6Enabled", nextUsev6Domain, asyncResp, ifaceId,
+    BMCWEB_LOG_DEBUG << "set DNSEnabled for dhcp6...";
+    setDHCPConfig("DNSEnabled", nextDNSv6, asyncResp, ifaceId, "dhcp6");
+    BMCWEB_LOG_DEBUG << "set NTPEnabled for dhcp6...";
+    setDHCPConfig("NTPEnabled", nextNTPv6, asyncResp, ifaceId, "dhcp6");
+    BMCWEB_LOG_DEBUG << "set HostNameEnabled for dhcp6...";
+    setDHCPConfig("HostNameEnabled", nextUsev6Domain, asyncResp, ifaceId,
                   "dhcp6");
 }
 


### PR DESCRIPTION
This PR is to fix the error introduced in https://github.com/ibm-openbmc/bmcweb/commit/cde6f8fc1322aed9186e0b87b155d0d10ed43a63
Property name of DHCP parameters are updated for dhcp6

Tested by:

Patch request:

 curl -k -H "X-Auth-Token: $bmc_token" -X  PATCH -d
 '{"DHCPv6":{"UseNTPServers":false}}'
 https://${bmc}/redfish/v1/Managers/bmc/EthernetInterfaces/eth1

Patch Response:
 {
  "@Message.ExtendedInfo": [
    {
      "@odata.type": "#Message.v1_1_1.Message",
      "Message": "The request completed successfully.",
      "MessageArgs": [],
      "MessageId": "Base.1.13.0.Success",
      "MessageSeverity": "OK",
      "Resolution": "None"
    }
  ],

Get Request:
curl -k -H "X-Auth-Token: $bmc_token" -X GET
https://${bmc}/redfish/v1/Managers/bmc/EthernetInterfaces/eth1

Get Response:
{
  "@odata.id": "/redfish/v1/Managers/bmc/EthernetInterfaces/eth1",
  "@odata.type": "#EthernetInterface.v1_8_0.EthernetInterface",
  "DHCPv4": {
    "DHCPEnabled": true,
    "UseDNSServers": true,
    "UseDomainName": true,
    "UseNTPServers": true
  },
  "DHCPv6": {
    "OperatingMode": "Enabled",
    "UseDNSServers": true,
    "UseDomainName": true,
    "UseNTPServers": false
  },
  
  Upstream commit : https://gerrit.openbmc.org/c/openbmc/bmcweb/+/63390

Change-Id: I5db29b6dfc8966ff5af51041da11e5b79da7d1dd