### PR TITLE
1110:  Add EnvironmentMetrics - PowerWatts and FanSpeedPercent

### DIFF
--- a/Redfish.md
+++ b/Redfish.md
@@ -228,6 +228,10 @@ Fields common to all schemas
 
 #### EnvironmentMetrics
 
+- FanSpeedsPercent/DataSourceUri
+- FanSpeedsPercent/DeviceName
+- FanSpeedsPercent/SpeedRPM
+
 ### /redfish/v1/Chassis/{ChassisId}/Power/
 
 #### Power

--- a/Redfish.md
+++ b/Redfish.md
@@ -231,6 +231,7 @@ Fields common to all schemas
 - FanSpeedsPercent/DataSourceUri
 - FanSpeedsPercent/DeviceName
 - FanSpeedsPercent/SpeedRPM
+- PowerLimitWatts
 - PowerWatts
 
 ### /redfish/v1/Chassis/{ChassisId}/Power/

--- a/Redfish.md
+++ b/Redfish.md
@@ -231,6 +231,7 @@ Fields common to all schemas
 - FanSpeedsPercent/DataSourceUri
 - FanSpeedsPercent/DeviceName
 - FanSpeedsPercent/SpeedRPM
+- PowerWatts
 
 ### /redfish/v1/Chassis/{ChassisId}/Power/
 

--- a/redfish-core/include/utils/fan_utils.hpp
+++ b/redfish-core/include/utils/fan_utils.hpp
@@ -1,0 +1,56 @@
+#pragma once
+
+#include "async_resp.hpp"
+#include "dbus_utility.hpp"
+#include "error_messages.hpp"
+
+#include <boost/system/error_code.hpp>
+
+#include <array>
+#include <functional>
+#include <memory>
+#include <optional>
+#include <string>
+#include <string_view>
+#include <utility>
+
+namespace redfish
+{
+namespace fan_utils
+{
+constexpr std::array<std::string_view, 1> fanInterface = {
+    "xyz.openbmc_project.Inventory.Item.Fan"};
+
+inline void getFanPaths(
+    const std::shared_ptr<bmcweb::AsyncResp>& asyncResp,
+    const std::optional<std::string>& validChassisPath,
+    std::function<void(const dbus::utility::MapperGetSubTreePathsResponse&
+                           fanPaths)>&& callback)
+{
+    sdbusplus::message::object_path endpointPath{*validChassisPath};
+    endpointPath /= "cooled_by";
+
+    dbus::utility::getAssociatedSubTreePaths(
+        endpointPath,
+        sdbusplus::message::object_path("/xyz/openbmc_project/inventory"), 0,
+        fanInterface,
+        [asyncResp, callback{std::move(callback)}](
+            const boost::system::error_code& ec,
+            const dbus::utility::MapperGetSubTreePathsResponse& subtreePaths) {
+        if (ec)
+        {
+            if (ec.value() != EBADR)
+            {
+                BMCWEB_LOG_ERROR(
+                    "DBUS response error for getAssociatedSubTreePaths {}",
+                    ec.value());
+                messages::internalError(asyncResp->res);
+            }
+            return;
+        }
+        callback(subtreePaths);
+    });
+}
+
+} // namespace fan_utils
+} // namespace redfish

--- a/redfish-core/lib/environment_metrics.hpp
+++ b/redfish-core/lib/environment_metrics.hpp
@@ -1,18 +1,144 @@
 #pragma once
 
 #include "app.hpp"
+#include "dbus_utility.hpp"
+#include "error_messages.hpp"
 #include "query.hpp"
 #include "registries/privilege_registry.hpp"
+#include "str_utility.hpp"
 #include "utils/chassis_utils.hpp"
+#include "utils/fan_utils.hpp"
 
 #include <boost/url/format.hpp>
 
+#include <array>
+#include <cstdint>
+#include <functional>
 #include <memory>
 #include <optional>
 #include <string>
