### PR TITLE
1110: Build Fabric Adapters Unique Path (#606)

### DIFF
--- a/redfish-core/include/utils/fabric_util.hpp
+++ b/redfish-core/include/utils/fabric_util.hpp
@@ -1,0 +1,104 @@
+#pragma once
+
+#include "async_resp.hpp"
+#include "dbus_utility.hpp"
+#include "error_messages.hpp"
+#include "http/utility.hpp"
+#include "human_sort.hpp"
+
+#include <boost/url/url.hpp>
+#include <nlohmann/json.hpp>
+
+#include <span>
+#include <string>
+#include <string_view>
+#include <vector>
+
+namespace redfish
+{
+namespace fabric_util
+{
+
+/**
+ * @brief Workaround to handle duplicate Fabric device list
+ *
+ * retrieve Fabric device endpoint information and if path is
+ * ~/chassisN/logical_slotN/io_moduleN then, replace redfish
+ * Fabric device as "chassisN-logical_slotN-io_moduleN"
+ *
+ * @param[i]   fullPath  object path of Fabric device
+ *
+ * @return string: unique Fabric device name
+ */
+inline std::string buildFabricUniquePath(const std::string& fullPath)
+{
+    sdbusplus::message::object_path path(fullPath);
+    sdbusplus::message::object_path parentPath = path.parent_path();
+
+    std::string devName;
+
+    if (!parentPath.parent_path().filename().empty())
+    {
+        devName = parentPath.parent_path().filename() + "-";
+    }
+    if (!parentPath.filename().empty())
+    {
+        devName += parentPath.filename() + "-";
+    }
+    devName += path.filename();
+    return devName;
+}
+
+/**
+ * @brief get FabricAdapters to resp
+ *
+ * @param[in,out]   asyncResp   Async HTTP response.
+ * @param[in]      jsonKeyName
+ */
+inline void
+    getFabricAdapterList(const std::shared_ptr<bmcweb::AsyncResp>& asyncResp,
+                         const nlohmann::json::json_pointer& jsonKeyName)
+{
+    static constexpr std::array<std::string_view, 1> fabricInterfaces = {
+        "xyz.openbmc_project.Inventory.Item.FabricAdapter"};
+
+    dbus::utility::getSubTreePaths(
+        "/xyz/openbmc_project/inventory", 0, fabricInterfaces,
+        [asyncResp, jsonKeyName](
+            const boost::system::error_code& ec,
+            const dbus::utility::MapperGetSubTreePathsResponse& paths) {
+        nlohmann::json::json_pointer jsonCountKeyName = jsonKeyName;
+        std::string back = jsonCountKeyName.back();
+        jsonCountKeyName.pop_back();
+        jsonCountKeyName /= back + "@odata.count";
+
+        nlohmann::json& members = asyncResp->res.jsonValue[jsonKeyName];
+        members = nlohmann::json::array();
+
+        if (ec)
+        {
+            // Not an error, system just doesn't have FabricAdapter
+            BMCWEB_LOG_DEBUG("no FabricAdapter paths found ec: {}", ec.value());
+            asyncResp->res.jsonValue[jsonCountKeyName] = members.size();
+            return;
+        }
+
+        for (const auto& pcieDevicePath : paths)
+        {
+            std::string adapterUniq = buildFabricUniquePath(pcieDevicePath);
+            if (adapterUniq.empty())
+            {
+                BMCWEB_LOG_DEBUG("Invalid Name");
+                continue;
+            }
+            nlohmann::json::object_t device;
+            device["@odata.id"] = boost::urls::format(
+                "/redfish/v1/Systems/system/FabricAdapters/{}", adapterUniq);
+            members.emplace_back(std::move(device));
+        }
+        asyncResp->res.jsonValue[jsonCountKeyName] = members.size();
+    });
+}
+
+} // namespace fabric_util
+} // namespace redfish

--- a/redfish-core/lib/fabric_adapters.hpp
+++ b/redfish-core/lib/fabric_adapters.hpp
@@ -16,26 +16,12 @@
 #include <array>
 #include <functional>
 #include <memory>
+#include <optional>
 #include <string>
 #include <string_view>
 
 namespace redfish
 {
-
-inline void handleAdapterError(const boost::system::error_code& ec,
-                               crow::Response& res,
-                               const std::string& adapterId)
-{
-    if (ec.value() == boost::system::errc::io_error)
-    {
-        messages::resourceNotFound(res, "#FabricAdapter.v1_4_0.FabricAdapter",
-                                   adapterId);
-        return;
-    }
-
-    BMCWEB_LOG_ERROR("DBus method call failed with error {}", ec.value());
-    messages::internalError(res);
-}
 
 inline void getFabricAdapterLocation(
     const std::shared_ptr<bmcweb::AsyncResp>& asyncResp,
@@ -198,51 +184,76 @@ inline void doAdapterGet(const std::shared_ptr<bmcweb::AsyncResp>& asyncResp,
     getFabricAdapterHealth(asyncResp, serviceName, fabricAdapterPath);
 }
 
-inline bool checkFabricAdapterId(const std::string& adapterPath,
-                                 const std::string& adapterId)
+inline void afterGetValidFabricAdapterPath(
+    const std::string& adapterId,
+    std::function<void(const boost::system::error_code&,
+                       const std::string& fabricAdapterPath,
+                       const std::string& serviceName)>& callback,
+    const boost::system::error_code& ec,
+    const dbus::utility::MapperGetSubTreeResponse& subtree)
 {
-    std::string fabricAdapterName =
-        sdbusplus::message::object_path(adapterPath).filename();
+    std::string fabricAdapterPath;
+    std::string serviceName;
+    if (ec)
+    {
+        callback(ec, fabricAdapterPath, serviceName);
+        return;
+    }
 
-    return !(fabricAdapterName.empty() || fabricAdapterName != adapterId);
+    for (const auto& [adapterPath, serviceMap] : subtree)
+    {
+        std::string fabricAdapterName =
+            sdbusplus::message::object_path(adapterPath).filename();
+        if (fabricAdapterName == adapterId)
+        {
+            fabricAdapterPath = adapterPath;
+            serviceName = serviceMap.begin()->first;
+            break;
+        }
+    }
+    callback(ec, fabricAdapterPath, serviceName);
 }
 
 inline void getValidFabricAdapterPath(
-    const std::string& adapterId, const std::string& systemName,
-    const std::shared_ptr<bmcweb::AsyncResp>& asyncResp,
-    std::function<void(const std::string& fabricAdapterPath,
+    const std::string& adapterId,
+    std::function<void(const boost::system::error_code& ec,
+                       const std::string& fabricAdapterPath,
                        const std::string& serviceName)>&& callback)
 {
-    if (systemName != "system")
-    {
-        messages::resourceNotFound(asyncResp->res, "ComputerSystem",
-                                   systemName);
-        return;
-    }
     constexpr std::array<std::string_view, 1> interfaces{
         "xyz.openbmc_project.Inventory.Item.FabricAdapter"};
+    dbus::utility::getSubTree("/xyz/openbmc_project/inventory", 0, interfaces,
+                              std::bind_front(afterGetValidFabricAdapterPath,
+                                              adapterId, std::move(callback)));
+}
 
-    dbus::utility::getSubTree(
-        "/xyz/openbmc_project/inventory", 0, interfaces,
-        [adapterId, asyncResp,
-         callback](const boost::system::error_code& ec,
-                   const dbus::utility::MapperGetSubTreeResponse& subtree) {
-        if (ec)
+inline void afterHandleFabricAdapterGet(
+    const std::shared_ptr<bmcweb::AsyncResp>& asyncResp,
+    const std::string& systemName, const std::string& adapterId,
+    const boost::system::error_code& ec, const std::string& fabricAdapterPath,
+    const std::string& serviceName)
+{
+    if (ec)
+    {
+        if (ec.value() == boost::system::errc::io_error)
         {
-            handleAdapterError(ec, asyncResp->res, adapterId);
+            messages::resourceNotFound(asyncResp->res, "FabricAdapter",
+                                       adapterId);
             return;
         }
-        for (const auto& [adapterPath, serviceMap] : subtree)
-        {
-            if (checkFabricAdapterId(adapterPath, adapterId))
-            {
-                callback(adapterPath, serviceMap.begin()->first);
-                return;
-            }
-        }
+
+        BMCWEB_LOG_ERROR("DBus method call failed with error {}", ec.value());
+        messages::internalError(asyncResp->res);
+        return;
+    }
+    if (fabricAdapterPath.empty() || serviceName.empty())
+    {
         BMCWEB_LOG_WARNING("Adapter not found");
         messages::resourceNotFound(asyncResp->res, "FabricAdapter", adapterId);
-    });
+        return;
+    }
+    doAdapterGet(asyncResp, systemName, adapterId, fabricAdapterPath,
+                 serviceName);
 }
 
 inline void
@@ -262,14 +273,15 @@ inline void
                                    systemName);
         return;
     }
-
+    if (systemName != "system")
+    {
+        messages::resourceNotFound(asyncResp->res, "ComputerSystem",
+                                   systemName);
+        return;
+    }
     getValidFabricAdapterPath(
-        adapterId, systemName, asyncResp,
-        [asyncResp, systemName, adapterId](const std::string& fabricAdapterPath,
-                                           const std::string& serviceName) {
-        doAdapterGet(asyncResp, systemName, adapterId, fabricAdapterPath,
-                     serviceName);
-    });
+        adapterId, std::bind_front(afterHandleFabricAdapterGet, asyncResp,
+                                   systemName, adapterId));
 }
 
 inline void handleFabricAdapterCollectionGet(
@@ -339,6 +351,35 @@ inline void handleFabricAdapterCollectionHead(
         "</redfish/v1/JsonSchemas/FabricAdapterCollection/FabricAdapterCollection.json>; rel=describedby");
 }
 
