### PR TITLE
Restrict the Operator role (#319) (#526)

### DIFF
--- a/redfish-core/lib/roles.hpp
+++ b/redfish-core/lib/roles.hpp
@@ -91,7 +91,7 @@ inline bool getOemPrivFromRole(std::string_view role, nlohmann::json& privArray)
 
 inline bool isRestrictedRole(const std::string& role)
 {
-    return role == "OemIBMServiceAgent";
+    return ((role == "Operator") || (role == "OemIBMServiceAgent"));
 }
 
 inline void requestRoutesRoles(App& app)


### PR DESCRIPTION
1110 update:
This is a straight cherry-pick of https://github.com/ibm-openbmc/bmcweb/commit/ca474f12a1d268c92901fc5c351698769c40b4f4 
It applied cleanly. 

1050 original commit msg:
* Restrict the Operator role (#319)

This changes the Operator role to Restricted=true which means no users can have the Operator role.

Tested:
1. GET /redfish/v1/AccountService/Roles/Operator and ensure it has Restricted:true.
2. POST /redfish/v1/AccountService/Accounts/new with Role:Operator Ensure it failed with message Base.1.9.0.RestrictedRole. Posting a new Administrator user is successful.
3. PATCH /redfish/v1/AccountService/Accounts/ordinary with Role:Operator.  Ensure it failed.
Changing a user to the ReadOnly role is successful.
4. PATCH the OemIBMServiceAgent role as the LocalRole within the RemoteRoleMapping property && ensure it failed.



* Fixup clang boolean expression
