### PR TITLE
Add Id back to PCIeSlots redfish json

### DIFF
--- a/redfish-core/lib/pcie_slots.hpp
+++ b/redfish-core/lib/pcie_slots.hpp
@@ -505,6 +505,7 @@ inline void afterHandlePCIeSlotCollectionGet(
     asyncResp->res.jsonValue["Name"] = "PCIe Slot Information";
     asyncResp->res.jsonValue["@odata.id"] =
         boost::urls::format("/redfish/v1/Chassis/{}/PCIeSlots", chassisID);
+    asyncResp->res.jsonValue["Id"] = "PCIeSlots";
     asyncResp->res.jsonValue["Slots"] = nlohmann::json::array();
 
     getValidPCIeSlotList(


### PR DESCRIPTION
A previous commit[1] improperly removed "Id" from PCIeSlots.

Unfortunately, it causes Redfish Service Validator error.

```
1 err.Resource.Id errors in /redfish/v1/Chassis/chassis/PCIeSlots
1 failMandatoryExist errors in /redfish/v1/Chassis/chassis/PCIeSlots
2 fails errors in /redfish/v1/Chassis/chassis/PCIeSlots

ERROR - Id: Mandatory prop does not exist
```

It is suggested to add "Id" as "PCIeSlots" like

```
{
    "@odata.id": "/redfish/v1/Chassis/chassis/PCIeSlots",
    "@odata.type": "#PCIeSlots.v1_5_0.PCIeSlots",
    "Name": "PCIe Slot Information",
    "Id": "PCIeSlots",
    ...
}
```

Tested:
  - GET PCIeSlots and check "Id" `curl -k -X GET https://${bmc}/redfish/v1/Chassis/chassis/PCIeSlots`
  - Redfish Service Validator passes on PCIeSlots

[1] https://github.com/ibm-openbmc/bmcweb/commit/67ce7565ab8fe69219dcacccbd05b8c9a65a394d