### PR TITLE
Use hypervisor n/w manager for hypervisor routes

### DIFF
--- a/redfish-core/lib/ethernet.hpp
+++ b/redfish-core/lib/ethernet.hpp
@@ -70,6 +70,7 @@ struct IPv6AddressData
     std::string address;
     std::string origin;
     uint8_t prefixLength = 0;
+    bool isActive{};
 };
 /**
  * Structure for keeping basic single Ethernet Interface information

--- a/redfish-core/lib/hypervisor_system.hpp
+++ b/redfish-core/lib/hypervisor_system.hpp
@@ -148,16 +148,168 @@ inline void
     });
 }
 
+inline bool translateSlaacEnabledToBool(const std::string& inputDHCP)
+{
+    return (
+        (inputDHCP ==
+         "xyz.openbmc_project.Network.EthernetInterface.DHCPConf.v6stateless") ||
+        (inputDHCP ==
+         "xyz.openbmc_project.Network.EthernetInterface.DHCPConf.v4v6stateless"));
+}
+
+inline bool translateDHCPEnabledToIPv6AutoConfig(const std::string& inputDHCP)
+{
+    return (inputDHCP ==
+            "xyz.openbmc_project.Network.EthernetInterface.DHCPConf.v4v6stateless") ||
+           (inputDHCP ==
+            "xyz.openbmc_project.Network.EthernetInterface.DHCPConf.v6stateless");
+}
+
+inline std::string
+    translateIPv6AutoConfigToDHCPEnabled(const std::string& inputDHCP,
+                                         const bool& ipv6AutoConfig)
+{
+    if (ipv6AutoConfig)
+    {
+        if ((inputDHCP ==
+             "xyz.openbmc_project.Network.EthernetInterface.DHCPConf.v4") ||
+            (inputDHCP ==
+             "xyz.openbmc_project.Network.EthernetInterface.DHCPConf.both"))
+        {
+            return "xyz.openbmc_project.Network.EthernetInterface.DHCPConf.v4v6stateless";
+        }
+        if ((inputDHCP ==
+             "xyz.openbmc_project.Network.EthernetInterface.DHCPConf.v6") ||
+            (inputDHCP ==
+             "xyz.openbmc_project.Network.EthernetInterface.DHCPConf.none"))
+        {
+            return "xyz.openbmc_project.Network.EthernetInterface.DHCPConf.v6stateless";
+        }
+    }
+    if (!ipv6AutoConfig)
+    {
+        if ((inputDHCP ==
+             "xyz.openbmc_project.Network.EthernetInterface.DHCPConf.v4v6stateless") ||
+            (inputDHCP ==
+             "xyz.openbmc_project.Network.EthernetInterface.DHCPConf.both"))
+        {
+            return "xyz.openbmc_project.Network.EthernetInterface.DHCPConf.v4";
+        }
+        if (inputDHCP ==
+            "xyz.openbmc_project.Network.EthernetInterface.DHCPConf.v6stateless")
+        {
+            return "xyz.openbmc_project.Network.EthernetInterface.DHCPConf.none";
+        }
+    }
+    return inputDHCP;
+}
+
 inline bool extractHypervisorInterfaceData(
     const std::string& ethIfaceId,
     const dbus::utility::ManagedObjectType& dbusData,
-    EthernetInterfaceData& ethData, std::vector<IPv4AddressData>& ipv4Config)
+    EthernetInterfaceData& ethData, std::vector<IPv4AddressData>& ipv4Config,
+    std::vector<IPv6AddressData>& ipv6Config)
 {
     bool idFound = false;
     for (const auto& objpath : dbusData)
     {
         for (const auto& ifacePair : objpath.second)
         {
+            IPv4AddressData& ipv4Address = ipv4Config.emplace_back();
+            IPv6AddressData& ipv6Address = ipv6Config.emplace_back();
+
+            for (std::string protocol : {"ipv4", "ipv6"})
+            {
+                std::string ipAddrObj = std::format(
+                    "/xyz/openbmc_project/network/hypervisor/{}/{}/addr0",
+                    ethIfaceId, protocol);
+                if (objpath.first == ipAddrObj)
+                {
+                    idFound = true;
+
+                    if (ifacePair.first == "xyz.openbmc_project.Network.IP")
+                    {
+                        const std::string* address = nullptr;
+                        const uint8_t* mask = nullptr;
+                        const std::string* gateway = nullptr;
+                        const std::string* origin = nullptr;
+
+                        const bool success = sdbusplus::unpackPropertiesNoThrow(
+                            dbus_utils::UnpackErrorPrinter(), ifacePair.second,
+                            "Address", address, "PrefixLength", mask, "Gateway",
+                            gateway, "Origin", origin);
+
+                        if (!success)
+                        {
+                            BMCWEB_LOG_INFO(
+                                "Failed to fetch dbus properties of Hypervisor IP Interface");
+                            return false;
+                        }
+                        if (address != nullptr)
+                        {
+                            if (protocol == "ipv4")
+                            {
+                                ipv4Address.address = *address;
+                            }
+                            else if (protocol == "ipv6")
+                            {
+                                ipv6Address.address = *address;
+                            }
+                        }
+
+                        if (mask != nullptr)
+                        {
+                            if (protocol == "ipv4")
+                            {
+                                ipv4Address.netmask = getNetmask(*mask);
+                            }
+                            else if (protocol == "ipv6")
+                            {
+                                ipv6Address.prefixLength = *mask;
+                            }
+                        }
+
+                        if (gateway != nullptr)
+                        {
+                            if (protocol == "ipv4")
+                            {
+                                ipv4Address.gateway = *gateway;
+                            }
+                        }
+
+                        if (origin != nullptr)
+                        {
+                            ipv4Address.origin =
+                                translateAddressOriginDbusToRedfish(*origin,
+                                                                    true);
+                        }
+                    }
+
+                    if (ifacePair.first == "xyz.openbmc_project.Object.Enable")
+                    {
+                        for (const auto& property : ifacePair.second)
+                        {
+                            if (property.first == "Enabled")
+                            {
+                                const bool* intfEnable =
+                                    std::get_if<bool>(&property.second);
+                                if (intfEnable != nullptr)
+                                {
+                                    if (protocol == "ipv4")
+                                    {
+                                        ipv4Address.isActive = *intfEnable;
+                                    }
+                                    else if (protocol == "ipv6")
+                                    {
+                                        ipv6Address.isActive = *intfEnable;
+                                    }
+                                    break;
+                                }
+                            }
+                        }
+                    }
+                }
+            }
             if (objpath.first ==
                 "/xyz/openbmc_project/network/hypervisor/" + ethIfaceId)
             {
@@ -180,96 +332,65 @@ inline bool extractHypervisorInterfaceData(
                 else if (ifacePair.first ==
                          "xyz.openbmc_project.Network.EthernetInterface")
                 {
-                    for (const auto& propertyPair : ifacePair.second)
+                    const std::string* dhcp = nullptr;
+                    const std::string* defaultGateway6 = nullptr;
+
+                    const bool success = sdbusplus::unpackPropertiesNoThrow(
+                        dbus_utils::UnpackErrorPrinter(), ifacePair.second,
+                        "DHCPEnabled", dhcp, "DefaultGateway6",
+                        defaultGateway6);
+                    if (!success)
                     {
-                        if (propertyPair.first == "DHCPEnabled")
-                        {
-                            const std::string* dhcp =
-                                std::get_if<std::string>(&propertyPair.second);
-                            if (dhcp != nullptr)
-                            {
-                                ethData.dhcpEnabled = *dhcp;
-                                break; // Interested on only "DHCPEnabled".
-                                       // Stop parsing since we got the
-                                       // "DHCPEnabled" value.
-                            }
-                        }
+                        BMCWEB_LOG_INFO(
+                            "Failed to fetch dbus properties of Hypervisor Ethernet Interface");
+                        return false;
                     }
-                }
-            }
-            if (objpath.first == "/xyz/openbmc_project/network/hypervisor/" +
-                                     ethIfaceId + "/ipv4/addr0")
-            {
-                IPv4AddressData& ipv4Address = ipv4Config.emplace_back();
-                if (ifacePair.first == "xyz.openbmc_project.Object.Enable")
-                {
-                    for (const auto& property : ifacePair.second)
+                    if (dhcp != nullptr)
                     {
-                        if (property.first == "Enabled")
+                        ethData.dhcpEnabled = *dhcp;
+                        if (!translateDhcpEnabledToBool(*dhcp, true))
                         {
-                            const bool* intfEnable =
-                                std::get_if<bool>(&property.second);
-                            if (intfEnable != nullptr)
-                            {
-                                ipv4Address.isActive = *intfEnable;
-                                break;
-                            }
-                        }
-                    }
-                }
-                if (ifacePair.first == "xyz.openbmc_project.Network.IP")
-                {
-                    for (const auto& property : ifacePair.second)
-                    {
-                        if (property.first == "Address")
-                        {
-                            const std::string* address =
-                                std::get_if<std::string>(&property.second);
-                            if (address != nullptr)
-                            {
-                                ipv4Address.address = *address;
-                            }
-                        }
-                        else if (property.first == "Origin")
-                        {
-                            const std::string* origin =
-                                std::get_if<std::string>(&property.second);
-                            if (origin != nullptr)
-                            {
-                                ipv4Address.origin =
-                                    translateAddressOriginDbusToRedfish(*origin,
-                                                                        true);
-                            }
-                        }
-                        else if (property.first == "PrefixLength")
-                        {
-                            const uint8_t* mask =
-                                std::get_if<uint8_t>(&property.second);
-                            if (mask != nullptr)
-                            {
-                                // convert it to the string
-                                ipv4Address.netmask = getNetmask(*mask);
-                            }
-                        }
-                        else if (property.first == "Type" ||
-                                 property.first == "Gateway")
-                        {
-                            // Type & Gateway is not used
-                            continue;
+                            ipv4Address.origin = "Static";
                         }
                         else
                         {
-                            BMCWEB_LOG_ERROR(
-                                "Got extra property: {} on the {} object",
-                                property.first, objpath.first.str);
+                            ipv4Address.origin = "DHCP";
+                        }
+
+                        if (!translateDhcpEnabledToBool(*dhcp, false))
+                        {
+                            if (!translateSlaacEnabledToBool(*dhcp))
+                            {
+                                ipv6Address.origin = "Static";
+                            }
+                            else
+                            {
+                                ipv6Address.origin = "SLAAC";
+                            }
+                        }
+                        else
+                        {
+                            ipv6Address.origin = "DHCP";
+                        }
+                    }
+
+                    if (defaultGateway6 != nullptr)
+                    {
+                        std::string defaultGateway6Str = *defaultGateway6;
+                        if (defaultGateway6Str.empty())
+                        {
+                            ethData.ipv6DefaultGateway = "::";
+                        }
+                        else
+                        {
+                            ethData.ipv6DefaultGateway = defaultGateway6Str;
                         }
                     }
                 }
             }
-            if (objpath.first == "/xyz/openbmc_project/network/hypervisor")
+            if (objpath.first ==
+                "/xyz/openbmc_project/network/hypervisor/config")
             {
-                // System configuration shows up in the global namespace, so no
-                // need to check eth number
                 if (ifacePair.first ==
                     "xyz.openbmc_project.Network.SystemConfiguration")
                 {
@@ -277,11 +398,11 @@ inline bool extractHypervisorInterfaceData(
                     {
                         if (propertyPair.first == "HostName")
                         {
-                            const std::string* hostName =
+                            const std::string* hostname =
                                 std::get_if<std::string>(&propertyPair.second);
-                            if (hostName != nullptr)
+                            if (hostname != nullptr)
                             {
-                                ethData.hostName = *hostName;
+                                ethData.hostName = *hostname;
                             }
                         }
                         else if (propertyPair.first == "DefaultGateway")
@@ -300,6 +421,7 @@ inline bool extractHypervisorInterfaceData(
     }
     return idFound;
 }
+
 /**
  * Function that retrieves all properties for given Hypervisor Ethernet
  * Interface Object from Settings Manager
@@ -311,247 +433,371 @@ template <typename CallbackFunc>
 void getHypervisorIfaceData(const std::string& ethIfaceId,
                             CallbackFunc&& callback)
 {
-    sdbusplus::message::object_path path("/");
+    sdbusplus::message::object_path path(
+        "/xyz/openbmc_project/network/hypervisor");
     dbus::utility::getManagedObjects(
-        "xyz.openbmc_project.Settings", path,
+        "xyz.openbmc_project.Network.Hypervisor", path,
         [ethIfaceId{std::string{ethIfaceId}},
          callback = std::forward<CallbackFunc>(callback)](
             const boost::system::error_code& ec,
             const dbus::utility::ManagedObjectType& resp) {
         EthernetInterfaceData ethData{};
         std::vector<IPv4AddressData> ipv4Data;
+        std::vector<IPv6AddressData> ipv6Data;
         if (ec)
         {
-            callback(false, ethData, ipv4Data);
+            callback(false, ethData, ipv4Data, ipv6Data);
             return;
         }
 
         bool found = extractHypervisorInterfaceData(ethIfaceId, resp, ethData,
-                                                    ipv4Data);
+                                                    ipv4Data, ipv6Data);
         if (!found)
         {
             BMCWEB_LOG_INFO("Hypervisor Interface not found");
-        }
-        callback(found, ethData, ipv4Data);
-    });
-}
-
-/**
- * @brief Sets the Hypervisor Interface IPAddress DBUS
- *
- * @param[in] asyncResp          Shared pointer for generating response message.
- * @param[in] ipv4Address    Address from the incoming request
- * @param[in] ethIfaceId     Hypervisor Interface Id
- *
- * @return None.
- */
-inline void setHypervisorIPv4Address(
-    const std::shared_ptr<bmcweb::AsyncResp>& asyncResp,
-    const std::string& ethIfaceId, const std::string& ipv4Address)
-{
-    BMCWEB_LOG_DEBUG("Setting the Hypervisor IPaddress : {} on Iface: {}",
-                     ipv4Address, ethIfaceId);
-    sdbusplus::asio::setProperty(
-        *crow::connections::systemBus, "xyz.openbmc_project.Settings",
-        "/xyz/openbmc_project/network/hypervisor/" + ethIfaceId + "/ipv4/addr0",
-        "xyz.openbmc_project.Network.IP", "Address", ipv4Address,
-        [asyncResp](const boost::system::error_code& ec) {
-        if (ec)
-        {
-            BMCWEB_LOG_ERROR("DBUS response error {}", ec);
             return;
         }
-        BMCWEB_LOG_DEBUG("Hypervisor IPaddress is Set");
+        callback(found, ethData, ipv4Data, ipv6Data);
     });
 }
 
 /**
- * @brief Sets the Hypervisor Interface SubnetMask DBUS
- *
- * @param[in] asyncResp     Shared pointer for generating response message.
- * @param[in] subnet    SubnetMask from the incoming request
- * @param[in] ethIfaceId Hypervisor Interface Id
- *
- * @return None.
- */
-inline void
-    setHypervisorIPv4Subnet(const std::shared_ptr<bmcweb::AsyncResp>& asyncResp,
-                            const std::string& ethIfaceId, const uint8_t subnet)
-{
-    BMCWEB_LOG_DEBUG("Setting the Hypervisor subnet : {} on Iface: {}", subnet,
-                     ethIfaceId);
-
-    sdbusplus::asio::setProperty(
-        *crow::connections::systemBus, "xyz.openbmc_project.Settings",
-        "/xyz/openbmc_project/network/hypervisor/" + ethIfaceId + "/ipv4/addr0",
-        "xyz.openbmc_project.Network.IP", "PrefixLength", subnet,
-        [asyncResp](const boost::system::error_code& ec) {
-        if (ec)
-        {
-            BMCWEB_LOG_ERROR("DBUS response error {}", ec);
-            return;
-        }
-        BMCWEB_LOG_DEBUG("SubnetMask is Set");
-    });
-}
-
-/**
- * @brief Sets the Hypervisor Interface Gateway DBUS
- *
- * @param[in] asyncResp          Shared pointer for generating response message.
- * @param[in] gateway        Gateway from the incoming request
- * @param[in] ethIfaceId     Hypervisor Interface Id
- *
- * @return None.
- */
-inline void setHypervisorIPv4Gateway(
-    const std::shared_ptr<bmcweb::AsyncResp>& asyncResp,
-    const std::string& gateway)
-{
-    BMCWEB_LOG_DEBUG(
-        "Setting the DefaultGateway to the last configured gateway");
-
-    sdbusplus::asio::setProperty(
-        *crow::connections::systemBus, "xyz.openbmc_project.Settings",
-        "/xyz/openbmc_project/network/hypervisor",
-        "xyz.openbmc_project.Network.SystemConfiguration", "DefaultGateway",
-        gateway, [asyncResp](const boost::system::error_code& ec) {
-        if (ec)
-        {
-            BMCWEB_LOG_ERROR("DBUS response error {}", ec);
-            return;
-        }
-        BMCWEB_LOG_DEBUG("Default Gateway is Set");
-    });
-}
-
-/**
- * @brief Creates a static IPv4 entry
- *
- * @param[in] ifaceId      Id of interface upon which to create the IPv4 entry
- * @param[in] prefixLength IPv4 prefix syntax for the subnet mask
- * @param[in] gateway      IPv4 address of this interfaces gateway
- * @param[in] address      IPv4 address to assign to this interface
- * @param[io] asyncResp    Response object that will be returned to client
- *
- * @return None
- */
-inline void
-    createHypervisorIPv4(const std::string& ifaceId, uint8_t prefixLength,
-                         const std::string& gateway, const std::string& address,
-                         const std::shared_ptr<bmcweb::AsyncResp>& asyncResp)
-{
-    setHypervisorIPv4Address(asyncResp, ifaceId, address);
-    setHypervisorIPv4Gateway(asyncResp, gateway);
-    setHypervisorIPv4Subnet(asyncResp, ifaceId, prefixLength);
-}
-
-/**
- * @brief Deletes given IPv4 interface
+ * @brief Deletes given IPv4/v6 interface
  *
  * @param[in] ifaceId     Id of interface whose IP should be deleted
+ * @param[in] protocol    Protocol (ipv4/ipv6)
  * @param[io] asyncResp   Response object that will be returned to client
  *
  * @return None
  */
 inline void
