### PR TITLE
Remove all ciphers which CBC

### DIFF
--- a/include/ssl_key_handler.hpp
+++ b/include/ssl_key_handler.hpp
@@ -462,9 +462,7 @@ inline std::shared_ptr<boost::asio::ssl::context>
                                 "ECDHE-ECDSA-AES128-GCM-SHA256:"
                                 "ECDHE-RSA-AES128-GCM-SHA256:"
                                 "ECDHE-ECDSA-AES256-SHA384:"
-                                "ECDHE-RSA-AES256-SHA384:"
-                                "ECDHE-ECDSA-AES128-SHA256:"
-                                "ECDHE-RSA-AES128-SHA256";
+                                "ECDHE-ECDSA-AES128-SHA256";
 
     if (SSL_CTX_set_cipher_list(mSslContext->native_handle(),
                                 mozillaModern.c_str()) != 1)


### PR DESCRIPTION
Ciphers which use cipher block chaining (CBC) mode of the message authenticate code (MAC) are deprecated.  These are being removed as supported HTTPS ciphers.
Ciphers which use newer modes such as GCM are still supported

Tested:
- HTTPS clients can still connect to the BMC
- Plan to perform a network security scan to confirm the deprecated ciphers are no longer offered.

Change-Id: Ie9f803252841d81844c22416d491edc9f61d1ed6