### PR TITLE
No connection issue fix

### DIFF
--- a/http/http_client.hpp
+++ b/http/http_client.hpp
@@ -151,7 +151,7 @@ class ConnectionInfo : public std::enable_shared_from_this<ConnectionInfo>
     boost::asio::io_context& ioc;
     std::optional<boost::beast::ssl_stream<boost::asio::ip::tcp::socket&>>
         sslConn;
-    std::unique_ptr<boost::asio::ip::tcp::socket> conn;
+    boost::asio::ip::tcp::socket conn;
 
     boost::asio::steady_timer timer;
 
@@ -194,7 +194,7 @@ class ConnectionInfo : public std::enable_shared_from_this<ConnectionInfo>
         timer.async_wait(std::bind_front(onTimeout, weak_from_this()));
 
         boost::asio::async_connect(
-            *conn, endpointList,
+            conn, endpointList,
             std::bind_front(&ConnectionInfo::afterConnect, this,
                             shared_from_this()));
     }
@@ -293,7 +293,7 @@ class ConnectionInfo : public std::enable_shared_from_this<ConnectionInfo>
         else
         {
             boost::beast::http::async_write(
-                *conn, req,
+                conn, req,
                 std::bind_front(&ConnectionInfo::afterWrite, this,
                                 shared_from_this()));
         }
@@ -346,7 +346,7 @@ class ConnectionInfo : public std::enable_shared_from_this<ConnectionInfo>
         else
         {
             boost::beast::http::async_read(
-                *conn, buffer, *parser,
+                conn, buffer, *parser,
                 std::bind_front(&ConnectionInfo::afterRead, this,
                                 shared_from_this()));
         }
@@ -364,7 +364,7 @@ class ConnectionInfo : public std::enable_shared_from_this<ConnectionInfo>
         }
 
         timer.cancel();
-        if (ec)
+        if (ec && ec != boost::asio::ssl::error::stream_truncated)
         {
             BMCWEB_LOG_ERROR << "recvMessage() failed: " << ec.message()
                              << " from " << host << ":" << std::to_string(port);
@@ -374,6 +374,10 @@ class ConnectionInfo : public std::enable_shared_from_this<ConnectionInfo>
         }
         BMCWEB_LOG_DEBUG << "recvMessage() bytes transferred: "
                          << bytesTransferred;
+        if (!parser)
+        {
+            return;
+        }
         BMCWEB_LOG_DEBUG << "recvMessage() data: " << parser->get().body();
 
         unsigned int respCode = parser->get().result_int();
@@ -520,8 +524,8 @@ class ConnectionInfo : public std::enable_shared_from_this<ConnectionInfo>
     void shutdownConn(bool retry)
     {
         boost::beast::error_code ec;
-        conn->shutdown(boost::asio::ip::tcp::socket::shutdown_both, ec);
-        conn->close();
+        conn.shutdown(boost::asio::ip::tcp::socket::shutdown_both, ec);
+        conn.close();
 
         // not_connected happens sometimes so don't bother reporting it.
         if (ec && ec != boost::beast::errc::not_connected)
@@ -541,7 +545,6 @@ class ConnectionInfo : public std::enable_shared_from_this<ConnectionInfo>
         {
             // Now let's try to resend the data
             state = ConnState::retry;
-            // reconnect to server using new socket
             restartConnection();
         }
         else
@@ -625,7 +628,7 @@ class ConnectionInfo : public std::enable_shared_from_this<ConnectionInfo>
 
     void initializeConnection(bool ssl)
     {
-        conn = std::make_unique<boost::asio::ip::tcp::socket>(ioc);
+        conn = boost::asio::ip::tcp::socket(ioc);
         if (ssl)
         {
             /* std::optional<boost::asio::ssl::context> sslCtx =
@@ -646,7 +649,7 @@ class ConnectionInfo : public std::enable_shared_from_this<ConnectionInfo>
             } */
             boost::asio::ssl::context sslCtx{
                 boost::asio::ssl::context::tlsv13_client};
-            sslConn.emplace(*conn.get(), sslCtx);
+            sslConn.emplace(conn, sslCtx);
             setCipherSuiteTLSext();
         }
     }
@@ -659,7 +662,7 @@ class ConnectionInfo : public std::enable_shared_from_this<ConnectionInfo>
         unsigned int connIdIn) :
         subId(idIn),
         connPolicy(connPolicyIn), host(destIPIn), port(destPortIn),
