### PR TITLE
1110: Add ACFWindowActive and AllowUnauthACFUpload (#525)(#678)

### DIFF
--- a/redfish-core/lib/account_service.hpp
+++ b/redfish-core/lib/account_service.hpp
@@ -27,6 +27,7 @@
 #include "utils/dbus_utils.hpp"
 #include "utils/json_utils.hpp"
 
+#include <boost/system/error_code.hpp>
 #include <sdbusplus/asio/property.hpp>
 #include <sdbusplus/unpack_properties.hpp>
 
@@ -274,7 +275,7 @@ inline void
         updatedUserGroups, [asyncResp](const boost::system::error_code& ec) {
         if (ec)
         {
-            BMCWEB_LOG_ERROR("D-Bus responses error: {}", ec);
+            BMCWEB_LOG_ERROR("D-Bus responses error: {}", ec.value());
             messages::internalError(asyncResp->res);
             return;
         }
@@ -997,6 +998,23 @@ inline void
     });
 }
 
+inline void setPropertyAllowUnauthACFUpload(
+    const std::shared_ptr<bmcweb::AsyncResp>& asyncResp, bool allow)
+{
+    sdbusplus::asio::setProperty(
+        *crow::connections::systemBus, "xyz.openbmc_project.Settings",
+        "/xyz/openbmc_project/ibmacf/allow_unauth_upload",
+        "xyz.openbmc_project.Object.Enable", "Enabled", allow,
+        [asyncResp](const boost::system::error_code& ec) {
+        if (ec)
+        {
+            BMCWEB_LOG_ERROR("D-Bus responses error: {}", ec.value());
+            messages::internalError(asyncResp->res);
+            return;
+        }
+    });
+}
+
 inline void getAcfProperties(
     const std::shared_ptr<bmcweb::AsyncResp>& asyncResp,
     const std::tuple<std::vector<uint8_t>, bool, std::string>& messageFDbus)
@@ -1093,6 +1111,22 @@ inline void getAcfProperties(
     }
     asyncResp->res.jsonValue["Oem"]["IBM"]["ACF"]["ACFInstalled"] =
         acfInstalled;
