### PR TITLE
clang-format-18

### DIFF
--- a/http/http2_connection.hpp
+++ b/http/http2_connection.hpp
@@ -54,9 +54,8 @@ class HTTP2Connection :
   public:
     HTTP2Connection(Adaptor&& adaptorIn, Handler* handlerIn,
                     std::function<std::string()>& getCachedDateStrF) :
-        adaptor(std::move(adaptorIn)),
-        ngSession(initializeNghttp2Session()), handler(handlerIn),
-        getCachedDateStr(getCachedDateStrF)
+        adaptor(std::move(adaptorIn)), ngSession(initializeNghttp2Session()),
+        handler(handlerIn), getCachedDateStr(getCachedDateStrF)
     {}
 
     void start()

--- a/http/http_body.hpp
+++ b/http/http_body.hpp
@@ -155,8 +155,7 @@ class HttpBody::writer
   public:
     template <bool IsRequest, class Fields>
     writer(boost::beast::http::header<IsRequest, Fields>& /*header*/,
-           value_type& bodyIn) :
-        body(bodyIn)
+           value_type& bodyIn) : body(bodyIn)
     {}
 
     static void init(boost::beast::error_code& ec)
@@ -234,8 +233,7 @@ class HttpBody::reader
   public:
     template <bool IsRequest, class Fields>
     reader(boost::beast::http::header<IsRequest, Fields>& /*headers*/,
-           value_type& body) :
-        value(body)
+           value_type& body) : value(body)
     {}
 
     void init(const boost::optional<std::uint64_t>& contentLength,

--- a/http/http_client.hpp
+++ b/http/http_client.hpp
@@ -120,8 +120,7 @@ struct PendingRequest
     PendingRequest(
         boost::beast::http::request<bmcweb::HttpBody>&& reqIn,
         const std::function<void(bool, uint32_t, Response&)>& callbackIn) :
-        req(std::move(reqIn)),
-        callback(callbackIn)
+        req(std::move(reqIn)), callback(callbackIn)
     {}
 };
 
@@ -634,9 +633,9 @@ class ConnectionInfo : public std::enable_shared_from_this<ConnectionInfo>
         const std::shared_ptr<ConnectionPolicy>& connPolicyIn,
         const boost::urls::url_view_base& hostIn,
         ensuressl::VerifyCertificate verifyCertIn, unsigned int connIdIn) :
-        subId(idIn),
-        connPolicy(connPolicyIn), host(hostIn), verifyCert(verifyCertIn),
-        connId(connIdIn), ioc(iocIn), resolver(iocIn), conn(iocIn), timer(iocIn)
+        subId(idIn), connPolicy(connPolicyIn), host(hostIn),
+        verifyCert(verifyCertIn), connId(connIdIn), ioc(iocIn), resolver(iocIn),
+        conn(iocIn), timer(iocIn)
     {
         initializeConnection(host.scheme() == "https");
     }
@@ -835,8 +834,7 @@ class ConnectionPool : public std::enable_shared_from_this<ConnectionPool>
         const std::shared_ptr<ConnectionPolicy>& connPolicyIn,
         const boost::urls::url_view_base& destIPIn,
         ensuressl::VerifyCertificate verifyCertIn) :
