### PR TITLE
Implement LocationIndicatorActive for CPU resource (#937)

### DIFF
--- a/Redfish.md
+++ b/Redfish.md
@@ -1002,6 +1002,7 @@ other.
 #### Processor
 
 - InstructionSet
+- LocationIndicatorActive
 - Manufacturer
 - MaxSpeedMHz
 - PartNumber

--- a/redfish-core/lib/processor.hpp
+++ b/redfish-core/lib/processor.hpp
@@ -12,6 +12,7 @@
 #include "generated/enums/processor.hpp"
 #include "generated/enums/resource.hpp"
 #include "http_request.hpp"
+#include "led.hpp"
 #include "logging.hpp"
 #include "query.hpp"
 #include "registries/privilege_registry.hpp"
@@ -728,20 +729,66 @@ inline void getCpuUniqueId(const std::shared_ptr<bmcweb::AsyncResp>& asyncResp,
         });
 }
 
+inline void handleProcessorSubtree(
+    const std::shared_ptr<bmcweb::AsyncResp>& asyncResp,
+    const std::string& processorId,
+    const std::function<
+        void(const std::string& objectPath,
+             const dbus::utility::MapperServiceMap& serviceMap)>& callback,
+    const boost::system::error_code& ec,
+    const dbus::utility::MapperGetSubTreeResponse& subtree)
+{
+    if (ec)
+    {
+        BMCWEB_LOG_ERROR("DBUS response error: {}", ec);
+        messages::internalError(asyncResp->res);
+        return;
+    }
+    for (const auto& [objectPath, serviceMap] : subtree)
+    {
+        // Ignore any objects which don't end with our desired cpu name
+        sdbusplus::message::object_path path(objectPath);
+        if (path.filename() == processorId)
+        {
+            // Filter out objects that don't have the CPU-specific
+            // interfaces to make sure we can return 404 on non-CPUs
+            // (e.g. /redfish/../Processors/dimm0)
+            for (const auto& [serviceName, interfaceList] : serviceMap)
+            {
+                if (std::ranges::find_first_of(interfaceList,
+                                               processorInterfaces) !=
+                    std::end(interfaceList))
+                {
+                    // Process the first object which matches cpu name and
+                    // required interfaces, and potentially ignore any other
+                    // matching objects. Assume all interfaces we want to
+                    // process must be on the same object path.
+
+                    callback(objectPath, serviceMap);
+                    return;
+                }
+            }
+        }
+    }
+    messages::resourceNotFound(asyncResp->res, "Processor", processorId);
+}
+
 /**
  * Find the D-Bus object representing the requested Processor, and call the
  * handler with the results. If matching object is not found, add 404 error to
  * response and don't call the handler.
  *
- * @param[in,out]   resp            Async HTTP response.
+ * @param[in,out]   asyncResp       Async HTTP response.
  * @param[in]       processorId     Redfish Processor Id.
- * @param[in]       handler         Callback to continue processing request upon
+ * @param[in]       callback        Callback to continue processing request upon
  *                                  successfully finding object.
  */
