### PR TITLE
1120: Add a missing slash at routing endpoint

### DIFF
--- a/redfish-core/lib/systems_logservices_audit.hpp
+++ b/redfish-core/lib/systems_logservices_audit.hpp
@@ -695,7 +695,7 @@ inline void requestRoutesLogServicesAudit(App& app)
 
     BMCWEB_ROUTE(
         app,
-        "/redfish/v1/Systems/<str>/LogServices/AuditLog/Entries/<str>/attachment")
+        "/redfish/v1/Systems/<str>/LogServices/AuditLog/Entries/<str>/attachment/")
         .privileges(redfish::privileges::getLogEntry)
         .methods(boost::beast::http::verb::get)(
             std::bind_front(handleFullAuditLogAttachment, std::ref(app)));


### PR DESCRIPTION
AuditLog get attachment routing endpoint needs to have a forward-slash at the end.

Tested:
- Compiles
- Visual inspection only