### PR TITLE
Add "GenerateSecretKeyRequired" registry in bmcweb 

### DIFF
--- a/redfish-core/include/error_messages.hpp
+++ b/redfish-core/include/error_messages.hpp
@@ -1128,6 +1128,24 @@ void arraySizeTooLong(crow::Response& res, std::string_view property,
 nlohmann::json restrictedRole(const std::string& arg1);
 
 void restrictedRole(crow::Response& res, const std::string& arg1);
+
+/**
+ * @brief Formats GenerateSecretKeyRequired message into JSON
+ * Message body: Secret key needs to be generated for the account before
+ * accessing the service. Account has to provide a time based OTP from the
+ * device configured with the secret key before access is granted. The secret
+ * key can be generated with a `POST` to the `GenerateSecretKey` action for
+ * the account located at the target URI '%1'.
+ *
+ * @param[in] arg1 Parameter of message that will replace %1 in its body.
+ *
+ * @returns Message GenerateSecretKeyRequired formatted to JSON */
+
+nlohmann::json
+    generateSecretKeyRequired(const boost::urls::url_view_base& arg1);
+
+void generateSecretKeyRequired(crow::Response& res,
+                               const boost::urls::url_view_base& arg1);
 } // namespace messages
 
 } // namespace redfish

--- a/redfish-core/lib/redfish_sessions.hpp
+++ b/redfish-core/lib/redfish_sessions.hpp
@@ -25,8 +25,11 @@
 #include "registries/privilege_registry.hpp"
 #include "utils/json_utils.hpp"
 
+#include <boost/system/error_code.hpp>
 #include <boost/url/format.hpp>
 
+#include <functional>
+#include <memory>
 #include <string>
 #include <vector>
 
@@ -197,6 +200,62 @@ inline void handleSessionCollectionMembersGet(
     asyncResp->res.jsonValue = getSessionCollectionMembers();
 }
 
+inline void processAfterSessionCreation(
+    const std::shared_ptr<bmcweb::AsyncResp>& asyncResp,
+    const crow::Request& req,
+    std::shared_ptr<persistent_data::UserSession> session,
+    bool isGenerateSecretkeyRequired)
+{
+    // When session is created by webui-vue give it session cookies as a
+    // non-standard Redfish extension. This is needed for authentication for
+    // WebSockets-based functionality.
+    if (!req.getHeaderValue("X-Requested-With").empty())
+    {
+        bmcweb::setSessionCookies(asyncResp->res, *session);
+    }
+    else
+    {
+        asyncResp->res.addHeader("X-Auth-Token", session->sessionToken);
+    }
+
+    boost::urls::url sessionUrl = boost::urls::format(
+        "/redfish/v1/SessionService/Sessions/{}", session->uniqueId);
+    asyncResp->res.addHeader("Location", sessionUrl.buffer());
+    asyncResp->res.result(boost::beast::http::status::created);
+    if (session->isConfigureSelfOnly)
+    {
+        boost::urls::url accountUri = boost::urls::format(
+            "/redfish/v1/AccountService/Accounts/{}", session->username);
+        if (!isGenerateSecretkeyRequired)
+        {
+            messages::passwordChangeRequired(asyncResp->res, accountUri);
+        }
+        else
+        {
+            messages::generateSecretKeyRequired(asyncResp->res, accountUri);
+        }
+    }
+
+    crow::getUserInfo(asyncResp, session->username, session,
+                      [asyncResp, session]() {
+        fillSessionObject(asyncResp->res, *session);
+    });
+}
+
+inline void checkGoogleAuthenticatorSecretKeyRequired(
+    const std::string& username,
+    std::function<void(const boost::system::error_code& ec, bool)> callback)
+{
+    sdbusplus::message::object_path userPath("/xyz/openbmc_project/user");
+    userPath /= username;
+    crow::connections::systemBus->async_method_call(
+        [callback = std::move(callback)](const boost::system::error_code& ec,
+                                         bool val) { callback(ec, val); },
+        "xyz.openbmc_project.User.Manager", userPath,
+        "xyz.openbmc_project.User.TOTPAuthenticator",
+        "IsGenerateSecretKeyRequired");
+}
+
 inline void handleSessionCollectionPost(
     crow::App& app, const crow::Request& req,
     const std::shared_ptr<bmcweb::AsyncResp>& asyncResp)
@@ -244,50 +303,45 @@ inline void handleSessionCollectionPost(
         return;
     }
 
-    // User is authenticated - create session
-    std::shared_ptr<persistent_data::UserSession> session =
-        persistent_data::SessionStore::getInstance().generateUserSession(
-            username, req.ipAddress, clientId,
-            persistent_data::SessionType::Session, isConfigureSelfOnly);
-    if (session == nullptr)
+    if (isConfigureSelfOnly)
     {
-        messages::internalError(asyncResp->res);
+        std::shared_ptr<persistent_data::UserSession> session =
+            persistent_data::SessionStore::getInstance().generateUserSession(
+                username, req.ipAddress, clientId,
+                persistent_data::SessionType::Session, true);
+        if (!session)
+        {
+            messages::internalError(asyncResp->res);
+            return;
+        }
+        // password change required in this path
+        processAfterSessionCreation(asyncResp, req, session, false);
         return;
     }
