### PR TITLE
Implement LocationIndicatorActive for PowerSupplies (#818)

### DIFF
--- a/Redfish.md
+++ b/Redfish.md
@@ -454,6 +454,7 @@ Fields common to all schemas
   - EfficiencyPercent
 - FirmwareVersion
 - Location
+- LocationIndicatorActive
 - Manufacturer
 - Model
 - PartNumber

--- a/redfish-core/lib/led.hpp
+++ b/redfish-core/lib/led.hpp
@@ -11,13 +11,22 @@
 #include "logging.hpp"
 #include "utils/dbus_utils.hpp"
 
+#include <asm-generic/errno.h>
+
+#include <boost/system/error_code.hpp>
 #include <sdbusplus/asio/property.hpp>
 #include <sdbusplus/message/native_types.hpp>
 
+#include <array>
+#include <functional>
 #include <memory>
+#include <string_view>
+#include <utility>
 
 namespace redfish
 {
+static constexpr std::array<std::string_view, 1> ledGroupInterface = {
+    "xyz.openbmc_project.Led.Group"};
 /**
  * @brief Retrieves identify led group properties over dbus
  *
@@ -232,4 +241,185 @@ inline void setSystemLocationIndicatorActive(
             }
         });
 }
+
+inline void handleLedGroupSubtree(
+    const std::string& objPath, const boost::system::error_code& ec,
+    const dbus::utility::MapperGetSubTreeResponse& subtree,
+    const std::function<void(const boost::system::error_code& ec,
+                             const std::string& ledGroupPath,
+                             const std::string& service)>& callback)
+{
+    if (ec)
+    {
+        // Callback will handle the error
+        callback(ec, "", "");
+        return;
+    }
+
+    if (subtree.empty())
+    {
+        // Callback will handle the error
+        BMCWEB_LOG_DEBUG(
+            "No LED group associated with the specified object path: {}",
+            objPath);
+        callback(ec, "", "");
+        return;
+    }
+
+    if (subtree.size() > 1)
+    {
+        // Callback will handle the error
+        BMCWEB_LOG_DEBUG(
+            "More than one LED group associated with the object {}: {}",
+            objPath, subtree.size());
+        callback(ec, "", "");
+        return;
+    }
+
+    const auto& [ledGroupPath, serviceMap] = *subtree.begin();
+    const auto& [service, interfaces] = *serviceMap.begin();
+    callback(ec, ledGroupPath, service);
+}
+
+inline void getLedGroupPath(
+    const std::shared_ptr<bmcweb::AsyncResp>& asyncResp,
+    const std::string& objPath,
+    std::function<void(const boost::system::error_code& ec,
+                       const std::string& ledGroupPath,
+                       const std::string& service)>&& callback)
+{
+    static constexpr const char* ledObjectPath =
+        "/xyz/openbmc_project/led/groups";
+    sdbusplus::message::object_path ledGroupAssociatedPath =
+        objPath + "/identifying";
+
+    dbus::utility::getAssociatedSubTree(
+        ledGroupAssociatedPath, sdbusplus::message::object_path(ledObjectPath),
+        0, ledGroupInterface,
+        [asyncResp, objPath, callback{std::move(callback)}](
+            const boost::system::error_code& ec,
+            const dbus::utility::MapperGetSubTreeResponse& subtree) {
+            handleLedGroupSubtree(objPath, ec, subtree, callback);
+        });
+}
+
+inline void afterGetLedState(
+    const std::shared_ptr<bmcweb::AsyncResp>& asyncResp,
+    const boost::system::error_code& ec, bool assert)
+{
+    if (ec)
+    {
+        if (ec.value() != EBADR)
+        {
+            BMCWEB_LOG_ERROR("DBUS response error for get ledState {}",
+                             ec.value());
+            messages::internalError(asyncResp->res);
+        }
+        return;
+    }
+
+    asyncResp->res.jsonValue["LocationIndicatorActive"] = assert;
+}
+
+inline void getLedState(const std::shared_ptr<bmcweb::AsyncResp>& asyncResp,
+                        const boost::system::error_code& ec,
+                        const std::string& ledGroupPath,
+                        const std::string& service)
+{
+    if (ec)
+    {
+        if (ec.value() != EBADR)
+        {
+            BMCWEB_LOG_ERROR("DBUS response error {}", ec.value());
+            messages::internalError(asyncResp->res);
+        }
+        return;
+    }
+
+    if (ledGroupPath.empty() || service.empty())
+    {
+        // No LED group associated, not an error
+        return;
+    }
+
+    sdbusplus::asio::getProperty<bool>(
+        *crow::connections::systemBus, service, ledGroupPath,
+        "xyz.openbmc_project.Led.Group", "Asserted",
+        std::bind_front(afterGetLedState, asyncResp));
+}
+
+/**
+ * @brief Retrieves identify led group properties over dbus
+ *
+ * @param[in] asyncResp Shared pointer for generating response
+ * message.
+ * @param[in] objPath   Object path on PIM
+ *
+ * @return None.
+ */
+inline void getLocationIndicatorActive(
+    const std::shared_ptr<bmcweb::AsyncResp>& asyncResp,
+    const std::string& objPath)
+{
+    BMCWEB_LOG_DEBUG("Get LocationIndicatorActive for {}", objPath);
+    getLedGroupPath(asyncResp, objPath,
+                    [asyncResp](const boost::system::error_code& ec,
+                                const std::string& ledGroupPath,
+                                const std::string& service) {
+                        getLedState(asyncResp, ec, ledGroupPath, service);
+                    });
+}
+
+inline void setLedState(const std::shared_ptr<bmcweb::AsyncResp>& asyncResp,
+                        bool ledState, const boost::system::error_code& ec,
+                        const std::string& ledGroupPath,
+                        const std::string& service)
+{
+    if (ec)
+    {
+        if (ec.value() == EBADR)
+        {
+            messages::propertyUnknown(asyncResp->res,
+                                      "LocationIndicatorActive");
+            return;
+        }
+        BMCWEB_LOG_ERROR("DBUS response error {}", ec.value());
+        messages::internalError(asyncResp->res);
+        return;
+    }
+
+    if (ledGroupPath.empty() || service.empty())
+    {
+        messages::propertyUnknown(asyncResp->res, "LocationIndicatorActive");
+        return;
+    }
+
+    setDbusProperty(asyncResp, "LocationIndicatorActive", service, ledGroupPath,
+                    "xyz.openbmc_project.Led.Group", "Asserted", ledState);
+}
+
+/**
+ * @brief Sets identify led group properties
+ *
+ * @param[in] asyncResp     Shared pointer for generating response
+ * message.
+ * @param[in] objPath       Object path on PIM
+ * @param[in] ledState      LED state passed from request
+ *
+ * @return None.
+ */
+inline void setLocationIndicatorActive(
+    const std::shared_ptr<bmcweb::AsyncResp>& asyncResp,
+    const std::string& objPath, bool ledState)
+{
+    BMCWEB_LOG_DEBUG("Set LocationIndicatorActive for {}", objPath);
+    getLedGroupPath(
+        asyncResp, objPath,
+        [asyncResp, ledState](const boost::system::error_code& ec,
+                              const std::string& ledGroupPath,
+                              const std::string& service) {
+            setLedState(asyncResp, ledState, ec, ledGroupPath, service);
+        });
+}
+
 } // namespace redfish


### PR DESCRIPTION
Cherry-pick of upstream commit https://gerrit.openbmc.org/c/openbmc/bmcweb/+/42221

Tested using upstream flash image on hardware simulator. Redfish validator was run. Lots of unrelated errors, but the checks for LocationIndicatorActive passed.

Implement LocationIndicatorActive for PowerSupplies schema to set/get the status of the location LED for each power supply.[1] When working with Redfish to get or set the "LocationIndicatorActive" property, the initial step involves locating the corresponding LED group through the "identifying" association.[2][3][4] Following this, we can proceed to either get or set the "Asserted" property.[5]

[1] https://redfish.dmtf.org/schemas/v1/PowerSupply.v1_5_0.json
[2] https://github.com/openbmc/phosphor-dbus-interfaces/tree/master/yaml/xyz/openbmc_project/Led#dbus-interfaces-for-led-groups
[3] https://github.com/openbmc/docs/blob/master/architecture/LED-architecture.md#redfish
[4] https://gerrit.openbmc.org/c/openbmc/phosphor-dbus-interfaces/+/58299
[5] https://github.com/openbmc/phosphor-dbus-interfaces/blob/master/yaml/xyz/openbmc_project/Led/Group.interface.yaml

Tested:
 - Validator passes.
 - Tested on p10bmc hardware simulator

1) Get LocationIndicatorActive
```
$ curl -k -H "X-Auth-Token: $token" -X GET https://${bmc}/redfish/v1/Chassis/chassis/PowerSubsystem/PowerSupplies/powersupply0
{
  "@odata.id": "/redfish/v1/Chassis/chassis/PowerSubsystem/PowerSupplies/powersupply0",
  "@odata.type": "#PowerSupply.v1_5_0.PowerSupply",
  "LocationIndicatorActive": false,
  ...
}
```

