### PR TITLE
1110: Add Get for PCIe properties LinkId (#578)

### DIFF
--- a/redfish-core/include/schemas.hpp
+++ b/redfish-core/include/schemas.hpp
@@ -133,5 +133,6 @@ namespace redfish
         "OpenBMCAccountService",
         "OemMessage",
         "OemUpdateService",
+        "OemPCIeSlots",
     };
 }

--- a/redfish-core/lib/pcie_slots.hpp
+++ b/redfish-core/lib/pcie_slots.hpp
@@ -59,11 +59,12 @@ inline void
     const size_t* lanes = nullptr;
     const std::string* slotType = nullptr;
     const bool* hotPluggable = nullptr;
+    const size_t* busId = nullptr;
 
     const bool success = sdbusplus::unpackPropertiesNoThrow(
         dbus_utils::UnpackErrorPrinter(), propertiesList, "Generation",
         generation, "Lanes", lanes, "SlotType", slotType, "HotPluggable",
-        hotPluggable);
+        hotPluggable, "BusId", busId);
 
     if (!success)
     {
@@ -118,6 +119,12 @@ inline void
     if (hotPluggable != nullptr)
     {
         slot["HotPluggable"] = *hotPluggable;
+    }
+
+    if (busId != nullptr)
+    {
+        slot["Oem"]["IBM"]["@odata.type"] = "#OemPCIeSlots.v1_0_0.PCIeSlot";
+        slot["Oem"]["IBM"]["LinkId"] = *busId;
     }
 
     size_t index = slots.size();

--- a/scripts/update_schemas.py
+++ b/scripts/update_schemas.py
@@ -149,6 +149,7 @@ oem_schema_names = [
     "OpenBMCAccountService",
     "OemMessage",
     "OemUpdateService",
+    "OemPCIeSlots",
 ]
 
 SCRIPT_DIR = os.path.dirname(os.path.realpath(__file__))

--- a/static/redfish/v1/$metadata/index.xml
+++ b/static/redfish/v1/$metadata/index.xml
@@ -3960,6 +3960,10 @@
         <edmx:Include Namespace="OemUpdateService"/>
         <edmx:Include Namespace="OemUpdateService.v1_0_0"/>
     </edmx:Reference>
+    <edmx:Reference Uri="/redfish/v1/schema/OemPCIeSlots_v1.xml">
+        <edmx:Include Namespace="OemPCIeSlots"/>
+        <edmx:Include Namespace="OemPCIeSlots.v1_0_0"/>
+    </edmx:Reference>
     <edmx:DataServices>
         <Schema xmlns="http://docs.oasis-open.org/odata/ns/edm" Namespace="Service">
             <EntityContainer Name="Service" Extends="ServiceRoot.v1_0_0.ServiceContainer"/>

--- a/static/redfish/v1/JsonSchemas/OemPCIeSlots/OemPCIeSlots.json
+++ b/static/redfish/v1/JsonSchemas/OemPCIeSlots/OemPCIeSlots.json
@@ -1,0 +1,99 @@
+{
+    "$id": "http://redfish.dmtf.org/schemas/v1/OemPCIeSlots.v1_0_0.json",
+    "$schema": "http://redfish.dmtf.org/schemas/v1/redfish-schema-v1.json",
+    "copyright": "Copyright 2014-2019 DMTF. For the full DMTF copyright policy, see http://www.dmtf.org/about/policies/copyright",
+    "definitions": {
+        "Oem": {
+            "additionalProperties": true,
+            "description": "OemPCIeSlots Oem properties.",
+            "patternProperties": {
+                "^([a-zA-Z_][a-zA-Z0-9_]*)?@(odata|Redfish|Message)\\.[a-zA-Z_][a-zA-Z0-9_]*$": {
+                    "description": "This property shall specify a valid odata or Redfish property.",
+                    "type": [
+                        "array",
+                        "boolean",
+                        "integer",
+                        "number",
+                        "null",
+                        "object",
+                        "string"
+                    ]
+                }
+            },
+            "properties": {
+                "IBM": {
+                    "anyOf": [
+                        {
+                            "$ref": "#/definitions/IBM"
+                        },
+                        {
+                            "type": "null"
+                        }
+                    ]
+                }
+            },
+            "type": "object"
+        },
+        "IBM": {
+            "additionalProperties": true,
+            "description": "Oem properties for IBM.",
+            "patternProperties": {
+                "^([a-zA-Z_][a-zA-Z0-9_]*)?@(odata|Redfish|Message)\\.[a-zA-Z_][a-zA-Z0-9_]*$": {
+                    "description": "This property shall specify a valid odata or Redfish property.",
+                    "type": [
+                        "array",
+                        "boolean",
+                        "integer",
+                        "number",
+                        "null",
+                        "object",
+                        "string"
+                    ]
+                }
+            },
+            "properties": {
+                 "PCIeSlot": {
+                    "anyOf": [
+                        {
+                            "$ref": "#/definitions/PCIeSlot"
+                        },
+                        {
+                            "type": "null"
+                        }
+                    ]
+                }
+            },
+            "type": "object"
+        },
+        "PCIeSlot": {
+            "additionalProperties": true,
+            "description": "Oem properties for IBM.",
+            "patternProperties": {
+                "^([a-zA-Z_][a-zA-Z0-9_]*)?@(odata|Redfish|Message)\\.[a-zA-Z_][a-zA-Z0-9_]*$": {
+                    "description": "This property shall specify a valid odata or Redfish property.",
+                    "type": [
+                        "array",
+                        "boolean",
+                        "integer",
+                        "number",
+                        "null",
+                        "object",
+                        "string"
+                    ]
+                }
+            },
+            "properties": {
+                "LinkId": {
+                    "description": "An identifier to detect the PCIe bus linked to the slot.",
+                    "readonly": true,
+                    "type": "integer"
+                }
+            },
+            "type": "object"
+        }
+
+    },
+    "owningEntity": "IBM",
+    "release": "1.0",
+    "title": "#OemPCIeSlots.v1_0_0"
+}

--- a/static/redfish/v1/schema/OemPCIeSlots_v1.xml
+++ b/static/redfish/v1/schema/OemPCIeSlots_v1.xml
@@ -1,0 +1,57 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<edmx:Edmx xmlns:edmx="http://docs.oasis-open.org/odata/ns/edmx" Version="4.0">
+
+  <edmx:Reference Uri="http://docs.oasis-open.org/odata/odata/v4.0/errata03/csd01/complete/vocabularies/Org.OData.Core.V1.xml">
+    <edmx:Include Namespace="Org.OData.Core.V1" Alias="OData"/>
+  </edmx:Reference>
+  <edmx:Reference Uri="http://docs.oasis-open.org/odata/odata/v4.0/errata03/csd01/complete/vocabularies/Org.OData.Measures.V1.xml">
+    <edmx:Include Namespace="Org.OData.Measures.V1" Alias="Measures"/>
+  </edmx:Reference>
+  <edmx:Reference Uri="http://redfish.dmtf.org/schemas/v1/RedfishExtensions_v1.xml">
+    <edmx:Include Namespace="RedfishExtensions.v1_0_0" Alias="Redfish"/>
+  </edmx:Reference>
+    <edmx:Reference Uri="http://redfish.dmtf.org/schemas/v1/PCIeSlots_v1.xml">
+        <edmx:Include Namespace="PCIeSlots"/>
+        <edmx:Include Namespace="PCIeSlots.v1_5_0"/>
+    </edmx:Reference>
+  <edmx:Reference Uri="http://redfish.dmtf.org/schemas/v1/Resource_v1.xml">
+    <edmx:Include Namespace="Resource"/>
+    <edmx:Include Namespace="Resource.v1_0_0"/>
+  </edmx:Reference>
+
+  <edmx:DataServices>
+
+    <Schema xmlns="http://docs.oasis-open.org/odata/ns/edm" Namespace="OemPCIeSlots">
+      <Annotation Term="Redfish.OwningEntity" String="IBM"/>
+    </Schema>
+
+    <Schema xmlns="http://docs.oasis-open.org/odata/ns/edm" Namespace="OemPCIeSlots.v1_0_0">
+      <Annotation Term="Redfish.OwningEntity" String="IBM"/>
+
+      <ComplexType Name="Oem" BaseType="Resource.OemObject">
+        <Annotation Term="OData.AdditionalProperties" Bool="true"/>
+        <Annotation Term="OData.Description" String="OemPCIeSlots Oem properties."/>
+        <Annotation Term="OData.AutoExpand"/>
+        <Property Name="IBM" Type="OemPCIeSlots.v1_0_0.IBM"/>
+      </ComplexType>
+
+      <ComplexType Name="IBM" BaseType="Resource.OemObject">
+        <Annotation Term="OData.AdditionalProperties" Bool="true" />
+        <Annotation Term="OData.Description" String="Oem properties for IBM." />
+        <Annotation Term="OData.AutoExpand"/>
+
+        <Property Name="PCIeSlot" Type="OemPCIeSlots.v1_0_0.PCIeSlot"/>
+
+      </ComplexType>
+
+      <ComplexType Name="PCIeSlot" BaseType="Resource.OemObject">
+        <Property Name="LinkId" Type="Edm.Int64">
+          <Annotation Term="OData.Permissions" EnumMember="OData.Permission/Read"/>
+          <Annotation Term="OData.Description" String="Number of PCIe lanes in use."/>
+        </Property>
+      </ComplexType>
+
+    </Schema>
+
+  </edmx:DataServices>
+</edmx:Edmx>


### PR DESCRIPTION
Added Redfish Oem property 'LinkId' to PCIeSlots under redfish/v1/Chassis. LinkId maps to dbus BusId property for the Inventory.Item.PCIeSlots interface.

Tested:
- Redfish validator passed

- Get PCIeSlots
```
$ curl -k <token> https://$bmc/redfish/v1/Chassis/chassis/PCIeSlots
    ...
    {
      "Links": {
        "PCIeDevice": [
          {
            "@odata.id": "/redfish/v1/Systems/system/PCIeDevices/pcie_card8"
          }
        ],
      ...
      "Oem": {
        "IBM": {
          "@odata.type": "#OemPCIeSlots.v1_0_0.PCIeSlot"
          "LinkId": 0
        }
      },
      "SlotType": "FullLength"
    },
```