### PR TITLE
1110: Software: Add LowestSupportedVersion

### DIFF
--- a/redfish-core/include/utils/sw_utils.hpp
+++ b/redfish-core/include/utils/sw_utils.hpp
@@ -13,6 +13,7 @@
 
 #include <algorithm>
 #include <array>
+#include <memory>
 #include <ranges>
 #include <string>
 #include <string_view>
@@ -280,6 +281,44 @@ inline std::string getRedfishSwHealth(const std::string& swState)
     }
     BMCWEB_LOG_DEBUG("Sw state {} to Warning", swState);
     return "Warning";
+}
+
+/**
+ * @brief Put LowestSupportedVersion of input swId into json response
+ *
+ * This function will put the MinimumVersion from D-Bus of the input
+ * software id to ["LowestSupportedVersion"].
+ *
+ * @param[i,o] asyncResp    Async response object
+ * @param[i] swId The software ID to get Minimum Version for
+ * @param[i]   dbusSvc  The dbus service implementing the software object
+ *
+ * @return void
+ */
+inline void
+    getSwMinimumVersion(const std::shared_ptr<bmcweb::AsyncResp>& asyncResp,
+                        const std::shared_ptr<std::string>& swId,
+                        const std::string& dbusSvc)
+{
+    BMCWEB_LOG_DEBUG("getSwMinimumVersion: svc {}", dbusSvc);
+
+    sdbusplus::asio::getProperty<std::string>(
+        *crow::connections::systemBus, dbusSvc,
+        "/xyz/openbmc_project/software/" + *swId,
+        "xyz.openbmc_project.Software.MinimumVersion", "MinimumVersion",
+        [asyncResp](const boost::system::error_code& ec,
+                    const std::string& swMinimumVersion) {
+        if (ec)
+        {
+            // not all software has this interface and it is not critical
+            return;
+        }
+
+        BMCWEB_LOG_DEBUG("getSwMinimumVersion: MinimumVersion {}",
+                         swMinimumVersion);
+
+        asyncResp->res.jsonValue["LowestSupportedVersion"] = swMinimumVersion;
+    });
 }
 
 /**

--- a/redfish-core/lib/update_service.hpp
+++ b/redfish-core/lib/update_service.hpp
@@ -1215,6 +1215,9 @@ inline void requestRoutesSoftwareInventory(App& app)
 
                 found = true;
                 sw_util::getSwStatus(asyncResp, swId, obj.second[0].first);
+                sw_util::getSwMinimumVersion(asyncResp, swId,
+                                             obj.second[0].first);
+
                 getSoftwareVersion(asyncResp, obj.second[0].first, obj.first,
                                    *swId);
             }


### PR DESCRIPTION
A Minimum Version interface was added.[1] This is the minimum software version that a component must have to operate. Like other interfaces it is optional. MinimumVersion maps to Redfish's LowestSupportedVersion.[2]

"LowestSupportedVersion": {
    "description": "The lowest supported version of this software.",
    "longDescription": "This property shall represent the lowest
supported version of this software.  This string is formatted using the same format used for the `Version` property.",
    "readonly": true,
    "type": [
        "string",
        "null"
    ],
    "versionAdded": "v1_1_0"

phosphor-bmc-code-mgmt has support for minimum version.[3]

phosphor-bmc-code-mgmt logs a Software Incompatible[4] error if this minimum version is not met. Mapping this error to a Redfish error is not done here but could be added later.

[1]: https://github.com/openbmc/phosphor-dbus-interfaces/commit/9012243e543abdc5851b7e878c17c991b2a2a8b7
[2]: https://redfish.dmtf.org/schemas/v1/SoftwareInventory.v1_10_2.json
[3]: https://github.com/openbmc/phosphor-bmc-code-mgmt/blob/85c71a13e0938cc4d36caf6b8e735e9740b2e351/meson.options#L100
[4]: https://github.com/openbmc/phosphor-dbus-interfaces/blob/1c140b9766a15d1cbb8546fa02d5050d772a171d/yaml/xyz/openbmc_project/Software/Version.errors.yaml#L1

Tested: Using an IBM p10bmc see:
```
{
"@odata.id": "/redfish/v1/UpdateService/FirmwareInventory/788d20be",
"@odata.type": "#SoftwareInventory.v1_1_0.SoftwareInventory",
"Description": "BMC image",
...
"LowestSupportedVersion": "fw1020.00-39.1",
...
```
The Redfish Validator has no new errors.

Upstream: https://gerrit.openbmc.org/c/openbmc/bmcweb/+/72224

Change-Id: I17e6d64c86a7d6312726783425101775a959dc04