We will see the powersupply0 identify led is false too.
```
$ busctl get-property xyz.openbmc_project.LED.GroupManager /xyz/openbmc_project/led/groups/powersupply0_identify xyz.openbmc_project.Led.Group Asserted
b false
```

2) Set LocationIndicatorActive to true
```
$ curl -k -H "X-Auth-Token: $token" -H "Content-Type: application/json" -X PATCH -d '{"LocationIndicatorActive":true}' https://${bmc}/redfish/v1/Chassis/chassis/PowerSubsystem/PowerSupplies/powersupply0
```

Then we will see the powersupply0 location LED lit up, and the value becomes true:
```
$ curl -k -H "X-Auth-Token: $token" -X GET https://${bmc}/redfish/v1/Chassis/chassis/PowerSubsystem/PowerSupplies/powersupply0
{
  "@odata.id": "/redfish/v1/Chassis/chassis/PowerSubsystem/PowerSupplies/powersupply0",
  "@odata.type": "#PowerSupply.v1_5_0.PowerSupply",
  "LocationIndicatorActive": true,
  ...
}

$ busctl get-property xyz.openbmc_project.LED.GroupManager /xyz/openbmc_project/led/groups/powersupply0_identify xyz.openbmc_project.Led.Group Asserted
b true
```

3) Use set-property to change the value back to false
```
$ busctl set-property xyz.openbmc_project.LED.GroupManager /xyz/openbmc_project/led/groups/powersupply0_identify xyz.openbmc_project.Led.Group Asserted b false
$ busctl get-property xyz.openbmc_project.LED.GroupManager /xyz/openbmc_project/led/groups/powersupply0_identify xyz.openbmc_project.Led.Group Asserted
b false
```

