### PR TITLE
1050: Show Update error type on logs if unknown

### DIFF
--- a/redfish-core/lib/update_service.hpp
+++ b/redfish-core/lib/update_service.hpp
@@ -478,6 +478,8 @@ static void monitorForSoftwareAvailable(
                     }
                     else
                     {
+                        BMCWEB_LOG_ERROR
+                            << "Unknown Software Image Error type= " << *type;
                         redfish::messages::internalError(asyncResp->res);
                     }
                 }


### PR DESCRIPTION
Update is failing due to unknown update dbus error type but the cause can not be determined as its value is not showing.

This change is to add the error cause to journal in addition to CRITICAL internalError.

```
Aug 02 09:00:16 bmcweb[2476]: (2023-08-02 09:00:14) [ERROR
    "update_service.hpp":396] Unknown Software Image Error type = <XXX>
Aug 02 09:00:16 bmcweb[2476]: (2023-08-02 09:00:14) [CRITICAL
    "error_messages.cpp":284] Internal Error ....`
```

Not tested, but successfully compiled.

Change-Id: I20833d24042bf8d2f7e2d8a8e4359e3d80af702a
upstream: https://gerrit.openbmc.org/c/openbmc/bmcweb/+/65700
