### PR TITLE
Increase bmcweb automatic restart (#356) (#810)

### DIFF
--- a/config/bmcweb.service.in
+++ b/config/bmcweb.service.in
@@ -1,5 +1,7 @@
 [Unit]
 Description=Start bmcwebd server
+StartLimitIntervalSec=30
+StartLimitBurst=4
 
 Wants=network.target
 After=network.target


### PR DESCRIPTION
Rebase for 1120.

Currently our systemd service are automatically restarted on failure a
max of 3 times over 30 seconds. I.e. our current settings are:
StartLimitInterval=30
StartLimitBurst=2 (this PR increases this to 4) 

Certificate manager restarts bmcweb when a new certificate is uploaded,
we have seen this happen more than 3 times in a 30 second period.
Allow bmcweb to be restarted 5 times over a 30 second period before
stopping.
This is a short term fix, the long term fix is Certificate manager will
throttle how often it restarts bmcweb.