### PR TITLE
1110: Fix core with upstream ssl fix

### DIFF
--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -3,7 +3,7 @@
     "files": "^.secrets.baseline$",
     "lines": null
   },
-  "generated_at": "2024-05-08T21:40:58Z",
+  "generated_at": "2024-05-21T20:43:43Z",
   "plugins_used": [
     {
       "name": "AWSKeyDetector"
@@ -210,7 +210,7 @@
         "hashed_secret": "6e069300b0db722cc2ad4b1425a30ff5a8ae20cf",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 2282,
+        "line_number": 2356,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -218,7 +218,7 @@
         "hashed_secret": "efb7b9c519415e44a5f30819aaa9bf534f6afb27",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 2298,
+        "line_number": 2372,
         "type": "Secret Keyword",
         "verified_result": null
       }

--- a/config/bmcweb_config.h.in
+++ b/config/bmcweb_config.h.in
@@ -25,5 +25,7 @@ constexpr const bool bmcwebEnableMultiHost = @BMCWEB_ENABLE_MULTI_HOST@ == 1;
 
 constexpr const bool bmcwebEnableHTTP2 = @BMCWEB_ENABLE_HTTP2@ == 1;
 
+constexpr const bool bmcwebEnableTLS = @BMCWEB_ENABLE_TLS@ == 1;
+
 constexpr const bool bmcwebMTLSCommonNameParsingMeta = @BMCWEB_ENABLE_MTLS_COMMON_NAME_PARSING_META@ == 1;
 // clang-format on

--- a/config/meson.build
+++ b/config/meson.build
@@ -20,8 +20,14 @@ enable_multi_host = get_option('experimental-redfish-multi-computer-system')
 conf_data.set10('BMCWEB_ENABLE_MULTI_HOST', enable_multi_host.allowed())
 enable_http2 = get_option('experimental-http2')
 conf_data.set10('BMCWEB_ENABLE_HTTP2', enable_http2.allowed())
-conf_data.set10('BMCWEB_ENABLE_MTLS_COMMON_NAME_PARSING_META', get_option('mutual-tls-common-name-parsing') == 'meta')
 
+enable_tls = get_option('insecure-disable-ssl')
+conf_data.set10('BMCWEB_ENABLE_TLS', enable_tls.disabled())
+
+conf_data.set10(
+    'BMCWEB_ENABLE_MTLS_COMMON_NAME_PARSING_META',
+    get_option('mutual-tls-common-name-parsing') == 'meta',
+)
 
 # Logging level
 loglvlopt = get_option('bmcweb-logging')

--- a/http/app.hpp
+++ b/http/app.hpp
@@ -8,10 +8,12 @@
 #include "routing.hpp"
 #include "utility.hpp"
 
+#include <systemd/sd-daemon.h>
+
 #include <boost/asio/io_context.hpp>
 #include <boost/asio/ip/tcp.hpp>
 #include <boost/asio/ssl/context.hpp>
-#include <boost/beast/ssl/ssl_stream.hpp>
+#include <boost/asio/ssl/stream.hpp>
 
 #include <chrono>
 #include <cstdint>
@@ -31,9 +33,11 @@ class App
 {
   public:
     using ssl_socket_t = boost::beast::ssl_stream<boost::asio::ip::tcp::socket>;
-    using ssl_server_t = Server<App, ssl_socket_t>;
-    using socket_t = boost::asio::ip::tcp::socket;
-    using server_t = Server<App, socket_t>;
+    using raw_socket_t = boost::asio::ip::tcp::socket;
+
+    using socket_type =
+        std::conditional_t<bmcwebEnableTLS, ssl_socket_t, raw_socket_t>;
+    using server_type = Server<App, socket_type>;
 
     explicit App(std::shared_ptr<boost::asio::io_context> ioIn =
                      std::make_shared<boost::asio::io_context>()) :
@@ -74,52 +78,52 @@ class App
         return router.newRuleTagged<Tag>(std::move(rule));
     }
 
-    App& socket(int existingSocket)
-    {
-        socketFd = existingSocket;
-        return *this;
-    }
-
-    App& port(std::uint16_t port)
-    {
-        portUint = port;
-        return *this;
-    }
-
     void validate()
     {
         router.validate();
     }
 
+    std::optional<boost::asio::ip::tcp::acceptor> setupSocket()
+    {
+        if (io == nullptr)
+        {
+            BMCWEB_LOG_CRITICAL("IO was nullptr?");
+            return std::nullopt;
+        }
+        constexpr int defaultPort = 18080;
+        int listenFd = sd_listen_fds(0);
+        if (listenFd == 1)
+        {
+            BMCWEB_LOG_INFO("attempting systemd socket activation");
+            if (sd_is_socket_inet(SD_LISTEN_FDS_START, AF_UNSPEC, SOCK_STREAM,
+                                  1, 0) != 0)
+            {
+                BMCWEB_LOG_INFO("Starting webserver on socket handle {}",
+                                SD_LISTEN_FDS_START);
+                return boost::asio::ip::tcp::acceptor(
+                    *io, boost::asio::ip::tcp::v6(), SD_LISTEN_FDS_START);
+            }
+            BMCWEB_LOG_ERROR(
+                "bad incoming socket, starting webserver on port {}",
+                defaultPort);
+        }
+        BMCWEB_LOG_INFO("Starting webserver on port {}", defaultPort);
+        return boost::asio::ip::tcp::acceptor(
+            *io, boost::asio::ip::tcp::endpoint(
+                     boost::asio::ip::make_address("0.0.0.0"), defaultPort));
+    }
+
     void run()
     {
         validate();
-#ifdef BMCWEB_ENABLE_SSL
-        if (-1 == socketFd)
+        std::optional<boost::asio::ip::tcp::acceptor> acceptor = setupSocket();
+        if (!acceptor)
         {
-            sslServer = std::make_unique<ssl_server_t>(this, portUint,
-                                                       sslContext, io);
+            BMCWEB_LOG_CRITICAL("Couldn't start server");
+            return;
         }
-        else
-        {
-            sslServer = std::make_unique<ssl_server_t>(this, socketFd,
-                                                       sslContext, io);
-        }
-        sslServer->run();
-
-#else
-
-        if (-1 == socketFd)
-        {
-            server = std::make_unique<server_t>(this, portUint, nullptr, io);
-        }
-        else
-        {
-            server = std::make_unique<server_t>(this, socketFd, nullptr, io);
-        }
+        server.emplace(this, std::move(*acceptor), sslContext, io);
         server->run();
-
-#endif
     }
 
     void stop()
@@ -160,19 +164,9 @@ class App
 
   private:
     std::shared_ptr<boost::asio::io_context> io;
-#ifdef BMCWEB_ENABLE_SSL
-    uint16_t portUint = 443;
-#else
-    uint16_t portUint = 80;
-#endif
-    int socketFd = -1;
-    Router router;
+    std::optional<server_type> server;
 
-#ifdef BMCWEB_ENABLE_SSL
-    std::unique_ptr<ssl_server_t> sslServer;
-#else
-    std::unique_ptr<server_t> server;
-#endif
+    Router router;
 };
 } // namespace crow
 using App = crow::App;

