### PR TITLE
1060: Move to boost 1.83 & clang17

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -14,26 +14,30 @@ AllowAllParametersOfDeclarationOnNextLine: true
 AllowShortBlocksOnASingleLine: Empty
 AllowShortCaseLabelsOnASingleLine: false
 AllowShortFunctionsOnASingleLine: Empty
-AllowShortIfStatementsOnASingleLine: false
+AllowShortIfStatementsOnASingleLine: Never
+AllowShortLambdasOnASingleLine: true
 AllowShortLoopsOnASingleLine: false
 AlwaysBreakAfterReturnType: None
 AlwaysBreakBeforeMultilineStrings: false
 AlwaysBreakTemplateDeclarations: Yes
 BinPackArguments: true
 BinPackParameters: true
+BitFieldColonSpacing: None
 BraceWrapping:
   AfterCaseLabel:  true
   AfterClass:      true
   AfterControlStatement: true
   AfterEnum:       true
+  AfterExternBlock: true
   AfterFunction:   true
   AfterNamespace:  true
   AfterObjCDeclaration: true
   AfterStruct:     true
   AfterUnion:      true
-  AfterExternBlock: true
   BeforeCatch:     true
   BeforeElse:      true
+  BeforeLambdaBody: false
+  BeforeWhile:     false
   IndentBraces:    false
   SplitEmptyFunction:   false
   SplitEmptyRecord:     false
@@ -48,17 +52,16 @@ BreakStringLiterals: false
 ColumnLimit:     80
 CommentPragmas:  '^ IWYU pragma:'
 CompactNamespaces: false
-ConstructorInitializerAllOnOneLineOrOnePerLine: false
 ConstructorInitializerIndentWidth: 4
 ContinuationIndentWidth: 4
 Cpp11BracedListStyle: true
-DeriveLineEnding: false
 DerivePointerAlignment: false
-PointerAlignment: Left
 DisableFormat:   false
-ExperimentalAutoDetectBinPacking: false
 FixNamespaceComments: true
-ForEachMacros:   [ foreach, Q_FOREACH, BOOST_FOREACH ]
+ForEachMacros:
+  - foreach
+  - Q_FOREACH
+  - BOOST_FOREACH
 IncludeBlocks: Regroup
 IncludeCategories:
   - Regex:           '^[<"](gtest|gmock)'
@@ -78,6 +81,7 @@ IncludeCategories:
   - Regex:           '.*'
     Priority:        6
 IndentCaseLabels: true
+IndentExternBlock: NoIndent
 IndentRequiresClause: true
 IndentWidth:     4
 IndentWrappedFunctionNames: true
@@ -92,6 +96,7 @@ NamespaceIndentation: None
 ObjCBlockIndentWidth: 2
 ObjCSpaceAfterProperty: false
 ObjCSpaceBeforeProtocolList: true
+PackConstructorInitializers: BinPack
 PenaltyBreakAssignment: 25
 PenaltyBreakBeforeFirstCallParameter: 19
 PenaltyBreakComment: 300
@@ -100,12 +105,13 @@ PenaltyBreakString: 1000
 PenaltyExcessCharacter: 1000000
 PenaltyReturnTypeOnItsOwnLine: 60
 PenaltyIndentedWhitespace: 0
+PointerAlignment: Left
 QualifierAlignment: Left
 ReferenceAlignment: Left
 ReflowComments:  true
 RequiresClausePosition: OwnLine
 RequiresExpressionIndentation: Keyword
-SortIncludes:    true
+SortIncludes: CaseSensitive
 SortUsingDeclarations: true
 SpaceAfterCStyleCast: false
 SpaceAfterTemplateKeyword: true
@@ -117,7 +123,7 @@ SpaceBeforeParens: ControlStatements
 SpaceBeforeRangeBasedForLoopColon: true
 SpaceInEmptyParentheses: false
 SpacesBeforeTrailingComments: 1
-SpacesInAngles:  false
+SpacesInAngles: Never
 SpacesInContainerLiterals: true
 SpacesInCStyleCastParentheses: false
 SpacesInParentheses: false

--- a/http/http_connection.hpp
+++ b/http/http_connection.hpp
@@ -438,7 +438,7 @@ class Connection :
                 // delete lambda with self shared_ptr
                 // to enable connection destruction
                 res.completeRequestHandler = nullptr;
-                });
+            });
 
             return;
         }
@@ -700,7 +700,7 @@ class Connection :
 #endif // BMCWEB_INSECURE_DISABLE_AUTHX
 
             doRead();
-            });
+        });
     }
 
     void doRead()

--- a/http/http_server.hpp
+++ b/http/http_server.hpp
@@ -204,7 +204,7 @@ class Server
                                   [connection] { connection->start(); });
             }
             doAccept();
-            });
+        });
     }
 
   private:

--- a/http/http_stream.hpp
+++ b/http/http_stream.hpp
@@ -84,7 +84,7 @@ class ConnectionImpl : public Connection
                 close();
                 return;
             }
-            });
+        });
     }
 
     void setStreamHeaders(const std::string& header,
@@ -108,7 +108,7 @@ class ConnectionImpl : public Connection
                 close();
                 return;
             }
-            });
+        });
     }
 
     void sendMessage(const boost::asio::mutable_buffer& buffer,
@@ -147,7 +147,7 @@ class ConnectionImpl : public Connection
                 return;
             }
             (handlerFunc)();
-            });
+        });
     }
 
   private:

--- a/http/routing.hpp
+++ b/http/routing.hpp
@@ -1560,7 +1560,7 @@ class Router
 
             req.userRole = userRole;
             rule.handle(req, asyncResp, params);
-            },
+        },
             "xyz.openbmc_project.User.Manager", "/xyz/openbmc_project/user",
             "xyz.openbmc_project.User.Manager", "GetUserInfo", username);
     }

--- a/http/utility.hpp
+++ b/http/utility.hpp
@@ -557,8 +557,8 @@ inline std::string convertToAscii(const uint64_t& element)
     std::span<unsigned char> bytearray{p, 8};
 
     if (std::count_if(bytearray.begin(), bytearray.end(), [](unsigned char c) {
-            return (std::isprint(c) == 0);
-        }) != 0)
+        return (std::isprint(c) == 0);
+    }) != 0)
     {
         return {};
     }

--- a/http/utility.hpp
+++ b/http/utility.hpp
@@ -800,7 +800,7 @@ inline bool validateAndSplitUrl(std::string_view destUrl, std::string& urlProto,
                                 std::string& host, uint16_t& port,
                                 std::string& path)
 {
-    boost::urls::result<boost::urls::url_view> url =
+    boost::system::result<boost::urls::url_view> url =
         boost::urls::parse_uri(destUrl);
     if (!url)
     {

--- a/http/websocket.hpp
+++ b/http/websocket.hpp
@@ -238,7 +238,7 @@ class ConnectionImpl : public Connection
                 BMCWEB_LOG_ERROR << "Error closing websocket " << ec;
                 return;
             }
-            });
+        });
     }
 
     void acceptDone()

--- a/include/async_resolve.hpp
+++ b/include/async_resolve.hpp
@@ -84,7 +84,7 @@ class Resolver
             }
             // All the resolved data is filled in the endpointList
             handler(ec, endpointList);
-            },
+        },
             "org.freedesktop.resolve1", "/org/freedesktop/resolve1",
             "org.freedesktop.resolve1.Manager", "ResolveHostname", 0, host,
             AF_UNSPEC, flag);

--- a/include/cors_preflight.hpp
+++ b/include/cors_preflight.hpp
@@ -14,6 +14,6 @@ inline void requestRoutes(App& app)
                const std::shared_ptr<bmcweb::AsyncResp>&, const std::string&) {
         // An empty body handler that simply returns the headers bmcweb
         // uses This allows browsers to do their CORS preflight checks
-        });
+    });
 }
 } // namespace cors_preflight

--- a/include/dbus_monitor.hpp
+++ b/include/dbus_monitor.hpp
@@ -111,15 +111,14 @@ inline void requestRoutes(App& app)
         .privileges({{"Login"}})
         .websocket()
         .onopen([&](crow::websocket::Connection& conn) {
-            BMCWEB_LOG_DEBUG << "Connection " << &conn << " opened";
-            sessions.try_emplace(&conn);
-        })
+        BMCWEB_LOG_DEBUG << "Connection " << &conn << " opened";
+        sessions.try_emplace(&conn);
+    })
         .onclose([&](crow::websocket::Connection& conn, const std::string&) {
-            sessions.erase(&conn);
-        })
-        .onmessage(
-            [&](crow::websocket::Connection& conn, const std::string& data,
-                bool) {
+        sessions.erase(&conn);
+    })
+        .onmessage([&](crow::websocket::Connection& conn,
+                       const std::string& data, bool) {
         const auto sessionPair = sessions.find(&conn);
         if (sessionPair == sessions.end())
         {
@@ -247,7 +246,7 @@ inline void requestRoutes(App& app)
                     *crow::connections::systemBus, objectManagerMatchString,
                     onPropertyUpdate, &conn));
         }
-        });
+    });
 }
 } // namespace dbus_monitor
 } // namespace crow

--- a/include/dbus_utility.hpp
+++ b/include/dbus_utility.hpp
@@ -156,7 +156,7 @@ inline void checkDbusPathExists(const std::string& path, Callback&& callback)
             const boost::system::error_code ec,
             const dbus::utility::MapperGetObject& objectNames) {
         callback(!ec && !objectNames.empty());
-        },
+    },
         "xyz.openbmc_project.ObjectMapper",
         "/xyz/openbmc_project/object_mapper",
         "xyz.openbmc_project.ObjectMapper", "GetObject", path,
@@ -190,7 +190,7 @@ inline void getSubTreePaths(
             const boost::system::error_code ec,
             const MapperGetSubTreePathsResponse& subtreePaths) {
         callback(ec, subtreePaths);
-        },
+    },
         "xyz.openbmc_project.ObjectMapper",
         "/xyz/openbmc_project/object_mapper",
         "xyz.openbmc_project.ObjectMapper", "GetSubTreePaths", path, depth,
@@ -208,7 +208,7 @@ inline void getAssociationEndPoints(
         [callback{std::move(callback)}](const boost::system::error_code& ec,
                                         const MapperEndPoints& endpoints) {
         callback(ec, endpoints);
-        });
+    });
 }
 
 inline void getAssociatedSubTree(
@@ -240,7 +240,7 @@ inline void getAssociatedSubTreePaths(
             const boost::system::error_code& ec,
             const MapperGetSubTreePathsResponse& subtreePaths) {
         callback(ec, subtreePaths);
-        },
+    },
         "xyz.openbmc_project.ObjectMapper",
         "/xyz/openbmc_project/object_mapper",
         "xyz.openbmc_project.ObjectMapper", "GetAssociatedSubTreePaths",
@@ -257,7 +257,7 @@ inline void
         [callback{std::move(callback)}](const boost::system::error_code& ec,
                                         const MapperGetObject& object) {
         callback(ec, object);
-        },
+    },
         "xyz.openbmc_project.ObjectMapper",
         "/xyz/openbmc_project/object_mapper",
         "xyz.openbmc_project.ObjectMapper", "GetObject", path, interfaces);
@@ -274,7 +274,7 @@ inline void
         [callback{std::move(callback)}](const boost::system::error_code& ec,
                                         const AssociationList& associations) {
         callback(ec, associations);
-        });
+    });
 }
 
 } // namespace utility

--- a/include/dump_offload.hpp
+++ b/include/dump_offload.hpp
@@ -85,7 +85,7 @@ class Handler : public std::enable_shared_from_this<Handler>
             this->connection->sendStreamHeaders(std::to_string(this->dumpSize),
                                                 "application/octet-stream");
             this->doReadStream();
-            });
+        });
     }
 
     /**
@@ -116,7 +116,7 @@ class Handler : public std::enable_shared_from_this<Handler>
                 this->cleanupSocketFiles();
                 return;
             }
-            },
+        },
             "xyz.openbmc_project.Dump.Manager",
             "/xyz/openbmc_project/dump/" + dumpType + "/entry/" + entryID,
             "xyz.openbmc_project.Dump.Entry", "InitiateOffload",
@@ -190,7 +190,7 @@ class Handler : public std::enable_shared_from_this<Handler>
             }
             BMCWEB_LOG_CRITICAL << "INFO: Reset OffloadUri of " << dumpType
                                 << " dump id " << entryID;
-            },
+        },
             "xyz.openbmc_project.Dump.Manager",
             "/xyz/openbmc_project/dump/" + dumpType + "/entry/" + entryID,
             "org.freedesktop.DBus.Properties", "Set",
@@ -259,7 +259,7 @@ class Handler : public std::enable_shared_from_this<Handler>
             this->dumpSize = *dumpsize;
             this->initiateOffload();
             this->doConnect();
-            },
+        },
             "xyz.openbmc_project.Dump.Manager",
             "/xyz/openbmc_project/dump/" + dumpEntryType + "/entry/" +
                 dumpEntryID,
@@ -306,7 +306,7 @@ class Handler : public std::enable_shared_from_this<Handler>
             };
             this->connection->sendMessage(this->outputBuffer.data(),
                                           streamHandler);
-            });
+        });
     }
 
     std::string entryID;
@@ -354,8 +354,7 @@ inline void requestRoutes(App& app)
         "/redfish/v1/Managers/bmc/LogServices/Dump/Entries/<str>/attachment/")
         .privileges({{"ConfigureComponents", "ConfigureManager"}})
         .streamingResponse()
-        .onopen(
-            [](crow::streaming_response::Connection& conn) {
+        .onopen([](crow::streaming_response::Connection& conn) {
         if (!bmcHandlers.empty())
         {
             BMCWEB_LOG_ERROR << "Can't allow dump offload opertaion, one "
@@ -407,30 +406,28 @@ inline void requestRoutes(App& app)
             << "INFO: " << dumpType << " Dump id " << dumpId
             << " offload initiated by: " << conn.req.session->clientIp;
         bmcHandlers[&conn]->getDumpSize(dumpId, dumpType);
-        })
-        .onclose([](crow::streaming_response::Connection& conn, bool& status) {
-            auto handler = bmcHandlers.find(&conn);
-            if (handler == bmcHandlers.end())
-            {
-                BMCWEB_LOG_DEBUG << "No handler to cleanup";
-                return;
-            }
-            handler->second->cleanupSocketFiles();
-            if (!status)
-            {
-                handler->second->resetOffloadURI();
-            }
-            handler->second->outputBuffer.clear();
-            bmcHandlers.erase(handler);
-        });
+    }).onclose([](crow::streaming_response::Connection& conn, bool& status) {
+        auto handler = bmcHandlers.find(&conn);
+        if (handler == bmcHandlers.end())
+        {
+            BMCWEB_LOG_DEBUG << "No handler to cleanup";
+            return;
+        }
+        handler->second->cleanupSocketFiles();
+        if (!status)
+        {
+            handler->second->resetOffloadURI();
+        }
+        handler->second->outputBuffer.clear();
+        bmcHandlers.erase(handler);
+    });
 
     BMCWEB_ROUTE(
         app,
         "/redfish/v1/Systems/system/LogServices/Dump/Entries/<str>/attachment/")
         .privileges({{"ConfigureComponents", "ConfigureManager"}})
         .streamingResponse()
-        .onopen(
-            [](crow::streaming_response::Connection& conn) {
+        .onopen([](crow::streaming_response::Connection& conn) {
         if (!systemHandlers.empty())
         {
             BMCWEB_LOG_ERROR << "Can't allow dump offload opertaion, one "
@@ -500,25 +497,24 @@ inline void requestRoutes(App& app)
             << "INFO: " << dumpType << " dump id " << dumpId
             << " offload initiated by: " << conn.req.session->clientIp;
         systemHandlers[&conn]->getDumpSize(dumpId, dumpType);
-        })
-        .onclose([](crow::streaming_response::Connection& conn, bool& status) {
-            auto handler = systemHandlers.find(&conn);
-            if (handler == systemHandlers.end())
-            {
-                BMCWEB_LOG_DEBUG << "No handler to cleanup";
-                return;
-            }
-            handler->second->cleanupSocketFiles();
-            if (!status)
-            {
-                handler->second->resetOffloadURI();
-            }
-            handler->second->outputBuffer.clear();
-            systemHandlers.clear();
-            BMCWEB_LOG_CRITICAL
-                << "INFO:Request closed for system dump offload with"
-                << "url: " << conn.req.target();
-        });
+    }).onclose([](crow::streaming_response::Connection& conn, bool& status) {
+        auto handler = systemHandlers.find(&conn);
+        if (handler == systemHandlers.end())
+        {
+            BMCWEB_LOG_DEBUG << "No handler to cleanup";
+            return;
+        }
+        handler->second->cleanupSocketFiles();
+        if (!status)
+        {
+            handler->second->resetOffloadURI();
+        }
+        handler->second->outputBuffer.clear();
+        systemHandlers.clear();
+        BMCWEB_LOG_CRITICAL
+            << "INFO:Request closed for system dump offload with"
+            << "url: " << conn.req.target();
+    });
 }
 
 } // namespace obmc_dump

--- a/include/google/google_service_root.hpp
+++ b/include/google/google_service_root.hpp
@@ -104,7 +104,7 @@ inline void resolveRoT(const std::string& command,
             const dbus::utility::MapperGetSubTreeResponse& subtree) {
         hothGetSubtreeCallback(command, asyncResp, rotId, entityHandler, ec,
                                subtree);
-        },
+    },
         "xyz.openbmc_project.ObjectMapper",
         "/xyz/openbmc_project/object_mapper",
         "xyz.openbmc_project.ObjectMapper", "GetSubTree",
@@ -180,7 +180,7 @@ inline void
         [asyncResp{asyncResp}](const boost::system::error_code ec,
                                const std::vector<uint8_t>& responseBytes) {
         invocationCallback(asyncResp, ec, responseBytes);
-        },
+    },
         resolvedEntity.service, resolvedEntity.object, resolvedEntity.interface,
         "SendHostCommand", bytes);
 }

--- a/include/hostname_monitor.hpp
+++ b/include/hostname_monitor.hpp
@@ -26,7 +26,7 @@ inline void installCertificate(const std::filesystem::path& certPath)
         BMCWEB_LOG_INFO << "Replace HTTPs Certificate Success, "
                            "remove temporary certificate file..";
         remove(certPath.c_str());
-        },
+    },
         "xyz.openbmc_project.Certs.Manager.Server.Https",
         "/xyz/openbmc_project/certs/server/https/1",
         "xyz.openbmc_project.Certs.Replace", "Replace", certPath.string());

--- a/include/http_utility.hpp
+++ b/include/http_utility.hpp
@@ -77,7 +77,7 @@ inline ContentType getPreferedContentType(std::string_view header,
             std::find_if(contentTypes.begin(), contentTypes.end(),
                          [encoding](const ContentTypePair& pair) {
             return pair.contentTypeString == encoding;
-            });
+        });
 
         if (knownContentType == contentTypes.end())
         {

--- a/include/ibm/management_console_rest.hpp
+++ b/include/ibm/management_console_rest.hpp
@@ -854,8 +854,8 @@ inline void
     deleteVMIDbusEntry(const std::shared_ptr<bmcweb::AsyncResp>& asyncResp,
                        const std::string& entryId)
 {
-    auto respHandler =
-        [asyncResp, entryId](const boost::system::error_code ec) {
+    auto respHandler = [asyncResp,
+                        entryId](const boost::system::error_code ec) {
         if (ec)
         {
             BMCWEB_LOG_ERROR << "deleteVMIDbusEntry respHandler got error "
@@ -911,7 +911,7 @@ inline void
 
         BMCWEB_LOG_CRITICAL << "INFO:Successfully got VMI client certificate";
         asyncResp->res.jsonValue["Certificate"] = *cert;
-        },
+    },
         "xyz.openbmc_project.Certs.ca.authority.Manager",
         "/xyz/openbmc_project/certs/ca/entry/" + entryId,
         "org.freedesktop.DBus.Properties", "Get",
@@ -972,7 +972,7 @@ inline void getCSREntryAck(const std::shared_ptr<bmcweb::AsyncResp>& asyncResp,
             BMCWEB_LOG_CRITICAL << "INFO:Erasing match of entryId: " << entryId;
             ackMatches.erase(entryId);
         }
-        },
+    },
         "xyz.openbmc_project.Certs.ca.authority.Manager",
         "/xyz/openbmc_project/certs/ca/entry/" + entryId,
         "org.freedesktop.DBus.Properties", "Get",
@@ -1030,8 +1030,8 @@ static void
 
         timeout->async_wait(timeoutHandler);
 
-        auto callback =
-            [asyncResp, timeout, entryId](sdbusplus::message::message& msg) {
+        auto callback = [asyncResp, timeout,
+                         entryId](sdbusplus::message::message& msg) {
             BMCWEB_LOG_DEBUG << "Match fired" << msg.get();
             boost::container::flat_map<std::string, std::variant<std::string>>
                 values;
@@ -1061,7 +1061,7 @@ static void
         ackMatches.emplace(
             entryId, std::make_unique<sdbusplus::bus::match::match>(
                          *crow::connections::systemBus, matchStr, callback));
-        },
+    },
         "xyz.openbmc_project.Certs.ca.authority.Manager",
         "/xyz/openbmc_project/certs/ca", "xyz.openbmc_project.Certs.Authority",
         "SignCSR", csrString);
@@ -1143,7 +1143,7 @@ inline void requestRoutes(App& app)
             "/ibm/v1/HMC/BroadcastService";
         asyncResp->res.jsonValue["Certificate"]["@odata.id"] =
             "/ibm/v1/Host/Certificate";
-        });
+    });
 
     BMCWEB_ROUTE(app, "/ibm/v1/Host/ConfigFiles")
         .privileges({{"ConfigureComponents", "ConfigureManager"}})
@@ -1151,7 +1151,7 @@ inline void requestRoutes(App& app)
             [](const crow::Request&,
                const std::shared_ptr<bmcweb::AsyncResp>& asyncResp) {
         handleConfigFileList(asyncResp);
-        });
+    });
 
     BMCWEB_ROUTE(app,
                  "/ibm/v1/Host/ConfigFiles/Actions/IBMConfigFiles.DeleteAll")
@@ -1160,7 +1160,7 @@ inline void requestRoutes(App& app)
             [](const crow::Request&,
                const std::shared_ptr<bmcweb::AsyncResp>& asyncResp) {
         deleteConfigFiles(asyncResp);
-        });
+    });
 
     BMCWEB_ROUTE(app, "/ibm/v1/Host/ConfigFiles/<str>")
         .privileges({{"ConfigureComponents", "ConfigureManager"}})
@@ -1177,7 +1177,7 @@ inline void requestRoutes(App& app)
             return;
         }
         handleFileUrl(req, asyncResp, fileName);
-        });
+    });
 
     BMCWEB_ROUTE(app, "/ibm/v1/Host/Certificate")
         .privileges({{"ConfigureComponents", "ConfigureManager"}})
@@ -1191,7 +1191,7 @@ inline void requestRoutes(App& app)
             {"target", "/ibm/v1/Host/Actions/SignCSR"}};
         asyncResp->res.jsonValue["root"] = {
             {"target", "/ibm/v1/Host/Certificate/root"}};
-        });
+    });
 
     BMCWEB_ROUTE(app, "/ibm/v1/Host/Certificate/root")
         .privileges({{"ConfigureComponents", "ConfigureManager"}})
@@ -1222,7 +1222,7 @@ inline void requestRoutes(App& app)
         strStream << inFile.rdbuf();
         inFile.close();
         asyncResp->res.jsonValue["Certificate"] = strStream.str();
-        });
+    });
 
     BMCWEB_ROUTE(app, "/ibm/v1/Host/Actions/SignCSR")
         .privileges({{"ConfigureComponents", "ConfigureManager"}})
@@ -1237,7 +1237,7 @@ inline void requestRoutes(App& app)
         }
 
         handleCsrRequest(asyncResp, csrString);
-        });
+    });
 
     BMCWEB_ROUTE(app, "/ibm/v1/Host/ConfigFiles")
         .privileges({{"ConfigureComponents", "ConfigureManager"}})
@@ -1250,7 +1250,7 @@ inline void requestRoutes(App& app)
             [](const crow::Request&,
                const std::shared_ptr<bmcweb::AsyncResp>& asyncResp) {
         getLockServiceData(asyncResp);
-        });
+    });
 
     BMCWEB_ROUTE(app, "/ibm/v1/HMC/LockService/Actions/LockService.AcquireLock")
         .privileges({{"ConfigureComponents", "ConfigureManager"}})
@@ -1266,7 +1266,7 @@ inline void requestRoutes(App& app)
             return;
         }
         handleAcquireLockAPI(req, asyncResp, body);
-        });
+    });
     BMCWEB_ROUTE(app, "/ibm/v1/HMC/LockService/Actions/LockService.ReleaseLock")
         .privileges({{"ConfigureComponents", "ConfigureManager"}})
         .methods(boost::beast::http::verb::post)(
@@ -1297,7 +1297,7 @@ inline void requestRoutes(App& app)
             redfish::messages::propertyValueNotInList(asyncResp->res, type,
                                                       "Type");
         }
-        });
+    });
     BMCWEB_ROUTE(app, "/ibm/v1/HMC/LockService/Actions/LockService.GetLockList")
         .privileges({{"ConfigureComponents", "ConfigureManager"}})
         .methods(boost::beast::http::verb::post)(
@@ -1312,7 +1312,7 @@ inline void requestRoutes(App& app)
             return;
         }
         handleGetLockListAPI(asyncResp, listSessionIds);
-        });
+    });
 
     BMCWEB_ROUTE(app, "/ibm/v1/HMC/BroadcastService")
         .privileges({{"ConfigureComponents", "ConfigureManager"}})
@@ -1320,7 +1320,7 @@ inline void requestRoutes(App& app)
             [](const crow::Request& req,
                const std::shared_ptr<bmcweb::AsyncResp>& asyncResp) {
         handleBroadcastService(req, asyncResp);
-        });
+    });
 
     BMCWEB_ROUTE(app, "/ibm/v1/OCC/Control/<str>/Actions/PassThrough.Send")
         .privileges({{"OemIBMPerformService"}})
@@ -1329,7 +1329,7 @@ inline void requestRoutes(App& app)
                const std::shared_ptr<bmcweb::AsyncResp>& asyncResp,
                const std::string& name) {
         handlePassThrough(req, asyncResp, name);
-        });
+    });
 }
 
 } // namespace ibm_mc

--- a/include/image_upload.hpp
+++ b/include/image_upload.hpp
@@ -68,7 +68,7 @@ inline void
         if (std::find_if(interfaces.begin(), interfaces.end(),
                          [](const auto& i) {
             return i.first == "xyz.openbmc_project.Software.Version";
-            }) != interfaces.end())
+        }) != interfaces.end())
         {
             timeout.cancel();
             std::string leaf = path.filename();
@@ -116,7 +116,7 @@ inline void requestRoutes(App& app)
             [](const crow::Request& req,
                const std::shared_ptr<bmcweb::AsyncResp>& asyncResp) {
         uploadImageHandler(req, asyncResp);
-        });
+    });
 }
 } // namespace image_upload
 } // namespace crow

--- a/include/login_routes.hpp
+++ b/include/login_routes.hpp
@@ -234,7 +234,7 @@ inline void requestRoutes(App& app)
             BMCWEB_LOG_DEBUG << "Couldn't interpret password";
             asyncResp->res.result(boost::beast::http::status::bad_request);
         }
-        });
+    });
 
     BMCWEB_ROUTE(app, "/logout")
         .methods(boost::beast::http::verb::post)(
@@ -256,7 +256,7 @@ inline void requestRoutes(App& app)
                                      R"("cache","cookies","storage")");
             persistent_data::SessionStore::getInstance().removeSession(session);
         }
-        });
+    });
 }
 } // namespace login_routes
 } // namespace crow

--- a/include/nbd_proxy.hpp
+++ b/include/nbd_proxy.hpp
@@ -164,8 +164,8 @@ struct NbdProxyServer : std::enable_shared_from_this<NbdProxyServer>
                     self2->ux2wsBuf.consume(self2->ux2wsBuf.size());
                     self2->doRead();
                 }
-                });
             });
+        });
     }
 
     void doWrite(std::function<void()>&& onDone)
@@ -212,7 +212,7 @@ struct NbdProxyServer : std::enable_shared_from_this<NbdProxyServer>
                 return;
             }
             onDone();
-            });
+        });
     }
 
     // Keeps UNIX socket endpoint file path

--- a/include/obmc_console.hpp
+++ b/include/obmc_console.hpp
@@ -64,7 +64,7 @@ inline void doWrite()
             return;
         }
         doWrite();
-        });
+    });
 }
 
 inline void doRead()
@@ -95,7 +95,7 @@ inline void doRead()
             session->sendBinary(payload);
         }
         doRead();
-        });
+    });
 }
 
 inline void connectHandler(const boost::system::error_code& ec)
@@ -120,11 +120,11 @@ inline void requestRoutes(App& app)
         .privileges({{"ConfigureManager"}})
         .websocket()
         .onopen([](crow::websocket::Connection& conn) {
-            BMCWEB_LOG_DEBUG << "Connection " << &conn << " opened";
-            // Ensure user has ConfigureManager, setting above does nothing
-            auto getUserInfo =
-                [&conn](const boost::system::error_code& ec,
-                        const dbus::utility::DBusPropertiesMap& userInfo) {
+        BMCWEB_LOG_DEBUG << "Connection " << &conn << " opened";
+        // Ensure user has ConfigureManager, setting above does nothing
+        auto getUserInfo =
+            [&conn](const boost::system::error_code& ec,
+                    const dbus::utility::DBusPropertiesMap& userInfo) {
             if (ec)
             {
                 BMCWEB_LOG_ERROR << "GetUserInfo failed...";
@@ -133,10 +133,9 @@ inline void requestRoutes(App& app)
             }
 
             const std::string* userRolePtr = nullptr;
-            auto userInfoIter = std::find_if(userInfo.begin(), userInfo.end(),
-                                             [](const auto& p) {
-                return p.first == "UserPrivilege";
-            });
+            auto userInfoIter = std::find_if(
+                userInfo.begin(), userInfo.end(),
+                [](const auto& p) { return p.first == "UserPrivilege"; });
             if (userInfoIter != userInfo.end())
             {
                 userRolePtr = std::get_if<std::string>(&userInfoIter->second);
@@ -176,29 +175,29 @@ inline void requestRoutes(App& app)
                     conn.getIoContext());
                 hostSocket->async_connect(ep, connectHandler);
             }
-            };
-            crow::connections::systemBus->async_method_call(
-                std::move(getUserInfo), "xyz.openbmc_project.User.Manager",
-                "/xyz/openbmc_project/user", "xyz.openbmc_project.User.Manager",
-                "GetUserInfo", conn.getUserName());
-        })
+        };
+        crow::connections::systemBus->async_method_call(
+            std::move(getUserInfo), "xyz.openbmc_project.User.Manager",
+            "/xyz/openbmc_project/user", "xyz.openbmc_project.User.Manager",
+            "GetUserInfo", conn.getUserName());
+    })
         .onclose([](crow::websocket::Connection& conn,
                     [[maybe_unused]] const std::string& reason) {
-            BMCWEB_LOG_INFO << "Closing websocket. Reason: " << reason;
+        BMCWEB_LOG_INFO << "Closing websocket. Reason: " << reason;
 
-            sessions.erase(&conn);
-            if (sessions.empty())
-            {
-                hostSocket = nullptr;
-                inputBuffer.clear();
-                inputBuffer.shrink_to_fit();
-            }
-        })
+        sessions.erase(&conn);
+        if (sessions.empty())
+        {
+            hostSocket = nullptr;
+            inputBuffer.clear();
+            inputBuffer.shrink_to_fit();
+        }
+    })
         .onmessage([]([[maybe_unused]] crow::websocket::Connection& conn,
                       const std::string& data, [[maybe_unused]] bool isBinary) {
-            inputBuffer += data;
-            doWrite();
-        });
+        inputBuffer += data;
+        doWrite();
+    });
 }
 } // namespace obmc_console
 } // namespace crow

--- a/include/obmc_hypervisor.hpp
+++ b/include/obmc_hypervisor.hpp
@@ -67,7 +67,7 @@ inline void doWrite()
             return;
         }
         doWrite();
-        });
+    });
 }
 
 inline void doRead()
@@ -98,7 +98,7 @@ inline void doRead()
             session->sendBinary(payload);
         }
         doRead();
-        });
+    });
 }
 
 inline void connectHandler(const boost::system::error_code& ec)
@@ -122,8 +122,7 @@ inline void requestRoutes(App& app)
     BMCWEB_ROUTE(app, "/console1")
         .privileges({{"OemIBMPerformService"}})
         .websocket()
-        .onopen(
-            [](crow::websocket::Connection& conn) {
+        .onopen([](crow::websocket::Connection& conn) {
         BMCWEB_LOG_DEBUG << "Connection " << &conn << " opened";
 
         // TODO: this user check must be removed when WebSocket privileges
@@ -144,24 +143,24 @@ inline void requestRoutes(App& app)
                     conn.getIoContext());
             hostSocket->async_connect(ep, connectHandler);
         }
-        })
+    })
         .onclose([](crow::websocket::Connection& conn,
                     [[maybe_unused]] const std::string& reason) {
-            BMCWEB_LOG_INFO << "Closing websocket. Reason: " << reason;
+        BMCWEB_LOG_INFO << "Closing websocket. Reason: " << reason;
 
-            sessions.erase(&conn);
-            if (sessions.empty())
-            {
-                hostSocket = nullptr;
-                inputBuffer.clear();
-                inputBuffer.shrink_to_fit();
-            }
-        })
+        sessions.erase(&conn);
+        if (sessions.empty())
+        {
+            hostSocket = nullptr;
+            inputBuffer.clear();
+            inputBuffer.shrink_to_fit();
+        }
+    })
         .onmessage([]([[maybe_unused]] crow::websocket::Connection& conn,
                       const std::string& data, [[maybe_unused]] bool isBinary) {
-            inputBuffer += data;
-            doWrite();
-        });
+        inputBuffer += data;
+        doWrite();
+    });
 }
 } // namespace obmc_hypervisor
 } // namespace crow

--- a/include/vm_websocket.hpp
+++ b/include/vm_websocket.hpp
@@ -108,7 +108,7 @@ class Handler : public std::enable_shared_from_this<Handler>
                 return;
             }
             doWrite();
-            });
+        });
     }
 
     void doRead()
@@ -142,7 +142,7 @@ class Handler : public std::enable_shared_from_this<Handler>
             outputBuffer->consume(bytesRead);
 
             doRead();
-            });
+        });
     }
 
     boost::process::async_pipe pipeOut;
@@ -165,57 +165,57 @@ inline void requestRoutes(App& app)
         .privileges({{"ConfigureComponents", "ConfigureManager"}})
         .websocket()
         .onopen([](crow::websocket::Connection& conn) {
-            BMCWEB_LOG_DEBUG << "Connection " << &conn << " opened";
+        BMCWEB_LOG_DEBUG << "Connection " << &conn << " opened";
 
-            if (session != nullptr)
-            {
-                conn.close("Session already connected");
-                return;
-            }
+        if (session != nullptr)
+        {
+            conn.close("Session already connected");
+            return;
+        }
 
-            if (handler != nullptr)
-            {
-                conn.close("Handler already running");
-                return;
-            }
+        if (handler != nullptr)
+        {
+            conn.close("Handler already running");
+            return;
+        }
 
-            session = &conn;
+        session = &conn;
 
-            // media is the last digit of the endpoint /vm/0/0. A future
-            // enhancement can include supporting different endpoint values.
-            const char* media = "0";
-            handler = std::make_shared<Handler>(media, conn.getIoContext());
-            handler->connect();
-        })
+        // media is the last digit of the endpoint /vm/0/0. A future
+        // enhancement can include supporting different endpoint values.
+        const char* media = "0";
+        handler = std::make_shared<Handler>(media, conn.getIoContext());
+        handler->connect();
+    })
         .onclose([](crow::websocket::Connection& conn,
                     const std::string& /*reason*/) {
-            if (&conn != session)
-            {
-                return;
-            }
+        if (&conn != session)
+        {
+            return;
+        }
 
-            session = nullptr;
-            handler->doClose();
-            handler->inputBuffer->clear();
-            handler->outputBuffer->clear();
-            handler.reset();
-        })
+        session = nullptr;
+        handler->doClose();
+        handler->inputBuffer->clear();
+        handler->outputBuffer->clear();
+        handler.reset();
+    })
         .onmessage([](crow::websocket::Connection& conn,
                       const std::string& data, bool) {
-            if (data.length() >
-                handler->inputBuffer->capacity() - handler->inputBuffer->size())
-            {
-                BMCWEB_LOG_ERROR << "Buffer overrun when writing "
-                                 << data.length() << " bytes";
-                conn.close("Buffer overrun");
-                return;
-            }
+        if (data.length() >
+            handler->inputBuffer->capacity() - handler->inputBuffer->size())
+        {
+            BMCWEB_LOG_ERROR << "Buffer overrun when writing " << data.length()
+                             << " bytes";
+            conn.close("Buffer overrun");
+            return;
+        }
 
-            boost::asio::buffer_copy(handler->inputBuffer->prepare(data.size()),
-                                     boost::asio::buffer(data));
-            handler->inputBuffer->commit(data.size());
-            handler->doWrite();
-        });
+        boost::asio::buffer_copy(handler->inputBuffer->prepare(data.size()),
+                                 boost::asio::buffer(data));
+        handler->inputBuffer->commit(data.size());
+        handler->doWrite();
+    });
 }
 
 } // namespace obmc_vm

