### PR TITLE
1120: Add PanelFunction and ChapData 

### DIFF
--- a/redfish-core/lib/systems.hpp
+++ b/redfish-core/lib/systems.hpp
@@ -2656,6 +2656,159 @@ inline void getIdlePowerSaver(
     BMCWEB_LOG_DEBUG("EXIT: Get idle power saver parameters");
 }
 
+/*
+ * Handle Enabled Panel Functions
+ */
+inline void doGetEnabledPanelFunctions(
+    const std::shared_ptr<bmcweb::AsyncResp>& asyncResp,
+    std::function<void(const boost::system::error_code& ec,
+                       const std::vector<uint8_t>&)>&& callback)
+{
+    BMCWEB_LOG_DEBUG("Get Enabled Panel functions");
+
+    crow::connections::systemBus->async_method_call(
+        [asyncResp, callback = std::move(callback)](
+            const boost::system::error_code& ec,
+            const std::vector<uint8_t>& enabledFuncs) {
+            callback(ec, enabledFuncs);
+        },
+        "com.ibm.PanelApp", "/com/ibm/panel_app", "com.ibm.panel",
+        "getEnabledFunctions");
+}
+
+/*
+ * Get Enabled Panel Functions
+ */
+inline void getEnabledPanelFunctions(
+    const std::shared_ptr<bmcweb::AsyncResp>& asyncResp)
+{
+    doGetEnabledPanelFunctions(
+        asyncResp, [asyncResp](const boost::system::error_code& ec,
+                               const std::vector<uint8_t>& enabledFuncs) {
+            if (ec)
+            {
+                if (ec.value() != EBADR &&
+                    ec.value() != boost::asio::error::host_unreachable)
+                {
+                    BMCWEB_LOG_ERROR(
+                        "Get Enabled Panel Functions D-bus error: {}",
+                        ec.value());
+                    messages::internalError(asyncResp->res);
+                }
+                return;
+            }
+            nlohmann::json& oem = asyncResp->res.jsonValue["Oem"];
+            oem["IBM"]["@odata.type"] = "#IBMComputerSystem.v1_0_0.IBM";
+            oem["IBM"]["EnabledPanelFunctions"] = enabledFuncs;
+        });
+}
+
+/**
+ * Execute a Panel Enabled Function
+ */
+inline void executePanelFunction(
+    const std::shared_ptr<bmcweb::AsyncResp>& asyncResp, const uint8_t funcNo)
+{
+    BMCWEB_LOG_DEBUG("Execute Panel function {}", std::to_string(funcNo));
+
+    crow::connections::systemBus->async_method_call(
+        [asyncResp,
+         funcNo](const boost::system::error_code& ec,
+                 const sdbusplus::message_t& msg,
+                 const std::tuple<bool, std::string, std::string>& result) {
+            if (ec)
+            {
+                const sd_bus_error* dbusError = msg.get_error();
+                if (dbusError == nullptr)
+                {
+                    BMCWEB_LOG_ERROR(
+                        "Execute a panel function D-bus error:  {}",
+                        ec.value());
+                    messages::internalError(asyncResp->res);
+                    return;
+                }
+                if (dbusError->name ==
+                    std::string_view(
+                        "xyz.openbmc_project.Common.Error.NotAllowed"))
+                {
+                    BMCWEB_LOG_WARNING("PanelFunction {} is not enabled",
+                                       std::to_string(funcNo));
+                    messages::operationNotAllowed(asyncResp->res);
+                    return;
+                }
+                if (dbusError->name ==
+                    std::string_view(
+                        "xyz.openbmc_project.Common.Error.InternalFailure"))
+                {
+                    BMCWEB_LOG_ERROR("ExecutePanelFunction {} is failed",
+                                     std::to_string(funcNo));
+                    messages::operationFailed(asyncResp->res);
+                    return;
+                }
+                BMCWEB_LOG_ERROR("Execute a panel function D-bus error:  {}",
+                                 ec.value());
+                messages::internalError(asyncResp->res);
+                return;
+            }
+
+            if (!std::get<0>(result))
+            {
+                BMCWEB_LOG_ERROR("ExecutePanelFunction {} is failed",
+                                 std::to_string(funcNo));
+                messages::operationFailed(asyncResp->res);
+                return;
+            }
+            asyncResp->res.jsonValue["Result"] = {std::get<1>(result),
+                                                  std::get<2>(result)};
+            messages::success(asyncResp->res);
+        },
+        "com.ibm.PanelApp", "/com/ibm/panel_app", "com.ibm.panel",
+        "ExecuteFunction", funcNo);
+}
+
+inline void handleSystemActionsOemExecutePanelFunctionPost(
+    App& app, const crow::Request& req,
+    const std::shared_ptr<bmcweb::AsyncResp>& asyncResp)
+{
+    BMCWEB_LOG_DEBUG("handleSystemActionsOemExecutePanelFunctionPost...");
+    if (!redfish::setUpRedfishRoute(app, req, asyncResp))
+    {
+        return;
+    }
+
+    uint8_t funcNo = 0;
+    if (!json_util::readJsonAction(req, asyncResp->res, "FuncNo", funcNo))
+    {
+        BMCWEB_LOG_WARNING("Missing funcNo");
+        messages::actionParameterMissing(asyncResp->res, "ExecutePanelFunction",
+                                         "FuncNo");
+        return;
+    }
+
+    doGetEnabledPanelFunctions(
+        asyncResp,
+        [funcNo, asyncResp](const boost::system::error_code& ec,
+                            const std::vector<uint8_t>& enabledFuncs) {
+            if (ec)
+            {
+                BMCWEB_LOG_ERROR("Get Enabled Panel Functions D-bus error: {}",
+                                 ec.value());
+                messages::internalError(asyncResp->res);
+                return;
+            }
+
+            auto it = std::ranges::find(enabledFuncs, funcNo);
+            if (it == enabledFuncs.end())
+            {
+                BMCWEB_LOG_WARNING("PanelFunction {} is not enabled",
+                                   std::to_string(funcNo));
+                messages::operationNotAllowed(asyncResp->res);
+                return;
+            }
+            executePanelFunction(asyncResp, funcNo);
+        });
+}
+
 /**
  * @brief Sets Idle Power Saver properties.
  *
@@ -3143,6 +3296,13 @@ inline void handleComputerSystemGet(
     getTrustedModuleRequiredToBoot(asyncResp);
     getPowerMode(asyncResp);
     getIdlePowerSaver(asyncResp);
+
+    // Panel Function
+    getEnabledPanelFunctions(asyncResp);
+
+    nlohmann::json& actionOem = asyncResp->res.jsonValue["Actions"]["Oem"];
+    actionOem["#IBMComputerSystem.v1_0_0.ExecutePanelFunction"]["target"] =
+        "/redfish/v1/Systems/system/Actions/Oem/IBM/IBMComputerSystem.ExecutePanelFunction";
 }
 
 inline void handleComputerSystemPatch(
@@ -3492,4 +3652,20 @@ inline void requestRoutesSystems(App& app)
         .methods(boost::beast::http::verb::get)(std::bind_front(
             handleSystemCollectionResetActionGet, std::ref(app)));
 }
+
+/**
+ * SystemActionsOemExecutePanelFunction class supports handle POST method for
+ * ExecutePanelFunction  action. The class retrieves and sends data directly to
+ * D-Bus.
+ */
+inline void requestRoutesSystemActionsOemExecutePanelFunction(App& app)
+{
+    BMCWEB_ROUTE(
+        app,
+        "/redfish/v1/Systems/system/Actions/Oem/IBM/IBMComputerSystem.ExecutePanelFunction/")
+        .privileges(redfish::privileges::postComputerSystem)
+        .methods(boost::beast::http::verb::post)(std::bind_front(
+            handleSystemActionsOemExecutePanelFunctionPost, std::ref(app)));
+}
+
 } // namespace redfish