Then we will see the value reflected in the Redfish query:
```
$ curl -k -H "X-Auth-Token: $token" -X GET https://${bmc}/redfish/v1/Chassis/chassis/PowerSubsystem/PowerSupplies/powersupply0
{
  "@odata.id": "/redfish/v1/Chassis/chassis/PowerSubsystem/PowerSupplies/powersupply0",
  "@odata.type": "#PowerSupply.v1_5_0.PowerSupply",
  "LocationIndicatorActive": false,
  ...
}
```

4) Error returned when trying to set the value to non-boolean:
```
$ curl -k -H "X-Auth-Token: $token" -H "Content-Type: application/json" -X PATCH -d '{"LocationIndicatorActive":"unknown"}' https://${bmc}/redfish/v1/Chassis/chassis/PowerSubsystem/PowerSupplies/powersupply0
{
  "LocationIndicatorActive@Message.ExtendedInfo": [
    {
      "@odata.type": "#Message.v1_1_1.Message",
      "Message": "The value '\"unknown\"' for the property LocationIndicatorActive is not a type that the property can accept.",
      "MessageArgs": [
        "\"unknown\"",
        "LocationIndicatorActive"
      ],
      "MessageId": "Base.1.19.PropertyValueTypeError",
      "MessageSeverity": "Warning",
      "Resolution": "Correct the value for the property in the request body and resubmit the request if the operation failed."
    }
  ]
}
```

