### PR TITLE
1110: Skip log entry if Hidden dbus property is missing

### DIFF
--- a/redfish-core/include/utils/error_log_utils.hpp
+++ b/redfish-core/include/utils/error_log_utils.hpp
@@ -7,7 +7,8 @@ namespace error_log_utils
 
 static void getHiddenPropertyValue(
     const std::shared_ptr<bmcweb::AsyncResp>& asyncResp,
-    const std::string& entryId, std::function<void(bool hidden)>&& callback)
+    const std::string& entryId,
+    std::function<void(const std::optional<bool>& hidden)>&& callback)
 {
     sdbusplus::asio::getProperty<bool>(
         *crow::connections::systemBus, "xyz.openbmc_project.Logging",
@@ -17,6 +18,15 @@ static void getHiddenPropertyValue(
          entryId](const boost::system::error_code& ec, bool hidden) {
             if (ec)
             {
+                if (ec.value() == EBADR)
+                {
+                    // Put this log trace to journal by default.
+                    BMCWEB_LOG_ERROR(
+                        "DBUS property 'Hidden' for entry {} does not exist",
+                        entryId);
+                    callback(std::nullopt);
+                    return;
+                }
                 BMCWEB_LOG_ERROR(
                     "Failed to get DBUS property 'Hidden' for entry {}: {}",
                     entryId, ec);
@@ -54,23 +64,28 @@ inline void setErrorLogUri(
     const nlohmann::json::json_pointer& errorLogPropPath, const bool isLink)
 {
     std::string entryID = errorLogObjPath.filename();
-    auto updateErrorLogPath =
-        [asyncResp, entryID, errorLogPropPath, isLink](bool hidden) {
-            std::string logPath = "EventLog";
-            if (hidden)
-            {
-                logPath = "CELog";
-            }
-            std::string linkAttachment;
-            if (!isLink)
-            {
-                linkAttachment = "/attachment";
-            }
-            asyncResp->res.jsonValue[errorLogPropPath]["@odata.id"] =
-                boost::urls::format(
-                    "/redfish/v1/Systems/system/LogServices/{}/Entries/{}{}",
-                    logPath, entryID, linkAttachment);
-        };
+    auto updateErrorLogPath = [asyncResp, entryID, errorLogPropPath,
+                               isLink](const std::optional<bool>& hidden) {
+        if (!hidden.has_value())
+        {
+            // Skip log entry if Hidden dbus property is missing
+            return;
+        }
+        std::string logPath = "EventLog";
+        if (*hidden)
+        {
+            logPath = "CELog";
+        }
+        std::string linkAttachment;
+        if (!isLink)
+        {
+            linkAttachment = "/attachment";
+        }
+        asyncResp->res.jsonValue[errorLogPropPath]["@odata.id"] =
+            boost::urls::format(
+                "/redfish/v1/Systems/system/LogServices/{}/Entries/{}{}",
+                logPath, entryID, linkAttachment);
+    };
     getHiddenPropertyValue(asyncResp, entryID, updateErrorLogPath);
 }
 

--- a/redfish-core/lib/log_services.hpp
+++ b/redfish-core/lib/log_services.hpp
@@ -2854,12 +2854,19 @@ inline void requestRoutesDBusEventLogEntry(App& app)
                         messages::internalError(asyncResp->res);
                         return;
                     }
+                    if (hidden == nullptr)
+                    {
+                        // Skip log entry if Hidden dbus property is missing
+                        messages::resourceNotFound(asyncResp->res,
+                                                   "EventLogEntry",
+                                                   std::to_string(*id));
+                        return;
+                    }
 
                     if (id == nullptr || eventId == nullptr ||
                         severity == nullptr || timestamp == nullptr ||
                         updateTimestamp == nullptr || resolved == nullptr ||
-                        notify == nullptr || hidden == nullptr ||
-                        subsystem == nullptr ||
+                        notify == nullptr || subsystem == nullptr ||
                         (BMCWEB_IBM_MANAGEMENT_CONSOLE &&
                          managementSystemAck == nullptr))
                     {
@@ -2987,8 +2994,8 @@ inline void requestRoutesDBusEventLogEntry(App& app)
 
                 auto updatePropertyCallback =
                     [resolved, managementSystemAck, asyncResp,
-                     entryId](bool hiddenPropVal) {
-                        if (hiddenPropVal)
+                     entryId](const std::optional<bool>& hiddenPropVal) {
+                        if (hiddenPropVal.value_or(true))
                         {
                             messages::resourceNotFound(asyncResp->res,
                                                        "LogEntry", entryId);
@@ -3033,8 +3040,9 @@ inline void requestRoutesDBusEventLogEntry(App& app)
                 dbus::utility::escapePathForDbus(entryID);
 
                 auto deleteEventLogCallback =
-                    [asyncResp, entryID](bool hiddenPropVal) {
-                        if (hiddenPropVal)
+                    [asyncResp,
+                     entryID](const std::optional<bool>& hiddenPropVal) {
+                        if (hiddenPropVal.value_or(true))
                         {
                             messages::resourceNotFound(asyncResp->res,
                                                        "LogEntry", entryID);
@@ -3121,11 +3129,18 @@ inline void requestRoutesDBusCELogEntry(App& app)
                         return;
                     }
 
+                    if (hidden == nullptr)
+                    {
+                        // Skip log entry if Hidden dbus property is missing
+                        messages::resourceNotFound(asyncResp->res, "LogEntry",
+                                                   std::to_string(*id));
+                        return;
+                    }
+
                     if (id == nullptr || eventId == nullptr ||
                         severity == nullptr || timestamp == nullptr ||
                         updateTimestamp == nullptr || resolved == nullptr ||
-                        hidden == nullptr || notify == nullptr ||
-                        subsystem == nullptr ||
+                        notify == nullptr || subsystem == nullptr ||
                         (BMCWEB_IBM_MANAGEMENT_CONSOLE &&
                          managementSystemAck == nullptr))
                     {
@@ -3243,8 +3258,8 @@ inline void requestRoutesDBusCELogEntry(App& app)
 
                 auto updatePropertyCallback =
                     [resolved, managementSystemAck, asyncResp,
-                     entryId](bool hiddenPropVal) {
-                        if (!hiddenPropVal)
+                     entryId](const std::optional<bool>& hiddenPropVal) {
+                        if (!hiddenPropVal.value_or(false))
                         {
                             messages::resourceNotFound(asyncResp->res,
                                                        "LogEntry", entryId);
@@ -3282,8 +3297,9 @@ inline void requestRoutesDBusCELogEntry(App& app)
                 dbus::utility::escapePathForDbus(entryID);
 
                 auto deleteCELogCallback =
-                    [asyncResp, entryID](bool hiddenPropVal) {
-                        if (!hiddenPropVal)
+                    [asyncResp,
+                     entryID](const std::optional<bool>& hiddenPropVal) {
+                        if (!hiddenPropVal.value_or(false))
                         {
                             messages::resourceNotFound(asyncResp->res,
                                                        "LogEntry", entryID);
@@ -3365,8 +3381,9 @@ inline void requestRoutesDBusEventLogEntryDownloadPelJson(App& app)
                 dbus::utility::escapePathForDbus(entryID);
 
                 auto eventLogAttachmentCallback =
-                    [asyncResp, entryID](bool hiddenPropVal) {
-                        if (hiddenPropVal)
+                    [asyncResp,
+                     entryID](const std::optional<bool>& hiddenPropVal) {
+                        if (hiddenPropVal.value_or(true))
                         {
                             messages::resourceNotFound(asyncResp->res,
                                                        "LogEntry", entryID);
@@ -3405,8 +3422,9 @@ inline void requestRoutesDBusCELogEntryDownloadPelJson(App& app)
                 dbus::utility::escapePathForDbus(entryID);
 
                 auto eventLogAttachmentCallback =
-                    [asyncResp, entryID](bool hiddenPropVal) {
-                        if (!hiddenPropVal)
+                    [asyncResp,
+                     entryID](const std::optional<bool>& hiddenPropVal) {
+                        if (hiddenPropVal.value_or(false))
                         {
                             messages::resourceNotFound(asyncResp->res,
                                                        "LogEntry", entryID);
@@ -4360,8 +4378,8 @@ inline void handleDBusEventLogEntryDownloadGet(
     }
 
     auto callback = [asyncResp, entryID, systemName, dumpType,
-                     hidden](bool hiddenPropVal) {
-        if (hiddenPropVal != hidden)
+                     hidden](const std::optional<bool>& hiddenPropVal) {
+        if (hiddenPropVal.value_or(!hidden) != hidden)
         {
             messages::resourceNotFound(asyncResp->res, "LogEntry", entryID);
             return;
@@ -7223,27 +7241,32 @@ inline void fillSystemHardwareIsolationLogEntry(
 
                             std::string entryID = errPath.filename();
 
-                            auto updateAdditionalDataURI = [asyncResp,
-                                                            entryJsonIdx,
-                                                            entryID](
-                                                               bool hidden) {
-                                nlohmann::json& entryJsonToupdateURI =
-                                    (entryJsonIdx > 0
-                                         ? asyncResp->res
-                                               .jsonValue["Members"]
-                                                         [entryJsonIdx - 1]
-                                         : asyncResp->res.jsonValue);
-                                std::string logPath = "EventLog";
+                            auto updateAdditionalDataURI = //
+                                [asyncResp, entryJsonIdx,
+                                 entryID](const std::optional<bool>& hidden) {
+                                    if (!hidden.has_value())
+                                    {
+                                        // Skip entry if Hidden  property does
+                                        // not exist
+                                        return;
+                                    }
+                                    nlohmann::json& entryJsonToupdateURI =
+                                        (entryJsonIdx > 0
+                                             ? asyncResp->res
+                                                   .jsonValue["Members"]
+                                                             [entryJsonIdx - 1]
+                                             : asyncResp->res.jsonValue);
 
-                                if (hidden)
-                                {
-                                    logPath = "CELog";
-                                }
-                                entryJsonToupdateURI["AdditionalDataURI"] =
-                                    boost::urls::format(
-                                        "/redfish/v1/Systems/system/LogServices/{}/Entries/{}/attachment",
-                                        logPath, entryID);
-                            };
+                                    std::string logPath = "EventLog";
+                                    if (*hidden)
+                                    {
+                                        logPath = "CELog";
+                                    }
+                                    entryJsonToupdateURI["AdditionalDataURI"] =
+                                        boost::urls::format(
+                                            "/redfish/v1/Systems/system/LogServices/{}/Entries/{}/attachment",
+                                            logPath, entryID);
+                                };
                             redfish::error_log_utils::getHiddenPropertyValue(
                                 asyncResp, entryID, updateAdditionalDataURI);
                         }


### PR DESCRIPTION
There may be a timing window that a PEL dbus entry may not have a field `Hidden`, as a PEL dbus entry is handled in a 2 steps
 - a dbus log entry without Hidden field is created first
 - PEL interface reads a dbus log entry and adds `Hidden` field.

During the period, a dbus log entry could have no `Hidden` field.

This commit is to skip those intermediate dbus log entries for LogEntry GET collection handling.

For example,

```
curl -k -X GET https://${bmc}/redfish/v1/Systems/system/LogServices/CELog/Entries/
```

Then, bmc journal may show like this
```
Jul 17 11:12:54 p10bmc bmcwebd[1168]: [log_services.hpp:1756] Skip the log entry /xyz/openbmc_project/logging/entry/2 as it has no Hidden property
```

Tested:
- Redfish Service Validator passes