### PR TITLE
Fix bad license conflict resolve

### DIFF
--- a/redfish-core/src/redfish.cpp
+++ b/redfish-core/src/redfish.cpp
@@ -207,18 +207,18 @@ RedfishService::RedfishService(App& app)
         requestRoutesDBusEventLogEntryDownloadPelJson(app);
         requestRoutesDBusCELogEntryDownloadPelJson(app);
     }
+    else
+    {
+        requestRoutesJournalEventLogEntryCollection(app);
+        requestRoutesJournalEventLogEntry(app);
+        requestRoutesJournalEventLogClear(app);
+    }
 
     if constexpr (BMCWEB_REDFISH_LICENSE)
     {
         requestRoutesLicenseService(app);
         requestRoutesLicenseEntryCollection(app);
         requestRoutesLicenseEntry(app);
-    }
-    else
-    {
-        requestRoutesJournalEventLogEntryCollection(app);
-        requestRoutesJournalEventLogEntry(app);
-        requestRoutesJournalEventLogClear(app);
     }
 
     if constexpr (BMCWEB_REDFISH_HOST_LOGGER)


### PR DESCRIPTION
The license commit [1] incorrectly moved the Journal else under the license if. Match upstream and move it under the BMCWEB_REDFISH_DBUS_LOG else.[2]

This should have no operations since both license and redfish dbus log are enabled downstream but would be important if license is ever turned off since these Journal routes and redfish dbus log conflict (use the same routes). Noticed when debugging a problem.

[1]: https://github.com/ibm-openbmc/bmcweb/commit/fd8e27c66eed86e2211fd8893780b1d1f57421ce
[2]: https://github.com/openbmc/bmcweb/blame/master/redfish-core/src/redfish.cpp#L181