### PR TITLE
1120: Enable IBM options by default

### DIFF
--- a/meson.options
+++ b/meson.options
@@ -110,7 +110,7 @@ option(
 option(
     'redfish-dump-log',
     type: 'feature',
-    value: 'disabled',
+    value: 'enabled',
     description: '''Enable Dump log service transactions through Redfish. Paths
                    are under /redfish/v1/Systems/system/LogServices/Dump
                    and /redfish/v1/Managers/bmc/LogServices/Dump''',
@@ -279,7 +279,7 @@ option(
 option(
     'ibm-management-console',
     type: 'feature',
-    value: 'disabled',
+    value: 'enabled',
     description: '''Enable the IBM management console specific functionality.
                     Paths are under /ibm/v1/''',
 )


### PR DESCRIPTION
1110 PR: https://github.com/ibm-openbmc/bmcweb/pull/924

Now CI tests these code paths.

License should enable by default at
https://github.com/ibm-openbmc/bmcweb/pull/1290

USB code update should do the same at
https://github.com/ibm-openbmc/bmcweb/pull/1288

Gard should enable by default at 
https://github.com/ibm-openbmc/bmcweb/pull/1279/files

D-Bus log already did at https://github.com/ibm-openbmc/bmcweb/commit/81befd054edf6c9b97b8034c0b82d2bdef2dfcf7