### PR TITLE
1050: Fix PCIeSlots Redfish validator Error

### DIFF
--- a/redfish-core/lib/pcie_slots.hpp
+++ b/redfish-core/lib/pcie_slots.hpp
@@ -229,12 +229,13 @@ inline void linkAssociatedDiskBackplane(
                                 drivePath);
             if (it != assemblyList.end())
             {
+                asyncResp->res.jsonValue["Slots"][index]["Links"]["Oem"]
+                                        ["@odata.type"] = "#OemPCIeSlots.Oem";
                 asyncResp->res.jsonValue["Slots"][index]["Links"]["Oem"]["IBM"]
-                                        ["AssociatedAssembly"] = {
-                    {{"@odata.id",
-                      "/redfish/v1/Chassis/" + chassisId +
-                          "/Assembly#/Assemblies/" +
-                          std::to_string(it - assemblyList.begin())}}};
+                                        ["AssociatedAssembly"]["@odata.id"] =
+                    "/redfish/v1/Chassis/" + chassisId +
+                    "/Assembly#/Assemblies/" +
+                    std::to_string(it - assemblyList.begin());
             }
             else
             {
@@ -325,7 +326,6 @@ inline void
         nlohmann::json& slot = asyncResp->res.jsonValue["Slots"][index];
 
         slot["Links"]["Oem"]["@odata.type"] = "#OemPCIeSlots.Oem";
-        slot["Links"]["Oem"]["IBM"]["@odata.type"] = "#OemPCIeSlots.IBM";
         slot["Links"]["Oem"]["IBM"]["UpstreamFabricAdapter"]["@odata.id"] =
             crow::utility::urlFromPieces(
                 "redfish", "v1", "Systems", "system", "FabricAdapters",
@@ -411,7 +411,6 @@ inline void getPCIeSlotProperties(
     if (busId != nullptr)
     {
         slot["Oem"]["@odata.type"] = "#OemPCIeSlots.Oem";
-        slot["Oem"]["IBM"]["@odata.type"] = "#OemPCIeSlots.IBM";
         slot["Oem"]["IBM"]["LinkId"] = *busId;
     }
 


### PR DESCRIPTION
The latest Redfish-Validator reports the following errors.

```
26 err.Collection(Processor.Processor) errors in /redfish/v1/Chassis/chassis/PCIeSlots
16 failInvalidArray errors in /redfish/v1/Chassis/chassis/PCIeSlots
26 failProp errors in /redfish/v1/Chassis/chassis/PCIeSlots

ERROR - Property AssociatedAssembly should not be a List
ERROR - This object's type AssociatedAssembly should be a Collection, but it's of type Resource.OemObject...
ERROR - AssociatedAssembly: Value of property is an array but is not a Collection
ERROR - AssociatedAssembly: Value of property is an array but is not a Collection
...
WARNING - Couldn't get schema for object (?), skipping OemObject IBM : 'IBM'
WARNING - Couldn't get schema for object (?), skipping OemObject IBM : 'IBM'
```

It is caused because `AssociatedAssembly` is incorrectly showing as an array.

```
$ curl -k -X GET https://${bmc}/redfish/v1/Chassis/chassis/PCIeSlots
  ...
            "AssociatedAssembly": [
              {
                "@odata.id": "/redfish/v1/Chassis/chassis/Assembly#/Assemblies/17"
              }
            ]

==>
            "AssociatedAssembly": {
              "@odata.id": "/redfish/v1/Chassis/chassis/Assembly%23/Assemblies/17"
            }
```

Tested:
- Redfish validator runs without the reported errors
- Redfish validator reduces warnings