### PR TITLE
Gunnar 1110 Bump the max password length to 64  and Increase bmcweb automatic restart

### DIFF
--- a/config/bmcweb.service.in
+++ b/config/bmcweb.service.in
@@ -1,5 +1,7 @@
 [Unit]
 Description=Start bmcweb server
+StartLimitIntervalSec=30
+StartLimitBurst=4
 
 Wants=network.target
 After=network.target

--- a/redfish-core/lib/account_service.hpp
+++ b/redfish-core/lib/account_service.hpp
@@ -1584,7 +1584,7 @@ inline void
     json["Name"] = "Account Service";
     json["Description"] = "Account Service";
     json["ServiceEnabled"] = true;
-    json["MaxPasswordLength"] = 20;
+    json["MaxPasswordLength"] = 64;
     json["Accounts"]["@odata.id"] = "/redfish/v1/AccountService/Accounts";
     json["Roles"]["@odata.id"] = "/redfish/v1/AccountService/Roles";
     json["Oem"]["OpenBMC"]["@odata.type"] =


### PR DESCRIPTION
1) Bump the max password length to 64 (https://github.com/ibm-openbmc/bmcweb/pull/437)

As mentioned in SW556104, Redfish accepts a password greater than 20
chars.

The 20 char limit comes from IPMI which is enabled upstream.

Downstream we have IPMI disabled be default, so up this limit to 64. (see some discussion here https://ibm-systems-power.slack.com/archives/G3WAVQYTH/p1707250701989799?thread_ts=1707239077.955159&cid=G3WAVQYTH ) 

Due to that, at this time, this is a downstream only change.

The GUI will then "Read the ManagerAccount object via GET
/redfish/v1/AccountService/Accounts/<USER> and look at the AccountTypes
property. If AccountTypes contains the "IPMI" AccountType, know that
MaxPasswordLength is effectively 20 for this user."

64 was choosen because it gives sufficient randomness for all practical
purposes.

It makes sense the limit reflects the default.
This limit is on the Account Service, not the account, hence why we
can't change this per account.

Upstream: I am not sure what to do here.. We could get a PDI property up? Have user manager set it? 
I opened https://jsw.ibm.com/browse/PFEBMC-2099


2) Increase bmcweb automatic restart (https://github.com/ibm-openbmc/bmcweb/pull/356)

Increase bmcweb automatic restart

Certificate manager restarts bmcweb when a new certificate is uploaded,
we have seen this happen more than 3 times in a 30 second period.
Allow bmcweb to be restarted 4 times over a 30 second period before
stopping.
This is a short term fix, the long term fix is Certificate manager will
throttle how often it restarts bmcweb. <--- asked here about a story https://ibm-systems-power.slack.com/archives/G3WAVQYTH/p1707249721632019

Tested: None. Code review only.