--- a/meson.build
+++ b/meson.build
@@ -298,19 +298,49 @@ else
 endif
 bmcweb_dependencies += nlohmann_json
 
-boost = dependency('boost', modules: ['url'], version : '>=1.83.0', required : false, include_type: 'system')
+boost = dependency(
+  'boost',
+  modules: [
+    'asio',
+    'beast',
+    'callable_traits',
+    'headers',
+    'process',
+    'type_index',
+    'url',
+    'uuid'
+    ],
+  version : '>=1.83.0',
+  required : false,
+  include_type: 'system'
+)
 if boost.found()
   bmcweb_dependencies += [boost]
 else
   cmake = import('cmake')
   opt = cmake.subproject_options()
   opt.add_cmake_defines({
-    'BOOST_INCLUDE_LIBRARIES': 'url'
+    'BOOST_INCLUDE_LIBRARIES': 'asio;beast;callable_traits;headers;process;type_index;url;uuid'
   })
   boost = cmake.subproject('boost', required: true, options: opt)
-  boost_url = boost.dependency('boost_url').as_system()
+  boost_asio = boost.dependency('boost_asio').as_system()
+  boost_beast = boost.dependency('boost_beast').as_system()
+  boost_callable_traits = boost.dependency('boost_callable_traits').as_system()
   boost_headers = boost.dependency('boost_headers').as_system()
-  bmcweb_dependencies += [boost_url, boost_headers]
+  boost_process = boost.dependency('boost_process').as_system()
+  boost_type_index = boost.dependency('boost_type_index').as_system()
+  boost_url = boost.dependency('boost_url').as_system()
+  boost_uuid = boost.dependency('boost_uuid').as_system()
+  bmcweb_dependencies += [
+    boost_asio,
+    boost_beast,
+    boost_callable_traits,
+    boost_headers,
+    boost_process,
+    boost_type_index,
+    boost_url,
+    boost_uuid
+  ]
 endif
 
 if get_option('tests').enabled()

--- a/meson.build
+++ b/meson.build
@@ -243,6 +243,7 @@ endif
 
 add_project_arguments(
 cxx.get_supported_arguments([
+  '-DBOOST_ASIO_DISABLE_CONCEPTS',
   '-DBOOST_ALL_NO_LIB',
   '-DBOOST_ALLOW_DEPRECATED_HEADERS',
   '-DBOOST_ASIO_DISABLE_THREADS',
@@ -297,12 +298,20 @@ else
 endif
 bmcweb_dependencies += nlohmann_json
 
-boost = dependency('boost',version : '>=1.81.0', required : false, include_type: 'system')
-if not boost.found()
-  boost = subproject('boost', required: true).get_variable('boost_dep')
-  boost = boost.as_system('system')
+boost = dependency('boost', modules: ['url'], version : '>=1.83.0', required : false, include_type: 'system')
+if boost.found()
+  bmcweb_dependencies += [boost]
+else
+  cmake = import('cmake')
+  opt = cmake.subproject_options()
+  opt.add_cmake_defines({
+    'BOOST_INCLUDE_LIBRARIES': 'url'
+  })
+  boost = cmake.subproject('boost', required: true, options: opt)
+  boost_url = boost.dependency('boost_url').as_system()
+  boost_headers = boost.dependency('boost_headers').as_system()
+  bmcweb_dependencies += [boost_url, boost_headers]
 endif
-bmcweb_dependencies += boost
 
 if get_option('tests').enabled()
   gtest = dependency('gtest', main: true,disabler: true, required : false)
@@ -342,7 +351,6 @@ srcfiles_bmcweb = files(
   'src/boost_asio_ssl.cpp',
   'src/boost_asio.cpp',
   'src/boost_beast.cpp',
-  'src/boost_url.cpp',
   'src/dbus_singleton.cpp',
 )
 

--- a/meson.build
+++ b/meson.build
@@ -301,14 +301,7 @@ bmcweb_dependencies += nlohmann_json
 boost = dependency(
   'boost',
   modules: [
-    'asio',
-    'beast',
-    'callable_traits',
-    'headers',
-    'process',
-    'type_index',
     'url',
-    'uuid'
     ],
   version : '>=1.83.0',
   required : false,

--- a/redfish-core/include/event_service_manager.hpp
+++ b/redfish-core/include/event_service_manager.hpp
@@ -100,7 +100,7 @@ static const Message*
         std::find_if(registry.begin(), registry.end(),
                      [&messageKey](const MessageEntry& messageEntry) {
         return messageKey == messageEntry.first;
-        });
+    });
     if (messageIt != registry.end())
     {
         return &messageIt->second;

--- a/redfish-core/include/redfish_aggregator.hpp
+++ b/redfish-core/include/redfish_aggregator.hpp
@@ -680,7 +680,7 @@ class RedfishAggregator
                     << "No satellite BMCs detected.  Redfish Aggregation not enabled";
             }
             handler(ec, satelliteInfo);
-            },
+        },
             "xyz.openbmc_project.EntityManager",
             "/xyz/openbmc_project/inventory",
             "org.freedesktop.DBus.ObjectManager", "GetManagedObjects");

--- a/redfish-core/include/redfish_aggregator.hpp
+++ b/redfish-core/include/redfish_aggregator.hpp
@@ -146,7 +146,7 @@ static inline void addPrefixToItem(nlohmann::json& item,
 }
 
 static inline void addAggregatedHeaders(crow::Response& asyncResp,
-                                        crow::Response& resp,
+                                        const crow::Response& resp,
                                         std::string_view prefix)
 {
     if (!resp.getHeaderValue("Content-Type").empty())

--- a/redfish-core/include/server_sent_events.hpp
+++ b/redfish-core/include/server_sent_events.hpp
@@ -133,7 +133,7 @@ class ServerSentEvents : public std::enable_shared_from_this<ServerSentEvents>
                              << bytesTransferred;
 
             self->doWrite();
-            });
+        });
     }
 
     void startSSE()
@@ -177,7 +177,7 @@ class ServerSentEvents : public std::enable_shared_from_this<ServerSentEvents>
             BMCWEB_LOG_DEBUG << "startSSE  Header sent.";
             state = SseConnState::initialized;
             checkQueue();
-            });
+        });
     }
 
     void checkQueue(const bool newRecord = false)

--- a/redfish-core/include/snmp_trap_event_clients.hpp
+++ b/redfish-core/include/snmp_trap_event_clients.hpp
@@ -39,7 +39,7 @@ inline void
 
             asyncResp->res.jsonValue["Destination"] = std::move(destination);
         }
-        });
+    });
 }
 
 inline void
@@ -109,7 +109,7 @@ inline void
 
         messages::resourceNotFound(asyncResp->res, "Subscriptions", id);
         EventServiceManager::getInstance().deleteSubscription(id);
-        },
+    },
         "xyz.openbmc_project.Network.SNMP",
         "/xyz/openbmc_project/network/snmp/manager",
         "org.freedesktop.DBus.ObjectManager", "GetManagedObjects");
@@ -146,7 +146,7 @@ inline void
                                  "/redfish/v1/EventService/Subscriptions/" +
                                      subscriptionId);
         messages::created(asyncResp->res);
-        },
+    },
         "xyz.openbmc_project.Network.SNMP",
         "/xyz/openbmc_project/network/snmp/manager",
         "xyz.openbmc_project.Network.Client.Create", "Client", host,
@@ -228,7 +228,7 @@ inline void
 
         // Create the snmp client
         createSnmpTrapClient(asyncResp, host, snmpTrapPort, subValue);
-        },
+    },
         "xyz.openbmc_project.Network.SNMP",
         "/xyz/openbmc_project/network/snmp/manager",
         "org.freedesktop.DBus.ObjectManager", "GetManagedObjects");
@@ -278,7 +278,7 @@ inline void
             return;
         }
         messages::success(asyncResp->res);
-        },
+    },
         "xyz.openbmc_project.Network.SNMP", snmpPath,
         "xyz.openbmc_project.Object.Delete", "Delete");
 }

--- a/redfish-core/include/utils/chassis_utils.hpp
+++ b/redfish-core/include/utils/chassis_utils.hpp
@@ -114,7 +114,7 @@ inline void
             std::sort(updatedAssemblyList.begin(), updatedAssemblyList.end());
             callback(updatedAssemblyList);
         }
-        },
+    },
         "xyz.openbmc_project.ObjectMapper",
         "/xyz/openbmc_project/object_mapper",
         "xyz.openbmc_project.ObjectMapper", "GetSubTree",
@@ -151,7 +151,7 @@ inline void
         checkAssemblyInterface(aResp, chassisPath, sortedAssemblyList,
                                std::move(callback));
         return;
-        });
+    });
 }
 
 template <typename Callback>
@@ -186,7 +186,7 @@ inline void checkForAssemblyAssociations(
             getAssemblyEndpoints(aResp, chassisPath, std::move(callback));
             break;
         }
-        });
+    });
 }
 
 template <typename Callback>
@@ -220,7 +220,7 @@ inline void checkAssociation(const std::shared_ptr<bmcweb::AsyncResp>& aResp,
                 }
             }
         }
-        },
+    },
         "xyz.openbmc_project.ObjectMapper",
         "/xyz/openbmc_project/object_mapper",
         "xyz.openbmc_project.ObjectMapper", "GetObject", chassisPath,
@@ -264,7 +264,7 @@ inline void getChassisAssembly(const std::shared_ptr<bmcweb::AsyncResp>& aResp,
 
         BMCWEB_LOG_ERROR << "Chassis not found";
         messages::resourceNotFound(aResp->res, "Chassis", chassisID);
-        },
+    },
         "xyz.openbmc_project.ObjectMapper",
         "/xyz/openbmc_project/object_mapper",
         "xyz.openbmc_project.ObjectMapper", "GetSubTreePaths",

--- a/redfish-core/include/utils/collection.hpp
+++ b/redfish-core/include/utils/collection.hpp
@@ -82,7 +82,7 @@ inline void getCollectionMembersWithPathConversion(
             members.push_back(std::move(member));
         }
         aResp->res.jsonValue["Members@odata.count"] = members.size();
