### PR TITLE
Core enabled hw iso onwards

### DIFF
--- a/redfish-core/include/utils/hw_isolation.hpp
+++ b/redfish-core/include/utils/hw_isolation.hpp
@@ -1,0 +1,338 @@
+#pragma once
+
+#include <error_messages.hpp>
+#include <sdbusplus/message.hpp>
+
+#include <memory>
+#include <string>
+#include <vector>
+
+namespace redfish
+{
+namespace hw_isolation_utils
+{
+
+/**
+ * @brief API used to isolate the given resource
+ *
+ * @param[in] asyncResp - The redfish response to return to the caller.
+ * @param[in] resourceName - The redfish resource name which trying to isolate.
+ * @param[in] resourceId - The redfish resource id which trying to isolate.
+ * @param[in] resourceObjPath - The redfish resource dbus object path.
+ * @param[in] hwIsolationDbusName - The HardwareIsolation dbus name which is
+ *                                  hosting isolation dbus interfaces.
+ *
+ * @return The redfish response in given response buffer.
+ *
+ * @note This function will return the appropriate error based on the isolation
+ *       dbus "Create" interface error.
+ */
+inline void
+    isolateResource(const std::shared_ptr<bmcweb::AsyncResp>& asyncResp,
+                    const std::string& resourceName,
+                    const std::string& resourceId,
+                    const sdbusplus::message::object_path& resourceObjPath,
+                    const std::string& hwIsolationDbusName)
+{
+    crow::connections::systemBus->async_method_call(
+        [asyncResp, resourceName, resourceId,
+         resourceObjPath](const boost::system::error_code& ec,
+                          const sdbusplus::message::message& msg) {
+        if (!ec)
+        {
+            messages::success(asyncResp->res);
+            return;
+        }
+
+        BMCWEB_LOG_ERROR(
+            "DBUS response error [{} : {}] when tried to isolate the given resource: {}",
+            ec.value(), ec.message(), resourceObjPath.str);
+
+        const sd_bus_error* dbusError = msg.get_error();
+        if (dbusError == nullptr)
+        {
+            messages::internalError(asyncResp->res);
+            return;
+        }
+
+        BMCWEB_LOG_ERROR("DBus ErrorName: {} ErrorMsg: {}", dbusError->name,
+                         dbusError->message);
+
+        if (std::string_view(
+                "xyz.openbmc_project.Common.Error.InvalidArgument") ==
+            dbusError->name)
+        {
+            constexpr bool isolate = false;
+            messages::propertyValueIncorrect(
+                asyncResp->res, "@odata.id",
+                std::to_string(static_cast<int>(isolate)));
+        }
+        else if (std::string_view(
+                     "xyz.openbmc_project.Common.Error.NotAllowed") ==
+                 dbusError->name)
+        {
+            messages::propertyNotWritable(asyncResp->res, "Enabled");
+        }
+        else if (std::string_view(
+                     "xyz.openbmc_project.Common.Error.Unavailable") ==
+                 dbusError->name)
+        {
+            messages::resourceInStandby(asyncResp->res);
+        }
+        else if (
+            std::string_view(
+                "xyz.openbmc_project.HardwareIsolation.Error.IsolatedAlready") ==
+            dbusError->name)
+        {
+            messages::resourceAlreadyExists(asyncResp->res, "@odata.id",
+                                            resourceName, resourceId);
+        }
+        else if (std::string_view(
+                     "xyz.openbmc_project.Common.Error.TooManyResources") ==
+                 dbusError->name)
+        {
+            messages::createLimitReachedForResource(asyncResp->res);
+        }
+        else
+        {
+            BMCWEB_LOG_ERROR(
+                "DBus Error is unsupported so returning as Internal Error");
+            messages::internalError(asyncResp->res);
+        }
+        return;
+    },
+        hwIsolationDbusName, "/xyz/openbmc_project/hardware_isolation",
+        "xyz.openbmc_project.HardwareIsolation.Create", "Create",
+        resourceObjPath,
+        "xyz.openbmc_project.HardwareIsolation.Entry.Type.Manual");
+}
+
+/**
+ * @brief API used to deisolate the given resource
+ *
+ * @param[in] asyncResp - The redfish response to return to the caller.
+ * @param[in] resourceObjPath - The redfish resource dbus object path.
+ * @param[in] hwIsolationDbusName - The HardwareIsolation dbus name which is
+ *                                  hosting isolation dbus interfaces.
+ *
+ * @return The redfish response in given response buffer.
+ *
+ * @note - This function will try to identify the hardware isolated dbus entry
+ *         from associations endpoints by using the given resource dbus object
+ *         of "isolated_hw_entry".
+ *       - This function will use the last endpoint from the list since the
+ *         HardwareIsolation manager may be used the "Resolved" dbus entry
+ *         property to indicate the deisolation instead of delete
+ *         the entry object.
+ */
+inline void
+    deisolateResource(const std::shared_ptr<bmcweb::AsyncResp>& asyncResp,
+                      const sdbusplus::message::object_path& resourceObjPath,
+                      const std::string& hwIsolationDbusName)
+{
+    // Get the HardwareIsolation entry by using the given resource
+    // associations endpoints
+    crow::connections::systemBus->async_method_call(
+        [asyncResp, resourceObjPath, hwIsolationDbusName](
+            boost::system::error_code& ec,
+            const std::variant<std::vector<std::string>>& vEndpoints) {
+        if (ec)
+        {
+            BMCWEB_LOG_ERROR(
+                "DBus response error [{} : {}] when tried to get the hardware isolation entry for the given resource dbus object path: ",
+                ec.value(), ec.message(), resourceObjPath.str);
+            messages::internalError(asyncResp->res);
+            return;
+        }
+
+        std::string resourceIsolatedHwEntry;
+        const std::vector<std::string>* endpoints =
+            std::get_if<std::vector<std::string>>(&(vEndpoints));
+        if (endpoints == nullptr)
+        {
+            BMCWEB_LOG_ERROR(
+                "Failed to get Associations endpoints for the given object path: {}",
+                resourceObjPath.str);
+            messages::internalError(asyncResp->res);
+            return;
+        }
+        resourceIsolatedHwEntry = endpoints->back();
+
+        // De-isolate the given resource
+        crow::connections::systemBus->async_method_call(
+            [asyncResp,
+             resourceIsolatedHwEntry](const boost::system::error_code& ec1,
+                                      const sdbusplus::message::message& msg) {
+            if (!ec1)
+            {
+                messages::success(asyncResp->res);
+                return;
+            }
+
+            BMCWEB_LOG_ERROR(
+                "DBUS response error [{} : {}] when tried to isolate the given resource: {}",
+                ec1.value(), ec1.message(), resourceIsolatedHwEntry);
+
+            const sd_bus_error* dbusError = msg.get_error();
+
+            if (dbusError == nullptr)
+            {
+                messages::internalError(asyncResp->res);
+                return;
+            }
+
+            BMCWEB_LOG_ERROR("DBus ErrorName: {} ErrorMsg: {}", dbusError->name,
+                             dbusError->message);
+
+            if (std::string_view(
+                    "xyz.openbmc_project.Common.Error.NotAllowed") ==
+                dbusError->name)
+            {
+                messages::propertyNotWritable(asyncResp->res, "Entry");
+            }
+            else if (std::string_view(
+                         "xyz.openbmc_project.Common.Error.Unavailable") ==
+                     dbusError->name)
+            {
+                messages::resourceInStandby(asyncResp->res);
+            }
+            else
+            {
+                BMCWEB_LOG_ERROR(
+                    "DBus Error is unsupported so returning as Internal Error");
+                messages::internalError(asyncResp->res);
+            }
+            return;
+        },
+            hwIsolationDbusName, resourceIsolatedHwEntry,
+            "xyz.openbmc_project.Object.Delete", "Delete");
+    },
+        "xyz.openbmc_project.ObjectMapper",
+        resourceObjPath.str + "/isolated_hw_entry",
+        "org.freedesktop.DBus.Properties", "Get",
+        "xyz.openbmc_project.Association", "endpoints");
+}
+
+/**
+ * @brief API used to process hardware (aka resource) isolation request
+ *        This API can be used to any redfish resource if that redfish
+ *        supporting isolation feature (the resource can be isolate
+ *        from system boot)
+ *
+ * @param[in] asyncResp - The redfish response to return to the caller.
+ * @param[in] resourceName - The redfish resource name which trying to isolate.
+ * @param[in] resourceId - The redfish resource id which trying to isolate.
+ * @param[in] enabled - The redfish resource "Enabled" property value.
+ * @param[in] interfaces - The redfish resource dbus interfaces which will use
+ *                         to get the given resource dbus objects from
+ *                         the inventory.
+ *
+ * @return The redfish response in given response buffer.
+ *
+ * @note - This function will identify the given resource dbus object from
+ *         the inventory by using the given resource dbus interfaces along
+ *         with "Object:Enable" interface (which is used to map the "Enabled"
+ *         redfish property to dbus "Enabled" property - The "Enabled" is
+ *         used to do isolate the resource from system boot) and the given
+ *         redfish resource "Id".
+ *       - This function will do either isolate or deisolate based on the
+ *         given "Enabled" property value.
+ */
+inline void processHardwareIsolationReq(
+    const std::shared_ptr<bmcweb::AsyncResp>& asyncResp,
+    const std::string& resourceName, const std::string& resourceId,
+    bool enabled, const std::vector<std::string_view>& interfaces)
+{
+    std::vector<std::string_view> resourceIfaces(interfaces.begin(),
+                                                 interfaces.end());
+    resourceIfaces.emplace_back("xyz.openbmc_project.Object.Enable");
+
+    // Make sure the given resourceId is present in inventory
+    crow::connections::systemBus->async_method_call(
+        [asyncResp, resourceName, resourceId,
+         enabled](boost::system::error_code& ec,
+                  const dbus::utility::MapperGetSubTreePathsResponse& objects) {
+        if (ec)
+        {
+            BMCWEB_LOG_ERROR(
+                "DBus response error [{} : {}] when tried to check the given resource is present in the inventory",
+                ec.value(), ec.message());
+            messages::internalError(asyncResp->res);
+            return;
+        }
+
+        sdbusplus::message::object_path resourceObjPath;
+        for (const auto& object : objects)
+        {
+            sdbusplus::message::object_path path(object);
+            if (path.filename() == resourceId)
+            {
+                resourceObjPath = path;
+                break;
+            }
+        }
+
+        if (resourceObjPath.str.empty())
+        {
+            messages::resourceNotFound(asyncResp->res, resourceName,
+                                       resourceId);
+            return;
+        }
+
+        // Get the HardwareIsolation DBus name
+        crow::connections::systemBus->async_method_call(
+            [asyncResp, resourceObjPath, enabled, resourceName,
+             resourceId](const boost::system::error_code& ec1,
+                         const dbus::utility::MapperGetObject& objType) {
+            if (ec1)
+            {
+                BMCWEB_LOG_ERROR(
+                    "DBUS response error [{} : {}] when tried to get the HardwareIsolation dbus name to isolate: ",
+                    ec1.value(), ec1.message(), resourceObjPath.str);
+                messages::internalError(asyncResp->res);
+                return;
+            }
+
+            if (objType.size() > 1)
+            {
+                BMCWEB_LOG_ERROR(
+                    "More than one dbus service implemented HardwareIsolation");
+                messages::internalError(asyncResp->res);
+                return;
+            }
+
+            if (objType[0].first.empty())
+            {
+                BMCWEB_LOG_ERROR(
+                    "The retrieved HardwareIsolation dbus name is empty");
+                messages::internalError(asyncResp->res);
+                return;
+            }
+
+            // Make sure whether need to isolate or de-isolate
+            // the given resource
+            if (!enabled)
+            {
+                isolateResource(asyncResp, resourceName, resourceId,
+                                resourceObjPath, objType[0].first);
+            }
+            else
+            {
+                deisolateResource(asyncResp, resourceObjPath, objType[0].first);
+            }
+        },
+            "xyz.openbmc_project.ObjectMapper",
+            "/xyz/openbmc_project/object_mapper",
+            "xyz.openbmc_project.ObjectMapper", "GetObject",
+            "/xyz/openbmc_project/hardware_isolation",
+            std::array<const char*, 1>{
+                "xyz.openbmc_project.HardwareIsolation.Create"});
+    },
+        "xyz.openbmc_project.ObjectMapper",
+        "/xyz/openbmc_project/object_mapper",
+        "xyz.openbmc_project.ObjectMapper", "GetSubTreePaths",
+        "/xyz/openbmc_project/inventory", 0, resourceIfaces);
+}
+
+} // namespace hw_isolation_utils
+} // namespace redfish

