### PR TITLE
1060: Fix OemFabricAdapters schema validator warnings

### DIFF
--- a/redfish-core/lib/fabric_adapters.hpp
+++ b/redfish-core/lib/fabric_adapters.hpp
@@ -307,9 +307,8 @@ inline void doAdapterGet(const std::shared_ptr<bmcweb::AsyncResp>& aResp,
         aResp, systemName, fabricAdapterPath,
         [aResp](const std::string& chassisName,
                 const dbus::utility::MapperEndPoints& /*pcieSlotPaths*/) {
-        aResp->res.jsonValue["Oem"]["@odata.type"] = "#OemFabricAdapter.Oem";
         aResp->res.jsonValue["Oem"]["IBM"]["@odata.type"] =
-            "#OemFabricAdapter.IBM";
+            "#OemFabricAdapter.v1_0_0.IBM";
         aResp->res.jsonValue["Oem"]["IBM"]["Slots"]["@odata.id"] =
             crow::utility::urlFromPieces("redfish", "v1", "Chassis",
                                          chassisName, "PCIeSlots");

--- a/static/redfish/v1/JsonSchemas/OemFabricAdapter/OemFabricAdapter.json
+++ b/static/redfish/v1/JsonSchemas/OemFabricAdapter/OemFabricAdapter.json
@@ -63,5 +63,7 @@
             "type": "object"
         }
     },
-    "title": "#OemFabricAdapter"
+    "owningEntity": "IBM",
+    "release": "1.0",
+    "title": "#OemFabricAdapter.v1_0_0"
 }

--- a/static/redfish/v1/schema/OemFabricAdapter_v1.xml
+++ b/static/redfish/v1/schema/OemFabricAdapter_v1.xml
@@ -40,7 +40,7 @@
         <Annotation Term="OData.Description" String="Oem properties for IBM." />
         <Annotation Term="OData.AutoExpand"/>
 
-        <Property Name="Slots" Type="OemFabricAdapter.IBM">
+        <Property Name="Slots" Type="Resource.Resource">
           <Annotation Term="OData.Permissions" EnumMember="OData.Permission/Read"/>
           <Annotation Term="OData.Description" String="PCIe Slots"/>
          <Annotation Term="OData.LongDescription" String="Represent PCIe Slots contained by the adapter"/>


### PR DESCRIPTION
Redfish validator produces warnings related to OemFabricAdapters

```
python3 RedfishServiceValidator.py --auth Session -i https://${bmc} \
    -u admin -p 0penBmc0 --payload Single \
    /redfish/v1/Systems/system/FabricAdapters/chassis15363-logical_slot2-io_module2

WARNING - Couldn't get schema for object (?), skipping OemObject IBM : 'IBM'
WARNING - Slots not defined in schema Complex IBM Resource.OemObject (check version, spelling and casing)
```

Tested:
- Validator passes without having OemFabricAdapters warnings