### PR TITLE
Add logs to  track connection request dump offload

### DIFF
--- a/include/dump_offload.hpp
+++ b/include/dump_offload.hpp
@@ -442,8 +442,9 @@ inline void requestRoutes(App& app)
         }
 
         std::string url(conn.req.target());
-        BMCWEB_LOG_DEBUG << "Request open  for offload of system dump with url: "<<url;
-        std::string startDelimiter = "Entries/";
+	BMCWEB_LOG_CRITICAL << "INFO:Request open for system dump offload with"
+                            << "url: " << url ;
+	std::string startDelimiter = "Entries/";
         std::size_t pos1 = url.rfind(startDelimiter);
         std::size_t pos2 = url.rfind("/attachment");
         if (pos1 == std::string::npos || pos2 == std::string::npos)
@@ -453,10 +454,13 @@ inline void requestRoutes(App& app)
             conn.close();
             return;
         }
+
+	BMCWEB_LOG_CRITICAL << "INFO:Request open for system dump offload with"
+		            << "Dump Entry: " <<dumpEntry ;
         std::string dumpEntry =
             url.substr(pos1 + startDelimiter.length(),
                        pos2 - pos1 - startDelimiter.length());
-        BMCWEB_LOG_DEBUG << "Request open for offload of system dump with dumpEntry"<<dumpEntry;
+
         // System and Resource dump entries are currently being
         // listed under /Systems/system/LogServices/Dump/Entries/
         // redfish path. To differentiate between the two, the dump
@@ -501,7 +505,6 @@ inline void requestRoutes(App& app)
         systemHandlers[&conn]->getDumpSize(dumpId, dumpType);
         })
         .onclose([](crow::streaming_response::Connection& conn, bool& status) {
-	    BMCWEB_LOG_DEBUG << "Request close for offload of system dump with url"<<conn.req.target();
             auto handler = systemHandlers.find(&conn);
             if (handler == systemHandlers.end())
             {
@@ -515,6 +518,8 @@ inline void requestRoutes(App& app)
             }
             handler->second->outputBuffer.clear();
             systemHandlers.clear();
+	    BMCWEB_LOG_CRITICAL << "INFO:Request closed for system dump offload with"
+	                        << "url: " << conn.req.target() ;
         });
 }
 

--- a/include/dump_offload.hpp
+++ b/include/dump_offload.hpp
@@ -442,9 +442,9 @@ inline void requestRoutes(App& app)
         }
 
         std::string url(conn.req.target());
-	BMCWEB_LOG_CRITICAL << "INFO:Request open for system dump offload with"
-                            << "url: " << url ;
-	std::string startDelimiter = "Entries/";
+        BMCWEB_LOG_CRITICAL << "INFO:Request open for system dump offload with"
+                            << "url: " << url;
+        std::string startDelimiter = "Entries/";
         std::size_t pos1 = url.rfind(startDelimiter);
         std::size_t pos2 = url.rfind("/attachment");
         if (pos1 == std::string::npos || pos2 == std::string::npos)
@@ -454,9 +454,8 @@ inline void requestRoutes(App& app)
             conn.close();
             return;
         }
-
-	BMCWEB_LOG_CRITICAL << "INFO:Request open for system dump offload with"
-		            << "Dump Entry: " <<dumpEntry ;
+        BMCWEB_LOG_CRITICAL << "INFO:Request open for system dump offload with"
+                            << "Dump Entry: " << dumpEntry;
         std::string dumpEntry =
             url.substr(pos1 + startDelimiter.length(),
                        pos2 - pos1 - startDelimiter.length());
@@ -518,8 +517,9 @@ inline void requestRoutes(App& app)
             }
             handler->second->outputBuffer.clear();
             systemHandlers.clear();
-	    BMCWEB_LOG_CRITICAL << "INFO:Request closed for system dump offload with"
-	                        << "url: " << conn.req.target() ;
+            BMCWEB_LOG_CRITICAL
+                << "INFO:Request closed for system dump offload with"
+                << "url: " << conn.req.target();
         });
 }
 

--- a/include/dump_offload.hpp
+++ b/include/dump_offload.hpp
@@ -442,7 +442,7 @@ inline void requestRoutes(App& app)
         }
 
         std::string url(conn.req.target());
-
+        BMCWEB_LOG_DEBUG << "Request open  for offload of system dump with url: "<<url;
         std::string startDelimiter = "Entries/";
         std::size_t pos1 = url.rfind(startDelimiter);
         std::size_t pos2 = url.rfind("/attachment");
@@ -453,11 +453,10 @@ inline void requestRoutes(App& app)
             conn.close();
             return;
         }
-
         std::string dumpEntry =
             url.substr(pos1 + startDelimiter.length(),
                        pos2 - pos1 - startDelimiter.length());
-
+        BMCWEB_LOG_DEBUG << "Request open for offload of system dump with dumpEntry"<<dumpEntry;
         // System and Resource dump entries are currently being
         // listed under /Systems/system/LogServices/Dump/Entries/
         // redfish path. To differentiate between the two, the dump
@@ -502,6 +501,7 @@ inline void requestRoutes(App& app)
         systemHandlers[&conn]->getDumpSize(dumpId, dumpType);
         })
         .onclose([](crow::streaming_response::Connection& conn, bool& status) {
+	    BMCWEB_LOG_DEBUG << "Request close for offload of system dump with url"<<conn.req.target();
             auto handler = systemHandlers.find(&conn);
             if (handler == systemHandlers.end())
             {

--- a/include/dump_offload.hpp
+++ b/include/dump_offload.hpp
@@ -454,8 +454,6 @@ inline void requestRoutes(App& app)
             conn.close();
             return;
         }
-        BMCWEB_LOG_CRITICAL << "INFO:Request open for system dump offload with"
-                            << "Dump Entry: " << dumpEntry;
         std::string dumpEntry =
             url.substr(pos1 + startDelimiter.length(),
                        pos2 - pos1 - startDelimiter.length());


### PR DESCRIPTION
Wasn't able to recreate the defect 13443 , adding BMCWEB logs which will helps us debug the issue if reoccurs .
 
**For defect :**
https://jazz07.rchland.ibm.com:13443/jazz/web/projects/CSSD#action=com.ibm.team.workitem.viewWorkItem&id=543814
 
**Observations from logs Provided in defect**
- In defect scenario , the current system dump offload request fails with message :
  `"Can't allow dump offload opertaion, one of the host dump is already offloading"`
- but there is no dump found on phyp , or HMC .
- this scenario only reoccurs previous dump fails with
   ` bmcweb[2557]: (2023-08-24 11:11:24) [ERROR "dump_offload.hpp":104] DBUS response error: generic:5`
  
 
  It seems like there was an earlier request made for system dump offload which doesn't close as expected , these logs will help us the url and dumpEntry of dump request which didn't close . 
