### PR TITLE
Fix snmp port out of range

### DIFF
--- a/redfish-core/lib/event_service.hpp
+++ b/redfish-core/lib/event_service.hpp
@@ -341,6 +341,14 @@ inline void requestRoutesEventDestinationCollection(App& app)
             return;
         }
         url->normalize();
+        if (url->has_port() && url->port_number() == 0)
+        {
+            BMCWEB_LOG_WARNING("Invalid port in destination url");
+            messages::propertyValueFormatError(asyncResp->res, destUrl,
+                                               "Destination");
+            return;
+        }
+
         crow::utility::setProtocolDefaults(*url, protocol);
         crow::utility::setPortDefaults(*url);
 


### PR DESCRIPTION
SNMP out of range port doesn't works, it should throw HTTPS 400 error It went ahead and configures it, with default port which is not the correct behaviour.

Fixes: https://github.com/ibm-openbmc/dev/issues/3643

Tested: If the snmp port is out of range, a 400 error will be thrown.
```
p10$ curl --header "Content-Type: application/json" X POST -i -k -u service:0penBmc https://{bmc}/redfish/v1/EventService/Subscriptions --data-raw '{"Destination": "snmp://xx.xx.xx.76:65537","SubscriptionType": "SNMPTrap", "Protocol": "SNMPv2c"}' -vv
Note: Unnecessary use of -X or --request, POST is already inferred.
*   Trying 127.0.0.1:2443...
* Connected to 127.0.0.1 (127.0.0.1) port 2443 (#0)
* ALPN, offering h2
* ALPN, offering http/1.1
* TLSv1.0 (OUT), TLS header, Certificate Status (22):
* TLSv1.3 (OUT), TLS handshake, Client hello (1):
* TLSv1.2 (IN), TLS header, Certificate Status (22):
* TLSv1.3 (IN), TLS handshake, Server hello (2):
* TLSv1.2 (IN), TLS header, Finished (20):
* TLSv1.2 (IN), TLS header, Supplemental data (23):
* TLSv1.3 (IN), TLS handshake, Encrypted Extensions (8):
* TLSv1.2 (IN), TLS header, Supplemental data (23):
* TLSv1.3 (IN), TLS handshake, Certificate (11):
* TLSv1.2 (IN), TLS header, Supplemental data (23):
* TLSv1.3 (IN), TLS handshake, CERT verify (15):
* TLSv1.2 (IN), TLS header, Supplemental data (23):
* TLSv1.3 (IN), TLS handshake, Finished (20):
* TLSv1.2 (OUT), TLS header, Finished (20):
* TLSv1.3 (OUT), TLS change cipher, Change cipher spec (1):
* TLSv1.2 (OUT), TLS header, Supplemental data (23):
* TLSv1.3 (OUT), TLS handshake, Finished (20):
* SSL connection using TLSv1.3 / TLS_AES_256_GCM_SHA384
* ALPN, server did not agree to a protocol
* Server certificate:
*  subject: C=US; O=OpenBMC; CN=testhost
*  start date: Dec 15 15:38:14 2023 GMT
*  expire date: Dec 12 15:38:14 2033 GMT
*  issuer: C=US; O=OpenBMC; CN=testhost
*  SSL certificate verify result: self-signed certificate (18), continuing anyway.
* Server auth using Basic with user 'service'
* TLSv1.2 (OUT), TLS header, Supplemental data (23):
> POST /redfish/v1/EventService/Subscriptions HTTP/1.1
> Host: 127.0.0.1:2443
> Authorization: Basic c2VydmljZTowcGVuQm1j
> User-Agent: curl/7.81.0
> Accept: */*
> Content-Type: application/json
> Content-Length: 97
>
* TLSv1.2 (IN), TLS header, Supplemental data (23):
* TLSv1.3 (IN), TLS handshake, Newsession Ticket (4):
* TLSv1.2 (IN), TLS header, Supplemental data (23):
* TLSv1.3 (IN), TLS handshake, Newsession Ticket (4):
* old SSL session ID is stale, removing
* TLSv1.2 (IN), TLS header, Supplemental data (23):
* Mark bundle as not supporting multiuse
< HTTP/1.1 400 Bad Request
HTTP/1.1 400 Bad Request
< Allow: GET, POST
Allow: GET, POST
< OData-Version: 4.0
OData-Version: 4.0
< Strict-Transport-Security: max-age=31536000; includeSubdomains
Strict-Transport-Security: max-age=31536000; includeSubdomains
< X-Frame-Options: DENY
X-Frame-Options: DENY
< Pragma: no-cache
Pragma: no-cache
< Cache-Control: no-store, max-age=0
Cache-Control: no-store, max-age=0
< X-Content-Type-Options: nosniff
X-Content-Type-Options: nosniff
< Referrer-Policy: no-referrer
Referrer-Policy: no-referrer
< Permissions-Policy: accelerometer=(),ambient-light-sensor=(),autoplay=(),battery=(),camera=(),display-capture=(),document-domain=(),encrypted-media=(),fullscreen=(),gamepad=(),geolocation=(),gyroscope=(),layout-animations=(self),legacy-image-formats=(self),magnetometer=(),microphone=(),midi=(),oversized-images=(self),payment=(),picture-in-picture=(),publickey-credentials-get=(),speaker-selection=(),sync-xhr=(self),unoptimized-images=(self),unsized-media=(self),usb=(),screen-wak-lock=(),web-share=(),xr-spatial-tracking=()
Permissions-Policy: accelerometer=(),ambient-light-sensor=(),autoplay=(),battery=(),camera=(),display-capture=(),document-domain=(),encrypted-media=(),fullscreen=(),gamepad=(),geolocation=(),gyroscope=(),layout-animations=(self),legacy-image-formats=(self),magnetometer=(),microphone=(),midi=(),oversized-images=(self),payment=(),picture-in-picture=(),publickey-credentials-get=(),speaker-selection=(),sync-xhr=(self),unoptimized-images=(self),unsized-media=(self),usb=(),screen-wak-lock=(),web-share=(),xr-spatial-tracking=()
* TLSv1.2 (IN), TLS header, Supplemental data (23):
< X-Permitted-Cross-Domain-Policies: none
X-Permitted-Cross-Domain-Policies: none
< Cross-Origin-Embedder-Policy: require-corp
Cross-Origin-Embedder-Policy: require-corp
< Cross-Origin-Opener-Policy: same-origin
Cross-Origin-Opener-Policy: same-origin
< Cross-Origin-Resource-Policy: same-origin
Cross-Origin-Resource-Policy: same-origin
< Content-Security-Policy: default-src 'none'; img-src 'self' data:; font-src 'self'; style-src 'self'; script-src 'self'; connect-src 'self' wss:; form-action 'none'; frame-ancestors 'none'; object-src 'none'; base-uri 'none'
Content-Security-Policy: default-src 'none'; img-src 'self' data:; font-src 'self'; style-src 'self'; script-src 'self'; connect-src 'self' wss:; form-action 'none'; frame-ancestors 'none'; object-src 'none'; base-uri 'none'
< Content-Type: application/json
Content-Type: application/json
< Date: Fri, 15 Dec 2023 15:54:16 GMT
Date: Fri, 15 Dec 2023 15:54:16 GMT
< Content-Length: 568
Content-Length: 568

<
{
  "Destination@Message.ExtendedInfo": [
    {
      "@odata.type": "#Message.v1_1_1.Message",
      "Message": "The value '\"snmp://xx.xx.xx.76:65537\"' for the property Destination is of a different format than the property can accept.",
      "MessageArgs": [
        "\"snmp://xx.xx.xx.76:65537\"",
        "Destination"
      ],
      "MessageId": "Base.1.16.0.PropertyValueFormatError",
      "MessageSeverity": "Warning",
      "Resolution": "Correct the value for the property in the request body and resubmit the request if the operation failed."
    }
  ]
* Connection #0 to host 127.0.0.1 left intact
}
```