### PR TITLE
1110: Fix 404 status from JsonSchemas FileGet

### DIFF
--- a/redfish-core/lib/redfish_v1.hpp
+++ b/redfish-core/lib/redfish_v1.hpp
@@ -211,8 +211,6 @@ inline void
             boost::beast::http::status::internal_server_error);
         return;
     }
-
-    messages::resourceNotFound(asyncResp->res, "JsonSchemaFile", schema);
 }
 
 inline void requestRoutesRedfish(App& app)


### PR DESCRIPTION
This will fix the 404 error from JsonSchema FileGet

```
% redfishtool raw GET  -r ${bmc}  -u root -p 0penBmc -S Always \ 
   /redfish/v1/JsonSchemas/ComputerSystem/ComputerSystem.v1_22_2.json
   redfishtool: Transport: Response Error: status_code: 404 -- Not Found
   redfishtool: raw: Error getting response
```

Tested:
- Get `/redfish/v1/JsonSchemas/<schema>/<schema>` and use its
`Location/Uri` for the next redfishtool
- Verify redfishtool result like
```
redfishtool raw GET  -r ${bmc}  -u root -p 0penBmc -S Always /redfish/v1/JsonSchemas/<schema>/<schema>.<version>.json
```
- Redfish Service validator passes

Change-Id: I0ca443177537d0a73a31a7195deb3cfb028c49b5