### PR TITLE
Audit Log: Handle nullptr for message args

### DIFF
--- a/redfish-core/lib/log_services.hpp
+++ b/redfish-core/lib/log_services.hpp
@@ -6728,9 +6728,22 @@ static LogParseError
     // Fill the MessageArgs into the Message
     if (messageArgs.size() > 0)
     {
-        int i = 0;
+        if (messageArgs[0] != "USYS_CONFIG")
+        {
+            BMCWEB_LOG_WARNING << "Unexpected audit log entry type: "
+                               << messageArgs[0];
+        }
+
+        uint i = 0;
         for (auto messageArg : messageArgs)
         {
+            if (messageArg == nullptr)
+            {
+                BMCWEB_LOG_DEBUG << "Handle null messageArg";
+                messageArg = "";
+                messageArgs[i] = "";
+            }
+
             std::string argStr = "%" + std::to_string(++i);
             size_t argPos = msg.find(argStr);
             if (argPos != std::string::npos)


### PR DESCRIPTION
fillAuditLogEntryJson() expects a string for each MessageArgs entry. When one of the entries was a nullptr bmcweb would core dump.

Handle a nullptr by replacing it with an empty string.

Note: Root cause here is that the entry being returned by
      phosphor-auditlog is not of the expected type. Added a warning
      message for this case for future debugging.

Tested:
  Recreated core dump. Then using the same audit log source files
  confirmed the nullptr was correctly handled and no core dump happened.

Fixes: 600216

Fix for phosphor-auditlog also coded: https://github.com/ibm-openbmc/phosphor-logging/pull/51