### PR TITLE
Resource dump create: Handle new errors

### DIFF
--- a/redfish-core/lib/log_services.hpp
+++ b/redfish-core/lib/log_services.hpp
@@ -1017,15 +1017,15 @@ inline DumpCreationProgress
                     messages::insufficientPrivilege());
                 return DumpCreationProgress::DUMP_CREATE_FAILED;
             }
-            if ((*value).ends_with("AcfFileInvalid") ||
-                (*value).ends_with("PasswordInvalid"))
+            if ((*value).ends_with("ACFFileInvalid") ||
+                (*value).ends_with("UserChallengeInvalid"))
             {
                 BMCWEB_LOG_WARNING(
                     "DumpRequestStatus: ACFFile Invalid/Password Invalid");
                 taskData->messages.emplace_back(
                     messages::resourceAtUriUnauthorized(
                         boost::urls::url_view(taskData->payload->targetUri),
-                        "Invalid Password/ACF File Invalid"));
+                        "Invalid User challenge/ACF File Invalid"));
                 return DumpCreationProgress::DUMP_CREATE_FAILED;
             }
             if ((*value).ends_with("ResourceSelectorInvalid"))


### PR DESCRIPTION
On every dump initiation, bmcweb creates a task with "Starting" state. bmcweb will listen to "DumpRequestStatus" property changed signal and move the task state to "Cancelled/Running" based on the validation of the user input for "resource dump" creation.

The following commit has changed a few enum values for "DumpRequestStatus" property:
[1] https://github.com/openbmc/phosphor-dbus-interfaces/commit/980fb7b56960951d8bfb471e9fe63b9d0bacf127

This PR contains changes made w.r.t the above dbus interfaces change to handle the new enum values.

Tested By:
* Created a resource dump and verified the task state move to "Running/Completed" based on the "DumpRequestStatus" property.