### PR TITLE
1120: Ship and install all schemas (#910)

### DIFF
--- a/redfish-core/schema/dmtf/installed/AccelerationFunctionCollection_v1.xml
+++ b/redfish-core/schema/dmtf/installed/AccelerationFunctionCollection_v1.xml
@@ -1,0 +1,1 @@
+../csdl/AccelerationFunctionCollection_v1.xml

--- a/redfish-core/schema/dmtf/installed/AccelerationFunction_v1.xml
+++ b/redfish-core/schema/dmtf/installed/AccelerationFunction_v1.xml
@@ -1,0 +1,1 @@
+../csdl/AccelerationFunction_v1.xml

--- a/redfish-core/schema/dmtf/installed/AccountService_v1.xml
+++ b/redfish-core/schema/dmtf/installed/AccountService_v1.xml
@@ -1,1 +1,1 @@
-../../../../redfish-core/schema/dmtf/csdl/AccountService_v1.xml
+../csdl/AccountService_v1.xml

--- a/redfish-core/schema/dmtf/installed/ActionInfo_v1.xml
+++ b/redfish-core/schema/dmtf/installed/ActionInfo_v1.xml
@@ -1,1 +1,1 @@
-../../../../redfish-core/schema/dmtf/csdl/ActionInfo_v1.xml
+../csdl/ActionInfo_v1.xml

--- a/redfish-core/schema/dmtf/installed/AddressPoolCollection_v1.xml
+++ b/redfish-core/schema/dmtf/installed/AddressPoolCollection_v1.xml
@@ -1,0 +1,1 @@
+../csdl/AddressPoolCollection_v1.xml

--- a/redfish-core/schema/dmtf/installed/AddressPool_v1.xml
+++ b/redfish-core/schema/dmtf/installed/AddressPool_v1.xml
@@ -1,0 +1,1 @@
+../csdl/AddressPool_v1.xml

--- a/redfish-core/schema/dmtf/installed/AggregateCollection_v1.xml
+++ b/redfish-core/schema/dmtf/installed/AggregateCollection_v1.xml
@@ -1,0 +1,1 @@
+../csdl/AggregateCollection_v1.xml

--- a/redfish-core/schema/dmtf/installed/Aggregate_v1.xml
+++ b/redfish-core/schema/dmtf/installed/Aggregate_v1.xml
@@ -1,0 +1,1 @@
+../csdl/Aggregate_v1.xml

--- a/redfish-core/schema/dmtf/installed/AggregationService_v1.xml
+++ b/redfish-core/schema/dmtf/installed/AggregationService_v1.xml
@@ -1,1 +1,1 @@
-../../../../redfish-core/schema/dmtf/csdl/AggregationService_v1.xml
+../csdl/AggregationService_v1.xml

--- a/redfish-core/schema/dmtf/installed/AggregationSourceCollection_v1.xml
+++ b/redfish-core/schema/dmtf/installed/AggregationSourceCollection_v1.xml
@@ -1,1 +1,1 @@
-../../../../redfish-core/schema/dmtf/csdl/AggregationSourceCollection_v1.xml
+../csdl/AggregationSourceCollection_v1.xml

--- a/redfish-core/schema/dmtf/installed/AggregationSource_v1.xml
+++ b/redfish-core/schema/dmtf/installed/AggregationSource_v1.xml
@@ -1,1 +1,1 @@
-../../../../redfish-core/schema/dmtf/csdl/AggregationSource_v1.xml
+../csdl/AggregationSource_v1.xml

--- a/redfish-core/schema/dmtf/installed/AllowDenyCollection_v1.xml
+++ b/redfish-core/schema/dmtf/installed/AllowDenyCollection_v1.xml
@@ -1,0 +1,1 @@
+../csdl/AllowDenyCollection_v1.xml

--- a/redfish-core/schema/dmtf/installed/AllowDeny_v1.xml
+++ b/redfish-core/schema/dmtf/installed/AllowDeny_v1.xml
@@ -1,0 +1,1 @@
+../csdl/AllowDeny_v1.xml

--- a/redfish-core/schema/dmtf/installed/ApplicationCollection_v1.xml
+++ b/redfish-core/schema/dmtf/installed/ApplicationCollection_v1.xml
@@ -1,0 +1,1 @@
+../csdl/ApplicationCollection_v1.xml

--- a/redfish-core/schema/dmtf/installed/Application_v1.xml
+++ b/redfish-core/schema/dmtf/installed/Application_v1.xml
@@ -1,0 +1,1 @@
+../csdl/Application_v1.xml

--- a/redfish-core/schema/dmtf/installed/Assembly_v1.xml
+++ b/redfish-core/schema/dmtf/installed/Assembly_v1.xml
@@ -1,1 +1,1 @@
-../../../../redfish-core/schema/dmtf/csdl/Assembly_v1.xml
+../csdl/Assembly_v1.xml

--- a/redfish-core/schema/dmtf/installed/AttributeRegistry_v1.xml
+++ b/redfish-core/schema/dmtf/installed/AttributeRegistry_v1.xml
@@ -1,1 +1,1 @@
-../../../../redfish-core/schema/dmtf/csdl/AttributeRegistry_v1.xml
+../csdl/AttributeRegistry_v1.xml

--- a/redfish-core/schema/dmtf/installed/AutomationInstrumentation_v1.xml
+++ b/redfish-core/schema/dmtf/installed/AutomationInstrumentation_v1.xml
@@ -1,0 +1,1 @@
+../csdl/AutomationInstrumentation_v1.xml

--- a/redfish-core/schema/dmtf/installed/AutomationNodeCollection_v1.xml
+++ b/redfish-core/schema/dmtf/installed/AutomationNodeCollection_v1.xml
@@ -1,0 +1,1 @@
+../csdl/AutomationNodeCollection_v1.xml

--- a/redfish-core/schema/dmtf/installed/AutomationNode_v1.xml
+++ b/redfish-core/schema/dmtf/installed/AutomationNode_v1.xml
@@ -1,0 +1,1 @@
+../csdl/AutomationNode_v1.xml

--- a/redfish-core/schema/dmtf/installed/BatteryCollection_v1.xml
+++ b/redfish-core/schema/dmtf/installed/BatteryCollection_v1.xml
@@ -1,0 +1,1 @@
+../csdl/BatteryCollection_v1.xml

--- a/redfish-core/schema/dmtf/installed/BatteryMetrics_v1.xml
+++ b/redfish-core/schema/dmtf/installed/BatteryMetrics_v1.xml
@@ -1,0 +1,1 @@
+../csdl/BatteryMetrics_v1.xml

--- a/redfish-core/schema/dmtf/installed/Battery_v1.xml
+++ b/redfish-core/schema/dmtf/installed/Battery_v1.xml
@@ -1,0 +1,1 @@
+../csdl/Battery_v1.xml

--- a/redfish-core/schema/dmtf/installed/Bios_v1.xml
+++ b/redfish-core/schema/dmtf/installed/Bios_v1.xml
@@ -1,1 +1,1 @@
-../../../../redfish-core/schema/dmtf/csdl/Bios_v1.xml
+../csdl/Bios_v1.xml

--- a/redfish-core/schema/dmtf/installed/BootOptionCollection_v1.xml
+++ b/redfish-core/schema/dmtf/installed/BootOptionCollection_v1.xml
@@ -1,0 +1,1 @@
+../csdl/BootOptionCollection_v1.xml

--- a/redfish-core/schema/dmtf/installed/BootOption_v1.xml
+++ b/redfish-core/schema/dmtf/installed/BootOption_v1.xml
@@ -1,0 +1,1 @@
+../csdl/BootOption_v1.xml

--- a/redfish-core/schema/dmtf/installed/CXLLogicalDeviceCollection_v1.xml
+++ b/redfish-core/schema/dmtf/installed/CXLLogicalDeviceCollection_v1.xml
@@ -1,0 +1,1 @@
+../csdl/CXLLogicalDeviceCollection_v1.xml

--- a/redfish-core/schema/dmtf/installed/CXLLogicalDevice_v1.xml
+++ b/redfish-core/schema/dmtf/installed/CXLLogicalDevice_v1.xml
@@ -1,0 +1,1 @@
+../csdl/CXLLogicalDevice_v1.xml

--- a/redfish-core/schema/dmtf/installed/CableCollection_v1.xml
+++ b/redfish-core/schema/dmtf/installed/CableCollection_v1.xml
@@ -1,1 +1,1 @@
-../../../../redfish-core/schema/dmtf/csdl/CableCollection_v1.xml
+../csdl/CableCollection_v1.xml

--- a/redfish-core/schema/dmtf/installed/Cable_v1.xml
+++ b/redfish-core/schema/dmtf/installed/Cable_v1.xml
@@ -1,1 +1,1 @@
-../../../../redfish-core/schema/dmtf/csdl/Cable_v1.xml
+../csdl/Cable_v1.xml

--- a/redfish-core/schema/dmtf/installed/CertificateCollection_v1.xml
+++ b/redfish-core/schema/dmtf/installed/CertificateCollection_v1.xml
@@ -1,1 +1,1 @@
-../../../../redfish-core/schema/dmtf/csdl/CertificateCollection_v1.xml
+../csdl/CertificateCollection_v1.xml

--- a/redfish-core/schema/dmtf/installed/CertificateLocations_v1.xml
+++ b/redfish-core/schema/dmtf/installed/CertificateLocations_v1.xml
@@ -1,1 +1,1 @@
-../../../../redfish-core/schema/dmtf/csdl/CertificateLocations_v1.xml
+../csdl/CertificateLocations_v1.xml

--- a/redfish-core/schema/dmtf/installed/CertificateService_v1.xml
+++ b/redfish-core/schema/dmtf/installed/CertificateService_v1.xml
@@ -1,1 +1,1 @@
-../../../../redfish-core/schema/dmtf/csdl/CertificateService_v1.xml
+../csdl/CertificateService_v1.xml

--- a/redfish-core/schema/dmtf/installed/Certificate_v1.xml
+++ b/redfish-core/schema/dmtf/installed/Certificate_v1.xml
@@ -1,1 +1,1 @@
-../../../../redfish-core/schema/dmtf/csdl/Certificate_v1.xml
+../csdl/Certificate_v1.xml

--- a/redfish-core/schema/dmtf/installed/ChassisCollection_v1.xml
+++ b/redfish-core/schema/dmtf/installed/ChassisCollection_v1.xml
@@ -1,1 +1,1 @@
-../../../../redfish-core/schema/dmtf/csdl/ChassisCollection_v1.xml
+../csdl/ChassisCollection_v1.xml

--- a/redfish-core/schema/dmtf/installed/Chassis_v1.xml
+++ b/redfish-core/schema/dmtf/installed/Chassis_v1.xml
@@ -1,1 +1,1 @@
-../../../../redfish-core/schema/dmtf/csdl/Chassis_v1.xml
+../csdl/Chassis_v1.xml

--- a/redfish-core/schema/dmtf/installed/CircuitCollection_v1.xml
+++ b/redfish-core/schema/dmtf/installed/CircuitCollection_v1.xml
@@ -1,0 +1,1 @@
+../csdl/CircuitCollection_v1.xml

--- a/redfish-core/schema/dmtf/installed/Circuit_v1.xml
+++ b/redfish-core/schema/dmtf/installed/Circuit_v1.xml
@@ -1,0 +1,1 @@
+../csdl/Circuit_v1.xml

--- a/redfish-core/schema/dmtf/installed/CollectionCapabilities_v1.xml
+++ b/redfish-core/schema/dmtf/installed/CollectionCapabilities_v1.xml
@@ -1,0 +1,1 @@
+../csdl/CollectionCapabilities_v1.xml

--- a/redfish-core/schema/dmtf/installed/ComponentIntegrityCollection_v1.xml
+++ b/redfish-core/schema/dmtf/installed/ComponentIntegrityCollection_v1.xml
@@ -1,1 +1,1 @@
-../../../../redfish-core/schema/dmtf/csdl/ComponentIntegrityCollection_v1.xml
+../csdl/ComponentIntegrityCollection_v1.xml

--- a/redfish-core/schema/dmtf/installed/ComponentIntegrity_v1.xml
+++ b/redfish-core/schema/dmtf/installed/ComponentIntegrity_v1.xml
@@ -1,1 +1,1 @@
-../../../../redfish-core/schema/dmtf/csdl/ComponentIntegrity_v1.xml
+../csdl/ComponentIntegrity_v1.xml

--- a/redfish-core/schema/dmtf/installed/CompositionReservationCollection_v1.xml
+++ b/redfish-core/schema/dmtf/installed/CompositionReservationCollection_v1.xml
@@ -1,0 +1,1 @@
+../csdl/CompositionReservationCollection_v1.xml

--- a/redfish-core/schema/dmtf/installed/CompositionReservation_v1.xml
+++ b/redfish-core/schema/dmtf/installed/CompositionReservation_v1.xml
@@ -1,0 +1,1 @@
+../csdl/CompositionReservation_v1.xml

--- a/redfish-core/schema/dmtf/installed/CompositionService_v1.xml
+++ b/redfish-core/schema/dmtf/installed/CompositionService_v1.xml
@@ -1,0 +1,1 @@
+../csdl/CompositionService_v1.xml

--- a/redfish-core/schema/dmtf/installed/ComputerSystemCollection_v1.xml
+++ b/redfish-core/schema/dmtf/installed/ComputerSystemCollection_v1.xml
@@ -1,1 +1,1 @@
-../../../../redfish-core/schema/dmtf/csdl/ComputerSystemCollection_v1.xml
+../csdl/ComputerSystemCollection_v1.xml

--- a/redfish-core/schema/dmtf/installed/ComputerSystem_v1.xml
+++ b/redfish-core/schema/dmtf/installed/ComputerSystem_v1.xml
@@ -1,1 +1,1 @@
-../../../../redfish-core/schema/dmtf/csdl/ComputerSystem_v1.xml
+../csdl/ComputerSystem_v1.xml

--- a/redfish-core/schema/dmtf/installed/ConnectionCollection_v1.xml
+++ b/redfish-core/schema/dmtf/installed/ConnectionCollection_v1.xml
@@ -1,0 +1,1 @@
+../csdl/ConnectionCollection_v1.xml

--- a/redfish-core/schema/dmtf/installed/ConnectionMethodCollection_v1.xml
+++ b/redfish-core/schema/dmtf/installed/ConnectionMethodCollection_v1.xml
@@ -1,0 +1,1 @@
+../csdl/ConnectionMethodCollection_v1.xml

--- a/redfish-core/schema/dmtf/installed/ConnectionMethod_v1.xml
+++ b/redfish-core/schema/dmtf/installed/ConnectionMethod_v1.xml
@@ -1,0 +1,1 @@
+../csdl/ConnectionMethod_v1.xml

--- a/redfish-core/schema/dmtf/installed/Connection_v1.xml
+++ b/redfish-core/schema/dmtf/installed/Connection_v1.xml
@@ -1,0 +1,1 @@
+../csdl/Connection_v1.xml

--- a/redfish-core/schema/dmtf/installed/ContainerCollection_v1.xml
+++ b/redfish-core/schema/dmtf/installed/ContainerCollection_v1.xml
@@ -1,0 +1,1 @@
+../csdl/ContainerCollection_v1.xml

--- a/redfish-core/schema/dmtf/installed/ContainerImageCollection_v1.xml
+++ b/redfish-core/schema/dmtf/installed/ContainerImageCollection_v1.xml
@@ -1,0 +1,1 @@
+../csdl/ContainerImageCollection_v1.xml

--- a/redfish-core/schema/dmtf/installed/ContainerImage_v1.xml
+++ b/redfish-core/schema/dmtf/installed/ContainerImage_v1.xml
@@ -1,0 +1,1 @@
+../csdl/ContainerImage_v1.xml

--- a/redfish-core/schema/dmtf/installed/Container_v1.xml
+++ b/redfish-core/schema/dmtf/installed/Container_v1.xml
@@ -1,0 +1,1 @@
+../csdl/Container_v1.xml

--- a/redfish-core/schema/dmtf/installed/ControlCollection_v1.xml
+++ b/redfish-core/schema/dmtf/installed/ControlCollection_v1.xml
@@ -1,0 +1,1 @@
+../csdl/ControlCollection_v1.xml

--- a/redfish-core/schema/dmtf/installed/Control_v1.xml
+++ b/redfish-core/schema/dmtf/installed/Control_v1.xml
@@ -1,0 +1,1 @@
+../csdl/Control_v1.xml

--- a/redfish-core/schema/dmtf/installed/CoolantConnectorCollection_v1.xml
+++ b/redfish-core/schema/dmtf/installed/CoolantConnectorCollection_v1.xml
@@ -1,0 +1,1 @@
+../csdl/CoolantConnectorCollection_v1.xml

--- a/redfish-core/schema/dmtf/installed/CoolantConnector_v1.xml
+++ b/redfish-core/schema/dmtf/installed/CoolantConnector_v1.xml
@@ -1,0 +1,1 @@
+../csdl/CoolantConnector_v1.xml

--- a/redfish-core/schema/dmtf/installed/CoolingLoopCollection_v1.xml
+++ b/redfish-core/schema/dmtf/installed/CoolingLoopCollection_v1.xml
@@ -1,0 +1,1 @@
+../csdl/CoolingLoopCollection_v1.xml

--- a/redfish-core/schema/dmtf/installed/CoolingLoop_v1.xml
+++ b/redfish-core/schema/dmtf/installed/CoolingLoop_v1.xml
@@ -1,0 +1,1 @@
+../csdl/CoolingLoop_v1.xml

--- a/redfish-core/schema/dmtf/installed/CoolingUnitCollection_v1.xml
+++ b/redfish-core/schema/dmtf/installed/CoolingUnitCollection_v1.xml
@@ -1,0 +1,1 @@
+../csdl/CoolingUnitCollection_v1.xml

--- a/redfish-core/schema/dmtf/installed/CoolingUnit_v1.xml
+++ b/redfish-core/schema/dmtf/installed/CoolingUnit_v1.xml
@@ -1,0 +1,1 @@
+../csdl/CoolingUnit_v1.xml

--- a/redfish-core/schema/dmtf/installed/DriveCollection_v1.xml
+++ b/redfish-core/schema/dmtf/installed/DriveCollection_v1.xml
@@ -1,1 +1,1 @@
-../../../../redfish-core/schema/dmtf/csdl/DriveCollection_v1.xml
+../csdl/DriveCollection_v1.xml

--- a/redfish-core/schema/dmtf/installed/DriveMetrics_v1.xml
+++ b/redfish-core/schema/dmtf/installed/DriveMetrics_v1.xml
@@ -1,0 +1,1 @@
+../csdl/DriveMetrics_v1.xml

--- a/redfish-core/schema/dmtf/installed/Drive_v1.xml
+++ b/redfish-core/schema/dmtf/installed/Drive_v1.xml
@@ -1,1 +1,1 @@
-../../../../redfish-core/schema/dmtf/csdl/Drive_v1.xml
+../csdl/Drive_v1.xml

--- a/redfish-core/schema/dmtf/installed/EndpointCollection_v1.xml
+++ b/redfish-core/schema/dmtf/installed/EndpointCollection_v1.xml
@@ -1,0 +1,1 @@
+../csdl/EndpointCollection_v1.xml

--- a/redfish-core/schema/dmtf/installed/EndpointGroupCollection_v1.xml
+++ b/redfish-core/schema/dmtf/installed/EndpointGroupCollection_v1.xml
@@ -1,0 +1,1 @@
+../csdl/EndpointGroupCollection_v1.xml

--- a/redfish-core/schema/dmtf/installed/EndpointGroup_v1.xml
+++ b/redfish-core/schema/dmtf/installed/EndpointGroup_v1.xml
@@ -1,0 +1,1 @@
+../csdl/EndpointGroup_v1.xml

--- a/redfish-core/schema/dmtf/installed/Endpoint_v1.xml
+++ b/redfish-core/schema/dmtf/installed/Endpoint_v1.xml
@@ -1,0 +1,1 @@
+../csdl/Endpoint_v1.xml

--- a/redfish-core/schema/dmtf/installed/EnvironmentMetrics_v1.xml
+++ b/redfish-core/schema/dmtf/installed/EnvironmentMetrics_v1.xml
@@ -1,1 +1,1 @@
-../../../../redfish-core/schema/dmtf/csdl/EnvironmentMetrics_v1.xml
+../csdl/EnvironmentMetrics_v1.xml

--- a/redfish-core/schema/dmtf/installed/EthernetInterfaceCollection_v1.xml
+++ b/redfish-core/schema/dmtf/installed/EthernetInterfaceCollection_v1.xml
@@ -1,1 +1,1 @@
-../../../../redfish-core/schema/dmtf/csdl/EthernetInterfaceCollection_v1.xml
+../csdl/EthernetInterfaceCollection_v1.xml

--- a/redfish-core/schema/dmtf/installed/EthernetInterface_v1.xml
+++ b/redfish-core/schema/dmtf/installed/EthernetInterface_v1.xml
@@ -1,1 +1,1 @@
-../../../../redfish-core/schema/dmtf/csdl/EthernetInterface_v1.xml
+../csdl/EthernetInterface_v1.xml

--- a/redfish-core/schema/dmtf/installed/EventDestinationCollection_v1.xml
+++ b/redfish-core/schema/dmtf/installed/EventDestinationCollection_v1.xml
@@ -1,1 +1,1 @@
-../../../../redfish-core/schema/dmtf/csdl/EventDestinationCollection_v1.xml
+../csdl/EventDestinationCollection_v1.xml

--- a/redfish-core/schema/dmtf/installed/EventDestination_v1.xml
+++ b/redfish-core/schema/dmtf/installed/EventDestination_v1.xml
@@ -1,1 +1,1 @@
-../../../../redfish-core/schema/dmtf/csdl/EventDestination_v1.xml
+../csdl/EventDestination_v1.xml

--- a/redfish-core/schema/dmtf/installed/EventService_v1.xml
+++ b/redfish-core/schema/dmtf/installed/EventService_v1.xml
@@ -1,1 +1,1 @@
-../../../../redfish-core/schema/dmtf/csdl/EventService_v1.xml
+../csdl/EventService_v1.xml

--- a/redfish-core/schema/dmtf/installed/Event_v1.xml
+++ b/redfish-core/schema/dmtf/installed/Event_v1.xml
@@ -1,1 +1,1 @@
-../../../../redfish-core/schema/dmtf/csdl/Event_v1.xml
+../csdl/Event_v1.xml

--- a/redfish-core/schema/dmtf/installed/ExternalAccountProviderCollection_v1.xml
+++ b/redfish-core/schema/dmtf/installed/ExternalAccountProviderCollection_v1.xml
@@ -1,0 +1,1 @@
+../csdl/ExternalAccountProviderCollection_v1.xml

--- a/redfish-core/schema/dmtf/installed/ExternalAccountProvider_v1.xml
+++ b/redfish-core/schema/dmtf/installed/ExternalAccountProvider_v1.xml
@@ -1,0 +1,1 @@
+../csdl/ExternalAccountProvider_v1.xml

--- a/redfish-core/schema/dmtf/installed/FabricAdapterCollection_v1.xml
+++ b/redfish-core/schema/dmtf/installed/FabricAdapterCollection_v1.xml
@@ -1,1 +1,1 @@
-../../../../redfish-core/schema/dmtf/csdl/FabricAdapterCollection_v1.xml
+../csdl/FabricAdapterCollection_v1.xml

--- a/redfish-core/schema/dmtf/installed/FabricAdapter_v1.xml
+++ b/redfish-core/schema/dmtf/installed/FabricAdapter_v1.xml
@@ -1,1 +1,1 @@
-../../../../redfish-core/schema/dmtf/csdl/FabricAdapter_v1.xml
+../csdl/FabricAdapter_v1.xml

--- a/redfish-core/schema/dmtf/installed/FabricCollection_v1.xml
+++ b/redfish-core/schema/dmtf/installed/FabricCollection_v1.xml
@@ -1,0 +1,1 @@
+../csdl/FabricCollection_v1.xml

--- a/redfish-core/schema/dmtf/installed/Fabric_v1.xml
+++ b/redfish-core/schema/dmtf/installed/Fabric_v1.xml
@@ -1,0 +1,1 @@
+../csdl/Fabric_v1.xml

--- a/redfish-core/schema/dmtf/installed/FacilityCollection_v1.xml
+++ b/redfish-core/schema/dmtf/installed/FacilityCollection_v1.xml
@@ -1,0 +1,1 @@
+../csdl/FacilityCollection_v1.xml

--- a/redfish-core/schema/dmtf/installed/Facility_v1.xml
+++ b/redfish-core/schema/dmtf/installed/Facility_v1.xml
@@ -1,0 +1,1 @@
+../csdl/Facility_v1.xml

--- a/redfish-core/schema/dmtf/installed/FanCollection_v1.xml
+++ b/redfish-core/schema/dmtf/installed/FanCollection_v1.xml
@@ -1,1 +1,1 @@
-../../../../redfish-core/schema/dmtf/csdl/FanCollection_v1.xml
+../csdl/FanCollection_v1.xml

--- a/redfish-core/schema/dmtf/installed/Fan_v1.xml
+++ b/redfish-core/schema/dmtf/installed/Fan_v1.xml
@@ -1,1 +1,1 @@
-../../../../redfish-core/schema/dmtf/csdl/Fan_v1.xml
+../csdl/Fan_v1.xml

--- a/redfish-core/schema/dmtf/installed/FilterCollection_v1.xml
+++ b/redfish-core/schema/dmtf/installed/FilterCollection_v1.xml
@@ -1,0 +1,1 @@
+../csdl/FilterCollection_v1.xml

--- a/redfish-core/schema/dmtf/installed/Filter_v1.xml
+++ b/redfish-core/schema/dmtf/installed/Filter_v1.xml
@@ -1,0 +1,1 @@
+../csdl/Filter_v1.xml

--- a/redfish-core/schema/dmtf/installed/GraphicsControllerCollection_v1.xml
+++ b/redfish-core/schema/dmtf/installed/GraphicsControllerCollection_v1.xml
@@ -1,0 +1,1 @@
+../csdl/GraphicsControllerCollection_v1.xml

--- a/redfish-core/schema/dmtf/installed/GraphicsController_v1.xml
+++ b/redfish-core/schema/dmtf/installed/GraphicsController_v1.xml
@@ -1,0 +1,1 @@
+../csdl/GraphicsController_v1.xml

--- a/redfish-core/schema/dmtf/installed/HeaterCollection_v1.xml
+++ b/redfish-core/schema/dmtf/installed/HeaterCollection_v1.xml
@@ -1,0 +1,1 @@
+../csdl/HeaterCollection_v1.xml

--- a/redfish-core/schema/dmtf/installed/HeaterMetrics_v1.xml
+++ b/redfish-core/schema/dmtf/installed/HeaterMetrics_v1.xml
@@ -1,0 +1,1 @@
+../csdl/HeaterMetrics_v1.xml

--- a/redfish-core/schema/dmtf/installed/Heater_v1.xml
+++ b/redfish-core/schema/dmtf/installed/Heater_v1.xml
@@ -1,0 +1,1 @@
+../csdl/Heater_v1.xml

--- a/redfish-core/schema/dmtf/installed/HostInterfaceCollection_v1.xml
+++ b/redfish-core/schema/dmtf/installed/HostInterfaceCollection_v1.xml
@@ -1,0 +1,1 @@
+../csdl/HostInterfaceCollection_v1.xml

--- a/redfish-core/schema/dmtf/installed/HostInterface_v1.xml
+++ b/redfish-core/schema/dmtf/installed/HostInterface_v1.xml
@@ -1,0 +1,1 @@
+../csdl/HostInterface_v1.xml

--- a/redfish-core/schema/dmtf/installed/IPAddresses_v1.xml
+++ b/redfish-core/schema/dmtf/installed/IPAddresses_v1.xml
@@ -1,1 +1,1 @@
-../../../../redfish-core/schema/dmtf/csdl/IPAddresses_v1.xml
+../csdl/IPAddresses_v1.xml

--- a/redfish-core/schema/dmtf/installed/JobCollection_v1.xml
+++ b/redfish-core/schema/dmtf/installed/JobCollection_v1.xml
@@ -1,0 +1,1 @@
+../csdl/JobCollection_v1.xml

--- a/redfish-core/schema/dmtf/installed/JobDocumentCollection_v1.xml
+++ b/redfish-core/schema/dmtf/installed/JobDocumentCollection_v1.xml
@@ -1,0 +1,1 @@
+../csdl/JobDocumentCollection_v1.xml

--- a/redfish-core/schema/dmtf/installed/JobDocument_v1.xml
+++ b/redfish-core/schema/dmtf/installed/JobDocument_v1.xml
@@ -1,0 +1,1 @@
+../csdl/JobDocument_v1.xml

--- a/redfish-core/schema/dmtf/installed/JobExecutorCollection_v1.xml
+++ b/redfish-core/schema/dmtf/installed/JobExecutorCollection_v1.xml
@@ -1,0 +1,1 @@
+../csdl/JobExecutorCollection_v1.xml

--- a/redfish-core/schema/dmtf/installed/JobExecutor_v1.xml
+++ b/redfish-core/schema/dmtf/installed/JobExecutor_v1.xml
@@ -1,0 +1,1 @@
+../csdl/JobExecutor_v1.xml

--- a/redfish-core/schema/dmtf/installed/JobService_v1.xml
+++ b/redfish-core/schema/dmtf/installed/JobService_v1.xml
@@ -1,0 +1,1 @@
+../csdl/JobService_v1.xml

--- a/redfish-core/schema/dmtf/installed/Job_v1.xml
+++ b/redfish-core/schema/dmtf/installed/Job_v1.xml
@@ -1,0 +1,1 @@
+../csdl/Job_v1.xml

--- a/redfish-core/schema/dmtf/installed/JsonSchemaFileCollection_v1.xml
+++ b/redfish-core/schema/dmtf/installed/JsonSchemaFileCollection_v1.xml
@@ -1,1 +1,1 @@
-../../../../redfish-core/schema/dmtf/csdl/JsonSchemaFileCollection_v1.xml
+../csdl/JsonSchemaFileCollection_v1.xml

--- a/redfish-core/schema/dmtf/installed/JsonSchemaFile_v1.xml
+++ b/redfish-core/schema/dmtf/installed/JsonSchemaFile_v1.xml
@@ -1,1 +1,1 @@
-../../../../redfish-core/schema/dmtf/csdl/JsonSchemaFile_v1.xml
+../csdl/JsonSchemaFile_v1.xml

--- a/redfish-core/schema/dmtf/installed/KeyCollection_v1.xml
+++ b/redfish-core/schema/dmtf/installed/KeyCollection_v1.xml
@@ -1,0 +1,1 @@
+../csdl/KeyCollection_v1.xml

--- a/redfish-core/schema/dmtf/installed/KeyPolicyCollection_v1.xml
+++ b/redfish-core/schema/dmtf/installed/KeyPolicyCollection_v1.xml
@@ -1,0 +1,1 @@
+../csdl/KeyPolicyCollection_v1.xml

--- a/redfish-core/schema/dmtf/installed/KeyPolicy_v1.xml
+++ b/redfish-core/schema/dmtf/installed/KeyPolicy_v1.xml
@@ -1,0 +1,1 @@
+../csdl/KeyPolicy_v1.xml

--- a/redfish-core/schema/dmtf/installed/KeyService_v1.xml
+++ b/redfish-core/schema/dmtf/installed/KeyService_v1.xml
@@ -1,0 +1,1 @@
+../csdl/KeyService_v1.xml

--- a/redfish-core/schema/dmtf/installed/Key_v1.xml
+++ b/redfish-core/schema/dmtf/installed/Key_v1.xml
@@ -1,0 +1,1 @@
+../csdl/Key_v1.xml

--- a/redfish-core/schema/dmtf/installed/LeakDetection_v1.xml
+++ b/redfish-core/schema/dmtf/installed/LeakDetection_v1.xml
@@ -1,0 +1,1 @@
+../csdl/LeakDetection_v1.xml

--- a/redfish-core/schema/dmtf/installed/LeakDetectorCollection_v1.xml
+++ b/redfish-core/schema/dmtf/installed/LeakDetectorCollection_v1.xml
@@ -1,0 +1,1 @@
+../csdl/LeakDetectorCollection_v1.xml

--- a/redfish-core/schema/dmtf/installed/LeakDetector_v1.xml
+++ b/redfish-core/schema/dmtf/installed/LeakDetector_v1.xml
@@ -1,0 +1,1 @@
+../csdl/LeakDetector_v1.xml

--- a/redfish-core/schema/dmtf/installed/LicenseCollection_v1.xml
+++ b/redfish-core/schema/dmtf/installed/LicenseCollection_v1.xml
@@ -1,0 +1,1 @@
+../csdl/LicenseCollection_v1.xml

--- a/redfish-core/schema/dmtf/installed/LicenseService_v1.xml
+++ b/redfish-core/schema/dmtf/installed/LicenseService_v1.xml
@@ -1,0 +1,1 @@
+../csdl/LicenseService_v1.xml

--- a/redfish-core/schema/dmtf/installed/License_v1.xml
+++ b/redfish-core/schema/dmtf/installed/License_v1.xml
@@ -1,0 +1,1 @@
+../csdl/License_v1.xml

--- a/redfish-core/schema/dmtf/installed/LogEntryCollection_v1.xml
+++ b/redfish-core/schema/dmtf/installed/LogEntryCollection_v1.xml
@@ -1,1 +1,1 @@
-../../../../redfish-core/schema/dmtf/csdl/LogEntryCollection_v1.xml
+../csdl/LogEntryCollection_v1.xml

--- a/redfish-core/schema/dmtf/installed/LogEntry_v1.xml
+++ b/redfish-core/schema/dmtf/installed/LogEntry_v1.xml
@@ -1,1 +1,1 @@
-../../../../redfish-core/schema/dmtf/csdl/LogEntry_v1.xml
+../csdl/LogEntry_v1.xml

--- a/redfish-core/schema/dmtf/installed/LogServiceCollection_v1.xml
+++ b/redfish-core/schema/dmtf/installed/LogServiceCollection_v1.xml
@@ -1,1 +1,1 @@
-../../../../redfish-core/schema/dmtf/csdl/LogServiceCollection_v1.xml
+../csdl/LogServiceCollection_v1.xml

--- a/redfish-core/schema/dmtf/installed/LogService_v1.xml
+++ b/redfish-core/schema/dmtf/installed/LogService_v1.xml
@@ -1,1 +1,1 @@
-../../../../redfish-core/schema/dmtf/csdl/LogService_v1.xml
+../csdl/LogService_v1.xml

--- a/redfish-core/schema/dmtf/installed/ManagerAccountCollection_v1.xml
+++ b/redfish-core/schema/dmtf/installed/ManagerAccountCollection_v1.xml
@@ -1,1 +1,1 @@
-../../../../redfish-core/schema/dmtf/csdl/ManagerAccountCollection_v1.xml
+../csdl/ManagerAccountCollection_v1.xml

--- a/redfish-core/schema/dmtf/installed/ManagerAccount_v1.xml
+++ b/redfish-core/schema/dmtf/installed/ManagerAccount_v1.xml
@@ -1,1 +1,1 @@
-../../../../redfish-core/schema/dmtf/csdl/ManagerAccount_v1.xml
+../csdl/ManagerAccount_v1.xml

--- a/redfish-core/schema/dmtf/installed/ManagerCollection_v1.xml
+++ b/redfish-core/schema/dmtf/installed/ManagerCollection_v1.xml
@@ -1,1 +1,1 @@
-../../../../redfish-core/schema/dmtf/csdl/ManagerCollection_v1.xml
+../csdl/ManagerCollection_v1.xml

--- a/redfish-core/schema/dmtf/installed/ManagerDiagnosticData_v1.xml
+++ b/redfish-core/schema/dmtf/installed/ManagerDiagnosticData_v1.xml
@@ -1,1 +1,1 @@
-../../../../redfish-core/schema/dmtf/csdl/ManagerDiagnosticData_v1.xml
+../csdl/ManagerDiagnosticData_v1.xml

--- a/redfish-core/schema/dmtf/installed/ManagerNetworkProtocol_v1.xml
+++ b/redfish-core/schema/dmtf/installed/ManagerNetworkProtocol_v1.xml
@@ -1,1 +1,1 @@
-../../../../redfish-core/schema/dmtf/csdl/ManagerNetworkProtocol_v1.xml
+../csdl/ManagerNetworkProtocol_v1.xml

--- a/redfish-core/schema/dmtf/installed/Manager_v1.xml
+++ b/redfish-core/schema/dmtf/installed/Manager_v1.xml
@@ -1,1 +1,1 @@
-../../../../redfish-core/schema/dmtf/csdl/Manager_v1.xml
+../csdl/Manager_v1.xml

--- a/redfish-core/schema/dmtf/installed/Manifest_v1.xml
+++ b/redfish-core/schema/dmtf/installed/Manifest_v1.xml
@@ -1,0 +1,1 @@
+../csdl/Manifest_v1.xml

--- a/redfish-core/schema/dmtf/installed/MediaControllerCollection_v1.xml
+++ b/redfish-core/schema/dmtf/installed/MediaControllerCollection_v1.xml
@@ -1,0 +1,1 @@
+../csdl/MediaControllerCollection_v1.xml

--- a/redfish-core/schema/dmtf/installed/MediaController_v1.xml
+++ b/redfish-core/schema/dmtf/installed/MediaController_v1.xml
@@ -1,0 +1,1 @@
+../csdl/MediaController_v1.xml

--- a/redfish-core/schema/dmtf/installed/MemoryChunksCollection_v1.xml
+++ b/redfish-core/schema/dmtf/installed/MemoryChunksCollection_v1.xml
@@ -1,0 +1,1 @@
+../csdl/MemoryChunksCollection_v1.xml

--- a/redfish-core/schema/dmtf/installed/MemoryChunks_v1.xml
+++ b/redfish-core/schema/dmtf/installed/MemoryChunks_v1.xml
@@ -1,0 +1,1 @@
+../csdl/MemoryChunks_v1.xml

--- a/redfish-core/schema/dmtf/installed/MemoryCollection_v1.xml
+++ b/redfish-core/schema/dmtf/installed/MemoryCollection_v1.xml
@@ -1,1 +1,1 @@
-../../../../redfish-core/schema/dmtf/csdl/MemoryCollection_v1.xml
+../csdl/MemoryCollection_v1.xml

--- a/redfish-core/schema/dmtf/installed/MemoryDomainCollection_v1.xml
+++ b/redfish-core/schema/dmtf/installed/MemoryDomainCollection_v1.xml
@@ -1,0 +1,1 @@
+../csdl/MemoryDomainCollection_v1.xml

--- a/redfish-core/schema/dmtf/installed/MemoryDomain_v1.xml
+++ b/redfish-core/schema/dmtf/installed/MemoryDomain_v1.xml
@@ -1,0 +1,1 @@
+../csdl/MemoryDomain_v1.xml

--- a/redfish-core/schema/dmtf/installed/MemoryMetrics_v1.xml
+++ b/redfish-core/schema/dmtf/installed/MemoryMetrics_v1.xml
@@ -1,0 +1,1 @@
+../csdl/MemoryMetrics_v1.xml

--- a/redfish-core/schema/dmtf/installed/MemoryRegionCollection_v1.xml
+++ b/redfish-core/schema/dmtf/installed/MemoryRegionCollection_v1.xml
@@ -1,0 +1,1 @@
+../csdl/MemoryRegionCollection_v1.xml

--- a/redfish-core/schema/dmtf/installed/MemoryRegion_v1.xml
+++ b/redfish-core/schema/dmtf/installed/MemoryRegion_v1.xml
@@ -1,0 +1,1 @@
+../csdl/MemoryRegion_v1.xml

--- a/redfish-core/schema/dmtf/installed/Memory_v1.xml
+++ b/redfish-core/schema/dmtf/installed/Memory_v1.xml
@@ -1,1 +1,1 @@
-../../../../redfish-core/schema/dmtf/csdl/Memory_v1.xml
+../csdl/Memory_v1.xml

--- a/redfish-core/schema/dmtf/installed/MessageRegistryCollection_v1.xml
+++ b/redfish-core/schema/dmtf/installed/MessageRegistryCollection_v1.xml
@@ -1,1 +1,1 @@
-../../../../redfish-core/schema/dmtf/csdl/MessageRegistryCollection_v1.xml
+../csdl/MessageRegistryCollection_v1.xml

--- a/redfish-core/schema/dmtf/installed/MessageRegistryFileCollection_v1.xml
+++ b/redfish-core/schema/dmtf/installed/MessageRegistryFileCollection_v1.xml
@@ -1,1 +1,1 @@
-../../../../redfish-core/schema/dmtf/csdl/MessageRegistryFileCollection_v1.xml
+../csdl/MessageRegistryFileCollection_v1.xml

--- a/redfish-core/schema/dmtf/installed/MessageRegistryFile_v1.xml
+++ b/redfish-core/schema/dmtf/installed/MessageRegistryFile_v1.xml
@@ -1,1 +1,1 @@
-../../../../redfish-core/schema/dmtf/csdl/MessageRegistryFile_v1.xml
+../csdl/MessageRegistryFile_v1.xml

--- a/redfish-core/schema/dmtf/installed/MessageRegistry_v1.xml
+++ b/redfish-core/schema/dmtf/installed/MessageRegistry_v1.xml
@@ -1,1 +1,1 @@
-../../../../redfish-core/schema/dmtf/csdl/MessageRegistry_v1.xml
+../csdl/MessageRegistry_v1.xml

--- a/redfish-core/schema/dmtf/installed/Message_v1.xml
+++ b/redfish-core/schema/dmtf/installed/Message_v1.xml
@@ -1,1 +1,1 @@
-../../../../redfish-core/schema/dmtf/csdl/Message_v1.xml
+../csdl/Message_v1.xml

--- a/redfish-core/schema/dmtf/installed/MetricDefinitionCollection_v1.xml
+++ b/redfish-core/schema/dmtf/installed/MetricDefinitionCollection_v1.xml
@@ -1,1 +1,1 @@
-../../../../redfish-core/schema/dmtf/csdl/MetricDefinitionCollection_v1.xml
+../csdl/MetricDefinitionCollection_v1.xml

--- a/redfish-core/schema/dmtf/installed/MetricDefinition_v1.xml
+++ b/redfish-core/schema/dmtf/installed/MetricDefinition_v1.xml
@@ -1,1 +1,1 @@
-../../../../redfish-core/schema/dmtf/csdl/MetricDefinition_v1.xml
+../csdl/MetricDefinition_v1.xml

--- a/redfish-core/schema/dmtf/installed/MetricReportCollection_v1.xml
+++ b/redfish-core/schema/dmtf/installed/MetricReportCollection_v1.xml
@@ -1,1 +1,1 @@
-../../../../redfish-core/schema/dmtf/csdl/MetricReportCollection_v1.xml
+../csdl/MetricReportCollection_v1.xml

--- a/redfish-core/schema/dmtf/installed/MetricReportDefinitionCollection_v1.xml
+++ b/redfish-core/schema/dmtf/installed/MetricReportDefinitionCollection_v1.xml
@@ -1,1 +1,1 @@
-../../../../redfish-core/schema/dmtf/csdl/MetricReportDefinitionCollection_v1.xml
+../csdl/MetricReportDefinitionCollection_v1.xml

--- a/redfish-core/schema/dmtf/installed/MetricReportDefinition_v1.xml
+++ b/redfish-core/schema/dmtf/installed/MetricReportDefinition_v1.xml
@@ -1,1 +1,1 @@
-../../../../redfish-core/schema/dmtf/csdl/MetricReportDefinition_v1.xml
+../csdl/MetricReportDefinition_v1.xml

--- a/redfish-core/schema/dmtf/installed/MetricReport_v1.xml
+++ b/redfish-core/schema/dmtf/installed/MetricReport_v1.xml
@@ -1,1 +1,1 @@
-../../../../redfish-core/schema/dmtf/csdl/MetricReport_v1.xml
+../csdl/MetricReport_v1.xml

--- a/redfish-core/schema/dmtf/installed/NetworkAdapterCollection_v1.xml
+++ b/redfish-core/schema/dmtf/installed/NetworkAdapterCollection_v1.xml
@@ -1,0 +1,1 @@
+../csdl/NetworkAdapterCollection_v1.xml

--- a/redfish-core/schema/dmtf/installed/NetworkAdapterMetrics_v1.xml
+++ b/redfish-core/schema/dmtf/installed/NetworkAdapterMetrics_v1.xml
@@ -1,0 +1,1 @@
+../csdl/NetworkAdapterMetrics_v1.xml

--- a/redfish-core/schema/dmtf/installed/NetworkAdapter_v1.xml
+++ b/redfish-core/schema/dmtf/installed/NetworkAdapter_v1.xml
@@ -1,0 +1,1 @@
+../csdl/NetworkAdapter_v1.xml

--- a/redfish-core/schema/dmtf/installed/NetworkDeviceFunctionCollection_v1.xml
+++ b/redfish-core/schema/dmtf/installed/NetworkDeviceFunctionCollection_v1.xml
@@ -1,0 +1,1 @@
+../csdl/NetworkDeviceFunctionCollection_v1.xml

--- a/redfish-core/schema/dmtf/installed/NetworkDeviceFunctionMetrics_v1.xml
+++ b/redfish-core/schema/dmtf/installed/NetworkDeviceFunctionMetrics_v1.xml
@@ -1,0 +1,1 @@
+../csdl/NetworkDeviceFunctionMetrics_v1.xml

--- a/redfish-core/schema/dmtf/installed/NetworkDeviceFunction_v1.xml
+++ b/redfish-core/schema/dmtf/installed/NetworkDeviceFunction_v1.xml
@@ -1,0 +1,1 @@
+../csdl/NetworkDeviceFunction_v1.xml

--- a/redfish-core/schema/dmtf/installed/NetworkInterfaceCollection_v1.xml
+++ b/redfish-core/schema/dmtf/installed/NetworkInterfaceCollection_v1.xml
@@ -1,0 +1,1 @@
+../csdl/NetworkInterfaceCollection_v1.xml

--- a/redfish-core/schema/dmtf/installed/NetworkInterface_v1.xml
+++ b/redfish-core/schema/dmtf/installed/NetworkInterface_v1.xml
@@ -1,0 +1,1 @@
+../csdl/NetworkInterface_v1.xml

--- a/redfish-core/schema/dmtf/installed/NetworkPortCollection_v1.xml
+++ b/redfish-core/schema/dmtf/installed/NetworkPortCollection_v1.xml
@@ -1,0 +1,1 @@
+../csdl/NetworkPortCollection_v1.xml

--- a/redfish-core/schema/dmtf/installed/NetworkPort_v1.xml
+++ b/redfish-core/schema/dmtf/installed/NetworkPort_v1.xml
@@ -1,0 +1,1 @@
+../csdl/NetworkPort_v1.xml

--- a/redfish-core/schema/dmtf/installed/OperatingConfigCollection_v1.xml
+++ b/redfish-core/schema/dmtf/installed/OperatingConfigCollection_v1.xml
@@ -1,1 +1,1 @@
-../../../../redfish-core/schema/dmtf/csdl/OperatingConfigCollection_v1.xml
+../csdl/OperatingConfigCollection_v1.xml

--- a/redfish-core/schema/dmtf/installed/OperatingConfig_v1.xml
+++ b/redfish-core/schema/dmtf/installed/OperatingConfig_v1.xml
@@ -1,1 +1,1 @@
-../../../../redfish-core/schema/dmtf/csdl/OperatingConfig_v1.xml
+../csdl/OperatingConfig_v1.xml

--- a/redfish-core/schema/dmtf/installed/OperatingSystem_v1.xml
+++ b/redfish-core/schema/dmtf/installed/OperatingSystem_v1.xml
@@ -1,0 +1,1 @@
+../csdl/OperatingSystem_v1.xml

--- a/redfish-core/schema/dmtf/installed/OutboundConnectionCollection_v1.xml
+++ b/redfish-core/schema/dmtf/installed/OutboundConnectionCollection_v1.xml
@@ -1,0 +1,1 @@
+../csdl/OutboundConnectionCollection_v1.xml

--- a/redfish-core/schema/dmtf/installed/OutboundConnection_v1.xml
+++ b/redfish-core/schema/dmtf/installed/OutboundConnection_v1.xml
@@ -1,0 +1,1 @@
+../csdl/OutboundConnection_v1.xml

--- a/redfish-core/schema/dmtf/installed/OutletCollection_v1.xml
+++ b/redfish-core/schema/dmtf/installed/OutletCollection_v1.xml
@@ -1,0 +1,1 @@
+../csdl/OutletCollection_v1.xml

--- a/redfish-core/schema/dmtf/installed/OutletGroupCollection_v1.xml
+++ b/redfish-core/schema/dmtf/installed/OutletGroupCollection_v1.xml
@@ -1,0 +1,1 @@
+../csdl/OutletGroupCollection_v1.xml

--- a/redfish-core/schema/dmtf/installed/OutletGroup_v1.xml
+++ b/redfish-core/schema/dmtf/installed/OutletGroup_v1.xml
@@ -1,0 +1,1 @@
+../csdl/OutletGroup_v1.xml

--- a/redfish-core/schema/dmtf/installed/Outlet_v1.xml
+++ b/redfish-core/schema/dmtf/installed/Outlet_v1.xml
@@ -1,0 +1,1 @@
+../csdl/Outlet_v1.xml

--- a/redfish-core/schema/dmtf/installed/PCIeDeviceCollection_v1.xml
+++ b/redfish-core/schema/dmtf/installed/PCIeDeviceCollection_v1.xml
@@ -1,1 +1,1 @@
-../../../../redfish-core/schema/dmtf/csdl/PCIeDeviceCollection_v1.xml
+../csdl/PCIeDeviceCollection_v1.xml

--- a/redfish-core/schema/dmtf/installed/PCIeDevice_v1.xml
+++ b/redfish-core/schema/dmtf/installed/PCIeDevice_v1.xml
@@ -1,1 +1,1 @@
-../../../../redfish-core/schema/dmtf/csdl/PCIeDevice_v1.xml
+../csdl/PCIeDevice_v1.xml

--- a/redfish-core/schema/dmtf/installed/PCIeFunctionCollection_v1.xml
+++ b/redfish-core/schema/dmtf/installed/PCIeFunctionCollection_v1.xml
@@ -1,1 +1,1 @@
-../../../../redfish-core/schema/dmtf/csdl/PCIeFunctionCollection_v1.xml
+../csdl/PCIeFunctionCollection_v1.xml

--- a/redfish-core/schema/dmtf/installed/PCIeFunction_v1.xml
+++ b/redfish-core/schema/dmtf/installed/PCIeFunction_v1.xml
@@ -1,1 +1,1 @@
-../../../../redfish-core/schema/dmtf/csdl/PCIeFunction_v1.xml
+../csdl/PCIeFunction_v1.xml

--- a/redfish-core/schema/dmtf/installed/PCIeSlots_v1.xml
+++ b/redfish-core/schema/dmtf/installed/PCIeSlots_v1.xml
@@ -1,1 +1,1 @@
-../../../../redfish-core/schema/dmtf/csdl/PCIeSlots_v1.xml
+../csdl/PCIeSlots_v1.xml

--- a/redfish-core/schema/dmtf/installed/PhysicalContext_v1.xml
+++ b/redfish-core/schema/dmtf/installed/PhysicalContext_v1.xml
@@ -1,1 +1,1 @@
-../../../../redfish-core/schema/dmtf/csdl/PhysicalContext_v1.xml
+../csdl/PhysicalContext_v1.xml

--- a/redfish-core/schema/dmtf/installed/PortCollection_v1.xml
+++ b/redfish-core/schema/dmtf/installed/PortCollection_v1.xml
@@ -1,1 +1,1 @@
-../../../../redfish-core/schema/dmtf/csdl/PortCollection_v1.xml
+../csdl/PortCollection_v1.xml

--- a/redfish-core/schema/dmtf/installed/PortMetrics_v1.xml
+++ b/redfish-core/schema/dmtf/installed/PortMetrics_v1.xml
@@ -1,0 +1,1 @@
+../csdl/PortMetrics_v1.xml

--- a/redfish-core/schema/dmtf/installed/Port_v1.xml
+++ b/redfish-core/schema/dmtf/installed/Port_v1.xml
@@ -1,1 +1,1 @@
-../../../../redfish-core/schema/dmtf/csdl/Port_v1.xml
+../csdl/Port_v1.xml

--- a/redfish-core/schema/dmtf/installed/PowerDistributionCollection_v1.xml
+++ b/redfish-core/schema/dmtf/installed/PowerDistributionCollection_v1.xml
@@ -1,0 +1,1 @@
+../csdl/PowerDistributionCollection_v1.xml

--- a/redfish-core/schema/dmtf/installed/PowerDistributionMetrics_v1.xml
+++ b/redfish-core/schema/dmtf/installed/PowerDistributionMetrics_v1.xml
@@ -1,0 +1,1 @@
+../csdl/PowerDistributionMetrics_v1.xml

--- a/redfish-core/schema/dmtf/installed/PowerDistribution_v1.xml
+++ b/redfish-core/schema/dmtf/installed/PowerDistribution_v1.xml
@@ -1,0 +1,1 @@
+../csdl/PowerDistribution_v1.xml

--- a/redfish-core/schema/dmtf/installed/PowerDomainCollection_v1.xml
+++ b/redfish-core/schema/dmtf/installed/PowerDomainCollection_v1.xml
@@ -1,0 +1,1 @@
+../csdl/PowerDomainCollection_v1.xml

--- a/redfish-core/schema/dmtf/installed/PowerDomain_v1.xml
+++ b/redfish-core/schema/dmtf/installed/PowerDomain_v1.xml
@@ -1,0 +1,1 @@
+../csdl/PowerDomain_v1.xml

--- a/redfish-core/schema/dmtf/installed/PowerEquipment_v1.xml
+++ b/redfish-core/schema/dmtf/installed/PowerEquipment_v1.xml
@@ -1,0 +1,1 @@
+../csdl/PowerEquipment_v1.xml

--- a/redfish-core/schema/dmtf/installed/PowerSubsystem_v1.xml
+++ b/redfish-core/schema/dmtf/installed/PowerSubsystem_v1.xml
@@ -1,1 +1,1 @@
-../../../../redfish-core/schema/dmtf/csdl/PowerSubsystem_v1.xml
+../csdl/PowerSubsystem_v1.xml

--- a/redfish-core/schema/dmtf/installed/PowerSupplyCollection_v1.xml
+++ b/redfish-core/schema/dmtf/installed/PowerSupplyCollection_v1.xml
@@ -1,1 +1,1 @@
-../../../../redfish-core/schema/dmtf/csdl/PowerSupplyCollection_v1.xml
+../csdl/PowerSupplyCollection_v1.xml

--- a/redfish-core/schema/dmtf/installed/PowerSupplyMetrics_v1.xml
+++ b/redfish-core/schema/dmtf/installed/PowerSupplyMetrics_v1.xml
@@ -1,0 +1,1 @@
+../csdl/PowerSupplyMetrics_v1.xml

--- a/redfish-core/schema/dmtf/installed/PowerSupply_v1.xml
+++ b/redfish-core/schema/dmtf/installed/PowerSupply_v1.xml
@@ -1,1 +1,1 @@
-../../../../redfish-core/schema/dmtf/csdl/PowerSupply_v1.xml
+../csdl/PowerSupply_v1.xml

--- a/redfish-core/schema/dmtf/installed/Power_v1.xml
+++ b/redfish-core/schema/dmtf/installed/Power_v1.xml
@@ -1,1 +1,1 @@
-../../../../redfish-core/schema/dmtf/csdl/Power_v1.xml
+../csdl/Power_v1.xml

--- a/redfish-core/schema/dmtf/installed/PrivilegeRegistry_v1.xml
+++ b/redfish-core/schema/dmtf/installed/PrivilegeRegistry_v1.xml
@@ -1,0 +1,1 @@
+../csdl/PrivilegeRegistry_v1.xml

--- a/redfish-core/schema/dmtf/installed/Privileges_v1.xml
+++ b/redfish-core/schema/dmtf/installed/Privileges_v1.xml
@@ -1,1 +1,1 @@
-../../../../redfish-core/schema/dmtf/csdl/Privileges_v1.xml
+../csdl/Privileges_v1.xml

--- a/redfish-core/schema/dmtf/installed/ProcessorCollection_v1.xml
+++ b/redfish-core/schema/dmtf/installed/ProcessorCollection_v1.xml
@@ -1,1 +1,1 @@
-../../../../redfish-core/schema/dmtf/csdl/ProcessorCollection_v1.xml
+../csdl/ProcessorCollection_v1.xml

--- a/redfish-core/schema/dmtf/installed/ProcessorMetrics_v1.xml
+++ b/redfish-core/schema/dmtf/installed/ProcessorMetrics_v1.xml
@@ -1,0 +1,1 @@
+../csdl/ProcessorMetrics_v1.xml

--- a/redfish-core/schema/dmtf/installed/Processor_v1.xml
+++ b/redfish-core/schema/dmtf/installed/Processor_v1.xml
@@ -1,1 +1,1 @@
-../../../../redfish-core/schema/dmtf/csdl/Processor_v1.xml
+../csdl/Processor_v1.xml

--- a/redfish-core/schema/dmtf/installed/Protocol_v1.xml
+++ b/redfish-core/schema/dmtf/installed/Protocol_v1.xml
@@ -1,1 +1,1 @@
-../../../../redfish-core/schema/dmtf/csdl/Protocol_v1.xml
+../csdl/Protocol_v1.xml

--- a/redfish-core/schema/dmtf/installed/PumpCollection_v1.xml
+++ b/redfish-core/schema/dmtf/installed/PumpCollection_v1.xml
@@ -1,0 +1,1 @@
+../csdl/PumpCollection_v1.xml

--- a/redfish-core/schema/dmtf/installed/Pump_v1.xml
+++ b/redfish-core/schema/dmtf/installed/Pump_v1.xml
@@ -1,0 +1,1 @@
+../csdl/Pump_v1.xml

--- a/redfish-core/schema/dmtf/installed/RedfishError_v1.xml
+++ b/redfish-core/schema/dmtf/installed/RedfishError_v1.xml
@@ -1,1 +1,1 @@
-../../../../redfish-core/schema/dmtf/csdl/RedfishError_v1.xml
+../csdl/RedfishError_v1.xml

--- a/redfish-core/schema/dmtf/installed/RedfishExtensions_v1.xml
+++ b/redfish-core/schema/dmtf/installed/RedfishExtensions_v1.xml
@@ -1,1 +1,1 @@
-../../../../redfish-core/schema/dmtf/csdl/RedfishExtensions_v1.xml
+../csdl/RedfishExtensions_v1.xml

--- a/redfish-core/schema/dmtf/installed/Redundancy_v1.xml
+++ b/redfish-core/schema/dmtf/installed/Redundancy_v1.xml
@@ -1,1 +1,1 @@
-../../../../redfish-core/schema/dmtf/csdl/Redundancy_v1.xml
+../csdl/Redundancy_v1.xml

--- a/redfish-core/schema/dmtf/installed/RegisteredClientCollection_v1.xml
+++ b/redfish-core/schema/dmtf/installed/RegisteredClientCollection_v1.xml
@@ -1,0 +1,1 @@
+../csdl/RegisteredClientCollection_v1.xml

--- a/redfish-core/schema/dmtf/installed/RegisteredClient_v1.xml
+++ b/redfish-core/schema/dmtf/installed/RegisteredClient_v1.xml
@@ -1,0 +1,1 @@
+../csdl/RegisteredClient_v1.xml

--- a/redfish-core/schema/dmtf/installed/ReservoirCollection_v1.xml
+++ b/redfish-core/schema/dmtf/installed/ReservoirCollection_v1.xml
@@ -1,0 +1,1 @@
+../csdl/ReservoirCollection_v1.xml

--- a/redfish-core/schema/dmtf/installed/Reservoir_v1.xml
+++ b/redfish-core/schema/dmtf/installed/Reservoir_v1.xml
@@ -1,0 +1,1 @@
+../csdl/Reservoir_v1.xml

--- a/redfish-core/schema/dmtf/installed/ResolutionStep_v1.xml
+++ b/redfish-core/schema/dmtf/installed/ResolutionStep_v1.xml
@@ -1,0 +1,1 @@
+../csdl/ResolutionStep_v1.xml

--- a/redfish-core/schema/dmtf/installed/ResourceBlockCollection_v1.xml
+++ b/redfish-core/schema/dmtf/installed/ResourceBlockCollection_v1.xml
@@ -1,0 +1,1 @@
+../csdl/ResourceBlockCollection_v1.xml

--- a/redfish-core/schema/dmtf/installed/ResourceBlock_v1.xml
+++ b/redfish-core/schema/dmtf/installed/ResourceBlock_v1.xml
@@ -1,0 +1,1 @@
+../csdl/ResourceBlock_v1.xml

--- a/redfish-core/schema/dmtf/installed/Resource_v1.xml
+++ b/redfish-core/schema/dmtf/installed/Resource_v1.xml
@@ -1,1 +1,1 @@
-../../../../redfish-core/schema/dmtf/csdl/Resource_v1.xml
+../csdl/Resource_v1.xml

--- a/redfish-core/schema/dmtf/installed/RoleCollection_v1.xml
+++ b/redfish-core/schema/dmtf/installed/RoleCollection_v1.xml
@@ -1,1 +1,1 @@
-../../../../redfish-core/schema/dmtf/csdl/RoleCollection_v1.xml
+../csdl/RoleCollection_v1.xml

--- a/redfish-core/schema/dmtf/installed/Role_v1.xml
+++ b/redfish-core/schema/dmtf/installed/Role_v1.xml
@@ -1,1 +1,1 @@
-../../../../redfish-core/schema/dmtf/csdl/Role_v1.xml
+../csdl/Role_v1.xml

--- a/redfish-core/schema/dmtf/installed/RouteEntryCollection_v1.xml
+++ b/redfish-core/schema/dmtf/installed/RouteEntryCollection_v1.xml
@@ -1,0 +1,1 @@
+../csdl/RouteEntryCollection_v1.xml

--- a/redfish-core/schema/dmtf/installed/RouteEntry_v1.xml
+++ b/redfish-core/schema/dmtf/installed/RouteEntry_v1.xml
@@ -1,0 +1,1 @@
+../csdl/RouteEntry_v1.xml

--- a/redfish-core/schema/dmtf/installed/RouteSetEntryCollection_v1.xml
+++ b/redfish-core/schema/dmtf/installed/RouteSetEntryCollection_v1.xml
@@ -1,0 +1,1 @@
+../csdl/RouteSetEntryCollection_v1.xml

--- a/redfish-core/schema/dmtf/installed/RouteSetEntry_v1.xml
+++ b/redfish-core/schema/dmtf/installed/RouteSetEntry_v1.xml
@@ -1,0 +1,1 @@
+../csdl/RouteSetEntry_v1.xml

--- a/redfish-core/schema/dmtf/installed/Schedule_v1.xml
+++ b/redfish-core/schema/dmtf/installed/Schedule_v1.xml
@@ -1,0 +1,1 @@
+../csdl/Schedule_v1.xml

--- a/redfish-core/schema/dmtf/installed/SecureBootDatabaseCollection_v1.xml
+++ b/redfish-core/schema/dmtf/installed/SecureBootDatabaseCollection_v1.xml
@@ -1,0 +1,1 @@
+../csdl/SecureBootDatabaseCollection_v1.xml

--- a/redfish-core/schema/dmtf/installed/SecureBootDatabase_v1.xml
+++ b/redfish-core/schema/dmtf/installed/SecureBootDatabase_v1.xml
@@ -1,0 +1,1 @@
+../csdl/SecureBootDatabase_v1.xml

--- a/redfish-core/schema/dmtf/installed/SecureBoot_v1.xml
+++ b/redfish-core/schema/dmtf/installed/SecureBoot_v1.xml
@@ -1,0 +1,1 @@
+../csdl/SecureBoot_v1.xml

--- a/redfish-core/schema/dmtf/installed/SecurityPolicy_v1.xml
+++ b/redfish-core/schema/dmtf/installed/SecurityPolicy_v1.xml
@@ -1,0 +1,1 @@
+../csdl/SecurityPolicy_v1.xml

--- a/redfish-core/schema/dmtf/installed/SensorCollection_v1.xml
+++ b/redfish-core/schema/dmtf/installed/SensorCollection_v1.xml
@@ -1,1 +1,1 @@
-../../../../redfish-core/schema/dmtf/csdl/SensorCollection_v1.xml
+../csdl/SensorCollection_v1.xml

--- a/redfish-core/schema/dmtf/installed/Sensor_v1.xml
+++ b/redfish-core/schema/dmtf/installed/Sensor_v1.xml
@@ -1,1 +1,1 @@
-../../../../redfish-core/schema/dmtf/csdl/Sensor_v1.xml
+../csdl/Sensor_v1.xml

--- a/redfish-core/schema/dmtf/installed/SerialInterfaceCollection_v1.xml
+++ b/redfish-core/schema/dmtf/installed/SerialInterfaceCollection_v1.xml
@@ -1,0 +1,1 @@
+../csdl/SerialInterfaceCollection_v1.xml

--- a/redfish-core/schema/dmtf/installed/SerialInterface_v1.xml
+++ b/redfish-core/schema/dmtf/installed/SerialInterface_v1.xml
@@ -1,0 +1,1 @@
+../csdl/SerialInterface_v1.xml

--- a/redfish-core/schema/dmtf/installed/ServiceConditions_v1.xml
+++ b/redfish-core/schema/dmtf/installed/ServiceConditions_v1.xml
@@ -1,0 +1,1 @@
+../csdl/ServiceConditions_v1.xml

--- a/redfish-core/schema/dmtf/installed/ServiceRoot_v1.xml
+++ b/redfish-core/schema/dmtf/installed/ServiceRoot_v1.xml
@@ -1,1 +1,1 @@
-../../../../redfish-core/schema/dmtf/csdl/ServiceRoot_v1.xml
+../csdl/ServiceRoot_v1.xml

--- a/redfish-core/schema/dmtf/installed/SessionCollection_v1.xml
+++ b/redfish-core/schema/dmtf/installed/SessionCollection_v1.xml
@@ -1,1 +1,1 @@
-../../../../redfish-core/schema/dmtf/csdl/SessionCollection_v1.xml
+../csdl/SessionCollection_v1.xml

--- a/redfish-core/schema/dmtf/installed/SessionService_v1.xml
+++ b/redfish-core/schema/dmtf/installed/SessionService_v1.xml
@@ -1,1 +1,1 @@
-../../../../redfish-core/schema/dmtf/csdl/SessionService_v1.xml
+../csdl/SessionService_v1.xml

--- a/redfish-core/schema/dmtf/installed/Session_v1.xml
+++ b/redfish-core/schema/dmtf/installed/Session_v1.xml
@@ -1,1 +1,1 @@
-../../../../redfish-core/schema/dmtf/csdl/Session_v1.xml
+../csdl/Session_v1.xml

--- a/redfish-core/schema/dmtf/installed/Settings_v1.xml
+++ b/redfish-core/schema/dmtf/installed/Settings_v1.xml
@@ -1,1 +1,1 @@
-../../../../redfish-core/schema/dmtf/csdl/Settings_v1.xml
+../csdl/Settings_v1.xml

--- a/redfish-core/schema/dmtf/installed/SignatureCollection_v1.xml
+++ b/redfish-core/schema/dmtf/installed/SignatureCollection_v1.xml
@@ -1,0 +1,1 @@
+../csdl/SignatureCollection_v1.xml

--- a/redfish-core/schema/dmtf/installed/Signature_v1.xml
+++ b/redfish-core/schema/dmtf/installed/Signature_v1.xml
@@ -1,0 +1,1 @@
+../csdl/Signature_v1.xml

--- a/redfish-core/schema/dmtf/installed/SimpleStorageCollection_v1.xml
+++ b/redfish-core/schema/dmtf/installed/SimpleStorageCollection_v1.xml
@@ -1,0 +1,1 @@
+../csdl/SimpleStorageCollection_v1.xml

--- a/redfish-core/schema/dmtf/installed/SimpleStorage_v1.xml
+++ b/redfish-core/schema/dmtf/installed/SimpleStorage_v1.xml
@@ -1,0 +1,1 @@
+../csdl/SimpleStorage_v1.xml

--- a/redfish-core/schema/dmtf/installed/SoftwareInventoryCollection_v1.xml
+++ b/redfish-core/schema/dmtf/installed/SoftwareInventoryCollection_v1.xml
@@ -1,1 +1,1 @@
-../../../../redfish-core/schema/dmtf/csdl/SoftwareInventoryCollection_v1.xml
+../csdl/SoftwareInventoryCollection_v1.xml

--- a/redfish-core/schema/dmtf/installed/SoftwareInventory_v1.xml
+++ b/redfish-core/schema/dmtf/installed/SoftwareInventory_v1.xml
@@ -1,1 +1,1 @@
-../../../../redfish-core/schema/dmtf/csdl/SoftwareInventory_v1.xml
+../csdl/SoftwareInventory_v1.xml

--- a/redfish-core/schema/dmtf/installed/StorageCollection_v1.xml
+++ b/redfish-core/schema/dmtf/installed/StorageCollection_v1.xml
@@ -1,1 +1,1 @@
-../../../../redfish-core/schema/dmtf/csdl/StorageCollection_v1.xml
+../csdl/StorageCollection_v1.xml

--- a/redfish-core/schema/dmtf/installed/StorageControllerCollection_v1.xml
+++ b/redfish-core/schema/dmtf/installed/StorageControllerCollection_v1.xml
@@ -1,1 +1,1 @@
-../../../../redfish-core/schema/dmtf/csdl/StorageControllerCollection_v1.xml
+../csdl/StorageControllerCollection_v1.xml

--- a/redfish-core/schema/dmtf/installed/StorageControllerMetrics_v1.xml
+++ b/redfish-core/schema/dmtf/installed/StorageControllerMetrics_v1.xml
@@ -1,0 +1,1 @@
+../csdl/StorageControllerMetrics_v1.xml

--- a/redfish-core/schema/dmtf/installed/StorageController_v1.xml
+++ b/redfish-core/schema/dmtf/installed/StorageController_v1.xml
@@ -1,1 +1,1 @@
-../../../../redfish-core/schema/dmtf/csdl/StorageController_v1.xml
+../csdl/StorageController_v1.xml

--- a/redfish-core/schema/dmtf/installed/StorageMetrics_v1.xml
+++ b/redfish-core/schema/dmtf/installed/StorageMetrics_v1.xml
@@ -1,0 +1,1 @@
+../csdl/StorageMetrics_v1.xml

--- a/redfish-core/schema/dmtf/installed/Storage_v1.xml
+++ b/redfish-core/schema/dmtf/installed/Storage_v1.xml
@@ -1,1 +1,1 @@
-../../../../redfish-core/schema/dmtf/csdl/Storage_v1.xml
+../csdl/Storage_v1.xml

--- a/redfish-core/schema/dmtf/installed/SwitchCollection_v1.xml
+++ b/redfish-core/schema/dmtf/installed/SwitchCollection_v1.xml
@@ -1,0 +1,1 @@
+../csdl/SwitchCollection_v1.xml

--- a/redfish-core/schema/dmtf/installed/SwitchMetrics_v1.xml
+++ b/redfish-core/schema/dmtf/installed/SwitchMetrics_v1.xml
@@ -1,0 +1,1 @@
+../csdl/SwitchMetrics_v1.xml

--- a/redfish-core/schema/dmtf/installed/Switch_v1.xml
+++ b/redfish-core/schema/dmtf/installed/Switch_v1.xml
@@ -1,0 +1,1 @@
+../csdl/Switch_v1.xml

--- a/redfish-core/schema/dmtf/installed/TaskCollection_v1.xml
+++ b/redfish-core/schema/dmtf/installed/TaskCollection_v1.xml
@@ -1,1 +1,1 @@
-../../../../redfish-core/schema/dmtf/csdl/TaskCollection_v1.xml
+../csdl/TaskCollection_v1.xml

--- a/redfish-core/schema/dmtf/installed/TaskService_v1.xml
+++ b/redfish-core/schema/dmtf/installed/TaskService_v1.xml
@@ -1,1 +1,1 @@
-../../../../redfish-core/schema/dmtf/csdl/TaskService_v1.xml
+../csdl/TaskService_v1.xml

--- a/redfish-core/schema/dmtf/installed/Task_v1.xml
+++ b/redfish-core/schema/dmtf/installed/Task_v1.xml
@@ -1,1 +1,1 @@
-../../../../redfish-core/schema/dmtf/csdl/Task_v1.xml
+../csdl/Task_v1.xml

--- a/redfish-core/schema/dmtf/installed/TelemetryDataCollection_v1.xml
+++ b/redfish-core/schema/dmtf/installed/TelemetryDataCollection_v1.xml
@@ -1,0 +1,1 @@
+../csdl/TelemetryDataCollection_v1.xml

--- a/redfish-core/schema/dmtf/installed/TelemetryData_v1.xml
+++ b/redfish-core/schema/dmtf/installed/TelemetryData_v1.xml
@@ -1,0 +1,1 @@
+../csdl/TelemetryData_v1.xml

--- a/redfish-core/schema/dmtf/installed/TelemetryService_v1.xml
+++ b/redfish-core/schema/dmtf/installed/TelemetryService_v1.xml
@@ -1,1 +1,1 @@
-../../../../redfish-core/schema/dmtf/csdl/TelemetryService_v1.xml
+../csdl/TelemetryService_v1.xml

--- a/redfish-core/schema/dmtf/installed/ThermalEquipment_v1.xml
+++ b/redfish-core/schema/dmtf/installed/ThermalEquipment_v1.xml
@@ -1,0 +1,1 @@
+../csdl/ThermalEquipment_v1.xml

--- a/redfish-core/schema/dmtf/installed/ThermalMetrics_v1.xml
+++ b/redfish-core/schema/dmtf/installed/ThermalMetrics_v1.xml
@@ -1,1 +1,1 @@
-../../../../redfish-core/schema/dmtf/csdl/ThermalMetrics_v1.xml
+../csdl/ThermalMetrics_v1.xml

--- a/redfish-core/schema/dmtf/installed/ThermalSubsystem_v1.xml
+++ b/redfish-core/schema/dmtf/installed/ThermalSubsystem_v1.xml
@@ -1,1 +1,1 @@
-../../../../redfish-core/schema/dmtf/csdl/ThermalSubsystem_v1.xml
+../csdl/ThermalSubsystem_v1.xml

--- a/redfish-core/schema/dmtf/installed/Thermal_v1.xml
+++ b/redfish-core/schema/dmtf/installed/Thermal_v1.xml
@@ -1,1 +1,1 @@
-../../../../redfish-core/schema/dmtf/csdl/Thermal_v1.xml
+../csdl/Thermal_v1.xml

--- a/redfish-core/schema/dmtf/installed/TriggersCollection_v1.xml
+++ b/redfish-core/schema/dmtf/installed/TriggersCollection_v1.xml
@@ -1,1 +1,1 @@
-../../../../redfish-core/schema/dmtf/csdl/TriggersCollection_v1.xml
+../csdl/TriggersCollection_v1.xml

--- a/redfish-core/schema/dmtf/installed/Triggers_v1.xml
+++ b/redfish-core/schema/dmtf/installed/Triggers_v1.xml
@@ -1,1 +1,1 @@
-../../../../redfish-core/schema/dmtf/csdl/Triggers_v1.xml
+../csdl/Triggers_v1.xml

--- a/redfish-core/schema/dmtf/installed/TrustedComponentCollection_v1.xml
+++ b/redfish-core/schema/dmtf/installed/TrustedComponentCollection_v1.xml
@@ -1,0 +1,1 @@
+../csdl/TrustedComponentCollection_v1.xml

--- a/redfish-core/schema/dmtf/installed/TrustedComponent_v1.xml
+++ b/redfish-core/schema/dmtf/installed/TrustedComponent_v1.xml
@@ -1,0 +1,1 @@
+../csdl/TrustedComponent_v1.xml

--- a/redfish-core/schema/dmtf/installed/USBControllerCollection_v1.xml
+++ b/redfish-core/schema/dmtf/installed/USBControllerCollection_v1.xml
@@ -1,0 +1,1 @@
+../csdl/USBControllerCollection_v1.xml

--- a/redfish-core/schema/dmtf/installed/USBController_v1.xml
+++ b/redfish-core/schema/dmtf/installed/USBController_v1.xml
@@ -1,0 +1,1 @@
+../csdl/USBController_v1.xml

--- a/redfish-core/schema/dmtf/installed/UpdateServiceCapabilities_v1.xml
+++ b/redfish-core/schema/dmtf/installed/UpdateServiceCapabilities_v1.xml
@@ -1,0 +1,1 @@
+../csdl/UpdateServiceCapabilities_v1.xml

--- a/redfish-core/schema/dmtf/installed/UpdateService_v1.xml
+++ b/redfish-core/schema/dmtf/installed/UpdateService_v1.xml
@@ -1,1 +1,1 @@
-../../../../redfish-core/schema/dmtf/csdl/UpdateService_v1.xml
+../csdl/UpdateService_v1.xml

--- a/redfish-core/schema/dmtf/installed/VCATEntryCollection_v1.xml
+++ b/redfish-core/schema/dmtf/installed/VCATEntryCollection_v1.xml
@@ -1,0 +1,1 @@
+../csdl/VCATEntryCollection_v1.xml

--- a/redfish-core/schema/dmtf/installed/VCATEntry_v1.xml
+++ b/redfish-core/schema/dmtf/installed/VCATEntry_v1.xml
@@ -1,0 +1,1 @@
+../csdl/VCATEntry_v1.xml

--- a/redfish-core/schema/dmtf/installed/VLanNetworkInterfaceCollection_v1.xml
+++ b/redfish-core/schema/dmtf/installed/VLanNetworkInterfaceCollection_v1.xml
@@ -1,0 +1,1 @@
+../csdl/VLanNetworkInterfaceCollection_v1.xml

--- a/redfish-core/schema/dmtf/installed/VLanNetworkInterface_v1.xml
+++ b/redfish-core/schema/dmtf/installed/VLanNetworkInterface_v1.xml
@@ -1,0 +1,1 @@
+../csdl/VLanNetworkInterface_v1.xml

--- a/redfish-core/schema/dmtf/installed/VirtualCXLSwitchCollection_v1.xml
+++ b/redfish-core/schema/dmtf/installed/VirtualCXLSwitchCollection_v1.xml
@@ -1,0 +1,1 @@
+../csdl/VirtualCXLSwitchCollection_v1.xml

--- a/redfish-core/schema/dmtf/installed/VirtualCXLSwitch_v1.xml
+++ b/redfish-core/schema/dmtf/installed/VirtualCXLSwitch_v1.xml
@@ -1,0 +1,1 @@
+../csdl/VirtualCXLSwitch_v1.xml

--- a/redfish-core/schema/dmtf/installed/VirtualMediaCollection_v1.xml
+++ b/redfish-core/schema/dmtf/installed/VirtualMediaCollection_v1.xml
@@ -1,1 +1,1 @@
-../../../../redfish-core/schema/dmtf/csdl/VirtualMediaCollection_v1.xml
+../csdl/VirtualMediaCollection_v1.xml

--- a/redfish-core/schema/dmtf/installed/VirtualMedia_v1.xml
+++ b/redfish-core/schema/dmtf/installed/VirtualMedia_v1.xml
@@ -1,1 +1,1 @@
-../../../../redfish-core/schema/dmtf/csdl/VirtualMedia_v1.xml
+../csdl/VirtualMedia_v1.xml

--- a/redfish-core/schema/dmtf/installed/VirtualPCI2PCIBridgeCollection_v1.xml
+++ b/redfish-core/schema/dmtf/installed/VirtualPCI2PCIBridgeCollection_v1.xml
@@ -1,0 +1,1 @@
+../csdl/VirtualPCI2PCIBridgeCollection_v1.xml

--- a/redfish-core/schema/dmtf/installed/VirtualPCI2PCIBridge_v1.xml
+++ b/redfish-core/schema/dmtf/installed/VirtualPCI2PCIBridge_v1.xml
@@ -1,0 +1,1 @@
+../csdl/VirtualPCI2PCIBridge_v1.xml

--- a/redfish-core/schema/dmtf/installed/VolumeCollection_v1.xml
+++ b/redfish-core/schema/dmtf/installed/VolumeCollection_v1.xml
@@ -1,0 +1,1 @@
+../csdl/VolumeCollection_v1.xml

--- a/redfish-core/schema/dmtf/installed/Volume_v1.xml
+++ b/redfish-core/schema/dmtf/installed/Volume_v1.xml
@@ -1,0 +1,1 @@
+../csdl/Volume_v1.xml

--- a/redfish-core/schema/dmtf/installed/ZoneCollection_v1.xml
+++ b/redfish-core/schema/dmtf/installed/ZoneCollection_v1.xml
@@ -1,0 +1,1 @@
+../csdl/ZoneCollection_v1.xml

--- a/redfish-core/schema/dmtf/installed/Zone_v1.xml
+++ b/redfish-core/schema/dmtf/installed/Zone_v1.xml
@@ -1,0 +1,1 @@
+../csdl/Zone_v1.xml

--- a/redfish-core/schema/dmtf/json-schema-installed/AccelerationFunction.v1_0_5.json
+++ b/redfish-core/schema/dmtf/json-schema-installed/AccelerationFunction.v1_0_5.json
@@ -1,0 +1,1 @@
+../json-schema/AccelerationFunction.v1_0_5.json

--- a/redfish-core/schema/dmtf/json-schema-installed/AccelerationFunctionCollection.json
+++ b/redfish-core/schema/dmtf/json-schema-installed/AccelerationFunctionCollection.json
@@ -1,0 +1,1 @@
+../json-schema/AccelerationFunctionCollection.json

--- a/redfish-core/schema/dmtf/json-schema-installed/AddressPool.v1_3_0.json
+++ b/redfish-core/schema/dmtf/json-schema-installed/AddressPool.v1_3_0.json
@@ -1,0 +1,1 @@
+../json-schema/AddressPool.v1_3_0.json

--- a/redfish-core/schema/dmtf/json-schema-installed/AddressPoolCollection.json
+++ b/redfish-core/schema/dmtf/json-schema-installed/AddressPoolCollection.json
@@ -1,0 +1,1 @@
+../json-schema/AddressPoolCollection.json

--- a/redfish-core/schema/dmtf/json-schema-installed/Aggregate.v1_0_3.json
+++ b/redfish-core/schema/dmtf/json-schema-installed/Aggregate.v1_0_3.json
@@ -1,0 +1,1 @@
+../json-schema/Aggregate.v1_0_3.json

--- a/redfish-core/schema/dmtf/json-schema-installed/AggregateCollection.json
+++ b/redfish-core/schema/dmtf/json-schema-installed/AggregateCollection.json
@@ -1,0 +1,1 @@
+../json-schema/AggregateCollection.json

--- a/redfish-core/schema/dmtf/json-schema-installed/AllowDeny.v1_0_3.json
+++ b/redfish-core/schema/dmtf/json-schema-installed/AllowDeny.v1_0_3.json
@@ -1,0 +1,1 @@
+../json-schema/AllowDeny.v1_0_3.json

--- a/redfish-core/schema/dmtf/json-schema-installed/AllowDenyCollection.json
+++ b/redfish-core/schema/dmtf/json-schema-installed/AllowDenyCollection.json
@@ -1,0 +1,1 @@
+../json-schema/AllowDenyCollection.json

--- a/redfish-core/schema/dmtf/json-schema-installed/Application.v1_0_1.json
+++ b/redfish-core/schema/dmtf/json-schema-installed/Application.v1_0_1.json
@@ -1,0 +1,1 @@
+../json-schema/Application.v1_0_1.json

--- a/redfish-core/schema/dmtf/json-schema-installed/ApplicationCollection.json
+++ b/redfish-core/schema/dmtf/json-schema-installed/ApplicationCollection.json
@@ -1,0 +1,1 @@
+../json-schema/ApplicationCollection.json

--- a/redfish-core/schema/dmtf/json-schema-installed/AutomationInstrumentation.v1_0_0.json
+++ b/redfish-core/schema/dmtf/json-schema-installed/AutomationInstrumentation.v1_0_0.json
@@ -1,0 +1,1 @@
+../json-schema/AutomationInstrumentation.v1_0_0.json

--- a/redfish-core/schema/dmtf/json-schema-installed/AutomationNode.v1_0_0.json
+++ b/redfish-core/schema/dmtf/json-schema-installed/AutomationNode.v1_0_0.json
@@ -1,0 +1,1 @@
+../json-schema/AutomationNode.v1_0_0.json

--- a/redfish-core/schema/dmtf/json-schema-installed/AutomationNodeCollection.json
+++ b/redfish-core/schema/dmtf/json-schema-installed/AutomationNodeCollection.json
@@ -1,0 +1,1 @@
+../json-schema/AutomationNodeCollection.json

--- a/redfish-core/schema/dmtf/json-schema-installed/Battery.v1_4_0.json
+++ b/redfish-core/schema/dmtf/json-schema-installed/Battery.v1_4_0.json
@@ -1,0 +1,1 @@
+../json-schema/Battery.v1_4_0.json

--- a/redfish-core/schema/dmtf/json-schema-installed/BatteryCollection.json
+++ b/redfish-core/schema/dmtf/json-schema-installed/BatteryCollection.json
@@ -1,0 +1,1 @@
+../json-schema/BatteryCollection.json

--- a/redfish-core/schema/dmtf/json-schema-installed/BatteryMetrics.v1_0_4.json
+++ b/redfish-core/schema/dmtf/json-schema-installed/BatteryMetrics.v1_0_4.json
@@ -1,0 +1,1 @@
+../json-schema/BatteryMetrics.v1_0_4.json

--- a/redfish-core/schema/dmtf/json-schema-installed/BootOption.v1_0_6.json
+++ b/redfish-core/schema/dmtf/json-schema-installed/BootOption.v1_0_6.json
@@ -1,0 +1,1 @@
+../json-schema/BootOption.v1_0_6.json

--- a/redfish-core/schema/dmtf/json-schema-installed/BootOptionCollection.json
+++ b/redfish-core/schema/dmtf/json-schema-installed/BootOptionCollection.json
@@ -1,0 +1,1 @@
+../json-schema/BootOptionCollection.json

--- a/redfish-core/schema/dmtf/json-schema-installed/CXLLogicalDevice.v1_2_1.json
+++ b/redfish-core/schema/dmtf/json-schema-installed/CXLLogicalDevice.v1_2_1.json
@@ -1,0 +1,1 @@
+../json-schema/CXLLogicalDevice.v1_2_1.json

--- a/redfish-core/schema/dmtf/json-schema-installed/CXLLogicalDeviceCollection.json
+++ b/redfish-core/schema/dmtf/json-schema-installed/CXLLogicalDeviceCollection.json
@@ -1,0 +1,1 @@
+../json-schema/CXLLogicalDeviceCollection.json

--- a/redfish-core/schema/dmtf/json-schema-installed/Circuit.v1_8_1.json
+++ b/redfish-core/schema/dmtf/json-schema-installed/Circuit.v1_8_1.json
@@ -1,0 +1,1 @@
+../json-schema/Circuit.v1_8_1.json

--- a/redfish-core/schema/dmtf/json-schema-installed/CircuitCollection.json
+++ b/redfish-core/schema/dmtf/json-schema-installed/CircuitCollection.json
@@ -1,0 +1,1 @@
+../json-schema/CircuitCollection.json

--- a/redfish-core/schema/dmtf/json-schema-installed/CollectionCapabilities.v1_4_1.json
+++ b/redfish-core/schema/dmtf/json-schema-installed/CollectionCapabilities.v1_4_1.json
@@ -1,0 +1,1 @@
+../json-schema/CollectionCapabilities.v1_4_1.json

--- a/redfish-core/schema/dmtf/json-schema-installed/CompositionReservation.v1_0_2.json
+++ b/redfish-core/schema/dmtf/json-schema-installed/CompositionReservation.v1_0_2.json
@@ -1,0 +1,1 @@
+../json-schema/CompositionReservation.v1_0_2.json

--- a/redfish-core/schema/dmtf/json-schema-installed/CompositionReservationCollection.json
+++ b/redfish-core/schema/dmtf/json-schema-installed/CompositionReservationCollection.json
@@ -1,0 +1,1 @@
+../json-schema/CompositionReservationCollection.json

--- a/redfish-core/schema/dmtf/json-schema-installed/CompositionService.v1_2_3.json
+++ b/redfish-core/schema/dmtf/json-schema-installed/CompositionService.v1_2_3.json
@@ -1,0 +1,1 @@
+../json-schema/CompositionService.v1_2_3.json

--- a/redfish-core/schema/dmtf/json-schema-installed/Connection.v1_4_0.json
+++ b/redfish-core/schema/dmtf/json-schema-installed/Connection.v1_4_0.json
@@ -1,0 +1,1 @@
+../json-schema/Connection.v1_4_0.json

--- a/redfish-core/schema/dmtf/json-schema-installed/ConnectionCollection.json
+++ b/redfish-core/schema/dmtf/json-schema-installed/ConnectionCollection.json
@@ -1,0 +1,1 @@
+../json-schema/ConnectionCollection.json

--- a/redfish-core/schema/dmtf/json-schema-installed/ConnectionMethod.v1_2_0.json
+++ b/redfish-core/schema/dmtf/json-schema-installed/ConnectionMethod.v1_2_0.json
@@ -1,0 +1,1 @@
+../json-schema/ConnectionMethod.v1_2_0.json

--- a/redfish-core/schema/dmtf/json-schema-installed/ConnectionMethodCollection.json
+++ b/redfish-core/schema/dmtf/json-schema-installed/ConnectionMethodCollection.json
@@ -1,0 +1,1 @@
+../json-schema/ConnectionMethodCollection.json

--- a/redfish-core/schema/dmtf/json-schema-installed/Container.v1_0_1.json
+++ b/redfish-core/schema/dmtf/json-schema-installed/Container.v1_0_1.json
@@ -1,0 +1,1 @@
+../json-schema/Container.v1_0_1.json

--- a/redfish-core/schema/dmtf/json-schema-installed/ContainerCollection.json
+++ b/redfish-core/schema/dmtf/json-schema-installed/ContainerCollection.json
@@ -1,0 +1,1 @@
+../json-schema/ContainerCollection.json

--- a/redfish-core/schema/dmtf/json-schema-installed/ContainerImage.v1_0_1.json
+++ b/redfish-core/schema/dmtf/json-schema-installed/ContainerImage.v1_0_1.json
@@ -1,0 +1,1 @@
+../json-schema/ContainerImage.v1_0_1.json

--- a/redfish-core/schema/dmtf/json-schema-installed/ContainerImageCollection.json
+++ b/redfish-core/schema/dmtf/json-schema-installed/ContainerImageCollection.json
@@ -1,0 +1,1 @@
+../json-schema/ContainerImageCollection.json

--- a/redfish-core/schema/dmtf/json-schema-installed/Control.v1_7_0.json
+++ b/redfish-core/schema/dmtf/json-schema-installed/Control.v1_7_0.json
@@ -1,0 +1,1 @@
+../json-schema/Control.v1_7_0.json

--- a/redfish-core/schema/dmtf/json-schema-installed/ControlCollection.json
+++ b/redfish-core/schema/dmtf/json-schema-installed/ControlCollection.json
@@ -1,0 +1,1 @@
+../json-schema/ControlCollection.json

--- a/redfish-core/schema/dmtf/json-schema-installed/CoolantConnector.v1_2_0.json
+++ b/redfish-core/schema/dmtf/json-schema-installed/CoolantConnector.v1_2_0.json
@@ -1,0 +1,1 @@
+../json-schema/CoolantConnector.v1_2_0.json

--- a/redfish-core/schema/dmtf/json-schema-installed/CoolantConnectorCollection.json
+++ b/redfish-core/schema/dmtf/json-schema-installed/CoolantConnectorCollection.json
@@ -1,0 +1,1 @@
+../json-schema/CoolantConnectorCollection.json

--- a/redfish-core/schema/dmtf/json-schema-installed/CoolingLoop.v1_0_3.json
+++ b/redfish-core/schema/dmtf/json-schema-installed/CoolingLoop.v1_0_3.json
@@ -1,0 +1,1 @@
+../json-schema/CoolingLoop.v1_0_3.json

--- a/redfish-core/schema/dmtf/json-schema-installed/CoolingLoopCollection.json
+++ b/redfish-core/schema/dmtf/json-schema-installed/CoolingLoopCollection.json
@@ -1,0 +1,1 @@
+../json-schema/CoolingLoopCollection.json

--- a/redfish-core/schema/dmtf/json-schema-installed/CoolingUnit.v1_3_0.json
+++ b/redfish-core/schema/dmtf/json-schema-installed/CoolingUnit.v1_3_0.json
@@ -1,0 +1,1 @@
+../json-schema/CoolingUnit.v1_3_0.json

--- a/redfish-core/schema/dmtf/json-schema-installed/CoolingUnitCollection.json
+++ b/redfish-core/schema/dmtf/json-schema-installed/CoolingUnitCollection.json
@@ -1,0 +1,1 @@
+../json-schema/CoolingUnitCollection.json

--- a/redfish-core/schema/dmtf/json-schema-installed/DriveMetrics.v1_2_1.json
+++ b/redfish-core/schema/dmtf/json-schema-installed/DriveMetrics.v1_2_1.json
@@ -1,0 +1,1 @@
+../json-schema/DriveMetrics.v1_2_1.json

--- a/redfish-core/schema/dmtf/json-schema-installed/Endpoint.v1_8_2.json
+++ b/redfish-core/schema/dmtf/json-schema-installed/Endpoint.v1_8_2.json
@@ -1,0 +1,1 @@
+../json-schema/Endpoint.v1_8_2.json

--- a/redfish-core/schema/dmtf/json-schema-installed/EndpointCollection.json
+++ b/redfish-core/schema/dmtf/json-schema-installed/EndpointCollection.json
@@ -1,0 +1,1 @@
+../json-schema/EndpointCollection.json

--- a/redfish-core/schema/dmtf/json-schema-installed/EndpointGroup.v1_3_4.json
+++ b/redfish-core/schema/dmtf/json-schema-installed/EndpointGroup.v1_3_4.json
@@ -1,0 +1,1 @@
+../json-schema/EndpointGroup.v1_3_4.json

--- a/redfish-core/schema/dmtf/json-schema-installed/EndpointGroupCollection.json
+++ b/redfish-core/schema/dmtf/json-schema-installed/EndpointGroupCollection.json
@@ -1,0 +1,1 @@
+../json-schema/EndpointGroupCollection.json

--- a/redfish-core/schema/dmtf/json-schema-installed/ExternalAccountProvider.v1_8_1.json
+++ b/redfish-core/schema/dmtf/json-schema-installed/ExternalAccountProvider.v1_8_1.json
@@ -1,0 +1,1 @@
+../json-schema/ExternalAccountProvider.v1_8_1.json

--- a/redfish-core/schema/dmtf/json-schema-installed/ExternalAccountProviderCollection.json
+++ b/redfish-core/schema/dmtf/json-schema-installed/ExternalAccountProviderCollection.json
@@ -1,0 +1,1 @@
+../json-schema/ExternalAccountProviderCollection.json

--- a/redfish-core/schema/dmtf/json-schema-installed/Fabric.v1_4_0.json
+++ b/redfish-core/schema/dmtf/json-schema-installed/Fabric.v1_4_0.json
@@ -1,0 +1,1 @@
+../json-schema/Fabric.v1_4_0.json

--- a/redfish-core/schema/dmtf/json-schema-installed/FabricCollection.json
+++ b/redfish-core/schema/dmtf/json-schema-installed/FabricCollection.json
@@ -1,0 +1,1 @@
+../json-schema/FabricCollection.json

--- a/redfish-core/schema/dmtf/json-schema-installed/Facility.v1_4_2.json
+++ b/redfish-core/schema/dmtf/json-schema-installed/Facility.v1_4_2.json
@@ -1,0 +1,1 @@
+../json-schema/Facility.v1_4_2.json

--- a/redfish-core/schema/dmtf/json-schema-installed/FacilityCollection.json
+++ b/redfish-core/schema/dmtf/json-schema-installed/FacilityCollection.json
@@ -1,0 +1,1 @@
+../json-schema/FacilityCollection.json

--- a/redfish-core/schema/dmtf/json-schema-installed/Filter.v1_1_0.json
+++ b/redfish-core/schema/dmtf/json-schema-installed/Filter.v1_1_0.json
@@ -1,0 +1,1 @@
+../json-schema/Filter.v1_1_0.json

--- a/redfish-core/schema/dmtf/json-schema-installed/FilterCollection.json
+++ b/redfish-core/schema/dmtf/json-schema-installed/FilterCollection.json
@@ -1,0 +1,1 @@
+../json-schema/FilterCollection.json

--- a/redfish-core/schema/dmtf/json-schema-installed/GraphicsController.v1_0_2.json
+++ b/redfish-core/schema/dmtf/json-schema-installed/GraphicsController.v1_0_2.json
@@ -1,0 +1,1 @@
+../json-schema/GraphicsController.v1_0_2.json

--- a/redfish-core/schema/dmtf/json-schema-installed/GraphicsControllerCollection.json
+++ b/redfish-core/schema/dmtf/json-schema-installed/GraphicsControllerCollection.json
@@ -1,0 +1,1 @@
+../json-schema/GraphicsControllerCollection.json

--- a/redfish-core/schema/dmtf/json-schema-installed/Heater.v1_0_2.json
+++ b/redfish-core/schema/dmtf/json-schema-installed/Heater.v1_0_2.json
@@ -1,0 +1,1 @@
+../json-schema/Heater.v1_0_2.json

--- a/redfish-core/schema/dmtf/json-schema-installed/HeaterCollection.json
+++ b/redfish-core/schema/dmtf/json-schema-installed/HeaterCollection.json
@@ -1,0 +1,1 @@
+../json-schema/HeaterCollection.json

--- a/redfish-core/schema/dmtf/json-schema-installed/HeaterMetrics.v1_0_2.json
+++ b/redfish-core/schema/dmtf/json-schema-installed/HeaterMetrics.v1_0_2.json
@@ -1,0 +1,1 @@
+../json-schema/HeaterMetrics.v1_0_2.json

--- a/redfish-core/schema/dmtf/json-schema-installed/HostInterface.v1_3_3.json
+++ b/redfish-core/schema/dmtf/json-schema-installed/HostInterface.v1_3_3.json
@@ -1,0 +1,1 @@
+../json-schema/HostInterface.v1_3_3.json

--- a/redfish-core/schema/dmtf/json-schema-installed/HostInterfaceCollection.json
+++ b/redfish-core/schema/dmtf/json-schema-installed/HostInterfaceCollection.json
@@ -1,0 +1,1 @@
+../json-schema/HostInterfaceCollection.json

--- a/redfish-core/schema/dmtf/json-schema-installed/Job.v1_3_0.json
+++ b/redfish-core/schema/dmtf/json-schema-installed/Job.v1_3_0.json
@@ -1,0 +1,1 @@
+../json-schema/Job.v1_3_0.json

--- a/redfish-core/schema/dmtf/json-schema-installed/JobCollection.json
+++ b/redfish-core/schema/dmtf/json-schema-installed/JobCollection.json
@@ -1,0 +1,1 @@
+../json-schema/JobCollection.json

--- a/redfish-core/schema/dmtf/json-schema-installed/JobDocument.v1_0_0.json
+++ b/redfish-core/schema/dmtf/json-schema-installed/JobDocument.v1_0_0.json
@@ -1,0 +1,1 @@
+../json-schema/JobDocument.v1_0_0.json

--- a/redfish-core/schema/dmtf/json-schema-installed/JobDocumentCollection.json
+++ b/redfish-core/schema/dmtf/json-schema-installed/JobDocumentCollection.json
@@ -1,0 +1,1 @@
+../json-schema/JobDocumentCollection.json

--- a/redfish-core/schema/dmtf/json-schema-installed/JobExecutor.v1_0_0.json
+++ b/redfish-core/schema/dmtf/json-schema-installed/JobExecutor.v1_0_0.json
@@ -1,0 +1,1 @@
+../json-schema/JobExecutor.v1_0_0.json

--- a/redfish-core/schema/dmtf/json-schema-installed/JobExecutorCollection.json
+++ b/redfish-core/schema/dmtf/json-schema-installed/JobExecutorCollection.json
@@ -1,0 +1,1 @@
+../json-schema/JobExecutorCollection.json

--- a/redfish-core/schema/dmtf/json-schema-installed/JobService.v1_1_0.json
+++ b/redfish-core/schema/dmtf/json-schema-installed/JobService.v1_1_0.json
@@ -1,0 +1,1 @@
+../json-schema/JobService.v1_1_0.json

--- a/redfish-core/schema/dmtf/json-schema-installed/Key.v1_4_1.json
+++ b/redfish-core/schema/dmtf/json-schema-installed/Key.v1_4_1.json
@@ -1,0 +1,1 @@
+../json-schema/Key.v1_4_1.json

--- a/redfish-core/schema/dmtf/json-schema-installed/KeyCollection.json
+++ b/redfish-core/schema/dmtf/json-schema-installed/KeyCollection.json
@@ -1,0 +1,1 @@
+../json-schema/KeyCollection.json

--- a/redfish-core/schema/dmtf/json-schema-installed/KeyPolicy.v1_0_1.json
+++ b/redfish-core/schema/dmtf/json-schema-installed/KeyPolicy.v1_0_1.json
@@ -1,0 +1,1 @@
+../json-schema/KeyPolicy.v1_0_1.json

--- a/redfish-core/schema/dmtf/json-schema-installed/KeyPolicyCollection.json
+++ b/redfish-core/schema/dmtf/json-schema-installed/KeyPolicyCollection.json
@@ -1,0 +1,1 @@
+../json-schema/KeyPolicyCollection.json

--- a/redfish-core/schema/dmtf/json-schema-installed/KeyService.v1_0_1.json
+++ b/redfish-core/schema/dmtf/json-schema-installed/KeyService.v1_0_1.json
@@ -1,0 +1,1 @@
+../json-schema/KeyService.v1_0_1.json

--- a/redfish-core/schema/dmtf/json-schema-installed/LeakDetection.v1_1_0.json
+++ b/redfish-core/schema/dmtf/json-schema-installed/LeakDetection.v1_1_0.json
@@ -1,0 +1,1 @@
+../json-schema/LeakDetection.v1_1_0.json

--- a/redfish-core/schema/dmtf/json-schema-installed/LeakDetector.v1_4_0.json
+++ b/redfish-core/schema/dmtf/json-schema-installed/LeakDetector.v1_4_0.json
@@ -1,0 +1,1 @@
+../json-schema/LeakDetector.v1_4_0.json

--- a/redfish-core/schema/dmtf/json-schema-installed/LeakDetectorCollection.json
+++ b/redfish-core/schema/dmtf/json-schema-installed/LeakDetectorCollection.json
@@ -1,0 +1,1 @@
+../json-schema/LeakDetectorCollection.json

--- a/redfish-core/schema/dmtf/json-schema-installed/License.v1_1_4.json
+++ b/redfish-core/schema/dmtf/json-schema-installed/License.v1_1_4.json
@@ -1,0 +1,1 @@
+../json-schema/License.v1_1_4.json

--- a/redfish-core/schema/dmtf/json-schema-installed/LicenseCollection.json
+++ b/redfish-core/schema/dmtf/json-schema-installed/LicenseCollection.json
@@ -1,0 +1,1 @@
+../json-schema/LicenseCollection.json

--- a/redfish-core/schema/dmtf/json-schema-installed/LicenseService.v1_1_2.json
+++ b/redfish-core/schema/dmtf/json-schema-installed/LicenseService.v1_1_2.json
@@ -1,0 +1,1 @@
+../json-schema/LicenseService.v1_1_2.json

--- a/redfish-core/schema/dmtf/json-schema-installed/Manifest.v1_1_2.json
+++ b/redfish-core/schema/dmtf/json-schema-installed/Manifest.v1_1_2.json
@@ -1,0 +1,1 @@
+../json-schema/Manifest.v1_1_2.json

--- a/redfish-core/schema/dmtf/json-schema-installed/MediaController.v1_3_2.json
+++ b/redfish-core/schema/dmtf/json-schema-installed/MediaController.v1_3_2.json
@@ -1,0 +1,1 @@
+../json-schema/MediaController.v1_3_2.json

--- a/redfish-core/schema/dmtf/json-schema-installed/MediaControllerCollection.json
+++ b/redfish-core/schema/dmtf/json-schema-installed/MediaControllerCollection.json
@@ -1,0 +1,1 @@
+../json-schema/MediaControllerCollection.json

--- a/redfish-core/schema/dmtf/json-schema-installed/MemoryChunks.v1_6_2.json
+++ b/redfish-core/schema/dmtf/json-schema-installed/MemoryChunks.v1_6_2.json
@@ -1,0 +1,1 @@
+../json-schema/MemoryChunks.v1_6_2.json

--- a/redfish-core/schema/dmtf/json-schema-installed/MemoryChunksCollection.json
+++ b/redfish-core/schema/dmtf/json-schema-installed/MemoryChunksCollection.json
@@ -1,0 +1,1 @@
+../json-schema/MemoryChunksCollection.json

--- a/redfish-core/schema/dmtf/json-schema-installed/MemoryDomain.v1_5_1.json
+++ b/redfish-core/schema/dmtf/json-schema-installed/MemoryDomain.v1_5_1.json
@@ -1,0 +1,1 @@
+../json-schema/MemoryDomain.v1_5_1.json

--- a/redfish-core/schema/dmtf/json-schema-installed/MemoryDomainCollection.json
+++ b/redfish-core/schema/dmtf/json-schema-installed/MemoryDomainCollection.json
@@ -1,0 +1,1 @@
+../json-schema/MemoryDomainCollection.json

--- a/redfish-core/schema/dmtf/json-schema-installed/MemoryMetrics.v1_7_3.json
+++ b/redfish-core/schema/dmtf/json-schema-installed/MemoryMetrics.v1_7_3.json
@@ -1,0 +1,1 @@
+../json-schema/MemoryMetrics.v1_7_3.json

--- a/redfish-core/schema/dmtf/json-schema-installed/MemoryRegion.v1_0_3.json
+++ b/redfish-core/schema/dmtf/json-schema-installed/MemoryRegion.v1_0_3.json
@@ -1,0 +1,1 @@
+../json-schema/MemoryRegion.v1_0_3.json

--- a/redfish-core/schema/dmtf/json-schema-installed/MemoryRegionCollection.json
+++ b/redfish-core/schema/dmtf/json-schema-installed/MemoryRegionCollection.json
@@ -1,0 +1,1 @@
+../json-schema/MemoryRegionCollection.json

--- a/redfish-core/schema/dmtf/json-schema-installed/NetworkAdapter.v1_12_1.json
+++ b/redfish-core/schema/dmtf/json-schema-installed/NetworkAdapter.v1_12_1.json
@@ -1,0 +1,1 @@
+../json-schema/NetworkAdapter.v1_12_1.json

--- a/redfish-core/schema/dmtf/json-schema-installed/NetworkAdapterCollection.json
+++ b/redfish-core/schema/dmtf/json-schema-installed/NetworkAdapterCollection.json
@@ -1,0 +1,1 @@
+../json-schema/NetworkAdapterCollection.json

--- a/redfish-core/schema/dmtf/json-schema-installed/NetworkAdapterMetrics.v1_1_0.json
+++ b/redfish-core/schema/dmtf/json-schema-installed/NetworkAdapterMetrics.v1_1_0.json
@@ -1,0 +1,1 @@
+../json-schema/NetworkAdapterMetrics.v1_1_0.json

--- a/redfish-core/schema/dmtf/json-schema-installed/NetworkDeviceFunction.v1_11_0.json
+++ b/redfish-core/schema/dmtf/json-schema-installed/NetworkDeviceFunction.v1_11_0.json
@@ -1,0 +1,1 @@
+../json-schema/NetworkDeviceFunction.v1_11_0.json

--- a/redfish-core/schema/dmtf/json-schema-installed/NetworkDeviceFunctionCollection.json
+++ b/redfish-core/schema/dmtf/json-schema-installed/NetworkDeviceFunctionCollection.json
@@ -1,0 +1,1 @@
+../json-schema/NetworkDeviceFunctionCollection.json

--- a/redfish-core/schema/dmtf/json-schema-installed/NetworkDeviceFunctionMetrics.v1_2_0.json
+++ b/redfish-core/schema/dmtf/json-schema-installed/NetworkDeviceFunctionMetrics.v1_2_0.json
@@ -1,0 +1,1 @@
+../json-schema/NetworkDeviceFunctionMetrics.v1_2_0.json

--- a/redfish-core/schema/dmtf/json-schema-installed/NetworkInterface.v1_2_3.json
+++ b/redfish-core/schema/dmtf/json-schema-installed/NetworkInterface.v1_2_3.json
@@ -1,0 +1,1 @@
+../json-schema/NetworkInterface.v1_2_3.json

--- a/redfish-core/schema/dmtf/json-schema-installed/NetworkInterfaceCollection.json
+++ b/redfish-core/schema/dmtf/json-schema-installed/NetworkInterfaceCollection.json
@@ -1,0 +1,1 @@
+../json-schema/NetworkInterfaceCollection.json

--- a/redfish-core/schema/dmtf/json-schema-installed/NetworkPort.v1_4_3.json
+++ b/redfish-core/schema/dmtf/json-schema-installed/NetworkPort.v1_4_3.json
@@ -1,0 +1,1 @@
+../json-schema/NetworkPort.v1_4_3.json

--- a/redfish-core/schema/dmtf/json-schema-installed/NetworkPortCollection.json
+++ b/redfish-core/schema/dmtf/json-schema-installed/NetworkPortCollection.json
@@ -1,0 +1,1 @@
+../json-schema/NetworkPortCollection.json

--- a/redfish-core/schema/dmtf/json-schema-installed/OperatingSystem.v1_0_2.json
+++ b/redfish-core/schema/dmtf/json-schema-installed/OperatingSystem.v1_0_2.json
@@ -1,0 +1,1 @@
+../json-schema/OperatingSystem.v1_0_2.json

--- a/redfish-core/schema/dmtf/json-schema-installed/OutboundConnection.v1_0_2.json
+++ b/redfish-core/schema/dmtf/json-schema-installed/OutboundConnection.v1_0_2.json
@@ -1,0 +1,1 @@
+../json-schema/OutboundConnection.v1_0_2.json

--- a/redfish-core/schema/dmtf/json-schema-installed/OutboundConnectionCollection.json
+++ b/redfish-core/schema/dmtf/json-schema-installed/OutboundConnectionCollection.json
@@ -1,0 +1,1 @@
+../json-schema/OutboundConnectionCollection.json

--- a/redfish-core/schema/dmtf/json-schema-installed/Outlet.v1_4_4.json
+++ b/redfish-core/schema/dmtf/json-schema-installed/Outlet.v1_4_4.json
@@ -1,0 +1,1 @@
+../json-schema/Outlet.v1_4_4.json

--- a/redfish-core/schema/dmtf/json-schema-installed/OutletCollection.json
+++ b/redfish-core/schema/dmtf/json-schema-installed/OutletCollection.json
@@ -1,0 +1,1 @@
+../json-schema/OutletCollection.json

--- a/redfish-core/schema/dmtf/json-schema-installed/OutletGroup.v1_2_0.json
+++ b/redfish-core/schema/dmtf/json-schema-installed/OutletGroup.v1_2_0.json
@@ -1,0 +1,1 @@
+../json-schema/OutletGroup.v1_2_0.json

--- a/redfish-core/schema/dmtf/json-schema-installed/OutletGroupCollection.json
+++ b/redfish-core/schema/dmtf/json-schema-installed/OutletGroupCollection.json
@@ -1,0 +1,1 @@
+../json-schema/OutletGroupCollection.json

--- a/redfish-core/schema/dmtf/json-schema-installed/PortMetrics.v1_7_0.json
+++ b/redfish-core/schema/dmtf/json-schema-installed/PortMetrics.v1_7_0.json
@@ -1,0 +1,1 @@
+../json-schema/PortMetrics.v1_7_0.json

--- a/redfish-core/schema/dmtf/json-schema-installed/PowerDistribution.v1_4_0.json
+++ b/redfish-core/schema/dmtf/json-schema-installed/PowerDistribution.v1_4_0.json
@@ -1,0 +1,1 @@
+../json-schema/PowerDistribution.v1_4_0.json

--- a/redfish-core/schema/dmtf/json-schema-installed/PowerDistributionCollection.json
+++ b/redfish-core/schema/dmtf/json-schema-installed/PowerDistributionCollection.json
@@ -1,0 +1,1 @@
+../json-schema/PowerDistributionCollection.json

--- a/redfish-core/schema/dmtf/json-schema-installed/PowerDistributionMetrics.v1_4_0.json
+++ b/redfish-core/schema/dmtf/json-schema-installed/PowerDistributionMetrics.v1_4_0.json
@@ -1,0 +1,1 @@
+../json-schema/PowerDistributionMetrics.v1_4_0.json

--- a/redfish-core/schema/dmtf/json-schema-installed/PowerDomain.v1_2_2.json
+++ b/redfish-core/schema/dmtf/json-schema-installed/PowerDomain.v1_2_2.json
@@ -1,0 +1,1 @@
+../json-schema/PowerDomain.v1_2_2.json

--- a/redfish-core/schema/dmtf/json-schema-installed/PowerDomainCollection.json
+++ b/redfish-core/schema/dmtf/json-schema-installed/PowerDomainCollection.json
@@ -1,0 +1,1 @@
+../json-schema/PowerDomainCollection.json

--- a/redfish-core/schema/dmtf/json-schema-installed/PowerEquipment.v1_2_3.json
+++ b/redfish-core/schema/dmtf/json-schema-installed/PowerEquipment.v1_2_3.json
@@ -1,0 +1,1 @@
+../json-schema/PowerEquipment.v1_2_3.json

--- a/redfish-core/schema/dmtf/json-schema-installed/PowerSupplyMetrics.v1_1_2.json
+++ b/redfish-core/schema/dmtf/json-schema-installed/PowerSupplyMetrics.v1_1_2.json
@@ -1,0 +1,1 @@
+../json-schema/PowerSupplyMetrics.v1_1_2.json

--- a/redfish-core/schema/dmtf/json-schema-installed/PrivilegeRegistry.v1_1_5.json
+++ b/redfish-core/schema/dmtf/json-schema-installed/PrivilegeRegistry.v1_1_5.json
@@ -1,0 +1,1 @@
+../json-schema/PrivilegeRegistry.v1_1_5.json

--- a/redfish-core/schema/dmtf/json-schema-installed/ProcessorMetrics.v1_6_4.json
+++ b/redfish-core/schema/dmtf/json-schema-installed/ProcessorMetrics.v1_6_4.json
@@ -1,0 +1,1 @@
+../json-schema/ProcessorMetrics.v1_6_4.json

--- a/redfish-core/schema/dmtf/json-schema-installed/Pump.v1_2_0.json
+++ b/redfish-core/schema/dmtf/json-schema-installed/Pump.v1_2_0.json
@@ -1,0 +1,1 @@
+../json-schema/Pump.v1_2_0.json

--- a/redfish-core/schema/dmtf/json-schema-installed/PumpCollection.json
+++ b/redfish-core/schema/dmtf/json-schema-installed/PumpCollection.json
@@ -1,0 +1,1 @@
+../json-schema/PumpCollection.json

--- a/redfish-core/schema/dmtf/json-schema-installed/RegisteredClient.v1_1_2.json
+++ b/redfish-core/schema/dmtf/json-schema-installed/RegisteredClient.v1_1_2.json
@@ -1,0 +1,1 @@
+../json-schema/RegisteredClient.v1_1_2.json

--- a/redfish-core/schema/dmtf/json-schema-installed/RegisteredClientCollection.json
+++ b/redfish-core/schema/dmtf/json-schema-installed/RegisteredClientCollection.json
@@ -1,0 +1,1 @@
+../json-schema/RegisteredClientCollection.json

--- a/redfish-core/schema/dmtf/json-schema-installed/Reservoir.v1_0_2.json
+++ b/redfish-core/schema/dmtf/json-schema-installed/Reservoir.v1_0_2.json
@@ -1,0 +1,1 @@
+../json-schema/Reservoir.v1_0_2.json

--- a/redfish-core/schema/dmtf/json-schema-installed/ReservoirCollection.json
+++ b/redfish-core/schema/dmtf/json-schema-installed/ReservoirCollection.json
@@ -1,0 +1,1 @@
+../json-schema/ReservoirCollection.json

--- a/redfish-core/schema/dmtf/json-schema-installed/ResolutionStep.v1_0_1.json
+++ b/redfish-core/schema/dmtf/json-schema-installed/ResolutionStep.v1_0_1.json
@@ -1,0 +1,1 @@
+../json-schema/ResolutionStep.v1_0_1.json

--- a/redfish-core/schema/dmtf/json-schema-installed/ResourceBlock.v1_4_3.json
+++ b/redfish-core/schema/dmtf/json-schema-installed/ResourceBlock.v1_4_3.json
@@ -1,0 +1,1 @@
+../json-schema/ResourceBlock.v1_4_3.json

--- a/redfish-core/schema/dmtf/json-schema-installed/ResourceBlockCollection.json
+++ b/redfish-core/schema/dmtf/json-schema-installed/ResourceBlockCollection.json
@@ -1,0 +1,1 @@
+../json-schema/ResourceBlockCollection.json

--- a/redfish-core/schema/dmtf/json-schema-installed/RouteEntry.v1_0_2.json
+++ b/redfish-core/schema/dmtf/json-schema-installed/RouteEntry.v1_0_2.json
@@ -1,0 +1,1 @@
+../json-schema/RouteEntry.v1_0_2.json

--- a/redfish-core/schema/dmtf/json-schema-installed/RouteEntryCollection.json
+++ b/redfish-core/schema/dmtf/json-schema-installed/RouteEntryCollection.json
@@ -1,0 +1,1 @@
+../json-schema/RouteEntryCollection.json

--- a/redfish-core/schema/dmtf/json-schema-installed/RouteSetEntry.v1_0_2.json
+++ b/redfish-core/schema/dmtf/json-schema-installed/RouteSetEntry.v1_0_2.json
@@ -1,0 +1,1 @@
+../json-schema/RouteSetEntry.v1_0_2.json

--- a/redfish-core/schema/dmtf/json-schema-installed/RouteSetEntryCollection.json
+++ b/redfish-core/schema/dmtf/json-schema-installed/RouteSetEntryCollection.json
@@ -1,0 +1,1 @@
+../json-schema/RouteSetEntryCollection.json

--- a/redfish-core/schema/dmtf/json-schema-installed/Schedule.v1_2_5.json
+++ b/redfish-core/schema/dmtf/json-schema-installed/Schedule.v1_2_5.json
@@ -1,0 +1,1 @@
+../json-schema/Schedule.v1_2_5.json

--- a/redfish-core/schema/dmtf/json-schema-installed/SecureBoot.v1_1_2.json
+++ b/redfish-core/schema/dmtf/json-schema-installed/SecureBoot.v1_1_2.json
@@ -1,0 +1,1 @@
+../json-schema/SecureBoot.v1_1_2.json

--- a/redfish-core/schema/dmtf/json-schema-installed/SecureBootDatabase.v1_0_3.json
+++ b/redfish-core/schema/dmtf/json-schema-installed/SecureBootDatabase.v1_0_3.json
@@ -1,0 +1,1 @@
+../json-schema/SecureBootDatabase.v1_0_3.json

--- a/redfish-core/schema/dmtf/json-schema-installed/SecureBootDatabaseCollection.json
+++ b/redfish-core/schema/dmtf/json-schema-installed/SecureBootDatabaseCollection.json
@@ -1,0 +1,1 @@
+../json-schema/SecureBootDatabaseCollection.json

--- a/redfish-core/schema/dmtf/json-schema-installed/SecurityPolicy.v1_0_3.json
+++ b/redfish-core/schema/dmtf/json-schema-installed/SecurityPolicy.v1_0_3.json
@@ -1,0 +1,1 @@
+../json-schema/SecurityPolicy.v1_0_3.json

--- a/redfish-core/schema/dmtf/json-schema-installed/SerialInterface.v1_3_0.json
+++ b/redfish-core/schema/dmtf/json-schema-installed/SerialInterface.v1_3_0.json
@@ -1,0 +1,1 @@
+../json-schema/SerialInterface.v1_3_0.json

--- a/redfish-core/schema/dmtf/json-schema-installed/SerialInterfaceCollection.json
+++ b/redfish-core/schema/dmtf/json-schema-installed/SerialInterfaceCollection.json
@@ -1,0 +1,1 @@
+../json-schema/SerialInterfaceCollection.json

--- a/redfish-core/schema/dmtf/json-schema-installed/ServiceConditions.v1_0_1.json
+++ b/redfish-core/schema/dmtf/json-schema-installed/ServiceConditions.v1_0_1.json
@@ -1,0 +1,1 @@
+../json-schema/ServiceConditions.v1_0_1.json

--- a/redfish-core/schema/dmtf/json-schema-installed/Signature.v1_0_3.json
+++ b/redfish-core/schema/dmtf/json-schema-installed/Signature.v1_0_3.json
@@ -1,0 +1,1 @@
+../json-schema/Signature.v1_0_3.json

--- a/redfish-core/schema/dmtf/json-schema-installed/SignatureCollection.json
+++ b/redfish-core/schema/dmtf/json-schema-installed/SignatureCollection.json
@@ -1,0 +1,1 @@
+../json-schema/SignatureCollection.json

--- a/redfish-core/schema/dmtf/json-schema-installed/SimpleStorage.v1_3_2.json
+++ b/redfish-core/schema/dmtf/json-schema-installed/SimpleStorage.v1_3_2.json
@@ -1,0 +1,1 @@
+../json-schema/SimpleStorage.v1_3_2.json

--- a/redfish-core/schema/dmtf/json-schema-installed/SimpleStorageCollection.json
+++ b/redfish-core/schema/dmtf/json-schema-installed/SimpleStorageCollection.json
@@ -1,0 +1,1 @@
+../json-schema/SimpleStorageCollection.json

--- a/redfish-core/schema/dmtf/json-schema-installed/StorageControllerMetrics.v1_0_3.json
+++ b/redfish-core/schema/dmtf/json-schema-installed/StorageControllerMetrics.v1_0_3.json
@@ -1,0 +1,1 @@
+../json-schema/StorageControllerMetrics.v1_0_3.json

--- a/redfish-core/schema/dmtf/json-schema-installed/StorageMetrics.v1_0_0.json
+++ b/redfish-core/schema/dmtf/json-schema-installed/StorageMetrics.v1_0_0.json
@@ -1,0 +1,1 @@
+../json-schema/StorageMetrics.v1_0_0.json

--- a/redfish-core/schema/dmtf/json-schema-installed/Switch.v1_10_0.json
+++ b/redfish-core/schema/dmtf/json-schema-installed/Switch.v1_10_0.json
@@ -1,0 +1,1 @@
+../json-schema/Switch.v1_10_0.json

--- a/redfish-core/schema/dmtf/json-schema-installed/SwitchCollection.json
+++ b/redfish-core/schema/dmtf/json-schema-installed/SwitchCollection.json
@@ -1,0 +1,1 @@
+../json-schema/SwitchCollection.json

--- a/redfish-core/schema/dmtf/json-schema-installed/SwitchMetrics.v1_0_2.json
+++ b/redfish-core/schema/dmtf/json-schema-installed/SwitchMetrics.v1_0_2.json
@@ -1,0 +1,1 @@
+../json-schema/SwitchMetrics.v1_0_2.json

--- a/redfish-core/schema/dmtf/json-schema-installed/TelemetryData.v1_0_0.json
+++ b/redfish-core/schema/dmtf/json-schema-installed/TelemetryData.v1_0_0.json
@@ -1,0 +1,1 @@
+../json-schema/TelemetryData.v1_0_0.json

--- a/redfish-core/schema/dmtf/json-schema-installed/TelemetryDataCollection.json
+++ b/redfish-core/schema/dmtf/json-schema-installed/TelemetryDataCollection.json
@@ -1,0 +1,1 @@
+../json-schema/TelemetryDataCollection.json

--- a/redfish-core/schema/dmtf/json-schema-installed/ThermalEquipment.v1_2_0.json
+++ b/redfish-core/schema/dmtf/json-schema-installed/ThermalEquipment.v1_2_0.json
@@ -1,0 +1,1 @@
+../json-schema/ThermalEquipment.v1_2_0.json

--- a/redfish-core/schema/dmtf/json-schema-installed/TrustedComponent.v1_4_0.json
+++ b/redfish-core/schema/dmtf/json-schema-installed/TrustedComponent.v1_4_0.json
@@ -1,0 +1,1 @@
+../json-schema/TrustedComponent.v1_4_0.json

--- a/redfish-core/schema/dmtf/json-schema-installed/TrustedComponentCollection.json
+++ b/redfish-core/schema/dmtf/json-schema-installed/TrustedComponentCollection.json
@@ -1,0 +1,1 @@
+../json-schema/TrustedComponentCollection.json

--- a/redfish-core/schema/dmtf/json-schema-installed/USBController.v1_0_1.json
+++ b/redfish-core/schema/dmtf/json-schema-installed/USBController.v1_0_1.json
@@ -1,0 +1,1 @@
+../json-schema/USBController.v1_0_1.json

--- a/redfish-core/schema/dmtf/json-schema-installed/USBControllerCollection.json
+++ b/redfish-core/schema/dmtf/json-schema-installed/USBControllerCollection.json
@@ -1,0 +1,1 @@
+../json-schema/USBControllerCollection.json

--- a/redfish-core/schema/dmtf/json-schema-installed/UpdateServiceCapabilities.v1_0_0.json
+++ b/redfish-core/schema/dmtf/json-schema-installed/UpdateServiceCapabilities.v1_0_0.json
@@ -1,0 +1,1 @@
+../json-schema/UpdateServiceCapabilities.v1_0_0.json

--- a/redfish-core/schema/dmtf/json-schema-installed/VCATEntry.v1_0_3.json
+++ b/redfish-core/schema/dmtf/json-schema-installed/VCATEntry.v1_0_3.json
@@ -1,0 +1,1 @@
+../json-schema/VCATEntry.v1_0_3.json

--- a/redfish-core/schema/dmtf/json-schema-installed/VCATEntryCollection.json
+++ b/redfish-core/schema/dmtf/json-schema-installed/VCATEntryCollection.json
@@ -1,0 +1,1 @@
+../json-schema/VCATEntryCollection.json

--- a/redfish-core/schema/dmtf/json-schema-installed/VLanNetworkInterface.v1_3_1.json
+++ b/redfish-core/schema/dmtf/json-schema-installed/VLanNetworkInterface.v1_3_1.json
@@ -1,0 +1,1 @@
+../json-schema/VLanNetworkInterface.v1_3_1.json

--- a/redfish-core/schema/dmtf/json-schema-installed/VLanNetworkInterfaceCollection.json
+++ b/redfish-core/schema/dmtf/json-schema-installed/VLanNetworkInterfaceCollection.json
@@ -1,0 +1,1 @@
+../json-schema/VLanNetworkInterfaceCollection.json

--- a/redfish-core/schema/dmtf/json-schema-installed/VirtualCXLSwitch.v1_0_0.json
+++ b/redfish-core/schema/dmtf/json-schema-installed/VirtualCXLSwitch.v1_0_0.json
@@ -1,0 +1,1 @@
+../json-schema/VirtualCXLSwitch.v1_0_0.json

--- a/redfish-core/schema/dmtf/json-schema-installed/VirtualCXLSwitchCollection.json
+++ b/redfish-core/schema/dmtf/json-schema-installed/VirtualCXLSwitchCollection.json
@@ -1,0 +1,1 @@
+../json-schema/VirtualCXLSwitchCollection.json

--- a/redfish-core/schema/dmtf/json-schema-installed/VirtualPCI2PCIBridge.v1_0_0.json
+++ b/redfish-core/schema/dmtf/json-schema-installed/VirtualPCI2PCIBridge.v1_0_0.json
@@ -1,0 +1,1 @@
+../json-schema/VirtualPCI2PCIBridge.v1_0_0.json

--- a/redfish-core/schema/dmtf/json-schema-installed/VirtualPCI2PCIBridgeCollection.json
+++ b/redfish-core/schema/dmtf/json-schema-installed/VirtualPCI2PCIBridgeCollection.json
@@ -1,0 +1,1 @@
+../json-schema/VirtualPCI2PCIBridgeCollection.json

--- a/redfish-core/schema/dmtf/json-schema-installed/Volume.v1_10_1.json
+++ b/redfish-core/schema/dmtf/json-schema-installed/Volume.v1_10_1.json
@@ -1,0 +1,1 @@
+../json-schema/Volume.v1_10_1.json

--- a/redfish-core/schema/dmtf/json-schema-installed/VolumeCollection.json
+++ b/redfish-core/schema/dmtf/json-schema-installed/VolumeCollection.json
@@ -1,0 +1,1 @@
+../json-schema/VolumeCollection.json

--- a/redfish-core/schema/dmtf/json-schema-installed/Zone.v1_6_3.json
+++ b/redfish-core/schema/dmtf/json-schema-installed/Zone.v1_6_3.json
@@ -1,0 +1,1 @@
+../json-schema/Zone.v1_6_3.json

--- a/redfish-core/schema/dmtf/json-schema-installed/ZoneCollection.json
+++ b/redfish-core/schema/dmtf/json-schema-installed/ZoneCollection.json
@@ -1,0 +1,1 @@
+../json-schema/ZoneCollection.json

--- a/redfish-core/schema/dmtf/json-schema-installed/redfish-payload-annotations-v1.json
+++ b/redfish-core/schema/dmtf/json-schema-installed/redfish-payload-annotations-v1.json
@@ -1,0 +1,1 @@
+../json-schema/redfish-payload-annotations-v1.json

--- a/scripts/update_schemas.py
+++ b/scripts/update_schemas.py
@@ -114,11 +114,10 @@ for csdl_file in csdl_filenames:
         content = content.replace(b"\r\n", b"\n")
         schema_out.write(content)
 
-    if csdl_file in csdl_installed_symlinks:
-        os.symlink(
-            os.path.join("..", "csdl", csdl_file),
-            os.path.join(schema_installed_path, csdl_file),
-        )
+    os.symlink(
+        os.path.join("..", "csdl", csdl_file),
+        os.path.join(schema_installed_path, csdl_file),
+    )
 
 # Get the currently-installed json symlinks
 json_base_symlinks = defaultdict(list)
@@ -140,11 +139,10 @@ for schema_filename, versions in json_schema_files.items():
         content = content.replace(b"\r\n", b"\n")
         schema_file.write(content)
 
-    if schema_filename in json_base_symlinks:
-        os.symlink(
-            os.path.join("..", "json-schema", versions[0]),
-            os.path.join(json_schema_installed_path, versions[0]),
-        )
+    os.symlink(
+        os.path.join("..", "json-schema", versions[0]),
+        os.path.join(json_schema_installed_path, versions[0]),
+    )
 
 zip_ref.close()
 


### PR DESCRIPTION
Ship and install all schemas (#910)

This commit is to include and ship all available schemas, as how it was
done in the previous releases.

After modification of update_schemas.py, the schema files are
re-generated and they will be included.

Tested:

- CI passes
- GET /redfish/v1/JsonSchemas to see all json schemas
- Redfish Service Validator passes
