### PR TITLE
Fix events destination url parsing for IPv6

### DIFF
--- a/http/utility.hpp
+++ b/http/utility.hpp
@@ -855,7 +855,7 @@ inline bool validateAndSplitUrl(std::string_view destUrl, std::string& urlProto,
 
     port = setPortDefaults(url.value());
 
-    host = url->encoded_host();
+    host = url->encoded_host_address();
 
     path = url->encoded_path();
     if (path.empty())


### PR DESCRIPTION
Currently while parsing destination URL, host address enclosed in [] braces for IPv6 addresses, so Resolve hostname fails for IPv6 addresses because of this invalid hostname which is enclosed in [] braces.

This commit uses encoded_host_address() method to fix this parsing hostname for IPv6 address.

Tested By: Configured redfish event subscription with IPv6 destination URI verified parsing logic of destination URI with IPv6 addresses.

Change-Id: I0e43468086ae0b961eb724de30e211d61ccda2d8