### PR TITLE
Link Fabric adapter to PCIeDevice schema

### DIFF
--- a/include/dbus_utility.hpp
+++ b/include/dbus_utility.hpp
@@ -66,9 +66,11 @@ using DBusInterfacesMap =
 using ManagedObjectType =
     std::vector<std::pair<sdbusplus::message::object_path, DBusInterfacesMap>>;
 
+// List of interfaces
+using InterfaceList = std::vector<std::string>;
+
 // Map of service name to list of interfaces
-using MapperServiceMap =
-    std::vector<std::pair<std::string, std::vector<std::string>>>;
+using MapperServiceMap = std::vector<std::pair<std::string, InterfaceList>>;
 
 // Map of object paths to MapperServiceMaps
 using MapperGetSubTreeResponse =

--- a/redfish-core/lib/fabric_adapters.hpp
+++ b/redfish-core/lib/fabric_adapters.hpp
@@ -27,6 +27,7 @@
 #include <sdbusplus/message/native_types.hpp>
 #include <sdbusplus/unpack_properties.hpp>
 
+#include <algorithm>
 #include <array>
 #include <functional>
 #include <memory>
@@ -199,11 +200,37 @@ inline void afterDoCheckFabricAdapterChassis(
         messages::internalError(asyncResp->res);
         return;
     }
-
     sdbusplus::message::object_path path(chassisPaths[0]);
     std::string chassisName = path.filename();
 
     callback(chassisName, pcieSlotPaths);
