### PR TITLE
1120: Revert boost 1.87 back to 1.86

### DIFF
--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -3,7 +3,7 @@
     "files": "^.secrets.baseline$",
     "lines": null
   },
-  "generated_at": "2025-04-01T18:32:39Z",
+  "generated_at": "2025-05-09T18:12:24Z",
   "plugins_used": [
     {
       "name": "AWSKeyDetector"
@@ -82,7 +82,7 @@
         "hashed_secret": "66a36e77fd002579809717841f998f4d21cd5913",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 147,
+        "line_number": 152,
         "type": "Secret Keyword",
         "verified_result": null
       }
@@ -92,7 +92,7 @@
         "hashed_secret": "a5d8d6626c0903f7050f795ace6c3e11ce03a03e",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 401,
+        "line_number": 101,
         "type": "Base64 High Entropy String",
         "verified_result": null
       }
@@ -182,7 +182,7 @@
         "hashed_secret": "5ef4ffb79f46bdb334115d166dd092402bdf6c13",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 1505,
+        "line_number": 1687,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -190,7 +190,7 @@
         "hashed_secret": "6e069300b0db722cc2ad4b1425a30ff5a8ae20cf",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 2196,
+        "line_number": 2388,
         "type": "Secret Keyword",
         "verified_result": null
       }
@@ -230,7 +230,7 @@
         "hashed_secret": "6e069300b0db722cc2ad4b1425a30ff5a8ae20cf",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 2835,
+        "line_number": 2299,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -238,7 +238,7 @@
         "hashed_secret": "efb7b9c519415e44a5f30819aaa9bf534f6afb27",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 2851,
+        "line_number": 2315,
         "type": "Secret Keyword",
         "verified_result": null
       }
@@ -363,7 +363,7 @@
     ],
     "subprojects/boost.wrap": [
       {
-        "hashed_secret": "43c3db238f84136b2760ab684650e059a94c41a4",
+        "hashed_secret": "d09c932ed68b0c696f9c22804723650d07b51efe",
         "is_secret": false,
         "is_verified": false,
         "line_number": 5,

--- a/subprojects/boost.wrap
+++ b/subprojects/boost.wrap
@@ -1,9 +1,9 @@
 [wrap-file]
-directory = boost-1.87.0
+directory = boost-1.86.0
 
-source_url = https://github.com/boostorg/boost/releases/download/boost-1.87.0/boost-1.87.0-cmake.tar.gz
-source_hash = 78fbf579e3caf0f47517d3fb4d9301852c3154bfecdc5eeebd9b2b0292366f5b
-source_filename = 1_87_0.tar.gz
+source_url = https://github.com/boostorg/boost/releases/download/boost-1.86.0/boost-1.86.0-cmake.tar.gz
+source_hash = c62ce6e64d34414864fef946363db91cea89c1b90360eabed0515f0eda74c75c
+source_filename = 1_86_0.tar.gz
 
 [provide]
 boost = boost_dep


### PR DESCRIPTION
Revert "Update boost to 1.87"
This reverts commit https://github.com/ibm-openbmc/bmcweb/commit/3d21c59f75576f705bc8e1e56cfe2b68aeed6248, as the current 1120-ghe uses boost 1.86.


