### PR TITLE
1120: Add BMC_SHELL web-base_shell (#483)(#473) (#936)

### DIFF
--- a/config/meson.build
+++ b/config/meson.build
@@ -5,6 +5,7 @@ conf_data = configuration_data()
 feature_options = [
     'audit-events',
     'basic-auth',
+    'bmc-shell-socket',
     'cookie-auth',
     'experimental-http2',
     'experimental-redfish-dbus-log-subscription',

--- a/http/websocket.hpp
+++ b/http/websocket.hpp
@@ -5,6 +5,7 @@
 
 #include <functional>
 #include <memory>
+#include <string>
 #include <string_view>
 
 namespace crow
@@ -27,6 +28,8 @@ struct Connection : std::enable_shared_from_this<Connection>
     Connection(Connection&&) = delete;
     Connection& operator=(const Connection&) = delete;
     Connection& operator=(const Connection&&) = delete;
+
+    virtual const std::string& getUserName() const = 0;
 
     virtual void sendBinary(std::string_view msg) = 0;
     virtual void sendEx(MessageType type, std::string_view msg,

--- a/http/websocket_impl.hpp
+++ b/http/websocket_impl.hpp
@@ -125,6 +125,11 @@ class ConnectionImpl : public Connection
                                         shared_from_this(), std::move(mobile)));
     }
 
