### PR TITLE
1110: Refresh of PCIe Topology(#593)

### DIFF
--- a/redfish-core/include/schemas.hpp
+++ b/redfish-core/include/schemas.hpp
@@ -15,7 +15,7 @@
 
 namespace redfish
 {
-    constexpr std::array<std::string_view,277> schemas {
+    constexpr std::array<std::string_view,279> schemas {
         "AccelerationFunction",
         "AccelerationFunctionCollection",
         "AccountService",

--- a/redfish-core/lib/oem/ibm/pcie_topology_refresh.hpp
+++ b/redfish-core/lib/oem/ibm/pcie_topology_refresh.hpp
@@ -1,0 +1,162 @@
+#pragma once
+
+#include "async_resp.hpp"
+#include "dbus_utility.hpp"
+#include "redfish_util.hpp"
+
+#include <boost/asio/steady_timer.hpp>
+#include <boost/system/error_code.hpp>
+#include <sdbusplus/asio/property.hpp>
+
+#include <chrono>
+#include <cstdint>
+#include <memory>
+#include <string>
+#include <variant>
+
+namespace redfish
+{
+// NOLINTBEGIN(cppcoreguidelines-avoid-non-const-global-variables)
+// Timer for PCIe Topology Refresh
+static std::unique_ptr<boost::asio::steady_timer> pcieTopologyRefreshTimer;
+static uint countPCIeTopologyRefresh = 0;
+// NOLINTEND(cppcoreguidelines-avoid-non-const-global-variables)
+
+/**
+ * @brief PCIe Topology Refresh monitor. which block incoming request
+ *
+ * @param[in] ec          error code to be handled
+ * @param[in] timer       pointer to steady timer which block call
+ * @param[in] asyncResp   Shared pointer for generating response message.
+ * @param[in] countPtr   how many time this method get called.
+ *
+ * @return None.
+ */
+static void pcieTopologyRefreshWatchdog(
+    const boost::system::error_code& ec, boost::asio::steady_timer* timer,
+    const std::shared_ptr<bmcweb::AsyncResp>& asyncResp, uint* countPtr)
+{
+    if (ec)
+    {
+        BMCWEB_LOG_ERROR("steady_timer error {}", ec.value());
+        messages::internalError(asyncResp->res);
+        pcieTopologyRefreshTimer = nullptr;
+        (*countPtr) = 0;
+        return;
+    }
+    //  This method can block incoming requests max for 8 seconds. So, each
+    //  call to this method adds a 1-second block, and the maximum call allow is
+    //  8 times which makes it a total of ~8 seconds
+    if ((*countPtr) >= 8)
+    {
+        messages::internalError(asyncResp->res);
+        pcieTopologyRefreshTimer = nullptr;
+        (*countPtr) = 0;
+        return;
+    }
+    ++(*countPtr);
+    sdbusplus::asio::getProperty<bool>(
+        *crow::connections::systemBus, "xyz.openbmc_project.PLDM",
+        "/xyz/openbmc_project/pldm", "com.ibm.PLDM.PCIeTopology",
+        "PCIeTopologyRefresh",
+        [asyncResp, timer, countPtr](const boost::system::error_code& ec1,
+                                     const bool pcieRefreshValue) {
+        if (ec1)
+        {
+            BMCWEB_LOG_ERROR("DBUS response error {}", ec1.value());
+            messages::internalError(asyncResp->res);
+            pcieTopologyRefreshTimer = nullptr;
+            (*countPtr) = 0;
+            return;
+        }
+        // After PCIe Topology Refresh, it sets the pcieRefreshValuePtr
+        // value to false. if a value is not false, extend the time, and if
+        // it is false, delete the timer and reset the counter
+        if (pcieRefreshValue)
+        {
+            BMCWEB_LOG_INFO("pcieRefreshValuePtr time extended");
+            timer->expires_at(timer->expiry() +
+                              boost::asio::chrono::seconds(1));
+            timer->async_wait([timer, asyncResp,
+                               countPtr](const boost::system::error_code& ec2) {
+                pcieTopologyRefreshWatchdog(ec2, timer, asyncResp, countPtr);
+            });
+        }
+        else
+        {
+            BMCWEB_LOG_ERROR("pcieRefreshValuePtr value refreshed");
+            pcieTopologyRefreshTimer = nullptr;
+            (*countPtr) = 0;
+            return;
+        }
+    });
+};
+
+/**
+ * @brief Sets PCIe Topology Refresh state.
+ *
+ * @param[in] req - The request data
+ * @param[in] asyncResp   Shared pointer for generating response message.
+ * @param[in] state   PCIe Topology Refresh state from request.
+ *
+ * @return None.
+ */
+inline void
+    setPCIeTopologyRefresh(const crow::Request& req,
+                           const std::shared_ptr<bmcweb::AsyncResp>& asyncResp,
+                           const bool state)
+{
+    BMCWEB_LOG_DEBUG("Set PCIe Topology Refresh status.");
+    sdbusplus::asio::setProperty(
+        *crow::connections::systemBus, "xyz.openbmc_project.PLDM",
+        "/xyz/openbmc_project/pldm", "com.ibm.PLDM.PCIeTopology",
+        "PCIeTopologyRefresh", state,
+        [&req, asyncResp](const boost::system::error_code& ec) {
+        if (ec)
+        {
+            BMCWEB_LOG_ERROR("PCIe Topology Refresh failed.{}", ec.value());
+            messages::internalError(asyncResp->res);
+            return;
+        }
+        countPCIeTopologyRefresh = 0;
+        pcieTopologyRefreshTimer =
+            std::make_unique<boost::asio::steady_timer>(*req.ioService);
+        pcieTopologyRefreshTimer->expires_after(std::chrono::seconds(1));
+        pcieTopologyRefreshTimer->async_wait(
+            [timer = pcieTopologyRefreshTimer.get(),
+             asyncResp](const boost::system::error_code& ec1) {
+            pcieTopologyRefreshWatchdog(ec1, timer, asyncResp,
+                                        &countPCIeTopologyRefresh);
+        });
+    });
+}
+
+/**
+ * @brief Sets Save PCIe Topology Info state.
+ *
+ * @param[in] asyncResp   Shared pointer for generating response message.
+ * @param[in] state   Save PCIe Topology Info state from request.
+ *
+ * @return None.
+ */
+inline void
+    setSavePCIeTopologyInfo(const std::shared_ptr<bmcweb::AsyncResp>& asyncResp,
+                            const bool state)
+{
+    BMCWEB_LOG_DEBUG("Set Save PCIe Topology Info status.");
+
+    sdbusplus::asio::setProperty(
+        *crow::connections::systemBus, "xyz.openbmc_project.PLDM",
+        "/xyz/openbmc_project/pldm", "com.ibm.PLDM.PCIeTopology",
+        "SavePCIeTopologyInfo", state,
+        [asyncResp](const boost::system::error_code& ec) {
+        if (ec)
+        {
+            BMCWEB_LOG_ERROR("Save PCIe Topology Info failed.{}", ec.value());
+            messages::internalError(asyncResp->res);
+            return;
+        }
+    });
+}
+
+} // namespace redfish

--- a/redfish-core/lib/systems.hpp
+++ b/redfish-core/lib/systems.hpp
@@ -37,6 +37,7 @@
 #include "oem/ibm/lamp_test.hpp"
 #include "oem/ibm/system_attention_indicator.hpp"
 #endif
+#include "oem/ibm/pcie_topology_refresh.hpp"
 
 #include <boost/asio/error.hpp>
 #include <boost/container/flat_map.hpp>
@@ -3588,10 +3589,14 @@ inline void handleComputerSystemPatch(
             std::optional<bool> lampTest;
             std::optional<bool> partitionSAI;
             std::optional<bool> platformSAI;
+            std::optional<bool> pcieTopologyRefresh;
+            std::optional<bool> savePCIeTopologyInfo;
             if (!json_util::readJson(
                     *ibmOem, asyncResp->res, "LampTest", lampTest,
                     "PartitionSystemAttentionIndicator", partitionSAI,
-                    "PlatformSystemAttentionIndicator", platformSAI))
+                    "PlatformSystemAttentionIndicator", platformSAI,
+                    "PCIeTopologyRefresh", pcieTopologyRefresh,
+                    "SavePCIeTopologyInfo", savePCIeTopologyInfo))
             {
                 return;
             }
@@ -3609,7 +3614,25 @@ inline void handleComputerSystemPatch(
                 setSAI(asyncResp, "PlatformSystemAttentionIndicator",
                        *platformSAI);
             }
+#else
+            std::optional<bool> pcieTopologyRefresh;
+            std::optional<bool> savePCIeTopologyInfo;
+            if (!json_util::readJson(*ibmOem, asyncResp->res,
+                                     "PCIeTopologyRefresh", pcieTopologyRefresh,
+                                     "SavePCIeTopologyInfo",
+                                     savePCIeTopologyInfo))
+            {
+                return;
+            }
 #endif
+            if (pcieTopologyRefresh)
+            {
+                setPCIeTopologyRefresh(req, asyncResp, *pcieTopologyRefresh);
+            }
+            if (savePCIeTopologyInfo)
+            {
+                setSavePCIeTopologyInfo(asyncResp, *savePCIeTopologyInfo);
+            }
         }
     }
 

--- a/static/redfish/v1/JsonSchemas/OemComputerSystem/OemComputerSystem.json
+++ b/static/redfish/v1/JsonSchemas/OemComputerSystem/OemComputerSystem.json
@@ -161,6 +161,24 @@
                         "null"
                     ]
                 },
