### PR TITLE
Remove link from Chassis to PCIeDevice

### DIFF
--- a/Redfish.md
+++ b/Redfish.md
@@ -197,7 +197,6 @@ Fields common to all schemas
 - HotPluggable
 - Links/ComputerSystems
 - Links/ManagedBy
-- PCIeDevices
 - PCIeSlots
 - Power
   - Shall be included if component contains voltage/current sensing components,

--- a/redfish-core/lib/chassis.hpp
+++ b/redfish-core/lib/chassis.hpp
@@ -508,8 +508,6 @@ inline void handleChassisGetSubTree(
             .jsonValue["Actions"]["#Chassis.Reset"]["@Redfish.ActionInfo"] =
             boost::urls::format("/redfish/v1/Chassis/{}/ResetActionInfo",
                                 chassisId);
-        asyncResp->res.jsonValue["PCIeDevices"]["@odata.id"] =
-            "/redfish/v1/Systems/system/PCIeDevices";
         asyncResp->res.jsonValue["PCIeSlots"]["@odata.id"] =
             boost::urls::format("/redfish/v1/Chassis/{}/PCIeSlots", chassisId);
 


### PR DESCRIPTION
The commit removes current support that assumes 1:1 system:Chassis for Chassis/PCIeDevices.

Current implementation populates the same collection of PCIeDevices w.r.t chassis as w.r.t. system.
For systems with multiple chassis the current assumption does not hold true.
upstream-https://gerrit.openbmc.org/c/openbmc/bmcweb/+/56996

Test:
Validator has been executed with no new errors.

curl -k -H "X-Auth-Token: $bmc_token" -X GET https://${bmc}/redfish/v1/Chassis/chassis |grep "PCIeDevices"
  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                 Dload  Upload   Total   Spent    Left  Speed
100  1484  100  1484    0     0   1112      0  0:00:01  0:00:01 --:--:--  1120
%

Change-Id: I51d1c66dc41d0ebfe0cb4b3669385e594ab67a1f