### PR TITLE
1120: Fix invalid dereference on logging

### DIFF
--- a/http/logging.hpp
+++ b/http/logging.hpp
@@ -66,7 +66,7 @@ constexpr int toSystemdLevel(LogLevel level)
         });
 
     // Unknown log level.  Just assume debug
-    if (it != mapping.end())
+    if (it == mapping.end())
     {
         return 6;
     }


### PR DESCRIPTION
cppcheck found a case which dereferences an invalid iterator like

```
http/logging.hpp:74:12: warning: Either the condition 'it!=mapping.end()' is redundant or there is possible dereference of an invalid iterator: it. [derefInvalidIteratorRedundantCheck]
    return it->second;
http/logging.hpp:69:12: note: Assuming that condition 'it!=mapping.end()' is not redundant
    if (it != mapping.end())
           ^
http/logging.hpp:74:12: note: Dereference of an invalid iterator
    return it->second;
           ^
```

Tested:
- Tries a various bmcweb loglevel.

Change-Id: Ieca8c5c5ee83f0b45a82c3d7e4f19b09bf1422e6