### PR TITLE
Enable more RC traces

### DIFF
--- a/redfish-core/lib/led.hpp
+++ b/redfish-core/lib/led.hpp
@@ -50,7 +50,7 @@ inline void
         // proceed to get enclosure_identify state.
         if (ec == boost::system::errc::invalid_argument)
         {
-            BMCWEB_LOG_DEBUG
+            BMCWEB_LOG_ERROR
                 << "Get identity blinking LED failed, missmatch in property type";
             messages::internalError(aResp->res);
             return;
@@ -71,7 +71,7 @@ inline void
             [aResp](const boost::system::error_code ec2, const bool ledOn) {
             if (ec2 == boost::system::errc::invalid_argument)
             {
-                BMCWEB_LOG_DEBUG
+                BMCWEB_LOG_ERROR
                     << "Get enclosure identity led failed, missmatch in property type";
                 messages::internalError(aResp->res);
                 return;
@@ -141,7 +141,7 @@ inline void
             [aResp](const boost::system::error_code ec2) {
             if (ec2)
             {
-                BMCWEB_LOG_DEBUG << "DBUS response error " << ec2;
+                BMCWEB_LOG_ERROR << "DBUS response error " << ec2;
                 messages::internalError(aResp->res);
                 return;
             }
@@ -184,6 +184,7 @@ inline void getLedAsset(const std::shared_ptr<bmcweb::AsyncResp>& aResp,
             {
                 if (ec1.value() != EBADR)
                 {
+                    BMCWEB_LOG_ERROR << "DBUS response error " << ec1.value();
                     messages::internalError(aResp->res);
                 }
                 return;
@@ -217,6 +218,7 @@ inline void setLedAsset(const std::shared_ptr<bmcweb::AsyncResp>& aResp,
             {
                 if (ec1.value() != EBADR)
                 {
+                    BMCWEB_LOG_ERROR << "DBUS response error " << ec1.value();
                     messages::internalError(aResp->res);
                 }
                 return;
@@ -249,6 +251,7 @@ inline void
         {
             if (ec.value() != EBADR)
             {
+                BMCWEB_LOG_ERROR << "DBUS response error " << ec.value();
                 messages::internalError(aResp->res);
             }
             return;
@@ -291,6 +294,7 @@ inline void
         {
             if (ec.value() != EBADR)
             {
+                BMCWEB_LOG_ERROR << "DBUS response error " << ec.value();
                 messages::internalError(aResp->res);
             }
             return;

--- a/redfish-core/lib/oem/ibm/lamp_test.hpp
+++ b/redfish-core/lib/oem/ibm/lamp_test.hpp
@@ -47,6 +47,7 @@ inline void getLampTestState(const std::shared_ptr<bmcweb::AsyncResp>& aResp)
             {
                 if (ec1.value() != EBADR)
                 {
+                    BMCWEB_LOG_ERROR << "DBUS response error " << ec1.value();
                     messages::internalError(aResp->res);
                 }
                 return;
@@ -96,6 +97,7 @@ inline void setLampTestState(const std::shared_ptr<bmcweb::AsyncResp>& aResp,
             {
                 if (ec1.value() != EBADR)
                 {
+                    BMCWEB_LOG_ERROR << "DBUS response error " << ec1.value();
                     messages::internalError(aResp->res);
                 }
                 return;
@@ -105,7 +107,7 @@ inline void setLampTestState(const std::shared_ptr<bmcweb::AsyncResp>& aResp,
                 [aResp](const boost::system::error_code& ec2) {
                 if (ec2)
                 {
-                    BMCWEB_LOG_DEBUG
+                    BMCWEB_LOG_ERROR
                         << "Panel Lamp test failed with error code " << ec2;
                     messages::internalError(aResp->res);
                     return;

--- a/redfish-core/lib/oem/ibm/system_attention_indicator.hpp
+++ b/redfish-core/lib/oem/ibm/system_attention_indicator.hpp
@@ -59,6 +59,7 @@ inline void getSAI(const std::shared_ptr<bmcweb::AsyncResp>& aResp,
             {
                 if (ec1.value() != EBADR)
                 {
+                    BMCWEB_LOG_ERROR << "DBUS response error " << ec.value();
                     messages::internalError(aResp->res);
                 }
                 return;
@@ -129,6 +130,7 @@ inline void setSAI(const std::shared_ptr<bmcweb::AsyncResp>& aResp,
             {
                 if (ec1.value() != EBADR)
                 {
+                    BMCWEB_LOG_ERROR << "DBUS response error " << ec1.value();
                     messages::internalError(aResp->res);
                 }
                 return;


### PR DESCRIPTION
The return code coming back from D-Bus is really useful. For example on 568739, assume these were all 110 (timeout) but don't know that without an return code trace.

These are all downstream only :/
LEDs are up for review at
https://gerrit.openbmc.org/c/openbmc/bmcweb/+/57765 but Lakshmi has already added this tracing.