### PR TITLE
1120: Refresh of PCIe Topology (#593)

### DIFF
--- a/redfish-core/lib/oem/ibm/pcie_topology_refresh.hpp
+++ b/redfish-core/lib/oem/ibm/pcie_topology_refresh.hpp
@@ -1,0 +1,166 @@
+#pragma once
+
+#include "async_resp.hpp"
+#include "dbus_singleton.hpp"
+#include "error_messages.hpp"
+#include "http_request.hpp"
+#include "io_context_singleton.hpp"
+#include "logging.hpp"
+
+#include <sys/types.h>
+
+#include <boost/asio/steady_timer.hpp>
+#include <boost/system/error_code.hpp>
+#include <sdbusplus/asio/property.hpp>
+
+#include <chrono>
+#include <memory>
+#include <string>
+
+namespace redfish
+{
+// NOLINTBEGIN(cppcoreguidelines-avoid-non-const-global-variables)
+// Timer for PCIe Topology Refresh
+static std::unique_ptr<boost::asio::steady_timer> pcieTopologyRefreshTimer;
+static uint countPCIeTopologyRefresh = 0;
+// NOLINTEND(cppcoreguidelines-avoid-non-const-global-variables)
+
+/**
+ * @brief PCIe Topology Refresh monitor. which block incoming request
+ *
+ * @param[in] ec          error code to be handled
+ * @param[in] timer       pointer to steady timer which block call
+ * @param[in] asyncResp   Shared pointer for generating response message.
+ * @param[in] countPtr   how many time this method get called.
+ *
+ * @return None.
+ */
+static void pcieTopologyRefreshWatchdog(
+    const boost::system::error_code& ec, boost::asio::steady_timer* timer,
+    const std::shared_ptr<bmcweb::AsyncResp>& asyncResp, uint* countPtr)
+{
+    if (ec)
+    {
+        BMCWEB_LOG_ERROR("steady_timer error {}", ec.value());
+        messages::internalError(asyncResp->res);
+        pcieTopologyRefreshTimer = nullptr;
+        (*countPtr) = 0;
+        return;
+    }
+    //  This method can block incoming requests max for 8 seconds. So, each
+    //  call to this method adds a 1-second block, and the maximum call allow is
+    //  8 times which makes it a total of ~8 seconds
+    if ((*countPtr) >= 8)
+    {
+        messages::internalError(asyncResp->res);
+        pcieTopologyRefreshTimer = nullptr;
+        (*countPtr) = 0;
+        return;
+    }
+    ++(*countPtr);
+    sdbusplus::asio::getProperty<bool>(
+        *crow::connections::systemBus, "xyz.openbmc_project.PLDM",
+        "/xyz/openbmc_project/pldm", "com.ibm.PLDM.PCIeTopology",
+        "PCIeTopologyRefresh",
+        [asyncResp, timer, countPtr](const boost::system::error_code& ec1,
+                                     const bool pcieRefreshValue) {
+            if (ec1)
+            {
+                BMCWEB_LOG_ERROR("DBUS response error {}", ec1.value());
+                messages::internalError(asyncResp->res);
+                pcieTopologyRefreshTimer = nullptr;
+                (*countPtr) = 0;
+                return;
+            }
+            // After PCIe Topology Refresh, it sets the pcieRefreshValuePtr
+            // value to false. if a value is not false, extend the time, and if
+            // it is false, delete the timer and reset the counter
+            if (pcieRefreshValue)
+            {
+                BMCWEB_LOG_INFO("pcieRefreshValuePtr time extended");
+                timer->expires_at(
+                    timer->expiry() + boost::asio::chrono::seconds(1));
+                timer->async_wait([timer, asyncResp, countPtr](
+                                      const boost::system::error_code& ec2) {
+                    pcieTopologyRefreshWatchdog(ec2, timer, asyncResp,
+                                                countPtr);
+                });
+            }
+            else
+            {
+                BMCWEB_LOG_ERROR("pcieRefreshValuePtr value refreshed");
+                pcieTopologyRefreshTimer = nullptr;
+                (*countPtr) = 0;
+                return;
+            }
+        });
+};
+
+/**
+ * @brief Sets PCIe Topology Refresh state.
+ *
+ * @param[in] req - The request data
+ * @param[in] asyncResp   Shared pointer for generating response message.
+ * @param[in] state   PCIe Topology Refresh state from request.
+ *
+ * @return None.
+ */
+inline void setPCIeTopologyRefresh(
+    const crow::Request& /* req */,
+    const std::shared_ptr<bmcweb::AsyncResp>& asyncResp, const bool state)
+{
+    BMCWEB_LOG_DEBUG("Set PCIe Topology Refresh status.");
+    sdbusplus::asio::setProperty(
+        *crow::connections::systemBus, "xyz.openbmc_project.PLDM",
+        "/xyz/openbmc_project/pldm", "com.ibm.PLDM.PCIeTopology",
+        "PCIeTopologyRefresh", state,
+        [asyncResp](const boost::system::error_code& ec) {
+            if (ec)
+            {
+                BMCWEB_LOG_ERROR("PCIe Topology Refresh failed {}.",
+                                 ec.value());
+                messages::internalError(asyncResp->res);
+                return;
+            }
+            countPCIeTopologyRefresh = 0;
+            pcieTopologyRefreshTimer =
+                std::make_unique<boost::asio::steady_timer>(getIoContext());
+            pcieTopologyRefreshTimer->expires_after(std::chrono::seconds(1));
+            pcieTopologyRefreshTimer->async_wait(
+                [timer = pcieTopologyRefreshTimer.get(),
+                 asyncResp](const boost::system::error_code& ec1) {
+                    pcieTopologyRefreshWatchdog(ec1, timer, asyncResp,
+                                                &countPCIeTopologyRefresh);
+                });
+        });
+}
+
+/**
+ * @brief Sets Save PCIe Topology Info state.
+ *
+ * @param[in] asyncResp   Shared pointer for generating response message.
+ * @param[in] state   Save PCIe Topology Info state from request.
+ *
+ * @return None.
+ */
+inline void setSavePCIeTopologyInfo(
+    const std::shared_ptr<bmcweb::AsyncResp>& asyncResp, const bool state)
+{
+    BMCWEB_LOG_DEBUG("Set Save PCIe Topology Info status.");
+
+    sdbusplus::asio::setProperty(
+        *crow::connections::systemBus, "xyz.openbmc_project.PLDM",
+        "/xyz/openbmc_project/pldm", "com.ibm.PLDM.PCIeTopology",
+        "SavePCIeTopologyInfo", state,
+        [asyncResp](const boost::system::error_code& ec) {
+            if (ec)
+            {
+                BMCWEB_LOG_ERROR("Save PCIe Topology Info failed {}.",
+                                 ec.value());
+                messages::internalError(asyncResp->res);
+                return;
+            }
+        });
+}
+
+} // namespace redfish

--- a/redfish-core/lib/systems.hpp
+++ b/redfish-core/lib/systems.hpp
@@ -18,6 +18,7 @@
 #include "hypervisor_system.hpp"
 #include "led.hpp"
 #include "logging.hpp"
+#include "oem/ibm/pcie_topology_refresh.hpp"
 #include "query.hpp"
 #include "redfish_util.hpp"
 #include "registries/privilege_registry.hpp"
@@ -3438,6 +3439,8 @@ inline void handleComputerSystemPatch(
     std::optional<uint64_t> ipsExitTime;
     std::optional<std::string> chapName;
     std::optional<std::string> chapSecret;
+    std::optional<bool> pcieTopologyRefresh;
+    std::optional<bool> savePCIeTopologyInfo;
 
     if (!json_util::readJsonPatch(                                         //
             req, asyncResp->res,                                           //
@@ -3461,7 +3464,9 @@ inline void handleComputerSystemPatch(
             "PowerMode", powerMode,                                        //
             "PowerRestorePolicy", powerRestorePolicy,                      //
             "Oem/IBM/ChapData/ChapName", chapName,                         //
-            "Oem/IBM/ChapData/ChapSecret", chapSecret                      //
+            "Oem/IBM/ChapData/ChapSecret", chapSecret,                     //
+            "Oem/IBM/PCIeTopologyRefresh", pcieTopologyRefresh,            //
+            "Oem/IBM/SavePCIeTopologyInfo", savePCIeTopologyInfo           //
             ))
     {
         return;
@@ -3538,6 +3543,15 @@ inline void handleComputerSystemPatch(
     if (chapName || chapSecret)
     {
         setChapData(asyncResp, chapName, chapSecret);
+    }
+
+    if (pcieTopologyRefresh)
+    {
+        setPCIeTopologyRefresh(req, asyncResp, *pcieTopologyRefresh);
+    }
+    if (savePCIeTopologyInfo)
+    {
+        setSavePCIeTopologyInfo(asyncResp, *savePCIeTopologyInfo);
     }
 }
 

--- a/redfish-core/schema/oem/ibm/csdl/IBMComputerSystem_v1.xml
+++ b/redfish-core/schema/oem/ibm/csdl/IBMComputerSystem_v1.xml
@@ -28,6 +28,21 @@
         <Annotation Term="OData.AdditionalProperties" Bool="true"/>
         <Annotation Term="OData.Description" String="Oem properties for IBM."/>
         <Annotation Term="OData.AutoExpand"/>
+        <Property Name="PCIeTopologyRefresh" Type="Edm.Boolean">
+          <Annotation Term="OData.Permissions" EnumMember="OData.Permission/ReadWrite"/>
+          <Annotation Term="OData.Description" String="An indication of topology information is ready."/>
+          <Annotation Term="OData.LongDescription" String="This property when set to 'true' refreshes the topology information. The application which uses this should set it to 'false' when a refresh occurs."/>
+        </Property>
+        <Property Name="SavePCIeTopologyInfo" Type="Edm.Boolean">
+          <Annotation Term="OData.Permissions" EnumMember="OData.Permission/ReadWrite"/>
+          <Annotation Term="OData.Description" String="An indication of PEL topology information is saves."/>
+          <Annotation Term="OData.LongDescription" String="This property when set to 'true' saves the topology information. The information is saved in the form of a PEL(Error Log)."/>
+        </Property>
+        <Property Name="SafeMode" Type="Edm.Boolean">
+          <Annotation Term="OData.Permissions" EnumMember="OData.Permission/Read"/>
+          <Annotation Term="OData.Description" String="An indication of whether safe mode is active."/>
+          <Annotation Term="OData.LongDescription" String="The value of this property shall indicate if safe mode is active."/>
+        </Property>
       </ComplexType>
     </Schema>
     <Schema xmlns="http://docs.oasis-open.org/odata/ns/edm" Namespace="IBMComputerSystem.v1_0_0">

--- a/redfish-core/schema/oem/ibm/json-schema/IBMComputerSystem.v1_0_0.json
+++ b/redfish-core/schema/oem/ibm/json-schema/IBMComputerSystem.v1_0_0.json
@@ -52,6 +52,18 @@
                 }
             },
             "properties": {
+                "PCIeTopologyRefresh": {
+                    "description": "An indication of topology information is ready.",
+                    "longDescription": "This property when set to 'true' refreshes the topology information. The application which uses this should set it to 'false' when a refresh occurs.",
+                    "readonly": true,
+                    "type": ["boolean", "null"]
+                },
+                "SavePCIeTopologyInfo": {
+                    "description": "An indication of PEL topology information is saved.",
+                    "longDescription": "This property when set to 'true' saves the topology information. The information is saved in the form of a PEL(Error Log).",
+                    "readonly": true,
+                    "type": ["boolean", "null"]
+                },
                 "EnabledPanelFunctions": {
                     "description": "Enabled Panel functions",
                     "longDescription": "This property shall contain the list of enabled panel functions.",


### PR DESCRIPTION
This implements PATCH of PCIeTopologyRefresh & SavePCIeTopologyInfo.

This pulls in the following 1030 PRs:

- https://github.com/ibm-openbmc/bmcweb/pull/377
- https://github.com/ibm-openbmc/bmcweb/pull/382
- https://github.com/ibm-openbmc/bmcweb/pull/404
- https://github.com/ibm-openbmc/bmcweb/pull/406

This commit also adds functionality, where bmcweb creates a watchdog (using timer), where timer waits for one second and then checks if PCIe Topology gets refreshed or not. If not, then wait for one more second and repeat this process eight times, and then then watchdog expires in between if it gets refreshed then unblock the request.

Tested:

- Successful PATCH:

```
curl -k -H "Content-Type: application/json" -X PATCH https://${bmc}/redfish/v1/Systems/system/ -d '{"Oem":{"IBM":{"PCIeTopologyRefresh":true}}}'
curl -k -H "Content-Type: application/json" -X PATCH https://${bmc}/redfish/v1/Systems/system/ -d '{"Oem":{"IBM":{"SavePCIeTopologyInfo":true}}}'
```