### PR TITLE
Resource cannot be deleted others

### DIFF
--- a/redfish-core/include/utils/hw_isolation.hpp
+++ b/redfish-core/include/utils/hw_isolation.hpp
@@ -127,8 +127,8 @@ inline void
                 "xyz.openbmc_project.Common.Error.InvalidArgument") ==
             dbusError->name)
         {
-            messages::propertyValueIncorrect(
-                asyncResp->res, "@odata.id",
+            messages::propertyValueExternalConflict(
+                asyncResp->res, "Enabled",
                 std::to_string(static_cast<int>(enabledPropVal)));
         }
         else if (std::string_view(

--- a/redfish-core/include/utils/hw_isolation.hpp
+++ b/redfish-core/include/utils/hw_isolation.hpp
@@ -262,6 +262,13 @@ inline void
                 retChassisPowerStateOffRequiredError(asyncResp,
                                                      resourceObjPath);
             }
+            else if (
+                std::string_view(
+                    "xyz.openbmc_project.Common.Error.InsufficientPermission") ==
+                dbusError->name)
+            {
+                messages::resourceCannotBeDeleted(asyncResp->res);
+            }
             else
             {
                 BMCWEB_LOG_ERROR(


### PR DESCRIPTION
Here is the list of the original commits that are cherry-picked

[HW-Isolation: Return ResourceCannotBeDeleted error](https://github.com/ibm-openbmc/bmcweb/pull/542/commits/6c60bc3f7e92c05c3f28052a6292892181904ae4)

[HW-Isolation: Fix, Don't handle the Unavailable D-Bus error](https://github.com/ibm-openbmc/bmcweb/pull/542/commits/3e3fdb5f8c0bc96d82a381bd91678c01e5e22747)

[LogService: HW-Isolation: Return an appropriate error](https://github.com/ibm-openbmc/bmcweb/pull/542/commits/a858ac1ecb46d94a4bbc66e14bbea24bdfc781d6)