### PR TITLE
Audit Log: Rebase service audit log

### DIFF
--- a/include/audit_events.hpp
+++ b/include/audit_events.hpp
@@ -1,0 +1,296 @@
+#pragma once
+
+#include "http_request.hpp"
+#include "logging.hpp"
+
+#include <libaudit.h>
+
+#include <boost/asio/ip/host_name.hpp>
+
+#include <cstring>
+#include <string>
+
+namespace audit
+{
+
+// NOLINTBEGIN(cppcoreguidelines-avoid-non-const-global-variables)
+static bool tryOpen = true;
+static int auditfd = -1;
+// NOLINTEND(cppcoreguidelines-avoid-non-const-global-variables)
+
+/**
+ * @brief Closes connection for recording audit events
+ */
+inline void auditClose()
+{
+    if (auditfd >= 0)
+    {
+        audit_close(auditfd);
+        auditfd = -1;
+        BMCWEB_LOG_DEBUG("Audit log closed.");
+    }
+}
+
+/**
+ * @brief Opens connection for recording audit events
+ *
+ * Reuses prior connection if available.
+ *
+ * @return If connection was successful or not
+ */
+inline bool auditOpen()
+{
+    if (auditfd < 0)
+    {
+        /* Blocking opening of audit connection */
+        if (!tryOpen)
+        {
+            BMCWEB_LOG_DEBUG("Audit connection disabled");
+            return false;
+        }
+
+        auditfd = audit_open();
+
+        if (auditfd < 0)
+        {
+            BMCWEB_LOG_ERROR("Error opening audit socket : {}", errno);
+            return false;
+        }
+        BMCWEB_LOG_DEBUG("Audit fd created : {}", auditfd);
+    }
+
+    return true;
+}
+
+/**
+ * @brief Establishes new connection for recording audit events
+ *
+ * Closes any existing connection and tries to create a new connection.
+ *
+ * @return If new connection was successful or not
+ */
+inline bool auditReopen()
+{
+    auditClose();
+    return auditOpen();
+}
+
+/**
+ * @brief Sets state for audit connection
+ * @param[in] enable    New state for audit connection.
+ *			If false, then any existing connection will be closed.
+ */
+inline void auditSetState(bool enable)
+{
+    if (!enable)
+    {
+        auditClose();
+    }
+
+    tryOpen = enable;
+
+    BMCWEB_LOG_DEBUG("Audit state: tryOpen = {}", tryOpen);
+}
+
+/**
+ * @brief Checks if POST request is a user connection event
+ *
+ * Login and Session requests are audited when the authentication is attempted.
+ * This allows failed requests to be audited with the user detail.
+ *
+ * @return True if request is a user connection event
+ */
+inline bool checkPostUser(const crow::Request& req)
+{
+    return (req.target() == "/redfish/v1/SessionService/Sessions") ||
+           (req.target() == "/redfish/v1/SessionService/Sessions/") ||
+           (req.target() == "/login");
+}
+
+/**
+ * @brief Checks if request should be audited after completion
+ * @return  True if request should be audited
+ */
+inline bool wantAudit(const crow::Request& req)
+{
+    return (req.method() == boost::beast::http::verb::patch) ||
+           (req.method() == boost::beast::http::verb::put) ||
+           (req.method() == boost::beast::http::verb::delete_) ||
+           ((req.method() == boost::beast::http::verb::post) &&
+            !checkPostUser(req));
+}
+
+/**
+ * @brief Checks if request should include additional data
+ *
+ * - Accounts requests data may contain passwords
+ * - IBM Management console events data is not useful. It can be binary data or
+ *   contents of file.
+ * - User login and session data may contain passwords
+ *
+ * @return True if request's data should not be logged
+ */
+inline bool checkSkipDetail(const crow::Request& req)
+{
+    return req.target().starts_with("/redfish/v1/AccountService/Accounts") ||
+           req.target().starts_with("/ibm/v1") ||
+           ((req.method() == boost::beast::http::verb::post) &&
+            checkPostUser(req));
+}
+
+/**
+ * @brief Checks if request's detail data should be logged
+ *
+ * @return True if request's detail data should be logged
+ */
+inline bool wantDetail(const crow::Request& req)
+{
+    switch (req.method())
+    {
+        case boost::beast::http::verb::patch:
+        case boost::beast::http::verb::post:
+            if (checkSkipDetail(req))
+            {
+                return false;
+            }
+            return true;
+
+        case boost::beast::http::verb::put:
+            return (!req.target().starts_with("/ibm/v1"));
+
+        case boost::beast::http::verb::delete_:
+            return true;
+
+        default:
+            // Shouldn't be here, don't log any data
+            BMCWEB_LOG_DEBUG("Unexpected verb {}", req.methodString());
+            return false;
+    }
+}
+
+/**
+ * @brief Appends item to strBuf only if strBuf won't exceed maxBufSize
+ *
+ * @param[in,out] strBuf Buffer to append up to maxBufSize only
+ * @param[in] maxBufSize Maximum length of strBuf
+ * @param[in] item String to append if it will fit within maxBufSize
+ *
+ * @return True if item was appended
+ */
+inline bool appendItemToBuf(std::string& strBuf, size_t maxBufSize,
+                            const std::string& item)
+{
+    if (strBuf.length() + item.length() > maxBufSize)
+    {
+        return false;
+    }
+    strBuf += item;
+    return true;
+}
+
+inline void auditEvent(const crow::Request& req, const std::string& userName,
+                       bool success)
+{
+    if (!auditOpen())
+    {
+        return;
+    }
+
+    std::string opPath = std::format("op={}:{} ",
+                                     std::string(req.methodString()),
+                                     std::string(req.target()));
+
+    size_t maxBuf = 256; // Limit message to avoid filling log with single entry
+    std::string cnfgBuff = opPath.substr(0, maxBuf);
+
+    if (cnfgBuff.length() < opPath.length())
+    {
+        // Event message truncated to fit into fixed sized buffer.
+        BMCWEB_LOG_WARNING(
+            "Audit buffer too small, truncating: cnfgBufLen={} opPathLen={}",
+            cnfgBuff.length(), opPath.length());
+    }
+
+    // Determine any additional info for the event
+    std::string detail;
+    if (wantDetail(req))
+    {
+        detail = req.body() + " ";
+    }
+
+    if (!detail.empty())
+    {
+        if (!appendItemToBuf(cnfgBuff, maxBuf, detail))
+        {
+            // Additional info won't fix into fixed sized buffer. Leave
+            // it off.
+            BMCWEB_LOG_WARNING(
+                "Audit buffer too small for data: bufLeft={} detailLen={}",
+                (maxBuf - cnfgBuff.length()), detail.length());
+        }
+    }
+
+    // encode user account name to ensure it is in an appropriate format
+    size_t userLen = 0;
+    char* user = audit_encode_nv_string("acct", userName.c_str(), 0);
+
+    if (user == nullptr)
+    {
+        BMCWEB_LOG_WARNING("Error encoding user for audit msg : {}", errno);
+    }
+    else
+    {
+        // setup a unique_ptr to handle freeing memory from user
+        std::unique_ptr<char, void (*)(char*)> userUP(user, [](char* ptr) {
+            if (ptr != nullptr)
+            {
+                // Linux audit mallocs memory we must free.
+                // NOLINTNEXTLINE(cppcoreguidelines-no-malloc)
+                ::free(ptr);
+            }
+        });
+
+        userLen = std::strlen(user);
+
+        if (!appendItemToBuf(cnfgBuff, maxBuf, std::string(user)))
+        {
+            // Username won't fit into fixed sized buffer. Leave it off.
+            BMCWEB_LOG_WARNING(
+                "Audit buffer too small for username: bufLeft={} userLen={}",
+                (maxBuf - cnfgBuff.length()), userLen);
+        }
+    }
+
+    BMCWEB_LOG_DEBUG(
+        "auditEvent: bufLeft={}  opPathLen={} detailLen={} userLen={}",
+        (maxBuf - cnfgBuff.length()), opPath.length(), detail.length(),
+        userLen);
+
+    std::string ipAddress = req.ipAddress.to_string();
+
+    int rc = audit_log_user_message(auditfd, AUDIT_USYS_CONFIG,
+                                    cnfgBuff.c_str(),
+                                    boost::asio::ip::host_name().c_str(),
+                                    ipAddress.c_str(), nullptr, int(success));
+
+    if (rc <= 0)
+    {
+        // Something failed with existing connection. Try to establish a new
+        // connection and retry if successful.
+        // Preserve original errno to report if the retry fails.
+        int origErrno = errno;
+        if (auditReopen())
+        {
+            rc = audit_log_user_message(
+                auditfd, AUDIT_USYS_CONFIG, cnfgBuff.c_str(),
+                boost::asio::ip::host_name().c_str(), ipAddress.c_str(),
+                nullptr, int(success));
+        }
+        if (rc <= 0)
+        {
+            BMCWEB_LOG_ERROR("Error writing audit message: {}", origErrno);
+        }
+    }
+}
+
+} // namespace audit

