### PR TITLE
Pull in all registries

### DIFF
--- a/redfish-core/include/registries/composition_message_registry.hpp
+++ b/redfish-core/include/registries/composition_message_registry.hpp
@@ -1,0 +1,209 @@
+#pragma once
+/****************************************************************
+ *                 READ THIS WARNING FIRST
+ * This is an auto-generated header which contains definitions
+ * for Redfish DMTF defined messages.
+ * DO NOT modify this registry outside of running the
+ * parse_registries.py script.  The definitions contained within
+ * this file are owned by DMTF.  Any modifications to these files
+ * should be first pushed to the relevant registry in the DMTF
+ * github organization.
+ ***************************************************************/
+#include "registries.hpp"
+
+#include <array>
+
+// clang-format off
+
+namespace redfish::registries::composition
+{
+const Header header = {
+    "Copyright 2019-2023 DMTF. All rights reserved.",
+    "#MessageRegistry.v1_6_2.MessageRegistry",
+    "Composition.1.1.2",
+    "Composition Message Registry",
+    "en",
+    "This registry defines the messages for composition related events.",
+    "Composition",
+    "1.1.2",
+    "DMTF",
+};
+constexpr const char* url =
+    "https://redfish.dmtf.org/registries/Composition.1.1.2.json";
+
+constexpr std::array registry =
+{
+    MessageEntry{
+        "ConstrainedResourceAlreadyReserved",
+        {
+            "Indicates that the requested resources are already reserved in response to a constrained composition request.",
+            "The requested resources are reserved under reservation '%1'.",
+            "Critical",
+            1,
+            {
+                "string",
+            },
+            "Delete the reservation containing the resources and resubmit the request.",
+        }},
+    MessageEntry{
+        "EmptyManifest",
+        {
+            "Indicates that the manifest contains no stanzas or that a stanza in the manifest contains no request.",
+            "The provided manifest is empty or a stanza in the manifest contains no request.",
+            "Warning",
+            0,
+            {},
+            "Provide a request content for the manifest and resubmit.",
+        }},
+    MessageEntry{
+        "IncompatibleZone",
+        {
+            "Indicates that not all referenced resource blocks are in the same resource zone.",
+            "The requested resource blocks span multiple resource zones.",
+            "Critical",
+            0,
+            {},
+            "Request resource blocks from the same resource zone.",
+        }},
+    MessageEntry{
+        "NoResourceMatch",
+        {
+            "Indicates that the service could not find a matching resource based on the given parameters.",
+            "The requested resources of type '%1' are not available for allocation.",
+            "Critical",
+            1,
+            {
+                "string",
+            },
+            "Change parameters associated with the resource, such as quantity or performance, and resubmit the request.",
+        }},
+    MessageEntry{
+        "ResourceBlockChanged",
+        {
+            "Indicates that a resource block has changed.  This is not used whenever there is another event message for that specific change, such as when only the state has changed.",
+            "Resource block '%1' has changed on the service.",
+            "OK",
+            1,
+            {
+                "string",
+            },
+            "None.",
+        }},
+    MessageEntry{
+        "ResourceBlockCompositionStateChanged",
+        {
+            "Indicates that the composition state of a resource block has changed, specifically the value of the `CompositionState` property within `CompositionStatus`.",
+            "The composition status of the resource block '%1' has changed.",
+            "OK",
+            1,
+            {
+                "string",
+            },
+            "None.",
+        }},
+    MessageEntry{
+        "ResourceBlockInUse",
+        {
+            "Indicates that the composition request contains a resource block that is unable to participate in more compositions.",
+            "Resource block '%1' cannot be part of any new compositions.",
+            "Warning",
+            1,
+            {
+                "string",
+            },
+            "Remove the resource block from the request and resubmit the request.",
+        }},
+    MessageEntry{
+        "ResourceBlockInvalid",
+        {
+            "Indicates that the `Id` of a referenced resource block is no longer valid.",
+            "Resource block '%1' is not valid.",
+            "Critical",
+            1,
+            {
+                "string",
+            },
+            "Remove the resource block and resubmit the request.",
+        }},
+    MessageEntry{
+        "ResourceBlockNotFound",
+        {
+            "Indicates that the referenced resource block was not found.",
+            "Resource block '%1' was not found.",
+            "Critical",
+            1,
+            {
+                "string",
+            },
+            "Remove the resource block and resubmit the request.",
+        }},
+    MessageEntry{
+        "ResourceBlockStateChanged",
+        {
+            "Indicates that the state of a resource block has changed, specifically the value of the `State` property within `Status`.",
+            "The state of resource block '%1' has changed.",
+            "OK",
+            1,
+            {
+                "string",
+            },
+            "None.",
+        }},
+    MessageEntry{
+        "ResourceZoneMembershipChanged",
+        {
+            "Indicates that the membership of a resource zone has changed due to resource blocks being added or removed from the resource zone.",
+            "The membership of resource zone '%1' has been changed.",
+            "OK",
+            1,
+            {
+                "string",
+            },
+            "None.",
+        }},
+    MessageEntry{
+        "SpecifiedResourceAlreadyReserved",
+        {
+            "Indicates that a resource block is already reserved in response to a specific composition request.",
+            "Resource block '%1' is already reserved under reservation '%2'.",
+            "Critical",
+            2,
+            {
+                "string",
+                "string",
+            },
+            "Delete the reservation containing the resource block or select a different resource block and resubmit the request.",
+        }},
+    MessageEntry{
+        "UnableToProcessStanzaRequest",
+        {
+            "Indicates that the manifest provided for the `Compose` action contains a stanza with `Content` that could not be processed.",
+            "The provided manifest for the Compose action of type %1 contains a stanza with Id of value '%2' with a Content parameter that could not be processed.",
+            "Critical",
+            2,
+            {
+                "string",
+                "string",
+            },
+            "Add the Content parameter to the stanza or remove the stanza, and resubmit the request.",
+        }},
+
+};
+
+enum class Index
+{
+    constrainedResourceAlreadyReserved = 0,
+    emptyManifest = 1,
+    incompatibleZone = 2,
+    noResourceMatch = 3,
+    resourceBlockChanged = 4,
+    resourceBlockCompositionStateChanged = 5,
+    resourceBlockInUse = 6,
+    resourceBlockInvalid = 7,
+    resourceBlockNotFound = 8,
+    resourceBlockStateChanged = 9,
+    resourceZoneMembershipChanged = 10,
+    specifiedResourceAlreadyReserved = 11,
+    unableToProcessStanzaRequest = 12,
+};
+} // namespace redfish::registries::composition

--- a/redfish-core/include/registries/environmental_message_registry.hpp
+++ b/redfish-core/include/registries/environmental_message_registry.hpp
@@ -1,0 +1,443 @@
+#pragma once
+/****************************************************************
+ *                 READ THIS WARNING FIRST
+ * This is an auto-generated header which contains definitions
+ * for Redfish DMTF defined messages.
+ * DO NOT modify this registry outside of running the
+ * parse_registries.py script.  The definitions contained within
+ * this file are owned by DMTF.  Any modifications to these files
+ * should be first pushed to the relevant registry in the DMTF
+ * github organization.
+ ***************************************************************/
+#include "registries.hpp"
+
+#include <array>
+
+// clang-format off
+
+namespace redfish::registries::environmental
+{
+const Header header = {
+    "Copyright 2023 DMTF. All rights reserved.",
+    "#MessageRegistry.v1_6_2.MessageRegistry",
+    "Environmental.1.0.1",
+    "Environmental Message Registry",
+    "en",
+    "This registry defines messages related to environmental sensors, heating and cooling equipment, or other environmental conditions.",
+    "Environmental",
+    "1.0.1",
+    "DMTF",
+};
+constexpr const char* url =
+    "https://redfish.dmtf.org/registries/Environmental.1.0.1.json";
+
+constexpr std::array registry =
+{
+    MessageEntry{
+        "FanFailed",
+        {
+            "Indicates that a fan has failed.",
+            "Fan '%1' has failed.",
+            "Warning",
+            1,
+            {
+                "string",
+            },
+            "Check the fan hardware and replace any faulty component.",
+        }},
+    MessageEntry{
+        "FanGroupCritical",
+        {
+            "Indicates that a fan group has a critical status.",
+            "Fan group '%1' is in a critical state.",
+            "Critical",
+            1,
+            {
+                "string",
+            },
+            "None.",
+        }},
+    MessageEntry{
+        "FanGroupNormal",
+        {
+            "Indicates that a fan group has returned to normal operations.",
+            "Fan group '%1' is operating normally.",
+            "OK",
+            1,
+            {
+                "string",
+            },
+            "None.",
+        }},
+    MessageEntry{
+        "FanGroupWarning",
+        {
+            "Indicates that a fan group has a warning status.",
+            "Fan group '%1' is in a warning state.",
+            "Warning",
+            1,
+            {
+                "string",
+            },
+            "None.",
+        }},
+    MessageEntry{
+        "FanInserted",
+        {
+            "Indicates that a fan was inserted or installed.",
+            "Fan '%1' was inserted.",
+            "OK",
+            1,
+            {
+                "string",
+            },
+            "None.",
+        }},
+    MessageEntry{
+        "FanRemoved",
+        {
+            "Indicates that a fan was removed.",
+            "Fan '%1' was removed.",
+            "OK",
+            1,
+            {
+                "string",
+            },
+            "None.",
+        }},
+    MessageEntry{
+        "FanRestored",
+        {
+            "Indicates that a fan was repaired or restored to normal operation.",
+            "Fan '%1' was restored.",
+            "OK",
+            1,
+            {
+                "string",
+            },
+            "None.",
+        }},
+    MessageEntry{
+        "HumidityAboveLowerCriticalThreshold",
+        {
+            "Indicates that a humidity reading is no longer below the lower critical threshold but is still outside of normal operating range.",
+            "Humidity '%1' reading of %2 percent is now above the %3 lower critical threshold but remains outside of normal range.",
+            "Warning",
+            3,
+            {
+                "string",
+                "number",
+                "number",
+            },
+            "Check the condition of the resource listed in OriginOfCondition.",
+        }},
+    MessageEntry{
+        "HumidityAboveUpperCautionThreshold",
+        {
+            "Indicates that a humidity reading is above the upper caution threshold.",
+            "Humidity '%1' reading of %2 percent is above the %3 upper caution threshold.",
+            "Warning",
+            3,
+            {
+                "string",
+                "number",
+                "number",
+            },
+            "Check the condition of the resource listed in OriginOfCondition.",
+        }},
+    MessageEntry{
+        "HumidityAboveUpperCriticalThreshold",
+        {
+            "Indicates that a humidity reading is above the upper critical threshold.",
+            "Humidity '%1' reading of %2 percent is above the %3 upper critical threshold.",
+            "Critical",
+            3,
+            {
+                "string",
+                "number",
+                "number",
+            },
+            "Check the condition of the resource listed in OriginOfCondition.",
+        }},
+    MessageEntry{
+        "HumidityBelowLowerCautionThreshold",
+        {
+            "Indicates that a humidity reading is below the lower caution threshold.",
+            "Humidity '%1' reading of %2 percent is below the %3 lower caution threshold.",
+            "Warning",
+            3,
+            {
+                "string",
+                "number",
+                "number",
+            },
+            "Check the condition of the resource listed in OriginOfCondition.",
+        }},
+    MessageEntry{
+        "HumidityBelowLowerCriticalThreshold",
+        {
+            "Indicates that a humidity reading is below the lower critical threshold.",
+            "Humidity '%1' reading of %2 percent is below the %3 lower critical threshold.",
+            "Critical",
+            3,
+            {
+                "string",
+                "number",
+                "number",
+            },
+            "Check the condition of the resource listed in OriginOfCondition.",
+        }},
+    MessageEntry{
+        "HumidityBelowUpperCriticalThreshold",
+        {
+            "Indicates that a humidity reading is no longer above the upper critical threshold but is still outside of normal operating range.",
+            "Humidity '%1' reading of %2 percent is now below the %3 upper critical threshold but remains outside of normal range.",
+            "Warning",
+            3,
+            {
+                "string",
+                "number",
+                "number",
+            },
+            "Check the condition of the resource listed in OriginOfCondition.",
+        }},
+    MessageEntry{
+        "HumidityNormal",
+        {
+            "Indicates that a humidity reading is now within normal operating range.",
+            "Humidity '%1' reading of %2 percent is within normal operating range.",
+            "OK",
+            2,
+            {
+                "string",
+                "number",
+            },
+            "None.",
+        }},
+    MessageEntry{
+        "TemperatureAboveLowerCriticalThreshold",
+        {
+            "Indicates that a temperature reading is no longer below the lower critical threshold but is still outside of normal operating range.",
+            "Temperature '%1' reading of %2 degrees (C) is now above the %3 lower critical threshold but remains outside of normal range.",
+            "Warning",
+            3,
+            {
+                "string",
+                "number",
+                "number",
+            },
+            "Check the condition of the resource listed in OriginOfCondition.",
+        }},
+    MessageEntry{
+        "TemperatureAboveLowerFatalThreshold",
+        {
+            "Indicates that a temperature reading is no longer below the lower fatal threshold but is still outside of normal operating range.",
+            "Temperature '%1' reading of %2 degrees (C) is now above the %3 lower fatal threshold but remains outside of normal range.",
+            "Critical",
+            3,
+            {
+                "string",
+                "number",
+                "number",
+            },
+            "Check the condition of the resource listed in OriginOfCondition.",
+        }},
+    MessageEntry{
+        "TemperatureAboveUpperCautionThreshold",
+        {
+            "Indicates that a temperature reading is above the upper caution threshold.",
+            "Temperature '%1' reading of %2 degrees (C) is above the %3 upper caution threshold.",
+            "Warning",
+            3,
+            {
+                "string",
+                "number",
+                "number",
+            },
+            "Check the condition of the resource listed in OriginOfCondition.",
+        }},
+    MessageEntry{
+        "TemperatureAboveUpperCriticalThreshold",
+        {
+            "Indicates that a temperature reading is above the upper critical threshold.",
+            "Temperature '%1' reading of %2 degrees (C) is above the %3 upper critical threshold.",
+            "Critical",
+            3,
+            {
+                "string",
+                "number",
+                "number",
+            },
+            "Check the condition of the resource listed in OriginOfCondition.",
+        }},
+    MessageEntry{
+        "TemperatureAboveUpperFatalThreshold",
+        {
+            "Indicates that a temperature reading is above the upper fatal threshold.",
+            "Temperature '%1' reading of %2 degrees (C) is above the %3 upper fatal threshold.",
+            "Critical",
+            3,
+            {
+                "string",
+                "number",
+                "number",
+            },
+            "Check the condition of the resource listed in OriginOfCondition.",
+        }},
+    MessageEntry{
+        "TemperatureBelowLowerCautionThreshold",
+        {
+            "Indicates that a temperature reading is below the lower caution threshold.",
+            "Temperature '%1' reading of %2 degrees (C) is below the %3 lower caution threshold.",
+            "Warning",
+            3,
+            {
+                "string",
+                "number",
+                "number",
+            },
+            "Check the condition of the resource listed in OriginOfCondition.",
+        }},
+    MessageEntry{
+        "TemperatureBelowLowerCriticalThreshold",
+        {
+            "Indicates that a temperature reading is below the lower critical threshold.",
+            "Temperature '%1' reading of %2 degrees (C) is below the %3 lower critical threshold.",
+            "Critical",
+            3,
+            {
+                "string",
+                "number",
+                "number",
+            },
+            "Check the condition of the resource listed in OriginOfCondition.",
+        }},
+    MessageEntry{
+        "TemperatureBelowLowerFatalThreshold",
+        {
+            "Indicates that a temperature reading is below the lower fatal threshold.",
+            "Temperature '%1' reading of %2 degrees (C) is below the %3 lower fatal threshold.",
+            "Critical",
+            3,
+            {
+                "string",
+                "number",
+                "number",
+            },
+            "Check the condition of the resource listed in OriginOfCondition.",
+        }},
+    MessageEntry{
+        "TemperatureBelowUpperCriticalThreshold",
+        {
+            "Indicates that a temperature reading is no longer above the upper critical threshold but is still outside of normal operating range.",
+            "Temperature '%1' reading of %2 degrees (C) is now below the %3 upper critical threshold but remains outside of normal range.",
+            "Warning",
+            3,
+            {
+                "string",
+                "number",
+                "number",
+            },
+            "Check the condition of the resource listed in OriginOfCondition.",
+        }},
+    MessageEntry{
+        "TemperatureBelowUpperFatalThreshold",
+        {
+            "Indicates that a temperature reading is no longer above the upper fatal threshold but is still outside of normal operating range.",
+            "Temperature '%1' reading of %2 degrees (C) is now below the %3 upper fatal threshold but remains outside of normal range.",
+            "Critical",
+            3,
+            {
+                "string",
+                "number",
+                "number",
+            },
+            "Check the condition of the resource listed in OriginOfCondition.",
+        }},
+    MessageEntry{
+        "TemperatureCritical",
+        {
+            "Indicates that a temperature reading exceeds an internal critical level.",
+            "Temperature '%1' reading of %2 degrees (C) exceeds the critical level.",
+            "Critical",
+            2,
+            {
+                "string",
+                "number",
+            },
+            "Check the condition of the resource listed in OriginOfCondition.",
+        }},
+    MessageEntry{
+        "TemperatureNoLongerCritical",
+        {
+            "Indicates that a temperature reading no longer exceeds an internal critical level but still exceeds an internal warning level.",
+            "Temperature '%1' reading of %2 degrees (C) no longer exceeds the critical level.",
+            "Warning",
+            2,
+            {
+                "string",
+                "number",
+            },
+            "Check the condition of the resource listed in OriginOfCondition.",
+        }},
+    MessageEntry{
+        "TemperatureNormal",
+        {
+            "Indicates that a temperature reading is now within normal operating range.",
+            "Temperature '%1' reading of %2 degrees (C) is within normal operating range.",
+            "OK",
+            2,
+            {
+                "string",
+                "number",
+            },
+            "None.",
+        }},
+    MessageEntry{
+        "TemperatureWarning",
+        {
+            "Indicates that a temperature reading exceeds an internal warning level.",
+            "Temperature '%1' reading of %2 degrees (C) exceeds the warning level.",
+            "Warning",
+            2,
+            {
+                "string",
+                "number",
+            },
+            "Check the condition of the resource listed in OriginOfCondition.",
+        }},
+
+};
+
+enum class Index
+{
+    fanFailed = 0,
+    fanGroupCritical = 1,
+    fanGroupNormal = 2,
+    fanGroupWarning = 3,
+    fanInserted = 4,
+    fanRemoved = 5,
+    fanRestored = 6,
+    humidityAboveLowerCriticalThreshold = 7,
+    humidityAboveUpperCautionThreshold = 8,
+    humidityAboveUpperCriticalThreshold = 9,
+    humidityBelowLowerCautionThreshold = 10,
+    humidityBelowLowerCriticalThreshold = 11,
+    humidityBelowUpperCriticalThreshold = 12,
+    humidityNormal = 13,
+    temperatureAboveLowerCriticalThreshold = 14,
+    temperatureAboveLowerFatalThreshold = 15,
+    temperatureAboveUpperCautionThreshold = 16,
+    temperatureAboveUpperCriticalThreshold = 17,
+    temperatureAboveUpperFatalThreshold = 18,
+    temperatureBelowLowerCautionThreshold = 19,
+    temperatureBelowLowerCriticalThreshold = 20,
+    temperatureBelowLowerFatalThreshold = 21,
+    temperatureBelowUpperCriticalThreshold = 22,
+    temperatureBelowUpperFatalThreshold = 23,
+    temperatureCritical = 24,
+    temperatureNoLongerCritical = 25,
+    temperatureNormal = 26,
+    temperatureWarning = 27,
+};
+} // namespace redfish::registries::environmental

