### PR TITLE
1110: Implement TemperatureReadingsCelsius property for ThermalMetrics

### DIFF
--- a/Redfish.md
+++ b/Redfish.md
@@ -338,8 +338,9 @@ Fields common to all schemas
 
 ##### ThermalMetrics
 
-- TemperatureReadingsCelsius/DataSourceUri
-- TemperatureReadingsCelsius/Reading
+- TemperatureReadingsCelsius[]/DataSourceUri
+- TemperatureReadingsCelsius[]/Reading
+- TemperatureReadingsCelsius@odata.count
 
 #### /redfish/v1/Chassis/{ChassisId}/ThermalSubsystem/Fans
 

--- a/redfish-core/lib/thermal_metrics.hpp
+++ b/redfish-core/lib/thermal_metrics.hpp
@@ -6,85 +6,98 @@
 #include "registries/privilege_registry.hpp"
 #include "sensors.hpp"
 #include "utils/chassis_utils.hpp"
+#include "utils/json_utils.hpp"
+#include "utils/sensor_utils.hpp"
 
 #include <boost/system/error_code.hpp>
 #include <boost/url/format.hpp>
 
+#include <array>
 #include <functional>
 #include <memory>
 #include <optional>
 #include <string>
+#include <string_view>
 
 namespace redfish
 {
 inline void afterGetTemperatureValue(
     const std::shared_ptr<bmcweb::AsyncResp>& asyncResp,
     const std::string& chassisId, const std::string& path,
-    const boost::system::error_code& ec, double val)
+    const boost::system::error_code& ec,
+    const dbus::utility::DBusPropertiesMap& valuesDict)
 {
     if (ec)
     {
         if (ec.value() != EBADR)
         {
-            BMCWEB_LOG_ERROR("handleTemperatureReadingsCelsius() failed: {}",
+            BMCWEB_LOG_ERROR("DBUS response error for getAllProperties {}",
                              ec.value());
             messages::internalError(asyncResp->res);
         }
         return;
     }
 
-    std::string sensorName = sdbusplus::message::object_path(path).filename();
-    nlohmann::json& temperatureArray =
-        asyncResp->res.jsonValue["TemperatureReadingsCelsius"];
+    nlohmann::json item = nlohmann::json::object();
 
-    nlohmann::json::object_t item;
-    item["@odata.id"] = boost::urls::format("/redfish/v1/Chassis/{}/Sensors/{}",
-                                            chassisId, sensorName);
-    item["DataSourceUri"] = boost::urls::format(
-        "/redfish/v1/Chassis/{}/Sensors/{}", chassisId, sensorName);
-    item["Reading"] = val;
+    /* Don't return an error for a failure to fill in properties from any of
+     * the sensors in the list. Just skip it.
+     */
+    if (sensor_utils::objectExcerptToJson(
+            path, chassisId, sensor_utils::ChassisSubNode::thermalMetricsNode,
+            "temperature", valuesDict, item))
+    {
+        nlohmann::json& temperatureReadings =
+            asyncResp->res.jsonValue["TemperatureReadingsCelsius"];
+        nlohmann::json::array_t* temperatureArray =
+            temperatureReadings.get_ptr<nlohmann::json::array_t*>();
+        if (temperatureArray == nullptr)
+        {
+            BMCWEB_LOG_ERROR("Missing TemperatureReadingsCelsius Json array");
+            messages::internalError(asyncResp->res);
+            return;
+        }
 
-    temperatureArray.emplace_back(std::move(item));
+        temperatureArray->emplace_back(std::move(item));
+        asyncResp->res.jsonValue["TemperatureReadingsCelsius@odata.count"] =
+            temperatureArray->size();
+
+        json_util::sortJsonArrayByKey(*temperatureArray, "DataSourceUri");
+    }
 }
 
 inline void handleTemperatureReadingsCelsius(
     const std::shared_ptr<bmcweb::AsyncResp>& asyncResp,
-    const dbus::utility::MapperGetSubTreeResponse& subtree,
-    const std::string& chassisId)
-{
-    for (const auto& [path, serviceMap] : subtree)
-    {
-        for (const auto& [service, interfaces] : serviceMap)
-        {
-            sdbusplus::asio::getProperty<double>(
-                *crow::connections::systemBus, service, path,
-                "xyz.openbmc_project.Sensor.Value", "Value",
-                std::bind_front(afterGetTemperatureValue, asyncResp, chassisId,
-                                path));
-        }
-    }
-}
-
-inline void afterGetAssociatedSubTree(
-    const std::shared_ptr<bmcweb::AsyncResp>& asyncResp,
     const std::string& chassisId, const boost::system::error_code& ec,
-    const dbus::utility::MapperGetSubTreeResponse& objects)
+    const sensor_utils::SensorServicePathList& sensorsServiceAndPath)
 {
-    if (ec == boost::system::errc::io_error)
-    {
-        asyncResp->res.jsonValue["TemperatureReadingsCelsius"] =
-            nlohmann::json::array();
-        return;
-    }
-
     if (ec)
     {
-        BMCWEB_LOG_ERROR("DBUS response error {}", ec.value());
-        messages::internalError(asyncResp->res);
+        if (ec.value() != EBADR)
+        {
+            BMCWEB_LOG_ERROR("DBUS response error for getAssociatedSubTree {}",
+                             ec.value());
+            messages::internalError(asyncResp->res);
+        }
         return;
     }
 
-    handleTemperatureReadingsCelsius(asyncResp, objects, chassisId);
+    asyncResp->res.jsonValue["TemperatureReadingsCelsius"] =
+        nlohmann::json::array_t();
+    asyncResp->res.jsonValue["TemperatureReadingsCelsius@odata.count"] = 0;
+
+    for (const auto& [service, sensorPath] : sensorsServiceAndPath)
+    {
+        sdbusplus::asio::getAllProperties(
+            *crow::connections::systemBus, service, sensorPath,
+            "xyz.openbmc_project.Sensor.Value",
+            [asyncResp, chassisId,
+             sensorPath](const boost::system::error_code& ec1,
+                         const dbus::utility::DBusPropertiesMap& properties) {
+            afterGetTemperatureValue(asyncResp, chassisId, sensorPath, ec1,
+                                     properties);
+        });
+    }
 }
 
 inline void getTemperatureReadingsCelsius(
@@ -94,15 +107,11 @@ inline void getTemperatureReadingsCelsius(
     constexpr std::array<std::string_view, 1> interfaces = {
         "xyz.openbmc_project.Sensor.Value"};
 
-    sdbusplus::message::object_path endpointPath{validChassisPath};
-    endpointPath /= "all_sensors";
-
-    dbus::utility::getAssociatedSubTree(
-        endpointPath,
-        sdbusplus::message::object_path(
-            "/xyz/openbmc_project/sensors/temperature"),
-        1, interfaces,
-        std::bind_front(afterGetAssociatedSubTree, asyncResp, chassisId));
+    sensor_utils::getAllSensorObjects(
+        validChassisPath, "/xyz/openbmc_project/sensors/temperature",
+        interfaces, 1,
+        std::bind_front(handleTemperatureReadingsCelsius, asyncResp,
+                        chassisId));
 }
 
 inline void

--- a/test/redfish-core/include/utils/sensor_utils_test.cpp
+++ b/test/redfish-core/include/utils/sensor_utils_test.cpp
@@ -61,6 +61,9 @@ TEST(ChassisSubNodeToString, Success)
     subNodeStr = chassisSubNodeToString(ChassisSubNode::thermalNode);
     EXPECT_EQ(subNodeStr, "Thermal");
 
+    subNodeStr = chassisSubNodeToString(ChassisSubNode::thermalMetricsNode);
+    EXPECT_EQ(subNodeStr, "ThermalMetrics");
+
     subNodeStr = chassisSubNodeToString(ChassisSubNode::unknownNode);
     EXPECT_EQ(subNodeStr, "");
 }
