### PR TITLE
1120: Add OemServiceRoot schema (#886)

### DIFF
--- a/redfish-core/lib/service_root.hpp
+++ b/redfish-core/lib/service_root.hpp
@@ -7,22 +7,139 @@
 
 #include "app.hpp"
 #include "async_resp.hpp"
+#include "dbus_utility.hpp"
 #include "http_request.hpp"
 #include "persistent_data.hpp"
 #include "query.hpp"
 #include "registries/privilege_registry.hpp"
+#include "utils/dbus_utils.hpp"
+#include "utils/systemd_utils.hpp"
 
 #include <boost/beast/http/field.hpp>
 #include <boost/beast/http/verb.hpp>
 #include <boost/url/format.hpp>
 #include <nlohmann/json.hpp>
+#include <persistent_data.hpp>
+#include <query.hpp>
+#include <registries/privilege_registry.hpp>
+#include <sdbusplus/asio/property.hpp>
+#include <sdbusplus/unpack_properties.hpp>
+#include <utils/systemd_utils.hpp>
+#include <utils/time_utils.hpp>
 
+#include <array>
 #include <functional>
 #include <memory>
+#include <ranges>
 #include <string>
+#include <string_view>
 
 namespace redfish
 {
+
+inline void fillServiceRootOemProperties(
+    const std::shared_ptr<bmcweb::AsyncResp>& asyncResp,
+    const boost::system::error_code& ec,
+    const dbus::utility::DBusPropertiesMap& propertiesList)
+{
+    if (ec)
+    {
+        // doesn't have to include this
+        // interface
+        return;
+    }
+    BMCWEB_LOG_DEBUG("Got {} properties for system", propertiesList.size());
+
+    const std::string* serialNumber = nullptr;
+    const std::string* model = nullptr;
+
+    const bool success = sdbusplus::unpackPropertiesNoThrow(
+        dbus_utils::UnpackErrorPrinter(), propertiesList, "SerialNumber",
+        serialNumber, "Model", model);
+
+    if (!success)
+    {
+        messages::internalError(asyncResp->res);
+        return;
+    }
+
+    if (serialNumber != nullptr)
+    {
+        asyncResp->res.jsonValue["Oem"]["IBM"]["SerialNumber"] = *serialNumber;
+    }
+
+    if (model != nullptr)
+    {
+        asyncResp->res.jsonValue["Oem"]["IBM"]["Model"] = *model;
+    }
+}
+
+inline void afterHandleServiceRootOem(
+    const std::shared_ptr<bmcweb::AsyncResp>& asyncResp,
+    const boost::system::error_code& ec,
+    const dbus::utility::MapperGetSubTreeResponse& subtree)
+{
+    if (ec)
+    {
+        BMCWEB_LOG_ERROR("DBUS response error {}", ec.value());
+        messages::internalError(asyncResp->res);
+        return;
+    }
+    // Iterate over all retrieved ObjectPaths.
+    for (const auto& object : subtree)
+    {
+        const std::string& path = object.first;
+        BMCWEB_LOG_DEBUG("Got path: {}", path);
+        const std::vector<std::pair<std::string, std::vector<std::string>>>&
+            connectionNames = object.second;
+        if (connectionNames.empty())
+        {
+            continue;
+        }
+
+        for (const auto& connection : connectionNames)
+        {
+            auto iter = std::ranges::find(
+                connection.second, "xyz.openbmc_project.Inventory.Item.System");
+            if (iter == connection.second.end())
+            {
+                continue;
+            }
+
+            sdbusplus::asio::getAllProperties(
+                *crow::connections::systemBus, connection.first, path,
+                "xyz.openbmc_project.Inventory.Decorator.Asset",
+                [asyncResp](
+                    const boost::system::error_code& ec2,
+                    const dbus::utility::DBusPropertiesMap& propertiesList) {
+                    fillServiceRootOemProperties(asyncResp, ec2,
+                                                 propertiesList);
+                });
+        }
+    }
+}
+
+inline void handleServiceRootOem(
+    const std::shared_ptr<bmcweb::AsyncResp>& asyncResp)
+{
+    constexpr std::array<std::string_view, 1> interfaces = {
+        "xyz.openbmc_project.Inventory.Decorator.Asset"};
+
+    dbus::utility::getSubTree(
+        "/xyz/openbmc_project/inventory", 0, interfaces,
+        std::bind_front(afterHandleServiceRootOem, asyncResp));
+
+    std::pair<std::string, std::string> redfishDateTimeOffset =
+        redfish::time_utils::getDateTimeOffsetNow();
+
+    asyncResp->res.jsonValue["Oem"]["IBM"]["DateTime"] =
+        redfishDateTimeOffset.first;
+    asyncResp->res.jsonValue["Oem"]["IBM"]["DateTimeLocalOffset"] =
+        redfishDateTimeOffset.second;
+
+    asyncResp->res.jsonValue["Oem"]["IBM"]["@odata.type"] =
+        "#IBMServiceRoot.v1_0_0.IBM";
+}
 
 inline void handleServiceRootHead(
     App& app, const crow::Request& req,
@@ -119,6 +236,7 @@ inline void handleServiceRootGet(
     }
 
     handleServiceRootGetImpl(asyncResp);
+    handleServiceRootOem(asyncResp);
 }
 
 inline void requestRoutesServiceRoot(App& app)

--- a/redfish-core/schema/oem/ibm/csdl/IBMServiceRoot_v1.xml
+++ b/redfish-core/schema/oem/ibm/csdl/IBMServiceRoot_v1.xml
@@ -1,0 +1,59 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<edmx:Edmx xmlns:edmx="http://docs.oasis-open.org/odata/ns/edmx" Version="4.0">
+  <edmx:Reference Uri="http://docs.oasis-open.org/odata/odata/v4.0/errata03/csd01/complete/vocabularies/Org.OData.Core.V1.xml">
+    <edmx:Include Namespace="Org.OData.Core.V1" Alias="OData"/>
+  </edmx:Reference>
+  <edmx:Reference Uri="http://docs.oasis-open.org/odata/odata/v4.0/errata03/csd01/complete/vocabularies/Org.OData.Measures.V1.xml">
+    <edmx:Include Namespace="Org.OData.Measures.V1" Alias="Measures"/>
+  </edmx:Reference>
+  <edmx:Reference Uri="http://redfish.dmtf.org/schemas/v1/RedfishExtensions_v1.xml">
+    <edmx:Include Namespace="RedfishExtensions.v1_0_0" Alias="Redfish"/>
+  </edmx:Reference>
+  <edmx:Reference Uri="http://redfish.dmtf.org/schemas/v1/ServiceRoot_v1.xml">
+    <edmx:Include Namespace="ServiceRoot"/>
+    <edmx:Include Namespace="ServiceRoot.v1_12_0"/>
+  </edmx:Reference>
+  <edmx:Reference Uri="http://redfish.dmtf.org/schemas/v1/Resource_v1.xml">
+    <edmx:Include Namespace="Resource"/>
+    <edmx:Include Namespace="Resource.v1_0_0"/>
+  </edmx:Reference>
+  <edmx:DataServices>
+    <Schema xmlns="http://docs.oasis-open.org/odata/ns/edm" Namespace="IBMServiceRoot">
+      <Annotation Term="Redfish.OwningEntity" String="IBM"/>
+    </Schema>
+    <Schema xmlns="http://docs.oasis-open.org/odata/ns/edm" Namespace="IBMServiceRoot.v1_0_0">
+      <Annotation Term="Redfish.OwningEntity" String="IBM"/>
+      <ComplexType Name="Oem" BaseType="Resource.OemObject">
+        <Annotation Term="OData.AdditionalProperties" Bool="true"/>
+        <Annotation Term="OData.Description" String="IBMServiceRoot Oem properties."/>
+        <Annotation Term="OData.AutoExpand"/>
+        <Property Name="IBM" Type="IBMServiceRoot.v1_0_0.IBM"/>
+      </ComplexType>
+      <ComplexType Name="IBM" BaseType="Resource.OemObject">
+        <Annotation Term="OData.AdditionalProperties" Bool="true"/>
+        <Annotation Term="OData.Description" String="Oem properties for IBM."/>
+        <Annotation Term="OData.AutoExpand"/>
+        <Property Name="Model" Type="Edm.String">
+          <Annotation Term="OData.Permissions" EnumMember="OData.Permission/Read"/>
+          <Annotation Term="OData.Description" String="The product name for this system, without the manufacturer name."/>
+          <Annotation Term="OData.LongDescription" String="This property shall describe how the manufacturer refers to this system.  Typically, this value is the product name for this system without the manufacturer name."/>
+        </Property>
+        <Property Name="SerialNumber" Type="Edm.String">
+          <Annotation Term="OData.Permissions" EnumMember="OData.Permission/Read"/>
+          <Annotation Term="OData.Description" String="The serial number for this system."/>
+          <Annotation Term="OData.LongDescription" String="This property shall contain the serial number for the system."/>
+        </Property>
+        <Property Name="DateTime" Type="Edm.DateTimeOffset">
+          <Annotation Term="OData.Permissions" EnumMember="OData.Permission/ReadWrite"/>
+          <Annotation Term="OData.Description" String="The current date and time with UTC offset of the manager."/>
+          <Annotation Term="OData.LongDescription" String="This property shall contain the current date and time with UTC offset of the manager."/>
+        </Property>
+        <Property Name="DateTimeLocalOffset" Type="Edm.String">
+          <Annotation Term="OData.Permissions" EnumMember="OData.Permission/ReadWrite"/>
+          <Annotation Term="OData.Description" String="The time offset from UTC that the DateTime property is in `+HH:MM` format."/>
+          <Annotation Term="OData.LongDescription" String="This property shall contain the offset from UTC time that the DateTime property contains.  If both DateTime and DateTimeLocalOffset are provided in modification requests, services shall apply DateTimeLocalOffset after DateTime is applied."/>
+        </Property>
+      </ComplexType>
+    </Schema>
+  </edmx:DataServices>
+</edmx:Edmx>

--- a/redfish-core/schema/oem/ibm/json-schema/IBMServiceRoot.json
+++ b/redfish-core/schema/oem/ibm/json-schema/IBMServiceRoot.json
@@ -1,0 +1,8 @@
+{
+    "$id": "https://github.com/ibm-openbmc/bmcweb/tree/HEAD/redfish-core/schema/oem/ibm/json-schema/IBMServiceRoot.json",
+    "$schema": "http://redfish.dmtf.org/schemas/v1/redfish-schema-v1.json",
+    "copyright": "Copyright 2025 OpenBMC.",
+    "definitions": {},
+    "owningEntity": "IBM",
+    "title": "#IBMServiceRoot"
+}

--- a/redfish-core/schema/oem/ibm/json-schema/IBMServiceRoot.v1_0_0.json
+++ b/redfish-core/schema/oem/ibm/json-schema/IBMServiceRoot.v1_0_0.json
@@ -1,0 +1,80 @@
+{
+    "$id": "http://redfish.dmtf.org/schemas/v1/IBMServiceRoot.json",
+    "$schema": "http://redfish.dmtf.org/schemas/v1/redfish-schema-v1.json",
+    "copyright": "Copyright 2025 OpenBMC.",
+    "definitions": {
+        "Oem": {
+            "additionalProperties": true,
+            "description": "IBMServiceRoot Oem properties.",
+            "patternProperties": {
+                "^([a-zA-Z_][a-zA-Z0-9_]*)?@(odata|Redfish|Message)\\.[a-zA-Z_][a-zA-Z0-9_]*$": {
+                    "description": "This property shall specify a valid odata or Redfish property.",
+                    "type": ["string", "null"]
+                }
+            },
+            "properties": {
+                "IBM": {
+                    "anyOf": [
+                        {
+                            "$ref": "#/definitions/IBM"
+                        },
+                        {
+                            "type": "null"
+                        }
+                    ]
+                }
+            },
+            "type": "object"
+        },
+        "IBM": {
+            "additionalProperties": true,
+            "description": "Oem properties for IBM.",
+            "patternProperties": {
+                "^([a-zA-Z_][a-zA-Z0-9_]*)?@(odata|Redfish|Message)\\.[a-zA-Z_][a-zA-Z0-9_]*$": {
+                    "description": "This property shall specify a valid odata or Redfish property.",
+                    "type": [
+                        "array",
+                        "boolean",
+                        "integer",
+                        "number",
+                        "null",
+                        "object",
+                        "string"
+                    ]
+                }
+            },
+            "properties": {
+                "Model": {
+                    "description": "The product name for this system, without the manufacturer name.",
+                    "longDescription": "This property shall describe how the manufacturer refers to this system.  Typically, this value is the product name for this system without the manufacturer name.",
+                    "readonly": true,
+                    "type": ["string", "null"]
+                },
+                "SerialNumber": {
+                    "description": "The serial number for this system.",
+                    "longDescription": "This property shall contain the serial number for the system.",
+                    "readonly": true,
+                    "type": ["string", "null"]
+                },
+                "DateTime": {
+                    "description": "The current date and time with UTC offset of the manager.",
+                    "format": "date-time",
+                    "longDescription": "This property shall contain the current date and time with UTC offset of the manager.",
+                    "readonly": false,
+                    "type": ["string", "null"]
+                },
+                "DateTimeLocalOffset": {
+                    "description": "The time offset from UTC that the DateTime property is in `+HH:MM` format.",
+                    "longDescription": "This property shall contain the offset from UTC time that the DateTime property contains.  If both DateTime and DateTimeLocalOffset are provided in modification requests, services shall apply DateTimeLocalOffset after DateTime is applied.",
+                    "pattern": "^([-+][0-1][0-9]:[0-5][0-9])$",
+                    "readonly": false,
+                    "type": ["string", "null"]
+                }
+            },
+            "type": "object"
+        }
+    },
+    "owningEntity": "IBM",
+    "release": "1.0",
+    "title": "#IBMServiceRoot.v1_0_0"
+}

--- a/redfish-core/schema/oem/ibm/meson.build
+++ b/redfish-core/schema/oem/ibm/meson.build
@@ -1,5 +1,10 @@
 # IBM schemas that should be installed
-schemas = ['IBMFabricAdapter', 'IBMManagerAccount', 'IBMPCIeSlots']
+schemas = [
+    'IBMFabricAdapter',
+    'IBMManagerAccount',
+    'IBMPCIeSlots',
+    'IBMServiceRoot',
+]
 
 foreach schema : schemas
     install_data(


### PR DESCRIPTION
This commit adds additional properties to IBM Oem ServiceRoot.

Testing:
1) redfish validator passes
2) curl command

```
curl -k -X GET https://${bmc}:18080/redfish/v1
  "Oem": {
    "@odata.type": "#IBMServiceRoot.IBM",
    "IBM": {
      "@odata.type": "#IBMServiceRoot.IBM",
      "DateTime": "2025-03-04T16:28:21+00:00",
      "DateTimeLocalOffset": "+00:00",
      "Model": "9105-22A",
      "SerialNumber": "139EF60"
    }
  },
```