--- a/redfish-core/include/registries/ethernet_fabric_message_registry.hpp
+++ b/redfish-core/include/registries/ethernet_fabric_message_registry.hpp
@@ -1,0 +1,154 @@
+#pragma once
+/****************************************************************
+ *                 READ THIS WARNING FIRST
+ * This is an auto-generated header which contains definitions
+ * for Redfish DMTF defined messages.
+ * DO NOT modify this registry outside of running the
+ * parse_registries.py script.  The definitions contained within
+ * this file are owned by DMTF.  Any modifications to these files
+ * should be first pushed to the relevant registry in the DMTF
+ * github organization.
+ ***************************************************************/
+#include "registries.hpp"
+
+#include <array>
+
+// clang-format off
+
+namespace redfish::registries::ethernet_fabric
+{
+const Header header = {
+    "Copyright 2020-2023 DMTF. All rights reserved.",
+    "#MessageRegistry.v1_6_2.MessageRegistry",
+    "EthernetFabric.1.0.1",
+    "Ethernet Fabric Message Registry",
+    "en",
+    "This registry defines messages for Ethernet fabrics.",
+    "EthernetFabric",
+    "1.0.1",
+    "DMTF",
+};
+constexpr const char* url =
+    "https://redfish.dmtf.org/registries/EthernetFabric.1.0.1.json";
+
+constexpr std::array registry =
+{
+    MessageEntry{
+        "LLDPInterfaceDisabled",
+        {
+            "Indicates that an interface has disabled Link Layer Discovery Protocol (LLDP).",
+            "LLDP was disabled on switch '%1' port '%2'.",
+            "Warning",
+            2,
+            {
+                "string",
+                "string",
+            },
+            "Check that LLDP is enabled on device endpoints.",
+        }},
+    MessageEntry{
+        "LLDPInterfaceEnabled",
+        {
+            "Indicates that an interface has enabled Link Layer Discovery Protocol (LLDP).",
+            "LLDP was enabled on switch '%1' port '%2'.",
+            "OK",
+            2,
+            {
+                "string",
+                "string",
+            },
+            "None.",
+        }},
+    MessageEntry{
+        "MLAGInterfaceDegraded",
+        {
+            "Indicates that multi-chassis link aggregation group (MLAG) interfaces were established, but at an unexpectedly low aggregated link speed.",
+            "MLAG interface '%1' is degraded on switch '%2'.",
+            "Warning",
+            2,
+            {
+                "string",
+                "string",
+            },
+            "Contact the network administrator for problem resolution.",
+        }},
+    MessageEntry{
+        "MLAGInterfaceDown",
+        {
+            "Indicates that the multi-chassis link aggregation group (MLAG) interface is down on a switch.",
+            "The MLAG interface '%1' on switch '%2' is down.",
+            "Warning",
+            2,
+            {
+                "string",
+                "string",
+            },
+            "Check physical connectivity and that the MLAG system ID matches on switch pairs.",
+        }},
+    MessageEntry{
+        "MLAGInterfacesUp",
+        {
+            "Indicates that all multi-chassis link aggregation group (MLAG) interfaces are up.",
+            "All MLAG interfaces were established for MLAG ID '%1'.",
+            "OK",
+            1,
+            {
+                "string",
+            },
+            "None.",
+        }},
+    MessageEntry{
+        "MLAGPeerDown",
+        {
+            "Indicates that the multi-chassis link aggregation group (MLAG) peer is down.",
+            "MLAG peer switch '%1' with MLAG ID '%2' is down.",
+            "Warning",
+            2,
+            {
+                "string",
+                "string",
+            },
+            "Check physical connectivity and that the port channel ID matches on switch pairs.",
+        }},
+    MessageEntry{
+        "MLAGPeerUp",
+        {
+            "Indicates that the multi-chassis link aggregation group (MLAG) peer is up.",
+            "MLAG peer switch '%1' with MLAG ID '%2' is up.",
+            "OK",
+            2,
+            {
+                "string",
+                "string",
+            },
+            "None.",
+        }},
+    MessageEntry{
+        "RoutingFailureThresholdExceeded",
+        {
+            "Indicates that a switch has encountered an unusually large number of routing errors.",
+            "Switch '%1' has encountered %2 routing errors in the last %3 minutes.",
+            "Warning",
+            3,
+            {
+                "string",
+                "number",
+                "number",
+            },
+            "Contact the network administrator for problem resolution.",
+        }},
+
+};
+
+enum class Index
+{
+    lLDPInterfaceDisabled = 0,
+    lLDPInterfaceEnabled = 1,
+    mLAGInterfaceDegraded = 2,
+    mLAGInterfaceDown = 3,
+    mLAGInterfacesUp = 4,
+    mLAGPeerDown = 5,
+    mLAGPeerUp = 6,
+    routingFailureThresholdExceeded = 7,
+};
+} // namespace redfish::registries::ethernet_fabric

