### PR TITLE
Redfish : Add USB code update Enable/Disable

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -70,6 +70,7 @@ feature_map = {
   'host-serial-socket'                          : '-DBMCWEB_ENABLE_HOST_SERIAL_WEBSOCKET',
   'ibm-management-console'                      : '-DBMCWEB_ENABLE_IBM_MANAGEMENT_CONSOLE',
   'insecure-disable-auth'                       : '-DBMCWEB_INSECURE_DISABLE_AUTHX',
+  'ibm-usb-code-update'                         : '-DBMCWEB_ENABLE_IBM_USB_CODE_UPDATE',
   'insecure-disable-csrf'                       : '-DBMCWEB_INSECURE_DISABLE_CSRF_PREVENTION',
   'insecure-disable-ssl'                        : '-DBMCWEB_INSECURE_DISABLE_SSL',
   'insecure-push-style-notification'            : '-DBMCWEB_INSECURE_ENABLE_HTTP_PUSH_STYLE_EVENTING',

--- a/meson_options.txt
+++ b/meson_options.txt
@@ -199,6 +199,13 @@ option(
 )
 
 option(
+    'ibm-usb-code-update',
+    type: 'feature',
+    value: 'disabled',
+    description: '''Enable the USB code update functionality'''
+)
+
+option(
     'ibm-management-console',
     type: 'feature',
     value: 'disabled',

--- a/redfish-core/lib/oem/ibm/usb_code_update.hpp
+++ b/redfish-core/lib/oem/ibm/usb_code_update.hpp
@@ -1,0 +1,106 @@
+#pragma once
+
+#include "async_resp.hpp"
+#include "dbus_utility.hpp"
+#include "redfish_util.hpp"
+
+#include <array>
+#include <string_view>
+#include <variant>
+
+namespace redfish
+{
+
+static constexpr const char* usbCodeUpdateObjectPath =
+    "/xyz/openbmc_project/control/service/_70hosphor_2dusb_2dcode_2dupdate";
+static constexpr const char* usbCodeUpdateInterface =
+    "xyz.openbmc_project.Control.Service.Attributes";
+
+constexpr std::array<std::string_view, 1> interfaces = {usbCodeUpdateInterface};
+
+/**
+ * @brief Retrieves BMC USB code update state.
+ *
+ * @param[in] asyncResp     Shared pointer for generating response message.
+ *
+ * @return None.
+ */
+inline void
+    getUSBCodeUpdateState(const std::shared_ptr<bmcweb::AsyncResp>& asyncResp)
+{
+    BMCWEB_LOG_DEBUG("Get USB code update state");
+    dbus::utility::getDbusObject(
+        usbCodeUpdateObjectPath, interfaces,
+        [asyncResp, usbCodeUpdateObjectPath](
+            const boost::system::error_code& ec1,
+            const dbus::utility::MapperGetObject& object) {
+        if (ec1 || object.empty())
+        {
+            BMCWEB_LOG_ERROR("DBUS response error {}", ec1);
+            messages::internalError(asyncResp->res);
+            return;
+        }
+
+        sdbusplus::asio::getProperty<bool>(
+            *crow::connections::systemBus, object.begin()->first,
+            usbCodeUpdateObjectPath, usbCodeUpdateInterface, "Enabled",
+            [asyncResp](const boost::system::error_code& ec2,
+                        bool usbCodeUpdateState) {
+            if (ec2)
+            {
+                BMCWEB_LOG_ERRO("DBUS response error: {}", ec2);
+                messages::internalError(asyncResp->res);
+                return;
+            }
+
+            asyncResp->res.jsonValue["Oem"]["IBM"]["@odata.type"] =
+                "#OemManager.IBM";
+            asyncResp->res.jsonValue["Oem"]["IBM"]["@odata.id"] =
+                "/redfish/v1/Managers/bmc#/Oem/IBM";
+            asyncResp->res.jsonValue["Oem"]["IBM"]["USBCodeUpdateEnabled"] =
+                usbCodeUpdateState;
+        });
+    });
+}
+
+/**
+ * @brief Sets BMC USB code update state.
+ *
+ * @param[in] asyncResp   Shared pointer for generating response message.
+ * @param[in] state       USB code update state from request.
+ *
+ * @return None.
+ */
+inline void
+    setUSBCodeUpdateState(const std::shared_ptr<bmcweb::AsyncResp>& asyncResp,
+                          const bool& state)
+{
+    BMCWEB_LOG_DEBUG("Set USB code update status.");
+    dbus::utility::getDbusObject(
+        usbCodeUpdateObjectPath, interfaces,
+        [asyncResp, usbCodeUpdateObjectPath,
+         state](const boost::system::error_code& ec1,
+                const dbus::utility::MapperGetObject& object) {
+        if (ec1 || object.empty())
+        {
+            BMCWEB_LOG_ERROR("DBUS response error {}", ec1);
+            messages::internalError(asyncResp->res);
+            return;
+        }
+
+        sdbusplus::asio::setProperty(
+            *crow::connections::systemBus, object.begin()->first,
+            usbCodeUpdateObjectPath, usbCodeUpdateInterface, "Enabled", state,
+            [asyncResp](const boost::system::error_code& ec2) {
+            if (ec2)
+            {
+                BMCWEB_LOG_ERRO("Can't set USB code update status. Error: {}",
+                                ec2);
+                messages::internalError(asyncResp->res);
+                return;
+            }
+            messages::success(asyncResp->res);
+        });
+    });
+}
+} // namespace redfish

--- a/static/redfish/v1/JsonSchemas/OemManager/OemManager.json
+++ b/static/redfish/v1/JsonSchemas/OemManager/OemManager.json
@@ -291,6 +291,16 @@
                             "type": "null"
                         }
                     ]
