### PR TITLE
WIP: Allow debug build

### DIFF
--- a/redfish-core/include/utils/json_utils.hpp
+++ b/redfish-core/include/utils/json_utils.hpp
@@ -154,7 +154,7 @@ UnpackErrorCode unpackValueVariant(nlohmann::json& j, std::string_view key,
 {
     if constexpr (Index < std::variant_size_v<std::variant<Args...>>)
     {
-        std::variant_alternative_t<Index, std::variant<Args...>> type;
+        std::variant_alternative_t<Index, std::variant<Args...>> type{};
         UnpackErrorCode unpack = unpackValueWithErrorCode(j, key, type);
         if (unpack == UnpackErrorCode::success)
         {


### PR DESCRIPTION
"--buildtype=debug" on 1110 fails, need for debugging this DVT issue. This is Gunnar's quick workaround. The
redfish-core/include/utils/json_utils.hpp change looks upstream at [1]

The redfish-core/include/event_service_manager.hpp change doesn't appear upstream.

[1]: https://github.com/openbmc/bmcweb/commit/ed4de7a8a5601b58b2e29824b10bf7fcc699a1b8#diff-29b031549e0da8e7f3ceb2c2a4f301f9de1061adbe5b4b5f073e8e8ebc84d149R154