--- a/redfish-core/include/registries/fabric_message_registry.hpp
+++ b/redfish-core/include/registries/fabric_message_registry.hpp
@@ -1,0 +1,634 @@
+#pragma once
+/****************************************************************
+ *                 READ THIS WARNING FIRST
+ * This is an auto-generated header which contains definitions
+ * for Redfish DMTF defined messages.
+ * DO NOT modify this registry outside of running the
+ * parse_registries.py script.  The definitions contained within
+ * this file are owned by DMTF.  Any modifications to these files
+ * should be first pushed to the relevant registry in the DMTF
+ * github organization.
+ ***************************************************************/
+#include "registries.hpp"
+
+#include <array>
+
+// clang-format off
+
+namespace redfish::registries::fabric
+{
+const Header header = {
+    "Copyright 2014-2023 DMTF. All rights reserved.",
+    "#MessageRegistry.v1_6_2.MessageRegistry",
+    "Fabric.1.0.2",
+    "Fabric Message Registry",
+    "en",
+    "This registry defines messages for generic fabrics.",
+    "Fabric",
+    "1.0.2",
+    "DMTF",
+};
+constexpr const char* url =
+    "https://redfish.dmtf.org/registries/Fabric.1.0.2.json";
+
+constexpr std::array registry =
+{
+    MessageEntry{
+        "AddressPoolCreated",
+        {
+            "Indicates that an address pool was created.",
+            "Address pool '%1' was created in fabric '%2'.",
+            "OK",
+            2,
+            {
+                "string",
+                "string",
+            },
+            "None.",
+        }},
+    MessageEntry{
+        "AddressPoolModified",
+        {
+            "Indicates that an address pool was modified.",
+            "Address pool '%1' in fabric '%2' was modified.",
+            "OK",
+            2,
+            {
+                "string",
+                "string",
+            },
+            "None.",
+        }},
+    MessageEntry{
+        "AddressPoolRemoved",
+        {
+            "Indicates that an address pool was removed.",
+            "Address pool '%1' was removed from fabric '%2'.",
+            "OK",
+            2,
+            {
+                "string",
+                "string",
+            },
+            "None.",
+        }},
+    MessageEntry{
+        "CableFailed",
+        {
+            "Indicates that a cable has failed.",
+            "The cable in switch '%1' port '%2' has failed.",
+            "Warning",
+            2,
+            {
+                "string",
+                "string",
+            },
+            "Contact the network administrator for problem resolution.",
+        }},
+    MessageEntry{
+        "CableInserted",
+        {
+            "Indicates that a cable was inserted into a switch's port.",
+            "A cable was inserted into switch '%1' port '%2'.",
+            "OK",
+            2,
+            {
+                "string",
+                "string",
+            },
+            "None.",
+        }},
+    MessageEntry{
+        "CableOK",
+        {
+            "Indicates that a cable has returned to working condition.",
+            "The cable in switch '%1' port '%2' has returned to working condition.",
+            "OK",
+            2,
+            {
+                "string",
+                "string",
+            },
+            "None.",
+        }},
+    MessageEntry{
+        "CableRemoved",
+        {
+            "Indicates that a cable was removed from a switch's port.",
+            "A cable was removed from switch '%1' port '%2'.",
+            "Warning",
+            2,
+            {
+                "string",
+                "string",
+            },
+            "None.",
+        }},
+    MessageEntry{
+        "ConnectionCreated",
+        {
+            "Indicates that a connection was created.",
+            "Connection '%1' was created in fabric '%2'.",
+            "OK",
+            2,
+            {
+                "string",
+                "string",
+            },
+            "None.",
+        }},
+    MessageEntry{
+        "ConnectionModified",
+        {
+            "Indicates that a connection was modified.",
+            "Connection '%1' in fabric '%2' was modified.",
+            "OK",
+            2,
+            {
+                "string",
+                "string",
+            },
+            "None.",
+        }},
+    MessageEntry{
+        "ConnectionRemoved",
+        {
+            "Indicates that a connection was removed.",
+            "Connection '%1' was removed from fabric '%2'.",
+            "OK",
+            2,
+            {
+                "string",
+                "string",
+            },
+            "None.",
+        }},
+    MessageEntry{
+        "DegradedDownstreamLinkEstablished",
+        {
+            "Indicates that a switch's downstream connection is established but is in a degraded state.",
+            "Switch '%1' downstream link is established on port '%2', but is running in a degraded state.",
+            "Warning",
+            2,
+            {
+                "string",
+                "string",
+            },
+            "Contact the network administrator for problem resolution.",
+        }},
+    MessageEntry{
+        "DegradedInterswitchLinkEstablished",
+        {
+            "Indicates that a switch's interswitch connection is established but is in a degraded state.",
+            "Switch '%1' interswitch link is established on port '%2', but is running in a degraded state.",
+            "Warning",
+            2,
+            {
+                "string",
+                "string",
+            },
+            "Contact the network administrator for problem resolution.",
+        }},
+    MessageEntry{
+        "DegradedUpstreamLinkEstablished",
+        {
+            "Indicates that a switch's upstream connection is established but is in a degraded state.",
+            "Switch '%1' upstream link is established on port '%2', but is running in a degraded state.",
+            "Warning",
+            2,
+            {
+                "string",
+                "string",
+            },
+            "Contact the network administrator for problem resolution.",
+        }},
+    MessageEntry{
+        "DownstreamLinkDropped",
+        {
+            "Indicates that a switch's downstream connection has gone down.",
+            "Switch '%1' downstream link has gone down on port '%2'.",
+            "Warning",
+            2,
+            {
+                "string",
+                "string",
+            },
+            "Contact the network administrator for problem resolution.",
+        }},
+    MessageEntry{
+        "DownstreamLinkEstablished",
+        {
+            "Indicates that a switch's downstream connection is established.",
+            "Switch '%1' downstream link is established on port '%2'.",
+            "OK",
+            2,
+            {
+                "string",
+                "string",
+            },
+            "None.",
+        }},
+    MessageEntry{
+        "DownstreamLinkFlapDetected",
+        {
+            "Indicates that a switch's downstream connection is highly unstable.",
+            "Switch '%1' downstream link on port '%2' was established and dropped %3 times in the last %4 minutes.",
+            "Warning",
+            4,
+            {
+                "string",
+                "string",
+                "number",
+                "number",
+            },
+            "Contact the network administrator for problem resolution.",
+        }},
+    MessageEntry{
+        "EndpointCreated",
+        {
+            "Indicates that an endpoint was created or discovered.",
+            "Endpoint '%1' was created in fabric '%2'.",
+            "OK",
+            2,
+            {
+                "string",
+                "string",
+            },
+            "None.",
+        }},
+    MessageEntry{
+        "EndpointModified",
+        {
+            "Indicates that an endpoint was modified.",
+            "Endpoint '%1' in fabric '%2' was modified.",
+            "OK",
+            2,
+            {
+                "string",
+                "string",
+            },
+            "None.",
+        }},
+    MessageEntry{
+        "EndpointRemoved",
+        {
+            "Indicates that an endpoint was removed.",
+            "Endpoint '%1' was removed from fabric '%2'.",
+            "OK",
+            2,
+            {
+                "string",
+                "string",
+            },
+            "None.",
+        }},
+    MessageEntry{
+        "InterswitchLinkDropped",
+        {
+            "Indicates that a switch's interswitch connection has gone down.",
+            "Switch '%1' interswitch link has gone down on port '%2'.",
+            "Warning",
+            2,
+            {
+                "string",
+                "string",
+            },
+            "Contact the network administrator for problem resolution.",
+        }},
+    MessageEntry{
+        "InterswitchLinkEstablished",
+        {
+            "Indicates that a switch's interswitch connection is established.",
+            "Switch '%1' interswitch link is established on port '%2'.",
+            "OK",
+            2,
+            {
+                "string",
+                "string",
+            },
+            "None.",
+        }},
+    MessageEntry{
+        "InterswitchLinkFlapDetected",
+        {
+            "Indicates that a switch's interswitch connection is highly unstable.",
+            "Switch '%1' interswitch link on port '%2' was established and dropped %3 times in the last %4 minutes.",
+            "Warning",
+            4,
+            {
+                "string",
+                "string",
+                "number",
+                "number",
+            },
+            "Contact the network administrator for problem resolution.",
+        }},
+    MessageEntry{
+        "MaxFrameSizeExceeded",
+        {
+            "Indicates that the maximum transmission unit (MTU) for the link was exceeded.",
+            "MTU size on switch '%1' port '%2' is set to %3.  One or more packets with a larger size were dropped.",
+            "Warning",
+            3,
+            {
+                "string",
+                "string",
+                "number",
+            },
+            "Ensure that path MTU discovery is enabled and functioning correctly.",
+        }},
+    MessageEntry{
+        "MediaControllerAdded",
+        {
+            "Indicates that a media controller was added.",
+            "Media controller '%1' was added to chassis '%2'.",
+            "OK",
+            2,
+            {
+                "string",
+                "string",
+            },
+            "None.",
+        }},
+    MessageEntry{
+        "MediaControllerModified",
+        {
+            "Indicates that a media controller was modified.",
+            "Media controller '%1' in chassis '%2' was modified.",
+            "OK",
+            2,
+            {
+                "string",
+                "string",
+            },
+            "None.",
+        }},
+    MessageEntry{
+        "MediaControllerRemoved",
+        {
+            "Indicates that a media controller was removed.",
+            "Media controller '%1' was removed from chassis '%2'.",
+            "OK",
+            2,
+            {
+                "string",
+                "string",
+            },
+            "None.",
+        }},
+    MessageEntry{
+        "PortAutomaticallyDisabled",
+        {
+            "Indicates that a switch's port was automatically disabled.",
+            "Switch '%1' port '%2' was automatically disabled.",
+            "OK",
+            2,
+            {
+                "string",
+                "string",
+            },
+            "None.",
+        }},
+    MessageEntry{
+        "PortAutomaticallyEnabled",
+        {
+            "Indicates that a switch's port was automatically enabled.",
+            "Switch '%1' port '%2' was automatically enabled.",
+            "OK",
+            2,
+            {
+                "string",
+                "string",
+            },
+            "None.",
+        }},
+    MessageEntry{
+        "PortDegraded",
+        {
+            "Indicates that a switch's port is in a degraded state.",
+            "Switch '%1' port '%2' is in a degraded state.",
+            "Warning",
+            2,
+            {
+                "string",
+                "string",
+            },
+            "Contact the network administrator for problem resolution.",
+        }},
+    MessageEntry{
+        "PortFailed",
+        {
+            "Indicates that a switch's port has become inoperative.",
+            "Switch '%1' port '%2' has failed and is inoperative.",
+            "Critical",
+            2,
+            {
+                "string",
+                "string",
+            },
+            "Contact the network administrator for problem resolution.",
+        }},
+    MessageEntry{
+        "PortManuallyDisabled",
+        {
+            "Indicates that a switch's port was manually disabled.",
+            "Switch '%1' port '%2' was manually disabled.",
+            "OK",
+            2,
+            {
+                "string",
+                "string",
+            },
+            "None.",
+        }},
+    MessageEntry{
+        "PortManuallyEnabled",
+        {
+            "Indicates that a switch's port was manually enabled.",
+            "Switch '%1' port '%2' was manually enabled.",
+            "OK",
+            2,
+            {
+                "string",
+                "string",
+            },
+            "None.",
+        }},
+    MessageEntry{
+        "PortOK",
+        {
+            "Indicates that a switch's port has returned to a functional state.",
+            "Switch '%1' port '%2' has returned to a functional state.",
+            "OK",
+            2,
+            {
+                "string",
+                "string",
+            },
+            "None.",
+        }},
+    MessageEntry{
+        "SwitchDegraded",
+        {
+            "Indicates that a switch is in a degraded state.",
+            "Switch '%1' is in a degraded state.",
+            "Warning",
+            1,
+            {
+                "string",
+            },
+            "Contact the network administrator for problem resolution.",
+        }},
+    MessageEntry{
+        "SwitchFailed",
+        {
+            "Indicates that a switch has become inoperative.",
+            "Switch '%1' has failed and is inoperative.",
+            "Critical",
+            1,
+            {
+                "string",
+            },
+            "Contact the network administrator for problem resolution.",
+        }},
+    MessageEntry{
+        "SwitchOK",
+        {
+            "Indicates that a switch has returned to a functional state.",
+            "Switch '%1' has returned to a functional state.",
+            "OK",
+            1,
+            {
+                "string",
+            },
+            "None.",
+        }},
+    MessageEntry{
+        "UpstreamLinkDropped",
+        {
+            "Indicates that a switch's upstream connection has gone down.",
+            "Switch '%1' upstream link has gone down on port '%2'.",
+            "Warning",
+            2,
+            {
+                "string",
+                "string",
+            },
+            "Contact the network administrator for problem resolution.",
+        }},
+    MessageEntry{
+        "UpstreamLinkEstablished",
+        {
+            "Indicates that a switch's upstream connection is established.",
+            "Switch '%1' upstream link is established on port '%2'.",
+            "OK",
+            2,
+            {
+                "string",
+                "string",
+            },
+            "None.",
+        }},
+    MessageEntry{
+        "UpstreamLinkFlapDetected",
+        {
+            "Indicates that a switch's upstream connection is highly unstable.",
+            "Switch '%1' upstream link on port '%2' was established and dropped %3 times in the last %4 minutes.",
+            "Warning",
+            4,
+            {
+                "string",
+                "string",
+                "number",
+                "number",
+            },
+            "Contact the network administrator for problem resolution.",
+        }},
+    MessageEntry{
+        "ZoneCreated",
+        {
+            "Indicates that a zone was created.",
+            "Zone '%1' was created in fabric '%2'.",
+            "OK",
+            2,
+            {
+                "string",
+                "string",
+            },
+            "None.",
+        }},
+    MessageEntry{
+        "ZoneModified",
+        {
+            "Indicates that a zone was modified.",
+            "Zone '%1' in fabric '%2' was modified.",
+            "OK",
+            2,
+            {
+                "string",
+                "string",
+            },
+            "None.",
+        }},
+    MessageEntry{
+        "ZoneRemoved",
+        {
+            "Indicates that a zone was removed.",
+            "Zone '%1' was removed from fabric '%2'.",
+            "OK",
+            2,
+            {
+                "string",
+                "string",
+            },
+            "None.",
+        }},
+
+};
+
+enum class Index
+{
+    addressPoolCreated = 0,
+    addressPoolModified = 1,
+    addressPoolRemoved = 2,
+    cableFailed = 3,
+    cableInserted = 4,
+    cableOK = 5,
+    cableRemoved = 6,
+    connectionCreated = 7,
+    connectionModified = 8,
+    connectionRemoved = 9,
+    degradedDownstreamLinkEstablished = 10,
+    degradedInterswitchLinkEstablished = 11,
+    degradedUpstreamLinkEstablished = 12,
+    downstreamLinkDropped = 13,
+    downstreamLinkEstablished = 14,
+    downstreamLinkFlapDetected = 15,
+    endpointCreated = 16,
+    endpointModified = 17,
+    endpointRemoved = 18,
+    interswitchLinkDropped = 19,
+    interswitchLinkEstablished = 20,
+    interswitchLinkFlapDetected = 21,
+    maxFrameSizeExceeded = 22,
+    mediaControllerAdded = 23,
+    mediaControllerModified = 24,
+    mediaControllerRemoved = 25,
+    portAutomaticallyDisabled = 26,
+    portAutomaticallyEnabled = 27,
+    portDegraded = 28,
+    portFailed = 29,
+    portManuallyDisabled = 30,
+    portManuallyEnabled = 31,
+    portOK = 32,
+    switchDegraded = 33,
+    switchFailed = 34,
+    switchOK = 35,
+    upstreamLinkDropped = 36,
+    upstreamLinkEstablished = 37,
+    upstreamLinkFlapDetected = 38,
+    zoneCreated = 39,
+    zoneModified = 40,
+    zoneRemoved = 41,
+};
+} // namespace redfish::registries::fabric

--- a/redfish-core/include/registries/heartbeat_event_message_registry.hpp
+++ b/redfish-core/include/registries/heartbeat_event_message_registry.hpp
@@ -1,0 +1,53 @@
+#pragma once
+/****************************************************************
+ *                 READ THIS WARNING FIRST
+ * This is an auto-generated header which contains definitions
+ * for Redfish DMTF defined messages.
+ * DO NOT modify this registry outside of running the
+ * parse_registries.py script.  The definitions contained within
+ * this file are owned by DMTF.  Any modifications to these files
+ * should be first pushed to the relevant registry in the DMTF
+ * github organization.
+ ***************************************************************/
+#include "registries.hpp"
+
+#include <array>
+
+// clang-format off
+
+namespace redfish::registries::heartbeat_event
+{
+const Header header = {
+    "Copyright 2021-2023 DMTF. All rights reserved.",
+    "#MessageRegistry.v1_6_2.MessageRegistry",
+    "HeartbeatEvent.1.0.1",
+    "Heartbeat Event Message Registry",
+    "en",
+    "This registry defines the messages to use for periodic heartbeat, also known as 'keep alive', events.",
+    "HeartbeatEvent",
+    "1.0.1",
+    "DMTF",
+};
+constexpr const char* url =
+    "https://redfish.dmtf.org/registries/HeartbeatEvent.1.0.1.json";
+
+constexpr std::array registry =
+{
+    MessageEntry{
+        "RedfishServiceFunctional",
+        {
+            "An event sent periodically upon request to indicates that the Redfish service is functional.",
+            "Redfish service is functional.",
+            "OK",
+            0,
+            {},
+            "None.",
+        }},
+
+};
+
+enum class Index
+{
+    redfishServiceFunctional = 0,
+};
+} // namespace redfish::registries::heartbeat_event

--- a/redfish-core/include/registries/job_event_message_registry.hpp
+++ b/redfish-core/include/registries/job_event_message_registry.hpp
@@ -1,0 +1,147 @@
+#pragma once
+/****************************************************************
+ *                 READ THIS WARNING FIRST
+ * This is an auto-generated header which contains definitions
+ * for Redfish DMTF defined messages.
+ * DO NOT modify this registry outside of running the
+ * parse_registries.py script.  The definitions contained within
+ * this file are owned by DMTF.  Any modifications to these files
+ * should be first pushed to the relevant registry in the DMTF
+ * github organization.
+ ***************************************************************/
+#include "registries.hpp"
+
+#include <array>
+
+// clang-format off
+
+namespace redfish::registries::job_event
+{
+const Header header = {
+    "Copyright 2014-2023 DMTF in cooperation with the Storage Networking Industry Association (SNIA). All rights reserved.",
+    "#MessageRegistry.v1_6_2.MessageRegistry",
+    "JobEvent.1.0.1",
+    "Job Event Message Registry",
+    "en",
+    "This registry defines the messages for job related events.",
+    "JobEvent",
+    "1.0.1",
+    "DMTF",
+};
+constexpr const char* url =
+    "https://redfish.dmtf.org/registries/JobEvent.1.0.1.json";
+
+constexpr std::array registry =
+{
+    MessageEntry{
+        "JobCancelled",
+        {
+            "A job was cancelled.",
+            "The job with Id '%1' was cancelled.",
+            "Warning",
+            1,
+            {
+                "string",
+            },
+            "None.",
+        }},
+    MessageEntry{
+        "JobCompletedException",
+        {
+            "A job has completed with warnings or errors.",
+            "The job with Id '%1' has completed with warnings or errors.",
+            "Warning",
+            1,
+            {
+                "string",
+            },
+            "None.",
+        }},
+    MessageEntry{
+        "JobCompletedOK",
+        {
+            "A job has completed.",
+            "The job with Id '%1' has completed.",
+            "OK",
+            1,
+            {
+                "string",
+            },
+            "None.",
+        }},
+    MessageEntry{
+        "JobProgressChanged",
+        {
+            "A job has changed progress.",
+            "The job with Id '%1' has changed to progress %2 percent complete.",
+            "OK",
+            2,
+            {
+                "string",
+                "number",
+            },
+            "None.",
+        }},
+    MessageEntry{
+        "JobRemoved",
+        {
+            "A job was removed.",
+            "The job with Id '%1' was removed.",
+            "Warning",
+            1,
+            {
+                "string",
+            },
+            "None.",
+        }},
+    MessageEntry{
+        "JobResumed",
+        {
+            "A job has resumed.",
+            "The job with Id '%1' has resumed.",
+            "OK",
+            1,
+            {
+                "string",
+            },
+            "None.",
+        }},
+    MessageEntry{
+        "JobStarted",
+        {
+            "A job has started.",
+            "The job with Id '%1' has started.",
+            "OK",
+            1,
+            {
+                "string",
+            },
+            "None.",
+        }},
+    MessageEntry{
+        "JobSuspended",
+        {
+            "A job was suspended.",
+            "The job with Id '%1' was suspended.",
+            "Warning",
+            1,
+            {
+                "string",
+            },
+            "None.",
+        }},
+
+};
+
+enum class Index
+{
+    jobCancelled = 0,
+    jobCompletedException = 1,
+    jobCompletedOK = 2,
+    jobProgressChanged = 3,
+    jobRemoved = 4,
+    jobResumed = 5,
+    jobStarted = 6,
+    jobSuspended = 7,
+};
+} // namespace redfish::registries::job_event

