### PR TITLE
Add FanSpeedsPercent for EnvironmentMetrics

### DIFF
--- a/Redfish.md
+++ b/Redfish.md
@@ -268,6 +268,9 @@ Fields common to all schemas
 
 #### EnvironmentMetrics
 
+- FanSpeedsPercent/DataSourceUri
+- FanSpeedsPercent/DeviceName
+- FanSpeedsPercent/SpeedRPM
 - PowerLimitWatts
 - PowerWatts/DataSourceUri
 - PowerWatts/Reading

--- a/redfish-core/include/utils/fan_utils.hpp
+++ b/redfish-core/include/utils/fan_utils.hpp
@@ -1,0 +1,83 @@
+#pragma once
+
+#include "dbus_utility.hpp"
+#include "logging.hpp"
+
+#include <boost/system/error_code.hpp>
+#include <sdbusplus/message/native_types.hpp>
+
+#include <array>
+#include <functional>
+#include <string>
+#include <string_view>
+#include <utility>
+#include <vector>
+
+namespace redfish
+{
+constexpr std::array<std::string_view, 1> fanInterface = {
+    "xyz.openbmc_project.Inventory.Item.Fan"};
+
+namespace fan_utils
+{
+constexpr std::array<std::string_view, 1> sensorInterface = {
+    "xyz.openbmc_project.Sensor.Value"};
+
+inline void afterGetFanSensorObjects(
+    const std::function<
+        void(const boost::system::error_code& ec,
+             std::vector<std::pair<std::string, std::string>>&)>& callback,
+    const boost::system::error_code& ec,
+    const dbus::utility::MapperGetSubTreeResponse& subtree)
+{
+    std::vector<std::pair<std::string, std::string>> sensorsPathAndService;
+
+    if (ec)
+    {
+        // Callback handles error
+        BMCWEB_LOG_DEBUG("DBUS response error for getAssociatedSubTree");
+        callback(ec, sensorsPathAndService);
+        return;
+    }
+    for (const auto& [sensorPath, serviceMaps] : subtree)
+    {
+        for (const auto& [service, interfaces] : serviceMaps)
+        {
+            sensorsPathAndService.emplace_back(service, sensorPath);
+        }
+    }
+
+    callback(ec, sensorsPathAndService);
+}
+
+inline void getFanSensorObjects(
+    const std::string& fanPath,
+    const std::function<
+        void(const boost::system::error_code& ec,
+             std::vector<std::pair<std::string, std::string>>&)>& callback)
+{
+    sdbusplus::message::object_path endpointPath{fanPath};
+    endpointPath /= "sensors";
+    dbus::utility::getAssociatedSubTree(
+        endpointPath,
+        sdbusplus::message::object_path("/xyz/openbmc_project/sensors"), 0,
+        sensorInterface, std::bind_front(afterGetFanSensorObjects, callback));
+}
+
+inline void getFanPaths(
+    const std::string& validChassisPath,
+    std::function<void(const boost::system::error_code& ec,
+                       const dbus::utility::MapperGetSubTreePathsResponse&
+                           fanPaths)>&& callback)
+{
+    sdbusplus::message::object_path endpointPath{validChassisPath};
+    endpointPath /= "cooled_by";
+
+    dbus::utility::getAssociatedSubTreePaths(
+        endpointPath,
+        sdbusplus::message::object_path("/xyz/openbmc_project/inventory"), 0,
+        fanInterface, std::move(callback));
+}
+
+} // namespace fan_utils
+} // namespace redfish


### PR DESCRIPTION
Cherry-pick commit e099a4a.
Upstream: https://gerrit.openbmc.org/c/openbmc/bmcweb/+/57715
Additional changes:

- Removed `<optional>` for `validChassisPath` in `fan_utils::getFanPaths()`. The function wasn't checking it and all the callers were checking before calling.
- Use `AlphanumLess` for sort
- Use `getSensorId()` for building DataSourceUri so link will work correctly.
- Switched `getFanSensorsProperties()` to use utility function `dbus::utility::getProperty()`
- Moved `fanInterface` to redfish interface in fan_utils.hpp and used it.

Tested on hardware simulator. Redfish validator passed EnvironmentMetrics tests with no warnings.

