### PR TITLE
1060 add audit log service

### DIFF
--- a/redfish-core/include/redfish.hpp
+++ b/redfish-core/include/redfish.hpp
@@ -180,6 +180,13 @@ class RedfishService
         requestRoutesBMCJournalLogEntry(app);
 #endif
 
+#ifdef BMCWEB_ENABLE_LINUX_AUDIT_EVENTS
+        requestRoutesAuditLogService(app);
+        requestRoutesAuditLogEntry(app);
+        requestRoutesAuditLogEntryCollection(app);
+        requestRoutesFullAuditLogDownload(app);
+#endif
+
 #ifdef BMCWEB_ENABLE_REDFISH_CPU_LOG
         requestRoutesCrashdumpService(app);
         requestRoutesCrashdumpEntryCollection(app);

--- a/redfish-core/include/registries.hpp
+++ b/redfish-core/include/registries.hpp
@@ -50,7 +50,7 @@ struct Message
     const char* message;
     const char* messageSeverity;
     const size_t numberOfArgs;
-    std::array<const char*, 5> paramTypes;
+    std::array<const char*, 8> paramTypes;
     const char* resolution;
 };
 using MessageEntry = std::pair<const char*, const Message>;

--- a/redfish-core/include/registries/openbmc_message_registry.hpp
+++ b/redfish-core/include/registries/openbmc_message_registry.hpp
@@ -63,14 +63,14 @@
 namespace redfish::registries::openbmc
 {
 const Header header = {
-    "Copyright 2022 OpenBMC. All rights reserved.",
+    "Copyright 2024 OpenBMC. All rights reserved.",
     "#MessageRegistry.v1_4_0.MessageRegistry",
-    "OpenBMC.0.4.0",
+    "OpenBMC.0.5.0",
     "OpenBMC Message Registry",
     "en",
     "This registry defines the base messages for OpenBMC.",
     "OpenBMC",
-    "0.4.0",
+    "0.5.0",
     "OpenBMC",
 };
 constexpr std::array registry = {
@@ -172,7 +172,36 @@ constexpr std::array registry = {
                      {},
                      "None.",
                  }},
-
+    MessageEntry{"AuditLogEntry",
+                 {
+                     "General audit log entry, use for non-parsed fields",
+                     "%1",
+                     "OK",
+                     1,
+                     {
+                         "string",
+                     },
+                     "None.",
+                 }},
+    MessageEntry{
+        "AuditLogUsysConfig",
+        {
+            "Description",
+            "type=%1 op=%2 acct=%3 exe=%4 hostname=%5 addr=%6 terminal=%7 res=%8",
+            "OK",
+            8,
+            {
+                "string",
+                "string",
+                "string",
+                "string",
+                "string",
+                "string",
+                "string",
+                "string",
+            },
+            "None.",
+        }},
     MessageEntry{"BIOSAttributesChanged",
                  {
                      "Indicates that a set of BIOS Attributes has changed.",

--- a/redfish-core/lib/log_services.hpp
+++ b/redfish-core/lib/log_services.hpp
@@ -1524,6 +1524,13 @@ inline void requestRoutesSystemLogServiceCollection(App& app)
         asyncResp->res.jsonValue["Members@odata.count"] =
             logServiceArrayLocal.size();
 #endif // BMCWEB_ENABLE_HW_ISOLATION
+
+#ifdef BMCWEB_ENABLE_LINUX_AUDIT_EVENTS
+        nlohmann::json::object_t auditLog;
+        auditLog["@odata.id"] =
+            "/redfish/v1/Systems/system/LogServices/AuditLog";
+        logServiceArray.push_back(std::move(auditLog));
+#endif // BMCWEB_ENABLE_LINUX_AUDIT_EVENTS
     });
 }
 
@@ -6605,5 +6612,614 @@ inline void requestRoutesSystemHardwareIsolationLogService(App& app)
             postSystemHardwareIsolationLogServiceClearLog);
 }
 #endif // BMCWEB_ENABLE_HW_ISOLATION
