### PR TITLE
Reduce memory usage during Firmware update (#739)

### DIFF
--- a/include/audit_events.hpp
+++ b/include/audit_events.hpp
@@ -215,7 +215,8 @@ inline void auditEvent(const crow::Request& req, const std::string& userName,
     std::string detail;
     if (wantDetail(req))
     {
-        detail = req.body() + " ";
+        detail = req.body().substr(0, maxBuf);
+        detail += " ";
     }
 
     if (!detail.empty())


### PR DESCRIPTION
Cherry-pick and rebase PR https://github.com/ibm-openbmc/bmcweb/pull/739

Tested:
- Verififed detail data for non-update actions properly logged.
- Verified data limit for update caught 
```
[WARNING audit_events.hpp:230] Audit buffer too small for data: bufLeft=215 detailLen=257
[DEBUG audit_events.hpp:268] auditEvent: bufLeft=201  opPathLen=41 detailLen=257 userLen=14
root@p10bmc:/tmp# ausearch -i | grep UpdateService
type=USYS_CONFIG msg=audit(01/22/25 22:17:21.909:34) : pid=1522 uid=root auid=unset ses=unset msg='op=POST:/redfish/v1/UpdateService/update acct=service exe=/tmp/bmcweb hostname=p10bmc addr=10.0.2.1 terminal=? res=success' 
```

bmcweb currently consumes the excessive memory during firmware update. It is due to the replications of the req.body (which is the full content of firmware).

- audit copies the entire req.body before truncating it to the buffer.

Tested:

- Redfish validator passes
- Monitor memory consumption of bmcweb process periodically. e.g., top -b -d 0.5 | grep /usr/bin/bmcweb
- With the fix, the max memory usage should only be increased about the size of the image.