### PR TITLE
1110 Sensors: Add SpeedRPM property

### DIFF
--- a/Redfish.md
+++ b/Redfish.md
@@ -272,6 +272,7 @@ Fields common to all schemas
 - ReadingRangeMin
 - ReadingType
 - ReadingUnits
+- SpeedRPM
 - Status
 - Thresholds
 

--- a/redfish-core/include/utils/sensor_utils.hpp
+++ b/redfish-core/include/utils/sensor_utils.hpp
@@ -509,7 +509,6 @@ inline void objectPropertiesToJson(
     std::vector<
         std::tuple<const char*, const char*, nlohmann::json::json_pointer>>
         properties;
-    properties.reserve(7);
 
     properties.emplace_back("xyz.openbmc_project.Sensor.Value", "Value", unit);
 
@@ -527,6 +526,13 @@ inline void objectPropertiesToJson(
         properties.emplace_back(
             "xyz.openbmc_project.Sensor.Threshold.Critical", "CriticalLow",
             "/Thresholds/LowerCritical/Reading"_json_pointer);
+
+        /* Add additional properties specific to sensorType */
+        if (sensorType == "fan_tach")
+        {
+            properties.emplace_back("xyz.openbmc_project.Sensor.Value", "Value",
+                                    "/SpeedRPM"_json_pointer);
+        }
     }
     else if (sensorType != "power")
     {


### PR DESCRIPTION
Cherry-pick upstream commit: https://gerrit.openbmc.org/c/openbmc/bmcweb/+/73700

Changes here are to add support for Redfish for Thermal Equipment[1].

Add the SpeedRPM property for a Rotational fan sensor. This property is part of the Redfish Sensor schema since version 1_2_0.[2]

This change is so we will always have a property with the RPM. This allows a client (e.g. webui-vue) to always look for the SpeedRPM property.

Note: Redfish defines the Reading property for a fan to be a percentage value. Currently for this type of fan sensor the Reading value is being set to the RPM value. To preserve backwards compatibility the SpeedRPM property is added without altering the Reading value. However this may change in the future to match the expected Redfish implementation. Clients are advised to use the new SpeedRPM value to assure continuing correct function.

[1] https://www.dmtf.org/sites/default/files/standards/documents/DSP2064_1.0.0.pdf
[2] http://redfish.dmtf.org/schemas/v1/Sensor.v1_10_0.json#/definitions/Sensor

Implementation Note: The objectPropertiesToJson() has existing  else if(sensorType ==) statements. However because the first if() statement is looking at the chassisSubNode these are never visited for sensors when using the
/redfish/v1/Chassis/<chassisId>/Sensors/<sensorName> URI. Those existing sensorType comparisons are used for the redfish-allow-deprecated-power-thermal Redfish interfaces.

```
$ curl -k -H "X-Auth-Token: $token" https://${bmc}/redfish/v1/Chassis/chassis/Sensors/fantach_fan1_0
{
  "@odata.id": "/redfish/v1/Chassis/chassis/Sensors/fantach_fan1_0",
  "@odata.type": "#Sensor.v1_2_0.Sensor",
  "Id": "fantach_fan1_0",
  "Name": "fan1 0",
  "Reading": 18000.0,
  "ReadingType": "Rotational",
  "ReadingUnits": "RPM",
  "SpeedRPM": 18000.0,
  "Status": {
    "Health": "OK",
    "State": "Enabled"
  }
}
```

Tested:
- Redfish Validator passes

Change-Id: Icd39fd70d4a24aafab0d9b66fa09c000b97b3199