### PR TITLE
Implement PCIeSlots LocationIndicatorActive

### DIFF
--- a/Redfish.md
+++ b/Redfish.md
@@ -198,6 +198,7 @@ Fields common to all schemas
 - Links/ComputerSystems
 - Links/ManagedBy
 - PCIeDevices
+- PCIeSlots
 - Power
   - Shall be included if component contains voltage/current sensing components,
     otherwise will be omitted.
@@ -236,6 +237,16 @@ Fields common to all schemas
 - PowerSupplies
 - Redundancy
 - Voltages
+
+### /redfish/v1/Chassis/{ChassisId}/PCIeSlots/
+
+#### Slots
+
+- HotPluggable
+- Lanes
+- LocationIndicatorActive
+- PCIeType
+- SlotType
 
 ### /redfish/v1/Chassis/{ChassisId}/Sensors/
 

--- a/redfish-core/include/redfish.hpp
+++ b/redfish-core/include/redfish.hpp
@@ -216,6 +216,7 @@ class RedfishService
         requestRoutesLDAPCertificate(app);
         requestRoutesTrustStoreCertificate(app);
 
+        requestRoutesPCIeSlots(app);
         requestRoutesSystemPCIeFunctionCollection(app);
         requestRoutesSystemPCIeFunction(app);
         requestRoutesSystemPCIeDeviceCollection(app);

--- a/redfish-core/lib/chassis.hpp
+++ b/redfish-core/lib/chassis.hpp
@@ -510,6 +510,8 @@ inline void handleChassisGetSubTree(
                                 chassisId);
         asyncResp->res.jsonValue["PCIeDevices"]["@odata.id"] =
             "/redfish/v1/Systems/system/PCIeDevices";
