### PR TITLE
1120: Hack to pass validator for hypervisor

### DIFF
--- a/redfish-core/lib/hypervisor_system.hpp
+++ b/redfish-core/lib/hypervisor_system.hpp
@@ -724,8 +724,8 @@ inline void handleHypervisorSystemGet(
                                                BMCWEB_REDFISH_MANAGER_URI_NAME);
     managedBy.emplace_back(std::move(manager));
     asyncResp->res.jsonValue["Links"]["ManagedBy"] = std::move(managedBy);
-    asyncResp->res.jsonValue["EthernetInterfaces"]["@odata.id"] =
-        "/redfish/v1/Systems/hypervisor/EthernetInterfaces";
+    // asyncResp->res.jsonValue["EthernetInterfaces"]["@odata.id"] =
+    //     "/redfish/v1/Systems/hypervisor/EthernetInterfaces";
     getHypervisorState(asyncResp);
     getHypervisorActions(asyncResp);
     // TODO: Add "SystemType" : "hypervisor"


### PR DESCRIPTION
Comment out the link so the validator doesn't find the hypervisor eth interfaces. Seeing errors like

```
2 err.Collection(EthernetInterface.EthernetInterface) errors in /redfish/v1/Systems/hypervisor/EthernetInterfaces
2 failMandatoryProp errors in /redfish/v1/Systems/hypervisor/EthernetInterfaces
2 fails errors in /redfish/v1/Systems/hypervisor/EthernetInterfaces
1 failGet errors in /redfish/v1/Systems/hypervisor/EthernetInterfaces/eth0
1 fails errors in /redfish/v1/Systems/hypervisor/EthernetInterfaces/eth0
1 failGet errors in /redfish/v1/Systems/hypervisor/EthernetInterfaces/eth1
1 fails errors in /redfish/v1/Systems/hypervisor/EthernetInterfaces/eth1
```

This is a temporary fix, long term https://github.com/ibm-openbmc/bmcweb/pull/1232 will fix. 
Have 8 bmcweb commits trying to go so have to do something https://github.ibm.com/openbmc/openbmc/pull/6176#top 

Could also turn off the hypervisor option but this is actually less invasive 

Tested: No validator errors here.