+inline void afterHandleFabricAdapterHead(
+    const std::shared_ptr<bmcweb::AsyncResp>& asyncResp,
+    const std::string& adapterId, const boost::system::error_code& ec,
+    const std::string& fabricAdapterPath, const std::string& serviceName)
+{
+    if (ec)
+    {
+        if (ec.value() == boost::system::errc::io_error)
+        {
+            messages::resourceNotFound(asyncResp->res, "FabricAdapter",
+                                       adapterId);
+            return;
+        }
+
+        BMCWEB_LOG_ERROR("DBus method call failed with error {}", ec.value());
+        messages::internalError(asyncResp->res);
+        return;
+    }
+    if (fabricAdapterPath.empty() || serviceName.empty())
+    {
+        BMCWEB_LOG_WARNING("Adapter not found");
+        messages::resourceNotFound(asyncResp->res, "FabricAdapter", adapterId);
+        return;
+    }
+    asyncResp->res.addHeader(
+        boost::beast::http::field::link,
+        "</redfish/v1/JsonSchemas/FabricAdapter/FabricAdapter.json>; rel=describedby");
+}
+
 inline void
     handleFabricAdapterHead(crow::App& app, const crow::Request& req,
                             const std::shared_ptr<bmcweb::AsyncResp>& asyncResp,
@@ -357,13 +398,15 @@ inline void
                                    systemName);
         return;
     }
