### PR TITLE
Update Privilege Registry from 1.3.0 to 1.5.0

### DIFF
--- a/redfish-core/include/redfish.hpp
+++ b/redfish-core/include/redfish.hpp
@@ -190,7 +190,7 @@ class RedfishService
         requestRoutesMemory(app);
 
         requestRoutesSystems(app);
-
+        requestRoutesSystemActionsOemExecutePanelFunction(app);
         requestRoutesBiosService(app);
         requestRoutesBiosReset(app);
 

--- a/redfish-core/include/registries/privilege_registry.hpp
+++ b/redfish-core/include/registries/privilege_registry.hpp
@@ -150,6 +150,22 @@ const static auto& putAllowDenyCollection = privilegeSetConfigureManager;
 const static auto& deleteAllowDenyCollection = privilegeSetConfigureManager;
 const static auto& postAllowDenyCollection = privilegeSetConfigureManager;
 
+// Application
+const static auto& getApplication = privilegeSetLogin;
+const static auto& headApplication = privilegeSetLogin;
+const static auto& patchApplication = privilegeSetConfigureComponents;
+const static auto& putApplication = privilegeSetConfigureComponents;
+const static auto& deleteApplication = privilegeSetConfigureComponents;
+const static auto& postApplication = privilegeSetConfigureComponents;
+
+// ApplicationCollection
+const static auto& getApplicationCollection = privilegeSetLogin;
+const static auto& headApplicationCollection = privilegeSetLogin;
+const static auto& patchApplicationCollection = privilegeSetConfigureComponents;
+const static auto& putApplicationCollection = privilegeSetConfigureComponents;
+const static auto& deleteApplicationCollection = privilegeSetConfigureComponents;
+const static auto& postApplicationCollection = privilegeSetConfigureComponents;
+
 // Assembly
 const static auto& getAssembly = privilegeSetLogin;
 const static auto& headAssembly = privilegeSetLogin;
@@ -157,6 +173,14 @@ const static auto& patchAssembly = privilegeSetConfigureComponents;
 const static auto& putAssembly = privilegeSetConfigureComponents;
 const static auto& deleteAssembly = privilegeSetConfigureComponents;
 const static auto& postAssembly = privilegeSetConfigureComponents;
+
+// AttributeRegistry
+const static auto& getAttributeRegistry = privilegeSetLogin;
+const static auto& headAttributeRegistry = privilegeSetLogin;
+const static auto& patchAttributeRegistry = privilegeSetConfigureManager;
+const static auto& putAttributeRegistry = privilegeSetConfigureManager;
+const static auto& deleteAttributeRegistry = privilegeSetConfigureManager;
+const static auto& postAttributeRegistry = privilegeSetConfigureManager;
 
 // Battery
 const static auto& getBattery = privilegeSetLogin;
@@ -286,6 +310,22 @@ const static auto& putCircuitCollection = privilegeSetConfigureComponents;
 const static auto& deleteCircuitCollection = privilegeSetConfigureComponents;
 const static auto& postCircuitCollection = privilegeSetConfigureComponents;
 
+// ComponentIntegrity
+const static auto& getComponentIntegrity = privilegeSetLogin;
+const static auto& headComponentIntegrity = privilegeSetLogin;
+const static auto& patchComponentIntegrity = privilegeSetConfigureManager;
+const static auto& putComponentIntegrity = privilegeSetConfigureManager;
+const static auto& deleteComponentIntegrity = privilegeSetConfigureManager;
+const static auto& postComponentIntegrity = privilegeSetConfigureManager;
+
+// ComponentIntegrityCollection
+const static auto& getComponentIntegrityCollection = privilegeSetLogin;
+const static auto& headComponentIntegrityCollection = privilegeSetLogin;
+const static auto& patchComponentIntegrityCollection = privilegeSetConfigureManager;
+const static auto& putComponentIntegrityCollection = privilegeSetConfigureManager;
+const static auto& deleteComponentIntegrityCollection = privilegeSetConfigureManager;
+const static auto& postComponentIntegrityCollection = privilegeSetConfigureManager;
+
 // CompositionReservation
 const static auto& getCompositionReservation = privilegeSetLogin;
 const static auto& headCompositionReservation = privilegeSetLogin;
@@ -358,6 +398,38 @@ const static auto& putConnectionMethodCollection = privilegeSetConfigureManager;
 const static auto& deleteConnectionMethodCollection = privilegeSetConfigureManager;
 const static auto& postConnectionMethodCollection = privilegeSetConfigureManager;
 
+// Container
+const static auto& getContainer = privilegeSetLogin;
+const static auto& headContainer = privilegeSetLogin;
+const static auto& patchContainer = privilegeSetConfigureComponents;
+const static auto& putContainer = privilegeSetConfigureComponents;
+const static auto& deleteContainer = privilegeSetConfigureComponents;
+const static auto& postContainer = privilegeSetConfigureComponents;
+
+// ContainerCollection
+const static auto& getContainerCollection = privilegeSetLogin;
+const static auto& headContainerCollection = privilegeSetLogin;
+const static auto& patchContainerCollection = privilegeSetConfigureComponents;
+const static auto& putContainerCollection = privilegeSetConfigureComponents;
+const static auto& deleteContainerCollection = privilegeSetConfigureComponents;
+const static auto& postContainerCollection = privilegeSetConfigureComponents;
+
+// ContainerImage
+const static auto& getContainerImage = privilegeSetLogin;
+const static auto& headContainerImage = privilegeSetLogin;
+const static auto& patchContainerImage = privilegeSetConfigureComponents;
+const static auto& putContainerImage = privilegeSetConfigureComponents;
+const static auto& deleteContainerImage = privilegeSetConfigureComponents;
+const static auto& postContainerImage = privilegeSetConfigureComponents;
+
+// ContainerImageCollection
+const static auto& getContainerImageCollection = privilegeSetLogin;
+const static auto& headContainerImageCollection = privilegeSetLogin;
+const static auto& patchContainerImageCollection = privilegeSetConfigureComponents;
+const static auto& putContainerImageCollection = privilegeSetConfigureComponents;
+const static auto& deleteContainerImageCollection = privilegeSetConfigureComponents;
+const static auto& postContainerImageCollection = privilegeSetConfigureComponents;
+
 // Control
 const static auto& getControl = privilegeSetLogin;
 const static auto& headControl = privilegeSetLogin;
@@ -374,6 +446,70 @@ const static auto& putControlCollection = privilegeSetConfigureManager;
 const static auto& deleteControlCollection = privilegeSetConfigureManager;
 const static auto& postControlCollection = privilegeSetConfigureManager;
 
