### PR TITLE
1110: Fix Assembly for MEX

### DIFF
--- a/redfish-core/lib/assembly.hpp
+++ b/redfish-core/lib/assembly.hpp
@@ -457,7 +457,7 @@ inline void handleChassisAssemblyGet(
     BMCWEB_LOG_DEBUG("Get chassis path");
 
     getChassisAssembly(
-        asyncResp, "chassis",
+        asyncResp, chassisID,
         [asyncResp,
          chassisID](const std::optional<std::string>& validChassisPath,
                     const std::vector<std::string>& assemblyList) {
@@ -777,7 +777,7 @@ inline void handleChassisAssemblyPatch(
     BMCWEB_LOG_DEBUG("Patch chassis path");
 
     getChassisAssembly(
-        asyncResp, "chassis",
+        asyncResp, chassisID,
         [req, asyncResp,
          chassisID](const std::optional<std::string>& validChassisPath,
                     const std::vector<std::string>& assemblyList) {


### PR DESCRIPTION
MEX Assemebly gives incorrectly as same as CEC assemblies.

For example,

- CEC Assembly : https://rain118bmc.aus.stglabs.ibm.com/redfish/v1/Chassis/chassis/Assembly
- MEX Assembly : https://rain118bmc.aus.stglabs.ibm.com/redfish/v1/Chassis/chassis15363/Assembly

Tested:
- Check MEX assembly