### PR TITLE
1110 environment metrics fan speeds percent

### DIFF
--- a/Redfish.md
+++ b/Redfish.md
@@ -228,6 +228,10 @@ Fields common to all schemas
 
 #### EnvironmentMetrics
 
+- FanSpeedsPercent/DataSourceUri
+- FanSpeedsPercent/DeviceName
+- FanSpeedsPercent/SpeedRPM
+
 ### /redfish/v1/Chassis/{ChassisId}/Power/
 
 #### Power

--- a/Redfish.md
+++ b/Redfish.md
@@ -231,6 +231,7 @@ Fields common to all schemas
 - FanSpeedsPercent/DataSourceUri
 - FanSpeedsPercent/DeviceName
 - FanSpeedsPercent/SpeedRPM
+- PowerLimitWatts
 - PowerWatts
 
 ### /redfish/v1/Chassis/{ChassisId}/Power/

--- a/Redfish.md
+++ b/Redfish.md
@@ -231,6 +231,7 @@ Fields common to all schemas
 - FanSpeedsPercent/DataSourceUri
 - FanSpeedsPercent/DeviceName
 - FanSpeedsPercent/SpeedRPM
+- PowerWatts
 
 ### /redfish/v1/Chassis/{ChassisId}/Power/
 

--- a/redfish-core/include/utils/fan_utils.hpp
+++ b/redfish-core/include/utils/fan_utils.hpp
@@ -1,0 +1,95 @@
+#pragma once
+
+#include "async_resp.hpp"
+#include "dbus_utility.hpp"
+#include "error_messages.hpp"
+
+#include <boost/system/error_code.hpp>
+
+#include <array>
+#include <memory>
+#include <optional>
+#include <string>
+#include <string_view>
+#include <utility>
+
+namespace redfish
+{
+namespace fan_utils
+{
+constexpr std::array<std::string_view, 1> fanInterface = {
+    "xyz.openbmc_project.Inventory.Item.Fan"};
+constexpr std::array<std::string_view, 1> sensorInterface = {
+    "xyz.openbmc_project.Sensor.Value"};
+
+template <typename Callback>
+inline void getFanSensorsObject(const std::string& fanPaths,
+                                Callback&& callback)
+{
+    sdbusplus::message::object_path endpointPath{fanPath};
+    endpointPath /= "all_sensors";
+
+    dbus::utility::getAssociatedSubTree(
+        endpointPath,
+        sdbusplus::message::object_path("/xyz/openbmc_project/inventory"), 0,
+        sensorInterface,
+        [asyncResp, callback{std::forward<Callback>(callback)}](
+            const boost::system::error_code& ec,
+            const dbus::utility::MapperGetSubTreeResponse& subtree) {
+        if (ec)
+        {
+            if (ec.value() != EBADR)
+            {
+                BMCWEB_LOG_ERROR(
+                    "DBUS response error for getAssociatedSubTree {}",
+                    ec.value());
+                messages::internalError(asyncResp->res);
+            }
+            return;
+        }
+
+        std::vector<std::pair<std::string, std::string>> serviceAndSensorPaths;
+        for (const auto& [sensorPath, serviceMaps] : subtree)
+        {
+            for (const auto& [service, interfaces] : serviceMaps)
+            {
+                std::pair<std::string, std::string> pair{service, sensorPath};
+                serviceAndSensorPaths.emplace_back(pair);
+            }
+        }
+        callback(std::move(serviceAndSensorPaths));
+    });
+}
+
+template <typename Callback>
+inline void getFanPaths(const std::shared_ptr<bmcweb::AsyncResp>& asyncResp,
+                        const std::optional<std::string>& validChassisPath,
+                        Callback&& callback)
+{
+    sdbusplus::message::object_path endpointPath{*validChassisPath};
+    endpointPath /= "cooled_by";
+
+    dbus::utility::getAssociatedSubTreePaths(
+        endpointPath,
+        sdbusplus::message::object_path("/xyz/openbmc_project/inventory"), 0,
+        fanInterface,
+        [asyncResp, callback{std::forward<Callback>(callback)}](
+            const boost::system::error_code& ec,
+            const dbus::utility::MapperGetSubTreePathsResponse& subtreePaths) {
+        if (ec)
+        {
+            if (ec.value() != EBADR)
+            {
+                BMCWEB_LOG_ERROR(
+                    "DBUS response error for getAssociatedSubTreePaths {}",
+                    ec.value());
+                messages::internalError(asyncResp->res);
+            }
+            return;
+        }
+        callback(subtreePaths);
+    });
+}
+
+} // namespace fan_utils
+} // namespace redfish