@@ -78,11 +81,27 @@ TEST(ChassisSubNodeFromString, Success)
     subNode = chassisSubNodeFromString("Thermal");
     EXPECT_EQ(subNode, ChassisSubNode::thermalNode);
 
+    subNode = chassisSubNodeFromString("ThermalMetrics");
+    EXPECT_EQ(subNode, ChassisSubNode::thermalMetricsNode);
+
     subNode = chassisSubNodeFromString("BadNode");
     EXPECT_EQ(subNode, ChassisSubNode::unknownNode);
 
     subNode = chassisSubNodeFromString("");
     EXPECT_EQ(subNode, ChassisSubNode::unknownNode);
+}
+
+TEST(IsExcerptNode, True)
+{
+    EXPECT_TRUE(isExcerptNode(ChassisSubNode::thermalMetricsNode));
+}
+
+TEST(IsExcerptNode, False)
+{
+    EXPECT_FALSE(isExcerptNode(ChassisSubNode::sensorsNode));
+    EXPECT_FALSE(isExcerptNode(ChassisSubNode::powerNode));
+    EXPECT_FALSE(isExcerptNode(ChassisSubNode::thermalNode));
+    EXPECT_FALSE(isExcerptNode(ChassisSubNode::unknownNode));
 }
 
 } // namespace


