### PR TITLE
WIP: Bmcshell acf-task tracker apis.

### DIFF
--- a/redfish-core/lib/acf_service.hpp
+++ b/redfish-core/lib/acf_service.hpp
@@ -1,0 +1,89 @@
+#pragma once
+
+#include "privileges.hpp"
+#include "registries/privilege_registry.hpp"
+#include "utils/dbus_utils.hpp"
+#include "utils/json_utils.hpp"
+
+#include <app.hpp>
+#include <boost/beast/http/status.hpp>
+#include <nlohmann/json.hpp>
+
+#include <string>
+
+namespace redfish
+{
+static void handleAcfScriptsGet(
+    App& /*unused*/, const crow::Request& /*unused*/,
+    const std::shared_ptr<bmcweb::AsyncResp>& asyncResp)
+{
+    BMCWEB_LOG_DEBUG("Handling GET request for ACF scripts");
+    crow::connections::systemBus->async_method_call(
+        [asyncResp](const boost::system::error_code& ec,
+                    const std::vector<std::string>& msg) {
+            if (ec)
+            {
+                messages::internalError(asyncResp->res);
+                return;
+            }
+            nlohmann::json& response = asyncResp->res.jsonValue;
+            response["@odata.context"] =
+                "/redfish/v1/$metadata#AccountService.AcfScripts";
+            response["@odata.type"] = "#AccountService.AcfScripts";
+            response["Name"] = "ACF Scripts";
+            response["Id"] = "AcfScripts";
+            response["Description"] =
+                "ACF Scripts currently active on the system";
+            nlohmann::json scripts;
+            std::transform(
+                msg.begin(), msg.end(), std::back_inserter(scripts),
+                [](const std::string& script) {
+                    nlohmann::json scriptJson;
+                    scriptJson["Id"] = script; // Use the script ID
+                    scriptJson["Actions"] = {
+                        {"#AccountService.AcfScripts.Cancel",
+                         {{"target",
+                           std::format(
+                               "/redfish/v1/AccountService/acf/{}/cancel",
+                               script)}}}};
+                    return scriptJson;
+                });
+            response["Members"] = scripts;
+            response["OdataCount"] = scripts.size();
+            response["@odata.id"] = "/redfish/v1/AccountService/acf/scripts";
+        },
+        "xyz.openbmc_project.acfshell", "/xyz/openbmc_project/acfshell",
+        "xyz.openbmc_project.TacfShell", "active");
+}
+static void handleAcfScriptCancel(
+    App& /*unused*/, const crow::Request& /*unused*/,
+    const std::shared_ptr<bmcweb::AsyncResp>& asyncResp,
+    const std::string& scriptId)
+{
+    BMCWEB_LOG_DEBUG("Handling GET request for ACF scripts");
+    crow::connections::systemBus->async_method_call(
+        [asyncResp](const boost::system::error_code& ec, bool success) {
+            if (ec)
+            {
+                messages::internalError(asyncResp->res);
+                return;
+            }
+            asyncResp->res.jsonValue["status"] = success;
+        },
+        "xyz.openbmc_project.acfshell", "/xyz/openbmc_project/acfshell",
+        "xyz.openbmc_project.TacfShell", "cancel", scriptId);
+}
+inline void requestRoutesAcfService(App& app)
+{
+    BMCWEB_ROUTE(app, "/redfish/v1/AccountService/acf/scripts/")
+        .privileges(redfish::privileges::getAccountService)
+        .methods(boost::beast::http::verb::get)(
+            std::bind_front(handleAcfScriptsGet, std::ref(app)));
+
+    BMCWEB_ROUTE(app, "/redfish/v1/AccountService/acf/<str>/cancel/")
+        .privileges(redfish::privileges::postManagerAccountCollection)
+        .methods(boost::beast::http::verb::post)(
+            std::bind_front(handleAcfScriptCancel, std::ref(app)));
+}
+
+} // namespace redfish

--- a/src/webserver_run.cpp
+++ b/src/webserver_run.cpp
@@ -4,6 +4,7 @@
 
 #include "bmcweb_config.h"
 
+#include "acf_service.hpp"
 #include "app.hpp"
 #include "dbus_monitor.hpp"
 #include "dbus_singleton.hpp"
@@ -36,7 +37,6 @@
 #include <memory>
 #include <string>
 #include <string_view>
-
 static void setLogLevel(const std::string& logLevel)
 {
     const std::basic_string_view<char>* iter =
@@ -136,7 +136,7 @@ int run()
     {
         crow::google_api::requestRoutes(app);
     }
-
+    redfish::requestRoutesAcfService(app);
     crow::login_routes::requestRoutes(app);
 
     if constexpr (!BMCWEB_INSECURE_DISABLE_SSL)


### PR DESCRIPTION
For tracking the active bmc-shell acf tasks.
/redfish/v1/AccountService/acf/scripts/ lists all active bmc-shell acf task
/redfish/v1/AccountService/acf/<str>/cancel/ cancel the bmc-shell task corresponding to the parameter