### PR TITLE
Rebase: 1120 Add ibm/v1 route features

### DIFF
--- a/include/ibm/locks.hpp
+++ b/include/ibm/locks.hpp
@@ -1,0 +1,617 @@
+#pragma once
+
+#include "logging.hpp"
+
+#include <boost/container/flat_map.hpp>
+#include <boost/endian/conversion.hpp> // NOLINT
+
+#include <cstdint>
+#include <iterator>
+#include <string>
+#include <tuple>
+#include <utility>
+#include <variant>
+#include <vector>
+
+namespace crow
+{
+namespace ibm_mc_lock
+{
+
+using SType = std::string;
+
+/*----------------------------------------
+|Segment flags : LockFlag | SegmentLength|
+------------------------------------------*/
+
+using SegmentFlags = std::vector<std::pair<SType, uint32_t>>;
+
+// Lockrequest = session-id | hmc-id | locktype | resourceid | segmentinfo
+using LockRequest = std::tuple<SType, SType, SType, uint64_t, SegmentFlags>;
+using LockRequests = std::vector<LockRequest>;
+// Rc is an abbreviation for return code.
+using Rc =
+    std::pair<bool, std::variant<uint32_t, std::pair<uint32_t, LockRequest>>>;
+using RcReleaseLock = std::pair<bool, std::pair<uint32_t, LockRequest>>;
+using RcGetLockList =
+    std::variant<std::string, std::vector<std::pair<uint32_t, LockRequests>>>;
+using ListOfTransactionIds = std::vector<uint32_t>;
+using RcAcquireLock = std::pair<bool, std::variant<Rc, std::pair<bool, int>>>;
+using RcReleaseLockApi = std::pair<bool, std::variant<bool, RcReleaseLock>>;
+using SessionFlags = std::pair<SType, SType>;
+using ListOfSessionIds = std::vector<std::string>;
+
+class Lock
+{
+    uint32_t transactionId = 0;
+    boost::container::flat_map<uint32_t, LockRequests> lockTable;
+
+  protected:
+    /*
+     * This function implements the logic for validating an incoming
+     * lock request/requests.
+     *
+     * Returns : True (if Valid)
+     * Returns : False (if not a Valid lock request)
+     */
+
+    virtual bool isValidLockRequest(const LockRequest& refLockRecord);
+
+    /*
+     * This function implements the logic of checking if the incoming
+     * multi-lock request is not having conflicting requirements.
+     *
+     * Returns : True (if conflicting)
+     * Returns : False (if not conflicting)
+     */
+
+    virtual bool isConflictRequest(const LockRequests& refLockRequestStructure);
+
+    /*
+     * Implements the core algorithm to find the conflicting
+     * lock requests.
+     *
+     * This functions takes two lock requests and check if both
+     * are conflicting to each other.
+     *
+     * Returns : True (if conflicting)
+     * Returns : False (if not conflicting)
+     */
+
+    virtual bool isConflictRecord(const LockRequest& refLockRecord1,
+                                  const LockRequest& refLockRecord2);
+
+    /*
+     * This function implements the logic of checking the conflicting
+     * locks from a incoming single/multi lock requests with the already
+     * existing lock request in the lock table.
+     *
+     */
+
+    virtual Rc isConflictWithTable(const LockRequests& refLockRequestStructure);
+
+    /*
+     * This function implements the logic of checking the ownership of the
+     * lock from the releaselock request.
+     *
+     * Returns : True (if the requesting HMC & Session owns the lock(s))
+     * Returns : False (if the request HMC or Session does not own the lock(s))
+     */
+
+    virtual RcReleaseLock isItMyLock(const ListOfTransactionIds& refRids,
+                                     const SessionFlags& ids);
+
+    /*
+     * This function validates the list of transactionID's and returns false
+     * if the transaction ID is not valid & not present in the lock table
+     */
+
+    virtual bool validateRids(const ListOfTransactionIds& refRids);
+
+    /*
+     * This function releases the locks that are already obtained by the
+     * requesting Management console.
+     */
+
+    void releaseLock(const ListOfTransactionIds& refRids);
+
+    Lock()
+    {
+        transactionId = lockTable.empty() ? 0 : prev(lockTable.end())->first;
+    }
+
+    /*
+     * This function implements the algorithm for checking the respective
+     * bytes of the resource id based on the lock management algorithm.
+     */
+
+    static bool checkByte(uint64_t resourceId1, uint64_t resourceId2,
+                          uint32_t position);
+
+    /*
+     * This functions implements a counter that generates a unique 32 bit
+     * number for every successful transaction. This number will be used by
+     * the Management Console for debug.
+     */
+    virtual uint32_t generateTransactionId();
+
+  public:
+    /*
+     * Explicitly deleted copy and move constructors
+     */
+    Lock(const Lock&) = delete;
+    Lock(Lock&&) = delete;
+    Lock& operator=(const Lock&) = delete;
+    Lock& operator=(Lock&&) = delete;
+
+    /*
+     * This function implements the logic for acquiring a lock on a
+     * resource if the incoming request is legitimate without any
+     * conflicting requirements & without any conflicting requirement
+     * with the existing locks in the lock table.
+     *
+     */
+
+    RcAcquireLock acquireLock(const LockRequests& lockRequestStructure);
+
+    /*
+     * This function implements the logic for releasing the lock that are
+     * owned by a management console session.
+     *
+     * The locks can be released by two ways
+     *  - Using list of transaction ID's
+     *  - Using a Session ID
+     *
+     * Client can choose either of the ways by using `Type` JSON key.
+     *
+     */
+    RcReleaseLockApi releaseLock(const ListOfTransactionIds& p,
+                                 const SessionFlags& ids);
+
+    /*
+     * This function implements the logic for getting the list of locks obtained
+     * by a particular management console.
+     */
+    RcGetLockList getLockList(const ListOfSessionIds& listSessionId);
+
+    /*
+     * This function releases all the locks obtained by a particular
+     * session.
+     */
+
+    void releaseLock(const std::string& sessionId);
+
+    static Lock& getInstance()
+    {
+        static Lock lockObject;
+        return lockObject;
+    }
+
+    virtual ~Lock() = default;
+};
+
+inline RcGetLockList Lock::getLockList(const ListOfSessionIds& listSessionId)
+{
+    std::vector<std::pair<uint32_t, LockRequests>> lockList{};
+
+    if (!lockTable.empty())
+    {
+        for (const auto& i : listSessionId)
+        {
+            auto it = lockTable.begin();
+            while (it != lockTable.end())
+            {
+                // Check if session id of this entry matches with session id
+                // given
+                if (std::get<0>(it->second[0]) == i)
+                {
+                    BMCWEB_LOG_DEBUG("Session id is found in the locktable");
+
+                    // Push the whole lock record into a vector for returning
+                    // the json
+                    lockList.emplace_back(it->first, it->second);
+                }
+                // Go to next entry in map
+                it++;
+            }
+        }
+    }
+
+    // we may have found at least one entry with the given session id
+    // return the list of lock records pertaining to the given
+    // session id, or send an empty list if lock table is empty
+    return {lockList};
+}
+
+inline RcReleaseLockApi Lock::releaseLock(const ListOfTransactionIds& p,
+                                          const SessionFlags& ids)
+{
+    bool status = validateRids(p);
+
+    if (!status)
+    {
+        // Validation of rids failed
+        BMCWEB_LOG_ERROR("releaseLock: Contains invalid request id");
+        return std::make_pair(false, status);
+    }
+    // Validation passed, check if all the locks are owned by the
+    // requesting HMC
+    auto status2 = isItMyLock(p, ids);
+    if (!status2.first)
+    {
+        return std::make_pair(false, status2);
+    }
+    return std::make_pair(true, status2);
+}
+
+inline RcAcquireLock Lock::acquireLock(const LockRequests& lockRequestStructure)
+{
+    // validate the lock request
+
+    for (const auto& lockRecord : lockRequestStructure)
+    {
+        bool status = isValidLockRequest(lockRecord);
+        if (!status)
+        {
+            BMCWEB_LOG_DEBUG("Not a Valid record");
+            BMCWEB_LOG_DEBUG("Bad json in request");
+            return std::make_pair(true, std::make_pair(status, 0));
+        }
+    }
+    // check for conflict record
+
+    const LockRequests& multiRequest = lockRequestStructure;
+    bool status = isConflictRequest(multiRequest);
+
+    if (status)
+    {
+        BMCWEB_LOG_ERROR("There is a conflict within itself");
+        return std::make_pair(true, std::make_pair(status, 1));
+    }
+    BMCWEB_LOG_DEBUG("The request is not conflicting within itself");
+
+    // Need to check for conflict with the locktable entries.
+
+    auto conflict = isConflictWithTable(multiRequest);
+
+    BMCWEB_LOG_DEBUG("Done with checking conflict with the locktable");
+    return std::make_pair(false, conflict);
+}
+
+inline void Lock::releaseLock(const std::string& sessionId)
+{
+    if (!lockTable.empty())
+    {
+        auto it = lockTable.begin();
+        while (it != lockTable.end())
+        {
+            if (!it->second.empty())
+            {
+                // Check if session id of this entry matches with session id
+                // given
+                if (std::get<0>(it->second[0]) == sessionId)
+                {
+                    BMCWEB_LOG_DEBUG(
+                        "Remove the lock from the locktable having sessionID={}",
+                        sessionId);
+                    BMCWEB_LOG_DEBUG("TransactionID ={}", it->first);
+                    it = lockTable.erase(it);
+                }
+                else
+                {
+                    it++;
+                }
+            }
+        }
+    }
+}
+inline RcReleaseLock Lock::isItMyLock(const ListOfTransactionIds& refRids,
+                                      const SessionFlags& ids)
+{
+    for (const auto& id : refRids)
+    {
+        // Just need to compare the client id of the first lock records in the
+        // complete lock row(in the map), because the rest of the lock records
+        // would have the same client id
+
+        std::string expectedClientId = std::get<1>(lockTable[id][0]);
+        std::string expectedSessionId = std::get<0>(lockTable[id][0]);
+
+        if ((expectedClientId == ids.first) &&
+            (expectedSessionId == ids.second))
+        {
+            // It is owned by the currently request hmc
+            BMCWEB_LOG_DEBUG("Lock is owned  by the current hmc");
+            // remove the lock
+            if (lockTable.erase(id) != 0U)
+            {
+                BMCWEB_LOG_DEBUG("Removing the locks with transaction ID : {}",
+                                 id);
+            }
+            else
+            {
+                BMCWEB_LOG_ERROR("Removing the locks from the lock table "
+                                 "failed, transaction ID: {}",
+                                 id);
+            }
+        }
+        else
+        {
+            BMCWEB_LOG_DEBUG("Lock is not owned by the current hmc");
+            return std::make_pair(false, std::make_pair(id, lockTable[id][0]));
+        }
+    }
+    return std::make_pair(true, std::make_pair(0, LockRequest()));
+}
+
+inline bool Lock::validateRids(const ListOfTransactionIds& refRids)
+{
+    for (const auto& id : refRids)
+    {
+        auto search = lockTable.find(id);
+
+        if (search != lockTable.end())
+        {
+            BMCWEB_LOG_DEBUG("Valid Transaction id");
+            //  continue for the next rid
+        }
+        else
+        {
+            BMCWEB_LOG_ERROR("validateRids: At least 1 inValid Request id: {}",
+                             id);
+            return false;
+        }
+    }
+    return true;
+}
+
+inline bool Lock::isValidLockRequest(const LockRequest& refLockRecord)
+{
+    // validate the locktype
+
+    if (!((std::get<2>(refLockRecord) == "Read" ||
+           (std::get<2>(refLockRecord) == "Write"))))
+    {
+        BMCWEB_LOG_DEBUG("Validation of LockType Failed");
+        BMCWEB_LOG_DEBUG("Locktype : {}", std::get<2>(refLockRecord));
+        return false;
+    }
+
+    BMCWEB_LOG_DEBUG("{}", static_cast<int>(std::get<4>(refLockRecord).size()));
+
+    // validate the number of segments
+    // Allowed No of segments are between 2 and 6
+    if ((static_cast<int>(std::get<4>(refLockRecord).size()) > 6) ||
+        (static_cast<int>(std::get<4>(refLockRecord).size()) < 2))
+    {
+        BMCWEB_LOG_DEBUG("Validation of Number of Segments Failed");
+        BMCWEB_LOG_DEBUG("Number of Segments provided : {}",
+                         std::get<4>(refLockRecord).size());
+        return false;
+    }
+
+    int lockFlag = 0;
+    // validate the lockflags & segment length
+
+    for (const auto& p : std::get<4>(refLockRecord))
+    {
+        // validate the lock flags
+        // Allowed lockflags are locksame,lockall & dontlock
+
+        if (!((p.first == "LockSame" || (p.first == "LockAll") ||
+               (p.first == "DontLock"))))
+        {
+            BMCWEB_LOG_DEBUG("Validation of lock flags failed");
+            BMCWEB_LOG_DEBUG("{}", p.first);
+            return false;
+        }
+
+        // validate the segment length
+        // Allowed values of segment length are between 1 and 4
+
+        if (p.second < 1 || p.second > 4)
+        {
+            BMCWEB_LOG_DEBUG("Validation of Segment Length Failed");
+            BMCWEB_LOG_DEBUG("{}", p.second);
+            return false;
+        }
+
+        if ((p.first == "LockSame" || (p.first == "LockAll")))
+        {
+            ++lockFlag;
+            if (lockFlag >= 2)
+            {
+                return false;
+            }
+        }
+    }
+
+    return true;
+}
+
+inline Rc Lock::isConflictWithTable(const LockRequests& refLockRequestStructure)
+{
+    if (lockTable.empty())
+    {
+        uint32_t thisTransactionId = generateTransactionId();
+        BMCWEB_LOG_DEBUG("{}", thisTransactionId);
+        // Lock table is empty, so we are safe to add the lockrecords
+        // as there will be no conflict
+        BMCWEB_LOG_DEBUG("Lock table is empty, so adding the lockrecords");
+        lockTable.emplace(thisTransactionId, refLockRequestStructure);
+
+        return std::make_pair(false, thisTransactionId);
+    }
+    BMCWEB_LOG_DEBUG(
+        "Lock table is not empty, check for conflict with lock table");
+    // Lock table is not empty, compare the lockrequest entries with
+    // the entries in the lock table
+
+    for (const auto& lockRecord1 : refLockRequestStructure)
+    {
+        for (const auto& map : lockTable)
+        {
+            for (const auto& lockRecord2 : map.second)
+            {
+                bool status = isConflictRecord(lockRecord1, lockRecord2);
+                if (status)
+                {
+                    return std::make_pair(
+                        true, std::make_pair(map.first, lockRecord2));
+                }
+            }
+        }
+    }
+
+    // Reached here, so no conflict with the locktable, so we are safe to
+    // add the request records into the lock table
+
+    // Lock table is empty, so we are safe to add the lockrecords
+    // as there will be no conflict
+    BMCWEB_LOG_DEBUG(" Adding elements into lock table");
+    transactionId = generateTransactionId();
+    lockTable.emplace(std::make_pair(transactionId, refLockRequestStructure));
+
+    return std::make_pair(false, transactionId);
+}
+
+inline bool Lock::isConflictRequest(const LockRequests& refLockRequestStructure)
+{
+    // check for all the locks coming in as a part of single request
+    // return conflict if any two lock requests are conflicting
+
+    if (refLockRequestStructure.size() == 1)
+    {
+        BMCWEB_LOG_DEBUG("Only single lock request, so there is no conflict");
+        // This means , we have only one lock request in the current
+        // request , so no conflict within the request
+        return false;
+    }
+
+    BMCWEB_LOG_DEBUG(
+        "There are multiple lock requests coming in a single request");
+
+    // There are multiple requests a part of one request
+
+    for (uint32_t i = 0; i < refLockRequestStructure.size(); i++)
+    {
+        for (uint32_t j = i + 1; j < refLockRequestStructure.size(); j++)
+        {
+            const LockRequest& p = refLockRequestStructure[i];
+            const LockRequest& q = refLockRequestStructure[j];
+            bool status = isConflictRecord(p, q);
+
+            if (status)
+            {
+                return true;
+            }
+        }
+    }
+    return false;
+}
+
+// This function converts the provided uint64_t resource id's from the two
+// lock requests subjected for comparison, and this function also compares
+// the content by bytes mentioned by a uint32_t number.
+
+// If all the elements in the lock requests which are subjected for comparison
+// are same, then the last comparison would be to check for the respective
+// bytes in the resourceid based on the segment length.
+inline bool Lock::checkByte(uint64_t resourceId1, uint64_t resourceId2,
+                            uint32_t position)
+{
+    if (position >= sizeof(resourceId1))
+    {
+        return false;
+    }
+
+    uint8_t pPosition = 0;
+    uint8_t qPosition = 0;
+    pPosition = 0xFF & (resourceId1 >> (8 * position));
+    qPosition = 0xFF & (resourceId2 >> (8 * position));
+
+    return pPosition == qPosition;
+}
+
+inline bool Lock::isConflictRecord(const LockRequest& refLockRecord1,
+                                   const LockRequest& refLockRecord2)
+{
+    // No conflict if both are read locks
+
+    if (std::get<2>(refLockRecord1) == "Read" &&
+        std::get<2>(refLockRecord2) == "Read")
+    {
+        BMCWEB_LOG_DEBUG("Both are read locks, no conflict");
+        return false;
+    }
+
+    uint32_t i = 0;
+    uint32_t segStartIndex = 0;
+    for (const auto& p : std::get<4>(refLockRecord1))
+    {
+        // return conflict when any of them is try to lock all resources
+        // under the current resource level.
+        if (p.first == "LockAll" ||
+            std::get<4>(refLockRecord2)[i].first == "LockAll")
+        {
+            BMCWEB_LOG_DEBUG(
+                "Either of the Comparing locks are trying to lock all "
+                "resources under the current resource level");
+            return true;
+        }
+
+        // determine if there is a lock-all-with-same-segment-size.
+        // If the current segment sizes are the same,then we should fail.
+
+        if ((p.first == "LockSame" ||
+             std::get<4>(refLockRecord2)[i].first == "LockSame") &&
+            (p.second == std::get<4>(refLockRecord2)[i].second))
+        {
+            return true;
+        }
+
+        // if segment lengths are not the same, it means two different locks
+        // So no conflict
+        if (p.second != std::get<4>(refLockRecord2)[i].second)
+        {
+            BMCWEB_LOG_DEBUG("Segment lengths are not same");
+            BMCWEB_LOG_DEBUG("Segment 1 length : {}", p.second);
+            BMCWEB_LOG_DEBUG("Segment 2 length : {}",
+                             std::get<4>(refLockRecord2)[i].second);
+            return false;
+        }
+
+        // compare segment data
+        for (uint32_t segLenItr = 0; segLenItr < p.second; segLenItr++)
+        {
+            for (uint32_t segItr = segStartIndex;
+                 segItr < segStartIndex + p.second; segItr++)
+            {
+                // NOLINTBEGIN(misc-include-cleaner)
+                if (!(checkByte(boost::endian::endian_reverse(
+                                    std::get<3>(refLockRecord1)),
+                                boost::endian::endian_reverse(
+                                    std::get<3>(refLockRecord2)),
+                                segItr)))
+                {
+                    return false;
+                }
+                // NOLINTEND(misc-include-cleaner)
+            }
+            segStartIndex = segStartIndex + p.second;
+        }
+
+        ++i;
+    }
+
+    return true;
+}
+
+inline uint32_t Lock::generateTransactionId()
+{
+    ++transactionId;
+    return transactionId;
+}
+
+} // namespace ibm_mc_lock
+} // namespace crow

