### PR TITLE
1110 rb use generated enums

### DIFF
--- a/redfish-core/include/event_service_manager.hpp
+++ b/redfish-core/include/event_service_manager.hpp
@@ -18,6 +18,8 @@
 #include "error_messages.hpp"
 #include "event_service_store.hpp"
 #include "filter_expr_executor.hpp"
+#include "generated/enums/event.hpp"
+#include "generated/enums/log_entry.hpp"
 #include "http_client.hpp"
 #include "metric_report.hpp"
 #include "ossl_random.hpp"
@@ -247,7 +249,13 @@ inline int formatEventLogEntry(const std::string& logEntryID,
 
     // Fill in the log entry with the gathered data
     logEntryJson["EventId"] = logEntryID;
+
     logEntryJson["EventType"] = "Event";
+
+    // TODO, the above is wrong.  Below should be correct, but would change
+    // behavior
+    // logEntryJson["EventType"] = event_destination::EventType::Alert;
+
     logEntryJson["Severity"] = message->messageSeverity;
     logEntryJson["Message"] = std::move(msg);
     logEntryJson["MessageId"] = messageID;
@@ -472,7 +480,12 @@ class Subscription : public persistent_data::UserSubscription
 
         logEntryJson["EventId"] = "TestID";
         logEntryJson["EventType"] = "Event";
-        logEntryJson["Severity"] = "OK";
+
+        // TODO, the above is wrong.  There's no "Event" type in the EventType
+        // enum  Below should be correct, but would change behavior
+        // logEntryJson["EventType"] = event::EventType::Alert;
+
+        logEntryJson["Severity"] = log_entry::EventSeverity::OK;
         logEntryJson["Message"] = "Generated test event";
         logEntryJson["MessageId"] = "OpenBMC.0.2.TestEventLog";
         // MemberId is 0 : since we are sending one event record.

--- a/redfish-core/include/snmp_trap_event_clients.hpp
+++ b/redfish-core/include/snmp_trap_event_clients.hpp
@@ -5,6 +5,7 @@
 #include "dbus_utility.hpp"
 #include "error_messages.hpp"
 #include "event_service_manager.hpp"
+#include "generated/enums/event_destination.hpp"
 #include "http_request.hpp"
 #include "http_response.hpp"
 #include "logging.hpp"
@@ -56,15 +57,18 @@ inline void
 {
     asyncResp->res.jsonValue["@odata.type"] =
         "#EventDestination.v1_8_0.EventDestination";
-    asyncResp->res.jsonValue["Protocol"] = "SNMPv2c";
+    asyncResp->res.jsonValue["Protocol"] =
+        event_destination::EventDestinationProtocol::SNMPv2c;
     asyncResp->res.jsonValue["@odata.id"] =
         boost::urls::format("/redfish/v1/EventService/Subscriptions/{}", id);
 
     asyncResp->res.jsonValue["Id"] = id;
     asyncResp->res.jsonValue["Name"] = "Event Destination";
 
-    asyncResp->res.jsonValue["SubscriptionType"] = "SNMPTrap";
-    asyncResp->res.jsonValue["EventFormatType"] = "Event";
+    asyncResp->res.jsonValue["SubscriptionType"] =
+        event_destination::SubscriptionType::SNMPTrap;
+    asyncResp->res.jsonValue["EventFormatType"] =
+        event_destination::EventFormatType::Event;
 
     std::shared_ptr<Subscription> subValue =
         EventServiceManager::getInstance().getSubscription(id);

--- a/redfish-core/include/utils/sw_utils.hpp
+++ b/redfish-core/include/utils/sw_utils.hpp
@@ -349,7 +349,8 @@ inline void getSwStatus(const std::shared_ptr<bmcweb::AsyncResp>& asyncResp,
         if (ec)
         {
             // not all swtypes are updateable, this is ok
-            asyncResp->res.jsonValue["Status"]["State"] = "Enabled";
+            asyncResp->res.jsonValue["Status"]["State"] =
+                resource::State::Enabled;
             return;
         }
 

--- a/redfish-core/lib/cable.hpp
+++ b/redfish-core/lib/cable.hpp
@@ -2,6 +2,7 @@
 
 #include "assembly.hpp"
 #include "dbus_utility.hpp"
+#include "generated/enums/resource.hpp"
 #include "query.hpp"
 #include "registries/privilege_registry.hpp"
 #include "utils/collection.hpp"
@@ -176,7 +177,8 @@ inline void
 
         if (!present)
         {
-            asyncResp->res.jsonValue["Status"]["State"] = "Absent";
+            asyncResp->res.jsonValue["Status"]["State"] =
+                resource::State::Absent;
         }
     });
 }

--- a/redfish-core/lib/chassis.hpp
+++ b/redfish-core/lib/chassis.hpp
@@ -135,7 +135,7 @@ inline void getChassisState(std::shared_ptr<bmcweb::AsyncResp> asyncResp)
         else if (chassisState ==
                  "xyz.openbmc_project.State.Chassis.PowerState.Off")
         {
-            asyncResp->res.jsonValue["PowerState"] = resource::PowerState::On;
+            asyncResp->res.jsonValue["PowerState"] = resource::PowerState::Off;
             asyncResp->res.jsonValue["Status"]["State"] =
                 resource::State::StandbyOffline;
         }

--- a/redfish-core/lib/chassis.hpp
+++ b/redfish-core/lib/chassis.hpp
@@ -19,6 +19,9 @@
 
 #include "app.hpp"
 #include "dbus_utility.hpp"
+#include "generated/enums/action_info.hpp"
+#include "generated/enums/chassis.hpp"
+#include "generated/enums/resource.hpp"
 #include "health.hpp"
 #include "led.hpp"
 #include "query.hpp"
@@ -125,14 +128,16 @@ inline void getChassisState(std::shared_ptr<bmcweb::AsyncResp> asyncResp)
         // Verify Chassis State
         if (chassisState == "xyz.openbmc_project.State.Chassis.PowerState.On")
         {
-            asyncResp->res.jsonValue["PowerState"] = "On";
-            asyncResp->res.jsonValue["Status"]["State"] = "Enabled";
+            asyncResp->res.jsonValue["PowerState"] = resource::PowerState::On;
+            asyncResp->res.jsonValue["Status"]["State"] =
+                resource::State::Enabled;
         }
         else if (chassisState ==
                  "xyz.openbmc_project.State.Chassis.PowerState.Off")
         {
-            asyncResp->res.jsonValue["PowerState"] = "Off";
-            asyncResp->res.jsonValue["Status"]["State"] = "StandbyOffline";
+            asyncResp->res.jsonValue["PowerState"] = resource::PowerState::On;
+            asyncResp->res.jsonValue["Status"]["State"] =
+                resource::State::StandbyOffline;
         }
     });
 }
