### PR TITLE
1110: Handle Missing PCIeSlot LinkStatus on PCIeDevice

### DIFF
--- a/redfish-core/lib/pcie.hpp
+++ b/redfish-core/lib/pcie.hpp
@@ -246,7 +246,7 @@ inline void addPCIeSlotProperties(
     std::string generation;
     size_t lanes = 0;
     std::string slotType;
-    std::string linkStatus;
+    const std::string* linkStatus = nullptr;
 
     bool success = sdbusplus::unpackPropertiesNoThrow(
         dbus_utils::UnpackErrorPrinter(), pcieSlotProperties, "Generation",
@@ -298,9 +298,9 @@ inline void addPCIeSlotProperties(
         res.jsonValue["Slot"]["SlotType"] = *redfishSlotType;
     }
 
-    if (!linkStatus.empty())
+    if (linkStatus != nullptr && !linkStatus->empty())
     {
-        fillPcieDeviceStatus(res, linkStatus);
+        fillPcieDeviceStatus(res, *linkStatus);
     }
 }
 


### PR DESCRIPTION
Not all PCIeSlots may have LinkStatus DBus properties. Currently it fails on PCIeDevice GET object like

```
curl -k -X GET https://${bmc}/redfish/v1/Systems/system/PCIeDevices/chassis_motherboard_pcieslot0_pcie_card0
{
...

    "code": "Base.1.16.0.InternalError",
    "message": "The request failed due to an internal service error.  The service is still operational."
  }
```

Its journal record may be:
```
[ERROR dbus_utils.hpp:20] DBUS property error in property: LinkStatus, reason: 0
[CRITICAL error_messages.cpp:286] Internal Error /usr/src/debug/bmcweb/1.0+git/redfish-core/lib/pcie.hpp(259:32)
     `void redfish::addPCIeSlotProperties(crow::Response&, const boost::system::error_code&, const dbus::utility::DBusPropertiesMap&)`:
```

This is to handle the case when the dbus field is not presented, like how it was handled in the previous release

Tested:

-Check the success of GET on non-existent PCIeDevice LinkStatus
```
curl -k -X GET https://${bmc}/redfish/v1/Systems/system/PCIeDevices/chassis_motherboard_pcieslot0_pcie_card0
```