### PR TITLE
Link PCIeSlots to Processor schema

### DIFF
--- a/redfish-core/include/redfish.hpp
+++ b/redfish-core/include/redfish.hpp
@@ -190,7 +190,7 @@ class RedfishService
         requestRoutesMemory(app);
 
         requestRoutesSystems(app);
-
+        requestRoutesSystemActionsOemExecutePanelFunction(app);
         requestRoutesBiosService(app);
         requestRoutesBiosReset(app);
 

--- a/redfish-core/lib/account_service.hpp
+++ b/redfish-core/lib/account_service.hpp
@@ -27,6 +27,7 @@
 #include "utils/dbus_utils.hpp"
 #include "utils/json_utils.hpp"
 
+#include <boost/system/error_code.hpp>
 #include <sdbusplus/asio/property.hpp>
 #include <sdbusplus/unpack_properties.hpp>
 
@@ -274,7 +275,7 @@ inline void
         updatedUserGroups, [asyncResp](const boost::system::error_code& ec) {
         if (ec)
         {
-            BMCWEB_LOG_ERROR("D-Bus responses error: {}", ec);
+            BMCWEB_LOG_ERROR("D-Bus responses error: {}", ec.value());
             messages::internalError(asyncResp->res);
             return;
         }
@@ -997,6 +998,23 @@ inline void
     });
 }
 
+inline void setPropertyAllowUnauthACFUpload(
+    const std::shared_ptr<bmcweb::AsyncResp>& asyncResp, bool allow)
+{
+    sdbusplus::asio::setProperty(
+        *crow::connections::systemBus, "xyz.openbmc_project.Settings",
+        "/xyz/openbmc_project/ibmacf/allow_unauth_upload",
+        "xyz.openbmc_project.Object.Enable", "Enabled", allow,
+        [asyncResp](const boost::system::error_code& ec) {
+        if (ec)
+        {
+            BMCWEB_LOG_ERROR("D-Bus responses error: {}", ec.value());
+            messages::internalError(asyncResp->res);
+            return;
+        }
+    });
+}
+
 inline void getAcfProperties(
     const std::shared_ptr<bmcweb::AsyncResp>& asyncResp,
     const std::tuple<std::vector<uint8_t>, bool, std::string>& messageFDbus)
@@ -1093,6 +1111,22 @@ inline void getAcfProperties(
     }
     asyncResp->res.jsonValue["Oem"]["IBM"]["ACF"]["ACFInstalled"] =
         acfInstalled;
