### PR TITLE
1020: Ignore Non-software-related events during Update (#751)

### DIFF
--- a/redfish-core/lib/update_service.hpp
+++ b/redfish-core/lib/update_service.hpp
@@ -477,10 +477,41 @@ static void monitorForSoftwareAvailable(
             {
                 redfish::messages::resourceExhaustion(asyncResp->res, url);
             }
-            else
+            else if (*type ==
+                     "xyz.openbmc_project.Software.Version.Error.Incompatible")
             {
+                redfish::messages::invalidUpload(asyncResp->res, url,
+                                                 "Incompatible image version");
+            }
+            else if (*type == "xyz.openbmc_project.Software.Version.Error."
+                              "ExpiredAccessKey")
+            {
+                redfish::messages::invalidUpload(asyncResp->res, url,
+                                                 "Update Access Key Expired");
+            }
+            else if (*type == "xyz.openbmc_project.Software.Version.Error."
+                              "InvalidSignature")
+            {
+                redfish::messages::invalidUpload(asyncResp->res, url,
+                                                 "Invalid image signature");
+            }
+            else if (*type == "xyz.openbmc_project.Software.Image.Error."
+                              "InternalFailure" ||
+                     *type ==
+                         "xyz.openbmc_project.Software.Version.Error.HostFile")
+
+            {
+                BMCWEB_LOG_ERROR << "Software Image Error type=" << *type;
                 redfish::messages::internalError(asyncResp->res);
             }
+            else
+            {
+                // Unrelated error types. Ignored
+                BMCWEB_LOG_INFO << "Non-Software-related Error type=" << *type
+                                << ". Ignored";
+                return;
+            }
+            // Clear the timer
             fwAvailableTimer = nullptr;
         });
 }


### PR DESCRIPTION
#### Ignore Non-software-related events during Update (#751)
```
During code update, if another application (e.g. pldm[1]) logs an error
unrelated to code update, this triggers an error event notification
and causes the code update failure.

```
$ uri=$(curl -k https://${bmc}/redfish/v1/UpdateService | jq -r ' .HttpPushUri'); echo $uri
$ curl -k -H "Content-Type: application/octet-stream" -X POST -T ${image}  https://${bmc}${uri}
{
  "error": {
    ...
    "code": "Base.1.13.0.InternalError",
    "message": "The request failed due to an internal service error.  The service is still operational."
  }
}
```

This commit is to filter out those non-update-related error events from concluding
the code update as failure.

The valid update-related errors are defined in
- https://github.com/openbmc/phosphor-dbus-interfaces/blob/master/yaml/xyz/openbmc_project/Software/Version.errors.yaml
- https://github.com/openbmc/phosphor-bmc-code-mgmt/blob/master/xyz/openbmc_project/Software/Image.errors.yaml

Tested:

1) Redfish validator passed

2) Error injection during Update.

  - Start the code update and wait for completion of update (e.g. using journalctl -f)

```
$ uri=$(curl -k https://${bmc}/redfish/v1/UpdateService | jq -r ' .HttpPushUri'); echo $uri
$ curl -k -H "Content-Type: application/octet-stream" -X POST -T ${image}  https://${bmc}${uri}
```
  - As soon as the image is untarring, and issue busctl cmd to inject a non-update error

```
busctl call xyz.openbmc_project.Logging /xyz/openbmc_project/logging  \
        xyz.openbmc_project.Logging.Create Create ssa{ss} \
        xyz.openbmc_project.Host.Error.Event  \
        xyz.openbmc_project.Logging.Entry.Level.Error 1 RAWPEL \
        /tmp/FILE_NBMC_UNRECOVERABLE
```

[1] https://github.com/openbmc/pldm/blob/master/oem/ibm/libpldmresponder/file_io_type_pel.cpp#L268

Change-Id: Ice54c403efacffa6a388e182bd04d97c3e2b97fc

Signed-off-by: Myung Bae <myungbae@us.ibm.com>```