### PR TITLE
1120: Added SubordinateOverrides & Fix privileges (#966)

### DIFF
--- a/redfish-core/include/registries/privilege_registry.hpp
+++ b/redfish-core/include/registries/privilege_registry.hpp
@@ -256,6 +256,14 @@ const static auto& putCertificate = privilegeSetConfigureManager;
 const static auto& deleteCertificate = privilegeSetConfigureManager;
 const static auto& postCertificate = privilegeSetConfigureManager;
 
+// Subordinate override for ComputerSystem -> Certificate
+const static auto& getCertificateSubOverComputerSystem = privilegeSetConfigureComponents;
+const static auto& headCertificateSubOverComputerSystem = privilegeSetConfigureComponents;
+const static auto& patchCertificateSubOverComputerSystem = privilegeSetConfigureComponents;
+const static auto& putCertificateSubOverComputerSystem = privilegeSetConfigureComponents;
+const static auto& deleteCertificateSubOverComputerSystem = privilegeSetConfigureComponents;
+const static auto& postCertificateSubOverComputerSystem = privilegeSetConfigureComponents;
+
 // CertificateCollection
 const static auto& getCertificateCollection = privilegeSetConfigureManager;
 const static auto& headCertificateCollection = privilegeSetConfigureManager;
@@ -263,6 +271,14 @@ const static auto& patchCertificateCollection = privilegeSetConfigureManager;
 const static auto& putCertificateCollection = privilegeSetConfigureManager;
 const static auto& deleteCertificateCollection = privilegeSetConfigureManager;
 const static auto& postCertificateCollection = privilegeSetConfigureManager;
+
+// Subordinate override for ComputerSystem -> CertificateCollection
+const static auto& getCertificateCollectionSubOverComputerSystem = privilegeSetConfigureComponents;
+const static auto& headCertificateCollectionSubOverComputerSystem = privilegeSetConfigureComponents;
+const static auto& patchCertificateCollectionSubOverComputerSystem = privilegeSetConfigureComponents;
+const static auto& putCertificateCollectionSubOverComputerSystem = privilegeSetConfigureComponents;
+const static auto& deleteCertificateCollectionSubOverComputerSystem = privilegeSetConfigureComponents;
+const static auto& postCertificateCollectionSubOverComputerSystem = privilegeSetConfigureComponents;
 
 // CertificateLocations
 const static auto& getCertificateLocations = privilegeSetConfigureManager;
@@ -576,6 +592,42 @@ const static auto& putEnvironmentMetrics = privilegeSetConfigureManager;
 const static auto& deleteEnvironmentMetrics = privilegeSetConfigureManager;
 const static auto& postEnvironmentMetrics = privilegeSetConfigureManager;
 
+// Subordinate override for Processor -> EnvironmentMetrics
+const static auto& patchEnvironmentMetricsSubOverProcessor = privilegeSetConfigureComponents;
+const static auto& putEnvironmentMetricsSubOverProcessor = privilegeSetConfigureComponents;
+const static auto& deleteEnvironmentMetricsSubOverProcessor = privilegeSetConfigureComponents;
+const static auto& postEnvironmentMetricsSubOverProcessor = privilegeSetConfigureComponents;
+
+// Subordinate override for Memory -> EnvironmentMetrics
+const static auto& patchEnvironmentMetricsSubOverMemory = privilegeSetConfigureComponents;
+const static auto& putEnvironmentMetricsSubOverMemory = privilegeSetConfigureComponents;
+const static auto& deleteEnvironmentMetricsSubOverMemory = privilegeSetConfigureComponents;
+const static auto& postEnvironmentMetricsSubOverMemory = privilegeSetConfigureComponents;
+
+// Subordinate override for Drive -> EnvironmentMetrics
+const static auto& patchEnvironmentMetricsSubOverDrive = privilegeSetConfigureComponents;
+const static auto& putEnvironmentMetricsSubOverDrive = privilegeSetConfigureComponents;
+const static auto& deleteEnvironmentMetricsSubOverDrive = privilegeSetConfigureComponents;
+const static auto& postEnvironmentMetricsSubOverDrive = privilegeSetConfigureComponents;
+
+// Subordinate override for PCIeDevice -> EnvironmentMetrics
+const static auto& patchEnvironmentMetricsSubOverPCIeDevice = privilegeSetConfigureComponents;
+const static auto& putEnvironmentMetricsSubOverPCIeDevice = privilegeSetConfigureComponents;
+const static auto& deleteEnvironmentMetricsSubOverPCIeDevice = privilegeSetConfigureComponents;
+const static auto& postEnvironmentMetricsSubOverPCIeDevice = privilegeSetConfigureComponents;
+
+// Subordinate override for StorageController -> EnvironmentMetrics
+const static auto& patchEnvironmentMetricsSubOverStorageController = privilegeSetConfigureComponents;
+const static auto& putEnvironmentMetricsSubOverStorageController = privilegeSetConfigureComponents;
+const static auto& deleteEnvironmentMetricsSubOverStorageController = privilegeSetConfigureComponents;
+const static auto& postEnvironmentMetricsSubOverStorageController = privilegeSetConfigureComponents;
+
+// Subordinate override for Port -> EnvironmentMetrics
+const static auto& patchEnvironmentMetricsSubOverPort = privilegeSetConfigureComponents;
+const static auto& putEnvironmentMetricsSubOverPort = privilegeSetConfigureComponents;
+const static auto& deleteEnvironmentMetricsSubOverPort = privilegeSetConfigureComponents;
+const static auto& postEnvironmentMetricsSubOverPort = privilegeSetConfigureComponents;
+
 // EthernetInterface
 const static auto& getEthernetInterface = privilegeSetLogin;
 const static auto& headEthernetInterface = privilegeSetLogin;
@@ -583,6 +635,12 @@ const static auto& patchEthernetInterface = privilegeSetConfigureComponents;
 const static auto& postEthernetInterface = privilegeSetConfigureComponents;
 const static auto& putEthernetInterface = privilegeSetConfigureComponents;
 const static auto& deleteEthernetInterface = privilegeSetConfigureComponents;
+
+// Subordinate override for Manager -> EthernetInterfaceCollection -> EthernetInterface
+const static auto& patchEthernetInterfaceSubOverManagerEthernetInterfaceCollection = privilegeSetConfigureManager;
+const static auto& postEthernetInterfaceSubOverManagerEthernetInterfaceCollection = privilegeSetConfigureManager;
+const static auto& putEthernetInterfaceSubOverManagerEthernetInterfaceCollection = privilegeSetConfigureManager;
+const static auto& deleteEthernetInterfaceSubOverManagerEthernetInterfaceCollection = privilegeSetConfigureManager;
 
 // EthernetInterfaceCollection
 const static auto& getEthernetInterfaceCollection = privilegeSetLogin;
@@ -904,6 +962,20 @@ const static auto& putLogEntry = privilegeSetConfigureManager;
 const static auto& deleteLogEntry = privilegeSetConfigureManager;
 const static auto& postLogEntry = privilegeSetConfigureManager;
 
+// Subordinate override for ComputerSystem -> LogServiceCollection -> LogService -> LogEntryCollection -> LogEntry
+const static auto& patchLogEntrySubOverComputerSystemLogServiceCollectionLogServiceLogEntryCollection = privilegeSetConfigureComponents;
+const static auto& putLogEntrySubOverComputerSystemLogServiceCollectionLogServiceLogEntryCollection = privilegeSetConfigureComponents;
+const static auto& deleteLogEntrySubOverComputerSystemLogServiceCollectionLogServiceLogEntryCollection = privilegeSetConfigureComponents;
+const static auto& postLogEntrySubOverComputerSystemLogServiceCollectionLogServiceLogEntryCollection = privilegeSetConfigureComponents;
+
+// Subordinate override for Chassis -> LogServiceCollection -> LogService -> LogEntryCollection -> LogEntry
+const static auto& getLogEntrySubOverChassisLogServiceCollectionLogServiceLogEntryCollection = privilegeSetLogin;
+const static auto& headLogEntrySubOverChassisLogServiceCollectionLogServiceLogEntryCollection = privilegeSetLogin;
+const static auto& patchLogEntrySubOverChassisLogServiceCollectionLogServiceLogEntryCollection = privilegeSetConfigureComponents;
+const static auto& putLogEntrySubOverChassisLogServiceCollectionLogServiceLogEntryCollection = privilegeSetConfigureComponents;
+const static auto& deleteLogEntrySubOverChassisLogServiceCollectionLogServiceLogEntryCollection = privilegeSetConfigureComponents;
+const static auto& postLogEntrySubOverChassisLogServiceCollectionLogServiceLogEntryCollection = privilegeSetConfigureComponents;
+
 // LogEntryCollection
 const static auto& getLogEntryCollection = privilegeSetLogin;
 const static auto& headLogEntryCollection = privilegeSetLogin;
@@ -911,6 +983,20 @@ const static auto& patchLogEntryCollection = privilegeSetConfigureManager;
 const static auto& putLogEntryCollection = privilegeSetConfigureManager;
 const static auto& deleteLogEntryCollection = privilegeSetConfigureManager;
 const static auto& postLogEntryCollection = privilegeSetConfigureManager;
+
+// Subordinate override for ComputerSystem -> LogServiceCollection -> LogService -> LogEntryCollection
+const static auto& patchLogEntryCollectionSubOverComputerSystemLogServiceCollectionLogService = privilegeSetConfigureComponents;
+const static auto& putLogEntryCollectionSubOverComputerSystemLogServiceCollectionLogService = privilegeSetConfigureComponents;
+const static auto& deleteLogEntryCollectionSubOverComputerSystemLogServiceCollectionLogService = privilegeSetConfigureComponents;
+const static auto& postLogEntryCollectionSubOverComputerSystemLogServiceCollectionLogService = privilegeSetConfigureComponents;
+
+// Subordinate override for Chassis -> LogServiceCollection -> LogService -> LogEntryCollection
+const static auto& getLogEntryCollectionSubOverChassisLogServiceCollectionLogService = privilegeSetLogin;
+const static auto& headLogEntryCollectionSubOverChassisLogServiceCollectionLogService = privilegeSetLogin;
+const static auto& patchLogEntryCollectionSubOverChassisLogServiceCollectionLogService = privilegeSetConfigureComponents;
+const static auto& putLogEntryCollectionSubOverChassisLogServiceCollectionLogService = privilegeSetConfigureComponents;
+const static auto& deleteLogEntryCollectionSubOverChassisLogServiceCollectionLogService = privilegeSetConfigureComponents;
+const static auto& postLogEntryCollectionSubOverChassisLogServiceCollectionLogService = privilegeSetConfigureComponents;
 
 // LogService
 const static auto& getLogService = privilegeSetLogin;
@@ -920,6 +1006,20 @@ const static auto& putLogService = privilegeSetConfigureManager;
 const static auto& deleteLogService = privilegeSetConfigureManager;
 const static auto& postLogService = privilegeSetConfigureManager;
 
+// Subordinate override for ComputerSystem -> LogServiceCollection -> LogService
+const static auto& patchLogServiceSubOverComputerSystemLogServiceCollection = privilegeSetConfigureComponents;
+const static auto& postLogServiceSubOverComputerSystemLogServiceCollection = privilegeSetConfigureComponents;
+const static auto& putLogServiceSubOverComputerSystemLogServiceCollection = privilegeSetConfigureComponents;
+const static auto& deleteLogServiceSubOverComputerSystemLogServiceCollection = privilegeSetConfigureComponents;
+
+// Subordinate override for Chassis -> LogServiceCollection -> LogService
+const static auto& getLogServiceSubOverChassisLogServiceCollection = privilegeSetLogin;
+const static auto& headLogServiceSubOverChassisLogServiceCollection = privilegeSetLogin;
+const static auto& patchLogServiceSubOverChassisLogServiceCollection = privilegeSetConfigureComponents;
+const static auto& putLogServiceSubOverChassisLogServiceCollection = privilegeSetConfigureComponents;
+const static auto& deleteLogServiceSubOverChassisLogServiceCollection = privilegeSetConfigureComponents;
+const static auto& postLogServiceSubOverChassisLogServiceCollection = privilegeSetConfigureComponents;
+
 // LogServiceCollection
 const static auto& getLogServiceCollection = privilegeSetLogin;
 const static auto& headLogServiceCollection = privilegeSetLogin;
@@ -927,6 +1027,20 @@ const static auto& patchLogServiceCollection = privilegeSetConfigureManager;
 const static auto& putLogServiceCollection = privilegeSetConfigureManager;
 const static auto& deleteLogServiceCollection = privilegeSetConfigureManager;
 const static auto& postLogServiceCollection = privilegeSetConfigureManager;
+
+// Subordinate override for ComputerSystem -> LogServiceCollection
+const static auto& patchLogServiceCollectionSubOverComputerSystem = privilegeSetConfigureComponents;
+const static auto& putLogServiceCollectionSubOverComputerSystem = privilegeSetConfigureComponents;
+const static auto& deleteLogServiceCollectionSubOverComputerSystem = privilegeSetConfigureComponents;
+const static auto& postLogServiceCollectionSubOverComputerSystem = privilegeSetConfigureComponents;
+
+// Subordinate override for Chassis -> LogServiceCollection
+const static auto& getLogServiceCollectionSubOverChassis = privilegeSetLogin;
+const static auto& headLogServiceCollectionSubOverChassis = privilegeSetLogin;
+const static auto& patchLogServiceCollectionSubOverChassis = privilegeSetConfigureComponents;
+const static auto& putLogServiceCollectionSubOverChassis = privilegeSetConfigureComponents;
+const static auto& deleteLogServiceCollectionSubOverChassis = privilegeSetConfigureComponents;
+const static auto& postLogServiceCollectionSubOverChassis = privilegeSetConfigureComponents;
 
 // Manager
 const static auto& getManager = privilegeSetLogin;
@@ -1775,6 +1889,14 @@ const static auto& patchStorageControllerMetrics = privilegeSetConfigureComponen
 const static auto& postStorageControllerMetrics = privilegeSetConfigureComponents;
 const static auto& putStorageControllerMetrics = privilegeSetConfigureComponents;
 const static auto& deleteStorageControllerMetrics = privilegeSetConfigureComponents;
+
+// StorageMetrics
+const static auto& getStorageMetrics = privilegeSetLogin;
+const static auto& headStorageMetrics = privilegeSetLogin;
+const static auto& patchStorageMetrics = privilegeSetConfigureComponents;
+const static auto& postStorageMetrics = privilegeSetConfigureComponents;
+const static auto& putStorageMetrics = privilegeSetConfigureComponents;
+const static auto& deleteStorageMetrics = privilegeSetConfigureComponents;
 
 // Switch
 const static auto& getSwitch = privilegeSetLogin;

--- a/redfish-core/lib/log_services.hpp
+++ b/redfish-core/lib/log_services.hpp
@@ -1365,7 +1365,8 @@ inline void requestRoutesJournalEventLogClear(App& app)
     BMCWEB_ROUTE(
         app,
         "/redfish/v1/Systems/<str>/LogServices/EventLog/Actions/LogService.ClearLog/")
-        .privileges({{"ConfigureComponents"}})
+        .privileges(redfish::privileges::
+                        postLogServiceSubOverComputerSystemLogServiceCollection)
         .methods(boost::beast::http::verb::post)(std::bind_front(
             handleSystemsLogServicesEventLogActionsClearPost, std::ref(app)));
 }
