### PR TITLE
1050: Use shared_ptr for request body

### DIFF
--- a/http/routing.hpp
+++ b/http/routing.hpp
@@ -1460,7 +1460,7 @@ class Router
         std::string username = req.session->username;
 
         crow::connections::systemBus->async_method_call(
-            [req{std::move(req)}, asyncResp, &rule, params](
+            [req, asyncResp, &rule, params](
                 const boost::system::error_code ec,
                 const dbus::utility::DBusPropertiesMap& userInfoMap) mutable {
             if (ec)


### PR DESCRIPTION
The `req` member data of the class `Request` is defined as a simple value.

```
struct Request
{
   boost::beast::http::request<boost::beast::http::string_body> req;
...
}
```

This may exhibit a few issues.

- If it is moved to a lambda of user authentication async method call, the original `completeRequest()` may observe the invalid content of it [1]. This is causing a problem for audit recording, esp on PATCH..

```
        crow::connections::systemBus->async_method_call(
            [req{std::move(req)}, asyncResp, &rule, params](
```

- It may be copied (e.g. captured by value) and causing the excessive memory consumption [2], in case `req` is large like the case of code update.

```
    getReqAsyncResp->res.setCompleteRequestHandler(std::bind_front(
        afterIfMatchRequest, std::ref(app), asyncResp, req, ifMatch));
```

To address those issues, the content of`req` would need to be valid until all references are done, and also the copy of `req` would need to be less overhead.

So, it can be changed as `shared_ptr` and captured by value for lambda.

```
   std::shared_ptr<boost::beast::http::request<boost::beast::http::string_body>> reqPtr;
```

```
         crow::connections::systemBus->async_method_call(
-            [req{std::move(req)}, asyncResp, &rule, params](
+            [req, asyncResp, &rule, params](

```

Tested:
- Audit runs correctly
- Debug stmt shows the content correct at `completeRequest()` on PATCH For example,
```
curl -k -d '{"PowerRestorePolicy":"LastState"}'  -X PATCH https://${bmc}:18080/redfish/v1/Systems/system
```
- Validator passes

[1] https://github.com/ibm-openbmc/bmcweb/blob/ef23e48288b35d30baaf57b61299597ca26b1930/http/routing.hpp#L1462C1-L1463C61
[2] https://github.com/ibm-openbmc/bmcweb/blob/ef23e48288b35d30baaf57b61299597ca26b1930/redfish-core/include/query.hpp#L97C1-L98C71