### PR TITLE
1110 GHE: Add Dump offload support using http dynamic response

### DIFF
--- a/http/http_response.hpp
+++ b/http/http_response.hpp
@@ -3,6 +3,9 @@
 #include "logging.hpp"
 #include "utils/hex_utils.hpp"
 
+#include <boost/asio/buffer.hpp>
+#include <boost/beast/core/flat_static_buffer.hpp>
+#include <boost/beast/http/basic_dynamic_body.hpp>
 #include <boost/beast/http/message.hpp>
 #include <boost/beast/http/message_generator.hpp>
 #include <boost/beast/http/string_body.hpp>
@@ -395,4 +398,115 @@ struct Response
     std::function<void(Response&)> completeRequestHandler;
     std::function<bool()> isAliveHelper;
 };
+
+struct DynamicResponse
+{
+    using response_type = boost::beast::http::response<
+        boost::beast::http::basic_dynamic_body<boost::beast::flat_static_buffer<
+            static_cast<std::size_t>(1024 * 1024)>>>;
+
+    std::optional<response_type> bufferResponse;
+
+    void addHeader(const std::string_view key, const std::string_view value)
+    {
+        bufferResponse->set(key, value);
+    }
+
+    void addHeader(boost::beast::http::field key, std::string_view value)
+    {
+        bufferResponse->set(key, value);
+    }
+
+    DynamicResponse() : bufferResponse(response_type{}) {}
+
+    ~DynamicResponse() = default;
+
+    DynamicResponse(const DynamicResponse&) = delete;
+
+    DynamicResponse(DynamicResponse&&) = delete;
+
+    DynamicResponse& operator=(const DynamicResponse& r) = delete;
+
+    DynamicResponse& operator=(DynamicResponse&& r) noexcept
+    {
+        BMCWEB_LOG_DEBUG("Moving response containers");
+        bufferResponse = std::move(r.bufferResponse);
+        r.bufferResponse.emplace(response_type{});
+        completed = r.completed;
+        return *this;
+    }
+
+    void result(boost::beast::http::status v)
+    {
+        bufferResponse->result(v);
+    }
+
+    boost::beast::http::status result()
+    {
+        return bufferResponse->result();
+    }
+
+    unsigned resultInt()
+    {
+        return bufferResponse->result_int();
+    }
+
+    std::string_view reason()
+    {
+        return bufferResponse->reason();
+    }
+
+    bool isCompleted() const noexcept
+    {
+        return completed;
+    }
+
+    void keepAlive(bool k)
+    {
+        bufferResponse->keep_alive(k);
+    }
+
+    bool keepAlive()
+    {
+        return bufferResponse->keep_alive();
+    }
+
+    void preparePayload()
+    {
+        bufferResponse->prepare_payload();
+    }
+
+    void clear()
+    {
+        bufferResponse.emplace(response_type{});
+        completed = false;
+    }
+
+    void end()
+    {
+        if (completed)
+        {
+            BMCWEB_LOG_DEBUG("Dynamic response was ended twice");
+            return;
+        }
+        completed = true;
+        BMCWEB_LOG_DEBUG("calling completion handler");
+        if (completeRequestHandler)
+        {
+            BMCWEB_LOG_DEBUG("completion handler was valid");
+            completeRequestHandler();
+        }
+    }
+
+    bool isAlive()
+    {
+        return isAliveHelper && isAliveHelper();
+    }
+    std::function<void()> completeRequestHandler;
+
+  private:
+    bool completed{};
+    std::function<bool()> isAliveHelper;
+};
+
 } // namespace crow

