### PR TITLE
Adding the correct EKU

### DIFF
--- a/redfish-core/lib/certificate_service.hpp
+++ b/redfish-core/lib/certificate_service.hpp
@@ -721,11 +721,11 @@ inline void
     {
         if (optKeyUsage->empty())
         {
-            optKeyUsage->emplace_back("ServerAuthentication");
+            optKeyUsage->emplace_back("serverAuth");
         }
         else if (optKeyUsage->size() == 1)
         {
-            if ((*optKeyUsage)[0] != "ServerAuthentication")
+            if ((*optKeyUsage)[0] != "serverAuth")
             {
                 messages::propertyValueNotInList(asyncResp->res,
                                                  (*optKeyUsage)[0], "KeyUsage");
@@ -744,11 +744,11 @@ inline void
     {
         if (optKeyUsage->empty())
         {
-            optKeyUsage->emplace_back("ClientAuthentication");
+            optKeyUsage->emplace_back("clientAuth");
         }
         else if (optKeyUsage->size() == 1)
         {
-            if ((*optKeyUsage)[0] != "ClientAuthentication")
+            if ((*optKeyUsage)[0] != "clientAuth")
             {
                 messages::propertyValueNotInList(asyncResp->res,
                                                  (*optKeyUsage)[0], "KeyUsage");


### PR DESCRIPTION
This commit adds proper EKU  extensions for server and client certificate subjectAltName.

Tested by:
Verified by generating the CSR and confirmed it has proper EKU strings.

Change-Id: I6106e36f207426f201164f5cc43cd22fd8234675