### PR TITLE
1050: Fix coredump on  PCIe Topology Refresh (#1307)

### DIFF
--- a/redfish-core/lib/oem/ibm/pcie_topology_refresh.hpp
+++ b/redfish-core/lib/oem/ibm/pcie_topology_refresh.hpp
@@ -105,7 +105,7 @@ inline void
 {
     BMCWEB_LOG_DEBUG << "Set PCIe Topology Refresh status.";
     crow::connections::systemBus->async_method_call(
-        [&req, aResp](const boost::system::error_code ec) {
+        [req, aResp](const boost::system::error_code ec) {
         if (ec)
         {
             BMCWEB_LOG_DEBUG << "PCIe Topology Refresh failed." << ec;


### PR DESCRIPTION
#### Fix coredump on  PCIe Topology Refresh (#1307)
```
Due to improper lambda capture `&req` [1], its reference inside the
async_method_call later may potentially become invalid if `req` is
already removed. This may cause the coredump of bmcweb at

````
    BMCWEB_LOG_DEBUG << "Set PCIe Topology Refresh status.";
    crow::connections::systemBus->async_method_call(
        [&req, aResp](const boost::system::error_code ec) {
        ...
        pcieTopologyRefreshTimer =
            std::make_unique<boost::asio::steady_timer>(*req.ioService);
        ...
```

The fix is to capture `req` as value so that `req` should be valid
inside the callback.
```
-        [&req, asyncResp](const boost::system::error_code& ec) {
+        [req, asyncResp](const boost::system::error_code& ec) {
```

Tested:
- Try setPCIeTopologRefresh multiple times without coredumps
```
curl -k -H "Content-Type: application/json" -X PATCH https://${bmc}/redfish/v1/Systems/system/ -d '{"Oem":{"IBM":{"PCIeTopologyRefresh":true}}}'
```

[1] https://github.com/ibm-openbmc/bmcweb/blob/2a42b4b15776e5f6e4777b856c59d0e5c34c7f1e/redfish-core/lib/oem/ibm/pcie_topology_refresh.hpp#L108

Signed-off-by: Myung Bae <myungbae@us.ibm.com>```