### PR TITLE
1110: Remove cookie clear

### DIFF
--- a/include/cookies.hpp
+++ b/include/cookies.hpp
@@ -23,7 +23,6 @@ inline void clearSessionCookies(crow::Response& res)
                   "BMCWEB-SESSION="
                   "; Path=/; SameSite=Strict; Secure; HttpOnly; "
                   "expires=Thu, 01 Jan 1970 00:00:00 GMT");
-    res.addHeader("Clear-Site-Data", R"("cache","cookies","storage")");
 }
 
 } // namespace bmcweb


### PR DESCRIPTION
Fixes 688940 

Upstream is merged at
https://gerrit.openbmc.org/c/openbmc/bmcweb/+/68251

This was broke by a rebase with master at
[commit]: https://github.com/ibm-openbmc/bmcweb/commit/ab9a4801960fd34f53179036c86f6f3f8e1c21f6

It is already in 1120 at
https://github.com/ibm-openbmc/bmcweb/blob/1120/include/cookies.hpp#L29

d8139c68[1] added:
asyncResp->res.addHeader("Clear-Site-Data",
R"("cache","cookies","storage")");

This causes the browsers to clear the cache, cookie, and storage for that site. [2]

Don't see where OWASP recommends Clear-Site-Data response header. [3]

This seems reasonable but breaks our server manager (HMC) when using webui-vue from the HMC proxy. [4][5]
The HMC is also using the cookie and storage from the same URI. The proxy works by going to a URI and the HMC proxing it forward/reverse for webui-vue.

Also had other problems clearing headers, Clear-Site-Data seems too strict, just remove it.

[1]: https://github.com/openbmc/bmcweb/commit/d8139c683a2f42c47ed913b731becc6cd681e2dd
[2]: https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Clear-Site-Data
[3]: https://cheatsheetseries.owasp.org/cheatsheets/HTTP_Headers_Cheat_Sheet.html
[4]: https://en.wikipedia.org/wiki/IBM_Hardware_Management_Console
[5]: https://www.ibm.com/docs/en/power10?topic=asmi-accessing-by-using-hmc

Tested: Firefox and Chrome no longer logout the HMC when logging out
        webui-vue.

Change-Id: I061eae9163ce5d88a3bd9f297ca5e10ff3a07984