+        asyncResp->res.jsonValue["PCIeSlots"]["@odata.id"] =
+            boost::urls::format("/redfish/v1/Chassis/{}/PCIeSlots", chassisId);
 
         dbus::utility::getAssociationEndPoints(
             path + "/drive",


### PR DESCRIPTION
This contains 3 PRs for PCIeSlots LocationIndicatorActive handling
- Implement LocationIndicatorActive for PCIeSlots (#543)
- Fix PCIeSlot LocationIndicatorActive Patch Handling (#712)
- Refactor and Simplify PCIeSlot handling (#722)

1. Implement LocationIndicatorActive for PCIeSlots (#543) Implement LocationIndicatorActive for PCIeSlot schema, We can use locationindicatoractive to set or get the status of the location led of each pcie slot.

https://redfish.dmtf.org/schemas/v1/PCIeSlots.v1_4_1.json

We need to set the LocationIndicatorActive of all the slots in the dopatch command, even if we only want to modify one of them.(ex: see the third test result)

Tested: Validator passes.
1. Get LocationIndicatorActive

```
curl -k -H "X-Auth-Token: $token" -X GET https://${bmc}/redfish/v1/Chassis/chassis/PCIeSlots
{
  "@odata.id": "/redfish/v1/Chassis/chassis/PCIeSlots",
  "@odata.type": "#PCIeSlots.v1_4_1.PCIeSlots",
  "Id": "PCIeSlots",
  "Name": "PCIe Slot Information",
  "Slots": [
    {
      "HotPluggable": false,
      "Lanes": 16,
      "LocationIndicatorActive": false,
      "PCIeType": "Gen1",
      "SlotType": "FullLength"
    },
    {
      "HotPluggable": false,
      "Lanes": 16,
      "LocationIndicatorActive": false,
      "PCIeType": "Gen1",
      "SlotType": "FullLength"
    }
  ]
}
```

2、Set LocationIndicatorActive to true
```
curl -k -H "X-Auth-Token: $token" -X PATCH -d '{"Slots":[{"LocationIndicatorActive":true},{"LocationIndicatorActive":true}]}' https://${bmc}/redfish/v1/Chassis/chassis/PCIeSlots
```

Then we will see the slot location LED lit up, and the LocationIndicatorActive value becomes true:
```
curl -k -H "X-Auth-Token: $token" -X GET https://${bmc}/redfish/v1/Chassis/chassis/PCIeSlots
{
  "@odata.id": "/redfish/v1/Chassis/chassis/PCIeSlots",
  "@odata.type": "#PCIeSlots.v1_4_1.PCIeSlots",
  "Id": "PCIeSlots",
  "Name": "PCIe Slot Information",
  "Slots": [
    {
      "HotPluggable": false,
      "Lanes": 16,
      "LocationIndicatorActive": true,
      "PCIeType": "Gen1",
      "SlotType": "FullLength"
    },
    {
      "HotPluggable": false,
      "Lanes": 16,
      "LocationIndicatorActive": true,
      "PCIeType": "Gen1",
      "SlotType": "FullLength"
    }
  ]
}
```

3、We need to set the LocationIndicatorActive of all the slots in the dopatch command, even if you only want to modify one of them for example:
Now LocationIndicatorActive of both slots is false:

```
curl -k -H "X-Auth-Token: $token" -X GET https://${bmc}/redfish/v1/Chassis/chassis/PCIeSlots
{
  "@odata.id": "/redfish/v1/Chassis/chassis/PCIeSlots",
  "@odata.type": "#PCIeSlots.v1_4_1.PCIeSlots",
  "Id": "PCIeSlots",
  "Name": "PCIe Slot Information",
  "Slots": [
    {
      "HotPluggable": false,
      "Lanes": 16,
      "LocationIndicatorActive": false,
      "PCIeType": "Gen1",
      "SlotType": "FullLength"
    },
    {
      "HotPluggable": false,
      "Lanes": 16,
      "LocationIndicatorActive": false,
      "PCIeType": "Gen1",
      "SlotType": "FullLength"
    }
  ]
}
```

We want to set LocationIndicatorActive of the second slot to true. We need to send this command:

```
curl -k -H "X-Auth-Token: $token" -X PATCH -d '{"Slots":[{"LocationIndicatorActive":false},{"LocationIndicatorActive":true}]}' https://${bmc}/redfish/v1/Chassis/chassis/PCIeSlots
```
This command contains the value of the first slot.

```
curl -k -H "X-Auth-Token: $token" -X GET https://${bmc}/redfish/v1/Chassis/chassis/PCIeSlots
{
  "@odata.id": "/redfish/v1/Chassis/chassis/PCIeSlots",
  "@odata.type": "#PCIeSlots.v1_4_1.PCIeSlots",
  "Id": "PCIeSlots",
  "Name": "PCIe Slot Information",
  "Slots": [
    {
      "HotPluggable": false,
      "Lanes": 16,
      "LocationIndicatorActive": false,
      "PCIeType": "Gen1",
      "SlotType": "FullLength"
    },
    {
      "HotPluggable": false,
      "Lanes": 16,
      "LocationIndicatorActive": true,
      "PCIeType": "Gen1",
      "SlotType": "FullLength"
    }
  ]
}
```

Change-Id: I64c0ed90b37a17d3b7d834a0844228406e82575f




2.  Fix PCIeSlot LocationIndicatorActive Patch Handling (#712)

PCIe Slot LocationIndicatorActive PATCH is not working correctly all the time.

https://github.com/ibm-openbmc/dev/issues/3631

Below is an Everest PATCH of all LEDs to true.
- You will notice not all go true.
- This has also been reported on Rainier.
- This has also been reported when moving the LocationIndicatorActive to false.
- This has been reported on the GUI.

```
Set all slots to be true.

$ curl -k  -X PATCH https://$bmc/redfish/v1/Chassis/chassis/PCIeSlots \
    -d '{"Slots":[{"LocationIndicatorActive":true},{"LocationIndicatorActive":true},  \
      ... \
        {"LocationIndicatorActive":true},{"LocationIndicatorActive":true}]}'

$ curl -s -k https://$bmc/redfish/v1/Chassis/chassis/PCIeSlots | grep LocationIndicatorActive
      "LocationIndicatorActive": true,
      "LocationIndicatorActive": true,
      ...
      "LocationIndicatorActive": true,
      "LocationIndicatorActive": false,     <--- Sometimes incorrect - esp at 21st entry
```

This can be addressed by getting the valid pcieSlots first, and then validate it before performing PATCH.

 - Get valid PCIeSlots `getValidPCIeSlotList()` - which filters out the improper slot and invoke callback at the last slots.
 - Validate it with input slots. (the number of inputs should match with the number of valid slots)
 - Execute the PATCH (i.e. `setLocationIndicatorActive()`) using the the obtained list.

Tested:
 - Redfish Validator performed
 - GET PCIeSlots and compare it with the existing output.
 - PATCH PCIeSlots and verify the correctness (e.g. number of input slots, and content)



3.  1050: Refactor and Simplify PCIeSlot handling (#722)

* Add missing GetAssociatedSubTree from upstream

The previous commit f99586afcbf03f8b2fe1c0ace84b8c52f332b0f9 missed a function `GetAssociatedSubTree` from upstream.

This commit will cherry-pick from upstream to have 2 functions of https://gerrit.openbmc.org/c/openbmc/phosphor-objmgr/+/57822

 - GetAssociatedSubTree
 - GetAssociatedSubTreePaths

The two methods are meant to be used to replace places where two dbus calls are used to get subtree and then get associated objects.

upstream:
https://gerrit.openbmc.org/c/openbmc/bmcweb/+/62522

Change-Id: I80a7ea935700a1ac5aebe6271f242aa103cc3d59



* Refactor and simplify PCIeSlot handling

PCIeSlots are currently obtained in 2 stages;
  - getSubTree for PCIeSlots
  - getAssociationEndPoint for each slot

However, this can be done in a simpler way by using `getAssociatedSubTreePaths()` in one step;
  - getAssociatedSubTreePaths for the given chassis



---------