+                "PCIeTopologyRefresh": {
+                    "description": "An indication of topology information is ready.",
+                    "longDescription": "This property when set to 'true' refreshes the topology information. The application which uses this should set it to 'false' when a refresh occurs.",
+                    "readonly": true,
+                    "type": [
+                        "boolean",
+                        "null"
+                    ]
+                },
+                "SavePCIeTopologyInfo": {
+                    "description": "An indication of PEL topology information is saved.",
+                    "longDescription": "This property when set to 'true' saves the topology information. The information is saved in the form of a PEL(Error Log).",
+                    "readonly": true,
+                    "type": [
+                        "boolean",
+                        "null"
+                    ]
+                },
                 "EnabledPanelFunctions": {
                     "description": "Enabled Panel functions",
                     "longDescription": "This property shall contain the list of enabled panel functions.",

--- a/static/redfish/v1/schema/OemComputerSystem_v1.xml
+++ b/static/redfish/v1/schema/OemComputerSystem_v1.xml
@@ -27,6 +27,7 @@
             </ComplexType>
 
             <ComplexType Name="IBM" BaseType="Resource.OemObject">
+                <Annotation Term="Redfish.OwningEntity" String="IBM"/>
                 <Annotation Term="OData.AdditionalProperties" Bool="true" />
                 <Annotation Term="OData.Description" String="Oem properties for IBM." />
                 <Annotation Term="OData.AutoExpand"/>
@@ -44,6 +45,16 @@
                     <Annotation Term="OData.Permissions" EnumMember="OData.Permission/ReadWrite"/>
                     <Annotation Term="OData.Description" String="An indicator allowing an operator to operate platform system attention."/>
                     <Annotation Term="OData.LongDescription" String="This property shall contain the state of the platform system attention of this resource."/>
+                </Property>
+                <Property Name="PCIeTopologyRefresh" Type="Edm.Boolean">
+                  <Annotation Term="OData.Permissions" EnumMember="OData.Permission/ReadWrite"/>
+                  <Annotation Term="OData.Description" String="An indication of topology information is ready."/>
+                  <Annotation Term="OData.LongDescription" String="This property when set to 'true' refreshes the topology information. The application which uses this should set it to 'false' when a refresh occurs."/>
+                </Property>
+                <Property Name="SavePCIeTopologyInfo" Type="Edm.Boolean">
+                  <Annotation Term="OData.Permissions" EnumMember="OData.Permission/ReadWrite"/>
+                  <Annotation Term="OData.Description" String="An indication of PEL topology information is saved."/>
+                  <Annotation Term="OData.LongDescription" String="This property when set to 'true' saves the topology information. The information is saved in the form of a PEL(Error Log)."/>
                 </Property>
                 <Property Name="EnabledPanelFunctions" Type="OemComputerSystem.IBM">
                   <Annotation Term="OData.Permissions" EnumMember="OData.Permission/Read"/>


### PR DESCRIPTION
This implements PATCH of PCIeTopologyRefresh & SavePCIeTopologyInfo.

This pulls in the following 1030 PRs:

- https://github.com/ibm-openbmc/bmcweb/pull/377
- https://github.com/ibm-openbmc/bmcweb/pull/382
- https://github.com/ibm-openbmc/bmcweb/pull/404
- https://github.com/ibm-openbmc/bmcweb/pull/406

This commit also adds functionality, where bmcweb creates a watchdog (using timer) where timer waits for one second and then checks if PCIe Topology gets refreshed or not. If not, then wait for one more second and repeat this process eight times, and then the watchdog expires in between if it gets refreshed then unblock the request.

Tested:

PATCH:

```
curl -k -H "Content-Type: application/json" -X PATCH https://${bmc}:18080/redfish/v1/Systems/system/ -d '{"Oem":{"IBM":{"PCIeTopologyRefresh":true}}}'
curl -k -H "Content-Type: application/json" -X PATCH https://${bmc}:18080/redfish/v1/Systems/system/ -d '{"Oem":{"IBM":{"SavePCIeTopologyInfo":true}}}'
```

GET:
```
curl -k -X GET https://${bmc}:18080/redfish/v1/Systems/system/
{
...
  "Oem": {
    "@odata.type": "#OemComputerSystem.Oem",
    "IBM": {
      "@odata.type": "#OemComputerSystem.IBM",
      "LampTest": false,
      "PartitionSystemAttentionIndicator": false,
      "PlatformSystemAttentionIndicator": false
    }
  },
...
}
```