### PR TITLE
Remove sessions on user password update

### DIFF
--- a/include/sessions.hpp
+++ b/include/sessions.hpp
@@ -336,6 +336,20 @@ class SessionStore
         });
     }
 
+    void removeSessionsByUsernameExceptSession(
+        std::string_view username, const std::shared_ptr<UserSession>& session)
+    {
+        std::erase_if(authTokens, [username, session](const auto& value) {
+            if (value.second == nullptr)
+            {
+                return false;
+            }
+
+            return value.second->username == username &&
+                   value.second->uniqueId != session->uniqueId;
+        });
+    }
+
     void updateAuthMethodsConfig(const AuthConfigMethods& config)
     {
         bool isTLSchanged = (authMethodsConfig.tls != config.tls);

--- a/redfish-core/lib/account_service.hpp
+++ b/redfish-core/lib/account_service.hpp
@@ -1514,7 +1514,8 @@ inline void updateUserProperties(
     std::shared_ptr<bmcweb::AsyncResp> asyncResp, const std::string& username,
     std::optional<std::string> password, std::optional<bool> enabled,
     std::optional<std::string> roleId, std::optional<bool> locked,
-    std::optional<std::vector<std::string>> accountType, bool isUserItself)
+    std::optional<std::vector<std::string>> accountType, bool isUserItself,
+    const std::shared_ptr<persistent_data::UserSession>& session)
 {
     sdbusplus::message::object_path tempObjPath(rootUserDbusPath);
     tempObjPath /= username;
@@ -1524,7 +1525,7 @@ inline void updateUserProperties(
         dbusObjectPath,
         [dbusObjectPath, username, password(std::move(password)),
          roleId(std::move(roleId)), enabled, locked,
-         accountType(std::move(accountType)), isUserItself,
+         accountType(std::move(accountType)), isUserItself, session,
          asyncResp{std::move(asyncResp)}](int rc) {
         if (rc <= 0)
         {
@@ -1556,6 +1557,9 @@ inline void updateUserProperties(
             }
             else
             {
+                // Remove existing sessions of the user when password changed
+                persistent_data::SessionStore::getInstance()
+                    .removeSessionsByUsernameExceptSession(username, session);
                 messages::success(asyncResp->res);
             }
         }
@@ -2645,13 +2649,13 @@ inline void
     if (!newUserName || (newUserName.value() == username))
     {
         updateUserProperties(asyncResp, username, password, enabled, roleId,
-                             locked, accountType, isUserItself);
+                             locked, accountType, isUserItself, req.session);
         return;
     }
     crow::connections::systemBus->async_method_call(
         [asyncResp, username, password(std::move(password)),
          roleId(std::move(roleId)), enabled, newUser{std::string(*newUserName)},
-         locked, isUserItself, accountType{std::move(accountType)}](
+         locked, isUserItself, req, accountType{std::move(accountType)}](
             const boost::system::error_code ec,
             sdbusplus::message::message& m) {
         if (ec)
@@ -2662,7 +2666,7 @@ inline void
         }
 
         updateUserProperties(asyncResp, newUser, password, enabled, roleId,
-                             locked, accountType, isUserItself);
+                             locked, accountType, isUserItself, req.session);
     },
         "xyz.openbmc_project.User.Manager", "/xyz/openbmc_project/user",
         "xyz.openbmc_project.User.Manager", "RenameUser", username,


### PR DESCRIPTION
When a user's password is changed, existing Redfish sessions for that user, created with the old password, continue to work.

As per OWASP session management, "The session ID must be renewed or regenerated by the web application after any privilege level change within the associated user session... Common scenarios to consider include; password changes, permission changes, or switching from a regular user role to an administrator role within the web application." [1] https://cheatsheetseries.owasp.org/cheatsheets/Session_Management_Cheat_Sheet.html

This commit removes existing user sessions when the user's password is changed. This commit leaves the current session in place though a new removeSessionsByUsernameExceptSession().

This commit doesn't completely get us fully to what owasp says but is a start.

Tested:
Create some users:
```
curl -k -v -X POST -H "Content-Type: application/json" \
https://$bmc/redfish/v1/AccountService/Accounts/ -d \
'{"UserName":"testadminuser","Password":"<password>","RoleId":"Administrator","Enabled":true}'
```

Using basic auth was able to update own password and another user's password.

Using token auth, verified the current session did not get deleted but other sessions from that user did.

```
curl -k -H "Content-Type: application/json" -X POST -D headers.txt \
https://${bmc}/redfish/v1/SessionService/Sessions -d \
'{"UserName":"testadminuser", "Password":"<password>"}'
```

```
curl -k -v -X PATCH -H "X-Auth-Token: $token" \
-H "Content-Type:application/json" \
https://$bmc/redfish/v1/AccountService/Accounts/testadminuser \
-d '{"Password":"<password>"}'
```

Verified when changing another user's password all sessions were dropped.

Change-Id: I4de60b84964a6b29c021dc3a2bece9ed4bc09eac