--- a/redfish-core/schema/oem/ibm/csdl/IBMComputerSystem_v1.xml
+++ b/redfish-core/schema/oem/ibm/csdl/IBMComputerSystem_v1.xml
@@ -37,6 +37,26 @@
           <Annotation Term="OData.Description" String="List of enabled panel functions."/>
           <Annotation Term="OData.LongDescription" String="This property shall contain the list of enabled panel functions."/>
         </Property>
+        <Property Name="ChapData" Type="IBMComputerSystem.v1_0_0.ChapData">
+          <Annotation Term="OData.Permissions" EnumMember="OData.Permission/Read"/>
+          <Annotation Term="OData.Description" String="ChapData details to Host."/>
+          <Annotation Term="OData.LongDescription" String="This property shall contain ChapData."/>
+        </Property>
+      </ComplexType>
+      <ComplexType Name="ChapData" BaseType="Resource.OemObject">
+        <Annotation Term="OData.AdditionalProperties" Bool="false"/>
+        <Annotation Term="OData.Description" String="ChapData details to Host."/>
+        <Annotation Term="OData.LongDescription" String="This type shall contain ChapData."/>
+        <Property Name="ChapName" Type="Edm.String">
+          <Annotation Term="OData.Permissions" EnumMember="OData.Permission/Read"/>
+          <Annotation Term="OData.Description" String="A user selected name associated with each of the chap secret password."/>
+          <Annotation Term="OData.LongDescription" String="This property shall contain ChapName that is a user selected name associated with each of the chap secret password."/>
+        </Property>
+        <Property Name="ChapSecret" Type="Edm.String">
+          <Annotation Term="OData.Permissions" EnumMember="OData.Permission/Read"/>
+          <Annotation Term="OData.Description" String="An encrypted secret password transferred to the Host for the respective ChapName."/>
+          <Annotation Term="OData.LongDescription" String="This property shall contain ChapSecret that is an encrypted secret password transferred to the Host for the respective ChapName."/>
+        </Property>
       </ComplexType>
       <Action Name="ExecutePanelFunction" IsBound="true">
         <Annotation Term="OData.Description" String="This action executes a panel function."/>

