### PR TITLE
1060: Fix OemPCIeSlots Schema Redfish Validator warnings

### DIFF
--- a/redfish-core/lib/pcie_slots.hpp
+++ b/redfish-core/lib/pcie_slots.hpp
@@ -229,10 +229,9 @@ inline void linkAssociatedDiskBackplane(
                                 drivePath);
             if (it != assemblyList.end())
             {
-                asyncResp->res.jsonValue["Slots"][index]["Links"]["Oem"]
-                                        ["@odata.type"] = "#OemPCIeSlots.Oem";
                 asyncResp->res.jsonValue["Slots"][index]["Links"]["Oem"]["IBM"]
-                                        ["@odata.type"] = "#OemPCIeSlots.IBM";
+                                        ["@odata.type"] =
+                    "#OemPCIeSlots.v1_0_0.PCIeLinks";
                 asyncResp->res.jsonValue["Slots"][index]["Links"]["Oem"]["IBM"]
                                         ["AssociatedAssembly"]["@odata.id"] =
                     "/redfish/v1/Chassis/" + chassisId +
@@ -327,8 +326,8 @@ inline void
         const std::string& fabricAdapterPath = fabricAdapterPaths.front();
         nlohmann::json& slot = asyncResp->res.jsonValue["Slots"][index];
 
-        slot["Links"]["Oem"]["@odata.type"] = "#OemPCIeSlots.Oem";
-        slot["Links"]["Oem"]["IBM"]["@odata.type"] = "#OemPCIeSlots.IBM";
+        slot["Links"]["Oem"]["IBM"]["@odata.type"] =
+            "#OemPCIeSlots.v1_0_0.PCIeLinks";
         slot["Links"]["Oem"]["IBM"]["UpstreamFabricAdapter"]["@odata.id"] =
             crow::utility::urlFromPieces(
                 "redfish", "v1", "Systems", "system", "FabricAdapters",
@@ -413,8 +412,7 @@ inline void getPCIeSlotProperties(
 
     if (busId != nullptr)
     {
-        slot["Oem"]["@odata.type"] = "#OemPCIeSlots.Oem";
-        slot["Oem"]["IBM"]["@odata.type"] = "#OemPCIeSlots.IBM";
+        slot["Oem"]["IBM"]["@odata.type"] = "#OemPCIeSlots.v1_0_0.PCIeSlot";
         slot["Oem"]["IBM"]["LinkId"] = *busId;
     }
 

--- a/static/redfish/v1/JsonSchemas/OemPCIeSlots/OemPCIeSlots.json
+++ b/static/redfish/v1/JsonSchemas/OemPCIeSlots/OemPCIeSlots.json
@@ -3,7 +3,7 @@
     "$schema": "http://redfish.dmtf.org/schemas/v1/redfish-schema-v1.json",
     "copyright": "Copyright 2014-2019 DMTF. For the full DMTF copyright policy, see http://www.dmtf.org/about/policies/copyright",
     "definitions": {
-        "IBM": {
+        "PCIeSlot": {
             "additionalProperties": true,
             "description": "Oem properties for IBM.",
             "patternProperties": {
@@ -25,7 +25,28 @@
                     "description": "An identifier to detect the PCIe bus linked to the slot.",
                     "readonly": true,
                     "type": "integer"
-                },
+                }
+            },
+            "type": "object"
+        },
+        "PCIeLinks": {
+            "additionalProperties": true,
+            "description": "Oem link properties for IBM.",
+            "patternProperties": {
+                "^([a-zA-Z_][a-zA-Z0-9_]*)?@(odata|Redfish|Message)\\.[a-zA-Z_][a-zA-Z0-9_]*$": {
+                    "description": "This property shall specify a valid odata or Redfish property.",
+                    "type": [
+                        "array",
+                        "boolean",
+                        "integer",
+                        "number",
+                        "null",
+                        "object",
+                        "string"
+                    ]
+                }
+            },
+            "properties": {
                 "AssociatedAssembly": {
                     "description": "Represent association slot with assembly.",
                     "readonly": true,
@@ -43,38 +64,9 @@
                 }
             },
             "type": "object"
-        },
-        "Oem": {
-            "additionalProperties": true,
-            "description": "OemPCIeSlots Oem properties.",
-            "patternProperties": {
-                "^([a-zA-Z_][a-zA-Z0-9_]*)?@(odata|Redfish|Message)\\.[a-zA-Z_][a-zA-Z0-9_]*$": {
-                    "description": "This property shall specify a valid odata or Redfish property.",
-                    "type": [
-                        "array",
-                        "boolean",
-                        "integer",
-                        "number",
-                        "null",
-                        "object",
-                        "string"
-                    ]
-                }
-            },
-            "properties": {
-                "IBM": {
-                    "anyOf": [
-                        {
-                            "$ref": "#/definitions/IBM"
-                        },
-                        {
-                            "type": "null"
-                        }
-                    ]
-                }
-            },
-            "type": "object"
         }
     },
-    "title": "#OemPCIeSlots"
+    "owningEntity": "IBM",
+    "release": "1.0",
+    "title": "#OemPCIeSlots.v1_0_0"
 }

--- a/static/redfish/v1/schema/OemPCIeSlots_v1.xml
+++ b/static/redfish/v1/schema/OemPCIeSlots_v1.xml
@@ -10,10 +10,13 @@
   <edmx:Reference Uri="http://redfish.dmtf.org/schemas/v1/RedfishExtensions_v1.xml">
     <edmx:Include Namespace="RedfishExtensions.v1_0_0" Alias="Redfish"/>
   </edmx:Reference>
-    <edmx:Reference Uri="http://redfish.dmtf.org/schemas/v1/PCIeSlots_v1.xml">
-        <edmx:Include Namespace="PCIeSlots"/>
-        <edmx:Include Namespace="PCIeSlots.v1_5_0"/>
-    </edmx:Reference>
+  <edmx:Reference Uri="http://redfish.dmtf.org/schemas/v1/FabricAdapter_v1.xml">
+    <edmx:Include Namespace="FabricAdapter"/>
+  </edmx:Reference>
+  <edmx:Reference Uri="http://redfish.dmtf.org/schemas/v1/PCIeSlots_v1.xml">
+    <edmx:Include Namespace="PCIeSlots"/>
+    <edmx:Include Namespace="PCIeSlots.v1_5_0"/>
+  </edmx:Reference>
   <edmx:Reference Uri="http://redfish.dmtf.org/schemas/v1/Resource_v1.xml">
     <edmx:Include Namespace="Resource"/>
     <edmx:Include Namespace="Resource.v1_0_0"/>
@@ -28,31 +31,27 @@
     <Schema xmlns="http://docs.oasis-open.org/odata/ns/edm" Namespace="OemPCIeSlots.v1_0_0">
       <Annotation Term="Redfish.OwningEntity" String="IBM"/>
 
-      <ComplexType Name="Oem" BaseType="Resource.OemObject">
-        <Annotation Term="OData.AdditionalProperties" Bool="true"/>
-        <Annotation Term="OData.Description" String="OemPCIeSlots Oem properties."/>
-        <Annotation Term="OData.AutoExpand"/>
-        <Property Name="IBM" Type="OemPCIeSlots.IBM"/>
-      </ComplexType>
-
-      <ComplexType Name="IBM" BaseType="Resource.OemObject">
-        <Annotation Term="OData.AdditionalProperties" Bool="true" />
-        <Annotation Term="OData.Description" String="Oem properties for IBM." />
-        <Annotation Term="OData.AutoExpand"/>
-
-        <Property Name="LinkId" Type="OemPCIeSlots.IBM">
+      <ComplexType Name="PCIeSlot" BaseType="Resource.OemObject">
+        <Property Name="LinkId" Type="Edm.Int64">
           <Annotation Term="OData.Permissions" EnumMember="OData.Permission/Read"/>
           <Annotation Term="OData.Description" String="Number of PCIe lanes in use."/>
         </Property>
-        <Property Name="AssociatedAssembly" Type="OemPCIeSlots.IBM">
+      </ComplexType>
+
+      <ComplexType Name="PCIeLinks" BaseType="Resource.OemObject">
+        <Annotation Term="OData.AdditionalProperties" Bool="true" />
+        <Annotation Term="OData.Description" String="Oem properties for IBM." />
+        <Annotation Term="OData.AutoExpand"/>
+        <Property Name="AssociatedAssembly" Type="Resource.Resource">
           <Annotation Term="OData.Permissions" EnumMember="OData.Permission/Read"/>
           <Annotation Term="OData.Description" String="Represent association slot with assembly."/>
         </Property>
-        <Property Name="UpstreamFabricAdapter" Type="OemPCIeSlots.IBM">
+        <Property Name="UpstreamFabricAdapter" Type="FabricAdapter.FabricAdapter">
           <Annotation Term="OData.Permissions" EnumMember="OData.Permission/Read"/>
           <Annotation Term="OData.Description" String="Upstream Link to FabricAdapter."/>
         </Property>
       </ComplexType>
+
     </Schema>
 
   </edmx:DataServices>


### PR DESCRIPTION
Redfish Validator generates warnings related to OemPCIeSlots schema.

For example,

```
$ python3 RedfishServiceValidator.py --auth Session -i https://${bmc}:18080 \
   --payload Single /redfish/v1/Chassis/chassis/PCIeSlots

WARNING - Couldn't get schema for object , skipping OemObject IBM : 'IBM'
WARNING - Couldn't get schema for object , skipping OemObject IBM : 'IBM'
...
WARNING - LinkId not defined in schema Complex IBM Resource.OemObject (check version, spelling and casing)
WARNING - AssociatedAssembly not defined in schema Complex IBM Resource.OemObject (check version, spelling and casing)
WARNING - LinkId not defined in schema Complex IBM Resource.OemObject (check version, spelling and casing)
WARNING - AssociatedAssembly not defined in schema Complex IBM Resource.OemObject (check version, spelling and casing)

```