### PR TITLE
1120: Check snmpTrap port

### DIFF
--- a/redfish-core/lib/event_service.hpp
+++ b/redfish-core/lib/event_service.hpp
@@ -420,6 +420,54 @@ inline void requestRoutesEventDestinationCollection(App& app)
                 return;
             }
 
+            /* Check snmpTrap port.
+            1. Allow empty port, eg:
+            "snmp://9.41.166.76:".
+            2. Invalid ports and out of range ports are not allowed, eg:
+            "snmp://9.41.166.76:ab"
+            "snmp://9.41.166.76:-40"
+            "snmp://9.41.166.76:65536".
+            */
+
+            if (protocol == "snmp")
+            {
+                if (!url.value().port().empty())
+                {
+                    uint16_t portTmp = 0;
+                    // Check the port
+                    auto ret = std::from_chars(
+                        url.value().port().data(),
+                        url.value().port().data() + url.value().port().size(),
+                        portTmp);
+                    if (ret.ec != std::errc())
+                    {
+                        messages::propertyValueFormatError(
+                            asyncResp->res, destUrl, "Destination");
+                        return;
+                    }
+                }
+                else
+                {
+                    size_t pos = destUrl.find(':');
+                    if (pos != std::string::npos)
+                    {
+                        std::string tmp_str =
+                            std::string(destUrl).substr(pos + 1);
+                        size_t pos2 = tmp_str.find(':');
+                        if (pos2 != std::string::npos)
+                        {
+                            std::string port_str = tmp_str.substr(pos2 + 1);
+                            if (!port_str.empty())
+                            {
+                                messages::propertyValueFormatError(
+                                    asyncResp->res, destUrl, "Destination");
+                                return;
+                            }
+                        }
+                    }
+                }
+            }
+
             if (protocol == "SNMPv2c")
             {
                 if (context)


### PR DESCRIPTION
1. Allow empty port, eg: "snmp://9.41.166.76:".
2. Invalid ports and out of range ports are not allowed, eg: "snmp://9.41.166.76:ab" "snmp://9.41.166.76:-40" "snmp://9.41.166.76:65536".

Tested:
1. Empty port:
```
curl -k -H "X-Auth-Token: $bmc_token" -X POST -D headers.txt https://${bmc}/redfish/v1/EventService/Subscriptions -d '{"Destination":"snmp://9.41.166.76:", "SubscriptionType":"SNMPTrap", "Protocol":"SNMPv2c"}'
{
  "@Message.ExtendedInfo": [
    {
      "@odata.type": "#Message.v1_1_1.Message",
      "Message": "The resource has been created successfully.",
      "MessageArgs": [],
      "MessageId": "Base.1.13.0.Created",
      "MessageSeverity": "OK",
      "Resolution": "None."
    }
  ]
}
```
2. Invalid port:
```
curl -k -H "X-Auth-Token: $bmc_token" -X POST -D headers.txt https://${bmc}/redfish/v1/EventService/Subscriptions -d '{"Destination":"snmp://9.41.166.76:ab", "SubscriptionType":"SNMPTrap", "Protocol":"SNMPv2c"}'
{
  "Destination@Message.ExtendedInfo": [
    {
      "@odata.type": "#Message.v1_1_1.Message",
      "Message": "The value 'snmp://9.41.166.76:ab' for the property Destination is of a different format than the property can accept.",
      "MessageArgs": [
        "snmp://9.41.166.76:ab",
        "Destination"
      ],
      "MessageId": "Base.1.13.0.PropertyValueFormatError",
      "MessageSeverity": "Warning",
      "Resolution": "Correct the value for the property in the request body and resubmit the request if the operation failed."
    }
  ]

curl -k -H "X-Auth-Token: $bmc_token" -X POST -D headers.txt https://${bmc}/redfish/v1/EventService/Subscriptions -d '{"Destination":"snmp://9.41.166.76:-40", "SubscriptionType":"SNMPTrap", "Protocol":"SNMPv2c"}'
{
  "Destination@Message.ExtendedInfo": [
    {
      "@odata.type": "#Message.v1_1_1.Message",
      "Message": "The value 'snmp://9.41.166.76:-40' for the property Destination is of a different format than the property can accept.",
      "MessageArgs": [
        "snmp://9.41.166.76:-40",
        "Destination"
      ],
      "MessageId": "Base.1.13.0.PropertyValueFormatError",
      "MessageSeverity": "Warning",
      "Resolution": "Correct the value for the property in the request body and resubmit the request if the operation failed."
    }
  ]
}
```
3. Out of range port:
```
curl -k -H "X-Auth-Token: $bmc_token" -X POST -D headers.txt https://${bmc}/redfish/v1/EventService/Subscriptions -d '{"Destination":"snmp://9.41.166.76:65536", "SubscriptionType":"SNMPTrap", "Protocol":"SNMPv2c"}'
{
  "Destination@Message.ExtendedInfo": [
    {
      "@odata.type": "#Message.v1_1_1.Message",
      "Message": "The value 'snmp://9.41.166.76:65536' for the property Destination is of a different format than the property can accept.",
      "MessageArgs": [
        "snmp://9.41.166.76:65536",
        "Destination"
      ],
      "MessageId": "Base.1.13.0.PropertyValueFormatError",
      "MessageSeverity": "Warning",
      "Resolution": "Correct the value for the property in the request body and resubmit the request if the operation failed."
    }
  ]
}
```