### PR TITLE
 Make the proxy GUI work

### DIFF
--- a/include/authentication.hpp
+++ b/include/authentication.hpp
@@ -127,7 +127,8 @@ inline std::shared_ptr<persistent_data::UserSession>
     {
         std::string_view cookieValue = it->value();
         BMCWEB_LOG_DEBUG("Checking cookie {}", cookieValue);
-        auto startIndex = cookieValue.find("SESSION=");
+        // TODO (Gunnar): Flipping to rfind is a hack, fix this
+        auto startIndex = cookieValue.rfind("SESSION=");
         if (startIndex == std::string::npos)
         {
             BMCWEB_LOG_DEBUG(


### PR DESCRIPTION
As PE00QD48 shows the HMC/TomCat cookie is interfering with the Cookie set by BMCWEB. This hack switches find to rfind so our cookie is found first.

This doesn't impact going to the GUI directly because we only have the one
SESSION cookie. Don't want to check both because this might allow
attackers to negate the anti brute force measures by testing multiple
passwords at once. [1]

Gets testing off the ground, doesn't break DVT, and 1 line change.

Upstream: https://gerrit.openbmc.org/c/openbmc/bmcweb/+/77539
https://jsw.ibm.com/browse/PFEBMC-3844 tracks fixing this correctly.
Drive upstream but will try to make it happen for 1110.

[1]: https://github.com/openbmc/bmcweb/commit/9f217c26f58c0a99c18e7cac7b095dcf6068562d

Tested: GUI works directly and the proxy now works