+
+    sdbusplus::asio::getProperty<bool>(
+        *crow::connections::systemBus, "xyz.openbmc_project.Settings",
+        "/xyz/openbmc_project/ibmacf/allow_unauth_upload",
+        "xyz.openbmc_project.Object.Enable", "Enabled",
+        [asyncResp](const boost::system::error_code& ec,
+                    const bool allowUnauthACFUpload) {
+        if (ec)
+        {
+            BMCWEB_LOG_ERROR("D-Bus responses error: {}", ec.value());
+            messages::internalError(asyncResp->res);
+            return;
+        }
+        asyncResp->res.jsonValue["Oem"]["IBM"]["ACF"]["AllowUnauthACFUpload"] =
+            allowUnauthACFUpload;
+    });
 }
 
 /**
@@ -1576,14 +1610,19 @@ inline void uploadACF(const std::shared_ptr<bmcweb::AsyncResp>& asyncResp,
         "InstallACF", decodedAcf);
 }
 
+// This is called when someone either is not authenticated or is not
+// authorized to upload an ACF, and they are trying to upload an ACF;
+// in this condition, uploading an ACF is allowed when
+// AllowUnauthACFUpload is true.
 inline void triggerUnauthenticatedACFUpload(
     const std::shared_ptr<bmcweb::AsyncResp>& asyncResp,
     std::optional<nlohmann::json> oem)
 {
+    std::vector<uint8_t> decodedAcf;
     std::optional<nlohmann::json> ibm;
     if (!redfish::json_util::readJson(*oem, asyncResp->res, "IBM", ibm))
     {
-        BMCWEB_LOG_ERROR("Illegal Property ");
+        BMCWEB_LOG_WARNING("Illegal Property");
         messages::propertyMissing(asyncResp->res, "IBM");
         return;
     }
@@ -1593,7 +1632,7 @@ inline void triggerUnauthenticatedACFUpload(
     {
         if (!redfish::json_util::readJson(*ibm, asyncResp->res, "ACF", acf))
         {
-            BMCWEB_LOG_ERROR("Illegal Property ");
+            BMCWEB_LOG_WARNING("Illegal Property");
             messages::propertyMissing(asyncResp->res, "ACF");
             return;
         }
@@ -1601,12 +1640,11 @@ inline void triggerUnauthenticatedACFUpload(
 
     if (acf)
     {
-        std::vector<uint8_t> decodedAcf;
         std::optional<std::string> acfFile{};
         if (!redfish::json_util::readJson(*acf, asyncResp->res, "ACFFile",
                                           acfFile))
         {
-            BMCWEB_LOG_ERROR("Illegal Property ");
+            BMCWEB_LOG_WARNING("Illegal Property");
             messages::propertyMissing(asyncResp->res, "ACFFile");
             return;
         }
@@ -1629,39 +1667,55 @@ inline void triggerUnauthenticatedACFUpload(
             messages::internalError(asyncResp->res);
             return;
         }
+    }
 
-        crow::connections::systemBus->async_method_call(
-            [asyncResp, decodedAcf](const boost::system::error_code ec,
-                                    const std::variant<bool>& retVal) {
-            if (ec)
+    // Allow ACF upload when D-Bus property allow_unauth_upload is true (aka
+    // Redfish property AllowUnauthACFUpload).
+    sdbusplus::asio::getProperty<bool>(
+        *crow::connections::systemBus, "xyz.openbmc_project.Settings",
+        "/xyz/openbmc_project/ibmacf/allow_unauth_upload",
+        "xyz.openbmc_project.Object.Enable", "Enabled",
+        [asyncResp, decodedAcf](const boost::system::error_code& ec,
+                                const bool allowUnauthACFUpload) {
+        if (ec)
+        {
+            BMCWEB_LOG_ERROR(
+                "D-Bus response error reading allow_unauth_upload: {}",
+                ec.value());
+            messages::internalError(asyncResp->res);
+            return;
+        }
+
+        if (allowUnauthACFUpload)
+        {
+            uploadACF(asyncResp, decodedAcf);
+            return;
+        }
+
+        // Allow ACF upload when D-Bus property ACFWindowActive is true
+        // (aka OpPanel function 74).
+        sdbusplus::asio::getProperty<bool>(
+            *crow::connections::systemBus, "com.ibm.PanelApp",
+            "/com/ibm/panel_app", "com.ibm.panel", "ACFWindowActive",
+            [asyncResp, decodedAcf](const boost::system::error_code& ec1,
+                                    const bool isACFWindowActive) {
+            if (ec1)
             {
                 BMCWEB_LOG_ERROR("Failed to read ACFWindowActive property");
-                messages::internalError(asyncResp->res);
-                return;
+                // The Panel app doesn't run on simulated systems.
             }
 
-            const bool* isACFWindowActive = std::get_if<bool>(&retVal);
-
-            if (isACFWindowActive == nullptr)
+            if (!isACFWindowActive)
             {
-                BMCWEB_LOG_ERROR("nullptr for ACFWindowActive");
-                messages::internalError(asyncResp->res);
-                return;
-            }
-
-            if (!*isACFWindowActive)
-            {
-                BMCWEB_LOG_WARNING("ACF window not set to active from panel");
+                BMCWEB_LOG_ERROR("ACF upload not allowed");
                 messages::insufficientPrivilege(asyncResp->res);
                 return;
             }
 
             uploadACF(asyncResp, decodedAcf);
-        },
-            "com.ibm.PanelApp", "/com/ibm/panel_app",
-            "org.freedesktop.DBus.Properties", "Get", "com.ibm.panel",
-            "ACFWindowActive");
-    }
+            return;
+        });
+    });
 }
 
 inline void handleAccountServiceHead(
@@ -2568,10 +2622,17 @@ inline void
 
     if (oem)
     {
+        if (username != "service")
+        {
+            // Only the service user has Oem properties
+            messages::propertyUnknown(asyncResp->res, "Oem");
+            return;
+        }
+
         std::optional<nlohmann::json> ibm;
         if (!redfish::json_util::readJson(*oem, asyncResp->res, "IBM", ibm))
         {
-            BMCWEB_LOG_ERROR("Illegal Property ");
+            BMCWEB_LOG_WARNING("Illegal Property");
             messages::propertyMissing(asyncResp->res, "IBM");
             return;
         }
@@ -2580,29 +2641,28 @@ inline void
             std::optional<nlohmann::json> acf;
             if (!redfish::json_util::readJson(*ibm, asyncResp->res, "ACF", acf))
             {
-                BMCWEB_LOG_ERROR("Illegal Property ");
+                BMCWEB_LOG_WARNING("Illegal Property");
                 messages::propertyMissing(asyncResp->res, "ACF");
                 return;
             }
-            if (acf && (username == "service"))
+            if (acf)
             {
-                std::vector<uint8_t> decodedAcf;
+                std::optional<bool> allowUnauthACFUpload;
                 std::optional<std::string> acfFile;
-                if (acf.value().contains("ACFFile") &&
-                    acf.value()["ACFFile"] == nullptr)
+                if (!redfish::json_util::readJson(
+                        *acf, asyncResp->res, "ACFFile", acfFile,
+                        "AllowUnauthACFUpload", allowUnauthACFUpload))
                 {
-                    acfFile = "";
+                    BMCWEB_LOG_WARNING("Illegal Property");
+                    messages::propertyMissing(asyncResp->res, "ACFFile");
+                    messages::propertyMissing(asyncResp->res,
+                                              "AllowUnauthACFUpload");
+                    return;
                 }
-                else
-                {
-                    if (!redfish::json_util::readJson(*acf, asyncResp->res,
-                                                      "ACFFile", acfFile))
-                    {
-                        BMCWEB_LOG_ERROR("Illegal Property ");
-                        messages::propertyMissing(asyncResp->res, "ACFFile");
-                        return;
-                    }
 
+                if (acfFile)
+                {
+                    std::vector<uint8_t> decodedAcf;
                     std::string sDecodedAcf;
                     if (!crow::utility::base64Decode(*acfFile, sDecodedAcf))
                     {
@@ -2621,16 +2681,14 @@ inline void
                         messages::internalError(asyncResp->res);
                         return;
                     }
+                    uploadACF(asyncResp, decodedAcf);
                 }
 
-                uploadACF(asyncResp, decodedAcf);
-            }
-            else if (acf && (username != "service"))
-            {
-                messages::resourceAtUriUnauthorized(
-                    asyncResp->res, req.url(),
-                    "ACF properties access not allowed by non service "
-                    "user");
+                if (allowUnauthACFUpload)
+                {
+                    setPropertyAllowUnauthACFUpload(asyncResp,
+                                                    *allowUnauthACFUpload);
+                }
             }
         }
     }

--- a/redfish-core/lib/service_root.hpp
+++ b/redfish-core/lib/service_root.hpp
@@ -27,6 +27,7 @@
 #include "utils/dbus_utils.hpp"
 #include "utils/systemd_utils.hpp"
 
+#include <boost/system/error_code.hpp>
 #include <nlohmann/json.hpp>
 #include <persistent_data.hpp>
 #include <query.hpp>
@@ -43,6 +44,59 @@
 
 namespace redfish
 {
+
+inline void
+    handleACFWindowActive(const std::shared_ptr<bmcweb::AsyncResp>& asyncResp)
+{
+    // Redfish property ACFWindowActive=true when either of these is true:
+    //  - D-Bus property allow_unauth_upload.  (This is aka the Redfish
+    //    property AllowUnauthACFUpload which the BMC admin can control.)
+    //  - D-Bus property ACFWindowActive.  (This is aka the Redfish
+    //    property ACFWindowActive under /redfish/v1/AccountService/
+    //    Accounts/service property Oem.IBM.ACF.  The value is provided by
+    //    the PanelApp and is true when panel function 74 is active.)
+    // Check D-Bus property allow_unauth_upload first.
+    sdbusplus::asio::getProperty<bool>(
+        *crow::connections::systemBus, "xyz.openbmc_project.Settings",
+        "/xyz/openbmc_project/ibmacf/allow_unauth_upload",
+        "xyz.openbmc_project.Object.Enable", "Enabled",
+        [asyncResp](const boost::system::error_code& ec,
+                    const bool allowUnauthACFUpload) {
+        if (ec)
+        {
+            BMCWEB_LOG_ERROR(
+                "D-Bus response error reading allow_unauth_upload: {}",
+                ec.value());
+            messages::internalError(asyncResp->res);
+            return;
+        }
+
+        if (allowUnauthACFUpload)
+        {
+            asyncResp->res.jsonValue["Oem"]["IBM"]["ACFWindowActive"] =
+                allowUnauthACFUpload;
+            return;
+        }
+
+        // Check D-Bus property ACFWindowActive
+        sdbusplus::asio::getProperty<bool>(
+            *crow::connections::systemBus, "com.ibm.PanelApp",
+            "/com/ibm/panel_app", "com.ibm.panel", "ACFWindowActive",
+            [asyncResp](const boost::system::error_code& ec1,
+                        const bool isACFWindowActive) {
+            if (ec1)
+            {
+                BMCWEB_LOG_ERROR("Failed to read ACFWindowActive property");
+                // Default value when panel app is unreachable.
+                asyncResp->res.jsonValue["Oem"]["IBM"]["ACFWindowActive"] =
+                    false;
+                return;
+            }
+            asyncResp->res.jsonValue["Oem"]["IBM"]["ACFWindowActive"] =
+                isACFWindowActive;
+        });
+    });
+}
 
 inline void fillServiceRootOemProperties(
     const std::shared_ptr<bmcweb::AsyncResp>& asyncResp,
@@ -142,7 +196,7 @@ inline void
         redfishDateTimeOffset.first;
     asyncResp->res.jsonValue["Oem"]["IBM"]["DateTimeLocalOffset"] =
         redfishDateTimeOffset.second;
-
+    handleACFWindowActive(asyncResp);
     asyncResp->res.jsonValue["Oem"]["@odata.type"] = "#OemServiceRoot.Oem";
     asyncResp->res.jsonValue["Oem"]["IBM"]["@odata.type"] =
         "#OemServiceRoot.IBM";

--- a/redfish-core/lib/systems.hpp
+++ b/redfish-core/lib/systems.hpp
@@ -2742,6 +2742,157 @@ inline void
     BMCWEB_LOG_DEBUG("EXIT: Get idle power saver parameters");
 }
 
+/*
+ * Handle Enabled Panel Functions
+ */
+inline void doGetEnabledPanelFunctions(
+    const std::shared_ptr<bmcweb::AsyncResp>& asyncResp,
+    std::function<void(const std::vector<uint8_t>&)>&& callback)
+{
+    BMCWEB_LOG_DEBUG("Get Enabled Panel functions");
+
+    crow::connections::systemBus->async_method_call(
+        [asyncResp, callback](const boost::system::error_code& ec,
+                              const std::vector<uint8_t>& enabledFuncs) {
+        if (ec)
+        {
+            BMCWEB_LOG_ERROR("Get Enabled Panel Functions D-bus error: {}",
+                             ec.value());
+            messages::internalError(asyncResp->res);
+            return;
+        }
+        callback(enabledFuncs);
+    },
+        "com.ibm.PanelApp", "/com/ibm/panel_app", "com.ibm.panel",
+        "getEnabledFunctions");
+}
+
+/*
+ * Get Enabled Panel Functions
+ */
+inline void getEnabledPanelFunctions(
+    const std::shared_ptr<bmcweb::AsyncResp>& asyncResp)
+{
+    doGetEnabledPanelFunctions(
+        asyncResp, [asyncResp](const std::vector<uint8_t>& enabledFuncs) {
+        nlohmann::json& oem = asyncResp->res.jsonValue["Oem"];
+        oem["@odata.type"] = "#OemComputerSystem.Oem";
+        oem["IBM"]["@odata.type"] = "#OemComputerSystem.IBM";
+        oem["IBM"]["EnabledPanelFunctions"] = enabledFuncs;
+    });
+}
+
+/**
+ * Execute a Panel Enabled Function
+ */
+inline void
+    executePanelFunction(const std::shared_ptr<bmcweb::AsyncResp>& asyncResp,
+                         const uint8_t funcNo)
+{
+    BMCWEB_LOG_DEBUG("Execute Panel function {}", std::to_string(funcNo));
+
+    crow::connections::systemBus->async_method_call(
+        [asyncResp,
+         funcNo](const boost::system::error_code& ec,
+                 const sdbusplus::message_t& msg,
+                 const std::tuple<bool, std::string, std::string>& result) {
+        if (ec)
+        {
+            const sd_bus_error* dbusError = msg.get_error();
+            if (dbusError == nullptr)
+            {
+                BMCWEB_LOG_ERROR("Execute a panel function D-bus error:  {}",
+                                 ec.value());
+                messages::internalError(asyncResp->res);
+                return;
+            }
+            if (dbusError->name ==
+                std::string_view("xyz.openbmc_project.Common.Error.NotAllowed"))
+            {
+                BMCWEB_LOG_WARNING("PanelFunction {} is not enabled",
+                                   std::to_string(funcNo));
+                messages::operationNotAllowed(asyncResp->res);
+                return;
+            }
+            if (dbusError->name ==
+                std::string_view(
+                    "xyz.openbmc_project.Common.Error.InternalFailure"))
+            {
+                BMCWEB_LOG_ERROR("ExecutePanelFunction {} is failed",
+                                 std::to_string(funcNo));
+                messages::operationFailed(asyncResp->res);
+                return;
+            }
+            BMCWEB_LOG_ERROR("Execute a panel function D-bus error:  {}",
+                             ec.value());
+            messages::internalError(asyncResp->res);
+            return;
+        }
+
+        if (!std::get<0>(result))
+        {
+            BMCWEB_LOG_ERROR("ExecutePanelFunction {} is failed",
+                             std::to_string(funcNo));
+            messages::operationFailed(asyncResp->res);
+            return;
+        }
+        asyncResp->res.jsonValue["Result"] = {std::get<1>(result),
+                                              std::get<2>(result)};
+        messages::success(asyncResp->res);
+    },
+        "com.ibm.PanelApp", "/com/ibm/panel_app", "com.ibm.panel",
+        "ExecuteFunction", funcNo);
+}
+
+inline void handleSystemActionsOemExecutePanelFunctionPost(
+    App& app, const crow::Request& req,
+    const std::shared_ptr<bmcweb::AsyncResp>& asyncResp)
+{
+    BMCWEB_LOG_DEBUG("handleSystemActionsOemExecutePanelFunctionPost...");
+    if (!redfish::setUpRedfishRoute(app, req, asyncResp))
+    {
+        return;
+    }
+
+    uint8_t funcNo = 0;
+    if (!json_util::readJsonAction(req, asyncResp->res, "FuncNo", funcNo))
+    {
+        BMCWEB_LOG_WARNING("Missing funcNo");
+        messages::actionParameterMissing(asyncResp->res, "ExecutePanelFunction",
+                                         "FuncNo");
+        return;
+    }
+
+    doGetEnabledPanelFunctions(
+        asyncResp,
+        [funcNo, asyncResp](const std::vector<uint8_t>& enabledFuncs) {
+        auto it = std::find(enabledFuncs.begin(), enabledFuncs.end(), funcNo);
+        if (it == enabledFuncs.end())
+        {
+            BMCWEB_LOG_WARNING("PanelFunction {} is not enabled",
+                               std::to_string(funcNo));
+            messages::operationNotAllowed(asyncResp->res);
+            return;
+        }
+        executePanelFunction(asyncResp, funcNo);
+    });
+}
+
+/**
+ * SystemActionsOemExecutePanelFunction class supports handle POST method for
+ * ExecutePanelFunction  action. The class retrieves and sends data directly to
+ * D-Bus.
+ */
+inline void requestRoutesSystemActionsOemExecutePanelFunction(App& app)
+{
+    BMCWEB_ROUTE(
+        app,
+        "/redfish/v1/Systems/system/Actions/Oem/OemComputerSystem.ExecutePanelFunction/")
+        .privileges(redfish::privileges::postComputerSystem)
+        .methods(boost::beast::http::verb::post)(std::bind_front(
+            handleSystemActionsOemExecutePanelFunctionPost, std::ref(app)));
+}
+
 /**
  * @brief Sets Idle Power Saver properties.
  *
@@ -3362,6 +3513,13 @@ inline void
     getTrustedModuleRequiredToBoot(asyncResp);
     getPowerMode(asyncResp);
     getIdlePowerSaver(asyncResp);
+
+    // Panel Function
+    getEnabledPanelFunctions(asyncResp);
+
+    nlohmann::json& actionOem = asyncResp->res.jsonValue["Actions"]["Oem"];
+    actionOem["#OemComputerSystem.v1_0_0.ExecutePanelFunction"]["target"] =
+        "/redfish/v1/Systems/system/Actions/Oem/OemComputerSystem.ExecutePanelFunction";
 }
 
 inline void handleComputerSystemPatch(

--- a/static/redfish/v1/$metadata/index.xml
+++ b/static/redfish/v1/$metadata/index.xml
@@ -3947,6 +3947,7 @@
     </edmx:Reference>
     <edmx:Reference Uri="/redfish/v1/schema/OemComputerSystem_v1.xml">
         <edmx:Include Namespace="OemComputerSystem"/>
+        <edmx:Include Namespace="OemComputerSystem.v1_0_0"/>
     </edmx:Reference>
     <edmx:Reference Uri="/redfish/v1/schema/OemVirtualMedia_v1.xml">
         <edmx:Include Namespace="OemVirtualMedia"/>

--- a/static/redfish/v1/JsonSchemas/OemComputerSystem/OemComputerSystem.json
+++ b/static/redfish/v1/JsonSchemas/OemComputerSystem/OemComputerSystem.json
@@ -160,6 +160,52 @@
                         "boolean",
                         "null"
                     ]
+                },
+                "EnabledPanelFunctions": {
+                    "description": "Enabled Panel functions",
+                    "longDescription": "This property shall contain the list of enabled panel functions.",
+                    "readonly": true,
+                    "type": [
+                        "array",
+                        "null"
+                    ]
+                }
+            },
+            "type": "object"
+        },
+        "ExecutePanelFunction": {
+            "additionalProperties": false,
+            "description": "This object executes a panel function",
+            "parameters": {
+                "FuncNo": {
+                    "description": "Panel function number.",
+                    "longDescription": "This parameter shall contain a  panel function number to be executed.",
+                    "type": "integer"
+                }
+            },
+            "patternProperties": {
+                "^([a-zA-Z_][a-zA-Z0-9_]*)?@(odata|Redfish|Message)\\.[a-zA-Z_][a-zA-Z0-9_]*$": {
+                    "description": "This property shall specify a valid odata or Redfish property.",
+                    "type": [
+                        "array",
+                        "boolean",
+                        "integer",
+                        "number",
+                        "null",
+                        "object",
+                        "string"
+                    ]
+                }
+            },
+            "properties": {
+                "target": {
+                    "description": "Link to invoke action",
+                    "format": "uri-reference",
+                    "type": "string"
+                },
+                "title": {
+                    "description": "Friendly action name",
+                    "type": "string"
                 }
             },
             "type": "object"

--- a/static/redfish/v1/JsonSchemas/OemManagerAccount/OemManagerAccount.json
+++ b/static/redfish/v1/JsonSchemas/OemManagerAccount/OemManagerAccount.json
@@ -85,6 +85,15 @@
                         "boolean"
                     ],
                     "versionAdded": "v1_0_0"
+                },
+                "AllowUnauthACFUpload": {
+                    "description": "This property shall indicate if unauthorized users shall be allowed to upload ACFs.",
+                    "longDescription": "This property indicates if unauthorized users are allowed to upload ACFs or not.  When this property is true, users are allowed to upload ACFs regardless of their authentication status, regardless of their Role, and regardless of the time window created by Operator Panel function 74.",
+                    "readonly": false,
+                    "type": [
+                        "boolean"
+                    ],
+                    "versionAdded": "v1_0_0"
                 }
             },
             "type": "object"

--- a/static/redfish/v1/JsonSchemas/OemServiceRoot/OemServiceRoot.json
+++ b/static/redfish/v1/JsonSchemas/OemServiceRoot/OemServiceRoot.json
@@ -85,6 +85,15 @@
                         "string",
                         "null"
                     ]
+                },
+                "ACFWindowActive": {
+                    "description": "An indication of whether the time window for an unauthorized agent to upload an ACF is active.",
+                    "longDescription": "This property shall indicate if the time window for an unauthorized agent to upload an ACF is active.",
+                    "readonly": true,
+                    "type": [
+                        "boolean",
+                        "null"
+                    ]
                 }
             },
             "type": "object"

--- a/static/redfish/v1/schema/OemComputerSystem_v1.xml
+++ b/static/redfish/v1/schema/OemComputerSystem_v1.xml
@@ -45,6 +45,11 @@
                     <Annotation Term="OData.Description" String="An indicator allowing an operator to operate platform system attention."/>
                     <Annotation Term="OData.LongDescription" String="This property shall contain the state of the platform system attention of this resource."/>
                 </Property>
+                <Property Name="EnabledPanelFunctions" Type="OemComputerSystem.IBM">
+                  <Annotation Term="OData.Permissions" EnumMember="OData.Permission/Read"/>
+                  <Annotation Term="OData.Description" String="List of enabled panel functions."/>
+                  <Annotation Term="OData.LongDescription" String="This property shall contain the list of enabled panel functions."/>
+                </Property>
             </ComplexType>
 
             <ComplexType Name="OpenBmc" BaseType="Resource.OemObject">
@@ -85,6 +90,16 @@
                     <Annotation Term="OData.LongDescription" String="Platform firmware is provisioned and locked. So re-provisioning is not allowed in this state."/>
                 </Member>
             </EnumType>
+        </Schema>
+        <Schema xmlns="http://docs.oasis-open.org/odata/ns/edm" Namespace="OemComputerSystem.v1_0_0">
+            <Action Name="ExecutePanelFunction" IsBound="true">
+                <Annotation Term="OData.Description" String="This action executes a panel function."/>
+                <Annotation Term="OData.LongDescription" String="This action executes a panel function if the function is enabled."/>
+                <Parameter Name="FuncNo" Type="OemComputerSystem.v1_0_0.OemActions" Nullable="false">
+                    <Annotation Term="OData.Description" String="Panel function number."/>
+                    <Annotation Term="OData.LongDescription" String="This parameter shall contain a  panel function number to be executed."/>
+                </Parameter>
+            </Action>
         </Schema>
     </edmx:DataServices>
 </edmx:Edmx>

--- a/static/redfish/v1/schema/OemManagerAccount_v1.xml
+++ b/static/redfish/v1/schema/OemManagerAccount_v1.xml
@@ -53,12 +53,17 @@
 				<Property Name="ExpirationDate" Type="Edm.String" Nullable="true">
 					<Annotation Term="OData.Permissions" EnumMember="OData.Permission/Read"/>
 					<Annotation Term="OData.Description" String="The expiration date of the ACF file."/>
-					<Annotation Term="OData.LongDescription" String="The expiration date of the ACF file, if the expiration date has been from the BMC then the ACF is not validD"/>
+					<Annotation Term="OData.LongDescription" String="The expiration date of the ACF file, if the expiration date has been from the BMC then the ACF is not valid."/>
 				</Property>
 				<Property Name="ACFInstalled" Type="Edm.Boolean">
 					<Annotation Term="OData.Permissions" EnumMember="OData.Permission/Read"/>
 					<Annotation Term="OData.Description" String="This property is set to true if the ACF is installed."/>
 					<Annotation Term="OData.LongDescription" String="This property indicates if the ACF is installed or not."/>
+				</Property>
+				<Property Name="AllowUnauthACFUpload" Type="Edm.Boolean">
+					<Annotation Term="OData.Permissions" EnumMember="OData.Permission/ReadWrite"/>
+					<Annotation Term="OData.Description" String="This property shall indicate if unauthorized users shall be allowed to upload ACFs."/>
+					<Annotation Term="OData.LongDescription" String="This property indicates if unauthorized users are allowed to upload ACFs or not.  When this property is true, users are allowed to upload ACFs regardless of their authentication status, regardless of their Role, and regardless of the time window created by Operator Panel function 74."/>
 				</Property>
 			</ComplexType>
 

--- a/static/redfish/v1/schema/OemServiceRoot_v1.xml
+++ b/static/redfish/v1/schema/OemServiceRoot_v1.xml
@@ -59,6 +59,11 @@
           <Annotation Term="OData.Description" String="The time offset from UTC that the DateTime property is in `+HH:MM` format."/>
           <Annotation Term="OData.LongDescription" String="This property shall contain the offset from UTC time that the DateTime property contains.  If both DateTime and DateTimeLocalOffset are provided in modification requests, services shall apply DateTimeLocalOffset after DateTime is applied."/>
         </Property>
+        <Property Name="ACFWindowActive" Type="OemServiceRoot.IBM">
+          <Annotation Term="OData.Permissions" EnumMember="OData.Permission/Read"/>
+          <Annotation Term="OData.Description" String="An indication of whether the time window for an unauthorized agent to upload an ACF is active."/>
+          <Annotation Term="OData.LongDescription" String="This property shall indicate if the time window for an unauthorized agent to upload an ACF is active."/>
+        </Property>
       </ComplexType>
 
     </Schema>


### PR DESCRIPTION
This commit populates link(s) to processor associated with a given
PCIeSlot. The association is established by fetching mapper endpoints
"connected_to" with respect to the given PCIeSlot.

Test:
Ran Validator, no new error.

Sample output:
    {
      "HotPluggable": false,
      "Links": {
        "Processors": [
          {
            "@odata.id": "/redfish/v1/Systems/system/Processors/dcm1-cpu1"
          }
        ],
        "Processors@odata.count": 1
      },
      "LocationIndicatorActive": false,
      "SlotType": "FullLength"
    },