### PR TITLE
1110: Fix inconsistent persistent subscription load

### DIFF
--- a/include/persistent_data.hpp
+++ b/include/persistent_data.hpp
@@ -165,19 +165,19 @@ class ConfigFile
 
                             if (!newSub)
                             {
-                                BMCWEB_LOG_ERROR("Problem reading subscription "
-                                                 "from persistent store");
+                                BMCWEB_LOG_ERROR(
+                                    "Problem reading subscription from persistent store");
                                 continue;
                             }
 
-                            BMCWEB_LOG_DEBUG("Restored subscription: {} {}",
-                                             newSub->id, newSub->customText);
+                            std::string id = newSub->id;
+                            BMCWEB_LOG_DEBUG("Restored subscription: {} {}", id,
+                                             newSub->customText);
 
                             EventServiceStore::getInstance()
                                 .subscriptionsConfigMap.emplace(
-                                    newSub->id,
-                                    std::make_shared<UserSubscription>(
-                                        std::move(*newSub)));
+                                    id, std::make_shared<UserSubscription>(
+                                            std::move(*newSub)));
                         }
                     }
                     else

--- a/redfish-core/include/event_service_manager.hpp
+++ b/redfish-core/include/event_service_manager.hpp
@@ -537,7 +537,7 @@ class EventServiceManager
         auto persistentObj = event.subscriptionsConfigMap.find(id);
         if (persistentObj == event.subscriptionsConfigMap.end())
         {
-            BMCWEB_LOG_ERROR("Subscription wasn't in persistent data");
+            BMCWEB_LOG_ERROR("Subscription {} wasn't in persistent data", id);
             return true;
         }
         persistent_data::EventServiceStore::getInstance()

--- a/src/webserver_run.cpp
+++ b/src/webserver_run.cpp
@@ -37,6 +37,9 @@ int run()
     sdbusplus::asio::connection systemBus(*io);
     crow::connections::systemBus = &systemBus;
 
+    // Load the peristent data
+    persistent_data::getConfig();
+
     // Static assets need to be initialized before Authorization, because auth
     // needs to build the whitelist from the static routes
 


### PR DESCRIPTION
When BMC reboots or bmcweb restarts, the persistent subscriptions may not be loaded properly but they may still be in the file.

Later on if BMC reboots or bmcweb restarts, those unloaded subscriptions may potentially and unexpectedly cause the reload into the active subscriptions.

Tested:
- Create many subscriptions
- GET subscriptions
```
curl -k -X GET https://${bmc}/redfish/v1/EventService/Subscriptions
{
  "@odata.id": "/redfish/v1/EventService/Subscriptions",
  "@odata.type": "#EventDestinationCollection.EventDestinationCollection",
  "Members": [
    {
      "@odata.id": "/redfish/v1/EventService/Subscriptions/1187258741"
    },
    ...
    {
      "@odata.id": "/redfish/v1/EventService/Subscriptions/949306789"
    }
  ],
  "Members@odata.count": 6,
  "Name": "Event Destination Collections"
}
```
- Restart bmcweb
- GET subscriptions again and check whether they are the same.
- Sometimes, none or only a few may be instantiated like

```
 curl -k -X GET https://${bmc}/redfish/v1/EventService/Subscriptions
{
  "@odata.id": "/redfish/v1/EventService/Subscriptions",
  "@odata.type": "#EventDestinationCollection.EventDestinationCollection",
  "Members": [
    {
      "@odata.id": "/redfish/v1/EventService/Subscriptions/1187258741"
    }
  ],
  "Members@odata.count": 1,
  "Name": "Event Destination Collections"
}
```
- However, the file `/home/root/bmcweb_persistent_data.json` still has the old entries.

- Also verify Redfish Service Validator to pass

Change-Id: Ia8a3c1bd3d4f4e479b599077ba8f26e47f8d22ef