### PR TITLE
Dimm: Look at Pretty Name 

### DIFF
--- a/redfish-core/lib/memory.hpp
+++ b/redfish-core/lib/memory.hpp
@@ -34,6 +34,7 @@
 #include <nlohmann/json.hpp>
 #include <sdbusplus/asio/property.hpp>
 #include <sdbusplus/unpack_properties.hpp>
+#include <utils/name_utils.hpp>
 
 #include <array>
 #include <cstdint>
@@ -414,7 +415,6 @@ inline void assembleDimmProperties(
     const nlohmann::json::json_pointer& jsonPtr)
 {
     asyncResp->res.jsonValue[jsonPtr]["Id"] = dimmId;
-    asyncResp->res.jsonValue[jsonPtr]["Name"] = "DIMM Slot";
     asyncResp->res.jsonValue[jsonPtr]["Status"]["State"] =
         resource::State::Enabled;
     asyncResp->res.jsonValue[jsonPtr]["Status"]["Health"] =
@@ -803,6 +803,8 @@ inline void handleGetDimmData(
                     dimmInterface = true;
                     getDimmDataByService(asyncResp, dimmId, serviceName,
                                          objectPath);
+                    name_util::getPrettyName(asyncResp, objectPath, serviceMap,
+                                             "/Name"_json_pointer);
                 }
                 else if (
                     interface ==


### PR DESCRIPTION
https://github.com/ibm-openbmc/bmcweb/pull/542 (1050/1060) https://github.com/ibm-openbmc/bmcweb/pull/918 (1110) added PrettyName for Processors, Assembly, Chassis, Storage but not Memory. I believe this was due to not needed it for Memory at the time. We want it now so the GUI can use on the inventory page.  (#973) pulled this in for 1060 but was missed for 1110. 
Fixes 667557

No upstream here, https://jsw.ibm.com/browse/PFEBMC-2871 tracks getting prettyname upstream 

Tested: 
```
curl -k https://$bmc/redfish/v1/Systems/system/Memory/dimm0
...
  "Name": "Memory module 0",
```