### PR TITLE
WIP: 1060: Allow logged in users to upload incrementally

### DIFF
--- a/http/http_connection.hpp
+++ b/http/http_connection.hpp
@@ -792,7 +792,6 @@ class Connection :
             // is so high to support our large code update images on
             // slow networks Need a better way to do this
             timeout = std::chrono::seconds(1560);
-            return;
         }
 
         std::weak_ptr<Connection<Adaptor, Handler>> weakSelf = weak_from_this();

--- a/http/http_connection.hpp
+++ b/http/http_connection.hpp
@@ -699,6 +699,12 @@ class Connection :
             }
 #endif // BMCWEB_INSECURE_DISABLE_AUTHX
 
+            if (parser->is_done())
+            {
+                handle();
+                return;
+            }
+
             doRead();
         });
     }
@@ -707,13 +713,14 @@ class Connection :
     {
         BMCWEB_LOG_DEBUG << this << " doRead";
         startDeadline();
-        boost::beast::http::async_read(adaptor, buffer, *parser,
-                                       [this, self(shared_from_this())](
-                                           const boost::system::error_code& ec,
-                                           std::size_t bytesTransferred) {
-            BMCWEB_LOG_DEBUG << this << " async_read " << bytesTransferred
+        boost::beast::http::async_read_some(
+            adaptor, buffer, *parser,
+            [this,
+             self(shared_from_this())](const boost::system::error_code& ec,
+                                       std::size_t bytesTransferred) {
+            BMCWEB_LOG_DEBUG << this << " async_read_some " << bytesTransferred
                              << " Bytes";
-            cancelDeadlineTimer();
+
             if (ec)
             {
                 BMCWEB_LOG_ERROR << this
@@ -722,8 +729,23 @@ class Connection :
                 BMCWEB_LOG_DEBUG << this << " from read(1)";
                 return;
             }
+
+            // If the user is logged in, allow them to send files incrementally
+            // one piece at a time. If authentication is disabled then there is
+            // no user session hence always allow to send one piece at a time.
+            if (userSession != nullptr)
+            {
+                cancelDeadlineTimer();
+            }
+            if (!parser->is_done())
+            {
+                doRead();
+                return;
+            }
+
+            cancelDeadlineTimer();
             handle();
-        });
+            });
     }
 
     void doWrite(crow::Response& thisRes)
@@ -781,22 +803,19 @@ class Connection :
 
     void startDeadline()
     {
-        cancelDeadlineTimer();
+        // Timer is already started so no further action is required.
+        if (timerStarted)
+        {
+            return;
+        }
 
         std::chrono::seconds timeout(15);
-        // allow slow uploads for logged in users
-        bool loggedIn = userSession != nullptr;
-        if (loggedIn)
-        {
-            timeout = std::chrono::seconds(60);
-        }
 
         std::weak_ptr<Connection<Adaptor, Handler>> weakSelf = weak_from_this();
         timer.expires_after(timeout);
         timer.async_wait([weakSelf](const boost::system::error_code ec) {
             // Note, we are ignoring other types of errors here;  If the timer
             // failed for any reason, we should still close the connection
-
             std::shared_ptr<Connection<Adaptor, Handler>> self =
                 weakSelf.lock();
             if (!self)
@@ -804,6 +823,9 @@ class Connection :
                 BMCWEB_LOG_CRITICAL << self << " Failed to capture connection";
                 return;
             }
+
+            self->timerStarted = false;
+
             if (ec == boost::asio::error::operation_aborted)
             {
                 // Canceled wait means the path succeeeded.
@@ -819,6 +841,7 @@ class Connection :
             self->close();
         });
 
+        timerStarted = true;
         BMCWEB_LOG_DEBUG << this << " timer started";
     }
 
@@ -845,6 +868,8 @@ class Connection :
     boost::asio::steady_timer timer;
 
     bool keepAlive = true;
+
+    bool timerStarted = false;
 
     std::function<std::string()>& getCachedDateStr;
 

--- a/http/http_connection.hpp
+++ b/http/http_connection.hpp
@@ -783,15 +783,12 @@ class Connection :
     {
         cancelDeadlineTimer();
 
-        std::chrono::seconds timeout(120);
+        std::chrono::seconds timeout(15);
         // allow slow uploads for logged in users
         bool loggedIn = userSession != nullptr;
         if (loggedIn)
         {
-            // drop all connections after 26 minutes, this time limit
-            // is so high to support our large code update images on
-            // slow networks Need a better way to do this
-            timeout = std::chrono::seconds(1560);
+            timeout = std::chrono::seconds(60);
         }
 
         std::weak_ptr<Connection<Adaptor, Handler>> weakSelf = weak_from_this();


### PR DESCRIPTION
Cherry pick 
https://gerrit.openbmc.org/c/openbmc/bmcweb/+/60423
and 
https://gerrit.openbmc.org/c/openbmc/bmcweb/+/60363

Revert https://github.com/ibm-openbmc/bmcweb/commit/218551441286221cf44c224814a82c399fcabadd 

This moves us to a 15 second timeout, that as long as the client has made progress in the last 15 seconds, we allow this to continue. This is what we have in 1110 and upstream. 