### PR TITLE
1050: Software: Add LowestSupportedVersion (#1012)

### DIFF
--- a/redfish-core/lib/update_service.hpp
+++ b/redfish-core/lib/update_service.hpp
@@ -1097,6 +1097,8 @@ inline void requestRoutesSoftwareInventory(App& app)
                 getSoftwareVersion(asyncResp, obj.second[0].first, obj.first,
                                    *swId);
                 asyncResp->res.jsonValue["Name"] = "Software Inventory";
+                sw_util::getSwMinimumVersion(asyncResp, swId,
+                                             obj.second[0].first);
             }
             if (!found)
             {


### PR DESCRIPTION
#### Software: Add LowestSupportedVersion (#1012)
```
A Minimum Version interface was added.[1] This is the minimum software
version that a component must have to operate. Like other interfaces it
is optional. MinimumVersion maps to Redfish's LowestSupportedVersion.[2]

"LowestSupportedVersion": {
    "description": "The lowest supported version of this software.",
    "longDescription": "This property shall represent the lowest
supported version of this software.  This string is formatted using the
same format used for the `Version` property.",
    "readonly": true,
    "type": [
        "string",
        "null"
    ],
    "versionAdded": "v1_1_0"

phosphor-bmc-code-mgmt has support for minimum version.[3]

phosphor-bmc-code-mgmt logs a Software Incompatible[4] error if this
minimum version is not met. Mapping this error to a Redfish error is
not done here but could be added later.

This assumes the D-Bus path is /xyz/openbmc_project/software. This is
where phosphor-bmc-code-mgmt put it. We assume D-Bus Paths like
/xyz/openbmc_project/software/ + $id already.

[1]: https://github.com/openbmc/phosphor-dbus-interfaces/commit/9012243e543abdc5851b7e878c17c991b2a2a8b7
[2]: https://redfish.dmtf.org/schemas/v1/SoftwareInventory.v1_10_2.json
[3]: https://github.com/openbmc/phosphor-bmc-code-mgmt/blob/85c71a13e0938cc4d36caf6b8e735e9740b2e351/meson.options#L100
[4]: https://github.com/openbmc/phosphor-dbus-interfaces/blob/1c140b9766a15d1cbb8546fa02d5050d772a171d/yaml/xyz/openbmc_project/Software/Version.errors.yaml#L1

Tested: Using an IBM p10bmc see:
{
"@odata.id": "/redfish/v1/UpdateService/FirmwareInventory/788d20be",
"@odata.type": "#SoftwareInventory.v1_1_0.SoftwareInventory",
"Description": "BMC image",
...
"LowestSupportedVersion": "fw1020.00-39.1",
...

The Redfish Validator has no new errors.

Change-Id: I17e6d64c86a7d6312726783425101775a959dc04

Signed-off-by: Gunnar Mills <gmills@us.ibm.com>```