### PR TITLE
1120: Add ACFWindowActive and AllowUnauthACFUpload (#920)(#1224)

### DIFF
--- a/redfish-core/schema/oem/ibm/csdl/IBMManagerAccount_v1.xml
+++ b/redfish-core/schema/oem/ibm/csdl/IBMManagerAccount_v1.xml
@@ -56,6 +56,11 @@
           <Annotation Term="OData.Description" String="This property is set to true if the ACF is installed."/>
           <Annotation Term="OData.LongDescription" String="This property indicates if the ACF is installed or not."/>
         </Property>
+        <Property Name="AllowUnauthACFUpload" Type="Edm.Boolean">
+          <Annotation Term="OData.Permissions" EnumMember="OData.Permission/ReadWrite"/>
+          <Annotation Term="OData.Description" String="This property shall indicate if unauthorized users shall be allowed to upload ACFs."/>
+          <Annotation Term="OData.LongDescription" String="This property indicates if unauthorized users are allowed to upload ACFs or not.  When this property is true, users are allowed to upload ACFs regardless of their authentication status, regardless of their Role, and regardless of the time window created by Operator Panel function 74."/>
+        </Property>
       </ComplexType>
     </Schema>
   </edmx:DataServices>

--- a/redfish-core/schema/oem/ibm/csdl/IBMServiceRoot_v1.xml
+++ b/redfish-core/schema/oem/ibm/csdl/IBMServiceRoot_v1.xml
@@ -53,6 +53,11 @@
           <Annotation Term="OData.Description" String="The time offset from UTC that the DateTime property is in `+HH:MM` format."/>
           <Annotation Term="OData.LongDescription" String="This property shall contain the offset from UTC time that the DateTime property contains.  If both DateTime and DateTimeLocalOffset are provided in modification requests, services shall apply DateTimeLocalOffset after DateTime is applied."/>
         </Property>
+        <Property Name="ACFWindowActive" Type="IBMServiceRoot.IBM">
+          <Annotation Term="OData.Permissions" EnumMember="OData.Permission/Read"/>
+          <Annotation Term="OData.Description" String="An indication of whether the time window for an unauthorized agent to upload an ACF is active."/>
+          <Annotation Term="OData.LongDescription" String="This property shall indicate if the time window for an unauthorized agent to upload an ACF is active."/>
+        </Property>
       </ComplexType>
     </Schema>
   </edmx:DataServices>

--- a/redfish-core/schema/oem/ibm/json-schema/IBMManagerAccount.v1_0_0.json
+++ b/redfish-core/schema/oem/ibm/json-schema/IBMManagerAccount.v1_0_0.json
@@ -77,6 +77,13 @@
                     "readonly": true,
                     "type": ["boolean"],
                     "versionAdded": "v1_0_0"
+                },
+                "AllowUnauthACFUpload": {
+                    "description": "This property shall indicate if unauthorized users shall be allowed to upload ACFs.",
+                    "longDescription": "This property indicates if unauthorized users are allowed to upload ACFs or not.  When this property is true, users are allowed to upload ACFs regardless of their authentication status, regardless of their Role, and regardless of the time window created by Operator Panel function 74.",
+                    "readonly": false,
+                    "type": ["boolean"],
+                    "versionAdded": "v1_0_0"
                 }
             },
             "type": "object"

--- a/redfish-core/schema/oem/ibm/json-schema/IBMServiceRoot.v1_0_0.json
+++ b/redfish-core/schema/oem/ibm/json-schema/IBMServiceRoot.v1_0_0.json
@@ -69,6 +69,12 @@
                     "pattern": "^([-+][0-1][0-9]:[0-5][0-9])$",
                     "readonly": false,
                     "type": ["string", "null"]
+                },
+                "ACFWindowActive": {
+                    "description": "An indication of whether the time window for an unauthorized agent to upload an ACF is active.",
+                    "longDescription": "This property shall indicate if the time window for an unauthorized agent to upload an ACF is active.",
+                    "readonly": true,
+                    "type": ["boolean", "null"]
                 }
             },
             "type": "object"


### PR DESCRIPTION

