### PR TITLE
1120: Fix CI errors

### DIFF
--- a/http/logging.hpp
+++ b/http/logging.hpp
@@ -14,6 +14,7 @@
 #include <string>
 #include <string_view>
 #include <type_traits>
+#include <utility>
 
 // NOLINTBEGIN(readability-convert-member-functions-to-static, cert-dcl58-cpp)
 template <>
@@ -46,7 +47,7 @@ enum class LogLevel
 
 constexpr int toSystemdLevel(LogLevel level)
 {
-    std::array<std::pair<LogLevel, int>, 5> mapping{
+    constexpr std::array<std::pair<LogLevel, int>, 5> mapping{
         {// EMERGENCY 0
          // ALERT 1
          {LogLevel::Critical, 2},
@@ -56,7 +57,7 @@ constexpr int toSystemdLevel(LogLevel level)
          {LogLevel::Info, 6},
          {LogLevel::Debug, 7}}};
 
-    auto* it = std::ranges::find_if(
+    const auto* it = std::ranges::find_if(
         mapping, [level](const std::pair<LogLevel, int>& elem) {
             return elem.first == level;
         });

--- a/redfish-core/lib/fabric_adapters.hpp
+++ b/redfish-core/lib/fabric_adapters.hpp
@@ -24,6 +24,7 @@
 #include <boost/beast/http/verb.hpp>
 #include <boost/system/error_code.hpp>
 #include <boost/url/format.hpp>
+#include <sdbusplus/message/native_types.hpp>
 #include <sdbusplus/unpack_properties.hpp>
 
 #include <array>

--- a/redfish-core/lib/pcie.hpp
+++ b/redfish-core/lib/pcie.hpp
@@ -8,6 +8,7 @@
 
 #include "app.hpp"
 #include "async_resp.hpp"
+#include "dbus_singleton.hpp"
 #include "dbus_utility.hpp"
 #include "error_messages.hpp"
 #include "generated/enums/pcie_device.hpp"
@@ -18,6 +19,7 @@
 #include "query.hpp"
 #include "registries/privilege_registry.hpp"
 #include "utils/dbus_utils.hpp"
+#include "utils/json_utils.hpp"
 #include "utils/pcie_util.hpp"
 
 #include <asm-generic/errno.h>
@@ -25,8 +27,10 @@
 #include <boost/beast/http/field.hpp>
 #include <boost/beast/http/verb.hpp>
 #include <boost/url/format.hpp>
+#include <sdbusplus/asio/property.hpp>
 #include <sdbusplus/unpack_properties.hpp>
 
+#include <algorithm>
 #include <array>
 #include <charconv>
 #include <cstddef>
@@ -42,7 +46,6 @@
 #include <system_error>
 #include <utility>
 #include <variant>
-#include <vector>
 
 namespace redfish
 {

--- a/redfish-core/lib/pcie_slots.hpp
+++ b/redfish-core/lib/pcie_slots.hpp
@@ -17,6 +17,7 @@
 #include "registries/privilege_registry.hpp"
 #include "utils/chassis_utils.hpp"
 #include "utils/dbus_utils.hpp"
+#include "utils/json_utils.hpp"
 #include "utils/pcie_util.hpp"
 
 #include <asm-generic/errno.h>
@@ -32,6 +33,7 @@
 #include <algorithm>
 #include <array>
 #include <cstddef>
+#include <cstdint>
 #include <functional>
 #include <map>
 #include <memory>
@@ -345,9 +347,9 @@ inline void afterGetValidPCIeSlotList(
 inline void getValidPCIeSlotList(
     const std::shared_ptr<bmcweb::AsyncResp>& asyncResp,
     const std::string& chassisID, const std::string& chassisPath,
-    std::function<void(
+    const std::function<void(
         const boost::system::error_code&,
-        const std::vector<std::pair<std::string, std::string>>&)>&& callback)
+        const std::vector<std::pair<std::string, std::string>>&)>& callback)
 {
     BMCWEB_LOG_DEBUG("Get properties for PCIeSlots associated to chassis = {}",
                      chassisID);

--- a/redfish-core/lib/service_root.hpp
+++ b/redfish-core/lib/service_root.hpp
@@ -7,32 +7,33 @@
 
 #include "app.hpp"
 #include "async_resp.hpp"
+#include "dbus_singleton.hpp"
 #include "dbus_utility.hpp"
+#include "error_messages.hpp"
 #include "http_request.hpp"
+#include "logging.hpp"
 #include "persistent_data.hpp"
 #include "query.hpp"
 #include "registries/privilege_registry.hpp"
 #include "utils/dbus_utils.hpp"
-#include "utils/systemd_utils.hpp"
 
 #include <boost/beast/http/field.hpp>
 #include <boost/beast/http/verb.hpp>
 #include <boost/url/format.hpp>
 #include <nlohmann/json.hpp>
-#include <persistent_data.hpp>
-#include <query.hpp>
-#include <registries/privilege_registry.hpp>
 #include <sdbusplus/asio/property.hpp>
 #include <sdbusplus/unpack_properties.hpp>
-#include <utils/systemd_utils.hpp>
 #include <utils/time_utils.hpp>
 
+#include <algorithm>
 #include <array>
 #include <functional>
 #include <memory>
 #include <ranges>
 #include <string>
 #include <string_view>
+#include <utility>
+#include <vector>
 
 namespace redfish
 {


### PR DESCRIPTION
This fixes the clang-tidy issues.

This PR matches with upstream commits
- https://gerrit.openbmc.org/c/openbmc/bmcweb/+/78267
- https://gerrit.openbmc.org/c/openbmc/bmcweb/+/77538
- 
Tested: 
- It compiles
- It passes the local CI 