### PR TITLE
Pull PEL related EventLog changes into 1110

### DIFF
--- a/redfish-core/include/redfish.hpp
+++ b/redfish-core/include/redfish.hpp
@@ -209,6 +209,8 @@ class RedfishService
         requestRoutesDBusCELogEntry(app);
         requestRoutesDBusEventLogEntryDownload(app);
         requestRoutesDBusCEEventLogEntryDownload(app);
+        requestRoutesDBusEventLogEntryDownloadPelJson(app);
+        requestRoutesDBusCELogEntryDownloadPelJson(app);
 #endif
 
 #ifdef BMCWEB_ENABLE_REDFISH_HOST_LOGGER

--- a/redfish-core/include/redfish.hpp
+++ b/redfish-core/include/redfish.hpp
@@ -200,10 +200,15 @@ class RedfishService
 #endif // BMCWEB_ENABLE_VM_NBDPROXY
 
 #ifdef BMCWEB_ENABLE_REDFISH_DBUS_LOG_ENTRIES
+        requestRoutesCELogService(app);
         requestRoutesDBusLogServiceActionsClear(app);
+        requestRoutesDBusCELogServiceActionsClear(app);
         requestRoutesDBusEventLogEntryCollection(app);
+        requestRoutesDBusCELogEntryCollection(app);
         requestRoutesDBusEventLogEntry(app);
+        requestRoutesDBusCELogEntry(app);
         requestRoutesDBusEventLogEntryDownload(app);
+        requestRoutesDBusCEEventLogEntryDownload(app);
 #endif
 
 #ifdef BMCWEB_ENABLE_REDFISH_HOST_LOGGER

--- a/redfish-core/include/schemas.hpp
+++ b/redfish-core/include/schemas.hpp
@@ -138,5 +138,6 @@ namespace redfish
         "OemFabricAdapter",
         "OemServiceRoot",
         "OemPCIeDevice",
+        "OemLogEntry",
     };
 }

--- a/redfish-core/include/schemas.hpp
+++ b/redfish-core/include/schemas.hpp
@@ -139,5 +139,6 @@ namespace redfish
         "OemServiceRoot",
         "OemPCIeDevice",
         "OemLogEntry",
+        "OemLogEntryAttachment",
     };
 }

--- a/redfish-core/lib/log_services.hpp
+++ b/redfish-core/lib/log_services.hpp
@@ -2070,21 +2070,11 @@ void getHiddenPropertyValue(const std::shared_ptr<bmcweb::AsyncResp>& asyncResp,
     });
 }
 
-inline void updateProperty(const crow::Request& req,
+inline void updateProperty(const std::optional<bool>& resolved,
+                           const std::optional<bool>& managementSystemAck,
                            const std::shared_ptr<bmcweb::AsyncResp>& asyncResp,
                            const std::string& entryId)
 {
-    std::optional<bool> resolved;
-    std::optional<nlohmann::json> oemObject;
-#ifdef BMCWEB_ENABLE_IBM_MANAGEMENT_CONSOLE
-    std::optional<bool> managementSystemAck;
-#endif
-    if (!json_util::readJsonPatch(req, asyncResp->res, "Resolved", resolved,
-                                  "Oem", oemObject))
-    {
-        return;
-    }
-
     if (resolved.has_value())
     {
         sdbusplus::asio::setProperty(
@@ -2101,21 +2091,7 @@ inline void updateProperty(const crow::Request& req,
         });
         BMCWEB_LOG_DEBUG("Set Resolved");
     }
-#ifdef BMCWEB_ENABLE_IBM_MANAGEMENT_CONSOLE
-    if (oemObject)
-    {
-        std::optional<nlohmann::json> bmcOem;
-        if (!json_util::readJson(*oemObject, asyncResp->res, "OpenBMC", bmcOem))
-        {
-            return;
-        }
-        if (!json_util::readJson(*bmcOem, asyncResp->res, "ManagementSystemAck",
-                                 managementSystemAck))
-        {
-            BMCWEB_LOG_ERROR << "Could not read managementSystemAck";
-            return;
-        }
-    }
+
     if (managementSystemAck.has_value())
     {
         sdbusplus::asio::setProperty(
@@ -2133,7 +2109,6 @@ inline void updateProperty(const crow::Request& req,
         });
         BMCWEB_LOG_DEBUG("Updated ManagementSystemAck Property");
     }
-#endif
 }
 
 inline void
@@ -2856,14 +2831,40 @@ inline void requestRoutesDBusEventLogEntry(App& app)
             return;
         }
 
