### PR TITLE
Implement LocationIndicatorActive for PowerSupplies

### DIFF
--- a/Redfish.md
+++ b/Redfish.md
@@ -410,6 +410,7 @@ Fields common to all schemas
   - EfficiencyPercent
 - FirmwareVersion
 - Location
+- LocationIndicatorActive
 - Manufacturer
 - Model
 - PartNumber

--- a/redfish-core/lib/led.hpp
+++ b/redfish-core/lib/led.hpp
@@ -20,10 +20,19 @@
 #include "dbus_utility.hpp"
 #include "redfish_util.hpp"
 
+#include <boost/system/error_code.hpp>
 #include <sdbusplus/asio/property.hpp>
+#include <sdbusplus/message/types.hpp>
+
+#include <array>
+#include <functional>
+#include <memory>
+#include <string_view>
 
 namespace redfish
 {
+static constexpr std::array<std::string_view, 1> ledGroupInterface = {
+    "xyz.openbmc_project.Led.Group"};
 /**
  * @brief Retrieves identify led group properties over dbus
  *
@@ -252,4 +261,169 @@ inline void setSystemLocationIndicatorActive(
         }
     });
 }
+
+inline void getLedGroupService(
+    const std::shared_ptr<bmcweb::AsyncResp>& asyncResp,
+    const std::string& ledGroupPath,
+    const std::function<void(const std::string& service)>& callback)
+{
+    dbus::utility::getDbusObject(
+        ledGroupPath, ledGroupInterface,
+        [asyncResp, callback](const boost::system::error_code& ec,
+                              const dbus::utility::MapperGetObject& object) {
+        if (ec || object.empty())
+        {
+            BMCWEB_LOG_ERROR("DBUS response error for getDbusObject: {}",
+                             ec.value());
+            messages::internalError(asyncResp->res);
+            return;
+        }
+        callback(object[0].first);
+    });
+}
+
+inline void afterGetLedGroupPath(
+    const std::shared_ptr<bmcweb::AsyncResp>& asyncResp,
+    const std::string& objPath, const boost::system::error_code& ec,
+    const dbus::utility::MapperGetSubTreePathsResponse& subtreePaths,
+    const std::function<void(const std::string& ledGroupPath,
+                             const std::string& service)>& callback)
+{
+    if (ec)
+    {
+        if (ec.value() != EBADR)
+        {
+            BMCWEB_LOG_ERROR(
+                "DBUS response error for getAssociatedSubTreePaths: {}",
+                ec.value());
+            messages::internalError(asyncResp->res);
+        }
+        return;
+    }
+
+    if (subtreePaths.empty())
+    {
+        BMCWEB_LOG_DEBUG(
+            "No LED group associated with the specified object path: {}",
+            objPath);
+        return;
+    }
+
+    if (subtreePaths.size() > 1)
+    {
+        BMCWEB_LOG_ERROR(
+            "More than one LED group associated with the object: {}",
+            subtreePaths.size());
+        messages::internalError(asyncResp->res);
+        return;
+    }
+
+    getLedGroupService(asyncResp, subtreePaths[0],
+                       std::bind_front(callback, subtreePaths[0]));
+}
+
+inline void getLedGroupPath(
+    const std::shared_ptr<bmcweb::AsyncResp>& asyncResp,
+    const std::string& objPath,
+    const std::function<void(const std::string& ledGroupPath,
+                             const std::string& service)>& callback)
+{
+    static constexpr const char* ledObjectPath =
+        "/xyz/openbmc_project/led/groups";
+    sdbusplus::message::object_path ledGroupAssociatedPath = objPath +
+                                                             "/identifying";
+
+    dbus::utility::getAssociatedSubTreePaths(
+        ledGroupAssociatedPath, sdbusplus::message::object_path(ledObjectPath),
+        0, ledGroupInterface,
+        [asyncResp, objPath, callback](
+            const boost::system::error_code& ec,
+            const dbus::utility::MapperGetSubTreePathsResponse& subtreePaths) {
+        afterGetLedGroupPath(asyncResp, objPath, ec, subtreePaths, callback);
+    });
+}
+
+inline void getLedState(const std::shared_ptr<bmcweb::AsyncResp>& asyncResp,
+                        const std::string& ledGroupPath,
+                        const std::string& service)
+{
+    sdbusplus::asio::getProperty<bool>(
+        *crow::connections::systemBus, service, ledGroupPath,
+        "xyz.openbmc_project.Led.Group", "Asserted",
+        [asyncResp, ledGroupPath](const boost::system::error_code& ec,
+                                  bool assert) {
+        if (ec)
+        {
+            if (ec.value() != EBADR)
+            {
+                BMCWEB_LOG_ERROR("DBUS response error for get ledState {}",
+                                 ec.value());
+                messages::internalError(asyncResp->res);
+                return;
+            }
+            return;
+        }
+
+        asyncResp->res.jsonValue["LocationIndicatorActive"] = assert;
+    });
+}
+
+/**
+ * @brief Retrieves identify led group properties over dbus
+ *
+ * @param[in] asyncResp Shared pointer for generating response message.
+ * @param[in] objPath   Object path on PIM
+ *
+ * @return None.
+ */
+inline void getLocationIndicatorActive(
+    const std::shared_ptr<bmcweb::AsyncResp>& asyncResp,
+    const std::string& objPath)
+{
+    BMCWEB_LOG_DEBUG("Get LocationIndicatorActive");
+    getLedGroupPath(asyncResp, objPath,
+                    std::bind_front(getLedState, asyncResp));
+}
+
+inline void setLedState(const std::shared_ptr<bmcweb::AsyncResp>& asyncResp,
+                        bool ledState, const std::string& ledGroupPath,
+                        const std::string& service)
+{
+    sdbusplus::asio::setProperty(
+        *crow::connections::systemBus, service, ledGroupPath,
+        "xyz.openbmc_project.Led.Group", "Asserted", ledState,
+        [asyncResp, ledGroupPath](const boost::system::error_code& ec) {
+        if (ec)
+        {
+            if (ec.value() != EBADR)
+            {
+                BMCWEB_LOG_ERROR("DBUS response error for set ledState {}",
+                                 ec.value());
+                messages::internalError(asyncResp->res);
+                return;
+            }
+            messages::resourceNotFound(asyncResp->res, "LedGroup",
+                                       ledGroupPath);
+        }
+    });
+}
+
+/**
+ * @brief Sets identify led group properties
+ *
+ * @param[in] asyncResp     Shared pointer for generating response message.
+ * @param[in] objPath       Object path on PIM
+ * @param[in] ledState      LED state passed from request
+ *
+ * @return None.
+ */
+inline void setLocationIndicatorActive(
+    const std::shared_ptr<bmcweb::AsyncResp>& asyncResp,
+    const std::string& objPath, bool ledState)
+{
+    BMCWEB_LOG_DEBUG("Set LocationIndicatorActive");
+    getLedGroupPath(asyncResp, objPath,
+                    std::bind_front(setLedState, asyncResp, ledState));
+}
+
 } // namespace redfish

