### PR TITLE
Pull Upstream commit: Create Redfish specific setProperty call

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -370,6 +370,7 @@ fs = import('fs')
 
 srcfiles_bmcweb = files(
   'redfish-core/src/error_messages.cpp',
+  'redfish-core/src/utils/dbus_utils.cpp',
   'redfish-core/src/utils/json_utils.cpp',
   'src/boost_asio_ssl.cpp',
   'src/boost_asio.cpp',
@@ -405,6 +406,7 @@ srcfiles_unittest = files(
   'test/redfish-core/include/redfish_aggregator_test.cpp',
   'test/redfish-core/include/registries_test.cpp',
   'test/redfish-core/include/utils/hex_utils_test.cpp',
+  'test/redfish-core/include/utils/dbus_utils.cpp',
   'test/redfish-core/include/utils/ip_utils_test.cpp',
   'test/redfish-core/include/utils/json_utils_test.cpp',
   'test/redfish-core/include/utils/query_param_test.cpp',

--- a/redfish-core/include/utils/dbus_utils.hpp
+++ b/redfish-core/include/utils/dbus_utils.hpp
@@ -1,8 +1,17 @@
 #pragma once
 
+#include "async_resp.hpp"
+#include "dbus_singleton.hpp"
+#include "error_messages.hpp"
 #include "logging.hpp"
 
+#include <nlohmann/json.hpp>
+#include <sdbusplus/asio/property.hpp>
+#include <sdbusplus/message.hpp>
 #include <sdbusplus/unpack_properties.hpp>
+
+#include <memory>
+#include <string_view>
 
 namespace redfish
 {
@@ -23,4 +32,37 @@ struct UnpackErrorPrinter
 };
 
 } // namespace dbus_utils
+
+namespace details
+{
+void afterSetProperty(const std::shared_ptr<bmcweb::AsyncResp>& asyncResp,
+                      const std::string& redfishPropertyName,
+                      const nlohmann::json& propertyValue,
+                      const boost::system::error_code& ec,
+                      const sdbusplus::message_t& msg);
+}
+
+template <typename PropertyType>
+void setDbusProperty(const std::shared_ptr<bmcweb::AsyncResp>& asyncResp,
+                     std::string_view processName,
+                     const sdbusplus::message::object_path& path,
+                     std::string_view interface, std::string_view dbusProperty,
+                     std::string_view redfishPropertyName,
+                     const PropertyType& prop)
+{
+    std::string processNameStr(processName);
+    std::string interfaceStr(interface);
+    std::string dbusPropertyStr(dbusProperty);
+
+    sdbusplus::asio::setProperty(
+        *crow::connections::systemBus, processNameStr, path.str, interfaceStr,
+        dbusPropertyStr, prop,
+        [asyncResp, redfishPropertyNameStr = std::string{redfishPropertyName},
+         jsonProp = nlohmann::json(prop)](const boost::system::error_code& ec,
+                                          const sdbusplus::message_t& msg) {
+        details::afterSetProperty(asyncResp, redfishPropertyNameStr, jsonProp,
+                                  ec, msg);
+    });
+}
+
 } // namespace redfish

--- a/redfish-core/lib/chassis.hpp
+++ b/redfish-core/lib/chassis.hpp
@@ -747,23 +747,8 @@ inline void
              */
             objectPath = "/xyz/openbmc_project/state/chassis0";
         }
-
-        crow::connections::systemBus->async_method_call(
-            [asyncResp](const boost::system::error_code& ec2,
-                        sdbusplus::message_t& sdbusErrMsg) {
-            // Use "Set" method to set the property value.
-            if (ec2)
-            {
-                handleChassisPowerCycleError(ec2, sdbusErrMsg, asyncResp->res);
-
-                return;
-            }
-
-            messages::success(asyncResp->res);
-        },
-            processName, objectPath, "org.freedesktop.DBus.Properties", "Set",
-            interfaceName, destProperty,
-            dbus::utility::DbusVariantType{propertyValue});
+        setDbusProperty(asyncResp, processName, objectPath, interfaceName,
+                        destProperty, "ResetType", propertyValue);
     },
         busName, path, interface, method, "/", 0, interfaces);
 }

