### PR TITLE
1120: Add Cable Status and Topology Links

### DIFF
--- a/redfish-core/lib/cable.hpp
+++ b/redfish-core/lib/cable.hpp
@@ -7,6 +7,7 @@
 #include "dbus_singleton.hpp"
 #include "dbus_utility.hpp"
 #include "error_messages.hpp"
+#include "generated/enums/cable.hpp"
 #include "generated/enums/resource.hpp"
 #include "http_request.hpp"
 #include "http_response.hpp"
@@ -58,10 +59,11 @@ inline void fillCableProperties(
 
     const std::string* cableTypeDescription = nullptr;
     const double* length = nullptr;
+    const std::string* cableStatus = nullptr;
 
     const bool success = sdbusplus::unpackPropertiesNoThrow(
         dbus_utils::UnpackErrorPrinter(), properties, "CableTypeDescription",
-        cableTypeDescription, "Length", length);
+        cableTypeDescription, "Length", length, "CableStatus", cableStatus);
 
     if (!success)
     {
@@ -91,6 +93,63 @@ inline void fillCableProperties(
             asyncResp->res.jsonValue["LengthMeters"] = *length;
         }
     }
+
+    if (cableStatus != nullptr && !cableStatus->empty())
+    {
+        if (*cableStatus ==
+            "xyz.openbmc_project.Inventory.Item.Cable.Status.Inactive")
+        {
+            asyncResp->res.jsonValue["CableStatus"] =
+                cable::CableStatus::Normal;
+            asyncResp->res.jsonValue["Status"]["State"] =
+                resource::State::StandbyOffline;
+            asyncResp->res.jsonValue["Status"]["Health"] = resource::Health::OK;
+        }
+        else if (*cableStatus ==
+                 "xyz.openbmc_project.Inventory.Item.Cable.Status.Running")
+        {
+            asyncResp->res.jsonValue["CableStatus"] =
+                cable::CableStatus::Normal;
+            asyncResp->res.jsonValue["Status"]["State"] =
+                resource::State::Enabled;
+            asyncResp->res.jsonValue["Status"]["Health"] = resource::Health::OK;
+        }
+        else if (*cableStatus ==
+                 "xyz.openbmc_project.Inventory.Item.Cable.Status.PoweredOff")
+        {
+            asyncResp->res.jsonValue["CableStatus"] =
+                cable::CableStatus::Disabled;
+            asyncResp->res.jsonValue["Status"]["State"] =
+                resource::State::StandbyOffline;
+            asyncResp->res.jsonValue["Status"]["Health"] = resource::Health::OK;
+        }
+    }
+}
+
+inline void fillCablePartNumber(
+    const std::shared_ptr<bmcweb::AsyncResp>& asyncResp,
+    const std::string& cableObjectPath, const std::string& service)
+{
+    dbus::utility::getProperty<std::string>(
+        *crow::connections::systemBus, service, cableObjectPath,
+        "xyz.openbmc_project.Inventory.Decorator.Asset", "PartNumber",
+        [asyncResp](const boost::system::error_code& ec,
+                    const std::string& property) {
+            if (ec)
+            {
+                if (ec.value() != EBADR)
+                {
+                    BMCWEB_LOG_ERROR("DBus response error for PartNumber, {}",
+                                     ec.value());
+                    messages::internalError(asyncResp->res);
+                }
+
+                // PartNumber is optional, ignore the failure if it doesn't
+                // exist.
+                return;
+            }
+            asyncResp->res.jsonValue["PartNumber"] = property;
+        });
 }
 
 inline void fillCableHealthState(
@@ -149,6 +208,11 @@ inline void getCableProperties(
             else if (interface == "xyz.openbmc_project.Inventory.Item")
             {
                 fillCableHealthState(asyncResp, cableObjectPath, service);
+            }
+            else if (interface ==
+                     "xyz.openbmc_project.Inventory.Decorator.Asset")
+            {
+                fillCablePartNumber(asyncResp, cableObjectPath, service);
             }
         }
     }

--- a/redfish-core/lib/cable.hpp
+++ b/redfish-core/lib/cable.hpp
@@ -14,10 +14,12 @@
 #include "logging.hpp"
 #include "query.hpp"
 #include "registries/privilege_registry.hpp"
