### PR TITLE
Make everything 0.6. for the OpenBMC message registry

### DIFF
--- a/redfish-core/include/registries/openbmc.json
+++ b/redfish-core/include/registries/openbmc.json
@@ -2,7 +2,7 @@
     "@Redfish.Copyright": "Copyright 2024 OpenBMC. All rights reserved.",
     "@odata.type": "#MessageRegistry.v1_4_0.MessageRegistry",
     "Description": "This registry defines the base messages for OpenBMC.",
-    "Id": "OpenBMC.0.5.0",
+    "Id": "OpenBMC.0.6.0",
     "Language": "en",
     "Messages": {
         "ADDDCCorrectable": {

--- a/redfish-core/include/registries/openbmc_message_registry.hpp
+++ b/redfish-core/include/registries/openbmc_message_registry.hpp
@@ -20,7 +20,7 @@ namespace redfish::registries::openbmc
 const Header header = {
     "Copyright 2024 OpenBMC. All rights reserved.",
     "#MessageRegistry.v1_4_0.MessageRegistry",
-    "OpenBMC.0.5.0",
+    "OpenBMC.0.6.0",
     "OpenBMC Message Registry",
     "en",
     "This registry defines the base messages for OpenBMC.",


### PR DESCRIPTION
https://github.com/ibm-openbmc/bmcweb/commit/a09d6d12e1c499672c4feb314ecbd5bef3d06840 pushed several things to 0.6. but forgot a few. We will go with 0.6. for 1110.00, even if we add another message. We can control when we release so we don't need to bump for every message like upstream. Upstream is 0.5 so it makes sense we are 1 version above since we added a few messages. 