### PR TITLE
Pretty name for fabric adapters

### DIFF
--- a/redfish-core/include/utils/name_utils.hpp
+++ b/redfish-core/include/utils/name_utils.hpp
@@ -1,0 +1,47 @@
+
+#pragma once
+#include <async_resp.hpp>
+
+namespace redfish
+{
+namespace name_util
+{
+
+/**
+ * @brief Populate the collection "Members" from a GetSubTreePaths search of
+ *        inventory
+ *
+ * @param[i,o] asyncResp  Async response object
+ * @param[i]   path       D-bus object path to find the find pretty name
+ * @param[i]   service    Service for Inventory interface
+ * @param[i]   namePath   Json pointer to the name field to update.
+ *
+ * @return void
+ */
+inline void getPrettyName(const std::shared_ptr<bmcweb::AsyncResp>& asyncResp,
+                          const std::string& path, const std::string& service,
+                          const nlohmann::json::json_pointer& namePath)
+{
+    sdbusplus::asio::getProperty<std::string>(
+        *crow::connections::systemBus, service, path,
+        "xyz.openbmc_project.Inventory.Item", "PrettyName",
+
+        [asyncResp, path, namePath](const boost::system::error_code ec,
+                                    const std::string& prettyName) {
+        if (ec)
+        {
+            BMCWEB_LOG_ERROR("DBUS response error ", ec);
+            return;
+        }
+
+        if (prettyName.empty())
+        {
+            return;
+        }
+
+        asyncResp->res.jsonValue[namePath] = prettyName;
+    });
+}
+
+} // namespace name_util
+} // namespace redfish

--- a/redfish-core/lib/fabric_adapters.hpp
+++ b/redfish-core/lib/fabric_adapters.hpp
@@ -7,6 +7,7 @@
 #include "utils/collection.hpp"
 #include "utils/dbus_utils.hpp"
 #include "utils/json_utils.hpp"
+#include "utils/name_utils.hpp"
 
 #include <boost/system/error_code.hpp>
 #include <boost/url/format.hpp>
@@ -236,6 +237,9 @@ inline void getValidFabricAdapterPath(
         {
             if (checkFabricAdapterId(adapterPath, adapterId))
             {
+                nlohmann::json::json_pointer namePtr("/Name");
+                name_util::getPrettyName(asyncResp, adapterPath,
+                                         serviceMap[0].first,namePtr);    
                 callback(adapterPath, serviceMap.begin()->first);
                 return;
             }


### PR DESCRIPTION
Add pretty name for fabric adapters
The commit implement changes to make use of util function to
populate the name of fabric adapters.

Test:
- Validator was executed and no new error was found.
- checked curl get call:`
{
  "@odata.id": "/redfish/v1/Systems/system/FabricAdapters/pcie_card0",
  "@odata.type": "#FabricAdapter.v1_4_0.FabricAdapter",
  "Id": "pcie_card0",
  "Location": {
    "PartLocation": {
      "ServiceLabel": "U78DA.ND0.WZS0042-P0-C0"
    }
  },
  "Name": "PCIe Card",
  "Status": {
    "Health": "OK",
    "State": "Absent"
  }
}

Change-Id: Ic61d083686a60dc235d4e5f447dc889346f4d3c1
Signed-off-by: Alpana Kumari <alpankum@in.ibm.com>