--- a/redfish-core/lib/processor.hpp
+++ b/redfish-core/lib/processor.hpp
@@ -2010,8 +2010,9 @@ inline void requestRoutesProcessor(App& app)
  *
  * @note - The "Enabled" member of the Processor Core is used to enable
  *         (aka isolate) or disable (aka deisolate) the resource from the
- *         system boot so this function will call "processHardwareIsolationReq"
- *         function which is used to handle the resource isolation request.
+ *         system boot so this function will call
+ * "processHardwareIsolationReq" function which is used to handle the
+ * resource isolation request.
  *       - The "Enabled" member of the Processor Core is mapped with
  *         "xyz.openbmc_project.Object.Enable::Enabled" dbus property.
  */
@@ -2029,15 +2030,17 @@ inline void
  * @brief API used to process the Processor Core members which are tried to
  *        patch.
  *
- * @param[in] req - The redfish patched request to identify the patched members
+ * @param[in] req - The redfish patched request to identify the patched
+ * members
  * @param[in] asyncResp - The redfish response to return.
- * @param[in] processorId - The patched Core Processor resource id (unused now)
+ * @param[in] processorId - The patched Core Processor resource id (unused
+ * now)
  * @param[in] coreId - The patched Processor Core resource id.
  *
  * @return The redfish response in the given buffer.
  *
