### PR TITLE
1120: Pull PEL related EventLog changes (#905)

### DIFF
--- a/meson.options
+++ b/meson.options
@@ -120,7 +120,7 @@ option(
 option(
     'redfish-dbus-log',
     type: 'feature',
-    value: 'disabled',
+    value: 'enabled',
     description: '''Enable DBUS log service transactions through Redfish. Paths
                     are under
                     /redfish/v1/Systems/system/LogServices/EventLog/Entries''',

--- a/redfish-core/include/utils/dbus_event_log_entry.hpp
+++ b/redfish-core/include/utils/dbus_event_log_entry.hpp
@@ -25,6 +25,11 @@ struct DbusEventLogEntry
     std::string Severity;
     uint64_t Timestamp = 0;
     uint64_t UpdateTimestamp = 0;
+    // Additional elements from upstream
+    std::string EventId;
+    bool Hidden = false;
+    bool ManagementSystemAck = false;
+    std::string Subsystem;
 };
 
 inline std::optional<DbusEventLogEntry> fillDbusEventLogEntryFromPropertyMap(
@@ -32,20 +37,22 @@ inline std::optional<DbusEventLogEntry> fillDbusEventLogEntryFromPropertyMap(
 {
     DbusEventLogEntry entry;
 
-    // clang-format off
     bool success = sdbusplus::unpackPropertiesNoThrow(
-        dbus_utils::UnpackErrorPrinter(), resp,
-        "Id", entry.Id,
-        "Message", entry.Message,
-        "Path", entry.Path,
-        "Resolution", entry.Resolution,
-        "Resolved", entry.Resolved,
-        "ServiceProviderNotify", entry.ServiceProviderNotify,
-        "Severity", entry.Severity,
-        "Timestamp", entry.Timestamp,
-        "UpdateTimestamp", entry.UpdateTimestamp
+        dbus_utils::UnpackErrorPrinter(), resp,               //
+        "Id", entry.Id,                                       //
+        "EventId", entry.EventId,                             //
+        "Message", entry.Message,                             //
+        "Path", entry.Path,                                   //
+        "Resolution", entry.Resolution,                       //
+        "Resolved", entry.Resolved,                           //
+        "ServiceProviderNotify", entry.ServiceProviderNotify, //
+        "Severity", entry.Severity,                           //
+        "Timestamp", entry.Timestamp,                         //
+        "UpdateTimestamp", entry.UpdateTimestamp,             //
+        "Hidden", entry.Hidden,                               //
+        "ManagementSystemAck", entry.ManagementSystemAck,     //
+        "Subsystem", entry.Subsystem                          //
     );
-    // clang-format on
     if (!success)
     {
         return std::nullopt;

--- a/redfish-core/lib/systems_logservices_celog.hpp
+++ b/redfish-core/lib/systems_logservices_celog.hpp
@@ -1,0 +1,469 @@
+// SPDX-License-Identifier: Apache-2.0
+// SPDX-FileCopyrightText: Copyright OpenBMC Authors
+#pragma once
+
+#include "bmcweb_config.h"
+
+#include "app.hpp"
+#include "async_resp.hpp"
+#include "dbus_singleton.hpp"
+#include "dbus_utility.hpp"
+#include "error_messages.hpp"
+#include "http_request.hpp"
+#include "log_services.hpp"
+#include "logging.hpp"
+#include "query.hpp"
+#include "registries/privilege_registry.hpp"
+#include "utils/dbus_utils.hpp"
+#include "utils/json_utils.hpp"
+#include "utils/time_utils.hpp"
+
+#include <asm-generic/errno.h>
+#include <systemd/sd-bus.h>
+
+#include <boost/beast/http/status.hpp>
+#include <boost/beast/http/verb.hpp>
+#include <boost/url/format.hpp>
+#include <boost/url/url.hpp>
+#include <nlohmann/json.hpp>
+#include <sdbusplus/message.hpp>
+#include <sdbusplus/message/native_types.hpp>
+
+#include <format>
+#include <functional>
+#include <memory>
+#include <optional>
+#include <string>
+#include <string_view>
+#include <utility>
+
+namespace redfish
+{
+
+inline void requestRoutesCELogService(App& app)
+{
+    BMCWEB_ROUTE(app, "/redfish/v1/Systems/<str>/LogServices/CELog/")
+        .privileges(redfish::privileges::getLogService)
+        .methods(
+            boost::beast::http::verb::
+                get)([&app](const crow::Request& req,
+                            const std::shared_ptr<bmcweb::AsyncResp>& asyncResp,
+                            const std::string& systemName) {
+            if (!redfish::setUpRedfishRoute(app, req, asyncResp))
+            {
+                return;
+            }
+            if constexpr (BMCWEB_EXPERIMENTAL_REDFISH_MULTI_COMPUTER_SYSTEM)
+            {
+                // Option currently returns no systems.  TBD
+                messages::resourceNotFound(asyncResp->res, "ComputerSystem",
+                                           systemName);
+                return;
+            }
+            if (systemName != BMCWEB_REDFISH_SYSTEM_URI_NAME)
+            {
+                messages::resourceNotFound(asyncResp->res, "ComputerSystem",
+                                           systemName);
+                return;
+            }
+            asyncResp->res.jsonValue["@odata.id"] =
+                boost::urls::format("/redfish/v1/Systems/{}/LogServices/CELog",
+                                    BMCWEB_REDFISH_SYSTEM_URI_NAME);
+            asyncResp->res.jsonValue["@odata.type"] =
+                "#LogService.v1_2_0.LogService";
+            asyncResp->res.jsonValue["Name"] = "CE Log Service";
+            asyncResp->res.jsonValue["Description"] = "System CE Log Service";
+            asyncResp->res.jsonValue["Id"] = "CELog";
+            asyncResp->res.jsonValue["OverWritePolicy"] = "WrapsWhenFull";
+
+            std::pair<std::string, std::string> redfishDateTimeOffset =
+                redfish::time_utils::getDateTimeOffsetNow();
+
+            asyncResp->res.jsonValue["DateTime"] = redfishDateTimeOffset.first;
+            asyncResp->res.jsonValue["DateTimeLocalOffset"] =
+                redfishDateTimeOffset.second;
+
+            asyncResp->res.jsonValue["Entries"]["@odata.id"] =
+                boost::urls::format(
+                    "/redfish/v1/Systems/{}/LogServices/CELog/Entries",
+                    BMCWEB_REDFISH_SYSTEM_URI_NAME);
+            asyncResp->res.jsonValue["Actions"]["#LogService.ClearLog"]
+                                    ["target"] = boost::urls::format(
+                "/redfish/v1/Systems/{}/LogServices/CELog/Actions/LogService.ClearLog",
+                BMCWEB_REDFISH_SYSTEM_URI_NAME);
+        });
+}
+
+inline void dBusCELogEntryCollection(
+    const std::shared_ptr<bmcweb::AsyncResp>& asyncResp)
+{
+    // Collections don't include the static data added by SubRoute
+    // because it has a duplicate entry for members
+    asyncResp->res.jsonValue["@odata.type"] =
+        "#LogEntryCollection.LogEntryCollection";
+    asyncResp->res.jsonValue["@odata.id"] =
+        boost::urls::format("/redfish/v1/Systems/{}/LogServices/CELog/Entries",
+                            BMCWEB_REDFISH_SYSTEM_URI_NAME);
+    asyncResp->res.jsonValue["Name"] = "System Event Log Entries";
+    asyncResp->res.jsonValue["Description"] =
+        "Collection of System Event Log Entries";
+
+    // DBus implementation of EventLog/Entries
+    // Make call to Logging Service to find all log entry objects
+    sdbusplus::message::object_path path("/xyz/openbmc_project/logging");
+    dbus::utility::getManagedObjects(
+        "xyz.openbmc_project.Logging", path,
+        [asyncResp](const boost::system::error_code& ec,
+                    const dbus::utility::ManagedObjectType& resp) {
+            boost::urls::url urlLogEntryPrefix = boost::urls::format(
+                "/redfish/v1/Systems/{}/LogServices/CELog/Entries",
+                BMCWEB_REDFISH_SYSTEM_URI_NAME);
+
+            afterLogEntriesGetManagedObjects(asyncResp, urlLogEntryPrefix, true,
+                                             ec, resp);
+        });
+}
+
+inline void updateManagementSystemAckProperty(
+    const std::optional<bool>& resolved,
+    const std::optional<bool>& managementSystemAck,
+    const std::shared_ptr<bmcweb::AsyncResp>& asyncResp,
+    const std::string& entryId)
+{
+    if (resolved.has_value())
+    {
+        setDbusProperty(asyncResp, "Resolved", "xyz.openbmc_project.Logging",
+                        "/xyz/openbmc_project/logging/entry/" + entryId,
+                        "xyz.openbmc_project.Logging.Entry", "Resolved",
+                        *resolved);
+    }
+
+    if (managementSystemAck.has_value())
+    {
+        BMCWEB_LOG_DEBUG("Updated ManagementSystemAck Property");
+        setDbusProperty(asyncResp, "ManagementSystemAck",
+                        "xyz.openbmc_project.Logging",
+                        "/xyz/openbmc_project/logging/entry/" + entryId,
+                        "org.open_power.Logging.PEL.Entry",
+                        "ManagementSystemAck", *managementSystemAck);
+    }
+}
+
+inline void deleteEventLogEntry(
+    const std::shared_ptr<bmcweb::AsyncResp>& asyncResp,
+    const std::string& entryId)
+{
+    // Process response from Logging service.
+    auto respHandler = [asyncResp,
+                        entryId](const boost::system::error_code& ec,
+                                 const sdbusplus::message::message& msg) {
+        BMCWEB_LOG_DEBUG("EventLogEntry (DBus) doDelete callback: Done");
+        if (ec)
+        {
+            if (ec.value() == EBADR)
+            {
+                messages::resourceNotFound(asyncResp->res, "LogEntry", entryId);
+                return;
+            }
+
+            const sd_bus_error* dbusError = msg.get_error();
+            if (dbusError == nullptr)
+            {
+                messages::internalError(asyncResp->res);
+                return;
+            }
+            if (std::string_view(
+                    "xyz.openbmc_project.Common.Error.Unavailable") ==
+                dbusError->name)
+            {
+                messages::propertyValueExternalConflict(asyncResp->res,
+                                                        "LogEntry", "Delete");
+                return;
+            }
+
+            BMCWEB_LOG_ERROR("EventLogEntry (DBus) doDelete "
+                             "respHandler got error {}",
+                             ec);
+
+            messages::internalError(asyncResp->res);
+            return;
+        }
+        asyncResp->res.result(boost::beast::http::status::ok);
+    };
+
+    // Make call to Logging service to request Delete Log
+    crow::connections::systemBus->async_method_call(
+        respHandler, "xyz.openbmc_project.Logging",
+        "/xyz/openbmc_project/logging/entry/" + entryId,
+        "xyz.openbmc_project.Object.Delete", "Delete");
+}
+
+inline void requestRoutesDBusCELogEntryCollection(App& app)
+{
+    BMCWEB_ROUTE(app, "/redfish/v1/Systems/<str>/LogServices/CELog/Entries/")
+        .privileges(redfish::privileges::getLogEntryCollection)
+        .methods(boost::beast::http::verb::get)(
+            [&app](const crow::Request& req,
+                   const std::shared_ptr<bmcweb::AsyncResp>& asyncResp,
+                   const std::string& systemName) {
+                if (!redfish::setUpRedfishRoute(app, req, asyncResp))
+                {
+                    return;
+                }
+                if constexpr (BMCWEB_EXPERIMENTAL_REDFISH_MULTI_COMPUTER_SYSTEM)
+                {
+                    // Option currently returns no systems.  TBD
+                    messages::resourceNotFound(asyncResp->res, "ComputerSystem",
+                                               systemName);
+                    return;
+                }
+                if (systemName != BMCWEB_REDFISH_SYSTEM_URI_NAME)
+                {
+                    messages::resourceNotFound(asyncResp->res, "ComputerSystem",
+                                               systemName);
+                    return;
+                }
+                dBusCELogEntryCollection(asyncResp);
+            });
+}
+
+inline void dBusCELogEntryPatch(
+    const crow::Request& req,
+    const std::shared_ptr<bmcweb::AsyncResp>& asyncResp,
+    const std::string& entryId)
+{
+    std::optional<bool> resolved;
+    std::optional<bool> managementSystemAck;
+    if (!json_util::readJsonPatch(
+            req, asyncResp->res,                                   //
+            "Resolved", resolved,                                  //
+            "Oem/OpenBMC/ManagementSystemAck", managementSystemAck //
+            ))
+    {
+        return;
+    }
+
+    getHiddenPropertyValue(
+        asyncResp, entryId,
+        [resolved, managementSystemAck, asyncResp,
+         entryId](bool hiddenPropVal) {
+            if (!hiddenPropVal)
+            {
+                messages::resourceNotFound(asyncResp->res, "LogEntry", entryId);
+                return;
+            }
+            updateManagementSystemAckProperty(resolved, managementSystemAck,
+                                              asyncResp, entryId);
+        });
+}
+
+inline void dBusCELogEntryDelete(
+    const std::shared_ptr<bmcweb::AsyncResp>& asyncResp, std::string entryID)
+{
+    BMCWEB_LOG_DEBUG("Do delete single event entries.");
+    dbus::utility::escapePathForDbus(entryID);
+
+    getHiddenPropertyValue(
+        asyncResp, entryID, [asyncResp, entryID](bool hiddenPropVal) {
+            if (!hiddenPropVal)
+            {
+                messages::resourceNotFound(asyncResp->res, "LogEntry", entryID);
+                return;
+            }
+            deleteEventLogEntry(asyncResp, entryID);
+        });
+}
+
+inline void requestRoutesDBusCELogEntry(App& app)
+{
+    BMCWEB_ROUTE(app,
+                 "/redfish/v1/Systems/<str>/LogServices/CELog/Entries/<str>/")
+        .privileges(redfish::privileges::getLogEntry)
+        .methods(boost::beast::http::verb::get)(
+            [&app](const crow::Request& req,
+                   const std::shared_ptr<bmcweb::AsyncResp>& asyncResp,
+                   const std::string& systemName, const std::string& entryId) {
+                if (!redfish::setUpRedfishRoute(app, req, asyncResp))
+                {
+                    return;
+                }
+                if constexpr (BMCWEB_EXPERIMENTAL_REDFISH_MULTI_COMPUTER_SYSTEM)
+                {
+                    // Option currently returns no systems.  TBD
+                    messages::resourceNotFound(asyncResp->res, "ComputerSystem",
+                                               systemName);
+                    return;
+                }
+                if (systemName != BMCWEB_REDFISH_SYSTEM_URI_NAME)
+                {
+                    messages::resourceNotFound(asyncResp->res, "ComputerSystem",
+                                               systemName);
+                    return;
+                }
+
+                boost::urls::url urlLogEntryPrefix = boost::urls::format(
+                    "/redfish/v1/Systems/{}/LogServices/CELog/Entries",
+                    BMCWEB_REDFISH_SYSTEM_URI_NAME);
+
+                dBusEventLogEntryGet(asyncResp, entryId, urlLogEntryPrefix,
+                                     true);
+            });
+
+    BMCWEB_ROUTE(app,
+                 "/redfish/v1/Systems/<str>/LogServices/CELog/Entries/<str>/")
+        .privileges(redfish::privileges::patchLogEntry)
+        .methods(boost::beast::http::verb::patch)(
+            [&app](const crow::Request& req,
+                   const std::shared_ptr<bmcweb::AsyncResp>& asyncResp,
+                   const std::string& systemName, const std::string& entryId) {
+                if (!redfish::setUpRedfishRoute(app, req, asyncResp))
+                {
+                    return;
+                }
+                if constexpr (BMCWEB_EXPERIMENTAL_REDFISH_MULTI_COMPUTER_SYSTEM)
+                {
+                    // Option currently returns no systems.  TBD
+                    messages::resourceNotFound(asyncResp->res, "ComputerSystem",
+                                               systemName);
+                    return;
+                }
+                if (systemName != BMCWEB_REDFISH_SYSTEM_URI_NAME)
+                {
+                    messages::resourceNotFound(asyncResp->res, "ComputerSystem",
+                                               systemName);
+                    return;
+                }
+
+                dBusCELogEntryPatch(req, asyncResp, entryId);
+            });
+
+    BMCWEB_ROUTE(app,
+                 "/redfish/v1/Systems/<str>/LogServices/CELog/Entries/<str>/")
+        .privileges(redfish::privileges::deleteLogEntry)
+        .methods(boost::beast::http::verb::delete_)(
+            [&app](const crow::Request& req,
+                   const std::shared_ptr<bmcweb::AsyncResp>& asyncResp,
+                   const std::string& systemName, const std::string& param) {
+                if (!redfish::setUpRedfishRoute(app, req, asyncResp))
+                {
+                    return;
+                }
+                if constexpr (BMCWEB_EXPERIMENTAL_REDFISH_MULTI_COMPUTER_SYSTEM)
+                {
+                    // Option currently returns no systems.  TBD
+                    messages::resourceNotFound(asyncResp->res, "ComputerSystem",
+                                               systemName);
+                    return;
+                }
+                if (systemName != BMCWEB_REDFISH_SYSTEM_URI_NAME)
+                {
+                    messages::resourceNotFound(asyncResp->res, "ComputerSystem",
+                                               systemName);
+                    return;
+                }
+
+                dBusCELogEntryDelete(asyncResp, param);
+            });
+}
+
+inline void requestRoutesDBusCELogEntryDownloadPelJson(App& app)
+{
+    BMCWEB_ROUTE(
+        app,
+        "/redfish/v1/Systems/<str>/LogServices/CELog/Entries/<str>/OemPelAttachment/")
+        .privileges(redfish::privileges::getLogEntry)
+        .methods(boost::beast::http::verb::get)(
+            [&app](const crow::Request& req,
+                   const std::shared_ptr<bmcweb::AsyncResp>& asyncResp,
+                   const std::string& systemName, const std::string& param)
+
+            {
+                if (!redfish::setUpRedfishRoute(app, req, asyncResp))
+                {
+                    return;
+                }
+                if constexpr (BMCWEB_EXPERIMENTAL_REDFISH_MULTI_COMPUTER_SYSTEM)
+                {
+                    // Option currently returns no systems.  TBD
+                    messages::resourceNotFound(asyncResp->res, "ComputerSystem",
+                                               systemName);
+                    return;
+                }
+                if (systemName != BMCWEB_REDFISH_SYSTEM_URI_NAME)
+                {
+                    messages::resourceNotFound(asyncResp->res, "ComputerSystem",
+                                               systemName);
+                    return;
+                }
+
+                std::string entryID = param;
+                dbus::utility::escapePathForDbus(entryID);
+
+                getHiddenPropertyValue(
+                    asyncResp, entryID,
+                    [asyncResp, entryID](bool hiddenPropVal) {
+                        if (!hiddenPropVal)
+                        {
+                            messages::resourceNotFound(asyncResp->res,
+                                                       "LogEntry", entryID);
+                            return;
+                        }
+                        displayOemPelAttachment(asyncResp, entryID);
+                    });
+            });
+}
+
+inline void requestRoutesDBusCELogEntryDownload(App& app)
+{
+    BMCWEB_ROUTE(
+        app,
+        "/redfish/v1/Systems/<str>/LogServices/CELog/Entries/<str>/attachment/")
+        .privileges(redfish::privileges::getLogEntry)
+        .methods(boost::beast::http::verb::get)(std::bind_front(
+            handleDBusEventLogEntryDownloadGet, std::ref(app), "System", true));
+}
+
+/**
+ * DBusLogServiceActionsClear class supports POST method for ClearLog
+ * action.
+ */
+inline void requestRoutesDBusCELogServiceActionsClear(App& app)
+{
+    /**
+     * Function handles POST method request.
+     * The Clear Log actions does not require any parameter.The action
+     * deletes all entries found in the Entries collection for this Log
+     * Service.
+     */
+
+    BMCWEB_ROUTE(
+        app,
+        "/redfish/v1/Systems/<str>/LogServices/CELog/Actions/LogService.ClearLog/")
+        .privileges(redfish::privileges::postLogService)
+        .methods(boost::beast::http::verb::post)(
+            [&app](const crow::Request& req,
+                   const std::shared_ptr<bmcweb::AsyncResp>& asyncResp,
+                   const std::string& systemName) {
+                if (!redfish::setUpRedfishRoute(app, req, asyncResp))
+                {
+                    return;
+                }
+                if constexpr (BMCWEB_EXPERIMENTAL_REDFISH_MULTI_COMPUTER_SYSTEM)
+                {
+                    // Option currently returns no systems.  TBD
+                    messages::resourceNotFound(asyncResp->res, "ComputerSystem",
+                                               systemName);
+                    return;
+                }
+                if (systemName != BMCWEB_REDFISH_SYSTEM_URI_NAME)
+                {
+                    messages::resourceNotFound(asyncResp->res, "ComputerSystem",
+                                               systemName);
+                    return;
+                }
+
+                dBusLogServiceActionsClear(asyncResp);
+            });
+}
+
+} // namespace redfish

--- a/redfish-core/schema/oem/ibm/json-schema/IBMLogEntryAttachment.v1_0_0.json
+++ b/redfish-core/schema/oem/ibm/json-schema/IBMLogEntryAttachment.v1_0_0.json
@@ -1,7 +1,7 @@
 {
     "$id": "https://github.com/openbmc/bmcweb/tree/master/redfish-core/schema/oem/openbmc/json-schema/IBMLogEntryAttachment.v1_0_0.json",
     "$schema": "http://redfish.dmtf.org/schemas/v1/redfish-schema-v1.json",
-    "copyright": "Copyright 2024 OpenBMC.",
+    "copyright": "Copyright 2025 OpenBMC.",
     "definitions": {
         "IBM": {
             "additionalProperties": false,
@@ -21,6 +21,11 @@
                 }
             },
             "properties": {
+                "PelJson": {
+                    "description": "PEL in Json format.",
+                    "readonly": true,
+                    "type": ["string", "null"]
+                },
                 "AdditionalDataFullAuditLogURI": {
                     "description": "Audit Log in Json format.",
                     "readonly": true,
@@ -61,7 +66,7 @@
             "type": "object"
         }
     },
-    "owningEntity": "OpenBMC",
+    "owningEntity": "IBM",
     "release": "1.0",
     "title": "#IBMLogEntryAttachment.v1_0_0"
 }

--- a/redfish-core/schema/oem/openbmc/csdl/OpenBMCLogEntry_v1.xml
+++ b/redfish-core/schema/oem/openbmc/csdl/OpenBMCLogEntry_v1.xml
@@ -14,29 +14,29 @@
     <edmx:Include Namespace="Resource.v1_0_0"/>
   </edmx:Reference>
   <edmx:DataServices>
-    <Schema xmlns="http://docs.oasis-open.org/odata/ns/edm" Namespace="IBMLogEntryAttachment">
-      <Annotation Term="Redfish.OwningEntity" String="IBM"/>
+    <Schema xmlns="http://docs.oasis-open.org/odata/ns/edm" Namespace="OpenBMCLogEntry">
+      <Annotation Term="Redfish.OwningEntity" String="OpenBMC"/>
     </Schema>
-    <Schema xmlns="http://docs.oasis-open.org/odata/ns/edm" Namespace="IBMLogEntryAttachment.v1_0_0">
+    <Schema xmlns="http://docs.oasis-open.org/odata/ns/edm" Namespace="OpenBMCLogEntry.v1_0_0">
       <Annotation Term="Redfish.OwningEntity" String="OpenBMC"/>
       <Annotation Term="Redfish.Release" String="1.0"/>
       <ComplexType Name="Oem" BaseType="Resource.OemObject">
         <Annotation Term="OData.AdditionalProperties" Bool="true"/>
-        <Annotation Term="OData.Description" String="IBMLogEntryAttachment Oem properties."/>
+        <Annotation Term="OData.Description" String="OpenBMCLogEntry Oem properties."/>
         <Annotation Term="OData.AutoExpand"/>
-        <Property Name="IBM" Type="IBMLogEntryAttachment.v1_0_0.IBM"/>
+        <Property Name="OpenBMC" Type="OpenBMCLogEntry.v1_0_0.OpenBMC"/>
       </ComplexType>
-      <ComplexType Name="IBM" BaseType="Resource.OemObject">
-        <Annotation Term="OData.AdditionalProperties" Bool="false"/>
-        <Annotation Term="OData.Description" String="Oem properties for IBM."/>
+      <ComplexType Name="OpenBMC">
+        <Annotation Term="OData.AdditionalProperties" Bool="true"/>
+        <Annotation Term="OData.Description" String="Oem properties for OpenBMC."/>
         <Annotation Term="OData.AutoExpand"/>
-        <Property Name="PelJson" Type="Edm.String">
-          <Annotation Term="OData.Permissions" EnumMember="OData.Permission/Read"/>
-          <Annotation Term="OData.Description" String="PEL in Json format."/>
+        <Property Name="ManagementSystemAck" Type="Edm.Boolean">
+          <Annotation Term="OData.Description" String="Flag to keep track of external interface acknowledgment."/>
+          <Annotation Term="OData.LongDescription" String="A true value says external interface acked error log, false says otherwise."/>
         </Property>
-        <Property Name="AdditionalDataFullAuditLogURI" Type="Edm.String">
-          <Annotation Term="OData.Permissions" EnumMember="OData.Permission/Read"/>
-          <Annotation Term="OData.Description" String="Audit Log in Json format."/>
+        <Property Name="GeneratorId" Type="Edm.String">
+          <Annotation Term="OData.Description" String="Id of the user who created the LogEntry."/>
+          <Annotation Term="OData.LongDescription" String="Unique id of the user who has caused the creation of the LogEntry. Eg: ip address, session id, client id."/>
         </Property>
       </ComplexType>
     </Schema>

--- a/redfish-core/schema/oem/openbmc/json-schema/OpenBMCLogEntry.json
+++ b/redfish-core/schema/oem/openbmc/json-schema/OpenBMCLogEntry.json
@@ -1,0 +1,8 @@
+{
+    "$id": "https://github.com/ibm-openbmc/bmcweb/tree/HEAD/redfish-core/schema/oem/openbmc/json-schema/OpenBMCLogEntry.json",
+    "$schema": "http://redfish.dmtf.org/schemas/v1/redfish-schema-v1.json",
+    "copyright": "Copyright 2025 OpenBMC.",
+    "definitions": {},
+    "owningEntity": "OpenBMC",
+    "title": "#OpenBMCLogEntry"
+}

--- a/redfish-core/schema/oem/openbmc/json-schema/OpenBMCLogEntry.v1_0_0.json
+++ b/redfish-core/schema/oem/openbmc/json-schema/OpenBMCLogEntry.v1_0_0.json
@@ -1,0 +1,93 @@
+{
+    "$id": "http://redfish.dmtf.org/schemas/v1/OemLogEntry.v1_0_0.json",
+    "$schema": "http://redfish.dmtf.org/schemas/v1/redfish-schema-v1.json",
+    "copyright": "Copyright 2014-2019 DMTF. For the full DMTF copyright policy, see http://www.dmtf.org/about/policies/copyright",
+    "definitions": {
+        "LogEntry": {
+            "additionalProperties": true,
+            "description": "OEM Extension for LogEntry",
+            "longDescription": "OEM Extension for LogEntry to provide the OEM specific details.",
+            "patternProperties": {
+                "^([a-zA-Z_][a-zA-Z0-9_]*)?@(odata|Redfish|Message)\\.[a-zA-Z_][a-zA-Z0-9_]*$": {
+                    "description": "This property shall specify a valid odata or Redfish property.",
+                    "type": [
+                        "array",
+                        "boolean",
+                        "integer",
+                        "number",
+                        "null",
+                        "object",
+                        "string"
+                    ]
+                }
+            },
+            "properties": {
+                "GeneratorId": {
+                    "description": "Id of the user who created the LogEntry.",
+                    "longDescription": "Unique id of the user who has caused the creation of the LogEntry. Eg: ip address, session id, client id.",
+                    "type": ["string", "null"]
+                },
+                "type": "object"
+            }
+        },
+        "Oem": {
+            "additionalProperties": true,
+            "description": "OemManager Oem properties.",
+            "patternProperties": {
+                "^([a-zA-Z_][a-zA-Z0-9_]*)?@(odata|Redfish|Message)\\.[a-zA-Z_][a-zA-Z0-9_.]+$": {
+                    "description": "This property shall specify a valid odata or Redfish property.",
+                    "type": [
+                        "array",
+                        "boolean",
+                        "number",
+                        "null",
+                        "object",
+                        "string"
+                    ]
+                }
+            },
+            "properties": {
+                "OpenBmc": {
+                    "anyOf": [
+                        {
+                            "$ref": "#/definitions/OpenBmc"
+                        },
+                        {
+                            "type": "null"
+                        }
+                    ]
+                }
+            },
+            "type": "object"
+        },
+        "OpenBmc": {
+            "additionalProperties": true,
+            "description": "Oem properties for OpenBmc.",
+            "patternProperties": {
+                "^([a-zA-Z_][a-zA-Z0-9_]*)?@(odata|Redfish|Message)\\.[a-zA-Z_][a-zA-Z0-9_.]+$": {
+                    "description": "This property shall specify a valid odata or Redfish property.",
+                    "type": [
+                        "array",
+                        "boolean",
+                        "number",
+                        "null",
+                        "object",
+                        "string"
+                    ]
+                }
+            },
+            "properties": {
+                "ManagementSystemAck": {
+                    "description": "Flag to keep track of external interface acknowledgment.",
+                    "longDescription": "A true value says external interface acked error log, false says otherwise.",
+                    "readonly": false,
+                    "type": ["boolean", "null"]
+                }
+            },
+            "type": "object"
+        }
+    },
+    "owningEntity": "OpenBMC",
+    "release": "1.0",
+    "title": "#OpenBMCLogEntry.v1_0_0"
+}

--- a/redfish-core/schema/oem/openbmc/meson.build
+++ b/redfish-core/schema/oem/openbmc/meson.build
@@ -23,7 +23,7 @@ foreach option_key, schema : schemas
 endforeach
 
 # Additional IBM schemas that should be installed
-ibm_schemas = ['OpenBMCAssembly', 'OpenBMCMessage']
+ibm_schemas = ['OpenBMCAssembly', 'OpenBMCLogEntry', 'OpenBMCMessage']
 
 foreach schema : ibm_schemas
     install_data(

--- a/redfish-core/src/redfish.cpp
+++ b/redfish-core/src/redfish.cpp
@@ -45,6 +45,7 @@
 #include "storage.hpp"
 #include "systems.hpp"
 #include "systems_logservices_audit.hpp"
+#include "systems_logservices_celog.hpp"
 #include "systems_logservices_hostlogger.hpp"
 #include "systems_logservices_hwisolation.hpp"
 #include "systems_logservices_postcodes.hpp"
@@ -185,10 +186,17 @@ RedfishService::RedfishService(App& app)
 
     if constexpr (BMCWEB_REDFISH_DBUS_LOG)
     {
+        requestRoutesCELogService(app);
         requestRoutesDBusLogServiceActionsClear(app);
+        requestRoutesDBusCELogServiceActionsClear(app);
         requestRoutesDBusEventLogEntryCollection(app);
+        requestRoutesDBusCELogEntryCollection(app);
         requestRoutesDBusEventLogEntry(app);
+        requestRoutesDBusCELogEntry(app);
         requestRoutesDBusEventLogEntryDownload(app);
+        requestRoutesDBusCELogEntryDownload(app);
+        requestRoutesDBusEventLogEntryDownloadPelJson(app);
+        requestRoutesDBusCELogEntryDownloadPelJson(app);
     }
     else
     {

--- a/test/redfish-core/include/dbus_log_watcher_test.cpp
+++ b/test/redfish-core/include/dbus_log_watcher_test.cpp
@@ -30,6 +30,11 @@ TEST(DBusLogWatcher, EventLogObjectFromDBusSuccess)
         {"Severity", DbusVariantType("")},
         {"Timestamp", DbusVariantType(static_cast<uint64_t>(1638312095123))},
         {"UpdateTimestamp", DbusVariantType(static_cast<uint64_t>(3899))},
+
+        // Additional elements for PEL
+        {"Hidden", DbusVariantType(false)},
+        {"ManagementSystemAck", DbusVariantType(false)},
+        {"Subsystem", DbusVariantType("Platform Firmware")},
     };
 
     EventLogObjectsType event;
@@ -63,6 +68,11 @@ TEST(DBusLogWatcher, EventLogObjectFromDBusFailMissingProperty)
         {"Severity", DbusVariantType("")},
         {"Timestamp", DbusVariantType(static_cast<uint64_t>(3832))},
         {"UpdateTimestamp", DbusVariantType(static_cast<uint64_t>(3899))},
+
+        // Additional elements for PEL
+        {"Hidden", DbusVariantType(false)},
+        {"ManagementSystemAck", DbusVariantType(false)},
+        {"Subsystem", DbusVariantType("Platform Firmware")},
     };
 
     EventLogObjectsType event;


### PR DESCRIPTION
Pull PEL related EventLog changes into 1110 (#905)

* bmcweb: Add support for CE Event Log

This commit allows users of any privilege to access Event Log entries
with 'Hidden' property set to false. The Log entries with 'Hidden'
property set to true are only accessed by users with admin role.

This commit is for downstream only

Testing:

Used P11 bring-up openbmc and upstream bmcweb. User Authentication was
disabled.

```
$ curl -k http://${bmc}/redfish/v1/Systems/system/LogServices
```

Note: Does not show URI to CELog due to an explicit check on whether
the requested operation is allowed with specified privileges. The
specified privilege 'ConfigureManager' is not allowed, and the entry
is not shown.

```
$ curl -k http://${bmc}/redfish/v1/Systems/system/LogServices/EventLog
{
...
  "DateTime": "2022-10-17T20:33:16+00:00",
  "DateTimeLocalOffset": "+00:00",
  "Description": "System Event Log Service",
  "Entries": {
    "@odata.id": "/redfish/v1/Systems/system/LogServices/Log/Entries"
  },
...
}
```

```
$ curl -k http://${bmc}/redfish/v1/Systems/system/LogServices/EventLog/Entries
{
...
  "Members": [
    {
      "@odata.id":
"/redfish/v1/Systems/system/LogServices/EventLog/Entries/1",
      "@odata.type": "#LogEntry.v1_9_0.LogEntry",
      "AdditionalDataURI":
"/redfish/v1/Systems/system/LogServices/EventLog/Entries/1/attachment",
      "Created": "2022-10-17T18:18:46.275+00:00",
      "EntryType": "Event",
      "Id": "1",
      "Message": "com.ibm.Panel.Error.CodeUpdateFailure",
      "Modified": "2022-10-17T18:18:46.275+00:00",
      "Name": "System Event Log Entry",
      "Resolution": "1. Location Code: U78DA.ND0.WZS007H-D1, Priority:
High, PN: 02WF367, SN: YA30UF073013, CCIN: 6B86\n",
      "Resolved": false,
      "Severity": "Critical"
    }
  ],
  "Members@odata.count": 1,
  "Name": "System Event Log Entries",
  "ServiceProviderNotified": true
}
```

Patch Resolved property
```
$ curl -k -X PATCH -d '{"Resolved": false}' \
   http://${bmc}/redfish/v1/Systems/system/LogServices/EventLog/Entries/1
```

List attachment
```
$ curl -k
http://${bmc}/redfish/v1/Systems/system/LogServices/EventLog/Entries/1/attachment -H "Accept: application/octet-stream"
```
Bad Request
Note: Looks like this is an upstream bug, It is supposed to print
attachment

Changed 'Hidden' property to 'true'.
```
$ curl -k http://${bmc}/redfish/v1/Systems/system/LogServices/CELog/Entries/1
{
  "@odata.id": "/redfish/v1/Systems/system/LogServices/CELog/Entries/1",
  "@odata.type": "#LogEntry.v1_9_0.LogEntry",
  "AdditionalDataURI":
"/redfish/v1/Systems/system/LogServices/CELog/Entries/1/attachment",
  "Created": "2022-10-17T18:18:46.275+00:00",
  "EntryType": "Event",
  "Id": "1",
  "Message": "com.ibm.Panel.Error.CodeUpdateFailure",
  "Modified": "2022-10-17T20:38:47.698+00:00",
  "Name": "System Event Log Entry",
  "Resolution": "1. Location Code: U78DA.ND0.WZS007H-D1, Priority: High,
PN: 02WF367, SN: YA30UF073013, CCIN: 6B86\n",
  "Resolved": false,
  "ServiceProviderNotified": true,
  "Severity": "Critical"
}
```

Patch resolved property
```
$ curl -k -H "Content-type: application/json"  -X PATCH -d '{"Resolved": false}' \
   http://${bmc}/redfish/v1/Systems/system/LogServices/CELog/Entries/1
```

Delete entry
```
$ curl -k -X DELETE http://${bmc}/redfish/v1/Systems/system/LogServices/CELog/Entries/1
```

Clear All:
```
$ curl -k -X POST http://${bmc}/redfish/v1/Systems/system/LogServices/CELog/Actions/LogService.ClearLog
```

Signed-off-by: Shantappa Teekappanavar <sbteeks@yahoo.com>

* Add properties from LogEntry

Added EvenId property. Also updated the Message property to use
subsystem property from org.open_power.Logging.PEL.Entry to make it more
meaningful.

Tested:

```
--old--
    curl -k -X GET https://$bmc/redfish/v1/Systems/system/LogServices/EventLog/Entries/1
    {
    "@odata.id": "/redfish/v1/Systems/system/LogServices/EventLog/Entries",
    "@odata.type": "#LogEntryCollection.LogEntryCollection",
    "Description": "Collection of System Event Log Entries",
    "Members": [
        {
        "@odata.id": "/redfish/v1/Systems/system/LogServices/EventLog/\
                            Entries/1",
        "@odata.type": "#LogEntry.v1_9_0.LogEntry",
        "AdditionalDataURI": "/redfish/v1/Systems/system/LogServices/EventLog/\
                            Entries/1/attachment",
        "Created": "2021-10-06T23:46:18+00:00",
        "EntryType": "Event",
        "Id": "1",
        "Message": "org.open_power.Logging.Error.TestError1",
        "Modified": "2021-10-06T23:46:18+00:00",
        "Name": "System Event Log Entry",
        "Resolved": false,
        "ServiceProviderNotified": true,
        "Severity": "Critical"
        }
    ],
    "Members@odata.count": 1,
    "Name": "System Event Log Entries"
    }
--new--
    curl -k -X GET https://$bmc/redfish/v1/Systems/system/LogServices/EventLog/Entries/1
    {
    "@odata.id": "/redfish/v1/Systems/system/LogServices/EventLog/Entries",
    "@odata.type": "#LogEntryCollection.LogEntryCollection",
    "Description": "Collection of System Event Log Entries",
    "Members": [
        {
        "@odata.id": "/redfish/v1/Systems/system/LogServices/EventLog/\
                            Entries/1",
        "@odata.type": "#LogEntry.v1_9_0.LogEntry",
        "AdditionalDataURI": "/redfish/v1/Systems/system/LogServices/EventLog/\
                            Entries/1/attachment",
        "Created": "2021-10-06T23:46:18+00:00",
        "EntryType": "Event",
        "EventId": "BD802003 00080055 2E330010 00000000 00000000 00000000\
                            00000000 00000000 00000000",
        "Id": "1",
        "Message": "BD802003 event in subsystem: Platform Firmware",
        "Modified": "2021-10-06T23:46:18+00:00",
        "Name": "System Event Log Entry",
        "Resolved": false,
        "ServiceProviderNotified": true,
        "Severity": "Critical"
        }
    ],
    "Members@odata.count": 1,
    "Name": "System Event Log Entries"
    }
```

    Validator passed

    Docker tests passed

Signed-off-by: Vijay Lobo <vijaylobo@gmail.com>

* Add HMC acknowledgment support

Supported OEM property for LogEntry and updated code for get and patch
redfish commands. Actual d-bus property name is ManagementSystemAck.

Tested:
1- Validator passed.

2- Docker passed.

3- All testcases w.r.t. CELog passed.

4- Complete image built and updated HW then ran following tests

a. get command
```
=> curl -k -X GET \
        https://$bmc/redfish/v1/Systems/system/LogServices/EventLog/Entries/1
{
  "@odata.id": "/redfish/v1/Systems/system/LogServices/EventLog/Entries/1",
  "@odata.type": "#LogEntry.v1_9_0.LogEntry",
  "AdditionalDataURI": "/redfish/v1/Systems/system/LogServices/EventLog/Entries
            /1/attachment",
  "Created": "2021-10-05T18:11:22+00:00",
  "EntryType": "Event",
  "Id": "1",
  "Message": "xyz.openbmc_project.Common.Error.Timeout",
  "Modified": "2021-10-05T18:11:22+00:00",
  "Name": "System Event Log Entry",
  "Oem": {
    "OpenBMC": {
      "@odata.type": "#OemLogEntry.v1_0_0.LogEntry",
      "ManagementSystemAck": false
    }
  },
  "Resolved": false,
  "ServiceProviderNotified": true,
  "Severity": "Critical"
}
```

b. patch command

```
[before]
=> busctl introspect xyz.openbmc_project.Logging /xyz/openbmc_project/logging/entry/1
org.open_power.Logging.PEL.Entry            interface -
.Hidden                                     property  b         false
.ManagementSystemAck                        property  b         false
.Subsystem                                  property  s         "Power Supply"

=> curl -k -X PATCH -d '{"Oem":{"OpenBMC":{"ManagementSystemAck": true}}}' \
                $bmc/redfish/v1/Systems/system/LogServices/EventLog/Entries/1
[after]
=> busctl introspect xyz.openbmc_project.Logging /xyz/openbmc_project/logging/entry/2
 ...
org.open_power.Logging.PEL.Entry            interface -
.Hidden                                     property  b         false
.ManagementSystemAck                        property  b         true
.Subsystem                                  property  s         "Power Supply"
...
```

```
{
  "@odata.id": "/redfish/v1/Systems/system/LogServices/EventLog/Entries/1",
  "@odata.type": "#LogEntry.v1_9_0.LogEntry",
  "AdditionalDataURI": "/redfish/v1/Systems/system/LogServices/EventLog/Entries\
             /1/attachment",
  "Created": "2021-10-05T18:11:22+00:00",
  "EntryType": "Event",
  "Id": "1",
  "Message": "xyz.openbmc_project.Common.Error.Timeout",
  "Modified": "2021-10-05T18:11:22+00:00",
  "Name": "System Event Log Entry",
  "Oem": {
    "OpenBMC": {
      "@odata.type": "#OemLogEntry.v1_0_0.LogEntry",
      "ManagementSystemAck": true
    }
  },
  "Resolved": false,
  "ServiceProviderNotified": true,
  "Severity": "Critical"
}
```

Signed-off-by: Vijay Lobo <vijaylobo@gmail.com>

* Fix OemLogEntry Schema

Co-authored-by: Abhishek Patel <Abhishek.Patel@ibm.com>
Signed-off-by: Shantappa Teekappanavar <shantappa.teekappanavar@ibm.com>

* Read patch data earlier during an event log patch (https://github.com/ibm-openbmc/bmcweb/pull/601)

This fixes MalformedJSON errors when trying to patch the Resolved or
ManagementSystemAck properties in an EventLog or CELog.

The first 8 bytes of the request JSON data in the Request structure was
corrupt if it was read after an async D-Bus method call.  Testing showed
that up until the method call was made, it was fine.

This commit changes the code to access that patch data earlier, before
any D-Bus calls are made.  This makes it similar to how it was done for
the Resolved property in the upstream code.

The code had been refactored when the CELog entries were added
downstream to give more commonality, and that is where the change had
been made to read the patch JSON data after reading the Hidden property
on D-Bus.  It did work fine then though, and it also even worked when
the commits were first pulled into 1050.

I'm not sure what changed to make it stop working.  Maybe it was never
valid to access the Request data after code goes back to the event loop
again?

Signed-off-by: Matt Spinler <spinler@us.ibm.com>

* Add call to getPELJson interface

Add call to getPELJson for both EventLog and CELog log services.
Returns PEL in json format.
EventLog path is redfish/v1/Systems/system/LogServices/EventLog
CELog    path is redfish/v1/Systems/system/LogServices/CELog
This commit also adds new route URI for OemPelAttachment to its parent.

Tested:
1) redfish validator: not tested
2) curl testing passed
```
$ curl -k http://${bmc}/redfish/v1/Systems/system/LogServices/EventLog/Entries/93
{
  "@odata.id": "/redfish/v1/Systems/system/LogServices/EventLog/Entries/93",
  "@odata.type": "#LogEntry.v1_9_0.LogEntry",
  "Oem": {
    "IBM": {
      "@odata.id": "/redfish/v1/Systems/system/LogServices/EventLog/Entries/93/OemPelAttachment"
    }
  },
...
}

$ curl -k http://${bmc}/redfish/v1/Systems/system/LogServices/EventLog/Entries/93/OemPelAttachment
{
  "Oem": {
    "@odata.type": "#OemLogEntryAttachment.Oem",
    "IBM": {
      "@odata.type": "#OemLogEntryAttachment.IBM",
      "PelJson": "{\n\"Private Header\":
      ...
    }
}

{
  "@odata.id": "/redfish/v1/Systems/system/LogServices/CELog/Entries/92",
  "Oem": {
    "IBM": {
      "@odata.id": "/redfish/v1/Systems/system/LogServices/CELog/Entries/92/OemPelAttachment"
    }
   ...
  },
}

$ curl -k
http://${bmc}/redfish/v1/Systems/system/LogServices/CELog/Entries/92/OemPelAttachment
{
  "Oem": {
    "@odata.type": "#OemLogEntryAttachment.Oem",
    "IBM": {
      "@odata.type": "#OemLogEntryAttachment.IBM",
      "PelJson": "{\n\"Private Header\":
...
}
```
