### PR TITLE
1110: Fix Validator Warning on Oem Schemas

### DIFF
--- a/redfish-core/lib/license_service.hpp
+++ b/redfish-core/lib/license_service.hpp
@@ -199,7 +199,7 @@ inline void requestRoutesLicenseService(App& app)
         .methods(boost::beast::http::verb::get)(
             [](const crow::Request&,
                const std::shared_ptr<bmcweb::AsyncResp>& asyncResp) {
-        asyncResp->res.jsonValue["@odata.id"] = "/redfish/v1/LicenseService/";
+        asyncResp->res.jsonValue["@odata.id"] = "/redfish/v1/LicenseService";
         asyncResp->res.jsonValue["@odata.type"] =
             "#LicenseService.v1_0_0.LicenseService";
         asyncResp->res.jsonValue["Name"] = "License Service";

--- a/redfish-core/lib/log_services.hpp
+++ b/redfish-core/lib/log_services.hpp
@@ -2361,6 +2361,9 @@ inline void requestRoutesDBusEventLogEntryCollection(App& app)
                     redfish::time_utils::getDateTimeUintMs(*timestamp);
                 thisEntry["Modified"] =
                     redfish::time_utils::getDateTimeUintMs(*updateTimestamp);
+
+                thisEntry["Oem"]["IBM"]["@odata.type"] =
+                    "#OemLogEntryAttachment.v1_0_0.IBM";
                 thisEntry["Oem"]["IBM"]["@odata.id"] = boost::urls::format(
                     "/redfish/v1/Systems/system/LogServices/EventLog/Entries/{}/OemPelAttachment",
                     std::to_string(*id));
@@ -2372,7 +2375,7 @@ inline void requestRoutesDBusEventLogEntryCollection(App& app)
                 }
 #ifdef BMCWEB_ENABLE_IBM_MANAGEMENT_CONSOLE
                 thisEntry["Oem"]["OpenBMC"]["@odata.type"] =
-                    "#OemLogEntry.v1_0_0.LogEntry";
+                    "#OemLogEntry.v1_0_0.OpenBMC";
                 thisEntry["Oem"]["OpenBMC"]["ManagementSystemAck"] =
                     *managementSystemAck;
 #endif
@@ -2623,6 +2626,8 @@ inline void requestRoutesDBusCELogEntryCollection(App& app)
                 {
                     thisEntry["ServiceProviderNotified"] = *notifyAction;
                 }
+                thisEntry["Oem"]["IBM"]["@odata.type"] =
+                    "#OemLogEntryAttachment.v1_0_0.IBM";
                 thisEntry["Oem"]["IBM"]["@odata.id"] = boost::urls::format(
                     "/redfish/v1/Systems/system/LogServices/CELog/Entries/{}/OemPelAttachment",
                     std::to_string(*id));
@@ -2634,7 +2639,7 @@ inline void requestRoutesDBusCELogEntryCollection(App& app)
                 }
 #ifdef BMCWEB_ENABLE_IBM_MANAGEMENT_CONSOLE
                 thisEntry["Oem"]["OpenBMC"]["@odata.type"] =
-                    "#OemLogEntry.v1_0_0.LogEntry";
+                    "#OemLogEntry.v1_0_0.OpenBMC";
                 thisEntry["Oem"]["OpenBMC"]["ManagementSystemAck"] =
                     managementSystemAck;
 #endif
@@ -2782,6 +2787,9 @@ inline void requestRoutesDBusEventLogEntry(App& app)
                 redfish::time_utils::getDateTimeUintMs(*timestamp);
             asyncResp->res.jsonValue["Modified"] =
                 redfish::time_utils::getDateTimeUintMs(*updateTimestamp);
+
+            asyncResp->res.jsonValue["Oem"]["IBM"]["@odata.type"] =
+                "#OemLogEntryAttachment.v1_0_0.IBM";
             asyncResp->res
                 .jsonValue["Oem"]["IBM"]["@odata.id"] = boost::urls::format(
                 "/redfish/v1/Systems/system/LogServices/EventLog/Entries/{}/OemPelAttachment",
@@ -2794,7 +2802,7 @@ inline void requestRoutesDBusEventLogEntry(App& app)
             }
 #ifdef BMCWEB_ENABLE_IBM_MANAGEMENT_CONSOLE
             asyncResp->res.jsonValue["Oem"]["OpenBMC"]["@odata.type"] =
