### PR TITLE
1120: Move to OpenSSH (#1136)

### DIFF
--- a/redfish-core/lib/network_protocol.hpp
+++ b/redfish-core/lib/network_protocol.hpp
@@ -48,7 +48,7 @@ namespace redfish
 void getNTPProtocolEnabled(const std::shared_ptr<bmcweb::AsyncResp>& asyncResp);
 std::string getHostName();
 
-static constexpr std::string_view sshServiceName = "dropbear";
+static constexpr std::string_view sshServiceName = "sshd";
 static constexpr std::string_view httpsServiceName = "bmcweb";
 static constexpr std::string_view ipmiServiceName = "phosphor-ipmi-net";
 


### PR DESCRIPTION
#### Move to OpenSSH (#1136)
```
This changes support for URI /redfish/v1/Managers/bmc/NetworkProtocol
property SSH.Enabled.  The implementation is currently hardcoded to
support the "dropbear" SSH service.  This commit changes it to "sshd"
which is the OpenSSH service.

This builds okay, but this function requires an accompanying change
in the service config manager.

The community is exploring the right way to adapt to whichever SSH
server is being used.

Tested:
Yes, together with the srvcfg-manager change.
curl -k -H "X-Auth-Token: $TOKEN" -H "Content-Type: application/json" \
-X PATCH https://${bmc}/redfish/v1/Managers/bmc/NetworkProtocol \
-d'{"SSH": {"ProtocolEnabled": true}}'

Change-Id: If680f62f9cdc88f83e9bb4ad995947be9ceba0b6

Signed-off-by: Joseph Reynolds <joseph.reynolds1@ibm.com>```