1. Add ACFWindowActive to /redfish/v1 (#331) (#525)

* Add ACFWindowActive to /redfish/v1 (#331)

This adds the Oem.IBM.ACFWindowActive boolean property to the Redfish service root at URI /redfish/v1.

Tested:
Via curl https://${BMC}/redfish/v1
Tested values true, false, and panel app not running. Simulated pressing function 74 via busctl set-property "com.ibm.PanelApp"
  "/com/ibm/panel_app" "com.ibm.panel" "ACFWindowActive" b true

* Add ACFWindowActive to /redfish/v1

This restructures the ACFWindowActive code to BMCWeb coding style. This defaults to ACFWindowActive=false when the value is not available. This add the XML schema.

Tested:
Tested both true and false values via:
curl -k https://127.0.0.1:2643/redfish/v1
and simulating button press via
busctl set-property "com.ibm.PanelApp" "/com/ibm/panel_app" \
  "com.ibm.panel" "ACFWindowActive" b true

2. New property to always AllowUnauthACFUpload (#466) (#678)

* New property to always AllowUnauthACFUpload

This adds a new BMC security setting as a Redfish OEM property: URI /redfish/v1/AccountService/Accounts/service property Oem.IBM.ACF.AllowUnauthACFUpload can be set by the admin.  When true, any network agent is allowed to upload an ACF file to the BMC. The default value is false.  This capability is included in the existing URI /redfish/v1 property Oem.IBM.ACFWindowActive.  For example, when AllowUnauthACFUpload=true, ACFWindowActive is true.

Tested: via Redfish scenarios
1. Ensure AllowUnauthACFUpload=false by default.
2. Ensure a non admin user is not allowed to GET or PATCH AllowUnauthACFUpload.
3. Ensure the admin can PATCH AllowUnauthACFUpload true and false, and GET the correct values, and these values survive BMC reboot.
4. With (OpPanel fn 74 is not active) and AllowUnauthACFUpload=false, ensure ACFWindowActive=false.  And unauth ACF upload is not allowed.
5. With (OpPanel fn 74 is not active) and AllowUnauthACFUpload=true,

Cheatsheet:
```
$ busctl set-property com.ibm.PanelApp /com/ibm/panel_app \
  com.ibm.panel ACFWindowActive b true

$ curl -k -H "Content-Type: application/json"  -H "X-Auth-Token: $TOKEN" \
     -X PATCH -d '{"Oem":{"IBM":{"ACF":{"AllowUnauthACFUpload": true}}}}' \
     https://${bmc}/redfish/v1/AccountService/Accounts/service

$ curl -k -H "X-Auth-Token: $TOKEN" -X GET https://${bmc}/redfish/v1

$ curl -k -H "Content-Type: application/json"  -X PATCH \
     -d '{"Oem":{"IBM":{"ACF":{"ACFFile":"'${acf}'"}}}}' \
     https://${bmc}/redfish/v1/AccountService/Accounts/service
```

Tested: Yes, repeated the REST API tests.
In addition, the Web GUI changes were tested based on this version.

The following tests are also done;

1. In case t AllowUnauthACFUpload=false.

```
bmc=service:<pwd>@<machine>
$ curl -k -H "X-Auth-Token: $TOKEN" -X PATCH \
    -d '{"Oem":{"IBM":{"ACF":{"AllowUnauthACFUpload": false}}}}' \
    https://${bmc}:18080/redfish/v1/AccountService/Accounts/service
```

1a) ACFWindowActive=false.

Attempt ACFupload under non-admin account. It will fail

```
$ busctl set-property com.ibm.PanelApp /com/ibm/panel_app com.ibm.panel ACFWindowActive b false

% bmc=testuser:<pwd>@<machine>
$ curl -k -H "Content-Type: application/json" -X PATCH \
    -d '{"Oem":{"IBM":{"ACF":{"ACFFile":"'${acf}'"}}}}' \
    https://${bmc}:18080/redfish/v1/AccountService/Accounts/service
{
  "error": {
    "@Message.ExtendedInfo": [
      {
        "@odata.type": "#Message.v1_1_1.Message",
        "Message": "There are insufficient privileges for the account or credentials ...
}%
```

1b) Now set ACFWindowActive=true, and do the same non-admin account upload.  It will succeed

```
$ busctl set-property com.ibm.PanelApp /com/ibm/panel_app com.ibm.panel ACFWindowActive b true

--

$ curl -k -H "Content-Type: application/json" -X PATCH \
    -d '{"Oem":{"IBM":{"ACF":{"ACFFile":"'${acf}'"}}}}' \
    https://${bmc}:18080/redfish/v1/AccountService/Accounts/service
```

In case, AllowUnauthACFUpload is set to true, it allows ACF upload (without needing D-bus setting).

```
bmc=service:<pwd>@<machine>
 $curl -k -H "X-Auth-Token: $TOKEN" -X PATCH \
     -d '{"Oem":{"IBM":{"ACF":{"AllowUnauthACFUpload": true}}}}' \
     https://${bmc}:18080/redfish/v1/AccountService/Accounts/service

curl -k -X PATCH -d '{"Oem":{"IBM":{"ACF":{"ACFFile":"'${acf}'"}}}}' \
     https://${bmc}:18080/redfish/v1/AccountService/Accounts/service
```