### PR TITLE
Remove cookie clear

### DIFF
--- a/include/login_routes.hpp
+++ b/include/login_routes.hpp
@@ -252,8 +252,6 @@ inline void requestRoutes(App& app)
                                      "SESSION="
                                      "; SameSite=Strict; Secure; HttpOnly; "
                                      "expires=Thu, 01 Jan 1970 00:00:00 GMT");
-            asyncResp->res.addHeader("Clear-Site-Data",
-                                     R"("cache","cookies","storage")");
             persistent_data::SessionStore::getInstance().removeSession(session);
         }
     });


### PR DESCRIPTION
Fix 563602 by removing 

```
asyncResp->res.addHeader("Clear-Site-Data",
R"("cache","cookies","storage")");
```

https://github.com/openbmc/bmcweb/commit/d8139c683a2f42c47ed913b731becc6cd681e2dd https://github.com/ibm-openbmc/bmcweb/blame/1050/include/login_routes.hpp#L255

Causes the browsers to clear the cahce, cookie, and storage for that site.
https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Clear-Site-Data

That is a problem for when using the GUI from the HMC proxy because the HMC is also using the cookie and storage from the same URI. The proxy works by going to a URI and the HMC proxing it forward/reverse for the eBMC GUI.

Tested this on both FireFox and Chrome 
