### PR TITLE
1110: Fix coredump and ifmatch etag handling

### DIFF
--- a/http/http_response.hpp
+++ b/http/http_response.hpp
@@ -270,11 +270,6 @@ struct Response
 
     void end()
     {
-        std::string etag = computeEtag();
-        if (!etag.empty())
-        {
-            addHeader(http::field::etag, etag);
-        }
         if (completed)
         {
             BMCWEB_LOG_ERROR("{} Response was ended twice", logPtr(this));

--- a/include/dbus_privileges.hpp
+++ b/include/dbus_privileges.hpp
@@ -150,7 +150,8 @@ void validatePrivilege(Request& req,
     }
     std::string username = req.session->username;
     crow::connections::systemBus->async_method_call(
-        [&req, asyncResp, &rule, callback(std::forward<CallbackFn>(callback))](
+        [req{std::move(req)}, asyncResp, &rule,
+         callback(std::forward<CallbackFn>(callback))](
             const boost::system::error_code& ec,
             const dbus::utility::DBusPropertiesMap& userInfoMap) mutable {
         afterGetUserInfo(req, asyncResp, rule,


### PR DESCRIPTION
Fix coredump and ifmatch etag handling

redfishtool PATCH may fail etag matching because bmcweb may return the
duplicated Etags on GET, and push it back on redfishtool PATCH call.

In addition, it may also cause bmcweb to coredump depending on timing
of  `validatePrivilege` execution. It is because `req' is captured as
reference, and it may be cleared-up before async-call method completes.
(This problem can be seen more frequently by enabling debug mode).

This commit is to put only one Etag on http_response on GET, and keep
`req` during to async-method execution.

Tested:

- Create a ReadOnly user - here, called as `readonly`
- Check the duplicated Etag on GET, and check it after fix

Before:
```
$ curl -v -k -X GET https://admin:${password}@${bmc}:18080/redfish/v1/AccountService/Accounts/readonly
...
< ETag: "D4B30BB4"
< ETag: "D4B30BB4"
```

After:
```
$ curl -v -k -X GET https://admin:${password}@${bmc}:18080/redfish/v1/AccountService/Accounts/readonly
...
< ETag: "D4B30BB4"
```

- Using `redfishtool`, run PATCH on `readonly` user role.

Before:
```
$ redfishtool  -vvvvv raw -r ${bmc}:18080 -u ${user} -p ${password} -S Always PATCH /redfish/v1/AccountService/Accounts/readonly --data='{"RoleId":"Administrator"}'
...

  redfishtool: Transport: Response Error: status_code: 412 -- Precondition Failed
```

After:

```
$ redfishtool  raw -r ${bmc}:18080 -u ${user} -p ${password} -S Always PATCH /redfish/v1/AccountService/Accounts/readonly --data='{"RoleId":"Administrator"}'
{
    "@odata.id": "/redfish/v1/AccountService/Accounts/readonly",
    "@odata.type": "#ManagerAccount.v1_7_0.ManagerAccount",
    ...
}
```

Change-Id: I5361919c5671b546181a26de792bc57de2c4f670
Change-Id: I2a28d1743cfc0fbd9239f69dec5584b34c7ebe43