### PR TITLE
Add trace for user create fail

### DIFF
--- a/redfish-core/lib/account_service.hpp
+++ b/redfish-core/lib/account_service.hpp
@@ -341,6 +341,7 @@ inline void userErrorMessageHandler(
     }
     else
     {
+        BMCWEB_LOG_ERROR << "DBUS response error: " << e;
         messages::internalError(asyncResp->res);
     }
 }


### PR DESCRIPTION
Seen this at 576807. The Create User is failing, returning an ec, but the user is there. Printing the error message returned will help debug.

Also seen at
526180
395562

Upstream is https://gerrit.openbmc.org/c/openbmc/bmcweb/+/66858
