### PR TITLE
1120: Inventory properties via Assembly schema on bmcweb (#816)(#844)(#1134)

### DIFF
--- a/redfish-core/lib/assembly.hpp
+++ b/redfish-core/lib/assembly.hpp
@@ -1,0 +1,268 @@
+#pragma once
+
+#include "app.hpp"
+#include "async_resp.hpp"
+#include "dbus_singleton.hpp"
+#include "dbus_utility.hpp"
+#include "error_messages.hpp"
+#include "http_request.hpp"
+#include "http_response.hpp"
+#include "logging.hpp"
+#include "registries/privilege_registry.hpp"
+#include "utils/chassis_utils.hpp"
+#include "utils/dbus_utils.hpp"
+
+#include <boost/beast/http/verb.hpp>
+#include <boost/system/error_code.hpp>
+#include <boost/url/format.hpp>
+#include <nlohmann/json.hpp>
+#include <sdbusplus/unpack_properties.hpp>
+
+#include <cstddef>
+#include <functional>
+#include <memory>
+#include <optional>
+#include <ranges>
+#include <string>
+#include <string_view>
+#include <vector>
+
+namespace redfish
+{
+
+/**
+ * @brief Get Asset properties on the given assembly.
+ * @param[in] asyncResp - Shared pointer for asynchronous calls.
+ * @param[in] serviceName - Service in which the assembly is hosted.
+ * @param[in] assembly - Assembly object.
+ * @param[in] assemblyIndex - Index on the assembly object.
+ * @return None.
+ */
+void getAssemblyAsset(const std::shared_ptr<bmcweb::AsyncResp>& asyncResp,
+                      const auto& serviceName, const auto& assembly,
+                      const auto& assemblyIndex)
+{
+    sdbusplus::asio::getAllProperties(
+        *crow::connections::systemBus, serviceName, assembly,
+        "xyz.openbmc_project.Inventory.Decorator.Asset",
+        [asyncResp, assemblyIndex](
+            const boost::system::error_code& ec1,
+            const dbus::utility::DBusPropertiesMap& propertiesList) {
+            if (ec1)
+            {
+                BMCWEB_LOG_ERROR("DBUS response error {}", ec1.value());
+                messages::internalError(asyncResp->res);
+                return;
+            }
+
+            const std::string* partNumber = nullptr;
+            const std::string* serialNumber = nullptr;
+            const std::string* sparePartNumber = nullptr;
+            const std::string* model = nullptr;
+
+            const bool success = sdbusplus::unpackPropertiesNoThrow(
+                dbus_utils::UnpackErrorPrinter(), propertiesList, "PartNumber",
+                partNumber, "SerialNumber", serialNumber, "SparePartNumber",
+                sparePartNumber, "Model", model);
+
+            if (!success)
+            {
+                messages::internalError(asyncResp->res);
+                return;
+            }
+
+            nlohmann::json& assemblyArray =
+                asyncResp->res.jsonValue["Assemblies"];
+            nlohmann::json& assemblyData = assemblyArray.at(assemblyIndex);
+
+            if (partNumber != nullptr)
+            {
+                assemblyData["PartNumber"] = *partNumber;
+            }
+
+            if (serialNumber != nullptr)
+            {
+                assemblyData["SerialNumber"] = *serialNumber;
+            }
+
+            if (sparePartNumber != nullptr)
+            {
+                assemblyData["SparePartNumber"] = *sparePartNumber;
+            }
+
+            if (model != nullptr)
+            {
+                assemblyData["Model"] = *model;
+            }
+        });
+}
+
+/**
+ * @brief Get Location code for the given assembly.
+ * @param[in] asyncResp - Shared pointer for asynchronous calls.
+ * @param[in] serviceName - Service in which the assembly is hosted.
+ * @param[in] assembly - Assembly object.
+ * @param[in] assemblyIndex - Index on the assembly object.
+ * @return None.
+ */
+void getAssemblyLocationCode(
+    const std::shared_ptr<bmcweb::AsyncResp>& asyncResp,
+    const auto& serviceName, const auto& assembly, const auto& assemblyIndex)
+{
+    sdbusplus::asio::getProperty<std::string>(
+        *crow::connections::systemBus, serviceName, assembly,
+        "xyz.openbmc_project.Inventory.Decorator.LocationCode", "LocationCode",
+        [asyncResp, assemblyIndex](const boost::system::error_code& ec1,
+                                   const std::string& value) {
+            if (ec1)
+            {
+                BMCWEB_LOG_ERROR("DBUS response error: {}", ec1.value());
+                messages::internalError(asyncResp->res);
+                return;
+            }
+
+            nlohmann::json& assemblyArray =
+                asyncResp->res.jsonValue["Assemblies"];
+            nlohmann::json& assemblyData = assemblyArray.at(assemblyIndex);
+
+            assemblyData["Location"]["PartLocation"]["ServiceLabel"] = value;
+        });
+}
+
+/**
+ * @brief Get properties for the assemblies associated to given chassis
+ * @param[in] asyncResp - Shared pointer for asynchronous calls.
+ * @param[in] chassisPath - Chassis the assemblies are associated with.
+ * @param[in] assemblies - list of all the assemblies associated with the
+ * chassis.
+ * @return None.
+ */
+inline void getAssemblyProperties(
+    const std::shared_ptr<bmcweb::AsyncResp>& asyncResp,
+    const std::string& chassisPath, const std::vector<std::string>& assemblies)
+{
+    BMCWEB_LOG_DEBUG("Get properties for assembly associated");
+
+    const std::string& chassis =
+        sdbusplus::message::object_path(chassisPath).filename();
+
+    std::size_t assemblyIndex = 0;
+
+    for (const auto& assembly : assemblies)
+    {
+        nlohmann::json& tempArray = asyncResp->res.jsonValue["Assemblies"];
+
+        nlohmann::json::object_t item;
+        item["@odata.type"] = "#Assembly.v1_3_0.AssemblyData";
+        item["@odata.id"] = boost::urls::format(
+            "/redfish/v1/Chassis/{}/Assembly#/Assemblies/{}", chassis,
+            std::to_string(assemblyIndex));
+        item["MemberId"] = std::to_string(assemblyIndex);
+
+        tempArray.emplace_back(item);
+
+        tempArray.at(assemblyIndex)["Name"] =
+            sdbusplus::message::object_path(assembly).filename();
+
+        dbus::utility::getDbusObject(
+            assembly, chassisAssemblyInterfaces,
+            [asyncResp, assemblyIndex,
+             assembly](const boost::system::error_code& ec,
+                       const dbus::utility::MapperGetObject& object) {
+                if (ec)
+                {
+                    BMCWEB_LOG_ERROR("DBUS response error : {}", ec.value());
+                    messages::internalError(asyncResp->res);
+                    return;
+                }
+
+                for (const auto& [serviceName, interfaceList] : object)
+                {
+                    for (const auto& interface : interfaceList)
+                    {
+                        if (interface ==
+                            "xyz.openbmc_project.Inventory.Decorator.Asset")
+                        {
+                            getAssemblyAsset(asyncResp, serviceName, assembly,
+                                             assemblyIndex);
+                        }
+                        else if (
+                            interface ==
+                            "xyz.openbmc_project.Inventory.Decorator.LocationCode")
+                        {
+                            getAssemblyLocationCode(asyncResp, serviceName,
+                                                    assembly, assemblyIndex);
+                        }
+                    }
+                }
+            });
+
+        nlohmann::json& assemblyArray = asyncResp->res.jsonValue["Assemblies"];
+        asyncResp->res.jsonValue["Assemblies@odata.count"] =
+            assemblyArray.size();
+
+        assemblyIndex++;
+    }
+}
+
+/**
+ * @brief Get chassis path with given chassis ID
+ * @param[in] asyncResp - Shared pointer for asynchronous calls.
+ * @param[in] chassisID - Chassis to which the assemblies are
+ * associated.
+ *
+ * @return None.
+ */
+inline void handleChassisAssemblyGet(
+    App& /*unused*/, const crow::Request& /*unused*/,
+    const std::shared_ptr<bmcweb::AsyncResp>& asyncResp,
+    const std::string& chassisID)
+{
+    BMCWEB_LOG_DEBUG("Get chassis path");
+
+    chassis_utils::getChassisAssembly(
+        asyncResp, chassisID,
+        [asyncResp,
+         chassisID](const std::optional<std::string>& validChassisPath,
+                    const std::vector<std::string>& assemblyList) {
+            if (!validChassisPath)
+            {
+                BMCWEB_LOG_WARNING("Chassis not found");
+                messages::resourceNotFound(asyncResp->res, "Chassis",
+                                           chassisID);
+                return;
+            }
+            const std::string& chassisPath = *validChassisPath;
+
+            asyncResp->res.jsonValue["@odata.type"] =
+                "#Assembly.v1_3_0.Assembly";
+            asyncResp->res.jsonValue["@odata.id"] = boost::urls::format(
+                "/redfish/v1/Chassis/{}/Assembly", chassisID);
+            asyncResp->res.jsonValue["Name"] = "Assembly Collection";
+            asyncResp->res.jsonValue["Id"] = "Assembly";
+
+            asyncResp->res.jsonValue["Assemblies"] = nlohmann::json::array();
+            asyncResp->res.jsonValue["Assemblies@odata.count"] = 0;
+
+            if (!assemblyList.empty())
+            {
+                getAssemblyProperties(asyncResp, chassisPath, assemblyList);
+            }
+        });
+}
+
+/**
+ * Systems derived class for delivering Assembly Schema.
+ */
+inline void requestRoutesAssembly(App& app)
+{
+    /**
+     * Functions triggers appropriate requests on DBus
+     */
+    BMCWEB_ROUTE(app, "/redfish/v1/Chassis/<str>/Assembly/")
+        .privileges(redfish::privileges::getAssembly)
+        .methods(boost::beast::http::verb::get)(
+            std::bind_front(handleChassisAssemblyGet, std::ref(app)));
+}
+
+} // namespace redfish

--- a/redfish-core/lib/chassis.hpp
+++ b/redfish-core/lib/chassis.hpp
@@ -387,6 +387,10 @@ inline void handleDecoratorAssetProperties(
             boost::urls::format("/redfish/v1/Chassis/{}/EnvironmentMetrics",
                                 chassisId);
     }
+
+    asyncResp->res.jsonValue["Assembly"]["@odata.id"] =
+        boost::urls::format("/redfish/v1/Chassis/{}/Assembly", chassisId);
+
     // SensorCollection
     asyncResp->res.jsonValue["Sensors"]["@odata.id"] =
         boost::urls::format("/redfish/v1/Chassis/{}/Sensors", chassisId);

--- a/redfish-core/src/redfish.cpp
+++ b/redfish-core/src/redfish.cpp
@@ -7,6 +7,7 @@
 #include "account_service.hpp"
 #include "aggregation_service.hpp"
 #include "app.hpp"
+#include "assembly.hpp"
 #include "bios.hpp"
 #include "cable.hpp"
 #include "certificate_service.hpp"
@@ -111,6 +112,7 @@ RedfishService::RedfishService(App& app)
     requestRoutesDrive(app);
     requestRoutesCable(app);
     requestRoutesCableCollection(app);
+    requestRoutesAssembly(app);
 
     requestRoutesSystemLogServiceCollection(app);
     requestRoutesEventLogService(app);


### PR DESCRIPTION
This commit implements Redfish Assembly schema on bmcweb. This schema will be used to publish inventory data for FRUs which are attached to a given chassis and do not map to any specific schema definition.

The properties which are published in this commit are LocationCode, SparePartNumber, Model, SerialNumber and PartNumber.

One of the major use case to publish these properties via redfish is for servce engineers to identify the FRU and its location in the system, which in thurn will help them in repair/replacement related to that FRU.

The validator has been executed on the change and no error has been found. A
As this has been tested on a development image some fields are empty in the below pasted output for which warning was thrown by validator but no errors.

Sample Output:

```
curl -k -H "X-Auth-Token: $bmc_token" -X GET https://${bmc}/redfish/v1
/Chassis/chassis/Assembly/
{
  "@odata.id": "/redfish/v1/Chassis/chassis/Assembly",
  "@odata.type": "#Assembly.v1_3_0.Assembly",
  "Assemblies": [
    {
      "@odata.id": "/redfish/v1/Chassis/chassis/Assembly#/Assemblies/0",
      "@odata.type": "#Assembly.v1_3_0.AssemblyData",
      "Location": {
        "PartLocation": {
          "ServiceLabel": "U78DA.ND0.WZS004A-D0"
        }
      },
      "MemberId": "0",
      "Model": "6B85",
      "Name": "base_op_panel_blyth",
      "PartNumber": "02WF427",
      "SerialNumber": "YA30UF05W00R",
      "SparePartNumber": "02PX028"
    },
    {
      "@odata.id": "/redfish/v1/Chassis/chassis/Assembly#/Assemblies/1",
      "@odata.type": "#Assembly.v1_3_0.AssemblyData",
      "Location": {
        "PartLocation": {
          "ServiceLabel": "U78DA.ND0.WZS004A-P1"
        }
      },
      "MemberId": "1",
      "Model": "6B89",
      "Name": "disk_backplane0",
      "PartNumber": "02WG686",
      "SerialNumber": "YA31UF06Y01X",
      "SparePartNumber": "02WG685"
    },
    {
      "@odata.id": "/redfish/v1/Chassis/chassis/Assembly#/Assemblies/2",
      "@odata.type": "#Assembly.v1_3_0.AssemblyData",
      "Location": {
        "PartLocation": {
          "ServiceLabel": "U78DA.ND0.WZS004A-P2"
        }
      },
      "MemberId": "2",
      "Name": "disk_backplane1"
    },
    {
      "@odata.id": "/redfish/v1/Chassis/chassis/Assembly#/Assemblies/3",
      "@odata.type": "#Assembly.v1_3_0.AssemblyData",
      "Location": {
        "PartLocation": {
          "ServiceLabel": "U78DA.ND0.WZS004A-D1"
        }
      },
      "MemberId": "3",
      "Model": "6B86",
      "Name": "lcd_op_panel_hill",
      "PartNumber": "02WF364",
      "SerialNumber": "YA30UF07300K",
      "SparePartNumber": "02WF367"
    },
    {
      "@odata.id": "/redfish/v1/Chassis/chassis/Assembly#/Assemblies/4",
      "@odata.type": "#Assembly.v1_3_0.AssemblyData",
      "Location": {
        "PartLocation": {
          "ServiceLabel": "U78DA.ND0.WZS004A-P0-E0"
        }
      },
      "MemberId": "4",
      "Model": "2E2D",
      "Name": "tod_battery",
      "PartNumber": "02WG678",
      "SerialNumber": "Y131UF07302J",
      "SparePartNumber": "02WG676"
    },
    {
      "@odata.id": "/redfish/v1/Chassis/chassis/Assembly#/Assemblies/5",
      "@odata.type": "#Assembly.v1_3_0.AssemblyData",
      "Location": {
        "PartLocation": {
          "ServiceLabel": "U78DA.ND0.WZS004A-P0-C22"
        }
      },
      "MemberId": "5",
      "Model": "6B59",
      "Name": "tpm_wilson",
      "PartNumber": "02WF338",
      "SerialNumber": "YL101314Y002",
      "SparePartNumber": "02WF429"
    },
    {
      "@odata.id": "/redfish/v1/Chassis/chassis/Assembly#/Assemblies/6",
      "@odata.type": "#Assembly.v1_3_0.AssemblyData",
      "Location": {
        "PartLocation": {
          "ServiceLabel": "U78DA.ND0.WZS004A-P0-C14"
        }
      },
      "MemberId": "6",
      "Model": "2E32",
      "Name": "vdd_vrm0",
      "PartNumber": "02CM286",
      "SerialNumber": "YH30A005M159",
      "SparePartNumber": "02CM285"
    },
    {
      "@odata.id": "/redfish/v1/Chassis/chassis/Assembly#/Assemblies/7",
      "@odata.type": "#Assembly.v1_3_0.AssemblyData",
      "Location": {
        "PartLocation": {
          "ServiceLabel": "U78DA.ND0.WZS004A-P0-C23"
        }
      },
      "MemberId": "7",
      "Model": "2E32",
      "Name": "vdd_vrm1",
      "PartNumber": "02CM286",
      "SerialNumber": "YH30A005M11V",
      "SparePartNumber": "02CM285"
    }
  ],
  "Assemblies@odata.count": 8,
  "Id": "Assembly",
  "Name": "Assembly Collection"
}
```

Change-Id: I2d462340fe1a0b0eb387697f0ff70fcafde3f8d9





2. Fix json-array copy and refactor assembly(#844)

A json array is mistakenly copied as a part of [1]. This is to remove the unnecessary copy operation but use const reference.

```
       nlohmann::json::array_t assemblyArray =
-            asyncResp->res.jsonValue["Assemblies"];

+        nlohmann::json& assemblyArray = asyncResp->res.jsonValue["Assemblies"];
```

[1] https://github.com/ibm-openbmc/bmcweb/blame/3ca5028e701457d1a0a454bbde2ec75b62ee87c9/redfish-core/lib/assembly.hpp#L194-L197C34




3. This includes the fix of incorrect GET of the attached chassis like MEX (#1134)

For example,

- CEC Assembly : https://rain118bmc.aus.stglabs.ibm.com/redfish/v1/Chassis/chassis/Assembly
- MEX Assembly : https://rain118bmc.aus.stglabs.ibm.com/redfish/v1/Chassis/chassis15363/Assembly

Tested:
- Check MEX assembly