### PR TITLE
Pull Upstream change: Create Redfish specific setProperty call

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -338,6 +338,7 @@ fs = import('fs')
 
 srcfiles_bmcweb = files(
   'redfish-core/src/error_messages.cpp',
+  'redfish-core/src/utils/dbus_utils.cpp',
   'redfish-core/src/utils/json_utils.cpp',
   'src/boost_asio_ssl.cpp',
   'src/boost_asio.cpp',
@@ -374,6 +375,7 @@ srcfiles_unittest = files(
   'test/redfish-core/include/redfish_aggregator_test.cpp',
   'test/redfish-core/include/registries_test.cpp',
   'test/redfish-core/include/utils/hex_utils_test.cpp',
+  'test/redfish-core/include/utils/dbus_utils.cpp',
   'test/redfish-core/include/utils/ip_utils_test.cpp',
   'test/redfish-core/include/utils/json_utils_test.cpp',
   'test/redfish-core/include/utils/query_param_test.cpp',

--- a/redfish-core/include/utils/dbus_utils.hpp
+++ b/redfish-core/include/utils/dbus_utils.hpp
@@ -1,8 +1,17 @@
 #pragma once
 
+#include "async_resp.hpp"
+#include "dbus_singleton.hpp"
+#include "error_messages.hpp"
 #include "logging.hpp"
 
+#include <nlohmann/json.hpp>
+#include <sdbusplus/asio/property.hpp>
+#include <sdbusplus/message.hpp>
 #include <sdbusplus/unpack_properties.hpp>
+
+#include <memory>
+#include <string_view>
 
 namespace redfish
 {
@@ -23,4 +32,37 @@ struct UnpackErrorPrinter
 };
 
 } // namespace dbus_utils
+
+namespace details
+{
+void afterSetProperty(const std::shared_ptr<bmcweb::AsyncResp>& asyncResp,
+                      const std::string& redfishPropertyName,
+                      const nlohmann::json& propertyValue,
+                      const boost::system::error_code& ec,
+                      const sdbusplus::message_t& msg);
+}
+
+template <typename PropertyType>
+void setDbusProperty(const std::shared_ptr<bmcweb::AsyncResp>& asyncResp,
+                     std::string_view processName,
+                     const sdbusplus::message::object_path& path,
+                     std::string_view interface, std::string_view dbusProperty,
+                     std::string_view redfishPropertyName,
+                     const PropertyType& prop)
+{
+    std::string processNameStr(processName);
+    std::string interfaceStr(interface);
+    std::string dbusPropertyStr(dbusProperty);
+
+    sdbusplus::asio::setProperty(
+        *crow::connections::systemBus, processNameStr, path.str, interfaceStr,
+        dbusPropertyStr, prop,
+        [asyncResp, redfishPropertyNameStr = std::string{redfishPropertyName},
+         jsonProp = nlohmann::json(prop)](const boost::system::error_code& ec,
+                                          const sdbusplus::message_t& msg) {
+        details::afterSetProperty(asyncResp, redfishPropertyNameStr, jsonProp,
+                                  ec, msg);
+    });
+}
+
 } // namespace redfish

--- a/redfish-core/lib/account_service.hpp
+++ b/redfish-core/lib/account_service.hpp
@@ -286,7 +286,7 @@ inline void translateAccountType(
     }
     setDbusProperty(asyncResp, "xyz.openbmc_project.User.Manager",
                     dbusObjectPath, "xyz.openbmc_project.User.Attributes",
-                    "UserGroups", "AccountTypes", updatedUserGroups);
+                    "UserGroups", "AccountTypes", updatedUserGroup);
 }
 
 inline void userErrorMessageHandler(
@@ -454,7 +454,7 @@ inline void handleRoleMapPatch(
                         asyncResp, ldapDbusService, roleMapObjData[index].first,
                         "xyz.openbmc_project.User.PrivilegeMapperEntry",
                         "GroupName",
-                        std::format("RemoteRoleMapping/{}/RemoteGroup", index),
+                        "RemoteRoleMapping/" + std::to_string(index) + "/RemoteGroup",
                         *remoteGroup);
                 }
 
@@ -465,7 +465,7 @@ inline void handleRoleMapPatch(
                         asyncResp, ldapDbusService, roleMapObjData[index].first,
                         "xyz.openbmc_project.User.PrivilegeMapperEntry",
                         "Privilege",
-                        std::format("RemoteRoleMapping/{}/LocalRole", index),
+			"RemoteRoleMapping/" + std::to_string(index) + "/LocalRole",
                         *localRole);
                 }
             }

--- a/redfish-core/lib/account_service.hpp
+++ b/redfish-core/lib/account_service.hpp
@@ -284,22 +284,9 @@ inline void translateAccountType(
         BMCWEB_LOG_ERROR << "accountType value unable to mapped";
         return;
     }