--- a/http/http_stream.hpp
+++ b/http/http_stream.hpp
@@ -1,0 +1,169 @@
+#pragma once
+#include "http/http_request.hpp"
+#include "http/http_response.hpp"
+
+#include <boost/algorithm/string/predicate.hpp>
+#include <boost/asio/io_context.hpp>
+#include <boost/asio/steady_timer.hpp>
+#include <boost/beast/core/ostream.hpp>
+#include <boost/beast/http/basic_dynamic_body.hpp>
+#include <boost/system/error_code.hpp>
+
+#include <functional>
+#include <memory>
+#include <string>
+
+namespace crow
+{
+
+namespace streaming_response
+{
+
+struct Connection : std::enable_shared_from_this<Connection>
+{
+  public:
+    explicit Connection(const crow::Request& reqIn) : req(reqIn) {}
+    virtual void sendMessage(const boost::asio::mutable_buffer& buffer,
+                             std::function<void()> handler) = 0;
+    virtual void close() = 0;
+    virtual boost::asio::io_context* getIoContext() = 0;
+    virtual void sendStreamHeaders(const std::string& streamDataSize,
+                                   const std::string& contentType) = 0;
+    virtual void sendStreamErrorStatus(boost::beast::http::status status) = 0;
+    virtual void setStreamHeaders(const std::string& header,
+                                  const std::string& headerValue) = 0;
+    virtual ~Connection() = default;
+    Connection(const Connection&) = delete;
+    Connection(Connection&&) = delete;
+    Connection& operator=(const Connection& c) = delete;
+    Connection& operator=(Connection&& c) = delete;
+
+    crow::Request req;
+    crow::DynamicResponse streamres;
+    bool completionStatus = false;
+};
+
+template <typename Adaptor>
+class ConnectionImpl : public Connection
+{
+  public:
+    ConnectionImpl(const crow::Request& reqIn, Adaptor&& adaptorIn,
+                   std::function<void(Connection&)> openHandlerIn,
+                   std::function<void(Connection&, const std::string&, bool)>
+                       messageHandlerIn,
+                   std::function<void(Connection&, bool&)> closeHandlerIn,
+                   std::function<void(Connection&)> errorHandlerIn) :
+
+        Connection(reqIn),
+        adaptor(std::move(adaptorIn)), waitTimer(*reqIn.ioService),
+        openHandler(std::move(openHandlerIn)),
+        messageHandler(std::move(messageHandlerIn)),
+        closeHandler(std::move(closeHandlerIn)),
+        errorHandler(std::move(errorHandlerIn))
+    {}
+
+    boost::asio::io_context* getIoContext() override
+    {
+        return req.ioService;
+    }
+
+    void start()
+    {
+        streamres.completeRequestHandler = [this, self(shared_from_this())] {
+            BMCWEB_LOG_DEBUG("running completeRequestHandler");
+            this->close();
+        };
+        openHandler(*this);
+    }
+
+    void sendStreamErrorStatus(boost::beast::http::status status) override
+    {
+        streamres.result(status);
+        boost::beast::http::async_write(
+            adaptor, *streamres.bufferResponse,
+            [this, self(shared_from_this())](
+                const boost::system::error_code& ec2, std::size_t) {
+            if (ec2)
+            {
+                BMCWEB_LOG_DEBUG("Error while writing on socket {}", ec2);
+                close();
+                return;
+            }
+        });
+    }
+
+    void setStreamHeaders(const std::string& header,
+                          const std::string& headerValue) override
+    {
+        streamres.addHeader(header, headerValue);
+    }
+
+    void sendStreamHeaders(const std::string& streamDataSize,
+                           const std::string& contentType) override
+    {
+        streamres.addHeader("Content-Length", streamDataSize);
+        streamres.addHeader("Content-Type", contentType);
+        boost::beast::http::async_write(
+            adaptor, *streamres.bufferResponse,
+            [this, self(shared_from_this())](
+                const boost::system::error_code& ec2, std::size_t) {
+            if (ec2)
+            {
+                BMCWEB_LOG_DEBUG("Error while writing on socket {}", ec2);
+                close();
+                return;
+            }
+        });
+    }
+
+    void sendMessage(const boost::asio::mutable_buffer& buffer,
+                     std::function<void()> handler) override
+    {
+        if (buffer.size() != 0)
+        {
+            this->handlerFunc = handler;
+            auto bytes = boost::asio::buffer_copy(
+                streamres.bufferResponse->body().prepare(buffer.size()),
+                buffer);
+            streamres.bufferResponse->body().commit(bytes);
+            doWrite();
+        }
+    }
+
+    void close() override
+    {
+        streamres.end();
+        boost::beast::get_lowest_layer(adaptor).close();
+        closeHandler(*this, completionStatus);
+    }
+
+    void doWrite()
+    {
+        boost::asio::async_write(
+            adaptor, streamres.bufferResponse->body().data(),
+            [this, self(shared_from_this())](boost::beast::error_code ec,
+                                             std::size_t bytesWritten) {
+            streamres.bufferResponse->body().consume(bytesWritten);
+
+            if (ec)
+            {
+                BMCWEB_LOG_DEBUG("Error in async_write {}", ec);
+                close();
+                return;
+            }
+            (handlerFunc)();
+        });
+    }
+
+  private:
+    Adaptor adaptor;
+    boost::asio::steady_timer waitTimer;
+    bool doingWrite = false;
+    std::function<void(Connection&)> openHandler;
+    std::function<void(Connection&, const std::string&, bool)> messageHandler;
+    std::function<void(Connection&, bool&)> closeHandler;
+    std::function<void(Connection&)> errorHandler;
+    std::function<void()> handlerFunc;
+};
+} // namespace streaming_response
+} // namespace crow

