### PR TITLE
1120: Consume availability interface for cores (#991)

### DIFF
--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -3,7 +3,7 @@
     "files": "^.secrets.baseline$",
     "lines": null
   },
-  "generated_at": "2025-04-01T18:32:39Z",
+  "generated_at": "2025-06-02T14:01:02Z",
   "plugins_used": [
     {
       "name": "AWSKeyDetector"
@@ -77,12 +77,22 @@
     }
   ],
   "results": {
+    ".clang-tidy": [
+      {
+        "hashed_secret": "c2e65a9f52c1af500164be8fa5ddab44aa63676c",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 400,
+        "type": "IBM Cloud IAM Key",
+        "verified_result": null
+      }
+    ],
     "config/meson.build": [
       {
         "hashed_secret": "66a36e77fd002579809717841f998f4d21cd5913",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 147,
+        "line_number": 154,
         "type": "Secret Keyword",
         "verified_result": null
       }
@@ -92,7 +102,7 @@
         "hashed_secret": "a5d8d6626c0903f7050f795ace6c3e11ce03a03e",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 401,
+        "line_number": 101,
         "type": "Base64 High Entropy String",
         "verified_result": null
       }
@@ -130,7 +140,7 @@
         "hashed_secret": "126bdaffcfebda9cc80cd50862e689c700ba1ce3",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 267,
+        "line_number": 347,
         "type": "Secret Keyword",
         "verified_result": null
       }
@@ -182,7 +192,7 @@
         "hashed_secret": "5ef4ffb79f46bdb334115d166dd092402bdf6c13",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 1505,
+        "line_number": 1687,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -190,7 +200,7 @@
         "hashed_secret": "6e069300b0db722cc2ad4b1425a30ff5a8ae20cf",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 2196,
+        "line_number": 2388,
         "type": "Secret Keyword",
         "verified_result": null
       }
@@ -230,7 +240,7 @@
         "hashed_secret": "6e069300b0db722cc2ad4b1425a30ff5a8ae20cf",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 2835,
+        "line_number": 2299,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -238,7 +248,7 @@
         "hashed_secret": "efb7b9c519415e44a5f30819aaa9bf534f6afb27",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 2851,
+        "line_number": 2315,
         "type": "Secret Keyword",
         "verified_result": null
       }


### PR DESCRIPTION
In the current state, the logic is bmcweb for displaying cores is: It checks the Present property on core dbus object to update the [Status][State] as Enabled/Absent.

In addition to Present property, we should also use the Available property , if the Available is false, then set the [Status][State] should be set as "UnavailableOffline".

Refer: ibm-openbmc/dev#3481