### PR TITLE
1110: Add BMC_SHELL web-base_shell (#483)(#473)

### DIFF
--- a/http/websocket.hpp
+++ b/http/websocket.hpp
@@ -34,6 +34,8 @@ struct Connection : std::enable_shared_from_this<Connection>
     Connection& operator=(const Connection&) = delete;
     Connection& operator=(const Connection&&) = delete;
 
+    virtual const std::string& getUserName() const = 0;
+
     virtual void sendBinary(std::string_view msg) = 0;
     virtual void sendEx(MessageType type, std::string_view msg,
                         std::function<void()>&& onDone) = 0;
@@ -134,6 +136,11 @@ class ConnectionImpl : public Connection
         ws.async_accept(*ptr,
                         std::bind_front(&self_t::acceptDone, this,
                                         shared_from_this(), std::move(mobile)));
+    }
+
+    const std::string& getUserName() const override
+    {
+        return session->username;
     }
 
     void sendBinary(std::string_view msg) override

--- a/include/obmc_shell.hpp
+++ b/include/obmc_shell.hpp
@@ -1,0 +1,248 @@
+#pragma once
+
+#include "app.hpp"
+#include "logging.hpp"
+#include "websocket.hpp"
+
+#include <pty.h>
+#include <pwd.h>
+#include <sys/types.h>
+#include <sys/wait.h>
+#include <termios.h>
+
+#include <boost/asio/buffer.hpp>
+#include <boost/asio/posix/stream_descriptor.hpp>
+#include <boost/process/io.hpp>
+#include <boost/system/error_code.hpp>
+
+#include <array>
+#include <cstddef>
+#include <map>
+#include <memory>
+#include <string>
+#include <string_view>
+#include <variant>
+
+namespace crow
+{
+
+namespace obmc_shell
+{
+
+class Handler : public std::enable_shared_from_this<Handler>
+{
+  public:
+    explicit Handler(crow::websocket::Connection* conn) :
+        session(conn), streamFileDescriptor(conn->getIoContext())
+    {
+        outputBuffer.fill(0);
+    }
+
+    ~Handler() = default;
+
+    Handler(const Handler&) = delete;
+    Handler(Handler&&) = delete;
+    Handler& operator=(const Handler&) = delete;
+    Handler& operator=(Handler&&) = delete;
+
+    void doClose()
+    {
+        streamFileDescriptor.close();
+
+        // boost::process::child::terminate uses SIGKILL, need to send SIGTERM
+        int rc = kill(pid, SIGKILL);
+        session = nullptr;
+        if (rc != 0)
+        {
+            return;
+        }
+        waitpid(pid, nullptr, 0);
+    }
+
+    void connect()
+    {
+        pid = forkpty(&ttyFileDescriptor, nullptr, nullptr, nullptr);
+
+        if (pid == -1)
+        {
+            // ERROR
+            if (session != nullptr)
+            {
+                session->close("Error creating child process for login shell.");
+            }
+            return;
+        }
+        if (pid == 0)
+        {
+            // CHILD
+
+            auto userName = session->getUserName();
+            if (!userName.empty())
+            {
+                // NOLINTNEXTLINE(cppcoreguidelines-pro-type-vararg)
+                execl("/bin/login", "/bin/login", "-f", userName.c_str(), NULL);
+                // execl only returns on fail
+                BMCWEB_LOG_ERROR("execl() for /bin/login failed: {}", errno);
+                session->close("Internal Error Login failed");
+            }
+            else
+            {
+                session->close("Error session user name not found");
+            }
+            return;
+        }
+        if (pid > 0)
+        {
+            // PARENT
+
+            // for io operation assing file discriptor
+            // to boost stream_descriptor
+            streamFileDescriptor.assign(ttyFileDescriptor);
+            doWrite();
+            doRead();
+        }
+    }
+
+    void doWrite()
+    {
+        if (session == nullptr)
+        {
+            BMCWEB_LOG_DEBUG("session is closed");
+            return;
+        }
+        if (doingWrite)
+        {
+            BMCWEB_LOG_DEBUG("Already writing.  Bailing out");
+            return;
+        }
+
+        if (inputBuffer.empty())
+        {
+            BMCWEB_LOG_DEBUG("inputBuffer empty.  Bailing out");
+            return;
+        }
+
+        doingWrite = true;
+        streamFileDescriptor.async_write_some(
+            boost::asio::buffer(inputBuffer.data(), inputBuffer.size()),
+            [this, self(shared_from_this())](
+                const boost::system::error_code& ec, std::size_t bytesWritten) {
+            BMCWEB_LOG_DEBUG("Wrote {} bytes", bytesWritten);
+            doingWrite = false;
+            inputBuffer.erase(0, bytesWritten);
+            if (ec == boost::asio::error::eof)
+            {
+                session->close("ssh socket port closed");
+                return;
+            }
+            if (ec)
+            {
+                session->close("Error in writing to processSSH port");
+                BMCWEB_LOG_ERROR("Error in ssh socket write {}", ec);
+                return;
+            }
+            doWrite();
+        });
+    }
+
+    void doRead()
+    {
+        if (session == nullptr)
+        {
+            BMCWEB_LOG_DEBUG("session is closed");
+            return;
+        }
+        streamFileDescriptor.async_read_some(
+            boost::asio::buffer(outputBuffer.data(), outputBuffer.size()),
+            [this, self(shared_from_this())](
+                const boost::system::error_code& ec, std::size_t bytesRead) {
+            BMCWEB_LOG_DEBUG("Read done.  Read {} bytes", bytesRead);
+            if (session == nullptr)
+            {
+                BMCWEB_LOG_DEBUG("session is closed");
+                return;
+            }
+            if (ec)
+            {
+                BMCWEB_LOG_ERROR("Couldn't read from ssh port: {}", ec);
+                session->close("Error in connecting to ssh port");
+                return;
+            }
+            std::string_view payload(outputBuffer.data(), bytesRead);
+            session->sendBinary(payload);
+            doRead();
+        });
+    }
+
+    // this has to public
+    std::string inputBuffer;
+
+  private:
+    crow::websocket::Connection* session;
+    boost::asio::posix::stream_descriptor streamFileDescriptor;
+    bool doingWrite{false};
+    int ttyFileDescriptor{0};
+    pid_t pid{0};
+
+    std::array<char, 4096> outputBuffer{};
+};
+
+// NOLINTBEGIN(cppcoreguidelines-avoid-non-const-global-variables)
+static std::map<crow::websocket::Connection*, std::shared_ptr<Handler>>
+    mapHandler;
+// NOLINTEND(cppcoreguidelines-avoid-non-const-global-variables)
+
+inline void onOpen(crow::websocket::Connection& conn)
+{
+    BMCWEB_LOG_DEBUG("Connection {} opened", logPtr(&conn));
+    auto it = mapHandler.find(&conn);
+    if (it == mapHandler.end())
+    {
+        auto insertData = mapHandler.emplace(&conn,
+                                             std::make_shared<Handler>(&conn));
+        if (std::get<bool>(insertData))
+        {
+            std::get<0>(insertData)->second->connect();
+        }
+    }
+}
+
+inline void onClose(crow::websocket::Connection& conn,
+                    const std::string& reason)
+{
+    BMCWEB_LOG_DEBUG("bmc-shell console.onclose(reason = '{}')", reason);
+    auto it = mapHandler.find(&conn);
+    if (it != mapHandler.end())
+    {
+        it->second->doClose();
+        mapHandler.erase(it);
+    }
+}
+
+inline void onMessage(crow::websocket::Connection& conn,
+                      const std::string& data, [[maybe_unused]] bool isBinary)
+{
+    auto it = mapHandler.find(&conn);
+    if (it != mapHandler.end())
+    {
+        it->second->inputBuffer += data;
+        it->second->doWrite();
+    }
+    else
+    {
+        BMCWEB_LOG_ERROR("connection to socket not found");
+    }
+}
+
+inline void requestRoutes(App& app)
+{
+    BMCWEB_ROUTE(app, "/bmc-console")
+        .privileges({{"OemIBMPerformService"}})
+        .websocket()
+        .onopen(onOpen)
+        .onclose(onClose)
+        .onmessage(onMessage);
+}
+
+} // namespace obmc_shell
+} // namespace crow

