### PR TITLE
1120: OEM Battery Concurrent Maintenance (#868)

### DIFF
--- a/redfish-core/lib/assembly.hpp
+++ b/redfish-core/lib/assembly.hpp
@@ -9,6 +9,7 @@
 #include "http_response.hpp"
 #include "led.hpp"
 #include "logging.hpp"
+#include "query.hpp"
 #include "registries/privilege_registry.hpp"
 #include "utils/chassis_utils.hpp"
 #include "utils/dbus_utils.hpp"
@@ -18,8 +19,11 @@
 #include <boost/system/error_code.hpp>
 #include <boost/url/format.hpp>
 #include <nlohmann/json.hpp>
+#include <sdbusplus/asio/property.hpp>
 #include <sdbusplus/unpack_properties.hpp>
 
+#include <algorithm>
+#include <array>
 #include <cstddef>
 #include <functional>
 #include <map>
@@ -133,6 +137,44 @@ void getAssemblyLocationCode(
         });
 }
 
+inline void afterGetReadyToRemoveOfTodBattery(
+    const std::shared_ptr<bmcweb::AsyncResp>& asyncResp,
+    std::size_t assemblyIndex, const boost::system::error_code& ec,
+    const dbus::utility::MapperGetObject& /*unused*/)
+{
+    nlohmann::json& assemblyArray = asyncResp->res.jsonValue["Assemblies"];
+    if (ec)
+    {
+        if (ec.value() == boost::system::errc::io_error)
+        {
+            // Battery voltage is not on DBUS so ADCSensor is not
+            // running.
+            nlohmann::json& oemOpenBMC =
+                assemblyArray.at(assemblyIndex)["Oem"]["OpenBMC"];
+            oemOpenBMC["@odata.type"] = "#OpenBMCAssembly.v1_0_0.OpenBMC";
+            oemOpenBMC["ReadyToRemove"] = true;
+            return;
+        }
+        BMCWEB_LOG_ERROR("DBUS response error {}", ec.value());
+        messages::internalError(asyncResp->res);
+        return;
+    }
+    nlohmann::json& oemOpenBMC =
+        assemblyArray.at(assemblyIndex)["Oem"]["OpenBMC"];
+    oemOpenBMC["@odata.type"] = "#OpenBMCAssembly.v1_0_0.OpenBMC";
+    oemOpenBMC["ReadyToRemove"] = false;
+}
+
+inline void getReadyToRemoveOfTodBattery(
+    const std::shared_ptr<bmcweb::AsyncResp>& asyncResp,
+    std::size_t assemblyIndex)
+{
+    dbus::utility::getDbusObject(
+        "/xyz/openbmc_project/sensors/voltage/Battery_Voltage", {},
+        std::bind_front(afterGetReadyToRemoveOfTodBattery, asyncResp,
+                        assemblyIndex));
+}
+
 /**
  * @brief Get properties for the assemblies associated to given chassis
  * @param[in] asyncResp - Shared pointer for asynchronous calls.
@@ -167,6 +209,16 @@ inline void getAssemblyProperties(
 
         tempArray.at(assemblyIndex)["Name"] =
             sdbusplus::message::object_path(assembly).filename();
+
+        // Handle special case for tod_battery assembly OEM ReadyToRemove
+        // property NOTE: The following method for the special case of the
+        // tod_battery ReadyToRemove property only works when there is only ONE
+        // adcsensor handled by the adcsensor application.
+        if (sdbusplus::message::object_path(assembly).filename() ==
+            "tod_battery")
+        {
+            getReadyToRemoveOfTodBattery(asyncResp, assemblyIndex);
+        }
 
         dbus::utility::getDbusObject(
             assembly, chassisAssemblyInterfaces,
@@ -263,6 +315,96 @@ inline void handleChassisAssemblyGet(
         });
 }
 
+inline void startOrStopADCSensor(
+    const bool start, const std::shared_ptr<bmcweb::AsyncResp>& asyncResp)
+{
+    std::string method{"StartUnit"};
+    if (!start)
+    {
+        method = "StopUnit";
+    }
+
+    crow::connections::systemBus->async_method_call(
+        [asyncResp](const boost::system::error_code& ec) {
+            if (ec)
+            {
+                BMCWEB_LOG_ERROR("Failed to start or stop ADCSensor:{}",
+                                 ec.value());
+                messages::internalError(asyncResp->res);
+                return;
+            }
+            messages::success(asyncResp->res);
+        },
+        "org.freedesktop.systemd1", "/org/freedesktop/systemd1",
+        "org.freedesktop.systemd1.Manager", method,
+        "xyz.openbmc_project.adcsensor.service", "replace");
+}
+
+inline void afterGetDbusObjectDoBatteryCM(
+    const std::shared_ptr<bmcweb::AsyncResp>& asyncResp,
+    const std::string& assembly, const boost::system::error_code& ec,
+    const dbus::utility::MapperGetObject& object)
+{
+    if (ec)
+    {
+        BMCWEB_LOG_ERROR("DBUS response error {}", ec.value());
+        messages::internalError(asyncResp->res);
+        return;
+    }
+
+    for (const auto& [serviceName, interfaceList] : object)
+    {
+        auto ifaceIt = std::ranges::find(
+            interfaceList,
+            "xyz.openbmc_project.State.Decorator.OperationalStatus");
+
+        if (ifaceIt == interfaceList.end())
+        {
+            continue;
+        }
+
+        sdbusplus::asio::setProperty(
+            *crow::connections::systemBus, serviceName, assembly,
+            "xyz.openbmc_project.State.Decorator."
+            "OperationalStatus",
+            "Functional", true,
+            [asyncResp, assembly](const boost::system::error_code& ec2) {
+                if (ec2)
+                {
+                    BMCWEB_LOG_ERROR(
+                        "Failed to set functional property on battery: {} ",
+                        ec2.value());
+                    messages::internalError(asyncResp->res);
+                    return;
+                }
+                startOrStopADCSensor(true, asyncResp);
+            });
+        return;
+    }
+
+    BMCWEB_LOG_ERROR("No OperationalStatus interface on {}", assembly);
+    messages::internalError(asyncResp->res);
+}
+
+inline void doBatteryCM(const std::shared_ptr<bmcweb::AsyncResp>& asyncResp,
+                        const std::string& assembly, const bool readyToRemove)
+{
+    if (readyToRemove)
+    {
+        // Stop the adcsensor service so it doesn't monitor the battery
+        startOrStopADCSensor(false, asyncResp);
+        return;
+    }
+
+    // Find the service that has the OperationalStatus iface, set the
+    // Functional property back to true, and then start the adcsensor service.
+    std::array<std::string_view, 1> interfaces = {
+        "xyz.openbmc_project.State.Decorator.OperationalStatus"};
+    dbus::utility::getDbusObject(
+        assembly, interfaces,
+        std::bind_front(afterGetDbusObjectDoBatteryCM, asyncResp, assembly));
+}
+
 /**
  * @brief Set location indicator for the assemblies associated to given chassis
  * @param[in] req - The request data
@@ -295,15 +437,17 @@ inline void setAssemblyLocationIndicators(
 
     std::vector<nlohmann::json> items = std::move(*assemblyData);
     std::map<std::string, bool> locationIndicatorActiveMap;
+    std::map<std::string, nlohmann::json> oemIndicatorMap;
 
     for (auto& item : items)
     {
         std::optional<std::string> memberId;
         std::optional<bool> locationIndicatorActive;
+        std::optional<nlohmann::json> oem;
 
-        if (!json_util::readJson(item, asyncResp->res,
-                                 "LocationIndicatorActive",
-                                 locationIndicatorActive, "MemberId", memberId))
+        if (!json_util::readJson(
+                item, asyncResp->res, "LocationIndicatorActive",
+                locationIndicatorActive, "MemberId", memberId, "Oem", oem))
         {
             return;
         }
@@ -322,6 +466,20 @@ inline void setAssemblyLocationIndicators(
                 return;
             }
         }
+        if (oem)
+        {
+            if (memberId)
+            {
+                oemIndicatorMap[*memberId] = *oem;
+            }
+            else
+            {
+                BMCWEB_LOG_WARNING(
+                    "Property Missing - MemberId must be included with Oem property");
+                messages::propertyMissing(asyncResp->res, "MemberId");
+                return;
+            }
+        }
     }
 
     std::size_t assemblyIndex = 0;
@@ -334,15 +492,61 @@ inline void setAssemblyLocationIndicators(
         {
             setLocationIndicatorActive(asyncResp, assembly, iter->second);
         }
+
+        auto iter2 = oemIndicatorMap.find(std::to_string(assemblyIndex));
+
+        if (iter2 != oemIndicatorMap.end())
+        {
+            std::optional<bool> readytoremove;
+            if (!json_util::readJson(iter2->second, asyncResp->res,
+                                     "OpenBMC/ReadyToRemove", readytoremove))
+            {
+                BMCWEB_LOG_WARNING("Property Value Format Error ");
+                messages::propertyValueFormatError(
+                    asyncResp->res, iter2->second, "OpenBMC/ReadyToRemove");
+                return;
+            }
+
+            if (!readytoremove)
+            {
+                BMCWEB_LOG_WARNING("Property Missing ");
+                messages::propertyMissing(asyncResp->res,
+                                          "OpenBMC/ReadyToRemove");
+                return;
+            }
+
+            // Handle special case for tod_battery assembly OEM ReadyToRemove
+            // property. NOTE: The following method for the special case of the
+            // tod_battery ReadyToRemove property only works when there is only
+            // ONE adcsensor handled by the adcsensor application.
+            if (sdbusplus::message::object_path(assembly).filename() ==
+                "tod_battery")
+            {
+                doBatteryCM(asyncResp, assembly, readytoremove.value());
+            }
+            else
+            {
+                BMCWEB_LOG_WARNING(
+                    "Property Unknown: ReadyToRemove on Assembly with MemberID: {}",
+                    assemblyIndex);
+                messages::propertyUnknown(asyncResp->res, "ReadyToRemove");
+                return;
+            }
+        }
         assemblyIndex++;
     }
 }
 
 inline void handleChassisAssemblyPatch(
-    App& /*unused*/, const crow::Request& req,
+    App& app, const crow::Request& req,
     const std::shared_ptr<bmcweb::AsyncResp>& asyncResp,
     const std::string& chassisID)
 {
+    if (!redfish::setUpRedfishRoute(app, req, asyncResp))
+    {
+        return;
+    }
+
     BMCWEB_LOG_DEBUG("Patch chassis path");
 
     chassis_utils::getChassisAssembly(

--- a/redfish-core/schema/oem/openbmc/csdl/OpenBMCAssembly_v1.xml
+++ b/redfish-core/schema/oem/openbmc/csdl/OpenBMCAssembly_v1.xml
@@ -1,0 +1,38 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<edmx:Edmx xmlns:edmx="http://docs.oasis-open.org/odata/ns/edmx" Version="4.0">
+  <edmx:Reference Uri="http://docs.oasis-open.org/odata/odata/v4.0/errata03/csd01/complete/vocabularies/Org.OData.Core.V1.xml">
+    <edmx:Include Namespace="Org.OData.Core.V1" Alias="OData"/>
+  </edmx:Reference>
+  <edmx:Reference Uri="http://redfish.dmtf.org/schemas/v1/Assembly_v1.xml">
+    <edmx:Include Namespace="Assembly"/>
+    <edmx:Include Namespace="Assembly.v1_0_0"/>
+  </edmx:Reference>
+  <edmx:Reference Uri="http://redfish.dmtf.org/schemas/v1/RedfishExtensions_v1.xml">
+    <edmx:Include Namespace="RedfishExtensions.v1_0_0" Alias="Redfish"/>
+  </edmx:Reference>
+  <edmx:Reference Uri="http://redfish.dmtf.org/schemas/v1/Resource_v1.xml">
+    <edmx:Include Namespace="Resource"/>
+    <edmx:Include Namespace="Resource.v1_0_0"/>
+  </edmx:Reference>
+  <edmx:DataServices>
+    <Schema xmlns="http://docs.oasis-open.org/odata/ns/edm" Namespace="OpenBMCAssembly">
+      <Annotation Term="Redfish.OwningEntity" String="OpenBMC"/>
+    </Schema>
+    <Schema xmlns="http://docs.oasis-open.org/odata/ns/edm" Namespace="OpenBMCAssembly.v1_0_0">
+      <ComplexType Name="Oem" BaseType="Resource.OemObject">
+        <Annotation Term="OData.AdditionalProperties" Bool="true"/>
+        <Annotation Term="OData.Description" String="OpenBMCAssembly Oem properties."/>
+        <Annotation Term="OData.AutoExpand"/>
+        <Property Name="OpenBMC" Type="OpenBMCAssembly.v1_0_0.OpenBMC"/>
+      </ComplexType>
+      <ComplexType Name="OpenBMC" BaseType="Resource.OemObject">
+        <Annotation Term="OData.AdditionalProperties" Bool="true"/>
+        <Annotation Term="OData.Description" String="Oem properties for OpenBMC."/>
+        <Annotation Term="OData.AutoExpand"/>
+        <Property Name="ReadyToRemove" Type="Edm.Boolean"/>
+        <Annotation Term="OData.Description" String="Indicates if the assembly is ready to be removed."/>
+        <Annotation Term="OData.LongDescription" String="Indicates if the system is prepared for the assembly to be removed."/>
+      </ComplexType>
+    </Schema>
+  </edmx:DataServices>
+</edmx:Edmx>

--- a/redfish-core/schema/oem/openbmc/json-schema/OpenBMCAssembly.json
+++ b/redfish-core/schema/oem/openbmc/json-schema/OpenBMCAssembly.json
@@ -1,0 +1,8 @@
+{
+    "$id": "https://github.com/ibm-openbmc/bmcweb/tree/HEAD/redfish-core/schema/oem/openbmc/json-schema/OpenBMCAssembly.json",
+    "$schema": "http://redfish.dmtf.org/schemas/v1/redfish-schema-v1.json",
+    "copyright": "Copyright 2025 OpenBMC.",
+    "definitions": {},
+    "owningEntity": "OpenBMC",
+    "title": "#OpenBMCAssembly"
+}

--- a/redfish-core/schema/oem/openbmc/json-schema/OpenBMCAssembly.v1_0_0.json
+++ b/redfish-core/schema/oem/openbmc/json-schema/OpenBMCAssembly.v1_0_0.json
@@ -1,0 +1,38 @@
+{
+    "$id": "http://redfish.dmtf.org/schemas/v1/OpenBMCAssembly.v1_0_0.json",
+    "$schema": "http://redfish.dmtf.org/schemas/v1/redfish-schema-v1.json",
+    "copyright": "Copyright 2025 OpenBMC.",
+    "definitions": {
+        "OpenBMC": {
+            "additionalProperties": false,
+            "description": "An indication of whether the system is prepared for the assembly to be removed.",
+            "parameters": {},
+            "patternProperties": {
+                "^([a-zA-Z_][a-zA-Z0-9_]*)?@(odata|Redfish|Message)\\.[a-zA-Z_][a-zA-Z0-9_]*$": {
+                    "description": "This property shall specify a valid odata or Redfish property.",
+                    "type": [
+                        "array",
+                        "boolean",
+                        "integer",
+                        "number",
+                        "null",
+                        "object",
+                        "string"
+                    ]
+                }
+            },
+            "properties": {
+                "ReadyToRemove": {
+                    "description": "An indication of whether the system is prepared for an assembly to be removed.",
+                    "longDescription": "This property shall indicate whether the system is ready for the assembly to be changed.  Setting the value to `true` shall cause the service to perform appropriate actions to allow the assembly to be removed.  Setting the value to `false` shall cause the service to perform appropriate actions to allow the assembly to be installed.",
+                    "readonly": false,
+                    "type": ["boolean", "null"],
+                    "versionAdded": "v1_0_0"
+                }
+            },
+            "type": "object"
+        }
+    },
+    "OwningEntity": "OpenBMC",
+    "title": "#OpenBMCAssembly.v1_0_0"
+}

--- a/redfish-core/schema/oem/openbmc/meson.build
+++ b/redfish-core/schema/oem/openbmc/meson.build
@@ -23,7 +23,7 @@ foreach option_key, schema : schemas
 endforeach
 
 # Additional IBM schemas that should be installed
-ibm_schemas = ['OpenBMCMessage']
+ibm_schemas = ['OpenBMCAssembly', 'OpenBMCMessage']
 
 foreach schema : ibm_schemas
     install_data(


### PR DESCRIPTION
This commit is doing Battery Concurrent Maintenance with proper setting functional property after that.

* Set Functional property after battery CM  (#558)

When bmcweb is told the RTC battery is replaced after a CM operation, set the Functional property on its assembly object path back to true before restarting the adcsensor daemon.

This does two things:
1) Causes the fault LED to turn off
2) Sets the Redfish representation back to healthy so the web UI doesn't
   show it has unhealthy it after the CM operation.  Of course if
   adcsensor detects an error again it would go back to unhealthy.

Since this is handling the fault LED, the previous code that explicitly turned off the fault LED group was removed.

* OEM Battery Concurrent Maintenance For Everest System (#549)

The current implementation of this feature supports the redfish OEM ReadyToRemove property for the TOD battery on assembly. The TOD battery is put in the ReadyToRemove state by stopping the adcsensor application. The reverse occurs when the adcsensor application is restarted. The adcsensor is stopped and started by calling systemd. Note that this implementation only works if the adcsensor application handles one ADC sensor.

The properties of an assembly have been extended to include `["Oem"]["OpenBMC"]["ReadyToRemove"]`

The GET and PATCH methods to the route
`/redfish/v1/Chassis/chassis/Assembly` now handle the property `["Oem"]["OpenBMC"]["ReadyToRemove"]`

The following commands were tested:
```
curl -k -X  GET https://${bmc}/redfish/v1/Chassis/chassis/Assembly
```

```
curl -k -H "Content-Type: application/json" -X PATCH \
     https://${bmc}/redfish/v1/Chassis/chassis/Assembly \
     -d '{"Assemblies":[{"MemberId" : "35", "LocationIndicatorActive": true, "Oem": { "OpenBMC": { "ReadyToRemove": true }}}]}'

curl -k -H "Content-Type: application/json" -X PATCH \
    https://${bmc}/redfish/v1/Chassis/chassis/Assembly \
    -d '{"Assemblies":[{"MemberId" : "35", "LocationIndicatorActive": false, "Oem": { "OpenBMC": { "ReadyToRemove": false }}}]}'
```

NOTE:
The explicit `-H "Content-Type: application/json"` request header is needed for the OWASP security guideline by
https://github.com/ibm-openbmc/bmcweb/commit/1aa0c2b

* The following modifications are included:

1) Currently there is only one assembly that contains an OEM entity. There must exist a method to identify the assembly that contains the TOD battery other than the presence of an OEM property, since more OEM properties could be added on other assemblies. Previously the memberId associated with the battery OEM assembly was used, but the memberId may change.  This modification identifies the OEM battery assembly by its name on DBUS.

2)The memberId will not be required in the PATCH request when only the Oem/OpenBMC/ReadyToRemove property for the battery is contained in the PATCH request.

3) If the LocationIndicatorActive LED flag is included in the PATCH request with the Oem/OpenBMC/ReadyToRemove property or without the  Oem/OpenBMC/ReadyToRemove property, the memberId will be required.

4) If the LocationIndicatorActive LED flag for any other assembly is included in the PATCH request the associated memberId is required.