--- a/redfish-core/lib/systems.hpp
+++ b/redfish-core/lib/systems.hpp
@@ -2522,46 +2522,6 @@ inline void doNMI(const std::shared_ptr<bmcweb::AsyncResp>& asyncResp)
 }
 
 /**
- * Handle error responses from d-bus for system power requests
- */
-inline void handleSystemActionResetError(const boost::system::error_code& ec,
-                                         const sdbusplus::message_t& eMsg,
-                                         std::string_view resetType,
-                                         crow::Response& res)
-{
-    if (ec.value() == boost::asio::error::invalid_argument)
-    {
-        messages::actionParameterNotSupported(res, resetType, "Reset");
-        return;
-    }
-
-    if (eMsg.get_error() == nullptr)
-    {
-        BMCWEB_LOG_ERROR << "D-Bus response error: " << ec;
-        messages::internalError(res);
-        return;
-    }
-    std::string_view errorMessage = eMsg.get_error()->name;
-
-    // If operation failed due to BMC not being in Ready state, tell
-    // user to retry in a bit
-    if ((errorMessage ==
-         std::string_view(
-             "xyz.openbmc_project.State.Chassis.Error.BMCNotReady")) ||
-        (errorMessage ==
-         std::string_view("xyz.openbmc_project.State.Host.Error.BMCNotReady")))
-    {
-        BMCWEB_LOG_DEBUG << "BMC not ready, operation not allowed right now";
-        messages::serviceTemporarilyUnavailable(res, "10");
-        return;
-    }
-
-    BMCWEB_LOG_ERROR << "System Action Reset transition fail " << ec
-                     << " sdbusplus:" << errorMessage;
-    messages::internalError(res);
-}
-
-/**
  * SystemActionsReset class supports handle POST method for Reset action.
  * The class retrieves and sends data directly to D-Bus.
  */
@@ -2628,45 +2588,20 @@ inline void requestRoutesSystemActionsReset(App& app)
                                              resetType);
             return;
         }
-
+        sdbusplus::message::object_path statePath("/xyz/openbmc_project/state");
         if (hostCommand)
         {
-            crow::connections::systemBus->async_method_call(
-                [asyncResp, resetType](const boost::system::error_code& ec,
-                                       sdbusplus::message_t& sdbusErrMsg) {
-                if (ec)
-                {
-                    handleSystemActionResetError(ec, sdbusErrMsg, resetType,
-                                                 asyncResp->res);
-
-                    return;
-                }
-                messages::success(asyncResp->res);
-            },
-                "xyz.openbmc_project.State.Host",
-                "/xyz/openbmc_project/state/host0",
-                "org.freedesktop.DBus.Properties", "Set",
-                "xyz.openbmc_project.State.Host", "RequestedHostTransition",
-                dbus::utility::DbusVariantType{command});
+            setDbusProperty(asyncResp, "xyz.openbmc_project.State.Host",
+                            statePath / "host0",
+                            "xyz.openbmc_project.State.Host",
+                            "RequestedHostTransition", "Reset", command);
         }
         else
         {
-            crow::connections::systemBus->async_method_call(
-                [asyncResp, resetType](const boost::system::error_code& ec,
-                                       sdbusplus::message_t& sdbusErrMsg) {
-                if (ec)
-                {
-                    handleSystemActionResetError(ec, sdbusErrMsg, resetType,
-                                                 asyncResp->res);
-                    return;
-                }
-                messages::success(asyncResp->res);
-            },
-                "xyz.openbmc_project.State.Chassis",
-                "/xyz/openbmc_project/state/chassis0",
-                "org.freedesktop.DBus.Properties", "Set",
-                "xyz.openbmc_project.State.Chassis", "RequestedPowerTransition",
-                dbus::utility::DbusVariantType{command});
+            setDbusProperty(asyncResp, "xyz.openbmc_project.State.Chassis",
+                            statePath / "chassis0",
+                            "xyz.openbmc_project.State.Chassis",
+                            "RequestedPowerTransition", "Reset", command);
         }
     });
 }

--- a/redfish-core/src/utils/dbus_utils.cpp
+++ b/redfish-core/src/utils/dbus_utils.cpp
@@ -1,0 +1,78 @@
+#include "utils/dbus_utils.hpp"
+
+#include "async_resp.hpp"
+
+#include <boost/system/error_code.hpp>
+#include <nlohmann/json.hpp>
+#include <sdbusplus/message.hpp>
+
+#include <memory>
+#include <string>
+#include <string_view>
+
+namespace redfish
+{
+namespace details
+{
+
+void afterSetProperty(const std::shared_ptr<bmcweb::AsyncResp>& asyncResp,
+                      const std::string& redfishPropertyName,
+                      const nlohmann::json& propertyValue,
+                      const boost::system::error_code& ec,
+                      const sdbusplus::message_t& msg)
+{
+    if (ec)
+    {
+        if (ec.value() == boost::system::errc::permission_denied)
+        {
+            messages::insufficientPrivilege(asyncResp->res);
+        }
+        const sd_bus_error* dbusError = msg.get_error();
+        std::string propertyValueStr = propertyValue.dump(
+            2, ' ', true, nlohmann::json::error_handler_t::replace);
+        if (dbusError != nullptr)
+        {
+            std::string_view errorName(dbusError->name);
+
+            if (errorName == "xyz.openbmc_project.Common.Error.InvalidArgument")
+            {
+                BMCWEB_LOG_WARNING << "DBUS response error: " << ec;
+                messages::propertyValueIncorrect(
+                    asyncResp->res, redfishPropertyName, propertyValueStr);
+                return;
+            }
+            if (errorName ==
+                "xyz.openbmc_project.State.Chassis.Error.BMCNotReady")
+            {
+                BMCWEB_LOG_WARNING
+                    << "BMC not ready, operation not allowed right now";
+                messages::serviceTemporarilyUnavailable(asyncResp->res, "10");
+                return;
+            }
+            if (errorName == "xyz.openbmc_project.State.Host.Error.BMCNotReady")
+            {
+                BMCWEB_LOG_WARNING
+                    << "BMC not ready, operation not allowed right now";
+                messages::serviceTemporarilyUnavailable(asyncResp->res, "10");
+                return;
+            }
+            if (errorName == "xyz.openbmc_project.Common.Error.NotAllowed")
+            {
+                messages::propertyNotWritable(asyncResp->res,
+                                              redfishPropertyName);
+                return;
+            }
+        }
+        BMCWEB_LOG_ERROR << "D-Bus error setting Redfish Property "
+                         << redfishPropertyName << " ec=" << ec;
+        messages::internalError(asyncResp->res);
+        return;
+    }
+    // Only set 204 if another erro hasn't already happened.
+    if (asyncResp->res.result() == boost::beast::http::status::ok)
+    {
+        asyncResp->res.result(boost::beast::http::status::no_content);
+    }
+};
+} // namespace details
+} // namespace redfish

