### PR TITLE
1110: Fix bug: bmcweb SNMP errors in the Journal

### DIFF
--- a/redfish-core/src/subscription.cpp
+++ b/redfish-core/src/subscription.cpp
@@ -183,6 +183,11 @@ void Subscription::onHbTimeout(const std::weak_ptr<Subscription>& weakSelf,
 
 bool Subscription::sendEventToSubscriber(std::string&& msg)
 {
+    if (userSub->subscriptionType == "SNMPTrap")
+    {
+        return false; // Don't need send SNMPTrap event.
+    }
+
     persistent_data::EventServiceConfig eventServiceConfig =
         persistent_data::EventServiceStore::getInstance()
             .getEventServiceConfig();


### PR DESCRIPTION
Fix this bug: ibm-openbmc/dev#3599
Don't send event to snmptrap subscription.