### PR TITLE
1110: Fix handling of lanesInUse default value

### DIFF
--- a/redfish-core/lib/pcie.hpp
+++ b/redfish-core/lib/pcie.hpp
@@ -31,6 +31,7 @@
 
 #include <array>
 #include <functional>
+#include <limits>
 #include <memory>
 #include <ranges>
 #include <string>
@@ -567,11 +568,19 @@ inline void addPCIeDeviceProperties(
         }
     }
 
-    // The default value of LanesInUse is 0, and the field will be
-    // left as off if it is a default value.
-    if (lanesInUse != nullptr && *lanesInUse != 0)
+    if (lanesInUse != nullptr)
     {
-        asyncResp->res.jsonValue["PCIeInterface"]["LanesInUse"] = *lanesInUse;
+        if (*lanesInUse == std::numeric_limits<size_t>::max())
+        {
+            // The default value of LanesInUse is "maxint", and the field will
+            // be null if it is a default value.
+            asyncResp->res.jsonValue["PCIeInterface"]["LanesInUse"] = nullptr;
+        }
+        else
+        {
+            asyncResp->res.jsonValue["PCIeInterface"]["LanesInUse"] =
+                *lanesInUse;
+        }
     }
     // The default value of MaxLanes is 0, and the field will be
     // left as off if it is a default value.


### PR DESCRIPTION
phophor-dbus-interfaces changes the default of lanesInUse to MAXINT by https://gerrit.openbmc.org/c/openbmc/phosphor-dbus-interfaces/+/53650

Thus bmcweb also changes the logic to hide the field if it is MAXINT.

Change-Id: Ib229112374eb5a65e0a8ac97669c09c498ac26c7
upstream: https://gerrit.openbmc.org/c/openbmc/bmcweb/+/70008