### PR TITLE
Remove Inventory.Item.Board interface from Chassis (#604)

### DIFF
--- a/redfish-core/include/utils/chassis_utils.hpp
+++ b/redfish-core/include/utils/chassis_utils.hpp
@@ -22,8 +22,7 @@ void getValidChassisPath(const std::shared_ptr<bmcweb::AsyncResp>& asyncResp,
                          const std::string& chassisId, Callback&& callback)
 {
     BMCWEB_LOG_DEBUG("checkChassisId enter");
-    constexpr std::array<std::string_view, 2> interfaces = {
-        "xyz.openbmc_project.Inventory.Item.Board",
+    constexpr std::array<std::string_view, 1> interfaces = {
         "xyz.openbmc_project.Inventory.Item.Chassis"};
 
     // Get the Chassis Collection


### PR DESCRIPTION
IBM does not use the `xyz.openbmc_project.Inventory.Item.Board` interface for chassis objects. 
Remove that interfaces so only objects implementing `xyz.openbmc_project.Inventory.Item.Chassis` are returned for getValidChassisPath