### PR TITLE
Replace "Fix keepalive false" with patchset 3

### DIFF
--- a/http/http_connection.hpp
+++ b/http/http_connection.hpp
@@ -364,6 +364,7 @@ class Connection :
             completeRequest(res);
             return;
         }
+        keepAlive = thisReq.keepAlive();
 #ifndef BMCWEB_INSECURE_DISABLE_AUTHX
         if (!crow::authentication::isOnAllowlist(req->url, req->method()) &&
             thisReq.session == nullptr)
@@ -493,6 +494,7 @@ class Connection :
             return;
         }
         res = std::move(thisRes);
+        res.keepAlive(keepAlive);
 
 #ifdef BMCWEB_ENABLE_LINUX_AUDIT_EVENTS
         if (audit::wantAudit(*req))
@@ -518,7 +520,7 @@ class Connection :
 #endif // BMCWEB_ENABLE_LINUX_AUDIT_EVENTS
 
         BMCWEB_LOG_INFO << "Response: " << this << ' ' << req->url << ' '
-                        << res.resultInt() << " keepalive=" << req->keepAlive();
+                        << res.resultInt() << " keepalive=" << keepAlive;
 
         addSecurityHeaders(*req, res);
 
@@ -744,7 +746,7 @@ class Connection :
                 BMCWEB_LOG_DEBUG << this << " from write(2)";
                 return;
             }
-            if (!res.keepAlive())
+            if (!keepAlive)
             {
                 close();
                 BMCWEB_LOG_DEBUG << this << " from write(1)";
@@ -845,6 +847,8 @@ class Connection :
     std::shared_ptr<persistent_data::UserSession> userSession;
 
     boost::asio::steady_timer timer;
+
+    bool keepAlive = true;
 
     std::function<std::string()>& getCachedDateStr;
 


### PR DESCRIPTION
This reverts commit 5ae6f9254161f7229216c08b591e31eaf10f69e4.

And replaces it with patchset 3 from the same review, for which was tested to work properly.  This commit was merged erroneously.


Change-Id: I201924ad27d33923d43bdf82ecb016a0f214b4dd