### PR TITLE
Fix compile

### DIFF
--- a/redfish-core/lib/oem/ibm/system_attention_indicator.hpp
+++ b/redfish-core/lib/oem/ibm/system_attention_indicator.hpp
@@ -59,7 +59,7 @@ inline void getSAI(const std::shared_ptr<bmcweb::AsyncResp>& aResp,
             {
                 if (ec1.value() != EBADR)
                 {
-                    BMCWEB_LOG_ERROR << "DBUS response error " << ec.value();
+                    BMCWEB_LOG_ERROR << "DBUS response error " << ec1.value();
                     messages::internalError(aResp->res);
                 }
                 return;


### PR DESCRIPTION
 https://github.com/ibm-openbmc/bmcweb/pull/760/files  caused this 

https://ibm-systems-power.slack.com/archives/C04KG79NAUA/p1694553582725739?thread_ts=1694463227.287219&cid=C04KG79NAUA 

```
bmcweb.p/src_webserver_main.cpp.o -MF bmcweb.p/src_webserver_main.cpp.o.d -o bmcweb.p/src_webserver_main.cpp.o -c ../git/src/webserver_main.cpp | In file included from ../git/redfish-core/lib/systems.hpp:27,
|                  from ../git/redfish-core/include/redfish.hpp:55,
|                  from ../git/src/webserver_main.cpp:21:
| ../git/redfish-core/lib/oem/ibm/system_attention_indicator.hpp: In lambda function:
| ../git/redfish-core/lib/oem/ibm/system_attention_indicator.hpp:62:67: error: 'ec' is not captured
|    62 |                     BMCWEB_LOG_ERROR << "DBUS response error " << ec.value();
|       |                                                                   ^~
| ../git/redfish-core/lib/oem/ibm/system_attention_indicator.hpp:56:34: note: the lambda has no capture-default
|    56 |             [aResp, propertyValue](const boost::system::error_code& ec1,
|       |                                  ^
| ../git/redfish-core/lib/oem/ibm/system_attention_indicator.hpp:44:58: note: 'const boost::system::error_code& ec' declared here
|    44 |          propertyValue](const boost::system::error_code& ec,
|       |                         ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~^~
| ninja: build stopped: subcommand failed.
```