-        });
+    });
 }
 
 /**

--- a/redfish-core/include/utils/error_log_utils.hpp
+++ b/redfish-core/include/utils/error_log_utils.hpp
@@ -70,7 +70,7 @@ inline void
             errLogUri.append("/attachment");
             aResp->res.jsonValue[errorLogPropPath] = errLogUri;
         }
-        });
+    });
 }
 
 } // namespace error_log_utils

--- a/redfish-core/include/utils/get_chassis_names.hpp
+++ b/redfish-core/include/utils/get_chassis_names.hpp
@@ -46,7 +46,7 @@ inline void getChassisNames(F&& cb)
         }
 
         callback(ec, chassisNames);
-        },
+    },
         "xyz.openbmc_project.ObjectMapper",
         "/xyz/openbmc_project/object_mapper",
         "xyz.openbmc_project.ObjectMapper", "GetSubTreePaths",

--- a/redfish-core/include/utils/hex_utils.hpp
+++ b/redfish-core/include/utils/hex_utils.hpp
@@ -43,11 +43,11 @@ inline uint8_t hexCharToNibble(char ch)
     }
     else if (ch >= 'A' && ch <= 'F')
     {
-        rc = static_cast<uint8_t>(ch) - 'A' + 10;
+        rc = static_cast<uint8_t>(ch - 'A') + 10U;
     }
     else if (ch >= 'a' && ch <= 'f')
     {
-        rc = static_cast<uint8_t>(ch) - 'a' + 10;
+        rc = static_cast<uint8_t>(ch - 'a') + 10U;
     }
 
     return rc;

--- a/redfish-core/include/utils/hw_isolation.hpp
+++ b/redfish-core/include/utils/hw_isolation.hpp
@@ -70,7 +70,7 @@ inline void retChassisPowerStateOffRequiredError(
             aResp->res,
             sdbusplus::message::object_path(ancestors.begin()->first)
                 .filename());
-        },
+    },
         "xyz.openbmc_project.ObjectMapper",
         "/xyz/openbmc_project/object_mapper",
         "xyz.openbmc_project.ObjectMapper", "GetAncestors", resourceObjPath.str,
@@ -158,7 +158,7 @@ inline void
             messages::internalError(aResp->res);
         }
         return;
-        },
+    },
         hwIsolationDbusName, "/xyz/openbmc_project/hardware_isolation",
         "xyz.openbmc_project.HardwareIsolation.Create", "Create",
         resourceObjPath,
@@ -263,10 +263,10 @@ inline void
                 messages::internalError(aResp->res);
             }
             return;
-            },
+        },
             hwIsolationDbusName, resourceIsolatedHwEntry,
             "xyz.openbmc_project.Object.Delete", "Delete");
-        });
+    });
 }
 
 /**
@@ -381,14 +381,14 @@ inline void processHardwareIsolationReq(
             {
                 deisolateResource(aResp, resourceObjPath, objType[0].first);
             }
-            },
+        },
             "xyz.openbmc_project.ObjectMapper",
             "/xyz/openbmc_project/object_mapper",
             "xyz.openbmc_project.ObjectMapper", "GetObject",
             "/xyz/openbmc_project/hardware_isolation",
             std::array<const char*, 1>{
                 "xyz.openbmc_project.HardwareIsolation.Create"});
-        },
+    },
         "xyz.openbmc_project.ObjectMapper",
         "/xyz/openbmc_project/object_mapper",
         "xyz.openbmc_project.ObjectMapper", "GetSubTreePaths",
@@ -666,13 +666,13 @@ inline void
 
                 assembleEventProperties(aResp, properties, condition,
                                         hwStatusEventObj);
-                });
-            },
+            });
+        },
             "xyz.openbmc_project.ObjectMapper",
             "/xyz/openbmc_project/object_mapper",
             "xyz.openbmc_project.ObjectMapper", "GetObject", hwStatusEventObj,
             std::array<const char*, 1>{"xyz.openbmc_project.Logging.Event"});
-        });
+    });
 }
 
 } // namespace hw_isolation_utils

--- a/redfish-core/include/utils/json_utils.hpp
+++ b/redfish-core/include/utils/json_utils.hpp
@@ -466,9 +466,9 @@ inline bool readJsonHelper(nlohmann::json& jsonRequest, crow::Response& res,
                     std::remove_pointer_t<std::decay_t<decltype(val)>>;
                 return details::unpackValue<ContainedT>(
                     item.value(), unpackSpec.key, res, *val);
-                         },
+            },
                          unpackSpec.value) &&
-                result;
+                     result;
 
             unpackSpec.complete = true;
             break;
@@ -490,7 +490,7 @@ inline bool readJsonHelper(nlohmann::json& jsonRequest, crow::Response& res,
                 using ContainedType =
                     std::remove_pointer_t<std::decay_t<decltype(val)>>;
                 return details::IsOptional<ContainedType>::value;
-                },
+            },
                 perUnpack.value);
             if (isOptional)
             {

--- a/redfish-core/include/utils/name_utils.hpp
+++ b/redfish-core/include/utils/name_utils.hpp
@@ -44,7 +44,7 @@ inline void getPrettyName(const std::shared_ptr<bmcweb::AsyncResp>& asyncResp,
         BMCWEB_LOG_DEBUG << "Pretty Name: " << prettyName;
 
         asyncResp->res.jsonValue[namePath] = prettyName;
-        });
+    });
 }
 
 } // namespace name_util

--- a/redfish-core/include/utils/sw_utils.hpp
+++ b/redfish-core/include/utils/sw_utils.hpp
@@ -212,15 +212,15 @@ inline void
                     {
                         aResp->res.jsonValue[activeVersionPropName] = *version;
                     }
-                    });
+                });
             }
-            },
+        },
             "xyz.openbmc_project.ObjectMapper",
             "/xyz/openbmc_project/object_mapper",
             "xyz.openbmc_project.ObjectMapper", "GetSubTree",
             "/xyz/openbmc_project/software", static_cast<int32_t>(0),
             std::array<const char*, 1>{"xyz.openbmc_project.Software.Version"});
-        });
+    });
 }
 
 /**
@@ -331,7 +331,7 @@ inline void getSwStatus(const std::shared_ptr<bmcweb::AsyncResp>& asyncResp,
             getRedfishSwState(*swInvActivation);
         asyncResp->res.jsonValue["Status"]["Health"] =
             getRedfishSwHealth(*swInvActivation);
-        });
+    });
 }
 
 /**
@@ -370,7 +370,7 @@ inline void
             asyncResp->res.jsonValue["Updateable"] = true;
             return;
         }
-        });
+    });
 }
 
 } // namespace sw_util

--- a/redfish-core/include/utils/telemetry_utils.hpp
+++ b/redfish-core/include/utils/telemetry_utils.hpp
@@ -39,7 +39,7 @@ inline std::optional<IncorrectMetricUri> getChassisSensorNode(
     size_t uriIdx = 0;
     for (const std::string& uri : uris)
     {
-        boost::urls::result<boost::urls::url_view> parsed =
+        boost::system::result<boost::urls::url_view> parsed =
             boost::urls::parse_relative_ref(uri);
 
         if (!parsed)

--- a/redfish-core/lib/account_service.hpp
+++ b/redfish-core/lib/account_service.hpp
@@ -295,7 +295,7 @@ inline void translateAccountType(
         }
         messages::success(asyncResp->res);
         return;
-        },
+    },
         "xyz.openbmc_project.User.Manager", dbusObjectPath,
         "org.freedesktop.DBus.Properties", "Set",
         "xyz.openbmc_project.User.Attributes", "UserGroups",
@@ -413,7 +413,7 @@ inline void handleRoleMapPatch(
                     }
                     asyncResp->res.jsonValue[serverType]["RemoteRoleMapping"]
                                             [index] = nullptr;
-                    },
+                },
                     ldapDbusService, roleMapObjData[index].first,
                     "xyz.openbmc_project.Object.Delete", "Delete");
             }
@@ -491,7 +491,7 @@ inline void handleRoleMapPatch(
                         asyncResp->res
                             .jsonValue[serverType]["RemoteRoleMapping"][index]
                                       ["RemoteGroup"] = *remoteGroup;
-                        },
+                    },
                         ldapDbusService, roleMapObjData[index].first,
                         propertyInterface, "Set",
                         "xyz.openbmc_project.User.PrivilegeMapperEntry",
@@ -531,7 +531,7 @@ inline void handleRoleMapPatch(
                         asyncResp->res
                             .jsonValue[serverType]["RemoteRoleMapping"][index]
                                       ["LocalRole"] = *localRole;
-                        },
+                    },
                         ldapDbusService, roleMapObjData[index].first,
                         propertyInterface, "Set",
                         "xyz.openbmc_project.User.PrivilegeMapperEntry",
@@ -607,7 +607,7 @@ inline void handleRoleMapPatch(
                     roleMapEntry["LocalRole"] = *localRole;
                     roleMapEntry["RemoteGroup"] = *remoteGroup;
                     remoteRoleJson.push_back(std::move(roleMapEntry));
-                    },
+                },
                     ldapDbusService, dbusObjectPath, ldapPrivMapperInterface,
                     "Create", *remoteGroup,
                     getPrivilegeFromRoleId(std::move(*localRole)));
@@ -776,9 +776,9 @@ inline void getLDAPConfigData(const std::string& ldapType,
                 }
             }
             callback(true, confData, ldapType);
-            },
-            service, ldapRootObject, dbusObjManagerIntf, "GetManagedObjects");
         },
+            service, ldapRootObject, dbusObjManagerIntf, "GetManagedObjects");
+    },
         mapperBusName, mapperObjectPath, mapperIntf, "GetObject",
         ldapConfigObjectName, interfaces);
 }
@@ -899,7 +899,7 @@ inline void handleServiceAddressPatch(
                                             serviceAddressList.front());
         }
         BMCWEB_LOG_DEBUG << "Updated the service address";
-        },
+    },
         ldapDbusService, ldapConfigObject, propertyInterface, "Set",
         ldapConfigInterface, "LDAPServerURI",
         dbus::utility::DbusVariantType(serviceAddressList.front()));
@@ -931,7 +931,7 @@ inline void
         asyncResp->res.jsonValue[ldapServerElementName]["Authentication"]
                                 ["Username"] = username;
         BMCWEB_LOG_DEBUG << "Updated the username";
-        },
+    },
         ldapDbusService, ldapConfigObject, propertyInterface, "Set",
         ldapConfigInterface, "LDAPBindDN",
         dbus::utility::DbusVariantType(username));
@@ -963,7 +963,7 @@ inline void
         asyncResp->res.jsonValue[ldapServerElementName]["Authentication"]
                                 ["Password"] = "";
         BMCWEB_LOG_DEBUG << "Updated the password";
-        },
+    },
         ldapDbusService, ldapConfigObject, propertyInterface, "Set",
         ldapConfigInterface, "LDAPBindDNPassword",
         dbus::utility::DbusVariantType(password));
@@ -1020,7 +1020,7 @@ inline void
                 asyncResp->res, "BaseDistinguishedNames", baseDNList.front());
         }
         BMCWEB_LOG_DEBUG << "Updated the base DN";
-        },
+    },
         ldapDbusService, ldapConfigObject, propertyInterface, "Set",
         ldapConfigInterface, "LDAPBaseDN",
         dbus::utility::DbusVariantType(baseDNList.front()));
@@ -1055,7 +1055,7 @@ inline void
             serverTypeJson["LDAPService"]["SearchSettings"];
         searchSettingsJson["UsernameAttribute"] = userNameAttribute;
         BMCWEB_LOG_DEBUG << "Updated the user name attr.";
-        },
+    },
         ldapDbusService, ldapConfigObject, propertyInterface, "Set",
         ldapConfigInterface, "UserNameAttribute",
         dbus::utility::DbusVariantType(userNameAttribute));
@@ -1075,7 +1075,7 @@ inline void setPropertyAllowUnauthACFUpload(
             messages::internalError(asyncResp->res);
             return;
         }
-        });
+    });
 }
 
 inline void getAcfProperties(
@@ -1189,7 +1189,7 @@ inline void getAcfProperties(
         }
         asyncResp->res.jsonValue["Oem"]["IBM"]["ACF"]["AllowUnauthACFUpload"] =
             allowUnauthACFUpload;
-        });
+    });
 }
 
 /**
@@ -1222,7 +1222,7 @@ inline void handleGroupNameAttrPatch(
             serverTypeJson["LDAPService"]["SearchSettings"];
         searchSettingsJson["GroupsAttribute"] = groupsAttribute;
         BMCWEB_LOG_DEBUG << "Updated the groupname attr";
-        },
+    },
         ldapDbusService, ldapConfigObject, propertyInterface, "Set",
         ldapConfigInterface, "GroupNameAttribute",
         dbus::utility::DbusVariantType(groupsAttribute));
@@ -1253,7 +1253,7 @@ inline void handleServiceEnablePatch(
         asyncResp->res.jsonValue[ldapServerElementName]["ServiceEnabled"] =
             serviceEnabled;
         BMCWEB_LOG_DEBUG << "Updated Service enable = " << serviceEnabled;
-        },
+    },
         ldapDbusService, ldapConfigObject, propertyInterface, "Set",
         ldapEnableInterface, "Enabled",
         dbus::utility::DbusVariantType(serviceEnabled));
@@ -1511,7 +1511,7 @@ inline void handleLDAPPatch(nlohmann::json& input,
             handleRoleMapPatch(asyncResp, confData.groupRoleList, serverT,
                                *remoteRoleMapData);
         }
-        });
+    });
 }
 
 inline void updateUserProperties(
@@ -1576,7 +1576,7 @@ inline void updateUserProperties(
                 }
                 messages::success(asyncResp->res);
                 return;
-                },
+            },
                 "xyz.openbmc_project.User.Manager", dbusObjectPath,
                 "org.freedesktop.DBus.Properties", "Set",
                 "xyz.openbmc_project.User.Attributes", "UserEnabled",
@@ -1602,7 +1602,7 @@ inline void updateUserProperties(
                     return;
                 }
                 messages::success(asyncResp->res);
-                },
+            },
                 "xyz.openbmc_project.User.Manager", dbusObjectPath,
                 "org.freedesktop.DBus.Properties", "Set",
                 "xyz.openbmc_project.User.Attributes", "UserPrivilege",
@@ -1631,7 +1631,7 @@ inline void updateUserProperties(
                 }
                 messages::success(asyncResp->res);
                 return;
-                },
+            },
                 "xyz.openbmc_project.User.Manager", dbusObjectPath,
                 "org.freedesktop.DBus.Properties", "Set",
                 "xyz.openbmc_project.User.Attributes",
@@ -1643,7 +1643,7 @@ inline void updateUserProperties(
             translateAccountType(accountType, asyncResp, dbusObjectPath,
                                  isUserItself);
         }
-        });
+    });
 }
 
 inline void uploadACF(const std::shared_ptr<bmcweb::AsyncResp>& asyncResp,
@@ -1672,7 +1672,7 @@ inline void uploadACF(const std::shared_ptr<bmcweb::AsyncResp>& asyncResp,
             return;
         }
         getAcfProperties(asyncResp, messageFDbus);
-        },
+    },
         "xyz.openbmc_project.Certs.ACF."
         "Manager",
         "/xyz/openbmc_project/certs/ACF", "xyz.openbmc_project.Certs.ACF",
@@ -1790,8 +1790,8 @@ inline void triggerUnauthenticatedACFUpload(
             BMCWEB_LOG_ERROR << "ACF upload not allowed";
             messages::insufficientPrivilege(asyncResp->res);
             return;
-            });
         });
+    });
 }
 
 inline void handleAccountServiceHead(
@@ -1896,7 +1896,7 @@ inline void
             asyncResp->res.jsonValue["AccountLockoutThreshold"] =
                 *maxLoginAttemptBeforeLockout;
         }
-        });
+    });
 
     auto callback = [asyncResp](bool success, const LDAPConfigData& confData,
                                 const std::string& ldapType) {
@@ -1947,7 +1947,7 @@ inline void handleAccountServicePatch(
                 return;
             }
             messages::success(asyncResp->res);
-            },
+        },
             "xyz.openbmc_project.User.Manager", "/xyz/openbmc_project/user",
             "org.freedesktop.DBus.Properties", "Set",
             "xyz.openbmc_project.User.AccountPolicy", "MinPasswordLength",
@@ -1995,7 +1995,7 @@ inline void handleAccountServicePatch(
                 return;
             }
             messages::success(asyncResp->res);
-            },
+        },
             "xyz.openbmc_project.User.Manager", "/xyz/openbmc_project/user",
             "org.freedesktop.DBus.Properties", "Set",
             "xyz.openbmc_project.User.AccountPolicy", "AccountUnlockTimeout",
@@ -2011,7 +2011,7 @@ inline void handleAccountServicePatch(
                 return;
             }
             messages::success(asyncResp->res);
-            },
+        },
             "xyz.openbmc_project.User.Manager", "/xyz/openbmc_project/user",
             "org.freedesktop.DBus.Properties", "Set",
             "xyz.openbmc_project.User.AccountPolicy",
@@ -2098,7 +2098,7 @@ inline void handleAccountCollectionGet(
             }
         }
         asyncResp->res.jsonValue["Members@odata.count"] = memberArray.size();
-        },
+    },
         "xyz.openbmc_project.User.Manager", "/xyz/openbmc_project/user",
         "org.freedesktop.DBus.ObjectManager", "GetManagedObjects");
 }
@@ -2204,7 +2204,7 @@ inline void handleAccountCollectionPost(
                     // If password is invalid
                     messages::propertyValueFormatError(asyncResp->res, password,
                                                        "Password");
-                    },
+                },
                     "xyz.openbmc_project.User.Manager", userPath,
                     "xyz.openbmc_project.Object.Delete", "Delete");
 
@@ -2215,11 +2215,11 @@ inline void handleAccountCollectionPost(
             messages::created(asyncResp->res);
             asyncResp->res.addHeader(
                 "Location", "/redfish/v1/AccountService/Accounts/" + username);
-            },
+        },
             "xyz.openbmc_project.User.Manager", "/xyz/openbmc_project/user",
             "xyz.openbmc_project.User.Manager", "CreateUser", username,
             *pModGroupsList, *roleId, *enabled);
-        });
+    });
 }
 
 inline void
@@ -2286,7 +2286,7 @@ inline void
                 const std::pair<sdbusplus::message::object_path,
                                 dbus::utility::DBusInteracesMap>& user) {
             return accountName == user.first.filename();
-            });
+        });
 
         if (userIt == users.end())
         {
@@ -2408,12 +2408,12 @@ inline void
                     return;
                 }
                 getAcfProperties(asyncResp, messageFDbus);
-                },
+            },
                 "xyz.openbmc_project.Certs.ACF.Manager",
                 "/xyz/openbmc_project/certs/ACF",
                 "xyz.openbmc_project.Certs.ACF", "GetACFInfo");
         }
-        },
+    },
         "xyz.openbmc_project.User.Manager", "/xyz/openbmc_project/user",
         "org.freedesktop.DBus.ObjectManager", "GetManagedObjects");
 }
@@ -2458,7 +2458,7 @@ inline void
         }
 
         messages::accountRemoved(asyncResp->res);
-        },
+    },
         "xyz.openbmc_project.User.Manager", userPath,
         "xyz.openbmc_project.Object.Delete", "Delete");
 }
@@ -2667,7 +2667,7 @@ inline void
 
         updateUserProperties(asyncResp, newUser, password, enabled, roleId,
                              locked, accountType, isUserItself);
-        },
+    },
         "xyz.openbmc_project.User.Manager", "/xyz/openbmc_project/user",
         "xyz.openbmc_project.User.Manager", "RenameUser", username,
         *newUserName);

--- a/redfish-core/lib/assembly.hpp
+++ b/redfish-core/lib/assembly.hpp
@@ -137,7 +137,7 @@ inline void
 
                 assemblyArray.at(
                     assemblyIndex)["Oem"]["OpenBMC"]["ReadyToRemove"] = false;
-                },
+            },
                 "xyz.openbmc_project.ObjectMapper",
                 "/xyz/openbmc_project/object_mapper",
                 "xyz.openbmc_project.ObjectMapper", "GetObject",
@@ -190,7 +190,7 @@ inline void
 
                             assembleAssemblyProperties(aResp, properties,
                                                        assemblyData, assembly);
-                            });
+                        });
                     }
                     else if (interface == "xyz.openbmc_project.Inventory."
                                           "Decorator.LocationCode")
@@ -215,7 +215,7 @@ inline void
 
                             assemblyData["Location"]["PartLocation"]
                                         ["ServiceLabel"] = property;
-                            });
+                        });
                     }
                     else if (interface == "xyz.openbmc_project.State."
                                           "Decorator.OperationalStatus")
@@ -249,7 +249,7 @@ inline void
                             {
                                 assemblyData["Status"]["Health"] = "OK";
                             }
-                            });
+                        });
                     }
                     else if (interface == "xyz.openbmc_project.Inventory.Item")
                     {
@@ -308,7 +308,7 @@ inline void
                             {
                                 assemblyData["Status"]["State"] = "Enabled";
                             }
-                            });
+                        });
                     }
                 }
             }
@@ -316,7 +316,7 @@ inline void
             nlohmann::json& assemblyArray = aResp->res.jsonValue["Assemblies"];
             nlohmann::json& assemblyData = assemblyArray.at(assemblyIndex);
             getLocationIndicatorActive(aResp, assembly, assemblyData);
-            },
+        },
             "xyz.openbmc_project.ObjectMapper",
             "/xyz/openbmc_project/object_mapper",
             "xyz.openbmc_project.ObjectMapper", "GetObject", assembly,
@@ -345,7 +345,7 @@ static void
             return;
         }
         messages::success(asyncResp->res);
-        },
+    },
         "org.freedesktop.systemd1", "/org/freedesktop/systemd1",
         "org.freedesktop.systemd1.Manager", method,
         "xyz.openbmc_project.adcsensor.service", "replace");
@@ -395,7 +395,7 @@ static void doBatteryCM(const std::string& assembly, const bool readyToRemove,
                     return;
                 }
                 startOrStopADCSensor(true, asyncResp);
-                },
+            },
                 serviceName, assembly, "org.freedesktop.DBus.Properties", "Set",
                 "xyz.openbmc_project.State.Decorator."
                 "OperationalStatus",
@@ -405,7 +405,7 @@ static void doBatteryCM(const std::string& assembly, const bool readyToRemove,
 
         BMCWEB_LOG_ERROR << "No OperationalStatus interface on " << assembly;
         messages::internalError(asyncResp->res);
-        },
+    },
         "xyz.openbmc_project.ObjectMapper",
         "/xyz/openbmc_project/object_mapper",
         "xyz.openbmc_project.ObjectMapper", "GetObject", assembly,
@@ -589,7 +589,7 @@ inline void setAssemblylocationIndicators(
                         messages::internalError(asyncResp->res);
                         return;
                     }
-                    },
+                },
                     "com.ibm.VPD.Manager", "/com/ibm/VPD/Manager",
                     "com.ibm.VPD.Manager", action,
                     sdbusplus::message::object_path(assembly));
@@ -676,7 +676,7 @@ inline void checkAssemblyInterface(
                 getAssemblyProperties(aResp, chassisPath, updatedAssemblyList);
             }
         }
-        },
+    },
         "xyz.openbmc_project.ObjectMapper",
         "/xyz/openbmc_project/object_mapper",
         "xyz.openbmc_project.ObjectMapper", "GetSubTree",
@@ -709,21 +709,21 @@ inline void
         assemblyPath, [aResp, chassisPath, setLocationIndicatorActiveFlag,
                        req](const boost::system::error_code ec,
                             const dbus::utility::MapperEndPoints& endpoints) {
-            if (ec)
-            {
-                BMCWEB_LOG_DEBUG << "DBUS response "
-                                    "error";
-                messages::internalError(aResp->res);
-                return;
-            }
-
-            dbus::utility::MapperEndPoints sortedAssemblyList = endpoints;
-            std::sort(sortedAssemblyList.begin(), sortedAssemblyList.end());
-
-            checkAssemblyInterface(aResp, chassisPath, sortedAssemblyList,
-                                   setLocationIndicatorActiveFlag, req);
+        if (ec)
+        {
+            BMCWEB_LOG_DEBUG << "DBUS response "
+                                "error";
+            messages::internalError(aResp->res);
             return;
-        });
+        }
+
+        dbus::utility::MapperEndPoints sortedAssemblyList = endpoints;
+        std::sort(sortedAssemblyList.begin(), sortedAssemblyList.end());
+
+        checkAssemblyInterface(aResp, chassisPath, sortedAssemblyList,
+                               setLocationIndicatorActiveFlag, req);
+        return;
+    });
 }
 
 /**
@@ -773,7 +773,7 @@ inline void checkForAssemblyAssociations(
             getAssemblyEndpoints(aResp, chassisPath,
                                  setLocationIndicatorActiveFlag, req);
         }
-        });
+    });
 }
 
 /**
@@ -835,7 +835,7 @@ inline void checkAssociation(const std::shared_ptr<bmcweb::AsyncResp>& aResp,
             }
         }
         return;
-        },
+    },
         "xyz.openbmc_project.ObjectMapper",
         "/xyz/openbmc_project/object_mapper",
         "xyz.openbmc_project.ObjectMapper", "GetObject", chassisPath,
@@ -900,7 +900,7 @@ inline void getChassis(const std::shared_ptr<bmcweb::AsyncResp>& aResp,
 
         BMCWEB_LOG_ERROR << "Chassis not found";
         messages::resourceNotFound(aResp->res, "Chassis", chassisID);
-        },
+    },
         "xyz.openbmc_project.ObjectMapper",
         "/xyz/openbmc_project/object_mapper",
         "xyz.openbmc_project.ObjectMapper", "GetSubTreePaths",
@@ -1095,13 +1095,13 @@ inline void fillWithAssemblyId(
                                  std::to_string(assembledObjectId));
 
             aResp->res.jsonValue[assemblyUriPropPath] = uriValwithId;
-            },
+        },
             "xyz.openbmc_project.ObjectMapper",
             "/xyz/openbmc_project/object_mapper",
             "xyz.openbmc_project.ObjectMapper", "GetSubTree",
             "/xyz/openbmc_project/inventory", int32_t(0),
             chassisAssemblyIfaces);
-        });
+    });
 }
 
 } // namespace assembly
@@ -1125,7 +1125,7 @@ inline void requestRoutesAssembly(App& app)
         BMCWEB_LOG_DEBUG << "chassis =" << chassisId;
         assembly::getChassis(asyncResp, chassisId,
                              setLocationIndicatorActiveFlag, req);
-        });
+    });
 
     BMCWEB_ROUTE(app, "/redfish/v1/Chassis/<str>/Assembly/")
         .privileges({{"ConfigureComponents"}})
@@ -1138,6 +1138,6 @@ inline void requestRoutesAssembly(App& app)
         BMCWEB_LOG_DEBUG << "Chassis = " << chassisID;
         assembly::getChassis(asyncResp, chassisID,
                              setLocationIndicatorActiveFlag, req);
-        });
+    });
 }
 } // namespace redfish

--- a/redfish-core/lib/bios.hpp
+++ b/redfish-core/lib/bios.hpp
@@ -232,11 +232,11 @@ inline void
                     messages::internalError(asyncResp->res);
                 }
             }
-            },
+        },
             service, "/xyz/openbmc_project/bios_config/manager",
             "org.freedesktop.DBus.Properties", "Get",
             "xyz.openbmc_project.BIOSConfig.Manager", "BaseBIOSTable");
-        },
+    },
         "xyz.openbmc_project.ObjectMapper",
         "/xyz/openbmc_project/object_mapper",
         "xyz.openbmc_project.ObjectMapper", "GetObject",
@@ -344,17 +344,17 @@ inline void requestRoutesBiosSettings(App& app)
                         messages::internalError(asyncResp->res);
                     }
                 }
-                },
+            },
                 service, "/xyz/openbmc_project/bios_config/manager",
                 "org.freedesktop.DBus.Properties", "Get",
                 "xyz.openbmc_project.BIOSConfig.Manager", "PendingAttributes");
-            },
+        },
             "xyz.openbmc_project.ObjectMapper",
             "/xyz/openbmc_project/object_mapper",
             "xyz.openbmc_project.ObjectMapper", "GetObject",
             "/xyz/openbmc_project/bios_config/manager",
             std::array<const char*, 0>());
-        });
+    });
 
     BMCWEB_ROUTE(app, "/redfish/v1/Systems/<str>/Bios/Settings")
         .privileges({{"ConfigureManager"}})
@@ -661,18 +661,18 @@ inline void requestRoutesBiosSettings(App& app)
                     messages::internalError(asyncResp->res);
                     return;
                 }
-                },
+            },
                 "xyz.openbmc_project.BIOSConfigManager",
                 "/xyz/openbmc_project/bios_config/manager",
                 "org.freedesktop.DBus.Properties", "Set",
                 "xyz.openbmc_project.BIOSConfig.Manager", "PendingAttributes",
                 std::variant<PendingAttributesType>(pendingAttributes));
-            },
+        },
             "xyz.openbmc_project.BIOSConfigManager",
             "/xyz/openbmc_project/bios_config/manager",
             "org.freedesktop.DBus.Properties", "Get",
             "xyz.openbmc_project.BIOSConfig.Manager", "BaseBIOSTable");
-        });
+    });
 }
 
 /**
@@ -843,17 +843,17 @@ inline void requestRoutesBiosAttributeRegistry(App& app)
                     }
                     attributeArray.push_back(attributeItem);
                 }
-                },
+            },
                 service, "/xyz/openbmc_project/bios_config/manager",
                 "org.freedesktop.DBus.Properties", "Get",
                 "xyz.openbmc_project.BIOSConfig.Manager", "BaseBIOSTable");
-            },
+        },
             "xyz.openbmc_project.ObjectMapper",
             "/xyz/openbmc_project/object_mapper",
             "xyz.openbmc_project.ObjectMapper", "GetObject",
             "/xyz/openbmc_project/bios_config/manager",
             std::array<const char*, 0>());
-        });
+    });
 }
 
 /**
@@ -888,7 +888,7 @@ inline void
             messages::internalError(asyncResp->res);
             return;
         }
-        },
+    },
         "org.open_power.Software.Host.Updater", "/xyz/openbmc_project/software",
         "xyz.openbmc_project.Common.FactoryReset", "Reset");
 }

--- a/redfish-core/lib/cable.hpp
+++ b/redfish-core/lib/cable.hpp
@@ -53,7 +53,7 @@ inline void
             return;
         }
         callback(endpoints);
-        });
+    });
 }
 
 /**
@@ -333,7 +333,7 @@ inline void
                     const boost::system::error_code ec,
                     const dbus::utility::DBusPropertiesMap& properties) {
                 fillCableProperties(asyncResp->res, ec, properties);
-                });
+            });
 
             sdbusplus::asio::getProperty<std::string>(
                 *crow::connections::systemBus, service, cableObjectPath,
@@ -353,7 +353,7 @@ inline void
                     return;
                 }
                 asyncResp->res.jsonValue["PartNumber"] = property;
-                });
+            });
         }
     }
 }
@@ -412,8 +412,8 @@ inline void requestRoutesCable(App& app)
                 return;
             }
             messages::resourceNotFound(asyncResp->res, "Cable", cableId);
-            });
         });
+    });
 }
 
 /**
@@ -439,7 +439,7 @@ inline void requestRoutesCableCollection(App& app)
             "xyz.openbmc_project.Inventory.Item.Cable"};
         collection_util::getCollectionMembers(
             asyncResp, boost::urls::url("/redfish/v1/Cables"), interfaces);
-        });
+    });
 }
 
 } // namespace redfish

--- a/redfish-core/lib/certificate_service.hpp
+++ b/redfish-core/lib/certificate_service.hpp
@@ -270,7 +270,7 @@ static void
         }
 
         asyncResp->res.jsonValue[countPtr] = links.size();
-        },
+    },
         "xyz.openbmc_project.ObjectMapper",
         "/xyz/openbmc_project/object_mapper",
         "xyz.openbmc_project.ObjectMapper", "GetSubTreePaths", basePath, 0,
@@ -373,7 +373,7 @@ static void getCertificateProperties(
         asyncResp->res.addHeader(
             boost::beast::http::field::location,
             std::string_view(certURL.data(), certURL.size()));
-        });
+    });
 }
 
 static void
@@ -391,7 +391,7 @@ static void
         }
         BMCWEB_LOG_INFO << "Certificate deleted";
         asyncResp->res.result(boost::beast::http::status::no_content);
-        },
+    },
         service, objectPath, certs::objDeleteIntf, "Delete");
 }
 
@@ -567,7 +567,7 @@ inline void handleReplaceCertificateAction(
         getCertificateProperties(asyncResp, objectPath, service, id, url, name);
         BMCWEB_LOG_DEBUG << "HTTPS certificate install file="
                          << certFile->getCertFilePath();
-        },
+    },
         service, objectPath, certs::certReplaceIntf, "Replace",
         certFile->getCertFilePath());
 }
@@ -609,7 +609,7 @@ static void getCSR(const std::shared_ptr<bmcweb::AsyncResp>& asyncResp,
         asyncResp->res.jsonValue["CSRString"] = csr;
         asyncResp->res.jsonValue["CertificateCollection"]["@odata.id"] =
             certURI;
-        },
+    },
         service, csrObjPath, "xyz.openbmc_project.Certs.CSR", "CSR");
 }
 
@@ -828,7 +828,7 @@ inline void
                 break;
             }
         }
-        });
+    });
     crow::connections::systemBus->async_method_call(
         [asyncResp](const boost::system::error_code ec, const std::string&) {
         if (ec)
@@ -837,7 +837,7 @@ inline void
             messages::internalError(asyncResp->res);
             return;
         }
-        },
+    },
         service, objectPath, "xyz.openbmc_project.Certs.CSR.Create",
         "GenerateCSR", *optAlternativeNames, *optChallengePassword, city,
         commonName, *optContactPerson, country, *optEmail, *optGivenName,
@@ -939,7 +939,7 @@ inline void handleHTTPSCertificateCollectionPost(
                                  certId, certURL, "HTTPS Certificate");
         BMCWEB_LOG_DEBUG << "HTTPS certificate install file="
                          << certFile->getCertFilePath();
-        },
+    },
         certs::httpsServiceName, certs::httpsObjectPath, certs::certInstallIntf,
         "Install", certFile->getCertFilePath());
 }
@@ -1045,7 +1045,7 @@ inline void handleLDAPCertificateCollectionPost(
                                  certId, certURL, "LDAP Certificate");
         BMCWEB_LOG_DEBUG << "LDAP certificate install file="
                          << certFile->getCertFilePath();
-        },
+    },
         certs::ldapServiceName, certs::ldapObjectPath, certs::certInstallIntf,
         "Install", certFile->getCertFilePath());
 }
@@ -1168,7 +1168,7 @@ inline void handleTrustStoreCertificateCollectionPost(
                                  "TrustStore Certificate");
         BMCWEB_LOG_DEBUG << "TrustStore certificate install file="
                          << certFile->getCertFilePath();
-        },
+    },
         certs::authorityServiceName, certs::authorityObjectPath,
         certs::certInstallIntf, "Install", certFile->getCertFilePath());
 }

--- a/redfish-core/lib/certificate_service.hpp
+++ b/redfish-core/lib/certificate_service.hpp
@@ -500,7 +500,7 @@ inline void handleReplaceCertificateAction(
     }
     BMCWEB_LOG_INFO << "Certificate URI to replace: " << certURI;
 
-    boost::urls::result<boost::urls::url> parsedUrl =
+    boost::system::result<boost::urls::url> parsedUrl =
         boost::urls::parse_relative_ref(certURI);
     if (!parsedUrl)
     {

--- a/redfish-core/lib/chassis.hpp
+++ b/redfish-core/lib/chassis.hpp
@@ -76,7 +76,7 @@ inline void getChassisState(std::shared_ptr<bmcweb::AsyncResp> aResp)
             aResp->res.jsonValue["PowerState"] = "Off";
             aResp->res.jsonValue["Status"]["State"] = "StandbyOffline";
         }
-        });
+    });
 }
 
 inline void getIntrusionByService(std::shared_ptr<bmcweb::AsyncResp> aResp,
@@ -100,7 +100,7 @@ inline void getIntrusionByService(std::shared_ptr<bmcweb::AsyncResp> aResp,
 
         aResp->res.jsonValue["PhysicalSecurity"]["IntrusionSensorNumber"] = 1;
         aResp->res.jsonValue["PhysicalSecurity"]["IntrusionSensor"] = value;
-        });
+    });
 }
 
 /**
@@ -128,7 +128,7 @@ inline void getPhysicalSecurityData(std::shared_ptr<bmcweb::AsyncResp> aResp)
                 return;
             }
         }
-        },
+    },
         "xyz.openbmc_project.ObjectMapper",
         "/xyz/openbmc_project/object_mapper",
         "xyz.openbmc_project.ObjectMapper", "GetSubTree",
@@ -186,7 +186,7 @@ inline void
 
         asyncResp->res.jsonValue["Location"]["PartLocation"]["ServiceLabel"] =
             property;
-        });
+    });
 }
 
 inline void getChassisUUID(const std::shared_ptr<bmcweb::AsyncResp>& asyncResp,
@@ -205,7 +205,7 @@ inline void getChassisUUID(const std::shared_ptr<bmcweb::AsyncResp>& asyncResp,
             return;
         }
         asyncResp->res.jsonValue["UUID"] = chassisUUID;
-        });
+    });
 }
 
 inline void
@@ -298,12 +298,12 @@ inline void
                     }
                     health->inventory.insert(health->inventory.end(),
                                              resp2.begin(), resp2.end());
-                    },
+                },
                     "xyz.openbmc_project.ObjectMapper",
                     "/xyz/openbmc_project/object_mapper",
                     "xyz.openbmc_project.ObjectMapper", "GetSubTreePaths", "/",
                     int32_t(0), inventoryForChassis);
-                });
+            });
 
             health->populate();
 
@@ -344,7 +344,7 @@ inline void
                 reference["@odata.id"] = crow::utility::urlFromPieces(
                     "redfish", "v1", "Chassis", chassisId, "Drives");
                 asyncResp->res.jsonValue["Drives"] = std::move(reference);
-                });
+            });
 
             const std::string& connectionName = connectionNames[0].first;
 
@@ -373,7 +373,7 @@ inline void
                         return;
                     }
                     asyncResp->res.jsonValue["AssetTag"] = property;
-                    });
+                });
             }
 
             for (const char* interface : hasIndicatorLed)
@@ -408,7 +408,7 @@ inline void
                         "#OemChassis.v1_0_0.Chassis";
                     asyncResp->res.jsonValue["Oem"]["OpenBMC"]
                                             ["FirmwareVersion"] = property;
-                    });
+                });
             }
 
             sdbusplus::asio::getAllProperties(
@@ -506,7 +506,7 @@ inline void
                 asyncResp->res.jsonValue["Links"]["ManagedBy"] =
                     std::move(managedBy);
                 getChassisState(asyncResp);
-                });
+            });
 
             for (const auto& interface : interfaces2)
             {
@@ -526,7 +526,7 @@ inline void
 
         // Couldn't find an object with that name.  return an error
         messages::resourceNotFound(asyncResp->res, "Chassis", chassisId);
-        },
+    },
         "xyz.openbmc_project.ObjectMapper",
         "/xyz/openbmc_project/object_mapper",
         "xyz.openbmc_project.ObjectMapper", "GetSubTree",
@@ -654,7 +654,7 @@ inline void
         }
 
         messages::resourceNotFound(asyncResp->res, "Chassis", chassisId);
-        },
+    },
         "xyz.openbmc_project.ObjectMapper",
         "/xyz/openbmc_project/object_mapper",
         "xyz.openbmc_project.ObjectMapper", "GetSubTree",
@@ -760,11 +760,11 @@ inline void
             }
 
             messages::success(asyncResp->res);
-            },
+        },
             processName, objectPath, "org.freedesktop.DBus.Properties", "Set",
             interfaceName, destProperty,
             dbus::utility::DbusVariantType{propertyValue});
-        },
+    },
         busName, path, interface, method, "/", 0, interfaces);
 }
 

--- a/redfish-core/lib/environment_metrics.hpp
+++ b/redfish-core/lib/environment_metrics.hpp
@@ -60,7 +60,7 @@ inline void getFanSensors(const std::shared_ptr<bmcweb::AsyncResp>& asyncResp,
         }
 
         updateFanSensorList(asyncResp, chassisId, path, value);
-        });
+    });
 }
 
 inline void
@@ -81,7 +81,7 @@ inline void
 
         getFanSensors(asyncResp, chassisId, object.begin()->first,
                       fanSensorPath);
-        });
+    });
 }
 
 inline void
@@ -123,9 +123,9 @@ inline void
                 {
                     getFanSensorPaths(asyncResp, sensorsEndpoint, chassisId);
                 }
-                });
+            });
         }
-        });
+    });
 }
 
 inline void handleEnvironmentMetricsHead(
@@ -222,9 +222,9 @@ inline void getPowerWatts(const std::shared_ptr<bmcweb::AsyncResp>& asyncResp,
                                                  chassisId, "Sensors",
                                                  "total_power");
                 asyncResp->res.jsonValue["PowerWatts"]["Reading"] = value;
-                });
             });
         });
+    });
 }
 
 inline void
@@ -287,7 +287,7 @@ inline void
             asyncResp->res.jsonValue["PowerLimitWatts"]["AllowableMax"] =
                 *maxCap;
         }
-        });
+    });
 }
 
 inline void handleEnvironmentMetricsGet(
@@ -346,7 +346,7 @@ inline void
             }
             return;
         }
-        });
+    });
 }
 
 inline void
@@ -377,15 +377,15 @@ inline void
         "/xyz/openbmc_project/control/host0/power_cap",
         "xyz.openbmc_project.Control.Power.Cap", "PowerCapEnable",
         powerCapEnable, [asyncResp](const boost::system::error_code& ec) {
-            if (ec)
+        if (ec)
+        {
+            if (ec.value() != EBADR)
             {
-                if (ec.value() != EBADR)
-                {
-                    messages::internalError(asyncResp->res);
-                }
-                return;
+                messages::internalError(asyncResp->res);
             }
-        });
+            return;
+        }
+    });
 }
 
 inline void handleEnvironmentMetricsPatch(
@@ -437,7 +437,7 @@ inline void handleEnvironmentMetricsPatch(
         {
             setPowerControlMode(asyncResp, *controlMode);
         }
-        });
+    });
 }
 
 inline void requestRoutesEnvironmentMetrics(App& app)

--- a/redfish-core/lib/ethernet.hpp
+++ b/redfish-core/lib/ethernet.hpp
@@ -761,7 +761,7 @@ inline void deleteIPv4(const std::string& ifaceId, const std::string& ipHash,
         {
             messages::internalError(asyncResp->res);
         }
-        },
+    },
         "xyz.openbmc_project.Network",
         "/xyz/openbmc_project/network/" + ifaceId + ipHash,
         "xyz.openbmc_project.Object.Delete", "Delete");
@@ -779,7 +779,7 @@ inline void updateIPv4DefaultGateway(
             return;
         }
         asyncResp->res.result(boost::beast::http::status::no_content);
-        },
+    },
         "xyz.openbmc_project.Network",
         "/xyz/openbmc_project/network/" + ifaceId,
         "org.freedesktop.DBus.Properties", "Set",
@@ -801,8 +801,8 @@ inline void createIPv4(const std::string& ifaceId, uint8_t prefixLength,
                        const std::string& gateway, const std::string& address,
                        const std::shared_ptr<bmcweb::AsyncResp>& asyncResp)
 {
-    auto createIpHandler =
-        [asyncResp, ifaceId, gateway](const boost::system::error_code ec) {
+    auto createIpHandler = [asyncResp, ifaceId,
+                            gateway](const boost::system::error_code ec) {
         if (ec)
         {
             messages::internalError(asyncResp->res);
@@ -855,13 +855,13 @@ inline void
                 return;
             }
             updateIPv4DefaultGateway(ifaceId, gateway, asyncResp);
-            },
+        },
             "xyz.openbmc_project.Network",
             "/xyz/openbmc_project/network/" + ifaceId,
             "xyz.openbmc_project.Network.IP.Create", "IP",
             "xyz.openbmc_project.Network.IP.Protocol.IPv4", address,
             prefixLength, gateway);
-        },
+    },
         "xyz.openbmc_project.Network",
         "/xyz/openbmc_project/network/" + ifaceId + id,
         "xyz.openbmc_project.Object.Delete", "Delete");
@@ -885,7 +885,7 @@ inline void deleteIPv6(const std::string& ifaceId, const std::string& ipHash,
         {
             messages::internalError(asyncResp->res);
         }
-        },
+    },
         "xyz.openbmc_project.Network",
         "/xyz/openbmc_project/network/" + ifaceId + ipHash,
         "xyz.openbmc_project.Object.Delete", "Delete");
@@ -921,13 +921,13 @@ inline void
             {
                 messages::internalError(asyncResp->res);
             }
-            },
+        },
             "xyz.openbmc_project.Network",
             "/xyz/openbmc_project/network/" + ifaceId,
             "xyz.openbmc_project.Network.IP.Create", "IP",
             "xyz.openbmc_project.Network.IP.Protocol.IPv6", address,
             prefixLength, "");
-        },
+    },
         "xyz.openbmc_project.Network",
         "/xyz/openbmc_project/network/" + ifaceId + id,
         "xyz.openbmc_project.Object.Delete", "Delete");
@@ -947,8 +947,8 @@ inline void createIPv6(const std::string& ifaceId, uint8_t prefixLength,
                        const std::string& address,
                        const std::shared_ptr<bmcweb::AsyncResp>& asyncResp)
 {
-    auto createIpHandler =
-        [asyncResp, address](const boost::system::error_code& ec) {
+    auto createIpHandler = [asyncResp,
+                            address](const boost::system::error_code& ec) {
         if (ec)
         {
             if (ec == boost::system::errc::io_error)
@@ -991,7 +991,7 @@ inline void
         {
             messages::internalError(asyncResp->res);
         }
-        },
+    },
         "xyz.openbmc_project.Network",
         "/xyz/openbmc_project/network/" + ifaceId + ipHash,
         "xyz.openbmc_project.Object.Delete", "Delete");
@@ -1027,13 +1027,13 @@ inline void deleteAndCreateIPv6DefaultGateway(
             {
                 messages::internalError(asyncResp->res);
             }
-            },
+        },
             "xyz.openbmc_project.Network",
             "/xyz/openbmc_project/network/" + ifaceId,
             "xyz.openbmc_project.Network.StaticRoute.Create", "StaticRoute",
             "0:0:0:0:0:0:0:0", gateway, prefixLength,
             "xyz.openbmc_project.Network.IP.Protocol.IPv6");
-        },
+    },
         "xyz.openbmc_project.Network",
         +"/xyz/openbmc_project/network/" + ifaceId + id,
         "xyz.openbmc_project.Object.Delete", "Delete");
@@ -1235,7 +1235,7 @@ void getEthernetIfaceData(const std::string& ethifaceId,
         extractIPv6DefaultGatewayData(ethifaceId, resp, ipv6GatewayData);
         // Finally make a callback with useful data
         callback(true, ethData, ipv4Data, ipv6Data, ipv6GatewayData);
-        },
+    },
         "xyz.openbmc_project.Network", "/xyz/openbmc_project/network",
         "org.freedesktop.DBus.ObjectManager", "GetManagedObjects");
 }
@@ -1287,7 +1287,7 @@ void getEthernetIfaceList(CallbackFunc&& callback)
         }
         // Finally make a callback with useful data
         callback(true, ifaceList);
-        },
+    },
         "xyz.openbmc_project.Network", "/xyz/openbmc_project/network",
         "org.freedesktop.DBus.ObjectManager", "GetManagedObjects");
 }
@@ -1309,7 +1309,7 @@ inline void
         {
             messages::internalError(asyncResp->res);
         }
-        },
+    },
         "xyz.openbmc_project.Network", "/xyz/openbmc_project/network/config",
         "org.freedesktop.DBus.Properties", "Set",
         "xyz.openbmc_project.Network.SystemConfiguration", "HostName",
@@ -1328,7 +1328,7 @@ inline void
         {
             messages::internalError(asyncResp->res);
         }
-        },
+    },
         "xyz.openbmc_project.Network", objPath,
         "org.freedesktop.DBus.Properties", "Set",
         "xyz.openbmc_project.Network.EthernetInterface", "MTU",
@@ -1347,7 +1347,7 @@ inline void
         {
             messages::internalError(asyncResp->res);
         }
-        },
+    },
         "xyz.openbmc_project.Network",
         "/xyz/openbmc_project/network/" + ifaceId,
         "org.freedesktop.DBus.Properties", "Set",
@@ -1441,7 +1441,7 @@ inline void
             messages::internalError(asyncResp->res);
             return;
         }
-        },
+    },
         "xyz.openbmc_project.Network",
         "/xyz/openbmc_project/network/" + ifaceId,
         "org.freedesktop.DBus.Properties", "Set",
@@ -1464,7 +1464,7 @@ inline void setDHCPEnabled(const std::string& ifaceId,
             return;
         }
         messages::success(asyncResp->res);
-        },
+    },
         "xyz.openbmc_project.Network",
         "/xyz/openbmc_project/network/" + ifaceId,
         "org.freedesktop.DBus.Properties", "Set",
@@ -1484,7 +1484,7 @@ inline void setIPv6AcceptRA(const std::string& ifaceId, const bool ipv6AcceptRA,
             return;
         }
         messages::success(asyncResp->res);
-        },
+    },
         "xyz.openbmc_project.Network",
         "/xyz/openbmc_project/network/" + ifaceId,
         "org.freedesktop.DBus.Properties", "Set",
@@ -1504,7 +1504,7 @@ inline void setEthernetInterfaceBoolProperty(
             messages::internalError(asyncResp->res);
             return;
         }
-        },
+    },
         "xyz.openbmc_project.Network",
         "/xyz/openbmc_project/network/" + ifaceId,
         "org.freedesktop.DBus.Properties", "Set",
@@ -1526,7 +1526,7 @@ inline void setDHCPConfig(const std::string& propertyName, const bool& value,
             messages::internalError(asyncResp->res);
             return;
         }
-        },
+    },
         "xyz.openbmc_project.Network",
         "/xyz/openbmc_project/network/" + ethifaceId + "/" + nwType,
         "org.freedesktop.DBus.Properties", "Set",
@@ -1547,7 +1547,7 @@ inline void handleSLAACAutoConfigPatch(
             return;
         }
         messages::success(asyncResp->res);
-        },
+    },
         "xyz.openbmc_project.Network",
         "/xyz/openbmc_project/network/" + ifaceId,
         "org.freedesktop.DBus.Properties", "Set",
@@ -1851,7 +1851,7 @@ inline void handleStaticNameServersPatch(
             messages::internalError(asyncResp->res);
             return;
         }
-        },
+    },
         "xyz.openbmc_project.Network",
         "/xyz/openbmc_project/network/" + ifaceId,
         "org.freedesktop.DBus.Properties", "Set",
@@ -2170,7 +2170,7 @@ inline void requestEthernetInterfacesRoutes(App& app)
             asyncResp->res.jsonValue["@odata.id"] =
                 "/redfish/v1/Managers/bmc/EthernetInterfaces";
         });
-        });
+    });
 
     BMCWEB_ROUTE(app, "/redfish/v1/Managers/bmc/EthernetInterfaces/<str>/")
         .privileges(redfish::privileges::getEthernetInterface)
@@ -2207,8 +2207,8 @@ inline void requestEthernetInterfacesRoutes(App& app)
 
             parseInterfaceData(asyncResp, ifaceId, ethData, ipv4Data, ipv6Data,
                                ipv6GatewayData);
-            });
         });
+    });
 
     BMCWEB_ROUTE(app, "/redfish/v1/Managers/bmc/EthernetInterfaces/<str>/")
         .privileges(redfish::privileges::patchEthernetInterface)
@@ -2390,8 +2390,8 @@ inline void requestEthernetInterfacesRoutes(App& app)
             {
                 handleMTUSizePatch(ifaceId, *mtuSize, asyncResp);
             }
-            });
         });
+    });
 }
 
 } // namespace redfish

--- a/redfish-core/lib/event_service.hpp
+++ b/redfish-core/lib/event_service.hpp
@@ -97,7 +97,7 @@ inline void requestRoutesEventService(App& app)
 
         asyncResp->res.jsonValue["SSEFilterPropertiesSupported"] =
             std::move(supportedSSEFilters);
-        });
+    });
 
     BMCWEB_ROUTE(app, "/redfish/v1/EventService/")
         .privileges(redfish::privileges::patchEventService)
@@ -161,7 +161,7 @@ inline void requestRoutesEventService(App& app)
 
         EventServiceManager::getInstance().setEventServiceConfig(
             eventServiceConfig);
-        });
+    });
 }
 
 inline void requestRoutesSubmitTestEvent(App& app)
@@ -183,7 +183,7 @@ inline void requestRoutesSubmitTestEvent(App& app)
             return;
         }
         asyncResp->res.result(boost::beast::http::status::no_content);
-        });
+    });
 }
 
 inline void doSubscriptionCollection(
@@ -258,11 +258,11 @@ inline void requestRoutesEventDestinationCollection(App& app)
             [asyncResp](const boost::system::error_code ec,
                         dbus::utility::ManagedObjectType& resp) {
             doSubscriptionCollection(ec, asyncResp, resp);
-            },
+        },
             "xyz.openbmc_project.Network.SNMP",
             "/xyz/openbmc_project/network/snmp/manager",
             "org.freedesktop.DBus.ObjectManager", "GetManagedObjects");
-        });
+    });
 
     BMCWEB_ROUTE(app, "/redfish/v1/EventService/Subscriptions/")
         .privileges(redfish::privileges::postEventDestinationCollection)
@@ -474,7 +474,7 @@ inline void requestRoutesEventDestinationCollection(App& app)
                             [&id](const redfish::registries::MessageEntry&
                                       messageEntry) {
                         return id == messageEntry.first;
-                            }))
+                    }))
                     {
                         validId = true;
                         break;
@@ -544,7 +544,7 @@ inline void requestRoutesEventDestinationCollection(App& app)
         messages::created(asyncResp->res);
         asyncResp->res.addHeader(
             "Location", "/redfish/v1/EventService/Subscriptions/" + id);
-        });
+    });
 }
 
 inline void requestRoutesEventDestination(App& app)
@@ -603,7 +603,7 @@ inline void requestRoutesEventDestination(App& app)
             mrdJsonArray.emplace_back(std::move(mdr));
         }
         asyncResp->res.jsonValue["MetricReportDefinitions"] = mrdJsonArray;
-        });
+    });
     BMCWEB_ROUTE(app, "/redfish/v1/EventService/Subscriptions/<str>/")
         // The below privilege is wrong, it should be ConfigureManager OR
         // ConfigureSelf
@@ -678,7 +678,7 @@ inline void requestRoutesEventDestination(App& app)
         }
 
         EventServiceManager::getInstance().updateSubscriptionData();
-        });
+    });
     BMCWEB_ROUTE(app, "/redfish/v1/EventService/Subscriptions/<str>/")
         // The below privilege is wrong, it should be ConfigureManager OR
         // ConfigureSelf
@@ -707,7 +707,7 @@ inline void requestRoutesEventDestination(App& app)
             return;
         }
         EventServiceManager::getInstance().deleteSubscription(param);
-        });
+    });
 }
 
 } // namespace redfish

--- a/redfish-core/lib/fabric_adapters.hpp
+++ b/redfish-core/lib/fabric_adapters.hpp
@@ -61,7 +61,7 @@ inline void
 
         aResp->res.jsonValue["Location"]["PartLocation"]["ServiceLabel"] =
             property;
-        });
+    });
 }
 
 inline void
@@ -120,7 +120,7 @@ inline void
         {
             aResp->res.jsonValue["SparePartNumber"] = *sparePartNumber;
         }
-        });
+    });
 }
 
 inline void
@@ -146,7 +146,7 @@ inline void
         {
             aResp->res.jsonValue["Status"]["State"] = "Absent";
         }
-        });
+    });
 }
 
 inline void
@@ -172,7 +172,7 @@ inline void
         {
             aResp->res.jsonValue["Status"]["Health"] = "Critical";
         }
-        });
+    });
 }
 
 inline void linkAsPCIeDevice(const std::shared_ptr<bmcweb::AsyncResp>& aResp,
@@ -238,7 +238,7 @@ inline void doGetFabricAdapterPCIeSlots(
         std::string chassisName = path.filename();
 
         callback(std::move(chassisName), pcieSlotPaths);
-        });
+    });
 }
 
 inline void getFabricAdapterPCIeSlots(
@@ -277,7 +277,7 @@ inline void getFabricAdapterPCIeSlots(
         // Check whether PCIeSlot is associated with chassis
         doGetFabricAdapterPCIeSlots(aResp, fabricAdapterPath, pcieSlotPaths,
                                     std::move(callback));
-        });
+    });
 }
 
 inline void doAdapterGet(const std::shared_ptr<bmcweb::AsyncResp>& aResp,
@@ -313,7 +313,7 @@ inline void doAdapterGet(const std::shared_ptr<bmcweb::AsyncResp>& aResp,
         aResp->res.jsonValue["Oem"]["IBM"]["Slots"]["@odata.id"] =
             crow::utility::urlFromPieces("redfish", "v1", "Chassis",
                                          chassisName, "PCIeSlots");
-        });
+    });
 
     getFabricAdapterLocation(aResp, serviceName, fabricAdapterPath);
     getFabricAdapterAsset(aResp, serviceName, fabricAdapterPath);
@@ -372,7 +372,7 @@ inline void getValidFabricAdapterPath(
         }
         BMCWEB_LOG_WARNING << "Adapter not found";
         messages::resourceNotFound(aResp->res, "FabricAdapter", adapterId);
-        });
+    });
 }
 
 inline void
@@ -394,7 +394,7 @@ inline void
                     const dbus::utility::InterfaceList& interfaces) {
         doAdapterGet(aResp, systemName, adapterId, fabricAdapterPath,
                      serviceName, interfaces);
-        });
+    });
 }
 
 inline void
@@ -427,7 +427,7 @@ inline void
             setLocationIndicatorActive(aResp, fabricAdapterPath,
                                        *locationIndicatorActive);
         }
-        });
+    });
 }
 
 inline void handleFabricAdapterCollectionGet(
@@ -512,7 +512,7 @@ inline void
         aResp->res.addHeader(boost::beast::http::field::link,
                              "</redfish/v1/JsonSchemas/FabricAdapter/"
                              "FabricAdapter.json>; rel=describedby");
-        });
+    });
 }
 
 inline void requestRoutesFabricAdapterCollection(App& app)

--- a/redfish-core/lib/fan.hpp
+++ b/redfish-core/lib/fan.hpp
@@ -82,7 +82,7 @@ inline void doFanCollection(const std::shared_ptr<bmcweb::AsyncResp>& asyncResp,
         {
             updateFanList(asyncResp, chassisId, endpoint);
         }
-        });
+    });
 }
 
 inline void
@@ -107,7 +107,7 @@ inline void
         asyncResp->res.addHeader(
             boost::beast::http::field::link,
             "</redfish/v1/JsonSchemas/FanCollection/FanCollection.json>; rel=describedby");
-        });
+    });
 }
 
 inline void
@@ -169,7 +169,7 @@ inline void
         }
 
         messages::resourceNotFound(asyncResp->res, "Fan", fanId);
-        });
+    });
 }
 
 inline void getFanHealth(const std::shared_ptr<bmcweb::AsyncResp>& asyncResp,
@@ -192,7 +192,7 @@ inline void getFanHealth(const std::shared_ptr<bmcweb::AsyncResp>& asyncResp,
         {
             asyncResp->res.jsonValue["Status"]["Health"] = "Critical";
         }
-        });
+    });
 }
 
 inline void getFanState(const std::shared_ptr<bmcweb::AsyncResp>& asyncResp,
@@ -215,7 +215,7 @@ inline void getFanState(const std::shared_ptr<bmcweb::AsyncResp>& asyncResp,
         {
             asyncResp->res.jsonValue["Status"]["State"] = "Absent";
         }
-        });
+    });
 }
 
 inline void getFanAsset(const std::shared_ptr<bmcweb::AsyncResp>& asyncResp,
@@ -276,7 +276,7 @@ inline void getFanAsset(const std::shared_ptr<bmcweb::AsyncResp>& asyncResp,
         {
             asyncResp->res.jsonValue["SparePartNumber"] = *sparePartNumber;
         }
-        });
+    });
 }
 
 inline void getFanLocation(const std::shared_ptr<bmcweb::AsyncResp>& asyncResp,
@@ -298,7 +298,7 @@ inline void getFanLocation(const std::shared_ptr<bmcweb::AsyncResp>& asyncResp,
 
         asyncResp->res.jsonValue["Location"]["PartLocation"]["ServiceLabel"] =
             value;
-        });
+    });
 }
 
 inline void doFanGet(const std::shared_ptr<bmcweb::AsyncResp>& asyncResp,
@@ -343,7 +343,7 @@ inline void doFanGet(const std::shared_ptr<bmcweb::AsyncResp>& asyncResp,
             getFanState(asyncResp, object.begin()->first, fanPath);
             getFanAsset(asyncResp, object.begin()->first, fanPath);
             getFanLocation(asyncResp, object.begin()->first, fanPath);
-            });
+        });
 
         getLocationIndicatorActive(asyncResp, fanPath);
     });
@@ -375,7 +375,7 @@ inline void handleFanHead(App& app, const crow::Request& req,
                 boost::beast::http::field::link,
                 "</redfish/v1/JsonSchemas/Fan/Fan.json>; rel=describedby");
         });
-        });
+    });
 }
 
 inline void handleFanGet(App& app, const crow::Request& req,
@@ -444,8 +444,8 @@ inline void handleFanPatch(App& app, const crow::Request& req,
                 setLocationIndicatorActive(asyncResp, fanPath,
                                            *locationIndicatorActive);
             }
-            });
         });
+    });
 }
 
 inline void requestRoutesFan(App& app)

--- a/redfish-core/lib/health.hpp
+++ b/redfish-core/lib/health.hpp
@@ -200,7 +200,7 @@ struct HealthPopulate : std::enable_shared_from_this<HealthPopulate>
                 return;
             }
             self->globalInventoryPath = resp[0];
-            },
+        },
             "xyz.openbmc_project.ObjectMapper",
             "/xyz/openbmc_project/object_mapper",
             "xyz.openbmc_project.ObjectMapper", "GetSubTreePaths", "/", 0,
@@ -229,7 +229,7 @@ struct HealthPopulate : std::enable_shared_from_this<HealthPopulate>
                 }
                 it = self->statuses.erase(it);
             }
-            },
+        },
             "xyz.openbmc_project.ObjectMapper", "/",
             "org.freedesktop.DBus.ObjectManager", "GetManagedObjects");
     }

--- a/redfish-core/lib/hypervisor_system.hpp
+++ b/redfish-core/lib/hypervisor_system.hpp
@@ -102,7 +102,7 @@ inline void getHypervisorState(const std::shared_ptr<bmcweb::AsyncResp>& aResp)
             messages::internalError(aResp->res);
             return;
         }
-        });
+    });
 }
 
 /**
@@ -154,7 +154,7 @@ inline void
             "/redfish/v1/Systems/hypervisor/Actions/ComputerSystem.Reset";
         reset["@Redfish.ActionInfo"] =
             "/redfish/v1/Systems/hypervisor/ResetActionInfo";
-        },
+    },
         "xyz.openbmc_project.ObjectMapper",
         "/xyz/openbmc_project/object_mapper",
         "xyz.openbmc_project.ObjectMapper", "GetObject",
@@ -444,7 +444,7 @@ void getHypervisorIfaceData(const std::shared_ptr<bmcweb::AsyncResp>& asyncResp,
             BMCWEB_LOG_DEBUG << "Hypervisor Interface not found";
         }
         callback(found, ethData, ipv4Data, ipv6Data);
-        },
+    },
         "xyz.openbmc_project.Network.Hypervisor",
         "/xyz/openbmc_project/network/hypervisor",
         "org.freedesktop.DBus.ObjectManager", "GetManagedObjects");
@@ -516,7 +516,7 @@ inline void handleHypSLAACAutoConfigPatch(
             return;
         }
         messages::success(asyncResp->res);
-        },
+    },
         "xyz.openbmc_project.Network.Hypervisor",
         "/xyz/openbmc_project/network/hypervisor/" + ifaceId,
         "org.freedesktop.DBus.Properties", "Set",
@@ -542,7 +542,7 @@ inline void
         {
             messages::internalError(asyncResp->res);
         }
-        },
+    },
         "xyz.openbmc_project.Network.Hypervisor",
         "/xyz/openbmc_project/network/hypervisor/config",
         "org.freedesktop.DBus.Properties", "Set",
@@ -596,7 +596,7 @@ inline void
 
             return;
         }
-        },
+    },
         "xyz.openbmc_project.Network.Hypervisor",
         "/xyz/openbmc_project/network/hypervisor/" + ifaceId,
         "xyz.openbmc_project.Network.IP.Create", "IP", protocol, address,
@@ -628,7 +628,7 @@ inline void
         redfish::EventServiceManager::getInstance().sendEvent(
             redfish::messages::resourceChanged(), eventOrigin,
             "EthernetInterface");
-        },
+    },
         "xyz.openbmc_project.Network.Hypervisor",
         "/xyz/openbmc_project/network/hypervisor/" + ifaceId + "/" + protocol +
             "/addr0",
@@ -790,7 +790,7 @@ inline void setIpv6DhcpOperatingMode(
             messages::internalError(asyncResp->res);
             return;
         }
-        },
+    },
         "xyz.openbmc_project.Network.Hypervisor",
         "/xyz/openbmc_project/network/hypervisor/" + ifaceId,
         "org.freedesktop.DBus.Properties", "Set",
@@ -862,7 +862,7 @@ inline void setDHCPEnabled(const std::string& ifaceId,
             messages::internalError(asyncResp->res);
             return;
         }
-        },
+    },
         "xyz.openbmc_project.Network.Hypervisor",
         "/xyz/openbmc_project/network/hypervisor/" + ifaceId,
         "org.freedesktop.DBus.Properties", "Set",
@@ -882,7 +882,7 @@ inline void
             messages::internalError(asyncResp->res);
             return;
         }
-        },
+    },
         "xyz.openbmc_project.Network.Hypervisor",
         "/xyz/openbmc_project/network/hypervisor/" + ifaceId + "/ipv4/addr0",
         "org.freedesktop.DBus.Properties", "Set",
@@ -1089,7 +1089,7 @@ inline void handleHypV6DefaultGatewayPatch(
             messages::internalError(asyncResp->res);
             return;
         }
-        },
+    },
         "xyz.openbmc_project.Network.Hypervisor",
         "/xyz/openbmc_project/network/hypervisor/" + ifaceId,
         "org.freedesktop.DBus.Properties", "Set",
@@ -1147,8 +1147,8 @@ inline void requestRoutesHypervisorSystems(App& app)
             getHypervisorState(asyncResp);
             getHypervisorActions(asyncResp);
             // TODO: Add "SystemType" : "hypervisor"
-            });
         });
+    });
 
     /**
      * HypervisorInterfaceCollection class to handle the GET and PATCH on
@@ -1204,12 +1204,12 @@ inline void requestRoutesHypervisorSystems(App& app)
                 ifaceArray.push_back(std::move(ethIface));
             }
             asyncResp->res.jsonValue["Members@odata.count"] = ifaceArray.size();
-            },
+        },
             "xyz.openbmc_project.ObjectMapper",
             "/xyz/openbmc_project/object_mapper",
             "xyz.openbmc_project.ObjectMapper", "GetSubTreePaths",
             "/xyz/openbmc_project/network/hypervisor", 0, interfaces);
-        });
+    });
 
     BMCWEB_ROUTE(app,
                  "/redfish/v1/Systems/hypervisor/EthernetInterfaces/<str>/")
@@ -1241,8 +1241,8 @@ inline void requestRoutesHypervisorSystems(App& app)
                 "Hypervisor's Virtual Management Ethernet Interface";
             parseInterfaceData(asyncResp->res.jsonValue, ifaceId, ethData,
                                ipv4Data, ipv6Data);
-            });
         });
+    });
 
     // Restrict the hypervisor ethernet interface PATCH to ConfigureManager
     BMCWEB_ROUTE(app,
@@ -1462,9 +1462,9 @@ inline void requestRoutesHypervisorSystems(App& app)
                 handleHypV6DefaultGatewayPatch(
                     ifaceId, ipv6StaticDefaultGw.front(), asyncResp);
             }
-            });
-        asyncResp->res.result(boost::beast::http::status::accepted);
         });
+        asyncResp->res.result(boost::beast::http::status::accepted);
+    });
 
     BMCWEB_ROUTE(app, "/redfish/v1/Systems/hypervisor/ResetActionInfo/")
         .privileges(redfish::privileges::getActionInfo)
@@ -1523,13 +1523,13 @@ inline void requestRoutesHypervisorSystems(App& app)
             parameter["AllowableValues"] = std::move(allowed);
             parameters.emplace_back(std::move(parameter));
             asyncResp->res.jsonValue["Parameters"] = std::move(parameters);
-            },
+        },
             "xyz.openbmc_project.ObjectMapper",
             "/xyz/openbmc_project/object_mapper",
             "xyz.openbmc_project.ObjectMapper", "GetObject",
             "/xyz/openbmc_project/state/hypervisor0",
             std::array<const char*, 1>{"xyz.openbmc_project.State.Host"});
-        });
+    });
 
     BMCWEB_ROUTE(app,
                  "/redfish/v1/Systems/hypervisor/Actions/ComputerSystem.Reset/")
@@ -1589,12 +1589,12 @@ inline void requestRoutesHypervisorSystems(App& app)
                 return;
             }
             messages::success(asyncResp->res);
-            },
+        },
             "xyz.openbmc_project.State.Hypervisor",
             "/xyz/openbmc_project/state/hypervisor0",
             "org.freedesktop.DBus.Properties", "Set",
             "xyz.openbmc_project.State.Host", "RequestedHostTransition",
             dbus::utility::DbusVariantType{std::move(command)});
-        });
+    });
 }
 } // namespace redfish::hypervisor

--- a/redfish-core/lib/led.hpp
+++ b/redfish-core/lib/led.hpp
@@ -90,8 +90,8 @@ inline void
             {
                 aResp->res.jsonValue["IndicatorLED"] = "Off";
             }
-            });
         });
+    });
 }
 
 /**
@@ -146,13 +146,13 @@ inline void
                 return;
             }
             messages::success(aResp->res);
-            },
+        },
             "xyz.openbmc_project.LED.GroupManager",
             "/xyz/openbmc_project/led/groups/enclosure_identify",
             "org.freedesktop.DBus.Properties", "Set",
             "xyz.openbmc_project.Led.Group", "Asserted",
             dbus::utility::DbusVariantType(ledOn));
-        },
+    },
         "xyz.openbmc_project.LED.GroupManager",
         "/xyz/openbmc_project/led/groups/enclosure_identify_blink",
         "org.freedesktop.DBus.Properties", "Set",
@@ -191,8 +191,8 @@ inline void getLedAsset(const std::shared_ptr<bmcweb::AsyncResp>& aResp,
             }
 
             jsonInput = assert;
-            });
         });
+    });
 }
 
 inline void setLedAsset(const std::shared_ptr<bmcweb::AsyncResp>& aResp,
@@ -223,8 +223,8 @@ inline void setLedAsset(const std::shared_ptr<bmcweb::AsyncResp>& aResp,
                 }
                 return;
             }
-            });
         });
+    });
 }
 
 /**
@@ -261,7 +261,7 @@ inline void
         {
             getLedAsset(aResp, endpoint, jsonIn);
         }
-        });
+    });
 }
 
 inline void
@@ -304,6 +304,6 @@ inline void
         {
             setLedAsset(aResp, endpoint, ledState);
         }
-        });
+    });
 }
 } // namespace redfish

--- a/redfish-core/lib/license_service.hpp
+++ b/redfish-core/lib/license_service.hpp
@@ -63,7 +63,7 @@ inline void getLicenseEntryCollection(
             asyncResp->res.jsonValue["Members@odata.count"] =
                 entriesArray.size();
         }
-        },
+    },
         "xyz.openbmc_project.PLDM", "/xyz/openbmc_project/license",
         "org.freedesktop.DBus.ObjectManager", "GetManagedObjects");
 }
@@ -90,7 +90,7 @@ inline void requestRoutesLicenseService(App& app)
                  "/redfish/v1/LicenseService/Actions/"
                  "LicenseService.Install",
              }}}};
-        });
+    });
 }
 
 static void resetLicenseActivationStatus(
@@ -108,7 +108,7 @@ static void resetLicenseActivationStatus(
             return;
         }
         licenseActivationStatusMatch = nullptr;
-        },
+    },
         "com.ibm.License.Manager", "/com/ibm/license",
         "org.freedesktop.DBus.Properties", "Set",
         "com.ibm.License.LicenseManager", "LicenseActivationStatus",
@@ -130,7 +130,7 @@ static void
             return;
         }
         resetLicenseActivationStatus(asyncResp);
-        },
+    },
         "com.ibm.License.Manager", "/com/ibm/license",
         "org.freedesktop.DBus.Properties", "Set",
         "com.ibm.License.LicenseManager", "LicenseString",
@@ -196,7 +196,7 @@ inline void requestRoutesLicenseEntryCollection(App& app)
         asyncResp->res.jsonValue["Name"] = "License Collection";
 
         getLicenseEntryCollection(asyncResp);
-        });
+    });
 
     BMCWEB_ROUTE(app, "/redfish/v1/LicenseService/Licenses")
         .privileges({{"ConfigureManager"}})
@@ -304,12 +304,12 @@ inline void requestRoutesLicenseEntryCollection(App& app)
                     "signal',"
                     "member='PropertiesChanged',path='/com/ibm/license'",
                     callback);
-            },
+        },
             "com.ibm.License.Manager", "/com/ibm/license",
             "org.freedesktop.DBus.Properties", "Set",
             "com.ibm.License.LicenseManager", "LicenseString",
             std::variant<std::string>(licenseString));
-        });
+    });
 }
 
 inline void translateLicenseTypeDbusToRedfish(
@@ -535,7 +535,7 @@ inline void
                     "UnavailableOffline";
             }
         }
-        },
+    },
         "xyz.openbmc_project.PLDM", "/xyz/openbmc_project/license",
         "org.freedesktop.DBus.ObjectManager", "GetManagedObjects");
 }
@@ -549,6 +549,6 @@ inline void requestRoutesLicenseEntry(App& app)
                const std::shared_ptr<bmcweb::AsyncResp>& asyncResp,
                const std::string& param) {
         getLicenseEntryById(asyncResp, param);
-        });
+    });
 }
 } // namespace redfish

--- a/redfish-core/lib/log_services.hpp
+++ b/redfish-core/lib/log_services.hpp
@@ -111,7 +111,7 @@ static const Message*
         std::find_if(registry.begin(), registry.end(),
                      [&messageKey](const MessageEntry& messageEntry) {
         return std::strcmp(messageEntry.first, messageKey.c_str()) == 0;
-        });
+    });
     if (messageIt != registry.end())
     {
         return &messageIt->second;
@@ -649,7 +649,7 @@ inline void
             entriesArray.push_back(std::move(thisEntry));
         }
         asyncResp->res.jsonValue["Members@odata.count"] = entriesArray.size();
-        },
+    },
         "xyz.openbmc_project.Dump.Manager", "/xyz/openbmc_project/dump",
         "org.freedesktop.DBus.ObjectManager", "GetManagedObjects");
 }
@@ -766,7 +766,7 @@ inline void
                                        entryID);
             return;
         }
-        },
+    },
         "xyz.openbmc_project.Dump.Manager", "/xyz/openbmc_project/dump",
         "org.freedesktop.DBus.ObjectManager", "GetManagedObjects");
 }
@@ -775,9 +775,9 @@ inline void deleteDumpEntry(const std::shared_ptr<bmcweb::AsyncResp>& asyncResp,
                             const std::string& entryID,
                             const std::string& dumpType)
 {
-    auto respHandler =
-        [asyncResp, entryID](const boost::system::error_code ec,
-                             const sdbusplus::message::message& msg) {
+    auto respHandler = [asyncResp,
+                        entryID](const boost::system::error_code ec,
+                                 const sdbusplus::message::message& msg) {
         BMCWEB_LOG_DEBUG << "Dump Entry doDelete callback: Done";
         if (ec)
         {
@@ -1037,7 +1037,7 @@ inline void createDumpTaskCallback(
                                 << ": Dump creation task completed";
             taskData->state = "Completed";
             return task::completed;
-            },
+        },
             "type='signal',interface='org.freedesktop.DBus.Properties',"
             "member='PropertiesChanged',path='" +
                 createdObjPath.str + "'");
@@ -1055,7 +1055,7 @@ inline void createDumpTaskCallback(
         task->startTimer(std::chrono::minutes(20));
         task->populateResp(asyncResp->res);
         task->payload.emplace(payload);
-        },
+    },
         "xyz.openbmc_project.Dump.Manager", createdObjPath,
         "org.freedesktop.DBus.Introspectable", "Introspect");
 }
@@ -1279,7 +1279,7 @@ inline void createDump(const std::shared_ptr<bmcweb::AsyncResp>& asyncResp,
         }
         BMCWEB_LOG_DEBUG << "Dump Created. Path: " << objPath.str;
         createDumpTaskCallback(std::move(payload), asyncResp, objPath);
-        },
+    },
         "xyz.openbmc_project.Dump.Manager",
         "/xyz/openbmc_project/dump/" +
             std::string(boost::algorithm::to_lower_copy(createDumpType)),
@@ -1324,7 +1324,7 @@ inline void clearDump(const std::shared_ptr<bmcweb::AsyncResp>& asyncResp,
             }
             deleteDumpEntry(asyncResp, logID, dumpType);
         }
-        },
+    },
         "xyz.openbmc_project.ObjectMapper",
         "/xyz/openbmc_project/object_mapper",
         "xyz.openbmc_project.ObjectMapper", "GetSubTreePaths",
@@ -1467,7 +1467,7 @@ inline void requestRoutesSystemLogServiceCollection(App& app)
                     return;
                 }
             }
-            },
+        },
             "xyz.openbmc_project.ObjectMapper",
             "/xyz/openbmc_project/object_mapper",
             "xyz.openbmc_project.ObjectMapper", "GetSubTreePaths", "/", 0,
@@ -1482,7 +1482,7 @@ inline void requestRoutesSystemLogServiceCollection(App& app)
         asyncResp->res.jsonValue["Members@odata.count"] =
             logServiceArrayLocal.size();
 #endif // BMCWEB_ENABLE_HW_ISOLATION
-        });
+    });
 }
 
 inline void requestRoutesEventLogService(App& app)
@@ -1525,7 +1525,7 @@ inline void requestRoutesEventLogService(App& app)
 
             {"target",
              "/redfish/v1/Systems/system/LogServices/EventLog/Actions/LogService.ClearLog"}};
-        });
+    });
 }
 
 inline void requestRoutesCELogService(App& app)
@@ -1568,7 +1568,7 @@ inline void requestRoutesCELogService(App& app)
 
             {"target",
              "/redfish/v1/Systems/system/LogServices/CELog/Actions/LogService.ClearLog"}};
-        });
+    });
 }
 
 inline void requestRoutesJournalEventLogClear(App& app)
@@ -1614,11 +1614,11 @@ inline void requestRoutesJournalEventLogClear(App& app)
             }
 
             messages::success(asyncResp->res);
-            },
+        },
             "org.freedesktop.systemd1", "/org/freedesktop/systemd1",
             "org.freedesktop.systemd1.Manager", "ReloadUnit", "rsyslog.service",
             "replace");
-        });
+    });
 }
 
 enum class LogParseError
@@ -1823,7 +1823,7 @@ inline void requestRoutesJournalEventLogEntryCollection(App& app)
                 "/redfish/v1/Systems/system/LogServices/EventLog/Entries?$skip=" +
                 std::to_string(skip + top);
         }
-        });
+    });
 }
 
 inline void requestRoutesJournalEventLogEntry(App& app)
@@ -1894,7 +1894,7 @@ inline void requestRoutesJournalEventLogEntry(App& app)
         }
         // Requested ID was not found
         messages::resourceNotFound(asyncResp->res, "LogEntry", targetID);
-        });
+    });
 }
 
 template <typename Callback>
@@ -1936,7 +1936,7 @@ inline void updateProperty(const std::optional<bool>& resolved,
                 messages::internalError(asyncResp->res);
                 return;
             }
-            },
+        },
             "xyz.openbmc_project.Logging",
             "/xyz/openbmc_project/logging/entry/" + entryId,
             "org.freedesktop.DBus.Properties", "Set",
@@ -1955,7 +1955,7 @@ inline void updateProperty(const std::optional<bool>& resolved,
                 messages::internalError(asyncResp->res);
                 return;
             }
-            },
+        },
             "xyz.openbmc_project.Logging",
             "/xyz/openbmc_project/logging/entry/" + entryId,
             "org.freedesktop.DBus.Properties", "Set",
@@ -1970,8 +1970,8 @@ inline void
                         const std::string& entryId)
 {
     // Process response from Logging service.
-    auto respHandler =
-        [asyncResp, entryId](const boost::system::error_code ec) {
+    auto respHandler = [asyncResp,
+                        entryId](const boost::system::error_code ec) {
         BMCWEB_LOG_DEBUG << "EventLogEntry (DBus) doDelete callback: Done";
         if (ec)
         {
@@ -2246,13 +2246,13 @@ inline void requestRoutesDBusEventLogEntryCollection(App& app)
                 entriesArray.begin(), entriesArray.end(),
                 [](const nlohmann::json& left, const nlohmann::json& right) {
                 return (left["Id"] <= right["Id"]);
-                });
+            });
             asyncResp->res.jsonValue["Members@odata.count"] =
                 entriesArray.size();
-            },
+        },
             "xyz.openbmc_project.Logging", "/xyz/openbmc_project/logging",
             "org.freedesktop.DBus.ObjectManager", "GetManagedObjects");
-        });
+    });
 }
 
 inline void requestRoutesDBusCELogEntryCollection(App& app)
@@ -2505,13 +2505,13 @@ inline void requestRoutesDBusCELogEntryCollection(App& app)
                 entriesArray.begin(), entriesArray.end(),
                 [](const nlohmann::json& left, const nlohmann::json& right) {
                 return (left["Id"] <= right["Id"]);
-                });
+            });
             asyncResp->res.jsonValue["Members@odata.count"] =
                 entriesArray.size();
-            },
+        },
             "xyz.openbmc_project.Logging", "/xyz/openbmc_project/logging",
             "org.freedesktop.DBus.ObjectManager", "GetManagedObjects");
-        });
+    });
 }
 
 inline void requestRoutesDBusEventLogEntry(App& app)
@@ -2654,8 +2654,8 @@ inline void requestRoutesDBusEventLogEntry(App& app)
             asyncResp->res.jsonValue["Oem"]["OpenBMC"]["ManagementSystemAck"] =
                 *managementSystemAck;
 #endif
-            });
         });
+    });
 
     BMCWEB_ROUTE(
         app, "/redfish/v1/Systems/<str>/LogServices/EventLog/Entries/<str>/")
@@ -2712,7 +2712,7 @@ inline void requestRoutesDBusEventLogEntry(App& app)
         };
         getHiddenPropertyValue(asyncResp, entryId,
                                std::move(updatePropertyCallback));
-        });
+    });
 
     BMCWEB_ROUTE(
         app, "/redfish/v1/Systems/<str>/LogServices/EventLog/Entries/<str>/")
@@ -2748,7 +2748,7 @@ inline void requestRoutesDBusEventLogEntry(App& app)
         };
         getHiddenPropertyValue(asyncResp, entryID,
                                std::move(deleteEventLogCallback));
-        });
+    });
 }
 
 inline void requestRoutesDBusCELogEntry(App& app)
@@ -2890,8 +2890,8 @@ inline void requestRoutesDBusCELogEntry(App& app)
             asyncResp->res.jsonValue["Oem"]["OpenBMC"]["ManagementSystemAck"] =
                 *managementSystemAck;
 #endif
-            });
         });
+    });
 
     BMCWEB_ROUTE(app,
                  "/redfish/v1/Systems/<str>/LogServices/CELog/Entries/<str>/")
@@ -2948,7 +2948,7 @@ inline void requestRoutesDBusCELogEntry(App& app)
         };
         getHiddenPropertyValue(asyncResp, entryId,
                                std::move(updatePropertyCallback));
-        });
+    });
 
     BMCWEB_ROUTE(app,
                  "/redfish/v1/Systems/<str>/LogServices/CELog/Entries/<str>/")
@@ -2984,7 +2984,7 @@ inline void requestRoutesDBusCELogEntry(App& app)
         };
         getHiddenPropertyValue(asyncResp, entryID,
                                std::move(deleteCELogCallback));
-        });
+    });
 }
 
 inline void
@@ -3043,7 +3043,7 @@ inline void requestRoutesDBusEventLogEntryDownloadPelJson(App& app)
                    const std::shared_ptr<bmcweb::AsyncResp>& asyncResp,
                    const std::string& systemName, const std::string& param)
 
-            {
+    {
         if (!redfish::setUpRedfishRoute(app, req, asyncResp))
         {
             return;
@@ -3058,8 +3058,8 @@ inline void requestRoutesDBusEventLogEntryDownloadPelJson(App& app)
         std::string entryID = param;
         dbus::utility::escapePathForDbus(entryID);
 
-        auto eventLogAttachmentCallback =
-            [asyncResp, entryID](bool hiddenPropVal) {
+        auto eventLogAttachmentCallback = [asyncResp,
+                                           entryID](bool hiddenPropVal) {
             if (hiddenPropVal)
             {
                 messages::resourceNotFound(asyncResp->res, "LogEntry", entryID);
@@ -3069,7 +3069,7 @@ inline void requestRoutesDBusEventLogEntryDownloadPelJson(App& app)
         };
         getHiddenPropertyValue(asyncResp, entryID,
                                std::move(eventLogAttachmentCallback));
-        });
+    });
 }
 
 inline void requestRoutesDBusCELogEntryDownloadPelJson(App& app)
@@ -3082,7 +3082,7 @@ inline void requestRoutesDBusCELogEntryDownloadPelJson(App& app)
                    const std::shared_ptr<bmcweb::AsyncResp>& asyncResp,
                    const std::string& systemName, const std::string& param)
 
-            {
+    {
         if (!redfish::setUpRedfishRoute(app, req, asyncResp))
         {
             return;
@@ -3097,8 +3097,8 @@ inline void requestRoutesDBusCELogEntryDownloadPelJson(App& app)
         std::string entryID = param;
         dbus::utility::escapePathForDbus(entryID);
 
-        auto eventLogAttachmentCallback =
-            [asyncResp, entryID](bool hiddenPropVal) {
+        auto eventLogAttachmentCallback = [asyncResp,
+                                           entryID](bool hiddenPropVal) {
             if (!hiddenPropVal)
             {
                 messages::resourceNotFound(asyncResp->res, "LogEntry", entryID);
@@ -3108,7 +3108,7 @@ inline void requestRoutesDBusCELogEntryDownloadPelJson(App& app)
         };
         getHiddenPropertyValue(asyncResp, entryID,
                                std::move(eventLogAttachmentCallback));
-        });
+    });
 }
 
 inline void getEventLogEntryAttachment(
@@ -3178,7 +3178,7 @@ inline void getEventLogEntryAttachment(
         asyncResp->res.addHeader(
             boost::beast::http::field::content_transfer_encoding, "Base64");
         asyncResp->res.body() = std::move(output);
-        },
+    },
         "xyz.openbmc_project.Logging",
         "/xyz/openbmc_project/logging/entry/" + entryID,
         "xyz.openbmc_project.Logging.Entry", "GetEntry");
@@ -3215,8 +3215,8 @@ inline void requestRoutesDBusEventLogEntryDownload(App& app)
         std::string entryID = param;
         dbus::utility::escapePathForDbus(entryID);
 
-        auto eventLogAttachmentCallback =
-            [asyncResp, entryID](bool hiddenPropVal) {
+        auto eventLogAttachmentCallback = [asyncResp,
+                                           entryID](bool hiddenPropVal) {
             if (hiddenPropVal)
             {
                 messages::resourceNotFound(asyncResp->res, "LogEntry", entryID);
@@ -3226,7 +3226,7 @@ inline void requestRoutesDBusEventLogEntryDownload(App& app)
         };
         getHiddenPropertyValue(asyncResp, entryID,
                                std::move(eventLogAttachmentCallback));
-        });
+    });
 }
 
 inline void requestRoutesDBusCELogEntryDownload(App& app)
@@ -3260,8 +3260,8 @@ inline void requestRoutesDBusCELogEntryDownload(App& app)
         std::string entryID = param;
         dbus::utility::escapePathForDbus(entryID);
 
-        auto eventLogAttachmentCallback =
-            [asyncResp, entryID](bool hiddenPropVal) {
+        auto eventLogAttachmentCallback = [asyncResp,
+                                           entryID](bool hiddenPropVal) {
             if (!hiddenPropVal)
             {
                 messages::resourceNotFound(asyncResp->res, "LogEntry", entryID);
@@ -3271,7 +3271,7 @@ inline void requestRoutesDBusCELogEntryDownload(App& app)
         };
         getHiddenPropertyValue(asyncResp, entryID,
                                std::move(eventLogAttachmentCallback));
-        });
+    });
 }
 
 constexpr const char* hostLoggerFolderPath = "/var/log/console";
@@ -3378,7 +3378,7 @@ inline void requestRoutesSystemHostLogger(App& app)
         asyncResp->res.jsonValue["Id"] = "HostLogger";
         asyncResp->res.jsonValue["Entries"]["@odata.id"] =
             "/redfish/v1/Systems/system/LogServices/HostLogger/Entries";
-        });
+    });
 }
 
 inline void requestRoutesSystemHostLoggerCollection(App& app)
@@ -3461,7 +3461,7 @@ inline void requestRoutesSystemHostLoggerCollection(App& app)
                     std::to_string(skip + top);
             }
         }
-        });
+    });
 }
 
 inline void requestRoutesSystemHostLoggerLogEntry(App& app)
@@ -3528,7 +3528,7 @@ inline void requestRoutesSystemHostLoggerLogEntry(App& app)
 
         // Requested ID was not found
         messages::resourceNotFound(asyncResp->res, "LogEntry", param);
-        });
+    });
 }
 
 constexpr const char* dumpManagerIface =
@@ -3646,7 +3646,7 @@ inline void requestRoutesBMCJournalLogService(App& app)
 
         asyncResp->res.jsonValue["Entries"]["@odata.id"] =
             "/redfish/v1/Managers/bmc/LogServices/Journal/Entries";
-        });
+    });
 }
 
 static int
@@ -3793,7 +3793,7 @@ inline void requestRoutesBMCJournalLogEntryCollection(App& app)
                 "/redfish/v1/Managers/bmc/LogServices/Journal/Entries?$skip=" +
                 std::to_string(skip + top);
         }
-        });
+    });
 }
 
 inline void requestRoutesBMCJournalLogEntry(App& app)
@@ -3865,7 +3865,7 @@ inline void requestRoutesBMCJournalLogEntry(App& app)
             return;
         }
         asyncResp->res.jsonValue.update(bmcJournalLogEntry);
-        });
+    });
 }
 
 inline void
@@ -4386,7 +4386,7 @@ inline void requestRoutesCrashdumpService(App& app)
         asyncResp->res.jsonValue["Actions"]["#LogService.CollectDiagnosticData"]
                                 ["target"] =
             "/redfish/v1/Systems/system/LogServices/Crashdump/Actions/LogService.CollectDiagnosticData";
-        });
+    });
 }
 
 void inline requestRoutesCrashdumpClear(App& app)
@@ -4419,9 +4419,9 @@ void inline requestRoutesCrashdumpClear(App& app)
                 return;
             }
             messages::success(asyncResp->res);
-            },
+        },
             crashdumpObject, crashdumpPath, deleteAllInterface, "DeleteAll");
-        });
+    });
 }
 
 static void
@@ -4555,12 +4555,12 @@ inline void requestRoutesCrashdumpEntryCollection(App& app)
                 logCrashdumpEntry(asyncResp, logID,
                                   asyncResp->res.jsonValue["Members"]);
             }
-            },
+        },
             "xyz.openbmc_project.ObjectMapper",
             "/xyz/openbmc_project/object_mapper",
             "xyz.openbmc_project.ObjectMapper", "GetSubTreePaths", "", 0,
             std::array<const char*, 1>{crashdumpInterface});
-        });
+    });
 }
 
 inline void requestRoutesCrashdumpEntry(App& app)
@@ -4588,7 +4588,7 @@ inline void requestRoutesCrashdumpEntry(App& app)
         }
         const std::string& logID = param;
         logCrashdumpEntry(asyncResp, logID, asyncResp->res.jsonValue);
-        });
+    });
 }
 
 inline void requestRoutesCrashdumpFile(App& app)
@@ -4667,7 +4667,7 @@ inline void requestRoutesCrashdumpFile(App& app)
             *crow::connections::systemBus, crashdumpObject,
             crashdumpPath + std::string("/") + logID, crashdumpInterface,
             std::move(getStoredLogCallback));
-        });
+    });
 }
 
 enum class OEMDiagnosticType
@@ -4803,7 +4803,7 @@ inline void requestRoutesCrashdumpCollect(App& app)
                     taskData->state = "Completed";
                 }
                 return task::completed;
-                },
+            },
                 taskMatchStr);
 
             task->startTimer(std::chrono::minutes(5));
@@ -4814,7 +4814,7 @@ inline void requestRoutesCrashdumpCollect(App& app)
         crow::connections::systemBus->async_method_call(
             std::move(collectCrashdumpCallback), crashdumpObject, crashdumpPath,
             iface, method);
-        });
+    });
 }
 
 /**
@@ -4869,7 +4869,7 @@ inline void requestRoutesDBusLogServiceActionsClear(App& app)
             respHandler, "xyz.openbmc_project.Logging",
             "/xyz/openbmc_project/logging",
             "xyz.openbmc_project.Collection.DeleteAll", "DeleteAll");
-        });
+    });
 }
 
 /**
@@ -4924,7 +4924,7 @@ inline void requestRoutesDBusCELogServiceActionsClear(App& app)
             respHandler, "xyz.openbmc_project.Logging",
             "/xyz/openbmc_project/logging",
             "xyz.openbmc_project.Collection.DeleteAll", "DeleteAll");
-        });
+    });
 }
 
 /****************************************************
@@ -4970,7 +4970,7 @@ inline void requestRoutesPostCodesLogService(App& app)
         asyncResp->res.jsonValue["Actions"]["#LogService.ClearLog"] = {
             {"target",
              "/redfish/v1/Systems/system/LogServices/PostCodes/Actions/LogService.ClearLog"}};
-        });
+    });
 }
 
 inline void requestRoutesPostCodesClear(App& app)
@@ -5010,11 +5010,11 @@ inline void requestRoutesPostCodesClear(App& app)
                 messages::internalError(asyncResp->res);
                 return;
             }
-            },
+        },
             "xyz.openbmc_project.State.Boot.PostCode0",
             "/xyz/openbmc_project/State/Boot/PostCode0",
             "xyz.openbmc_project.Collection.DeleteAll", "DeleteAll");
-        });
+    });
 }
 
 /**
@@ -5239,7 +5239,7 @@ static void getPostCodeForEntry(const std::shared_ptr<bmcweb::AsyncResp>& aResp,
             messages::resourceNotFound(aResp->res, "LogEntry", entryId);
             return;
         }
-        },
+    },
         "xyz.openbmc_project.State.Boot.PostCode0",
         "/xyz/openbmc_project/State/Boot/PostCode0",
         "xyz.openbmc_project.State.Boot.PostCode", "GetPostCodesWithTimeStamp",
@@ -5296,7 +5296,7 @@ static void getPostCodeForBoot(const std::shared_ptr<bmcweb::AsyncResp>& aResp,
                 "/redfish/v1/Systems/system/LogServices/PostCodes/Entries?$skip=" +
                 std::to_string(skip + top);
         }
-        },
+    },
         "xyz.openbmc_project.State.Boot.PostCode0",
         "/xyz/openbmc_project/State/Boot/PostCode0",
         "xyz.openbmc_project.State.Boot.PostCode", "GetPostCodesWithTimeStamp",
@@ -5322,7 +5322,7 @@ static void
             return;
         }
         getPostCodeForBoot(aResp, 1, bootCount, entryCount, skip, top);
-        });
+    });
 }
 
 inline void requestRoutesPostCodesEntryCollection(App& app)
@@ -5364,7 +5364,7 @@ inline void requestRoutesPostCodesEntryCollection(App& app)
         size_t skip = delegatedQuery.skip.value_or(0);
         size_t top = delegatedQuery.top.value_or(query_param::Query::maxTop);
         getCurrentBootNumber(asyncResp, skip, top);
-        });
+    });
 }
 
 inline void requestRoutesPostCodesEntryAdditionalData(App& app)
@@ -5449,11 +5449,11 @@ inline void requestRoutesPostCodesEntryAdditionalData(App& app)
             asyncResp->res.addHeader(
                 boost::beast::http::field::content_transfer_encoding, "Base64");
             asyncResp->res.body() = crow::utility::base64encode(strData);
-            },
+        },
             "xyz.openbmc_project.State.Boot.PostCode0",
             "/xyz/openbmc_project/State/Boot/PostCode0",
             "xyz.openbmc_project.State.Boot.PostCode", "GetPostCodes", index);
-        });
+    });
 }
 
 inline void requestRoutesPostCodesEntry(App& app)
@@ -5477,7 +5477,7 @@ inline void requestRoutesPostCodesEntry(App& app)
         }
 
         getPostCodeForEntry(asyncResp, targetID);
-        });
+    });
 }
 
 #ifdef BMCWEB_ENABLE_HW_ISOLATION
@@ -5664,7 +5664,7 @@ inline void getRedfishUriByDbusObjPath(
                 std::find_if(redfishUriList.begin(), redfishUriList.end(),
                              [parentRedfishUri](const auto& ele) {
                 return parentRedfishUri == ele.second;
-                });
+            });
 
             if (parentRedfishUriIt == redfishUriList.end())
             {
@@ -5691,7 +5691,7 @@ inline void getRedfishUriByDbusObjPath(
             std::back_inserter(ancestorsIfacesOnly),
             [](const std::pair<RedfishResourceDBusInterfaces, size_t>& p) {
             return p.first;
-            });
+        });
 
         crow::connections::systemBus->async_method_call(
             [asyncResp, dbusObjPath, entryJsonIdx, redfishUri, uriIdPos,
@@ -5812,12 +5812,12 @@ inline void getRedfishUriByDbusObjPath(
                         redfishUri);
                 }
             }
-            },
+        },
             "xyz.openbmc_project.ObjectMapper",
             "/xyz/openbmc_project/object_mapper",
             "xyz.openbmc_project.ObjectMapper", "GetAncestors", dbusObjPath.str,
             ancestorsIfacesOnly);
-        },
+    },
         "xyz.openbmc_project.ObjectMapper",
         "/xyz/openbmc_project/object_mapper",
         "xyz.openbmc_project.ObjectMapper", "GetObject", dbusObjPath.str,
@@ -5891,7 +5891,7 @@ inline void getPrettyNameByDbusObjPath(
             name_util::getPrettyName(asyncResp, dbusObjPath.str,
                                      objType[0].first, "/Message"_json_pointer);
         }
-        },
+    },
         "xyz.openbmc_project.ObjectMapper",
         "/xyz/openbmc_project/object_mapper",
         "xyz.openbmc_project.ObjectMapper", "GetObject", dbusObjPath.str,
@@ -6198,7 +6198,7 @@ inline void getSystemHardwareIsolationLogEntryCollection(
             getManagedObjectsHandler, objType[0].first,
             "/xyz/openbmc_project/hardware_isolation",
             "org.freedesktop.DBus.ObjectManager", "GetManagedObjects");
-        },
+    },
         "xyz.openbmc_project.ObjectMapper",
         "/xyz/openbmc_project/object_mapper",
         "xyz.openbmc_project.ObjectMapper", "GetObject",
@@ -6418,10 +6418,10 @@ inline void deleteSystemHardwareIsolationLogEntryById(
                 messages::internalError(asyncResp->res);
             }
             return;
-            },
+        },
             objType[0].first, entryObjPath.str,
             "xyz.openbmc_project.Object.Delete", "Delete");
-        },
+    },
         "xyz.openbmc_project.ObjectMapper",
         "/xyz/openbmc_project/object_mapper",
         "xyz.openbmc_project.ObjectMapper", "GetObject", entryObjPath.str,
@@ -6509,10 +6509,10 @@ inline void postSystemHardwareIsolationLogServiceClearLog(
                 messages::internalError(asyncResp->res);
             }
             return;
-            },
+        },
             objType[0].first, "/xyz/openbmc_project/hardware_isolation",
             "xyz.openbmc_project.Collection.DeleteAll", "DeleteAll");
-        },
+    },
         "xyz.openbmc_project.ObjectMapper",
         "/xyz/openbmc_project/object_mapper",
         "xyz.openbmc_project.ObjectMapper", "GetObject",

--- a/redfish-core/lib/managers.hpp
+++ b/redfish-core/lib/managers.hpp
@@ -89,7 +89,7 @@ inline void setLocationIndicatorActiveState(
 
         setLocationIndicatorActive(aResp, subtree[0].first,
                                    locationIndicatorActive);
-        },
+    },
         "xyz.openbmc_project.ObjectMapper",
         "/xyz/openbmc_project/object_mapper",
         "xyz.openbmc_project.ObjectMapper", "GetSubTree",
@@ -126,7 +126,7 @@ inline void
         }
 
         messages::success(asyncResp->res);
-        },
+    },
         processName, objectPath, "org.freedesktop.DBus.Properties", "Set",
         interfaceName, destProperty, dbusPropertyValue);
 }
@@ -155,7 +155,7 @@ inline void
         }
 
         messages::success(asyncResp->res);
-        },
+    },
         processName, objectPath, "org.freedesktop.DBus.Properties", "Set",
         interfaceName, destProperty, dbusPropertyValue);
 }
@@ -209,7 +209,7 @@ inline void requestRoutesManagerResetAction(App& app)
                                               "ResetType");
 
         return;
-        });
+    });
 }
 
 /**
@@ -275,11 +275,11 @@ inline void requestRoutesManagerResetToDefaultsAction(App& app)
             // Factory Reset doesn't actually happen until a reboot
             // Can't erase what the BMC is running on
             doBMCGracefulRestart(asyncResp);
-            },
+        },
             "xyz.openbmc_project.Software.BMC.Updater",
             "/xyz/openbmc_project/software",
             "xyz.openbmc_project.Common.FactoryReset", "Reset");
-        });
+    });
 }
 
 /**
@@ -322,7 +322,7 @@ inline void requestRoutesManagerResetActionInfo(App& app)
         parameters.emplace_back(std::move(parameter));
 
         asyncResp->res.jsonValue["Parameters"] = std::move(parameters);
-        });
+    });
 }
 
 static constexpr const char* objectManagerIface =
@@ -731,7 +731,7 @@ inline void
                 }
             }
         }
-        },
+    },
         connection, path, objectManagerIface, "GetManagedObjects");
 }
 
@@ -854,7 +854,7 @@ inline CreatePIDRet createPidInterface(
                 return;
             }
             messages::success(response->res);
-            },
+        },
             "xyz.openbmc_project.EntityManager", path, iface, "Delete");
         return CreatePIDRet::del;
     }
@@ -1253,7 +1253,7 @@ struct GetPIDValues : std::enable_shared_from_this<GetPIDValues>
                 return;
             }
             self->complete.subtree = subtreeLocal;
-            },
+        },
             "xyz.openbmc_project.ObjectMapper",
             "/xyz/openbmc_project/object_mapper",
             "xyz.openbmc_project.ObjectMapper", "GetSubTree", "/", 0,
@@ -1316,8 +1316,8 @@ struct GetPIDValues : std::enable_shared_from_this<GetPIDValues>
                 }
                 self->complete.currentProfile = *current;
                 self->complete.supportedProfiles = *supported;
-                });
-            },
+            });
+        },
             "xyz.openbmc_project.ObjectMapper",
             "/xyz/openbmc_project/object_mapper",
             "xyz.openbmc_project.ObjectMapper", "GetSubTree", "/", 0,
@@ -1471,7 +1471,7 @@ struct SetPIDValues : std::enable_shared_from_this<SetPIDValues>
                 }
             }
             self->managedObj = mObj;
-            },
+        },
             "xyz.openbmc_project.EntityManager",
             "/xyz/openbmc_project/inventory", objectManagerIface,
             "GetManagedObjects");
@@ -1529,8 +1529,8 @@ struct SetPIDValues : std::enable_shared_from_this<SetPIDValues>
                 self->supportedProfiles = *supported;
                 self->profileConnection = owner;
                 self->profilePath = path;
-                });
-            },
+            });
+        },
             "xyz.openbmc_project.ObjectMapper",
             "/xyz/openbmc_project/object_mapper",
             "xyz.openbmc_project.ObjectMapper", "GetSubTree", "/", 0,
@@ -1560,7 +1560,7 @@ struct SetPIDValues : std::enable_shared_from_this<SetPIDValues>
                     BMCWEB_LOG_ERROR << "Error patching profile" << ec;
                     messages::internalError(response->res);
                 }
-                },
+            },
                 profileConnection, profilePath,
                 "org.freedesktop.DBus.Properties", "Set", thermalModeIface,
                 "Current", dbus::utility::DbusVariantType(*profile));
@@ -1697,7 +1697,7 @@ struct SetPIDValues : std::enable_shared_from_this<SetPIDValues>
                                 return;
                             }
                             messages::success(response->res);
-                            },
+                        },
                             "xyz.openbmc_project.EntityManager", path,
                             "org.freedesktop.DBus.Properties", "Set", iface,
                             property.first, property.second);
@@ -1742,7 +1742,7 @@ struct SetPIDValues : std::enable_shared_from_this<SetPIDValues>
                             return;
                         }
                         messages::success(response->res);
-                        },
+                    },
                         "xyz.openbmc_project.EntityManager", chassis,
                         "xyz.openbmc_project.AddObject", "AddObject", output);
                 }
@@ -1803,7 +1803,7 @@ inline void getLocation(const std::shared_ptr<bmcweb::AsyncResp>& aResp,
 
         aResp->res.jsonValue["Location"]["PartLocation"]["ServiceLabel"] =
             property;
-        });
+    });
 }
 // avoid name collision systems.hpp
 inline void
@@ -1830,7 +1830,7 @@ inline void
         // Convert to ISO 8601 standard
         aResp->res.jsonValue["LastResetTime"] =
             redfish::time_utils::getDateTimeUint(lastResetTimeStamp);
-        });
+    });
 }
 
 /**
@@ -1931,14 +1931,14 @@ inline void
                 return;
             }
             doBMCGracefulRestart(aResp);
-            },
+        },
 
             "xyz.openbmc_project.Software.BMC.Updater",
             "/xyz/openbmc_project/software/" + firmwareId,
             "org.freedesktop.DBus.Properties", "Set",
             "xyz.openbmc_project.Software.RedundancyPriority", "Priority",
             dbus::utility::DbusVariantType(static_cast<uint8_t>(0)));
-        },
+    },
         "xyz.openbmc_project.Software.BMC.Updater",
         "/xyz/openbmc_project/software", "org.freedesktop.DBus.ObjectManager",
         "GetManagedObjects");
@@ -1978,7 +1978,7 @@ inline void setDateTime(std::shared_ptr<bmcweb::AsyncResp> aResp,
                 return;
             }
             aResp->res.jsonValue["DateTime"] = datetime;
-            },
+        },
             "xyz.openbmc_project.Time.Manager", "/xyz/openbmc_project/time/bmc",
             "org.freedesktop.DBus.Properties", "Set",
             "xyz.openbmc_project.Time.EpochTime", "Elapsed",
@@ -2039,7 +2039,7 @@ inline void getBMCState(const std::shared_ptr<bmcweb::AsyncResp>& aResp)
             aResp->res.jsonValue["Status"]["State"] = "Enabled";
             aResp->res.jsonValue["Status"]["Health"] = "OK";
         }
-        });
+    });
 }
 
 inline void requestRoutesManager(App& app)
@@ -2275,7 +2275,7 @@ inline void requestRoutesManager(App& app)
                             asyncResp->res.jsonValue["SparePartNumber"] =
                                 *sparePartNumber;
                         }
-                        });
+                    });
                 }
                 else if (interfaceName ==
                          "xyz.openbmc_project.Inventory.Decorator.LocationCode")
@@ -2288,14 +2288,14 @@ inline void requestRoutesManager(App& app)
                     getLocationIndicatorActive(asyncResp, path);
                 }
             }
-            },
+        },
             "xyz.openbmc_project.ObjectMapper",
             "/xyz/openbmc_project/object_mapper",
             "xyz.openbmc_project.ObjectMapper", "GetSubTree",
             "/xyz/openbmc_project/inventory", int32_t(0),
             std::array<const char*, 1>{
                 "xyz.openbmc_project.Inventory.Item.Bmc"});
-        });
+    });
 
     BMCWEB_ROUTE(app, "/redfish/v1/Managers/bmc/")
         .privileges(redfish::privileges::patchManager)
@@ -2417,7 +2417,7 @@ inline void requestRoutesManager(App& app)
             setLocationIndicatorActiveState(asyncResp,
                                             *locationIndicatorActive);
         }
-        });
+    });
 }
 
 inline void requestRoutesManagerCollection(App& app)
@@ -2442,6 +2442,6 @@ inline void requestRoutesManagerCollection(App& app)
         nlohmann::json& bmc = members.emplace_back();
         bmc["@odata.id"] = "/redfish/v1/Managers/bmc";
         asyncResp->res.jsonValue["Members"] = std::move(members);
-        });
+    });
 }
 } // namespace redfish

--- a/redfish-core/lib/memory.hpp
+++ b/redfish-core/lib/memory.hpp
@@ -625,7 +625,7 @@ inline void getDimmDataByService(std::shared_ptr<bmcweb::AsyncResp> aResp,
         // Check for the hardware status event
         hw_isolation_utils::getHwIsolationStatus(aResp, objPath);
 #endif // end of BMCWEB_ENABLE_HW_ISOLATION
-        });
+    });
 }
 
 inline void assembleDimmPartitionData(
@@ -700,7 +700,7 @@ inline void getDimmPartitionData(std::shared_ptr<bmcweb::AsyncResp> aResp,
         }
         nlohmann::json::json_pointer regionPtr = "/Regions"_json_pointer;
         assembleDimmPartitionData(aResp, properties, regionPtr);
-        }
+    }
 
     );
 }
@@ -735,7 +735,7 @@ inline void getObjectEnable(std::shared_ptr<bmcweb::AsyncResp> aResp,
         }
 
         aResp->res.jsonValue["Enabled"] = enabled;
-        });
+    });
 }
 
 inline void getDimmData(const std::shared_ptr<bmcweb::AsyncResp>& aResp,
@@ -837,7 +837,7 @@ inline void getDimmData(const std::shared_ptr<bmcweb::AsyncResp>& aResp,
         aResp->res.jsonValue["@odata.id"] = crow::utility::urlFromPieces(
             "redfish", "v1", "Systems", "system", "Memory", dimmId);
         return;
-        });
+    });
 }
 
 /**
@@ -898,7 +898,7 @@ inline void requestRoutesMemoryCollection(App& app)
         collection_util::getCollectionMembers(
             asyncResp, boost::urls::url("/redfish/v1/Systems/system/Memory"),
             interfaces);
-        });
+    });
 }
 
 /**
@@ -973,7 +973,7 @@ inline void setDimmData(const std::shared_ptr<bmcweb::AsyncResp>& asyncResp,
             }
         }
         messages::resourceNotFound(asyncResp->res, "Memory", dimmId);
-        });
+    });
 }
 
 inline void

--- a/redfish-core/lib/metric_definition.hpp
+++ b/redfish-core/lib/metric_definition.hpp
@@ -53,7 +53,7 @@ inline void getReadingRange(
         const double value = std::visit(ValueVisitor(ec), valueVariant);
 
         callback(ec, value);
-        },
+    },
         service2, path, "org.freedesktop.DBus.Properties", "Get",
         "xyz.openbmc_project.Sensor.Value", property);
 }
@@ -80,7 +80,7 @@ inline void
 
             asyncResp->res.jsonValue["MinReadingRange"] = readingRange;
         }
-        });
+    });
 
     telemetry::getReadingRange(
         serviceName, sensorPath, "MaxValue",
@@ -97,7 +97,7 @@ inline void
 
             asyncResp->res.jsonValue["MaxReadingRange"] = readingRange;
         }
-        });
+    });
 }
 
 inline void getSensorService(
@@ -135,7 +135,7 @@ inline void getSensorService(
         callback(boost::system::errc::make_error_code(
                      boost::system::errc::no_such_file_or_directory),
                  std::string{});
-        },
+    },
         "xyz.openbmc_project.ObjectMapper",
         "/xyz/openbmc_project/object_mapper",
         "xyz.openbmc_project.ObjectMapper", "GetSubTree",
@@ -268,7 +268,7 @@ inline void requestRoutesMetricDefinitionCollection(App& app)
         asyncResp->res.jsonValue["Name"] = "Metric Definition Collection";
         asyncResp->res.jsonValue["Members"] = nlohmann::json::array();
         asyncResp->res.jsonValue["Members@odata.count"] = 0;
-        });
+    });
 }
 
 inline void requestRoutesMetricDefinition(App& app)
@@ -345,9 +345,9 @@ inline void requestRoutesMetricDefinition(App& app)
 
                 telemetry::fillMinMaxReadingRange(asyncResp, serviceName,
                                                   sensorPath);
-                });
+            });
         });
-        });
+    });
 }
 
 } // namespace redfish

--- a/redfish-core/lib/metric_report.hpp
+++ b/redfish-core/lib/metric_report.hpp
@@ -79,7 +79,7 @@ inline void requestRoutesMetricReportCollection(App& app)
             boost::urls::url("/redfish/v1/TelemetryService/MetricReports"),
             interfaces,
             "/xyz/openbmc_project/Telemetry/Reports/TelemetryService");
-        });
+    });
 }
 
 inline void requestRoutesMetricReport(App& app)
@@ -123,10 +123,10 @@ inline void requestRoutesMetricReport(App& app)
                 }
 
                 telemetry::fillReport(asyncResp->res.jsonValue, id, ret);
-                });
-            },
+            });
+        },
             telemetry::service, reportPath, telemetry::reportInterface,
             "Update");
-        });
+    });
 }
 } // namespace redfish

--- a/redfish-core/lib/metric_report_definition.hpp
+++ b/redfish-core/lib/metric_report_definition.hpp
@@ -691,7 +691,7 @@ class AddReport
             }
 
             messages::created(asyncResp->res);
-            },
+        },
             telemetry::service, "/xyz/openbmc_project/Telemetry/Reports",
             "xyz.openbmc_project.Telemetry.ReportManager", "AddReport",
             "TelemetryService/" + args.id, args.name, args.reportingType,
@@ -742,7 +742,7 @@ inline void requestRoutesMetricReportDefinitionCollection(App& app)
                 "/redfish/v1/TelemetryService/MetricReportDefinitions"),
             interfaces,
             "/xyz/openbmc_project/Telemetry/Reports/TelemetryService");
-        });
+    });
 
     BMCWEB_ROUTE(app, "/redfish/v1/TelemetryService/MetricReportDefinitions/")
         .privileges(redfish::privileges::postMetricReportDefinitionCollection)
@@ -785,9 +785,9 @@ inline void requestRoutesMetricReportDefinitionCollection(App& app)
                     return;
                 }
                 addReportReq->insert(uriToDbus);
-                });
+            });
         }
-        });
+    });
 }
 
 inline void requestRoutesMetricReportDefinition(App& app)
@@ -825,8 +825,8 @@ inline void requestRoutesMetricReportDefinition(App& app)
             }
 
             telemetry::fillReportDefinition(asyncResp, id, properties);
-            });
         });
+    });
 
     BMCWEB_ROUTE(app,
                  "/redfish/v1/TelemetryService/MetricReportDefinitions/<str>/")
@@ -836,7 +836,7 @@ inline void requestRoutesMetricReportDefinition(App& app)
                    const std::shared_ptr<bmcweb::AsyncResp>& asyncResp,
                    const std::string& id)
 
-            {
+    {
         if (!redfish::setUpRedfishRoute(app, req, asyncResp))
         {
             return;
@@ -865,9 +865,9 @@ inline void requestRoutesMetricReportDefinition(App& app)
             }
 
             asyncResp->res.result(boost::beast::http::status::no_content);
-            },
+        },
             telemetry::service, reportPath, "xyz.openbmc_project.Object.Delete",
             "Delete");
-        });
+    });
 }
 } // namespace redfish

--- a/redfish-core/lib/network_protocol.hpp
+++ b/redfish-core/lib/network_protocol.hpp
@@ -108,7 +108,7 @@ void getEthernetIfaceData(CallbackFunc&& callback)
         extractNTPServersAndDomainNamesData(dbusData, ntpServers, domainNames);
 
         callback(true, ntpServers, domainNames);
-        },
+    },
         "xyz.openbmc_project.Network", "/xyz/openbmc_project/network",
         "org.freedesktop.DBus.ObjectManager", "GetManagedObjects");
 }
@@ -246,7 +246,7 @@ inline void handleNTPProtocolEnabled(
         {
             messages::internalError(asyncResp->res);
         }
-        },
+    },
         "xyz.openbmc_project.Settings", "/xyz/openbmc_project/time/sync_method",
         "org.freedesktop.DBus.Properties", "Set",
         "xyz.openbmc_project.Time.Synchronization", "TimeSyncMethod",
@@ -361,7 +361,7 @@ inline void
                             messages::internalError(asyncResp->res);
                             return;
                         }
-                        },
+                    },
                         service, objectPath, "org.freedesktop.DBus.Properties",
                         "Set", interface, "StaticNTPServers",
                         dbus::utility::DbusVariantType{currentNtpServers});
@@ -402,7 +402,7 @@ inline void
                         messages::internalError(asyncResp->res);
                         return;
                     }
-                    },
+                },
                     entry.second.begin()->first, entry.first,
                     "org.freedesktop.DBus.Properties", "Set",
                     "xyz.openbmc_project.Control.Service.Attributes", "Running",
@@ -415,7 +415,7 @@ inline void
                         messages::internalError(asyncResp->res);
                         return;
                     }
-                    },
+                },
                     entry.second.begin()->first, entry.first,
                     "org.freedesktop.DBus.Properties", "Set",
                     "xyz.openbmc_project.Control.Service.Attributes", "Enabled",
@@ -466,7 +466,7 @@ inline void
         {
             asyncResp->res.jsonValue["NTP"]["ProtocolEnabled"] = false;
         }
-        });
+    });
 }
 
 inline std::string encodeServiceObjectPath(std::string_view serviceName)
@@ -560,7 +560,7 @@ inline void requestRoutesNetworkProtocol(App& app)
             handleProtocolEnabled(*sshEnabled, asyncResp,
                                   encodeServiceObjectPath(sshServiceName));
         }
-        });
+    });
 
     BMCWEB_ROUTE(app, "/redfish/v1/Managers/bmc/NetworkProtocol/")
         .privileges(redfish::privileges::headManagerNetworkProtocol)
@@ -577,7 +577,7 @@ inline void requestRoutesNetworkProtocol(App& app)
             return;
         }
         getNetworkData(asyncResp, req);
-        });
+    });
 }
 
 } // namespace redfish

--- a/redfish-core/lib/oem/ibm/lamp_test.hpp
+++ b/redfish-core/lib/oem/ibm/lamp_test.hpp
@@ -58,8 +58,8 @@ inline void getLampTestState(const std::shared_ptr<bmcweb::AsyncResp>& aResp)
             aResp->res.jsonValue["Oem"]["IBM"]["@odata.type"] =
                 "#OemComputerSystem.IBM";
             aResp->res.jsonValue["Oem"]["IBM"]["LampTest"] = assert;
-            });
         });
+    });
 }
 
 /**
@@ -112,11 +112,11 @@ inline void setLampTestState(const std::shared_ptr<bmcweb::AsyncResp>& aResp,
                     messages::internalError(aResp->res);
                     return;
                 }
-                },
+            },
                 "com.ibm.PanelApp", "/com/ibm/panel_app", "com.ibm.panel",
                 "TriggerPanelLampTest", state);
-            });
         });
+    });
 }
 
 } // namespace redfish

--- a/redfish-core/lib/oem/ibm/pcie_topology_refresh.hpp
+++ b/redfish-core/lib/oem/ibm/pcie_topology_refresh.hpp
@@ -84,7 +84,7 @@ static void pcieTopologyRefreshWatchdog(
             (*countPtr) = 0;
             return;
         }
-        },
+    },
         "xyz.openbmc_project.PLDM", "/xyz/openbmc_project/pldm",
         "org.freedesktop.DBus.Properties", "Get", "com.ibm.PLDM.PCIeTopology",
         "PCIeTopologyRefresh");
@@ -121,7 +121,7 @@ inline void
              aResp](const boost::system::error_code ec1) {
             pcieTopologyRefreshWatchdog(ec1, timer, aResp, &count);
         });
-        },
+    },
         "xyz.openbmc_project.PLDM", "/xyz/openbmc_project/pldm",
         "org.freedesktop.DBus.Properties", "Set", "com.ibm.PLDM.PCIeTopology",
         "PCIeTopologyRefresh", std::variant<bool>(state));
@@ -148,7 +148,7 @@ inline void
             messages::internalError(aResp->res);
             return;
         }
-        },
+    },
         "xyz.openbmc_project.PLDM", "/xyz/openbmc_project/pldm",
         "org.freedesktop.DBus.Properties", "Set", "com.ibm.PLDM.PCIeTopology",
         "SavePCIeTopologyInfo", std::variant<bool>(state));

--- a/redfish-core/lib/oem/ibm/system_attention_indicator.hpp
+++ b/redfish-core/lib/oem/ibm/system_attention_indicator.hpp
@@ -75,8 +75,8 @@ inline void getSAI(const std::shared_ptr<bmcweb::AsyncResp>& aResp,
             {
                 oemSAI["PlatformSystemAttentionIndicator"] = assert;
             }
-            });
         });
+    });
 }
 
 /**
@@ -135,7 +135,7 @@ inline void setSAI(const std::shared_ptr<bmcweb::AsyncResp>& aResp,
                 }
                 return;
             }
-            });
         });
+    });
 }
 } // namespace redfish

--- a/redfish-core/lib/oem/ibm/usb_code_update.hpp
+++ b/redfish-core/lib/oem/ibm/usb_code_update.hpp
@@ -65,7 +65,7 @@ inline void getServiceName(const std::shared_ptr<bmcweb::AsyncResp>& aResp,
 
         BMCWEB_LOG_DEBUG << "Can't find usb code update service!";
         return;
-        },
+    },
         "xyz.openbmc_project.ObjectMapper",
         "/xyz/openbmc_project/object_mapper",
         "xyz.openbmc_project.ObjectMapper", "GetSubTree",
@@ -104,7 +104,7 @@ inline void
                 "/redfish/v1/Managers/bmc#/Oem/IBM";
             aResp->res.jsonValue["Oem"]["IBM"]["USBCodeUpdateEnabled"] =
                 usbCodeUpdateState;
-            });
+        });
     };
     getServiceName(aResp, usbCodeUpdateObjectPath, std::move(callback));
 }
@@ -133,7 +133,7 @@ inline void
                 messages::internalError(aResp->res);
                 return;
             }
-            },
+        },
             service, usbCodeUpdateObjectPath, "org.freedesktop.DBus.Properties",
             "Set", "xyz.openbmc_project.Control.Service.Attributes", "Enabled",
             std::variant<bool>(state));

--- a/redfish-core/lib/pcie.hpp
+++ b/redfish-core/lib/pcie.hpp
@@ -83,7 +83,7 @@ inline void getPcieDevicePath(
         // No matching pcieDevice found
         std::string pcieDevicePath;
         callback(ec, pcieDevicePath);
-        });
+    });
 }
 
 /* @brief get PCIeDevice path & service for the given device
@@ -119,7 +119,7 @@ inline void getPcieDevicePathAndService(
                 return;
             }
             callback(ec1, pcieDevicePath, object.begin()->first);
-            });
+        });
     });
 }
 
@@ -168,7 +168,7 @@ static inline void
             pcieDeviceList.push_back(std::move(pcieDevice));
         }
         asyncResp->res.jsonValue[name + "@odata.count"] = pcieDeviceList.size();
-        });
+    });
 }
 
 /**
@@ -288,7 +288,7 @@ static inline void getPcieSlotLinkAndStatusProperties(
                                 "#OemPCIeDevice.IBM";
                         }
                     }
-                    },
+                },
                     service, pcieSlotPath, "org.freedesktop.DBus.Properties",
                     "GetAll", interface);
             }
@@ -347,7 +347,7 @@ static inline void
             return;
         }
         BMCWEB_LOG_ERROR << "PCIe Slot not found for " << pcieDevice;
-        });
+    });
 }
 
 /**
@@ -412,7 +412,7 @@ inline void handleLinkReset(const std::shared_ptr<bmcweb::AsyncResp>& asyncResp,
                 BMCWEB_LOG_DEBUG << "linkReset property set to: "
                                  << (linkReset ? "true" : "false");
                 return;
-                },
+            },
                 service, pcieSlotPath, "org.freedesktop.DBus.Properties", "Set",
                 interface, "linkReset", std::variant<bool>{linkReset});
         }
@@ -450,7 +450,7 @@ inline void requestRoutesSystemPCIeDeviceCollection(App& app)
         asyncResp->res.jsonValue["Members"] = nlohmann::json::array();
         asyncResp->res.jsonValue["Members@odata.count"] = 0;
         getPCIeDeviceList(asyncResp, "Members");
-        });
+    });
 }
 
 inline std::optional<pcie_device::PCIeTypes>
@@ -677,8 +677,8 @@ inline void
             }
             getPCIeDevicePropertiesCallback(pcieDevProperties, device,
                                             pcieDevicePath, pcieSlotPath);
-            });
         });
+    });
 }
 
 inline void requestRoutesSystemPCIeDevice(App& app)
@@ -700,7 +700,7 @@ inline void requestRoutesSystemPCIeDevice(App& app)
             return;
         }
         getPCIeDeviceProperties(asyncResp, device);
-        });
+    });
 
     BMCWEB_ROUTE(app, "/redfish/v1/Systems/system/PCIeDevices/<str>/")
         .privileges(redfish::privileges::patchPCIeDevice)
@@ -750,7 +750,7 @@ inline void requestRoutesSystemPCIeDevice(App& app)
         };
 
         findPcieSlotPath(asyncResp, device, std::move(handleLinkResetCallback));
-        });
+    });
 }
 
 inline void requestRoutesSystemPCIeFunctionCollection(App& app)
@@ -852,7 +852,7 @@ inline void requestRoutesSystemPCIeFunctionCollection(App& app)
                 "xyz.openbmc_project.Inventory.Item.PCIeDevice",
                 std::move(getPCIeDeviceCallback));
         });
-        });
+    });
 } // namespace redfish
 
 inline void requestRoutesSystemPCIeFunction(App& app)
@@ -990,7 +990,7 @@ inline void requestRoutesSystemPCIeFunction(App& app)
                 "xyz.openbmc_project.Inventory.Item.PCIeDevice",
                 getPCIeDeviceCallback);
         });
-        });
+    });
 }
 
 } // namespace redfish

--- a/redfish-core/lib/pcie_slots.hpp
+++ b/redfish-core/lib/pcie_slots.hpp
@@ -127,7 +127,7 @@ inline void
         asyncResp->res.jsonValue["Slots"][index]["Links"]["PCIeDevice"] = {
             {{"@odata.id",
               "/redfish/v1/Systems/system/PCIeDevices/" + devName}}};
-        });
+    });
 }
 
 inline void
@@ -177,7 +177,7 @@ inline void
         asyncResp->res
             .jsonValue["Slots"][index]["Links"]["Processors@odata.count"] =
             processorArray.size();
-        });
+    });
 }
 
 /**
@@ -249,7 +249,7 @@ inline void linkAssociatedDiskBackplane(
 
         redfish::chassis_utils::getChassisAssembly(
             asyncResp, chassisId, std::move(backplaneAssemblyCallback));
-        });
+    });
 }
 
 inline void getLocationCode(const std::shared_ptr<bmcweb::AsyncResp>& asyncResp,
@@ -282,7 +282,7 @@ inline void getLocationCode(const std::shared_ptr<bmcweb::AsyncResp>& asyncResp,
         }
         asyncResp->res.jsonValue["Slots"][index]["Location"]["PartLocation"]
                                 ["ServiceLabel"] = property;
-        });
+    });
 }
 
 inline void
@@ -333,7 +333,7 @@ inline void
             crow::utility::urlFromPieces(
                 "redfish", "v1", "Systems", "system", "FabricAdapters",
                 fabric_util::buildFabricUniquePath(fabricAdapterPath));
-        });
+    });
 }
 
 inline void getPCIeSlotProperties(
@@ -497,7 +497,7 @@ inline void getValidPCIeSlotList(
         });
 
         callback(std::move(slotPathConnNames));
-        });
+    });
 }
 
 inline void doHandlePCIeSlotCollectionGet(
@@ -533,9 +533,9 @@ inline void doHandlePCIeSlotCollectionGet(
                 }
                 getPCIeSlotProperties(asyncResp, propertiesList, connectionName,
                                       pcieSlotPath);
-                });
+            });
         }
-        });
+    });
 }
 
 inline void handlePCIeSlotCollectionGet(
@@ -559,7 +559,7 @@ inline void handlePCIeSlotCollectionGet(
             return;
         }
         doHandlePCIeSlotCollectionGet(asyncResp, chassisID, *validChassisPath);
-        });
+    });
 }
 
 inline void doHandlePCIeSlotPatch(
@@ -593,7 +593,7 @@ inline void doHandlePCIeSlotPatch(
             auto indicatorOnOff = locationIndicatorActiveMap.at(idx);
             setLocationIndicatorActive(asyncResp, pcieSlotPath, indicatorOnOff);
         }
-        });
+    });
 }
 
 inline void
@@ -648,7 +648,7 @@ inline void
         }
         doHandlePCIeSlotPatch(asyncResp, total, chassisId, *validChassisPath,
                               std::move(locationIndicatorActiveMap));
-        });
+    });
 }
 
 inline void requestRoutesPCIeSlots(App& app)

--- a/redfish-core/lib/port.hpp
+++ b/redfish-core/lib/port.hpp
@@ -52,7 +52,7 @@ inline void getPortProperties(const std::shared_ptr<bmcweb::AsyncResp>& aResp,
 
                     aResp->res.jsonValue["Location"]["PartLocation"]
                                         ["ServiceLabel"] = value;
-                    });
+                });
             }
             else if (interface == "xyz.openbmc_project.Association.Definitions")
             {
@@ -114,7 +114,7 @@ inline void getPortCollection(const std::shared_ptr<bmcweb::AsyncResp>& aResp,
             members.emplace_back(std::move(item));
         }
         aResp->res.jsonValue["Members@odata.count"] = members.size();
-        });
+    });
 }
 
 inline void
@@ -169,7 +169,7 @@ inline void
         [aResp, systemName, adapterId](const std::string&, const std::string&,
                                        const dbus::utility::InterfaceList&) {
         doPortCollectionGet(aResp, systemName, adapterId);
-        });
+    });
 }
 
 /**
@@ -238,7 +238,7 @@ inline void getValidPortPath(
         }
         BMCWEB_LOG_WARNING << "Port not found";
         messages::resourceNotFound(aResp->res, "Port", portId);
-        });
+    });
 }
 
 inline void handlePortHead(crow::App& app, const crow::Request& req,
@@ -263,7 +263,7 @@ inline void handlePortHead(crow::App& app, const crow::Request& req,
                 boost::beast::http::field::link,
                 "</redfish/v1/JsonSchemas/Port/Port.json>; rel=describedby");
         });
-        });
+    });
 }
 
 inline void handlePortGet(App& app, const crow::Request& req,
@@ -299,8 +299,8 @@ inline void handlePortGet(App& app, const crow::Request& req,
             aResp->res.jsonValue["Name"] = portId;
 
             getPortProperties(aResp, portPath, serviceMap);
-            });
         });
+    });
 }
 
 inline void
@@ -354,7 +354,7 @@ inline void handlePortPatch(App& app, const crow::Request& req,
                 const dbus::utility::MapperServiceMap& serviceMap) {
             setPortProperties(aResp, portPath, serviceMap,
                               locationIndicatorActive);
-            });
+        });
     });
 }
 

--- a/redfish-core/lib/power.hpp
+++ b/redfish-core/lib/power.hpp
@@ -104,13 +104,13 @@ inline void setPowerCapOverride(
                 }
                 sensorsAsyncResp->asyncResp->res.result(
                     boost::beast::http::status::no_content);
-                },
+            },
                 "xyz.openbmc_project.Settings",
                 "/xyz/openbmc_project/control/host0/power_cap",
                 "org.freedesktop.DBus.Properties", "Set",
                 "xyz.openbmc_project.Control.Power.Cap", "PowerCap",
                 std::variant<uint32_t>(*value));
-            });
+        });
     };
     redfish::chassis_utils::getValidChassisPath(sensorsAsyncResp->asyncResp,
                                                 sensorsAsyncResp->chassisId,
@@ -302,7 +302,7 @@ inline void requestRoutesPower(App& app)
             "/xyz/openbmc_project/inventory", 0,
             std::array<const char*, 1>{
                 "xyz.openbmc_project.Inventory.Item.Chassis"});
-        });
+    });
 
     BMCWEB_ROUTE(app, "/redfish/v1/Chassis/<str>/Power/")
         .privileges(redfish::privileges::patchPower)
@@ -339,7 +339,7 @@ inline void requestRoutesPower(App& app)
             allCollections.emplace("Voltages", *std::move(voltageCollections));
             setSensorsOverride(sensorAsyncResp, allCollections);
         }
-        });
+    });
 }
 
 } // namespace redfish

--- a/redfish-core/lib/power_subsystem.hpp
+++ b/redfish-core/lib/power_subsystem.hpp
@@ -82,7 +82,7 @@ inline void getPowerSubsystemAllocationProperties(
             asyncResp->res.jsonValue["Allocation"]["RequestedWatts"] =
                 maxPowerCapValue;
         }
-        });
+    });
 }
 
 inline void getPowerSubsystemAllocation(
@@ -113,7 +113,7 @@ inline void getPowerSubsystemAllocation(
                                                       objectPath);
             }
         }
-        });
+    });
 }
 
 inline void doPowerSubsystemCollection(

--- a/redfish-core/lib/power_supply.hpp
+++ b/redfish-core/lib/power_supply.hpp
@@ -86,7 +86,7 @@ inline void
         {
             updatePowerSupplyList(asyncResp, chassisId, endpoint);
         }
-        });
+    });
 }
 
 inline void handlePowerSupplyCollectionHead(
@@ -111,7 +111,7 @@ inline void handlePowerSupplyCollectionHead(
         asyncResp->res.addHeader(
             boost::beast::http::field::link,
             "</redfish/v1/JsonSchemas/PowerSupplyCollection/PowerSupplyCollection.json>; rel=describedby");
-        });
+    });
 }
 
 inline void handlePowerSupplyCollectionGet(
@@ -169,7 +169,7 @@ inline void
         {
             asyncResp->res.jsonValue["Status"]["State"] = "UnavailableOffline";
         }
-        });
+    });
 }
 
 inline void
@@ -195,7 +195,7 @@ inline void
         {
             asyncResp->res.jsonValue["Status"]["Health"] = "Critical";
         }
-        });
+    });
 }
 
 inline void getPowerSupplyStateAndHealth(
@@ -219,7 +219,7 @@ inline void getPowerSupplyStateAndHealth(
         getPowerSupplyState(asyncResp, service, path, available);
 
         getPowerSupplyHealth(asyncResp, service, path, available);
-        });
+    });
 }
 
 inline void
@@ -282,7 +282,7 @@ inline void
         {
             asyncResp->res.jsonValue["SparePartNumber"] = *sparePartNumber;
         }
-        });
+    });
 }
 
 inline void getPowerSupplyFirmwareVersion(
@@ -303,7 +303,7 @@ inline void getPowerSupplyFirmwareVersion(
             return;
         }
         asyncResp->res.jsonValue["FirmwareVersion"] = value;
-        });
+    });
 }
 
 inline void
@@ -325,7 +325,7 @@ inline void
         }
         asyncResp->res.jsonValue["Location"]["PartLocation"]["ServiceLabel"] =
             value;
-        });
+    });
 }
 
 inline void
@@ -369,10 +369,10 @@ inline void
                     nlohmann::json& efficiencyList =
                         asyncResp->res.jsonValue["EfficiencyRatings"];
                     efficiencyList.emplace_back(std::move(item));
-                    });
+                });
             }
         }
-        },
+    },
         "xyz.openbmc_project.ObjectMapper",
         "/xyz/openbmc_project/object_mapper",
         "xyz.openbmc_project.ObjectMapper", "GetSubTree",
@@ -397,7 +397,7 @@ inline void
                     "redfish", "v1", "Chassis", chassisId, "PowerSubsystem",
                     "PowerSupplies", powerSupplyId, "Metrics");
         }
-        });
+    });
 }
 
 inline void
@@ -450,13 +450,13 @@ inline void
                                           powerSupplyPath);
             getPowerSupplyLocation(asyncResp, object.begin()->first,
                                    powerSupplyPath);
-            });
+        });
 
         getEfficiencyPercent(asyncResp);
         getLocationIndicatorActive(asyncResp, powerSupplyPath);
         getPowerSupplyMetrics(asyncResp, chassisId, powerSupplyId,
                               powerSupplyPath);
-        });
+    });
 }
 
 inline void
@@ -487,8 +487,8 @@ inline void
             asyncResp->res.addHeader(
                 boost::beast::http::field::link,
                 "</redfish/v1/JsonSchemas/PowerSupply/PowerSupply.json>; rel=describedby");
-            });
         });
+    });
 }
 
 inline void
@@ -553,7 +553,7 @@ inline void
             asyncResp, *validChassisPath, powerSupplyId,
             std::bind_front(doPatchPowerSupply, asyncResp,
                             locationIndicatorActive));
-        });
+    });
 }
 
 inline void requestRoutesPowerSupply(App& app)

--- a/redfish-core/lib/power_supply_metrics.hpp
+++ b/redfish-core/lib/power_supply_metrics.hpp
@@ -136,7 +136,7 @@ inline void getInputHistoryServiceAndInterface(
         const std::string& interface = *it;
 
         callback(service, interface);
-        });
+    });
 }
 
 inline void getInputHistory(const std::shared_ptr<bmcweb::AsyncResp>& asyncResp,
@@ -171,8 +171,8 @@ inline void getInputHistory(const std::shared_ptr<bmcweb::AsyncResp>& asyncResp,
                 historyPaths.erase(historyPaths.cbegin());
                 getInputHistory(asyncResp, historyPaths);
             }
-            });
         });
+    });
 }
 
 inline void getValidInputHistoryPaths(
@@ -210,9 +210,9 @@ inline void getValidInputHistoryPaths(
                 }
 
                 callback(historyPaths);
-                });
             });
         });
+    });
 }
 
 inline void handleHead(App& app, const crow::Request& req,
@@ -266,7 +266,7 @@ inline void handleGet(App& app, const crow::Request& req,
 
         // Get input history values and add them to the response
         getInputHistory(asyncResp, historyPaths);
-        });
+    });
 }
 
 } // namespace power_supply_metrics

--- a/redfish-core/lib/processor.hpp
+++ b/redfish-core/lib/processor.hpp
@@ -122,7 +122,7 @@ inline void getProcessorUUID(std::shared_ptr<bmcweb::AsyncResp> aResp,
             return;
         }
         aResp->res.jsonValue["UUID"] = property;
-        });
+    });
 }
 
 inline void getCpuDataByInterface(
@@ -338,7 +338,7 @@ inline void getCpuDataByService(std::shared_ptr<bmcweb::AsyncResp> aResp,
             aResp->res.jsonValue["TotalCores"] = totalCores;
         }
         return;
-        },
+    },
         service, "/xyz/openbmc_project/inventory",
         "org.freedesktop.DBus.ObjectManager", "GetManagedObjects");
 }
@@ -434,7 +434,7 @@ inline void
         [aResp](const boost::system::error_code& ec,
                 const dbus::utility::DBusPropertiesMap& properties) {
         readThrottleProperties(aResp, ec, properties);
-        });
+    });
 }
 
 inline void getCpuAssetData(std::shared_ptr<bmcweb::AsyncResp> aResp,
@@ -508,7 +508,7 @@ inline void getCpuAssetData(std::shared_ptr<bmcweb::AsyncResp> aResp,
         {
             aResp->res.jsonValue["SparePartNumber"] = *sparePartNumber;
         }
-        });
+    });
 }
 
 inline void getCpuRevisionData(std::shared_ptr<bmcweb::AsyncResp> aResp,
@@ -544,7 +544,7 @@ inline void getCpuRevisionData(std::shared_ptr<bmcweb::AsyncResp> aResp,
         {
             aResp->res.jsonValue["Version"] = *version;
         }
-        });
+    });
 }
 
 inline void getAcceleratorDataByService(
@@ -599,7 +599,7 @@ inline void getAcceleratorDataByService(
         aResp->res.jsonValue["Status"]["State"] = state;
         aResp->res.jsonValue["Status"]["Health"] = health;
         aResp->res.jsonValue["ProcessorType"] = "Accelerator";
-        });
+    });
 }
 
 // OperatingConfig D-Bus Types
@@ -741,7 +741,7 @@ inline void getCpuConfigData(const std::shared_ptr<bmcweb::AsyncResp>& aResp,
                 }
 
                 highSpeedCoreIdsHandler(aResp, baseSpeedList);
-                });
+            });
         }
 
         if (baseSpeedPriorityEnabled != nullptr)
@@ -749,7 +749,7 @@ inline void getCpuConfigData(const std::shared_ptr<bmcweb::AsyncResp>& aResp,
             json["BaseSpeedPriorityState"] =
                 *baseSpeedPriorityEnabled ? "Enabled" : "Disabled";
         }
-        });
+    });
 }
 
 /**
@@ -779,7 +779,7 @@ inline void getCpuLocationCode(std::shared_ptr<bmcweb::AsyncResp> aResp,
 
         aResp->res.jsonValue["Location"]["PartLocation"]["ServiceLabel"] =
             property;
-        });
+    });
 }
 
 /**
@@ -808,7 +808,7 @@ inline void getCpuUniqueId(const std::shared_ptr<bmcweb::AsyncResp>& aResp,
         }
         aResp->res.jsonValue["ProcessorId"]["ProtectedIdentificationNumber"] =
             id;
-        });
+    });
 }
 
 /**
@@ -890,7 +890,7 @@ inline void getProcessorObject(const std::shared_ptr<bmcweb::AsyncResp>& resp,
             return;
         }
         messages::resourceNotFound(resp->res, "Processor", processorId);
-        });
+    });
 }
 
 inline void getProcessorData(const std::shared_ptr<bmcweb::AsyncResp>& aResp,
@@ -1019,7 +1019,7 @@ inline void getProcessorPaths(const std::shared_ptr<bmcweb::AsyncResp>& aResp,
 
         // Object not found
         messages::resourceNotFound(aResp->res, "Processor", processorId);
-        },
+    },
         "xyz.openbmc_project.ObjectMapper",
         "/xyz/openbmc_project/object_mapper",
         "xyz.openbmc_project.ObjectMapper", "GetSubTreePaths",
@@ -1158,7 +1158,7 @@ inline void
             hw_isolation_utils::getHwIsolationStatus(aResp, objPath);
 #endif // end of BMCWEB_ENABLE_HW_ISOLATION
         }
-        },
+    },
         service, "/xyz/openbmc_project/inventory",
         "org.freedesktop.DBus.ObjectManager", "GetManagedObjects");
 }
@@ -1224,7 +1224,7 @@ inline void getSubProcessorData(const std::shared_ptr<bmcweb::AsyncResp>& aResp,
                 messages::resourceNotFound(aResp->res, "Processor", coreId);
                 return;
             }
-            },
+        },
             "xyz.openbmc_project.ObjectMapper",
             "/xyz/openbmc_project/object_mapper",
             "xyz.openbmc_project.ObjectMapper", "GetSubTree", cpuPath, 0,
@@ -1277,7 +1277,7 @@ inline void
                                            .filename()}});
             }
             aResp->res.jsonValue["Members@odata.count"] = members.size();
-            },
+        },
             "xyz.openbmc_project.ObjectMapper",
             "/xyz/openbmc_project/object_mapper",
             "xyz.openbmc_project.ObjectMapper", "GetSubTreePaths", cpuPath, 0,
@@ -1389,7 +1389,7 @@ inline void
                 baseSpeedArray.push_back(std::move(speed));
             }
         }
-        });
+    });
 }
 
 /**
@@ -1513,7 +1513,7 @@ inline void patchAppliedOperatingConfig(
         [resp, appliedConfigUri](const boost::system::error_code ec,
                                  const sdbusplus::message_t& msg) {
         handleAppliedConfigResponse(resp, appliedConfigUri, ec, msg);
-        },
+    },
         *controlService, cpuObjectPath, "org.freedesktop.DBus.Properties",
         "Set", "xyz.openbmc_project.Control.Processor.CurrentOperatingConfig",
         "AppliedConfig", dbus::utility::DbusVariantType(std::move(configPath)));
@@ -1647,7 +1647,7 @@ inline void setProcessorObject(const std::shared_ptr<bmcweb::AsyncResp>& resp,
             return;
         }
         messages::resourceNotFound(resp->res, "Processor", processorId);
-        });
+    });
 }
 
 inline void requestRoutesOperatingConfigCollection(App& app)
@@ -1696,9 +1696,8 @@ inline void requestRoutesOperatingConfigCollection(App& app)
 
                 // Use the common search routine to construct the
                 // Collection of all Config objects under this CPU.
-                constexpr std::array<std::string_view, 1> interface {
-                    "xyz.openbmc_project.Inventory.Item.Cpu.OperatingConfig"
-                };
+                constexpr std::array<std::string_view, 1> interface{
+                    "xyz.openbmc_project.Inventory.Item.Cpu.OperatingConfig"};
                 collection_util::getCollectionMembers(
                     asyncResp,
                     crow::utility::urlFromPieces("redfish", "v1", "Systems",
@@ -1707,14 +1706,14 @@ inline void requestRoutesOperatingConfigCollection(App& app)
                     interface, object.c_str());
                 return;
             }
-            },
+        },
             "xyz.openbmc_project.ObjectMapper",
             "/xyz/openbmc_project/object_mapper",
             "xyz.openbmc_project.ObjectMapper", "GetSubTreePaths",
             "/xyz/openbmc_project/inventory", 0,
             std::array<const char*, 1>{
                 "xyz.openbmc_project.Control.Processor.CurrentOperatingConfig"});
-        });
+    });
 }
 
 inline void requestRoutesOperatingConfig(App& app)
@@ -1781,14 +1780,14 @@ inline void requestRoutesOperatingConfig(App& app)
             }
             messages::resourceNotFound(asyncResp->res, "OperatingConfig",
                                        configName);
-            },
+        },
             "xyz.openbmc_project.ObjectMapper",
             "/xyz/openbmc_project/object_mapper",
             "xyz.openbmc_project.ObjectMapper", "GetSubTree",
             "/xyz/openbmc_project/inventory", 0,
             std::array<const char*, 1>{
                 "xyz.openbmc_project.Inventory.Item.Cpu.OperatingConfig"});
-        });
+    });
 }
 
 inline void requestRoutesProcessorCollection(App& app)
@@ -1883,8 +1882,8 @@ inline void requestRoutesProcessorCollection(App& app)
                 members.emplace_back(std::move(item));
             }
             asyncResp->res.jsonValue["Members@odata.count"] = members.size();
-            });
         });
+    });
 }
 
 inline void requestRoutesProcessor(App& app)
@@ -1927,7 +1926,7 @@ inline void requestRoutesProcessor(App& app)
         getProcessorObject(
             asyncResp, processorId,
             std::bind_front(getProcessorData, asyncResp, processorId));
-        });
+    });
 
     BMCWEB_ROUTE(app, "/redfish/v1/Systems/<str>/Processors/<str>/")
         .privileges(redfish::privileges::patchProcessor)
@@ -1976,7 +1975,7 @@ inline void requestRoutesProcessor(App& app)
         {
             setProcessorObject(asyncResp, processorId, locationIndicatorActive);
         }
-        });
+    });
 }
 
 inline void requestRoutesSubProcessors(App& app)
@@ -1994,7 +1993,7 @@ inline void requestRoutesSubProcessors(App& app)
         }
 
         getSubProcessorMembers(asyncResp, processorId);
-        });
+    });
 }
 
 /**
@@ -2080,7 +2079,7 @@ inline void requestRoutesSubProcessorsCore(App& app)
         }
 
         getSubProcessorData(asyncResp, processorId, coreId);
-        });
+    });
 
     BMCWEB_ROUTE(
         app, "/redfish/v1/Systems/system/Processors/<str>/SubProcessors/<str>")

--- a/redfish-core/lib/redfish_util.hpp
+++ b/redfish-core/lib/redfish_util.hpp
@@ -83,7 +83,7 @@ void getMainChassisId(std::shared_ptr<bmcweb::AsyncResp> asyncResp,
         std::string chassisId = subtree[0].first.substr(idPos + 1);
         BMCWEB_LOG_DEBUG << "chassisId = " << chassisId;
         callback(chassisId, asyncResp);
-        },
+    },
         "xyz.openbmc_project.ObjectMapper",
         "/xyz/openbmc_project/object_mapper",
         "xyz.openbmc_project.ObjectMapper", "GetSubTree",
@@ -194,7 +194,7 @@ void getPortStatusAndPath(
         }
 
         callback(ec, socketData);
-        },
+    },
         "org.freedesktop.systemd1", "/org/freedesktop/systemd1",
         "org.freedesktop.systemd1.Manager", "ListUnits");
 }
@@ -248,7 +248,7 @@ void getPortNumber(const std::string& socketPath, CallbackFunc&& callback)
             BMCWEB_LOG_ERROR << ec3;
         }
         callback(ec, port);
-        });
+    });
 }
 
 } // namespace redfish

--- a/redfish-core/lib/roles.hpp
+++ b/redfish-core/lib/roles.hpp
@@ -142,7 +142,7 @@ inline void requestRoutesRoles(App& app)
         {
             asyncResp->res.jsonValue["Description"] = roleId;
         }
-        });
+    });
 }
 
 inline void requestRoutesRoleCollection(App& app)
@@ -190,8 +190,8 @@ inline void requestRoutesRoleCollection(App& app)
             }
             asyncResp->res.jsonValue["Members@odata.count"] =
                 memberArray.size();
-            });
         });
+    });
 }
 
 } // namespace redfish

--- a/redfish-core/lib/sensors.hpp
+++ b/redfish-core/lib/sensors.hpp
@@ -580,7 +580,7 @@ void getChassis(const std::shared_ptr<bmcweb::AsyncResp>& asyncResp,
                              &nodeSensorList, culledSensorList);
             BMCWEB_LOG_DEBUG << "Finishing with " << culledSensorList->size();
             callback(culledSensorList);
-            });
+        });
     };
 
     // Get the Chassis Collection
@@ -1013,7 +1013,7 @@ inline void populateFanRedundancy(
                                  [sensorsAsyncResp](const std::string& entry) {
                     return entry.find(sensorsAsyncResp->chassisId) !=
                            std::string::npos;
-                    });
+                });
 
                 if (found == endpoints.end())
                 {
@@ -1100,7 +1100,7 @@ inline void populateFanRedundancy(
                             std::find_if(fanRedfish.begin(), fanRedfish.end(),
                                          [itemName](const nlohmann::json& fan) {
                             return fan["MemberId"] == itemName;
-                            });
+                        });
                         if (schemaItem != fanRedfish.end())
                         {
                             nlohmann::json::object_t collectionId;
@@ -1140,10 +1140,10 @@ inline void populateFanRedundancy(
                     redundancy["Status"]["State"] = "Enabled";
 
                     jResp.push_back(std::move(redundancy));
-                    });
                 });
+            });
         }
-        },
+    },
         "xyz.openbmc_project.ObjectMapper",
         "/xyz/openbmc_project/object_mapper",
         "xyz.openbmc_project.ObjectMapper", "GetSubTree",
@@ -1965,10 +1965,10 @@ void getPowerSupplyAttributesData(
     const std::string& psAttributesConnection = (*it).second;
 
     // Response handler for Get DeratingFactor property
-    auto respHandler =
-        [sensorsAsyncResp, inventoryItems,
-         callback{std::forward<Callback>(callback)}](
-            const boost::system::error_code ec, const uint32_t value) {
+    auto respHandler = [sensorsAsyncResp, inventoryItems,
+                        callback{std::forward<Callback>(callback)}](
+                           const boost::system::error_code ec,
+                           const uint32_t value) {
         BMCWEB_LOG_DEBUG << "getPowerSupplyAttributesData respHandler enter";
         if (ec)
         {
@@ -2721,7 +2721,7 @@ inline void setSensorsOverride(
                         messages::internalError(
                             sensorAsyncResp->asyncResp->res);
                     }
-                    },
+                },
                     item.second, item.first, "org.freedesktop.DBus.Properties",
                     "Set", "xyz.openbmc_project.Sensor.Value", "Value",
                     dbus::utility::DbusVariantType(iterator->second.first));
@@ -2884,7 +2884,7 @@ inline void
         std::string type = path.filename();
         objectPropertiesToJson(name, type, sensors::node::sensors, valuesDict,
                                asyncResp->res.jsonValue, nullptr);
-        });
+    });
 }
 
 inline void handleSensorGet(App& app, const crow::Request& req,
@@ -2936,7 +2936,7 @@ inline void handleSensorGet(App& app, const crow::Request& req,
         }
         getSensorFromDbus(asyncResp, sensorPath, subtree);
         BMCWEB_LOG_DEBUG << "respHandler1 exit";
-        });
+    });
 }
 
 } // namespace sensors

--- a/redfish-core/lib/service_root.hpp
+++ b/redfish-core/lib/service_root.hpp
@@ -82,8 +82,8 @@ inline void
             }
             asyncResp->res.jsonValue["Oem"]["IBM"]["ACFWindowActive"] =
                 isACFWindowActive;
-            });
         });
+    });
 }
 
 inline void
@@ -160,12 +160,12 @@ inline void
                                 asyncResp->res
                                     .jsonValue["Oem"]["IBM"]["Model"] = *model;
                             }
-                            });
+                        });
                     }
                 }
             }
         }
-        },
+    },
         "xyz.openbmc_project.ObjectMapper",
         "/xyz/openbmc_project/object_mapper",
         "xyz.openbmc_project.ObjectMapper", "GetSubTree",

--- a/redfish-core/lib/storage.hpp
+++ b/redfish-core/lib/storage.hpp
@@ -60,7 +60,7 @@ inline void requestRoutesStorageCollection(App& app)
         members.emplace_back(member);
         asyncResp->res.jsonValue["Members"] = std::move(members);
         asyncResp->res.jsonValue["Members@odata.count"] = 1;
-        });
+    });
 }
 
 inline void getDrives(const std::shared_ptr<bmcweb::AsyncResp>& asyncResp)
@@ -98,7 +98,7 @@ inline void getDrives(const std::shared_ptr<bmcweb::AsyncResp>& asyncResp)
         }
 
         count = driveArray.size();
-        },
+    },
         "xyz.openbmc_project.ObjectMapper",
         "/xyz/openbmc_project/object_mapper",
         "xyz.openbmc_project.ObjectMapper", "GetSubTreePaths",
@@ -174,7 +174,7 @@ inline void
                     asyncResp->res.jsonValue["StorageControllers"][index]
                                             ["Status"]["State"] = "Disabled";
                 }
-                });
+            });
 
             sdbusplus::asio::getAllProperties(
                 *crow::connections::systemBus, connectionName, path,
@@ -228,9 +228,9 @@ inline void
                 {
                     controller["Model"] = *model;
                 }
-                });
+            });
         }
-        },
+    },
         "xyz.openbmc_project.ObjectMapper",
         "/xyz/openbmc_project/object_mapper",
         "xyz.openbmc_project.ObjectMapper", "GetSubTree",
@@ -259,7 +259,7 @@ inline void requestRoutesStorage(App& app)
 
         getDrives(asyncResp);
         getStorageControllers(asyncResp);
-        });
+    });
 }
 
 inline void getDriveAsset(const std::shared_ptr<bmcweb::AsyncResp>& asyncResp,
@@ -314,7 +314,7 @@ inline void getDriveAsset(const std::shared_ptr<bmcweb::AsyncResp>& asyncResp,
         {
             asyncResp->res.jsonValue["Model"] = *model;
         }
-        });
+    });
 }
 
 inline void getDrivePresent(const std::shared_ptr<bmcweb::AsyncResp>& asyncResp,
@@ -337,7 +337,7 @@ inline void getDrivePresent(const std::shared_ptr<bmcweb::AsyncResp>& asyncResp,
         {
             asyncResp->res.jsonValue["Status"]["State"] = "Disabled";
         }
-        });
+    });
 }
 
 inline void getDriveState(const std::shared_ptr<bmcweb::AsyncResp>& asyncResp,
@@ -363,7 +363,7 @@ inline void getDriveState(const std::shared_ptr<bmcweb::AsyncResp>& asyncResp,
         {
             asyncResp->res.jsonValue["Status"]["State"] = "Updating";
         }
-        });
+    });
 }
 
 inline std::optional<drive::MediaType> convertDriveType(std::string_view type)
@@ -524,7 +524,7 @@ inline void
                 }
             }
         }
-        });
+    });
 }
 
 static void addAllDriveInfo(const std::shared_ptr<bmcweb::AsyncResp>& asyncResp,
@@ -590,7 +590,7 @@ inline void requestRoutesDrive(App& app)
                                     dbus::utility::MapperServiceMap>& object) {
                 return sdbusplus::message::object_path(object.first)
                            .filename() == driveId;
-                });
+            });
 
             if (drive == subtree.end())
             {
@@ -620,23 +620,23 @@ inline void requestRoutesDrive(App& app)
             getMainChassisId(
                 asyncResp, [](const std::string& chassisId,
                               const std::shared_ptr<bmcweb::AsyncResp>& aRsp) {
-                    aRsp->res.jsonValue["Links"]["Chassis"]["@odata.id"] =
-                        "/redfish/v1/Chassis/" + chassisId;
-                });
+                aRsp->res.jsonValue["Links"]["Chassis"]["@odata.id"] =
+                    "/redfish/v1/Chassis/" + chassisId;
+            });
 
             // default it to Enabled
             asyncResp->res.jsonValue["Status"]["State"] = "Enabled";
 
             addAllDriveInfo(asyncResp, connectionNames[0].first, path,
                             connectionNames[0].second);
-            },
+        },
             "xyz.openbmc_project.ObjectMapper",
             "/xyz/openbmc_project/object_mapper",
             "xyz.openbmc_project.ObjectMapper", "GetSubTree",
             "/xyz/openbmc_project/inventory", int32_t(0),
             std::array<const char*, 1>{
                 "xyz.openbmc_project.Inventory.Item.Drive"});
-        });
+    });
 }
 
 /**
@@ -727,10 +727,10 @@ inline void chassisDriveCollectionGet(
                     // navigation links will be registered in next patch set
                 }
                 asyncResp->res.jsonValue["Members@odata.count"] = resp.size();
-                }); // end association lambda
+            }); // end association lambda
 
-        }           // end Iterate over all retrieved ObjectPaths
-        },
+        }       // end Iterate over all retrieved ObjectPaths
+    },
         "xyz.openbmc_project.ObjectMapper",
         "/xyz/openbmc_project/object_mapper",
         "xyz.openbmc_project.ObjectMapper", "GetSubTree",
@@ -818,7 +818,7 @@ inline void
                 const boost::system::error_code ec,
                 const dbus::utility::MapperGetSubTreeResponse& subtree) {
             buildDrive(asyncResp, chassisId, driveName, ec, subtree);
-            },
+        },
             "xyz.openbmc_project.ObjectMapper",
             "/xyz/openbmc_project/object_mapper",
             "xyz.openbmc_project.ObjectMapper", "GetSubTree",
@@ -878,10 +878,10 @@ inline void
                     return; // no drives = no failures
                 }
                 matchAndFillDrive(asyncResp, chassisId, driveName, resp);
-                });
+            });
             break;
         }
-        },
+    },
         "xyz.openbmc_project.ObjectMapper",
         "/xyz/openbmc_project/object_mapper",
         "xyz.openbmc_project.ObjectMapper", "GetSubTree",

--- a/redfish-core/lib/systems.hpp
+++ b/redfish-core/lib/systems.hpp
@@ -232,7 +232,7 @@ inline void getProcessorSummary(const std::shared_ptr<bmcweb::AsyncResp>& aResp,
             return;
         }
         getProcessorProperties(aResp, properties);
-        });
+    });
 }
 
 /*
@@ -317,7 +317,7 @@ inline void getComputerSystem(const std::shared_ptr<bmcweb::AsyncResp>& aResp)
                                         return;
                                     }
                                     updateDimmProperties(aResp, dimmState);
-                                    });
+                                });
                                 return;
                             }
 
@@ -363,7 +363,7 @@ inline void getComputerSystem(const std::shared_ptr<bmcweb::AsyncResp>& aResp)
                                 aResp->res.jsonValue["MemorySummary"]["Status"]
                                                     ["State"] = "Enabled";
                             }
-                            });
+                        });
                     }
                     else if (interfaceName ==
                              "xyz.openbmc_project.Inventory.Item.Cpu")
@@ -420,7 +420,7 @@ inline void getComputerSystem(const std::shared_ptr<bmcweb::AsyncResp>& aResp)
                                 BMCWEB_LOG_DEBUG << "UUID = " << valueStr;
                                 aResp->res.jsonValue["UUID"] = valueStr;
                             }
-                            });
+                        });
                     }
                     else if (interfaceName ==
                              "xyz.openbmc_project.Inventory.Item.System")
@@ -493,7 +493,7 @@ inline void getComputerSystem(const std::shared_ptr<bmcweb::AsyncResp>& aResp)
                             sw_util::populateSoftwareInformation(
                                 aResp, sw_util::biosPurpose, "BiosVersion",
                                 false);
-                            });
+                        });
 
                         sdbusplus::asio::getProperty<std::string>(
                             *crow::connections::systemBus, connection.first,
@@ -511,13 +511,13 @@ inline void getComputerSystem(const std::shared_ptr<bmcweb::AsyncResp>& aResp)
                             }
 
                             aResp->res.jsonValue["AssetTag"] = value;
-                            });
+                        });
                     }
                 }
                 break;
             }
         }
-        },
+    },
         "xyz.openbmc_project.ObjectMapper",
         "/xyz/openbmc_project/object_mapper",
         "xyz.openbmc_project.ObjectMapper", "GetSubTree",
@@ -598,7 +598,7 @@ inline void getHostState(const std::shared_ptr<bmcweb::AsyncResp>& aResp)
             aResp->res.jsonValue["PowerState"] = "Off";
             aResp->res.jsonValue["Status"]["State"] = "Disabled";
         }
-        });
+    });
 }
 
 /**
@@ -729,7 +729,7 @@ inline void getBootProgress(const std::shared_ptr<bmcweb::AsyncResp>& aResp)
 
         aResp->res.jsonValue["BootProgress"]["LastState"] =
             dbusToRfBootProgress(bootProgressStr);
-        });
+    });
 }
 
 /**
@@ -763,7 +763,7 @@ inline void getBootProgressLastStateTime(
         // Convert to ISO 8601 standard
         aResp->res.jsonValue["BootProgress"]["LastStateTime"] =
             redfish::time_utils::getDateTimeUintUs(lastStateTime);
-        });
+    });
 }
 
 /**
@@ -800,7 +800,7 @@ inline void getLastResetTime(const std::shared_ptr<bmcweb::AsyncResp>& aResp)
         // Convert to ISO 8601 standard
         aResp->res.jsonValue["LastResetTime"] =
             redfish::time_utils::getDateTimeUint(lastResetTimeStamp);
-        });
+    });
 }
 
 /**
@@ -851,7 +851,7 @@ inline void getAutomaticRetry(const std::shared_ptr<bmcweb::AsyncResp>& aResp)
                 aResp->res
                     .jsonValue["Boot"]["RemainingAutomaticRetryAttempts"] =
                     autoRebootAttemptsLeft;
-                });
+            });
         }
         else
         {
@@ -868,7 +868,7 @@ inline void getAutomaticRetry(const std::shared_ptr<bmcweb::AsyncResp>& aResp)
         aResp->res.jsonValue["Boot"]
                             ["AutomaticRetryConfig@Redfish.AllowableValues"] = {
             "Disabled", "RetryAttempts"};
-        });
+    });
 }
 
 /**
@@ -913,7 +913,7 @@ inline void
         }
 
         aResp->res.jsonValue["PowerRestorePolicy"] = policyMapsIt->second;
-        });
+    });
 }
 
 /**
@@ -949,7 +949,7 @@ inline void getStopBootOnFault(const std::shared_ptr<bmcweb::AsyncResp>& aResp)
         {
             aResp->res.jsonValue["Boot"]["StopBootOnFault"] = "Never";
         }
-        });
+    });
 }
 
 /**
@@ -1029,8 +1029,8 @@ inline void getTrustedModuleRequiredToBoot(
                 aResp->res.jsonValue["Boot"]["TrustedModuleRequiredToBoot"] =
                     "Disabled";
             }
-            });
-        },
+        });
+    },
         "xyz.openbmc_project.ObjectMapper",
         "/xyz/openbmc_project/object_mapper",
         "xyz.openbmc_project.ObjectMapper", "GetSubTree", "/", int32_t(0),
@@ -1110,11 +1110,11 @@ inline void setTrustedModuleRequiredToBoot(
                 return;
             }
             BMCWEB_LOG_DEBUG << "Set TrustedModuleRequiredToBoot done.";
-            },
+        },
             serv, path, "org.freedesktop.DBus.Properties", "Set",
             "xyz.openbmc_project.Control.TPM.Policy", "TPMEnable",
             dbus::utility::DbusVariantType(tpmRequired));
-        },
+    },
         "xyz.openbmc_project.ObjectMapper",
         "/xyz/openbmc_project/object_mapper",
         "xyz.openbmc_project.ObjectMapper", "GetSubTree", "/", int32_t(0),
@@ -1182,11 +1182,11 @@ inline void setAssetTag(const std::shared_ptr<bmcweb::AsyncResp>& aResp,
                 messages::internalError(aResp->res);
                 return;
             }
-            },
+        },
             service, path, "org.freedesktop.DBus.Properties", "Set",
             "xyz.openbmc_project.Inventory.Decorator.AssetTag", "AssetTag",
             dbus::utility::DbusVariantType(assetTag));
-        },
+    },
         "xyz.openbmc_project.ObjectMapper",
         "/xyz/openbmc_project/object_mapper",
         "xyz.openbmc_project.ObjectMapper", "GetSubTree",
@@ -1244,12 +1244,11 @@ inline void setStopBootOnFault(const std::shared_ptr<bmcweb::AsyncResp>& aResp,
         return;
     }
 
-    sdbusplus::asio::setProperty(*crow::connections::systemBus,
-                                 "xyz.openbmc_project.Settings",
-                                 "/xyz/openbmc_project/logging/settings",
-                                 "xyz.openbmc_project.Logging.Settings",
-                                 "QuiesceOnHwError", *stopBootEnabled,
-                                 [aResp](const boost::system::error_code& ec) {
+    sdbusplus::asio::setProperty(
+        *crow::connections::systemBus, "xyz.openbmc_project.Settings",
+        "/xyz/openbmc_project/logging/settings",
+        "xyz.openbmc_project.Logging.Settings", "QuiesceOnHwError",
+        *stopBootEnabled, [aResp](const boost::system::error_code& ec) {
         if (ec)
         {
             if (ec.value() != EBADR)
@@ -1303,7 +1302,7 @@ inline void setAutomaticRetry(const std::shared_ptr<bmcweb::AsyncResp>& aResp,
             messages::internalError(aResp->res);
             return;
         }
-        },
+    },
         "xyz.openbmc_project.Settings",
         "/xyz/openbmc_project/control/host0/auto_reboot",
         "org.freedesktop.DBus.Properties", "Set",
@@ -1353,7 +1352,7 @@ inline void
             messages::internalError(aResp->res);
             return;
         }
-        },
+    },
         "xyz.openbmc_project.Settings",
         "/xyz/openbmc_project/control/host0/power_restore_policy",
         "org.freedesktop.DBus.Properties", "Set",
@@ -1426,7 +1425,7 @@ inline void getProvisioningStatus(std::shared_ptr<bmcweb::AsyncResp> aResp)
         {
             oemPFR["ProvisioningStatus"] = "NotProvisioned";
         }
-        });
+    });
 }
 #endif
 
@@ -1568,8 +1567,8 @@ inline void getPowerMode(const std::shared_ptr<bmcweb::AsyncResp>& aResp)
 
                 translatePowerMode(aResp, *powerMode);
             }
-            });
-        },
+        });
+    },
         "xyz.openbmc_project.ObjectMapper",
         "/xyz/openbmc_project/object_mapper",
         "xyz.openbmc_project.ObjectMapper", "GetSubTree", "/", int32_t(0),
@@ -1687,11 +1686,11 @@ inline void setPowerMode(const std::shared_ptr<bmcweb::AsyncResp>& aResp,
                 messages::internalError(aResp->res);
                 return;
             }
-            },
+        },
             service, path, "org.freedesktop.DBus.Properties", "Set",
             "xyz.openbmc_project.Control.Power.Mode", "PowerMode",
             dbus::utility::DbusVariantType(powerMode));
-        },
+    },
         "xyz.openbmc_project.ObjectMapper",
         "/xyz/openbmc_project/object_mapper",
         "xyz.openbmc_project.ObjectMapper", "GetSubTree", "/", int32_t(0),
@@ -1819,7 +1818,7 @@ inline void
             }
             hostWatchdogTimer["TimeoutAction"] = action;
         }
-        });
+    });
 }
 
 /**
@@ -1859,7 +1858,7 @@ inline void setWDTProperties(const std::shared_ptr<bmcweb::AsyncResp>& aResp,
                 messages::internalError(aResp->res);
                 return;
             }
-            },
+        },
             "xyz.openbmc_project.Watchdog",
             "/xyz/openbmc_project/watchdog/host0",
             "org.freedesktop.DBus.Properties", "Set",
@@ -1877,7 +1876,7 @@ inline void setWDTProperties(const std::shared_ptr<bmcweb::AsyncResp>& aResp,
                 messages::internalError(aResp->res);
                 return;
             }
-            },
+        },
             "xyz.openbmc_project.Watchdog",
             "/xyz/openbmc_project/watchdog/host0",
             "org.freedesktop.DBus.Properties", "Set",
@@ -2025,8 +2024,8 @@ inline void getIdlePowerSaver(const std::shared_ptr<bmcweb::AsyncResp>& aResp)
                 messages::internalError(aResp->res);
                 return;
             }
-            });
-        },
+        });
+    },
         "xyz.openbmc_project.ObjectMapper",
         "/xyz/openbmc_project/object_mapper",
         "xyz.openbmc_project.ObjectMapper", "GetSubTree", "/", int32_t(0),
@@ -2056,7 +2055,7 @@ inline void doGetEnabledPanelFunctions(
             return;
         }
         callback(enabledFuncs);
-        },
+    },
         "com.ibm.PanelApp", "/com/ibm/panel_app", "com.ibm.panel",
         "getEnabledFunctions");
 }
@@ -2069,11 +2068,11 @@ inline void getEnabledPanelFunctions(
 {
     doGetEnabledPanelFunctions(
         asyncResp, [asyncResp](const std::vector<uint8_t>& enabledFuncs) {
-            nlohmann::json& oem = asyncResp->res.jsonValue["Oem"];
-            oem["@odata.type"] = "#OemComputerSystem.Oem";
-            oem["IBM"]["@odata.type"] = "#OemComputerSystem.IBM";
-            oem["IBM"]["EnabledPanelFunctions"] = enabledFuncs;
-        });
+        nlohmann::json& oem = asyncResp->res.jsonValue["Oem"];
+        oem["@odata.type"] = "#OemComputerSystem.Oem";
+        oem["IBM"]["@odata.type"] = "#OemComputerSystem.IBM";
+        oem["IBM"]["EnabledPanelFunctions"] = enabledFuncs;
+    });
 }
 
 /**
@@ -2133,7 +2132,7 @@ inline void
         asyncResp->res.jsonValue["Result"] = {std::get<1>(result),
                                               std::get<2>(result)};
         messages::success(asyncResp->res);
-        },
+    },
         "com.ibm.PanelApp", "/com/ibm/panel_app", "com.ibm.panel",
         "ExecuteFunction", funcNo);
 }
@@ -2169,7 +2168,7 @@ inline void handleSystemActionsOemExecutePanelFunctionPost(
             return;
         }
         executePanelFunction(asyncResp, funcNo);
-        });
+    });
 }
 
 /**
@@ -2269,7 +2268,7 @@ inline void setIdlePowerSaver(const std::shared_ptr<bmcweb::AsyncResp>& aResp,
                     messages::internalError(aResp->res);
                     return;
                 }
-                },
+            },
                 service, path, "org.freedesktop.DBus.Properties", "Set",
                 "xyz.openbmc_project.Control.Power.IdlePowerSaver", "Enabled",
                 dbus::utility::DbusVariantType(*ipsEnable));
@@ -2284,7 +2283,7 @@ inline void setIdlePowerSaver(const std::shared_ptr<bmcweb::AsyncResp>& aResp,
                     messages::internalError(aResp->res);
                     return;
                 }
-                },
+            },
                 service, path, "org.freedesktop.DBus.Properties", "Set",
                 "xyz.openbmc_project.Control.Power.IdlePowerSaver",
                 "EnterUtilizationPercent",
@@ -2302,7 +2301,7 @@ inline void setIdlePowerSaver(const std::shared_ptr<bmcweb::AsyncResp>& aResp,
                     messages::internalError(aResp->res);
                     return;
                 }
-                },
+            },
                 service, path, "org.freedesktop.DBus.Properties", "Set",
                 "xyz.openbmc_project.Control.Power.IdlePowerSaver",
                 "EnterDwellTime",
@@ -2318,7 +2317,7 @@ inline void setIdlePowerSaver(const std::shared_ptr<bmcweb::AsyncResp>& aResp,
                     messages::internalError(aResp->res);
                     return;
                 }
-                },
+            },
                 service, path, "org.freedesktop.DBus.Properties", "Set",
                 "xyz.openbmc_project.Control.Power.IdlePowerSaver",
                 "ExitUtilizationPercent",
@@ -2336,13 +2335,13 @@ inline void setIdlePowerSaver(const std::shared_ptr<bmcweb::AsyncResp>& aResp,
                     messages::internalError(aResp->res);
                     return;
                 }
-                },
+            },
                 service, path, "org.freedesktop.DBus.Properties", "Set",
                 "xyz.openbmc_project.Control.Power.IdlePowerSaver",
                 "ExitDwellTime",
                 dbus::utility::DbusVariantType(timeMilliseconds));
         }
-        },
+    },
         "xyz.openbmc_project.ObjectMapper",
         "/xyz/openbmc_project/object_mapper",
         "xyz.openbmc_project.ObjectMapper", "GetSubTree", "/", int32_t(0),
@@ -2417,8 +2416,8 @@ inline void requestRoutesSystemsCollection(App& app)
                 ifaceArray.push_back(std::move(hypervisor));
                 resCount = ifaceArray.size();
             }
-            });
         });
+    });
 }
 
 /**
@@ -2441,7 +2440,7 @@ inline void doNMI(const std::shared_ptr<bmcweb::AsyncResp>& asyncResp)
             return;
         }
         messages::success(asyncResp->res);
-        },
+    },
         serviceName, objectPath, interfaceName, method);
 }
 
@@ -2566,7 +2565,7 @@ inline void requestRoutesSystemActionsReset(App& app)
                     return;
                 }
                 messages::success(asyncResp->res);
-                },
+            },
                 "xyz.openbmc_project.State.Host",
                 "/xyz/openbmc_project/state/host0",
                 "org.freedesktop.DBus.Properties", "Set",
@@ -2585,14 +2584,14 @@ inline void requestRoutesSystemActionsReset(App& app)
                     return;
                 }
                 messages::success(asyncResp->res);
-                },
+            },
                 "xyz.openbmc_project.State.Chassis",
                 "/xyz/openbmc_project/state/chassis0",
                 "org.freedesktop.DBus.Properties", "Set",
                 "xyz.openbmc_project.State.Chassis", "RequestedPowerTransition",
                 dbus::utility::DbusVariantType{command});
         }
-        });
+    });
 }
 
 inline void handleComputerSystemCollectionHead(
@@ -2767,7 +2766,7 @@ inline void requestRoutesSystems(App& app)
                 return;
             }
             getLocationIndicatorActive(asyncResp, *validSystemsPath);
-            });
+        });
 
         // TODO (Gunnar): Remove IndicatorLED after enough time has passed
         getIndicatorLedState(asyncResp);
@@ -2793,7 +2792,7 @@ inline void requestRoutesSystems(App& app)
         getPowerMode(asyncResp);
         getIdlePowerSaver(asyncResp);
         getEnabledPanelFunctions(asyncResp);
-        });
+    });
 
     BMCWEB_ROUTE(app, "/redfish/v1/Systems/<str>/")
         .privileges(redfish::privileges::patchComputerSystem)
@@ -2900,7 +2899,7 @@ inline void requestRoutesSystems(App& app)
                 }
                 setLocationIndicatorActive(asyncResp, *validSystemsPath,
                                            locationIndicatorActive);
-                });
+            });
         }
 
         // TODO (Gunnar): Remove IndicatorLED after enough time has
@@ -2992,7 +2991,7 @@ inline void requestRoutesSystems(App& app)
             setIdlePowerSaver(asyncResp, ipsEnable, ipsEnterUtil, ipsEnterTime,
                               ipsExitUtil, ipsExitTime);
         }
-        });
+    });
 }
 
 inline void handleSystemCollectionResetActionHead(
@@ -3059,6 +3058,6 @@ inline void requestRoutesSystemResetActionInfo(App& app)
         parameters.emplace_back(std::move(parameter));
 
         asyncResp->res.jsonValue["Parameters"] = std::move(parameters);
-        });
+    });
 }
 } // namespace redfish

--- a/redfish-core/lib/task.hpp
+++ b/redfish-core/lib/task.hpp
@@ -288,7 +288,7 @@ struct TaskData : std::enable_shared_from_this<TaskData>
                     [self] { self->match.reset(); });
                 return;
             }
-            });
+        });
 
         extendTimer(timeout);
         messages.emplace_back(messages::taskStarted(std::to_string(index)));
@@ -338,7 +338,7 @@ inline void requestRoutesTaskMonitor(App& app)
             // we compare against the string version as on failure
             // strtoul returns 0
             return std::to_string(task->index) == strParam;
-            });
+        });
 
         if (find == task::tasks.end())
         {
@@ -353,7 +353,7 @@ inline void requestRoutesTaskMonitor(App& app)
             return;
         }
         ptr->populateResp(asyncResp->res);
-        });
+    });
 }
 
 inline void requestRoutesTask(App& app)
@@ -379,7 +379,7 @@ inline void requestRoutesTask(App& app)
             // we compare against the string version as on failure
             // strtoul returns 0
             return std::to_string(task->index) == strParam;
-            });
+        });
 
         if (find == task::tasks.end())
         {
@@ -420,7 +420,7 @@ inline void requestRoutesTask(App& app)
                 2, ' ', true, nlohmann::json::error_handler_t::replace);
         }
         asyncResp->res.jsonValue["PercentComplete"] = ptr->percentComplete;
-        });
+    });
 }
 
 inline void requestRoutesTaskCollection(App& app)
@@ -453,7 +453,7 @@ inline void requestRoutesTaskCollection(App& app)
                                   std::to_string(task->index);
             members.emplace_back(std::move(member));
         }
-        });
+    });
 }
 
 inline void requestRoutesTaskService(App& app)
@@ -482,7 +482,7 @@ inline void requestRoutesTaskService(App& app)
         asyncResp->res.jsonValue["ServiceEnabled"] = true;
         asyncResp->res.jsonValue["Tasks"]["@odata.id"] =
             "/redfish/v1/TaskService/Tasks";
-        });
+    });
 }
 
 } // namespace redfish

--- a/redfish-core/lib/telemetry_service.hpp
+++ b/redfish-core/lib/telemetry_service.hpp
@@ -84,7 +84,7 @@ inline void handleTelemetryServiceGet(
         asyncResp->res.jsonValue["SupportedCollectionFunctions"] =
             std::array<std::string_view, 4>(
                 {"Maximum", "Minimum", "Average", "Summation"});
-        });
+    });
 }
 
 inline void requestRoutesTelemetryService(App& app)

--- a/redfish-core/lib/thermal.hpp
+++ b/redfish-core/lib/thermal.hpp
@@ -43,7 +43,7 @@ inline void requestRoutesThermal(App& app)
 
         // TODO Need to get Chassis Redundancy information.
         getChassisData(sensorAsyncResp);
-        });
+    });
 
     BMCWEB_ROUTE(app, "/redfish/v1/Chassis/<str>/Thermal/")
         .privileges(redfish::privileges::patchThermal)
@@ -87,7 +87,7 @@ inline void requestRoutesThermal(App& app)
             allCollections.emplace("Fans", *std::move(fanCollections));
         }
         setSensorsOverride(sensorsAsyncResp, allCollections);
-        });
+    });
 }
 
 } // namespace redfish

--- a/redfish-core/lib/thermal_metrics.hpp
+++ b/redfish-core/lib/thermal_metrics.hpp
@@ -201,7 +201,7 @@ void getThermalMetrics(
                              sensorsAsyncResp->types, nodeSensorList,
                              culledSensorList);
             callback(culledSensorList);
-            });
+        });
     };
     dbus::utility::getSubTreePaths("/xyz/openbmc_project/inventory", 0,
                                    interfaces, std::move(respHandler));
@@ -361,7 +361,7 @@ inline void
         [sensorsAsyncResp](
             const std::shared_ptr<std::set<std::string>>& sensorNames) {
         processThermalSensorList(sensorsAsyncResp, sensorNames);
-        });
+    });
 }
 
 inline void

--- a/redfish-core/lib/trigger.hpp
+++ b/redfish-core/lib/trigger.hpp
@@ -311,7 +311,7 @@ inline void requestRoutesTriggerCollection(App& app)
             boost::urls::url("/redfish/v1/TelemetryService/Triggers"),
             interfaces,
             "/xyz/openbmc_project/Telemetry/Triggers/TelemetryService");
-        });
+    });
 }
 
 inline void requestRoutesTrigger(App& app)
@@ -350,8 +350,8 @@ inline void requestRoutesTrigger(App& app)
             {
                 messages::internalError(asyncResp->res);
             }
-            });
         });
+    });
 
     BMCWEB_ROUTE(app, "/redfish/v1/TelemetryService/Triggers/<str>/")
         .privileges(redfish::privileges::deleteTriggers)
@@ -381,10 +381,10 @@ inline void requestRoutesTrigger(App& app)
             }
 
             asyncResp->res.result(boost::beast::http::status::no_content);
-            },
+        },
             telemetry::service, triggerPath,
             "xyz.openbmc_project.Object.Delete", "Delete");
-        });
+    });
 }
 
 } // namespace redfish

--- a/redfish-core/lib/update_service.hpp
+++ b/redfish-core/lib/update_service.hpp
@@ -55,7 +55,7 @@ inline static void activateImage(const std::string& objPath,
             BMCWEB_LOG_DEBUG << "error_code = " << errorCode;
             BMCWEB_LOG_DEBUG << "error msg = " << errorCode.message();
         }
-        },
+    },
         service, objPath, "org.freedesktop.DBus.Properties", "Set",
         "xyz.openbmc_project.Software.Activation", "RequestedActivation",
         dbus::utility::DbusVariantType(
@@ -154,7 +154,7 @@ inline void
                 }
             }
         }
-        },
+    },
         "xyz.openbmc_project.Logging", "/xyz/openbmc_project/logging",
         "org.freedesktop.DBus.ObjectManager", "GetManagedObjects");
 }
@@ -327,7 +327,7 @@ static void
                         // unless it is an error
 
                         return !task::completed;
-                            },
+                    },
                             "type='signal',interface='org.freedesktop.DBus.Properties',"
                             "member='PropertiesChanged',path='" +
                                 objPath.str + "'");
@@ -336,7 +336,7 @@ static void
                     task->payload.emplace(std::move(payload));
                 }
                 fwUpdateInProgress = false;
-                },
+            },
                 "xyz.openbmc_project.ObjectMapper",
                 "/xyz/openbmc_project/object_mapper",
                 "xyz.openbmc_project.ObjectMapper", "GetObject", objPath.str,
@@ -636,13 +636,13 @@ inline void requestRoutesUpdateServiceActionsSimpleUpdate(App& app)
             {
                 BMCWEB_LOG_DEBUG << "Call to DownloaViaTFTP Success";
             }
-            },
+        },
             "xyz.openbmc_project.Software.Download",
             "/xyz/openbmc_project/software", "xyz.openbmc_project.Common.TFTP",
             "DownloadViaTFTP", fwFile, tftpServer);
 
         BMCWEB_LOG_DEBUG << "Exit UpdateService.SimpleUpdate doPost";
-        });
+    });
 }
 
 inline void
@@ -685,7 +685,7 @@ inline void requestRoutesUpdateServiceActionsOemConcurrentUpdate(App& app)
         handleUpdateServicePost(app, req, asyncResp,
                                 "/redfish/v1/UpdateService/Actions/Oem/"
                                 "OemUpdateService.ConcurrentUpdate");
-            },
+    },
             std::ref(app)));
 }
 
@@ -771,8 +771,8 @@ inline void requestRoutesUpdateService(App& app)
                                         ["HttpPushUriApplyTime"]["ApplyTime"] =
                     "OnReset";
             }
-            });
         });
+    });
     BMCWEB_ROUTE(app, "/redfish/v1/UpdateService/")
         .privileges(redfish::privileges::patchUpdateService)
         .methods(boost::beast::http::verb::patch)(
@@ -841,7 +841,7 @@ inline void requestRoutesUpdateService(App& app)
                             return;
                         }
                         messages::success(asyncResp->res);
-                        },
+                    },
                         "xyz.openbmc_project.Settings",
                         "/xyz/openbmc_project/software/apply_time",
                         "org.freedesktop.DBus.Properties", "Set",
@@ -851,7 +851,7 @@ inline void requestRoutesUpdateService(App& app)
                 }
             }
         }
-        });
+    });
 
 // The "old" behavior of the update service URI causes redfish-service validator
 // failures when the Allow header is supported, given that in the spec,
@@ -873,7 +873,7 @@ inline void requestRoutesUpdateService(App& app)
             "the value contained within HttpPushUri.\"");
         handleUpdateServicePost(app, req, asyncResp,
                                 "/redfish/v1/UpdateService");
-        });
+    });
 #endif
     BMCWEB_ROUTE(app, "/redfish/v1/UpdateService/update/")
         .privileges(redfish::privileges::postUpdateService)
@@ -882,7 +882,7 @@ inline void requestRoutesUpdateService(App& app)
                    const std::shared_ptr<bmcweb::AsyncResp>& asyncResp) {
         handleUpdateServicePost(app, req, asyncResp,
                                 "/redfish/v1/UpdateService");
-            },
+    },
             std::ref(app)));
 }
 
@@ -934,7 +934,7 @@ inline void requestRoutesSoftwareInventoryCollection(App& app)
                 asyncResp->res.jsonValue["Members@odata.count"] =
                     members.size();
             }
-            },
+        },
             // Note that only firmware levels associated with a device
             // are stored under /xyz/openbmc_project/software therefore
             // to ensure only real FirmwareInventory items are returned,
@@ -945,7 +945,7 @@ inline void requestRoutesSoftwareInventoryCollection(App& app)
             "xyz.openbmc_project.ObjectMapper", "GetSubTree",
             "/xyz/openbmc_project/software", static_cast<int32_t>(0),
             std::array<const char*, 1>{"xyz.openbmc_project.Software.Version"});
-        });
+    });
 }
 /* Fill related item links (i.e. bmc, bios) in for inventory */
 inline static void
