### PR TITLE
Add path of problem device to trace

### DIFF
--- a/redfish-core/lib/pcie.hpp
+++ b/redfish-core/lib/pcie.hpp
@@ -377,8 +377,8 @@ inline void getPCIeDeviceSlotPath(
             if (endpoints.size() > 1)
             {
                 BMCWEB_LOG_ERROR(
-                    "PCIeDevice is associated with more than one PCIeSlot: {}",
-                    endpoints.size());
+                    "PCIeDevice {} is associated with more than one PCIeSlot: {}",
+                    pcieDevicePath, endpoints.size());
                 messages::internalError(asyncResp->res);
                 return;
             }


### PR DESCRIPTION
I needed this to debug a problem. Might be useful in the future.

[ERROR pcie.hpp:381] PCIeDevice /xyz/openbmc_project/inventory/system/chassis15873/motherboard3/slot24/logical_slot2/adapter1 is associated with more than one PCIeSlot: 2

Upstream is merged at https://gerrit.openbmc.org/c/openbmc/bmcweb/+/77209
