### PR TITLE
Update symlinks for 2024.4

### DIFF
--- a/redfish-core/schema/dmtf/json-schema-installed/AccountService.v1_16_0.json
+++ b/redfish-core/schema/dmtf/json-schema-installed/AccountService.v1_16_0.json
@@ -1,1 +1,0 @@
-../json-schema/AccountService.v1_16_0.json

--- a/redfish-core/schema/dmtf/json-schema-installed/AccountService.v1_17_0.json
+++ b/redfish-core/schema/dmtf/json-schema-installed/AccountService.v1_17_0.json
@@ -1,0 +1,1 @@
+../json-schema/AccountService.v1_17_0.json

--- a/redfish-core/schema/dmtf/json-schema-installed/Cable.v1_2_3.json
+++ b/redfish-core/schema/dmtf/json-schema-installed/Cable.v1_2_3.json
@@ -1,1 +1,0 @@
-../json-schema/Cable.v1_2_3.json

--- a/redfish-core/schema/dmtf/json-schema-installed/Cable.v1_2_4.json
+++ b/redfish-core/schema/dmtf/json-schema-installed/Cable.v1_2_4.json
@@ -1,0 +1,1 @@
+../json-schema/Cable.v1_2_4.json

--- a/redfish-core/schema/dmtf/json-schema-installed/CertificateService.v1_0_5.json
+++ b/redfish-core/schema/dmtf/json-schema-installed/CertificateService.v1_0_5.json
@@ -1,1 +1,0 @@
-../json-schema/CertificateService.v1_0_5.json

--- a/redfish-core/schema/dmtf/json-schema-installed/CertificateService.v1_0_6.json
+++ b/redfish-core/schema/dmtf/json-schema-installed/CertificateService.v1_0_6.json
@@ -1,0 +1,1 @@
+../json-schema/CertificateService.v1_0_6.json

--- a/redfish-core/schema/dmtf/json-schema-installed/Chassis.v1_25_2.json
+++ b/redfish-core/schema/dmtf/json-schema-installed/Chassis.v1_25_2.json
@@ -1,1 +1,0 @@
-../json-schema/Chassis.v1_25_2.json

--- a/redfish-core/schema/dmtf/json-schema-installed/Chassis.v1_26_0.json
+++ b/redfish-core/schema/dmtf/json-schema-installed/Chassis.v1_26_0.json
@@ -1,0 +1,1 @@
+../json-schema/Chassis.v1_26_0.json

--- a/redfish-core/schema/dmtf/json-schema-installed/ComputerSystem.v1_23_0.json
+++ b/redfish-core/schema/dmtf/json-schema-installed/ComputerSystem.v1_23_0.json
@@ -1,1 +1,0 @@
-../json-schema/ComputerSystem.v1_23_0.json

--- a/redfish-core/schema/dmtf/json-schema-installed/ComputerSystem.v1_23_1.json
+++ b/redfish-core/schema/dmtf/json-schema-installed/ComputerSystem.v1_23_1.json
@@ -1,0 +1,1 @@
+../json-schema/ComputerSystem.v1_23_1.json

--- a/redfish-core/schema/dmtf/json-schema-installed/Drive.v1_20_1.json
+++ b/redfish-core/schema/dmtf/json-schema-installed/Drive.v1_20_1.json
@@ -1,1 +1,0 @@
-../json-schema/Drive.v1_20_1.json

--- a/redfish-core/schema/dmtf/json-schema-installed/Drive.v1_21_0.json
+++ b/redfish-core/schema/dmtf/json-schema-installed/Drive.v1_21_0.json
@@ -1,0 +1,1 @@
+../json-schema/Drive.v1_21_0.json

--- a/redfish-core/schema/dmtf/json-schema-installed/EthernetInterface.v1_12_2.json
+++ b/redfish-core/schema/dmtf/json-schema-installed/EthernetInterface.v1_12_2.json
@@ -1,1 +1,0 @@
-../json-schema/EthernetInterface.v1_12_2.json

--- a/redfish-core/schema/dmtf/json-schema-installed/EthernetInterface.v1_12_3.json
+++ b/redfish-core/schema/dmtf/json-schema-installed/EthernetInterface.v1_12_3.json
@@ -1,0 +1,1 @@
+../json-schema/EthernetInterface.v1_12_3.json

--- a/redfish-core/schema/dmtf/json-schema-installed/EventDestination.v1_15_0.json
+++ b/redfish-core/schema/dmtf/json-schema-installed/EventDestination.v1_15_0.json
@@ -1,1 +1,0 @@
-../json-schema/EventDestination.v1_15_0.json

--- a/redfish-core/schema/dmtf/json-schema-installed/EventDestination.v1_15_1.json
+++ b/redfish-core/schema/dmtf/json-schema-installed/EventDestination.v1_15_1.json
@@ -1,0 +1,1 @@
+../json-schema/EventDestination.v1_15_1.json