+
+#ifdef BMCWEB_ENABLE_LINUX_AUDIT_EVENTS
+/****************************************************
+ * Redfish AuditLog interfaces
+ ******************************************************/
+inline void handleLogServicesAuditLogGet(
+    crow::App& app, const crow::Request& req,
+    const std::shared_ptr<bmcweb::AsyncResp>& asyncResp,
+    const std::string& systemName)
+{
+    if (!redfish::setUpRedfishRoute(app, req, asyncResp))
+    {
+        return;
+    }
+    if (systemName != "system")
+    {
+        messages::resourceNotFound(asyncResp->res, "ComputerSystem",
+                                   systemName);
+
+        return;
+    }
+    asyncResp->res.jsonValue["@odata.id"] =
+        "/redfish/v1/Systems/system/LogServices/AuditLog";
+    asyncResp->res.jsonValue["@odata.type"] = "#LogService.v1_2_0.LogService";
+    asyncResp->res.jsonValue["Name"] = "Audit Log Service";
+    asyncResp->res.jsonValue["Description"] = "Audit Log Service";
+    asyncResp->res.jsonValue["Id"] = "AuditLog";
+    asyncResp->res.jsonValue["OverWritePolicy"] = "WrapsWhenFull";
+    asyncResp->res.jsonValue["Entries"]["@odata.id"] =
+        "/redfish/v1/Systems/system/LogServices/AuditLog/Entries";
+
+    std::pair<std::string, std::string> redfishDateTimeOffset =
+        redfish::time_utils::getDateTimeOffsetNow();
+    asyncResp->res.jsonValue["DateTime"] = redfishDateTimeOffset.first;
+    asyncResp->res.jsonValue["DateTimeLocalOffset"] =
+        redfishDateTimeOffset.second;
+}
+
+inline void requestRoutesAuditLogService(App& app)
+{
+    BMCWEB_ROUTE(app, "/redfish/v1/Systems/<str>/LogServices/AuditLog/")
+        .privileges(redfish::privileges::getLogService)
+        .methods(boost::beast::http::verb::get)(
+            std::bind_front(handleLogServicesAuditLogGet, std::ref(app)));
+}
+
+static LogParseError
+    fillAuditLogEntryJson(const nlohmann::json& auditEntry,
+                          nlohmann::json::object_t& logEntryJson)
+{
+    if (auditEntry.is_discarded())
+    {
+        return LogParseError::parseFailed;
+    }
+
+    std::string logEntryID;
+    std::string entryTimeStr;
+    std::string messageID;
+    nlohmann::json messageArgs = nlohmann::json::array();
+    for (const auto& item : auditEntry.items())
+    {
+        if (item.key() == "ID")
+        {
+            logEntryID = item.value();
+        }
+
+        else if (item.key() == "EventTimestamp")
+        {
+            uint64_t timestamp = item.value();
+            entryTimeStr = redfish::time_utils::getDateTimeUint(timestamp);
+        }
+
+        else if (item.key() == "MessageId")
+        {
+            messageID = item.value();
+        }
+
+        else if (item.key() == "MessageArgs")
+        {
+            messageArgs = item.value();
+        }
+    }
+
+    // Check that we found all of the expected fields.
+    if (messageID.empty())
+    {
+        BMCWEB_LOG_ERROR << "Missing MessageID";
+        return LogParseError::parseFailed;
+    }
+
+    if (logEntryID.empty())
+    {
+        BMCWEB_LOG_ERROR << "Missing ID";
+        return LogParseError::parseFailed;
+    }
+
+    if (entryTimeStr.empty())
+    {
+        BMCWEB_LOG_ERROR << "Missing Timestamp";
+        return LogParseError::parseFailed;
+    }
+
+    // Get the Message from the MessageRegistry
+    const registries::Message* message = registries::getMessage(messageID);
+
+    if (message == nullptr)
+    {
+        BMCWEB_LOG_WARNING << "Log entry not found in registry: " << messageID;
+        return LogParseError::messageIdNotInRegistry;
+    }
+
+    std::string msg = message->message;
+
+    // Fill the MessageArgs into the Message
+    if (messageArgs.size() > 0)
+    {
+        int i = 0;
+        for (auto messageArg : messageArgs)
+        {
+            std::string argStr = "%" + std::to_string(++i);
+            size_t argPos = msg.find(argStr);
+            if (argPos != std::string::npos)
+            {
+                msg.replace(argPos, argStr.length(), messageArg);
+            }
+        }
+    }
+
+    // Fill in the log entry with the gathered data
+    logEntryJson["@odata.type"] = "#LogEntry.v1_9_0.LogEntry";
+    logEntryJson["@odata.id"] =
+        "/redfish/v1/Systems/system/LogServices/AuditLog/Entries/" + logEntryID;
+    logEntryJson["Name"] = "Audit Log Entry";
+    logEntryJson["Id"] = logEntryID;
+    logEntryJson["MessageId"] = std::move(messageID);
+    logEntryJson["Message"] = std::move(msg);
+    logEntryJson["MessageArgs"] = std::move(messageArgs);
+    logEntryJson["EntryType"] = "Event";
+    logEntryJson["EventTimestamp"] = std::move(entryTimeStr);
+
+    /* logEntryJson["Oem"]["IBM"]["@odata.id"] ?? */
+    logEntryJson["Oem"]["IBM"]["@odata.type"] = "#OemLogEntry.v1_0_0.LogEntry";
+    logEntryJson["Oem"]["IBM"]["AdditionalDataFullAuditLogURI"] =
+        "/redfish/v1/Systems/system/LogServices/AuditLog/Entries/FullAudit/attachment";
+
+    return LogParseError::success;
+}
+
+/**
+ * @brief Read single line from POSIX stream
+ * @details Maximum length of line read is 4096 characters. Longer lines than
+ *          this will be truncated and a warning is logged. This is to guard
+ *          against malformed data using unexpected amounts of memory.
+ *
+ * @param[in] logStream - POSIX stream
+ * @param[out] logLine - Filled in with line read on success
+ *
+ * @return True if line was read even if truncated. False if EOF reached or
+ *         error reading from the logStream.
+ */
+inline bool readLine(FILE* logStream, std::string& logLine)
+{
+    std::array<char, 4096> buffer;
+
+    if (fgets(buffer.data(), buffer.size(), logStream) == nullptr)
+    {
+        /* Failed to read, could be EOF.
+         * Report error if not EOF.
+         */
+        if (!feof(logStream))
+        {
+            BMCWEB_LOG_ERROR << "Failure reading logStream: " << errno;
+        }
+        return false;
+    }
+
+    logLine.assign(buffer.data());
+
+    if (!logLine.ends_with('\n'))
+    {
+        /* Line was too long for the buffer.
+         * Could repeat reads or increase size of buffer.
+         * Don't expect log lines to be longer than 4096 so
+         * read to get to end of this line and discard rest of the line.
+         * Return just the part of the line which fit in the original
+         * buffer and let the caller handle it.
+         */
+        std::array<char, 4096> skipBuffer;
+        std::string skipLine;
+        auto totalLength = logLine.size();
+
+        do
+        {
+            if (fgets(skipBuffer.data(), skipBuffer.size(), logStream) !=
+                nullptr)
+            {
+                skipLine.assign(skipBuffer.data());
+                totalLength += skipLine.size();
+            }
+
+            if (ferror(logStream))
+            {
+                BMCWEB_LOG_ERROR << "Failure reading logStream: " << errno;
+                break;
+            }
+
+            if (feof(logStream))
+            {
+                /* Reached EOF trying to find the end of this line. */
+                break;
+            }
+        } while (!skipLine.ends_with('\n'));
+
+        BMCWEB_LOG_WARNING
+            << "Line too long for logStream, line is truncated. Line length: "
+            << totalLength;
+    }
+
+    /* Return success even if line was truncated */
+    return true;
+}
+
+/**
+ * @brief Reads the audit log entries and writes them to Members array
+ *
+ * @param[in] asyncResp - The redfish response to return.
+ * @param[in] unixfd - File descriptor for Audit Log file
+ * @param[in] skip - Query paramater skip value
+ * @param[in] top - Query paramater top value
+ */
+void readAuditLogEntries(const std::shared_ptr<bmcweb::AsyncResp>& asyncResp,
+                         const sdbusplus::message::unix_fd& unixfd, size_t skip,
+                         size_t top)
+{
+    auto fd = dup(unixfd);
+    if (fd == -1)
+    {
+        BMCWEB_LOG_ERROR << "Failed to duplicate fd " << unixfd;
+        messages::internalError(asyncResp->res);
+        return;
+    }
+
+    auto logStream = fdopen(fd, "r");
+    if (logStream == nullptr)
+    {
+        BMCWEB_LOG_ERROR << "Failed to open fd " << fd;
+        messages::internalError(asyncResp->res);
+        close(fd);
+        return;
+    }
+
+    nlohmann::json& logEntryArray = asyncResp->res.jsonValue["Members"];
+    if (logEntryArray.empty())
+    {
+        logEntryArray = nlohmann::json::array();
+    }
+
+    uint64_t entryCount = 0;
+    std::string logLine;
+    while (readLine(logStream, logLine))
+    {
+        /* Note: entryCount counts all entries even ones with parse errors.
+         *       This allows the top/skip semantics to work correctly and a
+         *       consistent count to be returned.
+         */
+        entryCount++;
+        BMCWEB_LOG_DEBUG << entryCount << ":logLine: " << logLine;
+
+        /* Handle paging using skip (number of entries to skip from the
+         * start) and top (number of entries to display).
+         * Don't waste cycles parsing if we are going to skip sending this entry
+         */
+        if (entryCount <= skip || entryCount > skip + top)
+        {
+            BMCWEB_LOG_DEBUG << "Query param skips, line=" << entryCount;
+            continue;
+        }
+
+        nlohmann::json::object_t bmcLogEntry;
+
+        auto auditEntry = nlohmann::json::parse(logLine, nullptr, false);
+
+        LogParseError status = fillAuditLogEntryJson(auditEntry, bmcLogEntry);
+        if (status != LogParseError::success)
+        {
+            BMCWEB_LOG_ERROR << "Failed to parse line=" << entryCount;
+            messages::internalError(asyncResp->res);
+            continue;
+        }
+
+        logEntryArray.push_back(std::move(bmcLogEntry));
+    }
+
+    asyncResp->res.jsonValue["Members@odata.count"] = entryCount;
+
+    if (skip + top < entryCount)
+    {
+        asyncResp->res.jsonValue["Members@odata.nextLink"] =
+            "/redfish/v1/Systems/system/LogServices/AuditLog/Entries?$skip=" +
+            std::to_string(skip + top);
+    }
+
+    /* Not writing to file, so can safely ignore error on close */
+    (void)fclose(logStream);
+}
+
+/**
+ * @brief Retrieves the targetID entry from the unixfd
+ *
+ * @param[in] asyncResp - The redfish response to return.
+ * @param[in] unixfd - File descriptor for Audit Log file
+ * @param[in] targetID - ID of entry to retrieve
+ */
+void getAuditLogEntryByID(const std::shared_ptr<bmcweb::AsyncResp>& asyncResp,
+                          const sdbusplus::message::unix_fd& unixfd,
+                          const std::string& targetID)
+{
+    bool found = false;
+
+    auto fd = dup(unixfd);
+    if (fd == -1)
+    {
+        BMCWEB_LOG_ERROR << "Failed to duplicate fd " << unixfd;
+        messages::internalError(asyncResp->res);
+        return;
+    }
+
+    auto logStream = fdopen(fd, "r");
+    if (logStream == nullptr)
+    {
+        BMCWEB_LOG_ERROR << "Failed to open fd " << fd;
+        messages::internalError(asyncResp->res);
+        close(fd);
+        return;
+    }
+
+    uint64_t entryCount = 0;
+    std::string logLine;
+    while (readLine(logStream, logLine))
+    {
+        entryCount++;
+        BMCWEB_LOG_DEBUG << entryCount << ":logLine: " << logLine;
+
+        auto auditEntry = nlohmann::json::parse(logLine, nullptr, false);
+        auto idIt = auditEntry.find("ID");
+        if (idIt != auditEntry.end() && *idIt == targetID)
+        {
+            found = true;
+            nlohmann::json::object_t bmcLogEntry;
+            LogParseError status = fillAuditLogEntryJson(auditEntry,
+                                                         bmcLogEntry);
+            if (status != LogParseError::success)
+            {
+                BMCWEB_LOG_ERROR << "Failed to parse line=" << entryCount;
+                messages::internalError(asyncResp->res);
+            }
+            else
+            {
+                asyncResp->res.jsonValue.update(bmcLogEntry);
+            }
+            break;
+        }
+    }
+
+    if (!found)
+    {
+        messages::resourceNotFound(asyncResp->res, "LogEntry", targetID);
+    }
+
+    /* Not writing to file, so can safely ignore error on close */
+    (void)fclose(logStream);
+}
+
+void handleLogServicesAuditLogEntriesCollectionGet(
+    crow::App& app, const crow::Request& req,
+    const std::shared_ptr<bmcweb::AsyncResp>& asyncResp,
+    const std::string& systemName)
+{
+    query_param::QueryCapabilities capabilities = {
+        .canDelegateTop = true,
+        .canDelegateSkip = true,
+    };
+    query_param::Query delegatedQuery;
+    if (!redfish::setUpRedfishRouteWithDelegation(app, req, asyncResp,
+                                                  delegatedQuery, capabilities))
+    {
+        return;
+    }
+
+    if (systemName != "system")
+    {
+        messages::resourceNotFound(asyncResp->res, "ComputerSystem",
+                                   systemName);
+
+        return;
+    }
+
+    asyncResp->res.jsonValue["@odata.type"] =
+        "#LogEntryCollection.LogEntryCollection";
+    asyncResp->res.jsonValue["@odata.id"] =
+        "/redfish/v1/Systems/system/LogServices/AuditLog/Entries";
+    asyncResp->res.jsonValue["Name"] = "Audit Log Entries";
+    asyncResp->res.jsonValue["Description"] = "Collection of Audit Log Entries";
+    size_t skip = delegatedQuery.skip.value_or(0);
+    size_t top = delegatedQuery.top.value_or(query_param::Query::maxTop);
+
+    /* Create unique entry for each entry in log file.
+     */
+    crow::connections::systemBus->async_method_call(
+        [asyncResp, skip, top](const boost::system::error_code ec,
+                               const sdbusplus::message::unix_fd& unixfd) {
+        if (ec)
+        {
+            BMCWEB_LOG_ERROR << "AuditLog resp_handler got error " << ec;
+            messages::internalError(asyncResp->res);
+            return;
+        }
+
+        readAuditLogEntries(asyncResp, unixfd, skip, top);
+    },
+        "xyz.openbmc_project.Logging.AuditLog",
+        "/xyz/openbmc_project/logging/auditlog",
+        "xyz.openbmc_project.Logging.AuditLog", "GetLatestEntries", top);
+}
+
+inline void requestRoutesAuditLogEntryCollection(App& app)
+{
+    BMCWEB_ROUTE(app, "/redfish/v1/Systems/<str>/LogServices/AuditLog/Entries/")
+        .privileges(redfish::privileges::getLogEntryCollection)
+        .methods(boost::beast::http::verb::get)(std::bind_front(
+            handleLogServicesAuditLogEntriesCollectionGet, std::ref(app)));
+}
+
+inline void handleLogServicesAuditLogEntryGet(
+    crow::App& app, const crow::Request& req,
+    const std::shared_ptr<bmcweb::AsyncResp>& asyncResp,
+    const std::string& systemName, const std::string& targetID)
+{
+    if (!redfish::setUpRedfishRoute(app, req, asyncResp))
+    {
+        return;
+    }
+    if (systemName != "system")
+    {
+        messages::resourceNotFound(asyncResp->res, "ComputerSystem",
+                                   systemName);
+        return;
+    }
+
+    /* Search for entry matching targetID. */
+    crow::connections::systemBus->async_method_call(
+        [asyncResp, targetID](const boost::system::error_code ec,
+                              const sdbusplus::message::unix_fd& unixfd) {
+        if (ec)
+        {
+            if (ec.value() == EBADR)
+            {
+                messages::resourceNotFound(asyncResp->res, "AuditLog",
+                                           targetID);
+                return;
+            }
+            BMCWEB_LOG_ERROR << "AuditLog resp_handler got error " << ec;
+            messages::internalError(asyncResp->res);
+            return;
+        }
+
+        getAuditLogEntryByID(asyncResp, unixfd, targetID);
+    },
+        "xyz.openbmc_project.Logging.AuditLog",
+        "/xyz/openbmc_project/logging/auditlog",
+        "xyz.openbmc_project.Logging.AuditLog", "GetLatestEntries",
+        query_param::Query::maxTop);
+}
+
+inline void requestRoutesAuditLogEntry(App& app)
+{
+    BMCWEB_ROUTE(
+        app, "/redfish/v1/Systems/<str>/LogServices/AuditLog/Entries/<str>/")
+        .privileges(redfish::privileges::getLogEntry)
+        .methods(boost::beast::http::verb::get)(
+            std::bind_front(handleLogServicesAuditLogEntryGet, std::ref(app)));
+}
+
+inline void getFullAuditLogAttachment(
+    const std::shared_ptr<bmcweb::AsyncResp>& asyncResp,
+    const sdbusplus::message::unix_fd& unixfd)
+{
+    int fd = -1;
+    fd = dup(unixfd);
+    if (fd == -1)
+    {
+        BMCWEB_LOG_ERROR << "Failed to duplicate fd " << unixfd;
+        messages::internalError(asyncResp->res);
+        return;
+    }
+
+    long long int size = lseek(fd, 0, SEEK_END);
+    if (size == -1)
+    {
+        BMCWEB_LOG_ERROR << "Failed to get size of fd " << fd;
+        messages::internalError(asyncResp->res);
+        close(fd);
+        return;
+    }
+
+    // Max file size based on default configuration: 10MB
+    constexpr int maxFileSize = 10485760;
+    if (size > maxFileSize)
+    {
+        BMCWEB_LOG_ERROR << "File size exceeds maximum allowed size of "
+                         << maxFileSize;
+        messages::internalError(asyncResp->res);
+        close(fd);
+        return;
+    }
+    std::vector<char> data(static_cast<size_t>(size));
+    long long int rc = lseek(fd, 0, SEEK_SET);
+    if (rc == -1)
+    {
+        BMCWEB_LOG_ERROR << "Failed to seek fd " << fd;
+        messages::internalError(asyncResp->res);
+        close(fd);
+        return;
+    }
+    rc = read(fd, data.data(), data.size());
+    if ((rc == -1) || (rc != size))
+    {
+        BMCWEB_LOG_ERROR << "Failed to read fd " << fd;
+        messages::internalError(asyncResp->res);
+        close(fd);
+        return;
+    }
+    close(fd);
+
+    std::string_view strData(data.data(), data.size());
+    std::string output = crow::utility::base64encode(strData);
+
+    asyncResp->res.addHeader(boost::beast::http::field::content_type,
+                             "application/octet-stream");
+    asyncResp->res.addHeader(
+        boost::beast::http::field::content_transfer_encoding, "Base64");
+    asyncResp->res.body() = std::move(output);
+}
+
+inline void handleFullAuditLogAttachment(
+    crow::App& app, const crow::Request& req,
+    const std::shared_ptr<bmcweb::AsyncResp>& asyncResp,
+    const std::string& systemName, const std::string& entryID)
+{
+    if (!redfish::setUpRedfishRoute(app, req, asyncResp))
+    {
+        BMCWEB_LOG_DEBUG << "Route setup failed";
+        return;
+    }
+
+    if (!http_helpers::isContentTypeAllowed(
+            req.getHeaderValue("Accept"),
+            http_helpers::ContentType::OctetStream, true))
+    {
+        BMCWEB_LOG_ERROR << "Content type not allowed";
+        asyncResp->res.result(boost::beast::http::status::bad_request);
+        return;
+    }
+    if (systemName != "system")
+    {
+        messages::resourceNotFound(asyncResp->res, "ComputerSystem",
+                                   systemName);
+        return;
+    }
+    if (entryID != "FullAudit")
+    {
+        messages::resourceNotFound(asyncResp->res, "ID", entryID);
+        return;
+    }
+
+    /* Download attachment */
+    crow::connections::systemBus->async_method_call(
+        [asyncResp, entryID](const boost::system::error_code ec,
+                             const sdbusplus::message::unix_fd& unixfd) {
+        if (ec)
+        {
+            if (ec.value() == EBADR)
+            {
+                messages::resourceNotFound(asyncResp->res, "AuditLog", entryID);
+                return;
+            }
+            BMCWEB_LOG_ERROR << "AuditLog resp_handler got error " << ec;
+            messages::internalError(asyncResp->res);
+            return;
+        }
+
+        getFullAuditLogAttachment(asyncResp, unixfd);
+    },
+        "xyz.openbmc_project.Logging.AuditLog",
+        "/xyz/openbmc_project/logging/auditlog",
+        "xyz.openbmc_project.Logging.AuditLog", "GetAuditLog");
+}
+
+inline void requestRoutesFullAuditLogDownload(App& app)
+{
+    BMCWEB_ROUTE(
+        app,
+        "/redfish/v1/Systems/<str>/LogServices/AuditLog/Entries/<str>/attachment")
+        .privileges(redfish::privileges::getLogEntry)
+        .methods(boost::beast::http::verb::get)(
+            std::bind_front(handleFullAuditLogAttachment, std::ref(app)));
+}
+
+#endif // BMCWEB_ENABLE_LINUX_AUDIT_EVENTS
 
 } // namespace redfish


