### PR TITLE
Work In Progress : Add flightRecorder support to dump redfish events

### DIFF
--- a/http/http_server.hpp
+++ b/http/http_server.hpp
@@ -21,6 +21,7 @@
 #include <vector>
 #ifdef BMCWEB_ENABLE_IBM_MANAGEMENT_CONSOLE
 #include <persistent_data.hpp>
+#include <include/ibm/flight_recorder.hpp>
 #endif
 namespace crow
 {
@@ -161,6 +162,7 @@ class Server
                         << "INFO: Receivied USR1 signal to dump latest session "
                            "data for bmc dump";
                     persistent_data::getConfig().writeCurrentSessionData();
+                    bmcweb::flightrecorder::FlightRecorder::GetInstance().playRecorder();
                     this->startAsyncWaitForSignal();
                 }
 #endif

--- a/include/ibm/flight_recorder.hpp
+++ b/include/ibm/flight_recorder.hpp
@@ -1,0 +1,116 @@
+#pragma once
+
+#include <fstream>
+#include <iomanip>
+#include <iostream>
+#include <vector>
+
+#define FLIGHT_RECORDER_MAX_ENTRIES 300
+
+namespace bmcweb
+{
+namespace flightrecorder
+{
+using FlightRecorderData = nlohmann::json;
+using FlightRecorderTimeStamp = std::string;
+using FlightRecorderRecord =
+    std::tuple<FlightRecorderTimeStamp, FlightRecorderData>;
+using FlightRecorderCassette = std::vector<FlightRecorderRecord>;
+static constexpr auto flightRecorderDumpPath = "/tmp/redfish_events_flight_recorder";
+
+std::string getCurrentSystemTime()
+{
+    using namespace std::chrono;
+    const time_point<system_clock> tp = system_clock::now();
+    std::time_t tt = system_clock::to_time_t(tp);
+    auto ms = duration_cast<microseconds>(tp.time_since_epoch()) -
+              duration_cast<seconds>(tp.time_since_epoch());
+
+    std::stringstream ss;
+    ss << std::put_time(std::localtime(&tt), "%F %Z %T.")
+       << std::to_string(ms.count());
+    return ss.str();
+}
+
+/** @class FlightRecorder
+ *
+ *  The class for implementing the BMCWEB flight recorder logic. This class
+ *  handles the insertion of the data into the recorder and also provides
+ *  API's to dump the flight recorder into a file.
+ */
+
+class FlightRecorder
+{
+  private:
+    FlightRecorder() : index(0)
+    {
+        flightRecorderPolicy = FLIGHT_RECORDER_MAX_ENTRIES ? true : false;
+        if (flightRecorderPolicy)
+        {
+            tapeRecorder = FlightRecorderCassette(FLIGHT_RECORDER_MAX_ENTRIES);
+        }
+    }
+
+  protected:
+    unsigned int index;
+    FlightRecorderCassette tapeRecorder;
+    bool flightRecorderPolicy;
+
+  public:
+    FlightRecorder(const FlightRecorder&) = delete;
+    FlightRecorder(FlightRecorder&&) = delete;
+    FlightRecorder& operator=(const FlightRecorder&) = delete;
+    FlightRecorder& operator=(FlightRecorder&&) = delete;
+    ~FlightRecorder() = default;
+
+    static FlightRecorder& GetInstance()
+    {
+        static FlightRecorder flightRecorder;
+        return flightRecorder;
+    }
+ 
+    /** @brief Add records to the flightRecorder
+     *
+     *  @param[in] eventJson  - The redfish event json data
+     *
+     *  @return void
+     */
+    void saveRecord(const FlightRecorderData& eventJson)
+    {
+        // if the flight recorder policy is enabled, then only insert the
+        // messages into the flight recorder, if not this function will be just
+        // a no-op
+        if (flightRecorderPolicy)
+        {
+    	    unsigned int currentIndex = index++;
+            tapeRecorder[currentIndex] = std::make_tuple(
+                getCurrentSystemTime(), eventJson);
+            index = (currentIndex == FLIGHT_RECORDER_MAX_ENTRIES - 1) ? 0
+                                                                      : index;
+        }
+    }
+
+    /** @brief play flight recorder
+     *
+     *  @return void
+     */
+
+    void playRecorder()
+    {
+        if (flightRecorderPolicy)
+        {
+            std::ofstream recorderOutputFile(flightRecorderDumpPath);
+            for (const auto& message : tapeRecorder)
+            {
+                recorderOutputFile << std::get<0>(message)
+                                  << " : ";
+		recorderOutputFile << std::get<1>(message) << "\n";
+                recorderOutputFile << std::endl;
+            }
+            recorderOutputFile.close();
+        }
+    }
+};
+
+} // namespace flightrecorder
+} // namespace bmcweb

--- a/redfish-core/include/event_service_manager.hpp
+++ b/redfish-core/include/event_service_manager.hpp
@@ -36,7 +36,7 @@
 #include <sdbusplus/bus/match.hpp>
 #include <server_sent_events.hpp>
 #include <utils/json_utils.hpp>
-
+#include <include/ibm/flight_recorder.hpp>
 #include <cstdlib>
 #include <ctime>
 #include <fstream>
@@ -1071,6 +1071,9 @@ class EventServiceManager
                     2, ' ', true, nlohmann::json::error_handler_t::replace);
                 entry->sendEvent(strMsg);
                 eventId++; // increament the eventId
+#ifdef BMCWEB_ENABLE_IBM_MANAGEMENT_CONSOLE
+                bmcweb::flightrecorder::FlightRecorder::GetInstance().saveRecord(msgJson);
+#endif
             }
             else
             {


### PR DESCRIPTION
This commit adds flight recorder support to dump redfish events into a file which will be helpful for debugging eventing defects.
This event data will be collected as part BMC dump collection.

Tested by:
Created a BMC dump and check event data in file