### PR TITLE
redfish: remove ForceRestart from AllowableValues

### DIFF
--- a/redfish-core/lib/systems.hpp
+++ b/redfish-core/lib/systems.hpp
@@ -3074,11 +3074,6 @@ inline void handleComputerSystemResetActionPost(
         command = "xyz.openbmc_project.State.Chassis.Transition.Off";
         hostCommand = false;
     }
-    else if (resetType == "ForceRestart")
-    {
-        command = "xyz.openbmc_project.State.Host.Transition.ForceWarmReboot";
-        hostCommand = true;
-    }
     else if (resetType == "GracefulShutdown")
     {
         command = "xyz.openbmc_project.State.Host.Transition.Off";
@@ -3560,7 +3555,6 @@ inline void handleSystemCollectionResetActionGet(
     allowableValues.emplace_back("On");
     allowableValues.emplace_back("ForceOff");
     allowableValues.emplace_back("ForceOn");
-    allowableValues.emplace_back("ForceRestart");
     allowableValues.emplace_back("GracefulRestart");
     allowableValues.emplace_back("GracefulShutdown");
     allowableValues.emplace_back("PowerCycle");


### PR DESCRIPTION
IBM hypervisor firmware requires host reboots to always be graceful to ensure certain BIOS settings are correctly set.

There is no easy way to upstream this type of configuration without some fairly messy #ifdef's and it seems to be a pretty specific IBM requirement.

P10 PR: https://github.com/ibm-openbmc/bmcweb/pull/522

Tested:
```
curl -k -H "X-Auth-Token: $token" -X GET https://${bmc}/redfish/v1/Systems/system/ResetActionInfo {
  "@odata.id": "/redfish/v1/Systems/system/ResetActionInfo",
  "@odata.type": "#ActionInfo.v1_1_2.ActionInfo",
  "Id": "ResetActionInfo",
  "Name": "Reset Action Info",
  "Parameters": [
    {
      "AllowableValues": [
        "On",
        "ForceOff",
        "ForceOn",
        "GracefulRestart",
        "GracefulShutdown",
        "PowerCycle",
        "Nmi"
      ],
      "DataType": "String",
      "Name": "ResetType",
      "Required": true
    }
  ]
}
```