5) Error returned when specifying a unknown power supply:
```
$ curl -k -H "X-Auth-Token: $token" -H "Content-Type: application/json" -X PATCH -d '{"LocationIndicatorActive":true}' https://${bmc}/redfish/v1/Chassis/chassis/PowerSubsystem/PowerSupplies/powersupplyBAD
{
  "error": {
    "@Message.ExtendedInfo": [
      {
        "@odata.type": "#Message.v1_1_1.Message",
        "Message": "The requested resource of type PowerSupplies named 'powersupplyBAD' was not found.",
        "MessageArgs": [
          "PowerSupplies",
          "powersupplyBAD"
        ],
        "MessageId": "Base.1.19.ResourceNotFound",
        "MessageSeverity": "Critical",
        "Resolution": "Provide a valid resource identifier and resubmit the request."
      }
    ],
    "code": "Base.1.19.ResourceNotFound",
    "message": "The requested resource of type PowerSupplies named 'powersupplyBAD' was not found."
  }
}

6) Forced no LED group to test failure paths for GET/PATCH
/* GET succeeds with no LocationIndicatorActive */
$ curl -k -H "X-Auth-Token: $token"  https://${bmc}/redfish/v1/Chassis/chassis/PowerSubsystem/PowerSupplies/powersupply0
{
  "@odata.id": "/redfish/v1/Chassis/chassis/PowerSubsystem/PowerSupplies/powersupply0",
  "@odata.type": "#PowerSupply.v1_5_0.PowerSupply",
  "EfficiencyRatings": [
    {
      "EfficiencyPercent": 90
    }
  ],
  "FirmwareVersion": "313033323330",
  "Id": "powersupply0",
  "Location": {
    "PartLocation": {
      "ServiceLabel": "U78DA.ND0.1234567-E0"
    }
  },
  "Manufacturer": "",
  "Model": "51E9",
  "Name": "Power Supply",
  "PartNumber": "revisio",
  "SerialNumber": "YL10K serial",
  "SparePartNumber": "c      ",
  "Status": {
    "Health": "OK",
    "State": "Enabled"
  }
}

/* PATCH fails when no LocationIndicatorActive property exists for
 * object
 */
$ curl -k -H "X-Auth-Token: $token" -H "Content-Type: application/json" -X PATCH -d '{"LocationIndicatorActive":true}'  https://${bmc}/redfish/v1/Chassis/chassis/PowerSubsystem/PowerSupplies/powersupply0
{
  "error": {
    "@Message.ExtendedInfo": [
      {
        "@odata.type": "#Message.v1_1_1.Message",
        "Message": "The property LocationIndicatorActive is not in the list of valid properties for the resource.",
        "MessageArgs": [
          "LocationIndicatorActive"
        ],
        "MessageId": "Base.1.19.PropertyUnknown",
        "MessageSeverity": "Warning",
        "Resolution": "Remove the unknown property from the request body and resubmit the request if the operation failed."
      }
    ],
    "code": "Base.1.19.PropertyUnknown",
    "message": "The property LocationIndicatorActive is not in the list of valid properties for the resource."
  }
}
```


Change-Id: Id0c30fa3d7c1e7ed4ff7f8fd1d5951d24053fbde