### PR TITLE
1060: Fix OemComputerSystem schema validator warnings

### DIFF
--- a/redfish-core/lib/oem/ibm/lamp_test.hpp
+++ b/redfish-core/lib/oem/ibm/lamp_test.hpp
@@ -53,10 +53,8 @@ inline void getLampTestState(const std::shared_ptr<bmcweb::AsyncResp>& aResp)
                 return;
             }
 
-            aResp->res.jsonValue["Oem"]["@odata.type"] =
-                "#OemComputerSystem.Oem";
             aResp->res.jsonValue["Oem"]["IBM"]["@odata.type"] =
-                "#OemComputerSystem.IBM";
+                "#OemComputerSystem.v1_0_0.IBM";
             aResp->res.jsonValue["Oem"]["IBM"]["LampTest"] = assert;
         });
     });

--- a/redfish-core/lib/oem/ibm/system_attention_indicator.hpp
+++ b/redfish-core/lib/oem/ibm/system_attention_indicator.hpp
@@ -66,7 +66,7 @@ inline void getSAI(const std::shared_ptr<bmcweb::AsyncResp>& aResp,
             }
 
             nlohmann::json& oemSAI = aResp->res.jsonValue["Oem"]["IBM"];
-            oemSAI["@odata.type"] = "#OemComputerSystem.IBM";
+            oemSAI["@odata.type"] = "#OemComputerSystem.v1_0_0.IBM";
             if (propertyValue == "PartitionSystemAttentionIndicator")
             {
                 oemSAI["PartitionSystemAttentionIndicator"] = assert;

--- a/redfish-core/lib/systems.hpp
+++ b/redfish-core/lib/systems.hpp
@@ -1554,8 +1554,8 @@ inline void getPowerMode(const std::shared_ptr<bmcweb::AsyncResp>& aResp)
             {
                 BMCWEB_LOG_DEBUG << "Safe mode: " << *safeMode;
                 nlohmann::json& oemSafeMode = aResp->res.jsonValue["Oem"];
-                oemSafeMode["@odata.type"] = "#OemComputerSystem.Oem";
-                oemSafeMode["IBM"]["@odata.type"] = "#OemComputerSystem.IBM";
+                oemSafeMode["IBM"]["@odata.type"] =
+                    "#OemComputerSystem.v1_0_0.IBM";
                 oemSafeMode["IBM"]["SafeMode"] = *safeMode;
             }
             if (powerMode != nullptr)
@@ -2069,8 +2069,7 @@ inline void getEnabledPanelFunctions(
     doGetEnabledPanelFunctions(
         asyncResp, [asyncResp](const std::vector<uint8_t>& enabledFuncs) {
         nlohmann::json& oem = asyncResp->res.jsonValue["Oem"];
-        oem["@odata.type"] = "#OemComputerSystem.Oem";
-        oem["IBM"]["@odata.type"] = "#OemComputerSystem.IBM";
+        oem["IBM"]["@odata.type"] = "#OemComputerSystem.v1_0_0.IBM";
         oem["IBM"]["EnabledPanelFunctions"] = enabledFuncs;
     });
 }

--- a/static/redfish/v1/JsonSchemas/OemComputerSystem/OemComputerSystem.json
+++ b/static/redfish/v1/JsonSchemas/OemComputerSystem/OemComputerSystem.json
@@ -279,7 +279,8 @@
                     "type": "string"
                 }
             },
-            "type": "object"
+            "type": "object",
+            "versionAdded": "v1_0_0"
         }
     },
     "title": "#OemComputerSystem"

--- a/static/redfish/v1/schema/OemComputerSystem_v1.xml
+++ b/static/redfish/v1/schema/OemComputerSystem_v1.xml
@@ -26,68 +26,6 @@
                 <Property Name="IBM" Type="OemComputerSystem.IBM"/>
             </ComplexType>
 