### PR DESCRIPTION
Scaled down implementation of upstream design still under review [1].
This implements the LogService routes for retrieving audit log entries
and for downloading file of all audit log entries.

Routes for discovering the service:
```
$ curl -k -H "X-Auth-Token: $token" https://${BMC_IP}/redfish/v1/Systems/system/LogServices/
{
  "@odata.id": "/redfish/v1/Systems/system/LogServices",
  "@odata.type": "#LogServiceCollection.LogServiceCollection",
  "Description": "Collection of LogServices for this Computer System",
  "Members": [
[...]
    {
      "@odata.id": "/redfish/v1/Systems/system/LogServices/AuditLog"
    },
[...]
  ],
  "Members@odata.count": 7,
  "Name": "System Log Services Collection"
}

$ curl -k -H "X-Auth-Token: $token" https://${BMC_IP/redfish/v1/Systems/system/LogServices/AuditLog
{
  "@odata.id": "/redfish/v1/Systems/system/LogServices/AuditLog",
  "@odata.type": "#LogService.v1_2_0.LogService",
  "DateTime": "2024-01-18T20:20:48+00:00",
  "DateTimeLocalOffset": "+00:00",
  "Description": "Audit Log Service",
  "Entries": {
    "@odata.id": "/redfish/v1/Systems/system/LogServices/AuditLog/Entries"
  },
  "Id": "AuditLog",
  "Name": "Audit Log Service",
  "OverWritePolicy": "WrapsWhenFull"
}
```

