### PR TITLE
1120: Fix watchdog timeout variable

### DIFF
--- a/config/bmcweb.service.in
+++ b/config/bmcweb.service.in
@@ -17,7 +17,7 @@ ExecStart=@MESON_INSTALL_PREFIX@/libexec/bmcwebd
 Type=simple
 WorkingDirectory=/home/root
 SyslogLevelPrefix=true
-WatchdogSec=@WATCHDOG_TIMEOUT@s
+WatchdogSec=@BMCWEB_WATCHDOG_TIMEOUT_SECONDS@s
 
 [Install]
 WantedBy=network.target

--- a/config/meson.build
+++ b/config/meson.build
@@ -182,7 +182,9 @@ configure_file(
     configuration: configuration_data(
         {
             'MESON_INSTALL_PREFIX': get_option('prefix'),
-            'WATCHDOG_TIMEOUT_SECONDS': get_option('watchdog-timeout-seconds'),
+            'BMCWEB_WATCHDOG_TIMEOUT_SECONDS': get_option(
+                'watchdog-timeout-seconds',
+            ),
         },
     ),
 )

--- a/meson.options
+++ b/meson.options
@@ -485,7 +485,7 @@ option(
     description: 'Enable audit events support for bmcweb',
 )
 
-# BMCWEB_WATCHDOG_TIMEOUT
+# BMCWEB_WATCHDOG_TIMEOUT_SECONDS
 option(
     'watchdog-timeout-seconds',
     type: 'integer',


### PR DESCRIPTION
Merged at https://gerrit.openbmc.org/c/openbmc/bmcweb/+/79741

The meson option to define the watchdog timeout was written in different places with different names, resulting in the service file not having the configured timeout, and the bmcweb daemon not displaying the warning when the watchdog was disabled at runtime, but enabled at compile time.

Tested:
 - After building, the systemd service file contains the configured timeout
 - If the watchdog is disabled during runtime, the message is displayed properly

Change-Id: I21d23b02bc13e21a516f04527dbda5b4ec0659f1