### PR TITLE
Update schema to enable panel CM (#575)

### DIFF
--- a/redfish-core/lib/assembly.hpp
+++ b/redfish-core/lib/assembly.hpp
@@ -256,12 +256,13 @@ void getAssemblyPresence(const std::shared_ptr<bmcweb::AsyncResp>& asyncResp,
     nlohmann::json& assemblyData = assemblyArray.at(assemblyIndex);
 
     assemblyData["Status"]["State"] = "Enabled";
+    assemblyData["Oem"]["OpenBMC"]["ReadyToRemove"] = false;
 
     sdbusplus::asio::getProperty<bool>(
         *crow::connections::systemBus, serviceName, assembly,
         "xyz.openbmc_project.Inventory.Item", "Present",
-        [asyncResp, assemblyIndex](const boost::system::error_code& ec,
-                                   const bool value) {
+        [asyncResp, assemblyIndex,
+         assembly](const boost::system::error_code& ec, const bool value) {
         if (ec)
         {
             BMCWEB_LOG_ERROR("DBUS response error: {}", ec.value());
@@ -269,11 +270,24 @@ void getAssemblyPresence(const std::shared_ptr<bmcweb::AsyncResp>& asyncResp,
             return;
         }
 
+        nlohmann::json& array = asyncResp->res.jsonValue["Assemblies"];
+        nlohmann::json& data = array.at(assemblyIndex);
         if (!value)
         {
-            nlohmann::json& array = asyncResp->res.jsonValue["Assemblies"];
-            nlohmann::json& data = array.at(assemblyIndex);
             data["Status"]["State"] = "Absent";
+
+            std::string fru =
+                sdbusplus::message::object_path(assembly).filename();
+            // Special handling for LCD and base panel CM.
+            if (fru == "panel0" || fru == "panel1")
+            {
+                data["Oem"]["OpenBMC"]["@odata.type"] =
+                    "#OemAssembly.v1_0_0.Assembly";
+
+                // if panel is not present, implies it is already removed or can
+                // be placed.
+                data["Oem"]["OpenBMC"]["ReadyToRemove"] = !value;
+            }
         }
     });
 }
@@ -686,6 +700,42 @@ inline void setAssemblyLocationIndicators(
                 "tod_battery")
             {
                 doBatteryCM(asyncResp, assembly, readytoremove.value());
+            }
+
+            // Special handling for LCD and base panel. This is required to
+            // support concurrent maintenance for base and LCD panel.
+            else if (sdbusplus::message::object_path(assembly).filename() ==
+                         "panel0" ||
+                     sdbusplus::message::object_path(assembly).filename() ==
+                         "panel1")
+            {
+                // Based on the status of readytoremove flag, inventory data
+                // like CCIN and present property needs to be updated for this
+                // FRU.
+                // readytoremove as true implies FRU has been prepared for
+                // removal. Set action as "deleteFRUVPD". This is the api
+                // exposed by vpd-manager to clear CCIN and set present
+                // property as false for the FRU.
+                // readytoremove as false implies FRU has been replaced. Set
+                // action as "CollectFRUVPD". This is the api exposed by
+                // vpd-manager to recollect vpd for a given FRU.
+                std::string action = (readytoremove.value()) ? "deleteFRUVPD"
+                                                             : "CollectFRUVPD";
+
+                crow::connections::systemBus->async_method_call(
+                    [asyncResp, action](const boost::system::error_code ec) {
+                    if (ec)
+                    {
+                        BMCWEB_LOG_ERROR(
+                            "Call to Manager failed for action:{} with error:{}",
+                            action, ec.value());
+                        messages::internalError(asyncResp->res);
+                        return;
+                    }
+                },
+                    "com.ibm.VPD.Manager", "/com/ibm/VPD/Manager",
+                    "com.ibm.VPD.Manager", action,
+                    sdbusplus::message::object_path(assembly));
             }
             else
             {


### PR DESCRIPTION
The commit makes required change to enable base and LCD panel CM on
Everest systems. To achieve that whenever the FRU is set for removal, CCIN
property needs to be cleared as some sensors are dependent of panel
presence and listening for CCIN property of the FRU.
Also post the FRU is replaced, vpd-manager is trigerred to collect VPD of the
FRU and restore its CCIN value and present property.

Test:
Ran validator, no new error

Redfish run result-
    {
      "@odata.id": "/redfish/v1/Chassis/chassis/Assembly#/Assemblies/2",
      "@odata.type": "#Assembly.v1_3_0.AssemblyData",
      "Location": {
        "PartLocation": {
          "ServiceLabel": "UABCC.ND0.0000111-D0"
        }
      },
      "LocationIndicatorActive": false,
      "MemberId": "2",
      "Model": "51F4",
      "Name": "panel0",
      "Oem": {
        "OpenBMC": {
          "@odata.type": "#OemAssembly.v1_0_0.Assembly",
          "ReadyToRemove": true
        }
      },

Change-Id: I117ca2b27826c672e3dbdec631fb1bc16dc2494c
Signed-off-by: Sunny Srivastava <sunnsr25@in.ibm.com>
Signed-off-by: Alpana Kumari <alpankum@in.ibm.com>