--- a/redfish-core/include/registries/license_message_registry.hpp
+++ b/redfish-core/include/registries/license_message_registry.hpp
@@ -1,0 +1,142 @@
+#pragma once
+/****************************************************************
+ *                 READ THIS WARNING FIRST
+ * This is an auto-generated header which contains definitions
+ * for Redfish DMTF defined messages.
+ * DO NOT modify this registry outside of running the
+ * parse_registries.py script.  The definitions contained within
+ * this file are owned by DMTF.  Any modifications to these files
+ * should be first pushed to the relevant registry in the DMTF
+ * github organization.
+ ***************************************************************/
+#include "registries.hpp"
+
+#include <array>
+
+// clang-format off
+
+namespace redfish::registries::license
+{
+const Header header = {
+    "Copyright 2014-2023 DMTF. All rights reserved.",
+    "#MessageRegistry.v1_6_2.MessageRegistry",
+    "License.1.0.3",
+    "License Message Registry",
+    "en",
+    "This registry defines the license status and error messages.",
+    "License",
+    "1.0.3",
+    "DMTF",
+};
+constexpr const char* url =
+    "https://redfish.dmtf.org/registries/License.1.0.3.json";
+
+constexpr std::array registry =
+{
+    MessageEntry{
+        "DaysBeforeExpiration",
+        {
+            "Indicates the number of days remaining on a license before expiration.",
+            "The license '%1' will expire in %2 days.",
+            "OK",
+            2,
+            {
+                "string",
+                "number",
+            },
+            "None.",
+        }},
+    MessageEntry{
+        "Expired",
+        {
+            "Indicates that a license has expired and its functionality was disabled.",
+            "The license '%1' has expired.",
+            "Warning",
+            1,
+            {
+                "string",
+            },
+            "None.",
+        }},
+    MessageEntry{
+        "GracePeriod",
+        {
+            "Indicates that a license has expired and entered its grace period.",
+            "The license '%1' has expired, %2 day grace period before licensed functionality is disabled.",
+            "Warning",
+            2,
+            {
+                "string",
+                "number",
+            },
+            "None.",
+        }},
+    MessageEntry{
+        "InstallFailed",
+        {
+            "Indicates that the service failed to install the license.",
+            "Failed to install the license.  Reason: %1.",
+            "Critical",
+            1,
+            {
+                "string",
+            },
+            "None.",
+        }},
+    MessageEntry{
+        "InvalidLicense",
+        {
+            "Indicates that the license was not recognized, is corrupted, or is invalid.",
+            "The content of the license was not recognized, is corrupted, or is invalid.",
+            "Critical",
+            0,
+            {},
+            "Verify the license content is correct and resubmit the request.",
+        }},
+    MessageEntry{
+        "LicenseInstalled",
+        {
+            "Indicates that a license was installed.",
+            "The license '%1' was installed.",
+            "OK",
+            1,
+            {
+                "string",
+            },
+            "None.",
+        }},
+    MessageEntry{
+        "NotApplicableToTarget",
+        {
+            "Indicates that the license is not applicable to the target.",
+            "The license is not applicable to the target.",
+            "Critical",
+            0,
+            {},
+            "Check the license compatibility or applicability to the specified target.",
+        }},
+    MessageEntry{
+        "TargetsRequired",
+        {
+            "Indicates that one or more targets need to be specified with the license.",
+            "The license requires targets to be specified.",
+            "Critical",
+            0,
+            {},
+            "Add AuthorizedDevices to Links and resubmit the request.",
+        }},
+
+};
+
+enum class Index
+{
+    daysBeforeExpiration = 0,
+    expired = 1,
+    gracePeriod = 2,
+    installFailed = 3,
+    invalidLicense = 4,
+    licenseInstalled = 5,
+    notApplicableToTarget = 6,
+    targetsRequired = 7,
+};
+} // namespace redfish::registries::license

--- a/redfish-core/include/registries/log_service_message_registry.hpp
+++ b/redfish-core/include/registries/log_service_message_registry.hpp
@@ -1,0 +1,55 @@
+#pragma once
+/****************************************************************
+ *                 READ THIS WARNING FIRST
+ * This is an auto-generated header which contains definitions
+ * for Redfish DMTF defined messages.
+ * DO NOT modify this registry outside of running the
+ * parse_registries.py script.  The definitions contained within
+ * this file are owned by DMTF.  Any modifications to these files
+ * should be first pushed to the relevant registry in the DMTF
+ * github organization.
+ ***************************************************************/
+#include "registries.hpp"
+
+#include <array>
+
+// clang-format off
+
+namespace redfish::registries::log_service
+{
+const Header header = {
+    "Copyright 2020-2023 DMTF. All rights reserved.",
+    "#MessageRegistry.v1_6_2.MessageRegistry",
+    "LogService.1.0.1",
+    "Log Service Message Registry",
+    "en",
+    "This registry defines the messages for log service related events.",
+    "LogService",
+    "1.0.1",
+    "DMTF",
+};
+constexpr const char* url =
+    "https://redfish.dmtf.org/registries/LogService.1.0.1.json";
+
+constexpr std::array registry =
+{
+    MessageEntry{
+        "DiagnosticDataCollected",
+        {
+            "Indicates that diagnostic data was collected due to a client invoking the `CollectDiagnosticData` action.",
+            "'%1' diagnostic data collected.",
+            "OK",
+            1,
+            {
+                "string",
+            },
+            "None.",
+        }},
+
+};
+
+enum class Index
+{
+    diagnosticDataCollected = 0,
+};
+} // namespace redfish::registries::log_service

--- a/redfish-core/include/registries/network_device_message_registry.hpp
+++ b/redfish-core/include/registries/network_device_message_registry.hpp
@@ -1,0 +1,132 @@
+#pragma once
+/****************************************************************
+ *                 READ THIS WARNING FIRST
+ * This is an auto-generated header which contains definitions
+ * for Redfish DMTF defined messages.
+ * DO NOT modify this registry outside of running the
+ * parse_registries.py script.  The definitions contained within
+ * this file are owned by DMTF.  Any modifications to these files
+ * should be first pushed to the relevant registry in the DMTF
+ * github organization.
+ ***************************************************************/
+#include "registries.hpp"
+
+#include <array>
+
+// clang-format off
+
+namespace redfish::registries::network_device
+{
+const Header header = {
+    "Copyright 2019-2023 DMTF. All rights reserved.",
+    "#MessageRegistry.v1_6_2.MessageRegistry",
+    "NetworkDevice.1.0.3",
+    "Network Device Message Registry",
+    "en",
+    "This registry defines the messages for networking devices.",
+    "NetworkDevice",
+    "1.0.3",
+    "DMTF",
+};
+constexpr const char* url =
+    "https://redfish.dmtf.org/registries/NetworkDevice.1.0.3.json";
+
+constexpr std::array registry =
+{
+    MessageEntry{
+        "CableInserted",
+        {
+            "Indicates that a network cable was inserted.",
+            "A network cable was inserted into network adapter '%1' port '%2'.",
+            "OK",
+            2,
+            {
+                "string",
+                "string",
+            },
+            "None.",
+        }},
+    MessageEntry{
+        "CableRemoved",
+        {
+            "Indicates that a network cable was removed.",
+            "A cable was removed from network adapter '%1' port '%2'.",
+            "OK",
+            2,
+            {
+                "string",
+                "string",
+            },
+            "None.",
+        }},
+    MessageEntry{
+        "ConnectionDropped",
+        {
+            "Indicates that a network connection was dropped.",
+            "The connection is no longer active for network adapter '%1' port '%2' function '%3'.",
+            "OK",
+            3,
+            {
+                "string",
+                "string",
+                "string",
+            },
+            "None.",
+        }},
+    MessageEntry{
+        "ConnectionEstablished",
+        {
+            "Indicates that a network connection was established.",
+            "A network connection was established for network adapter '%1' port '%2' function '%3'.",
+            "OK",
+            3,
+            {
+                "string",
+                "string",
+                "string",
+            },
+            "None.",
+        }},
+    MessageEntry{
+        "DegradedConnectionEstablished",
+        {
+            "Indicates that a network connection was established, but at an unexpectedly low link speed.",
+            "A degraded network connection was established for network adapter '%1' port '%2' function '%3'.",
+            "Warning",
+            3,
+            {
+                "string",
+                "string",
+                "string",
+            },
+            "None.",
+        }},
+    MessageEntry{
+        "LinkFlapDetected",
+        {
+            "Indicates that a network connection is highly unstable.",
+            "The network connection for network adapter '%1' port '%2' function '%3' was established and dropped '%4' times in the last '%5' minutes.",
+            "Warning",
+            5,
+            {
+                "string",
+                "string",
+                "string",
+                "number",
+                "number",
+            },
+            "Contact the network administrator for problem resolution.",
+        }},
+
+};
+
+enum class Index
+{
+    cableInserted = 0,
+    cableRemoved = 1,
+    connectionDropped = 2,
+    connectionEstablished = 3,
+    degradedConnectionEstablished = 4,
+    linkFlapDetected = 5,
+};
+} // namespace redfish::registries::network_device

--- a/redfish-core/include/registries/platform_message_registry.hpp
+++ b/redfish-core/include/registries/platform_message_registry.hpp
@@ -1,0 +1,88 @@
+#pragma once
+/****************************************************************
+ *                 READ THIS WARNING FIRST
+ * This is an auto-generated header which contains definitions
+ * for Redfish DMTF defined messages.
+ * DO NOT modify this registry outside of running the
+ * parse_registries.py script.  The definitions contained within
+ * this file are owned by DMTF.  Any modifications to these files
+ * should be first pushed to the relevant registry in the DMTF
+ * github organization.
+ ***************************************************************/
+#include "registries.hpp"
+
+#include <array>
+
+// clang-format off
+
+namespace redfish::registries::platform
+{
+const Header header = {
+    "Copyright 2023 DMTF. All rights reserved.",
+    "#MessageRegistry.v1_6_2.MessageRegistry",
+    "Platform.1.0.1",
+    "Compute Platform Message Registry",
+    "en",
+    "This registry defines messages for compute platforms, covering topics related to processor, memory, and I/O device connectivity.",
+    "Platform",
+    "1.0.1",
+    "DMTF",
+};
+constexpr const char* url =
+    "https://redfish.dmtf.org/registries/Platform.1.0.1.json";
+
+constexpr std::array registry =
+{
+    MessageEntry{
+        "OperatingSystemCrash",
+        {
+            "Indicates the operating system was halted due to a catastrophic error.",
+            "An operating system crash occurred.",
+            "Critical",
+            0,
+            {},
+            "Check additional diagnostic data if available.",
+        }},
+    MessageEntry{
+        "PlatformError",
+        {
+            "Indicates that a platform error occurred.",
+            "A platform error occurred.",
+            "Warning",
+            0,
+            {},
+            "Check additional diagnostic data if available.",
+        }},
+    MessageEntry{
+        "PlatformErrorAtLocation",
+        {
+            "Indicates that a platform error occurred and device or other location information is available.",
+            "A platform error occurred at location '%1'.",
+            "Warning",
+            1,
+            {
+                "string",
+            },
+            "Check additional diagnostic data if available.",
+        }},
+    MessageEntry{
+        "UnhandledExceptionDetectedAfterReset",
+        {
+            "Indicates that an unhandled exception caused the platform to reset.",
+            "An unhandled exception caused a platform reset.",
+            "Critical",
+            0,
+            {},
+            "Check additional diagnostic data if available.",
+        }},
+
+};
+
+enum class Index
+{
+    operatingSystemCrash = 0,
+    platformError = 1,
+    platformErrorAtLocation = 2,
+    unhandledExceptionDetectedAfterReset = 3,
+};
+} // namespace redfish::registries::platform

