### PR TITLE
Bmcweb: Add PcieSlots Location Code(#650)

### DIFF
--- a/redfish-core/lib/pcie_slots.hpp
+++ b/redfish-core/lib/pcie_slots.hpp
@@ -278,10 +278,34 @@ inline void
     });
 }
 
+inline void getLocationCode(const std::shared_ptr<bmcweb::AsyncResp>& asyncResp,
+                            const size_t index,
+                            const std::string& connectionName,
+                            const std::string& pcieSlotPath)
+{
+    sdbusplus::asio::getProperty<std::string>(
+        *crow::connections::systemBus, connectionName, pcieSlotPath,
+        "xyz.openbmc_project.Inventory.Decorator.LocationCode", "LocationCode",
+        [asyncResp, index](const boost::system::error_code& ec1,
+                           const std::string& property) {
+        if (ec1)
+        {
+            BMCWEB_LOG_ERROR(
+                "Can't get location code property for PCIeSlot, Error:{}",
+                ec1.value());
+            messages::internalError(asyncResp->res);
+            return;
+        }
+        asyncResp->res.jsonValue["Slots"][index]["Location"]["PartLocation"]
+                                ["ServiceLabel"] = property;
+    });
+}
+
 inline void
     onPcieSlotGetAllDone(const std::shared_ptr<bmcweb::AsyncResp>& asyncResp,
                          const boost::system::error_code& ec,
                          const dbus::utility::DBusPropertiesMap& propertiesList,
+                         const std::string& connectionName,
                          const std::string& pcieSlotPath)
 {
     if (ec)
@@ -379,6 +403,9 @@ inline void
     size_t index = slots.size();
     slots.emplace_back(std::move(slot));
 
+    // Get and set the location code
+    getLocationCode(asyncResp, index, connectionName, pcieSlotPath);
+
     // Get pcie device link
     addLinkedPcieDevices(asyncResp, pcieSlotPath, index);
 
@@ -436,10 +463,11 @@ inline void onMapperAssociationDone(
     sdbusplus::asio::getAllProperties(
         *crow::connections::systemBus, connectionName, pcieSlotPath,
         "xyz.openbmc_project.Inventory.Item.PCIeSlot",
-        [asyncResp,
+        [asyncResp, connectionName,
          pcieSlotPath](const boost::system::error_code& ec2,
                        const dbus::utility::DBusPropertiesMap& propertiesList) {
-        onPcieSlotGetAllDone(asyncResp, ec2, propertiesList, pcieSlotPath);
+        onPcieSlotGetAllDone(asyncResp, ec2, propertiesList, connectionName,
+                             pcieSlotPath);
     });
 }
 


### PR DESCRIPTION
This commit fixes this STG Defect 478749. This commit adds location code for pcieSlots.
 

Tested:
-Ran Redfish service validator,
 No new error and can see the Location code for pcieSlots

-Verified on Rainier100 system, Location code shows up for PCIedevices.

curl -k -X GET https://${bmc}/redfish/v1/Chassis/chassis/PCIeSlots {
  "Slots": [
    {
        "PCIeDevice": [
          {
            "@odata.id": "/redfish/v1/Systems/system/PCIeDevices/
                         motherboard_disk_backplane0_nvme2_dp0_drive2"
          }
        ]
      },
      "Location": {
        "PartLocation": {
          "ServiceLabel": "U78DA.ND0.       -P1-C2"
        }
      },
...
    },

Change-Id: I2bef85d9dbd95d5f0b923f5453c8cc72381ce546