### PR TITLE
Add GET and Action for Panel Functions (#771)(#773)

### DIFF
--- a/redfish-core/include/redfish.hpp
+++ b/redfish-core/include/redfish.hpp
@@ -192,7 +192,7 @@ class RedfishService
         requestRoutesMemory(app);
 
         requestRoutesSystems(app);
-
+        requestRoutesSystemActionsOemExecutePanelFunction(app);
         requestRoutesBiosService(app);
         requestRoutesBiosSettings(app);
         requestRoutesBiosAttributeRegistry(app);

--- a/redfish-core/lib/systems.hpp
+++ b/redfish-core/lib/systems.hpp
@@ -47,8 +47,16 @@
 #include <sdbusplus/unpack_properties.hpp>
 
 #include <array>
+#include <cstdint>
+#include <functional>
+#include <memory>
+#include <optional>
+#include <ranges>
+#include <string>
 #include <string_view>
+#include <utility>
 #include <variant>
+#include <vector>
 
 namespace redfish
 {
@@ -2742,6 +2750,171 @@ inline void
     BMCWEB_LOG_DEBUG("EXIT: Get idle power saver parameters");
 }
 
+/*
+ * Handle Enabled Panel Functions
+ */
+inline void doGetEnabledPanelFunctions(
+    const std::shared_ptr<bmcweb::AsyncResp>& asyncResp,
+    std::function<void(const boost::system::error_code& ec,
+                       const std::vector<uint8_t>&)>&& callback)
+{
+    BMCWEB_LOG_DEBUG("Get Enabled Panel functions");
+
+    crow::connections::systemBus->async_method_call(
+        [asyncResp, callback](const boost::system::error_code& ec,
+                              const std::vector<uint8_t>& enabledFuncs) {
+        callback(ec, enabledFuncs);
+    },
+        "com.ibm.PanelApp", "/com/ibm/panel_app", "com.ibm.panel",
+        "getEnabledFunctions");
+}
+
+/*
+ * Get Enabled Panel Functions
+ */
+inline void getEnabledPanelFunctions(
+    const std::shared_ptr<bmcweb::AsyncResp>& asyncResp)
+{
+    doGetEnabledPanelFunctions(
+        asyncResp, [asyncResp](const boost::system::error_code& ec,
+                               const std::vector<uint8_t>& enabledFuncs) {
+        if (ec)
+        {
+            if (ec.value() != EBADR)
+            {
+                BMCWEB_LOG_ERROR("Get Enabled Panel Functions D-bus error: {}",
+                                 ec.value());
+                messages::internalError(asyncResp->res);
+            }
+            return;
+        }
+        nlohmann::json& oem = asyncResp->res.jsonValue["Oem"];
+        oem["@odata.type"] = "#OemComputerSystem.Oem";
+        oem["IBM"]["@odata.type"] = "#OemComputerSystem.IBM";
+        oem["IBM"]["EnabledPanelFunctions"] = enabledFuncs;
+    });
+}
+
+/**
+ * Execute a Panel Enabled Function
+ */
+inline void
+    executePanelFunction(const std::shared_ptr<bmcweb::AsyncResp>& asyncResp,
+                         const uint8_t funcNo)
+{
+    BMCWEB_LOG_DEBUG("Execute Panel function {}", std::to_string(funcNo));
+
+    crow::connections::systemBus->async_method_call(
+        [asyncResp,
+         funcNo](const boost::system::error_code& ec,
+                 const sdbusplus::message_t& msg,
+                 const std::tuple<bool, std::string, std::string>& result) {
+        if (ec)
+        {
+            const sd_bus_error* dbusError = msg.get_error();
+            if (dbusError == nullptr)
+            {
+                BMCWEB_LOG_ERROR("Execute a panel function D-bus error:  {}",
+                                 ec.value());
+                messages::internalError(asyncResp->res);
+                return;
+            }
+            if (dbusError->name ==
+                std::string_view("xyz.openbmc_project.Common.Error.NotAllowed"))
+            {
+                BMCWEB_LOG_WARNING("PanelFunction {} is not enabled",
+                                   std::to_string(funcNo));
+                messages::operationNotAllowed(asyncResp->res);
+                return;
+            }
+            if (dbusError->name ==
+                std::string_view(
+                    "xyz.openbmc_project.Common.Error.InternalFailure"))
+            {
+                BMCWEB_LOG_ERROR("ExecutePanelFunction {} is failed",
+                                 std::to_string(funcNo));
+                messages::operationFailed(asyncResp->res);
+                return;
+            }
+            BMCWEB_LOG_ERROR("Execute a panel function D-bus error:  {}",
+                             ec.value());
+            messages::internalError(asyncResp->res);
+            return;
+        }
+
+        if (!std::get<0>(result))
+        {
+            BMCWEB_LOG_ERROR("ExecutePanelFunction {} is failed",
+                             std::to_string(funcNo));
+            messages::operationFailed(asyncResp->res);
+            return;
+        }
+        asyncResp->res.jsonValue["Result"] = {std::get<1>(result),
+                                              std::get<2>(result)};
+        messages::success(asyncResp->res);
+    },
+        "com.ibm.PanelApp", "/com/ibm/panel_app", "com.ibm.panel",
+        "ExecuteFunction", funcNo);
+}
+
+inline void handleSystemActionsOemExecutePanelFunctionPost(
+    App& app, const crow::Request& req,
+    const std::shared_ptr<bmcweb::AsyncResp>& asyncResp)
+{
+    BMCWEB_LOG_DEBUG("handleSystemActionsOemExecutePanelFunctionPost...");
+    if (!redfish::setUpRedfishRoute(app, req, asyncResp))
+    {
+        return;
+    }
+
+    uint8_t funcNo = 0;
+    if (!json_util::readJsonAction(req, asyncResp->res, "FuncNo", funcNo))
+    {
+        BMCWEB_LOG_WARNING("Missing funcNo");
+        messages::actionParameterMissing(asyncResp->res, "ExecutePanelFunction",
+                                         "FuncNo");
+        return;
+    }
+
+    doGetEnabledPanelFunctions(
+        asyncResp,
+        [funcNo, asyncResp](const boost::system::error_code& ec,
+                            const std::vector<uint8_t>& enabledFuncs) {
+        if (ec)
+        {
+            BMCWEB_LOG_ERROR("Get Enabled Panel Functions D-bus error: {}",
+                             ec.value());
+            messages::internalError(asyncResp->res);
+            return;
+        }
+
+        auto it = std::ranges::find(enabledFuncs, funcNo);
+        if (it == enabledFuncs.end())
+        {
+            BMCWEB_LOG_WARNING("PanelFunction {} is not enabled",
+                               std::to_string(funcNo));
+            messages::operationNotAllowed(asyncResp->res);
+            return;
+        }
+        executePanelFunction(asyncResp, funcNo);
+    });
+}
+
+/**
+ * SystemActionsOemExecutePanelFunction class supports handle POST method for
+ * ExecutePanelFunction  action. The class retrieves and sends data directly to
+ * D-Bus.
+ */
+inline void requestRoutesSystemActionsOemExecutePanelFunction(App& app)
+{
+    BMCWEB_ROUTE(
+        app,
+        "/redfish/v1/Systems/system/Actions/Oem/OemComputerSystem.ExecutePanelFunction/")
+        .privileges(redfish::privileges::postComputerSystem)
+        .methods(boost::beast::http::verb::post)(std::bind_front(
+            handleSystemActionsOemExecutePanelFunctionPost, std::ref(app)));
+}
+
 /**
  * @brief Sets Idle Power Saver properties.
  *
@@ -3362,6 +3535,13 @@ inline void
     getTrustedModuleRequiredToBoot(asyncResp);
     getPowerMode(asyncResp);
     getIdlePowerSaver(asyncResp);
+
+    // Panel Function
+    getEnabledPanelFunctions(asyncResp);
+
+    nlohmann::json& actionOem = asyncResp->res.jsonValue["Actions"]["Oem"];
+    actionOem["#OemComputerSystem.v1_0_0.ExecutePanelFunction"]["target"] =
+        "/redfish/v1/Systems/system/Actions/Oem/OemComputerSystem.ExecutePanelFunction";
 }
 
 inline void handleComputerSystemPatch(

--- a/static/redfish/v1/$metadata/index.xml
+++ b/static/redfish/v1/$metadata/index.xml
@@ -5492,6 +5492,7 @@
     </edmx:Reference>
     <edmx:Reference Uri="/redfish/v1/schema/OemComputerSystem_v1.xml">
         <edmx:Include Namespace="OemComputerSystem"/>
+        <edmx:Include Namespace="OemComputerSystem.v1_0_0"/>
     </edmx:Reference>
     <edmx:Reference Uri="/redfish/v1/schema/OemVirtualMedia_v1.xml">
         <edmx:Include Namespace="OemVirtualMedia"/>

--- a/static/redfish/v1/JsonSchemas/OemComputerSystem/OemComputerSystem.json
+++ b/static/redfish/v1/JsonSchemas/OemComputerSystem/OemComputerSystem.json
@@ -160,6 +160,52 @@
                         "boolean",
                         "null"
                     ]
+                },
+                "EnabledPanelFunctions": {
+                    "description": "Enabled Panel functions",
+                    "longDescription": "This property shall contain the list of enabled panel functions.",
+                    "readonly": true,
+                    "type": [
+                        "array",
+                        "null"
+                    ]
+                }
+            },
+            "type": "object"
+        },
+        "ExecutePanelFunction": {
+            "additionalProperties": false,
+            "description": "This object executes a panel function",
+            "parameters": {
+                "FuncNo": {
+                    "description": "Panel function number.",
+                    "longDescription": "This parameter shall contain a  panel function number to be executed.",
+                    "type": "integer"
+                }
+            },
+            "patternProperties": {
+                "^([a-zA-Z_][a-zA-Z0-9_]*)?@(odata|Redfish|Message)\\.[a-zA-Z_][a-zA-Z0-9_]*$": {
+                    "description": "This property shall specify a valid odata or Redfish property.",
+                    "type": [
+                        "array",
+                        "boolean",
+                        "integer",
+                        "number",
+                        "null",
+                        "object",
+                        "string"
+                    ]
+                }
+            },
+            "properties": {
+                "target": {
+                    "description": "Link to invoke action",
+                    "format": "uri-reference",
+                    "type": "string"
+                },
+                "title": {
+                    "description": "Friendly action name",
+                    "type": "string"
                 }
             },
             "type": "object"

--- a/static/redfish/v1/schema/OemComputerSystem_v1.xml
+++ b/static/redfish/v1/schema/OemComputerSystem_v1.xml
@@ -45,6 +45,11 @@
                     <Annotation Term="OData.Description" String="An indicator allowing an operator to operate platform system attention."/>
                     <Annotation Term="OData.LongDescription" String="This property shall contain the state of the platform system attention of this resource."/>
                 </Property>
+                <Property Name="EnabledPanelFunctions" Type="OemComputerSystem.IBM">
+                  <Annotation Term="OData.Permissions" EnumMember="OData.Permission/Read"/>
+                  <Annotation Term="OData.Description" String="List of enabled panel functions."/>
+                  <Annotation Term="OData.LongDescription" String="This property shall contain the list of enabled panel functions."/>
+                </Property>
             </ComplexType>
 
             <ComplexType Name="OpenBmc" BaseType="Resource.OemObject">
@@ -85,6 +90,16 @@
                     <Annotation Term="OData.LongDescription" String="Platform firmware is provisioned and locked. So re-provisioning is not allowed in this state."/>
                 </Member>
             </EnumType>
+        </Schema>
+        <Schema xmlns="http://docs.oasis-open.org/odata/ns/edm" Namespace="OemComputerSystem.v1_0_0">
+            <Action Name="ExecutePanelFunction" IsBound="true">
+                <Annotation Term="OData.Description" String="This action executes a panel function."/>
+                <Annotation Term="OData.LongDescription" String="This action executes a panel function if the function is enabled."/>
+                <Parameter Name="FuncNo" Type="OemComputerSystem.v1_0_0.OemActions" Nullable="false">
+                    <Annotation Term="OData.Description" String="Panel function number."/>
+                    <Annotation Term="OData.LongDescription" String="This parameter shall contain a  panel function number to be executed."/>
+                </Parameter>
+            </Action>
         </Schema>
     </edmx:DataServices>
 </edmx:Edmx>


### PR DESCRIPTION
1. Add GET Panel EnabledFunctions (#771)

Add GET EnabledPanelFunctions in /redfish/v1/Systems/system.

An example output is:

```
curl -k -X GET https://${bmc}/redfish/v1/Systems/system
{
  "@odata.id": "/redfish/v1/Systems/system",
  "@odata.type": "#ComputerSystem.v1_16_0.ComputerSystem",
...
   "Oem": {
    "@odata.type": "#OemComputerSystem.Oem",
    "IBM": {
      "@odata.type": "#OemComputerSystem.IBM",
      "EnabledPanelFunctions": [
        21,
        22,
        65
      ],

```

Tested:
- Check `EnabledPanelFunctions` in /redfish/v1/Systems/system output
- Redfish Validator passed



2. Add Oem action to execute Panel function (#773)

Add an Oem Action to ExecutePanelFunction for Panel functions, and the action will be enabled and executable under a specific conditions (e.g. IBM i systems).

```
$ curl -k -X GET https://${bmc}/redfish/v1/Systems/system
{
...
  "Actions": {
    ...
    "Oem": {
      "#OemComputerSystem.v1_0_0.ExecutePanelFunction": {
        "target": "/redfish/v1/Systems/system/Actions/Oem/OemComputerSystem.ExecutePanelFunction"
      }
    }
  },
...
}
```

Action:

```
$ curl  -k -H "Content-Type: application/json" -X POST \
       https://${bmc}/redfish/v1/Systems/system/Actions/Oem/OemComputerSystem.ExecutePanelFunction \
         -d '{"FuncNo": <func-no>}'
```

Tested:

- Redfish validator passes

- Success case:
```
curl -k -H "Content-Type: application/json" -X POST \
    https://${bmc}:18080/redfish/v1/Systems/system/Actions/Oem/OemComputerSystem.ExecutePanelFunction \
    -d '{"FuncNo": 21}'
{
  "@Message.ExtendedInfo": [
    {
      "@odata.type": "#Message.v1_1_1.Message",
      "Message": "The request completed successfully.",
      "MessageArgs": [],
      "MessageId": "Base.1.13.0.Success",
      "MessageSeverity": "OK",
      "Resolution": "None"
    }
  ],
  "Result": [
    "21 00",
    ""
  ]
}%
```

- Failed case if the function is disabled:

```
curl -k -H "Content-Type: application/json" -X POST \
    https://${bmc}:18080/redfish/v1/Systems/system/Actions/Oem/OemComputerSystem.ExecutePanelFunction \
    -d '{"FuncNo": 21}'
{
  "error": {
    "@Message.ExtendedInfo": [
      {
        "@odata.type": "#Message.v1_1_1.Message",
        "Message": "The HTTP method is not allowed on this resource.",
        "MessageArgs": [],
        "MessageId": "Base.1.13.0.OperationNotAllowed",
        "MessageSeverity": "Critical",
        "Resolution": "None."
      }
    ],
    "code": "Base.1.13.0.OperationNotAllowed",
    "message": "The HTTP method is not allowed on this resource."
  }
}%
```

- Failed case if the function execution is failed:

```
curl -k -H "Content-Type: application/json" -X POST \
    https://${bmc}:18080/redfish/v1/Systems/system/Actions/Oem/OemComputerSystem.ExecutePanelFunction \
    -d '{"FuncNo": 21}'
{
  "error": {
    "@Message.ExtendedInfo": [
      {
        "@odata.type": "#Message.v1_1_1.Message",
        "Message": "An error occurred internal to the service as part of the overall request.  Partial results may have been returned.",
        "MessageArgs": [],
        "MessageId": "Base.1.13.0.OperationFailed",
        "MessageSeverity": "Warning",
        "Resolution": "Resubmit the request.  If the problem persists, consider resetting the service or provider."
      }
    ],
    "code": "Base.1.13.0.OperationFailed",
    "message": "An error occurred internal to the service as part of the overall request.  Partial results may have been returned."
  }
}%
```

- Internal error case:

```
curl -k -H "Content-Type: application/json" -X POST \
    https://${bmc}:18080/redfish/v1/Systems/system/Actions/Oem/OemComputerSystem.ExecutePanelFunction \
    -d '{"FuncNo": 21}'
{
  "error": {
    "@Message.ExtendedInfo": [
      {
        "@odata.type": "#Message.v1_1_1.Message",
        "Message": "The request failed due to an internal service error.  The service is still operational.",
        "MessageArgs": [],
        "MessageId": "Base.1.13.0.InternalError",
        "MessageSeverity": "Critical",
        "Resolution": "Resubmit the request.  If the problem persists, consider resetting the service."
      }
    ],
    "code": "Base.1.13.0.InternalError",
    "message": "The request failed due to an internal service error.  The service is still operational."
  }
}%
```