### PR TITLE
1120: Add Link PCIeSlot from PCIeDevices (#592)(#961)(#1100)

### DIFF
--- a/redfish-core/schema/oem/ibm/csdl/IBMPCIeDevice_v1.xml
+++ b/redfish-core/schema/oem/ibm/csdl/IBMPCIeDevice_v1.xml
@@ -39,6 +39,14 @@
           <Annotation Term="OData.LongDescription" String="A true value resets the PCIe Link."/>
         </Property>
       </ComplexType>
+
+      <ComplexType Name="PCIeLinks" BaseType="Resource.OemObject">
+        <Property Name="PCIeSlot" Type="Resource.Resource">
+          <Annotation Term="OData.Permissions" EnumMember="OData.Permission/Read"/>
+          <Annotation Term="OData.Description" String="PCIe Slot Link"/>
+          <Annotation Term="OData.LongDescription" String="Represent PCIe Slot Link which has all PCIe device list."/>
+        </Property>
+      </ComplexType>
     </Schema>
   </edmx:DataServices>
 </edmx:Edmx>

--- a/redfish-core/schema/oem/ibm/json-schema/IBMPCIeDevice.v1_0_0.json
+++ b/redfish-core/schema/oem/ibm/json-schema/IBMPCIeDevice.v1_0_0.json
@@ -60,6 +60,33 @@
                 }
             },
             "type": "object"
+        },
+        "PCIeLinks": {
+            "additionalProperties": true,
+            "description": "Oem link properties for IBM.",
+            "patternProperties": {
+                "^([a-zA-Z_][a-zA-Z0-9_]*)?@(odata|Redfish|Message)\\.[a-zA-Z_][a-zA-Z0-9_]*$": {
+                    "description": "This property shall specify a valid odata or Redfish property.",
+                    "type": [
+                        "array",
+                        "boolean",
+                        "integer",
+                        "number",
+                        "null",
+                        "object",
+                        "string"
+                    ]
+                }
+            },
+            "properties": {
+                "PCIeSlot": {
+                    "description": "PCIe Slot Link",
+                    "longDescription": "Represent PCIe Slot Link which has all PCIe device list.",
+                    "readonly": true,
+                    "type": "object"
+                }
+            },
+            "type": "object"
         }
     },
     "owningEntity": "IBM",


### PR DESCRIPTION
This commit allows us to associate the PCIe device with PCIe Slot. PCIe Slot doesn't have an individual route path, which provides a unique association with the PCIe device. As a solution, bmcweb includes a stander route path with all PCIe Slot information, and based on Device naming information users can determine which slot it is.

For example, "Links|Oem|IBM|PCIeSlot" property will be added like

Tested:

- GET PCIeDevice and check whether it has a link to PCIeSlot
```
curl -k -X GET https://${bmc}:18080/redfish/v1/Systems/system/PCIeDevices/pcie_card1
{
  "@odata.id": "/redfish/v1/Systems/system/PCIeDevices/pcie_card1",
  "@odata.type": "#PCIeDevice.v1_9_0.PCIeDevice",
  "Id": "pcie_card1",
  "Links": {
    "Oem": {
      "IBM": {
        "@odata.type": "#IBMPCIeDevice.v1_0_0.PCIeLinks",
        "PCIeSlot": {
          "@odata.id": "/redfish/v1/Chassis/chassis/PCIeSlots"
        }
      }
    }
  },
...
}
```
- Redfish Service Validator passes