### PR TITLE
Audit Log: Correct logging of sessions

### DIFF
--- a/redfish-core/lib/redfish_sessions.hpp
+++ b/redfish-core/lib/redfish_sessions.hpp
@@ -222,6 +222,12 @@ inline void processAfterSessionCreation(
         "/redfish/v1/SessionService/Sessions/{}", session->uniqueId);
     asyncResp->res.addHeader("Location", sessionUrl.buffer());
     asyncResp->res.result(boost::beast::http::status::created);
+
+    if constexpr (BMCWEB_AUDIT_EVENTS)
+    {
+        audit::auditEvent(req, session->username, true);
+    }
+
     if (session->isConfigureSelfOnly)
     {
         boost::urls::url accountUri = boost::urls::format(


### PR DESCRIPTION
Changes to add the GenerateSecretKeyRequired incorrectly removed the audit logging for session creation. [1] Adding it back.

This fixes STG Defect 673437.

Tested:
Created session. Checked audit entry added using both ausearch and was returned as part of /redfish/v1/Systems/system/LogServices/AuditLog/Entries

```
/* Session shows up in ausearch results */
type=USYS_CONFIG msg=audit(01/22/25 23:09:09.379:25) : pid=1603 uid=root auid=unset ses=unset msg='op=POST:/redfish/v1/SessionService/Sessions acct=service exe=/tmp/bmcweb hostname=p10bmc addr=10.0.2.1 terminal=? res=success' 

/* Session shows up in response from request to retrieve audit entries */
$ curl -k -H "X-Auth-Token: $token"  https://${BMC_IP}/redfish/v1/Systems/system/LogServices/AuditLog/Entries?\$top=1
{
  "@odata.id": "/redfish/v1/Systems/system/LogServices/AuditLog/Entries",
  "@odata.type": "#LogEntryCollection.LogEntryCollection",
  "Description": "Collection of Audit Log Entries",
  "Members": [
    {
      "@odata.id": "/redfish/v1/Systems/system/LogServices/AuditLog/Entries/1737587349.379:25",
      "@odata.type": "#LogEntry.v1_9_0.LogEntry",
      "EntryType": "Event",
      "EventTimestamp": "2025-01-22T23:09:09+00:00",
      "Id": "1737587349.379:25",
      "Message": "type=USYS_CONFIG op=POST:/redfish/v1/SessionService/Sessions acct=service exe=/tmp/bmcweb hostname=p10bmc addr=10.0.2.1 terminal=? res=success",
      "MessageArgs": [
        "USYS_CONFIG",
        "POST:/redfish/v1/SessionService/Sessions",
        "service",
        "/tmp/bmcweb",
        "p10bmc",
        "10.0.2.1",
        "?",
        "success"
      ],
      "MessageId": "OpenBMC.0.6.AuditLogUsysConfig",
      "Name": "Audit Log Entry",
      "Oem": {
        "IBM": {
          "@odata.type": "#IBMLogEntryAttachment.v1_0_0.IBM",
          "AdditionalDataFullAuditLogURI": "/redfish/v1/Systems/system/LogServices/AuditLog/Entries/FullAudit/attachment"
        }
      }
    }
  ],
  "Members@odata.count": 1,
  "Name": "Audit Log Entries"
}
```

[1] https://github.com/ibm-openbmc/bmcweb/pull/1084