-
-    crow::connections::systemBus->async_method_call(
-        [asyncResp](const boost::system::error_code ec) {
-        if (ec)
-        {
-            BMCWEB_LOG_ERROR << "D-Bus responses error: " << ec;
-            messages::internalError(asyncResp->res);
-            return;
-        }
-        messages::success(asyncResp->res);
-        return;
-        },
-        "xyz.openbmc_project.User.Manager", dbusObjectPath,
-        "org.freedesktop.DBus.Properties", "Set",
-        "xyz.openbmc_project.User.Attributes", "UserGroups",
-        dbus::utility::DbusVariantType{updatedUserGroup});
+    setDbusProperty(asyncResp, "xyz.openbmc_project.User.Manager",
+                    dbusObjectPath, "xyz.openbmc_project.User.Attributes",
+                    "UserGroups", "AccountTypes", updatedUserGroups);
 }
 
 inline void userErrorMessageHandler(
@@ -463,81 +450,23 @@ inline void handleRoleMapPatch(
                 // If "RemoteGroup" info is provided
                 if (remoteGroup)
                 {
-                    crow::connections::systemBus->async_method_call(
-                        [asyncResp, roleMapObjData, serverType, index,
-                         remoteGroup](const boost::system::error_code ec,
-                                      const sdbusplus::message::message& msg) {
-                        if (ec)
-                        {
-                            BMCWEB_LOG_ERROR << "DBUS response error: " << ec;
-                            const sd_bus_error* dbusError = msg.get_error();
-                            if (dbusError == nullptr)
-                            {
-                                messages::internalError(asyncResp->res);
-                                return;
-                            }
-                            if ((strcmp(dbusError->name,
-                                        "xyz.openbmc_project.Common.Error."
-                                        "InvalidArgument") == 0))
-                            {
-                                messages::propertyValueIncorrect(asyncResp->res,
-                                                                 "RemoteGroup",
-                                                                 *remoteGroup);
-                                return;
-                            }
-                            messages::internalError(asyncResp->res);
-                            return;
-                        }
-                        asyncResp->res
-                            .jsonValue[serverType]["RemoteRoleMapping"][index]
-                                      ["RemoteGroup"] = *remoteGroup;
-                        },
-                        ldapDbusService, roleMapObjData[index].first,
-                        propertyInterface, "Set",
+                    setDbusProperty(
+                        asyncResp, ldapDbusService, roleMapObjData[index].first,
                         "xyz.openbmc_project.User.PrivilegeMapperEntry",
                         "GroupName",
-                        dbus::utility::DbusVariantType(
-                            std::move(*remoteGroup)));
+                        std::format("RemoteRoleMapping/{}/RemoteGroup", index),
+                        *remoteGroup);
                 }
 
                 // If "LocalRole" info is provided
                 if (localRole)
                 {
-                    crow::connections::systemBus->async_method_call(
-                        [asyncResp, roleMapObjData, serverType, index,
-                         localRole](const boost::system::error_code ec,
-                                    const sdbusplus::message::message& msg) {
-                        if (ec)
-                        {
-                            BMCWEB_LOG_ERROR << "DBUS response error: " << ec;
-                            const sd_bus_error* dbusError = msg.get_error();
-                            if (dbusError == nullptr)
-                            {
-                                messages::internalError(asyncResp->res);
-                                return;
-                            }
-
-                            if ((strcmp(dbusError->name,
-                                        "xyz.openbmc_project.Common.Error."
-                                        "InvalidArgument") == 0))
-                            {
-                                messages::propertyValueIncorrect(
-                                    asyncResp->res, "LocalRole", *localRole);
-                                return;
-                            }
-                            messages::internalError(asyncResp->res);
-                            return;
-                        }
-                        asyncResp->res
-                            .jsonValue[serverType]["RemoteRoleMapping"][index]
-                                      ["LocalRole"] = *localRole;
-                        },
-                        ldapDbusService, roleMapObjData[index].first,
-                        propertyInterface, "Set",
+                    setDbusProperty(
+                        asyncResp, ldapDbusService, roleMapObjData[index].first,
                         "xyz.openbmc_project.User.PrivilegeMapperEntry",
                         "Privilege",
-                        dbus::utility::DbusVariantType(
-                            getPrivilegeFromRoleId(std::move(*localRole))));
+                        std::format("RemoteRoleMapping/{}/LocalRole", index),
+                        *localRole);
                 }
             }
             // Create a new RoleMapping Object.
@@ -863,46 +792,10 @@ inline void handleServiceAddressPatch(
     const std::string& ldapServerElementName,
     const std::string& ldapConfigObject)
 {
-    crow::connections::systemBus->async_method_call(
-        [asyncResp, ldapServerElementName,
-         serviceAddressList](const boost::system::error_code ec,
-                             const sdbusplus::message::message& msg) {
-        if (ec)
-        {
-            BMCWEB_LOG_DEBUG
-                << "Error Occurred in updating the service address";
-            const sd_bus_error* dbusError = msg.get_error();
-            if (dbusError == nullptr)
-            {
-                messages::internalError(asyncResp->res);
-                return;
-            }
-            if ((strcmp(dbusError->name,
-                        "xyz.openbmc_project.Common.Error.InvalidArgument") ==
-                 0))
-            {
-                messages::propertyValueIncorrect(asyncResp->res,
-                                                 "ServiceAddresses",
-                                                 serviceAddressList.front());
-                return;
-            }
-            messages::internalError(asyncResp->res);
-            return;
-        }
-        std::vector<std::string> modifiedserviceAddressList = {
-            serviceAddressList.front()};
-        asyncResp->res.jsonValue[ldapServerElementName]["ServiceAddresses"] =
-            modifiedserviceAddressList;
-        if ((serviceAddressList).size() > 1)
-        {
-            messages::propertyValueModified(asyncResp->res, "ServiceAddresses",
-                                            serviceAddressList.front());
-        }
-        BMCWEB_LOG_DEBUG << "Updated the service address";
-        },
-        ldapDbusService, ldapConfigObject, propertyInterface, "Set",
-        ldapConfigInterface, "LDAPServerURI",
-        dbus::utility::DbusVariantType(serviceAddressList.front()));
+    setDbusProperty(asyncResp, ldapDbusService, ldapConfigObject,
+                    ldapConfigInterface, "LDAPServerURI",
+                    ldapServerElementName + "/ServiceAddress",
+                    serviceAddressList.front());
 }
 /**
  * @brief updates the LDAP Bind DN and updates the
@@ -919,22 +812,10 @@ inline void
                         const std::string& ldapServerElementName,
                         const std::string& ldapConfigObject)
 {
-    crow::connections::systemBus->async_method_call(
-        [asyncResp, username,
-         ldapServerElementName](const boost::system::error_code ec) {
-        if (ec)
-        {
-            BMCWEB_LOG_DEBUG << "Error occurred in updating the username";
-            messages::internalError(asyncResp->res);
-            return;
-        }
-        asyncResp->res.jsonValue[ldapServerElementName]["Authentication"]
-                                ["Username"] = username;
-        BMCWEB_LOG_DEBUG << "Updated the username";
-        },
-        ldapDbusService, ldapConfigObject, propertyInterface, "Set",
-        ldapConfigInterface, "LDAPBindDN",
-        dbus::utility::DbusVariantType(username));
+    setDbusProperty(asyncResp, ldapDbusService, ldapConfigObject,
+                    ldapConfigInterface, "LDAPBindDN",
+                    ldapServerElementName + "/Authentication/Username",
+                    username);
 }
 
 /**
@@ -951,22 +832,10 @@ inline void
                         const std::string& ldapServerElementName,
                         const std::string& ldapConfigObject)
 {
-    crow::connections::systemBus->async_method_call(
-        [asyncResp, password,
-         ldapServerElementName](const boost::system::error_code ec) {
-        if (ec)
-        {
-            BMCWEB_LOG_DEBUG << "Error occurred in updating the password";
-            messages::internalError(asyncResp->res);
-            return;
-        }
-        asyncResp->res.jsonValue[ldapServerElementName]["Authentication"]
-                                ["Password"] = "";
-        BMCWEB_LOG_DEBUG << "Updated the password";
-        },
-        ldapDbusService, ldapConfigObject, propertyInterface, "Set",
-        ldapConfigInterface, "LDAPBindDNPassword",
-        dbus::utility::DbusVariantType(password));
+    setDbusProperty(asyncResp, ldapDbusService, ldapConfigObject,
+                    ldapConfigInterface, "LDAPBindDNPassword",
+                    ldapServerElementName + "/Authentication/Password",
+                    password);
 }
 
 /**
@@ -984,46 +853,11 @@ inline void
                       const std::string& ldapServerElementName,
                       const std::string& ldapConfigObject)
 {
-    crow::connections::systemBus->async_method_call(
-        [asyncResp, baseDNList,
-         ldapServerElementName](const boost::system::error_code ec,
-                                const sdbusplus::message::message& msg) {
-        if (ec)
-        {
-            BMCWEB_LOG_DEBUG << "Error Occurred in Updating the base DN";
-            const sd_bus_error* dbusError = msg.get_error();
-            if (dbusError == nullptr)
-            {
-                messages::internalError(asyncResp->res);
-                return;
-            }
-            if ((strcmp(dbusError->name,
-                        "xyz.openbmc_project.Common.Error.InvalidArgument") ==
-                 0))
-            {
-                messages::propertyValueIncorrect(asyncResp->res,
-                                                 "BaseDistinguishedNames",
-                                                 baseDNList.front());
-                return;
-            }
-            messages::internalError(asyncResp->res);
-            return;
-        }
-        auto& serverTypeJson = asyncResp->res.jsonValue[ldapServerElementName];
-        auto& searchSettingsJson =
-            serverTypeJson["LDAPService"]["SearchSettings"];
-        std::vector<std::string> modifiedBaseDNList = {baseDNList.front()};
-        searchSettingsJson["BaseDistinguishedNames"] = modifiedBaseDNList;
-        if (baseDNList.size() > 1)
-        {
-            messages::propertyValueModified(
-                asyncResp->res, "BaseDistinguishedNames", baseDNList.front());
-        }
-        BMCWEB_LOG_DEBUG << "Updated the base DN";
-        },
-        ldapDbusService, ldapConfigObject, propertyInterface, "Set",
-        ldapConfigInterface, "LDAPBaseDN",
-        dbus::utility::DbusVariantType(baseDNList.front()));
+    setDbusProperty(asyncResp, ldapDbusService, ldapConfigObject,
+                    ldapConfigInterface, "LDAPBaseDN",
+                    ldapServerElementName +
+                        "/LDAPService/SearchSettings/BaseDistinguishedNames",
+                    baseDNList.front());
 }
 /**
  * @brief updates the LDAP user name attribute and updates the
@@ -1040,25 +874,11 @@ inline void
                             const std::string& ldapServerElementName,
                             const std::string& ldapConfigObject)
 {
-    crow::connections::systemBus->async_method_call(
-        [asyncResp, userNameAttribute,
-         ldapServerElementName](const boost::system::error_code ec) {
-        if (ec)
-        {
-            BMCWEB_LOG_DEBUG << "Error Occurred in Updating the "
-                                "username attribute";
-            messages::internalError(asyncResp->res);
-            return;
-        }
-        auto& serverTypeJson = asyncResp->res.jsonValue[ldapServerElementName];
-        auto& searchSettingsJson =
-            serverTypeJson["LDAPService"]["SearchSettings"];
-        searchSettingsJson["UsernameAttribute"] = userNameAttribute;
-        BMCWEB_LOG_DEBUG << "Updated the user name attr.";
-        },
-        ldapDbusService, ldapConfigObject, propertyInterface, "Set",
-        ldapConfigInterface, "UserNameAttribute",
-        dbus::utility::DbusVariantType(userNameAttribute));
+    setDbusProperty(asyncResp, ldapDbusService, ldapConfigObject,
+                    ldapConfigInterface, "UserNameAttribute",
+                    ldapServerElementName +
+                        "LDAPService/SearchSettings/UsernameAttribute",
+                    userNameAttribute);
 }
 
 inline void setPropertyAllowUnauthACFUpload(
@@ -1207,25 +1027,11 @@ inline void handleGroupNameAttrPatch(
     const std::string& ldapServerElementName,
     const std::string& ldapConfigObject)
 {
-    crow::connections::systemBus->async_method_call(
-        [asyncResp, groupsAttribute,
-         ldapServerElementName](const boost::system::error_code ec) {
-        if (ec)
-        {
-            BMCWEB_LOG_DEBUG << "Error Occurred in Updating the "
-                                "groupname attribute";
-            messages::internalError(asyncResp->res);
-            return;
-        }
-        auto& serverTypeJson = asyncResp->res.jsonValue[ldapServerElementName];
-        auto& searchSettingsJson =
-            serverTypeJson["LDAPService"]["SearchSettings"];
-        searchSettingsJson["GroupsAttribute"] = groupsAttribute;
-        BMCWEB_LOG_DEBUG << "Updated the groupname attr";
-        },
-        ldapDbusService, ldapConfigObject, propertyInterface, "Set",
-        ldapConfigInterface, "GroupNameAttribute",
-        dbus::utility::DbusVariantType(groupsAttribute));
+    setDbusProperty(asyncResp, ldapDbusService, ldapConfigObject,
+                    ldapConfigInterface, "GroupNameAttribute",
+                    ldapServerElementName +
+                        "/LDAPService/SearchSettings/GroupsAttribute",
+                    groupsAttribute);
 }
 /**
  * @brief updates the LDAP service enable and updates the
@@ -1241,22 +1047,9 @@ inline void handleServiceEnablePatch(
     const std::string& ldapServerElementName,
     const std::string& ldapConfigObject)
 {
-    crow::connections::systemBus->async_method_call(
-        [asyncResp, serviceEnabled,
-         ldapServerElementName](const boost::system::error_code ec) {
-        if (ec)
-        {
-            BMCWEB_LOG_DEBUG << "Error Occurred in Updating the service enable";
-            messages::internalError(asyncResp->res);
-            return;
-        }
-        asyncResp->res.jsonValue[ldapServerElementName]["ServiceEnabled"] =
-            serviceEnabled;
-        BMCWEB_LOG_DEBUG << "Updated Service enable = " << serviceEnabled;
-        },
-        ldapDbusService, ldapConfigObject, propertyInterface, "Set",
-        ldapEnableInterface, "Enabled",
-        dbus::utility::DbusVariantType(serviceEnabled));
+    setDbusProperty(asyncResp, ldapDbusService, ldapConfigObject,
+                    ldapEnableInterface, "Enabled",
+                    ldapServerElementName + "/ServiceEnabled", serviceEnabled);
 }
 
 inline void
@@ -1566,21 +1359,10 @@ inline void updateUserProperties(
 
         if (enabled)
         {
-            crow::connections::systemBus->async_method_call(
-                [asyncResp](const boost::system::error_code ec) {
-                if (ec)
-                {
-                    BMCWEB_LOG_ERROR << "D-Bus responses error: " << ec;
-                    messages::internalError(asyncResp->res);
-                    return;
-                }
-                messages::success(asyncResp->res);
-                return;
-                },
-                "xyz.openbmc_project.User.Manager", dbusObjectPath,
-                "org.freedesktop.DBus.Properties", "Set",
-                "xyz.openbmc_project.User.Attributes", "UserEnabled",
-                dbus::utility::DbusVariantType{*enabled});
+            setDbusProperty(asyncResp, "xyz.openbmc_project.User.Manager",
+                            dbusObjectPath,
+                            "xyz.openbmc_project.User.Attributes",
+                            "UserEnabled", "Enabled", *enabled);
         }
 
         if (roleId)
@@ -1592,21 +1374,10 @@ inline void updateUserProperties(
                                                  "RoleId");
                 return;
             }
-
-            crow::connections::systemBus->async_method_call(
-                [asyncResp](const boost::system::error_code ec) {
-                if (ec)
-                {
-                    BMCWEB_LOG_ERROR << "D-Bus responses error: " << ec;
-                    messages::internalError(asyncResp->res);
-                    return;
-                }
-                messages::success(asyncResp->res);
-                },
-                "xyz.openbmc_project.User.Manager", dbusObjectPath,
-                "org.freedesktop.DBus.Properties", "Set",
-                "xyz.openbmc_project.User.Attributes", "UserPrivilege",
-                dbus::utility::DbusVariantType{priv});
+            setDbusProperty(asyncResp, "xyz.openbmc_project.User.Manager",
+                            dbusObjectPath,
+                            "xyz.openbmc_project.User.Attributes",
+                            "UserPrivilege", "RoleId", priv);
         }
 
         if (locked)
@@ -1620,23 +1391,10 @@ inline void updateUserProperties(
                                                  "Locked");
                 return;
             }
-
-            crow::connections::systemBus->async_method_call(
-                [asyncResp](const boost::system::error_code ec) {
-                if (ec)
-                {
-                    BMCWEB_LOG_ERROR << "D-Bus responses error: " << ec;
-                    messages::internalError(asyncResp->res);
-                    return;
-                }
-                messages::success(asyncResp->res);
-                return;
-                },
-                "xyz.openbmc_project.User.Manager", dbusObjectPath,
-                "org.freedesktop.DBus.Properties", "Set",
-                "xyz.openbmc_project.User.Attributes",
-                "UserLockedForFailedAttempt",
-                dbus::utility::DbusVariantType{*locked});
+            setDbusProperty(asyncResp, "xyz.openbmc_project.User.Manager",
+                            dbusObjectPath,
+                            "xyz.openbmc_project.User.Attributes",
+                            "UserLockedForFailedAttempt", "Locked", *locked);
         }
         if (accountType)
         {
@@ -1939,19 +1697,11 @@ inline void handleAccountServicePatch(
 
     if (minPasswordLength)
     {
-        crow::connections::systemBus->async_method_call(
-            [asyncResp](const boost::system::error_code ec) {
-            if (ec)
-            {
-                messages::internalError(asyncResp->res);
-                return;
-            }
-            messages::success(asyncResp->res);
-            },
-            "xyz.openbmc_project.User.Manager", "/xyz/openbmc_project/user",
-            "org.freedesktop.DBus.Properties", "Set",
+        setDbusProperty(
+            asyncResp, "xyz.openbmc_project.User.Manager",
+            sdbusplus::message::object_path("/xyz/openbmc_project/user"),
             "xyz.openbmc_project.User.AccountPolicy", "MinPasswordLength",
-            dbus::utility::DbusVariantType(*minPasswordLength));
+            "MinPasswordLength", *minPasswordLength);
     }
 
     if (maxPasswordLength)
@@ -1987,36 +1737,20 @@ inline void handleAccountServicePatch(
 
     if (unlockTimeout)
     {
-        crow::connections::systemBus->async_method_call(
-            [asyncResp](const boost::system::error_code ec) {
-            if (ec)
-            {
-                messages::internalError(asyncResp->res);
-                return;
-            }
-            messages::success(asyncResp->res);
-            },
-            "xyz.openbmc_project.User.Manager", "/xyz/openbmc_project/user",
-            "org.freedesktop.DBus.Properties", "Set",
+        setDbusProperty(
+            asyncResp, "xyz.openbmc_project.User.Manager",
+            sdbusplus::message::object_path("/xyz/openbmc_project/user"),
             "xyz.openbmc_project.User.AccountPolicy", "AccountUnlockTimeout",
-            dbus::utility::DbusVariantType(*unlockTimeout));
+            "AccountLockoutDuration", *unlockTimeout);
     }
     if (lockoutThreshold)
     {
-        crow::connections::systemBus->async_method_call(
-            [asyncResp](const boost::system::error_code ec) {
-            if (ec)
-            {
-                messages::internalError(asyncResp->res);
-                return;
-            }
-            messages::success(asyncResp->res);
-            },
-            "xyz.openbmc_project.User.Manager", "/xyz/openbmc_project/user",
-            "org.freedesktop.DBus.Properties", "Set",
+        setDbusProperty(
+            asyncResp, "xyz.openbmc_project.User.Manager",
+            sdbusplus::message::object_path("/xyz/openbmc_project/user"),
             "xyz.openbmc_project.User.AccountPolicy",
-            "MaxLoginAttemptBeforeLockout",
-            dbus::utility::DbusVariantType(*lockoutThreshold));
+            "MaxLoginAttemptBeforeLockout", "AccountLockoutThreshold",
+            *lockoutThreshold);
     }
 }
 

--- a/redfish-core/lib/chassis.hpp
+++ b/redfish-core/lib/chassis.hpp
@@ -678,36 +678,6 @@ inline void requestRoutesChassis(App& app)
             std::bind_front(handleChassisPatch, std::ref(app)));
 }
 
-/**
- * Handle error responses from d-bus for chassis power cycles
- */
-inline void handleChassisPowerCycleError(const boost::system::error_code& ec,
-                                         const sdbusplus::message_t& eMsg,
-                                         crow::Response& res)
-{
-    if (eMsg.get_error() == nullptr)
-    {
-        BMCWEB_LOG_ERROR << "D-Bus response error: " << ec;
-        messages::internalError(res);
-        return;
-    }
-    std::string_view errorMessage = eMsg.get_error()->name;
-
-    // If operation failed due to BMC not being in Ready state, tell
-    // user to retry in a bit
-    if (errorMessage ==
-        std::string_view("xyz.openbmc_project.State.Chassis.Error.BMCNotReady"))
-    {
-        BMCWEB_LOG_DEBUG << "BMC not ready, operation not allowed right now";
-        messages::serviceTemporarilyUnavailable(res, "10");
-        return;
-    }
-
-    BMCWEB_LOG_ERROR << "Chassis Power Cycle fail " << ec
-                     << " sdbusplus:" << errorMessage;
-    messages::internalError(res);
-}
-
 inline void
     doChassisPowerCycle(const std::shared_ptr<bmcweb::AsyncResp>& asyncResp)
 {
@@ -747,23 +717,8 @@ inline void
              */
             objectPath = "/xyz/openbmc_project/state/chassis0";
         }
-
-        crow::connections::systemBus->async_method_call(
-            [asyncResp](const boost::system::error_code& ec2,
-                        sdbusplus::message_t& sdbusErrMsg) {
-            // Use "Set" method to set the property value.
-            if (ec2)
-            {
-                handleChassisPowerCycleError(ec2, sdbusErrMsg, asyncResp->res);
-
-                return;
-            }
-
-            messages::success(asyncResp->res);
-            },
-            processName, objectPath, "org.freedesktop.DBus.Properties", "Set",
-            interfaceName, destProperty,
-            dbus::utility::DbusVariantType{propertyValue});
+        setDbusProperty(asyncResp, processName, objectPath, interfaceName,
+                        destProperty, "ResetType", propertyValue);
         },
         busName, path, interface, method, "/", 0, interfaces);
 }

