### PR TITLE
1110: Add OemMessage for taskAbort Error (#519)(#617)

### DIFF
--- a/redfish-core/include/schemas.hpp
+++ b/redfish-core/include/schemas.hpp
@@ -131,6 +131,7 @@ namespace redfish
         "OemComputerSystem",
         "OemVirtualMedia",
         "OpenBMCAccountService",
+        "OemMessage",
         "OemUpdateService",
     };
 }

--- a/redfish-core/include/task_messages.hpp
+++ b/redfish-core/include/task_messages.hpp
@@ -35,6 +35,26 @@ inline nlohmann::json
                               args);
 }
 
+inline nlohmann::json taskAborted(const std::string& arg1,
+                                  const std::string& arg2,
+                                  const std::string& arg3,
+                                  const std::string& arg4)
+{
+    return nlohmann::json{
+        {"@odata.type", "#Message.v1_0_0.Message"},
+        {"MessageId", "TaskEvent.1.0.1.TaskAborted"},
+        {"Message", "The task with id " + arg1 + " has been aborted."},
+        {"MessageArgs", {arg1, arg2, arg3, arg4}},
+        {"Severity", "Critical"},
+        {"Resolution", "None."},
+        {"Oem",
+         {{"OpenBMC",
+           {{"@odata.type", "#OemMessage.v1_0_0.Message"},
+            {"AbortReason", arg2},
+            {"AdditionalData", arg3},
+            {"EventId", arg4}}}}}};
+}
+
 inline nlohmann::json taskAborted(std::string_view arg1)
 {
     return getLogTaskEvent(registries::task_event::Index::taskAborted,

--- a/redfish-core/lib/task.hpp
+++ b/redfish-core/lib/task.hpp
@@ -191,8 +191,8 @@ struct TaskData : std::enable_shared_from_this<TaskData>
             self->finishTask();
             self->state = "Cancelled";
             self->status = "Warning";
-            self->messages.emplace_back(
-                messages::taskAborted(std::to_string(self->index)));
+            self->messages.emplace_back(messages::taskAborted(
+                std::to_string(self->index), "None", "None", "None"));
             // Send event :TaskAborted
             self->sendTaskEvent(self->state, self->index);
             self->callback(ec, msg, self);
@@ -237,8 +237,9 @@ struct TaskData : std::enable_shared_from_this<TaskData>
         else if (state == "Stopping")
         {
             redfish::EventServiceManager::getInstance().sendEvent(
-                redfish::messages::taskAborted(std::to_string(index)), origin,
-                resType);
+                redfish::messages::taskAborted(std::to_string(index), "None",
+                                               "None", "None"),
+                origin, resType);
         }
         else if (state == "Completed")
         {

--- a/redfish-core/lib/update_service.hpp
+++ b/redfish-core/lib/update_service.hpp
@@ -28,6 +28,8 @@
 #include "utils/dbus_utils.hpp"
 #include "utils/sw_utils.hpp"
 
+#include <boost/algorithm/string/case_conv.hpp>
+#include <boost/range/adaptor/reversed.hpp>
 #include <boost/system/error_code.hpp>
 #include <boost/url/format.hpp>
 #include <sdbusplus/asio/property.hpp>
@@ -35,8 +37,15 @@
 #include <sdbusplus/unpack_properties.hpp>
 
 #include <array>
+#include <chrono>
 #include <filesystem>
+#include <fstream>
+#include <memory>
+#include <optional>
+#include <string>
 #include <string_view>
+#include <variant>
+#include <vector>
 
 namespace redfish
 {
@@ -74,6 +83,108 @@ inline static void activateImage(const std::string& objPath,
             BMCWEB_LOG_DEBUG("error msg = {}", ec.message());
         }
     });
+}
+
+// Return true if Errror LoggingEntry handling is done
+inline bool doUpdateErrorLoggingEntry(
+    const std::shared_ptr<task::TaskData>& taskData, const std::string& index,
+    const dbus::utility::DBusPropertiesMap& properties)
+{
+    using AdditionalDataType = std::vector<std::string>;
+
+    const AdditionalDataType* addData = nullptr;
+    const std::string* message = nullptr;
+    const std::string* eventId = nullptr;
+
+    const bool success = sdbusplus::unpackPropertiesNoThrow(
+        dbus_utils::UnpackErrorPrinter(), properties, "Message", message,
+        "AdditionalData", addData, "EventId", eventId);
+    if (!success)
+    {
+        BMCWEB_LOG_ERROR("Log property has unexpected value");
+        taskData->messages.emplace_back(messages::internalError());
+        return true;
+    }
+    if (message == nullptr)
+    {
+        BMCWEB_LOG_ERROR("Log property has unexpected value");
+        taskData->messages.emplace_back(messages::internalError());
+        return true;
+    }
+
+    if (!message->starts_with("xyz.openbmc_project.Software"))
+    {
+        // Not a software error
+        return false;
+    }
+
+    if (addData == nullptr)
+    {
+        BMCWEB_LOG_ERROR("Log property has unexpected value");
+        taskData->messages.emplace_back(messages::internalError());
+        return true;
+    }
+    if (eventId == nullptr)
+    {
+        BMCWEB_LOG_ERROR("Log property has unexpected value");
+        taskData->messages.emplace_back(messages::internalError());
+        return true;
+    }
+
+    std::string addDataStr;
+    for (const auto& data : *addData)
+    {
+        addDataStr.append(data);
+        addDataStr.append(" ");
+    }
+
+    if (!message->empty() && !addDataStr.empty() && !eventId->empty())
+    {
+        taskData->messages.emplace_back(
+            messages::taskAborted(index, *message, addDataStr, *eventId));
+        return true;
+    }
+    return false;
+}
+
+inline void
+    afterUpdateErrorLogMessage(const std::shared_ptr<task::TaskData>& taskData,
+                               const std::string& index,
+                               const boost::system::error_code& ec,
+                               const dbus::utility::ManagedObjectType& resp)
+{
+    if (ec)
+    {
+        BMCWEB_LOG_ERROR("updateErrorLogMessage returned an error {}",
+                         ec.value());
+        return;
+    }
+
+    for (const auto& objectPath : boost::adaptors::reverse(resp))
+    {
+        for (const auto& interfaceMap : objectPath.second)
+        {
+            if (interfaceMap.first == "xyz.openbmc_project.Logging.Entry")
+            {
+                if (doUpdateErrorLoggingEntry(taskData, index,
+                                              interfaceMap.second))
+                {
+                    return;
+                }
+            }
+        }
+    }
+}
+
+inline void
+    updateErrorLogMessage(const std::shared_ptr<task::TaskData>& taskData,
+                          const std::string& index)
+{
+    sdbusplus::message::object_path path("/xyz/openbmc_project/logging");
+
+    dbus::utility::getManagedObjects(
+        "xyz.openbmc_project.Logging", path,
+        std::bind_front(afterUpdateErrorLogMessage, taskData, index));
 }
 
 // Note that asyncResp can be either a valid pointer or nullptr. If nullptr