--- a/redfish-core/lib/environment_metrics.hpp
+++ b/redfish-core/lib/environment_metrics.hpp
@@ -120,6 +120,85 @@ inline void handleEnvironmentMetricsHead(
                                                 std::move(respHandler));
 }
 
+inline void getPowerWatts(const std::shared_ptr<bmcweb::AsyncResp>& asyncResp,
+                          const std::string& chassisId)
+{
+    constexpr std::array<std::string_view, 1> interfaces = {
+        "xyz.openbmc_project.Sensor.Value"};
+    dbus::utility::getSubTreePaths(
+        "/xyz/openbmc_project/sensors", 0, interfaces,
+        [asyncResp,
+         chassisId](const boost::system::error_code& ec,
+                    const dbus::utility::MapperGetSubTreePathsResponse& paths) {
+        if (ec)
+        {
+            if (ec.value() != EBADR)
+            {
+                BMCWEB_LOG_ERROR("DBUS response error for getSubTreePaths: {}",
+                                 ec.value());
+                messages::internalError(asyncResp->res);
+            }
+            return;
+        }
+        bool find = false;
+        for (const auto& tempPath : paths)
+        {
+            sdbusplus::message::object_path path(tempPath);
+            std::string leaf = path.filename();
+            if (leaf == "total_power")
+            {
+                find = true;
+                break;
+            }
+        }
+        if (!find)
+        {
+            BMCWEB_LOG_DEBUG("There is not total_power");
+            return;
+        }
+
+        dbus::utility::getDbusObject(
+            "/xyz/openbmc_project/sensors/power/total_power", {},
+            [asyncResp,
+             chassisId](const boost::system::error_code& ec1,
+                        const dbus::utility::MapperGetObject& object) {
+            if (ec1 || object.empty())
+            {
+                BMCWEB_LOG_ERROR("DBUS response error: {}", ec1.value());
+                messages::internalError(asyncResp->res);
+                return;
+            }
+
+            sdbusplus::asio::getProperty<double>(
+                *crow::connections::systemBus, object.begin()->first,
+                "/xyz/openbmc_project/sensors/power/total_power",
+                "xyz.openbmc_project.Sensor.Value", "Value",
+                [asyncResp, chassisId](const boost::system::error_code& ec2,
+                                       double value) {
+                if (ec2)
+                {
+                    if (ec2.value() != EBADR)
+                    {
+                        BMCWEB_LOG_ERROR("Can't get Power Watts! {}",
+                                         ec2.value());
+                        messages::internalError(asyncResp->res);
+                    }
+                    return;
+                }
+                asyncResp->res.jsonValue["PowerWatts"]["@odata.id"] =
+                    boost::urls::format(
+                        "/redfish/v1/Chassis/{}/Sensors/total_power",
+                        chassisId);
+                asyncResp->res.jsonValue["PowerWatts"]["DataSourceUri"] =
+                    boost::urls::format(
+                        "/redfish/v1/Chassis/{}/Sensors/total_power",
+                        chassisId);
+                asyncResp->res.jsonValue["PowerWatts"]["Reading"] = value;
+            });
+        });
+    });
+}
+
 inline void handleEnvironmentMetricsGet(
     App& app, const crow::Request& req,
     const std::shared_ptr<bmcweb::AsyncResp>& asyncResp,
@@ -149,6 +228,7 @@ inline void handleEnvironmentMetricsGet(
             "/redfish/v1/Chassis/{}/EnvironmentMetrics", chassisId);
 
         getFanSpeedsPercent(asyncResp, *validChassisPath, chassisId);
+        getPowerWatts(asyncResp, chassisId);
     };
 
     redfish::chassis_utils::getValidChassisPath(asyncResp, chassisId,

--- a/redfish-core/lib/environment_metrics.hpp
+++ b/redfish-core/lib/environment_metrics.hpp
@@ -1,18 +1,97 @@
 #pragma once
 
 #include "app.hpp"
+#include "dbus_utility.hpp"
+#include "error_messages.hpp"
 #include "query.hpp"
 #include "registries/privilege_registry.hpp"
+#include "str_utility.hpp"
 #include "utils/chassis_utils.hpp"
+#include "utils/fan_utils.hpp"
 
 #include <boost/url/format.hpp>
 
+#include <array>
+#include <functional>
 #include <memory>
 #include <optional>
 #include <string>
+#include <string_view>
 
 namespace redfish
 {
+inline void
+    updateFanSensorList(const std::shared_ptr<bmcweb::AsyncResp>& asyncResp,
+                        const std::string& chassisId,
+                        const std::string& fanSensorPath, double value)
+{
+    std::string fanSensorName =
+        sdbusplus::message::object_path(fanSensorPath).filename();
+    if (fanSensorName.empty())
+    {
+        messages::internalError(asyncResp->res);
+        return;
+    }
+
+    nlohmann::json::object_t item;
+    item["SensorFanArrayExcerpt"]["DataSourceUri"] = boost::urls::format(
+        "/redfish/v1/Chassis/{}/Sensors/{}", chassisId, fanSensorName);
+    item["SensorFanArrayExcerpt"]["DeviceName"] = "Chassis #" + fanSensorName;
+    item["SensorFanArrayExcerpt"]["SpeedRPM"] = value;
+
+    nlohmann::json& fanSensorList =
+        asyncResp->res.jsonValue["FanSpeedsPercent"];
+    fanSensorList.emplace_back(std::move(item));
+    std::sort(fanSensorList.begin(), fanSensorList.end(),
+              [](const nlohmann::json& c1, const nlohmann::json& c2) {
+        return c1["SensorFanArrayExcerpt"]["DataSourceUri"] <
+               c2["SensorFanArrayExcerpt"]["DataSourceUri"];
+    });
+    asyncResp->res.jsonValue["FanSpeedsPercent@odata.count"] =
+        fanSensorList.size();
+}
+
+inline void
+    getFanSensorValues(const std::shared_ptr<bmcweb::AsyncResp>& asyncResp,
+                       const std::string& chassisId,
+                       const std::vector<std::pair<std::string, std::string>>&
+                           serviceAndSensorPaths)
+{
+    for (const auto& [service, path] : serviceAndSensorPaths)
+    {
+        sdbusplus::asio::getProperty<double>(
+            *crow::connections::systemBus, service, path,
+            "xyz.openbmc_project.Sensor.Value", "Value",
+            [asyncResp, chassisId, path](const boost::system::error_code& ec,
+                                         double value) {
+            if (ec)
+            {
+                BMCWEB_LOG_ERROR(
+                    "D-Bus response error for getFanSensorValues {}",
+                    ec.value());
+                messages::internalError(asyncResp->res);
+                return;
+            }
+
+            updateFanSensorList(asyncResp, chassisId, path, value);
+        });
+    }
+}
+
+inline void
+    getFanSpeedsPercent(const std::shared_ptr<bmcweb::AsyncResp>& asyncResp,
+                        const std::string& validChassisPath,
+                        const std::string& chassisId)
+{
+    redfish::fan_utils::getFanPaths(
+        asyncResp, validChassisPath,
+        [asyncResp, chassisId](
+            const dbus::utility::MapperGetSubTreePathsResponse& fanPaths) {
+        redfish::fan_utils::getFanSensorsObjects(
+            asyncResp, fanPaths,
+            std::bind_front(getFanSensorValues, asyncResp, chassisId));
+    });
+}
 
 inline void handleEnvironmentMetricsHead(
     App& app, const crow::Request& req,
@@ -68,6 +147,8 @@ inline void handleEnvironmentMetricsGet(
         asyncResp->res.jsonValue["Id"] = "EnvironmentMetrics";
         asyncResp->res.jsonValue["@odata.id"] = boost::urls::format(
             "/redfish/v1/Chassis/{}/EnvironmentMetrics", chassisId);
+
+        getFanSpeedsPercent(asyncResp, *validChassisPath, chassisId);
     };
 
     redfish::chassis_utils::getValidChassisPath(asyncResp, chassisId,

--- a/redfish-core/lib/environment_metrics.hpp
+++ b/redfish-core/lib/environment_metrics.hpp
@@ -199,6 +199,133 @@ inline void getPowerWatts(const std::shared_ptr<bmcweb::AsyncResp>& asyncResp,
     });
 }
 
+inline void
+    setPowerSetPoint(const std::shared_ptr<bmcweb::AsyncResp>& asyncResp,
+                     uint32_t powerCap)
+{
+    BMCWEB_LOG_DEBUG("Set Power Limit Watts Set Point");
+
+    sdbusplus::asio::setProperty(
+        *crow::connections::systemBus, "xyz.openbmc_project.Settings",
+        "/xyz/openbmc_project/control/host0/power_cap",
+        "xyz.openbmc_project.Control.Power.Cap", "PowerCap", powerCap,
+        [asyncResp](const boost::system::error_code& ec) {
+        if (ec)
+        {
+            if (ec.value() != EBADR)
+            {
+                BMCWEB_LOG_ERROR("Failed to set PowerCap: {}", ec.value());
+                messages::internalError(asyncResp->res);
+            }
+            return;
+        }
+    });
+}
+
+inline void
+    setPowerControlMode(const std::shared_ptr<bmcweb::AsyncResp>& asyncResp,
+                        const std::string& controlMode)
+{
+    BMCWEB_LOG_DEBUG("Set Power Limit Watts Control Mode");
+    bool powerCapEnable = false;
+    if (controlMode == "Disabled")
+    {
+        powerCapEnable = false;
+    }
+    else if (controlMode == "Automatic")
+    {
+        powerCapEnable = true;
+    }
+    else
+    {
+        BMCWEB_LOG_DEBUG("Power Control Mode  does not support this mode: {}",
+                         controlMode);
+        messages::propertyValueNotInList(asyncResp->res, controlMode,
+                                         "ControlMode");
+        return;
+    }
+
+    sdbusplus::asio::setProperty(
+        *crow::connections::systemBus, "xyz.openbmc_project.Settings",
+        "/xyz/openbmc_project/control/host0/power_cap",
+        "xyz.openbmc_project.Control.Power.Cap", "PowerCapEnable",
+        powerCapEnable, [asyncResp](const boost::system::error_code& ec) {
+        if (ec)
+        {
+            if (ec.value() != EBADR)
+            {
+                BMCWEB_LOG_ERROR("Failed to set PowerCapEnable: {}",
+                                 ec.value());
+                messages::internalError(asyncResp->res);
+            }
+            return;
+        }
+    });
+}
+
+inline void
+    getPowerLimitWatts(const std::shared_ptr<bmcweb::AsyncResp>& asyncResp)
+{
+    sdbusplus::asio::getAllProperties(
+        *crow::connections::systemBus, "xyz.openbmc_project.Settings",
+        "/xyz/openbmc_project/control/host0/power_cap",
+        "xyz.openbmc_project.Control.Power.Cap",
+        [asyncResp](const boost::system::error_code& ec,
+                    const dbus::utility::DBusPropertiesMap& propertiesList) {
+        if (ec)
+        {
+            if (ec.value() != EBADR)
+            {
+                messages::internalError(asyncResp->res);
+            }
+            return;
+        }
+
+        asyncResp->res.jsonValue["PowerLimitWatts"]["SetPoint"] = 0;
+        asyncResp->res.jsonValue["PowerLimitWatts"]["ControlMode"] =
+            "Automatic";
+
+        const uint32_t* powerCap = nullptr;
+        const bool* powerCapEnable = nullptr;
+        const uint32_t* minCap = nullptr;
+        const uint32_t* maxCap = nullptr;
+
+        const bool success = sdbusplus::unpackPropertiesNoThrow(
+            dbus_utils::UnpackErrorPrinter(), propertiesList, "PowerCap",
+            powerCap, "PowerCapEnable", powerCapEnable, "MinPowerCapValue",
+            minCap, "MaxPowerCapValue", maxCap);
+
+        if (!success)
+        {
+            messages::internalError(asyncResp->res);
+            return;
+        }
+
+        if (powerCap != nullptr)
+        {
+            asyncResp->res.jsonValue["PowerLimitWatts"]["SetPoint"] = *powerCap;
+        }
+
+        if (powerCapEnable != nullptr && !*powerCapEnable)
+        {
+            asyncResp->res.jsonValue["PowerLimitWatts"]["ControlMode"] =
+                "Disabled";
+        }
+
+        if (minCap != nullptr)
+        {
+            asyncResp->res.jsonValue["PowerLimitWatts"]["AllowableMin"] =
+                *minCap;
+        }
+
+        if (maxCap != nullptr)
+        {
+            asyncResp->res.jsonValue["PowerLimitWatts"]["AllowableMax"] =
+                *maxCap;
+        }
+    });
+}
+
 inline void handleEnvironmentMetricsGet(
     App& app, const crow::Request& req,
     const std::shared_ptr<bmcweb::AsyncResp>& asyncResp,
@@ -229,10 +356,63 @@ inline void handleEnvironmentMetricsGet(
 
         getFanSpeedsPercent(asyncResp, *validChassisPath, chassisId);
         getPowerWatts(asyncResp, chassisId);
+        getPowerLimitWatts(asyncResp);
     };
 
     redfish::chassis_utils::getValidChassisPath(asyncResp, chassisId,
                                                 std::move(respHandler));
+}
+
+inline void handleEnvironmentMetricsPatch(
+    App& app, const crow::Request& req,
+    const std::shared_ptr<bmcweb::AsyncResp>& asyncResp,
+    const std::string& chassisId)
+{
+    if (!redfish::setUpRedfishRoute(app, req, asyncResp))
+    {
+        return;
+    }
+
+    std::optional<nlohmann::json> powerLimitWatts;
+    if (!json_util::readJsonPatch(req, asyncResp->res, "PowerLimitWatts",
+                                  powerLimitWatts))
+    {
+        return;
+    }
+
+    if (!powerLimitWatts)
+    {
+        return;
+    }
+
+    std::optional<uint32_t> setPoint;
+    std::optional<std::string> controlMode;
+    if (!json_util::readJson(*powerLimitWatts, asyncResp->res, "SetPoint",
+                             setPoint, "ControlMode", controlMode))
+    {
+        return;
+    }
+
+    redfish::chassis_utils::getValidChassisPath(
+        asyncResp, chassisId,
+        [asyncResp, chassisId, setPoint,
+         controlMode](const std::optional<std::string>& validChassisPath) {
+        if (!validChassisPath)
+        {
+            messages::resourceNotFound(asyncResp->res, "Chassis", chassisId);
+            return;
+        }
+
+        if (setPoint)
+        {
+            setPowerSetPoint(asyncResp, *setPoint);
+        }
+
+        if (controlMode)
+        {
+            setPowerControlMode(asyncResp, *controlMode);
+        }
+    });
 }
 
 inline void requestRoutesEnvironmentMetrics(App& app)
@@ -246,6 +426,11 @@ inline void requestRoutesEnvironmentMetrics(App& app)
         .privileges(redfish::privileges::getEnvironmentMetrics)
         .methods(boost::beast::http::verb::get)(
             std::bind_front(handleEnvironmentMetricsGet, std::ref(app)));
+
+    BMCWEB_ROUTE(app, "/redfish/v1/Chassis/<str>/EnvironmentMetrics/")
+        .privileges(redfish::privileges::patchEnvironmentMetrics)
+        .methods(boost::beast::http::verb::patch)(
+            std::bind_front(handleEnvironmentMetricsPatch, std::ref(app)));
 }
 
 } // namespace redfish


### PR DESCRIPTION
1060: Redfish: Implement EnvironmentMetrics

- **Add FanSpeedsPercent**
  Upstream Link: https://gerrit.openbmc.org/c/openbmc/bmcweb/+/57715
  Changed-Id: I4cfc0aa28d68e7e0fa947251363deb6f06e36225
- **Add PowerWatts**
  Upstream Link: https://gerrit.openbmc.org/c/openbmc/bmcweb/+/57717
  Changed-Id: Ibe84a5e7fe0d2b232f925e457a094c021ca85d36
- **Add PowerLimitWantts:**
  Upstream Link: https://gerrit.openbmc.org/c/openbmc/bmcweb/+/47300
  Changed-Id: Iacd244e537ccab6572a0a55b7f30871774e097ff

upstream: https://gerrit.openbmc.org/q/topic:%22redfish-EnvironmentMetrics%22