+// CoolantConnector
+const static auto& getCoolantConnector = privilegeSetLogin;
+const static auto& headCoolantConnector = privilegeSetLogin;
+const static auto& patchCoolantConnector = privilegeSetConfigureComponents;
+const static auto& putCoolantConnector = privilegeSetConfigureComponents;
+const static auto& deleteCoolantConnector = privilegeSetConfigureComponents;
+const static auto& postCoolantConnector = privilegeSetConfigureComponents;
+
+// CoolantConnectorCollection
+const static auto& getCoolantConnectorCollection = privilegeSetLogin;
+const static auto& headCoolantConnectorCollection = privilegeSetLogin;
+const static auto& patchCoolantConnectorCollection = privilegeSetConfigureComponents;
+const static auto& putCoolantConnectorCollection = privilegeSetConfigureComponents;
+const static auto& deleteCoolantConnectorCollection = privilegeSetConfigureComponents;
+const static auto& postCoolantConnectorCollection = privilegeSetConfigureComponents;
+
+// CoolingLoop
+const static auto& getCoolingLoop = privilegeSetLogin;
+const static auto& headCoolingLoop = privilegeSetLogin;
+const static auto& patchCoolingLoop = privilegeSetConfigureComponents;
+const static auto& putCoolingLoop = privilegeSetConfigureComponents;
+const static auto& deleteCoolingLoop = privilegeSetConfigureComponents;
+const static auto& postCoolingLoop = privilegeSetConfigureComponents;
+
+// CoolingLoopCollection
+const static auto& getCoolingLoopCollection = privilegeSetLogin;
+const static auto& headCoolingLoopCollection = privilegeSetLogin;
+const static auto& patchCoolingLoopCollection = privilegeSetConfigureComponents;
+const static auto& putCoolingLoopCollection = privilegeSetConfigureComponents;
+const static auto& deleteCoolingLoopCollection = privilegeSetConfigureComponents;
+const static auto& postCoolingLoopCollection = privilegeSetConfigureComponents;
+
+// CoolingUnit
+const static auto& getCoolingUnit = privilegeSetLogin;
+const static auto& headCoolingUnit = privilegeSetLogin;
+const static auto& patchCoolingUnit = privilegeSetConfigureComponents;
+const static auto& putCoolingUnit = privilegeSetConfigureComponents;
+const static auto& deleteCoolingUnit = privilegeSetConfigureComponents;
+const static auto& postCoolingUnit = privilegeSetConfigureComponents;
+
+// CoolingUnitCollection
+const static auto& getCoolingUnitCollection = privilegeSetLogin;
+const static auto& headCoolingUnitCollection = privilegeSetLogin;
+const static auto& patchCoolingUnitCollection = privilegeSetConfigureComponents;
+const static auto& putCoolingUnitCollection = privilegeSetConfigureComponents;
+const static auto& deleteCoolingUnitCollection = privilegeSetConfigureComponents;
+const static auto& postCoolingUnitCollection = privilegeSetConfigureComponents;
+
+// CXLLogicalDevice
+const static auto& getCXLLogicalDevice = privilegeSetLogin;
+const static auto& headCXLLogicalDevice = privilegeSetLogin;
+const static auto& patchCXLLogicalDevice = privilegeSetConfigureComponents;
+const static auto& putCXLLogicalDevice = privilegeSetConfigureComponents;
+const static auto& deleteCXLLogicalDevice = privilegeSetConfigureComponents;
+const static auto& postCXLLogicalDevice = privilegeSetConfigureComponents;
+
+// CXLLogicalDeviceCollection
+const static auto& getCXLLogicalDeviceCollection = privilegeSetLogin;
+const static auto& headCXLLogicalDeviceCollection = privilegeSetLogin;
+const static auto& patchCXLLogicalDeviceCollection = privilegeSetConfigureComponents;
+const static auto& putCXLLogicalDeviceCollection = privilegeSetConfigureComponents;
+const static auto& deleteCXLLogicalDeviceCollection = privilegeSetConfigureComponents;
+const static auto& postCXLLogicalDeviceCollection = privilegeSetConfigureComponents;
+
 // Drive
 const static auto& getDrive = privilegeSetLogin;
 const static auto& headDrive = privilegeSetLogin;
@@ -389,6 +525,14 @@ const static auto& patchDriveCollection = privilegeSetConfigureComponents;
 const static auto& postDriveCollection = privilegeSetConfigureComponents;
 const static auto& putDriveCollection = privilegeSetConfigureComponents;
 const static auto& deleteDriveCollection = privilegeSetConfigureComponents;
+
+// DriveMetrics
+const static auto& getDriveMetrics = privilegeSetLogin;
+const static auto& headDriveMetrics = privilegeSetLogin;
+const static auto& patchDriveMetrics = privilegeSetConfigureComponents;
+const static auto& putDriveMetrics = privilegeSetConfigureComponents;
+const static auto& deleteDriveMetrics = privilegeSetConfigureComponents;
+const static auto& postDriveMetrics = privilegeSetConfigureComponents;
 
 // Endpoint
 const static auto& getEndpoint = privilegeSetLogin;
@@ -550,6 +694,22 @@ const static auto& putFanCollection = privilegeSetConfigureManager;
 const static auto& deleteFanCollection = privilegeSetConfigureManager;
 const static auto& postFanCollection = privilegeSetConfigureManager;
 
+// Filter
+const static auto& getFilter = privilegeSetLogin;
+const static auto& headFilter = privilegeSetLogin;
+const static auto& patchFilter = privilegeSetConfigureComponents;
+const static auto& putFilter = privilegeSetConfigureComponents;
+const static auto& deleteFilter = privilegeSetConfigureComponents;
+const static auto& postFilter = privilegeSetConfigureComponents;
+
+// FilterCollection
+const static auto& getFilterCollection = privilegeSetLogin;
+const static auto& headFilterCollection = privilegeSetLogin;
+const static auto& patchFilterCollection = privilegeSetConfigureComponents;
+const static auto& putFilterCollection = privilegeSetConfigureComponents;
+const static auto& deleteFilterCollection = privilegeSetConfigureComponents;
+const static auto& postFilterCollection = privilegeSetConfigureComponents;
+
 // GraphicsController
 const static auto& getGraphicsController = privilegeSetLogin;
 const static auto& headGraphicsController = privilegeSetLogin;
@@ -565,6 +725,30 @@ const static auto& patchGraphicsControllerCollection = privilegeSetConfigureComp
 const static auto& putGraphicsControllerCollection = privilegeSetConfigureComponents;
 const static auto& deleteGraphicsControllerCollection = privilegeSetConfigureComponents;
 const static auto& postGraphicsControllerCollection = privilegeSetConfigureComponents;
+
+// Heater
+const static auto& getHeater = privilegeSetLogin;
+const static auto& headHeater = privilegeSetLogin;
+const static auto& patchHeater = privilegeSetConfigureManager;
+const static auto& putHeater = privilegeSetConfigureManager;
+const static auto& deleteHeater = privilegeSetConfigureManager;
+const static auto& postHeater = privilegeSetConfigureManager;
+
+// HeaterCollection
+const static auto& getHeaterCollection = privilegeSetLogin;
+const static auto& headHeaterCollection = privilegeSetLogin;
+const static auto& patchHeaterCollection = privilegeSetConfigureManager;
+const static auto& putHeaterCollection = privilegeSetConfigureManager;
+const static auto& deleteHeaterCollection = privilegeSetConfigureManager;
+const static auto& postHeaterCollection = privilegeSetConfigureManager;
+
+// HeaterMetrics
+const static auto& getHeaterMetrics = privilegeSetLogin;
+const static auto& headHeaterMetrics = privilegeSetLogin;
+const static auto& patchHeaterMetrics = privilegeSetConfigureManager;
+const static auto& putHeaterMetrics = privilegeSetConfigureManager;
+const static auto& deleteHeaterMetrics = privilegeSetConfigureManager;
+const static auto& postHeaterMetrics = privilegeSetConfigureManager;
 
 // HostInterface
 const static auto& getHostInterface = privilegeSetLogin;
@@ -662,6 +846,54 @@ const static auto& putKeyService = privilegeSetConfigureManager;
 const static auto& deleteKeyService = privilegeSetConfigureManager;
 const static auto& postKeyService = privilegeSetConfigureManager;
 
