### PR TITLE
Hw-Isolation: Deconfiguration type for DIMMs

### DIFF
--- a/redfish-core/lib/memory.hpp
+++ b/redfish-core/lib/memory.hpp
@@ -640,9 +640,9 @@ inline void getDimmDataByService(
     BMCWEB_LOG_DEBUG("Get available system components.");
     sdbusplus::asio::getAllProperties(
         *crow::connections::systemBus, service, objPath, "",
-        [dimmId, asyncResp{std::move(asyncResp)}](
-            const boost::system::error_code& ec,
-            const dbus::utility::DBusPropertiesMap& properties) {
+        [dimmId, asyncResp{std::move(asyncResp)},
+         objPath](const boost::system::error_code& ec,
+                  const dbus::utility::DBusPropertiesMap& properties) {
             if (ec)
             {
                 BMCWEB_LOG_DEBUG("DBUS response error");
@@ -651,6 +651,11 @@ inline void getDimmDataByService(
             }
             assembleDimmProperties(dimmId, asyncResp, properties,
                                    ""_json_pointer);
+            if constexpr (BMCWEB_HW_ISOLATION)
+            {
+                // Check for the hardware status event
+                hw_isolation_utils::getHwIsolationStatus(asyncResp, objPath);
+            }
         });
 }
 


### PR DESCRIPTION
This change should have been part of
```https://github.com/ibm-openbmc/bmcweb/pull/953/commits/7d6dd2c6b632d24752eba7870343ed9c790d638e```

Here is the original commit.
```https://github.com/ibm-openbmc/bmcweb/pull/171/files```

Due to this missing change, the deconfiguration type is not displayed in the GUI. After including this change, here is the redfish output.

```

curl -k -H "X-Auth-Token: $bmc_token" -XGET https://${BMC_IP}/redfish/v1/Systems/system/Memory/dimm1
{
  "/Status/Conditions/0/Severity": "OK",
  "@odata.id": "/redfish/v1/Systems/system/Memory/dimm1",
  "@odata.type": "#Memory.v1_12_0.Memory",
  "AllowedSpeedsMHz": [],
  "BaseModuleType": "RDIMM",
  "BusWidthBits": 0,
  "CapacityMiB": 32768,
  "DataWidthBits": 0,
  "Enabled": false,
  "ErrorCorrection": "NoECC",
  "FirmwareRevision": "0",
  "Id": "dimm1",
  "Location": {
    "PartLocation": {
      "ServiceLabel": "U78DB.ND0.WZS000G-P0-C13"
    }
  },
  "LocationIndicatorActive": false,
  "Manufacturer": "",
  "Model": "327A",
  "Name": "Memory module 1",
  "OperatingSpeedMhz": 0,
  "PartNumber": "78P6574",
  "RankCount": 0,
  "SerialNumber": "YH30MS03T038",
  "SparePartNumber": "78P6574",
  "Status": {
    "Conditions": [
      {
        "Message": "The reason for the resource isolation: Manual",
        "MessageArgs": [
          "Manual"
        ],
        "MessageId": "OpenBMC.0.2.HardwareIsolationReason",
        "Timestamp": "2025-01-21T10:27:55+00:00"
      }
    ],
    "Health": "Critical",
    "State": "Disabled"
  }
}

```