### PR TITLE
Add missing odata.id field under OriginOfCondition for assemblies

### DIFF
--- a/redfish-core/lib/log_services.hpp
+++ b/redfish-core/lib/log_services.hpp
@@ -5802,6 +5802,7 @@ inline void getRedfishUriByDbusObjPath(
                 {
                     auto uriPropPath = "/Links"_json_pointer;
                     uriPropPath /= "OriginOfCondition";
+                    uriPropPath /= "@odata.id";
 
                     assembly::fillWithAssemblyId(
                         asyncResp, std::get<0>(assemblyParent),


### PR DESCRIPTION
The OriginOfCondition Link should have an odata.id which was missing for assemblies. All other Deconfig records already correctly had this property.

missing odata.id:

  "Links": {
    "OriginOfCondition": "/redfish/v1/Chassis/chassis/Assembly#/Assemblies/49"
<-- missing @odata.id
  },
  "Message": "TPM Card",
  "Name": "Hardware Isolation Entry",

Fixed:

   "Links": {
    "OriginOfCondition": {
      "@odata.id": "/redfish/v1/Chassis/chassis/Assembly#/Assemblies/49" <--
odata.id present
    }
  },
  "Message": "TPM Card",
  "Name": "Hardware Isolation Entry",