### PR TITLE
Accounts/service ACF properties added

### DIFF
--- a/meson.options
+++ b/meson.options
@@ -493,6 +493,14 @@ option(
                     Should be set to false for production systems.''',
 )
 
+# BMCWEB_IBM_OEM_MANAGER_ACCOUNT
+option(
+    'ibm-oem-manager-account',
+    type: 'feature',
+    value: 'enabled',
+    description: '''Enable the IBM OEM Manager account for IBM systems.''',
+)
+
 # BMCWEB_INSECURE_IGNORE_CONTENT_TYPE
 option(
     'insecure-ignore-content-type',

--- a/redfish-core/include/privileges.hpp
+++ b/redfish-core/include/privileges.hpp
@@ -44,9 +44,14 @@ constexpr const size_t maxPrivilegeCount = 32;
  * "hostconsole" user group. This privilege is required to access the host
  * console.
  */
-constexpr std::array<std::string_view, maxPrivilegeCount> privilegeNames{
-    "Login",         "ConfigureManager", "ConfigureComponents",
-    "ConfigureSelf", "ConfigureUsers",   "OpenBMCHostConsole"};
+static const std::array<std::string, maxPrivilegeCount> privilegeNames{
+    "Login",
+    "ConfigureManager",
+    "ConfigureComponents",
+    "ConfigureSelf",
+    "ConfigureUsers",
+    "OpenBMCHostConsole",
+    "OemIBMPerformService"};
 
 /**
  * @brief Redfish privileges
@@ -242,7 +247,16 @@ inline Privileges getUserPrivileges(const persistent_data::UserSession& session)
         privs.setSinglePrivilege("Login");
         privs.setSinglePrivilege("ConfigureSelf");
     }
-
+    else if (session.userRole == "priv-oemibmserviceagent")
+    {
+        // Redfish privilege : Administrator + IBM OEM
+        privs.setSinglePrivilege("Login");
+        privs.setSinglePrivilege("ConfigureManager");
+        privs.setSinglePrivilege("ConfigureSelf");
+        privs.setSinglePrivilege("ConfigureUsers");
+        privs.setSinglePrivilege("ConfigureComponents");
+        privs.setSinglePrivilege("OemIBMPerformService");
+    }
     return privs;
 }
 

--- a/redfish-core/schema/oem/openbmc/csdl/OemManagerAccount_v1.xml
+++ b/redfish-core/schema/oem/openbmc/csdl/OemManagerAccount_v1.xml
@@ -1,0 +1,67 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<edmx:Edmx xmlns:edmx="http://docs.oasis-open.org/odata/ns/edmx" Version="4.0">
+    <edmx:Reference Uri="http://docs.oasis-open.org/odata/odata/v4.0/errata03/csd01/complete/vocabularies/Org.OData.Core.V1.xml">
+        <edmx:Include Namespace="Org.OData.Core.V1" Alias="OData" />
+    </edmx:Reference>
+    <edmx:Reference Uri="http://redfish.dmtf.org/schemas/v1/RedfishExtensions_v1.xml">
+        <edmx:Include Namespace="Validation.v1_0_0" Alias="Validation"/>
+        <edmx:Include Namespace="RedfishExtensions.v1_0_0" Alias="Redfish"/>
+    </edmx:Reference>
+    <edmx:Reference Uri="http://redfish.dmtf.org/schemas/v1/ManagerAccount_v1.xml">
+        <edmx:Include Namespace="ManagerAccount"/>
+        <edmx:Include Namespace="ManagerAccount.v1_4_0"/>
+    </edmx:Reference>
+    <edmx:Reference Uri="http://redfish.dmtf.org/schemas/v1/Resource_v1.xml">
+        <edmx:Include Namespace="Resource"/>
+        <edmx:Include Namespace="Resource.v1_0_0"/>
+    </edmx:Reference>
+
+    <edmx:DataServices>
+       <Schema xmlns="http://docs.oasis-open.org/odata/ns/edm" Namespace="OemManagerAccount">
+          <Annotation Term="Redfish.OwningEntity" String="IBM"/>
+      </Schema>
+
+        <Schema xmlns="http://docs.oasis-open.org/odata/ns/edm" Namespace="OemManagerAccount.v1_0_0">
+            <ComplexType Name="Oem" BaseType="Resource.OemObject">
+                <Annotation Term="OData.AdditionalProperties" Bool="true" />
+                <Annotation Term="OData.Description" String="OemManagerAccount Oem properties." />
+                <Annotation Term="OData.AutoExpand"/>
+                <Property Name="IBM" Type="OemManagerAccount.v1_0_0.IBM"/>
+            </ComplexType>
+
+            <ComplexType Name="IBM">
+                <Annotation Term="OData.AdditionalProperties" Bool="true" />
+                <Annotation Term="OData.Description" String="Oem properties for IBM." />
+                <Annotation Term="OData.AutoExpand"/>
+                <Property Name="ACF" Type="OemManagerAccount.v1_0_0.ACF"/>
+            </ComplexType>
+
+            <ComplexType Name="ACF">
+                <Annotation Term="OData.Description" String="A collection of ACF properties."/>
+                <Annotation Term="OData.LongDescription" String="A collection of access control file properties."/>
+                <Annotation Term="OData.AdditionalProperties" Bool="false"/>
+                <Property Name="ACFFile" Type="Edm.String" Nullable="true">
+                    <Annotation Term="OData.Permissions" EnumMember="OData.Permission/ReadWrite"/>
+                    <Annotation Term="OData.Description" String="Base 64 encoded ACF contents."/>
+                    <Annotation Term="OData.LongDescription" String="Base 64 encoded ACF contents. Contents must have a valid signature, expiration date, and serial number must match BMC serial number"/>
+                </Property>
+                <Property Name="WarningLongDatedExpiration" Type="Edm.Boolean" Nullable="true">
+                    <Annotation Term="OData.Permissions" EnumMember="OData.Permission/Read"/>
+                    <Annotation Term="OData.Description" String="This property is set to true if there is a long dated expiration."/>
+                    <Annotation Term="OData.LongDescription" String="This property is set to true if the expiration date on the ACF exceeds 30 days from the BMC date."/>
+                </Property>
+                <Property Name="ExpirationDate" Type="Edm.String" Nullable="true">
+                    <Annotation Term="OData.Permissions" EnumMember="OData.Permission/Read"/>
+                    <Annotation Term="OData.Description" String="The expiration date of the ACF file."/>
+                    <Annotation Term="OData.LongDescription" String="The expiration date of the ACF file, if the expiration date has been from the BMC then the ACF is not validD"/>
+                </Property>
+                <Property Name="ACFInstalled" Type="Edm.Boolean">
+                    <Annotation Term="OData.Permissions" EnumMember="OData.Permission/Read"/>
+                    <Annotation Term="OData.Description" String="This property is set to true if the ACF is installed."/>
+                    <Annotation Term="OData.LongDescription" String="This property indicates if the ACF is installed or not."/>
+                </Property>
+            </ComplexType>
+
+        </Schema>
+    </edmx:DataServices>
+</edmx:Edmx>

--- a/redfish-core/schema/oem/openbmc/json-schema/OemManagerAccount.v1_0_0.json
+++ b/redfish-core/schema/oem/openbmc/json-schema/OemManagerAccount.v1_0_0.json
@@ -1,0 +1,88 @@
+{
+    "$id": "http://redfish.dmtf.org/schemas/v1/OemManagerAccount.v1_0_0.json",
+    "$schema": "http://redfish.dmtf.org/schemas/v1/redfish-schema-v1.json",
+    "copyright": "Copyright 2014-2019 DMTF. For the full DMTF copyright policy, see http://www.dmtf.org/about/policies/copyright",
+    "definitions": {
+        "IBM": {
+            "additionalProperties": true,
+            "description": "Oem IBM ManagerAccount extension.",
+            "longDescription": "Oem IBM ManagementAccount extension.",
+            "patternProperties": {
+                "^([a-zA-Z_][a-zA-Z0-9_]*)?@(odata|Redfish|Message)\\.[a-zA-Z_][a-zA-Z0-9_]*$": {
+                    "description": "This property shall specify a valid odata or Redfish property.",
+                    "type": [
+                        "array",
+                        "boolean",
+                        "integer",
+                        "number",
+                        "null",
+                        "object",
+                        "string"
+                    ]
+                }
+            },
+            "properties": {
+                "ACF": {
+                    "$ref": "#/definitions/ACF",
+                    "description": "A collection of ACF properties.",
+                    "longDescription": "A collection of access control file properties.",
+                    "readonly": false,
+                    "versionAdded": "v1_0_0"
+                }
+            }
+        },
+        "ACF": {
+            "additionalProperties": false,
+            "description": "OEM Extension for ManagerAccount",
+            "longDescription": "OEM Extension for ManagerAccount to provide the Service account extension.",
+            "patternProperties": {
+                "^([a-zA-Z_][a-zA-Z0-9_]*)?@(odata|Redfish|Message)\\.[a-zA-Z_][a-zA-Z0-9_]*$": {
+                    "description": "This property shall specify a valid odata or Redfish property.",
+                    "type": [
+                        "array",
+                        "boolean",
+                        "integer",
+                        "number",
+                        "null",
+                        "object",
+                        "string"
+                    ]
+                }
+            },
+            "properties": {
+                "ACFFile": {
+                    "description": "Base 64 encoded ACF contents.",
+                    "longDescription": "Base 64 encoded ACF contents. Contents must have a valid signature, expiration date, and serial number must match BMC serial number",
+                    "readonly": false,
+                    "type": "string",
+                    "versionAdded": "v1_0_0"
+                },
+                "ExpirationDate": {
+                    "description": "The expiration date of the ACF file.",
+                    "longDescription": "The expiration date of the ACF file, if the expiration date has been from the BMC then the ACF is not valid.",
+                    "readonly": true,
+                    "type": ["string", "null"],
+                    "versionAdded": "v1_0_0"
+                },
+                "WarningLongDatedExpiration": {
+                    "description": "This property is set to true if there is a long dated expiration.",
+                    "longDescription": "This property is set to true if the expiration date on the ACF exceeds 30 days from the BMC date.",
+                    "readonly": true,
+                    "type": ["boolean", "null"],
+                    "versionAdded": "v1_0_0"
+                },
+                "ACFInstalled": {
+                    "description": "This property is set to true if the ACF is installed.",
+                    "longDescription": "This property indicates if the ACF is installed or not.",
+                    "readonly": true,
+                    "type": ["boolean"],
+                    "versionAdded": "v1_0_0"
+                }
+            },
+            "type": "object"
+        }
+    },
+    "owningEntity": "OpenBMC",
+    "release": "1.0",
+    "title": "#OemManagerAccount"
+}

--- a/redfish-core/schema/oem/openbmc/meson.build
+++ b/redfish-core/schema/oem/openbmc/meson.build
@@ -3,6 +3,7 @@ schemas = {
     'insecure-disable-auth': 'OpenBMCAccountService',
     'redfish-oem-manager-fan-data': 'OpenBMCManager',
     'redfish-provisioning-feature': 'OpenBMCComputerSystem',
+    'ibm-oem-manager-account': 'OemManagerAccount',
     #'vm-nbdproxy': 'OpenBMCVirtualMedia',
 }
 


### PR DESCRIPTION
For the 1120 rebase, merge all ACF and Service user commits into one. This will ensure future cherry-picks of this downstream function are easier to bring in. Having it spread across multiple commits makes the process of bringing it back in during rebases unnecessarily complex.

The properties of the "service" user has been
    extended to include ["Oem"]["IBM"]["ACF"]

The patch and get methods to the route
    "/redfish/v1/AccountService/Accounts/service"
    now return the ACF properties to the request.

These properties include:
ACFFile, ExpirationDate, ACFInstalled,
WarningLongDatedExpiration, BMCCurrentDate

These were added in support for acf upload functionality.

A summary of these properties are as follows:
ACFFile : contents of the ACF file uploaded
ExpirationDate : date of expiration for the ACF file ACFInstalled : ACF installed state
WarningLongDatedExpiration : set if expiration is
    > than 30 days from the BMC date
BMCCurrentDate : BMC current date to display if
    warning message is enabled