### PR TITLE
1120: Enhance FFDC log traces related to PCIe associations

### DIFF
--- a/redfish-core/lib/pcie.hpp
+++ b/redfish-core/lib/pcie.hpp
@@ -179,14 +179,20 @@ inline void afterAddLinkToPCIeSlot(
             // This PCIeSlot has no chassis association.
             return;
         }
-        BMCWEB_LOG_ERROR("DBUS response ec={} for slot path={}", ec.value(),
+        BMCWEB_LOG_ERROR("DBUS response ec={} for slot path={}", ec,
                          pcieDeviceSlot);
         messages::internalError(asyncResp->res);
         return;
     }
     if (chassisPaths.size() != 1)
     {
-        BMCWEB_LOG_ERROR("PCIe Slot association error! ");
+        BMCWEB_LOG_ERROR(
+            "Association error for PCIeSlot:{} to chassis error. Its association count:{} is not equal to 1.",
+            pcieDeviceSlot, chassisPaths.size());
+        for (const auto& chassisPath : chassisPaths)
+        {
+            BMCWEB_LOG_ERROR("Invalid chassisPath: {}", chassisPath);
+        }
         messages::internalError(asyncResp->res);
         return;
     }

--- a/redfish-core/lib/pcie.hpp
+++ b/redfish-core/lib/pcie.hpp
@@ -390,6 +390,10 @@ inline void getPCIeDeviceSlotPath(
                 BMCWEB_LOG_ERROR(
                     "PCIeDevice {} is associated with more than one PCIeSlot: {}",
                     pcieDevicePath, endpoints.size());
+                for (const std::string& slotPath : endpoints)
+                {
+                    BMCWEB_LOG_ERROR("Invalid PCIeSlotPath: {}", slotPath);
+                }
                 messages::internalError(asyncResp->res);
                 return;
             }

--- a/redfish-core/lib/processor.hpp
+++ b/redfish-core/lib/processor.hpp
@@ -296,7 +296,7 @@ inline void getCpuDataByService(
             const dbus::utility::ManagedObjectType& dbusData) {
             if (ec)
             {
-                BMCWEB_LOG_DEBUG("DBUS response error");
+                BMCWEB_LOG_ERROR("DBUS response error, ec:", ec);
                 messages::internalError(asyncResp->res);
                 return;
             }


### PR DESCRIPTION
PCIe topology may show an empty page or entry due to the association error between pcie slot or device to chassis.

However, bmcweb log entries do not show the related dbus object paths or it shows only the error number.
This causes the difficulity of knowing the incorrect associations.

For example, journal shows like

```
Feb 21 15:14:13 p10bmc bmcweb[1135]: [ERROR processor.hpp:1074] DBUS response error, ec: 110
```
This may be ETIMEDOUT but it would be clearer if the log says `generic:110`.

```
Feb 21 15:14:30 p10bmc bmcweb[1135]: [ERROR pcie.hpp:224] PCIe Slot association error!
Feb 21 15:14:30 p10bmc bmcweb[1135]: [CRITICAL error_messages.cpp:287] Internal Error /usr/src/debug/bmcweb/1.0+git/redfish-core/lib/pcie.hpp(225:32) `void redfish::afterAddLinkToPCIeSlot(const std::shared_ptr<bmcweb::AsyncResp>&, const boost::system::error_code&, const dbus::utility::MapperEndPoints&)`:
```

This commit is to enhance ffdc log traces to show dbus object paths if the association is in error.

The areas of the changes are:
- the association error between pcie device to chassis
- the association error between pcie device to pcieSlot
- the association error between fabric adapter to chassis
- the association error between pcieslot to chassis

Tested:
- Redfish Service Validator runs and passes