--- a/meson.build
+++ b/meson.build
@@ -65,6 +65,7 @@ incdir = include_directories(
 
 feature_map = {
   'basic-auth'                                  : '-DBMCWEB_ENABLE_BASIC_AUTHENTICATION',
+  'bmc-shell-socket'                            : '-DBMCWEB_ENABLE_BMC_SHELL_WEBSOCKET',
   'cookie-auth'                                 : '-DBMCWEB_ENABLE_COOKIE_AUTHENTICATION',
   'event-subscription'                          : '-DBMCWEB_ENABLE_EVENT_SUBSCRIPTION_WEBSOCKET',
   'google-api'                                  : '-DBMCWEB_ENABLE_GOOGLE_API',

--- a/meson_options.txt
+++ b/meson_options.txt
@@ -396,6 +396,15 @@ option(
                     parameters such as only are not controlled by this option.'''
 )
 
+option(
+      'bmc-shell-socket',
+      type : 'feature',
+      value : 'enabled',
+      description : '''Enable BMC command shell WebSocket, which makes it
+                       possible to access secure shell. Path is
+                       \'/bmc-console\'.'''
+)
+
 option('ibm-led-extensions',
     type : 'feature',
     value : 'enabled',

--- a/src/webserver_main.cpp
+++ b/src/webserver_main.cpp
@@ -12,6 +12,7 @@
 #include "login_routes.hpp"
 #include "nbd_proxy.hpp"
 #include "obmc_console.hpp"
+#include "obmc_shell.hpp"
 #include "openbmc_dbus_rest.hpp"
 #include "redfish.hpp"
 #include "redfish_aggregator.hpp"
@@ -105,6 +106,10 @@ static int run()
 
 #ifdef BMCWEB_ENABLE_HOST_SERIAL_WEBSOCKET
     crow::obmc_console::requestRoutes(app);
+#endif
+
+#ifdef BMCWEB_ENABLE_BMC_SHELL_WEBSOCKET
+    crow::obmc_shell::requestRoutes(app);
 #endif
 
 #ifdef BMCWEB_ENABLE_VM_WEBSOCKET


### PR DESCRIPTION
This commit includes a web-based shell, making it possible to access secure shell servers through standard web browsers using WebSocket.

Path of WebSocket:
    wss://{hostname}/bmc-console

Implementation:

    So when bmcweb WebSocket gets a request for a new connection, it
    creates a child process of bmcweb using the forking bmcweb process
    (which begins a new process operating in a pseudoterminal).

    Then on that pseudoterminal call exec("/bin/sh") which replaces the
    current process image with a "/bin/sh" process image.

    bmcweb is communicating with that child process using
    stream_descriptor, similar to read write from a file descriptor,
    with asynchronous ability. So the shell can execute all commands
    like ls, cd, etc.

    WebSocket here only acts as a mediator between child process, which
    acts as a shell, and xterm.js, which write in NodeJS

Authorize user for Shell :

    Only service users can access this interface, which means only
    managers can access this interface.

Test:
    This commit gets tested using the xterm.js console.

    The essential operation can perform on this xterm console, Ex: ls,
    cd, grep, etc.

This change is downstream change only.