### PR TITLE
1110: remove Item.Board from Power Redfish_util sensors (#491)

### DIFF
--- a/redfish-core/lib/power.hpp
+++ b/redfish-core/lib/power.hpp
@@ -294,8 +294,7 @@ inline void requestRoutesPower(App& app)
                 std::move(valueHandler));
         };
 
-        constexpr std::array<std::string_view, 2> interfaces = {
-            "xyz.openbmc_project.Inventory.Item.Board",
+        constexpr std::array<std::string_view, 1> interfaces = {
             "xyz.openbmc_project.Inventory.Item.Chassis"};
 
         dbus::utility::getSubTreePaths("/xyz/openbmc_project/inventory", 0,

--- a/redfish-core/lib/redfish_util.hpp
+++ b/redfish-core/lib/redfish_util.hpp
@@ -64,8 +64,7 @@ void getMainChassisId(std::shared_ptr<bmcweb::AsyncResp> asyncResp,
                       CallbackFunc&& callback)
 {
     // Find managed chassis
-    constexpr std::array<std::string_view, 2> interfaces = {
-        "xyz.openbmc_project.Inventory.Item.Board",
+    constexpr std::array<std::string_view, 1> interfaces = {
         "xyz.openbmc_project.Inventory.Item.Chassis"};
     dbus::utility::getSubTree(
         "/xyz/openbmc_project/inventory", 0, interfaces,

--- a/redfish-core/lib/sensors.hpp
+++ b/redfish-core/lib/sensors.hpp
@@ -517,8 +517,7 @@ void getChassis(const std::shared_ptr<bmcweb::AsyncResp>& asyncResp,
                 Callback&& callback)
 {
     BMCWEB_LOG_DEBUG("getChassis enter");
-    constexpr std::array<std::string_view, 2> interfaces = {
-        "xyz.openbmc_project.Inventory.Item.Board",
+    constexpr std::array<std::string_view, 1> interfaces = {
         "xyz.openbmc_project.Inventory.Item.Chassis"};
 
     // Get the Chassis Collection


### PR DESCRIPTION
bmcweb failed Project Redfish-Service-Validator

removing Item.Boars from below file will fix error we seen in vaildator
- redfish-core/lib/power.hpp
- redfish-core/lib/redfish_util.hpp
- redfish-core/lib/sensors.hpp