--- a/redfish-core/schema/oem/ibm/csdl/IBMComputerSystem_v1.xml
+++ b/redfish-core/schema/oem/ibm/csdl/IBMComputerSystem_v1.xml
@@ -1,0 +1,51 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<edmx:Edmx xmlns:edmx="http://docs.oasis-open.org/odata/ns/edmx" Version="4.0">
+  <edmx:Reference Uri="http://docs.oasis-open.org/odata/odata/v4.0/errata03/csd01/complete/vocabularies/Org.OData.Core.V1.xml">
+    <edmx:Include Namespace="Org.OData.Core.V1" Alias="OData"/>
+  </edmx:Reference>
+  <edmx:Reference Uri="http://redfish.dmtf.org/schemas/v1/RedfishExtensions_v1.xml">
+    <edmx:Include Namespace="Validation.v1_0_0" Alias="Validation"/>
+    <edmx:Include Namespace="RedfishExtensions.v1_0_0" Alias="Redfish"/>
+  </edmx:Reference>
+  <edmx:Reference Uri="http://redfish.dmtf.org/schemas/v1/ComputerSystem_v1.xml">
+    <edmx:Include Namespace="ComputerSystem"/>
+    <edmx:Include Namespace="ComputerSystem.v1_4_0"/>
+  </edmx:Reference>
+  <edmx:Reference Uri="http://redfish.dmtf.org/schemas/v1/Resource_v1.xml">
+    <edmx:Include Namespace="Resource"/>
+    <edmx:Include Namespace="Resource.v1_0_0"/>
+  </edmx:Reference>
+  <edmx:DataServices>
+    <Schema xmlns="http://docs.oasis-open.org/odata/ns/edm" Namespace="IBMComputerSystem">
+      <ComplexType Name="Oem" BaseType="Resource.OemObject">
+        <Annotation Term="OData.AdditionalProperties" Bool="true"/>
+        <Annotation Term="OData.Description" String="IBMComputerSystem Oem properties."/>
+        <Annotation Term="OData.AutoExpand"/>
+        <Property Name="IBM" Type="IBMComputerSystem.IBM"/>
+      </ComplexType>
+      <ComplexType Name="IBM" BaseType="Resource.OemObject">
+        <Annotation Term="Redfish.OwningEntity" String="IBM"/>
+        <Annotation Term="OData.AdditionalProperties" Bool="true"/>
+        <Annotation Term="OData.Description" String="Oem properties for IBM."/>
+        <Annotation Term="OData.AutoExpand"/>
+      </ComplexType>
+    </Schema>
+    <Schema xmlns="http://docs.oasis-open.org/odata/ns/edm" Namespace="IBMComputerSystem.v1_0_0">
+      <ComplexType Name="IBM" BaseType="IBMComputerSystem.IBM">
+        <Property Name="EnabledPanelFunctions" Type="Collection(Edm.Int64)">
+          <Annotation Term="OData.Permissions" EnumMember="OData.Permission/Read"/>
+          <Annotation Term="OData.Description" String="List of enabled panel functions."/>
+          <Annotation Term="OData.LongDescription" String="This property shall contain the list of enabled panel functions."/>
+        </Property>
+      </ComplexType>
+      <Action Name="ExecutePanelFunction" IsBound="true">
+        <Annotation Term="OData.Description" String="This action executes a panel function."/>
+        <Annotation Term="OData.LongDescription" String="This action executes a panel function if the function is enabled."/>
+        <Parameter Name="FuncNo" Type="IBMComputerSystem.v1_0_0.OemActions" Nullable="false">
+          <Annotation Term="OData.Description" String="Panel function number."/>
+          <Annotation Term="OData.LongDescription" String="This parameter shall contain a  panel function number to be executed."/>
+        </Parameter>
+      </Action>
+    </Schema>
+  </edmx:DataServices>
+</edmx:Edmx>

