### PR TITLE
util: Add pretty name for resources (#918)

### DIFF
--- a/redfish-core/include/utils/name_utils.hpp
+++ b/redfish-core/include/utils/name_utils.hpp
@@ -1,0 +1,94 @@
+
+#pragma once
+#include "dbus_utility.hpp"
+#include "error_messages.hpp"
+#include "logging.hpp"
+
+#include <async_resp.hpp>
+#include <boost/system/error_code.hpp>
+
+#include <memory>
+#include <string>
+
+namespace redfish
+{
+namespace name_util
+{
+
+/**
+ * @brief Populate the collection "Members" from a GetSubTreePaths search of
+ *        inventory
+ *
+ * @param[i,o] asyncResp  Async response object
+ * @param[i]   path       D-bus object path to find the pretty name
+ * @param[i]   services   Service to exporting the D-bus object path
+ * @param[i]   namePath   Json pointer to the name field to update.
+ *
+ * @return void
+ */
+inline void getPrettyName(const std::shared_ptr<bmcweb::AsyncResp>& asyncResp,
+                          const std::string& path,
+                          const std::string& serviceName,
+                          const nlohmann::json::json_pointer& namePath)
+{
+    BMCWEB_LOG_DEBUG("Get PrettyName for: {}", path);
+
+    dbus::utility::getProperty<std::string>(
+        serviceName, path, "xyz.openbmc_project.Inventory.Item", "PrettyName",
+        [asyncResp, path, namePath](const boost::system::error_code& ec,
+                                    const std::string& prettyName) {
+            if (ec)
+            {
+                BMCWEB_LOG_DEBUG("DBUS response error : {}", ec.value());
+                return;
+            }
+
+            if (prettyName.empty())
+            {
+                return;
+            }
+
+            BMCWEB_LOG_DEBUG("Pretty Name: {}", prettyName);
+
+            asyncResp->res.jsonValue[namePath] = prettyName;
+        });
+}
+
+/**
+ * @brief Populate the collection "Members" from a GetSubTreePaths search of
+ *        inventory
+ *
+ * @param[i,o] asyncResp  Async response object
+ * @param[i]   path       D-bus object path to find the pretty name
+ * @param[i]   services   List of services to exporting the D-bus object path
+ * @param[i]   namePath   Json pointer to the name field to update.
+ *
+ * @return void
+ */
+inline void getPrettyName(const std::shared_ptr<bmcweb::AsyncResp>& asyncResp,
+                          const std::string& path,
+                          const dbus::utility::MapperServiceMap& services,
+                          const nlohmann::json::json_pointer& namePath)
+{
+    BMCWEB_LOG_DEBUG("Get PrettyName with MapperServiceMap for: {}", path);
+
+    // Ensure we only got one service back
+    if (services.size() != 1)
+    {
+        BMCWEB_LOG_ERROR("Invalid Service Size {}", services.size());
+        for (const auto& service : services)
+        {
+            BMCWEB_LOG_ERROR("Invalid Service Name: {}", service.first);
+        }
+        if (asyncResp)
+        {
+            messages::internalError(asyncResp->res);
+        }
+        return;
+    }
+
+    getPrettyName(asyncResp, path, services[0].first, namePath);
+}
+
+} // namespace name_util
+} // namespace redfish

--- a/redfish-core/lib/assembly.hpp
+++ b/redfish-core/lib/assembly.hpp
@@ -14,6 +14,7 @@
 #include "utils/chassis_utils.hpp"
 #include "utils/dbus_utils.hpp"
 #include "utils/json_utils.hpp"
+#include "utils/name_utils.hpp"
 
 #include <boost/beast/http/verb.hpp>
 #include <boost/system/error_code.hpp>
@@ -231,6 +232,10 @@ inline void getAssemblyProperties(
                     messages::internalError(asyncResp->res);
                     return;
                 }
+
+                nlohmann::json::json_pointer ptr(
+                    "/Assemblies/" + std::to_string(assemblyIndex) + "/Name");
+                name_util::getPrettyName(asyncResp, assembly, object, ptr);
 
                 for (const auto& [serviceName, interfaceList] : object)
                 {

--- a/redfish-core/lib/chassis.hpp
+++ b/redfish-core/lib/chassis.hpp
@@ -22,6 +22,7 @@
 #include "utils/collection.hpp"
 #include "utils/dbus_utils.hpp"
 #include "utils/json_utils.hpp"
+#include "utils/name_utils.hpp"
 
 #include <boost/beast/http/field.hpp>
 #include <boost/beast/http/verb.hpp>
@@ -478,7 +479,8 @@ inline void handleChassisGetSubTree(
         asyncResp->res.jsonValue["@odata.type"] = "#Chassis.v1_22_0.Chassis";
         asyncResp->res.jsonValue["@odata.id"] =
             boost::urls::format("/redfish/v1/Chassis/{}", chassisId);
-        asyncResp->res.jsonValue["Name"] = "Chassis Collection";
+        name_util::getPrettyName(asyncResp, path, connectionNames,
+                                 "/Name"_json_pointer);
         asyncResp->res.jsonValue["Actions"]["#Chassis.Reset"]["target"] =
             boost::urls::format("/redfish/v1/Chassis/{}/Actions/Chassis.Reset",
                                 chassisId);

--- a/redfish-core/lib/fabric_adapters.hpp
+++ b/redfish-core/lib/fabric_adapters.hpp
@@ -18,6 +18,7 @@
 #include "utils/collection.hpp"
 #include "utils/dbus_utils.hpp"
 #include "utils/json_utils.hpp"
+#include "utils/name_utils.hpp"
 
 #include <asm-generic/errno.h>
 
@@ -309,7 +310,10 @@ inline void doAdapterGet(
         "</redfish/v1/JsonSchemas/FabricAdapter/FabricAdapter.json>; rel=describedby");
     asyncResp->res.jsonValue["@odata.type"] =
         "#FabricAdapter.v1_4_0.FabricAdapter";
-    asyncResp->res.jsonValue["Name"] = "Fabric Adapter";
+
+    nlohmann::json::json_pointer ptr("/Name");
+    name_util::getPrettyName(asyncResp, fabricAdapterPath, serviceName, ptr);
+
     asyncResp->res.jsonValue["Id"] = adapterId;
     asyncResp->res.jsonValue["@odata.id"] = boost::urls::format(
         "/redfish/v1/Systems/{}/FabricAdapters/{}", systemName, adapterId);

--- a/redfish-core/lib/fabric_ports.hpp
+++ b/redfish-core/lib/fabric_ports.hpp
@@ -17,6 +17,7 @@
 #include "query.hpp"
 #include "registries/privilege_registry.hpp"
 #include "utils/json_utils.hpp"
+#include "utils/name_utils.hpp"
 
 #include <asm-generic/errno.h>
 
@@ -156,7 +157,10 @@ inline void getFabricPortProperties(
         boost::urls::format("/redfish/v1/Systems/{}/FabricAdapters/{}/Ports/{}",
                             systemName, adapterId, portId);
     asyncResp->res.jsonValue["Id"] = portId;
-    asyncResp->res.jsonValue["Name"] = "Fabric Port";
+
+    nlohmann::json::json_pointer ptr("/Name");
+    name_util::getPrettyName(asyncResp, portPath, serviceName, ptr);
+
     asyncResp->res.jsonValue["Status"]["State"] = resource::State::Enabled;
     asyncResp->res.jsonValue["Status"]["Health"] = resource::Health::OK;
 

--- a/redfish-core/lib/fan.hpp
+++ b/redfish-core/lib/fan.hpp
@@ -14,6 +14,7 @@
 #include "registries/privilege_registry.hpp"
 #include "utils/chassis_utils.hpp"
 #include "utils/json_utils.hpp"
+#include "utils/name_utils.hpp"
 
 #include <asm-generic/errno.h>
 
@@ -235,7 +236,6 @@ inline void addFanCommonProperties(crow::Response& resp,
     resp.addHeader(boost::beast::http::field::link,
                    "</redfish/v1/JsonSchemas/Fan/Fan.json>; rel=describedby");
     resp.jsonValue["@odata.type"] = "#Fan.v1_3_0.Fan";
-    resp.jsonValue["Name"] = "Fan";
     resp.jsonValue["Id"] = fanId;
     resp.jsonValue["@odata.id"] = boost::urls::format(
         "/redfish/v1/Chassis/{}/ThermalSubsystem/Fans/{}", chassisId, fanId);
@@ -387,6 +387,7 @@ inline void afterGetValidFanPath(
     getFanAsset(asyncResp, fanPath, service);
     getFanLocation(asyncResp, fanPath, service);
     getLocationIndicatorActive(asyncResp, fanPath);
+    name_util::getPrettyName(asyncResp, fanPath, service, "/Name"_json_pointer);
 }
 
 inline void doFanGet(const std::shared_ptr<bmcweb::AsyncResp>& asyncResp,

--- a/redfish-core/lib/memory.hpp
+++ b/redfish-core/lib/memory.hpp
@@ -20,6 +20,7 @@
 #include "utils/dbus_utils.hpp"
 #include "utils/hex_utils.hpp"
 #include "utils/json_utils.hpp"
+#include "utils/name_utils.hpp"
 
 #include <asm-generic/errno.h>
 
@@ -408,7 +409,6 @@ inline void assembleDimmProperties(
     const nlohmann::json::json_pointer& jsonPtr)
 {
     asyncResp->res.jsonValue[jsonPtr]["Id"] = dimmId;
-    asyncResp->res.jsonValue[jsonPtr]["Name"] = "DIMM Slot";
     asyncResp->res.jsonValue[jsonPtr]["Status"]["State"] =
         resource::State::Enabled;
     asyncResp->res.jsonValue[jsonPtr]["Status"]["Health"] =
@@ -623,6 +623,7 @@ inline void getDimmDataByService(
     const std::string& service, const std::string& objPath)
 {
     BMCWEB_LOG_DEBUG("Get available system components.");
+    name_util::getPrettyName(asyncResp, objPath, service, "/Name"_json_pointer);
     dbus::utility::getAllProperties(
         service, objPath, "",
         [dimmId, asyncResp{std::move(asyncResp)}](

--- a/redfish-core/lib/processor.hpp
+++ b/redfish-core/lib/processor.hpp
@@ -20,11 +20,13 @@
 #include "utils/dbus_utils.hpp"
 #include "utils/hex_utils.hpp"
 #include "utils/json_utils.hpp"
+#include "utils/name_utils.hpp"
 
 #include <boost/beast/http/field.hpp>
 #include <boost/beast/http/verb.hpp>
 #include <boost/system/error_code.hpp>
 #include <boost/url/format.hpp>
+#include <nlohmann/json.hpp>
 #include <sdbusplus/message/native_types.hpp>
 #include <sdbusplus/unpack_properties.hpp>
 
@@ -292,7 +294,8 @@ inline void getCpuDataByService(
                 return;
             }
             asyncResp->res.jsonValue["Id"] = cpuId;
-            asyncResp->res.jsonValue["Name"] = "Processor";
+            name_util::getPrettyName(asyncResp, objPath, service,
+                                     "/Name"_json_pointer);
             asyncResp->res.jsonValue["ProcessorType"] =
                 processor::ProcessorType::CPU;
 

--- a/redfish-core/lib/storage.hpp
+++ b/redfish-core/lib/storage.hpp
@@ -21,10 +21,12 @@
 #include "utils/chassis_utils.hpp"
 #include "utils/collection.hpp"
 #include "utils/dbus_utils.hpp"
+#include "utils/name_utils.hpp"
 
 #include <boost/beast/http/verb.hpp>
 #include <boost/system/error_code.hpp>
 #include <boost/url/format.hpp>
+#include <nlohmann/json.hpp>
 #include <sdbusplus/message/native_types.hpp>
 #include <sdbusplus/unpack_properties.hpp>
 
@@ -664,7 +666,8 @@ inline void afterGetSubtreeSystemsStorageDrive(
     asyncResp->res.jsonValue["@odata.id"] =
         boost::urls::format("/redfish/v1/Systems/{}/Storage/1/Drives/{}",
                             BMCWEB_REDFISH_SYSTEM_URI_NAME, driveId);
-    asyncResp->res.jsonValue["Name"] = driveId;
+    name_util::getPrettyName(asyncResp, path, connectionNames,
+                             "/Name"_json_pointer);
     asyncResp->res.jsonValue["Id"] = driveId;
 
     if (connectionNames.size() != 1)


### PR DESCRIPTION
Created a helper function to fetch pretty name and added for some resources.

- Chassis
- FirmwareInventory
- Storage
- StorageController
- System
- Processor

Implementation Details:
The helper function makes a call to ObjectMapper to get the services that support the object path with the interfaces we want. It expects only one service is exporting the object path.

Then it will try to get the `PrettyName` property. If it is found and is valid, it will set the `Name` to the value. If not, it will use the default value that is set before the function call.

This will affect all systems and replace the Name with the PrettyName if it exist within the resource's object path.

Tested:
Passed Redfish Validator

The output names release the existing `Name` property only if the PrettyName property exists. If not, it will use the default value.

Output with PrettyName
```
$ curl  -u root:0penBmc -X GET http://${bmc}/redfish/v1/Chassis/chassis0
{
  "@odata.id": "/redfish/v1/Chassis/chassis0",
  "@odata.type": "#Chassis.v1_14_0.Chassis",
  "ChassisType": "RackMount",
  "Id": "chassis0",
  "Links": {
    "ComputerSystems": [
      {
        "@odata.id": "/redfish/v1/Systems/system"
      }
    ],
    "ManagedBy": [
      {
        "@odata.id": "/redfish/v1/Managers/bmc"
      }
    ]
  },
  "Name": "Test Chassis",
  ...
}
```

Without PrettyName
```
$ curl  -u root:0penBmc -X GET http://${bmc}/redfish/v1/Chassis/chassis0
{
  "@odata.id": "/redfish/v1/Chassis/chassis0",
  "@odata.type": "#Chassis.v1_14_0.Chassis",
  "ChassisType": "RackMount",
  "Id": "chassis0",
  "Links": {
    "ComputerSystems": [
      {
        "@odata.id": "/redfish/v1/Systems/system"
      }
    ],
    "ManagedBy": [
      {
        "@odata.id": "/redfish/v1/Managers/bmc"
      }
    ]
  },
  "Name": "chassis0",
  ...
}
```

Performance Diff:
 - Before:
```
$ for i in {1..5}; do
    time curl -su root:0penBmc -X GET http://${bmc}/redfish/v1/Chassis/warthog_1 > /dev/null
  done

real    0m0.314s
user    0m0.006s
sys     0m0.003s

real    0m0.346s
user    0m0.003s
sys     0m0.009s

real    0m0.369s
user    0m0.001s
sys     0m0.013s

real    0m0.343s
user    0m0.005s
sys     0m0.010s

real    0m0.356s
user    0m0.006s
sys     0m0.010s
```
 - After:
```
$ for i in {1..5}; do
    time curl -su root:0penBmc -X GET http://${bmc}/redfish/v1/Chassis/warthog_1 > /dev/null;
  done

real    0m0.322s
user    0m0.009s
sys     0m0.005s

real    0m0.343s
user    0m0.007s
sys     0m0.007s

real    0m0.337s
user    0m0.000s
sys     0m0.009s

real    0m0.348s
user    0m0.011s
sys     0m0.005s

real    0m0.379s
user    0m0.010s
sys     0m0.005s

Change-Id: I76e65f4aae979365266ebb38525c4ac45298737b