### PR TITLE
1050: Fix the removal of unrelated queued http request

### DIFF
--- a/http/http_client.hpp
+++ b/http/http_client.hpp
@@ -797,13 +797,6 @@ class ConnectionPool : public std::enable_shared_from_this<ConnectionPool>
             dummyRes.result(boost::beast::http::status::too_many_requests);
             resHandler(dummyRes);
         }
-        if (requestQueue.size() == maxRequestQueueSize)
-        {
-            // We can remove the request from the queue at this point
-            BMCWEB_LOG_ERROR << "requestQueue is full. Clearing the queue for "
-                             << destIP << ":" << std::to_string(destPort);
-            requestQueue.pop_front();
-        }
     }
 
     // Callback to be called once the request has been sent


### PR DESCRIPTION
During RetryForever support implementation, the front queued item is removed if the queud becomes full, regardless whether it is related to RetryForever option or not.

This logic may cause the side-effect.
For example, theoretically, if the queued item is still being handled and left in the async-call schedulers, the removed object may be referenced when the scheduler pops.

This change is to preserve the queued items to be active as long as they are still connected.  If the newer requests cause the queue pool overflowed, they will be rejected (rather than the queue item is to removed).