### PR TITLE
1110: Fix Handling of BiosAttributeRegistry

### DIFF
--- a/redfish-core/lib/message_registries.hpp
+++ b/redfish-core/lib/message_registries.hpp
@@ -16,6 +16,7 @@
 #pragma once
 
 #include "app.hpp"
+#include "bios.hpp"
 #include "query.hpp"
 #include "registries.hpp"
 #include "registries/base_message_registry.hpp"
@@ -56,16 +57,7 @@ inline void handleMessageRegistryFileCollectionGet(
 
     for (const char* memberName :
          std::to_array({"Base", "TaskEvent", "ResourceEvent", "OpenBMC",
-                        "BiosAttributeRegistry"}))
-    {
-        nlohmann::json::object_t member;
-        member["@odata.id"] = boost::urls::format("/redfish/v1/Registries/{}",
-                                                  memberName);
-        members.emplace_back(std::move(member));
-    }
-
-    for (const char* memberName : std::to_array(
-             {"Base", "TaskEvent", "ResourceEvent", "OpenBMC", "License"}))
+                        "BiosAttributeRegistry", "License"}))
     {
         nlohmann::json::object_t member;
         member["@odata.id"] = boost::urls::format("/redfish/v1/Registries/{}",
@@ -180,6 +172,14 @@ inline void handleMessageRegistryGet(
     {
         return;
     }
+
+    if (registry == "BiosAttributeRegistry" &&
+        registryMatch == "BiosAttributeRegistry")
+    {
+        getBiosAttributeRegistry(asyncResp);
+        return;
+    }
+
     const registries::Header* header = nullptr;
     std::vector<const registries::MessageEntry*> registryEntries;
     if (registry == "Base")

--- a/redfish-core/src/redfish.cpp
+++ b/redfish-core/src/redfish.cpp
@@ -183,7 +183,6 @@ RedfishService::RedfishService(App& app)
     requestRoutesSystemActionsOemExecutePanelFunction(app);
     requestRoutesBiosService(app);
     requestRoutesBiosSettings(app);
-    requestRoutesBiosAttributeRegistry(app);
     requestRoutesBiosReset(app);
 
 #ifdef BMCWEB_ENABLE_VM_NBDPROXY


### PR DESCRIPTION
Redfish Service Validator is failing like this.
```
1 failGet errors in /redfish/v1/Registries/BiosAttributeRegistry/BiosAttributeRegistry
1 fails errors in /redfish/v1/Registries/BiosAttributeRegistry/BiosAttributeRegistry
ERROR - URI did not return resource /redfish/v1/Registries/BiosAttributeRegistry/BiosAttributeRegistry
```

It can also be verified by doing this.
```
curl -k -X GET https://${bmc}/redfish/v1/Registries/BiosAttributeRegistry/BiosAttributeRegistry
{
  "error": {
    "code": "Base.1.16.0.ResourceNotFound",
    "message": "The requested resource of type MessageRegistryFile named 'BiosAttributeRegistry' was not found."
```

It is because bmcweb does not handle the overlapping routes with
- `/redfish/v1/Registries/<str>/<str>`
- `/redfish/v1/Registries/BiosAttributeRegistry/BiosAttributeRegistry`

In fact, such routing logic worked before although it is not by intentional design, but it is no longer supported [1].

So, I've modified the logic to handle `BiosAttributeRegistry` so that it is routed from `/redfish/v1/Registries/<str>/<str>`

Tested:
- Success on `curl -k -X GET https://${bmc}/redfish/v1/Registries/BiosAttributeRegistry/BiosAttributeRegistry`

- Redfish Service Validaor passes on /redfish/v1/Registries/

[1] https://discord.com/channels/775381525260664832/1255570841568153702