### PR TITLE
Change Session Cookie name

### DIFF
--- a/include/authentication.hpp
+++ b/include/authentication.hpp
@@ -143,7 +143,7 @@ inline std::shared_ptr<persistent_data::UserSession> performCookieAuth(
     {
         std::string_view cookieValue = it->value();
         BMCWEB_LOG_DEBUG("Checking cookie {}", cookieValue);
-        auto startIndex = cookieValue.find("SESSION=");
+        auto startIndex = cookieValue.find("BMCWEB-SESSION=");
         if (startIndex == std::string::npos)
         {
             BMCWEB_LOG_DEBUG(
@@ -151,7 +151,7 @@ inline std::shared_ptr<persistent_data::UserSession> performCookieAuth(
                 cookieValue);
             continue;
         }
-        startIndex += sizeof("SESSION=") - 1;
+        startIndex += sizeof("BMCWEB-SESSION=") - 1;
         auto endIndex = cookieValue.find(';', startIndex);
         if (endIndex == std::string::npos)
         {

--- a/include/cookies.hpp
+++ b/include/cookies.hpp
@@ -17,14 +17,14 @@ inline void setSessionCookies(crow::Response& res,
                   "XSRF-TOKEN=" + session.csrfToken +
                       "; Path=/; SameSite=Strict; Secure");
     res.addHeader(boost::beast::http::field::set_cookie,
-                  "SESSION=" + session.sessionToken +
+                  "BMCWEB-SESSION=" + session.sessionToken +
                       "; Path=/; SameSite=Strict; Secure; HttpOnly");
 }
 
 inline void clearSessionCookies(crow::Response& res)
 {
     res.addHeader(boost::beast::http::field::set_cookie,
-                  "SESSION="
+                  "BMCWEB-SESSION="
                   "; Path=/; SameSite=Strict; Secure; HttpOnly; "
                   "expires=Thu, 01 Jan 1970 00:00:00 GMT");
 }


### PR DESCRIPTION
Upstream is https://gerrit.openbmc.org/c/openbmc/bmcweb/+/77539 

We have a use case where the GUI sits behind a Apache Tomcat proxy[1].

In this environment the cookie looks like:
```
en-US,en;q=0.9cookie:
JSESSIONIDSSO=4E999D77EF4E01CB72DE63949D5FF830;
CCFWSESSION=48A66EB93C00AD4F6327FB3FC2A338FC; LOGIN_MODE=Dashboard;
XSRF-TOKEN=Ue1La3Ik48Bn5NosyLnJ; SESSION=pCAdqApWt4Kb4IUV9vh8dnt:
```

The bmcweb code thinks the CCFWSESSION= is the SESSION. The bmcweb code could be made smarter to differentiate "CCFWSESSION" and "SESSION" but reading SESSION seems too generic of a name and something like "BMCWEB-SESSION" better matches [2], [3], and [4].

[1]: https://tomcat.apache.org/tomcat-9.0-doc/proxy-howto.html
[2]: https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Set-Cookie#session_cookie
[3]: https://http.dev/set-cookie
[4]: https://www.geeksforgeeks.org/http-headers-set-cookie/

Tested: The GUI works and this proxy environment now works.

Change-Id: I9b63093c1839e26602fe26313a330e337961cb81