@@ -338,7 +343,7 @@ inline void handleDecoratorAssetProperties(
     // SensorCollection
     asyncResp->res.jsonValue["Sensors"]["@odata.id"] =
         boost::urls::format("/redfish/v1/Chassis/{}/Sensors", chassisId);
-    asyncResp->res.jsonValue["Status"]["State"] = "Enabled";
+    asyncResp->res.jsonValue["Status"]["State"] = resource::State::Enabled;
 
     nlohmann::json::array_t computerSystems;
     nlohmann::json::object_t system;
@@ -443,7 +448,8 @@ inline void handleChassisGetSubTree(
             boost::urls::format("/redfish/v1/Chassis/{}", chassisId);
         name_util::getPrettyName(asyncResp, path, connectionNames,
                                  "/Name"_json_pointer);
-        asyncResp->res.jsonValue["ChassisType"] = "RackMount";
+        asyncResp->res.jsonValue["ChassisType"] =
+            chassis::ChassisType::RackMount;
         asyncResp->res.jsonValue["Actions"]["#Chassis.Reset"]["target"] =
             boost::urls::format("/redfish/v1/Chassis/{}/Actions/Chassis.Reset",
                                 chassisId);
@@ -846,7 +852,7 @@ inline void handleChassisResetActionInfoGet(
     nlohmann::json::object_t parameter;
     parameter["Name"] = "ResetType";
     parameter["Required"] = true;
-    parameter["DataType"] = "String";
+    parameter["DataType"] = action_info::ParameterTypes::String;
     nlohmann::json::array_t allowed;
     allowed.emplace_back("PowerCycle");
     parameter["AllowableValues"] = std::move(allowed);

--- a/redfish-core/lib/ethernet.hpp
+++ b/redfish-core/lib/ethernet.hpp
@@ -19,6 +19,8 @@
 #include "dbus_singleton.hpp"
 #include "dbus_utility.hpp"
 #include "error_messages.hpp"
+#include "generated/enums/ethernet_interface.hpp"
+#include "generated/enums/resource.hpp"
 #include "human_sort.hpp"
 #include "query.hpp"
 #include "registries/privilege_registry.hpp"
@@ -1768,13 +1770,15 @@ inline void
 
     if (ethData.nicEnabled)
     {
-        jsonResponse["LinkStatus"] = ethData.linkUp ? "LinkUp" : "LinkDown";
-        jsonResponse["Status"]["State"] = "Enabled";
+        jsonResponse["LinkStatus"] =
+            ethData.linkUp ? ethernet_interface::LinkStatus::LinkUp
+                           : ethernet_interface::LinkStatus::LinkDown;
+        jsonResponse["Status"]["State"] = resource::State::Enabled;
     }
     else
     {
-        jsonResponse["LinkStatus"] = "NoLink";
-        jsonResponse["Status"]["State"] = "Disabled";
+        jsonResponse["LinkStatus"] = ethernet_interface::LinkStatus::NoLink;
+        jsonResponse["Status"]["State"] = resource::State::Disabled;
     }
 
     jsonResponse["SpeedMbps"] = ethData.speed;

--- a/redfish-core/lib/event_service.hpp
+++ b/redfish-core/lib/event_service.hpp
@@ -16,6 +16,7 @@
 #pragma once
 #include "app.hpp"
 #include "event_service_manager.hpp"
+#include "generated/enums/event_service.hpp"
 #include "http/utility.hpp"
 #include "logging.hpp"
 #include "query.hpp"
@@ -706,7 +707,8 @@ inline void requestRoutesEventDestination(App& app)
 
         asyncResp->res.jsonValue["@odata.type"] =
             "#EventDestination.v1_8_0.EventDestination";
-        asyncResp->res.jsonValue["Protocol"] = "Redfish";
+        asyncResp->res.jsonValue["Protocol"] =
+            event_destination::EventDestinationProtocol::Redfish;
         asyncResp->res.jsonValue["@odata.id"] = boost::urls::format(
             "/redfish/v1/EventService/Subscriptions/{}", id);
         asyncResp->res.jsonValue["Id"] = id;

--- a/redfish-core/lib/fabric_adapters.hpp
+++ b/redfish-core/lib/fabric_adapters.hpp
@@ -2,6 +2,7 @@
 
 #include "app.hpp"
 #include "dbus_utility.hpp"
+#include "generated/enums/resource.hpp"
 #include "led.hpp"
 #include "query.hpp"
 #include "registries/privilege_registry.hpp"
@@ -128,7 +129,8 @@ inline void
 
         if (!present)
         {
-            asyncResp->res.jsonValue["Status"]["State"] = "Absent";
+            asyncResp->res.jsonValue["Status"]["State"] =
+                resource::State::Absent;
         }
     });
 }
@@ -155,7 +157,8 @@ inline void
 
         if (!functional)
         {
-            asyncResp->res.jsonValue["Status"]["Health"] = "Critical";
+            asyncResp->res.jsonValue["Status"]["Health"] =
+                resource::Health::Critical;
         }
     });
 }
@@ -301,8 +304,8 @@ inline void doAdapterGet(const std::shared_ptr<bmcweb::AsyncResp>& asyncResp,
     asyncResp->res.jsonValue["@odata.id"] = boost::urls::format(
         "/redfish/v1/Systems/{}/FabricAdapters/{}", systemName, adapterId);
 
-    asyncResp->res.jsonValue["Status"]["State"] = "Enabled";
-    asyncResp->res.jsonValue["Status"]["Health"] = "OK";
+    asyncResp->res.jsonValue["Status"]["State"] = resource::State::Enabled;
+    asyncResp->res.jsonValue["Status"]["Health"] = resource::Health::OK;
 
     // add pcieslots
     getFabricAdapterPCIeSlots(

--- a/redfish-core/lib/fan.hpp
+++ b/redfish-core/lib/fan.hpp
@@ -3,6 +3,7 @@
 #include "app.hpp"
 #include "dbus_utility.hpp"
 #include "error_messages.hpp"
+#include "generated/enums/resource.hpp"
 #include "led.hpp"
 #include "query.hpp"
 #include "registries/privilege_registry.hpp"
@@ -197,8 +198,8 @@ inline void addFanCommonProperties(crow::Response& resp,
     resp.jsonValue["Id"] = fanId;
     resp.jsonValue["@odata.id"] = boost::urls::format(
         "/redfish/v1/Chassis/{}/ThermalSubsystem/Fans/{}", chassisId, fanId);
-    resp.jsonValue["Status"]["State"] = "Enabled";
-    resp.jsonValue["Status"]["Health"] = "OK";
+    resp.jsonValue["Status"]["State"] = resource::State::Enabled;
+    resp.jsonValue["Status"]["Health"] = resource::Health::OK;
 }
 
 inline void getFanHealth(const std::shared_ptr<bmcweb::AsyncResp>& asyncResp,
@@ -221,7 +222,8 @@ inline void getFanHealth(const std::shared_ptr<bmcweb::AsyncResp>& asyncResp,
 
         if (!value)
         {
-            asyncResp->res.jsonValue["Status"]["Health"] = "Critical";
+            asyncResp->res.jsonValue["Status"]["Health"] =
+                resource::Health::Critical;
         }
     });
 }
@@ -246,7 +248,8 @@ inline void getFanState(const std::shared_ptr<bmcweb::AsyncResp>& asyncResp,
 
         if (!value)
         {
-            asyncResp->res.jsonValue["Status"]["State"] = "Absent";
+            asyncResp->res.jsonValue["Status"]["State"] =
+                resource::State::Absent;
         }
     });
 }

--- a/redfish-core/lib/hypervisor_system.hpp
+++ b/redfish-core/lib/hypervisor_system.hpp
@@ -6,6 +6,9 @@
 #include "error_messages.hpp"
 #include "ethernet.hpp"
 #include "event_service_manager.hpp"
+#include "generated/enums/action_info.hpp"
+#include "generated/enums/computer_system.hpp"
+#include "generated/enums/resource.hpp"
 #include "query.hpp"
 #include "registries/privilege_registry.hpp"
 #include "resource_messages.hpp"
@@ -55,37 +58,45 @@ inline void
         // Verify Host State
         if (hostState == "xyz.openbmc_project.State.Host.HostState.Running")
         {
-            asyncResp->res.jsonValue["PowerState"] = "On";
-            asyncResp->res.jsonValue["Status"]["State"] = "Enabled";
+            asyncResp->res.jsonValue["PowerState"] = resource::PowerState::On;
+            asyncResp->res.jsonValue["Status"]["State"] =
+                resource::State::Enabled;
         }
         else if (hostState == "xyz.openbmc_project.State.Host.HostState."
                               "Quiesced")
         {
-            asyncResp->res.jsonValue["PowerState"] = "On";
-            asyncResp->res.jsonValue["Status"]["State"] = "Quiesced";
+            asyncResp->res.jsonValue["PowerState"] = resource::PowerState::On;
+            asyncResp->res.jsonValue["Status"]["State"] =
+                resource::State::Quiesced;
         }
         else if (hostState == "xyz.openbmc_project.State.Host.HostState."
                               "Standby")
         {
-            asyncResp->res.jsonValue["PowerState"] = "On";
-            asyncResp->res.jsonValue["Status"]["State"] = "StandbyOffline";
+            asyncResp->res.jsonValue["PowerState"] = resource::PowerState::On;
+            asyncResp->res.jsonValue["Status"]["State"] =
+                resource::State::StandbyOffline;
         }
         else if (hostState == "xyz.openbmc_project.State.Host.HostState."
                               "TransitioningToRunning")
         {
-            asyncResp->res.jsonValue["PowerState"] = "PoweringOn";
-            asyncResp->res.jsonValue["Status"]["State"] = "Starting";
+            asyncResp->res.jsonValue["PowerState"] =
+                resource::PowerState::PoweringOn;
+            asyncResp->res.jsonValue["Status"]["State"] =
+                resource::State::Starting;
         }
         else if (hostState == "xyz.openbmc_project.State.Host.HostState."
                               "TransitioningToOff")
         {
-            asyncResp->res.jsonValue["PowerState"] = "PoweringOff";
-            asyncResp->res.jsonValue["Status"]["State"] = "Enabled";
+            asyncResp->res.jsonValue["PowerState"] =
+                resource::PowerState::PoweringOff;
+            asyncResp->res.jsonValue["Status"]["State"] =
+                resource::State::Enabled;
         }
         else if (hostState == "xyz.openbmc_project.State.Host.HostState.Off")
         {
-            asyncResp->res.jsonValue["PowerState"] = "Off";
-            asyncResp->res.jsonValue["Status"]["State"] = "Disabled";
+            asyncResp->res.jsonValue["PowerState"] = resource::PowerState::Off;
+            asyncResp->res.jsonValue["Status"]["State"] =
+                resource::State::Disabled;
         }
         else
         {
@@ -1178,7 +1189,8 @@ inline void handleHypervisorSystemGet(
         asyncResp->res.jsonValue["Description"] = "Hypervisor";
         asyncResp->res.jsonValue["Name"] = "Hypervisor";
         asyncResp->res.jsonValue["Id"] = "hypervisor";
-        asyncResp->res.jsonValue["SystemType"] = "OS";
+        asyncResp->res.jsonValue["SystemType"] =
+            computer_system::SystemType::OS;
         nlohmann::json::array_t managedBy;
         nlohmann::json::object_t manager;
         manager["@odata.id"] = boost::urls::format(
@@ -1446,7 +1458,7 @@ inline void handleHypervisorResetActionGet(
         nlohmann::json::object_t parameter;
         parameter["Name"] = "ResetType";
         parameter["Required"] = true;
-        parameter["DataType"] = "String";
+        parameter["DataType"] = action_info::ParameterTypes::String;
         nlohmann::json::array_t allowed;
         allowed.emplace_back("On");
         parameter["AllowableValues"] = std::move(allowed);

--- a/redfish-core/lib/led.hpp
+++ b/redfish-core/lib/led.hpp
@@ -18,6 +18,7 @@
 #include "app.hpp"
 #include "async_resp.hpp"
 #include "dbus_utility.hpp"
+#include "generated/enums/chassis.hpp"
 #include "redfish_util.hpp"
 
 #include <boost/system/error_code.hpp>
@@ -63,7 +64,8 @@ inline void
         // Blinking ON, no need to check enclosure_identify assert.
         if (!ec && blinking)
         {
-            asyncResp->res.jsonValue["IndicatorLED"] = "Blinking";
+            asyncResp->res.jsonValue["IndicatorLED"] =
+                chassis::IndicatorLED::Blinking;
             return;
         }
 
@@ -89,11 +91,13 @@ inline void
 
             if (ledOn)
             {
-                asyncResp->res.jsonValue["IndicatorLED"] = "Lit";
+                asyncResp->res.jsonValue["IndicatorLED"] =
+                    chassis::IndicatorLED::Lit;
             }
             else
             {
-                asyncResp->res.jsonValue["IndicatorLED"] = "Off";
+                asyncResp->res.jsonValue["IndicatorLED"] =
+                    chassis::IndicatorLED::Off;
             }
         });
     });