--- a/redfish-core/lib/power_supply.hpp
+++ b/redfish-core/lib/power_supply.hpp
@@ -2,6 +2,7 @@
 
 #include "app.hpp"
 #include "dbus_utility.hpp"
+#include "led.hpp"
 #include "query.hpp"
 #include "registries/privilege_registry.hpp"
 #include "utils/chassis_utils.hpp"
@@ -11,6 +12,7 @@
 #include <boost/system/error_code.hpp>
 #include <boost/url/format.hpp>
 
+#include <functional>
 #include <memory>
 #include <optional>
 #include <string>
@@ -502,6 +504,7 @@ inline void
         });
 
         getEfficiencyPercent(asyncResp);
+        getLocationIndicatorActive(asyncResp, powerSupplyPath);
     });
 }
 
@@ -552,6 +555,63 @@ inline void
         std::bind_front(doPowerSupplyGet, asyncResp, chassisId, powerSupplyId));
 }
 
+inline void
+    doPatchPowerSupply(const std::shared_ptr<bmcweb::AsyncResp>& asyncResp,
+                       const bool locationIndicatorActive,
+                       const std::string& powerSupplyPath)
+{
+    setLocationIndicatorActive(asyncResp, powerSupplyPath,
+                               locationIndicatorActive);
+}
+
+inline void powerSupplyPatchAfterValidateChassis(
+    const std::shared_ptr<bmcweb::AsyncResp>& asyncResp,
+    const std::string& chassisId, const std::string& powerSupplyId,
+    const bool locationIndicatorActive,
+    const std::optional<std::string>& validChassisPath)
+{
+    if (!validChassisPath)
+    {
+        BMCWEB_LOG_WARNING("Not a valid chassis ID: {}", chassisId);
+        messages::resourceNotFound(asyncResp->res, "Chassis", chassisId);
+        return;
+    }
+
+    // Get the correct power supply Path that match the input parameters
+    getValidPowerSupplyPath(asyncResp, *validChassisPath, powerSupplyId,
+                            std::bind_front(doPatchPowerSupply, asyncResp,
+                                            locationIndicatorActive));
+}
+
+inline void
+    handlePowerSupplyPatch(App& app, const crow::Request& req,
+                           const std::shared_ptr<bmcweb::AsyncResp>& asyncResp,
+                           const std::string& chassisId,
+                           const std::string& powerSupplyId)
+{
+    if (!redfish::setUpRedfishRoute(app, req, asyncResp))
+    {
+        return;
+    }
+
+    std::optional<bool> locationIndicatorActive;
+    if (!json_util::readJsonPatch(req, asyncResp->res,
+                                  "LocationIndicatorActive",
+                                  locationIndicatorActive))
+    {
+        return;
+    }
+
+    if (locationIndicatorActive)
+    {
+        redfish::chassis_utils::getValidChassisPath(
+            asyncResp, chassisId,
+            std::bind_front(powerSupplyPatchAfterValidateChassis, asyncResp,
+                            chassisId, powerSupplyId,
+                            *locationIndicatorActive));
+    }
+}
+
 inline void requestRoutesPowerSupply(App& app)
 {
     BMCWEB_ROUTE(
@@ -565,6 +625,12 @@ inline void requestRoutesPowerSupply(App& app)
         .privileges(redfish::privileges::getPowerSupply)
         .methods(boost::beast::http::verb::get)(
             std::bind_front(handlePowerSupplyGet, std::ref(app)));
+
+    BMCWEB_ROUTE(
+        app, "/redfish/v1/Chassis/<str>/PowerSubsystem/PowerSupplies/<str>/")
+        .privileges(redfish::privileges::patchPowerSupply)
+        .methods(boost::beast::http::verb::patch)(
+            std::bind_front(handlePowerSupplyPatch, std::ref(app)));
 }
 
 } // namespace redfish