--- a/include/login_routes.hpp
+++ b/include/login_routes.hpp
@@ -4,6 +4,9 @@
 #include "common.hpp"
 #include "http_request.hpp"
 #include "http_response.hpp"
+#ifdef BMCWEB_ENABLE_LINUX_AUDIT_EVENTS
+#include "audit_events.hpp"
+#endif
 #include "multipart_parser.hpp"
 #include "pam_authenticate.hpp"
 #include "webassets.hpp"
@@ -158,6 +161,9 @@ inline void handleLogin(const crow::Request& req,
         if ((pamrc != PAM_SUCCESS) && !isConfigureSelfOnly)
         {
             asyncResp->res.result(boost::beast::http::status::unauthorized);
+#ifdef BMCWEB_ENABLE_LINUX_AUDIT_EVENTS
+            audit::auditEvent(req, std::string(username), false);
+#endif
         }
         else
         {
@@ -176,6 +182,9 @@ inline void handleLogin(const crow::Request& req,
 
             // if content type is json, assume json token
             asyncResp->res.jsonValue["token"] = session->sessionToken;
+#ifdef BMCWEB_ENABLE_LINUX_AUDIT_EVENTS
+            audit::auditEvent(req, std::string(username), true);
+#endif
         }
     }
     else

--- a/meson.build
+++ b/meson.build
@@ -95,6 +95,7 @@ feature_map = {
   'experimental-redfish-multi-computer-system'  : '-DBMCWEB_ENABLE_MULTI_COMPUTERSYSTEM',
   'vm-websocket'                                : '-DBMCWEB_ENABLE_VM_WEBSOCKET',
   'xtoken-auth'                                 : '-DBMCWEB_ENABLE_XTOKEN_AUTHENTICATION',
+  'audit-events'                                : '-DBMCWEB_ENABLE_LINUX_AUDIT_EVENTS',
   #'vm-nbdproxy'                                : '-DBMCWEB_ENABLE_VM_NBDPROXY',
 }
 
@@ -292,6 +293,11 @@ if not nghttp2.found()
 endif
 bmcweb_dependencies += nghttp2
 
+if(get_option('audit-events').allowed())
+  audit = cxx.find_library('libaudit', required: true)
+  bmcweb_dependencies += audit
+endif
+
 sdbusplus = dependency('sdbusplus', required : false, include_type: 'system')
 if not sdbusplus.found()
   sdbusplus_proj = subproject('sdbusplus', required: true)
@@ -462,6 +468,9 @@ srcfiles_unittest = files(
   'test/redfish-core/lib/power_subsystem_test.cpp',
 )
 
+if (get_option('audit-events').allowed())
+	srcfiles_unittest += files('test/include/audit_events_test.cpp',)
+endif
 
 if(get_option('tests').allowed())
     # generate the test executable

--- a/meson_options.txt
+++ b/meson_options.txt
@@ -310,6 +310,12 @@ option(
                     on this option for any production systems.  It may have
                     behavior changes or be removed at any time.'''
 )
+option(
+    'audit-events',
+    type: 'feature',
+    value: 'disabled',
+    description: 'Enable audit events support for bmcweb'
+)
 
 # Insecure options. Every option that starts with a `insecure` flag should
 # not be enabled by default for any platform, unless the author fully comprehends

--- a/redfish-core/lib/redfish_sessions.hpp
+++ b/redfish-core/lib/redfish_sessions.hpp
@@ -16,6 +16,9 @@
 #pragma once
 
 #include "app.hpp"
+#ifdef BMCWEB_ENABLE_LINUX_AUDIT_EVENTS
+#include "audit_events.hpp"
+#endif
 #include "error_messages.hpp"
 #include "http/utility.hpp"
 #include "persistent_data.hpp"
@@ -227,6 +230,9 @@ inline void handleSessionCollectionPost(
     {
         messages::resourceAtUriUnauthorized(asyncResp->res, req.url(),
                                             "Invalid username or password");
+#ifdef BMCWEB_ENABLE_LINUX_AUDIT_EVENTS
+        audit::auditEvent(req, std::string(username), false);
+#endif
         return;
     }
 
@@ -245,6 +251,11 @@ inline void handleSessionCollectionPost(
     asyncResp->res.addHeader(
         "Location", "/redfish/v1/SessionService/Sessions/" + session->uniqueId);
     asyncResp->res.result(boost::beast::http::status::created);
+
+#ifdef BMCWEB_ENABLE_LINUX_AUDIT_EVENTS
+    audit::auditEvent(req, std::string(username), true);
+#endif
+
     if (session->isConfigureSelfOnly)
     {
         messages::passwordChangeRequired(

--- a/test/include/audit_events_test.cpp
+++ b/test/include/audit_events_test.cpp
@@ -1,0 +1,201 @@
+#include "audit_events.hpp"
+
+#include <gtest/gtest.h> // IWYU pragma: keep
+
+// IWYU pragma: no_include <gtest/gtest-message.h>
+// IWYU pragma: no_include <gtest/gtest-test-part.h>
+// IWYU pragma: no_include "gtest/gtest_pred_impl.h"
+
+namespace audit
+{
+namespace
+{
+
+TEST(auditSetState, PositiveTest)
+{
+    auditSetState(false);
+    EXPECT_FALSE(auditOpen());
+
+    auditSetState(true);
+    EXPECT_TRUE(auditOpen());
+    auditClose();
+}
+
+TEST(auditOpen, PositiveTest)
+{
+    int origFd = -1;
+
+    EXPECT_TRUE(auditOpen());
+    EXPECT_NE(auditfd, -1);
+
+    origFd = auditfd;
+    EXPECT_TRUE(auditOpen());
+    EXPECT_EQ(auditfd, origFd);
+}
+
+TEST(auditClose, PositiveTest)
+{
+    auditClose();
+    EXPECT_EQ(auditfd, -1);
+
+    EXPECT_TRUE(auditOpen());
+    auditClose();
+    EXPECT_EQ(auditfd, -1);
+}
+
+TEST(auditReopen, PositiveTest)
+{
+    EXPECT_TRUE(auditReopen());
+    EXPECT_NE(auditfd, -1);
+
+    // Cannot make expectation on different fd on reopen
+    EXPECT_TRUE(auditReopen());
+    EXPECT_NE(auditfd, -1);
+
+    auditClose();
+    EXPECT_TRUE(auditReopen());
+    EXPECT_NE(auditfd, -1);
+}
+
+TEST(wantAudit, PositiveTest)
+{
+    constexpr const std::string_view url = "/foo";
+    std::error_code ec;
+
+    crow::Request patchRequest{{boost::beast::http::verb::patch, url, 11}, ec};
+    EXPECT_TRUE(wantAudit(patchRequest));
+
+    crow::Request putRequest{{boost::beast::http::verb::put, url, 11}, ec};
+    EXPECT_TRUE(wantAudit(putRequest));
+
+    crow::Request deleteRequest{{boost::beast::http::verb::delete_, url, 11},
+                                ec};
+    EXPECT_TRUE(wantAudit(deleteRequest));
+
+    crow::Request postRequest{{boost::beast::http::verb::post, url, 11}, ec};
+    EXPECT_TRUE(wantAudit(postRequest));
+}
+
+TEST(wantAudit, NegativeTest)
+{
+    constexpr const std::string_view url = "/foo";
+    std::error_code ec;
+
+    crow::Request postRequest{{boost::beast::http::verb::post, url, 11}, ec};
+
+    postRequest.target("/redfish/v1/SessionService/Sessions");
+    EXPECT_FALSE(wantAudit(postRequest));
+
+    postRequest.target("/redfish/v1/SessionService/Sessions/");
+    EXPECT_FALSE(wantAudit(postRequest));
+
+    postRequest.target("/login");
+    EXPECT_FALSE(wantAudit(postRequest));
+
+    crow::Request getRequest{{boost::beast::http::verb::get, url, 11}, ec};
+    EXPECT_FALSE(wantAudit(getRequest));
+}
+
+TEST(wantDetail, PositiveTest)
+{
+    constexpr const std::string_view url = "/foo";
+    std::error_code ec;
+
+    crow::Request patchRequest{{boost::beast::http::verb::patch, url, 11}, ec};
+    EXPECT_TRUE(wantDetail(patchRequest));
+
+    crow::Request putRequest{{boost::beast::http::verb::put, url, 11}, ec};
+    EXPECT_TRUE(wantDetail(putRequest));
+
+    crow::Request deleteRequest{{boost::beast::http::verb::delete_, url, 11},
+                                ec};
+    EXPECT_TRUE(wantDetail(deleteRequest));
+
+    crow::Request postRequest{{boost::beast::http::verb::post, url, 11}, ec};
+    EXPECT_TRUE(wantDetail(postRequest));
+}
+
+TEST(wantDetail, NegativeTest)
+{
+    constexpr const std::string_view url = "/foo";
+    std::error_code ec;
+
+    crow::Request patchRequest{{boost::beast::http::verb::patch, url, 11}, ec};
+    patchRequest.target("/redfish/v1/AccountService/Accounts/foo");
+    EXPECT_FALSE(wantDetail(patchRequest));
+
+    patchRequest.target("/ibm/v1/foo");
+    EXPECT_FALSE(wantDetail(patchRequest));
+
+    crow::Request postRequest{{boost::beast::http::verb::post, url, 11}, ec};
+
+    postRequest.target("/redfish/v1/AccountService/Accounts/bar");
+    EXPECT_FALSE(wantDetail(postRequest));
+
+    postRequest.target("/ibm/v1/bar");
+    EXPECT_FALSE(wantDetail(postRequest));
+
+    postRequest.target("/redfish/v1/SessionService/Sessions");
+    EXPECT_FALSE(wantDetail(postRequest));
+
+    postRequest.target("/redfish/v1/SessionService/Sessions/");
+    EXPECT_FALSE(wantDetail(postRequest));
+
+    postRequest.target("/login");
+    EXPECT_FALSE(wantDetail(postRequest));
+
+    crow::Request getRequest{{boost::beast::http::verb::get, url, 11}, ec};
+    EXPECT_FALSE(wantDetail(getRequest));
+}
+
+TEST(appendItemToBuf, PositiveTest)
+{
+    std::string testBuf;
+    std::string data;
+    std::string cmpStr;
+
+    data = "Initial data ";
+    cmpStr = data;
+
+    EXPECT_TRUE(appendItemToBuf(testBuf, data.length() + 20, data));
+    EXPECT_EQ(testBuf, cmpStr);
+
+    data = "Append data ";
+    cmpStr += data;
+    EXPECT_TRUE(
+        appendItemToBuf(testBuf, testBuf.length() + data.length(), data));
+    EXPECT_EQ(testBuf, cmpStr);
+
+    data = "Append more data ";
+    cmpStr += data;
+
+    EXPECT_TRUE(
+        appendItemToBuf(testBuf, testBuf.length() + data.length(), data));
+    EXPECT_EQ(testBuf, cmpStr);
+}
+
+TEST(appendItemToBuf, NegativeTest)
+{
+    std::string testBuf;
+    std::string data;
+    std::string cmpStr;
+
+    cmpStr = testBuf;
+    data = "Data not appended";
+
+    EXPECT_FALSE(appendItemToBuf(testBuf, data.length() - 5, data));
+    EXPECT_EQ(testBuf, cmpStr);
+
+    testBuf = "Initial data ";
+    cmpStr = testBuf;
+
+    EXPECT_FALSE(appendItemToBuf(testBuf, testBuf.length(), data));
+    EXPECT_EQ(testBuf, cmpStr);
+
+    EXPECT_FALSE(
+        appendItemToBuf(testBuf, testBuf.length() + data.length() - 1, data));
+    EXPECT_EQ(testBuf, cmpStr);
+}
+
+} // namespace
+} // namespace audit


### PR DESCRIPTION
Rebase of all bmcweb commits to support service audit log.

This introduces a new bmcweb meson option, audit-events, which is defaulted to disabled. Recipe changes in GHE openbmc/openbmc enable audit logging.

When audit-events is enabled all bmcweb PATCH, POST, PUT, and DELETE events are logged using the Linux kernel auditd subsystem. Additionally, login events coming through bmcweb are also recorded.

The body of the events is recorded as well except in the following cases:
  - /redfish/v1/AccountService/Accounts PATCH/POST events - body is not recorded as it may contain clear text password
  - /ibm/v1 PATCH/POST/PUT events - body is not recorded as it contains HMC config file binary data

Events are recorded in /var/log/audit/. User type dreport will gather these log files.

Tested:
 - Enabled auditing then initiated a variety of Redfish events using curl.
 - Confirmed the events were recorded and confirmed the data recorded was accurate.
 - Confirmed password was not included in audit data recorded.

Commits included:
```
 -  4bc3e20f Audit Log: Hide details of building audit message into auditEvent() (#725)
 -  7483bb00 Audit Log: Factor out function to determine which events to audit (#718)
 -  2a4acf86 Audit Log: Add utility function to enable/disable audit connection
 -  bda2e617 Audit Log: Handle breaking of unexpected connection with auditd
 -  fab81331 Audit Log: Add unit test for auditOpen() and auditClose()
 -  3e352fcd Audit Log: Open and save fd for auditing future events
 -  b0901dd3 Audit Log: Correct logging of success login case. (#690)
 -  3976090f Merge pull request #680 from jeaaustx/1050-enableAuditLog
 -  f5745fc6 Audit Log: Exclude body data for all IBM management console events
 -  db0ccb2e Audit Log: Add PUT events to audit log for HMC config file management
 -  9bd97269 Audit log enhancements and fixs (#500)
 -  5ced90bd Expand Success Case For Audit Logging (#447)
 -  6dc7529e Add Audit Event Points to All POSTs
 -  9241b341 Add Audit Event Through bmcweb
```