--- a/redfish-core/include/registries/power_message_registry.hpp
+++ b/redfish-core/include/registries/power_message_registry.hpp
@@ -1,0 +1,1053 @@
+#pragma once
+/****************************************************************
+ *                 READ THIS WARNING FIRST
+ * This is an auto-generated header which contains definitions
+ * for Redfish DMTF defined messages.
+ * DO NOT modify this registry outside of running the
+ * parse_registries.py script.  The definitions contained within
+ * this file are owned by DMTF.  Any modifications to these files
+ * should be first pushed to the relevant registry in the DMTF
+ * github organization.
+ ***************************************************************/
+#include "registries.hpp"
+
+#include <array>
+
+// clang-format off
+
+namespace redfish::registries::power
+{
+const Header header = {
+    "Copyright 2023 DMTF. All rights reserved.",
+    "#MessageRegistry.v1_6_2.MessageRegistry",
+    "Power.1.0.1",
+    "Power Message Registry",
+    "en",
+    "This registry defines messages related to electrical measurements and power distribution equipment.",
+    "Power",
+    "1.0.1",
+    "DMTF",
+};
+constexpr const char* url =
+    "https://redfish.dmtf.org/registries/Power.1.0.1.json";
+
+constexpr std::array registry =
+{
+    MessageEntry{
+        "BreakerFault",
+        {
+            "Indicates that a circuit breaker has an internal fault.",
+            "Fault detected in breaker '%1'.",
+            "Critical",
+            1,
+            {
+                "string",
+            },
+            "Check the breaker hardware and replace any faulty components.",
+        }},
+    MessageEntry{
+        "BreakerReset",
+        {
+            "Indicates that a circuit breaker reset.",
+            "Breaker '%1' reset.",
+            "OK",
+            1,
+            {
+                "string",
+            },
+            "None.",
+        }},
+    MessageEntry{
+        "BreakerTripped",
+        {
+            "Indicates that a circuit breaker tripped.",
+            "Breaker '%1' has tripped.",
+            "Critical",
+            1,
+            {
+                "string",
+            },
+            "Check the circuit and connected devices, and disconnect or replace any faulty devices.",
+        }},
+    MessageEntry{
+        "CircuitPoweredOff",
+        {
+            "Indicates that a circuit was powered off.",
+            "Circuit '%1' powered off.",
+            "OK",
+            1,
+            {
+                "string",
+            },
+            "None.",
+        }},
+    MessageEntry{
+        "CircuitPoweredOn",
+        {
+            "Indicates that a circuit was powered on.",
+            "Circuit '%1' powered on.",
+            "OK",
+            1,
+            {
+                "string",
+            },
+            "None.",
+        }},
+    MessageEntry{
+        "CurrentAboveLowerCriticalThreshold",
+        {
+            "Indicates that a current reading is no longer below the lower critical threshold but is still outside of normal operating range.",
+            "Current '%1' reading of %2 amperes is now above the %3 lower critical threshold but remains outside of normal range.",
+            "Warning",
+            3,
+            {
+                "string",
+                "number",
+                "number",
+            },
+            "Check the condition of the resource listed in OriginOfCondition.",
+        }},
+    MessageEntry{
+        "CurrentAboveLowerFatalThreshold",
+        {
+            "Indicates that a current reading is no longer below the lower fatal threshold but is still outside of normal operating range.",
+            "Current '%1' reading of %2 amperes is now above the %3 lower fatal threshold but remains outside of normal range.",
+            "Critical",
+            3,
+            {
+                "string",
+                "number",
+                "number",
+            },
+            "Check the condition of the resource listed in OriginOfCondition.",
+        }},
+    MessageEntry{
+        "CurrentAboveUpperCautionThreshold",
+        {
+            "Indicates that a current reading is above the upper caution threshold.",
+            "Current '%1' reading of %2 amperes is above the %3 upper caution threshold.",
+            "Warning",
+            3,
+            {
+                "string",
+                "number",
+                "number",
+            },
+            "Check the condition of the resource listed in OriginOfCondition.",
+        }},
+    MessageEntry{
+        "CurrentAboveUpperCriticalThreshold",
+        {
+            "Indicates that a current reading is above the upper critical threshold.",
+            "Current '%1' reading of %2 amperes is above the %3 upper critical threshold.",
+            "Critical",
+            3,
+            {
+                "string",
+                "number",
+                "number",
+            },
+            "Check the condition of the resource listed in OriginOfCondition.",
+        }},
+    MessageEntry{
+        "CurrentAboveUpperFatalThreshold",
+        {
+            "Indicates that a current reading is above the upper fatal threshold.",
+            "Current '%1' reading of %2 amperes is above the %3 upper fatal threshold.",
+            "Critical",
+            3,
+            {
+                "string",
+                "number",
+                "number",
+            },
+            "Check the condition of the resource listed in OriginOfCondition.",
+        }},
+    MessageEntry{
+        "CurrentBelowLowerCautionThreshold",
+        {
+            "Indicates that a current reading is below the lower caution threshold.",
+            "Current '%1' reading of %2 amperes is below the %3 lower caution threshold.",
+            "Warning",
+            3,
+            {
+                "string",
+                "number",
+                "number",
+            },
+            "Check the condition of the resource listed in OriginOfCondition.",
+        }},
+    MessageEntry{
+        "CurrentBelowLowerCriticalThreshold",
+        {
+            "Indicates that a current reading is below the lower critical threshold.",
+            "Current '%1' reading of %2 amperes is below the %3 lower critical threshold.",
+            "Critical",
+            3,
+            {
+                "string",
+                "number",
+                "number",
+            },
+            "Check the condition of the resource listed in OriginOfCondition.",
+        }},
+    MessageEntry{
+        "CurrentBelowLowerFatalThreshold",
+        {
+            "Indicates that a current reading is below the lower fatal threshold.",
+            "Current '%1' reading of %2 amperes is below the %3 lower fatal threshold.",
+            "Critical",
+            3,
+            {
+                "string",
+                "number",
+                "number",
+            },
+            "Check the condition of the resource listed in OriginOfCondition.",
+        }},
+    MessageEntry{
+        "CurrentBelowUpperCriticalThreshold",
+        {
+            "Indicates that a current reading is no longer above the upper critical threshold but is still outside of normal operating range.",
+            "Current '%1' reading of %2 amperes is now below the %3 upper critical threshold but remains outside of normal range.",
+            "Warning",
+            3,
+            {
+                "string",
+                "number",
+                "number",
+            },
+            "Check the condition of the resource listed in OriginOfCondition.",
+        }},
+    MessageEntry{
+        "CurrentBelowUpperFatalThreshold",
+        {
+            "Indicates that a current reading is no longer above the upper fatal threshold but is still outside of normal operating range.",
+            "Current '%1' reading of %2 amperes is now below the %3 upper fatal threshold but remains outside of normal range.",
+            "Critical",
+            3,
+            {
+                "string",
+                "number",
+                "number",
+            },
+            "Check the condition of the resource listed in OriginOfCondition.",
+        }},
+    MessageEntry{
+        "CurrentCritical",
+        {
+            "Indicates that a current reading exceeds an internal critical level.",
+            "Current '%1' reading of %2 amperes exceeds the critical level.",
+            "Critical",
+            2,
+            {
+                "string",
+                "number",
+            },
+            "Check the condition of the resource listed in OriginOfCondition.",
+        }},
+    MessageEntry{
+        "CurrentNoLongerCritical",
+        {
+            "Indicates that a current reading no longer exceeds an internal critical level but still exceeds an internal warning level.",
+            "Current '%1' reading of %2 amperes no longer exceeds the critical level.",
+            "Warning",
+            2,
+            {
+                "string",
+                "number",
+            },
+            "Check the condition of the resource listed in OriginOfCondition.",
+        }},
+    MessageEntry{
+        "CurrentNormal",
+        {
+            "Indicates that a current reading is now within normal operating range.",
+            "Current '%1' reading of %2 amperes is within normal operating range.",
+            "OK",
+            2,
+            {
+                "string",
+                "number",
+            },
+            "None.",
+        }},
+    MessageEntry{
+        "CurrentWarning",
+        {
+            "Indicates that a current reading exceeds an internal warning level.",
+            "Current '%1' reading of %2 amperes exceeds the warning level.",
+            "Warning",
+            2,
+            {
+                "string",
+                "number",
+            },
+            "Check the condition of the resource listed in OriginOfCondition.",
+        }},
+    MessageEntry{
+        "FrequencyAboveLowerCriticalThreshold",
+        {
+            "Indicates that a frequency reading is no longer below the lower critical threshold but is still outside of normal operating range.",
+            "Frequency '%1' reading of %2 hertz is now above the %3 lower critical threshold but remains outside of normal range.",
+            "Warning",
+            3,
+            {
+                "string",
+                "number",
+                "number",
+            },
+            "Check the condition of the resource listed in OriginOfCondition.",
+        }},
+    MessageEntry{
+        "FrequencyAboveUpperCautionThreshold",
+        {
+            "Indicates that a frequency reading is above the upper caution threshold.",
+            "Frequency '%1' reading of %2 hertz is above the %3 upper caution threshold.",
+            "Warning",
+            3,
+            {
+                "string",
+                "number",
+                "number",
+            },
+            "Check the condition of the resource listed in OriginOfCondition.",
+        }},
+    MessageEntry{
+        "FrequencyAboveUpperCriticalThreshold",
+        {
+            "Indicates that a frequency reading is above the upper critical threshold.",
+            "Frequency '%1' reading of %2 hertz is above the %3 upper critical threshold.",
+            "Critical",
+            3,
+            {
+                "string",
+                "number",
+                "number",
+            },
+            "Check the condition of the resource listed in OriginOfCondition.",
+        }},
+    MessageEntry{
+        "FrequencyBelowLowerCautionThreshold",
+        {
+            "Indicates that a frequency reading is below the lower caution threshold.",
+            "Frequency '%1' reading of %2 hertz is below the %3 lower caution threshold.",
+            "Warning",
+            3,
+            {
+                "string",
+                "number",
+                "number",
+            },
+            "Check the condition of the resource listed in OriginOfCondition.",
+        }},
+    MessageEntry{
+        "FrequencyBelowLowerCriticalThreshold",
+        {
+            "Indicates that a frequency reading is below the lower critical threshold.",
+            "Frequency '%1' reading of %2 hertz is below the %3 lower critical threshold.",
+            "Critical",
+            3,
+            {
+                "string",
+                "number",
+                "number",
+            },
+            "Check the condition of the resource listed in OriginOfCondition.",
+        }},
+    MessageEntry{
+        "FrequencyBelowUpperCriticalThreshold",
+        {
+            "Indicates that a frequency reading is no longer above the upper critical threshold but is still outside of normal operating range.",
+            "Frequency '%1' reading of %2 hertz is now below the %3 upper critical threshold but remains outside of normal range.",
+            "Warning",
+            3,
+            {
+                "string",
+                "number",
+                "number",
+            },
+            "Check the condition of the resource listed in OriginOfCondition.",
+        }},
+    MessageEntry{
+        "FrequencyCritical",
+        {
+            "Indicates that a frequency reading exceeds an internal critical level.",
+            "Frequency '%1' reading of %2 hertz exceeds the critical level.",
+            "Critical",
+            2,
+            {
+                "string",
+                "number",
+            },
+            "Check the condition of the resource listed in OriginOfCondition.",
+        }},
+    MessageEntry{
+        "FrequencyNoLongerCritical",
+        {
+            "Indicates that a frequency reading no longer exceeds an internal critical level but still exceeds an internal warning level.",
+            "Frequency '%1' reading of %2 hertz no longer exceeds the critical level.",
+            "Warning",
+            2,
+            {
+                "string",
+                "number",
+            },
+            "Check the condition of the resource listed in OriginOfCondition.",
+        }},
+    MessageEntry{
+        "FrequencyNormal",
+        {
+            "Indicates that a frequency reading is now within normal operating range.",
+            "Frequency '%1' reading of %2 hertz is within normal operating range.",
+            "OK",
+            2,
+            {
+                "string",
+                "number",
+            },
+            "None.",
+        }},
+    MessageEntry{
+        "FrequencyWarning",
+        {
+            "Indicates that a frequency reading exceeds an internal warning level.",
+            "Frequency '%1' reading of %2 hertz exceeds the warning level.",
+            "Warning",
+            2,
+            {
+                "string",
+                "number",
+            },
+            "Check the condition of the resource listed in OriginOfCondition.",
+        }},
+    MessageEntry{
+        "LineInputPowerFault",
+        {
+            "Indicates a fault on an electrical power input.",
+            "Line input power fault at '%1'.",
+            "Warning",
+            1,
+            {
+                "string",
+            },
+            "Check the electrical power input and connections.",
+        }},
+    MessageEntry{
+        "LineInputPowerRestored",
+        {
+            "Indicates that an electrical power input was restored to normal operation.",
+            "Line input power at '%1' was restored.",
+            "OK",
+            1,
+            {
+                "string",
+            },
+            "None.",
+        }},
+    MessageEntry{
+        "LossOfInputPower",
+        {
+            "Indicates a loss of power at an electrical input.",
+            "Loss of input power at '%1'.",
+            "Warning",
+            1,
+            {
+                "string",
+            },
+            "Check the electrical power input and connections.",
+        }},
+    MessageEntry{
+        "OutletPoweredOff",
+        {
+            "Indicates that an outlet was powered off.",
+            "Outlet '%1' powered off.",
+            "OK",
+            1,
+            {
+                "string",
+            },
+            "None.",
+        }},
+    MessageEntry{
+        "OutletPoweredOn",
+        {
+            "Indicates that an outlet was powered on.",
+            "Outlet '%1' powered on.",
+            "OK",
+            1,
+            {
+                "string",
+            },
+            "None.",
+        }},
+    MessageEntry{
+        "PowerAboveLowerCriticalThreshold",
+        {
+            "Indicates that a power reading is no longer below the lower critical threshold but is still outside of normal operating range.",
+            "Power '%1' reading of %2 watts is now above the %3 lower critical threshold but remains outside of normal range.",
+            "Warning",
+            3,
+            {
+                "string",
+                "number",
+                "number",
+            },
+            "Check the condition of the resource listed in OriginOfCondition.",
+        }},
+    MessageEntry{
+        "PowerAboveLowerFatalThreshold",
+        {
+            "Indicates that a power reading is no longer below the lower fatal threshold but is still outside of normal operating range.",
+            "Power '%1' reading of %2 watts is now above the %3 lower fatal threshold but remains outside of normal range.",
+            "Critical",
+            3,
+            {
+                "string",
+                "number",
+                "number",
+            },
+            "Check the condition of the resource listed in OriginOfCondition.",
+        }},
+    MessageEntry{
+        "PowerAboveUpperCautionThreshold",
+        {
+            "Indicates that a power reading is above the upper caution threshold.",
+            "Power '%1' reading of %2 watts is above the %3 upper caution threshold.",
+            "Warning",
+            3,
+            {
+                "string",
+                "number",
+                "number",
+            },
+            "Check the condition of the resource listed in OriginOfCondition.",
+        }},
+    MessageEntry{
+        "PowerAboveUpperCriticalThreshold",
+        {
+            "Indicates that a power reading is above the upper critical threshold.",
+            "Power '%1' reading of %2 watts is above the %3 upper critical threshold.",
+            "Critical",
+            3,
+            {
+                "string",
+                "number",
+                "number",
+            },
+            "Check the condition of the resource listed in OriginOfCondition.",
+        }},
+    MessageEntry{
+        "PowerAboveUpperFatalThreshold",
+        {
+            "Indicates that a power reading is above the upper fatal threshold.",
+            "Power '%1' reading of %2 watts is above the %3 upper fatal threshold.",
+            "Critical",
+            3,
+            {
+                "string",
+                "number",
+                "number",
+            },
+            "Check the condition of the resource listed in OriginOfCondition.",
+        }},
+    MessageEntry{
+        "PowerBelowLowerCautionThreshold",
+        {
+            "Indicates that a power reading is below the lower caution threshold.",
+            "Power '%1' reading of %2 watts is below the %3 lower caution threshold.",
+            "Warning",
+            3,
+            {
+                "string",
+                "number",
+                "number",
+            },
+            "Check the condition of the resource listed in OriginOfCondition.",
+        }},
+    MessageEntry{
+        "PowerBelowLowerCriticalThreshold",
+        {
+            "Indicates that a power reading is below the lower critical threshold.",
+            "Power '%1' reading of %2 watts is below the %3 lower critical threshold.",
+            "Critical",
+            3,
+            {
+                "string",
+                "number",
+                "number",
+            },
+            "Check the condition of the resource listed in OriginOfCondition.",
+        }},
+    MessageEntry{
+        "PowerBelowLowerFatalThreshold",
+        {
+            "Indicates that a power reading is below the lower fatal threshold.",
+            "Power '%1' reading of %2 watts is below the %3 lower fatal threshold.",
+            "Critical",
+            3,
+            {
+                "string",
+                "number",
+                "number",
+            },
+            "Check the condition of the resource listed in OriginOfCondition.",
+        }},
+    MessageEntry{
+        "PowerBelowUpperCriticalThreshold",
+        {
+            "Indicates that a power reading is no longer above the upper critical threshold but is still outside of normal operating range.",
+            "Power '%1' reading of %2 watts is now below the %3 upper critical threshold but remains outside of normal range.",
+            "Warning",
+            3,
+            {
+                "string",
+                "number",
+                "number",
+            },
+            "Check the condition of the resource listed in OriginOfCondition.",
+        }},
+    MessageEntry{
+        "PowerBelowUpperFatalThreshold",
+        {
+            "Indicates that a power reading is no longer above the upper fatal threshold but is still outside of normal operating range.",
+            "Power '%1' reading of %2 watts is now below the %3 upper fatal threshold but remains outside of normal range.",
+            "Critical",
+            3,
+            {
+                "string",
+                "number",
+                "number",
+            },
+            "Check the condition of the resource listed in OriginOfCondition.",
+        }},
+    MessageEntry{
+        "PowerCritical",
+        {
+            "Indicates that a power reading exceeds an internal critical level.",
+            "Power '%1' reading of %2 watts exceeds the critical level.",
+            "Critical",
+            2,
+            {
+                "string",
+                "number",
+            },
+            "Check the condition of the resource listed in OriginOfCondition.",
+        }},
+    MessageEntry{
+        "PowerNoLongerCritical",
+        {
+            "Indicates that a power reading no longer exceeds an internal critical level but still exceeds an internal warning level.",
+            "Power '%1' reading of %2 watts no longer exceeds the critical level.",
+            "Warning",
+            2,
+            {
+                "string",
+                "number",
+            },
+            "Check the condition of the resource listed in OriginOfCondition.",
+        }},
+    MessageEntry{
+        "PowerNormal",
+        {
+            "Indicates that a power reading is now within normal operating range.",
+            "Power '%1' reading of %2 watts is within normal operating range.",
+            "OK",
+            2,
+            {
+                "string",
+                "number",
+            },
+            "None.",
+        }},
+    MessageEntry{
+        "PowerSupplyFailed",
+        {
+            "Indicates that a power supply has failed.",
+            "Power supply '%1' has failed.",
+            "Warning",
+            1,
+            {
+                "string",
+            },
+            "Check the power supply hardware and replace any faulty component.",
+        }},
+    MessageEntry{
+        "PowerSupplyGroupCritical",
+        {
+            "Indicates that a power supply group has a critical status.",
+            "Power supply group '%1' is in a critical state.",
+            "Critical",
+            1,
+            {
+                "string",
+            },
+            "None.",
+        }},
+    MessageEntry{
+        "PowerSupplyGroupNormal",
+        {
+            "Indicates that a power supply group has returned to normal operations.",
+            "Power supply group '%1' is operating normally.",
+            "OK",
+            1,
+            {
+                "string",
+            },
+            "None.",
+        }},
+    MessageEntry{
+        "PowerSupplyGroupWarning",
+        {
+            "Indicates that a power supply group has a warning status.",
+            "Power supply group '%1' is in a warning state.",
+            "Warning",
+            1,
+            {
+                "string",
+            },
+            "None.",
+        }},
+    MessageEntry{
+        "PowerSupplyInserted",
+        {
+            "Indicates that a power supply was inserted or installed.",
+            "Power supply '%1' was inserted.",
+            "OK",
+            1,
+            {
+                "string",
+            },
+            "None.",
+        }},
+    MessageEntry{
+        "PowerSupplyPredictiveFailure",
+        {
+            "Indicates that the power supply predicted a future failure condition.",
+            "Power supply '%1' has a predicted failure condition.",
+            "Warning",
+            1,
+            {
+                "string",
+            },
+            "Check the power supply hardware and replace any faulty component.",
+        }},
+    MessageEntry{
+        "PowerSupplyRemoved",
+        {
+            "Indicates that a power supply was removed.",
+            "Power supply '%1' was removed.",
+            "OK",
+            1,
+            {
+                "string",
+            },
+            "None.",
+        }},
+    MessageEntry{
+        "PowerSupplyRestored",
+        {
+            "Indicates that a power supply was repaired or restored to normal operation.",
+            "Power supply '%1' was restored.",
+            "OK",
+            1,
+            {
+                "string",
+            },
+            "None.",
+        }},
+    MessageEntry{
+        "PowerSupplyWarning",
+        {
+            "Indicates that a power supply has a warning condition.",
+            "Power supply '%1' has a warning condition.",
+            "Warning",
+            1,
+            {
+                "string",
+            },
+            "Check the power supply hardware and replace any faulty component.",
+        }},
+    MessageEntry{
+        "PowerWarning",
+        {
+            "Indicates that a power reading exceeds an internal warning level.",
+            "Power '%1' reading of %2 watts exceeds the warning level.",
+            "Warning",
+            2,
+            {
+                "string",
+                "number",
+            },
+            "Check the condition of the resource listed in OriginOfCondition.",
+        }},
+    MessageEntry{
+        "VoltageAboveLowerCriticalThreshold",
+        {
+            "Indicates that a voltage reading is no longer below the lower critical threshold but is still outside of normal operating range.",
+            "Voltage '%1' reading of %2 volts is now above the %3 lower critical threshold but remains outside of normal range.",
+            "Warning",
+            3,
+            {
+                "string",
+                "number",
+                "number",
+            },
+            "Check the condition of the resource listed in OriginOfCondition.",
+        }},
+    MessageEntry{
+        "VoltageAboveLowerFatalThreshold",
+        {
+            "Indicates that a voltage reading is no longer below the lower fatal threshold but is still outside of normal operating range.",
+            "Voltage '%1' reading of %2 volts is now above the %3 lower fatal threshold but remains outside of normal range.",
+            "Critical",
+            3,
+            {
+                "string",
+                "number",
+                "number",
+            },
+            "Check the condition of the resource listed in OriginOfCondition.",
+        }},
+    MessageEntry{
+        "VoltageAboveUpperCautionThreshold",
+        {
+            "Indicates that a voltage reading is above the upper caution threshold.",
+            "Voltage '%1' reading of %2 volts is above the %3 upper caution threshold.",
+            "Warning",
+            3,
+            {
+                "string",
+                "number",
+                "number",
+            },
+            "Check the condition of the resource listed in OriginOfCondition.",
+        }},
+    MessageEntry{
+        "VoltageAboveUpperCriticalThreshold",
+        {
+            "Indicates that a voltage reading is above the upper critical threshold.",
+            "Voltage '%1' reading of %2 volts is above the %3 upper critical threshold.",
+            "Critical",
+            3,
+            {
+                "string",
+                "number",
+                "number",
+            },
+            "Check the condition of the resource listed in OriginOfCondition.",
+        }},
+    MessageEntry{
+        "VoltageAboveUpperFatalThreshold",
+        {
+            "Indicates that a voltage reading is above the upper fatal threshold.",
+            "Voltage '%1' reading of %2 volts is above the %3 upper fatal threshold.",
+            "Critical",
+            3,
+            {
+                "string",
+                "number",
+                "number",
+            },
+            "Check the condition of the resource listed in OriginOfCondition.",
+        }},
+    MessageEntry{
+        "VoltageBelowLowerCautionThreshold",
+        {
+            "Indicates that a voltage reading is below the lower caution threshold.",
+            "Voltage '%1' reading of %2 volts is below the %3 lower caution threshold.",
+            "Warning",
+            3,
+            {
+                "string",
+                "number",
+                "number",
+            },
+            "Check the condition of the resource listed in OriginOfCondition.",
+        }},
+    MessageEntry{
+        "VoltageBelowLowerCriticalThreshold",
+        {
+            "Indicates that a voltage reading is below the lower critical threshold.",
+            "Voltage '%1' reading of %2 volts is below the %3 lower critical threshold.",
+            "Critical",
+            3,
+            {
+                "string",
+                "number",
+                "number",
+            },
+            "Check the condition of the resource listed in OriginOfCondition.",
+        }},
+    MessageEntry{
+        "VoltageBelowLowerFatalThreshold",
+        {
+            "Indicates that a voltage reading is below the lower fatal threshold.",
+            "Voltage '%1' reading of %2 volts is below the %3 lower fatal threshold.",
+            "Critical",
+            3,
+            {
+                "string",
+                "number",
+                "number",
+            },
+            "Check the condition of the resource listed in OriginOfCondition.",
+        }},
+    MessageEntry{
+        "VoltageBelowUpperCriticalThreshold",
+        {
+            "Indicates that a voltage reading is no longer above the upper critical threshold but is still outside of normal operating range.",
+            "Voltage '%1' reading of %2 volts is now below the %3 upper critical threshold but remains outside of normal range.",
+            "Warning",
+            3,
+            {
+                "string",
+                "number",
+                "number",
+            },
+            "Check the condition of the resource listed in OriginOfCondition.",
+        }},
+    MessageEntry{
+        "VoltageBelowUpperFatalThreshold",
+        {
+            "Indicates that a voltage reading is no longer above the upper fatal threshold but is still outside of normal operating range.",
+            "Voltage '%1' reading of %2 volts is now below the %3 upper fatal threshold but remains outside of normal range.",
+            "Critical",
+            3,
+            {
+                "string",
+                "number",
+                "number",
+            },
+            "Check the condition of the resource listed in OriginOfCondition.",
+        }},
+    MessageEntry{
+        "VoltageCritical",
+        {
+            "Indicates that a voltage reading exceeds an internal critical level.",
+            "Voltage '%1' reading of %2 volts exceeds the critical level.",
+            "Critical",
+            2,
+            {
+                "string",
+                "number",
+            },
+            "Check the condition of the resource listed in OriginOfCondition.",
+        }},
+    MessageEntry{
+        "VoltageNoLongerCritical",
+        {
+            "Indicates that a voltage reading no longer exceeds an internal critical level but still exceeds an internal warning level.",
+            "Voltage '%1' reading of %2 volts no longer exceeds the critical level.",
+            "Warning",
+            2,
+            {
+                "string",
+                "number",
+            },
+            "Check the condition of the resource listed in OriginOfCondition.",
+        }},
+    MessageEntry{
+        "VoltageNormal",
+        {
+            "Indicates that a voltage reading is now within normal operating range.",
+            "Voltage '%1' reading of %2 volts is within normal operating range.",
+            "OK",
+            2,
+            {
+                "string",
+                "number",
+            },
+            "None.",
+        }},
+    MessageEntry{
+        "VoltageWarning",
+        {
+            "Indicates that a voltage reading exceeds an internal warning level.",
+            "Voltage '%1' reading of %2 volts exceeds the warning level.",
+            "Warning",
+            2,
+            {
+                "string",
+                "number",
+            },
+            "Check the condition of the resource listed in OriginOfCondition.",
+        }},
+
+};
+
+enum class Index
+{
+    breakerFault = 0,
+    breakerReset = 1,
+    breakerTripped = 2,
+    circuitPoweredOff = 3,
+    circuitPoweredOn = 4,
+    currentAboveLowerCriticalThreshold = 5,
+    currentAboveLowerFatalThreshold = 6,
+    currentAboveUpperCautionThreshold = 7,
+    currentAboveUpperCriticalThreshold = 8,
+    currentAboveUpperFatalThreshold = 9,
+    currentBelowLowerCautionThreshold = 10,
+    currentBelowLowerCriticalThreshold = 11,
+    currentBelowLowerFatalThreshold = 12,
+    currentBelowUpperCriticalThreshold = 13,
+    currentBelowUpperFatalThreshold = 14,
+    currentCritical = 15,
+    currentNoLongerCritical = 16,
+    currentNormal = 17,
+    currentWarning = 18,
+    frequencyAboveLowerCriticalThreshold = 19,
+    frequencyAboveUpperCautionThreshold = 20,
+    frequencyAboveUpperCriticalThreshold = 21,
+    frequencyBelowLowerCautionThreshold = 22,
+    frequencyBelowLowerCriticalThreshold = 23,
+    frequencyBelowUpperCriticalThreshold = 24,
+    frequencyCritical = 25,
+    frequencyNoLongerCritical = 26,
+    frequencyNormal = 27,
+    frequencyWarning = 28,
+    lineInputPowerFault = 29,
+    lineInputPowerRestored = 30,
+    lossOfInputPower = 31,
+    outletPoweredOff = 32,
+    outletPoweredOn = 33,
+    powerAboveLowerCriticalThreshold = 34,
+    powerAboveLowerFatalThreshold = 35,
+    powerAboveUpperCautionThreshold = 36,
+    powerAboveUpperCriticalThreshold = 37,
+    powerAboveUpperFatalThreshold = 38,
+    powerBelowLowerCautionThreshold = 39,
+    powerBelowLowerCriticalThreshold = 40,
+    powerBelowLowerFatalThreshold = 41,
+    powerBelowUpperCriticalThreshold = 42,
+    powerBelowUpperFatalThreshold = 43,
+    powerCritical = 44,
+    powerNoLongerCritical = 45,
+    powerNormal = 46,
+    powerSupplyFailed = 47,
+    powerSupplyGroupCritical = 48,
+    powerSupplyGroupNormal = 49,
+    powerSupplyGroupWarning = 50,
+    powerSupplyInserted = 51,
+    powerSupplyPredictiveFailure = 52,
+    powerSupplyRemoved = 53,
+    powerSupplyRestored = 54,
+    powerSupplyWarning = 55,
+    powerWarning = 56,
+    voltageAboveLowerCriticalThreshold = 57,
+    voltageAboveLowerFatalThreshold = 58,
+    voltageAboveUpperCautionThreshold = 59,
+    voltageAboveUpperCriticalThreshold = 60,
+    voltageAboveUpperFatalThreshold = 61,
+    voltageBelowLowerCautionThreshold = 62,
+    voltageBelowLowerCriticalThreshold = 63,
+    voltageBelowLowerFatalThreshold = 64,
+    voltageBelowUpperCriticalThreshold = 65,
+    voltageBelowUpperFatalThreshold = 66,
+    voltageCritical = 67,
+    voltageNoLongerCritical = 68,
+    voltageNormal = 69,
+    voltageWarning = 70,
+};
+} // namespace redfish::registries::power

