### PR TITLE
1120 Trace URI on CRITICAL message Response

### DIFF
--- a/http/http2_connection.hpp
+++ b/http/http2_connection.hpp
@@ -28,6 +28,7 @@
 #include <boost/beast/http/verb.hpp>
 #include <boost/optional/optional.hpp>
 #include <boost/system/error_code.hpp>
+#include <boost/url/url_view.hpp>
 
 #include <array>
 #include <bit>
@@ -207,7 +208,12 @@ class HTTP2Connection :
 
         completeResponseFields(stream.accept, res);
         res.addHeader(boost::beast::http::field::date, getCachedDateStr());
-        res.preparePayload();
+        boost::urls::url_view urlView;
+        if (stream.req != nullptr)
+        {
+            urlView = stream.req->url();
+        }
+        res.preparePayload(urlView);
 
         boost::beast::http::fields& fields = res.fields();
         std::string code = std::to_string(res.resultInt());

--- a/http/http_connection.hpp
+++ b/http/http_connection.hpp
@@ -41,6 +41,7 @@
 #include <boost/beast/http/verb.hpp>
 #include <boost/none.hpp>
 #include <boost/optional/optional.hpp>
+#include <boost/url/url_view.hpp>
 
 #include <bit>
 #include <chrono>
@@ -849,7 +850,13 @@ class Connection :
     void doWrite()
     {
         BMCWEB_LOG_DEBUG("{} doWrite", logPtr(this));
-        res.preparePayload();
+
+        boost::urls::url_view urlView;
+        if (req != nullptr)
+        {
+            urlView = req->url();
+        }
+        res.preparePayload(urlView);
 
         startDeadline();
         if (httpType == HttpType::HTTP)

--- a/http/http_response.hpp
+++ b/http/http_response.hpp
@@ -13,6 +13,7 @@
 #include <boost/beast/http/fields.hpp>
 #include <boost/beast/http/message.hpp>
 #include <boost/beast/http/status.hpp>
+#include <boost/url/url_view.hpp>
 #include <nlohmann/json.hpp>
 
 #include <cstddef>
@@ -186,10 +187,8 @@ struct Response
         return response.body().payloadSize();
     }
 
-    void preparePayload()
+    void preparePayload(const boost::urls::url_view& urlView)
     {
-        // This code is a throw-free equivalent to
-        // beast::http::message::prepare_payload
         std::optional<uint64_t> pSize = response.body().payloadSize();
 
         using http::status;
@@ -209,8 +208,8 @@ struct Response
         {
             BMCWEB_LOG_CRITICAL("{} Response content provided but code was "
                                 "no-content or not_modified, which aren't "
-                                "allowed to have a body",
-                                logPtr(this));
+                                "allowed to have a body for url : \"{}\"",
+                                logPtr(this), urlView.path());
             response.content_length(0);
             return;
         }


### PR DESCRIPTION
Trace URI on CRITICAL message Response content provided but code was no-content or not_modified.