### PR TITLE
HW-Isolation: Fix info PEL AdditionalDataURI

### DIFF
--- a/redfish-core/lib/log_services.hpp
+++ b/redfish-core/lib/log_services.hpp
@@ -7128,6 +7128,8 @@ inline void fillSystemHardwareIsolationLogEntry(
              : asyncResp->res.jsonValue);
 
     std::string guardType;
+
+    bool hiddenPEL = false;
     // We need the severity details before getting the associations
     // to fill the message details.
     for (const auto& interface : dbusObjIt->second)
@@ -7159,6 +7161,7 @@ inline void fillSystemHardwareIsolationLogEntry(
                             "xyz.openbmc_project.HardwareIsolation.Entry.Type.Spare")
                     {
                         entryJson["Severity"] = "OK";
+                        hiddenPEL = true;
                     }
                 }
             }
@@ -7220,9 +7223,14 @@ inline void fillSystemHardwareIsolationLogEntry(
                         {
                             sdbusplus::message::object_path errPath =
                                 std::get<2>(assoc);
+                            std::string logPath = "EventLog";
+                            if (hiddenPEL)
+                            {
+                                logPath = "CELog";
+                            }
                             entryJson["AdditionalDataURI"] = boost::urls::format(
-                                "/redfish/v1/Systems/system/LogServices/EventLog/Entries/{}/attachment",
-                                errPath.filename());
+                                "/redfish/v1/Systems/system/LogServices/{}/Entries/{}/attachment",
+                                logPath, errPath.filename());
                         }
                     }
                 }


### PR DESCRIPTION
When the guard severity is OK, it could be associated with an informational PEL.  And the informational PELs are listed under /redfish/v1/Systems/system/LogServices/CELog/Entries/ and the other PELs are listed under
/redfish/v1/Systems/system/LogServices/EventLog/Entries/

So based on the guard type, assign the URI. Tested with guards that have severity as OK and the URI maps to CELog and for other guards, it maps to EventLog

Test Results:

```

curl -k -H "X-Auth-Token: $bmc_token" -XGET https://${BMC_IP}/redfish/v1/Systems/system/LogServices/HardwareIsolation/Entries

"@odata.id": "/redfish/v1/Systems/system/LogServices/HardwareIsolation/Entries",
"@odata.type": "#LogEntryCollection.LogEntryCollection",
"Description": "Collection of System Hardware Isolation Entries",
"Members": [
{
  "@odata.id": "/redfish/v1/Systems/system/LogServices/HardwareIsolation/Entries/1",
  "@odata.type": "#LogEntry.v1_9_0.LogEntry",
  "AdditionalDataURI": "/redfish/v1/Systems/system/LogServices/CELog/Entries/1401/attachment",
  ...
  ...
  ],
  "MessageId": "OpenBMC.0.6.GuardRecord",
  "Name": "Hardware Isolation Entry",
  "Severity": "OK"
}
...
],

```