### PR TITLE
1120: Rebase LocationIndicatorActive for Manager

### DIFF
--- a/Redfish.md
+++ b/Redfish.md
@@ -577,6 +577,7 @@ Fields common to all schemas
 - Links/ManagerInChassis
 - Links/SoftwareImages
 - Links/SoftwareImages@odata.count
+- LocationIndicatorActive
 - LogServices
 - ManagerType
 - Manufacturer

--- a/redfish-core/lib/managers.hpp
+++ b/redfish-core/lib/managers.hpp
@@ -682,6 +682,140 @@ inline void getBMCState(const std::shared_ptr<bmcweb::AsyncResp>& aResp)
         });
 }
 
+inline void getPhysicalAssets(
+    const std::shared_ptr<bmcweb::AsyncResp>& asyncResp,
+    const boost::system::error_code& ec,
+    const dbus::utility::DBusPropertiesMap& propertiesList)
+{
+    if (ec)
+    {
+        BMCWEB_LOG_DEBUG("Can't get bmc asset!");
+        return;
+    }
+
+    const std::string* partNumber = nullptr;
+    const std::string* serialNumber = nullptr;
+    const std::string* manufacturer = nullptr;
+    const std::string* model = nullptr;
+    const std::string* sparePartNumber = nullptr;
+
+    const bool success = sdbusplus::unpackPropertiesNoThrow(
+        dbus_utils::UnpackErrorPrinter(), propertiesList, "PartNumber",
+        partNumber, "SerialNumber", serialNumber, "Manufacturer", manufacturer,
+        "Model", model, "SparePartNumber", sparePartNumber);
+
+    if (!success)
+    {
+        messages::internalError(asyncResp->res);
+        return;
+    }
+
+    if (partNumber != nullptr)
+    {
+        asyncResp->res.jsonValue["PartNumber"] = *partNumber;
+    }
+
+    if (serialNumber != nullptr)
+    {
+        asyncResp->res.jsonValue["SerialNumber"] = *serialNumber;
+    }
+
+    if (manufacturer != nullptr)
+    {
+        asyncResp->res.jsonValue["Manufacturer"] = *manufacturer;
+    }
+
+    if (model != nullptr)
+    {
+        asyncResp->res.jsonValue["Model"] = *model;
+    }
+
+    if (sparePartNumber != nullptr)
+    {
+        asyncResp->res.jsonValue["SparePartNumber"] = *sparePartNumber;
+    }
+}
+
+inline void getManagerData(const std::shared_ptr<bmcweb::AsyncResp>& asyncResp,
+                           const std::string& managerPath,
+                           const dbus::utility::MapperServiceMap& serviceMap)
+{
+    if (managerPath.empty() || serviceMap.size() != 1)
+    {
+        BMCWEB_LOG_DEBUG("Error getting bmc D-Bus object!");
+        messages::internalError(asyncResp->res);
+        return;
+    }
+
+    for (const auto& [connectionName, interfaces] : serviceMap)
+    {
+        for (const auto& interfaceName : interfaces)
+        {
+            if (interfaceName ==
+                "xyz.openbmc_project.Inventory.Decorator.Asset")
+            {
+                dbus::utility::getAllProperties(
+                    *crow::connections::systemBus, connectionName, managerPath,
+                    "xyz.openbmc_project.Inventory.Decorator.Asset",
+                    std::bind_front(getPhysicalAssets, asyncResp));
+            }
+            else if (interfaceName ==
+                     "xyz.openbmc_project.Inventory.Decorator.LocationCode")
+            {
+                getLocation(asyncResp, connectionName, managerPath);
+            }
+        }
+    }
+}
+
+inline void afterGetManagerObject(
+    const std::shared_ptr<bmcweb::AsyncResp>& asyncResp,
+    const boost::system::error_code& ec,
+    const dbus::utility::MapperGetSubTreeResponse& subtree,
+    const std::function<
+        void(const std::string& managerPath,
+             const dbus::utility::MapperServiceMap& serviceMap)>& callback)
+{
+    if (ec)
+    {
+        BMCWEB_LOG_DEBUG("D-Bus response error on GetSubTree {}", ec);
+        return;
+    }
+    if (subtree.empty())
+    {
+        BMCWEB_LOG_DEBUG("Can't find bmc D-Bus object!");
+        return;
+    }
+    // Assume only 1 bmc D-Bus object
+    // Throw an error if there is more than 1
+    if (subtree.size() > 1)
+    {
+        BMCWEB_LOG_ERROR("Found more than 1 bmc D-Bus object!");
+        messages::internalError(asyncResp->res);
+        return;
+    }
+
+    callback(subtree[0].first, subtree[0].second);
+}
+
+inline void getManagerObject(
+    const std::shared_ptr<bmcweb::AsyncResp>& asyncResp,
+    const std::string& /* managerId */,
+    std::function<void(const std::string& managerPath,
+                       const dbus::utility::MapperServiceMap& serviceMap)>&&
+        callback)
+{
+    constexpr std::array<std::string_view, 1> interfaces = {
+        "xyz.openbmc_project.Inventory.Item.Bmc"};
+    dbus::utility::getSubTree(
+        "/xyz/openbmc_project/inventory", 0, interfaces,
+        [asyncResp, callback{std::move(callback)}](
+            const boost::system::error_code& ec,
+            const dbus::utility::MapperGetSubTreeResponse& subtree) {
+            afterGetManagerObject(asyncResp, ec, subtree, callback);
+        });
+}
+
 inline void requestRoutesManager(App& app)
 {
     std::string uuid = persistent_data::getConfig().systemUuid;
@@ -837,135 +971,8 @@ inline void requestRoutesManager(App& app)
                     chassiUrl;
             });
 
