### PR TITLE
1110: catch up upstream heartbeat logic 

### DIFF
--- a/config/meson.build
+++ b/config/meson.build
@@ -29,6 +29,7 @@ feature_options = [
     'mutual-tls-auth',
     'redfish-aggregation',
     'redfish-allow-deprecated-power-thermal',
+    'redfish-use-3-digit-messageid',
     'redfish-bmc-journal',
     'redfish-cpu-log',
     'redfish-dbus-log',

--- a/meson.options
+++ b/meson.options
@@ -22,6 +22,18 @@ option(
                     https://github.com/openbmc/jsnbd/blob/master/README.''',
 )
 
+option(
+    'redfish-use-3-digit-messageid',
+    type: 'feature',
+    value: 'disabled',
+    description: '''Prior to a bug fix, bmcweb exposed error messages with a
+                    MessageId of Base.x.y.z.Message which was incorrect.
+                    Enabling this option causes return codes to return the old
+                    incorrect version for backward compatibility.  Will be
+                    removed Q2-2025'''
+)
+
+# BMCWEB_NBDPROXY
 # if you use this option and are seeing this comment, please comment here:
 # https://github.com/openbmc/bmcweb/issues/188 and put forward your intentions
 # for this code.  At this point, no daemon has been upstreamed that implements

--- a/redfish-core/include/event_service_manager.hpp
+++ b/redfish-core/include/event_service_manager.hpp
@@ -660,8 +660,8 @@ class EventServiceManager
             std::string strMsg = msgJson.dump(
                 2, ' ', true, nlohmann::json::error_handler_t::replace);
             entry->sendEventToSubscriber(std::move(strMsg));
-            eventId++; // increment the eventId
         }
+        eventId++; // increment the eventId
     }
 };
 

--- a/redfish-core/include/registries.hpp
+++ b/redfish-core/include/registries.hpp
@@ -15,11 +15,14 @@
 */
 #pragma once
 
+#include "bmcweb_config.h"
+
 #include <nlohmann/json.hpp>
 
 #include <array>
 #include <charconv>
 #include <cstddef>
+#include <format>
 #include <numeric>
 #include <span>
 #include <string>
@@ -34,12 +37,13 @@ struct Header
 {
     const char* copyright;
     const char* type;
-    const char* id;
+    unsigned int versionMajor;
+    unsigned int versionMinor;
+    unsigned int versionPatch;
     const char* name;
     const char* language;
     const char* description;
     const char* registryPrefix;
-    const char* registryVersion;
     const char* owningEntity;
 };
 
