### PR TITLE
Verify MFA configuration for new user sessions

### DIFF
--- a/include/sessions.hpp
+++ b/include/sessions.hpp
@@ -52,6 +52,7 @@ struct UserSession
     SessionType sessionType{SessionType::None};
     bool cookieAuth = false;
     bool isConfigureSelfOnly = false;
+    bool isGenerateSecretKeyRequired = false;
     std::string userRole;
     std::vector<std::string> userGroups;
 
@@ -271,7 +272,8 @@ class SessionStore
     std::shared_ptr<UserSession> generateUserSession(
         std::string_view username, const boost::asio::ip::address& clientIp,
         const std::optional<std::string>& clientId, SessionType sessionType,
-        bool isConfigureSelfOnly = false)
+        bool isConfigureSelfOnly = false,
+        bool isGenerateSecretKeyRequired = false)
     {
         // Only need csrf tokens for cookie based auth, token doesn't matter
         std::string sessionToken =
@@ -297,6 +299,7 @@ class SessionStore
             sessionType,
             false,
             isConfigureSelfOnly,
+            isGenerateSecretKeyRequired,
             "",
             {}});
         auto it = authTokens.emplace(sessionToken, session);

--- a/redfish-core/lib/redfish_sessions.hpp
+++ b/redfish-core/lib/redfish_sessions.hpp
@@ -8,9 +8,11 @@
 #include "async_resp.hpp"
 #include "cookies.hpp"
 #include "dbus_privileges.hpp"
+#include "dbus_singleton.hpp"
 #include "error_messages.hpp"
 #include "http_request.hpp"
 #include "http_response.hpp"
+#include "logging.hpp"
 #include "pam_authenticate.hpp"
 #include "privileges.hpp"
 #include "query.hpp"
@@ -18,12 +20,15 @@
 #include "sessions.hpp"
 #include "utils/json_utils.hpp"
 
+#include <asm-generic/errno.h>
 #include <security/_pam_types.h>
 
 #include <boost/beast/http/field.hpp>
 #include <boost/beast/http/status.hpp>
 #include <boost/beast/http/verb.hpp>
 #include <boost/url/format.hpp>
+#include <boost/url/url.hpp>
+#include <sdbusplus/message/native_types.hpp>
 
 #include <chrono>
 #include <cstdint>
