### PR TITLE
Handle hostname D-bus errors

### DIFF
--- a/redfish-core/lib/ethernet.hpp
+++ b/redfish-core/lib/ethernet.hpp
@@ -1303,17 +1303,32 @@ inline void
                                            "HostName");
         return;
     }
-    crow::connections::systemBus->async_method_call(
-        [asyncResp](const boost::system::error_code ec) {
+
+    auto handleHostnameCallback =
+        [asyncResp, hostname](const boost::system::error_code& ec,
+                              const sdbusplus::message_t& msg) {
         if (ec)
         {
+            const sd_bus_error* dbusError = msg.get_error();
+            if ((dbusError != nullptr) &&
+                (dbusError->name ==
+                 std::string_view(
+                     "xyz.openbmc_project.Common.Error.InvalidArgument")))
+            {
+                BMCWEB_LOG_WARNING("DBUS response error: {}", ec);
+                messages::propertyValueIncorrect(asyncResp->res, "Hostname",
+                                                 hostname);
+                return;
+            }
             messages::internalError(asyncResp->res);
         }
-    },
-        "xyz.openbmc_project.Network", "/xyz/openbmc_project/network/config",
-        "org.freedesktop.DBus.Properties", "Set",
-        "xyz.openbmc_project.Network.SystemConfiguration", "HostName",
-        dbus::utility::DbusVariantType(hostname));
+    };
+
+    sdbusplus::asio::setProperty(
+        *crow::connections::systemBus, "xyz.openbmc_project.Network",
+        "/xyz/openbmc_project/network/config",
+        "xyz.openbmc_project.Network.SystemConfiguration", "HostName", hostname,
+        std::move(handleHostnameCallback));
 }
 
 inline void


### PR DESCRIPTION
Currently, hostname D-bus errors are not mapped to Redfish errors, so a hostname patch returns an internal error irrespective of the D-bus error.

This commit handles the InvalidArgument D-bus error for the hostname.

Tested By:
Configure hostname with various invalid arguments

Change-Id: Ia1a7ceb3c1722799881914e1c87212c6afb047f1