### PR TITLE
Redfish : Look for OperationalStatus for the memory Health

### DIFF
--- a/redfish-core/lib/memory.hpp
+++ b/redfish-core/lib/memory.hpp
@@ -424,6 +424,7 @@ inline void
     const std::string* sparePartNumber = nullptr;
     const std::string* model = nullptr;
     const std::string* locationCode = nullptr;
+    const bool* functional = nullptr;
 
     const bool success = sdbusplus::unpackPropertiesNoThrow(
         dbus_utils::UnpackErrorPrinter(), properties, "MemoryDataWidth",
@@ -436,7 +437,7 @@ inline void
         memoryConfiguredSpeedInMhz, "MemoryType", memoryType, "Channel",
         channel, "MemoryController", memoryController, "Slot", slot, "Socket",
         socket, "SparePartNumber", sparePartNumber, "Model", model,
-        "LocationCode", locationCode);
+        "LocationCode", locationCode, "Functional", functional);
 
     if (!success)
     {
@@ -597,6 +598,14 @@ inline void
     {
         asyncResp->res.jsonValue[jsonPtr]["Location"]["PartLocation"]
                                 ["ServiceLabel"] = *locationCode;
+    }
+
+    if (functional != nullptr)
+    {
+        if (!*functional)
+        {
+            asyncResp->res.jsonValue[jsonPtr]["Status"]["Health"] = "Critical";
+        }
     }
 
     getPersistentMemoryProperties(asyncResp, properties, jsonPtr);


### PR DESCRIPTION
Look for OperationalStatus for the memory Health.
When functional is false, health is critical.
When functional is true, health is ok.

Upstream link: https://gerrit.openbmc.org/c/openbmc/bmcweb/+/69859
Commit Id: Ifb7e4b5e6bfadd417122fda66ef3f6590ccc43b1

Tested: Validator passes.
Set the dimm0 OperationalStatus to false, and see the health:
```
curl -k -H "X-Auth-Token: $token" -X GET https://${bmc}/redfish/v1/Systems/system/Memory/dimm0
{
  "Status": {
    "Health": "Critical",
    "State": "Enabled"
  }
}
```