--- a/redfish-core/lib/ethernet.hpp
+++ b/redfish-core/lib/ethernet.hpp
@@ -798,20 +798,12 @@ inline void updateIPv4DefaultGateway(
     const std::string& ifaceId, const std::string& gateway,
     const std::shared_ptr<bmcweb::AsyncResp>& asyncResp)
 {
-    crow::connections::systemBus->async_method_call(
-        [asyncResp](const boost::system::error_code ec) {
-        if (ec)
-        {
-            messages::internalError(asyncResp->res);
-            return;
-        }
-        asyncResp->res.result(boost::beast::http::status::no_content);
-        },
-        "xyz.openbmc_project.Network",
-        "/xyz/openbmc_project/network/" + ifaceId,
-        "org.freedesktop.DBus.Properties", "Set",
+    setDbusProperty(
+        asyncResp, "xyz.openbmc_project.Network",
+        sdbusplus::message::object_path("/xyz/openbmc_project/network") /
+            ifaceId,
         "xyz.openbmc_project.Network.EthernetInterface", "DefaultGateway",
-        dbus::utility::DbusVariantType(gateway));
+        "Gateway", gateway);
 }
 /**
  * @brief Creates a static IPv4 entry
@@ -1330,36 +1322,22 @@ inline void
                                            "HostName");
         return;
     }
-    crow::connections::systemBus->async_method_call(
-        [asyncResp](const boost::system::error_code ec) {
-        if (ec)
-        {
-            messages::internalError(asyncResp->res);
-        }
-        },
-        "xyz.openbmc_project.Network", "/xyz/openbmc_project/network/config",
-        "org.freedesktop.DBus.Properties", "Set",
+    setDbusProperty(
+        asyncResp, "xyz.openbmc_project.Network",
+        sdbusplus::message::object_path("/xyz/openbmc_project/network/config"),
         "xyz.openbmc_project.Network.SystemConfiguration", "HostName",
-        dbus::utility::DbusVariantType(hostname));
+        "HostName", hostname);
 }
 
 inline void
     handleMTUSizePatch(const std::string& ifaceId, const size_t mtuSize,
                        const std::shared_ptr<bmcweb::AsyncResp>& asyncResp)
 {
-    sdbusplus::message::object_path objPath = "/xyz/openbmc_project/network/" +
-                                              ifaceId;
-    crow::connections::systemBus->async_method_call(
-        [asyncResp](const boost::system::error_code ec) {
-        if (ec)
-        {
-            messages::internalError(asyncResp->res);
-        }
-        },
-        "xyz.openbmc_project.Network", objPath,
-        "org.freedesktop.DBus.Properties", "Set",
-        "xyz.openbmc_project.Network.EthernetInterface", "MTU",
-        std::variant<size_t>(mtuSize));
+    sdbusplus::message::object_path objPath("/xyz/openbmc_project/network");
+    objPath /= ifaceId;
+    setDbusProperty(asyncResp, "xyz.openbmc_project.Network", objPath,
+                    "xyz.openbmc_project.Network.EthernetInterface", "MTU",
+                    "MTUSize", mtuSize);
 }
 
 inline void
@@ -1368,18 +1346,12 @@ inline void
                           const std::shared_ptr<bmcweb::AsyncResp>& asyncResp)
 {
     std::vector<std::string> vectorDomainname = {domainname};
-    crow::connections::systemBus->async_method_call(
-        [asyncResp](const boost::system::error_code ec) {
-        if (ec)
-        {
-            messages::internalError(asyncResp->res);
-        }
-        },
-        "xyz.openbmc_project.Network",
-        "/xyz/openbmc_project/network/" + ifaceId,
-        "org.freedesktop.DBus.Properties", "Set",
-        "xyz.openbmc_project.Network.EthernetInterface", "DomainName",
-        dbus::utility::DbusVariantType(vectorDomainname));
+    setDbusProperty(
+        asyncResp, "xyz.openbmc_project.Network",
+        sdbusplus::message::object_path("/xyz/openbmc_project/network") /
+            ifaceId,
+        "xyz.openbmc_project.Network.EthernetInterface", "DomainName", "FQDN",
+        vectorDomainname);
 }
 
 inline bool isHostnameValid(const std::string& hostname)
@@ -1446,34 +1418,12 @@ inline void
                           const std::string& macAddress,
                           const std::shared_ptr<bmcweb::AsyncResp>& asyncResp)
 {
-    static constexpr std::string_view dbusNotAllowedError =
-        "xyz.openbmc_project.Common.Error.NotAllowed";
-
-    crow::connections::systemBus->async_method_call(
-        [asyncResp, macAddress](const boost::system::error_code ec,
-                                const sdbusplus::message_t& msg) {
-        if (ec)
-        {
-            const sd_bus_error* err = msg.get_error();
-            if (err == nullptr)
-            {
-                messages::internalError(asyncResp->res);
-                return;
-            }
-            if (err->name == dbusNotAllowedError)
-            {
-                messages::propertyNotWritable(asyncResp->res, "MACAddress");
-                return;
-            }
-            messages::internalError(asyncResp->res);
-            return;
-        }
-        },
-        "xyz.openbmc_project.Network",
-        "/xyz/openbmc_project/network/" + ifaceId,
-        "org.freedesktop.DBus.Properties", "Set",
-        "xyz.openbmc_project.Network.MACAddress", "MACAddress",
-        dbus::utility::DbusVariantType(macAddress));
+    setDbusProperty(
+        asyncResp, "xyz.openbmc_project.Network",
+        sdbusplus::message::object_path("/xyz/openbmc_project/network") /
+            ifaceId,
+        "xyz.openbmc_project.Network.MACAddress", "MACAddress", "MACAddress",
+        macAddress);
 }
 
 inline void setDHCPEnabled(const std::string& ifaceId,
@@ -1482,61 +1432,35 @@ inline void setDHCPEnabled(const std::string& ifaceId,
                            const std::shared_ptr<bmcweb::AsyncResp>& asyncResp)
 {
     const std::string dhcp = getDhcpEnabledEnumeration(v4Value, v6Value);
-    crow::connections::systemBus->async_method_call(
-        [asyncResp](const boost::system::error_code ec) {
-        if (ec)
-        {
-            BMCWEB_LOG_ERROR << "D-Bus responses error: " << ec;
-            messages::internalError(asyncResp->res);
-            return;
-        }
-        messages::success(asyncResp->res);
-        },
-        "xyz.openbmc_project.Network",
-        "/xyz/openbmc_project/network/" + ifaceId,
-        "org.freedesktop.DBus.Properties", "Set",
-        "xyz.openbmc_project.Network.EthernetInterface", propertyName,
-        dbus::utility::DbusVariantType{dhcp});
+    setDbusProperty(
+        asyncResp, "xyz.openbmc_project.Network",
+        sdbusplus::message::object_path("/xyz/openbmc_project/network") /
+            ifaceId,
+        "xyz.openbmc_project.Network.EthernetInterface", propertyName, "DHCPv4",
+        dhcp);
 }
 
 inline void setIPv6AcceptRA(const std::string& ifaceId, const bool ipv6AcceptRA,
                             const std::shared_ptr<bmcweb::AsyncResp>& asyncResp)
 {
-    crow::connections::systemBus->async_method_call(
-        [asyncResp](const boost::system::error_code ec) {
-        if (ec)
-        {
-            BMCWEB_LOG_ERROR << "D-Bus responses error: " << ec;
-            messages::internalError(asyncResp->res);
-            return;
-        }
-        messages::success(asyncResp->res);
-        },
-        "xyz.openbmc_project.Network",
-        "/xyz/openbmc_project/network/" + ifaceId,
-        "org.freedesktop.DBus.Properties", "Set",
+    setDbusProperty(
+        asyncResp, "xyz.openbmc_project.Network",
+        sdbusplus::message::object_path("/xyz/openbmc_project/network") /
+            ifaceId,
         "xyz.openbmc_project.Network.EthernetInterface", "IPv6AcceptRA",
-        dbus::utility::DbusVariantType{ipv6AcceptRA});
+        "IPv6AcceptRA", ipv6AcceptRA);
 }
 
 inline void setEthernetInterfaceBoolProperty(
     const std::string& ifaceId, const std::string& propertyName,
     const bool& value, const std::shared_ptr<bmcweb::AsyncResp>& asyncResp)
 {
-    crow::connections::systemBus->async_method_call(
-        [asyncResp](const boost::system::error_code ec) {
-        if (ec)
-        {
-            BMCWEB_LOG_ERROR << "D-Bus responses error: " << ec;
-            messages::internalError(asyncResp->res);
-            return;
-        }
-        },
-        "xyz.openbmc_project.Network",
-        "/xyz/openbmc_project/network/" + ifaceId,
-        "org.freedesktop.DBus.Properties", "Set",
+    setDbusProperty(
+        asyncResp, "xyz.openbmc_project.Network",
+        sdbusplus::message::object_path("/xyz/openbmc_project/network") /
+            ifaceId,
         "xyz.openbmc_project.Network.EthernetInterface", propertyName,
-        dbus::utility::DbusVariantType{value});
+        "InterfaceEnabled", value);
 }
 
 enum class NetworkType
@@ -2427,8 +2351,13 @@ inline void requestEthernetInterfacesRoutes(App& app)
 
             if (interfaceEnabled)
             {
-                setEthernetInterfaceBoolProperty(ifaceId, "NICEnabled",
-                                                 *interfaceEnabled, asyncResp);
+                setDbusProperty(asyncResp, "xyz.openbmc_project.Network",
+                                sdbusplus::message::object_path(
+                                    "/xyz/openbmc_project/network") /
+                                    ifaceId,
+                                "xyz.openbmc_project.Network.EthernetInterface",
+                                "NICEnabled", "InterfaceEnabled",
+                                *interfaceEnabled);
             }
 
             if (mtuSize)

--- a/redfish-core/lib/hypervisor_system.hpp
+++ b/redfish-core/lib/hypervisor_system.hpp
@@ -507,21 +507,11 @@ inline void handleHypSLAACAutoConfigPatch(
 {
     const std::string dhcp = translateIPv6AutoConfigToDHCPEnabled(
         ethData.dhcpEnabled, ipv6AutoConfigEnabled);
-    crow::connections::systemBus->async_method_call(
-        [asyncResp](const boost::system::error_code ec) {
-        if (ec)
-        {
-            BMCWEB_LOG_ERROR << "D-Bus responses error: " << ec;
-            messages::internalError(asyncResp->res);
-            return;
-        }
-        messages::success(asyncResp->res);
-        },
-        "xyz.openbmc_project.Network.Hypervisor",
-        "/xyz/openbmc_project/network/hypervisor/" + ifaceId,
-        "org.freedesktop.DBus.Properties", "Set",
-        "xyz.openbmc_project.Network.EthernetInterface", "DHCPEnabled",
-        std::variant<std::string>{dhcp});
+    setDbusProperty(asyncResp, "xyz.openbmc_project.Network.Hypervisor",
+		    sdbusplus::message::object_path(
+			    "/xyz/openbmc_project/network/hypervisor") / ifaceId,
+		    "xyz.openbmc_project.Network.EthernetInterface", "DHCPEnabled",
+		    "StatelessAddressAutoConfig/IPv6AutoConfigEnabled", dhcp);
 }
 
 inline void
@@ -536,18 +526,11 @@ inline void
     }
 
     asyncResp->res.jsonValue["HostName"] = hostName;
-    crow::connections::systemBus->async_method_call(
-        [asyncResp](const boost::system::error_code ec) {
-        if (ec)
-        {
-            messages::internalError(asyncResp->res);
-        }
-        },
-        "xyz.openbmc_project.Network.Hypervisor",
-        "/xyz/openbmc_project/network/hypervisor/config",
-        "org.freedesktop.DBus.Properties", "Set",
-        "xyz.openbmc_project.Network.SystemConfiguration", "HostName",
-        std::variant<std::string>(hostName));
+    setDbusProperty(asyncResp, "xyz.openbmc_project.Network.Hypervisor",
+                    sdbusplus::message::object_path(
+                        "/xyz/openbmc_project/network/hypervisor/config"),
+                    "xyz.openbmc_project.Network.SystemConfiguration",
+                    "HostName", "HostName", hostName);
 }
 
 /**
@@ -783,19 +766,11 @@ inline void setIpv6DhcpOperatingMode(
                 "xyz.openbmc_project.Network.EthernetInterface.DHCPConf.none";
         }
     }
-    crow::connections::systemBus->async_method_call(
-        [asyncResp](const boost::system::error_code ec) {
-        if (ec)
-        {
-            messages::internalError(asyncResp->res);
-            return;
-        }
-        },
-        "xyz.openbmc_project.Network.Hypervisor",
-        "/xyz/openbmc_project/network/hypervisor/" + ifaceId,
-        "org.freedesktop.DBus.Properties", "Set",
-        "xyz.openbmc_project.Network.EthernetInterface", "DHCPEnabled",
-        std::variant<std::string>(ipv6DHCP));
+    setDbusProperty(asyncResp, "xyz.openbmc_project.Network.Hypervisor",
+		    sdbusplus::message::object_path(
+			    "/xyz/openbmc_project/network/hypervisor") / ifaceId,
+		    "xyz.openbmc_project.Network.EthernetInterface", "DHCPEnabled",
+		    "DHCPv6/OperatingMode", ipv6DHCP);
 }
 
 inline void setDHCPEnabled(const std::string& ifaceId,
@@ -855,39 +830,24 @@ inline void setDHCPEnabled(const std::string& ifaceId,
         }
     }
 
-    crow::connections::systemBus->async_method_call(
-        [asyncResp](const boost::system::error_code ec) {
-        if (ec)
-        {
-            messages::internalError(asyncResp->res);
-            return;
-        }
-        },
-        "xyz.openbmc_project.Network.Hypervisor",
-        "/xyz/openbmc_project/network/hypervisor/" + ifaceId,
-        "org.freedesktop.DBus.Properties", "Set",
-        "xyz.openbmc_project.Network.EthernetInterface", "DHCPEnabled",
-        std::variant<std::string>(ipv4DHCP));
+
+    setDbusProperty(asyncResp, "xyz.openbmc_project.Network.Hypervisor",
+                    sdbusplus::message::object_path(
+                        "/xyz/openbmc_project/network/hypervisor") /
+                        ifaceId,
+                    "xyz.openbmc_project.Network.EthernetInterface",
+                    "DHCPEnabled", "DHCPv4/DHCPEnabled", ipv4DHCP);
 }
 
 inline void
     setIPv4InterfaceEnabled(const std::string& ifaceId, const bool& isActive,
                             const std::shared_ptr<bmcweb::AsyncResp>& asyncResp)
 {
-    crow::connections::systemBus->async_method_call(
-        [asyncResp](const boost::system::error_code ec) {
-        if (ec)
-        {
-            BMCWEB_LOG_ERROR << "D-Bus responses error: " << ec;
-            messages::internalError(asyncResp->res);
-            return;
-        }
-        },
-        "xyz.openbmc_project.Network.Hypervisor",
-        "/xyz/openbmc_project/network/hypervisor/" + ifaceId + "/ipv4/addr0",
-        "org.freedesktop.DBus.Properties", "Set",
-        "xyz.openbmc_project.Object.Enable", "Enabled",
-        std::variant<bool>(isActive));
+    setDbusProperty(asyncResp, "xyz.openbmc_project.Network.Hypervisor",
+		    "/xyz/openbmc_project/network/hypervisor/" + ifaceId +
+                        "/ipv4/addr0",
+			"xyz.openbmc_project.Object.Enable", "Enabled",
+			"InterfaceEnabled", isActive);
 }
 
 inline void handleHypervisorIPv4StaticPatch(
@@ -1081,20 +1041,11 @@ inline void handleHypV6DefaultGatewayPatch(
     const std::string& ifaceId, const std::string& ipv6DefaultGateway,
     const std::shared_ptr<bmcweb::AsyncResp>& asyncResp)
 {
-    crow::connections::systemBus->async_method_call(
-        [asyncResp](const boost::system::error_code ec) {
-        if (ec)
-        {
-            BMCWEB_LOG_ERROR << "D-Bus responses error: " << ec;
-            messages::internalError(asyncResp->res);
-            return;
-        }
-        },
-        "xyz.openbmc_project.Network.Hypervisor",
-        "/xyz/openbmc_project/network/hypervisor/" + ifaceId,
-        "org.freedesktop.DBus.Properties", "Set",
-        "xyz.openbmc_project.Network.EthernetInterface", "DefaultGateway6",
-        std::variant<std::string>(ipv6DefaultGateway));
+    setDbusProperty(asyncResp, "xyz.openbmc_project.Network.Hypervisor",
+		    sdbusplus::message::object_path(
+			    "/xyz/openbmc_project/network/hypervisor") / ifaceId,
+		    "xyz.openbmc_project.Network.EthernetInterface", "DefaultGateway6",
+		    "IPv6DefaultGateway", ipv6DefaultGateway);
 }
 
 inline void requestRoutesHypervisorSystems(App& app)

--- a/redfish-core/lib/sensors.hpp
+++ b/redfish-core/lib/sensors.hpp
@@ -2611,7 +2611,7 @@ inline void setSensorsOverride(
     BMCWEB_LOG_INFO << "setSensorsOverride for subNode"
                     << sensorAsyncResp->chassisSubNode << "\n";
 
-    const char* propertyValueName = nullptr;
+    std::string_view propertyValueName;
     std::unordered_map<std::string, std::pair<double, std::string>> overrideMap;
     std::string memberId;
     double value = 0.0;
@@ -2643,7 +2643,8 @@ inline void setSensorsOverride(
     }
 
     auto getChassisSensorListCb =
-        [sensorAsyncResp, overrideMap](
+        [sensorAsyncResp, overrideMap,
+         propertyValueNameStr = std::string(propertyValueName)](
             const std::shared_ptr<std::set<std::string>>& sensorsList) {
         // Match sensor names in the PATCH request to those managed by the
         // chassis node
@@ -2665,10 +2666,10 @@ inline void setSensorsOverride(
         }
         // Get the connection to which the memberId belongs
         auto getObjectsWithConnectionCb =
-            [sensorAsyncResp,
-             overrideMap](const std::set<std::string>& /*connections*/,
-                          const std::set<std::pair<std::string, std::string>>&
-                              objectsWithConnection) {
+            [sensorAsyncResp, overrideMap, propertyValueNameStr](
+                const std::set<std::string>& /*connections*/,
+                const std::set<std::pair<std::string, std::string>>&
+                    objectsWithConnection) {
             if (objectsWithConnection.size() != overrideMap.size())
             {
                 BMCWEB_LOG_INFO
@@ -2701,30 +2702,10 @@ inline void setSensorsOverride(
                     messages::internalError(sensorAsyncResp->asyncResp->res);
                     return;
                 }
-                crow::connections::systemBus->async_method_call(
-                    [sensorAsyncResp](const boost::system::error_code ec) {
-                    if (ec)
-                    {
-                        if (ec.value() ==
-                            boost::system::errc::permission_denied)
-                        {
-                            BMCWEB_LOG_WARNING
-                                << "Manufacturing mode is not Enabled...can't "
-                                   "Override the sensor value. ";
-
-                            messages::insufficientPrivilege(
-                                sensorAsyncResp->asyncResp->res);
-                            return;
-                        }
-                        BMCWEB_LOG_DEBUG
-                            << "setOverrideValueStatus DBUS error: " << ec;
-                        messages::internalError(
-                            sensorAsyncResp->asyncResp->res);
-                    }
-                    },
-                    item.second, item.first, "org.freedesktop.DBus.Properties",
-                    "Set", "xyz.openbmc_project.Sensor.Value", "Value",
-                    dbus::utility::DbusVariantType(iterator->second.first));
+                setDbusProperty(sensorAsyncResp->asyncResp, item.second,
+                                item.first, "xyz.openbmc_project.Sensor.Value",
+                                "Value", propertyValueNameStr,
+                                iterator->second.first);
             }
         };
         // Get object with connection for the given sensor name

--- a/redfish-core/lib/systems.hpp
+++ b/redfish-core/lib/systems.hpp
@@ -2321,65 +2321,61 @@ inline void requestRoutesSystemActionsReset(App& app)
             return;
         }
 
