### PR TITLE
Ethernet Port: Add LLDP port schema to interfaces

### DIFF
--- a/Redfish.md
+++ b/Redfish.md
@@ -584,6 +584,22 @@ Fields common to all schemas
 - Status
 - UUID
 
+### /redfish/v1/Managers/bmc/DedicatedNetworkPorts/
+
+#### PortCollection
+
+- Description
+- Members
+- `Members@odata.count`
+
+### /redfish/v1/Managers/bmc/DedicatedNetworkPorts/{DedicatedNetworkPortId}
+
+#### DedicatedNetworkPort
+
+- Ethernet
+- Id
+- Links/EthernetInterfaces
+
 ### /redfish/v1/Managers/bmc/EthernetInterfaces/
 
 #### EthernetInterfaceCollection
@@ -610,6 +626,7 @@ Fields common to all schemas
 - IPv6StaticAddresses
 - IPv6StaticDefaultGateways
 - InterfaceEnabled
+- Links/Ports
 - Links/RelatedInterfaces
 - LinkStatus
 - MACAddress


### PR DESCRIPTION
Link Layer Discovery Protocol is a Data Link Layer protocol used for discovering devices on a local network. LLDP advertises information about themselves to directly connected devices. This information includes the device's identity, capabilities, and network management information, which can be used for network monitoring, topology discovery and network troubleshooting.

This commit will add Bmcweb changes required to enable/disable LLDP property in ethernet interfaces.

Schema:
https://redfish.dmtf.org/schemas/v1/PortCollection.json https://redfish.dmtf.org/schemas/v1/Port.v1_14_0.json

Redfish validator successfully executed for the changes.

Tested by
Get/Patch on
curl https://xxx/redfish/v1/Managers/bmc/DedicatedNetworkPorts/eth1

{
"@odata.id": "/redfish/v1/Managers/bmc/DedicatedNetworkPorts/eth1", "@odata.type": "#Port.v1_14_0.Port",
"Ethernet": {
"LLDPEnabled": false
},
"Id": "eth1",
"Links": {
"EthernetInterfaces": [
{
"@odata.id": "/redfish/v1/Managers/bmc/EthernetInterfaces/eth1" }
]
},
"Name": "Manager Dedicated Network Port"
}

Get on
curl https://xxx/redfish/v1/Managers/bmc/EthernetInterfaces {
...
"Links": {
"Ports": [
{
"@odata.id": "/redfish/v1/Managers/bmc/DedicatedNetworkPorts/eth1" }
],
"Ports@odata.count": 1
}
...
}
Get on
curl https://xxx/redfish/v1/Managers/bmc/DedicatedNetworkPorts

{
"@odata.id": "/redfish/v1/Managers/bmc/DedicatedNetworkPorts", "@odata.type": "#PortCollection.PortCollection",
"Members": [
{
"@odata.id": "/redfish/v1/Managers/bmc/DedicatedNetworkPorts/eth0" },
{
"@odata.id": "/redfish/v1/Managers/bmc/DedicatedNetworkPorts/eth1" }
],
"Members@odata.count": 2,
"Name": "Port Collection"
}

Change-Id: I84b49b043bfa83489e26ffe75754e830bd92d8f0