### PR TITLE
1120: Implement LocationIndicatorActive for Assembly (#548)

### DIFF
--- a/redfish-core/lib/assembly.hpp
+++ b/redfish-core/lib/assembly.hpp
@@ -7,10 +7,12 @@
 #include "error_messages.hpp"
 #include "http_request.hpp"
 #include "http_response.hpp"
+#include "led.hpp"
 #include "logging.hpp"
 #include "registries/privilege_registry.hpp"
 #include "utils/chassis_utils.hpp"
 #include "utils/dbus_utils.hpp"
+#include "utils/json_utils.hpp"
 
 #include <boost/beast/http/verb.hpp>
 #include <boost/system/error_code.hpp>
@@ -20,11 +22,13 @@
 
 #include <cstddef>
 #include <functional>
+#include <map>
 #include <memory>
 #include <optional>
 #include <ranges>
 #include <string>
 #include <string_view>
+#include <utility>
 #include <vector>
 
 namespace redfish
@@ -197,6 +201,14 @@ inline void getAssemblyProperties(
                 }
             });
 
+        getLocationIndicatorActive(
+            asyncResp, assembly, [asyncResp, assemblyIndex](bool asserted) {
+                nlohmann::json& assemblyArray =
+                    asyncResp->res.jsonValue["Assemblies"];
+                nlohmann::json& assemblyData = assemblyArray.at(assemblyIndex);
+                assemblyData["LocationIndicatorActive"] = asserted;
+            });
+
         nlohmann::json& assemblyArray = asyncResp->res.jsonValue["Assemblies"];
         asyncResp->res.jsonValue["Assemblies@odata.count"] =
             assemblyArray.size();
@@ -252,6 +264,106 @@ inline void handleChassisAssemblyGet(
 }
 
 /**
+ * @brief Set location indicator for the assemblies associated to given chassis
+ * @param[in] req - The request data
+ * @param[in] asyncResp - Shared pointer for asynchronous calls.
+ * @param[in] chassisID - Chassis the assemblies are associated with.
+ * @param[in] assemblies - list of all the assemblies associated with the
+ * chassis.
+
+ * @return None.
+ */
+inline void setAssemblyLocationIndicators(
+    const crow::Request& req,
+    const std::shared_ptr<bmcweb::AsyncResp>& asyncResp,
+    const std::string& chassisID, const std::vector<std::string>& assemblies)
+{
+    BMCWEB_LOG_DEBUG(
+        "Set LocationIndicatorActive for assembly associated to chassis = {}",
+        chassisID);
+
+    std::optional<std::vector<nlohmann::json>> assemblyData;
+    if (!json_util::readJsonAction(req, asyncResp->res, "Assemblies",
+                                   assemblyData))
+    {
+        return;
+    }
+    if (!assemblyData)
+    {
+        return;
+    }
+
+    std::vector<nlohmann::json> items = std::move(*assemblyData);
+    std::map<std::string, bool> locationIndicatorActiveMap;
+
+    for (auto& item : items)
+    {
+        std::optional<std::string> memberId;
+        std::optional<bool> locationIndicatorActive;
+
+        if (!json_util::readJson(item, asyncResp->res,
+                                 "LocationIndicatorActive",
+                                 locationIndicatorActive, "MemberId", memberId))
+        {
+            return;
+        }
+        if (locationIndicatorActive)
+        {
+            if (memberId)
+            {
+                locationIndicatorActiveMap[*memberId] =
+                    *locationIndicatorActive;
+            }
+            else
+            {
+                BMCWEB_LOG_WARNING(
+                    "Property Missing - MemberId must be included with LocationIndicatorActive ");
+                messages::propertyMissing(asyncResp->res, "MemberId");
+                return;
+            }
+        }
+    }
+
+    std::size_t assemblyIndex = 0;
+    for (const auto& assembly : assemblies)
+    {
+        auto iter =
+            locationIndicatorActiveMap.find(std::to_string(assemblyIndex));
+
+        if (iter != locationIndicatorActiveMap.end())
+        {
+            setLocationIndicatorActive(asyncResp, assembly, iter->second);
+        }
+        assemblyIndex++;
+    }
+}
+
+inline void handleChassisAssemblyPatch(
+    App& /*unused*/, const crow::Request& req,
+    const std::shared_ptr<bmcweb::AsyncResp>& asyncResp,
+    const std::string& chassisID)
+{
+    BMCWEB_LOG_DEBUG("Patch chassis path");
+
+    chassis_utils::getChassisAssembly(
+        asyncResp, chassisID,
+        [req, asyncResp,
+         chassisID](const std::optional<std::string>& validChassisPath,
+                    const std::vector<std::string>& assemblyList) {
+            if (!validChassisPath || assemblyList.empty())
+            {
+                BMCWEB_LOG_WARNING("Chassis not found");
+                messages::resourceNotFound(asyncResp->res, "Chassis",
+                                           chassisID);
+                return;
+            }
+
+            setAssemblyLocationIndicators(req, asyncResp, chassisID,
+                                          assemblyList);
+        });
+}
+
+/**
  * Systems derived class for delivering Assembly Schema.
  */
 inline void requestRoutesAssembly(App& app)
@@ -263,6 +375,10 @@ inline void requestRoutesAssembly(App& app)
         .privileges(redfish::privileges::getAssembly)
         .methods(boost::beast::http::verb::get)(
             std::bind_front(handleChassisAssemblyGet, std::ref(app)));
-}
 
+    BMCWEB_ROUTE(app, "/redfish/v1/Chassis/<str>/Assembly/")
+        .privileges(redfish::privileges::patchAssembly)
+        .methods(boost::beast::http::verb::patch)(
+            std::bind_front(handleChassisAssemblyPatch, std::ref(app)));
+}
 } // namespace redfish


### PR DESCRIPTION
Implement LocationIndicatorActive for Assembly (#548)

Implement LocationIndicatorActive for Assembly schema, We can use
locationindicatoractive to set or get the status of the location led of
each Assembly.


Tested: Validator passes.
1. Get LocationIndicatorActive
```
curl -k -H "X-Auth-Token: $token" -X GET https://${bmc}/redfish/v1/Chassis/chassis/Assembly
{
  "@odata.id": "/redfish/v1/Chassis/chassis/Assembly",
  "@odata.type": "#Assembly.v1_3_0.Assembly",
  "Assemblies": [
    {
      "@odata.id": "/redfish/v1/Chassis/chassis/Assembly#/Assemblies/0",
      "@odata.type": "#Assembly.v1_3_0.AssemblyData",
      "LocationIndicatorActive": false,
      "MemberId": "0",

      ...

    },
    {
      "@odata.id": "/redfish/v1/Chassis/chassis/Assembly#/Assemblies/1",
      "@odata.type": "#Assembly.v1_3_0.AssemblyData",
      "LocationIndicatorActive": false,
      "MemberId": "1",

      ...

    }
  ],
  "Assemblies@odata.count": 2,
  "Id": "Assembly",
  "Name": "Assembly Collection"
}
```


2. Set LocationIndicatorActive to true
```
curl -k -H "X-Auth-Token: $token" -H "Content-Type: application/json" \
     -X PATCH -d '{"Assemblies":[{"MemberId" : "0", "LocationIndicatorActive":true},{"MemberId": "1", "LocationIndicatorActive":true}]}' \
     https://${bmc}/redfish/v1/Chassis/chassis/Assembly
```


Change-Id: I5bc94cea536a99eb77aa2d8772e843bddc7ce39e
