### PR TITLE
1120: Show websocket timeout log as WARNING

### DIFF
--- a/http/websocket_impl.hpp
+++ b/http/websocket_impl.hpp
@@ -252,9 +252,13 @@ class ConnectionImpl : public Connection
                                     size_t bytesRead) {
             if (ec)
             {
-                if (ec != boost::beast::websocket::error::closed &&
-                    ec != boost::asio::error::eof &&
-                    ec != boost::asio::ssl::error::stream_truncated)
+                if (ec == boost::beast::error::timeout)
+                {
+                    BMCWEB_LOG_WARNING("doRead timeout: {}", ec);
+                }
+                else if (ec != boost::beast::websocket::error::closed &&
+                         ec != boost::asio::error::eof &&
+                         ec != boost::asio::ssl::error::stream_truncated)
                 {
                     BMCWEB_LOG_ERROR("doRead error {}", ec);
                 }


### PR DESCRIPTION
When websocket is closed due to a timeout under some situations like GUI
console not as responsive, itis currently logged as ERROR.
This commit changes it as WARNING.

```
May 02 10:09:31 ever28bmc pldmd[836]: BIOS attribute 'hb_cap_freq_mhz_min' updated to value '2000' by BMC 'false'
May 02 10:09:31 ever28bmc pldmd[836]: BIOS attribute 'hb_cap_freq_mhz_max' updated to value '3900' by BMC 'false'
May 02 10:09:31 ever28bmc bmcweb[1100]: [ERROR websocket.hpp:268] doRead error The socket was closed due to a timeout [boost.beast:1 at /usr/include/boost/beast/websocket/impl/stream_impl.hpp:346:13 in function 'bool boost::beast::websocket::stream< <template-parameter-1-1>, <anonymous> >::impl_type::check_stop_now(boost::beast::error_code&)']
May 02 10:09:34 ever28bmc pldmd[836]: BIOS attribute 'hb_max_number_huge_pages' updated to value '64' by BMC 'false'
```

Tested:
- Load GUI pages and kill web-browser multiple times while reading BMC journal records.

Change-Id: I7e15845be7d3762ef144744ca1aedadf96e43a2f