### PR TITLE
Move IsGenerateSecretKeyRequired from user to user manager level

### DIFF
--- a/redfish-core/lib/redfish_sessions.hpp
+++ b/redfish-core/lib/redfish_sessions.hpp
@@ -243,16 +243,14 @@ inline void processAfterSessionCreation(
 }
 
 inline void checkGoogleAuthenticatorSecretKeyRequired(
-    const std::string& username,
     std::function<void(const boost::system::error_code& ec, bool)> callback)
 {
     sdbusplus::message::object_path userPath("/xyz/openbmc_project/user");
-    userPath /= username;
     crow::connections::systemBus->async_method_call(
         [callback = std::move(callback)](const boost::system::error_code& ec,
                                          bool val) { callback(ec, val); },
         "xyz.openbmc_project.User.Manager", userPath,
-        "xyz.openbmc_project.User.TOTPAuthenticator",
+        "xyz.openbmc_project.User.TOTPAuthenticatorManager",
         "IsGenerateSecretKeyRequired");
 }
 
@@ -320,8 +318,8 @@ inline void handleSessionCollectionPost(
     }
     // check if secret key generation is required for the user
     checkGoogleAuthenticatorSecretKeyRequired(
-        username, [username, asyncResp, req, clientId = std::move(clientId)](
-                      const boost::system::error_code& ec, bool required) {
+        [username, asyncResp, req, clientId = std::move(clientId)](
+            const boost::system::error_code& ec, bool required) {
             if (ec)
             {
                 BMCWEB_LOG_ERROR("secretKeyRequired check failed = {}",


### PR DESCRIPTION
This commit moves the IsGenerateSecretKeyRequired method from  user to user manager level according to the dbus change in PR : https://github.com/ibm-openbmc/phosphor-dbus-interfaces/pull/157.

Tested by:

Enable MFA and try to create a session,

Response:

{
  "@Message.ExtendedInfo": [
    {
      "@odata.type": "#Message.v1_1_1.Message",
      "Message": "The Time-based One-Time Password (TOTP) secret key
for this account must be generated before access is granted. Perform the GenerateSecretKey action at URI
'/redfish/v1/AccountService/Accounts/service' and retain the secret key from the response.",
      "MessageArgs": [
        "/redfish/v1/AccountService/Accounts/service"
      ],
      "MessageId": "Base.1.19.0.GenerateSecretKeyRequired",
      "MessageSeverity": "Critical",
      "Resolution": "Generate secret key for this account by performing
the `GenerateSecretKey` action on the referenced URI and retaining the secret key from the action response to produce a Time-based One-Time Password (TOTP) for the `Token` property in future session creation requests."
    }
  ],
  "@odata.id": "/redfish/v1/SessionService/Sessions/neSLpiOFJz",
  "@odata.type": "#Session.v1_5_0.Session",
  "ClientOriginIPAddress": <ip>,
  "Description": "Manager User Session",
  "Id": "neSLpiOFJz",
  "Name": "User Session",
  "UserName": <user>

Upstream : https://gerrit.openbmc.org/c/openbmc/bmcweb/+/74938
Change-Id: Icfeb7486ae76d436a73afde51b0158b369a62ad0