### PR TITLE
1120: Redfish: Implement OEM lamp test and SAI (#827)

### DIFF
--- a/config/meson.build
+++ b/config/meson.build
@@ -15,6 +15,7 @@ feature_options = [
     'host-serial-socket',
     'hypervisor-computer-system',
     'hypervisor-serial-socket',
+    'ibm-led-extensions',
     'ibm-management-console',
     'insecure-disable-auth',
     'insecure-disable-csrf',

--- a/meson.options
+++ b/meson.options
@@ -267,6 +267,14 @@ option(
     ''',
 )
 
+# BMCWEB_IBM_LED_EXTENSIONS
+option(
+    'ibm-led-extensions',
+    type: 'feature',
+    value: 'enabled',
+    description: 'Enable the IBM LED extensions such as lamp test and system attention indicators.',
+)
+
 # BMCWEB_IBM_MANAGEMENT_CONSOLE
 option(
     'ibm-management-console',

--- a/redfish-core/lib/oem/ibm/lamp_test.hpp
+++ b/redfish-core/lib/oem/ibm/lamp_test.hpp
@@ -1,0 +1,128 @@
+#pragma once
+
+#include "async_resp.hpp"
+#include "dbus_singleton.hpp"
+#include "dbus_utility.hpp"
+#include "error_messages.hpp"
+#include "led.hpp"
+#include "logging.hpp"
+
+#include <asm-generic/errno.h>
+
+#include <boost/system/error_code.hpp>
+#include <sdbusplus/asio/property.hpp>
+
+#include <memory>
+
+namespace redfish
+{
+
+/**
+ * @brief Retrieves lamp test state.
+ *
+ * @param[in] asyncResp     Shared pointer for generating response message.
+ *
+ * @return None.
+ */
+inline void getLampTestState(
+    const std::shared_ptr<bmcweb::AsyncResp>& asyncResp)
+{
+    BMCWEB_LOG_DEBUG("Get lamp test state");
+
+    dbus::utility::getDbusObject(
+        "/xyz/openbmc_project/led/groups/lamp_test", ledGroupInterface,
+        [asyncResp](const boost::system::error_code& ec,
+                    const dbus::utility::MapperGetObject& object) {
+            if (ec || object.empty())
+            {
+                if (ec.value() == boost::system::errc::io_error)
+                {
+                    BMCWEB_LOG_DEBUG("lamp test not available yet!!");
+                    return;
+                }
+                BMCWEB_LOG_ERROR("DBUS response error: {}", ec.value());
+                messages::internalError(asyncResp->res);
+                return;
+            }
+
+            dbus::utility::getProperty<bool>(
+                object.begin()->first,
+                "/xyz/openbmc_project/led/groups/lamp_test",
+                "xyz.openbmc_project.Led.Group", "Asserted",
+                [asyncResp](const boost::system::error_code& ec1, bool assert) {
+                    if (ec1)
+                    {
+                        if (ec1.value() != EBADR)
+                        {
+                            BMCWEB_LOG_ERROR("DBUS response error: {}",
+                                             ec1.value());
+                            messages::internalError(asyncResp->res);
+                        }
+                        return;
+                    }
+
+                    asyncResp->res.jsonValue["Oem"]["IBM"]["@odata.type"] =
+                        "#IBMComputerSystem.v1_0_0.IBM";
+                    asyncResp->res.jsonValue["Oem"]["IBM"]["LampTest"] = assert;
+                });
+        });
+}
+
+/**
+ * @brief Sets lamp test state.
+ *
+ * @param[in] asyncResp   Shared pointer for generating response message.
+ * @param[in] state   Lamp test state from request.
+ *
+ * @return None.
+ */
+inline void setLampTestState(
+    const std::shared_ptr<bmcweb::AsyncResp>& asyncResp, const bool state)
+{
+    BMCWEB_LOG_DEBUG("Set lamp test status.");
+
+    dbus::utility::getDbusObject(
+        "/xyz/openbmc_project/led/groups/lamp_test", ledGroupInterface,
+        [asyncResp, state](const boost::system::error_code& ec,
+                           const dbus::utility::MapperGetObject& object) {
+            if (ec || object.empty())
+            {
+                BMCWEB_LOG_ERROR("DBUS response error: {}", ec.value());
+                messages::internalError(asyncResp->res);
+                return;
+            }
+
+            sdbusplus::asio::setProperty(
+                *crow::connections::systemBus, object.begin()->first,
+                "/xyz/openbmc_project/led/groups/lamp_test",
+                "xyz.openbmc_project.Led.Group", "Asserted", state,
+                [asyncResp, state](const boost::system::error_code& ec1) {
+                    if (ec1)
+                    {
+                        if (ec1.value() != EBADR)
+                        {
+                            BMCWEB_LOG_ERROR("DBUS response error: {}",
+                                             ec1.value());
+                            messages::internalError(asyncResp->res);
+                        }
+                        return;
+                    }
+
+                    crow::connections::systemBus->async_method_call(
+                        [asyncResp](const boost::system::error_code& ec2) {
+                            if (ec2)
+                            {
+                                BMCWEB_LOG_ERROR(
+                                    "Panel Lamp test failed with error code : {}",
+                                    ec2.value());
+                                messages::internalError(asyncResp->res);
+                                return;
+                            }
+                        },
+                        "com.ibm.PanelApp", "/com/ibm/panel_app",
+                        "com.ibm.panel", "TriggerPanelLampTest", state);
+                });
+        });
+}
+
+} // namespace redfish

--- a/redfish-core/lib/oem/ibm/system_attention_indicator.hpp
+++ b/redfish-core/lib/oem/ibm/system_attention_indicator.hpp
@@ -1,0 +1,152 @@
+#pragma once
+
+#include "async_resp.hpp"
+#include "dbus_singleton.hpp"
+#include "dbus_utility.hpp"
+#include "error_messages.hpp"
+#include "led.hpp"
+#include "logging.hpp"
+
+#include <asm-generic/errno.h>
+
+#include <boost/system/error_code.hpp>
+#include <sdbusplus/asio/property.hpp>
+
+#include <memory>
+#include <string>
+
+namespace redfish
+{
+/**
+ * @brief Get System Attention Indicator
+ *
+ * @param[in] asyncResp         Shared pointer for generating response message.
+ * @param[in] propertyValue     The property value
+ *                              (PartitionSystemAttentionIndicator/PlatformSystemAttentionIndicator).
+ *
+ * @return None.
+ */
+inline void getSAI(const std::shared_ptr<bmcweb::AsyncResp>& asyncResp,
+                   const std::string& propertyValue)
+{
+    BMCWEB_LOG_DEBUG("Get platform/partition system attention indicator");
+
+    std::string name{};
+    if (propertyValue == "PartitionSystemAttentionIndicator")
+    {
+        name = "partition_system_attention_indicator";
+    }
+    else if (propertyValue == "PlatformSystemAttentionIndicator")
+    {
+        name = "platform_system_attention_indicator";
+    }
+    else
+    {
+        messages::propertyUnknown(asyncResp->res, propertyValue);
+        return;
+    }
+
+    dbus::utility::getDbusObject(
+        "/xyz/openbmc_project/led/groups/" + name, ledGroupInterface,
+        [asyncResp, name,
+         propertyValue](const boost::system::error_code& ec,
+                        const dbus::utility::MapperGetObject& object) {
+            if (ec || object.empty())
+            {
+                BMCWEB_LOG_DEBUG("Failed to get LED DBus name: {}",
+                                 ec.message());
+                return;
+            }
+
+            dbus::utility::getProperty<bool>(
+                object.begin()->first,
+                "/xyz/openbmc_project/led/groups/" + name,
+                "xyz.openbmc_project.Led.Group", "Asserted",
+                [asyncResp, propertyValue](const boost::system::error_code& ec1,
+                                           bool assert) {
+                    if (ec1)
+                    {
+                        if (ec1.value() != EBADR)
+                        {
+                            BMCWEB_LOG_ERROR("DBUS response error: {}",
+                                             ec1.message());
+                            messages::internalError(asyncResp->res);
+                        }
+                        return;
+                    }
+
+                    nlohmann::json& oemSAI =
+                        asyncResp->res.jsonValue["Oem"]["IBM"];
+                    oemSAI["@odata.type"] = "#IBMComputerSystem.v1_0_0.IBM";
+                    if (propertyValue == "PartitionSystemAttentionIndicator")
+                    {
+                        oemSAI["PartitionSystemAttentionIndicator"] = assert;
+                    }
+                    else if (propertyValue ==
+                             "PlatformSystemAttentionIndicator")
+                    {
+                        oemSAI["PlatformSystemAttentionIndicator"] = assert;
+                    }
+                });
+        });
+}
+
+/**
+ * @brief Set System Attention Indicator
+ *
+ * @param[in] asyncResp         Shared pointer for generating response message.
+ * @param[in] propertyValue     The property value
+ *                              (PartitionSystemAttentionIndicator/PlatformSystemAttentionIndicator).
+ * @param[in] value             true or false
+ *
+ * @return None.
+ */
+inline void setSAI(const std::shared_ptr<bmcweb::AsyncResp>& asyncResp,
+                   const std::string& propertyValue, bool value)
+{
+    BMCWEB_LOG_DEBUG("Set platform/partition system attention indicator");
+
+    std::string name{};
+    if (propertyValue == "PartitionSystemAttentionIndicator")
+    {
+        name = "partition_system_attention_indicator";
+    }
+    else if (propertyValue == "PlatformSystemAttentionIndicator")
+    {
+        name = "platform_system_attention_indicator";
+    }
+    else
+    {
+        return;
+    }
+
+    dbus::utility::getDbusObject(
+        "/xyz/openbmc_project/led/groups/" + name, ledGroupInterface,
+        [asyncResp, name, value](const boost::system::error_code& ec,
+                                 const dbus::utility::MapperGetObject& object) {
+            if (ec || object.empty())
+            {
+                BMCWEB_LOG_ERROR("DBUS response error: {}", ec.message());
+                messages::internalError(asyncResp->res);
+                return;
+            }
+
+            sdbusplus::asio::setProperty(
+                *crow::connections::systemBus, object.begin()->first,
+                "/xyz/openbmc_project/led/groups/" + name,
+                "xyz.openbmc_project.Led.Group", "Asserted", value,
+                [asyncResp](const boost::system::error_code& ec1) {
+                    if (ec1)
+                    {
+                        if (ec1.value() != EBADR)
+                        {
+                            BMCWEB_LOG_ERROR("DBUS response error: {}",
+                                             ec1.message());
+                            messages::internalError(asyncResp->res);
+                        }
+                        return;
+                    }
+                });
+        });
+}
+} // namespace redfish

--- a/redfish-core/lib/systems.hpp
+++ b/redfish-core/lib/systems.hpp
@@ -18,7 +18,9 @@
 #include "hypervisor_system.hpp"
 #include "led.hpp"
 #include "logging.hpp"
+#include "oem/ibm/lamp_test.hpp"
 #include "oem/ibm/pcie_topology_refresh.hpp"
+#include "oem/ibm/system_attention_indicator.hpp"
 #include "query.hpp"
 #include "redfish_util.hpp"
 #include "registries/privilege_registry.hpp"
@@ -2822,6 +2824,12 @@ inline void handleComputerSystemGet(
     getStopBootOnFault(asyncResp);
     getAutomaticRetryPolicy(asyncResp);
     getLastResetTime(asyncResp);
+    if constexpr (BMCWEB_IBM_LED_EXTENSIONS)
+    {
+        getLampTestState(asyncResp);
+        getSAI(asyncResp, "PartitionSystemAttentionIndicator");
+        getSAI(asyncResp, "PlatformSystemAttentionIndicator");
+    }
     if constexpr (BMCWEB_REDFISH_PROVISIONING_FEATURE)
     {
         getProvisioningStatus(asyncResp);
@@ -2888,32 +2896,72 @@ inline void handleComputerSystemPatch(
     std::optional<std::string> chapSecret;
     std::optional<bool> pcieTopologyRefresh;
     std::optional<bool> savePCIeTopologyInfo;
+    std::optional<bool> lampTest;
+    std::optional<bool> partitionSAI;
+    std::optional<bool> platformSAI;
 
-    if (!json_util::readJsonPatch(                                         //
-            req, asyncResp->res,                                           //
-            "AssetTag", assetTag,                                          //
-            "Boot/AutomaticRetryAttempts", bootAutomaticRetryAttempts,     //
-            "Boot/AutomaticRetryConfig", bootAutomaticRetry,               //
-            "Boot/StopBootOnFault", stopBootOnFault,                       //
-            "Boot/TrustedModuleRequiredToBoot", bootTrustedModuleRequired, //
-            "HostWatchdogTimer/FunctionEnabled", wdtEnable,                //
-            "HostWatchdogTimer/TimeoutAction", wdtTimeOutAction,           //
-            "IdlePowerSaver/Enabled", ipsEnable,                           //
-            "IdlePowerSaver/EnterDwellTimeSeconds", ipsEnterTime,          //
-            "IdlePowerSaver/EnterUtilizationPercent", ipsEnterUtil,        //
-            "IdlePowerSaver/ExitDwellTimeSeconds", ipsExitTime,            //
-            "IdlePowerSaver/ExitUtilizationPercent", ipsExitUtil,          //
-            "IndicatorLED", indicatorLed,                                  //
-            "LocationIndicatorActive", locationIndicatorActive,            //
-            "PowerMode", powerMode,                                        //
-            "PowerRestorePolicy", powerRestorePolicy,                      //
-            "Oem/IBM/ChapData/ChapName", chapName,                         //
-            "Oem/IBM/ChapData/ChapSecret", chapSecret,                     //
-            "Oem/IBM/PCIeTopologyRefresh", pcieTopologyRefresh,            //
-            "Oem/IBM/SavePCIeTopologyInfo", savePCIeTopologyInfo           //
-            ))
+    if constexpr (BMCWEB_IBM_LED_EXTENSIONS)
     {
-        return;
+        if (!json_util::readJsonPatch(                                     //
+                req, asyncResp->res,                                       //
+                "AssetTag", assetTag,                                      //
+                "Boot/AutomaticRetryAttempts", bootAutomaticRetryAttempts, //
+                "Boot/AutomaticRetryConfig", bootAutomaticRetry,           //
+                "Boot/StopBootOnFault", stopBootOnFault,                   //
+                "Boot/TrustedModuleRequiredToBoot",
+                bootTrustedModuleRequired,                                 //
+                "HostWatchdogTimer/FunctionEnabled", wdtEnable,            //
+                "HostWatchdogTimer/TimeoutAction", wdtTimeOutAction,       //
+                "IdlePowerSaver/Enabled", ipsEnable,                       //
+                "IdlePowerSaver/EnterDwellTimeSeconds", ipsEnterTime,      //
+                "IdlePowerSaver/EnterUtilizationPercent", ipsEnterUtil,    //
+                "IdlePowerSaver/ExitDwellTimeSeconds", ipsExitTime,        //
+                "IdlePowerSaver/ExitUtilizationPercent", ipsExitUtil,      //
+                "IndicatorLED", indicatorLed,                              //
+                "LocationIndicatorActive", locationIndicatorActive,        //
+                "PowerMode", powerMode,                                    //
+                "PowerRestorePolicy", powerRestorePolicy,                  //
+                "Oem/IBM/ChapData/ChapName", chapName,                     //
+                "Oem/IBM/ChapData/ChapSecret", chapSecret,                 //
+                "Oem/IBM/PCIeTopologyRefresh", pcieTopologyRefresh,        //
+                "Oem/IBM/SavePCIeTopologyInfo", savePCIeTopologyInfo,      //
+                "Oem/IBM/LampTest", lampTest,                              //
+                "Oem/IBM/PartitionSystemAttentionIndicator", partitionSAI, //
+                "Oem/IBM/PlatformSystemAttentionIndicator", platformSAI    //
+                ))
+        {
+            return;
+        }
+    }
+    else
+    {
+        if (!json_util::readJsonPatch(                                     //
+                req, asyncResp->res,                                       //
+                "AssetTag", assetTag,                                      //
+                "Boot/AutomaticRetryAttempts", bootAutomaticRetryAttempts, //
+                "Boot/AutomaticRetryConfig", bootAutomaticRetry,           //
+                "Boot/StopBootOnFault", stopBootOnFault,                   //
+                "Boot/TrustedModuleRequiredToBoot",
+                bootTrustedModuleRequired,                                 //
+                "HostWatchdogTimer/FunctionEnabled", wdtEnable,            //
+                "HostWatchdogTimer/TimeoutAction", wdtTimeOutAction,       //
+                "IdlePowerSaver/Enabled", ipsEnable,                       //
+                "IdlePowerSaver/EnterDwellTimeSeconds", ipsEnterTime,      //
+                "IdlePowerSaver/EnterUtilizationPercent", ipsEnterUtil,    //
+                "IdlePowerSaver/ExitDwellTimeSeconds", ipsExitTime,        //
+                "IdlePowerSaver/ExitUtilizationPercent", ipsExitUtil,      //
+                "IndicatorLED", indicatorLed,                              //
+                "LocationIndicatorActive", locationIndicatorActive,        //
+                "PowerMode", powerMode,                                    //
+                "PowerRestorePolicy", powerRestorePolicy,                  //
+                "Oem/IBM/ChapData/ChapName", chapName,                     //
+                "Oem/IBM/ChapData/ChapSecret", chapSecret,                 //
+                "Oem/IBM/PCIeTopologyRefresh", pcieTopologyRefresh,        //
+                "Oem/IBM/SavePCIeTopologyInfo", savePCIeTopologyInfo       //
+                ))
+        {
+            return;
+        }
     }
 
     asyncResp->res.result(boost::beast::http::status::no_content);
@@ -2972,6 +3020,23 @@ inline void handleComputerSystemPatch(
     if (powerMode)
     {
         setPowerMode(asyncResp, *powerMode);
+    }
+
+    if constexpr (BMCWEB_IBM_LED_EXTENSIONS)
+    {
+        if (lampTest)
+        {
+            setLampTestState(asyncResp, *lampTest);
+        }
+        if (partitionSAI)
+        {
+            setSAI(asyncResp, "PartitionSystemAttentionIndicator",
+                   *partitionSAI);
+        }
+        if (platformSAI)
+        {
+            setSAI(asyncResp, "PlatformSystemAttentionIndicator", *platformSAI);
+        }
     }
 
     if (ipsEnable || ipsEnterUtil || ipsEnterTime || ipsExitUtil || ipsExitTime)

--- a/redfish-core/schema/oem/ibm/csdl/IBMComputerSystem_v1.xml
+++ b/redfish-core/schema/oem/ibm/csdl/IBMComputerSystem_v1.xml
@@ -28,6 +28,21 @@
         <Annotation Term="OData.AdditionalProperties" Bool="true"/>
         <Annotation Term="OData.Description" String="Oem properties for IBM."/>
         <Annotation Term="OData.AutoExpand"/>
+        <Property Name="LampTest" Type="Edm.Boolean">
+          <Annotation Term="OData.Permissions" EnumMember="OData.Permission/ReadWrite"/>
+          <Annotation Term="OData.Description" String="An indicator allowing an operator to run LED lamp test."/>
+          <Annotation Term="OData.LongDescription" String="This property shall contain the state of lamp state function for this resource."/>
+        </Property>
+        <Property Name="PartitionSystemAttentionIndicator" Type="Edm.Boolean">
+          <Annotation Term="OData.Permissions" EnumMember="OData.Permission/ReadWrite"/>
+          <Annotation Term="OData.Description" String="An indicator allowing an operator to operate partition system attention."/>
+          <Annotation Term="OData.LongDescription" String="This property shall contain the state of the partition system attention of this resource."/>
+        </Property>
+        <Property Name="PlatformSystemAttentionIndicator" Type="Edm.Boolean">
+          <Annotation Term="OData.Permissions" EnumMember="OData.Permission/ReadWrite"/>
+          <Annotation Term="OData.Description" String="An indicator allowing an operator to operate platform system attention."/>
+          <Annotation Term="OData.LongDescription" String="This property shall contain the state of the platform system attention of this resource."/>
+        </Property>
         <Property Name="PCIeTopologyRefresh" Type="Edm.Boolean">
           <Annotation Term="OData.Permissions" EnumMember="OData.Permission/ReadWrite"/>
           <Annotation Term="OData.Description" String="An indication of topology information is ready."/>

--- a/redfish-core/schema/oem/ibm/json-schema/IBMComputerSystem.v1_0_0.json
+++ b/redfish-core/schema/oem/ibm/json-schema/IBMComputerSystem.v1_0_0.json
@@ -52,6 +52,24 @@
                 }
             },
             "properties": {
+                "LampTest": {
+                    "description": "An indicator allowing an operator to run LED lamp test.",
+                    "longDescription": "This property shall contain the state of lamp state function for this resource.",
+                    "readonly": false,
+                    "type": ["boolean", "null"]
+                },
+                "PartitionSystemAttentionIndicator": {
+                    "description": "An indicator allowing an operator to operate partition system attention.",
+                    "longDescription": "This property shall contain the state of the partition system attention of this resource.",
+                    "readonly": false,
+                    "type": ["boolean", "null"]
+                },
+                "PlatformSystemAttentionIndicator": {
+                    "description": "An indicator allowing an operator to operate platform system attention.",
+                    "longDescription": "This property shall contain the state of the platform system attention of this resource.",
+                    "readonly": false,
+                    "type": ["boolean", "null"]
+                },
                 "PCIeTopologyRefresh": {
                     "description": "An indication of topology information is ready.",
                     "longDescription": "This property when set to 'true' refreshes the topology information. The application which uses this should set it to 'false' when a refresh occurs.",


### PR DESCRIPTION
Implement OEM lamp test in redfish/v1/Systems/system

Implement SystemAttentionIndicator in redfish/v1/Systems/system refer: ibm-openbmc/dev#2120

We use macros to control the URL, which need to be enabled in bmcweb_%.bbappend to see it, for example:
EXTRA_OEMESON_append = " \
    -Dibm-led-extensions=enabled \
    "

Tested:
1. Get the lamp test and SAI:
```
curl -k -H "X-Auth-Token: $token" https://${bmc}/redfish/v1/Systems/system
{
  "@odata.id": "/redfish/v1/Systems/system",
  "@odata.type": "#ComputerSystem.v1_16_0.ComputerSystem",
  ...
  "Oem": {
    "IBM": {
      "@odata.type": "#IBMComputerSystem.v1_0_0.IBM",
      "LampTest": false,
      "PartitionSystemAttentionIndicator": false,
      "PlatformSystemAttentionIndicator": false
    }
  },
  ...
}
```

2. Set the lamp test and SAI:
```
curl -k -H "X-Auth-Token: $token" -H "Content-type: application/json" \
       -X PATCH https://${bmc}/redfish/v1/Systems/system \
       -d '{"Oem":{"IBM":{"LampTest": true, "PartitionSystemAttentionIndicator": true}}}'
```

3. Get the lamp test and SAI:
```
curl -k -H "X-Auth-Token: $token" https://${bmc}/redfish/v1/Systems/system
{
  "@odata.id": "/redfish/v1/Systems/system",
  "@odata.type": "#ComputerSystem.v1_16_0.ComputerSystem",
  ...
  "Oem": {
    "IBM": {
      "@odata.type": "#IBMComputerSystem.v1_0_0.IBM",
      "LampTest": true,
      "PartitionSystemAttentionIndicator": true,
      "PlatformSystemAttentionIndicator": false
    }
  },
  ...
}
```

3. Redfish Service Validator passes