+// LeakDetection
+const static auto& getLeakDetection = privilegeSetLogin;
+const static auto& headLeakDetection = privilegeSetLogin;
+const static auto& patchLeakDetection = privilegeSetConfigureComponents;
+const static auto& postLeakDetection = privilegeSetConfigureComponents;
+const static auto& putLeakDetection = privilegeSetConfigureComponents;
+const static auto& deleteLeakDetection = privilegeSetConfigureComponents;
+
+// LeakDetector
+const static auto& getLeakDetector = privilegeSetLogin;
+const static auto& headLeakDetector = privilegeSetLogin;
+const static auto& patchLeakDetector = privilegeSetConfigureComponents;
+const static auto& postLeakDetector = privilegeSetConfigureComponents;
+const static auto& putLeakDetector = privilegeSetConfigureComponents;
+const static auto& deleteLeakDetector = privilegeSetConfigureComponents;
+
+// LeakDetectorCollection
+const static auto& getLeakDetectorCollection = privilegeSetLogin;
+const static auto& headLeakDetectorCollection = privilegeSetLogin;
+const static auto& patchLeakDetectorCollection = privilegeSetConfigureComponents;
+const static auto& postLeakDetectorCollection = privilegeSetConfigureComponents;
+const static auto& putLeakDetectorCollection = privilegeSetConfigureComponents;
+const static auto& deleteLeakDetectorCollection = privilegeSetConfigureComponents;
+
+// License
+const static auto& getLicense = privilegeSetLogin;
+const static auto& headLicense = privilegeSetLogin;
+const static auto& patchLicense = privilegeSetConfigureManager;
+const static auto& putLicense = privilegeSetConfigureManager;
+const static auto& deleteLicense = privilegeSetConfigureManager;
+const static auto& postLicense = privilegeSetConfigureManager;
+
+// LicenseCollection
+const static auto& getLicenseCollection = privilegeSetLogin;
+const static auto& headLicenseCollection = privilegeSetLogin;
+const static auto& patchLicenseCollection = privilegeSetConfigureManager;
+const static auto& putLicenseCollection = privilegeSetConfigureManager;
+const static auto& deleteLicenseCollection = privilegeSetConfigureManager;
+const static auto& postLicenseCollection = privilegeSetConfigureManager;
+
+// LicenseService
+const static auto& getLicenseService = privilegeSetLogin;
+const static auto& headLicenseService = privilegeSetLogin;
+const static auto& patchLicenseService = privilegeSetConfigureManager;
+const static auto& putLicenseService = privilegeSetConfigureManager;
+const static auto& deleteLicenseService = privilegeSetConfigureManager;
+const static auto& postLicenseService = privilegeSetConfigureManager;
+
 // LogEntry
 const static auto& getLogEntry = privilegeSetLogin;
 const static auto& headLogEntry = privilegeSetLogin;
@@ -731,6 +963,7 @@ const static auto& getManagerDiagnosticData = privilegeSetLogin;
 const static auto& headManagerDiagnosticData = privilegeSetLogin;
 const static auto& patchManagerDiagnosticData = privilegeSetConfigureManager;
 const static auto& postManagerDiagnosticData = privilegeSetConfigureManager;
+const static auto& deleteManagerDiagnosticData = privilegeSetConfigureManager;
 const static auto& putManagerDiagnosticData = privilegeSetConfigureManager;
 
 // ManagerNetworkProtocol
@@ -812,6 +1045,30 @@ const static auto& patchMemoryMetrics = privilegeSetConfigureComponents;
 const static auto& postMemoryMetrics = privilegeSetConfigureComponents;
 const static auto& putMemoryMetrics = privilegeSetConfigureComponents;
 const static auto& deleteMemoryMetrics = privilegeSetConfigureComponents;
+
+// MemoryRegion
+const static auto& getMemoryRegion = privilegeSetLogin;
+const static auto& headMemoryRegion = privilegeSetLogin;
+const static auto& patchMemoryRegion = privilegeSetConfigureComponents;
+const static auto& postMemoryRegion = privilegeSetConfigureComponents;
+const static auto& putMemoryRegion = privilegeSetConfigureComponents;
+const static auto& deleteMemoryRegion = privilegeSetConfigureComponents;
+
+// MemoryRegionCollection
+const static auto& getMemoryRegionCollection = privilegeSetLogin;
+const static auto& headMemoryRegionCollection = privilegeSetLogin;
+const static auto& patchMemoryRegionCollection = privilegeSetConfigureComponents;
+const static auto& postMemoryRegionCollection = privilegeSetConfigureComponents;
+const static auto& putMemoryRegionCollection = privilegeSetConfigureComponents;
+const static auto& deleteMemoryRegionCollection = privilegeSetConfigureComponents;
+
+// MessageRegistry
+const static auto& getMessageRegistry = privilegeSetLogin;
+const static auto& headMessageRegistry = privilegeSetLogin;
+const static auto& patchMessageRegistry = privilegeSetConfigureManager;
+const static auto& postMessageRegistry = privilegeSetConfigureManager;
+const static auto& putMessageRegistry = privilegeSetConfigureManager;
+const static auto& deleteMessageRegistry = privilegeSetConfigureManager;
 
 // MessageRegistryFile
 const static auto& getMessageRegistryFile = privilegeSetLogin;
@@ -972,6 +1229,30 @@ const static auto& patchOperatingConfigCollection = privilegeSetConfigureCompone
 const static auto& postOperatingConfigCollection = privilegeSetConfigureComponents;
 const static auto& putOperatingConfigCollection = privilegeSetConfigureComponents;
 const static auto& deleteOperatingConfigCollection = privilegeSetConfigureComponents;
+
+// OperatingSystem
+const static auto& getOperatingSystem = privilegeSetLogin;
+const static auto& headOperatingSystem = privilegeSetLogin;
+const static auto& patchOperatingSystem = privilegeSetConfigureComponents;
+const static auto& postOperatingSystem = privilegeSetConfigureComponents;
+const static auto& putOperatingSystem = privilegeSetConfigureComponents;
+const static auto& deleteOperatingSystem = privilegeSetConfigureComponents;
+
+// OutboundConnection
+const static auto& getOutboundConnection = privilegeSetLogin;
+const static auto& headOutboundConnection = privilegeSetLogin;
+const static auto& patchOutboundConnection = privilegeSetConfigureManager;
+const static auto& putOutboundConnection = privilegeSetConfigureManager;
+const static auto& deleteOutboundConnection = privilegeSetConfigureManager;
+const static auto& postOutboundConnection = privilegeSetConfigureManager;
+
+// OutboundConnectionCollection
+const static auto& getOutboundConnectionCollection = privilegeSetLogin;
+const static auto& headOutboundConnectionCollection = privilegeSetLogin;
+const static auto& patchOutboundConnectionCollection = privilegeSetConfigureManager;
+const static auto& putOutboundConnectionCollection = privilegeSetConfigureManager;
+const static auto& deleteOutboundConnectionCollection = privilegeSetConfigureManager;
+const static auto& postOutboundConnectionCollection = privilegeSetConfigureManager;
 
 // Outlet
 const static auto& getOutlet = privilegeSetLogin;
@@ -1157,6 +1438,14 @@ const static auto& putPowerSupplyMetrics = privilegeSetConfigureManager;
 const static auto& deletePowerSupplyMetrics = privilegeSetConfigureManager;
 const static auto& postPowerSupplyMetrics = privilegeSetConfigureManager;
 
+// PrivilegeRegistry
+const static auto& getPrivilegeRegistry = privilegeSetLogin;
+const static auto& headPrivilegeRegistry = privilegeSetLogin;
+const static auto& patchPrivilegeRegistry = privilegeSetConfigureManager;
+const static auto& postPrivilegeRegistry = privilegeSetConfigureManager;
+const static auto& putPrivilegeRegistry = privilegeSetConfigureManager;
+const static auto& deletePrivilegeRegistry = privilegeSetConfigureManager;
+
 // Processor
 const static auto& getProcessor = privilegeSetLogin;
 const static auto& headProcessor = privilegeSetLogin;
@@ -1180,6 +1469,54 @@ const static auto& patchProcessorMetrics = privilegeSetConfigureComponents;
 const static auto& putProcessorMetrics = privilegeSetConfigureComponents;
 const static auto& deleteProcessorMetrics = privilegeSetConfigureComponents;
 const static auto& postProcessorMetrics = privilegeSetConfigureComponents;
