### PR TITLE
Correct errors for spare core overwrite

### DIFF
--- a/redfish-core/lib/log_services.hpp
+++ b/redfish-core/lib/log_services.hpp
@@ -2118,19 +2118,10 @@ inline void updateProperty(const std::optional<bool>& resolved,
 {
     if (resolved.has_value())
     {
-        sdbusplus::asio::setProperty(
-            *crow::connections::systemBus, "xyz.openbmc_project.Logging",
-            "/xyz/openbmc_project/logging/entry/" + entryId,
-            "xyz.openbmc_project.Logging.Entry", "Resolved", *resolved,
-            [asyncResp](const boost::system::error_code& ec) {
-                if (ec)
-                {
-                    BMCWEB_LOG_ERROR("DBUS response error {}", ec);
-                    messages::internalError(asyncResp->res);
-                    return;
-                }
-            });
-        BMCWEB_LOG_DEBUG("Set Resolved");
+        setDbusProperty(asyncResp, "xyz.openbmc_project.Logging",
+                        "/xyz/openbmc_project/logging/entry/" + entryId,
+                        "xyz.openbmc_project.Logging.Entry", "Resolved",
+                        "Resolved", *resolved);
     }
 
     if (managementSystemAck.has_value())

--- a/redfish-core/src/utils/dbus_utils.cpp
+++ b/redfish-core/src/utils/dbus_utils.cpp
@@ -73,7 +73,8 @@ void afterSetProperty(
             }
             if (errorName == "xyz.openbmc_project.Common.Error.Unavailable")
             {
-                messages::resourceInStandby(asyncResp->res);
+                messages::propertyValueExternalConflict(
+                    asyncResp->res, redfishPropertyName, propertyValue);
                 return;
             }
         }


### PR DESCRIPTION
Three commits here to return a better error when resolve/delete error log is unavailable due to active gard record. This is part of the spare cores overwrite story. 

The 1st commit is  [Switch resolved to use SetProperty](https://github.com/ibm-openbmc/bmcweb/commit/ad5b2a67cd6032189c065e597ed044d7c8f66b87). This follows patterns elsewhere and is already done upstream at https://github.com/openbmc/bmcweb/blob/master/redfish-core/lib/log_services.hpp#L1806. There is a lot of downstream commits in this area so pulling upstream wasn't possible 
2nd commit is [Map Error.Unavailable to something better](https://github.com/ibm-openbmc/bmcweb/commit/1525466aaf0629f9f609c4105176b7aa0d4107cf). Upstream at https://gerrit.openbmc.org/c/openbmc/bmcweb/+/75570 
3rd commit is [Add specific error on Delete](https://github.com/ibm-openbmc/bmcweb/commit/e97723a0a8a73428d63799ee6cd1c3407c2a118f). Haven't seen us do this for detete, pending 75570 

Tested: Nikhil tested on the GUI and said this worked 