### PR DESCRIPTION
Cherry-picked upstream commit and resolved merge conflicts:
 - https://gerrit.openbmc.org/c/openbmc/bmcweb/+/65286

Change-Id: I6e4ed1f281fd5371c978983b6cc5666badd3752c

Note: TemperatureReadingsCelsius for ThermalMetrics was already implemented downstream. This commit is a rebase that aligns the implementation with upstream. This does result in some semantic differences with the current downstream implementation:

1. @odata.id is no longer part of TemperatureReadingsCelsius array element per Redfish spec.
2. DataSourceUri is corrected to be existing Redfish Uri for associated sensor.
3. The sort of TemperatureReadingsCelsius  array elements now uses the human sort. This results in a consistent sort.
4. @odata.count added for TemperatureReadingsCelsius  array.

Tested:
 - Redfish service validator - Run on Rainier hardware with no new failures
 - Compared output before and after change on Rainier hardware. Differences noted above.

Old implementation output:
```
$ curl -k -H "X-Auth-Token: ${token}" -X GET https://${bmc}/redfish/v1/Chassis/chassis/ThermalSubsystem/ThermalMetrics
{
  "@odata.id": "/redfish/v1/Chassis/chassis/ThermalSubsystem/ThermalMetrics",
  "@odata.type": "#ThermalMetrics.v1_0_1.ThermalMetrics",
  "Id": "ThermalMetrics",
  "Name": "Thermal Metrics",
  "TemperatureReadingsCelsius": [
    {
      "@odata.id": "/redfish/v1/Chassis/chassis/Sensors/ps1_temp0",
      "DataSourceUri": "/redfish/v1/Chassis/chassis/Sensors/ps1_temp0",
      "Reading": 24.0
    },
    {
      "@odata.id": "/redfish/v1/Chassis/chassis/Sensors/ps1_temp1",
      "DataSourceUri": "/redfish/v1/Chassis/chassis/Sensors/ps1_temp1",
      "Reading": 24.0
    },
    {
      "@odata.id": "/redfish/v1/Chassis/chassis/Sensors/ps1_temp2",
      "DataSourceUri": "/redfish/v1/Chassis/chassis/Sensors/ps1_temp2",
      "Reading": 30.0
    },
    {
      "@odata.id": "/redfish/v1/Chassis/chassis/Sensors/Ambient_0_Temp",
      "DataSourceUri": "/redfish/v1/Chassis/chassis/Sensors/Ambient_0_Temp",
      "Reading": 25.187
    },
    {
      "@odata.id": "/redfish/v1/Chassis/chassis/Sensors/Ambient_1_Temp",
      "DataSourceUri": "/redfish/v1/Chassis/chassis/Sensors/Ambient_1_Temp",
      "Reading": 25.799
    },
    {
      "@odata.id": "/redfish/v1/Chassis/chassis/Sensors/Ambient_2_Temp",
      "DataSourceUri": "/redfish/v1/Chassis/chassis/Sensors/Ambient_2_Temp",
      "Reading": 25.000202636136002
    },
    {
      "@odata.id": "/redfish/v1/Chassis/chassis/Sensors/PCIE_0_Temp",
      "DataSourceUri": "/redfish/v1/Chassis/chassis/Sensors/PCIE_0_Temp",
      "Reading": 29.125
    },
    {
      "@odata.id": "/redfish/v1/Chassis/chassis/Sensors/PCIE_1_Temp",
      "DataSourceUri": "/redfish/v1/Chassis/chassis/Sensors/PCIE_1_Temp",
      "Reading": 30.562
    },
    {
      "@odata.id": "/redfish/v1/Chassis/chassis/Sensors/ps2_temp0",
      "DataSourceUri": "/redfish/v1/Chassis/chassis/Sensors/ps2_temp0",
      "Reading": 25.0
    },
    {
      "@odata.id": "/redfish/v1/Chassis/chassis/Sensors/ps2_temp1",
      "DataSourceUri": "/redfish/v1/Chassis/chassis/Sensors/ps2_temp1",
      "Reading": 25.0
    },
    {
      "@odata.id": "/redfish/v1/Chassis/chassis/Sensors/ps2_temp2",
      "DataSourceUri": "/redfish/v1/Chassis/chassis/Sensors/ps2_temp2",
      "Reading": 30.0
    },
    {
      "@odata.id": "/redfish/v1/Chassis/chassis/Sensors/ps0_temp0",
      "DataSourceUri": "/redfish/v1/Chassis/chassis/Sensors/ps0_temp0",
      "Reading": 23.0
    },
    {
      "@odata.id": "/redfish/v1/Chassis/chassis/Sensors/ps0_temp1",
      "DataSourceUri": "/redfish/v1/Chassis/chassis/Sensors/ps0_temp1",
      "Reading": 23.0
    },
    {
      "@odata.id": "/redfish/v1/Chassis/chassis/Sensors/ps0_temp2",
      "DataSourceUri": "/redfish/v1/Chassis/chassis/Sensors/ps0_temp2",
      "Reading": 29.0
    },
    {
      "@odata.id": "/redfish/v1/Chassis/chassis/Sensors/ps3_temp0",
      "DataSourceUri": "/redfish/v1/Chassis/chassis/Sensors/ps3_temp0",
      "Reading": 26.0
    },
    {
      "@odata.id": "/redfish/v1/Chassis/chassis/Sensors/ps3_temp1",
      "DataSourceUri": "/redfish/v1/Chassis/chassis/Sensors/ps3_temp1",
      "Reading": 26.0
    },
    {
      "@odata.id": "/redfish/v1/Chassis/chassis/Sensors/ps3_temp2",
      "DataSourceUri": "/redfish/v1/Chassis/chassis/Sensors/ps3_temp2",
      "Reading": 31.0
    }
  ]
}

/* Demonstration of incorrect DataSourceUri */
$ curl -k -H "X-Auth-Token: ${token}" -X GET https://${bmc}/redfish/v1/Chassis/chassis/Sensors/ps1_temp0
{
  "@odata.id": "/redfish/v1/Chassis/chassis/Sensors/ps1_temp0",
  "error": {
    "@Message.ExtendedInfo": [
      {
        "@odata.type": "#Message.v1_1_1.Message",
        "Message": "The requested resource of type ps1_temp0 named 'Sensor' was not found.",
        "MessageArgs": [
          "ps1_temp0",
          "Sensor"
        ],
        "MessageId": "Base.1.19.0.ResourceNotFound",
        "MessageSeverity": "Critical",
        "Resolution": "Provide a valid resource identifier and resubmit the request."
      }
    ],
    "code": "Base.1.19.0.ResourceNotFound",
    "message": "The requested resource of type ps1_temp0 named 'Sensor' was not found."
  }
}
```
New implementation output:
```
$ curl -k -H "X-Auth-Token: ${token}" -X GET https://${bmc}/redfish/v1/Chassis/chassis/ThermalSubsystem/ThermalMetrics
{
  "@odata.id": "/redfish/v1/Chassis/chassis/ThermalSubsystem/ThermalMetrics",
  "@odata.type": "#ThermalMetrics.v1_0_1.ThermalMetrics",
  "Id": "ThermalMetrics",
  "Name": "Thermal Metrics",
  "TemperatureReadingsCelsius": [
    {
      "DataSourceUri": "/redfish/v1/Chassis/chassis/Sensors/temperature_Ambient_0_Temp",
      "Reading": 25.312
    },
    {
      "DataSourceUri": "/redfish/v1/Chassis/chassis/Sensors/temperature_Ambient_1_Temp",
      "Reading": 25.956
    },
    {
      "DataSourceUri": "/redfish/v1/Chassis/chassis/Sensors/temperature_Ambient_2_Temp",
      "Reading": 25.107453612696002
    },
    {
      "DataSourceUri": "/redfish/v1/Chassis/chassis/Sensors/temperature_PCIE_0_Temp",
      "Reading": 26.437
    },
    {
      "DataSourceUri": "/redfish/v1/Chassis/chassis/Sensors/temperature_PCIE_1_Temp",
      "Reading": 28.062
    },
    {
      "DataSourceUri": "/redfish/v1/Chassis/chassis/Sensors/temperature_ps0_temp0",
      "Reading": 22.0
    },
    {
      "DataSourceUri": "/redfish/v1/Chassis/chassis/Sensors/temperature_ps0_temp1",
      "Reading": 22.0
    },
    {
      "DataSourceUri": "/redfish/v1/Chassis/chassis/Sensors/temperature_ps0_temp2",
      "Reading": 27.0
    },
    {
      "DataSourceUri": "/redfish/v1/Chassis/chassis/Sensors/temperature_ps1_temp0",
      "Reading": 22.0
    },
    {
      "DataSourceUri": "/redfish/v1/Chassis/chassis/Sensors/temperature_ps1_temp1",
      "Reading": 22.0
    },
    {
      "DataSourceUri": "/redfish/v1/Chassis/chassis/Sensors/temperature_ps1_temp2",
      "Reading": 28.0
    },
    {
      "DataSourceUri": "/redfish/v1/Chassis/chassis/Sensors/temperature_ps2_temp0",
      "Reading": 23.0
    },
    {
      "DataSourceUri": "/redfish/v1/Chassis/chassis/Sensors/temperature_ps2_temp1",
      "Reading": 23.0
    },
    {
      "DataSourceUri": "/redfish/v1/Chassis/chassis/Sensors/temperature_ps2_temp2",
      "Reading": 28.0
    },
    {
      "DataSourceUri": "/redfish/v1/Chassis/chassis/Sensors/temperature_ps3_temp0",
      "Reading": 24.0
    },
    {
      "DataSourceUri": "/redfish/v1/Chassis/chassis/Sensors/temperature_ps3_temp1",
      "Reading": 24.0
    },
    {
      "DataSourceUri": "/redfish/v1/Chassis/chassis/Sensors/temperature_ps3_temp2",
      "Reading": 28.0
    }
  ],
  "TemperatureReadingsCelsius@odata.count": 17
}

/* Demonstration of correct DataSourceUri */
$ curl -k -H "X-Auth-Token: ${token}" -X GET https://${bmc}/redfish/v1/Chassis/chassis/Sensors/temperature_Ambient_0_Temp
{
  "@odata.id": "/redfish/v1/Chassis/chassis/Sensors/temperature_Ambient_0_Temp",
  "@odata.type": "#Sensor.v1_2_0.Sensor",
  "Id": "temperature_Ambient_0_Temp",
  "Name": "Ambient 0 Temp",
  "Reading": 25.25,
  "ReadingRangeMax": 127.0,
  "ReadingRangeMin": -128.0,
  "ReadingType": "Temperature",
  "ReadingUnits": "Cel",
  "Status": {
    "Health": "OK",
    "State": "Enabled"
  },
  "Thresholds": {
    "LowerCaution": {
      "Reading": 0.0
    },
    "UpperCaution": {
      "Reading": 100.0
    }
  }
}
```