### PR TITLE
Hypervisor fix validator errors

### DIFF
--- a/redfish-core/lib/hypervisor_system.hpp
+++ b/redfish-core/lib/hypervisor_system.hpp
@@ -506,7 +506,10 @@ inline void parseInterfaceData(nlohmann::json& jsonResponse,
     jsonResponse["Id"] = ifaceId;
     jsonResponse["@odata.id"] = boost::urls::format(
         "/redfish/v1/Systems/hypervisor/EthernetInterfaces/{}", ifaceId);
-    jsonResponse["MACAddress"] = ethData.macAddress;
+    if (!ethData.macAddress.empty())
+    {
+        jsonResponse["MACAddress"] = ethData.macAddress;
+    }
 
     jsonResponse["HostName"] = ethData.hostName;
     jsonResponse["DHCPv4"]["DHCPEnabled"] =
@@ -528,26 +531,48 @@ inline void parseInterfaceData(nlohmann::json& jsonResponse,
     ipv4Array = nlohmann::json::array();
     ipv4StaticArray = nlohmann::json::array();
     bool ipv4IsActive = false;
+    std::string v4Origin;
+    std::string v4Gateway;
+    std::string v4Netmask;
+    std::string v4Address;
+
     for (const auto& ipv4Config : ipv4Data)
     {
         if (ipv4Config.isActive)
         {
             ipv4IsActive = ipv4Config.isActive;
         }
+        if (!ipv4Config.origin.empty())
+        {
+            v4Origin = ipv4Config.origin;
+        }
+        if (!ipv4Config.gateway.empty())
+        {
+            v4Gateway = ethData.defaultGateway;
+        }
+        if (!ipv4Config.netmask.empty())
+        {
+            v4Netmask = ipv4Config.netmask;
+        }
         if (!ipv4Config.address.empty())
         {
-            nlohmann::json::object_t ipv4;
-            ipv4["AddressOrigin"] = ipv4Config.origin;
-            ipv4["SubnetMask"] = ipv4Config.netmask;
-            ipv4["Address"] = ipv4Config.address;
-            ipv4["Gateway"] = ipv4Config.gateway;
-
-            if (ipv4Config.origin == "Static")
-            {
-                ipv4StaticArray.emplace_back(ipv4);
-            }
-            ipv4Array.emplace_back(std::move(ipv4));
+            v4Address = ipv4Config.address;
         }
+    }
+    nlohmann::json::object_t ipv4;
+    ipv4["AddressOrigin"] = v4Origin;
+    ipv4["SubnetMask"] = v4Netmask;
+    ipv4["Address"] = v4Address;
+    ipv4["Gateway"] = v4Gateway;
+    if (v4Origin == "Static")
+    {
+        ipv4StaticArray.push_back(ipv4);
+    }
+    ipv4Array.emplace_back(std::move(ipv4));
+
+    if (ipv4IsActive)
+    {
+        jsonResponse["InterfaceEnabled"] = true;
     }
 
     std::string ipv6GatewayStr = ethData.ipv6DefaultGateway;


### PR DESCRIPTION
Currently, Redfish validator fails for two things when doing a GET on hypervisor ethernet interfaces:
1. Empty mac address getting displayed, and
2. Empty Address origin

This commit ensures that the redfish validator passes by adding appropriate checks in the GET handler method.

Upsrteam: https://gerrit.openbmc.org/c/openbmc/bmcweb/+/73196

Fixes: [
](https://jazz07.rchland.ibm.com:13443/jazz/web/projects/CSSD#action=com.ibm.team.workitem.viewWorkItem&id=637212)

Tested By:
Validator Passed.