### PR TITLE
1060: Skip log entry if Hidden dbus property is missing

### DIFF
--- a/redfish-core/include/utils/error_log_utils.hpp
+++ b/redfish-core/include/utils/error_log_utils.hpp
@@ -39,10 +39,19 @@ inline void
     sdbusplus::asio::getProperty<bool>(
         *crow::connections::systemBus, "xyz.openbmc_project.Logging",
         errorLogObjPath.str, "org.open_power.Logging.PEL.Entry", "Hidden",
-        [aResp, errorLogObjPath, errorLogPropPath, isLink](
-            const boost::system::error_code ec, const bool hiddenProperty) {
+        [aResp, errorLogObjPath, errorLogPropPath,
+         isLink](const boost::system::error_code ec, bool hiddenProperty) {
         if (ec)
         {
+            if (ec.value() == EBADR)
+            {
+                // Skip log entry if Hidden dbus property is missing
+                // Put this log trace to journal by default.
+                BMCWEB_LOG_ERROR << "DBUS property 'Hidden' for entry :"
+                                 << errorLogObjPath.str << "  does not exist";
+                return;
+            }
+
             BMCWEB_LOG_ERROR
                 << "DBus response error [" << ec.value() << " : "
                 << ec.message() << "] when tried to get the Hidden property "

--- a/redfish-core/lib/log_services.hpp
+++ b/redfish-core/lib/log_services.hpp
@@ -1978,11 +1978,19 @@ template <typename Callback>
 void getHiddenPropertyValue(const std::shared_ptr<bmcweb::AsyncResp>& asyncResp,
                             const std::string& entryId, Callback&& callback)
 {
-    auto respHandler = [callback{std::forward<Callback>(callback)},
-                        asyncResp](const boost::system::error_code ec,
-                                   const bool& hiddenProperty) {
+    auto respHandler = [callback{std::forward<Callback>(callback)}, asyncResp,
+                        entryId](const boost::system::error_code ec,
+                                 bool hiddenProperty) {
         if (ec)
         {
+            if (ec.value() == EBADR)
+            {
+                // Put this log trace to journal by default.
+                BMCWEB_LOG_ERROR << "DBUS property 'Hidden' for entry "
+                                 << entryId << " does not exist";
+                callback(std::nullopt);
+                return;
+            }
             BMCWEB_LOG_ERROR << "DBUS response error: " << ec;
             messages::internalError(asyncResp->res);
             return;
@@ -2666,11 +2674,19 @@ inline void requestRoutesDBusEventLogEntry(App& app)
                 messages::internalError(asyncResp->res);
                 return;
             }
+            if (hidden == nullptr)
+            {
+                // Skip log entry if Hidden dbus property is missing
+                BMCWEB_LOG_ERROR << "DBUS property 'Hidden' for entry "
+                                 << std::to_string(*id) << " does not exist";
+                messages::resourceNotFound(asyncResp->res, "EventLogEntry",
+                                           std::to_string(*id));
+                return;
+            }
 
             if (id == nullptr || eventId == nullptr || severity == nullptr ||
                 timestamp == nullptr || updateTimestamp == nullptr ||
-                resolved == nullptr || notify == nullptr || hidden == nullptr ||
-                subsystem == nullptr
+                resolved == nullptr || notify == nullptr || subsystem == nullptr
 #ifdef BMCWEB_ENABLE_IBM_MANAGEMENT_CONSOLE
                 || managementSystemAck == nullptr
 #endif
@@ -2778,9 +2794,10 @@ inline void requestRoutesDBusEventLogEntry(App& app)
             }
         }
 
-        auto updatePropertyCallback = [resolved, managementSystemAck, asyncResp,
-                                       entryId](bool hiddenPropVal) {
-            if (hiddenPropVal)
+        auto updatePropertyCallback =
+            [resolved, managementSystemAck, asyncResp,
+             entryId](const std::optional<bool>& hiddenPropVal) {
+            if (hiddenPropVal.value_or(true))
             {
                 messages::resourceNotFound(asyncResp->res, "LogEntry", entryId);
                 return;
@@ -2815,8 +2832,9 @@ inline void requestRoutesDBusEventLogEntry(App& app)
 
         dbus::utility::escapePathForDbus(entryID);
 
-        auto deleteEventLogCallback = [asyncResp, entryID](bool hiddenPropVal) {
-            if (hiddenPropVal)
+        auto deleteEventLogCallback =
+            [asyncResp, entryID](const std::optional<bool>& hiddenPropVal) {
+            if (hiddenPropVal.value_or(true))
             {
                 messages::resourceNotFound(asyncResp->res, "LogEntry", entryID);
                 return;
@@ -2903,10 +2921,19 @@ inline void requestRoutesDBusCELogEntry(App& app)
                 return;
             }
 
+            if (hidden == nullptr)
+            {
+                // Skip log entry if Hidden dbus property is missing
+                BMCWEB_LOG_ERROR << "DBUS property 'Hidden' for entry "
+                                 << std::to_string(*id) << " does not exist";
+                messages::resourceNotFound(asyncResp->res, "LogEntry",
+                                           std::to_string(*id));
+                return;
+            }
+
             if (id == nullptr || eventId == nullptr || severity == nullptr ||
                 timestamp == nullptr || updateTimestamp == nullptr ||
-                hidden == nullptr || subsystem == nullptr ||
-                resolved == nullptr || notify == nullptr
+                subsystem == nullptr || resolved == nullptr || notify == nullptr
 #ifdef BMCWEB_ENABLE_IBM_MANAGEMENT_CONSOLE
                 || managementSystemAck == nullptr
 #endif
@@ -3014,9 +3041,10 @@ inline void requestRoutesDBusCELogEntry(App& app)
             }
         }
 
-        auto updatePropertyCallback = [resolved, managementSystemAck, asyncResp,
-                                       entryId](bool hiddenPropVal) {
-            if (!hiddenPropVal)
+        auto updatePropertyCallback =
+            [resolved, managementSystemAck, asyncResp,
+             entryId](const std::optional<bool>& hiddenPropVal) {
+            if (!hiddenPropVal.value_or(false))
             {
                 messages::resourceNotFound(asyncResp->res, "LogEntry", entryId);
                 return;
@@ -3051,8 +3079,9 @@ inline void requestRoutesDBusCELogEntry(App& app)
 
         dbus::utility::escapePathForDbus(entryID);
 
-        auto deleteCELogCallback = [asyncResp, entryID](bool hiddenPropVal) {
-            if (!hiddenPropVal)
+        auto deleteCELogCallback =
+            [asyncResp, entryID](const std::optional<bool>& hiddenPropVal) {
+            if (!hiddenPropVal.value_or(false))
             {
                 messages::resourceNotFound(asyncResp->res, "LogEntry", entryID);
                 return;
@@ -3135,9 +3164,9 @@ inline void requestRoutesDBusEventLogEntryDownloadPelJson(App& app)
         std::string entryID = param;
         dbus::utility::escapePathForDbus(entryID);
 
-        auto eventLogAttachmentCallback = [asyncResp,
-                                           entryID](bool hiddenPropVal) {
-            if (hiddenPropVal)
+        auto eventLogAttachmentCallback =
+            [asyncResp, entryID](const std::optional<bool>& hiddenPropVal) {
+            if (hiddenPropVal.value_or(true))
             {
                 messages::resourceNotFound(asyncResp->res, "LogEntry", entryID);
                 return;
@@ -3174,9 +3203,9 @@ inline void requestRoutesDBusCELogEntryDownloadPelJson(App& app)
         std::string entryID = param;
         dbus::utility::escapePathForDbus(entryID);
 
-        auto eventLogAttachmentCallback = [asyncResp,
-                                           entryID](bool hiddenPropVal) {
-            if (!hiddenPropVal)
+        auto eventLogAttachmentCallback =
+            [asyncResp, entryID](const std::optional<bool>& hiddenPropVal) {
+            if (!hiddenPropVal.value_or(false))
             {
                 messages::resourceNotFound(asyncResp->res, "LogEntry", entryID);
                 return;
@@ -3292,9 +3321,9 @@ inline void requestRoutesDBusEventLogEntryDownload(App& app)
         std::string entryID = param;
         dbus::utility::escapePathForDbus(entryID);
 
-        auto eventLogAttachmentCallback = [asyncResp,
-                                           entryID](bool hiddenPropVal) {
-            if (hiddenPropVal)
+        auto eventLogAttachmentCallback =
+            [asyncResp, entryID](const std::optional<bool>& hiddenPropVal) {
+            if (hiddenPropVal.value_or(true))
             {
                 messages::resourceNotFound(asyncResp->res, "LogEntry", entryID);
                 return;
@@ -3337,9 +3366,9 @@ inline void requestRoutesDBusCELogEntryDownload(App& app)
         std::string entryID = param;
         dbus::utility::escapePathForDbus(entryID);
 
-        auto eventLogAttachmentCallback = [asyncResp,
-                                           entryID](bool hiddenPropVal) {
-            if (!hiddenPropVal)
+        auto eventLogAttachmentCallback =
+            [asyncResp, entryID](const std::optional<bool>& hiddenPropVal) {
+            if (!hiddenPropVal.value_or(false))
             {
                 messages::resourceNotFound(asyncResp->res, "LogEntry", entryID);
                 return;


### PR DESCRIPTION
There may be a timing window that a PEL dbus entry may not have a field `Hidden`, as a PEL dbus entry is handled in a 2 steps
 - a dbus log entry without Hidden field is created first
 - PEL interface reads a dbus log entry and adds `Hidden` field.

During the period, a dbus log entry could have no `Hidden` field.

This commit is to skip those intermediate dbus log entries for LogEntry GET collection handling.

For example,

```
curl -k -X GET https://${bmc}/redfish/v1/Systems/system/LogServices/CELog/Entries/
```

Then, bmc journal may show like this
```
Jul 17 11:12:54 p10bmc bmcwebd[1168]: [log_services.hpp:1756] Skip the log entry /xyz/openbmc_project/logging/entry/2 as it has no Hidden property
```

Tested:
- Redfish Service Validator passes