-            constexpr std::array<std::string_view, 1> interfaces = {
-                "xyz.openbmc_project.Inventory.Item.Bmc"};
-            dbus::utility::getSubTree(
-                "/xyz/openbmc_project/inventory", 0, interfaces,
-                [asyncResp](
-                    const boost::system::error_code& ec,
-                    const dbus::utility::MapperGetSubTreeResponse& subtree) {
-                    if (ec)
-                    {
-                        BMCWEB_LOG_DEBUG(
-                            "D-Bus response error on GetSubTree {}", ec);
-                        return;
-                    }
-                    if (subtree.empty())
-                    {
-                        BMCWEB_LOG_DEBUG("Can't find bmc D-Bus object!");
-                        return;
-                    }
-                    // Assume only 1 bmc D-Bus object
-                    // Throw an error if there is more than 1
-                    if (subtree.size() > 1)
-                    {
-                        BMCWEB_LOG_DEBUG("Found more than 1 bmc D-Bus object!");
-                        messages::internalError(asyncResp->res);
-                        return;
-                    }
-
-                    if (subtree[0].first.empty() ||
-                        subtree[0].second.size() != 1)
-                    {
-                        BMCWEB_LOG_DEBUG("Error getting bmc D-Bus object!");
-                        messages::internalError(asyncResp->res);
-                        return;
-                    }
-
-                    const std::string& path = subtree[0].first;
-                    const std::string& connectionName =
-                        subtree[0].second[0].first;
-
-                    for (const auto& interfaceName :
-                         subtree[0].second[0].second)
-                    {
-                        if (interfaceName ==
-                            "xyz.openbmc_project.Inventory.Decorator.Asset")
-                        {
-                            dbus::utility::getAllProperties(
-                                *crow::connections::systemBus, connectionName,
-                                path,
-                                "xyz.openbmc_project.Inventory.Decorator.Asset",
-                                [asyncResp](
-                                    const boost::system::error_code& ec2,
-                                    const dbus::utility::DBusPropertiesMap&
-                                        propertiesList) {
-                                    if (ec2)
-                                    {
-                                        BMCWEB_LOG_DEBUG(
-                                            "Can't get bmc asset!");
-                                        return;
-                                    }
-
-                                    const std::string* partNumber = nullptr;
-                                    const std::string* serialNumber = nullptr;
-                                    const std::string* manufacturer = nullptr;
-                                    const std::string* model = nullptr;
-                                    const std::string* sparePartNumber =
-                                        nullptr;
-
-                                    const bool success =
-                                        sdbusplus::unpackPropertiesNoThrow(
-                                            dbus_utils::UnpackErrorPrinter(),
-                                            propertiesList, "PartNumber",
-                                            partNumber, "SerialNumber",
-                                            serialNumber, "Manufacturer",
-                                            manufacturer, "Model", model,
-                                            "SparePartNumber", sparePartNumber);
-
-                                    if (!success)
-                                    {
-                                        messages::internalError(asyncResp->res);
-                                        return;
-                                    }
-
-                                    if (partNumber != nullptr)
-                                    {
-                                        asyncResp->res.jsonValue["PartNumber"] =
-                                            *partNumber;
-                                    }
-
-                                    if (serialNumber != nullptr)
-                                    {
-                                        asyncResp->res
-                                            .jsonValue["SerialNumber"] =
-                                            *serialNumber;
-                                    }
-
-                                    if (manufacturer != nullptr)
-                                    {
-                                        asyncResp->res
-                                            .jsonValue["Manufacturer"] =
-                                            *manufacturer;
-                                    }
-
-                                    if (model != nullptr)
-                                    {
-                                        asyncResp->res.jsonValue["Model"] =
-                                            *model;
-                                    }
-
-                                    if (sparePartNumber != nullptr)
-                                    {
-                                        asyncResp->res
-                                            .jsonValue["SparePartNumber"] =
-                                            *sparePartNumber;
-                                    }
-                                });
-                        }
-                        else if (
-                            interfaceName ==
-                            "xyz.openbmc_project.Inventory.Decorator.LocationCode")
-                        {
-                            getLocation(asyncResp, connectionName, path);
-                        }
-                        else if (interfaceName ==
-                                 "xyz.openbmc_project.Association.Definitions")
-                        {
-                            getLocationIndicatorActive(asyncResp, path);
-                        }
-                    }
-                });
+            getManagerObject(asyncResp, managerId,
+                             std::bind_front(getManagerData, asyncResp));
         });
 
     BMCWEB_ROUTE(app, "/redfish/v1/Managers/<str>/")

