### PR TITLE
Do not remove wrong cookies on Session DELETE

### DIFF
--- a/redfish-core/lib/redfish_sessions.hpp
+++ b/redfish-core/lib/redfish_sessions.hpp
@@ -129,7 +129,8 @@ inline void
         }
     }
 
-    if (session->cookieAuth)
+    if (req.session != nullptr && req.session->uniqueId == sessionId &&
+        session->cookieAuth)
     {
         bmcweb::clearSessionCookies(asyncResp->res);
     }


### PR DESCRIPTION
Upstream is merged at https://github.com/openbmc/bmcweb/commit/8812e8becaf44d810e68ed80692c2797b2f114ac
This fixes defect 674611 

When a web interface sends a DELETE request for a session other than it's using itself the reply shouldn't ask the web browser to delete the cookies and to clear the site data.

Tested: logging in to BMC, observing the session identifier returned by POST to Sessions, then opening another private window and logging in on the same BMC, getting another session ID. Then navigating to "Security and access -> Sessions" and pressing "Disconnect" button for the session opened in the first window just deletes the session normally and the web interface of the second private window that performed the operation continued to work. Pressing "Log out" deletes the current session and the web browser gets expected cookie and site data clearing headers. Before the patch the same test made the second private window lose its cookies essentially terminating both sessions instead of just the other one.

Fixes: 29aab242f2d3 ("Send cookies to webui-vue from Sessions POST")
Change-Id: If3f81764cb825253b9d6e1c7589340e6dc018a81