### PR TITLE
Add PowerWatts for EnvironmentMetrics (#956)

### DIFF
--- a/Redfish.md
+++ b/Redfish.md
@@ -268,6 +268,9 @@ Fields common to all schemas
 
 #### EnvironmentMetrics
 
+- PowerWatts/DataSourceUri
+- PowerWatts/Reading
+
 ### /redfish/v1/Chassis/{ChassisId}/Power/
 
 #### Power

--- a/redfish-core/include/utils/sensor_utils.hpp
+++ b/redfish-core/include/utils/sensor_utils.hpp
@@ -41,6 +41,7 @@ namespace sensor_utils
 
 enum class ChassisSubNode
 {
+    environmentMetricsNode,
     powerNode,
     sensorsNode,
     thermalNode,
@@ -52,6 +53,8 @@ constexpr std::string_view chassisSubNodeToString(ChassisSubNode subNode)
 {
     switch (subNode)
     {
+        case ChassisSubNode::environmentMetricsNode:
+            return "EnvironmentMetrics";
         case ChassisSubNode::powerNode:
             return "Power";
         case ChassisSubNode::sensorsNode:
@@ -71,7 +74,11 @@ inline ChassisSubNode chassisSubNodeFromString(const std::string& subNodeStr)
     // If none match unknownNode is returned
     ChassisSubNode subNode = ChassisSubNode::unknownNode;
 
-    if (subNodeStr == "Power")
+    if (subNodeStr == "EnvironmentMetrics")
+    {
+        subNode = ChassisSubNode::environmentMetricsNode;
+    }
+    else if (subNodeStr == "Power")
     {
         subNode = ChassisSubNode::powerNode;
     }
@@ -93,7 +100,8 @@ inline ChassisSubNode chassisSubNodeFromString(const std::string& subNodeStr)
 
 inline bool isExcerptNode(const ChassisSubNode subNode)
 {
-    return (subNode == ChassisSubNode::thermalMetricsNode);
+    return ((subNode == ChassisSubNode::thermalMetricsNode) ||
+            (subNode == ChassisSubNode::environmentMetricsNode));
 }
 
 /**

--- a/redfish-core/lib/environment_metrics.hpp
+++ b/redfish-core/lib/environment_metrics.hpp
@@ -4,24 +4,138 @@
 
 #include "app.hpp"
 #include "async_resp.hpp"
+#include "dbus_singleton.hpp"
+#include "dbus_utility.hpp"
 #include "error_messages.hpp"
 #include "http_request.hpp"
+#include "logging.hpp"
 #include "query.hpp"
 #include "registries/privilege_registry.hpp"
 #include "utils/chassis_utils.hpp"
+#include "utils/sensor_utils.hpp"
+
+#include <asm-generic/errno.h>
 
 #include <boost/beast/http/field.hpp>
 #include <boost/beast/http/verb.hpp>
 #include <boost/url/format.hpp>
+#include <nlohmann/json.hpp>
+#include <sdbusplus/asio/property.hpp>
 
+#include <array>
 #include <functional>
 #include <memory>
 #include <optional>
 #include <string>
+#include <string_view>
 #include <utility>
+#include <vector>
 
 namespace redfish
 {
+
+inline void afterGetPowerWatts(
+    const std::shared_ptr<bmcweb::AsyncResp>& asyncResp,
+    const std::string& chassisId, const std::string& path,
+    const boost::system::error_code& ec,
+    const dbus::utility::DBusPropertiesMap& valuesDict)
+{
+    if (ec)
+    {
+        if (ec.value() != EBADR)
+        {
+            BMCWEB_LOG_ERROR("DBUS response error for PowerWatts {}", ec);
+            messages::internalError(asyncResp->res);
+        }
+        return;
+    }
+
+    nlohmann::json item = nlohmann::json::object();
+
+    /* Don't return an error for a failure to fill in properties from the
+     * single sensor. Just skip adding it.
+     */
+    if (sensor_utils::objectExcerptToJson(
+            path, chassisId,
+            sensor_utils::ChassisSubNode::environmentMetricsNode, "power",
+            valuesDict, item))
+    {
+        asyncResp->res.jsonValue["PowerWatts"] = std::move(item);
+    }
+}
+
+inline void handleTotalPowerSensor(
+    const std::shared_ptr<bmcweb::AsyncResp>& asyncResp,
+    const std::string& chassisId, const std::string& sensorPath,
+    const std::string& serviceName, const boost::system::error_code& ec,
+    const std::vector<std::string>& purposeList)
+{
+    BMCWEB_LOG_DEBUG("handleTotalPowerSensor: {}", sensorPath);
+    if (ec)
+    {
+        if (ec.value() != EBADR)
+        {
+            BMCWEB_LOG_ERROR("D-Bus response error for {} Sensor.Purpose: {}",
+                             sensorPath, ec);
+            messages::internalError(asyncResp->res);
+        }
+        return;
+    }
+
+    for (const std::string& purposeStr : purposeList)
+    {
+        if (purposeStr ==
+            "xyz.openbmc_project.Sensor.Purpose.SensorPurpose.TotalPower")
+        {
+            sdbusplus::asio::getAllProperties(
+                *crow::connections::systemBus, serviceName, sensorPath,
+                "xyz.openbmc_project.Sensor.Value",
+                [asyncResp, chassisId, sensorPath](
+                    const boost::system::error_code& ec1,
+                    const dbus::utility::DBusPropertiesMap& propertiesList) {
+                    afterGetPowerWatts(asyncResp, chassisId, sensorPath, ec1,
+                                       propertiesList);
+                });
+            return;
+        }
+    }
+}
+
+inline void getTotalPowerSensor(
+    const std::shared_ptr<bmcweb::AsyncResp>& asyncResp,
+    const std::string& chassisId, const boost::system::error_code& ec,
+    const sensor_utils::SensorServicePathList& sensorsServiceAndPath)
+{
+    if (ec)
+    {
+        if (ec.value() != EBADR)
+        {
+            BMCWEB_LOG_ERROR("DBUS response error {}", ec);
+            messages::internalError(asyncResp->res);
+        }
+        return;
+    }
+
+    for (const auto& [serviceName, sensorPath] : sensorsServiceAndPath)
+    {
+        dbus::utility::getProperty<std::vector<std::string>>(
+            serviceName, sensorPath, "xyz.openbmc_project.Sensor.Purpose",
+            "Purpose",
+            std::bind_front(handleTotalPowerSensor, asyncResp, chassisId,
+                            sensorPath, serviceName));
+    }
+}
+
+inline void getPowerWatts(const std::shared_ptr<bmcweb::AsyncResp>& asyncResp,
+                          const std::string& validChassisPath,
+                          const std::string& chassisId)
+{
+    constexpr std::array<std::string_view, 1> interfaces = {
+        "xyz.openbmc_project.Sensor.Purpose"};
+    sensor_utils::getAllSensorObjects(
+        validChassisPath, "/xyz/openbmc_project/sensors/power", interfaces, 1,
+        std::bind_front(getTotalPowerSensor, asyncResp, chassisId));
+}
 
 inline void handleEnvironmentMetricsHead(
     App& app, const crow::Request& req,
@@ -50,6 +164,30 @@ inline void handleEnvironmentMetricsHead(
                                                 std::move(respHandler));
 }
 
+inline void doEnvironmentMetricsGet(
+    const std::shared_ptr<bmcweb::AsyncResp>& asyncResp,
+    const std::string& chassisId,
+    const std::optional<std::string>& validChassisPath)
+{
+    if (!validChassisPath)
+    {
+        messages::resourceNotFound(asyncResp->res, "Chassis", chassisId);
+        return;
+    }
+
+    asyncResp->res.addHeader(
+        boost::beast::http::field::link,
+        "</redfish/v1/JsonSchemas/EnvironmentMetrics/EnvironmentMetrics.json>; rel=describedby");
+    asyncResp->res.jsonValue["@odata.type"] =
+        "#EnvironmentMetrics.v1_3_0.EnvironmentMetrics";
+    asyncResp->res.jsonValue["Name"] = "Chassis Environment Metrics";
+    asyncResp->res.jsonValue["Id"] = "EnvironmentMetrics";
+    asyncResp->res.jsonValue["@odata.id"] = boost::urls::format(
+        "/redfish/v1/Chassis/{}/EnvironmentMetrics", chassisId);
+
+    getPowerWatts(asyncResp, *validChassisPath, chassisId);
+}
+
 inline void handleEnvironmentMetricsGet(
     App& app, const crow::Request& req,
     const std::shared_ptr<bmcweb::AsyncResp>& asyncResp,
@@ -60,27 +198,9 @@ inline void handleEnvironmentMetricsGet(
         return;
     }
 
-    auto respHandler = [asyncResp, chassisId](
-                           const std::optional<std::string>& validChassisPath) {
-        if (!validChassisPath)
-        {
-            messages::resourceNotFound(asyncResp->res, "Chassis", chassisId);
-            return;
-        }
-
-        asyncResp->res.addHeader(
-            boost::beast::http::field::link,
-            "</redfish/v1/JsonSchemas/EnvironmentMetrics/EnvironmentMetrics.json>; rel=describedby");
-        asyncResp->res.jsonValue["@odata.type"] =
-            "#EnvironmentMetrics.v1_3_0.EnvironmentMetrics";
-        asyncResp->res.jsonValue["Name"] = "Chassis Environment Metrics";
-        asyncResp->res.jsonValue["Id"] = "EnvironmentMetrics";
-        asyncResp->res.jsonValue["@odata.id"] = boost::urls::format(
-            "/redfish/v1/Chassis/{}/EnvironmentMetrics", chassisId);
-    };
-
-    redfish::chassis_utils::getValidChassisPath(asyncResp, chassisId,
-                                                std::move(respHandler));
+    redfish::chassis_utils::getValidChassisPath(
+        asyncResp, chassisId,
+        std::bind_front(doEnvironmentMetricsGet, asyncResp, chassisId));
 }
 
 inline void requestRoutesEnvironmentMetrics(App& app)


### PR DESCRIPTION
Rebase of [PR 956](https://github.com/ibm-openbmc/bmcweb/pull/956). Using cherry-pick of upstream commit https://gerrit.openbmc.org/c/openbmc/bmcweb/+/57717 since it is close to merging upstream and uses new PDI interface.

Tested using upstream flash image on hardware simulator. Redfish validator was run. Lots of unrelated errors, but the checks for PowerWatts passed.

The EnvironmentMetrics schema[1] provides for efficient retrieval of environmental metrics by separating them from performance metrics. EnvironmentMetrics is a property of the Chassis schema since v1_15_0[2]. EnvironmentMetrics was added to Redfish release 2021.2 [3] to be used instead of the deprecated Power schema.[4]

This commit adds PowerWatts property of the EnvironmentMetrics schema. PowerWatts has been part of the EnvironmentMetrics schema since v1_1_0. PowerWatts is a SensorPowerExcerpt[5].

Implementation notes: The new D-Bus interface
"xyz.openbmc_project.Sensor.Purpose" is used to find the sensor with the "TotalPower" purpose.[6][7] The existing getAllSensorObjects() function is used to find the power sensors associated to the chassis through "all_sensors" which implement this interface. The
sensor_utils::objectExcerptToJson() utility function is then used to fill the JSON object from the sensor with the "TotalPower" purpose.

If no sensor has the "TotalPower" purpose then PowerWatts is not added to EnvironmentMetrics and no error is returned.

[1] https://redfish.dmtf.org/schemas/v1/EnvironmentMetrics.v1_3_2.json
[2] https://redfish.dmtf.org/schemas/v1/Chassis.v1_25_2.json
[3] http://redfish.dmtf.org/schemas/Redfish_Release_History.pdf
[4] https://redfish.dmtf.org/schemas/v1/Power.v1_7_3.json
[5] http://redfish.dmtf.org/schemas/v1/Sensor.v1_9_1.json#/definitions/SensorPowerExcerpt
[6] https://gerrit.openbmc.org/c/openbmc/phosphor-dbus-interfaces/+/75943
[7] https://gerrit.openbmc.org/c/openbmc/openpower-occ-control/+/77408

Tested:
 - Redfish Service Validator passes (confirmed PowerWatts tested)
```
VERBOSE1 - ServiceRoot -> Chassis -> Members#4 -> EnvironmentMetrics, EnvironmentMetrics.v1_3_0, EnvironmentMetrics
VERBOSE1 - @odata.id                                               PASS
VERBOSE1 - @odata.type                                             PASS
VERBOSE1 - Id                                                      PASS
VERBOSE1 - Name                                                    PASS
VERBOSE1 - PowerWatts                                              PASS
```
 - No "TotalPower" sensor exists (system never powered on). PowerWatts is not shown and no error is returned.
```
curl -k -H "X-Auth-Token: $token" https://${bmc}/redfish/v1/Chassis/chassis/EnvironmentMetrics
{
  "@odata.id": "/redfish/v1/Chassis/chassis/EnvironmentMetrics",
  "@odata.type": "#EnvironmentMetrics.v1_3_0.EnvironmentMetrics",
  "Id": "EnvironmentMetrics",
  "Name": "Chassis Environment Metrics"
}
```

 - "TotalPower" sensor exists (system powered on)
```
curl -k -H "X-Auth-Token: $token" https://${bmc}/redfish/v1/Systems/system | grep PowerState
  "PowerState": "On",

curl -k -H "X-Auth-Token: $token" https://${bmc}/redfish/v1/Chassis/chassis/EnvironmentMetrics
{
  "@odata.id": "/redfish/v1/Chassis/chassis/EnvironmentMetrics",
  "@odata.type": "#EnvironmentMetrics.v1_3_0.EnvironmentMetrics",
  "Id": "EnvironmentMetrics",
  "Name": "Chassis Environment Metrics",
  "PowerWatts": {
    "DataSourceUri": "/redfish/v1/Chassis/chassis/Sensors/power_total_power",
    "Reading": 191.0
  }
}
```
   DataSourceUri is a valid sensor:
```
curl -k -H "X-Auth-Token: $token" https://${bmc}/redfish/v1/Chassis/chassis/Sensors/power_total_power
{
  "@odata.id": "/redfish/v1/Chassis/chassis/Sensors/power_total_power",
  "@odata.type": "#Sensor.v1_2_0.Sensor",
  "Id": "power_total_power",
  "Name": "total power",
  "Reading": 191.0,
  "ReadingType": "Power",
  "ReadingUnits": "W",
  "Status": {
    "Health": "OK",
    "State": "Enabled"
  }
}
```

 - "TotalPower" sensor exists but null value (system powered off)
```
curl -k -H "X-Auth-Token: $token" https://${bmc}/redfish/v1/Systems/system | grep PowerState
  "PowerState": "Off",

curl -k -H "X-Auth-Token: $token" https://${bmc}/redfish/v1/Chassis/chassis/EnvironmentMetrics
{
  "@odata.id": "/redfish/v1/Chassis/chassis/EnvironmentMetrics",
  "@odata.type": "#EnvironmentMetrics.v1_3_0.EnvironmentMetrics",
  "Id": "EnvironmentMetrics",
  "Name": "Chassis Environment Metrics",
  "PowerWatts": {
    "DataSourceUri": "/redfish/v1/Chassis/chassis/Sensors/power_total_power",
    "Reading": null
  }
}
```

And again the DataSourceUri points to a valid sensor:
```
curl -k -H "X-Auth-Token: $token" https://${bmc}/redfish/v1/Chassis/chassis/Sensors/power_total_power
{
  "@odata.id": "/redfish/v1/Chassis/chassis/Sensors/power_total_power",
  "@odata.type": "#Sensor.v1_2_0.Sensor",
  "Id": "power_total_power",
  "Name": "total power",
  "Reading": null,
  "ReadingType": "Power",
  "ReadingUnits": "W",
  "Status": {
    "Health": "OK",
    "State": "Enabled"
  }
}
```

 - Invalid chassis id ("TotalPower" sensor exists)
```
curl -k -H "X-Auth-Token: $token" https://${bmc}/redfish/v1/Chassis/chassisBAD/EnvironmentMetrics
{
  "error": {
    "@Message.ExtendedInfo": [
      {
        "@odata.type": "#Message.v1_1_1.Message",
        "Message": "The requested resource of type Chassis named 'chassisBAD' was not found.",
        "MessageArgs": [
          "Chassis",
          "chassisBAD"
        ],
        "MessageId": "Base.1.19.ResourceNotFound",
        "MessageSeverity": "Critical",
        "Resolution": "Provide a valid resource identifier and resubmit the request."
      }
    ],
    "code": "Base.1.19.ResourceNotFound",
    "message": "The requested resource of type Chassis named 'chassisBAD' was not found."
  }
}
```



Change-Id: Ibe84a5e7fe0d2b232f925e457a094c021ca85d36