+
+// Pump
+const static auto& getPump = privilegeSetLogin;
+const static auto& headPump = privilegeSetLogin;
+const static auto& patchPump = privilegeSetConfigureComponents;
+const static auto& putPump = privilegeSetConfigureComponents;
+const static auto& deletePump = privilegeSetConfigureComponents;
+const static auto& postPump = privilegeSetConfigureComponents;
+
+// PumpCollection
+const static auto& getPumpCollection = privilegeSetLogin;
+const static auto& headPumpCollection = privilegeSetLogin;
+const static auto& patchPumpCollection = privilegeSetConfigureComponents;
+const static auto& putPumpCollection = privilegeSetConfigureComponents;
+const static auto& deletePumpCollection = privilegeSetConfigureComponents;
+const static auto& postPumpCollection = privilegeSetConfigureComponents;
+
+// RegisteredClient
+const static auto& getRegisteredClient = privilegeSetLogin;
+const static auto& headRegisteredClient = privilegeSetLogin;
+const static auto& patchRegisteredClient = privilegeSetConfigureManagerOrConfigureSelf;
+const static auto& postRegisteredClient = privilegeSetConfigureManagerOrConfigureSelf;
+const static auto& putRegisteredClient = privilegeSetConfigureManagerOrConfigureSelf;
+const static auto& deleteRegisteredClient = privilegeSetConfigureManagerOrConfigureSelf;
+
+// RegisteredClientCollection
+const static auto& getRegisteredClientCollection = privilegeSetLogin;
+const static auto& headRegisteredClientCollection = privilegeSetLogin;
+const static auto& patchRegisteredClientCollection = privilegeSetConfigureManagerOrConfigureComponents;
+const static auto& postRegisteredClientCollection = privilegeSetConfigureManagerOrConfigureComponents;
+const static auto& putRegisteredClientCollection = privilegeSetConfigureManagerOrConfigureComponents;
+const static auto& deleteRegisteredClientCollection = privilegeSetConfigureManagerOrConfigureComponents;
+
+// Reservoir
+const static auto& getReservoir = privilegeSetLogin;
+const static auto& headReservoir = privilegeSetLogin;
+const static auto& patchReservoir = privilegeSetConfigureComponents;
+const static auto& putReservoir = privilegeSetConfigureComponents;
+const static auto& deleteReservoir = privilegeSetConfigureComponents;
+const static auto& postReservoir = privilegeSetConfigureComponents;
+
+// ReservoirCollection
+const static auto& getReservoirCollection = privilegeSetLogin;
+const static auto& headReservoirCollection = privilegeSetLogin;
+const static auto& patchReservoirCollection = privilegeSetConfigureComponents;
+const static auto& putReservoirCollection = privilegeSetConfigureComponents;
+const static auto& deleteReservoirCollection = privilegeSetConfigureComponents;
+const static auto& postReservoirCollection = privilegeSetConfigureComponents;
 
 // ResourceBlock
 const static auto& getResourceBlock = privilegeSetLogin;
@@ -1269,6 +1606,14 @@ const static auto& postSecureBootDatabaseCollection = privilegeSetConfigureCompo
 const static auto& putSecureBootDatabaseCollection = privilegeSetConfigureComponents;
 const static auto& deleteSecureBootDatabaseCollection = privilegeSetConfigureComponents;
 
+// SecurityPolicy
+const static auto& getSecurityPolicy = privilegeSetLogin;
+const static auto& headSecurityPolicy = privilegeSetLogin;
+const static auto& patchSecurityPolicy = privilegeSetConfigureManager;
+const static auto& putSecurityPolicy = privilegeSetConfigureManager;
+const static auto& deleteSecurityPolicy = privilegeSetConfigureManager;
+const static auto& postSecurityPolicy = privilegeSetConfigureManager;
+
 // Sensor
 const static auto& getSensor = privilegeSetLogin;
 const static auto& headSensor = privilegeSetLogin;
@@ -1301,6 +1646,14 @@ const static auto& putSerialInterfaceCollection = privilegeSetConfigureManager;
 const static auto& deleteSerialInterfaceCollection = privilegeSetConfigureManager;
 const static auto& postSerialInterfaceCollection = privilegeSetConfigureManager;
 
+// ServiceConditions
+const static auto& getServiceConditions = privilegeSetLogin;
+const static auto& headServiceConditions = privilegeSetLogin;
+const static auto& patchServiceConditions = privilegeSetConfigureManager;
+const static auto& putServiceConditions = privilegeSetConfigureManager;
+const static auto& deleteServiceConditions = privilegeSetConfigureManager;
+const static auto& postServiceConditions = privilegeSetConfigureManager;
+
 // ServiceRoot
 const static auto& getServiceRoot = privilegeSetLoginOrNoAuth;
 const static auto& headServiceRoot = privilegeSetLoginOrNoAuth;
@@ -1310,8 +1663,8 @@ const static auto& deleteServiceRoot = privilegeSetConfigureManager;
 const static auto& postServiceRoot = privilegeSetConfigureManager;
 
 // Session
-const static auto& getSession = privilegeSetLogin;
-const static auto& headSession = privilegeSetLogin;
+const static auto& getSession = privilegeSetConfigureManagerOrConfigureSelf;
+const static auto& headSession = privilegeSetConfigureManagerOrConfigureSelf;
 const static auto& patchSession = privilegeSetConfigureManager;
 const static auto& putSession = privilegeSetConfigureManager;
 const static auto& deleteSession = privilegeSetConfigureManagerOrConfigureSelf;
@@ -1413,6 +1766,14 @@ const static auto& postStorageControllerCollection = privilegeSetConfigureCompon
 const static auto& putStorageControllerCollection = privilegeSetConfigureComponents;
 const static auto& deleteStorageControllerCollection = privilegeSetConfigureComponents;
 
+// StorageControllerMetrics
+const static auto& getStorageControllerMetrics = privilegeSetLogin;
+const static auto& headStorageControllerMetrics = privilegeSetLogin;
+const static auto& patchStorageControllerMetrics = privilegeSetConfigureComponents;
+const static auto& postStorageControllerMetrics = privilegeSetConfigureComponents;
+const static auto& putStorageControllerMetrics = privilegeSetConfigureComponents;
+const static auto& deleteStorageControllerMetrics = privilegeSetConfigureComponents;
+
 // Switch
 const static auto& getSwitch = privilegeSetLogin;
 const static auto& headSwitch = privilegeSetLogin;
@@ -1428,6 +1789,14 @@ const static auto& patchSwitchCollection = privilegeSetConfigureComponents;
 const static auto& postSwitchCollection = privilegeSetConfigureComponents;
 const static auto& putSwitchCollection = privilegeSetConfigureComponents;
 const static auto& deleteSwitchCollection = privilegeSetConfigureComponents;
+
+// SwitchMetrics
+const static auto& getSwitchMetrics = privilegeSetLogin;
+const static auto& headSwitchMetrics = privilegeSetLogin;
+const static auto& patchSwitchMetrics = privilegeSetConfigureComponents;
+const static auto& postSwitchMetrics = privilegeSetConfigureComponents;
+const static auto& putSwitchMetrics = privilegeSetConfigureComponents;
+const static auto& deleteSwitchMetrics = privilegeSetConfigureComponents;
 
 // Task
 const static auto& getTask = privilegeSetLogin;
@@ -1469,6 +1838,14 @@ const static auto& putThermal = privilegeSetConfigureManager;
 const static auto& deleteThermal = privilegeSetConfigureManager;
 const static auto& postThermal = privilegeSetConfigureManager;
 
+// ThermalEquipment
+const static auto& getThermalEquipment = privilegeSetLogin;
+const static auto& headThermalEquipment = privilegeSetLogin;
+const static auto& patchThermalEquipment = privilegeSetConfigureManager;
+const static auto& putThermalEquipment = privilegeSetConfigureManager;
+const static auto& deleteThermalEquipment = privilegeSetConfigureManager;
+const static auto& postThermalEquipment = privilegeSetConfigureManager;
+
 // ThermalMetrics
 const static auto& getThermalMetrics = privilegeSetLogin;
 const static auto& headThermalMetrics = privilegeSetLogin;
@@ -1500,6 +1877,22 @@ const static auto& patchTriggersCollection = privilegeSetConfigureManager;
 const static auto& putTriggersCollection = privilegeSetConfigureManager;
 const static auto& deleteTriggersCollection = privilegeSetConfigureManager;
 const static auto& postTriggersCollection = privilegeSetConfigureManager;