--- a/redfish-core/lib/log_services.hpp
+++ b/redfish-core/lib/log_services.hpp
@@ -20,6 +20,7 @@
 #include "dbus_utility.hpp"
 #include "error_messages.hpp"
 #include "generated/enums/log_entry.hpp"
+#include "generated/enums/log_service.hpp"
 #include "gzfile.hpp"
 #include "http_utility.hpp"
 #include "human_sort.hpp"
@@ -1682,7 +1683,8 @@ inline void requestRoutesEventLogService(App& app)
         asyncResp->res.jsonValue["Name"] = "Event Log Service";
         asyncResp->res.jsonValue["Description"] = "System Event Log Service";
         asyncResp->res.jsonValue["Id"] = "EventLog";
-        asyncResp->res.jsonValue["OverWritePolicy"] = "WrapsWhenFull";
+        asyncResp->res.jsonValue["OverWritePolicy"] =
+            log_service::OverWritePolicy::WrapsWhenFull;
 
         std::pair<std::string, std::string> redfishDateTimeOffset =
             redfish::time_utils::getDateTimeOffsetNow();
@@ -3381,8 +3383,8 @@ inline void fillHostLoggerEntryJson(std::string_view logEntryID,
     logEntryJson["Name"] = "Host Logger Entry";
     logEntryJson["Id"] = logEntryID;
     logEntryJson["Message"] = msg;
-    logEntryJson["EntryType"] = "Oem";
-    logEntryJson["Severity"] = "OK";
+    logEntryJson["EntryType"] = log_entry::LogEntryType::Oem;
+    logEntryJson["Severity"] = log_entry::EventSeverity::OK;
     logEntryJson["OemRecordFormat"] = "Host Logger Entry";
 }
 
@@ -3974,28 +3976,29 @@ inline void
                        const std::string& dumpType)
 {
     std::string dumpPath;
-    std::string overWritePolicy;
+    log_service::OverWritePolicy overWritePolicy =
+        log_service::OverWritePolicy::Invalid;
     bool collectDiagnosticDataSupported = false;
 
     if (dumpType == "BMC")
     {
         dumpPath = std::format("/redfish/v1/Managers/{}/LogServices/Dump",
                                BMCWEB_REDFISH_MANAGER_URI_NAME);
-        overWritePolicy = "WrapsWhenFull";
+        overWritePolicy = log_service::OverWritePolicy::WrapsWhenFull;
         collectDiagnosticDataSupported = true;
     }
     else if (dumpType == "FaultLog")
     {
         dumpPath = std::format("/redfish/v1/Managers/{}/LogServices/FaultLog",
                                BMCWEB_REDFISH_MANAGER_URI_NAME);
-        overWritePolicy = "Unknown";
+        overWritePolicy = log_service::OverWritePolicy::Unknown;
         collectDiagnosticDataSupported = false;
     }
     else if (dumpType == "System")
     {
         dumpPath = std::format("/redfish/v1/Systems/{}/LogServices/Dump",
                                BMCWEB_REDFISH_SYSTEM_URI_NAME);
-        overWritePolicy = "WrapsWhenFull";
+        overWritePolicy = log_service::OverWritePolicy::WrapsWhenFull;
         collectDiagnosticDataSupported = true;
     }
     else
@@ -4011,7 +4014,7 @@ inline void
     asyncResp->res.jsonValue["Name"] = "Dump LogService";
     asyncResp->res.jsonValue["Description"] = dumpType + " Dump LogService";
     asyncResp->res.jsonValue["Id"] = std::filesystem::path(dumpPath).filename();
-    asyncResp->res.jsonValue["OverWritePolicy"] = std::move(overWritePolicy);
+    asyncResp->res.jsonValue["OverWritePolicy"] = overWritePolicy;
 
     std::pair<std::string, std::string> redfishDateTimeOffset =
         redfish::time_utils::getDateTimeOffsetNow();
@@ -4550,7 +4553,8 @@ inline void requestRoutesCrashdumpService(App& app)
         asyncResp->res.jsonValue["Name"] = "Open BMC Oem Crashdump Service";
         asyncResp->res.jsonValue["Description"] = "Oem Crashdump Service";
         asyncResp->res.jsonValue["Id"] = "Crashdump";
-        asyncResp->res.jsonValue["OverWritePolicy"] = "WrapsWhenFull";
+        asyncResp->res.jsonValue["OverWritePolicy"] =
+            log_service::OverWritePolicy::WrapsWhenFull;
         asyncResp->res.jsonValue["MaxNumberOfRecords"] = 3;
 
         std::pair<std::string, std::string> redfishDateTimeOffset =
@@ -4660,7 +4664,7 @@ static void
             BMCWEB_REDFISH_SYSTEM_URI_NAME, logID);
         logEntry["Name"] = "CPU Crashdump";
         logEntry["Id"] = logID;
-        logEntry["EntryType"] = "Oem";
+        logEntry["EntryType"] = log_entry::LogEntryType::Oem;
         logEntry["AdditionalDataURI"] = std::move(crashdumpURI);
         logEntry["DiagnosticDataType"] = "OEM";
         logEntry["OEMDiagnosticDataType"] = "PECICrashdump";
@@ -5184,7 +5188,8 @@ inline void requestRoutesPostCodesLogService(App& app)
         asyncResp->res.jsonValue["Name"] = "POST Code Log Service";
         asyncResp->res.jsonValue["Description"] = "POST Code Log Service";
         asyncResp->res.jsonValue["Id"] = "PostCodes";
-        asyncResp->res.jsonValue["OverWritePolicy"] = "WrapsWhenFull";
+        asyncResp->res.jsonValue["OverWritePolicy"] =
+            log_service::OverWritePolicy::WrapsWhenFull;
         asyncResp->res.jsonValue["Entries"]["@odata.id"] =
             std::format("/redfish/v1/Systems/{}/LogServices/PostCodes/Entries",
                         BMCWEB_REDFISH_SYSTEM_URI_NAME);
@@ -6275,19 +6280,10 @@ inline void getFullAuditLogAttachment(
         return;
     }
 
