### PR TITLE
Implement SubProcessors for processor core (#988)

### DIFF
--- a/Redfish.md
+++ b/Redfish.md
@@ -1047,11 +1047,19 @@ other.
 - Socket
 - SparePartNumber
 - Status
+- SubProcessors
 - ThrottleCauses
 - Throttled
 - TotalCores
 - TotalThreads
 - Version
+
+### /redfish/v1/Systems/system/Processors/{ProcessorId}/SubProcessors
+
+#### ProcessorCollection
+
+- Members
+- `Members@odata.count`
 
 ### /redfish/v1/Systems/system/ResetActionInfo/
 

--- a/redfish-core/src/redfish.cpp
+++ b/redfish-core/src/redfish.cpp
@@ -171,6 +171,7 @@ RedfishService::RedfishService(App& app)
     requestRoutesOperatingConfig(app);
     requestRoutesMemoryCollection(app);
     requestRoutesMemory(app);
+    requestRoutesSubProcessors(app);
 
     requestRoutesSystems(app);
     requestRoutesSystemActionsOemExecutePanelFunction(app);


### PR DESCRIPTION
Cherry-pick commit https://github.com/ibm-openbmc/bmcweb/commit/4315152ccb80731a6eb7d551de0f13860d0f0241
Made these additional changes:
- Modified error messages to not use full schema name
- Combined requestRoutes together into single one for SubProcessors to match upstream style
- Used Redfish generated enums
- Modified `afterGetCpuCoreDataByService()` to use utility function `unpackPropertiesNoThrow()`
- Included SubProcessors link under Processor response. (That was part of different commit for 1110: 723c0fd

Upstream: https://gerrit.openbmc.org/c/openbmc/bmcweb/+/38570
Tested using hardware simulator after powering on.

- Add the SubProcessors class to bmcweb to support processor cores.

- The SubProcessors collection is a collection under the processor schema. The cores are in the SubTree of the processor.

Tested: Redfish Validator passes
```
curl -k -H "X-Auth-Token: $token" https://${bmc}/redfish/v1/Systems/system/Processors/dcm0-cpu0
{
  "@odata.id": "/redfish/v1/Systems/system/Processors/dcm0-cpu0",
  "@odata.type": "#Processor.v1_18_0.Processor",
  "Id": "dcm0-cpu0",
  ...
  "SubProcessors": {
    "@odata.id": "/redfish/v1/Systems/system/Processors/dcm0-cpu0/SubProcessors"
  },
  ...
}

curl -k -H "X-Auth-Token: $token" https://${bmc}/redfish/v1/Systems/system/Processors/dcm0-cpu0/SubProcessors
{
  "@odata.id": "/redfish/v1/Systems/system/Processors/dcm0-cpu0/SubProcessors",
  "@odata.type": "#ProcessorCollection.ProcessorCollection",
  "Members": [
    {
      "@odata.id": "/redfish/v1/Systems/system/Processors/dcm0-cpu0/SubProcessors/core0"
    },
    {
      "@odata.id": "/redfish/v1/Systems/system/Processors/dcm0-cpu0/SubProcessors/core1"
    ...
  ],
  "Members@odata.count": 4,
  "Name": "SubProcessor Collection"
}

curl -k -H "X-Auth-Token: $token" https://${bmc}/redfish/v1/Systems/system/Processors/dcm0-cpu0/SubProcessors/core1
{
  "@odata.id": "/redfish/v1/Systems/system/Processors/dcm0-cpu0/SubProcessors/core1",
  "@odata.type": "#Processor.v1_18_0.Processor",
  "Id": "core1",
  "Name": "core1",
  "Status": {
    "Health": "OK",
    "State": "Enabled"
  }
}
```



Change-Id: If155b97b0c782d82541c00ecf5ee70cb0180f71f