@@ -103,10 +107,19 @@ inline nlohmann::json::object_t getLogFromRegistry(
     {
         jArgs.push_back(arg);
     }
-    std::string msgId = header.id;
-    msgId += ".";
-    msgId += entry.first;
-
+    std::string msgId;
+    if (BMCWEB_REDFISH_USE_3_DIGIT_MESSAGEID)
+    {
+        msgId = std::format("{}.{}.{}.{}.{}", header.registryPrefix,
+                            header.versionMajor, header.versionMinor,
+                            header.versionPatch, entry.first);
+    }
+    else
+    {
+        msgId =
+            std::format("{}.{}.{}.{}", header.registryPrefix,
+                        header.versionMajor, header.versionMinor, entry.first);
+    }
     nlohmann::json::object_t response;
     response["@odata.type"] = "#Message.v1_1_1.Message";
     response["MessageId"] = std::move(msgId);

--- a/redfish-core/include/registries/base_message_registry.hpp
+++ b/redfish-core/include/registries/base_message_registry.hpp
@@ -20,12 +20,13 @@ namespace redfish::registries::base
 const Header header = {
     "Copyright 2014-2024 DMTF. All rights reserved.",
     "#MessageRegistry.v1_6_2.MessageRegistry",
-    "Base.1.19.0",
+    1,
+    19,
+    0,
     "Base Message Registry",
     "en",
     "This registry defines the base messages for Redfish.",
     "Base",
-    "1.19.0",
     "DMTF",
 };
 constexpr const char* url =

--- a/redfish-core/include/registries/bios_message_registry.hpp
+++ b/redfish-core/include/registries/bios_message_registry.hpp
@@ -2,17 +2,21 @@
 
 #include "registries.hpp"
 
+#include <array>
+
 namespace redfish::registries::bios
 {
 const Header header = {
     "Copyright 2020 OpenBMC. All rights reserved.",
     "#MessageRegistry.v1_4_0.MessageRegistry",
-    "BiosAttributeRegistry.1.0.0",
+    1,
+    0,
+    0,
     "Bios Attribute Registry",
     "en",
     "This registry defines the messages for bios attribute registry.",
     "BiosAttributeRegistry",
-    "1.0.0",
     "OpenBMC",
 };
+constexpr const char* url = nullptr;
 } // namespace redfish::registries::bios

--- a/redfish-core/include/registries/composition_message_registry.hpp
+++ b/redfish-core/include/registries/composition_message_registry.hpp
@@ -20,12 +20,13 @@ namespace redfish::registries::composition
 const Header header = {
     "Copyright 2019-2023 DMTF. All rights reserved.",
     "#MessageRegistry.v1_6_2.MessageRegistry",
-    "Composition.1.1.2",
+    1,
+    1,
+    2,
     "Composition Message Registry",
     "en",
     "This registry defines the messages for composition related events.",
     "Composition",
-    "1.1.2",
     "DMTF",
 };
 constexpr const char* url =

--- a/redfish-core/include/registries/environmental_message_registry.hpp
+++ b/redfish-core/include/registries/environmental_message_registry.hpp
@@ -20,12 +20,13 @@ namespace redfish::registries::environmental
 const Header header = {
     "Copyright 2023 DMTF. All rights reserved.",
     "#MessageRegistry.v1_6_2.MessageRegistry",
-    "Environmental.1.0.1",
+    1,
+    0,
+    1,
     "Environmental Message Registry",
     "en",
     "This registry defines messages related to environmental sensors, heating and cooling equipment, or other environmental conditions.",
     "Environmental",
-    "1.0.1",
     "DMTF",
 };
 constexpr const char* url =

--- a/redfish-core/include/registries/ethernet_fabric_message_registry.hpp
+++ b/redfish-core/include/registries/ethernet_fabric_message_registry.hpp
@@ -20,12 +20,13 @@ namespace redfish::registries::ethernet_fabric
 const Header header = {
     "Copyright 2020-2023 DMTF. All rights reserved.",
     "#MessageRegistry.v1_6_2.MessageRegistry",
-    "EthernetFabric.1.0.1",
+    1,
+    0,
+    1,
     "Ethernet Fabric Message Registry",
     "en",
     "This registry defines messages for Ethernet fabrics.",
     "EthernetFabric",
-    "1.0.1",
     "DMTF",
 };
 constexpr const char* url =

--- a/redfish-core/include/registries/fabric_message_registry.hpp
+++ b/redfish-core/include/registries/fabric_message_registry.hpp
@@ -20,12 +20,13 @@ namespace redfish::registries::fabric
 const Header header = {
     "Copyright 2014-2023 DMTF. All rights reserved.",
     "#MessageRegistry.v1_6_2.MessageRegistry",
-    "Fabric.1.0.2",
+    1,
+    0,
+    2,
     "Fabric Message Registry",
     "en",
     "This registry defines messages for generic fabrics.",
     "Fabric",
-    "1.0.2",
     "DMTF",
 };
 constexpr const char* url =

--- a/redfish-core/include/registries/heartbeat_event_message_registry.hpp
+++ b/redfish-core/include/registries/heartbeat_event_message_registry.hpp
@@ -20,12 +20,13 @@ namespace redfish::registries::heartbeat_event
 const Header header = {
     "Copyright 2021-2023 DMTF. All rights reserved.",
     "#MessageRegistry.v1_6_2.MessageRegistry",
-    "HeartbeatEvent.1.0.1",
+    1,
+    0,
+    1,
     "Heartbeat Event Message Registry",
     "en",
     "This registry defines the messages to use for periodic heartbeat, also known as 'keep alive', events.",
     "HeartbeatEvent",
-    "1.0.1",
     "DMTF",
 };
 constexpr const char* url =

--- a/redfish-core/include/registries/job_event_message_registry.hpp
+++ b/redfish-core/include/registries/job_event_message_registry.hpp
@@ -20,12 +20,13 @@ namespace redfish::registries::job_event
 const Header header = {
     "Copyright 2014-2023 DMTF in cooperation with the Storage Networking Industry Association (SNIA). All rights reserved.",
     "#MessageRegistry.v1_6_2.MessageRegistry",
-    "JobEvent.1.0.1",
+    1,
+    0,
+    1,
     "Job Event Message Registry",
     "en",
     "This registry defines the messages for job related events.",
     "JobEvent",
-    "1.0.1",
     "DMTF",
 };
 constexpr const char* url =

--- a/redfish-core/include/registries/license_message_registry.hpp
+++ b/redfish-core/include/registries/license_message_registry.hpp
@@ -20,12 +20,13 @@ namespace redfish::registries::license
 const Header header = {
     "Copyright 2014-2023 DMTF. All rights reserved.",
     "#MessageRegistry.v1_6_2.MessageRegistry",
-    "License.1.0.3",
+    1,
+    0,
+    3,
     "License Message Registry",
     "en",
     "This registry defines the license status and error messages.",
     "License",
-    "1.0.3",
     "DMTF",
 };
 constexpr const char* url =

--- a/redfish-core/include/registries/log_service_message_registry.hpp
+++ b/redfish-core/include/registries/log_service_message_registry.hpp
@@ -20,12 +20,13 @@ namespace redfish::registries::log_service
 const Header header = {
     "Copyright 2020-2023 DMTF. All rights reserved.",
     "#MessageRegistry.v1_6_2.MessageRegistry",
-    "LogService.1.0.1",
+    1,
+    0,
+    1,
     "Log Service Message Registry",
     "en",
     "This registry defines the messages for log service related events.",
     "LogService",
-    "1.0.1",
     "DMTF",
 };
 constexpr const char* url =

--- a/redfish-core/include/registries/network_device_message_registry.hpp
+++ b/redfish-core/include/registries/network_device_message_registry.hpp
@@ -20,12 +20,13 @@ namespace redfish::registries::network_device
 const Header header = {
     "Copyright 2019-2023 DMTF. All rights reserved.",
     "#MessageRegistry.v1_6_2.MessageRegistry",
-    "NetworkDevice.1.0.3",
+    1,
+    0,
+    3,
     "Network Device Message Registry",
     "en",
     "This registry defines the messages for networking devices.",
     "NetworkDevice",
-    "1.0.3",
     "DMTF",
 };
 constexpr const char* url =

--- a/redfish-core/include/registries/openbmc_message_registry.hpp
+++ b/redfish-core/include/registries/openbmc_message_registry.hpp
@@ -20,12 +20,13 @@ namespace redfish::registries::openbmc
 const Header header = {
     "Copyright 2024 OpenBMC. All rights reserved.",
     "#MessageRegistry.v1_4_0.MessageRegistry",
-    "OpenBMC.0.6.0",
+    0,
+    6,
+    0,
     "OpenBMC Message Registry",
     "en",
     "This registry defines the base messages for OpenBMC.",
     "OpenBMC",
-    "0.6.0",
     "OpenBMC",
 };
 constexpr const char* url =

--- a/redfish-core/include/registries/platform_message_registry.hpp
+++ b/redfish-core/include/registries/platform_message_registry.hpp
@@ -20,12 +20,13 @@ namespace redfish::registries::platform
 const Header header = {
     "Copyright 2023 DMTF. All rights reserved.",
     "#MessageRegistry.v1_6_2.MessageRegistry",
-    "Platform.1.0.1",
+    1,
+    0,
+    1,
     "Compute Platform Message Registry",
     "en",
     "This registry defines messages for compute platforms, covering topics related to processor, memory, and I/O device connectivity.",
     "Platform",
-    "1.0.1",
     "DMTF",
 };
 constexpr const char* url =

--- a/redfish-core/include/registries/power_message_registry.hpp
+++ b/redfish-core/include/registries/power_message_registry.hpp
@@ -20,12 +20,13 @@ namespace redfish::registries::power
 const Header header = {
     "Copyright 2023 DMTF. All rights reserved.",
     "#MessageRegistry.v1_6_2.MessageRegistry",
-    "Power.1.0.1",
+    1,
+    0,
+    1,
     "Power Message Registry",
     "en",
     "This registry defines messages related to electrical measurements and power distribution equipment.",
     "Power",
-    "1.0.1",
     "DMTF",
 };
 constexpr const char* url =

--- a/redfish-core/include/registries/resource_event_message_registry.hpp
+++ b/redfish-core/include/registries/resource_event_message_registry.hpp
@@ -20,12 +20,13 @@ namespace redfish::registries::resource_event
 const Header header = {
     "Copyright 2014-2023 DMTF in cooperation with the Storage Networking Industry Association (SNIA). All rights reserved.",
     "#MessageRegistry.v1_6_0.MessageRegistry",
-    "ResourceEvent.1.3.0",
+    1,
+    3,
+    0,
     "Resource Event Message Registry",
     "en",
     "This registry defines the messages to use for resource events.",
     "ResourceEvent",
-    "1.3.0",
     "DMTF",
 };
 constexpr const char* url =

--- a/redfish-core/include/registries/sensor_event_message_registry.hpp
+++ b/redfish-core/include/registries/sensor_event_message_registry.hpp
@@ -20,12 +20,13 @@ namespace redfish::registries::sensor_event
 const Header header = {
     "Copyright 2022-2023 DMTF. All rights reserved.",
     "#MessageRegistry.v1_6_2.MessageRegistry",
-    "SensorEvent.1.0.1",
+    1,
+    0,
+    1,
     "Sensor Event Message Registry",
     "en",
     "This registry defines messages used for general events related to Sensor resources.",
     "SensorEvent",
-    "1.0.1",
     "DMTF",
 };
 constexpr const char* url =

--- a/redfish-core/include/registries/storage_device_message_registry.hpp
+++ b/redfish-core/include/registries/storage_device_message_registry.hpp
@@ -20,12 +20,13 @@ namespace redfish::registries::storage_device
 const Header header = {
     "Copyright 2020-2023 DMTF. All rights reserved.",
     "#MessageRegistry.v1_6_2.MessageRegistry",
-    "StorageDevice.1.2.1",
+    1,
+    2,
+    1,
     "Storage Device Message Registry",
     "en",
     "This registry defines the messages for storage devices.",
     "StorageDevice",
-    "1.2.1",
     "DMTF",
 };
 constexpr const char* url =

--- a/redfish-core/include/registries/task_event_message_registry.hpp
+++ b/redfish-core/include/registries/task_event_message_registry.hpp
@@ -20,12 +20,13 @@ namespace redfish::registries::task_event
 const Header header = {
     "Copyright 2014-2020 DMTF in cooperation with the Storage Networking Industry Association (SNIA). All rights reserved.",
     "#MessageRegistry.v1_4_1.MessageRegistry",
-    "TaskEvent.1.0.3",
+    1,
+    0,
+    3,
     "Task Event Message Registry",
     "en",
     "This registry defines the messages for task related events.",
     "TaskEvent",
-    "1.0.3",
     "DMTF",
 };
 constexpr const char* url =

--- a/redfish-core/include/registries/telemetry_message_registry.hpp
+++ b/redfish-core/include/registries/telemetry_message_registry.hpp
@@ -20,12 +20,13 @@ namespace redfish::registries::telemetry
 const Header header = {
     "Copyright 2023 DMTF. All rights reserved.",
     "#MessageRegistry.v1_6_2.MessageRegistry",
-    "Telemetry.1.0.0",
+    1,
+    0,
+    0,
     "Telemetry Message Registry",
     "en",
     "This registry defines the messages for telemetry related events.",
     "Telemetry",
-    "1.0.0",
     "DMTF",
 };
 constexpr const char* url =

--- a/redfish-core/include/registries/update_message_registry.hpp
+++ b/redfish-core/include/registries/update_message_registry.hpp
@@ -20,12 +20,13 @@ namespace redfish::registries::update
 const Header header = {
     "Copyright 2014-2023 DMTF. All rights reserved.",
     "#MessageRegistry.v1_6_2.MessageRegistry",
-    "Update.1.0.2",
+    1,
+    0,
+    2,
     "Update Message Registry",
     "en",
     "This registry defines the update status and error messages.",
     "Update",
-    "1.0.2",
     "DMTF",
 };
 constexpr const char* url =

--- a/redfish-core/include/registries_selector.hpp
+++ b/redfish-core/include/registries_selector.hpp
@@ -1,6 +1,7 @@
 #pragma once
 #include "registries.hpp"
 #include "registries/base_message_registry.hpp"
+#include "registries/bios_message_registry.hpp"
 #include "registries/heartbeat_event_message_registry.hpp"
 #include "registries/license_message_registry.hpp"
 #include "registries/openbmc_message_registry.hpp"
@@ -26,6 +27,10 @@ inline std::optional<registries::HeaderAndUrl>
     if (base::header.registryPrefix == registryName)
     {
         return HeaderAndUrl{base::header, base::url};
+    }
+    if (bios::header.registryPrefix == registryName)
+    {
+        return HeaderAndUrl{bios::header, bios::url};
     }
     if (heartbeat_event::header.registryPrefix == registryName)
     {
@@ -60,6 +65,11 @@ inline std::span<const MessageEntry>
     if (base::header.registryPrefix == registryName)
     {
         return {base::registry};
+    }
+    if (bios::header.registryPrefix == registryName)
+    {
+        // TODO - does this need a different registry?
+        return {openbmc::registry};
     }
     if (heartbeat_event::header.registryPrefix == registryName)
     {

--- a/redfish-core/include/registries_selector.hpp
+++ b/redfish-core/include/registries_selector.hpp
@@ -1,27 +1,89 @@
 #pragma once
+#include "registries.hpp"
 #include "registries/base_message_registry.hpp"
+#include "registries/heartbeat_event_message_registry.hpp"
+#include "registries/license_message_registry.hpp"
 #include "registries/openbmc_message_registry.hpp"
+#include "registries/resource_event_message_registry.hpp"
 #include "registries/task_event_message_registry.hpp"
+#include "registries/telemetry_message_registry.hpp"
 
+#include <optional>
 #include <span>
 #include <string_view>
 
 namespace redfish::registries
 {
+struct HeaderAndUrl
+{
+    const Header& header;
+    const char* url;
+};
+
+inline std::optional<registries::HeaderAndUrl>
+    getRegistryHeaderAndUrlFromPrefix(std::string_view registryName)
+{
+    if (base::header.registryPrefix == registryName)
+    {
+        return HeaderAndUrl{base::header, base::url};
+    }
+    if (heartbeat_event::header.registryPrefix == registryName)
+    {
+        return HeaderAndUrl{heartbeat_event::header, heartbeat_event::url};
+    }
+    if (license::header.registryPrefix == registryName)
+    {
+        return HeaderAndUrl{license::header, license::url};
+    }
+    if (openbmc::header.registryPrefix == registryName)
+    {
+        return HeaderAndUrl{openbmc::header, openbmc::url};
+    }
+    if (resource_event::header.registryPrefix == registryName)
+    {
+        return HeaderAndUrl{resource_event::header, resource_event::url};
+    }
+    if (task_event::header.registryPrefix == registryName)
+    {
+        return HeaderAndUrl{task_event::header, task_event::url};
+    }
+    if (telemetry::header.registryPrefix == registryName)
+    {
+        return HeaderAndUrl{telemetry::header, telemetry::url};
+    }
+    return std::nullopt;
+}
+
 inline std::span<const MessageEntry>
     getRegistryFromPrefix(std::string_view registryName)
 {
-    if (task_event::header.registryPrefix == registryName)
+    if (base::header.registryPrefix == registryName)
     {
-        return {task_event::registry};
+        return {base::registry};
+    }
+    if (heartbeat_event::header.registryPrefix == registryName)
+    {
+        return {heartbeat_event::registry};
+    }
+    if (license::header.registryPrefix == registryName)
+    {
+        return {license::registry};
     }
     if (openbmc::header.registryPrefix == registryName)
     {
         return {openbmc::registry};
     }
-    if (base::header.registryPrefix == registryName)
+    if (resource_event::header.registryPrefix == registryName)
     {
-        return {base::registry};
+        return {resource_event::registry};
+    }
+    if (task_event::header.registryPrefix == registryName)
+    {
+        return {task_event::registry};
+    }
+    if (telemetry::header.registryPrefix == registryName)
+    {
+        return {telemetry::registry};
     }
     return {openbmc::registry};
 }

--- a/redfish-core/lib/event_service.hpp
+++ b/redfish-core/lib/event_service.hpp
@@ -922,17 +922,17 @@ inline void requestRoutesEventDestination(App& app)
                     subValue->userSub->hbIntervalMinutes = *hbIntervalMinutes;
                 }
 
+                if (hbIntervalMinutes || sendHeartbeat)
+                {
+                    // if Heartbeat interval or send heart were changed, cancel
+                    // the heartbeat timer if running and start a new heartbeat
+                    // if needed
+                    subValue->heartbeatParametersChanged();
+                }
+
                 if (verifyCertificate)
                 {
                     subValue->userSub->verifyCertificate = *verifyCertificate;
-                }
-
-                // if Heartbeat interval or send heart were changed, cancel the
-                // heartbeat timer if running and start a new heartbeat if
-                // needed
-                if (hbIntervalMinutes || sendHeartbeat)
-                {
-                    subValue->heartbeatParametersChanged();
                 }
 
                 EventServiceManager::getInstance().updateSubscriptionData();

--- a/redfish-core/lib/message_registries.hpp
+++ b/redfish-core/lib/message_registries.hpp
@@ -91,7 +91,7 @@ inline void handleMessageRoutesMessageRegistryFileGet(
                                    registry);
         return;
     }
-    if (registry == "OpenBMC")
+    if (registry == "OpenBMC" || registry == "BiosAttributeRegistry")
     {
         dmtf.clear();
     }

--- a/redfish-core/lib/message_registries.hpp
+++ b/redfish-core/lib/message_registries.hpp
@@ -24,6 +24,7 @@
 #include <boost/url/format.hpp>
 
 #include <array>
+#include <format>
 
 namespace redfish
 {
@@ -105,7 +106,9 @@ inline void handleMessageRoutesMessageRegistryFileGet(
     asyncResp->res.jsonValue["Description"] =
         dmtf + registry + " Message Registry File Location";
     asyncResp->res.jsonValue["Id"] = header.registryPrefix;
-    asyncResp->res.jsonValue["Registry"] = header.id;
+    asyncResp->res.jsonValue["Registry"] =
+        std::format("{}.{}.{}", header.registryPrefix, header.versionMajor,
+                    header.versionMinor);
     nlohmann::json::array_t languages;
     languages.emplace_back(header.language);
     asyncResp->res.jsonValue["Languages@odata.count"] = languages.size();
@@ -168,12 +171,16 @@ inline void handleMessageRegistryGet(
 
     asyncResp->res.jsonValue["@Redfish.Copyright"] = header.copyright;
     asyncResp->res.jsonValue["@odata.type"] = header.type;
-    asyncResp->res.jsonValue["Id"] = header.id;
+    asyncResp->res.jsonValue["Id"] =
+        std::format("{}.{}.{}.{}", header.registryPrefix, header.versionMajor,
+                    header.versionMinor, header.versionPatch);
     asyncResp->res.jsonValue["Name"] = header.name;
     asyncResp->res.jsonValue["Language"] = header.language;
     asyncResp->res.jsonValue["Description"] = header.description;
     asyncResp->res.jsonValue["RegistryPrefix"] = header.registryPrefix;
-    asyncResp->res.jsonValue["RegistryVersion"] = header.registryVersion;
+    asyncResp->res.jsonValue["RegistryVersion"] =
+        std::format("{}.{}.{}", header.versionMajor, header.versionMinor,
+                    header.versionPatch);
     asyncResp->res.jsonValue["OwningEntity"] = header.owningEntity;
 
     nlohmann::json& messageObj = asyncResp->res.jsonValue["Messages"];

--- a/redfish-core/lib/message_registries.hpp
+++ b/redfish-core/lib/message_registries.hpp
@@ -19,15 +19,7 @@
 #include "bios.hpp"
 #include "query.hpp"
 #include "registries.hpp"
-#include "registries/base_message_registry.hpp"
-#include "registries/bios_registry.hpp"
-#include "registries/heartbeat_event_message_registry.hpp"
-#include "registries/license_message_registry.hpp"
-#include "registries/openbmc_message_registry.hpp"
-#include "registries/privilege_registry.hpp"
-#include "registries/resource_event_message_registry.hpp"
-#include "registries/task_event_message_registry.hpp"
-#include "registries/telemetry_message_registry.hpp"
+#include "registries_selector.hpp"
 
 #include <boost/url/format.hpp>
 
@@ -88,56 +80,22 @@ inline void handleMessageRoutesMessageRegistryFileGet(
     {
         return;
     }
-    const registries::Header* header = nullptr;
     std::string dmtf = "DMTF ";
-    const char* url = nullptr;
+    std::optional<registries::HeaderAndUrl> headerAndUrl =
+        registries::getRegistryHeaderAndUrlFromPrefix(registry);
 
-    if (registry == "Base")
-    {
-        header = &registries::base::header;
-        url = registries::base::url;
-    }
-    else if (registry == "TaskEvent")
-    {
-        header = &registries::task_event::header;
-        url = registries::task_event::url;
-    }
-    else if (registry == "OpenBMC")
-    {
-        header = &registries::openbmc::header;
-        dmtf.clear();
-    }
-    else if (registry == "ResourceEvent")
-    {
-        header = &registries::resource_event::header;
-        url = registries::resource_event::url;
-    }
-    else if (registry == "Telemetry")
-    {
-        header = &registries::telemetry::header;
-        url = registries::telemetry::url;
-    }
-    else if (registry == "BiosAttributeRegistry")
-    {
-        header = &registries::bios::header;
-        dmtf.clear();
-    }
-    else if (registry == "License")
-    {
-        header = &registries::license::header;
-        url = registries::license::url;
-    }
-    else if (registry == "HeartbeatEvent")
-    {
-        header = &registries::heartbeat_event::header;
-        url = registries::heartbeat_event::url;
-    }
-    else
+    if (!headerAndUrl)
     {
         messages::resourceNotFound(asyncResp->res, "MessageRegistryFile",
                                    registry);
         return;
     }
+    if (registry == "OpenBMC")
+    {
+        dmtf.clear();
+    }
+    const registries::Header& header = headerAndUrl->header;
+    const char* url = headerAndUrl->url;
 
     asyncResp->res.jsonValue["@odata.id"] =
         boost::urls::format("/redfish/v1/Registries/{}", registry);
@@ -146,15 +104,15 @@ inline void handleMessageRoutesMessageRegistryFileGet(
     asyncResp->res.jsonValue["Name"] = registry + " Message Registry File";
     asyncResp->res.jsonValue["Description"] =
         dmtf + registry + " Message Registry File Location";
-    asyncResp->res.jsonValue["Id"] = header->registryPrefix;
-    asyncResp->res.jsonValue["Registry"] = header->id;
+    asyncResp->res.jsonValue["Id"] = header.registryPrefix;
+    asyncResp->res.jsonValue["Registry"] = header.id;
     nlohmann::json::array_t languages;
-    languages.emplace_back(header->language);
+    languages.emplace_back(header.language);
     asyncResp->res.jsonValue["Languages@odata.count"] = languages.size();
     asyncResp->res.jsonValue["Languages"] = std::move(languages);
     nlohmann::json::array_t locationMembers;
     nlohmann::json::object_t location;
-    location["Language"] = header->language;
+    location["Language"] = header.language;
     location["Uri"] = "/redfish/v1/Registries/" + registry + "/" + registry;
 
     if (url != nullptr)
@@ -192,110 +150,52 @@ inline void handleMessageRegistryGet(
         return;
     }
 
-    const registries::Header* header = nullptr;
-    std::vector<const registries::MessageEntry*> registryEntries;
-    if (registry == "Base")
-    {
-        header = &registries::base::header;
-        for (const registries::MessageEntry& entry : registries::base::registry)
-        {
-            registryEntries.emplace_back(&entry);
-        }
-    }
-    else if (registry == "TaskEvent")
-    {
-        header = &registries::task_event::header;
-        for (const registries::MessageEntry& entry :
-             registries::task_event::registry)
-        {
-            registryEntries.emplace_back(&entry);
-        }
-    }
-    else if (registry == "OpenBMC")
-    {
-        header = &registries::openbmc::header;
-        for (const registries::MessageEntry& entry :
-             registries::openbmc::registry)
-        {
-            registryEntries.emplace_back(&entry);
-        }
-    }
-    else if (registry == "ResourceEvent")
-    {
-        header = &registries::resource_event::header;
-        for (const registries::MessageEntry& entry :
-             registries::resource_event::registry)
-        {
-            registryEntries.emplace_back(&entry);
-        }
-    }
-    else if (registry == "Telemetry")
-    {
-        header = &registries::telemetry::header;
-        for (const registries::MessageEntry& entry :
-             registries::telemetry::registry)
-        {
-            registryEntries.emplace_back(&entry);
-        }
-    }
-    else if (registry == "License")
-    {
-        header = &registries::license::header;
-        for (const registries::MessageEntry& entry :
-             registries::license::registry)
-        {
-            registryEntries.emplace_back(&entry);
-        }
-    }
-    else if (registry == "HeartbeatEvent")
-    {
-        header = &registries::heartbeat_event::header;
-        for (const registries::MessageEntry& entry :
-             registries::heartbeat_event::registry)
-        {
-            registryEntries.emplace_back(&entry);
-        }
-    }
-    else
+    std::optional<registries::HeaderAndUrl> headerAndUrl =
+        registries::getRegistryHeaderAndUrlFromPrefix(registry);
+    if (!headerAndUrl)
     {
         messages::resourceNotFound(asyncResp->res, "MessageRegistryFile",
                                    registry);
         return;
     }
 
+    const registries::Header& header = headerAndUrl->header;
     if (registry != registryMatch)
     {
-        messages::resourceNotFound(asyncResp->res, header->type, registryMatch);
+        messages::resourceNotFound(asyncResp->res, header.type, registryMatch);
         return;
     }
 
-    asyncResp->res.jsonValue["@Redfish.Copyright"] = header->copyright;
-    asyncResp->res.jsonValue["@odata.type"] = header->type;
-    asyncResp->res.jsonValue["Id"] = header->id;
-    asyncResp->res.jsonValue["Name"] = header->name;
-    asyncResp->res.jsonValue["Language"] = header->language;
-    asyncResp->res.jsonValue["Description"] = header->description;
-    asyncResp->res.jsonValue["RegistryPrefix"] = header->registryPrefix;
-    asyncResp->res.jsonValue["RegistryVersion"] = header->registryVersion;
-    asyncResp->res.jsonValue["OwningEntity"] = header->owningEntity;
+    asyncResp->res.jsonValue["@Redfish.Copyright"] = header.copyright;
+    asyncResp->res.jsonValue["@odata.type"] = header.type;
+    asyncResp->res.jsonValue["Id"] = header.id;
+    asyncResp->res.jsonValue["Name"] = header.name;
+    asyncResp->res.jsonValue["Language"] = header.language;
+    asyncResp->res.jsonValue["Description"] = header.description;
+    asyncResp->res.jsonValue["RegistryPrefix"] = header.registryPrefix;
+    asyncResp->res.jsonValue["RegistryVersion"] = header.registryVersion;
+    asyncResp->res.jsonValue["OwningEntity"] = header.owningEntity;
 
     nlohmann::json& messageObj = asyncResp->res.jsonValue["Messages"];
 
     // Go through the Message Registry and populate each Message
-    for (const registries::MessageEntry* message : registryEntries)
+    const std::span<const registries::MessageEntry> registryEntries =
+        registries::getRegistryFromPrefix(registry);
+
+    for (const registries::MessageEntry& message : registryEntries)
     {
-        nlohmann::json& obj = messageObj[message->first];
-        obj["Description"] = message->second.description;
-        obj["Message"] = message->second.message;
-        obj["Severity"] = message->second.messageSeverity;
-        obj["MessageSeverity"] = message->second.messageSeverity;
-        obj["NumberOfArgs"] = message->second.numberOfArgs;
-        obj["Resolution"] = message->second.resolution;
-        if (message->second.numberOfArgs > 0)
+        nlohmann::json& obj = messageObj[message.first];
+        obj["Description"] = message.second.description;
+        obj["Message"] = message.second.message;
+        obj["Severity"] = message.second.messageSeverity;
+        obj["MessageSeverity"] = message.second.messageSeverity;
+        obj["NumberOfArgs"] = message.second.numberOfArgs;
+        obj["Resolution"] = message.second.resolution;
+        if (message.second.numberOfArgs > 0)
         {
             nlohmann::json& messageParamArray = obj["ParamTypes"];
             messageParamArray = nlohmann::json::array();
-            for (const char* str : message->second.paramTypes)
+            for (const char* str : message.second.paramTypes)
             {
                 if (str == nullptr)
                 {

--- a/scripts/parse_registries.py
+++ b/scripts/parse_registries.py
@@ -80,18 +80,22 @@ def update_registries(files):
             print("{} not found".format(file))
 
         with open(file, "w") as registry:
+
+            version_split = json_dict["RegistryVersion"].split(".")
+
             registry.write(REGISTRY_HEADER.format(namespace))
             # Parse the Registry header info
             registry.write(
                 "const Header header = {{\n"
                 '    "{json_dict[@Redfish.Copyright]}",\n'
                 '    "{json_dict[@odata.type]}",\n'
-                '    "{json_dict[Id]}",\n'
+                "    {version_split[0]},\n"
+                "    {version_split[1]},\n"
+                "    {version_split[2]},\n"
                 '    "{json_dict[Name]}",\n'
                 '    "{json_dict[Language]}",\n'
                 '    "{json_dict[Description]}",\n'
                 '    "{json_dict[RegistryPrefix]}",\n'
-                '    "{json_dict[RegistryVersion]}",\n'
                 '    "{json_dict[OwningEntity]}",\n'
                 "}};\n"
                 "constexpr const char* url =\n"
@@ -101,6 +105,7 @@ def update_registries(files):
                 "{{\n".format(
                     json_dict=json_dict,
                     url=url,
+                    version_split=version_split,
                 )
             )
 

--- a/test/redfish-core/include/utils/dbus_utils.cpp
+++ b/test/redfish-core/include/utils/dbus_utils.cpp
@@ -39,7 +39,7 @@ TEST(DbusUtils, AfterPropertySetSuccess)
                             "@odata.type": "#Message.v1_1_1.Message",
                             "Message": "The request completed successfully.",
                             "MessageArgs": [],
-                            "MessageId": "Base.1.19.0.Success",
+                            "MessageId": "Base.1.19.Success",
                             "MessageSeverity": "OK",
                             "Resolution": "None."
                         }
@@ -71,12 +71,12 @@ TEST(DbusUtils, AfterPropertySetInternalError)
                         "@odata.type": "#Message.v1_1_1.Message",
                         "Message": "The request failed due to an internal service error.  The service is still operational.",
                         "MessageArgs": [],
-                        "MessageId": "Base.1.19.0.InternalError",
+                        "MessageId": "Base.1.19.InternalError",
                         "MessageSeverity": "Critical",
                         "Resolution": "Resubmit the request.  If the problem persists, consider resetting the service."
                         }
                     ],
-                    "code": "Base.1.19.0.InternalError",
+                    "code": "Base.1.19.InternalError",
                     "message": "The request failed due to an internal service error.  The service is still operational."
                     }
                 })"_json);

--- a/test/redfish-core/include/utils/json_utils_test.cpp
+++ b/test/redfish-core/include/utils/json_utils_test.cpp
@@ -393,7 +393,7 @@ TEST(ReadJsonPatch, VerifyReadJsonPatchIntegerReturnsOutOfRange)
         res.jsonValue["error"]["@Message.ExtendedInfo"];
     EXPECT_THAT(resExtInfo[0]["@odata.type"], "#Message.v1_1_1.Message");
     EXPECT_THAT(resExtInfo[0]["MessageId"],
-                "Base.1.19.0.PropertyValueOutOfRange");
+                "Base.1.19.PropertyValueOutOfRange");
     EXPECT_THAT(resExtInfo[0]["MessageSeverity"], "Warning");
 }
 


### PR DESCRIPTION
This is to catch up the latest upstream heartbeat logic. 
The following commits are included.

- https://gerrit.openbmc.org/c/openbmc/bmcweb/+/76180   // Make message registries use 2 digit versions
- https://gerrit.openbmc.org/c/openbmc/bmcweb/+/76261   // Make eventId increment per event
- https://gerrit.openbmc.org/c/openbmc/bmcweb/+/76260   // Refactor Message Header and Url Selector

This commit is synced
https://gerrit.openbmc.org/c/openbmc/bmcweb/+/75791   // Catch up the upstream Subscription Heartbeat Logic


Tested:
- Heartbeat logic (that describes in https://gerrit.openbmc.org/c/openbmc/bmcweb/+/75791)
- Redfish Service Validator passes (as it was)

