### PR TITLE
MFA Support

### DIFF
--- a/Redfish.md
+++ b/Redfish.md
@@ -61,6 +61,7 @@ Fields common to all schemas
 - LDAP
 - MaxPasswordLength
 - MinPasswordLength
+- MultiFactorAuth/GoogleAuthenticator/Enabled
 - Oem/OpenBMC/AuthMethods/BasicAuth
 - Oem/OpenBMC/AuthMethods/Cookie
 - Oem/OpenBMC/AuthMethods/SessionToken
@@ -109,6 +110,7 @@ Fields common to all schemas
 - Links/Role
 - Locked
 - Locked@Redfish.AllowableValues
+- MFABypass/BypassTypes
 - Password
 - PasswordChangeRequired
 - RoleId

--- a/redfish-core/lib/account_service.hpp
+++ b/redfish-core/lib/account_service.hpp
@@ -2782,6 +2782,65 @@ inline void
     });
 }
 
+inline void handleManagerAccountVerifyTotpAction(
+    App& app, const crow::Request& req,
+    const std::shared_ptr<bmcweb::AsyncResp>& asyncResp,
+    const std::string& username)
+{
+    if (!redfish::setUpRedfishRoute(app, req, asyncResp))
+    {
+        return;
+    }
+
+    if constexpr (BMCWEB_INSECURE_DISABLE_AUTH)
+    {
+        // If authentication is disabled, there are no user accounts
+        messages::resourceNotFound(asyncResp->res, "ManagerAccount", username);
+        return;
+    }
+
+    bool userSelf = (req.session != nullptr &&
+                     username == req.session->username);
+    if (!userSelf)
+    {
+        messages::insufficientPrivilege(asyncResp->res);
+        return;
+    }
+
+    std::string totp;
+    if (!json_util::readJsonAction(req, asyncResp->res,
+                                   "TimeBasedOneTimePassword", totp))
+    {
+        messages::actionParameterMissing(
+            asyncResp->res, "ManagerAccount.VerifyTimeBasedOneTimePassword",
+            "TimeBasedOneTimePassword");
+        return;
+    }
+    sdbusplus::message::object_path tempObjPath("/xyz/openbmc_project/user/");
+    tempObjPath /= username;
+    const std::string userPath(tempObjPath);
+    crow::connections::systemBus->async_method_call(
+        [asyncResp, username](const boost::system::error_code& ec,
+                              bool status) {
+        if (ec)
+        {
+            BMCWEB_LOG_ERROR("D-Bus response error: {}", ec.value());
+            messages::internalError(asyncResp->res);
+            return;
+        }
+        if (!status)
+        {
+            messages::actionParameterValueError(
+                asyncResp->res, "ManagerAccount.VerifyTimeBasedOneTimePassword",
+                "TimeBasedOneTimePassword");
+            return;
+        }
+        messages::success(asyncResp->res);
+    },
+        "xyz.openbmc_project.User.Manager", userPath,
+        "xyz.openbmc_project.User.TOTPAuthenticator", "VerifyOTP", totp);
+}
+
 inline void requestAccountServiceRoutes(App& app)
 {
     BMCWEB_ROUTE(app, "/redfish/v1/AccountService/")
@@ -2845,6 +2904,13 @@ inline void requestAccountServiceRoutes(App& app)
         .privileges(redfish::privileges::postManagerAccount)
         .methods(boost::beast::http::verb::post)(
             std::bind_front(handleGenerateSecretKey, std::ref(app)));
+
+    BMCWEB_ROUTE(
+        app,
+        "/redfish/v1/AccountService/Accounts/<str>/Actions/ManagerAccount.VerifyTimeBasedOneTimePassword")
+        .privileges(redfish::privileges::postManagerAccount)
+        .methods(boost::beast::http::verb::post)(std::bind_front(
+            handleManagerAccountVerifyTotpAction, std::ref(app)));
 }
 
 } // namespace redfish

