### PR TITLE
Create Redfish specific setProperty call

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -363,6 +363,7 @@ endif
 srcfiles_bmcweb = [
   'src/webserver_main.cpp',
   'redfish-core/src/error_messages.cpp',
+  'redfish-core/src/utils/dbus_utils.cpp',
   'redfish-core/src/utils/json_utils.cpp',
   'src/boost_url.cpp'
 ]
@@ -375,6 +376,7 @@ srcfiles_unittest = [
   'redfish-core/ut/privileges_test.cpp',
   'redfish-core/ut/lock_test.cpp',
   'redfish-core/ut/configfile_test.cpp',
+  'redfish-core/ut/dbus_utils.cpp',
   'redfish-core/ut/time_utils_test.cpp',
   'redfish-core/ut/stl_utils_test.cpp',
   'http/ut/utility_test.cpp'

--- a/redfish-core/include/utils/dbus_utils.hpp
+++ b/redfish-core/include/utils/dbus_utils.hpp
@@ -1,0 +1,68 @@
+#pragma once
+
+#include "async_resp.hpp"
+#include "dbus_singleton.hpp"
+#include "error_messages.hpp"
+#include "logging.hpp"
+
+#include <nlohmann/json.hpp>
+#include <sdbusplus/asio/property.hpp>
+#include <sdbusplus/message.hpp>
+#include <sdbusplus/unpack_properties.hpp>
+
+#include <memory>
+#include <string_view>
+
+namespace redfish
+{
+namespace dbus_utils
+{
+
+struct UnpackErrorPrinter
+{
+    void operator()(const sdbusplus::UnpackErrorReason reason,
+                    const std::string& property) const noexcept
+    {
+        BMCWEB_LOG_ERROR
+            << "DBUS property error in property: " << property << ", reason: "
+            << static_cast<
+                   std::underlying_type_t<sdbusplus::UnpackErrorReason>>(
+                   reason);
+    }
+};
+
+} // namespace dbus_utils
+
+namespace details
+{
+void afterSetProperty(const std::shared_ptr<bmcweb::AsyncResp>& asyncResp,
+                      const std::string& redfishPropertyName,
+                      const nlohmann::json& propertyValue,
+                      const boost::system::error_code& ec,
+                      const sdbusplus::message_t& msg);
+}
+
+template <typename PropertyType>
+void setDbusProperty(const std::shared_ptr<bmcweb::AsyncResp>& asyncResp,
+                     std::string_view processName,
+                     const sdbusplus::message::object_path& path,
+                     std::string_view interface, std::string_view dbusProperty,
+                     std::string_view redfishPropertyName,
+                     const PropertyType& prop)
+{
+    std::string processNameStr(processName);
+    std::string interfaceStr(interface);
+    std::string dbusPropertyStr(dbusProperty);
+
+    sdbusplus::asio::setProperty(
+        *crow::connections::systemBus, processNameStr, path.str, interfaceStr,
+        dbusPropertyStr, prop,
+        [asyncResp, redfishPropertyNameStr = std::string{redfishPropertyName},
+         jsonProp = nlohmann::json(prop)](const boost::system::error_code& ec,
+                                          const sdbusplus::message_t& msg) {
+        details::afterSetProperty(asyncResp, redfishPropertyNameStr, jsonProp,
+                                  ec, msg);
+    });
+}
+
+} // namespace redfish

--- a/redfish-core/lib/account_service.hpp
+++ b/redfish-core/lib/account_service.hpp
@@ -22,6 +22,7 @@
 #include <persistent_data.hpp>
 #include <registries/privilege_registry.hpp>
 #include <roles.hpp>
+#include <utils/dbus_utils.hpp>
 #include <utils/json_utils.hpp>
 
 #include <string>
@@ -279,22 +280,10 @@ inline void translateAccountType(
         BMCWEB_LOG_ERROR << "accountType value unable to mapped";
         return;
     }
-
-    crow::connections::systemBus->async_method_call(
-        [asyncResp](const boost::system::error_code ec) {
-            if (ec)
-            {
-                BMCWEB_LOG_ERROR << "D-Bus responses error: " << ec;
-                messages::internalError(asyncResp->res);
-                return;
-            }
-            messages::success(asyncResp->res);
-            return;
-        },
-        "xyz.openbmc_project.User.Manager", dbusObjectPath.c_str(),
-        "org.freedesktop.DBus.Properties", "Set",
-        "xyz.openbmc_project.User.Attributes", "UserGroups",
-        dbus::utility::DbusVariantType{updatedUserGroup});
+        //******"xyz.openbmc_project.User.Manager", dbusObjectPath.c_str(),
+    setDbusProperty(asyncResp, "xyz.openbmc_project.User.Manager",
+                    dbusObjectPath, "xyz.openbmc_project.User.Attributes",
+                    "UserGroups", "AccountTypes", updatedUserGroup);
 }
 
 inline void userErrorMessageHandler(
@@ -459,83 +448,23 @@ inline void handleRoleMapPatch(
                 // If "RemoteGroup" info is provided
                 if (remoteGroup)
                 {
-                    crow::connections::systemBus->async_method_call(
-                        [asyncResp, roleMapObjData, serverType, index,
-                         remoteGroup](const boost::system::error_code ec,
-                                      const sdbusplus::message::message& msg) {
-                            if (ec)
-                            {
-                                BMCWEB_LOG_ERROR << "DBUS response error: "
-                                                 << ec;
-                                const sd_bus_error* dbusError = msg.get_error();
-                                if (dbusError == nullptr)
-                                {
-                                    messages::internalError(asyncResp->res);
-                                    return;
-                                }
-                                if ((strcmp(dbusError->name,
-                                            "xyz.openbmc_project.Common.Error."
-                                            "InvalidArgument") == 0))
-                                {
-                                    messages::propertyValueIncorrect(
-                                        asyncResp->res, "RemoteGroup",
-                                        *remoteGroup);
-                                    return;
-                                }
-                                messages::internalError(asyncResp->res);
-                                return;
-                            }
-                            asyncResp->res
-                                .jsonValue[serverType]["RemoteRoleMapping"]
-                                          [index]["RemoteGroup"] = *remoteGroup;
-                        },
-                        ldapDbusService, roleMapObjData[index].first,
-                        propertyInterface, "Set",
+                    setDbusProperty(
+                        asyncResp, ldapDbusService, roleMapObjData[index].first,
                         "xyz.openbmc_project.User.PrivilegeMapperEntry",
                         "GroupName",
-                        std::variant<std::string>(std::move(*remoteGroup)));
+                        "RemoteRoleMapping/" + std::to_string(index) + "/RemoteGroup",
+                        *remoteGroup);
                 }
 
                 // If "LocalRole" info is provided
                 if (localRole)
                 {
-                    crow::connections::systemBus->async_method_call(
-                        [asyncResp, roleMapObjData, serverType, index,
-                         localRole](const boost::system::error_code ec,
-                                    const sdbusplus::message::message& msg) {
-                            if (ec)
-                            {
-                                BMCWEB_LOG_ERROR << "DBUS response error: "
-                                                 << ec;
-                                const sd_bus_error* dbusError = msg.get_error();
-                                if (dbusError == nullptr)
-                                {
-                                    messages::internalError(asyncResp->res);
-                                    return;
-                                }
-
-                                if ((strcmp(dbusError->name,
-                                            "xyz.openbmc_project.Common.Error."
-                                            "InvalidArgument") == 0))
-                                {
-                                    messages::propertyValueIncorrect(
-                                        asyncResp->res, "LocalRole",
-                                        *localRole);
-                                    return;
-                                }
-                                messages::internalError(asyncResp->res);
-                                return;
-                            }
-                            asyncResp->res
-                                .jsonValue[serverType]["RemoteRoleMapping"]
-                                          [index]["LocalRole"] = *localRole;
-                        },
-                        ldapDbusService, roleMapObjData[index].first,
-                        propertyInterface, "Set",
+                    setDbusProperty(
+                        asyncResp, ldapDbusService, roleMapObjData[index].first,
                         "xyz.openbmc_project.User.PrivilegeMapperEntry",
                         "Privilege",
-                        std::variant<std::string>(
-                            getPrivilegeFromRoleId(std::move(*localRole))));
+                        "RemoteRoleMapping/" + std::to_string(index) + "/LocalRole",
+                        getPrivilegeFromRoleId(std::move(*localRole)));
                 }
             }
             // Create a new RoleMapping Object.
@@ -873,49 +802,10 @@ inline void handleServiceAddressPatch(
     const std::string& ldapServerElementName,
     const std::string& ldapConfigObject)
 {
-    crow::connections::systemBus->async_method_call(
-        [asyncResp, ldapServerElementName,
-         serviceAddressList](const boost::system::error_code ec,
-                             const sdbusplus::message::message& msg) {
-            if (ec)
-            {
-                BMCWEB_LOG_DEBUG
-                    << "Error Occurred in updating the service address";
-                const sd_bus_error* dbusError = msg.get_error();
-                if (dbusError == nullptr)
-                {
-                    messages::internalError(asyncResp->res);
-                    return;
-                }
-                if ((strcmp(
-                         dbusError->name,
-                         "xyz.openbmc_project.Common.Error.InvalidArgument") ==
-                     0))
-                {
-                    messages::propertyValueIncorrect(
-                        asyncResp->res, "ServiceAddresses",
-                        serviceAddressList.front());
-                    return;
-                }
-                messages::internalError(asyncResp->res);
-                return;
-            }
-            std::vector<std::string> modifiedserviceAddressList = {
-                serviceAddressList.front()};
-            asyncResp->res
-                .jsonValue[ldapServerElementName]["ServiceAddresses"] =
-                modifiedserviceAddressList;
-            if ((serviceAddressList).size() > 1)
-            {
-                messages::propertyValueModified(asyncResp->res,
-                                                "ServiceAddresses",
-                                                serviceAddressList.front());
-            }
-            BMCWEB_LOG_DEBUG << "Updated the service address";
-        },
-        ldapDbusService, ldapConfigObject, propertyInterface, "Set",
-        ldapConfigInterface, "LDAPServerURI",
-        std::variant<std::string>(serviceAddressList.front()));
+    setDbusProperty(asyncResp, ldapDbusService, ldapConfigObject,
+                    ldapConfigInterface, "LDAPServerURI",
+                    ldapServerElementName + "/ServiceAddress",
+                    serviceAddressList.front());
 }
 /**
  * @brief updates the LDAP Bind DN and updates the
@@ -932,21 +822,10 @@ inline void
                         const std::string& ldapServerElementName,
                         const std::string& ldapConfigObject)
 {
-    crow::connections::systemBus->async_method_call(
-        [asyncResp, username,
-         ldapServerElementName](const boost::system::error_code ec) {
-            if (ec)
-            {
-                BMCWEB_LOG_DEBUG << "Error occurred in updating the username";
-                messages::internalError(asyncResp->res);
-                return;
-            }
-            asyncResp->res.jsonValue[ldapServerElementName]["Authentication"]
-                                    ["Username"] = username;
-            BMCWEB_LOG_DEBUG << "Updated the username";
-        },
-        ldapDbusService, ldapConfigObject, propertyInterface, "Set",
-        ldapConfigInterface, "LDAPBindDN", std::variant<std::string>(username));
+    setDbusProperty(asyncResp, ldapDbusService, ldapConfigObject,
+                    ldapConfigInterface, "LDAPBindDN",
+                    ldapServerElementName + "/Authentication/Username",
+                    username);
 }
 
 /**
@@ -963,22 +842,10 @@ inline void
                         const std::string& ldapServerElementName,
                         const std::string& ldapConfigObject)
 {
-    crow::connections::systemBus->async_method_call(
-        [asyncResp, password,
-         ldapServerElementName](const boost::system::error_code ec) {
-            if (ec)
-            {
-                BMCWEB_LOG_DEBUG << "Error occurred in updating the password";
-                messages::internalError(asyncResp->res);
-                return;
-            }
-            asyncResp->res.jsonValue[ldapServerElementName]["Authentication"]
-                                    ["Password"] = "";
-            BMCWEB_LOG_DEBUG << "Updated the password";
-        },
-        ldapDbusService, ldapConfigObject, propertyInterface, "Set",
-        ldapConfigInterface, "LDAPBindDNPassword",
-        std::variant<std::string>(password));
+    setDbusProperty(asyncResp, ldapDbusService, ldapConfigObject,
+                    ldapConfigInterface, "LDAPBindDNPassword",
+                    ldapServerElementName + "/Authentication/Password",
+                    password);
 }
 
 /**
@@ -996,49 +863,11 @@ inline void
                       const std::string& ldapServerElementName,
                       const std::string& ldapConfigObject)
 {
-    crow::connections::systemBus->async_method_call(
-        [asyncResp, baseDNList,
-         ldapServerElementName](const boost::system::error_code ec,
-                                const sdbusplus::message::message& msg) {
-            if (ec)
-            {
-                BMCWEB_LOG_DEBUG << "Error Occurred in Updating the base DN";
-                const sd_bus_error* dbusError = msg.get_error();
-                if (dbusError == nullptr)
-                {
-                    messages::internalError(asyncResp->res);
-                    return;
-                }
-                if ((strcmp(
-                         dbusError->name,
-                         "xyz.openbmc_project.Common.Error.InvalidArgument") ==
-                     0))
-                {
-                    messages::propertyValueIncorrect(asyncResp->res,
-                                                     "BaseDistinguishedNames",
-                                                     baseDNList.front());
-                    return;
-                }
-                messages::internalError(asyncResp->res);
-                return;
-            }
-            auto& serverTypeJson =
-                asyncResp->res.jsonValue[ldapServerElementName];
-            auto& searchSettingsJson =
-                serverTypeJson["LDAPService"]["SearchSettings"];
-            std::vector<std::string> modifiedBaseDNList = {baseDNList.front()};
-            searchSettingsJson["BaseDistinguishedNames"] = modifiedBaseDNList;
-            if (baseDNList.size() > 1)
-            {
-                messages::propertyValueModified(asyncResp->res,
-                                                "BaseDistinguishedNames",
-                                                baseDNList.front());
-            }
-            BMCWEB_LOG_DEBUG << "Updated the base DN";
-        },
-        ldapDbusService, ldapConfigObject, propertyInterface, "Set",
-        ldapConfigInterface, "LDAPBaseDN",
-        std::variant<std::string>(baseDNList.front()));
+    setDbusProperty(asyncResp, ldapDbusService, ldapConfigObject,
+                    ldapConfigInterface, "LDAPBaseDN",
+                    ldapServerElementName +
+                        "/LDAPService/SearchSettings/BaseDistinguishedNames",
+                    baseDNList.front());
 }
 /**
  * @brief updates the LDAP user name attribute and updates the
@@ -1055,26 +884,11 @@ inline void
                             const std::string& ldapServerElementName,
                             const std::string& ldapConfigObject)
 {
-    crow::connections::systemBus->async_method_call(
-        [asyncResp, userNameAttribute,
-         ldapServerElementName](const boost::system::error_code ec) {
-            if (ec)
-            {
-                BMCWEB_LOG_DEBUG << "Error Occurred in Updating the "
-                                    "username attribute";
-                messages::internalError(asyncResp->res);
-                return;
-            }
-            auto& serverTypeJson =
-                asyncResp->res.jsonValue[ldapServerElementName];
-            auto& searchSettingsJson =
-                serverTypeJson["LDAPService"]["SearchSettings"];
-            searchSettingsJson["UsernameAttribute"] = userNameAttribute;
-            BMCWEB_LOG_DEBUG << "Updated the user name attr.";
-        },
-        ldapDbusService, ldapConfigObject, propertyInterface, "Set",
-        ldapConfigInterface, "UserNameAttribute",
-        std::variant<std::string>(userNameAttribute));
+    setDbusProperty(asyncResp, ldapDbusService, ldapConfigObject,
+                    ldapConfigInterface, "UserNameAttribute",
+                    ldapServerElementName +
+                        "LDAPService/SearchSettings/UsernameAttribute",
+                    userNameAttribute);
 }
 
 inline void setPropertyAllowUnauthACFUpload(
@@ -1238,26 +1052,11 @@ inline void handleGroupNameAttrPatch(
     const std::string& ldapServerElementName,
     const std::string& ldapConfigObject)
 {
-    crow::connections::systemBus->async_method_call(
-        [asyncResp, groupsAttribute,
-         ldapServerElementName](const boost::system::error_code ec) {
-            if (ec)
-            {
-                BMCWEB_LOG_DEBUG << "Error Occurred in Updating the "
-                                    "groupname attribute";
-                messages::internalError(asyncResp->res);
-                return;
-            }
-            auto& serverTypeJson =
-                asyncResp->res.jsonValue[ldapServerElementName];
-            auto& searchSettingsJson =
-                serverTypeJson["LDAPService"]["SearchSettings"];
-            searchSettingsJson["GroupsAttribute"] = groupsAttribute;
-            BMCWEB_LOG_DEBUG << "Updated the groupname attr";
-        },
-        ldapDbusService, ldapConfigObject, propertyInterface, "Set",
-        ldapConfigInterface, "GroupNameAttribute",
-        std::variant<std::string>(groupsAttribute));
+    setDbusProperty(asyncResp, ldapDbusService, ldapConfigObject,
+                    ldapConfigInterface, "GroupNameAttribute",
+                    ldapServerElementName +
+                        "/LDAPService/SearchSettings/GroupsAttribute",
+                    groupsAttribute);
 }
 /**
  * @brief updates the LDAP service enable and updates the
@@ -1273,22 +1072,9 @@ inline void handleServiceEnablePatch(
     const std::string& ldapServerElementName,
     const std::string& ldapConfigObject)
 {
-    crow::connections::systemBus->async_method_call(
-        [asyncResp, serviceEnabled,
-         ldapServerElementName](const boost::system::error_code ec) {
-            if (ec)
-            {
-                BMCWEB_LOG_DEBUG
-                    << "Error Occurred in Updating the service enable";
-                messages::internalError(asyncResp->res);
-                return;
-            }
-            asyncResp->res.jsonValue[ldapServerElementName]["ServiceEnabled"] =
-                serviceEnabled;
-            BMCWEB_LOG_DEBUG << "Updated Service enable = " << serviceEnabled;
-        },
-        ldapDbusService, ldapConfigObject, propertyInterface, "Set",
-        ldapEnableInterface, "Enabled", std::variant<bool>(serviceEnabled));
+    setDbusProperty(asyncResp, ldapDbusService, ldapConfigObject,
+                    ldapEnableInterface, "Enabled",
+                    ldapServerElementName + "/ServiceEnabled", serviceEnabled);
 }
 
 inline void
@@ -1596,21 +1382,10 @@ inline void updateUserProperties(
 
             if (enabled)
             {
-                crow::connections::systemBus->async_method_call(
-                    [asyncResp](const boost::system::error_code ec) {
-                        if (ec)
-                        {
-                            BMCWEB_LOG_ERROR << "D-Bus responses error: " << ec;
-                            messages::internalError(asyncResp->res);
-                            return;
-                        }
-                        messages::success(asyncResp->res);
-                        return;
-                    },
-                    "xyz.openbmc_project.User.Manager", dbusObjectPath.c_str(),
-                    "org.freedesktop.DBus.Properties", "Set",
-                    "xyz.openbmc_project.User.Attributes", "UserEnabled",
-                    std::variant<bool>{*enabled});
+                setDbusProperty(asyncResp, "xyz.openbmc_project.User.Manager",
+                                dbusObjectPath,
+                                "xyz.openbmc_project.User.Attributes",
+                                "UserEnabled", "Enabled", *enabled);
             }
 
             if (roleId)
@@ -1655,21 +1430,10 @@ inline void updateUserProperties(
                     return;
                 }
 
-                crow::connections::systemBus->async_method_call(
-                    [asyncResp](const boost::system::error_code ec) {
-                        if (ec)
-                        {
-                            BMCWEB_LOG_ERROR << "D-Bus responses error: " << ec;
-                            messages::internalError(asyncResp->res);
-                            return;
-                        }
-                        messages::success(asyncResp->res);
-                        return;
-                    },
-                    "xyz.openbmc_project.User.Manager", dbusObjectPath.c_str(),
-                    "org.freedesktop.DBus.Properties", "Set",
-                    "xyz.openbmc_project.User.Attributes",
-                    "UserLockedForFailedAttempt", std::variant<bool>{*locked});
+                setDbusProperty(asyncResp, "xyz.openbmc_project.User.Manager",
+                                dbusObjectPath,
+                                "xyz.openbmc_project.User.Attributes",
+                                "UserLockedForFailedAttempt", "Locked", *locked);
             }
             if (accountType)
             {

--- a/redfish-core/lib/chassis.hpp
+++ b/redfish-core/lib/chassis.hpp
@@ -22,6 +22,7 @@
 #include <boost/container/flat_map.hpp>
 #include <registries/privilege_registry.hpp>
 #include <utils/collection.hpp>
+#include <utils/dbus_utils.hpp>
 #include <utils/name_utils.hpp>
 
 #include <variant>
@@ -785,22 +786,8 @@ inline void
                 objectPath = "/xyz/openbmc_project/state/chassis0";
             }
 
-            crow::connections::systemBus->async_method_call(
-                [asyncResp](const boost::system::error_code ec) {
-                    // Use "Set" method to set the property value.
-                    if (ec)
-                    {
-                        BMCWEB_LOG_DEBUG << "[Set] Bad D-Bus request error: "
-                                         << ec;
-                        messages::internalError(asyncResp->res);
-                        return;
-                    }
-
-                    messages::success(asyncResp->res);
-                },
-                processName, objectPath, "org.freedesktop.DBus.Properties",
-                "Set", interfaceName, destProperty,
-                std::variant<std::string>{propertyValue});
+            setDbusProperty(asyncResp, processName, objectPath, interfaceName,
+                            destProperty, "ResetType", propertyValue);
         },
         busName, path, interface, method, "/", 0, interfaces);
 }

--- a/redfish-core/lib/sensors.hpp
+++ b/redfish-core/lib/sensors.hpp
@@ -22,6 +22,7 @@
 #include <boost/range/algorithm/replace_copy_if.hpp>
 #include <dbus_singleton.hpp>
 #include <registries/privilege_registry.hpp>
+#include <utils/dbus_utils.hpp>
 #include <utils/json_utils.hpp>
 
 #include <cmath>

--- a/redfish-core/src/utils/dbus_utils.cpp
+++ b/redfish-core/src/utils/dbus_utils.cpp
@@ -1,0 +1,73 @@
+#include "utils/dbus_utils.hpp"
+
+#include "async_resp.hpp"
+
+#include <boost/system/error_code.hpp>
+#include <nlohmann/json.hpp>
+#include <sdbusplus/message.hpp>
+
+#include <memory>
+#include <string>
+#include <string_view>
+
+namespace redfish
+{
+namespace details
+{
+
+void afterSetProperty(const std::shared_ptr<bmcweb::AsyncResp>& asyncResp,
+                      const std::string& redfishPropertyName,
+                      const nlohmann::json& propertyValue,
+                      const boost::system::error_code& ec,
+                      const sdbusplus::message_t& msg)
+{
+    if (ec)
+    {
+        if (ec.value() == boost::system::errc::permission_denied)
+        {
+            messages::insufficientPrivilege(asyncResp->res);
+        }
+        const sd_bus_error* dbusError = msg.get_error();
+        if (dbusError != nullptr)
+        {
+            std::string_view errorName(dbusError->name);
+
+            if (errorName == "xyz.openbmc_project.Common.Error.InvalidArgument")
+            {
+                BMCWEB_LOG_WARNING << "DBUS response error: " << ec;
+                messages::propertyValueIncorrect(
+                    asyncResp->res, redfishPropertyName, propertyValue);
+                return;
+            }
+            if (errorName ==
+                "xyz.openbmc_project.State.Chassis.Error.BMCNotReady")
+            {
+                BMCWEB_LOG_WARNING << "BMC not ready, operation not allowed right now";
+                messages::serviceTemporarilyUnavailable(asyncResp->res, "10");
+                return;
+            }
+            if (errorName == "xyz.openbmc_project.State.Host.Error.BMCNotReady")
+            {
+                BMCWEB_LOG_WARNING << "BMC not ready, operation not allowed right now";
+                messages::serviceTemporarilyUnavailable(asyncResp->res, "10");
+                return;
+            }
+            if (errorName == "xyz.openbmc_project.Common.Error.NotAllowed")
+            {
+                messages::propertyNotWritable(asyncResp->res,
+                                              redfishPropertyName);
+                return;
+            }
+        }
+        BMCWEB_LOG_ERROR << "D-Bus error setting Redfish Property " << redfishPropertyName << " ec=" << ec;
+        messages::internalError(asyncResp->res);
+        return;
+    }
+    // Only set 204 if another erro hasn't already happened.
+    if (asyncResp->res.result() == boost::beast::http::status::ok)
+    {
+        asyncResp->res.result(boost::beast::http::status::no_content);
+    }
+};
+} // namespace details
+} // namespace redfish

--- a/redfish-core/ut/dbus_utils.cpp
+++ b/redfish-core/ut/dbus_utils.cpp
@@ -1,0 +1,74 @@
+
+#include "utils/dbus_utils.hpp"
+
+#include "http_request.hpp"
+#include "http_response.hpp"
+
+#include <boost/beast/http/status.hpp>
+#include <nlohmann/json.hpp>
+
+#include <cstdint>
+#include <optional>
+#include <string>
+#include <system_error>
+#include <vector>
+
+#include <gmock/gmock.h>
+#include <gtest/gtest.h>
+
+namespace redfish::details
+{
+namespace
+{
+
+TEST(DbusUtils, AfterPropertySetSuccess)
+{
+    std::shared_ptr<bmcweb::AsyncResp> asyncResp =
+        std::make_shared<bmcweb::AsyncResp>();
+
+    boost::system::error_code ec;
+    sdbusplus::message_t msg;
+    afterSetProperty(asyncResp, "MyRedfishProperty",
+                     nlohmann::json("MyRedfishValue"), ec, msg);
+
+    EXPECT_EQ(asyncResp->res.result(), boost::beast::http::status::no_content);
+    EXPECT_TRUE(asyncResp->res.jsonValue.empty());
+}
+
+TEST(DbusUtils, AfterPropertySetInternalError)
+{
+    std::shared_ptr<bmcweb::AsyncResp> asyncResp =
+        std::make_shared<bmcweb::AsyncResp>();
+
+    boost::system::error_code ec =
+        boost::system::errc::make_error_code(boost::system::errc::timed_out);
+    sdbusplus::message_t msg;
+    afterSetProperty(asyncResp, "MyRedfishProperty",
+                     nlohmann::json("MyRedfishValue"), ec, msg);
+
+    EXPECT_EQ(asyncResp->res.result(),
+              boost::beast::http::status::internal_server_error);
+    EXPECT_EQ(asyncResp->res.jsonValue.size(), 1);
+    using nlohmann::literals::operator""_json;
+
+    EXPECT_EQ(asyncResp->res.jsonValue,
+              R"({
+                    "error": {
+                    "@Message.ExtendedInfo": [
+                        {
+                        "@odata.type": "#Message.v1_1_1.Message",
+                        "Message": "The request failed due to an internal service error.  The service is still operational.",
+                        "MessageArgs": [],
+                        "MessageId": "Base.1.16.0.InternalError",
+                        "MessageSeverity": "Critical",
+                        "Resolution": "Resubmit the request.  If the problem persists, consider resetting the service."
+                        }
+                    ],
+                    "code": "Base.1.16.0.InternalError",
+                    "message": "The request failed due to an internal service error.  The service is still operational."
+                    }
+                })"_json);
+}
+
+} // namespace
+} // namespace redfish::details


### PR DESCRIPTION
PR #876 is pulled for 1030 branch explicitly as it had merge conflicts.
This commit invents a setDbusProperty method in the redfish namespace that tries to handle all DBus errors in a consistent manner.

Upstream commit: https://gerrit.openbmc.org/c/openbmc/bmcweb/+/69477