### PR TITLE
Logging invalid service name for debug (#291) (#626)

### DIFF
--- a/redfish-core/include/utils/name_utils.hpp
+++ b/redfish-core/include/utils/name_utils.hpp
@@ -37,7 +37,11 @@ inline void getPrettyName(const std::shared_ptr<bmcweb::AsyncResp>& asyncResp,
     // Ensure we only got one service back
     if (services.size() != 1)
     {
-        BMCWEB_LOG_ERROR("Invalid Service Size  {}", services.size());
+        BMCWEB_LOG_ERROR("Invalid Service Size {}", services.size());
+        for (const auto& service : services)
+        {
+            BMCWEB_LOG_ERROR("Invalid Service Name: {}", service.first);
+        }
         if (asyncResp)
         {
             messages::internalError(asyncResp->res);


### PR DESCRIPTION
The method getPrettyName() may be called more than one time.
This will generate journal logging messages for the required Service name
if there are unexpected service names.