### PR TITLE
Fix the BaseBIOSTable according to upstream schema

### DIFF
--- a/redfish-core/lib/bios.hpp
+++ b/redfish-core/lib/bios.hpp
@@ -33,16 +33,16 @@ using BiosBaseTableType = std::vector<std::pair<
         std::string, bool, std::string, std::string, std::string,
         std::variant<int64_t, std::string>, std::variant<int64_t, std::string>,
         std::vector<
-            std::tuple<std::string, std::variant<int64_t, std::string>>>>>>;
+            std::tuple<std::string, std::variant<int64_t, std::string>, std::string>>>>>;
 using BiosBaseTableItemType = std::pair<
     std::string,
     std::tuple<
         std::string, bool, std::string, std::string, std::string,
         std::variant<int64_t, std::string>, std::variant<int64_t, std::string>,
         std::vector<
-            std::tuple<std::string, std::variant<int64_t, std::string>>>>>;
+            std::tuple<std::string, std::variant<int64_t, std::string>, std::string>>>>;
 using OptionsItemType =
-    std::tuple<std::string, std::variant<int64_t, std::string>>;
+    std::tuple<std::string, std::variant<int64_t, std::string>, std::string>;
 
 enum BiosBaseTableIndex
 {


### PR DESCRIPTION
This change updates the BaseBIOSTable in bios.hpp according to the modifications made in the schema upstream.
Fixes the defect https://jazz07.rchland.ibm.com:13443/jazz/web/projects/CSSD#action=com.ibm.team.workitem.viewWorkItem&id=625977

schema : https://github.com/ibm-openbmc/phosphor-dbus-interfaces/blob/1110/yaml/xyz/openbmc_project/BIOSConfig/Manager.interface.yaml#L64

Upstream: NA, Downstream only code.

Tested by:

Redfish response before the fix:

get /redfish/v1/Systems/system/Bios
{
  "@Redfish.Settings": {
    "@odata.type": "#Settings.v1_3_0.Settings",
    "SettingsObject": {
      "@odata.id": "/redfish/v1/Systems/system/Bios/Settings"
    }
  },
  "@odata.id": "/redfish/v1/Systems/system/Bios",
  "@odata.type": "#Bios.v1_1_0.Bios",
  "Actions": {
    "#Bios.ResetBios": {
      "target": "/redfish/v1/Systems/system/Bios/Actions/Bios.ResetBios"
    }
  },
  "AttributeRegistry": "BiosAttributeRegistry",
  **"Attributes": null,**
  "Description": "BIOS Configuration Service",
  "Id": "BIOS",
  "Name": "BIOS Configuration"
}


Redfish response after the fix:


get /redfish/v1/Systems/system/Bios
{
  "@Redfish.Settings": {
    "@odata.type": "#Settings.v1_3_0.Settings",
    "SettingsObject": {
      "@odata.id": "/redfish/v1/Systems/system/Bios/Settings"
    }
  },
  "@odata.id": "/redfish/v1/Systems/system/Bios",
  "@odata.type": "#Bios.v1_1_0.Bios",
  "Actions": {
    "#Bios.ResetBios": {
      "target": "/redfish/v1/Systems/system/Bios/Actions/Bios.ResetBios"
    }
  },
  "AttributeRegistry": "BiosAttributeRegistry",
  "Attributes": {
    "fw_boot_side": "Temp",
    "fw_boot_side_current": "Temp",
    "hb_cap_freq_mhz_max": 0,
    "hb_cap_freq_mhz_min": 0,
    "hb_cap_freq_mhz_request": 0,
    "hb_cap_freq_mhz_request_current": 0,
    "hb_debug_console": "Disabled",
    "hb_effective_secure_version": 0,
    "hb_field_core_override": 0,
    "hb_field_core_override_current": 0,
    "hb_host_usb_enablement": "Enabled",
    "hb_host_usb_enablement_current": "Enabled",
    "hb_huge_page_size": 0,
    "hb_huge_page_size_current": 0,
    "hb_hyp_switch": "PowerVM",
    .
    .
    .
        "vmi_if1_ipv4_prefix_length": 0,
    "vmi_if1_ipv6_gateway": "::",
    "vmi_if1_ipv6_ipaddr": "::",
    "vmi_if1_ipv6_method": "IPv6Static",
    "vmi_if1_ipv6_prefix_length": 128
  },
  "Description": "BIOS Configuration Service",
  "Id": "BIOS",
  "Name": "BIOS Configuration"
}




