### PR TITLE
Fix 670598: dbus_util changes to fix response message

### DIFF
--- a/redfish-core/src/utils/dbus_utils.cpp
+++ b/redfish-core/src/utils/dbus_utils.cpp
@@ -10,6 +10,7 @@
 #include <boost/asio/error.hpp>
 #include <boost/beast/http/status.hpp>
 #include <boost/system/error_code.hpp>
+#include <nlohmann/json.hpp>
 #include <sdbusplus/message.hpp>
 
 #include <memory>
@@ -83,10 +84,10 @@ void afterSetProperty(
         messages::internalError(asyncResp->res);
         return;
     }
-    // Only set success if another error hasn't already happened.
+    // Only set 204 if another error hasn't already happened.
     if (asyncResp->res.result() == boost::beast::http::status::ok)
     {
-        messages::success(asyncResp->res);
+        asyncResp->res.result(boost::beast::http::status::no_content);
     }
 };
 

--- a/test/redfish-core/include/utils/dbus_utils.cpp
+++ b/test/redfish-core/include/utils/dbus_utils.cpp
@@ -1,19 +1,17 @@
 
 #include "utils/dbus_utils.hpp"
 
-#include "http_request.hpp"
+#include "async_resp.hpp"
 #include "http_response.hpp"
 
 #include <boost/beast/http/status.hpp>
+#include <boost/system/errc.hpp>
 #include <nlohmann/json.hpp>
+#include <sdbusplus/message.hpp>
 
-#include <cstdint>
-#include <optional>
+#include <memory>
 #include <string>
-#include <system_error>
-#include <vector>
 
-#include <gmock/gmock.h>
 #include <gtest/gtest.h>
 
 namespace redfish::details
@@ -30,6 +28,19 @@ TEST(DbusUtils, AfterPropertySetSuccess)
     sdbusplus::message_t msg;
     afterSetProperty(asyncResp, "MyRedfishProperty",
                      nlohmann::json("MyRedfishValue"), ec, msg);
+
+    EXPECT_EQ(asyncResp->res.result(), boost::beast::http::status::no_content);
+}
+
+TEST(DbusUtils, AfterActionPropertySetSuccess)
+{
+    std::shared_ptr<bmcweb::AsyncResp> asyncResp =
+        std::make_shared<bmcweb::AsyncResp>();
+
+    boost::system::error_code ec;
+    sdbusplus::message_t msg;
+    afterSetPropertyAction(asyncResp, "MyRedfishProperty",
+                           nlohmann::json("MyRedfishValue"), ec, msg);
 
     EXPECT_EQ(asyncResp->res.result(), boost::beast::http::status::ok);
     EXPECT_EQ(asyncResp->res.jsonValue,


### PR DESCRIPTION
Taking latest upstream changes to fix multiple success message seen in response. Now the behaviour is similar to what upstream does, which mean there is no message in the response. The response is set with no_content flag.

Upstream change : https://github.com/openbmc/bmcweb/blob/master/redfish-core/src/utils/dbus_utils.cpp#L91