-    deleteHypervisorIPv4(const std::string& ifaceId,
-                         const std::shared_ptr<bmcweb::AsyncResp>& asyncResp)
+    deleteHypervisorIP(const std::string& ifaceId, const std::string& protocol,
+                       const std::shared_ptr<bmcweb::AsyncResp>& asyncResp)
 {
-    std::string address = "0.0.0.0";
-    std::string gateway = "0.0.0.0";
-    const uint8_t prefixLength = 0;
-    setHypervisorIPv4Address(asyncResp, ifaceId, address);
-    setHypervisorIPv4Gateway(asyncResp, gateway);
-    setHypervisorIPv4Subnet(asyncResp, ifaceId, prefixLength);
+    crow::connections::systemBus->async_method_call(
+        [asyncResp, ifaceId](const boost::system::error_code& ec) {
+        if (ec)
+        {
+            messages::internalError(asyncResp->res);
+            return;
+        }
+        boost::urls::url url = boost::urls::format(
+            "/redfish/v1/Systems/hypervisor/EthernetInterfaces/eth{}",
+            std::to_string(ifaceId.back()));
+        std::string eventOrigin = url.buffer();
+        redfish::EventServiceManager::getInstance().sendEvent(
+            redfish::messages::resourceChanged(), eventOrigin,
+            "EthernetInterface");
+    },
+        "xyz.openbmc_project.Network.Hypervisor",
+        std::format("/xyz/openbmc_project/network/hypervisor/{}/{}/addr0",
+                    ifaceId, protocol),
+        "xyz.openbmc_project.Object.Delete", "Delete");
 }
 
 inline void parseInterfaceData(nlohmann::json& jsonResponse,
                                const std::string& ifaceId,
                                const EthernetInterfaceData& ethData,
-                               const std::vector<IPv4AddressData>& ipv4Data)
+                               const std::vector<IPv4AddressData>& ipv4Data,
+                               const std::vector<IPv6AddressData>& ipv6Data)
 {
     jsonResponse["Id"] = ifaceId;
     jsonResponse["@odata.id"] = boost::urls::format(
         "/redfish/v1/Systems/hypervisor/EthernetInterfaces/{}", ifaceId);
-    jsonResponse["InterfaceEnabled"] = true;
     jsonResponse["MACAddress"] = ethData.macAddress;
 
     jsonResponse["HostName"] = ethData.hostName;
     jsonResponse["DHCPv4"]["DHCPEnabled"] =
         translateDhcpEnabledToBool(ethData.dhcpEnabled, true);
+    jsonResponse["StatelessAddressAutoConfig"]["IPv6AutoConfigEnabled"] =
+        translateDHCPEnabledToIPv6AutoConfig(ethData.dhcpEnabled);
+
+    if (translateDhcpEnabledToBool(ethData.dhcpEnabled, false))
+    {
+        jsonResponse["DHCPv6"]["OperatingMode"] = "Enabled";
+    }
+    else
+    {
+        jsonResponse["DHCPv6"]["OperatingMode"] = "Disabled";
+    }
 
     nlohmann::json& ipv4Array = jsonResponse["IPv4Addresses"];
     nlohmann::json& ipv4StaticArray = jsonResponse["IPv4StaticAddresses"];
     ipv4Array = nlohmann::json::array();
     ipv4StaticArray = nlohmann::json::array();
+    bool ipv4IsActive = false;
     for (const auto& ipv4Config : ipv4Data)
     {
         if (ipv4Config.isActive)
+        {
+            ipv4IsActive = ipv4Config.isActive;
+        }
+        if (!ipv4Config.address.empty())
         {
             nlohmann::json::object_t ipv4;
             ipv4["AddressOrigin"] = ipv4Config.origin;
             ipv4["SubnetMask"] = ipv4Config.netmask;
             ipv4["Address"] = ipv4Config.address;
-            ipv4["Gateway"] = ethData.defaultGateway;
+            ipv4["Gateway"] = ipv4Config.gateway;
 
             if (ipv4Config.origin == "Static")
             {
-                ipv4StaticArray.push_back(ipv4);
+                ipv4StaticArray.emplace_back(ipv4);
             }
             ipv4Array.emplace_back(std::move(ipv4));
         }
     }
-}
 
