### PR TITLE
1110: Fix status for non-existent JsonSchema FileGet

### DIFF
--- a/include/openbmc_dbus_rest.hpp
+++ b/include/openbmc_dbus_rest.hpp
@@ -2564,7 +2564,7 @@ inline void requestRoutes(App& app)
 
         for (const auto& file : files)
         {
-            if (!asyncResp->res.openFile(file))
+            if (asyncResp->res.openFile(file) != crow::OpenCode::Success)
             {
                 continue;
             }

--- a/include/webassets.hpp
+++ b/include/webassets.hpp
@@ -101,7 +101,7 @@ inline void
         }
     }
 
-    if (!asyncResp->res.openFile(file.absolutePath))
+    if (asyncResp->res.openFile(file.absolutePath) != crow::OpenCode::Success)
     {
         BMCWEB_LOG_DEBUG("failed to read file");
         asyncResp->res.result(

--- a/redfish-core/lib/log_services.hpp
+++ b/redfish-core/lib/log_services.hpp
@@ -4861,7 +4861,8 @@ inline void requestRoutesCrashdumpFile(App& app)
                 return;
             }
 
-            if (!asyncResp->res.openFile(dbusFilepath))
+            if (asyncResp->res.openFile(dbusFilepath) !=
+                crow::OpenCode::Success)
             {
                 messages::resourceNotFound(asyncResp->res, "LogEntry", logID);
                 return;

--- a/redfish-core/lib/redfish_v1.hpp
+++ b/redfish-core/lib/redfish_v1.hpp
@@ -204,11 +204,16 @@ inline void
         return;
     }
 
-    if (!asyncResp->res.openFile(filepath))
+    crow::OpenCode ec = asyncResp->res.openFile(filepath);
+    if (ec == crow::OpenCode::FileDoesNotExist)
+    {
+        messages::resourceNotFound(asyncResp->res, "JsonSchemaFile", schema);
+        return;
+    }
+    if (ec == crow::OpenCode::InternalError)
     {
         BMCWEB_LOG_DEBUG("failed to read file");
-        asyncResp->res.result(
-            boost::beast::http::status::internal_server_error);
+        messages::internalError(asyncResp->res);
         return;
     }
 }


### PR DESCRIPTION
This will fix the incorrect status 500 to status 404 for the non-eixstent JsonSchema FileGet.

```
% redfishtool raw GET  -r ${bmc}  -u root -p 0penBmc -S Always /redfish/v1/JsonSchemas/ComputerSystem/ComputerSystem.v1_99_1.json
   redfishtool: Transport: Response Error: status_code: 500 -- Internal Server Error
   redfishtool: raw: Error getting response
```

This commit also refactor `Response::openFile()` to return `ec` so that the caller can check the reason of the failure.

Tested:
- Verify redfishtool result for the non-existent JsonSchema file like
```
% redfishtool raw GET  -r ${bmc}  -u root -p 0penBmc -S Always /redfish/v1/JsonSchemas/<schema>/<non-existent-schema>.json
   redfishtool: Transport: Response Error: status_code: 404 -- Not Found
   redfishtool: raw: Error getting response
```
- Redfish Service validator passes

Change-Id: I98927c076bb6e7dfb3742183b4b3545e328d2657