### PR TITLE
Ignore all ChapData errors

### DIFF
--- a/redfish-core/lib/systems.hpp
+++ b/redfish-core/lib/systems.hpp
@@ -2281,11 +2281,8 @@ inline void getChapData(const std::shared_ptr<bmcweb::AsyncResp>& asyncResp)
                     const dbus::utility::DBusPropertiesMap& propertiesList) {
         if (ec)
         {
-            if (ec.value() != EBADR)
-            {
-                BMCWEB_LOG_ERROR("Get ChapData D-bus error: {}", ec.value());
-                messages::internalError(asyncResp->res);
-            }
+            // ChapData isn't that important. Ignore all errors.
+            BMCWEB_LOG_DEBUG("Get ChapData D-bus error: {}", ec.value());
             return;
         }
 


### PR DESCRIPTION
Have seen pldm send back errors in cases like it is powering off. Just ignore all ChapData errors. The HMC doesn't use ChapData. We will still return a 500 here in 1050/1060 but for 1110, let's just ignore all errors.

Fixes defect 642324