### PR TITLE
Fix failing CI 

### DIFF
--- a/.clang-tidy
+++ b/.clang-tidy
@@ -331,5 +331,6 @@ CheckOptions:
   - { key: readability-identifier-naming.NamespaceCase, value: lower_case }
   - { key: readability-identifier-naming.StructCase,    value: CamelCase  }
   - { key: readability-identifier-naming.FunctionIgnoredRegexp,  value: (BMCWEB_LOG_DEBUG|BMCWEB_LOG_INFO|BMCWEB_LOG_WARNING|BMCWEB_LOG_ERROR|BMCWEB_LOG_CRITICAL) }
+  - { key: readability-identifier-naming.StructIgnoredRegexp,  value: (BMCWEB_LOG_DEBUG|BMCWEB_LOG_INFO|BMCWEB_LOG_WARNING|BMCWEB_LOG_ERROR|BMCWEB_LOG_CRITICAL) }
   - { key: cppcoreguidelines-macro-usage.AllowedRegexp, value: DEBUG*|NLOHMANN_JSON_SERIALIZE_ENUM }
   - { key: performance-unnecessary-value-param.AllowedTypes, value: ((segments_view)|(url_view)) }

--- a/http/app.hpp
+++ b/http/app.hpp
@@ -63,7 +63,7 @@ class App
         router.handle(req, asyncResp);
     }
 
-    DynamicRule& routeDynamic(std::string&& rule)
+    DynamicRule& routeDynamic(const std::string& rule)
     {
         return router.newRuleDynamic(rule);
     }

--- a/http/http_client.hpp
+++ b/http/http_client.hpp
@@ -790,8 +790,7 @@ class ConnectionPool : public std::enable_shared_from_this<ConnectionPool>
         {
             // If we can't buffer the request then we should let the
             // callback handle a 429 Too Many Requests dummy response
-            BMCWEB_LOG_ERROR("{}:{} request queue full.  Dropping request.",
-                             id);
+            BMCWEB_LOG_ERROR("{} request queue full.  Dropping request.", id);
             Response dummyRes;
             dummyRes.result(boost::beast::http::status::too_many_requests);
             resHandler(dummyRes);

--- a/http/logging.hpp
+++ b/http/logging.hpp
@@ -182,7 +182,7 @@ const void* logPtr(T p)
 }
 
 template <LogLevel level>
-inline void vlog(const FormatString& format, std::format_args&& args)
+inline void vlog(const FormatString& format, const std::format_args& args)
 {
     if constexpr (bmcwebCurrentLoggingLevel < level)
     {

--- a/http/logging.hpp
+++ b/http/logging.hpp
@@ -196,7 +196,8 @@ inline void vlog(const FormatString& format, std::format_args&& args)
     filename = filename.substr(filename.rfind('/') + 1);
     std::cout << std::format("[{} {}:{}] ", levelString, filename,
                              format.loc.line())
-              << std::vformat(format.str, args) << std::endl;
+              << std::vformat(format.str, args) << '\n'
+              << std::flush;
 }
 } // namespace crow
 

--- a/http/logging.hpp
+++ b/http/logging.hpp
@@ -160,19 +160,6 @@ constexpr crow::LogLevel getLogLevelFromName(std::string_view name)
 constexpr crow::LogLevel bmcwebCurrentLoggingLevel =
     getLogLevelFromName(bmcwebLoggingLevel);
 
-struct FormatString
-{
-    std::string_view str;
-    std::source_location loc;
-
-    // NOLINTNEXTLINE(google-explicit-constructor)
-    FormatString(const char* stringIn, const std::source_location& locIn =
-                                           std::source_location::current()) :
-        str(stringIn),
-        loc(locIn)
-    {}
-};
-
 template <typename T>
 const void* logPtr(T p)
 {
@@ -181,8 +168,9 @@ const void* logPtr(T p)
     return std::bit_cast<const void*>(p);
 }
 
-template <LogLevel level>
-inline void vlog(const FormatString& format, const std::format_args& args)
+template <LogLevel level, typename... Args>
+inline void vlog(std::format_string<Args...> format, Args... args,
+                 const std::source_location& loc) noexcept
 {
     if constexpr (bmcwebCurrentLoggingLevel < level)
     {
@@ -192,47 +180,90 @@ inline void vlog(const FormatString& format, const std::format_args& args)
     static_assert(stringIndex < mapLogLevelFromName.size(),
                   "Missing string for level");
     constexpr std::string_view levelString = mapLogLevelFromName[stringIndex];
-    std::string_view filename = format.loc.file_name();
+    std::string_view filename = loc.file_name();
     filename = filename.substr(filename.rfind('/') + 1);
-    std::cout << std::format("[{} {}:{}] ", levelString, filename,
-                             format.loc.line())
-              << std::vformat(format.str, args) << '\n'
+    std::cout << std::format("[{} {}:{}] ", levelString, filename, loc.line())
+              << std::format(format, std::forward<Args>(args)...) << '\n'
               << std::flush;
 }
 } // namespace crow
 
 template <typename... Args>
