### PR TITLE
Add missing comma in Permissions-Policy

### DIFF
--- a/include/security_headers.hpp
+++ b/include/security_headers.hpp
@@ -47,7 +47,7 @@ inline void addSecurityHeaders(const crow::Request& req [[maybe_unused]],
                                         "payment=(),"
                                         "picture-in-picture=(),"
                                         "publickey-credentials-get=(),"
-                                        "speaker-selection=()"
+                                        "speaker-selection=(),"
                                         "sync-xhr=(self),"
                                         "unoptimized-images=(self),"
                                         "unsized-media=(self),"


### PR DESCRIPTION
Upstream is merged at https://gerrit.openbmc.org/c/openbmc/bmcweb/+/66057

This adds a missing comma in the Permissions-Policy response header value.

Tested: no; I didn't even try to compile it.

Change-Id: I4f08b54a5e5af040e10a95d913ef8b457f5bd457