### PR TITLE
VMI:Not able to set static IPv6 address when DHCPv6 is enabled

### DIFF
--- a/redfish-core/lib/hypervisor_system.hpp
+++ b/redfish-core/lib/hypervisor_system.hpp
@@ -985,12 +985,11 @@ inline void handleHypervisorIPv4StaticPatch(
             << "INFO: Static ip configuration request from client: " << clientIp
             << " - ip: " << *address << "; gateway: " << *gateway
             << "; prefix length: " << static_cast<int64_t>(prefixLength);
-
+        // Set the DHCPEnabled to false since the Static IPv4 is set
+        setDHCPEnabled(ifaceId, ethData, false, asyncResp);
         createHypervisorIP(ifaceId, prefixLength, *gateway, *address,
                            "xyz.openbmc_project.Network.IP.Protocol.IPv4",
                            asyncResp);
-        // Set the DHCPEnabled to false since the Static IPv4 is set
-        setDHCPEnabled(ifaceId, ethData, false, asyncResp);
     }
     else
     {
@@ -1063,12 +1062,11 @@ inline void handleHypervisorIPv6StaticPatch(
             << req.session->clientIp << " - ip: " << *address
             << ";gateway: " << *gateway
             << "; prefix length: " << static_cast<int64_t>(*prefixLen);
-
+        // Set the DHCPEnabled to false since the Static IPv6 is set
+        setIpv6DhcpOperatingMode(ifaceId, ethData, "Disabled", asyncResp);
         createHypervisorIP(ifaceId, *prefixLen, *gateway, *address,
                            "xyz.openbmc_project.Network.IP.Protocol.IPv6",
                            asyncResp);
-        // Set the DHCPEnabled to false since the Static IPv6 is set
-        setIpv6DhcpOperatingMode(ifaceId, ethData, "Disabled", asyncResp);
     }
     else
     {


### PR DESCRIPTION
Bug Fix for 562664.
Pre-Condition:
DHCPv4::DHCPEnabled:true
DHCPv6::OperationMode:Enabled
Try to set IPV6 static address.
IPV6 static address is not set.

Fix:
There is an order mismatch in setting ip address and disabling operation mode.DHCP should be disabled first when there is a static configuration request. Right now, static ip is configured and then dhcp mode is disabled causing the ip properties to be resetted

Test Cases Run:
DHCPv4::DHCPEnabled:true
DHCPv6::OperationMode:Enabled
Try to set IPV6 static address.
Expected Result
IPV6 static address should be set.

DHCPv4::DHCPEnabled:false
DHCPv6::OperationMode:Enabled
Try to set IPV6 static address.
Expected Result
IPV6 static address should be set.

DHCPv4::DHCPEnabled:true
DHCPv6::OperationMode:Disabled
Try to set IPV6 static address.
Expected Result
IPV6 static address should be set.

DHCPv4::DHCPEnabled:false
DHCPv6::OperationMode:Disabled
Try to set IPV6 static address.
Expected Result
IPV6 static address should be set.

Change-Id: I1ede93305412ada9cedf27b88a048730e3c7fc15