### PR TITLE
Revert "Fix regression in metadata"

### DIFF
--- a/include/authentication.hpp
+++ b/include/authentication.hpp
@@ -225,18 +225,11 @@ static std::shared_ptr<persistent_data::UserSession>
 [[maybe_unused]] static bool isOnAllowlist(std::string_view url,
                                            boost::beast::http::verb method)
 {
-    // Handle the case where the router registers routes as both ending with /
-    // and not.
-    if (url.ends_with('/'))
-    {
-        url.remove_suffix(1);
-    }
     if (boost::beast::http::verb::get == method)
     {
-        if ((url == "/redfish") ||          //
-            (url == "/redfish/v1") ||       //
-            (url == "/redfish/v1/odata") || //
-            (url == "/redfish/v1/$metadata"))
+        if (url == "/redfish/v1" || url == "/redfish/v1/" ||
+            url == "/redfish" || url == "/redfish/" ||
+            url == "/redfish/v1/odata" || url == "/redfish/v1/odata/")
         {
             return true;
         }
@@ -262,7 +255,9 @@ static std::shared_ptr<persistent_data::UserSession>
     if (boost::beast::http::verb::post == method)
     {
         if ((url == "/redfish/v1/SessionService/Sessions") ||
+            (url == "/redfish/v1/SessionService/Sessions/") ||
             (url == "/redfish/v1/SessionService/Sessions/Members") ||
+            (url == "/redfish/v1/SessionService/Sessions/Members/") ||
             (url == "/login"))
         {
             return true;


### PR DESCRIPTION
This reverts commit 093eebecf9c395aff3543b8252e2794e51530e59 to fix defect 629044.

Defect 629044 reported an endless redirect loop of `/?next=/`

This was found using git bisect. 

Tested: A 2nd test with and without this commit showed, the endless redirect without this commit but fixed by this commit. 

