### PR TITLE
1060: Fix OemAssembly schema redfish validator warnings

### DIFF
--- a/static/redfish/v1/schema/OemAssembly_v1.xml
+++ b/static/redfish/v1/schema/OemAssembly_v1.xml
@@ -26,10 +26,10 @@
                 <Annotation Term="OData.AdditionalProperties" Bool="true" />
                 <Annotation Term="OData.Description" String="OemAssembly Oem properties." />
                 <Annotation Term="OData.AutoExpand" />
-                <Property Name="OpenBMC" Type="OemAssembly.v1_0_0.OpenBMC" />
+                <Property Name="Assembly" Type="OemAssembly.v1_0_0.Assembly" />
             </ComplexType>
-        
-            <ComplexType Name="OpenBMC">
+
+            <ComplexType Name="Assembly" BaseType="Resource.OemObject">
                 <Annotation Term="OData.AdditionalProperties" Bool="true" />
                 <Annotation Term="OData.Description" String="Oem properties for OpenBMC." />
                 <Annotation Term="OData.AutoExpand" />


### PR DESCRIPTION
Redfish validator produces warnings related to OemAssembly

````
$ python3 RedfishServiceValidator.py --auth Session -i https://${bmc} \
           --payload Single /redfish/v1/Chassis/chassis/Assembly
...
WARNING - Couldn't get schema for object (?), skipping OemObject OpenBMC : 'Assembly'
```

Tested:
- Validator run passes without those OemAssembly warnings