### PR TITLE
Audit Log: Skip detail for UpdateService URIs

### DIFF
--- a/src/audit_events.cpp
+++ b/src/audit_events.cpp
@@ -107,6 +107,7 @@ void auditSetState(bool enable)
  * @brief Checks if request should include additional data
  *
  * - Accounts requests data may contain passwords
+ * - UpdateService requests data may contain huge binary data.
  * - IBM Management console events data is not useful. It can be binary data or
  *   contents of file.
  * - User login and session data may contain passwords
@@ -116,6 +117,7 @@ void auditSetState(bool enable)
 inline bool checkSkipDetail(const crow::Request& req)
 {
     return req.target().starts_with("/redfish/v1/AccountService/Accounts") ||
+           req.target().starts_with("/redfish/v1/UpdateService") ||
            req.target().starts_with("/ibm/v1") ||
            ((req.method() == boost::beast::http::verb::post) &&
             checkPostUser(req));

--- a/test/include/audit_events_test.cpp
+++ b/test/include/audit_events_test.cpp
@@ -147,6 +147,13 @@ TEST(wantDetail, NegativeTest)
     postRequest.target("/login");
     EXPECT_FALSE(wantDetail(postRequest));
 
+    postRequest.target("/redfish/v1/UpdateService/update");
+    EXPECT_FALSE(wantDetail(postRequest));
+
+    postRequest.target(
+        "/redfish/v1/UpdateService/Actions/UpdateService.SimpleUpdate");
+    EXPECT_FALSE(wantDetail(postRequest));
+
     crow::Request getRequest{{boost::beast::http::verb::get, url, 11}, ec};
     EXPECT_FALSE(wantDetail(getRequest));
 }


### PR DESCRIPTION
The UpdateService Redfish URIs may contain huge binary data in their body. Add the URI to the list of URIs to skip adding detail when auditing.

Tested:
 - Issued update with DEBUG log messages turned on. Confirmed no detail was attempted to be added to audit record. Confirmed audit record was recorded as expected.
 - Confirmed other audit records with details were still recording detail as expected.