### PR TITLE
Revert "Change Session Cookie name (#1130)"

### DIFF
--- a/include/authentication.hpp
+++ b/include/authentication.hpp
@@ -127,7 +127,7 @@ inline std::shared_ptr<persistent_data::UserSession>
     {
         std::string_view cookieValue = it->value();
         BMCWEB_LOG_DEBUG("Checking cookie {}", cookieValue);
-        auto startIndex = cookieValue.find("BMCWEB-SESSION=");
+        auto startIndex = cookieValue.find("SESSION=");
         if (startIndex == std::string::npos)
         {
             BMCWEB_LOG_DEBUG(
@@ -135,7 +135,7 @@ inline std::shared_ptr<persistent_data::UserSession>
                 cookieValue);
             continue;
         }
-        startIndex += sizeof("BMCWEB-SESSION=") - 1;
+        startIndex += sizeof("SESSION=") - 1;
         auto endIndex = cookieValue.find(';', startIndex);
         if (endIndex == std::string::npos)
         {

--- a/include/cookies.hpp
+++ b/include/cookies.hpp
@@ -13,14 +13,14 @@ inline void setSessionCookies(crow::Response& res,
                   "XSRF-TOKEN=" + session.csrfToken +
                       "; Path=/; SameSite=Strict; Secure");
     res.addHeader(boost::beast::http::field::set_cookie,
-                  "BMCWEB-SESSION=" + session.sessionToken +
+                  "SESSION=" + session.sessionToken +
                       "; Path=/; SameSite=Strict; Secure; HttpOnly");
 }
 
 inline void clearSessionCookies(crow::Response& res)
 {
     res.addHeader(boost::beast::http::field::set_cookie,
-                  "BMCWEB-SESSION="
+                  "SESSION="
                   "; Path=/; SameSite=Strict; Secure; HttpOnly; "
                   "expires=Thu, 01 Jan 1970 00:00:00 GMT");
     res.addHeader("Clear-Site-Data", R"("cache","cookies","storage")");


### PR DESCRIPTION
This reverts commit 05b61c64f39e58e36cebfca10d52dbb1f6791f64.

In DVT, we are hitting an error 
```
Keyword 'Upload Image To BMC' failed after retrying 1 time. The last error was: SSLError: HTTPSConnectionPool(host='xxxxxx', port=443): Max retries exceeded with url: /redfish/v1/UpdateService/update (Caused by SSLError(SSLEOFError(8, 'EOF occurred in violation of protocol (_ssl.c:2427)')))
```

I can't explain it but reverting this commit appears to fix it 