### PR TITLE
Check expand uris & limit to 3 

### DIFF
--- a/redfish-core/include/query.hpp
+++ b/redfish-core/include/query.hpp
@@ -126,8 +126,8 @@ inline bool handleIfMatch(crow::App& app, const crow::Request& req,
 
     asyncResp->res.addHeader("OData-Version", "4.0");
 
-    std::optional<query_param::Query> queryOpt =
-        query_param::parseParameters(req.urlView.params(), asyncResp->res);
+    std::optional<query_param::Query> queryOpt = query_param::parseParameters(
+        req.urlView.params(), asyncResp->res, req.url);
     if (queryOpt == std::nullopt)
     {
         return false;

--- a/redfish-core/include/utils/query_param.hpp
+++ b/redfish-core/include/utils/query_param.hpp
@@ -290,6 +290,12 @@ inline bool getExpandType(std::string_view value, Query& query)
     {
         return false;
     }
+
+    if (query.expandLevel > 3)
+    {
+        return false;
+    }
+
     value.remove_prefix(static_cast<size_t>(it.ptr - value.data()));
     return value == ")";
 }

--- a/redfish-core/include/utils/query_param.hpp
+++ b/redfish-core/include/utils/query_param.hpp
@@ -374,7 +374,8 @@ inline bool getSelectParam(std::string_view value, Query& query)
 }
 
 inline std::optional<Query> parseParameters(boost::urls::params_view urlParams,
-                                            crow::Response& res)
+                                            crow::Response& res,
+                                            std::string_view url)
 {
     Query ret;
     for (const boost::urls::params_view::value_type& it : urlParams)
@@ -390,6 +391,14 @@ inline std::optional<Query> parseParameters(boost::urls::params_view urlParams,
         }
         else if (it.key == "$expand" && bmcwebInsecureEnableQueryParams)
         {
+            // Only allow expand for a few endpoints
+            if ((!url.starts_with("/redfish/v1/Cables")) &&
+                (!url.starts_with("/redfish/v1/Systems/system")) &&
+                (!url.starts_with("/redfish/v1/Chassis")))
+            {
+                messages::queryParameterValueFormatError(res, it.value, it.key);
+                return std::nullopt;
+            }
             if (!getExpandType(it.value, ret))
             {
                 messages::queryParameterValueFormatError(res, it.value, it.key);

--- a/redfish-core/lib/service_root.hpp
+++ b/redfish-core/lib/service_root.hpp
@@ -246,10 +246,10 @@ inline void handleServiceRootGetImpl(
 
     protocolFeatures["ExpandQuery"]["ExpandAll"] =
         bmcwebInsecureEnableQueryParams;
-    // This is the maximum level defined in ServiceRoot.v1_13_0.json
+    // This is the maximum level is defined by us
     if (bmcwebInsecureEnableQueryParams)
     {
-        protocolFeatures["ExpandQuery"]["MaxLevels"] = 6;
+        protocolFeatures["ExpandQuery"]["MaxLevels"] = 3;
     }
     protocolFeatures["ExpandQuery"]["Levels"] = bmcwebInsecureEnableQueryParams;
     protocolFeatures["ExpandQuery"]["Links"] = bmcwebInsecureEnableQueryParams;

--- a/test/redfish-core/include/utils/query_param_test.cpp
+++ b/test/redfish-core/include/utils/query_param_test.cpp
@@ -663,8 +663,8 @@ TEST(QueryParams, GetExpandType)
     EXPECT_TRUE(getExpandType(".", query));
     EXPECT_EQ(query.expandLevel, 1);
 
-    EXPECT_TRUE(getExpandType(".($levels=42)", query));
-    EXPECT_EQ(query.expandLevel, 42);
+    // We have a limit of 3
+    EXPECT_FALSE(getExpandType(".($levels=42)", query));
 
     // Overflow
     EXPECT_FALSE(getExpandType(".($levels=256)", query));

--- a/test/redfish-core/lib/service_root_test.cpp
+++ b/test/redfish-core/lib/service_root_test.cpp
@@ -92,7 +92,7 @@ void assertServiceRootGet(crow::Response& res)
     {
         EXPECT_EQ(json["ProtocolFeaturesSupported"]["ExpandQuery"].size(), 5);
         EXPECT_EQ(json["ProtocolFeaturesSupported"]["ExpandQuery"]["MaxLevels"],
-                  6);
+                  3);
     }
     else
     {


### PR DESCRIPTION
 1) Limit Query Expand to 3 
 
2) Only allow expand on three parts of the tree:
/redfish/v1/Chassis
/redfish/v1/Systems/system
/redfish/v1/Cables

 These URIs are where the GUI's sensor page and PCIe topology page uses expand 