### PR TITLE
1110: Create Event Subscription meson build option

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -66,6 +66,7 @@ incdir = include_directories(
 feature_map = {
   'basic-auth'                                  : '-DBMCWEB_ENABLE_BASIC_AUTHENTICATION',
   'cookie-auth'                                 : '-DBMCWEB_ENABLE_COOKIE_AUTHENTICATION',
+  'event-subscription'                          : '-DBMCWEB_ENABLE_EVENT_SUBSCRIPTION_WEBSOCKET',
   'google-api'                                  : '-DBMCWEB_ENABLE_GOOGLE_API',
   'host-serial-socket'                          : '-DBMCWEB_ENABLE_HOST_SERIAL_WEBSOCKET',
   'ibm-management-console'                      : '-DBMCWEB_ENABLE_IBM_MANAGEMENT_CONSOLE',

--- a/meson_options.txt
+++ b/meson_options.txt
@@ -292,6 +292,13 @@ option(
 )
 
 option(
+    'event-subscription',
+    type : 'feature',
+    value : 'enabled',
+    description: 'Enable Event Subscription through websocket'
+)
+
+option(
     'experimental-redfish-multi-computer-system',
     type: 'feature',
     value: 'disabled',

--- a/src/webserver_main.cpp
+++ b/src/webserver_main.cpp
@@ -95,9 +95,12 @@ static int run()
 #endif
 
 #ifdef BMCWEB_ENABLE_DBUS_REST
-    crow::dbus_monitor::requestRoutes(app);
     crow::image_upload::requestRoutes(app);
     crow::openbmc_mapper::requestRoutes(app);
+#endif
+
+#ifdef BMCWEB_ENABLE_EVENT_SUBSCRIPTION_WEBSOCKET
+    crow::dbus_monitor::requestRoutes(app);
 #endif
 
 #ifdef BMCWEB_ENABLE_HOST_SERIAL_WEBSOCKET


### PR DESCRIPTION
This is a PR of 1060 [c7592df96dbffe46702778375a0b67023c7ae428](https://github.com/ibm-openbmc/bmcweb/commit/c7592df96dbffe46702778375a0b67023c7ae428).

Create a Meson build option to enable and disable event subscription at /subscribe. 
By default, this is enabled.

