### PR TITLE
1110: redfish-core: Processor: Workaround to handle DCM

### DIFF
--- a/redfish-core/lib/processor.hpp
+++ b/redfish-core/lib/processor.hpp
@@ -49,6 +49,55 @@ constexpr std::array<std::string_view, 2> processorInterfaces = {
     "xyz.openbmc_project.Inventory.Item.Accelerator"};
 
 /**
+ * @brief Workaround to handle DCM (Dual-Chip Module) package for Redfish
+ *
+ * Make sure processor modeled as dual chip module ("dcmN-cpuN"),
+ * If yes then, replace Redfish processor id as "dcmN/cpuN" and check with
+ * given object path because Redfish does not support chip module concept.
+ *
+ * @param[in] processorId - The Redfish processor Id
+ * @param[in] objectPath  - The D-Bus object path that contain the processor
+ *                          segment
+ *
+ * @return true if matched with the given object path else false.
+ *
+ * @note Inventory modeled as "dcmN/cpuN" to support DCM so wherever using
+ *       Redfish processor id as "dcmN-cpuN" then this function (it support
+ *       both SCM and DCM) can be used for the inventory processor object
+ *       path validation.
+ */
+inline bool
+    isProcObjectMatched(const std::string& processorId,
+                        const sdbusplus::message::object_path& objectPath)
+{
+    bool isMatched = false;
+    if (processorId.find("dcm") != std::string::npos)
+    {
+        std::size_t delimiterPos = processorId.find('-');
+        if (delimiterPos != std::string::npos)
+        {
+            std::string procParent = processorId.substr(0, delimiterPos);
+            std::string procId = processorId.substr(delimiterPos + 1,
+                                                    processorId.length());
+
+            if ((objectPath.parent_path().filename() == procParent) &&
+                (objectPath.filename() == procId))
+            {
+                isMatched = true;
+            }
+        }
+    }
+    else
+    {
+        if (objectPath.filename() == processorId)
+        {
+            isMatched = true;
+        }
+    }
+    return isMatched;
+}
+
+/**
  * @brief Fill out uuid info of a processor by
  * requesting data from the given D-Bus object.
  *
@@ -805,9 +854,8 @@ inline void getProcessorObject(const std::shared_ptr<bmcweb::AsyncResp>& resp,
         for (const auto& [objectPath, serviceMap] : subtree)
         {
             // Ignore any objects which don't end with our desired cpu name
-            sdbusplus::message::object_path path(objectPath);
-            std::string name = path.filename();
-            if (name != processorId)
+            if (!isProcObjectMatched(
+                    processorId, sdbusplus::message::object_path(objectPath)))
             {
                 continue;
             }
@@ -1229,9 +1277,8 @@ inline void afterSetProcessorObject(
     for (const auto& [objectPath, serviceMap] : subtree)
     {
         // Ignore any objects which don't end with our desired cpu name
-        sdbusplus::message::object_path path(objectPath);
-        std::string name = path.filename();
-        if (name != processorId)
+        if (!isProcObjectMatched(processorId,
+                                 sdbusplus::message::object_path(objectPath)))
         {
             continue;
         }
@@ -1337,7 +1384,8 @@ inline void requestRoutesOperatingConfigCollection(App& app)
 
             for (const std::string& object : objects)
             {
-                if (!object.ends_with(cpuName))
+                if (!isProcObjectMatched(
+                        cpuName, sdbusplus::message::object_path(object)))
                 {
                     continue;
                 }
@@ -1409,6 +1457,12 @@ inline void requestRoutesOperatingConfig(App& app)
             const std::string expectedEnding = cpuName + '/' + configName;
             for (const auto& [objectPath, serviceMap] : subtree)
             {
+                if (!isProcObjectMatched(
+                        cpuName, sdbusplus::message::object_path(objectPath)
+                                     .parent_path()))
+                {
+                    continue;
+                }
                 // Ignore any configs without matching cpuX/configY
                 if (!objectPath.ends_with(expectedEnding) || serviceMap.empty())
                 {
@@ -1434,6 +1488,62 @@ inline void requestRoutesOperatingConfig(App& app)
                                        configName);
         });
     });
+}
+
+inline void handleProcessors(
+    const std::shared_ptr<bmcweb::AsyncResp>& asyncResp,
+    const boost::system::error_code& ec,
+    const dbus::utility::MapperGetSubTreePathsResponse& objects)
+{
+    if (ec)
+    {
+        BMCWEB_LOG_ERROR("DBUS response error {}", ec.value());
+        messages::internalError(asyncResp->res);
+        return;
+    }
+    nlohmann::json& members = asyncResp->res.jsonValue["Members"];
+    members = nlohmann::json::array();
+
+    for (const auto& object : objects)
+    {
+        sdbusplus::message::object_path path(object);
+        std::string leaf;
+
+        /**
+         * @brief Workaround to handle DCM (Dual-Chip Module)
+         *        package for Redfish
+         *
+         * Make sure processor modeled as dual chip module,
+         * If yes then, replace redfish processor id as
+         * "dcmN-cpuN" because redfish does not support chip
+         * module concept.
+         *
+         * @note Inventory modeled as "dcmN/cpuN" so wherever
+         *       using redfish processor id as "dcmN-cpuN" then
+         *       that need to convert as "dcmN/cpuN" before
+         *       validating the inventory processor object path
+         */
+        if (path.parent_path().filename().find("dcm") != std::string::npos)
+        {
+            leaf = std::format("{}-{}", path.parent_path().filename(),
+                               path.filename());
+        }
+        else
+        {
+            leaf = path.filename();
+        }
+
+        if (leaf.empty())
+        {
+            continue;
+        }
+
+        nlohmann::json::object_t member;
+        member["@odata.id"] = boost::urls::format(
+            "/redfish/v1/Systems/system/Processors/{}", leaf);
+        members.emplace_back(std::move(member));
+    }
+    asyncResp->res.jsonValue["Members@odata.count"] = members.size();
 }
 
 inline void requestRoutesProcessorCollection(App& app)
