### PR TITLE
Bump the max password length to 64 (#437)

### DIFF
--- a/redfish-core/lib/account_service.hpp
+++ b/redfish-core/lib/account_service.hpp
@@ -1499,7 +1499,7 @@ inline void handleAccountServiceGet(
     json["Name"] = "Account Service";
     json["Description"] = "Account Service";
     json["ServiceEnabled"] = true;
-    json["MaxPasswordLength"] = 20;
+    json["MaxPasswordLength"] = 64;
     json["Accounts"]["@odata.id"] = "/redfish/v1/AccountService/Accounts";
     json["Roles"]["@odata.id"] = "/redfish/v1/AccountService/Roles";
     json["HTTPBasicAuth"] = authMethodsConfig.basic


### PR DESCRIPTION
As mentioned in SW556104, Redfish accepts a password greater than 20 chars.

The 20 char limit comes from IPMI which is enabled upstream.

Downstream we have IPMI disabled be default, so up this limit to 64.

Due to that, at this time, this is a downstream only change.

The GUI will then "Read the ManagerAccount object via GET /redfish/v1/AccountService/Accounts/<USER> and look at the AccountTypes property. If AccountTypes contains the "IPMI" AccountType, know that MaxPasswordLength is effectively 20 for this user."

64 was choosen because it gives sufficient randomness for all practical purposes.

It makes sense the limit reflects the default.
This limit is on the Account Service, not the account, hence why we can't change this per account.

Tested: None. Code review only.