--- a/http/app.hpp
+++ b/http/app.hpp
@@ -32,7 +32,7 @@ namespace crow
 class App
 {
   public:
-    using ssl_socket_t = boost::beast::ssl_stream<boost::asio::ip::tcp::socket>;
+    using ssl_socket_t = boost::asio::ssl::stream<boost::asio::ip::tcp::socket>;
     using raw_socket_t = boost::asio::ip::tcp::socket;
 
     using socket_type =

--- a/http/http2_connection.hpp
+++ b/http/http2_connection.hpp
@@ -23,7 +23,6 @@
 #include <boost/beast/http/serializer.hpp>
 #include <boost/beast/http/string_body.hpp>
 #include <boost/beast/http/write.hpp>
-#include <boost/beast/ssl/ssl_stream.hpp>
 #include <boost/beast/websocket.hpp>
 
 #include <atomic>
@@ -489,7 +488,7 @@ class HTTP2Connection :
     void close()
     {
         if constexpr (std::is_same_v<Adaptor,
-                                     boost::beast::ssl_stream<
+                                     boost::asio::ssl::stream<
                                          boost::asio::ip::tcp::socket>>)
         {
             adaptor.next_layer().close();

--- a/http/http_client.hpp
+++ b/http/http_client.hpp
@@ -27,6 +27,7 @@
 #include <boost/asio/ip/tcp.hpp>
 #include <boost/asio/ssl/context.hpp>
 #include <boost/asio/ssl/error.hpp>
+#include <boost/asio/ssl/stream.hpp>
 #include <boost/asio/steady_timer.hpp>
 #include <boost/beast/core/flat_buffer.hpp>
 #include <boost/beast/core/flat_static_buffer.hpp>
@@ -35,8 +36,6 @@
 #include <boost/beast/http/read.hpp>
 #include <boost/beast/http/string_body.hpp>
 #include <boost/beast/http/write.hpp>
-#include <boost/beast/ssl/ssl_stream.hpp>
-#include <boost/beast/version.hpp>
 #include <boost/container/devector.hpp>
 #include <boost/system/error_code.hpp>
 #include <boost/url/format.hpp>
@@ -158,7 +157,7 @@ class ConnectionInfo : public std::enable_shared_from_this<ConnectionInfo>
     Resolver resolver;
 
     boost::asio::ip::tcp::socket conn;
-    std::optional<boost::beast::ssl_stream<boost::asio::ip::tcp::socket&>>
+    std::optional<boost::asio::ssl::stream<boost::asio::ip::tcp::socket&>>
         sslConn;
 
     boost::asio::steady_timer timer;

--- a/http/http_connection.hpp
+++ b/http/http_connection.hpp
@@ -29,7 +29,6 @@
 #include <boost/beast/http/parser.hpp>
 #include <boost/beast/http/read.hpp>
 #include <boost/beast/http/write.hpp>
-#include <boost/beast/ssl/ssl_stream.hpp>
 #include <boost/beast/websocket.hpp>
 
 #include <atomic>
@@ -58,7 +57,7 @@ struct IsTls : std::false_type
 {};
 
 template <typename T>
-struct IsTls<boost::beast::ssl_stream<T>> : std::true_type
+struct IsTls<boost::asio::ssl::stream<T>> : std::true_type
 {};
 
 template <typename Adaptor, typename Handler>

--- a/http/http_server.hpp
+++ b/http/http_server.hpp
@@ -8,8 +8,8 @@
 #include <boost/asio/ip/tcp.hpp>
 #include <boost/asio/signal_set.hpp>
 #include <boost/asio/ssl/context.hpp>
+#include <boost/asio/ssl/stream.hpp>
 #include <boost/asio/steady_timer.hpp>
-#include <boost/beast/ssl/ssl_stream.hpp>
 
 #include <atomic>
 #include <chrono>
@@ -165,7 +165,7 @@ class Server
         boost::asio::steady_timer timer(*ioService);
         std::shared_ptr<Connection<Adaptor, Handler>> connection;
         if constexpr (std::is_same<Adaptor,
-                                   boost::beast::ssl_stream<
+                                   boost::asio::ssl::stream<
                                        boost::asio::ip::tcp::socket>>::value)
         {
             if (adaptorCtx == nullptr)

--- a/http/routing.hpp
+++ b/http/routing.hpp
@@ -21,7 +21,7 @@
 #include "verb.hpp"
 #include "websocket.hpp"
 
-#include <boost/beast/ssl/ssl_stream.hpp>
+#include <boost/asio/ssl/stream.hpp>
 #include <boost/container/flat_map.hpp>
 #include <boost/url/format.hpp>
 #include <sdbusplus/unpack_properties.hpp>

--- a/http/routing/baserule.hpp
+++ b/http/routing/baserule.hpp
@@ -5,7 +5,8 @@
 #include "privileges.hpp"
 #include "verb.hpp"
 
-#include <boost/beast/ssl/ssl_stream.hpp>
+#include <boost/asio/ip/tcp.hpp>
+#include <boost/asio/ssl/stream.hpp>
 
 #include <memory>
 #include <string>
@@ -48,7 +49,7 @@ class BaseRule
     virtual void handleUpgrade(
         const Request& /*req*/,
         const std::shared_ptr<bmcweb::AsyncResp>& asyncResp,
-        boost::beast::ssl_stream<boost::asio::ip::tcp::socket>&& /*adaptor*/)
+        boost::asio::ssl::stream<boost::asio::ip::tcp::socket>&& /*adaptor*/)
     {
         asyncResp->res.result(boost::beast::http::status::not_found);
     }

--- a/http/routing/baserule.hpp
+++ b/http/routing/baserule.hpp
@@ -37,7 +37,6 @@ class BaseRule
     virtual void handle(const Request& /*req*/,
                         const std::shared_ptr<bmcweb::AsyncResp>&,
                         const std::vector<std::string>&) = 0;
-#ifndef BMCWEB_ENABLE_SSL
     virtual void
         handleUpgrade(const Request& /*req*/,
                       const std::shared_ptr<bmcweb::AsyncResp>& asyncResp,
@@ -45,7 +44,7 @@ class BaseRule
     {
         asyncResp->res.result(boost::beast::http::status::not_found);
     }
-#else
+
     virtual void handleUpgrade(
         const Request& /*req*/,
         const std::shared_ptr<bmcweb::AsyncResp>& asyncResp,
@@ -53,7 +52,6 @@ class BaseRule
     {
         asyncResp->res.result(boost::beast::http::status::not_found);
     }
-#endif
 
     size_t getMethods() const
     {

--- a/http/routing/sserule.hpp
+++ b/http/routing/sserule.hpp
@@ -30,7 +30,6 @@ class SseSocketRule : public BaseRule
         asyncResp->res.result(boost::beast::http::status::not_found);
     }
 
-#ifndef BMCWEB_ENABLE_SSL
     void handleUpgrade(const Request& /*req*/,
                        const std::shared_ptr<bmcweb::AsyncResp>& /*asyncResp*/,
                        boost::asio::ip::tcp::socket&& adaptor) override
@@ -42,7 +41,6 @@ class SseSocketRule : public BaseRule
                 std::move(adaptor), openHandler, closeHandler);
         myConnection->start();
     }
-#else
     void handleUpgrade(const Request& /*req*/,
                        const std::shared_ptr<bmcweb::AsyncResp>& /*asyncResp*/,
                        boost::beast::ssl_stream<boost::asio::ip::tcp::socket>&&
@@ -55,7 +53,6 @@ class SseSocketRule : public BaseRule
                 std::move(adaptor), openHandler, closeHandler);
         myConnection->start();
     }
-#endif
 
     template <typename Func>
     self_t& onopen(Func f)

--- a/http/routing/sserule.hpp
+++ b/http/routing/sserule.hpp
@@ -43,13 +43,13 @@ class SseSocketRule : public BaseRule
     }
     void handleUpgrade(const Request& /*req*/,
                        const std::shared_ptr<bmcweb::AsyncResp>& /*asyncResp*/,
-                       boost::beast::ssl_stream<boost::asio::ip::tcp::socket>&&
+                       boost::asio::ssl::stream<boost::asio::ip::tcp::socket>&&
                            adaptor) override
     {
         std::shared_ptr<crow::sse_socket::ConnectionImpl<
-            boost::beast::ssl_stream<boost::asio::ip::tcp::socket>>>
+            boost::asio::ssl::stream<boost::asio::ip::tcp::socket>>>
             myConnection = std::make_shared<crow::sse_socket::ConnectionImpl<
-                boost::beast::ssl_stream<boost::asio::ip::tcp::socket>>>(
+                boost::asio::ssl::stream<boost::asio::ip::tcp::socket>>>(
                 std::move(adaptor), openHandler, closeHandler);
         myConnection->start();
     }

--- a/http/routing/streamrule.hpp
+++ b/http/routing/streamrule.hpp
@@ -45,14 +45,14 @@ class StreamingResponseRule : public BaseRule
 
     void handleUpgrade(const Request& req,
                        const std::shared_ptr<bmcweb::AsyncResp>& /*asyncResp*/,
-                       boost::beast::ssl_stream<boost::asio::ip::tcp::socket>&&
+                       boost::asio::ssl::stream<boost::asio::ip::tcp::socket>&&
                            adaptor) override
     {
         std::shared_ptr<crow::streaming_response::ConnectionImpl<
-            boost::beast::ssl_stream<boost::asio::ip::tcp::socket>>>
+            boost::asio::ssl::stream<boost::asio::ip::tcp::socket>>>
             myConnection =
                 std::make_shared<crow::streaming_response::ConnectionImpl<
-                    boost::beast::ssl_stream<boost::asio::ip::tcp::socket>>>(
+                    boost::asio::ssl::stream<boost::asio::ip::tcp::socket>>>(
                     req, std::move(adaptor), openHandler, messageHandler,
                     closeHandler, errorHandler);
         myConnection->start();

--- a/http/routing/streamrule.hpp
+++ b/http/routing/streamrule.hpp
@@ -29,7 +29,6 @@ class StreamingResponseRule : public BaseRule
         asyncResp->res.result(boost::beast::http::status::not_found);
     }
 
-#ifndef BMCWEB_ENABLE_SSL
     void handleUpgrade(const Request& req,
                        const std::shared_ptr<bmcweb::AsyncResp>& /*asyncResp*/,
                        boost::asio::ip::tcp::socket&& adaptor) override
@@ -43,7 +42,7 @@ class StreamingResponseRule : public BaseRule
                                                    closeHandler, errorHandler);
         myConnection->start();
     }
-#else
+
     void handleUpgrade(const Request& req,
                        const std::shared_ptr<bmcweb::AsyncResp>& /*asyncResp*/,
                        boost::beast::ssl_stream<boost::asio::ip::tcp::socket>&&
@@ -58,7 +57,6 @@ class StreamingResponseRule : public BaseRule
                     closeHandler, errorHandler);
         myConnection->start();
     }
