### PR TITLE
Task: Initialise tasks with "Starting" State

### DIFF
--- a/redfish-core/lib/log_services.hpp
+++ b/redfish-core/lib/log_services.hpp
@@ -1197,6 +1197,16 @@ inline void createDumpTaskCallback(
             "member='PropertiesChanged',path='" +
                 createdObjPath.str + "'");
 
+        // Take the task state to "Running" for all dumps except
+        // Resource dumps as there is no validation on the user input
+        // for dump creation, meaning only in resource dump creation,
+        // validation will be done on the user input.
+        const std::string resourceDumpIdPrefix =
+            "/xyz/openbmc_project/dump/system/entry/B";
+        if (!(createdObjPath.str).starts_with(resourceDumpIdPrefix))
+        {
+            task->state = "Running";
+        }
         // The task timer is set to max time limit within which the
         // requested dump will be collected.
         task->startTimer(std::chrono::minutes(20));

--- a/redfish-core/lib/task.hpp
+++ b/redfish-core/lib/task.hpp
@@ -99,7 +99,7 @@ struct TaskData : std::enable_shared_from_this<TaskData>
         matchStr(matchIn), index(idx),
         startTime(std::chrono::system_clock::to_time_t(
             std::chrono::system_clock::now())),
-        status("OK"), state("Running"), messages(nlohmann::json::array()),
+        status("OK"), state("Starting"), messages(nlohmann::json::array()),
         timer(crow::connections::systemBus->get_io_context())
 
     {}


### PR DESCRIPTION
This change is required for resource dump creation usecase where a task is started on dump creation request. The task starts with "Running" state and moves to "Completed/Cancelled". For resource dump creation, there is validation of input parameters and this has to be notified back to the user. So the tasks are created with "Starting" state and moved to "Running" only when the inputs are validated, else the state changes to "Cancelled/Completed". For all other dumps, the task state change will be like: "Starting" -> "Running" -> "Completed/Cancelled".

Tested By:
[1] POST https://${bmc}/redfish/v1/Systems/system/LogServices/Dump/Actions/LogService.CollectDiagnosticData -d '{"DiagnosticDataType":"OEM", "OEMDiagnosticDataType":"Resource_vsp_globalfr_0penBmc0"}'