### PR TITLE
Fix resource dump create with multiple params (#889)

### DIFF
--- a/redfish-core/lib/log_services.hpp
+++ b/redfish-core/lib/log_services.hpp
@@ -1114,6 +1114,14 @@ inline void createDump(const std::shared_ptr<bmcweb::AsyncResp>& asyncResp,
                     "com.ibm.Dump.Create.CreateParameters.Password",
                     resourceDumpParams[2]));
             }
+
+            if (resourceDumpParams.size() > 3)
+            {
+                BMCWEB_LOG_WARNING << "Invalid value for OEMDiagnosticDataType";
+                messages::invalidObject(asyncResp->res,
+                                        "OEMDiagnosticDataType");
+                return;
+            }
         }
         else
         {


### PR DESCRIPTION
Currently, resource dump redfish request takes parameters like: "Resource_<vspstring>_<password>". bmcweb will:
1. extracts the parameters with '_' as the separator
2. If there are 2 strings, it means resource dump create request is with just vsp string; if there are 3 strings, it means password is present
3. Makes a call to the backend dbus app with these extracted strings

There is no check currently to handle if more than 3 strings are present (which is an invalid usecase and error should be thrown)

Tested By:
* Created resource dump with "Resource_<str1>_<str2>_<str3>" and verified that error is sent back to the redfish client [1] POST https://${bmc}/redfish/v1/Systems/system/LogServices/Dump/Actions/LogService.CollectDiagnosticData -d '{"DiagnosticDataType":"OEM", "OEMDiagnosticDataType":"Resource_<str1>_<str2>_<str3>"}'