### PR TITLE
Enable port 18080

### DIFF
--- a/config/meson.build
+++ b/config/meson.build
@@ -121,20 +121,20 @@ endif
 
 ports = get_option('additional-ports')
 binds = get_option('additional-bind-to-device')
-auth = get_option('additional-auth')
+auths = get_option('additional-auth')
 foreach index : range(ports.length())
     port_number = ports[index]
     bind_to_device = '0.0.0.0'
     auth = 'auth'
     if index < binds.length()
-        bind = auth[index]
+        bind_to_device = binds[index]
     endif
 
-    if index < auth.length()
-        auth = auth[index]
+    if index < auths.length()
+        auth = auths[index]
     endif
 
-    filename = 'bmcweb_' + port_number.to_string()
+    filename = 'bmcweb_' + port_number
     configure_file(
         input: 'bmcweb.socket.in',
         output: filename,
@@ -144,7 +144,7 @@ foreach index : range(ports.length())
             {
                 'BMCWEB_HTTPS_PORT': port_number,
                 'HTTP_LEVEL_ALLOWED': 'https',
-                'HTTP_BIND': bind,
+                'HTTP_BIND': bind_to_device,
                 'HTTP_AUTH_LEVEL': auth,
             },
         ),

--- a/http/app.hpp
+++ b/http/app.hpp
@@ -144,6 +144,16 @@ class App
             socketIndex++;
         }
 
+        if (acceptors.empty())
+        {
+            constexpr int defaultPort = 18080;
+            BMCWEB_LOG_INFO("Starting webserver on port {}", defaultPort);
+            using boost::asio::ip::tcp;
+            tcp::endpoint end(tcp::v6(), defaultPort);
+            tcp::acceptor acc(getIoContext(), end);
+            acceptors.emplace_back(std::move(acc), HttpType::HTTPS);
+        }
+
         return acceptors;
     }
 


### PR DESCRIPTION
1120: Cherry-pick of upstream commit: https://gerrit.openbmc.org/c/openbmc/bmcweb/+/78337

With this commit I'm able to run 1120 built bmcweb on upstream flash image on simulator. Running bmcweb out of /tmp I'm able to connect through port 18080.

The commit [1] altered how sockets are created and inadvertently removed the default port 18080. We use this port extensively in development. The bmcweb documentation describes the port 18080 for this use. [2] Adding back the default port 18080.

The commit [1] added meson build options for adding additional ports. In attempting to enable port 18080 using that mechanism I ran into various build errors when additional-ports has a value. I've corrected the config/meson.build file to address those errors. These changes are not necessary to re-enable port 18080 but worth fixing anyway.

Note: Meson defines arrays as containing strings so there is no to_string() method for the array member. [3]
```
../../../../../../workspace/sources/bmcweb/config/meson.build:137:39: ERROR: Unknown method "to_string" in object <[StringHolder] holds [str]: '18080'> of type StringHolder.
```

Tested:
 - Started bmcweb from /tmp and was able to connect through port 18080. Log shows:
```
[DEBUG app.hpp:111] Got 0 sockets to open
[INFO app.hpp:150] Starting webserver on port 18080
```

[1] https://gerrit.openbmc.org/c/openbmc/bmcweb/+/35265
[2] https://github.com/openbmc/bmcweb/blob/cc67d0a0fed101c930b334a583d9ca9b222ceb77/TESTING.md?plain=1#L57
[3] https://mesonbuild.com/Build-options.html#arrays

Change-Id: Ia1b326bedca808e43e73ce2b241178bc4bfab23c