--- a/redfish-core/include/registries/sensor_event_message_registry.hpp
+++ b/redfish-core/include/registries/sensor_event_message_registry.hpp
@@ -1,0 +1,301 @@
+#pragma once
+/****************************************************************
+ *                 READ THIS WARNING FIRST
+ * This is an auto-generated header which contains definitions
+ * for Redfish DMTF defined messages.
+ * DO NOT modify this registry outside of running the
+ * parse_registries.py script.  The definitions contained within
+ * this file are owned by DMTF.  Any modifications to these files
+ * should be first pushed to the relevant registry in the DMTF
+ * github organization.
+ ***************************************************************/
+#include "registries.hpp"
+
+#include <array>
+
+// clang-format off
+
+namespace redfish::registries::sensor_event
+{
+const Header header = {
+    "Copyright 2022-2023 DMTF. All rights reserved.",
+    "#MessageRegistry.v1_6_2.MessageRegistry",
+    "SensorEvent.1.0.1",
+    "Sensor Event Message Registry",
+    "en",
+    "This registry defines messages used for general events related to Sensor resources.",
+    "SensorEvent",
+    "1.0.1",
+    "DMTF",
+};
+constexpr const char* url =
+    "https://redfish.dmtf.org/registries/SensorEvent.1.0.1.json";
+
+constexpr std::array registry =
+{
+    MessageEntry{
+        "InvalidSensorReading",
+        {
+            "Indicates that the service received an invalid reading from a sensor.",
+            "Invalid reading received from sensor '%1'.",
+            "Warning",
+            1,
+            {
+                "string",
+            },
+            "Check the sensor hardware or connection.",
+        }},
+    MessageEntry{
+        "ReadingAboveLowerCriticalThreshold",
+        {
+            "Indicates that a sensor reading is no longer below the lower critical threshold but is still outside of normal operating range.",
+            "Sensor '%1' reading of %2 (%3) is now above the %4 lower critical threshold but remains outside of normal range.",
+            "Warning",
+            4,
+            {
+                "string",
+                "number",
+                "string",
+                "number",
+            },
+            "Check the condition of the resources listed in RelatedItem.",
+        }},
+    MessageEntry{
+        "ReadingAboveLowerFatalThreshold",
+        {
+            "Indicates that a sensor reading is no longer below the lower fatal threshold but is still outside of normal operating range.",
+            "Sensor '%1' reading of %2 (%3) is now above the %4 lower fatal threshold but remains outside of normal range.",
+            "Critical",
+            4,
+            {
+                "string",
+                "number",
+                "string",
+                "number",
+            },
+            "Check the condition of the resources listed in RelatedItem.",
+        }},
+    MessageEntry{
+        "ReadingAboveUpperCautionThreshold",
+        {
+            "Indicates that a sensor reading is above the upper caution threshold.",
+            "Sensor '%1' reading of %2 (%3) is above the %4 upper caution threshold.",
+            "Warning",
+            4,
+            {
+                "string",
+                "number",
+                "string",
+                "number",
+            },
+            "Check the condition of the resources listed in RelatedItem.",
+        }},
+    MessageEntry{
+        "ReadingAboveUpperCriticalThreshold",
+        {
+            "Indicates that a sensor reading is above the upper critical threshold.",
+            "Sensor '%1' reading of %2 (%3) is above the %4 upper critical threshold.",
+            "Critical",
+            4,
+            {
+                "string",
+                "number",
+                "string",
+                "number",
+            },
+            "Check the condition of the resources listed in RelatedItem.",
+        }},
+    MessageEntry{
+        "ReadingAboveUpperFatalThreshold",
+        {
+            "Indicates that a sensor reading is above the upper fatal threshold.",
+            "Sensor '%1' reading of %2 (%3) is above the %4 upper fatal threshold.",
+            "Critical",
+            4,
+            {
+                "string",
+                "number",
+                "string",
+                "number",
+            },
+            "Check the condition of the resources listed in RelatedItem.",
+        }},
+    MessageEntry{
+        "ReadingBelowLowerCautionThreshold",
+        {
+            "Indicates that a sensor reading is below the lower caution threshold.",
+            "Sensor '%1' reading of %2 (%3) is below the %4 lower caution threshold.",
+            "Warning",
+            4,
+            {
+                "string",
+                "number",
+                "string",
+                "number",
+            },
+            "Check the condition of the resources listed in RelatedItem.",
+        }},
+    MessageEntry{
+        "ReadingBelowLowerCriticalThreshold",
+        {
+            "Indicates that a sensor reading is below the lower critical threshold.",
+            "Sensor '%1' reading of %2 (%3) is below the %4 lower critical threshold.",
+            "Critical",
+            4,
+            {
+                "string",
+                "number",
+                "string",
+                "number",
+            },
+            "Check the condition of the resources listed in RelatedItem.",
+        }},
+    MessageEntry{
+        "ReadingBelowLowerFatalThreshold",
+        {
+            "Indicates that a sensor reading is below the lower fatal threshold.",
+            "Sensor '%1' reading of %2 (%3) is below the %4 lower fatal threshold.",
+            "Critical",
+            4,
+            {
+                "string",
+                "number",
+                "string",
+                "number",
+            },
+            "Check the condition of the resources listed in RelatedItem.",
+        }},
+    MessageEntry{
+        "ReadingBelowUpperCriticalThreshold",
+        {
+            "Indicates that a sensor reading is no longer above the upper critical threshold but is still outside of normal operating range.",
+            "Sensor '%1' reading of %2 (%3) is now below the %4 upper critical threshold but remains outside of normal range.",
+            "Warning",
+            4,
+            {
+                "string",
+                "number",
+                "string",
+                "number",
+            },
+            "Check the condition of the resources listed in RelatedItem.",
+        }},
+    MessageEntry{
+        "ReadingBelowUpperFatalThreshold",
+        {
+            "Indicates that a sensor reading is no longer above the upper fatal threshold but is still outside of normal operating range.",
+            "Sensor '%1' reading of %2 (%3) is now below the %4 upper fatal threshold but remains outside of normal range.",
+            "Critical",
+            4,
+            {
+                "string",
+                "number",
+                "string",
+                "number",
+            },
+            "Check the condition of the resources listed in RelatedItem.",
+        }},
+    MessageEntry{
+        "ReadingCritical",
+        {
+            "Indicates that a sensor reading exceeds an internal critical level.",
+            "Sensor '%1' reading of %2 (%3) exceeds the critical level.",
+            "Critical",
+            3,
+            {
+                "string",
+                "number",
+                "string",
+            },
+            "Check the condition of the resources listed in RelatedItem.",
+        }},
+    MessageEntry{
+        "ReadingNoLongerCritical",
+        {
+            "Indicates that a sensor reading no longer exceeds an internal critical level but still exceeds an internal warning level.",
+            "Sensor '%1' reading of %2 (%3) no longer exceeds the critical level.",
+            "Warning",
+            3,
+            {
+                "string",
+                "number",
+                "string",
+            },
+            "Check the condition of the resources listed in RelatedItem.",
+        }},
+    MessageEntry{
+        "ReadingWarning",
+        {
+            "Indicates that a sensor reading exceeds an internal warning level.",
+            "Sensor '%1' reading of %2 (%3) exceeds the warning level.",
+            "Warning",
+            3,
+            {
+                "string",
+                "number",
+                "string",
+            },
+            "Check the condition of the resources listed in RelatedItem.",
+        }},
+    MessageEntry{
+        "SensorFailure",
+        {
+            "Indicates that the service cannot communicate with a sensor or has detected a failure.",
+            "Sensor '%1' has failed.",
+            "Warning",
+            1,
+            {
+                "string",
+            },
+            "Check the sensor hardware or connection.",
+        }},
+    MessageEntry{
+        "SensorReadingNormalRange",
+        {
+            "Indicates that a sensor reading is now within normal operating range.",
+            "Sensor '%1' reading of %2 (%3) is within normal operating range.",
+            "OK",
+            3,
+            {
+                "string",
+                "number",
+                "string",
+            },
+            "None.",
+        }},
+    MessageEntry{
+        "SensorRestored",
+        {
+            "Indicates that a sensor was repaired or communications were restored.  It may also indicate that the service is receiving valid data from a sensor.",
+            "Sensor '%1' was restored.",
+            "OK",
+            1,
+            {
+                "string",
+            },
+            "None.",
+        }},
+
+};
+
+enum class Index
+{
+    invalidSensorReading = 0,
+    readingAboveLowerCriticalThreshold = 1,
+    readingAboveLowerFatalThreshold = 2,
+    readingAboveUpperCautionThreshold = 3,
+    readingAboveUpperCriticalThreshold = 4,
+    readingAboveUpperFatalThreshold = 5,
+    readingBelowLowerCautionThreshold = 6,
+    readingBelowLowerCriticalThreshold = 7,
+    readingBelowLowerFatalThreshold = 8,
+    readingBelowUpperCriticalThreshold = 9,
+    readingBelowUpperFatalThreshold = 10,
+    readingCritical = 11,
+    readingNoLongerCritical = 12,
+    readingWarning = 13,
+    sensorFailure = 14,
+    sensorReadingNormalRange = 15,
+    sensorRestored = 16,
+};
+} // namespace redfish::registries::sensor_event

