### PR TITLE
1120: Redfish OEM Update Command for Concurrent Update (#812)

### DIFF
--- a/redfish-core/lib/update_service.hpp
+++ b/redfish-core/lib/update_service.hpp
@@ -976,7 +976,7 @@ inline void processUpdateRequest(
 
 inline void updateMultipartContext(
     const std::shared_ptr<bmcweb::AsyncResp>& asyncResp,
-    const crow::Request& req, MultipartParser&& parser)
+    const crow::Request& req, MultipartParser&& parser, const std::string& url)
 {
     std::optional<MultiPartUpdateParameters> multipart =
         extractMultipartUpdateParameters(asyncResp, std::move(parser));
@@ -1008,15 +1008,14 @@ inline void updateMultipartContext(
         setApplyTime(asyncResp, *multipart->applyTime);
 
         // Setup callback for when new software detected
-        monitorForSoftwareAvailable(asyncResp, req,
-                                    "/redfish/v1/UpdateService");
+        monitorForSoftwareAvailable(asyncResp, req, url);
 
         uploadImageFile(asyncResp->res, multipart->uploadData);
     }
 }
 
 inline void doHTTPUpdate(const std::shared_ptr<bmcweb::AsyncResp>& asyncResp,
-                         const crow::Request& req)
+                         const crow::Request& req, const std::string& url)
 {
     if constexpr (BMCWEB_REDFISH_UPDATESERVICE_USE_DBUS)
     {
@@ -1035,8 +1034,8 @@ inline void doHTTPUpdate(const std::shared_ptr<bmcweb::AsyncResp>& asyncResp,
     else
     {
         // Setup callback for when new software detected
-        monitorForSoftwareAvailable(asyncResp, req,
-                                    "/redfish/v1/UpdateService");
+        // Setup callback for when new software detected
+        monitorForSoftwareAvailable(asyncResp, req, url);
 
         uploadImageFile(asyncResp->res, req.body());
     }
@@ -1044,7 +1043,7 @@ inline void doHTTPUpdate(const std::shared_ptr<bmcweb::AsyncResp>& asyncResp,
 
 inline void handleUpdateServicePost(
     App& app, const crow::Request& req,
-    const std::shared_ptr<bmcweb::AsyncResp>& asyncResp)
+    const std::shared_ptr<bmcweb::AsyncResp>& asyncResp, const std::string& url)
 {
     if (!redfish::setUpRedfishRoute(app, req, asyncResp))
     {
@@ -1058,7 +1057,7 @@ inline void handleUpdateServicePost(
     // multipart/form-data
     if (bmcweb::asciiIEquals(contentType, "application/octet-stream"))
     {
-        doHTTPUpdate(asyncResp, req);
+        doHTTPUpdate(asyncResp, req, url);
     }
     else if (contentType.starts_with("multipart/form-data"))
     {
@@ -1074,13 +1073,33 @@ inline void handleUpdateServicePost(
             return;
         }
 
-        updateMultipartContext(asyncResp, req, std::move(parser));
+        updateMultipartContext(asyncResp, req, std::move(parser), url);
     }
     else
     {
         BMCWEB_LOG_DEBUG("Bad content type specified:{}", contentType);
         asyncResp->res.result(boost::beast::http::status::bad_request);
     }
+}
+
+/**
+ * UpdateServiceActionsOemConcurrentUpdate class supports handle POST method for
+ * concurrent update action.
+ */
+inline void requestRoutesUpdateServiceActionsOemConcurrentUpdate(App& app)
+{
+    BMCWEB_ROUTE(
+        app,
+        "/redfish/v1/UpdateService/Actions/Oem/OemUpdateService.ConcurrentUpdate/")
+        .privileges(redfish::privileges::postUpdateService)
+        .methods(boost::beast::http::verb::post)(std::bind_front(
+            [&app](App&, const crow::Request& req,
+                   const std::shared_ptr<bmcweb::AsyncResp>& asyncResp) {
+                handleUpdateServicePost(
+                    app, req, asyncResp,
+                    "/redfish/v1/UpdateService/Actions/Oem/OemUpdateService.ConcurrentUpdate");
+            },
+            std::ref(app)));
 }
 
 inline void handleUpdateServiceGet(
@@ -1110,6 +1129,11 @@ inline void handleUpdateServiceGet(
     // Get the MaxImageSizeBytes
     asyncResp->res.jsonValue["MaxImageSizeBytes"] =
         BMCWEB_HTTP_BODY_LIMIT * 1024 * 1024;
+    nlohmann::json& updateSvcConUpdate =
+        asyncResp->res.jsonValue["Actions"]["Oem"]
+                                ["#OemUpdateService.v1_0_0.ConcurrentUpdate"];
+    updateSvcConUpdate["target"] =
+        "/redfish/v1/UpdateService/Actions/Oem/OemUpdateService.ConcurrentUpdate";
 
     if constexpr (BMCWEB_REDFISH_ALLOW_SIMPLE_UPDATE)
     {
@@ -1347,8 +1371,13 @@ inline void requestRoutesUpdateService(App& app)
 
     BMCWEB_ROUTE(app, "/redfish/v1/UpdateService/update/")
         .privileges(redfish::privileges::postUpdateService)
-        .methods(boost::beast::http::verb::post)(
-            std::bind_front(handleUpdateServicePost, std::ref(app)));
+        .methods(boost::beast::http::verb::post)(std::bind_front(
+            [&app](App&, const crow::Request& req,
+                   const std::shared_ptr<bmcweb::AsyncResp>& asyncResp) {
+                handleUpdateServicePost(app, req, asyncResp,
+                                        "/redfish/v1/UpdateService");
+            },
+            std::ref(app)));
 
     BMCWEB_ROUTE(app, "/redfish/v1/UpdateService/FirmwareInventory/")
         .privileges(redfish::privileges::getSoftwareInventoryCollection)

--- a/redfish-core/schema/oem/ibm/csdl/OemUpdateService_v1.xml
+++ b/redfish-core/schema/oem/ibm/csdl/OemUpdateService_v1.xml
@@ -1,0 +1,25 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<edmx:Edmx xmlns:edmx="http://docs.oasis-open.org/odata/ns/edmx" Version="4.0">
+  <edmx:Reference Uri="http://docs.oasis-open.org/odata/odata/v4.0/errata03/csd01/complete/vocabularies/Org.OData.Core.V1.xml">
+    <edmx:Include Namespace="Org.OData.Core.V1" Alias="OData"/>
+  </edmx:Reference>
+  <edmx:Reference Uri="http://redfish.dmtf.org/schemas/v1/UpdateService_v1.xml">
+    <edmx:Include Namespace="UpdateService"/>
+    <edmx:Include Namespace="UpdateService.v1_0_0"/>
+  </edmx:Reference>
+  <edmx:Reference Uri="http://redfish.dmtf.org/schemas/v1/RedfishExtensions_v1.xml">
+    <edmx:Include Namespace="RedfishExtensions.v1_0_0" Alias="Redfish"/>
+  </edmx:Reference>
+  <edmx:DataServices>
+    <Schema xmlns="http://docs.oasis-open.org/odata/ns/edm" Namespace="OemUpdateService">
+      <Annotation Term="Redfish.OwningEntity" String="IBM"/>
+    </Schema>
+    <Schema xmlns="http://docs.oasis-open.org/odata/ns/edm" Namespace="OemUpdateService.v1_0_0">
+      <Action Name="ConcurrentUpdate" IsBound="true">
+        <Annotation Term="OData.Description" String="This action concurrently updates firmware."/>
+        <Annotation Term="OData.LongDescription" String="This action concurrently updates firmware, synchronizing the host and bmc."/>
+        <Parameter Name="UpdateService" Type="UpdateService.v1_0_0.OemActions"/>
+      </Action>
+    </Schema>
+  </edmx:DataServices>
+</edmx:Edmx>

--- a/redfish-core/schema/oem/ibm/json-schema/OemUpdateService.json
+++ b/redfish-core/schema/oem/ibm/json-schema/OemUpdateService.json
@@ -1,0 +1,8 @@
+{
+    "$id": "https://github.com/ibm-openbmc/bmcweb/tree/HEAD/redfish-core/schema/oem/ibm/json-schema/OemUpdateService.json",
+    "$schema": "http://redfish.dmtf.org/schemas/v1/redfish-schema-v1.json",
+    "copyright": "Copyright 2025 OpenBMC.",
+    "definitions": {},
+    "owningEntity": "IBM",
+    "title": "#OemUpdateService"
+}

--- a/redfish-core/schema/oem/ibm/json-schema/OemUpdateService.v1_0_0.json
+++ b/redfish-core/schema/oem/ibm/json-schema/OemUpdateService.v1_0_0.json
@@ -1,0 +1,41 @@
+{
+    "$id": "http://redfish.dmtf.org/schemas/v1/OemUpdateService.v1_0_0.json",
+    "$schema": "http://redfish.dmtf.org/schemas/v1/redfish-schema-v1.json",
+    "Copyright": "Copyright 2025 OpenBMC.",
+    "definitions": {
+        "ConcurrentUpdate": {
+            "additionalProperties": false,
+            "description": "This object concurrently updates software components",
+            "parameters": {},
+            "patternProperties": {
+                "^([a-zA-Z_][a-zA-Z0-9_]*)?@(odata|Redfish|Message)\\.[a-zA-Z_][a-zA-Z0-9_]*$": {
+                    "description": "This property shall specify a valid odata or Redfish property.",
+                    "type": [
+                        "array",
+                        "boolean",
+                        "integer",
+                        "number",
+                        "null",
+                        "object",
+                        "string"
+                    ]
+                }
+            },
+            "properties": {
+                "target": {
+                    "description": "Link to invoke action",
+                    "format": "uri-reference",
+                    "type": "string"
+                },
+                "title": {
+                    "description": "Friendly action name",
+                    "type": "string"
+                }
+            },
+            "type": "object"
+        }
+    },
+    "OwningEntity": "OpenBMC",
+    "release": "1.0",
+    "title": "#OemUpdateService.v1_0_0"
+}

--- a/redfish-core/schema/oem/ibm/meson.build
+++ b/redfish-core/schema/oem/ibm/meson.build
@@ -5,6 +5,7 @@ schemas = [
     'IBMPCIeDevice',
     'IBMPCIeSlots',
     'IBMServiceRoot',
+    'OemUpdateService',
 ]
 
 foreach schema : schemas

--- a/redfish-core/src/redfish.cpp
+++ b/redfish-core/src/redfish.cpp
@@ -103,6 +103,7 @@ RedfishService::RedfishService(App& app)
     requestRoutesChassisDrive(app);
     requestRoutesChassisDriveName(app);
     requestRoutesUpdateService(app);
+    requestRoutesUpdateServiceActionsOemConcurrentUpdate(app);
     requestRoutesStorageCollection(app);
     requestRoutesStorage(app);
     requestRoutesStorageControllerCollection(app);


### PR DESCRIPTION
This commit adds a new update command to be used by the management console to perform concurrent updates. It works like the current update command, but with added support for the OnReset apply time setting.

Tested:
-  Ensured that redfish command updates as usual, and updates still occured while the ApplyTime was in OnReset state.

```
$ curl -k -H "X-Auth-Token: $token" -H "Content-Type: application/octet-stream"  -X POST -T ${image} \
          https://${bmc}/redfish/v1/UpdateService/Actions/Oem/OemUpdateService.ConcurrentUpdate
```

- Redfish Service Validator passes