### PR TITLE
1050: Fix PCIeSlots RedfishValidator Error

### DIFF
--- a/redfish-core/lib/pcie_slots.hpp
+++ b/redfish-core/lib/pcie_slots.hpp
@@ -232,6 +232,8 @@ inline void linkAssociatedDiskBackplane(
                 asyncResp->res.jsonValue["Slots"][index]["Links"]["Oem"]
                                         ["@odata.type"] = "#OemPCIeSlots.Oem";
                 asyncResp->res.jsonValue["Slots"][index]["Links"]["Oem"]["IBM"]
+                                        ["@odata.type"] = "#OemPCIeSlots.IBM";
+                asyncResp->res.jsonValue["Slots"][index]["Links"]["Oem"]["IBM"]
                                         ["AssociatedAssembly"]["@odata.id"] =
                     "/redfish/v1/Chassis/" + chassisId +
                     "/Assembly#/Assemblies/" +
@@ -326,6 +328,7 @@ inline void
         nlohmann::json& slot = asyncResp->res.jsonValue["Slots"][index];
 
         slot["Links"]["Oem"]["@odata.type"] = "#OemPCIeSlots.Oem";
+        slot["Links"]["Oem"]["IBM"]["@odata.type"] = "#OemPCIeSlots.IBM";
         slot["Links"]["Oem"]["IBM"]["UpstreamFabricAdapter"]["@odata.id"] =
             crow::utility::urlFromPieces(
                 "redfish", "v1", "Systems", "system", "FabricAdapters",
@@ -411,6 +414,7 @@ inline void getPCIeSlotProperties(
     if (busId != nullptr)
     {
         slot["Oem"]["@odata.type"] = "#OemPCIeSlots.Oem";
+        slot["Oem"]["IBM"]["@odata.type"] = "#OemPCIeSlots.IBM";
         slot["Oem"]["IBM"]["LinkId"] = *busId;
     }
 


### PR DESCRIPTION
Redfish Validator skips the validation on PCIeSlots by this
error.

```
1 exceptionResource errors in /redfish/v1/Chassis/chassis/PCIeSlots

ERROR - This complex object LinkId should be a dictionary or None, but it's of type int...
ERROR - Unable to gather property info for URI /redfish/v1/Chassis/chassis/PCIeSlots: AttributeError("'int' object has no attribute 'get'")
```

This change will enhance the code to avoid exceptionResource errors
and continue to examine PCIeSlots.

However, it will go back to previous errors like this.
```
26 err.Collection(Processor.Processor) errors in /redfish/v1/Chassis/chassis/PCIeSlots
26 failProp errors in /redfish/v1/Chassis/chassis/PCIeSlots
...
ERROR - Processors: Linked resource reports version Processor.v1_18_0.Processor not in Schema
```

This seems caused by the Processor schema definition issue and this
would be addressed separately.

```
python3 RedfishServiceValidator.py --auth Session -i https://${bmc}  --payload Single /redfish/v1/Systems/system/Processors
```

Signed-off-by: Myung Bae <myungbae@us.ibm.com>