### PR TITLE
Fixup unauthenticated ACF upload

### DIFF
--- a/redfish-core/lib/account_service.hpp
+++ b/redfish-core/lib/account_service.hpp
@@ -2326,12 +2326,6 @@ inline void
     std::optional<std::vector<std::string>> accountTypes;
     std::optional<nlohmann::json> oem;
 
-    if (req.session == nullptr)
-    {
-        messages::internalError(asyncResp->res);
-        return;
-    }
-
     if (!json_util::readJsonPatch(req, asyncResp->res, "UserName", newUserName,
                                   "Password", password, "RoleId", roleId,
                                   "Enabled", enabled, "Locked", locked, "Oem",


### PR DESCRIPTION
The IBM patch to allow ACF uploads by unauthenticated users in some cases https://github.com/ibm-openbmc/bmcweb/commit/bf5f34f394e4119845e14e5a5fa403736ef3fd6a missed an if test, which allowed no such uploads.

Tested: scenarios with these results:
- upload ACF authorized with good ACF - SUCCESS
- upload ACF authorized with bad ACF (bad base64) - took internal error (same as before), should have better message
- upload ACF bad-auth - correctly indicated unauthorized
- upload ACF no auth (unauthorized) - correctly indicated unauthorized
- upload ACF no auth (unauthorized) when allowed by system setting - SUCCESS

Change-Id: I509af6a969fa503c2ce7db93ea3b0de8ab99c7de