-inline void setDHCPEnabled(const std::string& ifaceId, bool ipv4DHCPEnabled,
-                           const std::shared_ptr<bmcweb::AsyncResp>& asyncResp)
-{
-    const std::string dhcp = getDhcpEnabledEnumeration(ipv4DHCPEnabled, false);
-    sdbusplus::asio::setProperty(
-        *crow::connections::systemBus, "xyz.openbmc_project.Settings",
-        "/xyz/openbmc_project/network/hypervisor/" + ifaceId,
-        "xyz.openbmc_project.Network.EthernetInterface", "DHCPEnabled", dhcp,
-        [asyncResp](const boost::system::error_code& ec) {
-        if (ec)
-        {
-            BMCWEB_LOG_ERROR("D-Bus responses error: {}", ec);
-            messages::internalError(asyncResp->res);
-            return;
-        }
-    });
-
-    // Set the IPv4 address origin to the DHCP / Static as per the new value
-    // of the DHCPEnabled property
-    std::string origin;
-    if (!ipv4DHCPEnabled)
+    std::string ipv6GatewayStr = ethData.ipv6DefaultGateway;
+    if (ipv6GatewayStr.empty())
     {
-        origin = "xyz.openbmc_project.Network.IP.AddressOrigin.Static";
+        ipv6GatewayStr = "::";
+    }
+
+    nlohmann::json& ipv6StaticDefaultGw =
+        jsonResponse["IPv6StaticDefaultGateways"];
+    ipv6StaticDefaultGw = nlohmann::json::array();
+    nlohmann::json& ipv6Array = jsonResponse["IPv6Addresses"];
+    nlohmann::json& ipv6StaticArray = jsonResponse["IPv6StaticAddresses"];
+    ipv6Array = nlohmann::json::array();
+    ipv6StaticArray = nlohmann::json::array();
+    nlohmann::json& ipv6AddrPolicyTable =
+        jsonResponse["IPv6AddressPolicyTable"];
+    ipv6AddrPolicyTable = nlohmann::json::array();
+    bool ipv6IsActive = false;
+
+    for (const auto& ipv6Config : ipv6Data)
+    {
+        if (ipv6Config.isActive)
+        {
+            ipv6IsActive = ipv6Config.isActive;
+        }
+        if (!ipv6Config.address.empty())
+        {
+            nlohmann::json::object_t ipv6;
+            ipv6["AddressOrigin"] = ipv6Config.origin;
+            ipv6["PrefixLength"] = ipv6Config.prefixLength;
+            ipv6["Address"] = ipv6Config.address;
+
+            if (ipv6Config.origin == "Static")
+            {
+                ipv6StaticArray.emplace_back(ipv6);
+                if (ipv6GatewayStr != "::")
+                {
+                    nlohmann::json::object_t ipv6StaticDefaultGwObj;
+                    ipv6StaticDefaultGwObj["Address"] = ipv6GatewayStr;
+                    ipv6StaticDefaultGw.emplace_back(ipv6StaticDefaultGwObj);
+                }
+            }
+            ipv6Array.emplace_back(std::move(ipv6));
+        }
+        jsonResponse["IPv6DefaultGateway"] = ipv6GatewayStr;
+    }
+
+    if (ipv4IsActive)
+    {
+        jsonResponse["InterfaceEnabled"] = true;
     }
     else
     {
-        // DHCPEnabled is set to true. Delete the current IPv4 settings
-        // to receive the new values from DHCP server.
-        deleteHypervisorIPv4(ifaceId, asyncResp);
-        origin = "xyz.openbmc_project.Network.IP.AddressOrigin.DHCP";
+        if (ipv6IsActive)
+        {
+            jsonResponse["InterfaceEnabled"] = true;
+        }
+        else
+        {
+            jsonResponse["InterfaceEnabled"] = false;
+        }
     }
+}
+
+inline void setIpv6DhcpOperatingMode(
+    const std::string& ifaceId, const EthernetInterfaceData& ethData,
+    const std::string& operatingMode,
+    const std::shared_ptr<bmcweb::AsyncResp>& asyncResp)
+{
+    if (operatingMode != "Enabled" && operatingMode != "Disabled")
+    {
+        messages::propertyValueIncorrect(asyncResp->res, "OperatingMode",
+                                         operatingMode);
+        return;
+    }
+    std::string ipv6DHCP;
+    if (ethData.dhcpEnabled ==
+            "xyz.openbmc_project.Network.EthernetInterface.DHCPConf.v4" ||
+        ethData.dhcpEnabled ==
+            "xyz.openbmc_project.Network.EthernetInterface.DHCPConf.both" ||
+        ethData.dhcpEnabled ==
+            "xyz.openbmc_project.Network.EthernetInterface.DHCPConf.v4v6stateless")
+    {
+        if (operatingMode == "Enabled")
+        {
+            ipv6DHCP =
+                "xyz.openbmc_project.Network.EthernetInterface.DHCPConf.both";
+        }
+        else if (operatingMode == "Disabled")
+        {
+            ipv6DHCP =
+                "xyz.openbmc_project.Network.EthernetInterface.DHCPConf.v4";
+        }
+    }
+    else if (
+        ethData.dhcpEnabled ==
+            "xyz.openbmc_project.Network.EthernetInterface.DHCPConf.none" ||
+        ethData.dhcpEnabled ==
+            "xyz.openbmc_project.Network.EthernetInterface.DHCPConf.v6" ||
+        ethData.dhcpEnabled ==
+            "xyz.openbmc_project.Network.EthernetInterface.DHCPConf.v6stateless")
+    {
+        if (operatingMode == "Enabled")
+        {
+            ipv6DHCP =
+                "xyz.openbmc_project.Network.EthernetInterface.DHCPConf.v6";
+        }
+        else if (operatingMode == "Disabled")
+        {
+            ipv6DHCP =
+                "xyz.openbmc_project.Network.EthernetInterface.DHCPConf.none";
+        }
+    }
+
     sdbusplus::asio::setProperty(
-        *crow::connections::systemBus, "xyz.openbmc_project.Settings",
-        "/xyz/openbmc_project/network/hypervisor/" + ifaceId + "/ipv4/addr0",
-        "xyz.openbmc_project.Network.IP", "Origin", origin,
-        [asyncResp](const boost::system::error_code& ec) {
+        *crow::connections::systemBus, "xyz.openbmc_project.Network.Hypervisor",
+        "/xyz/openbmc_project/network/hypervisor/" + ifaceId,
+        "xyz.openbmc_project.Network.EthernetInterface", "DHCPEnabled",
+        ipv6DHCP, [asyncResp](const boost::system::error_code& ec) {
         if (ec)
         {
-            BMCWEB_LOG_ERROR("DBUS response error {}", ec);
             messages::internalError(asyncResp->res);
-            return;
         }
-        BMCWEB_LOG_DEBUG("Hypervisor IPaddress Origin is Set");
     });
 }
 
+inline void setDHCPEnabled(const std::string& ifaceId,
+                           const EthernetInterfaceData& ethData,
+                           bool ipv4DHCPEnabled,
+                           const std::shared_ptr<bmcweb::AsyncResp>& asyncResp)
+{
+    std::string ipv4DHCP;
+    if (ethData.dhcpEnabled ==
+            "xyz.openbmc_project.Network.EthernetInterface.DHCPConf.v6" ||
+        ethData.dhcpEnabled ==
+            "xyz.openbmc_project.Network.EthernetInterface.DHCPConf.both")
+    {
+        if (ipv4DHCPEnabled)
+        {
+            ipv4DHCP =
+                "xyz.openbmc_project.Network.EthernetInterface.DHCPConf.both";
+        }
+        else
+        {
+            ipv4DHCP =
+                "xyz.openbmc_project.Network.EthernetInterface.DHCPConf.v6";
+        }
+    }
+    else if (
+        ethData.dhcpEnabled ==
+            "xyz.openbmc_project.Network.EthernetInterface.DHCPConf.none" ||
+        ethData.dhcpEnabled ==
+            "xyz.openbmc_project.Network.EthernetInterface.DHCPConf.v4")
+    {
+        if (ipv4DHCPEnabled)
+        {
+            ipv4DHCP =
+                "xyz.openbmc_project.Network.EthernetInterface.DHCPConf.v4";
+        }
+        else
+        {
+            ipv4DHCP =
+                "xyz.openbmc_project.Network.EthernetInterface.DHCPConf.none";
+        }
+    }
+    else if (
+        ethData.dhcpEnabled ==
+            "xyz.openbmc_project.Network.EthernetInterface.DHCPConf.v6stateless" ||
+        ethData.dhcpEnabled ==
+            "xyz.openbmc_project.Network.EthernetInterface.DHCPConf.v4v6stateless")
+    {
+        if (ipv4DHCPEnabled)
+        {
+            ipv4DHCP =
+                "xyz.openbmc_project.Network.EthernetInterface.DHCPConf.v4v6stateless";
+        }
+        else
+        {
+            ipv4DHCP =
+                "xyz.openbmc_project.Network.EthernetInterface.DHCPConf.v6stateless";
+        }
+    }
+    sdbusplus::asio::setProperty(
+        *crow::connections::systemBus, "xyz.openbmc_project.Network.Hypervisor",
+        "/xyz/openbmc_project/network/hypervisor/" + ifaceId,
+        "xyz.openbmc_project.Network.EthernetInterface", "DHCPEnabled",
+        ipv4DHCP, [asyncResp](const boost::system::error_code& ec) {
+        if (ec)
+        {
+            messages::internalError(asyncResp->res);
+        }
+    });
+    // Set the IPv4 address origin to the DHCP / Static as per the new value
+    // of the DHCPEnabled property will be taken care by the dbus app
+}
+
+/**
+ * @brief Creates a static IPv4/v6 entry
+ *
+ * @param[in] ifaceId      Id of interface upon which to create the IPv4/v6
+ * entry
+ * @param[in] prefixLength IPv4/v6 prefix length
+ * @param[in] gateway      IPv4/v6 address of this interfaces gateway
+ * @param[in] address      IPv4/v6 address to assign to this interface
+ * @param[io] asyncResp    Response object that will be returned to client
+ *
+ * @return None
+ */
+inline void
+    createHypervisorIP(const std::string& ifaceId, const uint8_t prefixLength,
+                       const std::string& gateway, const std::string& address,
+                       const std::string& protocol,
+                       const std::shared_ptr<bmcweb::AsyncResp>& asyncResp)
+{
+    crow::connections::systemBus->async_method_call(
+        [asyncResp, ifaceId, address](const boost::system::error_code& ec) {
+        if (ec)
+        {
+            BMCWEB_LOG_DEBUG("createHypervisorIP failed: ec: {}, ec.value: {}",
+                             ec.message(), ec.value());
+            if ((ec == boost::system::errc::invalid_argument) ||
+                (ec == boost::system::errc::argument_list_too_long))
+            {
+                messages::invalidObject(
+                    asyncResp->res,
+                    boost::urls::format(
+                        "/redfish/v1/Systems/hypervisor/EthernetInterfaces/{}",
+                        ifaceId));
+            }
+            else if (ec == boost::system::errc::io_error)
+            {
+                messages::propertyValueFormatError(asyncResp->res, address,
+                                                   "Address");
+            }
+            else
+            {
+                messages::internalError(asyncResp->res);
+            }
+
+            return;
+        }
+    },
+        "xyz.openbmc_project.Network.Hypervisor",
+        "/xyz/openbmc_project/network/hypervisor/" + ifaceId,
+        "xyz.openbmc_project.Network.IP.Create", "IP", protocol, address,
+        prefixLength, gateway);
+}
+
 inline void handleHypervisorIPv4StaticPatch(
-    const std::string& ifaceId, const nlohmann::json& input,
+    const std::string& clientIp, const std::string& ifaceId,
+    const nlohmann::json& input, const EthernetInterfaceData& ethData,
     const std::shared_ptr<bmcweb::AsyncResp>& asyncResp)
 {
     if ((!input.is_array()) || input.empty())
@@ -637,20 +883,138 @@ inline void handleHypervisorIPv4StaticPatch(
             return;
         }
 
-        BMCWEB_LOG_DEBUG("Calling createHypervisorIPv4 on : {},{}", ifaceId,
-                         *address);
-        createHypervisorIPv4(ifaceId, prefixLength, *gateway, *address,
-                             asyncResp);
+        BMCWEB_LOG_ERROR(
+            "INFO: Static ip configuration request from client: {} - IP Address: {}, Gateway: {}, Prefix Length: {}",
+            clientIp, *address, *gateway, static_cast<int64_t>(prefixLength));
         // Set the DHCPEnabled to false since the Static IPv4 is set
-        setDHCPEnabled(ifaceId, false, asyncResp);
+        setDHCPEnabled(ifaceId, ethData, false, asyncResp);
+        BMCWEB_LOG_DEBUG("Calling createHypervisorIP on : {},{}", ifaceId,
+                         *address);
+        createHypervisorIP(ifaceId, prefixLength, *gateway, *address,
+                           "xyz.openbmc_project.Network.IP.Protocol.IPv4",
+                           asyncResp);
     }
     else
     {
         if (thisJson.is_null())
         {
-            deleteHypervisorIPv4(ifaceId, asyncResp);
+            deleteHypervisorIP(ifaceId, "ipv4", asyncResp);
         }
     }
+}
+
+inline void handleHypervisorIPv6StaticPatch(
+    const crow::Request& req, const std::string& ifaceId,
+    const nlohmann::json& input, const EthernetInterfaceData& ethData,
+    const std::shared_ptr<bmcweb::AsyncResp>& asyncResp)
+{
+    if ((!input.is_array()) || input.empty())
+    {
+        messages::propertyValueTypeError(asyncResp->res, input,
+                                         "IPv6StaticAddresses");
+        return;
+    }
+
+    // Hypervisor considers the first IP address in the array list
+    // as the Hypervisor's virtual management interface supports single IPv4
+    // address
+    const nlohmann::json& thisJson = input[0];
+
+    if (!thisJson.is_null() && !thisJson.empty())
+    {
+        // For the error string
+        std::string pathString = "IPv6StaticAddresses/1";
+        std::optional<std::string> address;
+        std::optional<uint8_t> prefixLen;
+        std::optional<std::string> gateway;
+        nlohmann::json thisJsonCopy = thisJson;
+        if (!json_util::readJson(thisJsonCopy, asyncResp->res, "Address",
+                                 address, "PrefixLength", prefixLen, "Gateway",
+                                 gateway))
+        {
+            messages::propertyValueFormatError(asyncResp->res, thisJson,
+                                               pathString);
+            return;
+        }
+
+        bool errorInEntry = false;
+        if (address)
+        {
+            if (!ip_util::ipv4VerifyIpAndGetBitcount(*address))
+            {
+                messages::propertyValueFormatError(asyncResp->res, *address,
+                                                   pathString + "/Address");
+                errorInEntry = true;
+            }
+        }
+        else
+        {
+            messages::propertyMissing(asyncResp->res, pathString + "/Address");
+            return;
+        }
+
+        if (gateway)
+        {
+            if (!ip_util::ipv4VerifyIpAndGetBitcount(*gateway))
+            {
+                messages::propertyValueFormatError(asyncResp->res, *gateway,
+                                                   pathString + "/Gateway");
+                errorInEntry = true;
+            }
+        }
+        else
+        {
+            // Since gateway is optional, replace it with default value
+            *gateway = "::";
+        }
+
+        if (!prefixLen)
+        {
+            messages::propertyMissing(asyncResp->res,
+                                      pathString + "/PrefixLength");
+            return;
+        }
+
+        if (errorInEntry)
+        {
+            return;
+        }
+
+        BMCWEB_LOG_ERROR(
+            "INFO: Static ip configuration request from client: {} - IP Address: {}, Gateway: {}, Prefix Length: {}",
+            req.session->clientIp, *address, *gateway,
+            static_cast<int64_t>(*prefixLen));
+        // Set the DHCPEnabled to false since the Static IPv6 is set
+        setIpv6DhcpOperatingMode(ifaceId, ethData, "Disabled", asyncResp);
+        createHypervisorIP(ifaceId, *prefixLen, *gateway, *address,
+                           "xyz.openbmc_project.Network.IP.Protocol.IPv6",
+                           asyncResp);
+    }
+    else
+    {
+        if (thisJson.is_null())
+        {
+            deleteHypervisorIP(ifaceId, "ipv6", asyncResp);
+        }
+    }
+}
+
+inline void handleHypervisorV6DefaultGatewayPatch(
+    const std::string& ifaceId, const std::string& ipv6DefaultGateway,
+    const std::shared_ptr<bmcweb::AsyncResp>& asyncResp)
+{
+    sdbusplus::asio::setProperty(
+        *crow::connections::systemBus, "xyz.openbmc_project.Network.Hypervisor",
+        "/xyz/openbmc_project/network/hypervisor/" + ifaceId,
+        "xyz.openbmc_project.Network.EthernetInterface", "DefaultGateway6",
+        ipv6DefaultGateway, [asyncResp](const boost::system::error_code& ec) {
+        if (ec)
+        {
+            BMCWEB_LOG_ERROR("Dbus error {}", ec.value());
+            messages::internalError(asyncResp->res);
+            return;
+        }
+    });
 }
 
 inline void handleHypervisorHostnamePatch(
@@ -666,13 +1030,37 @@ inline void handleHypervisorHostnamePatch(
 
     asyncResp->res.jsonValue["HostName"] = hostName;
     sdbusplus::asio::setProperty(
-        *crow::connections::systemBus, "xyz.openbmc_project.Settings",
-        "/xyz/openbmc_project/network/hypervisor/",
+        *crow::connections::systemBus, "xyz.openbmc_project.Network.Hypervisor",
+        "/xyz/openbmc_project/network/hypervisor/config",
         "xyz.openbmc_project.Network.SystemConfiguration", "HostName", hostName,
         [asyncResp](const boost::system::error_code& ec) {
         if (ec)
         {
+            BMCWEB_LOG_ERROR("Dbus error {}", ec.value());
             messages::internalError(asyncResp->res);
+            return;
+        }
+    });
+}
+
+inline void handleHypervisorSLAACAutoConfigPatch(
+    const std::string& ifaceId, const EthernetInterfaceData& ethData,
+    const bool& ipv6AutoConfigEnabled,
+    const std::shared_ptr<bmcweb::AsyncResp>& asyncResp)
+{
+    const std::string dhcp = translateIPv6AutoConfigToDHCPEnabled(
+        ethData.dhcpEnabled, ipv6AutoConfigEnabled);
+
+    sdbusplus::asio::setProperty(
+        *crow::connections::systemBus, "xyz.openbmc_project.Network.Hypervisor",
+        "/xyz/openbmc_project/network/hypervisor/" + ifaceId,
+        "xyz.openbmc_project.Network.EthernetInterface", "DHCPEnabled", dhcp,
+        [asyncResp](const boost::system::error_code& ec) {
+        if (ec)
+        {
+            BMCWEB_LOG_ERROR("Dbus error {}", ec.value());
+            messages::internalError(asyncResp->res);
+            return;
         }
     });
 }
@@ -682,13 +1070,15 @@ inline void
                             const std::shared_ptr<bmcweb::AsyncResp>& asyncResp)
 {
     sdbusplus::asio::setProperty(
-        *crow::connections::systemBus, "xyz.openbmc_project.Settings",
+        *crow::connections::systemBus, "xyz.openbmc_project.Network.Hypervisor",
         "/xyz/openbmc_project/network/hypervisor/" + ifaceId + "/ipv4/addr0",
         "xyz.openbmc_project.Object.Enable", "Enabled", isActive,
         [asyncResp](const boost::system::error_code& ec) {
         if (ec)
         {
+            BMCWEB_LOG_ERROR("Dbus error {}", ec.value());
             messages::internalError(asyncResp->res);
+            return;
         }
     });
 }
