### PR TITLE
1110: Rebase: json utility: fixed core dump during sensor load

### DIFF
--- a/test/redfish-core/include/utils/json_utils_test.cpp
+++ b/test/redfish-core/include/utils/json_utils_test.cpp
@@ -489,6 +489,14 @@ TEST(objectKeyCmp, PositiveCases)
         0, objectKeyCmp("Name",
                         R"({"@odata.id": "/redfish/v1/1", "Name": "a"})"_json,
                         R"({"@odata.id": "/redfish/v1/1", "Name": "b"})"_json));
+    EXPECT_EQ(0, objectKeyCmp(
+                     "Name",
+                     R"({"@odata.id": "/redfish/v1/1", "Name": "a 45"})"_json,
+                     R"({"@odata.id": "/redfish/v1/1", "Name": "a 45"})"_json));
+    EXPECT_GT(0, objectKeyCmp(
+                     "Name",
+                     R"({"@odata.id": "/redfish/v1/1", "Name": "a 45"})"_json,
+                     R"({"@odata.id": "/redfish/v1/1", "Name": "b 45"})"_json));
 
     EXPECT_GT(
         0, objectKeyCmp("@odata.id",


### PR DESCRIPTION
Pulling in an upstream commit to fix a problem with objectKeyCmp() which causes bmcweb to core dump. Haven't seen this core dump downstream but thought it would be safer to pull in the fix since we are using this function:
 - https://gerrit.openbmc.org/c/openbmc/bmcweb/+/75867

bmcweb replaces underscores with spaces in sensor names for better readability. The existing objectKeyCmp function did not handle this case, leading to core dumps in the sensor load path.

Error details are provided below.

```
bmcwebd[1368]: [DEBUG sensors.hpp:507] Added sensor P0_NS_VR_FAN_2
bmcwebd[1368]: terminate called after throwing an instance of
       'boost::detail::with_throw_location<boost::system::system_error>'
bmcwebd[1368]:   what():  leftover [boost.url.grammar:4]
```

Implemented a new algorithm that alphabetically sorts non-URL keys and retains the existing logic for URL-type keys.

Tested: Updated and verified the test cases.

Change-Id: I39c3f7cc54dec5e7cf9658977e1078acb827afb2