### PR TITLE
Added Hypervisor Serial Socket (#488)

### DIFF
--- a/include/obmc_hypervisor.hpp
+++ b/include/obmc_hypervisor.hpp
@@ -1,0 +1,165 @@
+#pragma once
+
+#include "app.hpp"
+#include "async_resp.hpp"
+#include "websocket.hpp"
+
+#include <sys/socket.h>
+
+#include <boost/asio/local/stream_protocol.hpp>
+#include <boost/container/flat_map.hpp>
+#include <boost/container/flat_set.hpp>
+#include <boost/system/error_code.hpp>
+
+#include <array>
+#include <memory>
+#include <string>
+#include <string_view>
+
+namespace crow
+{
+namespace obmc_hypervisor
+{
+
+// NOLINTBEGIN(cppcoreguidelines-avoid-non-const-global-variables)
+static std::unique_ptr<boost::asio::local::stream_protocol::socket> hostSocket;
+
+static std::array<char, 4096> outputBuffer;
+static std::string inputBuffer;
+
+static boost::container::flat_set<crow::websocket::Connection*> sessions;
+
+static bool doingWrite = false;
+// NOLINTEND(cppcoreguidelines-avoid-non-const-global-variables)
+
+inline void doWrite()
+{
+    if (doingWrite)
+    {
+        BMCWEB_LOG_DEBUG("Already writing.  Bailing out");
+        return;
+    }
+
+    if (inputBuffer.empty())
+    {
+        BMCWEB_LOG_DEBUG("Outbuffer empty.  Bailing out");
+        return;
+    }
+
+    if (!hostSocket)
+    {
+        BMCWEB_LOG_ERROR("doWrite(): Socket closed.");
+        return;
+    }
+
+    doingWrite = true;
+    hostSocket->async_write_some(
+        boost::asio::buffer(inputBuffer.data(), inputBuffer.size()),
+        [](const boost::beast::error_code& ec, std::size_t bytesWritten) {
+        doingWrite = false;
+        inputBuffer.erase(0, bytesWritten);
+
+        if (ec == boost::asio::error::eof)
+        {
+            for (crow::websocket::Connection* session : sessions)
+            {
+                session->close("Error in reading to host port");
+            }
+            return;
+        }
+        if (ec)
+        {
+            BMCWEB_LOG_ERROR("Error in host serial write {}", ec);
+            return;
+        }
+        doWrite();
+    });
+}
+
+inline void doRead()
+{
+    if (!hostSocket)
+    {
+        BMCWEB_LOG_ERROR("doRead(): Socket closed.");
+        return;
+    }
+
+    BMCWEB_LOG_DEBUG("Reading from socket");
+    hostSocket->async_read_some(
+        boost::asio::buffer(outputBuffer.data(), outputBuffer.size()),
+        [](const boost::system::error_code& ec, std::size_t bytesRead) {
+        BMCWEB_LOG_DEBUG("read done.  Read {} bytes", bytesRead);
+        if (ec)
+        {
+            BMCWEB_LOG_ERROR("Couldn't read from host serial port: {}", ec);
+            for (crow::websocket::Connection* session : sessions)
+            {
+                session->close("Error in connecting to host port");
+            }
+            return;
+        }
+        std::string_view payload(outputBuffer.data(), bytesRead);
+        for (crow::websocket::Connection* session : sessions)
+        {
+            session->sendBinary(payload);
+        }
+        doRead();
+    });
+}
+
+inline void connectHandler(const boost::system::error_code& ec)
+{
+    if (ec)
+    {
+        BMCWEB_LOG_ERROR("Couldn't connect to host serial port: {}", ec);
+        for (crow::websocket::Connection* session : sessions)
+        {
+            session->close("Error in connecting to host port");
+        }
+        return;
+    }
+
+    doWrite();
+    doRead();
+}
+
+inline void requestRoutes(App& app)
+{
+    BMCWEB_ROUTE(app, "/console1")
+        .privileges({{"OemIBMPerformService"}})
+        .websocket()
+        .onopen([](crow::websocket::Connection& conn) {
+        BMCWEB_LOG_DEBUG("Connection {} opened", logPtr(&conn));
+
+        sessions.insert(&conn);
+        if (hostSocket == nullptr)
+        {
+            const std::string consoleName("\0obmc-console.hypervisor", 24);
+            boost::asio::local::stream_protocol::endpoint ep(consoleName);
+
+            hostSocket =
+                std::make_unique<boost::asio::local::stream_protocol::socket>(
+                    conn.getIoContext());
+            hostSocket->async_connect(ep, connectHandler);
+        }
+    })
+        .onclose([](crow::websocket::Connection& conn,
+                    [[maybe_unused]] const std::string& reason) {
+        BMCWEB_LOG_INFO("Closing websocket. Reason: {}", reason);
+
+        sessions.erase(&conn);
+        if (sessions.empty())
+        {
+            hostSocket = nullptr;
+            inputBuffer.clear();
+            inputBuffer.shrink_to_fit();
+        }
+    })
+        .onmessage([]([[maybe_unused]] crow::websocket::Connection& conn,
+                      const std::string& data, [[maybe_unused]] bool isBinary) {
+        inputBuffer += data;
+        doWrite();
+    });
+}
+} // namespace obmc_hypervisor
+} // namespace crow

--- a/meson.build
+++ b/meson.build
@@ -69,6 +69,7 @@ feature_map = {
   'event-subscription'                          : '-DBMCWEB_ENABLE_EVENT_SUBSCRIPTION_WEBSOCKET',
   'google-api'                                  : '-DBMCWEB_ENABLE_GOOGLE_API',
   'host-serial-socket'                          : '-DBMCWEB_ENABLE_HOST_SERIAL_WEBSOCKET',
+  'hypervisor-serial-socket'                    : '-DBMCWEB_ENABLE_HYPERVISOR_SERIAL_WEBSOCKET',
   'ibm-management-console'                      : '-DBMCWEB_ENABLE_IBM_MANAGEMENT_CONSOLE',
   'insecure-disable-auth'                       : '-DBMCWEB_INSECURE_DISABLE_AUTHX',
   'ibm-usb-code-update'                         : '-DBMCWEB_ENABLE_IBM_USB_CODE_UPDATE',

--- a/meson_options.txt
+++ b/meson_options.txt
@@ -402,3 +402,11 @@ option('ibm-led-extensions',
     description : '''Enable the IBM LED extensions such as lamp test and system
                      attention indicators.'''
 )
+
+option(
+      'hypervisor-serial-socket',
+      type: 'feature',
+      value: 'enabled',
+      description: '''Enable hypervisor serial console WebSocket. Path is
+                      \'/console1\'.'''
+)

--- a/src/webserver_main.cpp
+++ b/src/webserver_main.cpp
@@ -25,6 +25,7 @@
 
 #include <boost/asio/io_context.hpp>
 #include <event_dbus_monitor.hpp>
+#include <obmc_hypervisor.hpp>
 #include <sdbusplus/asio/connection.hpp>
 #include <sdbusplus/bus.hpp>
 #include <sdbusplus/server.hpp>
@@ -105,6 +106,9 @@ static int run()
 
 #ifdef BMCWEB_ENABLE_HOST_SERIAL_WEBSOCKET
     crow::obmc_console::requestRoutes(app);
+#endif
+#ifdef BMCWEB_ENABLE_HYPERVISOR_SERIAL_WEBSOCKET
+    crow::obmc_hypervisor::requestRoutes(app);
 #endif
 
 #ifdef BMCWEB_ENABLE_VM_WEBSOCKET


### PR DESCRIPTION
This commit adds `wss://${window.location.host}/console1` WebSocket into bmcweb. it retrieves 'PHYP debug shell' info and displays WebSocket data into WebUI using SOL (Serial over LAN) console.

console1 reads data from UNIX domain socket '@obmc-console.hypervisor' and display it in WebUI.

Privilege is set to {"OemIBMPerformService"}.

Tested:
  Used webUI to open Hypervisor console. Console window was displayed.
  However, we are not getting the shell because the BMC goes to
  Quiecsed state and the Host does not move to 'Running' state.
  There is still some level of missing support on 1110-ghe, and this
  needs testing once we have all the missing support is enabled.