This commit is to add FanSpeedsPercent information according to the Redfish EnvironmentMetrics schema.
Relevant associated documents are here:
https://gerrit.openbmc.org/c/openbmc/phosphor-dbus-interfaces/+/58300

ref:http://redfish.dmtf.org/schemas/v1/EnvironmentMetrics.v1_3_0.json

Tested: Validator passes
```
curl -k -H "X-Auth-Token: $token" -X GET https://${bmc}/redfish/v1/Chassis/chassis/EnvironmentMetrics
{
  "@odata.id": "/redfish/v1/Chassis/chassis/EnvironmentMetrics",
  "@odata.type": "#EnvironmentMetrics.v1_3_0.EnvironmentMetrics",
  "FanSpeedsPercent": [
    {
      "DataSourceUri": "/redfish/v1/Chassis/chassis/Sensors/fantach_fan0_0",
      "DeviceName": "Chassis #fan0_0",
      "SpeedRPM": 18000.0
    },
    {
      "DataSourceUri": "/redfish/v1/Chassis/chassis/Sensors/fantach_fan0_1",
      "DeviceName": "Chassis #fan0_1",
      "SpeedRPM": 12036.0
    },
    {
      "DataSourceUri": "/redfish/v1/Chassis/chassis/Sensors/fantach_fan1_0",
      "DeviceName": "Chassis #fan1_0",
      "SpeedRPM": 18000.0
    },
    {
      "DataSourceUri": "/redfish/v1/Chassis/chassis/Sensors/fantach_fan1_1",
      "DeviceName": "Chassis #fan1_1",
      "SpeedRPM": 12036.0
    },
    {
      "DataSourceUri": "/redfish/v1/Chassis/chassis/Sensors/fantach_fan2_0",
      "DeviceName": "Chassis #fan2_0",
      "SpeedRPM": 18000.0
    },
    {
      "DataSourceUri": "/redfish/v1/Chassis/chassis/Sensors/fantach_fan2_1",
      "DeviceName": "Chassis #fan2_1",
      "SpeedRPM": 12036.0
    },
    {
      "DataSourceUri": "/redfish/v1/Chassis/chassis/Sensors/fantach_fan3_0",
      "DeviceName": "Chassis #fan3_0",
      "SpeedRPM": 18000.0
    },
    {
      "DataSourceUri": "/redfish/v1/Chassis/chassis/Sensors/fantach_fan3_1",
      "DeviceName": "Chassis #fan3_1",
      "SpeedRPM": 12036.0
    },
    {
      "DataSourceUri": "/redfish/v1/Chassis/chassis/Sensors/fantach_fan4_0",
      "DeviceName": "Chassis #fan4_0",
      "SpeedRPM": 18000.0
    },
    {
      "DataSourceUri": "/redfish/v1/Chassis/chassis/Sensors/fantach_fan4_1",
      "DeviceName": "Chassis #fan4_1",
      "SpeedRPM": 12036.0
    },
    {
      "DataSourceUri": "/redfish/v1/Chassis/chassis/Sensors/fantach_fan5_0",
      "DeviceName": "Chassis #fan5_0",
      "SpeedRPM": 18000.0
    },
    {
      "DataSourceUri": "/redfish/v1/Chassis/chassis/Sensors/fantach_fan5_1",
      "DeviceName": "Chassis #fan5_1",
      "SpeedRPM": 12036.0
    }
  ],
  "FanSpeedsPercent@odata.count": 12,
  "Id": "EnvironmentMetrics",
  "Name": "Chassis Environment Metrics",
  ...
}

/* Confirmation that DataSourceUri is a valid link */
curl -k -H "X-Auth-Token: $token" -X GET https://${bmc}/redfish/v1/Chassis/chassis/Sensors/fantach_fan0_0
{
  "@odata.id": "/redfish/v1/Chassis/chassis/Sensors/fantach_fan0_0",
  "@odata.type": "#Sensor.v1_2_0.Sensor",
  "Id": "fantach_fan0_0",
  "Name": "fan0 0",
  "Reading": 18000.0,
  "ReadingRangeMax": 18000.0,
  "ReadingType": "Rotational",
  "ReadingUnits": "RPM",
  "SpeedRPM": 18000.0,
  "Status": {
    "Health": "OK",
    "State": "Enabled"
  }
}
```