### PR TITLE
Remove body after code update write

### DIFF
--- a/http/http_request.hpp
+++ b/http/http_request.hpp
@@ -16,7 +16,7 @@
 namespace crow
 {
 
-struct Request
+struct Request : std::enable_shared_from_this<Request>
 {
     using Body = boost::beast::http::request<bmcweb::HttpBody>;
     Body req;

--- a/http/http_request.hpp
+++ b/http/http_request.hpp
@@ -71,6 +71,11 @@ struct Request : std::enable_shared_from_this<Request>
         userRole = "";
     }
 
+    void clearBody()
+    {
+        req.clear();
+    }
+
     boost::beast::http::verb method() const
     {
         return req.method();

--- a/redfish-core/include/query.hpp
+++ b/redfish-core/include/query.hpp
@@ -101,12 +101,12 @@ inline bool handleIfMatch(crow::App& app, const crow::Request& req,
     std::shared_ptr<bmcweb::AsyncResp> getReqAsyncResp =
         std::make_shared<bmcweb::AsyncResp>();
 
-    // Ideally we would have a shared_ptr to the original Request which we could
-    // modify to remove the If-Match and restart it. But instead we have to make
-    // a full copy to restart it.
-    getReqAsyncResp->res.setCompleteRequestHandler(std::bind_front(
-        afterIfMatchRequest, std::ref(app), asyncResp,
-        std::make_shared<crow::Request>(req), std::move(ifMatch)));
+    // NOLINTBEGIN(cppcoreguidelines-pro-type-const-cast)
+    getReqAsyncResp->res.setCompleteRequestHandler(
+        std::bind_front(afterIfMatchRequest, std::ref(app), asyncResp,
+                        const_cast<crow::Request*>(&req)->shared_from_this(),
+                        std::move(ifMatch)));
+    // NOLINTEND(cppcoreguidelines-pro-type-const-cast)
 
     app.handle(getReq, getReqAsyncResp);
     return false;

--- a/redfish-core/lib/update_service.hpp
+++ b/redfish-core/lib/update_service.hpp
@@ -866,6 +866,12 @@ inline void handleUpdateServicePost(
         monitorForSoftwareAvailable(asyncResp, req, url);
 
         uploadImageFile(asyncResp->res, req.body());
+        // Not good code, goes against the bmcweb architecture but we have to
+        // clear this body for memory reasons. This body can be 200+ MB.. and
+        // untaring it can take up another 100MB.
+        // NOLINTNEXTLINE(cppcoreguidelines-pro-type-const-cast)
+        auto thisReq = const_cast<crow::Request*>(&req)->shared_from_this();
+        thisReq->clearBody();
     }
     else if (contentType.starts_with("multipart/form-data"))
     {
@@ -882,6 +888,12 @@ inline void handleUpdateServicePost(
         }
 
         updateMultipartContext(asyncResp, req, parser);
+        // Not good code, goes against the bmcweb architecture but we have to
+        // clear this body for memory reasons. This body can be 200+ MB.. and
+        // untaring it can take up another 100MB.
+        // NOLINTNEXTLINE(cppcoreguidelines-pro-type-const-cast)
+        auto thisReq = const_cast<crow::Request*>(&req)->shared_from_this();
+        thisReq->clearBody();
     }
     else
     {


### PR DESCRIPTION
https://github.com/ibm-openbmc/bmcweb/pull/1248 is the 1120 

2 commits: 

1)  Pull in https://github.com/ibm-openbmc/bmcweb/pull/1176 
The commit https://github.com/ibm-openbmc/bmcweb/commit/102a4cdacb0a6d8c8c3c97e10bedbb66000ac5dc [1] changes Request as shared_ptr<Request>, but handleIfMatch() still does the full copy of Request with If-Match with non-empty ETag [2], whether ETag matches or not.

For example,

curl   -k -X GET https://${bmc}/redfish/v1/AccountService/Accounts/readonly -etag-save etag.out
ETAG=`cat etag.out`;  echo $ETAG

redfishtool.py raw -r ${bmc} -u ${user} -p ${pass} \
    -S Always PATCH /redfish/v1/AccountService/Accounts/readonly \
    --data='{"RoleId":"Administrator"}'

Or,

curl   -k -H "Content-Type: application/json" -H "If-Match:${ETAG}" \
    -X PATCH ttps://${bmc}/redfish/v1/AccountService/Accounts/readonly \
    -d '{"RoleId":"Administrator"}'

This could also cause the more memory consumption if accidentally used for If-Match.

curl  -H "If-Match: ${ETAG}"  -k -H "Content-Type: application/octet-stream" \
     -X POST -T ${image}  https://${bmc}/redfish/v1/UpdateService/update

This can be avoided by accessing shared_ptr from Request, as Request is created and managed as a shared_ptr. 

2) Remove body after code update write. Monitor goes on for a while, clear the body after writing. This goes against bmcweb's design of only clearing the body at the complete. This is also fragile because only a check for URI keeps audit log from
accessing this... But we have bad defects were we are running out of memory after writing the image, when xz starts up. Based on https://github.com/ibm-openbmc/bmcweb/pull/1176 

Tested: 

Before code update: 
```
 1085     1 root     R    22924   3%   1   8% /usr/bin/bmcweb
```
`curl -k -H "Content-Type: application/octet-stream" -X POST -T $image https://${bmc}/redfish/v1/UpdateService/update`
For the 3 mins it takes for the image to upload, bmcweb memory looks like 
```
 1085     1 root     R     221m  27%   1  41% /usr/bin/bmcweb
 1085     1 root     S     221m  27%   1  37% /usr/bin/bmcweb
```
It appears to stay at ~221m for longer but we are talking seconds..  

```
awk '/^Pss:/ {pss+=$2} END {print pss}' < /proc/1924/smaps
6167
...

awk '/^Pss:/ {pss+=$2} END {print pss}' < /proc/1924/smaps
89467

...

awk '/^Pss:/ {pss+=$2} END {print pss}' < /proc/1924/smaps
5673
```