-inline void BMCWEB_LOG_CRITICAL(const crow::FormatString& format,
-                                Args&&... args)
+struct BMCWEB_LOG_CRITICAL
 {
-    crow::vlog<crow::LogLevel::Critical>(
-        format, std::make_format_args(std::forward<Args>(args)...));
-}
+    // NOLINTNEXTLINE(google-explicit-constructor)
+    BMCWEB_LOG_CRITICAL(std::format_string<Args...> format, Args&&... args,
+                        const std::source_location& loc =
+                            std::source_location::current()) noexcept
+    {
+        crow::vlog<crow::LogLevel::Critical, Args...>(format, args..., loc);
+    }
+};
 
 template <typename... Args>
-inline void BMCWEB_LOG_ERROR(const crow::FormatString& format, Args&&... args)
+struct BMCWEB_LOG_ERROR
 {
-    crow::vlog<crow::LogLevel::Error>(
-        format, std::make_format_args(std::forward<Args>(args)...));
-}
+    // NOLINTNEXTLINE(google-explicit-constructor)
+    BMCWEB_LOG_ERROR(std::format_string<Args...> format, Args&&... args,
+                     const std::source_location& loc =
+                         std::source_location::current()) noexcept
+    {
+        crow::vlog<crow::LogLevel::Error, Args...>(format, args..., loc);
+    }
+};
 
 template <typename... Args>
-inline void BMCWEB_LOG_WARNING(const crow::FormatString& format, Args&&... args)
+struct BMCWEB_LOG_WARNING
 {
-    crow::vlog<crow::LogLevel::Warning>(
-        format, std::make_format_args(std::forward<Args>(args)...));
-}
+    // NOLINTNEXTLINE(google-explicit-constructor)
+    BMCWEB_LOG_WARNING(std::format_string<Args...> format, Args&&... args,
+                       const std::source_location& loc =
+                           std::source_location::current()) noexcept
+    {
+        crow::vlog<crow::LogLevel::Warning, Args...>(format, args..., loc);
+    }
+};
 
 template <typename... Args>
-inline void BMCWEB_LOG_INFO(const crow::FormatString& format, Args&&... args)
+struct BMCWEB_LOG_INFO
 {
-    crow::vlog<crow::LogLevel::Info>(
-        format, std::make_format_args(std::forward<Args>(args)...));
-}
+    // NOLINTNEXTLINE(google-explicit-constructor)
+    BMCWEB_LOG_INFO(std::format_string<Args...> format, Args&&... args,
+                    const std::source_location& loc =
+                        std::source_location::current()) noexcept
+    {
+        crow::vlog<crow::LogLevel::Info, Args...>(format, args..., loc);
+    }
+};
 
 template <typename... Args>
-inline void BMCWEB_LOG_DEBUG(const crow::FormatString& format, Args&&... args)
+struct BMCWEB_LOG_DEBUG
 {
-    crow::vlog<crow::LogLevel::Debug>(
-        format, std::make_format_args(std::forward<Args>(args)...));
-}
+    // NOLINTNEXTLINE(google-explicit-constructor)
+    BMCWEB_LOG_DEBUG(std::format_string<Args...> format, Args&&... args,
+                     const std::source_location& loc =
+                         std::source_location::current()) noexcept
+    {
+        crow::vlog<crow::LogLevel::Debug, Args...>(format, args..., loc);
+    }
+};
+
+template <typename... Args>
+BMCWEB_LOG_CRITICAL(std::format_string<Args...>, Args&&...)
+    -> BMCWEB_LOG_CRITICAL<Args...>;
+
+template <typename... Args>
+BMCWEB_LOG_ERROR(std::format_string<Args...>, Args&&...)
+    -> BMCWEB_LOG_ERROR<Args...>;
+
+template <typename... Args>
+BMCWEB_LOG_WARNING(std::format_string<Args...>, Args&&...)
+    -> BMCWEB_LOG_WARNING<Args...>;
+
+template <typename... Args>
+BMCWEB_LOG_INFO(std::format_string<Args...>, Args&&...)
+    -> BMCWEB_LOG_INFO<Args...>;
+
+template <typename... Args>
+BMCWEB_LOG_DEBUG(std::format_string<Args...>, Args&&...)
+    -> BMCWEB_LOG_DEBUG<Args...>;

--- a/http/routing.hpp
+++ b/http/routing.hpp
@@ -319,7 +319,7 @@ class Trie
                     case ParamType::PATH:
                         BMCWEB_LOG_DEBUG("<path>");
                         break;
