### PR TITLE
Fix log entry

### DIFF
--- a/redfish-core/include/utils/error_log_utils.hpp
+++ b/redfish-core/include/utils/error_log_utils.hpp
@@ -51,46 +51,27 @@ static void getHiddenPropertyValue(
 inline void setErrorLogUri(
     const std::shared_ptr<bmcweb::AsyncResp>& asyncResp,
     const sdbusplus::message::object_path& errorLogObjPath,
-    const nlohmann::json_pointer<nlohmann::json>& errorLogPropPath,
-    const bool isLink)
+    const nlohmann::json::json_pointer& errorLogPropPath, const bool isLink)
 {
-    // Get the Hidden Property
-    sdbusplus::asio::getProperty<bool>(
-        *crow::connections::systemBus, "xyz.openbmc_project.Logging",
-        errorLogObjPath.str, "org.open_power.Logging.PEL.Entry", "Hidden",
-        [asyncResp, errorLogObjPath, errorLogPropPath, isLink](
-            const boost::system::error_code& ec, const bool hiddenProperty) {
-            if (ec)
+    std::string entryID = errorLogObjPath.filename();
+    auto updateErrorLogPath =
+        [asyncResp, entryID, errorLogPropPath, isLink](bool hidden) {
+            std::string logPath = "EventLog";
+            if (hidden)
             {
-                BMCWEB_LOG_ERROR(
-                    "DBus response error [{} : {}] when tried to get the Hidden property from the given error log object {}",
-                    ec.value(), ec.message(), errorLogObjPath.str);
-                return;
+                logPath = "CELog";
             }
-
-            std::string errLogUri{"/redfish/v1/Systems/system/LogServices/"};
-            if (hiddenProperty)
+            std::string linkAttachment;
+            if (!isLink)
             {
-                errLogUri.append("CELog/Entries/");
+                linkAttachment = "/attachment";
             }
-            else
-            {
-                errLogUri.append("EventLog/Entries/");
-            }
-            errLogUri.append(errorLogObjPath.filename());
-
-            if (isLink)
-            {
-                std::string path = errorLogPropPath.to_string();
-                asyncResp->res.jsonValue[path]["@odata.id"] = errLogUri;
-            }
-            else
-            {
-                errLogUri.append("/attachment");
-                std::string path = errorLogPropPath.to_string();
-                asyncResp->res.jsonValue[path]["@odata.id"] = errLogUri;
-            }
-        });
+            asyncResp->res.jsonValue[errorLogPropPath]["@odata.id"] =
+                boost::urls::format(
+                    "/redfish/v1/Systems/system/LogServices/{}/Entries/{}{}",
+                    logPath, entryID, linkAttachment);
+        };
+    getHiddenPropertyValue(asyncResp, entryID, updateErrorLogPath);
 }
 
 } // namespace error_log_utils

--- a/redfish-core/include/utils/hw_isolation.hpp
+++ b/redfish-core/include/utils/hw_isolation.hpp
@@ -407,29 +407,27 @@ inline void processHardwareIsolationReq(
  * @return True on success
  *         False on failure and set the error in the redfish response.
  */
-inline bool
-    setSeverity(const std::shared_ptr<bmcweb::AsyncResp>& asyncResp,
-                const sdbusplus::message::object_path& objPath,
-                const nlohmann::json_pointer<nlohmann::json>& severityPropPath,
-                const std::string& severityVal)
+inline bool setSeverity(const std::shared_ptr<bmcweb::AsyncResp>& asyncResp,
+                        const sdbusplus::message::object_path& objPath,
+                        const nlohmann::json::json_pointer& severityPropPath,
+                        const std::string& severityVal)
 {
-    std::string sevPropPath = severityPropPath.to_string();
     if (severityVal ==
         "xyz.openbmc_project.Logging.Event.SeverityLevel.Critical")
     {
-        asyncResp->res.jsonValue[sevPropPath] = "Critical";
+        asyncResp->res.jsonValue[severityPropPath] = "Critical";
     }
     else if ((severityVal ==
               "xyz.openbmc_project.Logging.Event.SeverityLevel.Warning") ||
              (severityVal ==
               "xyz.openbmc_project.Logging.Event.SeverityLevel.Unknown"))
     {
-        asyncResp->res.jsonValue[sevPropPath] = "Warning";
+        asyncResp->res.jsonValue[severityPropPath] = "Warning";
     }
     else if (severityVal ==
              "xyz.openbmc_project.Logging.Event.SeverityLevel.Ok")
     {
-        asyncResp->res.jsonValue[sevPropPath] = "OK";
+        asyncResp->res.jsonValue[severityPropPath] = "OK";
     }
     else
     {
@@ -473,7 +471,7 @@ static void
             {
                 sdbusplus::message::object_path errPath = std::get<2>(assoc);
                 // we have only one condition
-                nlohmann::json_pointer<nlohmann::json> logEntryPropPath(
+                nlohmann::json::json_pointer logEntryPropPath(
                     "/Status/Conditions/0/LogEntry");
                 error_log_utils::setErrorLogUri(asyncResp, errPath,
                                                 logEntryPropPath, true);
@@ -533,7 +531,7 @@ static void
     if (severity != nullptr)
     {
         // we have only one condition
-        nlohmann::json_pointer<nlohmann::json> severityPropPath(
+        nlohmann::json::json_pointer severityPropPath(
             "/Status/Conditions/0/Severity");
         if (!setSeverity(asyncResp, path, severityPropPath, *severity))
         {

--- a/redfish-core/lib/log_services.hpp
+++ b/redfish-core/lib/log_services.hpp
@@ -2091,26 +2091,6 @@ inline void requestRoutesJournalEventLogEntry(App& app)
             });
 }
 
-template <typename Callback>
-void getHiddenPropertyValue(const std::shared_ptr<bmcweb::AsyncResp>& asyncResp,
-                            const std::string& entryId, Callback&& callback)
-{
-    sdbusplus::asio::getProperty<bool>(
-        *crow::connections::systemBus, "xyz.openbmc_project.Logging",
-        "/xyz/openbmc_project/logging/entry/" + entryId,
-        "org.open_power.Logging.PEL.Entry", "Hidden",
-        [callback{std::forward<Callback>(callback)},
-         asyncResp](const boost::system::error_code& ec, bool hidden) {
-            if (ec)
-            {
-                BMCWEB_LOG_ERROR("DBUS response error: {}", ec);
-                messages::internalError(asyncResp->res);
-                return;
-            }
-            callback(hidden);
-        });
-}
-
 inline void updateProperty(const std::optional<bool>& resolved,
                            const std::optional<bool>& managementSystemAck,
                            const std::shared_ptr<bmcweb::AsyncResp>& asyncResp,
@@ -2999,8 +2979,8 @@ inline void requestRoutesDBusEventLogEntry(App& app)
                         updateProperty(resolved, managementSystemAck, asyncResp,
                                        entryId);
                     };
-                getHiddenPropertyValue(asyncResp, entryId,
-                                       std::move(updatePropertyCallback));
+                redfish::error_log_utils::getHiddenPropertyValue(
+                    asyncResp, entryId, std::move(updatePropertyCallback));
             });
 
     BMCWEB_ROUTE(
@@ -3044,8 +3024,8 @@ inline void requestRoutesDBusEventLogEntry(App& app)
                         }
                         deleteEventLogEntry(asyncResp, entryID);
                     };
-                getHiddenPropertyValue(asyncResp, entryID,
-                                       std::move(deleteEventLogCallback));
+                redfish::error_log_utils::getHiddenPropertyValue(
+                    asyncResp, entryID, std::move(deleteEventLogCallback));
             });
 }
 
