### PR TITLE
Updates to resolve getting a response for wrong URI in Update

### DIFF
--- a/redfish-core/lib/update_service.hpp
+++ b/redfish-core/lib/update_service.hpp
@@ -1227,13 +1227,10 @@ inline void requestRoutesSoftwareInventory(App& app)
             std::shared_ptr<std::string> swId =
                 std::make_shared<std::string>(param);
 
-            asyncResp->res.jsonValue["@odata.id"] = boost::urls::format(
-                "/redfish/v1/UpdateService/FirmwareInventory/{}", *swId);
-
             constexpr std::array<std::string_view, 1> interfaces = {
                 "xyz.openbmc_project.Software.Version"};
             dbus::utility::getSubTree(
-                "/", 0, interfaces,
+                "/xyz/openbmc_project/software/", 0, interfaces,
                 [asyncResp,
                  swId](const boost::system::error_code& ec,
                        const dbus::utility::MapperGetSubTreeResponse& subtree) {
@@ -1252,16 +1249,22 @@ inline void requestRoutesSoftwareInventory(App& app)
                                  std::string, std::vector<std::string>>>>& obj :
                          subtree)
                     {
-                        if (!obj.first.ends_with(*swId))
+                        sdbusplus::message::object_path path(obj.first);
+                        std::string id = path.filename();
+                        if (id.empty())
+                        {
+                            BMCWEB_LOG_DEBUG("Failed to find software id in {}",
+                                             obj.first);
+                            continue;
+                        }
+                        if (id != *swId)
                         {
                             continue;
                         }
-
                         if (obj.second.empty())
                         {
                             continue;
                         }
-
                         found = true;
                         sw_util::getSwStatus(asyncResp, swId,
                                              obj.second[0].first);
@@ -1281,6 +1284,9 @@ inline void requestRoutesSoftwareInventory(App& app)
                                 *swId));
                         return;
                     }
+                    asyncResp->res.jsonValue["@odata.id"] = boost::urls::format(
+                        "/redfish/v1/UpdateService/FirmwareInventory/{}",
+                        *swId);
                     asyncResp->res.jsonValue["@odata.type"] =
                         "#SoftwareInventory.v1_1_0.SoftwareInventory";
                     asyncResp->res.jsonValue["Name"] = "Software Inventory";


### PR DESCRIPTION
Updates to resolve getting a response for wrong URI in Update
Service URI (/redfish/v1/UpdateService/FirmwareInventory/)

Tested with the correct URI and results are correct.
Tested with wrong URI and 404 is returned
