### PR TITLE
network: fix dhcp values in redfish response

### DIFF
--- a/redfish-core/lib/ethernet.hpp
+++ b/redfish-core/lib/ethernet.hpp
@@ -155,7 +155,9 @@ inline bool translateDhcpEnabledToBool(const std::string& inputDHCP,
             (inputDHCP ==
              "xyz.openbmc_project.Network.EthernetInterface.DHCPConf.v4") ||
             (inputDHCP ==
-             "xyz.openbmc_project.Network.EthernetInterface.DHCPConf.both"));
+             "xyz.openbmc_project.Network.EthernetInterface.DHCPConf.both") ||
+            (inputDHCP ==
+             "xyz.openbmc_project.Network.EthernetInterface.DHCPConf.v4v6stateless"));
     }
     return ((inputDHCP ==
              "xyz.openbmc_project.Network.EthernetInterface.DHCPConf.v6") ||


### PR DESCRIPTION
Whenever IPv6 SLAAC is enabled and DHCPv4 is enabled, the "DHCPEnabled" value in the backend will be "v4v6stateless". Currently in bmcweb, the check to translate this value to bool for ipv4 is not present and will return false. That means, "DHCPEnabled" is wrongly displayed 'false' while the correct value is 'true'.

Upstream: https://gerrit.openbmc.org/c/openbmc/bmcweb/+/76560

Change-Id: I8713d73727c6a382f06b7bf0d598ab61a757e1e3