### PR TITLE
Util api to fetch pretty name for assemblies

### DIFF
--- a/redfish-core/lib/assembly.hpp
+++ b/redfish-core/lib/assembly.hpp
@@ -12,6 +12,7 @@
 #include <boost/system/error_code.hpp>
 #include <boost/url/format.hpp>
 #include <sdbusplus/unpack_properties.hpp>
+#include <utils/name_utils.hpp>
 
 #include <algorithm>
 #include <array>
@@ -382,6 +383,11 @@ inline void
                 messages::internalError(asyncResp->res);
                 return;
             }
+
+            nlohmann::json::json_pointer ptr(
+                "/Assemblies/" + std::to_string(assemblyIndex) + "/Name");
+
+            name_util::getPrettyName(asyncResp, assembly, object, ptr);
 
             for (const auto& [serviceName, interfaceList] : object)
             {


### PR DESCRIPTION
This commit implements change to use util api to fetch prettyName property for any given assembly and publish it as "Name" in assembly schema.

In case prettyName is blank for that FRU, then last part of the object path will be used to populate assembly name.

Validator executed with no new errors.