-        connId(connIdIn), ioc(iocIn), timer(iocIn)
+        connId(connIdIn), ioc(iocIn), conn(iocIn), timer(iocIn)
     {
         initializeConnection(useSSL);
     }
@@ -734,7 +737,7 @@ class ConnectionPool : public std::enable_shared_from_this<ConnectionPool>
                 // Server is not keep-alive enabled so we need to close the
                 // connection and then start over from resolve
                 conn->doClose();
-                conn->restartConnection();
+                conn->doResolve();
             }
             return;
         }

--- a/http/http_client.hpp
+++ b/http/http_client.hpp
@@ -48,7 +48,6 @@
 #include <memory>
 #include <queue>
 #include <string>
-
 namespace crow
 {
 
@@ -149,9 +148,10 @@ class ConnectionInfo : public std::enable_shared_from_this<ConnectionInfo>
     // Ascync callables
     std::function<void(bool, uint32_t, Response&)> callback;
     crow::async_resolve::Resolver resolver;
-    boost::asio::ip::tcp::socket conn;
+    boost::asio::io_context& ioc;
     std::optional<boost::beast::ssl_stream<boost::asio::ip::tcp::socket&>>
         sslConn;
+    std::unique_ptr<boost::asio::ip::tcp::socket> conn;
 
     boost::asio::steady_timer timer;
 
@@ -194,7 +194,7 @@ class ConnectionInfo : public std::enable_shared_from_this<ConnectionInfo>
         timer.async_wait(std::bind_front(onTimeout, weak_from_this()));
 
         boost::asio::async_connect(
-            conn, endpointList,
+            *conn, endpointList,
             std::bind_front(&ConnectionInfo::afterConnect, this,
                             shared_from_this()));
     }
@@ -293,7 +293,7 @@ class ConnectionInfo : public std::enable_shared_from_this<ConnectionInfo>
         else
         {
             boost::beast::http::async_write(
-                conn, req,
+                *conn, req,
                 std::bind_front(&ConnectionInfo::afterWrite, this,
                                 shared_from_this()));
         }
@@ -346,7 +346,7 @@ class ConnectionInfo : public std::enable_shared_from_this<ConnectionInfo>
         else
         {
             boost::beast::http::async_read(
-                conn, buffer, *parser,
+                *conn, buffer, *parser,
                 std::bind_front(&ConnectionInfo::afterRead, this,
                                 shared_from_this()));
         }
@@ -364,7 +364,7 @@ class ConnectionInfo : public std::enable_shared_from_this<ConnectionInfo>
         }
 
         timer.cancel();
-        if (ec && ec != boost::asio::ssl::error::stream_truncated)
+        if (ec)
         {
             BMCWEB_LOG_ERROR << "recvMessage() failed: " << ec.message()
                              << " from " << host << ":" << std::to_string(port);
@@ -496,14 +496,21 @@ class ConnectionInfo : public std::enable_shared_from_this<ConnectionInfo>
         }
 
         // Let's close the connection and restart from resolve.
-        doClose(true);
+        shutdownConn(true);
     }
-
+    void restartConnection()
+    {
+        BMCWEB_LOG_DEBUG << host << ":" << std::to_string(port)
+                         << ", id: " << std::to_string(connId)
+                         << " restartConnection ";
+        conn = makeConnection(ioc, sslConn.has_value());
+        doResolve();
+    }
     void shutdownConn(bool retry)
     {
         boost::beast::error_code ec;
-        conn.shutdown(boost::asio::ip::tcp::socket::shutdown_both, ec);
-        conn.close();
+        conn->shutdown(boost::asio::ip::tcp::socket::shutdown_both, ec);
+        conn->close();
 
         // not_connected happens sometimes so don't bother reporting it.
         if (ec && ec != boost::beast::errc::not_connected)
@@ -523,7 +530,8 @@ class ConnectionInfo : public std::enable_shared_from_this<ConnectionInfo>
         {
             // Now let's try to resend the data
             state = ConnState::retry;
-            doResolve();
+            // reconnect to server using new socket
+            restartConnection();
         }
         else
         {
@@ -603,18 +611,11 @@ class ConnectionInfo : public std::enable_shared_from_this<ConnectionInfo>
             return;
         }
     }