@@ -180,8 +291,7 @@ static void
                             {
                                 taskData->state = "Exception";
                                 taskData->status = "Warning";
-                                taskData->messages.emplace_back(
-                                    messages::taskAborted(index));
+                                updateErrorLogMessage(taskData, index);
                                 return task::completed;
                             }
 

--- a/scripts/update_schemas.py
+++ b/scripts/update_schemas.py
@@ -147,6 +147,7 @@ oem_schema_names = [
     "OemComputerSystem",
     "OemVirtualMedia",
     "OpenBMCAccountService",
+    "OemMessage",
     "OemUpdateService",
 ]
 

--- a/static/redfish/v1/$metadata/index.xml
+++ b/static/redfish/v1/$metadata/index.xml
@@ -3952,6 +3952,10 @@
         <edmx:Include Namespace="OpenBMCAccountService"/>
         <edmx:Include Namespace="OpenBMCAccountService.v1_0_0"/>
     </edmx:Reference>
+    <edmx:Reference Uri="/redfish/v1/schema/OemMessage_v1.xml">
+        <edmx:Include Namespace="OemMessage"/>
+        <edmx:Include Namespace="OemMessage.v1_0_0"/>
+    </edmx:Reference>
     <edmx:Reference Uri="/redfish/v1/schema/OemUpdateService_v1.xml">
         <edmx:Include Namespace="OemUpdateService"/>
         <edmx:Include Namespace="OemUpdateService.v1_0_0"/>

