### PR TITLE
Hypervisor issues fix

### DIFF
--- a/redfish-core/lib/hypervisor_system.hpp
+++ b/redfish-core/lib/hypervisor_system.hpp
@@ -1283,7 +1283,7 @@ inline void handleHypervisorEthernetInterfacePatch(
 
     const std::string& clientIp = req.session->clientIp;
     getHypervisorIfaceData(
-        ifaceId,
+        ifaceId, //
         [req, clientIp, asyncResp, ifaceId, hostName = std::move(hostName),
          ipv4StaticAddresses = std::move(ipv4StaticAddresses),
          ipv6StaticAddresses = std::move(ipv6StaticAddresses), ipv4DHCPEnabled,
@@ -1319,7 +1319,6 @@ inline void handleHypervisorEthernetInterfacePatch(
                         asyncResp->res, ipv4Static, "IPv4StaticAddresses");
                     return;
                 }
-
                 const nlohmann::json& ipv4Json = ipv4Static[0];
                 // Check if the param is 'null'. If its null, it means
                 // that user wants to delete the IP address. Deleting
@@ -1349,7 +1348,6 @@ inline void handleHypervisorEthernetInterfacePatch(
                                                      "IPv6StaticAddresses");
                     return;
                 }
-
                 // One and only one hypervisor instance supported
                 if (ipv6Static.size() != 1)
                 {
@@ -1382,7 +1380,6 @@ inline void handleHypervisorEthernetInterfacePatch(
             {
                 handleHypervisorHostnamePatch(*hostName, asyncResp);
             }
-
             if (dhcpv4)
             {
                 setDHCPEnabled(ifaceId, ethData, *ipv4DHCPEnabled, asyncResp);
@@ -1405,9 +1402,11 @@ inline void handleHypervisorEthernetInterfacePatch(
                 if (ipv6StaticDefaultGateways->empty())
                 {
                     BMCWEB_LOG_ERROR("IPv6 Default Gateway property is empty");
-                    messages::invalidObject(asyncResp->res,
+                    messages::invalidObject(
+                        asyncResp->res,
                         boost::urls::format(
-                        "/redfish/v1/Systems/hypervisor/EthernetInterfaces/{}", ifaceId));
+                            "/redfish/v1/Systems/hypervisor/EthernetInterfaces/{}",
+                            ifaceId));
                     return;
                 }
                 if (ipv6StaticDefaultGateways->size() > 1)
@@ -1418,8 +1417,8 @@ inline void handleHypervisorEthernetInterfacePatch(
                 }
                 if (ipv6StaticDefaultGateways->front().is_null())
                 {
-                    handleHypervisorV6DefaultGatewayPatch(
-                        ifaceId, "::", asyncResp);
+                    handleHypervisorV6DefaultGatewayPatch(ifaceId,
+                                                          "::", asyncResp);
                 }
                 else
                 {

--- a/redfish-core/lib/hypervisor_system.hpp
+++ b/redfish-core/lib/hypervisor_system.hpp
@@ -1427,11 +1427,6 @@ inline void handleHypervisorEthernetInterfacePatch(
                         ifaceId, ipv6StaticDefaultGateways->front(), asyncResp);
                 }
             }
-
-            // Set this interface to disabled/inactive. This will be set
-            // to enabled/active by the pldm once the hypervisor
-            // consumes the updated settings from the user.
-            setIPv4InterfaceEnabled(ifaceId, false, asyncResp);
         });
     asyncResp->res.result(boost::beast::http::status::accepted);
 }


### PR DESCRIPTION
This PR has two commits to fix issues with hypervisor network configurations:

Remove explicit setting of enabled prop - This commit removes explicit setting of Enabled property of IP address object in the backend. This logic will be done by the backend.

Fix error while patching defaultGateway6 with null.

Fixes:
https://jazz07.rchland.ibm.com:13443/jazz/web/projects/CSSD#action=com.ibm.team.workitem.viewWorkItem&id=685272
https://jazz07.rchland.ibm.com:13443/jazz/web/projects/CSSD#action=com.ibm.team.workitem.viewWorkItem&id=685259