### PR TITLE
1110: ReadOnly users should not have ssh (#408) (#514)

### DIFF
--- a/redfish-core/lib/account_service.hpp
+++ b/redfish-core/lib/account_service.hpp
@@ -2176,7 +2176,21 @@ inline void handleAccountCollectionPost(
             return;
         }
 
-        if (allGroupsList.empty())
+        // Create (modified) modGroupsList from allGroupsList.
+        // Remove the ipmi group.  Also Remove "ssh" if the new
+        // user is not an Administrator.
+        std::vector<std::string> modGroupsList;
+
+        for (const auto& group : allGroupsList)
+        {
+            if ((group != "ipmi") &&
+                ((group != "ssh") || (roleId == "Administrator")))
+            {
+                modGroupsList.push_back(group);
+            }
+        }
+
+        if (modGroupsList.empty())
         {
             messages::internalError(asyncResp->res);
             return;


### PR DESCRIPTION
* ReadOnly users should not have ssh

This changes the Redfish create new user API (POST /redfish/v1/AccountService/Accounts/) so only Administrator users will have the HostConsole AccountType value.  This is the same as the "ssh" phosphor privilege group.

Doing so prevents new ReadOnly users from using SSH port 2200.

Note that ReadOnly user created prior to this change will have the HostConsole AccountType privilege.  A BMC admin can PATCH a user's AccountTypes property to add or remove the Hostconsole value.

Tested: Yes