### PR TITLE
Fix IPv6 static default gateway

### DIFF
--- a/redfish-core/lib/ethernet.hpp
+++ b/redfish-core/lib/ethernet.hpp
@@ -835,8 +835,7 @@ inline bool extractIPv6DefaultGatewayData(
 
             bool success = sdbusplus::unpackPropertiesNoThrow(
                 redfish::dbus_utils::UnpackErrorPrinter(), interface.second,
-                "Gateway", staticGateway.gateway, "PrefixLength",
-                staticGateway.prefixLength, "ProtocolType",
+                "Gateway", staticGateway.gateway, "ProtocolType",
                 staticGateway.protocol);
             if (!success)
             {
@@ -919,14 +918,13 @@ inline void
  * @brief Creates IPv6 static default gateway with given data
  *
  * @param[in] ifaceId      Id of interface whose IP should be added
- * @param[in] prefixLength Prefix length that needs to be added
  * @param[in] gateway      Gateway address that needs to be added
  * @param[io] asyncResp    Response object that will be returned to client
  *
  * @return None
  */
 inline void createIPv6DefaultGateway(
-    std::string_view ifaceId, size_t prefixLength, std::string_view gateway,
+    std::string_view ifaceId, std::string_view gateway,
     const std::shared_ptr<bmcweb::AsyncResp>& asyncResp)
 {
     sdbusplus::message::object_path path("/xyz/openbmc_project/network");
@@ -940,7 +938,7 @@ inline void createIPv6DefaultGateway(
     crow::connections::systemBus->async_method_call(
         std::move(createIpHandler), "xyz.openbmc_project.Network", path,
         "xyz.openbmc_project.Network.StaticGateway.Create", "StaticGateway",
-        gateway, prefixLength, "xyz.openbmc_project.Network.IP.Protocol.IPv6");
+        gateway, "xyz.openbmc_project.Network.IP.Protocol.IPv6");
 }
 
 /**
@@ -950,28 +948,26 @@ inline void createIPv6DefaultGateway(
  * @param[in] ifaceId      Id of interface upon which to create the IPv6
  * entry
  * @param[in] gateway      IPv6 gateway to assign to this interface
- * @param[in] prefixLength IPv6 prefix syntax for the subnet mask
  * @param[io] asyncResp    Response object that will be returned to client
  *
  * @return None
  */
 inline void deleteAndCreateIPv6DefaultGateway(
     std::string_view ifaceId, std::string_view gatewayId,
-    std::string_view gateway, size_t prefixLength,
+    std::string_view gateway,
     const std::shared_ptr<bmcweb::AsyncResp>& asyncResp)
 {
     sdbusplus::message::object_path path("/xyz/openbmc_project/network");
     path /= ifaceId;
     path /= gatewayId;
     crow::connections::systemBus->async_method_call(
-        [asyncResp, ifaceId, gateway,
-         prefixLength](const boost::system::error_code& ec) {
+        [asyncResp, ifaceId, gateway](const boost::system::error_code& ec) {
         if (ec)
         {
             messages::internalError(asyncResp->res);
             return;
         }
-        createIPv6DefaultGateway(ifaceId, prefixLength, gateway, asyncResp);
+        createIPv6DefaultGateway(ifaceId, gateway, asyncResp);
     },
         "xyz.openbmc_project.Network", path,
         "xyz.openbmc_project.Object.Delete", "Delete");
@@ -999,7 +995,6 @@ inline void handleIPv6DefaultGateway(
 
     for (const nlohmann::json& thisJson : input)
     {
-        // find the next gateway entry
         while (staticGatewayEntry != staticGatewayData.end())
         {
             if (staticGatewayEntry->protocol ==
@@ -1011,75 +1006,54 @@ inline void handleIPv6DefaultGateway(
         }
         std::string pathString = "IPv6StaticDefaultGateways/" +
                                  std::to_string(entryIdx);
-        if (thisJson.is_null())
+        if (!thisJson.is_null() && !thisJson.empty())
         {
-            if (staticGatewayEntry == staticGatewayData.end())
+            std::optional<std::string> address;
+            nlohmann::json thisJsonCopy = thisJson;
+            if (!json_util::readJson(thisJsonCopy, asyncResp->res, "Address",
+                                     address))
             {
-                messages::resourceCannotBeDeleted(asyncResp->res);
                 return;
             }
-            deleteIPv6Gateway(ifaceId, staticGatewayEntry->id, asyncResp);
-            return;
-        }
-        if (thisJson.is_object() && thisJson.empty())
-        {
-            // Do nothing, but make sure the entry exists.
-            if (staticGatewayEntry == staticGatewayData.end())
+            const std::string* addr = nullptr;
+            if (address)
             {
-                messages::propertyValueFormatError(asyncResp->res, thisJson,
-                                                   pathString);
+                addr = &(*address);
+            }
+            else if (staticGatewayEntry != staticGatewayData.end())
+            {
+                addr = &(staticGatewayEntry->gateway);
+            }
+            else
+            {
+                messages::propertyMissing(asyncResp->res,
+                                          pathString + "/Address");
                 return;
             }
-        }
-        std::optional<std::string> address;
-        std::optional<size_t> prefixLength;
-
-        nlohmann::json thisJsonCopy = thisJson;
-        if (!json_util::readJson(thisJsonCopy, asyncResp->res, "Address",
-                                 address, "PrefixLength", prefixLength))
-        {
-            return;
-        }
-        const std::string* addr = nullptr;
-        size_t prefix = 0;
-        if (address)
-        {
-            addr = &(*address);
-        }
-        else if (staticGatewayEntry != staticGatewayData.end())
-        {
-            addr = &(staticGatewayEntry->gateway);
+            if (staticGatewayEntry != staticGatewayData.end())
+            {
+                deleteAndCreateIPv6DefaultGateway(
+                    ifaceId, staticGatewayEntry->id, *addr, asyncResp);
+                staticGatewayEntry++;
+            }
+            else
+            {
+                createIPv6DefaultGateway(ifaceId, *addr, asyncResp);
+            }
+            entryIdx++;
         }
         else
         {
-            messages::propertyMissing(asyncResp->res, pathString + "/Address");
-            return;
+            if (thisJson.is_null())
+            {
+                deleteIPv6Gateway(ifaceId, staticGatewayEntry->id, asyncResp);
+            }
+            if (staticGatewayEntry != staticGatewayData.end())
+            {
+                staticGatewayEntry++;
+            }
+            entryIdx++;
         }
-        if (prefixLength)
-        {
-            prefix = *prefixLength;
-        }
-        else if (staticGatewayEntry != staticGatewayData.end())
-        {
-            prefix = staticGatewayEntry->prefixLength;
-        }
-        else
-        {
-            messages::propertyMissing(asyncResp->res,
-                                      pathString + "/PrefixLength");
-            return;
-        }
-        if (staticGatewayEntry != staticGatewayData.end())
-        {
-            deleteAndCreateIPv6DefaultGateway(ifaceId, staticGatewayEntry->id,
-                                              *addr, prefix, asyncResp);
-            staticGatewayEntry++;
-        }
-        else
-        {
-            createIPv6DefaultGateway(ifaceId, prefix, *addr, asyncResp);
-        }
-        entryIdx++;
     }
 }
 


### PR DESCRIPTION
This commit updates IPv6 static default gateway implementation to use modified D-bus interfaces 

PrefixLength property removed from StaticGateway D-bus interface
https://gerrit.openbmc.org/c/openbmc/phosphor-dbus-interfaces/+/71271

Tested by:
-d '{"IPv6StaticDefaultGateways": [{"Address": "2006:905:15F:36:10:10:3:1"}]}'
-d '{"IPv6StaticDefaultGateways": [{},{"Address": "2007:905:18F:36:10:9:5:1"}]}'
