### PR TITLE
1120: Implement PCIeSlots LocationIndicatorActive (#811)

### DIFF
--- a/Redfish.md
+++ b/Redfish.md
@@ -286,6 +286,7 @@ Fields common to all schemas
 
 - HotPluggable
 - Lanes
+- LocationIndicatorActive
 - PCIeType
 - SlotType
 


### PR DESCRIPTION
This implements LocationIndicatorActive for PCIeSlot schema for getting and setting location led of each pcie slot - specified in
- https://redfish.dmtf.org/schemas/v1/PCIeSlots.v1_4_1.json

Tested: Validator passes.
1. Get LocationIndicatorActive

```
curl -k -H "X-Auth-Token: $token" -X GET https://${bmc}/redfish/v1/Chassis/chassis/PCIeSlots
{
  "@odata.id": "/redfish/v1/Chassis/chassis/PCIeSlots",
  "@odata.type": "#PCIeSlots.v1_4_1.PCIeSlots",
  "Id": "PCIeSlots",
  "Name": "PCIe Slot Information",
  "Slots": [
    {
      "HotPluggable": false,
      "Lanes": 16,
      "LocationIndicatorActive": false,
      "PCIeType": "Gen1",
      "SlotType": "FullLength"
    },
    {
      "HotPluggable": false,
      "Lanes": 16,
      "LocationIndicatorActive": false,
      "PCIeType": "Gen1",
      "SlotType": "FullLength"
    }
  ]
}
```

2、Set LocationIndicatorActive to true
```
curl -k -H "X-Auth-Token: $token" -X PATCH -d '{"Slots":[{"LocationIndicatorActive":true},{"LocationIndicatorActive":true}]}' \
     https://${bmc}/redfish/v1/Chassis/chassis/PCIeSlots
```

Then we will see the slot location LED lit up, and the LocationIndicatorActive value becomes true:

```
curl -k -H "X-Auth-Token: $token" -X GET https://${bmc}/redfish/v1/Chassis/chassis/PCIeSlots
{
  "@odata.id": "/redfish/v1/Chassis/chassis/PCIeSlots",
  "@odata.type": "#PCIeSlots.v1_4_1.PCIeSlots",
  "Id": "PCIeSlots",
  "Name": "PCIe Slot Information",
  "Slots": [
    {
      "HotPluggable": false,
      "Lanes": 16,
      "LocationIndicatorActive": true,
      "PCIeType": "Gen1",
      "SlotType": "FullLength"
    },
    {
      "HotPluggable": false,
      "Lanes": 16,
      "LocationIndicatorActive": true,
      "PCIeType": "Gen1",
      "SlotType": "FullLength"
    }
  ]
}
```

3、Set the LocationIndicatorActive of all the slots in the do patch command, even if you only want to modify one of them

for example:
Now LocationIndicatorActive of both slots is false:

```
curl -k -H "X-Auth-Token: $token" -X GET https://${bmc}/redfish/v1/Chassis/chassis/PCIeSlots
{
  "@odata.id": "/redfish/v1/Chassis/chassis/PCIeSlots",
  "@odata.type": "#PCIeSlots.v1_4_1.PCIeSlots",
  "Id": "PCIeSlots",
  "Name": "PCIe Slot Information",
  "Slots": [
    {
      "HotPluggable": false,
      "Lanes": 16,
      "LocationIndicatorActive": false,
      "PCIeType": "Gen1",
      "SlotType": "FullLength"
    },
    {
      "HotPluggable": false,
      "Lanes": 16,
      "LocationIndicatorActive": false,
      "PCIeType": "Gen1",
      "SlotType": "FullLength"
    }
  ]
}
```

To patch the second slot to be true, all of slots will be needed to set:

```
curl -k -H "X-Auth-Token: $token" -X PATCH -d '{"Slots":[{"LocationIndicatorActive":false},{"LocationIndicatorActive":true}]}' \
        https://${bmc}/redfish/v1/Chassis/chassis/PCIeSlots
```
This command contains the value of the first slot.

```
curl -k -H "X-Auth-Token: $token" -X GET https://${bmc}/redfish/v1/Chassis/chassis/PCIeSlots
{
  "@odata.id": "/redfish/v1/Chassis/chassis/PCIeSlots",
  "@odata.type": "#PCIeSlots.v1_4_1.PCIeSlots",
  "Id": "PCIeSlots",
  "Name": "PCIe Slot Information",
  "Slots": [
    {
      "HotPluggable": false,
      "Lanes": 16,
      "LocationIndicatorActive": false,
      "PCIeType": "Gen1",
      "SlotType": "FullLength"
    },
    {
      "HotPluggable": false,
      "Lanes": 16,
      "LocationIndicatorActive": true,
      "PCIeType": "Gen1",
      "SlotType": "FullLength"
    }
  ]
}
```


3.
For PATCH, in case the number of slots does not match with the number
of the number of input patch elements, it may give WARNING but it will
still continue to work only with the matching ones.

For example, even if the number of pcie slots is larger than 3, the
first and third elements can be modified without passing all of the
slots like
```
curl -k -H "Content-Type: application/json" -X PATCH https://${bmc}/redfish/v1/Chassis/chassis/PCIeSlots \
     -d '{"Slots":[ {"LocationIndicatorActive": true}, {}, {"LocationIndicatorActive": true}]}'
```

Change-Id: Ib1c3ffb57dd251d6a71acc958a63a9b51941f4c6

Tested:
 - Redfish Validator performed
 - GET PCIeSlots and compare it with the existing output.
 - PATCH PCIeSlots and verify the correctness (e.g. number of input slots, and the content)