-    // Get the command and host vs. chassis
-    std::string command;
-    bool hostCommand = true;
-    if ((resetType == "On") || (resetType == "ForceOn"))
-    {
-        command = "xyz.openbmc_project.State.Host.Transition.On";
-        hostCommand = true;
-    }
-    else if (resetType == "ForceOff")
-    {
-        command = "xyz.openbmc_project.State.Chassis.Transition.Off";
-        hostCommand = false;
-    }
-    else if (resetType == "ForceRestart")
-    {
-        command = "xyz.openbmc_project.State.Host.Transition.ForceWarmReboot";
-        hostCommand = true;
-    }
-    else if (resetType == "GracefulShutdown")
-    {
-        command = "xyz.openbmc_project.State.Host.Transition.Off";
-        hostCommand = true;
-    }
-    else if (resetType == "GracefulRestart")
-    {
-        command =
-            "xyz.openbmc_project.State.Host.Transition.GracefulWarmReboot";
-        hostCommand = true;
-    }
-    else if (resetType == "PowerCycle")
-    {
-        command = "xyz.openbmc_project.State.Host.Transition.Reboot";
-        hostCommand = true;
-    }
-    else if (resetType == "Nmi")
-    {
-        doNMI(asyncResp);
-        return;
-    }
-    else
-    {
-        messages::actionParameterUnknown(asyncResp->res, "Reset", resetType);
-        return;
-    }
-    sdbusplus::message::object_path statePath("/xyz/openbmc_project/state");
-
-    if (hostCommand)
-    {
-        setDbusProperty(asyncResp, "xyz.openbmc_project.State.Host",
-                        statePath / "host0", "xyz.openbmc_project.State.Host",
-                        "RequestedHostTransition", "Reset", command);
-    }
-    else
-    {
-        setDbusProperty(asyncResp, "xyz.openbmc_project.State.Chassis",
-                        statePath / "chassis0",
-                        "xyz.openbmc_project.State.Chassis",
-                        "RequestedPowerTransition", "Reset", command);
-    }
+        // Get the command and host vs. chassis
+        std::string command;
+        bool hostCommand = true;
+        if ((resetType == "On") || (resetType == "ForceOn"))
+        {
+            command = "xyz.openbmc_project.State.Host.Transition.On";
+            hostCommand = true;
+        }
+        else if (resetType == "ForceOff")
+        {
+            command = "xyz.openbmc_project.State.Chassis.Transition.Off";
+            hostCommand = false;
+        }
+        else if (resetType == "GracefulShutdown")
+        {
+            command = "xyz.openbmc_project.State.Host.Transition.Off";
+            hostCommand = true;
+        }
+        else if (resetType == "GracefulRestart")
+        {
+            command =
+                "xyz.openbmc_project.State.Host.Transition.GracefulWarmReboot";
+            hostCommand = true;
+        }
+        else if (resetType == "PowerCycle")
+        {
+            command = "xyz.openbmc_project.State.Host.Transition.Reboot";
+            hostCommand = true;
+        }
+        else if (resetType == "Nmi")
+        {
+            doNMI(asyncResp);
+            return;
+        }
+        else
+        {
+            messages::actionParameterUnknown(asyncResp->res, "Reset",
+                                             resetType);
+            return;
+        }
+	sdbusplus::message::object_path statePath("/xyz/openbmc_project/state");
+        if (hostCommand)
+        {
+            setDbusProperty(asyncResp, "xyz.openbmc_project.State.Host",
+                            statePath / "host0", "xyz.openbmc_project.State.Host",
+                            "RequestedHostTransition", "Reset", command);
+        }
+        else
+        {
+            setDbusProperty(asyncResp, "xyz.openbmc_project.State.Chassis",
+                            statePath / "chassis0",
+                            "xyz.openbmc_project.State.Chassis",
+                            "RequestedPowerTransition", "Reset", command);
+        }
+    });
 }
 
 inline void handleComputerSystemCollectionHead(

--- a/redfish-core/src/utils/dbus_utils.cpp
+++ b/redfish-core/src/utils/dbus_utils.cpp
@@ -28,29 +28,29 @@ void afterSetProperty(const std::shared_ptr<bmcweb::AsyncResp>& asyncResp,
             messages::insufficientPrivilege(asyncResp->res);
         }
         const sd_bus_error* dbusError = msg.get_error();
+        std::string propertyValueStr = propertyValue.dump(
+            2, ' ', true, nlohmann::json::error_handler_t::replace);
         if (dbusError != nullptr)
         {
             std::string_view errorName(dbusError->name);
 
             if (errorName == "xyz.openbmc_project.Common.Error.InvalidArgument")
             {
-                BMCWEB_LOG_WARNING("DBUS response error: {}", ec);
+                BMCWEB_LOG_WARNING << "DBUS response error: " << ec;
                 messages::propertyValueIncorrect(
-                    asyncResp->res, redfishPropertyName, propertyValue);
+                    asyncResp->res, redfishPropertyName, propertyValueStr);
                 return;
             }
             if (errorName ==
                 "xyz.openbmc_project.State.Chassis.Error.BMCNotReady")
             {
-                BMCWEB_LOG_WARNING(
-                    "BMC not ready, operation not allowed right now");
+                BMCWEB_LOG_WARNING << "BMC not ready, operation not allowed right now";
                 messages::serviceTemporarilyUnavailable(asyncResp->res, "10");
                 return;
             }
             if (errorName == "xyz.openbmc_project.State.Host.Error.BMCNotReady")
             {
-                BMCWEB_LOG_WARNING(
-                    "BMC not ready, operation not allowed right now");
+                BMCWEB_LOG_WARNING << "BMC not ready, operation not allowed right now";
                 messages::serviceTemporarilyUnavailable(asyncResp->res, "10");
                 return;
             }
@@ -61,8 +61,7 @@ void afterSetProperty(const std::shared_ptr<bmcweb::AsyncResp>& asyncResp,
                 return;
             }
         }
