### PR TITLE
1120: Fix CI failure of audit_events

### DIFF
--- a/src/audit_events.cpp
+++ b/src/audit_events.cpp
@@ -3,7 +3,8 @@
 #include "http_request.hpp"
 #include "logging.hpp"
 
-#include <libaudit.h>
+#include <audit-records.h>
+#include <audit_logging.h>
 
 #include <boost/asio/ip/host_name.hpp>
 #include <boost/beast/http/verb.hpp>


### PR DESCRIPTION
CI is failing on audit_events.cpp like
```

.../bmcweb/src/audit_events.cpp:6:1: error: included header libaudit.h is not used directly [misc-include-cleaner,-warnings-as-errors]
    6 | #include <libaudit.h>
      | ^~~~~~~~~~~~~~~~~~~~~
    7 |
.../bmcweb/src/audit_events.cpp:38:9: error: no header providing "audit_close" is directly included [misc-include-cleaner,-warnings-as-errors]
    6 |         audit_close(auditfd);
      |         ^
.../bmcweb/src/audit_events.cpp:62:19: error: no header providing "audit_open" is directly included [misc-include-cleaner,-warnings-as-errors]
   62 |         auditfd = audit_open();
      |                   ^
.../bmcweb/src/audit_events.cpp:218:18: error: no header providing "audit_encode_nv_string" is directly included [misc-include-cleaner,-warnings-as-errors]
  218 |     char* user = audit_encode_nv_string("acct", userName.c_str(), 0);
      |                  ^
.../bmcweb/src/audit_events.cpp:254:14: error: no header providing "audit_log_user_message" is directly included [misc-include-cleaner,-warnings-as-errors]
  254 |     int rc = audit_log_user_message(
      |              ^
.../bmcweb/src/audit_events.cpp:255:18: error: no header providing "AUDIT_USYS_CONFIG" is directly included [misc-include-cleaner,-warnings-as-errors]
    6 |         auditfd, AUDIT_USYS_CONFIG, cnfgBuff.c_str(),
      |                  ^

```

```
The new insertion has the same insert location as an existing replacement.
New replacement: .../bmcweb/src/audit_events.cpp: 81:+0:"#include <audit_logging.h>
"
Existing replacement: .../bmcweb/src/audit_events.cpp: 81:+0:"#include <audit-records.h>
"
Errors encountered while running clang-tidy
FAILED: meson-internal__clang-tidy-fix
```

Tested:
- Compiles
- CI passed