### PR TITLE
Redfish chassis: Only return Inventory.Item.Chassis

### DIFF
--- a/redfish-core/lib/chassis.hpp
+++ b/redfish-core/lib/chassis.hpp
@@ -196,8 +196,7 @@ inline void handleChassisCollectionGet(
     asyncResp->res.jsonValue["@odata.id"] = "/redfish/v1/Chassis";
     asyncResp->res.jsonValue["Name"] = "Chassis Collection";
 
-    constexpr std::array<std::string_view, 2> interfaces{
-        "xyz.openbmc_project.Inventory.Item.Board",
+    constexpr std::array<std::string_view, 1> interfaces{
         "xyz.openbmc_project.Inventory.Item.Chassis"};
     collection_util::getCollectionMembers(
         asyncResp, boost::urls::url("/redfish/v1/Chassis"), interfaces,
@@ -680,8 +679,7 @@ inline void
     {
         return;
     }
-    constexpr std::array<std::string_view, 2> interfaces = {
-        "xyz.openbmc_project.Inventory.Item.Board",
+    constexpr std::array<std::string_view, 1> interfaces = {
         "xyz.openbmc_project.Inventory.Item.Chassis"};
 
     dbus::utility::getSubTree(
@@ -732,8 +730,7 @@ inline void
             "299 - \"IndicatorLED is deprecated. Use LocationIndicatorActive instead.\"");
     }
 
-    constexpr std::array<std::string_view, 2> interfaces = {
-        "xyz.openbmc_project.Inventory.Item.Board",
+    constexpr std::array<std::string_view, 1> interfaces = {
         "xyz.openbmc_project.Inventory.Item.Chassis"};
 
     const std::string& chassisId = param;


### PR DESCRIPTION
1110 update: 
Cherry-pick of https://github.com/ibm-openbmc/bmcweb/commit/127442e8cf93198860f5a0a2eb70056dc7b4614d

 Redfish chassis: Only return Inventory.Item.Chassis 
 
 The first item to get this upstream is https://jsw.ibm.com/browse/PFEBMC-687
