### PR TITLE
1110: Fix Redfish Validator Errors on system

### DIFF
--- a/redfish-core/lib/systems.hpp
+++ b/redfish-core/lib/systems.hpp
@@ -1631,7 +1631,7 @@ inline void
         BMCWEB_LOG_DEBUG("Safe mode: {}", *safeMode);
         nlohmann::json& oemSafeMode = asyncResp->res.jsonValue["Oem"];
         oemSafeMode["@odata.type"] = "#OemComputerSystem.Oem";
-        oemSafeMode["IBM"]["@odata.type"] = "#OemComputerSystem.IBM";
+        oemSafeMode["IBM"]["@odata.type"] = "#OemComputerSystem.v1_0_0.IBM";
         oemSafeMode["IBM"]["SafeMode"] = *safeMode;
     }
 }
@@ -2215,7 +2215,7 @@ inline void getEnabledPanelFunctions(
         }
         nlohmann::json& oem = asyncResp->res.jsonValue["Oem"];
         oem["@odata.type"] = "#OemComputerSystem.Oem";
-        oem["IBM"]["@odata.type"] = "#OemComputerSystem.IBM";
+        oem["IBM"]["@odata.type"] = "#OemComputerSystem.v1_0_0.IBM";
         oem["IBM"]["EnabledPanelFunctions"] = enabledFuncs;
     });
 }
@@ -2374,7 +2374,7 @@ inline void getChapData(const std::shared_ptr<bmcweb::AsyncResp>& asyncResp)
         }
 
         nlohmann::json& oemIBM = asyncResp->res.jsonValue["Oem"]["IBM"];
-        oemIBM["@odata.type"] = "#OemComputerSystem.IBM";
+        oemIBM["@odata.type"] = "#OemComputerSystem.v1_0_0.IBM";
 
         nlohmann::json& chapData = oemIBM["ChapData"];
         chapData["ChapName"] = *chapName;


### PR DESCRIPTION
There are a few Redfish Service Validator errors like

```
python3 RedfishServiceValidator.py --auth Session -i https://${bmc} -u $USER -p $PASS \
        --payload Single  /redfish/v1/Systems/system
...
1 failInvalidArray errors in /redfish/v1/Systems/system
1 fails errors in /redfish/v1/Systems/system
```

Its details are:

```
ERROR - Property EnabledPanelFunctions should not be a List
ERROR - This object's type EnabledPanelFunctions should be a Collection, but it's of type Resource.OemObject...
ERROR - EnabledPanelFunctions: Value of property is an array but is not a Collection
```

```
{
    "@odata.id": "/redfish/v1/Systems/system",

    "Oem": {
        "@odata.type": "#OemComputerSystem.Oem",
        "IBM": {
            "@odata.type": "#OemComputerSystem.IBM", <---
            "EnabledPanelFunctions": [],
            "LampTest": false,
            "PartitionSystemAttentionIndicator": false,
            "PlatformSystemAttentionIndicator": false,
            "SafeMode": false
        }
    },
```

Tested:
- Redfish Service Validator passes for `/redfish/v1/Systems/system`