- * @note This function will call the appropriate function to handle the patched
- *       members of the Processor Core.
+ * @note This function will call the appropriate function to handle the
+ * patched members of the Processor Core.
  */
 inline void
     patchCpuCoreMembers(const crow::Request& req,
@@ -2057,4 +2060,23 @@ inline void
         patchCpuCoreMemberEnabled(asyncResp, coreId, *enabled);
     }
 }
+
+inline void requestRoutesSubProcessorsCore(App& app)
+{
+    BMCWEB_ROUTE(
+        app, "/redfish/v1/Systems/system/Processors/<str>/SubProcessors/<str>")
+        .privileges(redfish::privileges::getProcessor)
+        .methods(boost::beast::http::verb::get)(
+            [](const crow::Request&,
+               const std::shared_ptr<bmcweb::AsyncResp>& asyncResp,
+               const std::string& processorId, const std::string& coreId) {
+        getSubProcessorData(asyncResp, processorId, coreId);
+    });
+
+    BMCWEB_ROUTE(
+        app, "/redfish/v1/Systems/system/Processors/<str>/SubProcessors/<str>")
+        .privileges(redfish::privileges::patchProcessor)
+        .methods(boost::beast::http::verb::patch)(patchCpuCoreMembers);
+}
+
 } // namespace redfish

