### PR TITLE
1110: Add Redfish ChapData Refish OEM API (#794)(#798)

### DIFF
--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -3,7 +3,7 @@
     "files": "^.secrets.baseline$",
     "lines": null
   },
-  "generated_at": "2024-04-29T18:24:07Z",
+  "generated_at": "2024-05-08T21:40:58Z",
   "plugins_used": [
     {
       "name": "AWSKeyDetector"
@@ -202,6 +202,24 @@
         "is_verified": false,
         "line_number": 544,
         "type": "Base64 High Entropy String",
+        "verified_result": null
+      }
+    ],
+    "redfish-core/lib/systems.hpp": [
+      {
+        "hashed_secret": "6e069300b0db722cc2ad4b1425a30ff5a8ae20cf",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 2282,
+        "type": "Secret Keyword",
+        "verified_result": null
+      },
+      {
+        "hashed_secret": "efb7b9c519415e44a5f30819aaa9bf534f6afb27",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 2298,
+        "type": "Secret Keyword",
         "verified_result": null
       }
     ],

--- a/redfish-core/lib/systems.hpp
+++ b/redfish-core/lib/systems.hpp
@@ -2257,6 +2257,87 @@ inline void requestRoutesSystemActionsOemExecutePanelFunction(App& app)
             handleSystemActionsOemExecutePanelFunctionPost, std::ref(app)));
 }
 
