### PR TITLE
1110: Implement SubProcessors for processor core

### DIFF
--- a/redfish-core/src/redfish.cpp
+++ b/redfish-core/src/redfish.cpp
@@ -173,6 +173,8 @@ RedfishService::RedfishService(App& app)
     requestRoutesOperatingConfig(app);
     requestRoutesMemoryCollection(app);
     requestRoutesMemory(app);
+    requestRoutesSubProcessors(app);
+    requestRoutesSubProcessorsCore(app);
 
     requestRoutesSystems(app);
     requestRoutesSystemActionsOemExecutePanelFunction(app);


### PR DESCRIPTION
Rebase of two commits for SubProcessor for processor core. Includes changes to align with current upstream code style and some semantic changes.

(Note: https://github.com/ibm-openbmc/bmcweb/pull/986 pulled in this in-progress PR and merged first. So it added the new functions needed for SubProcessor support but not the routes.)

1) First commit (https://github.com/ibm-openbmc/bmcweb/commit/1afe3f87f66ecaa87f8f431d92869aac605f8866):
Implement SubProcessors for processor core

- Add the SubProcessors class to bmcweb to support processor cores.

- The SubProcessors collection is a collection under the processor schema. An association, <insert association name>, is used to link the core to the processor.

Tested: Validator passes
```
curl -k -H "X-Auth-Token: $token"
https://${bmc}/redfish/v1/Systems/system/Processors/cpu0
{
  "@odata.id": "/redfish/v1/Systems/system/Processors/cpu0",
  "@odata.type": "#Processor.v1_11_0.Processor",
  "Id": "cpu0",
  "InstructionSet": "PowerISA",
  "Manufacturer": "IBM",
  "SubProcessors": {
    "@odata.id": "/redfish/v1/Systems/system/Processors/cpu0/SubProcessors"
  }
    ... ...
}

curl -k -H "X-Auth-Token: $token"
https://${bmc}/redfish/v1/Systems/system/Processors/cpu0/SubProcessors
{
  "@odata.id": "/redfish/v1/Systems/system/Processors/cpu0/SubProcessors",
  "@odata.type": "#ProcessorCollection.ProcessorCollection",
  "Members": [
    {
      "@odata.id": "/redfish/v1/Systems/system/Processors/cpu0/SubProcessors/core0"
    },
    {
      "@odata.id": "/redfish/v1/Systems/system/Processors/cpu0/SubProcessors/core1"
    }
    ... ...
  ],
  ... ...
}

curl -k -H "X-Auth-Token: $token"
https://${bmc}/redfish/v1/Systems/system/Processors/cpu0/SubProcessors/core1
{
  "@odata.id": "/redfish/v1/Systems/system/Processors/cpu0/SubProcessors/core1",
  "@odata.type": "#Processor.v1_11_0.Processor",
  "Id": "core1",
    "Name": "",
    "Status": {
        "Health": "OK",
        "State": "Enabled"
    }
}
```


Change-Id: If155b97b0c782d82541c00ecf5ee70cb0180f71f

Conflicts:
  redfish-core/lib/processor.hpp

2) Second commit (https://github.com/ibm-openbmc/bmcweb/commit/bb811111eda602a603632dacbfd0db40984e36b2):

Implement SubProcessors for processor core

- Add the SubProcessors class to bmcweb to support processor cores.

- The SubProcessors collection is a collection under the processor schema. An association, <insert association name>, is used to link the core to the processor.

Tested: Validator passes
```
curl -k -H "X-Auth-Token: $token"
https://${bmc}/redfish/v1/Systems/system/Processors/cpu0
{
  "@odata.id": "/redfish/v1/Systems/system/Processors/cpu0",
  "@odata.type": "#Processor.v1_11_0.Processor",
  "Id": "cpu0",
  "InstructionSet": "PowerISA",
  "Manufacturer": "IBM",
  "SubProcessors": {
    "@odata.id": "/redfish/v1/Systems/system/Processors/cpu0/ \
                  SubProcessors"
  }
    ... ...
}

curl -k -H "X-Auth-Token: $token"
https://${bmc}/redfish/v1/Systems/system/Processors/cpu0/ \
SubProcessors
{
  "@odata.id": "/redfish/v1/Systems/system/Processors/cpu0/ \
                SubProcessors",
  "@odata.type": "#ProcessorCollection.ProcessorCollection",
  "Members": [
    {
      "@odata.id": "/redfish/v1/Systems/system/Processors/cpu0/ \
                    SubProcessors/core0"
    },
    {
      "@odata.id": "/redfish/v1/Systems/system/Processors/cpu0/ \
                    SubProcessors/core1"
    }
    ... ...
  ],
  ... ...
}

curl -k -H "X-Auth-Token: $token"
https://${bmc}/redfish/v1/Systems/system/Processors/cpu0/ \
SubProcessors/core1
{
  "@odata.id": "/redfish/v1/Systems/system/Processors/cpu0/ \
                SubProcessors/core1",
  "@odata.type": "#Processor.v1_11_0.Processor",
  "Id": "core1",
    "Name": "",
    "Status": {
        "Health": "OK",
        "State": "Enabled"
    }
}
```


3) Semantic changes:
 - Add "SubProcessors" link back into Processor response
 - Added check for "system" in routes.
 - Add check for DCM name for processor
 - Add 404 error for SubProcessors even when the cpu has none