-            <ComplexType Name="IBM" BaseType="Resource.OemObject">
-                <Annotation Term="OData.AdditionalProperties" Bool="true" />
-                <Annotation Term="OData.Description" String="Oem properties for IBM." />
-                <Annotation Term="OData.AutoExpand"/>
-                <Property Name="LampTest" Type="OemComputerSystem.IBM">
-                    <Annotation Term="OData.Permissions" EnumMember="OData.Permission/ReadWrite"/>
-                    <Annotation Term="OData.Description" String="An indicator allowing an operator to run LED lamp test."/>
-                    <Annotation Term="OData.LongDescription" String="This property shall contain the state of lamp state function for this resource."/>
-                </Property>
-                <Property Name="PartitionSystemAttentionIndicator" Type="OemComputerSystem.IBM">
-                    <Annotation Term="OData.Permissions" EnumMember="OData.Permission/ReadWrite"/>
-                    <Annotation Term="OData.Description" String="An indicator allowing an operator to operate partition system attention."/>
-                    <Annotation Term="OData.LongDescription" String="This property shall contain the state of the partition system attention of this resource."/>
-                </Property>
-                <Property Name="PlatformSystemAttentionIndicator" Type="OemComputerSystem.IBM">
-                    <Annotation Term="OData.Permissions" EnumMember="OData.Permission/ReadWrite"/>
-                    <Annotation Term="OData.Description" String="An indicator allowing an operator to operate platform system attention."/>
-                    <Annotation Term="OData.LongDescription" String="This property shall contain the state of the platform system attention of this resource."/>
-                </Property>
-                <Property Name="SafeMode" Type="OemComputerSystem.IBM">
-                  <Annotation Term="OData.Permissions" EnumMember="OData.Permission/Read"/>
-                  <Annotation Term="OData.Description" String="An indication of whether safe mode is enabled."/>
-                  <Annotation Term="OData.LongDescription" String="The value of this property shall indicate if safe mode is enabled."/>
-                </Property>
-                <Property Name="PCIeTopologyRefresh" Type="OemComputerSystem.IBM">
-                  <Annotation Term="OData.Permissions" EnumMember="OData.Permission/ReadWrite"/>
-                  <Annotation Term="OData.Description" String="An indication of topology information is ready."/>
-                  <Annotation Term="OData.LongDescription" String="This property when set to 'true' refreshes the topology information. The application which uses this should set it to 'false' when a refresh occurs."/>
-                </Property>
-                <Property Name="SavePCIeTopologyInfo" Type="OemComputerSystem.IBM">
-                  <Annotation Term="OData.Permissions" EnumMember="OData.Permission/ReadWrite"/>
-                  <Annotation Term="OData.Description" String="An indication of PEL topology information is saves."/>
-                  <Annotation Term="OData.LongDescription" String="This property when set to 'true' saves the topology information. The information is saved in the form of a PEL(Error Log)."/>
-                </Property>
-                <Property Name="EnabledPanelFunctions" Type="OemComputerSystem.IBM">
-                  <Annotation Term="OData.Permissions" EnumMember="OData.Permission/Read"/>
-                  <Annotation Term="OData.Description" String="List of enabled panel functions."/>
-                  <Annotation Term="OData.LongDescription" String="This property shall contain the list of enabled panel functions."/>
-                </Property>
-                <Property Name="ChapData" Type="OemComputerSystem.ChapData">
-                  <Annotation Term="OData.Permissions" EnumMember="OData.Permission/Read"/>
-                  <Annotation Term="OData.Description" String="ChapData details to Host."/>
-                  <Annotation Term="OData.LongDescription" String="This property shall contain ChapData."/>
-                </Property>
-            </ComplexType>
-
-            <ComplexType Name="ChapData" BaseType="Resource.OemObject">
-                <Annotation Term="OData.AdditionalProperties" Bool="false"/>
-                <Annotation Term="OData.Description" String="ChapData details to Host."/>
-                <Annotation Term="OData.LongDescription" String="This type shall contain ChapData."/>
-                <Property Name="ChapName" Type="Edm.String">
-                  <Annotation Term="OData.Permissions" EnumMember="OData.Permission/Read"/>
-                  <Annotation Term="OData.Description" String="A user selected name associated with each of the chap secret password."/>
-                  <Annotation Term="OData.LongDescription" String="This property shall contain ChapName that is a user selected name associated with each of the chap secret password."/>
-                </Property>
-                <Property Name="ChapSecret" Type="Edm.String">
-                  <Annotation Term="OData.Permissions" EnumMember="OData.Permission/Read"/>
-                  <Annotation Term="OData.Description" String="An encrypted secret password transferred to the Host for the respective ChapName."/>
-                  <Annotation Term="OData.LongDescription" String="This property shall contain ChapSecret that is an encrypted secret password transferred to the Host for the respective ChapName."/>
-                </Property>
-            </ComplexType>
-
             <ComplexType Name="OpenBmc" BaseType="Resource.OemObject">
                 <Annotation Term="OData.AdditionalProperties" Bool="true" />
                 <Annotation Term="OData.Description" String="Oem properties for OpenBmc." />