-#endif
 
     template <typename Func>
     self_t& onopen(Func f)

--- a/http/routing/websocketrule.hpp
+++ b/http/routing/websocketrule.hpp
@@ -27,7 +27,6 @@ class WebSocketRule : public BaseRule
         asyncResp->res.result(boost::beast::http::status::not_found);
     }
 
-#ifndef BMCWEB_ENABLE_SSL
     void handleUpgrade(const Request& req,
                        const std::shared_ptr<bmcweb::AsyncResp>& /*asyncResp*/,
                        boost::asio::ip::tcp::socket&& adaptor) override
@@ -41,7 +40,7 @@ class WebSocketRule : public BaseRule
                 messageHandler, messageExHandler, closeHandler, errorHandler);
         myConnection->start(req);
     }
-#else
+
     void handleUpgrade(const Request& req,
                        const std::shared_ptr<bmcweb::AsyncResp>& /*asyncResp*/,
                        boost::beast::ssl_stream<boost::asio::ip::tcp::socket>&&
@@ -56,7 +55,6 @@ class WebSocketRule : public BaseRule
                 messageHandler, messageExHandler, closeHandler, errorHandler);
         myConnection->start(req);
     }
-#endif
 
     template <typename Func>
     self_t& onopen(Func f)

--- a/http/routing/websocketrule.hpp
+++ b/http/routing/websocketrule.hpp
@@ -43,14 +43,14 @@ class WebSocketRule : public BaseRule
 
     void handleUpgrade(const Request& req,
                        const std::shared_ptr<bmcweb::AsyncResp>& /*asyncResp*/,
-                       boost::beast::ssl_stream<boost::asio::ip::tcp::socket>&&
+                       boost::asio::ssl::stream<boost::asio::ip::tcp::socket>&&
                            adaptor) override
     {
         BMCWEB_LOG_DEBUG("Websocket handles upgrade");
         std::shared_ptr<crow::websocket::ConnectionImpl<
-            boost::beast::ssl_stream<boost::asio::ip::tcp::socket>>>
+            boost::asio::ssl::stream<boost::asio::ip::tcp::socket>>>
             myConnection = std::make_shared<crow::websocket::ConnectionImpl<
-                boost::beast::ssl_stream<boost::asio::ip::tcp::socket>>>(
+                boost::asio::ssl::stream<boost::asio::ip::tcp::socket>>>(
                 req.url(), req.session, std::move(adaptor), openHandler,
                 messageHandler, messageExHandler, closeHandler, errorHandler);
         myConnection->start(req);

--- a/http/server_sent_event.hpp
+++ b/http/server_sent_event.hpp
@@ -8,13 +8,10 @@
 #include <boost/beast/core/multi_buffer.hpp>
 #include <boost/beast/http/buffer_body.hpp>
 #include <boost/beast/websocket.hpp>
+#include <boost/beast/websocket/ssl.hpp>
 
 #include <array>
 #include <functional>
-
-#ifdef BMCWEB_ENABLE_SSL
-#include <boost/beast/websocket/ssl.hpp>
-#endif
 
 namespace crow
 {

--- a/http/websocket.hpp
+++ b/http/websocket.hpp
@@ -5,13 +5,10 @@
 #include <boost/asio/buffer.hpp>
 #include <boost/beast/core/multi_buffer.hpp>
 #include <boost/beast/websocket.hpp>
+#include <boost/beast/websocket/ssl.hpp>
 
 #include <array>
 #include <functional>
-
-#ifdef BMCWEB_ENABLE_SSL
-#include <boost/beast/websocket/ssl.hpp>
-#endif
 
 namespace crow
 {

--- a/include/hostname_monitor.hpp
+++ b/include/hostname_monitor.hpp
@@ -1,5 +1,4 @@
 #pragma once
-#ifdef BMCWEB_ENABLE_SSL
 #include "dbus_singleton.hpp"
 #include "dbus_utility.hpp"
 #include "include/dbus_utility.hpp"
@@ -143,4 +142,3 @@ inline void registerHostnameSignal()
 }
 } // namespace hostname_monitor
 } // namespace crow
-#endif


### PR DESCRIPTION
This PR is to address the coredump related to client ssl connection.

It is caused at SSL stream and it has been fixed via cherry-picks of upstream commits
     - https://github.com/openbmc/bmcweb/commit/003301a2
     - https://github.com/openbmc/bmcweb/commit/8db83747

This is also confirmed by trying upstream code.

Test method:
- On GUI, `https://rain100bmc.aus.stglabs.ibm.com/#/operations/host-console`
- Login as `service` and put `https://rain100bmc.aus.stglabs.ibm.com/#/operations/host-console` again
