### PR TITLE
1110: Use Connector.Port interface for Cable Ports

### DIFF
--- a/redfish-core/lib/cable.hpp
+++ b/redfish-core/lib/cable.hpp
@@ -372,9 +372,7 @@ inline void
     sdbusplus::message::object_path endpointPath{cableObjectPath};
     endpointPath /= associationName;
 
-    // NOTE: "xyz.openbmc_project.Inventory.Item.Connector" may go away later
-    constexpr std::array<std::string_view, 2> portInterfaces = {
-        "xyz.openbmc_project.Inventory.Item.Connector",
+    constexpr std::array<std::string_view, 1> portInterfaces = {
         "xyz.openbmc_project.Inventory.Connector.Port"};
 
     dbus::utility::getAssociatedSubTreePaths(


### PR DESCRIPTION
To make Redfish Cable and Port consistent, this is to limit Cable ports to find only Connector.Port interfaces for
- UpstreamPorts
- DownStreamPorts

For example,

```
curl -k -X GET https://service:0penBmc0@gfwa816.aus.stglabs.ibm.com:2443/redfish/v1/Cables/dp0_cable0
{
  "Links": {
    "UpstreamPorts": [
      {
            "@odata.id": "/redfish/v1/Systems/system/FabricAdapters/motherboard-pcieslot10-pcie_card10/Ports/c10_connector0"
        ],
      }
    ],
```

However,  if `c10_connector0` is not an interface of `Connector.Port`, this UpstreamPorts may potentially point to the non-existent ports.

Tested:
- GET cable and check Upstream/DownstreamPorts like `curl -k -X GET https://${bmc}/redfish/v1/Cables/dp0_cable0`

- Redfish Service Validator for Cables