### PR TITLE
1050: Fix error user create fail (#805)

### DIFF
--- a/redfish-core/lib/account_service.hpp
+++ b/redfish-core/lib/account_service.hpp
@@ -341,7 +341,7 @@ inline void userErrorMessageHandler(
     }
     else
     {
-        BMCWEB_LOG_ERROR << "DBUS response error: " << e;
+        BMCWEB_LOG_ERROR << "DBUS response error: " << errorMessage;
         messages::internalError(asyncResp->res);
     }
 }


### PR DESCRIPTION
#### Fix error user create fail (#805)
```
I messed up https://github.com/ibm-openbmc/bmcweb/pull/768 but had this
correct upstream.
https://gerrit.openbmc.org/c/openbmc/bmcweb/+/66858/2/redfish-core/lib/account_service.hpp

Logging e doesn't hurt anything it just isn't helpful.

Signed-off-by: Gunnar Mills <gmills@us.ibm.com>```