### PR TITLE
AccountService: Restrict self-configure privilege

### DIFF
--- a/redfish-core/lib/account_service.hpp
+++ b/redfish-core/lib/account_service.hpp
@@ -2605,7 +2605,8 @@ inline void handleAccountPatch(
         redfish::getUserPrivileges(*req.session);
     Privileges configureUsers = {"ConfigureUsers"};
     bool userHasConfigureUsers =
-        effectiveUserPrivileges.isSupersetOf(configureUsers);
+        effectiveUserPrivileges.isSupersetOf(configureUsers) &&
+        !req.session->isConfigureSelfOnly;
     if (!userHasConfigureUsers)
     {
         // Irrespective of role can patch ACF if function


### PR DESCRIPTION
Restrict the admin user's privileges to only self-configuration when the session state is in self-configure mode. Currently, the admin can modify other users' information even when the admin session is in isConfigureSelfOnly mode, which appears to be incorrect. Eg:
1) Expire the admin user password
2) Login bmc with admin credentials
3) Password change required error is generated for the user

Expected after step 3

Admin should not be able to change any user information belonging to other users until they have changed their own password.

Observed after step 3

Admin was able to change other user's information before changing own password

Tested By:

1) Expire the admin password using passwd --expire 2) Change user name of other user  as below
```
patch /redfish/v1/AccountService/Accounts/newuser1 -d '{"UserName": "newuser2"}'
```
3) Observed response
```
{
  "error": {
    "@Message.ExtendedInfo": [
      {
        "@odata.type": "#Message.v1_1_1.Message",
        "Message": "There are insufficient privileges for the account or credentials associated with the current session to perform the requested operation.",
        "MessageArgs": [],
        "MessageId": "Base.1.19.InsufficientPrivilege",
        "MessageSeverity": "Critical",
        "Resolution": "Either abandon the operation or change the associated access rights and resubmit the request if the operation failed."
      }
    ],
    "code": "Base.1.19.InsufficientPrivilege",
    "message": "There are insufficient privileges for the account or credentials associated with the current session to perform the requested operation."
  }
}
```
4) Change the admin password
5) Do the step 2 above
6) Operation Resonded with Ok