### PR TITLE
1120: http_client: fixing ip displayed in error_log (#1254)

### DIFF
--- a/http/http_client.hpp
+++ b/http/http_client.hpp
@@ -219,8 +219,8 @@ class ConnectionInfo : public std::enable_shared_from_this<ConnectionInfo>
         if (ec)
         {
             BMCWEB_LOG_ERROR("Connect {}:{}, id: {} failed: {}",
-                             endpoint.address().to_string(), endpoint.port(),
-                             connId, ec.message());
+                             host.encoded_host_address(), host.port(), connId,
+                             ec.message());
             state = ConnState::connectFailed;
             waitAndRetry();
             return;


### PR DESCRIPTION
#### http_client: fixing ip displayed in error_log (#1254)
```
The IP address shown in the error log on connection failure was
incorrect because the endpoint received in the connection callback is
invalid when the connection fails. The code has been updated to log the
host and port used for the connection attempt instead.

Signed-off-by: abhilashraju <abhilash.kollam@gamil.com>
Co-authored-by: abhilashraju <abhilash.kollam@gamil.com>```