### PR TITLE
hw-isolation rebase: Added HardwareIsolation service

### DIFF
--- a/config/meson.build
+++ b/config/meson.build
@@ -13,6 +13,7 @@ feature_options = [
     'experimental-redfish-multi-computer-system',
     'google-api',
     'host-serial-socket',
+    'hw-isolation',
     'hypervisor-computer-system',
     'hypervisor-serial-socket',
     'ibm-led-extensions',

--- a/meson.options
+++ b/meson.options
@@ -578,3 +578,12 @@ option(
     description: '''Enable hypervisor serial console WebSocket. Path is
                       \'/console1\'.''',
 )
+
+# BMCWEB_HW_ISOLATION
+option(
+    'hw-isolation',
+    type: 'feature',
+    value: 'enabled',
+    description: 'Enable the Hardware Isolation feature',
+)
+

--- a/redfish-core/lib/log_services.hpp
+++ b/redfish-core/lib/log_services.hpp
@@ -1244,6 +1244,18 @@ inline void requestRoutesSystemLogServiceCollection(App& app)
                     "/redfish/v1/Systems/system/LogServices/AuditLog";
                 logServiceArray.push_back(std::move(auditLog));
             }
+            if constexpr (BMCWEB_HW_ISOLATION)
+            {
+                nlohmann::json& logServiceArrayLocal =
+                    asyncResp->res.jsonValue["Members"];
+                nlohmann::json::object_t member;
+                member["@odata.id"] = boost::urls::format(
+                    "redfish/v1/Systems/{}/LogServices/HardwareIsolation",
+                    BMCWEB_REDFISH_SYSTEM_URI_NAME);
+                logServiceArrayLocal.emplace_back(std::move(member));
+                asyncResp->res.jsonValue["Members@odata.count"] =
+                    logServiceArrayLocal.size();
+            }
         });
 }
 

--- a/redfish-core/lib/systems_logservices_hwisolation.hpp
+++ b/redfish-core/lib/systems_logservices_hwisolation.hpp
@@ -1,0 +1,72 @@
+#pragma once
+
+#include "bmcweb_config.h"
+
+#include "app.hpp"
+#include "async_resp.hpp"
+#include "http_request.hpp"
+#include "registries/privilege_registry.hpp"
+
+#include <boost/beast/http/verb.hpp>
+#include <boost/url/format.hpp>
+
+#include <memory>
+#include <string>
+#include <string_view>
+
+namespace redfish
+{
+
+/****************************************************
+ * Redfish HardwareIsolationLog interfaces
+ ******************************************************/
+
+/**
+ * @brief API Used to add the supported HardwareIsolation LogServices Members
+ *
+ * @param[in] req - The HardwareIsolation redfish request (unused now).
+ * @param[in] asyncResp - The redfish response to return.
+ *
+ * @return The redfish response in the given buffer.
+ */
+inline void getSystemHardwareIsolationLogService(
+    const crow::Request& /* req */,
+    const std::shared_ptr<bmcweb::AsyncResp>& asyncResp)
+{
+    asyncResp->res.jsonValue["@odata.id"] = boost::urls::format(
+        "/redfish/v1/Systems/{}/LogServices/HardwareIsolation",
+        BMCWEB_REDFISH_SYSTEM_URI_NAME);
+    asyncResp->res.jsonValue["@odata.type"] = "#LogService.v1_2_0.LogService";
+    asyncResp->res.jsonValue["Name"] = "Hardware Isolation LogService";
+    asyncResp->res.jsonValue["Description"] =
+        "Hardware Isolation LogService for system owned devices";
+    asyncResp->res.jsonValue["Id"] = "HardwareIsolation";
+
+    asyncResp->res.jsonValue["Entries"]["@odata.id"] = boost::urls::format(
+        "/redfish/v1/Systems/{}/LogServices/HardwareIsolation/Entries",
+        BMCWEB_REDFISH_SYSTEM_URI_NAME);
+
+    asyncResp->res.jsonValue["Actions"]["#LogService.ClearLog"]
+                            ["target"] = boost::urls::format(
+        "/redfish/v1/Systems/{}/LogServices/HardwareIsolation/Actions/LogService.ClearLog",
+        BMCWEB_REDFISH_SYSTEM_URI_NAME);
+}
+
+/**
+ * @brief API used to route the handler for HardwareIsolation Redfish
+ *        LogServices URI
+ *
+ * @param[in] app - Crow app on which Redfish will initialize
+ *
+ * @return The appropriate redfish response for the given redfish request.
+ */
+inline void requestRoutesSystemHardwareIsolationLogService(App& app)
+{
+    BMCWEB_ROUTE(app,
+                 "/redfish/v1/Systems/system/LogServices/HardwareIsolation/")
+        .privileges(redfish::privileges::getLogService)
+        .methods(boost::beast::http::verb::get)(
+            getSystemHardwareIsolationLogService);
+}
+
+} // namespace redfish

