### PR TITLE
certificate_service: Fix garbled display caused by dangling reference

### DIFF
--- a/redfish-core/lib/certificate_service.hpp
+++ b/redfish-core/lib/certificate_service.hpp
@@ -500,7 +500,7 @@ inline void handleReplaceCertificateAction(
     }
     BMCWEB_LOG_INFO << "Certificate URI to replace: " << certURI;
 
-    boost::urls::result<boost::urls::url_view> parsedUrl =
+    boost::urls::result<boost::urls::url> parsedUrl =
         boost::urls::parse_relative_ref(certURI);
     if (!parsedUrl)
     {


### PR DESCRIPTION
Upstream is https://gerrit.openbmc.org/c/openbmc/bmcweb/+/66453
Defect is https://jazz07.rchland.ibm.com:13443/jazz/web/projects/CSSD#action=com.ibm.team.workitem.viewWorkItem&id=548905

Post:
```
/redfish/v1/CertificateService/Actions/CertificateService.ReplaceCertificate
```
The "@odata.id" field in the response will appear garbled. This is caused by boost::urls::url_view outlives its original char sequence. Fix this issue.

Tested:
```
1.Get token
2.curl -k -H "X-Auth-Token: $token" -X POST https://${bmc}/redfish/v1/CertificateService/Actions/CertificateService.ReplaceCertificate -d '{"CertificateUri": {"@odata.id":"/redfish/v1/Managers/bmc/NetworkProtocol/HTTPS/Certificates/1"}, "CertificateString":"...", "CertificateType": "PEM"}'
{
  "@odata.id": "/redfish/v1/Managers/bmc/NetworkProtocol/HTTPS/Certificates/1",
  ...
}
```

Gunnar tested webui-vue with this and no longer see the "ERR_INVALID_HTTP_RESPONSE" on a chrome browser. 
Instead, see a "Successfully replaced LDAP Certificate." :) 

Change-Id: I6b16cbfaf22f835488a54097c83cee8a1b9e9f6a