### PR TITLE
Fix RemoteRoleMap PATCH operation

### DIFF
--- a/redfish-core/lib/account_service.hpp
+++ b/redfish-core/lib/account_service.hpp
@@ -445,12 +445,21 @@ inline void handleRoleMapPatch(
                 // If "LocalRole" info is provided
                 if (localRole)
                 {
+                    std::string priv = getPrivilegeFromRoleId(*localRole);
+                    if (priv.empty())
+                    {
+                        messages::propertyValueNotInList(
+                            asyncResp->res, *localRole,
+                            std::format("RemoteRoleMapping/{}/LocalRole",
+                                        index));
+                        return;
+                    }
                     setDbusProperty(
                         asyncResp, ldapDbusService, roleMapObjData[index].first,
                         "xyz.openbmc_project.User.PrivilegeMapperEntry",
                         "Privilege",
                         std::format("RemoteRoleMapping/{}/LocalRole", index),
-                        *localRole);
+                        priv);
                 }
             }
             // Create a new RoleMapping Object.


### PR DESCRIPTION
RemoteRoleMap "LocalRole" property update fails since there was conversion missing from redfish privilege to D-bus values

Looks like this commit dropped this change
https://gerrit.openbmc.org/c/openbmc/bmcweb/+/64325/

This commit fixes this issue

Tested by:
Verified patch operation on RemoteRoleMap

Change-Id: Ic05aa3457a45e98ea5dc8e9dd83e0f1a42772070