+/*
+ * Get ChapData
+ */
+inline void getChapData(const std::shared_ptr<bmcweb::AsyncResp>& asyncResp)
+{
+    BMCWEB_LOG_DEBUG("Get ChapData");
+    sdbusplus::asio::getAllProperties(
+        *crow::connections::systemBus, "xyz.openbmc_project.PLDM",
+        "/xyz/openbmc_project/pldm", "com.ibm.PLDM.ChapData",
+        [asyncResp](const boost::system::error_code ec,
+                    const dbus::utility::DBusPropertiesMap& propertiesList) {
+        if (ec)
+        {
+            if (ec.value() != EBADR)
+            {
+                BMCWEB_LOG_ERROR("Get ChapData D-bus error: {}", ec.value());
+                messages::internalError(asyncResp->res);
+            }
+            return;
+        }
+
+        const std::string* chapName = nullptr;
+        const std::string* chapSecret = nullptr;
+        const bool success = sdbusplus::unpackPropertiesNoThrow(
+            dbus_utils::UnpackErrorPrinter(), propertiesList, "ChapName",
+            chapName, "ChapSecret", chapSecret);
+
+        if (!success)
+        {
+            messages::internalError(asyncResp->res);
+            return;
+        }
+
+        nlohmann::json& oemIBM = asyncResp->res.jsonValue["Oem"]["IBM"];
+        oemIBM["@odata.type"] = "#OemComputerSystem.IBM";
+
+        nlohmann::json& chapData = oemIBM["ChapData"];
+        chapData["ChapName"] = *chapName;
+        chapData["ChapSecret"] = *chapSecret;
+    });
+}
+
+/*
+ * Set ChapData
+ */
+inline void setChapData(const std::shared_ptr<bmcweb::AsyncResp>& asyncResp,
+                        std::optional<std::string> chapName,
+                        std::optional<std::string> chapSecret)
+{
+    BMCWEB_LOG_DEBUG("Set ChapData");
+    if (chapName)
+    {
+        sdbusplus::asio::setProperty(
+            *crow::connections::systemBus, "xyz.openbmc_project.PLDM",
+            "/xyz/openbmc_project/pldm", "com.ibm.PLDM.ChapData", "ChapName",
+            *chapName, [asyncResp](const boost::system::error_code& ec) {
+            if (ec)
+            {
+                BMCWEB_LOG_ERROR("DBUS response error: {}", ec.value());
+                messages::internalError(asyncResp->res);
+                return;
+            }
+        });
+    }
+
+    if (chapSecret)
+    {
+        sdbusplus::asio::setProperty(
+            *crow::connections::systemBus, "xyz.openbmc_project.PLDM",
+            "/xyz/openbmc_project/pldm", "com.ibm.PLDM.ChapData", "ChapSecret",
+            *chapSecret, [asyncResp](const boost::system::error_code& ec) {
+            if (ec)
+            {
+                BMCWEB_LOG_ERROR("DBUS response error: {}", ec.value());
+                messages::internalError(asyncResp->res);
+                return;
+            }
+        });
+    }
+}
+
 /**
  * @brief Sets Idle Power Saver properties.
  *
@@ -2852,6 +2933,9 @@ inline void
     nlohmann::json& actionOem = asyncResp->res.jsonValue["Actions"]["Oem"];
     actionOem["#OemComputerSystem.v1_0_0.ExecutePanelFunction"]["target"] =
         "/redfish/v1/Systems/system/Actions/Oem/OemComputerSystem.ExecutePanelFunction";
+
+    // ChapData
+    getChapData(asyncResp);
 }
 
 inline void handleComputerSystemPatch(
@@ -2998,12 +3082,16 @@ inline void handleComputerSystemPatch(
             std::optional<bool> platformSAI;
             std::optional<bool> pcieTopologyRefresh;
             std::optional<bool> savePCIeTopologyInfo;
+            std::optional<std::string> chapName;
+            std::optional<std::string> chapSecret;
             if (!json_util::readJson(
                     *ibmOem, asyncResp->res, "LampTest", lampTest,
                     "PartitionSystemAttentionIndicator", partitionSAI,
                     "PlatformSystemAttentionIndicator", platformSAI,
                     "PCIeTopologyRefresh", pcieTopologyRefresh,
-                    "SavePCIeTopologyInfo", savePCIeTopologyInfo))
+                    "SavePCIeTopologyInfo", savePCIeTopologyInfo,
+                    "ChapData/ChapName", chapName, "ChapData/ChapSecret",
+                    chapSecret))
             {
                 return;
             }
@@ -3024,10 +3112,13 @@ inline void handleComputerSystemPatch(
 #else
             std::optional<bool> pcieTopologyRefresh;
             std::optional<bool> savePCIeTopologyInfo;
-            if (!json_util::readJson(*ibmOem, asyncResp->res,
-                                     "PCIeTopologyRefresh", pcieTopologyRefresh,
-                                     "SavePCIeTopologyInfo",
-                                     savePCIeTopologyInfo))
+            std::optional<std::string> chapName;
+            std::optional<std::string> chapSecret;
+            if (!json_util::readJson(
+                    *ibmOem, asyncResp->res, "PCIeTopologyRefresh",
+                    pcieTopologyRefresh, "SavePCIeTopologyInfo",
+                    savePCIeTopologyInfo, "ChapData/ChapName", chapName,
+                    "ChapData/ChapSecret", chapSecret))
             {
                 return;
             }
@@ -3039,6 +3130,10 @@ inline void handleComputerSystemPatch(
             if (savePCIeTopologyInfo)
             {
                 setSavePCIeTopologyInfo(asyncResp, *savePCIeTopologyInfo);
+            }
+            if (chapName || chapSecret)
+            {
+                setChapData(asyncResp, chapName, chapSecret);
             }
         }
     }

--- a/static/redfish/v1/JsonSchemas/OemComputerSystem/OemComputerSystem.json
+++ b/static/redfish/v1/JsonSchemas/OemComputerSystem/OemComputerSystem.json
@@ -187,6 +187,50 @@
                         "array",
                         "null"
                     ]
+                },
+                "ChapData": {
+                    "$ref": "#/definitions/ChapData",
+                    "description": "ChapData.",
+                    "longDescription": "This property shall describe ChapData."
+                }
+            },
+            "type": "object"
+        },
+
+        "ChapData": {
+            "additionalProperties": false,
+            "description": "ChapData details to Host.",
+            "longDescription": "This type shall contain properties that describe ChapData.",
+            "patternProperties": {
+                "^([a-zA-Z_][a-zA-Z0-9_]*)?@(odata|Redfish|Message)\\.[a-zA-Z_][a-zA-Z0-9_]*$": {
+                    "description": "This property shall specify a valid odata or Redfish property.",
+                    "type": [
+                        "array",
+                        "boolean",
+                        "integer",
+                        "number",
+                        "null",
+                        "object",
+                        "string"
+                    ]
+                }
+            },
+            "properties": {
+                "ChapName": {
+                    "description": "A user selected name associated with each of the chap secret password.",
+                    "longDescription": "This property shall contain ChapName that is a user selected name associated with each of the chap secret password.",
+                    "type": [
+                        "string",
+                        "null"
+                    ]
+                },
+                "ChapSecret": {
+                    "description": "An encrypted secret password transferred to the Host for the respective ChapName.",
+                    "longDescription": "This property shall contain ChapSecret that is an encrypted secret password transferred to the Host for the respective ChapName.",
+                    "type": [
+                        "string",
+                        "null"
+                    ]
                 }
             },
             "type": "object"
@@ -226,7 +270,8 @@
                     "type": "string"
                 }
             },
-            "type": "object"
+            "type": "object",
+            "versionAdded": "v1_0_0"
         }
     },
     "title": "#OemComputerSystem"

--- a/static/redfish/v1/schema/OemComputerSystem_v1.xml
+++ b/static/redfish/v1/schema/OemComputerSystem_v1.xml
@@ -26,43 +26,6 @@
                 <Property Name="IBM" Type="OemComputerSystem.IBM"/>
             </ComplexType>
 
-            <ComplexType Name="IBM" BaseType="Resource.OemObject">
-                <Annotation Term="Redfish.OwningEntity" String="IBM"/>
-                <Annotation Term="OData.AdditionalProperties" Bool="true" />
-                <Annotation Term="OData.Description" String="Oem properties for IBM." />
-                <Annotation Term="OData.AutoExpand"/>
-                <Property Name="LampTest" Type="Edm.Boolean">
-                    <Annotation Term="OData.Permissions" EnumMember="OData.Permission/ReadWrite"/>
-                    <Annotation Term="OData.Description" String="An indicator allowing an operator to run LED lamp test."/>
-                    <Annotation Term="OData.LongDescription" String="This property shall contain the state of lamp state function for this resource."/>
-                </Property>
-                <Property Name="PartitionSystemAttentionIndicator" Type="Edm.Boolean">
-                    <Annotation Term="OData.Permissions" EnumMember="OData.Permission/ReadWrite"/>
-                    <Annotation Term="OData.Description" String="An indicator allowing an operator to operate partition system attention."/>
-                    <Annotation Term="OData.LongDescription" String="This property shall contain the state of the partition system attention of this resource."/>
-                </Property>
-                <Property Name="PlatformSystemAttentionIndicator" Type="Edm.Boolean">
-                    <Annotation Term="OData.Permissions" EnumMember="OData.Permission/ReadWrite"/>
-                    <Annotation Term="OData.Description" String="An indicator allowing an operator to operate platform system attention."/>
-                    <Annotation Term="OData.LongDescription" String="This property shall contain the state of the platform system attention of this resource."/>
-                </Property>
-                <Property Name="PCIeTopologyRefresh" Type="Edm.Boolean">
-                  <Annotation Term="OData.Permissions" EnumMember="OData.Permission/ReadWrite"/>
-                  <Annotation Term="OData.Description" String="An indication of topology information is ready."/>
-                  <Annotation Term="OData.LongDescription" String="This property when set to 'true' refreshes the topology information. The application which uses this should set it to 'false' when a refresh occurs."/>
-                </Property>
-                <Property Name="SavePCIeTopologyInfo" Type="Edm.Boolean">
-                  <Annotation Term="OData.Permissions" EnumMember="OData.Permission/ReadWrite"/>
-                  <Annotation Term="OData.Description" String="An indication of PEL topology information is saved."/>
-                  <Annotation Term="OData.LongDescription" String="This property when set to 'true' saves the topology information. The information is saved in the form of a PEL(Error Log)."/>
-                </Property>
-                <Property Name="EnabledPanelFunctions" Type="OemComputerSystem.IBM">
-                  <Annotation Term="OData.Permissions" EnumMember="OData.Permission/Read"/>
-                  <Annotation Term="OData.Description" String="List of enabled panel functions."/>
-                  <Annotation Term="OData.LongDescription" String="This property shall contain the list of enabled panel functions."/>
-                </Property>
-            </ComplexType>
-
             <ComplexType Name="OpenBmc" BaseType="Resource.OemObject">
                 <Annotation Term="OData.AdditionalProperties" Bool="true" />
                 <Annotation Term="OData.Description" String="Oem properties for OpenBmc." />
@@ -101,8 +64,70 @@
                     <Annotation Term="OData.LongDescription" String="Platform firmware is provisioned and locked. So re-provisioning is not allowed in this state."/>
                 </Member>
             </EnumType>
+
+            <ComplexType Name="IBM" BaseType="Resource.OemObject">
+                <Annotation Term="Redfish.OwningEntity" String="IBM"/>
+                <Annotation Term="OData.AdditionalProperties" Bool="true" />
+                <Annotation Term="OData.Description" String="Oem properties for IBM." />
+                <Annotation Term="OData.AutoExpand"/>
+                <Property Name="LampTest" Type="Edm.Boolean">
+                    <Annotation Term="OData.Permissions" EnumMember="OData.Permission/ReadWrite"/>
+                    <Annotation Term="OData.Description" String="An indicator allowing an operator to run LED lamp test."/>
+                    <Annotation Term="OData.LongDescription" String="This property shall contain the state of lamp state function for this resource."/>
+                </Property>
+                <Property Name="PartitionSystemAttentionIndicator" Type="Edm.Boolean">
+                    <Annotation Term="OData.Permissions" EnumMember="OData.Permission/ReadWrite"/>
+                    <Annotation Term="OData.Description" String="An indicator allowing an operator to operate partition system attention."/>
+                    <Annotation Term="OData.LongDescription" String="This property shall contain the state of the partition system attention of this resource."/>
+                </Property>
+                <Property Name="PlatformSystemAttentionIndicator" Type="Edm.Boolean">
+                    <Annotation Term="OData.Permissions" EnumMember="OData.Permission/ReadWrite"/>
+                    <Annotation Term="OData.Description" String="An indicator allowing an operator to operate platform system attention."/>
+                    <Annotation Term="OData.LongDescription" String="This property shall contain the state of the platform system attention of this resource."/>
+                </Property>
+                <Property Name="PCIeTopologyRefresh" Type="Edm.Boolean">
+                  <Annotation Term="OData.Permissions" EnumMember="OData.Permission/ReadWrite"/>
+                  <Annotation Term="OData.Description" String="An indication of topology information is ready."/>
+                  <Annotation Term="OData.LongDescription" String="This property when set to 'true' refreshes the topology information. The application which uses this should set it to 'false' when a refresh occurs."/>
+                </Property>
+                <Property Name="SavePCIeTopologyInfo" Type="Edm.Boolean">
+                  <Annotation Term="OData.Permissions" EnumMember="OData.Permission/ReadWrite"/>
+                  <Annotation Term="OData.Description" String="An indication of PEL topology information is saves."/>
+                  <Annotation Term="OData.LongDescription" String="This property when set to 'true' saves the topology information. The information is saved in the form of a PEL(Error Log)."/>
+                </Property>
+            </ComplexType>
         </Schema>
+
         <Schema xmlns="http://docs.oasis-open.org/odata/ns/edm" Namespace="OemComputerSystem.v1_0_0">
+            <ComplexType Name="IBM" BaseType="OemComputerSystem.IBM">
+                <Property Name="EnabledPanelFunctions" Type="Collection(Edm.Int64)">
+                  <Annotation Term="OData.Permissions" EnumMember="OData.Permission/Read"/>
+                  <Annotation Term="OData.Description" String="List of enabled panel functions."/>
+                  <Annotation Term="OData.LongDescription" String="This property shall contain the list of enabled panel functions."/>
+                </Property>
+                <Property Name="ChapData" Type="OemComputerSystem.v1_0_0.ChapData">
+                  <Annotation Term="OData.Permissions" EnumMember="OData.Permission/Read"/>
+                  <Annotation Term="OData.Description" String="ChapData details to Host."/>
+                  <Annotation Term="OData.LongDescription" String="This property shall contain ChapData."/>
+                </Property>
+            </ComplexType>
+
+            <ComplexType Name="ChapData" BaseType="Resource.OemObject">
+                <Annotation Term="OData.AdditionalProperties" Bool="false"/>
+                <Annotation Term="OData.Description" String="ChapData details to Host."/>
+                <Annotation Term="OData.LongDescription" String="This type shall contain ChapData."/>
+                <Property Name="ChapName" Type="Edm.String">
+                  <Annotation Term="OData.Permissions" EnumMember="OData.Permission/Read"/>
+                  <Annotation Term="OData.Description" String="A user selected name associated with each of the chap secret password."/>
+                  <Annotation Term="OData.LongDescription" String="This property shall contain ChapName that is a user selected name associated with each of the chap secret password."/>
+                </Property>
+                <Property Name="ChapSecret" Type="Edm.String">
+                  <Annotation Term="OData.Permissions" EnumMember="OData.Permission/Read"/>
+                  <Annotation Term="OData.Description" String="An encrypted secret password transferred to the Host for the respective ChapName."/>
+                  <Annotation Term="OData.LongDescription" String="This property shall contain ChapSecret that is an encrypted secret password transferred to the Host for the respective ChapName."/>
+                </Property>
+            </ComplexType>
+
             <Action Name="ExecutePanelFunction" IsBound="true">
                 <Annotation Term="OData.Description" String="This action executes a panel function."/>
                 <Annotation Term="OData.LongDescription" String="This action executes a panel function if the function is enabled."/>


### PR DESCRIPTION
Add Redfish ChapData Redfish OEM API for GET and PATCH of ChapName and ChapSecret.

Its dbus property is added via
- https://github.com/ibm-openbmc/phosphor-dbus-interfaces/pull/88

The related PLDM PRs are:
- https://github.com/ibm-openbmc/pldm/pull/464
- https://github.com/ibm-openbmc/pldm/pull/482

1.Validator passes

2. GET /redfish/v1/Systems/system
```
curl -k -H "X-Auth-Token: $token" -X GET https://${bmc}/redfish/v1/Systems/system
{
  "@odata.id": "/redfish/v1/Systems/system",
  ...
 "Oem": {
    "IBM": {
      "@odata.type": "#OemComputerSystem.IBM",
      "ChapData": {
        "ChapName": "",
        "ChapSecret": ""
      },
 ...
}
```

3. PATCH ChapData

```
$ curl -k -H "X-Auth-Token: $token" -X PATCH \
   -d '{ "Oem" : { "IBM" : { "ChapData": { "ChapName": "chap-name", "ChapSecret" : "chap-secret" }}}}' \
   https://${bmc}/redfish/v1/Systems/system
```

Then,

```
$ curl -k -H "X-Auth-Token: $token" -X GET https://${bmc}/redfish/v1/Systems/system
{
  "@odata.id": "/redfish/v1/Systems/system",
  ...
 "Oem": {
    "IBM": {
      "@odata.type": "#OemComputerSystem.IBM",
      "ChapData": {
        "ChapName": "chap-name",
        "ChapSecret": "chap-secret"
      },
  ...
}
```

This also includes https://github.com/ibm-openbmc/bmcweb/pull/798

- Redfish validator produces warnings related to OemComputerSystem

```
$ python3 RedfishServiceValidator.py --auth Session -i https://${bmc} \
           --payload Single /redfish/v1/Systems/system
...
WARNING - Couldn't get schema for object (?), skipping OemObject IBM : maximum recursion depth exceeded while getting the str of an object
WARNING - EnabledPanelFunctions not defined in schema Complex IBM Resource.OemObject (check version, spelling and casing)
WARNING - LampTest not defined in schema Complex IBM Resource.OemObject (check version, spelling and casing)
WARNING - PartitionSystemAttentionIndicator not defined in schema Complex IBM Resource.OemObject (check version, spelling and casing)
WARNING - PlatformSystemAttentionIndicator not defined in schema Complex IBM Resource.OemObject (check version, spelling and casing)
WARNING - SafeMode not defined in schema Complex IBM Resource.OemObject (check version, spelling and casing)
```

```
$ curl -k -X GET https://${bmc}/redfish/v1/Systems/system
...
  "Oem": {
    "IBM": {
      "@odata.type": "#OemComputerSystem.v1_0_0.IBM",
      "EnabledPanelFunctions": [],
      ...
      },
```