### PR TITLE
Remove location header

### DIFF
--- a/redfish-core/lib/certificate_service.hpp
+++ b/redfish-core/lib/certificate_service.hpp
@@ -369,10 +369,6 @@ static void getCertificateProperties(
             asyncResp->res.jsonValue["ValidNotBefore"] =
                 redfish::time_utils::getDateTimeUint(*validNotBefore);
         }
-
-        asyncResp->res.addHeader(
-            boost::beast::http::field::location,
-            std::string_view(certURL.data(), certURL.size()));
         });
 }
 


### PR DESCRIPTION
https://jazz07.rchland.ibm.com:13443/jazz/web/projects/CSSD#action=com.ibm.team.workitem.viewWorkItem&id=548905 is the defect 

The location header is not used. This header is causing problems because it looks like the following when returned Location
	�Kõ�����/v1/AccountService/LDAP/Certificates/1
and chrome is rejecting that response with a
ERR_INVALID_HTTP_RESPONSE

