### PR TITLE
1050: Fix compiler error due to incorrect variable name (#760)

### DIFF
--- a/redfish-core/lib/oem/ibm/system_attention_indicator.hpp
+++ b/redfish-core/lib/oem/ibm/system_attention_indicator.hpp
@@ -59,7 +59,7 @@ inline void getSAI(const std::shared_ptr<bmcweb::AsyncResp>& aResp,
             {
                 if (ec1.value() != EBADR)
                 {
-                    BMCWEB_LOG_ERROR << "DBUS response error " << ec.value();
+                    BMCWEB_LOG_ERROR << "DBUS response error " << ec1.value();
                     messages::internalError(aResp->res);
                 }
                 return;


### PR DESCRIPTION
A previous PR #760 has an typo in using a wrong variable and it causes the compiler error.

```
| In file included from ../../../../../../../../../ibm-bmcweb/redfish-core/lib/systems.hpp:27,
|                  from ../../../../../../../../../ibm-bmcweb/redfish-core/include/redfish.hpp:55,
|                  from ../../../../../../../../../ibm-bmcweb/src/webserver_main.cpp:21:
| ../../../../../../../../../ibm-bmcweb/redfish-core/lib/oem/ibm/system_attention_indicator.hpp: In lambda function:
| ../../../../../../../../../ibm-bmcweb/redfish-core/lib/oem/ibm/system_attention_indicator.hpp:62:67: error: 'ec' is not captured
|    62 |                     BMCWEB_LOG_ERROR << "DBUS response error " << ec.value();
|       |                                                                   ^~
| ../../../../../../../../../ibm-bmcweb/redfish-core/lib/oem/ibm/system_attention_indicator.hpp:56:34: note: the lambda has no capture-default
|    56 |             [aResp, propertyValue](const boost::system::error_code& ec1,
|       |                                  ^
| ../../../../../../../../../ibm-bmcweb/redfish-core/lib/oem/ibm/system_attention_indicator.hpp:44:58: note: 'const boost::system::error_code& ec' declared here
|    44 |          propertyValue](const boost::system::error_code& ec,
|       |                         ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~^~
```

Tested:
- Compile pases