### PR TITLE
1110: Fix total power pointer

### DIFF
--- a/redfish-core/lib/environment_metrics.hpp
+++ b/redfish-core/lib/environment_metrics.hpp
@@ -182,9 +182,9 @@ inline void afterGetPropertyForPowerWatts(
         return;
     }
     asyncResp->res.jsonValue["PowerWatts"]["@odata.id"] = boost::urls::format(
-        "/redfish/v1/Chassis/{}/Sensors/total_power", chassisId);
+        "/redfish/v1/Chassis/{}/Sensors/power_total_power", chassisId);
     asyncResp->res.jsonValue["PowerWatts"]["DataSourceUri"] =
-        boost::urls::format("/redfish/v1/Chassis/{}/Sensors/total_power",
+        boost::urls::format("/redfish/v1/Chassis/{}/Sensors/power_total_power",
                             chassisId);
     asyncResp->res.jsonValue["PowerWatts"]["Reading"] = value;
 }


### PR DESCRIPTION
Starting in 1050, we picked up this Sensor Optimization[1] that moved the sensors to sensortype_sensorname. E.g.
/redfish/v1/Chassis/my_chassis/Sensors/temperature_my_sensor. This was wrong in Environment Metrics so fix this. Found while looking at a different defect.

[1]: https://github.com/openbmc/bmcweb/commit/c1d019a6056a2a0ef50e577b3139ab5a8dc49355

Commented upstream at https://gerrit.openbmc.org/c/openbmc/bmcweb/+/57717