### PR TITLE
WIP: Remove LocationIndicatorActive when no association

### DIFF
--- a/redfish-core/lib/led.hpp
+++ b/redfish-core/lib/led.hpp
@@ -242,11 +242,10 @@ inline void
 {
     BMCWEB_LOG_DEBUG << "Get LocationIndicatorActive";
 
-    nlohmann::json& jsonIn = jsonInput["LocationIndicatorActive"];
     dbus::utility::getAssociationEndPoints(
         objPath + "/identifying",
-        [aResp, &jsonIn](const boost::system::error_code& ec,
-                         const dbus::utility::MapperEndPoints& endpoints) {
+        [aResp, &jsonInput](const boost::system::error_code& ec,
+                            const dbus::utility::MapperEndPoints& endpoints) {
         if (ec)
         {
             if (ec.value() != EBADR)
@@ -256,6 +255,8 @@ inline void
             }
             return;
         }
+
+        nlohmann::json& jsonIn = jsonInput["LocationIndicatorActive"];
 
         for (const auto& endpoint : endpoints)
         {
@@ -288,8 +289,9 @@ inline void
 
     dbus::utility::getAssociationEndPoints(
         objPath + "/identifying",
-        [aResp, ledState](const boost::system::error_code& ec,
-                          const dbus::utility::MapperEndPoints& endpoints) {
+        [aResp, ledState,
+         objPath](const boost::system::error_code& ec,
+                  const dbus::utility::MapperEndPoints& endpoints) {
         if (ec)
         {
             if (ec.value() != EBADR)
@@ -297,6 +299,7 @@ inline void
                 BMCWEB_LOG_ERROR << "DBUS response error " << ec.value();
                 messages::internalError(aResp->res);
             }
+            messages::resourceNotFound(aResp->res, "LedGroup", objPath);
             return;
         }
 


### PR DESCRIPTION
Fixes 586076.

Bonnell's power supplies don't have firmware controlled LED. https://github.ibm.com/openbmc/openbmc/commit/7383a11080fa1b88bd6071e454648b308663d168 removed identify LED association to them.
Redfish still shows
  "LocationIndicatorActive": null,

Just have Redfish leave off the LocationIndicatorActive when no association.
This matches
https://gerrit.openbmc.org/c/openbmc/bmcweb/+/42221/38/redfish-core/lib/led.hpp#400

Also added a resourceNotFound when setting a LocationIndicatorActive with no association like 42221.

Tested: Myung is looking 