### PR TITLE
Configure DHCP4 and DHCP6 parameters independently

### DIFF
--- a/redfish-core/lib/ethernet.hpp
+++ b/redfish-core/lib/ethernet.hpp
@@ -1582,8 +1582,7 @@ inline void setDHCPConfig(const std::string& propertyName, const bool& value,
         path /= "dhcp6";
     }
 
-    sdbusplus::asio::setProperty(
-        crow::connections::systemBus->async_method_call(
+    crow::connections::systemBus->async_method_call(
         [asyncResp](const boost::system::error_code& ec) {
         if (ec)
         {

--- a/redfish-core/lib/ethernet.hpp
+++ b/redfish-core/lib/ethernet.hpp
@@ -100,11 +100,11 @@ struct EthernetInterfaceData
     uint32_t speed;
     size_t mtuSize;
     bool autoNeg;
-    bool dnsEnabled;
+    bool dnsv4Enabled;
     bool dnsv6Enabled;
-    bool ntpEnabled;
+    bool ntpv4Enabled;
     bool ntpv6Enabled;
-    bool hostNameEnabled;
+    bool hostNamev4Enabled;
     bool hostNamev6Enabled;
     bool linkUp;
     bool nicEnabled;
@@ -377,8 +377,13 @@ inline bool extractEthernetInterfaceData(
                 }
             }
 
-            if (objpath.first ==
-                "/xyz/openbmc_project/network/" + ethifaceId + "/dhcp4")
+            sdbusplus::message::object_path path(
+                "/xyz/openbmc_project/network");
+            sdbusplus::message::object_path dhcp4Path = path / ethifaceId /
+                                                        "dhcp4";
+
+            if (sdbusplus::message::object_path(objpath.first).parent_path() ==
+                dhcp4Path)
             {
                 if (ifacePair.first ==
                     "xyz.openbmc_project.Network.DHCPConfiguration")
@@ -391,7 +396,7 @@ inline bool extractEthernetInterfaceData(
                                 std::get_if<bool>(&propertyPair.second);
                             if (dnsEnabled != nullptr)
                             {
-                                ethData.dnsEnabled = *dnsEnabled;
+                                ethData.dnsv4Enabled = *dnsEnabled;
                             }
                         }
                         else if (propertyPair.first == "NTPEnabled")
@@ -400,7 +405,7 @@ inline bool extractEthernetInterfaceData(
                                 std::get_if<bool>(&propertyPair.second);
                             if (ntpEnabled != nullptr)
                             {
-                                ethData.ntpEnabled = *ntpEnabled;
+                                ethData.ntpv4Enabled = *ntpEnabled;
                             }
                         }
                         else if (propertyPair.first == "HostNameEnabled")
@@ -409,7 +414,49 @@ inline bool extractEthernetInterfaceData(
                                 std::get_if<bool>(&propertyPair.second);
                             if (hostNameEnabled != nullptr)
                             {
-                                ethData.hostNameEnabled = *hostNameEnabled;
+                                ethData.hostNamev4Enabled = *hostNameEnabled;
+                            }
+                        }
+                    }
+                }
+            }
+
+            sdbusplus::message::object_path dhcp6Path = path / ethifaceId /
+                                                        "dhcp6";
+
+            if (sdbusplus::message::object_path(objpath.first).parent_path() ==
+                dhcp6Path)
+            {
+                if (ifacePair.first ==
+                    "xyz.openbmc_project.Network.DHCPConfiguration")
+                {
+                    for (const auto& propertyPair : ifacePair.second)
+                    {
+                        if (propertyPair.first == "DNSEnabled")
+                        {
+                            const bool* dnsEnabled =
+                                std::get_if<bool>(&propertyPair.second);
+                            if (dnsEnabled != nullptr)
+                            {
+                                ethData.dnsv6Enabled = *dnsEnabled;
+                            }
+                        }
+                        else if (propertyPair.first == "NTPEnabled")
+                        {
+                            const bool* ntpEnabled =
+                                std::get_if<bool>(&propertyPair.second);
+                            if (ntpEnabled != nullptr)
+                            {
+                                ethData.ntpv6Enabled = *ntpEnabled;
+                            }
+                        }
+                        else if (propertyPair.first == "HostNameEnabled")
+                        {
+                            const bool* hostNameEnabled =
+                                std::get_if<bool>(&propertyPair.second);
+                            if (hostNameEnabled != nullptr)
+                            {
+                                ethData.hostNamev6Enabled = *hostNameEnabled;
                             }
                         }
                     }
@@ -1512,14 +1559,32 @@ inline void setEthernetInterfaceBoolProperty(
         dbus::utility::DbusVariantType{value});
 }
 
+enum class NetworkType
+{
+    dhcp4,
+    dhcp6
+};
+
 inline void setDHCPConfig(const std::string& propertyName, const bool& value,
                           const std::shared_ptr<bmcweb::AsyncResp>& asyncResp,
-                          const std::string& ethifaceId,
-                          const std::string& nwType)
+                          const std::string& ethifaceId, NetworkType type)
 {
     BMCWEB_LOG_DEBUG << propertyName << " = " << value;
-    crow::connections::systemBus->async_method_call(
-        [asyncResp](const boost::system::error_code ec) {
+    sdbusplus::message::object_path path("/xyz/openbmc_project/network/");
+    path /= ethifaceId;
+
+    if (type == NetworkType::dhcp4)
+    {
+        path /= "dhcp4";
+    }
+    else
+    {
+        path /= "dhcp6";
+    }
+
+    sdbusplus::asio::setProperty(
+        crow::connections::systemBus->async_method_call(
+        [asyncResp](const boost::system::error_code& ec) {
         if (ec)
         {
             BMCWEB_LOG_ERROR << "D-Bus responses error: " << ec;
@@ -1527,8 +1592,7 @@ inline void setDHCPConfig(const std::string& propertyName, const bool& value,
             return;
         }
         },
-        "xyz.openbmc_project.Network",
-        "/xyz/openbmc_project/network/" + ethifaceId + "/" + nwType,
+        "xyz.openbmc_project.Network", path,
         "org.freedesktop.DBus.Properties", "Set",
         "xyz.openbmc_project.Network.DHCPConfiguration", propertyName,
         dbus::utility::DbusVariantType{value});
@@ -1585,33 +1649,33 @@ inline void handleDHCPPatch(const std::string& ifaceId,
         nextv6DHCPState = ipv6Active;
     }
 
-    bool nextDNS = ethData.dnsEnabled;
+    bool nextDNSv4 = ethData.dnsv4Enabled;
     bool nextDNSv6 = ethData.dnsv6Enabled;
     if (v4dhcpParms.useDnsServers)
     {
-        nextDNS = *v4dhcpParms.useDnsServers;
+        nextDNSv4 = *v4dhcpParms.useDnsServers;
     }
     if (v6dhcpParms.useDnsServers)
     {
         nextDNSv6 = *v6dhcpParms.useDnsServers;
     }
 
-    bool nextNTP = ethData.ntpEnabled;
+    bool nextNTPv4 = ethData.ntpv4Enabled;
     bool nextNTPv6 = ethData.ntpv6Enabled;
     if (v4dhcpParms.useNtpServers)
     {
-        nextNTP = *v4dhcpParms.useNtpServers;
+        nextNTPv4 = *v4dhcpParms.useNtpServers;
     }
     if (v6dhcpParms.useNtpServers)
     {
         nextNTPv6 = *v6dhcpParms.useNtpServers;
     }
 
-    bool nextUseDomain = ethData.hostNameEnabled;
+    bool nextUsev4Domain = ethData.hostNamev4Enabled;
     bool nextUsev6Domain = ethData.hostNamev6Enabled;
     if (v4dhcpParms.useDomainName)
     {
-        nextUseDomain = *v4dhcpParms.useDomainName;
+        nextUsev4Domain = *v4dhcpParms.useDomainName;
     }
     if (v6dhcpParms.useDomainName)
     {
@@ -1622,19 +1686,23 @@ inline void handleDHCPPatch(const std::string& ifaceId,
     setDHCPEnabled(ifaceId, "DHCPEnabled", nextv4DHCPState, nextv6DHCPState,
                    asyncResp);
     BMCWEB_LOG_DEBUG << "set DNSEnabled...";
-    setDHCPConfig("DNSEnabled", nextDNS, asyncResp, ifaceId, "dhcp4");
+    setDHCPConfig("DNSEnabled", nextDNSv4, asyncResp, ifaceId,
+                  NetworkType::dhcp4);
     BMCWEB_LOG_DEBUG << "set NTPEnabled...";
-    setDHCPConfig("NTPEnabled", nextNTP, asyncResp, ifaceId, "dhcp4");
+    setDHCPConfig("NTPEnabled", nextNTPv4, asyncResp, ifaceId,
+                  NetworkType::dhcp4);
     BMCWEB_LOG_DEBUG << "set HostNameEnabled...";
-    setDHCPConfig("HostNameEnabled", nextUseDomain, asyncResp, ifaceId,
-                  "dhcp4");
+    setDHCPConfig("HostNameEnabled", nextUsev4Domain, asyncResp, ifaceId,
+                  NetworkType::dhcp4);
     BMCWEB_LOG_DEBUG << "set DNSEnabled for dhcp6...";
-    setDHCPConfig("DNSEnabled", nextDNSv6, asyncResp, ifaceId, "dhcp6");
+    setDHCPConfig("DNSEnabled", nextDNSv6, asyncResp, ifaceId,
+                  NetworkType::dhcp6);
     BMCWEB_LOG_DEBUG << "set NTPEnabled for dhcp6...";
-    setDHCPConfig("NTPEnabled", nextNTPv6, asyncResp, ifaceId, "dhcp6");
+    setDHCPConfig("NTPEnabled", nextNTPv6, asyncResp, ifaceId,
+                  NetworkType::dhcp6);
     BMCWEB_LOG_DEBUG << "set HostNameEnabled for dhcp6...";
     setDHCPConfig("HostNameEnabled", nextUsev6Domain, asyncResp, ifaceId,
-                  "dhcp6");
+                  NetworkType::dhcp6);
 }
 
 inline boost::container::flat_set<IPv4AddressData>::const_iterator
@@ -2009,9 +2077,9 @@ inline void parseInterfaceData(
     jsonResponse["MACAddress"] = ethData.macAddress;
     jsonResponse["DHCPv4"]["DHCPEnabled"] =
         translateDhcpEnabledToBool(ethData.dhcpEnabled, true);
-    jsonResponse["DHCPv4"]["UseNTPServers"] = ethData.ntpEnabled;
-    jsonResponse["DHCPv4"]["UseDNSServers"] = ethData.dnsEnabled;
-    jsonResponse["DHCPv4"]["UseDomainName"] = ethData.hostNameEnabled;
+    jsonResponse["DHCPv4"]["UseNTPServers"] = ethData.ntpv4Enabled;
+    jsonResponse["DHCPv4"]["UseDNSServers"] = ethData.dnsv4Enabled;
+    jsonResponse["DHCPv4"]["UseDomainName"] = ethData.hostNamev4Enabled;
     jsonResponse["DHCPv6"]["OperatingMode"] =
         translateDhcpEnabledToBool(ethData.dhcpEnabled, false) ? "Enabled"
                                                                : "Disabled";


### PR DESCRIPTION
This is a follow-up PR for https://github.com/ibm-openbmc/bmcweb/pull/700
It includes the review comments incorporations.

Upstream : https://gerrit.openbmc.org/c/openbmc/bmcweb/+/63390
tested by:
Used the redfish commands to set and get the parameter values individually for both DHCPv4 and DHCPv6.
Verified the network configuration file is updated accordingly.
Verified unwanted logs are not printed in the journal logs

Change-Id: I5db29b6dfc8966ff5af51041da11e5b79da7d1dd