-        auto updatePropertyCallback = [&req, asyncResp,
+        std::optional<bool> resolved;
+        std::optional<nlohmann::json> oemObject;
+        std::optional<bool> managementSystemAck;
+        if (!json_util::readJsonPatch(req, asyncResp->res, "Resolved", resolved,
+                                      "Oem", oemObject))
+        {
+            return;
+        }
+
+        if (oemObject)
+        {
+            std::optional<nlohmann::json> bmcOem;
+            if (!json_util::readJson(*oemObject, asyncResp->res, "OpenBMC",
+                                     bmcOem))
+            {
+                return;
+            }
+            if (!json_util::readJson(*bmcOem, asyncResp->res,
+                                     "ManagementSystemAck",
+                                     managementSystemAck))
+            {
+                BMCWEB_LOG_ERROR("Could not read managementSystemAck");
+                return;
+            }
+        }
+
+        auto updatePropertyCallback = [resolved, managementSystemAck, asyncResp,
                                        entryId](bool hiddenPropVal) {
             if (hiddenPropVal)
             {
                 messages::resourceNotFound(asyncResp->res, "LogEntry", entryId);
                 return;
             }
-            updateProperty(req, asyncResp, entryId);
+            updateProperty(resolved, managementSystemAck, asyncResp, entryId);
         };
         getHiddenPropertyValue(asyncResp, entryId,
                                std::move(updatePropertyCallback));
@@ -3070,14 +3071,40 @@ inline void requestRoutesDBusCELogEntry(App& app)
             return;
         }
 