@@ -3255,8 +3235,8 @@ inline void requestRoutesDBusCELogEntry(App& app)
                         updateProperty(resolved, managementSystemAck, asyncResp,
                                        entryId);
                     };
-                getHiddenPropertyValue(asyncResp, entryId,
-                                       std::move(updatePropertyCallback));
+                redfish::error_log_utils::getHiddenPropertyValue(
+                    asyncResp, entryId, std::move(updatePropertyCallback));
             });
 
     BMCWEB_ROUTE(app,
@@ -3293,8 +3273,8 @@ inline void requestRoutesDBusCELogEntry(App& app)
                         }
                         deleteEventLogEntry(asyncResp, entryID);
                     };
-                getHiddenPropertyValue(asyncResp, entryID,
-                                       std::move(deleteCELogCallback));
+                redfish::error_log_utils::getHiddenPropertyValue(
+                    asyncResp, entryID, std::move(deleteCELogCallback));
             });
 }
 
@@ -3376,8 +3356,8 @@ inline void requestRoutesDBusEventLogEntryDownloadPelJson(App& app)
                         }
                         displayOemPelAttachment(asyncResp, entryID);
                     };
-                getHiddenPropertyValue(asyncResp, entryID,
-                                       std::move(eventLogAttachmentCallback));
+                redfish::error_log_utils::getHiddenPropertyValue(
+                    asyncResp, entryID, std::move(eventLogAttachmentCallback));
             });
 }
 
@@ -3416,8 +3396,8 @@ inline void requestRoutesDBusCELogEntryDownloadPelJson(App& app)
                         }
                         displayOemPelAttachment(asyncResp, entryID);
                     };
-                getHiddenPropertyValue(asyncResp, entryID,
-                                       std::move(eventLogAttachmentCallback));
+                redfish::error_log_utils::getHiddenPropertyValue(
+                    asyncResp, entryID, std::move(eventLogAttachmentCallback));
             });
 }
 
@@ -4370,7 +4350,8 @@ inline void handleDBusEventLogEntryDownloadGet(
         }
         downloadEventLogEntry(asyncResp, systemName, entryID, dumpType);
     };
-    getHiddenPropertyValue(asyncResp, entryID, std::move(callback));
+    redfish::error_log_utils::getHiddenPropertyValue(asyncResp, entryID,
+                                                     std::move(callback));
 }
 
 inline void handleLogServicesDumpCollectDiagnosticDataPost(
@@ -7245,8 +7226,8 @@ inline void fillSystemHardwareIsolationLogEntry(
                                         "/redfish/v1/Systems/system/LogServices/{}/Entries/{}/attachment",
                                         logPath, entryID);
                             };
-                            getHiddenPropertyValue(asyncResp, entryID,
-                                                   updateAdditionalDataURI);
+                            redfish::error_log_utils::getHiddenPropertyValue(
+                                asyncResp, entryID, updateAdditionalDataURI);
                         }
                     }
                 }


### PR DESCRIPTION
Resolve the issue where LogEntry and Severity key-value pairs are being treated as separate elements instead of being structured under the status/Conditions hierarchy.