-                    case ParamType::MAX:
+                    default:
                         BMCWEB_LOG_DEBUG("<ERROR>");
                         break;
                 }

--- a/http/routing.hpp
+++ b/http/routing.hpp
@@ -605,7 +605,7 @@ class Router
         // appear to work with the std::move on adaptor.
         validatePrivilege(
             req, asyncResp, rule,
-            [&rule, asyncResp, adaptor(std::forward<Adaptor>(adaptor))](
+            [&rule, asyncResp, adaptor = std::forward<Adaptor>(adaptor)](
                 Request& thisReq) mutable {
             rule.handleUpgrade(thisReq, asyncResp, std::move(adaptor));
         });

--- a/http/routing.hpp
+++ b/http/routing.hpp
@@ -303,24 +303,24 @@ class Trie
   private:
     void debugNodePrint(Node* n, size_t level)
     {
+        std::string indent(2U * level, ' ');
         for (size_t i = 0; i < static_cast<size_t>(ParamType::MAX); i++)
         {
             if (n->paramChildrens[i] != 0U)
             {
-                BMCWEB_LOG_DEBUG(
-                    "{}({}{}",
-                    std::string(2U * level,
-                                ' ') /*, n->paramChildrens[i], ") "*/);
                 switch (static_cast<ParamType>(i))
                 {
                     case ParamType::STRING:
-                        BMCWEB_LOG_DEBUG("<str>");
+                        BMCWEB_LOG_DEBUG("{}({}) <str>", indent,
+                                         n->paramChildrens[i]);
                         break;
                     case ParamType::PATH:
+                        BMCWEB_LOG_DEBUG("{}({}) <path>", indent,
+                                         n->paramChildrens[i]);
                         BMCWEB_LOG_DEBUG("<path>");
                         break;
                     default:
-                        BMCWEB_LOG_DEBUG("<ERROR>");
+                        BMCWEB_LOG_DEBUG("{}<ERROR>", indent);
                         break;
                 }
 
@@ -329,9 +329,7 @@ class Trie
         }
         for (const Node::ChildMap::value_type& kv : n->children)
         {
-            BMCWEB_LOG_DEBUG("{}({}{}{}",
-                             std::string(2U * level, ' ') /*, kv.second, ") "*/,
-                             kv.first);
+            BMCWEB_LOG_DEBUG("{}({}{}) ", indent, kv.second, kv.first);
             debugNodePrint(&nodes[kv.second], level + 1);
         }
     }

--- a/http/verb.hpp
+++ b/http/verb.hpp
@@ -67,7 +67,7 @@ inline std::string_view httpVerbToString(HttpVerb verb)
             return "PUT";
         case HttpVerb::Options:
             return "OPTIONS";
-        case HttpVerb::Max:
+        default:
             return "";
     }
 

--- a/http/websocket.hpp
+++ b/http/websocket.hpp
@@ -35,11 +35,9 @@ struct Connection : std::enable_shared_from_this<Connection>
     Connection& operator=(const Connection&&) = delete;
 
     virtual void sendBinary(std::string_view msg) = 0;
-    virtual void sendBinary(std::string&& msg) = 0;
     virtual void sendEx(MessageType type, std::string_view msg,
                         std::function<void()>&& onDone) = 0;
     virtual void sendText(std::string_view msg) = 0;
-    virtual void sendText(std::string&& msg) = 0;
     virtual void close(std::string_view msg = "quit") = 0;
     virtual void deferRead() = 0;
     virtual void resumeRead() = 0;
@@ -180,23 +178,7 @@ class ConnectionImpl : public Connection
         });
     }
 
-    void sendBinary(std::string&& msg) override
-    {
-        ws.binary(true);
-        outBuffer.commit(boost::asio::buffer_copy(outBuffer.prepare(msg.size()),
-                                                  boost::asio::buffer(msg)));
-        doWrite();
-    }
-
     void sendText(std::string_view msg) override
