### PR TITLE
1060: Fix Inconsistent OemAssembly Schema type

### DIFF
--- a/redfish-core/lib/assembly.hpp
+++ b/redfish-core/lib/assembly.hpp
@@ -110,7 +110,7 @@ inline void
             "tod_battery")
         {
             tempyArray.at(assemblyIndex)["Oem"]["OpenBMC"]["@odata.type"] =
-                "#OemAssembly.v1_0_0.Assembly";
+                "#OemAssembly.v1_0_0.OpenBMC";
 
             crow::connections::systemBus->async_method_call(
                 [aResp, assemblyIndex](const boost::system::error_code ec) {
@@ -290,8 +290,7 @@ inline void
                             if (fru == "panel0" || fru == "panel1")
                             {
                                 assemblyData["Oem"]["OpenBMC"]["@odata.type"] =
-                                    "#OemAssembly.v1_0_"
-                                    "0.Assembly";
+                                    "#OemAssembly.v1_0_0.OpenBMC";
 
                                 // if panel is not present,
                                 // implies it is already

--- a/static/redfish/v1/JsonSchemas/OemAssembly/OemAssembly.json
+++ b/static/redfish/v1/JsonSchemas/OemAssembly/OemAssembly.json
@@ -3,7 +3,7 @@
     "$schema": "http://redfish.dmtf.org/schemas/v1/redfish-schema-v1.json",
     "copyright": "Copyright 2014-2019 DMTF. For the full DMTF copyright policy, see http://www.dmtf.org/about/policies/copyright",
     "definitions": {
-        "Assembly": {
+        "OpenBMC": {
             "additionalProperties": false,
             "description": "An indication of whether the system is prepared for the assembly to be removed.",
             "parameters": {},

--- a/static/redfish/v1/schema/OemAssembly_v1.xml
+++ b/static/redfish/v1/schema/OemAssembly_v1.xml
@@ -26,10 +26,10 @@
                 <Annotation Term="OData.AdditionalProperties" Bool="true" />
                 <Annotation Term="OData.Description" String="OemAssembly Oem properties." />
                 <Annotation Term="OData.AutoExpand" />
-                <Property Name="Assembly" Type="OemAssembly.v1_0_0.Assembly" />
+                <Property Name="OpenBMC" Type="OemAssembly.v1_0_0.OpenBMC" />
             </ComplexType>
 
-            <ComplexType Name="Assembly" BaseType="Resource.OemObject">
+            <ComplexType Name="OpenBMC" BaseType="Resource.OemObject">
                 <Annotation Term="OData.AdditionalProperties" Bool="true" />
                 <Annotation Term="OData.Description" String="Oem properties for OpenBMC." />
                 <Annotation Term="OData.AutoExpand" />


### PR DESCRIPTION
OemAssembly uses the inconsistent types between schema and the code. Schema uses like `Oem/Assembly/ReadyToRemove` [1], but the code is referencing it like `Oem/OpenBMC/ReadyToRemove` in Get/Patch [2].

```
    tempyArray.at(assemblyIndex)["Oem"]["OpenBMC"]["@odata.type"] =
                "#OemAssembly.v1_0_0.Assembly";
    ...
    assemblyArray.at(assemblyIndex)["Oem"]["OpenBMC"]["ReadyToRemove"] = false;
    ...
    if (!json_util::readJson(iter2->second, asyncResp->res, "OpenBMC", openbmc))
```

So, the schema will be changed to be consistent as `OpenBMC` like
```
`"#OemAssembly.v1_0_0.OpenBMC"
```

Tested:
- Validator passes

[1] https://github.com/ibm-openbmc/bmcweb/blob/44547a092b185ee76d6a6e3f5ab2a5814c3c8a47/static/redfish/v1/schema/OemAssembly_v1.xml#L32
[2] https://github.com/ibm-openbmc/bmcweb/blob/44547a092b185ee76d6a6e3f5ab2a5814c3c8a47/redfish-core/lib/assembly.hpp#L125C1-L127C34