### PR TITLE
1120: Redfish : Look for OperationalStatus for the memory Health

### DIFF
--- a/redfish-core/lib/memory.hpp
+++ b/redfish-core/lib/memory.hpp
@@ -435,6 +435,7 @@ inline void assembleDimmProperties(
     const std::string* sparePartNumber = nullptr;
     const std::string* model = nullptr;
     const std::string* locationCode = nullptr;
+    const bool* functional = nullptr;
 
     const bool success = sdbusplus::unpackPropertiesNoThrow(
         dbus_utils::UnpackErrorPrinter(), properties, "MemoryDataWidth",
@@ -447,7 +448,7 @@ inline void assembleDimmProperties(
         memoryConfiguredSpeedInMhz, "MemoryType", memoryType, "Channel",
         channel, "MemoryController", memoryController, "Slot", slot, "Socket",
         socket, "SparePartNumber", sparePartNumber, "Model", model,
-        "LocationCode", locationCode);
+        "LocationCode", locationCode, "Functional", functional);
 
     if (!success)
     {
@@ -613,6 +614,15 @@ inline void assembleDimmProperties(
         asyncResp->res
             .jsonValue[jsonPtr]["Location"]["PartLocation"]["ServiceLabel"] =
             *locationCode;
+    }
+
+    if (functional != nullptr)
+    {
+        if (!*functional)
+        {
+            asyncResp->res.jsonValue[jsonPtr]["Status"]["Health"] =
+                resource::Health::Critical;
+        }
     }
 
     getPersistentMemoryProperties(asyncResp, properties, jsonPtr);


### PR DESCRIPTION
Look for OperationalStatus for the memory Health.
When functional is false, health is critical.
When functional is true, health is ok.

Tested: Validator passes.
Set the dimm0 OperationalStatus to false, and see the health:
```
curl -k -H "X-Auth-Token: $token" -X GET https://${bmc}/redfish/v1/Systems/system/Memory/dimm0
{
  "Status": {
    "Health": "Critical",
    "State": "Enabled"
  }
}
```