### PR TITLE
1110:CI-only: create detect-secrets baseline file

### DIFF
--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -1,0 +1,398 @@
+{
+  "exclude": {
+    "files": "^.secrets.baseline$",
+    "lines": null
+  },
+  "generated_at": "2024-04-29T18:24:07Z",
+  "plugins_used": [
+    {
+      "name": "AWSKeyDetector"
+    },
+    {
+      "name": "ArtifactoryDetector"
+    },
+    {
+      "name": "AzureStorageKeyDetector"
+    },
+    {
+      "base64_limit": 4.5,
+      "name": "Base64HighEntropyString"
+    },
+    {
+      "name": "BasicAuthDetector"
+    },
+    {
+      "name": "BoxDetector"
+    },
+    {
+      "name": "CloudantDetector"
+    },
+    {
+      "ghe_instance": "github.ibm.com",
+      "name": "GheDetector"
+    },
+    {
+      "name": "GitHubTokenDetector"
+    },
+    {
+      "hex_limit": 3,
+      "name": "HexHighEntropyString"
+    },
+    {
+      "name": "IbmCloudIamDetector"
+    },
+    {
+      "name": "IbmCosHmacDetector"
+    },
+    {
+      "name": "JwtTokenDetector"
+    },
+    {
+      "keyword_exclude": null,
+      "name": "KeywordDetector"
+    },
+    {
+      "name": "MailchimpDetector"
+    },
+    {
+      "name": "NpmDetector"
+    },
+    {
+      "name": "PrivateKeyDetector"
+    },
+    {
+      "name": "SlackDetector"
+    },
+    {
+      "name": "SoftlayerDetector"
+    },
+    {
+      "name": "SquareOAuthDetector"
+    },
+    {
+      "name": "StripeDetector"
+    },
+    {
+      "name": "TwilioKeyDetector"
+    }
+  ],
+  "results": {
+    "include/ibm/management_console_rest.hpp": [
+      {
+        "hashed_secret": "a5d8d6626c0903f7050f795ace6c3e11ce03a03e",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 71,
+        "type": "Base64 High Entropy String",
+        "verified_result": null
+      }
+    ],
+    "include/login_routes.hpp": [
+      {
+        "hashed_secret": "7ea97b5e992094fd78796dbb6a4a71605e9ad335",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 104,
+        "type": "Secret Keyword",
+        "verified_result": null
+      },
+      {
+        "hashed_secret": "22ea76d063ae12fc2d2fa71961013d09698e22f6",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 142,
+        "type": "Secret Keyword",
+        "verified_result": null
+      }
+    ],
+    "include/persistent_data.hpp": [
+      {
+        "hashed_secret": "126bdaffcfebda9cc80cd50862e689c700ba1ce3",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 291,
+        "type": "Secret Keyword",
+        "verified_result": null
+      }
+    ],
+    "redfish-core/include/generated/enums/account_service.hpp": [
+      {
+        "hashed_secret": "e60afa4cb8bac864902c5ec15e4a45ed7c142417",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 86,
+        "type": "Secret Keyword",
+        "verified_result": null
+      },
+      {
+        "hashed_secret": "2b6c9c8614a42875f59702bf0005c488c2b58f9b",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 87,
+        "type": "Secret Keyword",
+        "verified_result": null
+      },
+      {
+        "hashed_secret": "153822dd35de1468adcc77cc5f5e695e5b9540cd",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 88,
+        "type": "Secret Keyword",
+        "verified_result": null
+      },
+      {
+        "hashed_secret": "383171be88fb6fe8c5d5e7c11badfb669215adaf",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 89,
+        "type": "Secret Keyword",
+        "verified_result": null
+      },
+      {
+        "hashed_secret": "d8dec8e3d7a7c25cbd3a319927fa815cfdc74466",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 90,
+        "type": "Secret Keyword",
+        "verified_result": null
+      }
+    ],
+    "redfish-core/lib/account_service.hpp": [
+      {
+        "hashed_secret": "6303c901093123ff7019188dcd12b2e18d4d9827",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 914,
+        "type": "Secret Keyword",
+        "verified_result": null
+      },
+      {
+        "hashed_secret": "6e069300b0db722cc2ad4b1425a30ff5a8ae20cf",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 2347,
+        "type": "Secret Keyword",
+        "verified_result": null
+      }
+    ],
+    "redfish-core/lib/aggregation_service.hpp": [
+      {
+        "hashed_secret": "6e069300b0db722cc2ad4b1425a30ff5a8ae20cf",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 180,
+        "type": "Secret Keyword",
+        "verified_result": null
+      }
+    ],
+    "redfish-core/lib/certificate_service.hpp": [
+      {
+        "hashed_secret": "6303c901093123ff7019188dcd12b2e18d4d9827",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 644,
+        "type": "Secret Keyword",
+        "verified_result": null
+      }
+    ],
+    "redfish-core/lib/metric_report_definition.hpp": [
+      {
+        "hashed_secret": "e3984cf8d3e5e87a07a61c4a181596742ad43a17",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 544,
+        "type": "Base64 High Entropy String",
+        "verified_result": null
+      }
+    ],
+    "redfish-core/lib/virtual_media.hpp": [
+      {
+        "hashed_secret": "9ff784a7d46c5ebadd261a3882a096779463a085",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 481,
+        "type": "Secret Keyword",
+        "verified_result": null
+      },
+      {
+        "hashed_secret": "6303c901093123ff7019188dcd12b2e18d4d9827",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 642,
+        "type": "Secret Keyword",
+        "verified_result": null
+      }
+    ],
+    "scripts/generate_auth_certificates.py": [
+      {
+        "hashed_secret": "fcbdc4c271c889825d8338d2d8f10b6e5e95c171",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 205,
+        "type": "Secret Keyword",
+        "verified_result": null
+      }
+    ],
+    "static/redfish/v1/JsonSchemas/AccountService/AccountService.json": [
+      {
+        "hashed_secret": "0975b17977b1a9f8b77c999fd85a55a3c7715964",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 493,
+        "type": "Secret Keyword",
+        "verified_result": null
+      }
+    ],
+    "static/redfish/v1/JsonSchemas/AggregationSource/AggregationSource.json": [
+      {
+        "hashed_secret": "792f174d59d8e3e91d55a849a89b5e24ade433bd",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 587,
+        "type": "Secret Keyword",
+        "verified_result": null
+      }
+    ],
+    "static/redfish/v1/JsonSchemas/AttributeRegistry/AttributeRegistry.json": [
+      {
+        "hashed_secret": "76c3c4836dee37d8d0642949f84092a9a24bbf46",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 142,
+        "type": "Secret Keyword",
+        "verified_result": null
+      }
+    ],
+    "static/redfish/v1/JsonSchemas/EventDestination/EventDestination.json": [
+      {
+        "hashed_secret": "e8b34c2ea053a674198143f528a126805a5a8cf3",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 838,
+        "type": "Secret Keyword",
+        "verified_result": null
+      }
+    ],
+    "static/redfish/v1/JsonSchemas/ExternalAccountProvider/ExternalAccountProvider.json": [
+      {
+        "hashed_secret": "0975b17977b1a9f8b77c999fd85a55a3c7715964",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 173,
+        "type": "Secret Keyword",
+        "verified_result": null
+      }
+    ],
+    "static/redfish/v1/JsonSchemas/HostInterface/HostInterface.json": [
+      {
+        "hashed_secret": "d67125ebe93bdd1715ab74a4a274980198f55ed7",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 46,
+        "type": "Secret Keyword",
+        "verified_result": null
+      }
+    ],
+    "static/redfish/v1/JsonSchemas/LogService/LogService.json": [
+      {
+        "hashed_secret": "e8b34c2ea053a674198143f528a126805a5a8cf3",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 532,
+        "type": "Secret Keyword",
+        "verified_result": null
+      }
+    ],
+    "static/redfish/v1/JsonSchemas/PowerDistributionCollection/PowerDistributionCollection.json": [
+      {
+        "hashed_secret": "fc6f1bfbc0e17f8a67660a4bd9146625ca45da5f",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 94,
+        "type": "Base64 High Entropy String",
+        "verified_result": null
+      }
+    ],
+    "subprojects/boost.wrap": [
+      {
+        "hashed_secret": "a429043532b6f9d90070b4513070b9efc448351a",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 5,
+        "type": "Hex High Entropy String",
+        "verified_result": null
+      }
+    ],
+    "subprojects/gtest.wrap": [
+      {
+        "hashed_secret": "dbda4722c93011b7c69745ea81d88292a3e81c3b",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 6,
+        "type": "Hex High Entropy String",
+        "verified_result": null
+      },
+      {
+        "hashed_secret": "0db0cfa1e3520bf6206b5f63dc0f556257b7a20c",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 10,
+        "type": "Hex High Entropy String",
+        "verified_result": null
+      }
+    ],
+    "subprojects/nghttp2.wrap": [
+      {
+        "hashed_secret": "4dd3136267b15e50498b6ea702c5f8696df5d487",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 5,
+        "type": "Hex High Entropy String",
+        "verified_result": null
+      }
+    ],
+    "subprojects/nlohmann_json.wrap": [
+      {
+        "hashed_secret": "926bd63c13d632cd861d574a1524edc7f608d20e",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 6,
+        "type": "Hex High Entropy String",
+        "verified_result": null
+      }
+    ],
+    "subprojects/tinyxml2.wrap": [
+      {
+        "hashed_secret": "07712d524690ec779a0432d7ab6d739069d0c0fd",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 5,
+        "type": "Hex High Entropy String",
+        "verified_result": null
+      }
+    ],
+    "test/redfish-core/lib/log_services_test.cpp": [
+      {
+        "hashed_secret": "c0ecae135abbca200d2bc63088b97b1f6bc0042f",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 27,
+        "type": "Hex High Entropy String",
+        "verified_result": null
+      },
+      {
+        "hashed_secret": "524f0caea81576bf6ba91d4f0e6469933e6fc44f",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 28,
+        "type": "Hex High Entropy String",
+        "verified_result": null
+      }
+    ]
+  },
+  "version": "0.13.1+ibm.62.dss",
+  "word_list": {
+    "file": null,
+    "hash": null
+  }
+}


### PR DESCRIPTION
This creates a baseline file (and initial responses to any potential secrets found).

After this file is merged, all CI jobs after will run the detect-secrets tool against incoming commits to verify no potential secrets are being shared. If one is found, CI will fail until the .secrets.baseline is updated for the new issue.

See the following for more info:
https://github.com/IBM/detect-secrets