### PR TITLE
Power Supply, Fan: Look at PrettyName

### DIFF
--- a/redfish-core/lib/fan.hpp
+++ b/redfish-core/lib/fan.hpp
@@ -10,6 +10,7 @@
 #include "utils/chassis_utils.hpp"
 #include "utils/fan_utils.hpp"
 #include "utils/json_utils.hpp"
+#include "utils/name_utils.hpp"
 
 #include <boost/system/error_code.hpp>
 #include <boost/url/format.hpp>
@@ -195,7 +196,6 @@ inline void addFanCommonProperties(crow::Response& resp,
     resp.addHeader(boost::beast::http::field::link,
                    "</redfish/v1/JsonSchemas/Fan/Fan.json>; rel=describedby");
     resp.jsonValue["@odata.type"] = "#Fan.v1_3_0.Fan";
-    resp.jsonValue["Name"] = "Fan";
     resp.jsonValue["Id"] = fanId;
     resp.jsonValue["@odata.id"] = boost::urls::format(
         "/redfish/v1/Chassis/{}/ThermalSubsystem/Fans/{}", chassisId, fanId);
@@ -349,6 +349,9 @@ inline void
     getFanAsset(asyncResp, fanPath, service);
     getFanLocation(asyncResp, fanPath, service);
     getLocationIndicatorActive(asyncResp, fanPath);
+    const dbus::utility::MapperServiceMap& serviceMatch = {{service, {""}}};
+    name_util::getPrettyName(asyncResp, fanPath, serviceMatch,
+                             "/Name"_json_pointer);
 }
 
 inline void doFanGet(const std::shared_ptr<bmcweb::AsyncResp>& asyncResp,

--- a/redfish-core/lib/power_supply.hpp
+++ b/redfish-core/lib/power_supply.hpp
@@ -9,6 +9,7 @@
 #include "utils/chassis_utils.hpp"
 #include "utils/dbus_utils.hpp"
 #include "utils/json_utils.hpp"
+#include "utils/name_utils.hpp"
 
 #include <boost/system/error_code.hpp>
 #include <boost/url/format.hpp>
@@ -510,7 +511,6 @@ inline void doPowerSupplyGet(
                 "</redfish/v1/JsonSchemas/PowerSupply/PowerSupply.json>; rel=describedby");
             asyncResp->res.jsonValue["@odata.type"] =
                 "#PowerSupply.v1_5_0.PowerSupply";
-            asyncResp->res.jsonValue["Name"] = "Power Supply";
             asyncResp->res.jsonValue["Id"] = powerSupplyId;
             asyncResp->res.jsonValue["@odata.id"] = boost::urls::format(
                 "/redfish/v1/Chassis/{}/PowerSubsystem/PowerSupplies/{}",
@@ -539,6 +539,8 @@ inline void doPowerSupplyGet(
                         asyncResp, object.begin()->first, powerSupplyPath);
                     getPowerSupplyLocation(asyncResp, object.begin()->first,
                                            powerSupplyPath);
+                    name_util::getPrettyName(asyncResp, powerSupplyPath, object,
+                                             "/Name"_json_pointer);
                 });
 
             getEfficiencyPercent(asyncResp);


### PR DESCRIPTION
Use getPrettyName like we do for Processors, Assembly, Chassis, Storage, Memory.

https://github.com/ibm-openbmc/bmcweb/pull/542 (1050/1060) https://github.com/ibm-openbmc/bmcweb/pull/918 (1110) added PrettyName for Processors, Assembly, Chassis, Storage but not PowerSupplies/Fan. I believe this was due to not needed at the time. https://github.com/ibm-openbmc/bmcweb/pull/1111 added PrettyName for Dimm. 

Fixes 668395

No upstream here, https://jsw.ibm.com/browse/PFEBMC-2871 tracks getting prettyname upstream

Tested: 
Before 
`"Name": "Power Supply",`
and 
`"Name": "Fan",`

After:
`"Name": "powersupply0",`
and 
`"Name": "fan1",`