### PR TITLE
1120: Skip log entry if Hidden dbus property is missing

### DIFF
--- a/redfish-core/include/utils/error_log_utils.hpp
+++ b/redfish-core/include/utils/error_log_utils.hpp
@@ -11,6 +11,8 @@
 #include "error_messages.hpp"
 #include "logging.hpp"
 
+#include <asm-generic/errno.h>
+
 #include <boost/system/error_code.hpp>
 #include <boost/url/format.hpp>
 #include <boost_formatters.hpp>
@@ -19,6 +21,7 @@
 
 #include <functional>
 #include <memory>
+#include <optional>
 #include <string>
 #include <utility>
 
@@ -29,7 +32,8 @@ namespace error_log_utils
 
 static void getHiddenPropertyValue(
     const std::shared_ptr<bmcweb::AsyncResp>& asyncResp,
-    const std::string& entryId, std::function<void(bool hidden)>&& callback)
+    const std::string& entryId,
+    std::function<void(const std::optional<bool>& hidden)>&& callback)
 {
     // Explicit move here to avoid clang tidy warning
     auto movedCallback = std::move(callback);
@@ -42,6 +46,15 @@ static void getHiddenPropertyValue(
          entryId](const boost::system::error_code& ec, bool hidden) {
             if (ec)
             {
+                if (ec.value() == EBADR)
+                {
+                    // Put this log trace to journal by default.
+                    BMCWEB_LOG_ERROR(
+                        "DBUS property 'Hidden' for entry {} does not exist",
+                        entryId);
+                    movedCallback(std::nullopt);
+                    return;
+                }
                 BMCWEB_LOG_ERROR(
                     "Failed to get DBUS property 'Hidden' for entry {}: {}",
                     entryId, ec);
@@ -79,24 +92,29 @@ inline void setErrorLogUri(
     const nlohmann::json::json_pointer& errorLogPropPath, const bool isLink)
 {
     std::string entryID = errorLogObjPath.filename();
-    auto updateErrorLogPath =
-        [asyncResp, entryID, errorLogPropPath, isLink](bool hidden) {
-            std::string logPath = "EventLog";
-            if (hidden)
-            {
-                logPath = "CELog";
-            }
-            std::string linkAttachment;
-            if (!isLink)
-            {
-                linkAttachment = "/attachment";
-            }
-            asyncResp->res.jsonValue[errorLogPropPath]["@odata.id"] =
-                boost::urls::format(
-                    "/redfish/v1/Systems/{}/LogServices/{}/Entries/{}{}",
-                    BMCWEB_REDFISH_SYSTEM_URI_NAME, logPath, entryID,
-                    linkAttachment);
-        };
+    auto updateErrorLogPath = [asyncResp, entryID, errorLogPropPath,
+                               isLink](const std::optional<bool>& hidden) {
+        if (!hidden.has_value())
+        {
+            // Skip log entry if Hidden dbus property is missing
+            return;
+        }
+        std::string logPath = "EventLog";
+        if (*hidden)
+        {
+            logPath = "CELog";
+        }
+        std::string linkAttachment;
+        if (!isLink)
+        {
+            linkAttachment = "/attachment";
+        }
+        asyncResp->res.jsonValue[errorLogPropPath]["@odata.id"] =
+            boost::urls::format(
+                "/redfish/v1/Systems/{}/LogServices/{}/Entries/{}{}",
+                BMCWEB_REDFISH_SYSTEM_URI_NAME, logPath, entryID,
+                linkAttachment);
+    };
     getHiddenPropertyValue(asyncResp, entryID, updateErrorLogPath);
 }
 

--- a/redfish-core/lib/log_services.hpp
+++ b/redfish-core/lib/log_services.hpp
@@ -1742,6 +1742,22 @@ inline void afterLogEntriesGetManagedObjects(
                                             propertyMap.second);
             }
         }
+
+        // Check whether Hidden field exist
+        auto hiddenIter = std::ranges::find_if(
+            propsFlattened,
+            [](const std::pair<std::string, dbus::utility::DbusVariantType>&
+                   item) { return item.first == "Hidden"; });
+        if (hiddenIter == propsFlattened.end())
+        {
+            // Skip the entry if Hidden field does not exist
+            // NOTE: Put this log trace to journal by default.
+            BMCWEB_LOG_ERROR(
+                "Skip the log entry {} as it has no Hidden property",
+                objectPath.first.str);
+            continue;
+        }
+
         std::optional<DbusEventLogEntry> optEntry =
             fillDbusEventLogEntryFromPropertyMap(propsFlattened);
 
@@ -2045,6 +2061,22 @@ inline void dBusEventLogEntryGet(
                 BMCWEB_LOG_ERROR(
                     "EventLogEntry (DBus) resp_handler got error {}", ec);
                 messages::internalError(asyncResp->res);
+                return;
+            }
+
+            // Check whether Hidden field exist
+            auto hiddenIter = std::ranges::find_if(
+                resp,
+                [](const std::pair<std::string, dbus::utility::DbusVariantType>&
+                       item) { return item.first == "Hidden"; });
+            if (hiddenIter == resp.end())
+            {
+                // Skip the entry if Hidden field does not exist
+                // NOTE: Put this log trace to journal by default.
+                BMCWEB_LOG_ERROR(
+                    "Skip the log entry {} as it has no Hidden property",
+                    entryID);
+                messages::resourceNotFound(asyncResp->res, "LogEntry", entryID);
                 return;
             }
 
@@ -2604,8 +2636,9 @@ inline void handleDBusEventLogEntryDownloadGet(
 
     redfish::error_log_utils::getHiddenPropertyValue(
         asyncResp, entryID,
-        [asyncResp, entryID, systemName, dumpType, hidden](bool hiddenPropVal) {
-            if (hiddenPropVal != hidden)
+        [asyncResp, entryID, systemName, dumpType,
+         hidden](const std::optional<bool>& hiddenPropVal) {
+            if (hiddenPropVal.value_or(!hidden) != hidden)
             {
                 messages::resourceNotFound(asyncResp->res, "LogEntry", entryID);
                 return;
@@ -2779,8 +2812,9 @@ inline void requestRoutesDBusEventLogEntryDownloadPelJson(App& app)
 
                 redfish::error_log_utils::getHiddenPropertyValue(
                     asyncResp, entryID,
-                    [asyncResp, entryID](bool hiddenPropVal) {
-                        if (hiddenPropVal)
+                    [asyncResp,
+                     entryID](const std::optional<bool>& hiddenPropVal) {
+                        if (hiddenPropVal.value_or(true))
                         {
                             messages::resourceNotFound(asyncResp->res,
                                                        "LogEntry", entryID);

--- a/redfish-core/lib/systems_logservices_celog.hpp
+++ b/redfish-core/lib/systems_logservices_celog.hpp
@@ -192,8 +192,8 @@ inline void dBusCELogEntryPatch(
     error_log_utils::getHiddenPropertyValue(
         asyncResp, entryId,
         [resolved, managementSystemAck, asyncResp,
-         entryId](bool hiddenPropVal) {
-            if (!hiddenPropVal)
+         entryId](const std::optional<bool>& hiddenPropVal) {
+            if (!hiddenPropVal.value_or(false))
             {
                 messages::resourceNotFound(asyncResp->res, "LogEntry", entryId);
                 return;
@@ -210,8 +210,9 @@ inline void dBusCELogEntryDelete(
     dbus::utility::escapePathForDbus(entryID);
 
     error_log_utils::getHiddenPropertyValue(
-        asyncResp, entryID, [asyncResp, entryID](bool hiddenPropVal) {
-            if (!hiddenPropVal)
+        asyncResp, entryID,
+        [asyncResp, entryID](const std::optional<bool>& hiddenPropVal) {
+            if (!hiddenPropVal.value_or(false))
             {
                 messages::resourceNotFound(asyncResp->res, "LogEntry", entryID);
                 return;
@@ -351,8 +352,9 @@ inline void requestRoutesDBusCELogEntryDownloadPelJson(App& app)
 
                 error_log_utils::getHiddenPropertyValue(
                     asyncResp, entryID,
-                    [asyncResp, entryID](bool hiddenPropVal) {
-                        if (!hiddenPropVal)
+                    [asyncResp,
+                     entryID](const std::optional<bool>& hiddenPropVal) {
+                        if (!hiddenPropVal.value_or(false))
                         {
                             messages::resourceNotFound(asyncResp->res,
                                                        "LogEntry", entryID);

--- a/redfish-core/lib/systems_logservices_hwisolation.hpp
+++ b/redfish-core/lib/systems_logservices_hwisolation.hpp
@@ -36,6 +36,7 @@
 #include <functional>
 #include <iterator>
 #include <memory>
+#include <optional>
 #include <span>
 #include <string>
 #include <string_view>
@@ -759,28 +760,33 @@ inline void fillSystemHardwareIsolationLogEntry(
 
                             std::string entryID = errPath.filename();
 
-                            auto updateAdditionalDataURI = [asyncResp,
-                                                            entryJsonIdx,
-                                                            entryID](
-                                                               bool hidden) {
-                                nlohmann::json& entryJsonToupdateURI =
-                                    (entryJsonIdx > 0
-                                         ? asyncResp->res
-                                               .jsonValue["Members"]
-                                                         [entryJsonIdx - 1]
-                                         : asyncResp->res.jsonValue);
-                                std::string logPath = "EventLog";
+                            auto updateAdditionalDataURI = //
+                                [asyncResp, entryJsonIdx,
+                                 entryID](const std::optional<bool>& hidden) {
+                                    if (!hidden.has_value())
+                                    {
+                                        // Skip log entry if Hidden dbus
+                                        // property is missing
+                                        return;
+                                    }
+                                    nlohmann::json& entryJsonToupdateURI =
+                                        (entryJsonIdx > 0
+                                             ? asyncResp->res
+                                                   .jsonValue["Members"]
+                                                             [entryJsonIdx - 1]
+                                             : asyncResp->res.jsonValue);
 
-                                if (hidden)
-                                {
-                                    logPath = "CELog";
-                                }
-                                entryJsonToupdateURI["AdditionalDataURI"] =
-                                    boost::urls::format(
-                                        "/redfish/v1/Systems/{}/LogServices/{}/Entries/{}/attachment",
-                                        BMCWEB_REDFISH_SYSTEM_URI_NAME, logPath,
-                                        entryID);
-                            };
+                                    std::string logPath = "EventLog";
+                                    if (*hidden)
+                                    {
+                                        logPath = "CELog";
+                                    }
+                                    entryJsonToupdateURI["AdditionalDataURI"] =
+                                        boost::urls::format(
+                                            "/redfish/v1/Systems/{}/LogServices/{}/Entries/{}/attachment",
+                                            BMCWEB_REDFISH_SYSTEM_URI_NAME,
+                                            logPath, entryID);
+                                };
                             redfish::error_log_utils::getHiddenPropertyValue(
                                 asyncResp, entryID, updateAdditionalDataURI);
                         }


### PR DESCRIPTION
There may be a timing window that a PEL dbus entry may not have a field `Hidden`, as a PEL dbus entry is handled in a 2 steps
 - a dbus log entry without Hidden field is created first
 - PEL interface reads a dbus log entry and adds `Hidden` field.

During the period, a dbus log entry could have no `Hidden` field.

This commit is to skip those intermediate dbus log entries for LogEntry GET collection handling.

For example,

```
curl -k -X GET https://${bmc}/redfish/v1/Systems/system/LogServices/CELog/Entries/
```

Then, bmc journal may show like this
```
Jul 17 11:12:54 p10bmc bmcwebd[1168]: [log_services.hpp:1756] Skip the log entry /xyz/openbmc_project/logging/entry/2 as it has no Hidden property
```

Tested:
- Redfish Service Validator passes