### PR TITLE
1110 ibm acf

### DIFF
--- a/config/bmcweb.service.in
+++ b/config/bmcweb.service.in
@@ -3,6 +3,11 @@ Description=Start bmcweb server
 
 Wants=network.target
 After=network.target
+After=xyz.openbmc_project.User.Manager.service
+After=xyz.openbmc_project.State.BMC.service
+After=xyz.openbmc_project.Software.BMC.Updater.service
+After=xyz.openbmc_project.State.Host@0.service
+After=srvcfg-manager.service
 
 [Service]
 ExecReload=kill -s HUP $MAINPID

--- a/redfish-core/include/error_messages.hpp
+++ b/redfish-core/include/error_messages.hpp
@@ -1082,7 +1082,17 @@ nlohmann::json arraySizeTooLong(std::string_view property, uint64_t length);
 
 void arraySizeTooLong(crow::Response& res, std::string_view property,
                       uint64_t length);
+/**
+ * RestrictedRole is new in
+ * https://github.com/DMTF/Redfish/blob/master/registries/Base.1.9.0.json
+ * @brief Formats RestrictedRole message into JSON
+ * Message body: "The operation was not successful because the role '<arg1>' is
+ * restricted."
+ *
+ * @returns Message RestrictedRole formatted to JSON */
+nlohmann::json restrictedRole(const std::string& arg1);
 
+void restrictedRole(crow::Response& res, const std::string& arg1);
 } // namespace messages
 
 } // namespace redfish

