### PR TITLE
Refactor Dump LogService as per latest dump-manager D-bus re-design

### DIFF
--- a/include/dump_offload.hpp
+++ b/include/dump_offload.hpp
@@ -370,26 +370,9 @@ inline void requestRoutes(App& app)
             conn.close();
             return;
         }
-        std::string dumpEntry =
-            url.substr(pos1 + startDelimiter.length(),
-                       pos2 - pos1 - startDelimiter.length());
-
-        // System and Resource dump entries are currently being
-        // listed under /Systems/system/LogServices/Dump/Entries/
-        // redfish path. To differentiate between the two, the dump
-        // entries would be listed as System_<id> and Resource_<id> for
-        // the respective dumps. Hence the dump id and type are being
-        // extracted here from the above format.
-        std::string dumpId;
-        std::string dumpType;
-        std::size_t idPos = dumpEntry.rfind('_');
-
-        if (idPos != std::string::npos)
-        {
-            dumpType =
-                boost::algorithm::to_lower_copy(dumpEntry.substr(0, idPos));
-            dumpId = dumpEntry.substr(idPos + 1);
-        }
+        std::string dumpId = url.substr(pos1 + startDelimiter.length(),
+                                        pos2 - pos1 - startDelimiter.length());
+        std::string dumpType = "system";
 
         boost::asio::io_context* ioCon = conn.getIoContext();
 

--- a/include/dump_utils.hpp
+++ b/include/dump_utils.hpp
@@ -47,27 +47,8 @@ inline void getValidDumpEntryForAttachment(
                  "Dump", "Entries", std::ref(entryID), "attachment"))
     {
         entriesPath = "/redfish/v1/Systems/system/LogServices/Dump/Entries/";
-
-        // All these types system,resource,sbe,hwdump and host boot dumps are
-        // currently being listed under
-        // /Systems/system/LogServices/Dump/Entries/ redfish path. To
-        // differentiate between the two, the dump entries would be listed as
-        // System_<id> and Resource_<id> for the respective dumps. Hence the
-        // dump id and type are being extracted here from the above format.
-
-        std::size_t pos = entryID.find_first_of('_');
-        if (pos == std::string::npos || (pos + 1) >= entryID.length())
-        {
-            // Requested ID is invalid
-            messages::invalidObject(
-                asyncResp->res,
-                boost::urls::format(
-                    "/redfish/v1/Systems/system/LogServices/Dump/Entries/{}",
-                    entryID));
-            return;
-        }
-        dumpType = boost::algorithm::to_lower_copy(entryID.substr(0, pos));
-        dumpId = entryID.substr(pos + 1);
+        dumpType = "System";
+        dumpId = entryID;
     }
 
     if (dumpType.empty() || entryID.empty())


### PR DESCRIPTION
This PR refactors the host dumps code to consume the latest interfaces that are changed in PDC.

Tested:
GET, DELETE, Create and ClearLog actions on both System and BMC dumps
BMC Dump offload