--- a/redfish-core/include/registries/storage_device_message_registry.hpp
+++ b/redfish-core/include/registries/storage_device_message_registry.hpp
@@ -1,0 +1,493 @@
+#pragma once
+/****************************************************************
+ *                 READ THIS WARNING FIRST
+ * This is an auto-generated header which contains definitions
+ * for Redfish DMTF defined messages.
+ * DO NOT modify this registry outside of running the
+ * parse_registries.py script.  The definitions contained within
+ * this file are owned by DMTF.  Any modifications to these files
+ * should be first pushed to the relevant registry in the DMTF
+ * github organization.
+ ***************************************************************/
+#include "registries.hpp"
+
+#include <array>
+
+// clang-format off
+
+namespace redfish::registries::storage_device
+{
+const Header header = {
+    "Copyright 2020-2023 DMTF. All rights reserved.",
+    "#MessageRegistry.v1_6_2.MessageRegistry",
+    "StorageDevice.1.2.1",
+    "Storage Device Message Registry",
+    "en",
+    "This registry defines the messages for storage devices.",
+    "StorageDevice",
+    "1.2.1",
+    "DMTF",
+};
+constexpr const char* url =
+    "https://redfish.dmtf.org/registries/StorageDevice.1.2.1.json";
+
+constexpr std::array registry =
+{
+    MessageEntry{
+        "BatteryCharging",
+        {
+            "A battery charging condition was detected.",
+            "A charging condition for the battery located in '%1' was detected.",
+            "Warning",
+            1,
+            {
+                "string",
+            },
+            "None.  There may be reduced performance and features while the battery is charging.",
+        }},
+    MessageEntry{
+        "BatteryFailure",
+        {
+            "A battery failure condition was detected.",
+            "A failure condition for the battery located in '%1' was detected.",
+            "Critical",
+            1,
+            {
+                "string",
+            },
+            "Ensure all cables are properly and securely connected.  Replace the failed battery.",
+        }},
+    MessageEntry{
+        "BatteryMissing",
+        {
+            "A battery missing condition was detected.",
+            "The battery located in '%1' is missing.",
+            "Critical",
+            1,
+            {
+                "string",
+            },
+            "Attach the battery.  Ensure all cables are properly and securely connected.",
+        }},
+    MessageEntry{
+        "BatteryOK",
+        {
+            "The health of a battery has changed to OK.",
+            "The health of the battery located in '%1' has changed to OK.",
+            "OK",
+            1,
+            {
+                "string",
+            },
+            "None.",
+        }},
+    MessageEntry{
+        "ControllerDegraded",
+        {
+            "A storage controller degraded condition was detected.",
+            "A degraded condition for the storage controller located in '%1' was detected due to reason '%2'.",
+            "Warning",
+            2,
+            {
+                "string",
+                "string",
+            },
+            "Reseat the storage controller in the PCI slot.  Update the controller to the latest firmware version.  If the issue persists, replace the controller.",
+        }},
+    MessageEntry{
+        "ControllerFailure",
+        {
+            "A storage controller failure was detected.",
+            "A failure condition for the storage controller located in '%1' was detected.",
+            "Critical",
+            1,
+            {
+                "string",
+            },
+            "Reseat the storage controller in the PCI slot.  Update the controller to the latest firmware version.  If the issue persists, replace the controller.",
+        }},
+    MessageEntry{
+        "ControllerOK",
+        {
+            "The storage controller health has changed to OK.",
+            "The health of the storage controller located in '%1' has changed to OK.",
+            "OK",
+            1,
+            {
+                "string",
+            },
+            "None.",
+        }},
+    MessageEntry{
+        "ControllerPasswordAccepted",
+        {
+            "The storage controller password was entered.",
+            "A password was entered for the storage controller located in '%1'.",
+            "OK",
+            1,
+            {
+                "string",
+            },
+            "None.",
+        }},
+    MessageEntry{
+        "ControllerPasswordRequired",
+        {
+            "The storage controller requires a password.",
+            "The storage controller located in '%1' requires a password.",
+            "Critical",
+            1,
+            {
+                "string",
+            },
+            "Enter the controller password.",
+        }},
+    MessageEntry{
+        "ControllerPortDegraded",
+        {
+            "A controller port degraded condition was detected.",
+            "A degraded condition for the controller port located in '%1' was detected due to reason '%2'.",
+            "Warning",
+            2,
+            {
+                "string",
+                "string",
+            },
+            "Ensure all cables are properly and securely connected.  Replace faulty cables.",
+        }},
+    MessageEntry{
+        "ControllerPortFailure",
+        {
+            "A controller port failure condition was detected.",
+            "A failure condition for the controller port located in '%1' was detected.",
+            "Critical",
+            1,
+            {
+                "string",
+            },
+            "Ensure all cables are properly and securely connected.  Replace faulty cables.",
+        }},
+    MessageEntry{
+        "ControllerPortOK",
+        {
+            "The health of a controller port has changed to OK.",
+            "The health of the controller port located in '%1' has changed to OK.",
+            "OK",
+            1,
+            {
+                "string",
+            },
+            "None.",
+        }},
+    MessageEntry{
+        "ControllerPreviousError",
+        {
+            "A storage controller error was detected prior to reboot.",
+            "A previous error condition for the storage controller located in '%1' was detected due to '%2'.",
+            "Warning",
+            2,
+            {
+                "string",
+                "string",
+            },
+            "Update the controller to the latest firmware version.  If the issue persists, replace the controller.",
+        }},
+    MessageEntry{
+        "DriveFailure",
+        {
+            "A drive failure condition was detected.",
+            "A failure condition for the drive located in '%1' was detected.",
+            "Critical",
+            1,
+            {
+                "string",
+            },
+            "Ensure all cables are properly and securely connected.  Ensure all drives are fully seated.  Replace the defective cables, drive, or both.",
+        }},
+    MessageEntry{
+        "DriveFailureCleared",
+        {
+            "A previously detected failure condition on a drive was cleared.",
+            "A failure condition for the drive located in '%1' was cleared.",
+            "OK",
+            1,
+            {
+                "string",
+            },
+            "None.",
+        }},
+    MessageEntry{
+        "DriveInserted",
+        {
+            "A drive was inserted.",
+            "The drive located in '%1' was inserted.",
+            "OK",
+            1,
+            {
+                "string",
+            },
+            "If the drive is not properly displayed, attempt to refresh the cached data.",
+        }},
+    MessageEntry{
+        "DriveMissing",
+        {
+            "A drive missing condition was detected.",
+            "A missing condition for the drive located in '%1' was detected.",
+            "Critical",
+            1,
+            {
+                "string",
+            },
+            "Ensure all cables are properly and securely connected.  Ensure all drives are fully seated.  Replace the defective cables, drive, or both.  Delete the volume if it is no longer needed.",
+        }},
+    MessageEntry{
+        "DriveMissingCleared",
+        {
+            "A previous drive missing condition was cleared.",
+            "A missing condition for the drive located in '%1' was cleared.",
+            "OK",
+            1,
+            {
+                "string",
+            },
+            "None.",
+        }},
+    MessageEntry{
+        "DriveOK",
+        {
+            "The health of a drive has changed to OK.",
+            "The health of the drive located in '%1' has changed to OK.",
+            "OK",
+            1,
+            {
+                "string",
+            },
+            "None.",
+        }},
+    MessageEntry{
+        "DriveOffline",
+        {
+            "A drive offline condition was detected.",
+            "An offline condition for the drive located in '%1' was detected.",
+            "Critical",
+            1,
+            {
+                "string",
+            },
+            "If the drive is unconfigured or needs an import, configure the drive.  If the drive operation is in progress, wait for the operation to complete.  If the drive is not supported, replace it.",
+        }},
+    MessageEntry{
+        "DriveOfflineCleared",
+        {
+            "A drive offline condition was cleared.",
+            "An offline condition for the drive located in '%1' was cleared.",
+            "OK",
+            1,
+            {
+                "string",
+            },
+            "None.",
+        }},
+    MessageEntry{
+        "DrivePredictiveFailure",
+        {
+            "A predictive drive failure condition was detected.",
+            "A predictive failure condition for the drive located in '%1' was detected.",
+            "Warning",
+            1,
+            {
+                "string",
+            },
+            "If this drive is not part of a fault-tolerant volume, first back up all data, then replace the drive and restore all data afterward.  If this drive is part of a fault-tolerant volume, replace this drive as soon as possible as long as the volume health is OK.",
+        }},
+    MessageEntry{
+        "DrivePredictiveFailureCleared",
+        {
+            "A previously detected predictive failure condition on a drive was cleared.",
+            "A predictive failure condition for the drive located in '%1' was cleared.",
+            "OK",
+            1,
+            {
+                "string",
+            },
+            "None.",
+        }},
+    MessageEntry{
+        "DriveRemoved",
+        {
+            "A drive was removed.",
+            "The drive located in '%1' was removed.",
+            "Critical",
+            1,
+            {
+                "string",
+            },
+            "If the drive is still displayed, attempt to refresh the cached data.",
+        }},
+    MessageEntry{
+        "VolumeDegraded",
+        {
+            "The storage controller has detected a degraded volume condition.",
+            "The volume '%1' attached to the storage controller located in '%2' is degraded.",
+            "Warning",
+            2,
+            {
+                "string",
+                "string",
+            },
+            "Ensure all cables are properly and securely connected.  Replace failed drives.",
+        }},
+    MessageEntry{
+        "VolumeFailure",
+        {
+            "The storage controller has detected a failed volume condition.",
+            "The volume '%1' attached to the storage controller located in '%2' has failed.",
+            "Critical",
+            2,
+            {
+                "string",
+                "string",
+            },
+            "Ensure all cables are properly and securely connected.  Ensure all drives are fully seated and operational.",
+        }},
+    MessageEntry{
+        "VolumeOK",
+        {
+            "A volume health has changed to OK.",
+            "The health of volume '%1' that is attached to the storage controller located in '%2' has changed to OK.",
+            "OK",
+            2,
+            {
+                "string",
+                "string",
+            },
+            "None.",
+        }},
+    MessageEntry{
+        "VolumeOffine",
+        {
+            "The storage controller has detected an offline volume condition.",
+            "The volume '%1' attached to the storage controller located in '%2' is offline.",
+            "Critical",
+            2,
+            {
+                "string",
+                "string",
+            },
+            "Use storage software to enable, repair, or import the volume.  You may also delete or move volume back to the original controller.",
+        }},
+    MessageEntry{
+        "VolumeOffline",
+        {
+            "The storage controller has detected an offline volume condition.",
+            "The volume '%1' attached to the storage controller located in '%2' is offline.",
+            "Critical",
+            2,
+            {
+                "string",
+                "string",
+            },
+            "Use storage software to enable, repair, or import the volume.  You may also delete or move volume back to the original controller.",
+        }},
+    MessageEntry{
+        "VolumeOfflineCleared",
+        {
+            "The storage controller has detected an online volume condition.",
+            "The volume '%1' attached to the storage controller located in '%2' is online.",
+            "OK",
+            2,
+            {
+                "string",
+                "string",
+            },
+            "None.",
+        }},
+    MessageEntry{
+        "WriteCacheDataLoss",
+        {
+            "The write cache is reporting loss of data in posted-writes memory.",
+            "The write cache on the storage controller located in '%1' has data loss.",
+            "Critical",
+            1,
+            {
+                "string",
+            },
+            "Check the controller resource properties to determine the cause of the write cache data loss.",
+        }},
+    MessageEntry{
+        "WriteCacheDegraded",
+        {
+            "The write cache state is degraded.",
+            "The write cache state on the storage controller located in '%1' is degraded.",
+            "Critical",
+            1,
+            {
+                "string",
+            },
+            "Check the controller to determine the cause of write cache degraded state, such as a missing battery or hardware failure.",
+        }},
+    MessageEntry{
+        "WriteCacheProtected",
+        {
+            "A storage controller write cache state is in protected mode.",
+            "The write cache state on the storage controller located in '%1' is in protected mode.",
+            "OK",
+            1,
+            {
+                "string",
+            },
+            "None.",
+        }},
+    MessageEntry{
+        "WriteCacheTemporarilyDegraded",
+        {
+            "The write cache state is temporarily degraded.",
+            "The write cache state on the storage controller located in '%1' is temporarily degraded.",
+            "Warning",
+            1,
+            {
+                "string",
+            },
+            "Check the controller to determine the cause of write cache temporarily degraded state, such as a battery is charging or a data recovery rebuild operation is pending.",
+        }},
+
+};
+
+enum class Index
+{
+    batteryCharging = 0,
+    batteryFailure = 1,
+    batteryMissing = 2,
+    batteryOK = 3,
+    controllerDegraded = 4,
+    controllerFailure = 5,
+    controllerOK = 6,
+    controllerPasswordAccepted = 7,
+    controllerPasswordRequired = 8,
+    controllerPortDegraded = 9,
+    controllerPortFailure = 10,
+    controllerPortOK = 11,
+    controllerPreviousError = 12,
+    driveFailure = 13,
+    driveFailureCleared = 14,
+    driveInserted = 15,
+    driveMissing = 16,
+    driveMissingCleared = 17,
+    driveOK = 18,
+    driveOffline = 19,
+    driveOfflineCleared = 20,
+    drivePredictiveFailure = 21,
+    drivePredictiveFailureCleared = 22,
+    driveRemoved = 23,
+    volumeDegraded = 24,
+    volumeFailure = 25,
+    volumeOK = 26,
+    volumeOffine = 27,
+    volumeOffline = 28,
+    volumeOfflineCleared = 29,
+    writeCacheDataLoss = 30,
+    writeCacheDegraded = 31,
+    writeCacheProtected = 32,
+    writeCacheTemporarilyDegraded = 33,
+};
+} // namespace redfish::registries::storage_device

