### PR TITLE
Remove cookie clear (#1043)

### DIFF
--- a/include/cookies.hpp
+++ b/include/cookies.hpp
@@ -27,7 +27,6 @@ inline void clearSessionCookies(crow::Response& res)
                   "SESSION="
                   "; Path=/; SameSite=Strict; Secure; HttpOnly; "
                   "expires=Thu, 01 Jan 1970 00:00:00 GMT");
-    res.addHeader("Clear-Site-Data", R"("cache","cookies","storage")");
 }
 
 } // namespace bmcweb


### PR DESCRIPTION
asyncResp->res.addHeader("Clear-Site-Data",
R"("cache","cookies","storage")");

https://github.com/openbmc/bmcweb/commit/d8139c683a2f42c47ed913b731becc6cd681e2dd https://github.com/ibm-openbmc/bmcweb/blame/1050/include/login_routes.hpp#L255

Causes the browsers to clear the cahce, cookie, and storage for that site.
https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Clear-Site-Data

That is a problem for when using the GUI from the HMC proxy because the HMC is also using the cookie and storage from the same URI. The proxy works by going to a URI and the HMC proxing it forward/reverse for the eBMC GUI.