### PR TITLE
1120: Implement LocationIndicatorActive for Fabric Port

### DIFF
--- a/Redfish.md
+++ b/Redfish.md
@@ -879,6 +879,7 @@ other.
 #### Port
 
 - Location
+- LocationIndicatorActive
 - Status
 
 ### /redfish/v1/Systems/system/LogServices/


### PR DESCRIPTION
Implement LocationIndicatorActive for Fabric Port

Using `getLocationIndicatorActive()` method and
`setLocationIndicatorActive()`, this implements LocationIndicatorActive
propery handling for FabricAdapter port like CXP.

Tested:
- Validator passes
- GET/PATCH of LocationIndicatorActive

```
$ curl -k -H "X-Auth-Token: $token" -X GET \
    https://${bmc}/redfish/v1/Systems/system/FabricAdapters/pcie_cable_card10/Ports/cxp_top
{

  "@odata.id": "/redfish/v1/Systems/system/FabricAdapters/ \
                pcie_cable_card10/Ports/cxp_top",
  "@odata.type": "#Port.v1_11_0.Port",
  "Id": "Port",
  "LocationIndicatorActive": true,
  "Name": "cxp_top"
}

$ curl -k -H "X-Auth-Token: $token" -X GET \
  https://${bmc}/redfish/v1/Systems/system/FabricAdapters/pcie_cable_card10/Ports/cxp_bot
{
  "@odata.id": "/redfish/v1/Systems/system/FabricAdapters/ \
                pcie_cable_card10/Ports/cxp_bot",
  "@odata.type": "#Port.v1_11_0.Port",
  "Id": "Port",
  "LocationIndicatorActive": false,
  "Name": "cxp_bot"
}
```


```
$ curl -k -H "Content-Type: application/json" -X PATCH -d \
  '{"LocationIndicatorActive":false}' \
  https://${bmc}/redfish/v1/Systems/system/FabricAdapters/pcie_cable_card10/Ports/cxp_top

$ curl -k -H "X-Auth-Token: $token" -X GET \
  https://${bmc}/redfish/v1/Systems/system/FabricAdapters/pcie_cable_card10/Ports/cxp_top
{
  "@odata.id": "/redfish/v1/Systems/system/FabricAdapters/ \
                pcie_cable_card10/Ports/cxp_top",
  "@odata.type": "#Port.v1_11_0.Port",
  "Id": "Port",
  "LocationIndicatorActive": false,
  "Name": "cxp_top"
}
```

Change-Id: I2cfe8a807cd6dc3bf3d6e50658b0d27a1253b887