### PR TITLE
Unauthorized ACF certificate upload (#243)

### DIFF
--- a/include/authentication.hpp
+++ b/include/authentication.hpp
@@ -236,6 +236,16 @@ static std::shared_ptr<persistent_data::UserSession>
         }
     }
 
+    // This patch is allowed for service user, without authorization to upload
+    // unauthenticated ACF.
+    if (boost::beast::http::verb::patch == method)
+    {
+        if (url == "/redfish/v1/AccountService/Accounts/service")
+        {
+            return true;
+        }
+    }
+
     // it's allowed to POST on session collection & login without
     // authentication
     if (boost::beast::http::verb::post == method)


### PR DESCRIPTION
This commit implements the change where, when OpPanel function 74 is active, an unauthorized agent is allowed to PATCH in the ACF.

The following command without creating a session has been to test the functionality.
```
curl  -k -X PATCH -d '{"Oem":{"IBM":{"ACF":{"ACFFile":"'${service_acf_base64}'"}}}}'
https://${BMC}/redfish/v1/AccountService/Accounts/service
```

In case function 74 is active this should allow to patch ACF crtificate otherwise gives following insufficient privilege message

```
{
  "error": {
    "@Message.ExtendedInfo": [
      {
        "@odata.type": "#Message.v1_1_1.Message",
        "Message": "There are insufficient privileges for the account or credentials associated with the current session to perform the requested operation.",
        "MessageArgs": [],
        "MessageId": "Base.1.8.1.InsufficientPrivilege",
        "MessageSeverity": "Critical",
        "Resolution": "Either abandon the operation or change the associated access rights and resubmit the request if the operation failed."
      }
    ],
    "code": "Base.1.8.1.InsufficientPrivilege",
    "message": "There are insufficient privileges for the account or credentials associated with the current session to perform the requested operation."
  }
}
```