--- a/redfish-core/lib/account_service.hpp
+++ b/redfish-core/lib/account_service.hpp
@@ -1294,6 +1294,7 @@ inline void updateUserProperties(
     const std::optional<bool>& enabled,
     const std::optional<std::string>& roleId, const std::optional<bool>& locked,
     std::optional<std::vector<std::string>> accountTypes, bool userSelf,
+    const std::optional<std::vector<std::string>>& mfaBypass,
     const std::shared_ptr<persistent_data::UserSession>& session)
 {
     sdbusplus::message::object_path tempObjPath(rootUserDbusPath);
@@ -1303,7 +1304,7 @@ inline void updateUserProperties(
     dbus::utility::checkDbusPathExists(
         dbusObjectPath,
         [dbusObjectPath, username, password, roleId, enabled, locked,
-         accountTypes(std::move(accountTypes)), userSelf, session,
+         accountTypes(std::move(accountTypes)), userSelf, session, mfaBypass,
          asyncResp{std::move(asyncResp)}](int rc) {
         if (rc <= 0)
         {
@@ -1340,6 +1341,72 @@ inline void updateUserProperties(
                     .removeSessionsByUsernameExceptSession(username, session);
                 messages::success(asyncResp->res);
             }
+        }
+
+        if (mfaBypass)
+        {
+            std::string mfaBypassDbusVal;
+            // Check if the input vector contains just one bypass type:
+            // as there are just two defined in the backend:
+            // GoogleAuthenticator  and None
+            if (mfaBypass->size() > 1)
+            {
+                messages::propertyNotWritable(asyncResp->res,
+                                              "MFABypass/BypassTypes");
+                return;
+            }
+            std::string mfaBypassDbusPrefix =
+                "xyz.openbmc_project.User.MultiFactorAuthConfiguration.Type.";
+            if (mfaBypass->empty())
+            {
+                mfaBypassDbusVal = mfaBypassDbusPrefix + "None";
+            }
+            else
+            {
+                std::string mfaBypassVal = mfaBypass->front();
+                if (mfaBypassVal == "GoogleAuthenticator" ||
+                    mfaBypassVal == "None")
+                {
+                    mfaBypassDbusVal = mfaBypassDbusPrefix + mfaBypassVal;
+                }
+                else
+                {
+                    messages::propertyValueNotInList(
+                        asyncResp->res, mfaBypassVal, "MFABypass/BypassTypes");
+                    return;
+                }
+            }
+            sdbusplus::asio::setProperty(
+                *crow::connections::systemBus,
+                "xyz.openbmc_project.User.Manager", dbusObjectPath,
+                "xyz.openbmc_project.User.TOTPAuthenticator",
+                "BypassedProtocol", mfaBypassDbusVal,
+                [asyncResp,
+                 mfaBypassDbusVal](const boost::system::error_code& ec,
+                                   const sdbusplus::message_t& msg) {
+                if (ec)
+                {
+                    const sd_bus_error* dbusError = msg.get_error();
+                    if (dbusError != nullptr)
+                    {
+                        std::string_view errorName(dbusError->name);
+
+                        if (errorName ==
+                            "xyz.openbmc_project.Common.Error.InvalidArgument")
+                        {
+                            BMCWEB_LOG_WARNING("DBUS response error: {}", ec);
+                            messages::propertyValueIncorrect(
+                                asyncResp->res, "MFABypass/BypassTypes",
+                                mfaBypassDbusVal);
+                            return;
+                        }
+                        BMCWEB_LOG_ERROR("DBUS response error: {}", ec.value());
+                        messages::internalError(asyncResp->res);
+                        return;
+                    }
+                }
+                messages::success(asyncResp->res);
+            });
         }
 
         if (enabled)
@@ -1544,6 +1611,33 @@ inline void handleAccountServiceHead(
         "</redfish/v1/JsonSchemas/AccountService/AccountService.json>; rel=describedby");
 }
 
+inline void getMultiFactorAuthConfiguration(
+    const std::shared_ptr<bmcweb::AsyncResp>& asyncResp)
+{
+    sdbusplus::asio::getProperty<std::string>(
+        *crow::connections::systemBus, "xyz.openbmc_project.User.Manager",
+        "/xyz/openbmc_project/user",
+        "xyz.openbmc_project.User.MultiFactorAuthConfiguration", "Enabled",
+        [asyncResp](const boost::system::error_code& ec,
+                    const std::string& multiFactorAuthEnabledVal) {
+        if (ec)
+        {
+            BMCWEB_LOG_ERROR(
+                "DBUS response error while fetching MultiFactorAuth property. Error: {}",
+                ec);
+            messages::internalError(asyncResp->res);
+            return;
+        }
+
+        constexpr std::string_view mfaGoogleAuthDbusVal =
+            "xyz.openbmc_project.User.MultiFactorAuthConfiguration.Type.GoogleAuthenticator";
+        bool googleAuthEnabled =
+            (multiFactorAuthEnabledVal == mfaGoogleAuthDbusVal);
+        asyncResp->res.jsonValue["MultiFactorAuth"]["GoogleAuthenticator"]
+                                ["Enabled"] = googleAuthEnabled;
+    });
+}
+
 inline void
     handleAccountServiceGet(App& app, const crow::Request& req,
                             const std::shared_ptr<bmcweb::AsyncResp>& asyncResp)
@@ -1649,6 +1743,9 @@ inline void
         }
     });
 
