### PR TITLE
1120: Create Event Subscription meson build option (#941)

### DIFF
--- a/config/meson.build
+++ b/config/meson.build
@@ -6,6 +6,7 @@ feature_options = [
     'audit-events',
     'basic-auth',
     'cookie-auth',
+    'event-subscription',
     'experimental-http2',
     'experimental-redfish-dbus-log-subscription',
     'experimental-redfish-multi-computer-system',

--- a/meson.options
+++ b/meson.options
@@ -440,6 +440,14 @@ option(
     resources such as EthernetInterfaces and ComputerSystem.Reset.''',
 )
 
+# BMCWEB_EVENT_SUBSCRIPTION
+option(
+    'event-subscription',
+    type: 'feature',
+    value: 'enabled',
+    description: 'Enable Event Subscription through websocket',
+)
+
 # BMCWEB_EXPERIMENTAL_REDFISH_MULTI_COMPUTER_SYSTEM
 option(
     'experimental-redfish-multi-computer-system',

--- a/src/webserver_run.cpp
+++ b/src/webserver_run.cpp
@@ -95,9 +95,13 @@ int run()
 
     if constexpr (BMCWEB_REST)
     {
-        crow::dbus_monitor::requestRoutes(app);
         crow::image_upload::requestRoutes(app);
         crow::openbmc_mapper::requestRoutes(app);
+    }
+
+    if constexpr (BMCWEB_EVENT_SUBSCRIPTION)
+    {
+        crow::dbus_monitor::requestRoutes(app);
     }
 
     if constexpr (BMCWEB_HOST_SERIAL_SOCKET)


### PR DESCRIPTION
Create a Meson build option to enable and disable event subscription at /subscribe. 
By default, this is enabled