### PR TITLE
Add missing path to SubProcessors from Processor

### DIFF
--- a/redfish-core/lib/processor.hpp
+++ b/redfish-core/lib/processor.hpp
@@ -1922,6 +1922,10 @@ inline void requestRoutesProcessor(App& app)
             "#Processor.v1_18_0.Processor";
         asyncResp->res.jsonValue["@odata.id"] = crow::utility::urlFromPieces(
             "redfish", "v1", "Systems", "system", "Processors", processorId);
+        asyncResp->res.jsonValue["SubProcessors"]["@odata.id"] =
+            boost::urls::format(
+                "/redfish/v1/Systems/system/Processors/{}/SubProcessors",
+                processorId);
 
         getProcessorObject(
             asyncResp, processorId,


### PR DESCRIPTION
Add missing path to SubProcessors from Processor

Fixes Defect 620172. Already fixed in 1110.

Since SubProcessors are supported there should be a link from the Processor to the Redfish URI for its SubProcessors. It is missing.

Without fix:
```
curl -k -H "X-Auth-Token: $token" https://${bmc}/redfish/v1/Systems/system/Processors/dcm0-cpu0
{
  "@odata.id": "/redfish/v1/Systems/system/Processors/dcm0-cpu0",
  "@odata.type": "#Processor.v1_18_0.Processor",
  "Id": "dcm0-cpu0",
  "Location": {
    "PartLocation": {
      "ServiceLabel": "U78DA.ND0.1234567-P0-C15"
    }
  },
  "LocationIndicatorActive": false,
  "Manufacturer": "",
  "MaxSpeedMHz": 0,
  "Model": "AB42",
  "Name": "System processor module 0",
  "PartNumber": "2345678",
  "ProcessorId": {
    "Step": "0xFFFF"
  },
  "ProcessorType": "CPU",
  "SerialNumber": "YLAB42010000",
  "Socket": "",
  "SparePartNumber": "1234567",
  "Status": {
    "Health": "OK",
    "State": "Enabled"
  },
  "ThrottleCauses": [],
  "Throttled": false,
  "TotalCores": 0,
  "TotalThreads": 0
}

curl -k -H "X-Auth-Token: $token" https://${bmc}/redfish/v1/Systems/system/Processors/dcm0-cpu0/SubProcessors
{
  "@odata.id": "/redfish/v1/Systems/system/Processors/dcm0-cpu0/SubProcessors",
  "@odata.type": "#ProcessorCollection.ProcessorCollection",
  "Members": [],
  "Members@odata.count": 0,
  "Name": "SubProcessor Collection"
}
```

Tested:
  - Redfish Validator passes
  - Path is returned

With fix, now see SubProcessor path:
```
curl -k -H "X-Auth-Token: $token" https://${bmc}/redfish/v1/Systems/system/Processors/dcm0-cpu0/
{
  "@odata.id": "/redfish/v1/Systems/system/Processors/dcm0-cpu0",
  "@odata.type": "#Processor.v1_18_0.Processor",
  "Id": "dcm0-cpu0",
  "Location": {
    "PartLocation": {
      "ServiceLabel": "U78DA.ND0.1234567-P0-C15"
    }
  },
  "LocationIndicatorActive": false,
  "Manufacturer": "",
  "MaxSpeedMHz": 0,
  "Model": "AB42",
  "Name": "System processor module 0",
  "PartNumber": "2345678",
  "ProcessorId": {
    "Step": "0xFFFF"
  },
  "ProcessorType": "CPU",
  "SerialNumber": "YLAB42010000",
  "Socket": "",
  "SparePartNumber": "1234567",
  "Status": {
    "Health": "OK",
    "State": "Enabled"
  },
  "SubProcessors": {
    "@odata.id": "/redfish/v1/Systems/system/Processors/dcm0-cpu0/SubProcessors"
  },
  "ThrottleCauses": [],
  "Throttled": false,
  "TotalCores": 0,
  "TotalThreads": 0
}
```