### PR TITLE
1110: Fix missing PCIeInterface fields on PCIeDevice for MEX or Splitter

### DIFF
--- a/redfish-core/lib/pcie.hpp
+++ b/redfish-core/lib/pcie.hpp
@@ -64,7 +64,7 @@ static inline void handlePCIeDevicePath(
         }
 
         dbus::utility::getDbusObject(
-            pcieDevicePath, {},
+            pcieDevicePath, pcieDeviceInterface,
             [pcieDevicePath, asyncResp,
              callback](const boost::system::error_code& ec,
                        const dbus::utility::MapperGetObject& object) {


### PR DESCRIPTION
Fx missing PCIeInterface fields on PCIeDevice for MEX or Splitter

The output has the missing fields like
```
% curl -k -X GET https://${bmc}/redfish/v1/Systems/system/PCIeDevices/system_chassis15361_logical_slot0_io_module0
```
It misses - PCIeInterface and PartLocation like

```
  "PCIeInterface": {
    "LanesInUse": 16,
    "PCIeType": "Gen4"
  },
  "Slot": {
    "Location": {
      "PartLocation": {
        "ServiceLabel": "U5B61.001.WZS000V-P0"
      }
```

Tested:
- GET on external PCIeDevice like io_module0
- Redfish Service Validator passes


This is due to the missed upstream commit - https://gerrit.openbmc.org/c/openbmc/bmcweb/+/73400 in 1110.

---
https://gerrit.openbmc.org/c/openbmc/bmcweb/+/73400:
Require Inventory.Item.PCIeDevice for PCIe objects

Currently when bmcweb tries to get PCIe device service it checks only path and doesn't limit search by any required interface. This can lead to wrong result if the 'xyz.openbmc_project.ObjectMapper' for example have object with the same path.
To fix the issue require xyz.openbmc_project.Inventory.Item.PCIeDevice interface to be present in the object.

Tested:
Patchest was tested on the system with a DBUS service that has objects with the "xyz.openbmc_project.Inventory.Item.PCIeDevice" interface.

Before the change request to the PCIe device endpoint like /redfish/v1/Systems/system/PCIeDevices/Bus_00_Device_00 outputs internal error message.

After the change request to the PCIe device endpoint like /redfish/v1/Systems/system/PCIeDevices/Bus_00_Device_00 outputs detailed PCIe device info including all the relevant links to its PCIe functions.

Change-Id: I25d60533fa8f7bdda26c81bde1fa0a88c25365f6