+    // Get MFA Config
+    getMultiFactorAuthConfiguration(asyncResp);
+
     auto callback = [asyncResp](bool success, const LDAPConfigData& confData,
                                 const std::string& ldapType) {
         if (!success)
@@ -1677,13 +1774,15 @@ inline void handleAccountServicePatch(
     std::optional<nlohmann::json> ldapObject;
     std::optional<nlohmann::json> activeDirectoryObject;
     std::optional<nlohmann::json> oemObject;
+    std::optional<bool> googleAuthenticatorEnabled;
 
     if (!json_util::readJsonPatch(
             req, asyncResp->res, "AccountLockoutDuration", unlockTimeout,
             "AccountLockoutThreshold", lockoutThreshold, "MaxPasswordLength",
             maxPasswordLength, "MinPasswordLength", minPasswordLength, "LDAP",
             ldapObject, "ActiveDirectory", activeDirectoryObject, "Oem",
-            oemObject))
+            oemObject, "MultiFactorAuth/GoogleAuthenticator/Enabled",
+            googleAuthenticatorEnabled))
     {
         return;
     }
@@ -1744,6 +1843,31 @@ inline void handleAccountServicePatch(
             "xyz.openbmc_project.User.AccountPolicy",
             "MaxLoginAttemptBeforeLockout", "AccountLockoutThreshold",
             *lockoutThreshold);
+    }
+    if (googleAuthenticatorEnabled)
+    {
+        std::string_view mfaType =
+            "xyz.openbmc_project.User.MultiFactorAuthConfiguration.Type.None";
+        if (*googleAuthenticatorEnabled)
+        {
+            mfaType =
+                "xyz.openbmc_project.User.MultiFactorAuthConfiguration.Type.GoogleAuthenticator";
+        }
+
+        sdbusplus::asio::setProperty(
+            *crow::connections::systemBus, "xyz.openbmc_project.User.Manager",
+            "/xyz/openbmc_project/user",
+            "xyz.openbmc_project.User.MultiFactorAuthConfiguration", "Enabled",
+            std::string(mfaType),
+            [asyncResp](const boost::system::error_code& ec) {
+            if (ec)
+            {
+                BMCWEB_LOG_ERROR("DBUS response error: {}", ec);
+                messages::internalError(asyncResp->res);
+                return;
+            }
+            messages::success(asyncResp->res);
+        });
     }
 }
 
@@ -2127,7 +2251,7 @@ inline void
         }
 
         asyncResp->res.jsonValue["@odata.type"] =
-            "#ManagerAccount.v1_7_0.ManagerAccount";
+            "#ManagerAccount.v1_13_0.ManagerAccount";
         asyncResp->res.jsonValue["Name"] = "User Account";
         asyncResp->res.jsonValue["Description"] = "User Account";
         asyncResp->res.jsonValue["Password"] = nullptr;
@@ -2224,6 +2348,51 @@ inline void
                             BMCWEB_LOG_ERROR("userGroups mapping failed");
                             messages::internalError(asyncResp->res);
                             return;
+                        }
+                    }
+                }
+                if (interface.first ==
+                    "xyz.openbmc_project.User.TOTPAuthenticator")
+                {
+                    for (const auto& property : interface.second)
+                    {
+                        if (property.first == "BypassedProtocol")
+                        {
+                            const std::string* bypassedProtocol =
+                                std::get_if<std::string>(&property.second);
+
+                            if (bypassedProtocol == nullptr)
+                            {
+                                BMCWEB_LOG_ERROR(
+                                    "BypassedProtocol Value fetch faile");
+                                messages::internalError(asyncResp->res);
+                                return;
+                            }
+                            nlohmann::json& mfaBypassArray =
+                                asyncResp->res
+                                    .jsonValue["MFABypass"]["BypassTypes"];
+                            mfaBypassArray = nlohmann::json::array();
+
+                            constexpr std::string_view mfaGoogleAuthDbusVal =
+                                "xyz.openbmc_project.User.MultiFactorAuthConfiguration.Type.GoogleAuthenticator";
+                            if (*bypassedProtocol == mfaGoogleAuthDbusVal)
+                            {
+                                mfaBypassArray.push_back("GoogleAuthenticator");
+                            }
+                        }
+                        if (property.first == "SecretKeyIsValid")
+                        {
+                            const bool* secretKeySet =
+                                std::get_if<bool>(&property.second);
+                            if (secretKeySet == nullptr)
+                            {
+                                BMCWEB_LOG_ERROR(
+                                    "SecretKeyIsValid value fetch failed");
+                                messages::internalError(asyncResp->res);
+                                return;
+                            }
+                            asyncResp->res.jsonValue["SecretKeySet"] =
+                                *secretKeySet;
                         }
                     }
                 }