--- a/redfish-core/lib/managers.hpp
+++ b/redfish-core/lib/managers.hpp
@@ -58,6 +58,44 @@
 namespace redfish
 {
 
+inline void handleSetLocationIndicatorActive(
+    const std::shared_ptr<bmcweb::AsyncResp>& asyncResp,
+    bool locationIndicatorActive, const std::string& managerId,
+    const boost::system::error_code& ec,
+    const dbus::utility::MapperGetSubTreePathsResponse& subtreePaths)
+{
+    if (ec)
+    {
+        if (ec == boost::system::errc::io_error)
+        {
+            // Not found
+            BMCWEB_LOG_WARNING("Manager {} not found", managerId);
+            messages::resourceNotFound(asyncResp->res, "Manager", managerId);
+            return;
+        }
+        BMCWEB_LOG_ERROR("D-Bus response error {}", ec.value());
+        messages::internalError(asyncResp->res);
+        return;
+    }
+    if (subtreePaths.empty())
+    {
+        BMCWEB_LOG_WARNING("Manager {} not found", managerId);
+        messages::resourceNotFound(asyncResp->res, "Manager", managerId);
+        return;
+    }
+    // Assume only 1 bmc D-Bus object
+    // Throw an error if there is more than 1
+    if (subtreePaths.size() != 1)
+    {
+        BMCWEB_LOG_ERROR("Found {} Bmc D-Bus paths", subtreePaths.size());
+        messages::internalError(asyncResp->res);
+        return;
+    }
+
+    setLocationIndicatorActive(asyncResp, subtreePaths[0],
+                               locationIndicatorActive);
+}
+
 /**
  * Set the locationIndicatorActive.
  *
@@ -68,41 +106,13 @@ inline void setLocationIndicatorActiveState(
     const std::shared_ptr<bmcweb::AsyncResp>& asyncResp,
     bool locationIndicatorActive, const std::string& managerId)
 {
-    BMCWEB_LOG_DEBUG("Get available manager resources.");
-
     // GetSubTree on all interfaces which provide info about a Manager
     constexpr std::array<std::string_view, 1> interfaces = {
         "xyz.openbmc_project.Inventory.Item.Bmc"};
     dbus::utility::getSubTreePaths(
         "/xyz/openbmc_project/inventory", 0, interfaces,
-        [asyncResp, locationIndicatorActive, managerId](
-            const boost::system::error_code& ec,
-            const dbus::utility::MapperGetSubTreePathsResponse& subtreePaths) {
-            if (ec)
-            {
-                BMCWEB_LOG_ERROR("DBUS response error {}", ec);
-                messages::internalError(asyncResp->res);
-                return;
-            }
-            if (subtreePaths.empty())
-            {
-                BMCWEB_LOG_WARNING("DBus object not found");
-                messages::resourceNotFound(asyncResp->res, "Manager",
-                                           managerId);
-                return;
-            }
-            // Assume only 1 bmc D-Bus object
-            // Throw an error if there is more than 1
-            if (subtreePaths.size() != 1)
-            {
-                BMCWEB_LOG_ERROR("DBus object count is not 1");
-                messages::internalError(asyncResp->res);
-                return;
-            }
-
-            setLocationIndicatorActive(asyncResp, subtreePaths[0],
-                                       locationIndicatorActive);
-        });
+        std::bind_front(handleSetLocationIndicatorActive, asyncResp,
+                        locationIndicatorActive, managerId));
 }
 
 inline std::string getBMCUpdateServiceName()
@@ -764,6 +774,11 @@ inline void getManagerData(const std::shared_ptr<bmcweb::AsyncResp>& asyncResp,
             {
                 getLocation(asyncResp, connectionName, managerPath);
             }
+            else if (interfaceName ==
+                     "xyz.openbmc_project.Association.Definitions")
+            {
+                getLocationIndicatorActive(asyncResp, managerPath);
+            }
         }
     }
 }
@@ -1010,6 +1025,8 @@ inline void requestRoutesManager(App& app)
                         locationIndicatorActive,                          //
                         "Links/ActiveSoftwareImage/@odata.id",
                         activeSoftwareImageOdataId,                       //
+                        "LocationIndicatorActive",
+                        locationIndicatorActive,                          //
                         "Oem/OpenBmc/Fan/FanControllers", fanControllers, //
                         "Oem/OpenBmc/Fan/FanZones", fanZones,             //
                         "Oem/OpenBmc/Fan/PidControllers", pidControllers, //
@@ -1087,6 +1104,7 @@ inline void requestRoutesManager(App& app)
                 {
                     setDateTime(asyncResp, *datetime);
                 }
+
                 if (locationIndicatorActive)
                 {
                     setLocationIndicatorActiveState(


### PR DESCRIPTION
Cherry-picked two upstream merged commits which implemented LocationIndicatorActive for Manager resource:
 - [Managers: Factor out large lambdas](https://gerrit.openbmc.org/c/openbmc/bmcweb/+/81245)
 - [Implement LocationIndicatorActive for Manager resource](https://gerrit.openbmc.org/c/openbmc/bmcweb/+/43179)

Support was already in 1120, but this rebases to upstream so we should not need to rebase this again in the future.

Tested by comparing output before and after change.