### PR TITLE
Rebase fabric adapter and  chassis 

### DIFF
--- a/include/dbus_utility.hpp
+++ b/include/dbus_utility.hpp
@@ -83,6 +83,9 @@ using DBusInterfacesMap =
 using ManagedObjectType =
     std::vector<std::pair<sdbusplus::message::object_path, DBusInterfacesMap>>;
 
+// List of interfaces
+using InterfaceList = std::vector<std::string>;
+
 // Map of service name to list of interfaces
 using MapperServiceMap =
     std::vector<std::pair<std::string, std::vector<std::string>>>;

--- a/redfish-core/lib/chassis.hpp
+++ b/redfish-core/lib/chassis.hpp
@@ -508,8 +508,6 @@ inline void handleChassisGetSubTree(
             .jsonValue["Actions"]["#Chassis.Reset"]["@Redfish.ActionInfo"] =
             boost::urls::format("/redfish/v1/Chassis/{}/ResetActionInfo",
                                 chassisId);
-        asyncResp->res.jsonValue["PCIeDevices"]["@odata.id"] =
-            "/redfish/v1/Systems/system/PCIeDevices";
         asyncResp->res.jsonValue["PCIeSlots"]["@odata.id"] =
             boost::urls::format("/redfish/v1/Chassis/{}/PCIeSlots", chassisId);
 


### PR DESCRIPTION
Link Fabric adapter to PCIeDevice schema: 
This commit implement changes to populate link to PCIeDevice schema in
case the given Fabric adapter also implements PCIeDevice interface.

Remove link from Chassis to PCIeDevice:
The commit removes current support that assumes 1:1
system:Chassis for Chassis/PCIeDevices.