### PR TITLE
1110: Chassis: Add support for Version property

### DIFF
--- a/redfish-core/lib/chassis.hpp
+++ b/redfish-core/lib/chassis.hpp
@@ -478,9 +478,8 @@ inline void handleChassisGetSubTree(
             "xyz.openbmc_project.Inventory.Decorator.AssetTag";
         const std::string replaceableInterface =
             "xyz.openbmc_project.Inventory.Decorator.Replaceable";
-        const std::string versionInterface =
-            "xyz.openbmc_project.Software.Version";
-
+        const std::string revisionInterface =
+            "xyz.openbmc_project.Inventory.Decorator.Revision";
         for (const auto& interface : interfaces2)
         {
             if (interface == assetTagInterface)
@@ -518,18 +517,17 @@ inline void handleChassisGetSubTree(
                     asyncResp->res.jsonValue["HotPluggable"] = property;
                 });
             }
-            else if (interface == replaceableInterface)
+            else if (interface == revisionInterface)
             {
                 sdbusplus::asio::getProperty<std::string>(
                     *crow::connections::systemBus, connectionName, path,
-                    versionInterface, "Version",
-                    [asyncResp, chassisId(std::string(chassisId))](
-                        const boost::system::error_code& ec2,
-                        const std::string& property) {
+                    revisionInterface, "Version",
+                    [asyncResp, chassisId](const boost::system::error_code& ec2,
+                                           const std::string& property) {
                     if (ec2)
                     {
-                        BMCWEB_LOG_ERROR("DBus response error for Version, {}",
-                                         ec2.value());
+                        BMCWEB_LOG_ERROR("DBus response error for Version: {}",
+                                         ec2);
                         messages::internalError(asyncResp->res);
                         return;
                     }


### PR DESCRIPTION
Add support for the Version property of Chassis resources.  That property was added in Chassis schema v1.21.0.

This makes use of the "xyz.openbmc_project.Inventory.Decorator.Revision" interface that is already defined by phosphor-dbus-interfaces.

Tested:
Validator passed and Version property was correctly populated.  No issues on other Chassis resources which do not have a Version property.

I added this to an entity-manager json config:

"xyz.openbmc_project.Inventory.Decorator.Revision": {
        "Version": "$PRODUCT_VERSION"
}

The PRODUCT_VERSION field from a given FRU eeprom was picked up by FruDevice and it was exposed under the associated Chassis resource:

busctl get-property xyz.openbmc_project.FruDevice \ /xyz/openbmc_project/FruDevice/Test \
xyz.openbmc_project.FruDevice PRODUCT_VERSION
s "V1.0"

curl -s 'localhost/redfish/v1/Chassis/TestChassis' {
  "@odata.id": "/redfish/v1/Chassis/TestChassis",
  ...
  "Version": "V1.0"
}


Change-Id: Ie1391d46e81fd8c503fe4b1e6d683dd4553a5419