### PR TITLE
Leave off USB code update if no backend

### DIFF
--- a/redfish-core/lib/oem/ibm/usb_code_update.hpp
+++ b/redfish-core/lib/oem/ibm/usb_code_update.hpp
@@ -36,6 +36,12 @@ inline void
                     const dbus::utility::MapperGetObject& object) {
         if (ec1 || object.empty())
         {
+            if (ec1 == boost::system::errc::io_error)
+            {
+                BMCWEB_LOG_WARNING("USB code update not found");
+                return;
+            }
+
             BMCWEB_LOG_ERROR("DBUS response error {}", ec1);
             messages::internalError(asyncResp->res);
             return;


### PR DESCRIPTION
This appears what we had in 1020-1060.

Tested: Enable USB code update. Load on rainier with no backend. 200 rc for manager resource.