### PR TITLE
1120 EventService: Fix Redfish Validator error

### DIFF
--- a/redfish-core/include/snmp_trap_event_clients.hpp
+++ b/redfish-core/include/snmp_trap_event_clients.hpp
@@ -79,6 +79,11 @@ inline void getSnmpTrapClientdata(
     asyncResp->res.jsonValue["EventFormatType"] =
         event_destination::EventFormatType::Event;
 
+    /* Context is required Redfish field,
+     * but SNMP backend doesn't support a context string.
+     */
+    asyncResp->res.jsonValue["Context"] = "";
+
     dbus::utility::getAllProperties(
         "xyz.openbmc_project.Network.SNMP", objectPath,
         "xyz.openbmc_project.Network.Client",


### PR DESCRIPTION
Cherry-pick of merged upstream commit: https://gerrit.openbmc.org/c/openbmc/bmcweb/+/81100

The Redfish Validator fails when there is a SNMPTrap type of subscription. The Context property is a required property and is missing for these types of subscriptions.

```
VERBOSE1 - Context
VERBOSE1 -      value: n/a <class 'str'>
VERBOSE1 -      Mandatory Test: FAIL
VERBOSE1 -      FAIL
ERROR - Context: Mandatory prop does not exist

VERBOSE1 - EventDestination.v1_8_0.EventDestination, Counter({'skipOptional': 15, 'pass': 6, 'passGet': 1, 'passRedfishUri': 1, 'err.Edm.String': 1, 'failMandatoryExist': 1})

curl -s https://redfish.dmtf.org/schemas/v1/EventDestination.v1_8_0.jso | jq .definitions.EventDestination.required
[
  "Context",
  "@odata.id",
  "@odata.type",
  "Id",
  "Name",
  "SubscriptionType"
]

Body Response of /redfish/v1/EventService/Subscriptions/snmp1:
{
    "@odata.id": "/redfish/v1/EventService/Subscriptions/snmp1",
    "@odata.type": "#EventDestination.v1_8_0.EventDestination",
    "Destination": "snmp://X.XX.XXX.XX:XXX",
    "EventFormatType": "Event",
    "Id": "snmp1",
    "Name": "Event Destination",
    "Protocol": "SNMPv2c",
    "SubscriptionType": "SNMPTrap"
}
```

The Context used to be part of the response for these subscriptions. It was removed by the commit 4b712a29 [1]. It was removed since the code
was incorrect. The SNMP backend owns the subscription not bmcweb.
    
The SNMP backend does not support context, so setting the Redfish
Context property to an empty string so the validator will pass.

Tested:
 - Redfish Service Validator passes
```
Body Response of /redfish/v1/EventService/Subscriptions/snmp1:
{
    "@odata.id": "/redfish/v1/EventService/Subscriptions/snmp1",
    "@odata.type": "#EventDestination.v1_8_0.EventDestination",
    "Context": "",
    "Destination": "snmp://X.XX.XXX.XX:XXX",
    "EventFormatType": "Event",
    "Id": "snmp1",
    "Name": "Event Destination",
    "Protocol": "SNMPv2c",
    "SubscriptionType": "SNMPTrap"
}

INFO -
*** /redfish/v1/EventService/Subscriptions/snmp1

...

VERBOSE1 - Context
VERBOSE1 -      value:  <class 'str'>
VERBOSE1 -      Mandatory Test: OK
DEBUG - (Edm.String, '', 'Edm.String', 'Property', 'Edm.String')
VERBOSE1 -      Success

...

VERBOSE1 - ServiceRoot -> EventService -> Subscriptions -> Members#0, EventDestination.v1_8_0, EventDestination
VERBOSE1 - @odata.id                                               PASS
VERBOSE1 - @odata.type                                             PASS
VERBOSE1 - Context                                                 PASS

...

VERBOSE1 - EventDestination.v1_8_0.EventDestination, Counter({'skipOptional': 15, 'pass': 7, 'passGet': 1, 'passRedfishUri': 1})

...

INFO - Validation has succeeded.
```

[1] https://gerrit.openbmc.org/c/openbmc/bmcweb/+/65720
[2] https://github.com/openbmc/bmcweb/blob/0a8823b0c27b8124018c8b084976ae350ae5cf7f/redfish-core/lib/event_service.hpp#L946


Change-Id: I0431e390ea98e9927207e30df220465d882e84cd