### PR TITLE
1060: Fix OemPCIeDevice schema RedfishValidator warnings

### DIFF
--- a/redfish-core/lib/pcie.hpp
+++ b/redfish-core/lib/pcie.hpp
@@ -281,11 +281,9 @@ static inline void getPcieSlotLinkAndStatusProperties(
 
                             asyncResp->res
                                 .jsonValue["Oem"]["IBM"]["LinkReset"] = *value;
-                            asyncResp->res.jsonValue["Oem"]["@odata.type"] =
-                                "#OemPCIeDevice.Oem";
                             asyncResp->res
                                 .jsonValue["Oem"]["IBM"]["@odata.type"] =
-                                "#OemPCIeDevice.IBM";
+                                "#OemPCIeDevice.v1_0_0.IBM";
                         }
                     }
                 },
@@ -515,6 +513,8 @@ inline void
         });
         if (it != splitText.cend())
         {
+            asyncResp->res.jsonValue["Links"]["Oem"]["IBM"]["@odata.type"] =
+                "#OemPCIeDevice.v1_0_0.PCIeLinks";
             asyncResp->res
                 .jsonValue["Links"]["Oem"]["IBM"]["PCIeSlot"]["@odata.id"] =
                 ("/redfish/v1/Chassis/" + *it + "/PCIeSlots");

--- a/static/redfish/v1/JsonSchemas/OemPCIeDevice/OemPCIeDevice.json
+++ b/static/redfish/v1/JsonSchemas/OemPCIeDevice/OemPCIeDevice.json
@@ -3,41 +3,9 @@
     "$schema": "http://redfish.dmtf.org/schemas/v1/redfish-schema-v1.json",
     "copyright": "Copyright 2014-2019 DMTF. For the full DMTF copyright policy, see http://www.dmtf.org/about/policies/copyright",
     "definitions": {
-        "Oem": {
-            "additionalProperties": true,
-            "description": "OemPCIeDevice Oem properties.",
-            "patternProperties": {
-                "^([a-zA-Z_][a-zA-Z0-9_]*)?@(odata|Redfish|Message)\\.[a-zA-Z_][a-zA-Z0-9_]*$": {
-                    "description": "This property shall specify a valid odata or Redfish property.",
-                    "type": [
-                        "array",
-                        "boolean",
-                        "integer",
-                        "number",
-                        "null",
-                        "object",
-                        "string"
-                    ]
-                }
-            },
-            "properties": {
-                "IBM": {
-                    "anyOf": [
-                        {
-                            "$ref": "#/definitions/IBM"
-                        },
-                        {
-                            "type": "null"
-                        }
-                    ]
-                }
-
-            },
-            "type": "object"
-        },
         "IBM": {
             "additionalProperties": true,
-            "description": "Oem properties for IBM.",
+            "description": "OemPCIeDevice Oem properties for IBM.",
             "patternProperties": {
                 "^([a-zA-Z_][a-zA-Z0-9_]*)?@(odata|Redfish|Message)\\.[a-zA-Z_][a-zA-Z0-9_]*$": {
                     "description": "This property shall specify a valid odata or Redfish property.",
@@ -58,7 +26,28 @@
                     "longDescription": "A true value resets the PCIe Link.",
                     "readonly": false,
                     "type": "boolean"
-                },
+                }
+            },
+            "type": "object"
+        },
+        "PCIeLinks": {
+            "additionalProperties": true,
+            "description": "Oem link properties for IBM.",
+            "patternProperties": {
+                "^([a-zA-Z_][a-zA-Z0-9_]*)?@(odata|Redfish|Message)\\.[a-zA-Z_][a-zA-Z0-9_]*$": {
+                    "description": "This property shall specify a valid odata or Redfish property.",
+                    "type": [
+                        "array",
+                        "boolean",
+                        "integer",
+                        "number",
+                        "null",
+                        "object",
+                        "string"
+                    ]
+                }
+            },
+            "properties": {
                 "PCIeSlot": {
                     "description": "PCIe Slot Link",
                     "longDescription": "Represent PCIe Slot Link which has all PCIe device list.",
@@ -71,5 +60,5 @@
     },
     "owningEntity": "IBM",
     "release": "1.0",
-    "title": "#OemPCIeDevice"
+    "title": "#OemPCIeDevice.v1_0_0"
 }

--- a/static/redfish/v1/schema/OemPCIeDevice_v1.xml
+++ b/static/redfish/v1/schema/OemPCIeDevice_v1.xml
@@ -10,10 +10,10 @@
   <edmx:Reference Uri="http://redfish.dmtf.org/schemas/v1/RedfishExtensions_v1.xml">
     <edmx:Include Namespace="RedfishExtensions.v1_0_0" Alias="Redfish"/>
   </edmx:Reference>
-    <edmx:Reference Uri="http://redfish.dmtf.org/schemas/v1/PCIeDevice_v1.xml">
-        <edmx:Include Namespace="PCIeDevice"/>
-        <edmx:Include Namespace="PCIeDevice.v1_9_0"/>
-    </edmx:Reference>
+  <edmx:Reference Uri="http://redfish.dmtf.org/schemas/v1/PCIeDevice_v1.xml">
+    <edmx:Include Namespace="PCIeDevice"/>
+    <edmx:Include Namespace="PCIeDevice.v1_9_0"/>
+  </edmx:Reference>
   <edmx:Reference Uri="http://redfish.dmtf.org/schemas/v1/Resource_v1.xml">
     <edmx:Include Namespace="Resource"/>
     <edmx:Include Namespace="Resource.v1_0_0"/>
@@ -26,32 +26,24 @@
 
     <Schema xmlns="http://docs.oasis-open.org/odata/ns/edm" Namespace="OemPCIeDevice.v1_0_0">
       <Annotation Term="Redfish.OwningEntity" String="IBM"/>
-
-      <ComplexType Name="Oem" BaseType="Resource.OemObject">
-        <Annotation Term="OData.AdditionalProperties" Bool="true"/>
-        <Annotation Term="OData.Description" String="OemPCIeDevice Oem properties."/>
-        <Annotation Term="OData.AutoExpand"/>
-        <Property Name="IBM" Type="OemPCIeDevice.IBM"/>
-      </ComplexType>
-
       <ComplexType Name="IBM" BaseType="Resource.OemObject">
         <Annotation Term="OData.AdditionalProperties" Bool="true" />
         <Annotation Term="OData.Description" String="Oem properties for IBM." />
         <Annotation Term="OData.AutoExpand"/>
-
-        <Property Name="LinkReset" Type="OemPCIeDevice.IBM">
+        <Property Name="LinkReset" Type="Edm.Boolean">
           <Annotation Term="OData.Permissions" EnumMember="OData.Permission/ReadWrite"/>
           <Annotation Term="OData.Description" String="Reset the PCIe Link"/>
           <Annotation Term="OData.LongDescription" String="A true value resets the PCIe Link."/>
         </Property>
-        
-        <Property Name="PCIeSlot" Type="OemPCIeDevice.IBM">
+      </ComplexType>
+
+      <ComplexType Name="PCIeLinks" BaseType="Resource.OemObject">
+        <Property Name="PCIeSlot" Type="Resource.Resource">
           <Annotation Term="OData.Permissions" EnumMember="OData.Permission/Read"/>
           <Annotation Term="OData.Description" String="PCIe Slot Link"/>
           <Annotation Term="OData.LongDescription" String="Represent PCIe Slot Link which has all PCIe device list."/>
         </Property>
       </ComplexType>
-
     </Schema>
 
   </edmx:DataServices>


### PR DESCRIPTION
Redfish validator produces warnings related to OemPCIeDevices

```
$ python3 RedfishServiceValidator.py --auth Session -i https://${bmc} \
  --payload Single /redfish/v1/Systems/system/PCIeDevices/chassis_motherboard_pcieslot1_pcie_card1

WARNING - Couldn't get schema for object (?), skipping OemObject IBM : 'IBM'
WARNING - LinkReset not defined in schema Complex IBM Resource.OemObject (check version, spelling and casing)
```

Tested:
- Validator run passes without those OemPCIeDevice warnings