-    getValidFabricAdapterPath(adapterId, systemName, asyncResp,
-                              [asyncResp, systemName, adapterId](
-                                  const std::string&, const std::string&) {
-        asyncResp->res.addHeader(
-            boost::beast::http::field::link,
-            "</redfish/v1/JsonSchemas/FabricAdapter/FabricAdapter.json>; rel=describedby");
-    });
+    if (systemName != "system")
+    {
+        messages::resourceNotFound(asyncResp->res, "ComputerSystem",
+                                   systemName);
+        return;
+    }
+    getValidFabricAdapterPath(
+        adapterId,
+        std::bind_front(afterHandleFabricAdapterHead, asyncResp, adapterId));
 }
 
 inline void requestRoutesFabricAdapterCollection(App& app)

--- a/redfish-core/lib/fabric_adapters.hpp
+++ b/redfish-core/lib/fabric_adapters.hpp
@@ -6,6 +6,7 @@
 #include "registries/privilege_registry.hpp"
 #include "utils/collection.hpp"
 #include "utils/dbus_utils.hpp"
+#include "utils/fabric_util.hpp"
 #include "utils/json_utils.hpp"
 
 #include <boost/system/error_code.hpp>
@@ -16,7 +17,6 @@
 #include <array>
 #include <functional>
 #include <memory>
