### PR TITLE
1110: Add ibm/v1 route features

### DIFF
--- a/include/ibm/locks.hpp
+++ b/include/ibm/locks.hpp
@@ -258,7 +258,7 @@ inline RcAcquireLock Lock::acquireLock(const LockRequests& lockRequestStructure)
 
     if (status)
     {
-        BMCWEB_LOG_DEBUG("There is a conflict within itself");
+        BMCWEB_LOG_ERROR("There is a conflict within itself");
         return std::make_pair(true, std::make_pair(status, 1));
     }
     BMCWEB_LOG_DEBUG("The request is not conflicting within itself");
@@ -539,6 +539,7 @@ inline bool Lock::isConflictRecord(const LockRequest& refLockRecord1,
     }
 
     uint32_t i = 0;
+    uint32_t segStartIndex = 0;
     for (const auto& p : std::get<4>(refLockRecord1))
     {
         // return conflict when any of them is try to lock all resources
@@ -574,24 +575,21 @@ inline bool Lock::isConflictRecord(const LockRequest& refLockRecord1,
         }
 
         // compare segment data
-
-        for (uint32_t j = 0; j < p.second; j++)
+        for (uint32_t segLenItr = 0; segLenItr < p.second; segLenItr++)
         {
-            // if the segment data is different, then the locks is on a
-            // different resource so no conflict between the lock
-            // records.
-            // BMC is little endian, but the resourceID is formed by
-            // the Management Console in such a way that, the first byte
-            // from the MSB Position corresponds to the First Segment
-            // data. Therefore we need to convert the incoming
-            // resourceID into Big Endian before processing further.
-            if (!(checkByte(
-                    boost::endian::endian_reverse(std::get<3>(refLockRecord1)),
-                    boost::endian::endian_reverse(std::get<3>(refLockRecord2)),
-                    j)))
+            for (uint32_t segItr = segStartIndex;
+                 segItr < segStartIndex + p.second; segItr++)
             {
-                return false;
+                if (!(checkByte(boost::endian::endian_reverse(
+                                    std::get<3>(refLockRecord1)),
+                                boost::endian::endian_reverse(
+                                    std::get<3>(refLockRecord2)),
+                                segItr)))
+                {
+                    return false;
+                }
             }
+            segStartIndex = segStartIndex + p.second;
         }
 
         ++i;

--- a/test/include/ibm/configfile_test.cpp
+++ b/test/include/ibm/configfile_test.cpp
@@ -16,40 +16,44 @@ namespace ibm_mc
 
 TEST(IsValidConfigFileName, FileNameValidCharReturnsTrue)
 {
-    crow::Response res;
-
-    EXPECT_TRUE(isValidConfigFileName("GoodConfigFile", res));
+    auto asyncResp = std::make_shared<bmcweb::AsyncResp>();
+    EXPECT_TRUE(
+        isValidConfigFileName("GoodConfigFile", asyncResp->res.jsonValue));
 }
 TEST(IsValidConfigFileName, FileNameInvalidCharReturnsFalse)
 {
-    crow::Response res;
+    auto asyncResp = std::make_shared<bmcweb::AsyncResp>();
 
-    EXPECT_FALSE(isValidConfigFileName("Bad@file", res));
+    EXPECT_FALSE(isValidConfigFileName("Bad@file", asyncResp->res.jsonValue));
 }
 TEST(IsValidConfigFileName, FileNameInvalidPathReturnsFalse)
 {
-    crow::Response res;
+    auto asyncResp = std::make_shared<bmcweb::AsyncResp>();
 
-    EXPECT_FALSE(isValidConfigFileName("/../../../../../etc/badpath", res));
-    EXPECT_FALSE(isValidConfigFileName("/../../etc/badpath", res));
-    EXPECT_FALSE(isValidConfigFileName("/mydir/configFile", res));
+    EXPECT_FALSE(isValidConfigFileName("/../../../../../etc/badpath",
+                                       asyncResp->res.jsonValue));
+    EXPECT_FALSE(
+        isValidConfigFileName("/../../etc/badpath", asyncResp->res.jsonValue));
+    EXPECT_FALSE(
+        isValidConfigFileName("/mydir/configFile", asyncResp->res.jsonValue));
 }
 
 TEST(IsValidConfigFileName, EmptyFileNameReturnsFalse)
 {
-    crow::Response res;
-    EXPECT_FALSE(isValidConfigFileName("", res));
+    auto asyncResp = std::make_shared<bmcweb::AsyncResp>();
+    EXPECT_FALSE(isValidConfigFileName("", asyncResp->res.jsonValue));
 }
 
 TEST(IsValidConfigFileName, SlashFileNameReturnsFalse)
 {
-    crow::Response res;
-    EXPECT_FALSE(isValidConfigFileName("/", res));
+    auto asyncResp = std::make_shared<bmcweb::AsyncResp>();
+    EXPECT_FALSE(isValidConfigFileName("/", asyncResp->res.jsonValue));
 }
 TEST(IsValidConfigFileName, FileNameMoreThan20CharReturnsFalse)
 {
-    crow::Response res;
-    EXPECT_FALSE(isValidConfigFileName("BadfileBadfileBadfile", res));
+    auto asyncResp = std::make_shared<bmcweb::AsyncResp>();
+    EXPECT_FALSE(isValidConfigFileName("BadfileBadfileBadfile",
+                                       asyncResp->res.jsonValue));
 }
 
 } // namespace ibm_mc


### PR DESCRIPTION
    This commit adds all the usecases of /ibm/v1
    1. ConfigFile multipart update
    2. Lock management fixes
    3. SignCSR feature for VMI interface
    4. Broadcast message event