-        ioc(iocIn),
-        id(idIn), connPolicy(connPolicyIn), destIP(destIPIn),
+        ioc(iocIn), id(idIn), connPolicy(connPolicyIn), destIP(destIPIn),
         verifyCert(verifyCertIn)
     {
         BMCWEB_LOG_DEBUG("Initializing connection pool for {}", id);
@@ -866,8 +864,7 @@ class HttpClient
     HttpClient() = delete;
     explicit HttpClient(boost::asio::io_context& iocIn,
                         const std::shared_ptr<ConnectionPolicy>& connPolicyIn) :
-        ioc(iocIn),
-        connPolicy(connPolicyIn)
+        ioc(iocIn), connPolicy(connPolicyIn)
     {}
 
     HttpClient(const HttpClient&) = delete;

--- a/http/http_connection.hpp
+++ b/http/http_connection.hpp
@@ -70,9 +70,8 @@ class Connection :
     Connection(Handler* handlerIn, boost::asio::steady_timer&& timerIn,
                std::function<std::string()>& getCachedDateStrF,
                Adaptor adaptorIn) :
-        adaptor(std::move(adaptorIn)),
-        handler(handlerIn), timer(std::move(timerIn)),
-        getCachedDateStr(getCachedDateStrF)
+        adaptor(std::move(adaptorIn)), handler(handlerIn),
+        timer(std::move(timerIn)), getCachedDateStr(getCachedDateStrF)
     {
         initParser();
 

--- a/http/http_server.hpp
+++ b/http/http_server.hpp
@@ -32,8 +32,7 @@ class Server
     Server(Handler* handlerIn, boost::asio::ip::tcp::acceptor&& acceptorIn,
            std::shared_ptr<boost::asio::ssl::context> adaptorCtxIn,
            std::shared_ptr<boost::asio::io_context> io) :
-        ioService(std::move(io)),
-        acceptor(std::move(acceptorIn)),
+        ioService(std::move(io)), acceptor(std::move(acceptorIn)),
         signals(*ioService, SIGINT, SIGTERM, SIGHUP), handler(handlerIn),
         adaptorCtx(std::move(adaptorCtxIn))
     {

--- a/http/http_stream.hpp
+++ b/http/http_stream.hpp
@@ -54,9 +54,8 @@ class ConnectionImpl : public Connection
                    std::function<void(Connection&, bool&)> closeHandlerIn,
                    std::function<void(Connection&)> errorHandlerIn) :
 
-        Connection(reqIn),
-        adaptor(std::move(adaptorIn)), waitTimer(*reqIn.ioService),
-        openHandler(std::move(openHandlerIn)),
+        Connection(reqIn), adaptor(std::move(adaptorIn)),
+        waitTimer(*reqIn.ioService), openHandler(std::move(openHandlerIn)),
         messageHandler(std::move(messageHandlerIn)),
         closeHandler(std::move(closeHandlerIn)),
         errorHandler(std::move(errorHandlerIn))

--- a/http/logging.hpp
+++ b/http/logging.hpp
@@ -173,21 +173,21 @@ struct BMCWEB_LOG_DEBUG
 };
 
 template <typename... Args>
-BMCWEB_LOG_CRITICAL(std::format_string<Args...>, Args&&...)
-    -> BMCWEB_LOG_CRITICAL<Args...>;
+BMCWEB_LOG_CRITICAL(std::format_string<Args...>,
+                    Args&&...) -> BMCWEB_LOG_CRITICAL<Args...>;
 
 template <typename... Args>
-BMCWEB_LOG_ERROR(std::format_string<Args...>, Args&&...)
-    -> BMCWEB_LOG_ERROR<Args...>;
+BMCWEB_LOG_ERROR(std::format_string<Args...>,
+                 Args&&...) -> BMCWEB_LOG_ERROR<Args...>;
 
 template <typename... Args>
-BMCWEB_LOG_WARNING(std::format_string<Args...>, Args&&...)
-    -> BMCWEB_LOG_WARNING<Args...>;
+BMCWEB_LOG_WARNING(std::format_string<Args...>,
+                   Args&&...) -> BMCWEB_LOG_WARNING<Args...>;
 
 template <typename... Args>
-BMCWEB_LOG_INFO(std::format_string<Args...>, Args&&...)
-    -> BMCWEB_LOG_INFO<Args...>;
+BMCWEB_LOG_INFO(std::format_string<Args...>,
+                Args&&...) -> BMCWEB_LOG_INFO<Args...>;
 
 template <typename... Args>
-BMCWEB_LOG_DEBUG(std::format_string<Args...>, Args&&...)
-    -> BMCWEB_LOG_DEBUG<Args...>;
+BMCWEB_LOG_DEBUG(std::format_string<Args...>,
+                 Args&&...) -> BMCWEB_LOG_DEBUG<Args...>;

--- a/http/websocket.hpp
+++ b/http/websocket.hpp
@@ -64,8 +64,7 @@ class ConnectionImpl : public Connection
             messageExHandlerIn,
         std::function<void(Connection&, const std::string&)> closeHandlerIn,
         std::function<void(Connection&)> errorHandlerIn) :
-        uri(urlViewIn),
-        ws(std::move(adaptorIn)), inBuffer(inString, 131088),
+        uri(urlViewIn), ws(std::move(adaptorIn)), inBuffer(inString, 131088),
         openHandler(std::move(openHandlerIn)),
         messageHandler(std::move(messageHandlerIn)),
         messageExHandler(std::move(messageExHandlerIn)),

--- a/include/dump_offload.hpp
+++ b/include/dump_offload.hpp
@@ -45,9 +45,8 @@ class Handler : public std::enable_shared_from_this<Handler>
     Handler(boost::asio::io_context& ios, const std::string& entryIDIn,
             const std::string& dumpTypeIn,
             const std::string& unixSocketPathIn) :