+
+// TrustedComponent
+const static auto& getTrustedComponent = privilegeSetLogin;
+const static auto& headTrustedComponent = privilegeSetLogin;
+const static auto& patchTrustedComponent = privilegeSetConfigureManager;
+const static auto& putTrustedComponent = privilegeSetConfigureManager;
+const static auto& deleteTrustedComponent = privilegeSetConfigureManager;
+const static auto& postTrustedComponent = privilegeSetConfigureManager;
+
+// TrustedComponentCollection
+const static auto& getTrustedComponentCollection = privilegeSetLogin;
+const static auto& headTrustedComponentCollection = privilegeSetLogin;
+const static auto& patchTrustedComponentCollection = privilegeSetConfigureManager;
+const static auto& putTrustedComponentCollection = privilegeSetConfigureManager;
+const static auto& deleteTrustedComponentCollection = privilegeSetConfigureManager;
+const static auto& postTrustedComponentCollection = privilegeSetConfigureManager;
 
 // UpdateService
 const static auto& getUpdateService = privilegeSetLogin;

--- a/redfish-core/lib/account_service.hpp
+++ b/redfish-core/lib/account_service.hpp
@@ -27,6 +27,7 @@
 #include "utils/dbus_utils.hpp"
 #include "utils/json_utils.hpp"
 
+#include <boost/system/error_code.hpp>
 #include <sdbusplus/asio/property.hpp>
 #include <sdbusplus/unpack_properties.hpp>
 
@@ -274,7 +275,7 @@ inline void
         updatedUserGroups, [asyncResp](const boost::system::error_code& ec) {
         if (ec)
         {
-            BMCWEB_LOG_ERROR("D-Bus responses error: {}", ec);
+            BMCWEB_LOG_ERROR("D-Bus responses error: {}", ec.value());
             messages::internalError(asyncResp->res);
             return;
         }
@@ -997,6 +998,23 @@ inline void
     });
 }
 
+inline void setPropertyAllowUnauthACFUpload(
+    const std::shared_ptr<bmcweb::AsyncResp>& asyncResp, bool allow)
+{
+    sdbusplus::asio::setProperty(
+        *crow::connections::systemBus, "xyz.openbmc_project.Settings",
+        "/xyz/openbmc_project/ibmacf/allow_unauth_upload",
+        "xyz.openbmc_project.Object.Enable", "Enabled", allow,
+        [asyncResp](const boost::system::error_code& ec) {
+        if (ec)
+        {
+            BMCWEB_LOG_ERROR("D-Bus responses error: {}", ec.value());
+            messages::internalError(asyncResp->res);
+            return;
+        }
+    });
+}
+
 inline void getAcfProperties(
     const std::shared_ptr<bmcweb::AsyncResp>& asyncResp,
     const std::tuple<std::vector<uint8_t>, bool, std::string>& messageFDbus)
@@ -1093,6 +1111,22 @@ inline void getAcfProperties(
     }
     asyncResp->res.jsonValue["Oem"]["IBM"]["ACF"]["ACFInstalled"] =
         acfInstalled;