-    off_t size = lseek(fd, 0, SEEK_END);
+    long long int size = lseek(fd, 0, SEEK_END);
     if (size == -1)
     {
         BMCWEB_LOG_ERROR("Failed to get size of fd {}", fd);
-        messages::internalError(asyncResp->res);
-        close(fd);
-        return;
-    }
-    /* Reset seek pointer so download will start at beginning */
-    off_t rc = lseek(fd, 0, SEEK_SET);
-    if (rc == -1)
-    {
-        BMCWEB_LOG_ERROR("Failed to reset file offset to 0");
         messages::internalError(asyncResp->res);
         close(fd);
         return;
@@ -6307,18 +6303,32 @@ inline void getFullAuditLogAttachment(
         return;
     }
 
-    if (!asyncResp->res.openFd(fd, bmcweb::EncodingType::Base64))
+    std::vector<char> data(static_cast<size_t>(size));
+    long long int rc = lseek(fd, 0, SEEK_SET);
+    if (rc == -1)
     {
-        BMCWEB_LOG_ERROR("Failed to open fd {} for response", fd);
+        BMCWEB_LOG_ERROR("Failed to seek fd {}", fd);
         messages::internalError(asyncResp->res);
         close(fd);
         return;
     }
+    rc = read(fd, data.data(), data.size());
+    if ((rc == -1) || (rc != size))
+    {
+        BMCWEB_LOG_ERROR("Failed to read fd {}", fd);
+        messages::internalError(asyncResp->res);
+        close(fd);
+        return;
+    }
+    close(fd);
+
+    std::string_view strData(data.data(), data.size());
 
     asyncResp->res.addHeader(boost::beast::http::field::content_type,
                              "application/octet-stream");
     asyncResp->res.addHeader(
         boost::beast::http::field::content_transfer_encoding, "Base64");
+    asyncResp->res.write(crow::utility::base64encode(strData));
 }
 
 inline void handleFullAuditLogAttachment(

--- a/redfish-core/lib/managers.hpp
+++ b/redfish-core/lib/managers.hpp
@@ -19,6 +19,9 @@
 
 #include "app.hpp"
 #include "dbus_utility.hpp"
+#include "generated/enums/action_info.hpp"
+#include "generated/enums/manager.hpp"
+#include "generated/enums/resource.hpp"
 #include "led.hpp"
 #include "oem/ibm/usb_code_update.hpp"
 #include "query.hpp"
@@ -336,7 +339,7 @@ inline void requestRoutesManagerResetActionInfo(App& app)
         nlohmann::json::object_t parameter;
         parameter["Name"] = "ResetType";
         parameter["Required"] = true;
-        parameter["DataType"] = "String";
+        parameter["DataType"] = action_info::ParameterTypes::String;
 
         nlohmann::json::array_t allowableValues;
         allowableValues.emplace_back("GracefulRestart");
@@ -1983,19 +1986,21 @@ inline void
         {
             if (val == "active")
             {
-                asyncResp->res.jsonValue["Status"]["Health"] = "Critical";
-                asyncResp->res.jsonValue["Status"]["State"] = "Quiesced";
+                asyncResp->res.jsonValue["Status"]["Health"] =
+                    resource::Health::Critical;
+                asyncResp->res.jsonValue["Status"]["State"] =
+                    resource::State::Quiesced;
                 return;
             }
         }
-        asyncResp->res.jsonValue["Status"]["Health"] = "OK";
-        asyncResp->res.jsonValue["Status"]["State"] = "Enabled";
+        asyncResp->res.jsonValue["Status"]["Health"] = resource::Health::OK;
+        asyncResp->res.jsonValue["Status"]["State"] = resource::State::Enabled;
     });
 }
 
 inline void getBMCState(const std::shared_ptr<bmcweb::AsyncResp>& aResp)
 {
-    aResp->res.jsonValue["PowerState"] = "On";
+    aResp->res.jsonValue["PowerState"] = resource::PowerState::On;
     sdbusplus::asio::getProperty<std::string>(
         *crow::connections::systemBus, "xyz.openbmc_project.State.BMC",
         "/xyz/openbmc_project/state/bmc0", "xyz.openbmc_project.State.BMC",
@@ -2006,14 +2011,14 @@ inline void getBMCState(const std::shared_ptr<bmcweb::AsyncResp>& aResp)
         {
             BMCWEB_LOG_DEBUG("DBUS response error reading CurrentBmcState");
             aResp->res.jsonValue["Status"]["State"] = "Enabled";
-            aResp->res.jsonValue["Status"]["Health"] = "OK";
+            aResp->res.jsonValue["Status"]["Health"] = resource::Health::OK;
             return;
         }
 
         if (bmcState == "xyz.openbmc_project.State.BMC.BMCState.Ready")
         {
             aResp->res.jsonValue["Status"]["State"] = "Enabled";
-            aResp->res.jsonValue["Status"]["Health"] = "OK";
+            aResp->res.jsonValue["Status"]["Health"] = resource::Health::OK;
         }
         else if (bmcState == "xyz.openbmc_project.State.BMC.BMCState."
                              "Quiesced")
@@ -2024,20 +2029,20 @@ inline void getBMCState(const std::shared_ptr<bmcweb::AsyncResp>& aResp)
         else if (bmcState == "xyz.openbmc_project.State.BMC.BMCState."
                              "NotReady")
         {
-            aResp->res.jsonValue["Status"]["State"] = "Starting";
-            aResp->res.jsonValue["Status"]["Health"] = "OK";
+            aResp->res.jsonValue["Status"]["State"] = resource::State::Starting;
+            aResp->res.jsonValue["Status"]["Health"] = resource::Health::OK;
         }
         else if (bmcState == "xyz.openbmc_project.State.BMC.BMCState."
                              "UpdateInProgress")
         {
             aResp->res.jsonValue["Status"]["State"] = "Updating";
-            aResp->res.jsonValue["Status"]["Health"] = "OK";
+            aResp->res.jsonValue["Status"]["Health"] = resource::Health::OK;
         }
         else
         {
             BMCWEB_LOG_DEBUG("Unsupported D-Bus CurrentBMCState: {}", bmcState);
             aResp->res.jsonValue["Status"]["State"] = "Enabled";
-            aResp->res.jsonValue["Status"]["Health"] = "OK";
+            aResp->res.jsonValue["Status"]["Health"] = resource::Health::OK;
         }
     });
 }
@@ -2071,7 +2076,7 @@ inline void requestRoutesManager(App& app)
         asyncResp->res.jsonValue["Description"] =
             "Baseboard Management Controller";
         getBMCState(asyncResp);
-        asyncResp->res.jsonValue["ManagerType"] = "BMC";
+        asyncResp->res.jsonValue["ManagerType"] = manager::ManagerType::BMC;
         asyncResp->res.jsonValue["UUID"] = systemd_utils::getUuid();
         asyncResp->res.jsonValue["ServiceEntryPointUUID"] = uuid;
         asyncResp->res.jsonValue["Model"] = "OpenBmc"; // TODO(ed), get model

--- a/redfish-core/lib/memory.hpp
+++ b/redfish-core/lib/memory.hpp
@@ -19,6 +19,8 @@
 
 #include "app.hpp"
 #include "dbus_utility.hpp"
+#include "generated/enums/memory.hpp"
+#include "generated/enums/resource.hpp"
 #include "query.hpp"
 #include "registries/privilege_registry.hpp"
 #include "utils/collection.hpp"
@@ -409,8 +411,10 @@ inline void
 {
     asyncResp->res.jsonValue[jsonPtr]["Id"] = dimmId;
     asyncResp->res.jsonValue[jsonPtr]["Name"] = "DIMM Slot";
-    asyncResp->res.jsonValue[jsonPtr]["Status"]["State"] = "Enabled";
-    asyncResp->res.jsonValue[jsonPtr]["Status"]["Health"] = "OK";
+    asyncResp->res.jsonValue[jsonPtr]["Status"]["State"] =
+        resource::State::Enabled;
+    asyncResp->res.jsonValue[jsonPtr]["Status"]["Health"] =
+        resource::Health::OK;
 
     const uint16_t* memoryDataWidth = nullptr;
     const size_t* memorySizeInKB = nullptr;
@@ -488,7 +492,8 @@ inline void
 
     if (present != nullptr && !*present)
     {
-        asyncResp->res.jsonValue[jsonPtr]["Status"]["State"] = "Absent";
+        asyncResp->res.jsonValue[jsonPtr]["Status"]["State"] =
+            resource::State::Absent;
     }
 
     if (memoryTotalWidth != nullptr)
@@ -563,11 +568,13 @@ inline void
         }
         if (memoryType->find("DDR") != std::string::npos)
         {
-            asyncResp->res.jsonValue[jsonPtr]["MemoryType"] = "DRAM";
+            asyncResp->res.jsonValue[jsonPtr]["MemoryType"] =
+                memory::MemoryType::DRAM;
         }
         else if (memoryType->ends_with("Logical"))
         {
-            asyncResp->res.jsonValue[jsonPtr]["MemoryType"] = "IntelOptane";
+            asyncResp->res.jsonValue[jsonPtr]["MemoryType"] =
+                memory::MemoryType::IntelOptane;
         }
     }
 