@@ -2325,11 +2494,12 @@ inline void
     std::optional<bool> locked;
     std::optional<std::vector<std::string>> accountTypes;
     std::optional<nlohmann::json> oem;
+    std::optional<std::vector<std::string>> mfaBypass;
 
-    if (!json_util::readJsonPatch(req, asyncResp->res, "UserName", newUserName,
-                                  "Password", password, "RoleId", roleId,
-                                  "Enabled", enabled, "Locked", locked, "Oem",
-                                  oem, "AccountTypes", accountTypes))
+    if (!json_util::readJsonPatch(
+            req, asyncResp->res, "UserName", newUserName, "Password", password,
+            "RoleId", roleId, "Enabled", enabled, "Locked", locked, "Oem", oem,
+            "AccountTypes", accountTypes, "MFABypass/BypassTypes", mfaBypass))
     {
         return;
     }
@@ -2486,14 +2656,16 @@ inline void
     if (!newUserName || (newUserName.value() == username))
     {
         updateUserProperties(asyncResp, username, password, enabled, roleId,
-                             locked, accountTypes, userSelf, req.session);
+                             locked, accountTypes, userSelf, mfaBypass,
+                             req.session);
         return;
     }
     crow::connections::systemBus->async_method_call(
         [asyncResp, username, password(std::move(password)),
          roleId(std::move(roleId)), enabled, newUser{std::string(*newUserName)},
-         locked, userSelf, req, accountTypes(std::move(accountTypes))](
-            const boost::system::error_code& ec, sdbusplus::message_t& m) {
+         locked, userSelf, req, accountTypes(std::move(accountTypes)),
+         mfaBypass](const boost::system::error_code& ec,
+                    sdbusplus::message_t& m) {
         if (ec)
         {
             userErrorMessageHandler(m.get_error(), asyncResp, newUser,
@@ -2502,11 +2674,112 @@ inline void
         }
 
         updateUserProperties(asyncResp, newUser, password, enabled, roleId,
-                             locked, accountTypes, userSelf, req.session);
+                             locked, accountTypes, userSelf, mfaBypass,
+                             req.session);
     },
         "xyz.openbmc_project.User.Manager", "/xyz/openbmc_project/user",
         "xyz.openbmc_project.User.Manager", "RenameUser", username,
         *newUserName);