Routes for retrieving a subset of the audit log entries sorted newest to
oldest:
```
$ curl -k -H "X-Auth-Token: $token" https://${BMC_IP/redfish/v1/Systems/system/LogServices/AuditLog/Entries
{
  "@odata.id": "/redfish/v1/Systems/system/LogServices/AuditLog/Entries",
  "@odata.type": "#LogEntryCollection.LogEntryCollection",
  "Description": "Collection of Audit Log Entries",
  "Members": [
    {
      "@odata.id": "/redfish/v1/Systems/system/LogServices/AuditLog/Entries/1705609196.191:10",
      "@odata.type": "#LogEntry.v1_9_0.LogEntry",
      "EntryType": "Event",
      "EventTimestamp": "2024-01-18T20:19:56+00:00",
      "Id": "1705609196.191:10",
      "Message": "type=USYS_CONFIG op=POST:/login acct=service exe=/usr/bin/bmcweb hostname=p10bmc addr=::ffff:10.0.2.1 terminal=? res=success",
      "MessageArgs": [
        "USYS_CONFIG",
        "POST:/login",
        "service",
        "/usr/bin/bmcweb",
        "p10bmc",
        "::ffff:10.0.2.1",
        "?",
        "success"
      ],
      "MessageId": "OpenBMC.0.5.AuditLogUsysConfig",
      "Name": "Audit Log Entry",
      "Oem": {
        "IBM": {
          "@odata.type": "#OemLogEntry.v1_0_0.LogEntry",
          "AdditionalDataFullAuditLogURI": "/redfish/v1/Systems/system/LogServices/AuditLog/Entries/FullAudit/attachment"
        }
      }
    },
[...]
    {
      "@odata.id": "/redfish/v1/Systems/system/LogServices/AuditLog/Entries/1705608465.844:9240",
      "@odata.type": "#LogEntry.v1_9_0.LogEntry",
      "EntryType": "Event",
      "EventTimestamp": "2024-01-18T20:07:45+00:00",
      "Id": "1705608465.844:9240",
      "Message": "type=DAEMON_START msg=audit(1705608465.844:9240): op=start ver=3.1.2 format=enriched kernel=6.5.4-c32d714-00105-gc32d7141d48b auid=4294967295 pid=264 uid=0 ses=4294967295 res=success",
      "MessageArgs": [
        "type=DAEMON_START msg=audit(1705608465.844:9240): op=start ver=3.1.2 format=enriched kernel=6.5.4-c32d714-00105-gc32d7141d48b auid=4294967295 pid=264 uid=0 ses=4294967295 res=success"
      ],
      "MessageId": "OpenBMC.0.5.AuditLogEntry",
      "Name": "Audit Log Entry",
      "Oem": {
        "IBM": {
          "@odata.type": "#OemLogEntry.v1_0_0.LogEntry",
          "AdditionalDataFullAuditLogURI": "/redfish/v1/Systems/system/LogServices/AuditLog/Entries/FullAudit/attachment"
        }
      }
    }
  ],
  "Members@odata.count": 17,
  "Name": "Audit Log Entries"
}

$ curl -k -H "X-Auth-Token: $token" https://${BMC_IP}/redfish/v1/Systems/system/LogServices/AuditLog/Entries?\$top=1
{
  "@odata.id": "/redfish/v1/Systems/system/LogServices/AuditLog/Entries",
  "@odata.type": "#LogEntryCollection.LogEntryCollection",
  "Description": "Collection of Audit Log Entries",
  "Members": [
    {
      "@odata.id": "/redfish/v1/Systems/system/LogServices/AuditLog/Entries/1705609196.191:10",
      "@odata.type": "#LogEntry.v1_9_0.LogEntry",
      "EntryType": "Event",
      "EventTimestamp": "2024-01-18T20:19:56+00:00",
      "Id": "1705609196.191:10",
      "Message": "type=USYS_CONFIG op=POST:/login acct=service exe=/usr/bin/bmcweb hostname=p10bmc addr=::ffff:10.0.2.1 terminal=? res=success",
      "MessageArgs": [
        "USYS_CONFIG",
        "POST:/login",
        "service",
        "/usr/bin/bmcweb",
        "p10bmc",
        "::ffff:10.0.2.1",
        "?",
        "success"
      ],
      "MessageId": "OpenBMC.0.5.AuditLogUsysConfig",
      "Name": "Audit Log Entry",
      "Oem": {
        "IBM": {
          "@odata.type": "#OemLogEntry.v1_0_0.LogEntry",
          "AdditionalDataFullAuditLogURI": "/redfish/v1/Systems/system/LogServices/AuditLog/Entries/FullAudit/attachment"
        }
      }
    }
  ],
  "Members@odata.count": 1,
  "Name": "Audit Log Entries"
}
```

