### PR TITLE
1050: Move PCIeSlots UpstreamFabricAdapter field under Links

### DIFF
--- a/redfish-core/lib/pcie_slots.hpp
+++ b/redfish-core/lib/pcie_slots.hpp
@@ -324,9 +324,9 @@ inline void
         const std::string& fabricAdapterPath = fabricAdapterPaths.front();
         nlohmann::json& slot = asyncResp->res.jsonValue["Slots"][index];
 
-        slot["Oem"]["@odata.type"] = "#OemPCIeSlots.Oem";
-        slot["Oem"]["IBM"]["@odata.type"] = "#OemPCIeSlots.IBM";
-        slot["Oem"]["IBM"]["UpstreamFabricAdapter"]["@odata.id"] =
+        slot["Links"]["Oem"]["@odata.type"] = "#OemPCIeSlots.Oem";
+        slot["Links"]["Oem"]["IBM"]["@odata.type"] = "#OemPCIeSlots.IBM";
+        slot["Links"]["Oem"]["IBM"]["UpstreamFabricAdapter"]["@odata.id"] =
             crow::utility::urlFromPieces(
                 "redfish", "v1", "Systems", "system", "FabricAdapters",
                 fabric_util::buildFabricUniquePath(fabricAdapterPath));


### PR DESCRIPTION
In PCIeSlots, Oem UpstreamFabricAdapter field is a link to the other resource (FabricAdapter) and thus it is more appropriate to put it as Links | Oem | IBM | UpstreamFabricAdapter.

Current:

```
$ curl -k -X GET https://${bmc}/redfish/v1/Chassis/chassis15363/PCIeSlots
    "Oem": {
        "IBM": {
          "UpstreamFabricAdapter": {
            "@odata.id": "/redfish/v1/Systems/system/FabricAdapters/chassis15363-logical_slot2-io_module2"
          }
```

After change:
```
$ curl -k -X GET https://${bmc}/redfish/v1/Chassis/chassis15363/PCIeSlots
 "Links": {
    "Oem": {
        "IBM": {
          "UpstreamFabricAdapter": {
            "@odata.id": "/redfish/v1/Systems/system/FabricAdapters/chassis15363-logical_slot2-io_module2"
          }
```

Tested:
- Redfish validator passes
- Query `curl -k -X GET https://${bmc}/redfish/v1/Chassis/chassis15363/PCIeSlots` to check the new output