### PR TITLE
1050: Fix missing updates for clang16

### DIFF
--- a/redfish-core/include/utils/hex_utils.hpp
+++ b/redfish-core/include/utils/hex_utils.hpp
@@ -43,11 +43,11 @@ inline uint8_t hexCharToNibble(char ch)
     }
     else if (ch >= 'A' && ch <= 'F')
     {
-        rc = static_cast<uint8_t>(ch) - 'A' + 10;
+        rc = static_cast<uint8_t>(ch - 'A') + 10U;
     }
     else if (ch >= 'a' && ch <= 'f')
     {
-        rc = static_cast<uint8_t>(ch) - 'a' + 10;
+        rc = static_cast<uint8_t>(ch - 'a') + 10U;
     }
 
     return rc;

--- a/test/redfish-core/include/utils/hex_utils_test.cpp
+++ b/test/redfish-core/include/utils/hex_utils_test.cpp
@@ -54,11 +54,11 @@ TEST(HexCharToNibble, ReturnsCorrectNibbleForEveryHexChar)
         }
         else if (c >= 'A' && c <= 'F')
         {
-            expected = static_cast<uint8_t>(c) - 'A' + 10;
+            expected = static_cast<uint8_t>(c - 'A') + 10U;
         }
         else if (c >= 'a' && c <= 'f')
         {
-            expected = static_cast<uint8_t>(c) - 'a' + 10;
+            expected = static_cast<uint8_t>(c - 'a') + 10U;
         }
 
         EXPECT_EQ(hexCharToNibble(c), expected);

--- a/test/redfish-core/include/utils/json_utils_test.cpp
+++ b/test/redfish-core/include/utils/json_utils_test.cpp
@@ -121,7 +121,8 @@ TEST(ReadJson, JsonArrayAreUnpackedCorrectly)
     ASSERT_TRUE(readJson(jsonRequest, res, "TestJson", jsonVec));
     EXPECT_EQ(res.result(), boost::beast::http::status::ok);
     EXPECT_THAT(res.jsonValue, IsEmpty());
-    EXPECT_EQ(jsonVec, R"([{"hello": "yes"}, [{"there": "no"}, "nice"]])"_json);
+    EXPECT_THAT(jsonVec, ElementsAre(R"({"hello": "yes"})"_json,
+                                     R"([{"there": "no"}, "nice"])"_json));
 }
 
 TEST(ReadJson, JsonSubElementValueAreUnpackedCorrectly)


### PR DESCRIPTION
The commit [1] updated bmcweb for clang16, but missed a few more. This fixes those to pass CI.

Tested:
- Run CI to pass

[1] https://github.com/ibm-openbmc/bmcweb/pull/687/commits/aeaeb33ec2e7e7dd4473e64d88ea90ee0bee757d