--- a/http/routing.hpp
+++ b/http/routing.hpp
@@ -7,6 +7,7 @@
 #include "error_messages.hpp"
 #include "http_request.hpp"
 #include "http_response.hpp"
+#include "http_stream.hpp"
 #include "logging.hpp"
 #include "privileges.hpp"
 #include "routing/baserule.hpp"

--- a/http/routing/ruleparametertraits.hpp
+++ b/http/routing/ruleparametertraits.hpp
@@ -1,6 +1,7 @@
 #pragma once
 
 #include "sserule.hpp"
+#include "streamrule.hpp"
 #include "websocketrule.hpp"
 
 #include <boost/beast/http/verb.hpp>
@@ -19,6 +20,14 @@ struct RuleParameterTraits
         self_t* self = static_cast<self_t*>(this);
         WebSocketRule* p = new WebSocketRule(self->rule);
         p->privilegesSet = self->privilegesSet;
+        self->ruleToUpgrade.reset(p);
+        return *p;
+    }
+
+    StreamingResponseRule& streamingResponse()
+    {
+        self_t* self = static_cast<self_t*>(this);
+        StreamingResponseRule* p = new StreamingResponseRule(self->rule);
         self->ruleToUpgrade.reset(p);
         return *p;
     }

--- a/http/routing/streamrule.hpp
+++ b/http/routing/streamrule.hpp
@@ -1,0 +1,100 @@
+#pragma once
+
+#include "baserule.hpp"
+#include "http_stream.hpp"
+
+#include <boost/beast/http/verb.hpp>
+
+#include <memory>
+#include <string>
+#include <vector>
+
+namespace crow
+{
+
+class StreamingResponseRule : public BaseRule
+{
+    using self_t = StreamingResponseRule;
+
+  public:
+    explicit StreamingResponseRule(const std::string& ruleIn) : BaseRule(ruleIn)
+    {}
+
+    void validate() override {}
+
+    void handle(const Request& /*req*/,
+                const std::shared_ptr<bmcweb::AsyncResp>& asyncResp,
+                const std::vector<std::string>& /*params*/) override
+    {
+        asyncResp->res.result(boost::beast::http::status::not_found);
+    }
+
+#ifndef BMCWEB_ENABLE_SSL
+    void handleUpgrade(const Request& req,
+                       const std::shared_ptr<bmcweb::AsyncResp>& /*asyncResp*/,
+                       boost::asio::ip::tcp::socket&& adaptor) override
+    {
+        std::shared_ptr<crow::streaming_response::ConnectionImpl<
+            boost::asio::ip::tcp::socket>>
+            myConnection =
+                std::make_shared<crow::streaming_response::ConnectionImpl<
+                    boost::asio::ip::tcp::socket>>(req, std::move(adaptor),
+                                                   openHandler, messageHandler,
+                                                   closeHandler, errorHandler);
+        myConnection->start();
+    }
+#else
+    void handleUpgrade(const Request& req,
+                       const std::shared_ptr<bmcweb::AsyncResp>& /*asyncResp*/,
+                       boost::beast::ssl_stream<boost::asio::ip::tcp::socket>&&
+                           adaptor) override
+    {
+        std::shared_ptr<crow::streaming_response::ConnectionImpl<
+            boost::beast::ssl_stream<boost::asio::ip::tcp::socket>>>
+            myConnection =
+                std::make_shared<crow::streaming_response::ConnectionImpl<
+                    boost::beast::ssl_stream<boost::asio::ip::tcp::socket>>>(
+                    req, std::move(adaptor), openHandler, messageHandler,
+                    closeHandler, errorHandler);
+        myConnection->start();
+    }
+#endif
+
+    template <typename Func>
+    self_t& onopen(Func f)
+    {
+        openHandler = f;
+        return *this;
+    }
+
+    template <typename Func>
+    self_t& onmessage(Func f)
+    {
+        messageHandler = f;
+        return *this;
+    }
+
+    template <typename Func>
+    self_t& onclose(Func f)
+    {
+        closeHandler = f;
+        return *this;
+    }
+
+    template <typename Func>
+    self_t& onerror(Func f)
+    {
+        errorHandler = f;
+        return *this;
+    }
+
+  protected:
+    std::function<void(crow::streaming_response::Connection&)> openHandler;
+    std::function<void(crow::streaming_response::Connection&,
+                       const std::string&, bool)>
+        messageHandler;
+    std::function<void(crow::streaming_response::Connection&, bool&)>
+        closeHandler;
+    std::function<void(crow::streaming_response::Connection&)> errorHandler;
+};
+} // namespace crow

