### PR TITLE
Add PowerLimitWatts in EnvironmentMetrics

### DIFF
--- a/Redfish.md
+++ b/Redfish.md
@@ -268,6 +268,7 @@ Fields common to all schemas
 
 #### EnvironmentMetrics
 
+- PowerLimitWatts
 - PowerWatts/DataSourceUri
 - PowerWatts/Reading
 


### PR DESCRIPTION
This is a cherry-pick of two commits:

- eb83b29 - Add PowerLimitWatts in EnvironmentMetrics
- a2f6f88 - Update to use power cap limits from CapLimits instead of Cap (https://github.com/ibm-openbmc/bmcweb/pull/1113). **Note**: For this commit only the part for the PowerLimitWatts was pulled in since the PowerSubsystem is not yet in 1120.

Additional changes made:

- Moved long lambda functions into named functions per current upstream coding requirements.
- Used Redfish generated enums.

Tested on hardware simulator after powering on. Redfish validator passes for PowerLimitWatts with no related warnings.

PowerLimitWatts is a new object in Redfish version 2021.2.

This property shall contain the power limit control for corresponding resource.
It contains "SetPoint","AllowableMax","AllowableMin", "ControlMode", etc.

The power cap limits were previously hosted by Settings, but those are system settings and the limits are not really settings (users can not adjust these). The dbus interface hosts these power cap limits:
  xyz.openbmc_project.Control.Power.CapLimits

Tested by: Validator passes

1.doGet method to get PowerLimitWatts in EnvironmentMetrics
```
curl -k -H "X-Auth-Token: $token" -X GET https://${bmc}/redfish/v1/Chassis/chassis/EnvironmentMetrics
{
  "@odata.id": "/redfish/v1/Chassis/chassis/EnvironmentMetrics",
  "@odata.type": "#EnvironmentMetrics.v1_3_0.EnvironmentMetrics",
  ...
  "PowerLimitWatts": {
    "AllowableMax": 2777,
    "AllowableMin": 899,
    "ControlMode": "Automatic",
    "SetPoint": 0
  },
  ...
}
```

2.Enter the wrong chassisId with the doGet method
```
curl -k -H "X-Auth-Token: $token" -X GET https://${bmc}/redfish/v1/Chassis/chassisERROR/EnvironmentMetrics
{
  "error": {
    "@Message.ExtendedInfo": [
      {
        "@odata.type": "#Message.v1_1_1.Message",
        "Message": "The requested resource of type Chassis named 'chassisERROR' was not found.",
        "MessageArgs": [
          "Chassis",
          "chassisERROR"
        ],
        "MessageId": "Base.1.19.ResourceNotFound",
        "MessageSeverity": "Critical",
        "Resolution": "Provide a valid resource identifier and resubmit the request."
      }
    ],
    "code": "Base.1.19.ResourceNotFound",
    "message": "The requested resource of type Chassis named 'chassisERROR' was not found."
  }
}
```

3.doPatch method to set SetPoint in PowerLimitWatts
```
curl -k -H "X-Auth-Token: $token"-H "Content-Type: application/json" -X PATCH -d '{ "PowerLimitWatts": {"SetPoint": 10}}}' https://${bmc}/redfish/v1/Chassis/chassis/EnvironmentMetrics

curl -k -H "X-Auth-Token: $token" -X GET https://${bmc}/redfish/v1/Chassis/chassis/EnvironmentMetrics
{
  "@odata.id": "/redfish/v1/Chassis/chassis/EnvironmentMetrics",
  "@odata.type": "#EnvironmentMetrics.v1_3_0.EnvironmentMetrics",
  ...
  "PowerLimitWatts": {
    "AllowableMax": 2777,
    "AllowableMin": 899,
    "ControlMode": "Automatic",
    "SetPoint": 10
  },
  ...
}
```
4.doPatch method to set ControlMode in PowerLimitWatts

1>When the ControlMode is changed to disabled, the modification is successful.
```
curl -k -H "X-Auth-Token: $token" -H "Content-Type: application/json" -X PATCH -d '{ "PowerLimitWatts": {"ControlMode": "Disabled"}}' https://${bmc}/redfish/v1/Chassis/chassis/EnvironmentMetrics

curl -k -H "X-Auth-Token: $token" -X GET https://${bmc}/redfish/v1/Chassis/chassis/EnvironmentMetrics
{
  "@odata.id": "/redfish/v1/Chassis/chassis/EnvironmentMetrics",
  "@odata.type": "#EnvironmentMetrics.v1_3_0.EnvironmentMetrics",
  ...
  "PowerLimitWatts": {
    "AllowableMax": 2777,
    "AllowableMin": 899,
    "ControlMode": "Disabled",
    "SetPoint": 10
  },
  ...
}
```

2>When the ControlMode is changed to automatic, the modification is successful.
```
curl -k -H "X-Auth-Token: $token"  -H "Content-Type: application/json" -X PATCH -d '{ "PowerLimitWatts": {"ControlMode": "Automatic"}}' https://${bmc}/redfish/v1/Chassis/chassis/EnvironmentMetrics

curl -k -H "X-Auth-Token: $token" -X GET https://${bmc}/redfish/v1/Chassis/chassis/EnvironmentMetrics
{
  "@odata.id": "/redfish/v1/Chassis/chassis/EnvironmentMetrics",
  "@odata.type": "#EnvironmentMetrics.v1_3_0.EnvironmentMetrics",
  ...
  "PowerLimitWatts": {
    "AllowableMax": 2777,
    "AllowableMin": 899,
    "ControlMode": "Automatic",
    "SetPoint": 10
  },
  ...
}
```

3>When the ControlMode is changed to other values, the modification fails and an error is reported.
```
curl -k -H "X-Auth-Token: $token"-H "Content-Type: application/json"  -X PATCH -d '{ "PowerLimitWatts": {"ControlMode":: "error"}}' https://${bmc}/redfish/v1/Chassis/chassis/EnvironmentMetrics
{
  "ControlMode@Message.ExtendedInfo": [
    {
      "@odata.type": "#Message.v1_1_1.Message",
      "Message": "The value '\"error\"' for the property ControlMode is not in the list of acceptable values.",
      "MessageArgs": [
        "\"error\"",
        "ControlMode"
      ],
      "MessageId": "Base.1.19.PropertyValueNotInList",
      "MessageSeverity": "Warning",
      "Resolution": "Choose a value from the enumeration list that the implementation can support and resubmit the request if the operation failed."
    }
  ]
}
```