### PR TITLE
1120: Rebase pcieslot base set

### DIFF
--- a/Redfish.md
+++ b/Redfish.md
@@ -234,6 +234,7 @@ Fields common to all schemas
 - Manufacturer
 - Model
 - PartNumber
+- PCIeSlots
 - Power
 - PowerSubsystem
 - PowerState
@@ -275,6 +276,15 @@ Fields common to all schemas
 - PowerSupplies
 - Redundancy
 - Voltages
+
+### /redfish/v1/Chassis/{ChassisId}/PCIeSlots/
+
+#### Slots
+
+- HotPluggable
+- Lanes
+- PCIeType
+- SlotType
 
 ### /redfish/v1/Chassis/{ChassisId}/Sensors/
 

--- a/redfish-core/lib/chassis.hpp
+++ b/redfish-core/lib/chassis.hpp
@@ -591,6 +591,9 @@ inline void handleChassisGetSubTree(
             .jsonValue["Actions"]["#Chassis.Reset"]["@Redfish.ActionInfo"] =
             boost::urls::format("/redfish/v1/Chassis/{}/ResetActionInfo",
                                 chassisId);
+        asyncResp->res.jsonValue["PCIeSlots"]["@odata.id"] =
+            boost::urls::format("/redfish/v1/Chassis/{}/PCIeSlots", chassisId);
+
         dbus::utility::getAssociationEndPoints(
             path + "/drive",
             [asyncResp, chassisId](const boost::system::error_code& ec3,

--- a/redfish-core/lib/pcie_slots.hpp
+++ b/redfish-core/lib/pcie_slots.hpp
@@ -129,11 +129,12 @@ inline void onPcieSlotGetAllDone(
     const size_t* lanes = nullptr;
     const std::string* slotType = nullptr;
     const bool* hotPluggable = nullptr;
+    const size_t* busId = nullptr;
 
     const bool success = sdbusplus::unpackPropertiesNoThrow(
         dbus_utils::UnpackErrorPrinter(), propertiesList, "Generation",
         generation, "Lanes", lanes, "SlotType", slotType, "HotPluggable",
-        hotPluggable);
+        hotPluggable, "BusId", busId);
 
     if (!success)
     {
@@ -188,6 +189,12 @@ inline void onPcieSlotGetAllDone(
     if (hotPluggable != nullptr)
     {
         slot["HotPluggable"] = *hotPluggable;
+    }
+
+    if (busId != nullptr)
+    {
+        slot["Oem"]["IBM"]["@odata.type"] = "#IBMPCIeSlots.v1_0_0.PCIeSlot";
+        slot["Oem"]["IBM"]["LinkId"] = *busId;
     }
 
     size_t index = slots.size();

--- a/redfish-core/schema/oem/ibm/csdl/IBMPCIeSlots_v1.xml
+++ b/redfish-core/schema/oem/ibm/csdl/IBMPCIeSlots_v1.xml
@@ -1,0 +1,46 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<edmx:Edmx xmlns:edmx="http://docs.oasis-open.org/odata/ns/edmx" Version="4.0">
+  <edmx:Reference Uri="http://docs.oasis-open.org/odata/odata/v4.0/errata03/csd01/complete/vocabularies/Org.OData.Core.V1.xml">
+    <edmx:Include Namespace="Org.OData.Core.V1" Alias="OData"/>
+  </edmx:Reference>
+  <edmx:Reference Uri="http://docs.oasis-open.org/odata/odata/v4.0/errata03/csd01/complete/vocabularies/Org.OData.Measures.V1.xml">
+    <edmx:Include Namespace="Org.OData.Measures.V1" Alias="Measures"/>
+  </edmx:Reference>
+  <edmx:Reference Uri="http://redfish.dmtf.org/schemas/v1/RedfishExtensions_v1.xml">
+    <edmx:Include Namespace="RedfishExtensions.v1_0_0" Alias="Redfish"/>
+  </edmx:Reference>
+    <edmx:Reference Uri="http://redfish.dmtf.org/schemas/v1/PCIeSlots_v1.xml">
+        <edmx:Include Namespace="PCIeSlots"/>
+        <edmx:Include Namespace="PCIeSlots.v1_5_0"/>
+    </edmx:Reference>
+  <edmx:Reference Uri="http://redfish.dmtf.org/schemas/v1/Resource_v1.xml">
+    <edmx:Include Namespace="Resource"/>
+    <edmx:Include Namespace="Resource.v1_0_0"/>
+  </edmx:Reference>
+  <edmx:DataServices>
+    <Schema xmlns="http://docs.oasis-open.org/odata/ns/edm" Namespace="IBMPCIeSlots">
+      <Annotation Term="Redfish.OwningEntity" String="IBM"/>
+    </Schema>
+    <Schema xmlns="http://docs.oasis-open.org/odata/ns/edm" Namespace="IBMPCIeSlots.v1_0_0">
+      <Annotation Term="Redfish.OwningEntity" String="IBM"/>
+      <ComplexType Name="Oem" BaseType="Resource.OemObject">
+        <Annotation Term="OData.AdditionalProperties" Bool="true"/>
+        <Annotation Term="OData.Description" String="IBMPCIeSlots Oem properties."/>
+        <Annotation Term="OData.AutoExpand"/>
+        <Property Name="IBM" Type="IBMPCIeSlots.v1_0_0.IBM"/>
+      </ComplexType>
+      <ComplexType Name="IBM" BaseType="Resource.OemObject">
+        <Annotation Term="OData.AdditionalProperties" Bool="true"/>
+        <Annotation Term="OData.Description" String="Oem properties for IBM."/>
+        <Annotation Term="OData.AutoExpand"/>
+        <Property Name="PCIeSlot" Type="IBMPCIeSlots.v1_0_0.PCIeSlot"/>
+      </ComplexType>
+      <ComplexType Name="PCIeSlot" BaseType="Resource.OemObject">
+        <Property Name="LinkId" Type="Edm.Int64">
+          <Annotation Term="OData.Permissions" EnumMember="OData.Permission/Read"/>
+          <Annotation Term="OData.Description" String="Number of PCIe lanes in use."/>
+        </Property>
+      </ComplexType>
+    </Schema>
+  </edmx:DataServices>
+</edmx:Edmx>

--- a/redfish-core/schema/oem/ibm/json-schema/IBMPCIeSlots.json
+++ b/redfish-core/schema/oem/ibm/json-schema/IBMPCIeSlots.json
@@ -1,0 +1,8 @@
+{
+    "$id": "https://github.com/ibm-openbmc/bmcweb/tree/HEAD/redfish-core/schema/oem/ibm/json-schema/IBMPCIeSlots.json",
+    "$schema": "http://redfish.dmtf.org/schemas/v1/redfish-schema-v1.json",
+    "copyright": "Copyright 2024 OpenBMC.",
+    "definitions": {},
+    "owningEntity": "IBM",
+    "title": "#IBMPCIeSlots"
+}

--- a/redfish-core/schema/oem/ibm/json-schema/IBMPCIeSlots.v1_0_0.json
+++ b/redfish-core/schema/oem/ibm/json-schema/IBMPCIeSlots.v1_0_0.json
@@ -1,0 +1,98 @@
+{
+    "$id": "http://redfish.dmtf.org/schemas/v1/IBMPCIeSlots.v1_0_0.json",
+    "$schema": "http://redfish.dmtf.org/schemas/v1/redfish-schema-v1.json",
+    "copyright": "Copyright 2014-2019 DMTF. For the full DMTF copyright policy, see http://www.dmtf.org/about/policies/copyright",
+    "definitions": {
+        "Oem": {
+            "additionalProperties": true,
+            "description": "IBMPCIeSlots Oem properties.",
+            "patternProperties": {
+                "^([a-zA-Z_][a-zA-Z0-9_]*)?@(odata|Redfish|Message)\\.[a-zA-Z_][a-zA-Z0-9_]*$": {
+                    "description": "This property shall specify a valid odata or Redfish property.",
+                    "type": [
+                        "array",
+                        "boolean",
+                        "integer",
+                        "number",
+                        "null",
+                        "object",
+                        "string"
+                    ]
+                }
+            },
+            "properties": {
+                "IBM": {
+                    "anyOf": [
+                        {
+                            "$ref": "#/definitions/IBM"
+                        },
+                        {
+                            "type": "null"
+                        }
+                    ]
+                }
+            },
+            "type": "object"
+        },
+        "IBM": {
+            "additionalProperties": true,
+            "description": "Oem properties for IBM.",
+            "patternProperties": {
+                "^([a-zA-Z_][a-zA-Z0-9_]*)?@(odata|Redfish|Message)\\.[a-zA-Z_][a-zA-Z0-9_]*$": {
+                    "description": "This property shall specify a valid odata or Redfish property.",
+                    "type": [
+                        "array",
+                        "boolean",
+                        "integer",
+                        "number",
+                        "null",
+                        "object",
+                        "string"
+                    ]
+                }
+            },
+            "properties": {
+                "PCIeSlot": {
+                    "anyOf": [
+                        {
+                            "$ref": "#/definitions/PCIeSlot"
+                        },
+                        {
+                            "type": "null"
+                        }
+                    ]
+                }
+            },
+            "type": "object"
+        },
+        "PCIeSlot": {
+            "additionalProperties": true,
+            "description": "Oem properties for IBM.",
+            "patternProperties": {
+                "^([a-zA-Z_][a-zA-Z0-9_]*)?@(odata|Redfish|Message)\\.[a-zA-Z_][a-zA-Z0-9_]*$": {
+                    "description": "This property shall specify a valid odata or Redfish property.",
+                    "type": [
+                        "array",
+                        "boolean",
+                        "integer",
+                        "number",
+                        "null",
+                        "object",
+                        "string"
+                    ]
+                }
+            },
+            "properties": {
+                "LinkId": {
+                    "description": "An identifier to detect the PCIe bus linked to the slot.",
+                    "readonly": true,
+                    "type": "integer"
+                }
+            },
+            "type": "object"
+        }
+    },
+    "owningEntity": "IBM",
+    "release": "1.0",
+    "title": "#IBMPCIeSlots.v1_0_0"
+}

--- a/redfish-core/schema/oem/ibm/meson.build
+++ b/redfish-core/schema/oem/ibm/meson.build
@@ -1,0 +1,18 @@
+# IBM schemas that should be installed
+schemas = [
+    'IBMPCIeSlots',
+]
+
+foreach schema : schemas
+    install_data(
+        'csdl/@0@_v1.xml'.format(schema),
+        install_dir: 'share/www/redfish/v1/schema',
+        follow_symlinks: true,
+    )
+
+    install_data(
+        'json-schema/@0@.v1_0_0.json'.format(schema),
+        install_dir: 'share/www/redfish/v1/JsonSchemas',
+        follow_symlinks: true,
+    )
+endforeach

--- a/redfish-core/schema/oem/meson.build
+++ b/redfish-core/schema/oem/meson.build
@@ -1,1 +1,2 @@
 subdir('openbmc')
+subdir('ibm')

--- a/redfish-core/src/redfish.cpp
+++ b/redfish-core/src/redfish.cpp
@@ -30,6 +30,7 @@
 #include "network_protocol.hpp"
 #include "odata.hpp"
 #include "pcie.hpp"
+#include "pcie_slots.hpp"
 #include "power.hpp"
 #include "power_subsystem.hpp"
 #include "power_supply.hpp"
@@ -198,6 +199,7 @@ RedfishService::RedfishService(App& app)
     requestRoutesLDAPCertificate(app);
     requestRoutesTrustStoreCertificate(app);
 
+    requestRoutesPCIeSlots(app);
     requestRoutesSystemPCIeFunctionCollection(app);
     requestRoutesSystemPCIeFunction(app);
     requestRoutesSystemPCIeDeviceCollection(app);


### PR DESCRIPTION
This is to layout the initial rebase set for PCIeSlots and Oem IBMPCIeSlots 

- 67ce7565ab  Fix PCIeSlots when empty association (#1031)
- 9004f77d08  Add Id back to PCIeSlots redfish json (#1045)
- 6b23780745 Add Pcie slot to Pcie device link (ibm-openbmc#570) (#847)
- d012981d35  Add Get for PCIe properties LinkId (#578) (#843)

Tested:
- Perform the tests for each commit
- Redfish-Service-Validator passes