### PR TITLE
FFDC: Collect current in-memory sessions for BMC dump

### DIFF
--- a/http/http_server.hpp
+++ b/http/http_server.hpp
@@ -19,7 +19,9 @@
 #include <memory>
 #include <utility>
 #include <vector>
-
+#ifdef BMCWEB_ENABLE_IBM_MANAGEMENT_CONSOLE
+#include <persistent_data.hpp>
+#endif
 namespace crow
 {
 
@@ -36,7 +38,11 @@ class Server
         acceptor(std::move(acceptorIn)),
         signals(*ioService, SIGINT, SIGTERM, SIGHUP), handler(handlerIn),
         adaptorCtx(std::move(adaptorCtxIn))
-    {}
+    {
+#ifdef BMCWEB_ENABLE_IBM_MANAGEMENT_CONSOLE
+        signals.add(SIGUSR1);
+#endif
+    }
 
     Server(Handler* handlerIn, uint16_t port,
            const std::shared_ptr<boost::asio::ssl::context>& adaptorCtxIn,
@@ -148,6 +154,15 @@ class Server
                     }
                     startAsyncWaitForSignal();
                 }
+#ifdef BMCWEB_ENABLE_IBM_MANAGEMENT_CONSOLE
+                if (signalNo == SIGUSR1)
+                {
+                    BMCWEB_LOG_CRITICAL(
+                        "INFO: Receivied USR1 signal to dump latest session  data for bmc dump");
+                    persistent_data::getConfig().writeCurrentSessionData();
+                    this->startAsyncWaitForSignal();
+                }
+#endif
                 else
                 {
                     stop();

--- a/include/persistent_data.hpp
+++ b/include/persistent_data.hpp
@@ -23,7 +23,8 @@ class ConfigFile
   public:
     // todo(ed) should read this from a fixed location somewhere, not CWD
     static constexpr const char* filename = "bmcweb_persistent_data.json";
-
+    static constexpr const char* dumpFilename =
+        "bmcweb_current_session_snapshot.json";
     ConfigFile()
     {
         readData();
@@ -187,6 +188,86 @@ class ConfigFile
             writeData();
         }
     }
+
+#ifdef BMCWEB_ENABLE_IBM_MANAGEMENT_CONSOLE
+    void writeCurrentSessionData()
+    {
+        std::ofstream persistentFile(dumpFilename);
+        std::filesystem::perms permission =
+            std::filesystem::perms::owner_read |
+            std::filesystem::perms::owner_write |
+            std::filesystem::perms::group_read;
+        std::filesystem::permissions(filename, permission);
+        const auto& eventServiceConfig =
+            EventServiceStore::getInstance().getEventServiceConfig();
+        nlohmann::json data{
+            {"eventservice_config",
+             {{"ServiceEnabled", eventServiceConfig.enabled},
+              {"DeliveryRetryAttempts", eventServiceConfig.retryAttempts},
+              {"DeliveryRetryIntervalSeconds",
+               eventServiceConfig.retryTimeoutInterval}}
+
+            },
+            {"system_uuid", systemUuid},
+            {"revision", jsonRevision},
+            {"timeout", SessionStore::getInstance().getTimeoutInSeconds()}};
+
+        nlohmann::json& sessions = data["sessions"];
+        sessions = nlohmann::json::array();
+        for (const auto& p : SessionStore::getInstance().authTokens)
+        {
+            if (p.second->persistence !=
+                persistent_data::PersistenceType::SINGLE_REQUEST)
+            {
+                nlohmann::json::object_t session;
+                session["unique_id"] = p.second->uniqueId;
+                session["username"] = p.second->username;
+                session["client_ip"] = p.second->clientIp;
+                if (p.second->clientId)
+                {
+                    session["client_id"] = *p.second->clientId;
+                }
+                sessions.push_back(std::move(session));
+            }
+        }
+
+        nlohmann::json& subscriptions = data["subscriptions"];
+        subscriptions = nlohmann::json::array();
+        for (const auto& it :
+             EventServiceStore::getInstance().subscriptionsConfigMap)
+        {
+            std::shared_ptr<UserSubscription> subValue = it.second;
+            if (subValue->subscriptionType == "SSE")
+            {
+                BMCWEB_LOG_DEBUG("The subscription type is SSE, so skipping.");
+                continue;
+            }
+            nlohmann::json::object_t headers;
+            for (const boost::beast::http::fields::value_type& header :
+                 subValue->httpHeaders)
+            {
+                std::string name(header.name_string());
+                headers[std::move(name)] = header.value();
+            }
+
+            subscriptions.push_back({
+                {"Id", subValue->id},
+                {"Context", subValue->customText},
+                {"DeliveryRetryPolicy", subValue->retryPolicy},
+                {"Destination", subValue->destinationUrl},
+                {"EventFormatType", subValue->eventFormatType},
+                {"HttpHeaders", std::move(headers)},
+                {"MessageIds", subValue->registryMsgIds},
+                {"Protocol", subValue->protocol},
+                {"RegistryPrefixes", subValue->registryPrefixes},
+                {"ResourceTypes", subValue->resourceTypes},
+                {"SubscriptionType", subValue->subscriptionType},
+                {"MetricReportDefinitions", subValue->metricReportDefinitions},
+            });
+        }
+        persistentFile << data;
+    }
+#endif
 
     void writeData()
     {


### PR DESCRIPTION
Currently it collects bmcweb_persistent_data.json as part of BMC dump, but this file does not contain all existing redfish sessions

This commit is to collect all sessions into bmcweb_current_session_persistent_data.json during bmc dump creation, on receiving SIGUSR1 from dump manager.

* Add event subscriptions data along with session data