### PR TITLE
1110: Use UniquePath on PCIeSlot UpstreamFabricAdapter

### DIFF
--- a/redfish-core/lib/pcie_slots.hpp
+++ b/redfish-core/lib/pcie_slots.hpp
@@ -62,11 +62,10 @@ inline void afterAddLinkedFabricAdapter(
     nlohmann::json& fabricArray = linkOemIbm["UpstreamFabricAdapters"];
     for (const auto& fabricAdapterPath : fabricAdapterPaths)
     {
-        std::string fabricAdapterName =
-            sdbusplus::message::object_path(fabricAdapterPath).filename();
         nlohmann::json::object_t item;
         item["@odata.id"] = boost::urls::format(
-            "/redfish/v1/Systems/system/FabricAdapters/{}", fabricAdapterName);
+            "/redfish/v1/Systems/system/FabricAdapters/{}",
+            fabric_util::buildFabricUniquePath(fabricAdapterPath));
         fabricArray.emplace_back(std::move(item));
     }
     linkOemIbm["UpstreamFabricAdapters@odata.count"] = fabricArray.size();


### PR DESCRIPTION
PCIeSlot UpstreamFabricAdapter link field shows URI incorrectly and it needs to be translated with `buildFabricUniquePath()`.

For example,
```
    {
      "HotPluggable": false,
      "Links": {
        "Oem": {
          "IBM": {
            "UpstreamFabricAdapters": [
              {
                "@odata.id": "/redfish/v1/Systems/system/FabricAdapters/io_module1"
              }
            ],
            "UpstreamFabricAdapters@odata.count": 1
          }
        },
```

This needs to be
```
 "@odata.id": "/redfish/v1/Systems/system/FabricAdapters/chassis15363-logical_slot1-io_module1"
```

Tested:
- GET PCIeSlots on MEX
- Redfish Validator on MEX chass