### PR TITLE
Add service root OEM for MFA flag

### DIFF
--- a/Redfish.md
+++ b/Redfish.md
@@ -49,6 +49,7 @@ Fields common to all schemas
 - TelemetryService
 - UUID
 - UpdateService
+- MultiFactorAuthEnabled
 
 ### /redfish/v1/AccountService/
 

--- a/redfish-core/schema/oem/ibm/csdl/IBMServiceRoot_v1.xml
+++ b/redfish-core/schema/oem/ibm/csdl/IBMServiceRoot_v1.xml
@@ -58,6 +58,11 @@
           <Annotation Term="OData.Description" String="An indication of whether the time window for an unauthorized agent to upload an ACF is active."/>
           <Annotation Term="OData.LongDescription" String="This property shall indicate if the time window for an unauthorized agent to upload an ACF is active."/>
         </Property>
+        <Property Name="MultiFactorAuthEnabled" Type="IBMServiceRoot.IBM">
+          <Annotation Term="OData.Permissions" EnumMember="OData.Permission/Read"/>
+          <Annotation Term="OData.Description" String="An indication of whether multi factor authentication is enabled."/>
+          <Annotation Term="OData.LongDescription" String="This property shall indicate if the multi factor authentication is enabled in the system."/>
+        </Property>
       </ComplexType>
     </Schema>
   </edmx:DataServices>

--- a/redfish-core/schema/oem/ibm/json-schema/IBMServiceRoot.v1_0_0.json
+++ b/redfish-core/schema/oem/ibm/json-schema/IBMServiceRoot.v1_0_0.json
@@ -75,6 +75,12 @@
                     "longDescription": "This property shall indicate if the time window for an unauthorized agent to upload an ACF is active.",
                     "readonly": true,
                     "type": ["boolean", "null"]
+                },
+                "MultiFactorAuthEnabled": {
+                    "description": "An indication of whether multi factor authentication is enabled.",
+                    "longDescription": "This property shall indicate if the multi factor authentication is enabled in the system.",
+                    "readonly": true,
+                    "type": ["boolean", "null"]
                 }
             },
             "type": "object"


### PR DESCRIPTION
This PR contains the changes to get the d-bus value of Multi factor enabled and populate it under service root in redfish response

Tested by:

GET https://${bmc}/redfish/v1

  "Name": "Root Service",
  "Oem": {
    "IBM": {
      "@odata.type": "#IBMServiceRoot.v1_0_0.IBM",
      "ACFWindowActive": false,
      "DateTime": "2024-11-08T09:00:58+00:00",
      "DateTimeLocalOffset": "+00:00",
      "Model": "9105-22A",
      "MultiFactorAuthEnabled": true,
      "SerialNumber": "139EF60"
    }
  },

Fixes : https://jsw.ibm.com/browse/PFEBMC-3585
Upstream : OEM property, downstream only.