--- a/include/dump_offload.hpp
+++ b/include/dump_offload.hpp
@@ -1,0 +1,435 @@
+#pragma once
+
+#include <sys/select.h>
+
+#include <boost/asio.hpp>
+#include <boost/asio/basic_socket_acceptor.hpp>
+#include <boost/asio/basic_stream_socket.hpp>
+#include <boost/asio/local/stream_protocol.hpp>
+#include <boost/beast/core/flat_static_buffer.hpp>
+#include <boost/beast/http.hpp>
+#include <boost/shared_ptr.hpp>
+#include <boost/system/error_code.hpp>
+#include <http_stream.hpp>
+#include <ibm/utils.hpp>
+
+#include <cstddef>
+#include <filesystem>
+#include <random>
+#include <string>
+
+namespace crow
+{
+namespace obmc_dump
+{
+
+static constexpr std::string_view unixSocketPathDir =
+    "/tmp/DumpOffloadSockets/";
+
+inline void handleDumpOffloadUrl(const crow::Request& req, crow::Response& res,
+                                 const std::string& entryId,
+                                 const std::string& dumpEntryType);
+inline void resetHandler();
+
+static constexpr size_t socketBufferSize = static_cast<size_t>(64 * 1024);
+static constexpr uint8_t maxConnectRetryCount = 3;
+
+/** class Handler
+ *  Handles data transfer between unix domain socket and http connection socket.
+ *  This handler invokes dump offload reads data from unix domain socket
+ *  and writes on to http stream connection socket.
+ */
+class Handler : public std::enable_shared_from_this<Handler>
+{
+  public:
+    Handler(boost::asio::io_context& ios, const std::string& entryIDIn,
+            const std::string& dumpTypeIn,
+            const std::string& unixSocketPathIn) :
+        entryID(entryIDIn),
+        dumpType(dumpTypeIn), unixSocketPath(unixSocketPathIn), unixSocket(ios),
+        waitTimer(ios)
+    {}
+
+    /**
+     * @brief Connects to unix socket to read dump data
+     *
+     * @return void
+     */
+    void doConnect()
+    {
+        this->unixSocket.async_connect(
+            unixSocketPath.c_str(), [this, self(shared_from_this())](
+                                        const boost::system::error_code& ec) {
+            if (ec)
+            {
+                // TODO:
+                // right now we don't have dbus method which can make sure
+                // unix socket is ready to accept connection so its possible
+                // that bmcweb can try to connect to socket before even
+                // socket setup, so using retry mechanism with timeout.
+                if (ec == boost::system::errc::no_such_file_or_directory ||
+                    ec == boost::system::errc::connection_refused)
+                {
+                    BMCWEB_LOG_DEBUG("UNIX Socket: async_connect {}", ec);
+                    retrySocketConnect();
+                    return;
+                }
+                BMCWEB_LOG_ERROR("UNIX Socket: async_connect error {}", ec);
+                waitTimer.cancel();
+                this->connection->sendStreamErrorStatus(
+                    boost::beast::http::status::internal_server_error);
+                this->connection->close();
+                this->cleanupSocketFiles();
+                return;
+            }
+            waitTimer.cancel();
+            this->connection->sendStreamHeaders(std::to_string(this->dumpSize),
+                                                "application/octet-stream");
+            this->doReadStream();
+        });
+    }
+
+    /**
+     * @brief  Invokes InitiateOffload method of dump manager which
+     *         directs dump manager to start writing on unix domain socket.
+     *
+     * @return void
+     */
+    void initiateOffload()
+    {
+        crow::connections::systemBus->async_method_call(
+            [this,
+             self(shared_from_this())](const boost::system::error_code& ec) {
+            if (ec)
+            {
+                if (ec.value() == EBADR)
+                {
+                    this->connection->sendStreamErrorStatus(
+                        boost::beast::http::status::not_found);
+                }
+                else
+                {
+                    BMCWEB_LOG_ERROR("DBUS response error: {}", ec);
+                    this->connection->sendStreamErrorStatus(
+                        boost::beast::http::status::internal_server_error);
+                }
+                this->connection->close();
+                this->cleanupSocketFiles();
+                return;
+            }
+        },
+            "xyz.openbmc_project.Dump.Manager",
+            "/xyz/openbmc_project/dump/" + dumpType + "/entry/" + entryID,
+            "xyz.openbmc_project.Dump.Entry", "InitiateOffload",
+            unixSocketPath.c_str());
+    }
+
+    /**
+     * @brief  This function setup a timer for retrying unix socket connect.
+     *
+     * @return void
+     */
+    void retrySocketConnect()
+    {
+        waitTimer.expires_after(std::chrono::milliseconds(1000));
+
+        waitTimer.async_wait([this, self(shared_from_this())](
+                                 const boost::system::error_code& ec) {
+            if (ec)
+            {
+                BMCWEB_LOG_ERROR("Async_wait failed {}", ec);
+                return;
+            }
+
+            if (connectRetryCount < maxConnectRetryCount)
+            {
+                BMCWEB_LOG_ERROR("Failed to connect, reached max retry count: ",
+                                 connectRetryCount);
+                connectRetryCount++;
+                doConnect();
+            }
+            else
+            {
+                BMCWEB_LOG_ERROR("Failed to connect, reached max retry count: ",
+                                 connectRetryCount);
+                waitTimer.cancel();
+                this->cleanupSocketFiles();
+                this->connection->setStreamHeaders("Retry-After", "60");
+                this->connection->sendStreamErrorStatus(
+                    boost::beast::http::status::service_unavailable);
+                this->connection->close();
+                return;
+            }
+        });
+    }
+
+    void resetOffloadURI()
+    {
+        std::string value;
+        crow::connections::systemBus->async_method_call(
+            [this,
+             self(shared_from_this())](const boost::system::error_code& ec) {
+            if (ec)
+            {
+                if (ec.value() == EBADR)
+                {
+                    this->connection->sendStreamErrorStatus(
+                        boost::beast::http::status::not_found);
+                }
+                else
+                {
+                    BMCWEB_LOG_ERROR("DBUS response error: Unable to set "
+                                     "the dump OffloadUri {}",
+                                     ec);
+                    this->connection->sendStreamErrorStatus(
+                        boost::beast::http::status::internal_server_error);
+                }
+                return;
+            }
+            BMCWEB_LOG_CRITICAL("INFO: Reset OffloadUri of {} dump id {}",
+                                dumpType, entryID);
+        },
+            "xyz.openbmc_project.Dump.Manager",
+            "/xyz/openbmc_project/dump/" + dumpType + "/entry/" + entryID,
+            "org.freedesktop.DBus.Properties", "Set",
+            "xyz.openbmc_project.Dump.Entry", "OffloadUri",
+            std::variant<std::string>(value));
+    }
+
+    void cleanupSocketFiles()
+    {
+        std::error_code ec;
+        bool fileExists = std::filesystem::exists(unixSocketPath, ec);
+        if (ec)
+        {
+            this->connection->sendStreamErrorStatus(
+                boost::beast::http::status::internal_server_error);
+            return;
+        }
+        if (fileExists)
+        {
+            unixSocket.close();
+            std::remove(unixSocketPath.c_str());
+        }
+    }
+
+    void getDumpSize(const std::string& dumpEntryID,
+                     const std::string& dumpEntryType)
+    {
+        crow::connections::systemBus->async_method_call(
+            [this,
+             self(shared_from_this())](const boost::system::error_code& ec,
+                                       const std::variant<uint64_t>& size) {
+            if (ec)
+            {
+                if (ec.value() == EBADR)
+                {
+                    this->connection->sendStreamErrorStatus(
+                        boost::beast::http::status::not_found);
+                }
+                else
+                {
+                    BMCWEB_LOG_ERROR(
+                        "DBUS response error: Unable to get the dump size {}",
+                        ec);
+                    this->connection->sendStreamErrorStatus(
+                        boost::beast::http::status::internal_server_error);
+                }
+                this->connection->close();
+                this->cleanupSocketFiles();
+                return;
+            }
+            const uint64_t* dumpsize = std::get_if<uint64_t>(&size);
+            if (dumpsize == nullptr)
+            {
+                BMCWEB_LOG_ERROR("DBUS response error: Unable to get "
+                                 "the dump size value {}",
+                                 ec);
+                this->connection->sendStreamErrorStatus(
+                    boost::beast::http::status::internal_server_error);
+                this->connection->close();
+                this->cleanupSocketFiles();
+                return;
+            }
+            this->dumpSize = *dumpsize;
+            this->initiateOffload();
+            this->doConnect();
+        },
+            "xyz.openbmc_project.Dump.Manager",
+            "/xyz/openbmc_project/dump/" + dumpEntryType + "/entry/" +
+                dumpEntryID,
+            "org.freedesktop.DBus.Properties", "Get",
+            "xyz.openbmc_project.Dump.Entry", "Size");
+    }
+
+    /**
+     * @brief  Reads data from unix domain socket and writes on
+     *         http stream connection socket.
+     *
+     * @return void
+     */
+
+    void doReadStream()
+    {
+        std::size_t bytes = this->outputBuffer.capacity() -
+                            this->outputBuffer.size();
+
+        this->unixSocket.async_read_some(
+            this->outputBuffer.prepare(bytes),
+            [this, self(shared_from_this())](
+                const boost::system::error_code& ec, std::size_t bytesRead) {
+            if (ec)
+            {
+                if (ec != boost::asio::error::eof)
+                {
+                    BMCWEB_LOG_ERROR("Couldn't read from local peer: {}", ec);
+                    this->connection->sendStreamErrorStatus(
+                        boost::beast::http::status::internal_server_error);
+                    this->connection->close();
+                    return;
+                }
+                BMCWEB_LOG_CRITICAL("INFO: Hit Dump end of file");
+                this->connection->completionStatus = true;
+                this->connection->close();
+                return;
+            }
+
+            this->outputBuffer.commit(bytesRead);
+            auto streamHandler = [this, bytesRead, self(shared_from_this())]() {
+                this->outputBuffer.consume(bytesRead);
+                this->doReadStream();
+            };
+            this->connection->sendMessage(this->outputBuffer.data(),
+                                          streamHandler);
+        });
+    }
+
+    std::string entryID;
+    std::string dumpType;
+    boost::beast::flat_static_buffer<socketBufferSize> outputBuffer;
+    std::filesystem::path unixSocketPath;
+    boost::asio::local::stream_protocol::socket unixSocket;
+    uint64_t dumpSize{0};
+    boost::asio::steady_timer waitTimer;
+    crow::streaming_response::Connection* connection = nullptr;
+    uint16_t connectRetryCount{0};
+};
+
+// NOLINTBEGIN(cppcoreguidelines-avoid-non-const-global-variables)
+static boost::container::flat_map<crow::streaming_response::Connection*,
+                                  std::shared_ptr<Handler>>
+    systemHandlers;
+// NOLINTEND(cppcoreguidelines-avoid-non-const-global-variables)
+
+inline void resetHandlers()
+{
+    if (!systemHandlers.empty())
+    {
+        auto handler = systemHandlers.begin();
+        if (handler == systemHandlers.end())
+        {
+            BMCWEB_LOG_DEBUG("No handler to cleanup");
+            return;
+        }
+        if ((handler->second->dumpType == "system") ||
+            (handler->second->dumpType == "resource"))
+        {
+            handler->first->close();
+            BMCWEB_LOG_CRITICAL("INFO: {} dump resetHandlers cleanup",
+                                handler->second->dumpType);
+        }
+    }
+}
+
+inline void requestRoutes(App& app)
+{
+    BMCWEB_ROUTE(
+        app,
+        "/redfish/v1/Systems/system/LogServices/Dump/Entries/<str>/attachment/")
+        .privileges({{"ConfigureComponents", "ConfigureManager"}})
+        .streamingResponse()
+        .onopen([](crow::streaming_response::Connection& conn) {
+        if (!systemHandlers.empty())
+        {
+            BMCWEB_LOG_WARNING("Can't allow dump offload opertaion, one "
+                               "of the host dump is already offloading");
+            conn.sendStreamErrorStatus(
+                boost::beast::http::status::service_unavailable);
+            conn.close();
+            return;
+        }
+
+        std::string url(conn.req.target());
+        std::string startDelimiter = "Entries/";
+        std::size_t pos1 = url.rfind(startDelimiter);
+        std::size_t pos2 = url.rfind("/attachment");
+        if (pos1 == std::string::npos || pos2 == std::string::npos)
+        {
+            BMCWEB_LOG_WARNING("Unable to extract the dump id");
+            conn.sendStreamErrorStatus(boost::beast::http::status::not_found);
+            conn.close();
+            return;
+        }
+        std::string dumpEntry =
+            url.substr(pos1 + startDelimiter.length(),
+                       pos2 - pos1 - startDelimiter.length());
+
+        // System and Resource dump entries are currently being
+        // listed under /Systems/system/LogServices/Dump/Entries/
+        // redfish path. To differentiate between the two, the dump
+        // entries would be listed as System_<id> and Resource_<id> for
+        // the respective dumps. Hence the dump id and type are being
+        // extracted here from the above format.
+        std::string dumpId;
+        std::string dumpType;
+        std::size_t idPos = dumpEntry.rfind('_');
+
+        if (idPos != std::string::npos)
+        {
+            dumpType =
+                boost::algorithm::to_lower_copy(dumpEntry.substr(0, idPos));
+            dumpId = dumpEntry.substr(idPos + 1);
+        }
+
+        boost::asio::io_context* ioCon = conn.getIoContext();
+
+        // Generating random id to create unique socket file
+        // for each dump offload request
+        std::random_device rd;
+        std::default_random_engine gen(rd());
+        std::uniform_int_distribution<> dist{0, 1024};
+        std::string unixSocketPath = std::string(unixSocketPathDir) + dumpType +
+                                     "_dump_" + std::to_string(dist(gen));
+        systemHandlers[&conn] =
+            std::make_shared<Handler>(*ioCon, dumpId, dumpType, unixSocketPath);
+        systemHandlers[&conn]->connection = &conn;
+
+        if (!crow::ibm_utils::createDirectory(unixSocketPathDir))
+        {
+            systemHandlers[&conn]->connection->sendStreamErrorStatus(
+                boost::beast::http::status::not_found);
+            systemHandlers[&conn]->connection->close();
+            return;
+        }
+        BMCWEB_LOG_CRITICAL("INFO: {}  dump id {} offload initiated by: ",
+                            dumpType, dumpId, conn.req.session->clientIp);
+        systemHandlers[&conn]->getDumpSize(dumpId, dumpType);
+    }).onclose([](crow::streaming_response::Connection& conn, bool& status) {
+        auto handler = systemHandlers.find(&conn);
+        if (handler == systemHandlers.end())
+        {
+            BMCWEB_LOG_DEBUG("No handler to cleanup");
+            return;
+        }
+        handler->second->cleanupSocketFiles();
+        if (!status)
+        {
+            handler->second->resetOffloadURI();
+        }
+        handler->second->outputBuffer.clear();
+        systemHandlers.clear();
+    });
+}
+
+} // namespace obmc_dump
+} // namespace crow