@@ -755,7 +1145,8 @@ inline void handleHypervisorEthernetInterfaceGet(
     getHypervisorIfaceData(
         id, [asyncResp, ifaceId{std::string(id)}](
                 bool success, const EthernetInterfaceData& ethData,
-                const std::vector<IPv4AddressData>& ipv4Data) {
+                const std::vector<IPv4AddressData>& ipv4Data,
+                const std::vector<IPv6AddressData>& ipv6Data) {
         if (!success)
         {
             messages::resourceNotFound(asyncResp->res, "EthernetInterface",
@@ -767,8 +1158,8 @@ inline void handleHypervisorEthernetInterfaceGet(
         asyncResp->res.jsonValue["Name"] = "Hypervisor Ethernet Interface";
         asyncResp->res.jsonValue["Description"] =
             "Hypervisor's Virtual Management Ethernet Interface";
-        parseInterfaceData(asyncResp->res.jsonValue, ifaceId, ethData,
-                           ipv4Data);
+        parseInterfaceData(asyncResp->res.jsonValue, ifaceId, ethData, ipv4Data,
+                           ipv6Data);
     });
 }
 
@@ -776,8 +1167,8 @@ inline void handleHypervisorSystemGet(
     const std::shared_ptr<bmcweb::AsyncResp>& asyncResp)
 {
     sdbusplus::asio::getProperty<std::string>(
-        *crow::connections::systemBus, "xyz.openbmc_project.Settings",
-        "/xyz/openbmc_project/network/hypervisor",
+        *crow::connections::systemBus, "xyz.openbmc_project.Network.Hypervisor",
+        "/xyz/openbmc_project/network/hypervisor/config",
         "xyz.openbmc_project.Network.SystemConfiguration", "HostName",
         [asyncResp](const boost::system::error_code& ec,
                     const std::string& /*hostName*/) {
@@ -820,14 +1211,22 @@ inline void handleHypervisorEthernetInterfacePatch(
     }
     std::optional<std::string> hostName;
     std::optional<std::vector<nlohmann::json>> ipv4StaticAddresses;
+    std::optional<std::vector<nlohmann::json>> ipv6StaticAddresses;
     std::optional<nlohmann::json> ipv4Addresses;
     std::optional<nlohmann::json> dhcpv4;
+    std::optional<nlohmann::json> dhcpv6;
     std::optional<bool> ipv4DHCPEnabled;
+    std::optional<std::string> ipv6OperatingMode;
+    std::optional<nlohmann::json> statelessAddressAutoConfig;
+    std::optional<bool> ipv6AutoConfigEnabled;
+    std::optional<std::vector<std::string>> ipv6StaticDefaultGateways;
 
-    if (!json_util::readJsonPatch(req, asyncResp->res, "HostName", hostName,
-                                  "IPv4StaticAddresses", ipv4StaticAddresses,
-                                  "IPv4Addresses", ipv4Addresses, "DHCPv4",
-                                  dhcpv4))
+    if (!json_util::readJsonPatch(
+            req, asyncResp->res, "HostName", hostName, "IPv4StaticAddresses",
+            ipv4StaticAddresses, "IPv6StaticAddresses", ipv6StaticAddresses,
+            "IPv4Addresses", ipv4Addresses, "DHCPv4", dhcpv4, "DHCPv6", dhcpv6,
+            "StatelessAddressAutoConfig", statelessAddressAutoConfig,
+            "IPv6StaticDefaultGateways", ipv6StaticDefaultGateways))
     {
         return;
     }
@@ -847,12 +1246,39 @@ inline void handleHypervisorEthernetInterfacePatch(
         }
     }
 
+    if (dhcpv6)
+    {
+        if (!json_util::readJson(*dhcpv6, asyncResp->res, "OperatingMode",
+                                 ipv6OperatingMode))
+        {
+            return;
+        }
+    }
+
+    if (statelessAddressAutoConfig)
+    {
+        if (!json_util::readJson(*statelessAddressAutoConfig, asyncResp->res,
+                                 "IPv6AutoConfigEnabled",
+                                 ipv6AutoConfigEnabled))
+        {
+            return;
+        }
+    }
+
+    const std::string& clientIp = req.session->clientIp;
     getHypervisorIfaceData(
-        ifaceId, [asyncResp, ifaceId, hostName = std::move(hostName),
-                  ipv4StaticAddresses = std::move(ipv4StaticAddresses),
-                  ipv4DHCPEnabled, dhcpv4 = std::move(dhcpv4)](
-                     bool success, const EthernetInterfaceData& ethData,
-                     const std::vector<IPv4AddressData>&) {
+        ifaceId,
+        [req, clientIp, asyncResp, ifaceId, hostName = std::move(hostName),
+         ipv4StaticAddresses = std::move(ipv4StaticAddresses),
+         ipv6StaticAddresses = std::move(ipv6StaticAddresses), ipv4DHCPEnabled,
+         dhcpv4 = std::move(dhcpv4), dhcpv6 = std::move(dhcpv6),
+         ipv6OperatingMode,
+         statelessAddressAutoConfig = std::move(statelessAddressAutoConfig),
+         ipv6StaticDefaultGateways = std::move(ipv6StaticDefaultGateways),
+         ipv6AutoConfigEnabled](const bool& success,
+                                const EthernetInterfaceData& ethData,
+                                const std::vector<IPv4AddressData>&,
+                                const std::vector<IPv6AddressData>&) {
         if (!success)
         {
             messages::resourceNotFound(asyncResp->res, "EthernetInterface",
@@ -892,7 +1318,45 @@ inline void handleHypervisorEthernetInterfacePatch(
             }
             else
             {
-                handleHypervisorIPv4StaticPatch(ifaceId, ipv4Static, asyncResp);
+                handleHypervisorIPv4StaticPatch(clientIp, ifaceId, ipv4Static,
+                                                ethData, asyncResp);
+            }
+            if (ipv6StaticAddresses)
+            {
+                const nlohmann::json& ipv6Static = *ipv6StaticAddresses;
+                if (ipv6Static.begin() == ipv6Static.end())
+                {
+                    messages::propertyValueTypeError(asyncResp->res, ipv6Static,
+                                                     "IPv6StaticAddresses");
+                    return;
+                }
+
+                // One and only one hypervisor instance supported
+                if (ipv6Static.size() != 1)
+                {
+                    messages::propertyValueFormatError(
+                        asyncResp->res, ipv6Static, "IPv6StaticAddresses");
+                    return;
+                }
+
+                const nlohmann::json& ipv6Json = ipv6Static[0];
+                // Check if the param is 'null'. If its null, it means
+                // that user wants to delete the IP address. Deleting
+                // the IP address is allowed only if its statically
+                // configured. Deleting the address originated from DHCP
+                // is not allowed.
+                if ((ipv6Json.is_null()) &&
+                    (translateDhcpEnabledToBool(ethData.dhcpEnabled, false)))
+                {
+                    BMCWEB_LOG_INFO(
+                        "Ignoring the delete on ipv6StaticAddresses "
+                        "as the interface is DHCP enabled");
+                }
+                else
+                {
+                    handleHypervisorIPv6StaticPatch(req, ifaceId, ipv6Static,
+                                                    ethData, asyncResp);
+                }
             }
         }
 
@@ -903,7 +1367,33 @@ inline void handleHypervisorEthernetInterfacePatch(
 
         if (dhcpv4)
         {
-            setDHCPEnabled(ifaceId, *ipv4DHCPEnabled, asyncResp);
+            setDHCPEnabled(ifaceId, ethData, *ipv4DHCPEnabled, asyncResp);
+        }
+
+        if (dhcpv6)
+        {
+            setIpv6DhcpOperatingMode(ifaceId, ethData, *ipv6OperatingMode,
+                                     asyncResp);
+        }
+
+        if (statelessAddressAutoConfig)
+        {
+            handleHypervisorSLAACAutoConfigPatch(
+                ifaceId, ethData, *ipv6AutoConfigEnabled, asyncResp);
+        }
+
+        if (ipv6StaticDefaultGateways)
+        {
+            const std::vector<std::string>& ipv6StaticDefaultGw =
+                *ipv6StaticDefaultGateways;
+            if ((ipv6StaticDefaultGw).size() > 1)
+            {
+                messages::propertyValueModified(asyncResp->res,
+                                                "IPv6StaticDefaultGateways",
+                                                ipv6StaticDefaultGw.front());
+            }
+            handleHypervisorV6DefaultGatewayPatch(
+                ifaceId, ipv6StaticDefaultGw.front(), asyncResp);
         }
 
         // Set this interface to disabled/inactive. This will be set
@@ -1038,7 +1528,6 @@ inline void requestRoutesHypervisorSystems(App& app)
      * HypervisorInterfaceCollection class to handle the GET and PATCH on
      * Hypervisor Interface
      */
-
     BMCWEB_ROUTE(app, "/redfish/v1/Systems/hypervisor/EthernetInterfaces/")
         .privileges(redfish::privileges::getEthernetInterfaceCollection)
         .methods(boost::beast::http::verb::get)(std::bind_front(


### PR DESCRIPTION
This commit adds support to update hypervisor ethernet interfaces routes to use hypervisor network manager dbus app.

Tested By:
[1] GET https://${bmc}/redfish/v1/Systems/hypervisor/EthernetInterfaces/eth0 [2] PATCH -d '{"DHCPv6": {"OperatingMode":"Disabled"}}' https://${bmc}/redfish/v1/Systems/hypervisor/EthernetInterfaces/eth0 [3] PATCH -d '{"StatelessAddressAutoConfig": {"IPv6AutoConfigEnabled":false}}' https://${bmc}/redfish/v1/Systems/hypervisor/EthernetInterfaces/eth0 [4] PATCH -D patch.txt -d '{"IPv4StaticAddresses": [{"Address": "<>", "SubnetMask": "<>", "Gateway": "<>"}]}' https://${bmc}/redfish/v1/Systems/hypervisor/EthernetInterfaces/eth0 [5] PATCH -D patch.txt -d '{"IPv6StaticAddresses": [{"Address": "", PrefixLength": <>}]}' https://${bmc}/redfish/v1/Systems/hypervisor/EthernetInterfaces/eth0