### PR TITLE
1060: Allow multiple fabric adapters on a slot

### DIFF
--- a/static/redfish/v1/JsonSchemas/OemPCIeSlots/OemPCIeSlots.json
+++ b/static/redfish/v1/JsonSchemas/OemPCIeSlots/OemPCIeSlots.json
@@ -55,12 +55,17 @@
                         "object"
                     ]
                 },
-                "UpstreamFabricAdapter": {
-                    "$ref": "http://redfish.dmtf.org/schemas/v1/FabricAdapter.json#/definitions/FabricAdapter",
-                    "description": "The link to the fabric adapter.",
-                    "longDescription": "This property shall contain a link to a resource of type FabricAdapter.",
+                "UpstreamFabricAdapters": {
+                    "description": "The upstream fabric adapters.",
+                    "items": {
+                        "$ref": "http://redfish.dmtf.org/schemas/v1/FabricAdapter.json#/definitions/FabricAdapter"
+                    },
+                    "longDescription": "This property shall contain an array of links to the upstream fabric adapters.",
                     "readonly": true,
-                    "type": "object"
+                    "type": "array"
+                },
+                "UpstreamFabricAdapters@odata.count": {
+                    "$ref": "http://redfish.dmtf.org/schemas/v1/odata-v4.json#/definitions/count"
                 }
             },
             "type": "object"

--- a/static/redfish/v1/schema/OemPCIeSlots_v1.xml
+++ b/static/redfish/v1/schema/OemPCIeSlots_v1.xml
@@ -46,9 +46,10 @@
           <Annotation Term="OData.Permissions" EnumMember="OData.Permission/Read"/>
           <Annotation Term="OData.Description" String="Represent association slot with assembly."/>
         </Property>
-        <Property Name="UpstreamFabricAdapter" Type="FabricAdapter.FabricAdapter">
+        <Property Name="UpstreamFabricAdapters" Type="Collection(FabricAdapter.FabricAdapter)">
           <Annotation Term="OData.Permissions" EnumMember="OData.Permission/Read"/>
-          <Annotation Term="OData.Description" String="Upstream Link to FabricAdapter."/>
+          <Annotation Term="OData.Description" String="The upstream fabric adapters."/>
+          <Annotation Term="OData.LongDescription" String="This property shall contain an array of links to the upstream fabric adapters."/>
         </Property>
       </ComplexType>
 


### PR DESCRIPTION
Previously, only one fabric adapter on a PCIeSlot can be allowed. However, multiple fabric adapters can be added to a slot, and it causes an error like

```
$ curl -k -X GET https://${bmc}/redfish/v1/Chassis/chassis15873/PCIeSlots

Jan 19 18:05:10 z1707cbmc bmcweb[766]: (2024-01-19 18:05:10) [CRITICAL "error_messages.cpp":258] Internal Error /usr/src/debug/bmcweb/1.0+git-r0/redfish-core/lib/pcie_slots.hpp(321:36) `red
Jan 19 18:05:10 z1707cbmc bmcweb[766]: (2024-01-19 18:05:10) [ERROR "pcie_slots.hpp":319] DBUS response has more than FabricAdapters of 2
```

This will fix the followings
- Allow multiple fabric adapters on a PCIeSlots
- Rename schema field `UpstreamFabricAdapter` to `UpstreamFabricAdapters`.

This would need the changes in webui-vue component.

Tested:
- After the fix, PCIeSlots will show like

```
$ curl -k -X GET https://${bmc}/redfish/v1/Chassis/chassis15873/PCIeSlots
      "Links": {
        "Oem": {
          "IBM": {
            "@odata.type": "#OemPCIeSlots.v1_0_0.PCIeLinks",
            "UpstreamFabricAdapters": [
              {
                "@odata.id": "/redfish/v1/Systems/system/FabricAdapters/board1-logical_slot1-io_module1"
              },
              {
                "@odata.id": "/redfish/v1/Systems/system/FabricAdapters/board2-logical_slot2-io_module1"
              }
            ],
            "UpstreamFabricAdapters@odata.count": 2
          }
        },
```

- Redfish Validator passes