### PR TITLE
Add pretty name for fabric adapters

### DIFF
--- a/redfish-core/lib/fabric_adapters.hpp
+++ b/redfish-core/lib/fabric_adapters.hpp
@@ -341,6 +341,7 @@ inline void doAdapterGet(const std::shared_ptr<bmcweb::AsyncResp>& asyncResp,
 
 inline void afterGetValidFabricAdapterPath(
     const std::string& adapterId,
+    const std::shared_ptr<bmcweb::AsyncResp>& asyncResp,
     std::function<void(
         const boost::system::error_code&, const std::string& fabricAdapterPath,
         const std::string& serviceName,
@@ -364,6 +365,9 @@ inline void afterGetValidFabricAdapterPath(
             fabricAdapterPath = adapterPath;
             serviceName = serviceMap.begin()->first;
             interfaces = serviceMap.begin()->second;
+
+            nlohmann::json::json_pointer ptr("/Name");
+            name_util::getPrettyName(asyncResp, adapterPath, serviceMap, ptr);
             break;
         }
     }
@@ -372,6 +376,7 @@ inline void afterGetValidFabricAdapterPath(
 
 inline void getValidFabricAdapterPath(
     const std::string& adapterId,
+    const std::shared_ptr<bmcweb::AsyncResp>& asyncResp,
     std::function<void(
         const boost::system::error_code& ec,
         const std::string& fabricAdapterPath, const std::string& serviceName,
@@ -381,7 +386,8 @@ inline void getValidFabricAdapterPath(
         "xyz.openbmc_project.Inventory.Item.FabricAdapter"};
     dbus::utility::getSubTree("/xyz/openbmc_project/inventory", 0, interfaces,
                               std::bind_front(afterGetValidFabricAdapterPath,
-                                              adapterId, std::move(callback)));
+                                              adapterId, asyncResp,
+                                              std::move(callback)));
 }
 
 inline void afterHandleFabricAdapterGet(
@@ -437,9 +443,10 @@ inline void
                                    systemName);
         return;
     }
-    getValidFabricAdapterPath(
-        adapterId, std::bind_front(afterHandleFabricAdapterGet, asyncResp,
-                                   systemName, adapterId));
+    getValidFabricAdapterPath(adapterId, asyncResp,
+                              std::bind_front(afterHandleFabricAdapterGet,
+                                              asyncResp, systemName,
+                                              adapterId));
 }
 
 inline void afterHandleFabricAdapterPatch(
@@ -501,9 +508,10 @@ inline void handleFabricAdapterPatch(
         return;
     }
 
-    getValidFabricAdapterPath(
-        adapterId, std::bind_front(afterHandleFabricAdapterPatch, asyncResp,
-                                   adapterId, locationIndicatorActive));
+    getValidFabricAdapterPath(adapterId, asyncResp,
+                              std::bind_front(afterHandleFabricAdapterPatch,
+                                              asyncResp, adapterId,
+                                              locationIndicatorActive));
 }
 
 inline void handleFabricAdapterCollectionGet(
@@ -624,7 +632,7 @@ inline void
         return;
     }
     getValidFabricAdapterPath(
-        adapterId,
+        adapterId, asyncResp,
         std::bind_front(afterHandleFabricAdapterHead, asyncResp, adapterId));
 }
 


### PR DESCRIPTION
The commit implement changes to make use of util function to
populate name for fabric adapters.

Validator was executed and no new error was found.

Test output:
curl -k -H "X-Auth-Token: $bmc_token" -X GET "https://${BMC_IP}/redfish/v1/Systems/system/FabricAdapters/motherboard-pcieslot8-pcie_card8"
{
  "@odata.id": "/redfish/v1/Systems/system/FabricAdapters/motherboard-pcieslot8-pcie_card8",
  "@odata.type": "#FabricAdapter.v1_4_0.FabricAdapter",
  "Id": "motherboard-pcieslot8-pcie_card8",
  "Links": {
    "PCIeDevices": [
      {
        "@odata.id": "/redfish/v1/Systems/system/PCIeDevices/chassis_motherboard_pcieslot8_pcie_card8"
      }
    ],
    "PCIeDevices@odata.count": 1
  },
  "Location": {
    "PartLocation": {
      "ServiceLabel": "U780C.ND0.RCH0011-P0-C8"
    }
  },
  "Model": "",
  "Name": "PCIe4 x16 or PCIe5 x8 adapter",
  "PartNumber": "",
  "Ports": {
    "@odata.id": "/redfish/v1/Systems/system/FabricAdapters/motherboard-pcieslot8-pcie_card8/Ports"
  },
  "SerialNumber": "",
  "Status": {
    "Health": "OK",
    "State": "Absent"
  }
}
