### PR TITLE
1120: Add PCIeSlot to Associated assembly link (#846)

### DIFF
--- a/redfish-core/schema/oem/ibm/csdl/IBMPCIeSlots_v1.xml
+++ b/redfish-core/schema/oem/ibm/csdl/IBMPCIeSlots_v1.xml
@@ -37,6 +37,7 @@
         <Annotation Term="OData.Description" String="Oem properties for IBM."/>
         <Annotation Term="OData.AutoExpand"/>
         <Property Name="PCIeSlot" Type="IBMPCIeSlots.v1_0_0.PCIeSlot"/>
+        <Property Name="PCIeLinks" Type="IBMPCIeSlots.v1_0_0.PCIeLinks"/>
       </ComplexType>
       <ComplexType Name="PCIeSlot" BaseType="Resource.OemObject">
         <Property Name="LinkId" Type="Edm.Int64">
@@ -44,18 +45,20 @@
           <Annotation Term="OData.Description" String="Number of PCIe lanes in use."/>
         </Property>
       </ComplexType>
-
       <ComplexType Name="PCIeLinks" BaseType="Resource.OemObject">
-        <Annotation Term="OData.AdditionalProperties" Bool="true" />
-        <Annotation Term="OData.Description" String="Oem properties for IBM." />
+        <Annotation Term="OData.AdditionalProperties" Bool="true"/>
+        <Annotation Term="OData.Description" String="Oem properties for IBM."/>
         <Annotation Term="OData.AutoExpand"/>
+        <Property Name="AssociatedAssembly" Type="Resource.Resource">
+          <Annotation Term="OData.Permissions" EnumMember="OData.Permission/Read"/>
+          <Annotation Term="OData.Description" String="Represent association slot with assembly."/>
+        </Property>
         <Property Name="UpstreamFabricAdapters" Type="Collection(FabricAdapter.FabricAdapter)">
           <Annotation Term="OData.Permissions" EnumMember="OData.Permission/Read"/>
           <Annotation Term="OData.Description" String="The upstream fabric adapters."/>
           <Annotation Term="OData.LongDescription" String="This property shall contain an array of links to the upstream fabric adapters."/>
         </Property>
       </ComplexType>
-
     </Schema>
   </edmx:DataServices>
 </edmx:Edmx>

--- a/redfish-core/schema/oem/ibm/json-schema/IBMPCIeSlots.v1_0_0.json
+++ b/redfish-core/schema/oem/ibm/json-schema/IBMPCIeSlots.v1_0_0.json
@@ -109,6 +109,11 @@
                 }
             },
             "properties": {
+                "AssociatedAssembly": {
+                    "description": "Represent association slot with assembly.",
+                    "readonly": true,
+                    "type": ["object", "null"]
+                },
                 "UpstreamFabricAdapters": {
                     "description": "The upstream fabric adapters.",
                     "items": {


### PR DESCRIPTION
Add PCIeSlot to Associated assembly link (#846)

This commit adds PCIeSlot to NVMe backplane assembly link as Json
output `AssociatedAssembly`.

The link is listed in Oem property for each of the configured
PCIe slots.

This is for downstream only.
Issue: https://github.com/ibm-openbmc/dev/issues/3535

Testing:
- Validator PASSED

- List properties for all PCIe Slots

```
$ curl -k -X GET https://${bmc}/redfish/v1/Chassis/chassis/PCIeSlots
{
  "@odata.id": "/redfish/v1/Chassis/chassis/PCIeSlots",
  "Slots": [
    {
      "Links": {
        "Oem": {
          "IBM": {
            "@odata.type": "#IBMPCIeSlots.v1_0_0.PCIeLinks",
            "AssociatedAssembly": {
              "@odata.id": "/redfish/v1/Chassis/chassis/Assembly#/Assemblies/24"
            }
          }
        },
      },
    },
...
}

```

Note: This is built on top of https://github.com/ibm-openbmc/bmcweb/pull/1197 (which can be used for other PRs).