### PR TITLE
1110: Implement FabricAdapter Oem Slots schema (#803)

### DIFF
--- a/redfish-core/include/schemas.hpp
+++ b/redfish-core/include/schemas.hpp
@@ -134,5 +134,6 @@ namespace redfish
         "OemMessage",
         "OemUpdateService",
         "OemPCIeSlots",
+        "OemFabricAdapter",
     };
 }

--- a/scripts/update_schemas.py
+++ b/scripts/update_schemas.py
@@ -150,6 +150,7 @@ oem_schema_names = [
     "OemMessage",
     "OemUpdateService",
     "OemPCIeSlots",
+    "OemFabricAdapter",
 ]
 
 SCRIPT_DIR = os.path.dirname(os.path.realpath(__file__))

--- a/static/redfish/v1/$metadata/index.xml
+++ b/static/redfish/v1/$metadata/index.xml
@@ -3964,6 +3964,10 @@
         <edmx:Include Namespace="OemPCIeSlots"/>
         <edmx:Include Namespace="OemPCIeSlots.v1_0_0"/>
     </edmx:Reference>
+    <edmx:Reference Uri="/redfish/v1/schema/OemFabricAdapter_v1.xml">
+        <edmx:Include Namespace="OemFabricAdapter"/>
+        <edmx:Include Namespace="OemFabricAdapter.v1_0_0"/>
+    </edmx:Reference>
     <edmx:DataServices>
         <Schema xmlns="http://docs.oasis-open.org/odata/ns/edm" Namespace="Service">
             <EntityContainer Name="Service" Extends="ServiceRoot.v1_0_0.ServiceContainer"/>

--- a/static/redfish/v1/JsonSchemas/OemFabricAdapter/OemFabricAdapter.json
+++ b/static/redfish/v1/JsonSchemas/OemFabricAdapter/OemFabricAdapter.json
@@ -1,0 +1,69 @@
+
+{
+    "$id": "http://redfish.dmtf.org/schemas/v1/OemFabricAdapter.json",
+    "$schema": "http://redfish.dmtf.org/schemas/v1/redfish-schema-v1.json",
+    "copyright": "Copyright 2014-2019 DMTF. For the full DMTF copyright policy, see http://www.dmtf.org/about/policies/copyright",
+    "definitions": {
+        "IBM": {
+            "additionalProperties": true,
+            "description": "Oem properties for IBM.",
+            "patternProperties": {
+                "^([a-zA-Z_][a-zA-Z0-9_]*)?@(odata|Redfish|Message)\\.[a-zA-Z_][a-zA-Z0-9_]*$": {
+                    "description": "This property shall specify a valid odata or Redfish property.",
+                    "type": [
+                        "array",
+                        "boolean",
+                        "integer",
+                        "number",
+                        "null",
+                        "object",
+                        "string"
+                    ]
+                }
+            },
+            "properties": {
+                "Slots": {
+                    "description": "PCIe Slots",
+                    "longDescription": "Represent PCIe Slots contained by the adapter.",
+                    "readonly": true,
+                    "type": "object"
+                }
+            },
+            "type": "object"
+        },
+        "Oem": {
+            "additionalProperties": true,
+            "description": "OemFabricAdapter Oem properties.",
+            "patternProperties": {
+                "^([a-zA-Z_][a-zA-Z0-9_]*)?@(odata|Redfish|Message)\\.[a-zA-Z_][a-zA-Z0-9_]*$": {
+                    "description": "This property shall specify a valid odata or Redfish property.",
+                    "type": [
+                        "array",
+                        "boolean",
+                        "integer",
+                        "number",
+                        "null",
+                        "object",
+                        "string"
+                    ]
+                }
+            },
+            "properties": {
+                "IBM": {
+                    "anyOf": [
+                        {
+                            "$ref": "#/definitions/IBM"
+                        },
+                        {
+                            "type": "null"
+                        }
+                    ]
+                }
+            },
+            "type": "object"
+        }
+    },
+    "owningEntity": "IBM",
+    "release": "1.0",
+    "title": "#OemFabricAdapter.v1_0_0"
+}