-                "#OemLogEntry.v1_0_0.LogEntry";
+                "#OemLogEntry.v1_0_0.OpenBMC";
             asyncResp->res.jsonValue["Oem"]["OpenBMC"]["ManagementSystemAck"] =
                 *managementSystemAck;
 #endif
@@ -3033,6 +3041,8 @@ inline void requestRoutesDBusCELogEntry(App& app)
                 asyncResp->res.jsonValue["ServiceProviderNotified"] =
                     *notifyAction;
             }
+            asyncResp->res.jsonValue["Oem"]["IBM"]["@odata.type"] =
+                "#OemLogEntryAttachment.v1_0_0.IBM";
             asyncResp->res
                 .jsonValue["Oem"]["IBM"]["@odata.id"] = boost::urls::format(
                 "/redfish/v1/Systems/system/LogServices/CELog/Entries/{}/OemPelAttachment",
@@ -3046,7 +3056,7 @@ inline void requestRoutesDBusCELogEntry(App& app)
             }
 #ifdef BMCWEB_ENABLE_IBM_MANAGEMENT_CONSOLE
             asyncResp->res.jsonValue["Oem"]["OpenBMC"]["@odata.type"] =
-                "#OemLogEntry.v1_0_0.LogEntry";
+                "#OemLogEntry.v1_0_0.OpenBMC";
             asyncResp->res.jsonValue["Oem"]["OpenBMC"]["ManagementSystemAck"] =
                 *managementSystemAck;
 #endif
@@ -3168,9 +3178,9 @@ inline void
 
         asyncResp->res.jsonValue["Oem"]["IBM"]["PelJson"] = pelJson;
         asyncResp->res.jsonValue["Oem"]["@odata.type"] =
-            "#OemLogEntryAttachment.Oem";
+            "#OemLogEntryAttachment.v1_0_0.Oem";
         asyncResp->res.jsonValue["Oem"]["IBM"]["@odata.type"] =
-            "#OemLogEntryAttachment.IBM";
+            "#OemLogEntryAttachment.v1_0_0.IBM";
     };
 
     uint32_t id = 0;
@@ -5746,7 +5756,8 @@ static LogParseError
     logEntryJson["EventTimestamp"] = std::move(entryTimeStr);
 
     /* logEntryJson["Oem"]["IBM"]["@odata.id"] ?? */
-    logEntryJson["Oem"]["IBM"]["@odata.type"] = "#OemLogEntry.v1_0_0.LogEntry";
+    logEntryJson["Oem"]["IBM"]["@odata.type"] =
+        "#OemLogEntryAttachment.v1_0_0.IBM";
     logEntryJson["Oem"]["IBM"]["AdditionalDataFullAuditLogURI"] =
         "/redfish/v1/Systems/system/LogServices/AuditLog/Entries/FullAudit/attachment";
 

--- a/redfish-core/schema/oem/openbmc/csdl/OemLogEntryAttachment_v1.xml
+++ b/redfish-core/schema/oem/openbmc/csdl/OemLogEntryAttachment_v1.xml
@@ -19,24 +19,32 @@
 
     <Schema xmlns="http://docs.oasis-open.org/odata/ns/edm" Namespace="OemLogEntryAttachment">
       <Annotation Term="Redfish.OwningEntity" String="IBM"/>
+    </Schema>
+
+    <Schema xmlns="http://docs.oasis-open.org/odata/ns/edm" Namespace="OemLogEntryAttachment.v1_0_0">
+      <Annotation Term="Redfish.OwningEntity" String="OpenBMC"/>
+      <Annotation Term="Redfish.Release" String="1.0"/>
 
       <ComplexType Name="Oem" BaseType="Resource.OemObject">
         <Annotation Term="OData.AdditionalProperties" Bool="true"/>
         <Annotation Term="OData.Description" String="OemLogEntryAttachment Oem properties."/>
         <Annotation Term="OData.AutoExpand"/>
