### PR TITLE
1120: Add errors for spare core

### DIFF
--- a/redfish-core/lib/log_services.hpp
+++ b/redfish-core/lib/log_services.hpp
@@ -1917,7 +1917,8 @@ inline void dBusEventLogEntryDelete(
 
     // Process response from Logging service.
     auto respHandler = [asyncResp,
-                        entryID](const boost::system::error_code& ec) {
+                        entryID](const boost::system::error_code& ec,
+                                 const sdbusplus::message::message& msg) {
         BMCWEB_LOG_DEBUG("EventLogEntry (DBus) doDelete callback: Done");
         if (ec)
         {
@@ -1926,7 +1927,25 @@ inline void dBusEventLogEntryDelete(
                 messages::resourceNotFound(asyncResp->res, "LogEntry", entryID);
                 return;
             }
-            // TODO Handle for specific error code
+
+            const sd_bus_error* dbusError = msg.get_error();
+
+            if (dbusError == nullptr)
+            {
+                messages::internalError(asyncResp->res);
+                return;
+            }
+
+            if (std::string_view(
+                    "xyz.openbmc_project.Common.Error.Unavailable") ==
+                dbusError->name)
+
+            {
+                messages::propertyValueExternalConflict(asyncResp->res,
+                                                        "LogEntry", "Delete");
+                return;
+            }
+
             BMCWEB_LOG_ERROR(
                 "EventLogEntry (DBus) doDelete respHandler got error {}", ec);
             asyncResp->res.result(

--- a/redfish-core/src/utils/dbus_utils.cpp
+++ b/redfish-core/src/utils/dbus_utils.cpp
@@ -76,7 +76,8 @@ void afterSetProperty(
             }
             if (errorName == "xyz.openbmc_project.Common.Error.Unavailable")
             {
-                messages::resourceInStandby(asyncResp->res);
+                messages::propertyValueExternalConflict(
+                    asyncResp->res, redfishPropertyName, propertyValue);
                 return;
             }
         }


### PR DESCRIPTION
1120 rebase of 3 commits (now two) of https://github.com/ibm-openbmc/bmcweb/pull/1109

Two commits here to return a better error when resolve/delete error log is unavailable due to active gard record. This is part of the spare cores overwrite story.


1st commit is [Map Error.Unavailable to something better](https://github.com/ibm-openbmc/bmcweb/commit/f0a47644946ab0381c428a85f9474de84e154e20). Upstream at https://gerrit.openbmc.org/c/openbmc/bmcweb/+/75570
2nd commit is [Add specific error on Delete](https://github.com/ibm-openbmc/bmcweb/commit/3540d16262d81c50522db9435982d2593cef79cf). Haven't seen us do this for detete, pending 75570

Tested: Nikhil tested 1110 on the GUI and said this worked