### PR TITLE
RedfishEvents: Avoid setting SNI for IP addresses

### DIFF
--- a/http/http_client.hpp
+++ b/http/http_client.hpp
@@ -37,6 +37,7 @@
 #include <boost/beast/version.hpp>
 #include <boost/container/devector.hpp>
 #include <boost/system/error_code.hpp>
+#include <boost/url/url_view.hpp>
 #include <logging.hpp>
 #include <ssl_key_handler.hpp>
 
@@ -564,6 +565,13 @@ class ConnectionInfo : public std::enable_shared_from_this<ConnectionInfo>
     {
         if (!sslConn)
         {
+            return;
+        }
+
+        boost::urls::url_view view("https://" + host);
+        if (view.host_type() != boost::urls::host_type::name)
+        {
+            // Avoid setting SNI hostname if its IP address
             return;
         }
         // NOTE: The SSL_set_tlsext_host_name is defined in tlsv1.h header


### PR DESCRIPTION
ssl_handshake fails while establishing connection to IPv6 destination address. as IPv6 addressses considered as invalid value for SNI hostname due to special characters.

SNI allows valid HostName which Allows characters are only {alphabetic
characters (A-Z), numeric characters (0-9), the minus sign.

Tested By: Verified redfish events 1. Subscribing Destination with IPv6 address.  2. Subscribing Destination with IPv4 address.

Change-Id: I32d30292bbc29c753f1c1815c66fcc93e8074eaa