### PR TITLE
Fix error user create fail

### DIFF
--- a/redfish-core/lib/account_service.hpp
+++ b/redfish-core/lib/account_service.hpp
@@ -341,7 +341,7 @@ inline void userErrorMessageHandler(
     }
     else
     {
-        BMCWEB_LOG_ERROR << "DBUS response error: " << e;
+        BMCWEB_LOG_ERROR << "DBUS response error: " << errorMessage;
         messages::internalError(asyncResp->res);
     }
 }


### PR DESCRIPTION
I messed up https://github.com/ibm-openbmc/bmcweb/pull/768 but had this correct upstream.
https://gerrit.openbmc.org/c/openbmc/bmcweb/+/66858/2/redfish-core/lib/account_service.hpp

Logging e doesn't hurt anything it just isn't helpful.

See 594123 

Jan 22 17:10:51 xxx bmcweb[2310]: (2024-01-22 17:10:51) [ERROR "account_service.hpp":344] DBUS response error: 0x290cb5c