### PR TITLE
mfa: Add right AccountService schema version

### DIFF
--- a/redfish-core/lib/account_service.hpp
+++ b/redfish-core/lib/account_service.hpp
@@ -1662,8 +1662,7 @@ inline void
 
     nlohmann::json& json = asyncResp->res.jsonValue;
     json["@odata.id"] = "/redfish/v1/AccountService";
-    json["@odata.type"] = "#AccountService."
-                          "v1_10_0.AccountService";
+    json["@odata.type"] = "#AccountService.v1_15_0.AccountService";
     json["Id"] = "AccountService";
     json["Name"] = "Account Service";
     json["Description"] = "Account Service";
@@ -2351,49 +2350,48 @@ inline void
                         }
                     }
                 }
-                if (interface.first ==
-                    "xyz.openbmc_project.User.TOTPAuthenticator")
+            }
+            if (interface.first == "xyz.openbmc_project.User.TOTPAuthenticator")
+            {
+                for (const auto& property : interface.second)
                 {
-                    for (const auto& property : interface.second)
+                    if (property.first == "BypassedProtocol")
                     {
-                        if (property.first == "BypassedProtocol")
-                        {
-                            const std::string* bypassedProtocol =
-                                std::get_if<std::string>(&property.second);
+                        const std::string* bypassedProtocol =
+                            std::get_if<std::string>(&property.second);
 
-                            if (bypassedProtocol == nullptr)
-                            {
-                                BMCWEB_LOG_ERROR(
-                                    "BypassedProtocol Value fetch faile");
-                                messages::internalError(asyncResp->res);
-                                return;
-                            }
-                            nlohmann::json& mfaBypassArray =
-                                asyncResp->res
-                                    .jsonValue["MFABypass"]["BypassTypes"];
-                            mfaBypassArray = nlohmann::json::array();
-
-                            constexpr std::string_view mfaGoogleAuthDbusVal =
-                                "xyz.openbmc_project.User.MultiFactorAuthConfiguration.Type.GoogleAuthenticator";
-                            if (*bypassedProtocol == mfaGoogleAuthDbusVal)
-                            {
-                                mfaBypassArray.push_back("GoogleAuthenticator");
-                            }
-                        }
-                        if (property.first == "SecretKeyIsValid")
+                        if (bypassedProtocol == nullptr)
                         {
-                            const bool* secretKeySet =
-                                std::get_if<bool>(&property.second);
-                            if (secretKeySet == nullptr)
-                            {
-                                BMCWEB_LOG_ERROR(
-                                    "SecretKeyIsValid value fetch failed");
-                                messages::internalError(asyncResp->res);
-                                return;
-                            }
-                            asyncResp->res.jsonValue["SecretKeySet"] =
-                                *secretKeySet;
+                            BMCWEB_LOG_ERROR(
+                                "BypassedProtocol Value fetch faile");
+                            messages::internalError(asyncResp->res);
+                            return;
                         }
+                        nlohmann::json& mfaBypassArray =
+                            asyncResp->res
+                                .jsonValue["MFABypass"]["BypassTypes"];
+                        mfaBypassArray = nlohmann::json::array();
+
+                        constexpr std::string_view mfaGoogleAuthDbusVal =
+                            "xyz.openbmc_project.User.MultiFactorAuthConfiguration.Type.GoogleAuthenticator";
+                        if (*bypassedProtocol == mfaGoogleAuthDbusVal)
+                        {
+                            mfaBypassArray.push_back("GoogleAuthenticator");
+                        }
+                    }
+                    if (property.first == "SecretKeyIsValid")
+                    {
+                        const bool* secretKeySet =
+                            std::get_if<bool>(&property.second);
+                        if (secretKeySet == nullptr)
+                        {
+                            BMCWEB_LOG_ERROR(
+                                "SecretKeyIsValid value fetch failed");
+                            messages::internalError(asyncResp->res);
+                            return;
+                        }
+                        asyncResp->res.jsonValue["SecretKeySet"] =
+                            *secretKeySet;
                     }
                 }
             }


### PR DESCRIPTION
This commit adds the correct AccountService schema version (AccountService_v1_15_0.*) and fixes the redfish validator failure. It also fixes a bug where "MFABypass" user-level option was not displayed in the redfish response.

Upstream: https://gerrit.openbmc.org/c/openbmc/bmcweb/+/74667

Tested By:
[1] GET https://${bmc}/redfish/v1/AccountService/Accounts/testmfaadminA

Redfish Validator passed.

Change-Id: I406e7113c3b6ceae9396bb5d9f0d9249299d6267