--- a/static/redfish/v1/JsonSchemas/OemPCIeSlots/OemPCIeSlots.json
+++ b/static/redfish/v1/JsonSchemas/OemPCIeSlots/OemPCIeSlots.json
@@ -90,8 +90,40 @@
                 }
             },
             "type": "object"
+        },
+        "PCIeLinks": {
+            "additionalProperties": true,
+            "description": "Oem link properties for IBM.",
+            "patternProperties": {
+                "^([a-zA-Z_][a-zA-Z0-9_]*)?@(odata|Redfish|Message)\\.[a-zA-Z_][a-zA-Z0-9_]*$": {
+                    "description": "This property shall specify a valid odata or Redfish property.",
+                    "type": [
+                        "array",
+                        "boolean",
+                        "integer",
+                        "number",
+                        "null",
+                        "object",
+                        "string"
+                    ]
+                }
+            },
+            "properties": {
+                "UpstreamFabricAdapters": {
+                    "description": "The upstream fabric adapters.",
+                    "items": {
+                        "$ref": "http://redfish.dmtf.org/schemas/v1/FabricAdapter.json#/definitions/FabricAdapter"
+                    },
+                    "longDescription": "This property shall contain an array of links to the upstream fabric adapters.",
+                    "readonly": true,
+                    "type": "array"
+                },
+                "UpstreamFabricAdapters@odata.count": {
+                    "$ref": "http://redfish.dmtf.org/schemas/v1/odata-v4.json#/definitions/count"
+                }
+            },
+            "type": "object"
         }
-
     },
     "owningEntity": "IBM",
     "release": "1.0",

--- a/static/redfish/v1/schema/OemFabricAdapter_v1.xml
+++ b/static/redfish/v1/schema/OemFabricAdapter_v1.xml
@@ -10,13 +10,10 @@
   <edmx:Reference Uri="http://redfish.dmtf.org/schemas/v1/RedfishExtensions_v1.xml">
     <edmx:Include Namespace="RedfishExtensions.v1_0_0" Alias="Redfish"/>
   </edmx:Reference>
-  <edmx:Reference Uri="http://redfish.dmtf.org/schemas/v1/FabricAdapter_v1.xml">
-    <edmx:Include Namespace="FabricAdapter"/>
-  </edmx:Reference>
-  <edmx:Reference Uri="http://redfish.dmtf.org/schemas/v1/PCIeSlots_v1.xml">
-    <edmx:Include Namespace="PCIeSlots"/>
-    <edmx:Include Namespace="PCIeSlots.v1_5_0"/>
-  </edmx:Reference>
+    <edmx:Reference Uri="http://redfish.dmtf.org/schemas/v1/PCIeDevice_v1.xml">
+        <edmx:Include Namespace="PCIeDevice"/>
+        <edmx:Include Namespace="PCIeDevice.v1_9_0"/>
+    </edmx:Reference>
   <edmx:Reference Uri="http://redfish.dmtf.org/schemas/v1/Resource_v1.xml">
     <edmx:Include Namespace="Resource"/>
     <edmx:Include Namespace="Resource.v1_0_0"/>
@@ -24,18 +21,18 @@
 
   <edmx:DataServices>
 
-    <Schema xmlns="http://docs.oasis-open.org/odata/ns/edm" Namespace="OemPCIeSlots">
+    <Schema xmlns="http://docs.oasis-open.org/odata/ns/edm" Namespace="OemFabricAdapter">
       <Annotation Term="Redfish.OwningEntity" String="IBM"/>
     </Schema>
 
-    <Schema xmlns="http://docs.oasis-open.org/odata/ns/edm" Namespace="OemPCIeSlots.v1_0_0">
+    <Schema xmlns="http://docs.oasis-open.org/odata/ns/edm" Namespace="OemFabricAdapter.v1_0_0">
       <Annotation Term="Redfish.OwningEntity" String="IBM"/>
 
       <ComplexType Name="Oem" BaseType="Resource.OemObject">
         <Annotation Term="OData.AdditionalProperties" Bool="true"/>
