### PR TITLE
1050: Reduce memory usage during Firmware update

### DIFF
--- a/http/routing.hpp
+++ b/http/routing.hpp
@@ -1460,7 +1460,7 @@ class Router
         std::string username = req.session->username;
 
         crow::connections::systemBus->async_method_call(
-            [req, asyncResp, &rule, params](
+            [&req, asyncResp, &rule, params](
                 const boost::system::error_code ec,
                 const dbus::utility::DBusPropertiesMap& userInfoMap) mutable {
             if (ec)

--- a/include/audit_events.hpp
+++ b/include/audit_events.hpp
@@ -229,7 +229,7 @@ inline void auditEvent(const crow::Request& req, const std::string& userName,
     std::string detail;
     if (wantDetail(req))
     {
-        detail = req.body + " ";
+        detail = req.body.substr(0, maxBuf) + " ";
     }
 
     if (!detail.empty())


### PR DESCRIPTION
bmcweb currently consumes the excessive memory during firmware update. It is due to the replications of the req.body (which is the full content of firmware).

- req.body is captured by-value instead of by-reference in a lambda when the user-validation.

- audit copies the entire req.body before truncating it to the buffer.

Tested:

- Redfish validator passes
- Monitor memory consumption of bmcweb process periodically. e.g., top -b -d 0.5 | grep /usr/bin/bmcweb
- With the fix, the max memory usage should only be increased about the size of the image.