### PR TITLE
1050: DHCP Conf: Fix UseDomainName configuration & Configure DHCP4 and DHCP6 parameters independently

### DIFF
--- a/redfish-core/lib/ethernet.hpp
+++ b/redfish-core/lib/ethernet.hpp
@@ -100,11 +100,11 @@ struct EthernetInterfaceData
     uint32_t speed;
     size_t mtuSize;
     bool autoNeg;
-    bool dnsEnabled;
+    bool dnsv4Enabled;
     bool dnsv6Enabled;
-    bool ntpEnabled;
+    bool ntpv4Enabled;
     bool ntpv6Enabled;
-    bool hostNameEnabled;
+    bool hostNamev4Enabled;
     bool hostNamev6Enabled;
     bool linkUp;
     bool nicEnabled;
@@ -377,8 +377,12 @@ inline bool extractEthernetInterfaceData(
                 }
             }
 
-            if (objpath.first ==
-                "/xyz/openbmc_project/network/" + ethifaceId + "/dhcp4")
+            sdbusplus::message::object_path path(
+                "/xyz/openbmc_project/network");
+            sdbusplus::message::object_path dhcp4Path = path / ethifaceId /
+                                                        "dhcp4";
+
+            if (sdbusplus::message::object_path(objpath.first) == dhcp4Path)
             {
                 if (ifacePair.first ==
                     "xyz.openbmc_project.Network.DHCPConfiguration")
@@ -391,7 +395,7 @@ inline bool extractEthernetInterfaceData(
                                 std::get_if<bool>(&propertyPair.second);
                             if (dnsEnabled != nullptr)
                             {
-                                ethData.dnsEnabled = *dnsEnabled;
+                                ethData.dnsv4Enabled = *dnsEnabled;
                             }
                         }
                         else if (propertyPair.first == "NTPEnabled")
@@ -400,7 +404,7 @@ inline bool extractEthernetInterfaceData(
                                 std::get_if<bool>(&propertyPair.second);
                             if (ntpEnabled != nullptr)
                             {
-                                ethData.ntpEnabled = *ntpEnabled;
+                                ethData.ntpv4Enabled = *ntpEnabled;
                             }
                         }
                         else if (propertyPair.first == "HostNameEnabled")
@@ -409,14 +413,17 @@ inline bool extractEthernetInterfaceData(
                                 std::get_if<bool>(&propertyPair.second);
                             if (hostNameEnabled != nullptr)
                             {
-                                ethData.hostNameEnabled = *hostNameEnabled;
+                                ethData.hostNamev4Enabled = *hostNameEnabled;
                             }
                         }
                     }
                 }
             }
-            if (objpath.first ==
-                "/xyz/openbmc_project/network/" + ethifaceId + "/dhcp6")
+
+            sdbusplus::message::object_path dhcp6Path = path / ethifaceId /
+                                                        "dhcp6";
+
+            if (sdbusplus::message::object_path(objpath.first) == dhcp6Path)
             {
                 if (ifacePair.first ==
                     "xyz.openbmc_project.Network.DHCPConfiguration")
@@ -1512,26 +1519,40 @@ inline void setEthernetInterfaceBoolProperty(
         dbus::utility::DbusVariantType{value});
 }
 
