### PR TITLE
1110: Fix Assembly ReadyToRemove GET

### DIFF
--- a/redfish-core/lib/assembly.hpp
+++ b/redfish-core/lib/assembly.hpp
@@ -256,7 +256,6 @@ void getAssemblyPresence(const std::shared_ptr<bmcweb::AsyncResp>& asyncResp,
     nlohmann::json& assemblyData = assemblyArray.at(assemblyIndex);
 
     assemblyData["Status"]["State"] = "Enabled";
-    assemblyData["Oem"]["OpenBMC"]["ReadyToRemove"] = false;
 
     sdbusplus::asio::getProperty<bool>(
         *crow::connections::systemBus, serviceName, assembly,


### PR DESCRIPTION
It currently produces Assembly output with the incorrect ReadyToRemove field where it should not be included.

```
curl -k -X GET https://${bmc}/redfish/v1/Chassis/chassis/Assembly
{
...
  "Assemblies": [
    {
      "@odata.id": "/redfish/v1/Chassis/chassis/Assembly#/Assemblies/0",
      "@odata.type": "#Assembly.v1_3_0.AssemblyData",
      ...
      "Name": "motherboard",
      "Oem": {
        "OpenBMC": {
          "ReadyToRemove": false     <== This should not be included
        }
      },
      ...
    },
```

This will also cause the Redfish Service Validator error because it does not contain the @odata.type.

Tested:
- Verify `curl -k -X GET https://${bmc}/redfish/v1/Chassis/chassis/Assembly`
- Redfish Service Validator passes

```
python3 RedfishServiceValidator.py --auth Session -i https://${bmc} -u $USER -p $PASS \
        --payload Single /redfish/v1/Chassis/chassis/Assembly
```