### PR TITLE
1120: Dump refactor

### DIFF
--- a/redfish-core/lib/task.hpp
+++ b/redfish-core/lib/task.hpp
@@ -112,7 +112,7 @@ struct TaskData : std::enable_shared_from_this<TaskData>
         callback(std::move(handler)), matchStr(matchIn), index(idx),
         startTime(std::chrono::system_clock::to_time_t(
             std::chrono::system_clock::now())),
-        status("OK"), state("Running"), messages(nlohmann::json::array()),
+        status("OK"), state("Starting"), messages(nlohmann::json::array()),
         timer(crow::connections::systemBus->get_io_context())
 
     {}


### PR DESCRIPTION
This commit adds support for dumps. All dumps are listed under bmc or system path based on the types. The following operations are supported on dumps: GET, DELETE, GET all dumps (bmc/system), ClearLog (clears all dumps), CollectDiagnosticData (create dumps), GET on dump attachment (dump offload).

One other change is, for resource dump creation usecase where a task is started on dump creation request, the task starts with "Running" state and moves to "Completed/Cancelled".
For resource dump creation, there is validation of input parameters and this has to be notified back to the user.
So the tasks are created with "Starting" state and moved to "Running" only when the inputs are validated, else the state changes to "Cancelled/Completed". For all other dumps, the task state change will be like: "Starting" -> "Running" -> "Completed/Cancelled".

Tested By:

bmcdumpPath="Managers/bmc"
systemdumpPath="Systems/system"
[1] POST https://${bmc}/redfish/v1/<$bmcdumpPath>/LogServices/Dump/Actions/LogService.CollectDiagnosticData -d '{"DiagnosticDataType":"Manager"}' [2] POST https://${bmc}/redfish/v1/$systemdumpPath/LogServices/Dump/Actions/LogService.CollectDiagnosticData -d '{"DiagnosticDataType":"OEM", "OEMDiagnosticDataType":"Resource_<resourceID>_<pwd>"}' [3] POST https://${bmc}/redfish/v1/systemdumpPath/LogServices/Dump/Actions/LogService.CollectDiagnosticData -d '{"DiagnosticDataType":"OEM", "OEMDiagnosticDataType":"System"}' [2] GET https://${bmc}/redfish/v1/<$bmcdumpPath or $systemdumpPath>/LogServices/Dump/Entries/ [3] GET https://${bmc}/redfish/v1/<$bmcdumpPath or $systemdumpPath>/LogServices/Dump/Entries/<DumpID> [4] DELETE https://${bmc}/redfish/v1/<$bmcdumpPath or $systemdumpPath>/LogServices/Dump/Entries/<DumpID> [5] POST https://${bmc}/redfish/v1/<$bmcdumpPath or $systemdumpPath>/LogServices/Dump/Actions/LogService.ClearLog