### PR TITLE
Add another segment to fabric adapter id

### DIFF
--- a/redfish-core/include/utils/fabric_util.hpp
+++ b/redfish-core/include/utils/fabric_util.hpp
@@ -23,8 +23,13 @@ namespace fabric_util
  * @brief Workaround to handle duplicate Fabric device list
  *
  * retrieve Fabric device endpoint information and if path is
- * ~/chassisN/logical_slotN/io_moduleN then, replace redfish
- * Fabric device as "chassisN-logical_slotN-io_moduleN"
+ * system/chassisN/logical_slotN/io_moduleN then, replace redfish
+ * Fabric device as "system-chassisN-logical_slotN-io_moduleN" (MEX)
+ *
+ * chassisN/boardN/logical_slotN/io_moduleN would be
+ * chassisN-boardN-logical_slotN-io_moduleN (Splitter)
+ *
+ * Because Splitter added an extra segment, had to go 4 deep.
  *
  * @param[i]   fullPath  object path of Fabric device
  *
@@ -34,12 +39,17 @@ inline std::string buildFabricUniquePath(const std::string& fullPath)
 {
     sdbusplus::message::object_path path(fullPath);
     sdbusplus::message::object_path parentPath = path.parent_path();
+    sdbusplus::message::object_path grandparentPath = parentPath.parent_path();
 
     std::string devName;
 
-    if (!parentPath.parent_path().filename().empty())
+    if (!grandparentPath.parent_path().filename().empty())
     {
-        devName = parentPath.parent_path().filename() + "-";
+        devName = grandparentPath.parent_path().filename() + "-";
+    }
+    if (!grandparentPath.filename().empty())
+    {
+        devName += grandparentPath.filename() + "-";
     }
     if (!parentPath.filename().empty())
     {


### PR DESCRIPTION
Splitter added a segment to the D-Bus path.. 

Currently given redfish to dbus mapping below, both map to the same redfish object.

"/redfish/v1/Systems/system/FabricAdapters/board1-logical_slot1-io_module1" <->
/xyz/openbmc_project/inventory/system/chassis15873/board1/logical_slot1/io_module1

"/redfish/v1/Systems/system/FabricAdapters/board1-logical_slot1-io_module1" <->
/xyz/openbmc_project/inventory/system/chassis15874/board1/logical_slot1/io_module1

Adding another segment to the redfish fabric adapter id will allow the chassis id to be considered for splitter, for mex, it will add the system segment but this shouldn't cause problems, it is just an id. We should hash like we do software ids, so using more segments to make unique should also work.

We have all this code because our D-Bus interfaces and Redfish interfaces for FabricAdapters don't match. We have a future plan to upstream this and make this work.

Tested: The GUI seems happy here in the inventory. Redfish validator has no new errors  

Upstream: This is all downstream. 