### PR TITLE
1060: Add another segment to fabric adapter id (#1094)

### DIFF
--- a/redfish-core/include/utils/fabric_util.hpp
+++ b/redfish-core/include/utils/fabric_util.hpp
@@ -37,8 +37,13 @@ inline bool checkFabricAdapterId(const std::string& adapterId,
  * @brief Workaround to handle duplicate Fabric device list
  *
  * retrieve Fabric device endpoint information and if path is
- * ~/chassisN/logical_slotN/io_moduleN then, replace redfish
- * Fabric device as "chassisN-logical_slotN-io_moduleN"
+ * system/chassisN/logical_slotN/io_moduleN then, replace redfish
+ * Fabric device as "system-chassisN-logical_slotN-io_moduleN" (MEX)
+ *
+ * chassisN/boardN/logical_slotN/io_moduleN would be
+ * chassisN-boardN-logical_slotN-io_moduleN (Splitter)
+ *
+ * Because Splitter added an extra segment, had to go 4 deep.
  *
  * @param[i]   fullPath  object path of Fabric device
  *
@@ -48,12 +53,17 @@ inline std::string buildFabricUniquePath(const std::string& fullPath)
 {
     sdbusplus::message::object_path path(fullPath);
     sdbusplus::message::object_path parentPath = path.parent_path();
+    sdbusplus::message::object_path grandparentPath = parentPath.parent_path();
 
     std::string devName;
 
-    if (!parentPath.parent_path().filename().empty())
+    if (!grandparentPath.parent_path().filename().empty())
     {
-        devName = parentPath.parent_path().filename() + "-";
+        devName = grandparentPath.parent_path().filename() + "-";
+    }
+    if (!grandparentPath.filename().empty())
+    {
+        devName += grandparentPath.filename() + "-";
     }
     if (!parentPath.filename().empty())
     {


### PR DESCRIPTION
#### Add another segment to fabric adapter id (#1094)
```
Currently given redfish to dbus mapping below, both map to the same
redfish object.

"/redfish/v1/Systems/system/FabricAdapters/board1-logical_slot1-io_module1"
<->
/xyz/openbmc_project/inventory/system/chassis15873/board1/logical_slot1/io_module1

"/redfish/v1/Systems/system/FabricAdapters/board1-logical_slot1-io_module1"
<->
/xyz/openbmc_project/inventory/system/chassis15874/board1/logical_slot1/io_module1

Adding another segment to the redfish fabric adapter id will allow the
chassis id to be considered.

We have all this code because our D-Bus interfaces and Redfish
interfaces for FabricAdapters don't match. We have a future plan to
upstream this and make this work.

Signed-off-by: Gunnar Mills <gmills@us.ibm.com>```