@@ -1043,7 +1043,7 @@ inline void
         std::string formatDesc = swInvPurpose->substr(endDesc);
         asyncResp->res.jsonValue["Description"] = formatDesc + " image";
         getRelatedItems(asyncResp, *swInvPurpose);
-        });
+    });
 }
 
 inline void requestRoutesSoftwareInventory(App& app)
@@ -1113,13 +1113,13 @@ inline void requestRoutesSoftwareInventory(App& app)
 
             asyncResp->res.jsonValue["Updateable"] = false;
             sw_util::getSwUpdatableStatus(asyncResp, swId);
-            },
+        },
             "xyz.openbmc_project.ObjectMapper",
             "/xyz/openbmc_project/object_mapper",
             "xyz.openbmc_project.ObjectMapper", "GetSubTree", "/",
             static_cast<int32_t>(0),
             std::array<const char*, 1>{"xyz.openbmc_project.Software.Version"});
-        });
+    });
 }
 
 } // namespace redfish

--- a/redfish-core/lib/virtual_media.hpp
+++ b/redfish-core/lib/virtual_media.hpp
@@ -31,7 +31,7 @@ namespace redfish
  */
 inline std::string getTransferProtocolTypeFromUri(const std::string& imageUri)
 {
-    boost::urls::result<boost::urls::url_view> url =
+    boost::system::result<boost::urls::url_view> url =
         boost::urls::parse_uri(imageUri);
     if (!url)
     {
@@ -400,7 +400,7 @@ inline bool
 
         return false;
     }
-    boost::urls::result<boost::urls::url_view> url =
+    boost::system::result<boost::urls::url_view> url =
         boost::urls::parse_uri(imageUrl);
     if (!url)
     {

--- a/redfish-core/lib/virtual_media.hpp
+++ b/redfish-core/lib/virtual_media.hpp
@@ -197,7 +197,7 @@ inline void getVmResourceList(std::shared_ptr<bmcweb::AsyncResp> aResp,
             members.emplace_back(std::move(item));
         }
         aResp->res.jsonValue["Members@odata.count"] = members.size();
-        },
+    },
         service, "/xyz/openbmc_project/VirtualMedia",
         "org.freedesktop.DBus.ObjectManager", "GetManagedObjects");
 }
