### PR TITLE
1110: OEM Battery Concurrent Maintenance (#549) (#558)

### DIFF
--- a/redfish-core/include/schemas.hpp
+++ b/redfish-core/include/schemas.hpp
@@ -126,6 +126,7 @@ namespace redfish
         "UpdateService",
         "VirtualMedia",
         "VirtualMediaCollection",
+        "OemAssembly",
         "OemManager",
         "OemManagerAccount",
         "OemComputerSystem",

--- a/scripts/update_schemas.py
+++ b/scripts/update_schemas.py
@@ -142,6 +142,7 @@ include_list = [
 
 # OEM schemas
 oem_schema_names = [
+    "OemAssembly",
     "OemManager",
     "OemManagerAccount",
     "OemComputerSystem",

--- a/static/redfish/v1/$metadata/index.xml
+++ b/static/redfish/v1/$metadata/index.xml
@@ -3934,6 +3934,10 @@
     <edmx:Reference Uri="/redfish/v1/schema/VirtualMediaCollection_v1.xml">
         <edmx:Include Namespace="VirtualMediaCollection"/>
     </edmx:Reference>
+    <edmx:Reference Uri="/redfish/v1/schema/OemAssembly_v1.xml">
+        <edmx:Include Namespace="OemAssembly"/>
+        <edmx:Include Namespace="OemAssembly.v1_0_0"/>
+    </edmx:Reference>
     <edmx:Reference Uri="/redfish/v1/schema/OemManager_v1.xml">
         <edmx:Include Namespace="OemManager"/>
     </edmx:Reference>

--- a/static/redfish/v1/JsonSchemas/OemAssembly/OemAssembly.json
+++ b/static/redfish/v1/JsonSchemas/OemAssembly/OemAssembly.json
@@ -1,0 +1,42 @@
+{
+    "$id": "http://redfish.dmtf.org/schemas/v1/OemAssembly.v1_0_0.json",
+    "$schema": "http://redfish.dmtf.org/schemas/v1/redfish-schema-v1.json",
+    "copyright": "Copyright 2014-2019 DMTF. For the full DMTF copyright policy, see http://www.dmtf.org/about/policies/copyright",
+    "definitions": {
+        "OpenBMC": {
+            "additionalProperties": false,
+            "description": "An indication of whether the system is prepared for the assembly to be removed.",
+            "parameters": {},
+            "patternProperties": {
+                "^([a-zA-Z_][a-zA-Z0-9_]*)?@(odata|Redfish|Message)\\.[a-zA-Z_][a-zA-Z0-9_]*$": {
+                    "description": "This property shall specify a valid odata or Redfish property.",
+                    "type": [
+                        "array",
+                        "boolean",
+                        "integer",
+                        "number",
+                        "null",
+                        "object",
+                        "string"
+                    ]
+                }
+            },
+            "properties": {
+                "ReadyToRemove": {
+                    "description": "An indication of whether the system is prepared for an assembly to be removed.",
+                    "longDescription": "This property shall indicate whether the system is ready for the assembly to be changed.  Setting the value to `true` shall cause the service to perform appropriate actions to allow the assembly to be removed.  Setting the value to `false` shall cause the service to perform appropriate actions to allow the assembly to be installed.",
+                    "readonly": false,
+                    "type": [
+                        "boolean",
+                        "null"
+                    ],
+                    "versionAdded": "v1_0_0"
+                }
+            },
+            "type": "object"
+        }
+    },
+    "OwningEntity": "OpenBMC",
+    "release": "1.0",
+    "title": "#OemAssembly.v1_0_0"
+}

--- a/static/redfish/v1/schema/OemAssembly_v1.xml
+++ b/static/redfish/v1/schema/OemAssembly_v1.xml
@@ -1,0 +1,43 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<edmx:Edmx xmlns:edmx="http://docs.oasis-open.org/odata/ns/edmx" Version="4.0">
+    <edmx:Reference Uri="http://docs.oasis-open.org/odata/odata/v4.0/errata03/csd01/complete/vocabularies/Org.OData.Core.V1.xml">
+        <edmx:Include Namespace="Org.OData.Core.V1" Alias="OData"/>
+    </edmx:Reference>
+    <edmx:Reference Uri="http://redfish.dmtf.org/schemas/v1/Assembly_v1.xml">
+        <edmx:Include Namespace="Assembly"/>
+        <edmx:Include Namespace="Assembly.v1_0_0"/>
+    </edmx:Reference>
+    <edmx:Reference Uri="http://redfish.dmtf.org/schemas/v1/RedfishExtensions_v1.xml">
+        <edmx:Include Namespace="RedfishExtensions.v1_0_0" Alias="Redfish"/>
+    </edmx:Reference>
+    <edmx:Reference Uri="http://redfish.dmtf.org/schemas/v1/Resource_v1.xml">
+        <edmx:Include Namespace="Resource"/>
+        <edmx:Include Namespace="Resource.v1_0_0"/>
+    </edmx:Reference>
+    
+    <edmx:DataServices>
+
+        <Schema xmlns="http://docs.oasis-open.org/odata/ns/edm" Namespace="OemAssembly">
+            <Annotation Term="Redfish.OwningEntity" String="OpenBMC"/>
+        </Schema>
+
+        <Schema xmlns="http://docs.oasis-open.org/odata/ns/edm" Namespace="OemAssembly.v1_0_0">
+            <ComplexType Name="Oem" BaseType="Resource.OemObject">
+                <Annotation Term="OData.AdditionalProperties" Bool="true" />
+                <Annotation Term="OData.Description" String="OemAssembly Oem properties." />
+                <Annotation Term="OData.AutoExpand" />
+                <Property Name="OpenBMC" Type="OemAssembly.v1_0_0.OpenBMC" />
+            </ComplexType>
+
+            <ComplexType Name="OpenBMC" BaseType="Resource.OemObject">
+                <Annotation Term="OData.AdditionalProperties" Bool="true" />
+                <Annotation Term="OData.Description" String="Oem properties for OpenBMC." />
+                <Annotation Term="OData.AutoExpand" />
+                <Property Name="ReadyToRemove" Type="Edm.Boolean" />
+                    <Annotation Term="OData.Description" String="Indicates if the assembly is ready to be removed." />
+                    <Annotation Term="OData.LongDescription" String="Indicates if the system is prepared for the assembly to be removed." />
+            </ComplexType>
+        </Schema>
+
+    </edmx:DataServices>
+</edmx:Edmx>


### PR DESCRIPTION
This has 2 changes (which are needed together).

* Set Functional property after battery CM  (#558)

When bmcweb is told the RTC battery is replaced after a CM operation, set the Functional property on its assembly object path back to true before restarting the adcsensor daemon.

This does two things:
1) Causes the fault LED to turn off
2) Sets the Redfish representation back to healthy so the web UI doesn't
   show it has unhealthy it after the CM operation.  Of course if
   adcsensor detects an error again it would go back to unhealthy.

Since this is handling the fault LED, the previous code that explicitly turned off the fault LED group was removed.





* OEM Battery Concurrent Maintenance For Everest System (#549)

The current impementation of this feature supports the redfish OEM ReadyToRemove property for the TOD battery on assembly. The TOD battery is put in the ReadyToRemove state by stopping the adcsensor application. The reverse occurs when the adcsensor application is restarted. The adcsensor is stopped and started by calling systemd. Note that this implementation only works if the adcsensor application handles one ADC sensor.

The properties of an assemby have been extended to include ["Oem"]["OpenBMC"]["ReadyToRemove"]

The GET and PATCH methods to the route "/redfish/v1/Chassis/chassis/Assembly" now handle the property ["Oem"]["OpenBMC"]["ReadyToRemove"]

The following commands were tested:
```
curl -k -X  GET https://${bmc}/redfish/v1/Chassis/chassis/Assembly
```

```
curl -k -H "Content-Type: application/json" -X PATCH \
    -d '{"Assemblies":[{"MemberId" : "1", "LocationIndicatorActive": true, \
    "Oem": { "OpenBMC": { "ReadyToRemove": true }}}]}' \
    https://${bmc}/redfish/v1/Chassis/chassis/Assembly

curl -k -H "Content-Type: application/json" -X PATCH \
   -d '{"Assemblies":[{"MemberId" : "1", "LocationIndicatorActive": false, \
   "Oem": { "OpenBMC": { "ReadyToRemove": false }}}]}' \
  https://${bmc}/redfish/v1/Chassis/chassis/Assembly
```

NOTE:
The explicit `-H "Content-Type: application/json"` request header is needed for the OWASP security guideline by https://github.com/ibm-openbmc/bmcweb/commit/1aa0c2b84be62a20d8c37a11ad877e0a8a48c69d

The further details are described in (#549).