@@ -126,8 +64,75 @@
                     <Annotation Term="OData.LongDescription" String="Platform firmware is provisioned and locked. So re-provisioning is not allowed in this state."/>
                 </Member>
             </EnumType>
+
+            <ComplexType Name="IBM" BaseType="Resource.OemObject">
+                <Annotation Term="Redfish.OwningEntity" String="IBM"/>
+                <Annotation Term="OData.AdditionalProperties" Bool="true" />
+                <Annotation Term="OData.Description" String="Oem properties for IBM." />
+                <Annotation Term="OData.AutoExpand"/>
+                <Property Name="LampTest" Type="Edm.Boolean">
+                    <Annotation Term="OData.Permissions" EnumMember="OData.Permission/ReadWrite"/>
+                    <Annotation Term="OData.Description" String="An indicator allowing an operator to run LED lamp test."/>
+                    <Annotation Term="OData.LongDescription" String="This property shall contain the state of lamp state function for this resource."/>
+                </Property>
+                <Property Name="PartitionSystemAttentionIndicator" Type="Edm.Boolean">
+                    <Annotation Term="OData.Permissions" EnumMember="OData.Permission/ReadWrite"/>
+                    <Annotation Term="OData.Description" String="An indicator allowing an operator to operate partition system attention."/>
+                    <Annotation Term="OData.LongDescription" String="This property shall contain the state of the partition system attention of this resource."/>
+                </Property>
+                <Property Name="PlatformSystemAttentionIndicator" Type="Edm.Boolean">
+                    <Annotation Term="OData.Permissions" EnumMember="OData.Permission/ReadWrite"/>
+                    <Annotation Term="OData.Description" String="An indicator allowing an operator to operate platform system attention."/>
+                    <Annotation Term="OData.LongDescription" String="This property shall contain the state of the platform system attention of this resource."/>
+                </Property>
+                <Property Name="SafeMode" Type="Edm.Boolean">
+                  <Annotation Term="OData.Permissions" EnumMember="OData.Permission/Read"/>
+                  <Annotation Term="OData.Description" String="An indication of whether safe mode is enabled."/>
+                  <Annotation Term="OData.LongDescription" String="The value of this property shall indicate if safe mode is enabled."/>
+                </Property>
+                <Property Name="PCIeTopologyRefresh" Type="Edm.Boolean">
+                  <Annotation Term="OData.Permissions" EnumMember="OData.Permission/ReadWrite"/>
+                  <Annotation Term="OData.Description" String="An indication of topology information is ready."/>
+                  <Annotation Term="OData.LongDescription" String="This property when set to 'true' refreshes the topology information. The application which uses this should set it to 'false' when a refresh occurs."/>
+                </Property>
+                <Property Name="SavePCIeTopologyInfo" Type="Edm.Boolean">
+                  <Annotation Term="OData.Permissions" EnumMember="OData.Permission/ReadWrite"/>
+                  <Annotation Term="OData.Description" String="An indication of PEL topology information is saves."/>
+                  <Annotation Term="OData.LongDescription" String="This property when set to 'true' saves the topology information. The information is saved in the form of a PEL(Error Log)."/>
+                </Property>
+            </ComplexType>
         </Schema>