--- a/redfish-core/lib/metric_report_definition.hpp
+++ b/redfish-core/lib/metric_report_definition.hpp
@@ -3,6 +3,7 @@
 #include "app.hpp"
 #include "dbus_utility.hpp"
 #include "generated/enums/metric_report_definition.hpp"
+#include "generated/enums/resource.hpp"
 #include "query.hpp"
 #include "registries/privilege_registry.hpp"
 #include "sensors.hpp"
@@ -356,11 +357,11 @@ inline void
 
     if (enabled)
     {
-        asyncResp->res.jsonValue["Status"]["State"] = "Enabled";
+        asyncResp->res.jsonValue["Status"]["State"] = resource::State::Enabled;
     }
     else
     {
-        asyncResp->res.jsonValue["Status"]["State"] = "Disabled";
+        asyncResp->res.jsonValue["Status"]["State"] = resource::State::Disabled;
     }
 
     metric_report_definition::ReportUpdatesEnum redfishReportUpdates =

--- a/redfish-core/lib/network_protocol.hpp
+++ b/redfish-core/lib/network_protocol.hpp
@@ -18,6 +18,7 @@
 #include "app.hpp"
 #include "dbus_utility.hpp"
 #include "error_messages.hpp"
+#include "generated/enums/resource.hpp"
 #include "query.hpp"
 #include "redfish_util.hpp"
 #include "registries/privilege_registry.hpp"
@@ -185,9 +186,9 @@ inline void getNetworkData(const std::shared_ptr<bmcweb::AsyncResp>& asyncResp,
     asyncResp->res.jsonValue["Id"] = "NetworkProtocol";
     asyncResp->res.jsonValue["Name"] = "Manager Network Protocol";
     asyncResp->res.jsonValue["Description"] = "Manager Network Service";
-    asyncResp->res.jsonValue["Status"]["Health"] = "OK";
-    asyncResp->res.jsonValue["Status"]["HealthRollup"] = "OK";
-    asyncResp->res.jsonValue["Status"]["State"] = "Enabled";
+    asyncResp->res.jsonValue["Status"]["Health"] = resource::Health::OK;
+    asyncResp->res.jsonValue["Status"]["HealthRollup"] = resource::Health::OK;
+    asyncResp->res.jsonValue["Status"]["State"] = resource::State::Enabled;
 
     // HTTP is Mandatory attribute as per OCP Baseline Profile - v1.0.0,
     // but from security perspective it is not recommended to use.

--- a/redfish-core/lib/pcie.hpp
+++ b/redfish-core/lib/pcie.hpp
@@ -18,6 +18,7 @@
 
 #include "app.hpp"
 #include "dbus_utility.hpp"
+#include "generated/enums/resource.hpp"
 #include "query.hpp"
 #include "registries/privilege_registry.hpp"
 #include "utils/collection.hpp"
@@ -165,39 +166,39 @@ inline void fillPcieDeviceStatus(crow::Response& resp,
     if (linkStatus ==
         "xyz.openbmc_project.Inventory.Item.PCIeSlot.Status.Operational")
     {
-        resp.jsonValue["Status"]["State"] = "Enabled";
-        resp.jsonValue["Status"]["Health"] = "OK";
+        resp.jsonValue["Status"]["State"] = resource::State::Enabled;
+        resp.jsonValue["Status"]["Health"] = resource::Health::OK;
         return;
     }
 
     if (linkStatus ==
         "xyz.openbmc_project.Inventory.Item.PCIeSlot.Status.Degraded")
     {
-        resp.jsonValue["Status"]["State"] = "Enabled";
-        resp.jsonValue["Status"]["Health"] = "Critical";
+        resp.jsonValue["Status"]["State"] = resource::State::Enabled;
+        resp.jsonValue["Status"]["Health"] = resource::Health::Critical;
         return;
     }
 
     if (linkStatus ==
         "xyz.openbmc_project.Inventory.Item.PCIeSlot.Status.Failed")
     {
-        resp.jsonValue["Status"]["State"] = "UnavailableOffline";
-        resp.jsonValue["Status"]["Health"] = "Warning";
+        resp.jsonValue["Status"]["State"] = resource::State::UnavailableOffline;
+        resp.jsonValue["Status"]["Health"] = resource::Health::Warning;
         return;
     }
 
     if (linkStatus ==
         "xyz.openbmc_project.Inventory.Item.PCIeSlot.Status.Inactive")
     {
-        resp.jsonValue["Status"]["State"] = "StandbyOffline";
-        resp.jsonValue["Status"]["Health"] = "OK";
+        resp.jsonValue["Status"]["State"] = resource::State::StandbyOffline;
+        resp.jsonValue["Status"]["Health"] = resource::Health::OK;
         return;
     }
 
     if (linkStatus == "xyz.openbmc_project.Inventory.Item.PCIeSlot.Status.Open")
     {
-        resp.jsonValue["Status"]["State"] = "Absent";
-        resp.jsonValue["Status"]["Health"] = "OK";
+        resp.jsonValue["Status"]["State"] = resource::State::Absent;
+        resp.jsonValue["Status"]["Health"] = resource::Health::OK;
         return;
     }
 }
@@ -633,8 +634,8 @@ inline void addPCIeDeviceCommonProperties(
                             BMCWEB_REDFISH_SYSTEM_URI_NAME, pcieDeviceId);
     asyncResp->res.jsonValue["Name"] = "PCIe Device";
     asyncResp->res.jsonValue["Id"] = pcieDeviceId;
-    asyncResp->res.jsonValue["Status"]["State"] = "Enabled";
-    asyncResp->res.jsonValue["Status"]["Health"] = "OK";
+    asyncResp->res.jsonValue["Status"]["State"] = resource::State::Enabled;
+    asyncResp->res.jsonValue["Status"]["Health"] = resource::Health::OK;
 }
 
 inline void afterGetValidPcieDevicePath(

--- a/redfish-core/lib/power.hpp
+++ b/redfish-core/lib/power.hpp
@@ -18,6 +18,7 @@
 
 #include "app.hpp"
 #include "dbus_utility.hpp"
+#include "generated/enums/power.hpp"
 #include "query.hpp"
 #include "registries/privilege_registry.hpp"
 #include "sensors.hpp"
@@ -277,7 +278,8 @@ inline void requestRoutesPower(App& app)
                 // LimitException is Mandatory attribute as per OCP
                 // Baseline Profile – v1.0.0, so currently making it
                 // "NoAction" as default value to make it OCP Compliant.
-                sensorJson["PowerLimit"]["LimitException"] = "NoAction";
+                sensorJson["PowerLimit"]["LimitException"] =
+                    power::PowerLimitException::NoAction;
 
                 if (enabled)
                 {

--- a/redfish-core/lib/power_subsystem.hpp
+++ b/redfish-core/lib/power_subsystem.hpp
@@ -3,6 +3,7 @@
 #include "app.hpp"
 #include "dbus_utility.hpp"
 #include "error_messages.hpp"
+#include "generated/enums/resource.hpp"
 #include "logging.hpp"
 #include "query.hpp"
 #include "registries/privilege_registry.hpp"
@@ -93,8 +94,8 @@ inline void doPowerSubsystemCollection(
     asyncResp->res.jsonValue["Id"] = "PowerSubsystem";
     asyncResp->res.jsonValue["@odata.id"] =
         boost::urls::format("/redfish/v1/Chassis/{}/PowerSubsystem", chassisId);
-    asyncResp->res.jsonValue["Status"]["State"] = "Enabled";
-    asyncResp->res.jsonValue["Status"]["Health"] = "OK";
+    asyncResp->res.jsonValue["Status"]["State"] = resource::State::Enabled;
+    asyncResp->res.jsonValue["Status"]["Health"] = resource::Health::OK;
     asyncResp->res.jsonValue["PowerSupplies"]["@odata.id"] =
         boost::urls::format(
             "/redfish/v1/Chassis/{}/PowerSubsystem/PowerSupplies", chassisId);

--- a/redfish-core/lib/power_supply.hpp
+++ b/redfish-core/lib/power_supply.hpp
@@ -2,6 +2,7 @@
 
 #include "app.hpp"
 #include "dbus_utility.hpp"
+#include "generated/enums/resource.hpp"
 #include "led.hpp"
 #include "query.hpp"
 #include "registries/privilege_registry.hpp"
@@ -226,7 +227,8 @@ inline void
 
         if (!value)
         {
-            asyncResp->res.jsonValue["Status"]["State"] = "Absent";
+            asyncResp->res.jsonValue["Status"]["State"] =
+                resource::State::Absent;
         }
         else if (!available)
         {
@@ -258,7 +260,8 @@ inline void
 
         if (!value || !available)
         {
-            asyncResp->res.jsonValue["Status"]["Health"] = "Critical";
+            asyncResp->res.jsonValue["Status"]["Health"] =
+                resource::Health::Critical;
         }
     });
 }
@@ -511,8 +514,8 @@ inline void
             "/redfish/v1/Chassis/{}/PowerSubsystem/PowerSupplies/{}", chassisId,
             powerSupplyId);
 
