### PR TITLE
Fix NTP set race condition

### DIFF
--- a/redfish-core/lib/network_protocol.hpp
+++ b/redfish-core/lib/network_protocol.hpp
@@ -242,31 +242,29 @@ inline void getNetworkData(const std::shared_ptr<bmcweb::AsyncResp>& asyncResp,
                          std::bind_front(afterNetworkPortRequest, asyncResp));
 } // namespace redfish
 
-inline void handleNTPProtocolEnabled(
-    const bool& ntpEnabled, const std::shared_ptr<bmcweb::AsyncResp>& asyncResp)
+inline void afterSetNTP(const std::shared_ptr<bmcweb::AsyncResp>& asyncResp,
+                        const boost::system::error_code& ec)
 {
-    std::string timeSyncMethod;
-    if (ntpEnabled)
+    if (ec)
     {
-        timeSyncMethod = "xyz.openbmc_project.Time.Synchronization.Method.NTP";
+        BMCWEB_LOG_ERROR("Failed to set elapsed time. DBUS response error {}",
+                         ec);
+        messages::internalError(asyncResp->res);
+        return;
     }
-    else
-    {
-        timeSyncMethod =
-            "xyz.openbmc_project.Time.Synchronization.Method.Manual";
-    }
-
+    asyncResp->res.result(boost::beast::http::status::no_content);
+}
+inline void handleNTPProtocolEnabled(
+    const std::shared_ptr<bmcweb::AsyncResp>& asyncResp, bool ntpEnabled)
+{
+    bool interactive = false;
+    auto callback = [asyncResp](const boost::system::error_code& ec) {
+        afterSetNTP(asyncResp, ec);
+    };
     crow::connections::systemBus->async_method_call(
-        [asyncResp](const boost::system::error_code errorCode) {
-        if (errorCode)
-        {
-            messages::internalError(asyncResp->res);
-        }
-        },
-        "xyz.openbmc_project.Settings", "/xyz/openbmc_project/time/sync_method",
-        "org.freedesktop.DBus.Properties", "Set",
-        "xyz.openbmc_project.Time.Synchronization", "TimeSyncMethod",
-        dbus::utility::DbusVariantType{timeSyncMethod});
+        std::move(callback), "org.freedesktop.timedate1",
+        "/org/freedesktop/timedate1", "org.freedesktop.timedate1", "SetNTP",
+        ntpEnabled, interactive);
 }
 
 inline void
@@ -461,28 +459,18 @@ inline std::string getHostName()
 inline void
     getNTPProtocolEnabled(const std::shared_ptr<bmcweb::AsyncResp>& asyncResp)
 {
-    sdbusplus::asio::getProperty<std::string>(
-        *crow::connections::systemBus, "xyz.openbmc_project.Settings",
-        "/xyz/openbmc_project/time/sync_method",
-        "xyz.openbmc_project.Time.Synchronization", "TimeSyncMethod",
-        [asyncResp](const boost::system::error_code errorCode,
-                    const std::string& timeSyncMethod) {
-        if (errorCode)
+    sdbusplus::asio::getProperty<bool>(
+        *crow::connections::systemBus, "org.freedesktop.timedate1",
+        "/org/freedesktop/timedate1", "org.freedesktop.timedate1", "NTP",
+        [asyncResp](const boost::system::error_code& ec, bool enabled) {
+        if (ec)
         {
+            BMCWEB_LOG_WARNING(
+                "Failed to get NTP status, assuming not supported");
             return;
         }
-
-        if (timeSyncMethod ==
-            "xyz.openbmc_project.Time.Synchronization.Method.NTP")
-        {
-            asyncResp->res.jsonValue["NTP"]["ProtocolEnabled"] = true;
-        }
-        else if (timeSyncMethod == "xyz.openbmc_project.Time.Synchronization."
-                                   "Method.Manual")
-        {
-            asyncResp->res.jsonValue["NTP"]["ProtocolEnabled"] = false;
-        }
-        });
+        asyncResp->res.jsonValue["NTP"]["ProtocolEnabled"] = enabled;
+    });
 }
 
 inline std::string encodeServiceObjectPath(std::string_view serviceName)
@@ -545,7 +533,7 @@ inline void requestRoutesNetworkProtocol(App& app)
 
         if (ntpEnabled)
         {
-            handleNTPProtocolEnabled(*ntpEnabled, asyncResp);
+            handleNTPProtocolEnabled(asyncResp, *ntpEnabled);
         }
         if (ntpServerObjects)
         {


### PR DESCRIPTION
There's currently a problem with phosphor-timesyncd, where enabling NTP doesn't immediately reflect in the system status on return[1].  To say it another way, NTP is not enabled/disabled atomically, which leads to the following problem.

// Disable NTP
PATCH /redfish/v1/Managers/bmc/NetworkProtocol
{"NTP":{"ProtocolEnabled": false}}
// Set the time manually
PATCH /redfish/v1/Managers/bmc {"DateTime": "<timestring"}

Doing this in rapid succession leads to a 500 error, which is obviously a bug.  In the prior commit, this error was changed to a PropertyValueConflict error, which is still incorrect, but at least informative of what's going on.  REST APIs are intended to have CRUD compliance.  The response should not be returned until the value has been accepted, and not doing that can lead to problems.

This commit changes the backend to use systemd directly, rather than routing through phosphor-settings, to avoid this race.

Tested: The above procedure succeeds.

[1] systemd/systemd#11424



Signed-off-by: Pavithra Barithaya <pavithrabarithaya07@gmail.com>