-        <Annotation Term="OData.Description" String="OemPCIeSlots Oem properties."/>
+        <Annotation Term="OData.Description" String="OemFabricAdapter Oem properties."/>
         <Annotation Term="OData.AutoExpand"/>
-        <Property Name="IBM" Type="OemPCIeSlots.v1_0_0.IBM"/>
+        <Property Name="IBM" Type="OemFabricAdapter.IBM"/>
       </ComplexType>
 
       <ComplexType Name="IBM" BaseType="Resource.OemObject">
@@ -43,25 +40,10 @@
         <Annotation Term="OData.Description" String="Oem properties for IBM." />
         <Annotation Term="OData.AutoExpand"/>
 
-        <Property Name="PCIeSlot" Type="OemPCIeSlots.v1_0_0.PCIeSlot"/>
-
-      </ComplexType>
-
-      <ComplexType Name="PCIeSlot" BaseType="Resource.OemObject">
-        <Property Name="LinkId" Type="Edm.Int64">
+        <Property Name="Slots" Type="Resource.Resource">
           <Annotation Term="OData.Permissions" EnumMember="OData.Permission/Read"/>
-          <Annotation Term="OData.Description" String="Number of PCIe lanes in use."/>
-        </Property>
-      </ComplexType>
-
-      <ComplexType Name="PCIeLinks" BaseType="Resource.OemObject">
-        <Annotation Term="OData.AdditionalProperties" Bool="true" />
-        <Annotation Term="OData.Description" String="Oem properties for IBM." />
-        <Annotation Term="OData.AutoExpand"/>
-        <Property Name="UpstreamFabricAdapters" Type="Collection(FabricAdapter.FabricAdapter)">
-          <Annotation Term="OData.Permissions" EnumMember="OData.Permission/Read"/>
-          <Annotation Term="OData.Description" String="The upstream fabric adapters."/>
-          <Annotation Term="OData.LongDescription" String="This property shall contain an array of links to the upstream fabric adapters."/>
+          <Annotation Term="OData.Description" String="PCIe Slots"/>
+         <Annotation Term="OData.LongDescription" String="Represent PCIe Slots contained by the adapter"/>
         </Property>
       </ComplexType>
 


### PR DESCRIPTION
To support the correct location codes for spliiter I/O slots, new associations between FabricAdapter and its PCIeSlots are created by:

- https://gerrit.openbmc.org/c/openbmc/phosphor-dbus-interfaces/+/63812
- https://github.com/ibm-openbmc/pldm/pull/416

Using these associations, BMCWEB will show them via OEM properties as follows.

This also allowes multiple fabric adapters on a slot.
- Allow multiple fabric adapters on a PCIeSlots via `UpstreamFabricAdapters`

- FabricAdapter -> PCIeSlots

```
  "@odata.id": "/redfish/v1/Systems/system/FabricAdapters/chassis15361-logical_slot2-io_module2",
  "@odata.type": "#FabricAdapter.v1_4_0.FabricAdapter",
  "Id": "chassis15361-logical_slot2-io_module2",
  ...
  "Oem": {
    "IBM": {
      "@odata.type": "#OemFabricAdapter.v1_0_0.IBM"
      "Slots": {
        "@odata.id": "/redfish/v1/Chassis/chassis15361/PCIeSlots"
      }
    }
  },
}
```

- PCIeSlots -> FabricAdapter

```
$ curl -k -X GET https://${bmc}/redfish/v1/Chassis/chassis15873/PCIeSlots
      "Links": {
        "Oem": {
          "IBM": {
            "@odata.type": "#OemPCIeSlots.v1_0_0.PCIeLinks",
            "UpstreamFabricAdapters": [
              {
                "@odata.id": "/redfish/v1/Systems/system/FabricAdapters/board1-logical_slot1-io_module1"
              },
              {
                "@odata.id": "/redfish/v1/Systems/system/FabricAdapters/board2-logical_slot2-io_module1"
              }
            ],
            "UpstreamFabricAdapters@odata.count": 2
          }
        },
```

Tested:
 - Verify GETs for FabricAdapter and PCIeSlots
 - Run Redfish validator