### PR TITLE
1060: Add Oem action to execute Panel function

### DIFF
--- a/redfish-core/include/redfish.hpp
+++ b/redfish-core/include/redfish.hpp
@@ -202,6 +202,7 @@ class RedfishService
         requestRoutesSystems(app);
         requestRoutesSystemActionsReset(app);
         requestRoutesSystemResetActionInfo(app);
+        requestRoutesSystemActionsOemExecutePanelFunction(app);
         requestRoutesBiosService(app);
         requestRoutesBiosSettings(app);
         requestRoutesBiosAttributeRegistry(app);

--- a/static/redfish/v1/$metadata/index.xml
+++ b/static/redfish/v1/$metadata/index.xml
@@ -4553,6 +4553,7 @@
     </edmx:Reference>
     <edmx:Reference Uri="/redfish/v1/schema/OemComputerSystem_v1.xml">
         <edmx:Include Namespace="OemComputerSystem"/>
+        <edmx:Include Namespace="OemComputerSystem.v1_0_0"/>
     </edmx:Reference>
     <edmx:Reference Uri="/redfish/v1/schema/OemVirtualMedia_v1.xml">
         <edmx:Include Namespace="OemVirtualMedia"/>

--- a/static/redfish/v1/JsonSchemas/OemComputerSystem/OemComputerSystem.json
+++ b/static/redfish/v1/JsonSchemas/OemComputerSystem/OemComputerSystem.json
@@ -199,6 +199,43 @@
                 }
             },
             "type": "object"
+        },
+        "ExecutePanelFunction": {
+            "additionalProperties": false,
+            "description": "This object executes a panel function",
+            "parameters": {
+                "FuncNo": {
+                    "description": "Panel function number.",
+                    "longDescription": "This parameter shall contain a  panel function number to be executed.",
+                    "type": "integer"
+                }
+            },
+            "patternProperties": {
+                "^([a-zA-Z_][a-zA-Z0-9_]*)?@(odata|Redfish|Message)\\.[a-zA-Z_][a-zA-Z0-9_]*$": {
+                    "description": "This property shall specify a valid odata or Redfish property.",
+                    "type": [
+                        "array",
+                        "boolean",
+                        "integer",
+                        "number",
+                        "null",
+                        "object",
+                        "string"
+                    ]
+                }
+            },
+            "properties": {
+                "target": {
+                    "description": "Link to invoke action",
+                    "format": "uri-reference",
+                    "type": "string"
+                },
+                "title": {
+                    "description": "Friendly action name",
+                    "type": "string"
+                }
+            },
+            "type": "object"
         }
     },
     "title": "#OemComputerSystem"

--- a/static/redfish/v1/schema/OemComputerSystem_v1.xml
+++ b/static/redfish/v1/schema/OemComputerSystem_v1.xml
@@ -106,5 +106,15 @@
                 </Member>
             </EnumType>
         </Schema>
+        <Schema xmlns="http://docs.oasis-open.org/odata/ns/edm" Namespace="OemComputerSystem.v1_0_0">
+            <Action Name="ExecutePanelFunction" IsBound="true">
+                <Annotation Term="OData.Description" String="This action executes a panel function."/>
+                <Annotation Term="OData.LongDescription" String="This action executes a panel function if the function is enabled."/>
+                <Parameter Name="FuncNo" Type="OemComputerSystem.v1_0_0.OemActions" Nullable="false">
+                    <Annotation Term="OData.Description" String="Panel function number."/>
+                    <Annotation Term="OData.LongDescription" String="This parameter shall contain a  panel function number to be executed."/>
+                </Parameter>
+            </Action>
+        </Schema>
     </edmx:DataServices>
 </edmx:Edmx>


### PR DESCRIPTION
Add an Oem Action to ExecutePanelFunction for Panel functions, and the action will be enabled and executable under a specific conditions (e.g. IBM i systems).

```
$ curl -k -X GET https://${bmc}/redfish/v1/Systems/system
{
...
  "Actions": {
    ...
    "Oem": {
      "#OemComputerSystem.v1_0_0.ExecutePanelFunction": {
        "target": "/redfish/v1/Systems/system/Actions/Oem/OemComputerSystem.ExecutePanelFunction"
      }
    }
  },
...
}
```

Action:

```
$ curl -k -X POST https://${bmc}/redfish/v1/Systems/system/Actions/Oem/OemComputerSystem.ExecutePanelFunction \
                 -d '{"FuncNo": <func-no>}'
```

Tested:

- Redfish validator passes

- Success case:
```
curl -k -X POST https://${bmc}/redfish/v1/Systems/system/Actions/Oem/OemComputerSystem.ExecutePanelFunction -d '{"FuncNo": 21}'
{
  "@Message.ExtendedInfo": [
    {
      "@odata.type": "#Message.v1_1_1.Message",
      "Message": "The request completed successfully.",
      "MessageArgs": [],
      "MessageId": "Base.1.13.0.Success",
      "MessageSeverity": "OK",
      "Resolution": "None"
    }
  ],
  "Result": [
    "21 00",
    ""
  ]
}%
```

- Failed case if the function is disabled:

```
curl -k -X POST https://${bmc}:18080/redfish/v1/Systems/system/Actions/Oem/OemComputerSystem.ExecutePanelFunction -d '{"FuncNo": 21}'
{
  "error": {
    "@Message.ExtendedInfo": [
      {
        "@odata.type": "#Message.v1_1_1.Message",
        "Message": "The HTTP method is not allowed on this resource.",
        "MessageArgs": [],
        "MessageId": "Base.1.13.0.OperationNotAllowed",
        "MessageSeverity": "Critical",
        "Resolution": "None."
      }
    ],
    "code": "Base.1.13.0.OperationNotAllowed",
    "message": "The HTTP method is not allowed on this resource."
  }
}%
```

- Failed case if the function execution is failed:

```
curl -k -X POST https://${bmc}:18080/redfish/v1/Systems/system/Actions/Oem/OemComputerSystem.ExecutePanelFunction -d '{"FuncNo": 21}'
{
  "error": {
    "@Message.ExtendedInfo": [
      {
        "@odata.type": "#Message.v1_1_1.Message",
        "Message": "An error occurred internal to the service as part of the overall request.  Partial results may have been returned.",
        "MessageArgs": [],
        "MessageId": "Base.1.13.0.OperationFailed",
        "MessageSeverity": "Warning",
        "Resolution": "Resubmit the request.  If the problem persists, consider resetting the service or provider."
      }
    ],
    "code": "Base.1.13.0.OperationFailed",
    "message": "An error occurred internal to the service as part of the overall request.  Partial results may have been returned."
  }
}%
```

- Internal error case:

```
curl -k -X POST https://${bmc}:18080/redfish/v1/Systems/system/Actions/Oem/OemComputerSystem.ExecutePanelFunction \
         -d '{"FuncNo": 21}'
{
  "error": {
    "@Message.ExtendedInfo": [
      {
        "@odata.type": "#Message.v1_1_1.Message",
        "Message": "The request failed due to an internal service error.  The service is still operational.",
        "MessageArgs": [],
        "MessageId": "Base.1.13.0.InternalError",
        "MessageSeverity": "Critical",
        "Resolution": "Resubmit the request.  If the problem persists, consider resetting the service."
      }
    ],
    "code": "Base.1.13.0.InternalError",
    "message": "The request failed due to an internal service error.  The service is still operational."
  }
}%
```