-        asyncResp->res.jsonValue["Status"]["State"] = "Enabled";
-        asyncResp->res.jsonValue["Status"]["Health"] = "OK";
+        asyncResp->res.jsonValue["Status"]["State"] = resource::State::Enabled;
+        asyncResp->res.jsonValue["Status"]["Health"] = resource::Health::OK;
 
         dbus::utility::getDbusObject(
             powerSupplyPath, powerSupplyInterface,

--- a/redfish-core/lib/processor.hpp
+++ b/redfish-core/lib/processor.hpp
@@ -20,6 +20,7 @@
 #include "dbus_utility.hpp"
 #include "error_messages.hpp"
 #include "generated/enums/processor.hpp"
+#include "generated/enums/resource.hpp"
 #include "led.hpp"
 #include "query.hpp"
 #include "registries/privilege_registry.hpp"
@@ -144,8 +145,8 @@ inline void getCpuDataByInterface(
     BMCWEB_LOG_DEBUG("Get CPU resources by interface.");
 
     // Set the default value of state
-    asyncResp->res.jsonValue["Status"]["State"] = "Enabled";
-    asyncResp->res.jsonValue["Status"]["Health"] = "OK";
+    asyncResp->res.jsonValue["Status"]["State"] = resource::State::Enabled;
+    asyncResp->res.jsonValue["Status"]["Health"] = resource::Health::OK;
 
     for (const auto& interface : cpuInterfacesProperties)
     {
@@ -163,7 +164,8 @@ inline void getCpuDataByInterface(
                 if (!*cpuPresent)
                 {
                     // Slot is not populated
-                    asyncResp->res.jsonValue["Status"]["State"] = "Absent";
+                    asyncResp->res.jsonValue["Status"]["State"] =
+                        resource::State::Absent;
                 }
             }
             else if (property.first == "Functional")
@@ -176,7 +178,8 @@ inline void getCpuDataByInterface(
                 }
                 if (!*cpuFunctional)
                 {
-                    asyncResp->res.jsonValue["Status"]["Health"] = "Critical";
+                    asyncResp->res.jsonValue["Status"]["Health"] =
+                        resource::Health::Critical;
                 }
             }
             else if (property.first == "CoreCount")
@@ -301,7 +304,8 @@ inline void getCpuDataByService(std::shared_ptr<bmcweb::AsyncResp> asyncResp,
         }
         asyncResp->res.jsonValue["Id"] = cpuId;
         asyncResp->res.jsonValue["Name"] = "Processor";
-        asyncResp->res.jsonValue["ProcessorType"] = "CPU";
+        asyncResp->res.jsonValue["ProcessorType"] =
+            processor::ProcessorType::CPU;
 
         bool slotPresent = false;
         std::string corePath = objPath + "/core";
@@ -609,7 +613,8 @@ inline void getAcceleratorDataByService(
         asyncResp->res.jsonValue["Name"] = "Processor";
         asyncResp->res.jsonValue["Status"]["State"] = state;
         asyncResp->res.jsonValue["Status"]["Health"] = health;
-        asyncResp->res.jsonValue["ProcessorType"] = "Accelerator";
+        asyncResp->res.jsonValue["ProcessorType"] =
+            processor::ProcessorType::Accelerator;
     });
 }
 

--- a/redfish-core/lib/sensors.hpp
+++ b/redfish-core/lib/sensors.hpp
@@ -18,8 +18,10 @@
 #include "app.hpp"
 #include "dbus_singleton.hpp"
 #include "dbus_utility.hpp"
+#include "generated/enums/redundancy.hpp"
 #include "generated/enums/resource.hpp"
 #include "generated/enums/sensor.hpp"
+#include "generated/enums/thermal.hpp"
 #include "query.hpp"
 #include "registries/privilege_registry.hpp"
 #include "str_utility.hpp"
