### PR TITLE
1060: Update to boost 1.83.0

### DIFF
--- a/http/utility.hpp
+++ b/http/utility.hpp
@@ -800,7 +800,7 @@ inline bool validateAndSplitUrl(std::string_view destUrl, std::string& urlProto,
                                 std::string& host, uint16_t& port,
                                 std::string& path)
 {
-    boost::urls::result<boost::urls::url_view> url =
+    boost::system::result<boost::urls::url_view> url =
         boost::urls::parse_uri(destUrl);
     if (!url)
     {

--- a/meson.build
+++ b/meson.build
@@ -298,19 +298,49 @@ else
 endif
 bmcweb_dependencies += nlohmann_json
 
-boost = dependency('boost', modules: ['url'], version : '>=1.83.0', required : false, include_type: 'system')
+boost = dependency(
+  'boost',
+  modules: [
+    'asio',
+    'beast',
+    'callable_traits',
+    'headers',
+    'process',
+    'type_index',
+    'url',
+    'uuid'
+    ],
+  version : '>=1.83.0',
+  required : false,
+  include_type: 'system'
+)
 if boost.found()
   bmcweb_dependencies += [boost]
 else
   cmake = import('cmake')
   opt = cmake.subproject_options()
   opt.add_cmake_defines({
-    'BOOST_INCLUDE_LIBRARIES': 'url'
+    'BOOST_INCLUDE_LIBRARIES': 'asio;beast;callable_traits;headers;process;type_index;url;uuid'
   })
   boost = cmake.subproject('boost', required: true, options: opt)
-  boost_url = boost.dependency('boost_url').as_system()
+  boost_asio = boost.dependency('boost_asio').as_system()
+  boost_beast = boost.dependency('boost_beast').as_system()
+  boost_callable_traits = boost.dependency('boost_callable_traits').as_system()
   boost_headers = boost.dependency('boost_headers').as_system()
-  bmcweb_dependencies += [boost_url, boost_headers]
+  boost_process = boost.dependency('boost_process').as_system()
+  boost_type_index = boost.dependency('boost_type_index').as_system()
+  boost_url = boost.dependency('boost_url').as_system()
+  boost_uuid = boost.dependency('boost_uuid').as_system()
+  bmcweb_dependencies += [
+    boost_asio,
+    boost_beast,
+    boost_callable_traits,
+    boost_headers,
+    boost_process,
+    boost_type_index,
+    boost_url,
+    boost_uuid
+  ]
 endif
 
 if get_option('tests').enabled()

--- a/meson.build
+++ b/meson.build
@@ -243,6 +243,7 @@ endif
 
 add_project_arguments(
 cxx.get_supported_arguments([
+  '-DBOOST_ASIO_DISABLE_CONCEPTS',
   '-DBOOST_ALL_NO_LIB',
   '-DBOOST_ALLOW_DEPRECATED_HEADERS',
   '-DBOOST_ASIO_DISABLE_THREADS',
@@ -297,12 +298,20 @@ else
 endif
 bmcweb_dependencies += nlohmann_json
 
-boost = dependency('boost',version : '>=1.81.0', required : false, include_type: 'system')
-if not boost.found()
-  boost = subproject('boost', required: true).get_variable('boost_dep')
-  boost = boost.as_system('system')
+boost = dependency('boost', modules: ['url'], version : '>=1.83.0', required : false, include_type: 'system')
+if boost.found()
+  bmcweb_dependencies += [boost]
+else
+  cmake = import('cmake')
+  opt = cmake.subproject_options()
+  opt.add_cmake_defines({
+    'BOOST_INCLUDE_LIBRARIES': 'url'
+  })
+  boost = cmake.subproject('boost', required: true, options: opt)
+  boost_url = boost.dependency('boost_url').as_system()
+  boost_headers = boost.dependency('boost_headers').as_system()
+  bmcweb_dependencies += [boost_url, boost_headers]
 endif
-bmcweb_dependencies += boost
 
 if get_option('tests').enabled()
   gtest = dependency('gtest', main: true,disabler: true, required : false)
@@ -342,7 +351,6 @@ srcfiles_bmcweb = files(
   'src/boost_asio_ssl.cpp',
   'src/boost_asio.cpp',
   'src/boost_beast.cpp',
-  'src/boost_url.cpp',
   'src/dbus_singleton.cpp',
 )
 

--- a/meson.build
+++ b/meson.build
@@ -301,14 +301,7 @@ bmcweb_dependencies += nlohmann_json
 boost = dependency(
   'boost',
   modules: [
-    'asio',
-    'beast',
-    'callable_traits',
-    'headers',
-    'process',
-    'type_index',
     'url',
-    'uuid'
     ],
   version : '>=1.83.0',
   required : false,

--- a/redfish-core/include/redfish_aggregator.hpp
+++ b/redfish-core/include/redfish_aggregator.hpp
@@ -146,7 +146,7 @@ static inline void addPrefixToItem(nlohmann::json& item,
 }
 
 static inline void addAggregatedHeaders(crow::Response& asyncResp,
-                                        crow::Response& resp,
+                                        const crow::Response& resp,
                                         std::string_view prefix)
 {
     if (!resp.getHeaderValue("Content-Type").empty())

--- a/redfish-core/include/utils/hex_utils.hpp
+++ b/redfish-core/include/utils/hex_utils.hpp
@@ -43,11 +43,11 @@ inline uint8_t hexCharToNibble(char ch)
     }
     else if (ch >= 'A' && ch <= 'F')
     {
-        rc = static_cast<uint8_t>(ch) - 'A' + 10;
+        rc = static_cast<uint8_t>(ch - 'A') + 10U;
     }
     else if (ch >= 'a' && ch <= 'f')
     {
-        rc = static_cast<uint8_t>(ch) - 'a' + 10;
+        rc = static_cast<uint8_t>(ch - 'a') + 10U;
     }
 
     return rc;

--- a/redfish-core/include/utils/telemetry_utils.hpp
+++ b/redfish-core/include/utils/telemetry_utils.hpp
@@ -39,7 +39,7 @@ inline std::optional<IncorrectMetricUri> getChassisSensorNode(
     size_t uriIdx = 0;
     for (const std::string& uri : uris)
     {
-        boost::urls::result<boost::urls::url_view> parsed =
+        boost::system::result<boost::urls::url_view> parsed =
             boost::urls::parse_relative_ref(uri);
 
         if (!parsed)

--- a/redfish-core/lib/certificate_service.hpp
+++ b/redfish-core/lib/certificate_service.hpp
@@ -500,7 +500,7 @@ inline void handleReplaceCertificateAction(
     }
     BMCWEB_LOG_INFO << "Certificate URI to replace: " << certURI;
 
-    boost::urls::result<boost::urls::url> parsedUrl =
+    boost::system::result<boost::urls::url> parsedUrl =
         boost::urls::parse_relative_ref(certURI);
     if (!parsedUrl)
     {

--- a/redfish-core/lib/virtual_media.hpp
+++ b/redfish-core/lib/virtual_media.hpp
@@ -31,7 +31,7 @@ namespace redfish
  */
 inline std::string getTransferProtocolTypeFromUri(const std::string& imageUri)
 {
-    boost::urls::result<boost::urls::url_view> url =
+    boost::system::result<boost::urls::url_view> url =
         boost::urls::parse_uri(imageUri);
     if (!url)
     {
@@ -400,7 +400,7 @@ inline bool
 
         return false;
     }
-    boost::urls::result<boost::urls::url_view> url =
+    boost::system::result<boost::urls::url_view> url =
         boost::urls::parse_uri(imageUrl);
     if (!url)
     {

--- a/src/boost_url.cpp
+++ b/src/boost_url.cpp
@@ -1,2 +1,0 @@
-
-#include <boost/url/src.hpp>

--- a/subprojects/boost.wrap
+++ b/subprojects/boost.wrap
@@ -1,11 +1,9 @@
 [wrap-file]
-directory = boost_1_82_0
+directory = boost-1.83.0
 
-source_url = https://boostorg.jfrog.io/artifactory/main/release/1.82.0/source/boost_1_82_0.tar.bz2
-source_hash = a6e1ab9b0860e6a2881dd7b21fe9f737a095e5f33a3a874afc6a345228597ee6
-source_filename = 1_82_0.tar.bz2
-
-patch_directory = boost
+source_url = https://github.com/boostorg/boost/releases/download/boost-1.83.0/boost-1.83.0.tar.gz
+source_hash = 0c6049764e80aa32754acd7d4f179fd5551d8172a83b71532ae093e7384e98da
+source_filename = 1_83_0.tar.gz
 
 [provide]
 boost = boost_dep

--- a/subprojects/packagefiles/boost/meson.build
+++ b/subprojects/packagefiles/boost/meson.build
@@ -1,9 +1,0 @@
-project('boost',
-    'cpp',
-    version : '1.80.0',
-    license : 'Boost'
-)
-
-boost_dep = declare_dependency(
-    include_directories : include_directories('.'),
-)

--- a/test/http/utility_test.cpp
+++ b/test/http/utility_test.cpp
@@ -98,7 +98,7 @@ TEST(Utility, UrlFromPieces)
 
 TEST(Utility, readUrlSegments)
 {
-    boost::urls::result<boost::urls::url_view> parsed =
+    boost::system::result<boost::urls::url_view> parsed =
         boost::urls::parse_relative_ref("/redfish/v1/Chassis#/Fans/0/Reading");
 
     EXPECT_TRUE(readUrlSegments(*parsed, "redfish", "v1", "Chassis"));

--- a/test/redfish-core/include/redfish_aggregator_test.cpp
+++ b/test/redfish-core/include/redfish_aggregator_test.cpp
@@ -413,7 +413,7 @@ TEST(processCollectionResponse, bothExist)
 
     bool foundLocal = false;
     bool foundSat = false;
-    for (auto& member : asyncResp->res.jsonValue["Members"])
+    for (const auto& member : asyncResp->res.jsonValue["Members"])
     {
         if (member["@odata.id"] == "/redfish/v1/Systems/system")
         {

--- a/test/redfish-core/include/utils/hex_utils_test.cpp
+++ b/test/redfish-core/include/utils/hex_utils_test.cpp
@@ -54,11 +54,11 @@ TEST(HexCharToNibble, ReturnsCorrectNibbleForEveryHexChar)
         }
         else if (c >= 'A' && c <= 'F')
         {
-            expected = static_cast<uint8_t>(c) - 'A' + 10;
+            expected = static_cast<uint8_t>(c - 'A') + 10U;
         }
         else if (c >= 'a' && c <= 'f')
         {
-            expected = static_cast<uint8_t>(c) - 'a' + 10;
+            expected = static_cast<uint8_t>(c - 'a') + 10U;
         }
 
         EXPECT_EQ(hexCharToNibble(c), expected);

--- a/test/redfish-core/include/utils/json_utils_test.cpp
+++ b/test/redfish-core/include/utils/json_utils_test.cpp
@@ -121,7 +121,8 @@ TEST(ReadJson, JsonArrayAreUnpackedCorrectly)
     ASSERT_TRUE(readJson(jsonRequest, res, "TestJson", jsonVec));
     EXPECT_EQ(res.result(), boost::beast::http::status::ok);
     EXPECT_THAT(res.jsonValue, IsEmpty());
-    EXPECT_EQ(jsonVec, R"([{"hello": "yes"}, [{"there": "no"}, "nice"]])"_json);
+    EXPECT_THAT(jsonVec, ElementsAre(R"({"hello": "yes"})"_json,
+                                     R"([{"there": "no"}, "nice"])"_json));
 }
 
 TEST(ReadJson, JsonSubElementValueAreUnpackedCorrectly)


### PR DESCRIPTION
Update boost to 1.83.0.

Tested: 
- Compiles with boost 1.83.0
- Redfish Validator passes

This PR  includes

1) Update boost to 1.83.0.
Change-Id: Ia7adfc0348588915440687c3ab83a1de3e6b845a
Signed-off-by: Ed Tanous <edtanous@google.com>

2) Fix local compile
Signed-off-by: Carson Labrado <clabrado@google.com>
Change-Id: I1d00ef561fed7e3ba799969a112ee58b6578ce32

3)  Fix boost build locally
Change-Id: I8cbb764dc564b84b4adb06ba80cb87b2a2c4701f
Signed-off-by: Ed Tanous <edtanous@google.com>
Signed-off-by: Carson Labrado <clabrado@google.com>

3) Don't rely on implicit operator comparison
Json has a bunch of implicit overloaded operators for comparing
vectors/arrays/maps with their json counterparts.  Unfortunately, when
used in unit tests, these cause warnings in clang, so update the code to
use the ElementsAre check from gmock.

Signed-off-by: Ed Tanous <edtanous@google.com>
Change-Id: I658557cb59d568fd50cf6f3bef73d6f90b5c56cf