+}
+
+inline void linkAsPCIeDevice(
+    const std::shared_ptr<bmcweb::AsyncResp>& asyncResp,
+    const std::string& fabricAdapterPath)
+{
+    const std::string pcieDeviceName =
+        sdbusplus::message::object_path(fabricAdapterPath).filename();
+
+    if (pcieDeviceName.empty())
+    {
+        BMCWEB_LOG_ERROR("Failed to find / in pcie device path");
+        messages::internalError(asyncResp->res);
+        return;
+    }
+
+    nlohmann::json::object_t device;
+    nlohmann::json::array_t deviceArray;
+
+    device["@odata.id"] = boost::urls::format(
+        "/redfish/v1/Systems/system/PCIeDevices/{}", pcieDeviceName);
+
+    deviceArray.emplace_back(device);
+
+    asyncResp->res.jsonValue["Links"]["PCIeDevices@odata.count"] =
+        deviceArray.size();
+    asyncResp->res.jsonValue["Links"]["PCIeDevices"] = std::move(deviceArray);
 }
 
 inline void doCheckFabricAdapterChassis(
@@ -275,7 +302,8 @@ inline void getFabricAdapterPCIeSlots(
 inline void doAdapterGet(
     const std::shared_ptr<bmcweb::AsyncResp>& asyncResp,
     const std::string& systemName, const std::string& adapterId,
-    const std::string& fabricAdapterPath, const std::string& serviceName)
+    const std::string& fabricAdapterPath, const std::string& serviceName,
+    const dbus::utility::InterfaceList& interfaces)
 {
     asyncResp->res.addHeader(
         boost::beast::http::field::link,
@@ -307,21 +335,32 @@ inline void doAdapterGet(
     getFabricAdapterState(asyncResp, serviceName, fabricAdapterPath);
     getFabricAdapterHealth(asyncResp, serviceName, fabricAdapterPath);
     getLocationIndicatorActive(asyncResp, fabricAdapterPath);
+
+    // if the adapter also implements this interface, link the adapter schema to
+    // PCIeDevice schema for this adapter.
+    if (std::ranges::find(interfaces,
+                          "xyz.openbmc_project.Inventory.Item.PCIeDevice") !=
+        interfaces.end())
+    {
+        linkAsPCIeDevice(asyncResp, fabricAdapterPath);
+    }
 }
 
 inline void afterGetValidFabricAdapterPath(
     const std::string& adapterId,
-    std::function<void(const boost::system::error_code&,
-                       const std::string& fabricAdapterPath,
-                       const std::string& serviceName)>& callback,
+    std::function<void(
+        const boost::system::error_code&, const std::string& fabricAdapterPath,
+        const std::string& serviceName,
+        const dbus::utility::InterfaceList& interfaces)>& callback,
     const boost::system::error_code& ec,
     const dbus::utility::MapperGetSubTreeResponse& subtree)
 {
     std::string fabricAdapterPath;
     std::string serviceName;
+    dbus::utility::InterfaceList interfaces;
     if (ec)
     {
-        callback(ec, fabricAdapterPath, serviceName);
+        callback(ec, fabricAdapterPath, serviceName, interfaces);
         return;
     }
 
@@ -333,17 +372,19 @@ inline void afterGetValidFabricAdapterPath(
         {
             fabricAdapterPath = adapterPath;
             serviceName = serviceMap.begin()->first;
+            interfaces = serviceMap.begin()->second;
             break;
         }
     }
-    callback(ec, fabricAdapterPath, serviceName);
+    callback(ec, fabricAdapterPath, serviceName, interfaces);
 }
 
 inline void getValidFabricAdapterPath(
     const std::string& adapterId,
-    std::function<void(const boost::system::error_code& ec,
-                       const std::string& fabricAdapterPath,
-                       const std::string& serviceName)>&& callback)
+    std::function<void(
+        const boost::system::error_code& ec,
+        const std::string& fabricAdapterPath, const std::string& serviceName,
+        const dbus::utility::InterfaceList& interfaces)>&& callback)
 {
     constexpr std::array<std::string_view, 1> interfaces{
         "xyz.openbmc_project.Inventory.Item.FabricAdapter"};
@@ -356,7 +397,8 @@ inline void afterHandleFabricAdapterGet(
     const std::shared_ptr<bmcweb::AsyncResp>& asyncResp,
     const std::string& systemName, const std::string& adapterId,
     const boost::system::error_code& ec, const std::string& fabricAdapterPath,
-    const std::string& serviceName)
+    const std::string& serviceName,
+    const dbus::utility::InterfaceList& interfaces)
 {
     if (ec)
     {
@@ -378,7 +420,7 @@ inline void afterHandleFabricAdapterGet(
         return;
     }
     doAdapterGet(asyncResp, systemName, adapterId, fabricAdapterPath,
-                 serviceName);
+                 serviceName, interfaces);
 }
 
 inline void handleFabricAdapterGet(
@@ -412,7 +454,8 @@ inline void afterHandleFabricAdapterPatch(
     const std::shared_ptr<bmcweb::AsyncResp>& asyncResp,
     const std::string& adapterId, std::optional<bool> locationIndicatorActive,
     const boost::system::error_code& ec, const std::string& fabricAdapterPath,
-    const std::string& serviceName)
+    const std::string& serviceName,
+    [[maybe_unused]] const dbus::utility::InterfaceList& interfaces)
 {
     if (ec)
     {
@@ -549,7 +592,8 @@ inline void handleFabricAdapterCollectionHead(
 inline void afterHandleFabricAdapterHead(
     const std::shared_ptr<bmcweb::AsyncResp>& asyncResp,
     const std::string& adapterId, const boost::system::error_code& ec,
-    const std::string& fabricAdapterPath, const std::string& serviceName)
+    const std::string& fabricAdapterPath, const std::string& serviceName,
+    const dbus::utility::InterfaceList& interfaces)
 {
     if (ec)
     {
@@ -564,7 +608,7 @@ inline void afterHandleFabricAdapterHead(
         messages::internalError(asyncResp->res);
         return;
     }
-    if (fabricAdapterPath.empty() || serviceName.empty())
+    if (fabricAdapterPath.empty() || serviceName.empty() || interfaces.empty())
     {
         BMCWEB_LOG_WARNING("Adapter not found");
         messages::resourceNotFound(asyncResp->res, "FabricAdapter", adapterId);


### PR DESCRIPTION
This commit implements changes to populate link to PCIeDevice schema in case the given Fabric adapter also implements PCIeDevice interface.

Test:

Validator has been executed and no new error was found.

Sample Output:
{
  "@odata.id": "/redfish/v1/Systems/system/FabricAdapters/pcie_card8",
  "@odata.type": "#FabricAdapter.v1_4_0.FabricAdapter",
  "Id": "pcie_card8",
  "Links": {
    "PCIeDevices": [
      {
        "@odata.id": "/redfish/v1/Systems/system/PCIeDevices/pcie_card8"
      }
    ],
    "PCIeDevices@odata.count": 1
  },
  "Location": {
    "PartLocation": {
      "ServiceLabel": "U78DB.ND0.WZS000G-P0-C8"
    }
  },
  "Name": "Fabric Adapter",
  "Status": {
    "Health": "OK",
    "State": "Absent"
  }
}

Change-Id: I473f7800230e09157d856f4daf4f34f7fb7addc5