### PR TITLE
1110: Fix get Processor data handling of PrettyName

### DIFF
--- a/redfish-core/lib/processor.hpp
+++ b/redfish-core/lib/processor.hpp
@@ -864,8 +864,9 @@ inline void getProcessorObject(const std::shared_ptr<bmcweb::AsyncResp>& resp,
             // Filter out objects that don't have the CPU-specific
             // interfaces to make sure we can return 404 on non-CPUs
             // (e.g. /redfish/../Processors/dimm0)
-            for (const auto& [serviceName, interfaceList] : serviceMap)
+            for (const auto& serviceEntry : serviceMap)
             {
+                const auto& interfaceList = serviceEntry.second;
                 if (std::ranges::find_first_of(interfaceList,
                                                processorInterfaces) !=
                     std::end(interfaceList))
@@ -876,7 +877,9 @@ inline void getProcessorObject(const std::shared_ptr<bmcweb::AsyncResp>& resp,
                     // process must be on the same object path.
 
                     handler(objectPath, serviceMap);
-                    name_util::getPrettyName(resp, objectPath, serviceMap,
+                    const dbus::utility::MapperServiceMap& serviceMatch = {
+                        serviceEntry};
+                    name_util::getPrettyName(resp, objectPath, serviceMatch,
                                              "/Name"_json_pointer);
                     return;
                 }


### PR DESCRIPTION
PR https://github.com/ibm-openbmc/bmcweb/pull/918 introduced a problem with getting the PrettyName for Processors.

getPrettyName() expects only a single object in the MapperServiceMap. Processors have two: org.open_power.OCC.Control and xyz.openbmc_project.Inventory.Manager.

Without fix, pretty name is not used and an error is returned:
```
$ curl -k -H "X-Auth-Token: $token" https://${bmc}/redfish/v1/Systems/system/Processors/dcm0-cpu0
{
  "@odata.id": "/redfish/v1/Systems/system/Processors/dcm0-cpu0",
  "@odata.type": "#Processor.v1_18_0.Processor",
  "Id": "dcm0-cpu0",
  "Location": {
    "PartLocation": {
      "ServiceLabel": "U78DA.ND0.WZS004A-P0-C15"
    }
  },
  "LocationIndicatorActive": false,
  "Manufacturer": "",
  "MaxSpeedMHz": 0,
  "Model": "5C67",
  "Name": "Processor",
  "PartNumber": "03JM290",
  "ProcessorType": "CPU",
  "SerialNumber": "YA3936079431",
  "Socket": "",
  "SparePartNumber": "F210110",
  "Status": {
    "Health": "Critical",
    "State": "Enabled"
  },
  "ThrottleCauses": [],
  "Throttled": false,
  "TotalCores": 8,
  "TotalThreads": 0,
  "error": {
    "@Message.ExtendedInfo": [
      {
        "@odata.type": "#Message.v1_1_1.Message",
        "Message": "The request failed due to an internal service error.  The service is still operational.",
        "MessageArgs": [],
        "MessageId": "Base.1.16.0.InternalError",
        "MessageSeverity": "Critical",
        "Resolution": "Resubmit the request.  If the problem persists, consider resetting the service."
      }
    ],
    "code": "Base.1.16.0.InternalError",
    "message": "The request failed due to an internal service error.  The service is still operational."
  }
}
```

The journal log shows an error as well:
```
[ERROR name_utils.hpp:40] Invalid Service Size  2
[CRITICAL error_messages.cpp:288] Internal Error /usr/src/debug/bmcweb/1.0+git/redfish-core/include/utils/name_utils.hpp(43:36) `void redfish::name_util::getPrettyName(const std::shared_ptr<bmcweb::AsyncResp>&, const std::string&, const dbus::utility::MapperServiceMap&, const nlohmann::json_abi_v3_11_3::basic_json<>::json_pointer&)`:
```
With fix, name shows using PrettyName and no error is reported:
```
$ curl -k -H "X-Auth-Token: $token" https://${bmc}/redfish/v1/Systems/system/Processors/dcm0-cpu0
{
  "@odata.id": "/redfish/v1/Systems/system/Processors/dcm0-cpu0",
  "@odata.type": "#Processor.v1_18_0.Processor",
  "Id": "dcm0-cpu0",
  "Location": {
    "PartLocation": {
      "ServiceLabel": "U78DA.ND0.WZS004A-P0-C15"
    }
  },
  "LocationIndicatorActive": false,
  "Manufacturer": "",
  "MaxSpeedMHz": 0,
  "Model": "5C67",
  "Name": "System processor module 0",
  "PartNumber": "03JM290",
  "ProcessorType": "CPU",
  "SerialNumber": "YA3936079431",
  "Socket": "",
  "SparePartNumber": "F210110",
  "Status": {
    "Health": "Critical",
    "State": "Enabled"
  },
  "ThrottleCauses": [],
  "Throttled": false,
  "TotalCores": 8,
  "TotalThreads": 0
}
```