### PR TITLE
1110: Avoid Request copy with If-Match ETag

### DIFF
--- a/http/http_request.hpp
+++ b/http/http_request.hpp
@@ -16,7 +16,7 @@
 namespace crow
 {
 
-struct Request
+struct Request : std::enable_shared_from_this<Request>
 {
     using Body = boost::beast::http::request<bmcweb::HttpBody>;
     Body req;

--- a/redfish-core/include/query.hpp
+++ b/redfish-core/include/query.hpp
@@ -101,12 +101,12 @@ inline bool handleIfMatch(crow::App& app, const crow::Request& req,
     std::shared_ptr<bmcweb::AsyncResp> getReqAsyncResp =
         std::make_shared<bmcweb::AsyncResp>();
 
-    // Ideally we would have a shared_ptr to the original Request which we could
-    // modify to remove the If-Match and restart it. But instead we have to make
-    // a full copy to restart it.
-    getReqAsyncResp->res.setCompleteRequestHandler(std::bind_front(
-        afterIfMatchRequest, std::ref(app), asyncResp,
-        std::make_shared<crow::Request>(req), std::move(ifMatch)));
+    // NOLINTBEGIN(cppcoreguidelines-pro-type-const-cast)
+    getReqAsyncResp->res.setCompleteRequestHandler(
+        std::bind_front(afterIfMatchRequest, std::ref(app), asyncResp,
+                        const_cast<crow::Request*>(&req)->shared_from_this(),
+                        std::move(ifMatch)));
+    // NOLINTEND(cppcoreguidelines-pro-type-const-cast)
 
     app.handle(getReq, getReqAsyncResp);
     return false;


### PR DESCRIPTION
The commit 102a4cdacb0a6d8c8c3c97e10bedbb66000ac5dc [1] changes `Request` as `shared_ptr<Request>`, but `handleIfMatch()` still does the full copy of Request with If-Match with non-empty ETag [2], whether ETag matches or not.

For example,
```
curl   -k -X GET https://${bmc}/redfish/v1/AccountService/Accounts/readonly -etag-save etag.out
ETAG=`cat etag.out`;  echo $ETAG

redfishtool.py raw -r ${bmc} -u ${user} -p ${pass} \
    -S Always PATCH /redfish/v1/AccountService/Accounts/readonly \
    --data='{"RoleId":"Administrator"}'
```
Or,
```
curl   -k -H "Content-Type: application/json" -H "If-Match:${ETAG}" \
    -X PATCH ttps://${bmc}/redfish/v1/AccountService/Accounts/readonly \
    -d '{"RoleId":"Administrator"}'
```

This could also cause the more memory consumption if accidentally used for If-Match.

```
curl  -H "If-Match: ${ETAG}"  -k -H "Content-Type: application/octet-stream" \
     -X POST -T ${image}  https://${bmc}/redfish/v1/UpdateService/update
```

This can be avoided by accessing shared_ptr from Request, as Request is created and managed as a shared_ptr.

With the combination of
https://gerrit.openbmc.org/c/openbmc/bmcweb/+/71547, the full copy of Request can be further reduced in the other areas.

Tested:
- bmcweb runs good on GET/etag
- Redfish Service Validator passes

[1] https://gerrit.openbmc.org/c/openbmc/bmcweb/+/71006
[2] https://github.com/openbmc/bmcweb/blob/1940677a35870b51eaffc50406609124668743d0/redfish-core/include/query.hpp#L107C1-L110C1

Change-Id: Ic4ccb426bd2ee5a4932874ac4fbd1022266455f9