### PR TITLE
Restrict the user till MFA setup is complete

### DIFF
--- a/include/dbus_privileges.hpp
+++ b/include/dbus_privileges.hpp
@@ -26,12 +26,14 @@ inline bool
     std::string userRole;
     bool remoteUser = false;
     std::optional<bool> passwordExpired;
+    std::optional<bool> secretKeyRequired;
     std::optional<std::vector<std::string>> userGroups;
 
     const bool success = sdbusplus::unpackPropertiesNoThrow(
         redfish::dbus_utils::UnpackErrorPrinter(), userInfoMap, "UserPrivilege",
         userRole, "RemoteUser", remoteUser, "UserPasswordExpired",
-        passwordExpired, "UserGroups", userGroups);
+        passwordExpired, "TOTPSecretkeyRequired", secretKeyRequired,
+        "UserGroups", userGroups);
 
     if (!success)
     {
@@ -49,10 +51,12 @@ inline bool
     session.userRole = userRole;
     BMCWEB_LOG_DEBUG("userName = {} userRole = {}", session.username, userRole);
 
+    session.isGenerateSecretKeyRequired = secretKeyRequired.value_or(false);
     // Set isConfigureSelfOnly based on D-Bus results.  This
     // ignores the results from both pamAuthenticateUser and the
     // value from any previous use of this session.
-    session.isConfigureSelfOnly = passwordExpired.value_or(false);
+    session.isConfigureSelfOnly = passwordExpired.value_or(false) ||
+                                  secretKeyRequired.value_or(false);
 
     session.userGroups.clear();
     if (userGroups)
@@ -90,10 +94,22 @@ inline bool
         asyncResp->res.result(boost::beast::http::status::forbidden);
         if (req.session->isConfigureSelfOnly)
         {
-            redfish::messages::passwordChangeRequired(
-                asyncResp->res,
-                boost::urls::format("/redfish/v1/AccountService/Accounts/{}",
-                                    req.session->username));
+            if (!req.session->isGenerateSecretKeyRequired)
+            {
+                redfish::messages::passwordChangeRequired(
+                    asyncResp->res,
+                    boost::urls::format(
+                        "/redfish/v1/AccountService/Accounts/{}",
+                        req.session->username));
+            }
+            else
+            {
+                redfish::messages::generateSecretKeyRequired(
+                    asyncResp->res,
+                    boost::urls::format(
+                        "/redfish/v1/AccountService/Accounts/{}",
+                        req.session->username));
+            }
         }
         return false;
     }

--- a/include/sessions.hpp
+++ b/include/sessions.hpp
@@ -45,6 +45,7 @@ struct UserSession
     SessionType sessionType{SessionType::None};
     bool cookieAuth = false;
     bool isConfigureSelfOnly = false;
+    bool isGenerateSecretKeyRequired = false;
     std::string userRole;
     std::vector<std::string> userGroups;
 
@@ -188,7 +189,8 @@ class SessionStore
     std::shared_ptr<UserSession> generateUserSession(
         std::string_view username, const boost::asio::ip::address& clientIp,
         const std::optional<std::string>& clientId, SessionType sessionType,
-        bool isConfigureSelfOnly = false)
+        bool isConfigureSelfOnly = false,
+        bool isGenerateSecretKeyRequired = false)
     {
         // Only need csrf tokens for cookie based auth, token doesn't matter
         std::string sessionToken =
@@ -214,6 +216,7 @@ class SessionStore
                         sessionType,
                         false,
                         isConfigureSelfOnly,
+                        isGenerateSecretKeyRequired,
                         "",
                         {}});
         auto it = authTokens.emplace(sessionToken, session);

--- a/redfish-core/lib/redfish_sessions.hpp
+++ b/redfish-core/lib/redfish_sessions.hpp
@@ -308,7 +308,7 @@ inline void handleSessionCollectionPost(
         std::shared_ptr<persistent_data::UserSession> session =
             persistent_data::SessionStore::getInstance().generateUserSession(
                 username, req.ipAddress, clientId,
-                persistent_data::SessionType::Session, true);
+                persistent_data::SessionType::Session, true, false);
         if (!session)
         {
             messages::internalError(asyncResp->res);
@@ -332,7 +332,7 @@ inline void handleSessionCollectionPost(
         std::shared_ptr<persistent_data::UserSession> session =
             persistent_data::SessionStore::getInstance().generateUserSession(
                 username, req.ipAddress, clientId,
-                persistent_data::SessionType::Session, required);
+                persistent_data::SessionType::Session, required, required);
         if (!session)
         {
             messages::internalError(asyncResp->res);


### PR DESCRIPTION
Return an error when the user try to get/patch without completing MFA setup when MFA is enabled.

Tested by:

Enable MFA in the system.
Verified generate secret key message is returned when creating a redfish session
Verified generate secret key message is returned if get/patch is executed.

Fixes : https://jazz07.rchland.ibm.com:13443/jazz/web/projects/CSSD#action=com.ibm.team.workitem.viewWorkItem&id=652534