### PR TITLE
1030: Remove sessions on user password expired

### DIFF
--- a/include/sessions.hpp
+++ b/include/sessions.hpp
@@ -313,6 +313,20 @@ class SessionStore
         needWrite = true;
     }
 
+    void removeSessionsByUsernameExceptSession(
+        std::string_view username, const std::shared_ptr<UserSession>& session)
+    {
+        std::erase_if(authTokens, [username, session](const auto& value) {
+            if (value.second == nullptr)
+            {
+                return false;
+            }
+
+            return value.second->username == username &&
+                   value.second->uniqueId != session->uniqueId;
+        });
+    }
+
     std::vector<const std::string*> getUniqueIds(
         bool getAll = true,
         const PersistenceType& type = PersistenceType::SINGLE_REQUEST)

--- a/redfish-core/lib/account_service.hpp
+++ b/redfish-core/lib/account_service.hpp
@@ -1547,7 +1547,8 @@ inline void updateUserProperties(
     std::shared_ptr<bmcweb::AsyncResp> asyncResp, const std::string& username,
     std::optional<std::string> password, std::optional<bool> enabled,
     std::optional<std::string> roleId, std::optional<bool> locked,
-    std::optional<std::vector<std::string>> accountType, bool isUserItself)
+    std::optional<std::vector<std::string>> accountType, bool isUserItself,
+    const std::shared_ptr<persistent_data::UserSession>& session)
 {
     std::string dbusObjectPath = "/xyz/openbmc_project/user/" + username;
     dbus::utility::escapePathForDbus(dbusObjectPath);
@@ -1556,7 +1557,7 @@ inline void updateUserProperties(
         dbusObjectPath,
         [dbusObjectPath, username, password(std::move(password)),
          roleId(std::move(roleId)), enabled, locked,
-         accountType(std::move(accountType)), isUserItself,
+         accountType(std::move(accountType)), isUserItself, session,
          asyncResp{std::move(asyncResp)}](int rc) {
             if (!rc)
             {
@@ -1568,26 +1569,61 @@ inline void updateUserProperties(
 
             if (password)
             {
-                int retval = pamUpdatePassword(username, *password);
+                crow::connections::systemBus->async_method_call(
+                    [asyncResp, password(std::move(password)), username,
+                     session](const boost::system::error_code ec,
+                              const std::variant<bool>& passwordExpired) {
+                        if (ec)
+                        {
+                            BMCWEB_LOG_ERROR << "D-Bus responses error: " << ec;
+                            messages::internalError(asyncResp->res);
+                            return;
+                        }
+                        const bool* passwordExpiredPtr =
+                            std::get_if<bool>(&passwordExpired);
+                        if (passwordExpiredPtr == nullptr)
+                        {
+                            BMCWEB_LOG_ERROR
+                                << " passwordExpiredPtr value nullptr";
+                            messages::internalError(asyncResp->res);
+                            return;
+                        }
+                        int retval = pamUpdatePassword(username, *password);
+                        if (retval == PAM_USER_UNKNOWN)
+                        {
+                            messages::resourceNotFound(
+                                asyncResp->res, "ManagerAccount", username);
+                            return;
+                        }
+                        if (retval == PAM_AUTHTOK_ERR)
+                        {
+                            // If password is invalid
+                            messages::propertyValueFormatError(
+                                asyncResp->res, *password, "Password");
+                            BMCWEB_LOG_ERROR << "pamUpdatePassword Failed";
+                            return;
+                        }
+                        if (retval != PAM_SUCCESS)
+                        {
+                            messages::internalError(asyncResp->res);
+                            return;
+                        }
 
-                if (retval == PAM_USER_UNKNOWN)
-                {
-                    messages::resourceNotFound(
-                        asyncResp->res, "#ManagerAccount.v1_4_0.ManagerAccount",
-                        username);
-                }
-                else if (retval == PAM_AUTHTOK_ERR)
-                {
-                    // If password is invalid
-                    messages::propertyValueFormatError(asyncResp->res,
-                                                       *password, "Password");
-                    BMCWEB_LOG_ERROR << "pamUpdatePassword Failed";
-                }
-                else if (retval != PAM_SUCCESS)
-                {
-                    messages::internalError(asyncResp->res);
-                    return;
-                }
+                        if (*passwordExpiredPtr)
+                        {
+                            // Remove existing sessions of the user when
+                            // password changed
+                            persistent_data::SessionStore::getInstance()
+                                .removeSessionsByUsernameExceptSession(username,
+                                                                       session);
+                        }
+                        messages::success(asyncResp->res);
+                        return;
+                    },
+                    "xyz.openbmc_project.User.Manager", dbusObjectPath,
+                    "org.freedesktop.DBus.Properties", "Get",
+                    "xyz.openbmc_project.User.Attributes",
+                    "UserPasswordExpired");
             }
 
             if (enabled)
@@ -2683,14 +2719,14 @@ inline void requestAccountServiceRoutes(App& app)
                 {
                     updateUserProperties(asyncResp, username, password, enabled,
                                          roleId, locked, accountType,
-                                         isUserItself);
+                                         isUserItself, req.session);
                     return;
                 }
                 crow::connections::systemBus->async_method_call(
                     [asyncResp, username, password(std::move(password)),
                      roleId(std::move(roleId)), enabled,
                      newUser{std::string(*newUserName)}, locked, isUserItself,
-                     accountType{std::move(accountType)}](
+                     req, accountType{std::move(accountType)}](
                         const boost::system::error_code ec,
                         sdbusplus::message::message& m) {
                         if (ec)
@@ -2700,9 +2736,9 @@ inline void requestAccountServiceRoutes(App& app)
                             return;
                         }
 
-                        updateUserProperties(asyncResp, newUser, password,
-                                             enabled, roleId, locked,
-                                             accountType, isUserItself);
+                        updateUserProperties(
+                            asyncResp, newUser, password, enabled, roleId,
+                            locked, accountType, isUserItself, req.session);
                     },
                     "xyz.openbmc_project.User.Manager",
                     "/xyz/openbmc_project/user",


### PR DESCRIPTION
#### Remove sessions on user password expired
```
This commit removes all existing redfish sessions of that user except
the current user when a user's password is expired.

password expired scenario hits during login of admin user during genesis
boot and factory reset.

Tested by:
Verified factory reset scenario
All redfish sessions removed except the current session after setting
expired password
```