+#include <string_view>
 
 namespace redfish
 {
+inline void
+    updateFanSensorList(const std::shared_ptr<bmcweb::AsyncResp>& asyncResp,
+                        const std::string& chassisId,
+                        const std::string& fanSensorPath, double value)
+{
+    std::string fanSensorName =
+        sdbusplus::message::object_path(fanSensorPath).filename();
+    if (fanSensorName.empty())
+    {
+        BMCWEB_LOG_ERROR("Fan Sensor name is empty and invalid");
+        messages::internalError(asyncResp->res);
+        return;
+    }
+
+    nlohmann::json::object_t item;
+    item["DataSourceUri"] = boost::urls::format(
+        "/redfish/v1/Chassis/{}/Sensors/{}", chassisId, fanSensorName);
+    item["DeviceName"] = "Chassis #" + fanSensorName;
+    item["SpeedRPM"] = value;
+
+    nlohmann::json& fanSensorList =
+        asyncResp->res.jsonValue["FanSpeedsPercent"];
+    fanSensorList.emplace_back(std::move(item));
+    std::sort(fanSensorList.begin(), fanSensorList.end(),
+              [](const nlohmann::json& c1, const nlohmann::json& c2) {
+        return c1["DataSourceUri"] < c2["DataSourceUri"];
+    });
+    asyncResp->res.jsonValue["FanSpeedsPercent@odata.count"] =
+        fanSensorList.size();
+}
+
+inline void
+    getFanSensorsProperties(const std::shared_ptr<bmcweb::AsyncResp>& asyncResp,
+                            const std::string& chassisId,
+                            const std::string& path,
+                            const boost::system::error_code& ec,
+                            const dbus::utility::MapperGetObject& object)
+{
+    if (ec || object.empty())
+    {
+        BMCWEB_LOG_ERROR("DBUS response error {}", ec.value());
+        messages::internalError(asyncResp->res);
+        return;
+    }
+
+    const std::string& service = object.begin()->first;
+    sdbusplus::asio::getProperty<double>(
+        *crow::connections::systemBus, service, path,
+        "xyz.openbmc_project.Sensor.Value", "Value",
+        [asyncResp, chassisId, path](const boost::system::error_code& ec1,
+                                     const double value) {
+        if (ec1)
+        {
+            if (ec1.value() != EBADR)
+            {
+                BMCWEB_LOG_ERROR("DBUS response error {}", ec1.value());
+                messages::internalError(asyncResp->res);
+            }
+            return;
+        }
+
+        updateFanSensorList(asyncResp, chassisId, path, value);
+    });
+}
+
+inline void
+    getFanSensorValues(const std::shared_ptr<bmcweb::AsyncResp>& asyncResp,
+                       const std::string& chassisId,
+                       const boost::system::error_code& ec,
+                       const dbus::utility::MapperEndPoints& fanSensorPaths)
+{
+    constexpr std::array<std::string_view, 1> sensorInterface = {
+        "xyz.openbmc_project.Sensor.Value"};
+
+    if (ec)
+    {
+        if (ec.value() != EBADR)
+        {
+            BMCWEB_LOG_ERROR("DBUS response error {}", ec.value());
+            messages::internalError(asyncResp->res);
+            return;
+        }
+    }
+
+    for (const auto& fanSensorPath : fanSensorPaths)
+    {
+        dbus::utility::getDbusObject(fanSensorPath, sensorInterface,
+                                     std::bind_front(getFanSensorsProperties,
+                                                     asyncResp, chassisId,
+                                                     fanSensorPath));
+    }
+}
+
+inline void afterGetFanSpeedsPercent(
+    const std::shared_ptr<bmcweb::AsyncResp>& asyncResp,
+    const std::string& chassisId,
+    const dbus::utility::MapperGetSubTreePathsResponse& fanPaths)
+{
+    for (const std::string& fanPath : fanPaths)
+    {
+        sdbusplus::message::object_path endpointPath{fanPath};
+        endpointPath /= "sensors";
+
+        dbus::utility::getAssociationEndPoints(
+            endpointPath,
+            std::bind_front(getFanSensorValues, asyncResp, chassisId));
+    }
+}
+
+inline void
+    getFanSpeedsPercent(const std::shared_ptr<bmcweb::AsyncResp>& asyncResp,
+                        const std::string& validChassisPath,
+                        const std::string& chassisId)
+{
+    redfish::fan_utils::getFanPaths(
+        asyncResp, validChassisPath,
+        std::bind_front(afterGetFanSpeedsPercent, asyncResp, chassisId));
+}
 
 inline void handleEnvironmentMetricsHead(
     App& app, const crow::Request& req,
@@ -68,6 +194,8 @@ inline void handleEnvironmentMetricsGet(
         asyncResp->res.jsonValue["Id"] = "EnvironmentMetrics";
         asyncResp->res.jsonValue["@odata.id"] = boost::urls::format(
             "/redfish/v1/Chassis/{}/EnvironmentMetrics", chassisId);
+
+        getFanSpeedsPercent(asyncResp, *validChassisPath, chassisId);
     };
 
     redfish::chassis_utils::getValidChassisPath(asyncResp, chassisId,

--- a/redfish-core/lib/environment_metrics.hpp
+++ b/redfish-core/lib/environment_metrics.hpp
@@ -249,6 +249,128 @@ inline void getPowerWatts(const std::shared_ptr<bmcweb::AsyncResp>& asyncResp,
         "/xyz/openbmc_project/sensors", 0, interfaces,
         std::bind_front(afterGetPowerWatts, asyncResp, chassisId));
 }
+
+inline void
+    setPowerSetPoint(const std::shared_ptr<bmcweb::AsyncResp>& asyncResp,
+                     uint32_t powerCap)
+{
+    BMCWEB_LOG_DEBUG("Set Power Limit Watts Set Point");
+
+    sdbusplus::asio::setProperty(
+        *crow::connections::systemBus, "xyz.openbmc_project.Settings",
+        "/xyz/openbmc_project/control/host0/power_cap",
+        "xyz.openbmc_project.Control.Power.Cap", "PowerCap", powerCap,
+        [asyncResp](const boost::system::error_code& ec) {
+        if (ec)
+        {
+            BMCWEB_LOG_ERROR("Failed to set PowerCap: {}", ec.value());
+            messages::internalError(asyncResp->res);
+            return;
+        }
+    });
+}
+
+inline void
+    setPowerControlMode(const std::shared_ptr<bmcweb::AsyncResp>& asyncResp,
+                        const std::string& controlMode)
+{
+    BMCWEB_LOG_DEBUG("Set Power Limit Watts Control Mode");
+    bool powerCapEnable = false;
+    if (controlMode == "Disabled")
+    {
+        powerCapEnable = false;
+    }
+    else if (controlMode == "Automatic")
+    {
+        powerCapEnable = true;
+    }
+    else
+    {
+        BMCWEB_LOG_WARNING("Power Control Mode  does not support this mode: {}",
+                           controlMode);
+        messages::propertyValueNotInList(asyncResp->res, controlMode,
+                                         "ControlMode");
+        return;
+    }
+
+    sdbusplus::asio::setProperty(
+        *crow::connections::systemBus, "xyz.openbmc_project.Settings",
+        "/xyz/openbmc_project/control/host0/power_cap",
+        "xyz.openbmc_project.Control.Power.Cap", "PowerCapEnable",
+        powerCapEnable, [asyncResp](const boost::system::error_code& ec) {
+        if (ec)
+        {
+            BMCWEB_LOG_ERROR("Failed to set PowerCapEnable: {}", ec.value());
+            messages::internalError(asyncResp->res);
+            return;
+        }
+    });
+}
+
+inline void
+    getPowerLimitWatts(const std::shared_ptr<bmcweb::AsyncResp>& asyncResp)
+{
+    sdbusplus::asio::getAllProperties(
+        *crow::connections::systemBus, "xyz.openbmc_project.Settings",
+        "/xyz/openbmc_project/control/host0/power_cap",
+        "xyz.openbmc_project.Control.Power.Cap",
+        [asyncResp](const boost::system::error_code& ec,
+                    const dbus::utility::DBusPropertiesMap& propertiesList) {
+        if (ec)
+        {
+            if (ec.value() != EBADR)
+            {
+                BMCWEB_LOG_ERROR("DBUS response error: {}", ec.value());
+                messages::internalError(asyncResp->res);
+            }
+            return;
+        }
+
+        asyncResp->res.jsonValue["PowerLimitWatts"]["SetPoint"] = 0;
+        asyncResp->res.jsonValue["PowerLimitWatts"]["ControlMode"] =
+            "Automatic";
+
+        const uint32_t* powerCap = nullptr;
+        const bool* powerCapEnable = nullptr;
+        const uint32_t* minCap = nullptr;
+        const uint32_t* maxCap = nullptr;
+
+        const bool success = sdbusplus::unpackPropertiesNoThrow(
+            dbus_utils::UnpackErrorPrinter(), propertiesList, "PowerCap",
+            powerCap, "PowerCapEnable", powerCapEnable, "MinPowerCapValue",
+            minCap, "MaxPowerCapValue", maxCap);
+
+        if (!success)
+        {
+            messages::internalError(asyncResp->res);
+            return;
+        }
+
+        if (powerCap != nullptr)
+        {
+            asyncResp->res.jsonValue["PowerLimitWatts"]["SetPoint"] = *powerCap;
+        }
+
+        if (powerCapEnable != nullptr && !*powerCapEnable)
+        {
+            asyncResp->res.jsonValue["PowerLimitWatts"]["ControlMode"] =
+                "Disabled";
+        }
+
+        if (minCap != nullptr)
+        {
+            asyncResp->res.jsonValue["PowerLimitWatts"]["AllowableMin"] =
+                *minCap;
+        }
+
+        if (maxCap != nullptr)
+        {
+            asyncResp->res.jsonValue["PowerLimitWatts"]["AllowableMax"] =
+                *maxCap;
+        }
+    });
+}
+
 inline void handleEnvironmentMetricsGet(
     App& app, const crow::Request& req,
     const std::shared_ptr<bmcweb::AsyncResp>& asyncResp,
@@ -279,10 +401,52 @@ inline void handleEnvironmentMetricsGet(
 
         getFanSpeedsPercent(asyncResp, *validChassisPath, chassisId);
         getPowerWatts(asyncResp, chassisId);
+        getPowerLimitWatts(asyncResp);
     };
 
     redfish::chassis_utils::getValidChassisPath(asyncResp, chassisId,
                                                 std::move(respHandler));
+}
+
+inline void handleEnvironmentMetricsPatch(
+    App& app, const crow::Request& req,
+    const std::shared_ptr<bmcweb::AsyncResp>& asyncResp,
+    const std::string& chassisId)
+{
+    if (!redfish::setUpRedfishRoute(app, req, asyncResp))
+    {
+        return;
+    }
+
+    std::optional<uint32_t> setPoint;
+    std::optional<std::string> controlMode;
+    if (!json_util::readJsonPatch(req, asyncResp->res,
+                                  "PowerLimitWatts/SetPoint", setPoint,
+                                  "PowerLimitWatts/ControlMode", controlMode))
+    {
+        return;
+    }
+
+    redfish::chassis_utils::getValidChassisPath(
+        asyncResp, chassisId,
+        [asyncResp, chassisId, setPoint,
+         controlMode](const std::optional<std::string>& validChassisPath) {
+        if (!validChassisPath)
+        {
+            messages::resourceNotFound(asyncResp->res, "Chassis", chassisId);
+            return;
+        }
+
+        if (setPoint)
+        {
+            setPowerSetPoint(asyncResp, *setPoint);
+        }
+
+        if (controlMode)
+        {
+            setPowerControlMode(asyncResp, *controlMode);
+        }
+    });
 }
 
 inline void requestRoutesEnvironmentMetrics(App& app)
@@ -296,6 +460,11 @@ inline void requestRoutesEnvironmentMetrics(App& app)
         .privileges(redfish::privileges::getEnvironmentMetrics)
         .methods(boost::beast::http::verb::get)(
             std::bind_front(handleEnvironmentMetricsGet, std::ref(app)));
+
+    BMCWEB_ROUTE(app, "/redfish/v1/Chassis/<str>/EnvironmentMetrics/")
+        .privileges(redfish::privileges::patchEnvironmentMetrics)
+        .methods(boost::beast::http::verb::patch)(
+            std::bind_front(handleEnvironmentMetricsPatch, std::ref(app)));
 }
 
 } // namespace redfish


### PR DESCRIPTION
This is a redo of https://github.com/ibm-openbmc/bmcweb/pull/837, but this keeps 1060's behavior (as PR 837 is not working).

1060: Redfish: Implement EnvironmentMetrics

- Add FanSpeedsPercent
Upstream Link: https://gerrit.openbmc.org/c/openbmc/bmcweb/+/57715
Changed-Id: I4cfc0aa28d68e7e0fa947251363deb6f06e36225
- Add PowerWatts
Upstream Link: https://gerrit.openbmc.org/c/openbmc/bmcweb/+/57717
Changed-Id: Ibe84a5e7fe0d2b232f925e457a094c021ca85d36
- Add PowerLimitWantts:
Upstream Link: https://gerrit.openbmc.org/c/openbmc/bmcweb/+/47300
Changed-Id: Iacd244e537ccab6572a0a55b7f30871774e097ff

upstream: https://gerrit.openbmc.org/q/topic:%22redfish-EnvironmentMetrics%22

