### PR TITLE
1060: Add Redfish ChapData Refish OEM API

### DIFF
--- a/static/redfish/v1/JsonSchemas/OemComputerSystem/OemComputerSystem.json
+++ b/static/redfish/v1/JsonSchemas/OemComputerSystem/OemComputerSystem.json
@@ -196,6 +196,50 @@
                         "array",
                         "null"
                     ]
+                },
+                "ChapData": {
+                    "$ref": "#/definitions/ChapData",
+                    "description": "ChapData.",
+                    "longDescription": "This property shall describe ChapData."
+                }
+            },
+            "type": "object"
+        },
+
+        "ChapData": {
+            "additionalProperties": false,
+            "description": "ChapData details to Host.",
+            "longDescription": "This type shall contain properties that describe ChapData.",
+            "patternProperties": {
+                "^([a-zA-Z_][a-zA-Z0-9_]*)?@(odata|Redfish|Message)\\.[a-zA-Z_][a-zA-Z0-9_]*$": {
+                    "description": "This property shall specify a valid odata or Redfish property.",
+                    "type": [
+                        "array",
+                        "boolean",
+                        "integer",
+                        "number",
+                        "null",
+                        "object",
+                        "string"
+                    ]
+                }
+            },
+            "properties": {
+                "ChapName": {
+                    "description": "A user selected name associated with each of the chap secret password.",
+                    "longDescription": "This property shall contain ChapName that is a user selected name associated with each of the chap secret password.",
+                    "type": [
+                        "string",
+                        "null"
+                    ]
+                },
+                "ChapSecret": {
+                    "description": "An encrypted secret password transferred to the Host for the respective ChapName.",
+                    "longDescription": "This property shall contain ChapSecret that is an encrypted secret password transferred to the Host for the respective ChapName.",
+                    "type": [
+                        "string",
+                        "null"
+                    ]
                 }
             },
             "type": "object"

--- a/static/redfish/v1/schema/OemComputerSystem_v1.xml
+++ b/static/redfish/v1/schema/OemComputerSystem_v1.xml
@@ -65,6 +65,27 @@
                   <Annotation Term="OData.Description" String="List of enabled panel functions."/>
                   <Annotation Term="OData.LongDescription" String="This property shall contain the list of enabled panel functions."/>
                 </Property>
+                <Property Name="ChapData" Type="OemComputerSystem.ChapData">
+                  <Annotation Term="OData.Permissions" EnumMember="OData.Permission/Read"/>
+                  <Annotation Term="OData.Description" String="ChapData details to Host."/>
+                  <Annotation Term="OData.LongDescription" String="This property shall contain ChapData."/>
+                </Property>
+            </ComplexType>
+
+            <ComplexType Name="ChapData" BaseType="Resource.OemObject">
+                <Annotation Term="OData.AdditionalProperties" Bool="false"/>
+                <Annotation Term="OData.Description" String="ChapData details to Host."/>
+                <Annotation Term="OData.LongDescription" String="This type shall contain ChapData."/>
+                <Property Name="ChapName" Type="Edm.String">
+                  <Annotation Term="OData.Permissions" EnumMember="OData.Permission/Read"/>
+                  <Annotation Term="OData.Description" String="A user selected name associated with each of the chap secret password."/>
+                  <Annotation Term="OData.LongDescription" String="This property shall contain ChapName that is a user selected name associated with each of the chap secret password."/>
+                </Property>
+                <Property Name="ChapSecret" Type="Edm.String">
+                  <Annotation Term="OData.Permissions" EnumMember="OData.Permission/Read"/>
+                  <Annotation Term="OData.Description" String="An encrypted secret password transferred to the Host for the respective ChapName."/>
+                  <Annotation Term="OData.LongDescription" String="This property shall contain ChapSecret that is an encrypted secret password transferred to the Host for the respective ChapName."/>
+                </Property>
             </ComplexType>
 
             <ComplexType Name="OpenBmc" BaseType="Resource.OemObject">


### PR DESCRIPTION
Add Redfish ChapData Redfish OEM API for GET and PATCH of ChapName and ChapSecret.

This is a part of 1KW - https://jsw.ibm.com/browse/PFEBMC-1852

Its dbus property is added via
- https://github.com/ibm-openbmc/phosphor-dbus-interfaces/pull/88

The related PLDM PRs are:
- https://github.com/ibm-openbmc/pldm/pull/464
- https://github.com/ibm-openbmc/pldm/pull/482

1.Validator passes

2. GET /redfish/v1/Systems/system
```
curl -k -H "X-Auth-Token: $token" -X GET https://${bmc}/redfish/v1/Systems/system
{
  "@odata.id": "/redfish/v1/Systems/system",
  ...
 "Oem": {
    "IBM": {
      "@odata.type": "#OemComputerSystem.IBM",
      "ChapData": {
        "ChapName": "",
        "ChapSecret": ""
      },
 ...
}
```

3. PATCH ChapData

```
$ curl -k -H "X-Auth-Token: $token" -X PATCH \
   -d '{ "Oem" : { "IBM" : { "ChapData": { "ChapName": "chap-name", "ChapSecret" : "chap-secret" }}}}' \
   https://${bmc}/redfish/v1/Systems/system
```

Then,

```
$ curl -k -H "X-Auth-Token: $token" -X GET https://${bmc}/redfish/v1/Systems/system
{
  "@odata.id": "/redfish/v1/Systems/system",
  ...
 "Oem": {
    "IBM": {
      "@odata.type": "#OemComputerSystem.IBM",
      "ChapData": {
        "ChapName": "chap-name",
        "ChapSecret": "chap-secret"
      },
  ...
}
```