@@ -1482,10 +1592,9 @@ inline void requestRoutesProcessorCollection(App& app)
         asyncResp->res.jsonValue["@odata.id"] =
             "/redfish/v1/Systems/system/Processors";
 
-        collection_util::getCollectionMembers(
-            asyncResp,
-            boost::urls::url("/redfish/v1/Systems/system/Processors"),
-            processorInterfaces, "/xyz/openbmc_project/inventory");
+        dbus::utility::getSubTreePaths(
+            "/xyz/openbmc_project/inventory", 0, processorInterfaces,
+            std::bind_front(handleProcessors, asyncResp));
     });
 }
 


### PR DESCRIPTION
This is a rebase of a single commit from https://github.com/ibm-openbmc/bmcweb/pull/542:
https://github.com/ibm-openbmc/bmcweb/commit/a7a3704428676da0886f4b1bef30cbb78d8c41dd

Also changes `afterSetProcessorObject()` to call the new function `isProcObjectMatched()`. This is a rebase of the equivalent call made with https://github.com/ibm-openbmc/bmcweb/commit/4dbe5ec81f8e11ba5f5e8e942715d04842f40814

Cleanup changes were made to follow current upstream coding style.

redfish-core: Processor: Workaround to handle DCM

- The BMC inventory modeled processor object as "dcmN/cpuN" to support DCM (Dual-Chip Module) package (that contains two processors) based on system model.

- The Redfish does not support "Chip Module" (DCM or MCM (Multi-Chip Module)) but, due to inventory changes ("dcmN/cpuN") the existing Processor schema support won't work i.e we will see it as like below so we cannot locate the correct cpu object into inventory when want to pull it details or it subunits details.
```
  -> "@odata.id": "/redfish/v1/Systems/system/Processors/cpu0  <--
  -> "@odata.id": "/redfish/v1/Systems/system/Processors/cpu1
  -> "@odata.id": "/redfish/v1/Systems/system/Processors/cpu0  <--
  -> "@odata.id": "/redfish/v1/Systems/system/Processors/cpu1
```

- In this patch, added a workaround to support DCM in the Redfish model until getting some better way in Redfish to support DCM.
  - There is a DMTF forum thread to track this. https://redfishforum.com/thread/434/model-dual-chip-module

Tested:

- Tested in DCM system model (Rainer 2s2u)
```
curl -k -H "X-Auth-Token: $bmc_token" -X GET \
https://${bmc}/redfish/v1/Systems/system/Processors

{
  "@odata.id": "/redfish/v1/Systems/system/Processors",
  "@odata.type": "#ProcessorCollection.ProcessorCollection",
  "Members": [
    {
      "@odata.id": "/redfish/v1/Systems/system/Processors/dcm0-cpu0"
    },
    {
      "@odata.id": "/redfish/v1/Systems/system/Processors/dcm0-cpu1"
    },
    {
      "@odata.id": "/redfish/v1/Systems/system/Processors/dcm1-cpu0"
    },
    {
      "@odata.id": "/redfish/v1/Systems/system/Processors/dcm1-cpu1"
    }
  ],
  "Members@odata.count": 4,
  "Name": "Processor Collection"
}
```

- Tested in SCM system model (Witherspoon)
```
curl -k -H "X-Auth-Token: $bmc_token" -X GET \
https://${bmc}/redfish/v1/Systems/system/Processors
{
  "@odata.id": "/redfish/v1/Systems/system/Processors",
  "@odata.type": "#ProcessorCollection.ProcessorCollection",
  "Members": [
    {
      "@odata.id": "/redfish/v1/Systems/system/Processors/cpu0"
    },
    {
      "@odata.id": "/redfish/v1/Systems/system/Processors/cpu1"
    },
    {
      "@odata.id": "/redfish/v1/Systems/system/Processors/gv100card0"
    },
    {
      "@odata.id": "/redfish/v1/Systems/system/Processors/gv100card1"
    },
    {
      "@odata.id": "/redfish/v1/Systems/system/Processors/gv100card2"
    },
    {
      "@odata.id": "/redfish/v1/Systems/system/Processors/gv100card3"
    },
    {
      "@odata.id": "/redfish/v1/Systems/system/Processors/gv100card4"
    },
    {
      "@odata.id": "/redfish/v1/Systems/system/Processors/gv100card5"
    }
  ],
  "Members@odata.count": 8,
  "Name": "Processor Collection"
}
```

Signed-off-by: Ramesh Iyyar <rameshi1@in.ibm.com>
Change-Id: I45085491a439b598dde137d890d456c465a3e4d7

Conflicts:
  redfish-core/lib/processor.hpp