### PR TITLE
1060: Fix coredump and ifmatch etag handling

### DIFF
--- a/http/app.hpp
+++ b/http/app.hpp
@@ -66,10 +66,9 @@ class App
     }
 
     void handle(Request& req,
-                const std::shared_ptr<bmcweb::AsyncResp>& asyncResp,
-                bool bypassAuth = false)
+                const std::shared_ptr<bmcweb::AsyncResp>& asyncResp)
     {
-        router.handle(req, asyncResp, bypassAuth);
+        router.handle(req, asyncResp);
     }
 
     DynamicRule& routeDynamic(std::string&& rule)

--- a/http/http_response.hpp
+++ b/http/http_response.hpp
@@ -181,11 +181,6 @@ struct Response
 
     void end()
     {
-        std::string etag = computeEtag();
-        if (!etag.empty())
-        {
-            addHeader(boost::beast::http::field::etag, etag);
-        }
         if (completed)
         {
             BMCWEB_LOG_ERROR << this << " Response was ended twice";

--- a/http/routing.hpp
+++ b/http/routing.hpp
@@ -1460,7 +1460,7 @@ class Router
         std::string username = req.session->username;
 
         crow::connections::systemBus->async_method_call(
-            [&req, asyncResp, &rule, params](
+            [req{std::move(req)}, asyncResp, &rule, params](
                 const boost::system::error_code ec,
                 const dbus::utility::DBusPropertiesMap& userInfoMap) mutable {
             if (ec)

--- a/http/routing.hpp
+++ b/http/routing.hpp
@@ -1395,8 +1395,7 @@ class Router
     }
 
     void handle(Request& req,
-                const std::shared_ptr<bmcweb::AsyncResp>& asyncResp,
-                bool bypassAuth = false)
+                const std::shared_ptr<bmcweb::AsyncResp>& asyncResp)
     {
         std::optional<HttpVerb> verb = httpVerbFromBoost(req.method());
         if (!verb || static_cast<size_t>(*verb) >= perMethods.size())
@@ -1453,7 +1452,7 @@ class Router
                          << static_cast<uint32_t>(*verb) << " / "
                          << rule.getMethods();
 
-        if (req.session == nullptr || bypassAuth)
+        if (req.session == nullptr)
         {
             rule.handle(req, asyncResp, params);
             return;

--- a/redfish-core/include/query.hpp
+++ b/redfish-core/include/query.hpp
@@ -48,7 +48,7 @@ inline void
     // Restart the request without if-match
     req.req.erase(boost::beast::http::field::if_match);
     BMCWEB_LOG_DEBUG << "Restarting request";
-    app.handle(req, asyncResp, true);
+    app.handle(req, asyncResp);
 }
 
 inline bool handleIfMatch(crow::App& app, const crow::Request& req,
@@ -97,7 +97,7 @@ inline bool handleIfMatch(crow::App& app, const crow::Request& req,
     getReqAsyncResp->res.setCompleteRequestHandler(std::bind_front(
         afterIfMatchRequest, std::ref(app), asyncResp, req, ifMatch));
 
-    app.handle(newReq, getReqAsyncResp, true);
+    app.handle(newReq, getReqAsyncResp);
     return false;
 }
 


### PR DESCRIPTION
Fix coredump and ifmatch etag handling

redfishtool PATCH may fail etag matching because bmcweb may return the
duplicated Etags on GET, and push it back on redfishtool PATCH call.

In addition, it may also cause bmcweb to coredump depending on timing
of  `validatePrivilege` execution. It is because `req' is captured as
reference, and it may be cleared-up before async-call method completes.
(This problem can be seen more frequently by enabling debug mode).

This commit is to put only one Etag on http_response on GET, and keep
`req` during to async-method execution.

Tested:

- Create a ReadOnly user - here, called as `readonly`
- Check the duplicated Etag on GET, and check it after fix

Before:
```
$ curl -v -k -X GET https://admin:${password}@${bmc}:18080/redfish/v1/AccountService/Accounts/readonly
...
< ETag: "D4B30BB4"
< ETag: "D4B30BB4"
```

After:
```
$ curl -v -k -X GET https://admin:${password}@${bmc}:18080/redfish/v1/AccountService/Accounts/readonly
...
< ETag: "D4B30BB4"
```

- Using `redfishtool`, run PATCH on `readonly` user role.

Before:
```
$ redfishtool  -vvvvv raw -r ${bmc}:18080 -u ${user} -p ${password} -S Always PATCH /redfish/v1/AccountService/Accounts/readonly --data='{"RoleId":"Administrator"}'
...

  redfishtool: Transport: Response Error: status_code: 412 -- Precondition Failed
```

After:

```
$ redfishtool  raw -r ${bmc}:18080 -u ${user} -p ${password} -S Always PATCH /redfish/v1/AccountService/Accounts/readonly --data='{"RoleId":"Administrator"}'
{
    "@odata.id": "/redfish/v1/AccountService/Accounts/readonly",
    "@odata.type": "#ManagerAccount.v1_7_0.ManagerAccount",
    ...
}
```

Change-Id: I5361919c5671b546181a26de792bc57de2c4f670
Change-Id: I2a28d1743cfc0fbd9239f69dec5584b34c7ebe43