--- a/test/redfish-core/include/utils/dbus_utils.cpp
+++ b/test/redfish-core/include/utils/dbus_utils.cpp
@@ -1,0 +1,74 @@
+
+#include "utils/dbus_utils.hpp"
+
+#include "http_request.hpp"
+#include "http_response.hpp"
+
+#include <boost/beast/http/status.hpp>
+#include <nlohmann/json.hpp>
+
+#include <cstdint>
+#include <optional>
+#include <string>
+#include <system_error>
+#include <vector>
+
+#include <gmock/gmock.h>
+#include <gtest/gtest.h>
+
+namespace redfish::details
+{
+namespace
+{
+
+TEST(DbusUtils, AfterPropertySetSuccess)
+{
+    std::shared_ptr<bmcweb::AsyncResp> asyncResp =
+        std::make_shared<bmcweb::AsyncResp>();
+
+    boost::system::error_code ec;
+    sdbusplus::message_t msg;
+    afterSetProperty(asyncResp, "MyRedfishProperty",
+                     nlohmann::json("MyRedfishValue"), ec, msg);
+
+    EXPECT_EQ(asyncResp->res.result(), boost::beast::http::status::no_content);
+    EXPECT_TRUE(asyncResp->res.jsonValue.empty());
+}
+
+TEST(DbusUtils, AfterPropertySetInternalError)
+{
+    std::shared_ptr<bmcweb::AsyncResp> asyncResp =
+        std::make_shared<bmcweb::AsyncResp>();
+
+    boost::system::error_code ec =
+        boost::system::errc::make_error_code(boost::system::errc::timed_out);
+    sdbusplus::message_t msg;
+    afterSetProperty(asyncResp, "MyRedfishProperty",
+                     nlohmann::json("MyRedfishValue"), ec, msg);
+
+    EXPECT_EQ(asyncResp->res.result(),
+              boost::beast::http::status::internal_server_error);
+    EXPECT_EQ(asyncResp->res.jsonValue.size(), 1);
+    using nlohmann::literals::operator""_json;
+
+    EXPECT_EQ(asyncResp->res.jsonValue,
+              R"({
+                    "error": {
+                    "@Message.ExtendedInfo": [
+                        {
+                        "@odata.type": "#Message.v1_1_1.Message",
+                        "Message": "The request failed due to an internal service error.  The service is still operational.",
+                        "MessageArgs": [],
+                        "MessageId": "Base.1.13.0.InternalError",
+                        "MessageSeverity": "Critical",
+                        "Resolution": "Resubmit the request.  If the problem persists, consider resetting the service."
+                        }
+                    ],
+                    "code": "Base.1.13.0.InternalError",
+                    "message": "The request failed due to an internal service error.  The service is still operational."
+                    }
+                })"_json);
+}
+
+} // namespace
+} // namespace redfish::details


### PR DESCRIPTION
There are currently 78 sdbusplus::asio::setProperty calls in redfish-core. 

This commit invents a setDbusProperty method in the redfish namespace that tries to handle all DBus errors in a consistent manner. 

Upstream commit: https://gerrit.openbmc.org/c/openbmc/bmcweb/+/69477

Tested:
```
curl  -k --user "root:0penBmc" -H "Content-Type: application/json" -X PATCH -d '{"HostName":"openbmc@#"}' https://192.168.7.2/redfish/v1/Managers/bmc/EthernetInterfaces/eth0
```

Returns the appropriate error in the response
Base.1.16.0.PropertyValueIncorrect

Change-Id: If033a1112ba516792c9386c997d090c8f9094f3a