### PR TITLE
1120: Stop bmcweb immediately on exit signals

### DIFF
--- a/http/http_server.hpp
+++ b/http/http_server.hpp
@@ -118,12 +118,6 @@ class Server
             }
             else
             {
-                if (signalNo == SIGHUP)
-                {
-                    BMCWEB_LOG_INFO("Receivied reload signal");
-                    loadCertificate();
-                    startAsyncWaitForSignal();
-                }
                 if constexpr (BMCWEB_IBM_MANAGEMENT_CONSOLE)
                 {
                     if (signalNo == SIGUSR1)
@@ -132,7 +126,15 @@ class Server
                             "INFO: Receivied USR1 signal to dump latest session  data for bmc dump");
                         persistent_data::getConfig().writeCurrentSessionData();
                         this->startAsyncWaitForSignal();
+                        return;
                     }
+                }
+
+                if (signalNo == SIGHUP)
+                {
+                    BMCWEB_LOG_INFO("Receivied reload signal");
+                    loadCertificate();
+                    startAsyncWaitForSignal();
                 }
                 else
                 {


### PR DESCRIPTION
The commit 6006660 [1] mistakenly forgot the invocation of stop() on the bmcweb process exit signals (e.g. SIGTERM).

This may cause the significant delay bmcweb process termination on the reboot or the graceful bmcweb stop request.

For example, stopping bmcweb may take almost 1m30s, instead of the immediate stopping.

```
root@p10bmc:~# date; systemctl stop bmcweb; date
Fri Jul 18 05:24:08 UTC 2025
Stopping 'bmcweb.service', but its triggering units are still active:
bmcweb.socket
Fri Jul 18 05:25:38 UTC 2025
```

Tested:
- bmcweb stop should be done immediately like
```
root@p10bmc:~# date; systemctl stop bmcweb; date
Fri Jul 18 16:58:38 UTC 2025
Stopping 'bmcweb.service', but its triggering units are still active:
bmcweb.socket
Fri Jul 18 16:58:38 UTC 2025
```

[1] https://github.com/ibm-openbmc/bmcweb/commit/60066601a34adf99c4e2beb01c2bf5ca4e5575ae