### PR TITLE
http_client: fixing ip displayed in error_log

### DIFF
--- a/http/http_client.hpp
+++ b/http/http_client.hpp
@@ -210,8 +210,8 @@ class ConnectionInfo : public std::enable_shared_from_this<ConnectionInfo>
         if (ec)
         {
             BMCWEB_LOG_ERROR("Connect {}:{}, id: {} failed: {}",
-                             endpoint.address().to_string(), endpoint.port(),
-                             connId, ec.message());
+                             host.encoded_host_address(), host.port(), connId,
+                             ec.message());
             state = ConnState::connectFailed;
             waitAndRetry();
             return;


### PR DESCRIPTION
The IP address shown in the error log on connection failure was incorrect because the endpoint received in the connection callback is invalid when the connection fails. The code has been updated to log the host and port used for the connection attempt instead.