### PR TITLE
Redfish.md: Changes to redfish documentation

### DIFF
--- a/Redfish.md
+++ b/Redfish.md
@@ -545,6 +545,22 @@ Fields common to all schemas
 - Status
 - UUID
 
+### /redfish/v1/Managers/bmc/DedicatedNetworkPorts/
+
+#### PortCollection
+
+- Description
+- Members
+- `Members@odata.count`
+
+### /redfish/v1/Managers/bmc/DedicatedNetworkPorts/{DedicatedNetworkPortId}
+
+#### DedicatedNetworkPort
+
+- Ethernet
+- Id
+- Links/EthernetInterfaces
+
 ### /redfish/v1/Managers/bmc/EthernetInterfaces/
 
 #### EthernetInterfaceCollection
@@ -570,6 +586,7 @@ Fields common to all schemas
 - IPv6DefaultGateway
 - IPv6StaticAddresses
 - InterfaceEnabled
+- Links/Ports
 - Links/RelatedInterfaces
 - LinkStatus
 - MACAddress


### PR DESCRIPTION
This commit will add redfish shema details on dedicated network port to
the redfish.md file
This was missed in below commit
https://github.com/ibm-openbmc/bmcweb/pull/1121

Upstream commit https://gerrit.openbmc.org/c/openbmc/bmcweb/+/76569