### PR TITLE
1120: Up the code update timeout to 50 secs

### DIFF
--- a/redfish-core/lib/update_service.hpp
+++ b/redfish-core/lib/update_service.hpp
@@ -447,7 +447,7 @@ inline void afterUpdateErrorMatcher(
 inline void monitorForSoftwareAvailable(
     const std::shared_ptr<bmcweb::AsyncResp>& asyncResp,
     const crow::Request& req, const std::string& url,
-    int timeoutTimeSeconds = 25)
+    int timeoutTimeSeconds = 50)
 {
     // Only allow one FW update at a time
     if (fwUpdateInProgress)


### PR DESCRIPTION
As seen in DVT with defect 661124, have cases where this times out. This timer includes both the time to write the image to /tmp/images/ as well as the time for the code update app to untar the image and create a D-Bus object.

https://gerrit.openbmc.org/c/openbmc/bmcweb/+/78644 is upstream 