--- a/include/ibm/management_console_rest.hpp
+++ b/include/ibm/management_console_rest.hpp
@@ -1,32 +1,58 @@
-// SPDX-License-Identifier: Apache-2.0
-// SPDX-FileCopyrightText: Copyright OpenBMC Authors
 #pragma once
 
-#include "app.hpp"
-#include "async_resp.hpp"
+#include "dbus_singleton.hpp"
 #include "http_request.hpp"
-#include "ibm/utils.hpp"
 #include "logging.hpp"
-#include "str_utility.hpp"
-#include "utils/json_utils.hpp"
+#include "multipart_parser.hpp"
+#include "query.hpp"
 
+#include <app.hpp>
+#include <async_resp.hpp>
+#include <boost/algorithm/string/predicate.hpp>
+#include <boost/asio/error.hpp>
+#include <boost/asio/steady_timer.hpp>
 #include <boost/beast/core/string_type.hpp>
 #include <boost/beast/http/field.hpp>
+#include <boost/beast/http/fields.hpp>
+#include <boost/beast/http/rfc7230.hpp>
 #include <boost/beast/http/status.hpp>
 #include <boost/beast/http/verb.hpp>
+#include <boost/container/flat_map.hpp>
+#include <error_messages.hpp>
+#include <event_service_manager.hpp>
+#include <ibm/locks.hpp>
+#include <ibm/utils.hpp>
 #include <nlohmann/json.hpp>
+#include <resource_messages.hpp>
+#include <sdbusplus/bus/match.hpp>
+#include <sdbusplus/message.hpp>
+#include <sdbusplus/message/native_types.hpp>
+#include <utils/json_utils.hpp>
 
+#include <chrono>
 #include <cstddef>
 #include <cstdint>
 #include <filesystem>
 #include <fstream>
+#include <functional>
 #include <iterator>
 #include <memory>
+#include <sstream>
 #include <string>
 #include <system_error>
+#include <tuple>
 #include <utility>
+#include <variant>
 #include <vector>
 
