### PR TITLE
1060: Find PCIeDevice with PCIeSlot with depth of 1

### DIFF
--- a/redfish-core/lib/pcie_slots.hpp
+++ b/redfish-core/lib/pcie_slots.hpp
@@ -95,7 +95,7 @@ inline void
     constexpr std::array<std::string_view, 1> interfaces = {
         "xyz.openbmc_project.Inventory.Item.PCIeDevice"};
     dbus::utility::getSubTree(
-        slotPath, 0, interfaces,
+        slotPath, 1, interfaces,
         [asyncResp,
          index](const boost::system::error_code& ec,
                 const dbus::utility::MapperGetSubTreeResponse& subtree) {


### PR DESCRIPTION
The associated PCIeDevice is currently searched from PCIeSlot subtree with depth of 0, but PDLM expects it is under slots, particularly for multipath splitter.

PLDM models
- One physical slot (Slot with location code Cx)
- Two Logical slots  (Slots with location code Cx-R1/Cx-R2)
- One adapter under each of the logical slot

```
 | |- /xyz/openbmc_project/inventory/system/chassis15873/motherboard3/slot1
    |     | | |- /xyz/openbmc_project/inventory/system/chassis15873/motherboard3/slot1/logical_slot1
    |     | | | `- /xyz/openbmc_project/inventory/system/chassis15873/motherboard3/slot1/logical_slot1/adapter1
    |     | | `- /xyz/openbmc_project/inventory/system/chassis15873/motherboard3/slot1/logical_slot2
    |     | |   `- /xyz/openbmc_project/inventory/system/chassis15873/motherboard3/slot1/logical_slot2/adapter1
```

PLDM expects devices to be populated just underneath the slots - e.g. `depth=1`.