### PR TITLE
Fix setting gateways

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -412,6 +412,7 @@ srcfiles_unittest = files(
     'test/redfish-core/include/utils/stl_utils_test.cpp',
     'test/redfish-core/include/utils/time_utils_test.cpp',
     'test/redfish-core/lib/chassis_test.cpp',
+    'test/redfish-core/lib/ethernet_test.cpp',
     'test/redfish-core/lib/log_services_dump_test.cpp',
     'test/redfish-core/lib/log_services_test.cpp',
     'test/redfish-core/lib/manager_diagnostic_data_test.cpp',

--- a/test/redfish-core/lib/ethernet_test.cpp
+++ b/test/redfish-core/lib/ethernet_test.cpp
@@ -1,0 +1,212 @@
+#include "ethernet.hpp"
+#include "http_response.hpp"
+
+#include <nlohmann/json.hpp>
+
+#include <cstddef>
+#include <string>
+#include <variant>
+#include <vector>
+
+#include <gmock/gmock.h>
+#include <gtest/gtest.h>
+
+namespace redfish
+{
+namespace
+{
+
+using ::testing::IsEmpty;
+
+TEST(Ethernet, parseAddressesEmpty)
+{
+    std::vector<std::variant<nlohmann::json::object_t, std::nullptr_t>> addr;
+    std::vector<IPv4AddressData> existingAddr;
+
+    std::vector<AddressPatch> addrOut;
+    std::string gatewayOut;
+
+    crow::Response res;
+
+    EXPECT_TRUE(parseAddresses(addr, existingAddr, res, addrOut, gatewayOut));
+    EXPECT_THAT(addrOut, IsEmpty());
+    EXPECT_THAT(gatewayOut, IsEmpty());
+}
+
+// Create full entry with all fields
+TEST(Ethernet, parseAddressesCreateOne)
+{
+    std::vector<std::variant<nlohmann::json::object_t, std::nullptr_t>> addr;
+    nlohmann::json::object_t eth;
+    eth["Address"] = "1.1.1.2";
+    eth["Gateway"] = "1.1.1.1";
+    eth["SubnetMask"] = "255.255.255.0";
+    addr.emplace_back(eth);
+    std::vector<IPv4AddressData> existingAddr;
+
+    std::vector<AddressPatch> addrOut;
+    std::string gatewayOut;
+
+    crow::Response res;
+
+    EXPECT_TRUE(parseAddresses(addr, existingAddr, res, addrOut, gatewayOut));
+    EXPECT_EQ(addrOut.size(), 1);
+    EXPECT_EQ(addrOut[0].address, "1.1.1.2");
+    EXPECT_EQ(addrOut[0].gateway, "1.1.1.1");
+    EXPECT_EQ(addrOut[0].prefixLength, 24);
+    EXPECT_EQ(addrOut[0].existingDbusId, "");
+    EXPECT_EQ(addrOut[0].operation, AddrChange::Update);
+    EXPECT_EQ(gatewayOut, "1.1.1.1");
+}
+
+// Missing gateway should default to no gateway
+TEST(Ethernet, parseAddressesCreateOneNoGateway)
+{
+    std::vector<std::variant<nlohmann::json::object_t, std::nullptr_t>> addr;
+    nlohmann::json::object_t eth;
+    eth["Address"] = "1.1.1.2";
+    eth["SubnetMask"] = "255.255.255.0";
+    addr.emplace_back(eth);
+    std::vector<IPv4AddressData> existingAddr;
+
+    std::vector<AddressPatch> addrOut;
+    std::string gatewayOut;
+
+    crow::Response res;
+
+    EXPECT_TRUE(parseAddresses(addr, existingAddr, res, addrOut, gatewayOut));
+    EXPECT_EQ(addrOut.size(), 1);
+    EXPECT_EQ(addrOut[0].address, "1.1.1.2");
+    EXPECT_EQ(addrOut[0].gateway, "");
+    EXPECT_EQ(addrOut[0].prefixLength, 24);
+    EXPECT_EQ(addrOut[0].existingDbusId, "");
+    EXPECT_EQ(addrOut[0].operation, AddrChange::Update);
+    EXPECT_EQ(gatewayOut, "");
+}
+
+// Create two entries with conflicting gateways.
+TEST(Ethernet, conflictingGatewaysNew)
+{
+    std::vector<std::variant<nlohmann::json::object_t, std::nullptr_t>> addr;
+    nlohmann::json::object_t eth;
+    eth["Address"] = "1.1.1.2";
+    eth["Gateway"] = "1.1.1.1";
+    eth["SubnetMask"] = "255.255.255.0";
+    addr.emplace_back(eth);
+    eth["Gateway"] = "1.1.1.5";
+    addr.emplace_back(eth);
+    std::vector<IPv4AddressData> existingAddr;
+
+    std::vector<AddressPatch> addrOut;
+    std::string gatewayOut;
+
+    crow::Response res;
+
+    EXPECT_FALSE(parseAddresses(addr, existingAddr, res, addrOut, gatewayOut));
+}
+
+// Create full entry with all fields
+TEST(Ethernet, conflictingGatewaysExisting)
+{
+    std::vector<std::variant<nlohmann::json::object_t, std::nullptr_t>> addr;
+    nlohmann::json::object_t eth;
+    addr.emplace_back(eth);
+    eth["Address"] = "1.1.1.2";
+    eth["Gateway"] = "1.1.1.1";
+    eth["SubnetMask"] = "255.255.255.0";
+    addr.emplace_back(eth);
+    std::vector<IPv4AddressData> existingAddr;
+    IPv4AddressData& existing = existingAddr.emplace_back();
+    existing.id = "my_ip_id";
+    existing.origin = "Static";
+    existing.gateway = "192.168.1.1";
+
+    std::vector<AddressPatch> addrOut;
+    std::string gatewayOut;
+
+    crow::Response res;
+
+    EXPECT_FALSE(parseAddresses(addr, existingAddr, res, addrOut, gatewayOut));
+}
+
+// Missing address should fail
+TEST(Ethernet, parseMissingAddress)
+{
+    std::vector<std::variant<nlohmann::json::object_t, std::nullptr_t>> addr;
+    nlohmann::json::object_t eth;
+    eth["SubnetMask"] = "255.255.255.0";
+    addr.emplace_back(eth);
+    std::vector<IPv4AddressData> existingAddr;
+
+    std::vector<AddressPatch> addrOut;
+    std::string gatewayOut;
+
+    crow::Response res;
+
+    EXPECT_FALSE(parseAddresses(addr, existingAddr, res, addrOut, gatewayOut));
+}
+
+// Missing subnet should fail
+TEST(Ethernet, parseAddressesMissingSubnet)
+{
+    std::vector<std::variant<nlohmann::json::object_t, std::nullptr_t>> addr;
+    nlohmann::json::object_t eth;
+    eth["Address"] = "1.1.1.2";
+    addr.emplace_back(eth);
+    std::vector<IPv4AddressData> existingAddr;
+
+    std::vector<AddressPatch> addrOut;
+    std::string gatewayOut;
+
+    crow::Response res;
+
+    EXPECT_FALSE(parseAddresses(addr, existingAddr, res, addrOut, gatewayOut));
+}
+
+// With one existing address, and a null, it should request deletion
+// and clear gateway
+TEST(Ethernet, parseAddressesDeleteExistingOnNull)
+{
+    std::vector<std::variant<nlohmann::json::object_t, std::nullptr_t>> addr;
+    addr.emplace_back(nullptr);
+    std::vector<IPv4AddressData> existingAddr;
+    IPv4AddressData& existing = existingAddr.emplace_back();
+    existing.id = "my_ip_id";
+    existing.origin = "Static";
+
+    std::vector<AddressPatch> addrOut;
+    std::string gatewayOut;
+
+    crow::Response res;
+
+    EXPECT_TRUE(parseAddresses(addr, existingAddr, res, addrOut, gatewayOut));
+    EXPECT_EQ(addrOut.size(), 1);
+    EXPECT_EQ(addrOut[0].existingDbusId, "my_ip_id");
+    EXPECT_EQ(addrOut[0].operation, AddrChange::Delete);
+    EXPECT_EQ(gatewayOut, "");
+}
+
+TEST(Ethernet, parseAddressesDeleteExistingOnShortLength)
+{
+    // With one existing address, and an input of len(0) it should request
+    // deletion and clear gateway
+    std::vector<std::variant<nlohmann::json::object_t, std::nullptr_t>> addr;
+    std::vector<IPv4AddressData> existingAddr;
+    IPv4AddressData& existing = existingAddr.emplace_back();
+    existing.id = "my_ip_id";
+    existing.origin = "Static";
+
+    std::vector<AddressPatch> addrOut;
+    std::string gatewayOut;
+
+    crow::Response res;
+
+    EXPECT_TRUE(parseAddresses(addr, existingAddr, res, addrOut, gatewayOut));
+    EXPECT_EQ(addrOut.size(), 1);
+    EXPECT_EQ(addrOut[0].existingDbusId, "my_ip_id");
+    EXPECT_EQ(addrOut[0].operation, AddrChange::Delete);
+    EXPECT_EQ(gatewayOut, "");
+}
+
+} // namespace
+} // namespace redfish


### PR DESCRIPTION
There's a number of conditions in setting gateways that don't work properly.  Specifically, one of the issues is setting a gateway on an address that already exists.  It returns a PropertyValueConflict error on Ipv4Addresses/1/Gateway with Ipv4Addresses/1/Gateway

Obviously an address can't conflict with itself, so this is wrong.

To address this, move the gateway setting and selection code into a routine outside of the main loop, after all the gateways are accounted for, and so we can treat them separately.

Tested;
PATCH to an existing ip address works, and no longer returns the error.


Fixes : https://jazz07.rchland.ibm.com:13443/jazz/web/projects/CSSD#action=com.ibm.team.workitem.viewWorkItem&id=635827
Upstream : https://gerrit.openbmc.org/c/openbmc/bmcweb/+/75859
Change-Id: I0339e02fc27164337416637153d0b0f744b64ad8