### PR TITLE
Bypass authentication for requests sent internally

### DIFF
--- a/http/app.hpp
+++ b/http/app.hpp
@@ -66,9 +66,10 @@ class App
     }
 
     void handle(Request& req,
-                const std::shared_ptr<bmcweb::AsyncResp>& asyncResp)
+                const std::shared_ptr<bmcweb::AsyncResp>& asyncResp,
+                bool bypassAuth = false)
     {
-        router.handle(req, asyncResp);
+        router.handle(req, asyncResp, bypassAuth);
     }
 
     DynamicRule& routeDynamic(std::string&& rule)

--- a/http/routing.hpp
+++ b/http/routing.hpp
@@ -1395,7 +1395,8 @@ class Router
     }
 
     void handle(Request& req,
-                const std::shared_ptr<bmcweb::AsyncResp>& asyncResp)
+                const std::shared_ptr<bmcweb::AsyncResp>& asyncResp,
+                bool bypassAuth = false)
     {
         std::optional<HttpVerb> verb = httpVerbFromBoost(req.method());
         if (!verb || static_cast<size_t>(*verb) >= perMethods.size())
@@ -1452,7 +1453,7 @@ class Router
                          << static_cast<uint32_t>(*verb) << " / "
                          << rule.getMethods();
 
-        if (req.session == nullptr)
+        if (req.session == nullptr || bypassAuth)
         {
             rule.handle(req, asyncResp, params);
             return;

--- a/redfish-core/include/query.hpp
+++ b/redfish-core/include/query.hpp
@@ -48,7 +48,7 @@ inline void
     // Restart the request without if-match
     req.req.erase(boost::beast::http::field::if_match);
     BMCWEB_LOG_DEBUG << "Restarting request";
-    app.handle(req, asyncResp);
+    app.handle(req, asyncResp, true);
 }
 
 inline bool handleIfMatch(crow::App& app, const crow::Request& req,
@@ -97,7 +97,7 @@ inline bool handleIfMatch(crow::App& app, const crow::Request& req,
     getReqAsyncResp->res.setCompleteRequestHandler(std::bind_front(
         afterIfMatchRequest, std::ref(app), asyncResp, req, ifMatch));
 
-    app.handle(newReq, getReqAsyncResp);
+    app.handle(newReq, getReqAsyncResp, true);
     return false;
 }
 


### PR DESCRIPTION
PATCH request containing If-Match header with the value of etag causes the BMCWEB to crash. To compute the etag, a new GET request for the same URI is internally generated. Same req.session is assigned to the new request. The new req gets authenticated and when privileges are assigned in  populateUserInfo() BMCWEB will get crashed when req.session members are accessed.

For the new GET request which have the same req.session created for original PATCH request, bypass authentication and privilege assignment, since the same credentials are already validated and its a overhead to validate again.

Tested: Run Redfish Protocol validator and got passed.

Change-Id: Iaad2b1f0e982b480e9fab24005ce8b7c258882c3

Upstream is https://gerrit.openbmc.org/c/openbmc/bmcweb/+/66685