### PR TITLE
1120: Help recover in DOS attack

### DIFF
--- a/http/http_connection.hpp
+++ b/http/http_connection.hpp
@@ -637,19 +637,9 @@ class Connection :
                 doWrite();
                 return;
             }
-            if (ec == boost::beast::http::error::end_of_stream ||
-                ec == boost::asio::ssl::error::stream_truncated)
-            {
-                BMCWEB_LOG_WARNING("{} End of stream, closing {}", logPtr(this),
-                                   ec);
-                hardClose();
-                return;
-            }
-
-            BMCWEB_LOG_DEBUG("{} Closing socket due to read error {}",
-                             logPtr(this), ec.message());
-            gracefulClose();
-
+            BMCWEB_LOG_WARNING("{} End of stream, closing {}", logPtr(this),
+                               ec);
+            hardClose();
             return;
         }
 
@@ -741,17 +731,10 @@ class Connection :
                 }
                 return;
             }
+            BMCWEB_LOG_WARNING("{} End of stream, closing {}", logPtr(this),
+                               ec);
+            hardClose();
 
-            if (ec == boost::beast::http::error::end_of_stream ||
-                ec == boost::asio::ssl::error::stream_truncated)
-            {
-                BMCWEB_LOG_WARNING("{} End of stream, closing {}", logPtr(this),
-                                   ec);
-                hardClose();
-                return;
-            }
-
-            gracefulClose();
             return;
         }
 

--- a/http/http_connection.hpp
+++ b/http/http_connection.hpp
@@ -22,6 +22,7 @@
 
 #include <boost/asio/error.hpp>
 #include <boost/asio/ip/tcp.hpp>
+#include <boost/asio/ssl/error.hpp>
 #include <boost/asio/ssl/stream.hpp>
 #include <boost/asio/ssl/stream_base.hpp>
 #include <boost/asio/ssl/verify_context.hpp>
@@ -636,7 +637,8 @@ class Connection :
                 doWrite();
                 return;
             }
-            if (ec == boost::beast::http::error::end_of_stream)
+            if (ec == boost::beast::http::error::end_of_stream ||
+                ec == boost::asio::ssl::error::stream_truncated)
             {
                 BMCWEB_LOG_WARNING("{} End of stream, closing {}", logPtr(this),
                                    ec);
@@ -740,6 +742,15 @@ class Connection :
                 return;
             }
 
+            if (ec == boost::beast::http::error::end_of_stream ||
+                ec == boost::asio::ssl::error::stream_truncated)
+            {
+                BMCWEB_LOG_WARNING("{} End of stream, closing {}", logPtr(this),
+                                   ec);
+                hardClose();
+                return;
+            }
+
             gracefulClose();
             return;
         }
@@ -807,6 +818,16 @@ class Connection :
             doWrite();
             return;
         }
+
+        if (ec == boost::beast::http::error::end_of_stream ||
+            ec == boost::asio::ssl::error::stream_truncated)
+        {
+            BMCWEB_LOG_WARNING("{} End of stream, closing {}", logPtr(this),
+                               ec);
+            hardClose();
+            return;
+        }
+
         if (ec)
         {
             BMCWEB_LOG_DEBUG("{} from write(2)", logPtr(this));


### PR DESCRIPTION
Upstream is https://gerrit.openbmc.org/c/openbmc/bmcweb/+/80819 and https://gerrit.openbmc.org/c/openbmc/bmcweb/+/80839 and has merged. The DOS attack we are helping clear up is coming from the HMC.  2 commits: 

1) Fix DOS attack scenario

Problem : When 201 connections made in parallel to BMC and closed them immediately without properly sending a close_notify alert it was observed that Bmcweb server was taking several minutes to close the sockets. All the 200 TCP sockets were in CLOSE_WAIT state.

Journal log shows below line
[CRITICAL http_connection.hpp:213] 0x29d1ef0Max connection count exceeded.

Not able to make new connection

```
$ curl -k -H "X-Auth-Token:$bmc_token"  -X GET https://${BMC_IP}/redfish
/v1/AccountService/Accounts
curl: (35) OpenSSL SSL_connect: SSL_ERROR_SYSCALL in connection to
127.0.0.1:2443
```

Fix : The bmcweb server failed to identify the end of stream at TCP (SSL
/TLS) layer, therefore added check to identify the end of stream which
closes the connection and socket

Change-Id: I1c277db0b774d33c656b4a2b1bd14f3575535bec

2) Do hard close if client disobeys protocol 

Do hard close if client disobeys protocol

There are cases bmcweb might close the connection due to a violation of
the protocol.  Currently these are done gracefully, under the assumption
that a client might attempt to recover.  But this opens us up to
potentially leaving sockets open for far longer than we intend if the
client is completely gone, due to a disconnect or explicitly closing the
socket hard.

In cases where we get a protocol error, shutdown the socket hard, rather
than attempt to do things "correctly".

Tested:

I tested this MR using a script that simulated 5,000 parallel
connections simultaneously to BMC and closed them immediately without
properly sending a close_notify alert

Observations:

The BMC became unresponsive for 30-40 seconds before recovering.

After recovery, it took approximately 90 seconds to close all
connections in QEMU.
On real hardware, connection closure times may be slightly higher
(though still within expected parameters).

Conclusion:
This behavior aligns with expectations.

After 90 seconds observed that

1) No sockets in CLOSE_WAIT state

2) Able to make new connection.

```

curl -k -H "X-Auth-Token:$bmc_token" https://${ip}/redfish/v1/AccountService/Accounts
{
  "@odata.id": "/redfish/v1/AccountService/Accounts",
  "@odata.type": "#ManagerAccountCollection.ManagerAccountCollection",
  "Description": "BMC User Accounts",
  "Members": [
    {
      "@odata.id": "/redfish/v1/AccountService/Accounts/root"
    }
  ],
  "Members@odata.count": 1,
  "Name": "Accounts Collection"
}

```
Change-Id: I6ab4347efd8fda9ae86bfbb8575666ad3eabe88c
Signed-off-by: Ed Tanous <etanous@nvidia.com>
Signed-off-by: Chandramohan Harkude <chandramohan.harkude@gmail.com>