--- a/static/redfish/v1/JsonSchemas/OemMessage/OemMessage.json
+++ b/static/redfish/v1/JsonSchemas/OemMessage/OemMessage.json
@@ -1,0 +1,86 @@
+{
+    "$id": "http://redfish.dmtf.org/schemas/v1/OemMessage.v1_0_0.json",
+    "$schema": "http://redfish.dmtf.org/schemas/v1/redfish-schema-v1.json",
+    "copyright": "Copyright 2014-2019 DMTF. For the full DMTF copyright policy, see http://www.dmtf.org/about/policies/copyright",
+    "definitions": {
+        "Oem": {
+            "additionalProperties": true,
+            "description": "OemMessage Oem properties.",
+            "patternProperties": {
+                "^([a-zA-Z_][a-zA-Z0-9_]*)?@(odata|Redfish|Message)\\.[a-zA-Z_][a-zA-Z0-9_]*$": {
+                    "description": "This property shall specify a valid odata or Redfish property.",
+                    "type": [
+                        "array",
+                        "boolean",
+                        "integer",
+                        "number",
+                        "null",
+                        "object",
+                        "string"
+                    ]
+                }
+            },
+            "properties": {
+                "OpenBmc": {
+                    "anyOf": [
+                        {
+                            "$ref": "#/definitions/OpenBmc"
+                        },
+                        {
+                            "type": "null"
+                        }
+                    ]
+                }
+            },
+            "type": "object"
+        },
+        "OpenBmc": {
+            "additionalProperties": true,
+            "description": "Oem properties for OpenBmc.",
+            "patternProperties": {
+                "^([a-zA-Z_][a-zA-Z0-9_]*)?@(odata|Redfish|Message)\\.[a-zA-Z_][a-zA-Z0-9_]*$": {
+                    "description": "This property shall specify a valid odata or Redfish property.",
+                    "type": [
+                        "array",
+                        "boolean",
+                        "integer",
+                        "number",
+                        "null",
+                        "object",
+                        "string"
+                    ]
+                }
+            },
+            "properties": {
+                "AbortReason": {
+                    "description": "Reason oem for message",
+                    "longDescription": "An extra property for Message to provide more information to the user",
+                    "type": [
+                        "string",
+                        "null"
+                    ]
+                },
+                "AdditionalData": {
+                    "description": "Reason oem for message",
+                    "longDescription": "An extra property for Message to provide more information to the user",
+                    "type": [
+                        "string",
+                        "null"
+                    ]
+                },
+                "EventId": {
+                    "description": "Reason oem for message",
+                    "longDescription": "An extra property for Message to provide more information to the user",
+                    "type": [
+                        "string",
+                        "null"
+                    ]
+                }
+            },
+            "type": "object"
+        }
+    },
+    "owningEntity": "OpenBMC",
+    "release": "1.0",
+    "title": "#OemMessage.v1_0_0"
+}

