### PR TITLE
1110: Revert "Add topology links for Chassis"

### DIFF
--- a/redfish-core/lib/chassis.hpp
+++ b/redfish-core/lib/chassis.hpp
@@ -204,103 +204,6 @@ inline void handleChassisCollectionGet(
         "/xyz/openbmc_project/inventory");
 }
 
-inline void getChassisContainedBy(
-    const std::shared_ptr<bmcweb::AsyncResp>& asyncResp,
-    const std::string& chassisId, const boost::system::error_code& ec,
-    const dbus::utility::MapperEndPoints& upstreamChassisPaths)
-{
-    if (ec)
-    {
-        if (ec.value() != EBADR)
-        {
-            BMCWEB_LOG_ERROR("DBUS response error {}", ec);
-            messages::internalError(asyncResp->res);
-        }
-        return;
-    }
-    if (upstreamChassisPaths.empty())
-    {
-        return;
-    }
-    if (upstreamChassisPaths.size() > 1)
-    {
-        BMCWEB_LOG_ERROR("{} is contained by multiple chassis", chassisId);
-        messages::internalError(asyncResp->res);
-        return;
-    }
-
-    sdbusplus::message::object_path upstreamChassisPath(
-        upstreamChassisPaths[0]);
-    std::string upstreamChassis = upstreamChassisPath.filename();
-    if (upstreamChassis.empty())
-    {
-        BMCWEB_LOG_WARNING("Malformed upstream Chassis path {} on {}",
-                           upstreamChassisPath.str, chassisId);
-        return;
-    }
-
-    asyncResp->res.jsonValue["Links"]["ContainedBy"]["@odata.id"] =
-        boost::urls::format("/redfish/v1/Chassis/{}", upstreamChassis);
-}
-
-inline void getChassisContains(
-    const std::shared_ptr<bmcweb::AsyncResp>& asyncResp,
-    const std::string& chassisId, const boost::system::error_code& ec,
-    const dbus::utility::MapperEndPoints& downstreamChassisPaths)
-{
-    if (ec)
-    {
-        if (ec.value() != EBADR)
-        {
-            BMCWEB_LOG_ERROR("DBUS response error {}", ec);
-            messages::internalError(asyncResp->res);
-        }
-        return;
-    }
-    if (downstreamChassisPaths.empty())
-    {
-        return;
-    }
-    nlohmann::json& jValue = asyncResp->res.jsonValue["Links"]["Contains"];
-    if (!jValue.is_array())
-    {
-        // Create the array if it was empty
-        jValue = nlohmann::json::array();
-    }
-    for (const auto& p : downstreamChassisPaths)
-    {
-        sdbusplus::message::object_path downstreamChassisPath(p);
-        std::string downstreamChassis = downstreamChassisPath.filename();
-        if (downstreamChassis.empty())
-        {
-            BMCWEB_LOG_WARNING("Malformed downstream Chassis path {} on {}",
-                               downstreamChassisPath.str, chassisId);
-            continue;
-        }
-        nlohmann::json link;
-        link["@odata.id"] = boost::urls::format("/redfish/v1/Chassis/{}",
-                                                downstreamChassis);
-        jValue.push_back(std::move(link));
-    }
-    asyncResp->res.jsonValue["Links"]["Contains@odata.count"] = jValue.size();
-}
-
-inline void
-    getChassisConnectivity(const std::shared_ptr<bmcweb::AsyncResp>& asyncResp,
-                           const std::string& chassisId,
-                           const std::string& chassisPath)
-{
-    BMCWEB_LOG_DEBUG("Get chassis connectivity");
-
-    dbus::utility::getAssociationEndPoints(
-        chassisPath + "/contained_by",
-        std::bind_front(getChassisContainedBy, asyncResp, chassisId));
-
-    dbus::utility::getAssociationEndPoints(
-        chassisPath + "/containing",
-        std::bind_front(getChassisContains, asyncResp, chassisId));
-}
-
 /**
  * ChassisCollection derived class for delivering Chassis Collection Schema
  *  Functions triggers appropriate requests on DBus
@@ -473,8 +376,6 @@ inline void handleChassisGetSubTree(
         {
             continue;
         }
-
-        getChassisConnectivity(asyncResp, chassisId, path);
 
         auto health = std::make_shared<HealthPopulate>(asyncResp);
 


### PR DESCRIPTION
https://gerrit.openbmc.org/c/openbmc/bmcweb/+/60914 implements topology links for chassis using `getAssociationEndPoints()` for `containing/contained_by` associations.

However, the same associations can also be used for the other cases which may also be used for the other types.

For example, https://gerrit.openbmc.org/c/openbmc/openbmc/+/70372 adds the associations between chassis and the other resources.

In that case, Chassis Links gives the incorrect result including the non-chassis resources in `Contains` collection..

```
$ curl -k -X GET https://${bmc}/redfish/v1/Chassis/chassis
{
  "@odata.id": "/redfish/v1/Chassis/chassis",
  "@odata.type": "#Chassis.v1_22_0.Chassis",

  "Links": {
    "Contains": [
      ...
      {
        "@odata.id": "/redfish/v1/Chassis/connector4"
      },
...
```

This causes Redfish Service Validator failures.  So, we've decided
to review this commit https://github.com/ibm-openbmc/bmcweb/commit/a56174963e1d8bd9fc90cdeb3aa7f1b7f2e0dca4.

Tested:

- Check Chassi/Links collection to check non-chassis resources.
```
curl -k -X GET https://${bmc}/redfish/v1/Chassis/chassis
```

- Redfish Service Validator passes

Change-Id: I472fc12379694acc35055965400141dbb1b33bfc