### PR TITLE
WIP: Remove 30 sec expire timer for sendMessage

### DIFF
--- a/http/http_client.hpp
+++ b/http/http_client.hpp
@@ -278,10 +278,6 @@ class ConnectionInfo : public std::enable_shared_from_this<ConnectionInfo>
     {
         state = ConnState::sendInProgress;
 
-        // Set a timeout on the operation
-        timer.expires_after(std::chrono::seconds(30));
-        timer.async_wait(std::bind_front(onTimeout, weak_from_this()));
-
         // Send the HTTP request to the remote host
         if (sslConn)
         {


### PR DESCRIPTION
https://github.com/ibm-openbmc/bmcweb/pull/283 is the 1020 change for this. Match it.