### PR TITLE
Avoid setting SNI hostname for IP addresses

### DIFF
--- a/http/http_client.hpp
+++ b/http/http_client.hpp
@@ -17,6 +17,7 @@
 
 #include "async_resolve.hpp"
 #include "http_response.hpp"
+#include "utility.hpp"
 
 #include <boost/asio/connect.hpp>
 #include <boost/asio/io_context.hpp>
@@ -568,12 +569,15 @@ class ConnectionInfo : public std::enable_shared_from_this<ConnectionInfo>
             return;
         }
 
-        boost::urls::url_view view("https://" + host);
+        boost::urls::url url("https://");
+        crow::utility::appendUrlPieces(url, host);
+        boost::urls::url_view view(url);
         if (view.host_type() != boost::urls::host_type::name)
         {
             // Avoid setting SNI hostname if its IP address
             return;
         }
+
         // NOTE: The SSL_set_tlsext_host_name is defined in tlsv1.h header
         // file but its having old style casting (name is cast to void*).
         // Since bmcweb compiler treats all old-style-cast as error, its


### PR DESCRIPTION
ssl_handshake fails while establishing connection to IPv6 destination address, as IPv6 addressses considered as invalid value for SNI hostname due to special characters.

SNI allows valid HostName which allows characters are only {alphabetic characters (A-Z), numeric characters (0-9), the minus sign

This commit adds check to avoid setting SNI hostname if its an IP address

Tested By: Verified redfish events 1. Subscribing Destination with IPv6 address.  2. Subscribing Destination with IPv4 address.

Change-Id: I32d30292bbc29c753f1c1815c66fcc93e8074eaa