-template <typename Handler>
-inline void getProcessorObject(const std::shared_ptr<bmcweb::AsyncResp>& resp,
-                               const std::string& processorId,
-                               Handler&& handler)
+inline void getProcessorObject(
+    const std::shared_ptr<bmcweb::AsyncResp>& asyncResp,
+    const std::string& processorId,
+    std::function<void(const std::string& objectPath,
+                       const dbus::utility::MapperServiceMap& serviceMap)>&&
+        callback)
 {
     BMCWEB_LOG_DEBUG("Get available system processor resources.");
 
@@ -758,52 +805,11 @@ inline void getProcessorObject(const std::shared_ptr<bmcweb::AsyncResp>& resp,
         "xyz.openbmc_project.Control.Power.Throttle"};
     dbus::utility::getSubTree(
         "/xyz/openbmc_project/inventory", 0, interfaces,
-        [resp, processorId, handler = std::forward<Handler>(handler)](
+        [asyncResp, processorId, callback{std::move(callback)}](
             const boost::system::error_code& ec,
             const dbus::utility::MapperGetSubTreeResponse& subtree) {
-            if (ec)
-            {
-                BMCWEB_LOG_DEBUG("DBUS response error: {}", ec);
-                messages::internalError(resp->res);
-                return;
-            }
-            for (const auto& [objectPath, serviceMap] : subtree)
-            {
-                // Ignore any objects which don't end with our desired cpu name
-                if (!objectPath.ends_with(processorId))
-                {
-                    continue;
-                }
-
-                bool found = false;
-                // Filter out objects that don't have the CPU-specific
-                // interfaces to make sure we can return 404 on non-CPUs
-                // (e.g. /redfish/../Processors/dimm0)
-                for (const auto& [serviceName, interfaceList] : serviceMap)
-                {
-                    if (std::ranges::find_first_of(interfaceList,
-                                                   processorInterfaces) !=
-                        std::end(interfaceList))
-                    {
-                        found = true;
-                        break;
-                    }
-                }
-
-                if (!found)
-                {
-                    continue;
-                }
-
-                // Process the first object which does match our cpu name and
-                // required interfaces, and potentially ignore any other
-                // matching objects. Assume all interfaces we want to process
-                // must be on the same object path.
-
-                handler(objectPath, serviceMap);
-                return;
-            }
-            messages::resourceNotFound(resp->res, "Processor", processorId);
+            handleProcessorSubtree(asyncResp, processorId, callback, ec,
+                                   subtree);
         });
 }
 
@@ -860,6 +866,10 @@ inline void getProcessorData(
             else if (interface == "xyz.openbmc_project.Control.Power.Throttle")
             {
                 getThrottleProperties(asyncResp, serviceName, objectPath);
+            }
+            else if (interface == "xyz.openbmc_project.Association.Definitions")
+            {
+                getLocationIndicatorActive(asyncResp, objectPath);
             }
         }
     }
@@ -1061,6 +1071,69 @@ inline void handleProcessorCollectionHead(
     asyncResp->res.addHeader(
         boost::beast::http::field::link,
         "</redfish/v1/JsonSchemas/ProcessorCollection/ProcessorCollection.json>; rel=describedby");
+}
+
+inline void doPatchProcessor(
+    const std::shared_ptr<bmcweb::AsyncResp>& asyncResp,
+    const std::string& processorId,
+    const std::optional<std::string>& appliedConfigUri,
+    std::optional<bool> locationIndicatorActive, const std::string& objectPath,
+    const dbus::utility::MapperServiceMap& serviceMap)
+{
+    if (appliedConfigUri)
+    {
+        patchAppliedOperatingConfig(asyncResp, processorId, *appliedConfigUri,
+                                    objectPath, serviceMap);
+    }
+
+    if (locationIndicatorActive)
+    {
+        // Utility function handles reporting errors
+        setLocationIndicatorActive(asyncResp, objectPath,
+                                   *locationIndicatorActive);
+    }
+}
+
+inline void handleProcessorPatch(
+    App& app, const crow::Request& req,
+    const std::shared_ptr<bmcweb::AsyncResp>& asyncResp,
+    const std::string& systemName, const std::string& processorId)
+{
+    if (!redfish::setUpRedfishRoute(app, req, asyncResp))
+    {
+        return;
+    }
+    if constexpr (BMCWEB_EXPERIMENTAL_REDFISH_MULTI_COMPUTER_SYSTEM)
+    {
+        // Option currently returns no systems.  TBD
+        messages::resourceNotFound(asyncResp->res, "ComputerSystem",
+                                   systemName);
+        return;
+    }
+    if (systemName != BMCWEB_REDFISH_SYSTEM_URI_NAME)
+    {
+        messages::resourceNotFound(asyncResp->res, "ComputerSystem",
+                                   systemName);
+        return;
+    }
+
+    std::optional<std::string> appliedConfigUri;
+    std::optional<bool> locationIndicatorActive;
+    if (!json_util::readJsonPatch(
+            req, asyncResp->res,                                  //
+            "AppliedOperatingConfig/@odata.id", appliedConfigUri, //
+            "LocationIndicatorActive", locationIndicatorActive    //
+            ))
+    {
+        return;
+    }
+
+    // Check for 404 and find matching D-Bus object, then run
+    // property patch handlers if that all succeeds.
+    getProcessorObject(
+        asyncResp, processorId,
+        std::bind_front(doPatchProcessor, asyncResp, processorId,
+                        appliedConfigUri, locationIndicatorActive));
 }
 
 inline void requestRoutesOperatingConfigCollection(App& app)