-        auto updatePropertyCallback = [&req, asyncResp,
+        std::optional<bool> resolved;
+        std::optional<nlohmann::json> oemObject;
+        std::optional<bool> managementSystemAck;
+        if (!json_util::readJsonPatch(req, asyncResp->res, "Resolved", resolved,
+                                      "Oem", oemObject))
+        {
+            return;
+        }
+
+        if (oemObject)
+        {
+            std::optional<nlohmann::json> bmcOem;
+            if (!json_util::readJson(*oemObject, asyncResp->res, "OpenBMC",
+                                     bmcOem))
+            {
+                return;
+            }
+            if (!json_util::readJson(*bmcOem, asyncResp->res,
+                                     "ManagementSystemAck",
+                                     managementSystemAck))
+            {
+                BMCWEB_LOG_ERROR("Could not read managementSystemAck");
+                return;
+            }
+        }
+
+        auto updatePropertyCallback = [resolved, managementSystemAck, asyncResp,
                                        entryId](bool hiddenPropVal) {
             if (!hiddenPropVal)
             {
                 messages::resourceNotFound(asyncResp->res, "LogEntry", entryId);
                 return;
             }
-            updateProperty(req, asyncResp, entryId);
+            updateProperty(resolved, managementSystemAck, asyncResp, entryId);
         };
         getHiddenPropertyValue(asyncResp, entryId,
                                std::move(updatePropertyCallback));

--- a/scripts/update_schemas.py
+++ b/scripts/update_schemas.py
@@ -154,6 +154,7 @@ oem_schema_names = [
     "OemFabricAdapter",
     "OemServiceRoot",
     "OemPCIeDevice",
+    "OemLogEntry",
 ]
 
 SCRIPT_DIR = os.path.dirname(os.path.realpath(__file__))

--- a/scripts/update_schemas.py
+++ b/scripts/update_schemas.py
@@ -155,6 +155,7 @@ oem_schema_names = [
     "OemServiceRoot",
     "OemPCIeDevice",
     "OemLogEntry",
+    "OemLogEntryAttachment",
 ]
 
 SCRIPT_DIR = os.path.dirname(os.path.realpath(__file__))

--- a/static/redfish/v1/$metadata/index.xml
+++ b/static/redfish/v1/$metadata/index.xml
@@ -3984,6 +3984,9 @@
         <edmx:Include Namespace="OemLogEntry"/>
         <edmx:Include Namespace="OemLogEntry.v1_0_0"/>
     </edmx:Reference>
+    <edmx:Reference Uri="/redfish/v1/schema/OemLogEntryAttachment_v1.xml">
+        <edmx:Include Namespace="OemLogEntryAttachment"/>
+    </edmx:Reference>
     <edmx:DataServices>
         <Schema xmlns="http://docs.oasis-open.org/odata/ns/edm" Namespace="Service">
             <EntityContainer Name="Service" Extends="ServiceRoot.v1_0_0.ServiceContainer"/>

--- a/static/redfish/v1/$metadata/index.xml
+++ b/static/redfish/v1/$metadata/index.xml
@@ -3980,6 +3980,10 @@
         <edmx:Include Namespace="OemPCIeDevice"/>
         <edmx:Include Namespace="OemPCIeDevice.v1_0_0"/>
     </edmx:Reference>
+    <edmx:Reference Uri="/redfish/v1/schema/OemLogEntry_v1.xml">
+        <edmx:Include Namespace="OemLogEntry"/>
+        <edmx:Include Namespace="OemLogEntry.v1_0_0"/>
+    </edmx:Reference>
     <edmx:DataServices>
         <Schema xmlns="http://docs.oasis-open.org/odata/ns/edm" Namespace="Service">
             <EntityContainer Name="Service" Extends="ServiceRoot.v1_0_0.ServiceContainer"/>

--- a/static/redfish/v1/JsonSchemas/OemLogEntry/OemLogEntry.json
+++ b/static/redfish/v1/JsonSchemas/OemLogEntry/OemLogEntry.json
@@ -1,0 +1,42 @@
+{
+    "$id": "http://redfish.dmtf.org/schemas/v1/OemLogEntry.v1_0_0.json",
+    "$schema": "http://redfish.dmtf.org/schemas/v1/redfish-schema-v1.json",
+    "copyright": "Copyright 2014-2019 DMTF. For the full DMTF copyright policy, see http://www.dmtf.org/about/policies/copyright",
+    "definitions": {
+        "LogEntry": {
+            "additionalProperties": true,
+            "description": "OEM Extension for LogEntry",
+            "longDescription": "OEM Extension for LogEntry to provide the OEM specific details.",
+            "patternProperties": {
+                "^([a-zA-Z_][a-zA-Z0-9_]*)?@(odata|Redfish|Message)\\.[a-zA-Z_][a-zA-Z0-9_]*$": {
+                    "description": "This property shall specify a valid odata or Redfish property.",
+                    "type": [
+                        "array",
+                        "boolean",
+                        "integer",
+                        "number",
+                        "null",
+                        "object",
+                        "string"
+                    ]
+                }
+            },
+            "properties": {
+                "ManagementSystemAck" : {
+                    "description": "Flag to keep track of external interface acknowledgment.",
+                    "longDescription": "A true value says external interface acked error log, false says otherwise.",
+                    "readonly": false,
+                    "type": [
+                        "boolean",
+                        "null"
+                    ]
+                },
+            "type": "object"
+            }
+        }
+    },
+    "owningEntity": "OpenBMC",
+    "release": "1.0",
+    "title": "#OemLogEntry.v1_0_0"
+}
+

--- a/static/redfish/v1/JsonSchemas/OemLogEntry/OemLogEntry.json
+++ b/static/redfish/v1/JsonSchemas/OemLogEntry/OemLogEntry.json
@@ -22,7 +22,65 @@
                 }
             },
             "properties": {
-                "ManagementSystemAck" : {
+                "GeneratorId": {
+                    "description": "Id of the user who created the LogEntry.",
+                    "longDescription": "Unique id of the user who has caused the creation of the LogEntry. Eg: ip address, session id, client id.",
+                    "type": [
+                        "string",
+                        "null"
+                    ]
+                },
+            "type": "object"
+            }
+        },
+        "Oem": {
+            "additionalProperties": true,
+            "description": "OemManager Oem properties.",
+            "patternProperties": {
+                "^([a-zA-Z_][a-zA-Z0-9_]*)?@(odata|Redfish|Message)\\.[a-zA-Z_][a-zA-Z0-9_.]+$": {
+                    "description": "This property shall specify a valid odata or Redfish property.",
+                    "type": [
+                        "array",
+                        "boolean",
+                        "number",
+                        "null",
+                        "object",
+                        "string"
+                    ]
+                }
+            },
+            "properties": {
+                "OpenBmc": {
+                    "anyOf": [
+                        {
+                            "$ref": "#/definitions/OpenBmc"
+                        },
+                        {
+                            "type": "null"
+                        }
+                    ]
+                }
+            },
+            "type": "object"
+        },
+        "OpenBmc": {
+            "additionalProperties": true,
+            "description": "Oem properties for OpenBmc.",
+            "patternProperties": {
+                "^([a-zA-Z_][a-zA-Z0-9_]*)?@(odata|Redfish|Message)\\.[a-zA-Z_][a-zA-Z0-9_.]+$": {
+                    "description": "This property shall specify a valid odata or Redfish property.",
+                    "type": [
+                        "array",
+                        "boolean",
+                        "number",
+                        "null",
+                        "object",
+                        "string"
+                    ]
+                }
+            },
+            "properties": {
+               "ManagementSystemAck" : {
                     "description": "Flag to keep track of external interface acknowledgment.",
                     "longDescription": "A true value says external interface acked error log, false says otherwise.",
                     "readonly": false,
@@ -30,9 +88,9 @@
                         "boolean",
                         "null"
                     ]
-                },
+                }
+            },
             "type": "object"
