### PR TITLE
Fix Oem AssociatedAssembly Link (#603)

### DIFF
--- a/static/redfish/v1/JsonSchemas/OemPCIeSlots/OemPCIeSlots.json
+++ b/static/redfish/v1/JsonSchemas/OemPCIeSlots/OemPCIeSlots.json
@@ -109,6 +109,14 @@
                 }
             },
             "properties": {
+                "AssociatedAssembly": {
+                    "description": "Represent association slot with assembly.",
+                    "readonly": true,
+                    "type": [
+                        "null",
+                        "object"
+                    ]
+                },
                 "UpstreamFabricAdapters": {
                     "description": "The upstream fabric adapters.",
                     "items": {

--- a/static/redfish/v1/schema/OemPCIeSlots_v1.xml
+++ b/static/redfish/v1/schema/OemPCIeSlots_v1.xml
@@ -42,9 +42,8 @@
         <Annotation Term="OData.AdditionalProperties" Bool="true" />
         <Annotation Term="OData.Description" String="Oem properties for IBM." />
         <Annotation Term="OData.AutoExpand"/>
-
         <Property Name="PCIeSlot" Type="OemPCIeSlots.v1_0_0.PCIeSlot"/>
-
+        <Property Name="PCIeLinks" Type="OemPCIeSlots.v1_0_0.PCIeLinks"/>
       </ComplexType>
 
       <ComplexType Name="PCIeSlot" BaseType="Resource.OemObject">
@@ -58,6 +57,10 @@
         <Annotation Term="OData.AdditionalProperties" Bool="true" />
         <Annotation Term="OData.Description" String="Oem properties for IBM." />
         <Annotation Term="OData.AutoExpand"/>
+        <Property Name="AssociatedAssembly" Type="Resource.Resource">
+          <Annotation Term="OData.Permissions" EnumMember="OData.Permission/Read"/>
+          <Annotation Term="OData.Description" String="Represent association slot with assembly."/>
+        </Property>
         <Property Name="UpstreamFabricAdapters" Type="Collection(FabricAdapter.FabricAdapter)">
           <Annotation Term="OData.Permissions" EnumMember="OData.Permission/Read"/>
           <Annotation Term="OData.Description" String="The upstream fabric adapters."/>


### PR DESCRIPTION
This fixes the incorrect/missing Oem association.
Prior to this, "AssociatedAssembly" is missing.

```
curl -k -X GET  https://${bmc}:18080/redfish/v1/Chassis/chassis/PCIeSlots

 "Slots": [
    {
      "HotPluggable": false,
      "Lanes": 0,
      "Links": {
        "Oem": {
          "IBM": {
            "AssociatedAssembly": [
              {
                "@odata.id": "/redfish/v1/Chassis/chassis/Assembly#/Assemblies/24"
              }
            ]
          }
        },
        "PCIeDevice": [
          {
            "@odata.id": "/redfish/v1/Systems/system/PCIeDevices/motherboard_disk_backplane0_nvme0_dp0_drive0"
          }
        ]
      },

```