@@ -271,7 +271,7 @@ inline void getVmData(const std::shared_ptr<bmcweb::AsyncResp>& aResp,
         }
 
         messages::resourceNotFound(aResp->res, "VirtualMedia", resName);
-        },
+    },
         service, "/xyz/openbmc_project/VirtualMedia",
         "org.freedesktop.DBus.ObjectManager", "GetManagedObjects");
 }
@@ -701,7 +701,7 @@ inline void doMountVmLegacy(const std::shared_ptr<bmcweb::AsyncResp>& asyncResp,
             BMCWEB_LOG_ERROR << "Service responded with error";
             messages::generalError(asyncResp->res);
         }
-        },
+    },
         service, "/xyz/openbmc_project/VirtualMedia/Legacy/" + name,
         "xyz.openbmc_project.VirtualMedia.Legacy", "Mount", imageUrl, rw,
         unixFd);
@@ -728,7 +728,7 @@ inline void doVmAction(const std::shared_ptr<bmcweb::AsyncResp>& asyncResp,
                 messages::internalError(asyncResp->res);
                 return;
             }
-            },
+        },
             service, "/xyz/openbmc_project/VirtualMedia/Legacy/" + name,
             "xyz.openbmc_project.VirtualMedia.Legacy", "Unmount");
     }
