### PR TITLE
Consume availability interface for cores (#254)

### DIFF
--- a/redfish-core/lib/processor.hpp
+++ b/redfish-core/lib/processor.hpp
@@ -1075,6 +1075,7 @@ inline void afterGetCpuCoreDataByService(
 
         bool present = true;
         bool functional = true;
+        bool available = true;
 
         for (const auto& [interface, properties] : interfaces)
         {
@@ -1111,18 +1112,37 @@ inline void afterGetCpuCoreDataByService(
                     }
                 }
             }
+            else if (interface ==
+                     "xyz.openbmc_project.State.Decorator.Availability")
+            {
+                for (const auto& [propName, propValue] : properties)
+                {
+                    if (propName == "Available")
+                    {
+                        const bool* value = std::get_if<bool>(&propValue);
+                        if (value == nullptr)
+                        {
+                            messages::internalError(asyncResp->res);
+                            return;
+                        }
+                        available = *value;
+                    }
+                }
+            }
         }
 
-        if (!present)
+        if (!available)
+        {
+            asyncResp->res.jsonValue["Status"]["State"] = "UnavailableOffline";
+        }
+        else if (!present)
         {
             asyncResp->res.jsonValue["Status"]["State"] = "Absent";
         }
-        else
+
+        if (!functional)
         {
-            if (!functional)
-            {
-                asyncResp->res.jsonValue["Status"]["Health"] = "Critical";
-            }
+            asyncResp->res.jsonValue["Status"]["Health"] = "Critical";
         }
     }
 }


### PR DESCRIPTION
In the current state, the logic is bmcweb for displaying cores is: It checks the Present property on core dbus object to update the [Status][State] as Enabled/Absent.

In addition to Present property, we should also use the Available property , if the Available is false, then set the [Status][State] should be set as "UnavailableOffline".

Refer: ibm-openbmc/dev#3481