### PR TITLE
1120: Add OemMessage for taskAbort Error (#822)(#1114)

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -376,6 +376,7 @@ srcfiles_bmcweb = files(
     'redfish-core/src/filter_expr_executor.cpp',
     'redfish-core/src/filter_expr_printer.cpp',
     'redfish-core/src/heartbeat_messages.cpp',
+    'redfish-core/src/oem_messages.cpp',
     'redfish-core/src/redfish.cpp',
     'redfish-core/src/registries.cpp',
     'redfish-core/src/resource_messages.cpp',

--- a/redfish-core/include/oem_messages.hpp
+++ b/redfish-core/include/oem_messages.hpp
@@ -1,0 +1,16 @@
+#pragma once
+
+#include <nlohmann/json.hpp>
+
+#include <string>
+
+namespace redfish
+{
+
+namespace messages
+{
+// Additional OEM taskAborted
+nlohmann::json taskAborted(const std::string& arg1, const std::string& arg2,
+                           const std::string& arg3, const std::string& arg4);
+} // namespace messages
+} // namespace redfish

--- a/redfish-core/lib/task.hpp
+++ b/redfish-core/lib/task.hpp
@@ -14,6 +14,7 @@
 #include "http_request.hpp"
 #include "http_response.hpp"
 #include "logging.hpp"
+#include "oem_messages.hpp"
 #include "query.hpp"
 #include "registries/privilege_registry.hpp"
 #include "task_messages.hpp"
@@ -205,8 +206,8 @@ struct TaskData : std::enable_shared_from_this<TaskData>
                 self->finishTask();
                 self->state = "Cancelled";
                 self->status = "Warning";
-                self->messages.emplace_back(
-                    messages::taskAborted(std::to_string(self->index)));
+                self->messages.emplace_back(messages::taskAborted(
+                    std::to_string(self->index), "None", "None", "None"));
                 // Send event :TaskAborted
                 sendTaskEvent(self->state, self->index);
                 self->callback(ec, msg, self);

--- a/redfish-core/schema/oem/openbmc/csdl/OpenBMCMessage_v1.xml
+++ b/redfish-core/schema/oem/openbmc/csdl/OpenBMCMessage_v1.xml
@@ -1,0 +1,48 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<edmx:Edmx xmlns:edmx="http://docs.oasis-open.org/odata/ns/edmx" Version="4.0">
+  <edmx:Reference Uri="http://docs.oasis-open.org/odata/odata/v4.0/errata03/csd01/complete/vocabularies/Org.OData.Core.V1.xml">
+    <edmx:Include Namespace="Org.OData.Core.V1" Alias="OData"/>
+  </edmx:Reference>
+  <edmx:Reference Uri="http://redfish.dmtf.org/schemas/v1/RedfishExtensions_v1.xml">
+    <edmx:Include Namespace="RedfishExtensions.v1_0_0" Alias="Redfish"/>
+  </edmx:Reference>
+  <edmx:Reference Uri="http://redfish.dmtf.org/schemas/v1/Message.xml">
+    <edmx:Include Namespace="Message"/>
+    <edmx:Include Namespace="Message.v1_1_2"/>
+  </edmx:Reference>
+  <edmx:Reference Uri="http://redfish.dmtf.org/schemas/v1/Resource_v1.xml">
+    <edmx:Include Namespace="Resource"/>
+    <edmx:Include Namespace="Resource.v1_0_0"/>
+  </edmx:Reference>
+  <edmx:DataServices>
+    <Schema xmlns="http://docs.oasis-open.org/odata/ns/edm" Namespace="OpenBMCMessage">
+      <Annotation Term="Redfish.OwningEntity" String="OpenBMC"/>
+    </Schema>
+    <Schema xmlns="http://docs.oasis-open.org/odata/ns/edm" Namespace="OpenBMCMessage.v1_0_0">
+      <Annotation Term="Redfish.OwningEntity" String="OpenBMC"/>
+      <ComplexType Name="Oem" BaseType="Resource.OemObject">
+        <Annotation Term="OData.AdditionalProperties" Bool="true"/>
+        <Annotation Term="OData.Description" String="OpenBMCMessage Oem properties."/>
+        <Annotation Term="OData.AutoExpand"/>
+        <Property Name="OpenBMC" Type="OpenBMCMessage.OpenBMC"/>
+      </ComplexType>
+      <ComplexType Name="OpenBMC">
+        <Annotation Term="OData.AdditionalProperties" Bool="true"/>
+        <Annotation Term="OData.Description" String="Oem properties for OpenBMC."/>
+        <Annotation Term="OData.AutoExpand"/>
+        <Property Name="AbortReason" Type="Edm.String">
+          <Annotation Term="OData.Description" String="String indicating the reason for exception."/>
+          <Annotation Term="OData.LongDescription" String="Unique string that provides reason for exception."/>
+        </Property>
+        <Property Name="AdditionalData" Type="Edm.String">
+          <Annotation Term="OData.Description" String="String indicating the reason for exception."/>
+          <Annotation Term="OData.LongDescription" String="Unique string that provides reason for exception."/>
+        </Property>
+        <Property Name="EventId" Type="Edm.String">
+          <Annotation Term="OData.Description" String="String indicating the reason for exception."/>
+          <Annotation Term="OData.LongDescription" String="Unique string that provides reason for exception."/>
+        </Property>
+      </ComplexType>
+    </Schema>
+  </edmx:DataServices>
+</edmx:Edmx>

--- a/redfish-core/schema/oem/openbmc/json-schema/OpenBMCMessage.json
+++ b/redfish-core/schema/oem/openbmc/json-schema/OpenBMCMessage.json
@@ -1,0 +1,8 @@
+{
+    "$id": "https://github.com/ibm-openbmc/bmcweb/tree/HEAD/redfish-core/schema/oem/openbmc/json-schema/OpenBMCMessage.json",
+    "$schema": "http://redfish.dmtf.org/schemas/v1/redfish-schema-v1.json",
+    "copyright": "Copyright 2025 OpenBMC.",
+    "definitions": {},
+    "owningEntity": "OpenBMC",
+    "title": "#OpenBMCMessage"
+}

--- a/redfish-core/schema/oem/openbmc/json-schema/OpenBMCMessage.v1_0_0.json
+++ b/redfish-core/schema/oem/openbmc/json-schema/OpenBMCMessage.v1_0_0.json
@@ -1,0 +1,76 @@
+{
+    "$id": "http://redfish.dmtf.org/schemas/v1/OpenBMCMessage.v1_0_0.json",
+    "$schema": "http://redfish.dmtf.org/schemas/v1/redfish-schema-v1.json",
+    "copyright": "Copyright 2025 OpenBMC.",
+    "definitions": {
+        "Oem": {
+            "additionalProperties": true,
+            "description": "OpenBMCMessage Oem properties.",
+            "patternProperties": {
+                "^([a-zA-Z_][a-zA-Z0-9_]*)?@(odata|Redfish|Message)\\.[a-zA-Z_][a-zA-Z0-9_]*$": {
+                    "description": "This property shall specify a valid odata or Redfish property.",
+                    "type": [
+                        "array",
+                        "boolean",
+                        "integer",
+                        "number",
+                        "null",
+                        "object",
+                        "string"
+                    ]
+                }
+            },
+            "properties": {
+                "OpenBmc": {
+                    "anyOf": [
+                        {
+                            "$ref": "#/definitions/OpenBmc"
+                        },
+                        {
+                            "type": "null"
+                        }
+                    ]
+                }
+            },
+            "type": "object"
+        },
+        "OpenBmc": {
+            "additionalProperties": true,
+            "description": "Oem properties for OpenBmc.",
+            "patternProperties": {
+                "^([a-zA-Z_][a-zA-Z0-9_]*)?@(odata|Redfish|Message)\\.[a-zA-Z_][a-zA-Z0-9_]*$": {
+                    "description": "This property shall specify a valid odata or Redfish property.",
+                    "type": [
+                        "array",
+                        "boolean",
+                        "integer",
+                        "number",
+                        "null",
+                        "object",
+                        "string"
+                    ]
+                }
+            },
+            "properties": {
+                "AbortReason": {
+                    "description": "Reason oem for message",
+                    "longDescription": "An extra property for Message to provide more information to the user",
+                    "type": ["string", "null"]
+                },
+                "AdditionalData": {
+                    "description": "Reason oem for message",
+                    "longDescription": "An extra property for Message to provide more information to the user",
+                    "type": ["string", "null"]
+                },
+                "EventId": {
+                    "description": "Reason oem for message",
+                    "longDescription": "An extra property for Message to provide more information to the user",
+                    "type": ["string", "null"]
+                }
+            },
+            "type": "object"
+        }
+    },
+    "owningEntity": "OpenBMC",
+    "title": "#OpenBMCMessage.v1_0_0"
+}

--- a/redfish-core/schema/oem/openbmc/meson.build
+++ b/redfish-core/schema/oem/openbmc/meson.build
@@ -21,3 +21,20 @@ foreach option_key, schema : schemas
         )
     endif
 endforeach
+
+# Additional IBM schemas that should be installed
+ibm_schemas = ['OpenBMCMessage']
+
+foreach schema : ibm_schemas
+    install_data(
+        'csdl/@0@_v1.xml'.format(schema),
+        install_dir: 'share/www/redfish/v1/schema',
+        follow_symlinks: true,
+    )
+
+    install_data(
+        'json-schema/@0@.v1_0_0.json'.format(schema),
+        install_dir: 'share/www/redfish/v1/JsonSchemas',
+        follow_symlinks: true,
+    )
+endforeach

--- a/redfish-core/src/oem_messages.cpp
+++ b/redfish-core/src/oem_messages.cpp
@@ -1,0 +1,70 @@
+
+#include "oem_messages.hpp"
+
+#include "bmcweb_config.h"
+
+#include "registries.hpp"
+#include "registries/task_event_message_registry.hpp"
+
+#include <nlohmann/json.hpp>
+
+#include <format>
+#include <string>
+#include <string_view>
+
+// Clang can't seem to decide whether this header needs to be included or not,
+// and is inconsistent.  Include it for now
+// NOLINTNEXTLINE(misc-include-cleaner)
+#include <utility>
+
+namespace redfish
+{
+
+namespace messages
+{
+
+/**
+ * @internal
+ * @brief Formats TaskAborted message into JSON
+ *
+ * See header file for more information
+ * @endinternal
+ */
+
+// Additional OEM taskAborted
+nlohmann::json taskAborted(const std::string& arg1, const std::string& arg2,
+                           const std::string& arg3, const std::string& arg4)
+{
+    const redfish::registries::Header& header =
+        redfish::registries::task_event::header;
+
+    std::string msgId;
+    std::string_view msgName = "TaskAborted";
+    if constexpr (BMCWEB_REDFISH_USE_3_DIGIT_MESSAGEID)
+    {
+        msgId = std::format("{}.{}.{}.{}.{}", header.registryPrefix,
+                            header.versionMajor, header.versionMinor,
+                            header.versionPatch, msgName);
+    }
+    else
+    {
+        msgId = std::format("{}.{}.{}.{}", header.registryPrefix,
+                            header.versionMajor, header.versionMinor, msgName);
+    }
+    return nlohmann::json{
+        {"@odata.type", "#Message.v1_0_0.Message"},
+        {"MessageId", msgId},
+        {"Message", "The task with id " + arg1 + " has been aborted."},
+        {"MessageArgs", {arg1, arg2, arg3, arg4}},
+        {"Severity", "Critical"},
+        {"Resolution", "None."},
+        {"Oem",
+         {{"OpenBMC",
+           {{"@odata.type", "#OpenBMCMessage.v1_0_0.Message"},
+            {"AbortReason", arg2},
+            {"AdditionalData", arg3},
+            {"EventId", arg4}}}}}};
+}
+
+} // namespace messages
+} // namespace redfish


### PR DESCRIPTION
This commit adds the Message OEM that will display error log information to taskAborted error. This addition allows the users to see the exact error cause of the code update failure.

Tested:
- Ensured that upon code update failure, the task message includes the populated OEM with the relevant information.

```
{
  "@odata.id": "/redfish/v1/TaskService/Tasks/0",
  "@odata.type": "#Task.v1_4_3.Task",
  "EndTime": "2022-05-11T17:01:15+00:00",
  "Id": "0",
  "Messages": [
    {
      "@odata.type": "#Message.v1_0_0.Message",
      "Message": "The task with id 0 has started.",
      "MessageArgs": [
        "0"
      ],
      "MessageId": "TaskEvent.1.0.TaskStarted",
      "Resolution": "None.",
      "Severity": "OK"
    },
    {
      "@odata.type": "#Message.v1_0_0.Message",
      "Message": "The task with id 0 has been aborted.",
      "MessageArgs": [
...
      ],
      "MessageId": "TaskEvent.1.0.TaskAborted",
      "Oem": {
        "OpenBMC": {
          "@odata.type": "#OemMessage.v1_0_0.Message",
          "AbortReason": "xyz.openbmc_project.Software.Version.Error.ExpiredAccessKey",
          "AdditionalData": "BUILD_ID=20220722 EXP_DATE=20220515 _PID=598 ",
          "EventId": "BD8D3608 00080055 2E330010 00000000 00000000 00000000 00000000 00000000 00000000"
        }
      },
      "Resolution": "None.",
      "Severity": "Critical"
    }
  ],
  "Name": "Task 0",
...
  "TaskMonitor": "/redfish/v1/TaskService/Tasks/0/Monitor",
  "TaskState": "Exception",
  "TaskStatus": "Warning"
}
```

Excerpt from validation pass:
```
Schema file OemMessage_v1.xml not found in ./SchemaFiles/metadata
Attempt 1 of /redfish/v1/schema/OemMessage_v1.xml
Response Time for GET to /redfish/v1/schema/OemMessage_v1.xml: 0.010929436422884464 seconds.
Writing online XML to file: OemMessage_v1.xml
```

Change-Id: Id0cdeb0887a7dfed54b0b2c41b0312fca6593110