### PR TITLE
1120: Remove Inventory.Item.Board interface from Chassis (#845)

### DIFF
--- a/redfish-core/include/utils/chassis_utils.hpp
+++ b/redfish-core/include/utils/chassis_utils.hpp
@@ -26,6 +26,9 @@
 namespace redfish
 {
 
+static constexpr std::array<std::string_view, 1> chassisInterfaces = {
+    "xyz.openbmc_project.Inventory.Item.Chassis"};
+
 static constexpr std::array<std::string_view, 9> chassisAssemblyInterfaces = {
     "xyz.openbmc_project.Inventory.Item.Vrm",
     "xyz.openbmc_project.Inventory.Item.Tpm",
@@ -49,13 +52,10 @@ void getValidChassisPath(const std::shared_ptr<bmcweb::AsyncResp>& asyncResp,
                          const std::string& chassisId, Callback&& callback)
 {
     BMCWEB_LOG_DEBUG("checkChassisId enter");
-    constexpr std::array<std::string_view, 2> interfaces = {
-        "xyz.openbmc_project.Inventory.Item.Board",
-        "xyz.openbmc_project.Inventory.Item.Chassis"};
 
     // Get the Chassis Collection
     dbus::utility::getSubTreePaths(
-        "/xyz/openbmc_project/inventory", 0, interfaces,
+        "/xyz/openbmc_project/inventory", 0, chassisInterfaces,
         [callback = std::forward<Callback>(callback), asyncResp,
          chassisId](const boost::system::error_code& ec,
                     const dbus::utility::MapperGetSubTreePathsResponse&

--- a/redfish-core/lib/cable.hpp
+++ b/redfish-core/lib/cable.hpp
@@ -435,10 +435,6 @@ inline void getCableAssociatedChassis(
     sdbusplus::message::object_path endpointPath{cableObjectPath};
     endpointPath /= associationName;
 
-    constexpr std::array<std::string_view, 2> chassisInterfaces = {
-        "xyz.openbmc_project.Inventory.Item.Board",
-        "xyz.openbmc_project.Inventory.Item.Chassis"};
-
     dbus::utility::getAssociatedSubTreePaths(
         endpointPath,
         sdbusplus::message::object_path("/xyz/openbmc_project/inventory"), 0,

--- a/redfish-core/lib/chassis.hpp
+++ b/redfish-core/lib/chassis.hpp
@@ -18,6 +18,7 @@
 #include "logging.hpp"
 #include "query.hpp"
 #include "registries/privilege_registry.hpp"
+#include "utils/chassis_utils.hpp"
 #include "utils/collection.hpp"
 #include "utils/dbus_utils.hpp"
 #include "utils/json_utils.hpp"
@@ -254,11 +255,8 @@ inline void handleChassisCollectionGet(
     asyncResp->res.jsonValue["@odata.id"] = "/redfish/v1/Chassis";
     asyncResp->res.jsonValue["Name"] = "Chassis Collection";
 
-    constexpr std::array<std::string_view, 2> interfaces{
-        "xyz.openbmc_project.Inventory.Item.Board",
-        "xyz.openbmc_project.Inventory.Item.Chassis"};
     collection_util::getCollectionMembers(
-        asyncResp, boost::urls::url("/redfish/v1/Chassis"), interfaces,
+        asyncResp, boost::urls::url("/redfish/v1/Chassis"), chassisInterfaces,
         "/xyz/openbmc_project/inventory");
 }
 
@@ -627,12 +625,9 @@ inline void handleChassisGet(
     {
         return;
     }
-    constexpr std::array<std::string_view, 2> interfaces = {
-        "xyz.openbmc_project.Inventory.Item.Board",
-        "xyz.openbmc_project.Inventory.Item.Chassis"};
 
     dbus::utility::getSubTree(
-        "/xyz/openbmc_project/inventory", 0, interfaces,
+        "/xyz/openbmc_project/inventory", 0, chassisInterfaces,
         std::bind_front(handleChassisGetSubTree, asyncResp, chassisId));
 
     constexpr std::array<std::string_view, 1> interfaces2 = {
@@ -681,14 +676,10 @@ inline void handleChassisPatch(
             "299 - \"IndicatorLED is deprecated. Use LocationIndicatorActive instead.\"");
     }
 
-    constexpr std::array<std::string_view, 2> interfaces = {
-        "xyz.openbmc_project.Inventory.Item.Board",
-        "xyz.openbmc_project.Inventory.Item.Chassis"};
-
     const std::string& chassisId = param;
 
     dbus::utility::getSubTree(
-        "/xyz/openbmc_project/inventory", 0, interfaces,
+        "/xyz/openbmc_project/inventory", 0, chassisInterfaces,
         [asyncResp, chassisId, locationIndicatorActive,
          indicatorLed](const boost::system::error_code& ec,
                        const dbus::utility::MapperGetSubTreeResponse& subtree) {

--- a/redfish-core/lib/fabric_adapters.hpp
+++ b/redfish-core/lib/fabric_adapters.hpp
@@ -14,6 +14,7 @@
 #include "logging.hpp"
 #include "query.hpp"
 #include "registries/privilege_registry.hpp"
+#include "utils/chassis_utils.hpp"
 #include "utils/collection.hpp"
 #include "utils/dbus_utils.hpp"
 #include "utils/json_utils.hpp"
@@ -241,12 +242,10 @@ inline void doCheckFabricAdapterChassis(
                        const dbus::utility::MapperEndPoints&)>
         callback)
 {
-    constexpr std::array<std::string_view, 1> chassisInterface{
-        "xyz.openbmc_project.Inventory.Item.Chassis"};
     dbus::utility::getAssociatedSubTreePaths(
         fabricAdapterPath + "/chassis",
         sdbusplus::message::object_path("/xyz/openbmc_project/inventory"), 0,
-        chassisInterface,
+        chassisInterfaces,
         std::bind_front(afterDoCheckFabricAdapterChassis, asyncResp,
                         pcieSlotPaths, std::move(callback)));
 }

--- a/redfish-core/lib/pcie.hpp
+++ b/redfish-core/lib/pcie.hpp
@@ -18,6 +18,7 @@
 #include "logging.hpp"
 #include "query.hpp"
 #include "registries/privilege_registry.hpp"
+#include "utils/chassis_utils.hpp"
 #include "utils/dbus_utils.hpp"
 #include "utils/json_utils.hpp"
 #include "utils/pcie_util.hpp"
@@ -201,9 +202,6 @@ inline void addLinkToPCIeSlot(
     const std::shared_ptr<bmcweb::AsyncResp>& asyncResp,
     const std::string& pcieDeviceSlot)
 {
-    constexpr std::array<std::string_view, 1> chassisInterfaces = {
-        "xyz.openbmc_project.Inventory.Item.Chassis"};
-
     dbus::utility::getAssociatedSubTreePaths(
         pcieDeviceSlot + "/contained_by",
         sdbusplus::message::object_path("/xyz/openbmc_project/inventory"), 0,

--- a/redfish-core/lib/power.hpp
+++ b/redfish-core/lib/power.hpp
@@ -24,7 +24,6 @@
 #include <nlohmann/json.hpp>
 #include <sdbusplus/message/native_types.hpp>
 
-#include <array>
 #include <cmath>
 #include <cstddef>
 #include <cstdint>
@@ -286,12 +285,8 @@ inline void handleChassisPowerGet(
     // This prevents things like power supplies providing the
     // chassis power limit
 
-    constexpr std::array<std::string_view, 2> interfaces = {
-        "xyz.openbmc_project.Inventory.Item.Board",
-        "xyz.openbmc_project.Inventory.Item.Chassis"};
-
     dbus::utility::getSubTreePaths(
-        "/xyz/openbmc_project/inventory", 0, interfaces,
+        "/xyz/openbmc_project/inventory", 0, chassisInterfaces,
         std::bind_front(afterGetChassis, sensorAsyncResp));
 }
 

--- a/redfish-core/lib/power_supply.hpp
+++ b/redfish-core/lib/power_supply.hpp
@@ -132,13 +132,10 @@ inline void handlePowerSupplyCollectionGet(
         return;
     }
 
-    constexpr std::array<std::string_view, 2> chasisInterfaces = {
-        "xyz.openbmc_project.Inventory.Item.Board",
-        "xyz.openbmc_project.Inventory.Item.Chassis"};
     const std::string reqpath = "/xyz/openbmc_project/inventory";
 
     dbus::utility::getAssociatedSubTreePathsById(
-        chassisId, reqpath, chasisInterfaces, "powered_by",
+        chassisId, reqpath, chassisInterfaces, "powered_by",
         powerSupplyInterface,
         [asyncResp, chassisId](
             const boost::system::error_code& ec,
@@ -196,13 +193,10 @@ inline void getValidPowerSupplyPath(
     std::function<void(const std::string& powerSupplyPath,
                        const std::string& service)>&& callback)
 {
-    constexpr std::array<std::string_view, 2> chasisInterfaces = {
-        "xyz.openbmc_project.Inventory.Item.Board",
-        "xyz.openbmc_project.Inventory.Item.Chassis"};
     const std::string reqpath = "/xyz/openbmc_project/inventory";
 
     dbus::utility::getAssociatedSubTreeById(
-        chassisId, reqpath, chasisInterfaces, "powered_by",
+        chassisId, reqpath, chassisInterfaces, "powered_by",
         powerSupplyInterface,
         [asyncResp, chassisId, powerSupplyId, callback{std::move(callback)}](
             const boost::system::error_code& ec,

--- a/redfish-core/lib/redfish_util.hpp
+++ b/redfish-core/lib/redfish_util.hpp
@@ -8,13 +8,13 @@
 #include "dbus_utility.hpp"
 #include "error_messages.hpp"
 #include "logging.hpp"
+#include "utils/chassis_utils.hpp"
 
 #include <boost/system/errc.hpp>
 #include <boost/system/error_code.hpp>
 #include <sdbusplus/message/native_types.hpp>
 
 #include <algorithm>
-#include <array>
 #include <charconv>
 #include <cstddef>
 #include <cstdint>
@@ -64,11 +64,8 @@ void getMainChassisId(const std::shared_ptr<bmcweb::AsyncResp>& asyncResp,
                       CallbackFunc&& callback)
 {
     // Find managed chassis
-    constexpr std::array<std::string_view, 2> interfaces = {
-        "xyz.openbmc_project.Inventory.Item.Board",
-        "xyz.openbmc_project.Inventory.Item.Chassis"};
     dbus::utility::getSubTree(
-        "/xyz/openbmc_project/inventory", 0, interfaces,
+        "/xyz/openbmc_project/inventory", 0, chassisInterfaces,
         [callback = std::forward<CallbackFunc>(callback),
          asyncResp](const boost::system::error_code& ec,
                     const dbus::utility::MapperGetSubTreeResponse& subtree) {

--- a/redfish-core/lib/sensors.hpp
+++ b/redfish-core/lib/sensors.hpp
@@ -17,6 +17,7 @@
 #include "query.hpp"
 #include "registries/privilege_registry.hpp"
 #include "str_utility.hpp"
+#include "utils/chassis_utils.hpp"
 #include "utils/dbus_utils.hpp"
 #include "utils/json_utils.hpp"
 #include "utils/query_param.hpp"
@@ -411,13 +412,10 @@ void getChassis(const std::shared_ptr<bmcweb::AsyncResp>& asyncResp,
                 Callback&& callback)
 {
     BMCWEB_LOG_DEBUG("getChassis enter");
-    constexpr std::array<std::string_view, 2> interfaces = {
-        "xyz.openbmc_project.Inventory.Item.Board",
-        "xyz.openbmc_project.Inventory.Item.Chassis"};
 
     // Get the Chassis Collection
     dbus::utility::getSubTreePaths(
-        "/xyz/openbmc_project/inventory", 0, interfaces,
+        "/xyz/openbmc_project/inventory", 0, chassisInterfaces,
         [callback = std::forward<Callback>(callback), asyncResp,
          chassisIdStr{std::string(chassisId)},
          chassisSubNode{std::string(chassisSubNode)},

--- a/redfish-core/lib/storage.hpp
+++ b/redfish-core/lib/storage.hpp
@@ -18,6 +18,7 @@
 #include "query.hpp"
 #include "redfish_util.hpp"
 #include "registries/privilege_registry.hpp"
+#include "utils/chassis_utils.hpp"
 #include "utils/collection.hpp"
 #include "utils/dbus_utils.hpp"
 
@@ -816,11 +817,8 @@ inline void chassisDriveCollectionGet(
     }
 
     // mapper call lambda
-    constexpr std::array<std::string_view, 2> interfaces = {
-        "xyz.openbmc_project.Inventory.Item.Board",
-        "xyz.openbmc_project.Inventory.Item.Chassis"};
     dbus::utility::getSubTree(
-        "/xyz/openbmc_project/inventory", 0, interfaces,
+        "/xyz/openbmc_project/inventory", 0, chassisInterfaces,
         std::bind_front(afterChassisDriveCollectionSubtreeGet, asyncResp,
                         chassisId));
 }
@@ -915,13 +913,10 @@ inline void handleChassisDriveGet(
     {
         return;
     }
-    constexpr std::array<std::string_view, 2> interfaces = {
-        "xyz.openbmc_project.Inventory.Item.Board",
-        "xyz.openbmc_project.Inventory.Item.Chassis"};
 
     // mapper call chassis
     dbus::utility::getSubTree(
-        "/xyz/openbmc_project/inventory", 0, interfaces,
+        "/xyz/openbmc_project/inventory", 0, chassisInterfaces,
         [asyncResp, chassisId,
          driveName](const boost::system::error_code& ec,
                     const dbus::utility::MapperGetSubTreeResponse& subtree) {


### PR DESCRIPTION
Remove Inventory.Item.Board interface from Chassis (#845)

IBM does not use the xyz.openbmc_project.Inventory.Item.Board interface
for chassis objects. Remove that interfaces so that only objects
implements xyz.openbmc_project.Inventory.Item.Chassis are returned for
`getValidChassisPath()`.

---

Refactor chassisInterfaces into chassis_utils

Some (e.g. IBM) do not use the
`xyz.openbmc_project.Inventory.Item.Board` interface for chassis
objects. To handle the use pattern easier, this refactors the Chassis
interface into one location and it is referenced from the needed places
(e.g. `getValidChassisPath()`).

Tested:
- GET Chassis related API and check they are the same as before
- Redfish Service Validator passes

Change-Id: Id4a51986262892c5dc81b1a3bc46fa5be7c0e9da