@@ -1336,47 +1409,7 @@ inline void requestRoutesProcessor(App& app)
     BMCWEB_ROUTE(app, "/redfish/v1/Systems/<str>/Processors/<str>/")
         .privileges(redfish::privileges::patchProcessor)
         .methods(boost::beast::http::verb::patch)(
-            [&app](const crow::Request& req,
-                   const std::shared_ptr<bmcweb::AsyncResp>& asyncResp,
-                   const std::string& systemName,
-                   const std::string& processorId) {
-                if (!redfish::setUpRedfishRoute(app, req, asyncResp))
-                {
-                    return;
-                }
-                if constexpr (BMCWEB_EXPERIMENTAL_REDFISH_MULTI_COMPUTER_SYSTEM)
-                {
-                    // Option currently returns no systems.  TBD
-                    messages::resourceNotFound(asyncResp->res, "ComputerSystem",
-                                               systemName);
-                    return;
-                }
-                if (systemName != BMCWEB_REDFISH_SYSTEM_URI_NAME)
-                {
-                    messages::resourceNotFound(asyncResp->res, "ComputerSystem",
-                                               systemName);
-                    return;
-                }
-
-                std::optional<std::string> appliedConfigUri;
-                if (!json_util::readJsonPatch(
-                        req, asyncResp->res,                                 //
-                        "AppliedOperatingConfig/@odata.id", appliedConfigUri //
-                        ))
-                {
-                    return;
-                }
-
-                if (appliedConfigUri)
-                {
-                    // Check for 404 and find matching D-Bus object, then run
-                    // property patch handlers if that all succeeds.
-                    getProcessorObject(
-                        asyncResp, processorId,
-                        std::bind_front(patchAppliedOperatingConfig, asyncResp,
-                                        processorId, *appliedConfigUri));
-                }
-            });
+            std::bind_front(handleProcessorPatch, std::ref(app)));
 }
 
 } // namespace redfish


### PR DESCRIPTION
Rebase of 1110 commit 7c25f4b. Also made some restructuring changes to address common upstream review comments.

Tested on 1120 using hardware simulator. Redfish validator was run. Lots of unrelated errors, but the checks for LocationIndicatorActive passed.

- Add the getLocationIndicatorActive method and the setLocationIndicatorActive method to bmcweb to support the LocationIndicatorActive property for processor.

- A client would use the `LocationIndicatorActive` property to identify or locate the processor. This would be accomplished `LocationIndicatorActive` to true by the `doPatch` method. The LED group manager, defined by the `identify_led_group` association, should then turn on the LEDs associated with this processor. The LEDs should then be turned off when `LocationIndeicatorActive` is PATCHed to false.

Refer:
[1] https://www.dmtf.org/sites/default/files/standards/documents/DSP0268_2020.4.pdf
[2] https://github.com/openbmc/docs/blob/a5c51bbd499ca747837ba3f4864ee283c4bd67cb/architecture/LED-architecture.md#resource-identify-operation

