### PR TITLE
Fix BIOS attributes Patch operation

### DIFF
--- a/redfish-core/lib/bios.hpp
+++ b/redfish-core/lib/bios.hpp
@@ -674,7 +674,7 @@ inline void requestRoutesBiosSettings(App& app)
                 "xyz.openbmc_project.BIOSConfigManager",
                 "/xyz/openbmc_project/bios_config/manager",
                 "xyz.openbmc_project.BIOSConfig.Manager", "PendingAttributes",
-                std::variant<PendingAttributesType>(pendingAttributes),
+                pendingAttributes,
                 [asyncResp](const boost::system::error_code& ec1) {
                 if (ec1)
                 {


### PR DESCRIPTION
Currently patch operation on BIOS attributes fails, This PR fixes this defect  631792

Tested By:
Verified Patch operation on bios attributes 