### PR TITLE
1110: Check nullptr before using var at log-services

### DIFF
--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -3,7 +3,7 @@
     "files": "^.secrets.baseline$",
     "lines": null
   },
-  "generated_at": "2024-05-08T21:40:58Z",
+  "generated_at": "2024-05-21T20:15:05Z",
   "plugins_used": [
     {
       "name": "AWSKeyDetector"
@@ -210,7 +210,7 @@
         "hashed_secret": "6e069300b0db722cc2ad4b1425a30ff5a8ae20cf",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 2282,
+        "line_number": 2356,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -218,7 +218,7 @@
         "hashed_secret": "efb7b9c519415e44a5f30819aaa9bf534f6afb27",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 2298,
+        "line_number": 2372,
         "type": "Secret Keyword",
         "verified_result": null
       }

--- a/redfish-core/lib/log_services.hpp
+++ b/redfish-core/lib/log_services.hpp
@@ -2609,7 +2609,8 @@ inline void requestRoutesDBusCELogEntryCollection(App& app)
                 // and continue.
                 if (id == nullptr || eventId == nullptr ||
                     severity == nullptr || timestamp == nullptr ||
-                    updateTimestamp == nullptr)
+                    updateTimestamp == nullptr || hidden == nullptr ||
+                    subsystem == nullptr)
                 {
                     continue;
                 }


### PR DESCRIPTION
requestRoutesDBusCELogEntryCollection() handling hits a core due to a missing nullptr of variable `hidden` in log_services.hpp.
This is introduced by a mistake during https://github.com/ibm-openbmc/bmcweb/commit/a325bc8c07cac21c02df624298b4f3b94864e42f


```
Core was generated by `/usr/bin/bmcweb'.
Program terminated with signal SIGSEGV, Segmentation fault.
...
   std::shared_ptr<bmcweb::AsyncResp> const&, std::__cxx11::basic_string<char, std::char_traits<char>,
   std::allocator<char> > const&)#1}::operator()(crow::Request const&, std::shared_ptr<bmcweb::AsyncResp> const&, std::__cxx11::basic_string<char,
...
    std::shared_ptr<bmcweb::AsyncResp> const&, std::__cxx11::basic_string<char, std::char_traits<char>,
    std::allocator<char> > const&)#1}::operator()(crow::Request const&, std::shared_ptr<bmcweb::AsyncResp> const&,
   std::__cxx11::basic_string<char,
....
long> > > > > > > > > > > > > const&) const ()
at /usr/src/debug/bmcweb/1.0+git/redfish-core/lib/log_services.hpp:2618

2618	   if (!(*hidden))
(gdb)

```