-            }
         }
     },
     "owningEntity": "OpenBMC",

--- a/static/redfish/v1/JsonSchemas/OemLogEntryAttachment/OemLogEntryAttachment.json
+++ b/static/redfish/v1/JsonSchemas/OemLogEntryAttachment/OemLogEntryAttachment.json
@@ -1,0 +1,66 @@
+{
+    "$id": "http://redfish.dmtf.org/schemas/v1/OemLogEntryAttachment.json",
+    "$schema": "http://redfish.dmtf.org/schemas/v1/redfish-schema-v1.json",
+    "copyright": "Copyright 2014-2019 DMTF. For the full DMTF copyright policy, see http://www.dmtf.org/about/policies/copyright",
+    "definitions": {
+        "Oem": {
+            "additionalProperties": true,
+            "description": "OemLogEntryAttachment Oem properties.",
+            "patternProperties": {
+                "^([a-zA-Z_][a-zA-Z0-9_]*)?@(odata|Redfish|Message)\\.[a-zA-Z_][a-zA-Z0-9_]*$": {
+                    "description": "This property shall specify a valid odata or Redfish property.",
+                    "type": [
+                        "null",
+                        "string"
+                    ]
+                }
+            },
+            "properties": {
+                "IBM": {
+                    "anyOf": [
+                        {
+                            "$ref": "#/definitions/IBM"
+                        },
+                        {
+                            "type": "null"
+                        }
+                    ]
+                }
+
+            },
+            "type": "object"
+        },
+        "IBM": {
+            "additionalProperties": true,
+            "description": "Oem properties for IBM.",
+            "patternProperties": {
+                "^([a-zA-Z_][a-zA-Z0-9_]*)?@(odata|Redfish|Message)\\.[a-zA-Z_][a-zA-Z0-9_]*$": {
+                    "description": "This property shall specify a valid odata or Redfish property.",
+                    "type": [
+                        "array",
+                        "boolean",
+                        "integer",
+                        "number",
+                        "null",
+                        "object",
+                        "string"
+                    ]
+                }
+            },
+            "properties": {
+                "PelJson": {
+                    "description": "PEL in Json format.",
+                    "readonly": true,
+                    "type": [
+                        "string",
+                        "null"
+                    ]
+                }
+            },
+            "type": "object"
+        }
+    },
+    "owningEntity": "IBM",
+    "release": "1.0",
+    "title": "#OemLogEntryAttachment"
+}

