### PR TITLE
Implement LocationIndicatorActive for Fan (#819)

### DIFF
--- a/Redfish.md
+++ b/Redfish.md
@@ -386,6 +386,7 @@ Fields common to all schemas
 #### Fan
 
 - Location
+- LocationIndicatorActive
 - Manufacturer
 - Model
 - PartNumber

--- a/redfish-core/lib/fan.hpp
+++ b/redfish-core/lib/fan.hpp
@@ -8,10 +8,12 @@
 #include "error_messages.hpp"
 #include "generated/enums/resource.hpp"
 #include "http_request.hpp"
+#include "led.hpp"
 #include "logging.hpp"
 #include "query.hpp"
 #include "registries/privilege_registry.hpp"
 #include "utils/chassis_utils.hpp"
+#include "utils/json_utils.hpp"
 
 #include <asm-generic/errno.h>
 
@@ -384,6 +386,7 @@ inline void afterGetValidFanPath(
     getFanHealth(asyncResp, fanPath, service);
     getFanAsset(asyncResp, fanPath, service);
     getFanLocation(asyncResp, fanPath, service);
+    getLocationIndicatorActive(asyncResp, fanPath);
 }
 
 inline void doFanGet(const std::shared_ptr<bmcweb::AsyncResp>& asyncResp,
@@ -445,6 +448,61 @@ inline void handleFanGet(App& app, const crow::Request& req,
         std::bind_front(doFanGet, asyncResp, chassisId, fanId));
 }
 
+inline void doPatchFan(const std::shared_ptr<bmcweb::AsyncResp>& asyncResp,
+                       const bool locationIndicatorActive,
+                       const std::string& fanPath,
+                       const std::string& /* service */)
+{
+    setLocationIndicatorActive(asyncResp, fanPath, locationIndicatorActive);
+}
+
+inline void fanPatchAfterValidateChassis(
+    const std::shared_ptr<bmcweb::AsyncResp>& asyncResp,
+    const std::string& chassisId, const std::string& fanId,
+    const bool locationIndicatorActive,
+    const std::optional<std::string>& validChassisPath)
+{
+    if (!validChassisPath)
+    {
+        BMCWEB_LOG_WARNING("Not a valid chassis ID: {}", chassisId);
+        messages::resourceNotFound(asyncResp->res, "Chassis", chassisId);
+        return;
+    }
+
+    // Verify that the fan has the correct chassis and whether fan has a
+    // chassis association
+    getValidFanPath(
+        asyncResp, *validChassisPath, fanId,
+        std::bind_front(doPatchFan, asyncResp, locationIndicatorActive));
+}
+
+inline void handleFanPatch(App& app, const crow::Request& req,
+                           const std::shared_ptr<bmcweb::AsyncResp>& asyncResp,
+                           const std::string& chassisId,
+                           const std::string& fanId)
+{
+    if (!redfish::setUpRedfishRoute(app, req, asyncResp))
+    {
+        return;
+    }
+
+    std::optional<bool> locationIndicatorActive;
+    if (!json_util::readJsonPatch(req, asyncResp->res,
+                                  "LocationIndicatorActive",
+                                  locationIndicatorActive))
+    {
+        return;
+    }
+
+    if (locationIndicatorActive)
+    {
+        redfish::chassis_utils::getValidChassisPath(
+            asyncResp, chassisId,
+            std::bind_front(fanPatchAfterValidateChassis, asyncResp, chassisId,
+                            fanId, *locationIndicatorActive));
+    }
+}
+
 inline void requestRoutesFan(App& app)
 {
     BMCWEB_ROUTE(app, "/redfish/v1/Chassis/<str>/ThermalSubsystem/Fans/<str>/")
@@ -456,6 +514,11 @@ inline void requestRoutesFan(App& app)
         .privileges(redfish::privileges::getFan)
         .methods(boost::beast::http::verb::get)(
             std::bind_front(handleFanGet, std::ref(app)));
+
+    BMCWEB_ROUTE(app, "/redfish/v1/Chassis/<str>/ThermalSubsystem/Fans/<str>/")
+        .privileges(redfish::privileges::patchFan)
+        .methods(boost::beast::http::verb::patch)(
+            std::bind_front(handleFanPatch, std::ref(app)));
 }
 
 } // namespace redfish


### PR DESCRIPTION
Rebase of [PR 819](https://github.com/ibm-openbmc/bmcweb/pull/819). That PR had two commits. The "Enable Redfish New Powersubsystem Thermalsubsystem" commit has merged upstream and is already part of 1120. So this PR only includes the "Fan LocationIndicatorActive" commit.

Upstream commit: https://gerrit.openbmc.org/c/openbmc/bmcweb/+/42210

Tested using upstream flash image on hardware simulator. Redfish validator was run. Lots of unrelated errors, but the checks for LocationIndicatorActive passed.
 
Implement LocationIndicatorActive for Fan schema to set/get the status of the location LED for each Fan. When working with Redfish to get or set the "Location Indicator Active" property, the initial step involves locating the corresponding LED group through the "identifying" association. Following this, we can proceed to either get or set the "Asserted" property.

Tested by: Validator passes
1.Set the "LocationIndicatorActive" property to true curl -k -H "X-Auth-Token: $token" -X GET
https://${bmc}/redfish/v1/Chassis/chassis/ThermalSubsystem/Fans/ fan2
{
  "@odata.id": "/redfish/v1/Chassis/chassis/ThermalSubsystem/Fans/
                fan2/",
  "@odata.type": "#Fan.v1_3_0.Fan",
  "Id": "fan2",
  "LocationIndicatorActive": false,
 ...
}

curl -k -H "X-Auth-Token: $token" -X PATCH -d
'{ "LocationIndicatorActive":true}' https://${bmc}/redfish/v1/ Chassis/chassis/ThermalSubsystem/Fans/fan2

curl -k -H "X-Auth-Token: $token" -X GET
https://${bmc}/redfish/v1/Chassis/chassis/ThermalSubsystem/Fans/ fan2
{
  "@odata.id": "/redfish/v1/Chassis/chassis/ThermalSubsystem/Fans/
                fan2/",
  "@odata.type": "#Fan.v1_3_0.Fan",
  "Id": "fan2",
  "LocationIndicatorActive": true,
 ...
}

2.Set the "LocationIndicatorActive" property to false curl -k -H "X-Auth-Token: $token" -X GET
https://${bmc}/redfish/v1/Chassis/chassis/ThermalSubsystem/Fans/fan2 {
  "@odata.id": "/redfish/v1/Chassis/chassis/ThermalSubsystem/Fans/
                fan2/",
  "@odata.type": "#Fan.v1_3_0.Fan",
  "Id": "fan2",
  "LocationIndicatorActive": true,
 ...
}

curl -k -H "X-Auth-Token: $token" -X PATCH -d
'{ "LocationIndicatorActive":false}'
https://${bmc}/redfish/v1/Chassis/chassis/ThermalSubsystem/Fans/fan2

curl -k -H "X-Auth-Token: $token" -X GET
https://${bmc}/redfish/v1/Chassis/chassis/ThermalSubsystem/Fans/fan2 {
  "@odata.id": "/redfish/v1/Chassis/chassis/ThermalSubsystem/Fans/
                fan2/",
  "@odata.type": "#Fan.v1_3_0.Fan",
  "Id": "fan2",
  "LocationIndicatorActive": false,
 ...
}

Change-Id: Ib9a96e016d062529d655f03ed11241ebf004051b