+
+    sdbusplus::asio::getProperty<bool>(
+        *crow::connections::systemBus, "xyz.openbmc_project.Settings",
+        "/xyz/openbmc_project/ibmacf/allow_unauth_upload",
+        "xyz.openbmc_project.Object.Enable", "Enabled",
+        [asyncResp](const boost::system::error_code& ec,
+                    const bool allowUnauthACFUpload) {
+        if (ec)
+        {
+            BMCWEB_LOG_ERROR("D-Bus responses error: {}", ec.value());
+            messages::internalError(asyncResp->res);
+            return;
+        }
+        asyncResp->res.jsonValue["Oem"]["IBM"]["ACF"]["AllowUnauthACFUpload"] =
+            allowUnauthACFUpload;
+    });
 }
 
 /**
@@ -1576,14 +1610,19 @@ inline void uploadACF(const std::shared_ptr<bmcweb::AsyncResp>& asyncResp,
         "InstallACF", decodedAcf);
 }
 
+// This is called when someone either is not authenticated or is not
+// authorized to upload an ACF, and they are trying to upload an ACF;
+// in this condition, uploading an ACF is allowed when
+// AllowUnauthACFUpload is true.
 inline void triggerUnauthenticatedACFUpload(
     const std::shared_ptr<bmcweb::AsyncResp>& asyncResp,
     std::optional<nlohmann::json> oem)
 {
+    std::vector<uint8_t> decodedAcf;
     std::optional<nlohmann::json> ibm;
     if (!redfish::json_util::readJson(*oem, asyncResp->res, "IBM", ibm))
     {
-        BMCWEB_LOG_ERROR("Illegal Property ");
+        BMCWEB_LOG_WARNING("Illegal Property");
         messages::propertyMissing(asyncResp->res, "IBM");
         return;
     }
@@ -1593,7 +1632,7 @@ inline void triggerUnauthenticatedACFUpload(
     {
         if (!redfish::json_util::readJson(*ibm, asyncResp->res, "ACF", acf))
         {
-            BMCWEB_LOG_ERROR("Illegal Property ");
+            BMCWEB_LOG_WARNING("Illegal Property");
             messages::propertyMissing(asyncResp->res, "ACF");
             return;
         }
@@ -1601,12 +1640,11 @@ inline void triggerUnauthenticatedACFUpload(
 
     if (acf)
     {
-        std::vector<uint8_t> decodedAcf;
         std::optional<std::string> acfFile{};
         if (!redfish::json_util::readJson(*acf, asyncResp->res, "ACFFile",
                                           acfFile))
         {
-            BMCWEB_LOG_ERROR("Illegal Property ");
+            BMCWEB_LOG_WARNING("Illegal Property");
             messages::propertyMissing(asyncResp->res, "ACFFile");
             return;
         }
@@ -1629,39 +1667,55 @@ inline void triggerUnauthenticatedACFUpload(
             messages::internalError(asyncResp->res);
             return;
         }
+    }
 
-        crow::connections::systemBus->async_method_call(
-            [asyncResp, decodedAcf](const boost::system::error_code ec,
-                                    const std::variant<bool>& retVal) {
-            if (ec)
+    // Allow ACF upload when D-Bus property allow_unauth_upload is true (aka
+    // Redfish property AllowUnauthACFUpload).
+    sdbusplus::asio::getProperty<bool>(
+        *crow::connections::systemBus, "xyz.openbmc_project.Settings",
+        "/xyz/openbmc_project/ibmacf/allow_unauth_upload",
+        "xyz.openbmc_project.Object.Enable", "Enabled",
+        [asyncResp, decodedAcf](const boost::system::error_code& ec,
+                                const bool allowUnauthACFUpload) {
+        if (ec)
+        {
+            BMCWEB_LOG_ERROR(
+                "D-Bus response error reading allow_unauth_upload: {}",
+                ec.value());
+            messages::internalError(asyncResp->res);
+            return;
+        }
+
+        if (allowUnauthACFUpload)
+        {
+            uploadACF(asyncResp, decodedAcf);
+            return;
+        }
+
+        // Allow ACF upload when D-Bus property ACFWindowActive is true
+        // (aka OpPanel function 74).
+        sdbusplus::asio::getProperty<bool>(
+            *crow::connections::systemBus, "com.ibm.PanelApp",
+            "/com/ibm/panel_app", "com.ibm.panel", "ACFWindowActive",
+            [asyncResp, decodedAcf](const boost::system::error_code& ec1,
+                                    const bool isACFWindowActive) {
+            if (ec1)
             {
                 BMCWEB_LOG_ERROR("Failed to read ACFWindowActive property");
-                messages::internalError(asyncResp->res);
-                return;
+                // The Panel app doesn't run on simulated systems.
             }
 
-            const bool* isACFWindowActive = std::get_if<bool>(&retVal);
-
-            if (isACFWindowActive == nullptr)
+            if (!isACFWindowActive)
             {
-                BMCWEB_LOG_ERROR("nullptr for ACFWindowActive");
-                messages::internalError(asyncResp->res);
-                return;
-            }
-
-            if (!*isACFWindowActive)
-            {
-                BMCWEB_LOG_WARNING("ACF window not set to active from panel");
+                BMCWEB_LOG_ERROR("ACF upload not allowed");
                 messages::insufficientPrivilege(asyncResp->res);
                 return;
             }
 
             uploadACF(asyncResp, decodedAcf);
-        },
-            "com.ibm.PanelApp", "/com/ibm/panel_app",
-            "org.freedesktop.DBus.Properties", "Get", "com.ibm.panel",
-            "ACFWindowActive");
-    }
+            return;
+        });
+    });
 }
 
 inline void handleAccountServiceHead(
@@ -2568,10 +2622,17 @@ inline void
 
     if (oem)
     {
+        if (username != "service")
+        {
+            // Only the service user has Oem properties
+            messages::propertyUnknown(asyncResp->res, "Oem");
+            return;
+        }
+
         std::optional<nlohmann::json> ibm;
         if (!redfish::json_util::readJson(*oem, asyncResp->res, "IBM", ibm))
         {
-            BMCWEB_LOG_ERROR("Illegal Property ");
+            BMCWEB_LOG_WARNING("Illegal Property");
             messages::propertyMissing(asyncResp->res, "IBM");
             return;
         }
@@ -2580,29 +2641,28 @@ inline void
             std::optional<nlohmann::json> acf;
             if (!redfish::json_util::readJson(*ibm, asyncResp->res, "ACF", acf))
             {
-                BMCWEB_LOG_ERROR("Illegal Property ");
+                BMCWEB_LOG_WARNING("Illegal Property");
                 messages::propertyMissing(asyncResp->res, "ACF");
                 return;
             }
-            if (acf && (username == "service"))
+            if (acf)
             {
-                std::vector<uint8_t> decodedAcf;
+                std::optional<bool> allowUnauthACFUpload;
                 std::optional<std::string> acfFile;
-                if (acf.value().contains("ACFFile") &&
-                    acf.value()["ACFFile"] == nullptr)
+                if (!redfish::json_util::readJson(
+                        *acf, asyncResp->res, "ACFFile", acfFile,
+                        "AllowUnauthACFUpload", allowUnauthACFUpload))
                 {
-                    acfFile = "";
+                    BMCWEB_LOG_WARNING("Illegal Property");
+                    messages::propertyMissing(asyncResp->res, "ACFFile");
+                    messages::propertyMissing(asyncResp->res,
+                                              "AllowUnauthACFUpload");
+                    return;
                 }
-                else
-                {
-                    if (!redfish::json_util::readJson(*acf, asyncResp->res,
-                                                      "ACFFile", acfFile))
-                    {
-                        BMCWEB_LOG_ERROR("Illegal Property ");
-                        messages::propertyMissing(asyncResp->res, "ACFFile");
-                        return;
-                    }
 
+                if (acfFile)
+                {
+                    std::vector<uint8_t> decodedAcf;
                     std::string sDecodedAcf;
                     if (!crow::utility::base64Decode(*acfFile, sDecodedAcf))
                     {
@@ -2621,16 +2681,14 @@ inline void
                         messages::internalError(asyncResp->res);
                         return;
                     }
+                    uploadACF(asyncResp, decodedAcf);
                 }
 
-                uploadACF(asyncResp, decodedAcf);
-            }
-            else if (acf && (username != "service"))
-            {
-                messages::resourceAtUriUnauthorized(
-                    asyncResp->res, req.url(),
-                    "ACF properties access not allowed by non service "
-                    "user");
+                if (allowUnauthACFUpload)
+                {
+                    setPropertyAllowUnauthACFUpload(asyncResp,
+                                                    *allowUnauthACFUpload);
+                }
             }
         }
     }

--- a/redfish-core/lib/service_root.hpp
+++ b/redfish-core/lib/service_root.hpp
@@ -27,6 +27,7 @@
 #include "utils/dbus_utils.hpp"
 #include "utils/systemd_utils.hpp"
 
+#include <boost/system/error_code.hpp>
 #include <nlohmann/json.hpp>
 #include <persistent_data.hpp>
 #include <query.hpp>
@@ -43,6 +44,59 @@
 
 namespace redfish
 {
+
+inline void
+    handleACFWindowActive(const std::shared_ptr<bmcweb::AsyncResp>& asyncResp)
+{
+    // Redfish property ACFWindowActive=true when either of these is true:
+    //  - D-Bus property allow_unauth_upload.  (This is aka the Redfish
+    //    property AllowUnauthACFUpload which the BMC admin can control.)
+    //  - D-Bus property ACFWindowActive.  (This is aka the Redfish
+    //    property ACFWindowActive under /redfish/v1/AccountService/
+    //    Accounts/service property Oem.IBM.ACF.  The value is provided by
+    //    the PanelApp and is true when panel function 74 is active.)
+    // Check D-Bus property allow_unauth_upload first.
+    sdbusplus::asio::getProperty<bool>(
+        *crow::connections::systemBus, "xyz.openbmc_project.Settings",
+        "/xyz/openbmc_project/ibmacf/allow_unauth_upload",
+        "xyz.openbmc_project.Object.Enable", "Enabled",
+        [asyncResp](const boost::system::error_code& ec,
+                    const bool allowUnauthACFUpload) {
+        if (ec)
+        {
+            BMCWEB_LOG_ERROR(
+                "D-Bus response error reading allow_unauth_upload: {}",
+                ec.value());
+            messages::internalError(asyncResp->res);
+            return;
+        }
+
+        if (allowUnauthACFUpload)
+        {
+            asyncResp->res.jsonValue["Oem"]["IBM"]["ACFWindowActive"] =
+                allowUnauthACFUpload;
+            return;
+        }
+
+        // Check D-Bus property ACFWindowActive
+        sdbusplus::asio::getProperty<bool>(
+            *crow::connections::systemBus, "com.ibm.PanelApp",
+            "/com/ibm/panel_app", "com.ibm.panel", "ACFWindowActive",
+            [asyncResp](const boost::system::error_code& ec1,
+                        const bool isACFWindowActive) {
+            if (ec1)
+            {
+                BMCWEB_LOG_ERROR("Failed to read ACFWindowActive property");
+                // Default value when panel app is unreachable.
+                asyncResp->res.jsonValue["Oem"]["IBM"]["ACFWindowActive"] =
+                    false;
+                return;
+            }
+            asyncResp->res.jsonValue["Oem"]["IBM"]["ACFWindowActive"] =
+                isACFWindowActive;
+        });
+    });
+}
 
 inline void fillServiceRootOemProperties(
     const std::shared_ptr<bmcweb::AsyncResp>& asyncResp,
@@ -142,7 +196,7 @@ inline void
         redfishDateTimeOffset.first;
     asyncResp->res.jsonValue["Oem"]["IBM"]["DateTimeLocalOffset"] =
         redfishDateTimeOffset.second;
-
+    handleACFWindowActive(asyncResp);
     asyncResp->res.jsonValue["Oem"]["@odata.type"] = "#OemServiceRoot.Oem";
     asyncResp->res.jsonValue["Oem"]["IBM"]["@odata.type"] =
         "#OemServiceRoot.IBM";

--- a/redfish-core/lib/systems.hpp
+++ b/redfish-core/lib/systems.hpp
@@ -2742,6 +2742,157 @@ inline void
     BMCWEB_LOG_DEBUG("EXIT: Get idle power saver parameters");
 }
 
+/*
+ * Handle Enabled Panel Functions
+ */
+inline void doGetEnabledPanelFunctions(
+    const std::shared_ptr<bmcweb::AsyncResp>& asyncResp,
+    std::function<void(const std::vector<uint8_t>&)>&& callback)
+{
+    BMCWEB_LOG_DEBUG("Get Enabled Panel functions");
+
+    crow::connections::systemBus->async_method_call(
+        [asyncResp, callback](const boost::system::error_code& ec,
+                              const std::vector<uint8_t>& enabledFuncs) {
+        if (ec)
+        {
+            BMCWEB_LOG_ERROR("Get Enabled Panel Functions D-bus error: {}",
+                             ec.value());
+            messages::internalError(asyncResp->res);
+            return;
+        }
+        callback(enabledFuncs);
+    },
+        "com.ibm.PanelApp", "/com/ibm/panel_app", "com.ibm.panel",
+        "getEnabledFunctions");
+}
+
+/*
+ * Get Enabled Panel Functions
+ */
+inline void getEnabledPanelFunctions(
+    const std::shared_ptr<bmcweb::AsyncResp>& asyncResp)
+{
+    doGetEnabledPanelFunctions(
+        asyncResp, [asyncResp](const std::vector<uint8_t>& enabledFuncs) {
+        nlohmann::json& oem = asyncResp->res.jsonValue["Oem"];
+        oem["@odata.type"] = "#OemComputerSystem.Oem";
+        oem["IBM"]["@odata.type"] = "#OemComputerSystem.IBM";
+        oem["IBM"]["EnabledPanelFunctions"] = enabledFuncs;
+    });
+}
+
+/**
+ * Execute a Panel Enabled Function
+ */
+inline void
+    executePanelFunction(const std::shared_ptr<bmcweb::AsyncResp>& asyncResp,
+                         const uint8_t funcNo)
+{
+    BMCWEB_LOG_DEBUG("Execute Panel function {}", std::to_string(funcNo));
+
+    crow::connections::systemBus->async_method_call(
+        [asyncResp,
+         funcNo](const boost::system::error_code& ec,
+                 const sdbusplus::message_t& msg,
+                 const std::tuple<bool, std::string, std::string>& result) {
+        if (ec)
+        {
+            const sd_bus_error* dbusError = msg.get_error();
+            if (dbusError == nullptr)
+            {
+                BMCWEB_LOG_ERROR("Execute a panel function D-bus error:  {}",
+                                 ec.value());
+                messages::internalError(asyncResp->res);
+                return;
+            }
+            if (dbusError->name ==
+                std::string_view("xyz.openbmc_project.Common.Error.NotAllowed"))
+            {
+                BMCWEB_LOG_WARNING("PanelFunction {} is not enabled",
+                                   std::to_string(funcNo));
+                messages::operationNotAllowed(asyncResp->res);
+                return;
+            }
+            if (dbusError->name ==
+                std::string_view(
+                    "xyz.openbmc_project.Common.Error.InternalFailure"))
+            {
+                BMCWEB_LOG_ERROR("ExecutePanelFunction {} is failed",
+                                 std::to_string(funcNo));
+                messages::operationFailed(asyncResp->res);
+                return;
+            }
+            BMCWEB_LOG_ERROR("Execute a panel function D-bus error:  {}",
+                             ec.value());
+            messages::internalError(asyncResp->res);
+            return;
+        }
+
+        if (!std::get<0>(result))
+        {
+            BMCWEB_LOG_ERROR("ExecutePanelFunction {} is failed",
+                             std::to_string(funcNo));
+            messages::operationFailed(asyncResp->res);
+            return;
+        }
+        asyncResp->res.jsonValue["Result"] = {std::get<1>(result),
+                                              std::get<2>(result)};
+        messages::success(asyncResp->res);
+    },
+        "com.ibm.PanelApp", "/com/ibm/panel_app", "com.ibm.panel",
+        "ExecuteFunction", funcNo);
+}
+
+inline void handleSystemActionsOemExecutePanelFunctionPost(
+    App& app, const crow::Request& req,
+    const std::shared_ptr<bmcweb::AsyncResp>& asyncResp)
+{
+    BMCWEB_LOG_DEBUG("handleSystemActionsOemExecutePanelFunctionPost...");
+    if (!redfish::setUpRedfishRoute(app, req, asyncResp))
+    {
+        return;
+    }
+
+    uint8_t funcNo = 0;
+    if (!json_util::readJsonAction(req, asyncResp->res, "FuncNo", funcNo))
+    {
+        BMCWEB_LOG_WARNING("Missing funcNo");
+        messages::actionParameterMissing(asyncResp->res, "ExecutePanelFunction",
+                                         "FuncNo");
+        return;
+    }
+
+    doGetEnabledPanelFunctions(
+        asyncResp,
+        [funcNo, asyncResp](const std::vector<uint8_t>& enabledFuncs) {
+        auto it = std::find(enabledFuncs.begin(), enabledFuncs.end(), funcNo);
+        if (it == enabledFuncs.end())
+        {
+            BMCWEB_LOG_WARNING("PanelFunction {} is not enabled",
+                               std::to_string(funcNo));
+            messages::operationNotAllowed(asyncResp->res);
+            return;
+        }
+        executePanelFunction(asyncResp, funcNo);
+    });
+}
+
+/**
+ * SystemActionsOemExecutePanelFunction class supports handle POST method for
+ * ExecutePanelFunction  action. The class retrieves and sends data directly to
+ * D-Bus.
+ */
+inline void requestRoutesSystemActionsOemExecutePanelFunction(App& app)
+{
+    BMCWEB_ROUTE(
+        app,
+        "/redfish/v1/Systems/system/Actions/Oem/OemComputerSystem.ExecutePanelFunction/")
+        .privileges(redfish::privileges::postComputerSystem)
+        .methods(boost::beast::http::verb::post)(std::bind_front(
+            handleSystemActionsOemExecutePanelFunctionPost, std::ref(app)));
+}
+
 /**
  * @brief Sets Idle Power Saver properties.
  *
@@ -3362,6 +3513,13 @@ inline void
     getTrustedModuleRequiredToBoot(asyncResp);
     getPowerMode(asyncResp);
     getIdlePowerSaver(asyncResp);
+
+    // Panel Function
+    getEnabledPanelFunctions(asyncResp);
+
+    nlohmann::json& actionOem = asyncResp->res.jsonValue["Actions"]["Oem"];
+    actionOem["#OemComputerSystem.v1_0_0.ExecutePanelFunction"]["target"] =
+        "/redfish/v1/Systems/system/Actions/Oem/OemComputerSystem.ExecutePanelFunction";
 }
 
 inline void handleComputerSystemPatch(

--- a/scripts/parse_registries.py
+++ b/scripts/parse_registries.py
@@ -189,7 +189,7 @@ namespace redfish::privileges
 
 def make_privilege_registry():
     path, json_file, type_name, url = make_getter(
-        "Redfish_1.3.0_PrivilegeRegistry.json",
+        "Redfish_1.5.0_PrivilegeRegistry.json",
         "privilege_registry.hpp",
         "privilege",
     )

--- a/static/redfish/v1/$metadata/index.xml
+++ b/static/redfish/v1/$metadata/index.xml
@@ -3947,6 +3947,7 @@
     </edmx:Reference>
     <edmx:Reference Uri="/redfish/v1/schema/OemComputerSystem_v1.xml">
         <edmx:Include Namespace="OemComputerSystem"/>
+        <edmx:Include Namespace="OemComputerSystem.v1_0_0"/>
     </edmx:Reference>
     <edmx:Reference Uri="/redfish/v1/schema/OemVirtualMedia_v1.xml">
         <edmx:Include Namespace="OemVirtualMedia"/>

--- a/static/redfish/v1/JsonSchemas/OemComputerSystem/OemComputerSystem.json
+++ b/static/redfish/v1/JsonSchemas/OemComputerSystem/OemComputerSystem.json
@@ -160,6 +160,52 @@
                         "boolean",
                         "null"
                     ]
+                },
+                "EnabledPanelFunctions": {
+                    "description": "Enabled Panel functions",
+                    "longDescription": "This property shall contain the list of enabled panel functions.",
+                    "readonly": true,
+                    "type": [
+                        "array",
+                        "null"
+                    ]
+                }
+            },
+            "type": "object"
+        },
+        "ExecutePanelFunction": {
+            "additionalProperties": false,
+            "description": "This object executes a panel function",
+            "parameters": {
+                "FuncNo": {
+                    "description": "Panel function number.",
+                    "longDescription": "This parameter shall contain a  panel function number to be executed.",
+                    "type": "integer"
+                }
+            },
+            "patternProperties": {
+                "^([a-zA-Z_][a-zA-Z0-9_]*)?@(odata|Redfish|Message)\\.[a-zA-Z_][a-zA-Z0-9_]*$": {
+                    "description": "This property shall specify a valid odata or Redfish property.",
+                    "type": [
+                        "array",
+                        "boolean",
+                        "integer",
+                        "number",
+                        "null",
+                        "object",
+                        "string"
+                    ]
+                }
+            },
+            "properties": {
+                "target": {
+                    "description": "Link to invoke action",
+                    "format": "uri-reference",
+                    "type": "string"
+                },
+                "title": {
+                    "description": "Friendly action name",
+                    "type": "string"
                 }
             },
             "type": "object"

--- a/static/redfish/v1/JsonSchemas/OemManagerAccount/OemManagerAccount.json
+++ b/static/redfish/v1/JsonSchemas/OemManagerAccount/OemManagerAccount.json
@@ -85,6 +85,15 @@
                         "boolean"
                     ],
                     "versionAdded": "v1_0_0"
+                },
+                "AllowUnauthACFUpload": {
+                    "description": "This property shall indicate if unauthorized users shall be allowed to upload ACFs.",
+                    "longDescription": "This property indicates if unauthorized users are allowed to upload ACFs or not.  When this property is true, users are allowed to upload ACFs regardless of their authentication status, regardless of their Role, and regardless of the time window created by Operator Panel function 74.",
+                    "readonly": false,
+                    "type": [
+                        "boolean"
+                    ],
+                    "versionAdded": "v1_0_0"
                 }
             },
             "type": "object"

--- a/static/redfish/v1/JsonSchemas/OemServiceRoot/OemServiceRoot.json
+++ b/static/redfish/v1/JsonSchemas/OemServiceRoot/OemServiceRoot.json
@@ -85,6 +85,15 @@
                         "string",
                         "null"
                     ]
+                },
+                "ACFWindowActive": {
+                    "description": "An indication of whether the time window for an unauthorized agent to upload an ACF is active.",
+                    "longDescription": "This property shall indicate if the time window for an unauthorized agent to upload an ACF is active.",
+                    "readonly": true,
+                    "type": [
+                        "boolean",
+                        "null"
+                    ]
                 }
             },
             "type": "object"

--- a/static/redfish/v1/schema/OemComputerSystem_v1.xml
+++ b/static/redfish/v1/schema/OemComputerSystem_v1.xml
@@ -45,6 +45,11 @@
                     <Annotation Term="OData.Description" String="An indicator allowing an operator to operate platform system attention."/>
                     <Annotation Term="OData.LongDescription" String="This property shall contain the state of the platform system attention of this resource."/>
                 </Property>
+                <Property Name="EnabledPanelFunctions" Type="OemComputerSystem.IBM">
+                  <Annotation Term="OData.Permissions" EnumMember="OData.Permission/Read"/>
+                  <Annotation Term="OData.Description" String="List of enabled panel functions."/>
+                  <Annotation Term="OData.LongDescription" String="This property shall contain the list of enabled panel functions."/>
+                </Property>
             </ComplexType>
 
             <ComplexType Name="OpenBmc" BaseType="Resource.OemObject">
@@ -85,6 +90,16 @@
                     <Annotation Term="OData.LongDescription" String="Platform firmware is provisioned and locked. So re-provisioning is not allowed in this state."/>
                 </Member>
             </EnumType>
+        </Schema>
+        <Schema xmlns="http://docs.oasis-open.org/odata/ns/edm" Namespace="OemComputerSystem.v1_0_0">
+            <Action Name="ExecutePanelFunction" IsBound="true">
+                <Annotation Term="OData.Description" String="This action executes a panel function."/>
+                <Annotation Term="OData.LongDescription" String="This action executes a panel function if the function is enabled."/>
+                <Parameter Name="FuncNo" Type="OemComputerSystem.v1_0_0.OemActions" Nullable="false">
+                    <Annotation Term="OData.Description" String="Panel function number."/>
+                    <Annotation Term="OData.LongDescription" String="This parameter shall contain a  panel function number to be executed."/>
+                </Parameter>
+            </Action>
         </Schema>
     </edmx:DataServices>
 </edmx:Edmx>

--- a/static/redfish/v1/schema/OemManagerAccount_v1.xml
+++ b/static/redfish/v1/schema/OemManagerAccount_v1.xml
@@ -53,12 +53,17 @@
 				<Property Name="ExpirationDate" Type="Edm.String" Nullable="true">
 					<Annotation Term="OData.Permissions" EnumMember="OData.Permission/Read"/>
 					<Annotation Term="OData.Description" String="The expiration date of the ACF file."/>
-					<Annotation Term="OData.LongDescription" String="The expiration date of the ACF file, if the expiration date has been from the BMC then the ACF is not validD"/>
+					<Annotation Term="OData.LongDescription" String="The expiration date of the ACF file, if the expiration date has been from the BMC then the ACF is not valid."/>
 				</Property>
 				<Property Name="ACFInstalled" Type="Edm.Boolean">
 					<Annotation Term="OData.Permissions" EnumMember="OData.Permission/Read"/>
 					<Annotation Term="OData.Description" String="This property is set to true if the ACF is installed."/>
 					<Annotation Term="OData.LongDescription" String="This property indicates if the ACF is installed or not."/>
+				</Property>
+				<Property Name="AllowUnauthACFUpload" Type="Edm.Boolean">
+					<Annotation Term="OData.Permissions" EnumMember="OData.Permission/ReadWrite"/>
+					<Annotation Term="OData.Description" String="This property shall indicate if unauthorized users shall be allowed to upload ACFs."/>
+					<Annotation Term="OData.LongDescription" String="This property indicates if unauthorized users are allowed to upload ACFs or not.  When this property is true, users are allowed to upload ACFs regardless of their authentication status, regardless of their Role, and regardless of the time window created by Operator Panel function 74."/>
 				</Property>
 			</ComplexType>
 

--- a/static/redfish/v1/schema/OemServiceRoot_v1.xml
+++ b/static/redfish/v1/schema/OemServiceRoot_v1.xml
@@ -59,6 +59,11 @@
           <Annotation Term="OData.Description" String="The time offset from UTC that the DateTime property is in `+HH:MM` format."/>
           <Annotation Term="OData.LongDescription" String="This property shall contain the offset from UTC time that the DateTime property contains.  If both DateTime and DateTimeLocalOffset are provided in modification requests, services shall apply DateTimeLocalOffset after DateTime is applied."/>
         </Property>
+        <Property Name="ACFWindowActive" Type="OemServiceRoot.IBM">
+          <Annotation Term="OData.Permissions" EnumMember="OData.Permission/Read"/>
+          <Annotation Term="OData.Description" String="An indication of whether the time window for an unauthorized agent to upload an ACF is active."/>
+          <Annotation Term="OData.LongDescription" String="This property shall indicate if the time window for an unauthorized agent to upload an ACF is active."/>
+        </Property>
       </ComplexType>
 
     </Schema>


### PR DESCRIPTION
Upstream is https://gerrit.openbmc.org/c/openbmc/bmcweb/+/70854 


Change 1 line in scripts/parse_registries.py and rerun the script.

Long term OpenBMC/bmcweb need more direction here on the Privilege Registry, but for now continue with the current direction of using the Privilege Registry and taking it from the DMTF.

There is new entries in 1.4/1.5 that are needed for future development.

Tested: It builds.

Change-Id: I4337dc44e794c58f00f7307ea0508b84f14e8c8f