### PR TITLE
Link PCIeSlots to Processor schema

### DIFF
--- a/redfish-core/lib/pcie_slots.hpp
+++ b/redfish-core/lib/pcie_slots.hpp
@@ -186,6 +186,62 @@ inline void getLocationCode(
         });
 }
 
+inline void linkAssociatedProcessor(
+    const std::shared_ptr<bmcweb::AsyncResp>& asyncResp,
+    const std::string& pcieSlotPath, size_t index)
+{
+    constexpr std::array<std::string_view, 1> cpuInterfaces = {
+        "xyz.openbmc_project.Inventory.Item.Cpu"};
+
+    dbus::utility::getAssociatedSubTreePaths(
+        pcieSlotPath + "/connected_to",
+        sdbusplus::message::object_path("/xyz/openbmc_project/inventory"), 0,
+        cpuInterfaces,
+        [asyncResp, pcieSlotPath,
+         index](const boost::system::error_code& ec,
+                const dbus::utility::MapperEndPoints& endpoints) {
+            if (ec)
+            {
+                if (ec.value() == EBADR)
+                {
+                    // This PCIeSlot have no processor association.
+                    BMCWEB_LOG_DEBUG("No processor association found");
+                    return;
+                }
+                BMCWEB_LOG_ERROR("DBUS response error {}", ec.message());
+                messages::internalError(asyncResp->res);
+                return;
+            }
+
+            if (endpoints.empty())
+            {
+                BMCWEB_LOG_DEBUG("No association found for processor");
+                return;
+            }
+
+            std::string cpuName =
+                sdbusplus::message::object_path(endpoints[0]).filename();
+            std::string dcmName =
+                (sdbusplus::message::object_path(endpoints[0]).parent_path())
+                    .filename();
+
+            std::string processorName = dcmName + '-' + cpuName;
+
+            nlohmann::json::object_t item;
+            item["@odata.id"] = boost::urls::format(
+                "/redfish/v1/Systems/system/Processors/{}", processorName);
+
+            nlohmann::json::array_t processorArray = nlohmann::json::array();
+            processorArray.emplace_back(std::move(item));
+
+            asyncResp->res
+                .jsonValue["Slots"][index]["Links"]["Processors@odata.count"] =
+                processorArray.size();
+            asyncResp->res.jsonValue["Slots"][index]["Links"]["Processors"] =
+                std::move(processorArray);
+        });
+}
+
 inline void onPcieSlotGetAllDone(
     const std::shared_ptr<bmcweb::AsyncResp>& asyncResp,
     const boost::system::error_code& ec,
@@ -303,6 +359,9 @@ inline void onPcieSlotGetAllDone(
 
     // Get pcie device link
     addLinkedPcieDevices(asyncResp, pcieSlotPath, index);
+
+    // Get processor link
+    linkAssociatedProcessor(asyncResp, pcieSlotPath, index);
 }
 
 // Get all valid  PCIe Slots which are on the given chassis


### PR DESCRIPTION
This commit populates link(s) to processor associated with a given PCIeSlot. The association is established by fetching mapper endpoints "connected_to" with respect to the given PCIeSlot.

Test:
Ran Validator, no new error.

Sample output:
    {
      "HotPluggable": false,
      "Links": {
        "Processors": [
          {
            "@odata.id": "/redfish/v1/Systems/system/Processors/dcm1-cpu1"
          }
        ],
        "Processors@odata.count": 1
      },
      "LocationIndicatorActive": false,
      "SlotType": "FullLength"
    },