Route for retrieving a specific entry:
```
$ curl -k -H "X-Auth-Token: $token" https://${BMC_IP}/redfish/v1/Systems/system/LogServices/AuditLog/Entrie/1705608482.239:8
{
  "@odata.id": "/redfish/v1/Systems/system/LogServices/AuditLog/Entries/1705608482.239:8",
  "@odata.type": "#LogEntry.v1_9_0.LogEntry",
  "EntryType": "Event",
  "EventTimestamp": "2024-01-18T20:08:02+00:00",
  "Id": "1705608482.239:8",
  "Message": "type=USYS_CONFIG op=PATCH:/redfish/v1/AccountService/Accounts/service acct=admin exe=/usr/bin/bmcweb hostname=p10bmc addr=::ffff:10.0.2.1 terminal=? res=success",
  "MessageArgs": [
    "USYS_CONFIG",
    "PATCH:/redfish/v1/AccountService/Accounts/service",
    "admin",
    "/usr/bin/bmcweb",
    "p10bmc",
    "::ffff:10.0.2.1",
    "?",
    "success"
  ],
  "MessageId": "OpenBMC.0.5.AuditLogUsysConfig",
  "Name": "Audit Log Entry",
  "Oem": {
    "IBM": {
      "@odata.type": "#OemLogEntry.v1_0_0.LogEntry",
      "AdditionalDataFullAuditLogURI": "/redfish/v1/Systems/system/LogServices/AuditLog/Entries/FullAudit/attachment"
    }
  }
}

$ curl -k -H "X-Auth-Token: $token" https://${BMC_IP}/redfish/v1/Systems/system/LogServices/AuditLog/Entries/1705608482.239:800
{
  "error": {
    "@Message.ExtendedInfo": [
      {
        "@odata.type": "#Message.v1_1_1.Message",
        "Message": "The requested resource of type LogEntry named '1705608482.239:800' was not found.",
        "MessageArgs": [
          "LogEntry",
          "1705608482.239:800"
        ],
        "MessageId": "Base.1.13.0.ResourceNotFound",
        "MessageSeverity": "Critical",
        "Resolution": "Provide a valid resource identifier and resubmit the request."
      }
    ],
    "code": "Base.1.13.0.ResourceNotFound",
    "message": "The requested resource of type LogEntry named '1705608482.239:800' was not found."
  }
}
```

Route for downloading file with all audit log events sorted oldest to
newest:
```
$ curl -k -H "X-Auth-Token: $token" https://${BMC_IP/redfish/v1/Systems/system/LogServices/AuditLog/Entries/FullAudit/attachment | base64 --decode
  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                 Dload  Upload   Total   Spent    Left  Speed
100  5876  100  5876    0     0  23467      0 --:--:-- --:--:-- --:--:-- 23504
{"Event":"type=DAEMON_START msg=audit(1705608465.844:9240): op=start ver=3.1.2 f
ormat=enriched kernel=6.5.4-c32d714-00105-gc32d7141d48b auid=4294967295 pid=264
uid=0 ses=4294967295 res=success","EventTimestamp":1705608465,"ID":"1705608465.8
44:9240"}
[...]

```

Added AuditLogUsysConfig to registry.
Added AuditLogEntry to registry.

Tested:
 - Redfish validator passed and visited AuditLog LogService routes
 - Verified all of the new routes.
 - Verified bad entry returns error as expected.
 - Verified able to download full audit log file.

[1] https://gerrit.openbmc.org/c/openbmc/docs/+/63915