### PR TITLE
1050: Populate DHCP UseDomainName with right D-bus values (#1036)

### DIFF
--- a/redfish-core/lib/ethernet.hpp
+++ b/redfish-core/lib/ethernet.hpp
@@ -2056,13 +2056,13 @@ inline void parseInterfaceData(
         translateDhcpEnabledToBool(ethData.dhcpEnabled, true);
     jsonResponse["DHCPv4"]["UseNTPServers"] = ethData.ntpv4Enabled;
     jsonResponse["DHCPv4"]["UseDNSServers"] = ethData.dnsv4Enabled;
-    jsonResponse["DHCPv4"]["UseDomainName"] = ethData.hostNamev4Enabled;
+    jsonResponse["DHCPv4"]["UseDomainName"] = ethData.domainv4Enabled;
     jsonResponse["DHCPv6"]["OperatingMode"] =
         translateDhcpEnabledToBool(ethData.dhcpEnabled, false) ? "Enabled"
                                                                : "Disabled";
     jsonResponse["DHCPv6"]["UseNTPServers"] = ethData.ntpv6Enabled;
     jsonResponse["DHCPv6"]["UseDNSServers"] = ethData.dnsv6Enabled;
-    jsonResponse["DHCPv6"]["UseDomainName"] = ethData.hostNamev6Enabled;
+    jsonResponse["DHCPv6"]["UseDomainName"] = ethData.domainv6Enabled;
     jsonResponse["StatelessAddressAutoConfig"]["IPv6AutoConfigEnabled"] =
         ethData.ipv6AcceptRa;
 


### PR DESCRIPTION
#### Populate DHCP UseDomainName with right D-bus values (#1036)
```
Currently UseDomainName status is not updated properly as per
corresponding UseDomainName D-bus value

This commit populates UseDomainName for DHCPv4 and DHCPv6 parameters as
per D-bus values.

Tested by:
Enable/Disable DHCP UseDomainName and check values of UseDomainName


Change-Id: I6440e9ee99cf48b140f6ef7df877768117b25175

Signed-off-by: Ravi Teja <raviteja28031990@gmail.com>
Co-authored-by: Ravi Teja <raviteja28031990@gmail.com>```