-    {
-        ws.text(true);
-        outBuffer.commit(boost::asio::buffer_copy(outBuffer.prepare(msg.size()),
-                                                  boost::asio::buffer(msg)));
-        doWrite();
-    }
-
-    void sendText(std::string&& msg) override
     {
         ws.text(true);
         outBuffer.commit(boost::asio::buffer_copy(outBuffer.prepare(msg.size()),

--- a/include/async_resolve.hpp
+++ b/include/async_resolve.hpp
@@ -83,7 +83,7 @@ class Resolver
         uint64_t flag = 0;
         crow::connections::systemBus->async_method_call(
             [host{std::string(host)}, portNum,
-             handler{std::forward<ResolveHandler>(handler)}](
+             handler = std::forward<ResolveHandler>(handler)](
                 const boost::system::error_code& ec,
                 const std::vector<
                     std::tuple<int32_t, int32_t, std::vector<uint8_t>>>& resp,

--- a/include/dbus_privileges.hpp
+++ b/include/dbus_privileges.hpp
@@ -109,7 +109,7 @@ inline bool
 template <typename CallbackFn>
 void afterGetUserInfo(Request& req,
                       const std::shared_ptr<bmcweb::AsyncResp>& asyncResp,
-                      BaseRule& rule, CallbackFn&& callback,
+                      BaseRule& rule, CallbackFn callback,
                       const boost::system::error_code& ec,
                       const dbus::utility::DBusPropertiesMap& userInfoMap)
 {
@@ -151,7 +151,7 @@ void validatePrivilege(Request& req,
     std::string username = req.session->username;
     crow::connections::systemBus->async_method_call(
         [req{std::move(req)}, asyncResp, &rule,
-         callback(std::forward<CallbackFn>(callback))](
+         callback = std::forward<CallbackFn>(callback)](
             const boost::system::error_code& ec,
             const dbus::utility::DBusPropertiesMap& userInfoMap) mutable {
         afterGetUserInfo(req, asyncResp, rule,

--- a/include/dbus_utility.hpp
+++ b/include/dbus_utility.hpp
@@ -149,7 +149,7 @@ template <typename Callback>
 inline void checkDbusPathExists(const std::string& path, Callback&& callback)
 {
     crow::connections::systemBus->async_method_call(
-        [callback{std::forward<Callback>(callback)}](
+        [callback = std::forward<Callback>(callback)](
             const boost::system::error_code& ec,
             const dbus::utility::MapperGetObject& objectNames) {
         callback(!ec && !objectNames.empty());

--- a/include/google/google_service_root.hpp
+++ b/include/google/google_service_root.hpp
@@ -104,8 +104,7 @@ inline void resolveRoT(const std::string& command,
         "xyz.openbmc_project.Control.Hoth"};
     dbus::utility::getSubTree(
         "/xyz/openbmc_project", 0, hothIfaces,
-        [command, asyncResp, rotId,
-         entityHandler{std::forward<ResolvedEntityHandler>(entityHandler)}](
+        [command, asyncResp, rotId, entityHandler{std::move(entityHandler)}](
             const boost::system::error_code& ec,
             const dbus::utility::MapperGetSubTreeResponse& subtree) {
         hothGetSubtreeCallback(command, asyncResp, rotId, entityHandler, ec,

--- a/include/multipart_parser.hpp
+++ b/include/multipart_parser.hpp
@@ -209,6 +209,8 @@ class MultipartParser
                 }
                 case State::END:
                     break;
+                default:
+                    return ParserError::ERROR_UNEXPECTED_END_OF_INPUT;
             }
         }
 

--- a/meson.build
+++ b/meson.build
@@ -153,6 +153,7 @@ if (cxx.get_id() == 'clang')
     '-Wno-weak-vtables',
     '-Wno-switch-enum',
     '-Wno-unused-macros',
+    '-Wno-covered-switch-default',
     language:'cpp')
 endif
 

--- a/meson.build
+++ b/meson.build
@@ -133,25 +133,13 @@ endif
 
 # Add compiler arguments
 
-# -Wpedantic, -Wextra comes by default with warning level
-add_project_arguments(
-  cxx.get_supported_arguments([
-  '-Wcast-align',
-  '-Wconversion',
-  '-Wformat=2',
-  '-Wold-style-cast',
-  '-Woverloaded-virtual',
-  '-Wsign-conversion',
-  '-Wunused',
-  '-Wno-attributes',
-  ]),
-  language: 'cpp'
-)
-
-if (cxx.get_id() == 'clang' and cxx.version().version_compare('>9.0'))
-add_project_arguments(
-  cxx.get_supported_arguments([
+if (cxx.get_id() == 'clang')
+  if (cxx.version().version_compare('<17.0'))
+    error('This project requires clang-17 or higher')
+  endif
+  add_project_arguments(
     '-Weverything',
+    '-Wformat=2',
     '-Wno-c++98-compat-pedantic',
     '-Wno-c++98-compat',
     '-Wno-documentation-unknown-command',
@@ -165,25 +153,30 @@ add_project_arguments(
     '-Wno-weak-vtables',
     '-Wno-switch-enum',
     '-Wno-unused-macros',
-  ]),
-  language:'cpp')
+    language:'cpp')
 endif
 
-# if compiler is gnu-gcc , and version is > 8.0 then we add few more
-# compiler arguments , we know that will pass
+if (cxx.get_id() == 'gcc')
+  if (cxx.version().version_compare('<13.0'))
+    error('This project requires gcc-13 or higher')
+  endif
 
-if (cxx.get_id() == 'gcc' and cxx.version().version_compare('>8.0'))
   add_project_arguments(
-    cxx.get_supported_arguments([
-     '-Wduplicated-cond',
-     '-Wduplicated-branches',
-     '-Wlogical-op',
-     '-Wnull-dereference',
-     '-Wunused-parameter',
-     '-Wdouble-promotion',
-     '-Wshadow',
-     '-Wno-psabi',
-     ]),
+    '-Wformat=2',
+    '-Wcast-align',
+    '-Wconversion',
+    '-Woverloaded-virtual',
+    '-Wsign-conversion',
+    '-Wunused',
+    '-Wduplicated-cond',
+    '-Wduplicated-branches',
+    '-Wlogical-op',
+    '-Wnull-dereference',
+    '-Wunused-parameter',
+    '-Wdouble-promotion',
+    '-Wshadow',
+    '-Wno-psabi',
+    '-Wno-attributes',
     language:'cpp')
 endif
 

--- a/meson_options.txt
+++ b/meson_options.txt
@@ -140,7 +140,7 @@ option(
     'bmcweb-logging',
     type: 'combo',
     choices : [ 'disabled', 'enabled', 'debug', 'info', 'warning', 'error', 'critical' ],
-    value: 'disabled',
+    value: 'error',
     description: '''Enable output the extended logging level.
                     - disabled: disable bmcweb log traces.
                     - enabled: treated as 'debug'

--- a/redfish-core/include/utils/chassis_utils.hpp
+++ b/redfish-core/include/utils/chassis_utils.hpp
@@ -28,7 +28,7 @@ void getValidChassisPath(const std::shared_ptr<bmcweb::AsyncResp>& asyncResp,
     // Get the Chassis Collection
     dbus::utility::getSubTreePaths(
         "/xyz/openbmc_project/inventory", 0, interfaces,
-        [callback{std::forward<Callback>(callback)}, asyncResp,
+        [callback = std::forward<Callback>(callback), asyncResp,
          chassisId](const boost::system::error_code& ec,
                     const dbus::utility::MapperGetSubTreePathsResponse&
                         chassisPaths) mutable {

--- a/redfish-core/include/utils/query_param.hpp
+++ b/redfish-core/include/utils/query_param.hpp
@@ -715,6 +715,8 @@ inline std::optional<std::string> formatQueryForExpand(const Query& query)
             queryTypeExpected = true;
             str += '*';
             break;
+        default:
+            return std::nullopt;
     }
     if (!queryTypeExpected)
     {

--- a/redfish-core/lib/account_service.hpp
+++ b/redfish-core/lib/account_service.hpp
@@ -578,8 +578,9 @@ inline void getLDAPConfigData(const std::string& ldapType,
 
     dbus::utility::getDbusObject(
         ldapConfigObjectName, interfaces,
-        [callback, ldapType](const boost::system::error_code& ec,
-                             const dbus::utility::MapperGetObject& resp) {
+        [callback = std::forward<CallbackFunc>(callback),
+         ldapType](const boost::system::error_code& ec,
+                   const dbus::utility::MapperGetObject& resp) mutable {
         if (ec || resp.empty())
         {
             BMCWEB_LOG_WARNING(

--- a/redfish-core/lib/ethernet.hpp
+++ b/redfish-core/lib/ethernet.hpp
@@ -797,7 +797,7 @@ void getEthernetIfaceData(const std::string& ethifaceId,
     dbus::utility::getManagedObjects(
         "xyz.openbmc_project.Network", path,
         [ethifaceId{std::string{ethifaceId}},
-         callback{std::forward<CallbackFunc>(callback)}](
+         callback = std::forward<CallbackFunc>(callback)](
             const boost::system::error_code& ec,
             const dbus::utility::ManagedObjectType& resp) {
         EthernetInterfaceData ethData{};
@@ -847,7 +847,7 @@ void getEthernetIfaceList(CallbackFunc&& callback)
     sdbusplus::message::object_path path("/xyz/openbmc_project/network");
     dbus::utility::getManagedObjects(
         "xyz.openbmc_project.Network", path,
-        [callback{std::forward<CallbackFunc>(callback)}](
+        [callback = std::forward<CallbackFunc>(callback)](
             const boost::system::error_code& ec,
             const dbus::utility::ManagedObjectType& resp) {
         // Callback requires vector<string> to retrieve all available

--- a/redfish-core/lib/hypervisor_system.hpp
+++ b/redfish-core/lib/hypervisor_system.hpp
@@ -315,7 +315,7 @@ void getHypervisorIfaceData(const std::string& ethIfaceId,
     dbus::utility::getManagedObjects(
         "xyz.openbmc_project.Settings", path,
         [ethIfaceId{std::string{ethIfaceId}},
-         callback{std::forward<CallbackFunc>(callback)}](
+         callback = std::forward<CallbackFunc>(callback)](
             const boost::system::error_code& ec,
             const dbus::utility::ManagedObjectType& resp) {
         EthernetInterfaceData ethData{};

--- a/redfish-core/lib/log_services.hpp
+++ b/redfish-core/lib/log_services.hpp
@@ -1076,7 +1076,7 @@ inline void createDumpTaskCallback(
     }
 
     crow::connections::systemBus->async_method_call(
-        [asyncResp, payload, createdObjPath,
+        [asyncResp, payload = std::move(payload), createdObjPath,
          dumpEntryPath{std::move(dumpEntryPath)},
          dumpId](const boost::system::error_code& ec,
                  const std::string& introspectXml) {

--- a/redfish-core/lib/network_protocol.hpp
+++ b/redfish-core/lib/network_protocol.hpp
@@ -101,7 +101,7 @@ void getEthernetIfaceData(CallbackFunc&& callback)
     sdbusplus::message::object_path path("/xyz/openbmc_project/network");
     dbus::utility::getManagedObjects(
         "xyz.openbmc_project.Network", path,
-        [callback{std::forward<CallbackFunc>(callback)}](
+        [callback = std::forward<CallbackFunc>(callback)](
             const boost::system::error_code& ec,
             const dbus::utility::ManagedObjectType& dbusData) {
         std::vector<std::string> ntpServers;

--- a/redfish-core/lib/pcie.hpp
+++ b/redfish-core/lib/pcie.hpp
@@ -274,7 +274,7 @@ inline void getPCIeDeviceSlotPath(
     dbus::utility::getAssociatedSubTreePaths(
         associationPath, sdbusplus::message::object_path(inventoryPath), 0,
         pcieSlotInterface,
-        [callback, asyncResp, pcieDevicePath](
+        [callback = std::move(callback), asyncResp, pcieDevicePath](
             const boost::system::error_code& ec,
             const dbus::utility::MapperGetSubTreePathsResponse& endpoints) {
         if (ec)

--- a/redfish-core/lib/redfish_util.hpp
+++ b/redfish-core/lib/redfish_util.hpp
@@ -69,7 +69,7 @@ void getMainChassisId(std::shared_ptr<bmcweb::AsyncResp> asyncResp,
         "xyz.openbmc_project.Inventory.Item.Chassis"};
     dbus::utility::getSubTree(
         "/xyz/openbmc_project/inventory", 0, interfaces,
-        [callback,
+        [callback = std::forward<CallbackFunc>(callback),
          asyncResp](const boost::system::error_code& ec,
                     const dbus::utility::MapperGetSubTreeResponse& subtree) {
         if (ec)
@@ -104,7 +104,7 @@ void getPortStatusAndPath(
     CallbackFunc&& callback)
 {
     crow::connections::systemBus->async_method_call(
-        [protocolToDBus, callback{std::forward<CallbackFunc>(callback)}](
+        [protocolToDBus, callback = std::forward<CallbackFunc>(callback)](
             const boost::system::error_code& ec,
             const std::vector<UnitStruct>& r) {
         std::vector<std::tuple<std::string, std::string, bool>> socketData;
@@ -211,7 +211,7 @@ void getPortNumber(const std::string& socketPath, CallbackFunc&& callback)
         std::vector<std::tuple<std::string, std::string>>>(
         *crow::connections::systemBus, "org.freedesktop.systemd1", socketPath,
         "org.freedesktop.systemd1.Socket", "Listen",
-        [callback{std::forward<CallbackFunc>(callback)}](
+        [callback = std::forward<CallbackFunc>(callback)](
             const boost::system::error_code& ec,
             const std::vector<std::tuple<std::string, std::string>>& resp) {
         if (ec)

--- a/redfish-core/lib/sensors.hpp
+++ b/redfish-core/lib/sensors.hpp
@@ -703,7 +703,7 @@ inline void setLedState(nlohmann::json& sensorJson,
             case LedState::BLINK:
                 sensorJson["IndicatorLED"] = "Blinking";
                 break;
-            case LedState::UNKNOWN:
+            default:
                 break;
         }
     }

--- a/redfish-core/lib/sensors.hpp
+++ b/redfish-core/lib/sensors.hpp
@@ -360,7 +360,7 @@ void getObjectsWithConnection(
     // Make call to ObjectMapper to find all sensors objects
     dbus::utility::getSubTree(
         path, 2, interfaces,
-        [callback{std::forward<Callback>(callback)}, sensorsAsyncResp,
+        [callback = std::forward<Callback>(callback), sensorsAsyncResp,
          sensorNames](const boost::system::error_code& ec,
                       const dbus::utility::MapperGetSubTreeResponse& subtree) {
         // Response handler for parsing objects subtree
@@ -422,9 +422,10 @@ void getConnections(std::shared_ptr<SensorsAsyncResp> sensorsAsyncResp,
                     Callback&& callback)
 {
     auto objectsWithConnectionCb =
-        [callback](const std::set<std::string>& connections,
-                   const std::set<std::pair<std::string, std::string>>&
-                   /*objectsWithConnection*/) { callback(connections); };
+        [callback = std::forward<Callback>(callback)](
+            const std::set<std::string>& connections,
+            const std::set<std::pair<std::string, std::string>>&
+            /*objectsWithConnection*/) { callback(connections); };
     getObjectsWithConnection(sensorsAsyncResp, sensorNames,
                              std::move(objectsWithConnectionCb));
 }
@@ -523,7 +524,7 @@ void getChassis(const std::shared_ptr<bmcweb::AsyncResp>& asyncResp,
     // Get the Chassis Collection
     dbus::utility::getSubTreePaths(
         "/xyz/openbmc_project/inventory", 0, interfaces,
-        [callback{std::forward<Callback>(callback)}, asyncResp,
+        [callback = std::forward<Callback>(callback), asyncResp,
          chassisIdStr{std::string(chassisId)},
          chassisSubNode{std::string(chassisSubNode)}, sensorTypes](
             const boost::system::error_code& ec,
@@ -566,7 +567,7 @@ void getChassis(const std::shared_ptr<bmcweb::AsyncResp>& asyncResp,
         dbus::utility::getAssociationEndPoints(
             sensorPath,
             [asyncResp, chassisSubNode, sensorTypes,
-             callback{std::forward<const Callback>(callback)}](
+             callback = std::forward<const Callback>(callback)](
                 const boost::system::error_code& ec2,
                 const dbus::utility::MapperEndPoints& nodeSensorList) {
             if (ec2)
@@ -1451,7 +1452,7 @@ static void getInventoryItemsData(
         dbus::utility::getManagedObjects(
             invConnection, path,
             [sensorsAsyncResp, inventoryItems, invConnections,
-             callback{std::forward<Callback>(callback)}, invConnectionsIndex](
+             callback = std::forward<Callback>(callback), invConnectionsIndex](
                 const boost::system::error_code& ec,
                 const dbus::utility::ManagedObjectType& resp) {
             BMCWEB_LOG_DEBUG("getInventoryItemsData respHandler enter");
@@ -1527,7 +1528,7 @@ static void getInventoryItemsConnections(
     // Make call to ObjectMapper to find all inventory items
     dbus::utility::getSubTree(
         path, 0, interfaces,
-        [callback{std::forward<Callback>(callback)}, sensorsAsyncResp,
+        [callback = std::forward<Callback>(callback), sensorsAsyncResp,
          inventoryItems](
             const boost::system::error_code& ec,
             const dbus::utility::MapperGetSubTreeResponse& subtree) {
@@ -1603,7 +1604,7 @@ static void getInventoryItemAssociations(
     sdbusplus::message::object_path path("/");
     dbus::utility::getManagedObjects(
         "xyz.openbmc_project.ObjectMapper", path,
-        [callback{std::forward<Callback>(callback)}, sensorsAsyncResp,
+        [callback = std::forward<Callback>(callback), sensorsAsyncResp,
          sensorNames](const boost::system::error_code& ec,
                       const dbus::utility::ManagedObjectType& resp) {
         BMCWEB_LOG_DEBUG("getInventoryItemAssociations respHandler enter");
@@ -1772,7 +1773,7 @@ void getInventoryLedData(
         // Response handler for Get State property
         auto respHandler =
             [sensorsAsyncResp, inventoryItems, ledConnections, ledPath,
-             callback{std::forward<Callback>(callback)}, ledConnectionsIndex](
+             callback = std::forward<Callback>(callback), ledConnectionsIndex](
                 const boost::system::error_code& ec, const std::string& state) {
             BMCWEB_LOG_DEBUG("getInventoryLedData respHandler enter");
             if (ec)
@@ -1863,7 +1864,7 @@ void getInventoryLeds(
     // Make call to ObjectMapper to find all inventory items
     dbus::utility::getSubTree(
         path, 0, interfaces,
-        [callback{std::forward<Callback>(callback)}, sensorsAsyncResp,
+        [callback = std::forward<Callback>(callback), sensorsAsyncResp,
          inventoryItems](
             const boost::system::error_code& ec,
             const dbus::utility::MapperGetSubTreeResponse& subtree) {
@@ -1953,7 +1954,7 @@ void getPowerSupplyAttributesData(
 
     // Response handler for Get DeratingFactor property
     auto respHandler = [sensorsAsyncResp, inventoryItems,
-                        callback{std::forward<Callback>(callback)}](
+                        callback = std::forward<Callback>(callback)](
                            const boost::system::error_code& ec,
                            const uint32_t value) {
         BMCWEB_LOG_DEBUG("getPowerSupplyAttributesData respHandler enter");
@@ -2035,7 +2036,7 @@ void getPowerSupplyAttributes(
     // Make call to ObjectMapper to find the PowerSupplyAttributes service
     dbus::utility::getSubTree(
         "/xyz/openbmc_project", 0, interfaces,
-        [callback{std::forward<Callback>(callback)}, sensorsAsyncResp,
+        [callback = std::forward<Callback>(callback), sensorsAsyncResp,
          inventoryItems](
             const boost::system::error_code& ec,
             const dbus::utility::MapperGetSubTreeResponse& subtree) {
@@ -2119,12 +2120,12 @@ static void
 {
     BMCWEB_LOG_DEBUG("getInventoryItems enter");
     auto getInventoryItemAssociationsCb =
-        [sensorsAsyncResp, callback{std::forward<Callback>(callback)}](
+        [sensorsAsyncResp, callback = std::forward<Callback>(callback)](
             std::shared_ptr<std::vector<InventoryItem>> inventoryItems) {
         BMCWEB_LOG_DEBUG("getInventoryItemAssociationsCb enter");
         auto getInventoryItemsConnectionsCb =
             [sensorsAsyncResp, inventoryItems,
-             callback{std::forward<const Callback>(callback)}](
+             callback = std::forward<const Callback>(callback)](
                 std::shared_ptr<std::set<std::string>> invConnections) {
             BMCWEB_LOG_DEBUG("getInventoryItemsConnectionsCb enter");
             auto getInventoryItemsDataCb = [sensorsAsyncResp, inventoryItems,
@@ -2772,7 +2773,7 @@ inline void retrieveUriToDbusMap(const std::string& chassis,
 
     auto asyncResp = std::make_shared<bmcweb::AsyncResp>();
     auto callback = [asyncResp,
-                     mapCompleteCb{std::forward<Callback>(mapComplete)}](
+                     mapCompleteCb = std::forward<Callback>(mapComplete)](
                         const boost::beast::http::status status,
                         const std::map<std::string, std::string>& uriToDbus) {
         mapCompleteCb(status, uriToDbus);

--- a/redfish-core/lib/virtual_media.hpp
+++ b/redfish-core/lib/virtual_media.hpp
@@ -98,9 +98,9 @@ inline void
     sdbusplus::message::object_path path("/xyz/openbmc_project/VirtualMedia");
     dbus::utility::getManagedObjects(
         service, path,
-        [service, resName, asyncResp,
-         handler](const boost::system::error_code& ec,
-                  const dbus::utility::ManagedObjectType& subtree) {
+        [service, resName, asyncResp, handler = std::move(handler)](
+            const boost::system::error_code& ec,
+            const dbus::utility::ManagedObjectType& subtree) {
         if (ec)
         {
             BMCWEB_LOG_DEBUG("DBUS response error");

--- a/src/json_html_serializer.cpp
+++ b/src/json_html_serializer.cpp
@@ -532,7 +532,7 @@ static void dump(std::string& out, const nlohmann::json& val)
             out += "null";
             return;
         }
-        case nlohmann::json::value_t::binary:
+        default:
         {
             // Do nothing;  Should never happen.
             return;


### PR DESCRIPTION
See this fail in CI
```
In file included from ../include/ibm/utils.hpp:3,
                 from ../include/ibm/locks.hpp:3,
                 from ../test/include/ibm/lock_test.cpp:1:
../http/logging.hpp: In instantiation of 'void BMCWEB_LOG_DEBUG(const crow::FormatString&, Args&& ...) [with Args = {int}]':
../include/ibm/locks.hpp:373:21:   required from here
../http/logging.hpp:236:38: error: cannot bind non-const lvalue reference of type 'int&' to an rvalue of type 'int'
  236 |         format, std::make_format_args(std::forward<Args>(args)...));
      |
```

Cherry-pick:
1) https://gerrit.openbmc.org/c/openbmc/bmcweb/+/69480
2) https://gerrit.openbmc.org/c/openbmc/bmcweb/+/70033 
3) https://gerrit.openbmc.org/c/openbmc/bmcweb/+/70575 
4) https://gerrit.openbmc.org/c/openbmc/bmcweb/+/70130 
5) https://gerrit.openbmc.org/c/openbmc/bmcweb/+/70286 
6) https://gerrit.openbmc.org/c/openbmc/bmcweb/+/70655 <- not merged 


Tested: GUI looks good on r100. Did some PATCH, DELETE, POST operations. Validator looks good. 
 