+using SType = std::string;
+using SegmentFlags = std::vector<std::pair<std::string, uint32_t>>;
+using LockRequest = std::tuple<SType, SType, SType, uint64_t, SegmentFlags>;
+using LockRequests = std::vector<LockRequest>;
+using Rc = std::pair<bool, std::variant<uint32_t, LockRequest>>;
+using RcGetLockList =
+    std::variant<std::string, std::vector<std::pair<uint32_t, LockRequests>>>;
+using ListOfSessionIds = std::vector<std::string>;
 namespace crow
 {
 namespace ibm_mc
@@ -35,46 +61,88 @@ constexpr const char* methodNotAllowedMsg = "Method Not Allowed";
 constexpr const char* resourceNotFoundMsg = "Resource Not Found";
 constexpr const char* contentNotAcceptableMsg = "Content Not Acceptable";
 constexpr const char* internalServerError = "Internal Server Error";
+constexpr uint32_t maxCSRLength = 4096;
+static const std::filesystem::path rootCertPath =
+    "/var/lib/ibm/bmcweb/RootCert";
+constexpr const char* internalFileSystemError = "Internal FileSystem Error";
+constexpr const char* badRequestMsg = "Bad Request";
+constexpr const char* propertyMissing = "Required Property Missing";
+constexpr const char* configFilePath =
+    "/var/lib/bmcweb/ibm-management-console/configfiles";
 
 constexpr size_t maxSaveareaDirSize =
-    25000000; // Allow save area dir size to be max 25MB
+    26214400; // Allow save area dir size to be max 25MB
 constexpr size_t minSaveareaFileSize =
     100;      // Allow save area file size of minimum 100B
 constexpr size_t maxSaveareaFileSize =
-    500000;   // Allow save area file size upto 500KB
+    26214400; // Allow save area file size up to 25MB
 constexpr size_t maxBroadcastMsgSize =
     1000;     // Allow Broadcast message size upto 1KB
 
-inline void handleFilePut(const crow::Request& req,
-                          const std::shared_ptr<bmcweb::AsyncResp>& asyncResp,
-                          const std::string& fileID)
+// NOLINTBEGIN(cppcoreguidelines-avoid-non-const-global-variables)
+static boost::container::flat_map<std::string,
+                                  std::unique_ptr<sdbusplus::bus::match::match>>
+    ackMatches;
+// NOLINTEND(cppcoreguidelines-avoid-non-const-global-variables)
+
+inline bool isValidConfigFileName(const std::string& fileName,
+                                  nlohmann::json& resp)
+{
+    if (fileName.empty())
+    {
+        BMCWEB_LOG_ERROR("Empty filename");
+        resp["Description"] = "Empty file path in the url";
+        return false;
+    }
+
+    // ConfigFile name is allowed to take upper and lowercase letters,
+    // numbers and hyphen
+    std::size_t found = fileName.find_first_not_of(
+        "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789-");
+    if (found != std::string::npos)
+    {
+        BMCWEB_LOG_ERROR("Unsupported character in filename: {}", fileName);
+        resp["Description"] = "Unsupported character in filename";
+        return false;
+    }
+
+    // Check the filename length
+    if (fileName.length() > 20)
+    {
+        BMCWEB_LOG_ERROR("Name must be maximum 20 characters. "
+                         "Input filename length is: {}",
+                         fileName.length());
+        resp["Description"] = "Filename must be maximum 20 characters";
+        return false;
+    }
+
+    return true;
+}
+
+inline bool saveConfigFile(const std::string& data, const std::string& fileID,
+                           const std::shared_ptr<bmcweb::AsyncResp>& asyncResp)
 {
     std::error_code ec;
-    // Check the content-type of the request
-    boost::beast::string_view contentType = req.getHeaderValue("content-type");
-    if (!bmcweb::asciiIEquals(contentType, "application/octet-stream"))
-    {
-        asyncResp->res.result(boost::beast::http::status::not_acceptable);
-        asyncResp->res.jsonValue["Description"] = contentNotAcceptableMsg;
-        return;
-    }
-    BMCWEB_LOG_DEBUG(
-        "File upload in application/octet-stream format. Continue..");
+    // Get the file size getting uploaded
+    BMCWEB_LOG_DEBUG("data length: {}", data.length());
+    BMCWEB_LOG_DEBUG("fileID: {} ", fileID);
 
-    BMCWEB_LOG_DEBUG(
-        "handleIbmPut: Request to create/update the save-area file");
-    std::string_view path =
-        "/var/lib/bmcweb/ibm-management-console/configfiles";
-    if (!crow::ibm_utils::createDirectory(path))
+    if (data.length() < minSaveareaFileSize)
     {
-        asyncResp->res.result(boost::beast::http::status::not_found);
-        asyncResp->res.jsonValue["Description"] = resourceNotFoundMsg;
-        return;
+        asyncResp->res.result(boost::beast::http::status::bad_request);
+        asyncResp->res.jsonValue["Description"] =
+            "File size is less than minimum allowed size[100B]";
+        return false;
     }
-
+    if (data.length() > maxSaveareaFileSize)
+    {
+        asyncResp->res.result(boost::beast::http::status::bad_request);
+        asyncResp->res.jsonValue["Description"] =
+            "File size exceeds maximum allowed size[25MB]";
+        return false;
+    }
     std::ofstream file;
-    std::filesystem::path loc(
-        "/var/lib/bmcweb/ibm-management-console/configfiles");
+    std::filesystem::path loc(configFilePath);
 
     // Get the current size of the savearea directory
     std::filesystem::recursive_directory_iterator iter(loc, ec);
@@ -82,11 +150,11 @@ inline void handleFilePut(const crow::Request& req,
     {
         asyncResp->res.result(
             boost::beast::http::status::internal_server_error);
-        asyncResp->res.jsonValue["Description"] = internalServerError;
-        BMCWEB_LOG_DEBUG("handleIbmPut: Failed to prepare save-area "
+        asyncResp->res.jsonValue["Description"] = internalFileSystemError;
+        BMCWEB_LOG_ERROR("saveConfigFile: Failed to prepare save-area "
                          "directory iterator. ec : {}",
                          ec.message());
-        return;
+        return false;
     }
     std::uintmax_t saveAreaDirSize = 0;
     for (const auto& it : iter)
@@ -97,46 +165,29 @@ inline void handleFilePut(const crow::Request& req,
             {
                 asyncResp->res.result(
                     boost::beast::http::status::internal_server_error);
-                asyncResp->res.jsonValue["Description"] = internalServerError;
-                BMCWEB_LOG_DEBUG("handleIbmPut: Failed to find save-area "
+                asyncResp->res.jsonValue["Description"] =
+                    internalFileSystemError;
+                BMCWEB_LOG_ERROR("saveConfigFile: Failed to find save-area "
                                  "directory . ec : {}",
                                  ec.message());
-                return;
+                return false;
             }
             std::uintmax_t fileSize = std::filesystem::file_size(it, ec);
             if (ec)
             {
                 asyncResp->res.result(
                     boost::beast::http::status::internal_server_error);
-                asyncResp->res.jsonValue["Description"] = internalServerError;
-                BMCWEB_LOG_DEBUG("handleIbmPut: Failed to find save-area "
+                asyncResp->res.jsonValue["Description"] =
+                    internalFileSystemError;
+                BMCWEB_LOG_ERROR("saveConfigFile: Failed to find save-area "
                                  "file size inside the directory . ec : {}",
                                  ec.message());
-                return;
+                return false;
             }
             saveAreaDirSize += fileSize;
         }
     }
     BMCWEB_LOG_DEBUG("saveAreaDirSize: {}", saveAreaDirSize);
-
-    // Get the file size getting uploaded
-    const std::string& data = req.body();
-    BMCWEB_LOG_DEBUG("data length: {}", data.length());
-
-    if (data.length() < minSaveareaFileSize)
-    {
-        asyncResp->res.result(boost::beast::http::status::bad_request);
-        asyncResp->res.jsonValue["Description"] =
-            "File size is less than minimum allowed size[100B]";
-        return;
-    }
-    if (data.length() > maxSaveareaFileSize)
-    {
-        asyncResp->res.result(boost::beast::http::status::bad_request);
-        asyncResp->res.jsonValue["Description"] =
-            "File size exceeds maximum allowed size[500KB]";
-        return;
-    }
 
     // Form the file path
     loc /= fileID;
@@ -148,12 +199,12 @@ inline void handleFilePut(const crow::Request& req,
     {
         asyncResp->res.result(
             boost::beast::http::status::internal_server_error);
-        asyncResp->res.jsonValue["Description"] = internalServerError;
-        BMCWEB_LOG_DEBUG("handleIbmPut: Failed to find if file exists. ec : {}",
-                         ec.message());
-        return;
+        asyncResp->res.jsonValue["Description"] = internalFileSystemError;
+        BMCWEB_LOG_ERROR(
+            "saveConfigFile: Failed to find if file exists. ec : {}",
+            ec.message());
+        return false;
     }
-
     std::uintmax_t newSizeToWrite = 0;
     if (fileExists)
     {
@@ -163,10 +214,11 @@ inline void handleFilePut(const crow::Request& req,
         {
             asyncResp->res.result(
                 boost::beast::http::status::internal_server_error);
-            asyncResp->res.jsonValue["Description"] = internalServerError;
-            BMCWEB_LOG_DEBUG("handleIbmPut: Failed to find file size. ec : {}",
-                             ec.message());
-            return;
+            asyncResp->res.jsonValue["Description"] = internalFileSystemError;
+            BMCWEB_LOG_ERROR(
+                "saveConfigFile: Failed to find file size. ec : {}",
+                ec.message());
+            return false;
         }
         // Calculate the difference in the file size.
         // If the data.length is greater than the existing file size, then
@@ -188,14 +240,13 @@ inline void handleFilePut(const crow::Request& req,
 
     // Calculate the total dir size before writing the new file
     BMCWEB_LOG_DEBUG("total new size: {}", saveAreaDirSize + newSizeToWrite);
-
     if ((saveAreaDirSize + newSizeToWrite) > maxSaveareaDirSize)
     {
         asyncResp->res.result(boost::beast::http::status::bad_request);
         asyncResp->res.jsonValue["Description"] =
             "File size does not fit in the savearea "
             "directory maximum allowed size[25MB]";
-        return;
+        return false;
     }
 
     file.open(loc, std::ofstream::out);
@@ -212,20 +263,144 @@ inline void handleFilePut(const crow::Request& req,
             boost::beast::http::status::internal_server_error);
         asyncResp->res.jsonValue["Description"] =
             "Error while creating the file";
-        return;
+        return false;
     }
     file << data;
-
+    std::string origin = "/ibm/v1/Host/ConfigFiles/" + fileID;
     // Push an event
     if (fileExists)
     {
         BMCWEB_LOG_DEBUG("config file is updated");
         asyncResp->res.jsonValue["Description"] = "File Updated";
+
+        redfish::EventServiceManager::getInstance().sendEvent(
+            redfish::messages::resourceChanged(), origin, "IBMConfigFile");
     }
     else
     {
         BMCWEB_LOG_DEBUG("config file is created");
         asyncResp->res.jsonValue["Description"] = "File Created";
+
+        redfish::EventServiceManager::getInstance().sendEvent(
+            redfish::messages::resourceCreated(), origin, "IBMConfigFile");
+    }
+    return true;
+}
+
+inline void handleFileUpload(
+    const crow::Request& req,
+    const std::shared_ptr<bmcweb::AsyncResp>& asyncResp,
+    const std::string& fileID = "")
+{
+    // Check the content-type of the request
+    boost::beast::string_view contentType = req.getHeaderValue("content-type");
+    BMCWEB_LOG_DEBUG("Content Type: {}", contentType);
+    if (((req.method() == boost::beast::http::verb::put) &&
+         (!boost::iequals(contentType, "application/octet-stream"))) ||
+        ((req.method() == boost::beast::http::verb::post) &&
+         (!boost::istarts_with(contentType, "multipart/form-data"))))
+    {
+        asyncResp->res.result(boost::beast::http::status::not_acceptable);
+        asyncResp->res.jsonValue["Description"] = contentNotAcceptableMsg;
+        return;
+    }
+
+    BMCWEB_LOG_DEBUG(
+        "handleFileUpload: Request to create/update the save-area file");
+    std::string_view path = configFilePath;
+    if (!crow::ibm_utils::createDirectory(path))
+    {
+        asyncResp->res.result(boost::beast::http::status::not_found);
+        asyncResp->res.jsonValue["Description"] = resourceNotFoundMsg;
+        return;
+    }
+
+    bool uploadStatus = true;
+    // Logic to parse the data if its multipart form
+    if (boost::istarts_with(contentType, "multipart/form-data"))
+    {
+        BMCWEB_LOG_DEBUG("This is a multipart upload");
+        MultipartParser parser;
+        ParserError ec = parser.parse(req);
+        if (ec != ParserError::PARSER_SUCCESS)
+        {
+            // handle error
+            BMCWEB_LOG_ERROR("MIME parse failed, ec : {}",
+                             static_cast<int>(ec));
+            asyncResp->res.result(boost::beast::http::status::bad_request);
+            asyncResp->res.jsonValue["Description"] = badRequestMsg;
+            return;
+        }
+        const std::string* uploadData = nullptr;
+        std::string fileName;
+        for (const FormPart& formpart : parser.mime_fields)
+        {
+            boost::beast::http::fields::const_iterator it =
+                formpart.fields.find("Content-Disposition");
+            if (it == formpart.fields.end())
+            {
+                BMCWEB_LOG_ERROR("Couldn't find Content-Disposition");
+                asyncResp->res.result(boost::beast::http::status::bad_request);
+                asyncResp->res.jsonValue["Description"] = badRequestMsg;
+                return;
+            }
+            BMCWEB_LOG_DEBUG("Parsing value {}", it->value());
+            // The construction parameters of param_list must start with
+            // `;`
+            size_t index = it->value().find(';');
+            if (index == std::string::npos)
+            {
+                BMCWEB_LOG_ERROR("Parsing value failed {}", it->value());
+                continue;
+            }
+            for (const auto& param :
+                 boost::beast::http::param_list{it->value().substr(index)})
+            {
+                if (param.first == "name")
+                {
+                    fileName = param.second;
+                    BMCWEB_LOG_DEBUG("file name : {}", fileName);
+
+                    // Validate the incoming fileName
+                    if (!isValidConfigFileName(fileName,
+                                               asyncResp->res.jsonValue))
+                    {
+                        asyncResp->res.result(
+                            boost::beast::http::status::bad_request);
+                        return;
+                    }
+                }
+                uploadData = &(formpart.content);
+            }
+            if ((uploadData == nullptr) || (fileName.empty()))
+            {
+                BMCWEB_LOG_ERROR("Upload data or filename is NULL");
+                asyncResp->res.result(boost::beast::http::status::bad_request);
+                asyncResp->res.jsonValue["Description"] = propertyMissing;
+                return;
+            }
+            uploadStatus = saveConfigFile(*uploadData, fileName, asyncResp);
+            if (!uploadStatus)
+            {
+                BMCWEB_LOG_INFO("ConfigFile upload failed!! FileName: {}",
+                                fileName);
+                return;
+            }
+            BMCWEB_LOG_INFO("ConfigFile upload complete!! Filename: {}",
+                            fileName);
+        }
+    }
+    else
+    {
+        // Single file upload
+        const std::string& data = req.body();
+        uploadStatus = saveConfigFile(data, fileID, asyncResp);
+        if (!uploadStatus)
+        {
+            BMCWEB_LOG_INFO("ConfigFile upload failed!! FileName: {}", fileID);
+            return;
+        }
+        BMCWEB_LOG_INFO("ConfigFile upload complete!! Filename: {}", fileID);
     }
 }
 
@@ -233,8 +408,7 @@ inline void handleConfigFileList(
     const std::shared_ptr<bmcweb::AsyncResp>& asyncResp)
 {
     std::vector<std::string> pathObjList;
-    std::filesystem::path loc(
-        "/var/lib/bmcweb/ibm-management-console/configfiles");
+    std::filesystem::path loc(configFilePath);
     if (std::filesystem::exists(loc) && std::filesystem::is_directory(loc))
     {
         for (const auto& file : std::filesystem::directory_iterator(loc))
@@ -242,7 +416,7 @@ inline void handleConfigFileList(
             const std::filesystem::path& pathObj = file.path();
             if (std::filesystem::is_regular_file(pathObj))
             {
-                pathObjList.emplace_back(
+                pathObjList.push_back(
                     "/ibm/v1/Host/ConfigFiles/" + pathObj.filename().string());
             }
         }
@@ -254,16 +428,16 @@ inline void handleConfigFileList(
     asyncResp->res.jsonValue["Name"] = "ConfigFiles";
 
     asyncResp->res.jsonValue["Members"] = std::move(pathObjList);
-    asyncResp->res.jsonValue["Actions"]["#IBMConfigFiles.DeleteAll"]["target"] =
-        "/ibm/v1/Host/ConfigFiles/Actions/IBMConfigFiles.DeleteAll";
+    asyncResp->res.jsonValue["Actions"]["#IBMConfigFiles.DeleteAll"] = {
+        {"target",
+         "/ibm/v1/Host/ConfigFiles/Actions/IBMConfigFiles.DeleteAll"}};
 }
 
 inline void deleteConfigFiles(
     const std::shared_ptr<bmcweb::AsyncResp>& asyncResp)
 {
     std::error_code ec;
-    std::filesystem::path loc(
-        "/var/lib/bmcweb/ibm-management-console/configfiles");
+    std::filesystem::path loc(configFilePath);
     if (std::filesystem::exists(loc) && std::filesystem::is_directory(loc))
     {
         std::filesystem::remove_all(loc, ec);
@@ -272,11 +446,32 @@ inline void deleteConfigFiles(
             asyncResp->res.result(
                 boost::beast::http::status::internal_server_error);
             asyncResp->res.jsonValue["Description"] = internalServerError;
-            BMCWEB_LOG_DEBUG("deleteConfigFiles: Failed to delete the "
+            BMCWEB_LOG_ERROR("deleteConfigFiles: Failed to delete the "
                              "config files directory. ec : {}",
                              ec.message());
         }
+        BMCWEB_LOG_INFO("Config files directory delete successful. PATH: {}",
+                        loc.string());
+        std::string origin = "/ibm/v1/Host/ConfigFiles";
+        redfish::EventServiceManager::getInstance().sendEvent(
+            redfish::messages::resourceRemoved(), origin, "IBMConfigFile");
     }
+}
+
+inline void getLockServiceData(
+    const std::shared_ptr<bmcweb::AsyncResp>& asyncResp)
+{
+    asyncResp->res.jsonValue["@odata.type"] = "#LockService.v1_0_0.LockService";
+    asyncResp->res.jsonValue["@odata.id"] = "/ibm/v1/HMC/LockService/";
+    asyncResp->res.jsonValue["Id"] = "LockService";
+    asyncResp->res.jsonValue["Name"] = "LockService";
+
+    asyncResp->res.jsonValue["Actions"]["#LockService.AcquireLock"] = {
+        {"target", "/ibm/v1/HMC/LockService/Actions/LockService.AcquireLock"}};
+    asyncResp->res.jsonValue["Actions"]["#LockService.ReleaseLock"] = {
+        {"target", "/ibm/v1/HMC/LockService/Actions/LockService.ReleaseLock"}};
+    asyncResp->res.jsonValue["Actions"]["#LockService.GetLockList"] = {
+        {"target", "/ibm/v1/HMC/LockService/Actions/LockService.GetLockList"}};
 }
 
 inline void handleFileGet(const std::shared_ptr<bmcweb::AsyncResp>& asyncResp,
@@ -324,12 +519,15 @@ inline void handleFileDelete(
     {
         if (remove(filePath.c_str()) == 0)
         {
-            BMCWEB_LOG_DEBUG("File removed!");
+            BMCWEB_LOG_INFO("ConfigFile removed, FilePath: {}", filePath);
             asyncResp->res.jsonValue["Description"] = "File Deleted";
+            std::string origin = "/ibm/v1/Host/ConfigFiles/" + fileID;
+            redfish::EventServiceManager::getInstance().sendEvent(
+                redfish::messages::resourceRemoved(), origin, "IBMConfigFile");
         }
         else
         {
-            BMCWEB_LOG_ERROR("File not removed!");
+            BMCWEB_LOG_ERROR("File not removed, FilePath: {}", filePath);
             asyncResp->res.result(
                 boost::beast::http::status::internal_server_error);
             asyncResp->res.jsonValue["Description"] = internalServerError;
@@ -337,7 +535,7 @@ inline void handleFileDelete(
     }
     else
     {
-        BMCWEB_LOG_WARNING("File not found!");
+        BMCWEB_LOG_ERROR("File not found, FilePath: {}", filePath);
         asyncResp->res.result(boost::beast::http::status::not_found);
         asyncResp->res.jsonValue["Description"] = resourceNotFoundMsg;
     }
@@ -362,6 +560,12 @@ inline void handleBroadcastService(
         asyncResp->res.result(boost::beast::http::status::bad_request);
         return;
     }
+
+    std::string origin = "/ibm/v1/HMC/BroadcastService";
+    nlohmann::json msgJson = {{"Message", broadcastMsg}};
+
+    redfish::EventServiceManager::getInstance().sendEvent(
+        msgJson, origin, "BroadcastService");
 }
 
 inline void handleFileUrl(const crow::Request& req,
@@ -370,7 +574,7 @@ inline void handleFileUrl(const crow::Request& req,
 {
     if (req.method() == boost::beast::http::verb::put)
     {
-        handleFilePut(req, asyncResp, fileID);
+        handleFileUpload(req, asyncResp, fileID);
         return;
     }
     if (req.method() == boost::beast::http::verb::get)
@@ -385,38 +589,573 @@ inline void handleFileUrl(const crow::Request& req,
     }
 }
 
-inline bool isValidConfigFileName(const std::string& fileName,
-                                  crow::Response& res)
+inline void handleFileUrlPost(
+    crow::App& app, const crow::Request& req,
+    const std::shared_ptr<bmcweb::AsyncResp>& asyncResp)
 {
-    if (fileName.empty())
+    if (!redfish::setUpRedfishRoute(app, req, asyncResp))
     {
-        BMCWEB_LOG_ERROR("Empty filename");
-        res.jsonValue["Description"] = "Empty file path in the url";
-        return false;
+        return;
+    }
+    handleFileUpload(req, asyncResp);
+}
+
+inline void handleAcquireLockAPI(
+    const crow::Request& req,
+    const std::shared_ptr<bmcweb::AsyncResp>& asyncResp,
+    std::vector<nlohmann::json> body)
+{
+    LockRequests lockRequestStructure;
+    for (auto& element : body)
+    {
+        std::string lockType;
+        uint64_t resourceId = 0;
+
+        SegmentFlags segInfo;
+        std::vector<nlohmann::json> segmentFlags;
+
+        if (!redfish::json_util::readJson(element, asyncResp->res, "LockType",
+                                          lockType, "ResourceID", resourceId,
+                                          "SegmentFlags", segmentFlags))
+        {
+            BMCWEB_LOG_DEBUG("Not a Valid JSON");
+            asyncResp->res.result(boost::beast::http::status::bad_request);
+            return;
+        }
+        BMCWEB_LOG_DEBUG("{}", lockType);
+        BMCWEB_LOG_DEBUG("{}", resourceId);
+
+        BMCWEB_LOG_DEBUG("Segment Flags are present");
+
+        for (auto& e : segmentFlags)
+        {
+            std::string lockFlags;
+            uint32_t segmentLength = 0;
+
+            if (!redfish::json_util::readJson(e, asyncResp->res, "LockFlag",
+                                              lockFlags, "SegmentLength",
+                                              segmentLength))
+            {
+                asyncResp->res.result(boost::beast::http::status::bad_request);
+                return;
+            }
+
+            BMCWEB_LOG_DEBUG("Lockflag : {}", lockFlags);
+            BMCWEB_LOG_DEBUG("SegmentLength : {}", segmentLength);
+
+            segInfo.emplace_back(lockFlags, segmentLength);
+        }
+
+        lockRequestStructure.emplace_back(req.session->uniqueId,
+                                          req.session->clientId.value_or(""),
+                                          lockType, resourceId, segInfo);
     }
 
-    // ConfigFile name is allowed to take upper and lowercase letters,
-    // numbers and hyphen
-    std::size_t found = fileName.find_first_not_of(
-        "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789-");
-    if (found != std::string::npos)
+    // print lock request into journal
+
+    for (auto& i : lockRequestStructure)
     {
-        BMCWEB_LOG_ERROR("Unsupported character in filename: {}", fileName);
-        res.jsonValue["Description"] = "Unsupported character in filename";
-        return false;
+        BMCWEB_LOG_DEBUG("{}", std::get<0>(i));
+        BMCWEB_LOG_DEBUG("{}", std::get<1>(i));
+        BMCWEB_LOG_DEBUG("{}", std::get<2>(i));
+        BMCWEB_LOG_DEBUG("{}", std::get<3>(i));
+
+        for (const auto& p : std::get<4>(i))
+        {
+            BMCWEB_LOG_DEBUG("{}, {}", p.first, p.second);
+        }
     }
 
-    // Check the filename length
-    if (fileName.length() > 20)
+    const LockRequests& t = lockRequestStructure;
+
+    auto varAcquireLock = crow::ibm_mc_lock::Lock::getInstance().acquireLock(t);
+
+    if (varAcquireLock.first)
     {
-        BMCWEB_LOG_ERROR("Name must be maximum 20 characters. "
-                         "Input filename length is: {}",
-                         fileName.length());
-        res.jsonValue["Description"] = "Filename must be maximum 20 characters";
-        return false;
+        // Either validity failure or there is a conflict with itself
+
+        auto validityStatus =
+            std::get<std::pair<bool, int>>(varAcquireLock.second);
+
+        if ((!validityStatus.first) && (validityStatus.second == 0))
+        {
+            BMCWEB_LOG_DEBUG("Not a Valid record");
+            BMCWEB_LOG_DEBUG("Bad json in request");
+            asyncResp->res.result(boost::beast::http::status::bad_request);
+            return;
+        }
+        if (validityStatus.first && (validityStatus.second == 1))
+        {
+            BMCWEB_LOG_ERROR(
+                "handleAcquireLockAPI: There is a conflict within itself");
+            asyncResp->res.result(boost::beast::http::status::conflict);
+            return;
+        }
+    }
+    else
+    {
+        auto conflictStatus =
+            std::get<crow::ibm_mc_lock::Rc>(varAcquireLock.second);
+        if (!conflictStatus.first)
+        {
+            BMCWEB_LOG_DEBUG("There is no conflict with the locktable");
+            asyncResp->res.result(boost::beast::http::status::ok);
+
+            auto var = std::get<uint32_t>(conflictStatus.second);
+            nlohmann::json returnJson;
+            returnJson["id"] = var;
+            asyncResp->res.jsonValue["TransactionID"] = var;
+            return;
+        }
+
+        // Check if the session is active. If active, send back the lock
+        // conflict, else clear the stale entry in the lock table.
+        auto var =
+            std::get<std::pair<uint32_t, LockRequest>>(conflictStatus.second);
+        std::string sessionId = std::get<0>(var.second);
+        auto session =
+            persistent_data::SessionStore::getInstance().getSessionByUid(
+                sessionId);
+
+        if (session == nullptr)
+        {
+            BMCWEB_LOG_ERROR("Releasing lock of the session id(stale): {}",
+                             sessionId);
+            // clear the stale entry
+            crow::ibm_mc_lock::Lock::getInstance().releaseLock(sessionId);
+
+            // create the new lock record for the session
+            varAcquireLock =
+                crow::ibm_mc_lock::Lock::getInstance().acquireLock(t);
+            conflictStatus =
+                std::get<crow::ibm_mc_lock::Rc>(varAcquireLock.second);
+            if (!conflictStatus.first)
+            {
+                asyncResp->res.result(boost::beast::http::status::ok);
+
+                auto id = std::get<uint32_t>(conflictStatus.second);
+                nlohmann::json returnJson;
+                returnJson["id"] = id;
+                asyncResp->res.jsonValue["TransactionID"] = id;
+                return;
+            }
+        }
+
+        BMCWEB_LOG_ERROR(
+            "handleAcquireLockAPI: There is a conflict with the lock table");
+
+        asyncResp->res.result(boost::beast::http::status::conflict);
+        nlohmann::json returnJson;
+        nlohmann::json segments;
+        nlohmann::json myarray = nlohmann::json::array();
+        returnJson["TransactionID"] = var.first;
+        returnJson["SessionID"] = sessionId;
+        returnJson["HMCID"] = std::get<1>(var.second);
+        returnJson["LockType"] = std::get<2>(var.second);
+        returnJson["ResourceID"] = std::get<3>(var.second);
+
+        for (const auto& i : std::get<4>(var.second))
+        {
+            segments["LockFlag"] = i.first;
+            segments["SegmentLength"] = i.second;
+            myarray.push_back(segments);
+        }
+
+        returnJson["SegmentFlags"] = myarray;
+        BMCWEB_LOG_ERROR("handleAcquireLockAPI: Conflicting lock record: {} ",
+                         returnJson);
+        asyncResp->res.jsonValue["Record"] = returnJson;
+        return;
+    }
+}
+inline void handleRelaseAllAPI(
+    const crow::Request& req,
+    const std::shared_ptr<bmcweb::AsyncResp>& asyncResp)
+{
+    crow::ibm_mc_lock::Lock::getInstance().releaseLock(req.session->uniqueId);
+    asyncResp->res.result(boost::beast::http::status::ok);
+}
+
+inline void handleReleaseLockAPI(
+    const crow::Request& req,
+    const std::shared_ptr<bmcweb::AsyncResp>& asyncResp,
+    const std::vector<uint32_t>& listTransactionIds)
+{
+    BMCWEB_LOG_DEBUG("{}", listTransactionIds.size());
+    BMCWEB_LOG_DEBUG("Data is present");
+    for (unsigned int listTransactionId : listTransactionIds)
+    {
+        BMCWEB_LOG_DEBUG("{}", listTransactionId);
     }
 
-    return true;
+    // validate the request ids
+
+    auto varReleaselock = crow::ibm_mc_lock::Lock::getInstance().releaseLock(
+        listTransactionIds, std::make_pair(req.session->clientId.value_or(""),
+                                           req.session->uniqueId));
+
+    if (!varReleaselock.first)
+    {
+        // validation Failed
+        BMCWEB_LOG_ERROR("handleReleaseLockAPI: validation failed");
+        asyncResp->res.result(boost::beast::http::status::bad_request);
+        return;
+    }
+    auto statusRelease =
+        std::get<crow::ibm_mc_lock::RcReleaseLock>(varReleaselock.second);
+    if (statusRelease.first)
+    {
+        // The current hmc owns all the locks, so we already released
+        // them
+        return;
+    }
+
+    // valid rid, but the current hmc does not own all the locks
+    BMCWEB_LOG_DEBUG(
+        "handleReleaseLockAPI: Current HMC does not own all the locks");
+    asyncResp->res.result(boost::beast::http::status::unauthorized);
+
+    auto var = statusRelease.second;
+    nlohmann::json returnJson;
+    nlohmann::json segments;
+    nlohmann::json myArray = nlohmann::json::array();
+    returnJson["TransactionID"] = var.first;
+    returnJson["SessionID"] = std::get<0>(var.second);
+    returnJson["HMCID"] = std::get<1>(var.second);
+    returnJson["LockType"] = std::get<2>(var.second);
+    returnJson["ResourceID"] = std::get<3>(var.second);
+
+    for (const auto& i : std::get<4>(var.second))
+    {
+        segments["LockFlag"] = i.first;
+        segments["SegmentLength"] = i.second;
+        myArray.push_back(segments);
+    }
+
+    returnJson["SegmentFlags"] = myArray;
+    BMCWEB_LOG_DEBUG("handleReleaseLockAPI: lockrecord: {} ", returnJson);
+    asyncResp->res.jsonValue["Record"] = returnJson;
+}
+
+inline void handleGetLockListAPI(
+    const std::shared_ptr<bmcweb::AsyncResp>& asyncResp,
+    const ListOfSessionIds& listSessionIds)
+{
+    BMCWEB_LOG_DEBUG("{}", listSessionIds.size());
+
+    auto status =
+        crow::ibm_mc_lock::Lock::getInstance().getLockList(listSessionIds);
+    auto var = std::get<std::vector<std::pair<uint32_t, LockRequests>>>(status);
+
+    nlohmann::json lockRecords = nlohmann::json::array();
+
+    for (const auto& transactionId : var)
+    {
+        for (const auto& lockRecord : transactionId.second)
+        {
+            nlohmann::json returnJson;
+
+            returnJson["TransactionID"] = transactionId.first;
+            returnJson["SessionID"] = std::get<0>(lockRecord);
+            returnJson["HMCID"] = std::get<1>(lockRecord);
+            returnJson["LockType"] = std::get<2>(lockRecord);
+            returnJson["ResourceID"] = std::get<3>(lockRecord);
+
+            nlohmann::json segments;
+            nlohmann::json segmentInfoArray = nlohmann::json::array();
+
+            for (const auto& segment : std::get<4>(lockRecord))
+            {
+                segments["LockFlag"] = segment.first;
+                segments["SegmentLength"] = segment.second;
+                segmentInfoArray.push_back(segments);
+            }
+
+            returnJson["SegmentFlags"] = segmentInfoArray;
+            lockRecords.push_back(returnJson);
+        }
+    }
+    asyncResp->res.result(boost::beast::http::status::ok);
+    asyncResp->res.jsonValue["Records"] = lockRecords;
+}
+
+inline void deleteVMIDbusEntry(
+    const std::shared_ptr<bmcweb::AsyncResp>& asyncResp,
+    const std::string& entryId)
+{
+    auto respHandler = [asyncResp,
+                        entryId](const boost::system::error_code ec) {
+        if (ec)
+        {
+            BMCWEB_LOG_ERROR("deleteVMIDbusEntry respHandler got error {}",
+                             ec.message());
+            asyncResp->res.result(
+                boost::beast::http::status::internal_server_error);
+            return;
+        }
+    };
+    crow::connections::systemBus->async_method_call(
+        respHandler, "xyz.openbmc_project.Certs.ca.authority.Manager",
+        "/xyz/openbmc_project/certs/ca/entry/" + entryId,
+        "xyz.openbmc_project.Object.Delete", "Delete");
+}
+
+inline void getCSREntryCertificate(
+    const std::shared_ptr<bmcweb::AsyncResp>& asyncResp,
+    const std::string& entryId)
+{
+    crow::connections::systemBus->async_method_call(
+        [asyncResp](const boost::system::error_code ec,
+                    const std::variant<std::string>& certificate) {
+            if (ec)
+            {
+                BMCWEB_LOG_ERROR(
+                    "getCSREntryCertificate respHandler got error: {}",
+                    ec.message());
+                asyncResp->res.result(
+                    boost::beast::http::status::internal_server_error);
+                asyncResp->res.jsonValue["Description"] =
+                    "Failed to get request status";
+                return;
+            }
+
+            const std::string* cert = std::get_if<std::string>(&certificate);
+            if (cert == nullptr)
+            {
+                asyncResp->res.result(
+                    boost::beast::http::status::internal_server_error);
+                asyncResp->res.jsonValue["Description"] =
+                    "Failed to get certificate from host";
+                return;
+            }
+
+            if (cert->empty())
+            {
+                BMCWEB_LOG_ERROR("Empty Client Certificate");
+                asyncResp->res.result(
+                    boost::beast::http::status::internal_server_error);
+                asyncResp->res.jsonValue["Description"] =
+                    "Empty Client Certificate";
+                return;
+            }
+
+            BMCWEB_LOG_INFO("Successfully got VMI client certificate");
+            asyncResp->res.jsonValue["Certificate"] = *cert;
+        },
+        "xyz.openbmc_project.Certs.ca.authority.Manager",
+        "/xyz/openbmc_project/certs/ca/entry/" + entryId,
+        "org.freedesktop.DBus.Properties", "Get",
+        "xyz.openbmc_project.Certs.Entry", "ClientCertificate");
+}
+
+inline void getCSREntryAck(const std::shared_ptr<bmcweb::AsyncResp>& asyncResp,
+                           const std::string& entryId)
+{
+    crow::connections::systemBus->async_method_call(
+        [asyncResp, entryId](const boost::system::error_code ec,
+                             const std::variant<std::string>& hostAck) {
+            if (ec)
+            {
+                BMCWEB_LOG_ERROR("getCSREntryAck respHandler got error: {}",
+                                 ec.message());
+                asyncResp->res.result(
+                    boost::beast::http::status::internal_server_error);
+                asyncResp->res.jsonValue["Description"] =
+                    "Failed to get request status";
+                return;
+            }
+
+            const std::string* status = std::get_if<std::string>(&hostAck);
+            if (status == nullptr)
+            {
+                asyncResp->res.result(
+                    boost::beast::http::status::internal_server_error);
+                asyncResp->res.jsonValue["Description"] =
+                    "Failed to get host ack status";
+                return;
+            }
+
+            BMCWEB_LOG_INFO("VMI Cert Entry {} new status property value {}",
+                            entryId, *status);
+            if (*status == "xyz.openbmc_project.Certs.Entry.State.Pending")
+            {
+                asyncResp->res.addHeader("Retry-After", "60");
+                asyncResp->res.result(
+                    boost::beast::http::status::service_unavailable);
+                asyncResp->res.jsonValue["Description"] =
+                    "Host is not ready to serve the request";
+            }
+            else if (*status == "xyz.openbmc_project.Certs.Entry.State.BadCSR")
+            {
+                asyncResp->res.result(boost::beast::http::status::bad_request);
+                asyncResp->res.jsonValue["Description"] = "Bad CSR";
+                BMCWEB_LOG_CRITICAL("SignCSR failed with Bad CSR");
+            }
+            else if (*status ==
+                     "xyz.openbmc_project.Certs.Entry.State.Complete")
+            {
+                getCSREntryCertificate(asyncResp, entryId);
+            }
+
+            deleteVMIDbusEntry(asyncResp, entryId);
+            auto entry = ackMatches.find(entryId);
+            if (entry != ackMatches.end())
+            {
+                BMCWEB_LOG_INFO("Erasing match of entryId: {}", entryId);
+                ackMatches.erase(entryId);
+            }
+        },
+        "xyz.openbmc_project.Certs.ca.authority.Manager",
+        "/xyz/openbmc_project/certs/ca/entry/" + entryId,
+        "org.freedesktop.DBus.Properties", "Get",
+        "xyz.openbmc_project.Certs.Entry", "Status");
+}
+
+static void handleCsrRequest(
+    const std::shared_ptr<bmcweb::AsyncResp>& asyncResp,
+    const std::string& csrString)
+{
+    std::shared_ptr<boost::asio::steady_timer> timeout =
+        std::make_shared<boost::asio::steady_timer>(
+            crow::connections::systemBus->get_io_context());
+
+    timeout->expires_after(std::chrono::seconds(30));
+    crow::connections::systemBus->async_method_call(
+        [asyncResp, timeout](const boost::system::error_code ec,
+                             sdbusplus::message::message& m) {
+            sdbusplus::message::object_path objPath;
+            m.read(objPath);
+            if (ec)
+            {
+                BMCWEB_LOG_ERROR("Error in creating CSR Entry object : {} ",
+                                 ec.message());
+                asyncResp->res.result(
+                    boost::beast::http::status::internal_server_error);
+                asyncResp->res.jsonValue["Description"] = internalServerError;
+                return;
+            }
+
+            std::string entryId = objPath.filename();
+            if (entryId.empty())
+            {
+                BMCWEB_LOG_ERROR("Invalid ID in objPath");
+                asyncResp->res.result(
+                    boost::beast::http::status::internal_server_error);
+                asyncResp->res.jsonValue["Description"] = internalServerError;
+                return;
+            }
+
+            BMCWEB_LOG_INFO("Created CSR Entry object with entryId: {}",
+                            entryId);
+            auto timeoutHandler =
+                [asyncResp, timeout,
+                 entryId](const boost::system::error_code errorCode) {
+                    if (errorCode)
+                    {
+                        if (errorCode != boost::asio::error::operation_aborted)
+                        {
+                            BMCWEB_LOG_ERROR("Async_wait failed {}", errorCode);
+                        }
+                        return;
+                    }
+
+                    getCSREntryAck(asyncResp, entryId);
+                    timeout->cancel();
+                };
+
+            timeout->async_wait(timeoutHandler);
+
+            auto callback = [asyncResp, timeout,
+                             entryId](sdbusplus::message::message& msg) {
+                boost::container::flat_map<std::string,
+                                           std::variant<std::string>>
+                    values;
+                std::string iface;
+                msg.read(iface, values);
+                if (iface == "xyz.openbmc_project.Certs.Entry")
+                {
+                    auto findStatus = values.find("Status");
+                    if (findStatus != values.end())
+                    {
+                        BMCWEB_LOG_INFO(
+                            "Found status prop change of VMI cert object with entryId: {}",
+                            entryId);
+                        getCSREntryAck(asyncResp, entryId);
+                        timeout->cancel();
+                    }
+                }
+            };
+
+            std::string matchStr(
+                "interface='org.freedesktop.DBus.Properties',type='"
+                "signal',"
+                "member='PropertiesChanged',path='/xyz/openbmc_project/certs/"
+                "ca/entry/" +
+                entryId + "'");
+
+            ackMatches.emplace(
+                entryId,
+                std::make_unique<sdbusplus::bus::match::match>(
+                    *crow::connections::systemBus, matchStr, callback));
+        },
+        "xyz.openbmc_project.Certs.ca.authority.Manager",
+        "/xyz/openbmc_project/certs/ca", "xyz.openbmc_project.Certs.Authority",
+        "SignCSR", csrString);
+}
+
+inline void handlePassThrough(
+    const crow::Request& req,
+    const std::shared_ptr<bmcweb::AsyncResp>& asyncResp,
+    const std::string& name)
+{
+    std::vector<int32_t> command;
+    if (!redfish::json_util::readJsonPatch(req, asyncResp->res, "Send",
+                                           command))
+    {
+        BMCWEB_LOG_DEBUG("Not a Valid JSON");
+        asyncResp->res.result(boost::beast::http::status::bad_request);
+        return;
+    }
+
+    if (command.empty())
+    {
+        BMCWEB_LOG_ERROR("Command is empty");
+        asyncResp->res.result(boost::beast::http::status::bad_request);
+        return;
+    }
+
+    auto respHandler = [asyncResp](const boost::system::error_code ec,
+                                   const std::vector<int32_t>& resp) {
+        if (ec)
+        {
+            BMCWEB_LOG_ERROR("handlePassThrough respHandler got error, ec = {}",
+                             ec.value());
+            asyncResp->res.result(
+                boost::beast::http::status::internal_server_error);
+            return;
+        }
+
+        if (resp.empty())
+        {
+            redfish::messages::internalError(asyncResp->res);
+            return;
+        }
+
+        std::string strData = "ai " + std::to_string(resp.size());
+        for (const auto& value : resp)
+        {
+            strData.append(" ");
+            strData.append(std::to_string(value));
+        }
+
+        asyncResp->res.addHeader("Content-Type", "application/octet-stream");
+        asyncResp->res.write(strData.c_str());
+    };
+
+    crow::connections::systemBus->async_method_call(
+        respHandler, "org.open_power.OCC.Control",
+        "/org/open_power/control/" + name, "org.open_power.OCC.PassThrough",
+        "Send", command);
 }
 
 inline void requestRoutes(App& app)
@@ -434,8 +1173,12 @@ inline void requestRoutes(App& app)
                 asyncResp->res.jsonValue["Name"] = "IBM Service Root";
                 asyncResp->res.jsonValue["ConfigFiles"]["@odata.id"] =
                     "/ibm/v1/Host/ConfigFiles";
+                asyncResp->res.jsonValue["LockService"]["@odata.id"] =
+                    "/ibm/v1/HMC/LockService";
                 asyncResp->res.jsonValue["BroadcastService"]["@odata.id"] =
                     "/ibm/v1/HMC/BroadcastService";
+                asyncResp->res.jsonValue["Certificate"]["@odata.id"] =
+                    "/ibm/v1/Host/Certificate";
             });
 
     BMCWEB_ROUTE(app, "/ibm/v1/Host/ConfigFiles")
@@ -464,7 +1207,7 @@ inline void requestRoutes(App& app)
                const std::string& fileName) {
                 BMCWEB_LOG_DEBUG("ConfigFile : {}", fileName);
                 // Validate the incoming fileName
-                if (!isValidConfigFileName(fileName, asyncResp->res))
+                if (!isValidConfigFileName(fileName, asyncResp->res.jsonValue))
                 {
                     asyncResp->res.result(
                         boost::beast::http::status::bad_request);
@@ -473,12 +1216,162 @@ inline void requestRoutes(App& app)
                 handleFileUrl(req, asyncResp, fileName);
             });
 
+    BMCWEB_ROUTE(app, "/ibm/v1/Host/Certificate")
+        .privileges({{"ConfigureComponents", "ConfigureManager"}})
+        .methods(boost::beast::http::verb::get)(
+            [](const crow::Request&,
+               const std::shared_ptr<bmcweb::AsyncResp>& asyncResp) {
+                asyncResp->res.jsonValue["@odata.id"] =
+                    "/ibm/v1/Host/Certificate";
+                asyncResp->res.jsonValue["Id"] = "Certificate";
+                asyncResp->res.jsonValue["Name"] = "Certificate";
+                asyncResp->res.jsonValue["Actions"]["SignCSR"] = {
+                    {"target", "/ibm/v1/Host/Actions/SignCSR"}};
+                asyncResp->res.jsonValue["root"] = {
+                    {"target", "/ibm/v1/Host/Certificate/root"}};
+            });
+
+    BMCWEB_ROUTE(app, "/ibm/v1/Host/Certificate/root")
+        .privileges({{"ConfigureComponents", "ConfigureManager"}})
+        .methods(boost::beast::http::verb::get)(
+            [](const crow::Request&,
+               const std::shared_ptr<bmcweb::AsyncResp>& asyncResp) {
+                if (!std::filesystem::exists(rootCertPath))
+                {
+                    BMCWEB_LOG_ERROR("RootCert file does not exist");
+                    asyncResp->res.result(
+                        boost::beast::http::status::internal_server_error);
+                    asyncResp->res.jsonValue["Description"] =
+                        internalServerError;
+                    return;
+                }
+                std::ifstream inFile;
+                inFile.open(rootCertPath.c_str());
+                if (inFile.fail())
+                {
+                    BMCWEB_LOG_DEBUG("Error while opening the root certificate "
+                                     "file for reading");
+                    asyncResp->res.result(
+                        boost::beast::http::status::internal_server_error);
+                    asyncResp->res.jsonValue["Description"] =
+                        internalServerError;
+                    return;
+                }
+
+                std::stringstream strStream;
+                strStream << inFile.rdbuf();
+                inFile.close();
+                asyncResp->res.jsonValue["Certificate"] = strStream.str();
+            });
+
+    BMCWEB_ROUTE(app, "/ibm/v1/Host/Actions/SignCSR")
+        .privileges({{"ConfigureComponents", "ConfigureManager"}})
+        .methods(boost::beast::http::verb::post)(
+            [](const crow::Request& req,
+               const std::shared_ptr<bmcweb::AsyncResp>& asyncResp) {
+                std::string csrString;
+                if (!redfish::json_util::readJsonPatch(req, asyncResp->res,
+                                                       "CsrString", csrString))
+                {
+                    return;
+                }
+
+                handleCsrRequest(asyncResp, csrString);
+            });
+
+    BMCWEB_ROUTE(app, "/ibm/v1/Host/ConfigFiles")
+        .privileges({{"ConfigureComponents", "ConfigureManager"}})
+        .methods(boost::beast::http::verb::post)(
+            std::bind_front(handleFileUrlPost, std::ref(app)));
+
+    BMCWEB_ROUTE(app, "/ibm/v1/HMC/LockService")
+        .privileges({{"ConfigureComponents", "ConfigureManager"}})
+        .methods(boost::beast::http::verb::get)(
+            [](const crow::Request&,
+               const std::shared_ptr<bmcweb::AsyncResp>& asyncResp) {
+                getLockServiceData(asyncResp);
+            });
+
+    BMCWEB_ROUTE(app, "/ibm/v1/HMC/LockService/Actions/LockService.AcquireLock")
+        .privileges({{"ConfigureComponents", "ConfigureManager"}})
+        .methods(boost::beast::http::verb::post)(
+            [](const crow::Request& req,
+               const std::shared_ptr<bmcweb::AsyncResp>& asyncResp) {
+                std::vector<nlohmann::json> body;
+                if (!redfish::json_util::readJsonAction(req, asyncResp->res,
+                                                        "Request", body))
+                {
+                    BMCWEB_LOG_DEBUG("Not a Valid JSON");
+                    asyncResp->res.result(
+                        boost::beast::http::status::bad_request);
+                    return;
+                }
+                handleAcquireLockAPI(req, asyncResp, body);
+            });
+    BMCWEB_ROUTE(app, "/ibm/v1/HMC/LockService/Actions/LockService.ReleaseLock")
+        .privileges({{"ConfigureComponents", "ConfigureManager"}})
+        .methods(boost::beast::http::verb::post)(
+            [](const crow::Request& req,
+               const std::shared_ptr<bmcweb::AsyncResp>& asyncResp) {
+                std::string type;
+                std::vector<uint32_t> listTransactionIds;
+
+                if (!redfish::json_util::readJsonPatch(
+                        req, asyncResp->res, "Type", type, "TransactionIDs",
+                        listTransactionIds))
+                {
+                    asyncResp->res.result(
+                        boost::beast::http::status::bad_request);
+                    return;
+                }
+                if (type == "Transaction")
+                {
+                    handleReleaseLockAPI(req, asyncResp, listTransactionIds);
+                }
+                else if (type == "Session")
+                {
+                    handleRelaseAllAPI(req, asyncResp);
+                }
+                else
+                {
+                    BMCWEB_LOG_DEBUG(" Value of Type : {} is Not a Valid key",
+                                     type);
+                    redfish::messages::propertyValueNotInList(asyncResp->res,
+                                                              type, "Type");
+                }
+            });
+    BMCWEB_ROUTE(app, "/ibm/v1/HMC/LockService/Actions/LockService.GetLockList")
+        .privileges({{"ConfigureComponents", "ConfigureManager"}})
+        .methods(boost::beast::http::verb::post)(
+            [](const crow::Request& req,
+               const std::shared_ptr<bmcweb::AsyncResp>& asyncResp) {
+                ListOfSessionIds listSessionIds;
+
+                if (!redfish::json_util::readJsonPatch(
+                        req, asyncResp->res, "SessionIDs", listSessionIds))
+                {
+                    asyncResp->res.result(
+                        boost::beast::http::status::bad_request);
+                    return;
+                }
+                handleGetLockListAPI(asyncResp, listSessionIds);
+            });
+
     BMCWEB_ROUTE(app, "/ibm/v1/HMC/BroadcastService")
         .privileges({{"ConfigureComponents", "ConfigureManager"}})
         .methods(boost::beast::http::verb::post)(
             [](const crow::Request& req,
                const std::shared_ptr<bmcweb::AsyncResp>& asyncResp) {
                 handleBroadcastService(req, asyncResp);
+            });
+
+    BMCWEB_ROUTE(app, "/ibm/v1/OCC/Control/<str>/Actions/PassThrough.Send")
+        .privileges({{"OemIBMPerformService"}})
+        .methods(boost::beast::http::verb::post)(
+            [](const crow::Request& req,
+               const std::shared_ptr<bmcweb::AsyncResp>& asyncResp,
+               const std::string& name) {
+                handlePassThrough(req, asyncResp, name);
             });
 }
 

--- a/test/include/ibm/configfile_test.cpp
+++ b/test/include/ibm/configfile_test.cpp
@@ -1,8 +1,8 @@
-// SPDX-License-Identifier: Apache-2.0
-// SPDX-FileCopyrightText: Copyright OpenBMC Authors
+#include "async_resp.hpp"
 #include "http_response.hpp"
 #include "ibm/management_console_rest.hpp"
 
+#include <memory>
 #include <string>
 
 #include <gtest/gtest.h>
@@ -14,40 +14,44 @@ namespace ibm_mc
 
 TEST(IsValidConfigFileName, FileNameValidCharReturnsTrue)
 {
-    crow::Response res;
-
-    EXPECT_TRUE(isValidConfigFileName("GoodConfigFile", res));
+    auto asyncResp = std::make_shared<bmcweb::AsyncResp>();
+    EXPECT_TRUE(
+        isValidConfigFileName("GoodConfigFile", asyncResp->res.jsonValue));
 }
 TEST(IsValidConfigFileName, FileNameInvalidCharReturnsFalse)
 {
-    crow::Response res;
+    auto asyncResp = std::make_shared<bmcweb::AsyncResp>();
 
-    EXPECT_FALSE(isValidConfigFileName("Bad@file", res));
+    EXPECT_FALSE(isValidConfigFileName("Bad@file", asyncResp->res.jsonValue));
 }
 TEST(IsValidConfigFileName, FileNameInvalidPathReturnsFalse)
 {
-    crow::Response res;
+    auto asyncResp = std::make_shared<bmcweb::AsyncResp>();
 
-    EXPECT_FALSE(isValidConfigFileName("/../../../../../etc/badpath", res));
-    EXPECT_FALSE(isValidConfigFileName("/../../etc/badpath", res));
-    EXPECT_FALSE(isValidConfigFileName("/mydir/configFile", res));
+    EXPECT_FALSE(isValidConfigFileName("/../../../../../etc/badpath",
+                                       asyncResp->res.jsonValue));
+    EXPECT_FALSE(
+        isValidConfigFileName("/../../etc/badpath", asyncResp->res.jsonValue));
+    EXPECT_FALSE(
+        isValidConfigFileName("/mydir/configFile", asyncResp->res.jsonValue));
 }
 
 TEST(IsValidConfigFileName, EmptyFileNameReturnsFalse)
 {
-    crow::Response res;
-    EXPECT_FALSE(isValidConfigFileName("", res));
+    auto asyncResp = std::make_shared<bmcweb::AsyncResp>();
+    EXPECT_FALSE(isValidConfigFileName("", asyncResp->res.jsonValue));
 }
 
 TEST(IsValidConfigFileName, SlashFileNameReturnsFalse)
 {
-    crow::Response res;
-    EXPECT_FALSE(isValidConfigFileName("/", res));
+    auto asyncResp = std::make_shared<bmcweb::AsyncResp>();
+    EXPECT_FALSE(isValidConfigFileName("/", asyncResp->res.jsonValue));
 }
 TEST(IsValidConfigFileName, FileNameMoreThan20CharReturnsFalse)
 {
-    crow::Response res;
-    EXPECT_FALSE(isValidConfigFileName("BadfileBadfileBadfile", res));
+    auto asyncResp = std::make_shared<bmcweb::AsyncResp>();
+    EXPECT_FALSE(isValidConfigFileName("BadfileBadfileBadfile",
+                                       asyncResp->res.jsonValue));
 }
 
 } // namespace ibm_mc

--- a/test/include/ibm/lock_test.cpp
+++ b/test/include/ibm/lock_test.cpp
@@ -1,0 +1,310 @@
+#include "ibm/locks.hpp"
+
+#include <cstdint>
+#include <string>
+#include <tuple>
+#include <utility>
+#include <variant>
+#include <vector>
+
+#include <gmock/gmock.h>
+#include <gtest/gtest.h>
+
+namespace crow::ibm_mc_lock
+{
+namespace
+{
+
+using SType = std::string;
+using LockRequest = std::tuple<SType, SType, SType, uint64_t, SegmentFlags>;
+using LockRequests = std::vector<LockRequest>;
+using Rc =
+    std::pair<bool, std::variant<uint32_t, std::pair<uint32_t, LockRequest>>>;
+using RcReleaseLock = std::pair<bool, std::pair<uint32_t, LockRequest>>;
+using RcGetLockList =
+    std::variant<std::string, std::vector<std::pair<uint32_t, LockRequests>>>;
+using ListOfTransactionIds = std::vector<uint32_t>;
+using RcAcquireLock = std::pair<bool, std::variant<Rc, std::pair<bool, int>>>;
+using RcReleaseLockApi = std::pair<bool, std::variant<bool, RcReleaseLock>>;
+using SessionFlags = std::pair<SType, SType>;
+using ListOfSessionIds = std::vector<std::string>;
+using ::testing::IsEmpty;
+
+class LockTest : public ::testing::Test
+{
+  protected:
+    LockRequests request;
+    LockRequests request1, request2;
+    LockRequest record;
+
+  public:
+    LockTest() :
+        // lockrequest with multiple lockrequests
+        request{{"xxxxx",
+                 "hmc-id",
+                 "Read",
+                 234,
+                 {{"DontLock", 2}, {"DontLock", 4}}},
+                {"xxxxx",
+                 "hmc-id",
+                 "Read",
+                 234,
+                 {{"DontLock", 2}, {"DontLock", 4}}}},
+        request1{{"xxxxx",
+                  "hmc-id",
+                  "Read",
+                  234,
+                  {{"DontLock", 2}, {"DontLock", 4}}}},
+        request2{{"xxxxx",
+                  "hmc-id",
+                  "Write",
+                  234,
+                  {{"LockAll", 2}, {"DontLock", 4}}}},
+        record{
+            "xxxxx", "hmc-id", "Read", 234, {{"DontLock", 2}, {"DontLock", 4}}}
+    {}
+
+    ~LockTest() override = default;
+
+    LockTest(const LockTest&) = delete;
+    LockTest(LockTest&&) = delete;
+    LockTest& operator=(const LockTest&) = delete;
+    LockTest& operator=(const LockTest&&) = delete;
+};
+
+class MockLock : public crow::ibm_mc_lock::Lock
+{
+  public:
+    bool isValidLockRequest(const LockRequest& record1) override
+    {
+        bool status = Lock::isValidLockRequest(record1);
+        return status;
+    }
+    bool isConflictRequest(const LockRequests& request) override
+    {
+        bool status = Lock::isConflictRequest(request);
+        return status;
+    }
+    Rc isConflictWithTable(const LockRequests& request) override
+    {
+        auto conflict = Lock::isConflictWithTable(request);
+        return conflict;
+    }
+    uint32_t generateTransactionId() override
+    {
+        uint32_t tid = Lock::generateTransactionId();
+        return tid;
+    }
+
+    bool validateRids(const ListOfTransactionIds& tids) override
+    {
+        bool status = Lock::validateRids(tids);
+        return status;
+    }
+    RcReleaseLock isItMyLock(const ListOfTransactionIds& tids,
+                             const SessionFlags& ids) override
+    {
+        auto status = Lock::isItMyLock(tids, ids);
+        return status;
+    }
+    friend class LockTest;
+};
+
+TEST_F(LockTest, ValidationGoodTestCase)
+{
+    MockLock lockManager;
+    const LockRequest& t = record;
+    EXPECT_TRUE(lockManager.isValidLockRequest(t));
+}
+
+TEST_F(LockTest, ValidationBadTestWithLocktype)
+{
+    MockLock lockManager;
+    // Corrupt the lock type
+    std::get<2>(record) = "rwrite";
+    const LockRequest& t = record;
+    EXPECT_FALSE(lockManager.isValidLockRequest(t));
+}
+
+TEST_F(LockTest, ValidationBadTestWithlockFlags)
+{
+    MockLock lockManager;
+    // Corrupt the lockflag
+    std::get<4>(record)[0].first = "lock";
+    const LockRequest& t = record;
+    EXPECT_FALSE(lockManager.isValidLockRequest(t));
+}
+
+TEST_F(LockTest, ValidationBadTestWithSegmentlength)
+{
+    MockLock lockManager;
+    // Corrupt the Segment length
+    std::get<4>(record)[0].second = 7;
+    const LockRequest& t = record;
+    EXPECT_FALSE(lockManager.isValidLockRequest(t));
+}
+
+TEST_F(LockTest, MultiRequestWithoutConflict)
+{
+    MockLock lockManager;
+    const LockRequests& t = request;
+    EXPECT_FALSE(lockManager.isConflictRequest(t));
+}
+
+TEST_F(LockTest, MultiRequestWithConflictduetoSameSegmentLength)
+{
+    MockLock lockManager;
+    // Corrupt the locktype
+    std::get<2>(request[0]) = "Write";
+    // Match the segment lengths to points them to lock similar kind of
+    // resource
+    std::get<4>(request[0])[0].first = "LockAll";
+    const LockRequests& t = request;
+    EXPECT_TRUE(lockManager.isConflictRequest(t));
+}
+
+TEST_F(LockTest, MultiRequestWithoutConflictduetoDifferentSegmentLength)
+{
+    MockLock lockManager;
+    // Corrupt the locktype
+    std::get<2>(request[0]) = "Write";
+    // Match the segment lengths to points them to lock similar kind of
+    // resource
+    std::get<4>(request[0])[0].first = "LockSame";
+    // Change the segment length , so that the requests are trying to lock
+    // two different kind of resources
+    std::get<4>(request[0])[0].second = 3;
+    const LockRequests& t = request;
+    // Return No Conflict
+    EXPECT_FALSE(lockManager.isConflictRequest(t));
+}
+
+TEST_F(LockTest, MultiRequestWithoutConflictduetoReadLocktype)
+{
+    MockLock lockManager;
+    // Match the segment lengths to points them to lock similar kind of
+    // resource
+    std::get<4>(request[0])[0].first = "LockAll";
+    const LockRequests& t = request;
+    // Return No Conflict
+    EXPECT_FALSE(lockManager.isConflictRequest(t));
+}
+
+TEST_F(LockTest, MultiRequestWithoutConflictduetoReadLocktypeAndLockall)
+{
+    MockLock lockManager;
+    // Match the segment lengths to points them to lock similar kind of
+    // resource
+    std::get<4>(request[0])[0].first = "LockAll";
+    std::get<4>(request[0])[1].first = "LockAll";
+    const LockRequests& t = request;
+    // Return No Conflict
+    EXPECT_FALSE(lockManager.isConflictRequest(t));
+}
+
+TEST_F(LockTest, RequestNotConflictedWithLockTableEntries)
+{
+    MockLock lockManager;
+    const LockRequests& t = request1;
+    // Insert the request1 into the lock table
+    auto rc1 = lockManager.isConflictWithTable(t);
+    // Corrupt the lock type
+    std::get<2>(request[0]) = "Read";
+    // Corrupt the lockflag
+    std::get<4>(request[0])[1].first = "LockAll";
+    const LockRequests& p = request;
+    auto rc2 = lockManager.isConflictWithTable(p);
+    // Return No Conflict
+    EXPECT_FALSE(rc2.first);
+}
+
+TEST_F(LockTest, TestGenerateTransactionIDFunction)
+{
+    MockLock lockManager;
+    uint32_t transactionId1 = lockManager.generateTransactionId();
+    uint32_t transactionId2 = lockManager.generateTransactionId();
+    EXPECT_EQ(transactionId2, ++transactionId1);
+}
+
+TEST_F(LockTest, ValidateTransactionIDsGoodTestCase)
+{
+    MockLock lockManager;
+    const LockRequests& t = request1;
+    // Insert the request1 into the lock table
+    auto rc1 = lockManager.isConflictWithTable(t);
+    std::vector<uint32_t> tids = {1};
+    const std::vector<uint32_t>& p = tids;
+    EXPECT_TRUE(lockManager.validateRids(p));
+}
+
+TEST_F(LockTest, ValidateTransactionIDsBadTestCase)
+{
+    MockLock lockManager;
+    // Insert the request1 into the lock table
+    const LockRequests& t = request1;
+    auto rc1 = lockManager.isConflictWithTable(t);
+    std::vector<uint32_t> tids = {10};
+    const std::vector<uint32_t>& p = tids;
+    EXPECT_FALSE(lockManager.validateRids(p));
+}
+
+TEST_F(LockTest, ValidateisItMyLockGoodTestCase)
+{
+    MockLock lockManager;
+    // Insert the request1 into the lock table
+    const LockRequests& t = request1;
+    auto rc1 = lockManager.isConflictWithTable(t);
+    std::vector<uint32_t> tids = {1};
+    const std::vector<uint32_t>& p = tids;
+    std::string hmcid = "hmc-id";
+    std::string sessionid = "xxxxx";
+    std::pair<SType, SType> ids = std::make_pair(hmcid, sessionid);
+    auto rc = lockManager.isItMyLock(p, ids);
+    EXPECT_TRUE(rc.first);
+}
+
+TEST_F(LockTest, ValidateisItMyLockBadTestCase)
+{
+    MockLock lockManager;
+    // Corrupt the client identifier
+    std::get<1>(request1[0]) = "randomid";
+    // Insert the request1 into the lock table
+    const LockRequests& t = request1;
+    auto rc1 = lockManager.isConflictWithTable(t);
+    std::vector<uint32_t> tids = {1};
+    const std::vector<uint32_t>& p = tids;
+    std::string hmcid = "hmc-id";
+    std::string sessionid = "random";
+    std::pair<SType, SType> ids = std::make_pair(hmcid, sessionid);
+    auto rc = lockManager.isItMyLock(p, ids);
+    EXPECT_FALSE(rc.first);
+}
+
+TEST_F(LockTest, ValidateSessionIDForGetlocklistBadTestCase)
+{
+    MockLock lockManager;
+    // Insert the request1 into the lock table
+    const LockRequests& t = request1;
+    auto rc1 = lockManager.isConflictWithTable(t);
+    std::vector<std::string> sessionid = {"random"};
+    auto status = lockManager.getLockList(sessionid);
+    auto result =
+        std::get<std::vector<std::pair<uint32_t, LockRequests>>>(status);
+    EXPECT_THAT(result, IsEmpty());
+}
+
+TEST_F(LockTest, ValidateSessionIDForGetlocklistGoodTestCase)
+{
+    MockLock lockManager;
+    // Insert the request1 into the lock table
+    const LockRequests& t = request1;
+    auto rc1 = lockManager.isConflictWithTable(t);
+    std::vector<std::string> sessionid = {"xxxxx"};
+    auto status = lockManager.getLockList(sessionid);
+    auto result =
+        std::get<std::vector<std::pair<uint32_t, LockRequests>>>(status);
+    EXPECT_EQ(result.size(), 1);
+}
+
+} // namespace
+} // namespace crow::ibm_mc_lock


### PR DESCRIPTION
This commit adds all the usecases of /ibm/v1
    1. ConfigFile multipart update
    2. Lock management fixes
    3. SignCSR feature for VMI interface
    4. Broadcast message event