+    const std::string& getUserName() const override
+    {
+        return session->username;
+    }
+
     void sendBinary(std::string_view msg) override
     {
         ws.binary(true);

--- a/include/obmc_shell.hpp
+++ b/include/obmc_shell.hpp
@@ -1,0 +1,250 @@
+#pragma once
+
+#include "app.hpp"
+#include "io_context_singleton.hpp"
+#include "logging.hpp"
+#include "websocket.hpp"
+
+#include <pty.h>
+#include <sys/wait.h>
+#include <unistd.h>
+
+#include <boost/asio/buffer.hpp>
+#include <boost/asio/error.hpp>
+#include <boost/asio/posix/stream_descriptor.hpp>
+#include <boost/process/io.hpp>
+#include <boost/system/error_code.hpp>
+
+#include <array>
+#include <cerrno>
+#include <csignal>
+#include <cstddef>
+#include <map>
+#include <memory>
+#include <string>
+#include <string_view>
+
+namespace crow
+{
+
+namespace obmc_shell
+{
+
+class Handler : public std::enable_shared_from_this<Handler>
+{
+  public:
+    explicit Handler(crow::websocket::Connection* conn) :
+        session(conn), streamFileDescriptor(getIoContext())
+    {
+        outputBuffer.fill(0);
+    }
+
+    ~Handler() = default;
+
+    Handler(const Handler&) = delete;
+    Handler(Handler&&) = delete;
+    Handler& operator=(const Handler&) = delete;
+    Handler& operator=(Handler&&) = delete;
+
+    void doClose()
+    {
+        streamFileDescriptor.close();
+
+        // boost::process::child::terminate uses SIGKILL, need to send SIGTERM
+        // NOLINTNEXTLINE(misc-include-cleaner)
+        int rc = kill(pid, SIGKILL);
+        session = nullptr;
+        if (rc != 0)
+        {
+            return;
+        }
+        waitpid(pid, nullptr, 0);
+    }
+
+    void connect()
+    {
+        pid = forkpty(&ttyFileDescriptor, nullptr, nullptr, nullptr);
+
+        if (pid == -1)
+        {
+            // ERROR
+            if (session != nullptr)
+            {
+                session->close("Error creating child process for login shell.");
+            }
+            return;
+        }
+        if (pid == 0)
+        {
+            // CHILD
+
+            auto userName = session->getUserName();
+            if (!userName.empty())
+            {
+                // NOLINTNEXTLINE(cppcoreguidelines-pro-type-vararg)
+                execl("/bin/login", "/bin/login", "-f", userName.c_str(), NULL);
+                // execl only returns on fail
+                BMCWEB_LOG_ERROR("execl() for /bin/login failed: {}", errno);
+                session->close("Internal Error Login failed");
+            }
+            else
+            {
+                session->close("Error session user name not found");
+            }
+            return;
+        }
+        if (pid > 0)
+        {
+            // PARENT
+
+            // for io operation assing file discriptor
+            // to boost stream_descriptor
+            streamFileDescriptor.assign(ttyFileDescriptor);
+            doWrite();
+            doRead();
+        }
+    }
+
+    void doWrite()
+    {
+        if (session == nullptr)
+        {
+            BMCWEB_LOG_DEBUG("session is closed");
+            return;
+        }
+        if (doingWrite)
+        {
+            BMCWEB_LOG_DEBUG("Already writing.  Bailing out");
+            return;
+        }
+
+        if (inputBuffer.empty())
+        {
+            BMCWEB_LOG_DEBUG("inputBuffer empty.  Bailing out");
+            return;
+        }
+
+        doingWrite = true;
+        streamFileDescriptor.async_write_some(
+            boost::asio::buffer(inputBuffer.data(), inputBuffer.size()),
+            [this, self(shared_from_this())](
+                const boost::system::error_code& ec, std::size_t bytesWritten) {
+                BMCWEB_LOG_DEBUG("Wrote {} bytes", bytesWritten);
+                doingWrite = false;
+                inputBuffer.erase(0, bytesWritten);
+                if (ec == boost::asio::error::eof)
+                {
+                    session->close("ssh socket port closed");
+                    return;
+                }
+                if (ec)
+                {
+                    session->close("Error in writing to processSSH port");
+                    BMCWEB_LOG_ERROR("Error in ssh socket write {}", ec);
+                    return;
+                }
+                doWrite();
+            });
+    }
+
+    void doRead()
+    {
+        if (session == nullptr)
+        {
+            BMCWEB_LOG_DEBUG("session is closed");
+            return;
+        }
+        streamFileDescriptor.async_read_some(
+            boost::asio::buffer(outputBuffer.data(), outputBuffer.size()),
+            [this, self(shared_from_this())](
+                const boost::system::error_code& ec, std::size_t bytesRead) {
+                BMCWEB_LOG_DEBUG("Read done.  Read {} bytes", bytesRead);
+                if (session == nullptr)
+                {
+                    BMCWEB_LOG_DEBUG("session is closed");
+                    return;
+                }
+                if (ec)
+                {
+                    BMCWEB_LOG_ERROR("Couldn't read from ssh port: {}", ec);
+                    session->close("Error in connecting to ssh port");
+                    return;
+                }
+                std::string_view payload(outputBuffer.data(), bytesRead);
+                session->sendBinary(payload);
+                doRead();
+            });
+    }
+
+    // this has to public
+    std::string inputBuffer;
+
+  private:
+    crow::websocket::Connection* session;
+    boost::asio::posix::stream_descriptor streamFileDescriptor;
+    bool doingWrite{false};
+    int ttyFileDescriptor{0};
+    pid_t pid{0};
+
+    std::array<char, 4096> outputBuffer{};
+};
+
+// NOLINTBEGIN(cppcoreguidelines-avoid-non-const-global-variables)
+static std::map<crow::websocket::Connection*, std::shared_ptr<Handler>>
+    mapHandler;
+// NOLINTEND(cppcoreguidelines-avoid-non-const-global-variables)
+
+inline void onOpen(crow::websocket::Connection& conn)
+{
+    BMCWEB_LOG_DEBUG("Connection {} opened", logPtr(&conn));
+    auto it = mapHandler.find(&conn);
+    if (it == mapHandler.end())
+    {
+        auto insertData =
+            mapHandler.emplace(&conn, std::make_shared<Handler>(&conn));
+        if (std::get<bool>(insertData))
+        {
+            std::get<0>(insertData)->second->connect();
+        }
+    }
+}
+
+inline void onClose(crow::websocket::Connection& conn,
+                    const std::string& reason)
+{
+    BMCWEB_LOG_DEBUG("bmc-shell console.onclose(reason = '{}')", reason);
+    auto it = mapHandler.find(&conn);
+    if (it != mapHandler.end())
+    {
+        it->second->doClose();
+        mapHandler.erase(it);
+    }
+}
+
+inline void onMessage(crow::websocket::Connection& conn,
+                      const std::string& data, [[maybe_unused]] bool isBinary)
+{
+    auto it = mapHandler.find(&conn);
+    if (it != mapHandler.end())
+    {
+        it->second->inputBuffer += data;
+        it->second->doWrite();
+    }
+    else
+    {
+        BMCWEB_LOG_ERROR("connection to socket not found");
+    }
+}
+
+inline void requestRoutes(App& app)
+{
+    BMCWEB_ROUTE(app, "/bmc-console")
+        .privileges({{"OemIBMPerformService"}})
+        .websocket()
+        .onopen(onOpen)
+        .onclose(onClose)
+        .onmessage(onMessage);
+}
+
+} // namespace obmc_shell
+} // namespace crow

--- a/meson.options
+++ b/meson.options
@@ -543,3 +543,13 @@ option(
                     enable on production systems at this time.  Other query
                     parameters such as only are not controlled by this option.''',
 )
+
+# BMCWEB_BMC_SHELL_SOCKET
+option(
+    'bmc-shell-socket',
+    type: 'feature',
+    value: 'enabled',
+    description: '''Enable BMC command shell WebSocket, which makes it
+                       possible to access secure shell. Path is
+                       \'/bmc-console\'.''',
+)

--- a/src/webserver_run.cpp
+++ b/src/webserver_run.cpp
@@ -17,6 +17,7 @@
 #include "logging.hpp"
 #include "login_routes.hpp"
 #include "obmc_console.hpp"
+#include "obmc_shell.hpp"
 #include "openbmc_dbus_rest.hpp"
 #include "redfish.hpp"
 #include "redfish_aggregator.hpp"
@@ -103,6 +104,11 @@ int run()
     if constexpr (BMCWEB_HOST_SERIAL_SOCKET)
     {
         crow::obmc_console::requestRoutes(app);
+    }
+
+    if constexpr (BMCWEB_BMC_SHELL_SOCKET)
+    {
+        crow::obmc_shell::requestRoutes(app);
     }
 
     crow::obmc_vm::requestRoutes(app);


### PR DESCRIPTION
This commit includes a web-based shell, making it possible to access secure shell servers through standard web browsers using WebSocket.

Path of WebSocket:
    wss://{hostname}/bmc-console

Implementation:

    So when bmcweb WebSocket gets a request for a new connection, it
    creates a child process of bmcweb using the forking bmcweb process
    (which begins a new process operating in a pseudoterminal).

    Then on that pseudoterminal call exec("/bin/sh") which replaces the
    current process image with a "/bin/sh" process image.

    bmcweb is communicating with that child process using
    stream_descriptor, similar to read write from a file descriptor,
    with asynchronous ability. So the shell can execute all commands
    like ls, cd, etc.

    WebSocket here only acts as a mediator between child process, which
    acts as a shell, and xterm.js, which write in NodeJS

Authorize user for Shell :

    Only service users can access this interface, which means only
    managers can access this interface.

Test:
    This commit gets tested using the xterm.js console.

    The essential operation can perform on this xterm console, Ex: ls,
    cd, grep, etc.

This change is downstream change only.