### PR TITLE
NetworkProtocol: Support NetworkSuppliedServers

### DIFF
--- a/redfish-core/lib/network_protocol.hpp
+++ b/redfish-core/lib/network_protocol.hpp
@@ -49,7 +49,8 @@ static constexpr std::array<std::pair<std::string_view, std::string_view>, 3>
 
 inline void extractNTPServersAndDomainNamesData(
     const dbus::utility::ManagedObjectType& dbusData,
-    std::vector<std::string>& ntpData, std::vector<std::string>& dnData)
+    std::vector<std::string>& ntpData, std::vector<std::string>& dynamicNtpData,
+    std::vector<std::string>& dnData)
 {
     for (const auto& obj : dbusData)
     {
@@ -71,6 +72,16 @@ inline void extractNTPServersAndDomainNamesData(
                     if (ntpServers != nullptr)
                     {
                         ntpData = *ntpServers;
+                    }
+                }
+                else if (propertyPair.first == "NTPServers")
+                {
+                    const std::vector<std::string>* dynamicNtpServers =
+                        std::get_if<std::vector<std::string>>(
+                            &propertyPair.second);
+                    if (dynamicNtpServers != nullptr)
+                    {
+                        dynamicNtpData = *dynamicNtpServers;
                     }
                 }
                 else if (propertyPair.first == "DomainName")
@@ -97,17 +108,19 @@ void getEthernetIfaceData(CallbackFunc&& callback)
             const boost::system::error_code errorCode,
             const dbus::utility::ManagedObjectType& dbusData) {
         std::vector<std::string> ntpServers;
+        std::vector<std::string> dynamicNtpServers;
         std::vector<std::string> domainNames;
 
         if (errorCode)
         {
-            callback(false, ntpServers, domainNames);
+            callback(false, ntpServers, dynamicNtpServers, domainNames);
             return;
         }
 
-        extractNTPServersAndDomainNamesData(dbusData, ntpServers, domainNames);
+        extractNTPServersAndDomainNamesData(dbusData, ntpServers,
+                                            dynamicNtpServers, domainNames);
 
-        callback(true, ntpServers, domainNames);
+        callback(true, ntpServers, dynamicNtpServers, domainNames);
     },
         "xyz.openbmc_project.Network", "/xyz/openbmc_project/network",
         "org.freedesktop.DBus.ObjectManager", "GetManagedObjects");
@@ -152,7 +165,7 @@ inline void getNetworkData(const std::shared_ptr<bmcweb::AsyncResp>& asyncResp,
         boost::beast::http::field::link,
         "</redfish/v1/JsonSchemas/ManagerNetworkProtocol/NetworkProtocol.json>; rel=describedby");
     asyncResp->res.jsonValue["@odata.type"] =
-        "#ManagerNetworkProtocol.v1_5_0.ManagerNetworkProtocol";
+        "#ManagerNetworkProtocol.v1_9_0.ManagerNetworkProtocol";
     asyncResp->res.jsonValue["@odata.id"] =
         "/redfish/v1/Managers/bmc/NetworkProtocol";
     asyncResp->res.jsonValue["Id"] = "NetworkProtocol";
@@ -189,6 +202,7 @@ inline void getNetworkData(const std::shared_ptr<bmcweb::AsyncResp>& asyncResp,
     getEthernetIfaceData(
         [hostName, asyncResp](const bool& success,
                               const std::vector<std::string>& ntpServers,
+                              const std::vector<std::string>& dynamicNtpServers,
                               const std::vector<std::string>& domainNames) {
         if (!success)
         {
@@ -197,6 +211,8 @@ inline void getNetworkData(const std::shared_ptr<bmcweb::AsyncResp>& asyncResp,
             return;
         }
         asyncResp->res.jsonValue["NTP"]["NTPServers"] = ntpServers;
+        asyncResp->res.jsonValue["NTP"]["NetworkSuppliedServers"] =
+            dynamicNtpServers;
         if (!hostName.empty())
         {
             std::string fqdn = hostName;
@@ -525,6 +541,7 @@ inline void requestRoutesNetworkProtocol(App& app)
                 [asyncResp, ntpServerObjects](
                     const bool success,
                     std::vector<std::string>& currentNtpServers,
+                    std::vector<std::string>& /*dynamicNtpServers*/,
                     const std::vector<std::string>& /*domainNames*/) {
                 if (!success)
                 {


### PR DESCRIPTION
Upstream : https://gerrit.openbmc.org/c/openbmc/bmcweb/+/71026
Fixes : https://jazz07.rchland.ibm.com:13443/jazz/web/projects/CSSD#action=com.ibm.team.workitem.viewWorkItem&id=599229

This commit re-introduces changes proposed earlier to support NetworkSuppliedServers property in bmcweb.
https://gerrit.openbmc.org/c/openbmc/bmcweb/+/52671

It helps to differentiate between the static and DHCP assigned NTP servers. Networkd and Dbus has added support for StaticNTPServers to save the static configuration.

Tested by:
 1. PATCH /redfish/v1/Managers/bmc/NetworkProtocol -d '{"NTP":{"NTPServers": [<ip>]}}' Verify that this adds the NTPs server to the NetworkProtocol
 2. Enable DHCP to fetch NTP servers list from the DHCP server. Verify that they are listed when GET on NetworkProtocol as below "NTP": { "NTPServers": [ <static ntp server ip> ], "NetworkSuppliedServers": [ <dynamic ntp server ip> ], "ProtocolEnabled": true },
 3. Redfish validator run

Change-Id: I22591ad6d49245bf74ef24dd68a51f015f6a8b07