### PR TITLE
1120: Add odata.type for ClientCertificate/Certificates

### DIFF
--- a/redfish-core/lib/account_service.hpp
+++ b/redfish-core/lib/account_service.hpp
@@ -1428,6 +1428,13 @@ inline void handleAccountServiceClientCertificatesGet(
     {
         return;
     }
+
+    nlohmann::json& json = asyncResp->res.jsonValue;
+    json["@odata.id"] =
+        "/redfish/v1/AccountService/MultiFactorAuth/ClientCertificate/Certificates";
+    json["@odata.type"] = "#CertificateCollection.CertificateCollection";
+    json["Name"] = "Certificates Collection";
+    json["Description"] = "MFA Client Certificates";
     getClientCertificates(asyncResp, "/Members"_json_pointer);
 }
 


### PR DESCRIPTION
This Certificate URI does not give the odata.type.

```
curl -k -X GET https://${bmc}/redfish/v1/AccountService/MultiFactorAuth/ClientCertificate/Certificates
{
  "Members": [],
  "Members@odata.count": 0
}
```
As a result, Redfish Service Validator may fail if this URI is triggered.

This adds the type like
```
curl -k -X GET https://${bmc}/redfish/v1/AccountService/MultiFactorAuth/ClientCertificate/Certificates

{
  "@odata.id": "/redfish/v1/AccountService/MultiFactorAuth/ClientCertificate/Certificates",
  "@odata.type": "#CertificateCollection.CertificateCollection"
  "Members": [],
  "Members@odata.count": 0
  "Name": "Certificates Collection"
}%
```

Change-Id: I9c453c6c5ba093a6a3a0530e99d2bf8766a98ed3