### PR TITLE
Audit Log: Correct maximum full file download check

### DIFF
--- a/redfish-core/lib/log_services.hpp
+++ b/redfish-core/lib/log_services.hpp
@@ -7117,12 +7117,15 @@ inline void getFullAuditLogAttachment(
         return;
     }
 
-    // Max file size based on default configuration: 10MB
-    constexpr int maxFileSize = 10485760;
+    /* Max file size based on default configuration:
+     *   - Raw audit log: 10MB
+     *   - Allow up to 20MB to adjust for JSON metadata
+     */
+    constexpr int maxFileSize = 20971520;
     if (size > maxFileSize)
     {
-        BMCWEB_LOG_ERROR << "File size exceeds maximum allowed size of "
-                         << maxFileSize;
+        BMCWEB_LOG_ERROR << "File size " << size
+                         << " exceeds maximum allowed size of " << maxFileSize;
         messages::internalError(asyncResp->res);
         close(fd);
         return;


### PR DESCRIPTION
Full audit log file download was only allowing 10MB size file based on the raw audit log file limit. But that didn't account for the added metadata when the audit log entries are turned into JSON format. Adjusted maximum size to allow for this growth.

Tested:
  - Verified on system with 10MB of audit log data that full file download succeeds and easily fits in the allowed size.
  
Fixes: Defect 599496