### PR TITLE
Publish Name under PCIeDevice schema

### DIFF
--- a/redfish-core/lib/pcie.hpp
+++ b/redfish-core/lib/pcie.hpp
@@ -21,6 +21,7 @@
 #include "utils/chassis_utils.hpp"
 #include "utils/dbus_utils.hpp"
 #include "utils/json_utils.hpp"
+#include "utils/name_utils.hpp"
 #include "utils/pcie_util.hpp"
 
 #include <asm-generic/errno.h>
@@ -676,6 +677,8 @@ inline void afterGetValidPcieDevicePath(
     getPCIeDeviceSlotPath(
         pcieDevicePath, asyncResp,
         std::bind_front(afterGetPCIeDeviceSlotPath, asyncResp));
+    name_util::getPrettyName(asyncResp, pcieDevicePath, service,
+                             nlohmann::json::json_pointer{"/Name"});
 }
 
 inline void handlePCIeDeviceGet(


### PR DESCRIPTION
This commit publishes Name under PCIeDevice schema.

Test:

```
Redfish Validator was executed and no new error was found.
{
"@odata.id": "/redfish/v1/Systems/system/PCIeDevices/
chassis_motherboard_pcieslot12_pcie_card12",
"@odata.type": "#PCIeDevice.v1_9_0.PCIeDevice",
"Id": "chassis_motherboard_pcieslot12_pcie_card12",
"Links": {
"Oem": {
"IBM": {
"@odata.type": "#IBMPCIeDevice.v1_0_0.PCIeLinks",
"PCIeSlot": {
"@odata.id": "/redfish/v1/Chassis/chassis/PCIeSlots"
}
}
}
},
"Name": "USB 3.0 port (front)",
"Oem": {
"IBM": {
"@odata.type": "#IBMPCIeDevice.v1_0_0.IBM",
"LinkReset": false
}
},
"PCIeFunctions": {
"@odata.id": "/redfish/v1/Systems/system/PCIeDevices/
chassis_motherboard_pcieslot12_pcie_card12/PCIeFunctions"
},
"PCIeInterface": {
"LanesInUse": null
},
"Slot": {
"Location": {
"PartLocation": {
"ServiceLabel": "U78DA.ND0.WZS0065-P0-T18"
}
},
"SlotType": "OEM"
},
"Status": {
"Health": "OK",
"State": "Enabled"
}
}
```