@@ -1981,7 +1982,9 @@ inline void requestRoutesDBusEventLogEntry(App& app)
 
     BMCWEB_ROUTE(
         app, "/redfish/v1/Systems/<str>/LogServices/EventLog/Entries/<str>/")
-        .privileges(redfish::privileges::patchLogEntry)
+        .privileges(
+            redfish::privileges::
+                patchLogEntrySubOverComputerSystemLogServiceCollectionLogServiceLogEntryCollection)
         .methods(boost::beast::http::verb::patch)(
             [&app](const crow::Request& req,
                    const std::shared_ptr<bmcweb::AsyncResp>& asyncResp,
@@ -2009,8 +2012,9 @@ inline void requestRoutesDBusEventLogEntry(App& app)
 
     BMCWEB_ROUTE(
         app, "/redfish/v1/Systems/<str>/LogServices/EventLog/Entries/<str>/")
-        .privileges(redfish::privileges::deleteLogEntry)
-
+        .privileges(
+            redfish::privileges::
+                deleteLogEntrySubOverComputerSystemLogServiceCollectionLogServiceLogEntryCollection)
         .methods(boost::beast::http::verb::delete_)(
             [&app](const crow::Request& req,
                    const std::shared_ptr<bmcweb::AsyncResp>& asyncResp,
@@ -2738,7 +2742,8 @@ inline void requestRoutesSystemDumpCreate(App& app)
     BMCWEB_ROUTE(
         app,
         "/redfish/v1/Systems/<str>/LogServices/Dump/Actions/LogService.CollectDiagnosticData/")
-        .privileges(redfish::privileges::postLogService)
+        .privileges(redfish::privileges::
+                        postLogServiceSubOverComputerSystemLogServiceCollection)
         .methods(boost::beast::http::verb::post)(std::bind_front(
             handleLogServicesDumpCollectDiagnosticDataComputerSystemPost,
             std::ref(app)));
@@ -2749,7 +2754,8 @@ inline void requestRoutesSystemDumpClear(App& app)
     BMCWEB_ROUTE(
         app,
         "/redfish/v1/Systems/<str>/LogServices/Dump/Actions/LogService.ClearLog/")
-        .privileges(redfish::privileges::postLogService)
+        .privileges(redfish::privileges::
+                        postLogServiceSubOverComputerSystemLogServiceCollection)
         .methods(boost::beast::http::verb::post)(std::bind_front(
             handleLogServicesDumpClearLogComputerSystemPost, std::ref(app)));
 }
@@ -2762,9 +2768,7 @@ inline void requestRoutesCrashdumpService(App& app)
      * Functions triggers appropriate requests on DBus
      */
     BMCWEB_ROUTE(app, "/redfish/v1/Systems/<str>/LogServices/Crashdump/")
-        // This is incorrect, should be:
-        //.privileges(redfish::privileges::getLogService)
-        .privileges({{"ConfigureManager"}})
+        .privileges(redfish::privileges::getLogService)
         .methods(
             boost::beast::http::verb::
                 get)([&app](const crow::Request& req,
@@ -2828,9 +2832,8 @@ void inline requestRoutesCrashdumpClear(App& app)
     BMCWEB_ROUTE(
         app,
         "/redfish/v1/Systems/<str>/LogServices/Crashdump/Actions/LogService.ClearLog/")
-        // This is incorrect, should be:
-        //.privileges(redfish::privileges::postLogService)
-        .privileges({{"ConfigureComponents"}})
+        .privileges(redfish::privileges::
+                        postLogServiceSubOverComputerSystemLogServiceCollection)
         .methods(boost::beast::http::verb::post)(
             [&app](const crow::Request& req,
                    const std::shared_ptr<bmcweb::AsyncResp>& asyncResp,
@@ -2948,9 +2951,7 @@ inline void requestRoutesCrashdumpEntryCollection(App& app)
      */
     BMCWEB_ROUTE(app,
                  "/redfish/v1/Systems/<str>/LogServices/Crashdump/Entries/")
-        // This is incorrect, should be.
-        //.privileges(redfish::privileges::postLogEntryCollection)
-        .privileges({{"ConfigureComponents"}})
+        .privileges(redfish::privileges::getLogEntryCollection)
         .methods(
             boost::beast::http::verb::
                 get)([&app](const crow::Request& req,
@@ -3028,9 +3029,7 @@ inline void requestRoutesCrashdumpEntry(App& app)
 
     BMCWEB_ROUTE(
         app, "/redfish/v1/Systems/<str>/LogServices/Crashdump/Entries/<str>/")
-        // this is incorrect, should be
-        // .privileges(redfish::privileges::getLogEntry)
-        .privileges({{"ConfigureComponents"}})
+        .privileges(redfish::privileges::getLogEntry)
         .methods(boost::beast::http::verb::get)(
             [&app](const crow::Request& req,
                    const std::shared_ptr<bmcweb::AsyncResp>& asyncResp,
@@ -3174,9 +3173,8 @@ inline void requestRoutesCrashdumpCollect(App& app)
     BMCWEB_ROUTE(
         app,
         "/redfish/v1/Systems/<str>/LogServices/Crashdump/Actions/LogService.CollectDiagnosticData/")
-        // The below is incorrect;  Should be ConfigureManager
-        //.privileges(redfish::privileges::postLogService)
-        .privileges({{"ConfigureComponents"}})
+        .privileges(redfish::privileges::
+                        postLogServiceSubOverComputerSystemLogServiceCollection)
         .methods(boost::beast::http::verb::post)(
             [&app](const crow::Request& req,
                    const std::shared_ptr<bmcweb::AsyncResp>& asyncResp,
@@ -3350,7 +3348,8 @@ inline void requestRoutesDBusLogServiceActionsClear(App& app)
     BMCWEB_ROUTE(
         app,
         "/redfish/v1/Systems/<str>/LogServices/EventLog/Actions/LogService.ClearLog/")
-        .privileges(redfish::privileges::postLogService)
+        .privileges(redfish::privileges::
+                        postLogServiceSubOverComputerSystemLogServiceCollection)
         .methods(boost::beast::http::verb::post)(
             [&app](const crow::Request& req,
                    const std::shared_ptr<bmcweb::AsyncResp>& asyncResp,

--- a/redfish-core/lib/systems_logservices_celog.hpp
+++ b/redfish-core/lib/systems_logservices_celog.hpp
@@ -311,7 +311,9 @@ inline void requestRoutesDBusCELogEntry(App& app)
 
     BMCWEB_ROUTE(app,
                  "/redfish/v1/Systems/<str>/LogServices/CELog/Entries/<str>/")
-        .privileges(redfish::privileges::patchLogEntry)
+        .privileges(
+            redfish::privileges::
+                patchLogEntrySubOverComputerSystemLogServiceCollectionLogServiceLogEntryCollection)
         .methods(boost::beast::http::verb::patch)(
             [&app](const crow::Request& req,
                    const std::shared_ptr<bmcweb::AsyncResp>& asyncResp,
@@ -339,7 +341,9 @@ inline void requestRoutesDBusCELogEntry(App& app)
 
     BMCWEB_ROUTE(app,
                  "/redfish/v1/Systems/<str>/LogServices/CELog/Entries/<str>/")
-        .privileges(redfish::privileges::deleteLogEntry)
+        .privileges(
+            redfish::privileges::
+                deleteLogEntrySubOverComputerSystemLogServiceCollectionLogServiceLogEntryCollection)
         .methods(boost::beast::http::verb::delete_)(
             [&app](const crow::Request& req,
                    const std::shared_ptr<bmcweb::AsyncResp>& asyncResp,
@@ -439,7 +443,8 @@ inline void requestRoutesDBusCELogServiceActionsClear(App& app)
     BMCWEB_ROUTE(
         app,
         "/redfish/v1/Systems/<str>/LogServices/CELog/Actions/LogService.ClearLog/")
-        .privileges(redfish::privileges::postLogService)
+        .privileges(redfish::privileges::
+                        postLogServiceSubOverComputerSystemLogServiceCollection)
         .methods(boost::beast::http::verb::post)(
             [&app](const crow::Request& req,
                    const std::shared_ptr<bmcweb::AsyncResp>& asyncResp,

--- a/redfish-core/lib/systems_logservices_postcodes.hpp
+++ b/redfish-core/lib/systems_logservices_postcodes.hpp
@@ -620,9 +620,8 @@ inline void requestRoutesSystemsLogServicesPostCode(App& app)
     BMCWEB_ROUTE(
         app,
         "/redfish/v1/Systems/<str>/LogServices/PostCodes/Actions/LogService.ClearLog/")
-        // The following privilege is correct; we need "SubordinateOverrides"
-        // before we can automate it.
-        .privileges({{"ConfigureComponents"}})
+        .privileges(redfish::privileges::
+                        postLogServiceSubOverComputerSystemLogServiceCollection)
         .methods(boost::beast::http::verb::post)(std::bind_front(
             handleSystemsLogServicesPostCodesPost, std::ref(app)));
 


### PR DESCRIPTION
SubordinateOverrides:
  This commit attempts to automate the creation of SubordinateOverrides
  privileges structures from the redfish privilege registry. In
  addition, it enhances the function of parse_registries.py.

  It read SubordinateOverrides privilege registry from DMTF and
  generates const defines SubordinateOverrides for all the privilege
  registry entries in the same format that the Privileges struct
  accepts.

  Moreover, it generates unique const defines for all
  SubordinateOverrides target levels.
  Ex: EthernetInterface SubordinateOverrides has two "Targets":
      ["Manager", "EthernetInterfaceCollection"]. So
      parse_registries.py generates two unique const

      1) Subordinate override for Manager -> EthernetInterface
      2) Subordinate override for Manager ->
         EthernetInterfaceCollection ->  EthernetInterface

  Note: if SubordinateOverrides privilege gets changed, then it
  automatically updates that route privilege, but if
  SubordinateOverrides target gets change, then the user needs to
  update that manually.

Fix Log_services privileges:
  In Log_services, some of the privileges not following the
  Redfish_1.1.0_PrivilegeRegistry registry.

  privilege Change this commit contains
  Get method:
    1) /redfish/v1/Systems/system/LogServices/Crashdump/
        ConfigureManager -> Login

    2)/redfish/v1/Systems/system/LogServices/Crashdump/Entries/
         ConfigureManager -> Login

    3) /redfish/v1/Systems/system/LogServices/Crashdump/Entries/<str>/
        ConfigureComponents -> Login

    Impact: ConfigureManager -> Login    and
          ConfigureComponents -> Login

    This change allows Admin, Operator, and Readonly users to access
    Crashdump data and related entries.

Tested: manually tested on Witherspoon system, there is no change in
        output. Run Redfish validator, with all different Privileges;
        Error Get: UUID: String '' does not match pattern ''
        this commit doesn't affect UUID

Email sent to openbmc list:
https://lists.ozlabs.org/pipermail/openbmc/2021-August/027232.html

It is also being pushed to upstream -
https://gerrit.openbmc.org/c/openbmc/bmcweb/+/45125.

Change-Id: I37d8a2882f1cfaa59a482083f180fdd0805e2e7d