--- a/redfish-core/schema/oem/ibm/json-schema/IBMComputerSystem.json
+++ b/redfish-core/schema/oem/ibm/json-schema/IBMComputerSystem.json
@@ -1,0 +1,8 @@
+{
+    "$id": "https://github.com/ibm-openbmc/bmcweb/tree/HEAD/redfish-core/schema/oem/ibm/json-schema/IBMComputerSystem.json",
+    "$schema": "http://redfish.dmtf.org/schemas/v1/redfish-schema-v1.json",
+    "copyright": "Copyright 2025 OpenBMC.",
+    "definitions": {},
+    "owningEntity": "IBM",
+    "title": "#IBMComputerSystem"
+}

--- a/redfish-core/schema/oem/ibm/json-schema/IBMComputerSystem.v1_0_0.json
+++ b/redfish-core/schema/oem/ibm/json-schema/IBMComputerSystem.v1_0_0.json
@@ -57,6 +57,50 @@
                     "longDescription": "This property shall contain the list of enabled panel functions.",
                     "readonly": true,
                     "type": ["array", "null"]
+                },
+                "ChapData": {
+                    "$ref": "#/definitions/ChapData",
+                    "description": "ChapData.",
+                    "longDescription": "This property shall describe ChapData."
+                },
+                "SafeMode": {
+                    "description": "An indication of whether safe mode is active.",
+                    "longDescription": "The value of this property shall indicate if safe mode is active.",
+                    "readonly": true,
+                    "type": ["boolean", "null"]
+                }
+            },
+            "type": "object"
+        },
+
+        "ChapData": {
+            "additionalProperties": false,
+            "description": "ChapData details to Host.",
+            "longDescription": "This type shall contain properties that describe ChapData.",
+            "patternProperties": {
+                "^([a-zA-Z_][a-zA-Z0-9_]*)?@(odata|Redfish|Message)\\.[a-zA-Z_][a-zA-Z0-9_]*$": {
+                    "description": "This property shall specify a valid odata or Redfish property.",
+                    "type": [
+                        "array",
+                        "boolean",
+                        "integer",
+                        "number",
+                        "null",
+                        "object",
+                        "string"
+                    ]
+                }
+            },
+            "properties": {
+                "ChapName": {
+                    "description": "A user selected name associated with each of the chap secret password.",
+                    "longDescription": "This property shall contain ChapName that is a user selected name associated with each of the chap secret password.",
+                    "type": ["string", "null"]
+                },
+                "ChapSecret": {
+                    "description": "An encrypted secret password transferred to the Host for the respective ChapName.",
+                    "longDescription": "This property shall contain ChapSecret that is an encrypted secret password transferred to the Host for the respective ChapName.",
+                    "type": ["string", "null"]
                 }
             },
             "type": "object"

--- a/redfish-core/schema/oem/ibm/json-schema/IBMComputerSystem.v1_0_0.json
+++ b/redfish-core/schema/oem/ibm/json-schema/IBMComputerSystem.v1_0_0.json
@@ -1,0 +1,105 @@
+{
+    "$id": "https://github.com/ibm-openbmc/bmcweb/tree/HEAD/redfish-core/schema/oem/ibm/json-schema/IBMComputerSystem.v1_0_0.json",
+    "$schema": "http://redfish.dmtf.org/schemas/v1/redfish-schema-v1.json",
+    "copyright": "Copyright 2025 OpenBMC.",
+    "definitions": {
+        "Oem": {
+            "additionalProperties": true,
+            "description": "IBMComputerSystem Oem properties.",
+            "patternProperties": {
+                "^([a-zA-Z_][a-zA-Z0-9_]*)?@(odata|Redfish|Message)\\.[a-zA-Z_][a-zA-Z0-9_]*$": {
+                    "description": "This property shall specify a valid odata or Redfish property.",
+                    "type": [
+                        "array",
+                        "boolean",
+                        "integer",
+                        "number",
+                        "null",
+                        "object",
+                        "string"
+                    ]
+                }
+            },
+            "properties": {
+                "IBM": {
+                    "anyOf": [
+                        {
+                            "$ref": "#/definitions/IBM"
+                        },
+                        {
+                            "type": "null"
+                        }
+                    ]
+                }
+            },
+            "type": "object"
+        },
+        "IBM": {
+            "additionalProperties": true,
+            "description": "Oem properties for IBM.",
+            "patternProperties": {
+                "^([a-zA-Z_][a-zA-Z0-9_]*)?@(odata|Redfish|Message)\\.[a-zA-Z_][a-zA-Z0-9_]*$": {
+                    "description": "This property shall specify a valid odata or Redfish property.",
+                    "type": [
+                        "array",
+                        "boolean",
+                        "integer",
+                        "number",
+                        "null",
+                        "object",
+                        "string"
+                    ]
+                }
+            },
+            "properties": {
+                "EnabledPanelFunctions": {
+                    "description": "Enabled Panel functions",
+                    "longDescription": "This property shall contain the list of enabled panel functions.",
+                    "readonly": true,
+                    "type": ["array", "null"]
+                }
+            },
+            "type": "object"
+        },
+        "ExecutePanelFunction": {
+            "additionalProperties": false,
+            "description": "This object executes a panel function",
+            "parameters": {
+                "FuncNo": {
+                    "description": "Panel function number.",
+                    "longDescription": "This parameter shall contain a  panel function number to be executed.",
+                    "type": "integer"
+                }
+            },
+            "patternProperties": {
+                "^([a-zA-Z_][a-zA-Z0-9_]*)?@(odata|Redfish|Message)\\.[a-zA-Z_][a-zA-Z0-9_]*$": {
+                    "description": "This property shall specify a valid odata or Redfish property.",
+                    "type": [
+                        "array",
+                        "boolean",
+                        "integer",
+                        "number",
+                        "null",
+                        "object",
+                        "string"
+                    ]
+                }
+            },
+            "properties": {
+                "target": {
+                    "description": "Link to invoke action",
+                    "format": "uri-reference",
+                    "type": "string"
+                },
+                "title": {
+                    "description": "Friendly action name",
+                    "type": "string"
+                }
+            },
+            "type": "object",
+            "versionAdded": "v1_0_0"
+        }
+    },
+    "owningEntity": "IBM",
+    "title": "#IBMComputerSystem.v1_0_0"
+}

--- a/redfish-core/schema/oem/ibm/meson.build
+++ b/redfish-core/schema/oem/ibm/meson.build
@@ -1,5 +1,6 @@
 # IBM schemas that should be installed
 schemas = [
+    'IBMComputerSystem',
     'IBMFabricAdapter',
     'IBMManagerAccount',
     'IBMPCIeDevice',

--- a/redfish-core/src/redfish.cpp
+++ b/redfish-core/src/redfish.cpp
@@ -162,6 +162,7 @@ RedfishService::RedfishService(App& app)
     requestRoutesMemory(app);
 
     requestRoutesSystems(app);
+    requestRoutesSystemActionsOemExecutePanelFunction(app);
 
     requestRoutesBiosService(app);
     requestRoutesBiosReset(app);


### PR DESCRIPTION
1)  Add Panel EnabledFunctions (#919) (#946)

Add GET EnabledPanelFunctions in /redfish/v1/Systems/system.

2) Bypass ACFWindow and PanelFunc without Backend (#946)

This also handles the case when Panel backend daemon is running.
```
Apr 25 20:57:35 p10bmc bmcweb[727]: [ERROR systems.hpp:2710] Get Enabled Panel Functions D-bus error: 113
Apr 25 20:57:35 p10bmc bmcweb[727]: [CRITICAL error_messages.cpp:286] Internal Error \
           /usr/src/debug/bmcweb/1.0+git/redfish-core/lib/systems.hpp(2711:40) \
          `redfish::getEnabledPanelFunctions(....)
Apr 25 20:57:35 p10bmc bmcweb[727]: [ERROR http_connection.hpp:514] 0x17bc500 Error while reading: stream truncated
```

3) Add Redfish ChapData Refish OEM API (#960) (#1059)

Add Redfish ChapData Redfish OEM API for GET and PATCH of ChapName and
ChapSecret.

Its dbus property is added via
- https://github.com/ibm-openbmc/phosphor-dbus-interfaces/pull/88

The related PLDM PRs are:
- https://github.com/ibm-openbmc/pldm/pull/464
- https://github.com/ibm-openbmc/pldm/pull/482

- Ignore all ChapData errors (#1059)
In addition, we have seen pldm sending back errors in case like when it
is powering off. So, all ChapData errors will be ignored.


Tested:

- Check `EnabledPanelFunctions` in /redfish/v1/Systems/system output
- PATCH EnabledPanelFunctions and ChapData
- Redfish Validator passed
