### PR TITLE
Revert "Temporary comment out run-ci (#1285)"

### DIFF
--- a/run-ci
+++ b/run-ci
@@ -4,8 +4,6 @@ set -e
 
 SCRIPT_DIR=$( cd -- "$( dirname -- "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )
 
-# These go out to https://redfish.dmtf.org/ which is currently blocked.
-# Temporary comment these out
-# "$SCRIPT_DIR/scripts/parse_registries.py"
-# "$SCRIPT_DIR/scripts/update_schemas.py"
+"$SCRIPT_DIR/scripts/parse_registries.py"
+"$SCRIPT_DIR/scripts/update_schemas.py"
 git --no-pager -C "$SCRIPT_DIR" diff --exit-code


### PR DESCRIPTION
This reverts commit e57fbba5e674437158920455bf8a258b30a71065.

This was a temp hack to get CI to pass. The lab has fixed this so revert the hack.