### PR TITLE
1120 Fix getting a response for wrong URI

### DIFF
--- a/redfish-core/lib/update_service.hpp
+++ b/redfish-core/lib/update_service.hpp
@@ -1390,13 +1390,10 @@ inline void handleUpdateServiceFirmwareInventoryGet(
     }
     std::shared_ptr<std::string> swId = std::make_shared<std::string>(param);
 
-    asyncResp->res.jsonValue["@odata.id"] = boost::urls::format(
-        "/redfish/v1/UpdateService/FirmwareInventory/{}", *swId);
-
     constexpr std::array<std::string_view, 1> interfaces = {
         "xyz.openbmc_project.Software.Version"};
     dbus::utility::getSubTree(
-        "/", 0, interfaces,
+        "/xyz/openbmc_project/software/", 0, interfaces,
         [asyncResp,
          swId](const boost::system::error_code& ec,
                const dbus::utility::MapperGetSubTreeResponse& subtree) {
@@ -1414,7 +1411,15 @@ inline void handleUpdateServiceFirmwareInventoryGet(
                                      std::string, std::vector<std::string>>>>&
                      obj : subtree)
             {
-                if (!obj.first.ends_with(*swId))
+                sdbusplus::message::object_path path(obj.first);
+                std::string id = path.filename();
+                if (id.empty())
+                {
+                    BMCWEB_LOG_DEBUG("Failed to find software id in {}",
+                                     obj.first);
+                    continue;
+                }
+                if (id != *swId)
                 {
                     continue;
                 }
@@ -1439,6 +1444,8 @@ inline void handleUpdateServiceFirmwareInventoryGet(
                         *swId));
                 return;
             }
+            asyncResp->res.jsonValue["@odata.id"] = boost::urls::format(
+                "/redfish/v1/UpdateService/FirmwareInventory/{}", *swId);
             asyncResp->res.jsonValue["@odata.type"] =
                 "#SoftwareInventory.v1_1_0.SoftwareInventory";
             asyncResp->res.jsonValue["Name"] = "Software Inventory";


### PR DESCRIPTION
Resolve getting a response for wrong URI in Update Service URI (/redfish/v1/UpdateService/FirmwareInventory/)

- After the fix a wrong URI that partially matches the last characters in a valid URI now gets a 404 as shown in the example below :

$ curl -k -H "X-Auth-Token: $bmc_token" -X GET
https://$bmc/redfish/v1/UpdateService/FirmwareInventory/5e {
  "error": {
    "@Message.ExtendedInfo": [
      {
        "@odata.type": "#Message.v1_1_1.Message",
        "Message": "The resource at the URI '/redfish/v1/
        UpdateService/FirmwareInventory/5e' was not found.",
        "MessageArgs": [
          "/redfish/v1/UpdateService/FirmwareInventory/5e"
        ],
        "MessageId": "Base.1.19.ResourceMissingAtURI",
        "MessageSeverity": "Critical",
        "Resolution": "Place a valid resource at the URI or
        correct the URI and resubmit the request."
      }
    ],
    "code": "Base.1.19.ResourceMissingAtURI",
    "message": "The resource at the URI '/redfish/v1/
    UpdateService/FirmwareInventory/5e' was not found."
  }

- Two common errors were fixed with the changes
  - imprecise-matching
  - not-responding-to-404

- The fix also includes changes to the software images to only look under /xyz/openbmc_project/software/.

Tested: No longer getting a response for wrong URI in Update Service URI.

Change-Id: I72d8452b8ca1ef095d093a57bc14fade380be617

Link to upstream commit : https://gerrit.openbmc.org/c/openbmc/bmcweb/+/79006