--- a/redfish-core/schema/dmtf/json-schema-installed/EventService.v1_10_2.json
+++ b/redfish-core/schema/dmtf/json-schema-installed/EventService.v1_10_2.json
@@ -1,1 +1,0 @@
-../json-schema/EventService.v1_10_2.json

--- a/redfish-core/schema/dmtf/json-schema-installed/EventService.v1_10_3.json
+++ b/redfish-core/schema/dmtf/json-schema-installed/EventService.v1_10_3.json
@@ -1,0 +1,1 @@
+../json-schema/EventService.v1_10_3.json

--- a/redfish-core/schema/dmtf/json-schema-installed/Manager.v1_19_2.json
+++ b/redfish-core/schema/dmtf/json-schema-installed/Manager.v1_19_2.json
@@ -1,1 +1,0 @@
-../json-schema/Manager.v1_19_2.json

--- a/redfish-core/schema/dmtf/json-schema-installed/Manager.v1_20_0.json
+++ b/redfish-core/schema/dmtf/json-schema-installed/Manager.v1_20_0.json
@@ -1,0 +1,1 @@
+../json-schema/Manager.v1_20_0.json

--- a/redfish-core/schema/dmtf/json-schema-installed/PCIeDevice.v1_16_0.json
+++ b/redfish-core/schema/dmtf/json-schema-installed/PCIeDevice.v1_16_0.json
@@ -1,1 +1,0 @@
-../json-schema/PCIeDevice.v1_16_0.json

--- a/redfish-core/schema/dmtf/json-schema-installed/PCIeDevice.v1_17_0.json
+++ b/redfish-core/schema/dmtf/json-schema-installed/PCIeDevice.v1_17_0.json
@@ -1,0 +1,1 @@
+../json-schema/PCIeDevice.v1_17_0.json

--- a/redfish-core/schema/dmtf/json-schema-installed/Port.v1_14_0.json
+++ b/redfish-core/schema/dmtf/json-schema-installed/Port.v1_14_0.json
@@ -1,1 +1,0 @@
-../json-schema/Port.v1_14_0.json

--- a/redfish-core/schema/dmtf/json-schema-installed/Port.v1_15_0.json
+++ b/redfish-core/schema/dmtf/json-schema-installed/Port.v1_15_0.json
@@ -1,0 +1,1 @@
+../json-schema/Port.v1_15_0.json

--- a/redfish-core/schema/dmtf/json-schema-installed/PowerSubsystem.v1_1_2.json
+++ b/redfish-core/schema/dmtf/json-schema-installed/PowerSubsystem.v1_1_2.json
@@ -1,1 +1,0 @@
-../json-schema/PowerSubsystem.v1_1_2.json

--- a/redfish-core/schema/dmtf/json-schema-installed/PowerSubsystem.v1_1_3.json
+++ b/redfish-core/schema/dmtf/json-schema-installed/PowerSubsystem.v1_1_3.json
@@ -1,0 +1,1 @@
+../json-schema/PowerSubsystem.v1_1_3.json

--- a/redfish-core/schema/dmtf/json-schema-installed/Redundancy.v1_4_2.json
+++ b/redfish-core/schema/dmtf/json-schema-installed/Redundancy.v1_4_2.json
@@ -1,1 +1,0 @@
-../json-schema/Redundancy.v1_4_2.json

--- a/redfish-core/schema/dmtf/json-schema-installed/Redundancy.v1_5_0.json
+++ b/redfish-core/schema/dmtf/json-schema-installed/Redundancy.v1_5_0.json
@@ -1,0 +1,1 @@
+../json-schema/Redundancy.v1_5_0.json

--- a/redfish-core/schema/dmtf/json-schema-installed/Resource.v1_20_0.json
+++ b/redfish-core/schema/dmtf/json-schema-installed/Resource.v1_20_0.json
@@ -1,1 +1,0 @@
-../json-schema/Resource.v1_20_0.json

--- a/redfish-core/schema/dmtf/json-schema-installed/Resource.v1_21_0.json
+++ b/redfish-core/schema/dmtf/json-schema-installed/Resource.v1_21_0.json
@@ -1,0 +1,1 @@
+../json-schema/Resource.v1_21_0.json

--- a/redfish-core/schema/dmtf/json-schema-installed/Role.v1_3_2.json
+++ b/redfish-core/schema/dmtf/json-schema-installed/Role.v1_3_2.json
@@ -1,1 +1,0 @@
-../json-schema/Role.v1_3_2.json

--- a/redfish-core/schema/dmtf/json-schema-installed/Role.v1_3_3.json
+++ b/redfish-core/schema/dmtf/json-schema-installed/Role.v1_3_3.json
@@ -1,0 +1,1 @@
+../json-schema/Role.v1_3_3.json

--- a/redfish-core/schema/dmtf/json-schema-installed/Session.v1_7_2.json
+++ b/redfish-core/schema/dmtf/json-schema-installed/Session.v1_7_2.json
@@ -1,1 +1,0 @@
-../json-schema/Session.v1_7_2.json