--- a/redfish-core/include/privileges.hpp
+++ b/redfish-core/include/privileges.hpp
@@ -61,8 +61,13 @@ constexpr const size_t maxPrivilegeCount = 32;
  * console.
  */
 static const std::array<std::string, maxPrivilegeCount> privilegeNames{
-    "Login",         "ConfigureManager", "ConfigureComponents",
-    "ConfigureSelf", "ConfigureUsers",   "OpenBMCHostConsole"};
+    "Login",
+    "ConfigureManager",
+    "ConfigureComponents",
+    "ConfigureSelf",
+    "ConfigureUsers",
+    "OpenBMCHostConsole",
+    "OemIBMPerformService"};
 
 /**
  * @brief Redfish privileges
@@ -258,7 +263,17 @@ inline Privileges getUserPrivileges(const persistent_data::UserSession& session)
         privs.setSinglePrivilege("Login");
         privs.setSinglePrivilege("ConfigureSelf");
     }
-
+    else if (session.userRole == "priv-oemibmserviceagent")
+    {
+        // Redfish privilege : Administrator + IBM OEM
+        privs.setSinglePrivilege("Login");
+        privs.setSinglePrivilege("Login");
+        privs.setSinglePrivilege("ConfigureManager");
+        privs.setSinglePrivilege("ConfigureSelf");
+        privs.setSinglePrivilege("ConfigureUsers");
+        privs.setSinglePrivilege("ConfigureComponents");
+        privs.setSinglePrivilege("OemIBMPerformService");
+    }
     return privs;
 }
 

--- a/redfish-core/include/schemas.hpp
+++ b/redfish-core/include/schemas.hpp
@@ -127,6 +127,7 @@ namespace redfish
         "VirtualMedia",
         "VirtualMediaCollection",
         "OemManager",
+        "OemManagerAccount",
         "OemComputerSystem",
         "OemVirtualMedia",
         "OpenBMCAccountService",

--- a/redfish-core/lib/roles.hpp
+++ b/redfish-core/lib/roles.hpp
@@ -123,7 +123,6 @@ inline void requestRoutesRoles(App& app)
 
         asyncResp->res.jsonValue["@odata.type"] = "#Role.v1_2_2.Role";
         asyncResp->res.jsonValue["Name"] = "User Role";
-        asyncResp->res.jsonValue["Description"] = roleId + " User Role";
         asyncResp->res.jsonValue["OemPrivileges"] = std::move(oemPrivArray);
         asyncResp->res.jsonValue["IsPredefined"] = true;
         asyncResp->res.jsonValue["Id"] = roleId;
@@ -132,6 +131,14 @@ inline void requestRoutesRoles(App& app)
             boost::urls::format("/redfish/v1/AccountService/Roles/{}", roleId);
         asyncResp->res.jsonValue["AssignedPrivileges"] = std::move(privArray);
         asyncResp->res.jsonValue["Restricted"] = isRestrictedRole(roleId);
+        if (roleId == "OemIBMServiceAgent")
+        {
+            asyncResp->res.jsonValue["Description"] = "ServiceAgent";
+        }
+        else
+        {
+            asyncResp->res.jsonValue["Description"] = roleId;
+        }
     });
 }
 

--- a/redfish-core/lib/roles.hpp
+++ b/redfish-core/lib/roles.hpp
@@ -41,13 +41,17 @@ inline std::string getRoleFromPrivileges(std::string_view priv)
     {
         return "Operator";
     }
+    if (priv == "priv-oemibmserviceagent")
+    {
+        return "OemIBMServiceAgent";
+    }
     return "";
 }
 
 inline bool getAssignedPrivFromRole(std::string_view role,
                                     nlohmann::json& privArray)
 {
-    if (role == "Administrator")
+    if ((role == "Administrator") || (role == "OemIBMServiceAgent"))
     {
         privArray = {"Login", "ConfigureManager", "ConfigureUsers",
                      "ConfigureSelf", "ConfigureComponents"};
@@ -65,6 +69,29 @@ inline bool getAssignedPrivFromRole(std::string_view role,
         return false;
     }
     return true;
+}
+
+inline bool getOemPrivFromRole(std::string_view role, nlohmann::json& privArray)
+{
+    if ((role == "Administrator") || (role == "Operator") ||
+        (role == "ReadOnly") || (role == "NoAccess"))
+    {
+        privArray = nlohmann::json::array();
+    }
+    else if (role == "OemIBMServiceAgent")
+    {
+        privArray = {"OemIBMPerformService"};
+    }
+    else
+    {
+        return false;
+    }
+    return true;
+}
+
+inline bool isRestrictedRole(const std::string& role)
+{
+    return role == "OemIBMServiceAgent";
 }
 
 inline void requestRoutesRoles(App& app)
@@ -87,16 +114,24 @@ inline void requestRoutesRoles(App& app)
             return;
         }
 
+        nlohmann::json oemPrivArray = nlohmann::json::array();
+        if (!getOemPrivFromRole(roleId, oemPrivArray))
+        {
+            messages::resourceNotFound(asyncResp->res, "Role", roleId);
+            return;
+        }
+
         asyncResp->res.jsonValue["@odata.type"] = "#Role.v1_2_2.Role";
         asyncResp->res.jsonValue["Name"] = "User Role";
         asyncResp->res.jsonValue["Description"] = roleId + " User Role";
-        asyncResp->res.jsonValue["OemPrivileges"] = nlohmann::json::array();
+        asyncResp->res.jsonValue["OemPrivileges"] = std::move(oemPrivArray);
         asyncResp->res.jsonValue["IsPredefined"] = true;
         asyncResp->res.jsonValue["Id"] = roleId;
         asyncResp->res.jsonValue["RoleId"] = roleId;
         asyncResp->res.jsonValue["@odata.id"] =
             boost::urls::format("/redfish/v1/AccountService/Roles/{}", roleId);
         asyncResp->res.jsonValue["AssignedPrivileges"] = std::move(privArray);
+        asyncResp->res.jsonValue["Restricted"] = isRestrictedRole(roleId);
     });
 }
 

--- a/redfish-core/src/error_messages.cpp
+++ b/redfish-core/src/error_messages.cpp
@@ -1855,6 +1855,33 @@ nlohmann::json invalidUpload(std::string_view arg1, std::string_view arg2)
     return ret;
 }
 
+/**
+ * @internal
+ * @brief Formats RestrictedRole into JSON
+ *
+ * See header file for more information
+ * @endinternal
+ */
+nlohmann::json restrictedRole(const std::string& arg1)
+{
+    return nlohmann::json{
+        {"@odata.type", "#Message.v1_1_1.Message"},
+        {"MessageId", "Base.1.9.0.RestrictedRole"},
+        {"Message", "The operation was not successful because the role '" +
+                        arg1 + "' is restricted."},
+        {"MessageArgs", {arg1}},
+        {"MessageSeverity", "Warning"},
+        {"Resolution",
+         "No resolution is required.  For standard roles, consider using the role "
+         "specified in the AlternateRoleId property in the Role resource."}};
+}
+
+void restrictedRole(crow::Response& res, const std::string& arg1)
+{
+    res.result(boost::beast::http::status::bad_request);
+    addMessageToErrorJson(res.jsonValue, restrictedRole(arg1));
+}
+
 } // namespace messages
 
 } // namespace redfish

