### PR TITLE
1120: Add getChassisAssembly utility function

### DIFF
--- a/redfish-core/include/utils/chassis_utils.hpp
+++ b/redfish-core/include/utils/chassis_utils.hpp
@@ -7,16 +7,35 @@
 #include "error_messages.hpp"
 #include "logging.hpp"
 
+#include <asm-generic/errno.h>
+
+#include <boost/system/error_code.hpp>
 #include <sdbusplus/message/native_types.hpp>
 
+#include <algorithm>
 #include <array>
+#include <functional>
 #include <memory>
 #include <optional>
+#include <ranges>
 #include <string>
 #include <string_view>
+#include <utility>
+#include <vector>
 
 namespace redfish
 {
+
+static constexpr std::array<std::string_view, 9> chassisAssemblyInterfaces = {
+    "xyz.openbmc_project.Inventory.Item.Vrm",
+    "xyz.openbmc_project.Inventory.Item.Tpm",
+    "xyz.openbmc_project.Inventory.Item.Panel",
+    "xyz.openbmc_project.Inventory.Item.Battery",
+    "xyz.openbmc_project.Inventory.Item.DiskBackplane",
+    "xyz.openbmc_project.Inventory.Item.Board",
+    "xyz.openbmc_project.Inventory.Item.Connector",
+    "xyz.openbmc_project.Inventory.Item.Drive",
+    "xyz.openbmc_project.Inventory.Item.Board.Motherboard"};
 
 namespace chassis_utils
 {
@@ -69,6 +88,81 @@ void getValidChassisPath(const std::shared_ptr<bmcweb::AsyncResp>& asyncResp,
             callback(chassisPath);
         });
     BMCWEB_LOG_DEBUG("checkChassisId exit");
+}
+
+inline void doGetAssociatedChassisAssembly(
+    const std::shared_ptr<bmcweb::AsyncResp>& asyncResp,
+    const std::string& chassisPath,
+    std::function<void(const std::vector<std::string>& assemblyList)>&&
+        callback)
+{
+    BMCWEB_LOG_DEBUG("Get associated chassis assembly");
+
+    sdbusplus::message::object_path endpointPath{chassisPath};
+    endpointPath /= "assembly";
+
+    dbus::utility::getAssociatedSubTreePaths(
+        endpointPath,
+        sdbusplus::message::object_path("/xyz/openbmc_project/inventory"), 0,
+        chassisAssemblyInterfaces,
+        [asyncResp, chassisPath, callback = std::move(callback)](
+            const boost::system::error_code& ec,
+            const dbus::utility::MapperGetSubTreePathsResponse& subtreePaths) {
+            if (ec)
+            {
+                if (ec.value() != EBADR)
+                {
+                    BMCWEB_LOG_ERROR(
+                        "DBUS response error for getAssociatedSubTreePaths {}",
+                        ec.value());
+                    messages::internalError(asyncResp->res);
+                    return;
+                }
+                // Pass the empty assemblyList to caller
+                callback(std::vector<std::string>());
+                return;
+            }
+
+            std::vector<std::string> sortedAssemblyList = subtreePaths;
+            std::ranges::sort(sortedAssemblyList);
+
+            callback(sortedAssemblyList);
+        });
+}
+
+/**
+ * @brief Get chassis path with given chassis ID
+ * @param[in] asyncResp - Shared pointer for asynchronous calls.
+ * @param[in] chassisID - Chassis to which the assemblies are
+ * associated.
+ * @param[in] callback
+ *
+ * @return None.
+ */
+inline void getChassisAssembly(
+    const std::shared_ptr<bmcweb::AsyncResp>& asyncResp,
+    const std::string& chassisID,
+    std::function<void(const std::optional<std::string>& validChassisPath,
+                       const std::vector<std::string>& sortedAssemblyList)>&&
+        callback)
+{
+    BMCWEB_LOG_DEBUG("Get ChassisAssembly");
+
+    // get the chassis path
+    redfish::chassis_utils::getValidChassisPath(
+        asyncResp, chassisID,
+        [asyncResp, callback = std::move(callback)](
+            const std::optional<std::string>& validChassisPath) {
+            if (!validChassisPath)
+            {
+                // tell the caller as not valid chassisPath
+                callback(validChassisPath, std::vector<std::string>());
+                return;
+            }
+            doGetAssociatedChassisAssembly(
+                asyncResp, *validChassisPath,
+                std::bind_front(callback, validChassisPath));
+        });
 }
 
 } // namespace chassis_utils


### PR DESCRIPTION
This adds a general utility function `getChassisAssembly()` to get the list of assemblies for a given `chassisID`. 
This will be utilized by the coming future commits.


Tested:
- Compiles

Change-Id: I415185b64e8c92be5145209944a1d47c9e921359