+
         <Schema xmlns="http://docs.oasis-open.org/odata/ns/edm" Namespace="OemComputerSystem.v1_0_0">
+            <ComplexType Name="IBM" BaseType="OemComputerSystem.IBM">
+                <Property Name="EnabledPanelFunctions" Type="Collection(Edm.Int64)">
+                  <Annotation Term="OData.Permissions" EnumMember="OData.Permission/Read"/>
+                  <Annotation Term="OData.Description" String="List of enabled panel functions."/>
+                  <Annotation Term="OData.LongDescription" String="This property shall contain the list of enabled panel functions."/>
+                </Property>
+                <Property Name="ChapData" Type="OemComputerSystem.v1_0_0.ChapData">
+                  <Annotation Term="OData.Permissions" EnumMember="OData.Permission/Read"/>
+                  <Annotation Term="OData.Description" String="ChapData details to Host."/>
+                  <Annotation Term="OData.LongDescription" String="This property shall contain ChapData."/>
+                </Property>
+            </ComplexType>
+
+            <ComplexType Name="ChapData" BaseType="Resource.OemObject">
+                <Annotation Term="OData.AdditionalProperties" Bool="false"/>
+                <Annotation Term="OData.Description" String="ChapData details to Host."/>
+                <Annotation Term="OData.LongDescription" String="This type shall contain ChapData."/>
+                <Property Name="ChapName" Type="Edm.String">
+                  <Annotation Term="OData.Permissions" EnumMember="OData.Permission/Read"/>
+                  <Annotation Term="OData.Description" String="A user selected name associated with each of the chap secret password."/>
+                  <Annotation Term="OData.LongDescription" String="This property shall contain ChapName that is a user selected name associated with each of the chap secret password."/>
+                </Property>
+                <Property Name="ChapSecret" Type="Edm.String">
+                  <Annotation Term="OData.Permissions" EnumMember="OData.Permission/Read"/>
+                  <Annotation Term="OData.Description" String="An encrypted secret password transferred to the Host for the respective ChapName."/>
+                  <Annotation Term="OData.LongDescription" String="This property shall contain ChapSecret that is an encrypted secret password transferred to the Host for the respective ChapName."/>
+                </Property>
+            </ComplexType>
+
             <Action Name="ExecutePanelFunction" IsBound="true">
                 <Annotation Term="OData.Description" String="This action executes a panel function."/>
                 <Annotation Term="OData.LongDescription" String="This action executes a panel function if the function is enabled."/>


### PR DESCRIPTION
Redfish validator produces warnings related to OemComputerSystem

````
$ python3 RedfishServiceValidator.py --auth Session -i https://${bmc} \
           --payload Single /redfish/v1/Systems/system
...
WARNING - Couldn't get schema for object (?), skipping OemObject IBM : maximum recursion depth exceeded while getting the str of an object
WARNING - EnabledPanelFunctions not defined in schema Complex IBM Resource.OemObject (check version, spelling and casing)
WARNING - LampTest not defined in schema Complex IBM Resource.OemObject (check version, spelling and casing)
WARNING - PartitionSystemAttentionIndicator not defined in schema Complex IBM Resource.OemObject (check version, spelling and casing)
WARNING - PlatformSystemAttentionIndicator not defined in schema Complex IBM Resource.OemObject (check version, spelling and casing)
WARNING - SafeMode not defined in schema Complex IBM Resource.OemObject (check version, spelling and casing)
```

```
$ curl -k -X GET https://${bmc}/redfish/v1/Systems/system
...
  "Oem": {
    "IBM": {
      "@odata.type": "#OemComputerSystem.v1_0_0.IBM",
      "EnabledPanelFunctions": [],
      ...
      },
```