--- a/include/event_dbus_monitor.hpp
+++ b/include/event_dbus_monitor.hpp
@@ -1,4 +1,5 @@
 #include <dbus_utility.hpp>
+#include <dump_offload.hpp>
 #include <error_messages.hpp>
 #include <event_service_manager.hpp>
 #include <resource_messages.hpp>
@@ -146,6 +147,8 @@ inline void hostStatePropertyChange(sdbusplus::message::message& msg)
     {
         if (*type == "xyz.openbmc_project.State.Host.HostState.Off")
         {
+            // Reset system dump handler to handle power off scenarios
+            crow::obmc_dump::resetHandlers();
             // reset the postCodeCounter
             postCodeCounter = 0;
             BMCWEB_LOG_CRITICAL(

--- a/redfish-core/include/redfish.hpp
+++ b/redfish-core/include/redfish.hpp
@@ -22,6 +22,7 @@
 #include "cable.hpp"
 #include "certificate_service.hpp"
 #include "chassis.hpp"
+#include "dump_offload.hpp"
 #include "environment_metrics.hpp"
 #include "ethernet.hpp"
 #include "event_service.hpp"
@@ -242,6 +243,7 @@ class RedfishService
         requestRoutesSubmitTestEvent(app);
 
         requestRoutesHypervisorSystems(app);
+        crow::obmc_dump::requestRoutes(app);
 
         requestRoutesTelemetryService(app);
         requestRoutesMetricReportDefinitionCollection(app);


### PR DESCRIPTION
This commit
1.Enables dynamic response support
2.Defines new bmcweb rule to support dump streaming 3.Implemented routes for system dump offload

Tested By:
System dump offload