### PR DESCRIPTION
Implement LocationIndicatorActive for PowerSupplies schema to set/get the status of the location LED for each power supply. When working with Redfish to get or set the "Location Indicator Active" property, the initial step involves locating the corresponding LED group through the "identifying" association. Following this, we can proceed to either get or set the "Asserted" property.

ref: https://redfish.dmtf.org/schemas/v1/PowerSupply.v1_5_0.json https://gerrit.openbmc.org/c/openbmc/phosphor-dbus-interfaces/+/58299

Tested: Validator passes. Tested in upstream p10bmc environment. 1、Get LocationIndicatorActive
curl -k  -H "X-Auth-Token: $token" -X GET https://${bmc} /redfish/v1/Chassis/chassis/PowerSubsystem/PowerSupplies/powersupply0 {
  "@odata.id":
    "/redfish/v1/Chassis/chassis/PowerSubsystem/PowerSupplies/
     powersupply0",
  "@odata.type": "#PowerSupply.v1_5_0.PowerSupply",
  "LocationIndicatorActive": false,
  ...
}

We will see the powersupply0 identify led is false too. busctl get-property xyz.openbmc_project.LED.GroupManager /xyz/openbmc_project/led/groups/powersupply0_identify xyz.openbmc_project.Led.Group Asserted
b false

2、Set LocationIndicatorActive to true
curl -k -H "X-Auth-Token: $token" -X PATCH -d
'{"LocationIndicatorActive":true}' https://${bmc}/redfish/v1/Chassis/ chassis/PowerSubsystem/PowerSupplies/powersupply0

Then we will see the powersupply0 location LED lit up, and the value becomes to true:
curl -k  -H "X-Auth-Token: $token" -X GET https://${bmc} /redfish/v1/Chassis/chassis/PowerSubsystem/PowerSupplies/powersupply0 {
  "@odata.id":
    "/redfish/v1/Chassis/chassis/PowerSubsystem/PowerSupplies/
     powersupply0",
  "@odata.type": "#PowerSupply.v1_5_0.PowerSupply",
  "LocationIndicatorActive": true,
  ...
}

busctl get-property xyz.openbmc_project.LED.GroupManager /xyz/openbmc_project/led/groups/powersupply0_identify xyz.openbmc_project.Led.Group Asserted
b true

3、Use set-property to change the value
busctl set-property xyz.openbmc_project.LED.GroupManager /xyz/openbmc_project/led/groups/powersupply0_identify xyz.openbmc_project.Led.Group Asserted b true

Then we will see the value becomes true:
curl -k  -H "X-Auth-Token: $token" -X GET https://${bmc} /redfish/v1/Chassis/chassis/PowerSubsystem/PowerSupplies/powersupply0 {
  "@odata.id":
    "/redfish/v1/Chassis/chassis/PowerSubsystem/PowerSupplies/
     powersupply0",
  "@odata.type": "#PowerSupply.v1_5_0.PowerSupply",
  "LocationIndicatorActive": true,
  ...
}

busctl get-property xyz.openbmc_project.LED.GroupManager /xyz/openbmc_project/led/groups/powersupply0_identify xyz.openbmc_project.Led.Group Asserted
b true

Change-Id: I9e71c7badc161292d96da43219a490e6e13c404b