-#include <optional>
 #include <string>
 #include <string_view>
 
@@ -202,9 +202,7 @@ inline void afterGetValidFabricAdapterPath(
 
     for (const auto& [adapterPath, serviceMap] : subtree)
     {
-        std::string fabricAdapterName =
-            sdbusplus::message::object_path(adapterPath).filename();
-        if (fabricAdapterName == adapterId)
+        if (adapterId == fabric_util::buildFabricUniquePath(adapterPath))
         {
             fabricAdapterPath = adapterPath;
             serviceName = serviceMap.begin()->first;
@@ -316,12 +314,8 @@ inline void handleFabricAdapterCollectionGet(
     asyncResp->res.jsonValue["@odata.id"] = boost::urls::format(
         "/redfish/v1/Systems/{}/FabricAdapters", systemName);
 
-    constexpr std::array<std::string_view, 1> interfaces{
-        "xyz.openbmc_project.Inventory.Item.FabricAdapter"};
-    collection_util::getCollectionMembers(
-        asyncResp,
-        boost::urls::url("/redfish/v1/Systems/system/FabricAdapters"),
-        interfaces, "/xyz/openbmc_project/inventory");
+    fabric_util::getFabricAdapterList(asyncResp,
+                                      nlohmann::json::json_pointer("/Members"));
 }
 
 inline void handleFabricAdapterCollectionHead(


### PR DESCRIPTION
Build Fabric Adapters Unique Path (#606)

Defect is https://w3.rchland.ibm.com/projects/bestquest/?defect=SW552762
This commit makesFabric Adapters objects unique, before this commit
bmcweb shows Fabric Adaptersobjects with the same path even though all
the dbus objects have unique paths

```
{"@odata.id": "/redfish/v1/Systems/system/FabricAdapters/io_module1"},
{"@odata.id": "/redfish/v1/Systems/system/FabricAdapters/io_module1"}
```

after this change bmcweb retrieve FabricAdapterdevice endpoint information and
then, replace redfish FabricAdapter device as
"chassisN-logical_slotN-io_moduleN".

Tested: Validator passed
Motherboard FabricAdapter also gets affected.

```
curl -k -H "X-Auth-Token: $token" -X GET  https://${bmc}/redfish/v1/Systems/system/FabricAdapters/
{
  ...
  ...
  "Members": [
   {
      "@odata.id": "/redfish/v1/Systems/system/FabricAdapters/chassis-motherboard-disk_backplane0"
    },
    {
      "@odata.id": "/redfish/v1/Systems/system/FabricAdapters/chassis-motherboard-disk_backplane1"
    },
    {
      "@odata.id": "/redfish/v1/Systems/system/FabricAdapters/motherboard-pcieslot0-pcie_card0"
    },
    {
      "@odata.id": "/redfish/v1/Systems/system/FabricAdapters/motherboard-pcieslot3-pcie_card3"
    },
    ...
   ],
   ...
}
```