### PR TITLE
Change FaultData dump type parameter as per dump manager

### DIFF
--- a/redfish-core/lib/log_services.hpp
+++ b/redfish-core/lib/log_services.hpp
@@ -1371,8 +1371,8 @@ inline void createDump(const std::shared_ptr<bmcweb::AsyncResp>& asyncResp,
             {
                 // Fault data dump
                 createDumpParams.emplace_back(
-                    "xyz.openbmc_project.Dump.Internal.Create.Type",
-                    "xyz.openbmc_project.Dump.Internal.Create.Type.FaultData");
+                    "xyz.openbmc_project.Dump.Create.CreateParameters.DumpType",
+                    "xyz.openbmc_project.Dump.Create.DumpType.FaultData");
             }
             else
             {


### PR DESCRIPTION
We removed internal interface in dump manager and we are currently using an external interface. So, changing it to support FaultData dump.

Before:
```
Dec 05 18:14:15 valid-hostname phosphor-dump-manager[521]: Initiating new BMC dump with type: user path:
Dec 05 18:14:41 valid-hostname pldmd[715]: Dumping the flight recorder into : /tmp/pldm_flight_recorder
Dec 05 18:14:53 valid-hostname phosphor-dump-manager[1658]: performing dump compression /tmp/BMCDUMP.139F230.00000002.20241205181415
Dec 05 18:14:56 valid-hostname phosphor-dump-manager[1658]: Adding Dump Header :/usr/share/dreport.d/include.d/gendumpheader
Dec 05 18:15:09 valid-hostname phosphor-dump-manager[1658]: Thu Dec  5 18:15:09 UTC 2024 Report is available in /var/lib/phosphor-debug-collector/dumps/2
Dec 05 18:15:09 valid-hostname phosphor-dump-manager[1282]: Thu Dec 5 18:15:09 UTC 2024 Successfully completed
Dec 05 18:15:09 valid-hostname phosphor-dump-manager[521]: User initiated dump completed, resetting flag
```

After:
```
Dec 05 18:23:40 valid-hostname phosphor-dump-manager[521]: Initiating new BMC dump with type: faultdata path:
Dec 05 18:23:40 valid-hostname faultlog[2131]: faultlog app to collect deconfig/guard records details
Dec 05 18:23:40 valid-hostname faultlog[2131]: Latest chassis poweron time read is :12/05/2024 07:00:01
Dec 05 18:23:42 valid-hostname phosphor-dump-manager[2136]: performing dump compression /tmp/NAGDUMP.139F230.00000003.20241205182340
Dec 05 18:23:42 valid-hostname phosphor-dump-manager[2136]: Adding Dump Header :/usr/share/dreport.d/include.d/gendumpheader
Dec 05 18:23:43 valid-hostname phosphor-dump-manager[2136]: Thu Dec  5 18:23:43 UTC 2024 Report is available in /var/lib/phosphor-debug-collector/dumps/3
Dec 05 18:23:43 valid-hostname phosphor-dump-manager[2119]: Thu Dec 5 18:23:43 UTC 2024 Successfully completed
```

Change-Id: I2695802a695ecc939d2cdcb373db7fe20214926c