@@ -208,7 +213,8 @@ inline void handleSessionCollectionMembersGet(
 inline void processAfterSessionCreation(
     const std::shared_ptr<bmcweb::AsyncResp>& asyncResp,
     const crow::Request& req, const std::string& username,
-    std::shared_ptr<persistent_data::UserSession>& session)
+    std::shared_ptr<persistent_data::UserSession>& session,
+    bool isGenerateSecretkeyRequired)
 {
     // When session is created by webui-vue give it session cookies as a
     // non-standard Redfish extension. This is needed for authentication for
@@ -227,15 +233,62 @@ inline void processAfterSessionCreation(
     asyncResp->res.result(boost::beast::http::status::created);
     if (session->isConfigureSelfOnly)
     {
-        messages::passwordChangeRequired(
-            asyncResp->res,
-            boost::urls::format("/redfish/v1/AccountService/Accounts/{}",
-                                session->username));
+        boost::urls::url accountUri = boost::urls::format(
+            "/redfish/v1/AccountService/Accounts/{}", username);
+        if (!isGenerateSecretkeyRequired)
+        {
+            messages::passwordChangeRequired(asyncResp->res, accountUri);
+        }
+        else
+        {
+            messages::generateSecretKeyRequired(asyncResp->res, accountUri);
+        }
     }
 
     crow::getUserInfo(asyncResp, username, session, [asyncResp, session]() {
         fillSessionObject(asyncResp->res, *session);
     });
+}
+
+inline void handleGoogleAuthenticatorSecretKeyCheck(
+    const std::string& username,
+    const std::shared_ptr<bmcweb::AsyncResp>& asyncResp,
+    const crow::Request& req, const std::optional<std::string>& clientId,
+    const boost::system::error_code& ec, bool required)
+{
+    if (ec)
+    {
+        if (ec.value() != EBADR)
+        {
+            BMCWEB_LOG_ERROR("secretKeyRequired check failed = {}",
+                             ec.message());
+            messages::internalError(asyncResp->res);
+        }
+        return;
+    }
+
+    std::shared_ptr<persistent_data::UserSession> session =
+        persistent_data::SessionStore::getInstance().generateUserSession(
+            username, req.ipAddress, clientId,
+            persistent_data::SessionType::Session, required, required);
+    if (!session)
+    {
+        messages::internalError(asyncResp->res);
+        return;
+    }
+    processAfterSessionCreation(asyncResp, req, username, session, required);
+}
+
+inline void checkGoogleAuthenticatorSecretKeyRequired(
+    const std::string& username,
+    std::function<void(const boost::system::error_code& ec, bool)> callback)
+{
+    sdbusplus::message::object_path userPath("/xyz/openbmc_project/user");
+    crow::connections::systemBus->async_method_call(
+        [callback = std::move(callback)](const boost::system::error_code& ec,
+                                         bool val) { callback(ec, val); },
+        "xyz.openbmc_project.User.Manager", userPath,
+        "xyz.openbmc_project.User.TOTPState", "SecretKeyRequired", username);
 }
 
 inline void handleSessionCollectionPost(
@@ -285,17 +338,28 @@ inline void handleSessionCollectionPost(
         return;
     }
 
-    // User is authenticated - create session
-    std::shared_ptr<persistent_data::UserSession> session =
-        persistent_data::SessionStore::getInstance().generateUserSession(
-            username, req.ipAddress, clientId,
-            persistent_data::SessionType::Session, isConfigureSelfOnly);
-    if (session == nullptr)
+    if (isConfigureSelfOnly)
     {
-        messages::internalError(asyncResp->res);
+        std::shared_ptr<persistent_data::UserSession> session =
+            persistent_data::SessionStore::getInstance().generateUserSession(
+                username, req.ipAddress, clientId,
+                persistent_data::SessionType::Session, true, false);
+        if (!session)
+        {
+            messages::internalError(asyncResp->res);
+            return;
+        }
+        // password change required in this path
+        processAfterSessionCreation(asyncResp, req, username, session, false);
         return;
     }
-    processAfterSessionCreation(asyncResp, req, username, session);
+    // check if secret key generation is required for the user
+    checkGoogleAuthenticatorSecretKeyRequired(
+        username, [username, asyncResp, req, clientId = std::move(clientId)](
+                      const boost::system::error_code& ec, bool required) {
+            handleGoogleAuthenticatorSecretKeyCheck(username, asyncResp, req,
+                                                    clientId, ec, required);
+        });
 }
 
 inline void handleSessionServiceHead(


### PR DESCRIPTION
This commit checks if Multi-Factor Authentication (MFA) is configured for a user every time they attempt to create a new session, if MFA is enabled at the system level.
If the system is MFA enabled and the user has not configured a valid secret key appropriate error will be returned.

Tested by:

Enable MFA and try to create a session,

Response:

{
  "@Message.ExtendedInfo": [
    {
      "@odata.type": "#Message.v1_1_1.Message",
      "Message": "The Time-based One-Time Password (TOTP) secret key
for this account must be generated before access is granted. Perform the GenerateSecretKey action at URI
'/redfish/v1/AccountService/Accounts/service' and retain the secret key from the response.",
      "MessageArgs": [
        "/redfish/v1/AccountService/Accounts/service"
      ],
      "MessageId": "Base.1.19.0.GenerateSecretKeyRequired",
      "MessageSeverity": "Critical",
      "Resolution": "Generate secret key for this account by performing
the `GenerateSecretKey` action on the referenced URI and retaining the secret key from the action response to produce a Time-based One-Time Password (TOTP) for the `Token` property in future session creation requests."
    }
  ],
  "@odata.id": "/redfish/v1/SessionService/Sessions/neSLpiOFJz",
  "@odata.type": "#Session.v1_5_0.Session",
  "ClientOriginIPAddress": <ip>,
  "Description": "Manager User Session",
  "Id": "neSLpiOFJz",
  "Name": "User Session",
  "UserName": <user>

Change-Id: Icfeb7486ae76d436a73afde51b0158b369a62ad0