### PR TITLE
1050: Upgrade to mozilla intermediate 5.7

### DIFF
--- a/include/ssl_key_handler.hpp
+++ b/include/ssl_key_handler.hpp
@@ -455,16 +455,15 @@ inline std::shared_ptr<boost::asio::ssl::context>
         BMCWEB_LOG_ERROR << "Error setting tmp ecdh list\n";
     }
 
-    std::string mozillaModern = "ECDHE-ECDSA-AES256-GCM-SHA384:"
+    std::string mozillaModern = "ECDHE-ECDSA-AES128-GCM-SHA256:"
+                                "ECDHE-RSA-AES128-GCM-SHA256:"
+                                "ECDHE-ECDSA-AES256-GCM-SHA384:"
                                 "ECDHE-RSA-AES256-GCM-SHA384:"
                                 "ECDHE-ECDSA-CHACHA20-POLY1305:"
                                 "ECDHE-RSA-CHACHA20-POLY1305:"
-                                "ECDHE-ECDSA-AES128-GCM-SHA256:"
-                                "ECDHE-RSA-AES128-GCM-SHA256:"
-                                "ECDHE-ECDSA-AES256-SHA384:"
-                                "ECDHE-RSA-AES256-SHA384:"
-                                "ECDHE-ECDSA-AES128-SHA256:"
-                                "ECDHE-RSA-AES128-SHA256";
+                                "DHE-RSA-AES128-GCM-SHA256:"
+                                "DHE-RSA-AES256-GCM-SHA384:"
+                                "DHE-RSA-CHACHA20-POLY1305";
 
     if (SSL_CTX_set_cipher_list(mSslContext->native_handle(),
                                 mozillaModern.c_str()) != 1)


### PR DESCRIPTION
#### Upgrade to mozilla intermediate 5.7
```
Mozilla intermediate 5.7 was released last month[1]

The last release to these was 3 years ago, so we haven't really had to
update much.  Update cipher suites to match new list for mozilla
intermediate.

Note, the variable is called "mozilla modern" but it hasn't tracked the
modern recommendations for some time.

Tested:
testssl.sh, from the master branch (864877df)
Returns a passing result, showing no change in supported products, and
the cipher suites correctly applied.

Redfish service validator shows no change in result.

[1] https://ssl-config.mozilla.org/guidelines/5.7.json
[2] https://github.com/mozilla/ssl-config-generator/tree/master/src/static/guidelines

Tested: WIP

Change-Id: Ie9ccb7757ae527fa3ac129f781ae32657c7dfdd9
Signed-off-by: Ed Tanous <edtanous@google.com>
```