-
-  public:
-    explicit ConnectionInfo(
-        boost::asio::io_context& iocIn, const std::string& idIn,
-        const std::shared_ptr<ConnectionPolicy>& connPolicyIn,
-        const std::string& destIPIn, uint16_t destPortIn, bool useSSL,
-        unsigned int connIdIn) :
-        subId(idIn),
-        connPolicy(connPolicyIn), host(destIPIn), port(destPortIn),
-        connId(connIdIn), conn(iocIn), timer(iocIn)
+    std::unique_ptr<boost::asio::ip::tcp::socket>
+        makeConnection(boost::asio::io_context& iocIn, bool useSsl)
     {
-        if (useSSL)
+        auto newconn = std::make_unique<boost::asio::ip::tcp::socket>(iocIn);
+        if (useSsl)
         {
             /* std::optional<boost::asio::ssl::context> sslCtx =
                 ensuressl::getSSLClientContext();
@@ -634,10 +635,23 @@ class ConnectionInfo : public std::enable_shared_from_this<ConnectionInfo>
             } */
             boost::asio::ssl::context sslCtx{
                 boost::asio::ssl::context::tlsv13_client};
-            sslConn.emplace(conn, sslCtx);
+            sslConn.emplace(*newconn.get(), sslCtx);
             setCipherSuiteTLSext();
         }
+        return newconn;
     }
+
+  public:
+    explicit ConnectionInfo(
+        boost::asio::io_context& iocIn, const std::string& idIn,
+        const std::shared_ptr<ConnectionPolicy>& connPolicyIn,
+        const std::string& destIPIn, uint16_t destPortIn, bool useSSL,
+        unsigned int connIdIn) :
+        subId(idIn),
+        connPolicy(connPolicyIn), host(destIPIn), port(destPortIn),
+        connId(connIdIn), ioc(iocIn), conn(makeConnection(iocIn, useSSL)),
+        timer(iocIn)
+    {}
 };
 
 class ConnectionPool : public std::enable_shared_from_this<ConnectionPool>
@@ -709,7 +723,7 @@ class ConnectionPool : public std::enable_shared_from_this<ConnectionPool>
                 // Server is not keep-alive enabled so we need to close the
                 // connection and then start over from resolve
                 conn->doClose();
-                conn->doResolve();
+                conn->restartConnection();
             }
             return;
         }
@@ -762,9 +776,7 @@ class ConnectionPool : public std::enable_shared_from_this<ConnectionPool>
                 }
                 else
                 {
-                    BMCWEB_LOG_DEBUG << "Reusing existing connection "
-                                     << commonMsg;
-                    conn->doResolve();
+                    conn->restartConnection();
                 }
                 return;
             }


### PR DESCRIPTION
This PR pulls the following commits that fixes HMC no connection issue (which was already merged to 1060 branch but is missed to be pulled down to 1050):

No Connection: Fix for http client stale connection ([link](https://github.com/ibm-openbmc/bmcweb/commit/2523e033cc84c2a0d9405a64e682969a0e8a8664))
http_client: fix for broken connection ([link](https://github.com/ibm-openbmc/bmcweb/commit/6363ab5631e90f518be748adb1fa7d30e7325959))
Sync http client socket handling to upstream ([link](https://github.com/ibm-openbmc/bmcweb/commit/44547a092b185ee76d6a6e3f5ab2a5814c3c8a47))

These commits are for fixing the broken HTTP connection issue (Eg: Connection termination by server due to keep alive timeout).
So whenever there is a connection termination, and when client tries to send/receive data over that broken connection, the operation fails. After this, the client tries to close the (already broken) connection and restart the connection. During this time, SSL shutdown will hang, the same SSL socket was re-used, which caused issues. To avoid this, there is a fix to start a fresh socket instead of re-using the old/stale object.

This fixes 623936 defect.

Tested By:
Tested HMC-BMC event flow
Tested the bad path by keeping the setup idle for 3 hours on the above and verified the events flow after this idle time