### PR TITLE
Fix OemPCIeDevice schema RedfishValidator warnings (#790)

### DIFF
--- a/static/redfish/v1/JsonSchemas/OemPCIeDevice/OemPCIeDevice.json
+++ b/static/redfish/v1/JsonSchemas/OemPCIeDevice/OemPCIeDevice.json
@@ -58,7 +58,28 @@
                     "longDescription": "A true value resets the PCIe Link.",
                     "readonly": false,
                     "type": "boolean"
-                },
+                }
+            },
+            "type": "object"
+        },
+        "PCIeLinks": {
+            "additionalProperties": true,
+            "description": "Oem link properties for IBM.",
+            "patternProperties": {
+                "^([a-zA-Z_][a-zA-Z0-9_]*)?@(odata|Redfish|Message)\\.[a-zA-Z_][a-zA-Z0-9_]*$": {
+                    "description": "This property shall specify a valid odata or Redfish property.",
+                    "type": [
+                        "array",
+                        "boolean",
+                        "integer",
+                        "number",
+                        "null",
+                        "object",
+                        "string"
+                    ]
+                }
+            },
+            "properties": {
                 "PCIeSlot": {
                     "description": "PCIe Slot Link",
                     "longDescription": "Represent PCIe Slot Link which has all PCIe device list.",

--- a/static/redfish/v1/schema/OemPCIeDevice_v1.xml
+++ b/static/redfish/v1/schema/OemPCIeDevice_v1.xml
@@ -43,14 +43,15 @@
           <Annotation Term="OData.Description" String="Reset the PCIe Link"/>
           <Annotation Term="OData.LongDescription" String="A true value resets the PCIe Link."/>
         </Property>
+      </ComplexType>
 
-        <Property Name="PCIeSlot" Type="OemPCIeDevice.IBM">
+      <ComplexType Name="PCIeLinks" BaseType="Resource.OemObject">
+        <Property Name="PCIeSlot" Type="Resource.Resource">
           <Annotation Term="OData.Permissions" EnumMember="OData.Permission/Read"/>
           <Annotation Term="OData.Description" String="PCIe Slot Link"/>
           <Annotation Term="OData.LongDescription" String="Represent PCIe Slot Link which has all PCIe device list."/>
         </Property>
       </ComplexType>
-
     </Schema>
 
   </edmx:DataServices>


### PR DESCRIPTION
Redfish validator produces warnings related to OemPCIeDevices

```
$ python3 RedfishServiceValidator.py --auth Session -i https://${bmc} \
  --payload Single /redfish/v1/Systems/system/PCIeDevices/chassis_motherboard_pcieslot1_pcie_card1

WARNING - Couldn't get schema for object (?), skipping OemObject IBM : 'IBM'
WARNING - LinkReset not defined in schema Complex IBM Resource.OemObject (check version, spelling and casing)
```

Tested:
- Validator run passes without those OemPCIeDevice warnings