--- a/static/redfish/v1/schema/OemLogEntryAttachment_v1.xml
+++ b/static/redfish/v1/schema/OemLogEntryAttachment_v1.xml
@@ -1,0 +1,43 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<edmx:Edmx xmlns:edmx="http://docs.oasis-open.org/odata/ns/edmx" Version="4.0">
+
+  <edmx:Reference Uri="http://docs.oasis-open.org/odata/odata/v4.0/errata03/csd01/complete/vocabularies/Org.OData.Core.V1.xml">
+    <edmx:Include Namespace="Org.OData.Core.V1" Alias="OData"/>
+  </edmx:Reference>
+  <edmx:Reference Uri="http://docs.oasis-open.org/odata/odata/v4.0/errata03/csd01/complete/vocabularies/Org.OData.Measures.V1.xml">
+    <edmx:Include Namespace="Org.OData.Measures.V1" Alias="Measures"/>
+  </edmx:Reference>
+  <edmx:Reference Uri="http://redfish.dmtf.org/schemas/v1/RedfishExtensions_v1.xml">
+    <edmx:Include Namespace="RedfishExtensions.v1_0_0" Alias="Redfish"/>
+  </edmx:Reference>
+  <edmx:Reference Uri="http://redfish.dmtf.org/schemas/v1/Resource_v1.xml">
+    <edmx:Include Namespace="Resource"/>
+    <edmx:Include Namespace="Resource.v1_0_0"/>
+  </edmx:Reference>
+
+  <edmx:DataServices>
+
+    <Schema xmlns="http://docs.oasis-open.org/odata/ns/edm" Namespace="OemLogEntryAttachment">
+      <Annotation Term="Redfish.OwningEntity" String="IBM"/>
+
+      <ComplexType Name="Oem" BaseType="Resource.OemObject">
+        <Annotation Term="OData.AdditionalProperties" Bool="true"/>
+        <Annotation Term="OData.Description" String="OemLogEntryAttachment Oem properties."/>
+        <Annotation Term="OData.AutoExpand"/>
+        <Property Name="IBM" Type="OemLogEntryAttachment.IBM"/>
+      </ComplexType>
+
+      <ComplexType Name="IBM" BaseType="Resource.OemObject">
+        <Annotation Term="OData.AdditionalProperties" Bool="false" />
+        <Annotation Term="OData.Description" String="Oem properties for IBM." />
+        <Annotation Term="OData.AutoExpand"/>
+        <Property Name="PelJson" Type="OemLogEntryAttachment.IBM">
+          <Annotation Term="OData.Permissions" EnumMember="OData.Permission/Read"/>
+          <Annotation Term="OData.Description" String="PEL in Json format."/>
+        </Property>
+      </ComplexType>
+
+    </Schema>
+
+  </edmx:DataServices>
+</edmx:Edmx>

--- a/static/redfish/v1/schema/OemLogEntry_v1.xml
+++ b/static/redfish/v1/schema/OemLogEntry_v1.xml
@@ -24,16 +24,28 @@
       <Annotation Term="Redfish.OwningEntity" String="OpenBMC"/>
       <Annotation Term="Redfish.Release" String="1.0"/>
 
-      <EntityType Name="LogEntry" BaseType="Resource.OemObject" Abstract="true">
-          <Annotation Term="OData.Description" String="OEM Extension for LogEntry"/>
-          <Annotation Term="OData.LongDescription" String="OEM Extension for LogEntry to provide the OEM specific details"/>
 
-            <Property Name="ManagementSystemAck" Type="Edm.Boolean">
-              <Annotation Term="OData.Description" String="Flag to keep track of external interface acknowledgment."/>
-              <Annotation Term="OData.LongDescription" String="A true value says external interface acked error log, false says otherwise."/>
-            </Property>
+<ComplexType Name="Oem" BaseType="Resource.OemObject">
+        <Annotation Term="OData.AdditionalProperties" Bool="true" />
+        <Annotation Term="OData.Description" String="OemLogEntry Oem properties." />
+        <Annotation Term="OData.AutoExpand" />
+        <Property Name="OpenBMC" Type="OemLogEntry.v1_0_0.OpenBMC" />
+      </ComplexType>
+        
+      <ComplexType Name="OpenBMC">
+        <Annotation Term="OData.AdditionalProperties" Bool="true" />
+        <Annotation Term="OData.Description" String="Oem properties for OpenBMC." />
+        <Annotation Term="OData.AutoExpand" />
+          <Property Name="ManagementSystemAck" Type="Edm.Boolean">
+            <Annotation Term="OData.Description" String="Flag to keep track of external interface acknowledgment."/>
+            <Annotation Term="OData.LongDescription" String="A true value says external interface acked error log, false says otherwise."/>
+          </Property>
 
