### PR TITLE
1060: Show LocationIndicatorActive only with association

### DIFF
--- a/redfish-core/lib/assembly.hpp
+++ b/redfish-core/lib/assembly.hpp
@@ -313,9 +313,13 @@ inline void
                 }
             }
 
-            nlohmann::json& assemblyArray = aResp->res.jsonValue["Assemblies"];
-            nlohmann::json& assemblyData = assemblyArray.at(assemblyIndex);
-            getLocationIndicatorActive(aResp, assembly, assemblyData);
+            getLocationIndicatorActive(aResp, assembly,
+                                       [aResp, assemblyIndex](bool asserted) {
+                nlohmann::json& assemblyArray =
+                    aResp->res.jsonValue["Assemblies"];
+                nlohmann::json& assemblyData = assemblyArray.at(assemblyIndex);
+                assemblyData["LocationIndicatorActive"] = asserted;
+            });
         },
             "xyz.openbmc_project.ObjectMapper",
             "/xyz/openbmc_project/object_mapper",

--- a/redfish-core/lib/pcie_slots.hpp
+++ b/redfish-core/lib/pcie_slots.hpp
@@ -434,8 +434,12 @@ inline void getPCIeSlotProperties(
     linkAssociatedDiskBackplane(asyncResp, pcieSlotPath, index);
 
     // Get pcie slot location indicator state
-    nlohmann::json& slotLIA = slots.back();
-    getLocationIndicatorActive(asyncResp, pcieSlotPath, slotLIA);
+    getLocationIndicatorActive(asyncResp, pcieSlotPath,
+                               [asyncResp, index](bool asserted) {
+        nlohmann::json& slotArray = asyncResp->res.jsonValue["Slots"];
+        nlohmann::json& slotItem = slotArray.at(index);
+        slotItem["LocationIndicatorActive"] = asserted;
+    });
 }
 
 // Get all valid  PCIe Slots which are on the given chassis


### PR DESCRIPTION
Fixes [586076](https://jazz07.rchland.ibm.com:13443/jazz/web/projects/CSSD#action=com.ibm.team.workitem.viewWorkItem&id=586076).

Bonnell's power supplies don't have firmware controlled LED. https://github.ibm.com/openbmc/openbmc/commit/7383a11080fa1b88bd6071e454648b308663d168 removed identify LED association to them.

Redfish still shows
      "LocationIndicatorActive": null,

Just have Redfish leave off the LocationIndicatorActive when no association.

This matches
https://gerrit.openbmc.org/c/openbmc/bmcweb/+/42221/38/redfish-core/lib/led.hpp#400

Also added a resourceNotFound when setting a LocationIndicatorActive with no association like 42221.

Tested:

- Validator passes
- PowerSupply without association

- GET

```
curl -k -H "X-Auth-Token: $bmc_token" -H "Content-Type: application/octet-stream" \
    -X GET  https://${bmc}:18080/redfish/v1/Chassis/chassis/PowerSubsystem/PowerSupplies/powersupply0
{
...
 <-- LocationIndicatorActive should not be shown
}
```

- PATCH

```
$ curl -k -H "X-Auth-Token: $token" -X PATCH -d '{"LocationIndicatorActive":false}' \
        https://${bmc}:18080/redfish/v1/Chassis/chassis/PowerSubsystem/PowerSupplies/powersupply0
{
  "error": {
    "@Message.ExtendedInfo": [
      {
        "@odata.type": "#Message.v1_1_1.Message",
        "Message": "The requested resource of type LedGroup named '/xyz/openbmc_project/inventory/system/chassis/motherboard/powersupply0' was not found.",
        "MessageArgs": [
          "LedGroup",
          "/xyz/openbmc_project/inventory/system/chassis/motherboard/powersupply0"
        ],
        "MessageId": "Base.1.13.0.ResourceNotFound",
        "MessageSeverity": "Critical",
        "Resolution": "Provide a valid resource identifier and resubmit the request."
      }
    ],
    "code": "Base.1.13.0.ResourceNotFound",
    "message": "The requested resource of type LedGroup named '/xyz/openbmc_project/inventory/system/chassis/motherboard/powersupply0' was not found."
  }
}%
```

- GET PCIeSlots & GET Assembly should have not coredump and no null LocationIndicatorActive
- /redfish/v1/Chassis/chassis/Assembly
- /redfish/v1/Chassis/chassis/PCIeSlots