### PR TITLE
WIP: Clear the body after writing to /tmp/images

### DIFF
--- a/http/http_request.hpp
+++ b/http/http_request.hpp
@@ -71,6 +71,11 @@ struct Request
         userRole = "";
     }
 
+    void bodyClear()
+    {
+        req.body().clear();
+    }
+
     boost::beast::http::verb method() const
     {
         return req.method();

--- a/redfish-core/lib/update_service.hpp
+++ b/redfish-core/lib/update_service.hpp
@@ -847,7 +847,7 @@ inline void updateMultipartContext(
 }
 
 inline void handleUpdateServicePost(
-    App& app, const crow::Request& req,
+    App& app, crow::Request req,
     const std::shared_ptr<bmcweb::AsyncResp>& asyncResp, const std::string& url)
 {
     if (!redfish::setUpRedfishRoute(app, req, asyncResp))
@@ -866,6 +866,11 @@ inline void handleUpdateServicePost(
         monitorForSoftwareAvailable(asyncResp, req, url);
 
         uploadImageFile(asyncResp->res, req.body());
+        // The request is going to be open for potentially another ~20 seconds
+        // while the code update app untars the image and creates a interface.
+        // In this time, we can experience high memory usage so clear the body
+        // as soon as we have wrote the image to /tmp/images.
+        req.bodyClear();
     }
     else if (contentType.starts_with("multipart/form-data"))
     {


### PR DESCRIPTION
We are having memory pressure during code update. The image has grown to 200 MB and we have seen a few cases where we run out of memory during code update. Specially the code update image is in memory following writing to /tmp/images, waiting for the tar file to untar and the interface to be created.

This change deletes the body as soon as /tmp/images/ is wrote.