### PR TITLE
1120: ReadOnly users should not have ssh (#890)(#1061)

### DIFF
--- a/redfish-core/lib/account_service.hpp
+++ b/redfish-core/lib/account_service.hpp
@@ -2112,6 +2112,16 @@ inline void processAfterGetAllGroups(
             }
             continue;
         }
+
+        // Remove the ipmi group.  Also Remove "ssh" if the new
+        // user is not an Administrator.
+        if ((grp == "ipmi") || ((grp == "ssh") && (roleId != "priv-admin")))
+
+        {
+            BMCWEB_LOG_DEBUG("group skipped {}", grp);
+            continue;
+        }
+
         userGroups.emplace_back(grp);
     }
 


### PR DESCRIPTION
ReadOnly users should not have ssh #890)((#1061)

1. ReadOnly users should not have ssh (#890)

This changes the Redfish create new user API (POST
/redfish/v1/AccountService/Accounts/) so only Administrator users
will have the HostConsole AccountType value.  This is the same as
the "ssh" phosphor privilege group.

Doing so prevents new ReadOnly users from using SSH port 2200.

Note that ReadOnly user created prior to this change will have the
HostConsole AccountType privilege.  A BMC admin can PATCH a user's
AccountTypes property to add or remove the Hostconsole value.

Tested: Yes

Signed-off-by: Joseph Reynolds <joseph-reynolds@charter.net>

2. Fix logic excluding groups (#1061)

https://github.com/ibm-openbmc/bmcweb/commit/b9468b9 came in but it
didn't actually set the group but it passed to modGroupsList [1].

We also already have a spot where we are excluding groups so just move
this logic to exclude ipmi and ssh (when user is not admin) to that
loop [2].

[1] https://github.com/ibm-openbmc/bmcweb/commit/b9468b9#diff-a6441dcR2200
[2] https://github.com/ibm-openbmc/bmcweb/blob/1110/redfish-core/lib/account_service.hpp#L1927