### PR TITLE
1120-FFDC:Collect current in-memory session for BMCdump

### DIFF
--- a/include/persistent_data.hpp
+++ b/include/persistent_data.hpp
@@ -34,7 +34,8 @@ class ConfigFile
   public:
     // todo(ed) should read this from a fixed location somewhere, not CWD
     static constexpr const char* filename = "bmcweb_persistent_data.json";
-
+    static constexpr const char* dumpFilename =
+        "bmcweb_current_session_snapshot.json";
     ConfigFile()
     {
         readData();
@@ -215,6 +216,85 @@ class ConfigFile
         {
             writeData();
         }
+    }
+
+    void writeCurrentSessionData()
+    {
+        std::ofstream persistentFile(dumpFilename);
+        std::filesystem::perms permission =
+            std::filesystem::perms::owner_read |
+            std::filesystem::perms::owner_write |
+            std::filesystem::perms::group_read;
+        std::filesystem::permissions(dumpFilename, permission);
+        const auto& eventServiceConfig =
+            EventServiceStore::getInstance().getEventServiceConfig();
+        nlohmann::json data{
+            {"eventservice_config",
+             {{"ServiceEnabled", eventServiceConfig.enabled},
+              {"DeliveryRetryAttempts", eventServiceConfig.retryAttempts},
+              {"DeliveryRetryIntervalSeconds",
+               eventServiceConfig.retryTimeoutInterval}}
+
+            },
+            {"system_uuid", systemUuid},
+            {"revision", jsonRevision},
+            {"timeout", SessionStore::getInstance().getTimeoutInSeconds()}};
+
+        nlohmann::json& sessions = data["sessions"];
+        sessions = nlohmann::json::array();
+        for (const auto& p : SessionStore::getInstance().authTokens)
+        {
+            if (p.second->sessionType != persistent_data::SessionType::Basic &&
+                p.second->sessionType !=
+                    persistent_data::SessionType::MutualTLS)
+            {
+                nlohmann::json::object_t session;
+                session["unique_id"] = p.second->uniqueId;
+                session["username"] = p.second->username;
+                session["client_ip"] = p.second->clientIp;
+                if (const auto& clientId = p.second->clientId)
+                {
+                    session["client_id"] = *clientId;
+                }
+                sessions.push_back(std::move(session));
+            }
+        }
+
+        nlohmann::json& subscriptions = data["subscriptions"];
+        subscriptions = nlohmann::json::array();
+        for (const auto& it :
+             EventServiceStore::getInstance().subscriptionsConfigMap)
+        {
+            std::shared_ptr<UserSubscription> subValue = it.second;
+            if (subValue->subscriptionType == "SSE")
+            {
+                BMCWEB_LOG_DEBUG("The subscription type is SSE, so skipping.");
+                continue;
+            }
+            nlohmann::json::object_t headers;
+            for (const boost::beast::http::fields::value_type& header :
+                 subValue->httpHeaders)
+            {
+                std::string name(header.name_string());
+                headers[std::move(name)] = header.value();
+            }
+
+            subscriptions.push_back({
+                {"Id", subValue->id},
+                {"Context", subValue->customText},
+                {"DeliveryRetryPolicy", subValue->retryPolicy},
+                {"Destination", subValue->destinationUrl},
+                {"EventFormatType", subValue->eventFormatType},
+                {"HttpHeaders", std::move(headers)},
+                {"MessageIds", subValue->registryMsgIds},
+                {"Protocol", subValue->protocol},
+                {"RegistryPrefixes", subValue->registryPrefixes},
+                {"ResourceTypes", subValue->resourceTypes},
+                {"SubscriptionType", subValue->subscriptionType},
+                {"MetricReportDefinitions", subValue->metricReportDefinitions},
+            });
+        }
+        persistentFile << data;
     }
 
     void writeData()


### PR DESCRIPTION
Currently it collects bmcweb_persistent_data.json as part of BMC dump, but this file does not contain all existing redfish sessions

This commit is to collect all sessions into bmcweb_current_session_persistent_data.json during bmc dump creation, on receiving SIGUSR1 from dump manager.

Add event subscriptions data along with session data