--- a/redfish-core/lib/processor.hpp
+++ b/redfish-core/lib/processor.hpp
@@ -25,6 +25,7 @@
 #include "registries/privilege_registry.hpp"
 #include "utils/collection.hpp"
 #include "utils/dbus_utils.hpp"
+#include "utils/hw_isolation.hpp"
 #include "utils/json_utils.hpp"
 #include "utils/name_utils.hpp"
 
@@ -48,6 +49,10 @@ namespace redfish
 constexpr std::array<std::string_view, 2> processorInterfaces = {
     "xyz.openbmc_project.Inventory.Item.Cpu",
     "xyz.openbmc_project.Inventory.Item.Accelerator"};
+
+// Interfaces which imply a D-Bus object represents a Processor Core
+constexpr std::array<std::string_view, 1> procCoreInterfaces = {
+    "xyz.openbmc_project.Inventory.Item.CpuCore"};
 
 /**
  * @brief Workaround to handle DCM (Dual-Chip Module) package for Redfish
@@ -727,8 +732,7 @@ inline void
             // config.
             sdbusplus::asio::getProperty<BaseSpeedPrioritySettingsProperty>(
                 *crow::connections::systemBus, service, dbusPath,
-                "xyz.openbmc_project.Inventory.Item.Cpu."
-                "OperatingConfig",
+                "xyz.openbmc_project.Inventory.Item.Cpu.OperatingConfig",
                 "BaseSpeedPrioritySettings",
                 [asyncResp](
                     const boost::system::error_code& ec2,
@@ -895,6 +899,14 @@ inline void
                      const std::string& objectPath,
                      const dbus::utility::MapperServiceMap& serviceMap)
 {
+    asyncResp->res.jsonValue["@odata.type"] = "#Processor.v1_18_0.Processor";
+    asyncResp->res.jsonValue["@odata.id"] = boost::urls::format(
+        "/redfish/v1/Systems/system/Processors/{}", processorId);
+    asyncResp->res.jsonValue["SubProcessors"]["@odata.id"] =
+        boost::urls::format(
+            "/redfish/v1/Systems/system/Processors/{}/SubProcessors",
+            processorId);
+
     for (const auto& [serviceName, interfaceList] : serviceMap)
     {
         bool assetInterface = false;
@@ -976,6 +988,277 @@ inline void
             getLocationIndicatorActive(asyncResp, objectPath);
         }
     }
+}
+
+template <typename Handler>
+inline void
+    getProcessorPaths(const std::shared_ptr<bmcweb::AsyncResp>& asyncResp,
+                      const std::string& processorId, Handler&& handler)
+{
+    crow::connections::systemBus->async_method_call(
+        [processorId, asyncResp, handler{std::forward<Handler>(handler)}](
+            const boost::system::error_code& ec,
+            const dbus::utility::MapperGetSubTreePathsResponse& subTreePaths) {
+        if (ec)
+        {
+            BMCWEB_LOG_ERROR("DBUS response error");
+            // No processor objects found by mapper
+            if (ec.value() == boost::system::errc::io_error)
+            {
+                messages::resourceNotFound(asyncResp->res,
+                                           "#Processor.v1_18_0.Processor",
+                                           processorId);
+                return;
+            }
+
+            messages::internalError(asyncResp->res);
+            return;
+        }
+
+        for (const std::string& cpuPath : subTreePaths)
+        {
+            if (!isProcObjectMatched(processorId,
+                                     sdbusplus::message::object_path(cpuPath)))
+            {
+                continue;
+            }
+
+            handler(cpuPath);
+            return;
+        }
+
+        // Object not found
+        messages::resourceNotFound(
+            asyncResp->res, "#Processor.v1_18_0.Processorr", processorId);
+    },
+        "xyz.openbmc_project.ObjectMapper",
+        "/xyz/openbmc_project/object_mapper",
+        "xyz.openbmc_project.ObjectMapper", "GetSubTreePaths",
+        "/xyz/openbmc_project/inventory", 0,
+        std::array<const char*, 1>{"xyz.openbmc_project.Inventory.Item.Cpu"});
+}
+
+inline void
+    getCpuCoreDataByService(const std::shared_ptr<bmcweb::AsyncResp>& asyncResp,
+                            const std::string& service,
+                            const std::string& objPath)
+{
+    BMCWEB_LOG_DEBUG("Get available system cpu core resources by service.");
+
+    asyncResp->res.jsonValue["Status"]["State"] = "Enabled";
+    asyncResp->res.jsonValue["Status"]["Health"] = "OK";
+
+    crow::connections::systemBus->async_method_call(
+        [objPath, asyncResp](const boost::system::error_code& ec,
+                             const dbus::utility::ManagedObjectType& dbusData) {
+        if (ec)
+        {
+            BMCWEB_LOG_DEBUG("DBUS response error, ec: {}", ec.value());
+            messages::internalError(asyncResp->res);
+            return;
+        }
+
+        for (const auto& [path, interfaces] : dbusData)
+        {
+            if (path != objPath)
+            {
+                continue;
+            }
+
+            bool present = true;
+            bool functional = true;
+
+            for (const auto& [interface, properties] : interfaces)
+            {
+                if (interface ==
+                    "xyz.openbmc_project.State.Decorator.OperationalStatus")
+                {
+                    for (const auto& [propName, propValue] : properties)
+                    {
+                        if (propName == "Functional")
+                        {
+                            const bool* value = std::get_if<bool>(&propValue);
+                            if (value == nullptr)
+                            {
+                                messages::internalError(asyncResp->res);
+                                return;
+                            }
+                            functional = *value;
+                        }
+                    }
+                }
+                else if (interface == "xyz.openbmc_project.Inventory.Item")
+                {
+                    for (const auto& [propName, propValue] : properties)
+                    {
+                        if (propName == "Present")
+                        {
+                            const bool* value = std::get_if<bool>(&propValue);
+                            if (value == nullptr)
+                            {
+                                messages::internalError(asyncResp->res);
+                                return;
+                            }
+                            present = *value;
+                        }
+                        else if (propName == "PrettyName")
+                        {
+                            const std::string* prettyName =
+                                std::get_if<std::string>(&propValue);
+                            if (prettyName == nullptr)
+                            {
+                                messages::internalError(asyncResp->res);
+                                return;
+                            }
+                            asyncResp->res.jsonValue["Name"] = *prettyName;
+                        }
+                    }
+                }
+            }
+
+            if (!present)
+            {
+                asyncResp->res.jsonValue["Status"]["State"] = "Absent";
+            }
+            else
+            {
+                if (!functional)
+                {
+                    asyncResp->res.jsonValue["Status"]["Health"] = "Critical";
+                }
+            }
+        }
+    },
+        service, "/xyz/openbmc_project/inventory",
+        "org.freedesktop.DBus.ObjectManager", "GetManagedObjects");
+}
+
+inline void
+    getSubProcessorData(const std::shared_ptr<bmcweb::AsyncResp>& asyncResp,
+                        const std::string& processorId,
+                        const std::string& coreId)
+{
+    BMCWEB_LOG_DEBUG("Get available system sub processor resources.");
+
+    auto callback = [asyncResp, processorId,
+                     coreId](const std::string& cpuPath) {
+        crow::connections::systemBus->async_method_call(
+            [asyncResp, processorId,
+             coreId](const boost::system::error_code& ec,
+                     const dbus::utility::MapperGetSubTreeResponse& subtree) {
+            if (ec)
+            {
+                BMCWEB_LOG_DEBUG("DBUS response error, ec: {}", ec.value());
+                // No processor objects found by mapper
+                if (ec.value() == boost::system::errc::io_error)
+                {
+                    messages::resourceNotFound(asyncResp->res,
+                                               "#Processor.v1_18_0.Processor",
+                                               processorId);
+                    return;
+                }
+
+                messages::internalError(asyncResp->res);
+                return;
+            }
+
+            for (const auto& object : subtree)
+            {
+                if (sdbusplus::message::object_path(object.first).filename() !=
+                    coreId)
+                {
+                    continue;
+                }
+
+                asyncResp->res.jsonValue["@odata.type"] =
+                    "#Processor.v1_18_0.Processor";
+                asyncResp->res.jsonValue["@odata.id"] = boost::urls::format(
+                    "/redfish/v1/Systems/system/Processors/{}/SubProcessors/{}",
+                    processorId, coreId);
+                asyncResp->res.jsonValue["Name"] = "SubProcessor";
+                asyncResp->res.jsonValue["Id"] = coreId;
+
+                for (const auto& service : object.second)
+                {
+                    getCpuCoreDataByService(asyncResp, service.first,
+                                            object.first);
+                    break;
+                }
+                return;
+            }
+
+            if (!subtree.empty())
+            {
+                // Object not found
+                messages::resourceNotFound(
+                    asyncResp->res, "#Processor.v1_18_0.Processor", coreId);
+                return;
+            }
+        },
+            "xyz.openbmc_project.ObjectMapper",
+            "/xyz/openbmc_project/object_mapper",
+            "xyz.openbmc_project.ObjectMapper", "GetSubTree", cpuPath, 0,
+            procCoreInterfaces);
+    };
+
+    getProcessorPaths(asyncResp, processorId, std::move(callback));
+}
+
+inline void
+    getSubProcessorMembers(const std::shared_ptr<bmcweb::AsyncResp>& asyncResp,
+                           const std::string& processorId)
+{
+    auto callback = [asyncResp, processorId](const std::string& cpuPath) {
+        crow::connections::systemBus->async_method_call(
+            [processorId,
+             asyncResp](const boost::system::error_code& ec,
+                        const std::vector<std::string>& subTreePaths) {
+            if (ec)
+            {
+                BMCWEB_LOG_ERROR("DBUS response error");
+                // No processor objects found by mapper
+                if (ec.value() == boost::system::errc::io_error)
+                {
+                    messages::resourceNotFound(asyncResp->res,
+                                               "#Processor.v1_18_0.Processor",
+                                               processorId);
+                    return;
+                }
+
+                messages::internalError(asyncResp->res);
+                return;
+            }
+
+            asyncResp->res.jsonValue["@odata.type"] =
+                "#ProcessorCollection.ProcessorCollection";
+            asyncResp->res.jsonValue["@odata.id"] = boost::urls::format(
+                "/redfish/v1/Systems/system/Processors/{}/SubProcessors",
+                processorId);
+            asyncResp->res.jsonValue["Name"] = "SubProcessor Collection";
+            nlohmann::json& members = asyncResp->res.jsonValue["Members"];
+            members = nlohmann::json::array();
+            std::string subProcessorsPath =
+                (boost::urls::format(
+                     "/redfish/v1/Systems/system/Processors/{}/SubProcessors",
+                     processorId)
+                     .buffer());
+            for (const std::string& corePath : subTreePaths)
+            {
+                nlohmann::json::object_t item;
+                item["@odata.id"] = boost::urls::format(
+                    "{}/{}", subProcessorsPath,
+                    sdbusplus::message::object_path(corePath).filename());
+                members.emplace_back(std::move(item));
+            }
+            asyncResp->res.jsonValue["Members@odata.count"] = members.size();
+        },
+            "xyz.openbmc_project.ObjectMapper",
+            "/xyz/openbmc_project/object_mapper",
+            "xyz.openbmc_project.ObjectMapper", "GetSubTreePaths", cpuPath, 0,
+            procCoreInterfaces);
+    };
+
+    getProcessorPaths(asyncResp, processorId, std::move(callback));
 }
 
 /**
@@ -1161,9 +1444,10 @@ inline void patchAppliedOperatingConfig(
     const std::string* controlService = nullptr;
     for (const auto& [serviceName, interfaceList] : serviceMap)
     {
-        if (std::ranges::find(interfaceList,
-                              "xyz.openbmc_project.Control.Processor."
-                              "CurrentOperatingConfig") != interfaceList.end())
+        if (std::ranges::find(
+                interfaceList,
+                "xyz.openbmc_project.Control.Processor.CurrentOperatingConfig") !=
+            interfaceList.end())
         {
             controlService = &serviceName;
             break;
@@ -1714,4 +1998,63 @@ inline void requestRoutesProcessor(App& app)
             std::bind_front(handleProcessorPatch, std::ref(app)));
 }
 
+/**
+ * @brief API used to process the Processor Core "Enabled" member which is
+ *        patched to do appropriate action.
+ *
+ * @param[in] asyncResp - The redfish response to return.
+ * @param[in] coreId - The patched Processor Core resource id.
+ * @param[in] enabled - The patched "Enabled" member value.
+ *
+ * @return The redfish response in the given buffer.
+ *
+ * @note - The "Enabled" member of the Processor Core is used to enable
+ *         (aka isolate) or disable (aka deisolate) the resource from the
+ *         system boot so this function will call "processHardwareIsolationReq"
+ *         function which is used to handle the resource isolation request.
+ *       - The "Enabled" member of the Processor Core is mapped with
+ *         "xyz.openbmc_project.Object.Enable::Enabled" dbus property.
+ */
+inline void
+    patchCpuCoreMemberEnabled(const std::shared_ptr<bmcweb::AsyncResp>& resp,
+                              const std::string& coreId, const bool enabled)
+{
+    redfish::hw_isolation_utils::processHardwareIsolationReq(
+        resp, "Core", coreId, enabled,
+        std::vector<std::string_view>(procCoreInterfaces.begin(),
+                                      procCoreInterfaces.end()));
+}
+
+/**
+ * @brief API used to process the Processor Core members which are tried to
+ *        patch.
+ *
+ * @param[in] req - The redfish patched request to identify the patched members
+ * @param[in] asyncResp - The redfish response to return.
+ * @param[in] processorId - The patched Core Processor resource id (unused now)
+ * @param[in] coreId - The patched Processor Core resource id.
+ *
+ * @return The redfish response in the given buffer.
+ *
+ * @note This function will call the appropriate function to handle the patched
+ *       members of the Processor Core.
+ */
+inline void
+    patchCpuCoreMembers(const crow::Request& req,
+                        const std::shared_ptr<bmcweb::AsyncResp>& asyncResp,
+                        const std::string& /* processorId */,
+                        const std::string& coreId)
+{
+    std::optional<bool> enabled;
+
+    if (!json_util::readJsonPatch(req, asyncResp->res, "Enabled", enabled))
+    {
+        return;
+    }
+
+    if (enabled.has_value())
+    {
+        patchCpuCoreMemberEnabled(asyncResp, coreId, *enabled);
+    }
+}
 } // namespace redfish


### PR DESCRIPTION
The following commits are cherry picked
[redfish-core: Core: Enabled the isolation (aka guard) feature](https://github.com/ibm-openbmc/bmcweb/pull/542/commits/1780452abef6b9e167ffac8c27d6cbdd0be7934f)

[redfish-core: Memory: Enabled the isolation (aka guard) feature](https://github.com/ibm-openbmc/bmcweb/pull/542/commits/70c213769052d24244ce58e9836f6f45cedf474c)