### PR TITLE
No Connection: Fix for http client stale connection

### DIFF
--- a/http/http_client.hpp
+++ b/http/http_client.hpp
@@ -48,7 +48,6 @@
 #include <memory>
 #include <queue>
 #include <string>
-
 namespace crow
 {
 
@@ -502,7 +501,9 @@ class ConnectionInfo : public std::enable_shared_from_this<ConnectionInfo>
     }
     void restartConnection()
     {
-        BMCWEB_LOG_ERROR << "restartConnection ";
+        BMCWEB_LOG_DEBUG << host << ":" << std::to_string(port)
+                         << ", id: " << std::to_string(connId)
+                         << " restartConnection ";
         conn = makeConnection(ioc, sslConn.has_value());
         doResolve();
     }
@@ -530,6 +531,7 @@ class ConnectionInfo : public std::enable_shared_from_this<ConnectionInfo>
         {
             // Now let's try to resend the data
             state = ConnState::retry;
+            // reconnect to server using new socket
             restartConnection();
         }
         else
@@ -618,7 +620,6 @@ class ConnectionInfo : public std::enable_shared_from_this<ConnectionInfo>
     std::unique_ptr<boost::asio::ip::tcp::socket>
         makeConnection(boost::asio::io_context& iocIn, bool useSsl)
     {
-        BMCWEB_LOG_ERROR << "makeConnection ssl" << useSsl;
         auto newconn = std::make_unique<boost::asio::ip::tcp::socket>(iocIn);
         if (useSsl)
         {
@@ -782,9 +783,6 @@ class ConnectionPool : public std::enable_shared_from_this<ConnectionPool>
                 }
                 else
                 {
-                    BMCWEB_LOG_ERROR << "Reusing existing connection "
-                                     << commonMsg << "with state "
-                                     << static_cast<int>(conn->state);
                     conn->restartConnection();
                 }
                 return;

--- a/http/http_client.hpp
+++ b/http/http_client.hpp
@@ -497,7 +497,7 @@ class ConnectionInfo : public std::enable_shared_from_this<ConnectionInfo>
         }
 
         // Let's close the connection and restart from resolve.
-        doCleanup(true);
+        shutdownConn(true);
     }
     void restartConnection()
     {
@@ -538,11 +538,6 @@ class ConnectionInfo : public std::enable_shared_from_this<ConnectionInfo>
         {
             state = ConnState::closed;
         }
-    }
-    void doCleanup(bool retry)
-    {
-        BMCWEB_LOG_ERROR << "doCleanup called with retry " << retry;
-        shutdownConn(retry);
     }
 
     void doClose(bool retry = false)

--- a/http/http_client.hpp
+++ b/http/http_client.hpp
@@ -643,7 +643,6 @@ class ConnectionInfo : public std::enable_shared_from_this<ConnectionInfo>
                 boost::asio::ssl::context::tlsv13_client};
             sslConn.emplace(*newconn.get(), sslCtx);
             setCipherSuiteTLSext();
-            BMCWEB_LOG_ERROR << "created  ssl Conn" << sslConn.has_value();
         }
         return newconn;
     }


### PR DESCRIPTION
http_client is not handling broken connections well. Eg: Connection termination by server due to keep alive timeout.

At present client is not aware of connection termination from server. So whenever next event ready to be sent client will try send/receives data over broken connection. After failed operation the client will try to restart the connection after closing the current connection. During the process the ssl shutdown will hang when it is made over a broken connection.

Solution:
Restart the connection using fresh new socket object rather than reusing object.Thus the ssl shutdown over broken connection can be avoided.

Tested:
Developer test has been done using bmc and hmc located in different network and let the keep-alive timeout occured. The connection has been restablished on arrival or new event and events are published succesfully to hmc

Change-Id: Ie983f57cbe6e688176501013401009ef0e057ac2