### PR TITLE
MFA-Bypass: Disable service user for MFA bypass

### DIFF
--- a/redfish-core/lib/account_service.hpp
+++ b/redfish-core/lib/account_service.hpp
@@ -1349,6 +1349,11 @@ inline void updateUserProperties(
             // Check if the input vector contains just one bypass type:
             // as there are just two defined in the backend:
             // GoogleAuthenticator  and None
+            if (username == "service")
+            {
+                messages::operationNotAllowed(asyncResp->res);
+                return;
+            }
             if (mfaBypass->size() > 1)
             {
                 messages::propertyNotWritable(asyncResp->res,


### PR DESCRIPTION
MFA-Bypass option is disabled for service user.
Service user will be always bypassed for MFA and the patch operation should be disabled from  altering it.