--- a/redfish-core/schema/dmtf/json-schema-installed/Session.v1_8_0.json
+++ b/redfish-core/schema/dmtf/json-schema-installed/Session.v1_8_0.json
@@ -1,0 +1,1 @@
+../json-schema/Session.v1_8_0.json

--- a/redfish-core/schema/dmtf/json-schema-installed/SessionService.v1_1_9.json
+++ b/redfish-core/schema/dmtf/json-schema-installed/SessionService.v1_1_9.json
@@ -1,1 +1,0 @@
-../json-schema/SessionService.v1_1_9.json

--- a/redfish-core/schema/dmtf/json-schema-installed/SessionService.v1_2_0.json
+++ b/redfish-core/schema/dmtf/json-schema-installed/SessionService.v1_2_0.json
@@ -1,0 +1,1 @@
+../json-schema/SessionService.v1_2_0.json

--- a/redfish-core/schema/dmtf/json-schema-installed/Storage.v1_17_1.json
+++ b/redfish-core/schema/dmtf/json-schema-installed/Storage.v1_17_1.json
@@ -1,1 +1,0 @@
-../json-schema/Storage.v1_17_1.json

--- a/redfish-core/schema/dmtf/json-schema-installed/Storage.v1_18_0.json
+++ b/redfish-core/schema/dmtf/json-schema-installed/Storage.v1_18_0.json
@@ -1,0 +1,1 @@
+../json-schema/Storage.v1_18_0.json

--- a/redfish-core/schema/dmtf/json-schema-installed/StorageController.v1_8_0.json
+++ b/redfish-core/schema/dmtf/json-schema-installed/StorageController.v1_8_0.json
@@ -1,1 +1,0 @@
-../json-schema/StorageController.v1_8_0.json

--- a/redfish-core/schema/dmtf/json-schema-installed/StorageController.v1_9_0.json
+++ b/redfish-core/schema/dmtf/json-schema-installed/StorageController.v1_9_0.json
@@ -1,0 +1,1 @@
+../json-schema/StorageController.v1_9_0.json

--- a/redfish-core/schema/dmtf/json-schema-installed/ThermalSubsystem.v1_3_2.json
+++ b/redfish-core/schema/dmtf/json-schema-installed/ThermalSubsystem.v1_3_2.json
@@ -1,1 +1,0 @@
-../json-schema/ThermalSubsystem.v1_3_2.json

--- a/redfish-core/schema/dmtf/json-schema-installed/ThermalSubsystem.v1_3_3.json
+++ b/redfish-core/schema/dmtf/json-schema-installed/ThermalSubsystem.v1_3_3.json
@@ -1,0 +1,1 @@
+../json-schema/ThermalSubsystem.v1_3_3.json

--- a/redfish-core/schema/dmtf/json-schema-installed/UpdateService.v1_14_1.json
+++ b/redfish-core/schema/dmtf/json-schema-installed/UpdateService.v1_14_1.json
@@ -1,1 +1,0 @@
-../json-schema/UpdateService.v1_14_1.json

--- a/redfish-core/schema/dmtf/json-schema-installed/UpdateService.v1_15_0.json
+++ b/redfish-core/schema/dmtf/json-schema-installed/UpdateService.v1_15_0.json
@@ -1,0 +1,1 @@
+../json-schema/UpdateService.v1_15_0.json

--- a/redfish-core/schema/dmtf/json-schema-installed/redfish-schema.v1_10_0.json
+++ b/redfish-core/schema/dmtf/json-schema-installed/redfish-schema.v1_10_0.json
@@ -1,1 +1,0 @@
-../json-schema/redfish-schema.v1_10_0.json

--- a/redfish-core/schema/dmtf/json-schema-installed/redfish-schema.v1_10_1.json
+++ b/redfish-core/schema/dmtf/json-schema-installed/redfish-schema.v1_10_1.json
@@ -1,0 +1,1 @@
+../json-schema/redfish-schema.v1_10_1.json


### PR DESCRIPTION
Wrote a quick bash script to update these symlinks.

These are versioned out in json schema directory[1].

The symlinks don't work without this update.

[1]: https://github.com/ibm-openbmc/bmcweb/tree/1110/redfish-core/schema/dmtf/json-schema

Fixes defect 673965 

Tested:

Before:
```
head -n 4 redfish-core/schema/dmtf/json-schema-installed/ComputerSystem.v1_*.json
head: cannot open 'redfish-core/schema/dmtf/json-schema-installed/ComputerSystem.v1_23_0.json' for reading: No such file or directory
```

After:
```
head -n 4 redfish-core/schema/dmtf/json-schema-installed/ComputerSystem.v1_*.json
{
    "$id": "http://redfish.dmtf.org/schemas/v1/ComputerSystem.v1_23_1.json",
    "$ref": "#/definitions/ComputerSystem",
    "$schema": "http://redfish.dmtf.org/schemas/v1/redfish-schema-v1.json",
```