@@ -743,7 +743,7 @@ inline void doVmAction(const std::shared_ptr<bmcweb::AsyncResp>& asyncResp,
                 messages::internalError(asyncResp->res);
                 return;
             }
-            },
+        },
             service, "/xyz/openbmc_project/VirtualMedia/Proxy/" + name,
             "xyz.openbmc_project.VirtualMedia.Proxy", "Unmount");
     }
@@ -873,10 +873,10 @@ inline void handleManagersVirtualMediaActionInsertPost(
             }
             BMCWEB_LOG_DEBUG << "Parent item not found";
             messages::resourceNotFound(asyncResp->res, "VirtualMedia", resName);
-            },
+        },
             service, "/xyz/openbmc_project/VirtualMedia",
             "org.freedesktop.DBus.ObjectManager", "GetManagedObjects");
-        },
+    },
         "xyz.openbmc_project.ObjectMapper",
         "/xyz/openbmc_project/object_mapper",
         "xyz.openbmc_project.ObjectMapper", "GetObject",
@@ -959,10 +959,10 @@ inline void handleManagersVirtualMediaActionEject(
             }
             BMCWEB_LOG_DEBUG << "Parent item not found";
             messages::resourceNotFound(asyncResp->res, "VirtualMedia", resName);
-            },
+        },
             service, "/xyz/openbmc_project/VirtualMedia",
             "org.freedesktop.DBus.ObjectManager", "GetManagedObjects");
