### PR TITLE
MFA: Disallow bypass option to Readonly user

### DIFF
--- a/redfish-core/lib/account_service.hpp
+++ b/redfish-core/lib/account_service.hpp
@@ -2574,6 +2574,14 @@ inline void
             return;
         }
 
+        // Read only users should not be allowed to bypass self
+        if (mfaBypass)
+        {
+            BMCWEB_LOG_ERROR("User has insufficient privilege to bypass self");
+            messages::insufficientPrivilege(asyncResp->res);
+            return;
+        }
+
         // ConfigureSelf accounts can only modify their password
         if (!json_util::readJsonPatch(req, asyncResp->res, "Password",
                                       password))


### PR DESCRIPTION
Currently, a readonly user is able to bypass MFA for self, which allows the user to continue with the session unauthorized.

This commit disallows a readonly user to bypass MFA when global MFA is enabled. Only users with admin privilege will be able to bypass MFA for self and for other users.

Tested By:

'''
 PATCH -D patch.txt -d '{"MFABypass":{"BypassTypes":["GoogleAuthenticator"]}}' https://${bmc}/redfish/v1/AccountService/Accounts/test_readonly -H "Content-Type: application/json"

This throws an "InsufficientPrivilege" error for readonly user. '''