+#include "utils/chassis_utils.hpp"
 #include "utils/collection.hpp"
 #include "utils/dbus_utils.hpp"
 
 #include <asm-generic/errno.h>
+#include <sys/types.h>
 
 #include <boost/beast/http/verb.hpp>
 #include <boost/system/error_code.hpp>
@@ -26,12 +28,17 @@
 #include <sdbusplus/message/native_types.hpp>
 #include <sdbusplus/unpack_properties.hpp>
 
+#include <algorithm>
 #include <array>
 #include <cmath>
 #include <functional>
 #include <memory>
+#include <optional>
+#include <ranges>
 #include <string>
 #include <string_view>
+#include <utility>
+#include <vector>
 
 namespace redfish
 {
@@ -181,6 +188,265 @@ inline void fillCableHealthState(
         });
 }
 
+inline void afterGetCableUpstreamResources(
+    const std::shared_ptr<bmcweb::AsyncResp>& asyncResp,
+    const boost::system::error_code& ec,
+    const dbus::utility::MapperEndPoints& endpoints)
+{
+    if (ec && ec.value() != EBADR)
+    {
+        BMCWEB_LOG_ERROR("DBUS response error {}", ec.value());
+        messages::internalError(asyncResp->res);
+        return;
+    }
+    if (endpoints.empty())
+    {
+        BMCWEB_LOG_DEBUG("No association found");
+        return;
+    }
+
+    nlohmann::json::array_t linkArray;
+    for (const auto& fullPath : endpoints)
+    {
+        sdbusplus::message::object_path path(fullPath);
+        std::string devName = path.filename();
+        if (devName.empty())
+        {
+            continue;
+        }
+        nlohmann::json::object_t item;
+        item["@odata.id"] = boost::urls::format(
+            "/redfish/v1/Systems/system/PCIeDevices/{}", devName);
+        linkArray.emplace_back(item);
+    }
+    asyncResp->res.jsonValue["Links"]["UpstreamResources@odata.count"] =
+        linkArray.size();
+    asyncResp->res.jsonValue["Links"]["UpstreamResources"] =
+        std::move(linkArray);
+}
+
+inline void getCableUpstreamResources(
+    const std::shared_ptr<bmcweb::AsyncResp>& asyncResp,
+    const std::string& cableObjectPath)
+{
+    // retrieve Upstream Resources
+    sdbusplus::message::object_path endpointPath{cableObjectPath};
+    endpointPath /= "upstream_resource";
+
+    constexpr std::array<std::string_view, 1> pcieDeviceInterface = {
+        "xyz.openbmc_project.Inventory.Item.PCIeDevice"};
+
+    dbus::utility::getAssociatedSubTreePaths(
+        endpointPath,
+        sdbusplus::message::object_path("/xyz/openbmc_project/inventory"), 0,
+        pcieDeviceInterface,
+        std::bind_front(afterGetCableUpstreamResources, asyncResp));
+}
+
+inline void afterGetCableDownstreamResources(
+    const std::shared_ptr<bmcweb::AsyncResp>& asyncResp,
+    const std::vector<std::string>& updatedAssemblyList,
+    const boost::system::error_code& ec,
+    const dbus::utility::MapperEndPoints& endpoints)
+{
+    if (ec && ec.value() != EBADR)
+    {
+        BMCWEB_LOG_ERROR("DBUS response error {}", ec.value());
+        messages::internalError(asyncResp->res);
+        return;
+    }
+    if (endpoints.empty())
+    {
+        BMCWEB_LOG_DEBUG("No association found");
+        return;
+    }
+
+    nlohmann::json::array_t linkArray;
+    for (const auto& fullPath : endpoints)
+    {
+        auto it = std::ranges::find(updatedAssemblyList.begin(),
+                                    updatedAssemblyList.end(), fullPath);
+
+        // If element was not found
+        if (it == updatedAssemblyList.end())
+        {
+            BMCWEB_LOG_WARNING(
+                "in Downstream Resources {} isn't found in chassis assembly list",
+                fullPath);
+            continue;
+        }
+        uint index = static_cast<uint>(it - updatedAssemblyList.begin());
+
+        nlohmann::json::object_t item;
+        item["@odata.id"] = boost::urls::format(
+            "/redfish/v1/Chassis/chassis/Assembly#/Assemblies/{}",
+            std::to_string(index));
+        linkArray.emplace_back(item);
+    }
+    asyncResp->res.jsonValue["Links"]["DownstreamResources@odata.count"] =
+        linkArray.size();
+    asyncResp->res.jsonValue["Links"]["DownstreamResources"] =
+        std::move(linkArray);
+}
+
+inline void doGetCableDownstreamResources(
+    const std::shared_ptr<bmcweb::AsyncResp>& asyncResp,
+    const std::string& cableObjectPath,
+    const std::vector<std::string>& updatedAssemblyList)
+{
+    sdbusplus::message::object_path endpointPath{cableObjectPath};
+    endpointPath /= "downstream_resource";
+    dbus::utility::getAssociationEndPoints(
+        endpointPath, std::bind_front(afterGetCableDownstreamResources,
+                                      asyncResp, updatedAssemblyList));
+}
+
+inline void getCableDownstreamResources(
+    const std::shared_ptr<bmcweb::AsyncResp>& asyncResp,
+    const std::string& cableObjectPath)
+{
+    // retrieve Downstream Resources
+    chassis_utils::getChassisAssembly(
+        asyncResp, "chassis",
+        [asyncResp,
+         cableObjectPath](const std::optional<std::string>& validChassisPath,
+                          const std::vector<std::string>& updatedAssemblyList) {
+            if (!validChassisPath || updatedAssemblyList.empty())
+            {
+                BMCWEB_LOG_DEBUG("Chassis not found");
+                return;
+            }
+            doGetCableDownstreamResources(asyncResp, cableObjectPath,
+                                          updatedAssemblyList);
+        });
+}
+
+inline void afterGetCableAssociatedPorts(
+    const std::shared_ptr<bmcweb::AsyncResp>& asyncResp,
+    const nlohmann::json::json_pointer& jsonKeyName,
+    const boost::system::error_code& ec,
+    const dbus::utility::MapperGetSubTreePathsResponse& endpoints)
+{
+    if (ec && ec.value() != EBADR)
+    {
+        BMCWEB_LOG_ERROR("DBUS response error {}", ec.value());
+        messages::internalError(asyncResp->res);
+        return;
+    }
+    if (endpoints.empty())
+    {
+        BMCWEB_LOG_DEBUG("No association found");
+        return;
+    }
+    nlohmann::json::json_pointer jsonCountKeyName = jsonKeyName;
+    std::string back = jsonCountKeyName.back();
+    jsonCountKeyName.pop_back();
+    jsonCountKeyName /= back + "@odata.count";
+
+    nlohmann::json::array_t linkArray;
+    for (const auto& fullPath : endpoints)
+    {
+        sdbusplus::message::object_path path(fullPath);
+        std::string portName = path.filename();
+        if (portName.empty())
+        {
+            continue;
+        }
+
+        // NOTE: adapterId is currently assumed as the parent of port
+        sdbusplus::message::object_path parentPath{path.parent_path()};
+        std::string adapterName = parentPath.filename();
+        if (adapterName.empty())
+        {
+            continue;
+        }
+        nlohmann::json::object_t item;
+        item["@odata.id"] = boost::urls::format(
+            "/redfish/v1/Systems/system/FabricAdapters/{}/Ports/{}",
+            adapterName, portName);
+        linkArray.emplace_back(item);
+    }
+    asyncResp->res.jsonValue["Links"][jsonCountKeyName] = linkArray.size();
+    asyncResp->res.jsonValue["Links"][jsonKeyName] = std::move(linkArray);
+}
+
+inline void getCableAssociatedPorts(
+    const std::shared_ptr<bmcweb::AsyncResp>& asyncResp,
+    const nlohmann::json::json_pointer& jsonKeyName,
+    const std::string& cableObjectPath, const std::string& associationName)
+{
+    sdbusplus::message::object_path endpointPath{cableObjectPath};
+    endpointPath /= associationName;
+
+    constexpr std::array<std::string_view, 1> portInterfaces = {
+        "xyz.openbmc_project.Inventory.Connector.Port"};
+
+    dbus::utility::getAssociatedSubTreePaths(
+        endpointPath,
+        sdbusplus::message::object_path("/xyz/openbmc_project/inventory"), 0,
+        portInterfaces,
+        std::bind_front(afterGetCableAssociatedPorts, asyncResp, jsonKeyName));
+}
+
+inline void afterGetCableAssociatedChassis(
+    const std::shared_ptr<bmcweb::AsyncResp>& asyncResp,
+    const nlohmann::json::json_pointer& jsonKeyName,
+    const boost::system::error_code& ec,
+    const dbus::utility::MapperGetSubTreePathsResponse& endpoints)
+{
+    if (ec && ec.value() != EBADR)
+    {
+        BMCWEB_LOG_ERROR("DBUS response error {}", ec.value());
+        messages::internalError(asyncResp->res);
+        return;
+    }
+    if (endpoints.empty())
+    {
+        BMCWEB_LOG_DEBUG("No association found");
+        return;
+    }
+    nlohmann::json::json_pointer jsonCountKeyName = jsonKeyName;
+    std::string back = jsonCountKeyName.back();
+    jsonCountKeyName.pop_back();
+    jsonCountKeyName /= back + "@odata.count";
+
+    nlohmann::json::array_t linkArray;
+    for (const auto& fullPath : endpoints)
+    {
+        sdbusplus::message::object_path path(fullPath);
+        std::string leaf = path.filename();
+        if (leaf.empty())
+        {
+            continue;
+        }
+        nlohmann::json::object_t item;
+        item["@odata.id"] = boost::urls::format("/redfish/v1/Chassis/{}", leaf);
+        linkArray.emplace_back(item);
+    }
+    asyncResp->res.jsonValue["Links"][jsonCountKeyName] = linkArray.size();
+    asyncResp->res.jsonValue["Links"][jsonKeyName] = std::move(linkArray);
+}
+
+inline void getCableAssociatedChassis(
+    const std::shared_ptr<bmcweb::AsyncResp>& asyncResp,
+    const nlohmann::json::json_pointer& jsonKeyName,
+    const std::string& cableObjectPath, const std::string& associationName)
+{
+    sdbusplus::message::object_path endpointPath{cableObjectPath};
+    endpointPath /= associationName;
+
+    constexpr std::array<std::string_view, 2> chassisInterfaces = {
+        "xyz.openbmc_project.Inventory.Item.Board",
+        "xyz.openbmc_project.Inventory.Item.Chassis"};
+
+    dbus::utility::getAssociatedSubTreePaths(
+        endpointPath,
+        sdbusplus::message::object_path("/xyz/openbmc_project/inventory"), 0,
+        chassisInterfaces,
+        std::bind_front(afterGetCableAssociatedChassis, asyncResp,
+                        jsonKeyName));
+}
+
 /**
  * @brief Api to get Cable properties.
  * @param[in,out]   asyncResp       Async HTTP response.
@@ -194,6 +460,26 @@ inline void getCableProperties(
     const dbus::utility::MapperServiceMap& serviceMap)
 {
     BMCWEB_LOG_DEBUG("Get Properties for cable {}", cableObjectPath);
+
+    // retrieve Upstream/downstream resources
+    getCableUpstreamResources(asyncResp, cableObjectPath);
+    getCableDownstreamResources(asyncResp, cableObjectPath);
+
+    // retrieve Upstream/downstream ports
+    getCableAssociatedPorts(asyncResp,
+                            nlohmann::json::json_pointer("/UpstreamPorts"),
+                            cableObjectPath, "upstream_connector");
+    getCableAssociatedPorts(asyncResp,
+                            nlohmann::json::json_pointer("/DownstreamPorts"),
+                            cableObjectPath, "downstream_connector");
+
+    // retrieve Upstream/downstream Chassis
+    getCableAssociatedChassis(asyncResp,
+                              nlohmann::json::json_pointer("/UpstreamChassis"),
+                              cableObjectPath, "upstream_chassis");
+    getCableAssociatedChassis(
+        asyncResp, nlohmann::json::json_pointer("/DownstreamChassis"),
+        cableObjectPath, "downstream_chassis");
 
     for (const auto& [service, interfaces] : serviceMap)
     {
@@ -244,7 +530,7 @@ inline void afterHandleCableGet(
             continue;
         }
 
-        asyncResp->res.jsonValue["@odata.type"] = "#Cable.v1_0_0.Cable";
+        asyncResp->res.jsonValue["@odata.type"] = "#Cable.v1_2_4.Cable";
         asyncResp->res.jsonValue["@odata.id"] =
             boost::urls::format("/redfish/v1/Cables/{}", cableId);
         asyncResp->res.jsonValue["Id"] = cableId;


### PR DESCRIPTION
1. Refactor Cable code
It is refactoring Cable code  for the future incoming codes into the
area. It includes the following to reduce the body size via the smaller
functions.
- getCableProperties
- requestRoutesCable

2. Add Cable State, Health, and PartNumber

This commit is to add CableStatus, Status, and PartNumber in Redfish
Cable, once CableStatus phosphor-dbus-interface is added.
- https://gerrit.openbmc.org/c/openbmc/phosphor-dbus-interfaces/+/70087

1) State and Health
```
curl -k -H "X-Auth-Token: $t" https://${bmc}/redfish/v1/Cables/dp0_cable1

{
  "@odata.id": "/redfish/v1/Cables/dp0_cable1",
  "@odata.type": "#Cable.v1_2_0.Cable",
  "CableStatus": "Normal",
  "Id": "dp0_cable1",
  ...
  "Name": "Cable",
  "Status": {
    "Health": "OK",
    "State": "StandbyOffline"
  }
}
```
Change-Id: I67d17da4acd09080cbacead07678d24119c4c2b5


2)  Add PartNumber to Cables

```
$ curl -k -H "X-Auth-Token: $token" -X GET \
     https://${bmc}/redfish/v1/Cables/external_cable_0
{
  "@odata.id": "/redfish/v1/Cables/external_cable_0",
  "@odata.type": "#Cable.v1_2_0.Cable",
  "CableStatus": "Normal",
  "CableType": "optical",
  "Id": "external_cable_0",
  "LengthMeters": 2.0,
  ...
  "Name": "Cable",
  "PartNumber": "78P6567 ",
  "Status": {
    "Health": "OK",
    "State": "Enabled"
  }
}
```

Change-Id: I9f99f7cfe348545506753cc4eedd81570fbf3fba


3. Add PCIe Topology Cable Links

This commit adds a downstream/upstream port, downstream/upstream
resource, and downstream/upstream chassis link into the cable JSON
response, which represents and association between associated cables for
willimakas and cable card.

This also updates Cable schema version to the latest - `#Cable.v1_2_4`
to address an issue [1].

```
$ curl -k -H "X-Auth-Token: $token" -X GET https://${bmc}/redfish/v1/Cables/dp0_cable0
{
  "@odata.id": "/redfish/v1/Cables/dp0_cable0",
  "@odata.type": "#Cable.v1_2_0.Cable",
  "CableStatus": "Normal",
  "CableType": "",
  "Id": "dp0_cable0",
  "Links": {
    "DownstreamPorts": [
      {
        "@odata.id": "/redfish/v1/Systems/system/FabricAdapters/disk_backplane0/Ports/dp0_connector1"
      }
    ],
    "DownstreamResources": [
      {
        "@odata.id": "/redfish/v1/Chassis/chassis/Assembly#/Assemblies/24"
      }
    ],
    "UpstreamPorts": [
      {
        "@odata.id": "/redfish/v1/Systems/system/FabricAdapters/pcie_card10/Ports/c10_connector0"
      }
    ],
    "UpstreamResources": [
      {
        "@odata.id": "/redfish/v1/Systems/system/PCIeDevices/pcie_card8"
      },
      {
        "@odata.id": "/redfish/v1/Systems/system/PCIeDevices/pcie_card10"
      }
    ]
  },
  "Name": "Cable",
  ...
}
```
[1] https://github.com/DMTF/Redfish/issues/6176

Change-Id: I87a3daf5c4f9ed4af6b9fdf967ca6852c3babeba

Tested:
-  Redfish-Service-Validator passes
- GET Cable
