### PR TITLE
Change Session Cookie name

### DIFF
--- a/include/authentication.hpp
+++ b/include/authentication.hpp
@@ -127,7 +127,7 @@ inline std::shared_ptr<persistent_data::UserSession>
     {
         std::string_view cookieValue = it->value();
         BMCWEB_LOG_DEBUG("Checking cookie {}", cookieValue);
-        auto startIndex = cookieValue.find("SESSION=");
+        auto startIndex = cookieValue.find("BMCWEB-SESSION=");
         if (startIndex == std::string::npos)
         {
             BMCWEB_LOG_DEBUG(
@@ -135,7 +135,7 @@ inline std::shared_ptr<persistent_data::UserSession>
                 cookieValue);
             continue;
         }
-        startIndex += sizeof("SESSION=") - 1;
+        startIndex += sizeof("BMCWEB-SESSION=") - 1;
         auto endIndex = cookieValue.find(';', startIndex);
         if (endIndex == std::string::npos)
         {

--- a/include/cookies.hpp
+++ b/include/cookies.hpp
@@ -13,14 +13,14 @@ inline void setSessionCookies(crow::Response& res,
                   "XSRF-TOKEN=" + session.csrfToken +
                       "; Path=/; SameSite=Strict; Secure");
     res.addHeader(boost::beast::http::field::set_cookie,
-                  "SESSION=" + session.sessionToken +
+                  "BMCWEB-SESSION=" + session.sessionToken +
                       "; Path=/; SameSite=Strict; Secure; HttpOnly");
 }
 
 inline void clearSessionCookies(crow::Response& res)
 {
     res.addHeader(boost::beast::http::field::set_cookie,
-                  "SESSION="
+                  "BMCWEB-SESSION="
                   "; Path=/; SameSite=Strict; Secure; HttpOnly; "
                   "expires=Thu, 01 Jan 1970 00:00:00 GMT");
     res.addHeader("Clear-Site-Data", R"("cache","cookies","storage")");


### PR DESCRIPTION
As PE00QD48 shows the HMC/TomCat cookie is interfering with the Cookie set by BMCWEB. Reading online shows a session cookie name of BMCWEB-SESSION is more inline so let's just rename our SESSION cookie to BMCWEB-SESSION.

Tested: Using the HMC proxy, this works 

Upstream: https://gerrit.openbmc.org/c/openbmc/bmcweb/+/77539