### PR TITLE
redfish: bump Role to v1_3_0

### DIFF
--- a/redfish-core/lib/roles.hpp
+++ b/redfish-core/lib/roles.hpp
@@ -121,7 +121,7 @@ inline void requestRoutesRoles(App& app)
             return;
         }
 
-        asyncResp->res.jsonValue["@odata.type"] = "#Role.v1_2_2.Role";
+        asyncResp->res.jsonValue["@odata.type"] = "#Role.v1_3_0.Role";
         asyncResp->res.jsonValue["Name"] = "User Role";
         asyncResp->res.jsonValue["OemPrivileges"] = std::move(oemPrivArray);
         asyncResp->res.jsonValue["IsPredefined"] = true;


### PR DESCRIPTION
https://github.com/ibm-openbmc/bmcweb/commit/06b023e584291b4b93f6c856692842736a796ab2 is the original commit 

ERROR - Restricted not defined in schema Role.v1_2_2 is the error 

This is required for the new "Restricted" property.

The comment on the spreadsheet was "This should either be done upstream or added as a part of whichever downstream commit utilizes the new Restricted property in v1.3". 
I think this was just missed. 
I updated the spreadsheet 

Seeing Validator errors because of this.