-        BMCWEB_LOG_ERROR("D-Bus error setting Redfish Property {} ec={}",
-                         redfishPropertyName, ec);
+        BMCWEB_LOG_ERROR << "D-Bus error setting Redfish Property " << redfishPropertyName << " ec=" << ec;
         messages::internalError(asyncResp->res);
         return;
     }

--- a/redfish-core/src/utils/dbus_utils.cpp
+++ b/redfish-core/src/utils/dbus_utils.cpp
@@ -1,0 +1,76 @@
+#include "utils/dbus_utils.hpp"
+
+#include "async_resp.hpp"
+
+#include <boost/system/error_code.hpp>
+#include <nlohmann/json.hpp>
+#include <sdbusplus/message.hpp>
+
+#include <memory>
+#include <string>
+#include <string_view>
+
+namespace redfish
+{
+namespace details
+{
+
+void afterSetProperty(const std::shared_ptr<bmcweb::AsyncResp>& asyncResp,
+                      const std::string& redfishPropertyName,
+                      const nlohmann::json& propertyValue,
+                      const boost::system::error_code& ec,
+                      const sdbusplus::message_t& msg)
+{
+    if (ec)
+    {
+        if (ec.value() == boost::system::errc::permission_denied)
+        {
+            messages::insufficientPrivilege(asyncResp->res);
+        }
+        const sd_bus_error* dbusError = msg.get_error();
+        if (dbusError != nullptr)
+        {
+            std::string_view errorName(dbusError->name);
+
+            if (errorName == "xyz.openbmc_project.Common.Error.InvalidArgument")
+            {
+                BMCWEB_LOG_WARNING("DBUS response error: {}", ec);
+                messages::propertyValueIncorrect(
+                    asyncResp->res, redfishPropertyName, propertyValue);
+                return;
+            }
+            if (errorName ==
+                "xyz.openbmc_project.State.Chassis.Error.BMCNotReady")
+            {
+                BMCWEB_LOG_WARNING(
+                    "BMC not ready, operation not allowed right now");
+                messages::serviceTemporarilyUnavailable(asyncResp->res, "10");
+                return;
+            }
+            if (errorName == "xyz.openbmc_project.State.Host.Error.BMCNotReady")
+            {
+                BMCWEB_LOG_WARNING(
+                    "BMC not ready, operation not allowed right now");
+                messages::serviceTemporarilyUnavailable(asyncResp->res, "10");
+                return;
+            }
+            if (errorName == "xyz.openbmc_project.Common.Error.NotAllowed")
+            {
+                messages::propertyNotWritable(asyncResp->res,
+                                              redfishPropertyName);
+                return;
+            }
+        }
+        BMCWEB_LOG_ERROR("D-Bus error setting Redfish Property {} ec={}",
+                         redfishPropertyName, ec);
+        messages::internalError(asyncResp->res);
+        return;
+    }
+    // Only set 204 if another erro hasn't already happened.
+    if (asyncResp->res.result() == boost::beast::http::status::ok)
+    {
+        asyncResp->res.result(boost::beast::http::status::no_content);
+    }
+};
+} // namespace details
+} // namespace redfish

