### PR TITLE
Fix IPv4 Static IP config with same DHCP gateway

### DIFF
--- a/redfish-core/lib/ethernet.hpp
+++ b/redfish-core/lib/ethernet.hpp
@@ -1726,12 +1726,7 @@ inline void handleIPv4StaticPatch(
         }
     }
 
-    // now update to the new gateway.
-    // Default gateway is already empty, so no need to update if we're clearing
-    if (!gatewayOut.empty() && ethData.defaultGateway != gatewayOut)
-    {
-        updateIPv4DefaultGateway(ifaceId, gatewayOut, asyncResp);
-    }
+    updateIPv4DefaultGateway(ifaceId, gatewayOut, asyncResp);
 }
 
 inline void handleStaticNameServersPatch(


### PR DESCRIPTION
This commit avoids same gateway check while setting gateway. While DHCP gateway already configured on the interface,then moving to static configuration with the same DHCP gateway fails to set.

This is commit needed to support switching from DHCP to static

Tested By:
Configure DHCP on interface
Configure Static IPv4 address with same dhcp gateway