### PR TITLE
Bypass ACFWindow and PanelFunc without Backend

### DIFF
--- a/redfish-core/lib/systems.hpp
+++ b/redfish-core/lib/systems.hpp
@@ -2704,7 +2704,8 @@ inline void getEnabledPanelFunctions(
                                const std::vector<uint8_t>& enabledFuncs) {
         if (ec)
         {
-            if (ec.value() != EBADR)
+            if (ec.value() != EBADR &&
+                ec.value() != boost::asio::error::host_unreachable)
             {
                 BMCWEB_LOG_ERROR("Get Enabled Panel Functions D-bus error: {}",
                                  ec.value());


### PR DESCRIPTION
If Panel backend daemon is not running, redfish API may fail

```
Apr 25 20:57:35 p10bmc bmcweb[727]: [ERROR systems.hpp:2710] Get Enabled Panel Functions D-bus error: 113
Apr 25 20:57:35 p10bmc bmcweb[727]: [CRITICAL error_messages.cpp:286] Internal Error \
           /usr/src/debug/bmcweb/1.0+git/redfish-core/lib/systems.hpp(2711:40) \
          `redfish::getEnabledPanelFunctions(....)
Apr 25 20:57:35 p10bmc bmcweb[727]: [ERROR http_connection.hpp:514] 0x17bc500 Error while reading: stream truncated
```

Tested:
- Stop panel daemon
- redfsih GET passes
```
curl -k -X GET https://${bmc}:18080/redfish/v1/Systems/system
```