### PR TITLE
1120: PCIe Topology: Redfish: Reset Link (#588)

### DIFF
--- a/redfish-core/lib/pcie.hpp
+++ b/redfish-core/lib/pcie.hpp
@@ -36,11 +36,13 @@
 #include <limits>
 #include <memory>
 #include <optional>
+#include <ranges>
 #include <string>
 #include <string_view>
 #include <system_error>
 #include <utility>
 #include <variant>
+#include <vector>
 
 namespace redfish
 {
@@ -225,6 +227,36 @@ inline void addPCIeSlotProperties(
     }
 }
 
+inline void addPCIeSlotLinkResetProperties(
+    const std::shared_ptr<bmcweb::AsyncResp>& asyncResp,
+    const boost::system::error_code& ec,
+    const dbus::utility::DBusPropertiesMap& pcieSlotProperties)
+{
+    if (ec)
+    {
+        BMCWEB_LOG_ERROR("DBUS response error for getAllProperties {}",
+                         ec.value());
+        messages::internalError(asyncResp->res);
+        return;
+    }
+
+    std::optional<bool> linkReset;
+    bool success = sdbusplus::unpackPropertiesNoThrow(
+        dbus_utils::UnpackErrorPrinter(), pcieSlotProperties, "linkReset",
+        linkReset);
+    if (!success)
+    {
+        messages::internalError(asyncResp->res);
+        return;
+    }
+    if (linkReset)
+    {
+        asyncResp->res.jsonValue["Oem"]["IBM"]["LinkReset"] = *linkReset;
+        asyncResp->res.jsonValue["Oem"]["IBM"]["@odata.type"] =
+            "#IBMPCIeDevice.v1_0_0.IBM";
+    }
+}
+
 inline void getPCIeDeviceSlotPath(
     const std::string& pcieDevicePath,
     const std::shared_ptr<bmcweb::AsyncResp>& asyncResp,
@@ -289,6 +321,25 @@ inline void afterGetDbusObject(
             const dbus::utility::DBusPropertiesMap& pcieSlotProperties) {
             addPCIeSlotProperties(asyncResp->res, ec2, pcieSlotProperties);
         });
+
+    for (const auto& [serviceName, interfaces] : object)
+    {
+        auto iter =
+            std::ranges::find(interfaces, "com.ibm.Control.Host.PCIeLink");
+        if (iter != interfaces.end())
+        {
+            sdbusplus::asio::getAllProperties(
+                *crow::connections::systemBus, serviceName, pcieDeviceSlot,
+                "com.ibm.Control.Host.PCIeLink",
+                [asyncResp](const boost::system::error_code& ec2,
+                            const dbus::utility::DBusPropertiesMap&
+                                pcieSlotProperties) {
+                    addPCIeSlotLinkResetProperties(asyncResp, ec2,
+                                                   pcieSlotProperties);
+                });
+            break;
+        }
+    }
 }
 
 inline void afterGetPCIeDeviceSlotPath(
@@ -605,12 +656,126 @@ inline void handlePCIeDeviceGet(
         std::bind_front(afterGetValidPcieDevicePath, asyncResp, pcieDeviceId));
 }
 
