### PR TITLE
1120 : Redfish : Add USB code update Enable/Disable (#813)(#913)(#916)

### DIFF
--- a/config/meson.build
+++ b/config/meson.build
@@ -17,6 +17,7 @@ feature_options = [
     'hypervisor-serial-socket',
     'ibm-led-extensions',
     'ibm-management-console',
+    'ibm-usb-code-update',
     'insecure-disable-auth',
     'insecure-disable-csrf',
     'insecure-disable-ssl',

--- a/meson.options
+++ b/meson.options
@@ -275,6 +275,14 @@ option(
     description: 'Enable the IBM LED extensions such as lamp test and system attention indicators.',
 )
 
+# BMCWEB_IBM_USB_CODE_UPDATE
+option(
+    'ibm-usb-code-update',
+    type: 'feature',
+    value: 'enabled',
+    description: 'Enable the USB code update functionality',
+)
+
 # BMCWEB_IBM_MANAGEMENT_CONSOLE
 option(
     'ibm-management-console',

--- a/redfish-core/lib/oem/ibm/usb_code_update.hpp
+++ b/redfish-core/lib/oem/ibm/usb_code_update.hpp
@@ -1,0 +1,107 @@
+#pragma once
+
+#include "async_resp.hpp"
+#include "dbus_singleton.hpp"
+#include "dbus_utility.hpp"
+#include "error_messages.hpp"
+#include "logging.hpp"
+#include "utils/dbus_utils.hpp"
+
+#include <sdbusplus/message/native_types.hpp>
+
+#include <array>
+#include <memory>
+#include <string_view>
+
+namespace redfish
+{
+
+static constexpr const char* usbCodeUpdateObjectPath =
+    "/xyz/openbmc_project/control/service/_70hosphor_2dusb_2dcode_2dupdate";
+static constexpr const char* usbCodeUpdateInterface =
+    "xyz.openbmc_project.Control.Service.Attributes";
+
+constexpr std::array<std::string_view, 1> usbCodeUpdateInterfaces = {
+    usbCodeUpdateInterface};
+
+/**
+ * @brief Retrieves BMC USB code update state.
+ *
+ * @param[in] asyncResp     Shared pointer for generating response message.
+ *
+ * @return None.
+ */
+inline void getUSBCodeUpdateState(
+    const std::shared_ptr<bmcweb::AsyncResp>& asyncResp)
+{
+    BMCWEB_LOG_DEBUG("Get USB code update state");
+    dbus::utility::getDbusObject(
+        usbCodeUpdateObjectPath, usbCodeUpdateInterfaces,
+        [asyncResp](const boost::system::error_code& ec1,
+                    const dbus::utility::MapperGetObject& object) {
+            if ((ec1 == boost::system::errc::io_error) || object.empty())
+            {
+                BMCWEB_LOG_DEBUG("USB code update not found");
+                return;
+            }
+            if (ec1)
+            {
+                BMCWEB_LOG_ERROR("DBUS response error {}", ec1);
+                messages::internalError(asyncResp->res);
+                return;
+            }
+
+            dbus::utility::getProperty<bool>(
+                *crow::connections::systemBus, object.begin()->first,
+                usbCodeUpdateObjectPath, usbCodeUpdateInterface, "Enabled",
+                [asyncResp](const boost::system::error_code& ec2,
+                            bool usbCodeUpdateState) {
+                    if (ec2)
+                    {
+                        BMCWEB_LOG_ERROR("DBUS response error: {}", ec2);
+                        messages::internalError(asyncResp->res);
+                        return;
+                    }
+
+                    asyncResp->res.jsonValue["Oem"]["IBM"]["@odata.type"] =
+                        "#IBMManager.v1_0_0.IBM";
+                    asyncResp->res.jsonValue["Oem"]["IBM"]["@odata.id"] =
+                        "/redfish/v1/Managers/bmc#/Oem/IBM";
+                    asyncResp->res
+                        .jsonValue["Oem"]["IBM"]["USBCodeUpdateEnabled"] =
+                        usbCodeUpdateState;
+                });
+        });
+}
+
+/**
+ * @brief Sets BMC USB code update state.
+ *
+ * @param[in] asyncResp   Shared pointer for generating response message.
+ * @param[in] state       USB code update state from request.
+ *
+ * @return None.
+ */
+inline void setUSBCodeUpdateState(
+    const std::shared_ptr<bmcweb::AsyncResp>& asyncResp, const bool& state)
+{
+    BMCWEB_LOG_DEBUG("Set USB code update status.");
+    dbus::utility::getDbusObject(
+        usbCodeUpdateObjectPath, usbCodeUpdateInterfaces,
+        [asyncResp, state](const boost::system::error_code& ec1,
+                           const dbus::utility::MapperGetObject& object) {
+            if (ec1 || object.empty())
+            {
+                BMCWEB_LOG_ERROR("DBUS response error {}", ec1);
+                messages::internalError(asyncResp->res);
+                return;
+            }
+
+            setDbusProperty(
+                asyncResp, "Oem/IBM/USBCodeUpdateEnabled",
+                object.begin()->first,
+                sdbusplus::message::object_path(usbCodeUpdateObjectPath),
+                usbCodeUpdateInterface, "Enabled", state);
+        });
+}
+} // namespace redfish

--- a/redfish-core/schema/oem/ibm/csdl/IBMManager_v1.xml
+++ b/redfish-core/schema/oem/ibm/csdl/IBMManager_v1.xml
@@ -1,0 +1,45 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<edmx:Edmx xmlns:edmx="http://docs.oasis-open.org/odata/ns/edmx" Version="4.0">
+  <edmx:Reference Uri="http://docs.oasis-open.org/odata/odata/v4.0/errata03/csd01/complete/vocabularies/Org.OData.Core.V1.xml">
+    <edmx:Include Namespace="Org.OData.Core.V1" Alias="OData"/>
+  </edmx:Reference>
+  <edmx:Reference Uri="http://redfish.dmtf.org/schemas/v1/RedfishExtensions_v1.xml">
+    <edmx:Include Namespace="Validation.v1_0_0" Alias="Validation"/>
+    <edmx:Include Namespace="RedfishExtensions.v1_0_0" Alias="Redfish"/>
+  </edmx:Reference>
+  <edmx:Reference Uri="http://redfish.dmtf.org/schemas/v1/Manager_v1.xml">
+    <edmx:Include Namespace="Manager"/>
+    <edmx:Include Namespace="Manager.v1_4_0"/>
+  </edmx:Reference>
+  <edmx:Reference Uri="http://redfish.dmtf.org/schemas/v1/Resource_v1.xml">
+    <edmx:Include Namespace="Resource"/>
+    <edmx:Include Namespace="Resource.v1_0_0"/>
+  </edmx:Reference>
+  <edmx:Reference Uri="http://redfish.dmtf.org/schemas/v1/Chassis_v1.xml">
+    <edmx:Include Namespace="Chassis"/>
+  </edmx:Reference>
+  <edmx:DataServices>
+    <Schema xmlns="http://docs.oasis-open.org/odata/ns/edm" Namespace="IBMManager">
+      <Annotation Term="Redfish.OwningEntity" String="IBM"/>
+      <Annotation Term="OData.Description" String="OpenBMC extensions to the standard manager."/>
+      <Annotation Term="OData.LongDescription" String="OpenBMC extensions to that standard manager."/>
+      <Annotation Term="Redfish.Uris">
+        <Collection>
+          <String>/redfish/v1/Managers#/Oem/IBMManager</String>
+        </Collection>
+      </Annotation>
+    </Schema>
+    <Schema xmlns="http://docs.oasis-open.org/odata/ns/edm" Namespace="IBMManager.v1_0_0">
+      <ComplexType Name="IBM" BaseType="Resource.OemObject">
+        <Annotation Term="OData.AdditionalProperties" Bool="true"/>
+        <Annotation Term="OData.Description" String="Oem properties for IBM."/>
+        <Annotation Term="OData.AutoExpand"/>
+        <Property Name="USBCodeUpdateEnabled" Type="Edm.Boolean" Nullable="false">
+          <Annotation Term="OData.Permissions" EnumMember="OData.Permission/ReadWrite"/>
+          <Annotation Term="OData.Description" String="An indication of whether the USB code update is enabled."/>
+          <Annotation Term="OData.LongDescription" String="An indication of whether the USB code update is enabled."/>
+        </Property>
+      </ComplexType>
+    </Schema>
+  </edmx:DataServices>
+</edmx:Edmx>

--- a/redfish-core/schema/oem/ibm/json-schema/IBMManager.json
+++ b/redfish-core/schema/oem/ibm/json-schema/IBMManager.json
@@ -1,0 +1,8 @@
+{
+    "$id": "https://github.com/ibm-openbmc/bmcweb/tree/HEAD/redfish-core/schema/oem/ibm/json-schema/IBMManager.json",
+    "$schema": "http://redfish.dmtf.org/schemas/v1/redfish-schema-v1.json",
+    "copyright": "Copyright 2025 OpenBMC.",
+    "definitions": {},
+    "owningEntity": "IBM",
+    "title": "#IBMManager"
+}

--- a/redfish-core/schema/oem/ibm/json-schema/IBMManager.v1_0_0.json
+++ b/redfish-core/schema/oem/ibm/json-schema/IBMManager.v1_0_0.json
@@ -1,0 +1,34 @@
+{
+    "$schema": "http://redfish.dmtf.org/schemas/v1/redfish-schema.v1_4_0.json",
+    "copyright": "Copyright 2025 OpenBMC.",
+    "definitions": {
+        "IBM": {
+            "additionalProperties": true,
+            "description": "Oem properties for IBM.",
+            "patternProperties": {
+                "^([a-zA-Z_][a-zA-Z0-9_]*)?@(odata|Redfish|Message)\\.[a-zA-Z_][a-zA-Z0-9_]*$": {
+                    "description": "This property shall specify a valid odata or Redfish property.",
+                    "type": [
+                        "array",
+                        "boolean",
+                        "integer",
+                        "number",
+                        "null",
+                        "object",
+                        "string"
+                    ]
+                }
+            },
+            "properties": {
+                "USBCodeUpdateEnabled": {
+                    "description": "An indication of whether the USB code update is enabled.",
+                    "longDescription": "An indication of whether the USB code update is enabled.",
+                    "type": "boolean"
+                }
+            },
+            "type": "object"
+        }
+    },
+    "owningEntity": "IBM",
+    "title": "#IBMManager.v1_0_0"
+}

--- a/redfish-core/schema/oem/ibm/meson.build
+++ b/redfish-core/schema/oem/ibm/meson.build
@@ -3,6 +3,7 @@ schemas = [
     'IBMComputerSystem',
     'IBMFabricAdapter',
     'IBMLogEntryAttachment',
+    'IBMManager',
     'IBMManagerAccount',
     'IBMPCIeDevice',
     'IBMPCIeSlots',


### PR DESCRIPTION
Implement USB code update Enable/Disable.
This is an OEM schema.

We can use "ibm-usb-code-update" option to enable/disable this feature.

Tested: Validator no error
First, we need to pick this commit:
[1] https://gerrit.openbmc-project.xyz/c/openbmc/service-config-manager/+/48780 or
[2] ibm-openbmc/service-config-manager#1

1. Get USB code update state
```
curl -k -H "X-Auth-Token: $token" -X GET https://${bmc}/redfish/v1/Managers/bmc
{
  "@odata.id": "/redfish/v1/Managers/bmc",
  "@odata.type": "#Manager.v1_11_0.Manager",

  ...

  "Oem": {
    "@odata.id": "/redfish/v1/Managers/bmc#/Oem",
    "@odata.type": "#OemManager.Oem",
    "IBM": {
      "@odata.id": "/redfish/v1/Managers/bmc#/Oem/IBM",
      "@odata.type": "#OemManager.IBM",
      "USBCodeUpdateEnabled": true
    },
    "OpenBmc": {
      "@odata.id": "/redfish/v1/Managers/bmc#/Oem/OpenBmc",
      "@odata.type": "#OemManager.OpenBmc",
      "Certificates": {
        "@odata.id": "/redfish/v1/Managers/bmc/Truststore/Certificates"
      }
    }
  },

  ...
```
2. Set disable USB code update
```
curl -k -H "X-Auth-Token: $token" -X PATCH https://${bmc}/redfish/v1/Managers/bmc -d '{"Oem":{"IBM":{"USBCodeUpdateEnabled": false}}}'

busctl get-property xyz.openbmc_project.Control.Service.Manager /xyz/openbmc_project/control/service/phosphor_2dusb_2dcode_2dupdate xyz.openbmc_project.Control.Service.Attributes Enabled
b false
```
3. Set enable USB code update
```
curl -k -H "X-Auth-Token: $token" -X PATCH https://${bmc}/redfish/v1/Managers/bmc -d '{"Oem":{"IBM":{"USBCodeUpdateEnabled": true}}}'

busctl get-property xyz.openbmc_project.Control.Service.Manager /xyz/openbmc_project/control/service/phosphor_2dusb_2dcode_2dupdate xyz.openbmc_project.Control.Service.Attributes Enabled
b true
```




Enable IBM options by default
* Cleanup License, pass unit test

When redfish-license was enabled, which is what I am doing in the commit above, this unit test fails. Make it pass.

Like we do upstream:
openbmc/bmcweb@7f3e84a
openbmc/bmcweb@8db8374




* Enable IBM options by default

Now CI tests these code paths.




Leave off USB code update if no backend (#916)
This appears what we had in 1020-1060.

Tested: Enable USB code update. Load on rainier with no backend. 200 rc for manager resource.




Fix USB code update errors
Was seeing the following errors when building with: https://github.ibm.com/openbmc/openbmc/pull/4649

```

bmcweb/redfish-core/lib/oem/ibm/usb_code_update.hpp:51:17: error: 'BMCWEB_LOG_ERRO' was not declared in this scope; did you mean 'BMCWEB_LOG_ERROR'?
|    51 |                 BMCWEB_LOG_ERRO("DBUS response error: {}", ec2);

redfish-core/lib/oem/ibm/usb_code_update.hpp:35:21: error: capture of variable 'redfish::usbCodeUpdateObjectPath' with non-automatic storage duration [-Werror]
|    35 |         [asyncResp, usbCodeUpdateObjectPath](

```

Tested: This builds with 4649.