### PR TITLE
RedfishEvents GHE: Enable TLS1.2 in http client

### DIFF
--- a/http/http_client.hpp
+++ b/http/http_client.hpp
@@ -631,7 +631,7 @@ class ConnectionInfo : public std::enable_shared_from_this<ConnectionInfo>
         conn = boost::asio::ip::tcp::socket(ioc);
         if (ssl)
         {
-            /* std::optional<boost::asio::ssl::context> sslCtx =
+            std::optional<boost::asio::ssl::context> sslCtx =
                 ensuressl::getSSLClientContext();
 
             if (!sslCtx)
@@ -646,10 +646,8 @@ class ConnectionInfo : public std::enable_shared_from_this<ConnectionInfo>
                 state = ConnState::sslInitFailed;
                 waitAndRetry();
                 return;
-            } */
-            boost::asio::ssl::context sslCtx{
-                boost::asio::ssl::context::tlsv13_client};
-            sslConn.emplace(conn, sslCtx);
+            }
+            sslConn.emplace(conn, *sslCtx);
             setCipherSuiteTLSext();
         }
     }

--- a/include/ssl_key_handler.hpp
+++ b/include/ssl_key_handler.hpp
@@ -494,9 +494,16 @@ inline std::optional<boost::asio::ssl::context> getSSLClientContext()
         return std::nullopt;
     }
 
+    // Currently remote server's certificate verfication fails for
+    // HMC provided self-signed certificates,
+    // so skip remote server's certificate verfication.
+
+    // TODO: certificate verfication can be enabled after supporting
+    // HMC-BMC connection certificate flows on both HMC and BMC.
+
     // Add a directory containing certificate authority files to be used
     // for performing verification.
-    sslCtx.set_default_verify_paths(ec);
+    /* sslCtx.set_default_verify_paths(ec);
     if (ec)
     {
         BMCWEB_LOG_ERROR << "SSL context set_default_verify failed";
@@ -509,7 +516,7 @@ inline std::optional<boost::asio::ssl::context> getSSLClientContext()
     {
         BMCWEB_LOG_ERROR << "SSL context set_verify_mode failed";
         return std::nullopt;
-    }
+    } */
 
     // All cipher suites are set as per OWASP datasheet.
     // https://cheatsheetseries.owasp.org/cheatsheets/TLS_Cipher_String_Cheat_Sheet.html


### PR DESCRIPTION
This is downstream only patch to enable TLS1.2 support
Currently TLS1.3 is hardcoded in http client which restricts redfish events path to work with TLS1.3
and fails with TLS1.2

This commit enables TLS1.2 along with TLS1.3 in http_client and make sure redfish events work with HMC for both TLS1.2 and TLS1.3

Tested by:
Verified redfish events on HMC with TLS1.2 and TLS1.3