### PR TITLE
1110 ghe : Add BIOS support (#907)

### DIFF
--- a/Redfish.md
+++ b/Redfish.md
@@ -809,6 +809,7 @@ other.
 #### Bios
 
 - Actions
+- Attributes
 - Description
 - Links/ActiveSoftwareImage
 - Links/SoftwareImages

--- a/redfish-core/include/registries/bios_registry.hpp
+++ b/redfish-core/include/registries/bios_registry.hpp
@@ -1,0 +1,20 @@
+#pragma once
+
+#include "registries.hpp"
+
+namespace redfish::registries::bios
+{
+const Header header = {
+    "Copyright 2020 OpenBMC. All rights reserved.",
+    "#MessageRegistry.v1_4_0.MessageRegistry",
+    1,
+    0,
+    0,
+    "Bios Attribute Registry",
+    "en",
+    "This registry defines the messages for bios attribute registry.",
+    "BiosAttributeRegistry",
+    "DMTF",
+};
+constexpr const char* url = "";
+} // namespace redfish::registries::bios

--- a/redfish-core/include/registries_selector.hpp
+++ b/redfish-core/include/registries_selector.hpp
@@ -3,6 +3,7 @@
 #pragma once
 #include "registries.hpp"
 #include "registries/base_message_registry.hpp"
+#include "registries/bios_registry.hpp"
 #include "registries/heartbeat_event_message_registry.hpp"
 #include "registries/openbmc_message_registry.hpp"
 #include "registries/resource_event_message_registry.hpp"
@@ -27,6 +28,10 @@ inline std::optional<registries::HeaderAndUrl>
     if (base::header.registryPrefix == registryName)
     {
         return HeaderAndUrl{base::header, base::url};
+    }
+    if (bios::header.registryPrefix == registryName)
+    {
+        return HeaderAndUrl{bios::header, bios::url};
     }
     if (heartbeat_event::header.registryPrefix == registryName)
     {

--- a/redfish-core/include/utils/bios_utils.hpp
+++ b/redfish-core/include/utils/bios_utils.hpp
@@ -1,0 +1,137 @@
+// SPDX-License-Identifier: Apache-2.0
+// SPDX-FileCopyrightText: Copyright OpenBMC Authors
+#pragma once
+
+#include "async_resp.hpp"
+#include "dbus_singleton.hpp"
+#include "dbus_utility.hpp"
+#include "error_messages.hpp"
+#include "logging.hpp"
+
+#include <array>
+#include <cstdint>
+#include <functional>
+#include <memory>
+#include <string>
+#include <string_view>
+#include <unordered_map>
+#include <variant>
+
+namespace redfish
+{
+namespace bios_utils
+{
+static constexpr std::string_view biosConfigManagerPath =
+    "/xyz/openbmc_project/bios_config/manager";
+static constexpr std::string_view biosConfigManagerInterface =
+    "xyz.openbmc_project.BIOSConfig.Manager";
+
+template <typename Type>
+inline void extractValue(nlohmann::json& attributes, const std::string& name,
+                         const dbus::utility::DbusVariantType& value)
+{
+    const Type* tValue = std::get_if<Type>(&value);
+    if (tValue != nullptr)
+    {
+        attributes[name] = *tValue;
+        return;
+    }
+    attributes[name] = Type{};
+}
+
+template <>
+inline void extractValue<bool>(nlohmann::json& attributes,
+                               const std::string& name,
+                               const dbus::utility::DbusVariantType& value)
+{
+    const int64_t* tValue = std::get_if<int64_t>(&value);
+    if (tValue != nullptr)
+    {
+        attributes[name] = (*tValue != 0);
+        return;
+    }
+    attributes[name] = false;
+}
+
+using HandlerType = std::function<void(nlohmann::json&, const std::string&,
+                                       const dbus::utility::DbusVariantType&)>;
+
+inline void addAttribute(nlohmann::json& attributes, const std::string& name,
+                         const dbus::utility::DbusVariantType& type,
+                         const dbus::utility::DbusVariantType& value)
+{
+    static const std::unordered_map<std::string, HandlerType> typeMap = {
+        {"xyz.openbmc_project.BIOSConfig.Manager.AttributeType.Enumeration",
+         extractValue<std::string>},
+        {"xyz.openbmc_project.BIOSConfig.Manager.AttributeType.String",
+         extractValue<std::string>},
+        {"xyz.openbmc_project.BIOSConfig.Manager.AttributeType.Password",
+         extractValue<std::string>},
+        {"xyz.openbmc_project.BIOSConfig.Manager.AttributeType.Integer",
+         extractValue<int64_t>},
+        {"xyz.openbmc_project.BIOSConfig.Manager.AttributeType.Boolean",
+         extractValue<bool>}};
+
+    const std::string* typeStr = std::get_if<std::string>(&type);
+    if (typeStr != nullptr)
+    {
+        auto it = typeMap.find(*typeStr);
+        if (it != typeMap.end())
+        {
+            it->second(attributes, name, value);
+        }
+    }
+}
+
+template <typename T>
+inline void getBIOSManagerProperty(
+    const std::shared_ptr<bmcweb::AsyncResp>& asyncResp,
+    const std::string& property, const std::string& objectPath,
+    std::function<void(const T&)> handler)
+{
+    sdbusplus::asio::getProperty<T>(
+        *crow::connections::systemBus, objectPath,
+        std::string(biosConfigManagerPath),
+        std::string(biosConfigManagerInterface), property,
+        [asyncResp, property, handler{std::move(handler)}](
+            const boost::system::error_code& ec, const T& value) {
+            if (ec)
+            {
+                BMCWEB_LOG_ERROR("DBus response error for {}: {}", property,
+                                 ec);
+                messages::internalError(asyncResp->res);
+                return;
+            }
+            handler(value);
+        });
+}
+
+template <typename CallbackFunc>
+inline void getBIOSManagerObject(
+    const std::shared_ptr<bmcweb::AsyncResp>& asyncResp,
+    CallbackFunc&& callback)
+{
+    dbus::utility::getDbusObject(
+        std::string(biosConfigManagerPath),
+        std::array<std::string_view, 1>{biosConfigManagerInterface},
+        [asyncResp, callback = std::forward<CallbackFunc>(callback)](
+            const boost::system::error_code& ec,
+            const dbus::utility::MapperGetObject& object) {
+            if (ec || object.empty())
+            {
+                BMCWEB_LOG_ERROR("Error finding BIOS Manager object {}", ec);
+                messages::internalError(asyncResp->res);
+                return;
+            }
+            if (object.size() > 1)
+            {
+                BMCWEB_LOG_ERROR("More than one BIOS Manager object found");
+                messages::internalError(asyncResp->res);
+                return;
+            }
+            callback(object.begin()->first);
+        });
+}
+
+} // namespace bios_utils
+} // namespace redfish

--- a/redfish-core/lib/bios.hpp
+++ b/redfish-core/lib/bios.hpp
@@ -19,6 +19,7 @@
 #include <sys/types.h>
 
 #include <boost/beast/http/verb.hpp>
+#include <boost/lexical_cast.hpp>
 
 #include <format>
 #include <functional>
@@ -33,11 +34,121 @@ namespace redfish
 {
 using BaseTableOption =
     std::tuple<std::string, dbus::utility::DbusVariantType, std::string>;
-
 using BaseTableAttribute =
     std::tuple<std::string, bool, std::string, std::string, std::string,
                dbus::utility::DbusVariantType, dbus::utility::DbusVariantType,
                std::vector<BaseTableOption>>;
+using BiosBaseTableItemType = std::pair<std::string, BaseTableAttribute>;
+using BiosBaseTableType = std::vector<BiosBaseTableItemType>;
+
+using PendingAttributesItemType =
+    std::pair<std::string,
+              std::tuple<std::string, dbus::utility::DbusVariantType>>;
+using PendingAttributesType = std::vector<PendingAttributesItemType>;
+
+enum PendingAttributesIndex
+{
+    pendingAttrType = 0,
+    pendingAttrValue
+};
+
+enum BiosBaseTableIndex
+{
+    biosBaseAttrType = 0,
+    biosBaseReadonlyStatus,
+    biosBaseDisplayName,
+    biosBaseDescription,
+    biosBaseMenuPath,
+    biosBaseCurrValue,
+    biosBaseDefaultValue,
+    biosBaseOptions
+};
+
+using OptionsItemType =
+    std::tuple<std::string, dbus::utility::DbusVariantType, std::string>;
+
+enum OptionsItemIndex
+{
+    optItemType = 0,
+    optItemValue
+};
+
+inline std::string mapAttrTypeToRedfish(const std::string_view typeDbus)
+{
+    std::string ret;
+    if (typeDbus ==
+        "xyz.openbmc_project.BIOSConfig.Manager.AttributeType.Enumeration")
+    {
+        ret = "Enumeration";
+    }
+    else if (typeDbus ==
+             "xyz.openbmc_project.BIOSConfig.Manager.AttributeType.String")
+    {
+        ret = "String";
+    }
+    else if (typeDbus ==
+             "xyz.openbmc_project.BIOSConfig.Manager.AttributeType.Password")
+    {
+        ret = "Password";
+    }
+    else if (typeDbus ==
+             "xyz.openbmc_project.BIOSConfig.Manager.AttributeType.Integer")
+    {
+        ret = "Integer";
+    }
+    else if (typeDbus ==
+             "xyz.openbmc_project.BIOSConfig.Manager.AttributeType.Boolean")
+    {
+        ret = "Boolean";
+    }
+    else
+    {
+        ret = "UNKNOWN";
+    }
+
+    return ret;
+}
+
+inline std::string mapBoundTypeToRedfish(const std::string_view typeDbus)
+{
+    std::string ret;
+    if (typeDbus ==
+        "xyz.openbmc_project.BIOSConfig.Manager.BoundType.ScalarIncrement")
+    {
+        ret = "ScalarIncrement";
+    }
+    else if (typeDbus ==
+             "xyz.openbmc_project.BIOSConfig.Manager.BoundType.LowerBound")
+    {
+        ret = "LowerBound";
+    }
+    else if (typeDbus ==
+             "xyz.openbmc_project.BIOSConfig.Manager.BoundType.UpperBound")
+    {
+        ret = "UpperBound";
+    }
+    else if (typeDbus ==
+             "xyz.openbmc_project.BIOSConfig.Manager.BoundType.MinStringLength")
+    {
+        ret = "MinLength";
+    }
+    else if (typeDbus ==
+             "xyz.openbmc_project.BIOSConfig.Manager.BoundType.MaxStringLength")
+    {
+        ret = "MaxLength";
+    }
+    else if (typeDbus ==
+             "xyz.openbmc_project.BIOSConfig.Manager.BoundType.OneOf")
+    {
+        ret = "OneOf";
+    }
+    else
+    {
+        ret = "UNKNOWN";
+    }
+
+    return ret;
+}
 
 enum class BaseTableAttributeIndex
 {
@@ -119,6 +230,8 @@ inline void handleBiosServiceGet(
     asyncResp->res.jsonValue["Actions"]["#Bios.ResetBios"]["target"] =
         std::format("/redfish/v1/Systems/{}/Bios/Actions/Bios.ResetBios",
                     BMCWEB_REDFISH_SYSTEM_URI_NAME);
+    asyncResp->res.jsonValue["@Redfish.Settings"]["@odata.type"] = "#Settings.v1_3_0.Settings";
+    asyncResp->res.jsonValue["@Redfish.Settings"]["SettingsObject"]["@odata.id"] = "/redfish/v1/Systems/system/Bios/Settings";
     dbus::utility::checkDbusPathExists(
         "/xyz/openbmc_project/bios_config/manager", [asyncResp](int rc) {
             if (rc > 0)
@@ -131,6 +244,388 @@ inline void handleBiosServiceGet(
                                          true);
 }
 
+inline void handleBiosAttributeRegistryGet(
+    crow::App& app, const crow::Request& req,
+    const std::shared_ptr<bmcweb::AsyncResp>& asyncResp)
+{
+    if (!redfish::setUpRedfishRoute(app, req, asyncResp))
+    {
+        return;
+    }
+    asyncResp->res.jsonValue["@odata.id"] =
+        "/redfish/v1/Registries/BiosAttributeRegistry/BiosAttributeRegistry";
+    asyncResp->res.jsonValue["@odata.type"] =
+        "#AttributeRegistry.v1_3_2.AttributeRegistry";
+    asyncResp->res.jsonValue["Name"] = "Bios Attribute Registry";
+    asyncResp->res.jsonValue["Id"] = "BiosAttributeRegistry";
+    asyncResp->res.jsonValue["RegistryVersion"] = "1.0.0";
+    asyncResp->res.jsonValue["Language"] = "en";
+    asyncResp->res.jsonValue["OwningEntity"] = "OpenBMC";
+    asyncResp->res.jsonValue["RegistryEntries"]["Attributes"] = nlohmann::json::array();
+
+    dbus::utility::getProperty<BiosBaseTableType>(
+        "xyz.openbmc_project.BIOSConfigManager",
+        "/xyz/openbmc_project/bios_config/manager",
+        "xyz.openbmc_project.BIOSConfig.Manager", "BaseBIOSTable",	    
+        [asyncResp](const boost::system::error_code& ec,
+                    const BiosBaseTableType& baseBiosTable) {
+            if (ec)
+            {
+                BMCWEB_LOG_ERROR("getProperty failed: {}", ec.message());
+                messages::resourceNotFound(asyncResp->res, "Registries/Bios", "Bios");
+                return;
+            }
+
+            nlohmann::json& attributeArray =
+                asyncResp->res.jsonValue["RegistryEntries"]["Attributes"];
+
+            for (const BiosBaseTableItemType& item : baseBiosTable)
+            {
+                nlohmann::json attributeItem;
+                nlohmann::json optionsArray = nlohmann::json::array();
+
+                const std::string& itemType = std::get<biosBaseAttrType>(item.second);
+                std::string attrType = mapAttrTypeToRedfish(itemType);
+                if (attrType == "UNKNOWN")
+                {
+                    BMCWEB_LOG_ERROR("attrType == UNKNOWN");
+                    messages::internalError(asyncResp->res);
+                    return;
+                }
+
+                attributeItem["AttributeName"] = item.first;
+                attributeItem["Type"] = attrType;
+                attributeItem["ReadOnly"] = std::get<biosBaseReadonlyStatus>(item.second);
+                attributeItem["DisplayName"] = std::get<biosBaseDisplayName>(item.second);
+                attributeItem["HelpText"] = std::get<biosBaseDescription>(item.second);
+
+                if (!std::get<biosBaseMenuPath>(item.second).empty())
+                {
+                    attributeItem["MenuPath"] = std::get<biosBaseMenuPath>(item.second);
+                }
+
+                if (attrType == "String" || attrType == "Enumeration")
+                {
+                    const std::string* currValue = std::get_if<std::string>(
+                        &std::get<biosBaseCurrValue>(item.second));
+                    const std::string* defValue = std::get_if<std::string>(
+                        &std::get<biosBaseDefaultValue>(item.second));
+
+                    if (currValue && !currValue->empty())
+                    {
+                        attributeItem["CurrentValue"] = *currValue;
+                    }
+                    if (defValue && !defValue->empty())
+                    {
+                        attributeItem["DefaultValue"] = *defValue;
+                    }
+                }
+                else if (attrType == "Integer")
+                {
+                    const int64_t* currValue = std::get_if<int64_t>(
+                        &std::get<biosBaseCurrValue>(item.second));
+                    const int64_t* defValue = std::get_if<int64_t>(
+                        &std::get<biosBaseDefaultValue>(item.second));
+
+                    attributeItem["CurrentValue"] = currValue ? *currValue : 0;
+                    attributeItem["DefaultValue"] = defValue ? *defValue : 0;
+                }
+                else
+                {
+                    BMCWEB_LOG_ERROR("Unsupported attribute type.");
+                    messages::internalError(asyncResp->res);
+                    return;
+                }
+
+                const std::vector<OptionsItemType>& optionsVector =
+                    std::get<biosBaseOptions>(item.second);
+                for (const OptionsItemType& optItem : optionsVector)
+                {
+                    nlohmann::json optItemJson;
+                    const std::string& strOptItemType =
+                        std::get<optItemType>(optItem);
+                    std::string optItemTypeRedfish =
+                        mapBoundTypeToRedfish(strOptItemType);
+                    if (optItemTypeRedfish == "UNKNOWN")
+                    {
+                        BMCWEB_LOG_ERROR("optItemTypeRedfish == UNKNOWN");
+                        messages::internalError(asyncResp->res);
+                        return;
+                    }
+
+                    if (optItemTypeRedfish == "OneOf")
+                    {
+                        const std::string* currValue = std::get_if<std::string>(
+                            &std::get<optItemValue>(optItem));
+                        if (currValue)
+                        {
+                            optItemJson["ValueName"] = *currValue;
+                            optionsArray.push_back(optItemJson);
+                        }
+                    }
+                    else
+                    {
+                        const int64_t* currValue = std::get_if<int64_t>(
+                            &std::get<optItemValue>(optItem));
+                        if (currValue)
+                        {
+                            attributeItem[optItemTypeRedfish] = *currValue;
+                        }
+                    }
+                }
+
+                if (!optionsArray.empty())
+                {
+                    attributeItem["Value"] = optionsArray;
+                }
+
+                attributeArray.push_back(attributeItem);
+            }
+        });
+}
+
+inline void handleBiosSettingsGet(
+    crow::App& app, const crow::Request& req,
+    const std::shared_ptr<bmcweb::AsyncResp>& asyncResp,
+    const std::string& systemName)
+{
+        if (!redfish::setUpRedfishRoute(app, req, asyncResp))
+        {
+            return;
+        }
+
+        if (systemName != "system")
+        {
+            messages::resourceNotFound(asyncResp->res, "ComputerSystem",
+                                       systemName);
+            return;
+        }
+        asyncResp->res.jsonValue["@odata.id"] =
+            "/redfish/v1/Systems/system/Bios/Settings";
+        asyncResp->res.jsonValue["@odata.type"] = "#Bios.v1_1_0.Bios";
+        asyncResp->res.jsonValue["Name"] = "Bios Settings";
+        asyncResp->res.jsonValue["Id"] = "BiosSettings";
+        asyncResp->res.jsonValue["AttributeRegistry"] = "BiosAttributeRegistry";
+        nlohmann::json attributes(nlohmann::json::value_t::object);
+        asyncResp->res.jsonValue["Attributes"] = attributes;
+
+        dbus::utility::getProperty<PendingAttributesType>(
+            "xyz.openbmc_project.BIOSConfigManager", 
+            "/xyz/openbmc_project/bios_config/manager",
+            "xyz.openbmc_project.BIOSConfig.Manager", "PendingAttributes",         
+        [asyncResp](const boost::system::error_code& ec,
+                    const PendingAttributesType& pendingAttributes) {
+                if (ec)
+                {
+                    BMCWEB_LOG_WARNING("getBiosSettings DBUS error: {}", ec);
+                    messages::resourceNotFound(
+                        asyncResp->res, "Systems/system/Bios", "Settings");
+                    return;
+                }
+                nlohmann::json& attributesJson =
+                    asyncResp->res.jsonValue["Attributes"];
+                for (const PendingAttributesItemType& item : pendingAttributes)
+                {
+                    const std::string& key = item.first;
+                    const std::string& itemType =
+                        std::get<pendingAttrType>(item.second);
+                    std::string attrType = mapAttrTypeToRedfish(itemType);
+                    if (attrType == "String" || attrType == "Enumeration")
+                    {
+                        const std::string* currValue = std::get_if<std::string>(
+                            &std::get<pendingAttrValue>(item.second));
+                        attributesJson.emplace(
+                            key, currValue != nullptr ? *currValue : "");
+                    }
+                    else if (attrType == "Integer")
+                    {
+                        const int64_t* currValue = std::get_if<int64_t>(
+                            &std::get<pendingAttrValue>(item.second));
+                        attributesJson.emplace(
+                            key, currValue != nullptr ? *currValue : 0);
+                    }
+                    else
+                    {
+                        BMCWEB_LOG_ERROR("Unsupported attribute type.");
+                        messages::internalError(asyncResp->res);
+                    }
+                }
+            });
+}
+
+inline void handleBiosSettingsPatch(
+    crow::App& app, const crow::Request& req,
+    const std::shared_ptr<bmcweb::AsyncResp>& asyncResp,
+    const std::string& systemName)
+{
+        if (!redfish::setUpRedfishRoute(app, req, asyncResp))
+        {
+            return;
+        }
+
+        if (systemName != "system")
+        {
+            messages::resourceNotFound(asyncResp->res, "ComputerSystem",
+                                       systemName);
+            return;
+        }
+        nlohmann::json attrsJson;
+
+        if (!redfish::json_util::readJsonPatch(req, asyncResp->res,
+                                               "Attributes", attrsJson))
+        {
+            return;
+        }
+
+        if (attrsJson.is_array())
+        {
+            BMCWEB_LOG_WARNING(
+                "The value for 'Attributes' is in a different format");
+            messages::propertyValueFormatError(asyncResp->res, attrsJson.dump(),
+                                               "Attributes");
+            return;
+        }
+
+        dbus::utility::getProperty<BiosBaseTableType>(
+            "xyz.openbmc_project.BIOSConfigManager", 
+            "/xyz/openbmc_project/bios_config/manager",
+            "xyz.openbmc_project.BIOSConfig.Manager", "BaseBIOSTable",         
+            [asyncResp, attrsJson, systemName](const boost::system::error_code& ec,
+                        const BiosBaseTableType& baseBiosTable) {
+            if (ec)
+            {
+                BMCWEB_LOG_ERROR("getBiosAttributes DBUS error: {}", ec);
+                messages::internalError(asyncResp->res);
+                return;
+            }
+
+            boost::container::flat_map<std::string,
+                                       std::pair<bool, std::string>>
+                biosAttrsType;
+
+            for (const BiosBaseTableItemType& item : baseBiosTable)
+            {
+                biosAttrsType.try_emplace(
+                    item.first,
+                    std::make_pair(
+                        std::get<biosBaseReadonlyStatus>(item.second),
+                        std::get<biosBaseAttrType>(item.second)));
+            }
+
+            PendingAttributesType pendingAttributes;
+            for (const auto& attrItr : attrsJson.items())
+            {
+                std::string attrName = attrItr.key();
+
+		BMCWEB_LOG_ERROR("attrName: {}", attrName);
+                if (attrName.empty())
+                {
+                    messages::invalidObject(
+                        asyncResp->res,
+                        boost::urls::format(
+                            "redfish/v1/Systems/systemName/Bios/Settings"));
+                    return;
+                }
+                auto it = biosAttrsType.find(attrName);
+                if (it == biosAttrsType.end())
+                {
+                    messages::propertyUnknown(asyncResp->res, attrName);
+                    return;
+                }
+
+                bool biosAttrReadOnlyStatus = ((*it).second).first;
+                if (biosAttrReadOnlyStatus)
+                {
+                    BMCWEB_LOG_WARNING(
+                        "Attribute Type is ReadOnly. Patch failed!");
+                    messages::propertyNotWritable(asyncResp->res, attrName);
+                    return;
+                }
+
+                std::string biosAttrType = ((*it).second).second;
+                if (biosAttrType.empty())
+                {
+                    BMCWEB_LOG_ERROR("Attribute type not found in BIOS Table");
+                    messages::internalError(asyncResp->res);
+                    return;
+                }
+
+                std::string biosRedfishAttrType =
+                    mapAttrTypeToRedfish(biosAttrType);
+                if (biosRedfishAttrType == "Integer")
+                {
+                    if (attrItr.value().type() !=
+                        nlohmann::json::value_t::number_unsigned)
+                    {
+                        BMCWEB_LOG_WARNING("The value must be of type int");
+                        std::string val =
+                            boost::lexical_cast<std::string>(attrItr.value());
+                        messages::propertyValueTypeError(asyncResp->res, val,
+                                                         attrName);
+                        return;
+                    }
+                    int64_t attrValue = attrItr.value();
+                    pendingAttributes.emplace_back(std::make_pair(
+                        attrName, std::make_tuple(biosAttrType, attrValue)));
+                }
+                else if (biosRedfishAttrType == "String" ||
+                         biosRedfishAttrType == "Enumeration" ||
+                         biosRedfishAttrType == "Password")
+                {
+                    if (attrItr.value().type() !=
+                        nlohmann::json::value_t::string)
+                    {
+                        BMCWEB_LOG_WARNING("The value must be of type string");
+                        std::string val =
+                            boost::lexical_cast<std::string>(attrItr.value());
+                        messages::propertyValueTypeError(asyncResp->res, val,
+                                                         attrName);
+                        return;
+                    }
+                    std::string attrValue = attrItr.value();
+                    pendingAttributes.emplace_back(std::make_pair(
+                        attrName, std::make_tuple(biosAttrType, attrValue)));
+                }
+                else if (biosRedfishAttrType == "Boolean")
+                {
+                    if (attrItr.value().type() !=
+                        nlohmann::json::value_t::boolean)
+                    {
+                        BMCWEB_LOG_WARNING("The value must be of type bool");
+                        std::string val =
+                            boost::lexical_cast<std::string>(attrItr.value());
+                        messages::propertyValueTypeError(asyncResp->res, val,
+                                                         attrName);
+                        return;
+                    }
+                    bool attrValue = attrItr.value();
+                    pendingAttributes.emplace_back(std::make_pair(
+                        attrName, std::make_tuple(biosAttrType, attrValue)));
+                }
+                else
+                {
+                    BMCWEB_LOG_ERROR("Attribute Type in BiosTable is Unknown");
+                    messages::internalError(asyncResp->res);
+                    return;
+                }
+            }
+
+	    sdbusplus::asio::setProperty(
+            *crow::connections::systemBus, "xyz.openbmc_project.BIOSConfigManager",
+	    "/xyz/openbmc_project/bios_config/manager",
+	    "xyz.openbmc_project.BIOSConfig.Manager", "PendingAttributes",
+	    pendingAttributes,
+	    [asyncResp](const boost::system::error_code& ec1) {
+                if (ec1)
+                {
+                    BMCWEB_LOG_ERROR("doPatch resp_handler got error: {}", ec1);
+                    messages::internalError(asyncResp->res);
+                    return;
+                }
+            });
+        });
+}
+
 inline void requestRoutesBiosService(App& app)
 {
     BMCWEB_ROUTE(app, "/redfish/v1/Systems/<str>/Bios/")
@@ -139,6 +634,18 @@ inline void requestRoutesBiosService(App& app)
             std::bind_front(handleBiosServiceGet, std::ref(app)));
 }
 
+inline void requestRoutesBiosSettings(App& app)
+{
+    BMCWEB_ROUTE(app, "/redfish/v1/Systems/<str>/Bios/Settings")
+        .privileges(redfish::privileges::getBios)
+        .methods(boost::beast::http::verb::get)(
+            std::bind_front(handleBiosSettingsGet, std::ref(app)));
+
+    BMCWEB_ROUTE(app, "/redfish/v1/Systems/<str>/Bios/Settings")
+        .privileges(redfish::privileges::patchBios)
+        .methods(boost::beast::http::verb::patch)(
+            std::bind_front(handleBiosSettingsPatch, std::ref(app)));
+}
 /**
  * BiosReset class supports handle POST method for Reset bios.
  * The class retrieves and sends data directly to D-Bus.

--- a/redfish-core/lib/bios.hpp
+++ b/redfish-core/lib/bios.hpp
@@ -9,20 +9,82 @@
 #include "dbus_singleton.hpp"
 #include "error_messages.hpp"
 #include "http_request.hpp"
+#include "http_response.hpp"
 #include "logging.hpp"
 #include "query.hpp"
 #include "registries/privilege_registry.hpp"
+#include "utils/bios_utils.hpp"
 #include "utils/sw_utils.hpp"
+
+#include <sys/types.h>
 
 #include <boost/beast/http/verb.hpp>
 
 #include <format>
 #include <functional>
+#include <map>
 #include <memory>
 #include <string>
+#include <string_view>
+#include <tuple>
+#include <vector>
 
 namespace redfish
 {
+using BaseTableOption =
+    std::tuple<std::string, dbus::utility::DbusVariantType, std::string>;
+
+using BaseTableAttribute =
+    std::tuple<std::string, bool, std::string, std::string, std::string,
+               dbus::utility::DbusVariantType, dbus::utility::DbusVariantType,
+               std::vector<BaseTableOption>>;
+
+enum class BaseTableAttributeIndex
+{
+    Type = 0,
+    ReadOnly,
+    Name,
+    Description,
+    Path,
+    CurrentValue,
+    DefaultValue,
+    Options
+};
+
+using BaseTable = std::map<std::string, BaseTableAttribute>;
+
+inline void populateRedfishFromBaseTable(crow::Response& response,
+                                         const BaseTable& baseTable)
+{
+    nlohmann::json& attributes = response.jsonValue["Attributes"];
+    for (const auto& [name, baseTableAttribute] : baseTable)
+    {
+        bios_utils::addAttribute(
+            attributes, name,
+            std::get<uint(BaseTableAttributeIndex::Type)>(baseTableAttribute),
+            std::get<uint(BaseTableAttributeIndex::CurrentValue)>(
+                baseTableAttribute));
+    }
+}
+
+inline void handleBiosManagerObjectForGetBiosAttributes(
+    const std::shared_ptr<bmcweb::AsyncResp>& asyncResp,
+    const std::string& objectPath)
+{
+    bios_utils::getBIOSManagerProperty<BaseTable>(
+        asyncResp, "BaseBIOSTable", objectPath,
+        std::bind_front(populateRedfishFromBaseTable,
+                        std::ref(asyncResp->res)));
+}
+
+inline void getBiosAttributes(
+    const std::shared_ptr<bmcweb::AsyncResp>& asyncResp)
+{
+    bios_utils::getBIOSManagerObject(
+        asyncResp, std::bind_front(handleBiosManagerObjectForGetBiosAttributes,
+                                   asyncResp));
+}
+
 /**
  * BiosService class supports handle get method for bios.
  */
@@ -57,7 +119,13 @@ inline void handleBiosServiceGet(
     asyncResp->res.jsonValue["Actions"]["#Bios.ResetBios"]["target"] =
         std::format("/redfish/v1/Systems/{}/Bios/Actions/Bios.ResetBios",
                     BMCWEB_REDFISH_SYSTEM_URI_NAME);
-
+    dbus::utility::checkDbusPathExists(
+        "/xyz/openbmc_project/bios_config/manager", [asyncResp](int rc) {
+            if (rc > 0)
+            {
+                getBiosAttributes(asyncResp);
+            }
+        });
     // Get the ActiveSoftwareImage and SoftwareImages
     sw_util::populateSoftwareInformation(asyncResp, sw_util::biosPurpose, "",
                                          true);

--- a/redfish-core/lib/message_registries.hpp
+++ b/redfish-core/lib/message_registries.hpp
@@ -9,6 +9,7 @@
 #include "http_request.hpp"
 #include "query.hpp"
 #include "registries.hpp"
+#include "registries/bios_registry.hpp"
 #include "registries/privilege_registry.hpp"
 #include "registries_selector.hpp"
 
@@ -48,7 +49,7 @@ inline void handleMessageRegistryFileCollectionGet(
 
     static constexpr const auto registryFiles = std::to_array(
         {"Base", "TaskEvent", "ResourceEvent", "OpenBMC", "Telemetry",
-         "HeartbeatEvent"});
+         "HeartbeatEvent", "BiosAttributeRegistry"});
 
     for (const char* memberName : registryFiles)
     {
@@ -94,6 +95,10 @@ inline void handleMessageRoutesMessageRegistryFileGet(
     {
         dmtf.clear();
     }
+    else if (registry == "BiosAttributeRegistry")
+    {
+        dmtf.clear();
+    }
     const registries::Header& header = headerAndUrl->header;
     const char* url = headerAndUrl->url;
 
@@ -117,7 +122,7 @@ inline void handleMessageRoutesMessageRegistryFileGet(
     location["Language"] = header.language;
     location["Uri"] = "/redfish/v1/Registries/" + registry + "/" + registry;
 
-    if (url != nullptr)
+    if (url != nullptr && std::strlen(url) != 0)
     {
         location["PublicationUri"] = url;
     }
@@ -145,6 +150,11 @@ inline void handleMessageRegistryGet(
         return;
     }
 
+    if (registry == "BiosAttributeRegistry")
+    {
+        handleBiosAttributeRegistryGet(app, req, asyncResp);
+        return;	
+    }
     std::optional<registries::HeaderAndUrl> headerAndUrl =
         registries::getRegistryHeaderAndUrlFromPrefix(registry);
     if (!headerAndUrl)

--- a/redfish-core/src/redfish.cpp
+++ b/redfish-core/src/redfish.cpp
@@ -176,7 +176,9 @@ RedfishService::RedfishService(App& app)
     requestRoutesSystems(app);
     requestRoutesSystemActionsOemExecutePanelFunction(app);
 
+    //requestRoutesBiosAttributeRegistry(app);
     requestRoutesBiosService(app);
+    requestRoutesBiosSettings(app);
     requestRoutesBiosReset(app);
 
     if constexpr (BMCWEB_VM_NBDPROXY)


### PR DESCRIPTION
This commit adds:

redfish interface "/Registries/Bios" for BIOS Attribute Registry
redfish interface "/Systems/system/Bios/Settings" for BIOS settings
support for PATCH operation of the bios variables that updates the BaseBiosTable.
The upstream commit for the same is here:
https://gerrit.openbmc.org/c/openbmc/bmcweb/+/29670/
The above is the parent commit, & there are close to 5 commits in the commit chain.

Tested By:
[1] -X GET https://<bmc_ip>/redfish/v1/Systems/system/Bios
[2] -X GET https://<bmc_ip>/redfish/v1/Registries/BiosAttributeRegistry
[3] -X POST https://ip_addr/redfish/v1/Systems/system/Bios/Actions/Bios.ResetBios
[4] Single/Multiple Attributes:
-X PATCH https://${bmc}/redfish/v1/Systems/system/Bios/Settings -d
'{"Attributes":{:, ... ,
:}}'

 This makes use of the "Set" of "PendingAttributes" in the
 backend and that updates the BaseBiosTable.