### PR TITLE
Limit Query Expand to 3

### DIFF
--- a/redfish-core/include/utils/query_param.hpp
+++ b/redfish-core/include/utils/query_param.hpp
@@ -291,6 +291,12 @@ inline bool getExpandType(std::string_view value, Query& query)
     {
         return false;
     }
+
+    if (query.expandLevel > 3)
+    {
+        return false;
+    }
+
     value.remove_prefix(
         static_cast<size_t>(std::distance(value.begin(), it.ptr)));
     return value == ")";

--- a/redfish-core/lib/service_root.hpp
+++ b/redfish-core/lib/service_root.hpp
@@ -210,10 +210,10 @@ inline void handleServiceRootGetImpl(
 
     protocolFeatures["ExpandQuery"]["ExpandAll"] =
         BMCWEB_INSECURE_ENABLE_REDFISH_QUERY;
-    // This is the maximum level defined in ServiceRoot.v1_13_0.json
+    // This is the maximum level is defined by us
     if constexpr (BMCWEB_INSECURE_ENABLE_REDFISH_QUERY)
     {
-        protocolFeatures["ExpandQuery"]["MaxLevels"] = 6;
+        protocolFeatures["ExpandQuery"]["MaxLevels"] = 3;
     }
     protocolFeatures["ExpandQuery"]["Levels"] =
         BMCWEB_INSECURE_ENABLE_REDFISH_QUERY;

--- a/test/redfish-core/include/utils/query_param_test.cpp
+++ b/test/redfish-core/include/utils/query_param_test.cpp
@@ -530,8 +530,8 @@ TEST(QueryParams, GetExpandType)
     EXPECT_TRUE(getExpandType(".", query));
     EXPECT_EQ(query.expandLevel, 1);
 
-    EXPECT_TRUE(getExpandType(".($levels=42)", query));
-    EXPECT_EQ(query.expandLevel, 42);
+    // We have a limit of 3
+    EXPECT_FALSE(getExpandType(".($levels=42)", query));
 
     // Overflow
     EXPECT_FALSE(getExpandType(".($levels=256)", query));

--- a/test/redfish-core/lib/service_root_test.cpp
+++ b/test/redfish-core/lib/service_root_test.cpp
@@ -92,7 +92,7 @@ void assertServiceRootGet(crow::Response& res)
     {
         EXPECT_EQ(json["ProtocolFeaturesSupported"]["ExpandQuery"].size(), 5);
         EXPECT_EQ(json["ProtocolFeaturesSupported"]["ExpandQuery"]["MaxLevels"],
-                  6);
+                  3);
     }
     else
     {


### PR DESCRIPTION
This was supposed to be done for 1050 but somehow was missed.

upstream this is https://gerrit.openbmc.org/c/openbmc/bmcweb/+/78192 

Tested: Any expand greater than 3 rejects.