@@ -711,13 +713,13 @@ inline void setLedState(nlohmann::json& sensorJson,
         switch (inventoryItem->ledState)
         {
             case LedState::OFF:
-                sensorJson["IndicatorLED"] = "Off";
+                sensorJson["IndicatorLED"] = resource::IndicatorLED::Off;
                 break;
             case LedState::ON:
-                sensorJson["IndicatorLED"] = "Lit";
+                sensorJson["IndicatorLED"] = resource::IndicatorLED::Lit;
                 break;
             case LedState::BLINK:
-                sensorJson["IndicatorLED"] = "Blinking";
+                sensorJson["IndicatorLED"] = resource::IndicatorLED::Blinking;
                 break;
             default:
                 break;
@@ -829,7 +831,7 @@ inline void objectPropertiesToJson(
     else if (sensorType == "fan" || sensorType == "fan_tach")
     {
         unit = "/Reading"_json_pointer;
-        sensorJson["ReadingUnits"] = "RPM";
+        sensorJson["ReadingUnits"] = thermal::ReadingUnits::RPM;
         sensorJson["@odata.type"] = "#Thermal.v1_3_0.Fan";
         setLedState(sensorJson, inventoryItem);
         forceToInt = true;
@@ -837,7 +839,7 @@ inline void objectPropertiesToJson(
     else if (sensorType == "fan_pwm")
     {
         unit = "/Reading"_json_pointer;
-        sensorJson["ReadingUnits"] = "Percent";
+        sensorJson["ReadingUnits"] = thermal::ReadingUnits::Percent;
         sensorJson["@odata.type"] = "#Thermal.v1_3_0.Fan";
         setLedState(sensorJson, inventoryItem);
         forceToInt = true;
@@ -1171,11 +1173,11 @@ inline void populateFanRedundancy(
                     redundancy["@odata.id"] = std::move(url);
                     redundancy["@odata.type"] = "#Redundancy.v1_3_2.Redundancy";
                     redundancy["MinNumNeeded"] = minNumNeeded;
-                    redundancy["Mode"] = "N+m";
+                    redundancy["Mode"] = redundancy::RedundancyType::NPlusM;
                     redundancy["Name"] = name;
                     redundancy["RedundancySet"] = redfishCollection;
                     redundancy["Status"]["Health"] = health;
-                    redundancy["Status"]["State"] = "Enabled";
+                    redundancy["Status"]["State"] = resource::State::Enabled;
 
                     jResp.emplace_back(std::move(redundancy));
                 });

--- a/redfish-core/lib/storage.hpp
+++ b/redfish-core/lib/storage.hpp
@@ -21,6 +21,7 @@
 #include "dbus_utility.hpp"
 #include "generated/enums/drive.hpp"
 #include "generated/enums/protocol.hpp"
+#include "generated/enums/resource.hpp"
 #include "human_sort.hpp"
 #include "query.hpp"
 #include "redfish_util.hpp"
@@ -179,7 +180,7 @@ inline void afterSystemsStorageGetSubtree(
                             BMCWEB_REDFISH_SYSTEM_URI_NAME, storageId);
     asyncResp->res.jsonValue["Name"] = "Storage";
     asyncResp->res.jsonValue["Id"] = storageId;
-    asyncResp->res.jsonValue["Status"]["State"] = "Enabled";
+    asyncResp->res.jsonValue["Status"]["State"] = resource::State::Enabled;
 
     getDrives(asyncResp);
     asyncResp->res.jsonValue["Controllers"]["@odata.id"] =
@@ -243,7 +244,7 @@ inline void afterSubtree(const std::shared_ptr<bmcweb::AsyncResp>& asyncResp,
         boost::urls::format("/redfish/v1/Storage/{}", storageId);
     asyncResp->res.jsonValue["Name"] = "Storage";
     asyncResp->res.jsonValue["Id"] = storageId;
-    asyncResp->res.jsonValue["Status"]["State"] = "Enabled";
+    asyncResp->res.jsonValue["Status"]["State"] = resource::State::Enabled;
 
     // Storage subsystem to Storage link.
     nlohmann::json::array_t storageServices;
@@ -361,7 +362,8 @@ inline void getDrivePresent(const std::shared_ptr<bmcweb::AsyncResp>& asyncResp,
 
         if (!isPresent)
         {
-            asyncResp->res.jsonValue["Status"]["State"] = "Absent";
+            asyncResp->res.jsonValue["Status"]["State"] =
+                resource::State::Absent;
         }
     });
 }
@@ -387,7 +389,8 @@ inline void getDriveState(const std::shared_ptr<bmcweb::AsyncResp>& asyncResp,
         // calls
         if (updating)
         {
-            asyncResp->res.jsonValue["Status"]["State"] = "Updating";
+            asyncResp->res.jsonValue["Status"]["State"] =
+                resource::State::Updating;
         }
     });
 }
@@ -682,7 +685,7 @@ inline void afterGetSubtreeSystemsStorageDrive(
     });
 
     // default it to Enabled
-    asyncResp->res.jsonValue["Status"]["State"] = "Enabled";
+    asyncResp->res.jsonValue["Status"]["State"] = resource::State::Enabled;
 
     addAllDriveInfo(asyncResp, connectionNames[0].first, path,
                     connectionNames[0].second);
@@ -867,7 +870,7 @@ inline void buildDrive(const std::shared_ptr<bmcweb::AsyncResp>& asyncResp,
         asyncResp->res.jsonValue["Name"] = driveName;
         asyncResp->res.jsonValue["Id"] = driveName;
         // default it to Enabled
-        asyncResp->res.jsonValue["Status"]["State"] = "Enabled";
+        asyncResp->res.jsonValue["Status"]["State"] = resource::State::Enabled;
 
         nlohmann::json::object_t linkChassisNav;
         linkChassisNav["@odata.id"] =
@@ -1033,7 +1036,7 @@ inline void populateStorageController(
                             BMCWEB_REDFISH_SYSTEM_URI_NAME, controllerId);
     asyncResp->res.jsonValue["Name"] = controllerId;
     asyncResp->res.jsonValue["Id"] = controllerId;
-    asyncResp->res.jsonValue["Status"]["State"] = "Enabled";
+    asyncResp->res.jsonValue["Status"]["State"] = resource::State::Enabled;
 
     sdbusplus::asio::getProperty<bool>(
         *crow::connections::systemBus, connectionName, path,
@@ -1048,7 +1051,8 @@ inline void populateStorageController(
         }
         if (!isPresent)
         {
-            asyncResp->res.jsonValue["Status"]["State"] = "Absent";
+            asyncResp->res.jsonValue["Status"]["State"] =
+                resource::State::Absent;
         }
     });
 

--- a/redfish-core/lib/systems.hpp
+++ b/redfish-core/lib/systems.hpp
@@ -20,7 +20,9 @@
 #include "app.hpp"
 #include "dbus_singleton.hpp"
 #include "dbus_utility.hpp"
+#include "generated/enums/action_info.hpp"
 #include "generated/enums/computer_system.hpp"
+#include "generated/enums/open_bmc_computer_system.hpp"
 #include "generated/enums/resource.hpp"
 #include "health.hpp"
 #include "hypervisor_system.hpp"
@@ -565,38 +567,46 @@ inline void getHostState(const std::shared_ptr<bmcweb::AsyncResp>& asyncResp)
         // Verify Host State
         if (hostState == "xyz.openbmc_project.State.Host.HostState.Running")
         {
-            asyncResp->res.jsonValue["PowerState"] = "On";
-            asyncResp->res.jsonValue["Status"]["State"] = "Enabled";
+            asyncResp->res.jsonValue["PowerState"] = resource::PowerState::On;
+            asyncResp->res.jsonValue["Status"]["State"] =
+                resource::State::Enabled;
         }
         else if (hostState ==
                  "xyz.openbmc_project.State.Host.HostState.Quiesced")
         {
-            asyncResp->res.jsonValue["PowerState"] = "On";
-            asyncResp->res.jsonValue["Status"]["State"] = "Quiesced";
+            asyncResp->res.jsonValue["PowerState"] = resource::PowerState::On;
+            asyncResp->res.jsonValue["Status"]["State"] =
+                resource::State::Quiesced;
         }
         else if (hostState ==
                  "xyz.openbmc_project.State.Host.HostState.DiagnosticMode")
         {
-            asyncResp->res.jsonValue["PowerState"] = "On";
-            asyncResp->res.jsonValue["Status"]["State"] = "InTest";
+            asyncResp->res.jsonValue["PowerState"] = resource::PowerState::On;
+            asyncResp->res.jsonValue["Status"]["State"] =
+                resource::State::InTest;
         }
         else if (
             hostState ==
             "xyz.openbmc_project.State.Host.HostState.TransitioningToRunning")
         {
-            asyncResp->res.jsonValue["PowerState"] = "PoweringOn";
-            asyncResp->res.jsonValue["Status"]["State"] = "Starting";
+            asyncResp->res.jsonValue["PowerState"] =
+                resource::PowerState::PoweringOn;
+            asyncResp->res.jsonValue["Status"]["State"] =
+                resource::State::Starting;
         }
         else if (hostState ==
                  "xyz.openbmc_project.State.Host.HostState.TransitioningToOff")
         {
-            asyncResp->res.jsonValue["PowerState"] = "PoweringOff";
-            asyncResp->res.jsonValue["Status"]["State"] = "Disabled";
+            asyncResp->res.jsonValue["PowerState"] =
+                resource::PowerState::PoweringOff;
+            asyncResp->res.jsonValue["Status"]["State"] =
+                resource::State::Disabled;
         }
         else
         {
-            asyncResp->res.jsonValue["PowerState"] = "Off";
-            asyncResp->res.jsonValue["Status"]["State"] = "Disabled";
+            asyncResp->res.jsonValue["PowerState"] = resource::PowerState::Off;
+            asyncResp->res.jsonValue["Status"]["State"] =
+                resource::State::Disabled;
         }
     });
 }
@@ -1025,11 +1035,13 @@ inline void
 
         if (value)
         {
-            asyncResp->res.jsonValue["Boot"]["StopBootOnFault"] = "AnyFault";
+            asyncResp->res.jsonValue["Boot"]["StopBootOnFault"] =
+                computer_system::StopBootOnFault::AnyFault;
         }
         else
         {
-            asyncResp->res.jsonValue["Boot"]["StopBootOnFault"] = "Never";
+            asyncResp->res.jsonValue["Boot"]["StopBootOnFault"] =
+                computer_system::StopBootOnFault::Never;
         }
     });
 }
@@ -1425,7 +1437,8 @@ inline void
         {
             BMCWEB_LOG_DEBUG("DBUS response error {}", ec);
             // not an error, don't have to have the interface
-            oemPFR["ProvisioningStatus"] = "NotProvisioned";
+            oemPFR["ProvisioningStatus"] = open_bmc_computer_system::
+                FirmwareProvisioningStatus::NotProvisioned;
             return;
         }
 
@@ -1453,16 +1466,19 @@ inline void
         {
             if (*lockState)
             {
-                oemPFR["ProvisioningStatus"] = "ProvisionedAndLocked";
+                oemPFR["ProvisioningStatus"] = open_bmc_computer_system::
+                    FirmwareProvisioningStatus::ProvisionedAndLocked;
             }
             else
             {
-                oemPFR["ProvisioningStatus"] = "ProvisionedButNotLocked";
+                oemPFR["ProvisioningStatus"] = open_bmc_computer_system::
+                    FirmwareProvisioningStatus::ProvisionedButNotLocked;
             }
         }
         else
         {
-            oemPFR["ProvisioningStatus"] = "NotProvisioned";
+            oemPFR["ProvisioningStatus"] = open_bmc_computer_system::
+                FirmwareProvisioningStatus::NotProvisioned;
         }
     });
 }
@@ -1871,7 +1887,7 @@ inline void
             asyncResp->res.jsonValue["HostWatchdogTimer"];
 
         // watchdog service is running/enabled
-        hostWatchdogTimer["Status"]["State"] = "Enabled";
+        hostWatchdogTimer["Status"]["State"] = resource::State::Enabled;
 
         const bool* enabled = nullptr;
         const std::string* expireAction = nullptr;
@@ -2751,7 +2767,8 @@ inline void
         "#ComputerSystem.v1_22_0.ComputerSystem";
     asyncResp->res.jsonValue["Name"] = BMCWEB_REDFISH_SYSTEM_URI_NAME;
     asyncResp->res.jsonValue["Id"] = BMCWEB_REDFISH_SYSTEM_URI_NAME;
-    asyncResp->res.jsonValue["SystemType"] = "Physical";
+    asyncResp->res.jsonValue["SystemType"] =
+        computer_system::SystemType::Physical;
     asyncResp->res.jsonValue["Description"] = "Computer System";
     asyncResp->res.jsonValue["ProcessorSummary"]["Count"] = 0;
     asyncResp->res.jsonValue["MemorySummary"]["TotalSystemMemoryGiB"] =
