### PR TITLE
Implement LocationIndicatorActive for Memory resource (#571) (#968)

### DIFF
--- a/Redfish.md
+++ b/Redfish.md
@@ -940,6 +940,7 @@ other.
 - DataWidthBits
 - ErrorCorrection
 - FirmwareRevision
+- LocationIndicatorActive
 - Manufacturer
 - Model
 - OperatingSpeedMhz


### PR DESCRIPTION
Cherry-pick of upstream commit: https://gerrit.openbmc.org/c/openbmc/bmcweb/+/37310

Tested using upstream flash image on hardware simulator. Redfish validator was run. Lots of unrelated errors, but the checks for LocationIndicatorActive passed.

**Note**: 1110 was using `#Memory.v1_12_0.Memory` but upstream still is using `#Memory.v1_11_0.Memory`. I made 1120 match upstream here since the version change is not needed for this resource.

Implement LocationIndicatorActive for Memory schema to set/get the status of the location LED for a Dimm.[1]

Uses the utility functions getLocationIndicatorActive() and setLocationIndicatorActive() to follow the association and get or set the LED value.

[1] https://redfish.dmtf.org/schemas/v1/Memory.v1_20_0.json

Tested:
 - Note: The pre-existing code had support for finding objects implementing the interface "xyz.openbmc_project.Inventory.Item.PersistentMemory.Partition". From the comments it looks like these are separate objects on the D-Bus. The property information for these objects are added to the response for the Dimm. I kept the GET path similar to avoid regressing that support. However I was not able to test it as our hardware does not implement that interface. (Those interfaces are not part of the PATCH path.)
 - Redfish service validator passes
 - Tested on p10bmc hardware simulator:

 1. Get LocationIndicatorActive
```
$ curl -k -H "X-Auth-Token: $token" https://${bmc}/redfish/v1/Systems/system/Memory/dimm0
{
  "@odata.id": "/redfish/v1/Systems/system/Memory/dimm0",
  "@odata.type": "#Memory.v1_11_0.Memory",
  "LocationIndicatorActive": false,
  ...
}
```
 2. Set LocationIndicatorActive to true
```
$ curl -k -H "X-Auth-Token: $token" -H "Content-Type: application/json" -X PATCH -d '{"LocationIndicatorActive":true}' https://${bmc}/redfish/v1/Systems/system/Memory/dimm0
$ curl -k -H "X-Auth-Token: $token" https://${bmc}/redfish/v1/Systems/system/Memory/dimm0
{
  "@odata.id": "/redfish/v1/Systems/system/Memory/dimm0",
  "@odata.type": "#Memory.v1_11_0.Memory",
  "LocationIndicatorActive": true,
  ...
}
```

 3. Use busctl set-propery to change the value back to false
```
$ busctl --json=pretty call xyz.openbmc_project.ObjectMapper /xyz/openbmc_project/object_mapper xyz.openbmc_project.ObjectMapper GetAssociatedSubTreePaths ooias /xyz/openbmc_project/inventory/system/chassis/motherboard/dimm0/identifying /xyz/openbmc_project/led/groups 0 1 xyz.openbmc_project.Led.Group
{
        "type" : "as",
        "data" : [
                [
                        "/xyz/openbmc_project/led/groups/ddimm16_identify"
                ]
        ]
}
$ busctl set-property xyz.openbmc_project.LED.GroupManager /xyz/openbmc_project/led/groups/ddimm16_identify xyz.openbmc_project.Led.Group Asserted b false
$ curl -k -H "X-Auth-Token: $token" https://${bmc}/redfish/v1/Systems/system/Memory/dimm0
{
  "@odata.id": "/redfish/v1/Systems/system/Memory/dimm0",
  "@odata.type": "#Memory.v1_11_0.Memory",
  "LocationIndicatorActive": false,
  ...
}
```

 4. Error returned when trying to set the value to non-boolean
```
$ curl -k -H "X-Auth-Token: $token" -H "Content-Type: application/json" -X PATCH -d '{"LocationIndicatorActive":"unknown"}' https://${bmc}/redfish/v1/Systems/system/Memory/dimm0
{
  "LocationIndicatorActive@Message.ExtendedInfo": [
    {
      "@odata.type": "#Message.v1_1_1.Message",
      "Message": "The value '\"unknown\"' for the property LocationIndicatorActive is not a type that the property can accept.",
      "MessageArgs": [
        "\"unknown\"",
        "LocationIndicatorActive"
      ],
      "MessageId": "Base.1.19.PropertyValueTypeError",
      "MessageSeverity": "Warning",
      "Resolution": "Correct the value for the property in the request body and resubmit the request if the operation failed."
    }
  ]
}
```

 5. Error returned when specifying an unknown Memory resource
```
$ curl -k -H "X-Auth-Token: $token" https://${bmc}/redfish/v1/Systems/system/Memory/dimm300
{
  "error": {
    "@Message.ExtendedInfo": [
      {
        "@odata.type": "#Message.v1_1_1.Message",
        "Message": "The requested resource of type Memory named 'dimm300' was not found.",
        "MessageArgs": [
          "Memory",
          "dimm300"
        ],
        "MessageId": "Base.1.19.ResourceNotFound",
        "MessageSeverity": "Critical",
        "Resolution": "Provide a valid resource identifier and resubmit the request."
      }
    ],
    "code": "Base.1.19.ResourceNotFound",
    "message": "The requested resource of type Memory named 'dimm300' was not found."
  }
}

$ curl -k -H "X-Auth-Token: $token" -H "Content-Type: application/json" -X PATCH -d '{"LocationIndicatorActive":true}' https://${bmc}/redfish/v1/Systems/system/Memory/dimm300
{
  "error": {
    "@Message.ExtendedInfo": [
      {
        "@odata.type": "#Message.v1_1_1.Message",
        "Message": "The requested resource of type Memory named 'dimm300' was not found.",
        "MessageArgs": [
          "Memory",
          "dimm300"
        ],
        "MessageId": "Base.1.19.ResourceNotFound",
        "MessageSeverity": "Critical",
        "Resolution": "Provide a valid resource identifier and resubmit the request."
      }
    ],
    "code": "Base.1.19.ResourceNotFound",
    "message": "The requested resource of type Memory named 'dimm300' was not found."
  }
}
```


Change-Id: Ifb705003380c2a83ada8a645b346b0ae52a06183