--- a/test/redfish-core/include/utils/dbus_utils.cpp
+++ b/test/redfish-core/include/utils/dbus_utils.cpp
@@ -1,0 +1,74 @@
+
+#include "utils/dbus_utils.hpp"
+
+#include "http_request.hpp"
+#include "http_response.hpp"
+
+#include <boost/beast/http/status.hpp>
+#include <nlohmann/json.hpp>
+
+#include <cstdint>
+#include <optional>
+#include <string>
+#include <system_error>
+#include <vector>
+
+#include <gmock/gmock.h>
+#include <gtest/gtest.h>
+
+namespace redfish::details
+{
+namespace
+{
+
+TEST(DbusUtils, AfterPropertySetSuccess)
+{
+    std::shared_ptr<bmcweb::AsyncResp> asyncResp =
+        std::make_shared<bmcweb::AsyncResp>();
+
+    boost::system::error_code ec;
+    sdbusplus::message_t msg;
+    afterSetProperty(asyncResp, "MyRedfishProperty",
+                     nlohmann::json("MyRedfishValue"), ec, msg);
+
+    EXPECT_EQ(asyncResp->res.result(), boost::beast::http::status::no_content);
+    EXPECT_TRUE(asyncResp->res.jsonValue.empty());
+}
+
+TEST(DbusUtils, AfterPropertySetInternalError)
+{
+    std::shared_ptr<bmcweb::AsyncResp> asyncResp =
+        std::make_shared<bmcweb::AsyncResp>();
+
+    boost::system::error_code ec =
+        boost::system::errc::make_error_code(boost::system::errc::timed_out);
+    sdbusplus::message_t msg;
+    afterSetProperty(asyncResp, "MyRedfishProperty",
+                     nlohmann::json("MyRedfishValue"), ec, msg);
+
+    EXPECT_EQ(asyncResp->res.result(),
+              boost::beast::http::status::internal_server_error);
+    EXPECT_EQ(asyncResp->res.jsonValue.size(), 1);
+    using nlohmann::literals::operator""_json;
+
+    EXPECT_EQ(asyncResp->res.jsonValue,
+              R"({
+                    "error": {
+                    "@Message.ExtendedInfo": [
+                        {
+                        "@odata.type": "#Message.v1_1_1.Message",
+                        "Message": "The request failed due to an internal service error.  The service is still operational.",
+                        "MessageArgs": [],
+                        "MessageId": "Base.1.16.0.InternalError",
+                        "MessageSeverity": "Critical",
+                        "Resolution": "Resubmit the request.  If the problem persists, consider resetting the service."
+                        }
+                    ],
+                    "code": "Base.1.16.0.InternalError",
+                    "message": "The request failed due to an internal service error.  The service is still operational."
+                    }
+                })"_json);
+}
+
+} // namespace
+} // namespace redfish::details


### PR DESCRIPTION
The following PR is pulled for 1050 branch explicitly as it had merge conflicts:
https://github.com/ibm-openbmc/bmcweb/pull/876

This commit invents a setDbusProperty method in the redfish namespace that tries to handle all DBus errors in a consistent manner.

Upstream commit: https://gerrit.openbmc.org/c/openbmc/bmcweb/+/69477