+enum class NetworkType
+{
+    dhcp4,
+    dhcp6
+};
+
 inline void setDHCPConfig(const std::string& propertyName, const bool& value,
                           const std::shared_ptr<bmcweb::AsyncResp>& asyncResp,
-                          const std::string& ethifaceId,
-                          const std::string& nwType)
+                          const std::string& ethifaceId, NetworkType type)
 {
     BMCWEB_LOG_DEBUG << propertyName << " = " << value;
-    crow::connections::systemBus->async_method_call(
-        [asyncResp](const boost::system::error_code ec) {
+    sdbusplus::message::object_path path("/xyz/openbmc_project/network/");
+    path /= ethifaceId;
+
+    if (type == NetworkType::dhcp4)
+    {
+        path /= "dhcp4";
+    }
+    else
+    {
+        path /= "dhcp6";
+    }
+
+    sdbusplus::asio::setProperty(
+        *crow::connections::systemBus, "xyz.openbmc_project.Network", path,
+        "xyz.openbmc_project.Network.DHCPConfiguration", propertyName, value,
+        [asyncResp](const boost::system::error_code& ec) {
         if (ec)
         {
             BMCWEB_LOG_ERROR << "D-Bus responses error: " << ec;
             messages::internalError(asyncResp->res);
             return;
         }
-        },
-        "xyz.openbmc_project.Network",
-        "/xyz/openbmc_project/network/" + ethifaceId + "/" + nwType,
-        "org.freedesktop.DBus.Properties", "Set",
-        "xyz.openbmc_project.Network.DHCPConfiguration", propertyName,
-        dbus::utility::DbusVariantType{value});
+        });
 }
 
 inline void handleSLAACAutoConfigPatch(
@@ -1585,33 +1606,33 @@ inline void handleDHCPPatch(const std::string& ifaceId,
         nextv6DHCPState = ipv6Active;
     }
 
-    bool nextDNS = ethData.dnsEnabled;
+    bool nextDNSv4 = ethData.dnsv4Enabled;
     bool nextDNSv6 = ethData.dnsv6Enabled;
     if (v4dhcpParms.useDnsServers)
     {
-        nextDNS = *v4dhcpParms.useDnsServers;
+        nextDNSv4 = *v4dhcpParms.useDnsServers;
     }
     if (v6dhcpParms.useDnsServers)
     {
         nextDNSv6 = *v6dhcpParms.useDnsServers;
     }
 
-    bool nextNTP = ethData.ntpEnabled;
+    bool nextNTPv4 = ethData.ntpv4Enabled;
     bool nextNTPv6 = ethData.ntpv6Enabled;
     if (v4dhcpParms.useNtpServers)
     {
-        nextNTP = *v4dhcpParms.useNtpServers;
+        nextNTPv4 = *v4dhcpParms.useNtpServers;
     }
     if (v6dhcpParms.useNtpServers)
     {
         nextNTPv6 = *v6dhcpParms.useNtpServers;
     }
 
-    bool nextUseDomain = ethData.hostNameEnabled;
+    bool nextUsev4Domain = ethData.hostNamev4Enabled;
     bool nextUsev6Domain = ethData.hostNamev6Enabled;
     if (v4dhcpParms.useDomainName)
     {
-        nextUseDomain = *v4dhcpParms.useDomainName;
+        nextUsev4Domain = *v4dhcpParms.useDomainName;
     }
     if (v6dhcpParms.useDomainName)
     {
@@ -1622,19 +1643,23 @@ inline void handleDHCPPatch(const std::string& ifaceId,
     setDHCPEnabled(ifaceId, "DHCPEnabled", nextv4DHCPState, nextv6DHCPState,
                    asyncResp);
     BMCWEB_LOG_DEBUG << "set DNSEnabled...";
-    setDHCPConfig("DNSEnabled", nextDNS, asyncResp, ifaceId, "dhcp4");
+    setDHCPConfig("DNSEnabled", nextDNSv4, asyncResp, ifaceId,
+                  NetworkType::dhcp4);
     BMCWEB_LOG_DEBUG << "set NTPEnabled...";
-    setDHCPConfig("NTPEnabled", nextNTP, asyncResp, ifaceId, "dhcp4");
+    setDHCPConfig("NTPEnabled", nextNTPv4, asyncResp, ifaceId,
+                  NetworkType::dhcp4);
     BMCWEB_LOG_DEBUG << "set HostNameEnabled...";
-    setDHCPConfig("HostNameEnabled", nextUseDomain, asyncResp, ifaceId,
-                  "dhcp4");
+    setDHCPConfig("HostNameEnabled", nextUsev4Domain, asyncResp, ifaceId,
+                  NetworkType::dhcp4);
     BMCWEB_LOG_DEBUG << "set DNSEnabled for dhcp6...";
-    setDHCPConfig("DNSEnabled", nextDNSv6, asyncResp, ifaceId, "dhcp6");
+    setDHCPConfig("DNSEnabled", nextDNSv6, asyncResp, ifaceId,
+                  NetworkType::dhcp6);
     BMCWEB_LOG_DEBUG << "set NTPEnabled for dhcp6...";
-    setDHCPConfig("NTPEnabled", nextNTPv6, asyncResp, ifaceId, "dhcp6");
+    setDHCPConfig("NTPEnabled", nextNTPv6, asyncResp, ifaceId,
+                  NetworkType::dhcp6);
     BMCWEB_LOG_DEBUG << "set HostNameEnabled for dhcp6...";
     setDHCPConfig("HostNameEnabled", nextUsev6Domain, asyncResp, ifaceId,
-                  "dhcp6");
+                  NetworkType::dhcp6);
 }
 
 inline boost::container::flat_set<IPv4AddressData>::const_iterator
@@ -2009,9 +2034,9 @@ inline void parseInterfaceData(
     jsonResponse["MACAddress"] = ethData.macAddress;
     jsonResponse["DHCPv4"]["DHCPEnabled"] =
         translateDhcpEnabledToBool(ethData.dhcpEnabled, true);
-    jsonResponse["DHCPv4"]["UseNTPServers"] = ethData.ntpEnabled;
-    jsonResponse["DHCPv4"]["UseDNSServers"] = ethData.dnsEnabled;
-    jsonResponse["DHCPv4"]["UseDomainName"] = ethData.hostNameEnabled;
+    jsonResponse["DHCPv4"]["UseNTPServers"] = ethData.ntpv4Enabled;
+    jsonResponse["DHCPv4"]["UseDNSServers"] = ethData.dnsv4Enabled;
+    jsonResponse["DHCPv4"]["UseDomainName"] = ethData.hostNamev4Enabled;
     jsonResponse["DHCPv6"]["OperatingMode"] =
         translateDhcpEnabledToBool(ethData.dhcpEnabled, false) ? "Enabled"
                                                                : "Disabled";

--- a/redfish-core/lib/ethernet.hpp
+++ b/redfish-core/lib/ethernet.hpp
@@ -102,6 +102,8 @@ struct EthernetInterfaceData
     bool autoNeg;
     bool dnsv4Enabled;
     bool dnsv6Enabled;
+    bool domainv4Enabled;
+    bool domainv6Enabled;
     bool ntpv4Enabled;
     bool ntpv6Enabled;
     bool hostNamev4Enabled;
@@ -398,6 +400,15 @@ inline bool extractEthernetInterfaceData(
                                 ethData.dnsv4Enabled = *dnsEnabled;
                             }
                         }
+                        else if (propertyPair.first == "DomainEnabled")
+                        {
+                            const bool* domainEnabled =
+                                std::get_if<bool>(&propertyPair.second);
+                            if (domainEnabled != nullptr)
+                            {
+                                ethData.domainv4Enabled = *domainEnabled;
+                            }
+                        }
                         else if (propertyPair.first == "NTPEnabled")
                         {
                             const bool* ntpEnabled =
@@ -437,6 +448,15 @@ inline bool extractEthernetInterfaceData(
                             if (dnsEnabled != nullptr)
                             {
                                 ethData.dnsv6Enabled = *dnsEnabled;
+                            }
+                        }
+                        if (propertyPair.first == "DomainEnabled")
+                        {
+                            const bool* domainEnabled =
+                                std::get_if<bool>(&propertyPair.second);
+                            if (domainEnabled != nullptr)
+                            {
+                                ethData.domainv6Enabled = *domainEnabled;
                             }
                         }
                         else if (propertyPair.first == "NTPEnabled")
@@ -1628,8 +1648,8 @@ inline void handleDHCPPatch(const std::string& ifaceId,
         nextNTPv6 = *v6dhcpParms.useNtpServers;
     }
 
-    bool nextUsev4Domain = ethData.hostNamev4Enabled;
-    bool nextUsev6Domain = ethData.hostNamev6Enabled;
+    bool nextUsev4Domain = ethData.domainv4Enabled;
+    bool nextUsev6Domain = ethData.domainv6Enabled;
     if (v4dhcpParms.useDomainName)
     {
         nextUsev4Domain = *v4dhcpParms.useDomainName;
@@ -1648,8 +1668,8 @@ inline void handleDHCPPatch(const std::string& ifaceId,
     BMCWEB_LOG_DEBUG << "set NTPEnabled...";
     setDHCPConfig("NTPEnabled", nextNTPv4, asyncResp, ifaceId,
                   NetworkType::dhcp4);
-    BMCWEB_LOG_DEBUG << "set HostNameEnabled...";
-    setDHCPConfig("HostNameEnabled", nextUsev4Domain, asyncResp, ifaceId,
+    BMCWEB_LOG_DEBUG << "set DomainEnabled...";
+    setDHCPConfig("DomainEnabled", nextUsev4Domain, asyncResp, ifaceId,
                   NetworkType::dhcp4);
     BMCWEB_LOG_DEBUG << "set DNSEnabled for dhcp6...";
     setDHCPConfig("DNSEnabled", nextDNSv6, asyncResp, ifaceId,
@@ -1657,8 +1677,8 @@ inline void handleDHCPPatch(const std::string& ifaceId,
     BMCWEB_LOG_DEBUG << "set NTPEnabled for dhcp6...";
     setDHCPConfig("NTPEnabled", nextNTPv6, asyncResp, ifaceId,
                   NetworkType::dhcp6);
-    BMCWEB_LOG_DEBUG << "set HostNameEnabled for dhcp6...";
-    setDHCPConfig("HostNameEnabled", nextUsev6Domain, asyncResp, ifaceId,
+    BMCWEB_LOG_DEBUG << "set DomainEnabled for dhcp6...";
+    setDHCPConfig("DomainEnabled", nextUsev6Domain, asyncResp, ifaceId,
                   NetworkType::dhcp6);
 }
 


### PR DESCRIPTION
#### DHCP Conf: Fix UseDomainName configuration
```
This commit modifies to use DomainEnabled D-bus property

Currently "UseDomainName" configuration is actually not controlling
DomainName setting in the backend networkd and networkd.
Networkd app does not have DomainName D-bus property implemented
and wrong D-bus property is being used in the bmcweb.

This fix make sure bmcweb uses DomainEnabled property and controls
UseDomainName configuration.

Here is backend networkd fix for DomainEnabled property
https://gerrit.openbmc.org/c/openbmc/phosphor-networkd/+/69604

Tested by:
Enabled DHCPv4 on one of the interface
Enable/Disable UseDomainName
Check if DHCP configured domain name configuration on BMC.

Change-Id: I68b86d4107a17db921ec463f5660a58aaa1396e3
Signed-off-by: Ravi Teja <raviteja28031990@gmail.com>
```
#### Configure DHCP4 and DHCP6 parameters independently
```
At present, DHCP parameters like DNSEnabled, NTPEnabled and
HostNameEnabled are at the system level at the network backend. It is
common across both IPv4 and IPv6 network types. Thus when a redfish
command is sent to enable the DNSEnabled property for IPv4 on eth0
interface, it internally sets the DNSEnabled to true for both IPv4 and
IPv6 on eth0 and eth1.

Here the change in parameter value for a non-requested network type in
the non-requested interface might be an unexpected behaviour for the
user. Also, with the current implementation in bmcweb and networkd, the
user has no option to configure DHCP parameters differently for
different interfaces and network types though it is supported by the
redfish.

With this change, the Redfish query for updating DHCP parameters will
only modify the requested parameter for the specified network type and
interface. User must make separate requests to modify the DHCP
parameters as per the DMTF schema

Current behavior: Request: curl -k -H "X-Auth-Token: $bmc_token" -X
PATCH -d '{"DHCPv4":{"UseDNSServers":false}}'
https://${bmc}/redfish/v1/Managers/bmc/EthernetInterfaces/eth0

Result: UseDNSServers value is set to false for DHCPv4 and DHCPv6 for
all interfaces.

After this commit: Request: curl -k -H "X-Auth-Token: $bmc_token" -X
PATCH -d '{"DHCPv4":{"UseDNSServers":false}}'
https://${bmc}/redfish/v1/Managers/bmc/EthernetInterfaces/eth0

Result: UseDNSServers value is set to false only for DHCPv4 only in eth0
as mentioned in the redfish request.

The DHCP configuration was in the network manager level earlier, it has
been moved to interface level with
https://gerrit.openbmc.org/c/openbmc/phosphor-networkd/+/63124.  This
bmcweb change is to separate out the values for IPv4 and IPv6 and to
move the dbus object to the interface level.

Tested by:

Patching the DHCP parameters with redfish request:

 curl -k -H "X-Auth-Token: $bmc_token" -X  PATCH -d
'{"<network_type>":{"<DHCP_param>":<value>}}'
https://${bmc}/redfish/v1/Managers/bmc/EthernetInterfaces/<interface_id>

Verify the value is updated in the network configuration.

Retrieve the DHCP parametrer value with the Get Request: curl -k -H
"X-Auth-Token: $bmc_token" -X GET
https://${bmc}/redfish/v1/Managers/bmc/EthernetInterfaces/<interface_id>

Change-Id: I5db29b6dfc8966ff5af51041da11e5b79da7d1dd
Signed-off-by: Jishnu CM <jishnunambiarcm@duck.com>
```