Tested: Validator passes
```
curl -k -H "X-Auth-Token: $token" -X GET https://${bmc}/redfish/v1/Systems/system/Processors/cpu0
{
  "@odata.id": "/redfish/v1/Systems/system/Processors/cpu0",
  "@odata.type": "#Processor.v1_18_0.Processor",
  "Id": "cpu0",
  "Location": {
    "PartLocation": {
      "ServiceLabel": "U78DA.ND0.1234567-P0-C15"
    }
  },
  "LocationIndicatorActive": false,
...
}

curl -k -H "X-Auth-Token: $token" -H "Content-Type: application/json" -X PATCH -d '{"LocationIndicatorActive":true}' https://${bmc}/redfish/v1/Systems/system/Processors/cpu0

curl -k -H "X-Auth-Token: $token" -X GET https://${bmc}/redfish/v1/Systems/system/Processors/cpu0
{
  "@odata.id": "/redfish/v1/Systems/system/Processors/cpu0",
  "@odata.type": "#Processor.v1_18_0.Processor",
  "Id": "cpu0",
  "Location": {
    "PartLocation": {
      "ServiceLabel": "U78DA.ND0.1234567-P0-C15"
    }
  },
  "LocationIndicatorActive": true,
...
}

// Failure seen when cpu does not exist
curl -k -H "X-Auth-Token: $token" -X GET https://${bmc}/redfish/v1/Systems/system/Processors/cpu100
{
  "@odata.id": "/redfish/v1/Systems/system/Processors/cpu100",
  "@odata.type": "#Processor.v1_18_0.Processor",
  "error": {
    "@Message.ExtendedInfo": [
      {
        "@odata.type": "#Message.v1_1_1.Message",
        "Message": "The requested resource of type Processor named 'cpu100' was not found.",
        "MessageArgs": [
          "Processor",
          "cpu100"
        ],
        "MessageId": "Base.1.19.ResourceNotFound",
        "MessageSeverity": "Critical",
        "Resolution": "Provide a valid resource identifier and resubmit the request."
      }
    ],
    "code": "Base.1.19.ResourceNotFound",
    "message": "The requested resource of type Processor named 'cpu100' was not found."
  }
}

curl -k -H "X-Auth-Token: $token" -H "Content-Type: application/json" -X PATCH -d '{"LocationIndicatorActive":true}'  https://${bmc}/redfish/v1/Systems/system/Processors/cpu100
{
  "error": {
    "@Message.ExtendedInfo": [
      {
        "@odata.type": "#Message.v1_1_1.Message",
        "Message": "The requested resource of type Processor named 'cpu100' was not found.",
        "MessageArgs": [
          "Processor",
          "cpu100"
        ],
        "MessageId": "Base.1.19.ResourceNotFound",
        "MessageSeverity": "Critical",
        "Resolution": "Provide a valid resource identifier and resubmit the request."
      }
    ],
    "code": "Base.1.19.ResourceNotFound",
    "message": "The requested resource of type Processor named 'cpu100' was not found."
  }
}

// Error when incorrect value used for LocationIndicatorActive
curl -k -H "X-Auth-Token: $token" -H "Content-Type: application/json" -X PATCH -d '{"LocationIndicatorActive":"unknown"}'  https://${bmc}/redfish/v1/Systems/system/Processors/cpu0
{
  "LocationIndicatorActive@Message.ExtendedInfo": [
    {
      "@odata.type": "#Message.v1_1_1.Message",
      "Message": "The value '\"unknown\"' for the property LocationIndicatorActive is not a type that the property can accept.",
      "MessageArgs": [
        "\"unknown\"",
        "LocationIndicatorActive"
      ],
      "MessageId": "Base.1.19.PropertyValueTypeError",
      "MessageSeverity": "Warning",
      "Resolution": "Correct the value for the property in the request body and resubmit the request if the operation failed."
    }
  ]
}
```



Change-Id: I511dc9ee0373c227c171d87e0475296eb326741e