--- a/redfish-core/src/redfish.cpp
+++ b/redfish-core/src/redfish.cpp
@@ -46,6 +46,7 @@
 #include "systems.hpp"
 #include "systems_logservices_audit.hpp"
 #include "systems_logservices_hostlogger.hpp"
+#include "systems_logservices_hwisolation.hpp"
 #include "systems_logservices_postcodes.hpp"
 #include "task.hpp"
 #include "telemetry_service.hpp"
@@ -201,6 +202,10 @@ RedfishService::RedfishService(App& app)
         requestRoutesSystemsLogServiceHostlogger(app);
     }
 
+    if constexpr (BMCWEB_HW_ISOLATION)
+    {
+        requestRoutesSystemHardwareIsolationLogService(app);
+    }
     requestRoutesMessageRegistryFileCollection(app);
     requestRoutesMessageRegistryFile(app);
     requestRoutesMessageRegistry(app);


### PR DESCRIPTION
- In an OpenPOWER based system, a user or an application (in the error path if the hardware is faulty) can isolate hardware and the respective isolated hardware part will be ignored to init during the next boot of the host.

- The isolated hardware details are stored in BMC and a user may need to get that information through an external interface.

- In this patch, added a new HardwareIsolation LogService to get or manage the isolated hardware.

- This HardwareIsolation feature can be enabled by using the "hw-isolation" compile-time feature flag. It is enabled by default.

Other Reference:

- Design document for hardware isolation (aka guard) https://github.com/openbmc/docs/blob/master/designs/guard-on-bmc.md

Tested:

- Checked whether the HardwareIsolation LogService is showing in LogServiceCollection.
```
curl -k -H "X-Auth-Token: $bmc_token" -X GET \
https://${bmc}/redfish/v1/Systems/system/LogServices
{
  "@odata.id": "/redfish/v1/Systems/system/LogServices",
  "@odata.type": "#LogServiceCollection.LogServiceCollection",
  "Description": "Collection of LogServices for this Computer System",
  "Members": [
    {
      "@odata.id": "/redfish/v1/Systems/system/LogServices/EventLog"
    },
    {
      "@odata.id": "/redfish/v1/Systems/system/LogServices/Dump"
    },
    {
      "@odata.id": "/redfish/v1/Systems/system/LogServices/PostCodes"
    },
    {
      "@odata.id": "/redfish/v1/Systems/system/LogServices/HardwareIsolation"
    }
  ],
  "Members@odata.count": 4,
  "Name": "System Log Services Collection"
}
```

- Checked whether the HardwareIsolation LogService is showing with all required LogService members.
```
curl -k -H "X-Auth-Token: $bmc_token" -X GET \
https://${bmc}/redfish/v1/Systems/system/LogServices/HardwareIsolation
{
  "@odata.id": "/redfish/v1/Systems/system/LogServices/HardwareIsolation",
  "@odata.type": "#LogService.v1_2_0.LogService",
  "Actions": {
    "#LogService.ClearLog": {
      "target": "/redfish/v1/Systems/system/LogServices/HardwareIsolation/Actions \
                 /LogService.ClearLog"
    }
  },
  "Description": "Hardware Isolation LogService for system owned devices",
  "Entries": {
    "@odata.id": "/redfish/v1/Systems/system/LogServices/HardwareIsolation/Entries"
  },
  "Id": "HardwareIsolation",
  "Name": "Hardware Isolation LogService"
}
```

