### PR TITLE
Fix 404 on Hypervisor Reset

### DIFF
--- a/redfish-core/lib/hypervisor_system.hpp
+++ b/redfish-core/lib/hypervisor_system.hpp
@@ -1440,13 +1440,9 @@ inline void handleHypervisorResetActionGet(
 }
 
 inline void handleHypervisorSystemResetPost(
-    App& app, const crow::Request& req,
+    const crow::Request& req,
     const std::shared_ptr<bmcweb::AsyncResp>& asyncResp)
 {
-    if (!redfish::setUpRedfishRoute(app, req, asyncResp))
-    {
-        return;
-    }
     std::optional<std::string> resetType;
     if (!json_util::readJsonAction(req, asyncResp->res, "ResetType", resetType))
     {
@@ -1521,11 +1517,5 @@ inline void requestRoutesHypervisorSystems(App& app)
         .privileges(redfish::privileges::patchEthernetInterface)
         .methods(boost::beast::http::verb::patch)(std::bind_front(
             handleHypervisorEthernetInterfacePatch, std::ref(app)));
-
-    BMCWEB_ROUTE(app,
-                 "/redfish/v1/Systems/hypervisor/Actions/ComputerSystem.Reset/")
-        .privileges(redfish::privileges::postComputerSystem)
-        .methods(boost::beast::http::verb::post)(
-            std::bind_front(handleHypervisorSystemResetPost, std::ref(app)));
 }
 } // namespace redfish

--- a/redfish-core/lib/systems.hpp
+++ b/redfish-core/lib/systems.hpp
@@ -2726,6 +2726,13 @@ inline void handleComputerSystemResetActionPost(
     {
         return;
     }
+
+    if (systemName == "hypervisor")
+    {
+        handleHypervisorSystemResetPost(req, asyncResp);
+        return;
+    }
+
     if (systemName != "system")
     {
         messages::resourceNotFound(asyncResp->res, "ComputerSystem",


### PR DESCRIPTION
/redfish/v1/Systems/hypervisor/Actions/ComputerSystem.Reset was returning a 404. On closer inspection, it was due to hitting the System .Reset Action and not making it to the Hypervisor specific action. [1].

Remove the Hypervisor specific action and call the method from the System .Reset Action. This is how we do the handleHypervisorSystemGet already. [2]

Fixes defects 637587 and 632508.

https://gerrit.openbmc.org/c/openbmc/bmcweb/+/73203 is upstream 

[1]: https://github.com/ibm-openbmc/bmcweb/blob/1110/redfish-core/lib/systems.hpp#L3335
[2]: https://github.com/ibm-openbmc/bmcweb/blob/1110/redfish-core/lib/systems.hpp#L2906C9-L2906C34

Tested: Loaded this on a system and was able to "Continue to OS running".