+/**
+ * @brief Set linkReset property
+ *
+ * @param[in, out]  asyncResp       Async HTTP response.
+ * @param[in]       pcieSlotPath    PCIe slot path.
+ * @param[in]       serviceMap      A map to hold Service and corresponding
+ * interface list for the given cable id.
+ * @param[in]       linkReset       Flag to reset.
+ */
+inline void handleLinkReset(const std::shared_ptr<bmcweb::AsyncResp>& asyncResp,
+                            const std::string& pcieSlotPath,
+                            const dbus::utility::MapperServiceMap& serviceMap,
+                            const bool linkReset)
+{
+    for (const auto& [service, interfaces] : serviceMap)
+    {
+        for (const auto& interface : interfaces)
+        {
+            if (interface != "com.ibm.Control.Host.PCIeLink")
+            {
+                continue;
+            }
+
+            sdbusplus::asio::setProperty(
+                *crow::connections::systemBus, service, pcieSlotPath, interface,
+                "linkReset", linkReset,
+                [asyncResp, linkReset](const boost::system::error_code& ec) {
+                    if (ec)
+                    {
+                        BMCWEB_LOG_ERROR("D-Bus responses error: {}",
+                                         ec.value());
+                        messages::internalError(asyncResp->res);
+                        return;
+                    }
+                    BMCWEB_LOG_DEBUG("linkReset property set to: {}",
+                                     (linkReset ? "true" : "false"));
+                    return;
+                });
+        }
+    }
+}
+
+inline void afterHandlePCIeDevicePatch(
+    const std::shared_ptr<bmcweb::AsyncResp>& asyncResp, bool linkReset,
+    const std::string& pcieDevicePath, const std::string& /*service*/)
+{
+    getPCIeDeviceSlotPath(
+        pcieDevicePath, asyncResp,
+        [asyncResp, pcieDevicePath,
+         linkReset](const std::string& pcieDeviceSlot) {
+            dbus::utility::getDbusObject(
+                pcieDeviceSlot, pcieSlotInterface,
+                [asyncResp, pcieDeviceSlot,
+                 linkReset](const boost::system::error_code& ec,
+                            const dbus::utility::MapperGetObject& object) {
+                    if (ec)
+                    {
+                        BMCWEB_LOG_ERROR(
+                            "DBUS response ec={} for getAllProperties",
+                            ec.value());
+                        messages::internalError(asyncResp->res);
+                        return;
+                    }
+                    handleLinkReset(asyncResp, pcieDeviceSlot, object,
+                                    linkReset);
+                });
+        });
+}
+
+inline void handlePCIeDevicePatch(
+    App& app, const crow::Request& req,
+    const std::shared_ptr<bmcweb::AsyncResp>& asyncResp,
+    const std::string& systemName, const std::string& pcieDeviceId)
+{
+    if (!redfish::setUpRedfishRoute(app, req, asyncResp))
+    {
+        return;
+    }
+    if constexpr (BMCWEB_EXPERIMENTAL_REDFISH_MULTI_COMPUTER_SYSTEM)
+    {
+        // Option currently returns no systems.  TBD
+        messages::resourceNotFound(asyncResp->res, "ComputerSystem",
+                                   systemName);
+        return;
+    }
+    if (systemName != BMCWEB_REDFISH_SYSTEM_URI_NAME)
+    {
+        messages::resourceNotFound(asyncResp->res, "ComputerSystem",
+                                   systemName);
+        return;
+    }
+
+    std::optional<bool> linkReset;
+    if (!json_util::readJsonPatch(req, asyncResp->res, "Oem/IBM/LinkReset",
+                                  linkReset))
+    {
+        return;
+    }
+    if (!linkReset)
+    {
+        messages::propertyMissing(asyncResp->res, "LinkReset");
+        return;
+    }
+
+    getValidPCIeDevicePath(
+        pcieDeviceId, asyncResp,
+        std::bind_front(afterHandlePCIeDevicePatch, asyncResp, *linkReset));
+}
+
 inline void requestRoutesSystemPCIeDevice(App& app)
 {
     BMCWEB_ROUTE(app, "/redfish/v1/Systems/<str>/PCIeDevices/<str>/")
         .privileges(redfish::privileges::getPCIeDevice)
         .methods(boost::beast::http::verb::get)(
             std::bind_front(handlePCIeDeviceGet, std::ref(app)));
+
+    BMCWEB_ROUTE(app, "/redfish/v1/Systems/<str>/PCIeDevices/<str>/")
+        .privileges(redfish::privileges::patchPCIeDevice)
+        .methods(boost::beast::http::verb::patch)(
+            std::bind_front(handlePCIeDevicePatch, std::ref(app)));
 }
 
 inline void addPCIeFunctionList(

--- a/redfish-core/schema/oem/ibm/csdl/IBMPCIeDevice_v1.xml
+++ b/redfish-core/schema/oem/ibm/csdl/IBMPCIeDevice_v1.xml
@@ -1,0 +1,44 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<edmx:Edmx xmlns:edmx="http://docs.oasis-open.org/odata/ns/edmx" Version="4.0">
+  <edmx:Reference Uri="http://docs.oasis-open.org/odata/odata/v4.0/errata03/csd01/complete/vocabularies/Org.OData.Core.V1.xml">
+    <edmx:Include Namespace="Org.OData.Core.V1" Alias="OData"/>
+  </edmx:Reference>
+  <edmx:Reference Uri="http://docs.oasis-open.org/odata/odata/v4.0/errata03/csd01/complete/vocabularies/Org.OData.Measures.V1.xml">
+    <edmx:Include Namespace="Org.OData.Measures.V1" Alias="Measures"/>
+  </edmx:Reference>
+  <edmx:Reference Uri="http://redfish.dmtf.org/schemas/v1/RedfishExtensions_v1.xml">
+    <edmx:Include Namespace="RedfishExtensions.v1_0_0" Alias="Redfish"/>
+  </edmx:Reference>
+  <edmx:Reference Uri="http://redfish.dmtf.org/schemas/v1/PCIeDevice_v1.xml">
+    <edmx:Include Namespace="PCIeDevice"/>
+    <edmx:Include Namespace="PCIeDevice.v1_9_0"/>
+  </edmx:Reference>
+  <edmx:Reference Uri="http://redfish.dmtf.org/schemas/v1/Resource_v1.xml">
+    <edmx:Include Namespace="Resource"/>
+    <edmx:Include Namespace="Resource.v1_0_0"/>
+  </edmx:Reference>
+  <edmx:DataServices>
+    <Schema xmlns="http://docs.oasis-open.org/odata/ns/edm" Namespace="IBMPCIeDevice">
+      <Annotation Term="Redfish.OwningEntity" String="IBM"/>
+    </Schema>
+    <Schema xmlns="http://docs.oasis-open.org/odata/ns/edm" Namespace="IBMPCIeDevice.v1_0_0">
+      <Annotation Term="Redfish.OwningEntity" String="IBM"/>
+      <ComplexType Name="Oem" BaseType="Resource.OemObject">
+        <Annotation Term="OData.AdditionalProperties" Bool="true"/>
+        <Annotation Term="OData.Description" String="IBMPCIeDevice Oem properties."/>
+        <Annotation Term="OData.AutoExpand"/>
+        <Property Name="IBM" Type="IBMPCIeDevice.v1_0_0.IBM"/>
+      </ComplexType>
+      <ComplexType Name="IBM" BaseType="Resource.OemObject">
+        <Annotation Term="OData.AdditionalProperties" Bool="true"/>
+        <Annotation Term="OData.Description" String="Oem properties for IBM."/>
+        <Annotation Term="OData.AutoExpand"/>
+        <Property Name="LinkReset" Type="Edm.Boolean">
+          <Annotation Term="OData.Permissions" EnumMember="OData.Permission/ReadWrite"/>
+          <Annotation Term="OData.Description" String="Reset the PCIe Link"/>
+          <Annotation Term="OData.LongDescription" String="A true value resets the PCIe Link."/>
+        </Property>
+      </ComplexType>
+    </Schema>
+  </edmx:DataServices>
+</edmx:Edmx>

--- a/redfish-core/schema/oem/ibm/json-schema/IBMPCIeDevice.json
+++ b/redfish-core/schema/oem/ibm/json-schema/IBMPCIeDevice.json
@@ -1,0 +1,8 @@
+{
+    "$id": "https://github.com/ibm-openbmc/bmcweb/tree/HEAD/redfish-core/schema/oem/ibm/json-schema/IBMPCIeDevice.json",
+    "$schema": "http://redfish.dmtf.org/schemas/v1/redfish-schema-v1.json",
+    "copyright": "Copyright 2025 OpenBMC.",
+    "definitions": {},
+    "owningEntity": "IBM",
+    "title": "#IBMPCIeDevice"
+}

--- a/redfish-core/schema/oem/ibm/json-schema/IBMPCIeDevice.v1_0_0.json
+++ b/redfish-core/schema/oem/ibm/json-schema/IBMPCIeDevice.v1_0_0.json
@@ -1,0 +1,68 @@
+{
+    "$id": "http://redfish.dmtf.org/schemas/v1/IBMPCIeDevice.json",
+    "$schema": "http://redfish.dmtf.org/schemas/v1/redfish-schema-v1.json",
+    "Copyright": "Copyright 2025 OpenBMC.",
+    "definitions": {
+        "Oem": {
+            "additionalProperties": true,
+            "description": "IBMPCIeDevice Oem properties.",
+            "patternProperties": {
+                "^([a-zA-Z_][a-zA-Z0-9_]*)?@(odata|Redfish|Message)\\.[a-zA-Z_][a-zA-Z0-9_]*$": {
+                    "description": "This property shall specify a valid odata or Redfish property.",
+                    "type": [
+                        "array",
+                        "boolean",
+                        "integer",
+                        "number",
+                        "null",
+                        "object",
+                        "string"
+                    ]
+                }
+            },
+            "properties": {
+                "IBM": {
+                    "anyOf": [
+                        {
+                            "$ref": "#/definitions/IBM"
+                        },
+                        {
+                            "type": "null"
+                        }
+                    ]
+                }
+            },
+            "type": "object"
+        },
+        "IBM": {
+            "additionalProperties": true,
+            "description": "IBMPCIeDevice Oem properties for IBM.",
+            "patternProperties": {
+                "^([a-zA-Z_][a-zA-Z0-9_]*)?@(odata|Redfish|Message)\\.[a-zA-Z_][a-zA-Z0-9_]*$": {
+                    "description": "This property shall specify a valid odata or Redfish property.",
+                    "type": [
+                        "array",
+                        "boolean",
+                        "integer",
+                        "number",
+                        "null",
+                        "object",
+                        "string"
+                    ]
+                }
+            },
+            "properties": {
+                "LinkReset": {
+                    "description": "Reset the PCIe Link",
+                    "longDescription": "A true value resets the PCIe Link.",
+                    "readonly": false,
+                    "type": "boolean"
+                }
+            },
+            "type": "object"
+        }
+    },
+    "owningEntity": "IBM",
+    "release": "1.0",
+    "title": "#IBMPCIeDevice.v1_0_0"
+}

--- a/redfish-core/schema/oem/ibm/meson.build
+++ b/redfish-core/schema/oem/ibm/meson.build
@@ -2,6 +2,7 @@
 schemas = [
     'IBMFabricAdapter',
     'IBMManagerAccount',
+    'IBMPCIeDevice',
     'IBMPCIeSlots',
     'IBMServiceRoot',
 ]


### PR DESCRIPTION
This commit sets linkReset property to the requested value.

This is downstream change only

Issue:
https://github.com/ibm-openbmc/dev/issues/3551

Redfish Validator: test passed

Testing:

- Set LinkReset to 'true' via PATCH, and verify the property on GET.

```
$ curl -k -H "Content-Type: application/json" -X PATCH \
 https://${bmc}/redfish/v1/Systems/system/PCIeDevices/pcie_card1 \
  -d '{"Oem": {"IBM": {"LinkReset": true}}}'
```

```
$ curl -k -X GET \
  https://${bmc}/redfish/v1/Systems/system/PCIeDevices/pcie_card1
{
  "@odata.id": "/redfish/v1/Systems/system/PCIeDevices/pcie_card1",
  "@odata.type": "#PCIeDevice.v1_9_0.PCIeDevice",
  "Id": "pcie_card1",
  "Manufacturer": "",
  "Name": "PCIe Device",
  "Oem": {
    "IBM": {
      "@odata.type": "#IBMPCIeDevice.v1_0_0.IBM",
      "LinkReset": true
    }
  },
...
}
```