### PR TITLE
redfish-core: Core: Enabled the isolation (aka guard) feature

### DIFF
--- a/redfish-core/include/utils/hw_isolation.hpp
+++ b/redfish-core/include/utils/hw_isolation.hpp
@@ -196,7 +196,7 @@ inline void
         if (ec)
         {
             BMCWEB_LOG_ERROR(
-                "DBus response error [{} : {}] when tried to get the hardware isolation entry for the given resource dbus object path: ",
+                "DBus response error [{} : {}] when tried to get the hardware isolation entry for the given resource dbus object path: {}",
                 ec.value(), ec.message(), resourceObjPath.str);
             // The error code (53 == Invalid request descriptor) will be
             // returned if dbus doesn't contains "isolated_hw_entry" for

--- a/redfish-core/lib/processor.hpp
+++ b/redfish-core/lib/processor.hpp
@@ -1110,6 +1110,33 @@ inline void afterGetCpuCoreDataByService(
                         }
                         present = *value;
                     }
+                    else if (propName == "PrettyName")
+                    {
+                        const std::string* prettyName =
+                            std::get_if<std::string>(&propValue);
+                        if (prettyName == nullptr)
+                        {
+                            messages::internalError(asyncResp->res);
+                            return;
+                        }
+                        asyncResp->res.jsonValue["Name"] = *prettyName;
+                    }
+                }
+            }
+            else if (interface == "xyz.openbmc_project.Object.Enable")
+            {
+                for (const auto& [propName, propValue] : properties)
+                {
+                    if (propName == "Enabled")
+                    {
+                        const bool* enabled = std::get_if<bool>(&propValue);
+                        if (enabled == nullptr)
+                        {
+                            messages::internalError(asyncResp->res);
+                            return;
+                        }
+                        asyncResp->res.jsonValue["Enabled"] = *enabled;
+                    }
                 }
             }
             else if (interface ==

--- a/redfish-core/lib/processor.hpp
+++ b/redfish-core/lib/processor.hpp
@@ -1093,6 +1093,7 @@ inline void afterGetCpuCoreDataByService(
                             return;
                         }
                         functional = *value;
+                        break;
                     }
                 }
             }
@@ -1136,6 +1137,7 @@ inline void afterGetCpuCoreDataByService(
                             return;
                         }
                         asyncResp->res.jsonValue["Enabled"] = *enabled;
+                        break;
                     }
                 }
             }
@@ -1153,6 +1155,7 @@ inline void afterGetCpuCoreDataByService(
                             return;
                         }
                         available = *value;
+                        break;
                     }
                 }
             }


### PR DESCRIPTION
- In an OpenPOWER based system, a user can isolate the Processor Core from the next boot of the system so add the support for same in this patch to do isolation through redfish interface.

- In Redfish, the "Enabled" property (which is added in Processor schema) to enable or disable the respective resource so using the same property for isolation feature.
  - The "Enabled" property was added in Processor.v1_12_0 version so bumped the processor schema version in all places.

- The "Enabled" Redfish property is mapped with "xyz.openbmc_project.Object.Enable::Enabled" dbus property.

- In this patch, added the utility function for hardware isolation so any redfish resource can use that utility function if that redfish resource will support hardware isolation for the system.

Note: The hardware isolation for the Processor Core is enabled on
      top of the below patch which will be used to model the
      Processor Core in redfish.
      https://gerrit.openbmc-project.xyz/c/openbmc/bmcweb/+/38570

Other Reference:

- Design document for hardware isolation (aka guard) https://github.com/openbmc/docs/blob/master/designs/guard-on-bmc.md

- DBus interface for "Enabled" https://github.com/openbmc/phosphor-dbus-interfaces/blob/master/yaml/ \ xyz/openbmc_project/Object/Enable.interface.yaml

- DBus interface for isolate hardware https://gerrit.openbmc-project.xyz/c/openbmc/phosphor-dbus-interfaces/ \ +/43533

Tested:

- Disabled the particular Processor Core by using below command.
```
curl -k -H "X-Auth-Token: $bmc_token" -X PATCH \
https://${bmc}/redfish/v1/Systems/system/Processors/cpu0/SubProcessors/core0 \
-d '{"Enabled" : false }'
{
  "@Message.ExtendedInfo": [
    {
      "@odata.type": "#Message.v1_1_1.Message",
      "Message": "Successfully Completed Request",
      "MessageArgs": [],
      "MessageId": "Base.1.8.1.Success",
      "MessageSeverity": "OK",
      "Resolution": "None"
    }
  ]
}
```

- Disabled the isolated Processor Core by using below command.
```
curl -k -H "X-Auth-Token: $bmc_token" -X PATCH \
https://${bmc}/redfish/v1/Systems/system/Processors/cpu0/SubProcessors/core0 \
-d '{"Enabled" : false }'
{
  "Core@Message.ExtendedInfo": [
    {
      "@odata.type": "#Message.v1_1_1.Message",
      "Message": "The requested resource of type @odata.id with the property Core \
                  with the value core0 already exists.",
      "MessageArgs": [
        "@odata.id",
        "Core",
        "core0"
      ],
      "MessageId": "Base.1.8.1.ResourceAlreadyExists",
      "MessageSeverity": "Critical",
      "Resolution": "Do not repeat the create operation as the resource has already \
                    been created."
    }
  ]
}
```

- Enabled the particular isolated Processor Core by using below command.
```
curl -k -H "X-Auth-Token: $bmc_token" -X PATCH \
https://${bmc}/redfish/v1/Systems/system/Processors/cpu0/SubProcessors/core0 \
-d '{"Enabled" : true }'
{
  "@Message.ExtendedInfo": [
    {
      "@odata.type": "#Message.v1_1_1.Message",
      "Message": "Successfully Completed Request",
      "MessageArgs": [],
      "MessageId": "Base.1.8.1.Success",
      "MessageSeverity": "OK",
      "Resolution": "None"
    }
  ]
}
```