-      </EntityType>
+          <Property Name="GeneratorId" Type="Edm.String">
+            <Annotation Term="OData.Description" String="Id of the user who created the LogEntry."/>
+            <Annotation Term="OData.LongDescription" String="Unique id of the user who has caused the creation of the LogEntry. Eg: ip address, session id, client id."/>
+          </Property>
+      </ComplexType>
     </Schema>
   </edmx:DataServices>
 </edmx:Edmx>

--- a/static/redfish/v1/schema/OemLogEntry_v1.xml
+++ b/static/redfish/v1/schema/OemLogEntry_v1.xml
@@ -1,0 +1,40 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<edmx:Edmx xmlns:edmx="http://docs.oasis-open.org/odata/ns/edmx" Version="4.0">
+
+  <edmx:Reference Uri="http://docs.oasis-open.org/odata/odata/v4.0/errata03/csd01/complete/vocabularies/Org.OData.Core.V1.xml">
+    <edmx:Include Namespace="Org.OData.Core.V1" Alias="OData"/>
+  </edmx:Reference>
+  <edmx:Reference Uri="http://docs.oasis-open.org/odata/odata/v4.0/errata03/csd01/complete/vocabularies/Org.OData.Measures.V1.xml">
+    <edmx:Include Namespace="Org.OData.Measures.V1" Alias="Measures"/>
+  </edmx:Reference>
+  <edmx:Reference Uri="http://redfish.dmtf.org/schemas/v1/RedfishExtensions_v1.xml">
+    <edmx:Include Namespace="RedfishExtensions.v1_0_0" Alias="Redfish"/>
+  </edmx:Reference>
+  <edmx:Reference Uri="http://redfish.dmtf.org/schemas/v1/Resource_v1.xml">
+    <edmx:Include Namespace="Resource"/>
+    <edmx:Include Namespace="Resource.v1_0_0"/>
+  </edmx:Reference>
+  <edmx:DataServices>
+
+    <Schema xmlns="http://docs.oasis-open.org/odata/ns/edm" Namespace="OemLogEntry">
+      <Annotation Term="Redfish.OwningEntity" String="OpenBMC"/>
+    </Schema>
+
+    <Schema xmlns="http://docs.oasis-open.org/odata/ns/edm" Namespace="OemLogEntry.v1_0_0">
+      <Annotation Term="Redfish.OwningEntity" String="OpenBMC"/>
+      <Annotation Term="Redfish.Release" String="1.0"/>
+
+      <EntityType Name="LogEntry" BaseType="Resource.OemObject" Abstract="true">
+          <Annotation Term="OData.Description" String="OEM Extension for LogEntry"/>
+          <Annotation Term="OData.LongDescription" String="OEM Extension for LogEntry to provide the OEM specific details"/>
+
+            <Property Name="ManagementSystemAck" Type="Edm.Boolean">
+              <Annotation Term="OData.Description" String="Flag to keep track of external interface acknowledgment."/>
+              <Annotation Term="OData.LongDescription" String="A true value says external interface acked error log, false says otherwise."/>
+            </Property>
+
+      </EntityType>
+    </Schema>
+  </edmx:DataServices>
+</edmx:Edmx>
+


### PR DESCRIPTION
This PR pulls in the downstream commits for the LogService modifications IBM made for PELs.  This includes:

- Adding the CELog log service that only shows event logs if their 'Hidden' property is true.
- Putting SRC words into the EventId property
- Updating the Message property to use PEL fields
- Adding the ManagementSystemAck property that is used for tracking HMC Acks
- Adding the OemPelAttachment that returns the parsed PEL in JSON.

I cherry picked the 5 commits in, and fixed up merge conflicts where necessary.  The biggest change was around the request-routes for the LogEntry attachment since there was some refactoring upstream.  I don't think we use this anymore anyway since it just returns the base64 PEL data, but I tested it does work.

There are no current plans to upstream any of this, at least based on current priorities.  If we did, we'd probably have to start over and use a Message Registry.

For testing I verified that:
- EventLog and CELog show the correct entries based on the hidden property
- The new properties added are correct
- Resolved could still be updated in both EventLog and CELog
- ManagementSystemAck could be updated in EventLog and CELog, and that it was reflected in the PEL
- The attachment would still download the PEL in base64
- The OemPelAttachment would download the PEL in JSON for both EventLog and CELog.



