### PR TITLE
hypervisor: Change origin to DHCPv6 from DHCP

### DIFF
--- a/redfish-core/lib/hypervisor_system.hpp
+++ b/redfish-core/lib/hypervisor_system.hpp
@@ -352,7 +352,7 @@ inline bool extractHypervisorInterfaceData(
                             }
                             else
                             {
-                                ipv6Address.origin = "DHCP";
+                                ipv6Address.origin = "DHCPv6";
                             }
                         }
                         else if (property.first == "DefaultGateway6")


### PR DESCRIPTION
This commit changes the AddressOrigin property of "IPv6Addresses" from DHCP to DHCPv6 in the redfish response. This will also fix the validator failure as "DHCP" is not one of the enum values for AddressOrigin in the redfish schema.

Fixes: https://jazz07.rchland.ibm.com:13443/jazz/web/projects/CSSD#action=com.ibm.team.workitem.viewWorkItem&id=645188

Tested By:
[1] PATCH -d '{"DHCPv6":{"OperatingMode": "Enabled"}}' https://${bmc}/redfish/v1/Systems/hypervisor/EthernetInterfaces/eth1
    Verified that the response contains "AddressOrigin": "DHCPv6"