### PR TITLE
Remove sessions on user password update

### DIFF
--- a/include/sessions.hpp
+++ b/include/sessions.hpp
@@ -336,6 +336,20 @@ class SessionStore
         });
     }
 
+    void removeSessionsByUsernameExceptSession(
+        std::string_view username, const std::shared_ptr<UserSession>& session)
+    {
+        std::erase_if(authTokens, [username, session](const auto& value) {
+            if (value.second == nullptr)
+            {
+                return false;
+            }
+
+            return value.second->username == username &&
+                   value.second->uniqueId != session->uniqueId;
+        });
+    }
+
     void updateAuthMethodsConfig(const AuthConfigMethods& config)
     {
         bool isTLSchanged = (authMethodsConfig.tls != config.tls);


### PR DESCRIPTION
When a user's password is changed, existing Redfish sessions for that user, created with the old password, continue to work.

As per OWASP session management, "The session ID must be renewed or regenerated by the web application after any privilege level change within the associated user session... Common scenarios to consider include; password changes, permission changes, or switching from a regular user role to an administrator role within the web application." [1] https://cheatsheetseries.owasp.org/cheatsheets/Session_Management_Cheat_Sheet.html

This commit removes existing user sessions when the user's password is changed. This commit leaves the current session in place though a new removeSessionsByUsernameExceptSession().

This commit doesn't completely get us fully to what owasp says but is a start.

Tested:
Create some users:
```
curl -k -v -X POST -H "Content-Type: application/json" \
https://$bmc/redfish/v1/AccountService/Accounts/ -d \
'{"UserName":"testadminuser","Password":"<password>","RoleId":"Administrator","Enabled":true}'
```

Using basic auth was able to update own password and another user's password.

Using token auth, verified the current session did not get deleted but other sessions from that user did.

```
curl -k -H "Content-Type: application/json" -X POST -D headers.txt \
https://${bmc}/redfish/v1/SessionService/Sessions -d \
'{"UserName":"testadminuser", "Password":"<password>"}'
```

```
curl -k -v -X PATCH -H "X-Auth-Token: $token" \
-H "Content-Type:application/json" \
https://$bmc/redfish/v1/AccountService/Accounts/testadminuser \
-d '{"Password":"<password>"}'
```

Verified when changing another user's password all sessions were dropped.

Change-Id: I4de60b84964a6b29c021dc3a2bece9ed4bc09eac