### PR TITLE
1110: Use shared_ptr for request body (#915)

### DIFF
--- a/http/http_request.hpp
+++ b/http/http_request.hpp
@@ -19,7 +19,8 @@ namespace crow
 struct Request
 {
     using Body = boost::beast::http::request<bmcweb::HttpBody>;
-    Body req;
+    std::shared_ptr<Body> reqPtr;
+    Body& req;
 
   private:
     boost::urls::url urlBase;
@@ -31,7 +32,8 @@ struct Request
     std::shared_ptr<persistent_data::UserSession> session;
 
     std::string userRole;
-    Request(Body reqIn, std::error_code& ec) : req(std::move(reqIn))
+    Request(Body reqIn, std::error_code& ec) :
+        reqPtr(std::make_shared<Body>(std::move(reqIn))), req(*reqPtr)
     {
         if (!setUrlInfo())
         {
@@ -39,16 +41,18 @@ struct Request
         }
     }
 
-    Request(std::string_view bodyIn, std::error_code& /*ec*/) : req({}, bodyIn)
+    Request(std::string_view bodyIn, std::error_code& /*ec*/) :
+        reqPtr(std::make_shared<Body>(Body({}, bodyIn))), req(*reqPtr)
     {}
 
-    Request() = default;
+    Request() : reqPtr(std::make_shared<Body>()), req(*reqPtr) {}
 
     Request(const Request& other) = default;
+
     Request(Request&& other) = default;
 
-    Request& operator=(const Request&) = default;
-    Request& operator=(Request&&) = default;
+    Request& operator=(const Request&) = delete;
+    Request& operator=(const Request&&) = delete;
     ~Request() = default;
 
     void addHeader(std::string_view key, std::string_view value)


### PR DESCRIPTION
The `req` member data of the class `Request` is defined as a simple value.

Even if the commit 102a4cdacb0a6d8c8c3c97e10bedbb66000ac5dc [1] changes `Request` as `shared_ptr<Request>`, but still lower functions (eg. route) use `crow::Request`.  This causes the memory deep-copy of the request body in handling `handleIfMatch()` [2].

This would cause the excessive memory consumption if the request body is too large (like the case of code update).

```
struct Request
{
    using Body = boost::beast::http::request<bmcweb::HttpBody>;
    Body req;
...
}
```

```
    getReqAsyncResp->res.setCompleteRequestHandler(std::bind_front(
        afterIfMatchRequest, std::ref(app), asyncResp,
        std::make_shared<crow::Request>(req), std::move(ifMatch)));
```

To address those issues, this commit is suggesting to use `shared_ptr` to the body content of`Request` so that the copy of `Request` becomes less overhead (as it is only incrementing ref-count to shared_ptr), and its content can be valid until all related code references are done.

So, by using `shared_ptr` to the body of `Request', it can captured by-value for lambda with less overhead (than deep copying).

```
struct Request
{
    using Body = boost::beast::http::request<bmcweb::HttpBody>;
    shared_ptr<Body> reqPtr;
    Body& req;   // This will be pointing to the *reqPtr
...
}
```

For example, there are a few lambda captures of `crow::Request &req' [3][4].

Tested:

- Redfish Service Validator passes

- Debug logging at `completeRequest()` shows the correct `req` value, esp it is done on PATCH.

For example,
```
curl -k -d '{"PowerRestorePolicy":"LastState"}'  -X PATCH https://${bmc}:18080/redfish/v1/Systems/system
```

- Try curl --http2 on GET and PATCH

[1] https://gerrit.openbmc.org/c/openbmc/bmcweb/+/71006
[2] https://github.com/openbmc/bmcweb/blob/1940677a35870b51eaffc50406609124668743d0/redfish-core/include/query.hpp#L107C1-L110C1
[3] https://github.com/ibm-openbmc/bmcweb/blob/2a86e0c5768b0010aa0d87617cb94db4c2433513/redfish-core/lib/account_service.hpp#L2718
[4] https://github.com/ibm-openbmc/bmcweb/blob/2a86e0c5768b0010aa0d87617cb94db4c2433513/redfish-core/lib/account_service.hpp#L2922

Change-Id: I40a5cc224c1d12e6ee65c99963b9bc6b46379226