@@ -2788,8 +2805,8 @@ inline void
     manager["@odata.id"] = boost::urls::format("/redfish/v1/Managers/{}",
                                                BMCWEB_REDFISH_MANAGER_URI_NAME);
     asyncResp->res.jsonValue["Links"]["ManagedBy"] = std::move(managedBy);
-    asyncResp->res.jsonValue["Status"]["Health"] = "OK";
-    asyncResp->res.jsonValue["Status"]["State"] = "Enabled";
+    asyncResp->res.jsonValue["Status"]["Health"] = resource::Health::OK;
+    asyncResp->res.jsonValue["Status"]["State"] = resource::State::Enabled;
 
     // Fill in SerialConsole info
     asyncResp->res.jsonValue["SerialConsole"]["MaxConcurrentSessions"] = 15;
@@ -3166,7 +3183,7 @@ inline void afterGetAllowedHostTransitions(
     nlohmann::json::object_t parameter;
     parameter["Name"] = "ResetType";
     parameter["Required"] = true;
-    parameter["DataType"] = "String";
+    parameter["DataType"] = action_info::ParameterTypes::String;
     parameter["AllowableValues"] = std::move(allowableValues);
     nlohmann::json::array_t parameters;
     parameters.emplace_back(std::move(parameter));

--- a/redfish-core/lib/task.hpp
+++ b/redfish-core/lib/task.hpp
@@ -18,6 +18,8 @@
 #include "app.hpp"
 #include "dbus_utility.hpp"
 #include "event_service_manager.hpp"
+#include "generated/enums/resource.hpp"
+#include "generated/enums/task_service.hpp"
 #include "http/parsing.hpp"
 #include "query.hpp"
 #include "registries/privilege_registry.hpp"
@@ -477,11 +479,12 @@ inline void requestRoutesTaskService(App& app)
         asyncResp->res.jsonValue["Id"] = "TaskService";
         asyncResp->res.jsonValue["DateTime"] =
             redfish::time_utils::getDateTimeOffsetNow().first;
-        asyncResp->res.jsonValue["CompletedTaskOverWritePolicy"] = "Oldest";
+        asyncResp->res.jsonValue["CompletedTaskOverWritePolicy"] =
+            task_service::OverWritePolicy::Oldest;
 
         asyncResp->res.jsonValue["LifeCycleEventOnTaskStateChange"] = true;
 
-        asyncResp->res.jsonValue["Status"]["State"] = "Enabled";
+        asyncResp->res.jsonValue["Status"]["State"] = resource::State::Enabled;
         asyncResp->res.jsonValue["ServiceEnabled"] = true;
         asyncResp->res.jsonValue["Tasks"]["@odata.id"] =
             "/redfish/v1/TaskService/Tasks";

--- a/redfish-core/lib/telemetry_service.hpp
+++ b/redfish-core/lib/telemetry_service.hpp
@@ -2,6 +2,7 @@
 
 #include "app.hpp"
 #include "dbus_utility.hpp"
+#include "generated/enums/resource.hpp"
 #include "query.hpp"
 #include "registries/privilege_registry.hpp"
 #include "utils/dbus_utils.hpp"
@@ -43,7 +44,8 @@ inline void handleTelemetryServiceGet(
                     const dbus::utility::DBusPropertiesMap& ret) {
         if (ec == boost::system::errc::host_unreachable)
         {
-            asyncResp->res.jsonValue["Status"]["State"] = "Absent";
+            asyncResp->res.jsonValue["Status"]["State"] =
+                resource::State::Absent;
             return;
         }
         if (ec)
@@ -53,7 +55,7 @@ inline void handleTelemetryServiceGet(
             return;
         }
 
-        asyncResp->res.jsonValue["Status"]["State"] = "Enabled";
+        asyncResp->res.jsonValue["Status"]["State"] = resource::State::Enabled;
 
         const size_t* maxReports = nullptr;
         const uint64_t* minInterval = nullptr;

--- a/redfish-core/lib/thermal_subsystem.hpp
+++ b/redfish-core/lib/thermal_subsystem.hpp
@@ -1,6 +1,7 @@
 #pragma once
 
 #include "app.hpp"
+#include "generated/enums/resource.hpp"
 #include "logging.hpp"
 #include "query.hpp"
 #include "registries/privilege_registry.hpp"
@@ -46,8 +47,8 @@ inline void doThermalSubsystemCollection(
             "/redfish/v1/Chassis/{}/ThermalSubsystem/ThermalMetrics",
             chassisId);
 
-    asyncResp->res.jsonValue["Status"]["State"] = "Enabled";
-    asyncResp->res.jsonValue["Status"]["Health"] = "OK";
+    asyncResp->res.jsonValue["Status"]["State"] = resource::State::Enabled;
+    asyncResp->res.jsonValue["Status"]["Health"] = resource::Health::OK;
 }
 
 inline void handleThermalSubsystemCollectionHead(

--- a/redfish-core/lib/trigger.hpp
+++ b/redfish-core/lib/trigger.hpp
@@ -1,6 +1,7 @@
 #pragma once
 
 #include "app.hpp"
+#include "generated/enums/metric_definition.hpp"
 #include "generated/enums/resource.hpp"
 #include "generated/enums/triggers.hpp"
 #include "query.hpp"
@@ -886,7 +887,7 @@ inline bool fillTrigger(
             json["DiscreteTriggers"] = *discreteTriggers;
             json["DiscreteTriggerCondition"] =
                 discreteTriggers->empty() ? "Changed" : "Specified";
-            json["MetricType"] = "Discrete";
+            json["MetricType"] = metric_definition::MetricType::Discrete;
         }
         else
         {
@@ -902,7 +903,7 @@ inline bool fillTrigger(
             }
 
             json["NumericThresholds"] = *numericThresholds;
-            json["MetricType"] = "Numeric";
+            json["MetricType"] = metric_definition::MetricType::Numeric;
         }
     }
 

--- a/redfish-core/lib/update_service.hpp
+++ b/redfish-core/lib/update_service.hpp
@@ -964,14 +964,14 @@ inline void requestRoutesUpdateService(App& app)
             {
                 asyncResp->res.jsonValue["HttpPushUriOptions"]
                                         ["HttpPushUriApplyTime"]["ApplyTime"] =
-                    "Immediate";
+                    update_service::ApplyTime::Immediate;
             }
             else if (applyTime == "xyz.openbmc_project.Software.ApplyTime."
                                   "RequestedApplyTimes.OnReset")
             {
                 asyncResp->res.jsonValue["HttpPushUriOptions"]
                                         ["HttpPushUriApplyTime"]["ApplyTime"] =
-                    "OnReset";
+                    update_service::ApplyTime::OnReset;
             }
         });
     });
@@ -1228,7 +1228,8 @@ inline void requestRoutesSoftwareInventory(App& app)
             asyncResp->res.jsonValue["@odata.type"] =
                 "#SoftwareInventory.v1_1_0.SoftwareInventory";
             asyncResp->res.jsonValue["Name"] = "Software Inventory";
-            asyncResp->res.jsonValue["Status"]["HealthRollup"] = "OK";
+            asyncResp->res.jsonValue["Status"]["HealthRollup"] =
+                resource::Health::OK;
 
             asyncResp->res.jsonValue["Updateable"] = false;
             sw_util::getSwUpdatableStatus(asyncResp, swId);

--- a/redfish-core/lib/virtual_media.hpp
+++ b/redfish-core/lib/virtual_media.hpp
@@ -257,7 +257,7 @@ inline nlohmann::json vmItemTemplate(const std::string& name,
     item["WriteProtected"] = true;
     item["ConnectedVia"] = virtual_media::ConnectedVia::NotConnected;
     item["MediaTypes"] = nlohmann::json::array_t({"CD", "USBStick"});
-    item["TransferMethod"] = "Stream";
+    item["TransferMethod"] = virtual_media::TransferMethod::Stream;
     item["Oem"]["OpenBMC"]["@odata.type"] =
         "#OpenBMCVirtualMedia.v1_0_0.VirtualMedia";
     item["Oem"]["OpenBMC"]["@odata.id"] = boost::urls::format(


### PR DESCRIPTION
Cherry-pick merged commits, some merge conflicts had to be resolved:

1. https://gerrit.openbmc.org/c/openbmc/bmcweb/+/72225 - Consistently use generated enumerations
2. https://gerrit.openbmc.org/c/openbmc/bmcweb/+/73530 - chassis: fix power state regression

Tested:

- Redfish Service Validator - no new failures or warnings. Ran on Rainier hardware.