### PR TITLE
1110: Handle invalid dump attachment better as redfish NotFound (#706)(#735)

### DIFF
--- a/include/dump_utils.hpp
+++ b/include/dump_utils.hpp
@@ -1,0 +1,119 @@
+#pragma once
+
+#include "async_resp.hpp"
+#include "dbus_utility.hpp"
+#include "error_messages.hpp"
+#include "logging.hpp"
+#include "utility.hpp"
+
+#include <boost/algorithm/string/case_conv.hpp>
+#include <boost/system/error_code.hpp>
+#include <boost/url/format.hpp>
+#include <dbus_singleton.hpp>
+#include <sdbusplus/message/native_types.hpp>
+
+#include <cstddef>
+#include <string>
+
+namespace redfish
+{
+namespace dump_utils
+{
+
+inline void getValidDumpEntryForAttachment(
+    const std::shared_ptr<bmcweb::AsyncResp>& asyncResp, const std::string& url,
+    std::function<void(const std::string& objectPath,
+                       const std::string& /*entryID*/,
+                       const std::string& /*dumpType*/)>&& callback)
+{
+    std::string dumpType;
+    std::string dumpId;
+    std::string entryID;
+    std::string entriesPath;
+
+    if (crow::utility::readUrlSegments(url, "redfish", "v1", "Managers", "bmc",
+                                       "LogServices", "Dump", "Entries",
+                                       std::ref(entryID), "attachment"))
+    {
+        // BMC type dump
+        dumpType = "BMC";
+        entriesPath = "/redfish/v1/Managers/bmc/LogServices/Dump/Entries/";
+        dumpId = entryID;
+    }
+    else if (crow::utility::readUrlSegments(
+                 url, "redfish", "v1", "Systems", "system", "LogServices",
+                 "Dump", "Entries", std::ref(entryID), "attachment"))
+    {
+        entriesPath = "/redfish/v1/Systems/system/LogServices/Dump/Entries/";
+
+        // All these types system,resource,sbe,hwdump and host boot dumps are
+        // currently being listed under
+        // /Systems/system/LogServices/Dump/Entries/ redfish path. To
+        // differentiate between the two, the dump entries would be listed as
+        // System_<id> and Resource_<id> for the respective dumps. Hence the
+        // dump id and type are being extracted here from the above format.
+
+        std::size_t pos = entryID.find_first_of('_');
+        if (pos == std::string::npos || (pos + 1) >= entryID.length())
+        {
+            // Requested ID is invalid
+            messages::invalidObject(
+                asyncResp->res,
+                boost::urls::format(
+                    "/redfish/v1/Systems/system/LogServices/Dump/Entries/{}",
+                    entryID));
+            return;
+        }
+        dumpType = boost::algorithm::to_lower_copy(entryID.substr(0, pos));
+        dumpId = entryID.substr(pos + 1);
+    }
+
+    if (dumpType.empty() || entryID.empty())
+    {
+        // Besides of system,resource,sbe,hwdump and host boot dumps
+        redfish::messages::resourceNotFound(asyncResp->res, "Dump", entryID);
+        return;
+    }
+
+    auto getValidDumpEntryCallback =
+        [asyncResp, entryID, dumpType, dumpId, entriesPath,
+         callback](const boost::system::error_code& ec,
+                   const dbus::utility::ManagedObjectType& resp) {
+        if (ec.value() == EBADR)
+        {
+            messages::resourceNotFound(asyncResp->res, dumpType + " dump",
+                                       entryID);
+            return;
+        }
+        if (ec)
+        {
+            BMCWEB_LOG_ERROR("DumpEntry resp_handler got error {}", ec);
+            messages::internalError(asyncResp->res);
+            return;
+        }
+
+        std::string dumpEntryIdPath =
+            "/xyz/openbmc_project/dump/" +
+            std::string(boost::algorithm::to_lower_copy(dumpType)) + "/entry/" +
+            dumpId;
+
+        for (const auto& objectPath : resp)
+        {
+            if (objectPath.first.str == dumpEntryIdPath)
+            {
+                callback(dumpEntryIdPath, entryID, dumpType);
+                return;
+            }
+        }
+        BMCWEB_LOG_WARNING("Dump entry {} is not found", entryID);
+        messages::resourceNotFound(asyncResp->res, dumpType + " dump", entryID);
+    };
+
+    dbus::utility::getManagedObjects(
+        "xyz.openbmc_project.Dump.Manager",
+        sdbusplus::message::object_path("/xyz/openbmc_project/dump"),
+        std::move(getValidDumpEntryCallback));
+}
+
+} // namespace dump_utils
+} // namespace redfish


### PR DESCRIPTION
Handle invalid dump attachment better as NotFound (#706)(#735)

An invalid `/redfish/v1/Managers/bmc/LogServices/Dump/Entries/INVALID/attachment` or `/redfish/v1/Systems/system/LogServices/Dump/Entries/INVALID/attachment` generates non-redfish style error messages.

```
% curl -k -X GET https://${bmc}:18080/redfish/v1/Managers/bmc/LogServices/Dump/Entries/INVALID/attachment
% echo $?

Output:
This <BMC> page can’t be found
No webpage was found for the web address:
`https://<BMC>:18080/redfish/v1/Managers/bmc/LogServices/Dump/Entries/INVALID/attachment`

HTTP ERROR 404
```

```
$https://${bmc}:18080/redfish/v1/Managers/bmc/LogServices/Dump/Entries/INVALID/attachment
<BMC> is currently unable to handle this request.
HTTP ERROR 503
```

The better output will be like
```
{
  "error": {
    "@Message.ExtendedInfo": [
      {
        "@odata.type": "#Message.v1_1_1.Message",
        "Message": "The requested resource of type BMC dump named 'INVALID' was not found.",
        "MessageArgs": [
          "BMC dump",
          "INVALID"
        ],
        "MessageId": "Base.1.13.0.ResourceNotFound",
        "MessageSeverity": "Critical",
        "Resolution": "Provide a valid resource identifier and resubmit the request."
      }
    ],
    "code": "Base.1.13.0.ResourceNotFound",
    "message": "The requested resource of type BMC dump named 'INVALID' was not found."
  }
}
```

Tested:
 - Run valid or invalid attachment queries like
```
    % curl -k -X GET https://${bmc}:18080/redfish/v1/Managers/bmc/LogServices/Dump/Entries/1/attachment
    % curl -k -X GET https://${bmc}:18080/redfish/v1/Managers/bmc/LogServices/Dump/Entries/INVALID/attachment
    % curl -k -X GET https://${bmc}:18080/redfish/v1/Systems/system/LogServices/Dump/Entries/System_1/attachment
    % curl -k -X GET https://${bmc}:18080/redfish/v1/Systems/system/LogServices/Dump/Entries/INVALID/attachment
    % curl -k -X GET https://${bmc}:18080/redfish/v1/Systems/system/LogServices/Dump/Entries/Hostboot_2/attachment
```
 - Run redfish validator
