### PR TITLE
WIP: To support Bonnell change Default Model to "BMC on System Backplane"

### DIFF
--- a/redfish-core/lib/managers.hpp
+++ b/redfish-core/lib/managers.hpp
@@ -2065,7 +2065,7 @@ inline void requestRoutesManager(App& app)
         asyncResp->res.jsonValue["ManagerType"] = "BMC";
         asyncResp->res.jsonValue["UUID"] = systemd_utils::getUuid();
         asyncResp->res.jsonValue["ServiceEntryPointUUID"] = uuid;
-        asyncResp->res.jsonValue["Model"] = "OpenBmc"; // TODO(ed), get model
+        asyncResp->res.jsonValue["Model"] = "BMC on System Backplane";
 
         asyncResp->res.jsonValue["LogServices"]["@odata.id"] =
             "/redfish/v1/Managers/bmc/LogServices";


### PR DESCRIPTION
WIP!

Discussed 1/31.
If we have to do something here for 586924.. We could do this.

https://github.com/ibm-openbmc/bmcweb/blob/a4a534e865211515608cdf3b4fa777a31c176002/redfish-core/lib/managers.hpp#L2235 gets the Model when we have an Inventory.Item.Decorator.Asset (rainier, everest) 
https://github.com/openbmc/phosphor-dbus-interfaces/blob/1abc0c57692b679753955b7273c1393369ef4987/yaml/xyz/openbmc_project/Inventory/Decorator/Asset.interface.yaml#L22

Since Bonnell doesn't have an Inventory.Item.Decorator.Asset interface, it is showing "OpenBmc"