-
-    // When session is created by webui-vue give it session cookies as a
-    // non-standard Redfish extension. This is needed for authentication for
-    // WebSockets-based functionality.
-    if (!req.getHeaderValue("X-Requested-With").empty())
-    {
-        bmcweb::setSessionCookies(asyncResp->res, *session);
-    }
-    else
-    {
-        asyncResp->res.addHeader("X-Auth-Token", session->sessionToken);
-    }
-
-    asyncResp->res.addHeader(
-        "Location", "/redfish/v1/SessionService/Sessions/" + session->uniqueId);
-    asyncResp->res.result(boost::beast::http::status::created);
-
-    if constexpr (BMCWEB_AUDIT_EVENTS)
-    {
-        audit::auditEvent(req, std::string(username), true);
-    }
-
-    if (session->isConfigureSelfOnly)
-    {
-        messages::passwordChangeRequired(
-            asyncResp->res,
-            boost::urls::format("/redfish/v1/AccountService/Accounts/{}",
-                                session->username));
-    }
-
-    crow::getUserInfo(asyncResp, username, session, [asyncResp, session]() {
-        fillSessionObject(asyncResp->res, *session);
+    // check if secret key generation is required for the user
+    checkGoogleAuthenticatorSecretKeyRequired(
+        username, [username, asyncResp, req, clientId = std::move(clientId)](
+                      const boost::system::error_code& ec, bool required) {
+        if (ec)
+        {
+            BMCWEB_LOG_ERROR("secretKeyRequired check failed = {}",
+                             ec.message());
+            messages::internalError(asyncResp->res);
+            return;
+        }
+        std::shared_ptr<persistent_data::UserSession> session =
+            persistent_data::SessionStore::getInstance().generateUserSession(
+                username, req.ipAddress, clientId,
+                persistent_data::SessionType::Session, required);
+        if (!session)
+        {
+            messages::internalError(asyncResp->res);
+            return;
+        }
+        processAfterSessionCreation(asyncResp, req, session, required);
     });
 }
+
 inline void handleSessionServiceHead(
     crow::App& app, const crow::Request& req,
     const std::shared_ptr<bmcweb::AsyncResp>& asyncResp)

--- a/redfish-core/src/error_messages.cpp
+++ b/redfish-core/src/error_messages.cpp
@@ -1927,7 +1927,7 @@ void restrictedRole(crow::Response& res, const std::string& arg1)
     addMessageToErrorJson(res.jsonValue, restrictedRole(arg1));
 }
 
-ohmann::json generateSecretKeyRequired(const boost::urls::url_view_base& arg1)
+nlohmann::json generateSecretKeyRequired(const boost::urls::url_view_base& arg1)
 {
     return getLog(redfish::registries::base::Index::generateSecretKeyRequired,
                   std::to_array<std::string_view>({arg1.buffer()}));

--- a/redfish-core/src/error_messages.cpp
+++ b/redfish-core/src/error_messages.cpp
@@ -1927,6 +1927,26 @@ void restrictedRole(crow::Response& res, const std::string& arg1)
     addMessageToErrorJson(res.jsonValue, restrictedRole(arg1));
 }
 
+ohmann::json generateSecretKeyRequired(const boost::urls::url_view_base& arg1)
+{
+    return getLog(redfish::registries::base::Index::generateSecretKeyRequired,
+                  std::to_array<std::string_view>({arg1.buffer()}));
+}
+
+/**
+ * @internal
+ * @brief Formats GenerateSecretKeyRequired message into JSON
+ *
+ * See header file for more information
+ * @endinternal
+ */
+void generateSecretKeyRequired(crow::Response& res,
+                               const boost::urls::url_view_base& arg1)
+{
+    messages::addMessageToJsonRoot(res.jsonValue,
+                                   generateSecretKeyRequired(arg1));
+}
+
 } // namespace messages
 
 } // namespace redfish


### PR DESCRIPTION
This commit adds the GenerateSecretKeyRequired to the bmcweb registry
which will indicate if the MFA is enabled and if the user has to
authenticate with TOTP configuring the secret key generated in a
device the user posses.

Tested by:

Enable MFA and try to create a session,

Response:

{
  "@Message.ExtendedInfo": [
    {
      "@odata.type": "#Message.v1_1_1.Message",
      "Message": "The Time-based One-Time Password (TOTP) secret key
for this account must be generated before access is granted. Perform
the GenerateSecretKey action at URI
'/redfish/v1/AccountService/Accounts/service' and retain the secret
key from the response.",
      "MessageArgs": [
        "/redfish/v1/AccountService/Accounts/service"
      ],
      "MessageId": "Base.1.19.0.GenerateSecretKeyRequired",
      "MessageSeverity": "Critical",
      "Resolution": "Generate secret key for this account by performing
the `GenerateSecretKey` action on the referenced URI and retaining the
secret key from the action response to produce a Time-based One-Time
Password (TOTP) for the `Token` property in future session creation
requests."
    }
  ],
  "@odata.id": "/redfish/v1/SessionService/Sessions/neSLpiOFJz",
  "@odata.type": "#Session.v1_5_0.Session",
  "ClientOriginIPAddress": <ip>,
  "Description": "Manager User Session",
  "Id": "neSLpiOFJz",
  "Name": "User Session",
  "UserName": <user>
  
  upstream : https://gerrit.openbmc.org/c/openbmc/bmcweb/+/74938
   https://gerrit.openbmc.org/c/openbmc/bmcweb/+/75339

Change-Id: Icfeb7486ae76d436a73afde51b0158b369a62ad0
Signed-off-by: Jishnu CM <jishnunambiarcm@duck.com>