+}
+
+static void
+    checkAndCreateSecretKey(const std::shared_ptr<bmcweb::AsyncResp>& asyncResp,
+                            const std::string& username,
+                            const std::string& userPath)
+{
+    sdbusplus::message::object_path userObjPath("/xyz/openbmc_project/user/" +
+                                                username);
+    sdbusplus::asio::getProperty<bool>(
+        *crow::connections::systemBus, "xyz.openbmc_project.User.Manager",
+        std::string(userObjPath), "xyz.openbmc_project.User.TOTPAuthenticator",
+        "SecretKeyIsValid",
+        [asyncResp, username, userPath](const boost::system::error_code& ec,
+                                        const bool& isSecretKeySet) {
+        if (ec)
+        {
+            BMCWEB_LOG_ERROR("D-Bus response error: {}", ec.value());
+            messages::internalError(asyncResp->res);
+            return;
+        }
+
+        if (isSecretKeySet)
+        {
+            BMCWEB_LOG_WARNING("Secret key is already setup for the user");
+            messages::actionNotSupported(asyncResp->res, "GenerateSecretKey");
+            return;
+        }
+
+        // If secret key is not set, then proceed to create it
+        crow::connections::systemBus->async_method_call(
+            [asyncResp, username](const boost::system::error_code& ec1,
+                                  const std::string& secretKey) {
+            if (ec1)
+            {
+                BMCWEB_LOG_ERROR("D-Bus response error: {}", ec1.value());
+                messages::internalError(asyncResp->res);
+                return;
+            }
+            asyncResp->res.jsonValue["@odata.type"] =
+                "#ManagerAccount.v1_13_0.ManagerAccount";
+            asyncResp->res.jsonValue["Name"] = "User Account";
+            asyncResp->res.jsonValue["Description"] = "User Account";
+            asyncResp->res.jsonValue["SecretKey"] = secretKey;
+        },
+            "xyz.openbmc_project.User.Manager", userPath,
+            "xyz.openbmc_project.User.TOTPAuthenticator", "CreateSecretKey");
+    });
+}
+
+inline void
+    handleGenerateSecretKey(App& app, const crow::Request& req,
+                            const std::shared_ptr<bmcweb::AsyncResp>& asyncResp,
+                            const std::string& username)
+{
+    if (!redfish::setUpRedfishRoute(app, req, asyncResp))
+    {
+        return;
+    }
+
+    if constexpr (BMCWEB_INSECURE_DISABLE_AUTH)
+    {
+        // If authentication is disabled, there are no user accounts
+        messages::resourceNotFound(asyncResp->res, "ManagerAccount", username);
+        return;
+    }
+
+    bool userSelf = (req.session != nullptr &&
+                     username == req.session->username);
+    if (!userSelf)
+    {
+        BMCWEB_LOG_WARNING("Insufficient Privilege");
+        messages::insufficientPrivilege(asyncResp->res);
+        return;
+    }
+    sdbusplus::message::object_path tempObjPath(rootUserDbusPath);
+    tempObjPath /= username;
+    const std::string userPath(tempObjPath);
+
+    sdbusplus::asio::getProperty<std::string>(
+        *crow::connections::systemBus, "xyz.openbmc_project.User.Manager",
+        "/xyz/openbmc_project/user",
+        "xyz.openbmc_project.User.MultiFactorAuthConfiguration", "Enabled",
+        [asyncResp, username, userPath](const boost::system::error_code& ec,
+                                        const std::string& mfaEnabled) {
+        if (ec)
+        {
+            BMCWEB_LOG_ERROR("D-Bus response error: {}", ec.value());
+            messages::internalError(asyncResp->res);
+            return;
+        }
+        if (mfaEnabled.ends_with("None"))
+        {
+            // MFA is not enabled
+            BMCWEB_LOG_WARNING("MFA is not enabled in the system");
+            messages::actionNotSupported(asyncResp->res, "GenerateSecretKey");
+            return;
+        }
+        checkAndCreateSecretKey(asyncResp, username, userPath);
+    });
 }
 
 inline void requestAccountServiceRoutes(App& app)
@@ -2563,6 +2836,15 @@ inline void requestAccountServiceRoutes(App& app)
         .privileges(redfish::privileges::deleteManagerAccount)
         .methods(boost::beast::http::verb::delete_)(
             std::bind_front(handleAccountDelete, std::ref(app)));
+
+    BMCWEB_ROUTE(
+        app,
+        "/redfish/v1/AccountService/Accounts/<str>/Actions/ManagerAccount.GenerateSecretKey")
+        // Only the user is authorized to configure or set up MFA for their own
+        // account.
+        .privileges(redfish::privileges::postManagerAccount)
+        .methods(boost::beast::http::verb::post)(
+            std::bind_front(handleGenerateSecretKey, std::ref(app)));
 }
 
 } // namespace redfish


### PR DESCRIPTION
This PR pulls the following upstream commits (currently under review) to support MFA on P11 systems
https://gerrit.openbmc.org/c/openbmc/bmcweb/+/74667
https://gerrit.openbmc.org/c/openbmc/bmcweb/+/74807

Tested By:
[1] GET https://${bmc}/redfish/v1/AccountService
    This lists "MultiFactorAuth" property defined in
    AccountService.v1_12_0 schema
    ```
    "MultiFactorAuth": {
        "GoogleAuthenticator": {
          "Enabled": false
        }
    }
    ```

[2] GET [https://${bmc}/redfish/v1/AccountService/Accounts/<user_name>](https://${bmc}/redfish/v1/AccountService/Accounts/%3Cuser_name%3E);
    This lists "MFABypass" property defined in ManagerAccount.v1_10_0
    schema
    ```
    "MFABypass": {
        "BypassTypes": [
          "GoogleAuthenticator"
        ]
    }
    ```

[3] curl -k -H "X-Auth-Token: $bmc_token" -H "Content-Type: application/json" -X POST https://${bmc}/redfish/v1/AccountService/Accounts/testadmin/Actions/ManagerAccount.VerifyTimeBasedOneTimePassword -d '{"TimeBasedOneTimePassword":"<>"}'