### PR TITLE
Audit Log: Rebase service audit log

### DIFF
--- a/config/meson.build
+++ b/config/meson.build
@@ -3,6 +3,7 @@
 conf_data = configuration_data()
 
 feature_options = [
+    'audit-events',
     'basic-auth',
     'cookie-auth',
     'experimental-http2',

--- a/include/audit_events.hpp
+++ b/include/audit_events.hpp
@@ -1,0 +1,53 @@
+#pragma once
+
+#include "http_request.hpp"
+
+#include <boost/beast/http/verb.hpp>
+
+#include <cstring>
+#include <string>
+
+namespace audit
+{
+
+int auditGetFD();
+void auditClose();
+bool auditOpen();
+bool auditReopen();
+void auditSetState(bool enable);
+bool wantDetail(const crow::Request& req);
+bool appendItemToBuf(std::string& strBuf, size_t maxBufSize,
+                     const std::string& item);
+
+/**
+ * @brief Checks if POST request is a user connection event
+ *
+ * Login and Session requests are audited when the authentication is attempted.
+ * This allows failed requests to be audited with the user detail.
+ *
+ * @return True if request is a user connection event
+ */
+inline bool checkPostUser(const crow::Request& req)
+{
+    return (req.target() == "/redfish/v1/SessionService/Sessions") ||
+           (req.target() == "/redfish/v1/SessionService/Sessions/") ||
+           (req.target() == "/login");
+}
+
+/**
+ * @brief Checks if request should be audited after completion
+ * @return  True if request should be audited
+ */
+inline bool wantAudit(const crow::Request& req)
+{
+    return (req.method() == boost::beast::http::verb::patch) ||
+           (req.method() == boost::beast::http::verb::put) ||
+           (req.method() == boost::beast::http::verb::delete_) ||
+           ((req.method() == boost::beast::http::verb::post) &&
+            !checkPostUser(req));
+}
+
+void auditEvent(const crow::Request& req, const std::string& userName,
+                bool success);
+
+} // namespace audit

--- a/include/login_routes.hpp
+++ b/include/login_routes.hpp
@@ -2,8 +2,11 @@
 // SPDX-FileCopyrightText: Copyright OpenBMC Authors
 #pragma once
 
+#include "bmcweb_config.h"
+
 #include "app.hpp"
 #include "async_resp.hpp"
+#include "audit_events.hpp"
 #include "cookies.hpp"
 #include "http_request.hpp"
 #include "http_response.hpp"
@@ -170,6 +173,10 @@ inline void handleLogin(const crow::Request& req,
         if ((pamrc != PAM_SUCCESS) && !isConfigureSelfOnly)
         {
             asyncResp->res.result(boost::beast::http::status::unauthorized);
+            if constexpr (BMCWEB_AUDIT_EVENTS)
+            {
+                audit::auditEvent(req, std::string(username), false);
+            }
         }
         else
         {
@@ -183,6 +190,10 @@ inline void handleLogin(const crow::Request& req,
 
             // if content type is json, assume json token
             asyncResp->res.jsonValue["token"] = session->sessionToken;
+            if constexpr (BMCWEB_AUDIT_EVENTS)
+            {
+                audit::auditEvent(req, std::string(username), true);
+            }
         }
     }
     else

--- a/meson.build
+++ b/meson.build
@@ -396,6 +396,12 @@ srcfiles_bmcweb = files(
     'src/webserver_run.cpp',
 )
 
+if (get_option('audit-events').allowed())
+    audit_dep = dependency('audit')
+    bmcweb_dependencies += audit_dep
+    srcfiles_bmcweb += files('src/audit_events.cpp')
+endif
+
 bmcweblib = static_library(
     'bmcweblib',
     srcfiles_bmcweb,
@@ -482,6 +488,10 @@ srcfiles_unittest = files(
     'test/redfish-core/lib/thermal_subsystem_test.cpp',
     'test/redfish-core/lib/update_service_test.cpp',
 )
+
+if (get_option('audit-events').allowed())
+    srcfiles_unittest += files('test/include/audit_events_test.cpp')
+endif
 
 if (get_option('tests').allowed())
     gtest = dependency(

--- a/meson.options
+++ b/meson.options
@@ -461,6 +461,14 @@ option(
                     behavior changes or be removed at any time.''',
 )
 
+# BMCWEB_AUDIT_EVENTS
+option(
+    'audit-events',
+    type: 'feature',
+    value: 'disabled',
+    description: 'Enable audit events support for bmcweb',
+)
+
 # Insecure options. Every option that starts with a `insecure` flag should
 # not be enabled by default for any platform, unless the author fully comprehends
 # the implications of doing so.In general, enabling these options will cause security

--- a/src/audit_events.cpp
+++ b/src/audit_events.cpp
@@ -1,0 +1,279 @@
+#include "audit_events.hpp"
+
+#include "http_request.hpp"
+#include "logging.hpp"
+
+#include <libaudit.h>
+
+#include <boost/asio/ip/host_name.hpp>
+#include <boost/beast/http/verb.hpp>
+
+#include <cerrno>
+#include <cstdlib>
+#include <cstring>
+#include <format>
+#include <memory>
+#include <string>
+
+namespace audit
+{
+
+// NOLINTBEGIN(cppcoreguidelines-avoid-non-const-global-variables)
+static bool tryOpen = true;
+static int auditfd = -1;
+// NOLINTEND(cppcoreguidelines-avoid-non-const-global-variables)
+
+int auditGetFD()
+{
+    return auditfd;
+}
+
+/**
+ * @brief Closes connection for recording audit events
+ */
+void auditClose()
+{
+    if (auditfd >= 0)
+    {
+        audit_close(auditfd);
+        auditfd = -1;
+        BMCWEB_LOG_DEBUG("Audit log closed.");
+    }
+}
+
+/**
+ * @brief Opens connection for recording audit events
+ *
+ * Reuses prior connection if available.
+ *
+ * @return If connection was successful or not
+ */
+bool auditOpen()
+{
+    if (auditfd < 0)
+    {
+        /* Blocking opening of audit connection */
+        if (!tryOpen)
+        {
+            BMCWEB_LOG_DEBUG("Audit connection disabled");
+            return false;
+        }
+
+        auditfd = audit_open();
+
+        if (auditfd < 0)
+        {
+            BMCWEB_LOG_ERROR("Error opening audit socket : {}", errno);
+            return false;
+        }
+        BMCWEB_LOG_DEBUG("Audit fd created : {}", auditfd);
+    }
+
+    return true;
+}
+
+/**
+ * @brief Establishes new connection for recording audit events
+ *
+ * Closes any existing connection and tries to create a new connection.
+ *
+ * @return If new connection was successful or not
+ */
+bool auditReopen()
+{
+    auditClose();
+    return auditOpen();
+}
+
+/**
+ * @brief Sets state for audit connection
+ * @param[in] enable    New state for audit connection.
+ *			If false, then any existing connection will be closed.
+ */
+void auditSetState(bool enable)
+{
+    if (!enable)
+    {
+        auditClose();
+    }
+
+    tryOpen = enable;
+
+    BMCWEB_LOG_DEBUG("Audit state: tryOpen = {}", tryOpen);
+}
+
+/**
+ * @brief Checks if request should include additional data
+ *
+ * - Accounts requests data may contain passwords
+ * - IBM Management console events data is not useful. It can be binary data or
+ *   contents of file.
+ * - User login and session data may contain passwords
+ *
+ * @return True if request's data should not be logged
+ */
+inline bool checkSkipDetail(const crow::Request& req)
+{
+    return req.target().starts_with("/redfish/v1/AccountService/Accounts") ||
+           req.target().starts_with("/ibm/v1") ||
+           ((req.method() == boost::beast::http::verb::post) &&
+            checkPostUser(req));
+}
+
+/**
+ * @brief Checks if request's detail data should be logged
+ *
+ * @return True if request's detail data should be logged
+ */
+bool wantDetail(const crow::Request& req)
+{
+    switch (req.method())
+    {
+        case boost::beast::http::verb::patch:
+        case boost::beast::http::verb::post:
+            if (checkSkipDetail(req))
+            {
+                return false;
+            }
+            return true;
+
+        case boost::beast::http::verb::put:
+            return (!req.target().starts_with("/ibm/v1"));
+
+        case boost::beast::http::verb::delete_:
+            return true;
+
+        default:
+            // Shouldn't be here, don't log any data
+            BMCWEB_LOG_DEBUG("Unexpected verb {}", req.methodString());
+            return false;
+    }
+}
+
+/**
+ * @brief Appends item to strBuf only if strBuf won't exceed maxBufSize
+ *
+ * @param[in,out] strBuf Buffer to append up to maxBufSize only
+ * @param[in] maxBufSize Maximum length of strBuf
+ * @param[in] item String to append if it will fit within maxBufSize
+ *
+ * @return True if item was appended
+ */
+bool appendItemToBuf(std::string& strBuf, size_t maxBufSize,
+                     const std::string& item)
+{
+    if (strBuf.length() + item.length() > maxBufSize)
+    {
+        return false;
+    }
+    strBuf += item;
+    return true;
+}
+
+void auditEvent(const crow::Request& req, const std::string& userName,
+                bool success)
+{
+    if (!auditOpen())
+    {
+        return;
+    }
+
+    std::string opPath =
+        std::format("op={}:{} ", std::string(req.methodString()),
+                    std::string(req.target()));
+
+    size_t maxBuf = 256; // Limit message to avoid filling log with single entry
+    std::string cnfgBuff = opPath.substr(0, maxBuf);
+
+    if (cnfgBuff.length() < opPath.length())
+    {
+        // Event message truncated to fit into fixed sized buffer.
+        BMCWEB_LOG_WARNING(
+            "Audit buffer too small, truncating: cnfgBufLen={} opPathLen={}",
+            cnfgBuff.length(), opPath.length());
+    }
+
+    // Determine any additional info for the event
+    std::string detail;
+    if (wantDetail(req))
+    {
+        detail = req.body().substr(0, maxBuf);
+        detail += " ";
+    }
+
+    if (!detail.empty())
+    {
+        if (!appendItemToBuf(cnfgBuff, maxBuf, detail))
+        {
+            // Additional info won't fit into fixed sized buffer. Leave
+            // it off.
+            BMCWEB_LOG_WARNING(
+                "Audit buffer too small for data: bufLeft={} detailLen={}",
+                (maxBuf - cnfgBuff.length()), detail.length());
+        }
+    }
+
+    // encode user account name to ensure it is in an appropriate format
+    size_t userLen = 0;
+    char* user = audit_encode_nv_string("acct", userName.c_str(), 0);
+
+    if (user == nullptr)
+    {
+        BMCWEB_LOG_WARNING("Error encoding user for audit msg : {}", errno);
+    }
+    else
+    {
+        // setup a unique_ptr to handle freeing memory from user
+        std::unique_ptr<char, void (*)(char*)> userUP(user, [](char* ptr) {
+            if (ptr != nullptr)
+            {
+                // Linux audit mallocs memory we must free.
+                // NOLINTNEXTLINE(cppcoreguidelines-no-malloc)
+                ::free(ptr);
+            }
+        });
+
+        userLen = std::strlen(user);
+
+        if (!appendItemToBuf(cnfgBuff, maxBuf, std::string(user)))
+        {
+            // Username won't fit into fixed sized buffer. Leave it off.
+            BMCWEB_LOG_WARNING(
+                "Audit buffer too small for username: bufLeft={} userLen={}",
+                (maxBuf - cnfgBuff.length()), userLen);
+        }
+    }
+
+    BMCWEB_LOG_DEBUG(
+        "auditEvent: bufLeft={}  opPathLen={} detailLen={} userLen={}",
+        (maxBuf - cnfgBuff.length()), opPath.length(), detail.length(),
+        userLen);
+
+    std::string ipAddress = req.ipAddress.to_string();
+
+    int rc = audit_log_user_message(
+        auditfd, AUDIT_USYS_CONFIG, cnfgBuff.c_str(),
+        boost::asio::ip::host_name().c_str(), ipAddress.c_str(), nullptr,
+        int(success));
+
+    if (rc <= 0)
+    {
+        // Something failed with existing connection. Try to establish a new
+        // connection and retry if successful.
+        // Preserve original errno to report if the retry fails.
+        int origErrno = errno;
+        if (auditReopen())
+        {
+            rc = audit_log_user_message(
+                auditfd, AUDIT_USYS_CONFIG, cnfgBuff.c_str(),
+                boost::asio::ip::host_name().c_str(), ipAddress.c_str(),
+                nullptr, int(success));
+        }
+        if (rc <= 0)
+        {
+            BMCWEB_LOG_ERROR("Error writing audit message: {}", origErrno);
+        }
+    }
+}
+
+} // namespace audit

--- a/test/include/audit_events_test.cpp
+++ b/test/include/audit_events_test.cpp
@@ -1,0 +1,204 @@
+#include "audit_events.hpp"
+#include "http_request.hpp"
+
+#include <boost/beast/http/verb.hpp>
+
+#include <string>
+#include <string_view>
+#include <system_error>
+
+#include <gtest/gtest.h>
+
+namespace audit
+{
+namespace
+{
+
+TEST(auditSetState, PositiveTest)
+{
+    auditSetState(false);
+    EXPECT_FALSE(auditOpen());
+
+    auditSetState(true);
+    EXPECT_TRUE(auditOpen());
+    auditClose();
+}
+
+TEST(auditOpen, PositiveTest)
+{
+    int origFd = -1;
+
+    EXPECT_TRUE(auditOpen());
+    EXPECT_NE(auditGetFD(), -1);
+
+    origFd = auditGetFD();
+    EXPECT_TRUE(auditOpen());
+    EXPECT_EQ(auditGetFD(), origFd);
+}
+
+TEST(auditClose, PositiveTest)
+{
+    auditClose();
+    EXPECT_EQ(auditGetFD(), -1);
+
+    EXPECT_TRUE(auditOpen());
+    auditClose();
+    EXPECT_EQ(auditGetFD(), -1);
+}
+
+TEST(auditReopen, PositiveTest)
+{
+    EXPECT_TRUE(auditReopen());
+    EXPECT_NE(auditGetFD(), -1);
+
+    // Cannot make expectation on different fd on reopen
+    EXPECT_TRUE(auditReopen());
+    EXPECT_NE(auditGetFD(), -1);
+
+    auditClose();
+    EXPECT_TRUE(auditReopen());
+    EXPECT_NE(auditGetFD(), -1);
+}
+
+TEST(wantAudit, PositiveTest)
+{
+    constexpr const std::string_view url = "/foo";
+    std::error_code ec;
+
+    crow::Request patchRequest{{boost::beast::http::verb::patch, url, 11}, ec};
+    EXPECT_TRUE(wantAudit(patchRequest));
+
+    crow::Request putRequest{{boost::beast::http::verb::put, url, 11}, ec};
+    EXPECT_TRUE(wantAudit(putRequest));
+
+    crow::Request deleteRequest{{boost::beast::http::verb::delete_, url, 11},
+                                ec};
+    EXPECT_TRUE(wantAudit(deleteRequest));
+
+    crow::Request postRequest{{boost::beast::http::verb::post, url, 11}, ec};
+    EXPECT_TRUE(wantAudit(postRequest));
+}
+
+TEST(wantAudit, NegativeTest)
+{
+    constexpr const std::string_view url = "/foo";
+    std::error_code ec;
+
+    crow::Request postRequest{{boost::beast::http::verb::post, url, 11}, ec};
+
+    postRequest.target("/redfish/v1/SessionService/Sessions");
+    EXPECT_FALSE(wantAudit(postRequest));
+
+    postRequest.target("/redfish/v1/SessionService/Sessions/");
+    EXPECT_FALSE(wantAudit(postRequest));
+
+    postRequest.target("/login");
+    EXPECT_FALSE(wantAudit(postRequest));
+
+    crow::Request getRequest{{boost::beast::http::verb::get, url, 11}, ec};
+    EXPECT_FALSE(wantAudit(getRequest));
+}
+
+TEST(wantDetail, PositiveTest)
+{
+    constexpr const std::string_view url = "/foo";
+    std::error_code ec;
+
+    crow::Request patchRequest{{boost::beast::http::verb::patch, url, 11}, ec};
+    EXPECT_TRUE(wantDetail(patchRequest));
+
+    crow::Request putRequest{{boost::beast::http::verb::put, url, 11}, ec};
+    EXPECT_TRUE(wantDetail(putRequest));
+
+    crow::Request deleteRequest{{boost::beast::http::verb::delete_, url, 11},
+                                ec};
+    EXPECT_TRUE(wantDetail(deleteRequest));
+
+    crow::Request postRequest{{boost::beast::http::verb::post, url, 11}, ec};
+    EXPECT_TRUE(wantDetail(postRequest));
+}
+
+TEST(wantDetail, NegativeTest)
+{
+    constexpr const std::string_view url = "/foo";
+    std::error_code ec;
+
+    crow::Request patchRequest{{boost::beast::http::verb::patch, url, 11}, ec};
+    patchRequest.target("/redfish/v1/AccountService/Accounts/foo");
+    EXPECT_FALSE(wantDetail(patchRequest));
+
+    patchRequest.target("/ibm/v1/foo");
+    EXPECT_FALSE(wantDetail(patchRequest));
+
+    crow::Request postRequest{{boost::beast::http::verb::post, url, 11}, ec};
+
+    postRequest.target("/redfish/v1/AccountService/Accounts/bar");
+    EXPECT_FALSE(wantDetail(postRequest));
+
+    postRequest.target("/ibm/v1/bar");
+    EXPECT_FALSE(wantDetail(postRequest));
+
+    postRequest.target("/redfish/v1/SessionService/Sessions");
+    EXPECT_FALSE(wantDetail(postRequest));
+
+    postRequest.target("/redfish/v1/SessionService/Sessions/");
+    EXPECT_FALSE(wantDetail(postRequest));
+
+    postRequest.target("/login");
+    EXPECT_FALSE(wantDetail(postRequest));
+
+    crow::Request getRequest{{boost::beast::http::verb::get, url, 11}, ec};
+    EXPECT_FALSE(wantDetail(getRequest));
+}
+
+TEST(appendItemToBuf, PositiveTest)
+{
+    std::string testBuf;
+    std::string data;
+    std::string cmpStr;
+
+    data = "Initial data ";
+    cmpStr = data;
+
+    EXPECT_TRUE(appendItemToBuf(testBuf, data.length() + 20, data));
+    EXPECT_EQ(testBuf, cmpStr);
+
+    data = "Append data ";
+    cmpStr += data;
+    EXPECT_TRUE(
+        appendItemToBuf(testBuf, testBuf.length() + data.length(), data));
+    EXPECT_EQ(testBuf, cmpStr);
+
+    data = "Append more data ";
+    cmpStr += data;
+
+    EXPECT_TRUE(
+        appendItemToBuf(testBuf, testBuf.length() + data.length(), data));
+    EXPECT_EQ(testBuf, cmpStr);
+}
+
+TEST(appendItemToBuf, NegativeTest)
+{
+    std::string testBuf;
+    std::string data;
+    std::string cmpStr;
+
+    cmpStr = testBuf;
+    data = "Data not appended";
+
+    EXPECT_FALSE(appendItemToBuf(testBuf, data.length() - 5, data));
+    EXPECT_EQ(testBuf, cmpStr);
+
+    testBuf = "Initial data ";
+    cmpStr = testBuf;
+
+    EXPECT_FALSE(appendItemToBuf(testBuf, testBuf.length(), data));
+    EXPECT_EQ(testBuf, cmpStr);
+
+    EXPECT_FALSE(
+        appendItemToBuf(testBuf, testBuf.length() + data.length() - 1, data));
+    EXPECT_EQ(testBuf, cmpStr);
+}
+
+} // namespace
+} // namespace audit


### PR DESCRIPTION
Rebase and squashed all 1110 bmcweb commits to support service audit log. 1110 commits included:
```
957cc7990c Audit Log: Rebase service audit log (#820)
5fd2e37e03 Audit Log: Correct logging of sessions (#1129)
2cc4e01f4c Reduce memory usage during Firmware update (#739)
```

Includes restructure of the code to split into audit-events.hpp and audit-events.cpp files. Only the .cpp file will include libaudit.h and will only be built if audit-events is enabled. This allows use of constexpr for calls to auditEvent().

Tested on hardware simulator. Built version with audit-events enabled and confirmed audit entries are recorded as expected. Note recipe changes are needed to enable linux audit service which will be part of an openbmc/openbmc PR.

This introduces a new bmcweb meson option, audit-events, which is defaulted to disabled. Recipe changes in GHE openbmc/openbmc enable audit logging.

When audit-events is enabled all bmcweb PATCH, POST, PUT, and DELETE events are logged using the Linux kernel auditd subsystem. Additionally, login events coming through bmcweb are also recorded.

The body of the events is recorded as well except in the following cases:
  - /redfish/v1/AccountService/Accounts PATCH/POST events - body is not recorded as it may contain clear text password
  - /ibm/v1 PATCH/POST/PUT events - body is not recorded as it contains HMC config file binary data
  - Limit size of body recorded to avoid flooding log or using too much memory.

Events are recorded in /var/log/audit/. User type dreport will gather these log files.

Tested:
 - Enabled auditing then initiated a variety of Redfish events using curl.
 - Confirmed the events were recorded and confirmed the data recorded was accurate.
 - Confirmed password was not included in audit data recorded.