### PR TITLE
BMCWEB log flooding : move ERROR trace log to DEBUG

### DIFF
--- a/http/http_client.hpp
+++ b/http/http_client.hpp
@@ -783,7 +783,7 @@ class ConnectionPool : public std::enable_shared_from_this<ConnectionPool>
         }
         else if (requestQueue.size() < maxRequestQueueSize)
         {
-            BMCWEB_LOG_ERROR << "Max pool size reached. Adding data to queue."
+            BMCWEB_LOG_DEBUG << "Max pool size reached. Adding data to queue."
                              << destIP << ":" << std::to_string(destPort);
             requestQueue.emplace_back(std::move(thisReq), std::move(cb));
         }


### PR DESCRIPTION
-   below error trace seems to flood the BMCWEB LOGS
`"Max pool size reached. Adding data to queue. destIP: "`
- will move the log level from ERROR to Debug to solve the problem 

UPSTREAM :
the log level of the mentioned trace is already DEBUG IN upstream 
so no changes need for upstream .
https://github.com/openbmc/bmcweb/blob/master/http/http_client.hpp#L757


DEFECT :
https://jazz07.rchland.ibm.com:13443/jazz/web/projects/CSSD#action=com.ibm.team.workitem.viewWorkItem&id=580659
       