+                },
+                "IBM": {
+                    "anyOf": [
+                        {
+                            "$ref": "#/definitions/IBM"
+                        },
+                        {
+                            "type": "null"
+                        }
+                    ]
                 }
             },
             "type": "object"
@@ -577,6 +587,32 @@
                     "description": "Input sensor reading for step.",
                     "longDescription": "Input sensor reading for step.",
                     "type": "number"
+                }
+            },
+            "type": "object"
+        },
+        "IBM": {
+            "additionalProperties": true,
+            "description": "Oem properties for IBM.",
+            "patternProperties": {
+                "^([a-zA-Z_][a-zA-Z0-9_]*)?@(odata|Redfish|Message)\\.[a-zA-Z_][a-zA-Z0-9_]*$": {
+                    "description": "This property shall specify a valid odata or Redfish property.",
+                    "type": [
+                        "array",
+                        "boolean",
+                        "integer",
+                        "number",
+                        "null",
+                        "object",
+                        "string"
+                    ]
+                }
+            },
+            "properties": {
+                "USBCodeUpdateEnabled": {
+                    "description": "An indication of whether the USB code update is enabled.",
+                    "longDescription": "An indication of whether the USB code update is enabled.",
+                    "type": "boolean"
                 }
             },
             "type": "object"

--- a/static/redfish/v1/schema/OemManager_v1.xml
+++ b/static/redfish/v1/schema/OemManager_v1.xml
@@ -26,6 +26,18 @@
         <Annotation Term="OData.Description" String="OemManager Oem properties." />
         <Annotation Term="OData.AutoExpand"/>
         <Property Name="OpenBmc" Type="OemManager.OpenBmc"/>
+        <Property Name="IBM" Type="OemManager.IBM"/>
+      </ComplexType>
+
+      <ComplexType Name="IBM" BaseType="Resource.OemObject">
+          <Annotation Term="OData.AdditionalProperties" Bool="true" />
+          <Annotation Term="OData.Description" String="Oem properties for IBM." />
+          <Annotation Term="OData.AutoExpand"/>
+          <Property Name="USBCodeUpdateEnabled" Type="Edm.Boolean" Nullable="false">
+              <Annotation Term="OData.Permissions" EnumMember="OData.Permission/ReadWrite"/>
+              <Annotation Term="OData.Description" String="An indication of whether the USB code update is enabled."/>
+              <Annotation Term="OData.LongDescription" String="An indication of whether the USB code update is enabled."/>
+          </Property>
       </ComplexType>
 
       <ComplexType Name="OpenBmc" BaseType="Resource.OemObject">


### PR DESCRIPTION
Implement USB code update Enable/Disable.
This is an OEM schema.

We can use "ibm-usb-code-update" option to enable/disable this feature.

Tested: Validator no error
First, we need to pick this commit:
[1] https://gerrit.openbmc-project.xyz/c/openbmc/service-config-manager/+/48780 or
[2] ibm-openbmc/service-config-manager#1

1. Get USB code update state
```
curl -k -H "X-Auth-Token: $token" -X GET https://${bmc}/redfish/v1/Managers/bmc
{
  "@odata.id": "/redfish/v1/Managers/bmc",
  "@odata.type": "#Manager.v1_11_0.Manager",

  ...

  "Oem": {
    "@odata.id": "/redfish/v1/Managers/bmc#/Oem",
    "@odata.type": "#OemManager.Oem",
    "IBM": {
      "@odata.id": "/redfish/v1/Managers/bmc#/Oem/IBM",
      "@odata.type": "#OemManager.IBM",
      "USBCodeUpdateEnabled": true
    },
    "OpenBmc": {
      "@odata.id": "/redfish/v1/Managers/bmc#/Oem/OpenBmc",
      "@odata.type": "#OemManager.OpenBmc",
      "Certificates": {
        "@odata.id": "/redfish/v1/Managers/bmc/Truststore/Certificates"
      }
    }
  },

  ...
```
2. Set disable USB code update
```
curl -k -H "X-Auth-Token: $token" -X PATCH https://${bmc}/redfish/v1/Managers/bmc -d '{"Oem":{"IBM":{"USBCodeUpdateEnabled": false}}}'

busctl get-property xyz.openbmc_project.Control.Service.Manager /xyz/openbmc_project/control/service/phosphor_2dusb_2dcode_2dupdate xyz.openbmc_project.Control.Service.Attributes Enabled
b false
```
3. Set enable USB code update
```
curl -k -H "X-Auth-Token: $token" -X PATCH https://${bmc}/redfish/v1/Managers/bmc -d '{"Oem":{"IBM":{"USBCodeUpdateEnabled": true}}}'

busctl get-property xyz.openbmc_project.Control.Service.Manager /xyz/openbmc_project/control/service/phosphor_2dusb_2dcode_2dupdate xyz.openbmc_project.Control.Service.Attributes Enabled
b true
```