-        },
+    },
         "xyz.openbmc_project.ObjectMapper",
         "/xyz/openbmc_project/object_mapper",
         "xyz.openbmc_project.ObjectMapper", "GetObject",
@@ -1005,7 +1005,7 @@ inline void handleManagersVirtualMediaCollectionGet(
         BMCWEB_LOG_DEBUG << "GetObjectType: " << service;
 
         getVmResourceList(asyncResp, service, name);
-        },
+    },
         "xyz.openbmc_project.ObjectMapper",
         "/xyz/openbmc_project/object_mapper",
         "xyz.openbmc_project.ObjectMapper", "GetObject",
@@ -1043,7 +1043,7 @@ inline void
         BMCWEB_LOG_DEBUG << "GetObjectType: " << service;
 
         getVmData(asyncResp, service, name, resName);
-        },
+    },
         "xyz.openbmc_project.ObjectMapper",
         "/xyz/openbmc_project/object_mapper",
         "xyz.openbmc_project.ObjectMapper", "GetObject",

--- a/src/boost_url.cpp
+++ b/src/boost_url.cpp
@@ -1,2 +1,0 @@
-
-#include <boost/url/src.hpp>

--- a/subprojects/boost.wrap
+++ b/subprojects/boost.wrap
@@ -1,11 +1,9 @@
 [wrap-file]