--- a/static/redfish/v1/schema/OemMessage_v1.xml
+++ b/static/redfish/v1/schema/OemMessage_v1.xml
@@ -1,0 +1,54 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<edmx:Edmx xmlns:edmx="http://docs.oasis-open.org/odata/ns/edmx" Version="4.0">
+
+  <edmx:Reference Uri="http://docs.oasis-open.org/odata/odata/v4.0/errata03/csd01/complete/vocabularies/Org.OData.Core.V1.xml">
+    <edmx:Include Namespace="Org.OData.Core.V1" Alias="OData"/>
+  </edmx:Reference>
+  <edmx:Reference Uri="http://redfish.dmtf.org/schemas/v1/RedfishExtensions_v1.xml">
+    <edmx:Include Namespace="RedfishExtensions.v1_0_0" Alias="Redfish"/>
+  </edmx:Reference>
+  <edmx:Reference Uri="http://redfish.dmtf.org/schemas/v1/Message.xml">
+    <edmx:Include Namespace="Message"/>
+    <edmx:Include Namespace="Message.v1_1_2"/>
+  </edmx:Reference>
+  <edmx:Reference Uri="http://redfish.dmtf.org/schemas/v1/Resource_v1.xml">
+    <edmx:Include Namespace="Resource"/>
+    <edmx:Include Namespace="Resource.v1_0_0"/>
+  </edmx:Reference>
+
+  <edmx:DataServices>
+    <Schema xmlns="http://docs.oasis-open.org/odata/ns/edm" Namespace="OemMessage">
+      <Annotation Term="Redfish.OwningEntity" String="OpenBMC"/>
+    </Schema>
+
+    <Schema xmlns="http://docs.oasis-open.org/odata/ns/edm" Namespace="OemMessage.v1_0_0">
+      <Annotation Term="Redfish.OwningEntity" String="OpenBMC"/>
+
+      <ComplexType Name="Oem" BaseType="Resource.OemObject">
+        <Annotation Term="OData.AdditionalProperties" Bool="true"/>
+        <Annotation Term="OData.Description" String="OemMessage Oem properties."/>
+        <Annotation Term="OData.AutoExpand"/>
+        <Property Name="OpenBMC" Type="OemMessage.OpenBMC"/>
+      </ComplexType>
+
+      <ComplexType Name="OpenBMC">
+        <Annotation Term="OData.AdditionalProperties" Bool="true" />
+        <Annotation Term="OData.Description" String="Oem properties for OpenBMC." />
+        <Annotation Term="OData.AutoExpand" />
+        <Property Name="AbortReason" Type="Edm.String">
+          <Annotation Term="OData.Description" String="String indicating the reason for exception."/>
+          <Annotation Term="OData.LongDescription" String="Unique string that provides reason for exception."/>
+        </Property>
+        <Property Name="AdditionalData" Type="Edm.String">
+          <Annotation Term="OData.Description" String="String indicating the reason for exception."/>
+          <Annotation Term="OData.LongDescription" String="Unique string that provides reason for exception."/>
+        </Property>
+        <Property Name="EventId" Type="Edm.String">
+          <Annotation Term="OData.Description" String="String indicating the reason for exception."/>
+          <Annotation Term="OData.LongDescription" String="Unique string that provides reason for exception."/>
+        </Property>
+      </ComplexType>
+    </Schema>
+  </edmx:DataServices>
+
+</edmx:Edmx>


### PR DESCRIPTION
This commit adds the Message OEM that will display error log information to taskAbort. This addition will allow users to see the exact error that caused the code update failure.

Tested:
- Ensured that upon code update failure, the task message includes the populated OEM with the relevant information.

```
{
  "@odata.id": "/redfish/v1/TaskService/Tasks/0",
  "@odata.type": "#Task.v1_4_3.Task",
  "EndTime": "2022-05-11T17:01:15+00:00",
  "Id": "0",
  "Messages": [
    {
      "@odata.type": "#Message.v1_0_0.Message",
      "Message": "The task with id 0 has started.",
      "MessageArgs": [
        "0"
      ],
      "MessageId": "TaskEvent.1.0.1.TaskStarted",
      "Resolution": "None.",
      "Severity": "OK"
    },
    {
      "@odata.type": "#Message.v1_0_0.Message",
      "Message": "The task with id 0 has been aborted.",
      "MessageArgs": [
...
      ],
      "MessageId": "TaskEvent.1.0.1.TaskAborted",
      "Oem": {
        "OpenBMC": {
          "@odata.type": "#OemMessage.v1_0_0.Message",
          "AbortReason": "xyz.openbmc_project.Software.Version.Error.ExpiredAccessKey",
          "AdditionalData": "BUILD_ID=20220722 EXP_DATE=20220515 _PID=598 ",
          "EventId": "BD8D3608 00080055 2E330010 00000000 00000000 00000000 00000000 00000000 00000000"
        }
      },
      "Resolution": "None.",
      "Severity": "Critical"
    }
  ],
  "Name": "Task 0",
...
  "TaskMonitor": "/redfish/v1/TaskService/Tasks/0/Monitor",
  "TaskState": "Exception",
  "TaskStatus": "Warning"
}
```

Excerpt from validation pass:
```
Schema file OemMessage_v1.xml not found in ./SchemaFiles/metadata
Attempt 1 of /redfish/v1/schema/OemMessage_v1.xml
Response Time for GET to /redfish/v1/schema/OemMessage_v1.xml: 0.010929436422884464 seconds.
Writing online XML to file: OemMessage_v1.xml
```

Change-Id: Id0cdeb0887a7dfed54b0b2c41b0312fca6593110