--- a/redfish-core/include/registries/telemetry_message_registry.hpp
+++ b/redfish-core/include/registries/telemetry_message_registry.hpp
@@ -1,0 +1,168 @@
+#pragma once
+/****************************************************************
+ *                 READ THIS WARNING FIRST
+ * This is an auto-generated header which contains definitions
+ * for Redfish DMTF defined messages.
+ * DO NOT modify this registry outside of running the
+ * parse_registries.py script.  The definitions contained within
+ * this file are owned by DMTF.  Any modifications to these files
+ * should be first pushed to the relevant registry in the DMTF
+ * github organization.
+ ***************************************************************/
+#include "registries.hpp"
+
+#include <array>
+
+// clang-format off
+
+namespace redfish::registries::telemetry
+{
+const Header header = {
+    "Copyright 2023 DMTF. All rights reserved.",
+    "#MessageRegistry.v1_6_2.MessageRegistry",
+    "Telemetry.1.0.0",
+    "Telemetry Message Registry",
+    "en",
+    "This registry defines the messages for telemetry related events.",
+    "Telemetry",
+    "1.0.0",
+    "DMTF",
+};
+constexpr const char* url =
+    "https://redfish.dmtf.org/registries/Telemetry.1.0.0.json";
+
+constexpr std::array registry =
+{
+    MessageEntry{
+        "TriggerDiscreteConditionMet",
+        {
+            "Indicates that a discrete trigger condition is met.",
+            "Metric '%1' has the value '%2', which meets the discrete condition of trigger '%3'",
+            "OK",
+            3,
+            {
+                "string",
+                "string",
+                "string",
+            },
+            "Check the condition of the metric that reported the trigger.",
+        }},
+    MessageEntry{
+        "TriggerNumericAboveLowerCritical",
+        {
+            "Indicates that a numeric metric reading is no longer below the lower critical trigger threshold, but is still outside of normal operating range.",
+            "Metric '%1' value of %2 is now above the %3 lower critical threshold of trigger '%4' but remains outside of normal range",
+            "Warning",
+            4,
+            {
+                "string",
+                "number",
+                "number",
+                "string",
+            },
+            "Check the condition of the metric that reported the trigger.",
+        }},
+    MessageEntry{
+        "TriggerNumericAboveUpperCritical",
+        {
+            "Indicates that a numeric metric reading is above the upper critical trigger threshold.",
+            "Metric '%1' value of %2 is above the %3 upper critical threshold of trigger '%4'",
+            "Critical",
+            4,
+            {
+                "string",
+                "number",
+                "number",
+                "string",
+            },
+            "Check the condition of the metric that reported the trigger.",
+        }},
+    MessageEntry{
+        "TriggerNumericAboveUpperWarning",
+        {
+            "Indicates that a numeric metric reading is above the upper warning trigger threshold.",
+            "Metric '%1' value of %2 is above the %3 upper warning threshold of trigger '%4'",
+            "Warning",
+            4,
+            {
+                "string",
+                "number",
+                "number",
+                "string",
+            },
+            "Check the condition of the metric that reported the trigger.",
+        }},
+    MessageEntry{
+        "TriggerNumericBelowLowerCritical",
+        {
+            "Indicates that a numeric metric reading is below the lower critical trigger threshold.",
+            "Metric '%1' value of %2 is below the %3 lower critical threshold of trigger '%4'",
+            "Critical",
+            4,
+            {
+                "string",
+                "number",
+                "number",
+                "string",
+            },
+            "Check the condition of the metric that reported the trigger.",
+        }},
+    MessageEntry{
+        "TriggerNumericBelowLowerWarning",
+        {
+            "Indicates that a numeric metric reading is below the lower warning trigger threshold.",
+            "Metric '%1' value of %2 is below the %3 lower warning threshold of trigger '%4'",
+            "Warning",
+            4,
+            {
+                "string",
+                "number",
+                "number",
+                "string",
+            },
+            "Check the condition of the metric that reported the trigger.",
+        }},
+    MessageEntry{
+        "TriggerNumericBelowUpperCritical",
+        {
+            "Indicates that a numeric metric reading is no longer above the upper critical trigger threshold, but is still outside of normal operating range.",
+            "Metric '%1' value of %2 is now below the %3 upper critical threshold of trigger '%4' but remains outside of normal range",
+            "Warning",
+            4,
+            {
+                "string",
+                "number",
+                "number",
+                "string",
+            },
+            "Check the condition of the metric that reported the trigger.",
+        }},
+    MessageEntry{
+        "TriggerNumericReadingNormal",
+        {
+            "Indicates that a numeric metric reading is now within normal operating range.",
+            "Metric '%1' value of %2 is within normal operating range of trigger '%3'",
+            "OK",
+            3,
+            {
+                "string",
+                "number",
+                "string",
+            },
+            "None.",
+        }},
+
+};
+
+enum class Index
+{
+    triggerDiscreteConditionMet = 0,
+    triggerNumericAboveLowerCritical = 1,
+    triggerNumericAboveUpperCritical = 2,
+    triggerNumericAboveUpperWarning = 3,
+    triggerNumericBelowLowerCritical = 4,
+    triggerNumericBelowLowerWarning = 5,
+    triggerNumericBelowUpperCritical = 6,
+    triggerNumericReadingNormal = 7,
+};
+} // namespace redfish::registries::telemetry

--- a/redfish-core/include/registries/update_message_registry.hpp
+++ b/redfish-core/include/registries/update_message_registry.hpp
@@ -1,0 +1,245 @@
+#pragma once
+/****************************************************************
+ *                 READ THIS WARNING FIRST
+ * This is an auto-generated header which contains definitions
+ * for Redfish DMTF defined messages.
+ * DO NOT modify this registry outside of running the
+ * parse_registries.py script.  The definitions contained within
+ * this file are owned by DMTF.  Any modifications to these files
+ * should be first pushed to the relevant registry in the DMTF
+ * github organization.
+ ***************************************************************/
+#include "registries.hpp"
+
+#include <array>
+
+// clang-format off
+
+namespace redfish::registries::update
+{
+const Header header = {
+    "Copyright 2014-2023 DMTF. All rights reserved.",
+    "#MessageRegistry.v1_6_2.MessageRegistry",
+    "Update.1.0.2",
+    "Update Message Registry",
+    "en",
+    "This registry defines the update status and error messages.",
+    "Update",
+    "1.0.2",
+    "DMTF",
+};
+constexpr const char* url =
+    "https://redfish.dmtf.org/registries/Update.1.0.2.json";
+
+constexpr std::array registry =
+{
+    MessageEntry{
+        "ActivateFailed",
+        {
+            "Indicates that the component failed to activate the image.",
+            "Activation of image '%1' on '%2' failed.",
+            "Critical",
+            2,
+            {
+                "string",
+                "string",
+            },
+            "None.",
+        }},
+    MessageEntry{
+        "AllTargetsDetermined",
+        {
+            "Indicates that all target resources or devices for an update operation were determined by the service.",
+            "All the target devices to be updated were determined.",
+            "OK",
+            0,
+            {},
+            "None.",
+        }},
+    MessageEntry{
+        "ApplyFailed",
+        {
+            "Indicates that the component failed to apply an image.",
+            "Installation of image '%1' to '%2' failed.",
+            "Critical",
+            2,
+            {
+                "string",
+                "string",
+            },
+            "None.",
+        }},
+    MessageEntry{
+        "ApplyingOnComponent",
+        {
+            "Indicates that a component is applying an image.",
+            "Image '%1' is being applied on '%2'.",
+            "OK",
+            2,
+            {
+                "string",
+                "string",
+            },
+            "None.",
+        }},
+    MessageEntry{
+        "AwaitToActivate",
+        {
+            "Indicates that the resource or device is waiting for an action to proceed with activating an image.",
+            "Awaiting for an action to proceed with activating image '%1' on '%2'.",
+            "OK",
+            2,
+            {
+                "string",
+                "string",
+            },
+            "Perform the requested action to advance the update operation.",
+        }},
+    MessageEntry{
+        "AwaitToUpdate",
+        {
+            "Indicates that the resource or device is waiting for an action to proceed with installing an image.",
+            "Awaiting for an action to proceed with installing image '%1' on '%2'.",
+            "OK",
+            2,
+            {
+                "string",
+                "string",
+            },
+            "Perform the requested action to advance the update operation.",
+        }},
+    MessageEntry{
+        "InstallingOnComponent",
+        {
+            "Indicates that a component is installing an image.",
+            "Image '%1' is being installed on '%2'.",
+            "OK",
+            2,
+            {
+                "string",
+                "string",
+            },
+            "None.",
+        }},
+    MessageEntry{
+        "OperationTransitionedToJob",
+        {
+            "Indicates that the update operation transitioned to a job for managing the progress of the operation.",
+            "The update operation has transitioned to the job at URI '%1'.",
+            "OK",
+            1,
+            {
+                "string",
+            },
+            "Follow the referenced job and monitor the job for further updates.",
+        }},
+    MessageEntry{
+        "TargetDetermined",
+        {
+            "Indicates that a target resource or device for an image was determined for update.",
+            "The target device '%1' will be updated with image '%2'.",
+            "OK",
+            2,
+            {
+                "string",
+                "string",
+            },
+            "None.",
+        }},
+    MessageEntry{
+        "TransferFailed",
+        {
+            "Indicates that the service failed to transfer an image to a component.",
+            "Transfer of image '%1' to '%2' failed.",
+            "Critical",
+            2,
+            {
+                "string",
+                "string",
+            },
+            "None.",
+        }},
+    MessageEntry{
+        "TransferringToComponent",
+        {
+            "Indicates that the service is transferring an image to a component.",
+            "Image '%1' is being transferred to '%2'.",
+            "OK",
+            2,
+            {
+                "string",
+                "string",
+            },
+            "None.",
+        }},
+    MessageEntry{
+        "UpdateInProgress",
+        {
+            "Indicates that an update is in progress.",
+            "An update is in progress.",
+            "OK",
+            0,
+            {},
+            "None.",
+        }},
+    MessageEntry{
+        "UpdateSuccessful",
+        {
+            "Indicates that a resource or device was updated.",
+            "Device '%1' successfully updated with image '%2'.",
+            "OK",
+            2,
+            {
+                "string",
+                "string",
+            },
+            "None.",
+        }},
+    MessageEntry{
+        "VerificationFailed",
+        {
+            "Indicates that the component failed to verify an image.",
+            "Verification of image '%1' at '%2' failed.",
+            "Critical",
+            2,
+            {
+                "string",
+                "string",
+            },
+            "None.",
+        }},
+    MessageEntry{
+        "VerifyingAtComponent",
+        {
+            "Indicates that a component is verifying an image.",
+            "Image '%1' is being verified at '%2'.",
+            "OK",
+            2,
+            {
+                "string",
+                "string",
+            },
+            "None.",
+        }},
+
+};
+
+enum class Index
+{
+    activateFailed = 0,
+    allTargetsDetermined = 1,
+    applyFailed = 2,
+    applyingOnComponent = 3,
+    awaitToActivate = 4,
+    awaitToUpdate = 5,
+    installingOnComponent = 6,
+    operationTransitionedToJob = 7,
+    targetDetermined = 8,
+    transferFailed = 9,
+    transferringToComponent = 10,
+    updateInProgress = 11,
+    updateSuccessful = 12,
+    verificationFailed = 13,
+    verifyingAtComponent = 14,
+};
+} // namespace redfish::registries::update

--- a/scripts/parse_registries.py
+++ b/scripts/parse_registries.py
@@ -234,12 +234,42 @@ def make_privilege_registry():
         )
 
 
+def to_pascal_case(text):
+    s = text.replace("_", " ")
+    s = s.split()
+    if len(text) == 0:
+        return text
+    return "".join(i.capitalize() for i in s[0:])
+
+
 def main():
+    dmtf_registries = (
+        ("base", "1.16.0"),
+        ("composition", "1.1.2"),
+        ("environmental", "1.0.1"),
+        ("ethernet_fabric", "1.0.1"),
+        ("fabric", "1.0.2"),
+        ("heartbeat_event", "1.0.1"),
+        ("job_event", "1.0.1"),
+        ("license", "1.0.3"),
+        ("log_service", "1.0.1"),
+        ("network_device", "1.0.3"),
+        ("platform", "1.0.1"),
+        ("power", "1.0.1"),
+        ("resource_event", "1.3.0"),
+        ("sensor_event", "1.0.1"),
+        ("storage_device", "1.2.1"),
+        ("task_event", "1.0.3"),
+        ("telemetry", "1.0.0"),
+        ("update", "1.0.2"),
+    )
+
     parser = argparse.ArgumentParser()
     parser.add_argument(
         "--registries",
         type=str,
-        default="base,task_event,resource_event,privilege,openbmc",
+        default="privilege,openbmc,"
+        + ",".join([dmtf[0] for dmtf in dmtf_registries]),
         help="Comma delimited list of registries to update",
     )
 
@@ -248,28 +278,16 @@ def main():
     registries = set(args.registries.split(","))
     files = []
 
-    if "base" in registries:
-        files.append(
-            make_getter(
-                "Base.1.16.0.json", "base_message_registry.hpp", "base"
+    for registry, version in dmtf_registries:
+        if registry in registries:
+            registry_pascal_case = to_pascal_case(registry)
+            files.append(
+                make_getter(
+                    f"{registry_pascal_case}.{version}.json",
+                    f"{registry}_message_registry.hpp",
+                    registry,
+                )
             )
-        )
-    if "task_event" in registries:
-        files.append(
-            make_getter(
-                "TaskEvent.1.0.3.json",
-                "task_event_message_registry.hpp",
-                "task_event",
-            )
-        )
-    if "resource_event" in registries:
-        files.append(
-            make_getter(
-                "ResourceEvent.1.3.0.json",
-                "resource_event_message_registry.hpp",
-                "resource_event",
-            )
-        )
     if "openbmc" in registries:
         files.append(openbmc_local_getter())
 


### PR DESCRIPTION
Upsteam: https://gerrit.openbmc.org/c/openbmc/bmcweb/+/70746
We want this for the license service https://github.com/ibm-openbmc/bmcweb/pull/873

Before Redfish put all messages in Base, but as the Messages became more specific Redfish started creating new registries. Redfish might have went a little registry happy. HeartbeatEvent just has 1 message and all these new ones registries each just have a handful of messages.

Add the remaining 15 registries:
composition, environmental, ethernetfabric, fabric, heartbeat_event, job_event, license, logservice, networkdevice, platform, power, sensor_event, storage_device, telemetry, update.

Some of these are wanted for both current development and future development but it is hard to decide which ones so just added them all. power, fabric, telemetry, update are all things we support today. Having a UpdateInProgress or UpdateSuccessful makes a lot of sense and this enables that.

Put these alphabetically. Use a new for loop to do this.

Make changes to scripts/parse_registries.py and run the tool.

No difference in size.

Before: 66928640 Apr 10 13:32
obmc-phosphor-image-p10bmc-20240410183051.ext4.mmc.tar

After: 66928640 Apr 10 13:18
obmc-phosphor-image-p10bmc-20240410181439.ext4.mmc.tar

Tested: bmcweb builds.
"./scripts/parse_registries.py --registries license,update" works.

Change-Id: I43b4d041531cf338e9e7e621714ca7d95f6b01a5