-directory = boost_1_82_0
+directory = boost-1.83.0
 
-source_url = https://boostorg.jfrog.io/artifactory/main/release/1.82.0/source/boost_1_82_0.tar.bz2
-source_hash = a6e1ab9b0860e6a2881dd7b21fe9f737a095e5f33a3a874afc6a345228597ee6
-source_filename = 1_82_0.tar.bz2
-
-patch_directory = boost
+source_url = https://github.com/boostorg/boost/releases/download/boost-1.83.0/boost-1.83.0.tar.gz
+source_hash = 0c6049764e80aa32754acd7d4f179fd5551d8172a83b71532ae093e7384e98da
+source_filename = 1_83_0.tar.gz
 
 [provide]
 boost = boost_dep

--- a/subprojects/packagefiles/boost/meson.build
+++ b/subprojects/packagefiles/boost/meson.build
@@ -1,9 +1,0 @@
-project('boost',
-    'cpp',
-    version : '1.80.0',
-    license : 'Boost'
-)
-
-boost_dep = declare_dependency(
-    include_directories : include_directories('.'),
-)

--- a/test/http/utility_test.cpp
+++ b/test/http/utility_test.cpp
@@ -98,7 +98,7 @@ TEST(Utility, UrlFromPieces)
 
 TEST(Utility, readUrlSegments)
 {
-    boost::urls::result<boost::urls::url_view> parsed =
+    boost::system::result<boost::urls::url_view> parsed =
         boost::urls::parse_relative_ref("/redfish/v1/Chassis#/Fans/0/Reading");
 
     EXPECT_TRUE(readUrlSegments(*parsed, "redfish", "v1", "Chassis"));

--- a/test/redfish-core/include/redfish_aggregator_test.cpp
+++ b/test/redfish-core/include/redfish_aggregator_test.cpp
@@ -413,7 +413,7 @@ TEST(processCollectionResponse, bothExist)
 
     bool foundLocal = false;
     bool foundSat = false;
-    for (auto& member : asyncResp->res.jsonValue["Members"])
+    for (const auto& member : asyncResp->res.jsonValue["Members"])
     {
         if (member["@odata.id"] == "/redfish/v1/Systems/system")
         {

--- a/test/redfish-core/include/utils/hex_utils_test.cpp
+++ b/test/redfish-core/include/utils/hex_utils_test.cpp
@@ -54,11 +54,11 @@ TEST(HexCharToNibble, ReturnsCorrectNibbleForEveryHexChar)
         }
         else if (c >= 'A' && c <= 'F')
         {
-            expected = static_cast<uint8_t>(c) - 'A' + 10;
+            expected = static_cast<uint8_t>(c - 'A') + 10U;
         }
         else if (c >= 'a' && c <= 'f')
         {
-            expected = static_cast<uint8_t>(c) - 'a' + 10;
+            expected = static_cast<uint8_t>(c - 'a') + 10U;
         }
 
         EXPECT_EQ(hexCharToNibble(c), expected);

--- a/test/redfish-core/include/utils/json_utils_test.cpp
+++ b/test/redfish-core/include/utils/json_utils_test.cpp
@@ -121,7 +121,8 @@ TEST(ReadJson, JsonArrayAreUnpackedCorrectly)
     ASSERT_TRUE(readJson(jsonRequest, res, "TestJson", jsonVec));
     EXPECT_EQ(res.result(), boost::beast::http::status::ok);
     EXPECT_THAT(res.jsonValue, IsEmpty());
-    EXPECT_EQ(jsonVec, R"([{"hello": "yes"}, [{"there": "no"}, "nice"]])"_json);
+    EXPECT_THAT(jsonVec, ElementsAre(R"({"hello": "yes"})"_json,
+                                     R"([{"there": "no"}, "nice"])"_json));
 }
 
 TEST(ReadJson, JsonSubElementValueAreUnpackedCorrectly)


### PR DESCRIPTION
This is https://github.com/ibm-openbmc/bmcweb/pull/779 as a base + the needed changes for clang17 (pulled in upstream .clang-format file and ran against our downstream code)