### PR TITLE
Fix bug: bmcweb SNMP errors in the Journal

### DIFF
--- a/redfish-core/include/event_service_manager.hpp
+++ b/redfish-core/include/event_service_manager.hpp
@@ -372,6 +372,11 @@ class Subscription : public persistent_data::UserSubscription
 
     bool sendEvent(std::string&& msg)
     {
+        if (subscriptionType == "SNMPTrap")
+        {
+            return true; // Don't need send SNMPTrap event.
+        }
+
         persistent_data::EventServiceConfig eventServiceConfig =
             persistent_data::EventServiceStore::getInstance()
                 .getEventServiceConfig();
@@ -1059,6 +1064,12 @@ class EventServiceManager
             {
                 isSubscribed = true;
             }
+
+            if (entry->subscriptionType == "SNMPTrap")
+            {
+                isSubscribed = false; // Don't need send SNMPTrap event.
+            }
+
             if (isSubscribed)
             {
                 nlohmann::json msgJson;


### PR DESCRIPTION
Fix this bug: ibm-openbmc/dev#3599
Don't send event to snmptrap subscription.