### PR TITLE
1120: Fix bug: bmcweb SNMP errors in the Journal

### DIFF
--- a/redfish-core/src/subscription.cpp
+++ b/redfish-core/src/subscription.cpp
@@ -181,6 +181,11 @@ void Subscription::onHbTimeout(const std::weak_ptr<Subscription>& weakSelf,
 
 bool Subscription::sendEventToSubscriber(uint64_t eventId, std::string&& msg)
 {
+    if (userSub->subscriptionType == "SNMPTrap")
+    {
+        return false; // Don't need send SNMPTrap event.
+    }
+
     persistent_data::EventServiceConfig eventServiceConfig =
         persistent_data::EventServiceStore::getInstance()
             .getEventServiceConfig();


### PR DESCRIPTION
Fix this bug: ibm-openbmc/dev#3599
Don't send event to snmptrap subscription.