-        entryID(entryIDIn),
-        dumpType(dumpTypeIn), unixSocketPath(unixSocketPathIn), unixSocket(ios),
-        waitTimer(ios)
+        entryID(entryIDIn), dumpType(dumpTypeIn),
+        unixSocketPath(unixSocketPathIn), unixSocket(ios), waitTimer(ios)
     {}
 
     /**

--- a/include/hostname_monitor.hpp
+++ b/include/hostname_monitor.hpp
@@ -33,8 +33,7 @@ inline void installCertificate(const std::filesystem::path& certPath)
         {
             BMCWEB_LOG_ERROR("Failed to remove certificate");
         }
-    },
-        "xyz.openbmc_project.Certs.Manager.Server.Https",
+    }, "xyz.openbmc_project.Certs.Manager.Server.Https",
         "/xyz/openbmc_project/certs/server/https/1",
         "xyz.openbmc_project.Certs.Replace", "Replace", certPath.string());
 }

--- a/include/obmc_console.hpp
+++ b/include/obmc_console.hpp
@@ -27,8 +27,7 @@ class ConsoleHandler : public std::enable_shared_from_this<ConsoleHandler>
   public:
     ConsoleHandler(boost::asio::io_context& ioc,
                    crow::websocket::Connection& connIn) :
-        hostSocket(ioc),
-        conn(connIn)
+        hostSocket(ioc), conn(connIn)
     {}
 
     ~ConsoleHandler() = default;

--- a/include/openbmc_dbus_rest.hpp
+++ b/include/openbmc_dbus_rest.hpp
@@ -211,8 +211,7 @@ inline void getPropertiesForEnumerate(
         for (const auto& [name, value] : propertiesList)
         {
             nlohmann::json& propertyJson = objectJson[name];
-            std::visit(
-                [&propertyJson](auto&& val) {
+            std::visit([&propertyJson](auto&& val) {
                 if constexpr (std::is_same_v<std::decay_t<decltype(val)>,
                                              sdbusplus::message::unix_fd>)
                 {
@@ -222,8 +221,7 @@ inline void getPropertiesForEnumerate(
                 {
                     propertyJson = val;
                 }
-            },
-                value);
+            }, value);
         }
     });
 }
@@ -267,8 +265,7 @@ struct InProgressEnumerateData
     InProgressEnumerateData(
         const std::string& objectPathIn,
         const std::shared_ptr<bmcweb::AsyncResp>& asyncRespIn) :
-        objectPath(objectPathIn),
-        asyncResp(asyncRespIn)
+        objectPath(objectPathIn), asyncResp(asyncRespIn)
     {}
 
     ~InProgressEnumerateData()
@@ -334,8 +331,7 @@ inline void getManagedObjectsForEnumerate(
                     {
                         nlohmann::json& propertyJson =
                             objectJson[property.first];
-                        std::visit(
-                            [&propertyJson](auto&& val) {
+                        std::visit([&propertyJson](auto&& val) {
                             if constexpr (std::is_same_v<
                                               std::decay_t<decltype(val)>,
                                               sdbusplus::message::unix_fd>)
@@ -346,8 +342,7 @@ inline void getManagedObjectsForEnumerate(
                             {
                                 propertyJson = val;
                             }
-                        },
-                            property.second);
+                        }, property.second);
                     }
                 }
             }
@@ -478,8 +473,7 @@ inline void getObjectAndEnumerate(
 struct InProgressActionData
 {
     explicit InProgressActionData(
-        const std::shared_ptr<bmcweb::AsyncResp>& res) :
-        asyncResp(res)
+        const std::shared_ptr<bmcweb::AsyncResp>& res) : asyncResp(res)
     {}
     ~InProgressActionData()
     {

--- a/include/vm_websocket.hpp
+++ b/include/vm_websocket.hpp
@@ -187,8 +187,7 @@ struct NbdProxyServer : std::enable_shared_from_this<NbdProxyServer>
     NbdProxyServer(crow::websocket::Connection& connIn,
                    const std::string& socketIdIn,
                    const std::string& endpointIdIn, const std::string& pathIn) :
-        socketId(socketIdIn),
-        endpointId(endpointIdIn), path(pathIn),
+        socketId(socketIdIn), endpointId(endpointIdIn), path(pathIn),
 
         peerSocket(connIn.getIoContext()),
         acceptor(connIn.getIoContext(), stream_protocol::endpoint(socketId)),

--- a/redfish-core/include/snmp_trap_event_clients.hpp
+++ b/redfish-core/include/snmp_trap_event_clients.hpp
@@ -236,8 +236,7 @@ inline void
             return;
         }
         messages::success(asyncResp->res);
-    },
-        "xyz.openbmc_project.Network.SNMP", static_cast<std::string>(snmpPath),
+    }, "xyz.openbmc_project.Network.SNMP", static_cast<std::string>(snmpPath),
         "xyz.openbmc_project.Object.Delete", "Delete");
 }
 

--- a/redfish-core/include/utils/json_utils.hpp
+++ b/redfish-core/include/utils/json_utils.hpp
@@ -209,8 +209,8 @@ UnpackErrorCode unpackValueWithErrorCode(nlohmann::json& jsonValue,
         value = static_cast<Type>(*jsonPtr);
     }
 
-    else if constexpr ((std::is_unsigned_v<Type>)&&(
-                           !std::is_same_v<bool, Type>))
+    else if constexpr ((std::is_unsigned_v<Type>) &&
+                       (!std::is_same_v<bool, Type>))
     {
         uint64_t* jsonPtr = jsonValue.get_ptr<uint64_t*>();
         if (jsonPtr == nullptr)
@@ -545,8 +545,7 @@ inline bool readJsonHelperObject(nlohmann::json::object_t& obj,
                     std::remove_pointer_t<std::decay_t<decltype(val)>>;
                 return details::unpackValue<ContainedT>(
                     item.second, unpackSpec.key, res, *val);
-            },
-                         unpackSpec.value) &&
+            }, unpackSpec.value) &&
                      result;
 
             unpackSpec.complete = true;
@@ -564,13 +563,11 @@ inline bool readJsonHelperObject(nlohmann::json::object_t& obj,
     {
         if (!perUnpack.complete)
         {
-            bool isOptional = std::visit(
-                [](auto&& val) {
+            bool isOptional = std::visit([](auto&& val) {
                 using ContainedType =
                     std::remove_pointer_t<std::decay_t<decltype(val)>>;
                 return details::IsOptional<ContainedType>::value;
-            },
-                perUnpack.value);
+            }, perUnpack.value);
             if (isOptional)
             {
                 continue;

--- a/redfish-core/include/utils/query_param.hpp
+++ b/redfish-core/include/utils/query_param.hpp
@@ -847,8 +847,7 @@ class MultiAsyncResp : public std::enable_shared_from_this<MultiAsyncResp>
     // class manages the final "merge" of the json resources.
     MultiAsyncResp(crow::App& appIn,
                    std::shared_ptr<bmcweb::AsyncResp> finalResIn) :
-        app(appIn),
-        finalRes(std::move(finalResIn))
+        app(appIn), finalRes(std::move(finalResIn))
     {}
 
     void addAwaitingResponse(

--- a/redfish-core/lib/account_service.hpp
+++ b/redfish-core/lib/account_service.hpp
@@ -1866,8 +1866,7 @@ inline void processAfterCreateUser(
             // If password is invalid
             messages::propertyValueFormatError(asyncResp->res, nullptr,
                                                "Password");
-        },
-            "xyz.openbmc_project.User.Manager", userPath,
+        }, "xyz.openbmc_project.User.Manager", userPath,
             "xyz.openbmc_project.Object.Delete", "Delete");
 
         BMCWEB_LOG_ERROR("pamUpdatePassword Failed");
@@ -2295,8 +2294,7 @@ inline void
         }
 
         messages::accountRemoved(asyncResp->res);
-    },
-        "xyz.openbmc_project.User.Manager", userPath,
+    }, "xyz.openbmc_project.User.Manager", userPath,
         "xyz.openbmc_project.Object.Delete", "Delete");
 }
 

--- a/redfish-core/lib/assembly.hpp
+++ b/redfish-core/lib/assembly.hpp
@@ -498,8 +498,7 @@ inline void
             return;
         }
         messages::success(asyncResp->res);
-    },
-        "org.freedesktop.systemd1", "/org/freedesktop/systemd1",
+    }, "org.freedesktop.systemd1", "/org/freedesktop/systemd1",
         "org.freedesktop.systemd1.Manager", method,
         "xyz.openbmc_project.adcsensor.service", "replace");
 }
@@ -741,8 +740,7 @@ inline void setAssemblyLocationIndicators(
                         messages::internalError(asyncResp->res);
                         return;
                     }
-                },
-                    "com.ibm.VPD.Manager", "/com/ibm/VPD/Manager",
+                }, "com.ibm.VPD.Manager", "/com/ibm/VPD/Manager",
                     "com.ibm.VPD.Manager", action,
                     sdbusplus::message::object_path(assembly));
             }

--- a/redfish-core/lib/bios.hpp
+++ b/redfish-core/lib/bios.hpp
@@ -901,8 +901,7 @@ inline void
             messages::internalError(asyncResp->res);
             return;
         }
-    },
-        "org.open_power.Software.Host.Updater", "/xyz/openbmc_project/software",
+    }, "org.open_power.Software.Host.Updater", "/xyz/openbmc_project/software",
         "xyz.openbmc_project.Common.FactoryReset", "Reset");
 }
 

--- a/redfish-core/lib/certificate_service.hpp
+++ b/redfish-core/lib/certificate_service.hpp
@@ -835,8 +835,7 @@ inline void
             messages::internalError(asyncResp->res);
             return;
         }
-    },
-        service, objectPath, "xyz.openbmc_project.Certs.CSR.Create",
+    }, service, objectPath, "xyz.openbmc_project.Certs.CSR.Create",
         "GenerateCSR", *optAlternativeNames, *optChallengePassword, city,
         commonName, *optContactPerson, country, *optEmail, *optGivenName,
         *optInitials, *optKeyBitLength, *optKeyCurveId, *optKeyPairAlgorithm,

--- a/redfish-core/lib/ethernet.hpp
+++ b/redfish-core/lib/ethernet.hpp
@@ -701,8 +701,7 @@ inline void deleteIPAddress(const std::string& ifaceId,
         {
             messages::internalError(asyncResp->res);
         }
-    },
-        "xyz.openbmc_project.Network",
+    }, "xyz.openbmc_project.Network",
         "/xyz/openbmc_project/network/" + ifaceId + ipHash,
         "xyz.openbmc_project.Object.Delete", "Delete");
 }
@@ -791,8 +790,7 @@ inline void deleteAndCreateIPAddress(
             {
                 messages::internalError(asyncResp->res);
             }
-        },
-            "xyz.openbmc_project.Network",
+        }, "xyz.openbmc_project.Network",
             "/xyz/openbmc_project/network/" + ifaceId,
             "xyz.openbmc_project.Network.IP.Create", "IP", protocol, address,
             prefixLength, gateway);
@@ -904,9 +902,8 @@ inline void
         {
             messages::internalError(asyncResp->res);
         }
-    },
-        "xyz.openbmc_project.Network", path,
-        "xyz.openbmc_project.Object.Delete", "Delete");
+    }, "xyz.openbmc_project.Network", path, "xyz.openbmc_project.Object.Delete",
+        "Delete");
 }
 
 /**

--- a/redfish-core/lib/health.hpp
+++ b/redfish-core/lib/health.hpp
@@ -35,8 +35,7 @@ struct HealthPopulate : std::enable_shared_from_this<HealthPopulate>
     // By default populate status to "/Status" of |asyncResp->res.jsonValue|.
     explicit HealthPopulate(
         const std::shared_ptr<bmcweb::AsyncResp>& asyncRespIn) :
-        asyncResp(asyncRespIn),
-        statusPtr("/Status")
+        asyncResp(asyncRespIn), statusPtr("/Status")
     {}
 
     // Takes a JSON pointer rather than a reference. This is pretty useful when
@@ -44,8 +43,7 @@ struct HealthPopulate : std::enable_shared_from_this<HealthPopulate>
     // array.
     HealthPopulate(const std::shared_ptr<bmcweb::AsyncResp>& asyncRespIn,
                    const nlohmann::json::json_pointer& ptr) :
-        asyncResp(asyncRespIn),
-        statusPtr(ptr)
+        asyncResp(asyncRespIn), statusPtr(ptr)
     {}
 
     HealthPopulate(const HealthPopulate&) = delete;

--- a/redfish-core/lib/hypervisor_system.hpp
+++ b/redfish-core/lib/hypervisor_system.hpp
@@ -499,8 +499,7 @@ inline void
         redfish::EventServiceManager::getInstance().sendEvent(
             redfish::messages::resourceChanged(), eventOrigin,
             "EthernetInterface");
-    },
-        "xyz.openbmc_project.Network.Hypervisor",
+    }, "xyz.openbmc_project.Network.Hypervisor",
         std::format("/xyz/openbmc_project/network/hypervisor/{}/{}/addr0",
                     ifaceId, protocol),
         "xyz.openbmc_project.Object.Delete", "Delete");
@@ -806,8 +805,7 @@ inline void
 
             return;
         }
-    },
-        "xyz.openbmc_project.Network.Hypervisor",
+    }, "xyz.openbmc_project.Network.Hypervisor",
         "/xyz/openbmc_project/network/hypervisor/" + ifaceId,
         "xyz.openbmc_project.Network.IP.Create", "IP", protocol, address,
         prefixLength, gateway);

--- a/redfish-core/lib/license_service.hpp
+++ b/redfish-core/lib/license_service.hpp
@@ -232,8 +232,7 @@ static void resetLicenseActivationStatus(
             return;
         }
         getLicenseActivationStatusMatch() = nullptr;
-    },
-        "com.ibm.License.Manager", "/com/ibm/license",
+    }, "com.ibm.License.Manager", "/com/ibm/license",
         "org.freedesktop.DBus.Properties", "Set",
         "com.ibm.License.LicenseManager", "LicenseActivationStatus",
         std::variant<std::string>(value));
@@ -254,8 +253,7 @@ static void
             return;
         }
         resetLicenseActivationStatus(asyncResp);
-    },
-        "com.ibm.License.Manager", "/com/ibm/license",
+    }, "com.ibm.License.Manager", "/com/ibm/license",
         "org.freedesktop.DBus.Properties", "Set",
         "com.ibm.License.LicenseManager", "LicenseString",
         std::variant<std::string>(value));

--- a/redfish-core/lib/log_services.hpp
+++ b/redfish-core/lib/log_services.hpp
@@ -1474,8 +1474,7 @@ inline void clearDump(const std::shared_ptr<bmcweb::AsyncResp>& asyncResp,
             messages::internalError(asyncResp->res);
             return;
         }
-    },
-        "xyz.openbmc_project.Dump.Manager", getDumpPath(dumpType),
+    }, "xyz.openbmc_project.Dump.Manager", getDumpPath(dumpType),
         "xyz.openbmc_project.Collection.DeleteAll", "DeleteAll");
 }
 
@@ -1788,8 +1787,7 @@ inline void requestRoutesJournalEventLogClear(App& app)
             }
 
             messages::success(asyncResp->res);
-        },
-            "org.freedesktop.systemd1", "/org/freedesktop/systemd1",
+        }, "org.freedesktop.systemd1", "/org/freedesktop/systemd1",
             "org.freedesktop.systemd1.Manager", "ReloadUnit", "rsyslog.service",
             "replace");
     });
@@ -5250,8 +5248,7 @@ inline void requestRoutesPostCodesClear(App& app)
                 return;
             }
             messages::success(asyncResp->res);
-        },
-            "xyz.openbmc_project.State.Boot.PostCode0",
+        }, "xyz.openbmc_project.State.Boot.PostCode0",
             "/xyz/openbmc_project/State/Boot/PostCode0",
             "xyz.openbmc_project.Collection.DeleteAll", "DeleteAll");
     });
@@ -7350,8 +7347,7 @@ inline void postSystemHardwareIsolationLogServiceClearLog(
                 return;
             }
             messages::success(asyncResp->res);
-        },
-            objType[0].first, "/xyz/openbmc_project/hardware_isolation",
+        }, objType[0].first, "/xyz/openbmc_project/hardware_isolation",
             "xyz.openbmc_project.Collection.DeleteAll", "DeleteAll");
     },
         "xyz.openbmc_project.ObjectMapper",

--- a/redfish-core/lib/managers.hpp
+++ b/redfish-core/lib/managers.hpp
@@ -293,8 +293,7 @@ inline void requestRoutesManagerResetToDefaultsAction(App& app)
             // Factory Reset doesn't actually happen until a reboot
             // Can't erase what the BMC is running on
             doBMCGracefulRestart(asyncResp);
-        },
-            "xyz.openbmc_project.Software.BMC.Updater",
+        }, "xyz.openbmc_project.Software.BMC.Updater",
             "/xyz/openbmc_project/software",
             "xyz.openbmc_project.Common.FactoryReset", "Reset");
     });
@@ -897,8 +896,7 @@ inline CreatePIDRet createPidInterface(
                 return;
             }
             messages::success(response->res);
-        },
-            "xyz.openbmc_project.EntityManager", path, iface, "Delete");
+        }, "xyz.openbmc_project.EntityManager", path, iface, "Delete");
         return CreatePIDRet::del;
     }
 
@@ -1403,8 +1401,7 @@ struct SetPIDValues : std::enable_shared_from_this<SetPIDValues>
             std::pair<std::string, std::optional<nlohmann::json::object_t>>>&&
             configurationsIn,
         std::optional<std::string>& profileIn) :
-        asyncResp(asyncRespIn),
-        configuration(std::move(configurationsIn)),
+        asyncResp(asyncRespIn), configuration(std::move(configurationsIn)),
         profile(std::move(profileIn))
     {}
 
@@ -1715,8 +1712,7 @@ struct SetPIDValues : std::enable_shared_from_this<SetPIDValues>
                             return;
                         }
                         messages::success(response->res);
-                    },
-                        "xyz.openbmc_project.EntityManager", chassis,
+                    }, "xyz.openbmc_project.EntityManager", chassis,
                         "xyz.openbmc_project.AddObject", "AddObject", output);
                 }
             }

--- a/redfish-core/lib/metric_report.hpp
+++ b/redfish-core/lib/metric_report.hpp
@@ -127,8 +127,7 @@ inline void requestRoutesMetricReport(App& app)
 
                 telemetry::fillReport(asyncResp->res.jsonValue, id, ret);
             });
-        },
-            telemetry::service, reportPath, telemetry::reportInterface,
+        }, telemetry::service, reportPath, telemetry::reportInterface,
             "Update");
     });
 }

--- a/redfish-core/lib/metric_report_definition.hpp
+++ b/redfish-core/lib/metric_report_definition.hpp
@@ -661,8 +661,7 @@ class AddReport
   public:
     AddReport(AddReportArgs&& argsIn,
               const std::shared_ptr<bmcweb::AsyncResp>& asyncRespIn) :
-        asyncResp(asyncRespIn),
-        args(std::move(argsIn))
+        asyncResp(asyncRespIn), args(std::move(argsIn))
     {}
 
     ~AddReport()
@@ -778,8 +777,7 @@ class UpdateMetrics
   public:
     UpdateMetrics(std::string_view idIn,
                   const std::shared_ptr<bmcweb::AsyncResp>& asyncRespIn) :
-        id(idIn),
-        asyncResp(asyncRespIn)
+        id(idIn), asyncResp(asyncRespIn)
     {}
 
     ~UpdateMetrics()
@@ -901,8 +899,7 @@ inline void
         {
             return;
         }
-    },
-        "xyz.openbmc_project.Telemetry", getDbusReportPath(id),
+    }, "xyz.openbmc_project.Telemetry", getDbusReportPath(id),
         "org.freedesktop.DBus.Properties", "Set",
         "xyz.openbmc_project.Telemetry.Report", "Enabled",
         dbus::utility::DbusVariantType{enabled});
@@ -918,8 +915,7 @@ inline void setReportTypeAndInterval(
         {
             return;
         }
-    },
-        "xyz.openbmc_project.Telemetry", getDbusReportPath(id),
+    }, "xyz.openbmc_project.Telemetry", getDbusReportPath(id),
         "xyz.openbmc_project.Telemetry.Report", "SetReportingProperties",
         reportingType, recurrenceInterval);
 }
@@ -934,8 +930,7 @@ inline void
         {
             return;
         }
-    },
-        "xyz.openbmc_project.Telemetry", getDbusReportPath(id),
+    }, "xyz.openbmc_project.Telemetry", getDbusReportPath(id),
         "org.freedesktop.DBus.Properties", "Set",
         "xyz.openbmc_project.Telemetry.Report", "ReportUpdates",
         dbus::utility::DbusVariantType{reportUpdates});
@@ -952,8 +947,7 @@ inline void
         {
             return;
         }
-    },
-        "xyz.openbmc_project.Telemetry", getDbusReportPath(id),
+    }, "xyz.openbmc_project.Telemetry", getDbusReportPath(id),
         "org.freedesktop.DBus.Properties", "Set",
         "xyz.openbmc_project.Telemetry.Report", "ReportActions",
         dbus::utility::DbusVariantType{dbusReportActions});
@@ -1347,8 +1341,7 @@ inline void handleMetricReportDelete(
         }
 
         asyncResp->res.result(boost::beast::http::status::no_content);
-    },
-        telemetry::service, reportPath, "xyz.openbmc_project.Object.Delete",
+    }, telemetry::service, reportPath, "xyz.openbmc_project.Object.Delete",
         "Delete");
 }
 

--- a/redfish-core/lib/oem/ibm/lamp_test.hpp
+++ b/redfish-core/lib/oem/ibm/lamp_test.hpp
@@ -115,8 +115,7 @@ inline void
                     messages::internalError(asyncResp->res);
                     return;
                 }
-            },
-                "com.ibm.PanelApp", "/com/ibm/panel_app", "com.ibm.panel",
+            }, "com.ibm.PanelApp", "/com/ibm/panel_app", "com.ibm.panel",
                 "TriggerPanelLampTest", state);
         });
     });

--- a/redfish-core/lib/sensors.hpp
+++ b/redfish-core/lib/sensors.hpp
@@ -215,9 +215,8 @@ class SensorsAsyncResp
                      const std::string& chassisIdIn,
                      std::span<const std::string_view> typesIn,
                      std::string_view subNode) :
-        asyncResp(asyncRespIn),
-        chassisId(chassisIdIn), types(typesIn), chassisSubNode(subNode),
-        efficientExpand(false)
+        asyncResp(asyncRespIn), chassisId(chassisIdIn), types(typesIn),
+        chassisSubNode(subNode), efficientExpand(false)
     {}
 
     // Store extra data about sensor mapping and return it in callback
@@ -226,9 +225,9 @@ class SensorsAsyncResp
                      std::span<const std::string_view> typesIn,
                      std::string_view subNode,
                      DataCompleteCb&& creationComplete) :
-        asyncResp(asyncRespIn),
-        chassisId(chassisIdIn), types(typesIn), chassisSubNode(subNode),
-        efficientExpand(false), metadata{std::vector<SensorData>()},
+        asyncResp(asyncRespIn), chassisId(chassisIdIn), types(typesIn),
+        chassisSubNode(subNode), efficientExpand(false),
+        metadata{std::vector<SensorData>()},
         dataComplete{std::move(creationComplete)}
     {}
 
@@ -237,9 +236,8 @@ class SensorsAsyncResp
                      const std::string& chassisIdIn,
                      std::span<const std::string_view> typesIn,
                      const std::string_view& subNode, bool efficientExpandIn) :
-        asyncResp(asyncRespIn),
-        chassisId(chassisIdIn), types(typesIn), chassisSubNode(subNode),
-        efficientExpand(efficientExpandIn)
+        asyncResp(asyncRespIn), chassisId(chassisIdIn), types(typesIn),
+        chassisSubNode(subNode), efficientExpand(efficientExpandIn)
     {}
 
     ~SensorsAsyncResp()

--- a/redfish-core/lib/storage.hpp
+++ b/redfish-core/lib/storage.hpp
@@ -798,7 +798,7 @@ inline void afterChassisDriveCollectionSubtreeGet(
             asyncResp->res.jsonValue["Members@odata.count"] = resp.size();
         }); // end association lambda
 
-    }       // end Iterate over all retrieved ObjectPaths
+    } // end Iterate over all retrieved ObjectPaths
 }
 /**
  * Chassis drives, this URL will show all the DriveCollection

--- a/redfish-core/lib/systems.hpp
+++ b/redfish-core/lib/systems.hpp
@@ -2566,8 +2566,7 @@ inline void doNMI(const std::shared_ptr<bmcweb::AsyncResp>& asyncResp)
             return;
         }
         messages::success(asyncResp->res);
-    },
-        serviceName, objectPath, interfaceName, method);
+    }, serviceName, objectPath, interfaceName, method);
 }
 
 inline void handleComputerSystemResetActionPost(

--- a/redfish-core/lib/task.hpp
+++ b/redfish-core/lib/task.hpp
@@ -95,8 +95,7 @@ struct TaskData : std::enable_shared_from_this<TaskData>
         std::function<bool(boost::system::error_code, sdbusplus::message_t&,
                            const std::shared_ptr<TaskData>&)>&& handler,
         const std::string& matchIn, size_t idx) :
-        callback(std::move(handler)),
-        matchStr(matchIn), index(idx),
+        callback(std::move(handler)), matchStr(matchIn), index(idx),
         startTime(std::chrono::system_clock::to_time_t(
             std::chrono::system_clock::now())),
         status("OK"), state("Starting"), messages(nlohmann::json::array()),

--- a/redfish-core/lib/trigger.hpp
+++ b/redfish-core/lib/trigger.hpp
@@ -1050,9 +1050,8 @@ inline void requestRoutesTrigger(App& app)
             }
 
             asyncResp->res.result(boost::beast::http::status::no_content);
-        },
-            telemetry::service, triggerPath,
-            "xyz.openbmc_project.Object.Delete", "Delete");
+        }, telemetry::service, triggerPath, "xyz.openbmc_project.Object.Delete",
+            "Delete");
     });
 }
 

--- a/redfish-core/lib/update_service.hpp
+++ b/redfish-core/lib/update_service.hpp
@@ -687,8 +687,7 @@ inline void requestRoutesUpdateServiceActionsSimpleUpdate(App& app)
             {
                 BMCWEB_LOG_DEBUG("Call to DownloaViaTFTP Success");
             }
-        },
-            "xyz.openbmc_project.Software.Download",
+        }, "xyz.openbmc_project.Software.Download",
             "/xyz/openbmc_project/software", "xyz.openbmc_project.Common.TFTP",
             "DownloadViaTFTP", ret->fwFile, ret->tftpServer);
 

--- a/redfish-core/lib/virtual_media.hpp
+++ b/redfish-core/lib/virtual_media.hpp
@@ -669,8 +669,7 @@ inline void doEjectAction(const std::shared_ptr<bmcweb::AsyncResp>& asyncResp,
                 messages::internalError(asyncResp->res);
                 return;
             }
-        },
-            service, "/xyz/openbmc_project/VirtualMedia/Legacy/" + name,
+        }, service, "/xyz/openbmc_project/VirtualMedia/Legacy/" + name,
             "xyz.openbmc_project.VirtualMedia.Legacy", "Unmount");
     }
     else // proxy
@@ -684,8 +683,7 @@ inline void doEjectAction(const std::shared_ptr<bmcweb::AsyncResp>& asyncResp,
                 messages::internalError(asyncResp->res);
                 return;
             }
-        },
-            service, "/xyz/openbmc_project/VirtualMedia/Proxy/" + name,
+        }, service, "/xyz/openbmc_project/VirtualMedia/Proxy/" + name,
             "xyz.openbmc_project.VirtualMedia.Proxy", "Unmount");
     }
 }


### PR DESCRIPTION
The new clang-format-18 is being enforced. Make CI happy. 
```
find include/ -iname *.hpp -o -iname *.cpp | xargs clang-format-18 -i
find http/ -iname *.hpp -o -iname *.cpp | xargs clang-format-18 -i
find redfish-core/ -iname *.hpp -o -iname *.cpp | xargs clang-format-18 -i
```