-        <Property Name="IBM" Type="OemLogEntryAttachment.IBM"/>
+        <Property Name="IBM" Type="OemLogEntryAttachment.v1_0_0.IBM"/>
       </ComplexType>
 
       <ComplexType Name="IBM" BaseType="Resource.OemObject">
         <Annotation Term="OData.AdditionalProperties" Bool="false" />
         <Annotation Term="OData.Description" String="Oem properties for IBM." />
         <Annotation Term="OData.AutoExpand"/>
-        <Property Name="PelJson" Type="OemLogEntryAttachment.IBM">
+        <Property Name="PelJson" Type="Edm.String">
           <Annotation Term="OData.Permissions" EnumMember="OData.Permission/Read"/>
           <Annotation Term="OData.Description" String="PEL in Json format."/>
         </Property>
+        <Property Name="AdditionalDataFullAuditLogURI" Type="Edm.String">
+          <Annotation Term="OData.Permissions" EnumMember="OData.Permission/Read"/>
+          <Annotation Term="OData.Description" String="Audit Log in Json format."/>
+        </Property>
       </ComplexType>
-
     </Schema>
 
   </edmx:DataServices>

--- a/redfish-core/schema/oem/openbmc/json-schema/OemLogEntryAttachment.json
+++ b/redfish-core/schema/oem/openbmc/json-schema/OemLogEntryAttachment.json
@@ -48,6 +48,11 @@
                     "description": "PEL in Json format.",
                     "readonly": true,
                     "type": ["string", "null"]
+                },
+                "AdditionalDataFullAuditLogURI": {
+                    "description": "Audit Log in Json format.",
+                    "readonly": true,
+                    "type": ["string", "null"]
                 }
             },
             "type": "object"
@@ -55,5 +60,5 @@
     },
     "owningEntity": "IBM",
     "release": "1.0",
-    "title": "#OemLogEntryAttachment"
+    "title": "#OemLogEntryAttachment.v1_0_0"
 }


### PR DESCRIPTION
This fixes 2 warnings

1) Fix Incorrect URI id on LicenseService

Redfish Service validator shows an warning on LicenseService.

```
WARNING - /redfish/v1/LicenseService @odata.id: Expected @odata.id to match URI link /redfish/v1/LicenseService/
```

```
curl -k -X GET https://${bmc}/redfish/v1/LicenseService
{
    "@odata.id": "/redfish/v1/LicenseService/",
}
```

2) Fix Redfish Validator Warnings on Oem LogServices


```
- On /redfish/v1/Systems/system/LogServices/EventLog/Entries
WARNING - Couldn't get schema for object (?), skipping OemObject OpenBMC : 'LogEntry'

- On /redfish/v1/Systems/system/LogServices/AuditLog/Entries
Couldn't get schema for object (?), skipping OemObject IBM : 'IBM'
WARNING - Couldn't get schema for object (?), skipping OemObject IBM : 'LogEntry'
```

```
$ curl -k -X GET https://${bmc}/redfish/v1/Systems/system/LogServices/EventLog/Entries/138
{
   ...
    "Oem": {
        "IBM": {
            "@odata.id": "/redfish/v1/Systems/system/LogServices/EventLog/Entries/138/OemPelAttachment"
        },
        "OpenBMC": {
            "@odata.type": "#OemLogEntry.v1_0_0.LogEntry",
            "ManagementSystemAck": false
        }
    },
```

```
$ curl --k -X GET https://${bmc}/redfish/v1/Systems/system/LogServices/AuditLog/Entries/1719600625.934:13
{
    ```
   "@odata.id": "/redfish/v1/Systems/system/LogServices/AuditLog/Entries/1719600625.934:13",
   "@odata.type": "#LogEntry.v1_9_0.LogEntry",
   "EntryType": "Event",

   "Oem": {
      "IBM": {
         "@odata.type": "#OemLogEntry.v1_0_0.LogEntry",
         "AdditionalDataFullAuditLogURI": "/redfish/v1/Systems/system/LogServices/AuditLog/Entries/FullAudit/attachment"
      }
  }
```