--- a/scripts/generate_auth_certificates.py
+++ b/scripts/generate_auth_certificates.py
@@ -231,9 +231,9 @@ def main():
         serverKeyDump.decode() + serverCertDump.decode()
     )
     serverCertificateUri = {}
-    serverCertificateUri[
-        "@odata.id"
-    ] = "/redfish/v1/Managers/bmc/NetworkProtocol/HTTPS/Certificates/1"
+    serverCertificateUri["@odata.id"] = (
+        "/redfish/v1/Managers/bmc/NetworkProtocol/HTTPS/Certificates/1"
+    )
     serverCertJSON["CertificateUri"] = serverCertificateUri
     serverCertJSON["CertificateType"] = "PEM"
     print("Replacing server certificate...")

--- a/scripts/update_schemas.py
+++ b/scripts/update_schemas.py
@@ -143,6 +143,7 @@ include_list = [
 # OEM schemas
 oem_schema_names = [
     "OemManager",
+    "OemManagerAccount",
     "OemComputerSystem",
     "OemVirtualMedia",
     "OpenBMCAccountService",

--- a/static/redfish/v1/$metadata/index.xml
+++ b/static/redfish/v1/$metadata/index.xml
@@ -3469,6 +3469,10 @@
     <edmx:Reference Uri="/redfish/v1/schema/OemManager_v1.xml">
         <edmx:Include Namespace="OemManager"/>
     </edmx:Reference>
+    <edmx:Reference Uri="/redfish/v1/schema/OemManagerAccount_v1.xml">
+        <edmx:Include Namespace="OemManagerAccount"/>
+        <edmx:Include Namespace="OemManagerAccount.v1_0_0"/>
+    </edmx:Reference>
     <edmx:Reference Uri="/redfish/v1/schema/OemComputerSystem_v1.xml">
         <edmx:Include Namespace="OemComputerSystem"/>
     </edmx:Reference>

--- a/static/redfish/v1/JsonSchemas/OemManagerAccount/OemManagerAccount.json
+++ b/static/redfish/v1/JsonSchemas/OemManagerAccount/OemManagerAccount.json
@@ -1,0 +1,97 @@
+{
+    "$id": "http://redfish.dmtf.org/schemas/v1/OemManagerAccount.v1_0_0.json",
+    "$schema": "http://redfish.dmtf.org/schemas/v1/redfish-schema-v1.json",
+    "copyright": "Copyright 2014-2019 DMTF. For the full DMTF copyright policy, see http://www.dmtf.org/about/policies/copyright",
+    "definitions": {
+        "IBM": {
+            "additionalProperties": true,
+            "description": "Oem IBM ManagerAccount extension.",
+            "longDescription": "Oem IBM ManagementAccount extension.",
+            "patternProperties": {
+                "^([a-zA-Z_][a-zA-Z0-9_]*)?@(odata|Redfish|Message)\\.[a-zA-Z_][a-zA-Z0-9_]*$": {
+                    "description": "This property shall specify a valid odata or Redfish property.",
+                    "type": [
+                        "array",
+                        "boolean",
+                        "integer",
+                        "number",
+                        "null",
+                        "object",
+                        "string"
+                    ]
+                }
+            },
+            "properties": {
+                "ACF": {
+                    "$ref": "#/definitions/ACF",
+                    "description": "A collection of ACF properties.",
+                    "longDescription": "A collection of access control file properties.",
+                    "readonly": false,
+                    "versionAdded": "v1_0_0"
+                }
+            }
+        },
+        "ACF": {
+            "additionalProperties": false,
+            "description": "OEM Extension for ManagerAccount",
+            "longDescription": "OEM Extension for ManagerAccount to provide the Service account extension.",
+            "patternProperties": {
+                "^([a-zA-Z_][a-zA-Z0-9_]*)?@(odata|Redfish|Message)\\.[a-zA-Z_][a-zA-Z0-9_]*$": {
+                    "description": "This property shall specify a valid odata or Redfish property.",
+                    "type": [
+                        "array",
+                        "boolean",
+                        "integer",
+                        "number",
+                        "null",
+                        "object",
+                        "string"
+                    ]
+                }
+            },
+            "properties": {
+                "ACFFile": {
+                    "description": "Base 64 encoded ACF contents.",
+                    "longDescription": "Base 64 encoded ACF contents. Contents must have a valid signature, expiration date, and serial number must match BMC serial number",
+                    "readonly": false,
+                    "type": "string",
+                    "versionAdded": "v1_0_0"
+                },
+                "ExpirationDate": {
+                    "description": "The expiration date of the ACF file.",
+                    "longDescription": "The expiration date of the ACF file, if the expiration date has been from the BMC then the ACF is not valid.",
+                    "readonly": true,
+                    "type": [
+                        "string",
+                        "null"
+                    ],
+                    "versionAdded": "v1_0_0"
+                },
+                "WarningLongDatedExpiration": {
+                    "description": "This property is set to true if there is a long dated expiration.",
+                    "longDescription": "This property is set to true if the expiration date on the ACF exceeds 30 days from the BMC date.",
+                    "readonly": true,
+                    "type": [
+                        "boolean",
+                        "null"
+                    ],
+                    "versionAdded": "v1_0_0"
+                },
+                "ACFInstalled": {
+                    "description": "This property is set to true if the ACF is installed.",
+                    "longDescription": "This property indicates if the ACF is installed or not.",
+                    "readonly": true,
+                    "type": [
+                        "boolean"
+                    ],
+                    "versionAdded": "v1_0_0"
+                }
+            },
+            "type": "object"
+            }
+    },
+    "owningEntity": "OpenBMC",
+    "release": "1.0",
+    "title": "#OemManagerAccount"
+}
+

--- a/static/redfish/v1/schema/OemManagerAccount_v1.xml
+++ b/static/redfish/v1/schema/OemManagerAccount_v1.xml
@@ -1,0 +1,68 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<edmx:Edmx xmlns:edmx="http://docs.oasis-open.org/odata/ns/edmx" Version="4.0">
+    <edmx:Reference Uri="http://docs.oasis-open.org/odata/odata/v4.0/errata03/csd01/complete/vocabularies/Org.OData.Core.V1.xml">
+        <edmx:Include Namespace="Org.OData.Core.V1" Alias="OData" />
+    </edmx:Reference>
+    <edmx:Reference Uri="http://redfish.dmtf.org/schemas/v1/RedfishExtensions_v1.xml">
+        <edmx:Include Namespace="Validation.v1_0_0" Alias="Validation"/>
+        <edmx:Include Namespace="RedfishExtensions.v1_0_0" Alias="Redfish"/>
+    </edmx:Reference>
+    <edmx:Reference Uri="http://redfish.dmtf.org/schemas/v1/ManagerAccount_v1.xml">
+        <edmx:Include Namespace="ManagerAccount"/>
+        <edmx:Include Namespace="ManagerAccount.v1_4_0"/>
+    </edmx:Reference>
+    <edmx:Reference Uri="http://redfish.dmtf.org/schemas/v1/Resource_v1.xml">
+        <edmx:Include Namespace="Resource"/>
+        <edmx:Include Namespace="Resource.v1_0_0"/>
+    </edmx:Reference>
+
+	<edmx:DataServices>
+       <Schema xmlns="http://docs.oasis-open.org/odata/ns/edm" Namespace="OemManagerAccount">
+          <Annotation Term="Redfish.OwningEntity" String="IBM"/>
+      </Schema>
+
+        <Schema xmlns="http://docs.oasis-open.org/odata/ns/edm" Namespace="OemManagerAccount.v1_0_0">
+			<ComplexType Name="Oem" BaseType="Resource.OemObject">
+				<Annotation Term="OData.AdditionalProperties" Bool="true" />
+                <Annotation Term="OData.Description" String="OemManagerAccount Oem properties." />
+                <Annotation Term="OData.AutoExpand"/>
+				<Property Name="IBM" Type="OemManagerAccount.v1_0_0.IBM"/>
+			</ComplexType>
+
+            <ComplexType Name="IBM">
+                <Annotation Term="OData.AdditionalProperties" Bool="true" />
+                <Annotation Term="OData.Description" String="Oem properties for IBM." />
+                <Annotation Term="OData.AutoExpand"/>
+                <Property Name="ACF" Type="OemManagerAccount.v1_0_0.ACF"/>
+            </ComplexType>
+
+			<ComplexType Name="ACF">
+				<Annotation Term="OData.Description" String="A collection of ACF properties."/>
+				<Annotation Term="OData.LongDescription" String="A collection of access control file properties."/>
+				<Annotation Term="OData.AdditionalProperties" Bool="false"/>
+				<Property Name="ACFFile" Type="Edm.String" Nullable="true">
+					<Annotation Term="OData.Permissions" EnumMember="OData.Permission/ReadWrite"/>
+					<Annotation Term="OData.Description" String="Base 64 encoded ACF contents."/>
+					<Annotation Term="OData.LongDescription" String="Base 64 encoded ACF contents. Contents must have a valid signature, expiration date, and serial number must match BMC serial number"/>
+				</Property>
+				<Property Name="WarningLongDatedExpiration" Type="Edm.Boolean" Nullable="true">
+					<Annotation Term="OData.Permissions" EnumMember="OData.Permission/Read"/>
+					<Annotation Term="OData.Description" String="This property is set to true if there is a long dated expiration."/>
+					<Annotation Term="OData.LongDescription" String="This property is set to true if the expiration date on the ACF exceeds 30 days from the BMC date."/>
+				</Property>
+				<Property Name="ExpirationDate" Type="Edm.String" Nullable="true">
+					<Annotation Term="OData.Permissions" EnumMember="OData.Permission/Read"/>
+					<Annotation Term="OData.Description" String="The expiration date of the ACF file."/>
+					<Annotation Term="OData.LongDescription" String="The expiration date of the ACF file, if the expiration date has been from the BMC then the ACF is not validD"/>
+				</Property>
+				<Property Name="ACFInstalled" Type="Edm.Boolean">
+					<Annotation Term="OData.Permissions" EnumMember="OData.Permission/Read"/>
+					<Annotation Term="OData.Description" String="This property is set to true if the ACF is installed."/>
+					<Annotation Term="OData.LongDescription" String="This property indicates if the ACF is installed or not."/>
+				</Property>
+			</ComplexType>
+
+		</Schema>
+	</edmx:DataServices>
+</edmx:Edmx>
+


### PR DESCRIPTION
These are all of the ACF commits required from our downstream work to get the ACF functionality working. I've modified a few of these commits as I cherry picked them in to adapt to upstream changes like 480662d4 and to update the code formatting based on new upstream changes. Nothing functionally was changed.

Tested:
- Confirmed that these plus all the ACF functions from other repos combined allow us to upload a ACF and login with the service ID in simulation
-  TODO: Flash on real hardware and run Redfish validator