### PR TITLE
Fix crash when modifying static v6 default gateway

### DIFF
--- a/redfish-core/lib/ethernet.hpp
+++ b/redfish-core/lib/ethernet.hpp
@@ -935,7 +935,7 @@ inline void
  * @return None
  */
 inline void createIPv6DefaultGateway(
-    std::string_view ifaceId, std::string_view gateway,
+    std::string_view ifaceId, const std::string& gateway,
     const std::shared_ptr<bmcweb::AsyncResp>& asyncResp)
 {
     sdbusplus::message::object_path path("/xyz/openbmc_project/network");
@@ -965,7 +965,7 @@ inline void createIPv6DefaultGateway(
  */
 inline void deleteAndCreateIPv6DefaultGateway(
     std::string_view ifaceId, std::string_view gatewayId,
-    std::string_view gateway,
+    const std::string& gateway,
     const std::shared_ptr<bmcweb::AsyncResp>& asyncResp)
 {
     sdbusplus::message::object_path path("/xyz/openbmc_project/network");


### PR DESCRIPTION
When modifying a static default gateway, the existing entry is deleted, and a new D-Bus object is created with the updated gateway.

Currently, this operation fails with an Internal Server Error and causes a bmcweb crash because the gateway value is passed as a std::string_view. Debugging revealed that the data's lifetime ends before it is accessed.

This commit resolves the issue by replacing std::string_view with const std::string&.

Tested By:
Assuming there are currently three IPv6StaticDefaultGateways configured, the following command modifies the second entry:

'''
PATCH -D patch.txt -d '{"IPv6StaticDefaultGateways": [{},{"Address": "<new modified gateway>"},{}]}' https://${bmc}/redfish/v1/Managers/bmc/EthernetInterfaces/eth1 '''

Change-Id: I1bd18005fb71a1567b1844b04c4cc4cd322cdf6e