+
+    sdbusplus::asio::getProperty<bool>(
+        *crow::connections::systemBus, "xyz.openbmc_project.Settings",
+        "/xyz/openbmc_project/ibmacf/allow_unauth_upload",
+        "xyz.openbmc_project.Object.Enable", "Enabled",
+        [asyncResp](const boost::system::error_code& ec,
+                    const bool allowUnauthACFUpload) {
+        if (ec)
+        {
+            BMCWEB_LOG_ERROR("D-Bus responses error: {}", ec.value());
+            messages::internalError(asyncResp->res);
+            return;
+        }
+        asyncResp->res.jsonValue["Oem"]["IBM"]["ACF"]["AllowUnauthACFUpload"] =
+            allowUnauthACFUpload;
+    });
 }
 
 /**
@@ -1576,14 +1610,19 @@ inline void uploadACF(const std::shared_ptr<bmcweb::AsyncResp>& asyncResp,
         "InstallACF", decodedAcf);
 }
 
+// This is called when someone either is not authenticated or is not
+// authorized to upload an ACF, and they are trying to upload an ACF;
+// in this condition, uploading an ACF is allowed when
+// AllowUnauthACFUpload is true.
 inline void triggerUnauthenticatedACFUpload(
     const std::shared_ptr<bmcweb::AsyncResp>& asyncResp,
     std::optional<nlohmann::json> oem)
 {
+    std::vector<uint8_t> decodedAcf;
     std::optional<nlohmann::json> ibm;
     if (!redfish::json_util::readJson(*oem, asyncResp->res, "IBM", ibm))
     {
-        BMCWEB_LOG_ERROR("Illegal Property ");
+        BMCWEB_LOG_WARNING("Illegal Property");
         messages::propertyMissing(asyncResp->res, "IBM");
         return;
     }
@@ -1593,7 +1632,7 @@ inline void triggerUnauthenticatedACFUpload(
     {
         if (!redfish::json_util::readJson(*ibm, asyncResp->res, "ACF", acf))
         {
-            BMCWEB_LOG_ERROR("Illegal Property ");
+            BMCWEB_LOG_WARNING("Illegal Property");
             messages::propertyMissing(asyncResp->res, "ACF");
             return;
         }
@@ -1601,12 +1640,11 @@ inline void triggerUnauthenticatedACFUpload(
 
     if (acf)
     {
-        std::vector<uint8_t> decodedAcf;
         std::optional<std::string> acfFile{};
         if (!redfish::json_util::readJson(*acf, asyncResp->res, "ACFFile",
                                           acfFile))
         {
-            BMCWEB_LOG_ERROR("Illegal Property ");
+            BMCWEB_LOG_WARNING("Illegal Property");
             messages::propertyMissing(asyncResp->res, "ACFFile");
             return;
         }
@@ -1629,39 +1667,55 @@ inline void triggerUnauthenticatedACFUpload(
             messages::internalError(asyncResp->res);
             return;
         }
+    }
 
-        crow::connections::systemBus->async_method_call(
-            [asyncResp, decodedAcf](const boost::system::error_code ec,
-                                    const std::variant<bool>& retVal) {
-            if (ec)
+    // Allow ACF upload when D-Bus property allow_unauth_upload is true (aka
+    // Redfish property AllowUnauthACFUpload).
+    sdbusplus::asio::getProperty<bool>(
+        *crow::connections::systemBus, "xyz.openbmc_project.Settings",
+        "/xyz/openbmc_project/ibmacf/allow_unauth_upload",
+        "xyz.openbmc_project.Object.Enable", "Enabled",
+        [asyncResp, decodedAcf](const boost::system::error_code& ec,
+                                const bool allowUnauthACFUpload) {
+        if (ec)
+        {
+            BMCWEB_LOG_ERROR(
+                "D-Bus response error reading allow_unauth_upload: {}",
+                ec.value());
+            messages::internalError(asyncResp->res);
+            return;
+        }
+
+        if (allowUnauthACFUpload)
+        {
+            uploadACF(asyncResp, decodedAcf);
+            return;
+        }
+
+        // Allow ACF upload when D-Bus property ACFWindowActive is true
+        // (aka OpPanel function 74).
+        sdbusplus::asio::getProperty<bool>(
+            *crow::connections::systemBus, "com.ibm.PanelApp",
+            "/com/ibm/panel_app", "com.ibm.panel", "ACFWindowActive",
+            [asyncResp, decodedAcf](const boost::system::error_code& ec1,
+                                    const bool isACFWindowActive) {
+            if (ec1)
             {
                 BMCWEB_LOG_ERROR("Failed to read ACFWindowActive property");
-                messages::internalError(asyncResp->res);
-                return;
+                // The Panel app doesn't run on simulated systems.
             }
 
-            const bool* isACFWindowActive = std::get_if<bool>(&retVal);
-
-            if (isACFWindowActive == nullptr)
+            if (!isACFWindowActive)
             {
-                BMCWEB_LOG_ERROR("nullptr for ACFWindowActive");
-                messages::internalError(asyncResp->res);
-                return;
-            }
-
-            if (!*isACFWindowActive)
-            {
-                BMCWEB_LOG_WARNING("ACF window not set to active from panel");
+                BMCWEB_LOG_ERROR("ACF upload not allowed");
                 messages::insufficientPrivilege(asyncResp->res);
                 return;
             }
 
             uploadACF(asyncResp, decodedAcf);
-        },
-            "com.ibm.PanelApp", "/com/ibm/panel_app",
-            "org.freedesktop.DBus.Properties", "Get", "com.ibm.panel",
-            "ACFWindowActive");
-    }
+            return;
+        });
+    });
 }
 
 inline void handleAccountServiceHead(
@@ -2568,10 +2622,17 @@ inline void
 
     if (oem)
     {
+        if (username != "service")
+        {
+            // Only the service user has Oem properties
+            messages::propertyUnknown(asyncResp->res, "Oem");
+            return;
+        }
+
         std::optional<nlohmann::json> ibm;
         if (!redfish::json_util::readJson(*oem, asyncResp->res, "IBM", ibm))
         {
-            BMCWEB_LOG_ERROR("Illegal Property ");
+            BMCWEB_LOG_WARNING("Illegal Property");
             messages::propertyMissing(asyncResp->res, "IBM");
             return;
         }
@@ -2580,29 +2641,28 @@ inline void
             std::optional<nlohmann::json> acf;
             if (!redfish::json_util::readJson(*ibm, asyncResp->res, "ACF", acf))
             {
-                BMCWEB_LOG_ERROR("Illegal Property ");
+                BMCWEB_LOG_WARNING("Illegal Property");
                 messages::propertyMissing(asyncResp->res, "ACF");
                 return;
             }
-            if (acf && (username == "service"))
+            if (acf)
             {
-                std::vector<uint8_t> decodedAcf;
+                std::optional<bool> allowUnauthACFUpload;
                 std::optional<std::string> acfFile;
-                if (acf.value().contains("ACFFile") &&
-                    acf.value()["ACFFile"] == nullptr)
+                if (!redfish::json_util::readJson(
+                        *acf, asyncResp->res, "ACFFile", acfFile,
+                        "AllowUnauthACFUpload", allowUnauthACFUpload))
                 {
-                    acfFile = "";
+                    BMCWEB_LOG_WARNING("Illegal Property");
+                    messages::propertyMissing(asyncResp->res, "ACFFile");
+                    messages::propertyMissing(asyncResp->res,
+                                              "AllowUnauthACFUpload");
+                    return;
                 }
-                else
-                {
-                    if (!redfish::json_util::readJson(*acf, asyncResp->res,
-                                                      "ACFFile", acfFile))
-                    {
-                        BMCWEB_LOG_ERROR("Illegal Property ");
-                        messages::propertyMissing(asyncResp->res, "ACFFile");
-                        return;
-                    }
 
+                if (acfFile)
+                {
+                    std::vector<uint8_t> decodedAcf;
                     std::string sDecodedAcf;
                     if (!crow::utility::base64Decode(*acfFile, sDecodedAcf))
                     {
@@ -2621,16 +2681,14 @@ inline void
                         messages::internalError(asyncResp->res);
                         return;
                     }
+                    uploadACF(asyncResp, decodedAcf);
                 }
 
-                uploadACF(asyncResp, decodedAcf);
-            }
-            else if (acf && (username != "service"))
-            {
-                messages::resourceAtUriUnauthorized(
-                    asyncResp->res, req.url(),
-                    "ACF properties access not allowed by non service "
-                    "user");
+                if (allowUnauthACFUpload)
+                {
+                    setPropertyAllowUnauthACFUpload(asyncResp,
+                                                    *allowUnauthACFUpload);
+                }
             }
         }
     }

--- a/redfish-core/lib/service_root.hpp
+++ b/redfish-core/lib/service_root.hpp
@@ -27,6 +27,7 @@
 #include "utils/dbus_utils.hpp"
 #include "utils/systemd_utils.hpp"
 
+#include <boost/system/error_code.hpp>
 #include <nlohmann/json.hpp>
 #include <persistent_data.hpp>
 #include <query.hpp>
@@ -43,6 +44,59 @@
 
 namespace redfish
 {
+
+inline void
+    handleACFWindowActive(const std::shared_ptr<bmcweb::AsyncResp>& asyncResp)
+{
+    // Redfish property ACFWindowActive=true when either of these is true:
+    //  - D-Bus property allow_unauth_upload.  (This is aka the Redfish
+    //    property AllowUnauthACFUpload which the BMC admin can control.)
+    //  - D-Bus property ACFWindowActive.  (This is aka the Redfish
+    //    property ACFWindowActive under /redfish/v1/AccountService/
+    //    Accounts/service property Oem.IBM.ACF.  The value is provided by
+    //    the PanelApp and is true when panel function 74 is active.)
+    // Check D-Bus property allow_unauth_upload first.
+    sdbusplus::asio::getProperty<bool>(
+        *crow::connections::systemBus, "xyz.openbmc_project.Settings",
+        "/xyz/openbmc_project/ibmacf/allow_unauth_upload",
+        "xyz.openbmc_project.Object.Enable", "Enabled",
+        [asyncResp](const boost::system::error_code& ec,
+                    const bool allowUnauthACFUpload) {
+        if (ec)
+        {
+            BMCWEB_LOG_ERROR(
+                "D-Bus response error reading allow_unauth_upload: {}",
+                ec.value());
+            messages::internalError(asyncResp->res);
+            return;
+        }
+
+        if (allowUnauthACFUpload)
+        {
+            asyncResp->res.jsonValue["Oem"]["IBM"]["ACFWindowActive"] =
+                allowUnauthACFUpload;
+            return;
+        }
+
+        // Check D-Bus property ACFWindowActive
+        sdbusplus::asio::getProperty<bool>(
+            *crow::connections::systemBus, "com.ibm.PanelApp",
+            "/com/ibm/panel_app", "com.ibm.panel", "ACFWindowActive",
+            [asyncResp](const boost::system::error_code& ec1,
+                        const bool isACFWindowActive) {
+            if (ec1)
+            {
+                BMCWEB_LOG_ERROR("Failed to read ACFWindowActive property");
+                // Default value when panel app is unreachable.
+                asyncResp->res.jsonValue["Oem"]["IBM"]["ACFWindowActive"] =
+                    false;
+                return;
+            }
+            asyncResp->res.jsonValue["Oem"]["IBM"]["ACFWindowActive"] =
+                isACFWindowActive;
+        });
+    });
+}
 
 inline void fillServiceRootOemProperties(
     const std::shared_ptr<bmcweb::AsyncResp>& asyncResp,
@@ -142,7 +196,7 @@ inline void
         redfishDateTimeOffset.first;
     asyncResp->res.jsonValue["Oem"]["IBM"]["DateTimeLocalOffset"] =
         redfishDateTimeOffset.second;
-
+    handleACFWindowActive(asyncResp);
     asyncResp->res.jsonValue["Oem"]["@odata.type"] = "#OemServiceRoot.Oem";
     asyncResp->res.jsonValue["Oem"]["IBM"]["@odata.type"] =
         "#OemServiceRoot.IBM";

--- a/static/redfish/v1/JsonSchemas/OemManagerAccount/OemManagerAccount.json
+++ b/static/redfish/v1/JsonSchemas/OemManagerAccount/OemManagerAccount.json
@@ -85,6 +85,15 @@
                         "boolean"
                     ],
                     "versionAdded": "v1_0_0"
+                },
+                "AllowUnauthACFUpload": {
+                    "description": "This property shall indicate if unauthorized users shall be allowed to upload ACFs.",
+                    "longDescription": "This property indicates if unauthorized users are allowed to upload ACFs or not.  When this property is true, users are allowed to upload ACFs regardless of their authentication status, regardless of their Role, and regardless of the time window created by Operator Panel function 74.",
+                    "readonly": false,
+                    "type": [
+                        "boolean"
+                    ],
+                    "versionAdded": "v1_0_0"
                 }
             },
             "type": "object"

--- a/static/redfish/v1/JsonSchemas/OemServiceRoot/OemServiceRoot.json
+++ b/static/redfish/v1/JsonSchemas/OemServiceRoot/OemServiceRoot.json
@@ -85,6 +85,15 @@
                         "string",
                         "null"
                     ]
+                },
+                "ACFWindowActive": {
+                    "description": "An indication of whether the time window for an unauthorized agent to upload an ACF is active.",
+                    "longDescription": "This property shall indicate if the time window for an unauthorized agent to upload an ACF is active.",
+                    "readonly": true,
+                    "type": [
+                        "boolean",
+                        "null"
+                    ]
                 }
             },
             "type": "object"

--- a/static/redfish/v1/schema/OemManagerAccount_v1.xml
+++ b/static/redfish/v1/schema/OemManagerAccount_v1.xml
@@ -53,12 +53,17 @@
 				<Property Name="ExpirationDate" Type="Edm.String" Nullable="true">
 					<Annotation Term="OData.Permissions" EnumMember="OData.Permission/Read"/>
 					<Annotation Term="OData.Description" String="The expiration date of the ACF file."/>
-					<Annotation Term="OData.LongDescription" String="The expiration date of the ACF file, if the expiration date has been from the BMC then the ACF is not validD"/>
+					<Annotation Term="OData.LongDescription" String="The expiration date of the ACF file, if the expiration date has been from the BMC then the ACF is not valid."/>
 				</Property>
 				<Property Name="ACFInstalled" Type="Edm.Boolean">
 					<Annotation Term="OData.Permissions" EnumMember="OData.Permission/Read"/>
 					<Annotation Term="OData.Description" String="This property is set to true if the ACF is installed."/>
 					<Annotation Term="OData.LongDescription" String="This property indicates if the ACF is installed or not."/>
+				</Property>
+				<Property Name="AllowUnauthACFUpload" Type="Edm.Boolean">
+					<Annotation Term="OData.Permissions" EnumMember="OData.Permission/ReadWrite"/>
+					<Annotation Term="OData.Description" String="This property shall indicate if unauthorized users shall be allowed to upload ACFs."/>
+					<Annotation Term="OData.LongDescription" String="This property indicates if unauthorized users are allowed to upload ACFs or not.  When this property is true, users are allowed to upload ACFs regardless of their authentication status, regardless of their Role, and regardless of the time window created by Operator Panel function 74."/>
 				</Property>
 			</ComplexType>
 

--- a/static/redfish/v1/schema/OemServiceRoot_v1.xml
+++ b/static/redfish/v1/schema/OemServiceRoot_v1.xml
@@ -59,6 +59,11 @@
           <Annotation Term="OData.Description" String="The time offset from UTC that the DateTime property is in `+HH:MM` format."/>
           <Annotation Term="OData.LongDescription" String="This property shall contain the offset from UTC time that the DateTime property contains.  If both DateTime and DateTimeLocalOffset are provided in modification requests, services shall apply DateTimeLocalOffset after DateTime is applied."/>
         </Property>
+        <Property Name="ACFWindowActive" Type="OemServiceRoot.IBM">
+          <Annotation Term="OData.Permissions" EnumMember="OData.Permission/Read"/>
+          <Annotation Term="OData.Description" String="An indication of whether the time window for an unauthorized agent to upload an ACF is active."/>
+          <Annotation Term="OData.LongDescription" String="This property shall indicate if the time window for an unauthorized agent to upload an ACF is active."/>
+        </Property>
       </ComplexType>
 
     </Schema>


### PR DESCRIPTION
1.  Add ACFWindowActive to /redfish/v1 (#331)(#525)

This adds the Oem.IBM.ACFWindowActive boolean property to the Redfish service root at URI /redfish/v1.

```
and simulating button press via
busctl set-property "com.ibm.PanelApp" "/com/ibm/panel_app" \
  "com.ibm.panel" "ACFWindowActive" b true
```

2. New property to always AllowUnauthACFUpload (#466) (#678)

* New property to always AllowUnauthACFUpload

This adds a new BMC security setting as a Redfish OEM property:
URI /redfish/v1/AccountService/Accounts/service property
Oem.IBM.ACF.AllowUnauthACFUpload can be set by the admin.  When
true, any network agent is allowed to upload an ACF file to the BMC.
The default value is false.  This capability is included in the
existing URI /redfish/v1 property Oem.IBM.ACFWindowActive.  For
example, when AllowUnauthACFUpload=true, ACFWindowActive is true.

Tested: via Redfish scenarios
1. Ensure AllowUnauthACFUpload=false by default.
2. Ensure a non admin user is not allowed to GET or PATCH
   AllowUnauthACFUpload.
3. Ensure the admin can PATCH AllowUnauthACFUpload true and false,
   and GET the correct values, and these values survive BMC reboot.
4. With (OpPanel fn 74 is not active) and AllowUnauthACFUpload=false,
   ensure ACFWindowActive=false.  And unauth ACF upload is not allowed.
5. With (OpPanel fn 74 is not active) and AllowUnauthACFUpload=true,


Cheatsheet:
```
$ busctl set-property com.ibm.PanelApp /com/ibm/panel_app \
  com.ibm.panel ACFWindowActive b true

$ curl -k -H "Content-Type: application/json"  -H "X-Auth-Token: $TOKEN" \
     -X PATCH -d '{"Oem":{"IBM":{"ACF":{"AllowUnauthACFUpload": true}}}}' \
     https://${bmc}/redfish/v1/AccountService/Accounts/service

$ curl -k -H "X-Auth-Token: $TOKEN" -X GET https://${bmc}/redfish/v1

$ curl -k -H "Content-Type: application/json"  -X PATCH \
     -d '{"Oem":{"IBM":{"ACF":{"ACFFile":"'${acf}'"}}}}' \
     https://${bmc}/redfish/v1/AccountService/Accounts/service
```
